### PR TITLE
fix(dolt-cleanup): resolve DROP-stage user via GC_DOLT_USER instead of hardcoded root (#4123)

### DIFF
--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -914,7 +914,7 @@ can still return successfully after emitting the report.`,
 				host = "127.0.0.1"
 			}
 			if fatalPortResolutionError(resolution) == nil {
-				client, openErr := newSQLCleanupDoltClient(host, strconv.Itoa(resolution.Port))
+				client, openErr := newSQLCleanupDoltClient(cityPath, host, strconv.Itoa(resolution.Port))
 				if openErr != nil {
 					opts.DoltClientOpenErr = openErr
 				} else {

--- a/cmd/gc/dolt_cleanup_drop.go
+++ b/cmd/gc/dolt_cleanup_drop.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/doltauth"
 )
 
 // CleanupDoltClient is the SQL surface the cleanup engine needs. The
@@ -175,10 +178,24 @@ type sqlCleanupDoltClient struct {
 	db *sql.DB
 }
 
+// resolveCleanupDoltUser returns the Dolt user the cleanup engine's DROP
+// stage should authenticate as for cityPath. It honors GC_DOLT_USER (set
+// for external-Dolt endpoints authed as a non-root user) and falls back to
+// "root", which is correct for the managed-local Dolt server this city
+// provisions itself.
+func resolveCleanupDoltUser(cityPath, host string, port int) string {
+	return doltauth.Resolve(cityPath, "root", host, port).User
+}
+
 // newSQLCleanupDoltClient opens a connection to the resolved Dolt server.
 // Caller must Close() when done.
-func newSQLCleanupDoltClient(host, port string) (CleanupDoltClient, error) {
-	db, err := managedDoltOpenDB(host, port, "root")
+func newSQLCleanupDoltClient(cityPath, host, port string) (CleanupDoltClient, error) {
+	portNum, err := strconv.Atoi(strings.TrimSpace(port))
+	if err != nil {
+		return nil, fmt.Errorf("invalid dolt port %q: %w", port, err)
+	}
+	user := resolveCleanupDoltUser(cityPath, host, portNum)
+	db, err := managedDoltOpenDB(host, port, user)
 	if err != nil {
 		return nil, fmt.Errorf("open dolt connection: %w", err)
 	}

--- a/cmd/gc/dolt_cleanup_drop_test.go
+++ b/cmd/gc/dolt_cleanup_drop_test.go
@@ -614,3 +614,29 @@ func TestPSEnumerationTimeoutExceedsProcEnumerationTimeout(t *testing.T) {
 			psEnumerationTimeout, procEnumerationTimeout)
 	}
 }
+
+// TestResolveCleanupDoltUserHonorsGCDoltUserEnv is a regression guard for
+// gascity#4123: the DROP stage's SQL client hardcoded "root" regardless of
+// the resolved external-Dolt credentials, so every DROP-stage query on an
+// external endpoint (authed as a non-root user like GC_DOLT_USER=superlzy)
+// failed with "Access denied for user 'root'" even though the same city's
+// `gc dolt sql` connections succeeded. The SCAN/list stage shares this same
+// client, so the failure surfaces on the very first ListDatabases call.
+func TestResolveCleanupDoltUserHonorsGCDoltUserEnv(t *testing.T) {
+	t.Setenv("GC_DOLT_USER", "superlzy")
+	got := resolveCleanupDoltUser(t.TempDir(), "127.0.0.1", 3306)
+	if got != "superlzy" {
+		t.Fatalf("resolveCleanupDoltUser() = %q, want %q", got, "superlzy")
+	}
+}
+
+// TestResolveCleanupDoltUserDefaultsToRootWhenUnset preserves today's
+// correct behavior for the managed-local Dolt server, which always
+// provisions a root user and has no GC_DOLT_USER override.
+func TestResolveCleanupDoltUserDefaultsToRootWhenUnset(t *testing.T) {
+	t.Setenv("GC_DOLT_USER", "")
+	got := resolveCleanupDoltUser(t.TempDir(), "127.0.0.1", 3306)
+	if got != "root" {
+		t.Fatalf("resolveCleanupDoltUser() = %q, want %q", got, "root")
+	}
+}


### PR DESCRIPTION
Fixes #4123.

**Bug:** `newSQLCleanupDoltClient` (the `gc dolt-cleanup` DROP stage's SQL client) hardcoded `"root"` for its connection regardless of the resolved external-Dolt credentials. On a city configured against an external Dolt endpoint authed as a non-root user (`GC_DOLT_USER=superlzy` in the report), every DROP-stage query — starting with the very first `ListDatabases`/`SHOW DATABASES` call, since the scan and drop stages share this one client — failed with `Access denied for user 'root'`, even though the same city's `gc dolt sql` connections succeeded with the correctly resolved user. The result was a spurious `errors_total=1` on every cleanup run with genuinely nothing to drop (`dropped.count=0`, `force_blockers=[]`), which `mol-dog-stale-db`'s escalate-on-error branch treats as a real problem — firing repeated identical escalation mails and re-opened work beads every ~4-hourly cleanup cycle for a condition that doesn't exist. The reporter had to disable the `mol-dog-*` orders on the affected city to quiet the board.

**Fix:** extracted `resolveCleanupDoltUser(cityPath, host, port)`, which mirrors the `doltauth.Resolve` pattern already used at other Dolt connection sites (e.g. `internal/api/convoy_sql.go`'s `resolveDoltConnection`): honor `GC_DOLT_USER` when set, fall back to `"root"` otherwise — which is correct and unchanged for the managed-local Dolt server this city provisions itself (it always grants root; `GC_DOLT_USER` is never set in that case). `password` resolution is untouched — `managedDoltOpenDB`'s existing `GC_DOLT_PASSWORD` env read already worked correctly per the report (no password error was ever surfaced, only the username).

**Test:** `TestResolveCleanupDoltUserHonorsGCDoltUserEnv` and `TestResolveCleanupDoltUserDefaultsToRootWhenUnset` — unit-test the extracted resolution function directly (pure, no live Dolt server needed) rather than the DB-opening side effect, which isn't practically assertable without a real connection. TDD RED confirmed: before extracting the function, both new tests failed to compile (`undefined: resolveCleanupDoltUser`); GREEN after.

## Validation

`-tags gms_pure_go`: `gofmt -l` clean, `go build ./...` clean, `go vet ./cmd/gc/...` clean. Targeted dolt-cleanup suite green (`TestResolveCleanupDoltUser*`, `TestRunDropStage*`, `TestPlanDoltDrops*`, `TestDoltCleanup*`, `TestCleanup*` — all pass). Full `cmd/gc` package run hit one panic in `TestScanAllOrdersRemoteImportedFlatPackOrders` (`internal/packman.EnsureRepoInCache`, a remote-pack-cache fetch test) — reproduced in isolation and it passed cleanly (0.75s), and that code path is fully disjoint from the two files this diff touches (`cmd/gc/dolt_cleanup_drop.go`, `cmd/gc/cmd_dolt_cleanup.go`). Judged as pre-existing shared-cache flakiness under full-package parallelism on this host, not something this diff introduced.

Verify-still-live: confirmed the bug is present on current `upstream/main` (`git show upstream/main:cmd/gc/dolt_cleanup_drop.go` shows the unconditional `managedDoltOpenDB(host, port, "root")` literal) before building.