### PR TITLE
test(cmd/gc): regression coverage for rig-scoped pool default scale_check + work_query (#4189)

### DIFF
--- a/cmd/gc/rig_pool_scale_hook_4189_test.go
+++ b/cmd/gc/rig_pool_scale_hook_4189_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestRigScopedPoolDefaultsCoverFieldScenario_4189 is a combined regression
+// guard for #4189 (the moneymachine field report): a rig-scoped pool agent
+// with NEITHER an explicit scale_check NOR an explicit work_query must still
+// (a) report non-zero controller demand and (b) have `gc hook` surface the
+// same ready, unassigned, routed bead — both sourced from the agent's own
+// rig store, with no local workaround. The two halves were previously
+// covered separately (scale-from-zero demand tests; hook rig-store env
+// wiring tests) but never asserted together against one shared bead/target,
+// which is the exact combination the field report needed verified.
+func TestRigScopedPoolDefaultsCoverFieldScenario_4189(t *testing.T) {
+	t.Run("demand", func(t *testing.T) {
+		cfg, cityStore, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+		if _, err := rigStores["rig-A"].Create(beads.Bead{
+			ID:       "bead-4189",
+			Status:   "open",
+			Type:     "task",
+			Metadata: map[string]string{"gc.routed_to": qualified},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		result := buildDesiredStateWithSessionBeads(
+			"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+			cityStore, rigStores, &sessionBeadSnapshot{}, nil, os.Stderr,
+		)
+
+		if got := result.ScaleCheckCounts[qualified]; got != 1 {
+			t.Errorf("controller demand = %d, want 1 (default scale_check must read the rig store for a no-scale_check rig pool agent)", got)
+		}
+	})
+
+	t.Run("hook", func(t *testing.T) {
+		clearGCEnv(t)
+		disableManagedDoltRecoveryForTest(t)
+		t.Setenv("GC_TMUX_SESSION", "rig-a-executor-4189")
+		cityDir := t.TempDir()
+		rigDir := filepath.Join(cityDir, "rig-A-repo")
+		fakeBin := t.TempDir()
+
+		if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "rig-A"
+path = %q
+
+[[agent]]
+name = "executor"
+dir = "rig-A"
+
+[agent.pool]
+min = 0
+max = 5
+`, rigDir)
+		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Fake bd: any invocation whose args contain the canonical
+		// routed/unassigned predicate for rig-A/executor returns one ready
+		// bead; every other invocation (assigned-tier probes, ephemeral
+		// probes, the legacy run_target migration tier) returns an empty
+		// array, exactly like a real store with no other work.
+		fakeBD := filepath.Join(fakeBin, "bd")
+		script := "#!/bin/sh\n" +
+			"for a in \"$@\"; do\n" +
+			"  case \"$a\" in\n" +
+			"    *'gc.routed_to=rig-A/executor'*)\n" +
+			"      printf '[{\"id\":\"bead-4189\",\"status\":\"open\",\"type\":\"task\",\"metadata\":{\"gc.routed_to\":\"rig-A/executor\"}}]'\n" +
+			"      exit 0\n" +
+			"      ;;\n" +
+			"  esac\n" +
+			"done\n" +
+			"printf '[]'\n"
+		if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		origPath := os.Getenv("PATH")
+		t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
+		t.Setenv("GC_CITY", cityDir)
+		t.Setenv("GC_AGENT", "rig-A/executor")
+
+		var stdout, stderr bytes.Buffer
+		code := cmdHook(nil, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("cmdHook() = %d, want 0 (default work_query must surface the routed rig-store bead); stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if !strings.Contains(stdout.String(), "bead-4189") {
+			t.Fatalf("stdout = %q, want it to surface bead-4189", stdout.String())
+		}
+	})
+}


### PR DESCRIPTION
# PR draft — test(cmd/gc): regression coverage for rig-scoped pool default scale_check + work_query (#4189)

**Branch:** `test/rig-pool-default-scale-hook-4189` (cut from `upstream/main` @ `b4f35f4a064bd3957a54177dca746a03869f6b67`)
**Commit:** `860bf1d9d`
**Files touched:** `cmd/gc/rig_pool_scale_hook_4189_test.go` (new, +114), no production code changes.

## Title

test(cmd/gc): regression coverage for rig-scoped pool default scale_check + work_query (#4189)

## Body

Closes the verification ask in #4189.

### Field report

Moneymachine hit an apparent pool-dispatch failure during a Gas Town
migration burn-in: a rig-scoped pool agent with no explicit `scale_check`
and no explicit `work_query` seemed to report zero demand and surface no
work, even with ready, unassigned, routed work sitting in its own rig
store. Moneymachine added local `scale_check`/`work_query` workarounds
pending upstream verification, and #4189 asked for:

> a regression that creates a rig-scoped pool agent with no explicit
> `scale_check` and no explicit `work_query`, creates ready unassigned
> work routed to that agent in the rig store, and proves both:
> - controller demand is non-zero / a worker is desired;
> - `gc hook` from that worker context surfaces the work.

### What I found

Both code paths already do the right thing on current `main`:

- `defaultScaleCheckTargetForAgent` (`cmd/gc/build_desired_state.go:1470`)
  correctly resolves a rig-scoped agent's default scale-check target to
  its own rig store (`"rig:" + rigName`), not the city store.
- `EffectiveWorkQueryForBeads`'s Tier-3 fallback
  (`internal/config/workquery.go:294-325`) and `cmd_hook.go`'s rig-scoped
  env wiring (`hookQueryEnv`, referencing #514) correctly build a
  `bd ready --metadata-field gc.routed_to=$target --unassigned ...` query
  against the rig store.

Existing tests cover each half separately:
`TestBuildDesiredState_ScaleFromZero_NoScaleCheck_OwnRigStillWakes` for
demand, `TestCmdHookOverridesInheritedCityBeadsDir` /
`TestCmdHookUsesAgentCityAndRigRoot` for the hook's rig-store env wiring.
Nothing asserted both halves together against one shared bead/target —
the exact combination the field report needed confirmed before
moneymachine could safely drop its local workarounds.

### What this PR adds

`TestRigScopedPoolDefaultsCoverFieldScenario_4189`, a single test with two
subtests sharing one scenario (rig `rig-A`, agent `executor`, no
`scale_check`, no `work_query`):

- `demand`: creates one ready, unassigned, `rig-A/executor`-routed bead in
  the rig store, calls `buildDesiredStateWithSessionBeads`, asserts
  `ScaleCheckCounts["rig-A/executor"] == 1`.
- `hook`: same city/agent shape via a real `city.toml`, a fake `bd` on
  `PATH` that returns the routed bead only when the invocation's args
  contain the canonical `gc.routed_to=rig-A/executor` predicate (`[]`
  otherwise, matching a real empty store for every other tier), calls the
  real `cmdHook`, asserts exit code 0 and that the bead is surfaced in
  stdout.

No production code changes — this is coverage, not a fix.

### Validation

- `go test ./cmd/gc/ -run 'TestRigScopedPoolDefaultsCoverFieldScenario_4189|TestBuildDesiredState_ScaleFromZero_NoScaleCheck|TestCmdHook' -tags gms_pure_go -v`:
  24/24 pass, no regressions.
- Confirmed the new test is not vacuous: temporarily mismatched the
  bead's `routed_to` target (demand half) and the fake `bd`'s match
  target (hook half) — both subtests fail as expected — then reverted.
- `gofmt -l` clean, `go vet ./cmd/gc/...` clean.

### Release note for the issue

Per #4189's acceptance criteria: the default rig-scoped pool
`scale_check`/`work_query` behavior verified here is present on current
`upstream/main` (`b4f35f4a0`). I did not bisect which specific release
first contained it (PR #1594 plus the rig-store scale-check work look
like the relevant landings, per the issue's own pointers) — flagging
that as still open for the reporter/maintainer to confirm the exact
release boundary. Once confirmed, moneymachine can drop its local
`.gascity/agents/polecat/agent.toml` workarounds.
