### PR TITLE
fix(reconciler): bind drain-ack poke seam on caller goroutine (kill cmd/gc CI flake)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -296,6 +296,13 @@ func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provi
 	if !tracking {
 		return
 	}
+	// Bind the poke seam on the caller's goroutine, at queue time. The async
+	// goroutine below may outlive its reconcile invocation (see the poke
+	// comment), and re-reading the mutable package-global seam from a detached
+	// goroutine races with tests that swap it — and lets a goroutine queued by
+	// one test poke a later test's swapped-in counter. Capturing the value here
+	// confines each goroutine to the seam that was live when its stop was queued.
+	poke := drainAckAsyncStopPokeController
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -330,7 +337,7 @@ func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provi
 		// the caller's subsequent writes on the same writer (data race on
 		// non-goroutine-safe buffers). The controller reconciles on the next
 		// patrol tick regardless.
-		_ = drainAckAsyncStopPokeController(cityPath)
+		_ = poke(cityPath)
 	}()
 }
 


### PR DESCRIPTION
## Problem

`packages-cmd-gc-4-of-6` fails intermittently on `main` and PRs (it took down `main` on `e8f071037` + `simplify-land/s02`, and was flagged on #4064). The offender is **`TestQueueDrainAckAsyncStopTokenFenceSkipsReusedName`**, failing at 0.00s on `pokeCalls != 0`.

## Root cause (confirmed with `-race`)

Cross-test contamination + data race on the package-global test seam `drainAckAsyncStopPokeController`:

- `TestReconcileSessionBeads_DrainAckConsumesRestartRequested` drives the real reconcile path with a **nil** async-stop tracker, so the goroutine `queueDrainAckAsyncStop` spawns is undrainable and **leaks past the test**.
- A later poke-counting test (e.g. `…TokenFenceSkipsReusedName`) swaps the package-global seam to a counting closure.
- The leaked goroutine then **reads that global from a detached goroutine** (`session_reconciler.go:333`) — racing the swap (`-race`: write `session_reconciler_test.go` vs the goroutine read) and, on CI without `-race`, calling the *later* test's counter → `pokeCalls != 0` fires.

Production is unaffected: the seam is assigned once at init and never swapped outside tests.

## Fix

Bind the seam to a local on the **caller's** goroutine at queue time; the async goroutine calls the captured value. This confines every leaked goroutine to the seam that was live when *its* stop was queued (fixing all 76+ call sites at once), killing both the race and the counter contamination. No-op in production. `+8/-1`.

## Verification

- `-race -count=60` on the drain-ack set (incl. the exact leaker+victim): **DATA RACE before → clean after**.
- Siblings `…TokenFenceKillsMatchingSession`, `…ShutdownWaitsForTrackedAsyncDrainAckStops…`: `-race -count=50` → pass.
- `go vet ./cmd/gc/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
