### PR TITLE
fix(cmd/gc): lint no longer flags the documented pool-disable form as a named-session conflict (#4184)

### DIFF
--- a/cmd/gc/cmd_lint.go
+++ b/cmd/gc/cmd_lint.go
@@ -220,11 +220,28 @@ func lintNamedSessionPoolConflicts(packPath string, loaded *config.LintPackLoad)
 }
 
 func agentHasPoolControls(agentCfg config.Agent) bool {
+	if agentPoolExplicitlyDisabled(agentCfg) {
+		return false
+	}
 	return agentCfg.MinActiveSessions != nil ||
 		agentCfg.MaxActiveSessions != nil ||
 		strings.TrimSpace(agentCfg.ScaleCheck) != "" ||
 		strings.TrimSpace(agentCfg.Namepool) != "" ||
 		len(agentCfg.NamepoolNames) > 0
+}
+
+// agentPoolExplicitlyDisabled reports whether agentCfg uses the documented
+// min_active_sessions=0 + max_active_sessions=0 form to intentionally
+// disable pooling (TestValidateAgentsPoolMaxZeroIsValid in
+// internal/config), as opposed to an actual pool configuration. That form
+// genuinely suppresses pool spawns, so it is not a pool/named-session
+// conflict.
+func agentPoolExplicitlyDisabled(agentCfg config.Agent) bool {
+	return agentCfg.MinActiveSessions != nil && *agentCfg.MinActiveSessions == 0 &&
+		agentCfg.MaxActiveSessions != nil && *agentCfg.MaxActiveSessions == 0 &&
+		strings.TrimSpace(agentCfg.ScaleCheck) == "" &&
+		strings.TrimSpace(agentCfg.Namepool) == "" &&
+		len(agentCfg.NamepoolNames) == 0
 }
 
 func collectLintPromptTargets(packDir string, loaded *config.LintPackLoad) ([]lintPromptTarget, []lintDiagnostic) {

--- a/cmd/gc/cmd_lint_test.go
+++ b/cmd/gc/cmd_lint_test.go
@@ -187,6 +187,43 @@ mode = "on_demand"
 	}
 }
 
+// TestLintAllowsNamedSessionOnExplicitlyDisabledPoolAgent is a regression
+// guard for #4184 problem 2: min_active_sessions=0 + max_active_sessions=0
+// is documented (TestValidateAgentsPoolMaxZeroIsValid) as the intentional
+// way to disable an agent's pool — it is not a pool. The lint rule must not
+// re-flag it as "pool-controlled" the same way it flags a real pool
+// (e.g. min=0/max=3 in TestLintRejectsNamedSessionBackedByPoolControlledAgent
+// above).
+func TestLintAllowsNamedSessionOnExplicitlyDisabledPoolAgent(t *testing.T) {
+	packDir := t.TempDir()
+	writeLintFile(t, filepath.Join(packDir, "pack.toml"), `[pack]
+name = "disabled-pool-named"
+version = "0.1.0"
+schema = 2
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.template.md"
+min_active_sessions = 0
+max_active_sessions = 0
+
+[[named_session]]
+template = "worker"
+scope = "rig"
+mode = "on_demand"
+`)
+	writeLintFile(t, filepath.Join(packDir, "prompts", "worker.template.md"), "hello {{.AgentName}}\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"lint", packDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc lint failed on an explicitly disabled pool agent, want pass\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "pool-controlled agent") {
+		t.Fatalf("stderr wrongly flagged the documented max=0 disable form as pool-controlled:\n%s", stderr.String())
+	}
+}
+
 func TestLintPromptDiscoverySkipsIgnoredDirs(t *testing.T) {
 	packDir := t.TempDir()
 	writeLintPack(t, packDir, "skip-dirs", "worker", "prompts/worker.template.md")


### PR DESCRIPTION
# PR draft — fix(cmd/gc): lint no longer flags the documented pool-disable form as a named-session conflict (#4184)

**Branch:** `fix/lint-named-session-pool-disable-form-4184` (cut from `upstream/main` @ `f604b1e7c4f47bd0599f4366140ea9df93aa1fe7`)
**Commit:** `43f63f409`
**Files touched:** `cmd/gc/cmd_lint.go` (+17), `cmd/gc/cmd_lint_test.go` (+37, new test).

## Title

fix(cmd/gc): lint no longer flags the documented pool-disable form as a named-session conflict (#4184)

## Body

Fixes problem 2 of #4184.

### Bug

`min_active_sessions = 0` + `max_active_sessions = 0` is upstream's
documented way to intentionally disable an agent's pool
(`TestValidateAgentsPoolMaxZeroIsValid` in `internal/config`) — it
genuinely suppresses pool spawns. But `gc lint`'s
`agentHasPoolControls` (`cmd/gc/cmd_lint.go`) treats any explicit
`min`/`max` setting as "this agent has pool control," so lint re-emits
`named_session "X" targets pool-controlled agent "X"; remove pool
settings from named-session templates...` for the disable form exactly
as it does for a real pool — even though the warning's own
prescription (remove the pool settings) doesn't apply: the settings
are already the maximally-disabled state.

### Fix

Added `agentPoolExplicitlyDisabled`, checked before the existing pool
checks in `agentHasPoolControls`. Recognizes the exact documented
disable shape (`min=0 AND max=0`, no `scale_check`/`namepool`/
`namepool_names`) and treats it as "no pool," matching
`ValidateAgents`' own semantics for the same shape.

### Scope note (deliberately narrow)

#4184 describes two problems. This PR only fixes problem 2 (the false
positive on the disable form). Problem 1 — that the warning's
prescribed fix for a *real* pool conflict (deleting the pool settings
entirely) resolves to an implicit `{0,-1}` pool rather than actually
ending pooling — is, per the issue's own writeup, entangled with
#4183's larger named-session/pool duality question ("there is
currently no pack-side edit that satisfies both this lint rule and
single-identity runtime behavior... filed separately: #4183"). Left
out of scope here rather than guessing at a fix ahead of that design
question landing.

### Validation

- New test `TestLintAllowsNamedSessionOnExplicitlyDisabledPoolAgent`
  (disable form, `min=0`/`max=0`): TDD RED — fails pre-fix with the
  same false-positive warning as a real pool conflict — → GREEN
  post-fix.
- The existing `TestLintRejectsNamedSessionBackedByPoolControlledAgent`
  (real pool, `min=0`/`max=3`) still fails lint exactly as before,
  confirming the fix narrows the check rather than silencing it.
- Full `cmd/gc` lint suite: 18/18 pass, no regressions.
- `gofmt -l` clean, `go vet ./cmd/gc/...` clean.
