### PR TITLE
fix(init): default the [api] port on the hosted-dolt init path

### DIFF
--- a/cmd/gc/init_hosted_dolt.go
+++ b/cmd/gc/init_hosted_dolt.go
@@ -135,6 +135,17 @@ func (o hostedDoltInitOptions) applyToCityConfig(cfg *config.City) error {
 	}
 	cfg.Dolt.Host = strings.TrimSpace(o.Host)
 	cfg.Dolt.Port = port
+	// A hosted city's controller runs out-of-session; the control dispatcher and
+	// gc CLI reach it only through the HTTP API, and every API consumer treats
+	// cfg.API.Port == 0 as "API disabled". Neither plain init nor the hosted
+	// endpoint flags write an [api] section (only the k8s-cell bootstrap profile
+	// does), so default the API port here — otherwise a hosted init yields a city
+	// whose control plane is unreachable until an [api] section is hand-added.
+	// applyBootstrapProfile runs first, so a profile that already pinned a
+	// port/bind (e.g. k8s-cell's 0.0.0.0 + allow_mutations) wins.
+	if cfg.API.Port == 0 {
+		cfg.API.Port = config.DefaultAPIPort
+	}
 	return nil
 }
 

--- a/cmd/gc/init_hosted_dolt_test.go
+++ b/cmd/gc/init_hosted_dolt_test.go
@@ -163,6 +163,42 @@ func TestHostedDoltInitOptionsValidate(t *testing.T) {
 	}
 }
 
+// TestHostedDoltInitAppliesAPIPortDefault pins the control-plane reachability
+// contract for hosted cities. A hosted city's controller runs out-of-session,
+// so the control dispatcher and gc CLI reach it only through the HTTP API, and
+// every API consumer treats cfg.API.Port == 0 as "API disabled". Neither plain
+// init nor the hosted endpoint flags write an [api] section (only the k8s-cell
+// bootstrap profile does), so without this default a hosted init yields a city
+// whose control plane is unreachable until an [api] section is hand-added.
+func TestHostedDoltInitAppliesAPIPortDefault(t *testing.T) {
+	t.Run("defaults the API port when no [api] section is set", func(t *testing.T) {
+		o := hostedDoltInitOptions{Host: "gateway.example.com", Port: "4406", Database: "bd_prj_x", ProjectID: "prj_x"}
+		var cfg config.City
+		if err := o.applyToCityConfig(&cfg); err != nil {
+			t.Fatalf("applyToCityConfig() error = %v", err)
+		}
+		if cfg.API.Port != config.DefaultAPIPort {
+			t.Fatalf("cfg.API.Port = %d, want %d (hosted controller is reachable only via the HTTP API)", cfg.API.Port, config.DefaultAPIPort)
+		}
+	})
+	t.Run("preserves an API config already pinned by a bootstrap profile", func(t *testing.T) {
+		o := hostedDoltInitOptions{Host: "gateway.example.com", Port: "4406", Database: "bd_prj_x", ProjectID: "prj_x"}
+		var cfg config.City
+		cfg.API.Port = 12345
+		cfg.API.Bind = "0.0.0.0"
+		cfg.API.AllowMutations = true
+		if err := o.applyToCityConfig(&cfg); err != nil {
+			t.Fatalf("applyToCityConfig() error = %v", err)
+		}
+		if cfg.API.Port != 12345 {
+			t.Fatalf("cfg.API.Port = %d, want 12345 preserved (bootstrap profile wins)", cfg.API.Port)
+		}
+		if cfg.API.Bind != "0.0.0.0" || !cfg.API.AllowMutations {
+			t.Fatalf("bootstrap-profile API config clobbered: bind=%q allowMutations=%v", cfg.API.Bind, cfg.API.AllowMutations)
+		}
+	})
+}
+
 func TestInitWizardConfigFromFlagsCapturesHostedDolt(t *testing.T) {
 	cmd := newInitCmd(io.Discard, io.Discard)
 	if err := cmd.Flags().Set("template", "custom"); err != nil {


### PR DESCRIPTION
## What

On the hosted-dolt `gc init` path, the `[api]` port was not being defaulted when no `[api]` section was present, leaving the initialized city without a usable API port unless a bootstrap profile pinned one.

## How

Apply the standard `[api]` port default during hosted-dolt init when no `[api]` section is set, and preserve an API config already pinned by a bootstrap profile.

## Tests

- `TestHostedDoltInitAppliesAPIPortDefault` (init_hosted_dolt_test.go) with two cases:
  - defaults the API port when no `[api]` section is set
  - preserves an API config already pinned by a bootstrap profile

Verified locally: `go vet ./cmd/gc` clean; `TestHostedDoltInitAppliesAPIPortDefault` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)