### PR TITLE
fix(reconciler): conditional orphan release, stop clobbering re-claims

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"path"
 	"strings"
@@ -203,7 +204,7 @@ func releaseOrphanedPoolAssignments(
 		if !allowsRelease {
 			continue
 		}
-		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID, clearDetached) {
+		if !releaseOrphanedPoolAssignment(ownerStore, wb, clearDetached) {
 			continue
 		}
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
@@ -365,23 +366,136 @@ func isCanonicalWorkflowRoot(wb beads.Bead) bool {
 	return sourceworkflow.IsWorkflowRoot(wb) && legacyWorkflowRunTarget(wb) == ""
 }
 
-func releaseOrphanedPoolAssignment(store beads.Store, id string, clearDetached bool) bool {
-	if store == nil || id == "" {
+// releaseOrphanedPoolAssignment clears wb's assignment (assignee -> "",
+// status -> open) plus the session-affinity metadata, preferring the store's
+// atomic conditional release so a legitimate re-claim landing between the
+// orphan staleness check and the release write is never clobbered.
+//
+// Release order:
+//
+//  1. beads.ConditionalAssignmentReleaser.ReleaseIfCurrent when the store
+//     offers it for this snapshot shape (in_progress with a non-empty
+//     assignee — the verb's contract). On BdStore this currently rides raw
+//     `bd sql`; when bd grows a native conditional-release verb it slots in
+//     inside BdStore.ReleaseIfCurrent (feature-detect the verb, fall back to
+//     `bd sql` on unsupported) and this caller needs no change.
+//  2. Otherwise the tightest conditional path the store layer offers:
+//     beads.UpdateOpts has no conditional fields, so re-verify the snapshot
+//     with a live read immediately before the unconditional write and re-read
+//     after it, logging loudly when a concurrent claim raced the release. The
+//     residual recheck->write window cannot be closed without a store-level
+//     conditional write; it is shrunk and made observable instead of silent.
+func releaseOrphanedPoolAssignment(store beads.Store, wb beads.Bead, clearDetached bool) bool {
+	if store == nil || strings.TrimSpace(wb.ID) == "" {
+		return false
+	}
+	if released, handled := releasePoolAssignmentIfCurrent(store, wb); handled {
+		if !released {
+			return false
+		}
+		clearReleasedPoolAssignmentMetadata(store, wb.ID, clearDetached)
+		return true
+	}
+	return releasePoolAssignmentWithRecheck(store, wb, clearDetached)
+}
+
+// releasePoolAssignmentIfCurrent attempts the store's atomic conditional
+// release. handled=false means the store cannot conditionally release this
+// snapshot (no ConditionalAssignmentReleaser, ErrConditionalReleaseUnsupported,
+// or a snapshot shape outside the verb's contract) and the caller must take
+// the recheck fallback. handled=true with released=false means the store
+// answered authoritatively and the release must NOT be retried unconditionally.
+func releasePoolAssignmentIfCurrent(store beads.Store, wb beads.Bead) (released, handled bool) {
+	expectedAssignee := strings.TrimSpace(wb.Assignee)
+	// ReleaseIfCurrent's contract covers in_progress assignments only, and bd
+	// backends may persist an unassigned bead as SQL NULL rather than '', so
+	// open-status strands (issue #2793) and assignee-less in_progress recovery
+	// take the recheck fallback.
+	if wb.Status != "in_progress" || expectedAssignee == "" {
+		return false, false
+	}
+	releaser, ok := store.(beads.ConditionalAssignmentReleaser)
+	if !ok {
+		return false, false
+	}
+	released, err := releaser.ReleaseIfCurrent(wb.ID, expectedAssignee)
+	if err != nil {
+		if errors.Is(err, beads.ErrConditionalReleaseUnsupported) {
+			return false, false
+		}
+		// The store supports conditional release but this attempt failed
+		// (transient backend error). Skip the tick rather than downgrade to an
+		// unconditional write that could clobber a concurrent re-claim; the
+		// reconciler retries next tick.
+		log.Printf("releaseOrphanedPoolAssignments: conditional release failed for %s: %v", wb.ID, err)
+		return false, true
+	}
+	if !released {
+		log.Printf("releaseOrphanedPoolAssignments: skipping release for %s: assignment changed since snapshot (re-claimed or transitioned)", wb.ID)
+	}
+	return released, true
+}
+
+// clearReleasedPoolAssignmentMetadata clears session-affinity (and optionally
+// detached-probe) metadata after a successful conditional release. The clear
+// rides a separate metadata-only write because ReleaseIfCurrent only swaps
+// status/assignee. A failure here does not undo the release: stale affinity
+// keys are overwritten on the next assignment, and detached-probe metadata is
+// only consulted for release candidates, which an open unassigned bead is not.
+func clearReleasedPoolAssignmentMetadata(store beads.Store, id string, clearDetached bool) {
+	metadata := clearedSessionAffinityMetadata()
+	if clearDetached {
+		metadata[detachedProbeMetadataKey] = ""
+	}
+	if err := store.Update(id, beads.UpdateOpts{Metadata: metadata}); err != nil {
+		log.Printf("releaseOrphanedPoolAssignments: clearing metadata after releasing %s: %v", id, err)
+	}
+}
+
+// releasePoolAssignmentWithRecheck is the conditional-release fallback for
+// stores without a usable ReleaseIfCurrent: re-verify (status, assignee) with
+// a live read immediately before the unconditional write — after the earlier
+// staleness gate and the potentially slow detached probe — then verify after
+// the write that no concurrent claim raced the release.
+func releasePoolAssignmentWithRecheck(store beads.Store, wb beads.Bead, clearDetached bool) bool {
+	expectedAssignee := strings.TrimSpace(wb.Assignee)
+	if !liveWorkAssignmentStillReleasable(store, wb.ID, wb.Status, expectedAssignee) {
+		log.Printf("releaseOrphanedPoolAssignments: skipping release for %s: assignment changed between staleness check and release write", wb.ID)
 		return false
 	}
 	opts := beads.UpdateOpts{
 		Assignee: stringPtr(""),
 		Status:   stringPtr("open"),
-		Metadata: withClearedSessionAffinityMetadata(nil),
+		Metadata: clearedSessionAffinityMetadata(),
 	}
 	if clearDetached {
 		opts.Metadata[detachedProbeMetadataKey] = ""
 	}
-	if err := store.Update(id, opts); err != nil {
-		log.Printf("releaseOrphanedPoolAssignments: releasing orphaned pool assignment %s: %v", id, err)
+	if err := store.Update(wb.ID, opts); err != nil {
+		log.Printf("releaseOrphanedPoolAssignments: releasing orphaned pool assignment %s: %v", wb.ID, err)
 		return false
 	}
+	verifyReleasedPoolAssignment(store, wb.ID, expectedAssignee)
 	return true
+}
+
+// verifyReleasedPoolAssignment makes a lost release race observable: when a
+// concurrent claim lands around the unconditional release write, the ordering
+// that survives (claim after release) shows up here as a foreign assignee. A
+// claim clobbered BY the release write (claim between recheck and write)
+// reads back empty and stays undetectable without a store-level conditional
+// write — that ordering is why ReleaseIfCurrent is preferred.
+func verifyReleasedPoolAssignment(store beads.Store, id, expectedAssignee string) {
+	got, err := store.Get(id)
+	if err != nil {
+		log.Printf("releaseOrphanedPoolAssignments: verify-after read failed for %s: %v", id, err)
+		return
+	}
+	observed := strings.TrimSpace(got.Assignee)
+	if observed == "" || observed == expectedAssignee {
+		return
+	}
+	log.Printf("releaseOrphanedPoolAssignments: RELEASE RACE on %s: observed assignee %q immediately after releasing %q — a concurrent claim raced the orphan release", id, observed, expectedAssignee)
 }
 
 func liveOpenSessionAssignmentExists(store beads.Store, assignee string) bool {

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
@@ -374,29 +375,60 @@ func isCanonicalWorkflowRoot(wb beads.Bead) bool {
 // Release order:
 //
 //  1. beads.ConditionalAssignmentReleaser.ReleaseIfCurrent when the store
-//     offers it for this snapshot shape (in_progress with a non-empty
-//     assignee — the verb's contract). On BdStore this currently rides raw
-//     `bd sql`; when bd grows a native conditional-release verb it slots in
-//     inside BdStore.ReleaseIfCurrent (feature-detect the verb, fall back to
-//     `bd sql` on unsupported) and this caller needs no change.
+//     offers it for this snapshot shape (in_progress with a non-empty assignee
+//     — the verb's contract) AND the bead carries no active continuation-group
+//     routing vector (see beadHasActiveContinuationGroup). On BdStore this
+//     currently rides raw `bd sql`; when bd grows a native conditional-release
+//     verb it slots in inside BdStore.ReleaseIfCurrent (feature-detect the
+//     verb, fall back to `bd sql` on unsupported) and this caller needs no
+//     change.
 //  2. Otherwise the tightest conditional path the store layer offers:
 //     beads.UpdateOpts has no conditional fields, so re-verify the snapshot
 //     with a live read immediately before the unconditional write and re-read
 //     after it, logging loudly when a concurrent claim raced the release. The
 //     residual recheck->write window cannot be closed without a store-level
 //     conditional write; it is shrunk and made observable instead of silent.
+//     This single Update also clears the affinity metadata alongside
+//     status/assignee, so it is the correct path for continuation-group beads:
+//     the group is never exposed on an open, unassigned bead.
 func releaseOrphanedPoolAssignment(store beads.Store, wb beads.Bead, clearDetached bool) bool {
 	if store == nil || strings.TrimSpace(wb.ID) == "" {
 		return false
 	}
-	if released, handled := releasePoolAssignmentIfCurrent(store, wb); handled {
-		if !released {
-			return false
+	// Continuation-group beads bypass the CAS fast path: ReleaseIfCurrent swaps
+	// only status/assignee, so clearing the group would need a second write, and
+	// that gap would expose the routing vector on a claimable bead. The recheck
+	// fallback clears status, assignee, and affinity metadata in one Update.
+	if !beadHasActiveContinuationGroup(wb) {
+		if released, handled := releasePoolAssignmentIfCurrent(store, wb); handled {
+			if !released {
+				return false
+			}
+			clearReleasedPoolAssignmentMetadata(store, wb.ID, clearDetached)
+			return true
 		}
-		clearReleasedPoolAssignmentMetadata(store, wb.ID, clearDetached)
-		return true
 	}
 	return releasePoolAssignmentWithRecheck(store, wb, clearDetached)
+}
+
+// beadHasActiveContinuationGroup reports whether wb still advertises the active
+// continuation-group routing vector (gc.continuation_group). Such beads must
+// skip the two-write CAS release path: ReleaseIfCurrent swaps only
+// status/assignee, so the follow-up metadata clear rides a separate write, and
+// in that gap the bead is open and unassigned while gc.continuation_group is
+// still set. A concurrent `gc hook --claim` can then vacuum the bead (or its
+// {root, group} siblings) onto a new session via the stale group —
+// preassignHookContinuationGroup / hookListContinuationWithBdStore route on
+// gc.continuation_group + gc.root_bead_id. Routing these beads through
+// releasePoolAssignmentWithRecheck clears status, assignee, and the affinity
+// metadata in a single Update, so the group is never visible on a claimable
+// bead. gc.session_affinity is an advisory marker no routing path reads (see the
+// beadmeta.SessionAffinityMetadataKeys doc), so it needs no such guard and the
+// CAS path still clears it. Lift this once bd's native conditional-release verb
+// can clear the metadata in the same guarded write (BdStore.ReleaseIfCurrent
+// SEAM).
+func beadHasActiveContinuationGroup(wb beads.Bead) bool {
+	return strings.TrimSpace(wb.Metadata[beadmeta.ContinuationGroupMetadataKey]) != ""
 }
 
 // releasePoolAssignmentIfCurrent attempts the store's atomic conditional

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
@@ -2189,14 +2190,27 @@ type releaseProbeCall struct {
 
 func newConditionalReleaseProbeStore(t *testing.T) (*conditionalReleaseProbeStore, beads.Bead) {
 	t.Helper()
+	return newConditionalReleaseProbeStoreWithMetadata(t, nil)
+}
+
+// newConditionalReleaseProbeStoreWithMetadata builds the orphan-release probe
+// store with extra metadata merged onto the default routed/affinity fixture, so
+// a test can add routing vectors (e.g. gc.continuation_group) without
+// duplicating the setup. A nil extra map reproduces the default fixture exactly.
+func newConditionalReleaseProbeStoreWithMetadata(t *testing.T, extra map[string]string) (*conditionalReleaseProbeStore, beads.Bead) {
+	t.Helper()
 	mem := beads.NewMemStore()
+	metadata := map[string]string{
+		"gc.routed_to":        "worker",
+		"gc.session_affinity": "require",
+	}
+	for k, v := range extra {
+		metadata[k] = v
+	}
 	work, err := mem.Create(beads.Bead{
 		Title:    "orphaned pool work",
 		Assignee: "worker-dead",
-		Metadata: map[string]string{
-			"gc.routed_to":        "worker",
-			"gc.session_affinity": "require",
-		},
+		Metadata: metadata,
 	})
 	if err != nil {
 		t.Fatalf("Create work bead: %v", err)
@@ -2298,6 +2312,56 @@ func TestReleaseOrphanedPoolAssignments_UsesConditionalReleaseWhenSupported(t *t
 	}
 	if got.Metadata["gc.session_affinity"] != "" {
 		t.Fatalf("gc.session_affinity = %q, want cleared after conditional release", got.Metadata["gc.session_affinity"])
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ContinuationGroupBeadBypassesCASWindow(t *testing.T) {
+	// A bead carrying the active continuation-group routing vector must NOT take
+	// the two-write CAS release path: ReleaseIfCurrent swaps only status/assignee,
+	// so a follow-up metadata clear would briefly expose an open, unassigned bead
+	// whose gc.continuation_group is still set, letting a concurrent
+	// `gc hook --claim` vacuum it (or its {root, group} siblings) onto a new
+	// session via the stale group. The release must instead take the recheck
+	// fallback, which clears status, assignee, and the group in a single Update —
+	// so the group is never visible on a claimable bead. This is the regression
+	// pin for the CAS release-then-clear ordering window.
+	store, work := newConditionalReleaseProbeStoreWithMetadata(t, map[string]string{
+		"gc.root_bead_id":       "root-1",
+		"gc.continuation_group": "grp-1",
+	})
+
+	released := releaseProbeAssignments(store, work)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+	if len(store.releaseCalls) != 0 {
+		t.Fatalf("ReleaseIfCurrent calls = %v, want none: a continuation-group bead must bypass the CAS fast path", store.releaseCalls)
+	}
+	if len(store.assignmentUpdates) != 1 {
+		t.Fatalf("assignment-shaped Update calls = %+v, want exactly one atomic release write", store.assignmentUpdates)
+	}
+	// The single release write must clear the assignment AND the continuation
+	// group together, leaving no open/unassigned/group-still-set window.
+	update := store.assignmentUpdates[0]
+	if update.Assignee == nil || *update.Assignee != "" || update.Status == nil || *update.Status != "open" {
+		t.Fatalf("release update = %+v, want assignee=\"\" and status=open", update)
+	}
+	if v, ok := update.Metadata[beadmeta.ContinuationGroupMetadataKey]; !ok || v != "" {
+		t.Fatalf("release update metadata[%s] = %q (present=%v), want cleared in the same write", beadmeta.ContinuationGroupMetadataKey, v, ok)
+	}
+
+	final, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if final.Status != "open" || final.Assignee != "" {
+		t.Fatalf("work = status %q assignee %q, want open/unassigned", final.Status, final.Assignee)
+	}
+	if strings.TrimSpace(final.Metadata[beadmeta.ContinuationGroupMetadataKey]) != "" {
+		t.Fatalf("gc.continuation_group = %q, want cleared after release", final.Metadata[beadmeta.ContinuationGroupMetadataKey])
+	}
+	if strings.TrimSpace(final.Metadata["gc.session_affinity"]) != "" {
+		t.Fatalf("gc.session_affinity = %q, want cleared after release", final.Metadata["gc.session_affinity"])
 	}
 }
 

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -2159,6 +2159,248 @@ func TestReleaseOrphanedPoolAssignments_PreservesNamedIdentityForSameStore(t *te
 	}
 }
 
+// conditionalReleaseProbeStore wraps a MemStore for the orphan-release TOCTOU
+// tests. It records the store writes the release path performs, can report the
+// conditional release unsupported (forcing the recheck fallback), and can
+// inject a concurrent re-claim at controlled points: right after the
+// pre-release live-work gate (a claim landing between the staleness check and
+// the release write) or right after the release write (a claim that survives
+// the race and should be observable in the verify-after read).
+type conditionalReleaseProbeStore struct {
+	beads.Store
+	t   *testing.T
+	mem *beads.MemStore
+
+	releaseUnsupported bool
+	claimID            string
+	claimAssignee      string
+	claimAfterLiveGate bool
+	claimAfterWrite    bool
+
+	releaseCalls      []releaseProbeCall
+	assignmentUpdates []beads.UpdateOpts
+	liveWorkLists     int
+}
+
+type releaseProbeCall struct {
+	id       string
+	assignee string
+}
+
+func newConditionalReleaseProbeStore(t *testing.T) (*conditionalReleaseProbeStore, beads.Bead) {
+	t.Helper()
+	mem := beads.NewMemStore()
+	work, err := mem.Create(beads.Bead{
+		Title:    "orphaned pool work",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{
+			"gc.routed_to":        "worker",
+			"gc.session_affinity": "require",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := mem.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = mem.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+	return &conditionalReleaseProbeStore{
+		Store:         mem,
+		t:             t,
+		mem:           mem,
+		claimID:       work.ID,
+		claimAssignee: "worker-live",
+	}, work
+}
+
+func (s *conditionalReleaseProbeStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	if s.releaseUnsupported {
+		return false, beads.ErrConditionalReleaseUnsupported
+	}
+	s.releaseCalls = append(s.releaseCalls, releaseProbeCall{id: id, assignee: expectedAssignee})
+	return s.mem.ReleaseIfCurrent(id, expectedAssignee)
+}
+
+func (s *conditionalReleaseProbeStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	out, err := s.Store.List(query)
+	if query.Live && query.Status == "in_progress" && query.Label == "" {
+		s.liveWorkLists++
+		if s.claimAfterLiveGate && s.liveWorkLists == 1 {
+			s.reclaim()
+		}
+	}
+	return out, err
+}
+
+func (s *conditionalReleaseProbeStore) Update(id string, opts beads.UpdateOpts) error {
+	if opts.Assignee != nil || opts.Status != nil {
+		s.assignmentUpdates = append(s.assignmentUpdates, opts)
+	}
+	err := s.Store.Update(id, opts)
+	if err == nil && s.claimAfterWrite && opts.Assignee != nil && *opts.Assignee == "" {
+		s.claimAfterWrite = false
+		s.reclaim()
+	}
+	return err
+}
+
+func (s *conditionalReleaseProbeStore) reclaim() {
+	s.t.Helper()
+	if err := s.mem.Update(s.claimID, beads.UpdateOpts{
+		Assignee: stringPtr(s.claimAssignee),
+		Status:   stringPtr("in_progress"),
+	}); err != nil {
+		s.t.Fatalf("injecting concurrent re-claim: %v", err)
+	}
+}
+
+func releaseProbeAssignments(store *conditionalReleaseProbeStore, work beads.Bead) []releasedPoolAssignment {
+	return releaseOrphanedPoolAssignments(
+		store,
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+}
+
+func TestReleaseOrphanedPoolAssignments_UsesConditionalReleaseWhenSupported(t *testing.T) {
+	store, work := newConditionalReleaseProbeStore(t)
+
+	released := releaseProbeAssignments(store, work)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	if len(store.releaseCalls) != 1 {
+		t.Fatalf("ReleaseIfCurrent calls = %v, want exactly one", store.releaseCalls)
+	}
+	if call := store.releaseCalls[0]; call.id != work.ID || call.assignee != "worker-dead" {
+		t.Fatalf("ReleaseIfCurrent call = %+v, want {%s worker-dead}", call, work.ID)
+	}
+	if len(store.assignmentUpdates) != 0 {
+		t.Fatalf("assignment-shaped Update calls = %+v, want none when ReleaseIfCurrent is supported", store.assignmentUpdates)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("work = status %q assignee %q, want open/unassigned", got.Status, got.Assignee)
+	}
+	if got.Metadata["gc.session_affinity"] != "" {
+		t.Fatalf("gc.session_affinity = %q, want cleared after conditional release", got.Metadata["gc.session_affinity"])
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ConditionalReleaseLosesRaceNoClobber(t *testing.T) {
+	store, work := newConditionalReleaseProbeStore(t)
+	store.claimAfterLiveGate = true
+
+	released := releaseProbeAssignments(store, work)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none when a concurrent claim wins the release race", released)
+	}
+	if len(store.assignmentUpdates) != 0 {
+		t.Fatalf("assignment-shaped Update calls = %+v, want none after losing the conditional release", store.assignmentUpdates)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-live" {
+		t.Fatalf("work = status %q assignee %q, want the concurrent claim preserved (in_progress/worker-live)", got.Status, got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_UnsupportedStoreRechecksBeforeWrite(t *testing.T) {
+	store, work := newConditionalReleaseProbeStore(t)
+	store.releaseUnsupported = true
+	store.claimAfterLiveGate = true
+
+	released := releaseProbeAssignments(store, work)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none when the assignee flips between check and write", released)
+	}
+	if len(store.assignmentUpdates) != 0 {
+		t.Fatalf("assignment-shaped Update calls = %+v, want none after the recheck observes the re-claim", store.assignmentUpdates)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-live" {
+		t.Fatalf("work = status %q assignee %q, want the concurrent claim preserved (in_progress/worker-live)", got.Status, got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_UnsupportedStoreLogsRacedClaimAfterRelease(t *testing.T) {
+	store, work := newConditionalReleaseProbeStore(t)
+	store.releaseUnsupported = true
+	store.claimAfterWrite = true
+
+	var buf bytes.Buffer
+	restore := captureLogOutput(&buf)
+	defer restore()
+
+	released := releaseProbeAssignments(store, work)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+	if !strings.Contains(buf.String(), "raced the orphan release") {
+		t.Fatalf("log output = %q, want a loud raced-claim detection after the release write", buf.String())
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-live" {
+		t.Fatalf("work = status %q assignee %q, want the surviving claim preserved (in_progress/worker-live)", got.Status, got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_UnsupportedStoreReleasesNormalOrphan(t *testing.T) {
+	store, work := newConditionalReleaseProbeStore(t)
+	store.releaseUnsupported = true
+
+	var buf bytes.Buffer
+	restore := captureLogOutput(&buf)
+	defer restore()
+
+	released := releaseProbeAssignments(store, work)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+	if len(store.assignmentUpdates) != 1 {
+		t.Fatalf("assignment-shaped Update calls = %+v, want exactly the release write", store.assignmentUpdates)
+	}
+	if strings.Contains(buf.String(), "raced the orphan release") {
+		t.Fatalf("log output = %q, want no raced-claim detection for an uncontended release", buf.String())
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("work = status %q assignee %q, want open/unassigned", got.Status, got.Assignee)
+	}
+	if got.Metadata["gc.session_affinity"] != "" {
+		t.Fatalf("gc.session_affinity = %q, want cleared after fallback release", got.Metadata["gc.session_affinity"])
+	}
+}
+
 // releaseOrphanedPoolAssignmentsFromBeads projects raw session beads to
 // session.Info and calls releaseOrphanedPoolAssignments, letting the existing
 // raw-bead fixtures exercise the WI-5 W4 typed signature.

--- a/cmd/gc/session_affinity_metadata.go
+++ b/cmd/gc/session_affinity_metadata.go
@@ -5,17 +5,15 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// withClearedSessionAffinityMetadata returns metadata with every
-// beadmeta.SessionAffinityMetadataKeys entry set to the empty string,
-// allocating the map when nil. cmd/gc clears affinity by persisting an empty
-// value rather than deleting the key (as internal/dispatch does) because these
-// helpers feed beads.UpdateOpts.Metadata, whose merge only touches supplied
-// keys. Every consumer treats the keys as absent when strings.TrimSpace is
-// empty, so empty-value and deleted are equivalent.
-func withClearedSessionAffinityMetadata(metadata map[string]string) map[string]string {
-	if metadata == nil {
-		metadata = make(map[string]string, len(beadmeta.SessionAffinityMetadataKeys))
-	}
+// clearedSessionAffinityMetadata returns a metadata map with every
+// beadmeta.SessionAffinityMetadataKeys entry set to the empty string. cmd/gc
+// clears affinity by persisting an empty value rather than deleting the key
+// (as internal/dispatch does) because these helpers feed
+// beads.UpdateOpts.Metadata, whose merge only touches supplied keys. Every
+// consumer treats the keys as absent when strings.TrimSpace is empty, so
+// empty-value and deleted are equivalent.
+func clearedSessionAffinityMetadata() map[string]string {
+	metadata := make(map[string]string, len(beadmeta.SessionAffinityMetadataKeys))
 	for _, key := range beadmeta.SessionAffinityMetadataKeys {
 		metadata[key] = ""
 	}
@@ -23,7 +21,7 @@ func withClearedSessionAffinityMetadata(metadata map[string]string) map[string]s
 }
 
 // clearSessionAffinityMetadataOnBead persists an empty value for every
-// session-affinity key on beadID. See withClearedSessionAffinityMetadata for
+// session-affinity key on beadID. See clearedSessionAffinityMetadata for
 // why cmd/gc clears by empty value rather than key deletion.
 func clearSessionAffinityMetadataOnBead(store beads.Store, beadID string) error {
 	for _, key := range beadmeta.SessionAffinityMetadataKeys {

--- a/cmd/gc/work_assignment.go
+++ b/cmd/gc/work_assignment.go
@@ -139,7 +139,7 @@ func (w workAssignment) ReleaseWorkBead(item beads.Bead, runTargetFallback strin
 	empty := ""
 	update := beads.UpdateOpts{
 		Assignee: &empty,
-		Metadata: withClearedSessionAffinityMetadata(nil),
+		Metadata: clearedSessionAffinityMetadata(),
 	}
 	if item.Status == "in_progress" {
 		open := "open"

--- a/cmd/gc/work_assignment_write_test.go
+++ b/cmd/gc/work_assignment_write_test.go
@@ -102,7 +102,7 @@ func TestWorkAssignmentReleaseWorkBead_OpenStaysOpen(t *testing.T) {
 	if got.opts.Status != nil {
 		t.Fatalf("Status should be nil for an already-open bead, got %q", *got.opts.Status)
 	}
-	wantMeta := withClearedSessionAffinityMetadata(nil)
+	wantMeta := clearedSessionAffinityMetadata()
 	if !reflect.DeepEqual(got.opts.Metadata, wantMeta) {
 		t.Fatalf("Metadata mismatch:\n got %#v\n want %#v", got.opts.Metadata, wantMeta)
 	}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1100,6 +1100,16 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 
 // ReleaseIfCurrent clears an in-progress assignment only when the bead still
 // has the expected assignee.
+//
+// SEAM (bd conditional-release verb): today this rides raw `bd sql`, which
+// several backends reject — the sqlite backend refuses raw DB access, and
+// embedded dolt takes the releaseIfCurrentViaEmbeddedDoltSQL fallback, both
+// ultimately surfacing ErrConditionalReleaseUnsupported. When bd ships its
+// native issueops CAS release verb, consume it HERE as the first attempt:
+// probe by invoking the verb and fall back to this `bd sql` path when bd
+// reports the command unknown (older pinned bd). Callers already treat
+// ErrConditionalReleaseUnsupported as "take a conditional recheck fallback"
+// (see cmd/gc releasePoolAssignmentIfCurrent), so no caller changes are needed.
 func (s *BdStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
 	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
 		" WHERE id = " + bdSQLStringLiteral(id) +

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1101,11 +1101,14 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 // ReleaseIfCurrent clears an in-progress assignment only when the bead still
 // has the expected assignee.
 //
-// SEAM (bd conditional-release verb): today this rides raw `bd sql`, which
-// several backends reject — the sqlite backend refuses raw DB access, and
-// embedded dolt takes the releaseIfCurrentViaEmbeddedDoltSQL fallback, both
-// ultimately surfacing ErrConditionalReleaseUnsupported. When bd ships its
-// native issueops CAS release verb, consume it HERE as the first attempt:
+// SEAM (bd conditional-release verb): today this rides raw `bd sql`. The
+// sqlite backend refuses raw DB access, so that rejection — and embedded dolt
+// WITHOUT a configured dolt directory — surface ErrConditionalReleaseUnsupported
+// (the latter via the releaseIfCurrentViaEmbeddedDoltSQL fallback). Embedded
+// dolt WITH a configured directory instead services the CAS directly through
+// that fallback, returning real rows-affected rather than reporting
+// unsupported. When bd ships its native issueops CAS release verb, consume it
+// HERE as the first attempt:
 // probe by invoking the verb and fall back to this `bd sql` path when bd
 // reports the command unknown (older pinned bd). Callers already treat
 // ErrConditionalReleaseUnsupported as "take a conditional recheck fallback"


### PR DESCRIPTION
## What

Makes the reconciler's pool orphan-release conditional on the claim it observed: prefer the store's atomic `ReleaseIfCurrent` CAS (status/assignee) and, where a store cannot conditionally release, re-verify the snapshot with a live read immediately before the write plus a verify-after read that logs a raced claim loudly — replacing the previous unconditional `Update(assignee:"", status:"open")`.

## Why

The 2026-07-11 sqlite infra-store concurrency audit flagged this as defect #6 (MED): the controller's orphan path (`releaseOrphanedPoolAssignment`, `cmd/gc/pool_session_name.go`) was a check-then-act TOCTOU — snapshot assigned work, run staleness gates (plus a potentially slow detached probe), then write an unconditional release. A legitimate re-claim landing in that window (crash recovery racing a live or revived claimer) was silently clobbered back to open/unassigned, with exit 0 everywhere and no runtime signal. Compounding it, conditional release was dead on the sqlite infra backend: `bd sql` is unsupported there (empirically confirmed by the audit), so `BdStore.ReleaseIfCurrent` fail-loud dies — and the orphan path never attempted it anyway.

Audit context: the same hammer ran ~5,900 real cross-process bd operations with 640/640 claim races producing exactly one winner — the engine-level claim CAS is sound. This gc-side unconditional write was the layer above it that could undo a legitimately won claim. A red-team harness against a real bd v1.1.0 sqlite workspace reproduced the clobber deterministically on unpatched code (numbers below). `internal/beads/bdstore.go` also gains a SEAM comment marking exactly where bd's native conditional-release verb slots in once it ships (callers already treat `ErrConditionalReleaseUnsupported` as "take the recheck fallback", so no caller changes will be needed).

## Verification

TDD unit tests (5 new tests covering: CAS preferred when supported, lost CAS race means no unconditional retry, unsupported store rechecks before write, raced claim after the fallback write is logged loudly, uncontended orphan still releases):

```
$ go test ./cmd/gc/ -run 'TestReleaseOrphanedPoolAssignments|TestWorkAssignmentReleaseWorkBead' -count=1
ok      github.com/gastownhall/gascity/cmd/gc   1.709s
$ go vet ./cmd/gc/ ./internal/beads/    # clean
```

Red-team empirical re-run — end-to-end against a **real bd v1.1.0 binary with a real sqlite-backend workspace** (scratch harness `rt_toctou_realbd_sqlite_e2e_test.go`, injected re-claim between the staleness check and the release write; harness is scratch-only, not part of this diff):

```
$ go test ./cmd/gc/ -run 'TestRT_RealBdSqlite' -count=1 -v
```

- **Unpatched base (`faa1d5bd1` + harness): 1/3 FAIL.** `TestRT_RealBdSqlite_ReclaimBetweenCheckAndWriteNotClobbered`: `released = [{gc-p6n 0}], want none when a concurrent claim landed mid-release` — the orphan release discarded the live `worker-live` re-claim.
- **Patched: 3/3 PASS.** The injected mid-window re-claim is preserved (`in_progress/worker-live`) and skipped loudly (`releaseOrphanedPoolAssignments: skipping release for gc-5sa: assignment changed between staleness check and release write`); `ReleaseIfCurrent` on sqlite surfaces `ErrConditionalReleaseUnsupported` (not a stranding error); and the regression guard confirms an uncontended sqlite orphan is still released, not permanently skipped.

Pre-commit (lint `0 issues`, `go vet ./...`, doc-gen) and the pre-push full fast suite both passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
