### PR TITLE
Route built-in pack bead commands through gc bd

### DIFF
--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -863,11 +863,17 @@ func TestFormulaFilesystemSearchGuidanceCoversPromptSources(t *testing.T) {
 				"`find ~`",
 				"`find /Users`",
 				"`find $HOME`",
-				"`gc` / `bd`",
 			} {
 				if !strings.Contains(text, want) {
 					t.Fatalf("%s missing %q", rel, want)
 				}
+			}
+			commandGuidance := "`gc` / `bd`"
+			if strings.Contains(rel, "packs/core/assets/prompts") {
+				commandGuidance = "`gc` introspection command"
+			}
+			if !strings.Contains(text, commandGuidance) {
+				t.Fatalf("%s missing %q", rel, commandGuidance)
 			}
 		})
 	}

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2286,7 +2286,7 @@ func TestMaintenanceDoltScriptsUseManagedRuntimePorts(t *testing.T) {
 				wantPort := fb.setup(t, cityDir)
 
 				writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-				writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+				writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 exit 0
 `)
 
@@ -2417,7 +2417,7 @@ exit 1
 				writeManagedRuntimeState(t, cityDir, listener.Addr().(*net.TCPAddr).Port)
 
 				writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-				writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+				writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 exit 0
 `)
 				writeExecutable(t, filepath.Join(binDir, "lsof"), tc.lsofBody)
@@ -2552,7 +2552,7 @@ exit 1
 				writeManagedRuntimeStateWithPID(t, cityDir, listener.Addr().(*net.TCPAddr).Port, 424242)
 
 				writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-				writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+				writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 exit 0
 `)
 				writeExecutable(t, filepath.Join(binDir, "lsof"), tc.lsofBody)
@@ -2644,7 +2644,7 @@ func TestMaintenanceDoltScriptsParseManagedRuntimeStateWithPortableSed(t *testin
 			writeManagedRuntimeState(t, cityDir, listener.Addr().(*net.TCPAddr).Port)
 
 			writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+			writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 exit 0
 `)
 			writeExecutable(t, filepath.Join(binDir, "sed"), fmt.Sprintf(`#!/bin/sh
@@ -2762,7 +2762,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -2840,7 +2840,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -2912,7 +2912,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -2981,7 +2981,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3025,7 +3025,7 @@ func TestReaperMailWispsSummaryFieldAlwaysPresent(t *testing.T) {
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3111,7 +3111,7 @@ func TestMaintenanceDoltScriptsSkipTestPatternDatabases(t *testing.T) {
 			gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 			writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+			writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3211,7 +3211,7 @@ case "$*" in
 esac
 exit 0
 `)
-			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+			writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3358,7 +3358,7 @@ func TestReaperSQLReflectsCurrentSchema(t *testing.T) {
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3455,7 +3455,7 @@ func TestReaperSkipsDependencyQueriesWithoutGenericDependencyTargets(t *testing.
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3506,7 +3506,7 @@ func TestReaperSkipsDependencyQueriesWithoutWispDependencyTable(t *testing.T) {
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3555,7 +3555,7 @@ func TestReaperSplitSchemaQueriesUseSplitColumns(t *testing.T) {
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3631,7 +3631,7 @@ func TestReaperPrunesClosedSessionBeadsWithBdPrune(t *testing.T) {
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
 	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3676,6 +3676,10 @@ exit 0
 	if err != nil {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
+	wantRoute := "bd --city " + canonicalCityDir + " prune --pattern gm-* --older-than 720h --force --json"
+	if !strings.Contains(string(gcData), wantRoute) {
+		t.Fatalf("reaper did not route session pruning through the explicit city scope %q:\n%s", wantRoute, gcData)
+	}
 	if !strings.Contains(string(gcData), "sessions-pruned:7") {
 		t.Fatalf("reaper summary did not report pruned sessions:\n%s", gcData)
 	}
@@ -3694,7 +3698,7 @@ func TestReaperPrunesTerminalSessionStatesWithGcSessionPrune(t *testing.T) {
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
 	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 case "$*" in
   "session prune --state drained --before 24h --json")
@@ -3744,7 +3748,7 @@ func TestReaperSessionStatePruneFailureEscalates(t *testing.T) {
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
 	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 case "$*" in
   "session prune --state drained --before 24h --json")
@@ -3798,7 +3802,7 @@ func TestReaperSessionPruneDryRunOmitsForce(t *testing.T) {
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
 	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3858,7 +3862,7 @@ func TestReaperSessionPruneAnomalyEscalates(t *testing.T) {
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
 	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3904,7 +3908,7 @@ func TestReaperSessionPruneMissingBdDegradesToZero(t *testing.T) {
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -3955,7 +3959,7 @@ esac
 exit 0
 `)
 	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4044,7 +4048,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4119,7 +4123,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4191,7 +4195,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4266,7 +4270,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4344,7 +4348,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4424,7 +4428,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4574,7 +4578,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4723,7 +4727,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4818,7 +4822,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4894,7 +4898,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -4965,7 +4969,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5033,7 +5037,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5114,7 +5118,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5196,7 +5200,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5265,7 +5269,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5354,7 +5358,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5448,7 +5452,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5527,7 +5531,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5632,7 +5636,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5703,7 +5707,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5789,7 +5793,7 @@ exit 0
 printf 'pwd=%s beads=%s args=%s\n' "$PWD" "${BEADS_DIR:-}" "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5826,6 +5830,14 @@ exit 0
 	}
 	if strings.Contains(bdLogText, "beads="+ambientBeadsDir) {
 		t.Fatalf("reaper used ambient BEADS_DIR for city auto-close:\n%s", bdLogText)
+	}
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	wantRoute := "bd --city " + canonicalCityDir + " close ga-city --reason stale:auto-closed by reaper"
+	if !strings.Contains(string(gcData), wantRoute) {
+		t.Fatalf("reaper did not route issue close through the explicit city scope %q:\n%s", wantRoute, gcData)
 	}
 }
 
@@ -5865,7 +5877,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -5949,7 +5961,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6026,7 +6038,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6106,7 +6118,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6179,7 +6191,7 @@ exit 0
 printf '%s\n' "$*" >> "$BD_CALL_LOG"
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6254,7 +6266,7 @@ case "$*" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6426,7 +6438,7 @@ func TestMaintenanceDoltScriptsSkipDatabasesWithoutWispsTable(t *testing.T) {
 			gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 			writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+			writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6524,7 +6536,7 @@ case "$1" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6579,7 +6591,7 @@ case "$1" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -6639,7 +6651,7 @@ case "$1" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 exit 0
 `)
 
@@ -6700,7 +6712,7 @@ case "$1" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 exit 0
 `)
 
@@ -6767,7 +6779,7 @@ case "$1" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 exit 0
 `)
 
@@ -6820,7 +6832,7 @@ func runReaperCloseFixture(t *testing.T, fixture string) (doltLog string, gcLog 
 	gcLog = filepath.Join(t.TempDir(), "gc.log")
 
 	writeReaperCloseFixtureDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
@@ -7042,6 +7054,32 @@ case "$1" in
 esac
 exit 0
 `)
+}
+
+// writeMaintenanceGCStub installs a gc test double whose gc-bd branch
+// conforms to the wrapper boundary used by the shipped maintenance scripts.
+// The caller-provided body continues to define every non-bd command.
+func writeMaintenanceGCStub(t *testing.T, path, body string) {
+	t.Helper()
+	const shebang = "#!/bin/sh\n"
+	if !strings.HasPrefix(body, shebang) {
+		t.Fatalf("gc stub must start with %q", strings.TrimSpace(shebang))
+	}
+	const gcBDRoute = `if [ "${1:-}" = "bd" ]; then
+  if [ -n "${GC_CALL_LOG:-}" ]; then
+    printf '%s\n' "$*" >> "$GC_CALL_LOG"
+  fi
+  shift
+  if [ "${1:-}" = "--city" ]; then
+    city="$2"
+    shift 2
+    cd "$city" || exit 1
+    export BEADS_DIR="$city/.beads"
+  fi
+  exec bd "$@"
+fi
+`
+	writeExecutable(t, path, shebang+gcBDRoute+strings.TrimPrefix(body, shebang))
 }
 
 func mergeTestEnv(overrides map[string]string) []string {
@@ -9981,6 +10019,7 @@ func gateSweepEnv(t *testing.T) (binDir, bdLog string, env map[string]string) {
 	t.Helper()
 	binDir = t.TempDir()
 	bdLog = filepath.Join(t.TempDir(), "bd.log")
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
 	env = map[string]string{
 		"BD_LOG":       bdLog,
 		"GC_CITY":      t.TempDir(),
@@ -10358,6 +10397,7 @@ EOF
     ;;
 esac
 `, beadsJSON))
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
 
 	env = map[string]string{
 		"BD_LOG":       bdLog,
@@ -10592,6 +10632,7 @@ EOF
     ;;
 esac
 `, closedJSON, depsJSON))
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
 
 	env = map[string]string{
 		"BD_LOG":       bdLog,
@@ -10707,6 +10748,7 @@ JSON
 esac
 exit 0
 `, beadsJSON))
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
 
 	env := map[string]string{
 		"BD_LOG":       bdLog,
@@ -10759,6 +10801,7 @@ JSON
 esac
 exit 0
 `, beadsJSON))
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
 
 	writeExecutable(t, filepath.Join(binDir, "date"), fmt.Sprintf(`#!/bin/sh
 printf '%%s\n' "$*" >> "$DATE_LOG"
@@ -10866,6 +10909,7 @@ JSON
 esac
 exit 0
 `, closedJSON, depsForClosed1, depsForClosed2, depsForClosedInternal))
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
 
 	env := map[string]string{
 		"BD_LOG":       bdLog,

--- a/internal/bootstrap/packs/core/README.md
+++ b/internal/bootstrap/packs/core/README.md
@@ -68,7 +68,7 @@ older than the retention window are pruned on each run.
 
 ## `cascade-nudge-on-blocker-close`
 
-**Why.** When a blocker bead closes (linked via `bd dep <dependent> --blocks
+**Why.** When a blocker bead closes (linked via `gc bd dep <dependent> --blocks
 <blocker>`), the assignee of each dependent has no event-driven signal that
 work can resume — they poll, get nudged by hand, or miss the unblock. This
 order removes that class of "the blocker closed but my agent didn't notice"
@@ -112,6 +112,7 @@ Entries older than the retention window are pruned on each run.
 
 ## Dependencies
 
-Both nudge scripts use only `bd`, `gc`, and `jq` — already required by the
-other core-pack scripts. `jq` is a hard dependency and the scripts fail
-loud at startup if it is missing.
+Both nudge scripts use only `gc`, `bd`, and `jq` — already required by the
+other core-pack scripts. `gc bd` routes the request, then delegates to the
+underlying `bd` binary. `jq` is a hard dependency and the scripts fail loud
+at startup if it is missing.

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -7,7 +7,7 @@ Your agent name is `$GC_AGENT`. Your session name is `$GC_SESSION_NAME`.
 
 ## Core Rule
 
-You work individual ready beads. Do NOT use `bd mol current`. Do NOT assume a
+You work individual ready beads. Do NOT use `gc bd mol current`. Do NOT assume a
 single parent bead describes the whole workflow. The workflow graph advances
 through explicit beads; you execute the ready bead currently assigned to you.
 
@@ -25,15 +25,15 @@ are done. If the result action is `work`, use `bead_id` as the work bead.
 ## How To Work
 
 1. Find your assigned bead (see Startup above).
-2. Read it with `bd show <id>`.
+2. Read it with `gc bd show <id>`.
 3. Execute exactly that bead's description.
 4. On success, close it:
    ```bash
-   bd update <id> --set-metadata gc.outcome=pass --status closed
+   gc bd update <id> --set-metadata gc.outcome=pass --status closed
    ```
 5. On transient failure, mark it transient and close it:
    ```bash
-   bd update <id> \
+   gc bd update <id> \
      --set-metadata gc.outcome=fail \
      --set-metadata gc.failure_class=transient \
      --set-metadata gc.failure_reason=<short_reason> \
@@ -41,7 +41,7 @@ are done. If the result action is `work`, use `bead_id` as the work bead.
    ```
 6. On unrecoverable failure, mark it hard-failed and close it:
    ```bash
-   bd update <id> \
+   gc bd update <id> \
      --set-metadata gc.outcome=fail \
      --set-metadata gc.failure_class=hard \
      --set-metadata gc.failure_reason=<short_reason> \
@@ -58,7 +58,7 @@ traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
 TCC-protected directories on macOS — Documents, Desktop, Downloads,
 removable volumes — and trigger permission prompts that block work. If
 you don't know how to locate a formula, recipe, bead, mail, or Dolt
-state, the answer is a `gc` / `bd` introspection command, not a
+state, the answer is a `gc` introspection command, not a
 filesystem search. If no command exists for what you need, file a bead.
 
 ## Continuation Group — Session Affinity

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -20,7 +20,7 @@ gc hook --claim --drain-ack --json
 ```
 
 If the result action is `drain`, your session is done. If the action is `work`,
-read the returned `bead_id` with `bd show <id>`.
+read the returned `bead_id` with `gc bd show <id>`.
 
 ## Following Your Formula
 
@@ -39,16 +39,16 @@ traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
 TCC-protected directories on macOS — Documents, Desktop, Downloads,
 removable volumes — and trigger permission prompts that block work. If
 you don't know how to locate a formula, recipe, bead, mail, or Dolt
-state, the answer is a `gc` / `bd` introspection command, not a
+state, the answer is a `gc` introspection command, not a
 filesystem search. If no command exists for what you need, file a bead.
 
 ## Molecules — STOP, check BEFORE you start working
 
-**CRITICAL:** When you run `bd show` in step 4, look at the METADATA
+**CRITICAL:** When you run `gc bd show` in step 4, look at the METADATA
 section. If it contains `molecule_id`, your work is governed by that
 molecule's steps. Do NOT just read the description and start coding.
 
-Run `bd mol current <molecule-id>` to see your steps:
+Run `gc bd mol current <molecule-id>` to see your steps:
 
 - `[done]` — step is complete
 - `[current]` — step is in progress (you are here)
@@ -56,10 +56,10 @@ Run `bd mol current <molecule-id>` to see your steps:
 - `[blocked]` — step is waiting on dependencies
 
 **Work one step at a time.** For each `[ready]` step:
-1. `bd show <step-id>` — read what to do
+1. `gc bd show <step-id>` — read what to do
 2. Do the work described in that step
-3. `bd close <step-id>` — mark it done
-4. `bd mol current <molecule-id>` — check your position, repeat
+3. `gc bd close <step-id>` — mark it done
+4. `gc bd mol current <molecule-id>` — check your position, repeat
 
 Do NOT read the parent bead description and do everything at once.
 Do NOT skip steps. Do NOT close steps you didn't execute.
@@ -70,10 +70,10 @@ the bead description directly.
 ## Your Tools
 
 - `gc hook --claim --json` — find and atomically claim work
-- `bd show <id>` — see details of a work item or step
-- `bd mol current <molecule-id>` — show position in molecule workflow
-- `bd mol progress <molecule-id>` — show molecule progress summary
-- `bd close <id>` — mark work or a step as done
+- `gc bd show <id>` — see details of a work item or step
+- `gc bd mol current <molecule-id>` — show position in molecule workflow
+- `gc bd mol progress <molecule-id>` — show molecule progress summary
+- `gc bd close <id>` — mark work or a step as done
 - `gc mail inbox` — check for messages
 - `gc runtime drain-ack` — end your session (you are ephemeral)
 
@@ -81,10 +81,10 @@ the bead description directly.
 
 1. Find and claim work: `gc hook --claim --drain-ack --json`
 2. If the action is `drain`, exit. If the action is `work`, read `bead_id`.
-3. **Check for molecule:** `bd show <id>` — look for `molecule_id` in METADATA
-4. **If molecule exists:** `bd mol current <mol-id>` → work each step in order (show → do → close → repeat)
+3. **Check for molecule:** `gc bd show <id>` — look for `molecule_id` in METADATA
+4. **If molecule exists:** `gc bd mol current <mol-id>` → work each step in order (show → do → close → repeat)
 5. **If no molecule:** execute the work directly from the bead description
-6. When all work is done, close the bead: `bd close <id>`
+6. When all work is done, close the bead: `gc bd close <id>`
 7. **MANDATORY — run this exact command as your final action:**
    ```bash
    gc runtime drain-ack

--- a/internal/bootstrap/packs/core/assets/scripts/_bd_trace.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/_bd_trace.sh
@@ -1,21 +1,21 @@
 #!/bin/sh
-# _bd_trace.sh — shell-side bd call trace helper.
+# _bd_trace.sh — shell-side bead call trace helper.
 #
 # Sourced by gas city application scripts (maintenance pack scripts, tmux
-# status-line). Overrides `bd` and `gc bd` in the calling shell so each
-# invocation appends a JSONL record to $GC_BD_TRACE_JSON. When $GC_BD_TRACE_JSON is
-# unset, calls pass through with no logging overhead.
+# status-line). Overrides `gc` in the calling shell so each `gc bd` invocation
+# appends a JSONL record to $GC_BD_TRACE_JSON. When $GC_BD_TRACE_JSON is unset,
+# calls pass through with no logging overhead.
 #
 # Source with a source tag identifying the calling script:
 #
 #   . "$(dirname "$0")/_bd_trace.sh" "gate-sweep"
 #
-# Then call `bd ...` and `gc ...` normally — calls are traced.
+# Then call `gc bd ...` normally — calls are traced.
 
 __bd_trace_source="${1:-unknown}"
 
 __bd_trace_emit() {
-    # $1 = command name (bd or gc), $2 = exit code, $3 = start_ns, $4..N = args
+    # $1 = command name, $2 = exit code, $3 = start_ns, $4..N = args
     if [ -z "${GC_BD_TRACE_JSON:-}" ]; then
         return 0
     fi
@@ -44,14 +44,6 @@ __bd_trace_emit() {
         "$$" \
         "${PPID:-0}" \
         >> "$GC_BD_TRACE_JSON" 2>/dev/null || true
-}
-
-bd() {
-    __bd_start="$(date +%s%N 2>/dev/null || printf '%s000000000' "$(date +%s)")"
-    command bd "$@"
-    __bd_exit=$?
-    __bd_trace_emit bd "$__bd_exit" "$__bd_start" "$@"
-    return "$__bd_exit"
 }
 
 gc() {

--- a/internal/bootstrap/packs/core/assets/scripts/cascade-nudge-on-blocker-close.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/cascade-nudge-on-blocker-close.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # cascade-nudge-on-blocker-close — notify dependents when a blocker closes.
 #
-# When a blocker bead closes (linked via `bd dep <dependent> --blocks
+# When a blocker bead closes (linked via `gc bd dep <dependent> --blocks
 # <blocker>`), the owner of each dependent has no event-driven signal that
 # work can resume: they poll, get nudged by hand, or miss the unblock.
 #

--- a/internal/bootstrap/packs/core/assets/scripts/cross-rig-deps.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/cross-rig-deps.sh
@@ -28,7 +28,7 @@ LOOKBACK="${CROSS_RIG_LOOKBACK:-15m}"
 SINCE=$(date -u -d "-${LOOKBACK%m} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
         date -u -v-"${LOOKBACK%m}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || exit 0
 
-CLOSED=$(bd list --status=closed --closed-after="$SINCE" --json 2>/dev/null) || exit 0
+CLOSED=$(gc bd list --status=closed --closed-after="$SINCE" --json 2>/dev/null) || exit 0
 if [ -z "$CLOSED" ] || [ "$CLOSED" = "[]" ]; then
     exit 0
 fi
@@ -43,7 +43,7 @@ RESOLVED=0
 CLOSED_IDS=$(echo "$CLOSED" | jq -r '.[].id' 2>/dev/null)
 while IFS= read -r closed_id; do
     # Find beads that have a blocks dep on this closed issue.
-    DEPS=$(bd dep list "$closed_id" --direction=up --type=blocks --json 2>/dev/null) || continue
+    DEPS=$(gc bd dep list "$closed_id" --direction=up --type=blocks --json 2>/dev/null) || continue
     if [ -z "$DEPS" ] || [ "$DEPS" = "[]" ]; then
         continue
     fi
@@ -58,8 +58,8 @@ while IFS= read -r closed_id; do
     fi
     while IFS= read -r dep_id; do
         # Convert blocks → related: remove blocking semantics, keep audit trail.
-        bd dep remove "$dep_id" "external:$closed_id" 2>/dev/null || true
-        bd dep add "$dep_id" "external:$closed_id" --type=related 2>/dev/null || true
+        gc bd dep remove "$dep_id" "external:$closed_id" 2>/dev/null || true
+        gc bd dep add "$dep_id" "external:$closed_id" --type=related 2>/dev/null || true
         RESOLVED=$((RESOLVED + 1))
     done <<< "$EXTERNAL_DEPS"
 done <<< "$CLOSED_IDS"

--- a/internal/bootstrap/packs/core/assets/scripts/gate-sweep.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/gate-sweep.sh
@@ -17,7 +17,7 @@
 #
 # Bead-type gates are skipped: in beads v1.0.2, checkBeadGate is
 # hard-coded to fail because cross-rig routing was removed upstream.
-# Restore `bd gate check --type=bead --escalate` when beads adds it back.
+# Restore `gc bd gate check --type=bead --escalate` when beads adds it back.
 set -euo pipefail
 
 # Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
@@ -25,5 +25,5 @@ __SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$__SCRIPT_DIR/_bd_trace.sh" "gate-sweep"
 
-bd gate check --type=timer --escalate
-bd gate check --type=gh --escalate || true
+gc bd gate check --type=timer --escalate
+gc bd gate check --type=gh --escalate || true

--- a/internal/bootstrap/packs/core/assets/scripts/reaper.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/reaper.sh
@@ -2,7 +2,7 @@
 # reaper — close stale wisps with closed parents/roots, purge old closed data, auto-close stale and TTL-expired issues.
 #
 # Core exec order. All operations are deterministic: SQL queries with age
-# thresholds, bd close/update commands, count comparisons against alert
+# thresholds, gc bd close/update commands, count comparisons against alert
 # thresholds.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
@@ -715,9 +715,9 @@ close_city_issue() {
     (
         cd "$CITY_ABS"
         if [ -n "$force" ]; then
-            BEADS_DIR="$CITY_BEADS_DIR" bd close "$issue_id" --force --reason "$reason"
+            gc bd --city "$CITY_ABS" close "$issue_id" --force --reason "$reason"
         else
-            BEADS_DIR="$CITY_BEADS_DIR" bd close "$issue_id" --reason "$reason"
+            gc bd --city "$CITY_ABS" close "$issue_id" --reason "$reason"
         fi
     )
 }
@@ -869,7 +869,7 @@ while IFS= read -r DB; do
     # stamped with gc.root_store_ref for another store are skipped; cross-store
     # subtrees require cross-store traversal before reaping can be safe.
     # Wisp roots can be closed in every bead store. Issue roots are city issues,
-    # so their city-store close path uses bd close below.
+    # so their city-store close path uses gc bd close below.
     get_sql_count "$DB" "workflow wisp roots skipped by root store ref" "$(workflow_root_store_ref_skipped_count_query "$DB" "workflow_wisp_root_candidates" "wisps" "w" "'message'")"
     TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED=$((TOTAL_WORKFLOW_ROOTS_STORE_REF_SKIPPED + SQL_COUNT_RESULT))
 
@@ -1150,7 +1150,7 @@ EOF
 if [ -d "$CITY_BEADS_DIR" ]; then
     SESSION_PRUNE_ATTEMPTED=1
     if [ -n "$SESSION_BEAD_PATTERN" ]; then
-        # ── bd prune path (existing behaviour, now pattern-configurable) ──────
+        # ── gc bd prune path (existing behaviour, now pattern-configurable) ──────
         SESSION_PRUNE_ANOMALY_SCOPE="session"
         case "$SESSION_BEAD_PATTERN" in
             *-*) SESSION_PRUNE_ANOMALY_SCOPE="${SESSION_BEAD_PATTERN%%-*}" ;;
@@ -1158,7 +1158,7 @@ if [ -d "$CITY_BEADS_DIR" ]; then
         BD_PRUNE_ARGS=(prune --pattern "$SESSION_BEAD_PATTERN" --older-than "$SESSION_PURGE_AGE")
         if [ -z "$DRY_RUN" ]; then BD_PRUNE_ARGS+=(--force); fi
         BD_PRUNE_ARGS+=(--json)
-        if PRUNE_JSON=$( ( cd "$CITY_ABS" && BEADS_DIR="$CITY_BEADS_DIR" bd "${BD_PRUNE_ARGS[@]}" ) 2>/dev/null ); then :
+        if PRUNE_JSON=$( ( cd "$CITY_ABS" && gc bd --city "$CITY_ABS" "${BD_PRUNE_ARGS[@]}" ) 2>/dev/null ); then :
         else PRUNE_JSON='{"pruned_count":0}'; fi
         PRUNE_COUNT=$(printf '%s' "$PRUNE_JSON" | sed -n 's/.*"pruned_count"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)
         [ -z "$PRUNE_COUNT" ] && PRUNE_COUNT=0

--- a/internal/bootstrap/packs/core/assets/scripts/spawn-storm-detect.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/spawn-storm-detect.sh
@@ -33,7 +33,7 @@ fi
 
 # Step 1: Find beads that were recently reset to pool.
 # Look for open beads that have been updated (recovery resets them to open + unassigned).
-OPEN_BEADS=$(bd list --status=open --assignee="" --json --limit=0 2>/dev/null) || exit 0
+OPEN_BEADS=$(gc bd list --status=open --assignee="" --json --limit=0 2>/dev/null) || exit 0
 if [ -z "$OPEN_BEADS" ] || [ "$OPEN_BEADS" = "[]" ]; then
     exit 0
 fi
@@ -54,7 +54,7 @@ while IFS= read -r bead_id; do
     COUNTS=$(echo "$COUNTS" | jq --arg id "$bead_id" --argjson n "$NEW" '.[$id] = $n')
 
     if [ "$NEW" -ge "$THRESHOLD" ]; then
-        TITLE_JSON=$(bd show "$bead_id" --json 2>/dev/null || true)
+        TITLE_JSON=$(gc bd show "$bead_id" --json 2>/dev/null || true)
         TITLE=$(echo "$TITLE_JSON" | jq -r 'if type == "array" then (.[0].title // "unknown") else "unknown" end' 2>/dev/null || echo "unknown")
         gc mail send mayor/ \
             -s "SPAWN_STORM: bead $bead_id reset ${NEW}x" \
@@ -62,7 +62,7 @@ while IFS= read -r bead_id; do
 This likely indicates a polecat crash loop on this specific work.
 
 Recommended actions:
-- Inspect the bead: bd show $bead_id --json
+- Inspect the bead: gc bd show $bead_id --json
 - Check rejection history: metadata.rejection_reason
 - Consider quarantining the bead or investigating the root cause." \
             2>/dev/null || true
@@ -72,11 +72,11 @@ done <<< "$RESET_IDS"
 
 # Step 4: Prune closed beads from ledger.
 # Only check beads actually tracked in the ledger (avoids expensive full scan
-# of all closed beads via bd list --status=closed --limit=0).
+# of all closed beads via gc bd list --status=closed --limit=0).
 TRACKED_IDS=$(echo "$COUNTS" | jq -r 'keys[]' 2>/dev/null) || true
 while IFS= read -r tid; do
     [ -z "$tid" ] && continue
-    if BEAD_OUTPUT=$(bd show "$tid" --json 2>&1); then
+    if BEAD_OUTPUT=$(gc bd show "$tid" --json 2>&1); then
         BEAD_STATUS=$(echo "$BEAD_OUTPUT" | jq -r 'if type == "array" then (.[0].status // "deleted") elif type == "object" and ((.error // "") | test("not found|no issue found"; "i")) then "deleted" else "unknown" end' 2>/dev/null || echo "unknown")
     elif echo "$BEAD_OUTPUT" | grep -qiE 'not found|no issue found'; then
         BEAD_STATUS="deleted"

--- a/internal/bootstrap/packs/core/assets/scripts/wisp-compact.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/wisp-compact.sh
@@ -24,7 +24,7 @@ __SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CITY="${GC_CITY:-.}"
 
 # Get all ephemeral beads.
-ALL=$(bd list --json --all -n 0 2>/dev/null) || exit 0
+ALL=$(gc bd list --json --all -n 0 2>/dev/null) || exit 0
 EPHEMERALS=$(echo "$ALL" | jq '[.[] | select(.ephemeral == true)]' 2>/dev/null) || exit 0
 
 if [ -z "$EPHEMERALS" ] || [ "$EPHEMERALS" = "[]" ]; then
@@ -80,14 +80,14 @@ while IFS= read -r bead; do
     if [ "$comment_count" -gt 0 ] || echo "$labels" | grep -q '^keep$' || [ "$status" != "closed" ]; then
         REASON="proven value"
         [ "$status" != "closed" ] && REASON="open past TTL (stuck detection)"
-        bd update "$id" --persistent 2>/dev/null || true
-        bd comment "$id" "Promoted from wisp: $REASON" 2>/dev/null || true
+        gc bd update "$id" --persistent 2>/dev/null || true
+        gc bd comment "$id" "Promoted from wisp: $REASON" 2>/dev/null || true
         PROMOTED=$((PROMOTED + 1))
         continue
     fi
 
     # Closed + past TTL + no special attributes → delete.
-    bd delete "$id" --force 2>/dev/null || true
+    gc bd delete "$id" --force 2>/dev/null || true
     DELETED=$((DELETED + 1))
 done <<< "$BEADS"
 

--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -39,7 +39,7 @@ if [ -z "$WORK_BEAD_ID" ]; then
   echo "mol-do-work requires an input convoy with exactly one tracked member" >&2
   exit 1
 fi
-bd show "$WORK_BEAD_ID"
+gc bd show "$WORK_BEAD_ID"
 ```
 
 Read the bead's title and description carefully. This is your task.
@@ -92,7 +92,7 @@ from `gc.work_outcome`.
 COMMIT=$(git rev-parse HEAD 2>/dev/null || true)
 WORK_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 [ "$WORK_BRANCH" = "HEAD" ] && WORK_BRANCH=""   # detached HEAD — no stable branch
-bd update "$WORK_BEAD_ID" \
+gc bd update "$WORK_BEAD_ID" \
   --set-metadata gc.outcome=pass \
   --set-metadata gc.work_outcome=shipped \
   --set-metadata gc.work_commit="$COMMIT" \
@@ -104,7 +104,7 @@ bd update "$WORK_BEAD_ID" \
 
 **No-op** (the bead needed no change — already satisfied / duplicate):
 ```bash
-bd update "$WORK_BEAD_ID" \
+gc bd update "$WORK_BEAD_ID" \
   --set-metadata gc.outcome=pass \
   --set-metadata gc.work_outcome=no-op \
   --status=closed \
@@ -120,7 +120,7 @@ prevents `mol-do-work` wrapper beads from remaining ready after the real work
 is complete.
 ```bash
 if [ -n "${GC_BEAD_ID:-}" ] && [ "$GC_BEAD_ID" != "$WORK_BEAD_ID" ]; then
-  bd update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Target $WORK_BEAD_ID completed. Commit: ${COMMIT:-none}."
+  gc bd update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Target $WORK_BEAD_ID completed. Commit: ${COMMIT:-none}."
 fi
 ```
 
@@ -143,7 +143,7 @@ session:
 
 ```bash
 if [ -n "${GC_BEAD_ID:-}" ]; then
-  bd update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Drain acknowledged."
+  gc bd update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Drain acknowledged."
 fi
 gc runtime drain-ack
 ```

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
@@ -65,7 +65,7 @@ Initialize your session and understand your assignment.
 **1. Prime your environment:**
 ```bash
 gc prime                    # Load role context
-bd prime                    # Load beads context
+gc bd prime                    # Load beads context
 ```
 
 **2. Derive your work bead and check your hook:**
@@ -76,13 +76,13 @@ if [ -z "$WORK_BEAD_ID" ]; then
   echo "mol-polecat-base requires an input convoy with exactly one tracked member" >&2
   exit 1
 fi
-bd list --assignee=$GC_AGENT --status=in_progress
+gc bd list --assignee=$GC_AGENT --status=in_progress
 ```
 
 The work bead is your assigned issue. Read it carefully:
 ```bash
-bd show "$WORK_BEAD_ID"           # Full issue details
-bd show "$WORK_BEAD_ID" --json | jq '.[0].metadata'  # Check for existing metadata
+gc bd show "$WORK_BEAD_ID"           # Full issue details
+gc bd show "$WORK_BEAD_ID" --json | jq '.[0].metadata'  # Check for existing metadata
 ```
 
 **3. Check for rejection (IMPORTANT):**
@@ -160,7 +160,7 @@ FORBIDDEN: Pushing to {{base_branch}}. FORBIDDEN: Fixing pre-existing failures.
 ```bash
 CONVOY_STATUS=$(gc convoy status {{convoy_id}} --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-bd create --title "Pre-existing failure: <description>" --type bug --priority 1
+gc bd create --title "Pre-existing failure: <description>" --type bug --priority 1
 gc mail send <rig>/witness -s "NOTICE: {{base_branch}} has failing pre-flights" \
   -m "Filed: <bead-id>. Proceeding with $WORK_BEAD_ID."
 ```
@@ -229,7 +229,7 @@ Commit types: feat, fix, refactor, perf, test, docs, chore
 
 **Discovered work (outside scope):**
 ```bash
-bd create --title "Found: <description>" --type bug --priority 2
+gc bd create --title "Found: <description>" --type bug --priority 2
 ```
 Do NOT fix unrelated issues in this branch.
 

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
@@ -57,7 +57,7 @@ fi
 
 Check if `metadata.work_dir` already records your worktree path:
 ```bash
-WORKTREE=$(bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+WORKTREE=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 ```
 
 **If worktree path exists in metadata** — reuse it:
@@ -75,7 +75,7 @@ cd "$WORKTREE_PATH"
 ```
 Record immediately so restarts and witness recovery can find it:
 ```bash
-bd update "$WORK_BEAD_ID" --set-metadata work_dir="$WORKTREE_PATH"
+gc bd update "$WORK_BEAD_ID" --set-metadata work_dir="$WORKTREE_PATH"
 ```
 
 **3. Ensure clean working state:**
@@ -138,13 +138,13 @@ done
 WORKTREE_PATH=$(pwd)
 cd ..
 git worktree remove "$WORKTREE_PATH" --force
-bd update "$WORK_BEAD_ID" --unset-metadata work_dir
+gc bd update "$WORK_BEAD_ID" --unset-metadata work_dir
 ```
 
 **4. Close the bead:**
 ```bash
-bd update "$WORK_BEAD_ID" --notes "Committed directly to {{base_branch}}: <brief summary>"
-bd close "$WORK_BEAD_ID"
+gc bd update "$WORK_BEAD_ID" --notes "Committed directly to {{base_branch}}: <brief summary>"
+gc bd close "$WORK_BEAD_ID"
 ```
 
 **5. Signal reconciler and exit.**

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
@@ -55,13 +55,13 @@ if [ -z "$WORK_BEAD_ID" ]; then
   echo "mol-polecat-report requires an input convoy with exactly one tracked member" >&2
   exit 1
 fi
-bd show "$WORK_BEAD_ID"
+gc bd show "$WORK_BEAD_ID"
 ```
 
 **2. Prime environment:**
 ```bash
 gc prime
-bd prime
+gc bd prime
 ```
 
 **Exit criteria:** Scope confirmed as investigation/analysis only."""
@@ -163,12 +163,12 @@ REPORT="$(cat <<'ENDREPORT'
 <unresolved items, caveats>
 ENDREPORT
 )"
-bd update "$WORK_BEAD_ID" --notes "$REPORT"
+gc bd update "$WORK_BEAD_ID" --notes "$REPORT"
 ```
 
 **2. Close the bead:**
 ```bash
-bd close "$WORK_BEAD_ID"
+gc bd close "$WORK_BEAD_ID"
 ```
 
 **3. Signal reconciler and exit.**

--- a/internal/bootstrap/packs/core/formulas/mol-prompt-synth.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-prompt-synth.toml
@@ -68,7 +68,7 @@ if [ -z "$WORK_BEAD_ID" ]; then
   echo "mol-prompt-synth requires an input convoy with exactly one tracked member" >&2
   exit 1
 fi
-bd show "$WORK_BEAD_ID"
+gc bd show "$WORK_BEAD_ID"
 ```
 
 The bead's metadata records the same `synth_role`, `dest_path`, and
@@ -134,8 +134,8 @@ completion signal:
 ```bash
 CONVOY_STATUS=$(gc convoy status {{convoy_id}} --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
-bd update "$WORK_BEAD_ID" --notes "Synthesized: {{dest_path}}"
-bd close "$WORK_BEAD_ID"
+gc bd update "$WORK_BEAD_ID" --notes "Synthesized: {{dest_path}}"
+gc bd close "$WORK_BEAD_ID"
 ```
 
 **4. Drain and exit:**

--- a/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
@@ -50,15 +50,15 @@ metadata before doing anything destructive.
 
 ```bash
 gc prime
-bd prime
+gc bd prime
 CONVOY_STATUS=$(gc convoy status {{convoy_id}} --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
 if [ -z "$WORK_BEAD_ID" ]; then
   echo "mol-scoped-work requires an input convoy with exactly one tracked member" >&2
   exit 1
 fi
-bd show "$WORK_BEAD_ID"
-bd show "$WORK_BEAD_ID" --json | jq '.[0].metadata'
+gc bd show "$WORK_BEAD_ID"
+gc bd show "$WORK_BEAD_ID" --json | jq '.[0].metadata'
 gc mail inbox
 ```
 """
@@ -96,11 +96,11 @@ if [ -z "$WORK_BEAD_ID" ]; then
   echo "mol-scoped-work requires an input convoy with exactly one tracked member" >&2
   exit 1
 fi
-WORKTREE=$(bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+WORKTREE=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORKTREE" ]; then
   WORKTREE_PATH=$(pwd)/worktrees/"$WORK_BEAD_ID"
   git worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
-  bd update "$WORK_BEAD_ID" --set-metadata work_dir="$WORKTREE_PATH"
+  gc bd update "$WORK_BEAD_ID" --set-metadata work_dir="$WORKTREE_PATH"
   WORKTREE="$WORKTREE_PATH"
 fi
 cd "$WORKTREE"
@@ -202,11 +202,11 @@ if [ -z "$WORK_BEAD_ID" ]; then
   echo "mol-scoped-work requires an input convoy with exactly one tracked member" >&2
   exit 1
 fi
-WORKTREE=$(bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
+WORKTREE=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   git worktree remove --force "$WORKTREE" || rm -rf "$WORKTREE"
 fi
-bd update "$WORK_BEAD_ID" --unset-metadata work_dir
+gc bd update "$WORK_BEAD_ID" --unset-metadata work_dir
 ```
 """
 metadata = { "gc.kind" = "cleanup", "gc.scope_ref" = "body", "gc.scope_role" = "teardown" }

--- a/internal/bootstrap/packs/core/orders/reaper.toml
+++ b/internal/bootstrap/packs/core/orders/reaper.toml
@@ -1,5 +1,5 @@
 # Converted from formula+pool to exec. All reaper operations are
-# deterministic: SQL age comparisons, bd close, count thresholds.
+# deterministic: SQL age comparisons, gc bd close, count thresholds.
 # No LLM judgment needed — runs inline in the controller.
 [order]
 description = "Reap stale wisps and purge closed molecules"

--- a/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/copilot-instructions.md
+++ b/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ check for new messages from other agents or the controller.
 Session startup should include the claim protocol for assigned work. When you
 finish your current task or have no active work mid-session, run `gc hook` to
 check for routed work, then claim exactly one returned bead with
-`bd update <id> --claim` before working it.
+`gc bd update <id> --claim` before working it.
 
 `gc hook --inject` is legacy compatibility for older Stop/session-end hook
 files. It exits successfully without checking or claiming work, and fresh
@@ -31,7 +31,7 @@ managed hook installs do not call it.
 - `gc prime` — load/reload agent context
 - `gc mail check --inject` — check for inter-agent messages
 - `gc hook` — check for available routed work
-- `bd update <id> --claim` — claim one bead before working it
-- `bd ready` — list ready beads (tasks)
-- `bd show <id>` — show bead details
-- `bd close <id>` — mark a bead as done
+- `gc bd update <id> --claim` — claim one bead before working it
+- `gc bd ready` — list ready beads (tasks)
+- `gc bd show <id>` — show bead details
+- `gc bd close <id>` — mark a bead as done

--- a/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
+++ b/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
@@ -31,6 +31,6 @@ check for and claim new work from the queue.
 - `gc nudge drain --inject` — drain queued nudges
 - `gc mail check --inject` — check for inter-agent messages
 - `gc hook` — check for and claim available work
-- `bd ready` — list ready beads (add `--include-ephemeral` only in bd 1.0.5+ cities)
-- `bd show <id>` — show bead details
-- `bd close <id>` — mark a bead as done
+- `gc bd ready` — list ready beads (add `--include-ephemeral` only in bd 1.0.5+ cities)
+- `gc bd show <id>` — show bead details
+- `gc bd close <id>` — mark a bead as done

--- a/internal/bootstrap/packs/core/pack_assets_test.go
+++ b/internal/bootstrap/packs/core/pack_assets_test.go
@@ -1,12 +1,125 @@
 package core
 
 import (
+	"bytes"
 	"io/fs"
 	"reflect"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
 )
+
+var (
+	bareBDSubcommand       = regexp.MustCompile(`\bbd[[:space:]\\]+(?:blocked|children|close|comment|comments|completion|config|count|create|delete|dep|doctor|dolt|epic|export|formula|gate|graph|help|hook|hooks|import|info|init|label|list|migrate|mol|orphans|prime|prune|ready|remember|rename-prefix|reopen|restore|search|show|sql|stale|stats|status|sync|update|version|where|worktree)\b`)
+	bareBDDynamicArg       = regexp.MustCompile(`\bbd[[:space:]\\]+["']\$(?:\{)?[A-Za-z_]`)
+	bareBDLeadingFlag      = regexp.MustCompile(`\bbd[[:space:]\\]+--[A-Za-z0-9]`)
+	bareBDCommand          = regexp.MustCompile(`\bcommand[[:space:]]+bd\b`)
+	bareBDSerializedArgv   = regexp.MustCompile(`["']bd["'][[:space:]]*,`)
+	bareBDSerializedScalar = regexp.MustCompile(`\b(?:command|cmd|executable)[ \t]*[:=][ \t]*["']?bd["']?(?:[ \t]|$)`)
+	bareBDYAMLArgv         = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+bd[ \t]*(?:\r?\n)[ \t]*-[ \t]+[A-Za-z]`)
+	gcImmediatelyBefore    = regexp.MustCompile(`(?:^|[^A-Za-z0-9_-])gc(?:[ \t]+--(?:city|rig)(?:=[^ \t\r\n]+|[ \t]+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^ \t\r\n]+)))*(?:[ \t]|\\\r?\n)+$`)
+	gcSerializedBefore     = regexp.MustCompile(`["']gc["'][[:space:]]*,(?:(?:[[:space:]]*["']--(?:city|rig)=[^"']+["'][[:space:]]*,)|(?:[[:space:]]*["']--(?:city|rig)["'][[:space:]]*,[[:space:]]*["'][^"']+["'][[:space:]]*,))*[[:space:]]*$`)
+)
+
+func findBareBDCommands(data []byte) []int {
+	body := string(data)
+	offsets := make(map[int]struct{})
+
+	for _, pattern := range []*regexp.Regexp{bareBDSubcommand, bareBDDynamicArg, bareBDLeadingFlag} {
+		for _, match := range pattern.FindAllStringIndex(body, -1) {
+			if gcImmediatelyBefore.MatchString(body[:match[0]]) {
+				continue
+			}
+			offsets[match[0]] = struct{}{}
+		}
+	}
+	for _, match := range bareBDSerializedArgv.FindAllStringIndex(body, -1) {
+		if gcSerializedBefore.MatchString(body[:match[0]]) {
+			continue
+		}
+		offsets[match[0]] = struct{}{}
+	}
+	for _, pattern := range []*regexp.Regexp{bareBDCommand, bareBDSerializedScalar, bareBDYAMLArgv} {
+		for _, match := range pattern.FindAllStringIndex(body, -1) {
+			offsets[match[0]] = struct{}{}
+		}
+	}
+
+	result := make([]int, 0, len(offsets))
+	for offset := range offsets {
+		result = append(result, offset)
+	}
+	sort.Ints(result)
+	return result
+}
+
+func TestCoreShippedAssetsRouteBDCommandsThroughGC(t *testing.T) {
+	err := fs.WalkDir(PackFS, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		data, err := fs.ReadFile(PackFS, path)
+		if err != nil {
+			return err
+		}
+		for _, offset := range findBareBDCommands(data) {
+			lineNumber := bytes.Count(data[:offset], []byte{'\n'}) + 1
+			lineStart := bytes.LastIndexByte(data[:offset], '\n') + 1
+			lineEnd := bytes.IndexByte(data[offset:], '\n')
+			if lineEnd < 0 {
+				lineEnd = len(data)
+			} else {
+				lineEnd += offset
+			}
+			t.Errorf("%s:%d: shipped bd commands must route through gc bd: %s", path, lineNumber, strings.TrimSpace(string(data[lineStart:lineEnd])))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking embedded core pack: %v", err)
+	}
+}
+
+func TestFindBareBDCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "plain shell", body: `bd show ga-123`, want: 1},
+		{name: "wrapped shell", body: "bd \\\n  show ga-123", want: 1},
+		{name: "wrapped markdown", body: "`bd\nshow ga-123`", want: 1},
+		{name: "serialized argv", body: "[\"bd\",\n \"future-command\", \"ga-123\"]", want: 1},
+		{name: "dir-scoped command", body: `bd --dir /tmp/rig show ga-123`, want: 1},
+		{name: "leading passthrough flag", body: `bd --no-daemon list`, want: 1},
+		{name: "unknown leading passthrough flag", body: `bd --future-routing-bypass list`, want: 1},
+		{name: "dynamic subcommand", body: `bd "$verb"`, want: 1},
+		{name: "wrapped gc command", body: "gc bd \\\n  show ga-123"},
+		{name: "plain gc command", body: `gc bd show ga-123`},
+		{name: "explicit gc city", body: `gc --city /tmp/city bd show ga-123`},
+		{name: "quoted explicit gc city", body: `gc --city "$CITY" bd list`},
+		{name: "explicit gc rig", body: `gc --rig frontend bd list`},
+		{name: "explicit gc city and rig", body: `gc --city /tmp/city --rig frontend bd list`},
+		{name: "serialized gc argv", body: `["gc", "bd", "show", "ga-123"]`},
+		{name: "serialized scoped gc argv", body: `["gc", "--city", "/x", "--rig", "r", "bd", "show"]`},
+		{name: "binary prose", body: `the bd CLI reads a bd-managed store`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := len(findBareBDCommands([]byte(tt.body))); got != tt.want {
+				t.Fatalf("findBareBDCommands() found %d commands, want %d in %q", got, tt.want, tt.body)
+			}
+		})
+	}
+}
 
 func TestCoreMaintenanceExecAssets(t *testing.T) {
 	required := []string{

--- a/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
@@ -30,7 +30,7 @@ where work goes. Example: bead `hw-42` → rig `hello-world` → target
 `hello-world/polecat`.
 
 **Rig-scoped beads:** `gc sling` automatically resolves the rig directory
-for rig-scoped bead IDs (e.g. `hw-abc`) and runs `bd update` from there,
+for rig-scoped bead IDs (e.g. `hw-abc`) and runs `gc bd update` from there,
 so the rig's `.beads` database is found without manual intervention.
 
 **Beads must be in the agent's rig database.** Sling operates on the

--- a/internal/bootstrap/packs/core/skills/gc-rigs/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-rigs/SKILL.md
@@ -11,16 +11,20 @@ scoped to rigs via the `dir` field.
 ## Beads
 
 Each rig has its own `.beads/` database with a unique prefix (e.g.
-`hw-` for hello-world). To create or query beads for a rig, run `bd`
-from the rig directory or pass `--dir`:
+`hw-` for hello-world). To create or query beads for a rig, route through
+Gas City with the rig's configured name:
 
 ```
-bd create "title" --dir /path/to/rig   # Create in rig's database
-bd list --dir /path/to/rig             # List rig's beads
+gc bd create "title" --rig <rig-name>   # Create in rig's database
+gc bd list --rig <rig-name>             # List rig's beads
 ```
 
-Running `bd` from the city root hits the city-level `.beads/`, not
-the rig's. Use `gc rig list` to find rig paths.
+Running `gc bd` from the city root without `--rig` targets the city-level
+store only when no stronger scope signal applies. Gas City also auto-detects
+scope from a bead ID prefix, `GC_RIG`, or an enclosing rig/worktree. Use
+`gc bd --city <city-path> ...` when HQ is required and `gc bd --rig
+<rig-name> ...` when a rig is required. Use `gc rig list` to find configured
+rig names and paths.
 
 ## Convention
 


### PR DESCRIPTION
## Summary
- route every shipped core-pack bead command in prompts, formulas, scripts, skills, and provider overlays through `gc bd`
- pin reaper HQ close/prune operations with explicit `--city` routing instead of ambient `BEADS_DIR`
- add a whole-file static guard for bare shell, wrapped Markdown, dynamic, YAML, and serialized argv command forms
- update maintenance test doubles to exercise the `gc bd` boundary while retaining strict underlying `bd` command assertions

## Verification
- `go test ./internal/bootstrap/... -count=1`
- `go test ./examples/gastown -count=1`
- `go test ./internal/formula ./internal/config -count=1`
- `GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 6 6`
- `go vet ./...`
- pre-commit hook: lint-changed, generated docs/schema checks, vet, and docsync passed
- fast parallel run: unit core and cmd/gc shards 1-5 passed; the sole stale prompt-expectation failure in shard 6 was corrected and shard 6 then passed

## Review
Reviewed across correctness, readability, architecture, security, and performance. Scope-sensitive `reaper.sh` operations use explicit canonical city routing; the guard allows supported `gc --city/--rig ... bd` forms and rejects bare leading flags and wrapped/container argv bypasses.