### PR TITLE
feat(api): accept Idempotency-Key on reply-mail, emit-event, extmsg-adapter, and city creates (P0 #4 S3)

### DIFF
--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -18152,6 +18152,15 @@
               "minLength": 1,
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -18180,7 +18189,7 @@
               }
             }
           },
-          "default": {
+          "401": {
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -18188,7 +18197,82 @@
                 }
               }
             },
-            "description": "Error",
+            "description": "Unauthorized",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Forbidden",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Unprocessable Entity",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Internal Server Error",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "501": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Not Implemented",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -24299,6 +24383,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -24366,6 +24459,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -24981,6 +25089,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -25048,6 +25165,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -29855,6 +29987,15 @@
               "description": "Rig hint.",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -29937,6 +30078,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -18152,6 +18152,15 @@
               "minLength": 1,
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -18180,7 +18189,7 @@
               }
             }
           },
-          "default": {
+          "401": {
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -18188,7 +18197,82 @@
                 }
               }
             },
-            "description": "Error",
+            "description": "Unauthorized",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Forbidden",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Unprocessable Entity",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Internal Server Error",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "501": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Not Implemented",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -24299,6 +24383,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -24366,6 +24459,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -24981,6 +25089,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -25048,6 +25165,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -29855,6 +29987,15 @@
               "description": "Rig hint.",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -29937,6 +30078,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -7152,6 +7152,10 @@ export type PostV0CityData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path?: never;
     query?: never;
@@ -7160,9 +7164,29 @@ export type PostV0CityData = {
 
 export type PostV0CityErrors = {
     /**
-     * Error
+     * Unauthorized
      */
-    default: ErrorModel;
+    401: ErrorModel;
+    /**
+     * Forbidden
+     */
+    403: ErrorModel;
+    /**
+     * Conflict
+     */
+    409: ErrorModel;
+    /**
+     * Unprocessable Entity
+     */
+    422: ErrorModel;
+    /**
+     * Internal Server Error
+     */
+    500: ErrorModel;
+    /**
+     * Not Implemented
+     */
+    501: ErrorModel;
 };
 
 export type PostV0CityError = PostV0CityErrors[keyof PostV0CityErrors];
@@ -9554,6 +9578,10 @@ export type EmitEventData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**
@@ -9578,6 +9606,10 @@ export type EmitEventErrors = {
      * Not Found
      */
     404: ErrorModel;
+    /**
+     * Conflict
+     */
+    409: ErrorModel;
     /**
      * Unprocessable Entity
      */
@@ -9840,6 +9872,10 @@ export type RegisterExtmsgAdapterData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**
@@ -9864,6 +9900,10 @@ export type RegisterExtmsgAdapterErrors = {
      * Not Found
      */
     404: ErrorModel;
+    /**
+     * Conflict
+     */
+    409: ErrorModel;
     /**
      * Unprocessable Entity
      */
@@ -11736,6 +11776,10 @@ export type ReplyMailData = {
          * Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
          */
         'X-GC-Request': string;
+        /**
+         * Idempotency key for safe retries.
+         */
+        'Idempotency-Key'?: string;
     };
     path: {
         /**
@@ -11769,6 +11813,10 @@ export type ReplyMailErrors = {
      * Not Found
      */
     404: ErrorModel;
+    /**
+     * Conflict
+     */
+    409: ErrorModel;
     /**
      * Unprocessable Entity
      */

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
@@ -5086,7 +5086,8 @@ export const zGetV0CitiesResponse = zSupervisorCitiesOutputBody;
 export const zPostV0CityBody = zCityCreateRequest;
 
 export const zPostV0CityHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 /**
@@ -5684,7 +5685,8 @@ export const zGetV0CityByCityNameEventsResponse = zListBodyWireEvent;
 export const zEmitEventBody = zEventEmitRequest;
 
 export const zEmitEventHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zEmitEventPath = z.object({
@@ -5769,7 +5771,8 @@ export const zGetV0CityByCityNameExtmsgAdaptersResponse = zListBodyExtmsgAdapter
 export const zRegisterExtmsgAdapterBody = zExtMsgAdapterRegisterInputBody;
 
 export const zRegisterExtmsgAdapterHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zRegisterExtmsgAdapterPath = z.object({
@@ -6262,7 +6265,8 @@ export const zPostV0CityByCityNameMailByIdReadResponse = zOkResponseBody;
 export const zReplyMailBody = zMailReplyInputBody;
 
 export const zReplyMailHeaders = z.object({
-    'X-GC-Request': z.string().min(1)
+    'X-GC-Request': z.string().min(1),
+    'Idempotency-Key': z.string().optional()
 });
 
 export const zReplyMailPath = z.object({

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -6322,6 +6322,9 @@ type WorkspaceResponse struct {
 type PostV0CityParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // PatchV0CityByCityNameParams defines parameters for PatchV0CityByCityName.
@@ -6586,6 +6589,9 @@ type GetV0CityByCityNameEventsParams struct {
 type EmitEventParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // RotateEventsParams defines parameters for RotateEvents.
@@ -6616,6 +6622,9 @@ type DeleteV0CityByCityNameExtmsgAdaptersParams struct {
 type RegisterExtmsgAdapterParams struct {
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // PostV0CityByCityNameExtmsgBindParams defines parameters for PostV0CityByCityNameExtmsgBind.
@@ -6901,6 +6910,9 @@ type ReplyMailParams struct {
 
 	// XGCRequest Anti-CSRF header required on mutation requests. Any non-empty value is accepted; the header's presence is what the server checks.
 	XGCRequest string `json:"X-GC-Request"`
+
+	// IdempotencyKey Idempotency key for safe retries.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
 // TriggerMaintenanceDoltGcParams defines parameters for TriggerMaintenanceDoltGc.
@@ -16435,6 +16447,17 @@ func NewPostV0CityRequestWithBody(server string, params *PostV0CityParams, conte
 
 		req.Header.Set("X-GC-Request", headerParam0)
 
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -19140,6 +19163,17 @@ func NewEmitEventRequestWithBody(server string, cityName string, params *EmitEve
 
 		req.Header.Set("X-GC-Request", headerParam0)
 
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -19433,6 +19467,17 @@ func NewRegisterExtmsgAdapterRequestWithBody(server string, cityName string, par
 		}
 
 		req.Header.Set("X-GC-Request", headerParam0)
+
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
 
 	}
 
@@ -21832,6 +21877,17 @@ func NewReplyMailRequestWithBody(server string, cityName string, id string, para
 		}
 
 		req.Header.Set("X-GC-Request", headerParam0)
+
+		if params.IdempotencyKey != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithOptions("simple", false, "Idempotency-Key", *params.IdempotencyKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam1)
+		}
 
 	}
 
@@ -27227,10 +27283,15 @@ func (r GetV0CitiesResponse) StatusCode() int {
 }
 
 type PostV0CityResponse struct {
-	Body                          []byte
-	HTTPResponse                  *http.Response
-	JSON202                       *AsyncAcceptedResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	Body                      []byte
+	HTTPResponse              *http.Response
+	JSON202                   *AsyncAcceptedResponse
+	ApplicationproblemJSON401 *ErrorModel
+	ApplicationproblemJSON403 *ErrorModel
+	ApplicationproblemJSON409 *ErrorModel
+	ApplicationproblemJSON422 *ErrorModel
+	ApplicationproblemJSON500 *ErrorModel
+	ApplicationproblemJSON501 *ErrorModel
 }
 
 // Status returns HTTPResponse.Status
@@ -28364,6 +28425,7 @@ type EmitEventResponse struct {
 	ApplicationproblemJSON401 *ErrorModel
 	ApplicationproblemJSON403 *ErrorModel
 	ApplicationproblemJSON404 *ErrorModel
+	ApplicationproblemJSON409 *ErrorModel
 	ApplicationproblemJSON422 *ErrorModel
 	ApplicationproblemJSON500 *ErrorModel
 	ApplicationproblemJSON503 *ErrorModel
@@ -28496,6 +28558,7 @@ type RegisterExtmsgAdapterResponse struct {
 	ApplicationproblemJSON401 *ErrorModel
 	ApplicationproblemJSON403 *ErrorModel
 	ApplicationproblemJSON404 *ErrorModel
+	ApplicationproblemJSON409 *ErrorModel
 	ApplicationproblemJSON422 *ErrorModel
 	ApplicationproblemJSON500 *ErrorModel
 	ApplicationproblemJSON503 *ErrorModel
@@ -29376,6 +29439,7 @@ type ReplyMailResponse struct {
 	ApplicationproblemJSON401 *ErrorModel
 	ApplicationproblemJSON403 *ErrorModel
 	ApplicationproblemJSON404 *ErrorModel
+	ApplicationproblemJSON409 *ErrorModel
 	ApplicationproblemJSON422 *ErrorModel
 	ApplicationproblemJSON500 *ErrorModel
 }
@@ -33447,12 +33511,47 @@ func ParsePostV0CityResponse(rsp *http.Response) (*PostV0CityResponse, error) {
 		}
 		response.JSON202 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest ErrorModel
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.ApplicationproblemJSONDefault = &dest
+		response.ApplicationproblemJSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON501 = &dest
 
 	}
 
@@ -36009,6 +36108,13 @@ func ParseEmitEventResponse(rsp *http.Response) (*EmitEventResponse, error) {
 		}
 		response.ApplicationproblemJSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON409 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest ErrorModel
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -36292,6 +36398,13 @@ func ParseRegisterExtmsgAdapterResponse(rsp *http.Response) (*RegisterExtmsgAdap
 			return nil, err
 		}
 		response.ApplicationproblemJSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest ErrorModel
@@ -38356,6 +38469,13 @@ func ParseReplyMailResponse(rsp *http.Response) (*ReplyMailResponse, error) {
 			return nil, err
 		}
 		response.ApplicationproblemJSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest ErrorModel

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -269,7 +269,7 @@ func (s *Server) humaHandleAgentCreate(ctx context.Context, input *AgentCreateIn
 	// write (visibility timeout 503/504) releases the reservation, so a
 	// same-key retry re-runs the create and surfaces the conflict — identical
 	// to an unkeyed retry today.
-	qualifiedName, err := withIdempotency(s, "/v0/agents", input.IdempotencyKey, input.Body,
+	qualifiedName, err := withIdempotency(s.idem, "/v0/agents", input.IdempotencyKey, input.Body,
 		func() (string, error) {
 			sm, ok := s.state.(StateMutator)
 			if !ok {

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -545,7 +545,7 @@ func (s *Server) humaHandleBeadCreate(ctx context.Context, input *BeadCreateInpu
 	// Idempotency: run the create at most once per Idempotency-Key. The helper
 	// owns reserve/replay/mismatch/in-flight and guarantees the reservation is
 	// released on any error, so every fallible step lives in the closure.
-	b, err := withIdempotency(s, "/v0/beads", input.IdempotencyKey, input.Body,
+	b, err := withIdempotency(s.idem, "/v0/beads", input.IdempotencyKey, input.Body,
 		func() (beads.Bead, error) {
 			store := s.findStore(input.Body.Rig)
 			if store == nil {

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -214,7 +214,7 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 	// Idempotency: create at most once per Idempotency-Key. Item validation,
 	// the convoy bead create, and the link loop (with its rollback) all live in
 	// the closure so a failed create releases the reservation for retry.
-	convoy, err := withIdempotency(s, "/v0/convoys", input.IdempotencyKey, input.Body,
+	convoy, err := withIdempotency(s.idem, "/v0/convoys", input.IdempotencyKey, input.Body,
 		func() (beads.Bead, error) {
 			store := s.findStore(input.Body.Rig)
 			if store == nil {

--- a/internal/api/huma_handlers_events.go
+++ b/internal/api/huma_handlers_events.go
@@ -159,20 +159,30 @@ func parseEventSince(value string) (time.Duration, bool, error) {
 // Body validation (Type and Actor required) is enforced by struct tags
 // on EventEmitInput.
 func (s *Server) humaHandleEventEmit(_ context.Context, input *EventEmitInput) (*EventEmitOutput, error) {
-	ep := s.state.EventProvider()
-	if ep == nil {
-		return nil, apierr.ServiceUnavailable.Msg("events not enabled")
+	// Idempotency: append at most once per Idempotency-Key — the log is
+	// append-only, so a timed-out retry would otherwise double-emit (and
+	// double any projection built over the log). The cached value is just the
+	// status constant; the whole point is skipping the duplicate Record.
+	status, err := withIdempotency(s.idem, "/v0/events", input.IdempotencyKey, input.Body,
+		func() (string, error) {
+			ep := s.state.EventProvider()
+			if ep == nil {
+				return "", apierr.ServiceUnavailable.Msg("events not enabled")
+			}
+			ep.Record(events.Event{
+				Type:    input.Body.Type,
+				Actor:   input.Body.Actor,
+				Subject: input.Body.Subject,
+				Message: input.Body.Message,
+			})
+			return "recorded", nil
+		})
+	if err != nil {
+		return nil, err
 	}
 
-	ep.Record(events.Event{
-		Type:    input.Body.Type,
-		Actor:   input.Body.Actor,
-		Subject: input.Body.Subject,
-		Message: input.Body.Message,
-	})
-
 	resp := &EventEmitOutput{}
-	resp.Body.Status = "recorded"
+	resp.Body.Status = status
 	return resp, nil
 }
 

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -536,24 +536,36 @@ func (s *Server) humaHandleExtMsgAdapterList(_ context.Context, _ *ExtMsgAdapter
 
 // humaHandleExtMsgAdapterRegister is the Huma-typed handler for POST /v0/extmsg/adapters.
 func (s *Server) humaHandleExtMsgAdapterRegister(_ context.Context, input *ExtMsgAdapterRegisterInput) (*ExtMsgAdapterRegisterOutput, error) {
-	reg, err := s.humaExtmsgAdapterRegistry()
+	// Idempotency: register at most once per Idempotency-Key. Register itself
+	// is an add-or-replace upsert; the win is suppressing a duplicate
+	// ExtMsgAdapterAdded event on retry. The cached value is the resolved
+	// adapter name — the other body fields are echoes of the input, which the
+	// body hash pins to be identical on replay.
+	name, err := withIdempotency(s.idem, "/v0/extmsg/adapters", input.IdempotencyKey, input.Body,
+		func() (string, error) {
+			reg, regErr := s.humaExtmsgAdapterRegistry()
+			if regErr != nil {
+				return "", regErr
+			}
+
+			resolved := input.Body.Name
+			if resolved == "" {
+				resolved = input.Body.Provider + "/" + input.Body.AccountID
+			}
+
+			adapter := extmsg.NewHTTPAdapter(resolved, input.Body.CallbackURL, input.Body.Capabilities)
+			key := extmsg.AdapterKey{Provider: input.Body.Provider, AccountID: input.Body.AccountID}
+			reg.Register(key, adapter)
+
+			s.extmsgEmitEvent()(events.ExtMsgAdapterAdded, resolved, extmsg.AdapterEventPayload{
+				Provider:  input.Body.Provider,
+				AccountID: input.Body.AccountID,
+			})
+			return resolved, nil
+		})
 	if err != nil {
 		return nil, err
 	}
-
-	name := input.Body.Name
-	if name == "" {
-		name = input.Body.Provider + "/" + input.Body.AccountID
-	}
-
-	adapter := extmsg.NewHTTPAdapter(name, input.Body.CallbackURL, input.Body.Capabilities)
-	key := extmsg.AdapterKey{Provider: input.Body.Provider, AccountID: input.Body.AccountID}
-	reg.Register(key, adapter)
-
-	s.extmsgEmitEvent()(events.ExtMsgAdapterAdded, name, extmsg.AdapterEventPayload{
-		Provider:  input.Body.Provider,
-		AccountID: input.Body.AccountID,
-	})
 	out := &ExtMsgAdapterRegisterOutput{}
 	out.Body.Status = "registered"
 	out.Body.Provider = input.Body.Provider

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -437,7 +438,7 @@ func (s *Server) humaHandleMailSend(ctx context.Context, input *MailSendInput) (
 	// Idempotency: send at most once per Idempotency-Key. On replay the closure
 	// is skipped entirely, so no duplicate Send, telemetry op, or MailSent event
 	// fires. The helper guarantees the reservation is released on a send error.
-	msg, err := withIdempotency(s, "/v0/mail", input.IdempotencyKey, input.Body,
+	msg, err := withIdempotency(s.idem, "/v0/mail", input.IdempotencyKey, input.Body,
 		func() (mail.Message, error) {
 			sent, sendErr := mp.Send(input.Body.From, resolved, input.Body.Subject, input.Body.Body)
 			telemetry.RecordMailOp(ctx, "send", sendErr)
@@ -687,21 +688,35 @@ func (s *Server) humaHandleMailReply(ctx context.Context, input *MailReplyInput)
 	id := input.ID
 	rig := input.Rig
 
-	mp, resolvedRig, mpErr := s.findMailProviderForMessage(id, rig)
-	if mpErr != nil {
-		return nil, apierr.Internal.Msg(mpErr.Error())
-	}
-	if mp == nil {
-		return nil, apierr.MailNotFound.Msg("message " + id + " not found")
-	}
+	// Idempotency: reply at most once per Idempotency-Key. The message ID is
+	// folded into the cache path because it lives in the URL, not the body —
+	// the same key + body against two different messages must not collide.
+	// PathEscape keeps a crafted ID (%2F-encoded slash) from forging the
+	// "/reply:" boundary and aliasing another (id, key) pair's scope. The
+	// provider lookup stays INSIDE the closure so a replay still succeeds
+	// after the original message was archived (the closure is skipped).
+	msg, err := withIdempotency(s.idem, "/v0/mail/"+url.PathEscape(id)+"/reply", input.IdempotencyKey, input.Body,
+		func() (mail.Message, error) {
+			mp, resolvedRig, mpErr := s.findMailProviderForMessage(id, rig)
+			if mpErr != nil {
+				return mail.Message{}, apierr.Internal.Msg(mpErr.Error())
+			}
+			if mp == nil {
+				return mail.Message{}, apierr.MailNotFound.Msg("message " + id + " not found")
+			}
 
-	msg, err := mp.Reply(id, input.Body.From, input.Body.Subject, input.Body.Body)
-	telemetry.RecordMailOp(ctx, "reply", err)
+			sent, replyErr := mp.Reply(id, input.Body.From, input.Body.Subject, input.Body.Body)
+			telemetry.RecordMailOp(ctx, "reply", replyErr)
+			if replyErr != nil {
+				return mail.Message{}, apierr.Internal.Msg(replyErr.Error())
+			}
+			sent.Rig = resolvedRig
+			s.recordMailEvent(events.MailReplied, sent.From, sent.ID, resolvedRig, &sent)
+			return sent, nil
+		})
 	if err != nil {
-		return nil, apierr.Internal.Msg(err.Error())
+		return nil, err
 	}
-	msg.Rig = resolvedRig
-	s.recordMailEvent(events.MailReplied, msg.From, msg.ID, resolvedRig, &msg)
 
 	return &IndexOutput[mail.Message]{
 		Index: s.latestIndex(),

--- a/internal/api/huma_handlers_packs.go
+++ b/internal/api/huma_handlers_packs.go
@@ -104,7 +104,7 @@ func (s *Server) humaHandlePackAdd(_ context.Context, input *PackAddInput) (*Pac
 	// Idempotency: import at most once per Idempotency-Key — a pack add shells
 	// out to git and is exactly the expensive, retry-prone create the key is
 	// for. The cached value is the AddResult the response body echoes.
-	res, err := withIdempotency(s, "/v0/packs", input.IdempotencyKey, input.Body,
+	res, err := withIdempotency(s.idem, "/v0/packs", input.IdempotencyKey, input.Body,
 		func() (importsvc.AddResult, error) {
 			// SSRF fence: AddImport shells `git ls-remote <source>` synchronously and
 			// its contract requires HTTP callers to validate the source first. Reject

--- a/internal/api/huma_handlers_providers.go
+++ b/internal/api/huma_handlers_providers.go
@@ -133,7 +133,7 @@ func (s *Server) humaHandleProviderGet(_ context.Context, input *ProviderGetInpu
 func (s *Server) humaHandleProviderCreate(_ context.Context, input *ProviderCreateInput) (*ProviderCreatedOutput, error) {
 	// Idempotency: create at most once per Idempotency-Key. The cached value is
 	// the provider name; the response body is rebuilt from it on replay.
-	name, err := withIdempotency(s, "/v0/providers", input.IdempotencyKey, input.Body,
+	name, err := withIdempotency(s.idem, "/v0/providers", input.IdempotencyKey, input.Body,
 		func() (string, error) {
 			sm, ok := s.state.(StateMutator)
 			if !ok {

--- a/internal/api/huma_handlers_rigs.go
+++ b/internal/api/huma_handlers_rigs.go
@@ -68,7 +68,7 @@ func (s *Server) humaHandleRigGet(_ context.Context, input *RigGetInput) (*Index
 func (s *Server) humaHandleRigCreate(_ context.Context, input *RigCreateInput) (*RigCreatedOutput, error) {
 	// Idempotency: create at most once per Idempotency-Key. The cached value is
 	// the rig name; the response body is rebuilt from it on replay.
-	name, err := withIdempotency(s, "/v0/rigs", input.IdempotencyKey, input.Body,
+	name, err := withIdempotency(s.idem, "/v0/rigs", input.IdempotencyKey, input.Body,
 		func() (string, error) {
 			sm, ok := s.state.(StateMutator)
 			if !ok {

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -373,81 +373,7 @@ func (sm *SupervisorMux) humaHandleCityCreate(ctx context.Context, input *Superv
 	// would break result-event correlation.
 	accepted, err := withIdempotency(sm.idem, "/v0/city", input.IdempotencyKey, input.Body,
 		func() (asyncAcceptedResponse, error) {
-			var zero asyncAcceptedResponse
-			dir := input.Body.Dir
-			if !filepath.IsAbs(dir) {
-				home, err := os.UserHomeDir()
-				if err != nil {
-					return zero, apierr.Internal.Msg(fmt.Sprintf("internal: resolving home dir: %v", err))
-				}
-				dir = filepath.Join(home, dir)
-			}
-
-			// Cheap pre-check that does not require a city initializer: if the
-			// target directory already looks like an initialized city on disk,
-			// return 409 before we try to scaffold. Keeps the API well-behaved
-			// in test configurations that build a SupervisorMux without an
-			// initializer.
-			if cityDirAlreadyInitialized(dir) {
-				return zero, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
-			}
-
-			if sm.initializer == nil {
-				return zero, apierr.NotImplemented.Msg("city creation is not available in this supervisor (no initializer wired)")
-			}
-
-			reqID, err := newRequestID()
-			if err != nil {
-				return zero, apierr.Internal.Msg(fmt.Sprintf("generating request ID: %v", err))
-			}
-			eventCursor, cursorErr := sm.currentSupervisorEventCursor()
-			if cursorErr != nil {
-				return zero, apierr.Internal.Msg(cursorErr.Error())
-			}
-			pendingStored := false
-			if store, ok := sm.resolver.(PendingRequestStore); ok {
-				if err := store.StorePendingRequestID(dir, reqID); err != nil {
-					if errors.Is(err, ErrPendingRequestExists) {
-						return zero, apierr.OperationInProgress.Msg("conflict: city initialization already in progress at " + dir)
-					}
-					return zero, apierr.Internal.Msg(fmt.Sprintf("storing pending request ID: %v", err))
-				}
-				pendingStored = true
-			}
-
-			result, scaffoldErr := sm.initializer.Scaffold(ctx, cityinit.InitRequest{
-				Dir:                   dir,
-				Provider:              input.Body.Provider,
-				StartCommand:          input.Body.StartCommand,
-				BootstrapProfile:      input.Body.BootstrapProfile,
-				SkipProviderReadiness: true,
-			})
-			postRegisterFailed := false
-			switch {
-			case errors.Is(scaffoldErr, cityinit.ErrAlreadyInitialized):
-				sm.clearPendingCityRequestID(dir, pendingStored)
-				return zero, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
-			case errors.Is(scaffoldErr, cityinit.ErrInvalidDirectory),
-				errors.Is(scaffoldErr, cityinit.ErrInvalidProvider),
-				errors.Is(scaffoldErr, cityinit.ErrInvalidBootstrapProfile):
-				sm.clearPendingCityRequestID(dir, pendingStored)
-				return zero, apierr.ValidationFailed.Msg(scaffoldErr.Error())
-			case errors.Is(scaffoldErr, cityinit.ErrPostRegisterFailure):
-				failureReqID := reqID
-				if consumedReqID, ok := sm.consumePendingCityRequestID(dir, pendingStored); ok {
-					failureReqID = consumedReqID
-				}
-				emitCityCreateFailed(sm.resolver, failureReqID, result, dir, "city_init_failed", scaffoldErr)
-				postRegisterFailed = true
-			case scaffoldErr != nil:
-				sm.clearPendingCityRequestID(dir, pendingStored)
-				return zero, apierr.Internal.Msg(scaffoldErr.Error())
-			}
-
-			if !pendingStored && !postRegisterFailed {
-				emitCityCreateSucceeded(sm.resolver, reqID, result, dir)
-			}
-			return asyncAcceptedResponse{RequestID: reqID, EventCursor: eventCursor}, nil
+			return sm.scaffoldCityOnce(ctx, input.Body)
 		})
 	if err != nil {
 		return nil, err
@@ -458,6 +384,91 @@ func (sm *SupervisorMux) humaHandleCityCreate(ctx context.Context, input *Superv
 	}
 	out.Body = accepted
 	return out, nil
+}
+
+// scaffoldCityOnce performs the one-shot city scaffold+register work behind
+// POST /v0/city and returns the accepted {request_id, event_cursor} body. It is
+// the operation wrapped by the supervisor idempotency cache in
+// humaHandleCityCreate: on the first request for a given Idempotency-Key it
+// resolves the target directory, scaffolds and registers the city, and stores
+// the request_id correlation for the reconciler. On a replay the cache
+// short-circuits before this runs, so it never executes twice for the same key.
+func (sm *SupervisorMux) scaffoldCityOnce(ctx context.Context, body cityCreateRequest) (asyncAcceptedResponse, error) {
+	var zero asyncAcceptedResponse
+	dir := body.Dir
+	if !filepath.IsAbs(dir) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return zero, apierr.Internal.Msg(fmt.Sprintf("internal: resolving home dir: %v", err))
+		}
+		dir = filepath.Join(home, dir)
+	}
+
+	// Cheap pre-check that does not require a city initializer: if the
+	// target directory already looks like an initialized city on disk,
+	// return 409 before we try to scaffold. Keeps the API well-behaved
+	// in test configurations that build a SupervisorMux without an
+	// initializer.
+	if cityDirAlreadyInitialized(dir) {
+		return zero, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
+	}
+
+	if sm.initializer == nil {
+		return zero, apierr.NotImplemented.Msg("city creation is not available in this supervisor (no initializer wired)")
+	}
+
+	reqID, err := newRequestID()
+	if err != nil {
+		return zero, apierr.Internal.Msg(fmt.Sprintf("generating request ID: %v", err))
+	}
+	eventCursor, cursorErr := sm.currentSupervisorEventCursor()
+	if cursorErr != nil {
+		return zero, apierr.Internal.Msg(cursorErr.Error())
+	}
+	pendingStored := false
+	if store, ok := sm.resolver.(PendingRequestStore); ok {
+		if err := store.StorePendingRequestID(dir, reqID); err != nil {
+			if errors.Is(err, ErrPendingRequestExists) {
+				return zero, apierr.OperationInProgress.Msg("conflict: city initialization already in progress at " + dir)
+			}
+			return zero, apierr.Internal.Msg(fmt.Sprintf("storing pending request ID: %v", err))
+		}
+		pendingStored = true
+	}
+
+	result, scaffoldErr := sm.initializer.Scaffold(ctx, cityinit.InitRequest{
+		Dir:                   dir,
+		Provider:              body.Provider,
+		StartCommand:          body.StartCommand,
+		BootstrapProfile:      body.BootstrapProfile,
+		SkipProviderReadiness: true,
+	})
+	postRegisterFailed := false
+	switch {
+	case errors.Is(scaffoldErr, cityinit.ErrAlreadyInitialized):
+		sm.clearPendingCityRequestID(dir, pendingStored)
+		return zero, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
+	case errors.Is(scaffoldErr, cityinit.ErrInvalidDirectory),
+		errors.Is(scaffoldErr, cityinit.ErrInvalidProvider),
+		errors.Is(scaffoldErr, cityinit.ErrInvalidBootstrapProfile):
+		sm.clearPendingCityRequestID(dir, pendingStored)
+		return zero, apierr.ValidationFailed.Msg(scaffoldErr.Error())
+	case errors.Is(scaffoldErr, cityinit.ErrPostRegisterFailure):
+		failureReqID := reqID
+		if consumedReqID, ok := sm.consumePendingCityRequestID(dir, pendingStored); ok {
+			failureReqID = consumedReqID
+		}
+		emitCityCreateFailed(sm.resolver, failureReqID, result, dir, "city_init_failed", scaffoldErr)
+		postRegisterFailed = true
+	case scaffoldErr != nil:
+		sm.clearPendingCityRequestID(dir, pendingStored)
+		return zero, apierr.Internal.Msg(scaffoldErr.Error())
+	}
+
+	if !pendingStored && !postRegisterFailed {
+		emitCityCreateSucceeded(sm.resolver, reqID, result, dir)
+	}
+	return asyncAcceptedResponse{RequestID: reqID, EventCursor: eventCursor}, nil
 }
 
 func (sm *SupervisorMux) clearPendingCityRequestID(cityPath string, stored bool) {

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -97,7 +97,8 @@ type asyncAcceptedResponse struct {
 
 // SupervisorCityCreateInput is the input for POST /v0/city.
 type SupervisorCityCreateInput struct {
-	Body cityCreateRequest
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           cityCreateRequest
 }
 
 // SupervisorCityCreateOutput is the response for POST /v0/city.
@@ -213,6 +214,12 @@ func (sm *SupervisorMux) registerSupervisorRoutes() {
 	// completion is signaled via request.result.city.create or request.failed.
 	huma.Post(sm.humaAPI, "/v0/city", sm.humaHandleCityCreate, addMutationCSRFParam, func(op *huma.Operation) {
 		op.DefaultStatus = http.StatusAccepted
+		// Enumerating any error drops Huma's catch-all `default` response, so
+		// list every status this op actually emits: 401/403 from the
+		// write-auth/CSRF middleware, 409 (already initialized / init in
+		// progress / idempotency-in-flight), 501 when the supervisor has no
+		// initializer (the controller-embedded mux). Huma auto-adds 422/500.
+		op.Errors = append(op.Errors, http.StatusUnauthorized, http.StatusForbidden, http.StatusConflict, http.StatusNotImplemented)
 	})
 	// Async unregister: returns 202 after the registry entry is removed
 	// and the supervisor is signaled. request.result.city.unregister or
@@ -358,84 +365,98 @@ func (sm *SupervisorMux) humaHandleProviderReadiness(ctx context.Context, input 
 // started the city runtime. See engdocs/architecture/api-control-plane.md
 // §1-§2 on the object model + typed events; §4 on the event registry.
 func (sm *SupervisorMux) humaHandleCityCreate(ctx context.Context, input *SupervisorCityCreateInput) (*SupervisorCityCreateOutput, error) {
-	dir := input.Body.Dir
-	if !filepath.IsAbs(dir) {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, apierr.Internal.Msg(fmt.Sprintf("internal: resolving home dir: %v", err))
-		}
-		dir = filepath.Join(home, dir)
-	}
-
-	// Cheap pre-check that does not require a city initializer: if the
-	// target directory already looks like an initialized city on disk,
-	// return 409 before we try to scaffold. Keeps the API well-behaved
-	// in test configurations that build a SupervisorMux without an
-	// initializer.
-	if cityDirAlreadyInitialized(dir) {
-		return nil, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
-	}
-
-	if sm.initializer == nil {
-		return nil, apierr.NotImplemented.Msg("city creation is not available in this supervisor (no initializer wired)")
-	}
-
-	reqID, err := newRequestID()
-	if err != nil {
-		return nil, apierr.Internal.Msg(fmt.Sprintf("generating request ID: %v", err))
-	}
-	eventCursor, cursorErr := sm.currentSupervisorEventCursor()
-	if cursorErr != nil {
-		return nil, apierr.Internal.Msg(cursorErr.Error())
-	}
-	pendingStored := false
-	if store, ok := sm.resolver.(PendingRequestStore); ok {
-		if err := store.StorePendingRequestID(dir, reqID); err != nil {
-			if errors.Is(err, ErrPendingRequestExists) {
-				return nil, apierr.OperationInProgress.Msg("conflict: city initialization already in progress at " + dir)
+	// Idempotency: scaffold at most once per Idempotency-Key (supervisor-scope
+	// cache — there is no per-city Server yet for a city being created). The
+	// cached value is the full accepted body, so a replay returns the ORIGINAL
+	// request_id (the client's correlation handle on /v0/events/stream) and
+	// the original pre-create event cursor — recomputing either on replay
+	// would break result-event correlation.
+	accepted, err := withIdempotency(sm.idem, "/v0/city", input.IdempotencyKey, input.Body,
+		func() (asyncAcceptedResponse, error) {
+			var zero asyncAcceptedResponse
+			dir := input.Body.Dir
+			if !filepath.IsAbs(dir) {
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return zero, apierr.Internal.Msg(fmt.Sprintf("internal: resolving home dir: %v", err))
+				}
+				dir = filepath.Join(home, dir)
 			}
-			return nil, apierr.Internal.Msg(fmt.Sprintf("storing pending request ID: %v", err))
-		}
-		pendingStored = true
-	}
 
-	result, scaffoldErr := sm.initializer.Scaffold(ctx, cityinit.InitRequest{
-		Dir:                   dir,
-		Provider:              input.Body.Provider,
-		StartCommand:          input.Body.StartCommand,
-		BootstrapProfile:      input.Body.BootstrapProfile,
-		SkipProviderReadiness: true,
-	})
-	postRegisterFailed := false
-	switch {
-	case errors.Is(scaffoldErr, cityinit.ErrAlreadyInitialized):
-		sm.clearPendingCityRequestID(dir, pendingStored)
-		return nil, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
-	case errors.Is(scaffoldErr, cityinit.ErrInvalidDirectory),
-		errors.Is(scaffoldErr, cityinit.ErrInvalidProvider),
-		errors.Is(scaffoldErr, cityinit.ErrInvalidBootstrapProfile):
-		sm.clearPendingCityRequestID(dir, pendingStored)
-		return nil, apierr.ValidationFailed.Msg(scaffoldErr.Error())
-	case errors.Is(scaffoldErr, cityinit.ErrPostRegisterFailure):
-		failureReqID := reqID
-		if consumedReqID, ok := sm.consumePendingCityRequestID(dir, pendingStored); ok {
-			failureReqID = consumedReqID
-		}
-		emitCityCreateFailed(sm.resolver, failureReqID, result, dir, "city_init_failed", scaffoldErr)
-		postRegisterFailed = true
-	case scaffoldErr != nil:
-		sm.clearPendingCityRequestID(dir, pendingStored)
-		return nil, apierr.Internal.Msg(scaffoldErr.Error())
-	}
+			// Cheap pre-check that does not require a city initializer: if the
+			// target directory already looks like an initialized city on disk,
+			// return 409 before we try to scaffold. Keeps the API well-behaved
+			// in test configurations that build a SupervisorMux without an
+			// initializer.
+			if cityDirAlreadyInitialized(dir) {
+				return zero, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
+			}
 
-	if !pendingStored && !postRegisterFailed {
-		emitCityCreateSucceeded(sm.resolver, reqID, result, dir)
+			if sm.initializer == nil {
+				return zero, apierr.NotImplemented.Msg("city creation is not available in this supervisor (no initializer wired)")
+			}
+
+			reqID, err := newRequestID()
+			if err != nil {
+				return zero, apierr.Internal.Msg(fmt.Sprintf("generating request ID: %v", err))
+			}
+			eventCursor, cursorErr := sm.currentSupervisorEventCursor()
+			if cursorErr != nil {
+				return zero, apierr.Internal.Msg(cursorErr.Error())
+			}
+			pendingStored := false
+			if store, ok := sm.resolver.(PendingRequestStore); ok {
+				if err := store.StorePendingRequestID(dir, reqID); err != nil {
+					if errors.Is(err, ErrPendingRequestExists) {
+						return zero, apierr.OperationInProgress.Msg("conflict: city initialization already in progress at " + dir)
+					}
+					return zero, apierr.Internal.Msg(fmt.Sprintf("storing pending request ID: %v", err))
+				}
+				pendingStored = true
+			}
+
+			result, scaffoldErr := sm.initializer.Scaffold(ctx, cityinit.InitRequest{
+				Dir:                   dir,
+				Provider:              input.Body.Provider,
+				StartCommand:          input.Body.StartCommand,
+				BootstrapProfile:      input.Body.BootstrapProfile,
+				SkipProviderReadiness: true,
+			})
+			postRegisterFailed := false
+			switch {
+			case errors.Is(scaffoldErr, cityinit.ErrAlreadyInitialized):
+				sm.clearPendingCityRequestID(dir, pendingStored)
+				return zero, apierr.ConflictWrongState.Msg("conflict: city already initialized at " + dir)
+			case errors.Is(scaffoldErr, cityinit.ErrInvalidDirectory),
+				errors.Is(scaffoldErr, cityinit.ErrInvalidProvider),
+				errors.Is(scaffoldErr, cityinit.ErrInvalidBootstrapProfile):
+				sm.clearPendingCityRequestID(dir, pendingStored)
+				return zero, apierr.ValidationFailed.Msg(scaffoldErr.Error())
+			case errors.Is(scaffoldErr, cityinit.ErrPostRegisterFailure):
+				failureReqID := reqID
+				if consumedReqID, ok := sm.consumePendingCityRequestID(dir, pendingStored); ok {
+					failureReqID = consumedReqID
+				}
+				emitCityCreateFailed(sm.resolver, failureReqID, result, dir, "city_init_failed", scaffoldErr)
+				postRegisterFailed = true
+			case scaffoldErr != nil:
+				sm.clearPendingCityRequestID(dir, pendingStored)
+				return zero, apierr.Internal.Msg(scaffoldErr.Error())
+			}
+
+			if !pendingStored && !postRegisterFailed {
+				emitCityCreateSucceeded(sm.resolver, reqID, result, dir)
+			}
+			return asyncAcceptedResponse{RequestID: reqID, EventCursor: eventCursor}, nil
+		})
+	if err != nil {
+		return nil, err
 	}
 
 	out := &SupervisorCityCreateOutput{
 		Status: http.StatusAccepted,
 	}
-	out.Body = asyncAcceptedResponse{RequestID: reqID, EventCursor: eventCursor}
+	out.Body = accepted
 	return out, nil
 }
 

--- a/internal/api/huma_types_events.go
+++ b/internal/api/huma_types_events.go
@@ -32,7 +32,8 @@ type EventEmitRequest struct {
 // EventEmitInput is the Huma input for POST /v0/city/{cityName}/events.
 type EventEmitInput struct {
 	CityScope
-	Body EventEmitRequest
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           EventEmitRequest
 }
 
 // EventEmitOutput is the response body for POST /v0/events.

--- a/internal/api/huma_types_extmsg.go
+++ b/internal/api/huma_types_extmsg.go
@@ -188,7 +188,8 @@ type ExtMsgAdapterListInput struct {
 // ExtMsgAdapterRegisterInput is the Huma input for POST /v0/city/{cityName}/extmsg/adapters.
 type ExtMsgAdapterRegisterInput struct {
 	CityScope
-	Body struct {
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           struct {
 		Provider     string                     `json:"provider" minLength:"1" doc:"Provider name."`
 		AccountID    string                     `json:"account_id" minLength:"1" doc:"Account ID."`
 		Name         string                     `json:"name,omitempty" doc:"Adapter display name."`

--- a/internal/api/huma_types_mail.go
+++ b/internal/api/huma_types_mail.go
@@ -89,9 +89,10 @@ type MailArchiveInput struct {
 // MailReplyInput is the Huma input for POST /v0/city/{cityName}/mail/{id}/reply.
 type MailReplyInput struct {
 	CityScope
-	ID   string `path:"id" doc:"Message ID."`
-	Rig  string `query:"rig" required:"false" doc:"Rig hint."`
-	Body struct {
+	ID             string `path:"id" doc:"Message ID."`
+	Rig            string `query:"rig" required:"false" doc:"Rig hint."`
+	IdempotencyKey string `header:"Idempotency-Key" required:"false" doc:"Idempotency key for safe retries."`
+	Body           struct {
 		From    string `json:"from,omitempty" doc:"Sender name."`
 		Subject string `json:"subject,omitempty" doc:"Reply subject."`
 		Body    string `json:"body,omitempty" doc:"Reply body."`

--- a/internal/api/idempotency_endpoints_test.go
+++ b/internal/api/idempotency_endpoints_test.go
@@ -1,15 +1,21 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/cityinit"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/importsvc"
+	"github.com/gastownhall/gascity/internal/mail"
 )
 
 // These tests pin the Idempotency-Key wire contract on the S2 create
@@ -164,6 +170,197 @@ func TestConvoyCreateIdempotentReplay(t *testing.T) {
 	}
 	if len(convoys) != 1 {
 		t.Fatalf("store holds %d convoy beads, want 1 (replay re-ran create)", len(convoys))
+	}
+}
+
+func TestMailReplyIdempotentReplay(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+	msg, _ := mp.Send("mayor", "worker", "Initial", "content")
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"worker","subject":"Re: Initial","body":"Done!"}`
+	first := postIdempotent(t, h, cityURL(state, "/mail/")+msg.ID+"/reply", "mail-reply-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first reply: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+
+	replay := postIdempotent(t, h, cityURL(state, "/mail/")+msg.ID+"/reply", "mail-reply-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201; body = %s", replay.Code, replay.Body.String())
+	}
+	// A re-run would mint a NEW message ID; the replay must return the first one.
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want %s", replay.Body.String(), first.Body.String())
+	}
+	// The MailReplied event must have fired exactly once.
+	ep := state.eventProv.(*events.Fake)
+	evts, err := ep.List(events.Filter{Type: events.MailReplied})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("MailReplied fired %d times, want 1 (replay re-ran the reply)", len(evts))
+	}
+}
+
+func TestMailReplySameKeyDifferentMessagesIndependent(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+	m1, _ := mp.Send("mayor", "worker", "One", "first")
+	m2, _ := mp.Send("mayor", "worker", "Two", "second")
+	h := newTestCityHandler(t, state)
+
+	// Same key + same body against two DIFFERENT messages must be two
+	// independent creates — the message ID participates in the cache scope.
+	// A regression to a constant cache path would replay m1's reply for m2.
+	body := `{"from":"worker","subject":"Re","body":"ack"}`
+	first := postIdempotent(t, h, cityURL(state, "/mail/")+m1.ID+"/reply", "mail-reply-x", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("reply to m1: status = %d; body = %s", first.Code, first.Body.String())
+	}
+	second := postIdempotent(t, h, cityURL(state, "/mail/")+m2.ID+"/reply", "mail-reply-x", body)
+	if second.Code != http.StatusCreated {
+		t.Fatalf("reply to m2: status = %d; body = %s", second.Code, second.Body.String())
+	}
+	var r1, r2 mail.Message
+	json.NewDecoder(first.Body).Decode(&r1)  //nolint:errcheck
+	json.NewDecoder(second.Body).Decode(&r2) //nolint:errcheck
+	if r1.ID == r2.ID {
+		t.Fatalf("reply to m2 replayed m1's reply (%s) — the message ID must participate in the cache scope", r1.ID)
+	}
+}
+
+func TestMailReplyReplayAfterOriginalDeleted(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+	msg, _ := mp.Send("mayor", "worker", "Initial", "content")
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"worker","subject":"Re: Initial","body":"Done!"}`
+	first := postIdempotent(t, h, cityURL(state, "/mail/")+msg.ID+"/reply", "mail-reply-del", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first reply: status = %d; body = %s", first.Code, first.Body.String())
+	}
+
+	// Delete the original message. The replay must still return the cached
+	// reply — the provider lookup lives inside the (skipped) closure, so the
+	// vanished original cannot turn a legitimate replay into a 404.
+	if err := mp.Delete(msg.ID); err != nil {
+		t.Fatalf("delete original: %v", err)
+	}
+	replay := postIdempotent(t, h, cityURL(state, "/mail/")+msg.ID+"/reply", "mail-reply-del", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay after delete: status = %d, want 201 (404 means the lookup ran outside the closure); body = %s", replay.Code, replay.Body.String())
+	}
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want %s", replay.Body.String(), first.Body.String())
+	}
+}
+
+func TestEventEmitIdempotentReplay(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	body := `{"type":"deploy.completed","actor":"ci","subject":"myapp","message":"v2.3.1"}`
+	first := postIdempotent(t, h, cityURL(state, "/events"), "emit-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first emit: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+
+	replay := postIdempotent(t, h, cityURL(state, "/events"), "emit-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201; body = %s", replay.Code, replay.Body.String())
+	}
+	// The event must have been appended exactly once.
+	ep := state.eventProv.(*events.Fake)
+	evts, err := ep.List(events.Filter{Type: "deploy.completed"})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("event appended %d times, want 1 (replay re-ran the emit)", len(evts))
+	}
+}
+
+func TestExtMsgAdapterRegisterIdempotentReplay(t *testing.T) {
+	state := newFakeState(t)
+	state.adapterReg = extmsg.NewAdapterRegistry()
+	h := newTestCityHandler(t, state)
+
+	body := `{"provider":"slack","account_id":"T123","callback_url":"http://127.0.0.1:9/cb"}`
+	first := postIdempotent(t, h, cityURL(state, "/extmsg/adapters"), "adapter-reg-1", body)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first register: status = %d, want 201; body = %s", first.Code, first.Body.String())
+	}
+
+	replay := postIdempotent(t, h, cityURL(state, "/extmsg/adapters"), "adapter-reg-1", body)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("replay: status = %d, want 201; body = %s", replay.Code, replay.Body.String())
+	}
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want %s", replay.Body.String(), first.Body.String())
+	}
+	// The ExtMsgAdapterAdded event must have fired exactly once.
+	ep := state.eventProv.(*events.Fake)
+	evts, err := ep.List(events.Filter{Type: events.ExtMsgAdapterAdded})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("ExtMsgAdapterAdded fired %d times, want 1 (replay re-ran the register)", len(evts))
+	}
+}
+
+// countingInitializer wraps fakeInitializer to count Scaffold invocations for
+// the supervisor city-create replay test.
+type countingInitializer struct {
+	*fakeInitializer
+	scaffoldCalls int
+}
+
+func (c *countingInitializer) Scaffold(ctx context.Context, req cityinit.InitRequest) (*cityinit.InitResult, error) {
+	c.scaffoldCalls++
+	return c.fakeInitializer.Scaffold(ctx, req)
+}
+
+func TestSupervisorCityCreateIdempotentReplay(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GC_HOME", filepath.Join(home, ".gc"))
+	cityPath := filepath.Join(home, "mc-city")
+	init := &countingInitializer{fakeInitializer: &fakeInitializer{
+		scaffoldResult: &cityinit.InitResult{CityName: "mc-city", CityPath: cityPath, ProviderUsed: "codex"},
+	}}
+	sm := newTestSupervisorMuxWithInitializer(t, init)
+
+	body := `{"dir":"mc-city","provider":"codex"}`
+	post := func(key string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v0/city", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GC-Request", "test")
+		req.Header.Set("Idempotency-Key", key)
+		rec := httptest.NewRecorder()
+		sm.ServeHTTP(rec, req)
+		return rec
+	}
+
+	first := post("city-create-1")
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first create: status = %d, want 202; body = %s", first.Code, first.Body.String())
+	}
+
+	// A re-run would either 409 on the still-pending request ID or mint a new
+	// request_id; the replay must return the ORIGINAL request_id + cursor.
+	replay := post("city-create-1")
+	if replay.Code != http.StatusAccepted {
+		t.Fatalf("replay: status = %d, want 202 (409 means the create re-ran); body = %s", replay.Code, replay.Body.String())
+	}
+	if replay.Body.String() != first.Body.String() {
+		t.Fatalf("replay body = %s, want the first-response body %s (original request_id)", replay.Body.String(), first.Body.String())
+	}
+	if init.scaffoldCalls != 1 {
+		t.Fatalf("Scaffold ran %d times, want 1 (replay re-ran the create)", init.scaffoldCalls)
 	}
 }
 

--- a/internal/api/idempotency_guard_test.go
+++ b/internal/api/idempotency_guard_test.go
@@ -14,13 +14,17 @@ import (
 // Idempotency-Key header. This set grows as each wiring slice (audit P0 #4)
 // lands; a regression that drops the header fails TestCreateEndpointsAreTriagedForIdempotency.
 var requireIdempotency = map[string]bool{
-	"create-bead":     true,
-	"send-mail":       true,
-	"create-agent":    true,
-	"create-provider": true,
-	"create-rig":      true,
-	"create-convoy":   true,
-	"add-pack":        true,
+	"create-bead":             true,
+	"send-mail":               true,
+	"create-agent":            true,
+	"create-provider":         true,
+	"create-rig":              true,
+	"create-convoy":           true,
+	"add-pack":                true,
+	"reply-mail":              true,
+	"register-extmsg-adapter": true,
+	"emit-event":              true,
+	"post-v0-city":            true,
 }
 
 // pendingIdempotency lists known create operations that are deliberately NOT
@@ -28,15 +32,10 @@ var requireIdempotency = map[string]bool{
 // TODO list, not an exemption: when a slice wires one of these, MOVE it to
 // requireIdempotency — the test enforces the move so the lists stay honest.
 var pendingIdempotency = map[string]bool{
-	"reply-mail":              true, // 201; mints a message (S3)
-	"register-extmsg-adapter": true, // 201 (S3)
-	"emit-event":              true, // 201; append-only, retry double-emits (S3)
-	"ensure-extmsg-group":     true, // 201; identity-idempotent already — moves to exempt in S3
-	"post-v0-city":            true, // 202; supervisor city create (S3)
-	"create-session":          true, // 202; raw+Huma split, deferred (S4)
-	"send-session-message":    true, // 202; deferred (S4)
-	"respond-session":         true, // 202; deferred (S4)
-	"submit-session":          true, // 202; deferred (S4)
+	"create-session":       true, // 202; raw+Huma split, deferred (S4)
+	"send-session-message": true, // 202; deferred (S4)
+	"respond-session":      true, // 202; deferred (S4)
+	"submit-session":       true, // 202; deferred (S4)
 }
 
 // exemptFromIdempotency lists POST operations that are NOT resource creates and
@@ -47,6 +46,13 @@ var pendingIdempotency = map[string]bool{
 // be classified, so a new create at ANY status (201, 202, …) that is neither
 // wired nor triaged fails the test.
 var exemptFromIdempotency = map[string]bool{
+	// ensure-extmsg-group is identity-idempotent by design: the ensure
+	// semantics (same group in → same group out) make a retry safe without a
+	// key, so wiring one would be dead weight (owner decision, 2026-07-11).
+	// Accepted trade-off: the ExtMsgGroupCreated event fires on every ensure,
+	// so a retry can double-emit it — tolerable for an ensure endpoint; move
+	// this opid to requireIdempotency if that ever matters.
+	"ensure-extmsg-group":                                      true,
 	"post-v0-city-by-city-name-agent-by-base-by-action":        true,
 	"post-v0-city-by-city-name-agent-by-dir-by-base-by-action": true,
 	"post-v0-city-by-city-name-bead-by-id-assign":              true,

--- a/internal/api/idempotency_helper.go
+++ b/internal/api/idempotency_helper.go
@@ -7,15 +7,16 @@ import "github.com/gastownhall/gascity/internal/api/apierr"
 //
 // The scoped key is "POST:<path>:<key>" — namespaced by path so the same
 // Idempotency-Key value on two different endpoints within one city can't
-// collide. Every caller passes a static endpoint path (e.g. "/v0/agents"), so
-// this scoping is intra-city only; cross-city isolation does NOT come from the
-// key. It comes from each city owning a separate *Server, and therefore a
-// separate idem cache, built per city by getCityServer via New(state). A future
-// refactor that hoisted idem to a process-wide scope would silently reintroduce
-// cross-city key collisions despite this scoping. On a repeat with a completed
-// reservation it replays the cached typed body value; an in-flight repeat
-// returns apierr.IdempotencyInFlight (409); a same-key/different-body repeat
-// returns apierr.IdempotencyMismatch (422).
+// collide. Every city-scoped caller passes a static endpoint path (e.g.
+// "/v0/agents"), so this scoping is intra-city only; cross-city isolation does
+// NOT come from the key. It comes from each city owning a separate *Server,
+// and therefore a separate idem cache, built per city by getCityServer via
+// New(state). A future refactor that hoisted a per-city cache to a
+// process-wide scope would silently reintroduce cross-city key collisions
+// despite this scoping. On a repeat with a completed reservation it replays
+// the cached typed body value; an in-flight repeat returns
+// apierr.IdempotencyInFlight (409); a same-key/different-body repeat returns
+// apierr.IdempotencyMismatch (422).
 //
 // It ALWAYS releases the pending reservation when create() returns an error OR
 // panics (via defer), so no caller can leak a reservation — the defect the
@@ -26,7 +27,11 @@ import "github.com/gastownhall/gascity/internal/api/apierr"
 // return the domain body value to cache. Callers wrap that value in their
 // response envelope after withIdempotency returns, so envelope fields derived
 // from live state (e.g. the X-GC-Index event sequence) stay fresh on replay.
-func withIdempotency[T any](s *Server, path, key string, body any, create func() (T, error)) (T, error) {
+//
+// idem is the owning cache: per-city handlers pass s.idem (the per-city cache
+// described above); supervisor-scope handlers (POST /v0/city, where no per-city
+// Server exists yet) pass sm.idem, the SupervisorMux's own process-wide cache.
+func withIdempotency[T any](idem *idempotencyCache, path, key string, body any, create func() (T, error)) (T, error) {
 	var zero T
 	if key == "" {
 		return create()
@@ -34,7 +39,7 @@ func withIdempotency[T any](s *Server, path, key string, body any, create func()
 	scopedKey := "POST:" + path + ":" + key
 	bodyHash := hashBody(body)
 
-	existing, found := s.idem.reserve(scopedKey, bodyHash)
+	existing, found := idem.reserve(scopedKey, bodyHash)
 	if found {
 		if existing.bodyHash != bodyHash {
 			return zero, apierr.IdempotencyMismatch.Msg("idempotency_mismatch: Idempotency-Key reused with different request body")
@@ -57,7 +62,7 @@ func withIdempotency[T any](s *Server, path, key string, body any, create func()
 	settled := false
 	defer func() {
 		if !settled {
-			s.idem.unreserve(scopedKey)
+			idem.unreserve(scopedKey)
 		}
 	}()
 
@@ -66,6 +71,6 @@ func withIdempotency[T any](s *Server, path, key string, body any, create func()
 		return zero, err
 	}
 	settled = true
-	s.idem.storeResponse(scopedKey, bodyHash, v)
+	idem.storeResponse(scopedKey, bodyHash, v)
 	return v, nil
 }

--- a/internal/api/idempotency_helper_test.go
+++ b/internal/api/idempotency_helper_test.go
@@ -22,7 +22,7 @@ type idemVal struct {
 func TestWithIdempotency_FirstCallRunsCreate(t *testing.T) {
 	s := newIdemTestServer()
 	calls := 0
-	got, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "1"},
+	got, err := withIdempotency(s.idem, "/v0/things", "key-1", map[string]string{"a": "1"},
 		func() (idemVal, error) {
 			calls++
 			return idemVal{ID: "t1", Body: "1"}, nil
@@ -46,12 +46,12 @@ func TestWithIdempotency_ReplayReturnsCachedWithoutRerunning(t *testing.T) {
 		calls++
 		return idemVal{ID: "t1", Body: "first"}, nil
 	}
-	if _, err := withIdempotency(s, "/v0/things", "key-1", body, create); err != nil {
+	if _, err := withIdempotency(s.idem, "/v0/things", "key-1", body, create); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
 	// Second call: same key + same body. create must NOT run again; the cached
 	// value (not a fresh "second" run) must come back.
-	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+	got, err := withIdempotency(s.idem, "/v0/things", "key-1", body,
 		func() (idemVal, error) {
 			calls++
 			return idemVal{ID: "t2", Body: "second"}, nil
@@ -69,12 +69,12 @@ func TestWithIdempotency_ReplayReturnsCachedWithoutRerunning(t *testing.T) {
 
 func TestWithIdempotency_MismatchReturns422(t *testing.T) {
 	s := newIdemTestServer()
-	if _, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "1"},
+	if _, err := withIdempotency(s.idem, "/v0/things", "key-1", map[string]string{"a": "1"},
 		func() (idemVal, error) { return idemVal{ID: "t1"}, nil }); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
 	calls := 0
-	_, err := withIdempotency(s, "/v0/things", "key-1", map[string]string{"a": "DIFFERENT"},
+	_, err := withIdempotency(s.idem, "/v0/things", "key-1", map[string]string{"a": "DIFFERENT"},
 		func() (idemVal, error) { calls++; return idemVal{}, nil })
 	if calls != 0 {
 		t.Fatalf("create ran on a body mismatch (calls=%d); it must not", calls)
@@ -96,7 +96,7 @@ func TestWithIdempotency_InFlightReturns409(t *testing.T) {
 	s.idem.reserve(scoped, hashBody(body))
 
 	calls := 0
-	_, err := withIdempotency(s, "/v0/things", "key-1", body,
+	_, err := withIdempotency(s.idem, "/v0/things", "key-1", body,
 		func() (idemVal, error) { calls++; return idemVal{}, nil })
 	if calls != 0 {
 		t.Fatalf("create ran while another request was in-flight (calls=%d)", calls)
@@ -114,7 +114,7 @@ func TestWithIdempotency_ErrorReleasesReservation(t *testing.T) {
 	s := newIdemTestServer()
 	body := map[string]string{"a": "1"}
 	sentinel := errors.New("create boom")
-	_, err := withIdempotency(s, "/v0/things", "key-1", body,
+	_, err := withIdempotency(s.idem, "/v0/things", "key-1", body,
 		func() (idemVal, error) { return idemVal{}, sentinel })
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("error = %v, want the create error propagated verbatim", err)
@@ -122,7 +122,7 @@ func TestWithIdempotency_ErrorReleasesReservation(t *testing.T) {
 	// The reservation must be released: a retry with the same key succeeds and
 	// runs create again (no leaked 409).
 	calls := 0
-	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+	got, err := withIdempotency(s.idem, "/v0/things", "key-1", body,
 		func() (idemVal, error) { calls++; return idemVal{ID: "t1"}, nil })
 	if err != nil {
 		t.Fatalf("retry after failed create: %v (reservation leaked?)", err)
@@ -137,14 +137,14 @@ func TestWithIdempotency_PanicReleasesReservation(t *testing.T) {
 	body := map[string]string{"a": "1"}
 	func() {
 		defer func() { _ = recover() }()
-		_, _ = withIdempotency(s, "/v0/things", "key-1", body,
+		_, _ = withIdempotency(s.idem, "/v0/things", "key-1", body,
 			func() (idemVal, error) { panic("boom") })
 		t.Fatal("expected panic to propagate")
 	}()
 	// The reservation must be released even though create() panicked: a retry
 	// with the same key runs create again (no key wedged for the TTL).
 	calls := 0
-	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+	got, err := withIdempotency(s.idem, "/v0/things", "key-1", body,
 		func() (idemVal, error) { calls++; return idemVal{ID: "t1"}, nil })
 	if err != nil {
 		t.Fatalf("retry after panic: %v (reservation leaked on panic?)", err)
@@ -162,7 +162,7 @@ func TestWithIdempotency_WrongTypedEntryFallsThroughToCreate(t *testing.T) {
 	// through to create() rather than serve a wrong-typed/zero replay.
 	s.idem.storeResponse("POST:/v0/things:key-1", hashBody(body), "not-an-idemVal")
 	calls := 0
-	got, err := withIdempotency(s, "/v0/things", "key-1", body,
+	got, err := withIdempotency(s.idem, "/v0/things", "key-1", body,
 		func() (idemVal, error) { calls++; return idemVal{ID: "fresh"}, nil })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -176,10 +176,10 @@ func TestWithIdempotency_EmptyKeyPassthrough(t *testing.T) {
 	s := newIdemTestServer()
 	calls := 0
 	create := func() (idemVal, error) { calls++; return idemVal{ID: "t"}, nil }
-	if _, err := withIdempotency(s, "/v0/things", "", nil, create); err != nil {
+	if _, err := withIdempotency(s.idem, "/v0/things", "", nil, create); err != nil {
 		t.Fatalf("first: %v", err)
 	}
-	if _, err := withIdempotency(s, "/v0/things", "", nil, create); err != nil {
+	if _, err := withIdempotency(s.idem, "/v0/things", "", nil, create); err != nil {
 		t.Fatalf("second: %v", err)
 	}
 	if calls != 2 {
@@ -191,12 +191,12 @@ func TestWithIdempotency_DistinctKeysAndPathsIndependent(t *testing.T) {
 	s := newIdemTestServer()
 	body := map[string]string{"a": "1"}
 	mk := func() (idemVal, error) { return idemVal{ID: "x"}, nil }
-	if _, err := withIdempotency(s, "/v0/things", "key-1", body, mk); err != nil {
+	if _, err := withIdempotency(s.idem, "/v0/things", "key-1", body, mk); err != nil {
 		t.Fatalf("k1: %v", err)
 	}
 	// Same key, different path → must not collide (independent create).
 	calls := 0
-	if _, err := withIdempotency(s, "/v0/others", "key-1", body,
+	if _, err := withIdempotency(s.idem, "/v0/others", "key-1", body,
 		func() (idemVal, error) { calls++; return idemVal{ID: "y"}, nil }); err != nil {
 		t.Fatalf("other path: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestWithIdempotency_DistinctKeysAndPathsIndependent(t *testing.T) {
 	// pins that the KEY participates in the cache scope (dropping it from
 	// scopedKey would make key-2 replay key-1's response).
 	calls = 0
-	if _, err := withIdempotency(s, "/v0/things", "key-2", body,
+	if _, err := withIdempotency(s.idem, "/v0/things", "key-2", body,
 		func() (idemVal, error) { calls++; return idemVal{ID: "z"}, nil }); err != nil {
 		t.Fatalf("second key: %v", err)
 	}

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -18152,6 +18152,15 @@
               "minLength": 1,
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -18180,7 +18189,7 @@
               }
             }
           },
-          "default": {
+          "401": {
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -18188,7 +18197,82 @@
                 }
               }
             },
-            "description": "Error",
+            "description": "Unauthorized",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Forbidden",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Unprocessable Entity",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Internal Server Error",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "501": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Not Implemented",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -24299,6 +24383,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -24366,6 +24459,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -24981,6 +25089,15 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -25048,6 +25165,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
@@ -29855,6 +29987,15 @@
               "description": "Rig hint.",
               "type": "string"
             }
+          },
+          {
+            "description": "Idempotency key for safe retries.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "schema": {
+              "description": "Idempotency key for safe retries.",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -29937,6 +30078,21 @@
               }
             },
             "description": "Not Found",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Conflict",
             "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"

--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -134,6 +134,11 @@ type SupervisorMux struct {
 	// the State pointer changes (city restarted → new controllerState).
 	cacheMu sync.RWMutex
 	cache   map[string]cachedCityServer
+
+	// idem caches responses for Idempotency-Key replay on supervisor-scope
+	// create endpoints (POST /v0/city). Per-city creates use the per-city
+	// Server's own cache instead.
+	idem *idempotencyCache
 }
 
 // NewSupervisorMux creates a SupervisorMux that routes requests to cities
@@ -156,6 +161,7 @@ func NewSupervisorMux(resolver CityResolver, initializer cityInitializer, readOn
 		humaMux:     humaMux,
 		humaAPI:     newSupervisorHumaAPI(humaMux, readOnly),
 		cache:       make(map[string]cachedCityServer),
+		idem:        newIdempotencyCache(30 * time.Minute),
 	}
 	sm.registerSupervisorRoutes()
 	sm.registerCityRoutes()

--- a/internal/api/supervisor_city_routes.go
+++ b/internal/api/supervisor_city_routes.go
@@ -200,7 +200,8 @@ func (sm *SupervisorMux) registerCityRoutes() {
 		Path:          "/mail/{id}/reply",
 		Summary:       "Reply to a mail message",
 		DefaultStatus: http.StatusCreated,
-		Errors:        []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound},
+		// 409: a concurrent repeat of the same Idempotency-Key (idempotency-in-flight).
+		Errors: []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict},
 	}, (*Server).humaHandleMailReply)
 	cityDelete(sm, "/mail/{id}", (*Server).humaHandleMailDelete, errorStatuses(http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound))
 
@@ -230,7 +231,8 @@ func (sm *SupervisorMux) registerCityRoutes() {
 		Path:          "/events",
 		Summary:       "Emit an event",
 		DefaultStatus: http.StatusCreated,
-		Errors:        []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusServiceUnavailable},
+		// 409: a concurrent repeat of the same Idempotency-Key (idempotency-in-flight).
+		Errors: []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict, http.StatusServiceUnavailable},
 	}, (*Server).humaHandleEventEmit)
 	cityRegister(sm, huma.Operation{
 		OperationID: "rotate-events",
@@ -426,7 +428,8 @@ func (sm *SupervisorMux) registerCityRoutes() {
 		Path:          "/extmsg/adapters",
 		Summary:       "Register an external messaging adapter",
 		DefaultStatus: http.StatusCreated,
-		Errors:        []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusServiceUnavailable},
+		// 409: a concurrent repeat of the same Idempotency-Key (idempotency-in-flight).
+		Errors: []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict, http.StatusServiceUnavailable},
 	}, (*Server).humaHandleExtMsgAdapterRegister)
 	cityDelete(sm, "/extmsg/adapters", (*Server).humaHandleExtMsgAdapterUnregister, errorStatuses(http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusServiceUnavailable))
 }


### PR DESCRIPTION
## What

S3 of **audit P0 #4 — `Idempotency-Key` on mutating create endpoints**: wires the final
four creates (per the owner-signed triage) and generalizes the helper for
supervisor-scope use:

- `reply-mail` (POST /mail/{id}/reply)
- `emit-event` (POST /events) — owner decision: **wire** (append-only log, retry double-emits)
- `register-extmsg-adapter` (POST /extmsg/adapters)
- `post-v0-city` (POST /v0/city, supervisor scope, 202)
- `ensure-extmsg-group` → moved to the **exempt** list (owner decision: identity-idempotent
  by design; the accepted retry double-emit of `ExtMsgGroupCreated` is documented in the guard)

**Depends on #4150 (S2) → #4147 (S1).** Base=main; the diff auto-cleans as parents merge.
Left unlabeled until the parents merge. After this slice, only the deferred **S4 session
creates** remain in `pendingIdempotency`.

## Key changes

- **Helper generalized**: `withIdempotency`'s first parameter changes `*Server` →
  `*idempotencyCache`. POST /v0/city is supervisor-scope — no per-city `Server` exists for
  a city being created — so `SupervisorMux` now owns its own cache; the seven prior call
  sites pass `s.idem` (mechanical).
- **reply-mail** caches the `mail.Message` with the message ID folded into the cache scope
  — **PathEscaped**, so a `%2F`-crafted ID cannot forge the `/reply:` boundary and alias
  another (id, key) pair (found by the red-team, pinned by
  `TestMailReplySameKeyDifferentMessagesIndependent`). The provider lookup moves inside
  the closure so a replay still succeeds after the original message is deleted
  (`TestMailReplyReplayAfterOriginalDeleted`).
- **emit-event** caches the status constant — the value is suppressing the duplicate
  append (and the double-count in projections like the Runs view built over events.jsonl).
- **register-extmsg-adapter** caches the resolved adapter name; `Register` is an upsert,
  so the win is suppressing the duplicate `ExtMsgAdapterAdded` event.
- **post-v0-city** caches the full accepted body so a replay returns the **original
  `request_id`** (the correlation handle on /v0/events/stream) and the original pre-create
  event cursor — recomputing either would break result-event correlation. The three 409
  guards (already-initialized, init-in-progress, idempotency-in-flight) coexist.

## Contract

- 4 ops gain the optional `Idempotency-Key` header + declare 409.
- **POST /v0/city error set completed**: it previously had no enumerated errors (Huma
  catch-all `default`); enumerating any error drops that default, so it now declares
  everything it actually emits — 401/403 (write-auth/CSRF middleware), 409, 501 (the
  controller-embedded supervisor runs with a nil initializer). Without this, generated
  clients would type those reachable statuses out-of-contract (red-team finding).
- Spec ×2 + `.txt` + Go client + dashboard TS client regenerated and committed.

## Tests / gates

- 4 new replay tests (incl. a `countingInitializer` proving Scaffold runs once and the
  replay returns the original request_id) + the 2 red-team-driven mail-reply tests.
- `gofmt`/`go vet` clean; full `internal/api` suite green; `TestOpenAPISpecInSync`,
  `TestGeneratedClientInSync`, `make dashboard-check` pass.
- Red-teamed pre-commit (5 lenses + adversarial verification, 13 agents; **all 8 findings
  upheld and fixed or documented** — the PathEscape fold, both mail-reply tests, the
  /v0/city error-set completion, and the honest exemption rationale all came out of it).

## Follow-ups

S4 (deferred, needs its own slice): the session creates (`create-session`,
`send-session-message`, `respond-session`, `submit-session`) — the legacy raw
`POST /v0/sessions` path has its own idempotency while the city-scoped Huma handlers have
none; unifying them is a larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
