### PR TITLE
fix(dispatch): retry transient route-config load failures on attempt/fanout routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Attempt/fanout control routing no longer fails closed on a transient
+  route-config load.** The store-scoped dispatcher routing made attempt-spawn
+  (`spawnNextAttempt`) and fanout (`routeFanoutFragmentSteps`) control routing
+  return a hard error when the attempt-time `city.toml` load failed, so a
+  momentary config read or include-resolution blip could permanently quarantine
+  an in-flight molecule. Such load/parse failures are now classified as
+  transient controller-boundary errors and retried as pending, matching the
+  retry/Ralph tolerance. Terminal fail-closed remains reserved for a config that
+  loads successfully but lacks the required `Dir`-matched `control-dispatcher`
+  agent.
 - **Pin the `beads` dependency to the stable v1.0.4.** v1.3.0 built against
   `beads v1.0.5`, which was subsequently withdrawn (demoted to a pre-release;
   `v1.0.4` is the current stable release). v1.3.1 repins the `beads` Go module

--- a/internal/dispatch/attempt_control_routing_test.go
+++ b/internal/dispatch/attempt_control_routing_test.go
@@ -1,6 +1,8 @@
 package dispatch
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -150,5 +152,79 @@ func TestLatestAttemptCandidateSkipsAllControlKinds(t *testing.T) {
 		if latestAttemptCandidateIsControlInfrastructure(kind) {
 			t.Errorf("latestAttemptCandidateIsControlInfrastructure(%q) = true, want false", kind)
 		}
+	}
+}
+
+// TestRouteFanoutFragmentStepsRouteConfigLoadFailureIsTransient is the post-merge
+// remediation of PR #4175: a route-config load/parse failure on the fanout path
+// must be classified as a transient controller-boundary error so the dispatcher
+// retries the control bead as pending, instead of a hard failure that
+// quarantines an in-flight molecule. A momentary city.toml read/parse blip is
+// environmental, not a permanent defect in the workflow.
+func TestRouteFanoutFragmentStepsRouteConfigLoadFailureIsTransient(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("this = = not valid toml ["), 0o644); err != nil {
+		t.Fatalf("write malformed city.toml: %v", err)
+	}
+	fragment := &formula.FragmentRecipe{
+		Name: "frag",
+		Steps: []formula.RecipeStep{{
+			ID: "frag.item.drain",
+			Metadata: map[string]string{
+				beadmeta.KindMetadataKey:         beadmeta.KindDrain,
+				beadmeta.RootStoreRefMetadataKey: "rig:gascity",
+			},
+		}},
+	}
+	control := beads.Bead{Metadata: map[string]string{
+		beadmeta.ExecutionRoutedToMetadataKey: "gascity/worker",
+		beadmeta.RootStoreRefMetadataKey:      "rig:gascity",
+	}}
+	// routeCfg unset so routeConfig() performs a fresh load from CityPath and
+	// surfaces the malformed-config error the dispatcher must tolerate.
+	opts := ProcessOptions{CityPath: cityPath}
+
+	err := routeFanoutFragmentSteps(fragment, control, opts, beads.NewMemStore())
+	if err == nil {
+		t.Fatal("routeFanoutFragmentSteps: want error on malformed route config, got nil")
+	}
+	if !IsTransientControllerError(err) {
+		t.Fatalf("route-config load failure classified hard (%v); want transient so the molecule retries as pending", err)
+	}
+}
+
+// TestRouteFanoutFragmentStepsMissingDispatcherStaysTerminal pins the reserved
+// fail-closed semantics of the same fix: when the route config loads
+// successfully but lacks the required store-scoped control dispatcher, the error
+// must stay terminal (not transient), so a genuine misconfiguration fails closed
+// rather than spinning forever on retry.
+func TestRouteFanoutFragmentStepsMissingDispatcherStaysTerminal(t *testing.T) {
+	fragment := &formula.FragmentRecipe{
+		Name: "frag",
+		Steps: []formula.RecipeStep{{
+			ID: "frag.item.drain",
+			Metadata: map[string]string{
+				beadmeta.KindMetadataKey:         beadmeta.KindDrain,
+				beadmeta.RootStoreRefMetadataKey: "rig:gascity",
+			},
+		}},
+	}
+	control := beads.Bead{Metadata: map[string]string{
+		beadmeta.ExecutionRoutedToMetadataKey: "gascity/worker",
+		beadmeta.RootStoreRefMetadataKey:      "rig:gascity",
+	}}
+	// Config loads fine but has no control-dispatcher agent scoped to rig gascity.
+	routeCfg := &routeConfigCache{}
+	routeCfg.once.Do(func() {
+		routeCfg.cfg = &config.City{Agents: []config.Agent{{Name: "worker", Dir: "gascity"}}}
+	})
+	opts := ProcessOptions{routeCfg: routeCfg}
+
+	err := routeFanoutFragmentSteps(fragment, control, opts, beads.NewMemStore())
+	if err == nil {
+		t.Fatal("routeFanoutFragmentSteps: want terminal error when store-scoped dispatcher is absent, got nil")
+	}
+	if IsTransientControllerError(err) {
+		t.Fatalf("missing store-scoped dispatcher classified transient (%v); want terminal fail-closed", err)
 	}
 }

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -513,7 +513,14 @@ func spawnNextAttempt(ctx context.Context, store beads.Store, control beads.Bead
 	executionRigContext := strings.TrimSpace(control.Metadata[beadmeta.ExecutionRigContextMetadataKey])
 	routeCfg, err := opts.routeConfig()
 	if err != nil {
-		return fmt.Errorf("loading attempt route config: %w", err)
+		// A route-config load/parse failure is environmental and transient (a
+		// momentary city.toml read or include-resolution blip), not a permanent
+		// defect in this molecule. Classify it as a transient controller-boundary
+		// error so the spawn boundary retries it as pending instead of
+		// quarantining an in-flight molecule. Terminal fail-closed stays reserved
+		// for a config that loads successfully but lacks the required
+		// store-scoped dispatcher (controlDispatcherTargetForExecutionTarget).
+		return markTransientControllerBoundaryError(fmt.Errorf("loading attempt route config: %w", err))
 	}
 	rootStoreRef := strings.TrimSpace(control.Metadata[beadmeta.RootStoreRefMetadataKey])
 	for i := range recipe.Steps {

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -837,6 +837,63 @@ func assertSpawnedSpecClosedAndUnrouted(t *testing.T, store beads.Store, rootID,
 	t.Fatalf("missing spec bead for %q under root %s", specFor, rootID)
 }
 
+// TestSpawnNextAttemptRouteConfigLoadFailureIsTransient is the post-merge
+// remediation of PR #4175 on the attempt-spawn path: a route-config load/parse
+// failure must be classified as a transient controller-boundary error (retried
+// as pending by markControllerSpawnError), not a hard failure that quarantines
+// the in-flight molecule. It complements the fanout-path coverage in
+// attempt_control_routing_test.go.
+func TestSpawnNextAttemptRouteConfigLoadFailureIsTransient(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("this = = not valid toml ["), 0o644); err != nil {
+		t.Fatalf("write malformed city.toml: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	spec := &formula.Step{
+		ID:    "review-loop",
+		Title: "Review / fix loop",
+		Type:  "task",
+		Ralph: &formula.RalphSpec{MaxAttempts: 3},
+		Children: []*formula.Step{{
+			ID:       "review-claude",
+			Title:    "Code review: Claude",
+			Type:     "task",
+			Metadata: map[string]string{"gc.run_target": "gascity/claude"},
+		}},
+	}
+	specJSON, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal step spec: %v", err)
+	}
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review-loop",
+		Metadata: map[string]string{
+			"gc.kind":                "ralph",
+			"gc.root_bead_id":        root.ID,
+			"gc.step_ref":            "mol-adopt-pr-v2.review-loop",
+			"gc.step_id":             "review-loop",
+			"gc.source_step_spec":    string(specJSON),
+			"gc.control_epoch":       "1",
+			"gc.execution_routed_to": "gascity/claude",
+		},
+	})
+
+	err = spawnNextAttempt(t.Context(), store, control, 2, ProcessOptions{CityPath: cityPath})
+	if err == nil {
+		t.Fatal("spawnNextAttempt: want error on malformed route config, got nil")
+	}
+	if !IsTransientControllerError(err) {
+		t.Fatalf("route-config load failure classified hard (%v); want transient so the molecule retries as pending", err)
+	}
+}
+
 func TestSpawnNextAttemptRoutesDirectSessionRetryControlViaDispatcher(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -290,7 +290,12 @@ func routeFanoutFragmentSteps(fragment *formula.FragmentRecipe, control beads.Be
 	executionRigContext := strings.TrimSpace(control.Metadata[beadmeta.ExecutionRigContextMetadataKey])
 	routeCfg, err := opts.routeConfig()
 	if err != nil {
-		return fmt.Errorf("loading fanout route config: %w", err)
+		// See spawnNextAttempt: a route-config load/parse failure is transient,
+		// so classify it as a transient controller-boundary error and let the
+		// caller retry it as pending rather than quarantining the molecule.
+		// Terminal fail-closed stays reserved for a loaded config that lacks the
+		// required store-scoped dispatcher (applyAttemptControlStepRoute below).
+		return markTransientControllerBoundaryError(fmt.Errorf("loading fanout route config: %w", err))
 	}
 	rootStoreRef := strings.TrimSpace(control.Metadata[beadmeta.RootStoreRefMetadataKey])
 	for i := range fragment.Steps {

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -481,8 +481,10 @@ func appendRalphRetry(store beads.Store, logicalID string, prevSubject, prevChec
 	// A routeConfig error is intentionally tolerated here: Ralph retry preserves
 	// the prior attempt's already-stamped routes rather than scope-routing, so a
 	// nil cfg degrades to metadata-only instead of mis-routing. Spawn/fanout
-	// (control.go, fanout.go) fail closed on this error because they scope-route
-	// through applyAttemptControlStepRoute.
+	// (control.go, fanout.go) cannot degrade to metadata-only because they
+	// scope-route fresh through applyAttemptControlStepRoute, so they instead
+	// classify a load/parse failure as a transient controller-boundary error and
+	// retry it as pending.
 	cfg, _ := opts.routeConfig()
 	if molecule.IsGraphApplyEnabled() {
 		if applier, ok := beads.GraphApplyFor(store); ok {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -166,8 +166,10 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 	// A routeConfig error is intentionally tolerated here: retry preserves the
 	// prior attempt's already-stamped routes rather than scope-routing, so a nil
 	// cfg degrades to metadata-only instead of mis-routing. Spawn/fanout
-	// (control.go, fanout.go) fail closed on this error because they scope-route
-	// through applyAttemptControlStepRoute.
+	// (control.go, fanout.go) cannot degrade to metadata-only because they
+	// scope-route fresh through applyAttemptControlStepRoute, so they instead
+	// classify a load/parse failure as a transient controller-boundary error and
+	// retry it as pending.
 	routeCfg, _ := opts.routeConfig()
 	if beadUsesMetadataPoolRouteWithConfig(subject, routeCfg) {
 		if opts.RecycleSession == nil {


### PR DESCRIPTION
## Summary

Post-merge review remediation for #4175 (restore store-scoped control dispatcher routing).

The store-scoped dispatcher routing that landed in #4175 made attempt-spawn
(`spawnNextAttempt`) and fanout (`routeFanoutFragmentSteps`) control routing
return a **hard** error when the attempt-time `city.toml` load failed. Because
the dispatcher classifies non-transient control errors as terminal (quarantine),
a momentary config read or include-resolution blip could permanently fail an
in-flight molecule — even though the `retry` and `ralph` paths already tolerate
the same load failure and degrade to metadata-only routing.

## Fix

Classify route-config **load/parse** failures on the spawn and fanout paths as
transient controller-boundary errors (`markTransientControllerBoundaryError`),
so the spawn boundary and the top-level dispatcher retry them as *pending*
instead of quarantining the molecule. Terminal fail-closed behavior stays
reserved for a config that **loads successfully** but lacks the required
`Dir`-matched `control-dispatcher` agent — the intended misconfiguration guard
from #4175. Spawn/fanout cannot safely degrade to metadata-only the way
retry/ralph do (they scope-route fresh through `applyAttemptControlStepRoute`),
so retrying as pending is the correct tolerance for them.

Also corrects the now-stale comments in `retry.go`/`ralph.go` that described
spawn/fanout as "fail closed on this error."

## Tests

- `TestSpawnNextAttemptRouteConfigLoadFailureIsTransient` — spawn-path load
  failure is classified transient (retried as pending).
- `TestRouteFanoutFragmentStepsRouteConfigLoadFailureIsTransient` — fanout-path
  load failure is classified transient.
- `TestRouteFanoutFragmentStepsMissingDispatcherStaysTerminal` — a loaded config
  missing the store-scoped dispatcher stays terminal (fail-closed preserved).

`go test ./internal/dispatch/` passes; `go vet ./...` and the pre-commit gate
(lint-changed, docsync) are clean.

The landed range `61ac46e6b..7d1385958` was reviewed after merge; this PR
addresses the one actionable correctness finding from that review.
