### PR TITLE
docs(herdr): correct per-agent herdr selection (session is transport-only)

### DIFF
--- a/docs/reference/herdr-provider.md
+++ b/docs/reference/herdr-provider.md
@@ -40,24 +40,38 @@ another backend by a patch (see below).
 
 ### Per-agent / per-rig
 
-Override the backend for a single agent — or every agent in a rig — with an
-agent patch. The override field is `session`:
+herdr has no per-agent selector: the backend is chosen city-wide by `[session]
+provider` (above) or by the `GC_SESSION` environment variable (below). The
+per-agent patch field is `session`, and it is a **transport** override — it
+accepts only `acp`, `tmux`, or omission. `session = "herdr"` is *not* valid and
+never selects the herdr runtime; it is flagged during config validation:
 
-```toml
-# one agent by name
-[[patches.agent]]
-name = "dog-1"
-session = "herdr"
-
-# every agent in a rig (match by the rig's working dir)
-[[patches.agent]]
-dir = "webapp"
-session = "herdr"
+```text
+session "herdr" is not a valid session transport (use "acp", "tmux", or omit)
 ```
 
-A per-agent `session` override wins over the `[session]` city default, so you
-can run the whole city on herdr while pinning specific agents to tmux (or the
-reverse — keep tmux as the default and pilot herdr on one agent).
+To put only some agents on herdr, keep herdr as the city default and pin the
+agents you *don't* want on it back to tmux — one agent by `name`, or every
+agent in a rig by its working `dir`:
+
+```toml
+[session]
+provider = "herdr"
+
+# keep one agent by name on tmux
+[[patches.agent]]
+name = "dog-1"
+session = "tmux"
+
+# keep every agent in a rig on tmux (match by the rig's working dir)
+[[patches.agent]]
+dir = "webapp"
+session = "tmux"
+```
+
+A per-agent `session = "tmux"` pin wins over the `[session]` city default, so
+the set of agents you pin back is what bounds herdr's reach. See **Piloting
+safely** below for the recommended roll-out order.
 
 ### Environment (one-off)
 
@@ -88,12 +102,15 @@ herdr is opt-in precisely so you can roll it out gradually. Recommended path:
    session = "tmux"
    ```
 
-2. **Start with one low-stakes agent** — a dog, or a single rig's witness —
-   by giving just that agent a `session = "herdr"` patch while the city default
-   stays tmux. Watch it through a normal work cycle before widening.
+2. **Keep the herdr surface small at first.** herdr is only selectable as the
+   city default, so put just a low-stakes agent or two (a dog, or a single
+   rig's witness) on it by flipping the default to `provider = "herdr"` and
+   pinning every *other* agent back to tmux with `session = "tmux"` patches (as
+   in step 1). Watch the pilot agents through a normal work cycle before
+   widening.
 
-3. **Widen** to a rig (`dir = "<rig>"`), then to the city default, once the
-   pilot agents are stable.
+3. **Widen** by removing tmux pins — a rig at a time (`dir = "<rig>"`) — until
+   the whole city runs on the herdr default, once the pilot agents are stable.
 
 ## Applying and verifying
 

--- a/docs/reference/herdr-provider.md
+++ b/docs/reference/herdr-provider.md
@@ -24,7 +24,9 @@ selected onto herdr fail to start; install it before flipping the selector.
 ## Enabling herdr
 
 `herdr` is selected with the same runtime selector used for every other
-backend, at one of three scopes.
+backend. That selector is city-wide (`[session] provider`) or, for a one-off
+run, process-wide (`GC_SESSION`); herdr cannot be selected for individual
+agents.
 
 ### City default
 
@@ -35,43 +37,37 @@ Set the session provider in `city.toml`:
 provider = "herdr"
 ```
 
-Every agent the city starts then runs under herdr, except agents pinned to
-another backend by a patch (see below).
+Every agent the city starts runs under herdr, except agents on the ACP transport
+(whether pinned `session = "acp"` or because their provider defaults to ACP),
+which route to the separate ACP backend instead (see below).
 
 ### Per-agent / per-rig
 
-herdr has no per-agent selector: the backend is chosen city-wide by `[session]
-provider` (above) or by the `GC_SESSION` environment variable (below). The
-per-agent patch field is `session`, and it is a **transport** override — it
-accepts only `acp`, `tmux`, or omission. `session = "herdr"` is *not* valid and
-never selects the herdr runtime; it is flagged during config validation:
+herdr cannot be selected for individual agents. The runtime backend is chosen
+city-wide by `[session] provider` (above) or process-wide by `GC_SESSION`
+(below); no patch puts an agent onto herdr when the city default is something
+else.
+
+The per-agent patch field is `session`, but it selects a **transport**, not a
+backend. It accepts only `acp`, `tmux`, or omission (`IsValidSessionTransport`
+in `internal/config/provider.go`), so `session = "herdr"` never selects the
+herdr runtime. Config validation flags it as a warning:
 
 ```text
-session "herdr" is not a valid session transport (use "acp", "tmux", or omit)
+agent "dog-1": session "herdr" is not a valid session transport (use "acp", "tmux", or omit)
 ```
 
-To put only some agents on herdr, keep herdr as the city default and pin the
-agents you *don't* want on it back to tmux — one agent by `name`, or every
-agent in a rig by its working `dir`:
+Under a herdr city, the transport router (`internal/runtime/auto`) sends only
+ACP-registered sessions to the separate ACP backend and routes everything else
+to the city's base provider, which is herdr. Two consequences follow:
 
-```toml
-[session]
-provider = "herdr"
-
-# keep one agent by name on tmux
-[[patches.agent]]
-name = "dog-1"
-session = "tmux"
-
-# keep every agent in a rig on tmux (match by the rig's working dir)
-[[patches.agent]]
-dir = "webapp"
-session = "tmux"
-```
-
-A per-agent `session = "tmux"` pin wins over the `[session]` city default, so
-the set of agents you pin back is what bounds herdr's reach. See **Piloting
-safely** below for the recommended roll-out order.
+- `session = "acp"` (or a provider that defaults to ACP) moves that agent off
+  herdr, onto the ACP backend. It is the one per-agent lever that changes which
+  backend an agent runs on.
+- `session = "tmux"` does not keep an agent on tmux. The herdr provider does not
+  implement the transport-capability check, so the pin is neither honored nor
+  rejected; the agent falls back to the base provider and runs on herdr. To put
+  an agent on tmux, the whole city (or process) must default to tmux.
 
 ### Environment (one-off)
 
@@ -87,30 +83,35 @@ way it selects `exec:<script>` or any other backend.
 
 ## Piloting safely
 
-herdr is opt-in precisely so you can roll it out gradually. Recommended path:
+herdr is opt-in, and the backend is a whole-city choice, so you pilot it by
+scoping which city runs on herdr, not by pinning individual agents. Recommended
+path:
 
-1. **Keep the mayor on tmux first.** Don't run the orchestrator on an
-   experimental backend. If you flip the city default to herdr, pin the mayor
-   back to tmux with a patch:
+1. **Try it per-process on a scratch city.** Select herdr with the environment
+   variable on a throwaway city, so nothing is committed and your real city is
+   untouched:
+
+   ```bash
+   GC_SESSION=herdr gc start <scratch-city>
+   ```
+
+   Every agent in that process runs under herdr, except agents on the ACP
+   transport (whether pinned `session = "acp"` or because their provider
+   defaults to ACP), which still route to the separate ACP backend. Watch it
+   through a normal work cycle.
+
+2. **Promote to the scratch city's default.** Once the per-process trial looks
+   good, set the default in that city's `city.toml` and run it end to end:
 
    ```toml
    [session]
    provider = "herdr"
-
-   [[patches.agent]]
-   name = "mayor"
-   session = "tmux"
    ```
 
-2. **Keep the herdr surface small at first.** herdr is only selectable as the
-   city default, so put just a low-stakes agent or two (a dog, or a single
-   rig's witness) on it by flipping the default to `provider = "herdr"` and
-   pinning every *other* agent back to tmux with `session = "tmux"` patches (as
-   in step 1). Watch the pilot agents through a normal work cycle before
-   widening.
-
-3. **Widen** by removing tmux pins — a rig at a time (`dir = "<rig>"`) — until
-   the whole city runs on the herdr default, once the pilot agents are stable.
+3. **Widen** to your real city by flipping its `[session] provider` to
+   `"herdr"`, once the scratch city has been stable across several work cycles.
+   The switch is city-wide with no way to move agents over one at a time, so
+   keep any city you are not ready to migrate on the tmux default.
 
 ## Applying and verifying
 


### PR DESCRIPTION
## What

`docs/reference/herdr-provider.md` tells readers to put a single agent or rig on herdr with a per-agent patch:

```toml
[[patches.agent]]
name = "dog-1"
session = "herdr"
```

This doesn't work. `session` is the session **transport** field, not a backend selector: `IsValidSessionTransport` accepts only `""`, `acp`, or `tmux` (`internal/config/provider.go`; constants `SessionTransportACP` / `SessionTransportTmux`, no herdr value). A `session = "herdr"` patch is flagged during config validation — `session "herdr" is not a valid session transport (use "acp", "tmux", or omit)` (`internal/config/validate_semantics.go`) — and never reaches the herdr runtime.

herdr is a session **backend**, chosen city-wide by `[session] provider` (resolved through the runtime registry, where `herdr` is registered) or process-wide by `GC_SESSION`. There is no per-agent backend selector — the effective backend is `GC_SESSION` else `cfg.Session.Provider` (`sessionProviderContextForCity`, `cmd/gc/providers.go`), with no per-agent input. (The per-agent `provider` field is the agent-CLI preset, checked against `[providers]` — also not a way to select herdr.)

## Fix (docs-only)

To run herdr on a subset of agents, keep herdr as the city default and pin the agents you *don't* want on it back to tmux with `session = "tmux"` — the pattern the **Piloting safely** section already uses in step 1. This PR:

- Rewrites the **Per-agent / per-rig** example to the city-default + `session = "tmux"` pin form, and notes that `session` is transport-only (`acp` / `tmux`).
- Aligns **Piloting safely** steps 2–3, which relied on the same invalid `session = "herdr"` patch.

No behavior change.

## Out of scope

If per-agent herdr selection is wanted as a feature, that's a code change (teach `session` to accept `herdr`, or add a per-agent backend override) — intentionally not attempted here.
