### PR TITLE
Clear reset_committed_at after successful session start

### DIFF
--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -267,6 +267,7 @@ func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 		"started_provision_hash":     input.ProvisionHash,
 		"started_launch_hash":        input.LaunchHash,
 		"continuation_reset_pending": "",
+		ResetCommittedAtKey:          "",
 	}
 	if input.CoreBreakdown != "" {
 		patch["core_hash_breakdown"] = input.CoreBreakdown

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -525,6 +525,7 @@ func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
 		"started_provision_hash":     "provision-hash",
 		"started_launch_hash":        "launch-hash",
 		"continuation_reset_pending": "",
+		ResetCommittedAtKey:          "",
 		"core_hash_breakdown":        `{"command":"core-hash"}`,
 		"state":                      string(StateActive),
 		"state_reason":               "creation_complete",
@@ -535,6 +536,27 @@ func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)
+	}
+}
+
+func TestCommitStartedPatchClearsResetCommittedAt(t *testing.T) {
+	committedAt := "2026-07-08T20:09:10Z"
+	patch := CommitStartedPatch(CommitStartedPatchInput{
+		CoreHash:     "core-hash",
+		ConfirmState: true,
+		Now:          time.Date(2026, 7, 8, 20, 10, 30, 0, time.UTC),
+	})
+
+	if got, ok := patch[ResetCommittedAtKey]; !ok || got != "" {
+		t.Fatalf("successful start must clear %s after prior reset %s; got present=%v value=%q", ResetCommittedAtKey, committedAt, ok, got)
+	}
+
+	merged := patch.Apply(MetadataPatch{ResetCommittedAtKey: committedAt, "continuation_reset_pending": "true"})
+	if merged[ResetCommittedAtKey] != "" {
+		t.Fatalf("merged metadata kept stale %s = %q", ResetCommittedAtKey, merged[ResetCommittedAtKey])
+	}
+	if merged["continuation_reset_pending"] != "" {
+		t.Fatalf("merged metadata kept continuation_reset_pending = %q", merged["continuation_reset_pending"])
 	}
 }
 
@@ -597,6 +619,7 @@ func TestCommitStartedPatchCanPersistHashesWithoutRestampingState(t *testing.T) 
 		"started_provision_hash":     "provision-hash",
 		"started_launch_hash":        "launch-hash",
 		"continuation_reset_pending": "",
+		ResetCommittedAtKey:          "",
 		"sleep_reason":               "",
 	}
 	if !reflect.DeepEqual(patch, want) {


### PR DESCRIPTION
## Summary
- clear `reset_committed_at` in `CommitStartedPatch` when a runtime successfully starts
- add regression coverage that a successful start clears both `continuation_reset_pending` and the durable reset timestamp

## Why
A reset handoff stamps `reset_committed_at`, but the successful-start commit only cleared `continuation_reset_pending`. Live `gt` sessions then kept stale reset timestamps after recovery (for example `mayor` was active with pending cleared while `reset_committed_at` still pointed at the earlier handoff). The detector gates on both fields, so this is mostly inert for decisioning, but it leaves alert-hostile bookkeeping and makes reset backlog investigations look older/noisier than the actual in-flight reset.

This does not claim to solve abrupt mayor reset insulation by itself; it removes the stale completion marker. The separate operational finding is that pinned/named sessions still need a graceful-reset/exemption path for collateral config-drift/restart resets.

## Tests
- `CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c@78/include" CGO_CXXFLAGS="-I/opt/homebrew/opt/icu4c@78/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c@78/lib" go test ./internal/session -count=1`
