### PR TITLE
feat(api): DRY idempotency into a withIdempotency helper + create-triage guard (P0 #4 S1)

### DIFF
--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -458,63 +458,43 @@ type BeadDepsResponse struct {
 // humaHandleBeadCreate is the Huma-typed handler for POST /v0/beads.
 // Title required via struct tag on BeadCreateInput.
 func (s *Server) humaHandleBeadCreate(ctx context.Context, input *BeadCreateInput) (*IndexOutput[beads.Bead], error) {
-	// Idempotency check — scope by method+path to prevent cross-endpoint collisions.
-	idemKey := ""
-	var bodyHash string
-	if input.IdempotencyKey != "" {
-		idemKey = "POST:/v0/beads:" + input.IdempotencyKey
-		bodyHash = hashBody(input.Body)
-		existing, found := s.idem.reserve(idemKey, bodyHash)
-		if found {
-			if existing.bodyHash != bodyHash {
-				return nil, apierr.IdempotencyMismatch.Msg("idempotency_mismatch: Idempotency-Key reused with different request body")
+	// Idempotency: run the create at most once per Idempotency-Key. The helper
+	// owns reserve/replay/mismatch/in-flight and guarantees the reservation is
+	// released on any error, so every fallible step lives in the closure.
+	b, err := withIdempotency(s, "/v0/beads", input.IdempotencyKey, input.Body,
+		func() (beads.Bead, error) {
+			store := s.findStore(input.Body.Rig)
+			if store == nil {
+				return beads.Bead{}, apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
 			}
-			if existing.pending {
-				return nil, apierr.IdempotencyInFlight.Msg("in_flight: request with this Idempotency-Key is already in progress")
+			assignee, err := s.normalizeRawBeadAssignee(ctx, input.Body.Assignee)
+			if err != nil {
+				return beads.Bead{}, apierr.InvalidRequest.Msg(err.Error())
 			}
-			// Replay cached typed response (Fix 3l).
-			if b, ok := replayAs[beads.Bead](existing); ok {
-				return &IndexOutput[beads.Bead]{
-					Index: s.latestIndex(),
-					Body:  b,
-				}, nil
+			created, err := store.Create(beads.Bead{
+				Title:       input.Body.Title,
+				Type:        input.Body.Type,
+				Priority:    input.Body.Priority,
+				Assignee:    assignee,
+				Description: input.Body.Description,
+				Labels:      input.Body.Labels,
+				ParentID:    input.Body.Parent,
+				Metadata:    input.Body.Metadata,
+				DeferUntil:  input.Body.DeferUntil,
+			})
+			if err != nil {
+				return beads.Bead{}, apierr.Internal.Msg(err.Error())
 			}
-		}
-	}
-
-	store := s.findStore(input.Body.Rig)
-	if store == nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
-	}
-	assignee, err := s.normalizeRawBeadAssignee(ctx, input.Body.Assignee)
+			// Some stores return a minimal create envelope and require a
+			// follow-up read for the canonical persisted bead state.
+			if persisted, getErr := store.Get(created.ID); getErr == nil {
+				created = persisted
+			}
+			return created, nil
+		})
 	if err != nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.InvalidRequest.Msg(err.Error())
+		return nil, err
 	}
-
-	b, err := store.Create(beads.Bead{
-		Title:       input.Body.Title,
-		Type:        input.Body.Type,
-		Priority:    input.Body.Priority,
-		Assignee:    assignee,
-		Description: input.Body.Description,
-		Labels:      input.Body.Labels,
-		ParentID:    input.Body.Parent,
-		Metadata:    input.Body.Metadata,
-		DeferUntil:  input.Body.DeferUntil,
-	})
-	if err != nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.Internal.Msg(err.Error())
-	}
-
-	// Some stores return a minimal create envelope and require a follow-up
-	// read for the canonical persisted bead state.
-	if persisted, getErr := store.Get(b.ID); getErr == nil {
-		b = persisted
-	}
-	s.idem.storeResponse(idemKey, bodyHash, b)
 
 	return &IndexOutput[beads.Bead]{
 		Index: s.latestIndex(),

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -434,39 +434,23 @@ func (s *Server) humaHandleMailSend(ctx context.Context, input *MailSendInput) (
 		return nil, apierr.InvalidRequest.Msg("no mail provider available")
 	}
 
-	// Idempotency check — scope by method+path to prevent cross-endpoint collisions.
-	idemKey := ""
-	var bodyHash string
-	if input.IdempotencyKey != "" {
-		idemKey = "POST:/v0/mail:" + input.IdempotencyKey
-		bodyHash = hashBody(input.Body)
-		existing, found := s.idem.reserve(idemKey, bodyHash)
-		if found {
-			if existing.bodyHash != bodyHash {
-				return nil, apierr.IdempotencyMismatch.Msg("idempotency_mismatch: Idempotency-Key reused with different request body")
+	// Idempotency: send at most once per Idempotency-Key. On replay the closure
+	// is skipped entirely, so no duplicate Send, telemetry op, or MailSent event
+	// fires. The helper guarantees the reservation is released on a send error.
+	msg, err := withIdempotency(s, "/v0/mail", input.IdempotencyKey, input.Body,
+		func() (mail.Message, error) {
+			sent, sendErr := mp.Send(input.Body.From, resolved, input.Body.Subject, input.Body.Body)
+			telemetry.RecordMailOp(ctx, "send", sendErr)
+			if sendErr != nil {
+				return mail.Message{}, apierr.Internal.Msg(sendErr.Error())
 			}
-			if existing.pending {
-				return nil, apierr.IdempotencyInFlight.Msg("in_flight: request with this Idempotency-Key is already in progress")
-			}
-			// Replay cached typed response (Fix 3l).
-			if msg, ok := replayAs[mail.Message](existing); ok {
-				return &IndexOutput[mail.Message]{
-					Index: s.latestIndex(),
-					Body:  msg,
-				}, nil
-			}
-		}
-	}
-
-	msg, err := mp.Send(input.Body.From, resolved, input.Body.Subject, input.Body.Body)
-	telemetry.RecordMailOp(ctx, "send", err)
+			sent.Rig = input.Body.Rig
+			s.recordMailEvent(events.MailSent, sent.From, sent.ID, input.Body.Rig, &sent)
+			return sent, nil
+		})
 	if err != nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.Internal.Msg(err.Error())
+		return nil, err
 	}
-	msg.Rig = input.Body.Rig
-	s.idem.storeResponse(idemKey, bodyHash, msg)
-	s.recordMailEvent(events.MailSent, msg.From, msg.ID, input.Body.Rig, &msg)
 
 	return &IndexOutput[mail.Message]{
 		Index: s.latestIndex(),

--- a/internal/api/idempotency_guard_test.go
+++ b/internal/api/idempotency_guard_test.go
@@ -1,0 +1,182 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api"
+)
+
+// requireIdempotency lists the create operations that MUST accept an
+// Idempotency-Key header. This set grows as each wiring slice (audit P0 #4)
+// lands; a regression that drops the header fails TestCreateEndpointsAreTriagedForIdempotency.
+var requireIdempotency = map[string]bool{
+	"create-bead": true,
+	"send-mail":   true,
+}
+
+// pendingIdempotency lists known create operations that are deliberately NOT
+// yet wired for Idempotency-Key (audit P0 #4, slices S2+). It is a reviewed
+// TODO list, not an exemption: when a slice wires one of these, MOVE it to
+// requireIdempotency — the test enforces the move so the lists stay honest.
+var pendingIdempotency = map[string]bool{
+	"create-agent":            true, // 201
+	"create-provider":         true, // 201
+	"create-rig":              true, // 201
+	"create-convoy":           true, // 201
+	"add-pack":                true, // 201; git fetch, retry-prone
+	"reply-mail":              true, // 201; mints a message
+	"register-extmsg-adapter": true, // 201
+	"emit-event":              true, // 201; append-only, retry double-emits
+	"ensure-extmsg-group":     true, // 201; identity-idempotent already
+	"post-v0-city":            true, // 202; supervisor city create
+	"create-session":          true, // 202; raw+Huma split, deferred (S4)
+	"send-session-message":    true, // 202; deferred (S4)
+	"respond-session":         true, // 202; deferred (S4)
+	"submit-session":          true, // 202; deferred (S4)
+}
+
+// exemptFromIdempotency lists POST operations that are NOT resource creates and
+// therefore need no Idempotency-Key: actions on an existing resource (id in the
+// path — naturally keyed by the target), dispatch/trigger endpoints (their own
+// conflict guards), and reads-via-POST. Listing them explicitly (rather than
+// relying on a status-code heuristic) makes the guard airtight: every POST must
+// be classified, so a new create at ANY status (201, 202, …) that is neither
+// wired nor triaged fails the test.
+var exemptFromIdempotency = map[string]bool{
+	"post-v0-city-by-city-name-agent-by-base-by-action":        true,
+	"post-v0-city-by-city-name-agent-by-dir-by-base-by-action": true,
+	"post-v0-city-by-city-name-bead-by-id-assign":              true,
+	"post-v0-city-by-city-name-bead-by-id-close":               true,
+	"post-v0-city-by-city-name-bead-by-id-reopen":              true,
+	"post-v0-city-by-city-name-bead-by-id-update":              true,
+	"post-v0-city-by-city-name-convoy-by-id-add":               true,
+	"post-v0-city-by-city-name-convoy-by-id-close":             true,
+	"post-v0-city-by-city-name-convoy-by-id-remove":            true,
+	"post-v0-city-by-city-name-extmsg-bind":                    true,
+	"post-v0-city-by-city-name-extmsg-inbound":                 true,
+	"post-v0-city-by-city-name-extmsg-outbound":                true,
+	"post-v0-city-by-city-name-extmsg-participants":            true,
+	"post-v0-city-by-city-name-extmsg-transcript-ack":          true,
+	"post-v0-city-by-city-name-extmsg-unbind":                  true,
+	"post-v0-city-by-city-name-formulas-by-name-preview":       true,
+	"post-v0-city-by-city-name-formulas-by-name-validate":      true,
+	"post-v0-city-by-city-name-mail-by-id-archive":             true,
+	"post-v0-city-by-city-name-mail-by-id-mark-unread":         true,
+	"post-v0-city-by-city-name-mail-by-id-read":                true,
+	"post-v0-city-by-city-name-order-by-name-disable":          true,
+	"post-v0-city-by-city-name-order-by-name-enable":           true,
+	"post-v0-city-by-city-name-order-by-name-run":              true,
+	"post-v0-city-by-city-name-rig-by-name-by-action":          true,
+	"post-v0-city-by-city-name-service-by-name-restart":        true,
+	"post-v0-city-by-city-name-session-by-id-close":            true,
+	"post-v0-city-by-city-name-session-by-id-kill":             true,
+	"post-v0-city-by-city-name-session-by-id-permission-mode":  true,
+	"post-v0-city-by-city-name-session-by-id-rename":           true,
+	"post-v0-city-by-city-name-session-by-id-stop":             true,
+	"post-v0-city-by-city-name-session-by-id-suspend":          true,
+	"post-v0-city-by-city-name-session-by-id-wake":             true,
+	"post-v0-city-by-city-name-sling":                          true,
+	"post-v0-city-by-city-name-unregister":                     true,
+	"rotate-events":                                            true,
+	"trigger-maintenance-dolt-gc":                              true,
+}
+
+type idemSpecDoc struct {
+	Paths map[string]map[string]idemSpecOp `json:"paths"`
+}
+
+type idemSpecOp struct {
+	OperationID string          `json:"operationId"`
+	Parameters  []idemSpecParam `json:"parameters"`
+	Responses   map[string]any  `json:"responses"`
+}
+
+type idemSpecParam struct {
+	In   string `json:"in"`
+	Name string `json:"name"`
+}
+
+func (op idemSpecOp) hasIdempotencyHeader() bool {
+	for _, p := range op.Parameters {
+		if p.In == "header" && p.Name == "Idempotency-Key" {
+			return true
+		}
+	}
+	return false
+}
+
+func liveIdemSpec(t *testing.T) idemSpecDoc {
+	t.Helper()
+	sm := api.NewSupervisorMux(emptyTestResolver{}, nil, false, "", "", time.Time{})
+	req := httptest.NewRequest(http.MethodGet, "/openapi.json", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /openapi.json returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var doc idemSpecDoc
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("parse live spec: %v", err)
+	}
+	return doc
+}
+
+// TestCreateEndpointsAreTriagedForIdempotency is the guard that no create
+// endpoint silently ships without Idempotency-Key. It requires EVERY POST
+// operation to be classified into exactly one of three sets:
+//
+//   - requireIdempotency  → MUST declare the header (regression guard)
+//   - pendingIdempotency  → known create, not yet wired; MUST NOT declare the
+//     header yet (wiring it forces a move to requireIdempotency)
+//   - exemptFromIdempotency → not a create (action/dispatch/read); no header
+//
+// A POST operation in none of the sets fails the test: a new endpoint was added
+// without triage. If it's a create, wire it through withIdempotency and add it
+// to requireIdempotency; otherwise add it to exemptFromIdempotency. This full
+// partition closes the gap where a create at a non-201 status (e.g. 202) could
+// slip past a status-code heuristic.
+func TestCreateEndpointsAreTriagedForIdempotency(t *testing.T) {
+	spec := liveIdemSpec(t)
+
+	seen := map[string]bool{}
+	for path, methods := range spec.Paths {
+		post, ok := methods["post"]
+		if !ok {
+			continue
+		}
+		opid := post.OperationID
+		seen[opid] = true
+
+		switch {
+		case requireIdempotency[opid]:
+			if !post.hasIdempotencyHeader() {
+				t.Errorf("create %q (POST %s) must declare an Idempotency-Key header but does not — "+
+					"wire it through withIdempotency and add the header input field", opid, path)
+			}
+		case pendingIdempotency[opid]:
+			if post.hasIdempotencyHeader() {
+				t.Errorf("%q (POST %s) now declares Idempotency-Key — move it from pendingIdempotency "+
+					"to requireIdempotency in idempotency_guard_test.go", opid, path)
+			}
+		case exemptFromIdempotency[opid]:
+			// Not a create; no assertion.
+		default:
+			t.Errorf("POST %s (op %q) is not triaged for idempotency. If it creates a resource, "+
+				"wire it through withIdempotency and add %q to requireIdempotency; otherwise add it "+
+				"to exemptFromIdempotency in idempotency_guard_test.go.", path, opid, opid)
+		}
+	}
+
+	// Catch typos / renamed operations: every listed opid must exist in the spec.
+	for _, set := range []map[string]bool{requireIdempotency, pendingIdempotency, exemptFromIdempotency} {
+		for opid := range set {
+			if !seen[opid] {
+				t.Errorf("idempotency guard lists %q but no such POST operation exists in the spec", opid)
+			}
+		}
+	}
+}

--- a/internal/api/idempotency_helper.go
+++ b/internal/api/idempotency_helper.go
@@ -1,0 +1,66 @@
+package api
+
+import "github.com/gastownhall/gascity/internal/api/apierr"
+
+// withIdempotency runs create() at most once per (scoped key, request body),
+// giving create endpoints safe retries via the Idempotency-Key header.
+//
+// The scoped key is "POST:<path>:<key>" — namespaced by path so the same
+// Idempotency-Key value on two different endpoints (or two different cities,
+// when the caller folds the city into path) can't collide. On a repeat with a
+// completed reservation it replays the cached typed body value; an in-flight
+// repeat returns apierr.IdempotencyInFlight (409); a same-key/different-body
+// repeat returns apierr.IdempotencyMismatch (422).
+//
+// It ALWAYS releases the pending reservation when create() returns an error OR
+// panics (via defer), so no caller can leak a reservation — the defect the
+// hand-rolled per-handler unreserve boilerplate was prone to. When key == "" it
+// is a passthrough: create() runs exactly once and nothing is cached.
+//
+// create() should perform all fallible work (validation, the store write) and
+// return the domain body value to cache. Callers wrap that value in their
+// response envelope after withIdempotency returns, so envelope fields derived
+// from live state (e.g. the X-GC-Index event sequence) stay fresh on replay.
+func withIdempotency[T any](s *Server, path, key string, body any, create func() (T, error)) (T, error) {
+	var zero T
+	if key == "" {
+		return create()
+	}
+	scopedKey := "POST:" + path + ":" + key
+	bodyHash := hashBody(body)
+
+	existing, found := s.idem.reserve(scopedKey, bodyHash)
+	if found {
+		if existing.bodyHash != bodyHash {
+			return zero, apierr.IdempotencyMismatch.Msg("idempotency_mismatch: Idempotency-Key reused with different request body")
+		}
+		if existing.pending {
+			return zero, apierr.IdempotencyInFlight.Msg("in_flight: request with this Idempotency-Key is already in progress")
+		}
+		if v, ok := replayAs[T](existing); ok {
+			return v, nil
+		}
+		// Completed entry of an unexpected type (should be impossible for a
+		// given endpoint's fixed T). Fall through and recreate rather than
+		// serve a wrong-typed replay.
+	}
+
+	// Release the reservation on any non-success exit — an error return OR a
+	// panic in create(). unreserve only drops a *pending* entry, so on the
+	// wrong-typed fall-through above (where this caller holds no reservation) it
+	// is a harmless no-op against the completed entry.
+	settled := false
+	defer func() {
+		if !settled {
+			s.idem.unreserve(scopedKey)
+		}
+	}()
+
+	v, err := create()
+	if err != nil {
+		return zero, err
+	}
+	settled = true
+	s.idem.storeResponse(scopedKey, bodyHash, v)
+	return v, nil
+}

--- a/internal/api/idempotency_helper_test.go
+++ b/internal/api/idempotency_helper_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api/apierr"
+)
+
+// newIdemTestServer builds a Server with only the idempotency cache wired —
+// withIdempotency touches nothing else.
+func newIdemTestServer() *Server {
+	return &Server{idem: newIdempotencyCache(30 * time.Minute)}
+}
+
+type idemVal struct {
+	ID   string
+	Body string
+}
+
+func TestWithIdempotency_FirstCallRunsCreate(t *testing.T) {
+	s := newIdemTestServer()
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "1"},
+		func() (idemVal, error) {
+			calls++
+			return idemVal{ID: "t1", Body: "1"}, nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("create calls = %d, want 1", calls)
+	}
+	if got.ID != "t1" {
+		t.Fatalf("got.ID = %q, want t1", got.ID)
+	}
+}
+
+func TestWithIdempotency_ReplayReturnsCachedWithoutRerunning(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	calls := 0
+	create := func() (idemVal, error) {
+		calls++
+		return idemVal{ID: "t1", Body: "first"}, nil
+	}
+	if _, err := withIdempotency(s, "/v0/things", "key-1", body, create); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// Second call: same key + same body. create must NOT run again; the cached
+	// value (not a fresh "second" run) must come back.
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) {
+			calls++
+			return idemVal{ID: "t2", Body: "second"}, nil
+		})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("create calls = %d, want 1 (replay must not re-run)", calls)
+	}
+	if got.ID != "t1" || got.Body != "first" {
+		t.Fatalf("replayed value = %+v, want the first-call value", got)
+	}
+}
+
+func TestWithIdempotency_MismatchReturns422(t *testing.T) {
+	s := newIdemTestServer()
+	if _, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "1"},
+		func() (idemVal, error) { return idemVal{ID: "t1"}, nil }); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	calls := 0
+	_, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "DIFFERENT"},
+		func() (idemVal, error) { calls++; return idemVal{}, nil })
+	if calls != 0 {
+		t.Fatalf("create ran on a body mismatch (calls=%d); it must not", calls)
+	}
+	var em *apierr.ErrorModel
+	if !errors.As(err, &em) {
+		t.Fatalf("error = %v, want *apierr.ErrorModel", err)
+	}
+	if em.Code != "idempotency-mismatch" || em.Status != 422 {
+		t.Fatalf("mismatch error = code %q status %d, want idempotency-mismatch/422", em.Code, em.Status)
+	}
+}
+
+func TestWithIdempotency_InFlightReturns409(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	// Simulate a concurrent in-flight request holding the reservation.
+	scoped := "POST:/v0/things:key-1"
+	s.idem.reserve(scoped, hashBody(body))
+
+	calls := 0
+	_, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{}, nil })
+	if calls != 0 {
+		t.Fatalf("create ran while another request was in-flight (calls=%d)", calls)
+	}
+	var em *apierr.ErrorModel
+	if !errors.As(err, &em) {
+		t.Fatalf("error = %v, want *apierr.ErrorModel", err)
+	}
+	if em.Code != "idempotency-in-flight" || em.Status != 409 {
+		t.Fatalf("in-flight error = code %q status %d, want idempotency-in-flight/409", em.Code, em.Status)
+	}
+}
+
+func TestWithIdempotency_ErrorReleasesReservation(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	sentinel := errors.New("create boom")
+	_, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { return idemVal{}, sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want the create error propagated verbatim", err)
+	}
+	// The reservation must be released: a retry with the same key succeeds and
+	// runs create again (no leaked 409).
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "t1"}, nil })
+	if err != nil {
+		t.Fatalf("retry after failed create: %v (reservation leaked?)", err)
+	}
+	if calls != 1 || got.ID != "t1" {
+		t.Fatalf("retry did not re-run create (calls=%d, got=%+v)", calls, got)
+	}
+}
+
+func TestWithIdempotency_PanicReleasesReservation(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = withIdempotency(s, "/v0/things", "key-1", body,
+			func() (idemVal, error) { panic("boom") })
+		t.Fatal("expected panic to propagate")
+	}()
+	// The reservation must be released even though create() panicked: a retry
+	// with the same key runs create again (no key wedged for the TTL).
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "t1"}, nil })
+	if err != nil {
+		t.Fatalf("retry after panic: %v (reservation leaked on panic?)", err)
+	}
+	if calls != 1 || got.ID != "t1" {
+		t.Fatalf("retry did not re-run create after panic (calls=%d, got=%+v)", calls, got)
+	}
+}
+
+func TestWithIdempotency_WrongTypedEntryFallsThroughToCreate(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	// Seed a COMPLETED entry whose cached value is a different type than the
+	// caller's T (idemVal). replayAs[idemVal] must fail and the helper must fall
+	// through to create() rather than serve a wrong-typed/zero replay.
+	s.idem.storeResponse("POST:/v0/things:key-1", hashBody(body), "not-an-idemVal")
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "fresh"}, nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 || got.ID != "fresh" {
+		t.Fatalf("wrong-typed entry did not fall through to create (calls=%d, got=%+v)", calls, got)
+	}
+}
+
+func TestWithIdempotency_EmptyKeyPassthrough(t *testing.T) {
+	s := newIdemTestServer()
+	calls := 0
+	create := func() (idemVal, error) { calls++; return idemVal{ID: "t"}, nil }
+	if _, err := withIdempotency(s, "/v0/things", "", nil, create); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if _, err := withIdempotency(s, "/v0/things", "", nil, create); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("empty key must be a passthrough: create calls = %d, want 2", calls)
+	}
+}
+
+func TestWithIdempotency_DistinctKeysAndPathsIndependent(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	mk := func() (idemVal, error) { return idemVal{ID: "x"}, nil }
+	if _, err := withIdempotency(s, "/v0/things", "key-1", body, mk); err != nil {
+		t.Fatalf("k1: %v", err)
+	}
+	// Same key, different path → must not collide (independent create).
+	calls := 0
+	if _, err := withIdempotency(s, "/v0/others", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "y"}, nil }); err != nil {
+		t.Fatalf("other path: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("same key on a different path collided (calls=%d, want 1)", calls)
+	}
+}


### PR DESCRIPTION
## What

S1 of **audit P0 #4 — `Idempotency-Key` on mutating create endpoints**. A client that
POSTs a create, times out, and retries with the same `Idempotency-Key` must not mint a
duplicate. Today only `create-bead` and `send-mail` are covered, and each hand-rolls the
two-phase reserve/replay/unreserve dance — calling `unreserve` on ~4 separate error
paths. Miss one and a failed create leaks a *pending* reservation that 409s that key for
the full 30-min TTL. Copy-pasting that into ~10 more handlers is a defect farm.

This slice extracts the pattern and converts the two existing sites. **No new endpoints
yet** (that's S2+), so `openapi.json` is unchanged.

## Changes

- **`withIdempotency[T]` helper** (`internal/api/idempotency_helper.go`) — owns
  reserve / replay / mismatch (422) / in-flight (409) and releases the reservation on any
  error **or panic** (via `defer`), so no caller can leak one. The cache infra
  (`idempotency.go`) is untouched.
- **Convert `humaHandleBeadCreate` + `humaHandleMailSend`** to the helper — all fallible
  work moves into a `create()` closure; the handler wraps the returned body in its
  response envelope, preserving the fresh `X-GC-Index` recompute on replay. Behavior-
  preserving: scoped keys are byte-identical (`POST:/v0/beads:<key>`, `POST:/v0/mail:<key>`),
  and mail replay still skips the duplicate `Send` / telemetry / `MailSent` event. Guarded
  by the existing `TestMailSendIdempotentReplay*` tests.
- **`TestCreateEndpointsAreTriagedForIdempotency`** — introspects the live OpenAPI spec
  and requires every POST op to be classified `require` / `pending` / `exempt`. A new
  create at **any** status (201 or 202) can't ship without an `Idempotency-Key` or an
  explicit triage decision. Verified non-vacuous (fails on a dropped header and on an
  unclassified POST).

## Design notes

- The helper caches the **body value `T`**, not the whole output envelope — the
  `X-GC-Index` header is a live read (`s.latestIndex()`), so caching the envelope would
  replay a stale index. This is the only behavior-preserving shape.
- `apierr.IdempotencyInFlight` (409) / `IdempotencyMismatch` (422) already exist — no new
  codes.

## Tests / gates

`gofmt` clean, `go vet ./internal/api/` clean, full `internal/api` suite green (incl. the
bead/mail idempotency + telemetry-replay pins and 9 new helper tests). Red-teamed
(Fable) before commit: no leaked-reservation, concurrency, or wrong-typed-replay defects;
the panic-release + full-partition guard were added in response to that review.

## Follow-ups

S2+ wire the remaining creates (agent, provider, rig, convoy, pack, reply-mail, …) in
batches of ≤5, moving each from `pendingIdempotency` → `requireIdempotency`. Triage list
in `engdocs/analysis/api-audit-2026-07-08/SPEC-idempotency.md` (scratch, not committed).
