### PR TITLE
Route real-Dolt reaper fixture through gc bd

### DIFF
--- a/examples/gastown/maintenance_scripts_dolt_integration_test.go
+++ b/examples/gastown/maintenance_scripts_dolt_integration_test.go
@@ -66,7 +66,7 @@ case "$1" in
 esac
 exit 0
 `)
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 case "$1 $2" in
   "session prune")
     printf '{"count":0}\n'


### PR DESCRIPTION
## Summary
- make the tagged real-Dolt reaper fixture use the shared `gc bd` maintenance test double
- preserve its existing `session prune` behavior while delegating `gc bd --city ... close` to the strict bd/Dolt fake

Follow-up to #4199. That PR auto-merged even though the non-required `packages-core-4-of-4` integration shard exposed this stale fixture.

## TDD evidence
RED before the fixture correction:
```
go test -tags=dolt_integration ./examples/gastown -run ^'TestReaperWorkflowRootCleanupRealDoltSemantics$' -count=1\n# ReadFile(bd log): no such file or directory\n```\n\nGREEN after the correction:\n```\nok github.com/gastownhall/gascity/examples/gastown 5.807s\n```\n\nThe pre-commit hook also passed lint-changed, generated-artifact checks, `go vet ./...`, and docsync.