### PR TITLE
fix(ralph): don't burn a ralph attempt when the gate can't execute

### DIFF
--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -44,6 +44,7 @@ const (
 	BondMetadataKey                      = "gc.bond"
 	BondVarsMetadataKey                  = "gc.bond_vars"
 	BrainParentSIDMetadataKey            = "gc.brain_parent_sid"
+	CheckInfraRetryMetadataKey           = "gc.check_infra_retry"
 	CheckModeMetadataKey                 = "gc.check_mode"
 	CheckPathMetadataKey                 = "gc.check_path"
 	CheckTimeoutMetadataKey              = "gc.check_timeout"
@@ -281,6 +282,7 @@ var KnownMetadataKeys = []string{
 	BondMetadataKey,
 	BondVarsMetadataKey,
 	BrainParentSIDMetadataKey,
+	CheckInfraRetryMetadataKey,
 	CheckModeMetadataKey,
 	CheckPathMetadataKey,
 	CheckTimeoutMetadataKey,

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -20,6 +20,18 @@ import (
 	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
+// maxCheckInfraRetries bounds how many times a ralph check gate may be re-run
+// because it could not EXECUTE (GateError/GateTimeout) before that infra error
+// is treated as a genuine failure. Infra re-runs do NOT burn a gc.attempt, so a
+// transport/store outage cannot exhaust a PR's ralph attempts and abort_scope a
+// green PR (maintainer-city incident: 3 attempts burned in one outage). The
+// bound guarantees a gate that can never run (a missing script, a perpetual
+// timeout) still terminates the workflow instead of pending forever. The
+// counter is cloned into each next attempt, so this is the ralph loop's total
+// infra-retry budget; at a ~15s reconcile cadence it rides a multi-minute
+// outage.
+const maxCheckInfraRetries = 20
+
 func processRalphCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
 	if bead.Metadata[beadmeta.TerminalMetadataKey] == "true" {
 		return ControlResult{}, nil
@@ -60,6 +72,32 @@ func processRalphCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		traceClipString(result.Stderr, traceCheckOutputCap), traceClipString(result.Stdout, traceCheckOutputCap))
 	if err := persistCheckResult(store, bead.ID, result); err != nil {
 		return ControlResult{}, fmt.Errorf("%s: persisting check result: %w", bead.ID, err)
+	}
+
+	// Gate-exec infra errors must not burn a ralph attempt. GateError (the gate
+	// could not run) and GateTimeout (the gate did not finish) mean the gate
+	// never produced a verdict; only a gate that ran to completion and returned
+	// GateFail is a real failure. Re-run the gate via the benign
+	// ErrControlPending path (no attempt increment, no close), bounded by
+	// maxCheckInfraRetries so an unrunnable gate still terminates.
+	if result.Outcome == convergence.GateError || result.Outcome == convergence.GateTimeout {
+		infraRetries, _ := strconv.Atoi(bead.Metadata[beadmeta.CheckInfraRetryMetadataKey])
+		if infraRetries < maxCheckInfraRetries {
+			if err := store.SetMetadata(bead.ID, beadmeta.CheckInfraRetryMetadataKey, strconv.Itoa(infraRetries+1)); err != nil {
+				if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
+					return ControlResult{}, ErrControlPending
+				}
+				return ControlResult{}, fmt.Errorf("%s: recording gate infra-retry: %w", bead.ID, err)
+			}
+			opts.tracef("ralph check-infra-retry bead=%s outcome=%s infra_retry=%d/%d attempt=%d (attempt not burned)",
+				bead.ID, result.Outcome, infraRetries+1, maxCheckInfraRetries, attempt)
+			return ControlResult{}, ErrControlPending
+		}
+		// Infra-retry budget spent: fall through to the normal exhaust/retry
+		// path so a gate that never becomes runnable still terminates the
+		// workflow rather than pending forever.
+		opts.tracef("ralph check-infra-exhausted bead=%s outcome=%s infra_retry=%d attempt=%d (falling through)",
+			bead.ID, result.Outcome, infraRetries, attempt)
 	}
 
 	if result.Outcome == convergence.GatePass {

--- a/internal/dispatch/ralph_check_infra_retry_test.go
+++ b/internal/dispatch/ralph_check_infra_retry_test.go
@@ -1,0 +1,79 @@
+package dispatch
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+)
+
+// TestProcessRalphCheckInfraTimeoutDoesNotBurnAttempt is the regression for the
+// maintainer-city "zero-merge day" incident: a transport/store outage made the
+// adopt-pr gates fail to EXECUTE, and each gate-exec error consumed a ralph
+// attempt, so after 3 attempts abort_scope fired on genuinely-green PRs.
+//
+// A GateTimeout (the gate could not finish) is an infra outcome — the gate
+// never produced a verdict — and must NOT burn a gc.attempt. It re-runs via the
+// benign ErrControlPending path, bumping only the separate infra-retry counter.
+func TestProcessRalphCheckInfraTimeoutDoesNotBurnAttempt(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	// A gate that never finishes within its timeout -> GateTimeout.
+	checkPath := writeCheckScript(t, cityPath, "slow-check.sh", "#!/bin/bash\nsleep 30\n")
+	store, _, run1, check1 := newSimpleRalphLoop(t, "implement", checkPath, 3)
+	if err := store.SetMetadata(check1.ID, beadmeta.CheckTimeoutMetadataKey, "100ms"); err != nil {
+		t.Fatalf("set check timeout: %v", err)
+	}
+	if err := store.Close(run1.ID); err != nil {
+		t.Fatalf("close run1: %v", err)
+	}
+	check1 = mustGetBead(t, store, check1.ID)
+
+	_, err := ProcessControl(store, check1, ProcessOptions{CityPath: cityPath})
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl on GateTimeout = %v, want ErrControlPending (re-run without burning an attempt)", err)
+	}
+
+	got := mustGetBead(t, store, check1.ID)
+	if a := got.Metadata[beadmeta.AttemptMetadataKey]; a != "1" {
+		t.Errorf("gc.attempt = %q, want 1 (an infra gate-exec error must not burn an attempt)", a)
+	}
+	if r := got.Metadata[beadmeta.CheckInfraRetryMetadataKey]; r != "1" {
+		t.Errorf("gc.check_infra_retry = %q, want 1", r)
+	}
+	if got.Status == "closed" {
+		t.Errorf("check bead should stay open for the re-run, got closed")
+	}
+}
+
+// TestProcessRalphCheckInfraRetryBudgetExhaustionBurns pins the required bound:
+// once the infra-retry budget is spent, a gate that still cannot run falls
+// through to the normal retry/burn path so a permanently-unrunnable gate
+// terminates the workflow rather than pending forever.
+func TestProcessRalphCheckInfraRetryBudgetExhaustionBurns(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	checkPath := writeCheckScript(t, cityPath, "slow-check.sh", "#!/bin/bash\nsleep 30\n")
+	store, _, run1, check1 := newSimpleRalphLoop(t, "implement", checkPath, 3)
+	if err := store.SetMetadataBatch(check1.ID, map[string]string{
+		beadmeta.CheckTimeoutMetadataKey:    "100ms",
+		beadmeta.CheckInfraRetryMetadataKey: strconv.Itoa(maxCheckInfraRetries),
+	}); err != nil {
+		t.Fatalf("prime infra-retry budget: %v", err)
+	}
+	if err := store.Close(run1.ID); err != nil {
+		t.Fatalf("close run1: %v", err)
+	}
+	check1 = mustGetBead(t, store, check1.ID)
+
+	result, err := ProcessControl(store, check1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if !result.Processed || result.Action != "retry" {
+		t.Fatalf("result = %+v, want processed retry (attempt burned once the infra-retry budget is spent)", result)
+	}
+}


### PR DESCRIPTION
## What

A ralph check gate that returns **GateError** (the gate could not run — controller cancel, exec-boundary failure) or **GateTimeout** (the gate did not finish) never produced a verdict, yet `processRalphCheck` only special-cased `GatePass` and let every other outcome fall through to the attempt-burning retry/exhaust path.

A transport/store outage that made the adopt-pr gates fail to **execute** therefore consumed a PR's ralph attempts and `abort_scope`'d genuinely-green PRs (maintainer-city: 3 attempts burned in one outage = a zero-merge day, replayable on any future infra hiccup).

## Fix

Re-run an infra gate-exec error via the existing benign `ErrControlPending` path (no attempt increment, no close), bounded by a separate `gc.check_infra_retry` counter (`maxCheckInfraRetries=20`) so a gate that can never run still terminates the workflow via the normal exhaust path instead of pending forever. A genuine `GateFail` (the gate ran and returned fail) still burns, exactly as before.

## Notes

Ported from the split-store deploy branch (`feat/split-store-conformance`); this dispatch fix is independent of the split-store work. Regression: `internal/dispatch/ralph_check_infra_retry_test.go` (timeout-doesn't-burn + budget-exhaustion-burns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
