### PR TITLE
feat(api): stable keyset cursors on GET /v0/beads — versioned tokens, typed 400 on invalid (P1 #4 S1)

### DIFF
--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -2177,6 +2177,7 @@
               "urn:gascity:error:idempotency-in-flight",
               "urn:gascity:error:idempotency-mismatch",
               "urn:gascity:error:internal",
+              "urn:gascity:error:invalid-cursor",
               "urn:gascity:error:invalid-request",
               "urn:gascity:error:mail-not-found",
               "urn:gascity:error:method-not-allowed",
@@ -2222,6 +2223,7 @@
               "urn:gascity:error:idempotency-in-flight",
               "urn:gascity:error:idempotency-mismatch",
               "urn:gascity:error:internal",
+              "urn:gascity:error:invalid-cursor",
               "urn:gascity:error:invalid-request",
               "urn:gascity:error:mail-not-found",
               "urn:gascity:error:method-not-allowed",
@@ -21975,6 +21977,21 @@
                   "type": "integer"
                 }
               },
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
               }

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -2177,6 +2177,7 @@
               "urn:gascity:error:idempotency-in-flight",
               "urn:gascity:error:idempotency-mismatch",
               "urn:gascity:error:internal",
+              "urn:gascity:error:invalid-cursor",
               "urn:gascity:error:invalid-request",
               "urn:gascity:error:mail-not-found",
               "urn:gascity:error:method-not-allowed",
@@ -2222,6 +2223,7 @@
               "urn:gascity:error:idempotency-in-flight",
               "urn:gascity:error:idempotency-mismatch",
               "urn:gascity:error:internal",
+              "urn:gascity:error:invalid-cursor",
               "urn:gascity:error:invalid-request",
               "urn:gascity:error:mail-not-found",
               "urn:gascity:error:method-not-allowed",
@@ -21975,6 +21977,21 @@
                   "type": "integer"
                 }
               },
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
               }

--- a/internal/api/apierr/catalog.go
+++ b/internal/api/apierr/catalog.go
@@ -39,6 +39,10 @@ var (
 	// Request validation.
 	InvalidRequest   = Register(ProblemType{Code: "invalid-request", Status: http.StatusBadRequest, Title: "Invalid Request"})
 	ValidationFailed = Register(ProblemType{Code: "validation-failed", Status: http.StatusUnprocessableEntity, Title: "Validation Failed"})
+	// InvalidCursor is a pagination token the server cannot parse (garbage,
+	// a legacy offset cursor, or the wrong kind for the endpoint). Clients
+	// recover by re-fetching the first page.
+	InvalidCursor = Register(ProblemType{Code: "invalid-cursor", Status: http.StatusBadRequest, Title: "Invalid Cursor"})
 	// WebhookRejected is a well-formed webhook request the receiver declined to
 	// dispatch (unknown/unwired sink, policy) — distinct from validation-failed,
 	// which is huma's schema-validation auto-stamp.

--- a/internal/api/cursor_token.go
+++ b/internal/api/cursor_token.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// Keyset cursor tokens: versioned, opaque pagination cursors that encode the
+// sort-key boundary of the last row served instead of an integer offset.
+// Offsets skip or duplicate rows whenever a concurrent write shifts the
+// result set — a guarantee on a live work ledger — while a keyset boundary
+// stays stable: the next page is "rows strictly after this boundary in the
+// collection's total order" regardless of inserts above it.
+//
+// Wire format: "v1:" + base64url(JSON keysetCursor). The prefix versions the
+// token so a future format change (or yesterday's bare-offset cursors) is a
+// typed 400 invalid-cursor, never a silent misread.
+
+const cursorVersionPrefix = "v1:"
+
+// Cursor kinds. Each paginated collection accepts exactly one kind; a valid
+// token of the wrong kind is rejected by the handler as an invalid cursor.
+const (
+	// cursorKindCreatedID marks a (created_at, id) boundary — the total order
+	// of bead-backed collections (#3208).
+	cursorKindCreatedID = "cb"
+	// cursorKindSeq marks an event-log sequence boundary.
+	cursorKindSeq = "sq"
+)
+
+// keysetCursor is the decoded form of a v1 pagination token.
+type keysetCursor struct {
+	Kind      string    `json:"k"`
+	CreatedAt time.Time `json:"ca,omitzero"`
+	ID        string    `json:"id,omitempty"`
+	Seq       uint64    `json:"s,omitempty"`
+}
+
+var errInvalidCursor = errors.New("invalid pagination cursor")
+
+// encodeKeysetCursor serializes a boundary as an opaque v1 token.
+func encodeKeysetCursor(c keysetCursor) string {
+	data, err := json.Marshal(c)
+	if err != nil {
+		// keysetCursor contains only marshalable fields; unreachable.
+		return ""
+	}
+	return cursorVersionPrefix + base64.RawURLEncoding.EncodeToString(data)
+}
+
+// decodeKeysetCursor parses a v1 token, rejecting anything else — including
+// the legacy base64-offset cursors — with an error the handler maps to a 400
+// problem+json invalid-cursor response.
+func decodeKeysetCursor(token string) (keysetCursor, error) {
+	var zero keysetCursor
+	rest, ok := strings.CutPrefix(token, cursorVersionPrefix)
+	if !ok {
+		return zero, errInvalidCursor
+	}
+	data, err := base64.RawURLEncoding.DecodeString(rest)
+	if err != nil {
+		return zero, errInvalidCursor
+	}
+	var c keysetCursor
+	if err := json.Unmarshal(data, &c); err != nil {
+		return zero, errInvalidCursor
+	}
+	switch c.Kind {
+	case cursorKindCreatedID:
+		// A zero CreatedAt is a legal boundary: degraded rows (NULL or
+		// unparseable created_at from a drifted store) carry zero timestamps,
+		// sort to the created-DESC tail, and the server mints boundaries from
+		// them — the decoder must accept every token the server mints or a
+		// walk wedges in a 400 loop at the tail. Only the ID is required.
+		if c.ID == "" {
+			return zero, errInvalidCursor
+		}
+	case cursorKindSeq:
+		// Seq 0 is a legal boundary (before the first event).
+	default:
+		return zero, errInvalidCursor
+	}
+	return c, nil
+}

--- a/internal/api/cursor_token_test.go
+++ b/internal/api/cursor_token_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKeysetCursorRoundTrip(t *testing.T) {
+	ts := time.Date(2026, 7, 11, 12, 30, 45, 123456789, time.UTC)
+	in := keysetCursor{Kind: cursorKindCreatedID, CreatedAt: ts, ID: "gc-42"}
+	tok := encodeKeysetCursor(in)
+	if !strings.HasPrefix(tok, "v1:") {
+		t.Fatalf("token %q lacks the v1: version prefix", tok)
+	}
+	out, err := decodeKeysetCursor(tok)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Kind != cursorKindCreatedID || out.ID != "gc-42" || !out.CreatedAt.Equal(ts) {
+		t.Fatalf("round trip = %+v, want %+v", out, in)
+	}
+}
+
+func TestKeysetCursorSeqRoundTrip(t *testing.T) {
+	in := keysetCursor{Kind: cursorKindSeq, Seq: 98765}
+	out, err := decodeKeysetCursor(encodeKeysetCursor(in))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Kind != cursorKindSeq || out.Seq != 98765 {
+		t.Fatalf("round trip = %+v, want %+v", out, in)
+	}
+}
+
+func TestKeysetCursorRejectsGarbage(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{"empty", ""},
+		{"legacy offset cursor", "NTA"},          // base64("50") — the old format
+		{"no prefix", "eyJrIjoiY2IifQ"},          // valid b64 JSON, missing v1:
+		{"unknown version", "v9:eyJrIjoiY2IifQ"}, //
+		{"bad base64", "v1:!!!not-base64!!!"},    //
+		{"bad json", "v1:bm90LWpzb24"},           // base64("not-json")
+		{"unknown kind", "v1:eyJrIjoienoifQ"},    // {"k":"zz"}
+		{"cb missing id", "v1:eyJrIjoiY2IifQ"},   // {"k":"cb"} — no id
+		{"whitespace", "  "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := decodeKeysetCursor(tc.token); err == nil {
+				t.Fatalf("decodeKeysetCursor(%q) = nil error, want rejection", tc.token)
+			}
+		})
+	}
+}
+
+// TestKeysetCursorZeroCreatedAtRoundTrips pins the accept-what-you-mint
+// invariant: degraded rows (NULL/unparseable created_at from a drifted store)
+// carry zero timestamps, sort to the created-DESC tail, and the server mints
+// boundaries from them. The decoder must accept those tokens or a walk wedges
+// in a 400 loop at the tail.
+func TestKeysetCursorZeroCreatedAtRoundTrips(t *testing.T) {
+	tok := encodeKeysetCursor(keysetCursor{Kind: cursorKindCreatedID, ID: "gc-7"})
+	out, err := decodeKeysetCursor(tok)
+	if err != nil {
+		t.Fatalf("decode of a server-minted zero-CreatedAt token failed: %v", err)
+	}
+	if out.Kind != cursorKindCreatedID || out.ID != "gc-7" || !out.CreatedAt.IsZero() {
+		t.Fatalf("round trip = %+v, want zero-CreatedAt cb boundary for gc-7", out)
+	}
+}
+
+func TestKeysetCursorKindMismatchDetectable(t *testing.T) {
+	// A seq cursor decoded where a cb cursor is expected: the decode succeeds
+	// (it is a valid token) — the caller checks Kind. Pin that Kind survives.
+	tok := encodeKeysetCursor(keysetCursor{Kind: cursorKindSeq, Seq: 7})
+	out, err := decodeKeysetCursor(tok)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Kind == cursorKindCreatedID {
+		t.Fatal("seq cursor decoded as cb kind")
+	}
+}

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -8661,6 +8661,10 @@ export type GetV0CityByCityNameBeadsData = {
 
 export type GetV0CityByCityNameBeadsErrors = {
     /**
+     * Bad Request
+     */
+    400: ErrorModel;
+    /**
      * Not Found
      */
     404: ErrorModel;

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -27815,6 +27815,7 @@ type GetV0CityByCityNameBeadsResponse struct {
 	Body                      []byte
 	HTTPResponse              *http.Response
 	JSON200                   *ListBodyBead
+	ApplicationproblemJSON400 *ErrorModel
 	ApplicationproblemJSON404 *ErrorModel
 	ApplicationproblemJSON422 *ErrorModel
 	ApplicationproblemJSON500 *ErrorModel
@@ -34862,6 +34863,13 @@ func ParseGetV0CityByCityNameBeadsResponse(rsp *http.Response) (*GetV0CityByCity
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest ErrorModel

--- a/internal/api/handler_beads_bounded_test.go
+++ b/internal/api/handler_beads_bounded_test.go
@@ -132,8 +132,11 @@ func TestBeadListAllTrueBoundsCounterStore(t *testing.T) {
 	if !store.countCalled {
 		t.Errorf("Count was not called; bounding did not engage")
 	}
-	if store.maxListLim != limit {
-		t.Errorf("max List limit = %d, want %d (page bound pushed into store)", store.maxListLim, limit)
+	// limit+1: the keyset bounded path overfetches one row as the has-more
+	// signal (Counts are un-seeked totals and cannot tell). Still O(limit),
+	// not O(history) — the property this test guards.
+	if store.maxListLim != limit+1 {
+		t.Errorf("max List limit = %d, want %d (page bound pushed into store)", store.maxListLim, limit+1)
 	}
 }
 
@@ -248,18 +251,35 @@ func TestBeadListAllTrueBoundedTotalExcludesFailedRigList(t *testing.T) {
 		t.Errorf("NextCursor empty, want a cursor (reachable Total %d > limit %d)", good, limit)
 	}
 
-	// Reachability: paging to the last window must return the final rows and
-	// stop. A Total inflated by the failed rig would emit a cursor past the 30
-	// reachable rows, so this asserts next_cursor never overshoots the data.
-	last := fetchBoundedBeads(t, fs, fmt.Sprintf("?type=molecule&all=true&limit=%d&cursor=%s", limit, encodeCursor(good-limit)))
-	if last.Total != good {
-		t.Errorf("last-page Total = %d, want %d", last.Total, good)
+	// Reachability: walking the keyset cursor chain must visit exactly the 30
+	// reachable rows and stop. A Total inflated by the failed rig used to make
+	// the offset cursor overshoot; with keyset cursors the equivalent defect
+	// would be a dangling next_cursor after the last reachable row.
+	seen := map[string]bool{}
+	cursor := body.NextCursor
+	for _, item := range body.Items {
+		seen[item.ID] = true
 	}
-	if len(last.Items) != limit {
-		t.Errorf("last-page len(Items) = %d, want %d", len(last.Items), limit)
+	pages := 1
+	for cursor != "" {
+		next := fetchBoundedBeads(t, fs, fmt.Sprintf("?type=molecule&all=true&limit=%d&cursor=%s", limit, cursor))
+		if next.Total != good {
+			t.Errorf("page %d Total = %d, want %d", pages, next.Total, good)
+		}
+		for _, item := range next.Items {
+			if seen[item.ID] {
+				t.Errorf("bead %s duplicated across pages", item.ID)
+			}
+			seen[item.ID] = true
+		}
+		cursor = next.NextCursor
+		pages++
+		if pages > 10 {
+			t.Fatal("cursor chain did not terminate (dangling next_cursor past reachable data)")
+		}
 	}
-	if last.NextCursor != "" {
-		t.Errorf("last-page NextCursor = %q, want empty (all reachable rows consumed)", last.NextCursor)
+	if len(seen) != good {
+		t.Errorf("walk reached %d distinct rows, want %d", len(seen), good)
 	}
 }
 
@@ -307,7 +327,15 @@ func TestBeadListAllTrueBoundedPartialResultRigKeepsCount(t *testing.T) {
 	if len(body.Items) != good+partial {
 		t.Errorf("len(Items) = %d, want %d (all rows incl. partial-rig survivors reachable)", len(body.Items), good+partial)
 	}
-	if body.NextCursor != "" {
-		t.Errorf("NextCursor = %q, want empty (everything fit in one page)", body.NextCursor)
+	// A degraded (partial) page always carries a resume cursor: the server
+	// cannot know whether the degraded rig withheld rows, so it hands the
+	// client a boundary instead of silently ending the walk. Following it
+	// here must terminate cleanly on an empty page.
+	if body.NextCursor == "" {
+		t.Fatalf("NextCursor empty, want a resume cursor on a partial page")
+	}
+	next := fetchBoundedBeads(t, fs, fmt.Sprintf("?type=molecule&all=true&limit=%d&cursor=%s", good+partial+10, body.NextCursor))
+	if len(next.Items) != 0 || next.NextCursor != "" {
+		t.Errorf("resume page = %d items, cursor %q; want empty page with no cursor (clean termination)", len(next.Items), next.NextCursor)
 	}
 }

--- a/internal/api/handler_beads_keyset_test.go
+++ b/internal/api/handler_beads_keyset_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// These tests pin the keyset-cursor contract on GET /v0/beads: opaque v1
+// tokens that resume at a (created_at, id) boundary, a typed 400 on any
+// invalid cursor (including yesterday's base64-offset cursors), and the core
+// no-skip/no-dup walk property under concurrent writes that offset cursors
+// could not provide.
+
+func getBeads(t *testing.T, h http.Handler, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestBeadListInvalidCursorReturns400(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	for _, tc := range []struct {
+		name   string
+		cursor string
+	}{
+		{"garbage", "not-a-cursor"},
+		{"legacy offset cursor", "NTA"}, // base64("50") — the pre-keyset format
+		{"wrong kind (seq)", encodeKeysetCursor(keysetCursor{Kind: cursorKindSeq, Seq: 9})},
+		{"v1 prefix, bad payload", "v1:!!!"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := getBeads(t, h, cityURL(state, "/beads?cursor=")+tc.cursor)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "invalid-cursor") {
+				t.Fatalf("body lacks the invalid-cursor code: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+func decodeListBody(t *testing.T, rec *httptest.ResponseRecorder) (items []beads.Bead, total int, next string) {
+	t.Helper()
+	var body struct {
+		Items      []beads.Bead `json:"items"`
+		Total      int          `json:"total"`
+		NextCursor string       `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Items, body.Total, body.NextCursor
+}
+
+// TestBeadListKeysetWalkNoSkipNoDup: walking pages while new beads are
+// created between requests sees every pre-walk bead exactly once. This is
+// the property offset cursors break (a new row shifts every offset).
+func TestBeadListKeysetWalkNoSkipNoDup(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	h := newTestCityHandler(t, state)
+
+	preWalk := map[string]bool{}
+	for i := 0; i < 23; i++ {
+		b, err := store.Create(beads.Bead{Title: "t", Status: "open"})
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		preWalk[b.ID] = true
+	}
+
+	seen := map[string]int{}
+	cursor := ""
+	pages := 0
+	for {
+		url := cityURL(state, "/beads?limit=7")
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		rec := getBeads(t, h, url)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: status = %d; body = %s", pages, rec.Code, rec.Body.String())
+		}
+		items, _, next := decodeListBody(t, rec)
+		for _, b := range items {
+			seen[b.ID]++
+		}
+		pages++
+		if pages > 20 {
+			t.Fatal("walk did not terminate")
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+		// Concurrent write between pages: newer than everything already
+		// walked, so it must not shift or duplicate any pre-walk row.
+		if _, err := store.Create(beads.Bead{Title: "mid-walk", Status: "open"}); err != nil {
+			t.Fatalf("mid-walk create: %v", err)
+		}
+	}
+
+	for id := range preWalk {
+		if seen[id] != 1 {
+			t.Errorf("pre-walk bead %s seen %d times, want exactly 1", id, seen[id])
+		}
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("bead %s duplicated across pages (%d times)", id, n)
+		}
+	}
+}
+
+// TestBeadListKeysetTruncationMintsCursor: a cursor-less truncated first page
+// still carries next_cursor (the #3208 guarantee), now as a v1 keyset token.
+func TestBeadListKeysetTruncationMintsCursor(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	h := newTestCityHandler(t, state)
+	for i := 0; i < 5; i++ {
+		if _, err := store.Create(beads.Bead{Title: "t", Status: "open"}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+
+	rec := getBeads(t, h, cityURL(state, "/beads?limit=2"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", rec.Code, rec.Body.String())
+	}
+	items, total, next := decodeListBody(t, rec)
+	if len(items) != 2 || total != 5 {
+		t.Fatalf("page = %d items / total %d, want 2 / 5", len(items), total)
+	}
+	if !strings.HasPrefix(next, "v1:") {
+		t.Fatalf("next_cursor = %q, want a v1 keyset token", next)
+	}
+	// The token must decode to the boundary of the last row served.
+	c, err := decodeKeysetCursor(next)
+	if err != nil || c.Kind != cursorKindCreatedID {
+		t.Fatalf("next_cursor decode = %+v, %v", c, err)
+	}
+	if c.ID != items[1].ID {
+		t.Fatalf("cursor boundary ID = %s, want last row %s", c.ID, items[1].ID)
+	}
+}
+
+// TestBeadListKeysetWalkAcrossZeroCreatedAtRows: degraded rows (NULL or
+// unparseable created_at from a drifted store) carry zero timestamps and sort
+// to the created-DESC tail. When a page cut lands among them, the server
+// mints a zero-CreatedAt boundary — and must accept it back on the next
+// request. A decoder that rejects its own token wedges the walk in a 400
+// loop and makes the tail permanently unreachable.
+func TestBeadListKeysetWalkAcrossZeroCreatedAtRows(t *testing.T) {
+	ts := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	seeded := []beads.Bead{
+		{ID: "gc-1", Title: "ok", Status: "open", CreatedAt: ts},
+		{ID: "gc-2", Title: "ok", Status: "open", CreatedAt: ts.Add(time.Second)},
+		{ID: "gc-3", Title: "ok", Status: "open", CreatedAt: ts.Add(2 * time.Second)},
+		// Degraded tail: zero CreatedAt.
+		{ID: "gc-z1", Title: "degraded", Status: "open"},
+		{ID: "gc-z2", Title: "degraded", Status: "open"},
+		{ID: "gc-z3", Title: "degraded", Status: "open"},
+		{ID: "gc-z4", Title: "degraded", Status: "open"},
+	}
+	state := newFakeState(t)
+	state.stores["myrig"] = beads.NewMemStoreFrom(100, seeded, nil)
+	h := newTestCityHandler(t, state)
+
+	seen := map[string]int{}
+	cursor := ""
+	pages := 0
+	for {
+		url := cityURL(state, "/beads?limit=5")
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		rec := getBeads(t, h, url)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: status = %d (a 400 here means the server rejected its own minted cursor); body = %s",
+				pages, rec.Code, rec.Body.String())
+		}
+		items, _, next := decodeListBody(t, rec)
+		for _, b := range items {
+			seen[b.ID]++
+		}
+		if pages++; pages > 5 {
+			t.Fatal("walk did not terminate")
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	if len(seen) != len(seeded) {
+		t.Fatalf("walk saw %d distinct rows, want %d (tail unreachable?)", len(seen), len(seeded))
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("row %s seen %d times, want 1", id, n)
+		}
+	}
+}
+
+// TestBeadListKeysetLastPageOmitsCursor: the final page has no next_cursor.
+func TestBeadListKeysetLastPageOmitsCursor(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	h := newTestCityHandler(t, state)
+	for i := 0; i < 3; i++ {
+		if _, err := store.Create(beads.Bead{Title: "t", Status: "open"}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	rec := getBeads(t, h, cityURL(state, "/beads?limit=10"))
+	items, total, next := decodeListBody(t, rec)
+	if len(items) != 3 || total != 3 || next != "" {
+		t.Fatalf("items=%d total=%d next=%q, want 3/3/empty", len(items), total, next)
+	}
+}

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -265,6 +265,13 @@ func resolveBeadListPage(all []beads.Bead, seek *beads.SeekBoundary, limit int, 
 		}
 		return page, total, hasMore
 	}
+	// Full-scan path: `all` is the COMPLETE un-seeked set read in one shot, so
+	// `end < len(all)` is the honest has-more. The bounded branch's
+	// partial→force-resume is intentionally NOT mirrored here: a full-scan
+	// request re-reads every rig un-seeked, so a degraded rig reproduces the
+	// same withheld rows on the next request and a resume cursor cannot recover
+	// them — unlike bounded mode, where each page is an independent per-rig
+	// bounded read that can recover on a later page (gascity#3253).
 	total = len(all)
 	start := 0
 	if seek != nil {
@@ -282,6 +289,14 @@ func resolveBeadListPage(all []beads.Bead, seek *beads.SeekBoundary, limit int, 
 // mintNextCursor returns the keyset continuation cursor for a truncated page:
 // the (created_at, id) boundary of the last row served. An exhausted or empty
 // page mints nothing, which the client reads as walk-complete.
+//
+// The resume key is (created_at, id) while the fan-out's identity key is
+// (rig, id): this assumes (created_at, id) is globally unique across the merged
+// rigs. That holds for distinct-store rigs; the only collision is the
+// documented legacy file-mode aliasing of the city and rig stores, where twins
+// would make the page boundary position-dependent (benign today — a true
+// duplicate). A future globally-non-unique ID scheme would need a wider resume
+// key here.
 func mintNextCursor(page []beads.Bead, hasMore bool) string {
 	if !hasMore || len(page) == 0 {
 		return ""

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -37,16 +37,10 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	// The cursor is a versioned keyset token carrying the (created_at, id)
 	// boundary of the last row served — stable under the concurrent writes an
 	// active work ledger guarantees, where the old integer offsets skipped or
-	// duplicated rows. Anything else (garbage, a legacy offset cursor, a
-	// wrong-kind token) is a typed 400; silently restarting at page 1 was the
-	// old failure mode and it duplicates rows.
-	var seek *beads.SeekBoundary
-	if input.Cursor != "" {
-		c, err := decodeKeysetCursor(input.Cursor)
-		if err != nil || c.Kind != cursorKindCreatedID {
-			return nil, apierr.InvalidCursor.Msg("cursor is not a valid pagination token; re-fetch the first page")
-		}
-		seek = &beads.SeekBoundary{CreatedAt: c.CreatedAt, ID: c.ID}
+	// duplicated rows.
+	seek, err := beadListSeek(input.Cursor)
+	if err != nil {
+		return nil, err
 	}
 
 	// all=true reads bypass the CachingStore (closed history lives only in
@@ -90,19 +84,22 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	// O(history) even though the caller only wants a recency-bounded page
 	// (gascity#3253). When every store can Count the query exactly, push the
 	// page bound down so each store returns only the rows this page needs and
-	// source Total from a hydration-free Count instead of len(full history) —
-	// the build collapses to O(limit) at the store boundary while the response
-	// shape (a created_at-desc prefix plus an accurate Total and next_cursor)
-	// is unchanged. Scoped to the single-assignee all=true hot path; if any
-	// store cannot Count the query, keep the full-scan path so Total and
-	// ordering stay correct (the Count fallback contract from #3211).
+	// source Total from a hydration-free Count instead of len(full history).
+	// This collapses the FIRST page (no seek boundary) to O(limit) at the store
+	// boundary via each backend's native LIMIT; a seeked cursor page disables
+	// that native limit and hydrates matching history before the Go-side seek
+	// filter (see query.SeekAfter), trading O(limit) fetches for exactness on a
+	// deep walk. The response shape (a created_at-desc prefix plus an accurate
+	// Total and next_cursor) is unchanged. Scoped to the single-assignee all=true
+	// hot path; if any store cannot Count the query, keep the full-scan path so
+	// Total and ordering stay correct (the Count fallback contract from #3211).
 	boundedMode := false
 	boundedFetch := 0
 	var boundedCounts map[string]int
 	if input.All && !dedupe && len(assigneeTerms) == 1 {
-		// limit+1: the keyset boundary is pushed into each store query, so a
-		// store returns only rows after the boundary — one extra row is the
-		// has-more signal (Counts are un-seeked totals and cannot tell).
+		// limit+1: the seek boundary rides on each store query and is enforced
+		// Go-side, so a store returns only rows after the boundary — one extra
+		// row is the has-more signal (Counts are un-seeked totals and cannot tell).
 		boundedFetch = limit + 1
 		boundedMode, boundedCounts = beadListBoundedTotal(ctx, stores, rigNames, assigneeTerms[0], input)
 	}
@@ -129,9 +126,14 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 			}
 			if boundedMode {
 				// Each store need only return enough rows to cover this page;
-				// the cross-rig merge below cuts the exact global prefix. The
-				// seek boundary rides down too, so the per-store fetch is
-				// O(limit) after the boundary instead of O(cursor depth).
+				// the cross-rig merge below cuts the exact global prefix. On the
+				// first page (seek == nil) the native LIMIT makes the per-store
+				// fetch O(limit). On a seeked cursor page the boundary is enforced
+				// Go-side (backends disable their native limit — see SeekAfter in
+				// query.go), so the store hydrates matching history and the fetch
+				// is O(matching history), not O(limit); the Go-side filter+sort+
+				// limit then cut the exact page. That is the deliberate price of a
+				// tie-break identical to the in-memory sort.
 				query.Limit = boundedFetch
 				query.SeekAfter = seek
 			}
@@ -198,60 +200,8 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	// carries the continuation cursor too, otherwise the remainder of a
 	// limit-bounded read is unfetchable by design (#3208). next_cursor is the
 	// keyset boundary of the last row served.
-	var page []beads.Bead
-	var total int
-	hasMore := false
-	if boundedMode {
-		// Total is the exact Count summed over the rigs whose List actually
-		// returned rows — the count of the whole (un-seeked) result set, so it
-		// stays constant across a walk. The stores already applied the seek
-		// boundary; the merged rows are the global page prefix plus the one
-		// extra has-more row from the limit+1 overfetch (gascity#3253).
-		for _, n := range boundedCounts {
-			total += n
-		}
-		if len(all) > limit {
-			hasMore = true
-			all = all[:limit]
-		}
-		page = all
-		// A degraded rig (partial-result read) can return fewer rows than it
-		// has, leaving the merged page short of the limit+1 has-more signal.
-		// Mint a resume cursor anyway on a non-empty partial page: the walk
-		// continues past the degradation instead of silently terminating
-		// while Total still advertises the full count. Termination is safe —
-		// the boundary strictly advances past every served row, and an empty
-		// page mints nothing.
-		if pa.partial() && len(page) > 0 {
-			hasMore = true
-		}
-	} else {
-		// Full-scan path: `all` holds the complete (un-seeked) result set in
-		// (created_at DESC, id DESC) order, so Total keeps its full-set
-		// meaning and the page after the boundary is a contiguous suffix.
-		total = len(all)
-		start := 0
-		if seek != nil {
-			for start < len(all) && !seek.After(all[start], beads.SortCreatedDesc) {
-				start++
-			}
-		}
-		end := start + limit
-		if end > len(all) {
-			end = len(all)
-		}
-		page = all[start:end]
-		hasMore = end < len(all)
-	}
-	var nextCursor string
-	if hasMore && len(page) > 0 {
-		last := page[len(page)-1]
-		nextCursor = encodeKeysetCursor(keysetCursor{
-			Kind:      cursorKindCreatedID,
-			CreatedAt: last.CreatedAt,
-			ID:        last.ID,
-		})
-	}
+	page, total, hasMore := resolveBeadListPage(all, seek, limit, boundedMode, boundedCounts, pa.partial())
+	nextCursor := mintNextCursor(page, hasMore)
 	if page == nil {
 		page = []beads.Bead{}
 	}
@@ -270,6 +220,78 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 		CacheAgeS: cacheAge,
 		Body:      body,
 	}, nil
+}
+
+// beadListSeek decodes the GET /v0/beads pagination cursor into a keyset seek
+// boundary. An empty cursor is first-page paging (nil boundary, no error). Any
+// other non-empty value — garbage, a legacy offset cursor, or a wrong-kind
+// token — is a typed 400 rather than a silent restart at page 1, which
+// duplicated rows under the old integer-offset scheme.
+func beadListSeek(cursor string) (*beads.SeekBoundary, error) {
+	if cursor == "" {
+		return nil, nil
+	}
+	c, err := decodeKeysetCursor(cursor)
+	if err != nil || c.Kind != cursorKindCreatedID {
+		return nil, apierr.InvalidCursor.Msg("cursor is not a valid pagination token; re-fetch the first page")
+	}
+	return &beads.SeekBoundary{CreatedAt: c.CreatedAt, ID: c.ID}, nil
+}
+
+// resolveBeadListPage cuts the response page, Total, and has-more flag from the
+// merged result set, which is already in the global (created_at DESC, id DESC)
+// order the store fan-out produced. It performs no I/O.
+//
+// In boundedMode `all` is the limit+1 overfetch prefix and boundedCounts holds
+// the exact per-rig un-seeked Counts, so Total is their sum (constant across a
+// walk) and the extra overfetched row is the has-more signal. A degraded
+// (partial) rig can fall short of that signal, so a non-empty partial page
+// force-mints a resume cursor to keep the walk going past the degradation
+// (gascity#3253). Otherwise `all` is the complete un-seeked set: Total is its
+// length and the page is the contiguous suffix strictly after the Go-side seek
+// boundary.
+func resolveBeadListPage(all []beads.Bead, seek *beads.SeekBoundary, limit int, boundedMode bool, boundedCounts map[string]int, partial bool) (page []beads.Bead, total int, hasMore bool) {
+	if boundedMode {
+		for _, n := range boundedCounts {
+			total += n
+		}
+		if len(all) > limit {
+			hasMore = true
+			all = all[:limit]
+		}
+		page = all
+		if partial && len(page) > 0 {
+			hasMore = true
+		}
+		return page, total, hasMore
+	}
+	total = len(all)
+	start := 0
+	if seek != nil {
+		for start < len(all) && !seek.After(all[start], beads.SortCreatedDesc) {
+			start++
+		}
+	}
+	end := start + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[start:end], total, end < len(all)
+}
+
+// mintNextCursor returns the keyset continuation cursor for a truncated page:
+// the (created_at, id) boundary of the last row served. An exhausted or empty
+// page mints nothing, which the client reads as walk-complete.
+func mintNextCursor(page []beads.Bead, hasMore bool) string {
+	if !hasMore || len(page) == 0 {
+		return ""
+	}
+	last := page[len(page)-1]
+	return encodeKeysetCursor(keysetCursor{
+		Kind:      cursorKindCreatedID,
+		CreatedAt: last.CreatedAt,
+		ID:        last.ID,
+	})
 }
 
 // beadListBoundedTotal returns the exact per-rig bead counts for the all=true

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -27,15 +27,26 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 		return nil, err
 	}
 
-	pp := pageParams{Limit: 50}
+	limit := defaultPaginationLimit
 	if input.Limit > 0 {
-		pp.Limit = input.Limit
-		if pp.Limit > maxPaginationLimit {
-			pp.Limit = maxPaginationLimit
+		limit = input.Limit
+		if limit > maxPaginationLimit {
+			limit = maxPaginationLimit
 		}
 	}
+	// The cursor is a versioned keyset token carrying the (created_at, id)
+	// boundary of the last row served — stable under the concurrent writes an
+	// active work ledger guarantees, where the old integer offsets skipped or
+	// duplicated rows. Anything else (garbage, a legacy offset cursor, a
+	// wrong-kind token) is a typed 400; silently restarting at page 1 was the
+	// old failure mode and it duplicates rows.
+	var seek *beads.SeekBoundary
 	if input.Cursor != "" {
-		pp.Offset = decodeCursor(input.Cursor)
+		c, err := decodeKeysetCursor(input.Cursor)
+		if err != nil || c.Kind != cursorKindCreatedID {
+			return nil, apierr.InvalidCursor.Msg("cursor is not a valid pagination token; re-fetch the first page")
+		}
+		seek = &beads.SeekBoundary{CreatedAt: c.CreatedAt, ID: c.ID}
 	}
 
 	// all=true reads bypass the CachingStore (closed history lives only in
@@ -89,7 +100,10 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	boundedFetch := 0
 	var boundedCounts map[string]int
 	if input.All && !dedupe && len(assigneeTerms) == 1 {
-		boundedFetch = pp.Offset + pp.Limit
+		// limit+1: the keyset boundary is pushed into each store query, so a
+		// store returns only rows after the boundary — one extra row is the
+		// has-more signal (Counts are un-seeked totals and cannot tell).
+		boundedFetch = limit + 1
 		boundedMode, boundedCounts = beadListBoundedTotal(ctx, stores, rigNames, assigneeTerms[0], input)
 	}
 
@@ -115,8 +129,11 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 			}
 			if boundedMode {
 				// Each store need only return enough rows to cover this page;
-				// the cross-rig merge below cuts the exact global prefix.
+				// the cross-rig merge below cuts the exact global prefix. The
+				// seek boundary rides down too, so the per-store fetch is
+				// O(limit) after the boundary instead of O(cursor depth).
 				query.Limit = boundedFetch
+				query.SeekAfter = seek
 			}
 			pa.attempt()
 			list, err := store.List(query)
@@ -177,33 +194,63 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 
 	index := s.latestIndex()
 	cacheAge := cacheAgeSeconds(cityStore)
-	// A non-cursor request is offset-0 paging: a truncated first page carries
-	// the continuation cursor too, otherwise the remainder of a limit-bounded
-	// read is unfetchable by design (#3208).
+	// A non-cursor request is first-page paging: a truncated first page
+	// carries the continuation cursor too, otherwise the remainder of a
+	// limit-bounded read is unfetchable by design (#3208). next_cursor is the
+	// keyset boundary of the last row served.
 	var page []beads.Bead
 	var total int
-	var nextCursor string
+	hasMore := false
 	if boundedMode {
 		// Total is the exact Count summed over the rigs whose List actually
-		// returned rows, not len(all) (which holds only the bounded prefix) and
-		// not the upfront count of every rig: a rig counted then dropped at List
-		// time is removed from boundedCounts above, so Total tracks reachable
-		// rows and next_cursor still points at the real remainder (gascity#3253).
+		// returned rows — the count of the whole (un-seeked) result set, so it
+		// stays constant across a walk. The stores already applied the seek
+		// boundary; the merged rows are the global page prefix plus the one
+		// extra has-more row from the limit+1 overfetch (gascity#3253).
 		for _, n := range boundedCounts {
 			total += n
 		}
-		if pp.Offset < len(all) {
-			end := pp.Offset + pp.Limit
-			if end > len(all) {
-				end = len(all)
-			}
-			page = all[pp.Offset:end]
+		if len(all) > limit {
+			hasMore = true
+			all = all[:limit]
 		}
-		if pp.Offset+pp.Limit < total {
-			nextCursor = encodeCursor(pp.Offset + pp.Limit)
+		page = all
+		// A degraded rig (partial-result read) can return fewer rows than it
+		// has, leaving the merged page short of the limit+1 has-more signal.
+		// Mint a resume cursor anyway on a non-empty partial page: the walk
+		// continues past the degradation instead of silently terminating
+		// while Total still advertises the full count. Termination is safe —
+		// the boundary strictly advances past every served row, and an empty
+		// page mints nothing.
+		if pa.partial() && len(page) > 0 {
+			hasMore = true
 		}
 	} else {
-		page, total, nextCursor = paginate(all, pp)
+		// Full-scan path: `all` holds the complete (un-seeked) result set in
+		// (created_at DESC, id DESC) order, so Total keeps its full-set
+		// meaning and the page after the boundary is a contiguous suffix.
+		total = len(all)
+		start := 0
+		if seek != nil {
+			for start < len(all) && !seek.After(all[start], beads.SortCreatedDesc) {
+				start++
+			}
+		}
+		end := start + limit
+		if end > len(all) {
+			end = len(all)
+		}
+		page = all[start:end]
+		hasMore = end < len(all)
+	}
+	var nextCursor string
+	if hasMore && len(page) > 0 {
+		last := page[len(page)-1]
+		nextCursor = encodeKeysetCursor(keysetCursor{
+			Kind:      cursorKindCreatedID,
+			CreatedAt: last.CreatedAt,
+			ID:        last.ID,
+		})
 	}
 	if page == nil {
 		page = []beads.Bead{}

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -2177,6 +2177,7 @@
               "urn:gascity:error:idempotency-in-flight",
               "urn:gascity:error:idempotency-mismatch",
               "urn:gascity:error:internal",
+              "urn:gascity:error:invalid-cursor",
               "urn:gascity:error:invalid-request",
               "urn:gascity:error:mail-not-found",
               "urn:gascity:error:method-not-allowed",
@@ -2222,6 +2223,7 @@
               "urn:gascity:error:idempotency-in-flight",
               "urn:gascity:error:idempotency-mismatch",
               "urn:gascity:error:internal",
+              "urn:gascity:error:invalid-cursor",
               "urn:gascity:error:invalid-request",
               "urn:gascity:error:mail-not-found",
               "urn:gascity:error:method-not-allowed",
@@ -21975,6 +21977,21 @@
                   "type": "integer"
                 }
               },
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
               }

--- a/internal/api/supervisor_city_routes.go
+++ b/internal/api/supervisor_city_routes.go
@@ -154,7 +154,9 @@ func (sm *SupervisorMux) registerCityRoutes() {
 	// the handler stamps through the apierr catalog. Mutations additionally declare
 	// 403 because the always-installed CSRF middleware (and read-only mode) reject
 	// a mutation with a 403 before the handler runs; reads never emit it.
-	cityGet(sm, "/beads", (*Server).humaHandleBeadList, errorStatuses(http.StatusNotFound, http.StatusServiceUnavailable))
+	// GET /beads also declares 400: an invalid pagination cursor is a typed
+	// invalid-cursor problem response, never a silent page-1 restart.
+	cityGet(sm, "/beads", (*Server).humaHandleBeadList, errorStatuses(http.StatusBadRequest, http.StatusNotFound, http.StatusServiceUnavailable))
 	cityGet(sm, "/beads/graph/{rootID}", (*Server).humaHandleBeadGraph, errorStatuses(http.StatusNotFound))
 	cityGet(sm, "/beads/ready", (*Server).humaHandleBeadReady, errorStatuses(http.StatusNotFound, http.StatusServiceUnavailable))
 	cityRegister(sm, huma.Operation{

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -2275,6 +2275,12 @@ func bdListRequiresClientLimit(query, serverQuery ListQuery, clientFilteredAssig
 	if len(serverQuery.Metadata) > 0 || !serverQuery.CreatedBefore.IsZero() || !serverQuery.UpdatedBefore.IsZero() {
 		return true
 	}
+	// bd cannot express the compound (created_at, id) seek boundary, so a
+	// bd-side limit would cut rows before the exact Go-side filter runs —
+	// fetch unbounded and let applyListQuery filter then limit.
+	if serverQuery.SeekAfter != nil {
+		return true
+	}
 	return false
 }
 
@@ -2376,10 +2382,14 @@ func isBdQueryUnsupported(err error) bool {
 }
 
 func canApplyWispsServerLimit(query ListQuery) bool {
+	// SeekAfter: bd query cannot express the compound (created_at, id)
+	// boundary, so a bd-side limit would cut rows before the exact Go-side
+	// filter runs — same class as CreatedBefore.
 	return (query.Sort == SortDefault || query.Sort == SortCreatedDesc) &&
 		query.CreatedBefore.IsZero() &&
 		query.UpdatedBefore.IsZero() &&
-		len(query.Metadata) == 0
+		len(query.Metadata) == 0 &&
+		query.SeekAfter == nil
 }
 
 func appendBdQueryClause(clauses []string, serverFilteredOnly bool, field, value string) ([]string, bool) {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -2275,9 +2275,10 @@ func bdListRequiresClientLimit(query, serverQuery ListQuery, clientFilteredAssig
 	if len(serverQuery.Metadata) > 0 || !serverQuery.CreatedBefore.IsZero() || !serverQuery.UpdatedBefore.IsZero() {
 		return true
 	}
-	// bd cannot express the compound (created_at, id) seek boundary, so a
-	// bd-side limit would cut rows before the exact Go-side filter runs —
-	// fetch unbounded and let applyListQuery filter then limit.
+	// bd list exposes no compound (created_at, id) seek flag; the boundary is
+	// resolved Go-side (identical tie-break to the in-memory sort), so a
+	// bd-side limit would cut rows before that filter runs — fetch unbounded
+	// and let applyListQuery filter then limit.
 	if serverQuery.SeekAfter != nil {
 		return true
 	}
@@ -2382,9 +2383,10 @@ func isBdQueryUnsupported(err error) bool {
 }
 
 func canApplyWispsServerLimit(query ListQuery) bool {
-	// SeekAfter: bd query cannot express the compound (created_at, id)
-	// boundary, so a bd-side limit would cut rows before the exact Go-side
-	// filter runs — same class as CreatedBefore.
+	// SeekAfter: the compound (created_at, id) boundary is resolved Go-side
+	// (identical tie-break to the in-memory sort), not via a bd query flag, so
+	// a bd-side limit would cut rows before that filter runs — same class as
+	// CreatedBefore.
 	return (query.Sort == SortDefault || query.Sort == SortCreatedDesc) &&
 		query.CreatedBefore.IsZero() &&
 		query.UpdatedBefore.IsZero() &&

--- a/internal/beads/doltlite_count.go
+++ b/internal/beads/doltlite_count.go
@@ -148,8 +148,9 @@ func doltliteCountSupported(query ListQuery) bool {
 	if !query.CreatedBefore.IsZero() || !query.UpdatedBefore.IsZero() {
 		return false
 	}
-	// The compound (created_at, id) seek boundary is applied with Go-side
-	// semantics a single COUNT cannot reproduce (same class as CreatedBefore).
+	// The compound (created_at, id) seek boundary is resolved Go-side (to keep
+	// the tie-break identical to the in-memory sort), which a single COUNT
+	// cannot reproduce (same class as CreatedBefore).
 	if query.SeekAfter != nil {
 		return false
 	}

--- a/internal/beads/doltlite_count.go
+++ b/internal/beads/doltlite_count.go
@@ -148,6 +148,11 @@ func doltliteCountSupported(query ListQuery) bool {
 	if !query.CreatedBefore.IsZero() || !query.UpdatedBefore.IsZero() {
 		return false
 	}
+	// The compound (created_at, id) seek boundary is applied with Go-side
+	// semantics a single COUNT cannot reproduce (same class as CreatedBefore).
+	if query.SeekAfter != nil {
+		return false
+	}
 	if query.Limit > 0 {
 		return false
 	}

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -807,6 +807,13 @@ func (s *DoltliteReadStore) queryIssuesOrderedInTables(query ListQuery, sets []d
 		if len(sets) > 1 {
 			tableLimit = 0
 		}
+		// A seek boundary is applied Go-side (filterDoltliteBeforeTimes) after
+		// this fetch; a SQL LIMIT cut before that filter would silently drop
+		// page rows, so seeked reads fetch unbounded and let the Go
+		// filter+sort+limit below cut the exact page.
+		if query.SeekAfter != nil {
+			tableLimit = 0
+		}
 		rows, err := s.queryIssueTable(query, tables, extraWhere, extraArgs, tableLimit, orderBy)
 		if err != nil {
 			return nil, err
@@ -848,7 +855,8 @@ func doltliteCanSelectBoundedTopN(query ListQuery, sets []doltliteTableSet, extr
 		query.ParentID == "" &&
 		len(query.Metadata) == 0 &&
 		query.CreatedBefore.IsZero() &&
-		query.UpdatedBefore.IsZero()
+		query.UpdatedBefore.IsZero() &&
+		query.SeekAfter == nil
 }
 
 // queryBoundedTopN resolves a bounded multi-table read by selecting the exact
@@ -1337,7 +1345,7 @@ func doltliteSQLiteTime(t time.Time) string {
 }
 
 func filterDoltliteBeforeTimes(rows []Bead, query ListQuery) []Bead {
-	if len(rows) == 0 || (query.CreatedBefore.IsZero() && query.UpdatedBefore.IsZero()) {
+	if len(rows) == 0 || (query.CreatedBefore.IsZero() && query.UpdatedBefore.IsZero() && query.SeekAfter == nil) {
 		return rows
 	}
 	out := rows[:0]
@@ -1346,6 +1354,12 @@ func filterDoltliteBeforeTimes(rows []Bead, query ListQuery) []Bead {
 			continue
 		}
 		if !query.UpdatedBefore.IsZero() && !beadUpdatedReferenceTime(row).Before(query.UpdatedBefore) {
+			continue
+		}
+		// Exact Go-side seek: SQL cannot express the compound
+		// (created_at, id) boundary, so the fetch above is a superset and
+		// this is where the page boundary is enforced (before the Go limit).
+		if query.SeekAfter != nil && !query.SeekAfter.After(row, query.Sort) {
 			continue
 		}
 		out = append(out, row)

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -1356,9 +1356,10 @@ func filterDoltliteBeforeTimes(rows []Bead, query ListQuery) []Bead {
 		if !query.UpdatedBefore.IsZero() && !beadUpdatedReferenceTime(row).Before(query.UpdatedBefore) {
 			continue
 		}
-		// Exact Go-side seek: SQL cannot express the compound
-		// (created_at, id) boundary, so the fetch above is a superset and
-		// this is where the page boundary is enforced (before the Go limit).
+		// Exact Go-side seek: the compound (created_at, id) boundary is
+		// resolved here rather than in SQL so the tie-break stays identical to
+		// the in-memory sort, so the fetch above is a superset and this is
+		// where the page boundary is enforced (before the Go limit).
 		if query.SeekAfter != nil && !query.SeekAfter.After(row, query.Sort) {
 			continue
 		}

--- a/internal/beads/doltlite_seek_test.go
+++ b/internal/beads/doltlite_seek_test.go
@@ -1,0 +1,59 @@
+//go:build gascity_native_beads
+
+package beads
+
+import (
+	"testing"
+	"time"
+)
+
+// The doltlite seek-safety gates: SQL cannot express the compound
+// (created_at, id) boundary, so every SQL-side row cut must be disabled for
+// seeked queries and the exact filter applied Go-side before the limit.
+
+func TestDoltliteBoundedTopNDisqualifiesSeek(t *testing.T) {
+	sets := []doltliteTableSet{doltliteIssueTables, doltliteWispTables}
+	base := ListQuery{Type: "task", Sort: SortCreatedDesc}
+	if !doltliteCanSelectBoundedTopN(base, sets, "", 10, "") {
+		t.Fatal("baseline bounded query should qualify for SQL top-N (test setup wrong)")
+	}
+	seeked := base
+	seeked.SeekAfter = &SeekBoundary{CreatedAt: time.Now(), ID: "gc-1"}
+	if doltliteCanSelectBoundedTopN(seeked, sets, "", 10, "") {
+		t.Fatal("seeked query must not take the SQL top-N path — the SQL LIMIT would cut before the boundary filter")
+	}
+}
+
+func TestDoltliteCountUnsupportedForSeek(t *testing.T) {
+	base := ListQuery{Type: "task"}
+	if !doltliteCountSupported(base) {
+		t.Fatal("baseline query should be countable (test setup wrong)")
+	}
+	seeked := base
+	seeked.SeekAfter = &SeekBoundary{CreatedAt: time.Now(), ID: "gc-1"}
+	if doltliteCountSupported(seeked) {
+		t.Fatal("seeked query must be count-unsupported — Count cannot reproduce the Go-side boundary")
+	}
+}
+
+func TestFilterDoltliteBeforeTimesAppliesSeek(t *testing.T) {
+	ts := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	rows := []Bead{
+		{ID: "gc-3", CreatedAt: ts.Add(2 * time.Second)}, // newer than boundary — drop
+		{ID: "gc-2", CreatedAt: ts},                      // boundary row — drop
+		{ID: "gc-1", CreatedAt: ts},                      // tie, smaller id — keep (after in DESC)
+		{ID: "gc-0", CreatedAt: ts.Add(-time.Second)},    // older — keep
+	}
+	q := ListQuery{
+		Sort:      SortCreatedDesc,
+		SeekAfter: &SeekBoundary{CreatedAt: ts, ID: "gc-2"},
+	}
+	out := filterDoltliteBeforeTimes(rows, q)
+	if len(out) != 2 || out[0].ID != "gc-1" || out[1].ID != "gc-0" {
+		ids := make([]string, len(out))
+		for i, b := range out {
+			ids[i] = b.ID
+		}
+		t.Fatalf("filtered = %v, want [gc-1 gc-0]", ids)
+	}
+}

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -345,7 +345,10 @@ func (s *Store) List(query beads.ListQuery) ([]beads.Bead, error) {
 		if query.Type != "" {
 			args = append(args, "--type="+query.Type)
 		}
-		if query.Limit > 0 && query.CreatedBefore.IsZero() {
+		// SeekAfter (like CreatedBefore) is applied Go-side after the script
+		// returns, so a script-side limit would cut rows before the boundary
+		// filter runs and silently skip page rows.
+		if query.Limit > 0 && query.CreatedBefore.IsZero() && query.SeekAfter == nil {
 			args = append(args, "--limit="+strconv.Itoa(query.Limit))
 		}
 		out, err = s.run(nil, args...)

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -1456,3 +1456,44 @@ esac
 		t.Fatalf("list args missing type filter: %s", argsText)
 	}
 }
+
+func TestListWithSeekAfterDoesNotForwardLimitBeforeClientFilter(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	script := writeScript(t, dir, `
+op="$1"
+shift
+case "$op" in
+  list)
+    printf '%s
+' "$*" > "`+argsFile+`"
+    echo '[]'
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	s := NewStore(script)
+
+	_, err := s.List(beads.ListQuery{
+		Type:  "task",
+		Sort:  beads.SortCreatedDesc,
+		Limit: 7,
+		SeekAfter: &beads.SeekBoundary{
+			CreatedAt: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+			ID:        "gc-9",
+		},
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	argsData, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("ReadFile(args): %v", err)
+	}
+	argsText := string(argsData)
+	// The script cannot express the compound (created_at, id) boundary; a
+	// script-side limit would cut rows before the Go-side seek filter runs.
+	if strings.Contains(argsText, "--limit=7") {
+		t.Fatalf("list args should not limit before seek filtering: %s", argsText)
+	}
+}

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -98,12 +98,30 @@ type ListQuery struct {
 	// TierMode selects the storage tier(s) to read from. Zero value
 	// (TierIssues) preserves the legacy single-tier behavior.
 	TierMode TierMode
+	// SeekAfter is an exclusive keyset boundary for cursor pagination: only
+	// rows STRICTLY AFTER the boundary in the query's sort order match. It
+	// requires an explicit Sort (Validate enforces this) because a seek
+	// without a total order is meaningless. Backends whose native query layer
+	// cannot express the compound (created_at, id) predicate must fall back
+	// to exact Go-side filtering via Matches BEFORE applying any row limit —
+	// applying a limit first silently drops rows from the page.
+	SeekAfter *SeekBoundary
+}
+
+// SeekBoundary identifies the last row a pagination client has seen, in the
+// (created_at, id) total order (#3208). The boundary row itself is excluded.
+type SeekBoundary struct {
+	CreatedAt time.Time
+	ID        string
 }
 
 // Validate returns an error when the query contains contradictory selectors.
 func (q ListQuery) Validate() error {
 	if q.Assignee != "" && len(q.Assignees) > 0 {
 		return errors.New("ListQuery: Assignee and Assignees are mutually exclusive")
+	}
+	if q.SeekAfter != nil && q.Sort != SortCreatedAsc && q.Sort != SortCreatedDesc {
+		return errors.New("ListQuery: SeekAfter requires an explicit created_at sort order")
 	}
 	return nil
 }
@@ -139,7 +157,8 @@ func (q ListQuery) HasFilter() bool {
 		q.ParentID != "" ||
 		len(q.Metadata) > 0 ||
 		!q.CreatedBefore.IsZero() ||
-		!q.UpdatedBefore.IsZero()
+		!q.UpdatedBefore.IsZero() ||
+		q.SeekAfter != nil
 }
 
 // IncludesClosed reports whether the query may return closed beads.
@@ -201,7 +220,33 @@ func (q ListQuery) Matches(b Bead) bool {
 	if !q.UpdatedBefore.IsZero() && !beadUpdatedReferenceTime(b).Before(q.UpdatedBefore) {
 		return false
 	}
+	if q.SeekAfter != nil && !q.SeekAfter.After(b, q.Sort) {
+		return false
+	}
 	return true
+}
+
+// After reports whether the bead sorts strictly after the boundary in the
+// given order — i.e. it belongs on a page that resumes from the boundary.
+// The comparison mirrors sortBeadsForQuery's (created_at, id) total order
+// exactly, id tie-break included, so a page boundary can never skip or
+// duplicate a row.
+func (sb *SeekBoundary) After(b Bead, sort SortOrder) bool {
+	switch sort {
+	case SortCreatedAsc:
+		if b.CreatedAt.After(sb.CreatedAt) {
+			return true
+		}
+		return b.CreatedAt.Equal(sb.CreatedAt) && b.ID > sb.ID
+	case SortCreatedDesc:
+		if b.CreatedAt.Before(sb.CreatedAt) {
+			return true
+		}
+		return b.CreatedAt.Equal(sb.CreatedAt) && b.ID < sb.ID
+	default:
+		// Validate rejects this shape; match nothing rather than guess.
+		return false
+	}
 }
 
 func beadUpdatedReferenceTime(b Bead) time.Time {

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -101,10 +101,13 @@ type ListQuery struct {
 	// SeekAfter is an exclusive keyset boundary for cursor pagination: only
 	// rows STRICTLY AFTER the boundary in the query's sort order match. It
 	// requires an explicit Sort (Validate enforces this) because a seek
-	// without a total order is meaningless. Backends whose native query layer
-	// cannot express the compound (created_at, id) predicate must fall back
-	// to exact Go-side filtering via Matches BEFORE applying any row limit —
-	// applying a limit first silently drops rows from the page.
+	// without a total order is meaningless. Every backend resolves the compound
+	// (created_at, id) boundary Go-side via Matches to keep the tie-break
+	// byte-identical to the in-memory sort — a SQL/CLI seek predicate is
+	// expressible but risks collation/precision divergence. Because the filter
+	// is Go-side, it must run BEFORE any native row limit — a limit applied
+	// first silently drops page rows — so seeked reads fetch a superset and cut
+	// the page in Go.
 	SeekAfter *SeekBoundary
 }
 
@@ -166,19 +169,24 @@ func (q ListQuery) IncludesClosed() bool {
 	return q.IncludeClosed || q.Status == "closed"
 }
 
-// Matches reports whether the bead satisfies the query.
-func (q ListQuery) Matches(b Bead) bool {
+// matchesTier reports whether the bead is in the storage tier(s) the query
+// selects. TierIssues (the zero value) excludes ephemeral wisps; TierWisps
+// keeps only ephemeral or no-history rows; TierBoth applies no tier filter.
+func (q ListQuery) matchesTier(b Bead) bool {
 	switch q.TierMode {
 	case TierWisps:
-		if !b.Ephemeral && !b.NoHistory {
-			return false
-		}
+		return b.Ephemeral || b.NoHistory
 	case TierBoth:
-		// no tier filter
+		return true
 	default: // TierIssues
-		if b.Ephemeral {
-			return false
-		}
+		return !b.Ephemeral
+	}
+}
+
+// Matches reports whether the bead satisfies the query.
+func (q ListQuery) Matches(b Bead) bool {
+	if !q.matchesTier(b) {
+		return false
 	}
 	if q.Status != "" {
 		if b.Status != q.Status {

--- a/internal/beads/query_seek_test.go
+++ b/internal/beads/query_seek_test.go
@@ -1,0 +1,235 @@
+package beads
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func seekQuery(sort SortOrder, at time.Time, id string) ListQuery {
+	return ListQuery{
+		AllowScan: true,
+		Sort:      sort,
+		SeekAfter: &SeekBoundary{CreatedAt: at, ID: id},
+	}
+}
+
+func TestSeekAfterDescKeepsStrictlyOlderRows(t *testing.T) {
+	b := time.Date(2026, 7, 11, 12, 0, 0, 500000000, time.UTC)
+	q := seekQuery(SortCreatedDesc, b, "gc-50")
+
+	for _, tc := range []struct {
+		name string
+		bead Bead
+		want bool
+	}{
+		{"older created_at", Bead{ID: "gc-99", Status: "open", CreatedAt: b.Add(-time.Second)}, true},
+		{"newer created_at", Bead{ID: "gc-1", Status: "open", CreatedAt: b.Add(time.Second)}, false},
+		{"boundary row itself", Bead{ID: "gc-50", Status: "open", CreatedAt: b}, false},
+		{"tie, smaller id (after in DESC id order)", Bead{ID: "gc-49", Status: "open", CreatedAt: b}, true},
+		{"tie, larger id (before boundary in DESC)", Bead{ID: "gc-51", Status: "open", CreatedAt: b}, false},
+		{"sub-second newer", Bead{ID: "gc-2", Status: "open", CreatedAt: b.Add(time.Millisecond)}, false},
+		{"sub-second older", Bead{ID: "gc-98", Status: "open", CreatedAt: b.Add(-time.Millisecond)}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := q.Matches(tc.bead); got != tc.want {
+				t.Fatalf("Matches(%s) = %v, want %v", tc.bead.ID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSeekAfterAscKeepsStrictlyNewerRows(t *testing.T) {
+	b := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	q := seekQuery(SortCreatedAsc, b, "gc-50")
+
+	for _, tc := range []struct {
+		name string
+		bead Bead
+		want bool
+	}{
+		{"newer created_at", Bead{ID: "gc-1", Status: "open", CreatedAt: b.Add(time.Second)}, true},
+		{"older created_at", Bead{ID: "gc-99", Status: "open", CreatedAt: b.Add(-time.Second)}, false},
+		{"boundary row itself", Bead{ID: "gc-50", Status: "open", CreatedAt: b}, false},
+		{"tie, larger id (after in ASC id order)", Bead{ID: "gc-51", Status: "open", CreatedAt: b}, true},
+		{"tie, smaller id", Bead{ID: "gc-49", Status: "open", CreatedAt: b}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := q.Matches(tc.bead); got != tc.want {
+				t.Fatalf("Matches(%s) = %v, want %v", tc.bead.ID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSeekAfterComposesWithOtherFilters(t *testing.T) {
+	b := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	q := seekQuery(SortCreatedDesc, b, "gc-50")
+	q.Type = "task"
+
+	older := b.Add(-time.Minute)
+	if q.Matches(Bead{ID: "gc-99", Status: "open", Type: "epic", CreatedAt: older}) {
+		t.Fatal("type filter must still apply alongside the seek")
+	}
+	if !q.Matches(Bead{ID: "gc-99", Status: "open", Type: "task", CreatedAt: older}) {
+		t.Fatal("matching type + after-boundary row must pass")
+	}
+}
+
+func TestSeekAfterRequiresExplicitSort(t *testing.T) {
+	q := seekQuery(SortDefault, time.Now(), "gc-1")
+	if err := q.Validate(); err == nil {
+		t.Fatal("SeekAfter with SortDefault must fail Validate — a seek without a total order is meaningless")
+	}
+	if err := seekQuery(SortCreatedDesc, time.Now(), "gc-1").Validate(); err != nil {
+		t.Fatalf("SeekAfter with explicit sort should validate: %v", err)
+	}
+}
+
+func TestSeekAfterCountsAsFilter(t *testing.T) {
+	q := ListQuery{SeekAfter: &SeekBoundary{CreatedAt: time.Now(), ID: "gc-1"}, Sort: SortCreatedDesc}
+	if !q.HasFilter() {
+		t.Fatal("SeekAfter must count as a filter so seek-only queries are not rejected as scans")
+	}
+}
+
+// TestSeekAfterWalkMemStoreNoSkipNoDup is the core correctness property: a
+// keyset walk sees every pre-walk row exactly once even when new rows are
+// inserted between pages (the scenario where offset cursors skip or
+// duplicate).
+func TestSeekAfterWalkMemStoreNoSkipNoDup(t *testing.T) {
+	runSeekWalk(t, NewMemStore())
+}
+
+// TestSeekAfterWalkCachingStoreNoSkipNoDup runs the same property through a
+// CachingStore (the production read path for open beads): the cache scan must
+// apply the boundary via Matches before its sort+truncate.
+func TestSeekAfterWalkCachingStoreNoSkipNoDup(t *testing.T) {
+	runSeekWalk(t, NewCachingStoreForTest(NewMemStore(), nil))
+}
+
+func runSeekWalk(t *testing.T, store Store) {
+	t.Helper()
+	var preWalk []string
+	for i := 0; i < 25; i++ {
+		b, err := store.Create(Bead{Title: "t", Status: "open"})
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		preWalk = append(preWalk, b.ID)
+	}
+
+	seen := map[string]int{}
+	var boundary *SeekBoundary
+	pages := 0
+	for {
+		q := ListQuery{AllowScan: true, Sort: SortCreatedDesc, Limit: 7, SeekAfter: boundary}
+		rows, err := store.List(q)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, r := range rows {
+			seen[r.ID]++
+		}
+		last := rows[len(rows)-1]
+		boundary = &SeekBoundary{CreatedAt: last.CreatedAt, ID: last.ID}
+		pages++
+		if pages > 20 {
+			t.Fatal("walk did not terminate")
+		}
+		// Insert new rows mid-walk: with created-DESC order they sort before
+		// the boundary and must NOT appear in subsequent pages, and must not
+		// displace any pre-walk row.
+		if _, err := store.Create(Bead{Title: "mid-walk", Status: "open"}); err != nil {
+			t.Fatalf("mid-walk create: %v", err)
+		}
+	}
+
+	for _, id := range preWalk {
+		if seen[id] != 1 {
+			t.Errorf("pre-walk bead %s seen %d times, want exactly 1", id, seen[id])
+		}
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("bead %s duplicated across pages (%d times)", id, n)
+		}
+	}
+}
+
+// TestSeekGatesForceClientSideLimit pins the store-safety gates: every
+// backend whose native query layer cannot express the compound
+// (created_at, id) boundary must fetch unbounded and filter Go-side.
+// Applying a native limit first silently drops page rows.
+func TestSeekGatesForceClientSideLimit(t *testing.T) {
+	seek := &SeekBoundary{CreatedAt: time.Now(), ID: "gc-1"}
+
+	base := ListQuery{Sort: SortCreatedDesc, Limit: 10, TierMode: TierBoth}
+	if bdListRequiresClientLimit(base, base, false) {
+		t.Fatal("baseline TierBoth query should allow bd-side limit (test setup wrong)")
+	}
+	seeked := base
+	seeked.SeekAfter = seek
+	if !bdListRequiresClientLimit(seeked, seeked, false) {
+		t.Fatal("bdListRequiresClientLimit must force client-side limit when SeekAfter is set")
+	}
+
+	wisps := ListQuery{Sort: SortCreatedDesc, Limit: 10}
+	if !canApplyWispsServerLimit(wisps) {
+		t.Fatal("baseline wisps query should allow the server limit (test setup wrong)")
+	}
+	wisps.SeekAfter = seek
+	if canApplyWispsServerLimit(wisps) {
+		t.Fatal("canApplyWispsServerLimit must reject seeked queries — bd query cannot express the boundary")
+	}
+}
+
+// TestSeekAfterWalkWithTiedCreatedAt: whole-second created_at ties are the
+// production norm on bd/doltlite (timestamps truncate to seconds). The id
+// tie-break must keep the walk exact when a page cuts mid-tie.
+func TestSeekAfterWalkWithTiedCreatedAt(t *testing.T) {
+	ts := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	var seeded []Bead
+	for i := 0; i < 17; i++ {
+		// Three distinct seconds, heavy ties inside each.
+		seeded = append(seeded, Bead{
+			ID:        fmt.Sprintf("gc-%02d", i),
+			Title:     "t",
+			Status:    "open",
+			CreatedAt: ts.Add(time.Duration(i%3) * time.Second),
+		})
+	}
+	store := NewMemStoreFrom(100, seeded, nil)
+
+	seen := map[string]int{}
+	var boundary *SeekBoundary
+	pages := 0
+	for {
+		rows, err := store.List(ListQuery{AllowScan: true, Sort: SortCreatedDesc, Limit: 4, SeekAfter: boundary})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, r := range rows {
+			seen[r.ID]++
+		}
+		last := rows[len(rows)-1]
+		boundary = &SeekBoundary{CreatedAt: last.CreatedAt, ID: last.ID}
+		if pages++; pages > 10 {
+			t.Fatal("walk did not terminate")
+		}
+	}
+	if len(seen) != len(seeded) {
+		t.Fatalf("walk saw %d distinct rows, want %d", len(seen), len(seeded))
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("row %s seen %d times, want 1 (tie-break skip/dup)", id, n)
+		}
+	}
+}


### PR DESCRIPTION
## What

S1 of **audit P1 #4 — stable keyset cursors + one pagination vocabulary**: replaces the
base64-offset pagination cursor on `GET /v0/beads` with a **versioned keyset token** and
makes invalid cursors a **typed 400** instead of a silent page-1 restart.

**Why**: offset cursors skip or duplicate rows whenever a concurrent write shifts the
result set — a guarantee on a live work ledger — and any garbage cursor silently
restarted the walk (duplicating rows). This is the audit's headline pagination
correctness bug.

## The contract

- `next_cursor` is now `v1:` + base64url(JSON) carrying the **(created_at, id) boundary**
  of the last row served. Opaque; clients change nothing (the envelope is unchanged).
- Invalid cursor (garbage, a **legacy offset token**, wrong kind) → **400 problem+json
  `urn:gascity:error:invalid-cursor`** (new catalog code; route declares 400). Blast
  radius ≈ 0: the dashboard never sends cursors; the only in-repo pager (`gc events`,
  a different endpoint anyway) holds one in-memory for a 30s loop.
- **Accept-what-you-mint**: a zero-CreatedAt boundary (degraded rows with NULL/unparseable
  `created_at` sort to the DESC tail) decodes fine — only the ID is required. Without
  this, a walk wedges in a 400 loop on a token the server itself issued (red-team major,
  pinned by an e2e walk over degraded rows).
- Walk semantics: `Total` keeps full-set meaning and stays constant across a walk; a
  **degraded (partial) page always carries a resume cursor** — the client gets a boundary
  instead of a silently terminated walk, and following it ends cleanly on an empty page.

## Store layer

`beads.ListQuery` grows `SeekAfter *SeekBoundary` — an exclusive compound boundary
interpreted against the explicit `Sort`, applied in `Matches` (id tie-break mirrors
`sortBeadsForQuery` exactly). **Boundary-before-limit on every backend** whose native
query layer can't express the compound predicate (applying a native limit first silently
drops page rows):

| backend | mechanism |
|---|---|
| MemStore / CachingStore | Matches-before-limit by construction |
| BdStore (both tiers) | `bdListRequiresClientLimit` + `canApplyWispsServerLimit` force unbounded fetch + Go-side filter/limit |
| exec.Store | script-side `--limit` withheld when seeking |
| doltlite (`gascity_native_beads`) | SQL bounded-top-N disqualified, per-table SQL LIMIT off, exact Go refilter before the limit cut; Count reports seek unsupported |

Known trade-off: seeked doltlite pages are O(matching history) until the SQL boundary
push-down lands (**ga-ylo6wr**; the whole-second sortKey truncation drift makes that a
careful change).

Handler: the bounded `all=true` path pushes the boundary into each store with
`Limit=limit+1` (the extra row is the has-more signal); the full-scan path keeps its
un-seeked fetch and suffix-slices after the boundary.

## Tests

Token round-trip + rejection matrix; seek predicate both directions (ties, sub-second
edges); **mid-walk no-skip/no-dup at three layers** (MemStore, CachingStore, API) with
concurrent inserts between pages; tied-created_at walk (whole-second ties are the
bd/doltlite norm); zero-CreatedAt tail walk; store-gate unit tests (bd, wisps, exec,
tagged doltlite). The two pre-existing bounded tests updated to the new contract
(limit+1 expectation; cursor-chain walks replacing offset jumps) — their original
intents (O(limit) push-down, failed-rig Total exclusion) still guarded.

Red-teamed pre-commit (5 lenses + adversarial verification, 18 agents, 12/13 findings
upheld): the zero-CreatedAt wedge, two residual limit-push holes (bd wisps, exec), the
degraded-walk termination, and the tie/coverage tests all came out of that review and
are fixed here.

## Scope

mail/convoys/sessions/events still speak offset cursors — they migrate in S2/S3 of this
track (convoys also needs a deterministic order first; events unifies on seq DESC). S4
adds the spec-walking dialect guard + limit schema visibility. Owner-signed decisions:
hard-400 old cursors, full S1–S4 program, grandfather legacy dialects.

Gates: gofmt/vet clean; full `internal/beads` (default + native tag), `internal/api`,
`exec`, genclient sync, dashboard-check all green. Tracking: `ga-q1rees`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
