### PR TITLE
fix(molecule): resolve attach root through the run chain, not gc.root_bead_id alone

### DIFF
--- a/internal/molecule/attach_test.go
+++ b/internal/molecule/attach_test.go
@@ -175,6 +175,52 @@ func TestAttachToWorkflowRoot(t *testing.T) {
 	assertBlockingDep(t, store, root.ID, result.RootID)
 }
 
+// TestAttachResolvesRootFromRunChainNotOwnID is the regression for the
+// maintainer-city grafted-wisp incident (gcg-wisp-y785sz). A wisp/source bead
+// grafted mid-workflow carries the true top workflow root in its run-chain
+// metadata (workflow_id / molecule_id, written by sling) but NOT its own
+// gc.root_bead_id. The old Attach fallback checked only gc.root_bead_id and
+// then defaulted to the parent's own id, stamping the whole sub-DAG (attempt
+// container, scope-check, every child) with the WRONG root. Downstream
+// reconciliation then enumerated siblings via listByWorkflowRoot(<wrong root>),
+// found the wrong set, and burned ralph attempts until abort_scope fired on
+// green work. Attach must resolve the root through the canonical run chain
+// (beadmeta.ResolveRunID), never the parent's own id.
+func TestAttachResolvesRootFromRunChainNotOwnID(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// The true top workflow root.
+	root := setupWorkflow(t, store)
+
+	// A wisp/source bead grafted mid-workflow: it carries the true root in the
+	// run chain (workflow_id) but has no gc.root_bead_id of its own.
+	wisp, err := store.Create(beads.Bead{
+		Title: "grafted wisp",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":     "wisp",
+			"workflow_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create grafted wisp: %v", err)
+	}
+
+	recipe := makeWorkflowRecipe("sub-work", "run", "eval")
+
+	result, err := Attach(context.Background(), store, recipe, wisp.ID, AttachOptions{})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// The sub-DAG must be rooted at the TRUE workflow root from the run chain,
+	// never at the grafted wisp's own id.
+	if result.WorkflowRootID != root.ID {
+		t.Errorf("WorkflowRootID = %q, want %q (true root from run chain, not the wisp's own id %q)", result.WorkflowRootID, root.ID, wisp.ID)
+	}
+	assertAllBeadsHaveRootID(t, store, result.IDMapping, root.ID)
+}
+
 // Test 3: Blocking dep prevents premature unblock
 func TestAttachBlockingDepPreventsClose(t *testing.T) {
 	store := beads.NewMemStore()

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -238,10 +238,18 @@ func Attach(ctx context.Context, store beads.Store, recipe *formula.Recipe, atta
 		return nil, fmt.Errorf("attach bead %s: %w", attachBeadID, err)
 	}
 
-	rootBeadID := parentBead.Metadata[beadmeta.RootBeadIDMetadataKey]
-	if rootBeadID == "" {
-		rootBeadID = attachBeadID
-	}
+	// Resolve the sub-DAG's workflow root through the canonical run chain
+	// (workflow_id -> molecule_id -> gc.root_bead_id -> the parent's own id),
+	// not gc.root_bead_id alone. A wisp/source bead grafted mid-workflow carries
+	// the true top root in workflow_id/molecule_id (written by sling) but no
+	// gc.root_bead_id of its own; the old fallback ignored those keys and rooted
+	// the whole sub-DAG at the parent's own id, stamping a WRONG gc.root_bead_id
+	// onto the attempt container, scope-check, and every child. Downstream
+	// reconciliation then enumerated siblings via listByWorkflowRoot(<wrong
+	// root>) and burned ralph attempts (maintainer-city incident,
+	// gcg-wisp-y785sz). A genuine top-level head with no run chain still
+	// self-roots via its own id (ResolveRunID's selfID fallback).
+	rootBeadID := beadmeta.ResolveRunID(parentBead.Metadata, attachBeadID, "")
 	rootStoreRef := parentBead.Metadata[beadmeta.RootStoreRefMetadataKey]
 
 	// Idempotency: check for existing sub-DAG with the same key.


### PR DESCRIPTION
## What

`molecule.Attach` derived a sub-DAG's workflow root from `gc.root_bead_id` alone and silently self-defaulted to the parent's own id when it was absent. But a wisp/source bead grafted mid-workflow carries the true top root in its **run chain** (`workflow_id`/`molecule_id`, written by sling) and no `gc.root_bead_id` of its own — so the fallback stamped every attempt container, scope-check, and child with the **wrong** root. Downstream reconciliation then enumerated siblings via `listByWorkflowRoot(<wrong root>)`, found the wrong set, and burned ralph attempts until `abort_scope` fired on green work (maintainer-city incident, `gcg-wisp-y785sz`).

## Fix

Resolve the root through `beadmeta.ResolveRunID` — the one canonical resolver (already used by the worker usage-fact emitters) — which walks `workflow_id → molecule_id → gc.root_bead_id → selfID`. A genuine top-level head with no run chain still self-roots via its own id, so **no existing behavior changes**; `TestAttachToWorkflowRoot` and the retry/scope-check root pins stay green.

## Notes

Found via the split-store conformance trace but the bug is **not split-store-specific** — it mis-roots grafted sub-DAGs in any city. Regression: `TestAttachResolvesRootFromRunChainNotOwnID` (reproduces the wrong-root stamp; RED before, GREEN after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
