### PR TITLE
fix: scaffold default agents on Windows (init prompt template path)

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -757,7 +757,10 @@ func normalizeBootstrapProfile(profile string) (string, error) {
 }
 
 func initPromptTemplatePath(templatePath string) (string, bool) {
-	if !strings.HasPrefix(templatePath, citylayout.PromptsRoot+string(filepath.Separator)) {
+	// Template paths come from embedded config and are always slash-separated,
+	// so compare against "/" rather than the OS separator (which is `\` on
+	// Windows and silently skipped every scaffold there).
+	if !strings.HasPrefix(filepath.ToSlash(templatePath), citylayout.PromptsRoot+"/") {
 		return "", false
 	}
 	base := filepath.Base(templatePath)

--- a/cmd/gc/init_prompt_template_path_test.go
+++ b/cmd/gc/init_prompt_template_path_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+)
+
+// TestInitPromptTemplatePath verifies that embedded prompt-template paths
+// resolve to their scaffolded agent destination on every OS.
+//
+// Regression test for a Windows-only bug: the prefix check compared the
+// always-slash embedded path (e.g. "prompts/mayor.md") against
+// citylayout.PromptsRoot+filepath.Separator, which is "prompts\\" on Windows.
+// The prefix never matched, so initPromptTemplatePath returned ("", false) and
+// every default-agent scaffold was silently skipped — the mayor named-session
+// ended up with no backing prompt template. The "os-native separator path"
+// case exercises exactly that path shape and fails on the pre-fix code on
+// Windows while passing on all platforms after the fix.
+func TestInitPromptTemplatePath(t *testing.T) {
+	wantMayor := filepath.Join("agents", "mayor", "prompt.template.md")
+
+	tests := []struct {
+		name     string
+		input    string
+		wantPath string
+		wantOK   bool
+	}{
+		{
+			name:     "canonical slash path (embedded-config shape)",
+			input:    citylayout.PromptsRoot + "/mayor.md",
+			wantPath: wantMayor,
+			wantOK:   true,
+		},
+		{
+			name:     "os-native separator path",
+			input:    filepath.Join(citylayout.PromptsRoot, "mayor.md"),
+			wantPath: wantMayor,
+			wantOK:   true,
+		},
+		{
+			name:     "canonical template suffix",
+			input:    citylayout.PromptsRoot + "/mayor.template.md",
+			wantPath: wantMayor,
+			wantOK:   true,
+		},
+		{
+			name:   "outside prompts root",
+			input:  "other/mayor.md",
+			wantOK: false,
+		},
+		{
+			name:   "prompts root but unsupported suffix",
+			input:  citylayout.PromptsRoot + "/notes.txt",
+			wantOK: false,
+		},
+		{
+			name:   "empty base after stripping suffix",
+			input:  citylayout.PromptsRoot + "/.md",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := initPromptTemplatePath(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("initPromptTemplatePath(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if ok && got != tt.wantPath {
+				t.Fatalf("initPromptTemplatePath(%q) = %q, want %q", tt.input, got, tt.wantPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`initPromptTemplatePath` decided whether a config's `PromptTemplate` points into
the embedded prompts tree by comparing it against
`citylayout.PromptsRoot + string(filepath.Separator)`. The template paths come
from embedded config and are **always slash-separated** (e.g.
`prompts/mayor.md`), but `filepath.Separator` is `\` on Windows — so the prefix
`prompts\` never matched the slash path.

The result: during `gc init` on Windows, `rewriteInitPromptTemplatePath` skipped
**every** default-agent scaffold, so the mayor named-session was created with no
backing `prompt.template.md`.

Fix: normalize the input with `filepath.ToSlash` and compare against a literal
`"/"`. This is a no-op on Linux/macOS (where `filepath.Separator` is already
`/`) and makes the check correct on Windows.

## Testing

Ran in a Linux `golang:1.26` container with `libicu-dev` (matching the CGO/ICU
toolchain the CI setup installs), scoped to the affected package:

- `go test ./cmd/gc/ -run TestInitPromptTemplatePath` — passes (6 cases)
- `go vet ./cmd/gc/` — clean
- `gofmt -l` on the changed files — clean
- `go build ./...` — clean

I did not run the full `make check` locally (my dev box is Windows and can't
build the upstream tree pre-port); I'm relying on CI for the tree-wide
lint/vet/test gate.

- [ ] `make check` — deferred to CI (see note above)
- [ ] `make check-docs` — no docs/nav/link changes
- [ ] `make test-integration` — no runtime/controller/workflow behavior change

## Note on the test

The bug is Windows-only. On Linux/macOS `filepath.Separator == '/'`, so the pre-
and post-fix code are behaviorally identical there and a Linux-run test cannot
distinguish them. The added table test therefore serves two roles: it documents
the contract on all platforms, and its `os-native separator path` case (built
with `filepath.Join`) actively guards the regression on Windows runners. Happy
to adjust if you'd prefer a `//go:build windows` variant instead.

## Checklist

- [x] Added a test for the behavior change
- [ ] No user-facing docs affected
- [ ] No breaking changes
- **Issue:** not filed — small, self-contained Windows correctness fix. Happy to
  open a tracking issue if you'd prefer one linked.
