### PR TITLE
feat(session): add "gc session cancel-reset" to clear a pending reset in place (#76)

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -44,7 +44,7 @@ continuity.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc session: missing subcommand (new, list, attach, submit, suspend, pin, unpin, reset, close, rename, prune, peek, kill, nudge, logs, wake, wait)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintln(stderr, "gc session: missing subcommand (new, list, attach, submit, suspend, pin, unpin, reset, cancel-reset, close, rename, prune, peek, kill, nudge, logs, wake, wait)") //nolint:errcheck // best-effort stderr
 			} else {
 				fmt.Fprintf(stderr, "gc session: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
 			}
@@ -60,6 +60,7 @@ continuity.`,
 		newSessionPinCmd(stdout, stderr),
 		newSessionUnpinCmd(stdout, stderr),
 		newSessionResetCmd(stdout, stderr),
+		newSessionCancelResetCmd(stdout, stderr),
 		newSessionCloseCmd(stdout, stderr),
 		newSessionRenameCmd(stdout, stderr),
 		newSessionPruneCmd(stdout, stderr),

--- a/cmd/gc/cmd_session_cancel_reset.go
+++ b/cmd/gc/cmd_session_cancel_reset.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/spf13/cobra"
+)
+
+// cancelResetOutcome is what `gc session cancel-reset` should do for a session,
+// derived from its runtime liveness and reset-state metadata.
+type cancelResetOutcome int
+
+const (
+	// cancelResetRefuseNotRunning: the runtime is not alive. Refuse — clearing a
+	// pending reset is only safe for a live session. A not-running session may be
+	// mid-restart (past the point of no return, marked by reset_committed_at set
+	// after the controller kills the runtime), and the pending reset only matters
+	// at the next wake the controller drives anyway.
+	cancelResetRefuseNotRunning cancelResetOutcome = iota
+	// cancelResetNothingPending: the session is live but carries no pending reset
+	// — nothing to cancel.
+	cancelResetNothingPending
+	// cancelResetClear: the session is live and carries a pending reset that would
+	// force a fresh (context-losing) conversation at its next wake; clear it.
+	cancelResetClear
+)
+
+// decideCancelReset chooses the cancel-reset action from the session's runtime
+// liveness and its reset-state metadata. Keeping the decision pure keeps the
+// judgment out of the I/O-bound command body and directly testable.
+func decideCancelReset(running bool, meta map[string]string) cancelResetOutcome {
+	if !running {
+		return cancelResetRefuseNotRunning
+	}
+	if meta["restart_requested"] != "true" && meta["continuation_reset_pending"] != "true" {
+		return cancelResetNothingPending
+	}
+	return cancelResetClear
+}
+
+// newSessionCancelResetCmd creates the "gc session cancel-reset <id-or-alias>"
+// command. It is the inverse of `gc session reset`: where reset requests a fresh
+// restart, cancel-reset clears a pending one.
+func newSessionCancelResetCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "cancel-reset <session-id-or-alias>",
+		Short: "Clear a pending reset on a live session without recycling it",
+		Long: `Clear a pending fresh-restart request on a running session, in place.
+
+A session can carry a pending reset (restart_requested / continuation_reset_pending)
+that has not executed yet — for example from an earlier "gc session reset" or
+"gc handoff", or from config drift. While the runtime stays alive the pending
+flag is harmless, but at the session's next sleep->wake the controller starts a
+fresh conversation and the prior context is lost. cancel-reset clears the pending
+request in place so the running session keeps its current conversation.
+
+It only acts on a running session (clearing is unsafe once a restart has been
+committed and the runtime killed) and does not touch session_key or the
+conversation itself. If the session is configured wake_mode=fresh, clearing the
+flag cannot prevent a fresh conversation on its next wake — change the agent
+config for that.
+
+Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if cmdSessionCancelReset(args, stdout, stderr, jsonOutput) != 0 {
+				return errExit
+			}
+			return nil
+		},
+		ValidArgsFunction: completeSessionIDs,
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
+}
+
+// cmdSessionCancelReset is the CLI entry point for "gc session cancel-reset".
+func cmdSessionCancelReset(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
+	store, code := openCityStore(stderr, "gc session cancel-reset")
+	if store == nil {
+		return code
+	}
+
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session cancel-reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	cfg, _ := loadCityConfig(cityPath, stderr)
+
+	// Every store consumer here is session-class (ID resolution, session-bead
+	// load, restart-flag clear), so route the whole flow through the session
+	// coordination-class store for relocation-safety.
+	sessStore := cliSessionStore(store, cfg, cityPath)
+	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, sessStore, args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session cancel-reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	bead, err := sessStore.Get(sessionID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session cancel-reset: loading session %s: %v\n", sessionID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	sp := newSessionProvider()
+	sessionName := strings.TrimSpace(bead.Metadata["session_name"])
+	running := sessionName != "" && sp.IsRunning(sessionName)
+
+	switch decideCancelReset(running, bead.Metadata) {
+	case cancelResetRefuseNotRunning:
+		fmt.Fprintf(stderr, "gc session cancel-reset: session %s is not running; cancel-reset clears a live session's pending reset (a not-running session may be mid-restart). Use \"gc session reset\" or \"gc session wake\" instead.\n", sessionID) //nolint:errcheck // best-effort stderr
+		return 1
+	case cancelResetNothingPending:
+		fmt.Fprintf(stdout, "Session %s has no pending reset to cancel.\n", sessionID) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+
+	// Clear the reset intent in place. clearRestartRequest clears
+	// restart_requested + continuation_reset_pending (bead) and the runtime
+	// GC_RESTART_REQUESTED flag; additionally clear reset_committed_at so a later
+	// re-arm of continuation_reset_pending cannot pair with a stale commit marker
+	// and trip a false reset-stalled alarm. Neither touches session_key or
+	// started_config_hash, so the live conversation is preserved.
+	if err := clearRestartRequest(sessStore, newDrainOps(sp), sessionName); err != nil {
+		fmt.Fprintf(stderr, "gc session cancel-reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := sessionFrontDoor(sessStore).ApplyPatch(sessionID, map[string]string{
+		session.ResetCommittedAtKey: "",
+	}); err != nil {
+		fmt.Fprintf(stderr, "gc session cancel-reset: clearing reset commit marker for %s: %v\n", sessionID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	_ = pokeController(cityPath)
+
+	if bead.Metadata["wake_mode"] == "fresh" {
+		fmt.Fprintf(stderr, "gc session cancel-reset: note: session %s is configured wake_mode=fresh; clearing the pending reset will not prevent a fresh conversation on its next wake (change the agent config for that).\n", sessionID) //nolint:errcheck // best-effort stderr
+	}
+
+	if asJSON {
+		if err := writeSessionActionJSON(stdout, sessionActionResult{
+			Action:    "cancel-reset",
+			SessionID: sessionID,
+			Identity:  namedSessionIdentity(bead),
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc session cancel-reset: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "Session %s pending reset cleared; the running session keeps its current conversation.\n", sessionID) //nolint:errcheck // best-effort stdout
+	return 0
+}

--- a/cmd/gc/cmd_session_cancel_reset_test.go
+++ b/cmd/gc/cmd_session_cancel_reset_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// TestDecideCancelReset covers the guard logic for `gc session cancel-reset`:
+// clearing a pending reset is only safe for a LIVE session (a not-running
+// session may be mid-restart, past the point of no return), and there must be a
+// pending reset to cancel.
+func TestDecideCancelReset(t *testing.T) {
+	tests := []struct {
+		name    string
+		running bool
+		meta    map[string]string
+		want    cancelResetOutcome
+	}{
+		{
+			name:    "live + continuation_reset_pending -> clear",
+			running: true,
+			meta:    map[string]string{"continuation_reset_pending": "true"},
+			want:    cancelResetClear,
+		},
+		{
+			name:    "live + restart_requested -> clear",
+			running: true,
+			meta:    map[string]string{"restart_requested": "true"},
+			want:    cancelResetClear,
+		},
+		{
+			name:    "live + no pending reset -> nothing to cancel",
+			running: true,
+			meta:    map[string]string{},
+			want:    cancelResetNothingPending,
+		},
+		{
+			name:    "not running (even with a pending reset) -> refuse",
+			running: false,
+			meta:    map[string]string{"continuation_reset_pending": "true"},
+			want:    cancelResetRefuseNotRunning,
+		},
+		{
+			name:    "not running, no flags -> refuse",
+			running: false,
+			meta:    map[string]string{},
+			want:    cancelResetRefuseNotRunning,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decideCancelReset(tc.running, tc.meta); got != tc.want {
+				t.Errorf("decideCancelReset(%v, %v) = %v, want %v", tc.running, tc.meta, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCmdSessionCancelReset_ClearsPendingResetOnLiveSession drives the command
+// end-to-end: a running session carrying a pending reset has its reset-intent
+// flags cleared in place, while its session_key (the live conversation) is
+// preserved and the runtime stays up.
+func TestCmdSessionCancelReset_ClearsPendingResetOnLiveSession(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-cancel-reset-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	fakeProvider := runtime.NewFake()
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(*config.City, string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "session-a"
+	const sessionName = "s-gc-cancel-reset-live"
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                      identity,
+			"template":                   "worker",
+			"session_name":               sessionName,
+			"state":                      "awake",
+			"session_key":                "original-key",
+			"started_config_hash":        "hash-before",
+			"restart_requested":          "true",
+			"continuation_reset_pending": "true",
+			session.ResetCommittedAtKey:  "2026-07-10T12:00:00Z",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+	if err := fakeProvider.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("fakeProvider.Start: %v", err)
+	}
+	if err := fakeProvider.SetMeta(sessionName, "GC_SESSION_ID", bead.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionCancelReset([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionCancelReset = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if !fakeProvider.IsRunning(sessionName) {
+		t.Fatalf("session %q was stopped; cancel-reset must not recycle a live session", sessionName)
+	}
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(session bead): %v", err)
+	}
+	if got := updated.Metadata["restart_requested"]; got != "" {
+		t.Fatalf("restart_requested = %q, want cleared", got)
+	}
+	if got := updated.Metadata["continuation_reset_pending"]; got != "" {
+		t.Fatalf("continuation_reset_pending = %q, want cleared", got)
+	}
+	if got := updated.Metadata[session.ResetCommittedAtKey]; got != "" {
+		t.Fatalf("reset_committed_at = %q, want cleared", got)
+	}
+	if got := updated.Metadata["session_key"]; got != "original-key" {
+		t.Fatalf("session_key = %q, want preserved (live conversation must survive)", got)
+	}
+	if got := updated.Metadata["started_config_hash"]; got != "hash-before" {
+		t.Fatalf("started_config_hash = %q, want preserved", got)
+	}
+}
+
+// TestCmdSessionCancelReset_RefusesWhenNotRunning is the safety guard: clearing a
+// pending reset on a session whose runtime is not alive could clobber a restart
+// that is genuinely mid-flight, so the command refuses and leaves the flag intact.
+func TestCmdSessionCancelReset_RefusesWhenNotRunning(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-cancel-reset-notrunning-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	fakeProvider := runtime.NewFake()
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(*config.City, string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "session-a"
+	// The runtime is never started, so sp.IsRunning is false.
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                      identity,
+			"template":                   "worker",
+			"session_name":               "s-gc-cancel-reset-notrunning",
+			"state":                      string(session.StateAsleep),
+			"continuation_reset_pending": "true",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionCancelReset([]string{identity}, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdSessionCancelReset = %d, want 1 (refuse); stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not running") {
+		t.Fatalf("stderr = %q, want not-running refusal", stderr.String())
+	}
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(session bead): %v", err)
+	}
+	if got := updated.Metadata["continuation_reset_pending"]; got != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want unchanged (true) after refusal", got)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3473,6 +3473,7 @@ gc session
 | Subcommand | Description |
 |------------|-------------|
 | [gc session attach](#gc-session-attach) | Attach to (or resume) a chat session |
+| [gc session cancel-reset](#gc-session-cancel-reset) | Clear a pending reset on a live session without recycling it |
 | [gc session close](#gc-session-close) | Close a session permanently |
 | [gc session kill](#gc-session-kill) | Force-kill session runtime (reconciler restarts) |
 | [gc session list](#gc-session-list) | List chat sessions |
@@ -3503,6 +3504,33 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).
 ```
 gc session attach <session-id-or-alias>
 ```
+
+## gc session cancel-reset
+
+Clear a pending fresh-restart request on a running session, in place.
+
+A session can carry a pending reset (restart_requested / continuation_reset_pending)
+that has not executed yet — for example from an earlier "gc session reset" or
+"gc handoff", or from config drift. While the runtime stays alive the pending
+flag is harmless, but at the session's next sleep-&gt;wake the controller starts a
+fresh conversation and the prior context is lost. cancel-reset clears the pending
+request in place so the running session keeps its current conversation.
+
+It only acts on a running session (clearing is unsafe once a restart has been
+committed and the runtime killed) and does not touch session_key or the
+conversation itself. If the session is configured wake_mode=fresh, clearing the
+flag cannot prevent a fresh conversation on its next wake — change the agent
+config for that.
+
+Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).
+
+```
+gc session cancel-reset <session-id-or-alias> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | emit JSONL |
 
 ## gc session close
 


### PR DESCRIPTION
## The juicy parts

The stuck state is concrete: a live session can carry a pending reset (`restart_requested` / `continuation_reset_pending`) that has not executed — left over from an earlier `gc session reset` or `gc handoff`, or from config drift. Nothing looks wrong while the runtime stays up, but at that session's next `sleep`→`wake` the controller starts a **fresh conversation** and the accumulated context is gone.

Today there is no "I changed my mind" command. The only non-recycling way to clear that flag is a side effect of `gc handoff`'s non-restartable branch — `clearRestartRequest` is reachable from nowhere else in `cmd/gc`. `gc session reset` requests the opposite; `kill` recycles.

Scope, stated plainly: this is a small opt-in operator verb, not a bug fix. No existing path changes, it never touches `session_key`, and it refuses on a not-running session so it cannot clobber a restart that is genuinely mid-flight. There is one open design question in the body — whether it should also handle the *asleep* session whose pending flag will detonate on the next wake — that would benefit from a maintainer's steer.

## TL;DR

Adds `gc session cancel-reset` — the inverse of `gc session reset`. It clears a
**pending** fresh-restart request on a running session **in place**, so a session
that is carrying a stale reset flag keeps its current conversation instead of
losing context at its next wake. New, opt-in operator verb; no existing behaviour
changes.

## The gap

A session can hold a pending reset (`restart_requested` /
`continuation_reset_pending`) that has not executed yet — from an earlier
`gc session reset` / `gc handoff`, or from config drift. While the runtime stays
alive the flag is inert, but at the next `sleep`→`wake` the controller starts a
**fresh conversation** and the prior context is lost.

Today the only non-recycling way to clear that flag is a side effect of
`gc handoff`'s non-restartable branch (`clearRestartRequest`) — there is no
discoverable, purpose-built command. `gc session reset` requests the opposite;
`kill` recycles.

## What this adds

`gc session cancel-reset <id-or-alias>` clears the pending request in place:

- Clears `restart_requested`, `continuation_reset_pending`, and the runtime
  `GC_RESTART_REQUESTED` flag (reusing `clearRestartRequest`), plus
  `reset_committed_at` so a later re-arm cannot pair with a stale commit marker
  and trip a false `session.reset_stalled` (#4067).
- **Does not** touch `session_key` or `started_config_hash`, so the live
  conversation is preserved — the whole point.
- **Runs only on a running session.** Clearing is unsafe once a restart has been
  committed and the runtime killed (`reset_committed_at` is stamped only after the
  controller kills the runtime), so a not-running session is refused rather than
  risk clobbering a restart that is genuinely mid-flight.
- **Warns on `wake_mode=fresh`** — clearing the flag cannot prevent a
  config-driven fresh wake; the message says to change the agent config for that,
  rather than silently no-op.

### Behaviour (Given/When/Then, matched to tests)

- **Clear** — *Given* a running session carrying a pending reset, *when*
  `cancel-reset` runs, *then* the reset-intent flags are cleared, `session_key` is
  preserved, and the runtime stays up.
  (`TestCmdSessionCancelReset_ClearsPendingResetOnLiveSession`)
- **Refuse** — *Given* the session's runtime is not alive, *when* `cancel-reset`
  runs, *then* it refuses and leaves the flag intact.
  (`TestCmdSessionCancelReset_RefusesWhenNotRunning`)
- **Guard unit** — the running/pending decision is a pure function.
  (`TestDecideCancelReset`)

## Why it is safe

- New subcommand; no existing path changes.
- Never touches the conversation state (`session_key`), so it cannot itself cause
  the fresh-start it exists to prevent.
- The running-only guard means it cannot interfere with a committed, in-flight
  restart.
- Metadata writes go through `sessionFrontDoor(...).ApplyPatch`, the same path
  `clearRestartRequest` already uses from `gc handoff`.

## Open question (please steer)

The guard is **running-only** for safety. That intentionally excludes an *asleep*
session whose pending flag would detonate on its next wake — an operator can't
pre-clear it while it sleeps. I kept the stricter rule because a not-running
session may be mid-restart, and refusing is the safe default. If you'd prefer it
also handle the asleep case (e.g. allow when `reset_committed_at` is empty), I'm
happy to extend it. Also glad to file a tracking issue if you'd rather have one.

## Related work

- #76 — precedent: a user-facing way to signal session lifecycle intent without
  reaching for internal gc commands (closed).
- #4067 — `reset_committed_at` never cleared → false `reset_stalled`; this clears
  it as part of the cancel (open).
- #2574 — stale `restart_requested` causing a phantom second restart (closed).

## Scope

- `cmd/gc/cmd_session_cancel_reset.go` (new) — decision + command
- `cmd/gc/cmd_session.go` — registration + subcommand hint
- tests + regenerated `docs/reference/cli.md`

