### PR TITLE
fix(gc): beads list/show honor remote flags (--city-url/--context)

### DIFF
--- a/cmd/gc/bead_format.go
+++ b/cmd/gc/bead_format.go
@@ -10,9 +10,11 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// parseBeadFormat extracts --format/--json flags from raw args (needed because
-// DisableFlagParsing is true). Returns the format ("text", "json", or "toon")
-// and the remaining positional args with the flag removed.
+// parseBeadFormat extracts --format/--json flags from raw args. It backs the
+// fake `bd` binary used by the testscript harness (bd_testscript_test.go); the
+// gc `beads` commands themselves parse these flags through cobra. Returns the
+// format ("text", "json", or "toon") and the remaining positional args with the
+// flag removed.
 func parseBeadFormat(args []string) (string, []string) {
 	format := "text"
 	var rest []string
@@ -39,8 +41,10 @@ type beadFilters struct {
 	all    bool
 }
 
-// parseBeadFilters extracts --label=X and --status=X from args, returning
-// the filters and the remaining args with those flags removed.
+// parseBeadFilters extracts --label, --status, and --all from args, returning
+// the filters and the remaining args with those flags removed. Like
+// parseBeadFormat it backs the testscript fake-bd harness; the gc `beads list`
+// command parses these flags through cobra.
 func parseBeadFilters(args []string) (beadFilters, []string) {
 	var f beadFilters
 	var rest []string

--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -40,6 +40,10 @@ fallback to direct bd reads.`,
 }
 
 func newBeadsListCmd(stdout, stderr io.Writer) *cobra.Command {
+	var (
+		label, status, format string
+		all                   bool
+	)
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List beads (API-routed with bd fallback)",
@@ -47,26 +51,30 @@ func newBeadsListCmd(stdout, stderr io.Writer) *cobra.Command {
 the controller is alive and falling back to a direct multi-store read
 otherwise.
 
-Supports --label, --status, --all, and --format flags. --json is an
-alias for --format=json. API-path JSON output includes _cache_age_s;
-fallback-path JSON omits it.`,
+Supports --label, --status, --all, and --format. --format=json emits
+JSON (API-path JSON includes _cache_age_s; fallback-path JSON omits
+it). The bare --json flag is reserved by the CLI's JSON-contract layer
+and is not wired for this command; use --format=json.`,
 		Example: `  gc beads list
   gc beads list --label ready-to-build
-  gc beads list --status open --json
-  gc beads list --format=toon`,
-		DisableFlagParsing: true,
-		Args:               cobra.ArbitraryArgs,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdBeadsList(args, stdout, stderr) != 0 {
+  gc beads list --status open --format=json`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdBeadsList(format, beadFilters{label: label, status: status, all: all}, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&label, "label", "", "filter to beads carrying this label")
+	cmd.Flags().StringVar(&status, "status", "", "filter to beads in this status")
+	cmd.Flags().BoolVar(&all, "all", false, "include closed beads (default: open only)")
+	cmd.Flags().StringVar(&format, "format", "text", "output format: text or json")
 	return cmd
 }
 
 func newBeadsShowCmd(stdout, stderr io.Writer) *cobra.Command {
+	var format string
 	cmd := &cobra.Command{
 		Use:   "show <bead-id>",
 		Short: "Show a single bead (API-routed with bd fallback)",
@@ -74,28 +82,38 @@ func newBeadsShowCmd(stdout, stderr io.Writer) *cobra.Command {
 controller is alive and falling back to a direct multi-store lookup
 otherwise.
 
-Supports --format and --json. API-path JSON output includes
-_cache_age_s; fallback-path JSON omits it.`,
+Supports --format. --format=json emits JSON (API-path JSON includes
+_cache_age_s; fallback-path JSON omits it). The bare --json flag is
+reserved by the CLI's JSON-contract layer and is not wired for this
+command; use --format=json.`,
 		Example: `  gc beads show ga-abc
-  gc beads show ga-abc --json`,
-		DisableFlagParsing: true,
-		Args:               cobra.ArbitraryArgs,
+  gc beads show ga-abc --format=json`,
+		// MaximumNArgs(1), not ExactArgs(1): a missing id must reach the internal
+		// guard AFTER resolveReadTarget (so a resolve error still takes
+		// precedence), which the routeReadCmdWithHooks ordering in cmdBeadsShow
+		// depends on. ExactArgs would reject the zero-arg case in cobra, before
+		// the resolver, inverting that documented ordering.
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdBeadsShow(args, stdout, stderr) != 0 {
+			id := ""
+			if len(args) > 0 {
+				id = args[0]
+			}
+			if cmdBeadsShow(id, format, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&format, "format", "text", "output format: text or json")
 	return cmd
 }
 
-// cmdBeadsList is the CLI entry point for "gc beads list". Routes through
-// the supervisor API when a controller is up and falls back to direct bd
-// multi-store reads otherwise.
-func cmdBeadsList(args []string, stdout, stderr io.Writer) int {
-	format, rest := parseBeadFormat(args)
-	filters, _ := parseBeadFilters(rest)
+// cmdBeadsList is the CLI entry point for "gc beads list". The output format
+// and filters are parsed by cobra (see newBeadsListCmd) and passed in. Routes
+// through the supervisor API when a controller is up and falls back to a direct
+// multi-store read otherwise.
+func cmdBeadsList(format string, filters beadFilters, stdout, stderr io.Writer) int {
 	return routeReadCmd("beads list", stderr, beadsListAPIClient, func(cityPath string, c *api.Client, nilReason string) int {
 		return routeBeadsList(cityPath, c, nilReason, format, filters, stdout, stderr)
 	})
@@ -176,28 +194,27 @@ func doBeadsListFallback(cityPath, format string, filters beadFilters, stdout, s
 	return 0
 }
 
-// cmdBeadsShow is the CLI entry point for "gc beads show". Routes through
-// the supervisor API and falls back to a direct store lookup.
+// cmdBeadsShow is the CLI entry point for "gc beads show". The bead id and
+// output format are parsed by cobra (see newBeadsShowCmd) and passed in. Routes
+// through the supervisor API and falls back to a direct store lookup.
 //
 // It uses routeReadCmdWithHooks with a guard hook because the missing-id guard
 // must fire AFTER resolveReadTarget (so a resolve error still takes precedence)
 // but BEFORE the local beadsShowAPIClient seam (whose apiClient() call has
 // observable side effects — the classifyGCNoAPI stderr warning on a malformed
 // GC_NO_API, plus a controller-liveness probe and config.Load). The hook runs in
-// exactly that slot. parseBeadFormat is pure, so hoisting it above the call is
-// side-effect-free.
-func cmdBeadsShow(args []string, stdout, stderr io.Writer) int {
-	format, rest := parseBeadFormat(args)
+// exactly that slot.
+func cmdBeadsShow(id, format string, stdout, stderr io.Writer) int {
 	return routeReadCmdWithHooks("beads show", stderr, readCmdHooks{
 		guard: func() (int, bool) {
-			if len(rest) == 0 {
+			if id == "" {
 				fmt.Fprintln(stderr, "gc beads show: missing bead id") //nolint:errcheck // best-effort stderr
 				return 1, true
 			}
 			return 0, false
 		},
 	}, beadsShowAPIClient, func(cityPath string, c *api.Client, nilReason string) int {
-		return routeBeadsShow(cityPath, c, nilReason, rest[0], format, stdout, stderr)
+		return routeBeadsShow(cityPath, c, nilReason, id, format, stdout, stderr)
 	})
 }
 

--- a/cmd/gc/cmd_beads_test.go
+++ b/cmd/gc/cmd_beads_test.go
@@ -431,7 +431,7 @@ func TestCmdBeadsShow_MissingID_DoesNotProbeAPIClient(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdBeadsShow(nil, &stdout, &stderr) // no bead id
+	code := cmdBeadsShow("", "text", &stdout, &stderr) // no bead id
 
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1; stderr=%q", code, stderr.String())
@@ -590,5 +590,173 @@ func TestDoBeadsHealth_BdSkip(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Beads provider: healthy") {
 		t.Errorf("GC_DOLT=skip should pass: %s", stdout.String())
+	}
+}
+
+// The tests below drive the REAL cobra entry point via run() with argv flags,
+// exercising the flag-PARSING path. The earlier remote test
+// (TestCmdBeadsList_RemoteRoutesToServerNoFallback) sets contextFlag/cityURLFlag
+// package vars directly, so it never proved cobra parses --city-url on a beads
+// command — which it did NOT, because `beads list`/`show` set
+// DisableFlagParsing: the persistent remote flags were silently dropped and the
+// command fell back to a LOCAL read. These lock the fix (real cobra flags): the
+// persistent remote flags now reach the resolver AND the bead-specific flags
+// still parse.
+
+// TestRun_BeadsListCityURLFlagRoutesRemote proves `gc --city-url <loopback>
+// --city-name mc beads list --status open --label X --all` parses the persistent
+// --city-url (routing REMOTE, not the silent local fallback of the
+// DisableFlagParsing era) AND parses every bead filter flag, each of which must
+// land on the request query. Asserting all three (label/status/all) — not just
+// one — catches a wiring drop or a label<->status swap in the RunE beadFilters
+// literal that a single-flag assertion would miss.
+func TestRun_BeadsListCityURLFlagRoutesRemote(t *testing.T) {
+	clearGCEnv(t)
+
+	var gotPath, gotStatus, gotLabel, gotAll string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotStatus = r.URL.Query().Get("status")
+		gotLabel = r.URL.Query().Get("label")
+		gotAll = r.URL.Query().Get("all")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	prev := beadsListAPIClient
+	beadsListAPIClient = func(string) (*api.Client, string) {
+		t.Fatal("local beadsListAPIClient must not run under --city-url — the flag was unparsed and it fell back to local")
+		return nil, ""
+	}
+	t.Cleanup(func() { beadsListAPIClient = prev })
+
+	var out, errb bytes.Buffer
+	code := run([]string{
+		"--city-url", srv.URL, "--city-name", "mc", "beads", "list",
+		"--status", "open", "--label", "ready-to-build", "--all",
+	}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr = %q", code, errb.String())
+	}
+	if !strings.Contains(gotPath, "/v0/city/mc/beads") {
+		t.Fatalf("remote path = %q, want it to include /v0/city/mc/beads", gotPath)
+	}
+	if gotStatus != "open" {
+		t.Fatalf("--status did not reach the request query: status = %q, want open", gotStatus)
+	}
+	if gotLabel != "ready-to-build" {
+		t.Fatalf("--label did not reach the request query: label = %q, want ready-to-build", gotLabel)
+	}
+	if gotAll != "true" {
+		t.Fatalf("--all did not reach the request query: all = %q, want true", gotAll)
+	}
+}
+
+// TestRun_BeadsShowCityURLFlagRoutesRemote is the show-side sibling: the bead-id
+// positional and the persistent --city-url both parse, routing the single-bead
+// read to the remote city (never the local seam).
+func TestRun_BeadsShowCityURLFlagRoutesRemote(t *testing.T) {
+	clearGCEnv(t)
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	prev := beadsShowAPIClient
+	beadsShowAPIClient = func(string) (*api.Client, string) {
+		t.Fatal("local beadsShowAPIClient must not run under --city-url")
+		return nil, ""
+	}
+	t.Cleanup(func() { beadsShowAPIClient = prev })
+
+	var out, errb bytes.Buffer
+	code := run([]string{"--city-url", srv.URL, "--city-name", "mc", "beads", "show", "ga-abc"}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr = %q", code, errb.String())
+	}
+	if !strings.Contains(gotPath, "ga-abc") {
+		t.Fatalf("remote path = %q, want it to include the bead id ga-abc", gotPath)
+	}
+}
+
+// TestRun_BeadsListRejectsUnknownFlag locks the fail-loud upgrade: with real
+// cobra parsing an unknown flag is a hard error routed through the root
+// FlagErrorFunc (the DisableFlagParsing era silently swallowed it).
+func TestRun_BeadsListRejectsUnknownFlag(t *testing.T) {
+	clearGCEnv(t)
+	var out, errb bytes.Buffer
+	code := run([]string{"beads", "list", "--no-such-flag"}, &out, &errb)
+	if code == 0 {
+		t.Fatalf("exit = 0, want non-zero for an unknown flag; stderr = %q", errb.String())
+	}
+	if !strings.Contains(errb.String(), "unknown flag") {
+		t.Fatalf("stderr = %q, want it to mention 'unknown flag'", errb.String())
+	}
+}
+
+// TestRun_BeadsListHelpNotSwallowed locks that `gc beads list --help` now prints
+// help. DisableFlagParsing used to swallow --help (and `beads show --help` even
+// tried to resolve a bead literally named "--help").
+func TestRun_BeadsListHelpNotSwallowed(t *testing.T) {
+	clearGCEnv(t)
+	var out, errb bytes.Buffer
+	code := run([]string{"beads", "list", "--help"}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("--help exit = %d, want 0; stderr = %q", code, errb.String())
+	}
+	if combined := out.String() + errb.String(); !strings.Contains(combined, "--status") {
+		t.Fatalf("help output missing the --status flag listing; got %q", combined)
+	}
+}
+
+// TestRun_BeadsShowMissingIDReachesGuard pins Args:MaximumNArgs(1) (not
+// ExactArgs(1)) together with the resolve-before-guard ordering: with a RESOLVED
+// remote target, a zero-arg `beads show` must reach the internal missing-id guard
+// (printing "missing bead id") and NEVER dispatch to the server. ExactArgs(1)
+// would make cobra reject the zero-arg case before the resolver, changing the
+// message and inverting the documented ordering — this test would then fail.
+func TestRun_BeadsShowMissingIDReachesGuard(t *testing.T) {
+	clearGCEnv(t)
+
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	code := run([]string{"--city-url", srv.URL, "--city-name", "mc", "beads", "show"}, &out, &errb)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (missing-id guard); stderr = %q", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "missing bead id") {
+		t.Fatalf("stderr = %q, want the missing-id guard message", errb.String())
+	}
+	if hit {
+		t.Fatal("server was dispatched despite a missing bead id — guard did not fire before dispatch")
+	}
+}
+
+// TestRun_BeadsShowRejectsExtraArgs locks that a second positional is a loud
+// error (MaximumNArgs(1)); the DisableFlagParsing era silently ignored extras
+// and showed the first.
+func TestRun_BeadsShowRejectsExtraArgs(t *testing.T) {
+	clearGCEnv(t)
+	var out, errb bytes.Buffer
+	code := run([]string{"beads", "show", "ga-abc", "ga-def"}, &out, &errb)
+	if code == 0 {
+		t.Fatalf("exit = 0, want non-zero for two positionals; stderr = %q", errb.String())
+	}
+	if !strings.Contains(errb.String(), "accepts at most 1 arg") {
+		t.Fatalf("stderr = %q, want an at-most-1-arg error", errb.String())
 	}
 }

--- a/cmd/gc/remote_client_test.go
+++ b/cmd/gc/remote_client_test.go
@@ -98,12 +98,53 @@ func TestCmdBeadsList_RemoteRoutesToServerNoFallback(t *testing.T) {
 
 	out.Reset()
 	errb.Reset()
-	_ = cmdBeadsList(nil, &out, &errb)
+	_ = cmdBeadsList("text", beadFilters{}, &out, &errb)
 
 	if !strings.Contains(gotPath, "/v0/city/mc/beads") {
 		t.Errorf("remote server path = %q, want it to include /v0/city/mc/beads", gotPath)
 	}
 	if gotReq != "true" {
 		t.Errorf("X-GC-Request = %q, want true", gotReq)
+	}
+}
+
+// TestRun_BeadsListContextFlagRoutesRemote proves the OTHER persistent remote
+// flag the DisableFlagParsing bug dropped — --context — now parses on a beads
+// command and routes remote. Unlike TestCmdBeadsList_RemoteRoutesToServerNoFallback
+// (which sets contextFlag directly, bypassing cobra), this drives --context
+// through run()'s real argv parsing — the path the fix repairs. --context takes
+// a different resolver branch (contexts.toml → targetFromContext) than --city-url,
+// so it needs its own end-to-end coverage.
+func TestRun_BeadsListContextFlagRoutesRemote(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	var gotPath string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	var seed, seedErr bytes.Buffer
+	if code := doContextAdd(clientcontext.Context{Name: "prod", URL: srv.URL, City: "mc", InsecureSkipVerify: true}, &seed, &seedErr); code != 0 {
+		t.Fatalf("seed context: %q", seedErr.String())
+	}
+
+	prev := beadsListAPIClient
+	beadsListAPIClient = func(string) (*api.Client, string) {
+		t.Fatal("local beadsListAPIClient must not run under --context")
+		return nil, ""
+	}
+	t.Cleanup(func() { beadsListAPIClient = prev })
+
+	var out, errb bytes.Buffer
+	code := run([]string{"--context", "prod", "beads", "list"}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr = %q", code, errb.String())
+	}
+	if !strings.Contains(gotPath, "/v0/city/mc/beads") {
+		t.Fatalf("remote path = %q, want /v0/city/mc/beads", gotPath)
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -389,12 +389,13 @@ List beads across all rigs, routed through the supervisor API when
 the controller is alive and falling back to a direct multi-store read
 otherwise.
 
-Supports --label, --status, --all, and --format flags. --json is an
-alias for --format=json. API-path JSON output includes _cache_age_s;
-fallback-path JSON omits it.
+Supports --label, --status, --all, and --format. --format=json emits
+JSON (API-path JSON includes _cache_age_s; fallback-path JSON omits
+it). The bare --json flag is reserved by the CLI's JSON-contract layer
+and is not wired for this command; use --format=json.
 
 ```
-gc beads list
+gc beads list [flags]
 ```
 
 **Example:**
@@ -402,9 +403,15 @@ gc beads list
 ```
 gc beads list
 gc beads list --label ready-to-build
-gc beads list --status open --json
-gc beads list --format=toon
+gc beads list --status open --format=json
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all` | bool |  | include closed beads (default: open only) |
+| `--format` | string | `text` | output format: text or json |
+| `--label` | string |  | filter to beads carrying this label |
+| `--status` | string |  | filter to beads in this status |
 
 ## gc beads show
 
@@ -412,19 +419,25 @@ Show one bead by ID, routed through the supervisor API when the
 controller is alive and falling back to a direct multi-store lookup
 otherwise.
 
-Supports --format and --json. API-path JSON output includes
-_cache_age_s; fallback-path JSON omits it.
+Supports --format. --format=json emits JSON (API-path JSON includes
+_cache_age_s; fallback-path JSON omits it). The bare --json flag is
+reserved by the CLI's JSON-contract layer and is not wired for this
+command; use --format=json.
 
 ```
-gc beads show <bead-id>
+gc beads show <bead-id> [flags]
 ```
 
 **Example:**
 
 ```
 gc beads show ga-abc
-gc beads show ga-abc --json
+gc beads show ga-abc --format=json
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | string | `text` | output format: text or json |
 
 ## gc build-image
 


### PR DESCRIPTION
## What

Makes `gc beads list` and `gc beads show` honor the remote-city selector flags (`--city-url` / `--context` / `--city-name`). **Stacked on #4085** (`feat/cli-unification`), which introduced the remote-read control plane these flags drive.

## The bug

Both commands set `DisableFlagParsing: true` to hand-parse their `--label`/`--status`/`--all`/`--format` flags. That also stopped cobra from parsing the **root persistent** remote selectors, so:

```
gc --city-url https://host --city-name c beads list   # silently read LOCAL
```

fell back to a local multi-store read (`route=fallback reason=controller-down`) instead of routing to the remote city — a remote flag that silently does the wrong thing.

## Why not `FParseErrWhitelist{UnknownFlags:true}`

Empirically rejected: it parses `--city-url` but destroys the hand-rolled flags — space-form `--label ready` loses both tokens, and the boolean `--json` swallows the positional bead id (residual args come back empty).

## The fix

Convert the bead filter/format flags to real cobra flags and drop `DisableFlagParsing`. Cobra then parses everything unambiguously; the remote selectors reach the resolver. `parseBeadFormat`/`parseBeadFilters` are retained (now only the testscript fake-`bd` harness uses them).

Honesty cleanups surfaced by review:

- **Removed `--json`** from these two commands. The CLI's JSON-contract front door intercepts `--json` *before* cobra and returns `json_unsupported` — these commands have no registered result schema, and can't cleanly get one, since their JSON shape is lane-dependent (`_cache_age_s` on the API path, absent on the fallback path). `--json` never worked here; `--format=json` does. Pre-existing — the flag conversion would only have advertised the dead flag more loudly.
- **Removed `toon`** from `--format` advertising (no code path renders TOON).
- Unknown flags now **error loudly** (were silently ignored); `beads list --help` now **works** (was swallowed).

## Tests

New entry-point tests drive `run()` with real argv flags — the existing remote tests set the flag package vars directly, bypassing cobra's parser, which is exactly why the bug slipped through. Coverage: `--city-url` and `--context` routing (distinct resolver branches), `--label`/`--status`/`--all` reaching the request query, unknown-flag/`--help` behavior, and the `show` missing-id-reaches-guard (pins `MaximumNArgs(1)` + the resolve-before-guard ordering) and extra-args guards.

Verified live against a running controller: `gc --city-url http://127.0.0.1:8372 --city-name maintainer-city beads list --status open` now shows `route=api` and returns real remote beads.

## Follow-up (not in this PR)

Making `--json` actually work for `beads list/show` needs JSON-contract result schemas, which first requires resolving the lane-dependent `_cache_age_s` envelope divergence between the API and fallback paths.

## Review

Fable design + Fable red-team (8 findings, all addressed or dispositioned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
