### PR TITLE
Classify Claude spend-limit modal as rate limit

### DIFF
--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -4240,6 +4240,15 @@ func TestReconcileSessionBeads_SkipsAliveSession(t *testing.T) {
 }
 
 func TestReconcileSessionBeads_RateLimitScreenQuarantinesBeforeHeal(t *testing.T) {
+	assertRateLimitScrollbackQuarantinesBeforeHeal(t, "You've hit your limit, Pro plan\n\n/rate-limit-options")
+}
+
+func TestReconcileSessionBeads_SpendLimitModalQuarantinesBeforeHeal(t *testing.T) {
+	assertRateLimitScrollbackQuarantinesBeforeHeal(t, "What do you want to do?\nUsage credit balance: $573.37\n❯ Adjust monthly spend limit: $1503.19\n  Wait for limit to reset      Resets Jul 12 at 11pm (America/Los_Angeles)\nEnter to confirm · Esc to cancel")
+}
+
+func assertRateLimitScrollbackQuarantinesBeforeHeal(t *testing.T, peekOutput string) {
+	t.Helper()
 	env := newReconcilerTestEnv()
 	rec := events.NewFake()
 	env.rec = rec
@@ -4254,7 +4263,7 @@ func TestReconcileSessionBeads_RateLimitScreenQuarantinesBeforeHeal(t *testing.T
 		t.Fatalf("Start(worker): %v", err)
 	}
 	env.sp.Zombies["worker"] = true
-	env.sp.SetPeekOutput("worker", "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	env.sp.SetPeekOutput("worker", peekOutput)
 	session := env.createSessionBead("worker", "worker")
 	env.setSessionMetadata(&session, map[string]string{
 		"state":               "active",

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -1036,12 +1036,32 @@ func ContainsProviderRateLimitScreen(content string) bool {
 		strings.Contains(content, "Stop")
 }
 
+// spendLimitModalWindowLines bounds how many consecutive lines the Claude
+// spend-limit modal's anchor tokens may span. The modal renders "Usage credit
+// balance", "Adjust monthly spend limit", and "Wait for limit to reset" on
+// adjacent lines inside one bordered box; a small window tolerates a border or
+// blank line between them while still rejecting the same tokens scattered across
+// unrelated scrollback.
+const spendLimitModalWindowLines = 6
+
+// containsClaudeSpendLimitModal reports whether pane content shows Claude's
+// spend-limit modal (which is a rate-limit, not a crash).
+//
+// It requires the modal's three anchor tokens to co-occur within one on-screen
+// block rather than matching each token anywhere in the buffer. Whole-buffer
+// strings.Contains for each token independently lets the tokens land on
+// unrelated scrollback lines — e.g. a pane displaying billing notes or these
+// very test fixtures — and misclassify a genuinely crashed session as
+// rate-limited. That suppresses the session's SessionCrashed event and, because
+// the rate-limit quarantine re-detects the same scrollback every reconcile
+// cycle, masks the real crash indefinitely with no self-heal. "Wait for limit
+// to reset" is always present in the real modal and is the reliable anchor, so
+// the loose "Resets " arm is dropped as too weak.
 func containsClaudeSpendLimitModal(content string) bool {
-	hasLimitAction := strings.Contains(content, "Adjust monthly spend limit")
-	hasCreditBalance := strings.Contains(content, "Usage credit balance")
-	hasResetOption := strings.Contains(content, "Wait for limit to reset") ||
-		strings.Contains(content, "Resets ")
-	return hasLimitAction && hasCreditBalance && hasResetOption
+	return linesContainAllWithin(content, spendLimitModalWindowLines,
+		"Usage credit balance",
+		"Adjust monthly spend limit",
+		"Wait for limit to reset")
 }
 
 // ProviderTerminalErrorReason classifies high-confidence provider errors that
@@ -1076,6 +1096,33 @@ func lineContainsAll(content string, subs ...string) bool {
 		all := true
 		for _, sub := range subs {
 			if !strings.Contains(line, sub) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+// linesContainAllWithin reports whether some window of at most maxSpan
+// consecutive lines in content jointly contains every substring in subs. Like
+// lineContainsAll it bounds a loose multi-token match to co-occurring text, but
+// across a small block of adjacent lines (e.g. a modal box) rather than a single
+// line, so the tokens cannot smear across unrelated scrollback lines and wrongly
+// classify the pane.
+func linesContainAllWithin(content string, maxSpan int, subs ...string) bool {
+	if maxSpan < 1 || len(subs) == 0 {
+		return false
+	}
+	lines := strings.Split(content, "\n")
+	for start := range lines {
+		window := strings.Join(lines[start:min(start+maxSpan, len(lines))], "\n")
+		all := true
+		for _, sub := range subs {
+			if !strings.Contains(window, sub) {
 				all = false
 				break
 			}

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -1028,9 +1028,20 @@ func ContainsProviderRateLimitScreen(content string) bool {
 		strings.Contains(content, "/rate-limit-options") {
 		return true
 	}
+	if containsClaudeSpendLimitModal(content) {
+		return true
+	}
 	return strings.Contains(strings.ToLower(content), "rate limit") &&
 		strings.Contains(content, "Keep trying") &&
 		strings.Contains(content, "Stop")
+}
+
+func containsClaudeSpendLimitModal(content string) bool {
+	hasLimitAction := strings.Contains(content, "Adjust monthly spend limit")
+	hasCreditBalance := strings.Contains(content, "Usage credit balance")
+	hasResetOption := strings.Contains(content, "Wait for limit to reset") ||
+		strings.Contains(content, "Resets ")
+	return hasLimitAction && hasCreditBalance && hasResetOption
 }
 
 // ProviderTerminalErrorReason classifies high-confidence provider errors that

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -1017,6 +1017,38 @@ func TestContainsRateLimitDialog(t *testing.T) {
 	}
 }
 
+// spendLimitTokensScatteredScrollback simulates a pane that merely happens to
+// contain the spend-limit modal's three anchor tokens on unrelated, far-apart
+// scrollback lines (e.g. a session paging through these test fixtures). All
+// three tokens are present, but no small window of consecutive lines holds them
+// together, so this must NOT be classified as a rate-limit screen — otherwise a
+// crashed session viewing this content would be wrongly quarantined and its
+// crash masked.
+const spendLimitTokensScatteredScrollback = `$ less internal/runtime/dialog_test.go
+comment: the fixture mentions Usage credit balance in a doc comment here
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+comment: another fixture names Adjust monthly spend limit as a menu option
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+scrollback line unrelated to any modal
+comment: and a third names Wait for limit to reset as the confirm arm`
+
 func TestContainsProviderRateLimitScreen(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -1030,6 +1062,7 @@ func TestContainsProviderRateLimitScreen(t *testing.T) {
 		{name: "provider menu shape", content: "Rate limit reached\n1. Keep trying\n2. Stop", want: true},
 		{name: "claude spend limit modal", content: "What do you want to do?\nUsage credit balance: $573.37\n❯ Adjust monthly spend limit: $1503.19\n  Wait for limit to reset      Resets Jul 12 at 11pm (America/Los_Angeles)\nEnter to confirm · Esc to cancel", want: true},
 		{name: "spend limit words without reset option", content: "notes mention Adjust monthly spend limit and Usage credit balance while documenting billing", want: false},
+		{name: "spend limit tokens scattered across unrelated scrollback", content: spendLimitTokensScatteredScrollback, want: false},
 		{name: "generic crash output", content: "worker failed while parsing rate limit config", want: false},
 		{name: "generic lower-case mention", content: "rate limit exceeded", want: false},
 		{name: "normal output", content: "Hello world", want: false},

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -1028,6 +1028,8 @@ func TestContainsProviderRateLimitScreen(t *testing.T) {
 		{name: "claude hit limit", content: "You've hit your limit, Pro plan", want: true},
 		{name: "claude rate limit options", content: "/rate-limit-options", want: true},
 		{name: "provider menu shape", content: "Rate limit reached\n1. Keep trying\n2. Stop", want: true},
+		{name: "claude spend limit modal", content: "What do you want to do?\nUsage credit balance: $573.37\n❯ Adjust monthly spend limit: $1503.19\n  Wait for limit to reset      Resets Jul 12 at 11pm (America/Los_Angeles)\nEnter to confirm · Esc to cancel", want: true},
+		{name: "spend limit words without reset option", content: "notes mention Adjust monthly spend limit and Usage credit balance while documenting billing", want: false},
 		{name: "generic crash output", content: "worker failed while parsing rate limit config", want: false},
 		{name: "generic lower-case mention", content: "rate limit exceeded", want: false},
 		{name: "normal output", content: "Hello world", want: false},


### PR DESCRIPTION
## Summary
- classify Claude's interactive spend-limit modal as a high-confidence provider rate-limit screen
- keep the match narrow by requiring the spend-limit action, usage-credit balance, and reset affordance together
- add reconciler coverage proving this scrollback is quarantined as `rate_limit` before zombie healing/crash telemetry

## Root cause
The reconciler already suppresses generic `session.crashed` telemetry when zombie scrollback is recognized as a provider rate-limit screen. Claude's spend-limit modal (`Adjust monthly spend limit` / `Usage credit balance` / `Wait for limit to reset`) was not in that classifier, so a provider billing ceiling could wedge sessions and surface as fleet-wide `zombie process` crashes instead of rate-limit quarantine.

Refs #4093 (this lands scoped-fix #1; suggested-fixes #2 auto-dismiss and #3 consolidated ops alert tracked separately).

## Validation
- `go test ./internal/runtime -run 'TestContainsProviderRateLimitScreen|TestProviderTerminalErrorReason'`
- `CGO_CPPFLAGS="-I$(brew --prefix icu4c@78)/include" CGO_LDFLAGS="-L$(brew --prefix icu4c@78)/lib" go test ./cmd/gc -run 'TestReconcileSessionBeads_(RateLimitScreenQuarantinesBeforeHeal|SpendLimitModalQuarantinesBeforeHeal|RateLimitScreenBeyondCrashCaptureSuppressesTelemetry)|TestCheckStability_RateLimitScreen_DoesNotCountAsCrash'`
- `CGO_CPPFLAGS="-I$(brew --prefix icu4c@78)/include" CGO_LDFLAGS="-L$(brew --prefix icu4c@78)/lib" go test ./internal/runtime -count=1`
- `CGO_CPPFLAGS="-I$(brew --prefix icu4c@78)/include" CGO_LDFLAGS="-L$(brew --prefix icu4c@78)/lib" go test ./cmd/gc -run 'TestReconcileSessionBeads_(RateLimitScreenQuarantinesBeforeHeal|SpendLimitModalQuarantinesBeforeHeal|RateLimitScreenBeyondCrashCaptureSuppressesTelemetry)|TestCheckStability_RateLimitScreen_DoesNotCountAsCrash' -count=1`