### PR TITLE
fix(runproj,dashboardbff): honest run states, stage ladder, iteration ordering, and read-only diff denial

### DIFF
--- a/internal/api/dashboardbff/rundiff.go
+++ b/internal/api/dashboardbff/rundiff.go
@@ -135,9 +135,18 @@ func (p *Plane) handleRunDiff(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// The exec methods return a validation error when the cwd fails the
 		// shape/allowlist gate; surface that as a 400 rather than a 500 so the
-		// browser sees a client error for a bad execution path.
+		// browser sees a client error for a bad execution path. On a read-only
+		// deployment (the public floor runs with a minimal allowlist by
+		// design) the same rejection is expected for any run executing outside
+		// the served city, so tell the visitor the feature is unavailable here
+		// instead of implying the run is broken. The panel renders this
+		// message verbatim.
 		var ee *execError
 		if errors.As(err, &ee) {
+			if p.deps.ReadOnly && ee.kind == execErrValidation {
+				writeError(w, http.StatusForbidden, "Run diff isn't available on this read-only dashboard.")
+				return
+			}
 			writeError(w, http.StatusBadRequest, "invalid execution path")
 			return
 		}

--- a/internal/api/dashboardbff/rundiff_readonly_test.go
+++ b/internal/api/dashboardbff/rundiff_readonly_test.go
@@ -1,0 +1,25 @@
+package dashboardbff
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// On a read-only deployment (the public factory floor), a run whose execution
+// folder is outside the allowed roots can never diff — the visitor should be
+// told the diff is unavailable on this dashboard, not "invalid execution path".
+func TestRunDiffOutsideRootsReadOnlyExplains(t *testing.T) {
+	cityDir := t.TempDir()
+	outside := t.TempDir()
+	p := New(Deps{Resolver: mapResolver{"alpha": cityDir}, ReadOnly: true})
+
+	rec := postRunDiff(t, p, "/api/city/alpha/runs/gc-run-1/diff",
+		`{"executionPath":{"kind":"known","path":`+jsonString(outside)+`}}`)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 on the read-only floor", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "read-only dashboard") {
+		t.Errorf("body = %s, want a read-only-dashboard explanation", rec.Body.String())
+	}
+}

--- a/internal/runproj/build_lane_test.go
+++ b/internal/runproj/build_lane_test.go
@@ -75,3 +75,55 @@ func TestBuildRunLaneRejectsNonRun(t *testing.T) {
 func runIDf(i int) string {
 	return "run-" + string(rune('a'+i/26)) + string(rune('a'+i%26))
 }
+
+// runStep builds a primary step bead grouped under rootID via gc.root_bead_id.
+func runStep(id, rootID, stepID, status string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Title:  stepID,
+		Status: status,
+		Type:   "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": rootID,
+			"gc.step_id":      stepID,
+		},
+	}
+}
+
+// TestBuildRunLaneResolvesAttemptSuffixedActiveStep is the summary-level
+// regression for the attempt-suffixed active step: a live adopt-pr retry exposes
+// repair-pre-review-ci-failures.attempt.1 as its active step id. The lane must
+// resolve the formula stage position, mark FormulaStageResolved, AND surface the
+// step attempt — none of which held while summary compared/looked up the raw
+// suffixed id against the authored base ids in the stage tables. The honest raw
+// step id is still carried on progress.stepID.
+func TestBuildRunLaneResolvesAttemptSuffixedActiveStep(t *testing.T) {
+	root := runRoot("run-retry", "mol-adopt-pr-v2")
+	root.Status = "open"
+	beadList := []beads.Bead{
+		root,
+		runStep("s-preflight", "run-retry", "preflight", "closed"),
+		runStep("s-rebase", "run-retry", "rebase-check", "closed"),
+		runStep("s-repair", "run-retry", "repair-pre-review-ci-failures.attempt.1", "in_progress"),
+	}
+
+	lane, ok := BuildRunLane(beadList, "run-retry")
+	if !ok {
+		t.Fatal("BuildRunLane(run-retry) ok=false, want a resolvable lane")
+	}
+	if lane.Progress.Status != "active_step" {
+		t.Fatalf("progress.status = %q, want active_step", lane.Progress.Status)
+	}
+	if lane.Progress.StepID != "repair-pre-review-ci-failures.attempt.1" {
+		t.Fatalf("progress.stepID = %q, want the honest attempt-suffixed id", lane.Progress.StepID)
+	}
+	if lane.Progress.Stage.Status != "available" || lane.Progress.Stage.Key != "pre-review-ci" {
+		t.Fatalf("progress.stage = %+v, want available pre-review-ci", lane.Progress.Stage)
+	}
+	if !lane.FormulaStageResolved {
+		t.Fatal("formulaStageResolved = false, want true for the attempt-suffixed active step")
+	}
+	if lane.Progress.Attempt.Status != "available" || lane.Progress.Attempt.Value != 1 {
+		t.Fatalf("progress.attempt = %+v, want available value 1", lane.Progress.Attempt)
+	}
+}

--- a/internal/runproj/detail.go
+++ b/internal/runproj/detail.go
@@ -481,7 +481,7 @@ func buildRunningFormulaRun(input runningFormulaRunInput) runningFormulaRun {
 	for i := range input.beads {
 		issues = append(issues, fromRunSnapshotBead(input.beads[i]))
 	}
-	phase := mapRunPhase(issues)
+	phase := mapRunPhase(input.runID, issues)
 	formulaName, hasFormulaName := "", false
 	if formula.Kind == "known" {
 		formulaName, hasFormulaName = formula.Name, true

--- a/internal/runproj/detail.go
+++ b/internal/runproj/detail.go
@@ -481,6 +481,10 @@ func buildRunningFormulaRun(input runningFormulaRunInput) runningFormulaRun {
 	for i := range input.beads {
 		issues = append(issues, fromRunSnapshotBead(input.beads[i]))
 	}
+	// The run id feeds mapRunPhase's terminal-fail lookup, but the detail view
+	// carries run failure through node statuses in the DAG rather than a
+	// run-header label: only phase.phase is projected below, so the honest
+	// "failed" label stays a summary/lane-level signal (RunLane.PhaseLabel).
 	phase := mapRunPhase(input.runID, issues)
 	formulaName, hasFormulaName := "", false
 	if formula.Kind == "known" {

--- a/internal/runproj/detail_displaystate.go
+++ b/internal/runproj/detail_displaystate.go
@@ -10,10 +10,11 @@ var terminalStatuses = map[string]bool{
 	"canceled":  true,
 }
 
-// applyDisplayNodeStates promotes pending nodes to ready or blocked based on
-// their upstream edges. Port of TS applyDisplayNodeStates. The returned slice is
-// a fresh copy with the pending → ready/blocked transitions applied, mirroring
-// the TS immutable update (the field order of each node is preserved).
+// applyDisplayNodeStates promotes pending nodes to ready based on their
+// upstream edges (dep-waiting nodes stay pending). Port of TS
+// applyDisplayNodeStates minus its pending→blocked promotion. The returned
+// slice is a fresh copy, mirroring the TS immutable update (the field order of
+// each node is preserved).
 func applyDisplayNodeStates(nodes []RunDisplayNode, edges []RunDisplayEdge) []RunDisplayNode {
 	byID := make(map[string]RunDisplayNode, len(nodes))
 	for _, node := range nodes {
@@ -61,7 +62,11 @@ func displayStatusFor(node RunDisplayNode, blockers []string, byID map[string]Ru
 	for _, blockerID := range blockers {
 		blocker, ok := byID[blockerID]
 		if !ok || !terminalStatuses[blocker.Status] {
-			return "blocked"
+			// Waiting on an unfinished upstream is the normal life of a
+			// pending node, not an alarm: it stays "pending". "blocked" is
+			// reserved for nodes the store itself marks blocked (operator
+			// attention), which return through the early exit above.
+			return "pending"
 		}
 	}
 	return "ready"

--- a/internal/runproj/detail_displaystate_fixes_test.go
+++ b/internal/runproj/detail_displaystate_fixes_test.go
@@ -1,0 +1,55 @@
+package runproj
+
+import "testing"
+
+// Regression tests: a pending node whose upstream has not finished is WAITING
+// ITS TURN — it stays "pending" (neutral) rather than being promoted to
+// "blocked" (the operator-attention alarm). "blocked" is reserved for nodes the
+// store itself marks blocked.
+
+func TestDisplayStatusDepWaitingStaysPending(t *testing.T) {
+	nodes := []RunDisplayNode{
+		{ID: "a", Status: "active"},
+		{ID: "b", Status: "pending"},
+	}
+	edges := []RunDisplayEdge{{From: "a", To: "b", Kind: "blocks"}}
+	out := applyDisplayNodeStates(nodes, edges)
+	if got := statusOf(t, out, "b"); got != "pending" {
+		t.Fatalf("dep-waiting node status = %q, want %q", got, "pending")
+	}
+}
+
+func TestDisplayStatusDepsMetPromotesToReady(t *testing.T) {
+	nodes := []RunDisplayNode{
+		{ID: "a", Status: "completed"},
+		{ID: "b", Status: "pending"},
+	}
+	edges := []RunDisplayEdge{{From: "a", To: "b", Kind: "blocks"}}
+	out := applyDisplayNodeStates(nodes, edges)
+	if got := statusOf(t, out, "b"); got != "ready" {
+		t.Fatalf("deps-met node status = %q, want %q", got, "ready")
+	}
+}
+
+func TestDisplayStatusStoreBlockedIsPreserved(t *testing.T) {
+	nodes := []RunDisplayNode{
+		{ID: "a", Status: "active"},
+		{ID: "b", Status: "blocked"},
+	}
+	edges := []RunDisplayEdge{{From: "a", To: "b", Kind: "blocks"}}
+	out := applyDisplayNodeStates(nodes, edges)
+	if got := statusOf(t, out, "b"); got != "blocked" {
+		t.Fatalf("store-blocked node status = %q, want %q", got, "blocked")
+	}
+}
+
+func statusOf(t *testing.T, nodes []RunDisplayNode, id string) string {
+	t.Helper()
+	for _, n := range nodes {
+		if n.ID == id {
+			return n.Status
+		}
+	}
+	t.Fatalf("node %q missing", id)
+	return ""
+}

--- a/internal/runproj/detail_order.go
+++ b/internal/runproj/detail_order.go
@@ -216,6 +216,14 @@ func aliasVariants(value, formulaName string) []string {
 	for _, c := range candidates {
 		candidates = append(candidates, stripAttemptSuffix(c))
 	}
+	// The compiled formula's preview carries only iteration-1 refs, so later
+	// iterations (scope.iteration.2.step) would rank +Inf and sort after the
+	// run's final steps. Iteration-agnostic variants let every iteration rank
+	// at the authored step position; the stable sort keeps iteration order
+	// within the tie.
+	for _, c := range candidates {
+		candidates = append(candidates, stripIterationSegments(c))
+	}
 	seen := make(map[string]bool)
 	var out []string
 	for _, candidate := range candidates {

--- a/internal/runproj/detail_order.go
+++ b/internal/runproj/detail_order.go
@@ -210,6 +210,12 @@ func aliasVariants(value, formulaName string) []string {
 	}
 	stripped := stripFormulaPrefix(clean, formulaName)
 	candidates := []string{clean, stripped, stripScopeCheckSuffix(clean), stripScopeCheckSuffix(stripped)}
+	// Retry iterations suffix step ids with .attempt.N; the compiled formula
+	// ranks the authored base id, so each candidate also contributes its
+	// attempt-stripped form (else those groups rank +Inf and sort last).
+	for _, c := range candidates {
+		candidates = append(candidates, stripAttemptSuffix(c))
+	}
 	seen := make(map[string]bool)
 	var out []string
 	for _, candidate := range candidates {

--- a/internal/runproj/detail_order_fixes_test.go
+++ b/internal/runproj/detail_order_fixes_test.go
@@ -1,0 +1,19 @@
+package runproj
+
+import "testing"
+
+// Regression test: iteration retries carry .attempt.N-suffixed step ids
+// (repair-pre-review-ci-failures.attempt.1). aliasVariants must include the
+// attempt-stripped form so those groups rank at their authored step position
+// instead of falling to +Inf and sorting after the run's final steps.
+
+func TestAliasVariantsIncludeAttemptStrippedForm(t *testing.T) {
+	variants := aliasVariants("pre-review-ci.repair-pre-review-ci-failures.attempt.1", "")
+	want := externalizeID("pre-review-ci.repair-pre-review-ci-failures")
+	for _, v := range variants {
+		if v == want {
+			return
+		}
+	}
+	t.Fatalf("aliasVariants = %v, want %q included", variants, want)
+}

--- a/internal/runproj/detail_order_fixes_test.go
+++ b/internal/runproj/detail_order_fixes_test.go
@@ -17,3 +17,21 @@ func TestAliasVariantsIncludeAttemptStrippedForm(t *testing.T) {
 	}
 	t.Fatalf("aliasVariants = %v, want %q included", variants, want)
 }
+
+// Regression test: the compiled formula's preview only carries iteration-1
+// refs, so a later iteration's groups (pre-review-ci.iteration.2.repair-...)
+// matched nothing and sorted after the run's final steps. aliasVariants must
+// contribute iteration-agnostic forms so every iteration ranks at the authored
+// step position (stable sort keeps iteration order within the tie).
+func TestAliasVariantsIncludeIterationAgnosticForm(t *testing.T) {
+	rank := aliasVariants("mol-adopt-pr-v2.pre-review-ci.iteration.1.repair-pre-review-ci-failures", "mol-adopt-pr-v2")
+	group := aliasVariants("pre-review-ci.iteration.2.repair-pre-review-ci-failures.attempt.2", "")
+	for _, r := range rank {
+		for _, g := range group {
+			if r == g {
+				return
+			}
+		}
+	}
+	t.Fatalf("no shared alias between rank side %v and group side %v", rank, group)
+}

--- a/internal/runproj/detail_parity_test.go
+++ b/internal/runproj/detail_parity_test.go
@@ -19,7 +19,7 @@ import (
 // stage — the kind of error the narrow golden cannot see — fails here.
 func TestStagesForFormulaCoversEverySupportedFormula(t *testing.T) {
 	want := map[string][]string{
-		"mol-adopt-pr-v2":                  {"preflight", "rebase", "review", "ci", "approval", "finalize", "cleanup"},
+		"mol-adopt-pr-v2":                  {"preflight", "rebase", "pre-review-ci", "review", "ci", "approval", "finalize", "cleanup"},
 		"mol-design-review-v2":             {"setup", "personas", "fanout", "synthesis", "apply", "finalize"},
 		"mol-bug-report-flow-v2":           {"intake", "repro", "audit", "classify", "approval", "publish", "dispatch"},
 		"mol-bug-report-implementation-v2": {"plan", "design", "implement", "review", "pr", "ci", "merge"},
@@ -63,7 +63,9 @@ func TestFormulaStageProgressMarksCompleteActivePending(t *testing.T) {
 	}
 
 	got := formulaStageProgress(stages, issues)
-	want := []string{"complete", "complete", "active", "pending", "pending", "pending", "pending"}
+	// pre-review-ci sits before the active review stage, so it reads complete
+	// even with no issues of its own (stage status is positional).
+	want := []string{"complete", "complete", "complete", "active", "pending", "pending", "pending", "pending"}
 	if len(got) != len(want) {
 		t.Fatalf("got %d stages, want %d", len(got), len(want))
 	}

--- a/internal/runproj/golden_regen_test.go
+++ b/internal/runproj/golden_regen_test.go
@@ -1,0 +1,47 @@
+package runproj
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRegenerateGoldens rewrites the golden fixtures from the current pipeline
+// when RUNPROJ_UPDATE_GOLDENS=1 is set. It exists so an intentional semantic
+// change regenerates all three goldens through the exact build calls their
+// tests use; audit the resulting git diff before committing.
+func TestRegenerateGoldens(t *testing.T) {
+	if os.Getenv("RUNPROJ_UPDATE_GOLDENS") == "" {
+		t.Skip("set RUNPROJ_UPDATE_GOLDENS=1 to rewrite testdata goldens")
+	}
+
+	beadList := loadFixtureBeads(t)
+
+	detail, err := BuildRunDetail(beadList, detailGoldenRunID, detailGoldenSnapshotVersion, detailGoldenSnapshotEventSeq)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	writeGolden(t, "rundetail_golden.json", detail)
+
+	summary := BuildRunSummary(beadList)
+	writeGolden(t, "runsummary_golden.json", summary)
+
+	sessions := loadFixtureSessions(t)
+	inFlight := make([]RunLane, 0, len(summary.Lanes)+len(summary.BlockedLanes))
+	inFlight = append(inFlight, summary.Lanes...)
+	inFlight = append(inFlight, summary.BlockedLanes...)
+	marks := AdvanceProgressMarks(nil, inFlight)
+	enriched := EnrichRunSummary(summary, sessions, true, mustMillis(t, "2026-06-09T00:00:00Z"), marks)
+	writeGolden(t, "runsummary_enriched_golden.json", enriched)
+}
+
+func writeGolden(t *testing.T, name string, v any) {
+	t.Helper()
+	data, err := canonicalJSON(v)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", name, err)
+	}
+	if err := os.WriteFile(filepath.Join("testdata", name), data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}

--- a/internal/runproj/phasemapping.go
+++ b/internal/runproj/phasemapping.go
@@ -590,6 +590,21 @@ func stripAttemptSuffix(id string) string {
 	return stripped
 }
 
+// iterationSegmentRE matches the .iteration.N path segments loop
+// materialization inserts into a step ref (scope.iteration.2.step).
+var iterationSegmentRE = regexp.MustCompile(`\.iteration\.\d+`)
+
+// stripIterationSegments removes every .iteration.N segment from a step ref,
+// yielding the iteration-agnostic authored form. A value that is nothing but
+// segments is returned unchanged rather than stripped to the empty string.
+func stripIterationSegments(id string) string {
+	stripped := iterationSegmentRE.ReplaceAllString(id, "")
+	if stripped == "" {
+		return id
+	}
+	return stripped
+}
+
 // formulaStageStatus resolves one stage's status relative to the active and
 // furthest-closed stage indices. Port of the TS status switch.
 func formulaStageStatus(idx, activeIndex, furthestClosedIndex int, stage formulaStage, primary []runIssue) string {

--- a/internal/runproj/phasemapping.go
+++ b/internal/runproj/phasemapping.go
@@ -147,6 +147,19 @@ var (
 	intakeStageTokens         = map[string]bool{"intake": true, "bootstrap": true, "context": true, "router": true, "request": true, "preflight": true, "setup": true, "rebase": true}
 )
 
+// reviewPrepImplementationSteps names review-preparation steps that are
+// themselves implementation work rather than the review gate or intake. Such a
+// step carries a review lead-up qualifier (so the review classifier rejects it)
+// plus a generic intake token, so neither the review nor the implementation
+// token set resolves it; it must be pinned explicitly. Keys are authored base
+// step ids (attempt suffix stripped). prepare-review-context builds the review
+// context a later code review consumes and belongs to the bug-implementation
+// formula's "implement" stage, yet its only non-rejected token is the intake
+// token "context"; without this it falls through to intake.
+var reviewPrepImplementationSteps = map[string]bool{
+	"prepare-review-context": true,
+}
+
 // stepIDPhase classifies a single gc.step_id into a generic RunPhase.
 // Port of TS stepIdPhase.
 func stepIDPhase(stepID string) string {
@@ -162,6 +175,15 @@ func stepIDPhase(stepID string) string {
 	// review, it is not the review.
 	if hasStageToken(tokens, reviewStageTokens, true) {
 		return "review"
+	}
+	// A named review-preparation step that is implementation work (e.g.
+	// prepare-review-context) is rejected as review above and would otherwise be
+	// misread as intake by its "context" token; pin it to implementation before
+	// the token fallthrough. pre-review-ci / repair-pre-review-ci-failures are
+	// deliberately absent: the CI gate leads up to review without being
+	// implementation, and its repair step already resolves via the "repair" token.
+	if reviewPrepImplementationSteps[stripAttemptSuffix(strings.ToLower(strings.TrimSpace(stepID)))] {
+		return "implementation"
 	}
 	if hasStageToken(tokens, implementationStageTokens, false) {
 		return "implementation"
@@ -751,12 +773,16 @@ func byMostRecentThenStage(a, b runIssue) int {
 }
 
 // stepIssues returns the issues whose gc.step_id equals step, treating an
-// attempt-suffixed id (step.attempt.N) as its authored base id. Port of TS
-// stepIssues.
+// attempt-suffixed id (step.attempt.N) as its authored base id on BOTH sides.
+// The authored stage tables query with base ids, but a live retry's active step
+// id (runStepAttempt) still carries the suffix; stripping the query too keeps
+// the match symmetric so attempt lookup resolves for in-flight retries. Port of
+// TS stepIssues, extended to normalize the query side.
 func stepIssues(issues []runIssue, step string) []runIssue {
+	base := stripAttemptSuffix(step)
 	var out []runIssue
 	for _, i := range issues {
-		if stripAttemptSuffix(stringValue(i.metadata[beadmeta.StepIDMetadataKey])) == step {
+		if stripAttemptSuffix(stringValue(i.metadata[beadmeta.StepIDMetadataKey])) == base {
 			out = append(out, i)
 		}
 	}

--- a/internal/runproj/phasemapping.go
+++ b/internal/runproj/phasemapping.go
@@ -32,15 +32,15 @@ type phaseMapping struct {
 	hasRound    bool // TS reviewRound: number | null
 }
 
-// mapRunPhase classifies a run group into a phase. Port of TS mapRunPhase.
-func mapRunPhase(issues []runIssue) phaseMapping {
-	// Status-based branches first — authoritative.
-	for _, i := range issues {
-		if i.status == "blocked" || strings.Contains(textForIssue(i), "blocked") {
-			return phaseMapping{phase: "blocked", label: "blocked"}
-		}
-	}
-
+// mapRunPhase classifies a run group into a phase. Port of TS mapRunPhase,
+// with the terminal check hoisted above the blocked check: a fully-closed run
+// is history, even when a member's status or text mentions "blocked" (the old
+// order pinned aborted runs into the blocked lane with a claim-a-worker remedy
+// that could do nothing). rootID names the group root so a terminal run whose
+// ROOT closed with gc.outcome=fail keeps the honest "failed" label — the phase
+// stays "complete" (the RunPhase union has no failed member, and complete is
+// what routes the lane to history).
+func mapRunPhase(rootID string, issues []runIssue) phaseMapping {
 	if len(issues) > 0 {
 		allClosed := true
 		for _, i := range issues {
@@ -50,7 +50,25 @@ func mapRunPhase(issues []runIssue) phaseMapping {
 			}
 		}
 		if allClosed {
-			return phaseMapping{phase: "complete", label: "complete"}
+			label := "complete"
+			for _, i := range issues {
+				if i.id != rootID {
+					continue
+				}
+				outcome := strings.ToLower(stringValue(i.metadata[beadmeta.OutcomeMetadataKey]))
+				if outcome == "fail" || outcome == "failed" {
+					label = "failed"
+				}
+				break
+			}
+			return phaseMapping{phase: "complete", label: label}
+		}
+	}
+
+	// Status-based blocked branch — authoritative for open runs.
+	for _, i := range issues {
+		if i.status == "blocked" || strings.Contains(textForIssue(i), "blocked") {
+			return phaseMapping{phase: "blocked", label: "blocked"}
 		}
 	}
 
@@ -125,7 +143,7 @@ var (
 	approvalStageTokens       = map[string]bool{"approval": true, "approve": true, "approved": true, "gate": true}
 	finalizationStageTokens   = map[string]bool{"finalize": true, "finalization": true, "merge": true, "cleanup": true, "publish": true}
 	reviewStageTokens         = map[string]bool{"review": true, "reviewer": true, "scorecard": true, "persona": true, "personas": true, "audit": true, "repro": true, "baseline": true, "investigation": true, "classify": true, "classification": true}
-	implementationStageTokens = map[string]bool{"implement": true, "implementation": true, "patch": true, "fixes": true, "work": true, "design": true}
+	implementationStageTokens = map[string]bool{"implement": true, "implementation": true, "patch": true, "fixes": true, "repair": true, "work": true, "design": true}
 	intakeStageTokens         = map[string]bool{"intake": true, "bootstrap": true, "context": true, "router": true, "request": true, "preflight": true, "setup": true, "rebase": true}
 )
 
@@ -139,7 +157,10 @@ func stepIDPhase(stepID string) string {
 	if hasStageToken(tokens, finalizationStageTokens, true) {
 		return "finalization"
 	}
-	if hasStageToken(tokens, reviewStageTokens, false) {
+	// Review rejects lead-up qualifiers like approval/finalization do: a
+	// pre-review CI repair step ("repair-PRE-REVIEW-ci-failures") leads up to
+	// review, it is not the review.
+	if hasStageToken(tokens, reviewStageTokens, true) {
 		return "review"
 	}
 	if hasStageToken(tokens, implementationStageTokens, false) {
@@ -443,6 +464,7 @@ func stagesForFormula(formula string, hasFormula bool) []formulaStage {
 		return []formulaStage{
 			{"preflight", "Preflight", []string{"preflight"}},
 			{"rebase", "Worktree / rebase", []string{"rebase-check"}},
+			{"pre-review-ci", "Pre-review CI", []string{"pre-review-ci", "repair-pre-review-ci-failures"}},
 			{"review", "Review loop", []string{
 				"review-loop",
 				"review-pipeline.review-claude",
@@ -452,7 +474,8 @@ func stagesForFormula(formula string, hasFormula bool) []formulaStage {
 				"review-pipeline.quality-scorecard",
 				"apply-fixes",
 			}},
-			{"ci", "Pre-approval CI", []string{"pre-approval-ci", "repair-ci-failures"}},
+			// repair-ci-failures is the pre-rename id kept for older runs.
+			{"ci", "Pre-approval CI", []string{"pre-approval-ci", "repair-pre-approval-ci-failures", "repair-ci-failures"}},
 			{"approval", "Human approval", []string{"human-approval"}},
 			{"finalize", "Merge-ready", []string{"finalize"}},
 			{"cleanup", "Cleanup", []string{"cleanup-worktree"}},
@@ -541,12 +564,30 @@ func formulaActiveStageIndex(stages []formulaStage, primary []runIssue) int {
 	if !hasActiveStep {
 		return firstOpenStageIndex(stages, primary)
 	}
+	// Retry iterations carry attempt-suffixed step ids
+	// (repair-x-failures.attempt.1); the tables list the authored base ids.
+	activeStepID = stripAttemptSuffix(activeStepID)
 	for idx, s := range stages {
 		if containsString(s.steps, activeStepID) {
 			return idx
 		}
 	}
 	return -1
+}
+
+// attemptSuffixRE matches the .attempt.N suffix runtime retries append to a
+// step id (possibly stacked, e.g. ".attempt.1.attempt.2").
+var attemptSuffixRE = regexp.MustCompile(`(\.attempt\.\d+)+$`)
+
+// stripAttemptSuffix reduces an attempt-suffixed step id to its authored base
+// id. A value that is nothing but the suffix is returned unchanged rather than
+// stripped to the empty string.
+func stripAttemptSuffix(id string) string {
+	stripped := attemptSuffixRE.ReplaceAllString(id, "")
+	if stripped == "" {
+		return id
+	}
+	return stripped
 }
 
 // formulaStageStatus resolves one stage's status relative to the active and
@@ -694,12 +735,13 @@ func byMostRecentThenStage(a, b runIssue) int {
 	return 0
 }
 
-// stepIssues returns the issues whose gc.step_id equals step. Port of TS
+// stepIssues returns the issues whose gc.step_id equals step, treating an
+// attempt-suffixed id (step.attempt.N) as its authored base id. Port of TS
 // stepIssues.
 func stepIssues(issues []runIssue, step string) []runIssue {
 	var out []runIssue
 	for _, i := range issues {
-		if stringValue(i.metadata[beadmeta.StepIDMetadataKey]) == step {
+		if stripAttemptSuffix(stringValue(i.metadata[beadmeta.StepIDMetadataKey])) == step {
 			out = append(out, i)
 		}
 	}

--- a/internal/runproj/phasemapping_fixes_test.go
+++ b/internal/runproj/phasemapping_fixes_test.go
@@ -176,3 +176,77 @@ func TestStripAttemptSuffix(t *testing.T) {
 		}
 	}
 }
+
+func TestStripIterationSegments(t *testing.T) {
+	cases := map[string]string{
+		"review-loop.iteration.2.apply-fixes":        "review-loop.apply-fixes",
+		"pre-review-ci.iteration.10.repair":          "pre-review-ci.repair",
+		"scope.iteration.1.step.iteration.2.substep": "scope.step.substep",
+		"plain-step":   "plain-step",
+		"iteration.3":  "iteration.3",  // no leading dot: not a segment
+		".iteration.3": ".iteration.3", // nothing but a segment: never strip to empty
+	}
+	for in, want := range cases {
+		if got := stripIterationSegments(in); got != want {
+			t.Errorf("stripIterationSegments(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestStepIDPhasePrepareReviewContextIsImplementation pins the review-preparation
+// implementation steps: prepare-review-context is rejected as review by its
+// "prepare" lead-up token, and its "context" token must NOT drop it to intake —
+// it is implementation work in the bug-implementation formula's implement stage.
+func TestStepIDPhasePrepareReviewContextIsImplementation(t *testing.T) {
+	cases := []struct {
+		stepID string
+		want   string
+	}{
+		{"prepare-review-context", "implementation"},
+		{"prepare-review-context.attempt.1", "implementation"},
+		// A sibling implement-stage step is unaffected.
+		{"implement-change", "implementation"},
+		// Guard against over-broadening: the narrower pre-review-ci lead-up
+		// behavior is preserved (gate stays neutral, its repair step stays impl).
+		{"pre-review-ci", "active"},
+		{"repair-pre-review-ci-failures", "implementation"},
+	}
+	for _, tc := range cases {
+		if got := stepIDPhase(tc.stepID); got != tc.want {
+			t.Errorf("stepIDPhase(%q) = %q, want %q", tc.stepID, got, tc.want)
+		}
+	}
+}
+
+// TestMapRunPhasePrepareReviewContextRunIsImplementation proves the run-phase
+// regression end-to-end: a live bug-implementation run whose active step is
+// prepare-review-context reads as the implementation phase, not intake.
+func TestMapRunPhasePrepareReviewContextRunIsImplementation(t *testing.T) {
+	issues := []runIssue{
+		{id: "root-1", title: "mol-bug-report-implementation-v2", status: "open", metadata: map[string]string{
+			beadmeta.KindMetadataKey: "run",
+		}},
+		{id: "step-1", title: "Prepare review context", status: "in_progress", parent: "root-1", updatedAt: "2026-07-11T03:00:00Z", metadata: map[string]string{
+			beadmeta.StepIDMetadataKey: "prepare-review-context",
+		}},
+	}
+	got := mapRunPhase("root-1", issues)
+	if got.phase != "implementation" {
+		t.Fatalf("mapRunPhase phase = %q, want %q", got.phase, "implementation")
+	}
+}
+
+// TestMapRunPhaseFailedRootAcceptsUppercaseAlias pins the outcome normalization:
+// mapRunPhase lowercases the root outcome and accepts both "fail" and "failed",
+// so an uppercase "FAILED" still yields the honest failed label.
+func TestMapRunPhaseFailedRootAcceptsUppercaseAlias(t *testing.T) {
+	issues := []runIssue{
+		{id: "root-1", title: "mol-adopt-pr-v2", status: "closed", metadata: map[string]string{
+			beadmeta.OutcomeMetadataKey: "FAILED",
+		}},
+	}
+	got := mapRunPhase("root-1", issues)
+	if got.phase != "complete" || got.label != "failed" {
+		t.Fatalf("mapRunPhase = %+v, want phase complete with failed label", got)
+	}
+}

--- a/internal/runproj/phasemapping_fixes_test.go
+++ b/internal/runproj/phasemapping_fixes_test.go
@@ -1,0 +1,178 @@
+package runproj
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+)
+
+// Regression tests for the 2026-07-11 run-view misclassification fixes: steps
+// that LEAD UP TO review (pre-review CI repair) classified as the review phase,
+// terminal runs classified blocked off a text match, the missing pre-review-ci
+// stage in the adopt-pr ladder, and .attempt.N step ids missing every exact
+// stage/step match.
+
+func TestStepIDPhaseLeadUpToReviewIsNotReview(t *testing.T) {
+	cases := []struct {
+		stepID string
+		want   string
+	}{
+		// Leading up to review: the pre-review CI gate and its repair step are
+		// implementation-side work, not the review itself.
+		{"pre-review-ci", "active"},
+		{"repair-pre-review-ci-failures", "implementation"},
+		{"repair-pre-review-ci-failures.attempt.1", "implementation"},
+		// The review loop itself still classifies as review.
+		{"review-loop", "review"},
+		{"review-pipeline.review-claude", "review"},
+		{"review-pipeline.quality-scorecard", "review"},
+		// Approval keeps its existing lead-up behavior.
+		{"pre-approval-ci", "active"},
+		{"repair-pre-approval-ci-failures", "implementation"},
+	}
+	for _, tc := range cases {
+		if got := stepIDPhase(tc.stepID); got != tc.want {
+			t.Errorf("stepIDPhase(%q) = %q, want %q", tc.stepID, got, tc.want)
+		}
+	}
+}
+
+func TestMapRunPhaseTerminalWinsOverBlockedText(t *testing.T) {
+	issues := []runIssue{
+		{id: "root-1", title: "mol-adopt-pr-v2", status: "closed", metadata: map[string]string{
+			beadmeta.KindMetadataKey: "run",
+		}},
+		// A closed member whose text mentions "blocked" must not pin the whole
+		// terminal run into the blocked lane.
+		{id: "step-1", title: "Preflight", desc: "aborted: blocked by missing worktree", status: "closed", parent: "root-1"},
+	}
+	got := mapRunPhase("root-1", issues)
+	if got.phase != "complete" {
+		t.Fatalf("mapRunPhase phase = %q, want %q", got.phase, "complete")
+	}
+}
+
+func TestMapRunPhaseBlockedStillWinsWhileRunIsOpen(t *testing.T) {
+	issues := []runIssue{
+		{id: "root-1", title: "mol-adopt-pr-v2", status: "open"},
+		{id: "step-1", title: "Preflight", status: "blocked", parent: "root-1"},
+	}
+	got := mapRunPhase("root-1", issues)
+	if got.phase != "blocked" {
+		t.Fatalf("mapRunPhase phase = %q, want %q", got.phase, "blocked")
+	}
+}
+
+func TestMapRunPhaseFailedRootKeepsCompletePhaseWithFailedLabel(t *testing.T) {
+	issues := []runIssue{
+		{id: "root-1", title: "mol-adopt-pr-v2", status: "closed", metadata: map[string]string{
+			beadmeta.OutcomeMetadataKey: "fail",
+		}},
+		{id: "step-1", title: "Preflight", status: "closed", parent: "root-1", metadata: map[string]string{
+			beadmeta.OutcomeMetadataKey: "fail",
+		}},
+	}
+	got := mapRunPhase("root-1", issues)
+	if got.phase != "complete" {
+		t.Fatalf("mapRunPhase phase = %q, want %q (RunPhase union has no failed member)", got.phase, "complete")
+	}
+	if got.label != "failed" {
+		t.Fatalf("mapRunPhase label = %q, want %q", got.label, "failed")
+	}
+}
+
+func TestMapRunPhaseRecoveredRunIsNotLabeledFailed(t *testing.T) {
+	// A failed attempt that was retried to success leaves outcome=fail on the
+	// attempt bead; only the ROOT outcome speaks for the run.
+	issues := []runIssue{
+		{id: "root-1", title: "mol-adopt-pr-v2", status: "closed"},
+		{id: "step-1", title: "Repair CI", status: "closed", parent: "root-1", metadata: map[string]string{
+			beadmeta.OutcomeMetadataKey: "fail",
+		}},
+	}
+	got := mapRunPhase("root-1", issues)
+	if got.phase != "complete" || got.label == "failed" {
+		t.Fatalf("mapRunPhase = %+v, want phase complete without failed label", got)
+	}
+}
+
+func TestAdoptPrStageLadderCoversPreReviewCI(t *testing.T) {
+	stages := stagesForFormula("mol-adopt-pr-v2", true)
+	keys := make([]string, len(stages))
+	byKey := map[string]formulaStage{}
+	for i, s := range stages {
+		keys[i] = s.key
+		byKey[s.key] = s
+	}
+
+	pre, ok := byKey["pre-review-ci"]
+	if !ok {
+		t.Fatalf("mol-adopt-pr-v2 ladder %v lacks a pre-review-ci stage", keys)
+	}
+	if !containsString(pre.steps, "pre-review-ci") || !containsString(pre.steps, "repair-pre-review-ci-failures") {
+		t.Fatalf("pre-review-ci stage steps = %v, want pre-review-ci + repair-pre-review-ci-failures", pre.steps)
+	}
+
+	// It must sit between rebase and review.
+	idx := map[string]int{}
+	for i, k := range keys {
+		idx[k] = i
+	}
+	if idx["rebase"] >= idx["pre-review-ci"] || idx["pre-review-ci"] >= idx["review"] {
+		t.Fatalf("stage order %v: pre-review-ci must be between rebase and review", keys)
+	}
+
+	// The pre-approval CI stage must match the step ids runs actually emit.
+	ci := byKey["ci"]
+	if !containsString(ci.steps, "repair-pre-approval-ci-failures") {
+		t.Fatalf("ci stage steps = %v, want repair-pre-approval-ci-failures included", ci.steps)
+	}
+}
+
+func TestFormulaActiveStageIndexMatchesAttemptSuffixedStep(t *testing.T) {
+	stages := stagesForFormula("mol-adopt-pr-v2", true)
+	issues := []runIssue{
+		// Closed earlier stages.
+		{id: "s1", status: "closed", metadata: map[string]string{beadmeta.StepIDMetadataKey: "preflight"}, updatedAt: "2026-07-11T01:00:00Z"},
+		{id: "s2", status: "closed", metadata: map[string]string{beadmeta.StepIDMetadataKey: "rebase-check"}, updatedAt: "2026-07-11T02:00:00Z"},
+		// The live iteration-2 repair attempt carries an attempt-suffixed step id.
+		{id: "s3", status: "in_progress", metadata: map[string]string{beadmeta.StepIDMetadataKey: "repair-pre-review-ci-failures.attempt.1"}, updatedAt: "2026-07-11T03:00:00Z"},
+		// Review steps exist but have not started.
+		{id: "s4", status: "open", metadata: map[string]string{beadmeta.StepIDMetadataKey: "review-pipeline.review-claude"}, updatedAt: "2026-07-11T02:30:00Z"},
+	}
+	got := formulaActiveStageIndex(stages, issues)
+	want := -1
+	for i, s := range stages {
+		if s.key == "pre-review-ci" {
+			want = i
+		}
+	}
+	if want == -1 {
+		t.Fatal("ladder lacks pre-review-ci stage")
+	}
+	if got != want {
+		t.Fatalf("formulaActiveStageIndex = %d (%s), want %d (pre-review-ci)", got, stageKeyAt(stages, got), want)
+	}
+}
+
+func stageKeyAt(stages []formulaStage, idx int) string {
+	if idx < 0 || idx >= len(stages) {
+		return "none"
+	}
+	return stages[idx].key
+}
+
+func TestStripAttemptSuffix(t *testing.T) {
+	cases := map[string]string{
+		"repair-pre-review-ci-failures.attempt.1": "repair-pre-review-ci-failures",
+		"finalize.attempt.12":                     "finalize",
+		"review-loop.iteration.1.apply-fixes":     "review-loop.iteration.1.apply-fixes",
+		"plain-step":                              "plain-step",
+		"attempt.1":                               "attempt.1", // never strip to empty
+	}
+	for in, want := range cases {
+		if got := stripAttemptSuffix(in); got != want {
+			t.Errorf("stripAttemptSuffix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/runproj/summary.go
+++ b/internal/runproj/summary.go
@@ -246,8 +246,13 @@ func runLane(rootID string, issues []runIssue, feedScopes map[string]RunFeedScop
 	formulaStages := stagesForFormula(formulaName, hasFormula)
 	formulaStageResolved := false
 	if len(formulaStages) > 0 && progress.Status == "active_step" {
+		// A live retry exposes an attempt-suffixed active step id; the stage
+		// tables list authored base ids, so strip the suffix before matching
+		// (mirrors formulaActiveStageIndex, which resolves the stage ladder the
+		// same way).
+		activeBaseStepID := stripAttemptSuffix(progress.StepID)
 		for _, st := range formulaStages {
-			if containsString(st.steps, progress.StepID) {
+			if containsString(st.steps, activeBaseStepID) {
 				formulaStageResolved = true
 				break
 			}

--- a/internal/runproj/summary.go
+++ b/internal/runproj/summary.go
@@ -220,7 +220,7 @@ func runKind(formula RunLaneFormula) string {
 
 // runLane builds a single lane. Port of TS runLane.
 func runLane(rootID string, issues []runIssue, feedScopes map[string]RunFeedScope) RunLane {
-	phase := mapRunPhase(issues)
+	phase := mapRunPhase(rootID, issues)
 	updatedAt := latestUpdatedAt(issues)
 	formula := runFormula(rootID, issues)
 	formulaName, hasFormula := runFormulaName(formula)

--- a/internal/runproj/testdata/rundetail_golden.json
+++ b/internal/runproj/testdata/rundetail_golden.json
@@ -69,6 +69,11 @@
       "status": "complete"
     },
     {
+      "key": "pre-review-ci",
+      "label": "Pre-review CI",
+      "status": "complete"
+    },
+    {
       "key": "review",
       "label": "Review loop",
       "status": "active"

--- a/internal/runproj/testdata/runsummary_enriched_golden.json
+++ b/internal/runproj/testdata/runsummary_enriched_golden.json
@@ -153,6 +153,11 @@
           "status": "complete"
         },
         {
+          "key": "pre-review-ci",
+          "label": "Pre-review CI",
+          "status": "complete"
+        },
+        {
           "key": "review",
           "label": "Review loop",
           "status": "active"
@@ -183,7 +188,7 @@
         "stepId": "review-loop",
         "stage": {
           "status": "available",
-          "index": 2,
+          "index": 3,
           "key": "review",
           "label": "Review loop"
         },

--- a/internal/runproj/testdata/runsummary_golden.json
+++ b/internal/runproj/testdata/runsummary_golden.json
@@ -130,6 +130,11 @@
           "status": "complete"
         },
         {
+          "key": "pre-review-ci",
+          "label": "Pre-review CI",
+          "status": "complete"
+        },
+        {
           "key": "review",
           "label": "Review loop",
           "status": "active"
@@ -160,7 +165,7 @@
         "stepId": "review-loop",
         "stage": {
           "status": "available",
-          "index": 2,
+          "index": 3,
           "key": "review",
           "label": "Review loop"
         },


### PR DESCRIPTION
## What

Five projection fixes plus one read-only UX fix for the runs views, all BFF/Go-owned (the SPA renders these fields verbatim — no frontend changes):

1. **Phase misattribution** — `stepIDPhase` review tokens now reject lead-up qualifiers, so a pre-review CI repair step (`repair-PRE-REVIEW-ci-failures`) classifies as implementation work instead of flipping the run to "review round N" while CI is still being repaired. `repair` joins the implementation tokens.
2. **Stage ladder** — the `mol-adopt-pr-v2` table gains the missing `pre-review-ci` stage and the real `repair-pre-approval-ci-failures` step id (legacy `repair-ci-failures` kept), so the active marker lands on the stage actually executing instead of falling back to first-open (review).
3. **Terminal beats blocked** — `mapRunPhase` checks all-closed before the blocked branch, so an aborted/failed run files under history instead of sitting in the blocked lane advertising "No worker assigned. Claim or dispatch one."; a root closed with `gc.outcome=fail` keeps the honest `failed` label (phase stays `complete` — the RunPhase union has no failed member).
4. **Dep-waiting ≠ blocked** — `applyDisplayNodeStates` keeps a pending node with unfinished upstreams at `pending` (neutral `·`) instead of promoting it to `blocked` (alarm `!`); `blocked` is reserved for store-marked blockage. A healthy mid-flight run no longer renders 16 of 19 nodes as `! BLOCKED`.
5. **Iteration ordering** — `.attempt.N` suffixes are stripped for stage matching, and ordering alias variants gain attempt- and iteration-agnostic forms (the compiled formula's preview only carries iteration-1 refs), so retry iterations rank at their authored step position instead of sorting after Finalize.
6. **Read-only run-diff denial** — on a `ReadOnly` dashboardbff plane, a run-diff cwd-validation rejection answers 403 "Run diff isn't available on this read-only dashboard." instead of 400 "invalid execution path" (any run executing outside the served city can never diff there by design; the panel renders the server message verbatim). Non-read-only deployments keep the 400.

## Testing

- 20 new tests across `phasemapping_fixes_test.go`, `detail_displaystate_fixes_test.go`, `detail_order_fixes_test.go`, `rundiff_readonly_test.go` (TDD: written red first)
- Golden fixtures regenerated via the new `RUNPROJ_UPDATE_GOLDENS=1` hook (`golden_regen_test.go`); the diff is exactly the new ladder stage + the review-stage index shift
- `go test ./internal/runproj/ ./internal/api/dashboardbff/` green; `go vet` and `golangci-lint` clean on both packages; pre-push `make test-fast-parallel` passed

## Field validation

Deployed on the maintainer-city read-only dashboard (factory.gascity.com) since 2026-07-11 ~18:20Z: list/detail phases now agree, dep-waiting nodes render neutral, aborted runs file under history with the `failed` label, and iteration-2 lanes sit at their authored position. Root-caused from live event-log evidence (bead-by-bead traces in the run views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)