### PR TITLE
fix(hook): gc hook run consumes provider stdin so wrapped commands can't EPIPE it

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -115,12 +115,23 @@ func cmdHookRun(args []string, opts hookRunOptions, stdin io.Reader, stdout, std
 		return 1
 	}
 	cmd := exec.CommandContext(ctx, exe, args...)
-	// Forward the provider hook stdin so wrapped commands like
-	// `nudge drain --inject` still receive the UserPromptSubmit JSON
-	// (carrying transcript_path) they need for context-pressure injection.
-	// readHookStdin already bounds the read with an io.LimitReader and the
-	// hard timeout below bounds any block, so forwarding is safe.
-	cmd.Stdin = stdin
+	// Read the provider's hook stdin FULLY into a buffer before running the
+	// wrapped command, then hand it that buffer. Forwarding the live stdin
+	// (cmd.Stdin = stdin) let the wrapped command exit — on its fast path or on
+	// the timeout — before consuming the payload, so gc hook run returned and
+	// closed the pipe under the provider's in-flight write. Codex surfaced that
+	// fleet-wide as "UserPromptSubmit hook (failed): failed to write hook stdin:
+	// Broken pipe (os error 32)", silently killing nudge-drain and mail-check
+	// injection on every prompt submit. Buffering up front guarantees the
+	// provider's write always completes regardless of the wrapped command. The
+	// 1<<20 bound matches readHookStdin, so `nudge drain --inject` still sees the
+	// same UserPromptSubmit JSON (carrying transcript_path) for context
+	// injection.
+	var hookStdin []byte
+	if stdin != nil {
+		hookStdin, _ = io.ReadAll(io.LimitReader(stdin, 1<<20)) //nolint:errcheck // best-effort; a partial read still lets the wrapped command run
+	}
+	cmd.Stdin = bytes.NewReader(hookStdin)
 	// Buffer child stdout instead of streaming it straight to the provider so
 	// a wedged command cannot leak partial injectable output before the
 	// fail-open timeout path runs. The buffer is flushed only on a clean or

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -127,11 +127,19 @@ func cmdHookRun(args []string, opts hookRunOptions, stdin io.Reader, stdout, std
 	// 1<<20 bound matches readHookStdin, so `nudge drain --inject` still sees the
 	// same UserPromptSubmit JSON (carrying transcript_path) for context
 	// injection.
-	var hookStdin []byte
-	if stdin != nil {
-		hookStdin, _ = io.ReadAll(io.LimitReader(stdin, 1<<20)) //nolint:errcheck // best-effort; a partial read still lets the wrapped command run
-	}
-	cmd.Stdin = bytes.NewReader(hookStdin)
+	//
+	// drainHookStdin skips an interactive/inherited terminal (a char-device
+	// stdin never EOFs, so a manual gc hook run must not drain it) and bounds the
+	// pipe drain by ctx: os.Stdin carries no read deadline, so a provider pipe
+	// that writes < 1 MiB and never closes (no EOF) would otherwise block this
+	// read forever — before cmd.Run() and past the hard timeout — freezing the
+	// prompt-submit hot path. Bounding it keeps the "gc hook run is always
+	// bounded by the timeout" invariant enforced in code rather than assumed of
+	// every present and future provider. On the deadline drainHookStdin returns
+	// with ctx already expired, so cmd.Run() sees the canceled context and never
+	// spawns the child: gc hook run fails open to the timeout exit code in the
+	// timeout branch below instead of hanging before it spawns.
+	cmd.Stdin = bytes.NewReader(drainHookStdin(ctx, stdin))
 	// Buffer child stdout instead of streaming it straight to the provider so
 	// a wedged command cannot leak partial injectable output before the
 	// fail-open timeout path runs. The buffer is flushed only on a clean or
@@ -164,6 +172,45 @@ func cmdHookRun(args []string, opts hookRunOptions, stdin io.Reader, stdout, std
 	}
 	fmt.Fprintf(stderr, "gc hook run: %v\n", err) //nolint:errcheck
 	return 1
+}
+
+// drainHookStdin reads up to 1 MiB of the provider's hook stdin, bounded by ctx.
+// A normal provider write-then-close returns the full payload well before the
+// timeout; a pipe that writes less than the limit and stays open (no EOF) is
+// abandoned when ctx's hard timeout fires, so gc hook run cannot wedge before it
+// even spawns the child. The read runs in a goroutine that can outlive a
+// timed-out call: that is safe because gc hook run is a short-lived process
+// which exits right after, and the buffered channel keeps the goroutine from
+// blocking on send if it later unblocks. A partial buffer still lets the wrapped
+// command run.
+//
+// An interactive or inherited terminal is skipped entirely, matching
+// readHookStdin: a char-device stdin never reaches EOF on its own, so draining
+// it would only unblock when ctx's hard timeout fired, handing the child an
+// empty reader after gc hook run had already burned its whole budget — a manual
+// `gc hook run -- <cmd>` would then time out without ever running <cmd>. Provider
+// hooks always arrive on a pipe, which this guard leaves buffered and
+// timeout-bounded.
+func drainHookStdin(ctx context.Context, stdin io.Reader) []byte {
+	if stdin == nil {
+		return nil
+	}
+	if f, ok := stdin.(*os.File); ok {
+		if st, err := f.Stat(); err != nil || st.Mode()&os.ModeCharDevice != 0 {
+			return nil
+		}
+	}
+	done := make(chan []byte, 1)
+	go func() {
+		data, _ := io.ReadAll(io.LimitReader(stdin, 1<<20)) //nolint:errcheck // best-effort; a partial read still lets the wrapped command run
+		done <- data
+	}()
+	select {
+	case data := <-done:
+		return data
+	case <-ctx.Done():
+		return nil
+	}
 }
 
 type hookCommandOptions struct {

--- a/cmd/gc/cmd_hook_stdin_drain_test.go
+++ b/cmd/gc/cmd_hook_stdin_drain_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// trackingReader counts how many bytes were read from the wrapped reader, so a
+// test can assert gc hook run fully consumed the provider's hook stdin.
+type trackingReader struct {
+	r    io.Reader
+	read int
+}
+
+func (t *trackingReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	t.read += n
+	return n, err
+}
+
+// TestHookRunConsumesStdinWhenWrappedCommandIgnoresIt is the regression for the
+// fleet-wide "UserPromptSubmit hook (failed): failed to write hook stdin:
+// Broken pipe (os error 32)" on every codex prompt submit. gc hook run forwards
+// the provider's stdin to the wrapped command (e.g. `nudge drain --inject`);
+// when that command exits — on its fast path or on the timeout — before
+// consuming the payload, gc hook run returned and closed the pipe under codex's
+// in-flight write, killing nudge-drain and mail-check injection silently.
+//
+// gc hook run must fully consume its stdin so the provider's write always
+// completes, regardless of whether the wrapped command reads it. The wrapped
+// executable here is /bin/true, which exits 0 without reading stdin.
+func TestHookRunConsumesStdinWhenWrappedCommandIgnoresIt(t *testing.T) {
+	orig := hookRunExecutable
+	hookRunExecutable = func() (string, error) { return "/bin/true", nil }
+	t.Cleanup(func() { hookRunExecutable = orig })
+
+	payload := strings.Repeat("x", 8192)
+	tr := &trackingReader{r: strings.NewReader(payload)}
+	var stdout, stderr bytes.Buffer
+
+	code := cmdHookRun(
+		[]string{"nudge", "drain", "--inject"},
+		hookRunOptions{Timeout: 5 * time.Second, TimeoutExitCode: 0},
+		tr, &stdout, &stderr,
+	)
+
+	if code != 0 {
+		t.Fatalf("cmdHookRun = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if tr.read < len(payload) {
+		t.Fatalf("gc hook run consumed only %d/%d bytes of the provider's stdin; a wrapped command that ignores stdin must not leave the provider's write unconsumed (that is the EPIPE)", tr.read, len(payload))
+	}
+}

--- a/cmd/gc/cmd_hook_stdin_drain_test.go
+++ b/cmd/gc/cmd_hook_stdin_drain_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -52,5 +53,121 @@ func TestHookRunConsumesStdinWhenWrappedCommandIgnoresIt(t *testing.T) {
 	}
 	if tr.read < len(payload) {
 		t.Fatalf("gc hook run consumed only %d/%d bytes of the provider's stdin; a wrapped command that ignores stdin must not leave the provider's write unconsumed (that is the EPIPE)", tr.read, len(payload))
+	}
+}
+
+// blockingReader delivers a finite prefix, then blocks on the next Read until
+// release is closed — modeling a provider pipe that writes less than the 1 MiB
+// drain limit of hook stdin and never closes it (no EOF). The test closes
+// release on cleanup so the gc hook run drain goroutine cannot leak past it.
+type blockingReader struct {
+	prefix  []byte
+	release <-chan struct{}
+}
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	if len(b.prefix) > 0 {
+		n := copy(p, b.prefix)
+		b.prefix = b.prefix[n:]
+		return n, nil
+	}
+	<-b.release
+	return 0, io.EOF
+}
+
+// TestHookRunReturnsWithinTimeoutWhenStdinNeverEOFs pins the fix for the review
+// finding that the pre-spawn stdin drain was not bounded by the hard timeout. gc
+// hook run buffers provider stdin before running the wrapped command, and
+// os.Stdin has no read deadline, so a provider that writes less than 1 MiB
+// without closing stdin (no EOF) blocked io.ReadAll forever — before cmd.Run()
+// and past the advertised timeout — freezing the prompt-submit hot path. The
+// drain must stay bounded by ctx so gc hook run always fails open within the
+// configured timeout instead of wedging before it spawns the child.
+func TestHookRunReturnsWithinTimeoutWhenStdinNeverEOFs(t *testing.T) {
+	orig := hookRunExecutable
+	hookRunExecutable = func() (string, error) { return "/bin/true", nil }
+	t.Cleanup(func() { hookRunExecutable = orig })
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	stdin := &blockingReader{prefix: []byte(`{"transcript_path":"/tmp/t.jsonl"}`), release: release}
+	var stdout, stderr bytes.Buffer
+
+	const timeout = 200 * time.Millisecond
+	done := make(chan int, 1)
+	start := time.Now()
+	go func() {
+		done <- cmdHookRun(
+			[]string{"nudge", "drain", "--inject"},
+			hookRunOptions{Timeout: timeout, TimeoutExitCode: 124},
+			stdin, &stdout, &stderr,
+		)
+	}()
+
+	select {
+	case code := <-done:
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Fatalf("cmdHookRun returned after %s, want ~%s: the pre-spawn stdin drain is not bounded by the hard timeout", elapsed, timeout)
+		}
+		if code != 124 {
+			t.Fatalf("cmdHookRun = %d, want 124 (fail-open timeout); stderr=%q", code, stderr.String())
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("cmdHookRun did not return within 10s: the pre-spawn stdin drain blocked past the hard timeout (the regression)")
+	}
+}
+
+// TestHookRunSkipsStdinDrainForTerminal pins the fix for the iteration-2 review
+// finding that the pre-spawn drain omitted readHookStdin's terminal guard. A
+// char-device stdin (an interactive or inherited terminal on os.Stdin) never
+// reaches EOF on its own, so draining it unblocks only when the hard timeout
+// fires — a manual `gc hook run -- <cmd>` then returns the fail-open timeout code
+// without ever running <cmd>. drainHookStdin must skip a terminal exactly like
+// readHookStdin and run the child immediately with empty stdin, while still
+// buffering and timeout-bounding pipe-based provider stdin.
+//
+// A PTY master from /dev/ptmx is the terminal proxy: it is a char-device
+// *os.File whose Read blocks forever with no EOF while no slave writes to it,
+// which is exactly the shape of os.Stdin on a real terminal. The wrapped
+// executable is /bin/true, which exits 0 without reading stdin.
+func TestHookRunSkipsStdinDrainForTerminal(t *testing.T) {
+	tty, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("cannot open /dev/ptmx as a terminal-stdin proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = tty.Close() })
+	// Guard the guard: the proxy only proves anything if it is actually a
+	// char-device that blocks, matching a real terminal on os.Stdin.
+	st, err := tty.Stat()
+	if err != nil || st.Mode()&os.ModeCharDevice == 0 {
+		t.Skipf("/dev/ptmx is not a char device here (mode=%v err=%v); cannot model terminal stdin", st.Mode(), err)
+	}
+
+	orig := hookRunExecutable
+	hookRunExecutable = func() (string, error) { return "/bin/true", nil }
+	t.Cleanup(func() { hookRunExecutable = orig })
+
+	var stdout, stderr bytes.Buffer
+	const timeout = 3 * time.Second
+	done := make(chan int, 1)
+	start := time.Now()
+	go func() {
+		done <- cmdHookRun(
+			[]string{"nudge", "drain", "--inject"},
+			hookRunOptions{Timeout: timeout, TimeoutExitCode: 124},
+			tty, &stdout, &stderr,
+		)
+	}()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("cmdHookRun = %d, want 0: a terminal-backed gc hook run must skip the stdin drain and run the child, not drain the terminal until the timeout; stderr=%q", code, stderr.String())
+		}
+		if elapsed := time.Since(start); elapsed >= timeout {
+			t.Fatalf("cmdHookRun returned after %s (>= the %s timeout): terminal stdin was drained to the deadline instead of skipped", elapsed, timeout)
+		}
+	case <-time.After(timeout + 5*time.Second):
+		t.Fatalf("cmdHookRun did not return: terminal stdin was drained past the hard timeout instead of being skipped (the regression)")
 	}
 }


### PR DESCRIPTION
## Summary

`gc hook run` forwarded the provider's hook stdin (`cmd.Stdin = stdin`) straight to the wrapped command (e.g. `gc nudge drain --inject`). When that command exited — on its fast path or on the 15s timeout — **before** consuming the `UserPromptSubmit` payload, `gc hook run` returned and closed the pipe under the provider's in-flight write.

Codex surfaced this fleet-wide as `UserPromptSubmit hook (failed): failed to write hook stdin: Broken pipe (os error 32)` on **every** prompt submit, silently killing nudge-drain and mail-check context injection across all workers.

This buffers the provider's stdin fully into memory up front (`io.ReadAll` bounded to `1<<20`, matching `readHookStdin`) before running the wrapped command, then hands it that buffer. The provider's write now always completes regardless of the wrapped command's lifecycle; the wrapped command still receives the same payload.

Reported by maintainer-city ops (2× "Broken pipe" per codex pane — on `nudge drain --inject` and `mail check --inject`).

## Testing

- [x] `make check` scope: `go build ./cmd/gc/`, `go vet ./cmd/gc/`, new unit test green
- New TDD: `TestHookRunConsumesStdinWhenWrappedCommandIgnoresIt` — a wrapped command that ignores stdin must leave the provider's write fully consumed
- [ ] `make check-docs` — n/a (no docs changed)
- [ ] `make test-integration` — n/a (behavior localized to the hook-run wrapper; unit-covered)

## Checklist

- [ ] Linked an issue — reported by maintainer-city ops; no tracking issue yet
- [x] Added a test for the behavior change
- [x] No user-facing/doc changes
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
