### PR TITLE
fix(beads): retry managed-Dolt rebind on BdStore read path (unblocks merge queue, ga-gellq1)

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1004,7 +1004,13 @@ func effectiveStorageFlags(b Bead, storage StorageClass) (ephemeral bool, noHist
 
 // Get retrieves a bead by ID via bd show.
 func (s *BdStore) Get(id string) (Bead, error) {
-	out, err := s.runner(s.dir, "bd", "show", "--json", id)
+	// Read via the transient-retry wrapper so a Get that races a managed-Dolt
+	// restart (SIGKILL + port rebind) recovers instead of surfacing a one-shot
+	// "invalid connection"/"i/o timeout" transport error. The runner performs a
+	// single recover-and-retry per call; the wrapper's outer attempts give the
+	// rebind enough total time to complete under CI load, matching every other
+	// BdStore read/write path (ga-gellq1).
+	out, err := s.runBDTransientRead("show", "--json", id)
 	if err != nil {
 		if isBdNotFound(err) {
 			return Bead{}, fmt.Errorf("getting bead %q: %w", id, ErrNotFound)
@@ -2545,7 +2551,7 @@ func (s *BdStore) DepList(id, direction string) ([]Dep, error) {
 	if direction == "up" {
 		args = append(args, "--direction=up")
 	}
-	out, err := s.runner(s.dir, "bd", args...)
+	out, err := s.runBDTransientRead(args...)
 	if err != nil {
 		// Empty dep list may return error on some bd versions.
 		if isBdNotFound(err) {
@@ -2587,7 +2593,7 @@ func (s *BdStore) DepListBatch(ids []string) (map[string][]Dep, error) {
 	}
 	args := append([]string{"dep", "list"}, ids...)
 	args = append(args, "--json")
-	out, err := s.runner(s.dir, "bd", args...)
+	out, err := s.runBDTransientRead(args...)
 	if err != nil {
 		if isBdNotFound(err) {
 			return make(map[string][]Dep), nil


### PR DESCRIPTION
## What

Routes `BdStore.Get`, `DepList`, and `DepListBatch` through the existing
`runBDTransientRead` retry wrapper instead of calling the bd runner directly.

## Why (unblocks the merge queue)

`TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind`
(`cmd/gc/cmd_bd_test.go`) has been **effectively always-red under CI load**
(box ~130), blocking all merges and jamming #4175, #4111, #4152, #4085 on the
adopt-pr CLEAN gate (shards 3/4/11). Re-runs did not clear it.

Root cause: the runner (`bdCommandRunnerWithManagedRetryErr`) performs a
**single** recover-and-retry per bd call. A managed-Dolt `SIGKILL` + port
rebind under load needs more than one recover cycle to become ready. Every
other `BdStore` read/write already wraps the runner in the 3-attempt transient
loop (`runBDTransientRead` / `runBDTransientWrite`) — but `Get`/`DepList`/
`DepListBatch` did not, so a read that raced the rebind surfaced a one-shot
`begin read tx: invalid connection` / mysql `i/o timeout` and failed.

`isBdAmbiguousWriteError` already classifies `invalid connection`,
`bad connection`, `i/o timeout`, `connection reset`, and `broken pipe` as
retryable. This is the **read-side mirror of the write-side busy/locked retry
in #4155** and is real production robustness: a managed-Dolt restart no longer
breaks the first read.

## Verification

- `go build` + `go vet ./internal/beads/` clean; `internal/beads` unit tests pass.
- `TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind` + its sibling
  `TestGcBdRigListRecoversAfterManagedHardKillPortRebind` pass **4/4 under
  ambient load ~190** (harder than the CI ~130 that made it always-red).

Fixes ga-gellq1. Same one-line fix is also on `feat/split-store-conformance`
(where the test currently lives in that lineage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)