### PR TITLE
test(api): #2723 dashboard host-allowlist regression corpus

### DIFF
--- a/internal/api/middleware_host_test.go
+++ b/internal/api/middleware_host_test.go
@@ -1,0 +1,75 @@
+package api
+
+import "testing"
+
+// TestIsAllowedSupervisorHost pins the full Host-header allowlist corpus for
+// the DNS-rebinding defense (#2723). The attack variants are ported from the
+// adversarially reviewed dashboard host-allowlist branch (abe825284): a
+// browser tricked into resolving an attacker name to a loopback bind carries
+// the attacker's Host header, so every non-loopback, non-configured identity
+// must be rejected. Shorthand loopback spellings a browser could normalize
+// (decimal/octal/short IPs) are rejected rather than allowed — the safe
+// direction.
+func TestIsAllowedSupervisorHost(t *testing.T) {
+	cases := []struct {
+		name  string
+		host  string
+		extra []string
+		want  bool
+	}{
+		// Genuine loopback identities — always allowed.
+		{"localhost", "localhost", nil, true},
+		{"localhost with port", "localhost:8080", nil, true},
+		{"uppercase localhost", "LOCALHOST:8080", nil, true},
+		{"ipv4 loopback", "127.0.0.1", nil, true},
+		{"ipv4 loopback with port", "127.0.0.1:8080", nil, true},
+		{"ipv4 loopback empty port", "127.0.0.1:", nil, true},
+		{"ipv4 loopback range", "127.0.0.2:8080", nil, true},
+		{"ipv6 loopback", "::1", nil, true},
+		{"ipv6 loopback bracketed", "[::1]", nil, true},
+		{"ipv6 loopback with port", "[::1]:8080", nil, true},
+		{"ipv4-mapped ipv6 loopback", "[::ffff:127.0.0.1]", nil, true},
+		{"fully expanded ipv6 loopback", "0:0:0:0:0:0:0:1", nil, true},
+
+		// Attack forms — all rejected.
+		{"empty host", "", nil, false},
+		{"public host", "evil.example", nil, false},
+		{"public host with port", "evil.example:8080", nil, false},
+		{"localhost-suffix attack", "localhost.evil.example", nil, false},
+		{"private ip", "192.168.1.20:8080", nil, false},
+		{"userinfo", "evil@127.0.0.1", nil, false},
+		{"userinfo with port", "evil@127.0.0.1:8080", nil, false},
+		{"space injection", "127.0.0.1 evil.example", nil, false},
+		{"tab injection", "127.0.0.1\tevil", nil, false},
+		{"null byte injection", "localhost\x00.evil", nil, false},
+		{"percent-encoded null", "127.0.0.1%00", nil, false},
+		{"decimal ip", "2130706433", nil, false},
+		{"short ip", "127.1", nil, false},
+		{"octal ip", "0177.0.0.1", nil, false},
+		{"trailing dot localhost", "localhost.", nil, false},
+		{"trailing dot ipv4", "127.0.0.1.", nil, false},
+		{"unspecified ipv4", "0.0.0.0", nil, false},
+		{"unspecified ipv4 with port", "0.0.0.0:8080", nil, false},
+		{"bare port", ":8080", nil, false},
+		{"ipv6 zone id", "[::1%eth0]", nil, false},
+		{"hex-encoded loopback", "0x7f000001", nil, false},
+		{"ipv4-mapped ipv6 non-loopback", "[::ffff:169.254.169.254]", nil, false},
+		{"ipv4-compatible ipv6 loopback embed", "::127.0.0.1", nil, false},
+		{"homoglyph localhost", "lοcalhost", nil, false},
+
+		// Operator allowlist — hostname-only match, case-insensitive,
+		// ports ignored on both sides.
+		{"configured host", "dash.internal:8080", []string{"dash.internal"}, true},
+		{"configured host case-insensitive", "Dash.Internal:8080", []string{"dash.internal"}, true},
+		{"configured host with port in allowlist", "dash.internal:8080", []string{"dash.internal:9999"}, true},
+		{"unconfigured host rejected", "other.internal:8080", []string{"dash.internal"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAllowedSupervisorHost(tc.host, tc.extra); got != tc.want {
+				t.Fatalf("isAllowedSupervisorHost(%q, %v) = %v, want %v", tc.host, tc.extra, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/middleware_host_test.go
+++ b/internal/api/middleware_host_test.go
@@ -23,12 +23,15 @@ func TestIsAllowedSupervisorHost(t *testing.T) {
 		{"uppercase localhost", "LOCALHOST:8080", nil, true},
 		{"ipv4 loopback", "127.0.0.1", nil, true},
 		{"ipv4 loopback with port", "127.0.0.1:8080", nil, true},
-		{"ipv4 loopback empty port", "127.0.0.1:", nil, true},
 		{"ipv4 loopback range", "127.0.0.2:8080", nil, true},
 		{"ipv6 loopback", "::1", nil, true},
 		{"ipv6 loopback bracketed", "[::1]", nil, true},
 		{"ipv6 loopback with port", "[::1]:8080", nil, true},
 		{"ipv4-mapped ipv6 loopback", "[::ffff:127.0.0.1]", nil, true},
+		// The next two pin incidental parser tolerance (SplitHostPort accepts
+		// an empty port; ParseIP accepts unbracketed expanded IPv6), not
+		// contract — tightening them to rejection is an acceptable change.
+		{"ipv4 loopback empty port", "127.0.0.1:", nil, true},
 		{"fully expanded ipv6 loopback", "0:0:0:0:0:0:0:1", nil, true},
 
 		// Attack forms — all rejected.

--- a/internal/api/supervisor_security_test.go
+++ b/internal/api/supervisor_security_test.go
@@ -137,11 +137,8 @@ func TestDashboardSurfacesServedBehindHostAllowlist(t *testing.T) {
 		wantBody string
 	}{
 		{"spa loopback ipv4", "/", "127.0.0.1:8080", http.StatusOK, "spa-shell"},
-		{"spa localhost", "/", "localhost:8080", http.StatusOK, "spa-shell"},
-		{"spa ipv6 loopback", "/", "[::1]:8080", http.StatusOK, "spa-shell"},
 		{"spa deep route loopback", "/city/thriva/agents", "127.0.0.1:8080", http.StatusOK, "spa-shell"},
 		{"spa rebinding host rejected", "/", "evil.example:8080", http.StatusMisdirectedRequest, "host_not_allowed"},
-		{"spa localhost-suffix rejected", "/", "localhost.evil.example", http.StatusMisdirectedRequest, "host_not_allowed"},
 		{"plane loopback", "/api/host/cities", "127.0.0.1:8080", http.StatusOK, "api-plane"},
 		{"plane rebinding host rejected", "/api/host/cities", "evil.example:8080", http.StatusMisdirectedRequest, "host_not_allowed"},
 	}

--- a/internal/api/supervisor_security_test.go
+++ b/internal/api/supervisor_security_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -102,6 +104,127 @@ func TestSupervisorHostAllowlistAcceptsLoopbackAndConfiguredHost(t *testing.T) {
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestDashboardSurfacesServedBehindHostAllowlist is the mount-topology guard
+// for the dashboard half of #2723. The allowlist logic itself is pinned by
+// TestIsAllowedSupervisorHost; what this test protects is the wiring — the
+// embedded SPA "/" catch-all and the host-side "/api/" plane must stay INSIDE
+// the host gate that SupervisorMux.Handler() wraps around the whole mux. A
+// future refactor that mounts either surface on a separate listener or ahead
+// of withHostAllowing would reopen DNS rebinding against the dashboard and
+// fail here.
+func TestDashboardSurfacesServedBehindHostAllowlist(t *testing.T) {
+	spa := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("spa-shell"))
+	})
+	plane := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("api-plane"))
+	})
+	handler := newTestSupervisorMux(t, map[string]*fakeState{}).
+		WithStaticHandler(spa).
+		WithAPIPlane(plane).
+		Handler()
+
+	cases := []struct {
+		name     string
+		path     string
+		host     string
+		wantCode int
+		wantBody string
+	}{
+		{"spa loopback ipv4", "/", "127.0.0.1:8080", http.StatusOK, "spa-shell"},
+		{"spa localhost", "/", "localhost:8080", http.StatusOK, "spa-shell"},
+		{"spa ipv6 loopback", "/", "[::1]:8080", http.StatusOK, "spa-shell"},
+		{"spa deep route loopback", "/city/thriva/agents", "127.0.0.1:8080", http.StatusOK, "spa-shell"},
+		{"spa rebinding host rejected", "/", "evil.example:8080", http.StatusMisdirectedRequest, "host_not_allowed"},
+		{"spa localhost-suffix rejected", "/", "localhost.evil.example", http.StatusMisdirectedRequest, "host_not_allowed"},
+		{"plane loopback", "/api/host/cities", "127.0.0.1:8080", http.StatusOK, "api-plane"},
+		{"plane rebinding host rejected", "/api/host/cities", "evil.example:8080", http.StatusMisdirectedRequest, "host_not_allowed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://"+tc.host+tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantBody) {
+				t.Fatalf("body = %q, want it to contain %q", rec.Body.String(), tc.wantBody)
+			}
+			if tc.wantCode == http.StatusMisdirectedRequest && strings.Contains(rec.Body.String(), "spa-shell") {
+				t.Fatalf("body = %q, SPA content must not leak on a rejected Host", rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestSupervisorHostAllowlistRawRequestLine covers the request-line smuggling
+// cases httptest.NewRequest cannot represent, against a real net/http server
+// over raw TCP. Per RFC 9112 an absolute-form request-target overrides the
+// Host header (Go binds r.Host to the URI authority), so a loopback Host
+// header cannot be smuggled past the allowlist alongside an attacker
+// authority; duplicate Host headers are rejected by net/http with 400 before
+// the handler runs.
+func TestSupervisorHostAllowlistRawRequestLine(t *testing.T) {
+	sm := newTestSupervisorMux(t, map[string]*fakeState{})
+	srv := httptest.NewServer(sm.Handler())
+	defer srv.Close()
+
+	cases := []struct {
+		name     string
+		request  string
+		wantCode string
+	}{
+		{
+			"absolute-uri attacker authority beats loopback host header",
+			"GET http://evil.example/v0/cities HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+			"421",
+		},
+		{
+			"absolute-uri loopback authority beats attacker host header",
+			"GET http://127.0.0.1/v0/cities HTTP/1.1\r\nHost: evil.example\r\nConnection: close\r\n\r\n",
+			"200",
+		},
+		{
+			"duplicate host headers loopback first",
+			"GET /v0/cities HTTP/1.1\r\nHost: 127.0.0.1\r\nHost: evil.example\r\nConnection: close\r\n\r\n",
+			"400",
+		},
+		{
+			"duplicate host headers attacker first",
+			"GET /v0/cities HTTP/1.1\r\nHost: evil.example\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+			"400",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			defer conn.Close() //nolint:errcheck // test cleanup
+			if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				t.Fatalf("set deadline: %v", err)
+			}
+			if _, err := conn.Write([]byte(tc.request)); err != nil {
+				t.Fatalf("write request: %v", err)
+			}
+			raw, err := io.ReadAll(conn)
+			if err != nil {
+				t.Fatalf("read response: %v", err)
+			}
+			statusLine, _, _ := strings.Cut(string(raw), "\r\n")
+			if !strings.Contains(statusLine, " "+tc.wantCode+" ") {
+				t.Fatalf("status line = %q, want code %s; full response:\n%s", statusLine, tc.wantCode, raw)
 			}
 		})
 	}

--- a/internal/api/supervisor_security_test.go
+++ b/internal/api/supervisor_security_test.go
@@ -111,12 +111,15 @@ func TestSupervisorHostAllowlistAcceptsLoopbackAndConfiguredHost(t *testing.T) {
 
 // TestDashboardSurfacesServedBehindHostAllowlist is the mount-topology guard
 // for the dashboard half of #2723. The allowlist logic itself is pinned by
-// TestIsAllowedSupervisorHost; what this test protects is the wiring — the
-// embedded SPA "/" catch-all and the host-side "/api/" plane must stay INSIDE
-// the host gate that SupervisorMux.Handler() wraps around the whole mux. A
-// future refactor that mounts either surface on a separate listener or ahead
-// of withHostAllowing would reopen DNS rebinding against the dashboard and
-// fail here.
+// TestIsAllowedSupervisorHost; what this test pins is the SupervisorMux-internal
+// wiring — surfaces attached via WithStaticHandler (SPA "/" catch-all) and
+// WithAPIPlane ("/api/" plane) are served INSIDE the host gate that
+// SupervisorMux.Handler() wraps around the whole mux, so remounting either
+// ahead of withHostAllowing within the mux fails here. It exercises only
+// SupervisorMux with fake handlers and cannot see cmd/gc topology: a refactor
+// that serves the real dashboard from a separate listener would bypass this
+// guard entirely (production attach site: attachDashboard in
+// cmd/gc/supervisor_dashboard.go).
 func TestDashboardSurfacesServedBehindHostAllowlist(t *testing.T) {
 	spa := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("spa-shell"))
@@ -191,12 +194,10 @@ func TestSupervisorHostAllowlistRawRequestLine(t *testing.T) {
 			"200",
 		},
 		{
-			"duplicate host headers loopback first",
-			"GET /v0/cities HTTP/1.1\r\nHost: 127.0.0.1\r\nHost: evil.example\r\nConnection: close\r\n\r\n",
-			"400",
-		},
-		{
-			"duplicate host headers attacker first",
+			// Pins net/http stdlib behavior (400 before the handler runs),
+			// not repo code — kept as one canary so a Go release that
+			// relaxes duplicate-Host handling surfaces here.
+			"duplicate host headers rejected before handler",
 			"GET /v0/cities HTTP/1.1\r\nHost: evil.example\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
 			"400",
 		},


### PR DESCRIPTION
Ports the #2723 dashboard host-allowlist regression corpus onto the restructured main.

The Host-header allowlist implementation (`isAllowedSupervisorHost`, `internal/api/middleware.go:252`) already landed on main; this adds the regression test corpus that pins its behavior (DNS-rebinding / misdirected-Host 421 coverage).

- `test(api): port #2723 dashboard host-allowlist regression corpus` — the host + supervisor-security regression tests.
- `test(api): trim topology-test rows duplicating the unit corpus` — dedup.
- `test(api): scope mount-topology guard comment to what the test pins` — comment reword from review.

Two independent reviews approved, 0 findings (bead gc-c5zd7). Rebased clean onto current main; `go test ./internal/api/` passes.

Closes the test-coverage half of #2723.
