### PR TITLE
fix(events): archive-aware Watch — SSE resume, exporter cursors, and mid-rotation tails survive log rotation

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -75,6 +75,7 @@ type controllerState struct {
 	maintenanceLoop        *supervisor.StoreMaintenanceLoop // nil when [maintenance.dolt] enabled=false
 	updateMu               sync.Mutex                       // serializes rebuild+swap so stale reloads cannot overtake newer mutations
 	beadEventStartSeq      uint64
+	beadEventStartSeqOK    bool // false when LatestSeq errored at construction; 0+true = genuinely empty log
 
 	// emergencyCh receives emergency.Record values from the gc emergency
 	// subsystem. startEmergencyEventRelay drains this channel and mirrors
@@ -128,24 +129,27 @@ func newControllerState(
 	}
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	var beadEventStartSeq uint64
+	var beadEventStartSeqOK bool
 	if ep != nil {
 		if seq, err := ep.LatestSeq(); err == nil {
 			beadEventStartSeq = seq
+			beadEventStartSeqOK = true
 		}
 	}
 	cs := &controllerState{
-		cfg:               cfg,
-		sp:                sp,
-		cacheCtx:          ctx,
-		eventProv:         ep,
-		usageSink:         usageSinkForCity(cfg, cityPath),
-		editor:            configedit.NewEditor(fsys.OSFS{}, tomlPath),
-		cityName:          cityName,
-		cityPath:          cityPath,
-		version:           version,
-		startedAt:         time.Now(),
-		adapterReg:        extmsg.NewAdapterRegistry(),
-		beadEventStartSeq: beadEventStartSeq,
+		cfg:                 cfg,
+		sp:                  sp,
+		cacheCtx:            ctx,
+		eventProv:           ep,
+		usageSink:           usageSinkForCity(cfg, cityPath),
+		editor:              configedit.NewEditor(fsys.OSFS{}, tomlPath),
+		cityName:            cityName,
+		cityPath:            cityPath,
+		version:             version,
+		startedAt:           time.Now(),
+		adapterReg:          extmsg.NewAdapterRegistry(),
+		beadEventStartSeq:   beadEventStartSeq,
+		beadEventStartSeqOK: beadEventStartSeqOK,
 	}
 	cs.beadStores = cs.buildStores(cfg)
 	// Capture the initial raw config snapshot so provenance reads before the
@@ -392,15 +396,21 @@ func (cs *controllerState) startBeadEventWatcher(ctx context.Context) {
 		return
 	}
 	seq := cs.beadEventStartSeq
-	// Fail closed if the start seq could not be resolved at construction: Watch
-	// now treats afterSeq=0 as "replay the entire retained history" (across
-	// archives), so a seq of 0 from a transient LatestSeq error would flood the
-	// bead caches with the whole log. Re-resolve the head here; only a genuinely
-	// empty log legitimately yields 0.
-	if seq == 0 {
-		if latest, err := ep.LatestSeq(); err == nil {
-			seq = latest
+	// A captured seq of 0 with OK=true means the log was genuinely empty at
+	// construction — Watch(0) then replays exactly the prime-window events and
+	// nothing more (nothing older is retained), which is the replay contract
+	// this watcher exists for. Only when LatestSeq ERRORED at construction is 0
+	// untrusted: Watch now treats afterSeq=0 as "replay the entire retained
+	// history" (across archives), so re-resolve the head here and fail closed
+	// (skip the watcher; the scale patrol still converges) rather than flood
+	// the bead caches with the whole log.
+	if !cs.beadEventStartSeqOK {
+		latest, err := ep.LatestSeq()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "api: bead event watcher: start cursor unresolved (%v); skipping watcher\n", err)
+			return
 		}
+		seq = latest
 	}
 	go func() {
 		for {

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -392,6 +392,16 @@ func (cs *controllerState) startBeadEventWatcher(ctx context.Context) {
 		return
 	}
 	seq := cs.beadEventStartSeq
+	// Fail closed if the start seq could not be resolved at construction: Watch
+	// now treats afterSeq=0 as "replay the entire retained history" (across
+	// archives), so a seq of 0 from a transient LatestSeq error would flood the
+	// bead caches with the whole log. Re-resolve the head here; only a genuinely
+	// empty log legitimately yields 0.
+	if seq == 0 {
+		if latest, err := ep.LatestSeq(); err == nil {
+			seq = latest
+		}
+	}
 	go func() {
 		for {
 			watcher, err := ep.Watch(ctx, seq)

--- a/internal/api/global_stream_precheck_test.go
+++ b/internal/api/global_stream_precheck_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// afterSeqRecordingProvider is an events.Provider test double that reports a
+// fixed LatestSeq and records every afterSeq passed to Watch. Tests use it to
+// assert a caller attached at head (afterSeq == latestSeq) rather than at
+// Watch(0) — the cursor that this PR redefines as "replay the entire retained
+// history across archives", which triggers an archive gunzip/backfill.
+type afterSeqRecordingProvider struct {
+	mu        sync.Mutex
+	latestSeq uint64
+	latestErr error
+	watchArgs []uint64
+}
+
+func (p *afterSeqRecordingProvider) Record(events.Event) {}
+
+func (p *afterSeqRecordingProvider) List(events.Filter) ([]events.Event, error) { return nil, nil }
+
+func (p *afterSeqRecordingProvider) LatestSeq() (uint64, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.latestSeq, p.latestErr
+}
+
+func (p *afterSeqRecordingProvider) Watch(ctx context.Context, afterSeq uint64) (events.Watcher, error) {
+	p.mu.Lock()
+	p.watchArgs = append(p.watchArgs, afterSeq)
+	p.mu.Unlock()
+	return newBlockingWatcher(ctx), nil
+}
+
+func (p *afterSeqRecordingProvider) Close() error { return nil }
+
+func (p *afterSeqRecordingProvider) watchedAfterSeqs() []uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]uint64(nil), p.watchArgs...)
+}
+
+// blockingWatcher is a minimal events.Watcher whose Next blocks until the
+// parent context is canceled or Close is called, mirroring a real watcher so
+// the multiplexer's fan-in goroutine does not spin.
+type blockingWatcher struct {
+	ctx  context.Context
+	done chan struct{}
+	once sync.Once
+}
+
+func newBlockingWatcher(ctx context.Context) *blockingWatcher {
+	return &blockingWatcher{ctx: ctx, done: make(chan struct{})}
+}
+
+func (w *blockingWatcher) Next() (events.Event, error) {
+	select {
+	case <-w.ctx.Done():
+		return events.Event{}, w.ctx.Err()
+	case <-w.done:
+		return events.Event{}, errors.New("watcher closed")
+	}
+}
+
+func (w *blockingWatcher) Close() error {
+	w.once.Do(func() { close(w.done) })
+	return nil
+}
+
+// TestGlobalEventStreamPrecheckAttachesAtHeadNotZero guards the iteration-3
+// review finding: the mandatory global-SSE precheck used to attach with
+// mux.Watch(ctx, nil), and nil per-city cursors default to Watch(0), which this
+// PR redefines as a full retained-history replay across archives. Because
+// Multiplexer.Watch eagerly drives each child's Next, that bare probe could
+// gunzip/decode archived batches for every city just to discard them. The
+// precheck must instead attach at each city's head cursor.
+func TestGlobalEventStreamPrecheckAttachesAtHeadNotZero(t *testing.T) {
+	alpha := newFakeState(t)
+	alpha.cityName = "alpha"
+	alphaProv := &afterSeqRecordingProvider{latestSeq: 5}
+	alpha.eventProv = alphaProv
+
+	beta := newFakeState(t)
+	beta.cityName = "beta"
+	betaProv := &afterSeqRecordingProvider{latestSeq: 3}
+	beta.eventProv = betaProv
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"alpha": alpha,
+		"beta":  beta,
+	})
+
+	if err := sm.precheckGlobalEventStream(context.Background(), &SupervisorEventStreamInput{}); err != nil {
+		t.Fatalf("precheckGlobalEventStream: %v", err)
+	}
+
+	// afterSeq < latestSeq is exactly the condition that triggers a full
+	// retained-history archive backfill (internal/events/recorder.go). Attaching
+	// at afterSeq == latestSeq keeps the probe cheap.
+	assertAttachedAtHead := func(name string, prov *afterSeqRecordingProvider, want uint64) {
+		t.Helper()
+		got := prov.watchedAfterSeqs()
+		if len(got) != 1 {
+			t.Fatalf("%s: Watch called %d times, want exactly 1: %v", name, len(got), got)
+		}
+		if got[0] != want {
+			t.Errorf("%s: precheck attached at afterSeq=%d, want %d (head); afterSeq<latest would trigger archive backfill", name, got[0], want)
+		}
+	}
+	assertAttachedAtHead("alpha", alphaProv, 5)
+	assertAttachedAtHead("beta", betaProv, 3)
+}
+
+// TestResolveGlobalStreamCursors pins the shared cursor-resolution helper used
+// by both the precheck and streamGlobalEvents so neither can regress into a
+// Watch(0) full-history flood.
+func TestResolveGlobalStreamCursors(t *testing.T) {
+	newMux := func() *events.Multiplexer {
+		mux := events.NewMultiplexer()
+		mux.Add("alpha", &afterSeqRecordingProvider{latestSeq: 5})
+		mux.Add("beta", &afterSeqRecordingProvider{latestSeq: 3})
+		return mux
+	}
+
+	t.Run("head start resolves every city to its latest cursor", func(t *testing.T) {
+		cursors, err := resolveGlobalStreamCursors(newMux(), "")
+		if err != nil {
+			t.Fatalf("resolveGlobalStreamCursors: %v", err)
+		}
+		if cursors["alpha"] != 5 || cursors["beta"] != 3 {
+			t.Fatalf("cursors = %v, want alpha=5 beta=3", cursors)
+		}
+	})
+
+	t.Run("resume preserves present cities and floors omitted cities to latest", func(t *testing.T) {
+		// A resume cursor that names alpha at 2 but omits the registered beta.
+		resume := events.FormatCursor(map[string]uint64{"alpha": 2})
+		cursors, err := resolveGlobalStreamCursors(newMux(), resume)
+		if err != nil {
+			t.Fatalf("resolveGlobalStreamCursors: %v", err)
+		}
+		if cursors["alpha"] != 2 {
+			t.Errorf("alpha = %d, want 2 (resume position preserved)", cursors["alpha"])
+		}
+		if cursors["beta"] != 3 {
+			t.Errorf("beta = %d, want 3 (omitted city floored to latest, not Watch(0))", cursors["beta"])
+		}
+	})
+
+	t.Run("fails closed when latest cursor errors", func(t *testing.T) {
+		mux := events.NewMultiplexer()
+		mux.Add("alpha", &afterSeqRecordingProvider{latestErr: errors.New("boom")})
+		if _, err := resolveGlobalStreamCursors(mux, ""); err == nil {
+			t.Fatal("expected error when LatestCursor fails, got nil")
+		}
+	})
+}

--- a/internal/api/huma_handlers_events.go
+++ b/internal/api/huma_handlers_events.go
@@ -270,12 +270,17 @@ func (s *Server) streamEvents(hctx huma.Context, input *EventStreamInput, send s
 	ep := s.state.EventProvider()
 	afterSeq := input.resolveAfterSeq()
 	if strings.TrimSpace(input.LastEventID) == "" && strings.TrimSpace(input.AfterSeq) == "" {
+		// Head-start (no resume cursor): stream from now. Fail closed on a
+		// LatestSeq error rather than fall through to afterSeq=0, which Watch now
+		// treats as "replay the entire retained history" (across archives) — a
+		// head-start client must not get a full-history flood. The client can
+		// reconnect.
 		seq, err := ep.LatestSeq()
 		if err != nil {
-			log.Printf("api: events-stream: latest seq failed: %v", err)
-		} else {
-			afterSeq = seq
+			log.Printf("api: events-stream: latest seq failed, refusing head-start replay: %v", err)
+			return
 		}
+		afterSeq = seq
 	}
 	watcher, err := ep.Watch(ctx, afterSeq)
 	if err != nil {

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -767,10 +767,17 @@ func (sm *SupervisorMux) streamGlobalEvents(hctx huma.Context, input *Supervisor
 	mux := sm.buildMultiplexer()
 	var cursors map[string]uint64
 	if cursor == "" {
+		// Head-start (no resume cursor): every city streams from now. Fail
+		// closed on a LatestCursor error rather than let unresolved cities fall
+		// through to cursor 0, which Watch now treats as "replay the entire
+		// retained history" (across archives) — a head-start client must not get
+		// a full-history flood for a city whose head read hiccuped. The client
+		// can reconnect.
 		var err error
 		cursors, err = mux.LatestCursor()
 		if err != nil {
-			log.Printf("api: supervisor events-stream: latest cursor failed: %v", err)
+			log.Printf("api: supervisor events-stream: latest cursor failed, refusing head-start replay: %v", err)
+			return
 		}
 	} else {
 		cursors = events.ParseCursor(cursor)

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -724,6 +724,44 @@ func supervisorEventCursorFromMux(mux *events.Multiplexer) (string, error) {
 
 // --- Supervisor global events stream (Fix 3g final wiring) ---
 
+// resolveGlobalStreamCursors builds the per-city cursor map for a global
+// event-stream Watch so that no registered city falls through to Watch(0),
+// which now replays a city's entire retained history across archives.
+//
+// With no resume cursor — a head-start client or the attach-only precheck —
+// every city starts from its latest cursor. With a resume cursor, cities the
+// cursor omits are floored to their latest cursor so a cursor that predates a
+// newly registered city cannot trigger a full-history flood for it. It fails
+// closed on a LatestCursor error rather than letting unresolved cities default
+// to cursor 0. The returned map is always non-nil on success.
+func resolveGlobalStreamCursors(mux *events.Multiplexer, resumeCursor string) (map[string]uint64, error) {
+	resumeCursor = strings.TrimSpace(resumeCursor)
+	if resumeCursor == "" {
+		cursors, err := mux.LatestCursor()
+		if err != nil {
+			return nil, err
+		}
+		if cursors == nil {
+			cursors = make(map[string]uint64)
+		}
+		return cursors, nil
+	}
+	cursors := events.ParseCursor(resumeCursor)
+	if cursors == nil {
+		cursors = make(map[string]uint64)
+	}
+	latest, err := mux.LatestCursor()
+	if err != nil {
+		return nil, err
+	}
+	for city, seq := range latest {
+		if _, ok := cursors[city]; !ok {
+			cursors[city] = seq
+		}
+	}
+	return cursors, nil
+}
+
 // precheckGlobalEventStream validates that the global event stream
 // can actually deliver events before committing 200 headers. Two
 // failure modes both produce 503 Problem Details instead of 200+EOF:
@@ -736,15 +774,24 @@ func supervisorEventCursorFromMux(mux *events.Multiplexer) (string, error) {
 //     finds the newly-registered city in the mux.
 //  2. Providers exist but none can attach a watcher right now.
 //
-// The precheck attaches a watcher and closes it immediately — a
-// cheap probe that surfaces per-city watcher failures at the point
-// where we can still return a proper HTTP error.
+// The precheck attaches a watcher at each city's head cursor and closes it
+// immediately — a cheap probe that surfaces per-city watcher failures at the
+// point where we can still return a proper HTTP error. It must not attach with
+// nil cursors: nil defaults every child to Watch(0), which now replays the
+// entire retained history across archives, so a bare probe would gunzip and
+// decode archived batches for every city only to discard them when it closes.
+// Resolving head cursors keeps the probe cheap and fails closed exactly like
+// the streamGlobalEvents head-start path.
 func (sm *SupervisorMux) precheckGlobalEventStream(ctx context.Context, _ *SupervisorEventStreamInput) error {
 	mux := sm.buildMultiplexer()
 	if mux.Len() == 0 {
 		return apierr.ServiceUnavailable.Msg("no_providers: no event providers available")
 	}
-	probe, err := mux.Watch(ctx, nil)
+	cursors, err := resolveGlobalStreamCursors(mux, "")
+	if err != nil {
+		return apierr.ServiceUnavailable.Msg("cursor_failed: " + err.Error())
+	}
+	probe, err := mux.Watch(ctx, cursors)
 	if err != nil {
 		if errors.Is(err, events.ErrNoWatchers) {
 			return apierr.ServiceUnavailable.Msg("no_watchers: event providers are registered but none are watchable")
@@ -765,25 +812,14 @@ func (sm *SupervisorMux) streamGlobalEvents(hctx huma.Context, input *Supervisor
 	}
 
 	mux := sm.buildMultiplexer()
-	var cursors map[string]uint64
-	if cursor == "" {
-		// Head-start (no resume cursor): every city streams from now. Fail
-		// closed on a LatestCursor error rather than let unresolved cities fall
-		// through to cursor 0, which Watch now treats as "replay the entire
-		// retained history" (across archives) — a head-start client must not get
-		// a full-history flood for a city whose head read hiccuped. The client
-		// can reconnect.
-		var err error
-		cursors, err = mux.LatestCursor()
-		if err != nil {
-			log.Printf("api: supervisor events-stream: latest cursor failed, refusing head-start replay: %v", err)
-			return
-		}
-	} else {
-		cursors = events.ParseCursor(cursor)
-	}
-	if cursors == nil {
-		cursors = make(map[string]uint64)
+	// Resolve per-city cursors so no city falls through to Watch(0) full-history
+	// replay: head-start clients start every city from now, and a resume cursor
+	// that omits a registered city floors that city to its latest cursor. Fail
+	// closed on a LatestCursor error — the client can reconnect.
+	cursors, err := resolveGlobalStreamCursors(mux, cursor)
+	if err != nil {
+		log.Printf("api: supervisor events-stream: resolving stream cursors failed, refusing full-history replay: %v", err)
+		return
 	}
 	mw, err := mux.Watch(hctx.Context(), cursors)
 	if err != nil {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -311,9 +311,15 @@ type Provider interface {
 	// LatestSeq returns the highest sequence number, or 0 if empty.
 	LatestSeq() (uint64, error)
 
-	// Watch returns a Watcher that yields events with Seq > afterSeq.
-	// The watcher blocks on Next() until an event arrives or ctx is
-	// canceled. Callers must call Close() when done.
+	// Watch returns a Watcher that yields every RETAINED event with
+	// Seq > afterSeq, in sequence order, exactly once per watcher —
+	// including events recorded before Watch was called and events that
+	// have since rotated into an archive. (Across separate watcher
+	// instances delivery is at-least-once; callers de-dupe by seq.) The
+	// watcher blocks on Next() until an event arrives or ctx is
+	// canceled. afterSeq=0 therefore requests the entire retained
+	// history; pass LatestSeq() to stream only from now. Callers must
+	// call Close() when done.
 	Watch(ctx context.Context, afterSeq uint64) (Watcher, error)
 
 	// Close releases any resources held by the provider.

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1260,6 +1260,84 @@ func TestFileRecorderWatchContextCancel(t *testing.T) {
 	}
 }
 
+// TestWatchNextBlockedThenContextEndsReturnsContextErr pins the watcher
+// cancellation contract for a Next that is already blocked waiting for new
+// events (the steady state of an idle SSE stream). When the context ends while
+// Next sleeps it must return the context cause — context.Canceled or
+// context.DeadlineExceeded — not errWatcherClosed, so callers that classify the
+// context error can tell a real cancellation/deadline from a closed watcher.
+func TestWatchNextBlockedThenContextEndsReturnsContextErr(t *testing.T) {
+	newBlockedWatcher := func(t *testing.T, ctx context.Context) (Watcher, func()) {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "events.jsonl")
+		var stderr bytes.Buffer
+		rec, err := NewFileRecorder(path, &stderr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "seed"})
+		w, err := rec.Watch(ctx, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Consume the seed so the next Next has nothing to return and blocks in
+		// the poll sleep.
+		if _, err := w.Next(); err != nil {
+			t.Fatalf("draining seed: %v", err)
+		}
+		return w, func() {
+			_ = w.Close()
+			_ = rec.Close()
+		}
+	}
+
+	t.Run("canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		w, cleanup := newBlockedWatcher(t, ctx)
+		defer cleanup()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := w.Next()
+			errCh <- err
+		}()
+		// End the context from a timer so Next is already parked in its poll
+		// sleep when cancellation lands, exercising the blocked-Next path
+		// without a wall-clock time.Sleep (mirrors the deadline subtest below).
+		time.AfterFunc(50*time.Millisecond, cancel)
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("Next after cancel-while-blocked = %v, want context.Canceled", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("Next did not observe cancellation while blocked")
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+		defer cancel()
+		w, cleanup := newBlockedWatcher(t, ctx)
+		defer cleanup()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := w.Next()
+			errCh <- err
+		}()
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("Next after deadline-while-blocked = %v, want context.DeadlineExceeded", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("Next did not observe deadline while blocked")
+		}
+	})
+}
+
 // writeEmpty creates an empty file at path.
 func writeEmpty(path string) error {
 	f, err := os.Create(path)

--- a/internal/events/eventstest/conformance.go
+++ b/internal/events/eventstest/conformance.go
@@ -6,6 +6,7 @@ package eventstest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -600,6 +601,58 @@ func RunProviderTests(t *testing.T, newProvider func(t *testing.T) (events.Provi
 		}
 		if e.Seq <= lastSeq {
 			t.Errorf("Seq = %d, want > %d", e.Seq, lastSeq)
+		}
+	})
+
+	// WatchReplaysRetainedHistory pins the Watch contract: a watcher attached
+	// with afterSeq below the retained head must replay every retained event
+	// with Seq > afterSeq, in order, exactly once — including events recorded
+	// before Watch was called. This is provider-neutral (no rotation); the
+	// FileRecorder-specific resume-across-rotation case lives in RunRotationTests.
+	t.Run("WatchReplaysRetainedHistory", func(t *testing.T) {
+		p, cleanup := newProvider(t)
+		defer cleanup()
+
+		for i := 0; i < 5; i++ {
+			p.Record(events.Event{Type: events.BeadCreated, Actor: "human", Subject: fmt.Sprintf("h-%d", i)})
+		}
+		all, err := p.List(events.Filter{})
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(all) < 5 {
+			t.Fatalf("need 5 events, got %d", len(all))
+		}
+		// Resume from the 2nd event's seq: expect events 3,4,5 (indices 2,3,4).
+		afterSeq := all[1].Seq
+		want := all[2:]
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		w, err := p.Watch(ctx, afterSeq)
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+		defer w.Close() //nolint:errcheck // test cleanup
+
+		for i, wantEv := range want {
+			type res struct {
+				e   events.Event
+				err error
+			}
+			ch := make(chan res, 1)
+			go func() { e, err := w.Next(); ch <- res{e, err} }()
+			select {
+			case r := <-ch:
+				if r.err != nil {
+					t.Fatalf("Next %d: %v", i, r.err)
+				}
+				if r.e.Seq != wantEv.Seq {
+					t.Fatalf("replay event %d seq = %d, want %d (pre-Watch history skipped?)", i, r.e.Seq, wantEv.Seq)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("replay event %d (seq %d) never delivered", i, wantEv.Seq)
+			}
 		}
 	})
 

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -558,6 +558,16 @@ func ReadFrom(path string, offset int64) ([]Event, int64, error) {
 	}
 	defer f.Close() //nolint:errcheck // read-only file
 
+	return readEventsFrom(f, offset)
+}
+
+// readEventsFrom scans events from an already-open active log starting at offset,
+// returning the decoded events and the offset advanced past every complete line.
+// A trailing partial line (no newline) does not advance the offset, so a later
+// read re-reads it once the writer completes it. Reading from a caller-supplied
+// fd (rather than re-opening by path) lets a tailer pin the file identity across
+// a concurrent rotation.
+func readEventsFrom(f *os.File, offset int64) ([]Event, int64, error) {
 	if _, err := f.Seek(offset, io.SeekStart); err != nil {
 		return nil, offset, fmt.Errorf("seeking events: %w", err)
 	}

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -512,11 +513,24 @@ func (r *FileRecorder) Watch(ctx context.Context, afterSeq uint64) (Watcher, err
 	// Backfill is needed only when the cursor predates the active file's head.
 	if haveStat && afterSeq < latestSeq {
 		w.needsBackfill = true
+		w.bfActive = true
 	} else if activeFile != nil {
-		_ = activeFile.Close()
-		w.activeFile = nil
+		// No backfill: close the captured fd immediately (once).
+		w.closeFd()
 	}
 	return w, nil
+}
+
+// closeFd closes the captured active fd exactly once. The pointer is never
+// niled (writing it would race an unsynchronized read in the Next goroutine);
+// os.File tolerates a concurrent Close vs Read, so a mid-read Close just makes
+// the in-flight scan return an error, which the caller treats as cancellation.
+func (w *fileWatcher) closeFd() {
+	w.closeFdOnce.Do(func() {
+		if w.activeFile != nil {
+			_ = w.activeFile.Close()
+		}
+	})
 }
 
 // Close closes the underlying file. It is safe to call multiple times;
@@ -573,10 +587,26 @@ type fileWatcher struct {
 	done     chan struct{}
 
 	// Resume-backfill state (W1): the archive/rotating segments to replay before
-	// tailing, and the active file's fd + size captured at Watch time.
+	// tailing, and the active file's fd + size captured at Watch time. The fd is
+	// assigned once in Watch and never reassigned; closeFdOnce closes it exactly
+	// once from whichever of Close / finishBackfill runs first, so the pointer is
+	// never written after Watch and cannot race a read.
 	needsBackfill bool
 	activeFile    *os.File
 	activeSize    int64
+	closeFdOnce   sync.Once
+
+	// Incremental backfill iterator state (bounded memory): the remaining
+	// segments, the index into them, whether the active leg is pending, and the
+	// currently-open segment reader (persisted across Next batches so each
+	// segment is read exactly once).
+	bfSources  []backfillSource
+	bfIdx      int
+	bfListed   bool
+	bfActive   bool
+	bfReader   *segmentReader
+	bfCatchUp  bool // true while draining a mid-watch rotation catch-up
+	catchUpErr int  // consecutive catch-up failures, for backoff
 
 	closeOnce sync.Once
 }
@@ -604,10 +634,11 @@ func (w *fileWatcher) Next() (Event, error) {
 		}
 
 		// Resume backfill (W1): replay archived/rotating events before tailing.
-		// Runs lazily here, one source per batch, so a never-polled watcher pays
-		// nothing and memory stays bounded to one segment.
+		// Runs lazily here, at most backfillBatch events per call, so a
+		// never-polled watcher pays nothing and resident memory is bounded to one
+		// batch regardless of history size or connection count.
 		if w.needsBackfill {
-			if err := w.runResumeBackfill(); err != nil {
+			if err := w.stepBackfill(Filter{}, false); err != nil {
 				return Event{}, err
 			}
 			if len(w.buf) > 0 {
@@ -619,23 +650,39 @@ func (w *fileWatcher) Next() (Event, error) {
 		// across the just-rotated archive (W2): events appended to the OLD active
 		// file after the last poll now live only in the rotating/.gz file, so a
 		// bare offset reset would drop them. Commit the fresh identity only after
-		// a successful catch-up; on error keep the old identity and retry next
-		// poll (an early commit would make the next poll see no rotation).
+		// the catch-up fully drains; on error do NOT poll the fresh file at the
+		// stale offset (that would advance maxSeq past the unread window and lose
+		// it forever) — sleep and retry with a bounded backoff instead.
 		if info, err := os.Stat(w.path); err == nil {
 			if curr := inodeOf(info); curr != 0 {
 				if w.inode != 0 && curr != w.inode {
-					if cerr := w.catchUpRotation(); cerr != nil {
+					done, cerr := w.stepCatchUp()
+					if cerr != nil {
 						if isCancelErr(cerr) {
 							return Event{}, cerr
 						}
-						// Transient read error: leave identity/offset, retry.
-					} else {
-						w.inode = curr
-						w.offset = 0
-						if len(w.buf) > 0 {
-							continue
+						// Transient read error: keep the old identity/offset, back
+						// off, and retry — never fall through to the stale-offset
+						// poll below.
+						w.catchUpErr++
+						if w.catchUpErr == 1 || w.catchUpErr%40 == 0 {
+							log.Printf("events: watcher rotation catch-up failed (attempt %d) for %q: %v", w.catchUpErr, w.path, cerr)
 						}
+						if !w.sleepBackoff() {
+							return Event{}, errWatcherClosed
+						}
+						continue
 					}
+					if len(w.buf) > 0 {
+						return w.pop(), nil
+					}
+					if !done {
+						continue // more catch-up batches pending
+					}
+					// Catch-up drained: commit the fresh identity and re-tail.
+					w.catchUpErr = 0
+					w.inode = curr
+					w.offset = 0
 				} else {
 					w.inode = curr
 				}
@@ -662,134 +709,208 @@ func (w *fileWatcher) Next() (Event, error) {
 		}
 
 		// No new events — wait and retry.
-		select {
-		case <-w.ctx.Done():
-			return Event{}, w.ctx.Err()
-		case <-w.done:
+		if !w.sleep() {
 			return Event{}, errWatcherClosed
-		case <-time.After(w.poll):
 		}
 	}
 }
 
-// runResumeBackfill streams the next resume segment (archive, rotating file, or
-// the captured active-file tail) into w.buf, advancing w.maxSeq. It processes
-// one segment per call so memory stays bounded and the consumer paces it; when
-// every segment is exhausted it clears needsBackfill and positions the tail at
-// the captured active size. The archive walk holds a concurrency slot so N cold
-// resumes queue instead of multiplying gunzip cost.
-func (w *fileWatcher) runResumeBackfill() error {
-	if err := acquireBackfillSlot(w.ctx); err != nil {
-		return err
-	}
-	defer releaseBackfillSlot()
-
-	srcs, err := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
-	if err != nil {
-		// Directory listing failed: skip straight to the active-file leg + tail.
-		srcs = nil
-	}
-	filter := Filter{}
-	for i := range srcs {
-		if err := streamBackfillSource(w.ctx, w.done, srcs[i], filter, &w.maxSeq, &w.buf); err != nil {
-			return err
-		}
-		if len(w.buf) > 0 {
-			return nil // one segment per batch; resume on the next Next
-		}
-	}
-	// Active-file leg: read from the captured fd (not the path) up to the size
-	// captured at Watch time, so a rotation mid-backfill cannot swap the bytes.
-	if w.activeFile != nil {
-		if err := w.streamActiveLeg(filter); err != nil {
-			return err
-		}
-	}
-	w.finishBackfill()
-	return nil
+func (w *fileWatcher) pop() Event {
+	e := w.buf[0]
+	w.buf = w.buf[1:]
+	return e
 }
 
-// streamActiveLeg replays the captured active-file fd (0..activeSize) into
-// w.buf, honoring the monotonic guard and cancellation.
-func (w *fileWatcher) streamActiveLeg(filter Filter) error {
-	if _, err := w.activeFile.Seek(0, 0); err != nil {
-		return err
-	}
-	lr := &io.LimitedReader{R: w.activeFile, N: w.activeSize}
-	guard := func(e Event) bool {
-		select {
-		case <-w.ctx.Done():
-			return false
-		case <-w.done:
-			return false
-		default:
-		}
-		if e.Seq > w.maxSeq {
-			w.maxSeq = e.Seq
-			w.buf = append(w.buf, e)
-		}
+// sleep waits one poll interval, returning false on ctx cancel / Close.
+func (w *fileWatcher) sleep() bool {
+	select {
+	case <-w.ctx.Done():
+		return false
+	case <-w.done:
+		return false
+	case <-time.After(w.poll):
 		return true
 	}
-	if err := scanJSONL(lr, filter, guard); err != nil {
-		return err
+}
+
+// sleepBackoff waits poll * min(catchUpErr, 8) so a persistently failing
+// catch-up (e.g. a poisoned archive) does not re-gunzip at 4/sec and starve
+// other watchers' backfill slots.
+func (w *fileWatcher) sleepBackoff() bool {
+	mult := time.Duration(w.catchUpErr)
+	if mult > 8 {
+		mult = 8
 	}
 	select {
 	case <-w.ctx.Done():
-		return w.ctx.Err()
+		return false
 	case <-w.done:
-		return errWatcherClosed
-	default:
-		return nil
+		return false
+	case <-time.After(w.poll * mult):
+		return true
 	}
 }
 
-// finishBackfill releases the captured fd and positions the incremental tail at
-// the captured active size so it re-reads only bytes appended after Watch.
-func (w *fileWatcher) finishBackfill() {
-	w.needsBackfill = false
-	if w.activeFile != nil {
-		_ = w.activeFile.Close()
-		w.activeFile = nil
-	}
-	if w.offset < w.activeSize {
-		w.offset = w.activeSize
-	}
-}
-
-// catchUpRotation streams events after w.maxSeq from the archives/rotating files
-// (where the just-rotated tail now lives) into w.buf before the caller resets
-// the offset. AfterSeq = maxSeq bounds it to the rotation window.
-func (w *fileWatcher) catchUpRotation() error {
-	if err := acquireBackfillSlot(w.ctx); err != nil {
+// stepBackfill advances the resume backfill by up to backfillBatch events. It
+// keeps the current segment reader open across calls so each segment is read
+// exactly once, holding a decode slot only for the duration of one batch read.
+// When every segment and the active leg are exhausted it clears needsBackfill
+// and positions the tail at the captured active size.
+func (w *fileWatcher) stepBackfill(filter Filter, catchUp bool) error {
+	if err := acquireBackfillSlot(w.ctx, w.done); err != nil {
 		return err
 	}
 	defer releaseBackfillSlot()
 
-	srcs, err := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
-	if err != nil {
-		return err
+	if !w.bfListed {
+		srcs, err := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
+		if err != nil {
+			if catchUp {
+				return err
+			}
+			srcs = nil // resume: fall through to the active leg + tail
+		}
+		w.bfSources = srcs
+		w.bfIdx = 0
+		w.bfListed = true
 	}
-	filter := Filter{AfterSeq: w.maxSeq}
-	for i := range srcs {
-		if err := streamBackfillSource(w.ctx, w.done, srcs[i], filter, &w.maxSeq, &w.buf); err != nil {
+
+	// Advance through segments, one batch per call.
+	for w.bfIdx < len(w.bfSources) {
+		if w.bfReader == nil {
+			f := filter
+			if f.AfterSeq < w.maxSeq {
+				f.AfterSeq = w.maxSeq
+			}
+			sr, err := openSegmentReader(w.bfSources[w.bfIdx])
+			if err != nil {
+				return err
+			}
+			if sr == nil { // vanished (promoted rotating file); its .gz covers it
+				w.bfIdx++
+				continue
+			}
+			w.bfReader = sr
+		}
+		eof, err := w.bfReader.readInto(withAfterSeq(filter, w.maxSeq), &w.maxSeq, &w.buf, backfillBatch)
+		if err != nil {
+			w.bfReader.close()
+			w.bfReader = nil
 			return err
 		}
+		if eof {
+			w.bfReader.close()
+			w.bfReader = nil
+			w.bfIdx++
+		}
+		if len(w.buf) > 0 {
+			return nil // yield this batch; resume on the next call
+		}
+	}
+
+	// Active leg (resume only): read the captured fd up to the captured size.
+	if w.bfActive && w.activeFile != nil {
+		if w.bfReader == nil {
+			sr, err := activeSegmentReader(w.activeFile, w.activeSize)
+			if err != nil {
+				return err
+			}
+			w.bfReader = sr
+		}
+		eof, err := w.bfReader.readInto(withAfterSeq(filter, w.maxSeq), &w.maxSeq, &w.buf, backfillBatch)
+		if err != nil {
+			w.bfReader.close()
+			w.bfReader = nil
+			return err
+		}
+		if !eof && len(w.buf) > 0 {
+			return nil
+		}
+		if eof {
+			w.bfReader.close() // closes the wrapper, not the caller-owned fd
+			w.bfReader = nil
+			w.finishResume()
+		}
+		return nil
+	}
+
+	if !catchUp {
+		w.finishResume()
 	}
 	return nil
+}
+
+// stepCatchUp advances a mid-watch rotation catch-up by up to backfillBatch
+// events. It reuses the same incremental segment machinery bounded by
+// AfterSeq=maxSeq (the rotation window). Returns done=true when the catch-up has
+// drained every segment; a fresh catch-up resets the iterator state first.
+func (w *fileWatcher) stepCatchUp() (bool, error) {
+	if !w.bfCatchUp {
+		// Starting a new catch-up: reset the segment iterator to re-list.
+		w.resetBackfillIter()
+		w.bfCatchUp = true
+	}
+	before := len(w.buf)
+	if err := w.stepBackfill(Filter{AfterSeq: w.maxSeq}, true); err != nil {
+		return false, err
+	}
+	// Not done while a batch was produced or segments remain.
+	if len(w.buf) > before {
+		return false, nil
+	}
+	done := w.bfIdx >= len(w.bfSources) && w.bfReader == nil
+	if done {
+		w.bfCatchUp = false
+		w.resetBackfillIter()
+	}
+	return done, nil
+}
+
+// withAfterSeq returns filter with AfterSeq raised to at least floor.
+func withAfterSeq(filter Filter, floor uint64) Filter {
+	if filter.AfterSeq < floor {
+		filter.AfterSeq = floor
+	}
+	return filter
+}
+
+// finishResume ends the W1 resume: closes the captured fd (once) and positions
+// the incremental tail at the captured active size so it re-reads only bytes
+// appended after Watch.
+func (w *fileWatcher) finishResume() {
+	w.needsBackfill = false
+	w.bfActive = false
+	w.closeFd()
+	if w.offset < w.activeSize {
+		w.offset = w.activeSize
+	}
+	w.resetBackfillIter()
+}
+
+// resetBackfillIter clears the segment-iterator state, closing any open reader.
+func (w *fileWatcher) resetBackfillIter() {
+	if w.bfReader != nil {
+		w.bfReader.close()
+		w.bfReader = nil
+	}
+	w.bfSources = nil
+	w.bfIdx = 0
+	w.bfListed = false
 }
 
 func isCancelErr(err error) bool {
 	return errors.Is(err, errWatcherClosed) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
-// Close unblocks any pending Next call and releases the captured active fd.
+// Close unblocks any pending Next call and releases the captured active fd. It
+// does not touch the segment-iterator state — the single Next goroutine owns
+// that and will observe w.done. The fd pointer is never niled; closeFd closes it
+// exactly once whether Close or finishResume runs first, so no field write races
+// the Next goroutine's reads.
 func (w *fileWatcher) Close() error {
 	w.closeOnce.Do(func() {
 		close(w.done)
-		if w.activeFile != nil {
-			_ = w.activeFile.Close()
-			w.activeFile = nil
-		}
+		w.closeFd()
 	})
 	return nil
 }

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -685,6 +685,14 @@ func (w *fileWatcher) Next() (Event, error) {
 					w.offset = 0
 				} else {
 					w.inode = curr
+					// Same identity but a cursor beyond EOF is stale (e.g. an
+					// inode reused across a rotation the stat window missed, or
+					// a truncated file): ReadFrom would seek past EOF and skip
+					// everything below it forever. Rewind; the seq guard drops
+					// any overlap re-read.
+					if w.offset > info.Size() {
+						w.offset = 0
+					}
 				}
 			}
 		}

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -599,7 +599,14 @@ type fileWatcher struct {
 	// Incremental backfill iterator state (bounded memory): the remaining
 	// segments, the index into them, whether the active leg is pending, and the
 	// currently-open segment reader (persisted across Next batches so each
-	// segment is read exactly once).
+	// segment is read exactly once). bfSources/bfIdx/bfListed are owned solely by
+	// the single Next consumer. bfReader is the one exception: a consumer that
+	// abandons the watcher mid-backfill (e.g. an SSE client that disconnects
+	// after a partial archive batch) reaches Close on a possibly different
+	// goroutine than Next, so bfMu serializes every bfReader open/read/close with
+	// that Close and lets it release the archive fd + gzip.Reader instead of
+	// leaking them until GC.
+	bfMu       sync.Mutex
 	bfSources  []backfillSource
 	bfIdx      int
 	bfListed   bool
@@ -614,113 +621,214 @@ type fileWatcher struct {
 // errWatcherClosed is returned by Next after Close.
 var errWatcherClosed = fmt.Errorf("watcher closed")
 
-// Next blocks until the next event is available or the context is canceled.
+// Next blocks until the next event is available or the context is canceled. It
+// runs a uniform per-poll pipeline: drain any buffered batch, then resume
+// backfill (W1) and rotation catch-up (W2) — each reporting whether Next should
+// re-loop — before tailing the active file. Each step is a small method so the
+// loop stays readable and the individual state machines are independently
+// testable.
 func (w *fileWatcher) Next() (Event, error) {
 	for {
-		// Drain buffer first.
 		if len(w.buf) > 0 {
-			e := w.buf[0]
-			w.buf = w.buf[1:]
-			return e, nil
+			return w.pop(), nil
 		}
-
-		// Check context and close.
-		select {
-		case <-w.ctx.Done():
-			return Event{}, w.ctx.Err()
-		case <-w.done:
-			return Event{}, errWatcherClosed
-		default:
+		if err := w.ctxErr(); err != nil {
+			return Event{}, err
 		}
-
-		// Resume backfill (W1): replay archived/rotating events before tailing.
-		// Runs lazily here, at most backfillBatch events per call, so a
-		// never-polled watcher pays nothing and resident memory is bounded to one
-		// batch regardless of history size or connection count.
-		if w.needsBackfill {
-			if err := w.stepBackfill(Filter{}, false); err != nil {
-				return Event{}, err
-			}
-			if len(w.buf) > 0 {
-				continue
-			}
-		}
-
-		// Detect rotation by inode change. Before resetting the offset, catch up
-		// across the just-rotated archive (W2): events appended to the OLD active
-		// file after the last poll now live only in the rotating/.gz file, so a
-		// bare offset reset would drop them. Commit the fresh identity only after
-		// the catch-up fully drains; on error do NOT poll the fresh file at the
-		// stale offset (that would advance maxSeq past the unread window and lose
-		// it forever) — sleep and retry with a bounded backoff instead.
-		if info, err := os.Stat(w.path); err == nil {
-			if curr := inodeOf(info); curr != 0 {
-				if w.inode != 0 && curr != w.inode {
-					done, cerr := w.stepCatchUp()
-					if cerr != nil {
-						if isCancelErr(cerr) {
-							return Event{}, cerr
-						}
-						// Transient read error: keep the old identity/offset, back
-						// off, and retry — never fall through to the stale-offset
-						// poll below.
-						w.catchUpErr++
-						if w.catchUpErr == 1 || w.catchUpErr%40 == 0 {
-							log.Printf("events: watcher rotation catch-up failed (attempt %d) for %q: %v", w.catchUpErr, w.path, cerr)
-						}
-						if !w.sleepBackoff() {
-							return Event{}, errWatcherClosed
-						}
-						continue
-					}
-					if len(w.buf) > 0 {
-						return w.pop(), nil
-					}
-					if !done {
-						continue // more catch-up batches pending
-					}
-					// Catch-up drained: commit the fresh identity and re-tail.
-					w.catchUpErr = 0
-					w.inode = curr
-					w.offset = 0
-				} else {
-					w.inode = curr
-					// Same identity but a cursor beyond EOF is stale (e.g. an
-					// inode reused across a rotation the stat window missed, or
-					// a truncated file): ReadFrom would seek past EOF and skip
-					// everything below it forever. Rewind; the seq guard drops
-					// any overlap re-read.
-					if w.offset > info.Size() {
-						w.offset = 0
-					}
-				}
-			}
-		}
-
-		// Poll for new events.
-		evts, newOffset, err := ReadFrom(w.path, w.offset)
+		cont, err := w.stepResume()
 		if err != nil {
 			return Event{}, err
 		}
-		w.offset = newOffset
-
-		// Filter to events after our cursor.
-		for _, e := range evts {
-			if e.Seq > w.maxSeq {
-				w.maxSeq = e.Seq
-				w.buf = append(w.buf, e)
-			}
+		if cont {
+			continue
 		}
-
+		cont, err = w.stepRotation()
+		if err != nil {
+			return Event{}, err
+		}
+		if cont {
+			continue
+		}
+		// Tail the active file from the current offset.
+		if err := w.stepTail(); err != nil {
+			return Event{}, err
+		}
 		if len(w.buf) > 0 {
-			continue // drain buffer on next iteration
+			continue
 		}
-
 		// No new events — wait and retry.
-		if !w.sleep() {
-			return Event{}, errWatcherClosed
+		if err := w.sleep(); err != nil {
+			return Event{}, err
 		}
 	}
+}
+
+// stepResume advances the resume backfill (W1) by one batch, replaying archived
+// and rotating events before the tail starts. It runs lazily and buffers at most
+// backfillBatch events per call, so a never-polled watcher pays nothing and
+// resident memory stays bounded to one batch. It returns cont=true when a batch
+// was buffered (Next should yield it) and false once resume is done or was never
+// needed.
+func (w *fileWatcher) stepResume() (cont bool, err error) {
+	if !w.needsBackfill {
+		return false, nil
+	}
+	if err := w.stepBackfill(Filter{}, false); err != nil {
+		return false, err
+	}
+	return len(w.buf) > 0, nil
+}
+
+// ctxErr reports a terminal error when the watcher's context is canceled or it
+// has been closed, so Next can bail before doing more work. It prefers the
+// context cause so callers that classify context.Canceled / DeadlineExceeded
+// keep that signal.
+func (w *fileWatcher) ctxErr() error {
+	select {
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	case <-w.done:
+		return errWatcherClosed
+	default:
+		return nil
+	}
+}
+
+// stepRotation detects a mid-watch rotation (active-file inode change) and
+// drains the just-rotated archive(s) before the tail resumes on the fresh
+// active file. It stays correct across repeated rotations that land while an
+// earlier catch-up is still draining: the same-inode fast path is suppressed
+// while a catch-up is active (so a later rotation that reused our anchor inode
+// cannot abandon the drain and poll the fresh file at a stale offset), and
+// stepCatchUp re-lists by seq so an extra rotation window is not skipped.
+//
+// It returns cont=true when Next should re-loop (a catch-up batch was buffered,
+// more batches remain, or a transient error backed off) and cont=false when no
+// rotation is in progress and Next should tail the active file.
+func (w *fileWatcher) stepRotation() (cont bool, err error) {
+	info, statErr := os.Stat(w.path)
+	if statErr != nil {
+		return false, nil // let stepTail surface any real read error
+	}
+	curr := inodeOf(info)
+	if curr == 0 {
+		return false, nil
+	}
+	if !w.bfCatchUp && (w.inode == 0 || curr == w.inode) {
+		// Steady state: same active file (or first poll). Adopt the inode and
+		// rewind a cursor stranded past EOF (an inode reuse the stat window
+		// missed, or a truncation) so ReadFrom does not seek past the tail.
+		w.inode = curr
+		if w.offset > info.Size() {
+			w.offset = 0
+		}
+		return false, nil
+	}
+
+	// A rotation was detected, or a catch-up is still draining. Drive it.
+	done, cerr := w.stepCatchUp()
+	if cerr != nil {
+		if isCancelErr(cerr) {
+			return false, cerr
+		}
+		// Transient read error: keep the old identity/offset and back off —
+		// never fall through to a stale-offset poll (which would advance maxSeq
+		// past the unread window and lose it forever).
+		if berr := w.backoffCatchUp(cerr); berr != nil {
+			return false, berr
+		}
+		return true, nil
+	}
+	if len(w.buf) > 0 || !done {
+		return true, nil // deliver this batch, or keep draining
+	}
+	// Catch-up drained and the active file is contiguous with the cursor:
+	// commit the fresh identity and re-tail from its start.
+	w.catchUpErr = 0
+	w.inode = curr
+	w.offset = 0
+	return false, nil
+}
+
+// backoffCatchUp records a transient rotation catch-up failure, logs it at a
+// throttled cadence, and waits with escalating backoff. It returns a terminal
+// error when the wait was canceled/closed and nil to retry.
+func (w *fileWatcher) backoffCatchUp(cerr error) error {
+	w.catchUpErr++
+	if w.catchUpErr == 1 || w.catchUpErr%40 == 0 {
+		log.Printf("events: watcher rotation catch-up failed (attempt %d) for %q: %v", w.catchUpErr, w.path, cerr)
+	}
+	return w.sleepBackoff()
+}
+
+// stepTail polls the active file from the current offset and buffers any events
+// beyond the cursor. It reads through an identity-checked fd (readActiveTail) so
+// a rotation landing in the catch-up conclusion window — after stepCatchUp's
+// final empty re-list but before this read — cannot redirect the tail to a fresh
+// active file and advance maxSeq past a just-archived window. On such a mismatch
+// it defers to rotation catch-up without advancing. The strictly-monotonic
+// maxSeq guard drops any overlap re-read after a rewind or catch-up.
+func (w *fileWatcher) stepTail() error {
+	evts, newOffset, matched, err := readActiveTail(w.path, w.offset, w.inode)
+	if err != nil {
+		return err
+	}
+	if !matched {
+		// The active path rotated between the rotation check and this read. Do
+		// not advance maxSeq/offset from the unverified fresh file; the next
+		// poll's rotation catch-up re-lists by seq and drains the just-archived
+		// window before this fresh active file is tailed.
+		return nil
+	}
+	w.offset = newOffset
+	for _, e := range evts {
+		if e.Seq > w.maxSeq {
+			w.maxSeq = e.Seq
+			w.buf = append(w.buf, e)
+		}
+	}
+	return nil
+}
+
+// readActiveTail reads events appended to the active log after offset, reading
+// THROUGH a freshly-opened fd whose identity is checked against wantInode. A
+// rotation renames the active file and creates a fresh one at the same path, so
+// reading by path alone can observe a different (post-rotation) file than the
+// one the caller committed and skip a just-archived window. Reading through the
+// fd — and refusing to advance when the path now resolves to a different inode
+// than wantInode — keeps the tail identity-stable: a rotation that lands mid-read
+// still reads the committed inode's bytes, and a rotation that lands before the
+// read is deferred to rotation catch-up (matched=false) rather than tailing an
+// unverified file.
+//
+// wantInode==0 (first poll, before any inode was committed) or a filesystem that
+// reports inode 0 disables the gate and falls back to plain by-path tailing.
+func readActiveTail(path string, offset int64, wantInode uint64) (evts []Event, newOffset int64, matched bool, err error) {
+	f, oerr := os.Open(path)
+	if oerr != nil {
+		if os.IsNotExist(oerr) {
+			// The active file is briefly absent between a rotation's rename and
+			// re-create; treat it as "no new bytes" and let the next poll retry.
+			return nil, offset, true, nil
+		}
+		return nil, offset, false, fmt.Errorf("reading events: %w", oerr)
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+
+	if wantInode != 0 {
+		info, serr := f.Stat()
+		if serr != nil {
+			return nil, offset, false, fmt.Errorf("stat active log: %w", serr)
+		}
+		if got := inodeOf(info); got != 0 && got != wantInode {
+			// The active path now names a different inode than the committed one:
+			// a rotation raced this tail. Do not advance.
+			return nil, offset, false, nil
+		}
+	}
+
+	evts, newOffset, err = readEventsFrom(f, offset)
+	return evts, newOffset, true, err
 }
 
 func (w *fileWatcher) pop() Event {
@@ -729,70 +837,102 @@ func (w *fileWatcher) pop() Event {
 	return e
 }
 
-// sleep waits one poll interval, returning false on ctx cancel / Close.
-func (w *fileWatcher) sleep() bool {
+// waitPoll blocks for d, returning nil when the interval elapsed (keep polling)
+// or a terminal error when the watcher was canceled or closed meanwhile. The
+// context cause is preferred over errWatcherClosed so a Next blocked here still
+// surfaces context.Canceled / context.DeadlineExceeded to callers that classify
+// it — the watcher contract is "blocks until an event arrives or ctx is
+// canceled", not "until Close".
+func (w *fileWatcher) waitPoll(d time.Duration) error {
 	select {
 	case <-w.ctx.Done():
-		return false
+		return w.ctx.Err()
 	case <-w.done:
-		return false
-	case <-time.After(w.poll):
-		return true
+		if err := w.ctx.Err(); err != nil {
+			return err
+		}
+		return errWatcherClosed
+	case <-time.After(d):
+		return nil
 	}
 }
 
+// sleep waits one poll interval. See waitPoll for the return contract.
+func (w *fileWatcher) sleep() error { return w.waitPoll(w.poll) }
+
 // sleepBackoff waits poll * min(catchUpErr, 8) so a persistently failing
 // catch-up (e.g. a poisoned archive) does not re-gunzip at 4/sec and starve
-// other watchers' backfill slots.
-func (w *fileWatcher) sleepBackoff() bool {
+// other watchers' backfill slots. See waitPoll for the return contract.
+func (w *fileWatcher) sleepBackoff() error {
 	mult := time.Duration(w.catchUpErr)
 	if mult > 8 {
 		mult = 8
 	}
-	select {
-	case <-w.ctx.Done():
-		return false
-	case <-w.done:
-		return false
-	case <-time.After(w.poll * mult):
-		return true
-	}
+	return w.waitPoll(w.poll * mult)
 }
 
 // stepBackfill advances the resume backfill by up to backfillBatch events. It
-// keeps the current segment reader open across calls so each segment is read
-// exactly once, holding a decode slot only for the duration of one batch read.
-// When every segment and the active leg are exhausted it clears needsBackfill
-// and positions the tail at the captured active size.
+// lists the segments once, drains them one batch per call (keeping each segment
+// reader open across calls so each segment is read exactly once), then reads the
+// captured active leg. When every segment and the active leg are exhausted it
+// clears needsBackfill and positions the tail at the captured active size.
 func (w *fileWatcher) stepBackfill(filter Filter, catchUp bool) error {
 	if err := acquireBackfillSlot(w.ctx, w.done); err != nil {
 		return err
 	}
 	defer releaseBackfillSlot()
 
-	if !w.bfListed {
-		srcs, err := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
-		if err != nil {
-			if catchUp {
-				return err
-			}
-			srcs = nil // resume: fall through to the active leg + tail
-		}
-		w.bfSources = srcs
-		w.bfIdx = 0
-		w.bfListed = true
+	if err := w.ensureBackfillListed(); err != nil {
+		return err
 	}
+	produced, err := w.drainSegments(filter)
+	if err != nil || produced {
+		return err
+	}
+	if w.bfActive && w.activeFile != nil {
+		return w.drainActiveLeg(filter)
+	}
+	if !catchUp {
+		w.finishResume()
+	}
+	return nil
+}
 
-	// Advance through segments, one batch per call.
+// ensureBackfillListed lists the archive/rotating segments to replay, once per
+// backfill/catch-up round. A listing error is surfaced (not swallowed) so a
+// resuming caller reconnects/retries instead of silently receiving active-only
+// history that omits archived events the cursor asked for.
+func (w *fileWatcher) ensureBackfillListed() error {
+	if w.bfListed {
+		return nil
+	}
+	srcs, err := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
+	if err != nil {
+		return err
+	}
+	w.bfSources = srcs
+	w.bfIdx = 0
+	w.bfListed = true
+	return nil
+}
+
+// drainSegments reads up to one batch from the pending archive/rotating
+// segments, opening each segment reader lazily and skipping vanished or
+// exhausted segments. It returns produced=true once a batch is buffered so the
+// caller yields it before doing more work.
+func (w *fileWatcher) drainSegments(filter Filter) (produced bool, err error) {
+	// Hold bfMu for the whole drain so a Close arriving from another goroutine
+	// (an SSE client disconnecting mid-replay) cannot close the archive fd/gzip
+	// stream while readInto is reading through it. The lock is released between
+	// Next calls, so Close can still promptly reclaim a segment left open across
+	// batches.
+	w.bfMu.Lock()
+	defer w.bfMu.Unlock()
 	for w.bfIdx < len(w.bfSources) {
 		if w.bfReader == nil {
-			f := filter
-			if f.AfterSeq < w.maxSeq {
-				f.AfterSeq = w.maxSeq
-			}
-			sr, err := openSegmentReader(w.bfSources[w.bfIdx])
-			if err != nil {
-				return err
+			sr, oerr := openSegmentReader(w.bfSources[w.bfIdx])
+			if oerr != nil {
+				return false, oerr
 			}
 			if sr == nil { // vanished (promoted rotating file); its .gz covers it
 				w.bfIdx++
@@ -800,11 +940,11 @@ func (w *fileWatcher) stepBackfill(filter Filter, catchUp bool) error {
 			}
 			w.bfReader = sr
 		}
-		eof, err := w.bfReader.readInto(withAfterSeq(filter, w.maxSeq), &w.maxSeq, &w.buf, backfillBatch)
-		if err != nil {
+		eof, rerr := w.bfReader.readInto(withAfterSeq(filter, w.maxSeq), &w.maxSeq, &w.buf, backfillBatch)
+		if rerr != nil {
 			w.bfReader.close()
 			w.bfReader = nil
-			return err
+			return false, rerr
 		}
 		if eof {
 			w.bfReader.close()
@@ -812,66 +952,98 @@ func (w *fileWatcher) stepBackfill(filter Filter, catchUp bool) error {
 			w.bfIdx++
 		}
 		if len(w.buf) > 0 {
-			return nil // yield this batch; resume on the next call
+			return true, nil // yield this batch; resume on the next call
 		}
 	}
+	return false, nil
+}
 
-	// Active leg (resume only): read the captured fd up to the captured size.
-	if w.bfActive && w.activeFile != nil {
-		if w.bfReader == nil {
-			sr, err := activeSegmentReader(w.activeFile, w.activeSize)
-			if err != nil {
-				return err
-			}
-			w.bfReader = sr
-		}
-		eof, err := w.bfReader.readInto(withAfterSeq(filter, w.maxSeq), &w.maxSeq, &w.buf, backfillBatch)
-		if err != nil {
-			w.bfReader.close()
-			w.bfReader = nil
-			return err
-		}
-		if !eof && len(w.buf) > 0 {
-			return nil
-		}
-		if eof {
-			w.bfReader.close() // closes the wrapper, not the caller-owned fd
-			w.bfReader = nil
-			w.finishResume()
-		}
-		return nil
+// drainActiveLeg reads up to one batch from the captured active-file leg (the
+// resume tail, bounded to the size captured at Watch). On EOF it finishes the
+// resume and positions the incremental tail at that captured size.
+func (w *fileWatcher) drainActiveLeg(filter Filter) error {
+	eof, err := w.readActiveLegLocked(filter)
+	if err != nil {
+		return err
 	}
-
-	if !catchUp {
+	if eof {
+		// finishResume re-enters resetBackfillIter (which locks bfMu), so run it
+		// once the read lock is released to avoid a self-deadlock.
 		w.finishResume()
 	}
 	return nil
 }
 
+// readActiveLegLocked reads up to one batch from the captured active leg under
+// bfMu (see the bfReader field comment) and reports eof when the leg is
+// exhausted. The active-leg reader wraps the caller-owned active fd (its own
+// close is a no-op for that fd), but it is still guarded so a concurrent Close
+// cannot race the bfReader pointer.
+func (w *fileWatcher) readActiveLegLocked(filter Filter) (eof bool, err error) {
+	w.bfMu.Lock()
+	defer w.bfMu.Unlock()
+	if w.bfReader == nil {
+		sr, serr := activeSegmentReader(w.activeFile, w.activeSize)
+		if serr != nil {
+			return false, serr
+		}
+		w.bfReader = sr
+	}
+	done, rerr := w.bfReader.readInto(withAfterSeq(filter, w.maxSeq), &w.maxSeq, &w.buf, backfillBatch)
+	if rerr != nil {
+		w.bfReader.close()
+		w.bfReader = nil
+		return false, rerr
+	}
+	if done {
+		w.bfReader.close() // closes the wrapper, not the caller-owned fd
+		w.bfReader = nil
+	}
+	return done, nil
+}
+
 // stepCatchUp advances a mid-watch rotation catch-up by up to backfillBatch
-// events. It reuses the same incremental segment machinery bounded by
-// AfterSeq=maxSeq (the rotation window). Returns done=true when the catch-up has
-// drained every segment; a fresh catch-up resets the iterator state first.
-func (w *fileWatcher) stepCatchUp() (bool, error) {
+// events, reusing the incremental segment machinery bounded by AfterSeq=maxSeq
+// (the rotation window). When the frozen source list drains it re-lists against
+// the advanced cursor: a rotation that landed mid-drain appended a new segment
+// whose window sits above the original list, and re-listing by seq (rather than
+// by inode) picks it up even when the fresh active file reused a prior inode.
+// Returns done=true only once no archived segment holds events beyond the
+// cursor, i.e. the active file is the next contiguous source.
+func (w *fileWatcher) stepCatchUp() (done bool, err error) {
 	if !w.bfCatchUp {
 		// Starting a new catch-up: reset the segment iterator to re-list.
 		w.resetBackfillIter()
 		w.bfCatchUp = true
 	}
 	before := len(w.buf)
-	if err := w.stepBackfill(Filter{AfterSeq: w.maxSeq}, true); err != nil {
-		return false, err
+	if berr := w.stepBackfill(Filter{AfterSeq: w.maxSeq}, true); berr != nil {
+		return false, berr
 	}
-	// Not done while a batch was produced or segments remain.
 	if len(w.buf) > before {
-		return false, nil
+		return false, nil // produced a batch; keep draining
 	}
-	done := w.bfIdx >= len(w.bfSources) && w.bfReader == nil
-	if done {
-		w.bfCatchUp = false
-		w.resetBackfillIter()
+	if w.backfillReaderOpen() || w.bfIdx < len(w.bfSources) {
+		return false, nil // segments still pending
 	}
-	return done, nil
+
+	// The frozen list drained. Re-list against the advanced cursor to pick up a
+	// rotation that landed mid-drain (seq-bounded, so it is robust to an inode
+	// the later rotation reused). Only when nothing archived remains beyond the
+	// cursor is the active file the next contiguous source.
+	more, lerr := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
+	if lerr != nil {
+		return false, lerr
+	}
+	if len(more) > 0 {
+		w.bfSources = more
+		w.bfIdx = 0
+		w.bfListed = true
+		return false, nil // another catch-up round for the mid-drain rotation
+	}
+	w.bfCatchUp = false
+	w.resetBackfillIter()
+	return true, nil
 }
 
 // withAfterSeq returns filter with AfterSeq raised to at least floor.
@@ -896,29 +1068,53 @@ func (w *fileWatcher) finishResume() {
 }
 
 // resetBackfillIter clears the segment-iterator state, closing any open reader.
+// It runs on the Next consumer and must not hold bfMu (releaseBackfillReader
+// takes it); bfSources/bfIdx/bfListed are Next-owned and need no lock.
 func (w *fileWatcher) resetBackfillIter() {
+	w.releaseBackfillReader()
+	w.bfSources = nil
+	w.bfIdx = 0
+	w.bfListed = false
+}
+
+// releaseBackfillReader closes the open backfill segment reader (an archive fd +
+// gzip.Reader, or a no-op wrapper over the caller-owned active fd) under bfMu and
+// clears the pointer. It is the single close site shared by the Next consumer and
+// Close, so whichever runs first releases the descriptor exactly once.
+func (w *fileWatcher) releaseBackfillReader() {
+	w.bfMu.Lock()
 	if w.bfReader != nil {
 		w.bfReader.close()
 		w.bfReader = nil
 	}
-	w.bfSources = nil
-	w.bfIdx = 0
-	w.bfListed = false
+	w.bfMu.Unlock()
+}
+
+// backfillReaderOpen reports whether a segment reader is currently open, under
+// bfMu so the Next consumer's read cannot race a concurrent Close's clear.
+func (w *fileWatcher) backfillReaderOpen() bool {
+	w.bfMu.Lock()
+	defer w.bfMu.Unlock()
+	return w.bfReader != nil
 }
 
 func isCancelErr(err error) bool {
 	return errors.Is(err, errWatcherClosed) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
-// Close unblocks any pending Next call and releases the captured active fd. It
-// does not touch the segment-iterator state — the single Next goroutine owns
-// that and will observe w.done. The fd pointer is never niled; closeFd closes it
-// exactly once whether Close or finishResume runs first, so no field write races
-// the Next goroutine's reads.
+// Close unblocks any pending Next call and releases the watcher's descriptors:
+// the captured active fd (closeFd, closed exactly once whether Close or
+// finishResume runs first) and any open backfill segment reader. The active fd
+// pointer is never niled, so it cannot race the Next goroutine's reads;
+// releaseBackfillReader takes bfMu so a consumer that abandons the watcher
+// mid-backfill (e.g. an SSE client disconnecting after a partial archive batch,
+// which reaches Close on a different goroutine than Next) does not orphan the
+// archive fd + gzip.Reader until GC.
 func (w *fileWatcher) Close() error {
 	w.closeOnce.Do(func() {
 		close(w.done)
 		w.closeFd()
+		w.releaseBackfillReader()
 	})
 	return nil
 }

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -451,24 +451,41 @@ func (r *FileRecorder) LatestSeq() (uint64, error) {
 	return seq, nil
 }
 
-// Watch returns a Watcher that polls the event file for new events.
-// The watcher detects rotation (inode change between polls) and resets
-// its byte offset to the start of the new active file so the
-// events.rotated anchor and any post-rotation events are yielded
-// without gap (designer §8.1). Already-yielded events are deduped via
-// the afterSeq cursor.
+// Watch returns a Watcher that delivers every retained event with Seq > afterSeq
+// exactly once per watcher, in sequence order. When afterSeq is below the active
+// file's history it first backfills across the sibling .gz archives and in-flight
+// rotating-* files (lazily, on the first Next call) before tailing the active
+// file. It also detects rotation mid-watch (inode change) and catches up across
+// the just-rotated archive before re-tailing the fresh active file, so no
+// pre-rotation tail is lost. Backfill/catch-up reads are deduped by a strictly
+// monotonic seq cursor; across separate watcher instances the stream is
+// at-least-once (callers already de-dupe by seq).
+//
+// Watch itself stays O(1): a single stat/open of the active file plus one
+// ReadLatestSeq. The (potentially expensive) archive walk is deferred to Next so
+// a never-polled watcher — e.g. the multiplexer's attach probe — costs nothing.
 func (r *FileRecorder) Watch(ctx context.Context, afterSeq uint64) (Watcher, error) {
 	var offset int64
 	var inode uint64
 	var size int64
 	var haveStat bool
-	if info, err := os.Stat(r.path); err == nil {
-		size = info.Size()
-		inode = inodeOf(info)
-		haveStat = true
+	// Open the active file once and keep the fd: the resume backfill reads its
+	// tail leg from this fd (capped at the captured size), so a rotation landing
+	// mid-backfill still reads the correct bytes instead of the fresh file the
+	// path now names.
+	activeFile, openErr := os.Open(r.path)
+	if openErr == nil {
+		if info, serr := activeFile.Stat(); serr == nil {
+			size = info.Size()
+			inode = inodeOf(info)
+			haveStat = true
+		}
 	}
 	latestSeq, err := ReadLatestSeq(r.path)
 	if err != nil {
+		if activeFile != nil {
+			_ = activeFile.Close()
+		}
 		return nil, err
 	}
 	r.mu.Lock()
@@ -479,15 +496,27 @@ func (r *FileRecorder) Watch(ctx context.Context, afterSeq uint64) (Watcher, err
 		offset = size
 	}
 	r.mu.Unlock()
-	return &fileWatcher{
-		path:     r.path,
-		afterSeq: afterSeq,
-		ctx:      ctx,
-		poll:     250 * time.Millisecond,
-		offset:   offset,
-		inode:    inode,
-		done:     make(chan struct{}),
-	}, nil
+
+	w := &fileWatcher{
+		path:       r.path,
+		afterSeq:   afterSeq,
+		maxSeq:     afterSeq,
+		ctx:        ctx,
+		poll:       250 * time.Millisecond,
+		offset:     offset,
+		inode:      inode,
+		done:       make(chan struct{}),
+		activeFile: activeFile,
+		activeSize: size,
+	}
+	// Backfill is needed only when the cursor predates the active file's head.
+	if haveStat && afterSeq < latestSeq {
+		w.needsBackfill = true
+	} else if activeFile != nil {
+		_ = activeFile.Close()
+		w.activeFile = nil
+	}
+	return w, nil
 }
 
 // Close closes the underlying file. It is safe to call multiple times;
@@ -533,16 +562,27 @@ func (r *FileRecorder) WaitForRotations() {
 // active file. The afterSeq cursor dedupes against already-yielded
 // events.
 type fileWatcher struct {
-	path      string
-	afterSeq  uint64
-	ctx       context.Context
-	poll      time.Duration
-	offset    int64
-	inode     uint64
-	buf       []Event // buffered events from last poll
-	done      chan struct{}
+	path     string
+	afterSeq uint64
+	maxSeq   uint64 // strictly monotonic guard: highest seq delivered so far
+	ctx      context.Context
+	poll     time.Duration
+	offset   int64
+	inode    uint64
+	buf      []Event // buffered events from last poll
+	done     chan struct{}
+
+	// Resume-backfill state (W1): the archive/rotating segments to replay before
+	// tailing, and the active file's fd + size captured at Watch time.
+	needsBackfill bool
+	activeFile    *os.File
+	activeSize    int64
+
 	closeOnce sync.Once
 }
+
+// errWatcherClosed is returned by Next after Close.
+var errWatcherClosed = fmt.Errorf("watcher closed")
 
 // Next blocks until the next event is available or the context is canceled.
 func (w *fileWatcher) Next() (Event, error) {
@@ -559,21 +599,46 @@ func (w *fileWatcher) Next() (Event, error) {
 		case <-w.ctx.Done():
 			return Event{}, w.ctx.Err()
 		case <-w.done:
-			return Event{}, fmt.Errorf("watcher closed")
+			return Event{}, errWatcherClosed
 		default:
 		}
 
-		// Detect rotation by inode change. On rotation, ReadFrom would
-		// otherwise seek past EOF in the new (smaller) file and skip
-		// the events.rotated anchor; resetting offset to 0 lets the
-		// watcher rescan the new active file from the top while
-		// afterSeq prevents re-yielding already-seen events.
+		// Resume backfill (W1): replay archived/rotating events before tailing.
+		// Runs lazily here, one source per batch, so a never-polled watcher pays
+		// nothing and memory stays bounded to one segment.
+		if w.needsBackfill {
+			if err := w.runResumeBackfill(); err != nil {
+				return Event{}, err
+			}
+			if len(w.buf) > 0 {
+				continue
+			}
+		}
+
+		// Detect rotation by inode change. Before resetting the offset, catch up
+		// across the just-rotated archive (W2): events appended to the OLD active
+		// file after the last poll now live only in the rotating/.gz file, so a
+		// bare offset reset would drop them. Commit the fresh identity only after
+		// a successful catch-up; on error keep the old identity and retry next
+		// poll (an early commit would make the next poll see no rotation).
 		if info, err := os.Stat(w.path); err == nil {
 			if curr := inodeOf(info); curr != 0 {
 				if w.inode != 0 && curr != w.inode {
-					w.offset = 0
+					if cerr := w.catchUpRotation(); cerr != nil {
+						if isCancelErr(cerr) {
+							return Event{}, cerr
+						}
+						// Transient read error: leave identity/offset, retry.
+					} else {
+						w.inode = curr
+						w.offset = 0
+						if len(w.buf) > 0 {
+							continue
+						}
+					}
+				} else {
+					w.inode = curr
 				}
-				w.inode = curr
 			}
 		}
 
@@ -586,8 +651,8 @@ func (w *fileWatcher) Next() (Event, error) {
 
 		// Filter to events after our cursor.
 		for _, e := range evts {
-			if e.Seq > w.afterSeq {
-				w.afterSeq = e.Seq
+			if e.Seq > w.maxSeq {
+				w.maxSeq = e.Seq
 				w.buf = append(w.buf, e)
 			}
 		}
@@ -601,14 +666,130 @@ func (w *fileWatcher) Next() (Event, error) {
 		case <-w.ctx.Done():
 			return Event{}, w.ctx.Err()
 		case <-w.done:
-			return Event{}, fmt.Errorf("watcher closed")
+			return Event{}, errWatcherClosed
 		case <-time.After(w.poll):
 		}
 	}
 }
 
-// Close unblocks any pending Next call.
+// runResumeBackfill streams the next resume segment (archive, rotating file, or
+// the captured active-file tail) into w.buf, advancing w.maxSeq. It processes
+// one segment per call so memory stays bounded and the consumer paces it; when
+// every segment is exhausted it clears needsBackfill and positions the tail at
+// the captured active size. The archive walk holds a concurrency slot so N cold
+// resumes queue instead of multiplying gunzip cost.
+func (w *fileWatcher) runResumeBackfill() error {
+	if err := acquireBackfillSlot(w.ctx); err != nil {
+		return err
+	}
+	defer releaseBackfillSlot()
+
+	srcs, err := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
+	if err != nil {
+		// Directory listing failed: skip straight to the active-file leg + tail.
+		srcs = nil
+	}
+	filter := Filter{}
+	for i := range srcs {
+		if err := streamBackfillSource(w.ctx, w.done, srcs[i], filter, &w.maxSeq, &w.buf); err != nil {
+			return err
+		}
+		if len(w.buf) > 0 {
+			return nil // one segment per batch; resume on the next Next
+		}
+	}
+	// Active-file leg: read from the captured fd (not the path) up to the size
+	// captured at Watch time, so a rotation mid-backfill cannot swap the bytes.
+	if w.activeFile != nil {
+		if err := w.streamActiveLeg(filter); err != nil {
+			return err
+		}
+	}
+	w.finishBackfill()
+	return nil
+}
+
+// streamActiveLeg replays the captured active-file fd (0..activeSize) into
+// w.buf, honoring the monotonic guard and cancellation.
+func (w *fileWatcher) streamActiveLeg(filter Filter) error {
+	if _, err := w.activeFile.Seek(0, 0); err != nil {
+		return err
+	}
+	lr := &io.LimitedReader{R: w.activeFile, N: w.activeSize}
+	guard := func(e Event) bool {
+		select {
+		case <-w.ctx.Done():
+			return false
+		case <-w.done:
+			return false
+		default:
+		}
+		if e.Seq > w.maxSeq {
+			w.maxSeq = e.Seq
+			w.buf = append(w.buf, e)
+		}
+		return true
+	}
+	if err := scanJSONL(lr, filter, guard); err != nil {
+		return err
+	}
+	select {
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	case <-w.done:
+		return errWatcherClosed
+	default:
+		return nil
+	}
+}
+
+// finishBackfill releases the captured fd and positions the incremental tail at
+// the captured active size so it re-reads only bytes appended after Watch.
+func (w *fileWatcher) finishBackfill() {
+	w.needsBackfill = false
+	if w.activeFile != nil {
+		_ = w.activeFile.Close()
+		w.activeFile = nil
+	}
+	if w.offset < w.activeSize {
+		w.offset = w.activeSize
+	}
+}
+
+// catchUpRotation streams events after w.maxSeq from the archives/rotating files
+// (where the just-rotated tail now lives) into w.buf before the caller resets
+// the offset. AfterSeq = maxSeq bounds it to the rotation window.
+func (w *fileWatcher) catchUpRotation() error {
+	if err := acquireBackfillSlot(w.ctx); err != nil {
+		return err
+	}
+	defer releaseBackfillSlot()
+
+	srcs, err := listBackfillSources(filepath.Dir(w.path), w.maxSeq)
+	if err != nil {
+		return err
+	}
+	filter := Filter{AfterSeq: w.maxSeq}
+	for i := range srcs {
+		if err := streamBackfillSource(w.ctx, w.done, srcs[i], filter, &w.maxSeq, &w.buf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isCancelErr(err error) bool {
+	return errors.Is(err, errWatcherClosed) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// Close unblocks any pending Next call and releases the captured active fd.
 func (w *fileWatcher) Close() error {
-	w.closeOnce.Do(func() { close(w.done) })
+	w.closeOnce.Do(func() {
+		close(w.done)
+		if w.activeFile != nil {
+			_ = w.activeFile.Close()
+			w.activeFile = nil
+		}
+	})
 	return nil
 }

--- a/internal/events/watch_backfill.go
+++ b/internal/events/watch_backfill.go
@@ -2,36 +2,48 @@ package events
 
 import (
 	"bufio"
+	"compress/gzip"
 	"context"
 	"encoding/json"
-	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 )
 
-// backfillConcurrency bounds how many watchers may walk archives concurrently.
-// A cold resume gunzips archives; without a cap, N simultaneous resumes multiply
-// the CPU/IO cost. Excess resumes queue on this semaphore rather than piling on.
+// backfillConcurrency bounds how many watchers may actively read archive/rotating
+// segments concurrently. A cold resume gunzips archives; without a cap, N
+// simultaneous resumes multiply the CPU/IO cost. Excess resumes queue on this
+// semaphore. The slot is held only during a single bounded batch read (not
+// across the consumer's drain), so it caps concurrent decode work without
+// pinning memory.
 const backfillConcurrency = 2
+
+// backfillBatch bounds how many events one backfill step buffers before yielding
+// to the consumer. It caps a watcher's resident backfill memory to O(batch)
+// events (not a whole archive segment), so many concurrent cold resumes cannot
+// aggregate into an OOM.
+const backfillBatch = 256
 
 var backfillSlots = make(chan struct{}, backfillConcurrency)
 
-func acquireBackfillSlot(ctx context.Context) error {
+// acquireBackfillSlot blocks for a decode slot, returning early if ctx is
+// canceled or done is closed (a Close mid-wait must unblock Next).
+func acquireBackfillSlot(ctx context.Context, done <-chan struct{}) error {
 	select {
 	case backfillSlots <- struct{}{}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-done:
+		return errWatcherClosed
 	}
 }
 
 func releaseBackfillSlot() { <-backfillSlots }
 
-// backfillSourceKind distinguishes a gzip archive from a plain-JSONL segment
-// (an in-flight rotating-* file or the captured active file) so the streamer
-// picks the right decoder.
+// backfillSourceKind distinguishes a gzip archive from a plain-JSONL segment.
 type backfillSourceKind int
 
 const (
@@ -40,9 +52,7 @@ const (
 )
 
 // backfillSource is one on-disk segment contributing to a resume backfill,
-// ordered by its first sequence. Archives and rotating files carry a
-// filename-encoded seq window used both to order them and to skip segments
-// wholly at or below the resume cursor.
+// ordered by its first sequence.
 type backfillSource struct {
 	path     string
 	kind     backfillSourceKind
@@ -53,10 +63,8 @@ type backfillSource struct {
 // listBackfillSources returns the .gz archives and in-flight rotating-* files in
 // dir whose seq window may contain events with Seq > afterSeq, sorted by first
 // sequence. A .gz archive and its not-yet-removed rotating source share a seq
-// window (equal FirstSeq); the streamed monotonic guard drops the duplicate, so
-// both are safe to include. The active file is appended by the caller (it reads
-// from a captured fd, not by path, to stay correct across a mid-backfill
-// rotation).
+// window; the streamed monotonic guard drops the duplicate, so both are safe to
+// include.
 func listBackfillSources(dir string, afterSeq uint64) ([]backfillSource, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -102,100 +110,104 @@ func listBackfillSources(dir string, afterSeq uint64) ([]backfillSource, error) 
 		if srcs[i].firstSeq != srcs[j].firstSeq {
 			return srcs[i].firstSeq < srcs[j].firstSeq
 		}
-		// A rotating file and its promoted .gz share FirstSeq; order is
-		// irrelevant to correctness (the monotonic guard dedupes), but keep it
-		// deterministic.
 		return srcs[i].kind < srcs[j].kind
 	})
 	return srcs, nil
 }
 
-// isCanonicalArchiveBasename reports whether name is a canonical .gz archive
-// (not a legacy pre-seq-window one, which parseArchiveBasename rejects anyway).
+// isCanonicalArchiveBasename reports whether name is a canonical .gz archive.
 func isCanonicalArchiveBasename(name string) bool {
 	return strings.HasPrefix(name, "events.jsonl.archive-") && strings.HasSuffix(name, ".gz")
 }
 
-// streamPlainJSONL streams filter-matching events from a plain-JSONL events file
-// (a rotating-* segment or the active file), invoking fn per event until fn
-// returns false or the file ends. It is the plain-text sibling of streamArchive.
-// A missing file yields no events and no error (a rotating file may be promoted
-// and removed between listing and read; its .gz counterpart covers the window).
-func streamPlainJSONL(path string, filter Filter, fn func(Event) bool) error {
-	f, err := os.Open(path)
+// segmentReader streams events from one open backfill segment line by line via
+// bufio.Reader.ReadBytes — which, unlike bufio.Scanner, imposes no maximum line
+// length, so an event larger than 1 MiB cannot poison the resume. It owns the
+// underlying file (and gzip stream, for archives) and is closed exactly once.
+type segmentReader struct {
+	f  *os.File
+	gz *gzip.Reader
+	br *bufio.Reader
+}
+
+// openSegmentReader opens src (a captured active fd, or an archive/rotating path)
+// bounded by limit bytes when limit >= 0 (the active leg). A missing file yields
+// (nil, nil): a rotating file may have been promoted to its .gz and removed
+// between listing and open; the .gz counterpart (also listed) covers the window.
+func openSegmentReader(src backfillSource) (*segmentReader, error) {
+	f, err := os.Open(src.path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
-	defer f.Close() //nolint:errcheck // read-only file
-	return scanJSONL(f, filter, fn)
+	sr := &segmentReader{f: f}
+	var r io.Reader = f
+	if src.kind == sourceArchive {
+		gz, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			_ = f.Close()
+			return nil, gerr
+		}
+		sr.gz = gz
+		r = gz
+	}
+	sr.br = bufio.NewReaderSize(r, 64*1024)
+	return sr, nil
 }
 
-// scanJSONL streams filter-matching events from r (a plain-JSONL reader),
-// stopping when fn returns false. Malformed lines are skipped.
-func scanJSONL(r interface{ Read([]byte) (int, error) }, filter Filter, fn func(Event) bool) error {
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		var e Event
-		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
-			continue
-		}
-		if !matchesFilter(e, filter) {
-			continue
-		}
-		if !fn(e) {
-			return nil
-		}
+// activeSegmentReader wraps a captured active fd (0..size) as a segment reader.
+func activeSegmentReader(f *os.File, size int64) (*segmentReader, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, err
 	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scanning events: %w", err)
-	}
-	return nil
+	return &segmentReader{f: nil, br: bufio.NewReaderSize(&io.LimitedReader{R: f, N: size}, 64*1024)}, nil
 }
 
-// streamBackfillSource streams one source's filter-matching events with Seq
-// strictly greater than *lastDelivered into out, advancing *lastDelivered. It
-// stops early (returning ctx/done error) on cancellation.
-func streamBackfillSource(ctx context.Context, done <-chan struct{}, src backfillSource, filter Filter, lastDelivered *uint64, out *[]Event) error {
-	guard := func(e Event) bool {
-		select {
-		case <-ctx.Done():
-			return false
-		case <-done:
-			return false
-		default:
+// readInto reads up to batch filter-matching events with Seq > *maxSeq from the
+// segment into out, advancing *maxSeq. It returns done=true at end of segment.
+// Malformed and oversized-but-unparseable lines are skipped, never fatal.
+func (sr *segmentReader) readInto(filter Filter, maxSeq *uint64, out *[]Event, batch int) (bool, error) {
+	added := 0
+	for added < batch {
+		line, err := sr.br.ReadBytes('\n')
+		if len(line) > 0 {
+			var e Event
+			if json.Unmarshal(trimLine(line), &e) == nil && matchesFilter(e, filter) && e.Seq > *maxSeq {
+				*maxSeq = e.Seq
+				*out = append(*out, e)
+				added++
+			}
 		}
-		if e.Seq <= *lastDelivered {
-			return true // dedupe / below cursor; keep scanning
+		if err != nil {
+			if err == io.EOF {
+				return true, nil
+			}
+			return false, err
 		}
-		*lastDelivered = e.Seq
-		*out = append(*out, e)
-		return true
 	}
-	// Apply the AfterSeq floor so the archive/rotating scan can skip cheaply.
-	f := filter
-	if f.AfterSeq < *lastDelivered {
-		f.AfterSeq = *lastDelivered
+	return false, nil
+}
+
+func trimLine(b []byte) []byte {
+	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r') {
+		b = b[:len(b)-1]
 	}
-	var err error
-	switch src.kind {
-	case sourceArchive:
-		err = streamArchive(src.path, f, guard)
-	default:
-		err = streamPlainJSONL(src.path, f, guard)
+	return b
+}
+
+// close releases the segment's gzip stream and file. Safe to call once; the
+// owning fileWatcher is single-consumer, so no concurrent close occurs.
+func (sr *segmentReader) close() {
+	if sr == nil {
+		return
 	}
-	if err != nil {
-		return err
+	if sr.gz != nil {
+		_ = sr.gz.Close()
 	}
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-done:
-		return errWatcherClosed
-	default:
-		return nil
+	// A nil f means the reader wraps a caller-owned active fd (closed elsewhere).
+	if sr.f != nil {
+		_ = sr.f.Close()
 	}
 }

--- a/internal/events/watch_backfill.go
+++ b/internal/events/watch_backfill.go
@@ -1,0 +1,201 @@
+package events
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// backfillConcurrency bounds how many watchers may walk archives concurrently.
+// A cold resume gunzips archives; without a cap, N simultaneous resumes multiply
+// the CPU/IO cost. Excess resumes queue on this semaphore rather than piling on.
+const backfillConcurrency = 2
+
+var backfillSlots = make(chan struct{}, backfillConcurrency)
+
+func acquireBackfillSlot(ctx context.Context) error {
+	select {
+	case backfillSlots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func releaseBackfillSlot() { <-backfillSlots }
+
+// backfillSourceKind distinguishes a gzip archive from a plain-JSONL segment
+// (an in-flight rotating-* file or the captured active file) so the streamer
+// picks the right decoder.
+type backfillSourceKind int
+
+const (
+	sourceArchive backfillSourceKind = iota
+	sourceRotating
+)
+
+// backfillSource is one on-disk segment contributing to a resume backfill,
+// ordered by its first sequence. Archives and rotating files carry a
+// filename-encoded seq window used both to order them and to skip segments
+// wholly at or below the resume cursor.
+type backfillSource struct {
+	path     string
+	kind     backfillSourceKind
+	firstSeq uint64
+	lastSeq  uint64
+}
+
+// listBackfillSources returns the .gz archives and in-flight rotating-* files in
+// dir whose seq window may contain events with Seq > afterSeq, sorted by first
+// sequence. A .gz archive and its not-yet-removed rotating source share a seq
+// window (equal FirstSeq); the streamed monotonic guard drops the duplicate, so
+// both are safe to include. The active file is appended by the caller (it reads
+// from a captured fd, not by path, to stay correct across a mid-backfill
+// rotation).
+func listBackfillSources(dir string, afterSeq uint64) ([]backfillSource, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var srcs []backfillSource
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		switch {
+		case isCanonicalArchiveBasename(name):
+			info, perr := parseArchiveBasename(name)
+			if perr != nil {
+				continue
+			}
+			if afterSeq > 0 && info.LastSeq <= afterSeq {
+				continue
+			}
+			srcs = append(srcs, backfillSource{
+				path: filepath.Join(dir, name), kind: sourceArchive,
+				firstSeq: info.FirstSeq, lastSeq: info.LastSeq,
+			})
+		case hasRotatingPrefix(name):
+			_, first, last, ok := parseRotatingBasename(name)
+			if !ok {
+				continue // legacy rotating file without a window; reaper promotes it
+			}
+			if afterSeq > 0 && last <= afterSeq {
+				continue
+			}
+			srcs = append(srcs, backfillSource{
+				path: filepath.Join(dir, name), kind: sourceRotating,
+				firstSeq: first, lastSeq: last,
+			})
+		}
+	}
+	sort.Slice(srcs, func(i, j int) bool {
+		if srcs[i].firstSeq != srcs[j].firstSeq {
+			return srcs[i].firstSeq < srcs[j].firstSeq
+		}
+		// A rotating file and its promoted .gz share FirstSeq; order is
+		// irrelevant to correctness (the monotonic guard dedupes), but keep it
+		// deterministic.
+		return srcs[i].kind < srcs[j].kind
+	})
+	return srcs, nil
+}
+
+// isCanonicalArchiveBasename reports whether name is a canonical .gz archive
+// (not a legacy pre-seq-window one, which parseArchiveBasename rejects anyway).
+func isCanonicalArchiveBasename(name string) bool {
+	return strings.HasPrefix(name, "events.jsonl.archive-") && strings.HasSuffix(name, ".gz")
+}
+
+// streamPlainJSONL streams filter-matching events from a plain-JSONL events file
+// (a rotating-* segment or the active file), invoking fn per event until fn
+// returns false or the file ends. It is the plain-text sibling of streamArchive.
+// A missing file yields no events and no error (a rotating file may be promoted
+// and removed between listing and read; its .gz counterpart covers the window).
+func streamPlainJSONL(path string, filter Filter, fn func(Event) bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+	return scanJSONL(f, filter, fn)
+}
+
+// scanJSONL streams filter-matching events from r (a plain-JSONL reader),
+// stopping when fn returns false. Malformed lines are skipped.
+func scanJSONL(r interface{ Read([]byte) (int, error) }, filter Filter, fn func(Event) bool) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var e Event
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue
+		}
+		if !matchesFilter(e, filter) {
+			continue
+		}
+		if !fn(e) {
+			return nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning events: %w", err)
+	}
+	return nil
+}
+
+// streamBackfillSource streams one source's filter-matching events with Seq
+// strictly greater than *lastDelivered into out, advancing *lastDelivered. It
+// stops early (returning ctx/done error) on cancellation.
+func streamBackfillSource(ctx context.Context, done <-chan struct{}, src backfillSource, filter Filter, lastDelivered *uint64, out *[]Event) error {
+	guard := func(e Event) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-done:
+			return false
+		default:
+		}
+		if e.Seq <= *lastDelivered {
+			return true // dedupe / below cursor; keep scanning
+		}
+		*lastDelivered = e.Seq
+		*out = append(*out, e)
+		return true
+	}
+	// Apply the AfterSeq floor so the archive/rotating scan can skip cheaply.
+	f := filter
+	if f.AfterSeq < *lastDelivered {
+		f.AfterSeq = *lastDelivered
+	}
+	var err error
+	switch src.kind {
+	case sourceArchive:
+		err = streamArchive(src.path, f, guard)
+	default:
+		err = streamPlainJSONL(src.path, f, guard)
+	}
+	if err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return errWatcherClosed
+	default:
+		return nil
+	}
+}

--- a/internal/events/watch_backfill.go
+++ b/internal/events/watch_backfill.go
@@ -52,12 +52,18 @@ const (
 )
 
 // backfillSource is one on-disk segment contributing to a resume backfill,
-// ordered by its first sequence.
+// ordered by its first sequence. fallbackPath, set for rotating files, is the
+// canonical .gz archive the recorder promotes the file to: the promotion
+// (rename .gz into place, THEN remove the rotating source) can land between the
+// directory listing and the open, in which case the archive did not exist at
+// list time and the rotating file no longer does — reading the derived archive
+// path is the only way not to lose that window.
 type backfillSource struct {
-	path     string
-	kind     backfillSourceKind
-	firstSeq uint64
-	lastSeq  uint64
+	path         string
+	fallbackPath string
+	kind         backfillSourceKind
+	firstSeq     uint64
+	lastSeq      uint64
 }
 
 // listBackfillSources returns the .gz archives and in-flight rotating-* files in
@@ -93,7 +99,7 @@ func listBackfillSources(dir string, afterSeq uint64) ([]backfillSource, error) 
 				firstSeq: info.FirstSeq, lastSeq: info.LastSeq,
 			})
 		case hasRotatingPrefix(name):
-			_, first, last, ok := parseRotatingBasename(name)
+			ts, first, last, ok := parseRotatingBasename(name)
 			if !ok {
 				continue // legacy rotating file without a window; reaper promotes it
 			}
@@ -101,8 +107,10 @@ func listBackfillSources(dir string, afterSeq uint64) ([]backfillSource, error) 
 				continue
 			}
 			srcs = append(srcs, backfillSource{
-				path: filepath.Join(dir, name), kind: sourceRotating,
-				firstSeq: first, lastSeq: last,
+				path:         filepath.Join(dir, name),
+				fallbackPath: filepath.Join(dir, formatArchiveBasename(ts, first, last)),
+				kind:         sourceRotating,
+				firstSeq:     first, lastSeq: last,
 			})
 		}
 	}
@@ -130,12 +138,21 @@ type segmentReader struct {
 	br *bufio.Reader
 }
 
-// openSegmentReader opens src (a captured active fd, or an archive/rotating path)
-// bounded by limit bytes when limit >= 0 (the active leg). A missing file yields
-// (nil, nil): a rotating file may have been promoted to its .gz and removed
-// between listing and open; the .gz counterpart (also listed) covers the window.
+// openSegmentReader opens one backfill segment. A rotating file that vanished
+// between listing and open was promoted (the recorder renames the .gz into place
+// BEFORE removing the rotating source), so its derived archive path is read
+// instead — skipping would silently lose the window whenever the promotion lands
+// in that gap, because the .gz did not exist at list time. A missing archive
+// yields (nil, nil): archives are only removed by retention reaping, which never
+// touches windows a live backfill can still need (and the monotonic cursor makes
+// a re-listed duplicate harmless).
 func openSegmentReader(src backfillSource) (*segmentReader, error) {
 	f, err := os.Open(src.path)
+	kind := src.kind
+	if err != nil && os.IsNotExist(err) && src.fallbackPath != "" {
+		f, err = os.Open(src.fallbackPath)
+		kind = sourceArchive
+	}
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -144,7 +161,7 @@ func openSegmentReader(src backfillSource) (*segmentReader, error) {
 	}
 	sr := &segmentReader{f: f}
 	var r io.Reader = f
-	if src.kind == sourceArchive {
+	if kind == sourceArchive {
 		gz, gerr := gzip.NewReader(f)
 		if gerr != nil {
 			_ = f.Close()

--- a/internal/events/watch_backfill_test.go
+++ b/internal/events/watch_backfill_test.go
@@ -1,0 +1,256 @@
+package events
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// drainWatcher pulls exactly n events (or fails) with a per-call deadline.
+func drainWatcher(t *testing.T, w Watcher, n int) []Event {
+	t.Helper()
+	out := make([]Event, 0, n)
+	type res struct {
+		e   Event
+		err error
+	}
+	for i := 0; i < n; i++ {
+		ch := make(chan res, 1)
+		go func() {
+			e, err := w.Next()
+			ch <- res{e, err}
+		}()
+		select {
+		case r := <-ch:
+			if r.err != nil {
+				t.Fatalf("Next %d/%d: %v", i+1, n, r.err)
+			}
+			out = append(out, r.e)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Next %d/%d timed out (archive-blind watcher?)", i+1, n)
+		}
+	}
+	return out
+}
+
+func recordN(rec *FileRecorder, prefix string, n int) {
+	for i := 0; i < n; i++ {
+		rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: fmt.Sprintf("%s-%d", prefix, i)})
+	}
+}
+
+// W1: a watcher attached with afterSeq BELOW the rotation boundary must replay
+// the archived events, not silently start at the post-rotation anchor.
+func TestWatchResumeAcrossRotationReplaysArchive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "pre", 5) // seq 1..5
+	res, err := rec.ForceRotate()
+	if err != nil || !res.Rotated {
+		t.Fatalf("ForceRotate: %v rotated=%v", err, res.Rotated)
+	}
+	rec.WaitForRotations() // ensure the .gz archive exists
+	recordN(rec, "post", 3)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	// Resume from seq 2: expect seq 3,4,5 (archived) + the rotation anchor + post-0,1,2.
+	w, err := rec.Watch(ctx, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	// At least the three archived events (3,4,5) must arrive, in order, before
+	// any post-rotation event.
+	got := drainWatcher(t, w, 3)
+	wantSubjects := []string{"pre-2", "pre-3", "pre-4"}
+	for i, e := range got {
+		if e.Subject != wantSubjects[i] {
+			t.Fatalf("event %d subject = %q, want %q (archived events skipped?)", i, e.Subject, wantSubjects[i])
+		}
+		if e.Seq <= 2 {
+			t.Fatalf("event %d seq = %d, want > 2", i, e.Seq)
+		}
+	}
+}
+
+// The strictly-monotonic guard must never emit a seq at or below afterSeq, and
+// must never duplicate, even across the archive/active boundary.
+func TestWatchResumeNoDuplicatesAcrossBoundary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "a", 4)
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+	recordN(rec, "b", 4)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, 0) // full retained history
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	// 4 pre + 1 anchor + 4 post = 9 events, strictly increasing seq, no dupes.
+	got := drainWatcher(t, w, 9)
+	seen := map[uint64]bool{}
+	var last uint64
+	for i, e := range got {
+		if e.Seq <= last {
+			t.Fatalf("event %d seq %d not strictly increasing (last %d)", i, e.Seq, last)
+		}
+		if seen[e.Seq] {
+			t.Fatalf("duplicate seq %d", e.Seq)
+		}
+		seen[e.Seq] = true
+		last = e.Seq
+	}
+}
+
+// A canceled context must unblock a mid-backfill Next promptly.
+func TestWatchBackfillHonorsCancel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "x", 50)
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := w.Next()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Next after cancel returned nil error")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Next did not observe cancellation")
+	}
+}
+
+// W2: events appended to the OLD active file, then rotation, with the watcher's
+// offset behind them, must not be lost when the watcher detects the rotation.
+func TestWatchMidRotationTailNotLost(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "seed", 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	drainWatcher(t, w, 2) // consume seed; offset now at EOF of the active file
+
+	// Append a "tail" event, then rotate BEFORE the watcher polls it. The tail
+	// event lives only in the rotating/archived file after the rename.
+	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "tail"})
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "after"})
+
+	// Expect: tail (from archive), the rotation anchor, then after — tail must
+	// not be skipped.
+	var sawTail bool
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && !sawTail {
+		e := drainWatcher(t, w, 1)[0]
+		if e.Subject == "tail" {
+			sawTail = true
+		}
+		if e.Subject == "after" && !sawTail {
+			t.Fatal("saw 'after' before 'tail' — pre-rotation tail was lost")
+		}
+	}
+	if !sawTail {
+		t.Fatal("mid-rotation tail event was never delivered")
+	}
+}
+
+// Concurrent cold resumes must all complete (semaphore must not deadlock).
+func TestWatchConcurrentResumes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "c", 6)
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+			defer cancel()
+			w, err := rec.Watch(ctx, 0)
+			if err != nil {
+				t.Errorf("Watch: %v", err)
+				return
+			}
+			defer w.Close() //nolint:errcheck // test cleanup
+			drainWatcher(t, w, 6)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/events/watch_backfill_test.go
+++ b/internal/events/watch_backfill_test.go
@@ -3,7 +3,9 @@ package events
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -280,17 +282,78 @@ func TestWatchCloseDuringBackfillNoRace(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		// Signal once the drain goroutine returns from its first Next so Close
+		// races a genuinely in-flight watcher rather than an arbitrary
+		// wall-clock delay (lifecycle signal, no time.Sleep).
+		started := make(chan struct{})
 		go func() {
+			first := true
 			for {
-				if _, err := w.Next(); err != nil {
+				_, err := w.Next()
+				if first {
+					close(started)
+					first = false
+				}
+				if err != nil {
 					return
 				}
 			}
 		}()
-		time.Sleep(time.Duration(iter%3) * time.Millisecond)
+		<-started
 		_ = w.Close()
 		cancel()
 		rec.Close() //nolint:errcheck // test cleanup
+	}
+}
+
+// A watcher abandoned mid-archive-backfill must release the open segment reader
+// at Close, not orphan the archive fd + gzip.Reader until GC. Regression for the
+// iteration-4 major: Close deliberately skipped bfReader, so a cold-resume SSE
+// client that read a partial batch and disconnected leaked the .gz descriptor.
+func TestWatchCloseReleasesArchiveBackfillReader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "m", 5000) // one archive segment spanning several backfill batches
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fw, err := rec.Watch(ctx, 0) // cold resume replays the archive
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := fw.(*fileWatcher)
+
+	// One Next reads a bounded batch and keeps the archive segment reader open
+	// for the next call — the mid-backfill state a disconnect can strand.
+	if _, err := fw.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	sr := w.bfReader
+	if sr == nil || sr.f == nil {
+		t.Fatalf("precondition: want an open archive segment reader after one Next, got %v", sr)
+	}
+
+	// Abandon the watcher without draining the rest of the archive.
+	if err := fw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if w.bfReader != nil {
+		t.Fatal("Close left the backfill reader open; archive fd leaks until GC")
+	}
+	if _, err := sr.f.Stat(); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("archive fd still open after Close: Stat err = %v, want os.ErrClosed", err)
 	}
 }
 
@@ -481,5 +544,269 @@ func TestBackfillRotatingPromotedBetweenListAndOpen(t *testing.T) {
 	}
 	if len(out) != 3 {
 		t.Fatalf("fallback archive yielded %d events, want 3", len(out))
+	}
+}
+
+// TestWatchRepeatedRotationDuringCatchUpNotLost pins the multi-rotation
+// catch-up fix: a second rotation that lands while the watcher is still
+// draining the first rotation's archive must not truncate or drop the second
+// rotation's window. Before the fix the catch-up froze its source list at the
+// first rotation, so once that frozen list drained the watcher committed the
+// newest inode and skipped the intervening window (or, on inode reuse, hung).
+func TestWatchRepeatedRotationDuringCatchUpNotLost(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "seed", 2) // seq 1..2
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()       //nolint:errcheck // test cleanup
+	drainWatcher(t, w, 2) // consume seed; offset at EOF of the active file
+
+	// Fill the active file so draining the first rotation's archive spans
+	// several backfill batches, giving the second rotation room to land while
+	// the catch-up is provably mid-drain.
+	const firstWindow = 2 * backfillBatch
+	recordN(rec, "w1", firstWindow)
+	if _, err := rec.ForceRotate(); err != nil { // rotation 1
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+
+	// Start the catch-up and pull a few events so it is mid-drain of archive-1
+	// (bfCatchUp true, first archive not yet exhausted): consumes seq 3..7.
+	drainWatcher(t, w, 5)
+
+	// Second rotation lands now, while the first catch-up is still draining.
+	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "mid"})
+	if _, err := rec.ForceRotate(); err != nil { // rotation 2
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "after"})
+
+	latest, err := rec.LatestSeq()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seq 1..7 consumed so far. Everything after must arrive contiguously, in
+	// strictly-increasing seq with no gap, and include both markers.
+	remaining := int(latest) - 7
+	got := drainWatcher(t, w, remaining)
+	var last uint64 = 7
+	sawMid, sawAfter := false, false
+	for i, e := range got {
+		if e.Seq != last+1 {
+			t.Fatalf("event %d seq = %d, want %d (gap → a rotation window was dropped)", i, e.Seq, last+1)
+		}
+		last = e.Seq
+		switch e.Subject {
+		case "mid":
+			sawMid = true
+		case "after":
+			sawAfter = true
+		}
+	}
+	if !sawMid {
+		t.Fatal("'mid' event (second rotation window) was never delivered")
+	}
+	if !sawAfter {
+		t.Fatal("'after' event (post second rotation) was never delivered")
+	}
+	if last != latest {
+		t.Fatalf("last delivered seq = %d, want %d", last, latest)
+	}
+}
+
+// TestStepRotationDrivesCatchUpDespiteReusedInode pins the same-inode guard for
+// the repeated-rotation fix. Genuine inode reuse — a later rotation's fresh
+// active file reusing the freed inode the watcher is anchored to — is
+// filesystem-dependent and cannot be forced deterministically from a black-box
+// test, so this drives the watcher state machine directly: with a catch-up in
+// progress and the active inode equal to the watcher's anchor inode, stepRotation
+// must keep draining the catch-up rather than take the same-inode fast path
+// (which abandoned the drain and polled the fresh file at a stale offset before
+// the fix, hanging the stream).
+func TestStepRotationDrivesCatchUpDespiteReusedInode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "arch", 4) // seq 1..4 → archived
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations() // archive-1 (seq 1..4) exists; active holds the anchor
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeInode := inodeOf(info)
+	if activeInode == 0 {
+		t.Skip("inode unavailable on this platform")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+	fw, ok := w.(*fileWatcher)
+	if !ok {
+		t.Fatalf("Watch returned %T, want *fileWatcher", w)
+	}
+
+	// Simulate a tailing watcher that detected a rotation and began a catch-up,
+	// then had its anchor inode reused by a second rotation's fresh active file.
+	fw.needsBackfill = false
+	fw.bfActive = false
+	fw.closeFd() // release the resume fd we are not exercising here
+	fw.bfCatchUp = true
+	fw.bfListed = false
+	fw.maxSeq = 0
+	fw.inode = activeInode // == current active inode (as if reused)
+
+	cont, err := fw.stepRotation()
+	if err != nil {
+		t.Fatalf("stepRotation: %v", err)
+	}
+	if !cont {
+		t.Fatal("stepRotation took the same-inode fast path during a catch-up; the archived window would be skipped")
+	}
+	if len(fw.buf) == 0 {
+		t.Fatal("catch-up produced no events; the archived window was not replayed")
+	}
+	if fw.buf[0].Seq != 1 {
+		t.Fatalf("first catch-up event seq = %d, want 1 (archive replay from genesis)", fw.buf[0].Seq)
+	}
+}
+
+// TestWatchConclusionWindowRotationNotLost pins the fix for the catch-up
+// *conclusion* window race. When stepCatchUp's final re-list is empty it
+// concludes catch-up and stepRotation commits the active inode with offset 0,
+// then stepTail reads the active file. A rotation that lands in that seam — after
+// the empty re-list, before the tail read — archives the committed active file
+// and points the path at a fresh active file; a by-path tail would read the
+// fresh file, advance maxSeq past the just-archived window, and lose it forever.
+// The seam is sub-poll and filesystem-timing dependent, so this drives the
+// watcher state machine directly and injects the rotation exactly at it.
+func TestWatchConclusionWindowRotationNotLost(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "arch", 4) // seq 1..4 → archive-1
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations() // archive-1 (seq 1..4); active holds the anchor (seq 5)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeInode := inodeOf(info)
+	if activeInode == 0 {
+		t.Skip("inode unavailable on this platform")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+	fw, ok := w.(*fileWatcher)
+	if !ok {
+		t.Fatalf("Watch returned %T, want *fileWatcher", w)
+	}
+
+	// Simulate a live tail mid-catch-up whose archived window (seq 1..4) is
+	// already drained: resume done, cursor past the archive, and the current
+	// active file (anchor seq 5) the next contiguous source with nothing archived
+	// beyond the cursor. The next stepRotation therefore concludes catch-up and
+	// commits the active inode.
+	fw.needsBackfill = false
+	fw.bfActive = false
+	fw.closeFd()
+	fw.bfCatchUp = true
+	fw.bfListed = false
+	fw.maxSeq = 4
+	fw.inode = activeInode
+	fw.offset = 0
+
+	cont, err := fw.stepRotation()
+	if err != nil {
+		t.Fatalf("stepRotation (conclude catch-up): %v", err)
+	}
+	if cont {
+		t.Fatal("catch-up did not conclude; expected the active file to be the next contiguous source")
+	}
+	if fw.maxSeq != 4 {
+		t.Fatalf("maxSeq after catch-up conclusion = %d, want 4", fw.maxSeq)
+	}
+
+	// Conclusion-window rotation: append seq 6, then rotate. The just-committed
+	// active file (seq 5..6) is archived and the path now names a fresh active
+	// file whose anchor is seq 7. Do NOT settle rotations yet, so the committed
+	// inode cannot be freed and reused for the fresh active file (which would
+	// defeat the identity check for reasons orthogonal to this finding).
+	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "seq6"}) // seq 6
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The by-path tail would read the fresh active file (anchor seq 7) and jump
+	// maxSeq to 7, skipping [5..6]. The identity-checked tail must refuse to
+	// advance from the unverified fresh file.
+	if err := fw.stepTail(); err != nil {
+		t.Fatalf("stepTail (conclusion-window rotation): %v", err)
+	}
+	if fw.maxSeq != 4 {
+		t.Fatalf("maxSeq after conclusion-window rotation = %d, want 4 (tail read the fresh active file and skipped the just-archived [5..6] window)", fw.maxSeq)
+	}
+	if len(fw.buf) != 0 {
+		t.Fatalf("stepTail buffered %d events from the unverified fresh active file; want 0", len(fw.buf))
+	}
+
+	// Rotation catch-up on the next poll must recover the just-archived [5..6]
+	// window before the fresh active file is tailed.
+	rec.WaitForRotations()
+	cont, err = fw.stepRotation()
+	if err != nil {
+		t.Fatalf("stepRotation (recover conclusion window): %v", err)
+	}
+	if !cont {
+		t.Fatal("stepRotation did not re-enter catch-up for the conclusion-window rotation; the [5..6] window would be lost")
+	}
+	if len(fw.buf) < 2 {
+		t.Fatalf("catch-up recovered %d events; want the [5..6] window (2 events)", len(fw.buf))
+	}
+	if fw.buf[0].Seq != 5 || fw.buf[1].Seq != 6 {
+		t.Fatalf("recovered window seqs = [%d, %d], want [5, 6]", fw.buf[0].Seq, fw.buf[1].Seq)
 	}
 }

--- a/internal/events/watch_backfill_test.go
+++ b/internal/events/watch_backfill_test.go
@@ -430,3 +430,56 @@ func TestWatchBackfillBoundedBuffer(t *testing.T) {
 		drainWatcher(t, fw, 1)
 	}
 }
+
+// Promotion window: a rotating file listed at T0 but promoted (renamed to its
+// .gz, source removed) before the open must be read via its derived archive
+// path, not silently skipped — the .gz did not exist at list time.
+func TestBackfillRotatingPromotedBetweenListAndOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "p", 3)
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations() // .gz now exists, rotating file removed
+
+	// Reconstruct the exact race state a watcher would see: a source list that
+	// names the (now vanished) rotating file with the archive as fallback.
+	archives, err := archiveFilesIn(dir)
+	if err != nil || len(archives) != 1 {
+		t.Fatalf("archives = %v err = %v, want exactly 1", archives, err)
+	}
+	info := archives[0]
+	src := backfillSource{
+		path:         filepath.Join(dir, "events.jsonl.rotating-vanished"), // gone
+		fallbackPath: filepath.Join(dir, info.Basename),
+		kind:         sourceRotating,
+		firstSeq:     info.FirstSeq,
+		lastSeq:      info.LastSeq,
+	}
+	sr, err := openSegmentReader(src)
+	if err != nil {
+		t.Fatalf("openSegmentReader: %v", err)
+	}
+	if sr == nil {
+		t.Fatal("vanished rotating file with existing .gz was skipped — promotion window lost")
+	}
+	defer sr.close()
+
+	var maxSeq uint64
+	var out []Event
+	eof, err := sr.readInto(Filter{}, &maxSeq, &out, 100)
+	if err != nil || !eof {
+		t.Fatalf("readInto: eof=%v err=%v", eof, err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("fallback archive yielded %d events, want 3", len(out))
+	}
+}

--- a/internal/events/watch_backfill_test.go
+++ b/internal/events/watch_backfill_test.go
@@ -254,3 +254,179 @@ func TestWatchConcurrentResumes(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// --- Red-team regression coverage ---
+
+// A concurrent Close during a mid-backfill Next must not race the captured fd
+// (run with -race). Also asserts Close promptly unblocks.
+func TestWatchCloseDuringBackfillNoRace(t *testing.T) {
+	for iter := 0; iter < 40; iter++ {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "events.jsonl")
+		var stderr bytes.Buffer
+		rec, err := NewFileRecorder(path, &stderr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		recordN(rec, "a", 400)
+		if _, err := rec.ForceRotate(); err != nil {
+			t.Fatal(err)
+		}
+		rec.WaitForRotations()
+		recordN(rec, "b", 400)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		w, err := rec.Watch(ctx, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		go func() {
+			for {
+				if _, err := w.Next(); err != nil {
+					return
+				}
+			}
+		}()
+		time.Sleep(time.Duration(iter%3) * time.Millisecond)
+		_ = w.Close()
+		cancel()
+		rec.Close() //nolint:errcheck // test cleanup
+	}
+}
+
+// A failed rotation catch-up must NOT poll the fresh file at the stale offset and
+// advance past the unread window. Here a >1MiB line no longer poisons the scan
+// (ReadBytes handles it), so we assert nothing is lost across such a rotation.
+func TestWatchRotationLargeLineNotLost(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "seed", 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()       //nolint:errcheck // test cleanup
+	drainWatcher(t, w, 1) // consume seed
+
+	big := make([]byte, 2*1024*1024)
+	for i := range big {
+		big[i] = 'x'
+	}
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "big", Message: string(big)})
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "small"})
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "after"})
+
+	// "big" and "small" (pre-rotation tail) must both arrive before "after".
+	seen := map[string]bool{}
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) && !seen["after"] {
+		e := drainWatcher(t, w, 1)[0]
+		seen[e.Subject] = true
+		if e.Subject == "after" && (!seen["big"] || !seen["small"]) {
+			t.Fatalf("saw 'after' before big=%v small=%v — large-line rotation lost the tail", seen["big"], seen["small"])
+		}
+	}
+	if !seen["big"] || !seen["small"] {
+		t.Fatalf("pre-rotation tail lost: big=%v small=%v", seen["big"], seen["small"])
+	}
+}
+
+// The ordering-loss race: a .gz for a LATER window coexisting with a rotating
+// file for an EARLIER window must still deliver the earlier window (FirstSeq
+// order + monotonic guard).
+func TestWatchBackfillOrderingAcrossSegments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "w1", 3) // window 1: seq 1..3
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	recordN(rec, "w2", 3) // window 2 (after anchor)
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+	recordN(rec, "w3", 2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	// Everything strictly increasing in seq; window 1 must arrive first.
+	got := drainWatcher(t, w, 3)
+	if got[0].Subject != "w1-0" {
+		t.Fatalf("first backfilled event = %q, want w1-0 (earlier window skipped?)", got[0].Subject)
+	}
+	var last uint64
+	for i, e := range got {
+		if e.Seq <= last {
+			t.Fatalf("event %d seq %d not increasing (last %d)", i, e.Seq, last)
+		}
+		last = e.Seq
+	}
+}
+
+// Resident memory during backfill is bounded to ~backfillBatch, not a whole
+// segment: after one Next, the buffer must not hold the entire archive.
+func TestWatchBackfillBoundedBuffer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	recordN(rec, "m", 5000) // one big archive segment
+	if _, err := rec.ForceRotate(); err != nil {
+		t.Fatal(err)
+	}
+	rec.WaitForRotations()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	fw, err := rec.Watch(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fw.Close() //nolint:errcheck // test cleanup
+
+	// First Next triggers a backfill batch; the internal buffer must be bounded.
+	if _, err := fw.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	w := fw.(*fileWatcher)
+	if len(w.buf) > backfillBatch {
+		t.Fatalf("backfill buffered %d events after one Next, want <= %d (whole segment pinned?)", len(w.buf), backfillBatch)
+	}
+
+	// And it still delivers all 5000 across many Next calls.
+	for count := 1; count < 5000; count++ {
+		drainWatcher(t, fw, 1)
+	}
+}

--- a/internal/runtime/t3bridge/provider.go
+++ b/internal/runtime/t3bridge/provider.go
@@ -1821,9 +1821,13 @@ func (p *Provider) runEventWatcher(ctx context.Context, _ string, cfg runtime.Co
 	cache := beadStoreForWatcher(cfg.WorkDir, cfg.Env)
 	_ = cache.Prime(ctx)
 
+	// Fail closed on a LatestSeq error: Watch now treats afterSeq=0 as "replay
+	// the entire retained history" (across archives), so defaulting to 0 here
+	// would flood the bead cache with the whole log. This watcher only needs
+	// events from now on, so skip this poll rather than replay everything.
 	afterSeq, err := recorder.LatestSeq()
 	if err != nil {
-		afterSeq = 0
+		return
 	}
 	watcher, err := recorder.Watch(ctx, afterSeq)
 	if err != nil {

--- a/internal/runtime/t3bridge/provider.go
+++ b/internal/runtime/t3bridge/provider.go
@@ -1802,6 +1802,40 @@ func (p *Provider) refreshAssignmentProjection(threadID string, envelope Startup
 	_ = p.dispatchThreadMeta(threadID, buildGCMetadata(next, providerName, nil))
 }
 
+// latestSeqRetryInitialBackoff is the first wait between LatestSeq retries; it
+// doubles each attempt. A package var so tests can shrink it.
+var latestSeqRetryInitialBackoff = 100 * time.Millisecond
+
+// latestSeqWithBackoff resolves the current head sequence, retrying a transient
+// read failure with context-aware exponential backoff before giving up. Watch
+// treats afterSeq=0 as "replay the entire retained history", so the head must be
+// resolved before watching; returning on the first hiccup would permanently
+// disable the session's only event-projection goroutine. It returns the context
+// error if canceled while waiting, or the last read error after exhausting the
+// attempt budget.
+func latestSeqWithBackoff(ctx context.Context, latest func() (uint64, error)) (uint64, error) {
+	const maxAttempts = 5
+	backoff := latestSeqRetryInitialBackoff
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		seq, err := latest()
+		if err == nil {
+			return seq, nil
+		}
+		lastErr = err
+		if attempt == maxAttempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return 0, lastErr
+}
+
 func (p *Provider) runEventWatcher(ctx context.Context, _ string, cfg runtime.Config, binding threadBinding, envelope StartupEnvelope, providerName string) {
 	cityPath := cfg.Env["GC_CITY_PATH"]
 	if cityPath == "" {
@@ -1821,12 +1855,16 @@ func (p *Provider) runEventWatcher(ctx context.Context, _ string, cfg runtime.Co
 	cache := beadStoreForWatcher(cfg.WorkDir, cfg.Env)
 	_ = cache.Prime(ctx)
 
-	// Fail closed on a LatestSeq error: Watch now treats afterSeq=0 as "replay
+	// Resolve the head before watching: Watch now treats afterSeq=0 as "replay
 	// the entire retained history" (across archives), so defaulting to 0 here
-	// would flood the bead cache with the whole log. This watcher only needs
-	// events from now on, so skip this poll rather than replay everything.
-	afterSeq, err := recorder.LatestSeq()
+	// would flood the bead cache with the whole log. A transient LatestSeq error
+	// must not permanently kill this watcher — it is the session's only
+	// event-projection goroutine — so retry with context-aware backoff and log
+	// the terminal give-up so operators can tell a dead watcher from a healthy
+	// idle one.
+	afterSeq, err := latestSeqWithBackoff(ctx, recorder.LatestSeq)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "t3bridge: event watcher for %q exiting — could not resolve latest seq: %v\n", providerName, err) //nolint:errcheck // best-effort debug logging
 		return
 	}
 	watcher, err := recorder.Watch(ctx, afterSeq)

--- a/internal/runtime/t3bridge/watch_latest_seq_test.go
+++ b/internal/runtime/t3bridge/watch_latest_seq_test.go
@@ -1,0 +1,71 @@
+package t3bridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// shrinkRetryBackoff makes latestSeqWithBackoff's waits negligible for tests and
+// restores the production value on cleanup.
+func shrinkRetryBackoff(t *testing.T) {
+	t.Helper()
+	prev := latestSeqRetryInitialBackoff
+	latestSeqRetryInitialBackoff = time.Millisecond
+	t.Cleanup(func() { latestSeqRetryInitialBackoff = prev })
+}
+
+func TestLatestSeqWithBackoffRetriesThenSucceeds(t *testing.T) {
+	shrinkRetryBackoff(t)
+	calls := 0
+	seq, err := latestSeqWithBackoff(context.Background(), func() (uint64, error) {
+		calls++
+		if calls < 3 {
+			return 0, fmt.Errorf("transient hiccup %d", calls)
+		}
+		return 42, nil
+	})
+	if err != nil {
+		t.Fatalf("latestSeqWithBackoff: %v", err)
+	}
+	if seq != 42 {
+		t.Fatalf("seq = %d, want 42", seq)
+	}
+	if calls != 3 {
+		t.Fatalf("LatestSeq calls = %d, want 3", calls)
+	}
+}
+
+func TestLatestSeqWithBackoffHonorsContextCancel(t *testing.T) {
+	shrinkRetryBackoff(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	_, err := latestSeqWithBackoff(ctx, func() (uint64, error) {
+		calls++
+		return 0, errors.New("always fails")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if calls == 0 {
+		t.Fatal("expected at least one LatestSeq attempt before honoring cancel")
+	}
+}
+
+func TestLatestSeqWithBackoffGivesUpAfterMaxAttempts(t *testing.T) {
+	shrinkRetryBackoff(t)
+	calls := 0
+	_, err := latestSeqWithBackoff(context.Background(), func() (uint64, error) {
+		calls++
+		return 0, fmt.Errorf("attempt %d", calls)
+	})
+	if err == nil {
+		t.Fatal("expected an error after exhausting the attempt budget")
+	}
+	if calls != 5 {
+		t.Fatalf("LatestSeq calls = %d, want 5 (maxAttempts)", calls)
+	}
+}


### PR DESCRIPTION
## Problem (live-proven on maintainer-city)

`FileRecorder.Watch` read only the active `events.jsonl`, so after a rotation:

- an SSE reconnect with `Last-Event-ID`/`after_seq` below the rotation boundary **silently skipped every archived event** in the gap (probed live: resume at 13276000 delivered 13276046 first — 45 events lost, no error) — breaking the documented reconnect contract and the async city-create result-delivery flow;
- the event exporter's durable-cursor resume permanently lost rotated-away events, violating its at-least-once promise;
- events appended to the old active file in the last poll window before a mid-watch rotation were dropped by the bare offset reset.

Every live-streaming consumer inherited these: city + supervisor SSE streams, `eventfeed.MuxSource`/exporter, `gc events --follow/--watch --after`, t3bridge. (`runproj.ColdLoad` and the dashboardbff runtailer were already archive-aware — the runtailer had privately fixed the rotation gap; this generalizes that fix at the substrate.)

## Fix

`fileWatcher` now delivers **every retained event with `Seq > afterSeq`, exactly once per watcher, in seq order** (contract doc updated; across watcher instances the system stays at-least-once):

- **Resume backfill (W1):** archives + in-flight `rotating-*` files + a captured active-fd leg, ordered by filename seq window, streamed through an incremental iterator — lazily on first `Next` (the mux attach probe stays O(1)), at most 256 events resident per watcher (no whole-segment buffering), decode work capped by a 2-slot semaphore, lines read without `bufio.Scanner`'s 1 MiB limit (the write path imposes none).
- **Mid-watch rotation catch-up (W2):** on inode change, drain the rotation window from the rotating/`.gz` files before committing the new identity and offset; on a catch-up error, back off and retry without polling the fresh file at the stale offset (which would advance the cursor past the unread window permanently).
- **Promotion window:** a rotating file promoted between listing and open is read via its derived archive path (`.gz` rename precedes source removal) instead of being skipped.
- **Fail-closed `afterSeq=0`:** since `Watch(0)` now means "entire retained history", the four call sites that defaulted to 0 on a `LatestSeq` error (t3bridge, controller bead-cache watcher, city + supervisor SSE head-start) fail closed instead; the controller watcher distinguishes a genuinely-empty log (start seq 0 stands — the cache-prime replay contract) from an unresolved cursor via an explicit flag.

## Process

Designed → hardened by a 3-lens design-review panel (concurrency / performance / API-compat; every blocker addressed, incl. lazy-in-Next placement and merge-correct segment ordering) → implemented TDD → adversarially red-teamed (5 confirmed findings, each fixed + regression-tested: fd data race, catch-up-error tail loss, Close vs semaphore, >1MiB line poisoning, per-connection segment-sized buffering OOM).

## Testing

- 12 new tests in `watch_backfill_test.go` (resume across real rotations, mid-rotation tails, ordering across coexisting `.gz`/rotating windows, cancel/Close mid-backfill, bounded buffer, concurrent resumes, >1MiB lines, promotion window)
- provider-neutral conformance case `WatchReplaysRetainedHistory` (File/Fake/exec all pass) + contract doc updates
- `go test -race ./internal/events/...` clean; consumer suites green (`internal/api` 198s, eventfeed, t3bridge, dashboardbff, `cmd/gc` watcher family); `go vet` + `golangci-lint` clean; pre-push `make test-fast-parallel` passed

## Deferred (filed)

- #4167 — `ReadFilteredTail` (no-cursor list fast path) is archive-blind too, but fixing it needs a per-request archive budget + `Since`-timestamp prune to avoid a gunzip-per-request DoS on the unauthenticated `/v0/events` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)