### PR TITLE
fix(dispatch): recover Ralph checks from stale work directories

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2068,6 +2068,79 @@ func TestQuarantineControlFailureBeadClosesWithDiagnostics(t *testing.T) {
 	}
 }
 
+func TestQuarantineControlFailureBeadAbortsScopeBeforeDependencyCanRun(t *testing.T) {
+	store := beads.NewMemStore()
+	create := func(bead beads.Bead) beads.Bead {
+		t.Helper()
+		created, err := store.Create(bead)
+		if err != nil {
+			t.Fatalf("create %q: %v", bead.Title, err)
+		}
+		return created
+	}
+	body := create(beads.Bead{
+		Title: "workflow scope",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": "wf-1",
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	control := create(beads.Bead{
+		Title:  "required validator",
+		Type:   "task",
+		Status: "open",
+		Labels: []string{"gc:control"},
+		Metadata: map[string]string{
+			"gc.kind":         "check",
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	downstream := create(beads.Bead{
+		Title: "downstream work",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.on_fail":      "abort_scope",
+		},
+	})
+	for _, dep := range []beads.Dep{
+		{IssueID: body.ID, DependsOnID: control.ID, Type: "blocks"},
+		{IssueID: downstream.ID, DependsOnID: control.ID, Type: "blocks"},
+	} {
+		if err := store.DepAdd(dep.IssueID, dep.DependsOnID, dep.Type); err != nil {
+			t.Fatalf("add dependency %+v: %v", dep, err)
+		}
+	}
+
+	if err := quarantineControlFailureBead(store, control.ID, errors.New("validator infrastructure failed")); err != nil {
+		t.Fatalf("quarantineControlFailureBead: %v", err)
+	}
+
+	got, err := store.Get(downstream.ID)
+	if err != nil {
+		t.Fatalf("get downstream: %v", err)
+	}
+	if got.Status != "closed" || got.Metadata["gc.outcome"] != "skipped" {
+		t.Fatalf("downstream = status %q outcome %q, want closed/skipped", got.Status, got.Metadata["gc.outcome"])
+	}
+	ready, err := store.Ready()
+	if err != nil {
+		t.Fatalf("ready: %v", err)
+	}
+	for _, bead := range ready {
+		if bead.ID == downstream.ID {
+			t.Fatalf("quarantined required control made downstream %s ready", downstream.ID)
+		}
+	}
+}
+
 func TestQuarantineControlFailureBeadTruncatesReasonAtUTF8Boundary(t *testing.T) {
 	store := beads.NewMemStore()
 	control, err := store.Create(beads.Bead{

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -211,6 +212,21 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		// trusted roots below; for those, work_dir is only the process cwd.
 		if !filepath.IsAbs(checkPath) && !pathutil.PathWithin(cityPath, resolvedWorkDir) && !pathutil.PathWithin(storePath, resolvedWorkDir) {
 			return convergence.GateResult{}, fmt.Errorf("%s: work_dir %q escapes both city and store roots", bead.ID, workDir)
+		}
+		// gc.work_dir can outlive the transient worker directory it names. A
+		// missing inherited directory must not remain the check process cwd:
+		// even when the script can be recovered from the stable store root,
+		// exec would otherwise fail while changing into the stale directory.
+		// Treat only a genuinely missing path as absent. Other stat failures
+		// and non-directories remain configuration errors and fail closed.
+		info, statErr := os.Stat(resolvedWorkDir)
+		switch {
+		case errors.Is(statErr, fs.ErrNotExist):
+			resolvedWorkDir = ""
+		case statErr != nil:
+			return convergence.GateResult{}, fmt.Errorf("%s: inspecting work_dir %q: %w", bead.ID, workDir, statErr)
+		case !info.IsDir():
+			return convergence.GateResult{}, fmt.Errorf("%s: work_dir %q is not a directory", bead.ID, workDir)
 		}
 	}
 	scriptBase := storePath

--- a/internal/dispatch/ralph_test.go
+++ b/internal/dispatch/ralph_test.go
@@ -200,6 +200,55 @@ func TestRunRalphCheckPackRelativeCheckPathWorkDirFallback(t *testing.T) {
 	}
 }
 
+// TestRunRalphCheckMissingWorkDirFallsBackToStableCWD covers
+// gastownhall/gascity#4128: a transient worker directory may be removed while
+// its inherited gc.work_dir remains on the workflow. Resolving the script from
+// the stable store root is insufficient if exec still tries to chdir into the
+// vanished directory.
+func TestRunRalphCheckMissingWorkDirFallsBackToStableCWD(t *testing.T) {
+	cityPath := t.TempDir()
+	checkRel := filepath.Join("assets", "demo-pack", "scripts", "check.sh")
+	storeScript := filepath.Join(cityPath, checkRel)
+	if err := os.MkdirAll(filepath.Dir(storeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(storeScript, []byte("#!/bin/sh\nprintf 'cwd=%s\\n' \"$PWD\"\nprintf 'work_dir=%s\\n' \"${GC_WORK_DIR-unset}\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missingWorkDir := filepath.Join(cityPath, "worktrees", "removed-worker")
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.check_path":   filepath.ToSlash(checkRel),
+			"gc.work_dir":     missingWorkDir,
+			"gc.max_attempts": "3",
+		},
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+
+	result, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass", result.Outcome, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "cwd="+cityPath+"\n") {
+		t.Fatalf("stdout = %q, want stable cwd %q", result.Stdout, cityPath)
+	}
+	if !strings.Contains(result.Stdout, "work_dir=unset\n") {
+		t.Fatalf("stdout = %q, want stale GC_WORK_DIR omitted", result.Stdout)
+	}
+}
+
 // TestRunRalphCheckWorkDirRelativeCheckPathKeepsPrecedence guards that the
 // #3008 fallback only fires when the work_dir join is missing: a check_path
 // that DOES exist under the worktree must still resolve against the worktree,


### PR DESCRIPTION
## Summary

- validate inherited `gc.work_dir` values before using them as a Ralph check resolution base or subprocess cwd
- treat only a genuinely missing transient directory as absent, falling back to the stable store root and omitting stale `GC_WORK_DIR`
- preserve containment checks and existing workdir-local script precedence while failing closed for stat errors and non-directories
- add regressions for stable cwd/environment selection and for quarantined scoped controls keeping downstream work unclaimable

This completes the path fallback introduced by #3782: resolving a validator from `storePath` no longer leaves `cmd.Dir` pointed at a deleted session directory.

## Tests

- `go test ./internal/dispatch ./internal/convergence`
- `go test ./cmd/gc -run 'TestQuarantineControlFailureBead(ClosesWithDiagnostics|AbortsScopeBeforeDependencyCanRun)$'`\n\nFixes #4128.\n\nCompanion pack fix: gastownhall/gascity-packs#194.