### PR TITLE
fix(bd): scope dog agent work_dir off the city root (#4077)

### DIFF
--- a/examples/bd/dolt/agent_workdir_test.go
+++ b/examples/bd/dolt/agent_workdir_test.go
@@ -1,0 +1,41 @@
+package dolt_test
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/workdir"
+)
+
+// TestDogAgentWorkDirDoesNotResolveToCityRoot is a regression guard for
+// gascity#4077: the bundled dog agent is scope=city with no configured
+// rig, so an omitted work_dir/dir falls back to workdir.ResolveDirPath's
+// dir=="" case, which returns the city root itself. Every per-run artifact
+// the dog session creates relative to its cwd then leaks into the
+// operator's city root instead of a scratch/worktree location.
+func TestDogAgentWorkDirDoesNotResolveToCityRoot(t *testing.T) {
+	agents, err := config.DiscoverPackAgents(fsys.OSFS{}, repoRoot(t), "dolt", nil)
+	if err != nil {
+		t.Fatalf("DiscoverPackAgents() error = %v", err)
+	}
+
+	var dog *config.Agent
+	for i := range agents {
+		if agents[i].Name == "dog" {
+			dog = &agents[i]
+		}
+	}
+	if dog == nil {
+		t.Fatalf("dog agent not found under %s/agents", repoRoot(t))
+	}
+	if dog.Scope != "city" {
+		t.Fatalf("dog agent scope = %q, want %q (test assumes the city-scoped, rig-less case)", dog.Scope, "city")
+	}
+
+	cityPath := t.TempDir()
+	got := workdir.ResolveWorkDirPath(cityPath, "city", "dog", *dog, nil)
+	if got == cityPath {
+		t.Fatalf("dog agent work_dir resolved to the city root %q; want a scratch subdirectory", cityPath)
+	}
+}

--- a/examples/bd/dolt/agents/dog/agent.toml
+++ b/examples/bd/dolt/agents/dog/agent.toml
@@ -1,4 +1,5 @@
 scope = "city"
+work_dir = ".gc/agents/{{.AgentBase}}"
 nudge = "Check your hook for Dolt maintenance work."
 idle_timeout = "2h"
 min_active_sessions = 0


### PR DESCRIPTION
## What

Give the bundled `dog` agent (examples/bd/dolt, scope=city, no explicit
`dir`/`work_dir`) an explicit `work_dir = ".gc/agents/{{.AgentBase}}"`,
matching the existing pool-worker convention.

## Why

Without a configured rig, `dog` fell through
`ResolveWorkDirPathStrict`'s rig-less default and resolved its session
cwd to the city root itself — leaking per-run artifacts there on every
dog run instead of a scratch directory.

## Testing

Added `TestDogAgentWorkDirDoesNotResolveToCityRoot`, a regression guard
that discovers the `dog` agent from the pack, asserts it is still
`scope=city` (the case this bug depends on), and asserts
`workdir.ResolveWorkDirPath` no longer returns the city root for it.

Closes #4077.