### PR TITLE
fix(molecule): drop deadlocking finalize->root tracks edge for single-step v2 workflows

### DIFF
--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -286,8 +286,21 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 	// through the dependency graph without making the workflow root a
 	// readiness blocker for finalizers and teardown work.
 	if graphWorkflow && rootKey != "" {
+		singleStep := graphWorkflowIsSingleStep(plan.Nodes, rootKey)
 		for _, node := range plan.Nodes {
 			if node.Key == rootKey {
+				continue
+			}
+			// Single-step workflows deadlock if the generated workflow-finalize
+			// gains a "tracks" edge back to the root: the compiler already emits
+			// root --blocks--> workflow-finalize (addWorkflowRootDeps), so a
+			// workflow-finalize --tracks--> root edge closes a mutual finalize
+			// <-> root cycle that neither controller-managed bead can ever
+			// break — both stay open forever (su-mla5h). The root already
+			// reaches the finalizer through that blocks edge and the finalizer
+			// carries gc.root_bead_id, so the ownership tracks edge is redundant
+			// here. Multi-step workflows keep the tracks edge unchanged.
+			if singleStep && node.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflowFinalize {
 				continue
 			}
 			if graphApplyPlanHasEdgeFromKeyToTarget(plan.Edges, node.Key, rootKey, "") {
@@ -329,6 +342,30 @@ func ensureGraphNodeMetadata(node *beads.GraphApplyNode) {
 	if node.Metadata == nil {
 		node.Metadata = make(map[string]string, 1)
 	}
+}
+
+// graphWorkflowIsSingleStep reports whether a graph workflow plan carries a
+// single worker-executed step. Control beads (workflow-finalize, scope-check,
+// fanout, ...) and spec sidecars are compiler-generated scaffolding, not
+// authored work, so they are excluded from the count. A single-step workflow
+// is the shape that deadlocks on the generated finalize <-> root edge pair
+// (su-mla5h).
+func graphWorkflowIsSingleStep(nodes []beads.GraphApplyNode, rootKey string) bool {
+	workSteps := 0
+	for _, node := range nodes {
+		if node.Key == rootKey {
+			continue
+		}
+		kind := node.Metadata[beadmeta.KindMetadataKey]
+		if beadmeta.IsControlKind(kind) || kind == beadmeta.KindSpec {
+			continue
+		}
+		workSteps++
+		if workSteps > 1 {
+			return false
+		}
+	}
+	return workSteps == 1
 }
 
 func graphApplyPlanHasEdgeFromKeyToTarget(edges []beads.GraphApplyEdge, fromKey, toKey, toID string) bool {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -775,16 +775,23 @@ func TestIsTransientGraphApplyErrorTreatsCommandTimeoutAsTransient(t *testing.T)
 }
 
 func TestBuildRecipeApplyPlan_GraphWorkflowOwnershipUsesTracks(t *testing.T) {
+	// Multi-step workflow (two authored work nodes): every non-root node,
+	// including the generated workflow-finalize, gains a "tracks" ownership
+	// edge back to the root. Single-step workflows drop the finalize edge to
+	// avoid the finalize <-> root deadlock (su-mla5h); see
+	// TestBuildRecipeApplyPlan_SingleStepOmitsFinalizeRootTracks.
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
 			{ID: "wf", Title: "Workflow", Type: "task", IsRoot: true, Metadata: map[string]string{"gc.kind": "workflow"}},
 			{ID: "wf.body", Title: "Body", Type: "task", Metadata: map[string]string{"gc.kind": "scope"}},
+			{ID: "wf.body2", Title: "Body 2", Type: "task", Metadata: map[string]string{"gc.kind": "scope"}},
 			{ID: "wf.workflow-finalize", Title: "Finalize", Type: "task", Metadata: map[string]string{"gc.kind": "workflow-finalize"}},
 		},
 		Deps: []formula.RecipeDep{
 			{StepID: "wf", DependsOnID: "wf.workflow-finalize", Type: "blocks"},
 			{StepID: "wf.workflow-finalize", DependsOnID: "wf.body", Type: "blocks"},
+			{StepID: "wf.workflow-finalize", DependsOnID: "wf.body2", Type: "blocks"},
 		},
 	}
 
@@ -824,6 +831,64 @@ func TestBuildRecipeApplyPlan_GraphWorkflowOwnershipUsesTracks(t *testing.T) {
 	}
 	if !finalizeTracksRoot {
 		t.Fatal("missing workflow-finalize -> root tracks ownership edge")
+	}
+}
+
+// TestBuildRecipeApplyPlan_SingleStepOmitsFinalizeRootTracks regresses the
+// single-step graph-workflow deadlock (su-mla5h). The v2 compiler emits
+// root --blocks--> workflow-finalize for every graph workflow. When the
+// workflow also gains a workflow-finalize --tracks--> root ownership edge, the
+// two controller-managed beads form a mutual finalize <-> root cycle that
+// never resolves: neither the finalizer nor the root can close because each
+// depends on the other, so both strand open until force-closed. A single
+// authored work step is the shape that recurred in production
+// (mol-superlzy-capture). The finalizer must not gain the tracks edge here,
+// while the lone work step still tracks the root and the root still blocks on
+// the finalizer.
+func TestBuildRecipeApplyPlan_SingleStepOmitsFinalizeRootTracks(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{ID: "wf", Title: "Workflow", Type: "task", IsRoot: true, Metadata: map[string]string{"gc.kind": "workflow"}},
+			{ID: "wf.review", Title: "Review", Type: "task"},
+			{ID: "wf.workflow-finalize", Title: "Finalize", Type: "task", Metadata: map[string]string{"gc.kind": "workflow-finalize"}},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf", DependsOnID: "wf.workflow-finalize", Type: "blocks"},
+			{StepID: "wf.workflow-finalize", DependsOnID: "wf.review", Type: "blocks"},
+		},
+	}
+
+	plan, graphWorkflow, rootKey, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	if !graphWorkflow || rootKey != "wf" {
+		t.Fatalf("graphWorkflow=%v rootKey=%q, want true/wf", graphWorkflow, rootKey)
+	}
+
+	var rootBlocksFinalize bool
+	var reviewTracksRoot bool
+	var finalizeTracksRoot bool
+	for _, edge := range plan.Edges {
+		if edge.FromKey == "wf" && edge.ToKey == "wf.workflow-finalize" && edge.Type == "blocks" {
+			rootBlocksFinalize = true
+		}
+		if edge.FromKey == "wf.review" && edge.ToKey == "wf" && edge.Type == "tracks" {
+			reviewTracksRoot = true
+		}
+		if edge.FromKey == "wf.workflow-finalize" && edge.ToKey == "wf" && edge.Type == "tracks" {
+			finalizeTracksRoot = true
+		}
+	}
+	if !rootBlocksFinalize {
+		t.Fatal("missing root -> workflow-finalize blocks edge (workflow must still block on its finalizer)")
+	}
+	if !reviewTracksRoot {
+		t.Fatal("missing review -> root tracks ownership edge (the lone work step must still track the root)")
+	}
+	if finalizeTracksRoot {
+		t.Fatal("single-step workflow emitted a deadlocking workflow-finalize -> root tracks edge (su-mla5h)")
 	}
 }
 


### PR DESCRIPTION
## Problem

The v2 graph compiler builds a mutual finalize↔root 2-cycle: `root --blocks--> workflow-finalize` (from `internal/formula/compile.go`) plus `workflow-finalize --tracks--> root` (from `buildRecipeApplyPlan` in `internal/molecule/graph_apply.go`). For **single-step molecules** both beads are controller-managed, so nothing ever breaks the cycle → the workflow deadlocks: the finalize bead depends on its own still-in_progress root, is never `bd ready`, registers no demand, and the drain-at-zero dispatcher scales to zero with the root wedged OPEN even though the real work shipped.

Observed repeatedly in production on single-step formula invocations (4+ occurrences in two days, each requiring a manual force-close of both the finalize and root beads).

## Fix

`graph_apply.go` now skips the finalize→root `tracks` edge when the workflow has exactly one work step (new helper `graphWorkflowIsSingleStep`). Multi-step workflows are untouched.

## Tests

Regression test in `internal/molecule/molecule_test.go` (fails-before/passes-after). `go build ./...` clean; molecule/formula/dispatch test packages pass. Re-validated after rebasing onto current main.

## Caveats

- The 2-cycle is generated for ALL v2 workflows; this fix is deliberately scoped to the single-step case that demonstrably deadlocks. Why multi-step workflows escape the deadlock at runtime was not re-verified as part of this change.
