### PR TITLE
fix: allow bd-shim raw JSON passthrough

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -130,6 +130,9 @@ func newBdShimCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short:              "Alias for `gc bd` (forwards to the bd wrapper)",
 		Hidden:             true,
 		DisableFlagParsing: true,
+		Annotations: map[string]string{
+			jsonRawPassthroughAnnotation: "true",
+		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			return exitForCode(doBd(args, stdout, stderr))
 		},

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -591,6 +591,24 @@ func TestJSONContractAllowsBdPassthrough(t *testing.T) {
 	}
 }
 
+func TestJSONContractAllowsBdShimPassthrough(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	root := newRootCmd(&stdout, &stderr)
+	t.Setenv("GC_JSON_CONTRACT_STRICT", "1")
+
+	args := []string{"bd-shim", "mol", "current", "gcg-1", "--json"}
+	handled, code := handleJSONContractRequest(root, args, &stdout, &stderr)
+	if handled || code != 0 {
+		t.Fatalf("bd-shim --json must pass through the contract: handled=%v code=%d stdout=%q stderr=%q", handled, code, stdout.String(), stderr.String())
+	}
+	if shouldBufferJSONExecution(root, args) {
+		t.Fatal("bd-shim --json should stream the shim-owned payload without buffering")
+	}
+	if shouldReportJSONExecutionError(root, args) {
+		t.Fatal("bd-shim should preserve the delegated bd exit and error contract")
+	}
+}
+
 func TestJSONContractAllowsHookClaimJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root := newRootCmd(&stdout, &stderr)


### PR DESCRIPTION
## Summary

- mark the hidden gc bd-shim alias as an owner of its delegated raw JSON payload
- prevent strict JSON contract handling from returning json_unsupported to adopt-pr check scripts and spuriously materializing retry iterations
- keep Ralph/check-loop verdict semantics unchanged

## Root cause

The pass observed on iteration 1 belonged to the iteration scope. The loop then correctly ran its external check, but that check called gc bd-shim with --json. The strict JSON front door rejected the hidden alias before bd could return iteration metadata, so the check failed and the controller legitimately materialized another iteration.

## Testing

- [x] Regression test proved RED before the fix and GREEN after it
- [x] go test ./cmd/gc -run ^(TestJSONContract|TestJSONSchema|TestBdShim) -count=1
- [x] make test-fast-parallel (all eight shards; also passed in pre-push)
- [x] go vet ./...
- [ ] make check-docs (not applicable; no docs changed)
- [ ] make test-integration (not run; no runtime, controller, or materializer logic changed)

## Checklist

- [x] Tracked as internal bead ga-vl3j11; no GitHub issue was needed for this live operational report
- [x] Added a regression test for the behavior change
- [x] No user-facing documentation change is needed
- [x] No breaking change or migration is introduced