### PR TITLE
feat(api): accept Idempotency-Key on agent/provider/rig/convoy/pack creates (P0 #4 S2)

### DIFF
--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -20207,6 +20207,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -23653,6 +23662,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -23750,6 +23768,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -31259,6 +31292,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -34244,6 +34286,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -35379,6 +35430,15 @@
               "description": "City name.",
               "minLength": 1,
               "pattern": "\\S",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
               "type": "string"
             }
           }

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -20207,6 +20207,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -23653,6 +23662,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -23750,6 +23768,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -31259,6 +31292,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -34244,6 +34286,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -35379,6 +35430,15 @@
               "description": "City name.",
               "minLength": 1,
               "pattern": "\\S",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
               "type": "string"
             }
           }

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -7936,6 +7936,10 @@ export type CreateAgentData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**
@@ -9257,6 +9261,10 @@ export type CreateConvoyData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**
@@ -9285,6 +9293,10 @@ export type CreateConvoyErrors = {
      * Not Found
      */
     404: ErrorModel;
+    /**
+     * Conflict
+     */
+    409: ErrorModel;
     /**
      * Unprocessable Entity
      */
@@ -12264,6 +12276,10 @@ export type AddPackData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**
@@ -13423,6 +13439,10 @@ export type CreateProviderData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**
@@ -13870,6 +13890,10 @@ export type CreateRigData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
@@ -5248,7 +5248,8 @@ export const zGetV0CityByCityNameAgentsResponse = zListBodyAgentResponse;
 export const zCreateAgentBody = zAgentCreateInputBody;
 
 export const zCreateAgentHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zCreateAgentPath = z.object({
@@ -5567,7 +5568,8 @@ export const zGetV0CityByCityNameConvoysResponse = zListBodyBead;
 export const zCreateConvoyBody = zConvoyCreateInputBody;
 
 export const zCreateConvoyHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zCreateConvoyPath = z.object({
@@ -6354,7 +6356,8 @@ export const zGetV0CityByCityNamePacksResponse = zPackListBody;
 export const zAddPackBody = zPackAddInputBody;
 
 export const zAddPackHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zAddPackPath = z.object({
@@ -6625,7 +6628,8 @@ export const zGetV0CityByCityNameProvidersResponse = zListBodyProviderResponse;
 export const zCreateProviderBody = zProviderCreateInputBody;
 
 export const zCreateProviderHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zCreateProviderPath = z.object({
@@ -6741,7 +6745,8 @@ export const zGetV0CityByCityNameRigsResponse = zListBodyRigResponse;
 export const zCreateRigBody = zRigCreateInputBody;
 
 export const zCreateRigHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zCreateRigPath = z.object({

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -6214,6 +6214,9 @@ type GetV0CityByCityNameAgentsParamsRunning string
 type CreateAgentParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // DeleteV0CityByCityNameBeadByIdParams defines parameters for DeleteV0CityByCityNameBeadById.
@@ -6346,6 +6349,9 @@ type GetV0CityByCityNameConvoysParams struct {
 type CreateConvoyParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // GetV0CityByCityNameEventsParams defines parameters for GetV0CityByCityNameEvents.
@@ -6760,6 +6766,9 @@ type GetV0CityByCityNameOrdersHistoryParams struct {
 type AddPackParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // DeleteV0CityByCityNamePacksByNameParams defines parameters for DeleteV0CityByCityNamePacksByName.
@@ -6835,6 +6844,9 @@ type PatchV0CityByCityNameProviderByNameParams struct {
 type CreateProviderParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // GetV0CityByCityNameReadinessParams defines parameters for GetV0CityByCityNameReadiness.
@@ -6889,6 +6901,9 @@ type GetV0CityByCityNameRigsParams struct {
 type CreateRigParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // PostV0CityByCityNameServiceByNameRestartParams defines parameters for PostV0CityByCityNameServiceByNameRestart.
@@ -17162,6 +17177,17 @@ func NewCreateAgentRequestWithBody(server string, cityName string, params *Creat
 
 		req.Header.Set("X-GC-Request", headerParam0)
 
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -18614,6 +18640,17 @@ func NewCreateConvoyRequestWithBody(server string, cityName string, params *Crea
 		}
 
 		req.Header.Set("X-GC-Request", headerParam0)
+
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
 
 	}
 
@@ -22258,6 +22295,17 @@ func NewAddPackRequestWithBody(server string, cityName string, params *AddPackPa
 
 		req.Header.Set("X-GC-Request", headerParam0)
 
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -23350,6 +23398,17 @@ func NewCreateProviderRequestWithBody(server string, cityName string, params *Cr
 
 		req.Header.Set("X-GC-Request", headerParam0)
 
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -23848,6 +23907,17 @@ func NewCreateRigRequestWithBody(server string, cityName string, params *CreateR
 		}
 
 		req.Header.Set("X-GC-Request", headerParam0)
+
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
 
 	}
 
@@ -27759,6 +27829,7 @@ type CreateConvoyResponse struct {
 	ApplicationproblemJSON401 *ErrorModel
 	ApplicationproblemJSON403 *ErrorModel
 	ApplicationproblemJSON404 *ErrorModel
+	ApplicationproblemJSON409 *ErrorModel
 	ApplicationproblemJSON422 *ErrorModel
 	ApplicationproblemJSON500 *ErrorModel
 }
@@ -35187,6 +35258,13 @@ func ParseCreateConvoyResponse(rsp *http.Response) (*CreateConvoyResponse, error
 			return nil, err
 		}
 		response.ApplicationproblemJSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest ErrorModel

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -262,35 +262,49 @@ func (s *Server) agentByName(name string) (*IndexOutput[agentResponse], error) {
 // Body validation (Name and Provider required with minLength:"1") is
 // enforced by the framework from AgentCreateInput's struct tags.
 func (s *Server) humaHandleAgentCreate(ctx context.Context, input *AgentCreateInput) (*AgentCreatedOutput, error) {
-	sm, ok := s.state.(StateMutator)
-	if !ok {
-		return nil, errMutationsNotSupported
-	}
+	// Idempotency: create at most once per Idempotency-Key. The cached value is
+	// the qualified agent name (the response body is rebuilt from it), and the
+	// visibility wait stays inside the closure so a cached 201 keeps its strict
+	// read-after-write meaning. A create that fails after the durable config
+	// write (visibility timeout 503/504) releases the reservation, so a
+	// same-key retry re-runs the create and surfaces the conflict — identical
+	// to an unkeyed retry today.
+	qualifiedName, err := withIdempotency(s, "/v0/agents", input.IdempotencyKey, input.Body,
+		func() (string, error) {
+			sm, ok := s.state.(StateMutator)
+			if !ok {
+				return "", errMutationsNotSupported
+			}
 
-	a := config.Agent{
-		Name:     input.Body.Name,
-		Dir:      input.Body.Dir,
-		Provider: input.Body.Provider,
-		Scope:    input.Body.Scope,
-	}
+			a := config.Agent{
+				Name:     input.Body.Name,
+				Dir:      input.Body.Dir,
+				Provider: input.Body.Provider,
+				Scope:    input.Body.Scope,
+			}
 
-	if err := sm.CreateAgent(a); err != nil {
-		return nil, mutationError(err)
-	}
-	// Block until the new agent is reachable through findAgent, so the
-	// 201 response is a strict read-after-write signal: a follow-up
-	// POST /sling against the same target will not race a stale runtime
-	// config snapshot. This is intentionally scoped to agents because sling
-	// target resolution reads the agent projection immediately after create.
-	qualifiedName := a.QualifiedName()
-	if waiter, ok := s.state.(AgentVisibilityWaiter); ok {
-		waitCtx, cancel := context.WithTimeout(ctx, s.agentCreateVisibilityWaitTimeout())
-		err := waiter.WaitForAgentVisibility(waitCtx, qualifiedName)
-		cancel()
-		if err != nil {
-			log.Printf("api: agent %s visibility confirmation failed after create: %v", qualifiedName, err)
-			return nil, agentVisibilityWaitHTTPError(err)
-		}
+			if err := sm.CreateAgent(a); err != nil {
+				return "", mutationError(err)
+			}
+			// Block until the new agent is reachable through findAgent, so the
+			// 201 response is a strict read-after-write signal: a follow-up
+			// POST /sling against the same target will not race a stale runtime
+			// config snapshot. This is intentionally scoped to agents because sling
+			// target resolution reads the agent projection immediately after create.
+			name := a.QualifiedName()
+			if waiter, ok := s.state.(AgentVisibilityWaiter); ok {
+				waitCtx, cancel := context.WithTimeout(ctx, s.agentCreateVisibilityWaitTimeout())
+				err := waiter.WaitForAgentVisibility(waitCtx, name)
+				cancel()
+				if err != nil {
+					log.Printf("api: agent %s visibility confirmation failed after create: %v", name, err)
+					return "", agentVisibilityWaitHTTPError(err)
+				}
+			}
+			return name, nil
+		})
+	if err != nil {
+		return nil, err
 	}
 	resp := &AgentCreatedOutput{}
 	resp.Body.Status = "created"

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -458,63 +458,43 @@ type BeadDepsResponse struct {
 // humaHandleBeadCreate is the Huma-typed handler for POST /v0/beads.
 // Title required via struct tag on BeadCreateInput.
 func (s *Server) humaHandleBeadCreate(ctx context.Context, input *BeadCreateInput) (*IndexOutput[beads.Bead], error) {
-	// Idempotency check — scope by method+path to prevent cross-endpoint collisions.
-	idemKey := ""
-	var bodyHash string
-	if input.IdempotencyKey != "" {
-		idemKey = "POST:/v0/beads:" + input.IdempotencyKey
-		bodyHash = hashBody(input.Body)
-		existing, found := s.idem.reserve(idemKey, bodyHash)
-		if found {
-			if existing.bodyHash != bodyHash {
-				return nil, apierr.IdempotencyMismatch.Msg("idempotency_mismatch: Idempotency-Key reused with different request body")
+	// Idempotency: run the create at most once per Idempotency-Key. The helper
+	// owns reserve/replay/mismatch/in-flight and guarantees the reservation is
+	// released on any error, so every fallible step lives in the closure.
+	b, err := withIdempotency(s, "/v0/beads", input.IdempotencyKey, input.Body,
+		func() (beads.Bead, error) {
+			store := s.findStore(input.Body.Rig)
+			if store == nil {
+				return beads.Bead{}, apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
 			}
-			if existing.pending {
-				return nil, apierr.IdempotencyInFlight.Msg("in_flight: request with this Idempotency-Key is already in progress")
+			assignee, err := s.normalizeRawBeadAssignee(ctx, input.Body.Assignee)
+			if err != nil {
+				return beads.Bead{}, apierr.InvalidRequest.Msg(err.Error())
 			}
-			// Replay cached typed response (Fix 3l).
-			if b, ok := replayAs[beads.Bead](existing); ok {
-				return &IndexOutput[beads.Bead]{
-					Index: s.latestIndex(),
-					Body:  b,
-				}, nil
+			created, err := store.Create(beads.Bead{
+				Title:       input.Body.Title,
+				Type:        input.Body.Type,
+				Priority:    input.Body.Priority,
+				Assignee:    assignee,
+				Description: input.Body.Description,
+				Labels:      input.Body.Labels,
+				ParentID:    input.Body.Parent,
+				Metadata:    input.Body.Metadata,
+				DeferUntil:  input.Body.DeferUntil,
+			})
+			if err != nil {
+				return beads.Bead{}, apierr.Internal.Msg(err.Error())
 			}
-		}
-	}
-
-	store := s.findStore(input.Body.Rig)
-	if store == nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
-	}
-	assignee, err := s.normalizeRawBeadAssignee(ctx, input.Body.Assignee)
+			// Some stores return a minimal create envelope and require a
+			// follow-up read for the canonical persisted bead state.
+			if persisted, getErr := store.Get(created.ID); getErr == nil {
+				created = persisted
+			}
+			return created, nil
+		})
 	if err != nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.InvalidRequest.Msg(err.Error())
+		return nil, err
 	}
-
-	b, err := store.Create(beads.Bead{
-		Title:       input.Body.Title,
-		Type:        input.Body.Type,
-		Priority:    input.Body.Priority,
-		Assignee:    assignee,
-		Description: input.Body.Description,
-		Labels:      input.Body.Labels,
-		ParentID:    input.Body.Parent,
-		Metadata:    input.Body.Metadata,
-		DeferUntil:  input.Body.DeferUntil,
-	})
-	if err != nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.Internal.Msg(err.Error())
-	}
-
-	// Some stores return a minimal create envelope and require a follow-up
-	// read for the canonical persisted bead state.
-	if persisted, getErr := store.Get(b.ID); getErr == nil {
-		b = persisted
-	}
-	s.idem.storeResponse(idemKey, bodyHash, b)
 
 	return &IndexOutput[beads.Bead]{
 		Index: s.latestIndex(),

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -211,38 +211,48 @@ func (s *Server) humaHandleConvoyGet(_ context.Context, input *ConvoyGetInput) (
 // humaHandleConvoyCreate is the Huma-typed handler for POST /v0/convoys.
 // Title required via struct tag on ConvoyCreateInput.
 func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateInput) (*IndexOutput[beads.Bead], error) {
-	store := s.findStore(input.Body.Rig)
-	if store == nil {
-		return nil, apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
-	}
-
-	// Pre-validate all items exist before creating the convoy.
-	for _, itemID := range input.Body.Items {
-		if _, err := store.Get(itemID); err != nil {
-			return nil, storeError(err)
-		}
-	}
-
-	convoy, err := store.Create(beads.Bead{
-		Title: input.Body.Title,
-		Type:  "convoy",
-	})
-	if err != nil {
-		return nil, apierr.Internal.Msg(err.Error())
-	}
-
-	// Link child items to convoy one at a time. On first failure, roll
-	// back previously-created tracks deps and THEN delete the new convoy.
-	applied := make([]string, 0, len(input.Body.Items))
-	for _, itemID := range input.Body.Items {
-		if err := convoycore.TrackItem(store, convoy.ID, itemID); err != nil {
-			rollbackConvoyTracks(store, convoy.ID, applied, "convoy.create")
-			if delErr := store.Delete(convoy.ID); delErr != nil {
-				log.Printf("gc api: convoy create rollback: delete %s after link failure: %v", convoy.ID, delErr)
+	// Idempotency: create at most once per Idempotency-Key. Item validation,
+	// the convoy bead create, and the link loop (with its rollback) all live in
+	// the closure so a failed create releases the reservation for retry.
+	convoy, err := withIdempotency(s, "/v0/convoys", input.IdempotencyKey, input.Body,
+		func() (beads.Bead, error) {
+			store := s.findStore(input.Body.Rig)
+			if store == nil {
+				return beads.Bead{}, apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
 			}
-			return nil, apierr.Internal.Msg("failed to link item " + itemID + ": " + err.Error())
-		}
-		applied = append(applied, itemID)
+
+			// Pre-validate all items exist before creating the convoy.
+			for _, itemID := range input.Body.Items {
+				if _, err := store.Get(itemID); err != nil {
+					return beads.Bead{}, storeError(err)
+				}
+			}
+
+			created, err := store.Create(beads.Bead{
+				Title: input.Body.Title,
+				Type:  "convoy",
+			})
+			if err != nil {
+				return beads.Bead{}, apierr.Internal.Msg(err.Error())
+			}
+
+			// Link child items to convoy one at a time. On first failure, roll
+			// back previously-created tracks deps and THEN delete the new convoy.
+			applied := make([]string, 0, len(input.Body.Items))
+			for _, itemID := range input.Body.Items {
+				if err := convoycore.TrackItem(store, created.ID, itemID); err != nil {
+					rollbackConvoyTracks(store, created.ID, applied, "convoy.create")
+					if delErr := store.Delete(created.ID); delErr != nil {
+						log.Printf("gc api: convoy create rollback: delete %s after link failure: %v", created.ID, delErr)
+					}
+					return beads.Bead{}, apierr.Internal.Msg("failed to link item " + itemID + ": " + err.Error())
+				}
+				applied = append(applied, itemID)
+			}
+			return created, nil
+		})
+	if err != nil {
+		return nil, err
 	}
 
 	return &IndexOutput[beads.Bead]{

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -434,39 +434,23 @@ func (s *Server) humaHandleMailSend(ctx context.Context, input *MailSendInput) (
 		return nil, apierr.InvalidRequest.Msg("no mail provider available")
 	}
 
-	// Idempotency check — scope by method+path to prevent cross-endpoint collisions.
-	idemKey := ""
-	var bodyHash string
-	if input.IdempotencyKey != "" {
-		idemKey = "POST:/v0/mail:" + input.IdempotencyKey
-		bodyHash = hashBody(input.Body)
-		existing, found := s.idem.reserve(idemKey, bodyHash)
-		if found {
-			if existing.bodyHash != bodyHash {
-				return nil, apierr.IdempotencyMismatch.Msg("idempotency_mismatch: Idempotency-Key reused with different request body")
+	// Idempotency: send at most once per Idempotency-Key. On replay the closure
+	// is skipped entirely, so no duplicate Send, telemetry op, or MailSent event
+	// fires. The helper guarantees the reservation is released on a send error.
+	msg, err := withIdempotency(s, "/v0/mail", input.IdempotencyKey, input.Body,
+		func() (mail.Message, error) {
+			sent, sendErr := mp.Send(input.Body.From, resolved, input.Body.Subject, input.Body.Body)
+			telemetry.RecordMailOp(ctx, "send", sendErr)
+			if sendErr != nil {
+				return mail.Message{}, apierr.Internal.Msg(sendErr.Error())
 			}
-			if existing.pending {
-				return nil, apierr.IdempotencyInFlight.Msg("in_flight: request with this Idempotency-Key is already in progress")
-			}
-			// Replay cached typed response (Fix 3l).
-			if msg, ok := replayAs[mail.Message](existing); ok {
-				return &IndexOutput[mail.Message]{
-					Index: s.latestIndex(),
-					Body:  msg,
-				}, nil
-			}
-		}
-	}
-
-	msg, err := mp.Send(input.Body.From, resolved, input.Body.Subject, input.Body.Body)
-	telemetry.RecordMailOp(ctx, "send", err)
+			sent.Rig = input.Body.Rig
+			s.recordMailEvent(events.MailSent, sent.From, sent.ID, input.Body.Rig, &sent)
+			return sent, nil
+		})
 	if err != nil {
-		s.idem.unreserve(idemKey)
-		return nil, apierr.Internal.Msg(err.Error())
+		return nil, err
 	}
-	msg.Rig = input.Body.Rig
-	s.idem.storeResponse(idemKey, bodyHash, msg)
-	s.recordMailEvent(events.MailSent, msg.From, msg.ID, input.Body.Rig, &msg)
 
 	return &IndexOutput[mail.Message]{
 		Index: s.latestIndex(),

--- a/internal/api/huma_handlers_packs.go
+++ b/internal/api/huma_handlers_packs.go
@@ -78,7 +78,8 @@ func (s *Server) humaHandlePackList(_ context.Context, _ *PackListInput) (*PackL
 // PackAddInput is the body for POST /v0/city/{cityName}/packs.
 type PackAddInput struct {
 	CityScope
-	Body struct {
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           struct {
 		Source  string `json:"source" minLength:"1" doc:"Pack source: a remote git URL or registry ref (a sub-path of a repo is allowed)." example:"https://github.com/org/repo/tree/main/packs/review"`
 		Name    string `json:"name,omitempty" doc:"Optional local binding name override; derived from the source when omitted."`
 		Version string `json:"version,omitempty" doc:"Optional semver constraint for a git-backed pack." example:"^1.2.0"`
@@ -100,21 +101,31 @@ type PackAddedOutput struct {
 // lock + install, so the pack's templates compose into the city.
 // POST /v0/city/{cityName}/packs.
 func (s *Server) humaHandlePackAdd(_ context.Context, input *PackAddInput) (*PackAddedOutput, error) {
-	// SSRF fence: AddImport shells `git ls-remote <source>` synchronously and
-	// its contract requires HTTP callers to validate the source first. Reject
-	// local/file sources and internal-network destinations before the import
-	// seam runs. Kept outside the write lock — it is read-only and may resolve
-	// DNS.
-	if err := validateHTTPPackSource(input.Body.Source); err != nil {
-		return nil, packImportHTTPError(err)
-	}
-	var res *importsvc.AddResult
-	if err := s.serializeConfigWrite(func() error {
-		var addErr error
-		res, addErr = packAddImport(fsys.OSFS{}, s.state.CityPath(), input.Body.Source, input.Body.Name, input.Body.Version)
-		return addErr
-	}); err != nil {
-		return nil, packImportHTTPError(err)
+	// Idempotency: import at most once per Idempotency-Key — a pack add shells
+	// out to git and is exactly the expensive, retry-prone create the key is
+	// for. The cached value is the AddResult the response body echoes.
+	res, err := withIdempotency(s, "/v0/packs", input.IdempotencyKey, input.Body,
+		func() (importsvc.AddResult, error) {
+			// SSRF fence: AddImport shells `git ls-remote <source>` synchronously and
+			// its contract requires HTTP callers to validate the source first. Reject
+			// local/file sources and internal-network destinations before the import
+			// seam runs. Kept outside the write lock — it is read-only and may resolve
+			// DNS.
+			if err := validateHTTPPackSource(input.Body.Source); err != nil {
+				return importsvc.AddResult{}, packImportHTTPError(err)
+			}
+			var added *importsvc.AddResult
+			if err := s.serializeConfigWrite(func() error {
+				var addErr error
+				added, addErr = packAddImport(fsys.OSFS{}, s.state.CityPath(), input.Body.Source, input.Body.Name, input.Body.Version)
+				return addErr
+			}); err != nil {
+				return importsvc.AddResult{}, packImportHTTPError(err)
+			}
+			return *added, nil
+		})
+	if err != nil {
+		return nil, err
 	}
 	out := &PackAddedOutput{}
 	out.Body.Name = res.Name

--- a/internal/api/huma_handlers_providers.go
+++ b/internal/api/huma_handlers_providers.go
@@ -131,39 +131,48 @@ func (s *Server) humaHandleProviderGet(_ context.Context, input *ProviderGetInpu
 // humaHandleProviderCreate is the Huma-typed handler for POST /v0/providers.
 // Name and Command required via struct tags on ProviderCreateInput.
 func (s *Server) humaHandleProviderCreate(_ context.Context, input *ProviderCreateInput) (*ProviderCreatedOutput, error) {
-	sm, ok := s.state.(StateMutator)
-	if !ok {
-		return nil, errMutationsNotSupported
-	}
+	// Idempotency: create at most once per Idempotency-Key. The cached value is
+	// the provider name; the response body is rebuilt from it on replay.
+	name, err := withIdempotency(s, "/v0/providers", input.IdempotencyKey, input.Body,
+		func() (string, error) {
+			sm, ok := s.state.(StateMutator)
+			if !ok {
+				return "", errMutationsNotSupported
+			}
 
-	spec := config.ProviderSpec{
-		DisplayName: input.Body.DisplayName,
-		Base:        input.Body.Base,
-		Command:     input.Body.Command,
-		ACPCommand:  input.Body.ACPCommand,
-		Args:        input.Body.Args,
-		ACPArgs:     input.Body.ACPArgs,
-		ArgsAppend:  input.Body.ArgsAppend,
-		PromptMode:  input.Body.PromptMode,
-		PromptFlag:  input.Body.PromptFlag,
-		Env:         input.Body.Env,
-	}
-	if input.Body.ReadyDelayMs != 0 {
-		spec.ReadyDelayMs = input.Body.ReadyDelayMs
-	}
-	if input.Body.OptionsSchemaMerge != nil {
-		spec.OptionsSchemaMerge = *input.Body.OptionsSchemaMerge
-	}
-	if input.Body.OptionDefaults != nil {
-		spec.OptionDefaults = input.Body.OptionDefaults
-	}
+			spec := config.ProviderSpec{
+				DisplayName: input.Body.DisplayName,
+				Base:        input.Body.Base,
+				Command:     input.Body.Command,
+				ACPCommand:  input.Body.ACPCommand,
+				Args:        input.Body.Args,
+				ACPArgs:     input.Body.ACPArgs,
+				ArgsAppend:  input.Body.ArgsAppend,
+				PromptMode:  input.Body.PromptMode,
+				PromptFlag:  input.Body.PromptFlag,
+				Env:         input.Body.Env,
+			}
+			if input.Body.ReadyDelayMs != 0 {
+				spec.ReadyDelayMs = input.Body.ReadyDelayMs
+			}
+			if input.Body.OptionsSchemaMerge != nil {
+				spec.OptionsSchemaMerge = *input.Body.OptionsSchemaMerge
+			}
+			if input.Body.OptionDefaults != nil {
+				spec.OptionDefaults = input.Body.OptionDefaults
+			}
 
-	if err := sm.CreateProvider(input.Body.Name, spec); err != nil {
-		return nil, mutationError(err)
+			if err := sm.CreateProvider(input.Body.Name, spec); err != nil {
+				return "", mutationError(err)
+			}
+			return input.Body.Name, nil
+		})
+	if err != nil {
+		return nil, err
 	}
 	resp := &ProviderCreatedOutput{}
 	resp.Body.Status = "created"
-	resp.Body.Provider = input.Body.Name
+	resp.Body.Provider = name
 	return resp, nil
 }
 

--- a/internal/api/huma_handlers_rigs.go
+++ b/internal/api/huma_handlers_rigs.go
@@ -66,24 +66,33 @@ func (s *Server) humaHandleRigGet(_ context.Context, input *RigGetInput) (*Index
 // humaHandleRigCreate is the Huma-typed handler for POST /v0/rigs.
 // Name and Path required via struct tags on RigCreateInput.
 func (s *Server) humaHandleRigCreate(_ context.Context, input *RigCreateInput) (*RigCreatedOutput, error) {
-	sm, ok := s.state.(StateMutator)
-	if !ok {
-		return nil, errMutationsNotSupported
-	}
+	// Idempotency: create at most once per Idempotency-Key. The cached value is
+	// the rig name; the response body is rebuilt from it on replay.
+	name, err := withIdempotency(s, "/v0/rigs", input.IdempotencyKey, input.Body,
+		func() (string, error) {
+			sm, ok := s.state.(StateMutator)
+			if !ok {
+				return "", errMutationsNotSupported
+			}
 
-	rig := config.Rig{
-		Name:          input.Body.Name,
-		Path:          input.Body.Path,
-		Prefix:        input.Body.Prefix,
-		DefaultBranch: input.Body.DefaultBranch,
-	}
+			rig := config.Rig{
+				Name:          input.Body.Name,
+				Path:          input.Body.Path,
+				Prefix:        input.Body.Prefix,
+				DefaultBranch: input.Body.DefaultBranch,
+			}
 
-	if err := sm.CreateRig(rig); err != nil {
-		return nil, mutationError(err)
+			if err := sm.CreateRig(rig); err != nil {
+				return "", mutationError(err)
+			}
+			return input.Body.Name, nil
+		})
+	if err != nil {
+		return nil, err
 	}
 	resp := &RigCreatedOutput{}
 	resp.Body.Status = "created"
-	resp.Body.Rig = input.Body.Name
+	resp.Body.Rig = name
 	return resp, nil
 }
 

--- a/internal/api/huma_types_agents.go
+++ b/internal/api/huma_types_agents.go
@@ -55,7 +55,8 @@ func (i *AgentGetQualifiedInput) QualifiedName() string {
 // AgentCreateInput is the Huma input for POST /v0/city/{cityName}/agents.
 type AgentCreateInput struct {
 	CityScope
-	Body struct {
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           struct {
 		Name     string `json:"name" doc:"Agent name." minLength:"1" example:"deacon-1"`
 		Dir      string `json:"dir,omitempty" doc:"Working directory (rig name)."`
 		Provider string `json:"provider" doc:"Provider name." minLength:"1" example:"claude"`

--- a/internal/api/huma_types_convoys.go
+++ b/internal/api/huma_types_convoys.go
@@ -86,7 +86,8 @@ type ConvoyGetInput struct {
 // ConvoyCreateInput is the Huma input for POST /v0/city/{cityName}/convoys.
 type ConvoyCreateInput struct {
 	CityScope
-	Body struct {
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           struct {
 		Rig   string   `json:"rig,omitempty" doc:"Rig name."`
 		Title string   `json:"title" doc:"Convoy title." minLength:"1"`
 		Items []string `json:"items,omitempty" doc:"Bead IDs to include."`

--- a/internal/api/huma_types_providers.go
+++ b/internal/api/huma_types_providers.go
@@ -56,7 +56,8 @@ type ProviderGetInput struct {
 // ProviderCreateInput is the Huma input for POST /v0/city/{cityName}/providers.
 type ProviderCreateInput struct {
 	CityScope
-	Body struct {
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           struct {
 		Name               string            `json:"name" doc:"Provider name." minLength:"1"`
 		DisplayName        string            `json:"display_name,omitempty" doc:"Human-readable display name."`
 		Base               *string           `json:"base,omitempty" doc:"Optional provider base for inheritance."`

--- a/internal/api/huma_types_rigs.go
+++ b/internal/api/huma_types_rigs.go
@@ -23,7 +23,8 @@ type RigGetInput struct {
 // RigCreateInput is the Huma input for POST /v0/city/{cityName}/rigs.
 type RigCreateInput struct {
 	CityScope
-	Body struct {
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           struct {
 		Name          string `json:"name" doc:"Rig name." minLength:"1"`
 		Path          string `json:"path" doc:"Filesystem path." minLength:"1"`
 		Prefix        string `json:"prefix,omitempty" doc:"Session name prefix."`

--- a/internal/api/idempotency_endpoints_test.go
+++ b/internal/api/idempotency_endpoints_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/importsvc"
+)
+
+// These tests pin the Idempotency-Key wire contract on the S2 create
+// endpoints: a repeat POST with the same key + same body replays the first
+// response without re-running the create. The helper-level semantics
+// (mismatch 422, in-flight 409, unreserve-on-error) are covered by
+// idempotency_helper_test.go; here each test proves the endpoint is actually
+// wired through withIdempotency.
+
+func postIdempotent(t *testing.T, h http.Handler, url, key, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := newPostRequest(url, strings.NewReader(body))
+	req.Header.Set("Idempotency-Key", key)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAgentCreateIdempotentReplay(t *testing.T) {
+	fs := newFakeMutatorState(t)
+	h := newTestCityHandler(t, fs)
+
+	body := `{"name":"coder","provider":"claude"}`
+	first := postIdempotent(t, h, cityURL(fs, "/agents"), "agent-create-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+
+	replay := postIdempotent(t, h, cityURL(fs, "/agents"), "agent-create-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201; body = %s", replay.Code, replay.Body.String())
+	}
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want first-response body %s", replay.Body.String(), first.Body.String())
+	}
+	// The create must have run exactly once.
+	count := 0
+	for _, a := range fs.cfg.Agents {
+		if a.Name == "coder" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("agent 'coder' appears %d times in config, want 1 (replay re-ran create)", count)
+	}
+}
+
+func TestAgentCreateIdempotencyMismatch(t *testing.T) {
+	fs := newFakeMutatorState(t)
+	h := newTestCityHandler(t, fs)
+
+	first := postIdempotent(t, h, cityURL(fs, "/agents"), "agent-create-1", `{"name":"coder","provider":"claude"}`)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+	// Same key, different body → 422, and no second agent is created.
+	mismatch := postIdempotent(t, h, cityURL(fs, "/agents"), "agent-create-1", `{"name":"other","provider":"claude"}`)
+	if mismatch.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("mismatch: status = %d, want 422; body = %s", mismatch.Code, mismatch.Body.String())
+	}
+	for _, a := range fs.cfg.Agents {
+		if a.Name == "other" {
+			t.Fatal("mismatched request created agent 'other'; it must not run the create")
+		}
+	}
+}
+
+func TestProviderCreateIdempotentReplay(t *testing.T) {
+	fs := newFakeMutatorState(t)
+	h := newTestCityHandler(t, fs)
+
+	// fakeMutatorState.CreateProvider rejects duplicates with ErrAlreadyExists,
+	// so a replay that re-ran the create would surface as a 409 here.
+	body := `{"name":"ollama","command":"ollama run"}`
+	first := postIdempotent(t, h, cityURL(fs, "/providers"), "prov-create-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+
+	replay := postIdempotent(t, h, cityURL(fs, "/providers"), "prov-create-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201 (409 means the create re-ran); body = %s", replay.Code, replay.Body.String())
+	}
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want %s", replay.Body.String(), first.Body.String())
+	}
+}
+
+func TestRigCreateIdempotentReplay(t *testing.T) {
+	fs := newFakeMutatorState(t)
+	h := newTestCityHandler(t, fs)
+
+	body := `{"name":"backend","path":"` + t.TempDir() + `"}`
+	first := postIdempotent(t, h, cityURL(fs, "/rigs"), "rig-create-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+
+	replay := postIdempotent(t, h, cityURL(fs, "/rigs"), "rig-create-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201; body = %s", replay.Code, replay.Body.String())
+	}
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want %s", replay.Body.String(), first.Body.String())
+	}
+	count := 0
+	for _, r := range fs.cfg.Rigs {
+		if r.Name == "backend" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("rig 'backend' appears %d times in config, want 1 (replay re-ran create)", count)
+	}
+}
+
+func TestConvoyCreateIdempotentReplay(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+
+	store := state.stores["myrig"]
+	item, err := store.Create(beads.Bead{Title: "task-1"})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	body := `{"rig":"myrig","title":"test convoy","items":["` + item.ID + `"]}`
+	first := postIdempotent(t, h, cityURL(state, "/convoys"), "convoy-create-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+	var firstConvoy beads.Bead
+	if err := json.NewDecoder(first.Body).Decode(&firstConvoy); err != nil {
+		t.Fatalf("decode first response: %v", err)
+	}
+
+	replay := postIdempotent(t, h, cityURL(state, "/convoys"), "convoy-create-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201; body = %s", replay.Code, replay.Body.String())
+	}
+	var replayConvoy beads.Bead
+	if err := json.NewDecoder(replay.Body).Decode(&replayConvoy); err != nil {
+		t.Fatalf("decode replay response: %v", err)
+	}
+	if replayConvoy.ID != firstConvoy.ID {
+		t.Fatalf("replay returned convoy %s, want the first convoy %s", replayConvoy.ID, firstConvoy.ID)
+	}
+	// Exactly one convoy bead must exist.
+	convoys, err := store.List(beads.ListQuery{Type: "convoy", IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("list beads: %v", err)
+	}
+	if len(convoys) != 1 {
+		t.Fatalf("store holds %d convoy beads, want 1 (replay re-ran create)", len(convoys))
+	}
+}
+
+func TestPackAddIdempotentReplay(t *testing.T) {
+	calls := 0
+	orig := packAddImport
+	packAddImport = func(_ fsys.FS, _, source, _, version string) (*importsvc.AddResult, error) {
+		calls++
+		return &importsvc.AddResult{Name: "review", Source: source, Version: version, GitBacked: true}, nil
+	}
+	defer func() { packAddImport = orig }()
+
+	fs := newFakeMutatorState(t)
+	h := newTestCityHandler(t, fs)
+
+	body := `{"source":"https://github.com/org/repo/tree/main/packs/review"}`
+	first := postIdempotent(t, h, cityURL(fs, "/packs"), "pack-add-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first add: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+
+	replay := postIdempotent(t, h, cityURL(fs, "/packs"), "pack-add-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201; body = %s", replay.Code, replay.Body.String())
+	}
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want %s", replay.Body.String(), first.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("packAddImport ran %d times, want 1 (replay re-ran the import)", calls)
+	}
+}

--- a/internal/api/idempotency_guard_test.go
+++ b/internal/api/idempotency_guard_test.go
@@ -1,0 +1,182 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api"
+)
+
+// requireIdempotency lists the create operations that MUST accept an
+// Idempotency-Key header. This set grows as each wiring slice (audit P0 #4)
+// lands; a regression that drops the header fails TestCreateEndpointsAreTriagedForIdempotency.
+var requireIdempotency = map[string]bool{
+	"create-bead": true,
+	"send-mail":   true,
+}
+
+// pendingIdempotency lists known create operations that are deliberately NOT
+// yet wired for Idempotency-Key (audit P0 #4, slices S2+). It is a reviewed
+// TODO list, not an exemption: when a slice wires one of these, MOVE it to
+// requireIdempotency — the test enforces the move so the lists stay honest.
+var pendingIdempotency = map[string]bool{
+	"create-agent":            true, // 201
+	"create-provider":         true, // 201
+	"create-rig":              true, // 201
+	"create-convoy":           true, // 201
+	"add-pack":                true, // 201; git fetch, retry-prone
+	"reply-mail":              true, // 201; mints a message
+	"register-extmsg-adapter": true, // 201
+	"emit-event":              true, // 201; append-only, retry double-emits
+	"ensure-extmsg-group":     true, // 201; identity-idempotent already
+	"post-v0-city":            true, // 202; supervisor city create
+	"create-session":          true, // 202; raw+Huma split, deferred (S4)
+	"send-session-message":    true, // 202; deferred (S4)
+	"respond-session":         true, // 202; deferred (S4)
+	"submit-session":          true, // 202; deferred (S4)
+}
+
+// exemptFromIdempotency lists POST operations that are NOT resource creates and
+// therefore need no Idempotency-Key: actions on an existing resource (id in the
+// path — naturally keyed by the target), dispatch/trigger endpoints (their own
+// conflict guards), and reads-via-POST. Listing them explicitly (rather than
+// relying on a status-code heuristic) makes the guard airtight: every POST must
+// be classified, so a new create at ANY status (201, 202, …) that is neither
+// wired nor triaged fails the test.
+var exemptFromIdempotency = map[string]bool{
+	"post-v0-city-by-city-name-agent-by-base-by-action":        true,
+	"post-v0-city-by-city-name-agent-by-dir-by-base-by-action": true,
+	"post-v0-city-by-city-name-bead-by-id-assign":              true,
+	"post-v0-city-by-city-name-bead-by-id-close":               true,
+	"post-v0-city-by-city-name-bead-by-id-reopen":              true,
+	"post-v0-city-by-city-name-bead-by-id-update":              true,
+	"post-v0-city-by-city-name-convoy-by-id-add":               true,
+	"post-v0-city-by-city-name-convoy-by-id-close":             true,
+	"post-v0-city-by-city-name-convoy-by-id-remove":            true,
+	"post-v0-city-by-city-name-extmsg-bind":                    true,
+	"post-v0-city-by-city-name-extmsg-inbound":                 true,
+	"post-v0-city-by-city-name-extmsg-outbound":                true,
+	"post-v0-city-by-city-name-extmsg-participants":            true,
+	"post-v0-city-by-city-name-extmsg-transcript-ack":          true,
+	"post-v0-city-by-city-name-extmsg-unbind":                  true,
+	"post-v0-city-by-city-name-formulas-by-name-preview":       true,
+	"post-v0-city-by-city-name-formulas-by-name-validate":      true,
+	"post-v0-city-by-city-name-mail-by-id-archive":             true,
+	"post-v0-city-by-city-name-mail-by-id-mark-unread":         true,
+	"post-v0-city-by-city-name-mail-by-id-read":                true,
+	"post-v0-city-by-city-name-order-by-name-disable":          true,
+	"post-v0-city-by-city-name-order-by-name-enable":           true,
+	"post-v0-city-by-city-name-order-by-name-run":              true,
+	"post-v0-city-by-city-name-rig-by-name-by-action":          true,
+	"post-v0-city-by-city-name-service-by-name-restart":        true,
+	"post-v0-city-by-city-name-session-by-id-close":            true,
+	"post-v0-city-by-city-name-session-by-id-kill":             true,
+	"post-v0-city-by-city-name-session-by-id-permission-mode":  true,
+	"post-v0-city-by-city-name-session-by-id-rename":           true,
+	"post-v0-city-by-city-name-session-by-id-stop":             true,
+	"post-v0-city-by-city-name-session-by-id-suspend":          true,
+	"post-v0-city-by-city-name-session-by-id-wake":             true,
+	"post-v0-city-by-city-name-sling":                          true,
+	"post-v0-city-by-city-name-unregister":                     true,
+	"rotate-events":                                            true,
+	"trigger-maintenance-dolt-gc":                              true,
+}
+
+type idemSpecDoc struct {
+	Paths map[string]map[string]idemSpecOp `json:"paths"`
+}
+
+type idemSpecOp struct {
+	OperationID string          `json:"operationId"`
+	Parameters  []idemSpecParam `json:"parameters"`
+	Responses   map[string]any  `json:"responses"`
+}
+
+type idemSpecParam struct {
+	In   string `json:"in"`
+	Name string `json:"name"`
+}
+
+func (op idemSpecOp) hasIdempotencyHeader() bool {
+	for _, p := range op.Parameters {
+		if p.In == "header" && p.Name == "Idempotency-Key" {
+			return true
+		}
+	}
+	return false
+}
+
+func liveIdemSpec(t *testing.T) idemSpecDoc {
+	t.Helper()
+	sm := api.NewSupervisorMux(emptyTestResolver{}, nil, false, "", "", time.Time{})
+	req := httptest.NewRequest(http.MethodGet, "/openapi.json", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /openapi.json returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var doc idemSpecDoc
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("parse live spec: %v", err)
+	}
+	return doc
+}
+
+// TestCreateEndpointsAreTriagedForIdempotency is the guard that no create
+// endpoint silently ships without Idempotency-Key. It requires EVERY POST
+// operation to be classified into exactly one of three sets:
+//
+//   - requireIdempotency  → MUST declare the header (regression guard)
+//   - pendingIdempotency  → known create, not yet wired; MUST NOT declare the
+//     header yet (wiring it forces a move to requireIdempotency)
+//   - exemptFromIdempotency → not a create (action/dispatch/read); no header
+//
+// A POST operation in none of the sets fails the test: a new endpoint was added
+// without triage. If it's a create, wire it through withIdempotency and add it
+// to requireIdempotency; otherwise add it to exemptFromIdempotency. This full
+// partition closes the gap where a create at a non-201 status (e.g. 202) could
+// slip past a status-code heuristic.
+func TestCreateEndpointsAreTriagedForIdempotency(t *testing.T) {
+	spec := liveIdemSpec(t)
+
+	seen := map[string]bool{}
+	for path, methods := range spec.Paths {
+		post, ok := methods["post"]
+		if !ok {
+			continue
+		}
+		opid := post.OperationID
+		seen[opid] = true
+
+		switch {
+		case requireIdempotency[opid]:
+			if !post.hasIdempotencyHeader() {
+				t.Errorf("create %q (POST %s) must declare an Idempotency-Key header but does not — "+
+					"wire it through withIdempotency and add the header input field", opid, path)
+			}
+		case pendingIdempotency[opid]:
+			if post.hasIdempotencyHeader() {
+				t.Errorf("%q (POST %s) now declares Idempotency-Key — move it from pendingIdempotency "+
+					"to requireIdempotency in idempotency_guard_test.go", opid, path)
+			}
+		case exemptFromIdempotency[opid]:
+			// Not a create; no assertion.
+		default:
+			t.Errorf("POST %s (op %q) is not triaged for idempotency. If it creates a resource, "+
+				"wire it through withIdempotency and add %q to requireIdempotency; otherwise add it "+
+				"to exemptFromIdempotency in idempotency_guard_test.go.", path, opid, opid)
+		}
+	}
+
+	// Catch typos / renamed operations: every listed opid must exist in the spec.
+	for _, set := range []map[string]bool{requireIdempotency, pendingIdempotency, exemptFromIdempotency} {
+		for opid := range set {
+			if !seen[opid] {
+				t.Errorf("idempotency guard lists %q but no such POST operation exists in the spec", opid)
+			}
+		}
+	}
+}

--- a/internal/api/idempotency_guard_test.go
+++ b/internal/api/idempotency_guard_test.go
@@ -14,8 +14,13 @@ import (
 // Idempotency-Key header. This set grows as each wiring slice (audit P0 #4)
 // lands; a regression that drops the header fails TestCreateEndpointsAreTriagedForIdempotency.
 var requireIdempotency = map[string]bool{
-	"create-bead": true,
-	"send-mail":   true,
+	"create-bead":     true,
+	"send-mail":       true,
+	"create-agent":    true,
+	"create-provider": true,
+	"create-rig":      true,
+	"create-convoy":   true,
+	"add-pack":        true,
 }
 
 // pendingIdempotency lists known create operations that are deliberately NOT
@@ -23,16 +28,11 @@ var requireIdempotency = map[string]bool{
 // TODO list, not an exemption: when a slice wires one of these, MOVE it to
 // requireIdempotency — the test enforces the move so the lists stay honest.
 var pendingIdempotency = map[string]bool{
-	"create-agent":            true, // 201
-	"create-provider":         true, // 201
-	"create-rig":              true, // 201
-	"create-convoy":           true, // 201
-	"add-pack":                true, // 201; git fetch, retry-prone
-	"reply-mail":              true, // 201; mints a message
-	"register-extmsg-adapter": true, // 201
-	"emit-event":              true, // 201; append-only, retry double-emits
-	"ensure-extmsg-group":     true, // 201; identity-idempotent already
-	"post-v0-city":            true, // 202; supervisor city create
+	"reply-mail":              true, // 201; mints a message (S3)
+	"register-extmsg-adapter": true, // 201 (S3)
+	"emit-event":              true, // 201; append-only, retry double-emits (S3)
+	"ensure-extmsg-group":     true, // 201; identity-idempotent already — moves to exempt in S3
+	"post-v0-city":            true, // 202; supervisor city create (S3)
 	"create-session":          true, // 202; raw+Huma split, deferred (S4)
 	"send-session-message":    true, // 202; deferred (S4)
 	"respond-session":         true, // 202; deferred (S4)

--- a/internal/api/idempotency_helper.go
+++ b/internal/api/idempotency_helper.go
@@ -1,0 +1,66 @@
+package api
+
+import "github.com/gastownhall/gascity/internal/api/apierr"
+
+// withIdempotency runs create() at most once per (scoped key, request body),
+// giving create endpoints safe retries via the Idempotency-Key header.
+//
+// The scoped key is "POST:<path>:<key>" — namespaced by path so the same
+// Idempotency-Key value on two different endpoints (or two different cities,
+// when the caller folds the city into path) can't collide. On a repeat with a
+// completed reservation it replays the cached typed body value; an in-flight
+// repeat returns apierr.IdempotencyInFlight (409); a same-key/different-body
+// repeat returns apierr.IdempotencyMismatch (422).
+//
+// It ALWAYS releases the pending reservation when create() returns an error OR
+// panics (via defer), so no caller can leak a reservation — the defect the
+// hand-rolled per-handler unreserve boilerplate was prone to. When key == "" it
+// is a passthrough: create() runs exactly once and nothing is cached.
+//
+// create() should perform all fallible work (validation, the store write) and
+// return the domain body value to cache. Callers wrap that value in their
+// response envelope after withIdempotency returns, so envelope fields derived
+// from live state (e.g. the X-GC-Index event sequence) stay fresh on replay.
+func withIdempotency[T any](s *Server, path, key string, body any, create func() (T, error)) (T, error) {
+	var zero T
+	if key == "" {
+		return create()
+	}
+	scopedKey := "POST:" + path + ":" + key
+	bodyHash := hashBody(body)
+
+	existing, found := s.idem.reserve(scopedKey, bodyHash)
+	if found {
+		if existing.bodyHash != bodyHash {
+			return zero, apierr.IdempotencyMismatch.Msg("idempotency_mismatch: Idempotency-Key reused with different request body")
+		}
+		if existing.pending {
+			return zero, apierr.IdempotencyInFlight.Msg("in_flight: request with this Idempotency-Key is already in progress")
+		}
+		if v, ok := replayAs[T](existing); ok {
+			return v, nil
+		}
+		// Completed entry of an unexpected type (should be impossible for a
+		// given endpoint's fixed T). Fall through and recreate rather than
+		// serve a wrong-typed replay.
+	}
+
+	// Release the reservation on any non-success exit — an error return OR a
+	// panic in create(). unreserve only drops a *pending* entry, so on the
+	// wrong-typed fall-through above (where this caller holds no reservation) it
+	// is a harmless no-op against the completed entry.
+	settled := false
+	defer func() {
+		if !settled {
+			s.idem.unreserve(scopedKey)
+		}
+	}()
+
+	v, err := create()
+	if err != nil {
+		return zero, err
+	}
+	settled = true
+	s.idem.storeResponse(scopedKey, bodyHash, v)
+	return v, nil
+}

--- a/internal/api/idempotency_helper.go
+++ b/internal/api/idempotency_helper.go
@@ -6,11 +6,16 @@ import "github.com/gastownhall/gascity/internal/api/apierr"
 // giving create endpoints safe retries via the Idempotency-Key header.
 //
 // The scoped key is "POST:<path>:<key>" — namespaced by path so the same
-// Idempotency-Key value on two different endpoints (or two different cities,
-// when the caller folds the city into path) can't collide. On a repeat with a
-// completed reservation it replays the cached typed body value; an in-flight
-// repeat returns apierr.IdempotencyInFlight (409); a same-key/different-body
-// repeat returns apierr.IdempotencyMismatch (422).
+// Idempotency-Key value on two different endpoints within one city can't
+// collide. Every caller passes a static endpoint path (e.g. "/v0/agents"), so
+// this scoping is intra-city only; cross-city isolation does NOT come from the
+// key. It comes from each city owning a separate *Server, and therefore a
+// separate idem cache, built per city by getCityServer via New(state). A future
+// refactor that hoisted idem to a process-wide scope would silently reintroduce
+// cross-city key collisions despite this scoping. On a repeat with a completed
+// reservation it replays the cached typed body value; an in-flight repeat
+// returns apierr.IdempotencyInFlight (409); a same-key/different-body repeat
+// returns apierr.IdempotencyMismatch (422).
 //
 // It ALWAYS releases the pending reservation when create() returns an error OR
 // panics (via defer), so no caller can leak a reservation — the defect the

--- a/internal/api/idempotency_helper_test.go
+++ b/internal/api/idempotency_helper_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api/apierr"
+)
+
+// newIdemTestServer builds a Server with only the idempotency cache wired —
+// withIdempotency touches nothing else.
+func newIdemTestServer() *Server {
+	return &Server{idem: newIdempotencyCache(30 * time.Minute)}
+}
+
+type idemVal struct {
+	ID   string
+	Body string
+}
+
+func TestWithIdempotency_FirstCallRunsCreate(t *testing.T) {
+	s := newIdemTestServer()
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "1"},
+		func() (idemVal, error) {
+			calls++
+			return idemVal{ID: "t1", Body: "1"}, nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("create calls = %d, want 1", calls)
+	}
+	if got.ID != "t1" {
+		t.Fatalf("got.ID = %q, want t1", got.ID)
+	}
+}
+
+func TestWithIdempotency_ReplayReturnsCachedWithoutRerunning(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	calls := 0
+	create := func() (idemVal, error) {
+		calls++
+		return idemVal{ID: "t1", Body: "first"}, nil
+	}
+	if _, err := withIdempotency(s, "/v0/things", "key-1", body, create); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// Second call: same key + same body. create must NOT run again; the cached
+	// value (not a fresh "second" run) must come back.
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) {
+			calls++
+			return idemVal{ID: "t2", Body: "second"}, nil
+		})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("create calls = %d, want 1 (replay must not re-run)", calls)
+	}
+	if got.ID != "t1" || got.Body != "first" {
+		t.Fatalf("replayed value = %+v, want the first-call value", got)
+	}
+}
+
+func TestWithIdempotency_MismatchReturns422(t *testing.T) {
+	s := newIdemTestServer()
+	if _, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "1"},
+		func() (idemVal, error) { return idemVal{ID: "t1"}, nil }); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	calls := 0
+	_, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "DIFFERENT"},
+		func() (idemVal, error) { calls++; return idemVal{}, nil })
+	if calls != 0 {
+		t.Fatalf("create ran on a body mismatch (calls=%d); it must not", calls)
+	}
+	var em *apierr.ErrorModel
+	if !errors.As(err, &em) {
+		t.Fatalf("error = %v, want *apierr.ErrorModel", err)
+	}
+	if em.Code != "idempotency-mismatch" || em.Status != 422 {
+		t.Fatalf("mismatch error = code %q status %d, want idempotency-mismatch/422", em.Code, em.Status)
+	}
+}
+
+func TestWithIdempotency_InFlightReturns409(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	// Simulate a concurrent in-flight request holding the reservation.
+	scoped := "POST:/v0/things:key-1"
+	s.idem.reserve(scoped, hashBody(body))
+
+	calls := 0
+	_, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{}, nil })
+	if calls != 0 {
+		t.Fatalf("create ran while another request was in-flight (calls=%d)", calls)
+	}
+	var em *apierr.ErrorModel
+	if !errors.As(err, &em) {
+		t.Fatalf("error = %v, want *apierr.ErrorModel", err)
+	}
+	if em.Code != "idempotency-in-flight" || em.Status != 409 {
+		t.Fatalf("in-flight error = code %q status %d, want idempotency-in-flight/409", em.Code, em.Status)
+	}
+}
+
+func TestWithIdempotency_ErrorReleasesReservation(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	sentinel := errors.New("create boom")
+	_, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { return idemVal{}, sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want the create error propagated verbatim", err)
+	}
+	// The reservation must be released: a retry with the same key succeeds and
+	// runs create again (no leaked 409).
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "t1"}, nil })
+	if err != nil {
+		t.Fatalf("retry after failed create: %v (reservation leaked?)", err)
+	}
+	if calls != 1 || got.ID != "t1" {
+		t.Fatalf("retry did not re-run create (calls=%d, got=%+v)", calls, got)
+	}
+}
+
+func TestWithIdempotency_PanicReleasesReservation(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = withIdempotency(s, "/v0/things", "key-1", body,
+			func() (idemVal, error) { panic("boom") })
+		t.Fatal("expected panic to propagate")
+	}()
+	// The reservation must be released even though create() panicked: a retry
+	// with the same key runs create again (no key wedged for the TTL).
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "t1"}, nil })
+	if err != nil {
+		t.Fatalf("retry after panic: %v (reservation leaked on panic?)", err)
+	}
+	if calls != 1 || got.ID != "t1" {
+		t.Fatalf("retry did not re-run create after panic (calls=%d, got=%+v)", calls, got)
+	}
+}
+
+func TestWithIdempotency_WrongTypedEntryFallsThroughToCreate(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	// Seed a COMPLETED entry whose cached value is a different type than the
+	// caller's T (idemVal). replayAs[idemVal] must fail and the helper must fall
+	// through to create() rather than serve a wrong-typed/zero replay.
+	s.idem.storeResponse("POST:/v0/things:key-1", hashBody(body), "not-an-idemVal")
+	calls := 0
+	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "fresh"}, nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 || got.ID != "fresh" {
+		t.Fatalf("wrong-typed entry did not fall through to create (calls=%d, got=%+v)", calls, got)
+	}
+}
+
+func TestWithIdempotency_EmptyKeyPassthrough(t *testing.T) {
+	s := newIdemTestServer()
+	calls := 0
+	create := func() (idemVal, error) { calls++; return idemVal{ID: "t"}, nil }
+	if _, err := withIdempotency(s, "/v0/things", "", nil, create); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if _, err := withIdempotency(s, "/v0/things", "", nil, create); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("empty key must be a passthrough: create calls = %d, want 2", calls)
+	}
+}
+
+func TestWithIdempotency_DistinctKeysAndPathsIndependent(t *testing.T) {
+	s := newIdemTestServer()
+	body := map[string]string{"a": "1"}
+	mk := func() (idemVal, error) { return idemVal{ID: "x"}, nil }
+	if _, err := withIdempotency(s, "/v0/things", "key-1", body, mk); err != nil {
+		t.Fatalf("k1: %v", err)
+	}
+	// Same key, different path → must not collide (independent create).
+	calls := 0
+	if _, err := withIdempotency(s, "/v0/others", "key-1", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "y"}, nil }); err != nil {
+		t.Fatalf("other path: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("same key on a different path collided (calls=%d, want 1)", calls)
+	}
+}

--- a/internal/api/idempotency_helper_test.go
+++ b/internal/api/idempotency_helper_test.go
@@ -203,4 +203,15 @@ func TestWithIdempotency_DistinctKeysAndPathsIndependent(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("same key on a different path collided (calls=%d, want 1)", calls)
 	}
+	// Different keys, same path, same body → must not collide either. This
+	// pins that the KEY participates in the cache scope (dropping it from
+	// scopedKey would make key-2 replay key-1's response).
+	calls = 0
+	if _, err := withIdempotency(s, "/v0/things", "key-2", body,
+		func() (idemVal, error) { calls++; return idemVal{ID: "z"}, nil }); err != nil {
+		t.Fatalf("second key: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("a different key on the same path replayed the first key's response (calls=%d, want 1)", calls)
+	}
 }

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -20207,6 +20207,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -23653,6 +23662,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -23750,6 +23768,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -31259,6 +31292,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -34244,6 +34286,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -35379,6 +35430,15 @@
               "description": "City name.",
               "minLength": 1,
               "pattern": "\\S",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
               "type": "string"
             }
           }

--- a/internal/api/supervisor_city_routes.go
+++ b/internal/api/supervisor_city_routes.go
@@ -210,7 +210,8 @@ func (sm *SupervisorMux) registerCityRoutes() {
 		Path:          "/convoys",
 		Summary:       "Create a convoy",
 		DefaultStatus: http.StatusCreated,
-		Errors:        []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound},
+		// 409: a concurrent repeat of the same Idempotency-Key (idempotency-in-flight).
+		Errors: []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict},
 	}, (*Server).humaHandleConvoyCreate)
 	cityGet(sm, "/convoy/{id}", (*Server).humaHandleConvoyGet, errorStatuses(http.StatusNotFound, http.StatusServiceUnavailable))
 	cityPost(sm, "/convoy/{id}/add", (*Server).humaHandleConvoyAdd, errorStatuses(http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound))


### PR DESCRIPTION
## What

S2 of **audit P0 #4 — `Idempotency-Key` on mutating create endpoints**: wires the five
batch-A creates through the `withIdempotency` helper from S1 (#4147) so a timed-out
client retry cannot mint a duplicate:

- `create-agent` (POST /agents)
- `create-provider` (POST /providers)
- `create-rig` (POST /rigs)
- `create-convoy` (POST /convoys)
- `add-pack` (POST /packs)

**Depends on #4147 (S1).** Base=main per the pipeline convention — the diff shows both
slices until S1 merges, then auto-cleans to S2 only. Left unlabeled until #4147 merges.

## How each endpoint is wired

Each input struct gains the optional `Idempotency-Key` header field, and **all fallible
work moves into the `create()` closure** — validation, the pack SSRF fence, the
config/store write, the agent visibility wait, the convoy link loop + rollback — so the
helper's deferred release covers every error and panic path (no leaked reservations).

Replay caches the response **body value** only:

| endpoint | cached `T` | why |
|---|---|---|
| create-agent / provider / rig | `string` (the name) | output envelopes have anonymous inline bodies `{status, name}` — naming them would rename generated OpenAPI schema components; the body is rebuilt from the name |
| create-convoy | `beads.Bead` | `IndexOutput` envelope; `X-GC-Index` recomputed fresh on replay (the create-bead pattern) |
| add-pack | `importsvc.AddResult` | the body echoes all four fields |

Cache paths are static (`/v0/agents`, …) — safe because the idempotency cache lives on
the **per-city `Server`** (`getCityServer` caches one Server per city), the same
property the beads/mail slices already rely on.

## Deliberate semantics (unchanged from an unkeyed retry)

A create that fails **after** a durable write (agent visibility timeout 503/504, pack
lockfile, convoy rollback failure) releases the reservation, so a same-key retry re-runs
the create and surfaces the conflict (409 already-exists) rather than replaying success.
Idempotency replays only completed successes; it cannot invent one.

## Contract changes

- 5 ops gain the optional `Idempotency-Key` header parameter (spec + Go client +
  dashboard TS client regenerated and committed).
- `create-convoy` now declares 409 (`idempotency-in-flight`); the other four already
  declared 409.
- Guard lists (`TestCreateEndpointsAreTriagedForIdempotency`): the 5 opids moved
  `pending` → `require`.

## Tests / gates

- New `idempotency_endpoints_test.go`: per-endpoint replay-without-re-running-create
  (config/store/import-call counting) + a wire-level 422 mismatch test.
- Helper test now pins that the **key participates in the cache scope**
  (mutation-verified: dropping `+ key` from `scopedKey` fails two tests).
- `gofmt`/`go vet` clean; full `internal/api` suite green; `TestOpenAPISpecInSync`,
  `TestGeneratedClientInSync`, `make dashboard-check` all pass.
- Red-teamed pre-commit (5 lenses + adversarial verification, 13 agents): no code
  defects confirmed; the mutation-hardening test and explicit staging of the new test
  file came out of that review.

## Follow-ups

S3 wires reply-mail, register-extmsg-adapter, emit-event, and supervisor create-city
(needs the `withIdempotency` receiver generalized from `*Server` to the cache, since
`SupervisorMux` has no Server), and moves `ensure-extmsg-group` → exempt
(identity-idempotent by design). S4 (deferred): the session creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
