### PR TITLE
feat(api): keyset cursors on convoys, mail, and sessions lists (P1 #4 S2)

### DIFF
--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -23817,6 +23817,21 @@
               }
             }
           },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
           "404": {
             "content": {
               "application/problem+json": {
@@ -39547,6 +39562,21 @@
                   "type": "integer"
                 }
               },
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
               }

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -23817,6 +23817,21 @@
               }
             }
           },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
           "404": {
             "content": {
               "application/problem+json": {
@@ -39547,6 +39562,21 @@
                   "type": "integer"
                 }
               },
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
               }

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -9369,6 +9369,10 @@ export type GetV0CityByCityNameConvoysData = {
 
 export type GetV0CityByCityNameConvoysErrors = {
     /**
+     * Bad Request
+     */
+    400: ErrorModel;
+    /**
      * Not Found
      */
     404: ErrorModel;
@@ -15519,6 +15523,10 @@ export type GetV0CityByCityNameSessionsData = {
 };
 
 export type GetV0CityByCityNameSessionsErrors = {
+    /**
+     * Bad Request
+     */
+    400: ErrorModel;
     /**
      * Not Found
      */

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -28187,6 +28187,7 @@ type GetV0CityByCityNameConvoysResponse struct {
 	Body                      []byte
 	HTTPResponse              *http.Response
 	JSON200                   *ListBodyBead
+	ApplicationproblemJSON400 *ErrorModel
 	ApplicationproblemJSON404 *ErrorModel
 	ApplicationproblemJSON422 *ErrorModel
 	ApplicationproblemJSON500 *ErrorModel
@@ -31112,6 +31113,7 @@ type GetV0CityByCityNameSessionsResponse struct {
 	Body                      []byte
 	HTTPResponse              *http.Response
 	JSON200                   *ListBodySessionResponse
+	ApplicationproblemJSON400 *ErrorModel
 	ApplicationproblemJSON404 *ErrorModel
 	ApplicationproblemJSON422 *ErrorModel
 	ApplicationproblemJSON500 *ErrorModel
@@ -35675,6 +35677,13 @@ func ParseGetV0CityByCityNameConvoysResponse(rsp *http.Response) (*GetV0CityByCi
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest ErrorModel
@@ -42454,6 +42463,13 @@ func ParseGetV0CityByCityNameSessionsResponse(rsp *http.Response) (*GetV0CityByC
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest ErrorModel

--- a/internal/api/handler_lists_keyset_test.go
+++ b/internal/api/handler_lists_keyset_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// S2 of the keyset-cursor track: convoys, mail, and sessions speak the same
+// contract the bead list shipped in S1 — opaque v1 tokens, typed 400 on
+// invalid cursors, one (created_at DESC, id DESC) total order, and a
+// truncated response ALWAYS carrying next_cursor (cursor-less requests
+// previously truncated silently, making the remainder unfetchable).
+
+func getList(t *testing.T, h http.Handler, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeGenericList(t *testing.T, rec *httptest.ResponseRecorder) (items []json.RawMessage, total int, next string) {
+	t.Helper()
+	var body struct {
+		Items      []json.RawMessage `json:"items"`
+		Total      int               `json:"total"`
+		NextCursor string            `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Items, body.Total, body.NextCursor
+}
+
+func itemID(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var v struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("unmarshal item id: %v", err)
+	}
+	return v.ID
+}
+
+// walkKeysetList drives a full cursor walk over a list endpoint and returns
+// how many times each row id was seen plus the page count.
+func walkKeysetList(t *testing.T, h http.Handler, base string, sep string, wantTotal int) map[string]int {
+	t.Helper()
+	seen := map[string]int{}
+	cursor := ""
+	pages := 0
+	for {
+		url := base
+		if cursor != "" {
+			url += sep + "cursor=" + cursor
+		}
+		rec := getList(t, h, url)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: status = %d; body = %s", pages, rec.Code, rec.Body.String())
+		}
+		items, total, next := decodeGenericList(t, rec)
+		if total != wantTotal {
+			t.Fatalf("page %d: total = %d, want %d (full-set meaning, constant across a walk)", pages, total, wantTotal)
+		}
+		for _, it := range items {
+			seen[itemID(t, it)]++
+		}
+		if pages++; pages > 20 {
+			t.Fatal("walk did not terminate")
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	return seen
+}
+
+func assertExactlyOnce(t *testing.T, seen map[string]int, want int) {
+	t.Helper()
+	if len(seen) != want {
+		t.Fatalf("walk saw %d distinct rows, want %d", len(seen), want)
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("row %s seen %d times, want 1", id, n)
+		}
+	}
+}
+
+// --- Convoys ---
+
+func TestConvoyListKeysetWalkNoSkipNoDup(t *testing.T) {
+	state := newFakeMutatorState(t)
+	store := state.stores["myrig"]
+	h := newTestCityHandler(t, state)
+
+	const n = 11
+	for i := 0; i < n; i++ {
+		if _, err := store.Create(beads.Bead{Title: "c", Type: "convoy"}); err != nil {
+			t.Fatalf("create convoy: %v", err)
+		}
+	}
+	seen := walkKeysetList(t, h, cityURL(state, "/convoys?limit=4"), "&", n)
+	assertExactlyOnce(t, seen, n)
+}
+
+// TestConvoyListTruncationMintsCursor pins the audit fix: a cursor-less
+// truncated response carries next_cursor instead of silently cutting.
+func TestConvoyListTruncationMintsCursor(t *testing.T) {
+	state := newFakeMutatorState(t)
+	store := state.stores["myrig"]
+	h := newTestCityHandler(t, state)
+	for i := 0; i < 5; i++ {
+		if _, err := store.Create(beads.Bead{Title: "c", Type: "convoy"}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	rec := getList(t, h, cityURL(state, "/convoys?limit=2"))
+	items, total, next := decodeGenericList(t, rec)
+	if len(items) != 2 || total != 5 {
+		t.Fatalf("items=%d total=%d, want 2/5", len(items), total)
+	}
+	if !strings.HasPrefix(next, "v1:") {
+		t.Fatalf("next_cursor = %q, want a v1 keyset token on a truncated cursor-less page", next)
+	}
+}
+
+func TestConvoyListInvalidCursorReturns400(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+	rec := getList(t, h, cityURL(state, "/convoys?cursor=NTA")) // legacy offset token
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "invalid-cursor") {
+		t.Fatalf("status = %d body = %s, want 400 invalid-cursor", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Mail ---
+
+func TestMailListKeysetWalkNoSkipNoDup(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+	h := newTestCityHandler(t, state)
+
+	const n = 9
+	for i := 0; i < n; i++ {
+		if _, err := mp.Send("alice", "worker", "s", "b"); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+	}
+	seen := walkKeysetList(t, h, cityURL(state, "/mail?limit=4"), "&", n)
+	assertExactlyOnce(t, seen, n)
+}
+
+func TestMailListTruncationMintsCursor(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+	h := newTestCityHandler(t, state)
+	for i := 0; i < 5; i++ {
+		if _, err := mp.Send("alice", "worker", "s", "b"); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+	}
+	rec := getList(t, h, cityURL(state, "/mail?limit=2"))
+	items, total, next := decodeGenericList(t, rec)
+	if len(items) != 2 || total != 5 {
+		t.Fatalf("items=%d total=%d, want 2/5", len(items), total)
+	}
+	if !strings.HasPrefix(next, "v1:") {
+		t.Fatalf("next_cursor = %q, want a v1 keyset token on a truncated cursor-less page", next)
+	}
+}
+
+func TestMailListInvalidCursorReturns400(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+	rec := getList(t, h, cityURL(state, "/mail?cursor=garbage"))
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "invalid-cursor") {
+		t.Fatalf("status = %d body = %s, want 400 invalid-cursor", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Sessions ---
+
+func TestSessionListTruncationMintsCursor(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	createTestSession(t, fs.cityBeadStore, fs.sp, "S1")
+	createTestSession(t, fs.cityBeadStore, fs.sp, "S2")
+	createTestSession(t, fs.cityBeadStore, fs.sp, "S3")
+
+	rec := getList(t, h, cityURL(fs, "/sessions?limit=2"))
+	items, total, next := decodeGenericList(t, rec)
+	if len(items) != 2 || total != 3 {
+		t.Fatalf("items=%d total=%d, want 2/3", len(items), total)
+	}
+	if !strings.HasPrefix(next, "v1:") {
+		t.Fatalf("next_cursor = %q, want a v1 keyset token on a truncated cursor-less page", next)
+	}
+	// Following it must complete the walk without skips or dups.
+	rec2 := getList(t, h, cityURL(fs, "/sessions?limit=2&cursor=")+next)
+	items2, total2, next2 := decodeGenericList(t, rec2)
+	if len(items2) != 1 || total2 != 3 || next2 != "" {
+		t.Fatalf("page2 items=%d total=%d next=%q, want 1/3/empty", len(items2), total2, next2)
+	}
+	first := map[string]bool{}
+	for _, it := range items {
+		first[itemID(t, it)] = true
+	}
+	if first[itemID(t, items2[0])] {
+		t.Fatal("page 2 repeated a page 1 row")
+	}
+}
+
+func TestSessionListInvalidCursorReturns400(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+	rec := getList(t, h, cityURL(fs, "/sessions?cursor=NTA"))
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "invalid-cursor") {
+		t.Fatalf("status = %d body = %s, want 400 invalid-cursor", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -751,28 +751,11 @@ func TestHandleSessionListPagination(t *testing.T) {
 	createTestSession(t, fs.cityBeadStore, fs.sp, "S2")
 	createTestSession(t, fs.cityBeadStore, fs.sp, "S3")
 
-	// Limit without cursor truncates but returns no next_cursor.
+	// A truncated cursor-less page carries the keyset continuation cursor —
+	// the old offset scheme silently cut here, leaving the remainder
+	// unfetchable (the #3208 defect class).
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", cityURL(fs, "/sessions?limit=2"), nil)
-	h.ServeHTTP(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("limit-only: status %d", w.Code)
-	}
-	var resp listResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	items, _ := resp.Items.([]any)
-	if len(items) != 2 {
-		t.Errorf("limit-only: got %d items, want 2", len(items))
-	}
-	if resp.NextCursor != "" {
-		t.Errorf("limit-only: got next_cursor %q, want empty (no cursor mode)", resp.NextCursor)
-	}
-
-	// Cursor mode: first page.
-	w = httptest.NewRecorder()
-	r = httptest.NewRequest("GET", cityURL(fs, "/sessions?cursor=&limit=2"), nil)
 	h.ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("page1: status %d", w.Code)
@@ -789,10 +772,10 @@ func TestHandleSessionListPagination(t *testing.T) {
 		t.Errorf("page1: total = %d, want 3", page1.Total)
 	}
 	if page1.NextCursor == "" {
-		t.Fatal("page1: expected next_cursor, got empty")
+		t.Fatal("page1: expected next_cursor on a truncated page, got empty")
 	}
 
-	// Cursor mode: second page.
+	// Follow the keyset cursor to the final page.
 	w = httptest.NewRecorder()
 	r = httptest.NewRequest("GET", cityURL(fs, "/sessions?cursor=")+page1.NextCursor+"&limit=2", nil)
 	h.ServeHTTP(w, r)
@@ -806,6 +789,9 @@ func TestHandleSessionListPagination(t *testing.T) {
 	items2, _ := page2.Items.([]any)
 	if len(items2) != 1 {
 		t.Errorf("page2: got %d items, want 1", len(items2))
+	}
+	if page2.Total != 3 {
+		t.Errorf("page2: total = %d, want 3 (full-set meaning, constant across a walk)", page2.Total)
 	}
 	if page2.NextCursor != "" {
 		t.Errorf("page2: got next_cursor %q, want empty (last page)", page2.NextCursor)

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -68,16 +68,16 @@ func (s *Server) humaHandleConvoyList(ctx context.Context, input *ConvoyListInpu
 		return nil, err
 	}
 
-	pp := pageParams{Limit: 50}
+	limit := defaultPaginationLimit
 	if input.Limit > 0 {
-		pp.Limit = input.Limit
-		if pp.Limit > maxPaginationLimit {
-			pp.Limit = maxPaginationLimit
+		limit = input.Limit
+		if limit > maxPaginationLimit {
+			limit = maxPaginationLimit
 		}
 	}
-	if input.Cursor != "" {
-		pp.Offset = decodeCursor(input.Cursor)
-		pp.IsPaging = true
+	seek, err := keysetSeek(input.Cursor)
+	if err != nil {
+		return nil, err
 	}
 
 	stores := s.state.BeadStores()
@@ -87,7 +87,10 @@ func (s *Server) humaHandleConvoyList(ctx context.Context, input *ConvoyListInpu
 	for _, rigName := range rigNames {
 		store := stores[rigName]
 		pa.attempt()
-		list, err := store.List(beads.ListQuery{Type: "convoy"})
+		// Explicit sort: with SortDefault the CachingStore returns
+		// map-iteration order, and keyset paging needs one deterministic
+		// total order (#3208 — the same fix the bead list carries).
+		list, err := store.List(beads.ListQuery{Type: "convoy", Sort: beads.SortCreatedDesc})
 		if err != nil {
 			pa.record("rig "+rigName, err)
 			continue
@@ -102,27 +105,18 @@ func (s *Server) humaHandleConvoyList(ctx context.Context, input *ConvoyListInpu
 	if convoys == nil {
 		convoys = []beads.Bead{}
 	}
+	// The cross-rig concatenation is not globally ordered; impose the one
+	// (created_at DESC, id DESC) total order keyset pages cut against.
+	beadKey := func(b beads.Bead) keysetKey { return keysetKey{CreatedAt: b.CreatedAt, ID: b.ID} }
+	sortKeysetDesc(convoys, beadKey)
 
 	index := s.latestIndex()
 	cacheAge := cacheAgeSeconds(cityStore)
-	if !pp.IsPaging {
-		total := len(convoys)
-		if pp.Limit < len(convoys) {
-			convoys = convoys[:pp.Limit]
-		}
-		return &ListOutput[beads.Bead]{
-			Index:     index,
-			CacheAgeS: cacheAge,
-			Body: ListBody[beads.Bead]{
-				Items:         convoys,
-				Total:         total,
-				Partial:       pa.partial(),
-				PartialErrors: pa.messages(),
-			},
-		}, nil
-	}
-
-	page, total, nextCursor := paginate(convoys, pp)
+	// A truncated response always carries next_cursor — cursor-less requests
+	// previously truncated silently, making the remainder unfetchable (the
+	// #3208 defect class the bead list already fixed).
+	page, total, hasMore := resolveKeysetPage(convoys, beadKey, seek, limit)
+	nextCursor := mintKeysetNextCursor(page, beadKey, hasMore)
 	if page == nil {
 		page = []beads.Bead{}
 	}

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -172,6 +172,23 @@ func allMailProvidersFailedError(partialErrs []string, storeSlow bool) error {
 	return apierr.ServiceUnavailable.Msg(detail)
 }
 
+// mailKeysetBody assembles a mail list page: one deterministic
+// (created_at DESC, id DESC) total order (within-provider store order is
+// nondeterministic), the contiguous page suffix strictly after the keyset
+// boundary, and a continuation cursor whenever the response is truncated —
+// cursor-less requests previously truncated silently, making the remainder
+// unfetchable (the #3208 defect class the bead list already fixed).
+func mailKeysetBody(msgs []mail.Message, seek *keysetKey, limit int, partial bool, partialErrs []string) MailListBody {
+	msgKey := func(m mail.Message) keysetKey { return keysetKey{CreatedAt: m.CreatedAt, ID: m.ID} }
+	sortKeysetDesc(msgs, msgKey)
+	page, total, hasMore := resolveKeysetPage(msgs, msgKey, seek, limit)
+	next := mintKeysetNextCursor(page, msgKey, hasMore)
+	if page == nil {
+		page = []mail.Message{}
+	}
+	return MailListBody{Items: page, Total: total, NextCursor: next, Partial: partial, PartialErrors: partialErrs}
+}
+
 // humaHandleMailList is the Huma-typed handler for GET /v0/mail.
 func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (*MailListOutput, error) {
 	bp := input.toBlockingParams()
@@ -184,16 +201,16 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		return nil, err
 	}
 
-	pp := pageParams{Limit: 50}
+	limit := defaultPaginationLimit
 	if input.Limit > 0 {
-		pp.Limit = input.Limit
-		if pp.Limit > maxPaginationLimit {
-			pp.Limit = maxPaginationLimit
+		limit = input.Limit
+		if limit > maxPaginationLimit {
+			limit = maxPaginationLimit
 		}
 	}
-	if input.Cursor != "" {
-		pp.Offset = decodeCursor(input.Cursor)
-		pp.IsPaging = true
+	seek, err := keysetSeek(input.Cursor)
+	if err != nil {
+		return nil, err
 	}
 
 	agents := s.resolveMailQueryRecipientsWithContext(ctx, input.Agent)
@@ -223,25 +240,10 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 				msgs = []mail.Message{}
 			}
 			msgs = tagRig(msgs, rig)
-			if !pp.IsPaging {
-				total := len(msgs)
-				if pp.Limit < len(msgs) {
-					msgs = msgs[:pp.Limit]
-				}
-				return &MailListOutput{
-					Index:     index,
-					CacheAgeS: cacheAge,
-					Body:      MailListBody{Items: msgs, Total: total},
-				}, nil
-			}
-			page, total, nextCursor := paginate(msgs, pp)
-			if page == nil {
-				page = []mail.Message{}
-			}
 			return &MailListOutput{
 				Index:     index,
 				CacheAgeS: cacheAge,
-				Body:      MailListBody{Items: page, Total: total, NextCursor: nextCursor},
+				Body:      mailKeysetBody(msgs, seek, limit, false, nil),
 			}, nil
 		}
 
@@ -266,26 +268,10 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		if allMsgs == nil {
 			allMsgs = []mail.Message{}
 		}
-		partial := len(partialErrs) > 0
-		if !pp.IsPaging {
-			total := len(allMsgs)
-			if pp.Limit < len(allMsgs) {
-				allMsgs = allMsgs[:pp.Limit]
-			}
-			return &MailListOutput{
-				Index:     index,
-				CacheAgeS: cacheAge,
-				Body:      MailListBody{Items: allMsgs, Total: total, Partial: partial, PartialErrors: partialErrs},
-			}, nil
-		}
-		page, total, nextCursor := paginate(allMsgs, pp)
-		if page == nil {
-			page = []mail.Message{}
-		}
 		return &MailListOutput{
 			Index:     index,
 			CacheAgeS: cacheAge,
-			Body:      MailListBody{Items: page, Total: total, NextCursor: nextCursor, Partial: partial, PartialErrors: partialErrs},
+			Body:      mailKeysetBody(allMsgs, seek, limit, len(partialErrs) > 0, partialErrs),
 		}, nil
 
 	case "all":
@@ -308,25 +294,10 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 				msgs = []mail.Message{}
 			}
 			msgs = tagRig(msgs, rig)
-			if !pp.IsPaging {
-				total := len(msgs)
-				if pp.Limit < len(msgs) {
-					msgs = msgs[:pp.Limit]
-				}
-				return &MailListOutput{
-					Index:     index,
-					CacheAgeS: cacheAge,
-					Body:      MailListBody{Items: msgs, Total: total},
-				}, nil
-			}
-			page, total, nextCursor := paginate(msgs, pp)
-			if page == nil {
-				page = []mail.Message{}
-			}
 			return &MailListOutput{
 				Index:     index,
 				CacheAgeS: cacheAge,
-				Body:      MailListBody{Items: page, Total: total, NextCursor: nextCursor},
+				Body:      mailKeysetBody(msgs, seek, limit, false, nil),
 			}, nil
 		}
 
@@ -351,26 +322,10 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		if allMsgs == nil {
 			allMsgs = []mail.Message{}
 		}
-		partial := len(partialErrs) > 0
-		if !pp.IsPaging {
-			total := len(allMsgs)
-			if pp.Limit < len(allMsgs) {
-				allMsgs = allMsgs[:pp.Limit]
-			}
-			return &MailListOutput{
-				Index:     index,
-				CacheAgeS: cacheAge,
-				Body:      MailListBody{Items: allMsgs, Total: total, Partial: partial, PartialErrors: partialErrs},
-			}, nil
-		}
-		page, total, nextCursor := paginate(allMsgs, pp)
-		if page == nil {
-			page = []mail.Message{}
-		}
 		return &MailListOutput{
 			Index:     index,
 			CacheAgeS: cacheAge,
-			Body:      MailListBody{Items: page, Total: total, NextCursor: nextCursor, Partial: partial, PartialErrors: partialErrs},
+			Body:      mailKeysetBody(allMsgs, seek, limit, len(partialErrs) > 0, partialErrs),
 		}, nil
 
 	default:

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -24,6 +24,13 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	if store.Store == nil {
 		return nil, apierr.ServiceUnavailable.Msg("no bead store configured")
 	}
+	// Validate the cursor before the read-model listing and per-session
+	// runtime enrichment — a garbage cursor gets its 400 without paying the
+	// full probe cost (matching the convoy and mail handlers).
+	seek, err := keysetSeek(input.Cursor)
+	if err != nil {
+		return nil, err
+	}
 	mgr := s.sessionManager(store.Store)
 	cfg := s.state.Config()
 
@@ -41,7 +48,8 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 		s.enrichSessionResponse(&items[i], sess, cfg, s.runtimeSessionResponseHandle(sess), wantPeek, false, false, 0)
 	}
 
-	// Pagination support.
+	// Pagination support. The session default page is the server cap, not the
+	// 50-row default other lists use — preserved from the offset-cursor era.
 	limit := maxPaginationLimit
 	if input.Limit > 0 {
 		limit = input.Limit
@@ -50,34 +58,26 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 		}
 	}
 
-	pp := pageParams{
-		Offset:   decodeCursor(input.Cursor),
-		Limit:    limit,
-		IsPaging: input.cursorPresent,
+	// items[i] mirrors sessions[i], and the read model returns them in the
+	// canonical (created_at DESC, id DESC) total order. The keyset boundary is
+	// compared and minted from the UNDERLYING session times (sessions[i]),
+	// never the response's RFC3339-formatted string, so sub-second precision
+	// survives the round trip — hence the index-keyed reuse of the shared
+	// helpers. Total keeps its full-match-count meaning, and a truncated
+	// response always carries next_cursor — cursor-less requests previously
+	// truncated silently, the #3208 defect class the bead list already fixed.
+	rowIdx := make([]int, len(items))
+	for i := range rowIdx {
+		rowIdx[i] = i
 	}
-
-	if !pp.IsPaging {
-		// No pagination cursor — capture the full match count BEFORE truncating
-		// so clients can tell how many items exist vs. how many fit the page.
-		total := len(items)
-		if pp.Limit < len(items) {
-			items = items[:pp.Limit]
-		}
-		return &ListOutput[sessionResponse]{
-			Index:     s.latestIndex(),
-			CacheAgeS: cacheAgeSeconds(store.Store),
-			Body: ListBody[sessionResponse]{
-				Items:         items,
-				Total:         total,
-				Partial:       len(partialErrors) > 0,
-				PartialErrors: partialErrors,
-			},
-		}, nil
+	infoKey := func(i int) keysetKey {
+		return keysetKey{CreatedAt: sessions[i].CreatedAt, ID: sessions[i].ID}
 	}
-
-	page, total, nextCursor := paginate(items, pp)
-	if page == nil {
-		page = []sessionResponse{}
+	pageIdx, total, hasMore := resolveKeysetPage(rowIdx, infoKey, seek, limit)
+	nextCursor := mintKeysetNextCursor(pageIdx, infoKey, hasMore)
+	page := make([]sessionResponse, len(pageIdx))
+	for j, i := range pageIdx {
+		page[j] = items[i]
 	}
 	return &ListOutput[sessionResponse]{
 		Index:     s.latestIndex(),

--- a/internal/api/huma_types_sessions.go
+++ b/internal/api/huma_types_sessions.go
@@ -6,30 +6,18 @@ package api
 // These types drive the OpenAPI spec for all /v0/session* endpoints.
 
 import (
-	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
 // SessionListInput is the Huma input for GET /v0/city/{cityName}/sessions.
+// Keyset cursors made the old "cursor present but empty" distinction moot: an
+// empty cursor is first-page paging, anything else must be a valid v1 token.
 type SessionListInput struct {
 	CityScope
 	PaginationParam
 	State    string `query:"state" required:"false" doc:"Filter by session state (e.g. active, closed)."`
 	Template string `query:"template" required:"false" doc:"Filter by session template (agent qualified name)."`
 	Peek     bool   `query:"peek" required:"false" doc:"Include last output preview."`
-
-	// cursorPresent is set by Resolve to distinguish "cursor absent" from
-	// "cursor present but empty" in the query string. Huma gives "" for both.
-	cursorPresent bool
-}
-
-// Resolve implements huma.Resolver to detect whether the cursor query
-// parameter was explicitly provided (even as an empty string).
-func (s *SessionListInput) Resolve(ctx huma.Context) []error {
-	// huma.Context.URL() returns the parsed URL; check raw query for cursor key.
-	u := ctx.URL()
-	s.cursorPresent = u.Query().Has("cursor")
-	return nil
 }
 
 // CityPendingInput is the Huma input for GET /v0/city/{cityName}/pending.

--- a/internal/api/keyset_page.go
+++ b/internal/api/keyset_page.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"sort"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api/apierr"
+)
+
+// Generic keyset pagination over non-bead collections (mail messages,
+// sessions, convoys). Same contract as the bead list (see beadListSeek /
+// resolveBeadListPage): opaque v1 "cb" tokens carrying the (created_at, id)
+// boundary of the last row served, a typed 400 on anything else, pages cut as
+// the contiguous suffix strictly after the boundary in the collection's
+// (created_at DESC, id DESC) total order, and Total keeping its full-set
+// meaning across a walk.
+
+// keysetKey is the (created_at, id) sort key of a paginated row.
+type keysetKey struct {
+	CreatedAt time.Time
+	ID        string
+}
+
+// keysetAfterDesc reports whether k sorts strictly after boundary b in
+// (created_at DESC, id DESC) order. The comparison mirrors
+// beads.SeekBoundary.After exactly — tie-break included — so a page boundary
+// can never skip or duplicate a row.
+func keysetAfterDesc(k, b keysetKey) bool {
+	if k.CreatedAt.Before(b.CreatedAt) {
+		return true
+	}
+	return k.CreatedAt.Equal(b.CreatedAt) && k.ID < b.ID
+}
+
+// sortKeysetDesc sorts items into the (created_at DESC, id DESC) total order —
+// the precondition for keyset paging. Collections whose sources return
+// store-default (nondeterministic) or CreatedAt-only orders get one canonical
+// order here.
+func sortKeysetDesc[T any](items []T, key func(T) keysetKey) {
+	sort.Slice(items, func(i, j int) bool {
+		ki, kj := key(items[i]), key(items[j])
+		if !ki.CreatedAt.Equal(kj.CreatedAt) {
+			return ki.CreatedAt.After(kj.CreatedAt)
+		}
+		return ki.ID > kj.ID
+	})
+}
+
+// keysetSeek parses a request cursor into a page boundary. An empty cursor is
+// first-page paging (nil boundary, no error). Any other non-empty value —
+// garbage, a legacy offset cursor, or a wrong-kind token — is a typed 400
+// rather than a silent restart at page 1, which duplicated rows under the old
+// integer-offset scheme.
+func keysetSeek(cursor string) (*keysetKey, error) {
+	if cursor == "" {
+		return nil, nil
+	}
+	c, err := decodeKeysetCursor(cursor)
+	if err != nil || c.Kind != cursorKindCreatedID {
+		return nil, apierr.InvalidCursor.Msg("cursor is not a valid pagination token; re-fetch the first page")
+	}
+	return &keysetKey{CreatedAt: c.CreatedAt, ID: c.ID}, nil
+}
+
+// resolveKeysetPage cuts the response page, Total, and has-more flag from the
+// complete result set, which must already be in (created_at DESC, id DESC)
+// order. Total is the full set's length — constant across a walk — and the
+// page is the contiguous suffix strictly after the boundary. It performs no
+// I/O.
+func resolveKeysetPage[T any](items []T, key func(T) keysetKey, seek *keysetKey, limit int) (page []T, total int, hasMore bool) {
+	total = len(items)
+	start := 0
+	if seek != nil {
+		for start < len(items) && !keysetAfterDesc(key(items[start]), *seek) {
+			start++
+		}
+	}
+	end := start + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	return items[start:end], total, end < len(items)
+}
+
+// mintKeysetNextCursor returns the continuation cursor for a truncated page:
+// the (created_at, id) boundary of the last row served. An exhausted or empty
+// page mints nothing, which the client reads as walk-complete.
+func mintKeysetNextCursor[T any](page []T, key func(T) keysetKey, hasMore bool) string {
+	if !hasMore || len(page) == 0 {
+		return ""
+	}
+	k := key(page[len(page)-1])
+	return encodeKeysetCursor(keysetCursor{
+		Kind:      cursorKindCreatedID,
+		CreatedAt: k.CreatedAt,
+		ID:        k.ID,
+	})
+}

--- a/internal/api/keyset_page_test.go
+++ b/internal/api/keyset_page_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type kpRow struct {
+	id string
+	at time.Time
+}
+
+func kpKey(r kpRow) keysetKey { return keysetKey{CreatedAt: r.at, ID: r.id} }
+
+func TestSortKeysetDescTotalOrderWithTies(t *testing.T) {
+	ts := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	rows := []kpRow{
+		{"b", ts}, {"a", ts.Add(time.Second)}, {"c", ts}, {"d", ts.Add(-time.Second)}, {"a2", ts},
+	}
+	sortKeysetDesc(rows, kpKey)
+	want := []string{"a", "c", "b", "a2", "d"} // newest first; ties by ID DESC
+	for i, w := range want {
+		if rows[i].id != w {
+			t.Fatalf("rows[%d] = %s, want %s (order: %v)", i, rows[i].id, w, rows)
+		}
+	}
+}
+
+func TestResolveKeysetPageWalkNoSkipNoDupWithTies(t *testing.T) {
+	ts := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	var rows []kpRow
+	for i := 0; i < 17; i++ {
+		rows = append(rows, kpRow{id: fmt.Sprintf("m-%02d", i), at: ts.Add(time.Duration(i%3) * time.Second)})
+	}
+	sortKeysetDesc(rows, kpKey)
+
+	seen := map[string]int{}
+	var seek *keysetKey
+	pages := 0
+	for {
+		page, total, hasMore := resolveKeysetPage(rows, kpKey, seek, 4)
+		if total != len(rows) {
+			t.Fatalf("total = %d, want %d (must keep full-set meaning)", total, len(rows))
+		}
+		for _, r := range page {
+			seen[r.id]++
+		}
+		if !hasMore {
+			break
+		}
+		tok := mintKeysetNextCursor(page, kpKey, hasMore)
+		if tok == "" {
+			t.Fatal("hasMore page minted no cursor")
+		}
+		var err error
+		seek, err = keysetSeek(tok)
+		if err != nil {
+			t.Fatalf("server-minted cursor rejected: %v", err)
+		}
+		if pages++; pages > 10 {
+			t.Fatal("walk did not terminate")
+		}
+	}
+	if len(seen) != len(rows) {
+		t.Fatalf("walk saw %d rows, want %d", len(seen), len(rows))
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("row %s seen %d times, want 1", id, n)
+		}
+	}
+}
+
+func TestKeysetSeekContract(t *testing.T) {
+	if b, err := keysetSeek(""); b != nil || err != nil {
+		t.Fatalf("empty cursor = (%v, %v), want (nil, nil)", b, err)
+	}
+	if _, err := keysetSeek("NTA"); err == nil {
+		t.Fatal("legacy offset cursor must be rejected")
+	}
+	if _, err := keysetSeek(encodeKeysetCursor(keysetCursor{Kind: cursorKindSeq, Seq: 3})); err == nil {
+		t.Fatal("seq-kind cursor must be rejected on cb collections")
+	}
+}

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -23817,6 +23817,21 @@
               }
             }
           },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
           "404": {
             "content": {
               "application/problem+json": {
@@ -39547,6 +39562,21 @@
                   "type": "integer"
                 }
               },
+              "X-GC-Request-Id": {
+                "$ref": "#/components/headers/X-GC-Request-Id"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
               "X-GC-Request-Id": {
                 "$ref": "#/components/headers/X-GC-Request-Id"
               }

--- a/internal/api/supervisor_city_routes.go
+++ b/internal/api/supervisor_city_routes.go
@@ -205,7 +205,8 @@ func (sm *SupervisorMux) registerCityRoutes() {
 	cityDelete(sm, "/mail/{id}", (*Server).humaHandleMailDelete, errorStatuses(http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound))
 
 	// Convoys.
-	cityGet(sm, "/convoys", (*Server).humaHandleConvoyList, errorStatuses(http.StatusNotFound, http.StatusServiceUnavailable))
+	// 400: invalid pagination cursor (invalid-cursor problem type).
+	cityGet(sm, "/convoys", (*Server).humaHandleConvoyList, errorStatuses(http.StatusBadRequest, http.StatusNotFound, http.StatusServiceUnavailable))
 	cityRegister(sm, huma.Operation{
 		OperationID:   "create-convoy",
 		Method:        http.MethodPost,
@@ -320,7 +321,8 @@ func (sm *SupervisorMux) registerCityRoutes() {
 		DefaultStatus: http.StatusAccepted,
 		Errors:        []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusServiceUnavailable},
 	}, (*Server).humaHandleSessionCreate)
-	cityGet(sm, "/sessions", (*Server).humaHandleSessionList, errorStatuses(http.StatusNotFound, http.StatusServiceUnavailable))
+	// 400: invalid pagination cursor (invalid-cursor problem type).
+	cityGet(sm, "/sessions", (*Server).humaHandleSessionList, errorStatuses(http.StatusBadRequest, http.StatusNotFound, http.StatusServiceUnavailable))
 	cityGet(sm, "/session/{id}", (*Server).humaHandleSessionGet, errorStatuses(http.StatusNotFound, http.StatusConflict, http.StatusServiceUnavailable))
 	cityGet(sm, "/session/{id}/transcript", (*Server).humaHandleSessionTranscript, errorStatuses(http.StatusNotFound, http.StatusConflict, http.StatusServiceUnavailable))
 	cityGet(sm, "/session/{id}/pending", (*Server).humaHandleSessionPending, errorStatuses(http.StatusNotFound, http.StatusConflict, http.StatusServiceUnavailable))

--- a/internal/session/list_all.go
+++ b/internal/session/list_all.go
@@ -89,16 +89,11 @@ func ListAllSessionBeads(store beads.Store, base beads.ListQuery) ([]beads.Bead,
 	// the union concatenates them — sort globally so mixed-shape rows
 	// interleave correctly. Unknown Sort values are left alone for
 	// forward-compat with future sort modes.
-	switch base.Sort {
-	case beads.SortCreatedAsc:
-		sort.SliceStable(out, func(i, j int) bool {
-			return out[i].CreatedAt.Before(out[j].CreatedAt)
-		})
-	case beads.SortCreatedDesc:
-		sort.SliceStable(out, func(i, j int) bool {
-			return out[i].CreatedAt.After(out[j].CreatedAt)
-		})
-	}
+	// beads.SortBeads applies the canonical (created_at, id) total order —
+	// the id tie-break keeps keyset pagination exact when rows share a
+	// timestamp (whole-second times are the norm on bd-backed stores).
+	// SortDefault and unknown Sort values are left alone, same as before.
+	beads.SortBeads(out, base.Sort)
 
 	if base.Limit > 0 && len(out) > base.Limit {
 		out = out[:base.Limit]
@@ -402,16 +397,9 @@ func (s *Store) cachedListUnion(opts ListAllOptions) ([]beads.Bead, bool) {
 	add(typeRows)
 	add(labelRows)
 
-	switch opts.Sort {
-	case beads.SortCreatedAsc:
-		sort.SliceStable(merged, func(i, j int) bool {
-			return merged[i].CreatedAt.Before(merged[j].CreatedAt)
-		})
-	case beads.SortCreatedDesc:
-		sort.SliceStable(merged, func(i, j int) bool {
-			return merged[i].CreatedAt.After(merged[j].CreatedAt)
-		})
-	}
+	// Canonical (created_at, id) total order — see the matching comment on
+	// the union sort above.
+	beads.SortBeads(merged, opts.Sort)
 
 	if opts.Limit > 0 && len(merged) > opts.Limit {
 		merged = merged[:opts.Limit]


### PR DESCRIPTION
## What

S2 of **audit P1 #4 — stable keyset cursors**: converts the three remaining core list
endpoints (`GET /convoys`, `GET /mail`, `GET /sessions`) from base64-offset cursors to
the v1 keyset tokens `GET /beads` shipped in S1 (#4157).

**Depends on #4157 (S1)** — stacked on its maintainer-fixed tip (`868cc564c`); base=main,
diff auto-cleans when S1 merges. Unlabeled until then per pipeline convention.

## The same contract, three more endpoints

- Opaque `v1:` tokens carrying the `(created_at, id)` boundary — stable under concurrent
  writes where offsets skipped/duplicated rows
- Invalid cursor → typed 400 `invalid-cursor` (routes declare it)
- One `(created_at DESC, id DESC)` total order per collection
- **A truncated response always carries `next_cursor`** — all three endpoints previously
  truncated cursor-less requests silently, leaving the remainder unfetchable (the #3208
  defect class)

New `internal/api/keyset_page.go` generalizes S1's helpers for non-bead rows;
`keysetAfterDesc` mirrors `beads.SeekBoundary.After` exactly (id tie-break + zero-time
handling — the accept-what-you-mint invariant from S1 holds here too).

## Per-endpoint notes

| endpoint | the interesting bit |
|---|---|
| convoys | had **no deterministic order at all** (`SortDefault` = CachingStore map-iteration); store query now pins `SortCreatedDesc` + handler imposes the global order |
| mail | within-provider store order was nondeterministic; all four branches (unread/all × rig/all-providers) collapse onto one `mailKeysetBody` with the merged set sorted per request — `Partial`/`PartialErrors` and total-outage error paths preserved branch-for-branch |
| sessions | `list_all.go`'s CreatedAt-only stable sorts become canonical `beads.SortBeads` (whole-second bd timestamps need the id tie-break for exact boundaries; all other consumers pass `SortDefault` where it's a no-op — blast radius verified with oracle suites). Boundaries seek/mint from the **underlying `session.Info` times** (the response's RFC3339 string loses sub-second precision) via index-keyed reuse of the shared helpers. Cursor validated before the read-model/probe pass. Dead `cursorPresent`/`Resolve` removed. Session default page stays the server cap. |

## Verification

- 8 new endpoint tests (walks with ties, truncation-mints, invalid-400) + keyset_page
  unit tests; `TestHandleSessionListPagination` rewritten to the new contract
- Full gates green: `internal/api` (245s), `internal/session`, genclient sync,
  dashboard-check
- Red-teamed pre-commit across two passes (6 lenses + adversarial verification; the
  second pass re-ran the two deepest lenses after a usage-cap interruption): **two nits
  confirmed and fixed** (cursor validation hoisted above session enrichment; sessions
  page-cut de-inlined onto the shared helpers), everything else refuted — including the
  list_all blast-radius and mail branch-parity probes, which came back clean

## Remaining in this track

S3: events (`seq` cursors + unifying the two-path window flip onto one order). S4: the
spec-walking dialect CI guard + limit schema visibility. Tracking: `ga-q1rees`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
