### PR TITLE
fix(beads): retry sqlite busy/locked errors in the bd write classifier

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -271,6 +271,12 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 	if cfg == nil || runner == nil {
 		return nil
 	}
+	if stderr == nil {
+		// Callers that don't care about diagnostics pass nil; the error
+		// branches below must degrade to skipping the agent, not panic
+		// inside fmt.Fprintf.
+		stderr = io.Discard
+	}
 	// Collect the per-agent probe work first so the bd subprocess
 	// calls can run concurrently. Each work_query shells out to `bd`,
 	// which serializes on the shared dolt sql-server, so a sequential

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1015,6 +1015,44 @@ func TestComputeWorkSet_SkipsAgentsOnSuspendedRig(t *testing.T) {
 	}
 }
 
+// TestComputeWorkSet_NilStderrToleratesProbeEnvError pins the boundary
+// guard: computeWorkSet accepts a nil stderr (reconciler tests and
+// fire-and-forget callers pass nil), so the probe-env error branch must
+// degrade to skipping the agent instead of panicking on
+// fmt.Fprintf(nil, ...). The fixture reproduces a real failure mode:
+// a city scope that resolves to an authoritative postgres backend with
+// no resolvable password makes controllerQueryRuntimeEnv return an error.
+func TestComputeWorkSet_NilStderrToleratesProbeEnvError(t *testing.T) {
+	clearAmbientPostgresEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+
+	cityPath := t.TempDir()
+	writePGScopeFixture(t, cityPath, "")
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: city
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Agents: []config.Agent{{Name: "agent"}}}
+
+	// Prove the fixture still errors — otherwise this test silently stops
+	// exercising the guarded branch.
+	if _, err := controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[0]); err == nil {
+		t.Fatal("fixture did not produce a probe-env error; the guarded branch is no longer reachable from this test")
+	}
+
+	runner := func(_, _ string, _ map[string]string) (string, error) {
+		return `[{"id":"BL-1"}]`, nil
+	}
+
+	work := computeWorkSet(cfg, runner, "test-city", cityPath, nil, nil, nil)
+	if len(work) != 0 {
+		t.Errorf("work = %v, want empty when the probe env cannot be built", work)
+	}
+}
+
 // TestComputeWorkSet_SkipsAllWhenCitySuspended verifies that no agent is
 // probed when the whole city is suspended — suspension inherits downward.
 func TestComputeWorkSet_SkipsAllWhenCitySuspended(t *testing.T) {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -746,7 +746,7 @@ func TestComputeWorkSet_RunsWorkQuery(t *testing.T) {
 		return "", nil // empty = no work for idle's custom query
 	}
 
-	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, nil)
+	work := computeWorkSet(cfg, runner, "test-city", t.TempDir(), nil, nil, nil)
 	if !work["worker"] {
 		t.Error("expected worker to have work")
 	}
@@ -902,7 +902,7 @@ func TestComputeWorkSet_NilRunner(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{{Name: "worker"}},
 	}
-	work := computeWorkSet(cfg, nil, "test-city", "/tmp", nil, nil, nil)
+	work := computeWorkSet(cfg, nil, "test-city", t.TempDir(), nil, nil, nil)
 	if work != nil {
 		t.Errorf("expected nil, got %v", work)
 	}
@@ -917,7 +917,7 @@ func TestComputeWorkSet_CommandError(t *testing.T) {
 		return "", fmt.Errorf("connection refused")
 	}
 
-	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, nil)
+	work := computeWorkSet(cfg, runner, "test-city", t.TempDir(), nil, nil, nil)
 	if work["worker"] {
 		t.Error("command error should not produce work")
 	}
@@ -932,7 +932,7 @@ func TestComputeWorkSet_IgnoresNoReadyMessage(t *testing.T) {
 		return "✨ No ready work found (all issues have blocking dependencies)\n", nil
 	}
 
-	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, nil)
+	work := computeWorkSet(cfg, runner, "test-city", t.TempDir(), nil, nil, nil)
 	if work["worker"] {
 		t.Error("no-ready message should not produce work")
 	}
@@ -958,7 +958,7 @@ func TestComputeWorkSet_SkipsSuspendedAgent(t *testing.T) {
 		return `[{"id":"BL-1"}]`, nil
 	}
 
-	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, nil)
+	work := computeWorkSet(cfg, runner, "test-city", t.TempDir(), nil, nil, nil)
 	if !work["live"] {
 		t.Error("expected live agent to be probed")
 	}
@@ -999,7 +999,7 @@ func TestComputeWorkSet_SkipsAgentsOnSuspendedRig(t *testing.T) {
 		return `[{"id":"BL-1"}]`, nil
 	}
 
-	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, nil)
+	work := computeWorkSet(cfg, runner, "test-city", t.TempDir(), nil, nil, nil)
 	if !work["live-rig/alpha"] {
 		t.Error("agent on live rig should be probed")
 	}
@@ -1069,7 +1069,7 @@ func TestComputeWorkSet_SkipsAllWhenCitySuspended(t *testing.T) {
 		return `[{"id":"BL-1"}]`, nil
 	}
 
-	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, nil)
+	work := computeWorkSet(cfg, runner, "test-city", t.TempDir(), nil, nil, nil)
 	if probed {
 		t.Error("no agent should be probed when city is suspended")
 	}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1878,7 +1878,24 @@ func isBdTransientWriteError(err error) bool {
 	return strings.Contains(msg, "Error 1213 (40001): serialization failure") ||
 		strings.Contains(msg, "this transaction conflicts with a committed transaction") ||
 		strings.Contains(msg, "failed to prepare catalog") ||
+		isBdSqliteBusyError(msg) ||
 		isBdAmbiguousWriteError(err)
+}
+
+// isBdSqliteBusyError reports whether msg carries an explicit sqlite
+// busy/locked result-code marker ("database is locked (5) (SQLITE_BUSY)"
+// and friends) — the sqlite analog of a Dolt serialization failure: the
+// write lost a lock race without applying, so it is safe to retry. Only
+// the unambiguous SQLITE_BUSY / SQLITE_LOCKED code markers match. bd's
+// sqlite driver (modernc.org/sqlite) always appends the code marker, so
+// this loses no real coverage, while bare "database is locked" phrasings
+// stay excluded on purpose: Dolt's embedded mode emits "database is
+// locked by another dolt process" for a persistent lock-file condition
+// that a bounded retry cannot clear and must keep failing fast.
+func isBdSqliteBusyError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "sqlite_busy") ||
+		strings.Contains(lower, "sqlite_locked")
 }
 
 func isBdAmbiguousWriteError(err error) bool {

--- a/internal/beads/bdstore_internal_test.go
+++ b/internal/beads/bdstore_internal_test.go
@@ -1,6 +1,59 @@
 package beads
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
+
+// TestIsBdTransientWriteError pins the write-retry classifier's needle set.
+// A bd backed by sqlite (modernc.org/sqlite) surfaces
+// "database is locked (5) (SQLITE_BUSY)" on lock contention — the textbook
+// transient write failure, which must be retried. Only the explicit
+// SQLITE_BUSY / SQLITE_LOCKED code markers match: bare "database is locked"
+// phrasings must NOT be retried, because Dolt's embedded mode uses that
+// phrasing for a persistent lock-file condition. Constraint and syntax
+// errors are permanent and must NOT be retried either.
+func TestIsBdTransientWriteError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+
+		// sqlite busy/locked code markers: transient, retried.
+		{name: "sqlite database locked", err: errors.New("exit status 1: creating issue: database is locked (5) (SQLITE_BUSY)"), want: true},
+		{name: "sqlite table locked", err: errors.New("exit status 1: updating issue: database table is locked (6) (SQLITE_LOCKED)"), want: true},
+		{name: "sqlite busy bare code", err: errors.New("exit status 1: SQLITE_BUSY: database busy"), want: true},
+
+		// Lock phrasings without a sqlite code marker: NOT retried. Dolt's
+		// embedded mode holds a lock file for the life of another process;
+		// a bounded retry cannot clear it and must keep failing fast.
+		{name: "dolt embedded lock file", err: errors.New("exit status 1: database is locked by another dolt process"), want: false},
+		{name: "bare database is locked", err: errors.New("exit status 1: database is locked"), want: false},
+
+		// sqlite permanent errors: NOT retried.
+		{name: "sqlite unique constraint", err: errors.New("exit status 1: constraint failed: UNIQUE constraint failed: issues.id (1555) (SQLITE_CONSTRAINT_UNIQUE)"), want: false},
+		{name: "sqlite syntax error", err: errors.New(`exit status 1: SQL logic error: near "FROM": syntax error (1) (SQLITE_ERROR)`), want: false},
+
+		// Existing dolt/mysql needles: unchanged.
+		{name: "dolt serialization failure", err: errors.New("exit status 1: Error 1213 (40001): serialization failure"), want: true},
+		{name: "dolt committed transaction conflict", err: errors.New("exit status 1: this transaction conflicts with a committed transaction"), want: true},
+		{name: "dolt catalog prepare failure", err: errors.New("exit status 1: failed to prepare catalog"), want: true},
+		{name: "mysql invalid connection", err: errors.New("exit status 1: [mysql] invalid connection"), want: true},
+		{name: "broken pipe", err: errors.New("exit status 1: write: broken pipe"), want: true},
+
+		// Generic permanent errors: unchanged.
+		{name: "plain bd failure", err: errors.New("exit status 1: no issue found bd-42"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBdTransientWriteError(tt.err); got != tt.want {
+				t.Fatalf("isBdTransientWriteError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestBdStdoutErrorDetail(t *testing.T) {
 	tests := []struct {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3681,6 +3681,28 @@ func TestBdStoreDepAddRetriesTransientDoltConnectionError(t *testing.T) {
 	}
 }
 
+// TestBdStoreDepAddRetriesSqliteBusyError proves a sqlite-backed bd write
+// that loses a lock race ("database is locked (5) (SQLITE_BUSY)") goes
+// through the same transient-write retry loop as Dolt serialization
+// failures instead of failing permanently on first contention.
+func TestBdStoreDepAddRetriesSqliteBusyError(t *testing.T) {
+	calls := 0
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("exit status 1: adding dependency: database is locked (5) (SQLITE_BUSY)")
+		}
+		return nil, nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	if err := s.DepAdd("bd-42", "bd-41", "blocks"); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2 (1 sqlite busy + 1 retry success)", calls)
+	}
+}
+
 func TestBdStoreDepAddError(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("exit status 1")


### PR DESCRIPTION
## What

`isBdTransientWriteError` gets a deliberately conservative sqlite arm: bd write errors carrying an explicit `SQLITE_BUSY` / `SQLITE_LOCKED` result-code marker (e.g. `database is locked (5) (SQLITE_BUSY)`) are now classified transient and flow through the existing bounded-backoff write retry loop, exactly like Dolt serialization failures. Only the unambiguous code markers match — bd's sqlite driver (modernc.org/sqlite) always appends them, so no real coverage is lost, while bare "database is locked" phrasings stay excluded on purpose: Dolt's embedded mode emits `database is locked by another dolt process` for a persistent lock-file condition that a bounded retry cannot clear and must keep failing fast.

Two hardening commits ride along in `cmd/gc` (see Why): a nil-`stderr` guard in `computeWorkSet`, and `t.TempDir()` instead of literal `/tmp` as the city dir in the `computeWorkSet` tests.

## Why

The sqlite concurrency audit of the infra store (defect #4, CONFIRMED) found the write classifier matched only Dolt/MySQL needles, so a `SQLITE_BUSY` from a sqlite-backed bd was classified permanent and never retried: any write that lost a lock race failed on first contention. The audit's empirical hammer proved the trigger window is real and wide — because bd reads also take the single write lock, one long writer (a 26k-issue `bd import` holding the lock ~118s) failed 100% of concurrent operations with `SQLITE_BUSY` rc=1, each surfaced to gc as a permanent error even though a retry would have succeeded once the lock cleared. A BUSY write is the sqlite analog of a Dolt serialization failure: it lost the race without applying, so it is safe to retry.

The red-team pass on the fix blocked the first push: the pre-push suite failed in the `computeWorkSet` tests with a nil-pointer panic inside `fmt.Fprintf`. Tracing it produced the two-part revision in this branch instead of a workaround:

- `computeWorkSet` took `stderr io.Writer` and wrote probe-env diagnostics to it, but several callers (all reconciler unit tests, and any future fire-and-forget caller) pass nil — the probe-env error branch then panics instead of degrading to "skip this agent". The guard defaults nil to `io.Discard` at the function boundary.
- The tests passed literal `/tmp` as `cityDir`, so they read whatever bead-store state the machine had at `/tmp/.beads` / `/tmp/.gc`. Hostile residue there (an authoritative-but-unresolvable scope config left by an unrelated process) made `controllerQueryRuntimeEnv("/tmp")` error for every agent, which is what reached the panic. Base-vs-branch was established explicitly: with the residue planted, these tests fail identically at the merge base — the hazard is latent at base and independent of the classifier change — but it deterministically blocked this push, so both halves are fixed here rather than papered over. Each test now uses `t.TempDir()`.

## Verification

- `TestIsBdTransientWriteError` (new) pins the full needle set: sqlite BUSY/LOCKED markers retried; bare `database is locked` and Dolt's embedded lock-file phrasing NOT retried; sqlite constraint/syntax errors NOT retried; all pre-existing Dolt/MySQL needles unchanged.
- `TestBdStoreDepAddRetriesSqliteBusyError` (new) proves end-to-end that a write failing once with `SQLITE_BUSY` is retried and succeeds on the second attempt.
- New `computeWorkSet` regression test builds a real erroring probe-env fixture (authoritative scope config + postgres metadata with no resolvable password) and proves a nil-`stderr` caller skips the agent instead of panicking.
- Red-team results: the nil-writer panic and the `/tmp` residue sensitivity reproduce identically at the merge base (pre-existing, now fixed); the full `TestComputeWorkSet` set passes with hostile `/tmp/.beads` residue deliberately planted; the conservative needle set was checked against Dolt embedded-mode lock errors to confirm no fail-fast regression.
- Pre-push suite (`scripts/test-local-parallel fast`, 8 jobs: unit-core + 6 cmd/gc shards + darwin compile) passed in full on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)