### PR TITLE
simplify(S01) phase 2: collapse runReconciliation via reconcileMergeDecision (differential-gated)

### DIFF
--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -376,9 +376,15 @@ type mergeDecision struct {
 	// notification is the event type to synthesize: "", "bead.created",
 	// "bead.updated", or "bead.closed".
 	notification string
-	// degradeDepsComplete reports that this skip leaves a deps coverage hole
-	// (cached row with no deps entry), so the pass must fold
-	// nextDepsComplete = false. Matches the two Branch-A skip-arm degradations.
+	// degradeDepsComplete reports that this skip leaves the cached deps map an
+	// unfaithful projection of the fresh full scan, so the pass must fold
+	// nextDepsComplete = false and dep readers fall back to the backing. Two
+	// shapes trip it: a coverage hole (cached row with no deps entry), and a
+	// recency-keep that retains cached deps which diverge from the fresh
+	// snapshot's deps (the row's body is kept as local truth, but its deps can
+	// no longer be claimed complete). The first shape matches the two Branch-A
+	// skip-arm degradations; the second closes the D4 contract gap where a
+	// recency-keep could serve stale cached deps under depsComplete=true.
 	degradeDepsComplete bool
 }
 
@@ -422,7 +428,7 @@ func reconcileMergeDecision(in mergeRowInput) mergeDecision {
 			beadChanged(in.cached, in.fresh, in.skipLabels) {
 			return mergeDecision{
 				action:              mergeSkipRecentLocal,
-				degradeDepsComplete: !in.hasCachedDeps,
+				degradeDepsComplete: !in.hasCachedDeps || depsChanged(in.cachedDeps, in.freshDeps),
 			}
 		}
 		n := ""

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -333,6 +333,156 @@ func (c *CachingStore) runReconciliation() {
 
 	c.mu.Lock()
 	now := time.Now()
+	res := c.mergeSnapshotLocked(freshByID, confirmedClosed, depMap, useFreshDeps, startSeq, now)
+	durMs := float64(time.Since(start).Microseconds()) / 1000.0
+	c.stats.LastReconcileMs = durMs
+	c.recordReconcileLatencyLocked(bdLatency)
+	c.recomputeCadenceLocked()
+	c.updateStatsLocked()
+	logLine, emit := c.reconcileSuccessLogLocked(now, time.Since(start), res.adds, res.removes, res.updates)
+	c.mu.Unlock()
+	if emit {
+		log.Print(logLine)
+	}
+	c.notifyChanges(res.notifications)
+}
+
+// mergeAction is what the reconcile merge does with one id.
+type mergeAction int
+
+const (
+	// mergeAbsorb installs the fresh row via
+	// absorbFreshLocked{depsExplicit freshDeps, seqClearGuarded, clearDirty:true}.
+	mergeAbsorb mergeAction = iota
+	// mergeEvict removes the cached row via evictLocked.
+	mergeEvict
+	// mergeSkipFenced leaves everything for id untouched: a tombstone or
+	// beadSeq fence > startSeq proves local state is newer than the snapshot.
+	mergeSkipFenced
+	// mergeSkipRecentLocal leaves everything for id untouched: the recency
+	// window (5 s) protects an in-flight local write bd may not reflect yet.
+	mergeSkipRecentLocal
+	// mergeGCFences drops every orphan fence/deps entry for id (deletedSeq,
+	// dirty, beadSeq, localBeadAt, deps). Only reachable when id has no row on
+	// either side.
+	mergeGCFences
+)
+
+// mergeDecision is the pure per-id verdict of reconcileMergeDecision. Payload
+// assembly (confirmedClosed override, cloneBead) and counter bookkeeping stay
+// at the seam call site.
+type mergeDecision struct {
+	action mergeAction
+	// notification is the event type to synthesize: "", "bead.created",
+	// "bead.updated", or "bead.closed".
+	notification string
+	// degradeDepsComplete reports that this skip leaves a deps coverage hole
+	// (cached row with no deps entry), so the pass must fold
+	// nextDepsComplete = false. Matches the two Branch-A skip-arm degradations.
+	degradeDepsComplete bool
+}
+
+// mergeRowInput is the complete per-id state the decision depends on.
+// Everything is a value; zero values are the documented "absent" sentinels
+// (mutationSeq starts at 1 — noteMutationLocked pre-increments — so seq 0
+// means "no entry"; time.Time zero means "no recency stamp").
+type mergeRowInput struct {
+	freshExists   bool // id present in freshByID (post-recoverMissingFromList)
+	fresh         Bead
+	freshDeps     []Dep // depsForReconcileLocked output, computed by caller
+	cachedExists  bool  // id present in c.beads
+	cached        Bead
+	cachedDeps    []Dep // c.deps[id] value (nil when absent)
+	hasCachedDeps bool  // c.deps[id] presence — distinct from nil/empty value
+	deletedAtSeq  uint64
+	beadAtSeq     uint64
+	startSeq      uint64
+	localAt       time.Time
+	now           time.Time // the single pass-level clock read
+	skipLabels    bool
+}
+
+// reconcileMergeDecision decides the fate of one id's state transition in the
+// collapsed reconcile: the absorb loop, the eviction loop, and the fence/deps
+// GC sweep all route through it. It is pure — no receiver, no locks, no map
+// mutation, no clock reads, no I/O — so it is exhaustively enumerable and
+// trivially comparable in the differential gate. The fence ordering in each
+// case is tombstone/seq fence beats recency beats mutate.
+func reconcileMergeDecision(in mergeRowInput) mergeDecision {
+	switch {
+	case in.freshExists: // absorb-loop cell
+		if in.deletedAtSeq > in.startSeq || in.beadAtSeq > in.startSeq {
+			return mergeDecision{
+				action:              mergeSkipFenced,
+				degradeDepsComplete: in.cachedExists && !in.hasCachedDeps,
+			}
+		}
+		if in.cachedExists &&
+			recentLocalMutation(in.localAt, in.now) &&
+			beadChanged(in.cached, in.fresh, in.skipLabels) {
+			return mergeDecision{
+				action:              mergeSkipRecentLocal,
+				degradeDepsComplete: !in.hasCachedDeps,
+			}
+		}
+		n := ""
+		switch {
+		case !in.cachedExists:
+			n = "bead.created"
+		case beadChanged(in.cached, in.fresh, in.skipLabels):
+			n = "bead.updated"
+		case depsChanged(in.cachedDeps, in.freshDeps):
+			n = "bead.updated"
+		}
+		return mergeDecision{action: mergeAbsorb, notification: n}
+
+	case in.cachedExists: // eviction-loop cell (id absent from snapshot)
+		if in.deletedAtSeq > in.startSeq || in.beadAtSeq > in.startSeq {
+			return mergeDecision{action: mergeSkipFenced}
+		}
+		if in.cached.Status != "closed" && recentLocalMutation(in.localAt, in.now) {
+			return mergeDecision{action: mergeSkipRecentLocal}
+		}
+		n := ""
+		if in.cached.Status != "closed" {
+			n = "bead.closed"
+		}
+		return mergeDecision{action: mergeEvict, notification: n}
+
+	default: // fence-GC cell (no row on either side; orphan fence/deps only)
+		if in.deletedAtSeq > in.startSeq || in.beadAtSeq > in.startSeq {
+			return mergeDecision{action: mergeSkipFenced}
+		}
+		if recentLocalMutation(in.localAt, in.now) {
+			return mergeDecision{action: mergeSkipRecentLocal}
+		}
+		return mergeDecision{action: mergeGCFences}
+	}
+}
+
+// mergeSectionResult carries the deterministic outputs of mergeSnapshotLocked
+// back to runReconciliation: the notifications to emit after unlock and the
+// per-pass add/remove/update counts.
+type mergeSectionResult struct {
+	notifications []cacheNotification
+	adds          int64
+	removes       int64
+	updates       int64
+}
+
+// mergeSnapshotLocked applies a full-scan snapshot to the cache under c.mu.
+// It is the deterministic seam of runReconciliation: pure in-memory, no I/O,
+// no clock reads (now injected), no notifications emitted (returned for the
+// caller to emit after unlock). Every per-id fate is decided by
+// reconcileMergeDecision; the three index sets it iterates (freshByID, the
+// cached rows absent from freshByID, and the orphan fence/deps ids) are
+// pairwise disjoint, so the passes cannot perturb each other. Caller must hold
+// c.mu (write lock).
+func (c *CachingStore) mergeSnapshotLocked(
+	freshByID map[string]Bead, confirmedClosed map[string]Bead,
+	depMap map[string][]Dep, useFreshDeps bool,
+	startSeq uint64, now time.Time,
+) mergeSectionResult {
 	// Preserve a cached is_blocked for any row the projection did not return
 	// this cycle. Two cases land here: a full projection failure (enrichErr
 	// left every row unenriched) and the narrower race where a row is still
@@ -341,204 +491,168 @@ func (c *CachingStore) runReconciliation() {
 	// the row's is_blocked flips false->nil and beadChanged emits a spurious
 	// bead.updated. The guards inside drop the preservation when the row's deps
 	// or a blocking target's status actually changed, so a real transition is
-	// never masked.
+	// never masked. Runs first, on pre-merge state, because it reads other
+	// rows' cached status.
 	c.preserveCachedReadyProjectionLocked(freshByID, depMap, useFreshDeps)
-	if c.mutationSeq != startSeq {
-		var adds, removes, updates int64
-		notifications := make([]cacheNotification, 0, len(freshByID))
-		nextDepsComplete := useFreshDeps
 
-		for id, freshBead := range freshByID {
-			if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
-				if _, exists := c.beads[id]; exists {
-					if _, ok := c.deps[id]; !ok {
-						nextDepsComplete = false
-					}
-				}
-				continue
-			}
-			if _, keep := c.recentLocalBeadConflictLocked(id, freshBead, now, true); keep {
-				if _, ok := c.deps[id]; !ok {
-					nextDepsComplete = false
-				}
-				continue
-			}
-			freshDeps := c.depsForReconcileLocked(id, freshBead, depMap, useFreshDeps)
+	res := mergeSectionResult{notifications: make([]cacheNotification, 0, len(freshByID))}
+	nextDepsComplete := useFreshDeps
 
-			old, exists := c.beads[id]
-			switch {
-			case !exists:
-				adds++
-				notifications = append(notifications, cacheNotification{
-					eventType: "bead.created",
-					bead:      cloneBead(freshBead),
-				})
-			case beadChanged(old, freshBead, true):
-				updates++
-				notifications = append(notifications, cacheNotification{
-					eventType: "bead.updated",
-					bead:      cloneBead(freshBead),
-				})
-			case depsChanged(c.deps[id], freshDeps):
-				updates++
-				notifications = append(notifications, cacheNotification{
-					eventType: "bead.updated",
-					bead:      cloneBead(freshBead),
-				})
-			}
-
-			c.absorbFreshLocked(id, freshBead, now, absorbOpts{
-				depsMode:   depsExplicit,
-				deps:       freshDeps,
-				seqMode:    seqClearGuarded,
-				clearDirty: true,
-			})
-		}
-
-		for id, old := range c.beads {
-			if _, exists := freshByID[id]; exists {
-				continue
-			}
-			if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
-				continue
-			}
-			if old.Status != "closed" && recentLocalMutation(c.localBeadAt[id], now) {
-				continue
-			}
-			removes++
-			if old.Status != "closed" {
-				closed := cloneBead(old)
-				closed.Status = "closed"
-				if freshClosed, ok := confirmedClosed[id]; ok {
-					closed = cloneBead(freshClosed)
-				}
-				notifications = append(notifications, cacheNotification{
-					eventType: "bead.closed",
-					bead:      closed,
-				})
-			}
-			c.evictLocked(id)
-		}
-
-		c.syncFailures = 0
-		c.depsComplete = nextDepsComplete
-		c.primePartialErr = nil
-		c.promoteLiveLocked()
-		durMs := float64(time.Since(start).Microseconds()) / 1000.0
-		c.stats.LastReconcileAt = now
-		c.stats.LastReconcileMs = durMs
-		c.stats.Adds += adds
-		c.stats.Removes += removes
-		c.stats.Updates += updates
-		c.markFreshLocked(now)
-		c.recordReconcileLatencyLocked(bdLatency)
-		c.recomputeCadenceLocked()
-		c.updateStatsLocked()
-		logLine, emit := c.reconcileSuccessLogLocked(now, time.Since(start), adds, removes, updates)
-		c.mu.Unlock()
-		if emit {
-			log.Print(logLine)
-		}
-		c.notifyChanges(notifications)
-		return
-	}
-
-	var adds, removes, updates int64
-	notifications := make([]cacheNotification, 0, len(freshByID))
-	nextBeads := make(map[string]Bead, len(freshByID))
-	nextDeps := make(map[string][]Dep, len(freshByID))
-	nextDirty := make(map[string]struct{})
-	nextBeadSeq := make(map[string]uint64)
-	nextLocalBeadAt := make(map[string]time.Time)
-
+	// 1. Absorb loop — over freshByID. Classification reads pre-absorb state.
 	for id, freshBead := range freshByID {
-		beadForCache := freshBead
-		preservedRecentLocal := false
-		if current, keep := c.recentLocalBeadConflictLocked(id, freshBead, now, true); keep {
-			beadForCache = current
-			preservedRecentLocal = true
-			c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
-		}
 		freshDeps := c.depsForReconcileLocked(id, freshBead, depMap, useFreshDeps)
-		nextBeads[id] = cloneBead(beadForCache)
-		nextDeps[id] = cloneDeps(freshDeps)
-
-		old, exists := c.beads[id]
-		switch {
-		case !exists:
-			adds++
-			notifications = append(notifications, cacheNotification{
+		cached, cachedExists := c.beads[id]
+		cachedDeps, hasCachedDeps := c.deps[id]
+		d := reconcileMergeDecision(mergeRowInput{
+			freshExists:   true,
+			fresh:         freshBead,
+			freshDeps:     freshDeps,
+			cachedExists:  cachedExists,
+			cached:        cached,
+			cachedDeps:    cachedDeps,
+			hasCachedDeps: hasCachedDeps,
+			deletedAtSeq:  c.deletedSeq[id],
+			beadAtSeq:     c.beadSeq[id],
+			startSeq:      startSeq,
+			localAt:       c.localBeadAt[id],
+			now:           now,
+			skipLabels:    true,
+		})
+		if d.degradeDepsComplete {
+			nextDepsComplete = false
+		}
+		if d.action != mergeAbsorb {
+			continue
+		}
+		switch d.notification {
+		case "bead.created":
+			res.adds++
+			res.notifications = append(res.notifications, cacheNotification{
 				eventType: "bead.created",
-				bead:      cloneBead(beadForCache),
-			})
-		case !preservedRecentLocal && beadChanged(old, freshBead, true):
-			updates++
-			notifications = append(notifications, cacheNotification{
-				eventType: "bead.updated",
 				bead:      cloneBead(freshBead),
 			})
-		case !preservedRecentLocal && depsChanged(c.deps[id], freshDeps):
-			updates++
-			notifications = append(notifications, cacheNotification{
+		case "bead.updated":
+			res.updates++
+			res.notifications = append(res.notifications, cacheNotification{
 				eventType: "bead.updated",
 				bead:      cloneBead(freshBead),
 			})
 		}
+		c.absorbFreshLocked(id, freshBead, now, absorbOpts{
+			depsMode:   depsExplicit,
+			deps:       freshDeps,
+			seqMode:    seqClearGuarded,
+			clearDirty: true,
+		})
 	}
 
-	for id, old := range c.beads {
-		if _, exists := freshByID[id]; !exists {
-			if old.Status != "closed" && recentLocalMutation(c.localBeadAt[id], now) {
-				nextBeads[id] = cloneBead(old)
-				if deps, ok := c.deps[id]; ok {
-					nextDeps[id] = cloneDeps(deps)
-				}
-				c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
-				continue
-			}
-			removes++
-			if old.Status == "closed" {
-				continue
-			}
-			closed := cloneBead(old)
+	// 2. Eviction loop — over c.beads \ freshByID. Deleting the current key
+	//    inside range c.beads is safe per the Go spec.
+	for id, cached := range c.beads {
+		if _, exists := freshByID[id]; exists {
+			continue
+		}
+		d := reconcileMergeDecision(mergeRowInput{
+			freshExists:  false,
+			cachedExists: true,
+			cached:       cached,
+			deletedAtSeq: c.deletedSeq[id],
+			beadAtSeq:    c.beadSeq[id],
+			startSeq:     startSeq,
+			localAt:      c.localBeadAt[id],
+			now:          now,
+			skipLabels:   true,
+		})
+		if d.action != mergeEvict {
+			continue
+		}
+		res.removes++
+		if d.notification == "bead.closed" {
+			closed := cloneBead(cached)
 			closed.Status = "closed"
 			if freshClosed, ok := confirmedClosed[id]; ok {
 				closed = cloneBead(freshClosed)
 			}
-			notifications = append(notifications, cacheNotification{
+			res.notifications = append(res.notifications, cacheNotification{
 				eventType: "bead.closed",
 				bead:      closed,
 			})
 		}
+		c.evictLocked(id)
 	}
 
-	c.beads = nextBeads
-	c.deps = nextDeps
-	c.depsComplete = useFreshDeps
-	c.dirty = nextDirty
-	c.beadSeq = nextBeadSeq
-	c.localBeadAt = nextLocalBeadAt
-	c.deletedSeq = make(map[string]uint64)
+	// 3. Fence/deps-GC sweep — over orphan ids (a fence or deps entry with no
+	//    row on either side). Replaces Branch B's implicit wholesale reset:
+	//    stale orphans are collected, recent ones kept one more cycle. The id
+	//    set is snapshotted before deleting to avoid iterate-while-delete.
+	for _, id := range c.orphanFenceIDsLocked(freshByID) {
+		d := reconcileMergeDecision(mergeRowInput{
+			freshExists:  false,
+			cachedExists: false,
+			deletedAtSeq: c.deletedSeq[id],
+			beadAtSeq:    c.beadSeq[id],
+			startSeq:     startSeq,
+			localAt:      c.localBeadAt[id],
+			now:          now,
+			skipLabels:   true,
+		})
+		if d.action != mergeGCFences {
+			continue
+		}
+		delete(c.deletedSeq, id)
+		delete(c.dirty, id)
+		delete(c.beadSeq, id)
+		delete(c.localBeadAt, id)
+		delete(c.deps, id)
+	}
+
+	// 4. Shared tail (was duplicated per branch).
 	c.syncFailures = 0
+	c.depsComplete = nextDepsComplete
 	c.primePartialErr = nil
 	c.promoteLiveLocked()
-
-	durMs := float64(time.Since(start).Microseconds()) / 1000.0
 	c.stats.LastReconcileAt = now
-	c.stats.LastReconcileMs = durMs
-	c.stats.Adds += adds
-	c.stats.Removes += removes
-	c.stats.Updates += updates
+	c.stats.Adds += res.adds
+	c.stats.Removes += res.removes
+	c.stats.Updates += res.updates
 	c.markFreshLocked(now)
-	c.recordReconcileLatencyLocked(bdLatency)
-	c.recomputeCadenceLocked()
-	c.updateStatsLocked()
-	logLine, emit := c.reconcileSuccessLogLocked(now, time.Since(start), adds, removes, updates)
-	c.mu.Unlock()
-	if emit {
-		log.Print(logLine)
+	return res
+}
+
+// orphanFenceIDsLocked returns the ids carrying a fence or deps entry but no
+// cached row and no fresh row this cycle — the fence/deps-GC sweep's work set.
+// Caller must hold c.mu.
+func (c *CachingStore) orphanFenceIDsLocked(freshByID map[string]Bead) []string {
+	seen := make(map[string]struct{})
+	add := func(id string) {
+		if _, ok := c.beads[id]; ok {
+			return
+		}
+		if _, ok := freshByID[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
 	}
-	c.notifyChanges(notifications)
+	for id := range c.deletedSeq {
+		add(id)
+	}
+	for id := range c.dirty {
+		add(id)
+	}
+	for id := range c.beadSeq {
+		add(id)
+	}
+	for id := range c.localBeadAt {
+		add(id)
+	}
+	for id := range c.deps {
+		add(id)
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 // promoteLiveLocked marks the cache live after a clean full-scan

--- a/internal/beads/caching_store_reconcile_census_test.go
+++ b/internal/beads/caching_store_reconcile_census_test.go
@@ -1,0 +1,128 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Writers census (plan §6.1 leg 1): the collapsed reconcile's regime invariant
+// Q — quiescent ⇒ no fence value exceeds startSeq — rests on every fence VALUE
+// being minted by a post-increment of mutationSeq under c.mu. This test proves
+// the only sites that assign a fence map (index-assign a value, or replace the
+// whole map) are the sanctioned ones, so a future bypass in reconcile (or a
+// resurrected Branch B) fails the build. Extended per the council's V-soundness
+// nit to also match whole-map replacement, not just indexed writes.
+func TestReconcileFenceWritersCensus(t *testing.T) {
+	files := packageGoFiles(t)
+
+	indexAssign := regexp.MustCompile(`c\.(beadSeq|deletedSeq|localBeadAt)\[[^\]]+\]\s*=[^=]`)
+	wholeAssign := regexp.MustCompile(`c\.(beadSeq|deletedSeq|localBeadAt)\s*=[^=]`)
+
+	// Allowed enclosing functions for index-assignments (value minting / setting).
+	allowedIndex := map[string]bool{
+		"noteMutationLocked":      true, // beadSeq
+		"noteLocalMutationLocked": true, // localBeadAt
+		"tombstoneLocked":         true, // deletedSeq
+	}
+	// Allowed enclosing functions for whole-map replacement. Only prime()'s
+	// own B-shaped rebuild remains after the Phase-2 collapse deleted reconcile
+	// Branch B; if reconcile ever regrows a wholesale fence reset, this fails.
+	allowedWhole := map[string]bool{
+		"prime": true,
+	}
+
+	for _, f := range files {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		fn := ""
+		funcRe := regexp.MustCompile(`^func (?:\([^)]*\) )?([A-Za-z0-9_]+)`)
+		for i, line := range strings.Split(string(src), "\n") {
+			if m := funcRe.FindStringSubmatch(line); m != nil {
+				fn = m[1]
+			}
+			if indexAssign.MatchString(line) && !allowedIndex[fn] {
+				t.Errorf("%s:%d fence index-assignment in unsanctioned func %q: %s",
+					filepath.Base(f), i+1, fn, strings.TrimSpace(line))
+			}
+			if wholeAssign.MatchString(line) && !allowedWhole[fn] {
+				t.Errorf("%s:%d whole-map fence assignment in unsanctioned func %q: %s",
+					filepath.Base(f), i+1, fn, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+func packageGoFiles(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		n := e.Name()
+		if strings.HasSuffix(n, ".go") && !strings.HasSuffix(n, "_test.go") {
+			out = append(out, n)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no package source files found")
+	}
+	return out
+}
+
+// Field-coverage census (plan §5.1 hardening): the oracle's end-state
+// comparison must be structurally exhaustive. Every CachingStore and CacheStats
+// field is either compared by the oracle or on a justified-exclusion list; a
+// field added later that is neither fails this test, forcing a conscious
+// classification instead of a silent oracle blind spot.
+func TestMergeOracleFieldCoverage(t *testing.T) {
+	comparedStore := map[string]bool{
+		"beads": true, "deps": true, "depsComplete": true, "dirty": true,
+		"beadSeq": true, "localBeadAt": true, "deletedSeq": true, "state": true,
+		"lastFreshAt": true, "mutationSeq": true, "primePartialErr": true,
+		"syncFailures": true, "stats": true, // stats compared field-wise below
+	}
+	excludedStore := map[string]bool{
+		"backing": true, "idPrefix": true, "mu": true, "reconciling": true,
+		"onChange": true, "problemf": true, "problemLog": true,
+		"lastReconcileLogAt": true, "primeMu": true, "primeRunning": true,
+		"primeCycle": true, "lastFullPrimeStartedAt": true, "primeRetryDelay": true,
+		"lifecycleMu": true, "lifecycleWG": true, "cancelFn": true, "stopCh": true,
+		"stopped": true, "latencyWindow": true, "latencyDriverActive": true,
+		"applyEventBeforeCommitForTest": true,
+	}
+	assertFieldsClassified(t, reflect.TypeOf(CachingStore{}), comparedStore, excludedStore)
+
+	comparedStats := map[string]bool{
+		"LastFreshAt": true, "LastReconcileAt": true,
+		"Adds": true, "Removes": true, "Updates": true,
+	}
+	excludedStats := map[string]bool{
+		"TotalBeads": true, "TotalDeps": true, "LastReconcileMs": true,
+		"ReconcileRecoveries": true, "ReconcileCloseDeferrals": true,
+		"SyncFailures": true, "ProblemCount": true, "LastProblemAt": true,
+		"LastProblem": true, "State": true, "StaggerOffsetMs": true,
+		"CurrentReconcileInterval": true, "LatencyP95Ms": true, "CadenceDriver": true,
+	}
+	assertFieldsClassified(t, reflect.TypeOf(CacheStats{}), comparedStats, excludedStats)
+}
+
+func assertFieldsClassified(t *testing.T, ty reflect.Type, compared, excluded map[string]bool) {
+	t.Helper()
+	for i := 0; i < ty.NumField(); i++ {
+		name := ty.Field(i).Name
+		if !compared[name] && !excluded[name] {
+			t.Errorf("%s.%s is neither compared nor justified-excluded by the merge oracle — classify it (a seam-written field must be compared)", ty.Name(), name)
+		}
+		if compared[name] && excluded[name] {
+			t.Errorf("%s.%s is in both compared and excluded sets", ty.Name(), name)
+		}
+	}
+}

--- a/internal/beads/caching_store_reconcile_coverage_test.go
+++ b/internal/beads/caching_store_reconcile_coverage_test.go
@@ -108,16 +108,17 @@ func classifyRow(st storeState, in snapshotInputs, id string) coverageKey {
 
 	postPreserve := computePostPreserveFresh(st, in)
 	pf := postPreserve[id]
-	if f && c {
+	switch {
+	case f && c:
 		k.changed = changedCell(cached, pf)
 		k.statusPair = cached.Status + ">" + fresh.Status
-	} else if f {
+	case f:
 		k.changed = "na"
 		k.statusPair = "?>" + fresh.Status
-	} else if c {
+	case c:
 		k.changed = "na"
 		k.statusPair = cached.Status + ">?"
-	} else {
+	default:
 		k.changed = "na"
 		k.statusPair = "na"
 	}
@@ -245,7 +246,7 @@ func preserveOutcomeCell(st storeState, in snapshotInputs, id string) string {
 	if !cok || cached.IsBlocked == nil {
 		return "no-cached"
 	}
-	c, _ := newMergeHarnessStore(st, nil)
+	c, _ := newMergeHarnessStore(st)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	freshDeps := c.depsForReconcileLocked(id, item, in.depMap, in.useFreshDeps)

--- a/internal/beads/caching_store_reconcile_coverage_test.go
+++ b/internal/beads/caching_store_reconcile_coverage_test.go
@@ -1,0 +1,331 @@
+package beads
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// coverageKey is the discretized per-row decision cell. The guard dimensions
+// (regime, presence, tomb, seqFence, recency, changed) are the axes the
+// user-visible guards actually branch on; the differential gate requires the
+// full V-filtered cross of those. The remaining "soft" dimensions prove
+// insensitivity / exercise the council-hardened sub-axes and are required only
+// marginally (each value observed at least once).
+type coverageKey struct {
+	regime     string
+	presence   string
+	tomb       string
+	seqFence   string
+	recency    string
+	changed    string
+	statusPair string
+
+	// Soft / hardened axes (marginal coverage).
+	dirty           bool
+	depMapCell      string // fresh deps via depMap (useFreshDeps): na|nil|empty|nonempty
+	fieldDeps       string // council axis-9 split: fresh bead dep fields: na|none|needs|deps|both
+	cachedDeps      string // cached c.deps[id]: absent|nil|empty|nonempty
+	useFreshDeps    bool
+	backingIsBd     bool
+	confirmedClosed bool
+	preserveOutcome string
+}
+
+// guardCell is the projection over the guard-critical axes; the gate requires
+// full V-filtered cross occupancy over these.
+type guardCell struct {
+	regime, presence, tomb, seqFence, recency, changed, statusPair string
+}
+
+func (k coverageKey) guard() guardCell {
+	return guardCell{k.regime, k.presence, k.tomb, k.seqFence, k.recency, k.changed, k.statusPair}
+}
+
+// coverageRecorder accumulates observed cells across generator tiers.
+type coverageRecorder struct {
+	mu       sync.Mutex
+	guards   map[guardCell]int
+	marginal map[string]int // "axis=value" → count
+	full     map[coverageKey]int
+}
+
+func newCoverageRecorder() *coverageRecorder {
+	return &coverageRecorder{
+		guards:   map[guardCell]int{},
+		marginal: map[string]int{},
+		full:     map[coverageKey]int{},
+	}
+}
+
+func (r *coverageRecorder) record(k coverageKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.guards[k.guard()]++
+	r.full[k]++
+	r.marginal[fmt.Sprintf("dirty=%v", k.dirty)]++
+	r.marginal["depMapCell="+k.depMapCell]++
+	r.marginal["fieldDeps="+k.fieldDeps]++
+	r.marginal["cachedDeps="+k.cachedDeps]++
+	r.marginal[fmt.Sprintf("useFreshDeps=%v", k.useFreshDeps)]++
+	r.marginal[fmt.Sprintf("backingIsBd=%v", k.backingIsBd)]++
+	r.marginal[fmt.Sprintf("confirmedClosed=%v", k.confirmedClosed)]++
+	r.marginal["preserveOutcome="+k.preserveOutcome]++
+	r.marginal["recency="+k.recency]++
+	r.marginal["changed="+k.changed]++
+	r.marginal["tomb="+k.tomb]++
+	r.marginal["seqFence="+k.seqFence]++
+	r.marginal["presence="+k.presence]++
+	r.marginal["regime="+k.regime]++
+}
+
+// classifyRow derives the coverageKey for id from the INPUT (st, in). The
+// id universe callers use is the union of all six maps plus freshByID, so
+// deps-only orphans classify too.
+func classifyRow(st storeState, in snapshotInputs, id string) coverageKey {
+	k := coverageKey{}
+	if in.quiescent(st) {
+		k.regime = "quiescent"
+	} else {
+		k.regime = "mutated"
+	}
+	fresh, f := in.freshByID[id]
+	cached, c := st.beads[id]
+	switch {
+	case f && c:
+		k.presence = "both"
+	case f:
+		k.presence = "snap"
+	case c:
+		k.presence = "cache"
+	default:
+		k.presence = "neither"
+	}
+	k.tomb = fenceCell(st.deletedSeq, id, in.startSeq)
+	k.seqFence = fenceCell(st.beadSeq, id, in.startSeq)
+	k.recency = recencyCell(st.localBeadAt, id, in.now)
+
+	postPreserve := computePostPreserveFresh(st, in)
+	pf := postPreserve[id]
+	if f && c {
+		k.changed = changedCell(cached, pf)
+		k.statusPair = cached.Status + ">" + fresh.Status
+	} else if f {
+		k.changed = "na"
+		k.statusPair = "?>" + fresh.Status
+	} else if c {
+		k.changed = "na"
+		k.statusPair = cached.Status + ">?"
+	} else {
+		k.changed = "na"
+		k.statusPair = "na"
+	}
+
+	_, k.dirty = st.dirty[id]
+	k.useFreshDeps = in.useFreshDeps
+	k.backingIsBd = st.backingIsBd
+	if in.useFreshDeps {
+		k.depMapCell = depSliceCell(in.depMap, id)
+		k.fieldDeps = "na"
+	} else {
+		k.depMapCell = "na"
+		k.fieldDeps = fieldDepsCell(fresh, f)
+	}
+	k.cachedDeps = depSliceCell(st.deps, id)
+	_, k.confirmedClosed = in.confirmedClosed[id]
+	k.preserveOutcome = preserveOutcomeCell(st, in, id)
+	return k
+}
+
+func fenceCell(m map[string]uint64, id string, startSeq uint64) string {
+	v, ok := m[id]
+	if !ok {
+		return "none"
+	}
+	switch {
+	case v < startSeq:
+		return "lt"
+	case v == startSeq:
+		return "eq"
+	default:
+		return "gt"
+	}
+}
+
+func recencyCell(m map[string]time.Time, id string, now time.Time) string {
+	t, ok := m[id]
+	if !ok || t.IsZero() {
+		return "none"
+	}
+	d := now.Sub(t)
+	switch {
+	case d <= 0:
+		return "now"
+	case d <= 2500*millis:
+		return "recent"
+	case d <= 5000*millis:
+		return "boundary"
+	case d <= 5001*millis:
+		return "justover"
+	default:
+		return "stale"
+	}
+}
+
+const millis = 1000000 // time.Millisecond in ns as a bare constant for arithmetic
+
+func changedCell(cached, fresh Bead) string {
+	if !beadChanged(cached, fresh, true) {
+		// Distinguish labels-only (skipLabels=true masks it) from truly equal.
+		if !slicesEqualStr(cached.Labels, fresh.Labels) {
+			return "labels"
+		}
+		return "equal"
+	}
+	switch {
+	case cached.Status != fresh.Status:
+		return "status"
+	case !boolPtrEqual(cached.IsBlocked, fresh.IsBlocked):
+		return "isblocked"
+	case !mapsEqualStr(cached.Metadata, fresh.Metadata):
+		return "metadata"
+	case !slicesEqualStr(cached.Needs, fresh.Needs):
+		return "needs"
+	case !depsSliceEqual(cached.Dependencies, fresh.Dependencies):
+		return "depsfield"
+	default:
+		return "other"
+	}
+}
+
+func depSliceCell(m map[string][]Dep, id string) string {
+	v, ok := m[id]
+	if !ok {
+		return "absent"
+	}
+	if v == nil {
+		return "nil"
+	}
+	if len(v) == 0 {
+		return "empty"
+	}
+	return "nonempty"
+}
+
+func fieldDepsCell(b Bead, present bool) string {
+	if !present {
+		return "na"
+	}
+	hasNeeds := len(b.Needs) > 0
+	hasDeps := len(b.Dependencies) > 0
+	switch {
+	case hasNeeds && hasDeps:
+		return "both"
+	case hasNeeds:
+		return "needs"
+	case hasDeps:
+		return "deps"
+	default:
+		return "none"
+	}
+}
+
+// preserveOutcomeCell re-runs the preserve eligibility predicate on the INPUT
+// state (council input-coverage hardening), using the shared helpers.
+func preserveOutcomeCell(st storeState, in snapshotInputs, id string) string {
+	item, ok := in.freshByID[id]
+	if !ok {
+		return "na"
+	}
+	if item.IsBlocked != nil {
+		return "inapplicable"
+	}
+	cached, cok := st.beads[id]
+	if !cok || cached.IsBlocked == nil {
+		return "no-cached"
+	}
+	c, _ := newMergeHarnessStore(st, nil)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	freshDeps := c.depsForReconcileLocked(id, item, in.depMap, in.useFreshDeps)
+	if depsChanged(c.deps[id], freshDeps) {
+		return "blocked-deps"
+	}
+	if c.readyBlockingDependencyTargetStatusChangedLocked(freshDeps, in.freshByID) {
+		return "blocked-target"
+	}
+	return "applied"
+}
+
+// --- small comparison helpers (test-local, avoid importing maps/slices) ---
+
+func slicesEqualStr(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func mapsEqualStr(a, b StringMap) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func depsSliceEqual(a, b []Dep) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// rowIDUniverse is the maximal id set for classification/oracle iteration: the
+// union of all six maps plus freshByID (council delete-B hardening — deps-only
+// orphans must classify).
+func rowIDUniverse(st storeState, in snapshotInputs) []string {
+	set := map[string]struct{}{}
+	for id := range st.beads {
+		set[id] = struct{}{}
+	}
+	for id := range st.deps {
+		set[id] = struct{}{}
+	}
+	for id := range st.dirty {
+		set[id] = struct{}{}
+	}
+	for id := range st.beadSeq {
+		set[id] = struct{}{}
+	}
+	for id := range st.localBeadAt {
+		set[id] = struct{}{}
+	}
+	for id := range st.deletedSeq {
+		set[id] = struct{}{}
+	}
+	for id := range in.freshByID {
+		set[id] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/beads/caching_store_reconcile_decision_test.go
+++ b/internal/beads/caching_store_reconcile_decision_test.go
@@ -6,11 +6,19 @@ import (
 )
 
 // T4: exhaustive test of the pure reconcileMergeDecision over its input
-// lattice, plus the §1.2 structural invariants. An independent transcription
-// of the normative semantics (expectedDecision) is asserted equal to the
-// production function on every lattice point — a decision-table oracle that
-// catches any drift of the production switch away from the spec — and the
-// structural invariants pin type-level properties the switch must uphold.
+// lattice, plus the §1.2 structural invariants.
+//
+// Scope of the oracle: expectedDecision is a hand-transcription of the same
+// decision table the production switch encodes, so this test is DRIFT and
+// STRUCTURAL-INVARIANT coverage — it catches an accidental future edit that
+// moves one function out of step with the other, and the invariants pin
+// type-level properties the switch must uphold on every lattice point. It is
+// deliberately NOT an independent semantic oracle: a spec misunderstanding
+// baked into both functions would pass here. The independent semantic ground
+// truth is the frozen Branch A / Branch B differential gate
+// (caching_store_reconcile_differential_test.go), which runs the real
+// pre-collapse bodies and would fail on a wrong decision; this table sits on
+// top of that as cheap, exhaustive drift protection.
 
 func expectedDecision(in mergeRowInput) mergeDecision {
 	switch {
@@ -19,7 +27,7 @@ func expectedDecision(in mergeRowInput) mergeDecision {
 			return mergeDecision{action: mergeSkipFenced, degradeDepsComplete: in.cachedExists && !in.hasCachedDeps}
 		}
 		if in.cachedExists && recentLocalMutation(in.localAt, in.now) && beadChanged(in.cached, in.fresh, in.skipLabels) {
-			return mergeDecision{action: mergeSkipRecentLocal, degradeDepsComplete: !in.hasCachedDeps}
+			return mergeDecision{action: mergeSkipRecentLocal, degradeDepsComplete: !in.hasCachedDeps || depsChanged(in.cachedDeps, in.freshDeps)}
 		}
 		n := ""
 		switch {

--- a/internal/beads/caching_store_reconcile_decision_test.go
+++ b/internal/beads/caching_store_reconcile_decision_test.go
@@ -1,0 +1,157 @@
+package beads
+
+import (
+	"testing"
+	"time"
+)
+
+// T4: exhaustive test of the pure reconcileMergeDecision over its input
+// lattice, plus the §1.2 structural invariants. An independent transcription
+// of the normative semantics (expectedDecision) is asserted equal to the
+// production function on every lattice point — a decision-table oracle that
+// catches any drift of the production switch away from the spec — and the
+// structural invariants pin type-level properties the switch must uphold.
+
+func expectedDecision(in mergeRowInput) mergeDecision {
+	switch {
+	case in.freshExists:
+		if in.deletedAtSeq > in.startSeq || in.beadAtSeq > in.startSeq {
+			return mergeDecision{action: mergeSkipFenced, degradeDepsComplete: in.cachedExists && !in.hasCachedDeps}
+		}
+		if in.cachedExists && recentLocalMutation(in.localAt, in.now) && beadChanged(in.cached, in.fresh, in.skipLabels) {
+			return mergeDecision{action: mergeSkipRecentLocal, degradeDepsComplete: !in.hasCachedDeps}
+		}
+		n := ""
+		switch {
+		case !in.cachedExists:
+			n = "bead.created"
+		case beadChanged(in.cached, in.fresh, in.skipLabels):
+			n = "bead.updated"
+		case depsChanged(in.cachedDeps, in.freshDeps):
+			n = "bead.updated"
+		}
+		return mergeDecision{action: mergeAbsorb, notification: n}
+	case in.cachedExists:
+		if in.deletedAtSeq > in.startSeq || in.beadAtSeq > in.startSeq {
+			return mergeDecision{action: mergeSkipFenced}
+		}
+		if in.cached.Status != "closed" && recentLocalMutation(in.localAt, in.now) {
+			return mergeDecision{action: mergeSkipRecentLocal}
+		}
+		n := ""
+		if in.cached.Status != "closed" {
+			n = "bead.closed"
+		}
+		return mergeDecision{action: mergeEvict, notification: n}
+	default:
+		if in.deletedAtSeq > in.startSeq || in.beadAtSeq > in.startSeq {
+			return mergeDecision{action: mergeSkipFenced}
+		}
+		if recentLocalMutation(in.localAt, in.now) {
+			return mergeDecision{action: mergeSkipRecentLocal}
+		}
+		return mergeDecision{action: mergeGCFences}
+	}
+}
+
+func TestReconcileMergeDecision_Exhaustive(t *testing.T) {
+	const startSeq = uint64(100)
+	now := fxNow
+	seqVals := []uint64{0, 99, 100, 101}
+	recVals := []time.Time{{}, fxRecent(), fxBoundary(), fxJustOver(), fxStale()}
+	// Beads chosen to drive beadChanged both ways under each status.
+	beadOpen := bead("x", "open")
+	beadOpenChanged := beadWith("x", "open", func(b *Bead) { b.Title = "changed" })
+	beadClosed := bead("x", "closed")
+	beadInProg := bead("x", "in_progress")
+	beadSet := []Bead{beadOpen, beadOpenChanged, beadClosed, beadInProg}
+	depSet := [][]Dep{nil, {dep("x", "d1")}}
+
+	var count int
+	for _, fe := range []bool{true, false} {
+		for _, ce := range []bool{true, false} {
+			for _, fresh := range beadSet {
+				for _, cached := range beadSet {
+					for _, fdeps := range depSet {
+						for _, cdeps := range depSet {
+							for _, hcd := range []bool{true, false} {
+								for _, del := range seqVals {
+									for _, bs := range seqVals {
+										for _, rec := range recVals {
+											for _, skip := range []bool{true, false} {
+												in := mergeRowInput{
+													freshExists:   fe,
+													fresh:         fresh,
+													freshDeps:     fdeps,
+													cachedExists:  ce,
+													cached:        cached,
+													cachedDeps:    cdeps,
+													hasCachedDeps: hcd,
+													deletedAtSeq:  del,
+													beadAtSeq:     bs,
+													startSeq:      startSeq,
+													localAt:       rec,
+													now:           now,
+													skipLabels:    skip,
+												}
+												got := reconcileMergeDecision(in)
+												want := expectedDecision(in)
+												if got != want {
+													t.Fatalf("decision mismatch\n in=%+v\n got=%+v\n want=%+v", in, got, want)
+												}
+												assertDecisionInvariants(t, in, got)
+												count++
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if count < 10000 {
+		t.Fatalf("lattice too small: %d points", count)
+	}
+}
+
+func assertDecisionInvariants(t *testing.T, in mergeRowInput, d mergeDecision) {
+	t.Helper()
+	// INV-A: an uncached absorb-cell row can never yield mergeSkipRecentLocal.
+	if in.freshExists && !in.cachedExists && d.action == mergeSkipRecentLocal {
+		t.Fatalf("uncached absorb cell yielded mergeSkipRecentLocal: %+v", in)
+	}
+	// INV-B: mergeGCFences only when both rows absent.
+	if d.action == mergeGCFences && (in.freshExists || in.cachedExists) {
+		t.Fatalf("mergeGCFences with a present row: %+v", in)
+	}
+	// INV-C: degradeDepsComplete is only ever set on absorb-cell skip arms.
+	if d.degradeDepsComplete {
+		absorbCellSkip := in.freshExists &&
+			(d.action == mergeSkipFenced || d.action == mergeSkipRecentLocal)
+		if !absorbCellSkip {
+			t.Fatalf("degradeDepsComplete set outside an absorb-cell skip arm: in=%+v d=%+v", in, d)
+		}
+	}
+	// INV-D: eviction-cell never degrades depsComplete.
+	if !in.freshExists && in.cachedExists && d.degradeDepsComplete {
+		t.Fatalf("eviction cell degraded depsComplete: %+v", in)
+	}
+	// INV-E: notifications only accompany their action.
+	switch d.action {
+	case mergeAbsorb:
+		if d.notification != "" && d.notification != "bead.created" && d.notification != "bead.updated" {
+			t.Fatalf("absorb produced notification %q", d.notification)
+		}
+	case mergeEvict:
+		if d.notification != "" && d.notification != "bead.closed" {
+			t.Fatalf("evict produced notification %q", d.notification)
+		}
+	default:
+		if d.notification != "" {
+			t.Fatalf("action %v produced notification %q", d.action, d.notification)
+		}
+	}
+}

--- a/internal/beads/caching_store_reconcile_differential_test.go
+++ b/internal/beads/caching_store_reconcile_differential_test.go
@@ -215,15 +215,13 @@ func (b *countingBacking) List(q ListQuery) ([]Bead, error) {
 // type assertion (no call), so a stray call would panic — a louder failure
 // than a count mismatch. The store starts cacheLive (promoteLiveLocked
 // overwrites it regardless).
-func newMergeHarnessStore(st storeState, backingTruth *MemStore) (*CachingStore, *countingBacking) {
+func newMergeHarnessStore(st storeState) (*CachingStore, *countingBacking) {
 	var counter *countingBacking
 	var backing Store
 	if st.backingIsBd {
 		backing = (*BdStore)(nil)
 	} else {
-		if backingTruth == nil {
-			backingTruth = NewMemStore()
-		}
+		backingTruth := NewMemStore()
 		counter = &countingBacking{Store: backingTruth, inner: backingTruth}
 		backing = counter
 	}
@@ -306,8 +304,8 @@ type mergeImplResult struct {
 }
 
 // runNewMerge exercises the LIVE collapsed seam (mergeSnapshotLocked).
-func runNewMerge(st storeState, in snapshotInputs, backingTruth *MemStore) mergeImplResult {
-	c, counter := newMergeHarnessStore(st, backingTruth)
+func runNewMerge(st storeState, in snapshotInputs) mergeImplResult {
+	c, counter := newMergeHarnessStore(st)
 	c.mu.Lock()
 	res := c.mergeSnapshotLocked(in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
 	c.mu.Unlock()
@@ -315,8 +313,8 @@ func runNewMerge(st storeState, in snapshotInputs, backingTruth *MemStore) merge
 }
 
 // runLegacyA exercises the frozen Branch A body.
-func runLegacyA(st storeState, in snapshotInputs, backingTruth *MemStore) mergeImplResult {
-	c, counter := newMergeHarnessStore(st, backingTruth)
+func runLegacyA(st storeState, in snapshotInputs) mergeImplResult {
+	c, counter := newMergeHarnessStore(st)
 	c.mu.Lock()
 	res := legacyBranchAMerge(c, in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
 	c.mu.Unlock()
@@ -324,8 +322,8 @@ func runLegacyA(st storeState, in snapshotInputs, backingTruth *MemStore) mergeI
 }
 
 // runLegacyB exercises the frozen Branch B body.
-func runLegacyB(st storeState, in snapshotInputs, backingTruth *MemStore) mergeImplResult {
-	c, counter := newMergeHarnessStore(st, backingTruth)
+func runLegacyB(st storeState, in snapshotInputs) mergeImplResult {
+	c, counter := newMergeHarnessStore(st)
 	c.mu.Lock()
 	res := legacyBranchBMerge(c, in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
 	c.mu.Unlock()
@@ -456,7 +454,7 @@ func legacyBranchBMerge(
 	c *CachingStore,
 	freshByID map[string]Bead, confirmedClosed map[string]Bead,
 	depMap map[string][]Dep, useFreshDeps bool,
-	startSeq uint64, now time.Time,
+	_ uint64, now time.Time,
 ) mergeSectionResult {
 	c.preserveCachedReadyProjectionLocked(freshByID, depMap, useFreshDeps)
 

--- a/internal/beads/caching_store_reconcile_differential_test.go
+++ b/internal/beads/caching_store_reconcile_differential_test.go
@@ -116,12 +116,11 @@ func cloneDepMap(m map[string][]Dep) map[string][]Dep {
 	}
 	out := make(map[string][]Dep, len(m))
 	for k, v := range m {
-		// Preserve the nil-vs-empty distinction: cloneDeps(nil)==nil and
-		// cloneDeps([]Dep{}) stays non-nil, both faithfully.
-		if v == nil {
-			out[k] = nil
-			continue
-		}
+		// Match the production cloneDeps helper: an empty entry (nil or []Dep{})
+		// clones to nil, a non-empty one is copied. This mirrors what the live
+		// seam stores, so the differential oracle reasons about the same
+		// normalized deps. Key presence is preserved; the empty-vs-nil value
+		// distinction is intentionally collapsed, exactly as the seam collapses it.
 		out[k] = cloneDeps(v)
 	}
 	return out

--- a/internal/beads/caching_store_reconcile_differential_test.go
+++ b/internal/beads/caching_store_reconcile_differential_test.go
@@ -1,0 +1,557 @@
+package beads
+
+// Differential gate for the S01 Phase-2 reconcile collapse.
+//
+// The fleet-critical beads read cache reconciles a full-scan snapshot into six
+// in-memory maps. Before Phase 2 this was two branches: Branch A (per-row
+// in-place merge, taken when a local write raced the scan) and Branch B
+// (whole-map rebuild, taken in the quiescent regime). Phase 2 collapses both
+// into a single pipeline routed through the pure reconcileMergeDecision plus a
+// fence/deps-GC sweep.
+//
+// A merge divergence does not crash — it silently serves stale or wrong beads
+// to every agent (#2987 class). This gate is the sole quality assurance for
+// the collapse. It runs the FROZEN legacy Branch A and Branch B bodies and the
+// LIVE collapsed seam on byte-identical inputs and asserts their end-states are
+// identical modulo the exactly-enumerated §2 deltas (D1, D1', D2, D3, D3', D4,
+// D5), over a provably-covered decision space.
+//
+// Provenance of the frozen copies: mechanical transliterations of
+// runReconciliation's two branches at the pre-collapse commit 84c010a1b
+// (internal/beads/caching_store_reconcile.go lines 346-542), extracted
+// 2026-07-08. They call the REAL in-package helpers (recentLocalBeadConflictLocked,
+// depsForReconcileLocked, carryRecentLocalMutationLocked,
+// preserveCachedReadyProjectionLocked, beadChanged, depsChanged, cloneBead,
+// cloneDeps, absorbFreshLocked, evictLocked) so helper semantics are shared by
+// construction; the differential surface is exactly the branch structure being
+// collapsed. Scope: this gate proves branch-structure equivalence GIVEN shared
+// helpers; helper semantics are pinned separately by the white-box suite + T4.
+//
+// DO NOT edit or delete the frozen copies. They are the ongoing guard: every
+// CI run re-proves the collapsed loop against Branch A/B semantics.
+
+import (
+	"reflect"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Harness state types
+// ---------------------------------------------------------------------------
+
+// storeState is the pre-merge cache state the seam reads: the six per-row maps
+// plus the two scalars that steer it (depsComplete is written, mutationSeq
+// selects the OLD regime). backingIsBd drives depsForReconcileLocked's
+// off-BdStore cached-deps fallback and is a shared input to all three
+// implementations.
+type storeState struct {
+	beads        map[string]Bead
+	deps         map[string][]Dep
+	depsComplete bool
+	dirty        map[string]struct{}
+	beadSeq      map[string]uint64
+	localBeadAt  map[string]time.Time
+	deletedSeq   map[string]uint64
+	mutationSeq  uint64
+	backingIsBd  bool
+}
+
+// snapshotInputs is the seam's argument tuple (mergeSnapshotLocked's params).
+type snapshotInputs struct {
+	freshByID       map[string]Bead
+	confirmedClosed map[string]Bead
+	depMap          map[string][]Dep
+	useFreshDeps    bool
+	startSeq        uint64
+	now             time.Time
+}
+
+// quiescent reports whether the OLD selector would take Branch B.
+func (in snapshotInputs) quiescent(st storeState) bool {
+	return st.mutationSeq == in.startSeq
+}
+
+// mergeEndState is the deterministic post-merge cache state the oracle compares.
+// It captures every field the seam writes; the field-coverage census
+// (TestMergeOracleFieldCoverage) proves this list stays exhaustive.
+type mergeEndState struct {
+	beads        map[string]Bead
+	deps         map[string][]Dep
+	depsComplete bool
+	dirty        map[string]struct{}
+	beadSeq      map[string]uint64
+	localBeadAt  map[string]time.Time
+	deletedSeq   map[string]uint64
+	state        cacheState
+	lastFreshAt  time.Time
+	mutationSeq  uint64
+	primeErr     string
+	syncFailures int
+	// stats fields the seam writes.
+	statsAdds            int64
+	statsRemoves         int64
+	statsUpdates         int64
+	statsLastReconcileAt time.Time
+	statsLastFreshAt     time.Time
+}
+
+// ---------------------------------------------------------------------------
+// Deep clone (so the three runs see byte-identical, independent inputs)
+// ---------------------------------------------------------------------------
+
+func cloneBeadMap(m map[string]Bead) map[string]Bead {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]Bead, len(m))
+	for k, v := range m {
+		out[k] = cloneBead(v)
+	}
+	return out
+}
+
+func cloneDepMap(m map[string][]Dep) map[string][]Dep {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string][]Dep, len(m))
+	for k, v := range m {
+		// Preserve the nil-vs-empty distinction: cloneDeps(nil)==nil and
+		// cloneDeps([]Dep{}) stays non-nil, both faithfully.
+		if v == nil {
+			out[k] = nil
+			continue
+		}
+		out[k] = cloneDeps(v)
+	}
+	return out
+}
+
+func cloneDirty(m map[string]struct{}) map[string]struct{} {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]struct{}, len(m))
+	for k := range m {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+func cloneU64Map(m map[string]uint64) map[string]uint64 {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]uint64, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneTimeMap(m map[string]time.Time) map[string]time.Time {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]time.Time, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneStoreState(st storeState) storeState {
+	return storeState{
+		beads:        cloneBeadMap(st.beads),
+		deps:         cloneDepMap(st.deps),
+		depsComplete: st.depsComplete,
+		dirty:        cloneDirty(st.dirty),
+		beadSeq:      cloneU64Map(st.beadSeq),
+		localBeadAt:  cloneTimeMap(st.localBeadAt),
+		deletedSeq:   cloneU64Map(st.deletedSeq),
+		mutationSeq:  st.mutationSeq,
+		backingIsBd:  st.backingIsBd,
+	}
+}
+
+func cloneSnapshotInputs(in snapshotInputs) snapshotInputs {
+	return snapshotInputs{
+		freshByID:       cloneBeadMap(in.freshByID),
+		confirmedClosed: cloneBeadMap(in.confirmedClosed),
+		depMap:          cloneDepMap(in.depMap),
+		useFreshDeps:    in.useFreshDeps,
+		startSeq:        in.startSeq,
+		now:             in.now,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Harness store construction + end-state capture
+// ---------------------------------------------------------------------------
+
+// countingBacking wraps a Store and counts Get/List so the merge-purity
+// assertion can prove the seam performs zero backing I/O. Every other Store
+// method delegates through the embedded interface.
+type countingBacking struct {
+	Store
+	inner Store
+	gets  int
+	lists int
+}
+
+func (b *countingBacking) Get(id string) (Bead, error) {
+	b.gets++
+	return b.inner.Get(id)
+}
+
+func (b *countingBacking) List(q ListQuery) ([]Bead, error) {
+	b.lists++
+	return b.inner.List(q)
+}
+
+// newMergeHarnessStore builds a CachingStore seeded directly from st. The
+// backing is a call-counting fake for the off-BdStore case; for backingIsBd
+// it is a nil *BdStore whose only in-seam use is depsForReconcileLocked's
+// type assertion (no call), so a stray call would panic — a louder failure
+// than a count mismatch. The store starts cacheLive (promoteLiveLocked
+// overwrites it regardless).
+func newMergeHarnessStore(st storeState, backingTruth *MemStore) (*CachingStore, *countingBacking) {
+	var counter *countingBacking
+	var backing Store
+	if st.backingIsBd {
+		backing = (*BdStore)(nil)
+	} else {
+		if backingTruth == nil {
+			backingTruth = NewMemStore()
+		}
+		counter = &countingBacking{Store: backingTruth, inner: backingTruth}
+		backing = counter
+	}
+	c := &CachingStore{
+		backing:      backing,
+		beads:        cloneBeadMap(st.beads),
+		deps:         cloneDepMap(st.deps),
+		depsComplete: st.depsComplete,
+		dirty:        cloneDirty(st.dirty),
+		beadSeq:      cloneU64Map(st.beadSeq),
+		localBeadAt:  cloneTimeMap(st.localBeadAt),
+		deletedSeq:   cloneU64Map(st.deletedSeq),
+		mutationSeq:  st.mutationSeq,
+		state:        cacheLive,
+	}
+	ensureMaps(c)
+	return c, counter
+}
+
+// ensureMaps guarantees non-nil maps so seeded-empty states behave like a
+// freshly constructed store.
+func ensureMaps(c *CachingStore) {
+	if c.beads == nil {
+		c.beads = make(map[string]Bead)
+	}
+	if c.deps == nil {
+		c.deps = make(map[string][]Dep)
+	}
+	if c.dirty == nil {
+		c.dirty = make(map[string]struct{})
+	}
+	if c.beadSeq == nil {
+		c.beadSeq = make(map[string]uint64)
+	}
+	if c.localBeadAt == nil {
+		c.localBeadAt = make(map[string]time.Time)
+	}
+	if c.deletedSeq == nil {
+		c.deletedSeq = make(map[string]uint64)
+	}
+}
+
+func captureEndState(c *CachingStore) mergeEndState {
+	primeErr := ""
+	if c.primePartialErr != nil {
+		primeErr = c.primePartialErr.Error()
+	}
+	return mergeEndState{
+		beads:                cloneBeadMap(c.beads),
+		deps:                 cloneDepMap(c.deps),
+		depsComplete:         c.depsComplete,
+		dirty:                cloneDirty(c.dirty),
+		beadSeq:              cloneU64Map(c.beadSeq),
+		localBeadAt:          cloneTimeMap(c.localBeadAt),
+		deletedSeq:           cloneU64Map(c.deletedSeq),
+		state:                c.state,
+		lastFreshAt:          c.lastFreshAt,
+		mutationSeq:          c.mutationSeq,
+		primeErr:             primeErr,
+		syncFailures:         c.syncFailures,
+		statsAdds:            c.stats.Adds,
+		statsRemoves:         c.stats.Removes,
+		statsUpdates:         c.stats.Updates,
+		statsLastReconcileAt: c.stats.LastReconcileAt,
+		statsLastFreshAt:     c.stats.LastFreshAt,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The three implementations under test
+// ---------------------------------------------------------------------------
+
+// mergeImpl runs one merge implementation against a store seeded from st with
+// snapshot inputs in, and returns the captured end-state, notifications,
+// counters, and backing-call counts.
+type mergeImplResult struct {
+	end           mergeEndState
+	notifications []cacheNotification
+	backingCalls  int
+}
+
+// runNewMerge exercises the LIVE collapsed seam (mergeSnapshotLocked).
+func runNewMerge(st storeState, in snapshotInputs, backingTruth *MemStore) mergeImplResult {
+	c, counter := newMergeHarnessStore(st, backingTruth)
+	c.mu.Lock()
+	res := c.mergeSnapshotLocked(in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
+	c.mu.Unlock()
+	return mergeImplResult{end: captureEndState(c), notifications: res.notifications, backingCalls: counterCalls(counter)}
+}
+
+// runLegacyA exercises the frozen Branch A body.
+func runLegacyA(st storeState, in snapshotInputs, backingTruth *MemStore) mergeImplResult {
+	c, counter := newMergeHarnessStore(st, backingTruth)
+	c.mu.Lock()
+	res := legacyBranchAMerge(c, in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
+	c.mu.Unlock()
+	return mergeImplResult{end: captureEndState(c), notifications: res.notifications, backingCalls: counterCalls(counter)}
+}
+
+// runLegacyB exercises the frozen Branch B body.
+func runLegacyB(st storeState, in snapshotInputs, backingTruth *MemStore) mergeImplResult {
+	c, counter := newMergeHarnessStore(st, backingTruth)
+	c.mu.Lock()
+	res := legacyBranchBMerge(c, in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
+	c.mu.Unlock()
+	return mergeImplResult{end: captureEndState(c), notifications: res.notifications, backingCalls: counterCalls(counter)}
+}
+
+func counterCalls(counter *countingBacking) int {
+	if counter == nil {
+		return 0
+	}
+	return counter.gets + counter.lists
+}
+
+// ---------------------------------------------------------------------------
+// FROZEN legacy Branch A — DO NOT EDIT (see provenance header above)
+// ---------------------------------------------------------------------------
+
+// legacyBranchAMerge is the transliteration of the c.mutationSeq != startSeq
+// arm of runReconciliation at 84c010a1b, minus the impure tail that stays in
+// runReconciliation (backing.List, latency/cadence bookkeeping, the success
+// log, notifyChanges). It performs the preserve pass, the per-row in-place
+// absorb loop, and the eviction loop, then the tail scalars that the seam
+// owns, and returns the notifications + counters. Caller holds c.mu.
+func legacyBranchAMerge(
+	c *CachingStore,
+	freshByID map[string]Bead, confirmedClosed map[string]Bead,
+	depMap map[string][]Dep, useFreshDeps bool,
+	startSeq uint64, now time.Time,
+) mergeSectionResult {
+	c.preserveCachedReadyProjectionLocked(freshByID, depMap, useFreshDeps)
+
+	var adds, removes, updates int64
+	notifications := make([]cacheNotification, 0, len(freshByID))
+	nextDepsComplete := useFreshDeps
+
+	for id, freshBead := range freshByID {
+		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
+			if _, exists := c.beads[id]; exists {
+				if _, ok := c.deps[id]; !ok {
+					nextDepsComplete = false
+				}
+			}
+			continue
+		}
+		if _, keep := c.recentLocalBeadConflictLocked(id, freshBead, now, true); keep {
+			if _, ok := c.deps[id]; !ok {
+				nextDepsComplete = false
+			}
+			continue
+		}
+		freshDeps := c.depsForReconcileLocked(id, freshBead, depMap, useFreshDeps)
+
+		old, exists := c.beads[id]
+		switch {
+		case !exists:
+			adds++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.created",
+				bead:      cloneBead(freshBead),
+			})
+		case beadChanged(old, freshBead, true):
+			updates++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.updated",
+				bead:      cloneBead(freshBead),
+			})
+		case depsChanged(c.deps[id], freshDeps):
+			updates++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.updated",
+				bead:      cloneBead(freshBead),
+			})
+		}
+
+		c.absorbFreshLocked(id, freshBead, now, absorbOpts{
+			depsMode:   depsExplicit,
+			deps:       freshDeps,
+			seqMode:    seqClearGuarded,
+			clearDirty: true,
+		})
+	}
+
+	for id, old := range c.beads {
+		if _, exists := freshByID[id]; exists {
+			continue
+		}
+		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
+			continue
+		}
+		if old.Status != "closed" && recentLocalMutation(c.localBeadAt[id], now) {
+			continue
+		}
+		removes++
+		if old.Status != "closed" {
+			closed := cloneBead(old)
+			closed.Status = "closed"
+			if freshClosed, ok := confirmedClosed[id]; ok {
+				closed = cloneBead(freshClosed)
+			}
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.closed",
+				bead:      closed,
+			})
+		}
+		c.evictLocked(id)
+	}
+
+	c.syncFailures = 0
+	c.depsComplete = nextDepsComplete
+	c.primePartialErr = nil
+	c.promoteLiveLocked()
+	c.stats.LastReconcileAt = now
+	c.stats.Adds += adds
+	c.stats.Removes += removes
+	c.stats.Updates += updates
+	c.markFreshLocked(now)
+	return mergeSectionResult{notifications: notifications, adds: adds, removes: removes, updates: updates}
+}
+
+// ---------------------------------------------------------------------------
+// FROZEN legacy Branch B — DO NOT EDIT (see provenance header above)
+// ---------------------------------------------------------------------------
+
+// legacyBranchBMerge is the transliteration of the quiescent (else) arm of
+// runReconciliation at 84c010a1b: the whole-map rebuild. Same seam boundary
+// as legacyBranchAMerge. Caller holds c.mu.
+func legacyBranchBMerge(
+	c *CachingStore,
+	freshByID map[string]Bead, confirmedClosed map[string]Bead,
+	depMap map[string][]Dep, useFreshDeps bool,
+	startSeq uint64, now time.Time,
+) mergeSectionResult {
+	c.preserveCachedReadyProjectionLocked(freshByID, depMap, useFreshDeps)
+
+	var adds, removes, updates int64
+	notifications := make([]cacheNotification, 0, len(freshByID))
+	nextBeads := make(map[string]Bead, len(freshByID))
+	nextDeps := make(map[string][]Dep, len(freshByID))
+	nextDirty := make(map[string]struct{})
+	nextBeadSeq := make(map[string]uint64)
+	nextLocalBeadAt := make(map[string]time.Time)
+
+	for id, freshBead := range freshByID {
+		beadForCache := freshBead
+		preservedRecentLocal := false
+		if current, keep := c.recentLocalBeadConflictLocked(id, freshBead, now, true); keep {
+			beadForCache = current
+			preservedRecentLocal = true
+			c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
+		}
+		freshDeps := c.depsForReconcileLocked(id, freshBead, depMap, useFreshDeps)
+		nextBeads[id] = cloneBead(beadForCache)
+		nextDeps[id] = cloneDeps(freshDeps)
+
+		old, exists := c.beads[id]
+		switch {
+		case !exists:
+			adds++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.created",
+				bead:      cloneBead(beadForCache),
+			})
+		case !preservedRecentLocal && beadChanged(old, freshBead, true):
+			updates++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.updated",
+				bead:      cloneBead(freshBead),
+			})
+		case !preservedRecentLocal && depsChanged(c.deps[id], freshDeps):
+			updates++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.updated",
+				bead:      cloneBead(freshBead),
+			})
+		}
+	}
+
+	for id, old := range c.beads {
+		if _, exists := freshByID[id]; !exists {
+			if old.Status != "closed" && recentLocalMutation(c.localBeadAt[id], now) {
+				nextBeads[id] = cloneBead(old)
+				if deps, ok := c.deps[id]; ok {
+					nextDeps[id] = cloneDeps(deps)
+				}
+				c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
+				continue
+			}
+			removes++
+			if old.Status == "closed" {
+				continue
+			}
+			closed := cloneBead(old)
+			closed.Status = "closed"
+			if freshClosed, ok := confirmedClosed[id]; ok {
+				closed = cloneBead(freshClosed)
+			}
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.closed",
+				bead:      closed,
+			})
+		}
+	}
+
+	c.beads = nextBeads
+	c.deps = nextDeps
+	c.depsComplete = useFreshDeps
+	c.dirty = nextDirty
+	c.beadSeq = nextBeadSeq
+	c.localBeadAt = nextLocalBeadAt
+	c.deletedSeq = make(map[string]uint64)
+	c.syncFailures = 0
+	c.primePartialErr = nil
+	c.promoteLiveLocked()
+	c.stats.LastReconcileAt = now
+	c.stats.Adds += adds
+	c.stats.Removes += removes
+	c.stats.Updates += updates
+	c.markFreshLocked(now)
+	return mergeSectionResult{notifications: notifications, adds: adds, removes: removes, updates: updates}
+}
+
+// endStatesEqual is exact structural equality of two captured end-states,
+// including nil-vs-empty distinctions for every map (reflect.DeepEqual treats
+// nil and empty maps/slices as unequal, which is what depsComplete-degradation
+// and entry-presence semantics require). time.Time values are exact copies of
+// injected inputs across all runs, so DeepEqual compares them soundly.
+func endStatesEqual(a, b mergeEndState) bool {
+	return reflect.DeepEqual(a, b)
+}

--- a/internal/beads/caching_store_reconcile_diffutil_test.go
+++ b/internal/beads/caching_store_reconcile_diffutil_test.go
@@ -1,0 +1,180 @@
+package beads
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+func reflectDeepEqual(a, b any) bool { return reflect.DeepEqual(a, b) }
+
+// diffEndStates renders a human-readable field-by-field diff of two end-states
+// for test failure output.
+func diffEndStates(want, got mergeEndState) string {
+	var b strings.Builder
+	diffBeadMap(&b, "beads", want.beads, got.beads)
+	diffDepMap(&b, "deps", want.deps, got.deps)
+	diffStructSet(&b, "dirty", want.dirty, got.dirty)
+	diffU64Map(&b, "beadSeq", want.beadSeq, got.beadSeq)
+	diffTimeMap(&b, "localBeadAt", want.localBeadAt, got.localBeadAt)
+	diffU64Map(&b, "deletedSeq", want.deletedSeq, got.deletedSeq)
+	if want.depsComplete != got.depsComplete {
+		fmt.Fprintf(&b, "  depsComplete: want=%v got=%v\n", want.depsComplete, got.depsComplete)
+	}
+	if want.state != got.state {
+		fmt.Fprintf(&b, "  state: want=%v got=%v\n", want.state, got.state)
+	}
+	if !want.lastFreshAt.Equal(got.lastFreshAt) {
+		fmt.Fprintf(&b, "  lastFreshAt: want=%v got=%v\n", want.lastFreshAt, got.lastFreshAt)
+	}
+	if want.mutationSeq != got.mutationSeq {
+		fmt.Fprintf(&b, "  mutationSeq: want=%v got=%v\n", want.mutationSeq, got.mutationSeq)
+	}
+	if want.primeErr != got.primeErr {
+		fmt.Fprintf(&b, "  primeErr: want=%q got=%q\n", want.primeErr, got.primeErr)
+	}
+	if want.syncFailures != got.syncFailures {
+		fmt.Fprintf(&b, "  syncFailures: want=%v got=%v\n", want.syncFailures, got.syncFailures)
+	}
+	if want.statsAdds != got.statsAdds {
+		fmt.Fprintf(&b, "  stats.Adds: want=%v got=%v\n", want.statsAdds, got.statsAdds)
+	}
+	if want.statsRemoves != got.statsRemoves {
+		fmt.Fprintf(&b, "  stats.Removes: want=%v got=%v\n", want.statsRemoves, got.statsRemoves)
+	}
+	if want.statsUpdates != got.statsUpdates {
+		fmt.Fprintf(&b, "  stats.Updates: want=%v got=%v\n", want.statsUpdates, got.statsUpdates)
+	}
+	if !want.statsLastReconcileAt.Equal(got.statsLastReconcileAt) {
+		fmt.Fprintf(&b, "  stats.LastReconcileAt: want=%v got=%v\n", want.statsLastReconcileAt, got.statsLastReconcileAt)
+	}
+	if !want.statsLastFreshAt.Equal(got.statsLastFreshAt) {
+		fmt.Fprintf(&b, "  stats.LastFreshAt: want=%v got=%v\n", want.statsLastFreshAt, got.statsLastFreshAt)
+	}
+	if b.Len() == 0 {
+		return "  (no field-level diff detected — check reflect.DeepEqual edge cases)\n"
+	}
+	return b.String()
+}
+
+func sortedKeysAny[V any](m map[string]V) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+func diffBeadMap(b *strings.Builder, label string, want, got map[string]Bead) {
+	keys := unionKeysBead(want, got)
+	for _, k := range keys {
+		wv, wok := want[k]
+		gv, gok := got[k]
+		switch {
+		case wok && !gok:
+			fmt.Fprintf(b, "  %s[%q]: want present, got absent\n", label, k)
+		case !wok && gok:
+			fmt.Fprintf(b, "  %s[%q]: want absent, got present\n", label, k)
+		case wok && gok && !reflect.DeepEqual(wv, gv):
+			fmt.Fprintf(b, "  %s[%q]: bead differs\n    want=%+v\n    got =%+v\n", label, k, wv, gv)
+		}
+	}
+}
+
+func diffDepMap(b *strings.Builder, label string, want, got map[string][]Dep) {
+	keys := unionKeysDep(want, got)
+	for _, k := range keys {
+		wv, wok := want[k]
+		gv, gok := got[k]
+		switch {
+		case wok && !gok:
+			fmt.Fprintf(b, "  %s[%q]: want present (%v), got absent\n", label, k, wv)
+		case !wok && gok:
+			fmt.Fprintf(b, "  %s[%q]: want absent, got present (%v)\n", label, k, gv)
+		case wok && gok && !reflect.DeepEqual(wv, gv):
+			fmt.Fprintf(b, "  %s[%q]: want=%v got=%v\n", label, k, wv, gv)
+		}
+	}
+}
+
+func diffStructSet(b *strings.Builder, label string, want, got map[string]struct{}) {
+	for _, k := range sortedKeysAny(want) {
+		if _, ok := got[k]; !ok {
+			fmt.Fprintf(b, "  %s[%q]: want present, got absent\n", label, k)
+		}
+	}
+	for _, k := range sortedKeysAny(got) {
+		if _, ok := want[k]; !ok {
+			fmt.Fprintf(b, "  %s[%q]: want absent, got present\n", label, k)
+		}
+	}
+}
+
+func diffU64Map(b *strings.Builder, label string, want, got map[string]uint64) {
+	keys := unionKeysU64(want, got)
+	for _, k := range keys {
+		wv, wok := want[k]
+		gv, gok := got[k]
+		if wok != gok || wv != gv {
+			fmt.Fprintf(b, "  %s[%q]: want=(%d,present=%v) got=(%d,present=%v)\n", label, k, wv, wok, gv, gok)
+		}
+	}
+}
+
+func diffTimeMap(b *strings.Builder, label string, want, got map[string]time.Time) {
+	keys := unionKeysTime(want, got)
+	for _, k := range keys {
+		wv, wok := want[k]
+		gv, gok := got[k]
+		if wok != gok || !wv.Equal(gv) {
+			fmt.Fprintf(b, "  %s[%q]: want=(%v,present=%v) got=(%v,present=%v)\n", label, k, wv, wok, gv, gok)
+		}
+	}
+}
+
+func unionKeysBead(a, b map[string]Bead) []string {
+	set := map[string]struct{}{}
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	return sortedKeysAny(set)
+}
+
+func unionKeysDep(a, b map[string][]Dep) []string {
+	set := map[string]struct{}{}
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	return sortedKeysAny(set)
+}
+
+func unionKeysU64(a, b map[string]uint64) []string {
+	set := map[string]struct{}{}
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	return sortedKeysAny(set)
+}
+
+func unionKeysTime(a, b map[string]time.Time) []string {
+	set := map[string]struct{}{}
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	return sortedKeysAny(set)
+}

--- a/internal/beads/caching_store_reconcile_fixtures_test.go
+++ b/internal/beads/caching_store_reconcile_fixtures_test.go
@@ -87,7 +87,7 @@ func mergeFixtures() []mergeFixture {
 	// --- B3/D4/D2: quiescent recency-keep, cached deps present → keep cached deps ---
 	{
 		in := quiIn()
-		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) {})} // status change ⇒ beadChanged
+		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(_ *Bead) {})} // status change ⇒ beadChanged
 		in.depMap = map[string][]Dep{"a": {dep("a", "fresh")}}
 		fx = append(fx, mergeFixture{
 			name: "B3_D4_recency_keep_with_cached_deps",
@@ -371,7 +371,7 @@ func mergeFixtures() []mergeFixture {
 	// --- #2210 shape: local DepAdd inside window, snapshot lags (recency keep) ---
 	{
 		in := quiIn()
-		in.freshByID = map[string]Bead{"a": beadWith("a", "in_progress", func(b *Bead) {})}
+		in.freshByID = map[string]Bead{"a": beadWith("a", "in_progress", func(_ *Bead) {})}
 		in.depMap = map[string][]Dep{"a": {}} // snapshot dropped the just-added dep
 		fx = append(fx, mergeFixture{
 			name: "reg_2210_local_depadd_in_window",
@@ -406,7 +406,7 @@ func mergeFixtures() []mergeFixture {
 	// --- boundary recency 5.000s: still recent (keeps) ---
 	{
 		in := quiIn()
-		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) {})}
+		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(_ *Bead) {})}
 		in.depMap = map[string][]Dep{"a": {dep("a", "fresh")}}
 		fx = append(fx, mergeFixture{
 			name: "boundary_recency_5000ms_recent",
@@ -424,7 +424,7 @@ func mergeFixtures() []mergeFixture {
 	// --- boundary recency 5.001s: stale (absorbs) ---
 	{
 		in := quiIn()
-		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) {})}
+		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(_ *Bead) {})}
 		in.depMap = map[string][]Dep{"a": {dep("a", "fresh")}}
 		fx = append(fx, mergeFixture{
 			name: "boundary_recency_5001ms_stale",

--- a/internal/beads/caching_store_reconcile_fixtures_test.go
+++ b/internal/beads/caching_store_reconcile_fixtures_test.go
@@ -1,0 +1,462 @@
+package beads
+
+import (
+	"testing"
+	"time"
+)
+
+// Fixed reference clock for all fixtures; recency offsets are relative to it.
+var fxNow = time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+
+func fxRecent() time.Time   { return fxNow.Add(-2 * time.Second) }         // well inside window
+func fxBoundary() time.Time { return fxNow.Add(-5 * time.Second) }         // exactly 5s → still recent
+func fxJustOver() time.Time { return fxNow.Add(-5001 * time.Millisecond) } // 5.001s → stale
+func fxStale() time.Time    { return fxNow.Add(-time.Hour) }               // far stale
+
+func bead(id, status string) Bead {
+	return Bead{ID: id, Title: id, Status: status, Type: "task", CreatedAt: fxNow}
+}
+
+func beadWith(id, status string, mut func(*Bead)) Bead {
+	b := bead(id, status)
+	mut(&b)
+	return b
+}
+
+func dep(issue, dependsOn string) Dep {
+	return Dep{IssueID: issue, DependsOnID: dependsOn, Type: "blocks"}
+}
+
+type mergeFixture struct {
+	name string
+	st   storeState
+	in   snapshotInputs
+}
+
+// mergeFixtures enumerates the §1.4 cells (B1-B11), the §2 deltas, and the
+// bug-lineage regression shapes. Both regimes are represented.
+func mergeFixtures() []mergeFixture {
+	var fx []mergeFixture
+
+	// Regime scaffolding: quiescent has mutationSeq==startSeq and all fences
+	// <= startSeq; mutated has mutationSeq>startSeq and may fence > startSeq.
+	const qseq = uint64(100)
+	const mseq = uint64(200)
+	quiIn := func() snapshotInputs {
+		return snapshotInputs{startSeq: qseq, now: fxNow, useFreshDeps: true}
+	}
+	mutIn := func() snapshotInputs {
+		return snapshotInputs{startSeq: qseq, now: fxNow, useFreshDeps: true}
+	}
+	_ = mutIn
+
+	// --- B1: quiescent, in snapshot ∧ cached ∧ not recent ∧ changed → absorb ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": beadWith("a", "open", func(b *Bead) { b.Title = "new" })}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "B1_absorb_changed",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "y")}},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B2/D5: quiescent absorb, recent, NOT beadChanged → NEW keeps fences ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": bead("a", "open")}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "B2_D5_recent_no_conflict",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B3/D4/D2: quiescent recency-keep, cached deps present → keep cached deps ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) {})} // status change ⇒ beadChanged
+		in.depMap = map[string][]Dep{"a": {dep("a", "fresh")}}
+		fx = append(fx, mergeFixture{
+			name: "B3_D4_recency_keep_with_cached_deps",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "cached")}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B3/D2: quiescent recency-keep, NO cached deps entry → depsComplete flip ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": bead("a", "closed")}
+		in.depMap = map[string][]Dep{"a": {dep("a", "fresh")}}
+		fx = append(fx, mergeFixture{
+			name: "B3_D2_recency_keep_no_cached_deps",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{}, // no entry for a
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B4: quiescent, in snapshot ∧ NOT cached → created ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": bead("a", "open")}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "B4_created",
+			st: storeState{
+				beads:       map[string]Bead{},
+				deps:        map[string][]Dep{},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B4-orphan/D5: created over a stale orphan fence, recent → keep fences ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": bead("a", "open")}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "B4orphan_D5_recent_orphan_now_in_snapshot",
+			st: storeState{
+				beads:       map[string]Bead{},
+				deps:        map[string][]Dep{},
+				beadSeq:     map[string]uint64{"a": 88},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B5: quiescent, missing ∧ cached ∧ non-closed ∧ recent → carry (skip) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "B5_evict_recency_keep",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B6: quiescent, missing ∧ cached ∧ closed → evict, no notification ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "B6_evict_closed",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "closed")},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B7: quiescent, missing ∧ cached ∧ non-closed ∧ stale → evict + closed ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		in.confirmedClosed = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) { b.Title = "auth" })}
+		fx = append(fx, mergeFixture{
+			name: "B7_evict_confirmed_closed",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				localBeadAt: map[string]time.Time{"a": fxStale()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B8/D3': quiescent orphan fences, recent → keep ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "B8_D3prime_orphan_recent",
+			st: storeState{
+				beads:       map[string]Bead{},
+				dirty:       map[string]struct{}{"a": {}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B8: quiescent orphan fences, stale → GC'd (≡ B) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "B8_orphan_stale_gc",
+			st: storeState{
+				beads:       map[string]Bead{},
+				dirty:       map[string]struct{}{"a": {}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxStale()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B9/D1': quiescent tombstone with recent localAt → keep-all ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "B9_D1prime_tombstone_recent",
+			st: storeState{
+				beads:       map[string]Bead{},
+				deletedSeq:  map[string]uint64{"a": 95},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- B9: quiescent tombstone, stale → GC'd (≡ B wholesale wipe) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "B9_tombstone_stale_gc",
+			st: storeState{
+				beads:       map[string]Bead{},
+				deletedSeq:  map[string]uint64{"a": 95},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- Orphan deps-only, recent → kept (D3' deps family, council delete-B gap) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "orphan_deps_only_recent_kept",
+			st: storeState{
+				beads:       map[string]Bead{},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- Orphan deps-only, stale → GC'd (immortal-deps regression guard) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{}
+		fx = append(fx, mergeFixture{
+			name: "orphan_deps_only_stale_gc",
+			st: storeState{
+				beads:       map[string]Bead{},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- MUTATED / D1: tombstone unprotected orphan the sweep collects (vs A) ---
+	{
+		in := snapshotInputs{startSeq: qseq, now: fxNow, useFreshDeps: true}
+		in.freshByID = map[string]Bead{"a": bead("a", "open")}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "D1_mutated_tombstone_orphan_gc",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				deletedSeq:  map[string]uint64{"gone": 95}, // orphan tombstone, seq<=startSeq
+				mutationSeq: mseq,                          // mutated regime
+			},
+			in: in,
+		})
+	}
+
+	// --- MUTATED / D3: orphan dirty/beadSeq leaked, sweep collects (vs A) ---
+	{
+		in := snapshotInputs{startSeq: qseq, now: fxNow, useFreshDeps: true}
+		in.freshByID = map[string]Bead{"a": bead("a", "open")}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "D3_mutated_orphan_fences_gc",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				dirty:       map[string]struct{}{"gone": {}},
+				beadSeq:     map[string]uint64{"gone": 80},
+				mutationSeq: mseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- MUTATED / fence arm: beadSeq > startSeq keeps the row (skipFenced) ---
+	{
+		in := snapshotInputs{startSeq: qseq, now: fxNow, useFreshDeps: true}
+		in.freshByID = map[string]Bead{"a": beadWith("a", "open", func(b *Bead) { b.Title = "stale-scan" })}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "mutated_beadSeq_fence_skip",
+			st: storeState{
+				beads:       map[string]Bead{"a": beadWith("a", "open", func(b *Bead) { b.Title = "local-write" })},
+				deps:        map[string][]Dep{"a": {dep("a", "x")}},
+				beadSeq:     map[string]uint64{"a": 150}, // > startSeq
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: mseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- MUTATED / tombstone fence: deletedSeq > startSeq keeps eviction skip ---
+	{
+		in := snapshotInputs{startSeq: qseq, now: fxNow, useFreshDeps: true}
+		in.freshByID = map[string]Bead{"a": bead("a", "open")}
+		in.depMap = map[string][]Dep{"a": {dep("a", "x")}}
+		fx = append(fx, mergeFixture{
+			name: "mutated_tombstone_fence_absorb_skip",
+			st: storeState{
+				beads:       map[string]Bead{},
+				deletedSeq:  map[string]uint64{"a": 150}, // delete raced the scan
+				mutationSeq: mseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- #2210 shape: local DepAdd inside window, snapshot lags (recency keep) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": beadWith("a", "in_progress", func(b *Bead) {})}
+		in.depMap = map[string][]Dep{"a": {}} // snapshot dropped the just-added dep
+		fx = append(fx, mergeFixture{
+			name: "reg_2210_local_depadd_in_window",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "just-added")}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxRecent()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- nil-vs-empty deps classification: must NOT emit bead.updated ---
+	{
+		in := quiIn()
+		in.useFreshDeps = true
+		in.freshByID = map[string]Bead{"a": bead("a", "open")}
+		in.depMap = map[string][]Dep{} // fresh deps nil
+		fx = append(fx, mergeFixture{
+			name: "reg_nil_vs_empty_deps",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {}}, // cached empty (non-nil)
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- boundary recency 5.000s: still recent (keeps) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) {})}
+		in.depMap = map[string][]Dep{"a": {dep("a", "fresh")}}
+		fx = append(fx, mergeFixture{
+			name: "boundary_recency_5000ms_recent",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "cached")}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxBoundary()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	// --- boundary recency 5.001s: stale (absorbs) ---
+	{
+		in := quiIn()
+		in.freshByID = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) {})}
+		in.depMap = map[string][]Dep{"a": {dep("a", "fresh")}}
+		fx = append(fx, mergeFixture{
+			name: "boundary_recency_5001ms_stale",
+			st: storeState{
+				beads:       map[string]Bead{"a": bead("a", "open")},
+				deps:        map[string][]Dep{"a": {dep("a", "cached")}},
+				beadSeq:     map[string]uint64{"a": 90},
+				localBeadAt: map[string]time.Time{"a": fxJustOver()},
+				mutationSeq: qseq,
+			},
+			in: in,
+		})
+	}
+
+	return fx
+}
+
+func TestReconcileMergeDifferential_Fixtures(t *testing.T) {
+	for _, f := range mergeFixtures() {
+		f := f
+		t.Run(f.name, func(t *testing.T) {
+			// Run both backing variants so the depsForReconcileLocked fallback
+			// is exercised on the same shapes.
+			for _, bd := range []bool{false, true} {
+				st := cloneStoreState(f.st)
+				st.backingIsBd = bd
+				variant := "memBacking"
+				if bd {
+					variant = "bdBacking"
+				}
+				assertDifferential(t, f.name+"/"+variant, st, cloneSnapshotInputs(f.in))
+			}
+		})
+	}
+}

--- a/internal/beads/caching_store_reconcile_generators_test.go
+++ b/internal/beads/caching_store_reconcile_generators_test.go
@@ -22,10 +22,12 @@ type guardCellSpec struct {
 	freshStatus  string
 }
 
-var changedVals = []string{"equal", "status", "labels", "isblocked", "metadata", "needs", "depsfield"}
-var cachedStatusVals = []string{"open", "in_progress", "closed"}
-var freshStatusVals = []string{"open", "closed"}
-var recencyVals = []string{"none", "recent", "boundary", "justover", "stale"}
+var (
+	changedVals      = []string{"equal", "status", "labels", "isblocked", "metadata", "needs", "depsfield"}
+	cachedStatusVals = []string{"open", "in_progress", "closed"}
+	freshStatusVals  = []string{"open", "closed"}
+	recencyVals      = []string{"none", "recent", "boundary", "justover", "stale"}
+)
 
 func fenceValsFor(regime string) []string {
 	if regime == "mutated" {
@@ -290,7 +292,7 @@ func genMarginalStates() []mergeFixture {
 		st, in := base()
 		st.beads["a"] = bead("a", "open")
 		st.localBeadAt["a"] = fxNow
-		in.freshByID["a"] = beadWith("a", "closed", func(b *Bead) {})
+		in.freshByID["a"] = beadWith("a", "closed", func(_ *Bead) {})
 		in.depMap["a"] = []Dep{dep("a", "x")}
 		out = append(out, mergeFixture{"marg_recency_now", st, in})
 	}
@@ -395,7 +397,7 @@ func genRandomState(rng *rand.Rand, idx int) mergeFixture {
 				in.depMap[id] = randDeps(rng, id)
 			}
 			if cachedPresent && !isClosed(st.beads[id]) && rng.Intn(4) == 0 {
-				in.confirmedClosed[id] = beadWith(id, "closed", func(b *Bead) {})
+				in.confirmedClosed[id] = beadWith(id, "closed", func(_ *Bead) {})
 			}
 		}
 		// Fences (respect V: V4 seq <= mutationSeq; quiescent ⇒ <= startSeq

--- a/internal/beads/caching_store_reconcile_generators_test.go
+++ b/internal/beads/caching_store_reconcile_generators_test.go
@@ -1,0 +1,635 @@
+package beads
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Tier 1: exhaustive guard-axis grid (single source of truth for the cross)
+// ---------------------------------------------------------------------------
+
+type guardCellSpec struct {
+	regime       string
+	presence     string
+	tomb         string
+	seq          string
+	recency      string
+	changed      string // "na" outside presence=both
+	cachedStatus string
+	freshStatus  string
+}
+
+var changedVals = []string{"equal", "status", "labels", "isblocked", "metadata", "needs", "depsfield"}
+var cachedStatusVals = []string{"open", "in_progress", "closed"}
+var freshStatusVals = []string{"open", "closed"}
+var recencyVals = []string{"none", "recent", "boundary", "justover", "stale"}
+
+func fenceValsFor(regime string) []string {
+	if regime == "mutated" {
+		return []string{"none", "lt", "eq", "gt"}
+	}
+	return []string{"none", "lt", "eq"}
+}
+
+// forEachGuardCell drives BOTH enumeration and generation so the intended
+// cross and the generated corpus can never drift.
+func forEachGuardCell(fn func(spec guardCellSpec)) {
+	for _, regime := range []string{"quiescent", "mutated"} {
+		fences := fenceValsFor(regime)
+		for _, seq := range fences {
+			for _, rec := range recencyVals {
+				// presence = both (cached ⇒ tomb=none by V1)
+				for _, cs := range cachedStatusVals {
+					for _, ch := range changedVals {
+						fn(guardCellSpec{regime, "both", "none", seq, rec, ch, cs, derivedFreshStatus(cs, ch)})
+					}
+				}
+				// presence = cache (cached ⇒ tomb=none)
+				for _, cs := range cachedStatusVals {
+					fn(guardCellSpec{regime, "cache", "none", seq, rec, "na", cs, "na"})
+				}
+				// presence = snap (no cached bead ⇒ tomb may be set)
+				for _, tomb := range fences {
+					for _, fs := range freshStatusVals {
+						fn(guardCellSpec{regime, "snap", tomb, seq, rec, "na", "na", fs})
+					}
+					// presence = neither (orphan fences/deps only)
+					fn(guardCellSpec{regime, "neither", tomb, seq, rec, "na", "na", "na"})
+				}
+			}
+		}
+	}
+}
+
+func derivedFreshStatus(cached, changed string) string {
+	if changed == "status" {
+		if cached == "closed" {
+			return "open"
+		}
+		return "closed"
+	}
+	return cached
+}
+
+func fenceValue(cell string) uint64 {
+	switch cell {
+	case "lt":
+		return 90
+	case "eq":
+		return 100
+	case "gt":
+		return 150
+	default:
+		return 0
+	}
+}
+
+func recencyValue(cell string) (time.Time, bool) {
+	switch cell {
+	case "recent":
+		return fxRecent(), true
+	case "boundary":
+		return fxBoundary(), true
+	case "justover":
+		return fxJustOver(), true
+	case "stale":
+		return fxStale(), true
+	default:
+		return time.Time{}, false
+	}
+}
+
+// buildGuardState materializes a single-row state for id "a" from a spec.
+func buildGuardState(spec guardCellSpec) (storeState, snapshotInputs, string) {
+	const startSeq = uint64(100)
+	st := storeState{
+		beads:       map[string]Bead{},
+		deps:        map[string][]Dep{},
+		dirty:       map[string]struct{}{},
+		beadSeq:     map[string]uint64{},
+		localBeadAt: map[string]time.Time{},
+		deletedSeq:  map[string]uint64{},
+	}
+	in := snapshotInputs{
+		freshByID:    map[string]Bead{},
+		depMap:       map[string][]Dep{},
+		useFreshDeps: true,
+		startSeq:     startSeq,
+		now:          fxNow,
+	}
+	if spec.regime == "mutated" {
+		st.mutationSeq = 200
+	} else {
+		st.mutationSeq = startSeq
+	}
+	const id = "a"
+
+	cachedPresent := spec.presence == "both" || spec.presence == "cache"
+	freshPresent := spec.presence == "both" || spec.presence == "snap"
+
+	var cached Bead
+	if cachedPresent {
+		cached = bead(id, spec.cachedStatus)
+		st.beads[id] = cached
+		st.deps[id] = []Dep{dep(id, "cacheddep")}
+	}
+	if freshPresent {
+		var fresh Bead
+		if spec.presence == "both" {
+			fresh = deriveFresh(cached, spec.changed)
+		} else {
+			fresh = bead(id, spec.freshStatus)
+		}
+		in.freshByID[id] = fresh
+		in.depMap[id] = []Dep{dep(id, "cacheddep")} // equal to cached ⇒ no depsChanged noise
+	}
+
+	// Fences / recency / tombstone.
+	if v := fenceValue(spec.seq); v != 0 {
+		st.beadSeq[id] = v
+	}
+	if !cachedPresent { // V1: no tombstone alongside a live row
+		if v := fenceValue(spec.tomb); v != 0 {
+			st.deletedSeq[id] = v
+		}
+	}
+	if t, ok := recencyValue(spec.recency); ok {
+		st.localBeadAt[id] = t
+	}
+
+	name := fmt.Sprintf("%s_%s_tomb-%s_seq-%s_rec-%s_ch-%s_cs-%s_fs-%s",
+		spec.regime, spec.presence, spec.tomb, spec.seq, spec.recency, spec.changed, spec.cachedStatus, spec.freshStatus)
+	return st, in, name
+}
+
+func deriveFresh(cached Bead, changed string) Bead {
+	f := cloneBead(cached)
+	switch changed {
+	case "status":
+		if cached.Status == "closed" {
+			f.Status = "open"
+		} else {
+			f.Status = "closed"
+		}
+	case "labels":
+		f.Labels = []string{"L1"}
+	case "isblocked":
+		v := true
+		f.IsBlocked = &v
+	case "metadata":
+		f.Metadata = StringMap{"k": "v"}
+	case "needs":
+		f.Needs = []string{"n1"}
+	case "depsfield":
+		f.Dependencies = []Dep{dep(cached.ID, "d1")}
+	case "equal":
+		// identical
+	}
+	return f
+}
+
+func genGridStates() []mergeFixture {
+	var out []mergeFixture
+	forEachGuardCell(func(spec guardCellSpec) {
+		st, in, name := buildGuardState(spec)
+		out = append(out, mergeFixture{name: name, st: st, in: in})
+	})
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Marginal generator: guarantees each soft/hardened axis value is observed
+// ---------------------------------------------------------------------------
+
+func genMarginalStates() []mergeFixture {
+	var out []mergeFixture
+	const q = uint64(100)
+	base := func() (storeState, snapshotInputs) {
+		return storeState{
+				beads: map[string]Bead{}, deps: map[string][]Dep{}, dirty: map[string]struct{}{},
+				beadSeq: map[string]uint64{}, localBeadAt: map[string]time.Time{}, deletedSeq: map[string]uint64{},
+				mutationSeq: q,
+			},
+			snapshotInputs{freshByID: map[string]Bead{}, depMap: map[string][]Dep{}, useFreshDeps: true, startSeq: q, now: fxNow}
+	}
+
+	// dirty=true
+	{
+		st, in := base()
+		st.beads["a"] = bead("a", "open")
+		st.deps["a"] = []Dep{dep("a", "x")}
+		st.dirty["a"] = struct{}{}
+		in.freshByID["a"] = beadWith("a", "open", func(b *Bead) { b.Title = "chg" })
+		in.depMap["a"] = []Dep{dep("a", "x")}
+		out = append(out, mergeFixture{"marg_dirty_true", st, in})
+	}
+	// depMapCell nil / empty / nonempty (useFreshDeps=true)
+	for _, dc := range []string{"nil", "empty", "nonempty"} {
+		st, in := base()
+		st.beads["a"] = bead("a", "open")
+		st.deps["a"] = []Dep{dep("a", "x")}
+		in.freshByID["a"] = bead("a", "open")
+		switch dc {
+		case "nil":
+			in.depMap["a"] = nil
+			in.depMap = map[string][]Dep{"a": nil}
+		case "empty":
+			in.depMap["a"] = []Dep{}
+		case "nonempty":
+			in.depMap["a"] = []Dep{dep("a", "x")}
+		}
+		out = append(out, mergeFixture{"marg_depMap_" + dc, st, in})
+	}
+	// fieldDeps none/needs/deps/both (useFreshDeps=false)
+	for _, fd := range []string{"none", "needs", "deps", "both"} {
+		st, in := base()
+		in.useFreshDeps = false
+		st.beads["a"] = bead("a", "open")
+		fresh := bead("a", "open")
+		switch fd {
+		case "needs":
+			fresh.Needs = []string{"n1"}
+		case "deps":
+			fresh.Dependencies = []Dep{dep("a", "d1")}
+		case "both":
+			fresh.Needs = []string{"n1"}
+			fresh.Dependencies = []Dep{dep("a", "d1")}
+		}
+		in.freshByID["a"] = fresh
+		out = append(out, mergeFixture{"marg_fieldDeps_" + fd, st, in})
+	}
+	// cachedDeps absent/nil/empty/nonempty
+	for _, cd := range []string{"absent", "nil", "empty", "nonempty"} {
+		st, in := base()
+		st.beads["a"] = bead("a", "open")
+		switch cd {
+		case "nil":
+			st.deps = map[string][]Dep{"a": nil}
+		case "empty":
+			st.deps["a"] = []Dep{}
+		case "nonempty":
+			st.deps["a"] = []Dep{dep("a", "x")}
+		}
+		in.freshByID["a"] = beadWith("a", "open", func(b *Bead) { b.Title = "chg" })
+		in.depMap["a"] = []Dep{dep("a", "x")}
+		out = append(out, mergeFixture{"marg_cachedDeps_" + cd, st, in})
+	}
+	// confirmedClosed=true (cache-only non-closed stale eviction)
+	{
+		st, in := base()
+		st.beads["a"] = bead("a", "open")
+		st.localBeadAt["a"] = fxStale()
+		in.confirmedClosed = map[string]Bead{"a": beadWith("a", "closed", func(b *Bead) { b.Title = "auth" })}
+		out = append(out, mergeFixture{"marg_confirmedClosed", st, in})
+	}
+	// recency "now" (zero elapsed) — council boundary cell
+	{
+		st, in := base()
+		st.beads["a"] = bead("a", "open")
+		st.localBeadAt["a"] = fxNow
+		in.freshByID["a"] = beadWith("a", "closed", func(b *Bead) {})
+		in.depMap["a"] = []Dep{dep("a", "x")}
+		out = append(out, mergeFixture{"marg_recency_now", st, in})
+	}
+	// preserveOutcome: inapplicable / no-cached / applied / blocked-deps / blocked-target
+	// applied: fresh IsBlocked nil, cached IsBlocked set, deps unchanged, no target flip
+	mkPreserve := func(name string, setup func(st *storeState, in *snapshotInputs)) {
+		st, in := base()
+		setup(&st, &in)
+		out = append(out, mergeFixture{"marg_preserve_" + name, st, in})
+	}
+	tb := true
+	mkPreserve("inapplicable", func(st *storeState, in *snapshotInputs) {
+		st.beads["a"] = beadWith("a", "open", func(b *Bead) { b.IsBlocked = &tb })
+		st.deps["a"] = []Dep{dep("a", "x")}
+		fresh := beadWith("a", "open", func(b *Bead) { v := false; b.IsBlocked = &v })
+		in.freshByID["a"] = fresh
+		in.depMap["a"] = []Dep{dep("a", "x")}
+	})
+	mkPreserve("no-cached", func(st *storeState, in *snapshotInputs) {
+		st.beads["a"] = bead("a", "open") // cached IsBlocked nil
+		st.deps["a"] = []Dep{dep("a", "x")}
+		in.freshByID["a"] = bead("a", "open") // fresh IsBlocked nil
+		in.depMap["a"] = []Dep{dep("a", "x")}
+	})
+	mkPreserve("applied", func(st *storeState, in *snapshotInputs) {
+		st.beads["a"] = beadWith("a", "open", func(b *Bead) { b.IsBlocked = &tb })
+		st.deps["a"] = []Dep{dep("a", "x")}
+		in.freshByID["a"] = bead("a", "open") // fresh IsBlocked nil
+		in.depMap["a"] = []Dep{dep("a", "x")}
+	})
+	mkPreserve("blocked-deps", func(st *storeState, in *snapshotInputs) {
+		st.beads["a"] = beadWith("a", "open", func(b *Bead) { b.IsBlocked = &tb })
+		st.deps["a"] = []Dep{dep("a", "x")}
+		in.freshByID["a"] = bead("a", "open")
+		in.depMap["a"] = []Dep{dep("a", "different")} // deps changed ⇒ preserve blocked
+	})
+	mkPreserve("blocked-target", func(st *storeState, in *snapshotInputs) {
+		st.beads["a"] = beadWith("a", "open", func(b *Bead) { b.IsBlocked = &tb })
+		st.deps["a"] = []Dep{{IssueID: "a", DependsOnID: "t", Type: "blocks"}}
+		st.beads["t"] = bead("t", "open")
+		in.freshByID["a"] = bead("a", "open")
+		in.freshByID["t"] = bead("t", "closed") // target status flipped ⇒ preserve blocked
+		in.depMap["a"] = []Dep{{IssueID: "a", DependsOnID: "t", Type: "blocks"}}
+		in.depMap["t"] = nil
+	})
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: seeded pseudo-random multi-row states
+// ---------------------------------------------------------------------------
+
+func genSeededStates(seed int64, count int) []mergeFixture {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]mergeFixture, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, genRandomState(rng, i))
+	}
+	return out
+}
+
+func genRandomState(rng *rand.Rand, idx int) mergeFixture {
+	const startSeq = uint64(100)
+	mutated := rng.Intn(2) == 0
+	st := storeState{
+		beads: map[string]Bead{}, deps: map[string][]Dep{}, dirty: map[string]struct{}{},
+		beadSeq: map[string]uint64{}, localBeadAt: map[string]time.Time{}, deletedSeq: map[string]uint64{},
+		backingIsBd: rng.Intn(2) == 0,
+	}
+	in := snapshotInputs{
+		freshByID: map[string]Bead{}, confirmedClosed: map[string]Bead{}, depMap: map[string][]Dep{},
+		useFreshDeps: rng.Intn(2) == 0, startSeq: startSeq, now: fxNow,
+	}
+	if mutated {
+		st.mutationSeq = startSeq + uint64(1+rng.Intn(100))
+	} else {
+		st.mutationSeq = startSeq
+	}
+
+	nRows := 1 + rng.Intn(6)
+	statuses := []string{"open", "in_progress", "closed"}
+	recencies := []string{"none", "recent", "boundary", "justover", "stale", "now"}
+	for r := 0; r < nRows; r++ {
+		id := fmt.Sprintf("r%d", r)
+		presence := rng.Intn(4) // 0 both,1 snap,2 cache,3 neither
+		cachedPresent := presence == 0 || presence == 2
+		freshPresent := presence == 0 || presence == 1
+
+		if cachedPresent {
+			cb := bead(id, statuses[rng.Intn(3)])
+			applyRandomFields(rng, &cb)
+			st.beads[id] = cb
+			if rng.Intn(3) != 0 {
+				st.deps[id] = randDeps(rng, id)
+			}
+		}
+		if freshPresent {
+			fb := bead(id, statuses[rng.Intn(3)])
+			applyRandomFields(rng, &fb)
+			in.freshByID[id] = fb
+			if in.useFreshDeps && rng.Intn(3) != 0 {
+				in.depMap[id] = randDeps(rng, id)
+			}
+			if cachedPresent && !isClosed(st.beads[id]) && rng.Intn(4) == 0 {
+				in.confirmedClosed[id] = beadWith(id, "closed", func(b *Bead) {})
+			}
+		}
+		// Fences (respect V: V4 seq <= mutationSeq; quiescent ⇒ <= startSeq
+		// since mutationSeq==startSeq; tombstone ⇒ no live row).
+		if rng.Intn(2) == 0 {
+			st.beadSeq[id] = randFence(rng, startSeq, st.mutationSeq)
+		}
+		if !cachedPresent && rng.Intn(2) == 0 {
+			st.deletedSeq[id] = randFence(rng, startSeq, st.mutationSeq)
+		}
+		if rng.Intn(2) == 0 {
+			if t, ok := recencyValue2(recencies[rng.Intn(len(recencies))]); ok {
+				st.localBeadAt[id] = t
+			}
+		}
+		if rng.Intn(3) == 0 {
+			st.dirty[id] = struct{}{}
+		}
+		// Orphan deps-only entries for a never-present id occasionally.
+		if presence == 3 && rng.Intn(2) == 0 {
+			st.deps[id] = randDeps(rng, id)
+		}
+	}
+	return mergeFixture{name: fmt.Sprintf("seed%d_case%d", 0, idx), st: st, in: in}
+}
+
+func recencyValue2(cell string) (time.Time, bool) {
+	if cell == "now" {
+		return fxNow, true
+	}
+	return recencyValue(cell)
+}
+
+// randFence returns a fence value in [1, mutationSeq] (V4). When mutationSeq >
+// startSeq (mutated regime) it biases toward the (startSeq, mutationSeq] band so
+// the > startSeq fence arms are exercised; it never exceeds mutationSeq, so a
+// quiescent state (mutationSeq==startSeq) automatically satisfies invariant Q.
+func randFence(rng *rand.Rand, startSeq, mutationSeq uint64) uint64 {
+	if mutationSeq > startSeq && rng.Intn(2) == 0 {
+		return startSeq + 1 + uint64(rng.Intn(int(mutationSeq-startSeq)))
+	}
+	return uint64(1 + rng.Intn(int(startSeq)))
+}
+
+func applyRandomFields(rng *rand.Rand, b *Bead) {
+	if rng.Intn(2) == 0 {
+		b.Title = fmt.Sprintf("t%d", rng.Intn(3))
+	}
+	if rng.Intn(3) == 0 {
+		b.Labels = []string{fmt.Sprintf("l%d", rng.Intn(2))}
+	}
+	if rng.Intn(3) == 0 {
+		v := rng.Intn(2) == 0
+		b.IsBlocked = &v
+	}
+	if rng.Intn(3) == 0 {
+		b.Metadata = StringMap{"k": fmt.Sprintf("%d", rng.Intn(2))}
+	}
+	if rng.Intn(3) == 0 {
+		b.Needs = []string{fmt.Sprintf("n%d", rng.Intn(2))}
+	}
+	if rng.Intn(3) == 0 {
+		b.Dependencies = []Dep{dep(b.ID, fmt.Sprintf("d%d", rng.Intn(2)))}
+	}
+}
+
+func randDeps(rng *rand.Rand, id string) []Dep {
+	switch rng.Intn(4) {
+	case 0:
+		return nil
+	case 1:
+		return []Dep{}
+	default:
+		n := 1 + rng.Intn(2)
+		ds := make([]Dep, n)
+		for i := range ds {
+			ds[i] = dep(id, fmt.Sprintf("t%d", rng.Intn(3)))
+		}
+		return ds
+	}
+}
+
+func isClosed(b Bead) bool { return b.Status == "closed" }
+
+// ---------------------------------------------------------------------------
+// Differential tests over the tiers
+// ---------------------------------------------------------------------------
+
+func TestReconcileMergeDifferential_Grid(t *testing.T) {
+	for _, f := range genGridStates() {
+		f := f
+		for _, bd := range []bool{false, true} {
+			st := cloneStoreState(f.st)
+			st.backingIsBd = bd
+			assertDifferential(t, f.name+backingSuffix(bd), st, cloneSnapshotInputs(f.in))
+		}
+	}
+}
+
+func TestReconcileMergeDifferential_Marginal(t *testing.T) {
+	for _, f := range genMarginalStates() {
+		f := f
+		for _, bd := range []bool{false, true} {
+			st := cloneStoreState(f.st)
+			st.backingIsBd = bd
+			assertDifferential(t, f.name+backingSuffix(bd), st, cloneSnapshotInputs(f.in))
+		}
+	}
+}
+
+func TestReconcileMergeDifferential_Seeded(t *testing.T) {
+	states := genSeededStates(1, 12000)
+	for _, f := range states {
+		assertDifferential(t, f.name, cloneStoreState(f.st), cloneSnapshotInputs(f.in))
+	}
+}
+
+func backingSuffix(bd bool) string {
+	if bd {
+		return "/bd"
+	}
+	return "/mem"
+}
+
+// ---------------------------------------------------------------------------
+// Coverage assertions
+// ---------------------------------------------------------------------------
+
+func classifyAllInto(rec *coverageRecorder, states []mergeFixture) {
+	// Classify the SAME (deep-cloned) state+inputs the differential actually
+	// runs — cloneStoreState/cloneSnapshotInputs collapse empty deps slices to
+	// nil exactly as production's cloneDeps does, so classification and
+	// execution can never disagree on an unreachable empty-deps cell.
+	for _, f := range states {
+		for _, bd := range []bool{false, true} {
+			st := cloneStoreState(f.st)
+			st.backingIsBd = bd
+			in := cloneSnapshotInputs(f.in)
+			for _, id := range rowIDUniverse(st, in) {
+				rec.record(classifyRow(st, in, id))
+			}
+		}
+	}
+}
+
+func TestReconcileMergeCoverage_AllCellsExecuted(t *testing.T) {
+	rec := newCoverageRecorder()
+	classifyAllInto(rec, genGridStates())
+	classifyAllInto(rec, genMarginalStates())
+	classifyAllInto(rec, mergeFixtures())
+	classifyAllInto(rec, genSeededStates(1, 3000))
+
+	// 1. Full guard-axis cross: every intended guard cell must be observed.
+	var missing []string
+	forEachGuardCell(func(spec guardCellSpec) {
+		gc := guardCell{spec.regime, spec.presence, spec.tomb, spec.seq, spec.recency, spec.changed, expectedStatusPair(spec)}
+		if rec.guards[gc] == 0 {
+			missing = append(missing, fmt.Sprintf("%+v", gc))
+		}
+	})
+	if len(missing) > 0 {
+		t.Fatalf("%d guard cells never executed (generator/classifier drift):\n%s",
+			len(missing), joinLimited(missing, 25))
+	}
+
+	// 2. Marginal coverage: every value of every soft/hardened axis observed.
+	// Empty (non-nil) deps slices are V-excluded: production's cloneDeps and
+	// depsFromBeadFields collapse them to nil, so absent / present-nil /
+	// present-nonempty are the only reachable deps-presence cells.
+	requireMarginal(t, rec, "dirty", []string{"true", "false"})
+	requireMarginal(t, rec, "depMapCell", []string{"na", "nil", "nonempty"})
+	requireMarginal(t, rec, "fieldDeps", []string{"na", "none", "needs", "deps", "both"})
+	requireMarginal(t, rec, "cachedDeps", []string{"absent", "nil", "nonempty"})
+	requireMarginal(t, rec, "useFreshDeps", []string{"true", "false"})
+	requireMarginal(t, rec, "backingIsBd", []string{"true", "false"})
+	requireMarginal(t, rec, "confirmedClosed", []string{"true", "false"})
+	requireMarginal(t, rec, "preserveOutcome", []string{"inapplicable", "no-cached", "applied", "blocked-deps", "blocked-target", "na"})
+	requireMarginal(t, rec, "recency", []string{"none", "recent", "boundary", "justover", "stale", "now"})
+}
+
+func TestReconcileMergeCoverage_QuiescentCellsExecuted(t *testing.T) {
+	// The Branch-B deletion precondition: every B-reachable (quiescent) guard
+	// cell must have been exercised against the frozen Branch B.
+	rec := newCoverageRecorder()
+	classifyAllInto(rec, genGridStates())
+	classifyAllInto(rec, genMarginalStates())
+	classifyAllInto(rec, mergeFixtures())
+	classifyAllInto(rec, genSeededStates(1, 3000))
+
+	var missing []string
+	forEachGuardCell(func(spec guardCellSpec) {
+		if spec.regime != "quiescent" {
+			return
+		}
+		gc := guardCell{spec.regime, spec.presence, spec.tomb, spec.seq, spec.recency, spec.changed, expectedStatusPair(spec)}
+		if rec.guards[gc] == 0 {
+			missing = append(missing, fmt.Sprintf("%+v", gc))
+		}
+	})
+	if len(missing) > 0 {
+		t.Fatalf("%d quiescent guard cells never executed — Branch B deletion is NOT safe:\n%s",
+			len(missing), joinLimited(missing, 25))
+	}
+}
+
+func expectedStatusPair(spec guardCellSpec) string {
+	switch spec.presence {
+	case "both":
+		return spec.cachedStatus + ">" + spec.freshStatus
+	case "snap":
+		return "?>" + spec.freshStatus
+	case "cache":
+		return spec.cachedStatus + ">?"
+	default:
+		return "na"
+	}
+}
+
+func requireMarginal(t *testing.T, rec *coverageRecorder, axis string, vals []string) {
+	t.Helper()
+	for _, v := range vals {
+		if rec.marginal[axis+"="+v] == 0 {
+			t.Errorf("marginal coverage gap: %s=%s never observed", axis, v)
+		}
+	}
+}
+
+func joinLimited(ss []string, n int) string {
+	if len(ss) > n {
+		ss = append(ss[:n:n], fmt.Sprintf("... (+%d more)", len(ss)-n))
+	}
+	out := ""
+	for _, s := range ss {
+		out += "  " + s + "\n"
+	}
+	return out
+}

--- a/internal/beads/caching_store_reconcile_oracle_test.go
+++ b/internal/beads/caching_store_reconcile_oracle_test.go
@@ -186,14 +186,8 @@ func buildExpectedNewEnd(st storeState, in snapshotInputs, postPreserveFresh map
 	exp.localBeadAt = map[string]time.Time{}
 	exp.deletedSeq = map[string]uint64{}
 
-	depsCompleteFlip := false
 	for id := range allOracleIDs(st, in, refEnd) {
 		kind := classifyDelta(st, in, postPreserveFresh, refEnd, id)
-		if kind == deltaD4RecencyKept {
-			if _, ok := st.deps[id]; !ok {
-				depsCompleteFlip = true
-			}
-		}
 		v := expectedNewView(st, in, refEnd, id, kind)
 		if v.hasBead {
 			exp.beads[id] = v.bead
@@ -214,11 +208,61 @@ func buildExpectedNewEnd(st storeState, in snapshotInputs, postPreserveFresh map
 			exp.deletedSeq[id] = v.deletedSeq
 		}
 	}
-	if in.quiescent(st) {
-		exp.depsComplete = refEnd.depsComplete && !depsCompleteFlip
-	}
-	// (Mutated regime: NEW's depsComplete == A's; refEnd already carries it.)
+	// depsComplete is regime-uniform in the collapsed seam: reconcileMergeDecision
+	// has no regime concept, so the flag is a single fold — useFreshDeps, dropped
+	// to false the moment any absorb-cell skip leaves the cached deps map an
+	// unfaithful projection of the fresh scan. Re-derived here independently from
+	// the input state and the shared pure helpers (never reconcileMergeDecision).
+	// Without the D4 divergent-deps term this reproduces refEnd.depsComplete for
+	// BOTH frozen branches exactly; the term adds the degradation the collapse
+	// deliberately introduces so a recency-keep can no longer serve stale cached
+	// deps under depsComplete=true.
+	exp.depsComplete = expectedNextDepsComplete(st, in, postPreserveFresh)
 	return exp
+}
+
+// expectedNextDepsComplete independently reproduces the seam's nextDepsComplete
+// fold: it starts at useFreshDeps and drops to false on any absorb-cell (fresh
+// present) skip over a cached row that leaves a deps hole — a fence or recency
+// skip whose row has no cached deps entry, or a recency-keep that retains cached
+// deps diverging from the fresh snapshot. Fence beats recency, matching the
+// decision's arm ordering. Derived from input state + shared pure helpers only.
+func expectedNextDepsComplete(st storeState, in snapshotInputs, postPreserveFresh map[string]Bead) bool {
+	freshDepsByID := computeFreshDepsByID(st, in, postPreserveFresh)
+	complete := in.useFreshDeps
+	for id, fresh := range postPreserveFresh {
+		cached, cachedExists := st.beads[id]
+		if !cachedExists {
+			continue // created row: no skip, no degradation
+		}
+		cachedDeps, hasCachedDeps := st.deps[id]
+		switch {
+		case st.deletedSeq[id] > in.startSeq || st.beadSeq[id] > in.startSeq:
+			if !hasCachedDeps {
+				complete = false
+			}
+		case recentLocalMutation(st.localBeadAt[id], in.now) && beadChanged(cached, fresh, true):
+			if !hasCachedDeps || depsChanged(cachedDeps, freshDepsByID[id]) {
+				complete = false
+			}
+		}
+	}
+	return complete
+}
+
+// computeFreshDepsByID returns, per fresh row, the deps depsForReconcileLocked
+// would compute — the identical fresh-deps input all three implementations feed
+// their skip/absorb arms. A pre-merge harness store gives depsForReconcileLocked
+// the same cached-deps view (and BdStore vs mem fallback) the live seam reads.
+func computeFreshDepsByID(st storeState, in snapshotInputs, postPreserveFresh map[string]Bead) map[string][]Dep {
+	c, _ := newMergeHarnessStore(st)
+	out := make(map[string][]Dep, len(postPreserveFresh))
+	c.mu.Lock()
+	for id, fresh := range postPreserveFresh {
+		out[id] = c.depsForReconcileLocked(id, fresh, in.depMap, in.useFreshDeps)
+	}
+	c.mu.Unlock()
+	return out
 }
 
 // allOracleIDs is the id universe the oracle must decide: every id referenced
@@ -400,6 +444,17 @@ func assertNewEndInvariants(t *testing.T, name string, end mergeEndState, in sna
 // flake.
 func assertDifferential(t *testing.T, name string, st storeState, in snapshotInputs) {
 	t.Helper()
+
+	// Normalize inputs exactly as the seam does before any implementation or the
+	// oracle reads them. cloneStoreState/cloneSnapshotInputs run cloneDeps over
+	// every deps entry, collapsing an empty-non-nil []Dep{} to nil just as the
+	// live seam stores it. The three impl runs already clone internally, but the
+	// case-oracle reads st directly (viewOfState/expectedNewView); without this
+	// the oracle would expect a raw []Dep{} on a recency-kept orphan while the
+	// seam produced nil — a harness-only false divergence (regression-pinned by
+	// the FuzzReconcileMergeDifferential seed).
+	st = cloneStoreState(st)
+	in = cloneSnapshotInputs(in)
 
 	// Determinism self-check per implementation.
 	newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in))

--- a/internal/beads/caching_store_reconcile_oracle_test.go
+++ b/internal/beads/caching_store_reconcile_oracle_test.go
@@ -1,0 +1,453 @@
+package beads
+
+// The equivalence oracle for the reconcile differential gate.
+//
+// Design (proved in the plan §5 and re-derived here):
+//   * The collapsed pipeline's absorb and eviction loops are line-for-line
+//     transliterations of Branch A's loops, and the GC sweep emits no
+//     notifications and touches no counters. Therefore NEW's notification
+//     multiset, add/remove/update counters, and every seam-written scalar
+//     (state, lastFreshAt, mutationSeq, primeErr, syncFailures, stats times)
+//     are IDENTICAL to the reference branch on every input — no delta.
+//   * Only the six per-row maps + depsComplete diverge, and only on the
+//     exactly-enumerated §2 delta id-sets.
+//
+// The oracle builds the FULL expected NEW end-state from the reference
+// end-state: scalars/notifications copied verbatim (asserting exact equality),
+// the six maps + depsComplete transformed per an INDEPENDENT case-oracle that
+// derives the §2 deltas from the INPUT state alone (it calls the shared pure
+// helpers beadChanged/recentLocalMutation/preserve — pinned separately — but
+// never reconcileMergeDecision or the merge pipeline). Assertion is exact
+// reflect.DeepEqual: this pins apply(delta, refEnd) == newEnd bidirectionally,
+// so both under-collection (a missed GC) and over-collection (a GC'd protected
+// fence) fail. Spec-independent invariants on NEW-end alone add redundant
+// power against a matrix misread.
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+// perIDView is the full per-id slice of the six maps, with presence tracked
+// separately from value so nil-vs-empty and zero-vs-absent are distinguished.
+type perIDView struct {
+	hasBead    bool
+	bead       Bead
+	hasDeps    bool
+	deps       []Dep
+	dirty      bool
+	hasBeadSeq bool
+	beadSeq    uint64
+	hasLocalAt bool
+	localAt    time.Time
+	hasDeleted bool
+	deletedSeq uint64
+}
+
+func viewOf(end mergeEndState, id string) perIDView {
+	v := perIDView{}
+	v.bead, v.hasBead = end.beads[id]
+	v.deps, v.hasDeps = end.deps[id]
+	_, v.dirty = end.dirty[id]
+	v.beadSeq, v.hasBeadSeq = end.beadSeq[id]
+	v.localAt, v.hasLocalAt = end.localBeadAt[id]
+	v.deletedSeq, v.hasDeleted = end.deletedSeq[id]
+	return v
+}
+
+func viewOfState(st storeState, id string) perIDView {
+	v := perIDView{}
+	v.bead, v.hasBead = st.beads[id]
+	v.deps, v.hasDeps = st.deps[id]
+	_, v.dirty = st.dirty[id]
+	v.beadSeq, v.hasBeadSeq = st.beadSeq[id]
+	v.localAt, v.hasLocalAt = st.localBeadAt[id]
+	v.deletedSeq, v.hasDeleted = st.deletedSeq[id]
+	return v
+}
+
+// deltaKind is the §2 delta an id exhibits (or none).
+type deltaKind int
+
+const (
+	deltaNone           deltaKind = iota
+	deltaGCOrphan                 // D1/D3 (mutated): stale unprotected orphan the sweep collects
+	deltaD4RecencyKept            // quiescent absorb recencyKeep: NEW keeps cached deps
+	deltaD5RecentAbsorb           // quiescent absorb, recent, no recencyKeep: NEW keeps fences
+	deltaD1RecentOrphan           // quiescent orphan with recent localAt: NEW keeps everything
+)
+
+// classifyDelta derives the delta for id from the INPUT (st, in) and the
+// post-preserve fresh view. It is written from the §2 matrix and shares no
+// code with reconcileMergeDecision or mergeSnapshotLocked.
+func classifyDelta(st storeState, in snapshotInputs, postPreserveFresh map[string]Bead, refEnd mergeEndState, id string) deltaKind {
+	if in.quiescent(st) {
+		freshBead, f := in.freshByID[id]
+		_ = freshBead
+		cached, c := st.beads[id]
+		recent := recentLocalMutation(st.localBeadAt[id], in.now)
+		switch {
+		case f:
+			recencyKeep := c && recent && beadChanged(cached, postPreserveFresh[id], true)
+			switch {
+			case recencyKeep:
+				return deltaD4RecencyKept
+			case recent:
+				return deltaD5RecentAbsorb
+			default:
+				return deltaNone
+			}
+		case c:
+			return deltaNone // eviction cell never diverges from B
+		default:
+			// orphan (no row either side). Quiescent ⇒ fences <= startSeq
+			// (invariant Q), so the only protector is recency.
+			if recent {
+				return deltaD1RecentOrphan
+			}
+			return deltaNone
+		}
+	}
+	// Mutated regime, reference = Branch A end-state. NEW = A + GC sweep.
+	// Divergence is exactly the orphan ids the sweep collects (D1/D3).
+	if _, inBeads := refEnd.beads[id]; inBeads {
+		return deltaNone
+	}
+	if _, inFresh := in.freshByID[id]; inFresh {
+		return deltaNone
+	}
+	if !stateHasAnyOrphanEntry(refEnd, id) {
+		return deltaNone
+	}
+	// Protector check against A-end values (the sweep runs on post-loop state).
+	if refEnd.deletedSeq[id] > in.startSeq || refEnd.beadSeq[id] > in.startSeq {
+		return deltaNone
+	}
+	if recentLocalMutation(refEnd.localBeadAt[id], in.now) {
+		return deltaNone
+	}
+	return deltaGCOrphan
+}
+
+func stateHasAnyOrphanEntry(end mergeEndState, id string) bool {
+	if _, ok := end.deletedSeq[id]; ok {
+		return true
+	}
+	if _, ok := end.dirty[id]; ok {
+		return true
+	}
+	if _, ok := end.beadSeq[id]; ok {
+		return true
+	}
+	if _, ok := end.localBeadAt[id]; ok {
+		return true
+	}
+	if _, ok := end.deps[id]; ok {
+		return true
+	}
+	return false
+}
+
+// expectedNewView returns the per-id view NEW must produce, transforming the
+// reference view per the classified delta.
+func expectedNewView(st storeState, in snapshotInputs, refEnd mergeEndState, id string, kind deltaKind) perIDView {
+	base := viewOf(refEnd, id)
+	switch kind {
+	case deltaNone:
+		return base
+	case deltaGCOrphan:
+		return perIDView{} // fully collected
+	case deltaD4RecencyKept:
+		// NEW leaves the cached deps in place instead of installing fresh deps.
+		base.deps, base.hasDeps = st.deps[id]
+		return base
+	case deltaD5RecentAbsorb:
+		// seqClearGuarded keeps the input beadSeq/localBeadAt through the window.
+		base.beadSeq, base.hasBeadSeq = st.beadSeq[id]
+		base.localAt, base.hasLocalAt = st.localBeadAt[id]
+		return base
+	case deltaD1RecentOrphan:
+		// NEW keeps every input orphan entry; B wiped them.
+		return viewOfState(st, id)
+	default:
+		return base
+	}
+}
+
+// buildExpectedNewEnd assembles the full expected NEW end-state from the
+// reference end-state and the per-id case-oracle.
+func buildExpectedNewEnd(st storeState, in snapshotInputs, postPreserveFresh map[string]Bead, refEnd mergeEndState) mergeEndState {
+	exp := refEnd // copies scalars verbatim — asserts exact scalar equality
+	exp.beads = map[string]Bead{}
+	exp.deps = map[string][]Dep{}
+	exp.dirty = map[string]struct{}{}
+	exp.beadSeq = map[string]uint64{}
+	exp.localBeadAt = map[string]time.Time{}
+	exp.deletedSeq = map[string]uint64{}
+
+	depsCompleteFlip := false
+	for id := range allOracleIDs(st, in, refEnd) {
+		kind := classifyDelta(st, in, postPreserveFresh, refEnd, id)
+		if kind == deltaD4RecencyKept {
+			if _, ok := st.deps[id]; !ok {
+				depsCompleteFlip = true
+			}
+		}
+		v := expectedNewView(st, in, refEnd, id, kind)
+		if v.hasBead {
+			exp.beads[id] = v.bead
+		}
+		if v.hasDeps {
+			exp.deps[id] = v.deps
+		}
+		if v.dirty {
+			exp.dirty[id] = struct{}{}
+		}
+		if v.hasBeadSeq {
+			exp.beadSeq[id] = v.beadSeq
+		}
+		if v.hasLocalAt {
+			exp.localBeadAt[id] = v.localAt
+		}
+		if v.hasDeleted {
+			exp.deletedSeq[id] = v.deletedSeq
+		}
+	}
+	if in.quiescent(st) {
+		exp.depsComplete = refEnd.depsComplete && !depsCompleteFlip
+	}
+	// (Mutated regime: NEW's depsComplete == A's; refEnd already carries it.)
+	return exp
+}
+
+// allOracleIDs is the id universe the oracle must decide: every id referenced
+// by the reference end-state, the input state, or the snapshot.
+func allOracleIDs(st storeState, in snapshotInputs, refEnd mergeEndState) map[string]struct{} {
+	ids := map[string]struct{}{}
+	add := func(id string) { ids[id] = struct{}{} }
+	for id := range refEnd.beads {
+		add(id)
+	}
+	for id := range refEnd.deps {
+		add(id)
+	}
+	for id := range refEnd.dirty {
+		add(id)
+	}
+	for id := range refEnd.beadSeq {
+		add(id)
+	}
+	for id := range refEnd.localBeadAt {
+		add(id)
+	}
+	for id := range refEnd.deletedSeq {
+		add(id)
+	}
+	for id := range st.beads {
+		add(id)
+	}
+	for id := range st.deps {
+		add(id)
+	}
+	for id := range st.dirty {
+		add(id)
+	}
+	for id := range st.beadSeq {
+		add(id)
+	}
+	for id := range st.localBeadAt {
+		add(id)
+	}
+	for id := range st.deletedSeq {
+		add(id)
+	}
+	for id := range in.freshByID {
+		add(id)
+	}
+	return ids
+}
+
+// computePostPreserveFresh returns freshByID after the (shared, unchanged)
+// preserve pass, so the case-oracle sees the exact fresh beads all three
+// implementations see.
+func computePostPreserveFresh(st storeState, in snapshotInputs) map[string]Bead {
+	c, _ := newMergeHarnessStore(st, nil)
+	fresh := cloneBeadMap(in.freshByID)
+	c.mu.Lock()
+	c.preserveCachedReadyProjectionLocked(fresh, in.depMap, in.useFreshDeps)
+	c.mu.Unlock()
+	return fresh
+}
+
+// ---------------------------------------------------------------------------
+// Notification multiset comparison
+// ---------------------------------------------------------------------------
+
+func assertNotificationsEqual(t *testing.T, name string, want, got []cacheNotification) {
+	t.Helper()
+	assertPerIDUnique(t, name+" (ref)", want)
+	assertPerIDUnique(t, name+" (new)", got)
+	ws := sortNotifications(want)
+	gs := sortNotifications(got)
+	if len(ws) != len(gs) {
+		t.Fatalf("%s: notification count ref=%d new=%d\nref=%v\nnew=%v", name, len(ws), len(gs), ws, gs)
+	}
+	for i := range ws {
+		if ws[i].eventType != gs[i].eventType || !beadsIdentical(ws[i].bead, gs[i].bead) {
+			t.Fatalf("%s: notification[%d] ref={%s %s} new={%s %s} (payload differs=%v)",
+				name, i, ws[i].eventType, ws[i].bead.ID, gs[i].eventType, gs[i].bead.ID,
+				!beadsIdentical(ws[i].bead, gs[i].bead))
+		}
+	}
+}
+
+func assertPerIDUnique(t *testing.T, name string, ns []cacheNotification) {
+	t.Helper()
+	seen := map[string]struct{}{}
+	for _, n := range ns {
+		if _, dup := seen[n.bead.ID]; dup {
+			t.Fatalf("%s: per-id notification uniqueness broken for %q — the multiset comparison assumption is invalid", name, n.bead.ID)
+		}
+		seen[n.bead.ID] = struct{}{}
+	}
+}
+
+func sortNotifications(ns []cacheNotification) []cacheNotification {
+	out := make([]cacheNotification, len(ns))
+	copy(out, ns)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].bead.ID != out[j].bead.ID {
+			return out[i].bead.ID < out[j].bead.ID
+		}
+		return out[i].eventType < out[j].eventType
+	})
+	return out
+}
+
+// beadsIdentical is exact struct equality (reflect.DeepEqual), NOT beadChanged
+// — a lost Labels slice or metadata entry must fail even where skipLabels-blind
+// comparison would pass it.
+func beadsIdentical(a, b Bead) bool {
+	return reflectDeepEqual(a, b)
+}
+
+// ---------------------------------------------------------------------------
+// Spec-independent NEW-end invariants (redundant power vs a matrix misread)
+// ---------------------------------------------------------------------------
+
+func assertNewEndInvariants(t *testing.T, name string, end mergeEndState, in snapshotInputs) {
+	t.Helper()
+	// INV1 (no leaks): every orphan id (no bead) carrying any fence/deps entry
+	// must have a live protector — a fence > startSeq or a recent localAt.
+	orphanIDs := map[string]struct{}{}
+	for id := range end.deletedSeq {
+		orphanIDs[id] = struct{}{}
+	}
+	for id := range end.dirty {
+		orphanIDs[id] = struct{}{}
+	}
+	for id := range end.beadSeq {
+		orphanIDs[id] = struct{}{}
+	}
+	for id := range end.localBeadAt {
+		orphanIDs[id] = struct{}{}
+	}
+	for id := range end.deps {
+		orphanIDs[id] = struct{}{}
+	}
+	for id := range orphanIDs {
+		if _, hasBead := end.beads[id]; hasBead {
+			continue
+		}
+		protected := end.deletedSeq[id] > in.startSeq ||
+			end.beadSeq[id] > in.startSeq ||
+			recentLocalMutation(end.localBeadAt[id], in.now)
+		if !protected {
+			t.Fatalf("%s: INV1 leak — orphan %q retained a fence/deps entry with no protector (deletedSeq=%d beadSeq=%d localAt=%v startSeq=%d)",
+				name, id, end.deletedSeq[id], end.beadSeq[id], end.localBeadAt[id], in.startSeq)
+		}
+	}
+	// INV2 (V1): deletedSeq present ⇒ beads absent.
+	for id := range end.deletedSeq {
+		if _, ok := end.beads[id]; ok {
+			t.Fatalf("%s: INV2 violated — %q has both a live row and a tombstone", name, id)
+		}
+	}
+	// INV3: the sentinel convention forbids a zero-valued fence entry.
+	for id, v := range end.beadSeq {
+		if v == 0 {
+			t.Fatalf("%s: INV3 violated — beadSeq[%q]==0 (zero means absent by convention)", name, id)
+		}
+	}
+	for id, v := range end.deletedSeq {
+		if v == 0 {
+			t.Fatalf("%s: INV3 violated — deletedSeq[%q]==0", name, id)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The differential assertion
+// ---------------------------------------------------------------------------
+
+// assertDifferential runs the frozen reference branch (selected by regime) and
+// the live collapsed seam on byte-identical clones of (st, in), and asserts
+// full end-state + notification equivalence modulo the §2 deltas. Each
+// implementation is run twice on fresh clones (Go randomizes map iteration per
+// range) to detect any order dependence before cross-comparing — an
+// order-dependent divergence would otherwise surface as an unreproducible CI
+// flake.
+func assertDifferential(t *testing.T, name string, st storeState, in snapshotInputs) {
+	t.Helper()
+
+	// Determinism self-check per implementation.
+	newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+	newRes2 := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+	assertSelfDeterministic(t, name+" NEW", newRes, newRes2)
+
+	var ref mergeImplResult
+	if in.quiescent(st) {
+		ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		ref2 := runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		assertSelfDeterministic(t, name+" legacyB", ref, ref2)
+	} else {
+		ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		ref2 := runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		assertSelfDeterministic(t, name+" legacyA", ref, ref2)
+	}
+
+	// Merge purity: zero backing I/O inside the seam (off-BdStore path).
+	if !st.backingIsBd {
+		if newRes.backingCalls != 0 {
+			t.Fatalf("%s: NEW made %d backing calls during merge — the seam must be I/O-free", name, newRes.backingCalls)
+		}
+		if ref.backingCalls != 0 {
+			t.Fatalf("%s: reference made %d backing calls during merge", name, ref.backingCalls)
+		}
+	}
+
+	// Notifications and counters must be EXACTLY equal (no delta by analysis).
+	assertNotificationsEqual(t, name, ref.notifications, newRes.notifications)
+
+	// Six-map + depsComplete: build the full expected NEW end-state from the
+	// reference and assert exact equality (scalars/counters copied ⇒ asserted
+	// equal; maps transformed per the independent case-oracle).
+	postPreserve := computePostPreserveFresh(st, in)
+	exp := buildExpectedNewEnd(st, in, postPreserve, ref.end)
+	if !endStatesEqual(exp, newRes.end) {
+		t.Fatalf("%s: end-state divergence\n%s", name, diffEndStates(exp, newRes.end))
+	}
+
+	// Spec-independent invariants on the NEW end-state alone.
+	assertNewEndInvariants(t, name, newRes.end, in)
+}
+
+func assertSelfDeterministic(t *testing.T, name string, a, b mergeImplResult) {
+	t.Helper()
+	if !endStatesEqual(a.end, b.end) {
+		t.Fatalf("%s: NON-DETERMINISTIC end-state across two runs (map-iteration order dependence)\n%s",
+			name, diffEndStates(a.end, b.end))
+	}
+	assertNotificationsEqual(t, name+" self-determinism", a.notifications, b.notifications)
+}

--- a/internal/beads/caching_store_reconcile_oracle_test.go
+++ b/internal/beads/caching_store_reconcile_oracle_test.go
@@ -151,7 +151,7 @@ func stateHasAnyOrphanEntry(end mergeEndState, id string) bool {
 
 // expectedNewView returns the per-id view NEW must produce, transforming the
 // reference view per the classified delta.
-func expectedNewView(st storeState, in snapshotInputs, refEnd mergeEndState, id string, kind deltaKind) perIDView {
+func expectedNewView(st storeState, _ snapshotInputs, refEnd mergeEndState, id string, kind deltaKind) perIDView {
 	base := viewOf(refEnd, id)
 	switch kind {
 	case deltaNone:
@@ -272,7 +272,7 @@ func allOracleIDs(st storeState, in snapshotInputs, refEnd mergeEndState) map[st
 // preserve pass, so the case-oracle sees the exact fresh beads all three
 // implementations see.
 func computePostPreserveFresh(st storeState, in snapshotInputs) map[string]Bead {
-	c, _ := newMergeHarnessStore(st, nil)
+	c, _ := newMergeHarnessStore(st)
 	fresh := cloneBeadMap(in.freshByID)
 	c.mu.Lock()
 	c.preserveCachedReadyProjectionLocked(fresh, in.depMap, in.useFreshDeps)
@@ -402,18 +402,18 @@ func assertDifferential(t *testing.T, name string, st storeState, in snapshotInp
 	t.Helper()
 
 	// Determinism self-check per implementation.
-	newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
-	newRes2 := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+	newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in))
+	newRes2 := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in))
 	assertSelfDeterministic(t, name+" NEW", newRes, newRes2)
 
 	var ref mergeImplResult
 	if in.quiescent(st) {
-		ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
-		ref2 := runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in))
+		ref2 := runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in))
 		assertSelfDeterministic(t, name+" legacyB", ref, ref2)
 	} else {
-		ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
-		ref2 := runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in))
+		ref2 := runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in))
 		assertSelfDeterministic(t, name+" legacyA", ref, ref2)
 	}
 

--- a/internal/beads/caching_store_reconcile_probes_test.go
+++ b/internal/beads/caching_store_reconcile_probes_test.go
@@ -37,13 +37,13 @@ func TestReconcileMergeDeltas_AreReal(t *testing.T) {
 		in := cloneSnapshotInputs(f.in)
 		var ref mergeImplResult
 		if in.quiescent(st) {
-			ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+			ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in))
 		} else {
-			ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+			ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in))
 		}
-		newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in))
 		if endStatesEqual(ref.end, newRes.end) {
-			t.Errorf("%s: labelled a delta but NEW == reference (delta is vacuous)", f.name)
+			t.Errorf("%s: labeled a delta but NEW == reference (delta is vacuous)", f.name)
 		}
 		checked++
 	}
@@ -56,7 +56,7 @@ func TestReconcileMergeDeltas_AreReal(t *testing.T) {
 // end-state, guarding against a vacuous reflect.DeepEqual.
 func TestReconcileMergeOracleHasTeeth(t *testing.T) {
 	f := mergeFixtures()[0]
-	newRes := runNewMerge(cloneStoreState(f.st), cloneSnapshotInputs(f.in), nil)
+	newRes := runNewMerge(cloneStoreState(f.st), cloneSnapshotInputs(f.in))
 	corrupt := newRes.end
 	corrupt.beads = cloneBeadMap(newRes.end.beads)
 	corrupt.beads["injected-ghost"] = bead("injected-ghost", "open")
@@ -109,11 +109,11 @@ func TestReconcileMergeReadProjection(t *testing.T) {
 
 		var ref mergeImplResult
 		if in.quiescent(st) {
-			ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+			ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in))
 		} else {
-			ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+			ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in))
 		}
-		newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in))
 
 		// Backing truth: the active beads a full scan returned this cycle.
 		truthRef := NewMemStore()
@@ -216,7 +216,7 @@ func TestReconcileMergeNoInputAliasing(t *testing.T) {
 		st := cloneStoreState(f.st)
 		in := cloneSnapshotInputs(f.in)
 
-		c, _ := newMergeHarnessStore(st, nil)
+		c, _ := newMergeHarnessStore(st)
 		c.mu.Lock()
 		res := c.mergeSnapshotLocked(in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
 		snapshot := captureEndState(c)
@@ -329,7 +329,7 @@ func decodeFuzzState(data []byte) (storeState, snapshotInputs) {
 				in.depMap[id] = fuzzDeps(cur, id)
 			}
 			if cachedPresent && st.beads[id].Status != "closed" && cur.intn(4) == 0 {
-				in.confirmedClosed[id] = beadWith(id, "closed", func(b *Bead) {})
+				in.confirmedClosed[id] = beadWith(id, "closed", func(_ *Bead) {})
 			}
 		}
 		if cur.intn(2) == 0 {

--- a/internal/beads/caching_store_reconcile_probes_test.go
+++ b/internal/beads/caching_store_reconcile_probes_test.go
@@ -1,0 +1,411 @@
+package beads
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Oracle teeth: prove the gate is not vacuous
+// ---------------------------------------------------------------------------
+
+// TestReconcileMergeDeltas_AreReal asserts that every fixture named for a §2
+// delta actually produces a NEW end-state that DIFFERS from the reference
+// branch — i.e. the delta is a genuine behavioral change the oracle is
+// characterizing, not rubber-stamped equality. assertDifferential still passes
+// on these (proving the difference is exactly the enumerated delta).
+func TestReconcileMergeDeltas_AreReal(t *testing.T) {
+	// Markers for fixtures that are GENUINE deltas vs the reference branch.
+	// Quiescent stale-orphan GC cases are ≡ to Branch B (both wipe), so they are
+	// deliberately NOT listed here.
+	deltaMarkers := []string{"D5", "D4", "D2", "D3prime", "D1prime", "recent_kept", "orphan_gc", "fences_gc"}
+	var checked int
+	for _, f := range mergeFixtures() {
+		isDelta := false
+		for _, m := range deltaMarkers {
+			if strings.Contains(f.name, m) {
+				isDelta = true
+				break
+			}
+		}
+		if !isDelta {
+			continue
+		}
+		st := cloneStoreState(f.st)
+		in := cloneSnapshotInputs(f.in)
+		var ref mergeImplResult
+		if in.quiescent(st) {
+			ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		} else {
+			ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		}
+		newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		if endStatesEqual(ref.end, newRes.end) {
+			t.Errorf("%s: labelled a delta but NEW == reference (delta is vacuous)", f.name)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("no delta fixtures found — teeth test is inert")
+	}
+}
+
+// TestReconcileMergeOracleHasTeeth proves the comparison detects a corrupted
+// end-state, guarding against a vacuous reflect.DeepEqual.
+func TestReconcileMergeOracleHasTeeth(t *testing.T) {
+	f := mergeFixtures()[0]
+	newRes := runNewMerge(cloneStoreState(f.st), cloneSnapshotInputs(f.in), nil)
+	corrupt := newRes.end
+	corrupt.beads = cloneBeadMap(newRes.end.beads)
+	corrupt.beads["injected-ghost"] = bead("injected-ghost", "open")
+	if endStatesEqual(newRes.end, corrupt) {
+		t.Fatal("oracle failed to detect an injected ghost row")
+	}
+	// A one-field scalar change must also be caught.
+	corrupt2 := newRes.end
+	corrupt2.statsAdds++
+	if endStatesEqual(newRes.end, corrupt2) {
+		t.Fatal("oracle failed to detect a stats.Adds drift")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Read-projection probe (plan §5.1(5))
+// ---------------------------------------------------------------------------
+
+// mountEndState builds a live cacheLive store from an end-state over a MemStore
+// backing seeded with the "reality" rows (the active beads bd would return).
+func mountEndState(end mergeEndState, truth *MemStore) *CachingStore {
+	c := &CachingStore{
+		backing:      truth,
+		beads:        cloneBeadMap(end.beads),
+		deps:         cloneDepMap(end.deps),
+		depsComplete: end.depsComplete,
+		dirty:        cloneDirty(end.dirty),
+		beadSeq:      cloneU64Map(end.beadSeq),
+		localBeadAt:  cloneTimeMap(end.localBeadAt),
+		deletedSeq:   cloneU64Map(end.deletedSeq),
+		state:        cacheLive,
+	}
+	ensureMaps(c)
+	return c
+}
+
+// TestReconcileMergeReadProjection mounts the reference and NEW end-states over
+// an identical backing that reflects reality (freshByID rows exist; orphan and
+// deleted ids do not) and asserts Get/DepList/CachedReady serve identically.
+// Map equality already implies read equality on non-delta cells; this probe is
+// the check that the §2 delta divergences are invisible at the read surface —
+// D1's tombstone GC falls through to a backing that also says not-found, etc.
+func TestReconcileMergeReadProjection(t *testing.T) {
+	states := append(mergeFixtures(), genGridStates()...)
+	states = append(states, genSeededStates(3, 400)...)
+	for _, f := range states {
+		f := f
+		st := cloneStoreState(f.st)
+		in := cloneSnapshotInputs(f.in)
+
+		var ref mergeImplResult
+		if in.quiescent(st) {
+			ref = runLegacyB(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		} else {
+			ref = runLegacyA(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+		}
+		newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in), nil)
+
+		// Backing truth: the active beads a full scan returned this cycle.
+		truthRef := NewMemStore()
+		truthNew := NewMemStore()
+		var truthRows []Bead
+		for _, b := range in.freshByID {
+			truthRows = append(truthRows, cloneBead(b))
+		}
+		seedMem(truthRef, truthRows)
+		seedMem(truthNew, truthRows)
+
+		cRef := mountEndState(ref.end, truthRef)
+		cNew := mountEndState(newRes.end, truthNew)
+
+		ids := rowIDUniverse(st, in)
+		ids = append(ids, "never-seen-id")
+		for _, id := range ids {
+			bRef, eRef := cRef.Get(id)
+			bNew, eNew := cNew.Get(id)
+			if !sameGetResult(bRef, eRef, bNew, eNew) {
+				t.Fatalf("%s: Get(%q) read-projection divergence ref=(%v,%v) new=(%v,%v)",
+					f.name, id, bRef.ID, eRef, bNew.ID, eNew)
+			}
+		}
+
+		rRef, okRef := cRef.CachedReady()
+		rNew, okNew := cNew.CachedReady()
+		switch {
+		case okRef && okNew:
+			// Both serve from cache ⇒ identical served set required (beads maps
+			// are equal on non-GC'd ids, so served readiness must match).
+			if !sameBeadSet(rRef, rNew) {
+				t.Fatalf("%s: CachedReady served set differs", f.name)
+			}
+		case in.quiescent(st):
+			// Reference = Branch B. The quiescent deltas (D2 depsComplete, D1'/D3'
+			// a kept orphan dirty/fence) can only make NEW MORE conservative:
+			// NEW may decline where B served, never the reverse.
+			if okNew && !okRef {
+				t.Fatalf("%s: CachedReady served from NEW but declined on Branch B — unsafe direction", f.name)
+			}
+		default:
+			// Mutated regime, reference = Branch A. The D1/D3 orphan GC REMOVES a
+			// leaked dirty/fence that made A decline permanently; NEW may serve
+			// where A declined (the intended fix), never decline where A served.
+			if okRef && !okNew {
+				t.Fatalf("%s: CachedReady declined on NEW but Branch A served — a serving regression", f.name)
+			}
+		}
+	}
+}
+
+func seedMem(m *MemStore, rows []Bead) {
+	for _, r := range rows {
+		m.beads = append(m.beads, cloneBead(r))
+	}
+}
+
+func sameGetResult(bRef Bead, eRef error, bNew Bead, eNew error) bool {
+	refNF := errors.Is(eRef, ErrNotFound)
+	newNF := errors.Is(eNew, ErrNotFound)
+	if refNF || newNF {
+		return refNF && newNF
+	}
+	if (eRef == nil) != (eNew == nil) {
+		return false
+	}
+	if eRef != nil {
+		return eRef.Error() == eNew.Error()
+	}
+	return beadsIdentical(bRef, bNew)
+}
+
+func sameBeadSet(a, b []Bead) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]Bead{}
+	for _, x := range a {
+		seen[x.ID] = x
+	}
+	for _, y := range b {
+		x, ok := seen[y.ID]
+		if !ok || !beadsIdentical(x, y) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Aliasing probe (plan §5.1 hardening): equal-clone and shared-backing compare
+// identical, so scribble on every input/notification reference field after the
+// merge and assert the store's maps do not move — pins today's clone discipline.
+// ---------------------------------------------------------------------------
+
+func TestReconcileMergeNoInputAliasing(t *testing.T) {
+	for _, f := range mergeFixtures() {
+		f := f
+		st := cloneStoreState(f.st)
+		in := cloneSnapshotInputs(f.in)
+
+		c, _ := newMergeHarnessStore(st, nil)
+		c.mu.Lock()
+		res := c.mergeSnapshotLocked(in.freshByID, in.confirmedClosed, in.depMap, in.useFreshDeps, in.startSeq, in.now)
+		snapshot := captureEndState(c)
+		c.mu.Unlock()
+
+		// Scribble on every reference field of the inputs and notifications.
+		scribbleBeadMap(in.freshByID)
+		scribbleBeadMap(in.confirmedClosed)
+		for k, v := range in.depMap {
+			for i := range v {
+				v[i] = dep("SCRIBBLE", "SCRIBBLE")
+			}
+			in.depMap[k] = append(v, dep("EXTRA", "EXTRA"))
+		}
+		for i := range res.notifications {
+			res.notifications[i].bead.Labels = []string{"SCRIBBLE"}
+			res.notifications[i].bead.Metadata = StringMap{"SCRIBBLE": "1"}
+			if res.notifications[i].bead.Dependencies != nil {
+				for j := range res.notifications[i].bead.Dependencies {
+					res.notifications[i].bead.Dependencies[j] = dep("SCRIBBLE", "SCRIBBLE")
+				}
+			}
+		}
+
+		c.mu.Lock()
+		after := captureEndState(c)
+		c.mu.Unlock()
+		if !endStatesEqual(snapshot, after) {
+			t.Fatalf("%s: store mutated after scribbling on inputs/notifications — aliasing leak\n%s",
+				f.name, diffEndStates(snapshot, after))
+		}
+	}
+}
+
+func scribbleBeadMap(m map[string]Bead) {
+	for k, b := range m {
+		b.Labels = []string{"SCRIBBLE"}
+		b.Metadata = StringMap{"SCRIBBLE": "1"}
+		b.Needs = []string{"SCRIBBLE"}
+		b.Dependencies = []Dep{dep("SCRIBBLE", "SCRIBBLE")}
+		m[k] = b
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fuzz tier
+// ---------------------------------------------------------------------------
+
+type byteCursor struct {
+	data []byte
+	pos  int
+}
+
+func (c *byteCursor) next() byte {
+	if c.pos >= len(c.data) {
+		return 0
+	}
+	b := c.data[c.pos]
+	c.pos++
+	return b
+}
+
+func (c *byteCursor) intn(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	return int(c.next()) % n
+}
+
+// decodeFuzzState interprets fuzz bytes as V-valid grid indices (rejection-free).
+func decodeFuzzState(data []byte) (storeState, snapshotInputs) {
+	cur := &byteCursor{data: data}
+	const startSeq = uint64(100)
+	mutated := cur.intn(2) == 0
+	st := storeState{
+		beads: map[string]Bead{}, deps: map[string][]Dep{}, dirty: map[string]struct{}{},
+		beadSeq: map[string]uint64{}, localBeadAt: map[string]time.Time{}, deletedSeq: map[string]uint64{},
+		backingIsBd: cur.intn(2) == 0,
+	}
+	in := snapshotInputs{
+		freshByID: map[string]Bead{}, confirmedClosed: map[string]Bead{}, depMap: map[string][]Dep{},
+		useFreshDeps: cur.intn(2) == 0, startSeq: startSeq, now: fxNow,
+	}
+	if mutated {
+		st.mutationSeq = startSeq + uint64(1+cur.intn(80))
+	} else {
+		st.mutationSeq = startSeq
+	}
+	statuses := []string{"open", "in_progress", "closed"}
+	recCells := []string{"none", "recent", "boundary", "justover", "stale", "now"}
+	nRows := 1 + cur.intn(4)
+	for r := 0; r < nRows; r++ {
+		id := string(rune('a' + r))
+		presence := cur.intn(4)
+		cachedPresent := presence == 0 || presence == 2
+		freshPresent := presence == 0 || presence == 1
+		if cachedPresent {
+			cb := bead(id, statuses[cur.intn(3)])
+			fuzzFields(cur, &cb)
+			st.beads[id] = cb
+			if cur.intn(3) != 0 {
+				st.deps[id] = fuzzDeps(cur, id)
+			}
+		}
+		if freshPresent {
+			fb := bead(id, statuses[cur.intn(3)])
+			fuzzFields(cur, &fb)
+			in.freshByID[id] = fb
+			if in.useFreshDeps && cur.intn(3) != 0 {
+				in.depMap[id] = fuzzDeps(cur, id)
+			}
+			if cachedPresent && st.beads[id].Status != "closed" && cur.intn(4) == 0 {
+				in.confirmedClosed[id] = beadWith(id, "closed", func(b *Bead) {})
+			}
+		}
+		if cur.intn(2) == 0 {
+			st.beadSeq[id] = randFenceFuzz(cur, startSeq, st.mutationSeq)
+		}
+		if !cachedPresent && cur.intn(2) == 0 {
+			st.deletedSeq[id] = randFenceFuzz(cur, startSeq, st.mutationSeq)
+		}
+		if cur.intn(2) == 0 {
+			if t, ok := recencyValue2(recCells[cur.intn(len(recCells))]); ok {
+				st.localBeadAt[id] = t
+			}
+		}
+		if cur.intn(3) == 0 {
+			st.dirty[id] = struct{}{}
+		}
+		if presence == 3 && cur.intn(2) == 0 {
+			st.deps[id] = fuzzDeps(cur, id)
+		}
+	}
+	return st, in
+}
+
+func randFenceFuzz(cur *byteCursor, startSeq, mutationSeq uint64) uint64 {
+	if mutationSeq > startSeq && cur.intn(2) == 0 {
+		return startSeq + 1 + uint64(cur.intn(int(mutationSeq-startSeq)))
+	}
+	return uint64(1 + cur.intn(int(startSeq)))
+}
+
+func fuzzFields(cur *byteCursor, b *Bead) {
+	if cur.intn(2) == 0 {
+		b.Title = "t" + string(rune('0'+cur.intn(3)))
+	}
+	if cur.intn(3) == 0 {
+		b.Labels = []string{"l" + string(rune('0'+cur.intn(2)))}
+	}
+	if cur.intn(3) == 0 {
+		v := cur.intn(2) == 0
+		b.IsBlocked = &v
+	}
+	if cur.intn(3) == 0 {
+		b.Metadata = StringMap{"k": string(rune('0' + cur.intn(2)))}
+	}
+	if cur.intn(3) == 0 {
+		b.Needs = []string{"n" + string(rune('0'+cur.intn(2)))}
+	}
+	if cur.intn(3) == 0 {
+		b.Dependencies = []Dep{dep(b.ID, "d"+string(rune('0'+cur.intn(2))))}
+	}
+}
+
+func fuzzDeps(cur *byteCursor, id string) []Dep {
+	switch cur.intn(4) {
+	case 0:
+		return nil
+	case 1:
+		return []Dep{}
+	default:
+		n := 1 + cur.intn(2)
+		ds := make([]Dep, n)
+		for i := range ds {
+			ds[i] = dep(id, "t"+string(rune('0'+cur.intn(3))))
+		}
+		return ds
+	}
+}
+
+func FuzzReconcileMergeDifferential(f *testing.F) {
+	// Seed the corpus from a few fixtures' byte-equivalents (arbitrary bytes
+	// decode to V-valid states, so any seed is legal).
+	f.Add([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	f.Add([]byte{1, 1, 1, 0, 2, 2, 2, 3, 3, 3, 4, 4})
+	f.Add([]byte{255, 254, 253, 200, 100, 50, 25, 12, 6, 3, 1})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		st, in := decodeFuzzState(data)
+		assertDifferential(t, "fuzz", st, in)
+	})
+}

--- a/internal/beads/caching_store_reconcile_probes_test.go
+++ b/internal/beads/caching_store_reconcile_probes_test.go
@@ -95,10 +95,13 @@ func mountEndState(end mergeEndState, truth *MemStore) *CachingStore {
 
 // TestReconcileMergeReadProjection mounts the reference and NEW end-states over
 // an identical backing that reflects reality (freshByID rows exist; orphan and
-// deleted ids do not) and asserts Get/DepList/CachedReady serve identically.
-// Map equality already implies read equality on non-delta cells; this probe is
-// the check that the §2 delta divergences are invisible at the read surface —
-// D1's tombstone GC falls through to a backing that also says not-found, etc.
+// deleted ids do not) and asserts Get and CachedReady serve identically (or that
+// NEW only ever moves in the safe direction). Map equality already implies read
+// equality on non-delta cells; this probe is the check that the §2 delta
+// divergences are invisible at the read surface — D1's tombstone GC falls
+// through to a backing that also says not-found, etc. The dependency-list read
+// surface is covered separately by TestReconcileMergeD4RecencyKeepDepListContract,
+// which exercises the one delta (D4) that touches deps.
 func TestReconcileMergeReadProjection(t *testing.T) {
 	states := append(mergeFixtures(), genGridStates()...)
 	states = append(states, genSeededStates(3, 400)...)
@@ -163,6 +166,76 @@ func TestReconcileMergeReadProjection(t *testing.T) {
 				t.Fatalf("%s: CachedReady declined on NEW but Branch A served — a serving regression", f.name)
 			}
 		}
+	}
+}
+
+// TestReconcileMergeD4RecencyKeepDepListContract pins the dependency-read
+// contract for the D4 cell — a quiescent recency-keep whose retained cached deps
+// diverge from the fresh full-scan snapshot. The collapse keeps the local deps
+// (they may reflect an in-flight local write the snapshot lags — see the
+// reg_2210 fixture) but must not then advertise the deps map as a complete,
+// faithful projection of the scan. This closes the attempt-2 gap: the general
+// read-projection probe exercised only Get and CachedReady, leaving the deps
+// read surface for this delta unproven.
+func TestReconcileMergeD4RecencyKeepDepListContract(t *testing.T) {
+	const startSeq = uint64(100)
+	// Quiescent recency-keep: the cached row is recent and body-changed vs the
+	// fresh row, and its cached deps ([cached]) differ from the fresh snapshot
+	// deps ([fresh]).
+	st := storeState{
+		beads:       map[string]Bead{"a": bead("a", "open")},
+		deps:        map[string][]Dep{"a": {dep("a", "cached")}},
+		beadSeq:     map[string]uint64{"a": 90},
+		localBeadAt: map[string]time.Time{"a": fxRecent()},
+		mutationSeq: startSeq,
+	}
+	in := snapshotInputs{
+		freshByID:    map[string]Bead{"a": beadWith("a", "closed", func(_ *Bead) {})},
+		depMap:       map[string][]Dep{"a": {dep("a", "fresh")}},
+		useFreshDeps: true,
+		startSeq:     startSeq,
+		now:          fxNow,
+	}
+	newRes := runNewMerge(cloneStoreState(st), cloneSnapshotInputs(in))
+
+	// The fix: a divergent recency-keep degrades depsComplete instead of
+	// over-claiming a complete deps projection.
+	if newRes.end.depsComplete {
+		t.Fatal("D4 divergent recency-keep left depsComplete=true — the cache over-claims a complete deps projection")
+	}
+	// The retained local deps stay in the cache (the collapse keeps them where
+	// Branch B overwrote them with the snapshot deps).
+	if depsChanged(newRes.end.deps["a"], []Dep{dep("a", "cached")}) {
+		t.Fatalf("D4 recency-keep should retain cached deps, got %v", newRes.end.deps["a"])
+	}
+
+	// Mount the NEW end-state over a backing whose DepList is the authoritative
+	// answer, distinct from both the cached and the snapshot deps, so a fallback
+	// is observable.
+	truth := NewMemStore()
+	truth.deps = []Dep{dep("a", "authoritative")}
+	c := mountEndState(newRes.end, truth)
+
+	// The public DepList reader fails closed to the backing: with depsComplete
+	// degraded it must NOT serve the retained (possibly stale) cached deps as an
+	// authoritative, complete projection.
+	got, err := c.DepList("a", "down")
+	if err != nil {
+		t.Fatalf("DepList returned error: %v", err)
+	}
+	if depsChanged(got, []Dep{dep("a", "authoritative")}) {
+		t.Fatalf("DepList must fall back to the backing when depsComplete is degraded; got %v (cached deps leaked to an authoritative read)", got)
+	}
+
+	// The cache-only reader still surfaces the retained local deps — the same
+	// local-truth view cachedGetOnly serves for the retained bead body. It is the
+	// explicit best-effort cache surface, not the authoritative projection.
+	cached, err := c.cachedDepListOnly("a", "down")
+	if err != nil {
+		t.Fatalf("cachedDepListOnly returned error: %v", err)
+	}
+	if depsChanged(cached, []Dep{dep("a", "cached")}) {
+		t.Fatalf("cachedDepListOnly should surface the retained local deps, got %v", cached)
 	}
 }
 
@@ -404,6 +477,12 @@ func FuzzReconcileMergeDifferential(f *testing.F) {
 	f.Add([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 	f.Add([]byte{1, 1, 1, 0, 2, 2, 2, 3, 3, 3, 4, 4})
 	f.Add([]byte{255, 254, 253, 200, 100, 50, 25, 12, 6, 3, 1})
+	// Regression seed: decodes to a recent quiescent orphan (delta
+	// D1RecentOrphan) carrying an empty-non-nil deps entry. Before the harness
+	// normalized its inputs, the oracle read that raw []Dep{} while the seam
+	// stored the cloneDeps-normalized nil, producing a false end-state
+	// divergence. Pinned so the fuzz tier stays honest.
+	f.Add([]byte("100071101001"))
 	f.Fuzz(func(t *testing.T, data []byte) {
 		st, in := decodeFuzzState(data)
 		assertDifferential(t, "fuzz", st, in)

--- a/internal/beads/caching_store_reconcile_twopass_test.go
+++ b/internal/beads/caching_store_reconcile_twopass_test.go
@@ -1,0 +1,137 @@
+package beads
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Tier 4: metamorphic two-pass sequences. From a base state we run one merge,
+// apply an intervening REAL-primitive operation (the lifecycle a single-pass
+// grid cannot reach — Delete→Update, Update→Delete, event-absorb→update, etc.),
+// then re-run the differential on the compound post-op state with a pass-2
+// clock advanced by a delta-now drawn from the fence-window boundary set and a
+// startSeq captured either before or after the op. This is the fence-lifecycle
+// coverage (#2210/#2987 shape) and the delta-now expiry axis.
+
+// extractStoreState snapshots a live store's merge-relevant state.
+func extractStoreState(c *CachingStore) storeState {
+	_, isBd := c.backing.(*BdStore)
+	return storeState{
+		beads:        cloneBeadMap(c.beads),
+		deps:         cloneDepMap(c.deps),
+		depsComplete: c.depsComplete,
+		dirty:        cloneDirty(c.dirty),
+		beadSeq:      cloneU64Map(c.beadSeq),
+		localBeadAt:  cloneTimeMap(c.localBeadAt),
+		deletedSeq:   cloneU64Map(c.deletedSeq),
+		mutationSeq:  c.mutationSeq,
+		backingIsBd:  isBd,
+	}
+}
+
+// twoPassOp is one intervening operation using the real primitives.
+type twoPassOp struct {
+	name  string
+	apply func(c *CachingStore, id string, opNow time.Time)
+}
+
+func twoPassOps() []twoPassOp {
+	return []twoPassOp{
+		{"tombstone", func(c *CachingStore, id string, opNow time.Time) {
+			c.tombstoneLocked(id, c.noteMutationLocked(id))
+		}},
+		{"markDirty", func(c *CachingStore, id string, opNow time.Time) {
+			c.markDirtyLocked(id)
+		}},
+		{"event_absorb_seqKeep", func(c *CachingStore, id string, opNow time.Time) {
+			// ApplyEvent-shape: bump the seq fence then absorb keeping it.
+			c.noteMutationLocked(id)
+			c.absorbFreshLocked(id, beadWith(id, "in_progress", func(b *Bead) { b.Title = "evt" }), opNow, absorbOpts{
+				depsMode: depsFromFields, seqMode: seqKeep, clearDirty: true,
+			})
+		}},
+		{"local_update", func(c *CachingStore, id string, opNow time.Time) {
+			// Update-shape with a CONTROLLED recency stamp (noteLocalMutationLocked
+			// reads the real wall clock, which we cannot inject; replicate its
+			// effect deterministically at opNow).
+			c.mutationSeq++
+			c.beadSeq[id] = c.mutationSeq
+			c.localBeadAt[id] = opNow
+			c.absorbFreshLocked(id, beadWith(id, "open", func(b *Bead) { b.Title = "upd" }), opNow, absorbOpts{
+				depsMode: depsFromFields, seqMode: seqKeep, clearDirty: true,
+			})
+		}},
+		{"tombstone_then_update", func(c *CachingStore, id string, opNow time.Time) {
+			// D1' genesis: Delete then a post-tombstone Update attempt.
+			c.tombstoneLocked(id, c.noteMutationLocked(id))
+			c.mutationSeq++
+			c.beadSeq[id] = c.mutationSeq
+			c.localBeadAt[id] = opNow
+			c.absorbFreshLocked(id, bead(id, "open"), opNow, absorbOpts{
+				depsMode: depsFromFields, seqMode: seqKeep, clearDirty: true,
+			})
+		}},
+	}
+}
+
+var deltaNows = []time.Duration{0, 2500 * time.Millisecond, 5 * time.Second, 5001 * time.Millisecond, time.Hour}
+
+func TestReconcileMergeDifferential_TwoPass(t *testing.T) {
+	bases := []mergeFixture{}
+	// A handful of grid states plus a few seeded states as pass-1 inputs.
+	grid := genGridStates()
+	for i := 0; i < len(grid); i += 40 { // sample the grid to bound runtime
+		bases = append(bases, grid[i])
+	}
+	bases = append(bases, genSeededStates(7, 60)...)
+
+	ops := twoPassOps()
+	targetIDs := []string{"a", "r0"}
+
+	for _, base := range bases {
+		for _, op := range ops {
+			for _, dn := range deltaNows {
+				for _, capAfter := range []bool{false, true} {
+					name := fmt.Sprintf("%s/%s/dn=%s/after=%v", base.name, op.name, dn, capAfter)
+
+					// Pass 1: differential on the base, then advance a live NEW
+					// store through pass 1 + the intervening op.
+					st0 := cloneStoreState(base.st)
+					in1 := cloneSnapshotInputs(base.in)
+					assertDifferential(t, name+"/pass1", cloneStoreState(st0), cloneSnapshotInputs(in1))
+
+					live := cloneSnapshotInputs(in1) // pass1's preserve mutates freshByID
+					c, _ := newMergeHarnessStore(st0, nil)
+					c.mu.Lock()
+					c.mergeSnapshotLocked(live.freshByID, live.confirmedClosed, live.depMap, live.useFreshDeps, live.startSeq, live.now)
+					seqBefore := c.mutationSeq
+					opNow := in1.now
+					id := targetIDs[0]
+					if _, ok := c.beads["r0"]; ok {
+						id = "r0"
+					}
+					op.apply(c, id, opNow)
+					seqAfter := c.mutationSeq
+					st2 := extractStoreState(c)
+					c.mu.Unlock()
+
+					// Pass 2: fresh differential on the compound post-op state.
+					startSeq2 := seqAfter
+					if !capAfter {
+						startSeq2 = seqBefore // op raced the scan
+					}
+					in2 := snapshotInputs{
+						freshByID:    cloneBeadMap(in1.freshByID),
+						depMap:       cloneDepMap(in1.depMap),
+						useFreshDeps: in1.useFreshDeps,
+						startSeq:     startSeq2,
+						now:          in1.now.Add(dn),
+					}
+					// V4: startSeq <= mutationSeq. seqBefore/seqAfter both satisfy it.
+					assertDifferential(t, name+"/pass2", st2, in2)
+				}
+			}
+		}
+	}
+}

--- a/internal/beads/caching_store_reconcile_twopass_test.go
+++ b/internal/beads/caching_store_reconcile_twopass_test.go
@@ -38,10 +38,10 @@ type twoPassOp struct {
 
 func twoPassOps() []twoPassOp {
 	return []twoPassOp{
-		{"tombstone", func(c *CachingStore, id string, opNow time.Time) {
+		{"tombstone", func(c *CachingStore, id string, _ time.Time) {
 			c.tombstoneLocked(id, c.noteMutationLocked(id))
 		}},
-		{"markDirty", func(c *CachingStore, id string, opNow time.Time) {
+		{"markDirty", func(c *CachingStore, id string, _ time.Time) {
 			c.markDirtyLocked(id)
 		}},
 		{"event_absorb_seqKeep", func(c *CachingStore, id string, opNow time.Time) {
@@ -102,7 +102,7 @@ func TestReconcileMergeDifferential_TwoPass(t *testing.T) {
 					assertDifferential(t, name+"/pass1", cloneStoreState(st0), cloneSnapshotInputs(in1))
 
 					live := cloneSnapshotInputs(in1) // pass1's preserve mutates freshByID
-					c, _ := newMergeHarnessStore(st0, nil)
+					c, _ := newMergeHarnessStore(st0)
 					c.mu.Lock()
 					c.mergeSnapshotLocked(live.freshByID, live.confirmedClosed, live.depMap, live.useFreshDeps, live.startSeq, live.now)
 					seqBefore := c.mutationSeq


### PR DESCRIPTION
<Phase 2: runReconciliation two branches collapse to one pure reconcileMergeDecision; Branch B deleted after a red-teamed T3 differential gate (old-vs-new merge equivalence over corpus + fuzzed decision-space) proved ZERO divergence; existing corpus unmodified; -race clean. Stacked on #4046 (re-target to main after it merges). #2987/#2153>