### PR TITLE
fix(runtime): auto-accept Claude Code external-CLAUDE.md-import trust dialog

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -33,10 +33,11 @@ func StartupDialogTimeout() time.Duration {
 //  1. Claude resume selector — requires Down+Enter to resume the full session
 //  2. Codex update dialog ("Update available") — requires Down+Enter to skip
 //  3. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?")
-//  4. MCP trust dialog (Claude "New MCP server found in this project") — requires Down+Enter to trust all project MCP servers
-//  5. Codex hook review dialog — requires Down+Enter to trust hooks
-//  6. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
-//  7. Claude custom API key confirmation — requires Up+Enter to select "Yes"
+//  4. External CLAUDE.md imports dialog (Claude "Allow external CLAUDE.md file imports?") — requires Enter to allow (option 1 pre-selected)
+//  5. MCP trust dialog (Claude "New MCP server found in this project") — requires Down+Enter to trust all project MCP servers
+//  6. Codex hook review dialog — requires Down+Enter to trust hooks
+//  7. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
+//  8. Claude custom API key confirmation — requires Up+Enter to select "Yes"
 //
 // The peek function should return the last N lines of the session's terminal output.
 // The sendKeys function should send bare tmux-style keystrokes (e.g., "Enter", "Down").
@@ -104,6 +105,17 @@ func AcceptStartupDialogsFromStreamWithStatus(
 	phaseObserved, err = acceptWorkspaceTrustDialogFromStream(ctx, timeout, stream, trackingSendKeys)
 	if err != nil {
 		return observed, fmt.Errorf("workspace trust dialog: %w", err)
+	}
+	observed = observed || phaseObserved
+	if !phaseObserved && !observed {
+		return false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return observed, err
+	}
+	phaseObserved, err = acceptExternalImportsDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	if err != nil {
+		return observed, fmt.Errorf("external imports dialog: %w", err)
 	}
 	observed = observed || phaseObserved
 	if !phaseObserved && !observed {
@@ -202,6 +214,12 @@ func AcceptStartupDialogsWithTimeout(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if err := acceptExternalImportsDialog(ctx, timeout, peek, sendKeys); err != nil {
+		return fmt.Errorf("external imports dialog: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := acceptMCPTrustDialog(ctx, timeout, peek, sendKeys); err != nil {
 		return fmt.Errorf("mcp trust dialog: %w", err)
 	}
@@ -264,6 +282,7 @@ func acceptClaudeResumeDialog(
 		if containsPromptIndicator(content) ||
 			containsCodexUpdateDialog(content) ||
 			containsWorkspaceTrustDialog(content) ||
+			containsExternalImportsDialog(content) ||
 			containsMCPTrustDialog(content) ||
 			containsCodexHookReviewDialog(content) ||
 			strings.Contains(content, "Bypass Permissions mode") ||
@@ -301,6 +320,7 @@ func acceptClaudeResumeDialogFromStream(
 func containsPostClaudeResumeStartupDialog(content string) bool {
 	return containsCodexUpdateDialog(content) ||
 		containsWorkspaceTrustDialog(content) ||
+		containsExternalImportsDialog(content) ||
 		containsMCPTrustDialog(content) ||
 		containsCodexHookReviewDialog(content) ||
 		strings.Contains(content, "Bypass Permissions mode") ||
@@ -337,6 +357,7 @@ func acceptCodexUpdateDialog(
 
 		if containsPromptIndicator(content) ||
 			containsWorkspaceTrustDialog(content) ||
+			containsExternalImportsDialog(content) ||
 			containsMCPTrustDialog(content) ||
 			containsCodexHookReviewDialog(content) ||
 			strings.Contains(content, "Bypass Permissions mode") ||
@@ -373,6 +394,7 @@ func acceptCodexUpdateDialogFromStream(
 
 func containsPostUpdateStartupDialog(content string) bool {
 	return containsWorkspaceTrustDialog(content) ||
+		containsExternalImportsDialog(content) ||
 		containsMCPTrustDialog(content) ||
 		containsCodexHookReviewDialog(content) ||
 		strings.Contains(content, "Bypass Permissions mode") ||
@@ -413,7 +435,8 @@ func acceptWorkspaceTrustDialog(
 			return nil
 		}
 
-		if containsMCPTrustDialog(content) ||
+		if containsExternalImportsDialog(content) ||
+			containsMCPTrustDialog(content) ||
 			containsCodexHookReviewDialog(content) ||
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
@@ -449,6 +472,85 @@ func containsWorkspaceTrustDialog(content string) bool {
 }
 
 func containsPostTrustStartupDialog(content string) bool {
+	return containsExternalImportsDialog(content) ||
+		containsMCPTrustDialog(content) ||
+		containsCodexHookReviewDialog(content) ||
+		strings.Contains(content, "Bypass Permissions mode") ||
+		containsCustomAPIKeyDialog(content) ||
+		ContainsRateLimitDialog(content)
+}
+
+// acceptExternalImportsDialog dismisses Claude Code's "Allow external
+// CLAUDE.md file imports?" modal. It appears at startup when the project's
+// CLAUDE.md @-imports a file outside the current working directory (this fork's
+// CLAUDE.md imports ../AGENTS.md). A headless managed agent cannot answer it, so
+// gc accepts the pre-selected option 1, "Yes, allow external imports", with
+// Enter. The modal appears after workspace trust and before MCP server
+// discovery, so this runs after acceptWorkspaceTrustDialog. See Claude Code
+// v2.1.207.
+func acceptExternalImportsDialog(
+	ctx context.Context,
+	timeout time.Duration,
+	peek func(lines int) (string, error),
+	sendKeys func(keys ...string) error,
+) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		content, err := peek(startupDialogPeekLines)
+		if err != nil {
+			return err
+		}
+
+		if containsExternalImportsDialog(content) {
+			if err := sendKeys("Enter"); err != nil {
+				return err
+			}
+			sleep(ctx, startupDialogAcceptDelay)
+			return nil
+		}
+
+		if containsPromptIndicator(content) {
+			return nil
+		}
+
+		if containsMCPTrustDialog(content) ||
+			containsCodexHookReviewDialog(content) ||
+			strings.Contains(content, "Bypass Permissions mode") ||
+			containsCustomAPIKeyDialog(content) ||
+			ContainsRateLimitDialog(content) {
+			return nil
+		}
+
+		sleep(ctx, dialogPollInterval)
+	}
+	return nil
+}
+
+func acceptExternalImportsDialogFromStream(
+	ctx context.Context,
+	timeout time.Duration,
+	snapshots *replayableSnapshotCursor,
+	sendKeys func(keys ...string) error,
+) (bool, error) {
+	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
+		match:       containsExternalImportsDialog,
+		matchKeys:   []string{"Enter"},
+		matchDelay:  startupDialogAcceptDelay,
+		ready:       containsPromptIndicator,
+		readyOrNext: containsPostExternalImportsStartupDialog,
+	})
+}
+
+func containsExternalImportsDialog(content string) bool {
+	return strings.Contains(content, "Allow external CLAUDE.md") &&
+		strings.Contains(content, "allow external imports")
+}
+
+func containsPostExternalImportsStartupDialog(content string) bool {
 	return containsMCPTrustDialog(content) ||
 		containsCodexHookReviewDialog(content) ||
 		strings.Contains(content, "Bypass Permissions mode") ||

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +29,39 @@ func StartupDialogTimeout() time.Duration {
 	return dialogPollTimeout
 }
 
+// StartupDialogOption configures optional policy for the startup-dialog helpers.
+// Options are variadic so existing callers stay source-compatible.
+type StartupDialogOption func(*startupDialogConfig)
+
+// startupDialogConfig holds resolved optional startup-dialog policy.
+type startupDialogConfig struct {
+	// trustedImportRoot gates auto-acceptance of the "Allow external CLAUDE.md
+	// file imports?" modal. When set, only imports within this first-party
+	// workspace tree are accepted automatically; when empty the modal is left
+	// for a human. See externalImportsTrusted.
+	trustedImportRoot string
+}
+
+// WithTrustedImportRoot restricts external-CLAUDE.md-import auto-acceptance to
+// imports that resolve within dir, the root of the repository the session runs
+// in (resolve it with WorkspaceImportTrustRoot). Without it, the external-imports
+// modal is left unaccepted so a human can decide, because auto-accepting imports
+// from outside the repository would trust files the worker was never meant to
+// read.
+func WithTrustedImportRoot(dir string) StartupDialogOption {
+	return func(c *startupDialogConfig) { c.trustedImportRoot = dir }
+}
+
+func newStartupDialogConfig(opts []StartupDialogOption) startupDialogConfig {
+	var cfg startupDialogConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}
+
 // AcceptStartupDialogs dismisses startup dialogs that can block automated
 // sessions. Handles (in order):
 //  1. Claude resume selector — requires Down+Enter to resume the full session
@@ -47,8 +81,9 @@ func AcceptStartupDialogs(
 	ctx context.Context,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
+	opts ...StartupDialogOption,
 ) error {
-	return AcceptStartupDialogsWithTimeout(ctx, dialogPollTimeout, peek, sendKeys)
+	return AcceptStartupDialogsWithTimeout(ctx, dialogPollTimeout, peek, sendKeys, opts...)
 }
 
 // AcceptStartupDialogsFromStream dismisses known startup dialogs using an
@@ -58,8 +93,9 @@ func AcceptStartupDialogsFromStream(
 	timeout time.Duration,
 	snapshots <-chan string,
 	sendKeys func(keys ...string) error,
+	opts ...StartupDialogOption,
 ) error {
-	_, err := AcceptStartupDialogsFromStreamWithStatus(ctx, timeout, snapshots, sendKeys)
+	_, err := AcceptStartupDialogsFromStreamWithStatus(ctx, timeout, snapshots, sendKeys, opts...)
 	return err
 }
 
@@ -71,7 +107,9 @@ func AcceptStartupDialogsFromStreamWithStatus(
 	timeout time.Duration,
 	snapshots <-chan string,
 	sendKeys func(keys ...string) error,
+	opts ...StartupDialogOption,
 ) (bool, error) {
+	cfg := newStartupDialogConfig(opts)
 	stream := newReplayableSnapshotCursor(snapshots)
 	observed := false
 	handledDialog := false
@@ -113,7 +151,7 @@ func AcceptStartupDialogsFromStreamWithStatus(
 	if err := ctx.Err(); err != nil {
 		return observed, err
 	}
-	phaseObserved, err = acceptExternalImportsDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	phaseObserved, err = acceptExternalImportsDialogFromStream(ctx, timeout, stream, trackingSendKeys, cfg.trustedImportRoot)
 	if err != nil {
 		return observed, fmt.Errorf("external imports dialog: %w", err)
 	}
@@ -195,7 +233,9 @@ func AcceptStartupDialogsWithTimeout(
 	timeout time.Duration,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
+	opts ...StartupDialogOption,
 ) error {
+	cfg := newStartupDialogConfig(opts)
 	if err := acceptClaudeResumeDialog(ctx, timeout, peek, sendKeys); err != nil {
 		return fmt.Errorf("claude resume dialog: %w", err)
 	}
@@ -214,7 +254,7 @@ func AcceptStartupDialogsWithTimeout(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptExternalImportsDialog(ctx, timeout, peek, sendKeys); err != nil {
+	if err := acceptExternalImportsDialog(ctx, timeout, peek, sendKeys, cfg.trustedImportRoot); err != nil {
 		return fmt.Errorf("external imports dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
@@ -488,11 +528,19 @@ func containsPostTrustStartupDialog(content string) bool {
 // Enter. The modal appears after workspace trust and before MCP server
 // discovery, so this runs after acceptWorkspaceTrustDialog. See Claude Code
 // v2.1.207.
+//
+// Auto-acceptance is gated on trustedRoot (the worker's repository root): only
+// imports that resolve inside it are accepted (see externalImportsTrusted). The
+// modal warns not to allow external imports for third-party repositories, so an
+// import that escapes the repository, or one that cannot be verified, is left
+// unaccepted for a human rather than pressing Enter on files outside the
+// repository. An empty trustedRoot trusts nothing.
 func acceptExternalImportsDialog(
 	ctx context.Context,
 	timeout time.Duration,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
+	trustedRoot string,
 ) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -505,7 +553,7 @@ func acceptExternalImportsDialog(
 			return err
 		}
 
-		if containsExternalImportsDialog(content) {
+		if containsExternalImportsDialog(content) && externalImportsTrusted(content, trustedRoot) {
 			if err := sendKeys("Enter"); err != nil {
 				return err
 			}
@@ -535,9 +583,12 @@ func acceptExternalImportsDialogFromStream(
 	timeout time.Duration,
 	snapshots *replayableSnapshotCursor,
 	sendKeys func(keys ...string) error,
+	trustedRoot string,
 ) (bool, error) {
 	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
-		match:       containsExternalImportsDialog,
+		match: func(content string) bool {
+			return containsExternalImportsDialog(content) && externalImportsTrusted(content, trustedRoot)
+		},
 		matchKeys:   []string{"Enter"},
 		matchDelay:  startupDialogAcceptDelay,
 		ready:       containsPromptIndicator,
@@ -556,6 +607,116 @@ func containsPostExternalImportsStartupDialog(content string) bool {
 		strings.Contains(content, "Bypass Permissions mode") ||
 		containsCustomAPIKeyDialog(content) ||
 		ContainsRateLimitDialog(content)
+}
+
+// externalImportsTrusted reports whether every path listed in the "Allow
+// external CLAUDE.md file imports?" modal is a first-party file inside
+// trustRoot, the root of the repository the worker runs in (see
+// WorkspaceImportTrustRoot). The modal fires because a project CLAUDE.md
+// @-imports a file outside the working directory — for this fork, the
+// repository's own AGENTS.md, which a worktree subdirectory sees as external.
+// That file still lives inside the repository root, so it is first-party; an
+// import that escapes the repository root (a sibling repo, a parent directory, a
+// home or system path) is not, and neither is an in-root path that descends
+// through a repository metadata or runtime directory such as .git or .gc (see
+// importPathFirstParty). An empty trustRoot, or a modal with no parseable import
+// path, trusts nothing so a human decides.
+func externalImportsTrusted(content, trustRoot string) bool {
+	if strings.TrimSpace(trustRoot) == "" {
+		return false
+	}
+	imports := parseExternalImportPaths(content)
+	if len(imports) == 0 {
+		return false
+	}
+	for _, importPath := range imports {
+		if !importPathFirstParty(importPath, trustRoot) {
+			return false
+		}
+	}
+	return true
+}
+
+// parseExternalImportPaths returns the absolute filesystem paths the external
+// imports modal lists under its "External imports:" header. Each import renders
+// on its own line; collection stops at the first blank line after a path or at
+// the first non-absolute line (the trailing guidance text or numbered options).
+func parseExternalImportPaths(content string) []string {
+	const header = "External imports:"
+	idx := strings.Index(content, header)
+	if idx < 0 {
+		return nil
+	}
+	var paths []string
+	for _, line := range strings.Split(content[idx+len(header):], "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if len(paths) > 0 {
+				break
+			}
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "/") {
+			break
+		}
+		paths = append(paths, trimmed)
+	}
+	return paths
+}
+
+// pathWithinTrustRoot reports whether importPath resolves inside (or equal to)
+// trustRoot. Both are cleaned before comparison and the prefix test is
+// path-segment aware, so "/a/b" never matches "/a/bc" and a "../" escape is
+// rejected after cleaning. Only absolute paths are trusted; anything else (a
+// "~"-relative or truncated path) fails closed.
+func pathWithinTrustRoot(importPath, trustRoot string) bool {
+	if !strings.HasPrefix(importPath, "/") {
+		return false
+	}
+	root := filepath.Clean(trustRoot)
+	imp := filepath.Clean(importPath)
+	if !filepath.IsAbs(root) || !filepath.IsAbs(imp) {
+		return false
+	}
+	return isPathPrefix(root, imp)
+}
+
+// importPathFirstParty reports whether importPath is a first-party instruction
+// file the worker may auto-import. The path must resolve inside trustRoot (see
+// pathWithinTrustRoot) AND must not descend through a repository metadata or
+// runtime directory. Any component that is a hidden ("dot") directory relative
+// to the root — VCS metadata such as .git, Gas City runtime state such as .gc,
+// or per-tool caches such as .claude — is refused, because a PR-controlled
+// CLAUDE.md could otherwise auto-import repository-internal state (for example
+// .git/config, which can hold remote credentials) instead of a genuine
+// instruction file. Those imports fail closed and are left for a human.
+func importPathFirstParty(importPath, trustRoot string) bool {
+	if !pathWithinTrustRoot(importPath, trustRoot) {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(trustRoot), filepath.Clean(importPath))
+	if err != nil {
+		return false
+	}
+	for _, segment := range strings.Split(rel, string(filepath.Separator)) {
+		if strings.HasPrefix(segment, ".") {
+			return false
+		}
+	}
+	return true
+}
+
+// isPathPrefix reports whether ancestor equals descendant or is a
+// path-segment-boundary prefix of it.
+func isPathPrefix(ancestor, descendant string) bool {
+	if ancestor == descendant {
+		return true
+	}
+	sep := string(filepath.Separator)
+	if !strings.HasSuffix(ancestor, sep) {
+		ancestor += sep
+	}
+	return strings.HasPrefix(descendant, ancestor)
 }
 
 // acceptMCPTrustDialog dismisses Claude Code's project-MCP trust modal

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -437,6 +437,105 @@ func TestAcceptStartupDialogsFromStreamAcceptsMCPTrustDialog(t *testing.T) {
 	}
 }
 
+func TestContainsExternalImportsDialog(t *testing.T) {
+	t.Parallel()
+
+	if !containsExternalImportsDialog(externalImportsDialogFixture()) {
+		t.Error("containsExternalImportsDialog should match the external imports modal")
+	}
+	if containsExternalImportsDialog(mcpTrustDialogFixture()) {
+		t.Error("containsExternalImportsDialog should not match the MCP trust dialog")
+	}
+	if containsExternalImportsDialog("Do you trust the contents of this directory?") {
+		t.Error("containsExternalImportsDialog should not match the workspace trust dialog")
+	}
+	if containsExternalImportsDialog("› Implement {feature}") {
+		t.Error("containsExternalImportsDialog should not match a ready prompt")
+	}
+}
+
+func TestAcceptStartupDialogsAcceptsExternalImportsDialog(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) {
+			if len(sent) == 0 {
+				return externalImportsDialogFixture(), nil
+			}
+			return "› Implement {feature}", nil
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
+func TestAcceptStartupDialogsHandlesTrustThenExternalImportsThenMCP(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) {
+			switch len(sent) {
+			case 0:
+				return "Do you trust the contents of this directory?", nil
+			case 1:
+				return externalImportsDialogFixture(), nil
+			case 2:
+				return mcpTrustDialogFixture(), nil
+			default:
+				return "› Implement {feature}", nil
+			}
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Enter,Enter,Down,Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
+func TestAcceptStartupDialogsFromStreamAcceptsExternalImportsDialog(t *testing.T) {
+	var sent []string
+	snapshots := make(chan string, 2)
+	snapshots <- externalImportsDialogFixture()
+	snapshots <- "› Implement {feature}"
+	close(snapshots)
+
+	err := AcceptStartupDialogsFromStream(
+		context.Background(),
+		time.Second,
+		snapshots,
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
 func TestAcceptStartupDialogsFromStreamSkipsCodexUpdateDialog(t *testing.T) {
 	var sent []string
 	snapshots := make(chan string, 2)
@@ -867,6 +966,17 @@ func mcpTrustDialogFixture() string {
 		"❯ 1. Use this MCP server\n" +
 		"  2. Use this and all future MCP servers in this project\n" +
 		"  3. Continue without using this MCP server\n" +
+		"Enter to confirm · Esc to cancel"
+}
+
+func externalImportsDialogFixture() string {
+	return "Allow external CLAUDE.md file imports?\n" +
+		"This project's CLAUDE.md imports files outside the current working directory. Never allow this for third-party repositories.\n" +
+		"External imports:\n" +
+		"  /data/projects/gascity/AGENTS.md\n" +
+		"Important: Only use Claude Code with files you trust...\n" +
+		"❯ 1. Yes, allow external imports\n" +
+		"  2. No, disable external imports\n" +
 		"Enter to confirm · Esc to cancel"
 }
 

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -454,6 +454,134 @@ func TestContainsExternalImportsDialog(t *testing.T) {
 	}
 }
 
+func TestParseExternalImportPaths(t *testing.T) {
+	t.Parallel()
+
+	got := parseExternalImportPaths(externalImportsDialogFixture())
+	want := []string{"/data/projects/gascity/AGENTS.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseExternalImportPaths = %v, want %v", got, want)
+	}
+
+	if got := parseExternalImportPaths(mcpTrustDialogFixture()); len(got) != 0 {
+		t.Fatalf("parseExternalImportPaths on unrelated modal = %v, want none", got)
+	}
+
+	multi := "External imports:\n" +
+		"  /data/projects/gascity/AGENTS.md\n" +
+		"  /data/projects/gascity/docs/CLAUDE.md\n" +
+		"Important: only use files you trust\n"
+	if got, want := parseExternalImportPaths(multi),
+		[]string{"/data/projects/gascity/AGENTS.md", "/data/projects/gascity/docs/CLAUDE.md"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseExternalImportPaths(multi) = %v, want %v", got, want)
+	}
+}
+
+func TestPathWithinTrustRoot(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		importPath string
+		trustRoot  string
+		want       bool
+	}{
+		{"repo-root file inside root", "/data/projects/gascity/AGENTS.md", "/data/projects/gascity", true},
+		{"nested file inside root", "/data/projects/gascity/docs/CLAUDE.md", "/data/projects/gascity", true},
+		{"import equals root", "/data/projects/gascity", "/data/projects/gascity", true},
+		{"parent-directory file is not trusted", "/data/projects/secrets.md", "/data/projects/gascity", false},
+		{"grandparent file is not trusted", "/data/secrets.md", "/data/projects/gascity", false},
+		{"sibling prefix is not trusted", "/data/projects/gascity-evil/CLAUDE.md", "/data/projects/gascity", false},
+		{"unrelated third-party path", "/home/attacker/repo/CLAUDE.md", "/data/projects/gascity", false},
+		{"dot-dot traversal is cleaned then rejected", "/data/projects/gascity/../secrets.md", "/data/projects/gascity", false},
+		{"relative import path rejected", "relative/CLAUDE.md", "/data/projects/gascity", false},
+		{"tilde import path rejected", "~/secrets/CLAUDE.md", "/data/projects/gascity", false},
+		{"empty root rejects", "/data/projects/gascity/AGENTS.md", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := pathWithinTrustRoot(tc.importPath, tc.trustRoot); got != tc.want {
+				t.Fatalf("pathWithinTrustRoot(%q, %q) = %v, want %v", tc.importPath, tc.trustRoot, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExternalImportsTrusted(t *testing.T) {
+	t.Parallel()
+
+	if !externalImportsTrusted(externalImportsDialogFixture(), trustedImportRootFixture) {
+		t.Error("first-party import within an enclosing repo should be trusted")
+	}
+	if externalImportsTrusted(externalImportsDialogFixture(), "/tmp/other/wt") {
+		t.Error("import outside the trust root must not be trusted")
+	}
+	if externalImportsTrusted(externalImportsDialogFixture(), "") {
+		t.Error("empty trust root must trust nothing")
+	}
+	// A modal with no parseable "External imports:" list is unverifiable and
+	// must fail closed even when a trust root is supplied.
+	if externalImportsTrusted("Allow external CLAUDE.md ... allow external imports", trustedImportRootFixture) {
+		t.Error("unparseable import list must not be trusted")
+	}
+	// If any listed import escapes the trust root, the whole modal is untrusted.
+	mixed := "Allow external CLAUDE.md file imports?\nallow external imports\n" +
+		"External imports:\n" +
+		"  /data/projects/gascity/AGENTS.md\n" +
+		"  /home/attacker/evil.md\n"
+	if externalImportsTrusted(mixed, trustedImportRootFixture) {
+		t.Error("a single untrusted import must make the modal untrusted")
+	}
+	// An in-root import that points at repository metadata or runtime state
+	// (.git, .gc) is not a first-party instruction file and must fail closed,
+	// even though it resolves inside the trust root.
+	for _, runtimePath := range []string{
+		"/data/projects/gascity/.git/config",
+		"/data/projects/gascity/.gc/worktrees/other/CLAUDE.md",
+	} {
+		modal := "Allow external CLAUDE.md file imports?\nallow external imports\n" +
+			"External imports:\n  " + runtimePath + "\n"
+		if externalImportsTrusted(modal, trustedImportRootFixture) {
+			t.Errorf("import of repository runtime path %q must not be trusted", runtimePath)
+		}
+	}
+}
+
+func TestImportPathFirstParty(t *testing.T) {
+	t.Parallel()
+
+	const root = "/data/projects/gascity"
+	cases := []struct {
+		name       string
+		importPath string
+		want       bool
+	}{
+		{"repo-root AGENTS.md is first-party", root + "/AGENTS.md", true},
+		{"repo-root CLAUDE.md is first-party", root + "/CLAUDE.md", true},
+		{"nested instruction file is first-party", root + "/docs/CLAUDE.md", true},
+		{"git config is refused", root + "/.git/config", false},
+		{"nested git metadata is refused", root + "/.git/hooks/pre-commit", false},
+		{"gc runtime state is refused", root + "/.gc/worktrees/other/CLAUDE.md", false},
+		{"hidden tool cache is refused", root + "/.claude/settings.json", false},
+		{"hidden file at root is refused", root + "/.env", false},
+		{"path outside the root is refused", "/data/projects/secrets.md", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := importPathFirstParty(tc.importPath, root); got != tc.want {
+				t.Fatalf("importPathFirstParty(%q, %q) = %v, want %v", tc.importPath, root, got, tc.want)
+			}
+		})
+	}
+}
+
+// trustedImportRootFixture is the repository root that contains the external
+// import in externalImportsDialogFixture (/data/projects/gascity/AGENTS.md), so
+// the import is first-party and auto-acceptance is allowed.
+const trustedImportRootFixture = "/data/projects/gascity"
+
 func TestAcceptStartupDialogsAcceptsExternalImportsDialog(t *testing.T) {
 	withZeroDialogTimings(t)
 	dialogPollTimeout = time.Second
@@ -471,12 +599,58 @@ func TestAcceptStartupDialogsAcceptsExternalImportsDialog(t *testing.T) {
 			sent = append(sent, keys...)
 			return nil
 		},
+		WithTrustedImportRoot(trustedImportRootFixture),
 	)
 	if err != nil {
 		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
 	}
 	if got, want := strings.Join(sent, ","), "Enter"; got != want {
 		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
+func TestAcceptStartupDialogsLeavesUntrustedExternalImportsDialog(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = 200 * time.Millisecond
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) { return externalImportsDialogFixture(), nil },
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+		// A third-party worktree unrelated to the imported path: the modal must
+		// be left unaccepted rather than pressing Enter on external files.
+		WithTrustedImportRoot("/tmp/some-third-party-repo/wt"),
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if len(sent) != 0 {
+		t.Fatalf("sent keys = %v, want none (untrusted external import must not be accepted)", sent)
+	}
+}
+
+func TestAcceptStartupDialogsLeavesExternalImportsWithoutTrustRoot(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = 200 * time.Millisecond
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) { return externalImportsDialogFixture(), nil },
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if len(sent) != 0 {
+		t.Fatalf("sent keys = %v, want none (no trust root configured)", sent)
 	}
 }
 
@@ -503,6 +677,7 @@ func TestAcceptStartupDialogsHandlesTrustThenExternalImportsThenMCP(t *testing.T
 			sent = append(sent, keys...)
 			return nil
 		},
+		WithTrustedImportRoot(trustedImportRootFixture),
 	)
 	if err != nil {
 		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
@@ -527,11 +702,71 @@ func TestAcceptStartupDialogsFromStreamAcceptsExternalImportsDialog(t *testing.T
 			sent = append(sent, keys...)
 			return nil
 		},
+		WithTrustedImportRoot(trustedImportRootFixture),
 	)
 	if err != nil {
 		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
 	}
 	if got, want := strings.Join(sent, ","), "Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
+func TestAcceptStartupDialogsFromStreamLeavesUntrustedExternalImportsDialog(t *testing.T) {
+	var sent []string
+	snapshots := make(chan string, 2)
+	snapshots <- externalImportsDialogFixture()
+	snapshots <- "› Implement {feature}"
+	close(snapshots)
+
+	err := AcceptStartupDialogsFromStream(
+		context.Background(),
+		200*time.Millisecond,
+		snapshots,
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+		// A third-party worktree unrelated to the imported path.
+		WithTrustedImportRoot("/tmp/some-third-party-repo/wt"),
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
+	}
+	if len(sent) != 0 {
+		t.Fatalf("sent keys = %v, want none (untrusted external import must not be accepted)", sent)
+	}
+}
+
+// TestAcceptStartupDialogsFromStreamHandlesTrustThenExternalImportsThenMCP
+// mirrors the poll-path ordering test on the stream path: workspace-trust yields
+// to the external-imports phase (via post-trust snapshots) and then to MCP trust.
+// It guards the containsExternalImportsDialog entry in
+// containsPostTrustStartupDialog so a future edit cannot silently drop the
+// post-trust stream handoff into the new phase.
+func TestAcceptStartupDialogsFromStreamHandlesTrustThenExternalImportsThenMCP(t *testing.T) {
+	var sent []string
+	snapshots := make(chan string, 4)
+	snapshots <- "Do you trust the contents of this directory?"
+	snapshots <- externalImportsDialogFixture()
+	snapshots <- mcpTrustDialogFixture()
+	snapshots <- "› Implement {feature}"
+	close(snapshots)
+
+	err := AcceptStartupDialogsFromStream(
+		context.Background(),
+		time.Second,
+		snapshots,
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+		WithTrustedImportRoot(trustedImportRootFixture),
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Enter,Enter,Down,Enter"; got != want {
 		t.Fatalf("sent keys = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/exec/exec.go
+++ b/internal/runtime/exec/exec.go
@@ -231,6 +231,10 @@ func (p *Provider) dismissStartupDialogs(ctx context.Context, name string, cfg r
 	}
 
 	dialogTimeout := runtime.StartupDialogTimeout()
+	// Gate external-CLAUDE.md-import auto-acceptance to imports within this
+	// session's own repository; an import that escapes the repo (a third-party
+	// or system path) is left for a human rather than auto-trusted.
+	trustRoot := runtime.WithTrustedImportRoot(runtime.WorkspaceImportTrustRoot(ctx, cfg.WorkDir))
 	snapshots, closeWatch, ok, err := p.startStartupWatch(ctx, name, startupWatchFirstEventTimeout())
 	if err != nil {
 		return err
@@ -238,6 +242,7 @@ func (p *Provider) dismissStartupDialogs(ctx context.Context, name string, cfg r
 	if ok {
 		streamObserved, streamErr := runtime.AcceptStartupDialogsFromStreamWithStatus(ctx, dialogTimeout, snapshots,
 			func(keys ...string) error { return p.SendKeys(name, keys...) },
+			trustRoot,
 		)
 		closeErr := closeWatch()
 		switch {
@@ -249,6 +254,7 @@ func (p *Provider) dismissStartupDialogs(ctx context.Context, name string, cfg r
 			return runtime.AcceptStartupDialogs(ctx,
 				func(lines int) (string, error) { return p.Peek(name, lines) },
 				func(keys ...string) error { return p.SendKeys(name, keys...) },
+				trustRoot,
 			)
 		}
 	}
@@ -256,6 +262,7 @@ func (p *Provider) dismissStartupDialogs(ctx context.Context, name string, cfg r
 	return runtime.AcceptStartupDialogs(ctx,
 		func(lines int) (string, error) { return p.Peek(name, lines) },
 		func(keys ...string) error { return p.SendKeys(name, keys...) },
+		trustRoot,
 	)
 }
 
@@ -438,6 +445,16 @@ func formatStartupWatchError(stderr string, err error) error {
 
 // DismissKnownDialogs best-effort clears known trust/permissions dialogs on a
 // running session using a bounded timeout.
+//
+// Unlike the startup path (dismissStartupDialogs), this mid-session clear is
+// deliberately not given a trusted import root: exec has no reliable
+// mid-session work-dir lookup for a running box (the workdir is provision-half
+// and is not persisted to queryable meta), so there is no exec analog of tmux's
+// GetPaneWorkDir here. Leaving the root empty means the external-CLAUDE.md-import
+// modal fails closed on this path — it is left for a human rather than
+// auto-accepted — which is the safe asymmetry: the common startup case is
+// gated, and the rare mid-session re-surface (resume/reattach) never
+// auto-trusts an unverified import.
 func (p *Provider) DismissKnownDialogs(ctx context.Context, name string, timeout time.Duration) error {
 	return runtime.AcceptStartupDialogsWithTimeout(ctx, timeout,
 		func(lines int) (string, error) { return p.Peek(name, lines) },

--- a/internal/runtime/import_trust.go
+++ b/internal/runtime/import_trust.go
@@ -1,0 +1,39 @@
+package runtime
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// WorkspaceImportTrustRoot returns the root of the git repository that contains
+// dir, to be used as the trusted boundary for external CLAUDE.md imports with
+// WithTrustedImportRoot. It resolves the common git directory (so a linked
+// worktree under `<repo>/.gc/worktrees/<id>` maps back to `<repo>`, the main
+// working tree that holds the repository's own AGENTS.md), then returns that
+// tree's root.
+//
+// It returns "" when dir is empty or is not inside a git repository. Callers
+// pass the result straight to WithTrustedImportRoot, so an empty result simply
+// leaves the external-imports modal for a human instead of auto-accepting.
+func WorkspaceImportTrustRoot(ctx context.Context, dir string) string {
+	if strings.TrimSpace(dir) == "" {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		return ""
+	}
+	common := strings.TrimSpace(string(out))
+	if common == "" {
+		return ""
+	}
+	// --git-common-dir is absolute for linked worktrees and may be relative
+	// (e.g. ".git") for the main tree; resolve it against dir before taking the
+	// parent so the repository root is absolute.
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(dir, common)
+	}
+	return filepath.Dir(filepath.Clean(common))
+}

--- a/internal/runtime/import_trust_test.go
+++ b/internal/runtime/import_trust_test.go
@@ -1,0 +1,67 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkspaceImportTrustRoot(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+	runGit(t, repo, "-c", "user.email=t@example.com", "-c", "user.name=t", "commit",
+		"--allow-empty", "-q", "-m", "init")
+
+	// A linked worktree under the repo must resolve back to the main repo root,
+	// so an import of the repo-root AGENTS.md (seen as external from the
+	// worktree subdirectory) is recognized as first-party.
+	wtParent := filepath.Join(repo, ".gc", "worktrees")
+	if err := os.MkdirAll(wtParent, 0o755); err != nil {
+		t.Fatalf("mkdir worktrees: %v", err)
+	}
+	wt := filepath.Join(wtParent, "wt")
+	runGit(t, repo, "worktree", "add", "-q", "--detach", wt)
+
+	wantRoot := evalSymlinks(t, repo)
+
+	for _, dir := range []string{repo, wt} {
+		if got := evalSymlinks(t, WorkspaceImportTrustRoot(context.Background(), dir)); got != wantRoot {
+			t.Errorf("WorkspaceImportTrustRoot(%q) = %q, want repo root %q", dir, got, wantRoot)
+		}
+	}
+
+	if got := WorkspaceImportTrustRoot(context.Background(), t.TempDir()); got != "" {
+		t.Errorf("WorkspaceImportTrustRoot(non-git dir) = %q, want empty", got)
+	}
+	if got := WorkspaceImportTrustRoot(context.Background(), ""); got != "" {
+		t.Errorf("WorkspaceImportTrustRoot(empty) = %q, want empty", got)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func evalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	if path == "" {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", path, err)
+	}
+	return resolved
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -1979,6 +1979,12 @@ func (t *Tmux) AcceptStartupDialogs(ctx context.Context, sess string) error {
 // DismissKnownDialogs dismisses known trust, permissions, and rate-limit
 // dialogs using a bounded timeout.
 func (t *Tmux) DismissKnownDialogs(ctx context.Context, sess string, timeout time.Duration) error {
+	// Gate external-CLAUDE.md-import auto-acceptance to imports within the
+	// pane's own repository; an import that escapes the repo is left for a
+	// human. Both lookups are best-effort: if either fails, the trust root
+	// stays empty and the external-imports modal is left unaccepted.
+	paneDir, _ := t.GetPaneWorkDir(sess)
+	trustRoot := runtime.WorkspaceImportTrustRoot(ctx, paneDir)
 	return runtime.AcceptStartupDialogsWithTimeout(ctx, timeout,
 		func(lines int) (string, error) { return t.CapturePane(sess, lines) },
 		func(keys ...string) error {
@@ -1989,6 +1995,7 @@ func (t *Tmux) DismissKnownDialogs(ctx context.Context, sess string, timeout tim
 			}
 			return nil
 		},
+		runtime.WithTrustedImportRoot(trustRoot),
 	)
 }
 


### PR DESCRIPTION
## Problem

Claude Code v2.1.207 introduced a new startup trust prompt — **"Allow external CLAUDE.md file imports?"** — that appears when a workspace's `CLAUDE.md` uses `@import` to pull in files outside the project (which this repo does: `CLAUDE.md` → `@AGENTS.md`, and the global `~/.claude/CLAUDE.md`). gc's startup-dialog auto-accept (`internal/runtime/dialog.go`) handled the workspace-trust and MCP-trust prompts but not this new one, so worker sessions froze at the prompt waiting for input that never comes.

Observed live: 12/16 implementation-workers in maintainer-city stalled on this dialog, producing "zero review comments" with a healthy dispatcher.

## Fix

Add the external-imports dialog to the startup auto-accept list, consistent with how gc already handles the other per-CLI startup prompts:

- `containsExternalImportsDialog` — matches both "Allow external CLAUDE.md" and the generic "allow external imports" phrasing.
- `acceptExternalImportsDialog` / `...FromStream` — send Enter (accept default).
- Wired into `AcceptStartupDialogsFromStreamWithStatus` + `AcceptStartupDialogsWithTimeout`, between workspace-trust and MCP-trust, with matching guard groups.
- 4 new tests in `dialog_test.go`.

## Verification

- `go build ./cmd/gc/` = 0
- `go test ./internal/runtime/` = ok

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>