### PR TITLE
fix(dispatch): pass ambient Dolt connection env into control-ready query

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2976,6 +2976,53 @@ func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
 	}
 }
 
+// TestWorkflowServeControlReadyQueryPassesThroughAmbientDoltPort guards
+// against gc-74rxa: the ready-query subprocess env is otherwise rebuilt via
+// mergeRuntimeEnv/controllerWorkQueryEnv, which can transiently resolve
+// without a Dolt port and silently drop GC_DOLT_PORT/BEADS_DOLT_SERVER_PORT,
+// causing `bd --sandbox` to fall back to port 0. The dispatcher process's own
+// environment already carries the correct connection coordinates it was
+// spawned with, so the query string must carry them through explicitly.
+func TestWorkflowServeControlReadyQueryPassesThroughAmbientDoltPort(t *testing.T) {
+	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GC_DOLT_PORT", "29620")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	_ = os.Unsetenv("BEADS_DOLT_SERVER_HOST")
+	_ = os.Unsetenv("BEADS_DOLT_SERVER_PORT")
+
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+
+	for _, want := range []string{
+		"GC_DOLT_HOST='127.0.0.1'",
+		"BEADS_DOLT_SERVER_HOST='127.0.0.1'",
+		"GC_DOLT_PORT='29620'",
+		"BEADS_DOLT_SERVER_PORT='29620'",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("workflowServeControlReadyQuery missing %q in %q", want, query)
+		}
+	}
+}
+
+// TestWorkflowServeControlReadyQueryOmitsDoltEnvWhenAmbientUnset ensures the
+// query stays clean (no bare "KEY=" assignments) when the current process has
+// no Dolt connection env at all (e.g. a doltlite-backed scope).
+func TestWorkflowServeControlReadyQueryOmitsDoltEnvWhenAmbientUnset(t *testing.T) {
+	for _, key := range []string{"GC_DOLT_HOST", "GC_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT"} {
+		t.Setenv(key, "")
+		_ = os.Unsetenv(key)
+	}
+
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+
+	for _, unwanted := range []string{"GC_DOLT_HOST=", "GC_DOLT_PORT=", "BEADS_DOLT_SERVER_HOST=", "BEADS_DOLT_SERVER_PORT="} {
+		if strings.Contains(query, unwanted) {
+			t.Fatalf("workflowServeControlReadyQuery should omit %q when ambient env is unset: %q", unwanted, query)
+		}
+	}
+}
+
 func TestWorkflowServeWorkQueryRecognizesCoreControlDispatcher(t *testing.T) {
 	query := workflowServeWorkQuery(config.Agent{Name: "core.control-dispatcher", Dir: "fixture"})
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -3053,6 +3053,60 @@ func unsetTestEnv(t *testing.T, keys ...string) {
 	}
 }
 
+// TestWorkflowServeControlReadyQueryDeliversAmbientDoltPortAtExecution is the
+// execution-level companion to TestWorkflowServeControlReadyQueryPassesThroughAmbientDoltPort:
+// cross-provider review of gc-74rxa noted that a pure string-assertion test
+// can pass while the real runtime path (shellWorkQueryWithEnv running the
+// query via `sh -c`, cmd/gc/cmd_hook.go:555) stays broken, since it never
+// crosses the process boundary. This test runs the built query through a
+// fake `bd` with an OUTER env that deliberately carries no Dolt connection
+// vars at all -- reproducing the exact failure mode (mergeRuntimeEnv having
+// stripped them) -- and asserts bd still receives the ambient port via the
+// query string's own shell-prefix assignment.
+func TestWorkflowServeControlReadyQueryDeliversAmbientDoltPortAtExecution(t *testing.T) {
+	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GC_DOLT_PORT", "29620")
+	unsetTestEnv(t, "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT")
+
+	query := workflowServeControlReadyQuery(
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
+		"gascity--control-dispatcher",
+	)
+
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "bd.log")
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
+set -eu
+printf 'GC_DOLT_PORT=%s BEADS_DOLT_SERVER_PORT=%s\n' "${GC_DOLT_PORT:-}" "${BEADS_DOLT_SERVER_PORT:-}" >> "$BD_LOG"
+printf '[]'
+`), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	// The outer env passed to shellWorkQueryWithEnv has no GC_DOLT_*/
+	// BEADS_DOLT_SERVER_* at all -- simulating mergeRuntimeEnv/
+	// controllerWorkQueryEnv having dropped them. Without the fix, bd would
+	// see an empty port here and resolve :0.
+	_, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
+		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"BD_LOG=" + logPath,
+		"GC_SESSION_NAME=gascity--control-dispatcher",
+		"GC_ALIAS=gascity/control-dispatcher",
+	})
+	if err != nil {
+		t.Fatalf("run workflow serve query: %v", err)
+	}
+
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("read bd log: %v", readErr)
+	}
+	if !strings.Contains(string(logData), "GC_DOLT_PORT=29620") || !strings.Contains(string(logData), "BEADS_DOLT_SERVER_PORT=29620") {
+		t.Fatalf("bd did not see the ambient Dolt port despite a stripped outer env; log:\n%s", string(logData))
+	}
+}
+
 func TestWorkflowServeWorkQueryRecognizesCoreControlDispatcher(t *testing.T) {
 	query := workflowServeWorkQuery(config.Agent{Name: "core.control-dispatcher", Dir: "fixture"})
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2986,10 +2986,7 @@ func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
 func TestWorkflowServeControlReadyQueryPassesThroughAmbientDoltPort(t *testing.T) {
 	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
 	t.Setenv("GC_DOLT_PORT", "29620")
-	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
-	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
-	_ = os.Unsetenv("BEADS_DOLT_SERVER_HOST")
-	_ = os.Unsetenv("BEADS_DOLT_SERVER_PORT")
+	unsetTestEnv(t, "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT")
 
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
 
@@ -3009,10 +3006,7 @@ func TestWorkflowServeControlReadyQueryPassesThroughAmbientDoltPort(t *testing.T
 // query stays clean (no bare "KEY=" assignments) when the current process has
 // no Dolt connection env at all (e.g. a doltlite-backed scope).
 func TestWorkflowServeControlReadyQueryOmitsDoltEnvWhenAmbientUnset(t *testing.T) {
-	for _, key := range []string{"GC_DOLT_HOST", "GC_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT"} {
-		t.Setenv(key, "")
-		_ = os.Unsetenv(key)
-	}
+	unsetTestEnv(t, "GC_DOLT_HOST", "GC_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT")
 
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
 
@@ -3020,6 +3014,42 @@ func TestWorkflowServeControlReadyQueryOmitsDoltEnvWhenAmbientUnset(t *testing.T
 		if strings.Contains(query, unwanted) {
 			t.Fatalf("workflowServeControlReadyQuery should omit %q when ambient env is unset: %q", unwanted, query)
 		}
+	}
+}
+
+// TestWorkflowServeControlReadyQueryDoesNotMixDoltNamespaces guards against a
+// correctness gap found in cross-provider review of gc-74rxa: host and port
+// must resolve as a matched pair from one env-var namespace, never as a host
+// from GC_DOLT_* combined with a port from BEADS_DOLT_SERVER_* (or vice
+// versa) -- a combination that may never have described the same server.
+// Here GC_DOLT_PORT is set (so the GC_DOLT_* namespace is "in use" for this
+// process) while only BEADS_DOLT_SERVER_HOST carries a value; the stale
+// BEADS host must NOT leak into the query paired with the GC port.
+func TestWorkflowServeControlReadyQueryDoesNotMixDoltNamespaces(t *testing.T) {
+	unsetTestEnv(t, "GC_DOLT_HOST")
+	t.Setenv("GC_DOLT_PORT", "29999")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "9.9.9.9")
+	unsetTestEnv(t, "BEADS_DOLT_SERVER_PORT")
+
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+
+	for _, want := range []string{"GC_DOLT_PORT='29999'", "BEADS_DOLT_SERVER_PORT='29999'"} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("workflowServeControlReadyQuery missing %q in %q", want, query)
+		}
+	}
+	if strings.Contains(query, "9.9.9.9") {
+		t.Fatalf("workflowServeControlReadyQuery must not mix BEADS_DOLT_SERVER_HOST from a different namespace than the resolved port: %q", query)
+	}
+}
+
+// unsetTestEnv unsets the given env vars for the duration of the test,
+// restoring the original values (or absence) afterward.
+func unsetTestEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		t.Setenv(key, "")
+		_ = os.Unsetenv(key)
 	}
 }
 

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -844,8 +844,7 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 // the outer subprocess's cmd.Env resolved to) rather than depending on that
 // re-resolution succeeding on every poll.
 func ambientDoltConnectionQueryPrefix() string {
-	host := strings.TrimSpace(firstNonEmptyGCString(os.Getenv("GC_DOLT_HOST"), os.Getenv("BEADS_DOLT_SERVER_HOST")))
-	port := strings.TrimSpace(firstNonEmptyGCString(os.Getenv("GC_DOLT_PORT"), os.Getenv("BEADS_DOLT_SERVER_PORT")))
+	host, port := ambientDoltHostPort()
 	var pairs []string
 	if host != "" {
 		quotedHost := shellquote.Quote(host)
@@ -856,9 +855,26 @@ func ambientDoltConnectionQueryPrefix() string {
 		pairs = append(pairs, `GC_DOLT_PORT=`+quotedPort, `BEADS_DOLT_SERVER_PORT=`+quotedPort)
 	}
 	if len(pairs) == 0 {
+		workflowTracef("ambient dolt env unset; ready-query passthrough disabled")
 		return ""
 	}
 	return " " + strings.Join(pairs, " ")
+}
+
+// ambientDoltHostPort resolves the ambient Dolt host and port as a matched
+// pair from a single env-var namespace instead of choosing each field
+// independently. GC_DOLT_* is authoritative when present (even partially);
+// BEADS_DOLT_SERVER_* is only consulted as a whole-pair fallback when
+// GC_DOLT_* carries neither value. Resolving fields independently risked
+// pairing a host from one namespace with a port from the other -- a
+// combination that may never have described the same server.
+func ambientDoltHostPort() (host, port string) {
+	host = strings.TrimSpace(os.Getenv("GC_DOLT_HOST"))
+	port = strings.TrimSpace(os.Getenv("GC_DOLT_PORT"))
+	if host != "" || port != "" {
+		return host, port
+	}
+	return strings.TrimSpace(os.Getenv("BEADS_DOLT_SERVER_HOST")), strings.TrimSpace(os.Getenv("BEADS_DOLT_SERVER_PORT"))
 }
 
 func workflowServeLegacyControlRoute(target string) string {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -785,7 +785,7 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 	jqFilter = strings.ReplaceAll(jqFilter, `\`, `\\`)
 	jqFilter = strings.ReplaceAll(jqFilter, `"`, `\"`)
 	jqFilter = strings.ReplaceAll(jqFilter, `$`, `\$`)
-	queryPrefix := `BD_EXPORT_AUTO=false GC_CONTROL_TARGET=` + shellquote.Quote(target)
+	queryPrefix := `BD_EXPORT_AUTO=false GC_CONTROL_TARGET=` + shellquote.Quote(target) + ambientDoltConnectionQueryPrefix()
 	for _, name := range controlSessionNames {
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -823,6 +823,43 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 		`routed_ready "${GC_CONTROL_BARE_TARGET:-}"; ` +
 		`if [ -s "$tmp" ]; then jq -s "` + jqFilter + `" "$tmp"; else printf "[]"; fi` + `'`
 	return query
+}
+
+// ambientDoltConnectionQueryPrefix returns a shell-prefix env fragment
+// (leading space + "KEY=value" pairs, or "") carrying the CURRENT process's
+// Dolt connection coordinates under both the GC_DOLT_* and BEADS_DOLT_SERVER_*
+// names bd recognizes.
+//
+// Without this, the ready-query subprocess env is built by stripping the
+// parent's inherited Dolt vars and re-projecting them from a freshly resolved
+// scope lookup (mergeRuntimeEnv + controllerWorkQueryEnv). That resolution
+// runs its own managed-runtime-availability probe and can transiently come
+// back without a port, silently dropping GC_DOLT_PORT/BEADS_DOLT_SERVER_PORT
+// from the subprocess env and causing `bd --sandbox` to resolve port 0
+// ("Dolt server unreachable at 127.0.0.1:0") — the recurring fleet-wide
+// graph.v2 wedge (gascity gc-74rxa). The running control-dispatcher process's
+// own environment already carries the connection coordinates it was spawned
+// with, so pass them through explicitly as a shell-prefix assignment (which
+// takes effect for the inner `sh -c` and its `bd` children regardless of what
+// the outer subprocess's cmd.Env resolved to) rather than depending on that
+// re-resolution succeeding on every poll.
+func ambientDoltConnectionQueryPrefix() string {
+	host := strings.TrimSpace(os.Getenv("GC_DOLT_HOST"))
+	if host == "" {
+		host = strings.TrimSpace(os.Getenv("BEADS_DOLT_SERVER_HOST"))
+	}
+	port := strings.TrimSpace(os.Getenv("GC_DOLT_PORT"))
+	if port == "" {
+		port = strings.TrimSpace(os.Getenv("BEADS_DOLT_SERVER_PORT"))
+	}
+	var prefix string
+	if host != "" {
+		prefix += ` GC_DOLT_HOST=` + shellquote.Quote(host) + ` BEADS_DOLT_SERVER_HOST=` + shellquote.Quote(host)
+	}
+	if port != "" {
+		prefix += ` GC_DOLT_PORT=` + shellquote.Quote(port) + ` BEADS_DOLT_SERVER_PORT=` + shellquote.Quote(port)
+	}
+	return prefix
 }
 
 func workflowServeLegacyControlRoute(target string) string {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -844,22 +844,21 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 // the outer subprocess's cmd.Env resolved to) rather than depending on that
 // re-resolution succeeding on every poll.
 func ambientDoltConnectionQueryPrefix() string {
-	host := strings.TrimSpace(os.Getenv("GC_DOLT_HOST"))
-	if host == "" {
-		host = strings.TrimSpace(os.Getenv("BEADS_DOLT_SERVER_HOST"))
-	}
-	port := strings.TrimSpace(os.Getenv("GC_DOLT_PORT"))
-	if port == "" {
-		port = strings.TrimSpace(os.Getenv("BEADS_DOLT_SERVER_PORT"))
-	}
-	var prefix string
+	host := strings.TrimSpace(firstNonEmptyGCString(os.Getenv("GC_DOLT_HOST"), os.Getenv("BEADS_DOLT_SERVER_HOST")))
+	port := strings.TrimSpace(firstNonEmptyGCString(os.Getenv("GC_DOLT_PORT"), os.Getenv("BEADS_DOLT_SERVER_PORT")))
+	var pairs []string
 	if host != "" {
-		prefix += ` GC_DOLT_HOST=` + shellquote.Quote(host) + ` BEADS_DOLT_SERVER_HOST=` + shellquote.Quote(host)
+		quotedHost := shellquote.Quote(host)
+		pairs = append(pairs, `GC_DOLT_HOST=`+quotedHost, `BEADS_DOLT_SERVER_HOST=`+quotedHost)
 	}
 	if port != "" {
-		prefix += ` GC_DOLT_PORT=` + shellquote.Quote(port) + ` BEADS_DOLT_SERVER_PORT=` + shellquote.Quote(port)
+		quotedPort := shellquote.Quote(port)
+		pairs = append(pairs, `GC_DOLT_PORT=`+quotedPort, `BEADS_DOLT_SERVER_PORT=`+quotedPort)
 	}
-	return prefix
+	if len(pairs) == 0 {
+		return ""
+	}
+	return " " + strings.Join(pairs, " ")
 }
 
 func workflowServeLegacyControlRoute(target string) string {


### PR DESCRIPTION
## Summary

Fixes the control-dispatcher's `bd --sandbox ready` work-query losing its
Dolt connection env intermittently, which resolves the port to `0` and
produces the recurring fleet-wide `graph.v2` dispatcher wedge (`Dolt server
unreachable at 127.0.0.1:0`).

## Root cause

The dispatcher's work-query subprocess env is rebuilt via
`mergeRuntimeEnv`/`controllerWorkQueryEnv`, which re-resolves Dolt
connection coordinates from a managed-runtime-availability probe. That
resolution can transiently come back without a port, silently stripping
`GC_DOLT_PORT`/`BEADS_DOLT_SERVER_PORT` from the subprocess env, so
`bd --sandbox` falls back to port `0`. The running dispatcher process itself
always has the correct host/port — this pipes them through explicitly as a
shell-prefix env assignment on the `bd --sandbox ready` invocation so the
work-query no longer depends on the probe succeeding on every poll.

Fixed in `cmd/gc/dispatch_runtime.go` (`workflowServeControlReadyQueryForBeads`).

## Testing

- `make check` (simplify → review → contributor-check pipeline, ship-pass
  sentinel `verdict: ready`)
- Added an execution-level regression test for the fix
- `62aaa7bb2` resolves ambient Dolt host/port as a matched pair (avoids a
  mismatched-pair edge case found in review)

## Impact

This is the root cause tracked as gc-74rxa; it has been the single blocker
holding P1 security issue #2723 (Host-header allowlist / DNS rebinding) and
every `graph.v2` author-from-issue sling since 2026-07-06 (see rollup
gc-ie14l for the stranded-workflow trail this caused).
