### PR TITLE
fix(status): bound the store-health row scan so gc status can't stall for minutes

### DIFF
--- a/cmd/gc/store_health.go
+++ b/cmd/gc/store_health.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
@@ -9,6 +10,14 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/storehealth"
 )
+
+// statusStoreHealthTimeout bounds the store-health row count so a live city
+// with a large closed-history table cannot stall `gc status` for minutes. The
+// count drives only the on-disk size ratio and is best-effort, so a timeout
+// returns 0 — mirroring the API server's countBeadStoreRows defense
+// (internal/api/store_health.go, statusStoreReadTimeout), which this CLI local
+// fallback never inherited. It matches the server's 1s bound.
+const statusStoreHealthTimeout = time.Second
 
 // storeHealthFromInputs assembles a CLI-facing *StoreHealth from the raw
 // measurements. LastGCAt is serialized as RFC3339 UTC when present;
@@ -42,19 +51,54 @@ func collectStoreHealth(cityPath string, store beads.Store, ep events.Provider) 
 	return storeHealthFromInputs(cityPath, size, rows, lastAt, lastStatus)
 }
 
-// liveRowCount returns the number of beads known to store, or 0 when
-// store is nil or the list fails. Counts all statuses (including
-// closed) because the ratio is about on-disk row footprint, not
-// actionable work.
+// liveRowCount returns the number of beads known to store, or 0 when store is
+// nil, the count fails, or it does not finish within statusStoreHealthTimeout.
+// Counts all statuses (including closed) because the ratio is about on-disk row
+// footprint, not actionable work — but that closed-inclusive scan is never
+// cache-answerable and hydrates the whole history from the backend, so it is
+// bounded to keep `gc status` responsive. A Counter-capable store (Dolt /
+// CachingStore) answers from the catalog without hydrating rows; otherwise a
+// bounded full scan is the fallback.
 func liveRowCount(store beads.Store) int {
 	if store == nil {
 		return 0
 	}
-	list, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	ctx, cancel := context.WithTimeout(context.Background(), statusStoreHealthTimeout)
+	defer cancel()
+	query := beads.ListQuery{AllowScan: true, IncludeClosed: true}
+	if counter, ok := store.(beads.Counter); ok {
+		if n, err := counter.Count(ctx, query); err == nil {
+			return n
+		}
+	}
+	list, err := listBeadsWithTimeout(ctx, store, query)
 	if err != nil {
 		return 0
 	}
 	return len(list)
+}
+
+// listBeadsWithTimeout runs store.List on a goroutine and returns its result,
+// or ctx.Err() if the deadline fires first. beads.Store.List takes no context,
+// so a stalled scan cannot be canceled — the goroutine is left to finish on
+// its own (harmless in the short-lived `gc status` process). Mirrors the API
+// server's statusListStoreWithTimeout.
+func listBeadsWithTimeout(ctx context.Context, store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
+	type listResult struct {
+		list []beads.Bead
+		err  error
+	}
+	done := make(chan listResult, 1)
+	go func() {
+		list, err := store.List(query)
+		done <- listResult{list: list, err: err}
+	}()
+	select {
+	case r := <-done:
+		return r.list, r.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // renderStoreHealthBlock prints the human-readable "Store health:"

--- a/cmd/gc/store_health_timeout_test.go
+++ b/cmd/gc/store_health_timeout_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// fakeHealthStore is a beads.Store whose List and Count behavior the test
+// controls. The embedded nil interface is never used — liveRowCount only calls
+// Count (via the beads.Counter assertion) and List.
+type fakeHealthStore struct {
+	beads.Store
+	countFn func(context.Context, beads.ListQuery) (int, error)
+	listFn  func(beads.ListQuery) ([]beads.Bead, error)
+}
+
+func (f *fakeHealthStore) Count(ctx context.Context, q beads.ListQuery, _ ...string) (int, error) {
+	return f.countFn(ctx, q)
+}
+
+func (f *fakeHealthStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	return f.listFn(q)
+}
+
+// TestLiveRowCountBoundsSlowScan is the regression for the ~105s silent stall in
+// `gc status`: liveRowCount ran an unbounded IncludeClosed full-history scan
+// (store.List) with no timeout, so a live city with a large closed-history
+// table hung status for ~2 minutes. When the Counter cannot answer, the scan
+// must be bounded and return 0 (best-effort) rather than stall.
+func TestLiveRowCountBoundsSlowScan(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) }) // let the leaked List goroutine exit
+	store := &fakeHealthStore{
+		countFn: func(context.Context, beads.ListQuery) (int, error) {
+			return 0, errors.New("count unsupported for this query")
+		},
+		listFn: func(beads.ListQuery) ([]beads.Bead, error) {
+			<-release // simulate the multi-minute closed-history hydration
+			return nil, nil
+		},
+	}
+
+	start := time.Now()
+	got := liveRowCount(store)
+	elapsed := time.Since(start)
+
+	if got != 0 {
+		t.Fatalf("liveRowCount = %d, want 0 when the scan times out", got)
+	}
+	if elapsed > statusStoreHealthTimeout+2*time.Second {
+		t.Fatalf("liveRowCount did not bound the scan: took %s (bound %s)", elapsed, statusStoreHealthTimeout)
+	}
+}
+
+// TestLiveRowCountUsesCounterFastPath pins that a Counter-capable store answers
+// from the catalog without hydrating rows — List must not be called.
+func TestLiveRowCountUsesCounterFastPath(t *testing.T) {
+	store := &fakeHealthStore{
+		countFn: func(_ context.Context, q beads.ListQuery) (int, error) {
+			if !q.IncludeClosed {
+				t.Errorf("row-footprint count must IncludeClosed, got query %+v", q)
+			}
+			return 42, nil
+		},
+		listFn: func(beads.ListQuery) ([]beads.Bead, error) {
+			t.Fatal("List must not be called when the Counter answers")
+			return nil, nil
+		},
+	}
+
+	if got := liveRowCount(store); got != 42 {
+		t.Fatalf("liveRowCount = %d, want 42 from the Counter fast path", got)
+	}
+}


### PR DESCRIPTION
## Summary

`gc status`'s local fallback (supervisor-managed cities with no standalone `[api]` port) ran `liveRowCount` → `store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})` — an unbounded full closed-history hydration with **no timeout, no cache, no cancellation**. On a live city with a large closed-history table this silently stalled `gc status` for ~105s (measured 114s total); anything shelling `gc status` ate ~2 min per call, while `gc session list` / `gc pool status` / `gc rig list` all returned in ~1.3s.

The API server already defends this exact scan — `internal/api/store_health.go` `countBeadStoreRows` bounds it with a 1s read timeout (`statusStoreReadTimeout`) plus a 30s cache. The CLI local fallback (`cmd/gc/store_health.go`) is a parallel implementation that never inherited that defense.

This bounds `liveRowCount` to `statusStoreHealthTimeout` (1s, matching the server), prefers the hydration-free `beads.Counter` fast path (Dolt / `CachingStore` answer from the catalog without loading closed history), and returns 0 on timeout — `LiveRows` is best-effort and drives only the on-disk size ratio. Adds `listBeadsWithTimeout` mirroring the server's `statusListStoreWithTimeout`.

Reported by maintainer-city ops with a measured repro (the ~105s is upstream of the 50ms bounded runtime-status provider).

## Testing

- [x] `make check` scope: `go build ./cmd/gc/`, `go vet ./cmd/gc/`, new unit tests green
- New TDD: `TestLiveRowCountBoundsSlowScan` (a slow-scan store returns within the bound instead of stalling) and `TestLiveRowCountUsesCounterFastPath` (Counter answers without touching `List`)
- [ ] `make check-docs` — n/a (no docs changed)
- [ ] `make test-integration` — n/a (bounds a best-effort read; no runtime/controller behavior change)

## Checklist

- [ ] Linked an issue — reported by maintainer-city ops; no tracking issue yet
- [x] Added tests for the behavior change
- [x] No user-facing/doc changes (LiveRows already best-effort; degrades to 0 on timeout exactly as the server does)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
