### PR TITLE
test(integration): make async session E2E provider-hermetic

### DIFF
--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
 )
 
 // TestHumaBinary_SupervisorBootsAndServesSpec builds `gc`, starts the
@@ -761,6 +763,10 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 	bin := buildGCBinary(t)
 
 	root := shortTempDir(t)
+	providerBinDir := filepath.Join(root, "bin")
+	if err := helpers.StageIdleProviderBinary(providerBinDir, "claude"); err != nil {
+		t.Fatalf("stage Claude provider double: %v", err)
+	}
 	gcHome := filepath.Join(root, "home")
 	runtimeDir := filepath.Join(root, "run")
 	for _, dir := range []string{gcHome, runtimeDir} {
@@ -776,7 +782,9 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 
 	baseURL := "http://127.0.0.1:" + strconv.Itoa(port)
 	env := integrationEnvFor(gcHome, runtimeDir, true)
-	env = append(env, "GC_SESSION=fake")
+	envMap := parseEnvList(env)
+	env = replaceEnv(env, "PATH", prependPath(providerBinDir, envMap["PATH"]))
+	env = replaceEnv(env, "GC_SESSION", "fake")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)


### PR DESCRIPTION
## Summary

- stage a test-owned Claude executable only for TestHumaBinary_SessionMessageAsync
- prepend its isolated bin directory to the supervisor PATH
- keep GC_SESSION=fake so the test remains focused on the HTTP/SSE async contract

## Root cause

Main push CI retained the full REST shard but no longer installs the heavyweight Claude CLI. Provider-session validation resolves the configured executable before the fake runtime is selected, so POST /sessions returned 503 on a clean runner.

## Verification

- helper unit test passed
- targeted E2E passed with host Claude excluded from PATH: 149.9s
- rest-full-8-of-16 passed: 273.5s
- go vet ./... passed
- pre-commit and pre-push fast suite passed
- independent review approved with no blockers

The broad 192-job local sweep separately exposed a pre-existing eventfeed timing flake; the focused test then passed 20/20 and the conservative pre-push suite passed.