### PR TITLE
fix(reconcile): record the launcher's actual worktree path, not a re-derived suffix-less form

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2708,12 +2708,27 @@ func bindPoolSessionTriggerBead(bp *agentBuildParams, cfgAgent *config.Agent, qu
 	if workspace := packWorkspaceSlug(request); strings.TrimSpace(sessionBead.Metadata[beadmeta.PackWorkspaceMetadataKey]) != workspace {
 		metadata[beadmeta.PackWorkspaceMetadataKey] = workspace
 	}
-	if workDir := poolTriggerWorkDir(bp, cfgAgent, qualifiedName, request); workDir != "" {
-		if strings.TrimSpace(sessionBead.Metadata[beadmeta.WorkDirMetadataKey]) != workDir {
-			metadata[beadmeta.WorkDirMetadataKey] = workDir
-		}
-		if strings.TrimSpace(sessionBead.Metadata[beadmeta.LegacyWorkDirMetadataKey]) != workDir {
-			metadata[beadmeta.LegacyWorkDirMetadataKey] = workDir
+	// Only (re)derive the work_dir when the binding is new or re-pointed to a
+	// different trigger bead. For an unchanged trigger bead the recorded
+	// gc.work_dir is the path the launcher ACTUALLY created (with the work-bead
+	// title-slug suffix, e.g. "dip-<bead>-implement-compound-work-item") and is
+	// the single source of truth: it must not be re-derived here. A resume/wake
+	// SessionRequest for the same bead does not carry WorkBeadTitle, so
+	// poolTriggerWorkDir would re-derive the suffix-less "dip-<bead>" form and
+	// clobber the real worktree path — the recorded value would then point at a
+	// directory that never existed, breaking the build-artifact-valid gate that
+	// chdirs into it (sc-s5mfl3). Sibling to the reaped-workdir bug in #4021:
+	// there the recorded path was correct but later deleted; here it is wrong
+	// from birth.
+	existingWorkDir := strings.TrimSpace(sessionBead.Metadata[beadmeta.WorkDirMetadataKey])
+	if oldWorkBeadID != workBeadID || existingWorkDir == "" {
+		if workDir := poolTriggerWorkDir(bp, cfgAgent, qualifiedName, request); workDir != "" {
+			if existingWorkDir != workDir {
+				metadata[beadmeta.WorkDirMetadataKey] = workDir
+			}
+			if strings.TrimSpace(sessionBead.Metadata[beadmeta.LegacyWorkDirMetadataKey]) != workDir {
+				metadata[beadmeta.LegacyWorkDirMetadataKey] = workDir
+			}
 		}
 	}
 	if len(metadata) == 0 {

--- a/cmd/gc/build_desired_state_worktree_record_test.go
+++ b/cmd/gc/build_desired_state_worktree_record_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestBindPoolSessionTriggerBead_PreservesLauncherWorktreePath is the
+// regression guard for sc-s5mfl3: the recorded gc.work_dir must match the
+// worktree the launcher actually created, including the work-bead title slug
+// suffix (e.g. "dip-<bead>-implement-compound-work-item").
+//
+// The launcher derives the worktree name from the work bead's id+title slug
+// when the session is first created ("new" tier, title known). On a subsequent
+// reconcile the same session is re-bound to the same trigger bead via a
+// resume/wake request that does NOT carry the title (WorkBeadTitle == ""). The
+// pre-fix code unconditionally re-derived the work_dir from the incomplete
+// request, producing the suffix-less "dip-<bead>" form and clobbering the
+// launcher-created path that was already recorded. The build-artifact-valid
+// gate then chdirs into a path that never existed.
+//
+// The fix makes the recorded launcher path the single source of truth: for an
+// unchanged trigger bead, the already-recorded work_dir is preserved rather
+// than re-derived from a request that may be missing the title.
+func TestBindPoolSessionTriggerBead_PreservesLauncherWorktreePath(t *testing.T) {
+	const (
+		workBead = "dip-42"
+		title    = "implement compound work item"
+	)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "dip"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			WorkDir:           ".gc/workspaces/{{.AgentBase}}",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+	var stderr bytes.Buffer
+	store := beads.NewMemStore()
+	bp := newAgentBuildParams("dip", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+
+	// The base workspace root the launcher joins the trigger slug under.
+	base := filepath.Join(bp.cityPath, ".gc", "workspaces", "worker")
+	// What the launcher actually creates the first time, title in hand.
+	launcherCreated := filepath.Join(base, "dip-42-implement-compound-work-item")
+
+	// 1. First bind: "new" tier carries the title. This mirrors the launcher's
+	//    own path derivation, so the recorded work_dir == the created worktree.
+	created, err := store.Create(beads.Bead{ID: "sess-1", Type: "session"})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	bound, err := bindPoolSessionTriggerBead(bp, &cfg.Agents[0], "worker", created, SessionRequest{
+		Tier:          "new",
+		WorkBeadID:    workBead,
+		WorkBeadTitle: title,
+	})
+	if err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+	recorded := bound.Metadata[beadmeta.WorkDirMetadataKey]
+	if recorded != launcherCreated {
+		t.Fatalf("first-bind work_dir = %q, want launcher-created %q", recorded, launcherCreated)
+	}
+
+	// 2. Re-bind on the next reconcile: a resume/wake request for the SAME
+	//    trigger bead, but WITHOUT the title (the resume/wake tiers never
+	//    populate WorkBeadTitle). The recorded launcher path must survive.
+	reBound, err := bindPoolSessionTriggerBead(bp, &cfg.Agents[0], "worker", bound, SessionRequest{
+		Tier:       "wake-known-identity",
+		WorkBeadID: workBead,
+		// WorkBeadTitle intentionally empty.
+	})
+	if err != nil {
+		t.Fatalf("re-bind: %v", err)
+	}
+
+	got := reBound.Metadata[beadmeta.WorkDirMetadataKey]
+	if got != launcherCreated {
+		t.Fatalf("re-bind dropped the title suffix:\n  recorded = %q\n  created  = %q\nrecorded path never existed", got, launcherCreated)
+	}
+
+	// The store copy must agree with the returned bead.
+	persisted, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got := persisted.Metadata[beadmeta.WorkDirMetadataKey]; got != launcherCreated {
+		t.Fatalf("persisted work_dir = %q, want %q", got, launcherCreated)
+	}
+}


### PR DESCRIPTION
### Symptom
The `build-artifact-valid` gate chdirs into a compound-work root bead's recorded `gc.work_dir` and hits a directory that never existed: the launcher created `dip-<bead>-implement-compound-work-item` but the recording is the suffix-less `dip-<bead>`.

### Root cause
`bindPoolSessionTriggerBead` re-derives `gc.work_dir` on every reconcile via `poolTriggerWorkDir` → `triggerBeadPathSlug(WorkBeadID, WorkBeadTitle)`. The `new` tier populates `WorkBeadTitle`, so the initial recording matches the launcher-created worktree — but the `resume`/`wake-known-identity` tiers never populate it, so the next reconcile re-derives the suffix-less form and **clobbers the correct value**. `stampRunSessionIdentity`/`stampRunRootFromStep` then copy the clobbered path onto the compound-work root, which the artifact gate later chdirs into. Wrong from birth on the first post-launch reconcile. Introduced in #3617 (`a3e81227a`).

### Fix
For an unchanged trigger bead with a `work_dir` already recorded, preserve it — the launcher-created path is the single source of truth. Only (re)derive when the binding is new or re-pointed to a different trigger bead.

### Band-aid retired
Removes the need for the live containment where workers pre-create symlink dirs bridging the recorded/created divergence.

### Tests
New regression `TestBindPoolSessionTriggerBead_PreservesLauncherWorktreePath` — pre-fix FAIL (`re-bind dropped the title suffix... recorded path never existed`), post-fix PASS. Full `cmd/gc`, `internal/convergence`, `internal/dispatch` suites green; build/vet/gofmt clean.

### Refs
Sibling to #4021 (reaped-workdir): there the recorded path was correct but later deleted; here it was wrong from birth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)