### PR TITLE
fix(dispatch): re-read live bead before re-stamping gc.routed_to (stop re-dispatch flap)

### DIFF
--- a/cmd/gc/route_recovery.go
+++ b/cmd/gc/route_recovery.go
@@ -60,6 +60,11 @@ func carriedPoolRoute(b beads.Bead) string {
 // which pool ad-hoc work belongs to is the owner's judgment, not the
 // controller's. Idempotent: an already-routed bead yields no route and is
 // skipped.
+//
+// Concurrency-safe: the open-bead List is a snapshot, so before writing each
+// bead is re-read live and skipped unless it is still open, unassigned, and
+// carries the same recoverable route. This prevents the re-stamp from clobbering
+// a route a polecat consumed by claiming the bead after the snapshot (ga-bgu).
 func restoreCarriedWorkRoutes(store beads.Store) (int, error) {
 	if store == nil {
 		return 0, nil
@@ -88,6 +93,24 @@ func restoreCarriedWorkRoutes(store beads.Store) (int, error) {
 		// holds regardless of store-level filtering semantics.)
 		if b.Status != "open" || strings.TrimSpace(b.Assignee) != "" {
 			continue
+		}
+		// Re-read the live bead immediately before writing. The open-bead List is
+		// a snapshot; a polecat may have claimed this bead in the window since,
+		// which atomically flips it open->in_progress, records gc.run_target, and
+		// consumes gc.routed_to in one update (ga-sa0). A blind SetMetadata keyed
+		// on the stale snapshot would re-stamp gc.routed_to onto the now-claimed
+		// bead, undoing that consumption and handing the dispatcher a phantom
+		// pool-demand bead that flaps open<->in_progress and thrashes owners
+		// (ga-bgu). Recomputing carriedPoolRoute on the live bead also yields ""
+		// once another restore has already re-stamped it, so concurrent passes
+		// stay idempotent.
+		live, getErr := store.Get(b.ID)
+		if getErr != nil {
+			errs = append(errs, fmt.Errorf("bead %s: re-reading before route restore: %w", b.ID, getErr))
+			continue
+		}
+		if live.Status != "open" || strings.TrimSpace(live.Assignee) != "" || carriedPoolRoute(live) != route {
+			continue // claimed, closed, or already routed since the snapshot — don't clobber
 		}
 		if setErr := store.SetMetadata(b.ID, beadmeta.RoutedToMetadataKey, route); setErr != nil {
 			errs = append(errs, fmt.Errorf("bead %s: restoring gc.routed_to=%q: %w", b.ID, route, setErr))

--- a/cmd/gc/route_recovery.go
+++ b/cmd/gc/route_recovery.go
@@ -61,10 +61,15 @@ func carriedPoolRoute(b beads.Bead) string {
 // controller's. Idempotent: an already-routed bead yields no route and is
 // skipped.
 //
-// Concurrency-safe: the open-bead List is a snapshot, so before writing each
-// bead is re-read live and skipped unless it is still open, unassigned, and
-// carries the same recoverable route. This prevents the re-stamp from clobbering
-// a route a polecat consumed by claiming the bead after the snapshot (ga-bgu).
+// TOCTOU-narrowing (not eliminating): the open-bead List is a snapshot, so
+// before writing, each bead is re-read through the store's authoritative,
+// cache-bypassing live handle and skipped unless it is still open, unassigned,
+// and carries the same recoverable route. This shrinks — but does not close —
+// the window in which the re-stamp could clobber a route a polecat consumed by
+// claiming the bead after the snapshot (ga-bgu): a claim landing between the
+// live re-read and SetMetadata is still possible. The re-stamp stays monotonic
+// (never worse than the prior blind write), so the residual window degrades to
+// the pre-guard behavior rather than a new failure.
 func restoreCarriedWorkRoutes(store beads.Store) (int, error) {
 	if store == nil {
 		return 0, nil
@@ -83,6 +88,12 @@ func restoreCarriedWorkRoutes(store beads.Store) (int, error) {
 		restored int
 		errs     []error
 	)
+	// Resolve the authoritative, cache-bypassing read handle once. Production
+	// stores are CachingStore-wrapped (see wrapWithCachingStore), so a plain
+	// store.Get can return a cached bead that predates a cross-process claim;
+	// handles.Live reads the backing store directly. For a plain store this
+	// degrades to store.Get.
+	handles := beads.HandlesFor(store)
 	for _, b := range items {
 		route := carriedPoolRoute(b)
 		if route == "" {
@@ -94,17 +105,21 @@ func restoreCarriedWorkRoutes(store beads.Store) (int, error) {
 		if b.Status != "open" || strings.TrimSpace(b.Assignee) != "" {
 			continue
 		}
-		// Re-read the live bead immediately before writing. The open-bead List is
-		// a snapshot; a polecat may have claimed this bead in the window since,
-		// which atomically flips it open->in_progress, records gc.run_target, and
-		// consumes gc.routed_to in one update (ga-sa0). A blind SetMetadata keyed
-		// on the stale snapshot would re-stamp gc.routed_to onto the now-claimed
-		// bead, undoing that consumption and handing the dispatcher a phantom
-		// pool-demand bead that flaps open<->in_progress and thrashes owners
-		// (ga-bgu). Recomputing carriedPoolRoute on the live bead also yields ""
-		// once another restore has already re-stamped it, so concurrent passes
-		// stay idempotent.
-		live, getErr := store.Get(b.ID)
+		// Re-read the live bead immediately before writing, through the
+		// authoritative cache-bypassing handle. The open-bead List is a snapshot;
+		// a polecat — often in another process — may have claimed this bead in the
+		// window since, which atomically flips it open->in_progress, records
+		// gc.run_target, and consumes gc.routed_to in one update (ga-sa0). A plain
+		// store.Get would go through the wrapping CachingStore and could return a
+		// stale cached copy that predates a cross-process claim not yet absorbed
+		// into this process's cache; handles.Live reads the backing store and sees
+		// the claim. A blind SetMetadata keyed on the stale snapshot would re-stamp
+		// gc.routed_to onto the now-claimed bead, undoing that consumption and
+		// handing the dispatcher a phantom pool-demand bead that flaps
+		// open<->in_progress and thrashes owners (ga-bgu). Recomputing
+		// carriedPoolRoute on the live bead also yields "" once another restore has
+		// already re-stamped it, so concurrent passes stay idempotent.
+		live, getErr := handles.Live.Get(b.ID)
 		if getErr != nil {
 			errs = append(errs, fmt.Errorf("bead %s: re-reading before route restore: %w", b.ID, getErr))
 			continue

--- a/cmd/gc/route_recovery_test.go
+++ b/cmd/gc/route_recovery_test.go
@@ -142,10 +142,12 @@ func TestRestoreCarriedWorkRoutesSkipsRaceClaimedBead(t *testing.T) {
 	// Live store: the bead has ALREADY been claimed — open->in_progress, assignee
 	// set, gc.routed_to consumed, gc.run_target carrying the route (ga-sa0 claim).
 	live := beads.NewMemStoreFrom(0, []beads.Bead{
-		{ID: "T-1", Title: "work", Type: "task", Status: "in_progress",
+		{
+			ID: "T-1", Title: "work", Type: "task", Status: "in_progress",
 			Assignee: pool + "/th-abc", Metadata: map[string]string{
 				"gc.run_target": pool,
-			}},
+			},
+		},
 	}, nil)
 	// Stale snapshot: List captured T-1 BEFORE the claim — open, unassigned,
 	// unrouted, carrying gc.run_target, so carriedPoolRoute(snapshot) == pool.

--- a/cmd/gc/route_recovery_test.go
+++ b/cmd/gc/route_recovery_test.go
@@ -181,6 +181,84 @@ func TestRestoreCarriedWorkRoutesSkipsRaceClaimedBead(t *testing.T) {
 	}
 }
 
+// staleCacheStore models a CachingStore-wrapped production store whose plain Get
+// returns a STALE cached bead — a cross-process claim not yet absorbed into this
+// process's cache — while its authoritative Live handle bypasses the cache to the
+// backing store and sees the claim. List likewise serves the stale open snapshot.
+// It reproduces the production hazard restoreCarriedWorkRoutes must survive: both
+// the List snapshot and a plain store.Get show the pre-claim bead, so only a
+// cache-bypassing live read (HandlesFor(store).Live.Get) catches the race.
+type staleCacheStore struct {
+	beads.Store            // backing/live store: authoritative, already holds the claim
+	cached      beads.Bead // stale cached view returned by plain Get and List
+}
+
+// Get returns the stale cached bead (a cache hit that predates the claim).
+func (s staleCacheStore) Get(string) (beads.Bead, error) {
+	return s.cached, nil
+}
+
+// List returns the stale open snapshot.
+func (s staleCacheStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return []beads.Bead{s.cached}, nil
+}
+
+// Handles exposes a Live reader that bypasses the stale cache to the backing
+// store, mirroring CachingStore.Handles().Live.
+func (s staleCacheStore) Handles() beads.StoreHandles {
+	h := beads.HandlesFor(s.Store)
+	return beads.StoreHandles{Cached: h.Cached, Live: h.Live, Writer: s.Store}
+}
+
+// TestRestoreCarriedWorkRoutesSkipsCacheStaleClaimedBead covers the CachingStore
+// leg of ga-bgu: on production stores a plain Get can return a cached bead that
+// predates a cross-process claim, so restore must re-read through the
+// authoritative cache-bypassing live handle. With a stale-cache Get the bead
+// still looks open+unassigned+unrouted; only the live backing read shows the
+// claim (in_progress, assigned, route consumed). Restore must skip the re-stamp.
+// It fails against a plain store.Get re-read and passes with handles.Live.Get.
+func TestRestoreCarriedWorkRoutesSkipsCacheStaleClaimedBead(t *testing.T) {
+	const pool = "gascity/gastown.polecat"
+	// Backing/live store: T-1 has ALREADY been claimed (ga-sa0).
+	live := beads.NewMemStoreFrom(0, []beads.Bead{
+		{
+			ID: "T-1", Title: "work", Type: "task", Status: "in_progress",
+			Assignee: pool + "/th-abc", Metadata: map[string]string{
+				"gc.run_target": pool,
+			},
+		},
+	}, nil)
+	// Stale cache: both List and plain Get still return the pre-claim T-1 — open,
+	// unassigned, unrouted, carrying gc.run_target — so a plain re-read would
+	// clobber the claim. Only HandlesFor(store).Live.Get sees the live claim.
+	store := staleCacheStore{
+		Store: live,
+		cached: beads.Bead{
+			ID: "T-1", Title: "work", Type: "task", Status: "open",
+			Metadata: map[string]string{"gc.run_target": pool},
+		},
+	}
+
+	restored, err := restoreCarriedWorkRoutes(store)
+	if err != nil {
+		t.Fatalf("restoreCarriedWorkRoutes: %v", err)
+	}
+	if restored != 0 {
+		t.Fatalf("restored = %d, want 0 (stale-cache Get must not defeat the claim guard)", restored)
+	}
+	// The claim's route consumption must survive in the live store.
+	if got := mustRoutedTo(t, live, "T-1"); got != "" {
+		t.Fatalf("T-1 gc.routed_to = %q, want empty (claim consumed the route; restore must not re-stamp)", got)
+	}
+	b, err := live.Get("T-1")
+	if err != nil {
+		t.Fatalf("get T-1: %v", err)
+	}
+	if b.Status != "in_progress" || strings.TrimSpace(b.Assignee) == "" {
+		t.Fatalf("T-1 status=%q assignee=%q, want in_progress + assigned (untouched)", b.Status, b.Assignee)
+	}
+}
+
 // TestCityRuntimeRecoverUnroutedWorkRoutes confirms the controller method
 // sweeps both the city store and every rig store, and recovers both carried-route
 // shapes (workflow root and plain work bead).

--- a/cmd/gc/route_recovery_test.go
+++ b/cmd/gc/route_recovery_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -111,6 +112,70 @@ func TestRestoreCarriedWorkRoutesNilStore(t *testing.T) {
 	}
 	if restored != 0 {
 		t.Errorf("restored = %d, want 0 for nil store", restored)
+	}
+}
+
+// staleOpenListStore returns a fixed open-bead snapshot from List while
+// delegating every live read/write (Get, SetMetadata, …) to an embedded store.
+// It reproduces the reconcile TOCTOU: restoreCarriedWorkRoutes captures the open
+// snapshot, but a polecat claims the bead before the per-bead re-stamp runs, so
+// the live store already holds the claimed (in_progress) bead.
+type staleOpenListStore struct {
+	beads.Store
+	openSnapshot []beads.Bead
+}
+
+func (s staleOpenListStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return append([]beads.Bead(nil), s.openSnapshot...), nil
+}
+
+// TestRestoreCarriedWorkRoutesSkipsRaceClaimedBead covers ga-bgu: restore must
+// not re-stamp gc.routed_to onto a bead that a polecat claimed after the
+// open-bead List snapshot. The claim atomically consumes the pool route
+// (open->in_progress, assignee set, gc.routed_to cleared, gc.run_target recorded
+// — ga-sa0). A blind SetMetadata keyed on the stale snapshot resurrects
+// gc.routed_to on the now-in_progress bead, feeding the dispatcher a phantom
+// pool-demand bead that flaps open<->in_progress. Restore must re-read the live
+// bead and skip the write when it is no longer open+unassigned.
+func TestRestoreCarriedWorkRoutesSkipsRaceClaimedBead(t *testing.T) {
+	const pool = "gascity/gastown.polecat"
+	// Live store: the bead has ALREADY been claimed — open->in_progress, assignee
+	// set, gc.routed_to consumed, gc.run_target carrying the route (ga-sa0 claim).
+	live := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "T-1", Title: "work", Type: "task", Status: "in_progress",
+			Assignee: pool + "/th-abc", Metadata: map[string]string{
+				"gc.run_target": pool,
+			}},
+	}, nil)
+	// Stale snapshot: List captured T-1 BEFORE the claim — open, unassigned,
+	// unrouted, carrying gc.run_target, so carriedPoolRoute(snapshot) == pool.
+	store := staleOpenListStore{
+		Store: live,
+		openSnapshot: []beads.Bead{
+			{ID: "T-1", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{
+				"gc.run_target": pool,
+			}},
+		},
+	}
+
+	restored, err := restoreCarriedWorkRoutes(store)
+	if err != nil {
+		t.Fatalf("restoreCarriedWorkRoutes: %v", err)
+	}
+	if restored != 0 {
+		t.Fatalf("restored = %d, want 0 (must not re-stamp a bead claimed since the snapshot)", restored)
+	}
+	// The claim's route consumption must survive: gc.routed_to stays empty.
+	if got := mustRoutedTo(t, live, "T-1"); got != "" {
+		t.Fatalf("T-1 gc.routed_to = %q, want empty (claim consumed the route; restore must not re-stamp)", got)
+	}
+	// And the bead must remain claimed, not silently mutated back toward demand.
+	b, err := live.Get("T-1")
+	if err != nil {
+		t.Fatalf("get T-1: %v", err)
+	}
+	if b.Status != "in_progress" || strings.TrimSpace(b.Assignee) == "" {
+		t.Fatalf("T-1 status=%q assignee=%q, want in_progress + assigned (untouched)", b.Status, b.Assignee)
 	}
 }
 


### PR DESCRIPTION
## What
Guard `restoreCarriedWorkRoutes` with a live re-read of the bead before re-stamping `gc.routed_to`, closing the reconcile TOCTOU that clobbered a concurrent claim's route consumption. +23 LOC in `cmd/gc/route_recovery.go`, plus a new regression test `TestRestoreCarriedWorkRoutesSkipsRaceClaimedBead`.

## Why
A pool bead's `gc.routed_to` could persist after a worker claimed it, so the dispatcher re-saw it as needing dispatch and re-dispatched an actively-claimed bead → oscillation `open`↔`in_progress`, owner thrash, and re-spawned recovery/shadow wisps. A control bead dispatched at the same instant cleared its `routed_to` on claim and stayed stable — proving a per-bead claim-vs-scan race, not a pool-wide issue. The reconcile path now re-reads live state and skips a bead whose route was already consumed by a claim.

## Testing
- `go vet` clean.
- Route-recovery targeted tests 4/4 pass, including the new `TestRestoreCarriedWorkRoutesSkipsRaceClaimedBead` (proven to fail without the guard).
- dispatch/recovery/convoy neighborhood suite green.
- Purely additive (+88 lines, no deletions); compiles clean against current `main`.
