### PR TITLE
fix(materialize): remember gc-written symlink targets so pack-sha bumps self-heal (#4130)

### DIFF
--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -36,6 +36,7 @@ package materialize
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -45,6 +46,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/bootstrap"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // vendorSinks maps an agent provider to the relative directory under the
@@ -352,6 +354,69 @@ type Result struct {
 	Warnings []string
 }
 
+// ownershipManifestFile is the name of the small bookkeeping file the
+// materializer keeps inside each sink directory (gastownhall/gascity#4130).
+const ownershipManifestFile = ".gc-skill-ownership.json"
+
+// ownershipManifest durably records, per sink entry name, the last
+// canonicalized absolute target this materializer wrote a symlink to.
+// It exists solely so a symlink can still be recognized as gc's own once
+// its target's root falls out of the CURRENT pass's OwnedRoots — e.g. a
+// pinned pack sha bump moves an imported catalog's root to a new
+// content-addressed cache checkout with an unrelated path (cache keys
+// are sha256(source+commit), so there is no stable parent directory to
+// widen ownership to instead). Without this, the cleanup walk's
+// targetUnderOwnedRoot check treats the old-sha symlink as
+// user-placed and leaves it alone, and the create step then finds the
+// occupied path and reports "user-owned symlink at sink path" forever
+// (gastownhall/gascity#4130).
+//
+// A missing or corrupt manifest is treated as empty: ownership
+// recognition falls back to today's targetUnderOwnedRoot-only behavior,
+// so there is no migration step and no new failure mode for existing
+// sinks — self-healing only starts working going forward from the first
+// pass that writes a manifest entry for a given name.
+type ownershipManifest struct {
+	Targets map[string]string `json:"targets"`
+}
+
+// loadOwnershipManifest is best-effort: any read or parse failure (file
+// absent, corrupt JSON, permission error) yields an empty manifest so
+// the cleanup walk falls back to today's targetUnderOwnedRoot-only
+// ownership check rather than failing the pass.
+func loadOwnershipManifest(absSink string) ownershipManifest {
+	data, err := os.ReadFile(filepath.Join(absSink, ownershipManifestFile))
+	if err != nil {
+		return ownershipManifest{Targets: map[string]string{}}
+	}
+	var m ownershipManifest
+	if err := json.Unmarshal(data, &m); err != nil || m.Targets == nil {
+		return ownershipManifest{Targets: map[string]string{}}
+	}
+	return m
+}
+
+// saveOwnershipManifest writes the manifest atomically (temp file +
+// rename, matching this package's other on-disk writes). Callers treat a
+// save failure as a warning, not a pass-level error: it only affects
+// self-healing on a future pass, not the correctness of this one.
+func saveOwnershipManifest(absSink string, m ownershipManifest) error {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("encoding ownership manifest: %w", err)
+	}
+	return fsys.WriteFileAtomic(fsys.OSFS{}, filepath.Join(absSink, ownershipManifestFile), data, 0o644)
+}
+
+// manifestRecordsTarget reports whether the manifest's last-known target
+// for name matches canonTarget exactly — i.e. this materializer itself
+// wrote this symlink in a previous pass, even if canonTarget's root is no
+// longer in the current pass's OwnedRoots.
+func manifestRecordsTarget(m ownershipManifest, name, canonTarget string) bool {
+	recorded, ok := m.Targets[name]
+	return ok && recorded == canonTarget
+}
+
 // Run runs one materialization pass for an agent's sink.
 //
 // Pass order:
@@ -403,6 +468,9 @@ func Run(req Request) (Result, error) {
 		owned = append(owned, canon)
 	}
 
+	manifest := loadOwnershipManifest(absSink)
+	manifestDirty := false
+
 	// Step 2: legacy stub migration.
 	for _, name := range req.LegacyNames {
 		path := filepath.Join(absSink, name)
@@ -449,8 +517,11 @@ func Run(req Request) (Result, error) {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("canonicalize target %q: %v", target, terr))
 			continue
 		}
-		if !targetUnderOwnedRoot(canonTarget, owned) {
-			// External target — symlink the user placed themselves.
+		if !targetUnderOwnedRoot(canonTarget, owned) && !manifestRecordsTarget(manifest, name, canonTarget) {
+			// External target — symlink the user placed themselves. Not
+			// under any currently-owned root, and not a target this
+			// materializer's own manifest remembers writing for this name
+			// in a previous pass.
 			continue
 		}
 		desired, want := desiredByName[name]
@@ -458,6 +529,9 @@ func Run(req Request) (Result, error) {
 			// Owned but not desired — delete (covers dangling and orphaned).
 			if rmErr := os.Remove(path); rmErr != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("removing orphan symlink %q: %v", path, rmErr))
+			} else if _, had := manifest.Targets[name]; had {
+				delete(manifest.Targets, name)
+				manifestDirty = true
 			}
 			continue
 		}
@@ -475,6 +549,10 @@ func Run(req Request) (Result, error) {
 			// Already correct — record and move on. The create loop
 			// will see this name has been satisfied via desiredByName
 			// removal below.
+			if manifest.Targets[name] != canonTarget {
+				manifest.Targets[name] = canonTarget
+				manifestDirty = true
+			}
 			result.Materialized = append(result.Materialized, name)
 			delete(desiredByName, name)
 			continue
@@ -486,6 +564,8 @@ func Run(req Request) (Result, error) {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("replacing symlink %q: %v", path, rerr))
 			continue
 		}
+		manifest.Targets[name] = canonDesired
+		manifestDirty = true
 		result.Materialized = append(result.Materialized, name)
 		delete(desiredByName, name)
 	}
@@ -534,7 +614,17 @@ func Run(req Request) (Result, error) {
 		if cerr := atomicSymlink(desiredAbs, path); cerr != nil {
 			return result, fmt.Errorf("creating symlink %q -> %q: %w", path, desiredAbs, cerr)
 		}
+		if canonDesired, cerr := canonicalizePath(desiredAbs); cerr == nil {
+			manifest.Targets[name] = canonDesired
+			manifestDirty = true
+		}
 		result.Materialized = append(result.Materialized, name)
+	}
+
+	if manifestDirty {
+		if serr := saveOwnershipManifest(absSink, manifest); serr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("saving ownership manifest: %v", serr))
+		}
 	}
 
 	sort.Strings(result.Materialized)

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -804,6 +804,111 @@ func TestMaterializeAgentAliasedOwnedRoot(t *testing.T) {
 	}
 }
 
+// TestMaterializeAgentSelfHealsAfterOwnedRootMoves pins
+// gastownhall/gascity#4130: a pinned pack sha bump moves an imported
+// catalog's OwnedRoots entry to a brand-new content-addressed cache
+// checkout (unrelated path — cache keys are sha256(source+commit), no
+// stable parent to widen ownership to). The symlink materialize wrote
+// under the OLD root is no longer under any CURRENT owned root, so
+// without the ownership manifest the cleanup walk would misclassify it
+// as user-placed and the create step would report "user-owned symlink
+// at sink path" forever, instead of self-healing to the new sha.
+func TestMaterializeAgentSelfHealsAfterOwnedRootMoves(t *testing.T) {
+	t.Parallel()
+	// Two unrelated cache checkouts, standing in for sha A and sha B —
+	// deliberately NOT nested under a shared parent, matching the real
+	// sha256(source+commit) cache-key scheme that gives each pin its own
+	// unrelated directory name.
+	shaA := filepath.Join(t.TempDir(), "cache-aaaa")
+	mkSkill(t, shaA, "alpha")
+	shaB := filepath.Join(t.TempDir(), "cache-bbbb")
+	mkSkill(t, shaB, "alpha")
+	sink := filepath.Join(t.TempDir(), "skills")
+
+	// Pass 1: pin resolves to sha A.
+	res1, err := Run(Request{
+		SinkDir:    sink,
+		Desired:    []SkillEntry{{Name: "alpha", Source: filepath.Join(shaA, "alpha"), Origin: "city"}},
+		OwnedRoots: []string{shaA},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res1.Materialized, []string{"alpha"}) {
+		t.Fatalf("pass 1 materialized = %v, want [alpha]", res1.Materialized)
+	}
+
+	// Pass 2: pin bumps to sha B. OwnedRoots no longer includes shaA at
+	// all — the pre-fix bug: cleanup sees the existing symlink still
+	// pointing at shaA, finds it under no current owned root, leaves it
+	// alone as "external", and the create step then finds the sink path
+	// occupied and reports it as user-owned instead of replacing it.
+	res2, err := Run(Request{
+		SinkDir:    sink,
+		Desired:    []SkillEntry{{Name: "alpha", Source: filepath.Join(shaB, "alpha"), Origin: "city"}},
+		OwnedRoots: []string{shaB},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res2.Materialized, []string{"alpha"}) {
+		t.Fatalf("pass 2 materialized = %v (want [alpha] via self-heal); skipped=%+v warnings=%v",
+			res2.Materialized, res2.Skipped, res2.Warnings)
+	}
+	if len(res2.Skipped) != 0 {
+		t.Fatalf("sha-bump symlink misclassified as user-owned: %+v", res2.Skipped)
+	}
+	got, err := os.Readlink(filepath.Join(sink, "alpha"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Join(shaB, "alpha") {
+		t.Errorf("symlink target = %q, want %q (still pointing at the old sha A checkout)", got, filepath.Join(shaB, "alpha"))
+	}
+}
+
+// TestMaterializeAgentSelfHealDoesNotAdoptGenuineUserSymlink guards the
+// safety property #4130's fix must preserve: the ownership manifest only
+// recognizes a symlink as gc's own when its CURRENT on-disk target
+// matches what THIS materializer previously wrote for that exact name.
+// A symlink a user placed themselves at a name gc also wants to manage —
+// pointing at a path gc never wrote — must still be left alone as
+// user-owned, manifest or no manifest.
+func TestMaterializeAgentSelfHealDoesNotAdoptGenuineUserSymlink(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mkSkill(t, src, "alpha")
+	userTarget := t.TempDir()
+	mkSkill(t, userTarget, "override")
+	sink := filepath.Join(t.TempDir(), "skills")
+
+	// User places their own override symlink at the sink path gc also
+	// wants to manage, pointing at a location gc never wrote.
+	mustSymlink(t, filepath.Join(userTarget, "override"), filepath.Join(sink, "alpha"))
+
+	res, err := Run(Request{
+		SinkDir:    sink,
+		Desired:    []SkillEntry{{Name: "alpha", Source: filepath.Join(src, "alpha"), Origin: "city"}},
+		OwnedRoots: []string{src},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Materialized) != 0 {
+		t.Fatalf("materialized = %v, want none — user's symlink must be left alone", res.Materialized)
+	}
+	if len(res.Skipped) != 1 || res.Skipped[0].Name != "alpha" {
+		t.Fatalf("Skipped = %+v, want alpha reported as user-owned", res.Skipped)
+	}
+	got, err := os.Readlink(filepath.Join(sink, "alpha"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Join(userTarget, "override") {
+		t.Errorf("user's symlink target changed to %q, want untouched %q", got, filepath.Join(userTarget, "override"))
+	}
+}
+
 // TestMaterializeAgentRelativeSymlinkLeftAlone is the regression for
 // the pass-2 Codex finding: a sink entry that is a relative-target
 // symlink (which the materializer never writes — it always uses


### PR DESCRIPTION
Fixes #4130.

**Bug:** when a pinned pack `sha` is bumped, `gc internal materialize-skills` (and the same stage-1 pass at supervisor start) reports every skill from that pack as `"user-owned symlink at sink path"` — permanently skipped, never refreshed to the new checkout, even across restarts. The sink keeps serving content from the old pinned sha indefinitely.

**Root cause:** `LoadCityCatalog` builds `CityCatalog.OwnedRoots` from the *current* config's pack/import source directories only. Pack cache checkouts are content-addressed — `packman.RepoCachePath` keys each checkout by `sha256(source+commit)` — so bumping a pin does not move the checkout to a sibling path under a shared parent; it produces a completely unrelated directory name with no structural relationship to the old one. The cleanup walk's `targetUnderOwnedRoot` check classifies an existing sink symlink as gc-owned purely by whether its target lives under a *current* owned root. A symlink materialize wrote under the old sha's root is therefore misclassified as "external target — symlink the user placed themselves" and left untouched; the create step then finds the sink path already occupied by that stale symlink and reports it as user-owned, forever.

**Fix:** a small per-sink ownership manifest, `.gc-skill-ownership.json`, records — per skill name — the last canonicalized absolute target this materializer itself wrote. The cleanup walk's ownership check now recognizes a symlink as gc's own when *either* it's under a current owned root (today's check, unchanged) *or* its exact current target matches the manifest's recorded value for that name (new — survives the root itself moving). A missing or corrupt manifest is treated as empty, so ownership recognition falls back to today's `targetUnderOwnedRoot`-only behavior: no migration step, no new failure mode for existing sinks — self-healing starts working going forward from the first pass that writes a manifest entry for a given name. The manifest is updated whenever a symlink is created or drift-replaced, and pruned when an owned-but-undesired symlink is deleted, so it doesn't grow unboundedly with stale entries. Manifest save failures are recorded as `Warnings`, not pass-level errors — they only affect self-healing on a *future* pass, not the correctness of the current one.

**Safety property preserved:** the manifest only recognizes a symlink as gc's own when its *current on-disk target* exactly matches what this materializer previously wrote for that exact name. A symlink a user genuinely placed themselves — pointing at a path gc never wrote — is still left alone as user-owned, manifest or no manifest; see the dedicated regression test below.

**Scope note:** this follows the report's own recommended "Fix candidate A" (persist historical owned roots across materialization passes) over "Fix candidate B" (a separate marker/xattr format + migration pass) — smaller, stays within the existing `OwnedRoots`/ownership model, and needs no migration for sinks that predate this fix.

## Test

Two new regression tests in `internal/materialize/skills_test.go`:

- `TestMaterializeAgentSelfHealsAfterOwnedRootMoves` — two-pass test: pass 1 materializes against an owned root standing in for sha A; pass 2 changes `OwnedRoots` to an *unrelated* directory standing in for sha B (deliberately not nested under a shared parent, matching the real `sha256(source+commit)` cache-key scheme) with `Desired` now pointing at sha B's copy of the skill. Asserts pass 2 replaces the symlink (self-heals) instead of reporting it as user-owned.
- `TestMaterializeAgentSelfHealDoesNotAdoptGenuineUserSymlink` — a user places their own override symlink at a sink name gc also wants to manage, pointing at a location gc never wrote. Asserts it's still reported as user-owned and left completely untouched.

TDD RED confirmed: reverted `skills.go`, reran `TestMaterializeAgentSelfHealsAfterOwnedRootMoves` — failed with `pass 2 materialized = [] ... Reason:user-owned symlink at sink path`, reproducing the exact reported symptom. GREEN after restoring the fix.

## Validation

`-tags gms_pure_go`: `gofmt -l` clean, `go build ./...` clean, `go vet ./internal/materialize/... ./internal/fsys/... ./cmd/gc/...` clean. Full `internal/materialize` suite green (36 test functions) — no regressions on the existing ownership/cleanup/idempotency matrix. Targeted `cmd/gc` skill/materialize call-site suites green — both `materialize.Run` callers require zero changes since the manifest lives entirely inside the sink directory `Run` already resolves from `req.SinkDir`.