### PR TITLE
fix(materialize): log a debug line when a shared skill-catalog name is shadowed (#4131)

### DIFF
--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -38,6 +38,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -172,9 +173,15 @@ func LoadCityCatalog(packSkillsDir string, imported ...config.DiscoveredSkillCat
 
 	addEntry := func(entry SkillEntry) {
 		if existing, dup := nameOwner[entry.Name]; dup {
+			winner := cat.Entries[existing].Origin
+			slog.Debug("skill shared-catalog name shadowed",
+				"name", entry.Name,
+				"winner", winner,
+				"loser", entry.Origin,
+			)
 			cat.Shadowed = append(cat.Shadowed, ShadowedEntry{
 				Name:   entry.Name,
-				Winner: cat.Entries[existing].Origin,
+				Winner: winner,
 				Loser:  entry.Origin,
 			})
 			return

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -1,6 +1,8 @@
 package materialize
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -243,6 +245,65 @@ func TestLoadCityCatalogBootstrapMerge(t *testing.T) {
 	// City root + every bootstrap pack root that contributed.
 	if len(cat.OwnedRoots) < 3 {
 		t.Fatalf("want >=3 owned roots (city + 2 bootstrap), got %v", cat.OwnedRoots)
+	}
+}
+
+// TestLoadCityCatalogLogsDebugLineOnShadow is a regression guard for #4131:
+// engdocs/proposals/skill-materialization.md promises "the materializer
+// logs a debug line noting the shadowed source" on a shared-catalog name
+// collision, but addEntry's collision branch never called any logger.
+// This pins the promised signal without changing the winner/loser
+// precedence itself.
+func TestLoadCityCatalogLogsDebugLineOnShadow(t *testing.T) {
+	overrideBootstrapPacks(t, "core", "registry")
+	gcHome := setupBootstrapHome(t, map[string][]string{
+		"core":     {"alpha", "shared"},
+		"registry": {"reg-only"},
+	})
+	t.Setenv("GC_HOME", gcHome)
+
+	pack := t.TempDir()
+	cityDir := filepath.Join(pack, "skills")
+	mkSkill(t, cityDir, "city-only")
+	mkSkill(t, cityDir, "shared") // collides with core/shared — city must win
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cat, err := LoadCityCatalog(cityDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cat.Shadowed) != 1 {
+		t.Fatalf("want 1 shadowed entry (setup precondition), got %+v", cat.Shadowed)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "level=DEBUG") {
+		t.Fatalf("want a DEBUG-level log line on shadow, got: %q", logged)
+	}
+	if !strings.Contains(logged, "name=shared") {
+		t.Fatalf("want the shadowed name in the log line, got: %q", logged)
+	}
+	if !strings.Contains(logged, "winner=city") {
+		t.Fatalf("want the winning origin in the log line, got: %q", logged)
+	}
+	if !strings.Contains(logged, "loser=core") {
+		t.Fatalf("want the shadowed origin in the log line, got: %q", logged)
+	}
+
+	// A non-colliding load must stay silent: the debug line is diagnostic
+	// signal for an actual shadow, not routine catalog-load noise.
+	buf.Reset()
+	quietDir := filepath.Join(t.TempDir(), "skills")
+	mkSkill(t, quietDir, "solo")
+	if _, err := LoadCityCatalog(quietDir); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("want no log output for a collision-free load, got: %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
# PR draft — fix(materialize): log a debug line when a shared skill-catalog name is shadowed (#4131)

**Branch:** `fix/skill-catalog-shadow-debug-log-4131` (cut from `upstream/main` @ `f9c1fc52022bc866e3e5a39fde14e2811f4b49f1`)
**Commit:** `d8bf8b28b`
**Files touched:** `internal/materialize/skills.go` (+9/-1), `internal/materialize/skills_test.go` (+61, new test).

## Title

fix(materialize): log a debug line when a shared skill-catalog name is shadowed (#4131)

## Body

Fixes the specific gap in #4131 (Fix candidate A from the issue's own writeup).

### Bug

`engdocs/proposals/skill-materialization.md` promises that a shared-catalog
name collision (e.g. a city-level pack import and a rig-level pack import
both binding a skill named the same thing) "logs a debug line noting the
shadowed source." `LoadCityCatalog`'s `addEntry` (`internal/materialize/skills.go`)
already computes and records the collision in `cat.Shadowed`, but never
called any logger — the promised signal did not exist anywhere in the code.
The only three call sites that touch `cat.Shadowed`
(`cmd/gc/skill_supervisor.go`, `cmd/gc/cmd_internal_materialize_skills.go`,
`cmd/gc/skill_catalog_cache.go`) discard it without reading it back.

### Fix

Added the promised `slog.Debug` call inside `addEntry`'s collision branch,
logging `name`/`winner`/`loser` origins. No change to precedence (city
still wins over bootstrap/imports, as designed) and no change to
`gc doctor`'s collision validator.

### Scope note (matches the issue's own recommendation to leave this open)

The issue's writeup lays out two fix candidates: (A) the debug line this PR
adds, and (B) extending `gc doctor`'s collision check — currently
agent-local-skills only — to also surface `cat.Shadowed` from the shared
pack catalog. The reporter explicitly flagged B as needing a maintainer
decision on severity (warning vs. hard error, whether it should block
`gc start` the way agent-local collisions do today) before it's built. This
PR only does A — it closes the literal design-doc gap without presuming
that severity decision. Happy to follow up with B once there's a steer on
severity, if maintainers want it as a separate PR.

### Validation

- New test `TestLoadCityCatalogLogsDebugLineOnShadow`: asserts the DEBUG
  line fires with the correct `name`/`winner`/`loser` on a collision (reusing
  the existing `TestLoadCityCatalogBootstrapMerge` collision fixture), and
  stays silent on a collision-free load. TDD RED (test written and run
  against pre-fix code, fails as expected — no log line) → GREEN.
- Full `internal/materialize` suite: 58 tests pass, no regressions.
- `cmd/gc` skills subsystem (materialize-skills, skill list, catalog cache,
  collision checks, prompt fragments): 49 tests pass, no regressions.
- `gofmt -l` clean, `go vet ./internal/materialize/... ./cmd/gc/...` clean.
