### PR TITLE
docs: use Homebrew core install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ heavy write load.
 Install from Homebrew:
 
 ```bash
-brew install gastownhall/gascity/gascity
+brew install gascity
 gc version
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@
 | **Homebrew tap** (`gastownhall/gascity`) | `release.yml` writes an asset-based formula after archives upload | Yes |
 | **Homebrew core** (`Homebrew/homebrew-core`) | BrewTestBot autobump, once listed | Yes (~3h delay) |
 
-The homebrew-core submission is [in progress](https://github.com/Homebrew/homebrew-core). Until it lands and is added to the autobump list, users install via `brew install gastownhall/gascity/gascity`.
+The homebrew-core submission is [in progress](https://github.com/Homebrew/homebrew-core). Until it lands and is added to the autobump list, users install via `brew install gascity`.
 
 ## How to Release
 
@@ -97,7 +97,7 @@ The release workflow automatically overwrites `Formula/gascity.rb` in the `gasto
 The tap formula installs prebuilt release assets, so users do not need Go or a source build:
 
 ```bash
-brew install gastownhall/gascity/gascity
+brew install gascity
 ```
 
 The intended long-term user-facing Homebrew path is homebrew-core:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,7 +44,7 @@ The exact versions CI pins are in [`deps.env`](https://github.com/gastownhall/ga
 ## Homebrew (recommended)
 
 ```bash
-brew install gastownhall/gascity/gascity
+brew install gascity
 ```
 
 This taps the `gastownhall/gascity` formula, downloads the matching `gc`


### PR DESCRIPTION
## Summary

Updates the documented Homebrew install command from the tap-qualified formula to the normal Homebrew core formula:

- README quick-start install snippet now uses `brew install gascity`.
- Getting started installation guide now uses `brew install gascity` for the recommended Homebrew path.
- Release notes now describe `brew install gascity` as the user-facing install path while retaining the existing Homebrew tap/core distribution context.

## Testing

- `make check-docs`
- `git diff --check origin/main...HEAD`
- Secret-pattern scan across `origin/main...HEAD`

Note: the full pre-push hook test matrix was intentionally skipped on push because this branch only changes docs copy.