### PR TITLE
feat(worker): add gpt-5.6-sol/terra/luna codex model choices

### DIFF
--- a/docs/guides/harness-recipes.md
+++ b/docs/guides/harness-recipes.md
@@ -89,7 +89,7 @@ Reads `OPENAI_BASE_URL` and `OPENAI_API_KEY`.
 ```toml
 # Direct
 provider        = "codex"
-option_defaults = { model = "gpt-5.5" }    # gpt-5.5 · gpt-5.3-codex-spark · o3 · o4-mini
+option_defaults = { model = "gpt-5.5" }    # gpt-5.6-sol · gpt-5.6-terra · gpt-5.6-luna · gpt-5.5 · gpt-5.3-codex · o3 · o4-mini
 ```
 
 ```toml

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -219,6 +219,9 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
+					{Value: "gpt-5.6-sol", Label: "GPT-5.6 Sol", FlagArgs: []string{"--model", "gpt-5.6-sol"}, FlagAliases: [][]string{{"-m", "gpt-5.6-sol"}}},
+					{Value: "gpt-5.6-terra", Label: "GPT-5.6 Terra", FlagArgs: []string{"--model", "gpt-5.6-terra"}, FlagAliases: [][]string{{"-m", "gpt-5.6-terra"}}},
+					{Value: "gpt-5.6-luna", Label: "GPT-5.6 Luna", FlagArgs: []string{"--model", "gpt-5.6-luna"}, FlagAliases: [][]string{{"-m", "gpt-5.6-luna"}}},
 					{Value: "gpt-5.5", Label: "GPT-5.5", FlagArgs: []string{"--model", "gpt-5.5"}, FlagAliases: [][]string{{"-m", "gpt-5.5"}}},
 					{Value: "gpt-5.3-codex", Label: "GPT-5.3 Codex", FlagArgs: []string{"--model", "gpt-5.3-codex"}, FlagAliases: [][]string{{"-m", "gpt-5.3-codex"}}},
 					{Value: "o3", Label: "o3", FlagArgs: []string{"--model", "o3"}, FlagAliases: [][]string{{"-m", "o3"}}},

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -129,3 +129,49 @@ func TestBuiltinCodexModelChoicesUseAvailable53CodexAlias(t *testing.T) {
 		t.Fatal("codex model choices missing gpt-5.3-codex")
 	}
 }
+
+func TestBuiltinCodexModelChoicesIncludeGPT56Variants(t *testing.T) {
+	codex, ok := BuiltinProviders()["codex"]
+	if !ok {
+		t.Fatal("BuiltinProviders() missing codex")
+	}
+
+	var modelOption BuiltinProviderOption
+	for _, option := range codex.OptionsSchema {
+		if option.Key == "model" {
+			modelOption = option
+			break
+		}
+	}
+	if modelOption.Key == "" {
+		t.Fatal("codex provider missing model option")
+	}
+
+	byValue := make(map[string]BuiltinOptionChoice, len(modelOption.Choices))
+	for _, choice := range modelOption.Choices {
+		byValue[choice.Value] = choice
+	}
+
+	wantLabels := map[string]string{
+		"gpt-5.6-sol":   "GPT-5.6 Sol",
+		"gpt-5.6-terra": "GPT-5.6 Terra",
+		"gpt-5.6-luna":  "GPT-5.6 Luna",
+	}
+	for value, wantLabel := range wantLabels {
+		choice, ok := byValue[value]
+		if !ok {
+			t.Fatalf("codex model choices missing %q", value)
+		}
+		if choice.Label != wantLabel {
+			t.Errorf("%s label = %q, want %q", value, choice.Label, wantLabel)
+		}
+		wantFlagArgs := []string{"--model", value}
+		if len(choice.FlagArgs) != 2 || choice.FlagArgs[0] != wantFlagArgs[0] || choice.FlagArgs[1] != wantFlagArgs[1] {
+			t.Errorf("%s FlagArgs = %v, want %v", value, choice.FlagArgs, wantFlagArgs)
+		}
+		if len(choice.FlagAliases) != 1 || len(choice.FlagAliases[0]) != 2 ||
+			choice.FlagAliases[0][0] != "-m" || choice.FlagAliases[0][1] != value {
+			t.Errorf("%s FlagAliases = %v, want [[-m %s]]", value, choice.FlagAliases, value)
+		}
+	}
+}


### PR DESCRIPTION
## What

Registers three new supported codex/OpenAI models — `gpt-5.6-sol`,
`gpt-5.6-terra`, and `gpt-5.6-luna` — as `BuiltinOptionChoice` entries in the
codex provider's `model` `OptionsSchema` (`internal/worker/builtin/profiles.go`),
placed newest-first ahead of `gpt-5.5` per the file's descending-version
convention.

## Why

They surface in the model dropdown and resolve to `--model <id>` / `-m <id>`
launch args. Everything downstream derives generically from this single list:

- config `ProviderSpec` materialization (`deepCopyProviderOptions`)
- dashboard model choices (served from the builtin `OptionsSchema` via the API)
- context-window sizing — `gpt-5.6-*` already matches the `gpt-5` substring in
  `internal/sessionlog/context.go` → 258k, no change needed

So no other wiring is required. This is an **add** only — the codex default
model (`gpt-5.5`) and `TitleModel` (`o4-mini`) are intentionally unchanged.

There is no gascity-side model allowlist and no shipped codex pricing table, so
those paths need no edits either.

## Also

Refreshes the stale codex model comment in `docs/guides/harness-recipes.md`,
which listed the never-shipped `gpt-5.3-codex-spark` alias instead of the real
`gpt-5.3-codex`.

## Testing

- New guard test `TestBuiltinCodexModelChoicesIncludeGPT56Variants` (value,
  label, `FlagArgs`, `FlagAliases` for all three) — TDD: written failing first,
  then made to pass.
- `go build ./...`, `go vet ./internal/worker/builtin/` clean.
- `internal/config`, `internal/worker/...`, `internal/sessionlog` packages pass.
- Adversarial self-review (three independent lenses: correctness/pattern-fidelity,
  missed-registration-sites, test+doc accuracy) returned zero findings.

Note: the local pre-push fast suite flagged one unrelated pre-existing flake,
`TestQueueDrainAckAsyncStopTokenFenceSkipsReusedName` (session-reconciler
async token-fence race in `cmd/gc`, a package this PR does not touch); it passes
10/10 in isolation. CI runs the authoritative gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)