### PR TITLE
diag(reconcile): env-gated log of recover-missing eviction decisions

### DIFF
--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -6,11 +6,27 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"os"
 	"sort"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/telemetry"
 )
+
+// reconcileEvictDiag reports whether GC_RECONCILE_EVICT_DIAG is set. When on, the
+// reconcile re-verify logs a rate-limited, per-candidate classification of every
+// cached-but-missing bead — recovered-alive, confirmed-closed, EVICT-notfound, or
+// defer-transient — so an operator can see which live beads the reconciler is
+// evicting (EVICT-notfound) versus recovering. Off by default; read per call so
+// it can be toggled by restarting a process with the env set. Diagnostic only —
+// it changes no reconcile behavior.
+func reconcileEvictDiag() bool {
+	return os.Getenv("GC_RECONCILE_EVICT_DIAG") == "1"
+}
+
+// reconcileEvictDiagPerPassCap bounds how many per-candidate diag lines one
+// reconcile pass emits, so a large divergence can't flood the log.
+const reconcileEvictDiagPerPassCap = 40
 
 // cacheLatencyWindowSize is the size of the rolling window of bd-list
 // durations the reconciler uses for adaptive cadence decisions. Doubles
@@ -753,6 +769,22 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) map[str
 	var confirmedClosed map[string]Bead
 	var recoveredAlive int64
 	var deferredClose int64
+	diag := reconcileEvictDiag()
+	diagLogged := 0
+	var diagEvict, diagRecovered, diagClosed, diagDefer int
+	logDiag := func(kind, id, status string) {
+		if !diag {
+			return
+		}
+		if kind == "EVICT-notfound" {
+			diagEvict++
+		}
+		if diagLogged >= reconcileEvictDiagPerPassCap {
+			return
+		}
+		diagLogged++
+		log.Printf("beads reconcile-evict-diag: %s id=%s cached_status=%s", kind, id, status)
+	}
 	for id, cached := range candidates {
 		bead, err := c.backing.Get(id)
 		switch {
@@ -764,6 +796,8 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) map[str
 				)
 				freshByID[id] = cached
 				deferredClose++
+				diagDefer++
+				logDiag("defer-id-mismatch", id, cached.Status)
 				continue
 			}
 			if bead.Status == "closed" {
@@ -771,12 +805,17 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) map[str
 					confirmedClosed = make(map[string]Bead)
 				}
 				confirmedClosed[id] = cloneBead(bead)
+				diagClosed++
+				logDiag("confirmed-closed", id, cached.Status)
 				continue
 			}
 			freshByID[id] = cloneBead(bead)
 			recoveredAlive++
+			diagRecovered++
+			logDiag("recovered-alive", id, cached.Status)
 		case errors.Is(err, ErrNotFound):
 			// Confirmed gone; let the diff path emit bead.closed.
+			logDiag("EVICT-notfound", id, cached.Status)
 		default:
 			c.recordProblem(
 				"verify missing bead before close",
@@ -784,7 +823,13 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) map[str
 			)
 			freshByID[id] = cached
 			deferredClose++
+			diagDefer++
+			logDiag("defer-transient", id, cached.Status)
 		}
+	}
+	if diag {
+		log.Printf("beads reconcile-evict-diag SUMMARY: candidates=%d evict_notfound=%d recovered_alive=%d confirmed_closed=%d deferred=%d",
+			len(candidates), diagEvict, diagRecovered, diagClosed, diagDefer)
 	}
 	if recoveredAlive != 0 || deferredClose != 0 {
 		c.mu.Lock()

--- a/internal/beads/caching_store_reconcile_evict_diag_test.go
+++ b/internal/beads/caching_store_reconcile_evict_diag_test.go
@@ -1,0 +1,52 @@
+package beads
+
+import (
+	"testing"
+)
+
+func TestReconcileEvictDiagEnvGate(t *testing.T) {
+	if reconcileEvictDiag() {
+		t.Fatal("reconcileEvictDiag must be off by default")
+	}
+	t.Setenv("GC_RECONCILE_EVICT_DIAG", "1")
+	if !reconcileEvictDiag() {
+		t.Fatal("reconcileEvictDiag must be on when GC_RECONCILE_EVICT_DIAG=1")
+	}
+}
+
+// The diagnostic must not change reconcile behavior: recoverMissingFromList
+// recovers an alive cached bead and leaves a genuinely-gone one to be evicted,
+// identically whether the diag env is set or not.
+func TestReconcileEvictDiagIsDiagnosticOnly(t *testing.T) {
+	backing := NewMemStore()
+	alive, err := backing.Create(Bead{Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("create alive: %v", err)
+	}
+
+	run := func() map[string]Bead {
+		cs := NewCachingStoreForTest(backing, nil)
+		cs.mu.Lock()
+		cs.beads = map[string]Bead{
+			alive.ID:  {ID: alive.ID, Status: "open"},
+			"gone-id": {ID: "gone-id", Status: "open"}, // in cache, absent from backing
+		}
+		cs.mu.Unlock()
+		fresh := map[string]Bead{}
+		cs.recoverMissingFromList(fresh)
+		return fresh
+	}
+
+	assertOutcome := func(label string, fresh map[string]Bead) {
+		if _, ok := fresh[alive.ID]; !ok {
+			t.Errorf("%s: alive bead should be recovered into freshByID", label)
+		}
+		if _, ok := fresh["gone-id"]; ok {
+			t.Errorf("%s: gone bead (ErrNotFound) must NOT be recovered", label)
+		}
+	}
+
+	assertOutcome("diag-off", run())
+	t.Setenv("GC_RECONCILE_EVICT_DIAG", "1")
+	assertOutcome("diag-on", run())
+}


### PR DESCRIPTION
## Why

Live approve/finalize/review-loop control beads are being deleted+re-created by the reconciler (`actor=cache-reconcile`) before they can complete, so PRs stall after review, before merge. The leading hypothesis is a **false-evict**: `recoverMissingFromList`'s re-verify `backing.Get` returns a clean `ErrNotFound` for a live bead, so the diff path evicts it. This instrumentation captures that decision directly so we can confirm or rule it out — instead of betting on a fix (e.g. #4198, which is Codex-blocked on exactly this premise).

## What

`GC_RECONCILE_EVICT_DIAG=1` (off by default) makes `recoverMissingFromList` log, per cached-but-missing bead:

- `recovered-alive` — backing.Get found it open → re-added, **not** evicted
- `confirmed-closed` — backing.Get found it closed
- `EVICT-notfound` — backing.Get returned `ErrNotFound` → the diff path will evict it
- `defer-transient` / `defer-id-mismatch` — deferred, not evicted

Plus a per-pass `SUMMARY` with counts. Rate-limited to 40 lines/pass.

**Reading the result:** if `EVICT-notfound` fires on live control beads, the re-verify is false-negativing them → the fix is a tier-consistent / retry-resilient re-verify. If `evict_notfound=0` while the churn continues, the churn is a **different** path → a follow-up diag on the create/delete emit points.

## Safety / deploy

Diagnostic only — **no behavior change**. Test asserts `recoverMissingFromList` produces the identical recover outcome with the env on and off. Off by default. Prepped ready to deploy the instant the current deploy hold lifts; capture ~2 min with the env set, then read the `reconcile-evict-diag` lines.

## Validation

`go build ./...`, `go vet`, gofmt clean; new tests green (env-gate + diagnostic-only invariance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
