### PR TITLE
perf(beads): native store Ready() fetches all open-class statuses in one backing query

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -1295,43 +1295,51 @@ func (s *NativeDoltStore) Ready(queries ...ReadyQuery) ([]Bead, error) {
 		var beads []Bead
 		seen := make(map[string]bool)
 		now := time.Now().UTC()
-	statusLoop:
-		for _, status := range nativeDoltOpenReadyStatuses {
-			filter := beadslib.WorkFilter{Status: status}
-			if q.TierMode == TierBoth || q.TierMode == TierWisps {
-				filter.IncludeEphemeral = true
+		// One GetReadyWork call covers every open-class backing status via
+		// WorkFilter.Statuses. The previous one-call-per-status loop re-paid
+		// the deferred-parents pre-query, the wisp arm, and the transaction
+		// round trips seven times per Ready() (sr-5rz: ~30-70ms per call on
+		// a live server-mode store). The backing Limit stays 0 because the
+		// gc-side post-filter below (tier, excluded types/labels, defer)
+		// discards rows the store cannot, so a server-side limit could
+		// under-fill the result.
+		filter := beadslib.WorkFilter{Statuses: nativeDoltOpenReadyStatuses}
+		if q.TierMode == TierBoth || q.TierMode == TierWisps {
+			filter.IncludeEphemeral = true
+		}
+		if q.Assignee != "" {
+			filter.Assignee = &q.Assignee
+		}
+		issues, err := storage.GetReadyWork(ctx, filter)
+		if err != nil {
+			return err
+		}
+		for _, issue := range issues {
+			// The StatusDeferred branch exists so an expired time-bound
+			// deferral (defer_until in the past) can resurface. An issue
+			// with no defer_until at all was never time-bound — it's bd
+			// defer's status-based indefinite deferral — and must stay
+			// hidden. mapBdStatus collapses status to "open" and
+			// IsDeferred only inspects DeferUntil, so both would
+			// otherwise look identical to an ordinary open bead once
+			// beadFromNativeIssue erases the raw status. The per-status
+			// loop keyed this on the filter status it was querying for;
+			// with the whole set in one call the row's own raw status is
+			// the equivalent discriminator.
+			if issue.Status == beadslib.StatusDeferred && issue.DeferUntil == nil {
+				continue
 			}
-			if q.Assignee != "" {
-				filter.Assignee = &q.Assignee
-			}
-			issues, err := storage.GetReadyWork(ctx, filter)
+			bead, err := beadFromNativeIssue(issue)
 			if err != nil {
 				return err
 			}
-			for _, issue := range issues {
-				// The StatusDeferred branch exists so an expired time-bound
-				// deferral (defer_until in the past) can resurface. An issue
-				// with no defer_until at all was never time-bound — it's bd
-				// defer's status-based indefinite deferral — and must stay
-				// hidden. mapBdStatus collapses status to "open" and
-				// IsDeferred only inspects DeferUntil, so both would
-				// otherwise look identical to an ordinary open bead once
-				// beadFromNativeIssue erases the raw status.
-				if status == beadslib.StatusDeferred && issue.DeferUntil == nil {
-					continue
-				}
-				bead, err := beadFromNativeIssue(issue)
-				if err != nil {
-					return err
-				}
-				if !IsReadyCandidateForTier(bead, now, q.TierMode) || seen[bead.ID] {
-					continue
-				}
-				seen[bead.ID] = true
-				beads = append(beads, bead)
-				if q.Limit > 0 && len(beads) >= q.Limit {
-					break statusLoop
-				}
+			if !IsReadyCandidateForTier(bead, now, q.TierMode) || seen[bead.ID] {
+				continue
+			}
+			seen[bead.ID] = true
+			beads = append(beads, bead)
+			if q.Limit > 0 && len(beads) >= q.Limit {
+				break
 			}
 		}
 		out = beads

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -1154,32 +1154,37 @@ func (s *NativeDoltStore) Ready(queries ...ReadyQuery) ([]Bead, error) {
 		var beads []Bead
 		seen := make(map[string]bool)
 		now := time.Now().UTC()
-	statusLoop:
-		for _, status := range nativeDoltOpenReadyStatuses {
-			filter := beadslib.WorkFilter{Status: status}
-			if q.TierMode == TierBoth || q.TierMode == TierWisps {
-				filter.IncludeEphemeral = true
-			}
-			if q.Assignee != "" {
-				filter.Assignee = &q.Assignee
-			}
-			issues, err := storage.GetReadyWork(ctx, filter)
+		// One GetReadyWork call covers every open-class backing status via
+		// WorkFilter.Statuses. The previous one-call-per-status loop re-paid
+		// the deferred-parents pre-query, the wisp arm, and the transaction
+		// round trips seven times per Ready() (sr-5rz: ~30-70ms per call on
+		// a live server-mode store). The backing Limit stays 0 because the
+		// gc-side post-filter below (tier, excluded types/labels, defer)
+		// discards rows the store cannot, so a server-side limit could
+		// under-fill the result.
+		filter := beadslib.WorkFilter{Statuses: nativeDoltOpenReadyStatuses}
+		if q.TierMode == TierBoth || q.TierMode == TierWisps {
+			filter.IncludeEphemeral = true
+		}
+		if q.Assignee != "" {
+			filter.Assignee = &q.Assignee
+		}
+		issues, err := storage.GetReadyWork(ctx, filter)
+		if err != nil {
+			return err
+		}
+		for _, issue := range issues {
+			bead, err := beadFromNativeIssue(issue)
 			if err != nil {
 				return err
 			}
-			for _, issue := range issues {
-				bead, err := beadFromNativeIssue(issue)
-				if err != nil {
-					return err
-				}
-				if !IsReadyCandidateForTier(bead, now, q.TierMode) || seen[bead.ID] {
-					continue
-				}
-				seen[bead.ID] = true
-				beads = append(beads, bead)
-				if q.Limit > 0 && len(beads) >= q.Limit {
-					break statusLoop
-				}
+			if !IsReadyCandidateForTier(bead, now, q.TierMode) || seen[bead.ID] {
+				continue
+			}
+			seen[bead.ID] = true
+			beads = append(beads, bead)
+			if q.Limit > 0 && len(beads) >= q.Limit {
+				break
 			}
 		}
 		out = beads

--- a/internal/beads/native_dolt_store_ready_statuses_test.go
+++ b/internal/beads/native_dolt_store_ready_statuses_test.go
@@ -1,0 +1,88 @@
+package beads
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// workFilterMatchesStatus mirrors the backing store's status selection for
+// GetReadyWork spies: Statuses carries the whole open-class set with OR
+// semantics, and singular Status remains honored for callers that still set
+// it. Spies that key off filter.Status alone silently match nothing once
+// Ready() moved to the single multi-status query.
+func workFilterMatchesStatus(filter beadslib.WorkFilter, status beadslib.Status) bool {
+	if filter.Status != "" {
+		return status == filter.Status
+	}
+	for _, s := range filter.Statuses {
+		if status == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Ready must fetch all open-class backing statuses in ONE GetReadyWork call
+// (WorkFilter.Statuses) instead of one call per status: each backing call
+// re-pays the deferred-parents pre-query, the wisp arm, and the transaction
+// round trips (sr-5rz: ~30-70ms per call on a live server-mode store, ~7x
+// per Ready()).
+func TestNativeDoltStoreReadySingleBackingCallWithAllStatuses(t *testing.T) {
+	var calls []beadslib.WorkFilter
+	storage := &nativeDoltStorageSpy{
+		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
+			calls = append(calls, filter)
+			return []*beadslib.Issue{
+				{ID: "gc-open", Title: "open", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2},
+			}, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	got, err := store.Ready(ReadyQuery{TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "gc-open" {
+		t.Fatalf("Ready = %+v, want the one open bead", got)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("backing GetReadyWork calls = %d, want 1 (filters: %+v)", len(calls), calls)
+	}
+	if calls[0].Status != "" {
+		t.Fatalf("singular Status = %q, want empty (Statuses must carry the set)", calls[0].Status)
+	}
+	if !reflect.DeepEqual(calls[0].Statuses, nativeDoltOpenReadyStatuses) {
+		t.Fatalf("Statuses = %v, want %v", calls[0].Statuses, nativeDoltOpenReadyStatuses)
+	}
+	if !calls[0].IncludeEphemeral {
+		t.Fatal("IncludeEphemeral must be set for TierBoth")
+	}
+}
+
+func TestNativeDoltStoreReadyAssigneeSingleBackingCall(t *testing.T) {
+	var calls []beadslib.WorkFilter
+	storage := &nativeDoltStorageSpy{
+		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
+			calls = append(calls, filter)
+			return nil, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	if _, err := store.Ready(ReadyQuery{TierMode: TierBoth, Assignee: "probe-me", Limit: 3}); err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("backing GetReadyWork calls = %d, want 1", len(calls))
+	}
+	if calls[0].Assignee == nil || *calls[0].Assignee != "probe-me" {
+		t.Fatalf("Assignee filter = %v, want probe-me", calls[0].Assignee)
+	}
+	if calls[0].Limit != 0 {
+		t.Fatalf("backing Limit = %d, want 0 (limit applies client-side after the gc post-filter)", calls[0].Limit)
+	}
+}

--- a/internal/beads/native_dolt_store_ready_statuses_test.go
+++ b/internal/beads/native_dolt_store_ready_statuses_test.go
@@ -1,0 +1,71 @@
+package beads
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// Ready must fetch all open-class backing statuses in ONE GetReadyWork call
+// (WorkFilter.Statuses) instead of one call per status: each backing call
+// re-pays the deferred-parents pre-query, the wisp arm, and the transaction
+// round trips (sr-5rz: ~30-70ms per call on a live server-mode store, ~7x
+// per Ready()).
+func TestNativeDoltStoreReadySingleBackingCallWithAllStatuses(t *testing.T) {
+	var calls []beadslib.WorkFilter
+	storage := &nativeDoltStorageSpy{
+		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
+			calls = append(calls, filter)
+			return []*beadslib.Issue{
+				{ID: "gc-open", Title: "open", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2},
+			}, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	got, err := store.Ready(ReadyQuery{TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "gc-open" {
+		t.Fatalf("Ready = %+v, want the one open bead", got)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("backing GetReadyWork calls = %d, want 1 (filters: %+v)", len(calls), calls)
+	}
+	if calls[0].Status != "" {
+		t.Fatalf("singular Status = %q, want empty (Statuses must carry the set)", calls[0].Status)
+	}
+	if !reflect.DeepEqual(calls[0].Statuses, nativeDoltOpenReadyStatuses) {
+		t.Fatalf("Statuses = %v, want %v", calls[0].Statuses, nativeDoltOpenReadyStatuses)
+	}
+	if !calls[0].IncludeEphemeral {
+		t.Fatal("IncludeEphemeral must be set for TierBoth")
+	}
+}
+
+func TestNativeDoltStoreReadyAssigneeSingleBackingCall(t *testing.T) {
+	var calls []beadslib.WorkFilter
+	storage := &nativeDoltStorageSpy{
+		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
+			calls = append(calls, filter)
+			return nil, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	if _, err := store.Ready(ReadyQuery{TierMode: TierBoth, Assignee: "probe-me", Limit: 3}); err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("backing GetReadyWork calls = %d, want 1", len(calls))
+	}
+	if calls[0].Assignee == nil || *calls[0].Assignee != "probe-me" {
+		t.Fatalf("Assignee filter = %v, want probe-me", calls[0].Assignee)
+	}
+	if calls[0].Limit != 0 {
+		t.Fatalf("backing Limit = %d, want 0 (limit applies client-side after the gc post-filter)", calls[0].Limit)
+	}
+}

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -359,7 +359,7 @@ func TestNativeDoltStoreReadyOnlyIncludesOpenAndDeferredUpstreamStatuses(t *test
 		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
 			var result []*beadslib.Issue
 			for _, issue := range issues {
-				if issue.Status != filter.Status {
+				if !workFilterMatchesStatus(filter, issue.Status) {
 					continue
 				}
 				result = append(result, cloneNativeIssueForTest(issue))
@@ -444,7 +444,7 @@ func TestNativeDoltStoreReadyExcludesIndefinitelyDeferredBeads(t *testing.T) {
 		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
 			var result []*beadslib.Issue
 			for _, issue := range issues {
-				if issue.Status != filter.Status {
+				if !workFilterMatchesStatus(filter, issue.Status) {
 					continue
 				}
 				result = append(result, cloneNativeIssueForTest(issue))

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -312,9 +312,20 @@ func TestNativeDoltStoreReadyIncludesOpenNormalizedUpstreamStatuses(t *testing.T
 	}
 	storage := &nativeDoltStorageSpy{
 		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
+			match := func(status beadslib.Status) bool {
+				if filter.Status != "" {
+					return status == filter.Status
+				}
+				for _, s := range filter.Statuses {
+					if status == s {
+						return true
+					}
+				}
+				return false
+			}
 			var result []*beadslib.Issue
 			for _, issue := range issues {
-				if issue.Status != filter.Status {
+				if !match(issue.Status) {
 					continue
 				}
 				result = append(result, cloneNativeIssueForTest(issue))


### PR DESCRIPTION
> **Dependency satisfied — ready for review.** This PR waited on `WorkFilter.Statuses` (gastownhall/beads#4752, merged 2026-07-26, plus the index fix #4751, merged 2026-07-28). `main` already pins a beads version that carries the field (`steveyegge/beads v1.1.1-0.20260805093327-bf97b73749ac`, `internal/types/types.go` `WorkFilter.Statuses`), so no go.mod bump is needed and the fork pin branch is obsolete. Rebased onto `main` @ `b1153eb25`.

## Problem

`NativeDoltStore.Ready()` issues one `storage.GetReadyWork` per status in `nativeDoltOpenReadyStatuses` — 7 sequential backing calls. Each re-pays the deferred-parents pre-query (whose wisps `defer_until` probe is an unindexed fat-row scan until beads#4751), the wisps search arm, and the per-transaction round trips.

Measured on a live server-mode store (~190 issues, ~1.8k wisps): one `Ready(assignee)` probe costs **~240-500ms**; the reconciler pays that per assignee per store per tick inside `collect_assigned_work`, which keeps the demand-snapshot phase dominant in steady state.

## Change

One `GetReadyWork` call with `WorkFilter.Statuses` carrying the whole set. Client-side post-filter, status normalization, dedup, and limit semantics unchanged; backing `Limit` stays 0 because the gc-side post-filter (tier, excluded types/labels, defer) discards rows the store cannot, so a server-side limit could under-fill.

### The indefinite-deferral guard, ported

`main` gained a guard inside the per-status loop since this branch was opened: skip `status=deferred` rows whose `defer_until` is nil, so `bd defer <id>`'s status-based indefinite hide is not resurfaced as an ordinary open bead once `beadFromNativeIssue` erases the raw status. It keyed off `status` — the status the loop was *querying for* — which no longer exists when the whole set travels in one call.

The row's own raw status is the equivalent discriminator, so the guard now reads `issue.Status`. It is load-bearing and verified so: with the guard disabled, `TestNativeDoltStoreReadyExcludesIndefinitelyDeferredBeads` fails with `gc-deferred-indefinite` surfacing as ready (`Ready len = 3, want 2`).

## Measured (live store)

| call | before | after |
|---|---|---|
| Ready(assignee probe, TierBoth) | 401ms med | **31ms med (~13x)** |
| Ready(TierBoth, limit=3) | 128ms med | **41ms med** |

Results verified identical against live data across TierBoth/TierIssues × with/without assignee.

## Tests

- `TestNativeDoltStoreReadySingleBackingCallWithAllStatuses` — one call, full status set, empty singular `Status`, `IncludeEphemeral` for TierBoth
- `TestNativeDoltStoreReadyAssigneeSingleBackingCall` — assignee propagated, backing `Limit` stays 0
- Both existing `GetReadyWork` spies that keyed on `filter.Status` now share a `workFilterMatchesStatus` helper (assertions unchanged). This is a trap worth naming: a spy matching only the singular field silently returns **nothing** once the query moves to `Statuses`, so the test passes vacuously or fails far from the cause.

Verification on the rebased tree (`TMPDIR` on disk, `CGO_ENABLED=1 -tags gms_pure_go`): `go build ./...` ✓, `go vet ./internal/beads/` ✓, `gofmt` clean, full `go test ./internal/beads/...` PASS (44.9s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
