### PR TITLE
fix(order): redact projected GitHub token from successful manual exec output (post-merge #4111)

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -903,12 +903,12 @@ func doOrderRunExecResult(a orders.Order, cityPath string, cfg *config.City, var
 	}
 
 	output, err := shellExecRunner(ctx, a.Exec, target.ScopeRoot, env)
+	// The exec env now projects the controller's GH_TOKEN/GITHUB_TOKEN into the
+	// child, so any order that echoes one would leak it. Redact the exec error
+	// and combined output against the projected env on both the failure and
+	// success paths, matching the controller dispatch path (order_dispatch.go).
+	redactionEnv := append(os.Environ(), env...)
 	if err != nil {
-		// The exec env now projects the controller's GH_TOKEN/GITHUB_TOKEN into
-		// the child, so a failing order that echoes one would leak it to stderr.
-		// Redact the exec error and combined output against the projected env,
-		// matching the controller dispatch path (order_dispatch.go).
-		redactionEnv := append(os.Environ(), env...)
 		fmt.Fprintf(stderr, "gc order run: exec failed: %s\n", execenv.RedactText(err.Error(), redactionEnv)) //nolint:errcheck
 		if len(output) > 0 {
 			fmt.Fprintf(stderr, "%s", execenv.RedactText(string(output), redactionEnv)) //nolint:errcheck
@@ -916,7 +916,7 @@ func doOrderRunExecResult(a orders.Order, cityPath string, cfg *config.City, var
 		return orderRunExecResult{code: 1, failureLabel: "exec-failed"}
 	}
 	if len(output) > 0 {
-		fmt.Fprintf(stdout, "%s", output) //nolint:errcheck
+		fmt.Fprintf(stdout, "%s", execenv.RedactText(string(output), redactionEnv)) //nolint:errcheck
 	}
 	fmt.Fprintf(stdout, "Order %q executed (exec)\n", a.Name) //nolint:errcheck
 	return orderRunExecResult{code: 0}

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -3072,6 +3072,52 @@ prefix = "ct"
 	}
 }
 
+// TestOrderRunExecSuccessRedactsProjectedGitHubToken proves that when a manual
+// `gc order run` exec order succeeds after echoing the controller's projected
+// GitHub token, the token is redacted from the combined output printed to
+// stdout. The exec env projects GH_TOKEN/GITHUB_TOKEN into the child (see
+// projectGitHubTokenExecEnv), so the success path must scrub them just like the
+// failure path does — a passing order that prints the token would otherwise
+// leak it verbatim.
+func TestOrderRunExecSuccessRedactsProjectedGitHubToken(t *testing.T) {
+	clearAmbientPostgresEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	const secret = "ghp_projectedControllerToken0123456789"
+	t.Setenv("GITHUB_TOKEN", secret)
+	t.Setenv("GH_TOKEN", secret)
+
+	cityDir := t.TempDir()
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+`)
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	// Echo the projected token to the child's combined output, then succeed so
+	// the success (stdout) branch runs.
+	a := orders.Order{
+		Name:     "leaky",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     `printf '%s\n' "$GITHUB_TOKEN"`,
+	}
+
+	var stdout, stderr bytes.Buffer
+	result := doOrderRunExecResult(a, cityDir, cfg, nil, &stdout, &stderr)
+	if result.code != 0 {
+		t.Fatalf("doOrderRunExecResult = %d, want exec success; stdout=%q stderr=%q", result.code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), secret) {
+		t.Fatalf("stdout leaked projected GitHub token: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "[redacted]") {
+		t.Fatalf("stdout = %q, want redaction marker for the echoed token", stdout.String())
+	}
+}
+
 // --- gc order history ---
 
 func TestOrderHistory(t *testing.T) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2093,6 +2093,69 @@ func TestOrderDispatchExecFailureRedactsSecrets(t *testing.T) {
 	}
 }
 
+// TestOrderDispatchExecFailureRedactsProjectedGitHubToken pins the controller
+// dispatch path for the specific tokens projectGitHubTokenExecEnv injects. The
+// exec env now projects the controller's ambient GH_TOKEN/GITHUB_TOKEN into
+// every exec order, so a failing order that echoes one must have it redacted
+// from both the logged output and the OrderFailed event message. The general
+// TestOrderDispatchExecFailureRedactsSecrets covers an order-scoped secret;
+// this one is scoped to the newly projected GitHub auth keys.
+func TestOrderDispatchExecFailureRedactsProjectedGitHubToken(t *testing.T) {
+	const secret = "ghp_projectedControllerToken0123456789"
+	t.Setenv("GH_TOKEN", secret)
+	t.Setenv("GITHUB_TOKEN", secret)
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+	tracking, err := store.Create(beads.Bead{
+		Title:  "order:leaky-exec",
+		Labels: []string{"order-run:leaky-exec", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Echo the projected token to combined output and the error, then fail so the
+	// controller failure branch redacts both against the projected env.
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		return []byte("GITHUB_TOKEN=" + secret + "\n"), fmt.Errorf("auth failed for token=%s", secret)
+	}
+
+	aa := []orders.Order{{
+		Name:     "leaky-exec",
+		Trigger:  "cooldown",
+		Interval: "2m",
+		Exec:     "scripts/fail.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, &rec)
+	mad := ad.(*memoryOrderDispatcher)
+	mad.stderr = &stderr
+
+	logs := captureCmdOrderLogs(t, func() {
+		mad.dispatchExec(context.Background(), orders.NewStore(beads.OrdersStore{Store: store}), execStoreTarget{ScopeRoot: t.TempDir()}, aa[0], t.TempDir(), tracking.ID, nil)
+	})
+
+	combined := logs + "\n" + stderr.String()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("order exec logs leaked projected GitHub token:\n%s", combined)
+	}
+	if !strings.Contains(combined, "[redacted]") {
+		t.Fatalf("order exec logs = %q, want redaction marker", combined)
+	}
+	sawFailed := false
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed {
+			sawFailed = true
+		}
+		if strings.Contains(event.Message, secret) {
+			t.Fatalf("order failed event leaked projected GitHub token: %#v", event)
+		}
+	}
+	if !sawFailed {
+		t.Fatalf("expected an OrderFailed event; got %#v", rec.events)
+	}
+}
+
 func TestOrderDispatchFormulaCookFailureLabelsTrackingBead(t *testing.T) {
 	store := beads.NewMemStore()
 	var rec memRecorder


### PR DESCRIPTION
## Post-merge review remediation for #4111

A post-merge review of the landed range `6e5173b2d..61ac46e6b` (PR #4111,
"project GH_TOKEN/GITHUB_TOKEN into exec-order env") found one security issue and
one test-coverage gap. This PR remediates both.

### Fixed: successful manual `gc order run` could leak the projected GitHub token

PR #4111 projects the controller's ambient `GH_TOKEN`/`GITHUB_TOKEN` into the
exec-order env so shelled-out `gh` calls authenticate. Its manual-run **failure**
path was updated to redact the projected token from stderr, but the **success**
path wrote the child's combined output to stdout verbatim. A passing order that
echoed the token (e.g. `printf '%s' "$GITHUB_TOKEN"`) would therefore leak it
(CWE-200, sensitive information exposure).

`doOrderRunExecResult` now hoists the redaction env and redacts the success-path
output too, so both paths scrub the projected token — matching the controller
dispatch path in `order_dispatch.go`.

### Hardened: targeted regression coverage for the projected token

- `TestOrderRunExecSuccessRedactsProjectedGitHubToken` — a successful manual exec
  that prints `$GITHUB_TOKEN` has the token redacted from stdout (fails without
  the fix; verified).
- `TestOrderDispatchExecFailureRedactsProjectedGitHubToken` — the controller
  dispatch path redacts the projected token from both the logged failure output
  and the `OrderFailed` event message. Scopes the existing generic
  `TestOrderDispatchExecFailureRedactsSecrets` to the keys
  `projectGitHubTokenExecEnv` injects.

### Testing

- `go vet ./cmd/gc` — clean.
- Focused: `go test ./cmd/gc -run 'Test(OrderRunExecSuccessRedactsProjectedGitHubToken|OrderRunExecFailureRedactsProjectedGitHubToken|OrderDispatchExecFailureRedactsProjectedGitHubToken|OrderDispatchExecFailureRedactsSecrets|ProjectGitHubTokenExecEnv|OrderRun)'` — all pass.
- Pre-push `make test-fast-parallel` — run at push time.

Scope: `cmd/gc/cmd_order.go` (production redaction), `cmd/gc/cmd_order_test.go`,
`cmd/gc/order_dispatch_test.go` (tests). No behavior change beyond redacting the
already-projected secret from success-path output.
