### PR TITLE
feat(agent-image): CLI coding-agent fleet — codex, opencode, pi, antigravity + node, all pinned

### DIFF
--- a/.github/scripts/install-antigravity-archive.sh
+++ b/.github/scripts/install-antigravity-archive.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: install-antigravity-archive.sh VERSION [--cache]
+
+Downloads a google-antigravity/antigravity-cli release tarball, verifies its
+pinned SHA-256, and installs the Antigravity CLI as `agy` (the tarball ships
+the binary as `antigravity`; upstream's installer renames it to `agy`). Use
+--cache on self-hosted runners to install under RUNNER_TOOL_CACHE/HOME and add
+that bin directory to GITHUB_PATH.
+USAGE
+}
+
+version="${1:-}"
+if [[ -z "$version" ]]; then
+  usage
+  exit 2
+fi
+shift || true
+
+use_cache=false
+while (($#)); do
+  case "$1" in
+    --cache) use_cache=true ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$(uname -s)" in
+  Darwin) os=mac ;;
+  Linux) os=linux ;;
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64|amd64) arch=x64 ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+version_no_v="${version#v}"
+tag="${version_no_v}"
+platform="${os}_${arch}"
+archive="agy_cli_${platform}.tar.gz"
+expected_sha=""
+case "${tag}:${platform}" in
+  1.1.1:linux_x64) expected_sha="2ee167841cdc9a1d7dc5a624f1f15b84ee5dbb94b85af662a7299118cb4b1586" ;;
+  1.1.1:linux_arm64) expected_sha="3fc542686c5c82d7a01e3796a8bfcda5ed849c6e70f07d4d0c93e51368952784" ;;
+  1.1.1:mac_x64) expected_sha="f04855a9d14a9f29476b2343b5f827e897b187a7adce065201fef15c5d1a70bd" ;;
+  1.1.1:mac_arm64) expected_sha="83333dd7131bebcce2dfa5f94722efce442d7b67e9ab9b240c91f100a26d4675" ;;
+esac
+
+github_release_asset_sha() {
+  local owner_repo="$1"
+  local release_tag="$2"
+  local asset="$3"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to resolve GitHub release asset checksums" >&2
+    exit 1
+  fi
+  local auth_header=()
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth_header=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused "${auth_header[@]}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${owner_repo}/releases/tags/${release_tag}" \
+    | jq -r --arg asset "$asset" '.assets[] | select(.name == $asset) | .digest // empty' \
+    | sed 's/^sha256://'
+}
+
+if [[ -z "$expected_sha" ]]; then
+  expected_sha="$(github_release_asset_sha "google-antigravity/antigravity-cli" "$tag" "$archive")"
+  if [[ -z "$expected_sha" ]]; then
+    echo "No Antigravity CLI checksum found for ${tag}/${platform}" >&2
+    exit 1
+  fi
+fi
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  fi
+}
+
+install_binary() {
+  local src="$1"
+  local dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  install -m 0755 "$src" "$dst"
+}
+
+install_binary_with_sudo_fallback() {
+  local src="$1"
+  local dst="$2"
+  local dst_dir
+  dst_dir="$(dirname "$dst")"
+  mkdir -p "$dst_dir"
+  if [[ -w "$dst_dir" ]]; then
+    install_binary "$src" "$dst"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo install -m 0755 "$src" "$dst"
+  else
+    echo "Cannot write $dst and sudo is unavailable" >&2
+    exit 1
+  fi
+}
+
+if $use_cache; then
+  cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
+  bin_dir="${cache_root}/gascity-antigravity/${tag}/${platform}/bin"
+else
+  bin_dir="${ANTIGRAVITY_INSTALL_BIN_DIR:-/usr/local/bin}"
+fi
+
+target="${bin_dir}/agy"
+if [[ -x "$target" ]]; then
+  echo "Reusing cached Antigravity CLI ${tag} at ${target}"
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused -o "${tmp}/${archive}" \
+    "https://github.com/google-antigravity/antigravity-cli/releases/download/${tag}/${archive}"
+  actual_sha="$(sha256_file "${tmp}/${archive}")"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "Antigravity CLI checksum mismatch for ${tag}/${platform}" >&2
+    echo "expected: $expected_sha" >&2
+    echo "actual:   $actual_sha" >&2
+    exit 1
+  fi
+  tar -xzf "${tmp}/${archive}" -C "$tmp"
+  src="${tmp}/antigravity"
+  if [[ ! -x "$src" ]]; then
+    echo "antigravity binary not found in ${archive}" >&2
+    exit 1
+  fi
+  if $use_cache; then
+    install_binary "$src" "$target"
+  else
+    install_binary_with_sudo_fallback "$src" "$target"
+  fi
+fi
+
+if $use_cache && [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$bin_dir" >> "$GITHUB_PATH"
+fi
+
+"$target" --version

--- a/.github/scripts/install-claude-native.sh
+++ b/.github/scripts/install-claude-native.sh
@@ -56,6 +56,10 @@ esac
 platform="${os}-${arch}"
 expected_sha=""
 case "${version}:${platform}" in
+  2.1.197:darwin-arm64) expected_sha="8cc0c4d1e4eb1dca3b0cc92ab02ee3505de764e023f8c901761c167b72041fb8" ;;
+  2.1.197:darwin-x64) expected_sha="5e8a57cc7a92377f0744fa4c79191cf93d4b26c79cb919b07a407511fed1be26" ;;
+  2.1.197:linux-arm64) expected_sha="fb48473c467c27615ac799a754f4ef0b68c363e4596cefbb59c3815d51a0cc8a" ;;
+  2.1.197:linux-x64) expected_sha="f54e69cbc89b2da61a415700af7ff52a147e862517d4f1b0eecf768448cf7f83" ;;
   2.1.123:darwin-arm64) expected_sha="44597dff0f1c11e37c1954d4ac3965909be376e5961b558345723357253bcc90" ;;
   2.1.123:darwin-x64) expected_sha="ddea227d4c2b2602d650d2c5d5c812f7680701a1504bcaff81e42c165c583ef9" ;;
   2.1.123:linux-arm64) expected_sha="825c526035d1d75ff0bc1eebf18c887f98d07ea49ea80bd312ff416fe61a39b3" ;;

--- a/.github/scripts/install-codex-archive.sh
+++ b/.github/scripts/install-codex-archive.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: install-codex-archive.sh VERSION [--cache]
+
+Downloads an openai/codex release tarball, verifies its pinned SHA-256, and
+installs the codex binary. Use --cache on self-hosted runners to install under
+RUNNER_TOOL_CACHE/HOME and add that bin directory to GITHUB_PATH.
+USAGE
+}
+
+version="${1:-}"
+if [[ -z "$version" ]]; then
+  usage
+  exit 2
+fi
+shift || true
+
+use_cache=false
+while (($#)); do
+  case "$1" in
+    --cache) use_cache=true ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux) os=linux ;;
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  arm64|aarch64) cpu=aarch64 ;;
+  x86_64|amd64) cpu=x86_64 ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+version_no_v="${version#v}"
+case "$os" in
+  linux) triple="${cpu}-unknown-linux-musl" ;;
+  darwin) triple="${cpu}-apple-darwin" ;;
+esac
+tag="rust-v${version_no_v}"
+archive="codex-${triple}.tar.gz"
+expected_sha=""
+case "${version_no_v}:${triple}" in
+  0.144.1:x86_64-unknown-linux-musl) expected_sha="84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28" ;;
+  0.144.1:aarch64-unknown-linux-musl) expected_sha="b9f8ef5f98e46ced4dbbd3756a4223e3ee299a457ff488a3305bea455da8b5b8" ;;
+  0.144.1:x86_64-apple-darwin) expected_sha="0ea72d21c794504342d5fe0d5d057b0221c0a42f4bdf4a48b95af243af2b0c0e" ;;
+  0.144.1:aarch64-apple-darwin) expected_sha="88e72ac8bd30815f7d18e62dac333dc20ce3ad1cba94be1649a1977dd9bfdbb8" ;;
+esac
+
+github_release_asset_sha() {
+  local owner_repo="$1"
+  local release_tag="$2"
+  local asset="$3"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to resolve GitHub release asset checksums" >&2
+    exit 1
+  fi
+  local auth_header=()
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth_header=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused "${auth_header[@]}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${owner_repo}/releases/tags/${release_tag}" \
+    | jq -r --arg asset "$asset" '.assets[] | select(.name == $asset) | .digest // empty' \
+    | sed 's/^sha256://'
+}
+
+if [[ -z "$expected_sha" ]]; then
+  expected_sha="$(github_release_asset_sha "openai/codex" "$tag" "$archive")"
+  if [[ -z "$expected_sha" ]]; then
+    echo "No codex checksum found for ${version_no_v}/${triple}" >&2
+    exit 1
+  fi
+fi
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  fi
+}
+
+install_binary() {
+  local src="$1"
+  local dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  install -m 0755 "$src" "$dst"
+}
+
+install_binary_with_sudo_fallback() {
+  local src="$1"
+  local dst="$2"
+  local dst_dir
+  dst_dir="$(dirname "$dst")"
+  mkdir -p "$dst_dir"
+  if [[ -w "$dst_dir" ]]; then
+    install_binary "$src" "$dst"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo install -m 0755 "$src" "$dst"
+  else
+    echo "Cannot write $dst and sudo is unavailable" >&2
+    exit 1
+  fi
+}
+
+if $use_cache; then
+  cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
+  bin_dir="${cache_root}/gascity-codex/${version_no_v}/${triple}/bin"
+else
+  bin_dir="${CODEX_INSTALL_BIN_DIR:-/usr/local/bin}"
+fi
+
+target="${bin_dir}/codex"
+if [[ -x "$target" ]]; then
+  echo "Reusing cached codex ${version_no_v} at ${target}"
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused -o "${tmp}/${archive}" \
+    "https://github.com/openai/codex/releases/download/${tag}/${archive}"
+  actual_sha="$(sha256_file "${tmp}/${archive}")"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "codex checksum mismatch for ${version_no_v}/${triple}" >&2
+    echo "expected: $expected_sha" >&2
+    echo "actual:   $actual_sha" >&2
+    exit 1
+  fi
+  tar -xzf "${tmp}/${archive}" -C "$tmp"
+  src="${tmp}/codex-${triple}"
+  if [[ ! -x "$src" ]]; then
+    echo "codex binary not found in ${archive}" >&2
+    exit 1
+  fi
+  if $use_cache; then
+    install_binary "$src" "$target"
+  else
+    install_binary_with_sudo_fallback "$src" "$target"
+  fi
+fi
+
+if $use_cache && [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$bin_dir" >> "$GITHUB_PATH"
+fi
+
+"$target" --version

--- a/.github/scripts/install-node-archive.sh
+++ b/.github/scripts/install-node-archive.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: install-node-archive.sh VERSION [--cache]
+
+Downloads an official Node.js release tarball from nodejs.org, verifies its
+pinned SHA-256 against the release SHASUMS256.txt, and installs node/npm/npx
+into the target prefix. Use --cache on self-hosted runners to install under
+RUNNER_TOOL_CACHE/HOME and add that bin directory to GITHUB_PATH.
+USAGE
+}
+
+version="${1:-}"
+if [[ -z "$version" ]]; then
+  usage
+  exit 2
+fi
+shift || true
+
+use_cache=false
+while (($#)); do
+  case "$1" in
+    --cache) use_cache=true ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux) os=linux ;;
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64|amd64) arch=x64 ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+version_no_v="${version#v}"
+platform="${os}-${arch}"
+archive="node-v${version_no_v}-${platform}.tar.gz"
+expected_sha=""
+case "${version_no_v}:${platform}" in
+  22.23.1:linux-x64) expected_sha="7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129" ;;
+  22.23.1:linux-arm64) expected_sha="543fa39e57d4c07855939459a323f4deb9a79dd1bb45e6e99458b0f2de10db8d" ;;
+  22.23.1:darwin-x64) expected_sha="b8da981b8a0b1241b70249204916da76c63573ddf5814dbd2d1e41069105cb81" ;;
+  22.23.1:darwin-arm64) expected_sha="ef28d8fab2c0e4314522d4bb1b7173270aa3937e93b92cb7de79c112ac1fa953" ;;
+esac
+
+if [[ -z "$expected_sha" ]]; then
+  shasums_url="https://nodejs.org/dist/v${version_no_v}/SHASUMS256.txt"
+  expected_sha="$(curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused "$shasums_url" \
+    | awk -v file="$archive" '$2 == file {print $1}')"
+  if [[ -z "$expected_sha" ]]; then
+    echo "No Node.js checksum found for ${version_no_v}/${platform}" >&2
+    exit 1
+  fi
+fi
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  fi
+}
+
+install_tree_with_sudo_fallback() {
+  local src_dir="$1"
+  local prefix="$2"
+  local sudo_cmd=()
+  if [[ ! -w "$prefix" ]] && [[ -d "$prefix" || ! -w "$(dirname "$prefix")" ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo_cmd=(sudo)
+    else
+      echo "Cannot write $prefix and sudo is unavailable" >&2
+      exit 1
+    fi
+  fi
+  local dir
+  for dir in bin include lib share; do
+    [[ -d "${src_dir}/${dir}" ]] || continue
+    "${sudo_cmd[@]}" mkdir -p "${prefix}/${dir}"
+    "${sudo_cmd[@]}" cp -R "${src_dir}/${dir}/." "${prefix}/${dir}/"
+  done
+}
+
+if $use_cache; then
+  cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
+  prefix="${cache_root}/gascity-node/${version_no_v}/${platform}"
+else
+  prefix="${NODE_INSTALL_PREFIX:-/usr/local}"
+fi
+
+bin_dir="${prefix}/bin"
+target="${bin_dir}/node"
+if [[ -x "$target" ]] && [[ "$("$target" --version 2>/dev/null)" == "v${version_no_v}" ]]; then
+  echo "Reusing cached Node.js ${version_no_v} at ${target}"
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused -o "${tmp}/${archive}" \
+    "https://nodejs.org/dist/v${version_no_v}/${archive}"
+  actual_sha="$(sha256_file "${tmp}/${archive}")"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "Node.js checksum mismatch for ${version_no_v}/${platform}" >&2
+    echo "expected: $expected_sha" >&2
+    echo "actual:   $actual_sha" >&2
+    exit 1
+  fi
+  tar -xzf "${tmp}/${archive}" -C "$tmp"
+  install_tree_with_sudo_fallback "${tmp}/node-v${version_no_v}-${platform}" "$prefix"
+fi
+
+if $use_cache && [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$bin_dir" >> "$GITHUB_PATH"
+fi
+
+"$target" --version

--- a/.github/scripts/install-node-archive.sh
+++ b/.github/scripts/install-node-archive.sh
@@ -116,6 +116,12 @@ install_tree_with_sudo_fallback() {
 if $use_cache; then
   cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
   prefix="${cache_root}/gascity-node/${version_no_v}/${platform}"
+  # Create the cache prefix up front, under the writable cache root, so the
+  # install writes there directly. A fresh RUNNER_TOOL_CACHE has none of the
+  # nested gascity-node/<version>/<platform> parents yet, and without this the
+  # sudo-fallback below sees a non-existent immediate parent and wrongly takes
+  # the sudo path. Mirrors install-pi-npm.sh.
+  mkdir -p "$prefix"
 else
   prefix="${NODE_INSTALL_PREFIX:-/usr/local}"
 fi
@@ -142,6 +148,12 @@ fi
 
 if [[ -n "$npm_version" ]]; then
   npm_bin="${bin_dir}/npm"
+  # npm launches through its `#!/usr/bin/env node` shim, so the freshly
+  # installed node must be first on PATH; otherwise a host node (or none) runs
+  # the npm upgrade and it fails (e.g. EBADENGINE) or uses the wrong runtime.
+  # bin_dir is appended to GITHUB_PATH below for later steps, but this process
+  # needs it on PATH now.
+  export PATH="${bin_dir}:${PATH}"
   if [[ "$("$npm_bin" --version 2>/dev/null)" == "$npm_version" ]]; then
     echo "Reusing npm ${npm_version} at ${npm_bin}"
   else
@@ -151,8 +163,12 @@ if [[ -n "$npm_version" ]]; then
     if [[ -w "${prefix}/lib/node_modules" ]]; then
       "$npm_bin" install -g "npm@${npm_version}"
     elif command -v sudo >/dev/null 2>&1; then
+      # sudo resets PATH to its secure_path, so npm's `#!/usr/bin/env node`
+      # shim would resolve node from secure_path instead of the bin_dir just
+      # prepended above. Pass an explicit PATH through env so the sudo'd npm
+      # still runs under the freshly installed node.
       sudo --preserve-env=npm_config_fund,npm_config_audit,npm_config_update_notifier \
-        "$npm_bin" install -g "npm@${npm_version}"
+        env "PATH=${bin_dir}:${PATH}" "$npm_bin" install -g "npm@${npm_version}"
     else
       echo "Cannot write ${prefix}/lib/node_modules and sudo is unavailable" >&2
       exit 1

--- a/.github/scripts/install-node-archive.sh
+++ b/.github/scripts/install-node-archive.sh
@@ -3,12 +3,16 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: install-node-archive.sh VERSION [--cache]
+Usage: install-node-archive.sh VERSION [NPM_VERSION] [--cache]
 
 Downloads an official Node.js release tarball from nodejs.org, verifies its
 pinned SHA-256 against the release SHASUMS256.txt, and installs node/npm/npx
-into the target prefix. Use --cache on self-hosted runners to install under
-RUNNER_TOOL_CACHE/HOME and add that bin directory to GITHUB_PATH.
+into the target prefix. When NPM_VERSION is given, upgrades the bundled npm
+to that exact version afterwards (npm verifies the package tarball against
+the registry's sha512 integrity digest and fails on mismatch): the tarball's
+bundled npm can lag on fixes for vulnerable transitive dependencies. Use
+--cache on self-hosted runners to install under RUNNER_TOOL_CACHE/HOME and
+add that bin directory to GITHUB_PATH.
 USAGE
 }
 
@@ -18,6 +22,12 @@ if [[ -z "$version" ]]; then
   exit 2
 fi
 shift || true
+
+npm_version=""
+if (($#)) && [[ "$1" != -* ]]; then
+  npm_version="${1#v}"
+  shift
+fi
 
 use_cache=false
 while (($#)); do
@@ -128,6 +138,33 @@ else
   fi
   tar -xzf "${tmp}/${archive}" -C "$tmp"
   install_tree_with_sudo_fallback "${tmp}/node-v${version_no_v}-${platform}" "$prefix"
+fi
+
+if [[ -n "$npm_version" ]]; then
+  npm_bin="${bin_dir}/npm"
+  if [[ "$("$npm_bin" --version 2>/dev/null)" == "$npm_version" ]]; then
+    echo "Reusing npm ${npm_version} at ${npm_bin}"
+  else
+    export npm_config_fund=false
+    export npm_config_audit=false
+    export npm_config_update_notifier=false
+    if [[ -w "${prefix}/lib/node_modules" ]]; then
+      "$npm_bin" install -g "npm@${npm_version}"
+    elif command -v sudo >/dev/null 2>&1; then
+      sudo --preserve-env=npm_config_fund,npm_config_audit,npm_config_update_notifier \
+        "$npm_bin" install -g "npm@${npm_version}"
+    else
+      echo "Cannot write ${prefix}/lib/node_modules and sudo is unavailable" >&2
+      exit 1
+    fi
+  fi
+  actual_npm="$("$npm_bin" --version)"
+  if [[ "$actual_npm" != "$npm_version" ]]; then
+    echo "npm version mismatch after upgrade" >&2
+    echo "expected: $npm_version" >&2
+    echo "actual:   $actual_npm" >&2
+    exit 1
+  fi
 fi
 
 if $use_cache && [[ -n "${GITHUB_PATH:-}" ]]; then

--- a/.github/scripts/install-opencode-archive.sh
+++ b/.github/scripts/install-opencode-archive.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: install-opencode-archive.sh VERSION [--cache]
+
+Downloads an sst/opencode release archive, verifies its pinned SHA-256, and
+installs the opencode binary. Use --cache on self-hosted runners to install
+under RUNNER_TOOL_CACHE/HOME and add that bin directory to GITHUB_PATH.
+USAGE
+}
+
+version="${1:-}"
+if [[ -z "$version" ]]; then
+  usage
+  exit 2
+fi
+shift || true
+
+use_cache=false
+while (($#)); do
+  case "$1" in
+    --cache) use_cache=true ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux) os=linux ;;
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64|amd64) arch=x64 ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+version_no_v="${version#v}"
+tag="v${version_no_v}"
+# Linux ships a gzip tarball; macOS ships a zip. Both extract a single
+# `opencode` binary.
+case "$os" in
+  linux) archive="opencode-linux-${arch}.tar.gz" ;;
+  darwin) archive="opencode-darwin-${arch}.zip" ;;
+esac
+platform="${os}-${arch}"
+expected_sha=""
+case "${tag}:${platform}" in
+  v1.17.18:linux-x64) expected_sha="e149d32ee5667c0cd5fb84d0bf8393b312e93782eeb4d74d29bbb0392de7133c" ;;
+  v1.17.18:linux-arm64) expected_sha="db9b53eae485da969a0a855bca465f9901dd84676384f724f320e3ccc5a9b107" ;;
+  v1.17.18:darwin-x64) expected_sha="cebf209aad2c0bd998fbac3f8dd1b45eef35da1af18cd698e78b111b73c5fbb0" ;;
+  v1.17.18:darwin-arm64) expected_sha="24327f89c103526c0518fc9b797767f318ab85ef3cee8636e722d6138f33aa3d" ;;
+esac
+
+github_release_asset_sha() {
+  local owner_repo="$1"
+  local release_tag="$2"
+  local asset="$3"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to resolve GitHub release asset checksums" >&2
+    exit 1
+  fi
+  local auth_header=()
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth_header=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused "${auth_header[@]}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${owner_repo}/releases/tags/${release_tag}" \
+    | jq -r --arg asset "$asset" '.assets[] | select(.name == $asset) | .digest // empty' \
+    | sed 's/^sha256://'
+}
+
+if [[ -z "$expected_sha" ]]; then
+  expected_sha="$(github_release_asset_sha "sst/opencode" "$tag" "$archive")"
+  if [[ -z "$expected_sha" ]]; then
+    echo "No opencode checksum found for ${tag}/${platform}" >&2
+    exit 1
+  fi
+fi
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  fi
+}
+
+install_binary() {
+  local src="$1"
+  local dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  install -m 0755 "$src" "$dst"
+}
+
+install_binary_with_sudo_fallback() {
+  local src="$1"
+  local dst="$2"
+  local dst_dir
+  dst_dir="$(dirname "$dst")"
+  mkdir -p "$dst_dir"
+  if [[ -w "$dst_dir" ]]; then
+    install_binary "$src" "$dst"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo install -m 0755 "$src" "$dst"
+  else
+    echo "Cannot write $dst and sudo is unavailable" >&2
+    exit 1
+  fi
+}
+
+if $use_cache; then
+  cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
+  bin_dir="${cache_root}/gascity-opencode/${tag}/${platform}/bin"
+else
+  bin_dir="${OPENCODE_INSTALL_BIN_DIR:-/usr/local/bin}"
+fi
+
+target="${bin_dir}/opencode"
+if [[ -x "$target" ]]; then
+  echo "Reusing cached opencode ${tag} at ${target}"
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused -o "${tmp}/${archive}" \
+    "https://github.com/sst/opencode/releases/download/${tag}/${archive}"
+  actual_sha="$(sha256_file "${tmp}/${archive}")"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "opencode checksum mismatch for ${tag}/${platform}" >&2
+    echo "expected: $expected_sha" >&2
+    echo "actual:   $actual_sha" >&2
+    exit 1
+  fi
+  case "$archive" in
+    *.tar.gz) tar -xzf "${tmp}/${archive}" -C "$tmp" ;;
+    *.zip) unzip -q -o "${tmp}/${archive}" -d "$tmp" ;;
+  esac
+  src="${tmp}/opencode"
+  if [[ ! -x "$src" ]]; then
+    src="$(find "$tmp" -type f -name opencode -perm -111 | head -n 1)"
+  fi
+  if [[ -z "${src:-}" || ! -x "$src" ]]; then
+    echo "opencode binary not found in ${archive}" >&2
+    exit 1
+  fi
+  if $use_cache; then
+    install_binary "$src" "$target"
+  else
+    install_binary_with_sudo_fallback "$src" "$target"
+  fi
+fi
+
+if $use_cache && [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$bin_dir" >> "$GITHUB_PATH"
+fi
+
+"$target" --version

--- a/.github/scripts/install-pi-npm.sh
+++ b/.github/scripts/install-pi-npm.sh
@@ -66,8 +66,14 @@ else
   if [[ -w "$prefix" ]] || [[ -w "$bin_dir" ]]; then
     npm install -g "$package"
   elif command -v sudo >/dev/null 2>&1; then
+    # sudo resets PATH to its secure_path, so npm's `#!/usr/bin/env node` shim
+    # would resolve node from secure_path instead of the node next to the
+    # selected npm. Resolve the intended npm and pass an explicit PATH through
+    # env so the sudo'd install runs under that same node/npm.
+    npm_bin="$(command -v npm)"
+    npm_bin_dir="$(dirname "$npm_bin")"
     sudo --preserve-env=npm_config_fund,npm_config_audit,npm_config_update_notifier \
-      npm install -g "$package"
+      env "PATH=${npm_bin_dir}:${PATH}" "$npm_bin" install -g "$package"
   else
     echo "Cannot write ${prefix} and sudo is unavailable" >&2
     exit 1

--- a/.github/scripts/install-pi-npm.sh
+++ b/.github/scripts/install-pi-npm.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: install-pi-npm.sh VERSION [--cache]
+
+Installs the pi coding agent (@earendil-works/pi-coding-agent) globally at an
+exact version via npm. npm verifies the package tarball against the registry's
+Subresource Integrity (sha512) digest and fails on mismatch, so the pinned
+version is integrity-checked at install time. Requires node/npm on PATH
+(install-node-archive.sh). Use --cache on self-hosted runners to install under
+RUNNER_TOOL_CACHE/HOME and add that bin directory to GITHUB_PATH.
+USAGE
+}
+
+version="${1:-}"
+if [[ -z "$version" ]]; then
+  usage
+  exit 2
+fi
+shift || true
+
+use_cache=false
+while (($#)); do
+  case "$1" in
+    --cache) use_cache=true ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required to install pi; run install-node-archive.sh first" >&2
+  exit 1
+fi
+
+version_no_v="${version#v}"
+package="@earendil-works/pi-coding-agent@${version_no_v}"
+
+export npm_config_fund=false
+export npm_config_audit=false
+export npm_config_update_notifier=false
+
+if $use_cache; then
+  cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
+  prefix="${cache_root}/gascity-pi/${version_no_v}"
+  mkdir -p "$prefix"
+  npm install -g --prefix "$prefix" "$package"
+  bin_dir="${prefix}/bin"
+  if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "$bin_dir" >> "$GITHUB_PATH"
+  fi
+  target="${bin_dir}/pi"
+else
+  prefix="$(npm prefix -g)"
+  bin_dir="${prefix}/bin"
+  if [[ -w "$prefix" ]] || [[ -w "$bin_dir" ]]; then
+    npm install -g "$package"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo --preserve-env=npm_config_fund,npm_config_audit,npm_config_update_notifier \
+      npm install -g "$package"
+  else
+    echo "Cannot write ${prefix} and sudo is unavailable" >&2
+    exit 1
+  fi
+  target="${bin_dir}/pi"
+fi
+
+if [[ ! -x "$target" ]] && command -v pi >/dev/null 2>&1; then
+  target="$(command -v pi)"
+fi
+
+"$target" --version

--- a/.github/scripts/smoke-install-node-cache.sh
+++ b/.github/scripts/smoke-install-node-cache.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Smoke test for install-node-archive.sh --cache against an empty
+# RUNNER_TOOL_CACHE. Regression guard for the cache-mode contract: a fresh cache
+# prefix must not trip the sudo fallback, and the npm upgrade must run under the
+# freshly installed node rather than whatever node is on the caller's PATH.
+set -euo pipefail
+
+node_version="${1:-}"
+npm_version="${2:-}"
+if [[ -z "$node_version" || -z "$npm_version" ]]; then
+  echo "Usage: smoke-install-node-cache.sh NODE_VERSION NPM_VERSION" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+installer="${script_dir}/install-node-archive.sh"
+
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux) os=linux ;;
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+case "$(uname -m)" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64|amd64) arch=x64 ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+node_version_no_v="${node_version#v}"
+platform="${os}-${arch}"
+
+workdir="$(mktemp -d)"
+cache_dir="$(mktemp -d)"
+github_path="$(mktemp)"
+trap 'rm -rf "$workdir" "$cache_dir" "$github_path"' EXIT
+
+# Decoy node placed first on the caller's PATH. If the installer resolves npm's
+# `#!/usr/bin/env node` shim to this host node instead of the node it just
+# installed, the decoy aborts and this smoke test fails — which is exactly the
+# regression this test guards. It makes the check independent of whatever node
+# the CI runner happens to preinstall.
+decoy_bin="${workdir}/decoy-bin"
+mkdir -p "$decoy_bin"
+cat >"${decoy_bin}/node" <<'DECOY'
+#!/usr/bin/env bash
+echo "smoke failure: npm ran under the host (decoy) node, not the installed node" >&2
+exit 97
+DECOY
+chmod +x "${decoy_bin}/node"
+
+echo "Running install-node-archive.sh ${node_version} ${npm_version} --cache against a fresh RUNNER_TOOL_CACHE"
+PATH="${decoy_bin}:${PATH}" \
+  RUNNER_TOOL_CACHE="$cache_dir" \
+  GITHUB_PATH="$github_path" \
+  "$installer" "$node_version" "$npm_version" --cache
+
+prefix="${cache_dir}/gascity-node/${node_version_no_v}/${platform}"
+node_bin="${prefix}/bin/node"
+npm_bin="${prefix}/bin/npm"
+
+if [[ ! -x "$node_bin" ]]; then
+  echo "smoke failure: node not installed at ${node_bin}" >&2
+  exit 1
+fi
+
+actual_node="$("$node_bin" --version)"
+if [[ "$actual_node" != "v${node_version_no_v}" ]]; then
+  echo "smoke failure: node ${actual_node} != v${node_version_no_v}" >&2
+  exit 1
+fi
+
+# Invoke npm through the installed node explicitly so the assertion does not
+# depend on the caller's PATH resolution.
+actual_npm="$("$node_bin" "$npm_bin" --version)"
+if [[ "$actual_npm" != "$npm_version" ]]; then
+  echo "smoke failure: npm ${actual_npm} != ${npm_version}" >&2
+  exit 1
+fi
+
+if ! grep -qxF "${prefix}/bin" "$github_path"; then
+  echo "smoke failure: ${prefix}/bin not appended to GITHUB_PATH" >&2
+  exit 1
+fi
+
+echo "OK: cached node ${actual_node} and npm ${actual_npm} installed without a host node"

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -11,6 +11,7 @@ on:
       - ".github/requirements/mcp-agent-mail.overrides.txt"
       - ".github/requirements/mcp-agent-mail.txt"
       - ".github/scripts/install-*.sh"
+      - ".github/scripts/smoke-*.sh"
       - ".github/workflows/container-scan.yml"
       - "contrib/beads-scripts/gc-beads-br"
       - "contrib/events-scripts/gc-events-k8s"
@@ -35,6 +36,7 @@ on:
       - ".github/requirements/mcp-agent-mail.overrides.txt"
       - ".github/requirements/mcp-agent-mail.txt"
       - ".github/scripts/install-*.sh"
+      - ".github/scripts/smoke-*.sh"
       - ".github/workflows/container-scan.yml"
       - "contrib/beads-scripts/gc-beads-br"
       - "contrib/events-scripts/gc-events-k8s"
@@ -138,6 +140,25 @@ jobs:
             --exit-code 1 \
             --format table \
             contrib/k8s
+
+  node-cache-smoke:
+    name: Node cache-mode smoke
+    needs: runner-policy
+    runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: install-node-archive.sh --cache smoke
+        run: |
+          set -euo pipefail
+          . ./deps.env
+          .github/scripts/smoke-install-node-cache.sh "$NODE_VERSION" "$NPM_VERSION"
 
   image-vulnerabilities:
     name: Image vulnerabilities

--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -53,10 +53,13 @@ RUN /tmp/install-dolt-archive.sh "${DOLT_VERSION}" \
     && rm -f /tmp/install-dolt-archive.sh
 
 # Node.js — required by the pi coding agent (npm global install). Pinned
-# version (keep in sync with deps.env), installed into /usr/local.
+# version (keep in sync with deps.env), installed into /usr/local. npm is
+# upgraded past the tarball-bundled copy: the bundled npm ships vulnerable
+# transitive deps (picomatch, sigstore) that newer npm releases have fixed.
 ARG NODE_VERSION=22.23.1
+ARG NPM_VERSION=12.0.1
 COPY .github/scripts/install-node-archive.sh /tmp/install-node-archive.sh
-RUN /tmp/install-node-archive.sh "${NODE_VERSION}" \
+RUN /tmp/install-node-archive.sh "${NODE_VERSION}" "${NPM_VERSION}" \
     && rm -f /tmp/install-node-archive.sh
 
 # Codex CLI — openai/codex release binary, pinned + SHA-256 verified.

--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -1,8 +1,9 @@
 # Gas City agent base image — system dependencies.
 #
 # Contains everything an agent needs EXCEPT gc/bd/br binaries: OS packages,
-# Claude Code CLI, Dolt. Rebuild only when system dependencies change
-# (~2.5 min). Agent image rebuilds on top take ~5s.
+# the agent CLI fleet (Claude Code, Codex, opencode, pi, Antigravity), Node,
+# and Dolt. Rebuild only when system dependencies change (~2.5 min). Agent
+# image rebuilds on top take ~5s.
 #
 # Build:
 #   make docker-base
@@ -11,7 +12,7 @@
 FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG CLAUDE_CODE_VERSION=2.1.123
+ARG CLAUDE_CODE_VERSION=2.1.197
 ARG DOLT_VERSION=2.1.7
 
 # System packages.
@@ -51,6 +52,39 @@ COPY .github/scripts/install-dolt-archive.sh /tmp/install-dolt-archive.sh
 RUN /tmp/install-dolt-archive.sh "${DOLT_VERSION}" \
     && rm -f /tmp/install-dolt-archive.sh
 
+# Node.js — required by the pi coding agent (npm global install). Pinned
+# version (keep in sync with deps.env), installed into /usr/local.
+ARG NODE_VERSION=22.23.1
+COPY .github/scripts/install-node-archive.sh /tmp/install-node-archive.sh
+RUN /tmp/install-node-archive.sh "${NODE_VERSION}" \
+    && rm -f /tmp/install-node-archive.sh
+
+# Codex CLI — openai/codex release binary, pinned + SHA-256 verified.
+ARG CODEX_VERSION=0.144.1
+COPY .github/scripts/install-codex-archive.sh /tmp/install-codex-archive.sh
+RUN /tmp/install-codex-archive.sh "${CODEX_VERSION}" \
+    && rm -f /tmp/install-codex-archive.sh
+
+# opencode CLI — sst/opencode release binary, pinned + SHA-256 verified.
+ARG OPENCODE_VERSION=1.17.18
+COPY .github/scripts/install-opencode-archive.sh /tmp/install-opencode-archive.sh
+RUN /tmp/install-opencode-archive.sh "${OPENCODE_VERSION}" \
+    && rm -f /tmp/install-opencode-archive.sh
+
+# pi coding agent — @earendil-works/pi-coding-agent, exact version via npm
+# (integrity-verified by npm). Requires Node from the step above.
+ARG PI_VERSION=0.80.6
+COPY .github/scripts/install-pi-npm.sh /tmp/install-pi-npm.sh
+RUN /tmp/install-pi-npm.sh "${PI_VERSION}" \
+    && rm -f /tmp/install-pi-npm.sh
+
+# Antigravity CLI (agy) — google-antigravity/antigravity-cli release tarball,
+# pinned + SHA-256 verified.
+ARG ANTIGRAVITY_VERSION=1.1.1
+COPY .github/scripts/install-antigravity-archive.sh /tmp/install-antigravity-archive.sh
+RUN /tmp/install-antigravity-archive.sh "${ANTIGRAVITY_VERSION}" \
+    && rm -f /tmp/install-antigravity-archive.sh
+
 # Default non-root user for Claude Code (--dangerously-skip-permissions rejects root).
 # When LINUX_USERNAME is set at runtime, the pod entrypoint creates a dynamic
 # user via useradd and drops privileges via su. gcagent is kept as fallback.
@@ -60,3 +94,13 @@ RUN useradd -m -s /bin/bash gcagent \
 ENV HOME=/home/gcagent
 
 USER gcagent
+
+# Smoke test: every bundled agent CLI must run for the non-root runtime user.
+# The build fails fast if any binary is missing from PATH or otherwise broken.
+RUN set -eux; \
+    node --version; \
+    claude --version; \
+    codex --version; \
+    opencode --version; \
+    pi --version; \
+    agy --version

--- a/deps.env
+++ b/deps.env
@@ -9,6 +9,15 @@ BD_REPO=gastownhall/beads
 BD_VERSION=v1.1.0
 BR_VERSION=0.1.20
 
+# Agent CLI fleet baked into contrib/k8s/Dockerfile.base. Keep these in sync
+# with the Dockerfile ARG defaults; the install-*.sh scripts pin per-arch
+# SHA-256 checksums for each version (with an upstream fallback for bumps).
+NODE_VERSION=22.23.1
+CODEX_VERSION=0.144.1
+OPENCODE_VERSION=1.17.18
+PI_VERSION=0.80.6
+ANTIGRAVITY_VERSION=1.1.1
+
 # Cross-version contract-test matrix pins.
 # See engdocs/design/beads-gascity-contract-test-system.md.
 # BD_PREV_VERSION is the minimum-supported bd: a published release whose tarball

--- a/deps.env
+++ b/deps.env
@@ -12,7 +12,10 @@ BR_VERSION=0.1.20
 # Agent CLI fleet baked into contrib/k8s/Dockerfile.base. Keep these in sync
 # with the Dockerfile ARG defaults; the install-*.sh scripts pin per-arch
 # SHA-256 checksums for each version (with an upstream fallback for bumps).
+# NPM_VERSION replaces the npm bundled in the Node tarball, which ships
+# vulnerable transitive deps (picomatch, sigstore) fixed in newer npm.
 NODE_VERSION=22.23.1
+NPM_VERSION=12.0.1
 CODEX_VERSION=0.144.1
 OPENCODE_VERSION=1.17.18
 PI_VERSION=0.80.6

--- a/renovate.json
+++ b/renovate.json
@@ -176,6 +176,18 @@
         "/^contrib/k8s/Dockerfile\\.base$/"
       ],
       "matchStrings": [
+        "NPM_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "npm"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "/^deps\\.env$/",
+        "/^contrib/k8s/Dockerfile\\.base$/"
+      ],
+      "matchStrings": [
         "CODEX_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-releases",

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,11 @@
     {
       "matchManagers": ["custom.regex"],
       "groupName": "pinned build tools"
+    },
+    {
+      "matchDatasources": ["node-version"],
+      "matchPackageNames": ["node"],
+      "allowedVersions": "<23"
     }
   ],
   "customManagers": [
@@ -151,6 +156,68 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "Dicklesworthstone/beads_rust",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "/^deps\\.env$/",
+        "/^contrib/k8s/Dockerfile\\.base$/"
+      ],
+      "matchStrings": [
+        "NODE_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "node-version",
+      "depNameTemplate": "node"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "/^deps\\.env$/",
+        "/^contrib/k8s/Dockerfile\\.base$/"
+      ],
+      "matchStrings": [
+        "CODEX_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "openai/codex",
+      "extractVersionTemplate": "^rust-v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "/^deps\\.env$/",
+        "/^contrib/k8s/Dockerfile\\.base$/"
+      ],
+      "matchStrings": [
+        "OPENCODE_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "sst/opencode",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "/^deps\\.env$/",
+        "/^contrib/k8s/Dockerfile\\.base$/"
+      ],
+      "matchStrings": [
+        "PI_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@earendil-works/pi-coding-agent"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "/^deps\\.env$/",
+        "/^contrib/k8s/Dockerfile\\.base$/"
+      ],
+      "matchStrings": [
+        "ANTIGRAVITY_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "google-antigravity/antigravity-cli"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## What

Extends the k8s agent base image beyond Claude Code with four more CLI coding agents — every install **version-pinned and checksum-verified** (mirroring the `install-claude-native.sh` pattern; no `curl|bash`, no `:latest`):

| Tool | Version | Source |
|---|---|---|
| Claude Code | 2.1.123 → **2.1.197** (npm `stable` channel) | native manifest, per-arch SHA-256 (2.1.123 pins kept for existing consumers) |
| Codex CLI | **0.144.1** | `openai/codex` `rust-v` release, musl static |
| opencode | **1.17.18** | `sst/opencode` release |
| pi | **0.80.6** | npm `@earendil-works/pi-coding-agent`, exact-version |
| Antigravity (`agy`) | **1.1.1** | `google-antigravity/antigravity-cli` versioned tarball (binary installed as `agy`, matching the upstream installer) |
| Node.js | **22.23.1** LTS | nodejs.org dist + SHASUMS256 (required by pi) |

Release-artifact SHAs were computed from downloaded artifacts and cross-checked against GitHub's published digests.

## Update pipeline

- `deps.env` records every pin; `renovate.json` gains a customManager per pin (npm / github-releases / node-version, node held `<23`) so bumps arrive as PRs.
- A final Dockerfile `RUN` smoke-tests every CLI (`--version`) **as the `gcagent` runtime user** — the build fails fast on a broken binary, and container-scan CI already rebuilds the base on `Dockerfile.base`/`install-*`/`deps.env` changes, so the smoke runs on every bump PR.

## Verification

Local `docker build` of base + agent layers passes; all six `--version` checks pass in-image (build-time RUN + standalone `docker run`); `renovate-config-validator` clean; shellcheck clean on all install scripts; Trivy Dockerfile gate 0 findings. Adversarially reviewed pre-PR (supply-chain, Renovate-regex matching against the real files, image-integrity dimensions; all raised findings refuted on verification, including independent re-download + checksum re-verification of pinned artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)