### PR TITLE
fix(orders): ignore order-generated bead events

### DIFF
--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -260,9 +260,9 @@ func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult 
 	}
 	var count int
 	for _, e := range matched {
-		// Exclude the dispatcher's own order-tracking bookkeeping beads so an event
-		// order never self-fires on lifecycle events emitted by those beads (#3720).
-		if !payloadHasLabel(e.Payload, labelOrderTracking) {
+		// Exclude order-generated beads so event orders never self-fire on their
+		// tracking lifecycle or spawned wisp roots (#3720).
+		if !payloadHasOrderMarker(e.Payload) {
 			count++
 		}
 	}
@@ -272,20 +272,27 @@ func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult 
 	return TriggerResult{Due: true, Reason: fmt.Sprintf("event: %d %s event(s)", count, a.On)}
 }
 
-// payloadHasLabel reports whether a JSON bead payload contains the given label.
-func payloadHasLabel(payload json.RawMessage, label string) bool {
+// payloadHasOrderMarker reports whether a JSON bead payload contains an
+// order-tracking label or an order-run label. Older event logs wrap the bead
+// snapshot under payload.bead, while current events put labels at the top level.
+func payloadHasOrderMarker(payload json.RawMessage) bool {
 	if len(payload) == 0 {
 		return false
 	}
 	var p struct {
 		Labels []string `json:"labels"`
+		Bead   struct {
+			Labels []string `json:"labels"`
+		} `json:"bead"`
 	}
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return false
 	}
-	for _, l := range p.Labels {
-		if l == label {
-			return true
+	for _, labels := range [][]string{p.Labels, p.Bead.Labels} {
+		for _, label := range labels {
+			if label == labelOrderTracking || strings.HasPrefix(label, labelOrderRunPrefix) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -417,6 +417,27 @@ func TestCheckTriggerEventAllOrderTrackingFiltered(t *testing.T) {
 	}
 }
 
+func TestRegressionCheckTriggerEventOrderGeneratedBeadsFiltered(t *testing.T) {
+	// Regression: order-created wisps can carry only order-run before or instead
+	// of order-tracking, and v1.3.4 event logs wrap bead labels under payload.bead.
+	payloads := []json.RawMessage{
+		mustMarshalLabels(t, []string{"order-run:nudge-on-route"}),
+		json.RawMessage(`{"bead":{"labels":["order-tracking"]}}`),
+		json.RawMessage(`{"bead":{"labels":["order-run:nudge-on-route"]}}`),
+	}
+
+	for _, payload := range payloads {
+		ep := newEventsProvider(t, []events.Event{
+			{Type: "bead.updated", Payload: payload},
+		})
+		a := Order{Name: "nudge-on-route", Trigger: "event", On: "bead.updated"}
+		result := CheckTrigger(a, time.Time{}, neverRan, ep, nil)
+		if result.Due {
+			t.Errorf("Due = true, want false for order-generated payload %s; reason: %s", payload, result.Reason)
+		}
+	}
+}
+
 func TestCheckTriggerEventNoPayloadNotFiltered(t *testing.T) {
 	// Events with no payload (legacy or non-bead events) must pass through —
 	// absence of a label is not the same as having the order-tracking label.


### PR DESCRIPTION
## Summary

- Ignore bead events marked with either `order-tracking` or `order-run:*` when evaluating event-triggered orders.
- Read labels from both current top-level event payloads and legacy v1.3.4 `payload.bead` wrappers.
- Preserve existing behavior for regular bead events, malformed payloads, and events without payloads.

## Root cause

This follows up on #3720 and the [Yakushido production findings](https://github.com/gastownhall/gascity/pull/3720#issuecomment-4955273642).

The #3720 guard only recognized an exact top-level `order-tracking` label. Order-created wisp roots can carry only `order-run:<scoped-name>` before or instead of `order-tracking`, and v1.3.4 event logs can wrap the bead snapshot under `payload.bead`. Those events therefore remained eligible to trigger event orders, allowing order-generated lifecycle events to feed back into dispatch.

The regression test was added first on current `main` (`7d138595`) and failed for all three missed shapes:

- top-level `order-run:*`
- nested `payload.bead.labels: ["order-tracking"]`
- nested `payload.bead.labels: ["order-run:*"]`

## Validation

Red on unmodified `main`:

```text
CGO_ENABLED=0 go test ./internal/orders -run '^TestRegressionCheckTriggerEventOrderGeneratedBeadsFiltered$' -count=1
FAIL: all three order-generated payload shapes returned Due=true
```

Green with this change:

```text
CGO_ENABLED=0 go test ./internal/orders -run '^TestRegressionCheckTriggerEventOrderGeneratedBeadsFiltered$' -count=1
CGO_ENABLED=0 go test ./internal/orders -count=1
CGO_ENABLED=0 go vet ./internal/orders/...
git diff --check
```

The repository-wide `make check` completed formatting, `golangci-lint` (`0 issues`), and `go vet ./...`. Its unit phase then failed only in two unchanged `cmd/gc` tests because they hardcode `/bin/true`, which does not exist on this macOS host (`/usr/bin/true` does). Both failures reproduce unchanged on `main`:

```text
TestHookRunConsumesStdinWhenWrappedCommandIgnoresIt
TestHookRunSkipsStdinDrainForTerminal
fork/exec /bin/true: no such file or directory
```

Production validation on Yakushido showed the behavioral distinction:

- direct #3720 backport: 18 core event-order fires in 5 minutes
- nested-payload-only filter: 16 fires in 5 minutes
- filter both marker families at both payload locations: 0 fires over 60 seconds, then 300 seconds, then another 60 seconds after reinstall; no controller restarts

## Behavioral scope

The filter applies to all order-generated bead events, preventing both self-triggering and cross-triggering between event orders. Events without internal order markers continue to count normally.

Follow-up to #3720.
