### PR TITLE
fix(session): gc session attach waits for an in-flight controller reset instead of racing it (#4079)

### DIFF
--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -347,6 +347,32 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 		}
 		return nil
 	}
+	// The runtime is not running. If a controller-driven reset is already
+	// in flight for this session (durable continuation_reset_pending
+	// marker, cleared by PreWakePatch only immediately before the
+	// reconciler's own fresh Start), wait for it instead of independently
+	// starting a second, uncoordinated runtime — the reconciler runs in a
+	// separate long-lived controller process, so withSessionMutationLock
+	// (in-process only) cannot serialize against it (#4079).
+	if strings.TrimSpace(b.Metadata["continuation_reset_pending"]) == "true" {
+		landed, fresh, err := m.waitForInFlightReset(ctx, id, sessName)
+		if err != nil {
+			return err
+		}
+		if landed {
+			b = fresh
+			if b.Metadata["transport"] == "" && transportVerified {
+				m.persistTransport(id, b.Metadata["provider"], transport)
+			}
+			if err := m.confirmLiveSessionState(id, &b); err != nil {
+				return err
+			}
+			return nil
+		}
+		// Timed out — the controller-driven reset itself appears stalled.
+		// Fall through to the existing independent-start behavior below
+		// rather than hang gc session attach indefinitely.
+	}
 	if resumeCommand == "" {
 		return fmt.Errorf("%w: %s", ErrResumeRequired, id)
 	}
@@ -458,6 +484,39 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 		return err
 	}
 	return nil
+}
+
+// inFlightResetPollInterval and inFlightResetWaitTimeout bound how long
+// waitForInFlightReset polls for a controller-driven reset to land before
+// giving up and letting the caller start the runtime itself. Declared as
+// vars (not consts) so tests can shrink them.
+var (
+	inFlightResetPollInterval = 200 * time.Millisecond
+	inFlightResetWaitTimeout  = 5 * time.Second
+)
+
+// waitForInFlightReset polls for a controller-driven reset already in
+// flight for id (continuation_reset_pending=="true") to complete, instead
+// of racing it with an independent Start (#4079). Returns landed=true and
+// the refreshed bead once continuation_reset_pending clears and the
+// runtime is live; landed=false if inFlightResetWaitTimeout elapses first
+// (e.g. the reconciler itself is stalled), so the caller can fall back to
+// starting the runtime itself rather than hang indefinitely.
+func (m *Manager) waitForInFlightReset(ctx context.Context, id, sessName string) (landed bool, fresh beads.Bead, err error) {
+	deadline := time.Now().Add(inFlightResetWaitTimeout)
+	for time.Now().Before(deadline) {
+		if err := sleepWithContext(ctx, inFlightResetPollInterval); err != nil {
+			return false, beads.Bead{}, err
+		}
+		fresh, err := m.store.Get(id)
+		if err != nil {
+			return false, beads.Bead{}, fmt.Errorf("polling in-flight reset for %s: %w", id, err)
+		}
+		if strings.TrimSpace(fresh.Metadata["continuation_reset_pending"]) != "true" && m.sp.IsRunning(sessName) {
+			return true, fresh, nil
+		}
+	}
+	return false, beads.Bead{}, nil
 }
 
 func (m *Manager) ensureRunningRuntimeOnly(ctx context.Context, id string, b beads.Bead, sessName, resumeCommand string, hints runtime.Config) error {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -58,6 +59,28 @@ func (p *orphanScanProvider) FindRuntimesBySessionID(id string) ([]runtime.LiveR
 func (p *orphanScanProvider) TerminateRuntime(r runtime.LiveRuntime) error {
 	p.events = append(p.events, "terminate:"+r.SessionID)
 	return p.terminateErr
+}
+
+// startCountingProvider counts Start calls so a test can assert that a
+// concurrent Attach did not race an in-flight controller-driven reset
+// (continuation_reset_pending) with its own independent Start.
+type startCountingProvider struct {
+	*runtime.Fake
+	mu         sync.Mutex
+	startCalls int
+}
+
+func (p *startCountingProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	p.mu.Lock()
+	p.startCalls++
+	p.mu.Unlock()
+	return p.Fake.Start(ctx, name, cfg)
+}
+
+func (p *startCountingProvider) StartCalls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.startCalls
 }
 
 type nonRunningStopRecorder struct {
@@ -2096,6 +2119,105 @@ func TestAttachActiveReattach(t *testing.T) {
 	}
 	if got.State != StateActive {
 		t.Errorf("State = %q, want %q", got.State, StateActive)
+	}
+}
+
+// TestAttachWaitsForInFlightResetInsteadOfRacingIt is a regression guard for
+// gascity#4079: gc session attach could race an in-flight gc session reset
+// and produce a blank no-continuity instance. The session reconciler that
+// executes a reset runs in a separate long-lived controller process from
+// the short-lived `gc session attach` CLI invocation, so the in-process
+// withSessionMutationLock provides no cross-process protection between
+// them. The reconciler stops the runtime immediately but defers the actual
+// fresh Start to a later phase of reconciliation, marking the durable
+// continuation_reset_pending="true" the whole time (cleared only by
+// PreWakePatch immediately before its own Start). This test simulates that
+// exact window — runtime stopped, continuation_reset_pending set, with a
+// goroutine completing the "reconciler's" restart shortly after — and
+// asserts Attach waits for it instead of independently calling Start.
+func TestAttachWaitsForInFlightResetInsteadOfRacingIt(t *testing.T) {
+	origPoll, origTimeout := inFlightResetPollInterval, inFlightResetWaitTimeout
+	inFlightResetPollInterval = 5 * time.Millisecond
+	inFlightResetWaitTimeout = 500 * time.Millisecond
+	defer func() {
+		inFlightResetPollInterval = origPoll
+		inFlightResetWaitTimeout = origTimeout
+	}()
+
+	store := beads.NewMemStore()
+	sp := &startCountingProvider{Fake: runtime.NewFake()}
+	mgr := NewManagerWithOptions(store, sp)
+
+	info, err := mgr.CreateSession(context.Background(), CreateOptions{Template: "helper", Title: "", Command: "claude", WorkDir: "/tmp", Provider: "claude", Env: nil, Resume: ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	baseline := sp.StartCalls()
+
+	// Simulate the reconciler's restart-requested handling
+	// (session_reconciler.go): stop the runtime, mark the durable
+	// in-flight-reset signal, and defer the actual fresh Start.
+	if err := sp.Stop(info.SessionName); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := store.SetMetadata(info.ID, "continuation_reset_pending", "true"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	// Simulate the reconciler completing its own fresh restart shortly
+	// after, on a separate goroutine — the cross-process timing this fix
+	// has to tolerate.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = sp.Start(context.Background(), info.SessionName, runtime.Config{Command: "claude"})
+		_ = store.SetMetadata(info.ID, "continuation_reset_pending", "")
+	}()
+
+	if err := mgr.Attach(context.Background(), info.ID, "claude --resume", runtime.Config{}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	if got := sp.StartCalls(); got != baseline+1 {
+		t.Errorf("Start calls = %d, want %d (attach should wait for the reconciler's restart, not race it with its own Start)", got, baseline+1)
+	}
+}
+
+// TestAttachFallsBackToOwnStartWhenInFlightResetNeverClears guards the
+// bounded-wait fallback: if the controller-driven reset never completes
+// (a stalled/dead reconciler), Attach must still converge — start the
+// runtime itself after the bounded wait — rather than hang indefinitely.
+func TestAttachFallsBackToOwnStartWhenInFlightResetNeverClears(t *testing.T) {
+	origPoll, origTimeout := inFlightResetPollInterval, inFlightResetWaitTimeout
+	inFlightResetPollInterval = 5 * time.Millisecond
+	inFlightResetWaitTimeout = 30 * time.Millisecond
+	defer func() {
+		inFlightResetPollInterval = origPoll
+		inFlightResetWaitTimeout = origTimeout
+	}()
+
+	store := beads.NewMemStore()
+	sp := &startCountingProvider{Fake: runtime.NewFake()}
+	mgr := NewManagerWithOptions(store, sp)
+
+	info, err := mgr.CreateSession(context.Background(), CreateOptions{Template: "helper", Title: "", Command: "claude", WorkDir: "/tmp", Provider: "claude", Env: nil, Resume: ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := sp.Stop(info.SessionName); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := store.SetMetadata(info.ID, "continuation_reset_pending", "true"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	// Nothing ever clears continuation_reset_pending.
+
+	if err := mgr.Attach(context.Background(), info.ID, "claude --resume", runtime.Config{}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	if !sp.IsRunning(info.SessionName) {
+		t.Error("session should be running after Attach's bounded-wait fallback")
 	}
 }
 


### PR DESCRIPTION
Fixes #4079.

**Bug:** `gc session attach <alias>` restarts the runtime whenever tmux looks dead — but this can misfire during the transition window of an *in-flight* `gc session reset <alias>`, producing a second, uncoordinated restart that races the first and lands the operator in a blank, no-continuity instance instead of a clean reattach.

**Root cause (confirmed by direct code trace, deeper than the report suspected):** the session reconciler that actually executes a reset runs inside the long-lived controller process; `gc session attach` runs as a fresh, short-lived CLI subprocess. `withSessionMutationLock` (`internal/session/chat.go`), the lock `Manager.Attach` takes before deciding whether to restart, is an **in-process** `sync.Mutex` map — it provides **zero cross-process coordination** between the two. The reconciler's restart-requested handling (`cmd/gc/session_reconciler.go:2492-2559`) stops the tmux runtime immediately but defers the actual fresh `Start` to a later phase of the same reconcile tick (or the next one). During that gap the bead's `continuation_reset_pending` metadata stays `"true"` the whole time — it's only cleared by `PreWakePatch`, applied immediately before the reconciler's own `Start` (`internal/session/lifecycle_transition.go`). If `gc session attach` lands in that gap, `Manager.ensureRunning` just sees "runtime not running," treats it as an ordinary dead/suspended session, and independently calls `Start` — racing the reconciler's own restart.

**Fix:** in `ensureRunning`, before falling through to an independent `Start`, check `continuation_reset_pending == "true"`. If set, that's the durable, store-mediated signal a controller-driven reset is in flight — the fix that actually works here, since beads (not an in-memory lock) are the only coordination substrate shared across the two processes. Bounded-poll (`waitForInFlightReset`, re-`Get` the bead every 200ms up to a 5s default, both declared as `var` so tests can shrink them) for the flag to clear and the runtime to come back, then reattach to what the reconciler started. If the bound elapses (the reconciler itself is stalled/dead), fall back to today's behavior so `gc session attach` never hangs indefinitely.

**Scope note:** intentionally limited to `ensureRunning` (the path `Attach` uses). `ensureRunningRuntimeOnly` (used by the separate `StartResolved` path) has the same theoretical race shape but is out of scope for this fix — not what #4079 reports, and expanding scope there risked a broader, less-reviewable diff for an unreported symptom.

## Test

Two new regression tests in `internal/session/manager_test.go`, both using a new `startCountingProvider` (wraps `runtime.Fake`, counts `Start` calls) so assertions target behavior, not implementation:

- `TestAttachWaitsForInFlightResetInsteadOfRacingIt` — simulates the exact race window (runtime stopped, `continuation_reset_pending="true"` set, a goroutine completing the "reconciler's" restart 30ms later) and asserts `Attach` waits for it rather than calling `Start` itself (asserts exactly one `Start` call total, from the simulated reconciler).
- `TestAttachFallsBackToOwnStartWhenInFlightResetNeverClears` — guards the bounded-wait fallback: when `continuation_reset_pending` never clears (a stalled controller), `Attach` still converges by starting the runtime itself after the timeout, rather than hanging indefinitely.

TDD RED confirmed: both tests failed to compile before `inFlightResetPollInterval`/`inFlightResetWaitTimeout`/`waitForInFlightReset` existed. GREEN after.

## Validation

`-tags gms_pure_go`: `gofmt -l` clean, `go build ./...` clean, `go vet ./internal/session/... ./internal/worker/...` clean. Full `internal/session` suite green (9.0s). Full `internal/worker` suite green (13.8s, incl. `builtin`/`fake`/`transcript`/`workertest`). Targeted `cmd/gc` reconciler/session/attach/drain/restart suite green (40.9s).

Verify-still-live: confirmed the race is unmitigated on current `upstream/main` (`git show upstream/main:internal/session/chat.go` shows `ensureRunning` falling straight from the `IsRunning` check to building the resume command, no `continuation_reset_pending` check) before building.