### PR TITLE
fix(api): bound /status scoped-store resolution by the read timeout

### DIFF
--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -446,21 +446,12 @@ func (s *Server) statusSessionSnapshot(ctx context.Context) statusSessionSnapsho
 		return snapshot
 	}
 
-	// A throwaway, ctx-bound clone of store when it's bd-CLI-backed: on
-	// timeout below, canceling reqCtx kills an in-flight bd child instead
-	// of abandoning it to run past this function's return (gascity
-	// ga-cdmx6x). ScopedStoreLike answers (nil, nil) for non-bd-CLI
-	// backends, which have no subprocess to leak — those keep reading
-	// through store directly, unchanged.
+	// reqCtx bounds the scoped-store read below; defer cancel() fires on
+	// every return path (including the time.After timeout), killing an
+	// in-flight bd child instead of leaking it past this function's budget
+	// (gascity ga-cdmx6x).
 	reqCtx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
 	defer cancel()
-	readStore := store
-	if scoped, err := s.state.ScopedStoreLike(reqCtx, store); err != nil {
-		snapshot.partialErrors = []string{fmt.Sprintf("sessions: resolving scoped store: %v", err)}
-		return snapshot
-	} else if scoped != nil {
-		readStore = scoped
-	}
 
 	type snapshotResult struct {
 		rows          []beads.Bead
@@ -469,6 +460,22 @@ func (s *Server) statusSessionSnapshot(ctx context.Context) statusSessionSnapsho
 	}
 	done := make(chan snapshotResult, 1)
 	go func() {
+		// Resolve the ctx-bound scoped store INSIDE the timed goroutine.
+		// ScopedStoreLike hands back a bd-CLI-backed clone reqCtx can cancel,
+		// or (nil, nil) for non-bd backends (native/file/mem) — those read
+		// through store unchanged. Its resolution (bd env / managed-dolt
+		// connection state) is synchronous and can block on a mutex the
+		// reconcile loop holds without honoring reqCtx; kept before the select
+		// it hung the whole handler past its read budget, dragging the
+		// supervisor loop (gc-08qgn). Under the goroutine the same time.After
+		// as the read bounds it.
+		readStore := store
+		if scoped, err := s.state.ScopedStoreLike(reqCtx, store); err != nil {
+			done <- snapshotResult{err: fmt.Errorf("resolving scoped store: %w", err)}
+			return
+		} else if scoped != nil {
+			readStore = scoped
+		}
 		rows, partialErrors, err := sessionReadModelRows(readStore)
 		done <- snapshotResult{rows: rows, partialErrors: partialErrors, err: err}
 	}()
@@ -643,18 +650,23 @@ func statusListStoreWithTimeout(ctx context.Context, state State, store beads.St
 	}
 	reqCtx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
 	defer cancel()
-	readStore := store
-	if scoped, err := state.ScopedStoreLike(reqCtx, store); err != nil {
-		return nil, fmt.Errorf("resolving scoped store: %w", err)
-	} else if scoped != nil {
-		readStore = scoped
-	}
 	type listResult struct {
 		rows []beads.Bead
 		err  error
 	}
 	done := make(chan listResult, 1)
 	go func() {
+		// Resolve the ctx-bound scoped store INSIDE the timed goroutine so a
+		// slow, ctx-blind resolution (a store mutex held by the reconcile
+		// loop) is bounded by the same time.After as the list instead of
+		// hanging the handler synchronously (gc-08qgn).
+		readStore := store
+		if scoped, err := state.ScopedStoreLike(reqCtx, store); err != nil {
+			done <- listResult{err: fmt.Errorf("resolving scoped store: %w", err)}
+			return
+		} else if scoped != nil {
+			readStore = scoped
+		}
 		rows, err := readStore.List(query)
 		done <- listResult{rows: rows, err: err}
 	}()

--- a/internal/api/handler_status_scoped_store_test.go
+++ b/internal/api/handler_status_scoped_store_test.go
@@ -263,6 +263,63 @@ func TestStatusListStoreWithTimeoutKillsBdChildOnTimeout(t *testing.T) {
 	t.Fatalf("bd child process %s survived statusListStoreWithTimeout's timeout", childPid)
 }
 
+// TestStatusSessionSnapshotBoundsSlowScopedStoreResolution proves the
+// scoped-store *resolution* itself (not just the read through it) is bounded
+// by statusStoreReadTimeout. ScopedStoreLike resolves the bd env / managed-
+// dolt connection state synchronously, and that work can block on a mutex the
+// reconcile loop holds without honoring the request ctx (gc-08qgn: /status
+// hung ~20s-2min dragging the supervisor loop). A resolution that ignores ctx
+// must still not hang the handler past its own read budget.
+func TestStatusSessionSnapshotBoundsSlowScopedStoreResolution(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	// Block for far longer than statusStoreReadTimeout WITHOUT honoring ctx,
+	// mirroring a ctx-blind mutex acquire in the real env/store resolution.
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		time.Sleep(3 * time.Second)
+		return nil, nil
+	}
+	s := &Server{state: state}
+
+	start := time.Now()
+	snapshot := s.statusSessionSnapshot(context.Background())
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("statusSessionSnapshot blocked %s on scoped-store resolution; want bounded by statusStoreReadTimeout", elapsed)
+	}
+	joined := strings.Join(snapshot.partialErrors, "; ")
+	if !strings.Contains(joined, "timed out") {
+		t.Fatalf("partialErrors = %v, want a timed-out entry when resolution exceeds the budget", snapshot.partialErrors)
+	}
+}
+
+// TestStatusListStoreWithTimeoutBoundsSlowScopedStoreResolution is the
+// per-rig work-count analog of the above: a slow, ctx-blind ScopedStoreLike
+// resolution must not hang statusListStoreWithTimeout past its read budget.
+func TestStatusListStoreWithTimeoutBoundsSlowScopedStoreResolution(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	state := newFakeState(t)
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		time.Sleep(3 * time.Second)
+		return nil, nil
+	}
+
+	start := time.Now()
+	_, err := statusListStoreWithTimeout(context.Background(), state, beads.NewMemStore(), beads.ListQuery{AllowScan: true})
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("statusListStoreWithTimeout blocked %s on scoped-store resolution; want bounded by statusStoreReadTimeout", elapsed)
+	}
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("statusListStoreWithTimeout error = %v, want a timed-out error when resolution exceeds the budget", err)
+	}
+}
+
 func writeExecutableScopedTest(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {


### PR DESCRIPTION
## Problem

`GET /v0/city/status` resolved its ctx-bound scoped store via `state.ScopedStoreLike(reqCtx, store)` synchronously, before the `select` + `time.After(statusStoreReadTimeout)` guard that bounds the read. `reqCtx` carries the timeout but only binds the resulting bd subprocess runner; the resolution work itself (bd env and managed-dolt connection-state reads, plus any mutex the reconcile loop holds) does not honor `reqCtx`. A slow resolution hung the handler for roughly 20s to 2min, which dragged the supervisor reconcile/dispatch loop along with it.

## Fix

Move the `ScopedStoreLike` call into the already-existing timed goroutine at both call sites, `statusSessionSnapshot` and `statusListStoreWithTimeout`, so the same `time.After` budget bounds resolve and read together. On timeout the handler returns a partial/timeout error within `statusStoreReadTimeout` instead of blocking. The subprocess-kill contract is preserved: `defer cancel()` still fires on every return path, so an in-flight bd child is killed rather than leaked past the function's budget.

## Test Plan

Two regression tests pin a ctx-blind, slow `ScopedStoreLike` resolution to the read budget:

- `TestStatusSessionSnapshotBoundsSlowScopedStoreResolution` drives a resolution that sleeps 3s while `statusStoreReadTimeout` is 200ms and asserts the snapshot returns bounded with a timed-out partial error.
- `TestStatusListStoreWithTimeoutBoundsSlowScopedStoreResolution` is the per-rig work-count analog, asserting a bounded return with a timed-out error.

- `make build`: pass.
- `make check` (lint, vet, full suite): pass.
- go-reviewer clean under `-race`.
