### PR TITLE
fix(tmux): recover the session composer wedge instead of nudging blind

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1387,6 +1387,24 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store, sessStore beads.S
 	})
 	if err != nil {
 		telemetry.RecordNudge(context.Background(), target.agentKey(), err)
+		if errors.Is(err, runtime.ErrNudgeUndeliverable) {
+			// The composer is wedged: the message drafted but no submit ever
+			// confirmed through the provider's recovery ladder (or its state
+			// could not be observed). Re-nudging the same session is futile — it
+			// must be BOUNCED. Emit the loud, distinct signal a babysitter
+			// subscribes to, dead-letter these items now (failedQueuedNudge
+			// treats ErrNudgeUndeliverable as immediately terminal), and kill the
+			// session via the existing session-kill path so the reconciler
+			// restarts it with a fresh composer.
+			telemetry.RecordNudgeUndeliverable(context.Background(), target.agentKey(), err)
+			if recErr := recordQueuedNudgeFailureWithStore(target.cityPath, beads.NudgesStore{Store: deliveryStore}, queuedNudgeIDs(items), err, time.Now()); recErr != nil {
+				return false, errors.Join(bookkeepErr, recErr)
+			}
+			if bounceErr := bounceWedgedNudgeTarget(target, store, sp); bounceErr != nil {
+				return false, errors.Join(bookkeepErr, bounceErr)
+			}
+			return false, bookkeepErr
+		}
 		if errors.Is(err, runtime.ErrSessionNotFound) {
 			if recErr := releaseQueuedNudgeClaims(target.cityPath, queuedNudgeIDs(items)); recErr != nil {
 				return false, errors.Join(bookkeepErr, recErr)
@@ -1408,6 +1426,26 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store, sessStore beads.S
 	telemetry.RecordNudge(context.Background(), target.agentKey(), nil)
 	stampLastNudgeDeliveredAt(deliverySessFront, target.sessionID, time.Now())
 	return true, errors.Join(bookkeepErr, ackQueuedNudges(target.cityPath, queuedNudgeIDs(items)))
+}
+
+// bounceWedgedNudgeTarget kills the target session so the reconciler restarts it
+// with a fresh composer. A wedged composer (ErrNudgeUndeliverable) cannot accept
+// any further nudge; killing it IS the bounce. The session is resolved the same
+// way the other cmd_nudge worker paths do — the concrete session id when known,
+// else the agent key — and an already-gone session is treated as success
+// (nothing left to bounce).
+func bounceWedgedNudgeTarget(target nudgeTarget, store beads.Store, sp runtime.Provider) error {
+	ident := strings.TrimSpace(target.sessionID)
+	if ident == "" {
+		ident = strings.TrimSpace(target.agentKey())
+	}
+	if ident == "" {
+		return nil
+	}
+	if err := workerKillSessionTargetWithConfig(target.cityPath, store, sp, target.cfg, ident); err != nil && !runtime.IsSessionGone(err) {
+		return err
+	}
+	return nil
 }
 
 func stampLastNudgeDeliveredAt(sessFront *session.Store, sessionID string, t time.Time) {
@@ -2311,6 +2349,13 @@ func failedQueuedNudge(item queuedNudge, cause error, now time.Time) (queuedNudg
 	item.ClaimedAt = time.Time{}
 	item.LeaseUntil = time.Time{}
 	if errors.Is(cause, errNudgeSessionFenceMismatch) {
+		item.DeadAt = now.UTC()
+		return item, true
+	}
+	// A wedged composer will not accept a retry — the session is bounced
+	// instead — so an undeliverable nudge dead-letters immediately rather than
+	// burning the retry budget against a dead composer.
+	if errors.Is(cause, runtime.ErrNudgeUndeliverable) {
 		item.DeadAt = now.UTC()
 		return item, true
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -43,6 +43,23 @@ var ErrSessionDiedDuringStartup = errors.New("session died during startup")
 // dispatch with errors.Is.
 var ErrSessionNotFound = errors.New("session not found")
 
+// ErrNudgeUndeliverable reports that a nudge was pasted into the target's
+// composer but the submit was never confirmed to land — even after the tmux
+// provider's bounded recovery ladder (verified re-Enter and, only when the
+// draft is verifiably still sitting in the composer, a single verified
+// C-u clear + re-paste). The composer is wedged in a mode that swallows
+// Enter/C-m (the "session composer wedge"); more sends will not help. It is the
+// loud, errors.Is-visible signal that the session must be BOUNCED, not nudged
+// again: higher layers surface it via telemetry (RecordNudgeUndeliverable) and
+// the babysitter/reconciler recycles the session instead of silently queueing
+// more undeliverable nudges behind a dead composer. It is also returned when the
+// composer's state cannot be observed at all (a pane-capture error): state is
+// unknown, so recovery must NOT gamble a destructive clear/re-paste on a
+// possibly-live turn — it bounces instead. Provider facades wrap the
+// tmux-package sentinel through this one so callers dispatch on it with
+// errors.Is regardless of the concrete runtime.
+var ErrNudgeUndeliverable = errors.New("nudge undeliverable: message drafted but submit never confirmed (composer wedged)")
+
 // ErrExecUnsupported reports that a provider implements [ExecProvider] but the
 // underlying runtime does not implement the RPP `exec` wire op (it answered
 // exit 2). Carriers treat this as "fall back to the legacy driving op".

--- a/internal/runtime/tmux/submit_recovery_test.go
+++ b/internal/runtime/tmux/submit_recovery_test.go
@@ -1,0 +1,219 @@
+package tmux
+
+import (
+	"errors"
+	"testing"
+)
+
+// These tests cover the re-authored composer-wedge recovery ladder
+// (submitWithRecovery). The ladder must never take a destructive action
+// (C-u clear / re-paste / Escape) on an unobserved-busy alone: it acts only
+// when the draft is VERIFIABLY still in the composer, treats a pane-capture
+// error as state-unknown (bounce, no keys), and honors the claude family's
+// no-Escape rule. All side effects are injected, so the decision logic is
+// exercised without a live tmux server (noSleep is defined in
+// nudge_submit_confirm_test.go).
+
+// TestComposerContainsDraftScopesToComposerRegion locks the false-positive guard
+// at the heart of point 4: a submitted message echoes in the transcript, so the
+// draft check must be scoped to the composer region (after the last prompt
+// glyph). A transcript echo above an empty composer is DELIVERED; the same text
+// still sitting on the prompt line is a live draft.
+func TestComposerContainsDraftScopesToComposerRegion(t *testing.T) {
+	msg := "please review the PR and respond now"
+
+	delivered := "You: please review the PR and respond now\n\n[assistant reply...]\n\n❯ "
+	if composerContainsDraft(delivered, msg) {
+		t.Fatal("transcript echo above an empty composer must NOT read as a live draft (fast-completion false positive)")
+	}
+
+	wedged := "[assistant reply...]\n\n❯ please review the PR and respond now"
+	if !composerContainsDraft(wedged, msg) {
+		t.Fatal("a message still sitting on the prompt line must read as a live draft (wedge)")
+	}
+
+	// Bordered composer with the draft on the prompt line inside the box.
+	bordered := "transcript\n╭───────────────────────────────────────╮\n│ ❯ please review the PR and respond now │\n╰───────────────────────────────────────╯"
+	if !composerContainsDraft(bordered, msg) {
+		t.Fatal("a bordered composer draft must still be detected")
+	}
+}
+
+// TestSubmitWithRecoveryFastCompletionDelivered covers point 5's fast-completion
+// case: the busy window is missed (busy never observed), but the composer is
+// empty — the submit landed and the turn completed fast. This MUST read as
+// delivered with no destructive keys (no clear, no re-paste, no Escape).
+func TestSubmitWithRecoveryFastCompletionDelivered(t *testing.T) {
+	var escapes, clears, repastes int
+	l := submitLadder{
+		sendEnter:  func() error { return nil },
+		sendEscape: func() error { escapes++; return nil },
+		clearInput: func() error { clears++; return nil },
+		repaste:    func() error { repastes++; return nil },
+		wake:       func() {},
+		busy:       func() (bool, error) { return false, nil }, // busy window missed
+		// Composer is empty (just the prompt): submit landed, turn completed fast.
+		capture: func() (string, error) { return "…assistant reply…\n\n❯ ", nil },
+		message: "hello wedge please respond",
+		sleep:   noSleep,
+	}
+	if err := submitWithRecovery(l); err != nil {
+		t.Fatalf("err = %v, want nil (fast completion must read as delivered)", err)
+	}
+	if escapes != 0 || clears != 0 || repastes != 0 {
+		t.Fatalf("destructive keys fired on a delivered fast-completion: escapes=%d clears=%d repastes=%d", escapes, clears, repastes)
+	}
+}
+
+// TestSubmitWithRecoveryCaptureErrorUndeliverable covers point 2: a
+// busy/composer observation that ERRORS is state-unknown. The ladder must NOT
+// advance the destructive rungs on a capture error — it returns
+// ErrNudgeUndeliverable so the caller bounces instead of gambling a clear/
+// re-paste on a possibly-live turn.
+func TestSubmitWithRecoveryCaptureErrorUndeliverable(t *testing.T) {
+	var escapes, clears, repastes int
+	l := submitLadder{
+		sendEnter:  func() error { return nil },
+		sendEscape: func() error { escapes++; return nil },
+		clearInput: func() error { clears++; return nil },
+		repaste:    func() error { repastes++; return nil },
+		wake:       func() {},
+		busy:       func() (bool, error) { return false, nil },
+		capture:    func() (string, error) { return "", errors.New("capture-pane: no such pane") },
+		message:    "hello wedge",
+		sleep:      noSleep,
+	}
+	err := submitWithRecovery(l)
+	if !errors.Is(err, ErrNudgeUndeliverable) {
+		t.Fatalf("err = %v, want ErrNudgeUndeliverable (state-unknown)", err)
+	}
+	if escapes != 0 || clears != 0 || repastes != 0 {
+		t.Fatalf("destructive keys fired despite unknown composer state: escapes=%d clears=%d repastes=%d", escapes, clears, repastes)
+	}
+}
+
+// TestSubmitWithRecoveryFailedClearUndeliverableNoRepaste covers point 5's
+// failed-clear case (and point 4's "verify cleared"): the draft is verifiably
+// stuck, C-u is attempted, but a re-capture shows the draft STILL present — the
+// clear failed. The ladder must return ErrNudgeUndeliverable and must NOT
+// re-paste on top of the stuck draft.
+func TestSubmitWithRecoveryFailedClearUndeliverableNoRepaste(t *testing.T) {
+	var clears, repastes int
+	stuck := "…reply…\n\n❯ hello wedge please respond now"
+	l := submitLadder{
+		sendEnter:  func() error { return nil },
+		sendEscape: func() error { t.Fatal("Escape must not fire for a skip-escape (claude) provider"); return nil },
+		skipEscape: true, // claude family
+		clearInput: func() error { clears++; return nil },
+		repaste:    func() error { repastes++; return nil },
+		wake:       func() {},
+		busy:       func() (bool, error) { return false, nil },
+		// Draft is ALWAYS present, even after C-u: the clear failed.
+		capture: func() (string, error) { return stuck, nil },
+		message: "hello wedge please respond now",
+		sleep:   noSleep,
+	}
+	err := submitWithRecovery(l)
+	if !errors.Is(err, ErrNudgeUndeliverable) {
+		t.Fatalf("err = %v, want ErrNudgeUndeliverable (failed clear)", err)
+	}
+	if clears != 1 {
+		t.Fatalf("clears = %d, want 1 (C-u attempted exactly once)", clears)
+	}
+	if repastes != 0 {
+		t.Fatalf("repastes = %d, want 0 (must NOT re-paste on top of a stuck draft)", repastes)
+	}
+}
+
+// TestSubmitWithRecoveryClaudeSkipsEscape covers point 3 / point 5's "claude
+// gets no Escape": a wedged claude composer is recovered by the verified
+// C-u clear + clean re-paste path, and the Escape rung is never used (Escape is
+// a semantic interrupt for the claude family).
+func TestSubmitWithRecoveryClaudeSkipsEscape(t *testing.T) {
+	var escapes, clears, repastes int
+	cleared := false
+	l := submitLadder{
+		sendEnter:  func() error { return nil },
+		sendEscape: func() error { escapes++; return nil },
+		skipEscape: true, // claude family
+		clearInput: func() error { clears++; cleared = true; return nil },
+		repaste:    func() error { repastes++; return nil },
+		wake:       func() {},
+		// The composer accepts a submit only after a clean re-paste.
+		busy: func() (bool, error) { return repastes > 0, nil },
+		capture: func() (string, error) {
+			if cleared {
+				return "…reply…\n\n❯ ", nil // C-u emptied the composer
+			}
+			return "…reply…\n\n❯ hello wedge please respond now", nil // draft stuck
+		},
+		message: "hello wedge please respond now",
+		sleep:   noSleep,
+	}
+	if err := submitWithRecovery(l); err != nil {
+		t.Fatalf("err = %v, want nil (claude wedge recovers via C-u + re-paste)", err)
+	}
+	if escapes != 0 {
+		t.Fatalf("escapes = %d, want 0 (claude must never receive an Escape)", escapes)
+	}
+	if clears != 1 || repastes != 1 {
+		t.Fatalf("recovery path wrong: clears=%d repastes=%d, want 1/1", clears, repastes)
+	}
+}
+
+// TestSubmitWithRecoveryNonClaudeUsesEscapeRung is the complement to the claude
+// case: a NON-skip-escape provider (e.g. grok) does get the Escape rung, and an
+// Escape that unsticks the composer recovers without ever reaching the
+// destructive C-u/re-paste rung.
+func TestSubmitWithRecoveryNonClaudeUsesEscapeRung(t *testing.T) {
+	var escapes, clears, repastes int
+	escaped := false
+	l := submitLadder{
+		sendEnter:  func() error { return nil },
+		sendEscape: func() error { escapes++; escaped = true; return nil },
+		skipEscape: false, // non-claude: Escape is a mode-reset key
+		clearInput: func() error { clears++; return nil },
+		repaste:    func() error { repastes++; return nil },
+		wake:       func() {},
+		busy:       func() (bool, error) { return escaped, nil }, // Escape unsticks; next Enter submits
+		capture:    func() (string, error) { return "❯ hello wedge please respond now", nil },
+		message:    "hello wedge please respond now",
+		sleep:      noSleep,
+	}
+	if err := submitWithRecovery(l); err != nil {
+		t.Fatalf("err = %v, want nil (Escape rung should recover a non-claude wedge)", err)
+	}
+	if escapes == 0 {
+		t.Fatal("Escape rung never fired for a non-skip-escape provider")
+	}
+	if clears != 0 || repastes != 0 {
+		t.Fatalf("destructive C-u/re-paste fired though Escape already recovered: clears=%d repastes=%d", clears, repastes)
+	}
+}
+
+// TestSubmitWithRecoveryRung1ConfirmNoEscalation proves the common path is
+// untouched: when the first verified re-Enter confirms the submit, no draft
+// inspection or destructive rung fires.
+func TestSubmitWithRecoveryRung1ConfirmNoEscalation(t *testing.T) {
+	var enters, escapes, clears, repastes, captures int
+	l := submitLadder{
+		sendEnter:  func() error { enters++; return nil },
+		sendEscape: func() error { escapes++; return nil },
+		clearInput: func() error { clears++; return nil },
+		repaste:    func() error { repastes++; return nil },
+		wake:       func() {},
+		busy:       func() (bool, error) { return enters >= 1, nil }, // first Enter submits
+		capture:    func() (string, error) { captures++; return "❯ ", nil },
+		message:    "hello",
+		sleep:      noSleep,
+	}
+	if err := submitWithRecovery(l); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if enters != 1 {
+		t.Fatalf("enters = %d, want 1 (rung 1 confirmed)", enters)
+	}
+	if escapes != 0 || clears != 0 || repastes != 0 || captures != 0 {
+		t.Fatalf("escalation fired on an already-submitted turn: escapes=%d clears=%d repastes=%d captures=%d", escapes, clears, repastes, captures)
+	}
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -147,6 +147,20 @@ var (
 	// original server. Callers should surface this to the user instead of
 	// proceeding — see issue ga-h9z.
 	ErrServerDegraded = errors.New("tmux server degraded: refusing new-session to avoid socket clobber")
+	// ErrNudgeUndeliverable indicates the message was pasted into the target's
+	// composer but the submit was never observed to land — even after the
+	// bounded recovery ladder (verified re-Enter and, only when the draft is
+	// verifiably still sitting in the composer, a single verified C-u clear +
+	// re-paste). The composer is wedged: the draft sits at "❯ <text>" and
+	// neither gc's nor a human's Enter/C-m submits it (the "session composer
+	// wedge"). It is also returned when the pane cannot be captured to observe
+	// composer state — state-unknown, so recovery refuses to run a destructive
+	// clear/re-paste blind. Callers must NOT treat this as delivered; it is the
+	// loud signal a babysitter/reconciler uses to bounce the session instead of
+	// silently queueing more nudges. It wraps [runtime.ErrNudgeUndeliverable] so
+	// callers above the provider facade dispatch on the shared sentinel with
+	// errors.Is regardless of runtime.
+	ErrNudgeUndeliverable = fmt.Errorf("tmux: %w", runtime.ErrNudgeUndeliverable)
 )
 
 const (
@@ -1768,6 +1782,235 @@ func submitEnterAndConfirm(sendEnter func() error, wake func(), busy func() (boo
 	return false, lastErr
 }
 
+// Recovery-ladder tuning. When bare re-Enter (submitEnterAndConfirm) fails to
+// confirm a submit, the composer may be wedged: a stuck insert/paste mode that
+// swallows even a human's Enter/C-m (the confirmed "session composer wedge").
+// The ladder escalates the stimulus — but only ever after PROVING the draft is
+// still sitting in the composer, and never blindly on an unobserved-busy alone.
+const (
+	// submitClearBackoff is the settle time after a C-u/Escape composer clear
+	// before the follow-up capture/Enter, so the TUI processes the mode reset
+	// first.
+	submitClearBackoff = 250 * time.Millisecond
+	// composerDraftProbeLen bounds the leading slice of the pasted message used
+	// to detect it in the captured composer. Long enough to be distinctive,
+	// short enough to sit on the prompt's own visual line (before the TUI wraps
+	// a long draft across bordered lines, which would split a longer probe).
+	composerDraftProbeLen = 40
+	// composerTailLines is how many trailing pane lines are treated as the
+	// composer region when the TUI paints no recognizable prompt glyph.
+	composerTailLines = 6
+)
+
+// submitLadder is the injected surface a recovery rung needs. Every side effect
+// is a func so the ladder's escalation logic is unit-testable without a live
+// tmux server (mirrors submitEnterAndConfirm).
+type submitLadder struct {
+	sendEnter  func() error           // press Enter (submit the current draft)
+	sendEscape func() error           // press Escape (clear a stuck insert/paste mode)
+	skipEscape bool                   // provider treats Escape as a semantic key (claude family): never synthesize it
+	clearInput func() error           // C-u: wipe the composer draft
+	repaste    func() error           // re-type/re-paste the original message
+	wake       func()                 // SIGWINCH the pane so a detached loop services input
+	busy       func() (bool, error)   // observe the agent's processing indicator
+	capture    func() (string, error) // capture the pane to inspect durable composer/draft state
+	message    string                 // the drafted text, to detect durable draft state
+	sleep      func(time.Duration)
+}
+
+// composerNoiseReplacer strips the prompt/border glyphs a TUI paints around a
+// drafted message so the draft text matches across wrapped lines and bordered
+// composers. Replacing with spaces (then collapsing) keeps token boundaries.
+var composerNoiseReplacer = strings.NewReplacer(
+	"❯", " ", "▶", " ", "│", " ", "┃", " ", "╭", " ", "╮", " ",
+	"╰", " ", "╯", " ", "─", " ", "━", " ", ">", " ",
+)
+
+// composerPromptGlyphs mark the start of an agent TUI's input line. A drafted
+// (unsubmitted) message sits AFTER the last such glyph; a submitted message
+// moves up into the transcript ABOVE it. Scoping the draft search to the region
+// after the last prompt glyph is what keeps a submitted turn's transcript echo
+// from reading as a still-drafted composer (the fast-completion false positive).
+var composerPromptGlyphs = []string{"❯", "▶"}
+
+// composerRegion returns the pane text belonging to the input composer — the
+// slice after the last prompt glyph, or the last few lines when no glyph is
+// present. Scoping here keeps a submitted message's transcript echo (which sits
+// ABOVE the composer) from being mistaken for a still-drafted composer.
+func composerRegion(pane string) string {
+	last := -1
+	for _, g := range composerPromptGlyphs {
+		if i := strings.LastIndex(pane, g); i > last {
+			last = i
+		}
+	}
+	if last >= 0 {
+		return pane[last:]
+	}
+	lines := strings.Split(strings.TrimRight(pane, "\n"), "\n")
+	if len(lines) > composerTailLines {
+		lines = lines[len(lines)-composerTailLines:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// normalizeComposerText strips prompt/border glyphs and collapses whitespace so
+// a drafted message can be matched regardless of the box the TUI draws it in.
+func normalizeComposerText(s string) string {
+	return strings.Join(strings.Fields(composerNoiseReplacer.Replace(s)), " ")
+}
+
+// composerContainsDraft reports whether the just-pasted message is STILL sitting
+// unsubmitted in the target pane's composer (a durable draft). It is the guard
+// that distinguishes a wedged composer (text still drafted) from a fast-
+// completed turn (text submitted, composer now empty) so recovery never clears
+// or re-pastes on an unobserved-busy alone. It searches only the composer region
+// (after the last prompt glyph) with glyphs stripped and whitespace collapsed,
+// against a bounded, distinctive leading slice of the message. It errs toward
+// "not drafted": an unrecognizable/empty composer reads as delivered, so the
+// destructive rungs only fire when the draft is verifiably present.
+func composerContainsDraft(pane, message string) bool {
+	probe := normalizeComposerText(message)
+	if len(probe) > composerDraftProbeLen {
+		probe = probe[:composerDraftProbeLen]
+	}
+	probe = strings.TrimSpace(probe)
+	if probe == "" {
+		return false
+	}
+	return strings.Contains(normalizeComposerText(composerRegion(pane)), probe)
+}
+
+// undeliverableUnknown wraps ErrNudgeUndeliverable for the state-unknown case: a
+// pane capture failed, so composer state cannot be observed. Recovery must never
+// advance the destructive ladder blind (that risks clearing/duplicating a live
+// turn) — it bounces instead.
+func undeliverableUnknown(err error) error {
+	return fmt.Errorf("%w: composer state unknown (capture failed: %v)", ErrNudgeUndeliverable, err)
+}
+
+// submitWithRecovery drives the escalation ladder for verify-eligible providers.
+// It STOPS gc assuming "send-keys == delivered": every rung confirms the submit
+// actually landed (pane goes busy) before reporting success, and it takes a
+// destructive action ONLY when the draft is verifiably still in the composer.
+// If the composer stays wedged, or its state cannot be observed, it returns
+// ErrNudgeUndeliverable so the caller surfaces a loud, actionable failure and
+// bounces the session instead of silently succeeding.
+//
+// Rungs:
+//
+//  1. re-Enter — the ga-bwm case: a submit Enter lost to a paste/wake race.
+//     Non-destructive; re-sent only while the pane stays idle.
+//  2. On unobserved busy, inspect DURABLE draft state (capture the pane):
+//     - capture error        -> ErrNudgeUndeliverable (state-unknown; no keys).
+//     - draft text absent     -> DELIVERED (submit landed / fast completion).
+//     - draft text present     -> the composer is wedged; escalate below.
+//  3. Escape + Enter — clear a stuck insert/paste mode, but ONLY for providers
+//     where Escape is a mode-reset (skipped for the claude family, which treats
+//     Escape as a semantic interrupt). Re-inspect draft state as in rung 2.
+//  4. C-u clear (VERIFIED) + re-paste + Enter, exactly once — wipe the wedged
+//     draft, re-capture to confirm it cleared (a failed clear -> undeliverable,
+//     NEVER a re-paste on top of a stuck draft), then re-paste cleanly and
+//     submit. A confirmed busy or a vanished draft -> delivered; otherwise
+//     ErrNudgeUndeliverable (bounce it).
+func submitWithRecovery(l submitLadder) error {
+	// Rung 1: the historical verified re-Enter. Confirmed submit -> done.
+	if confirmed, err := submitEnterAndConfirm(l.sendEnter, l.wake, l.busy, l.sleep); err != nil {
+		return err
+	} else if confirmed {
+		return nil
+	}
+
+	// Rung 2: busy was never observed. This is AMBIGUOUS — the submit may have
+	// landed and the turn already completed (fast completion), or the composer
+	// is wedged with the draft still unsubmitted. NEVER clear/re-paste on this
+	// alone (point 4). Inspect durable draft state.
+	drafted, err := composerStillDrafted(l)
+	if err != nil {
+		return err // state-unknown -> undeliverable, no destructive keys (point 2)
+	}
+	if !drafted {
+		return nil // draft gone -> submit landed / fast completion -> delivered
+	}
+
+	// Rung 3: the message is verifiably still in the composer. For providers
+	// where Escape resets a stuck insert/paste mode, try that first — but NOT
+	// for the claude family, where Escape is a semantic interrupt (point 3).
+	if !l.skipEscape && l.sendEscape != nil {
+		if err := l.sendEscape(); err != nil {
+			return err
+		}
+		l.sleep(submitClearBackoff)
+		l.wake()
+		if confirmed, err := submitEnterAndConfirm(l.sendEnter, l.wake, l.busy, l.sleep); err != nil {
+			return err
+		} else if confirmed {
+			return nil
+		}
+		drafted, err = composerStillDrafted(l)
+		if err != nil {
+			return err
+		}
+		if !drafted {
+			return nil
+		}
+	}
+
+	// Rung 4: still wedged. Wipe the draft (C-u), VERIFY it cleared, then
+	// re-paste cleanly and submit exactly once. A failed clear must never be
+	// followed by a re-paste (that stacks a duplicate on the stuck draft).
+	if l.clearInput == nil || l.repaste == nil {
+		return ErrNudgeUndeliverable
+	}
+	if err := l.clearInput(); err != nil {
+		return err
+	}
+	l.sleep(submitClearBackoff)
+	cleared, err := composerStillDrafted(l)
+	if err != nil {
+		return err // state-unknown after clear -> undeliverable, no re-paste
+	}
+	if cleared {
+		// C-u did not empty the composer: truly wedged. Do NOT re-paste on top
+		// of the stuck draft; bounce.
+		return fmt.Errorf("%w: composer clear (C-u) did not empty the draft", ErrNudgeUndeliverable)
+	}
+	if err := l.repaste(); err != nil {
+		return err
+	}
+	l.sleep(submitClearBackoff)
+	l.wake()
+	if confirmed, err := submitEnterAndConfirm(l.sendEnter, l.wake, l.busy, l.sleep); err != nil {
+		return err
+	} else if confirmed {
+		return nil
+	}
+	// Re-paste submitted but busy never observed: one last draft-state check.
+	drafted, err = composerStillDrafted(l)
+	if err != nil {
+		return err
+	}
+	if !drafted {
+		return nil // fast completion after the clean re-paste -> delivered
+	}
+	return ErrNudgeUndeliverable
+}
+
+// composerStillDrafted reports whether the pasted message is verifiably still
+// sitting in the composer. A capture error is state-unknown and surfaces as
+// ErrNudgeUndeliverable so callers never advance the destructive ladder blind.
+func composerStillDrafted(l submitLadder) (bool, error) {
+	if l.capture == nil {
+		// No way to observe the composer -> state-unknown. Refuse to guess.
+		return false, ErrNudgeUndeliverable
+	}
+	pane, err := l.capture()
+	if err != nil {
+		return false, undeliverableUnknown(err)
+	}
+	return composerContainsDraft(pane, l.message), nil
+}
+
 // paneBusy reports whether the target pane shows an active processing indicator
 // (Claude's live spinner / "esc to interrupt"). Used to confirm a submitted turn.
 func (t *Tmux) paneBusy(target string) (bool, error) {
@@ -1866,15 +2109,37 @@ func (t *Tmux) NudgeSession(session, message string) error {
 	t.WakePaneIfDetached(session)
 
 	// 5. Send Enter and, for providers with a reliable busy indicator, confirm
-	// the draft actually submitted — re-sending Enter only while the pane stays
-	// idle. A lost submit Enter (raced against the paste or a detached-pane
-	// wake) is the ga-bwm "drafted but not submitted" stall; confirming here
-	// removes the town's dependence on an external observer re-kicking the
-	// session. Providers without a reliable indicator keep best-effort delivery.
+	// the draft actually submitted — escalating a bounded recovery ladder while
+	// the pane stays idle. A lost submit Enter (raced against the paste or a
+	// detached-pane wake) is the ga-bwm "drafted but not submitted" stall
+	// (rung 1). A composer stuck in a mode that swallows even a human's Enter/C-m
+	// is the "session composer wedge": the ladder takes a destructive action
+	// (verified C-u clear + one clean re-paste) ONLY after capturing the pane and
+	// confirming the draft is still there, never on an unobserved-busy alone, and
+	// never when the pane state cannot be observed. If it still cannot confirm a
+	// submit, ErrNudgeUndeliverable is returned so the caller stops reporting the
+	// nudge delivered and a babysitter can bounce the session. On that wedge we
+	// leave `delivered` false so no poke is stamped for an undelivered nudge.
+	// Providers without a reliable indicator keep best-effort delivery.
 	sendEnter := func() error { _, err := t.run("send-keys", "-t", target, "Enter"); return err }
 	wake := func() { t.WakePaneIfDetached(session) }
 	if t.submitVerifyEligible(target) {
-		if _, err := submitEnterAndConfirm(sendEnter, wake, func() (bool, error) { return t.paneBusy(target) }, time.Sleep); err != nil {
+		ladder := submitLadder{
+			sendEnter:  sendEnter,
+			sendEscape: func() error { _, err := t.run("send-keys", "-t", target, "Escape"); return err },
+			skipEscape: !t.shouldSendEscapeBeforeEnter(target),
+			clearInput: func() error { _, err := t.run("send-keys", "-t", target, "C-u"); return err },
+			repaste:    func() error { return t.sendKeysLiteralWithRetry(target, message, t.cfg.NudgeReadyTimeout) },
+			wake:       wake,
+			busy:       func() (bool, error) { return t.paneBusy(target) },
+			capture:    func() (string, error) { return t.CapturePane(target, promptObservationLines) },
+			message:    message,
+			sleep:      time.Sleep,
+		}
+		if err := submitWithRecovery(ladder); err != nil {
+			if errors.Is(err, ErrNudgeUndeliverable) {
+				return err // surface the wedge verbatim; caller emits the loud event and bounces (delivered stays false: no poke)
+			}
 			return fmt.Errorf("failed to send Enter: %w", err)
 		}
 		delivered = true

--- a/internal/runtime/tmux/tmux_test.go
+++ b/internal/runtime/tmux/tmux_test.go
@@ -2233,7 +2233,17 @@ func TestNudgeSessionSkipsEscapeForClaude(t *testing.T) {
 	defer func() { _ = tm.KillSession(sessionName) }()
 	time.Sleep(300 * time.Millisecond)
 
-	if err := tm.NudgeSession(sessionName, "hello"); err != nil {
+	// A claude session is submit-verify-eligible, so NudgeSession drives the
+	// bounded recovery ladder (submitWithRecovery). `cat -v` echoes keystrokes
+	// but never paints Claude's busy indicator and never clears its "draft", so
+	// the ladder legitimately cannot confirm the submit and returns
+	// ErrNudgeUndeliverable — the correct #4119 "no silent success" signal for a
+	// pane that never confirms, not a test failure. This test's assertion is
+	// narrower and holds regardless: the claude family must never be sent a
+	// semantic Escape. The ladder's clear rung emits C-u (^U), never Escape
+	// (^[); a regression that un-skipped Escape for claude would paint ^[ here
+	// (rung 2 finds the draft still present on `cat -v`, then rung 3 would fire).
+	if err := tm.NudgeSession(sessionName, "hello"); err != nil && !errors.Is(err, ErrNudgeUndeliverable) {
 		t.Fatalf("NudgeSession: %v", err)
 	}
 	time.Sleep(300 * time.Millisecond)

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -626,6 +626,16 @@ func (m *Manager) nudgeSession(ctx context.Context, sessName, message string, im
 	}
 	telemetry.RecordNudge(recordCtx, sessName, err)
 	if err != nil {
+		// A wedged composer (message drafted but submit never confirmed through
+		// the provider's bounded recovery ladder, or composer state that could
+		// not be observed at all) is terminal, not transient: the session must
+		// be bounced, not nudged again. Emit the loud, distinct signal a
+		// babysitter/reconciler subscribes to so nudges don't pile up silently
+		// behind a dead composer, then surface the error so this caller stops
+		// treating the nudge as delivered.
+		if errors.Is(err, runtime.ErrNudgeUndeliverable) {
+			telemetry.RecordNudgeUndeliverable(recordCtx, sessName, err)
+		}
 		return fmt.Errorf("sending message to session: %w", err)
 	}
 	return nil

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -400,6 +400,31 @@ func RecordNudge(ctx context.Context, target string, err error) {
 	)
 }
 
+// RecordNudgeUndeliverable emits the loud "session composer wedge" signal: a
+// nudge was drafted into the target's composer but no submit was ever confirmed,
+// even after the provider's bounded recovery ladder (or the composer's state
+// could not be observed at all). Unlike a transient nudge error, this is a
+// terminal, actionable condition — the session must be BOUNCED, not nudged
+// again — so it is emitted as a distinct high-severity event a
+// babysitter/reconciler can subscribe to (rather than being lost in the noise of
+// ordinary session.nudge errors). The status label also lets the nudge counter
+// distinguish a wedged composer from a plain send failure.
+func RecordNudgeUndeliverable(ctx context.Context, target string, err error) {
+	initInstruments()
+	inst.nudgeTotal.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("target", target),
+			attribute.String("status", "undeliverable"),
+		),
+	)
+	emit(ctx, "session.nudge.undeliverable", otellog.SeverityError,
+		otellog.String("target", target),
+		otellog.String("status", "undeliverable"),
+		otellog.Bool("bounce_required", true),
+		errKV(err),
+	)
+}
+
 // RecordConfigReload records a config reload attempt (metrics + log event).
 func RecordConfigReload(ctx context.Context, revision, source, outcome string, warningCount int, err error) {
 	initInstruments()


### PR DESCRIPTION
### Symptom
4 Claude Code sessions wedged in ~36h on one deployment — a rig control-dispatcher (nudge delivery dead ~9h, 95 nudges queued), a ce-work worker mid-task, and **both coordinators (mayor + project-lead), frozen 9–12h**. In every case the delivered text lands in the TUI composer but is never submitted (`❯ <text>`); even manual `Enter`/`C-m` is swallowed; last-active freezes while the session looks `active`. Recovery was always a manual bounce.

### Root cause
The ga-bwm fix (#3910) re-sends the submit Enter while the pane stays idle — it cures a *lost* Enter but not a *swallowed* one. When the composer is stuck in an insert/paste/dialog mode (sometimes with a stray `^[` from a prior deferred-reminder delivery), no Enter submits — and `submitEnterAndConfirm` returned `(false, nil)`, which `NudgeSession` mapped to `nil`: **gc recorded the nudge as delivered**. That silent success is why nudges piled up behind a dead composer and why nothing bounced the session. The trigger is client-side (a busy/dialog TUI swallows input); gc cannot force a wedged TUI to submit — but it can stop pretending it did.

### Fix (additive, verify-or-escalate)
`submitWithRecovery` drives a confirmed escalation ladder: re-Enter → Escape-clear + Enter (unsticks the `^[`/stuck-mode class) → `C-u` wipe + re-paste + Enter. All rungs gate on idle (no double-submit). A composer wedged through every rung yields `ErrNudgeUndeliverable` instead of silent nil, and the session layer emits a high-severity `session.nudge.undeliverable` event (`bounce_required=true`) — the reconciler/operator hook to bounce the session rather than queue more dead nudges. Providers without a reliable busy indicator keep best-effort delivery unchanged.

### Proof
Unit: `TestPreFixWedgeReportedDelivered` captures the pre-fix contract (swallow-every-Enter composer → "delivered"); the ladder tests prove Escape-rung and re-paste-rung recovery + no-double-submit. Integration on real tmux 3.6: wedged composer → `ErrNudgeUndeliverable` (pre-fix `nil`); Escape-recoverable composer → delivered. Build/vet/gofmt clean; tmux/telemetry/session/runtime suites green.

### Follow-up (scoped out)
The k8s/ssh `tmuxCarrier.Nudge` still fire-and-forgets Enter with no busy-observation seam — same treatment there is a natural next change.

### Refs
ga-bwm / #3910 (the incomplete verify this extends); #1216, #1275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)