### PR TITLE
Fix rig workflows stalling because no dispatcher could claim their control steps

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -763,9 +763,9 @@ func buildDesiredStateWithSessionBeads(
 		// string, so the route must be canonicalized before demand is counted or
 		// the cold pool never wakes for it.
 		subPhaseStart = time.Now()
-		unassignedRoutedBeads, unassignedRoutedStores := collectOpenUnassignedRoutedWork(cfg, store, rigStores, suspendedRigPaths, stderr)
+		unassignedRoutedBeads, unassignedRoutedStores, unassignedRoutedStoreRefs := collectOpenUnassignedRoutedWork(cfg, store, rigStores, suspendedRigPaths, stderr)
 		canonicalizeLegacyBoundUnassignedRoutedWork(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
-		controlDispatcherOpenDemand := openControlDispatcherDemand(cfg, unassignedRoutedBeads)
+		controlDispatcherOpenDemand := openControlDispatcherDemand(cityPath, cfg, unassignedRoutedBeads, unassignedRoutedStoreRefs)
 		recordDemandSubPhase(trace, "demand_snapshot.collect_unassigned_routed", subPhaseStart, map[string]any{
 			"beads": len(unassignedRoutedBeads),
 		})
@@ -1703,7 +1703,7 @@ func controllerDemandRouteCandidates(b beads.Bead) []string {
 	return routedToAndLegacyWorkflowCandidates(b)
 }
 
-func openControlDispatcherDemand(cfg *config.City, workBeads []beads.Bead) map[string]bool {
+func openControlDispatcherDemand(cityPath string, cfg *config.City, workBeads []beads.Bead, workStoreRefs []string) map[string]bool {
 	demand := make(map[string]bool)
 	if cfg == nil || len(workBeads) == 0 {
 		return demand
@@ -1715,6 +1715,15 @@ func openControlDispatcherDemand(cfg *config.City, workBeads []beads.Bead) map[s
 	// upgrade scaling the qualified dispatcher (keyed by the template name the
 	// scaler matches).
 	aliasToCanonical := make(map[string]string)
+	// Control-step routing deliberately stamps the CITY singleton's qualified
+	// name for every scope (config.PreferredDeterministicControlDispatcher), so
+	// control beads minted into a rig store carry a city-singleton alias. Only
+	// the rig dispatcher serving that store can claim them (the city dispatcher
+	// never queries rig stores), so demand for those beads must wake the RIG
+	// dispatcher, not the city one — otherwise the city dispatcher wakes to an
+	// empty city store while the rig-store bead wedges forever (ga-8jx).
+	citySingletonAliases := make(map[string]bool)
+	rigDispatcherByDir := make(map[string]string)
 	for i := range cfg.Agents {
 		if !config.IsDeterministicControlDispatcher(&cfg.Agents[i]) {
 			continue
@@ -1726,19 +1735,42 @@ func openControlDispatcherDemand(cfg *config.City, workBeads []beads.Bead) map[s
 				aliasToCanonical[bare] = qualified
 			}
 		}
+		if strings.TrimSpace(cfg.Agents[i].Dir) != "" {
+			if rigName := configuredRigName(cityPath, &cfg.Agents[i], cfg.Rigs); rigName != "" {
+				if _, taken := rigDispatcherByDir[rigName]; !taken {
+					rigDispatcherByDir[rigName] = qualified
+				}
+			}
+		} else {
+			citySingletonAliases[qualified] = true
+			if bare := controlDispatcherBareRoute(qualified); bare != "" {
+				citySingletonAliases[bare] = true
+			}
+		}
 	}
 	if len(aliasToCanonical) == 0 {
 		return demand
 	}
-	for _, wb := range workBeads {
+	for i, wb := range workBeads {
 		if wb.Status != "open" || strings.TrimSpace(wb.Assignee) != "" {
 			continue
 		}
+		storeRef := ""
+		if i < len(workStoreRefs) {
+			storeRef = workStoreRefs[i]
+		}
 		for _, candidate := range controllerDemandRouteCandidates(wb) {
-			if canonical, ok := aliasToCanonical[candidate]; ok {
-				demand[canonical] = true
-				break
+			canonical, ok := aliasToCanonical[candidate]
+			if !ok {
+				continue
 			}
+			if citySingletonAliases[candidate] && storeRef != "" && storeRef != "city" {
+				if rigCanonical, ok := rigDispatcherByDir[storeRef]; ok {
+					canonical = rigCanonical
+				}
+			}
+			demand[canonical] = true
+			break
 		}
 	}
 	return demand
@@ -4194,9 +4226,9 @@ func canonicalizeLegacyBoundUnassignedRoutedWork(cfg *config.City, workBeads []b
 // by the assignee-keyed collectAssignedWorkBeadsWithStores passes, so the
 // migration re-home needs its own scan. Active-only List queries are served from
 // the CachingStore in steady state, so this adds no backing-store round trip.
-func collectOpenUnassignedRoutedWork(cfg *config.City, store beads.Store, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool, stderr io.Writer) ([]beads.Bead, []beads.Store) {
+func collectOpenUnassignedRoutedWork(cfg *config.City, store beads.Store, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool, stderr io.Writer) ([]beads.Bead, []beads.Store, []string) {
 	if cfg == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	// Work arm (unassigned-routed re-home scan): iterate the work-class
 	// candidate fan-out, labeling the city store "city" for the diagnostic
@@ -4205,6 +4237,7 @@ func collectOpenUnassignedRoutedWork(cfg *config.City, store beads.Store, rigSto
 
 	var workBeads []beads.Bead
 	var workStores []beads.Store
+	var workStoreRefs []string
 	seen := make(map[string]struct{})
 	for _, source := range stores {
 		if source.store == nil {
@@ -4228,9 +4261,10 @@ func collectOpenUnassignedRoutedWork(cfg *config.City, store beads.Store, rigSto
 			seen[b.ID] = struct{}{}
 			workBeads = append(workBeads, b)
 			workStores = append(workStores, source.store)
+			workStoreRefs = append(workStoreRefs, source.ref)
 		}
 	}
-	return workBeads, workStores
+	return workBeads, workStores, workStoreRefs
 }
 
 func selectOrCreateDependencyPoolSessionBead(

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -11007,9 +11007,101 @@ func TestOpenControlDispatcherDemandHonorsBareLegacyRoute(t *testing.T) {
 			"gc.routed_to": config.ControlDispatcherAgentName, // bare, pre-1.3 route
 		},
 	}}
-	demand := openControlDispatcherDemand(cfg, work)
+	demand := openControlDispatcherDemand(t.TempDir(), cfg, work, []string{"city"})
 	if !demand["core.control-dispatcher"] {
 		t.Fatalf("openControlDispatcherDemand = %v, want demand keyed by qualified name from bare route", demand)
+	}
+}
+
+// TestOpenControlDispatcherDemandAttributesRigStoreBeadsToRigDispatcher guards
+// the ga-8jx wedge: control-step routing stamps the CITY singleton's qualified
+// name ("core.control-dispatcher") for every scope, so control beads minted
+// into a rig store carry the unprefixed city name. Demand for those beads must
+// wake the RIG dispatcher serving that store — the city dispatcher never
+// queries rig stores, so attributing the demand to it wakes a dispatcher that
+// finds an empty city store while the rig-store bead wedges forever.
+func TestOpenControlDispatcherDemandAttributesRigStoreBeadsToRigDispatcher(t *testing.T) {
+	maxActive := 1
+	rigMaxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{{
+			Name: "fixture",
+			Path: "/tmp/fixture",
+		}},
+		Agents: []config.Agent{
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MaxActiveSessions: &maxActive,
+			},
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				Dir:               "fixture",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MaxActiveSessions: &rigMaxActive,
+			},
+		},
+	}
+	work := []beads.Bead{
+		{
+			ID:     "rig-ralph-container",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.kind":      "ralph",
+				"gc.routed_to": "core.control-dispatcher",
+			},
+		},
+		{
+			ID:     "city-finalize",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.kind":      "workflow-finalize",
+				"gc.routed_to": "core.control-dispatcher",
+			},
+		},
+	}
+	demand := openControlDispatcherDemand(t.TempDir(), cfg, work, []string{"fixture", "city"})
+	if !demand["fixture/core.control-dispatcher"] {
+		t.Fatalf("openControlDispatcherDemand = %v, want rig-store bead to wake the rig dispatcher", demand)
+	}
+	if !demand["core.control-dispatcher"] {
+		t.Fatalf("openControlDispatcherDemand = %v, want city-store bead to keep waking the city dispatcher", demand)
+	}
+}
+
+// TestOpenControlDispatcherDemandRigStoreFallsBackToCityWithoutRigDispatcher
+// pins the fallback: a rig-store bead routed to the city singleton still
+// creates city-dispatcher demand when the config has no rig-scoped dispatcher
+// copy, preserving pre-ga-8jx behavior for cities without per-rig dispatchers.
+func TestOpenControlDispatcherDemandRigStoreFallsBackToCityWithoutRigDispatcher(t *testing.T) {
+	maxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{{
+			Name: "fixture",
+			Path: "/tmp/fixture",
+		}},
+		Agents: []config.Agent{{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			MaxActiveSessions: &maxActive,
+		}},
+	}
+	work := []beads.Bead{{
+		ID:     "rig-ralph-container",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":      "ralph",
+			"gc.routed_to": "core.control-dispatcher",
+		},
+	}}
+	demand := openControlDispatcherDemand(t.TempDir(), cfg, work, []string{"fixture"})
+	if !demand["core.control-dispatcher"] {
+		t.Fatalf("openControlDispatcherDemand = %v, want fallback to city dispatcher demand", demand)
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1054,6 +1054,14 @@ func (cr *CityRuntime) tick(
 
 	if !configChanged && cr.shouldSkipTickForFSPressure(trace, trigger) {
 		cr.processConvergenceRequests(ctx)
+		// Keep the singleton control dispatchers alive even while shedding full
+		// ticks: they are the only agents that advance workflow control beads
+		// (ralph containers, workflow-finalize), so a dispatcher that dies
+		// during a sustained IO-pressure episode would otherwise stay dead for
+		// the whole episode and wedge every in-flight run (ga-8jx). The
+		// dispatcher-only pass reconciles just the city + rig control
+		// dispatchers — a bounded fraction of a full tick.
+		cr.controlDispatcherTick(ctx)
 		completion = TraceCompletionCompleted
 		tickCompleted = true
 		return

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -3172,6 +3172,72 @@ func TestControlDispatcherBareRoute(t *testing.T) {
 	}
 }
 
+// TestControlDispatcherCitySingletonRoute pins the dir-stripping alias
+// derivation (ga-8jx): a rig dispatcher must also claim control beads stamped
+// with the city singleton's qualified name, because control-step routing
+// prefers the city singleton for every scope while the beads land in the rig
+// store the city dispatcher never queries.
+func TestControlDispatcherCitySingletonRoute(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"rig/core.control-dispatcher", "core.control-dispatcher"},
+		{"rig/control-dispatcher", "control-dispatcher"},
+		{"core.control-dispatcher", ""}, // city target: already the city alias
+		{"control-dispatcher", ""},      // city bare target: already the city alias
+		{"rig/gascity.polecat", ""},     // not a control dispatcher
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := controlDispatcherCitySingletonRoute(tc.in); got != tc.want {
+			t.Errorf("controlDispatcherCitySingletonRoute(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestWorkflowServeControlReadyQueryHonorsCitySingletonRoute guards the
+// ga-8jx wedge at the query layer: a rig-scoped dispatcher's serve query must
+// scan for control beads routed to the unprefixed city-singleton name, and
+// the city dispatcher's own query must not grow a redundant self-alias.
+func TestWorkflowServeControlReadyQueryHonorsCitySingletonRoute(t *testing.T) {
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, BindingName: "core", Dir: "fixture"})
+	if !strings.Contains(query, "GC_CONTROL_TARGET='fixture/core.control-dispatcher'") {
+		t.Fatalf("serve query missing qualified target: %q", query)
+	}
+	if !strings.Contains(query, "GC_CONTROL_CITY_TARGET='core.control-dispatcher'") {
+		t.Fatalf("serve query missing city-singleton target: %q", query)
+	}
+	if !strings.Contains(query, `routed_ready "${GC_CONTROL_CITY_TARGET:-}"`) {
+		t.Fatalf("serve query missing city-singleton routed_ready scan: %q", query)
+	}
+
+	cityQuery := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, BindingName: "core"})
+	if strings.Contains(cityQuery, "GC_CONTROL_CITY_TARGET=") {
+		t.Fatalf("city serve query should not carry a redundant city-singleton alias: %q", cityQuery)
+	}
+}
+
+// TestWorkflowServeControlReadyQueryClaimsCityRoutedRigStoreControlWork is the
+// end-to-end regression for the ga-8jx wedge: a ralph container in a rig store
+// routed to "core.control-dispatcher" must surface in the rig dispatcher's
+// ready queue.
+func TestWorkflowServeControlReadyQueryClaimsCityRoutedRigStoreControlWork(t *testing.T) {
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, BindingName: "core", Dir: "fixture"})
+	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
+		"GC_SESSION_NAME": "fixture--core__control-dispatcher",
+		"GC_ALIAS":        "fixture/core.control-dispatcher",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  "--readonly --sandbox ready --metadata-field gc.routed_to=core.control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+    printf '[{"id":"tlp-ralph-container","metadata":{"gc.routed_to":"core.control-dispatcher","gc.kind":"ralph"}}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	assertJSONEqual(t, out, `[{"id":"tlp-ralph-container","metadata":{"gc.routed_to":"core.control-dispatcher","gc.kind":"ralph"}}]`)
+}
+
 func TestWorkflowServeControlReadyQueryIgnoresInProgressAssigned(t *testing.T) {
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
 	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
@@ -5263,6 +5329,56 @@ func TestRunWorkflowServeFollowSurvivesTransientWorkQueryTimeout(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("workflowServeList calls = %d, want 2 (survive transient, then exit on fatal)", calls)
+	}
+}
+
+// TestRunWorkflowServeFollowSurvivesDoltCircuitBreakerOutage guards the ga-8jx
+// serve-loop death: when the rig dolt sql-server goes down, bd's client-side
+// breaker first surfaces "connection refused (circuit breaker tripped)" and
+// then flips to fail-fast "dolt circuit breaker is open: server appears down,
+// failing fast (cooldown 5s)". Both are recoverable outage shapes — the follow
+// loop must keep sweeping through them instead of exiting, otherwise the rig
+// dispatcher dies mid-outage and every in-flight run wedges once dolt returns.
+func TestRunWorkflowServeFollowSurvivesDoltCircuitBreakerOutage(t *testing.T) {
+	eventsDir := t.TempDir()
+	ep := newTestProvider(t, eventsDir)
+
+	prevList := workflowServeList
+	prevProvider := workflowServeOpenEventsProvider
+	prevWait := workflowServeWaitForWake
+	t.Cleanup(func() {
+		workflowServeList = prevList
+		workflowServeOpenEventsProvider = prevProvider
+		workflowServeWaitForWake = prevWait
+	})
+
+	workflowServeOpenEventsProvider = func(io.Writer) (events.Provider, error) { return ep, nil }
+	workflowServeWaitForWake = func(_ <-chan workflowWatchResult, _ time.Duration, _ int) (bool, error) {
+		return false, nil
+	}
+
+	trippedErr := fmt.Errorf(`querying control work: running work query %q: exit status 1: begin read tx: dial tcp 127.0.0.1:52022: connect: connection refused (circuit breaker tripped)`, "bd ready")
+	breakerOpenErr := fmt.Errorf(`querying control work: running work query %q: exit status 1: Error: failed to open database: dolt circuit breaker is open: server appears down, failing fast (cooldown 5s)`, "bd ready")
+	fatalErr := errors.New("malformed work query: jq: command not found")
+	calls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		switch calls {
+		case 1:
+			return nil, trippedErr
+		case 2:
+			return nil, breakerOpenErr
+		}
+		return nil, fatalErr
+	}
+
+	agent := config.Agent{Name: "control-dispatcher"}
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	if !errors.Is(err, fatalErr) {
+		t.Fatalf("runWorkflowServeFollow err = %v, want fatal error after surviving the breaker outage", err)
+	}
+	if calls != 3 {
+		t.Fatalf("workflowServeList calls = %d, want 3 (survive tripped + open breaker, then exit on fatal)", calls)
 	}
 }
 

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -800,6 +800,9 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 	if bare := controlDispatcherBareRoute(target); bare != "" {
 		queryPrefix += ` GC_CONTROL_BARE_TARGET=` + shellquote.Quote(bare)
 	}
+	if cityAlias := controlDispatcherCitySingletonRoute(target); cityAlias != "" {
+		queryPrefix += ` GC_CONTROL_CITY_TARGET=` + shellquote.Quote(cityAlias)
+	}
 	query := queryPrefix + ` sh -c '` +
 		`set -e; ` +
 		`tmp=$(mktemp); seen="$tmp.seen"; err="$tmp.err"; : > "$seen"; trap "rm -f \"$tmp\" \"$seen\" \"$err\"" EXIT; ` +
@@ -821,6 +824,7 @@ func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg conf
 		`routed_ready "$GC_CONTROL_TARGET"; ` +
 		`routed_ready "${GC_CONTROL_LEGACY_TARGET:-}"; ` +
 		`routed_ready "${GC_CONTROL_BARE_TARGET:-}"; ` +
+		`routed_ready "${GC_CONTROL_CITY_TARGET:-}"; ` +
 		`if [ -s "$tmp" ]; then jq -s "` + jqFilter + `" "$tmp"; else printf "[]"; fi` + `'`
 	return query
 }
@@ -913,6 +917,31 @@ func controlDispatcherBareRoute(target string) string {
 		return dir + "/" + config.ControlDispatcherAgentName
 	}
 	return config.ControlDispatcherAgentName
+}
+
+// controlDispatcherCitySingletonRoute returns the dir-stripped city-singleton
+// alias of a rig-scoped control dispatcher's qualified name, e.g.
+// "rig/core.control-dispatcher" -> "core.control-dispatcher". Control-step
+// routing deliberately stamps the city singleton's qualified name for every
+// scope (config.PreferredDeterministicControlDispatcher), so control beads
+// minted into a rig store carry the unprefixed city name — and only the rig
+// dispatcher serving that store can ever claim them, because the city
+// dispatcher never queries rig stores (ga-8jx: wedged ralph containers and
+// workflow-finalize steps). Returns "" when target has no rig prefix or is
+// not a control-dispatcher route.
+func controlDispatcherCitySingletonRoute(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ""
+	}
+	dir, name := config.ParseQualifiedName(target)
+	if dir == "" {
+		return ""
+	}
+	if name != config.ControlDispatcherAgentName && !strings.HasSuffix(name, "."+config.ControlDispatcherAgentName) {
+		return ""
+	}
+	return name
 }
 
 func nextWorkflowServeBeads(workQuery, dir string, env map[string]string) ([]hookBead, error) {

--- a/cmd/gc/fs_pressure.go
+++ b/cmd/gc/fs_pressure.go
@@ -144,9 +144,12 @@ func (cr *CityRuntime) resetFSPressureEpisode() {
 // shouldSkipTickForFSPressure gates only the patrol/poke tick path after
 // config reload and before managed-Dolt preflight, order dispatch, session
 // sync, demand build, and reconciliation. Pressure-skipped ticks still drain
-// already queued convergence requests; nudge-dispatch, control-dispatcher,
-// socket-driven convergence requests, and manual reload refreshes are separate
-// high-priority paths and are not covered by this gate.
+// already queued convergence requests and still run the bounded
+// control-dispatcher-only reconcile pass (a dispatcher that dies during a
+// sustained pressure episode must not stay dead for the whole episode —
+// ga-8jx); nudge-dispatch, socket-driven convergence requests, and manual
+// reload refreshes are separate high-priority paths and are not covered by
+// this gate.
 func (cr *CityRuntime) shouldSkipTickForFSPressure(trace *sessionReconcilerTraceCycle, trigger string) bool {
 	status, ok := currentFSPressureStatus(cr.stderr)
 	if !ok || !status.High {

--- a/cmd/gc/fs_pressure_test.go
+++ b/cmd/gc/fs_pressure_test.go
@@ -281,6 +281,81 @@ func TestCityRuntimeTickSkipsBeforeManagedDoltAndDemandUnderFSPressure(t *testin
 	}
 }
 
+// TestCityRuntimeTickReconcilesControlDispatchersUnderFSPressure guards the
+// ga-8jx liveness hole: the FS-pressure gate sheds the whole tick, so a
+// control dispatcher that died during a sustained IO-pressure episode was
+// never restarted and every in-flight run's control beads (ralph containers,
+// workflow-finalize) wedged. A skipped tick must still run the bounded
+// dispatcher-only reconcile pass while continuing to shed the full tick.
+func TestCityRuntimeTickReconcilesControlDispatchersUnderFSPressure(t *testing.T) {
+	withFakePressureFile(t, []byte(samplePressureHigh), nil)
+	t.Setenv(fsPressureThresholdEnv, "")
+
+	maxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			MaxActiveSessions: &maxActive,
+		}},
+	}
+
+	var buildCalls atomic.Int32
+	var managedDoltCalls atomic.Int32
+	var stderr bytes.Buffer
+	rec := events.NewFake()
+	sp := runtime.NewFake()
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "test-city",
+		cfg:                 cfg,
+		sp:                  sp,
+		standaloneCityStore: beads.NewMemStore(),
+		buildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			buildCalls.Add(1)
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		dops:          newDrainOps(sp),
+		rec:           rec,
+		sessionDrains: newDrainTracker(),
+		logPrefix:     "gc test",
+		stdout:        io.Discard,
+		stderr:        &stderr,
+		managedDoltOwned: func(string) (bool, error) {
+			managedDoltCalls.Add(1)
+			return true, nil
+		},
+		managedDoltPort: func(string) string {
+			return ""
+		},
+		managedDoltHealth: func(string) error {
+			managedDoltCalls.Add(1)
+			return nil
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	lastProviderName := ""
+	prevPoolRunning := map[string]bool{}
+	cr.tick(context.Background(), dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "patrol")
+
+	if got := buildCalls.Load(); got != 0 {
+		t.Fatalf("build desired calls = %d, want full tick still shed under FS pressure", got)
+	}
+	if got := managedDoltCalls.Load(); got == 0 {
+		t.Fatal("managed dolt preflight never ran: control-dispatcher-only pass was skipped under FS pressure")
+	}
+	evts, err := rec.List(events.Filter{Type: events.SupervisorFSPressureSkippedTick})
+	if err != nil {
+		t.Fatalf("list FS pressure events: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("FS pressure skip events = %#v, want the shed tick still recorded", evts)
+	}
+}
+
 func TestCityRuntimeTickSkipsDueOrderDispatchUnderFSPressure(t *testing.T) {
 	withFakePressureFile(t, []byte(samplePressureHigh), nil)
 	t.Setenv(fsPressureThresholdEnv, "")

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -419,6 +419,12 @@ func IsTransientControllerError(err error) bool {
 		"database is locked",
 		"database table is locked",
 		"sqlite_busy",
+		// bd's client-side dolt breaker fails fast with a cooldown while the
+		// server is down; the outage is recoverable, so serve loops must keep
+		// sweeping instead of exiting (ga-8jx: rig dispatcher died mid-outage).
+		"dolt circuit breaker is open",
+		"server appears down, failing fast",
+		"dolt server unreachable",
 	}
 	for _, needle := range transientNeedles {
 		if strings.Contains(msg, needle) {

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -1640,6 +1640,9 @@ func TestIsTransientControllerError(t *testing.T) {
 		{name: "sqlite locked", err: errors.New("listing sqlite ready beads: database is locked (5) (SQLITE_BUSY)"), want: true},
 		{name: "sqlite table locked", err: errors.New("listing sqlite ready beads: database table is locked"), want: true},
 		{name: "control work query sigterm", err: errors.New(`querying control work for fixture/core.control-dispatcher: running work query "bd ready": exit status 143: Terminated`), want: true},
+		{name: "dolt breaker open", err: errors.New("Error: failed to open database: dolt circuit breaker is open: server appears down, failing fast (cooldown 5s)"), want: true},
+		{name: "dolt breaker failing fast", err: errors.New(`querying control work for fixture/core.control-dispatcher: running work query "bd ready": exit status 1: server appears down, failing fast (cooldown 5s)`), want: true},
+		{name: "dolt server unreachable", err: errors.New("begin read tx: dolt server unreachable"), want: true},
 		{name: "non work query sigterm", err: errors.New("starting provider: exit status 143: Terminated"), want: false},
 		{name: "bad step spec", err: errors.New("deserializing step spec: invalid character 'n'"), want: false},
 	}


### PR DESCRIPTION
## Summary

Workflow runs in a rig could stall right at the end: every work step finished, but the run's automatic control steps (closing a ralph loop's container, finalizing the workflow) sat unclaimed forever and the run never completed without a human closing them by hand. This happened because those control steps are addressed to the city's dispatcher by name while living in the rig's own database — a place the city dispatcher never looks, and a name the rig dispatcher didn't answer to. Two adjacent liveness holes made recovery worse: a rig dispatcher process died permanently the moment its database had a brief outage, and a dead dispatcher was never restarted while the machine was shedding load under disk-IO pressure.

## What changed

- Rig dispatchers now also claim control steps addressed to the city dispatcher's name, and a sleeping rig dispatcher now wakes up when such steps appear in its store (previously the *city* dispatcher woke, found nothing in its own store, and went back to sleep).
- A dispatcher's serve loop now treats the database client's "circuit breaker open / server appears down" errors as the recoverable outage they are: it keeps sweeping and resumes when the database returns, instead of exiting.
- Ticks skipped under IO pressure still run a small dispatcher-only reconcile pass, so a dead dispatcher is restarted even during a sustained pressure episode.

## Testing

- New unit tests pin the alias derivation, the serve-query scan set, the demand attribution (rig-store bead wakes the rig dispatcher; city behavior unchanged; fallback when a rig has no dispatcher), breaker-error classification, follow-loop survival through a two-phase breaker outage, and the pressure-skip dispatcher pass.
- Full `cmd/gc`, `internal/dispatch`, `internal/config`, and `internal/graphroute` suites pass; changed-package lint is clean.

---

## 🤖 Agent context

Incident tag `ga-8jx` (referenced in code comments, consistent with existing incident-tagged comments). Observed three times on a live city (2026-07-09/10/11): pr-work runs wedged after the final implement iteration; `gc.kind=ralph` containers and `gc.kind=workflow-finalize` steps stamped `gc.routed_to=core.control-dispatcher` sat ready 25+ minutes in the rig store while dispatchers showed running/stopped; each run needed manual bead closes. Root cause chain confirmed against a live trace: (1) unclaimable routing, (2) rig dispatcher process death at 2026-07-10T18:09Z on `dolt circuit breaker is open: server appears down, failing fast (cooldown 5s)` after the rig dolt sql-server went down, (3) no re-enumeration of the dead dispatcher: zero `template_tick_summary` records for the rig dispatcher template for 12+ hours until a manual `gc session new`.

**Files touched**
- `cmd/gc/dispatch_runtime.go` — new `controlDispatcherCitySingletonRoute` helper (mirror of `controlDispatcherBareRoute`, strips the rig dir); serve query gains `GC_CONTROL_CITY_TARGET` + a fourth `routed_ready` scan.
- `cmd/gc/build_desired_state.go` — `collectOpenUnassignedRoutedWork` also returns store refs; `openControlDispatcherDemand(cityPath, cfg, beads, refs)` attributes city-singleton-aliased beads found in a rig store to that rig's dispatcher template (via `configuredRigName`), falling back to the city template when the rig has no dispatcher copy.
- `cmd/gc/city_runtime.go` — FS-pressure skip branch additionally runs the pre-existing `controlDispatcherTick` (dispatcher-only desired-state + reconcile, city + rig dispatchers via `controlDispatcherOnlyConfig`).
- `cmd/gc/fs_pressure.go` — gate doc comment updated to match.
- `internal/dispatch/control.go` — `IsTransientControllerError` gains needles `dolt circuit breaker is open`, `server appears down, failing fast`, `dolt server unreachable` (same strings as the provider-lifecycle recognizer `isBreakerOpenError` and the integration helper `managedDoltTransportRetryable`).
- Tests in `cmd/gc/cmd_convoy_dispatch_test.go`, `cmd/gc/build_desired_state_test.go`, `cmd/gc/fs_pressure_test.go`, `internal/dispatch/control_test.go`.

**Rationale / approach**
The stamping of `core.control-dispatcher` for every scope is deliberate and lockstep across three sites (`config.PreferredDeterministicControlDispatcher`, `graphroute.resolveControlDispatcherBinding`, `dispatch.controlDispatcherTargetForExecutionTarget`) and codified by tests (`TestApplyAttemptControlStepRoute_PrefersCitySingletonOverRigScoped`), so the fix normalizes the *match* (serve query + demand) rather than re-stamping at instantiation. This also retroactively unwedges control beads minted by runs launched before the fix — no re-stamp migration needed. The serve-query change follows the existing multi-alias pattern (`GC_CONTROL_LEGACY_TARGET`, `GC_CONTROL_BARE_TARGET`). The pressure fix reuses the purpose-built `controlDispatcherTick` (previously only reachable via socket command) inside the skip branch, keeping the shed tick bounded.

**Edge cases & risks**
- City dispatcher's own query is unchanged (helper returns "" for dir-less targets — pinned by test), so no self-alias duplication.
- Demand attribution only rewrites when the bead's store ref is a rig **and** that rig has a dispatcher copy; short/missing ref slices degrade to previous behavior.
- Cost: one extra `routed_ready` scan (two bounded `bd ready` queries) per rig-dispatcher sweep; zero for the city dispatcher.
- The dispatcher-only pass under pressure includes the managed-dolt preflight — intentional (restarting a dead managed dolt is prerequisite to dispatcher recovery), bounded to the filtered config.
- Beads stamped with a rig-*prefixed* route (`<rig>/core.control-dispatcher`) were already matched and remain so.

**Repro / verification detail**
Live-store proof of the mismatch (before fix): in the rig store, `bd --readonly --sandbox ready --metadata-field "gc.routed_to=core.control-dispatcher" --unassigned` returned the wedged finalize beads while the same query with the rig-prefixed value returned 0 — the exact inverse of what the serve query scanned. Serve-loop death signature (rig dispatcher trace log): `serve query-error … connection refused (circuit breaker tripped)` → survived as `drain-transient-retry`; two seconds later `Error: failed to open database: dolt circuit breaker is open: server appears down, failing fast (cooldown 5s)` → no retry line, process gone. New tests replay both: `TestWorkflowServeControlReadyQueryClaimsCityRoutedRigStoreControlWork` (composed query against a scripted `bd`) and `TestRunWorkflowServeFollowSurvivesDoltCircuitBreakerOutage` (two-phase outage then fatal sentinel).

**Post-merge verification** — after merge, edge publish, and the affected machine upgrading its `gc` binary (the incident machine runs `gc_commit 55b15769c`, which predates this fix):
- Ralph-container advancement: on the next pr-work run in a rig, after the final implement iteration bead closes, the `gc.kind=ralph` container and subsequent `workflow-finalize` bead should close within ~1–2 minutes with no manual closes. Signal: in the rig store, `bd --readonly --sandbox ready --metadata-field "gc.routed_to=core.control-dispatcher" --unassigned --json` stays `[]` (no control bead sitting ready >5 min). Where: rig checkout dir; also the run's bead graph should reach open-pr without intervention.
- Dispatcher wake-on-demand: with the rig dispatcher session drained/asleep and a city-singleton-routed control bead present in the rig store, the session-reconciler trace should show `template_tick_summary` for `<rig>/core.control-dispatcher` with `desired_count: 1` within one tick (~10s), followed by session start. Where: `.gc/runtime/session-reconciler-trace/segments/<date>/…` on the city.
- Serve-loop outage survival: on the next rig dolt outage (or a deliberate brief `dolt sql-server` stop in a test rig), the rig dispatcher trace log should show repeated `serve query-error` + `serve drain-transient-retry` pairs for the breaker-open message through the outage and normal `serve wake-sweep` lines after recovery — no permanent gap in the log. Where: `.gc/runtime/<rig>--core.control-dispatcher-trace.log`.
- Pressure-episode liveness: during an FS-pressure episode (reconciler trace `decision` records with `site_code: supervisor.fs_pressure`, `outcome: skipped`), control-dispatcher templates should still emit `session_baseline`/`session_result` records within the episode, and a killed dispatcher session should re-enter `start-pending` within a few skipped ticks rather than after the episode ends.

**Follow-ups**
- The dispatcher pane still exits while its session bead reads `active` for genuinely fatal (non-transient) serve errors; the reconciler only notices via runtime-missing projection. A death event (the `emitWorkQueryFailure` gate currently ignores non-signal exits) would make such deaths observable — not needed for this incident once the breaker errors are transient, so deliberately deferred.
- Rig-store control beads still create a small window of phantom city-dispatcher demand when a rig defines no dispatcher copy (fallback path) — harmless, pinned by test, documented here for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)