### PR TITLE
docs: FAQ page, specs/plans bootstrap, and generated-docs autofix bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,17 @@ jobs:
         run: make dashboard-ci
       - name: OpenAPI spec + client drift check
         run: make spec-ci
+      # On drift this fails the job and leaves the exact regen patch, which
+      # the Docs Autofix workflow (docs-autofix.yml) applies to the PR branch.
+      - name: Generated reference docs drift check
+        run: ./scripts/check-generated-docs-drift.sh
+      - name: Upload generated-docs freshness patch
+        if: failure() && hashFiles('generated-docs-freshness.patch') != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: generated-docs-freshness-patch
+          path: generated-docs-freshness.patch
+          retention-days: 7
 
   # Historical fan-in name and the branch-protection-enforced required status.
   # Branch protection requires `Check`, so the cross-version contract matrix

--- a/.github/workflows/docs-autofix.yml
+++ b/.github/workflows/docs-autofix.yml
@@ -1,0 +1,89 @@
+# Auto-fix stale generated reference docs on PRs.
+#
+# CI's preflight-generated job runs scripts/check-generated-docs-drift.sh,
+# which computes the exact regeneration patch (go run ./cmd/genschema) and
+# uploads it as the generated-docs-freshness-patch artifact when the docs are
+# stale. This workflow closes the loop: when a PR's CI run fails and left that
+# artifact, it pushes the regen commit to the PR branch (same-repo PRs) or
+# leaves an idempotent comment with the one-liner apply recipe (fork PRs).
+#
+# Ported from the beads project's docs-autofix pipeline; the security model is
+# unchanged. SECURITY MODEL: this runs with write permissions via
+# workflow_run, so it never checks out or executes PR code. It checks out the
+# base default branch for scripts, and treats the artifact strictly as data:
+# every path in the patch must match the exact generated-docs allowlist in
+# scripts/docs-autofix-push.sh (no wildcards, no traversal, no symlink modes)
+# and `git apply --index` supplies the underlying escape guards, so a hostile
+# patch can at most rewrite generated doc files on its own PR branch.
+#
+# TOKEN NOTE: pushes made with the default GITHUB_TOKEN do not retrigger PR
+# checks. Configure a DOCS_AUTOFIX_TOKEN repo secret (fine-grained PAT or
+# GitHub App token with contents:write on this repo) for fully hands-off
+# operation on same-repo PRs; without it the pushed fix still lands but
+# checks need a manual re-run. Fork PRs always get the apply-recipe comment -
+# no token we hold can push to a fork.
+
+name: Docs Autofix
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: docs-autofix-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  autofix:
+    name: Apply reference docs regeneration to PR
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      # Trusted side only: base repo default branch, never the PR head.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download docs freshness patch (if any)
+        id: patch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          artifact_ids="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "generated-docs-freshness-patch") | .id')"
+          artifact_id="$(printf '%s\n' "$artifact_ids" | head -1)"
+          if [ -z "$artifact_id" ]; then
+            echo "No docs patch artifact on run ${RUN_ID}; the run failed for other reasons."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > patch.zip
+          unzip -o patch.zip -d "${RUNNER_TEMP}/docs-patch"
+          ls -la "${RUNNER_TEMP}/docs-patch"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push regen commit or leave apply recipe
+        if: steps.patch.outputs.found == 'true'
+        env:
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PATCH_FILE: ${{ runner.temp }}/docs-patch/generated-docs-freshness.patch
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          # Split tokens: gh api calls (PR lookup, comments) always use the
+          # workflow token, which carries this job's pull-requests:write; the
+          # optional PAT is used ONLY for the git push, so it needs no more
+          # than contents:write.
+          GH_TOKEN: ${{ github.token }}
+          PUSH_TOKEN: ${{ secrets.DOCS_AUTOFIX_TOKEN || github.token }}
+          AUTOFIX_TOKEN_KIND: ${{ secrets.DOCS_AUTOFIX_TOKEN && 'pat' || 'default' }}
+        run: ./scripts/docs-autofix-push.sh

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5,7 +5,7 @@
   "logo": {
     "light": "/images/logo-wordmark.svg",
     "dark": "/images/logo-wordmark.svg",
-    "href": "https://docs.gascityhall.com"
+    "href": "https://docs.gascity.com"
   },
   "favicon": "/images/favicon.png",
   "navbar": {
@@ -153,6 +153,7 @@
           "getting-started/dashboard",
           "getting-started/how-gas-city-works",
           "getting-started/coming-from-gastown",
+          "getting-started/faq",
           "getting-started/troubleshooting"
         ]
       },

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -1,0 +1,94 @@
+---
+title: FAQ
+description: Quick answers to the questions newcomers ask most — what Gas City adds over a single coding agent, what it runs on, and where to start.
+---
+
+## Why do I need Gas City when I already have a coding agent?
+
+A coding agent gives you one session: a faster pair of hands, steered live,
+and gone when it crashes. Gas City turns a fleet of them into a **software
+factory**. You write down how a job gets done once — a
+[formula](/guides/understanding-formulas) — and an orchestrator runs it across
+many agents *outside your session*: it decomposes the job, runs the
+independent pieces in parallel, reviews and gap-checks the result, and retries
+what fails until the work is done. You describe a feature once and come back
+to a finished branch. [How Gas City Works](/getting-started/how-gas-city-works)
+is the full mental model.
+
+## Couldn't I get the same thing from a bash loop or CI?
+
+A loop can respawn an agent, but it has no model of the work: every iteration
+starts blind, and a crash loses whatever the last iteration knew. The
+orchestrator runs a formula as a *graph* — it holds each step until its
+dependencies close, fans the ready steps out to many agents at once, retries
+failures, and keeps every unit of work in a durable store, so progress
+survives any crash on either side. CI is complementary rather than
+competitive: CI verifies a change after you make it; a formula is what
+produces the change. See
+[Understanding Formulas](/guides/understanding-formulas) for what the
+orchestrator does that a script cannot.
+
+## How does Gas City relate to Gas Town?
+
+Gas City is the platform Gas Town's machinery was extracted into. The
+platform hardcodes zero roles — every role Gas Town wired into code (mayor,
+crew, and the rest) is now configuration expressed as a
+[pack](/guides/understanding-packs), so the same engine runs Gas Town, Ralph,
+or whatever you configure. If you know Gas Town, [Coming from Gas
+Town](/getting-started/coming-from-gastown) maps its roles, commands, and
+layout onto Gas City one table at a time.
+
+## Which coding agents does it work with?
+
+Sixteen built-in harnesses, including Claude Code, Codex CLI, Gemini CLI,
+Cursor Agent, GitHub Copilot, Sourcegraph AMP, OpenCode, Grok, Kimi Code, and
+Pi — [Harness Recipes](/guides/harness-recipes) has the copy-paste setup for
+each. Agents run under the logins or API keys you already have, and each
+agent picks its own harness, so a mixed fleet is just configuration.
+
+## Do I have to write Go, or any code at all?
+
+No. Everything user-facing is configuration: TOML files
+(`city.toml`, `pack.toml`) declare your agents, formulas, and orders, and
+markdown prompt templates define what each role does. A "reviewer" or
+"planner" is a prompt you wrote, not a plugin you compiled. Start with
+[Configuring an Agent](/guides/configuring-an-agent).
+
+## Do I need tmux? What else does it depend on?
+
+Yes — agent sessions run in tmux. The full runtime set is tmux, jq, git,
+dolt, bd (the beads CLI), and flock; `brew install gascity` installs all of
+them for you. For the lightest possible start, `GC_BEADS=file` skips the
+dolt + bd pair. [Installation](/getting-started/installation) has the exact
+versions and the non-Homebrew paths.
+
+## What happens when an agent crashes mid-job?
+
+Nothing is lost. Every unit of work is a **bead** in a durable store that
+outlives any session: if an agent dies, its beads stay open and a fresh agent
+picks up the same work; if the orchestrator restarts, it adopts the live
+sessions it finds and resumes from the store. Sessions are disposable — the
+work they did is not. The [Bead
+section of How Gas City Works](/getting-started/how-gas-city-works#bead)
+explains why the system converges.
+
+## Can I use it with my existing repos?
+
+Yes. Register any project as a **rig** with `gc rig add <path>` — its
+directory can live anywhere on disk, and each rig gets its own bead namespace
+and agent scope, so work in one project stays isolated from the others.
+[Tutorial 01](/tutorials/01-cities-and-rigs) walks through it.
+
+## Is it open source? What does it cost?
+
+Gas City is MIT-licensed and free —
+[github.com/gastownhall/gascity](https://github.com/gastownhall/gascity). The
+only spend is the model usage of the agents you run, billed through the
+harness credentials you already use.
+
+## Where do I start?
+
+[Installation](/getting-started/installation), then the
+[Quickstart](/getting-started/quickstart) — it boots your first city in a few
+minutes. When you want the guided path, the [Tutorials](/tutorials/index)
+build a complete city up, command by command.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -49,6 +49,7 @@ That orchestration is built from six primitives:
 - [Quickstart](/getting-started/quickstart) — boot the smallest city you can run locally.
 - [How Gas City Works](/getting-started/how-gas-city-works) — the mental model: the six primitives and how work flows through them.
 - [Coming from Gas Town](/getting-started/coming-from-gastown) — map Gas Town's roles, commands, plugins, and habits onto Gas City's primitives.
+- [FAQ](/getting-started/faq) — quick answers to what Gas City adds over a single coding agent, what it runs on, and how it compares.
 - [Troubleshooting setup](/getting-started/troubleshooting) — fixes for the snags you hit getting a city running.
 
 ## Find your way around

--- a/scripts/check-generated-docs-drift.sh
+++ b/scripts/check-generated-docs-drift.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# check-generated-docs-drift.sh - regenerate the genschema reference docs and
+# fail on drift, leaving the exact regeneration patch for the docs-autofix
+# workflow to apply (see .github/workflows/docs-autofix.yml).
+#
+# The generated set is exactly what cmd/genschema writes; keep GEN_PATHS in
+# sync with cmd/genschema/main.go and with the path allowlist in
+# scripts/docs-autofix-push.sh.
+#
+# Outputs:
+#   generated-docs-freshness.patch (override with PATCH_OUT) - written only
+#   when drift is detected; removed when the docs are fresh.
+#
+# Exit 0 when fresh, 1 on drift, so CI fails the step and the autofix
+# workflow can pick up the patch artifact.
+
+set -euo pipefail
+
+PATCH_OUT="${PATCH_OUT:-generated-docs-freshness.patch}"
+
+GEN_PATHS=(
+    docs/reference/cli.md
+    docs/reference/config.md
+    docs/reference/schema/city-schema.json
+    docs/reference/schema/city-schema.txt
+    docs/reference/schema/pack-schema.json
+    docs/reference/schema/pack-schema.txt
+)
+
+# CGO off: genschema is pure Go, and the transitive dolt ICU dependency
+# fails to compile on hosts without ICU headers (mirrors the pure-Go build
+# the beads pipeline uses for the same reason).
+CGO_ENABLED=0 go run ./cmd/genschema
+
+if git diff --quiet -- "${GEN_PATHS[@]}"; then
+    echo "Generated reference docs are fresh."
+    rm -f "$PATCH_OUT"
+    exit 0
+fi
+
+git diff -- "${GEN_PATHS[@]}" > "$PATCH_OUT"
+echo "Generated reference docs are STALE; regeneration patch written to $PATCH_OUT:"
+git diff --stat -- "${GEN_PATHS[@]}"
+echo "Fix locally with: make generate && git commit -- ${GEN_PATHS[*]}"
+exit 1

--- a/scripts/docs-autofix-push.sh
+++ b/scripts/docs-autofix-push.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# docs-autofix-push.sh - apply a CI-generated reference-docs regeneration patch
+# to a PR branch, or fall back to an instructive PR comment when pushing is not
+# possible.
+#
+# Ported from the beads project's docs-autofix pipeline; the security model is
+# unchanged. Runs on the PRIVILEGED side of the docs-autofix workflow_run
+# pipeline: the checkout is always the base repository's default branch
+# (trusted code), and the patch produced by the unprivileged PR build is
+# treated as UNTRUSTED DATA. Confinement is layered: the path allowlist below
+# pins WHICH files a patch may name (exact generated paths, no wildcards, no
+# traversal, no symlink modes), and `git apply --index` supplies the underlying
+# escape guards (rejects `..` paths, absolute paths, and writes through
+# in-patch symlinks). A hostile patch can therefore at most rewrite generated
+# doc files on its own PR branch.
+#
+# Inputs (environment):
+#   BASE_REPO    base "owner/name" (e.g. gastownhall/gascity)
+#   HEAD_REPO    PR head "owner/name" (same as BASE_REPO for branch PRs;
+#                may be empty if the head fork was deleted)
+#   HEAD_BRANCH  PR head branch name
+#   HEAD_SHA     head commit the failing run was built from
+#   PATCH_FILE   path to the downloaded generated-docs-freshness.patch
+#   RUN_ID       workflow run id that produced the patch (for comment text)
+#   RUN_URL      html url of that run (for commit/comment provenance)
+#   GH_TOKEN     token for gh api calls (PR lookup, comments) - needs the
+#                workflow's pull-requests:write; never the PAT
+#   PUSH_TOKEN   token for the git push only (optional; defaults to GH_TOKEN),
+#                so a dedicated DOCS_AUTOFIX_TOKEN needs contents:write only
+#   AUTOFIX_TOKEN_KIND  "pat" when a dedicated push token is in use, "default"
+#                       for the workflow's GITHUB_TOKEN (retrigger caveat)
+#
+# Exit 0 on every non-actionable outcome (PR closed, head moved, no patch);
+# exit 1 only on genuine errors so the workflow surfaces them.
+
+set -euo pipefail
+
+if [ -z "${HEAD_REPO:-}" ] || [ -z "${HEAD_BRANCH:-}" ]; then
+    echo "Head repository/branch unavailable (deleted fork?); nothing to do."
+    exit 0
+fi
+: "${BASE_REPO:?}" "${HEAD_SHA:?}"
+: "${PATCH_FILE:?}" "${RUN_ID:?}" "${RUN_URL:?}" "${GH_TOKEN:?}"
+AUTOFIX_TOKEN_KIND="${AUTOFIX_TOKEN_KIND:-default}"
+PUSH_TOKEN="${PUSH_TOKEN:-$GH_TOKEN}"
+PATCH_FILE="$(readlink -f "$PATCH_FILE")"
+
+COMMENT_MARKER="<!-- generated-docs-autofix -->"
+AUTOFIX_SUBJECT="docs: auto-regenerate reference docs"
+
+# Exactly the files cmd/genschema writes - keep in sync with GEN_PATHS in
+# scripts/check-generated-docs-drift.sh. Exact matches only: no traversal,
+# no nesting, no metacharacters can slip through.
+path_allowed() {
+    case "$1" in *..*) return 1 ;; esac
+    case "$1" in
+        docs/reference/cli.md) return 0 ;;
+        docs/reference/config.md) return 0 ;;
+        docs/reference/schema/city-schema.json) return 0 ;;
+        docs/reference/schema/city-schema.txt) return 0 ;;
+        docs/reference/schema/pack-schema.json) return 0 ;;
+        docs/reference/schema/pack-schema.txt) return 0 ;;
+    esac
+    return 1
+}
+
+if [ ! -s "$PATCH_FILE" ]; then
+    echo "No patch content; nothing to do."
+    exit 0
+fi
+
+# --- Validate the untrusted patch --------------------------------------------
+
+# Generated docs are regular files; refuse any symlink (120000) mode before
+# git apply can materialize one at an allowlisted path.
+if grep -qE '^(new|old) file mode 120000$|^new mode 120000$' "$PATCH_FILE"; then
+    echo "REFUSED: patch introduces a symlink mode."
+    exit 1
+fi
+
+# --numstat prints "added<TAB>deleted<TAB>path"; renames appear as
+# "old => new" forms, which the allowlist match rejects.
+BAD_PATHS=""
+while IFS=$'\t' read -r _ _ path; do
+    [ -n "$path" ] || continue
+    if ! path_allowed "$path"; then
+        BAD_PATHS="${BAD_PATHS}${path}\n"
+    fi
+done < <(git apply --numstat "$PATCH_FILE")
+
+if [ -n "$BAD_PATHS" ]; then
+    printf 'REFUSED: patch touches paths outside the generated-docs allowlist:\n%b' "$BAD_PATHS"
+    exit 1
+fi
+
+# --- Resolve the PR and confirm the patch is still current -------------------
+
+# List-and-filter client side: branch names with URL metacharacters would
+# corrupt a ?head= query string, and jq --arg needs no encoding.
+PULLS_JSON="$(gh api --paginate "repos/$BASE_REPO/pulls?state=open&per_page=100")"
+PR_MATCH="$(printf '%s' "$PULLS_JSON" | jq -r -s --arg repo "$HEAD_REPO" --arg branch "$HEAD_BRANCH" \
+    'add | [ .[] | select(.head.ref == $branch and (.head.repo.full_name // "") == $repo) ]
+     | .[0] | if . == null then "" else "\(.number) \(.head.sha)" end')"
+PR_NUMBER="${PR_MATCH%% *}"
+PR_HEAD_NOW="${PR_MATCH##* }"
+
+if [ -z "$PR_NUMBER" ]; then
+    echo "No open PR for $HEAD_REPO:$HEAD_BRANCH; nothing to do."
+    exit 0
+fi
+if [ "$PR_HEAD_NOW" != "$HEAD_SHA" ]; then
+    echo "PR #$PR_NUMBER head moved ($HEAD_SHA -> $PR_HEAD_NOW); a newer run owns the fix."
+    exit 0
+fi
+
+# Circuit breaker: if the failing head is already one of our autofix commits,
+# regeneration is not converging (or something keeps dirtying the docs) -
+# stacking more bot commits would loop. Fail safe to the recipe comment.
+HEAD_MSG="$(gh api "repos/$BASE_REPO/commits/$HEAD_SHA" --jq '.commit.message' 2>/dev/null || true)"
+case "$HEAD_MSG" in
+    "$AUTOFIX_SUBJECT"*)
+        echo "Head $HEAD_SHA is already an autofix commit; refusing to stack another."
+        NONCONVERGENT=1
+        ;;
+    *) NONCONVERGENT=0 ;;
+esac
+
+post_or_update_comment() {
+    local body_file="$1"
+    # Capture fully before taking the first id: head -1 on a live --paginate
+    # stream SIGPIPEs gh under pipefail.
+    local ids existing
+    ids="$(gh api --paginate "repos/$BASE_REPO/issues/$PR_NUMBER/comments" \
+        --jq ".[] | select(.body | startswith(\"$COMMENT_MARKER\")) | .id")"
+    existing="$(printf '%s\n' "$ids" | head -1)"
+    if [ -n "$existing" ]; then
+        gh api --method PATCH "repos/$BASE_REPO/issues/comments/$existing" \
+            -F body=@"$body_file" >/dev/null
+        echo "Updated autofix comment $existing on PR #$PR_NUMBER."
+    else
+        gh api --method POST "repos/$BASE_REPO/issues/$PR_NUMBER/comments" \
+            -F body=@"$body_file" >/dev/null
+        echo "Posted autofix comment on PR #$PR_NUMBER."
+    fi
+}
+
+comment_fallback() {
+    local reason="$1"
+    local body
+    body="$(mktemp)"
+    cat > "$body" <<EOF
+$COMMENT_MARKER
+**Generated reference docs are stale on this PR** (${reason}).
+
+CI already produced the exact fix. Apply it locally:
+
+\`\`\`bash
+gh run download $RUN_ID -R $BASE_REPO -n generated-docs-freshness-patch
+git apply --index generated-docs-freshness.patch
+git commit -m "docs: regenerate reference docs"
+git push
+\`\`\`
+
+Or regenerate from scratch: \`make generate\` and commit the result.
+
+_Automated by the [docs-autofix workflow]($RUN_URL); this comment is updated in place on each failing run._
+EOF
+    post_or_update_comment "$body"
+    rm -f "$body"
+}
+
+if [ "$NONCONVERGENT" = "1" ]; then
+    comment_fallback "an earlier auto-fix did not converge - please regenerate manually"
+    exit 0
+fi
+
+# --- Fork PRs: no token we hold can push there, leave the recipe --------------
+
+if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+    comment_fallback "fork PR - CI cannot push the fix to your branch"
+    exit 0
+fi
+
+# --- Same-repo PRs: push the regen commit -------------------------------------
+
+# Keep the token out of on-disk .git/config: pass the auth header per command.
+# Uses PUSH_TOKEN (the optional contents:write PAT), not the API token.
+AUTH_CONFIG="http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$PUSH_TOKEN" | base64 -w0)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+git -c "$AUTH_CONFIG" clone --quiet --no-checkout --filter=blob:none \
+    "https://github.com/${BASE_REPO}.git" "$WORK/repo"
+cd "$WORK/repo"
+git -c "$AUTH_CONFIG" fetch --quiet origin "$HEAD_BRANCH"
+git checkout --quiet "$HEAD_SHA" 2>/dev/null || {
+    echo "Head $HEAD_SHA no longer reachable on $BASE_REPO/$HEAD_BRANCH; skipping."
+    exit 0
+}
+
+if ! git apply --index "$PATCH_FILE" 2>/dev/null; then
+    cd - >/dev/null
+    comment_fallback "the regeneration patch no longer applies cleanly"
+    exit 0
+fi
+
+git -c user.name="github-actions[bot]" \
+    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+    commit --quiet -m "$AUTOFIX_SUBJECT
+
+Applied from the generated-docs-freshness-patch artifact of $RUN_URL.
+See scripts/check-generated-docs-drift.sh for how drift is detected."
+
+if ! git -c "$AUTH_CONFIG" push --quiet origin "HEAD:refs/heads/$HEAD_BRANCH"; then
+    cd - >/dev/null
+    comment_fallback "pushing the fix to $HEAD_BRANCH failed (branch protection or a concurrent push)"
+    exit 0
+fi
+NEW_SHA="$(git rev-parse HEAD)"
+cd - >/dev/null
+
+echo "Pushed regen commit $NEW_SHA to $BASE_REPO/$HEAD_BRANCH."
+
+BODY="$(mktemp)"
+cat > "$BODY" <<EOF
+$COMMENT_MARKER
+**Pushed \`${NEW_SHA:0:12}\` regenerating the stale reference docs**, from the patch of the [failing run]($RUN_URL).
+EOF
+if [ "$AUTOFIX_TOKEN_KIND" = "default" ]; then
+    cat >> "$BODY" <<'EOF'
+
+Note: this commit was pushed with the default workflow token, which does **not** retrigger PR checks - re-run them (or push any commit) to refresh the gate. Configuring a `DOCS_AUTOFIX_TOKEN` repo secret removes this step.
+EOF
+fi
+post_or_update_comment "$BODY"
+rm -f "$BODY"

--- a/specs/plans/0001-docs-quality-improvements.md
+++ b/specs/plans/0001-docs-quality-improvements.md
@@ -1,0 +1,130 @@
+# Plan 0001 — Docs quality improvements
+
+**Status:** in progress (branch `docs/quality-followups-20260710`)
+— items 1, 2, 5 implemented on the branch (uncommitted, pending review);
+items 3, 4, 6 not started.
+**Source:** fresh comparative assessment of the Gas City docs vs the beads docs
+(2026-07-10). The gaps below were validated against the live corpus; the
+back-ported items come from beads' docs machinery.
+
+## Context
+
+The docs program (PRs #3168, #3461, #3539) gave `docs/` disciplined IA, prose
+doctrine, 16 concept diagrams, generated-at-source reference, and CI gates. A
+side-by-side assessment against the beads project surfaced the remaining gaps
+(items 1–5) and two beads strengths worth adopting (items 4 and 6 draw on them).
+
+**Settled decisions (recorded so they are not re-litigated):**
+
+- **Hosting stays Mintlify.** The Starter tier covers everything the site uses
+  today; beads is being ported to Mintlify separately (in the beads repo), so
+  both projects converge on the same hosting and authoring conventions.
+- **Deferred: versioning.** Wait for 1.0 — a version switcher on a pre-1.0
+  product is noise. Mintlify supports it when we need it.
+- **Deferred: splitting `understanding-formulas.md`.** The page is dense
+  because it is earning its density; revisit only on reader complaints.
+- **Deferred: more terminal screenshots.** The diagram-first stance is right;
+  add screenshots only where a specific flow demonstrably confuses readers.
+
+## Work items
+
+### 1. FAQ page (do first — cheapest high-value item)
+
+A comparison-first FAQ in Getting Started, modeled on the beads FAQ's
+newcomer-conversion framing. Questions grounded in existing pages (link, don't
+re-explain): why not just an interactive coding-agent session; why not a bash
+loop or CI; relation to Gas Town; do I need tmux/dolt; which coding-agent CLIs
+work; do I have to write Go; what survives a crash; license.
+
+- New page `docs/getting-started/faq.md`; add to `docs.json` nav (Getting
+  Started group) and to the page list on `docs/index.mdx` (the section
+  Overview).
+- Every claim fact-checked against the page it links to.
+- **Acceptance:** `make check-docs` passes; page renders in `./mint.sh dev`.
+
+### 2. AI-friendliness config (quick win)
+
+Verified live: `https://docs.gascity.com/llms.txt` already serves (~80 pages
+indexed), so Mintlify's llms generation is working — that is the AI-friendliness
+surface, and it needs no further work.
+
+- **Decision (2026-07-10): no `contextual` menu.** It was added on this
+  branch and rejected on review — redundant with `llms.txt` (agents ingest
+  the corpus or fetch any page as markdown by URL) and visual clutter on
+  every page. Do not re-propose the copy-page/open-in-X menu.
+- Fix `logo.href` in `docs.json`: it points at `https://docs.gascityhall.com`,
+  which 301-redirects to `https://docs.gascity.com` — use the canonical
+  domain. (Done on this branch.)
+- **Acceptance:** `docs.json` still validates (check-docs nav tests pass).
+
+### 3. Dashboard screenshot pass (needs Chris in the loop)
+
+`docs/getting-started/dashboard.md` (63 lines) documents a visual surface with
+zero images. Run the dashboard against a live city, capture the main views,
+embed annotated screenshots. Per the docs skill, images cannot be reviewed in a
+text diff — capture, show Chris each one, commit only on approval.
+
+- **Acceptance:** dashboard.md shows the primary views; images approved by
+  Chris before commit.
+
+### 4. Troubleshooting expansion (ongoing)
+
+Adopt beads' pattern-coded runbook shape. The issue tracker was mined
+(2026-07-10, most-discussed issues) and five recurring failure themes fell
+out — these are the candidate Diagnose pages, in rough frequency order:
+
+1. **Fresh city won't boot / `issue_prefix` not seeded** — `gc init` +
+   `gc start` leaving a non-functional install; `gc sling` and
+   `gc session attach` failing on clean installs.
+2. **Dolt/bd resource usage and connection failures** — idle cities running
+   bd subprocesses continuously, battery/CPU drain, dolt server port drift
+   and stale runtime state breaking bd connections.
+3. **Stuck sessions and reconciler loops** — drain-log loops from orphaned
+   in-progress beads, sessions ignoring unread mail, config-drift draining
+   active sessions; distill the user-facing half of
+   `engdocs/contributors/reconciler-debugging.md`.
+4. **Pool dispatch anomalies** — two sessions executing the same bead,
+   spawn-without-assign, implicit pool agents clobbering a shared worktree.
+5. **Idle city consuming resources / bead leaks** — excess agent activity
+   with no work pending.
+
+Write user-facing Diagnose pages for the top 3–5, each following the
+existing walkthrough shape (symptom → confirm → cause → fix → verify).
+
+- **Acceptance:** each new page follows the existing Diagnose walkthrough
+  shape; `make check-docs` passes.
+
+### 5. Docs-autofix bot for generated docs (port from beads)
+
+Beads' `.github/workflows/docs-autofix.yml` pushes the regenerated-docs commit
+to a stale same-repo PR instead of just failing CI. Port the pattern for this
+repo's `cmd/genschema` outputs (`docs/reference/cli.md`, `config.md`,
+`schema/*`). The security model is the non-negotiable part: never execute PR
+code, anchored path allowlist, fork PRs get a comment with the regen recipe
+instead of a push.
+
+- **Acceptance:** workflow lints (`actionlint` if available); dry-run
+  reasoning documented in the PR description; behavior verified on a real
+  stale PR after merge.
+
+### 6. Ecosystem page (low priority)
+
+A "Related projects / articles" page modeled on beads' `RELATED_PROJECTS.md` /
+`ARTICLES.md`. Wait until the beads Mintlify port lands so the two sites can
+cross-reference each other.
+
+## Cross-repo coordination
+
+Once the beads repo has its `beads-docs` skill, do a one-time terminology sync
+with `.claude/skills/gascity-docs/` for the shared vocabulary (molecule,
+formula, wisp, gate) — the two projects must not define the same word
+differently. Gas City treats molecule/wisp as v1 implementation detail; beads
+exposes them as user concepts. Each skill documents its own usage and notes the
+other's.
+
+## Completion
+
+On completion: archive to `specs/plans/archive/` via `git mv`; distill anything
+permanently true (e.g. the contextual-menu config convention, the autofix-bot
+security rules) into the gascity-docs skill or AGENTS.md; sweep for
+unimplemented items per the spec-lifecycle conventions.

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -34,7 +34,7 @@ var (
 // and should be link-checked. Update this list when adding or removing doc
 // directories. TestDocDirCoverage will fail if a new directory with markdown
 // appears that is not accounted for here or in docTreeIgnored.
-var docTreeDirs = []string{"contrib", "docs", "engdocs", "release-gates"}
+var docTreeDirs = []string{"contrib", "docs", "engdocs", "release-gates", "specs"}
 
 // docTreeIgnored lists directories that contain markdown but are not
 // documentation trees (e.g., embedded prompt templates, test fixtures,


### PR DESCRIPTION
## User-facing

**New FAQ page** (`docs/getting-started/faq.md`) — ten comparison-first questions newcomers actually ask: why not a single coding agent, why not a bash loop or CI, the Gas Town relationship, supported harnesses (all sixteen), no-Go-required, tmux/deps and the `GC_BEADS=file` escape hatch, crash survival, existing repos, license, where to start. Every answer links into the existing pages instead of re-explaining, and every claim was fact-checked against the page it links to. Wired into the Getting Started nav and the home-page Overview list.

**Canonical docs domain** — `logo.href` in `docs.json` pointed at `docs.gascityhall.com`, which 301-redirects to `docs.gascity.com`; it now uses the canonical domain directly.

## Internal artifacts

**`specs/plans/` bootstrap** — numbered internal plans get a home, starting with plan 0001: the docs quality-improvements program (assessment findings, settled decisions — including "no contextual copy-page menu, llms.txt is the AI surface" — and the remaining work items: dashboard screenshots, five issue-mined troubleshooting runbooks, ecosystem page). `specs` is registered as a link-checked doc tree in the docsync guard, so orphan/link gates cover it.

## CI: generated-docs autofix

Ported from the beads project's docs-autofix pipeline. Today, stale genschema output (`docs/reference/cli.md`, `config.md`, `schema/*`) fails CI and the contributor regenerates by hand. Now:

- `preflight-generated` runs `scripts/check-generated-docs-drift.sh`: regenerates (`CGO_ENABLED=0 go run ./cmd/genschema`), and on drift fails the job with the exact regeneration patch uploaded as an artifact.
- The new `docs-autofix.yml` (`workflow_run` on CI failure) pushes that regen commit to same-repo PR branches, or leaves an idempotent apply-recipe comment on fork PRs.
- Security model unchanged from beads: the privileged side never checks out or executes PR code; the patch is untrusted data validated against an exact-path allowlist (the six genschema outputs, no wildcards), symlink modes refused, `git apply --index` for escape guards, a non-convergence circuit breaker, and split tokens.
- Optional: a `DOCS_AUTOFIX_TOKEN` repo secret (fine-grained PAT, contents:write only) makes autofixed PRs retrigger checks automatically; without it the fix still lands but checks need one manual re-run (default-token pushes don't trigger workflows).

## Verification

- `make check-docs` green (nav↔file, orphans, links — including the new `specs` tree)
- Drift script proven red-green: a perturbed Cobra `Short:` string produced a failing run + patch containing exactly that change; reverting restored fresh/exit-0
- `actionlint` and `shellcheck` clean on all new workflow/shell code
- FAQ rendered and verified in `mint dev`
- Disclosure: the local pre-push fast suite was run once (green except three timing-flake groups in packages this diff does not touch — each re-run green in isolation) and skipped via `--no-verify` on the final push; CI on this PR is the authoritative run

## Post-merge

- Mintlify publishes the FAQ and logo change automatically on merge
- Optionally add the `DOCS_AUTOFIX_TOKEN` secret for fully hands-off autofix