### PR TITLE
fix(beads): reconnect+retry NativeDoltStore reads across a managed-Dolt rebind

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -368,7 +368,7 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 			// scan / Get recovers a managed-Dolt hard-kill/rebind instead of
 			// dialing the dead port for the whole retry budget.
 			reopen := func(ctx context.Context) (beads.NativeStorage, error) {
-				freshEnv, rerr := nativeDoltOpenEnvForScope(cs.cityPath, cfg, scopeRoot)
+				freshEnv, rerr := nativeDoltOpenEnvForScopeContext(ctx, cs.cityPath, cfg, scopeRoot)
 				if rerr != nil {
 					return nil, fmt.Errorf("re-resolve native rig store env %s: %w", scopeRoot, rerr)
 				}

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -362,7 +362,19 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 			if err != nil {
 				return nil, fmt.Errorf("project native rig store env %s: %w", scopeRoot, err)
 			}
-			return beads.OpenNativeDoltStoreAt(context.Background(), scopeRoot, env)
+			// Reopen hook for the native read-path reconnect (see the matching
+			// comment in main.go openStoreResultAtForCity): re-resolve the CURRENT
+			// managed Dolt env on every reconnect so the controller's reconcile
+			// scan / Get recovers a managed-Dolt hard-kill/rebind instead of
+			// dialing the dead port for the whole retry budget.
+			reopen := func(ctx context.Context) (beads.NativeStorage, error) {
+				freshEnv, rerr := nativeDoltOpenEnvForScope(cs.cityPath, cfg, scopeRoot)
+				if rerr != nil {
+					return nil, fmt.Errorf("re-resolve native rig store env %s: %w", scopeRoot, rerr)
+				}
+				return beads.OpenNativeStorage(ctx, scopeRoot, freshEnv)
+			}
+			return beads.OpenNativeDoltStoreAt(context.Background(), scopeRoot, env, beads.WithNativeReopen(reopen))
 		},
 	})
 	if err != nil {

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -916,6 +917,13 @@ func currentPublishedOrRecoveredManagedDoltPort(cityPath string, allowRecovery b
 }
 
 func resolvedRuntimeCityDoltTarget(cityPath string, allowRecovery bool) (contract.DoltConnectionTarget, bool, error) {
+	return resolvedRuntimeCityDoltTargetContext(context.Background(), cityPath, allowRecovery)
+}
+
+func resolvedRuntimeCityDoltTargetContext(ctx context.Context, cityPath string, allowRecovery bool) (contract.DoltConnectionTarget, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return contract.DoltConnectionTarget{}, false, err
+	}
 	var managedRuntimeErr error
 	var recoveryErr error
 	recoveryChecked := false
@@ -962,11 +970,13 @@ func resolvedRuntimeCityDoltTarget(cityPath string, allowRecovery bool) (contrac
 		return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
 	}
 	if allowRecovery {
-		if err := healthBeadsProvider(cityPath); err == nil {
+		if err := healthBeadsProviderContext(ctx, cityPath, false); err == nil {
 			resetRecoveryCache()
 			if port := recoveredManagedDoltPort(); port != "" {
 				return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
 			}
+		} else if ctxErr := ctx.Err(); ctxErr != nil {
+			return contract.DoltConnectionTarget{}, false, ctxErr
 		}
 	}
 	// Last-resort: when all other recovery paths have been exhausted but the
@@ -1139,7 +1149,11 @@ func bdCommandRunnerWithManagedRetryErr(cityPath string, envFn func(dir string) 
 }
 
 func applyResolvedCityDoltEnv(env map[string]string, cityPath string, allowRecovery bool) error {
-	target, ok, err := resolvedRuntimeCityDoltTarget(cityPath, allowRecovery)
+	return applyResolvedCityDoltEnvContext(context.Background(), env, cityPath, allowRecovery)
+}
+
+func applyResolvedCityDoltEnvContext(ctx context.Context, env map[string]string, cityPath string, allowRecovery bool) error {
+	target, ok, err := resolvedRuntimeCityDoltTargetContext(ctx, cityPath, allowRecovery)
 	if err != nil {
 		return err
 	}
@@ -1192,19 +1206,23 @@ func rigAllowsResolvedCityTargetFallback(cityPath, rigPath string) bool {
 }
 
 func applyResolvedRigDoltEnv(env map[string]string, cityPath, rigPath string, explicitRig *config.Rig, allowRecovery bool) error {
+	return applyResolvedRigDoltEnvContext(context.Background(), env, cityPath, rigPath, explicitRig, allowRecovery)
+}
+
+func applyResolvedRigDoltEnvContext(ctx context.Context, env map[string]string, cityPath, rigPath string, explicitRig *config.Rig, allowRecovery bool) error {
 	if usedCanonical, err := applyCanonicalScopeBackendEnv(env, cityPath, rigPath); err != nil {
 		var invalid *contract.InvalidCanonicalConfigError
 		if errors.As(err, &invalid) {
 			fallback, fallbackErr := contract.AllowsInvalidInheritedCityFallback(fsys.OSFS{}, cityPath, rigPath)
 			if fallbackErr == nil && fallback {
-				return applyResolvedCityDoltEnv(env, cityPath, allowRecovery)
+				return applyResolvedCityDoltEnvContext(ctx, env, cityPath, allowRecovery)
 			}
 		}
 		if rigAllowsResolvedCityTargetFallback(cityPath, rigPath) {
-			return applyResolvedCityDoltEnv(env, cityPath, allowRecovery)
+			return applyResolvedCityDoltEnvContext(ctx, env, cityPath, allowRecovery)
 		}
 		if allowRecovery && contract.IsManagedRuntimeUnavailable(err) && rigAllowsManagedCityRuntimeRecovery(cityPath, rigPath) {
-			return applyResolvedCityDoltEnv(env, cityPath, true)
+			return applyResolvedCityDoltEnvContext(ctx, env, cityPath, true)
 		}
 		return err
 	} else if usedCanonical {
@@ -1220,7 +1238,7 @@ func applyResolvedRigDoltEnv(env map[string]string, cityPath, rigPath string, ex
 	}
 	// Rigs without local endpoint authority inherit the resolved city target.
 	// A minimal local .beads/config.yaml must not suppress valid city compat fallback.
-	return applyResolvedCityDoltEnv(env, cityPath, allowRecovery)
+	return applyResolvedCityDoltEnvContext(ctx, env, cityPath, allowRecovery)
 }
 
 // applyLegacyRigExternalTarget projects a legacy config.Rig{DoltHost,DoltPort}
@@ -1278,7 +1296,11 @@ func bdRuntimeEnvForRigWithErrorNoRecovery(cityPath string, cfg *config.City, ri
 }
 
 func bdRuntimeEnvForRigWithErrorRecovery(cityPath string, cfg *config.City, rigPath string, allowRecovery bool) (map[string]string, error) {
-	env, cityErr := bdRuntimeEnvWithErrorRecovery(cityPath, allowRecovery)
+	return bdRuntimeEnvForRigWithErrorRecoveryContext(context.Background(), cityPath, cfg, rigPath, allowRecovery)
+}
+
+func bdRuntimeEnvForRigWithErrorRecoveryContext(ctx context.Context, cityPath string, cfg *config.City, rigPath string, allowRecovery bool) (map[string]string, error) {
+	env, cityErr := bdRuntimeEnvWithErrorRecoveryContext(ctx, cityPath, allowRecovery)
 	rigPath = filepath.Clean(rigPath)
 	// Pin the rig store explicitly. The gc-beads-bd provider derives its Dolt
 	// data root from GC_CITY_PATH unless BEADS_DIR is set, so cwd-based
@@ -1302,7 +1324,7 @@ func bdRuntimeEnvForRigWithErrorRecovery(cityPath string, cfg *config.City, rigP
 		mirrorBeadsDoltEnv(env)
 		return env, nil
 	}
-	if err := applyResolvedRigDoltEnv(env, cityPath, rigPath, explicitRig, allowRecovery); err != nil {
+	if err := applyResolvedRigDoltEnvContext(ctx, env, cityPath, rigPath, explicitRig, allowRecovery); err != nil {
 		clearProjectedDoltEnv(env)
 		clearProjectedPostgresEnv(env)
 		mirrorBeadsDoltEnv(env)
@@ -1318,9 +1340,13 @@ func bdRuntimeEnvForRigWithErrorRecovery(cityPath string, cfg *config.City, rigP
 }
 
 func nativeDoltOpenEnvForScope(cityPath string, cfg *config.City, scopeRoot string) (map[string]string, error) {
+	return nativeDoltOpenEnvForScopeContext(context.Background(), cityPath, cfg, scopeRoot)
+}
+
+func nativeDoltOpenEnvForScopeContext(ctx context.Context, cityPath string, cfg *config.City, scopeRoot string) (map[string]string, error) {
 	scopeRoot = resolveStoreScopeRoot(cityPath, scopeRoot)
 	if samePath(scopeRoot, cityPath) {
-		return bdRuntimeEnvWithError(cityPath)
+		return bdRuntimeEnvWithErrorRecoveryContext(ctx, cityPath, true)
 	}
 	if cfg == nil {
 		loaded, err := loadCityConfig(cityPath, io.Discard)
@@ -1329,7 +1355,7 @@ func nativeDoltOpenEnvForScope(cityPath string, cfg *config.City, scopeRoot stri
 		}
 		cfg = loaded
 	}
-	return bdRuntimeEnvForRigWithError(cityPath, cfg, scopeRoot)
+	return bdRuntimeEnvForRigWithErrorRecoveryContext(ctx, cityPath, cfg, scopeRoot, true)
 }
 
 func bdRuntimeEnvWithError(cityPath string) (map[string]string, error) {
@@ -1350,6 +1376,10 @@ func bdRuntimeEnvWithErrorNoRecovery(cityPath string) (map[string]string, error)
 }
 
 func bdRuntimeEnvWithErrorRecovery(cityPath string, allowRecovery bool) (map[string]string, error) {
+	return bdRuntimeEnvWithErrorRecoveryContext(context.Background(), cityPath, allowRecovery)
+}
+
+func bdRuntimeEnvWithErrorRecoveryContext(ctx context.Context, cityPath string, allowRecovery bool) (map[string]string, error) {
 	env := cityRuntimeEnvMapForCity(cityPath)
 	env["BEADS_DIR"] = filepath.Join(cityPath, ".beads")
 	env["GC_RIG"] = ""
@@ -1402,7 +1432,7 @@ func bdRuntimeEnvWithErrorRecovery(cityPath string, allowRecovery bool) (map[str
 	} else if usedPostgres {
 		return env, nil
 	}
-	if err := applyResolvedCityDoltEnv(env, cityPath, allowRecovery); err != nil {
+	if err := applyResolvedCityDoltEnvContext(ctx, env, cityPath, allowRecovery); err != nil {
 		clearProjectedDoltEnv(env)
 		mirrorBeadsDoltEnv(env)
 		if isRecoverableManagedDoltEnvError(err) {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -4451,6 +4453,48 @@ dolt.auto-start: false
 	if got, ok := env["BEADS_DOLT_SERVER_TLS"]; !ok || got != "1" {
 		t.Fatalf("BEADS_DOLT_SERVER_TLS = %q (present=%v), want %q: ambient hosted-gateway TLS must be carried to a legacy external rig native-open env", got, ok, "1")
 	}
+}
+
+func TestNativeDoltOpenEnvForScopeContextCancelsManagedRecovery(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "")
+	cityPath := t.TempDir()
+	writeManagedBdCityFixture(t, cityPath)
+
+	childPIDFile := filepath.Join(cityPath, "provider.pid")
+	script := gcBeadsBdScriptPath(cityPath)
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `#!/bin/sh
+echo $$ > "$GC_TEST_CHILD_PID"
+while :; do sleep 1; done
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_TEST_CHILD_PID", childPIDFile)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := nativeDoltOpenEnvForScopeContext(ctx, cityPath, nil, cityPath)
+		resultCh <- err
+	}()
+
+	pid := waitForProviderTestChildPID(t, childPIDFile)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("native env recovery error = %v, want context canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("native env recovery did not return after parent cancellation")
+	}
+	waitForProviderTestPIDExit(t, pid, "native env recovery")
 }
 
 // TestBdRuntimeEnvForRig_ExplicitLocalExternalRigClearsAmbientTLS is the

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1050,6 +1050,17 @@ func initFileStoreForDir(cityPath, dir string) error {
 // Acquires a per-city semaphore to prevent concurrent health/recovery
 // operations from causing a thundering herd when dolt bounces.
 func healthBeadsProvider(cityPath string) error {
+	return healthBeadsProviderContext(context.Background(), cityPath, true)
+}
+
+// healthBeadsProviderContext is healthBeadsProvider with a caller-owned
+// deadline. Native read reconnects skip the all-scope readiness barrier: their
+// immediately following OpenNativeStorage call is the scoped readiness check
+// and already shares this context.
+func healthBeadsProviderContext(ctx context.Context, cityPath string, waitForScopes bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
 		return nil
 	}
@@ -1058,7 +1069,7 @@ func healthBeadsProvider(cityPath string) error {
 	}
 	provider := beadsProvider(cityPath)
 	if strings.HasPrefix(provider, "exec:") {
-		release, err := acquireProviderSemaphoreForOp(cityPath, "health")
+		release, err := acquireProviderSemaphoreForOpContext(ctx, cityPath, "health")
 		if err != nil {
 			return err
 		}
@@ -1069,7 +1080,7 @@ func healthBeadsProvider(cityPath string) error {
 		if err != nil {
 			return err
 		}
-		if err := runProviderOpWithEnv(script, providerEnv, "health"); err != nil {
+		if err := runProviderOpWithEnvContext(ctx, script, providerEnv, "health"); err != nil {
 			if providerUsesBdStoreContract(provider) {
 				owned, ownershipErr := managedDoltLifecycleOwned(cityPath)
 				if ownershipErr != nil {
@@ -1098,14 +1109,16 @@ func healthBeadsProvider(cityPath string) error {
 				}
 				lastBeadsProviderRecover.Store(cityKey, now)
 			}
-			if recErr := runProviderOpWithEnv(script, providerEnv, "recover"); recErr != nil {
+			if recErr := runProviderOpWithEnvContext(ctx, script, providerEnv, "recover"); recErr != nil {
 				return fmt.Errorf("unhealthy (%w) and recovery failed: %w", err, recErr)
 			}
 			if pubErr := publishManagedDoltRuntimeStateIfOwned(cityPath); pubErr != nil {
 				return fmt.Errorf("recovered but failed to publish managed dolt runtime state: %w", pubErr)
 			}
-			if waitErr := waitForAllBeadsScopesReadyAfterRecovery(cityPath, 10*time.Second); waitErr != nil {
-				return fmt.Errorf("recovered but store not ready: %w", waitErr)
+			if waitForScopes {
+				if waitErr := waitForAllBeadsScopesReadyAfterRecovery(cityPath, 10*time.Second); waitErr != nil {
+					return fmt.Errorf("recovered but store not ready: %w", waitErr)
+				}
 			}
 		} else if providerUsesBdStoreContract(provider) && currentManagedDoltPort(cityPath) == "" {
 			owned, ownershipErr := managedDoltLifecycleOwned(cityPath)
@@ -1118,8 +1131,10 @@ func healthBeadsProvider(cityPath string) error {
 			if pubErr := publishManagedDoltRuntimeStateIfOwned(cityPath); pubErr != nil {
 				return fmt.Errorf("healthy but failed to publish managed dolt runtime state: %w", pubErr)
 			}
-			if waitErr := waitForAllBeadsScopesReadyAfterRecovery(cityPath, 10*time.Second); waitErr != nil {
-				return fmt.Errorf("healthy but store not ready after publishing managed dolt runtime state: %w", waitErr)
+			if waitForScopes {
+				if waitErr := waitForAllBeadsScopesReadyAfterRecovery(cityPath, 10*time.Second); waitErr != nil {
+					return fmt.Errorf("healthy but store not ready after publishing managed dolt runtime state: %w", waitErr)
+				}
 			}
 		}
 		return nil
@@ -2116,7 +2131,11 @@ func acquireProviderSemaphore(ctx context.Context, cityPath string) (func(), err
 }
 
 func acquireProviderSemaphoreForOp(cityPath, op string) (func(), error) {
-	ctx, cancel := providerLifecycleContext(context.Background(), providerOpTimeout(op))
+	return acquireProviderSemaphoreForOpContext(context.Background(), cityPath, op)
+}
+
+func acquireProviderSemaphoreForOpContext(parent context.Context, cityPath, op string) (func(), error) {
+	ctx, cancel := providerLifecycleContext(parent, providerOpTimeout(op))
 	release, err := acquireProviderSemaphore(ctx, cityPath)
 	if err != nil {
 		cancel()
@@ -2162,11 +2181,15 @@ func runProviderOp(script, cityPath string, args ...string) error {
 }
 
 func runProviderOpWithEnv(script string, environ []string, args ...string) error {
+	return runProviderOpWithEnvContext(context.Background(), script, environ, args...)
+}
+
+func runProviderOpWithEnvContext(parent context.Context, script string, environ []string, args ...string) error {
 	op := ""
 	if len(args) > 0 {
 		op = args[0]
 	}
-	ctx, cancel := providerLifecycleContext(context.Background(), providerOpTimeout(op))
+	ctx, cancel := providerLifecycleContext(parent, providerOpTimeout(op))
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, script, args...)
@@ -2181,6 +2204,9 @@ func runProviderOpWithEnv(script string, environ []string, args ...string) error
 
 	err := cmd.Run()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("exec beads %s: %w", args[0], ctxErr)
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 2 {
 			return nil // Not needed

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -4164,6 +4164,39 @@ wait
 	waitForProviderTestPIDExit(t, pid, "provider op")
 }
 
+func TestRunProviderOpWithEnvContextParentCancellationKillsProcessGroup(t *testing.T) {
+	dir := t.TempDir()
+	childPIDFile := filepath.Join(dir, "child.pid")
+	script := filepath.Join(dir, "provider-op.sh")
+	content := `#!/bin/sh
+sh -c 'echo $$ > "$GC_TEST_CHILD_PID"; while :; do sleep 1; done' &
+wait
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- runProviderOpWithEnvContext(ctx, script, append(os.Environ(), "GC_TEST_CHILD_PID="+childPIDFile), "health")
+	}()
+
+	pid := waitForProviderTestChildPID(t, childPIDFile)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("provider op error = %v, want context canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider op did not return after parent cancellation")
+	}
+	waitForProviderTestPIDExit(t, pid, "provider op with parent context")
+}
+
 func TestRunProviderProbeKillsProcessGroupOnTimeout(t *testing.T) {
 	cancelCh := useCancelableProviderLifecycleContext(t)
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1236,7 +1236,7 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 			// direct native path (which bypasses the factory preflight/identity
 			// gate, so an absent scope project_id cannot block the reconnect).
 			reopen := func(ctx context.Context) (beads.NativeStorage, error) {
-				freshEnv, rerr := nativeDoltOpenEnvForScope(runtimeCityPath, nil, scopeRoot)
+				freshEnv, rerr := nativeDoltOpenEnvForScopeContext(ctx, runtimeCityPath, nil, scopeRoot)
 				if rerr != nil {
 					return nil, fmt.Errorf("re-resolve native store env %s: %w", scopeRoot, rerr)
 				}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1226,7 +1226,23 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 			if err != nil {
 				return nil, fmt.Errorf("project native store env %s: %w", scopeRoot, err)
 			}
-			return beads.OpenNativeDoltStoreAt(context.Background(), scopeRoot, env)
+			// Reopen hook for the native read-path reconnect: the store's cached
+			// open env pins the managed Dolt port as of open time, which is dead
+			// after a hard-kill/rebind. Re-resolve the CURRENT env on every
+			// reconnect — nativeDoltOpenEnvForScope re-reads the live port and
+			// triggers managed-Dolt recovery/restart when the server is down
+			// (allowRecovery=true), mirroring how each bd subprocess re-resolves
+			// the port per command — then re-open against the live server via the
+			// direct native path (which bypasses the factory preflight/identity
+			// gate, so an absent scope project_id cannot block the reconnect).
+			reopen := func(ctx context.Context) (beads.NativeStorage, error) {
+				freshEnv, rerr := nativeDoltOpenEnvForScope(runtimeCityPath, nil, scopeRoot)
+				if rerr != nil {
+					return nil, fmt.Errorf("re-resolve native store env %s: %w", scopeRoot, rerr)
+				}
+				return beads.OpenNativeStorage(ctx, scopeRoot, freshEnv)
+			}
+			return beads.OpenNativeDoltStoreAt(context.Background(), scopeRoot, env, beads.WithNativeReopen(reopen))
 		},
 	})
 	if err != nil {

--- a/cmd/gc/native_reopen_wiring_test.go
+++ b/cmd/gc/native_reopen_wiring_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNativeReopenHookWiredAtBothStoreOpenSites pins the two production sites
+// that must arm the NativeDoltStore read-path reconnect hook: the CLI provider
+// store (openStoreResultAtForCity in main.go) and the controller reconcile rig
+// store (openRigStore in api_state.go). Deleting either WithNativeReopen wiring
+// would silently re-expose the managed-Dolt hard-kill/rebind read failure #4197
+// fixed, so this test fails if either the hook or its ctx-threaded env
+// re-resolution goes missing.
+func TestNativeReopenHookWiredAtBothStoreOpenSites(t *testing.T) {
+	for _, tc := range []struct {
+		file string
+		site string
+	}{
+		{file: "main.go", site: "openStoreResultAtForCity"},
+		{file: "api_state.go", site: "openRigStore"},
+	} {
+		data, err := os.ReadFile(tc.file)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.file, err)
+		}
+		src := string(data)
+		if !strings.Contains(src, "beads.WithNativeReopen(") {
+			t.Fatalf("%s (%s): native reopen hook wiring beads.WithNativeReopen(...) is missing — the #4197 managed-Dolt rebind reconnect must stay armed", tc.file, tc.site)
+		}
+		if !strings.Contains(src, "nativeDoltOpenEnvForScopeContext(ctx") {
+			t.Fatalf("%s (%s): the reopen hook must re-resolve the managed Dolt env under the wall context via nativeDoltOpenEnvForScopeContext(ctx, ...)", tc.file, tc.site)
+		}
+	}
+}

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -187,8 +187,19 @@ type NativeDoltStore struct {
 	// the store factory (which owns managed-Dolt port discovery + restart); a
 	// nil reopen disables reconnect and preserves fail-fast behavior for test
 	// handles built directly from a storage value.
-	reopen      NativeReopenFunc
-	reconnectMu sync.Mutex
+	reopen NativeReopenFunc
+	// reconnectGate is a single token used to serialize reconnects. Readers wait
+	// on it with their retry context, so a reconnect already in progress cannot
+	// make another read outlive its wall-clock budget.
+	reconnectGate chan struct{}
+	// closed is the one-way terminal latch. CloseStore sets it (under mu) so an
+	// in-flight reconnect's post-reopen re-check discards its fresh handle instead
+	// of installing it after the store is permanently closed.
+	closed bool
+	// readRetryBudgetOverride, when non-zero, replaces nativeReadRetryBudget as the
+	// single wall-clock bound on a read's whole reconnect-and-retry chain. Only
+	// tests set it (to exercise budget exhaustion without a real 90s wait).
+	readRetryBudgetOverride time.Duration
 }
 
 // NativeStorage is the upstream beads storage handle a NativeDoltStore wraps.
@@ -321,7 +332,7 @@ func (s *NativeDoltStore) acquireStorage() (beadslib.Storage, func(), error) {
 		return nil, nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
 	}
 	s.mu.RLock()
-	if s.storage == nil {
+	if s.closed || s.storage == nil {
 		s.mu.RUnlock()
 		return nil, nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
 	}
@@ -336,7 +347,7 @@ func (s *NativeDoltStore) acquireStorageGen() (beadslib.Storage, uint64, func(),
 		return nil, 0, nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
 	}
 	s.mu.RLock()
-	if s.storage == nil {
+	if s.closed || s.storage == nil {
 		s.mu.RUnlock()
 		return nil, 0, nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
 	}
@@ -375,31 +386,105 @@ const (
 // long-lived provider-store handle had no equivalent recovery — so a rig store's
 // reconcile scan / Get surfaced "begin read tx: dial tcp <old-port>: i/o
 // timeout" after a managed-Dolt rebind instead of recovering.
-func (s *NativeDoltStore) withReadRetry(fn func(beadslib.Storage) error) error {
-	deadline := time.Now().Add(nativeReadRetryBudget)
+func (s *NativeDoltStore) withReadRetry(fn func(context.Context, beadslib.Storage) error) error {
+	if s == nil {
+		return fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+	}
+	budget := nativeReadRetryBudget
+	if s.readRetryBudgetOverride > 0 {
+		budget = s.readRetryBudgetOverride
+	}
+	// One wall-clock context bounds the WHOLE chain — the read, the reconnect
+	// (env re-resolution + recovery + reopen), the retried read, and the backoff.
+	// Every step derives its deadline from this ctx and is canceled in-flight
+	// when it expires, so the total cannot stack per-call timeouts past budget.
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
 	for {
 		storage, gen, release, err := s.acquireStorageGen()
 		if err != nil {
 			return err
 		}
-		opErr := fn(storage)
+		opErr := fn(ctx, storage)
 		release()
 		if opErr == nil {
 			return nil
 		}
-		if !isNativeDoltTransientReadError(opErr) || s.reopen == nil || time.Now().After(deadline) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nativeReadRetryBudgetError(ctxErr, opErr)
+		}
+		reopen, closed := s.reopenState()
+		if closed {
+			return fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+		}
+		if !isNativeDoltTransientReadError(opErr) || reopen == nil {
 			return opErr
 		}
-		if rcErr := s.reconnect(gen); rcErr != nil {
+		if rcErr := s.reconnect(ctx, gen); rcErr != nil {
+			reconnectErr := fmt.Errorf("native Dolt reconnect after transient read error (%w): %w", opErr, rcErr)
 			// A reconnect that itself fails transiently (server mid-restart) is
 			// worth another pass while the budget remains; a non-transient
 			// reconnect failure or an exhausted budget is terminal.
-			if !isNativeDoltTransientReadError(rcErr) || time.Now().After(deadline) {
-				return fmt.Errorf("native Dolt reconnect after transient read error (%w): %w", opErr, rcErr)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nativeReadRetryBudgetError(ctxErr, reconnectErr)
+			}
+			if !isNativeDoltTransientReadError(rcErr) {
+				return reconnectErr
 			}
 		}
-		time.Sleep(nativeReadRetryBackoff)
+		// Cancellable backoff: budget expiry during the wait aborts the chain
+		// instead of sleeping past the wall.
+		select {
+		case <-ctx.Done():
+			return nativeReadRetryBudgetError(ctx.Err(), opErr)
+		case <-time.After(nativeReadRetryBackoff):
+		}
 	}
+}
+
+func nativeReadRetryBudgetError(ctxErr, lastErr error) error {
+	if lastErr == nil {
+		return fmt.Errorf("native Dolt read retry budget exhausted: %w", ctxErr)
+	}
+	return fmt.Errorf("native Dolt read retry budget exhausted (%w), last error: %w", ctxErr, lastErr)
+}
+
+// reopenState returns the reconnect hook and terminal-close state atomically.
+func (s *NativeDoltStore) reopenState() (NativeReopenFunc, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.reopen, s.closed
+}
+
+// acquireReconnectGate waits for the single reconnect token or the caller's
+// deadline. Lazy initialization keeps zero-value test stores safe without a
+// second constructor-only invariant.
+func (s *NativeDoltStore) acquireReconnectGate(ctx context.Context) (chan struct{}, error) {
+	if s == nil {
+		return nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+	}
+	s.mu.Lock()
+	if s.reconnectGate == nil {
+		s.reconnectGate = make(chan struct{}, 1)
+		s.reconnectGate <- struct{}{}
+	}
+	gate := s.reconnectGate
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-gate:
+		if err := ctx.Err(); err != nil {
+			gate <- struct{}{}
+			return nil, err
+		}
+		return gate, nil
+	}
+}
+
+func (s *NativeDoltStore) releaseReconnectGate(gate chan struct{}) {
+	gate <- struct{}{}
 }
 
 // nativeDoltTransientReadErrorSignatures are the substrings that mark a native
@@ -440,27 +525,33 @@ func isNativeDoltTransientReadError(err error) bool {
 // caller simply retries against the new handle. The fresh handle comes from the
 // injected reopen hook, which re-resolves the CURRENT managed port (the cached
 // open env pins the old, now-dead port) and re-opens against the live server.
-func (s *NativeDoltStore) reconnect(observedGen uint64) error {
-	s.reconnectMu.Lock()
-	defer s.reconnectMu.Unlock()
+func (s *NativeDoltStore) reconnect(ctx context.Context, observedGen uint64) error {
+	gate, err := s.acquireReconnectGate(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.releaseReconnectGate(gate)
 
 	s.mu.RLock()
 	curGen := s.generation
+	closed := s.closed
 	old := s.storage
 	reopen := s.reopen
 	s.mu.RUnlock()
 
+	if closed || reopen == nil {
+		return fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+	}
 	if curGen != observedGen {
 		return nil // another reader already reconnected
 	}
-	if reopen == nil {
-		return fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
-	}
 
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
+	// The reopen hook re-resolves the current managed port and re-opens under the
+	// caller's wall context, so a stuck env-resolution/recovery is canceled at
+	// the budget rather than running under its own separate timeout.
 	fresh, err := reopen(ctx)
 	if err != nil {
+		closeStorageQuietly(fresh)
 		return err
 	}
 	if fresh == nil {
@@ -468,8 +559,15 @@ func (s *NativeDoltStore) reconnect(observedGen uint64) error {
 	}
 
 	s.mu.Lock()
+	// Void the install if the store was closed while we were reopening (terminal
+	// latch — never resurrect a closed store) or another reader reconnected first
+	// (generation advanced). Either way the fresh handle is discarded, not leaked.
+	if s.closed {
+		s.mu.Unlock()
+		closeStorageQuietly(fresh)
+		return fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+	}
 	if s.generation != observedGen {
-		// Lost the race after opening; discard the handle we just built.
 		s.mu.Unlock()
 		closeStorageQuietly(fresh)
 		return nil
@@ -494,15 +592,41 @@ func closeStorageQuietly(storage beadslib.Storage) {
 	go func() { _ = storage.Close() }()
 }
 
-// CloseStore releases the underlying native beads storage handle.
+// CloseStore permanently releases the underlying native beads storage handle.
+// It is a one-way terminal latch that must win any race with an in-flight
+// reconnect: after it returns no reconnect may install a fresh handle (which
+// would resurrect a closed store and leak a live Dolt connection).
 func (s *NativeDoltStore) CloseStore() error {
 	if s == nil {
 		return nil
 	}
+	// Phase 1 — latch closed immediately under mu before waiting on the reconnect
+	// gate, so a reconnect currently blocked in its reopen observes the close on
+	// its post-reopen re-check, while new operations fail with ErrStoreClosed.
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	// Phase 2 — serialize the teardown with any in-flight reconnect,
+	// then advance generation + drop the storage handle + drop the reopen hook
+	// atomically under mu. Combined with the phase-1 latch, no fresh handle can be
+	// installed after this point.
+	gate, err := s.acquireReconnectGate(context.Background())
+	if err != nil {
+		return err
+	}
 	s.mu.Lock()
 	storage := s.storage
 	s.storage = nil
+	s.reopen = nil
+	s.generation++
 	s.mu.Unlock()
+	s.releaseReconnectGate(gate)
+
 	if storage == nil {
 		return nil
 	}
@@ -717,9 +841,7 @@ func (s *NativeDoltStore) Create(b Bead) (Bead, error) {
 // Get retrieves a bead by ID from the upstream beads storage layer.
 func (s *NativeDoltStore) Get(id string) (Bead, error) {
 	var out Bead
-	err := s.withReadRetry(func(storage beadslib.Storage) error {
-		ctx, cancel := nativeDoltOperationContext(context.TODO())
-		defer cancel()
+	err := s.withReadRetry(func(ctx context.Context, storage beadslib.Storage) error {
 		issues, err := storage.SearchIssues(ctx, "", beadslib.IssueFilter{
 			IDs:                 []string{id},
 			IncludeDependencies: true,
@@ -989,10 +1111,8 @@ func (s *NativeDoltStore) List(query ListQuery) ([]Bead, error) {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
 	}
 	var out []Bead
-	err := s.withReadRetry(func(storage beadslib.Storage) error {
+	err := s.withReadRetry(func(ctx context.Context, storage beadslib.Storage) error {
 		filter := nativeIssueFilterFromListQuery(query)
-		ctx, cancel := nativeDoltOperationContext(context.TODO())
-		defer cancel()
 		issues, err := storage.SearchIssues(ctx, "", filter)
 		if err != nil {
 			return err
@@ -1030,9 +1150,7 @@ func (s *NativeDoltStore) ListOpen(status ...string) ([]Bead, error) {
 func (s *NativeDoltStore) Ready(queries ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(queries)
 	var out []Bead
-	err := s.withReadRetry(func(storage beadslib.Storage) error {
-		ctx, cancel := nativeDoltOperationContext(context.TODO())
-		defer cancel()
+	err := s.withReadRetry(func(ctx context.Context, storage beadslib.Storage) error {
 		var beads []Bead
 		seen := make(map[string]bool)
 		now := time.Now().UTC()
@@ -1317,9 +1435,7 @@ func (s *NativeDoltStore) DepRemove(issueID, dependsOnID string) error {
 // DepList returns dependencies for a bead.
 func (s *NativeDoltStore) DepList(id, direction string) ([]Dep, error) {
 	var out []Dep
-	err := s.withReadRetry(func(storage beadslib.Storage) error {
-		ctx, cancel := nativeDoltOperationContext(context.TODO())
-		defer cancel()
+	err := s.withReadRetry(func(ctx context.Context, storage beadslib.Storage) error {
 		deps, err := s.depList(ctx, storage, id, direction)
 		if err != nil {
 			return err

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -170,10 +171,22 @@ func restoreNativeDoltOpenEnv(previous map[string]*string) {
 // library over Dolt. It is constructed by the store factory after native-store
 // preflight gates pass.
 type NativeDoltStore struct {
-	mu       sync.RWMutex
-	storage  beadslib.Storage
-	actor    string
-	idPrefix string
+	mu      sync.RWMutex
+	storage beadslib.Storage
+	// generation increments on every successful reconnect. A read that fails
+	// with a transient connection error records the generation it observed and
+	// asks reconnect to swap the dead handle only if no other reader already did.
+	generation uint64
+	actor      string
+	idPrefix   string
+
+	// scopeRoot and openEnv are captured at open so the read path can transparently
+	// re-open the managed Dolt connection after a :3307 hard-kill/rebind. An empty
+	// scopeRoot (e.g. a test store built directly from a storage handle) disables
+	// reconnect and preserves the prior fail-fast behavior.
+	scopeRoot   string
+	openEnv     map[string]string
+	reconnectMu sync.Mutex
 }
 
 var (
@@ -207,19 +220,39 @@ func OpenNativeDoltStoreAt(ctx context.Context, scopeRoot string, env map[string
 func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[string]string) (*NativeDoltStore, error) {
 	ctx, cancel := nativeDoltOperationContext(parent)
 	defer cancel()
-	restoreEnv, err := withNativeDoltOpenEnv(env)
+	storage, prefix, err := openAndRepairNativeStorage(ctx, scopeRoot, env, true)
 	if err != nil {
 		return nil, err
+	}
+	store := newNativeDoltStoreWithStorageAndPrefix(storage, nativeDoltStoreActor, prefix)
+	store.scopeRoot = scopeRoot
+	store.openEnv = maps.Clone(env)
+	return store, nil
+}
+
+// openAndRepairNativeStorage projects the scoped Dolt env, opens the
+// best-available native storage, repairs the id-default columns some Dolt
+// versions strip, and (when readPrefix) reads the configured issue prefix while
+// the env is still projected. It is shared by the initial open and by the
+// read-path reconnect that recovers from a managed-Dolt hard-kill/rebind, so
+// both establish an identically configured connection.
+func openAndRepairNativeStorage(ctx context.Context, scopeRoot string, env map[string]string, readPrefix bool) (beadslib.Storage, string, error) {
+	restoreEnv, err := withNativeDoltOpenEnv(env)
+	if err != nil {
+		return nil, "", err
 	}
 	defer restoreEnv()
 	storage, err := nativeDoltOpenBestAvailable(ctx, filepath.Join(scopeRoot, ".beads"))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	prefix, err := storage.GetConfig(ctx, "issue_prefix")
-	if err != nil {
-		_ = storage.Close()
-		return nil, fmt.Errorf("reading native issue prefix: %w", err)
+	var prefix string
+	if readPrefix {
+		prefix, err = storage.GetConfig(ctx, "issue_prefix")
+		if err != nil {
+			_ = storage.Close()
+			return nil, "", fmt.Errorf("reading native issue prefix: %w", err)
+		}
 	}
 	if accessor, ok := storage.(rawDBGetter); ok {
 		for _, table := range idDefaultRepairTables {
@@ -230,7 +263,7 @@ func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[stri
 			}
 		}
 	}
-	return newNativeDoltStoreWithStorageAndPrefix(storage, nativeDoltStoreActor, prefix), nil
+	return storage, prefix, nil
 }
 
 func newNativeDoltStoreForTest(storage beadslib.Storage) *NativeDoltStore {
@@ -259,6 +292,166 @@ func (s *NativeDoltStore) acquireStorage() (beadslib.Storage, func(), error) {
 		return nil, nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
 	}
 	return s.storage, s.mu.RUnlock, nil
+}
+
+// acquireStorageGen is acquireStorage plus the current reconnect generation, so
+// the read-retry path can ask reconnect to swap only the exact handle it saw
+// fail (single-flight across concurrent readers).
+func (s *NativeDoltStore) acquireStorageGen() (beadslib.Storage, uint64, func(), error) {
+	if s == nil {
+		return nil, 0, nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+	}
+	s.mu.RLock()
+	if s.storage == nil {
+		s.mu.RUnlock()
+		return nil, 0, nil, fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+	}
+	return s.storage, s.generation, s.mu.RUnlock, nil
+}
+
+const (
+	// nativeReadRetryBudget bounds the total reconnect-and-retry time for a
+	// single read. It must comfortably exceed the managed-Dolt hard-kill/rebind
+	// window (~40-56s of mysql i/o timeouts before the dead handle surfaces the
+	// error, plus the restart) so a read spanning a rebind recovers rather than
+	// failing, while still failing fast for a genuinely down server.
+	nativeReadRetryBudget = 90 * time.Second
+	// nativeReadRetryBackoff spaces reconnect-and-retry passes.
+	nativeReadRetryBackoff = 200 * time.Millisecond
+)
+
+// withReadRetry runs a read against the native storage handle, transparently
+// re-opening the managed Dolt connection and retrying when the handle fails with
+// a transient connection error — the :3307 hard-kill/rebind class ("invalid
+// connection", "i/o timeout", "broken pipe", "dial tcp", "unexpected EOF",
+// "use of closed network connection"). Retrying the same handle is pointless:
+// its *sql.DB pool points at the killed server's port, so each retry first
+// reconnects (openAndRepairNativeStorage re-runs the managed auto-start, which
+// rebinds Dolt to a fresh port and reconnects). Reconnect is single-flight
+// across concurrent readers via the generation guard. The loop is deadline-
+// bounded (nativeReadRetryBudget) rather than a fixed attempt count so it spans
+// the whole rebind window. Non-transient errors (ErrNotFound, decode failures)
+// return immediately, and a store without a captured scopeRoot (test handle)
+// keeps the prior fail-fast behavior.
+//
+// This closes the gap #4188 left: runBDTransientRead hardened the bd-CLI read
+// path, but factory.go prefers NativeDoltStore when native preflight passes, and
+// that provider-store read path had no equivalent recovery — so a rig store's
+// reconcile scan / Get surfaced "begin read tx: invalid connection" after a
+// managed-Dolt rebind instead of recovering.
+func (s *NativeDoltStore) withReadRetry(fn func(beadslib.Storage) error) error {
+	deadline := time.Now().Add(nativeReadRetryBudget)
+	for {
+		storage, gen, release, err := s.acquireStorageGen()
+		if err != nil {
+			return err
+		}
+		opErr := fn(storage)
+		release()
+		if opErr == nil {
+			return nil
+		}
+		if !isNativeDoltTransientReadError(opErr) || s.scopeRoot == "" || time.Now().After(deadline) {
+			return opErr
+		}
+		if rcErr := s.reconnect(gen); rcErr != nil {
+			// A reconnect that itself fails transiently (server mid-restart) is
+			// worth another pass while the budget remains; a non-transient
+			// reconnect failure or an exhausted budget is terminal.
+			if !isNativeDoltTransientReadError(rcErr) || time.Now().After(deadline) {
+				return fmt.Errorf("native Dolt reconnect after transient read error (%w): %w", opErr, rcErr)
+			}
+		}
+		time.Sleep(nativeReadRetryBackoff)
+	}
+}
+
+// nativeDoltTransientReadErrorSignatures are the substrings that mark a native
+// read failure as a transient managed-Dolt connection error worth reconnecting
+// and retrying for. It mirrors and extends the bd read path's connection-error
+// set (#4188) with the mysql/net signatures a :3307 hard-kill/rebind emits.
+var nativeDoltTransientReadErrorSignatures = []string{
+	"invalid connection",
+	"bad connection",
+	"connection reset",
+	"broken pipe",
+	"i/o timeout",
+	"dial tcp",
+	"unexpected eof",
+	"use of closed network connection",
+	"connection refused",
+}
+
+// isNativeDoltTransientReadError reports whether err is a transient managed-Dolt
+// connection error worth reconnecting-and-retrying for.
+func isNativeDoltTransientReadError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, sig := range nativeDoltTransientReadErrorSignatures {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// reconnect swaps the dead storage handle for a freshly opened one after a
+// transient connection failure, single-flighted so concurrent readers reconnect
+// once. observedGen is the generation the failing read ran under; if another
+// reader already reconnected (generation advanced), this is a no-op and the
+// caller simply retries against the new handle.
+func (s *NativeDoltStore) reconnect(observedGen uint64) error {
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+
+	s.mu.RLock()
+	curGen := s.generation
+	old := s.storage
+	scopeRoot := s.scopeRoot
+	env := s.openEnv
+	s.mu.RUnlock()
+
+	if curGen != observedGen {
+		return nil // another reader already reconnected
+	}
+	if scopeRoot == "" {
+		return fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
+	}
+
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+	fresh, _, err := openAndRepairNativeStorage(ctx, scopeRoot, env, false)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	if s.generation != observedGen {
+		// Lost the race after opening; discard the handle we just built.
+		s.mu.Unlock()
+		closeStorageQuietly(fresh)
+		return nil
+	}
+	s.storage = fresh
+	s.generation++
+	s.mu.Unlock()
+
+	closeStorageQuietly(old)
+	return nil
+}
+
+// closeStorageQuietly closes a (possibly dead) storage handle without blocking
+// the caller: a handle whose server was hard-killed can wedge on Close, so it is
+// closed on a detached goroutine and any error is ignored. The handle is
+// unreferenced by the time this is called (the swap took the write lock, so no
+// reader still holds it), making the detached close safe.
+func closeStorageQuietly(storage beadslib.Storage) {
+	if storage == nil {
+		return
+	}
+	go func() { _ = storage.Close() }()
 }
 
 // CloseStore releases the underlying native beads storage handle.
@@ -483,26 +676,30 @@ func (s *NativeDoltStore) Create(b Bead) (Bead, error) {
 
 // Get retrieves a bead by ID from the upstream beads storage layer.
 func (s *NativeDoltStore) Get(id string) (Bead, error) {
-	storage, release, err := s.acquireStorage()
-	if err != nil {
-		return Bead{}, err
-	}
-	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
-	issues, err := storage.SearchIssues(ctx, "", beadslib.IssueFilter{
-		IDs:                 []string{id},
-		IncludeDependencies: true,
-	})
-	if err != nil {
-		return Bead{}, nativeStoreError(id, err)
-	}
-	for _, issue := range issues {
-		if issue != nil && issue.ID == id {
-			return beadFromNativeIssue(issue)
+	var out Bead
+	err := s.withReadRetry(func(storage beadslib.Storage) error {
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		issues, err := storage.SearchIssues(ctx, "", beadslib.IssueFilter{
+			IDs:                 []string{id},
+			IncludeDependencies: true,
+		})
+		if err != nil {
+			return nativeStoreError(id, err)
 		}
-	}
-	return Bead{}, fmt.Errorf("bead %q: %w", id, ErrNotFound)
+		for _, issue := range issues {
+			if issue != nil && issue.ID == id {
+				bead, err := beadFromNativeIssue(issue)
+				if err != nil {
+					return err
+				}
+				out = bead
+				return nil
+			}
+		}
+		return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+	})
+	return out, err
 }
 
 // Update modifies an existing bead through the upstream beads storage layer.
@@ -751,27 +948,30 @@ func (s *NativeDoltStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
 	}
-	storage, release, err := s.acquireStorage()
-	if err != nil {
-		return nil, err
-	}
-	defer release()
-	filter := nativeIssueFilterFromListQuery(query)
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
-	issues, err := storage.SearchIssues(ctx, "", filter)
-	if err != nil {
-		return nil, err
-	}
-	beads := make([]Bead, 0, len(issues))
-	for _, issue := range issues {
-		bead, err := beadFromNativeIssue(issue)
+	var out []Bead
+	err := s.withReadRetry(func(storage beadslib.Storage) error {
+		filter := nativeIssueFilterFromListQuery(query)
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		issues, err := storage.SearchIssues(ctx, "", filter)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		beads = append(beads, bead)
+		beads := make([]Bead, 0, len(issues))
+		for _, issue := range issues {
+			bead, err := beadFromNativeIssue(issue)
+			if err != nil {
+				return err
+			}
+			beads = append(beads, bead)
+		}
+		out = ApplyListQuery(beads, query)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return ApplyListQuery(beads, query), nil
+	return out, nil
 }
 
 // ListOpen returns non-closed beads by default, or beads with the given status.
@@ -789,45 +989,48 @@ func (s *NativeDoltStore) ListOpen(status ...string) ([]Bead, error) {
 // Ready returns open, unblocked actionable beads.
 func (s *NativeDoltStore) Ready(queries ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(queries)
-	storage, release, err := s.acquireStorage()
+	var out []Bead
+	err := s.withReadRetry(func(storage beadslib.Storage) error {
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		var beads []Bead
+		seen := make(map[string]bool)
+		now := time.Now().UTC()
+	statusLoop:
+		for _, status := range nativeDoltOpenReadyStatuses {
+			filter := beadslib.WorkFilter{Status: status}
+			if q.TierMode == TierBoth || q.TierMode == TierWisps {
+				filter.IncludeEphemeral = true
+			}
+			if q.Assignee != "" {
+				filter.Assignee = &q.Assignee
+			}
+			issues, err := storage.GetReadyWork(ctx, filter)
+			if err != nil {
+				return err
+			}
+			for _, issue := range issues {
+				bead, err := beadFromNativeIssue(issue)
+				if err != nil {
+					return err
+				}
+				if !IsReadyCandidateForTier(bead, now, q.TierMode) || seen[bead.ID] {
+					continue
+				}
+				seen[bead.ID] = true
+				beads = append(beads, bead)
+				if q.Limit > 0 && len(beads) >= q.Limit {
+					break statusLoop
+				}
+			}
+		}
+		out = beads
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
-	var beads []Bead
-	seen := make(map[string]bool)
-	now := time.Now().UTC()
-statusLoop:
-	for _, status := range nativeDoltOpenReadyStatuses {
-		filter := beadslib.WorkFilter{Status: status}
-		if q.TierMode == TierBoth || q.TierMode == TierWisps {
-			filter.IncludeEphemeral = true
-		}
-		if q.Assignee != "" {
-			filter.Assignee = &q.Assignee
-		}
-		issues, err := storage.GetReadyWork(ctx, filter)
-		if err != nil {
-			return nil, err
-		}
-		for _, issue := range issues {
-			bead, err := beadFromNativeIssue(issue)
-			if err != nil {
-				return nil, err
-			}
-			if !IsReadyCandidateForTier(bead, now, q.TierMode) || seen[bead.ID] {
-				continue
-			}
-			seen[bead.ID] = true
-			beads = append(beads, bead)
-			if q.Limit > 0 && len(beads) >= q.Limit {
-				break statusLoop
-			}
-		}
-	}
-	return beads, nil
+	return out, nil
 }
 
 // Children returns all beads whose parent-child dependency points at parentID.
@@ -1073,14 +1276,21 @@ func (s *NativeDoltStore) DepRemove(issueID, dependsOnID string) error {
 
 // DepList returns dependencies for a bead.
 func (s *NativeDoltStore) DepList(id, direction string) ([]Dep, error) {
-	storage, release, err := s.acquireStorage()
+	var out []Dep
+	err := s.withReadRetry(func(storage beadslib.Storage) error {
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		deps, err := s.depList(ctx, storage, id, direction)
+		if err != nil {
+			return err
+		}
+		out = deps
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
-	return s.depList(ctx, storage, id, direction)
+	return out, nil
 }
 
 func (s *NativeDoltStore) depList(ctx context.Context, storage beadslib.Storage, id, direction string) ([]Dep, error) {

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,13 +179,36 @@ type NativeDoltStore struct {
 	actor      string
 	idPrefix   string
 
-	// scopeRoot and openEnv are captured at open so the read path can transparently
-	// re-open the managed Dolt connection after a :3307 hard-kill/rebind. An empty
-	// scopeRoot (e.g. a test store built directly from a storage handle) disables
-	// reconnect and preserves the prior fail-fast behavior.
-	scopeRoot   string
-	openEnv     map[string]string
+	// reopen re-establishes the managed Dolt connection after a transient
+	// connection failure (a :3307 hard-kill/rebind). It MUST re-resolve the
+	// CURRENT managed Dolt port and return a fresh storage handle bound to the
+	// live server — the store's original open env pins the now-dead port, so a
+	// naive re-open of the cached env would keep dialing it. It is injected by
+	// the store factory (which owns managed-Dolt port discovery + restart); a
+	// nil reopen disables reconnect and preserves fail-fast behavior for test
+	// handles built directly from a storage value.
+	reopen      NativeReopenFunc
 	reconnectMu sync.Mutex
+}
+
+// NativeStorage is the upstream beads storage handle a NativeDoltStore wraps.
+// It is aliased so a caller (e.g. the store factory) can build a WithNativeReopen
+// hook without importing the upstream beads package directly.
+type NativeStorage = beadslib.Storage
+
+// NativeReopenFunc re-establishes a native Dolt storage handle after a transient
+// connection failure. See WithNativeReopen and NativeDoltStore.reopen.
+type NativeReopenFunc func(context.Context) (NativeStorage, error)
+
+// NativeDoltStoreOption configures a NativeDoltStore at open.
+type NativeDoltStoreOption func(*NativeDoltStore)
+
+// WithNativeReopen injects the reconnect hook the read path uses to recover the
+// managed Dolt connection after a transient failure. The hook must re-resolve
+// the current managed port (the cached open env pins the old one) and return a
+// fresh storage handle. See NativeDoltStore.reopen.
+func WithNativeReopen(reopen NativeReopenFunc) NativeDoltStoreOption {
+	return func(s *NativeDoltStore) { s.reopen = reopen }
 }
 
 var (
@@ -213,11 +235,13 @@ func newNativeDoltStoreWithStorageAndPrefix(storage beadslib.Storage, actor, idP
 
 // OpenNativeDoltStoreAt opens a native Dolt-backed beads store at scopeRoot
 // while projecting the supplied scoped Dolt environment for upstream beads.
-func OpenNativeDoltStoreAt(ctx context.Context, scopeRoot string, env map[string]string) (*NativeDoltStore, error) {
-	return newNativeDoltStoreAt(ctx, scopeRoot, env)
+// Pass WithNativeReopen to arm transparent reconnect across a managed-Dolt
+// rebind.
+func OpenNativeDoltStoreAt(ctx context.Context, scopeRoot string, env map[string]string, opts ...NativeDoltStoreOption) (*NativeDoltStore, error) {
+	return newNativeDoltStoreAt(ctx, scopeRoot, env, opts...)
 }
 
-func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[string]string) (*NativeDoltStore, error) {
+func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[string]string, opts ...NativeDoltStoreOption) (*NativeDoltStore, error) {
 	ctx, cancel := nativeDoltOperationContext(parent)
 	defer cancel()
 	storage, prefix, err := openAndRepairNativeStorage(ctx, scopeRoot, env, true)
@@ -225,9 +249,19 @@ func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[stri
 		return nil, err
 	}
 	store := newNativeDoltStoreWithStorageAndPrefix(storage, nativeDoltStoreActor, prefix)
-	store.scopeRoot = scopeRoot
-	store.openEnv = maps.Clone(env)
+	for _, opt := range opts {
+		opt(store)
+	}
 	return store, nil
+}
+
+// OpenNativeStorage opens a native Dolt storage handle for the given scope and
+// projected env. It is the building block for a NativeDoltStore reopen hook: a
+// caller that has re-resolved the CURRENT managed Dolt env (fresh port) passes
+// it here to get a fresh handle bound to the live server.
+func OpenNativeStorage(ctx context.Context, scopeRoot string, env map[string]string) (NativeStorage, error) {
+	storage, _, err := openAndRepairNativeStorage(ctx, scopeRoot, env, false)
+	return storage, err
 }
 
 // openAndRepairNativeStorage projects the scoped Dolt env, opens the
@@ -321,24 +355,26 @@ const (
 )
 
 // withReadRetry runs a read against the native storage handle, transparently
-// re-opening the managed Dolt connection and retrying when the handle fails with
-// a transient connection error — the :3307 hard-kill/rebind class ("invalid
-// connection", "i/o timeout", "broken pipe", "dial tcp", "unexpected EOF",
-// "use of closed network connection"). Retrying the same handle is pointless:
-// its *sql.DB pool points at the killed server's port, so each retry first
-// reconnects (openAndRepairNativeStorage re-runs the managed auto-start, which
-// rebinds Dolt to a fresh port and reconnects). Reconnect is single-flight
-// across concurrent readers via the generation guard. The loop is deadline-
-// bounded (nativeReadRetryBudget) rather than a fixed attempt count so it spans
-// the whole rebind window. Non-transient errors (ErrNotFound, decode failures)
-// return immediately, and a store without a captured scopeRoot (test handle)
-// keeps the prior fail-fast behavior.
+// reconnecting and retrying when the handle fails with a transient connection
+// error — the :3307 hard-kill/rebind class ("invalid connection", "i/o timeout",
+// "broken pipe", "dial tcp", "unexpected EOF", "use of closed network
+// connection"). Retrying the same handle is pointless: its *sql.DB pool points
+// at the killed server's port, so each retry first reconnects via the injected
+// reopen hook, which re-resolves the CURRENT managed Dolt port (restarting the
+// server if needed) and returns a fresh handle bound to the live server.
+// Reconnect is single-flight across concurrent readers via the generation guard.
+// The loop is deadline-bounded (nativeReadRetryBudget) rather than a fixed
+// attempt count so it spans the whole rebind window. Non-transient errors
+// (ErrNotFound, decode failures) return immediately, and a store without a
+// reopen hook (test handle built directly from a storage value) keeps the prior
+// fail-fast behavior.
 //
 // This closes the gap #4188 left: runBDTransientRead hardened the bd-CLI read
-// path, but factory.go prefers NativeDoltStore when native preflight passes, and
-// that provider-store read path had no equivalent recovery — so a rig store's
-// reconcile scan / Get surfaced "begin read tx: invalid connection" after a
-// managed-Dolt rebind instead of recovering.
+// path (each bd subprocess re-resolves the port and restarts Dolt), but
+// factory.go prefers NativeDoltStore when native preflight passes, and that
+// long-lived provider-store handle had no equivalent recovery — so a rig store's
+// reconcile scan / Get surfaced "begin read tx: dial tcp <old-port>: i/o
+// timeout" after a managed-Dolt rebind instead of recovering.
 func (s *NativeDoltStore) withReadRetry(fn func(beadslib.Storage) error) error {
 	deadline := time.Now().Add(nativeReadRetryBudget)
 	for {
@@ -351,7 +387,7 @@ func (s *NativeDoltStore) withReadRetry(fn func(beadslib.Storage) error) error {
 		if opErr == nil {
 			return nil
 		}
-		if !isNativeDoltTransientReadError(opErr) || s.scopeRoot == "" || time.Now().After(deadline) {
+		if !isNativeDoltTransientReadError(opErr) || s.reopen == nil || time.Now().After(deadline) {
 			return opErr
 		}
 		if rcErr := s.reconnect(gen); rcErr != nil {
@@ -401,7 +437,9 @@ func isNativeDoltTransientReadError(err error) bool {
 // transient connection failure, single-flighted so concurrent readers reconnect
 // once. observedGen is the generation the failing read ran under; if another
 // reader already reconnected (generation advanced), this is a no-op and the
-// caller simply retries against the new handle.
+// caller simply retries against the new handle. The fresh handle comes from the
+// injected reopen hook, which re-resolves the CURRENT managed port (the cached
+// open env pins the old, now-dead port) and re-opens against the live server.
 func (s *NativeDoltStore) reconnect(observedGen uint64) error {
 	s.reconnectMu.Lock()
 	defer s.reconnectMu.Unlock()
@@ -409,22 +447,24 @@ func (s *NativeDoltStore) reconnect(observedGen uint64) error {
 	s.mu.RLock()
 	curGen := s.generation
 	old := s.storage
-	scopeRoot := s.scopeRoot
-	env := s.openEnv
+	reopen := s.reopen
 	s.mu.RUnlock()
 
 	if curGen != observedGen {
 		return nil // another reader already reconnected
 	}
-	if scopeRoot == "" {
+	if reopen == nil {
 		return fmt.Errorf("native Dolt store: %w", ErrStoreClosed)
 	}
 
 	ctx, cancel := nativeDoltOperationContext(context.TODO())
 	defer cancel()
-	fresh, _, err := openAndRepairNativeStorage(ctx, scopeRoot, env, false)
+	fresh, err := reopen(ctx)
 	if err != nil {
 		return err
+	}
+	if fresh == nil {
+		return fmt.Errorf("native Dolt reopen returned nil storage")
 	}
 
 	s.mu.Lock()

--- a/internal/beads/native_dolt_store_reconnect_test.go
+++ b/internal/beads/native_dolt_store_reconnect_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	beadslib "github.com/steveyegge/beads"
 )
@@ -149,4 +151,236 @@ func TestIsNativeDoltTransientReadError(t *testing.T) {
 
 func errContains(err error, sub string) bool {
 	return err != nil && strings.Contains(err.Error(), sub)
+}
+
+func nativeDoltStoreClosedForTest(s *NativeDoltStore) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.closed
+}
+
+func nativeDoltStoreStateForTest(s *NativeDoltStore) (beadslib.Storage, NativeReopenFunc) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.storage, s.reopen
+}
+
+func TestNativeDoltStoreCloseStoreWinsInFlightReconnect(t *testing.T) {
+	var oldCloseCalls atomic.Int32
+	var freshCloseCalls atomic.Int32
+	var freshReadCalls atomic.Int32
+	old := deadSearchStorage(errors.New("invalid connection"))
+	old.close = func() error {
+		oldCloseCalls.Add(1)
+		return nil
+	}
+	fresh := &nativeDoltStorageSpy{
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			freshReadCalls.Add(1)
+			return nil, nil
+		},
+		close: func() error {
+			freshCloseCalls.Add(1)
+			return nil
+		},
+	}
+
+	reopenStarted := make(chan struct{})
+	releaseReopen := make(chan struct{})
+	var once sync.Once
+	store := newNativeDoltStoreForTest(old)
+	store.reopen = func(context.Context) (beadslib.Storage, error) {
+		once.Do(func() { close(reopenStarted) })
+		<-releaseReopen
+		return fresh, nil
+	}
+
+	getDone := make(chan error, 1)
+	go func() { _, err := store.Get("gc-1"); getDone <- err }()
+
+	select {
+	case <-reopenStarted:
+	case <-time.After(time.Second):
+		t.Fatal("reopen hook did not start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- store.CloseStore() }()
+
+	deadline := time.Now().Add(time.Second)
+	for !nativeDoltStoreClosedForTest(store) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !nativeDoltStoreClosedForTest(store) {
+		t.Fatal("CloseStore did not latch the store closed")
+	}
+	if storage, _, release, err := store.acquireStorageGen(); !errors.Is(err, ErrStoreClosed) {
+		if release != nil {
+			release()
+		}
+		t.Fatalf("acquireStorageGen after close latch = (%T, %v), want ErrStoreClosed", storage, err)
+	}
+	if storage, release, err := store.acquireStorage(); !errors.Is(err, ErrStoreClosed) {
+		if release != nil {
+			release()
+		}
+		t.Fatalf("acquireStorage after close latch = (%T, %v), want ErrStoreClosed", storage, err)
+	}
+
+	close(releaseReopen)
+	select {
+	case err := <-getDone:
+		if !errors.Is(err, ErrStoreClosed) {
+			t.Fatalf("Get racing CloseStore = %v, want ErrStoreClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Get did not return after reopen was released")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("CloseStore: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CloseStore did not return after reopen was released")
+	}
+
+	storage, reopen := nativeDoltStoreStateForTest(store)
+	if storage != nil || reopen != nil {
+		t.Fatalf("closed store state = (storage=%T, reopen=%v), want both nil", storage, reopen != nil)
+	}
+	deadline = time.Now().Add(time.Second)
+	for freshCloseCalls.Load() != 1 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := oldCloseCalls.Load(); got != 1 {
+		t.Fatalf("old storage close calls = %d, want 1", got)
+	}
+	if got := freshCloseCalls.Load(); got != 1 {
+		t.Fatalf("fresh storage close calls = %d, want 1", got)
+	}
+	if got := freshReadCalls.Load(); got != 0 {
+		t.Fatalf("fresh storage read calls = %d, want 0", got)
+	}
+	if _, err := store.Get("gc-1"); !errors.Is(err, ErrStoreClosed) {
+		t.Fatalf("Get after CloseStore = %v, want ErrStoreClosed", err)
+	}
+}
+
+func TestNativeDoltStoreReadRetrySharesOneWallClockBudget(t *testing.T) {
+	const budget = 100 * time.Millisecond
+	firstReadDeadline := make(chan time.Time, 1)
+	reopenDeadline := make(chan time.Time, 1)
+	dead := &nativeDoltStorageSpy{
+		searchIssues: func(ctx context.Context, _ string, _ beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			deadline, _ := ctx.Deadline()
+			firstReadDeadline <- deadline
+			time.Sleep(10 * time.Millisecond)
+			return nil, errors.New("invalid connection")
+		},
+	}
+	stillDead := deadSearchStorage(errors.New("invalid connection"))
+	store := newNativeDoltStoreForTest(dead)
+	store.readRetryBudgetOverride = budget
+	store.reopen = func(ctx context.Context) (beadslib.Storage, error) {
+		deadline, _ := ctx.Deadline()
+		reopenDeadline <- deadline
+		time.Sleep(10 * time.Millisecond)
+		return stillDead, nil
+	}
+
+	started := time.Now()
+	_, err := store.Get("gc-1")
+	elapsed := time.Since(started)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Get error = %v, want context deadline exceeded", err)
+	}
+	if !isNativeDoltTransientReadError(err) {
+		t.Fatalf("Get error = %v, want the last transient cause preserved", err)
+	}
+	if elapsed < 50*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("Get elapsed = %s, want one %s wall-clock budget", elapsed, budget)
+	}
+	read := <-firstReadDeadline
+	var reopen time.Time
+	select {
+	case reopen = <-reopenDeadline:
+	case <-time.After(time.Second):
+		t.Fatal("reopen did not receive the shared retry context")
+	}
+	if !read.Equal(reopen) {
+		t.Fatalf("read deadline = %s, reopen deadline = %s; want one shared deadline", read, reopen)
+	}
+}
+
+func TestNativeDoltStoreReadRetryBudgetBoundsReconnectGateWait(t *testing.T) {
+	store := newNativeDoltStoreForTest(deadSearchStorage(errors.New("invalid connection")))
+	store.readRetryBudgetOverride = 40 * time.Millisecond
+	var reopens atomic.Int32
+	store.reopen = func(context.Context) (beadslib.Storage, error) {
+		reopens.Add(1)
+		return healthySearchStorage(), nil
+	}
+
+	gate, err := store.acquireReconnectGate(context.Background())
+	if err != nil {
+		t.Fatalf("acquire reconnect gate: %v", err)
+	}
+	defer store.releaseReconnectGate(gate)
+
+	started := time.Now()
+	_, err = store.Get("gc-1")
+	elapsed := time.Since(started)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Get waiting for reconnect gate = %v, want context deadline exceeded", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("Get waiting for reconnect gate took %s, want <= 200ms", elapsed)
+	}
+	if got := reopens.Load(); got != 0 {
+		t.Fatalf("reopen calls while reconnect gate held = %d, want 0", got)
+	}
+}
+
+func TestNativeDoltStoreNilReadReturnsStoreClosed(t *testing.T) {
+	var store *NativeDoltStore
+	if _, err := store.Get("gc-1"); !errors.Is(err, ErrStoreClosed) {
+		t.Fatalf("nil store Get = %v, want ErrStoreClosed", err)
+	}
+}
+
+// TestNativeDoltStoreConcurrentReadersReopenOnce pins single-flight: many
+// readers racing a dead handle trigger exactly one reopen; the losers discard
+// and retry against the installed handle.
+func TestNativeDoltStoreConcurrentReadersReopenOnce(t *testing.T) {
+	healthy := healthySearchStorage(&beadslib.Issue{
+		ID: "gc-1", Title: "recovered", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2,
+	})
+	var reopens int32
+	store := newNativeDoltStoreForTest(deadSearchStorage(errors.New("invalid connection")))
+	store.reopen = func(context.Context) (beadslib.Storage, error) {
+		atomic.AddInt32(&reopens, 1)
+		return healthy, nil
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = store.Get("gc-1")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Fatalf("reader %d: %v", i, e)
+		}
+	}
+	if got := atomic.LoadInt32(&reopens); got != 1 {
+		t.Fatalf("reopen called %d times, want exactly 1 (single-flight)", got)
+	}
 }

--- a/internal/beads/native_dolt_store_reconnect_test.go
+++ b/internal/beads/native_dolt_store_reconnect_test.go
@@ -1,0 +1,174 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// transientThenHealthyStorage helpers build a NativeDoltStore whose initial
+// handle fails every read with a transient connection error, plus a healthy
+// replacement handed back by the overridden open. Together they exercise the
+// read-path reconnect: attempt 1 fails transient -> reconnect swaps the dead
+// handle for the healthy one -> attempt 2 succeeds.
+
+func healthySearchStorage(issues ...*beadslib.Issue) *nativeDoltStorageSpy {
+	return &nativeDoltStorageSpy{
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return issues, nil
+		},
+	}
+}
+
+func TestNativeDoltStoreGetReconnectsAfterTransientConnError(t *testing.T) {
+	healthy := healthySearchStorage(&beadslib.Issue{
+		ID: "gc-1", Title: "recovered", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2,
+	})
+	var reopens int32
+	oldOpen := nativeDoltOpenBestAvailable
+	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
+	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
+		atomic.AddInt32(&reopens, 1)
+		return healthy, nil
+	}
+
+	dead := &nativeDoltStorageSpy{
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return nil, errors.New("begin read tx: invalid connection")
+		},
+	}
+	store := newNativeDoltStoreForTest(dead)
+	store.scopeRoot = t.TempDir() // enable reconnect
+
+	got, err := store.Get("gc-1")
+	if err != nil {
+		t.Fatalf("Get after transient conn error: %v", err)
+	}
+	if got.ID != "gc-1" {
+		t.Fatalf("Get.ID = %q, want gc-1", got.ID)
+	}
+	if n := atomic.LoadInt32(&reopens); n == 0 {
+		t.Fatalf("expected a reconnect (nativeDoltOpenBestAvailable call); got %d", n)
+	}
+}
+
+func TestNativeDoltStoreListReconnectsAfterTransientConnError(t *testing.T) {
+	healthy := healthySearchStorage(&beadslib.Issue{
+		ID: "gc-2", Title: "recovered list", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2,
+	})
+	var reopens int32
+	oldOpen := nativeDoltOpenBestAvailable
+	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
+	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
+		atomic.AddInt32(&reopens, 1)
+		return healthy, nil
+	}
+
+	dead := &nativeDoltStorageSpy{
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return nil, errors.New("[mysql] i/o timeout")
+		},
+	}
+	store := newNativeDoltStoreForTest(dead)
+	store.scopeRoot = t.TempDir()
+
+	got, err := store.List(ListQuery{AllowScan: true, TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("List after transient conn error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "gc-2" {
+		t.Fatalf("List = %#v, want [gc-2]", got)
+	}
+	if n := atomic.LoadInt32(&reopens); n == 0 {
+		t.Fatalf("expected a reconnect (nativeDoltOpenBestAvailable call); got %d", n)
+	}
+}
+
+func TestNativeDoltStoreReadDoesNotRetryNonTransientError(t *testing.T) {
+	var reopens int32
+	oldOpen := nativeDoltOpenBestAvailable
+	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
+	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
+		atomic.AddInt32(&reopens, 1)
+		return nil, errors.New("should not be called")
+	}
+
+	permanent := errors.New("syntax error near 'FROM'")
+	storage := &nativeDoltStorageSpy{
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return nil, permanent
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+	store.scopeRoot = t.TempDir()
+
+	if _, err := store.Get("gc-1"); err == nil || !errContains(err, "syntax error") {
+		t.Fatalf("Get error = %v, want the non-transient syntax error", err)
+	}
+	if n := atomic.LoadInt32(&reopens); n != 0 {
+		t.Fatalf("non-transient error must not reconnect; got %d reopens", n)
+	}
+}
+
+func TestNativeDoltStoreReadWithoutScopeRootDoesNotReconnect(t *testing.T) {
+	var reopens int32
+	oldOpen := nativeDoltOpenBestAvailable
+	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
+	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
+		atomic.AddInt32(&reopens, 1)
+		return nil, errors.New("should not be called")
+	}
+
+	dead := &nativeDoltStorageSpy{
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return nil, errors.New("invalid connection")
+		},
+	}
+	store := newNativeDoltStoreForTest(dead) // scopeRoot empty -> reconnect disabled
+
+	if _, err := store.Get("gc-1"); err == nil || !errContains(err, "invalid connection") {
+		t.Fatalf("Get error = %v, want the transient error returned as-is (fail fast)", err)
+	}
+	if n := atomic.LoadInt32(&reopens); n != 0 {
+		t.Fatalf("a store without a captured scopeRoot must not reconnect; got %d reopens", n)
+	}
+}
+
+func TestIsNativeDoltTransientReadError(t *testing.T) {
+	transient := []string{
+		"begin read tx: invalid connection",
+		"[mysql] i/o timeout",
+		"dial tcp 127.0.0.1:3307: connect: connection refused",
+		"write: broken pipe",
+		"unexpected EOF",
+		"use of closed network connection",
+		"bad connection",
+		"read: connection reset by peer",
+	}
+	for _, msg := range transient {
+		if !isNativeDoltTransientReadError(errors.New(msg)) {
+			t.Errorf("isNativeDoltTransientReadError(%q) = false, want true", msg)
+		}
+	}
+	permanent := []string{
+		"issue gc-1 not found",
+		"syntax error",
+		"no rows in result set",
+	}
+	for _, msg := range permanent {
+		if isNativeDoltTransientReadError(errors.New(msg)) {
+			t.Errorf("isNativeDoltTransientReadError(%q) = true, want false", msg)
+		}
+	}
+	if isNativeDoltTransientReadError(nil) {
+		t.Errorf("isNativeDoltTransientReadError(nil) = true, want false")
+	}
+}
+
+func errContains(err error, sub string) bool {
+	return err != nil && strings.Contains(err.Error(), sub)
+}

--- a/internal/beads/native_dolt_store_reconnect_test.go
+++ b/internal/beads/native_dolt_store_reconnect_test.go
@@ -10,11 +10,11 @@ import (
 	beadslib "github.com/steveyegge/beads"
 )
 
-// transientThenHealthyStorage helpers build a NativeDoltStore whose initial
-// handle fails every read with a transient connection error, plus a healthy
-// replacement handed back by the overridden open. Together they exercise the
-// read-path reconnect: attempt 1 fails transient -> reconnect swaps the dead
-// handle for the healthy one -> attempt 2 succeeds.
+// These tests exercise the native read-path reconnect: a read against the
+// initial (dead) handle fails with a transient connection error, the injected
+// reopen hook hands back a fresh (healthy) handle, and the retry succeeds. The
+// reopen hook stands in for the store factory's real hook, which re-resolves the
+// current managed Dolt port and re-opens against the live server.
 
 func healthySearchStorage(issues ...*beadslib.Issue) *nativeDoltStorageSpy {
 	return &nativeDoltStorageSpy{
@@ -24,25 +24,31 @@ func healthySearchStorage(issues ...*beadslib.Issue) *nativeDoltStorageSpy {
 	}
 }
 
+func deadSearchStorage(err error) *nativeDoltStorageSpy {
+	return &nativeDoltStorageSpy{
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return nil, err
+		},
+	}
+}
+
+// storeWithReopen builds a test NativeDoltStore starting on dead and swapping to
+// fresh via the reopen hook; reopens counts hook invocations.
+func storeWithReopen(dead beadslib.Storage, fresh beadslib.Storage, reopens *int32) *NativeDoltStore {
+	store := newNativeDoltStoreForTest(dead)
+	store.reopen = func(context.Context) (beadslib.Storage, error) {
+		atomic.AddInt32(reopens, 1)
+		return fresh, nil
+	}
+	return store
+}
+
 func TestNativeDoltStoreGetReconnectsAfterTransientConnError(t *testing.T) {
 	healthy := healthySearchStorage(&beadslib.Issue{
 		ID: "gc-1", Title: "recovered", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2,
 	})
 	var reopens int32
-	oldOpen := nativeDoltOpenBestAvailable
-	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
-	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
-		atomic.AddInt32(&reopens, 1)
-		return healthy, nil
-	}
-
-	dead := &nativeDoltStorageSpy{
-		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
-			return nil, errors.New("begin read tx: invalid connection")
-		},
-	}
-	store := newNativeDoltStoreForTest(dead)
-	store.scopeRoot = t.TempDir() // enable reconnect
+	store := storeWithReopen(deadSearchStorage(errors.New("begin read tx: dial tcp 127.0.0.1:58216: i/o timeout")), healthy, &reopens)
 
 	got, err := store.Get("gc-1")
 	if err != nil {
@@ -52,7 +58,7 @@ func TestNativeDoltStoreGetReconnectsAfterTransientConnError(t *testing.T) {
 		t.Fatalf("Get.ID = %q, want gc-1", got.ID)
 	}
 	if n := atomic.LoadInt32(&reopens); n == 0 {
-		t.Fatalf("expected a reconnect (nativeDoltOpenBestAvailable call); got %d", n)
+		t.Fatalf("expected the reopen hook to fire; got %d", n)
 	}
 }
 
@@ -61,20 +67,7 @@ func TestNativeDoltStoreListReconnectsAfterTransientConnError(t *testing.T) {
 		ID: "gc-2", Title: "recovered list", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2,
 	})
 	var reopens int32
-	oldOpen := nativeDoltOpenBestAvailable
-	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
-	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
-		atomic.AddInt32(&reopens, 1)
-		return healthy, nil
-	}
-
-	dead := &nativeDoltStorageSpy{
-		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
-			return nil, errors.New("[mysql] i/o timeout")
-		},
-	}
-	store := newNativeDoltStoreForTest(dead)
-	store.scopeRoot = t.TempDir()
+	store := storeWithReopen(deadSearchStorage(errors.New("[mysql] i/o timeout")), healthy, &reopens)
 
 	got, err := store.List(ListQuery{AllowScan: true, TierMode: TierBoth})
 	if err != nil {
@@ -84,27 +77,13 @@ func TestNativeDoltStoreListReconnectsAfterTransientConnError(t *testing.T) {
 		t.Fatalf("List = %#v, want [gc-2]", got)
 	}
 	if n := atomic.LoadInt32(&reopens); n == 0 {
-		t.Fatalf("expected a reconnect (nativeDoltOpenBestAvailable call); got %d", n)
+		t.Fatalf("expected the reopen hook to fire; got %d", n)
 	}
 }
 
 func TestNativeDoltStoreReadDoesNotRetryNonTransientError(t *testing.T) {
 	var reopens int32
-	oldOpen := nativeDoltOpenBestAvailable
-	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
-	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
-		atomic.AddInt32(&reopens, 1)
-		return nil, errors.New("should not be called")
-	}
-
-	permanent := errors.New("syntax error near 'FROM'")
-	storage := &nativeDoltStorageSpy{
-		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
-			return nil, permanent
-		},
-	}
-	store := newNativeDoltStoreForTest(storage)
-	store.scopeRoot = t.TempDir()
+	store := storeWithReopen(deadSearchStorage(errors.New("syntax error near 'FROM'")), healthySearchStorage(), &reopens)
 
 	if _, err := store.Get("gc-1"); err == nil || !errContains(err, "syntax error") {
 		t.Fatalf("Get error = %v, want the non-transient syntax error", err)
@@ -114,27 +93,26 @@ func TestNativeDoltStoreReadDoesNotRetryNonTransientError(t *testing.T) {
 	}
 }
 
-func TestNativeDoltStoreReadWithoutScopeRootDoesNotReconnect(t *testing.T) {
-	var reopens int32
-	oldOpen := nativeDoltOpenBestAvailable
-	t.Cleanup(func() { nativeDoltOpenBestAvailable = oldOpen })
-	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
-		atomic.AddInt32(&reopens, 1)
-		return nil, errors.New("should not be called")
-	}
-
-	dead := &nativeDoltStorageSpy{
-		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
-			return nil, errors.New("invalid connection")
-		},
-	}
-	store := newNativeDoltStoreForTest(dead) // scopeRoot empty -> reconnect disabled
+func TestNativeDoltStoreReadWithoutReopenHookDoesNotReconnect(t *testing.T) {
+	// No reopen hook injected -> reconnect disabled, transient error returns as-is.
+	store := newNativeDoltStoreForTest(deadSearchStorage(errors.New("invalid connection")))
 
 	if _, err := store.Get("gc-1"); err == nil || !errContains(err, "invalid connection") {
 		t.Fatalf("Get error = %v, want the transient error returned as-is (fail fast)", err)
 	}
-	if n := atomic.LoadInt32(&reopens); n != 0 {
-		t.Fatalf("a store without a captured scopeRoot must not reconnect; got %d reopens", n)
+}
+
+func TestNativeDoltStoreReconnectReopenErrorIsTerminalWhenNonTransient(t *testing.T) {
+	store := newNativeDoltStoreForTest(deadSearchStorage(errors.New("invalid connection")))
+	store.reopen = func(context.Context) (beadslib.Storage, error) {
+		return nil, errors.New("permission denied resolving managed dolt port")
+	}
+	_, err := store.Get("gc-1")
+	if err == nil || !errContains(err, "reconnect after transient read error") {
+		t.Fatalf("Get error = %v, want a wrapped reconnect failure", err)
+	}
+	if !errContains(err, "permission denied") {
+		t.Fatalf("Get error = %v, want the reopen cause preserved", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`NativeDoltStore` (the native provider store `factory.go` prefers when native preflight passes — the CI provider-store path) held a **single long-lived `beadslib.Storage` handle with no recovery**, and didn't even capture `scopeRoot`/`env` to reconnect. After a managed-Dolt `:3307` hard-kill and port **rebind**, every read surfaced `begin read tx: invalid connection` (~40–56s of mysql i/o timeouts) and never recovered.

`#4188` hardened the **bd-CLI** read path (`runBDTransientRead`) but not this native path, so the provider-store lifecycle tests were deterministically red on the native cmd/gc process shards:

- `TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind` (primary: `providerStore.Get` after the hard-kill/rebind)
- `TestManagedBdRigStoreConsistentAcrossRawBdGcBdAndProviderStore`
- `TestManagedBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore`
- `TestManagedBdCityStoreConsistentAcrossRawBdGcBdAndProviderStore`
- `TestInheritedExternalBdRigStoreConsistentAcrossRawBdGcBdAndProviderStore`

## Fix

Deadline-bounded (**90s** budget, comfortably over the rebind window) **reconnect-and-retry** on the native **read** path — `Get`, `List`, `Ready`, `DepList` route through `withReadRetry`. On a transient connection error the store **re-opens** the managed Dolt connection (`openAndRepairNativeStorage` re-runs the managed auto-start, which rebinds Dolt to a fresh port) and retries against the fresh handle.

- Reconnect is **single-flight** across concurrent readers via a generation guard.
- The store now captures `scopeRoot`/`openEnv` at open; an empty `scopeRoot` (test handle) preserves the prior fail-fast behavior.
- Non-transient errors (`ErrNotFound`, decode failures) return immediately — no false retry.
- The transient classifier extends the bd connection-error set with `dial tcp` / `unexpected EOF` / `use of closed network connection`.

### Write path

Left unchanged (matching `#4188`'s read scope). The one hard-kill test does `Get` **before** `Create`, so the read reconnect restores the shared handle for the subsequent write. The other four set `GC_DOLT_PORT` but do **not** kill the server, so the existing native handle stays valid (their cross-visibility assertions prove they share one server) and `Create` works without retry. A connection-error-only `Create` reconnect can be a targeted follow-up if any sibling stays red.

## Validation

- New deterministic unit tests: `Get`/`List` reconnect+retry, non-transient no-retry, no-`scopeRoot` fail-fast, and the transient classifier.
- `go test ./internal/beads/` green; `go vet` clean; `-race` on the reconnect tests clean; gofmt clean.
- All 5 named integration tests pass locally with `GC_FAST_UNIT=0` (154s). (Local resolves the provider store to the `BdStore` fallback, so the unit tests are the authoritative native-path proof.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)