### PR TITLE
fix(runproj): warming snapshot no longer marshals historicalLanes/recentChanges as null (#4142)

### DIFF
--- a/internal/runproj/enrich.go
+++ b/internal/runproj/enrich.go
@@ -112,6 +112,17 @@ func EnrichRunSummary(s RunSummary, sessions []DashboardSession, sessionsAvailab
 	out.BlockedLanes = blockedLanes
 	out.RunCounts = runCounts(liveActive, len(liveActive), len(blockedLanes))
 	out.Census = RunCensusState{Status: "available", Data: buildCensus(censusInput)}
+	// HistoricalLanes/RecentChanges are not derived here (BuildRunSummary owns
+	// them); a zero-value input (the warming snapshot, served while the run
+	// projection is still cold-replaying) would otherwise leave them nil,
+	// which marshals as JSON null. The SPA's strict edge decoder requires
+	// every RunSummary array field to be an actual array (issue #4142).
+	if out.HistoricalLanes == nil {
+		out.HistoricalLanes = []RunLane{}
+	}
+	if out.RecentChanges == nil {
+		out.RecentChanges = []RunChange{}
+	}
 	return out
 }
 

--- a/internal/runproj/enrich_test.go
+++ b/internal/runproj/enrich_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,33 @@ func TestEnrichRunSummaryGolden(t *testing.T) {
 	}
 	if !bytes.Equal(got, want) {
 		t.Errorf("enriched run summary does not match golden:\n%s", unifiedDiff(string(want), string(got)))
+	}
+}
+
+// TestEnrichRunSummaryWarmingPathMarshalsArraysNotNull is a regression guard
+// for #4142: the dashboard warming snapshot (cityRunTailer.enrichedSummary,
+// served while the run projection is still cold-replaying) enriches a
+// zero-value RunSummary. EnrichRunSummary sets Lanes/BlockedLanes/RunCounts/
+// Census but never touched HistoricalLanes/RecentChanges, so those two
+// stayed nil and marshaled as JSON null. The SPA's strict edge decoder
+// (decodeRunSummary) requires all four array fields to be actual arrays —
+// Array.isArray(null) is false — so a warming response threw
+// ApiResponseDecodeError on an HTTP 200, and AmbientHome permanently showed
+// "Run data is unavailable" for the life of the tab (only a manual reload
+// after warm-up recovered it).
+func TestEnrichRunSummaryWarmingPathMarshalsArraysNotNull(t *testing.T) {
+	enriched := EnrichRunSummary(RunSummary{}, nil, false, 0, nil)
+	enriched.LanesPartial = true
+
+	raw, err := json.Marshal(enriched)
+	if err != nil {
+		t.Fatalf("marshal warming summary: %v", err)
+	}
+	body := string(raw)
+	for _, field := range []string{"lanes", "historicalLanes", "blockedLanes", "recentChanges"} {
+		if strings.Contains(body, `"`+field+`":null`) {
+			t.Errorf("warming summary marshals %q as null (SPA decodeRunSummary requires an array): %s", field, body)
+		}
 	}
 }
 


### PR DESCRIPTION
# PR draft — fix(runproj): warming snapshot no longer marshals historicalLanes/recentChanges as null (#4142)

**Branch:** `fix/warming-summary-null-arrays-4142` (cut from `upstream/main` @ `c321da9c717ad43b3eb0f005c7497b479bb38435`)
**Commit:** `13629c8da`
**Files touched:** `internal/runproj/enrich.go` (+11), `internal/runproj/enrich_test.go` (+28, new test).

## Title

fix(runproj): warming snapshot no longer marshals historicalLanes/recentChanges as null (#4142)

## Body

Fixes #4142.

### Bug

`cityRunTailer.enrichedSummary` serves a "warming" snapshot on a city's
first `GET /api/city/:city/runs/summary` after supervisor start, built by
enriching the zero-value `RunSummary` while the run projection is still
cold-replaying (`runColdLoadWait`, 5s). `EnrichRunSummary` sets
`Lanes`/`BlockedLanes`/`RunCounts`/`Census` but never touched
`HistoricalLanes`/`RecentChanges` — they stayed `nil`, and Go marshals nil
slices as JSON `null`.

The SPA's strict edge decoder (`decodeRunSummary`) requires those fields
to be arrays (`Array.isArray(null)` is `false`), so it throws
`ApiResponseDecodeError` on an HTTP 200 — nothing in server logs.
`loadRunSummarySource` converts the throw to `{status:'error'}`,
`useCachedData` caches it, and `AmbientHome` renders "Run data is
unavailable" — permanently, since Home only fetches on mount.

### Fix

Initialize both fields to empty slices when nil in `EnrichRunSummary`,
matching the fix the issue itself proposed.

### Validation

- New test `TestEnrichRunSummaryWarmingPathMarshalsArraysNotNull` (adapted
  from the regression probe already included in the issue body, fit to
  this package's existing conventions rather than a standalone file): TDD
  RED reproduced the exact reported bytes (`historicalLanes`/
  `recentChanges` as `null`) → GREEN after the fix.
- The existing `TestEnrichRunSummaryGolden` (real, non-zero-value
  enrichment against the TS-oracle golden fixture) still passes
  unchanged, confirming the fix only affects the nil/zero-value case.
- Full `internal/runproj` + `internal/api/dashboardbff` suites pass, no
  regressions.
- `gofmt -l` clean, `go vet ./internal/runproj/... ./internal/api/dashboardbff/...` clean.

### Scope note

The issue also flags a "secondary wart": Home caches a transient warming
error as permanent `SourceState` data with no retry/poll, so a *transient*
failure becomes *permanent* per tab even independent of this bug. That's a
frontend TS change in a different subsystem (`useCachedData`/
`loadRunSummarySource`) — left out of this Go-side PR; happy to follow up
separately if useful.
