### PR TITLE
ci: make triage/needs-info label removal idempotent (swallow 404)

### DIFF
--- a/.github/workflows/remove-needs-info.yml
+++ b/.github/workflows/remove-needs-info.yml
@@ -43,11 +43,23 @@ jobs:
 
             for (const label of labels) {
               if (!currentNames.includes(label)) continue;
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: number,
-                name: label,
-              });
-              console.log(`Removed '${label}' from #${number}`);
+              // Idempotent removal: concurrent triggers can race to remove the
+              // same label, leaving the loser with a 404 "Label does not
+              // exist". Treat an already-absent label as success rather than
+              // failing the job.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  name: label,
+                });
+                console.log(`Removed '${label}' from #${number}`);
+              } catch (err) {
+                if (err.status === 404) {
+                  console.log(`'${label}' already absent from #${number} (concurrent removal); nothing to do`);
+                  continue;
+                }
+                throw err;
+              }
             }

--- a/.github/workflows/remove-needs-triage.yml
+++ b/.github/workflows/remove-needs-triage.yml
@@ -35,10 +35,25 @@ jobs:
 
             if (!current.data.some(l => l.name === target)) return;
 
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: number,
-              name: target,
-            });
-            console.log(`Removed '${target}' from #${number} (triaged with '${added}')`);
+            // The check above narrows a race but cannot close it: adding
+            // several non-status labels at once fires one `labeled` event
+            // (and one job) each, and they run concurrently. Every run sees
+            // the label present here, then all race to remove it. The winner
+            // gets 204; the losers get 404 "Label does not exist". Treat an
+            // already-absent label as success so a benign lost race does not
+            // paint a red X on the PR's checks.
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                name: target,
+              });
+              console.log(`Removed '${target}' from #${number} (triaged with '${added}')`);
+            } catch (err) {
+              if (err.status === 404) {
+                console.log(`'${target}' already absent from #${number} (concurrent removal); nothing to do`);
+                return;
+              }
+              throw err;
+            }


### PR DESCRIPTION
## Problem

The two label-hygiene workflows remove a label with a **check-then-act**
sequence:

```js
const current = await github.rest.issues.listLabelsOnIssue({...});
if (!current.data.some(l => l.name === target)) return;   // check
await github.rest.issues.removeLabel({..., name: target}); // act
```

This is a TOCTOU race. `remove-needs-triage` triggers on every `labeled`
event, so adding *N* non-status labels at once fires *N* concurrent jobs.
Each job observes the target label present at check time, then all race to
remove it. The winner gets `204`; every loser gets an unhandled
`404 "Label does not exist"` and the job goes red — a false failure on a
PR whose code is fine.

### Observed

PR #3870: a reviewer added `kind/bug` and `priority/p1` in the same second.

```
2026-07-08T23:24:26Z  labeled   kind/bug             by @julianknutsen
2026-07-08T23:24:26Z  labeled   priority/p1          by @julianknutsen
2026-07-08T23:24:32Z  unlabeled status/needs-triage  by @github-actions[bot]  ← winner
```

The second job (`priority/p1` trigger) lost the race:

```
HttpError: Label does not exist  (404)
DELETE /repos/gastownhall/gascity/issues/3870/labels/status%2Fneeds-triage
```

The pre-existing `if (!current.data.some(...)) return;` guard has been in
place since the workflow was first added (`af08f9324`, 2026-03-26) — it
narrows the window but cannot close it, because both jobs pass the check
before either calls `removeLabel`.

## Fix

Make removal idempotent: wrap `removeLabel` and treat a `404` as success.
Removal is idempotent by intent, so "the label is already gone" is exactly
the benign outcome — not a failure. Applied to both `remove-needs-triage.yml`
(the observed culprit) and `remove-needs-info.yml`, which shares the pattern.

No behavior change on the happy path; a genuine label removal still logs and
succeeds. Only the lost-race 404 changes: red job → benign log line.

## Validation

- Both workflows parse as YAML.
- Both `github-script` bodies pass `node --check` when wrapped in the async
  IIFE that `actions/github-script` uses to run them.
- The change is confined to error handling around an already-guarded call;
  there is no local runtime to exercise a `pull_request_target` workflow.

Root-caused while triaging the stale-CI audit bead for PR #3870
(`ga-nvwdqo`). That PR's own code is green; the only red check was this
race.
