### PR TITLE
fix(runtime): dismiss pi's workspace trust dialog at session start

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -66,7 +66,7 @@ func newStartupDialogConfig(opts []StartupDialogOption) startupDialogConfig {
 // sessions. Handles (in order):
 //  1. Claude resume selector — requires Down+Enter to resume the full session
 //  2. Codex update dialog ("Update available") — requires Down+Enter to skip
-//  3. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?")
+//  3. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?", pi "Trust project folder?")
 //  4. External CLAUDE.md imports dialog (Claude "Allow external CLAUDE.md file imports?") — requires Enter to allow (option 1 pre-selected)
 //  5. MCP trust dialog (Claude "New MCP server found in this project") — requires Down+Enter to trust all project MCP servers
 //  6. Codex hook review dialog — requires Down+Enter to trust hooks
@@ -444,8 +444,9 @@ func containsPostUpdateStartupDialog(content string) bool {
 
 // acceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
 // agents. Claude shows "Quick safety check"; Codex shows
-// "Do you trust the contents of this directory?". In both cases the safe
-// continue option is pre-selected, so Enter accepts.
+// "Do you trust the contents of this directory?"; pi (>= 0.79) shows
+// "Trust project folder?". In all cases the safe continue option is
+// pre-selected, so Enter accepts.
 func acceptWorkspaceTrustDialog(
 	ctx context.Context,
 	timeout time.Duration,
@@ -508,7 +509,8 @@ func containsWorkspaceTrustDialog(content string) bool {
 	return strings.Contains(content, "trust this folder") ||
 		strings.Contains(content, "Quick safety check") ||
 		strings.Contains(content, "Do you trust the contents of this directory?") ||
-		strings.Contains(content, "Do you trust the files in this folder?")
+		strings.Contains(content, "Do you trust the files in this folder?") ||
+		strings.Contains(content, "Trust project folder?")
 }
 
 func containsPostTrustStartupDialog(content string) bool {

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -56,6 +56,11 @@ func TestContainsWorkspaceTrustDialog(t *testing.T) {
 			want:    true,
 		},
 		{
+			name:    "pi trust dialog",
+			content: "Trust project folder?\n/home/user/project\n\nThis allows pi to load .pi settings and resources, install missing project packages, and execute project extensions.\n\n\u2192 Trust\n  Trust parent folder (/home/user)\n  Trust (this session only)\n  Do not trust\n  Do not trust (this session only)",
+			want:    true,
+		},
+		{
 			name:    "normal prompt text",
 			content: "> waiting for input",
 			want:    false,
@@ -112,6 +117,32 @@ func TestAcceptStartupDialogsAcceptsGeminiTrustDialog(t *testing.T) {
 				return "Do you trust the files in this folder?\n● 1. Trust folder (city)\n  2. Trust parent folder\n  3. Don't trust", nil
 			}
 			return "Type your message or @path/to/file", nil
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs() error = %v", err)
+	}
+	if !reflect.DeepEqual(sent, []string{"Enter"}) {
+		t.Fatalf("sent keys = %v, want [Enter]", sent)
+	}
+}
+
+func TestAcceptStartupDialogsAcceptsPiTrustDialog(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) {
+			if len(sent) == 0 {
+				return "Trust project folder?\n/home/user/project\n\nThis allows pi to load .pi settings and resources, install missing project packages, and execute project extensions.\n\n\u2192 Trust\n  Trust parent folder (/home/user)\n  Trust (this session only)\n  Do not trust\n  Do not trust (this session only)", nil
+			}
+			return "\u276f ", nil
 		},
 		func(keys ...string) error {
 			sent = append(sent, keys...)


### PR DESCRIPTION
pi >= 0.79 shows an interactive "Trust project folder?" select dialog when the session workdir carries .pi inputs — which is every gc-managed session, since gc stages .pi/extensions/gc-hooks.js into each workdir. The startup dialog dismissal knows the Claude/Codex/gemini trust phrasings but not pi's, so pi sessions freeze at the dialog before their first turn while reading as active in the session list (observed: 9 of 11 sessions in a city parked on it after a respawn).

Add pi's prompt to containsWorkspaceTrustDialog. The dialog pre-selects "Trust" as its first option, so the existing Enter accept applies unchanged.

Validation: go test ./internal/runtime (full package), go vet.

## Summary

- Explain the change and why it is needed.

## Testing

- [y] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed - none changed
  > **Note:** `docs/` is authored for [docs.gascityhall.com](https://docs.gascityhall.com) (Mintlify), not for direct GitHub viewing. Use extensionless page links (e.g. `/tutorials/01-beads`, not `/tutorials/01-beads.md`). If something looks broken on GitHub but works on the live site, that's intentional.
- [y] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [y] Linked an issue, or explained why one is not needed - no issue - small change to make pi coding agent work
- [y] Added or updated tests for behavior changes - detection table case with 
- [y ] Updated docs for user-facing changes - doc comment updated in code
- [y] Called out breaking changes or migration notes - none
