### PR TITLE
test: guard reusable runtime provider doubles

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -476,11 +476,30 @@ the constructor-specific source of truth.
 Builtin runtime production compositions are source-bound to `cmd/gc`'s
 registry, their constructor-specific contract dispositions, and the table
 below. The auto composition lives outside that registry and is bound to the
-exact production function and `runtime/auto.New` result it returns. The known
-`runtime.NewFake` and `runtime.NewFailFake` rows are explicitly
-classified as reusable doubles; automatic discovery of newly exported reusable
-doubles is deferred to `ga-80po0c.1.1` and is not claimed by this slice. A waiver
-is a visible contract gap, not evidence that conformance passes.
+exact production function and `runtime/auto.New` result it returns. A waiver is
+a visible contract gap, not evidence that conformance passes.
+
+Reusable-double discovery is intentionally bounded, not repository-wide. The
+designated boundary is `internal/runtime/fake.go` for the `runtime.Provider`
+port. The guard type-checks its declared runtime type context, discovers every
+exported concrete type in that file whose value or pointer implements
+`runtime.Provider`, and scans the package's buildable non-test files for each
+exported receiverless function whose first result itself implements
+`runtime.Provider` and resolves to that exact type, either as the value or its
+pointer. Constructors may return additional results such as `error`; function
+bodies are outside the source guard. A value-returning constructor counts only
+when the value method set implements the port. The current surface is
+`runtime.Fake` through `runtime.NewFake` and `runtime.NewFailFake`. Aliases do
+not create a second double type and collapse to their tracked concrete type; an
+exported provider alias that exposes an otherwise-untracked type fails closed.
+Caller-local types, methods, unexported helpers, and provider types declared in
+other files are outside this boundary. An exported generic concrete type in the
+boundary fails closed because an uninstantiated generic has no single provider
+method set to inventory.
+
+Other reusable-support boundaries remain explicit follow-up work:
+`beadstest.RecordingStore`, the events and mail fakes, `fsys.Fake`, and
+`clock.Fake` are not claimed by this table.
 
 The hybrid row deliberately chooses `cmd/gc.newHybridProvider` as its
 construction boundary because that is the wrapper returned directly by the
@@ -497,23 +516,23 @@ execution; it does not own these constructor bindings.
 <!-- BEGIN CHECKED RUNTIME PROVIDER LEDGER -->
 This table is rendered from `internal/testutil/providerledger` and checked by `go test ./internal/testutil/providerledger`; edit the Go ledger, then use the expected block printed on drift.
 
-| Provider path | Roles | Port | Constructor | Discovery | Contract | Status |
-|---|---|---|---|---|---|---|
-| `runtime.builtin.acp` | production_provider | `runtime.Provider` | `internal/runtime/acp.NewSeamBacked` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw ACP provider, not the NewSeamBacked production composition |
-| `runtime.builtin.acp` | production_provider | `runtime.Provider` | `internal/runtime/acp.NewSeamBackedWithDir` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw ACP provider, not the NewSeamBackedWithDir production composition |
-| `runtime.builtin.exec` | production_provider | `runtime.Provider` | `internal/runtime/exec.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw exec provider, not the production seam-backed prefix composition |
-| `runtime.builtin.exec` | production_provider | `runtime.Provider` | `internal/runtime/t3bridge.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the legacy gc-session-t3 prefix branch selects the T3 bridge composition, which has no full shared runtime contract |
-| `runtime.builtin.fail` | production_provider, reusable_double | `runtime.Provider` | `internal/runtime.NewFailFake` | runtime.builtin/exact:fail | `runtime.Provider` | not applicable: intentional faulting double: a successful lifecycle cannot be exercised, so the successful-provider contract is not applicable |
-| `runtime.builtin.fake` | production_provider, reusable_double | `runtime.Provider` | `internal/runtime.NewFake` | runtime.builtin/exact:fake | `runtime.Provider` | waived by ga-80po0c.1.2 through 2026-08-12: existing full conformance is not yet structurally bound to runtime.NewFake; exact proof binding is deferred to ga-80po0c.1.2 |
-| `runtime.builtin.herdr` | production_provider | `runtime.Provider` | `internal/runtime/herdr.New` | runtime.builtin/exact:herdr | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the existing full conformance run skips in short mode or when the herdr executable is absent |
-| `runtime.builtin.hybrid` | production_provider | `runtime.Provider` | `cmd/gc.newHybridProvider` | runtime.builtin/exact:hybrid | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: cmd/gc.newHybridProvider is the selected registry construction boundary; its internal tmux, K8s, and hybrid constructors are not claimed here, and the wrapper has no full shared runtime contract |
-| `runtime.builtin.k8s` | production_provider | `runtime.Provider` | `internal/runtime/k8s.NewSeamBacked` | runtime.builtin/exact:k8s | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the actual K8s production composition has no full shared runtime contract |
-| `runtime.builtin.ssh` | production_provider | `runtime.Provider` | `internal/runtime/ssh.NewSeamBacked` | runtime.builtin/prefix:ssh: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the production SSH composition has no full shared runtime contract |
-| `runtime.builtin.subprocess` | production_provider | `runtime.Provider` | `internal/runtime/subprocess.NewSeamBacked` | runtime.builtin/exact:subprocess | `runtime.Provider` | waived by ga-80po0c.1.2 through 2026-08-12: NewSeamBacked exact production-constructor proof binding is deferred to ga-80po0c.1.2 |
-| `runtime.builtin.subprocess` | production_provider | `runtime.Provider` | `internal/runtime/subprocess.NewSeamBackedWithDir` | runtime.builtin/exact:subprocess | `runtime.Provider` | waived by ga-80po0c.1.2 through 2026-08-12: NewSeamBackedWithDir exact production-constructor proof binding is deferred to ga-80po0c.1.2 |
-| `runtime.builtin.t3bridge` | production_provider | `runtime.Provider` | `internal/runtime/t3bridge.NewSeamBacked` | runtime.builtin/exact:t3bridge | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the production T3 bridge composition has focused tests but no full shared runtime contract |
-| `runtime.builtin.tmux` | production_provider | `runtime.Provider` | `internal/runtime/tmux.NewSeamBackedWithConfig` | runtime.builtin/exact:tmux | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the existing full conformance run skips when the tmux executable is absent |
-| `runtime.composition.auto` | production_provider | `runtime.Provider` | `internal/runtime/auto.New` | source: cmd/gc/providers.go#resolveSessionTransportProvider — conditional transport composition is outside the runtime registry | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the production auto base/ACP composition has no full shared runtime contract |
+| Provider path | Roles | Reusable type | Port | Constructor | Discovery | Contract | Status |
+|---|---|---|---|---|---|---|---|
+| `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBacked` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw ACP provider, not the NewSeamBacked production composition |
+| `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBackedWithDir` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw ACP provider, not the NewSeamBackedWithDir production composition |
+| `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/exec.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw exec provider, not the production seam-backed prefix composition |
+| `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/t3bridge.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the legacy gc-session-t3 prefix branch selects the T3 bridge composition, which has no full shared runtime contract |
+| `runtime.builtin.fail` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFailFake` | runtime.builtin/exact:fail; reusable: internal/runtime/fake.go | `runtime.Provider` | not applicable: intentional faulting double: a successful lifecycle cannot be exercised, so the successful-provider contract is not applicable |
+| `runtime.builtin.fake` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFake` | runtime.builtin/exact:fake; reusable: internal/runtime/fake.go | `runtime.Provider` | waived by ga-80po0c.1.2 through 2026-08-12: existing full conformance is not yet structurally bound to runtime.NewFake; exact proof binding is deferred to ga-80po0c.1.2 |
+| `runtime.builtin.herdr` | production_provider | — | `runtime.Provider` | `internal/runtime/herdr.New` | runtime.builtin/exact:herdr | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the existing full conformance run skips in short mode or when the herdr executable is absent |
+| `runtime.builtin.hybrid` | production_provider | — | `runtime.Provider` | `cmd/gc.newHybridProvider` | runtime.builtin/exact:hybrid | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: cmd/gc.newHybridProvider is the selected registry construction boundary; its internal tmux, K8s, and hybrid constructors are not claimed here, and the wrapper has no full shared runtime contract |
+| `runtime.builtin.k8s` | production_provider | — | `runtime.Provider` | `internal/runtime/k8s.NewSeamBacked` | runtime.builtin/exact:k8s | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the actual K8s production composition has no full shared runtime contract |
+| `runtime.builtin.ssh` | production_provider | — | `runtime.Provider` | `internal/runtime/ssh.NewSeamBacked` | runtime.builtin/prefix:ssh: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the production SSH composition has no full shared runtime contract |
+| `runtime.builtin.subprocess` | production_provider | — | `runtime.Provider` | `internal/runtime/subprocess.NewSeamBacked` | runtime.builtin/exact:subprocess | `runtime.Provider` | waived by ga-80po0c.1.2 through 2026-08-12: NewSeamBacked exact production-constructor proof binding is deferred to ga-80po0c.1.2 |
+| `runtime.builtin.subprocess` | production_provider | — | `runtime.Provider` | `internal/runtime/subprocess.NewSeamBackedWithDir` | runtime.builtin/exact:subprocess | `runtime.Provider` | waived by ga-80po0c.1.2 through 2026-08-12: NewSeamBackedWithDir exact production-constructor proof binding is deferred to ga-80po0c.1.2 |
+| `runtime.builtin.t3bridge` | production_provider | — | `runtime.Provider` | `internal/runtime/t3bridge.NewSeamBacked` | runtime.builtin/exact:t3bridge | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the production T3 bridge composition has focused tests but no full shared runtime contract |
+| `runtime.builtin.tmux` | production_provider | — | `runtime.Provider` | `internal/runtime/tmux.NewSeamBackedWithConfig` | runtime.builtin/exact:tmux | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the existing full conformance run skips when the tmux executable is absent |
+| `runtime.composition.auto` | production_provider | — | `runtime.Provider` | `internal/runtime/auto.New` | source: cmd/gc/providers.go#resolveSessionTransportProvider — conditional transport composition is outside the runtime registry | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the production auto base/ACP composition has no full shared runtime contract |
 <!-- END CHECKED RUNTIME PROVIDER LEDGER -->
 
 Conformance tests verify the behavioral contract (create/read/update/delete,

--- a/internal/testutil/providerledger/guard.go
+++ b/internal/testutil/providerledger/guard.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"go/build"
+	"go/importer"
 	"go/parser"
 	"go/token"
 	"go/types"
@@ -19,6 +21,15 @@ import (
 // constructors returned by its registry factory.
 type RuntimeRegistration struct {
 	Key          string
+	Constructors []SymbolRef
+}
+
+const runtimeDoubleBoundaryFile = "fake.go"
+
+// ReusableDouble is one exported provider-double type from the designated type
+// boundary and the package-level constructors that return it.
+type ReusableDouble struct {
+	Type         SymbolRef
 	Constructors []SymbolRef
 }
 
@@ -53,6 +64,242 @@ func newBindingInfo(fset *token.FileSet, file *ast.File) *bindingInfo {
 
 type emptyPackageImporter struct {
 	packages map[string]*types.Package
+}
+
+type standardOrEmptyImporter struct {
+	standard types.Importer
+	empty    *emptyPackageImporter
+}
+
+func (i *standardOrEmptyImporter) Import(importPath string) (*types.Package, error) {
+	// Runtime's module-local imports are currently body-only. Empty packages
+	// keep those ignored bodies hermetic; any selector used by a declaration
+	// remains unresolved and makes the guard fail closed below.
+	if strings.HasPrefix(importPath, moduleImportPath+"/") {
+		return i.empty.Import(importPath)
+	}
+	return i.standard.Import(importPath)
+}
+
+// DiscoverRuntimeProviderDoubles discovers every exported concrete type in
+// internal/runtime/fake.go that implements runtime.Provider. It scans all
+// buildable non-test files in that package for exported receiverless
+// constructors whose first result implements Provider as an exact discovered
+// type or pointer to one.
+func DiscoverRuntimeProviderDoubles(runtimeDir string) ([]ReusableDouble, error) {
+	entries, err := os.ReadDir(runtimeDir)
+	if err != nil {
+		return nil, fmt.Errorf("read runtime package %q: %w", runtimeDir, err)
+	}
+
+	fset := token.NewFileSet()
+	var files []*ast.File
+	var boundary *ast.File
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		matches, err := build.Default.MatchFile(runtimeDir, name)
+		if err != nil {
+			return nil, fmt.Errorf("match runtime package file %q: %w", name, err)
+		}
+		if !matches {
+			continue
+		}
+		path := filepath.Join(runtimeDir, name)
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read runtime package file %q: %w", name, err)
+		}
+		file, err := parser.ParseFile(fset, path, source, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("parse runtime package file %q: %w", name, err)
+		}
+		if file.Name.Name != "runtime" {
+			if name == runtimeDoubleBoundaryFile {
+				return nil, fmt.Errorf("%s must declare package runtime", runtimeDoubleBoundaryFile)
+			}
+			return nil, fmt.Errorf("runtime package file %s must declare package runtime", name)
+		}
+		if name == runtimeDoubleBoundaryFile {
+			boundary = file
+		}
+		files = append(files, file)
+	}
+	if boundary == nil {
+		return nil, fmt.Errorf("designated runtime double boundary %s is missing", runtimeDoubleBoundaryFile)
+	}
+
+	info := types.Info{Defs: make(map[*ast.Ident]types.Object)}
+	var typeProblems []string
+	config := types.Config{
+		Importer: &standardOrEmptyImporter{
+			standard: importer.Default(),
+			empty:    &emptyPackageImporter{packages: make(map[string]*types.Package)},
+		},
+		DisableUnusedImportCheck: true,
+		IgnoreFuncBodies:         true,
+		Error: func(err error) {
+			typeProblems = append(typeProblems, err.Error())
+		},
+	}
+	pkg, _ := config.Check(moduleImportPath+"/internal/runtime", fset, files, &info)
+	if len(typeProblems) > 0 {
+		sort.Strings(typeProblems)
+		return nil, fmt.Errorf("type-check runtime double boundary: %s", strings.Join(typeProblems, "; "))
+	}
+	if pkg == nil {
+		return nil, errors.New("type-check runtime double boundary returned no package")
+	}
+	providerName, ok := pkg.Scope().Lookup("Provider").(*types.TypeName)
+	if !ok || providerName.IsAlias() {
+		return nil, errors.New("runtime.Provider must be exactly one declared interface")
+	}
+	providerNamed, ok := providerName.Type().(*types.Named)
+	if !ok {
+		return nil, errors.New("runtime.Provider must be exactly one declared interface")
+	}
+	provider, ok := providerNamed.Underlying().(*types.Interface)
+	if !ok {
+		return nil, errors.New("runtime.Provider must be exactly one declared interface")
+	}
+	provider.Complete()
+
+	var doubles []ReusableDouble
+	trackedTypes := make(map[*types.TypeName]bool)
+	for _, decl := range boundary.Decls {
+		declaration, ok := decl.(*ast.GenDecl)
+		if !ok || declaration.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range declaration.Specs {
+			typeSpec := spec.(*ast.TypeSpec)
+			if !typeSpec.Name.IsExported() || typeSpec.Assign.IsValid() {
+				continue
+			}
+			typeName, ok := info.Defs[typeSpec.Name].(*types.TypeName)
+			if !ok {
+				return nil, fmt.Errorf("resolve exported type %s in %s", typeSpec.Name.Name, runtimeDoubleBoundaryFile)
+			}
+			named, ok := typeName.Type().(*types.Named)
+			if !ok {
+				continue
+			}
+			if named.TypeParams() != nil && named.TypeParams().Len() > 0 {
+				return nil, fmt.Errorf("generic exported type %s in %s cannot be classified as a reusable provider double", typeName.Name(), runtimeDoubleBoundaryFile)
+			}
+			if _, isInterface := named.Underlying().(*types.Interface); isInterface {
+				continue
+			}
+			if !types.Implements(named, provider) && !types.Implements(types.NewPointer(named), provider) {
+				continue
+			}
+
+			constructors := runtimeDoubleConstructors(files, info, named, provider)
+			typeRef := repoSymbol("internal/runtime", typeName.Name())
+			if len(constructors) == 0 {
+				return nil, fmt.Errorf("runtime provider double %s has no exported receiverless constructor", renderSymbolRef(typeRef))
+			}
+			doubles = append(doubles, ReusableDouble{Type: typeRef, Constructors: constructors})
+			trackedTypes[named.Obj()] = true
+		}
+	}
+	for _, decl := range boundary.Decls {
+		declaration, ok := decl.(*ast.GenDecl)
+		if !ok || declaration.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range declaration.Specs {
+			typeSpec := spec.(*ast.TypeSpec)
+			if !typeSpec.Name.IsExported() || !typeSpec.Assign.IsValid() {
+				continue
+			}
+			typeName, ok := info.Defs[typeSpec.Name].(*types.TypeName)
+			if !ok {
+				return nil, fmt.Errorf("resolve exported alias %s in %s", typeSpec.Name.Name, runtimeDoubleBoundaryFile)
+			}
+			canonical, isProvider := runtimeProviderAliasTarget(typeName.Type(), provider)
+			if !isProvider {
+				continue
+			}
+			if canonical == nil || !trackedTypes[canonical.Obj()] {
+				return nil, fmt.Errorf("exported provider alias %s in %s resolves to an untracked concrete type", typeName.Name(), runtimeDoubleBoundaryFile)
+			}
+		}
+	}
+	if len(doubles) == 0 {
+		return nil, fmt.Errorf("%s declares no exported runtime.Provider double", runtimeDoubleBoundaryFile)
+	}
+	sort.Slice(doubles, func(i, j int) bool { return symbolRefLess(doubles[i].Type, doubles[j].Type) })
+	return doubles, nil
+}
+
+func runtimeDoubleConstructors(files []*ast.File, info types.Info, doubleType *types.Named, provider *types.Interface) []SymbolRef {
+	var constructors []SymbolRef
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			function, ok := decl.(*ast.FuncDecl)
+			if !ok || function.Recv != nil || !function.Name.IsExported() {
+				continue
+			}
+			object, ok := info.Defs[function.Name].(*types.Func)
+			if !ok {
+				continue
+			}
+			signature, ok := object.Type().(*types.Signature)
+			if !ok || signature.Results().Len() == 0 {
+				continue
+			}
+			named, ok := runtimeProviderConstructorType(signature.Results().At(0).Type(), provider)
+			if !ok || named.Obj() != doubleType.Obj() {
+				continue
+			}
+			constructors = append(constructors, repoSymbol("internal/runtime", function.Name.Name))
+		}
+	}
+	return normalizeSymbolRefs(constructors)
+}
+
+func runtimeProviderAliasTarget(alias types.Type, provider *types.Interface) (*types.Named, bool) {
+	target := types.Unalias(alias)
+	if _, isInterface := target.Underlying().(*types.Interface); isInterface {
+		return nil, false
+	}
+	implements := types.Implements(target, provider)
+	if !implements {
+		if _, isPointer := target.(*types.Pointer); !isPointer {
+			implements = types.Implements(types.NewPointer(target), provider)
+		}
+	}
+	if !implements {
+		return nil, false
+	}
+	switch target := target.(type) {
+	case *types.Named:
+		return target, true
+	case *types.Pointer:
+		named, _ := types.Unalias(target.Elem()).(*types.Named)
+		return named, true
+	default:
+		return nil, true
+	}
+}
+
+func runtimeProviderConstructorType(result types.Type, provider *types.Interface) (*types.Named, bool) {
+	result = types.Unalias(result)
+	if !types.Implements(result, provider) {
+		return nil, false
+	}
+	switch result := result.(type) {
+	case *types.Named:
+		return result, true
+	case *types.Pointer:
+		named, ok := types.Unalias(result.Elem()).(*types.Named)
+		return named, ok
+	default:
+		return nil, false
+	}
 }
 
 func (i *emptyPackageImporter) Import(importPath string) (*types.Package, error) {
@@ -543,6 +790,89 @@ func CompareRuntimeCatalog(entries []Entry, discovered []RuntimeRegistration) er
 		}
 	}
 	sort.Strings(problems)
+	return joinProblems(problems)
+}
+
+// CompareReusableDoubles checks discovered reusable-double constructors and
+// their concrete types against reusable-double ledger ownership in both
+// directions.
+func CompareReusableDoubles(entries []Entry, discovered []ReusableDouble) error {
+	type owner struct {
+		entryID    string
+		doubleType SymbolRef
+	}
+
+	ledger := make(map[SymbolRef][]owner)
+	var problems []string
+	for _, entry := range entries {
+		if !hasRole(entry.Roles, RoleReusableDouble) {
+			continue
+		}
+		if entry.DoubleType == nil {
+			problems = append(problems, fmt.Sprintf("entry %q reusable_double role requires a double type", entry.ID))
+			continue
+		}
+		if entry.DoubleBoundary != runtimeDoubleBoundaryPath {
+			problems = append(problems, fmt.Sprintf("entry %q reusable double boundary is %q, want %q", entry.ID, entry.DoubleBoundary, runtimeDoubleBoundaryPath))
+			continue
+		}
+		for _, constructor := range entry.Constructors {
+			ledger[constructor] = append(ledger[constructor], owner{entryID: entry.ID, doubleType: *entry.DoubleType})
+		}
+	}
+
+	production := make(map[SymbolRef][]SymbolRef)
+	seenTypes := make(map[SymbolRef]bool)
+	for _, double := range discovered {
+		if seenTypes[double.Type] {
+			problems = append(problems, fmt.Sprintf("runtime provider double %s is discovered more than once", renderSymbolRef(double.Type)))
+		}
+		seenTypes[double.Type] = true
+		if len(double.Constructors) == 0 {
+			problems = append(problems, fmt.Sprintf("runtime provider double %s has no exported receiverless constructor", renderSymbolRef(double.Type)))
+		}
+		seenConstructors := make(map[SymbolRef]bool)
+		for _, constructor := range double.Constructors {
+			if seenConstructors[constructor] {
+				problems = append(problems, fmt.Sprintf("runtime provider double %s repeats constructor %s", renderSymbolRef(double.Type), renderSymbolRef(constructor)))
+			}
+			seenConstructors[constructor] = true
+			production[constructor] = append(production[constructor], double.Type)
+		}
+	}
+
+	for constructor, doubleTypes := range production {
+		if len(doubleTypes) > 1 {
+			problems = append(problems, fmt.Sprintf("reusable double %s constructs multiple declared types: %s", renderSymbolRef(constructor), renderSymbolRefs(doubleTypes)))
+			continue
+		}
+		owners := ledger[constructor]
+		sort.Slice(owners, func(i, j int) bool { return owners[i].entryID < owners[j].entryID })
+		switch len(owners) {
+		case 0:
+			problems = append(problems, fmt.Sprintf("reusable double %s is missing from the ledger", renderSymbolRef(constructor)))
+		case 1:
+			if owners[0].doubleType != doubleTypes[0] {
+				problems = append(problems, fmt.Sprintf(
+					"reusable double %s constructs %s, ledger declares %s",
+					renderSymbolRef(constructor),
+					renderSymbolRef(doubleTypes[0]),
+					renderSymbolRef(owners[0].doubleType),
+				))
+			}
+		default:
+			ids := make([]string, len(owners))
+			for i, owner := range owners {
+				ids[i] = strconv.Quote(owner.entryID)
+			}
+			problems = append(problems, fmt.Sprintf("reusable double %s is owned by multiple ledger entries: %s", renderSymbolRef(constructor), strings.Join(ids, ", ")))
+		}
+	}
+	for constructor := range ledger {
+		if _, ok := production[constructor]; !ok {
+			problems = append(problems, fmt.Sprintf("ledger reusable double %s is not discovered for type boundary %s", renderSymbolRef(constructor), runtimeDoubleBoundaryPath))
+		}
+	}
 	return joinProblems(problems)
 }
 

--- a/internal/testutil/providerledger/ledger.go
+++ b/internal/testutil/providerledger/ledger.go
@@ -13,7 +13,7 @@ import (
 
 const moduleImportPath = "github.com/gastownhall/gascity"
 
-// SymbolRef identifies a Go function by import path and declared name.
+// SymbolRef identifies a Go declaration by import path and declared name.
 type SymbolRef struct {
 	ImportPath string
 	Name       string
@@ -58,6 +58,8 @@ const (
 const (
 	// RuntimeBuiltinCatalog names cmd/gc's static runtime provider registry.
 	RuntimeBuiltinCatalog = "runtime.builtin"
+	// runtimeDoubleBoundaryPath is the designated runtime.Provider double source.
+	runtimeDoubleBoundaryPath = "internal/runtime/fake.go"
 
 	// MarkdownStart begins the generated TESTING.md table.
 	MarkdownStart = "<!-- BEGIN CHECKED RUNTIME PROVIDER LEDGER -->"
@@ -98,10 +100,12 @@ type ContractClaim struct {
 
 // Entry connects one provider construction path to its required contracts.
 type Entry struct {
-	ID           string
-	Roles        []Role
-	Port         Port
-	Constructors []SymbolRef
+	ID             string
+	Roles          []Role
+	Port           Port
+	Constructors   []SymbolRef
+	DoubleType     *SymbolRef
+	DoubleBoundary string
 
 	// Production providers have exactly one catalog or source binding.
 	Catalog *CatalogRef
@@ -114,16 +118,16 @@ type Entry struct {
 func Catalog() []Entry {
 	autoConstructor := repoSymbol("internal/runtime/auto", "New")
 	return []Entry{
-		builtin(
-			"fake", "exact:fake", []Role{RoleReusableDouble},
+		reusableBuiltin(
+			"fake", "exact:fake", repoSymbol("internal/runtime", "Fake"),
 			waivedRuntime(
 				repoSymbol("internal/runtime", "NewFake"),
 				"ga-80po0c.1.2",
 				"existing full conformance is not yet structurally bound to runtime.NewFake; exact proof binding is deferred to ga-80po0c.1.2",
 			),
 		),
-		builtin(
-			"fail", "exact:fail", []Role{RoleReusableDouble},
+		reusableBuiltin(
+			"fail", "exact:fail", repoSymbol("internal/runtime", "Fake"),
 			notApplicableRuntime(
 				repoSymbol("internal/runtime", "NewFailFake"),
 				"intentional faulting double: a successful lifecycle cannot be exercised, so the successful-provider contract is not applicable",
@@ -257,6 +261,13 @@ func builtin(id, key string, extraRoles []Role, claims ...ContractClaim) Entry {
 	}
 }
 
+func reusableBuiltin(id, key string, doubleType SymbolRef, claims ...ContractClaim) Entry {
+	entry := builtin(id, key, []Role{RoleReusableDouble}, claims...)
+	entry.DoubleType = &doubleType
+	entry.DoubleBoundary = runtimeDoubleBoundaryPath
+	return entry
+}
+
 func waivedRuntime(constructor SymbolRef, owner, reason string) ContractClaim {
 	return ContractClaim{
 		Constructor: constructor,
@@ -323,6 +334,22 @@ func Validate(entries []Entry, now time.Time) error {
 		}
 		if len(roles) == 0 {
 			problems = append(problems, prefix+" requires at least one role")
+		}
+		switch {
+		case roles[RoleReusableDouble]:
+			if entry.DoubleType == nil {
+				problems = append(problems, prefix+" reusable_double role requires a double type")
+			} else if err := validateSymbolRef(*entry.DoubleType); err != nil {
+				problems = append(problems, fmt.Sprintf("%s double type: %v", prefix, err))
+			}
+			boundary := pathpkg.Clean(strings.TrimSpace(entry.DoubleBoundary))
+			if boundary == "." || strings.HasPrefix(boundary, "../") || strings.HasPrefix(boundary, "/") {
+				problems = append(problems, prefix+" reusable_double role requires a repository-relative double boundary")
+			}
+		case entry.DoubleType != nil:
+			problems = append(problems, prefix+" double type requires role reusable_double")
+		case strings.TrimSpace(entry.DoubleBoundary) != "":
+			problems = append(problems, prefix+" double boundary requires role reusable_double")
 		}
 		if (entry.Catalog != nil || entry.Source != nil) && !roles[RoleProductionProvider] {
 			problems = append(problems, prefix+" discovery binding requires role production_provider")
@@ -518,8 +545,8 @@ func RenderMarkdown(entries []Entry) string {
 	out.WriteString(MarkdownStart)
 	out.WriteString("\n")
 	out.WriteString("This table is rendered from `internal/testutil/providerledger` and checked by `go test ./internal/testutil/providerledger`; edit the Go ledger, then use the expected block printed on drift.\n\n")
-	out.WriteString("| Provider path | Roles | Port | Constructor | Discovery | Contract | Status |\n")
-	out.WriteString("|---|---|---|---|---|---|---|\n")
+	out.WriteString("| Provider path | Roles | Reusable type | Port | Constructor | Discovery | Contract | Status |\n")
+	out.WriteString("|---|---|---|---|---|---|---|---|\n")
 	for _, entry := range entries {
 		claims := append([]ContractClaim(nil), entry.Claims...)
 		sort.Slice(claims, func(i, j int) bool {
@@ -529,9 +556,10 @@ func RenderMarkdown(entries []Entry) string {
 			return claims[i].Contract < claims[j].Contract
 		})
 		for _, claim := range claims {
-			fmt.Fprintf(&out, "| `%s` | %s | `%s` | `%s` | %s | `%s` | %s |\n",
+			fmt.Fprintf(&out, "| `%s` | %s | %s | `%s` | `%s` | %s | `%s` | %s |\n",
 				markdownCell(entry.ID),
 				markdownCell(renderRoles(entry.Roles)),
+				renderDoubleType(entry),
 				markdownCell(string(entry.Port)),
 				markdownCell(renderSymbolRef(claim.Constructor)),
 				markdownCell(renderDiscovery(entry)),
@@ -542,6 +570,13 @@ func RenderMarkdown(entries []Entry) string {
 	}
 	out.WriteString(MarkdownEnd)
 	return out.String()
+}
+
+func renderDoubleType(entry Entry) string {
+	if entry.DoubleType == nil {
+		return "—"
+	}
+	return "`" + markdownCell(renderSymbolRef(*entry.DoubleType)) + "`"
 }
 
 func symbolRefLess(left, right SymbolRef) bool {
@@ -561,13 +596,20 @@ func renderRoles(roles []Role) string {
 }
 
 func renderDiscovery(entry Entry) string {
+	var bindings []string
 	if entry.Catalog != nil {
-		return entry.Catalog.Name + "/" + entry.Catalog.Key
+		bindings = append(bindings, entry.Catalog.Name+"/"+entry.Catalog.Key)
 	}
 	if entry.Source != nil {
-		return fmt.Sprintf("source: %s#%s — %s", entry.Source.File, entry.Source.Function, entry.Source.Reason)
+		bindings = append(bindings, fmt.Sprintf("source: %s#%s — %s", entry.Source.File, entry.Source.Function, entry.Source.Reason))
 	}
-	return "invalid: no discovery binding"
+	if hasRole(entry.Roles, RoleReusableDouble) && strings.TrimSpace(entry.DoubleBoundary) != "" {
+		bindings = append(bindings, "reusable: "+entry.DoubleBoundary)
+	}
+	if len(bindings) == 0 {
+		return "invalid: no discovery binding"
+	}
+	return strings.Join(bindings, "; ")
 }
 
 func renderClaim(claim ContractClaim) string {

--- a/internal/testutil/providerledger/ledger_test.go
+++ b/internal/testutil/providerledger/ledger_test.go
@@ -180,6 +180,51 @@ func TestValidateRequiresProductionRoleForDiscoveryBindings(t *testing.T) {
 	}
 }
 
+func TestValidateRequiresReusableDoubleTypeWithReusableRole(t *testing.T) {
+	now := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+
+	t.Run("role without type", func(t *testing.T) {
+		entry := reusableRuntimeEntry("runtime.fake", "exact:fake", "Fake", "NewFake")
+		entry.DoubleType = nil
+		err := Validate([]Entry{entry}, now)
+		if err == nil || !strings.Contains(err.Error(), "reusable_double role requires a double type") {
+			t.Fatalf("Validate() error = %v, want missing-double-type error", err)
+		}
+	})
+
+	t.Run("role without boundary", func(t *testing.T) {
+		entry := reusableRuntimeEntry("runtime.fake", "exact:fake", "Fake", "NewFake")
+		entry.DoubleBoundary = ""
+		err := Validate([]Entry{entry}, now)
+		if err == nil || !strings.Contains(err.Error(), "reusable_double role requires a repository-relative double boundary") {
+			t.Fatalf("Validate() error = %v, want missing-double-boundary error", err)
+		}
+	})
+
+	t.Run("type without role", func(t *testing.T) {
+		entry := reusableRuntimeEntry("runtime.fake", "exact:fake", "Fake", "NewFake")
+		entry.Roles = []Role{RoleProductionProvider}
+		err := Validate([]Entry{entry}, now)
+		if err == nil || !strings.Contains(err.Error(), "double type requires role reusable_double") {
+			t.Fatalf("Validate() error = %v, want missing-reusable-role error", err)
+		}
+	})
+}
+
+func TestRenderMarkdownShowsReusableOnlyBoundary(t *testing.T) {
+	entry := reusableRuntimeEntry("runtime.double.gated", "unused", "GatedFake", "NewGatedFake")
+	entry.Roles = []Role{RoleReusableDouble}
+	entry.Catalog = nil
+
+	if err := Validate([]Entry{entry}, time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("Validate(reusable-only entry): %v", err)
+	}
+	got := RenderMarkdown([]Entry{entry})
+	if !strings.Contains(got, "reusable: internal/runtime/fake.go") || strings.Contains(got, "invalid: no discovery binding") {
+		t.Fatalf("RenderMarkdown(reusable-only entry) = %q, want honest reusable boundary", got)
+	}
+}
+
 func TestValidateRejectsDuplicateSourceBindings(t *testing.T) {
 	now := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
 	claim := ContractClaim{
@@ -302,6 +347,255 @@ func TestCatalogDefersExactConstructorContractsToOwnedFollowups(t *testing.T) {
 		if !got[key] {
 			t.Errorf("ga-80po0c.1.2 waiver row %s is missing", key)
 		}
+	}
+}
+
+func TestDiscoverRuntimeProviderDoublesUsesDeclaredPortIdentity(t *testing.T) {
+	dir := writeRuntimeDoubleFixture(t, map[string]string{
+		"runtime.go": `package runtime
+type Provider interface { Run() }
+`,
+		"fake.go": `package runtime
+type Fake struct{}
+func (*Fake) Run() {}
+
+type FakeAlias = Fake
+type OtherFake Fake
+type helper struct{}
+
+func NewFake() *Fake { return nil }
+func NewAlias() *FakeAlias { return nil }
+func NewOther() *OtherFake { return nil }
+func NewValue() Fake { return Fake{} }
+func NewPair() (*Fake, error) { return nil, nil }
+func newPrivate() *Fake { return nil }
+func (helper) NewMethod() *Fake { return nil }
+func NewShadow[Fake any]() *Fake { return nil }
+func caller() {
+	type Fake struct{}
+	_ = func() *Fake { return nil }
+}
+
+type GatedFake struct{ *Fake }
+func NewGatedFake() (*GatedFake, error) { return nil, nil }
+func NewGatedValue() GatedFake { return GatedFake{} }
+
+type Support struct{}
+func NewSupport() *Support { return nil }
+`,
+		"constructors.go": `package runtime
+func NewExternalFake() *Fake { return nil }
+`,
+	})
+
+	got, err := DiscoverRuntimeProviderDoubles(dir)
+	if err != nil {
+		t.Fatalf("DiscoverRuntimeProviderDoubles: %v", err)
+	}
+	want := []ReusableDouble{
+		{
+			Type: repoSymbol("internal/runtime", "Fake"),
+			Constructors: []SymbolRef{
+				repoSymbol("internal/runtime", "NewAlias"),
+				repoSymbol("internal/runtime", "NewExternalFake"),
+				repoSymbol("internal/runtime", "NewFake"),
+				repoSymbol("internal/runtime", "NewPair"),
+			},
+		},
+		{
+			Type: repoSymbol("internal/runtime", "GatedFake"),
+			Constructors: []SymbolRef{
+				repoSymbol("internal/runtime", "NewGatedFake"),
+				repoSymbol("internal/runtime", "NewGatedValue"),
+			},
+		},
+	}
+	if gotText, wantText := renderReusableDoubles(got), renderReusableDoubles(want); gotText != wantText {
+		t.Fatalf("doubles = %s, want %s", gotText, wantText)
+	}
+}
+
+func TestDiscoverRuntimeProviderDoublesFailsClosed(t *testing.T) {
+	const provider = `package runtime
+type Provider interface { Run() }
+`
+	const validDouble = `package runtime
+type Fake struct{}
+func (*Fake) Run() {}
+func NewFake() *Fake { return nil }
+`
+
+	tests := []struct {
+		name  string
+		files map[string]string
+		want  string
+	}{
+		{
+			name:  "boundary file renamed",
+			files: map[string]string{"runtime.go": provider, "doubles.go": validDouble},
+			want:  "designated runtime double boundary fake.go is missing",
+		},
+		{
+			name:  "boundary package changed",
+			files: map[string]string{"runtime.go": provider, "fake.go": strings.Replace(validDouble, "package runtime", "package other", 1)},
+			want:  "fake.go must declare package runtime",
+		},
+		{
+			name:  "provider declaration missing",
+			files: map[string]string{"runtime.go": "package runtime\n", "fake.go": validDouble},
+			want:  "runtime.Provider must be exactly one declared interface",
+		},
+		{
+			name:  "provider is not an interface",
+			files: map[string]string{"runtime.go": "package runtime\ntype Provider struct{}\n", "fake.go": validDouble},
+			want:  "runtime.Provider must be exactly one declared interface",
+		},
+		{
+			name:  "no exported provider double",
+			files: map[string]string{"runtime.go": provider, "fake.go": "package runtime\ntype Support struct{}\n"},
+			want:  "fake.go declares no exported runtime.Provider double",
+		},
+		{
+			name: "provider double has no constructor",
+			files: map[string]string{
+				"runtime.go": provider,
+				"fake.go":    "package runtime\ntype Fake struct{}\nfunc (*Fake) Run() {}\n",
+			},
+			want: "runtime provider double internal/runtime.Fake has no exported receiverless constructor",
+		},
+		{
+			name: "declaration type error",
+			files: map[string]string{
+				"runtime.go": provider,
+				"fake.go":    validDouble + "\nvar broken MissingType\n",
+			},
+			want: "type-check runtime double boundary",
+		},
+		{
+			name: "generic boundary type",
+			files: map[string]string{
+				"runtime.go": provider,
+				"fake.go": `package runtime
+type GenericFake[T any] struct{}
+func (*GenericFake[T]) Run() {}
+func NewGenericFake[T any]() *GenericFake[T] { return nil }
+`,
+			},
+			want: "generic exported type GenericFake in fake.go cannot be classified as a reusable provider double",
+		},
+		{
+			name: "exported alias exposes untracked provider type",
+			files: map[string]string{
+				"runtime.go": provider,
+				"fake.go": validDouble + `
+type hiddenFake struct{ *Fake }
+type GatedFake = hiddenFake
+func NewGatedFake() *GatedFake { return nil }
+`,
+			},
+			want: "exported provider alias GatedFake in fake.go resolves to an untracked concrete type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := writeRuntimeDoubleFixture(t, tt.files)
+			_, err := DiscoverRuntimeProviderDoubles(dir)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("DiscoverRuntimeProviderDoubles() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareReusableDoublesChecksConstructorsBothDirections(t *testing.T) {
+	entries := []Entry{
+		reusableRuntimeEntry("runtime.fake", "exact:fake", "Fake", "NewFake"),
+		reusableRuntimeEntry("runtime.removed", "exact:removed", "Fake", "NewRemovedFake"),
+	}
+	discovered := []ReusableDouble{
+		{
+			Type: repoSymbol("internal/runtime", "Fake"),
+			Constructors: []SymbolRef{
+				repoSymbol("internal/runtime", "NewFake"),
+				repoSymbol("internal/runtime", "NewFailFake"),
+			},
+		},
+		{
+			Type:         repoSymbol("internal/runtime", "GatedFake"),
+			Constructors: []SymbolRef{repoSymbol("internal/runtime", "NewGatedFake")},
+		},
+	}
+
+	err := CompareReusableDoubles(entries, discovered)
+	if err == nil {
+		t.Fatal("CompareReusableDoubles() succeeded, want missing and stale errors")
+	}
+	for _, want := range []string{
+		"internal/runtime.NewFailFake is missing from the ledger",
+		"internal/runtime.NewGatedFake is missing from the ledger",
+		"internal/runtime.NewRemovedFake is not discovered for type boundary internal/runtime/fake.go",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("CompareReusableDoubles() error = %v, want containing %q", err, want)
+		}
+	}
+}
+
+func TestCompareReusableDoublesBindsConstructorToDeclaredType(t *testing.T) {
+	entry := reusableRuntimeEntry("runtime.fake", "exact:fake", "Fake", "NewFake")
+	discovered := []ReusableDouble{{
+		Type:         repoSymbol("internal/runtime", "RenamedFake"),
+		Constructors: []SymbolRef{repoSymbol("internal/runtime", "NewFake")},
+	}}
+
+	err := CompareReusableDoubles([]Entry{entry}, discovered)
+	if err == nil || !strings.Contains(err.Error(), "internal/runtime.NewFake constructs internal/runtime.RenamedFake, ledger declares internal/runtime.Fake") {
+		t.Fatalf("CompareReusableDoubles() error = %v, want declared-type drift", err)
+	}
+}
+
+func TestCompareReusableDoublesRequiresReusableRole(t *testing.T) {
+	entry := reusableRuntimeEntry("runtime.fake", "exact:fake", "Fake", "NewFake")
+	entry.Roles = []Role{RoleProductionProvider}
+	discovered := []ReusableDouble{{
+		Type:         repoSymbol("internal/runtime", "Fake"),
+		Constructors: []SymbolRef{repoSymbol("internal/runtime", "NewFake")},
+	}}
+
+	err := CompareReusableDoubles([]Entry{entry}, discovered)
+	if err == nil || !strings.Contains(err.Error(), "internal/runtime.NewFake is missing from the ledger") {
+		t.Fatalf("CompareReusableDoubles() error = %v, want reusable-role error", err)
+	}
+}
+
+func TestCompareReusableDoublesRequiresDesignatedBoundary(t *testing.T) {
+	entry := reusableRuntimeEntry("runtime.fake", "exact:fake", "Fake", "NewFake")
+	entry.DoubleBoundary = "internal/runtime/other.go"
+	discovered := []ReusableDouble{{
+		Type:         repoSymbol("internal/runtime", "Fake"),
+		Constructors: []SymbolRef{repoSymbol("internal/runtime", "NewFake")},
+	}}
+
+	err := CompareReusableDoubles([]Entry{entry}, discovered)
+	if err == nil || !strings.Contains(err.Error(), `reusable double boundary is "internal/runtime/other.go", want "internal/runtime/fake.go"`) {
+		t.Fatalf("CompareReusableDoubles() error = %v, want designated-boundary error", err)
+	}
+}
+
+func TestCompareReusableDoublesRejectsDuplicateOwnership(t *testing.T) {
+	entries := []Entry{
+		reusableRuntimeEntry("runtime.fake.first", "exact:first", "Fake", "NewFake"),
+		reusableRuntimeEntry("runtime.fake.second", "exact:second", "Fake", "NewFake"),
+	}
+	discovered := []ReusableDouble{{
+		Type:         repoSymbol("internal/runtime", "Fake"),
+		Constructors: []SymbolRef{repoSymbol("internal/runtime", "NewFake")},
+	}}
+
+	err := CompareReusableDoubles(entries, discovered)
+	if err == nil || !strings.Contains(err.Error(), `internal/runtime.NewFake is owned by multiple ledger entries: "runtime.fake.first", "runtime.fake.second"`) {
+		t.Fatalf("CompareReusableDoubles() error = %v, want duplicate ownership", err)
 	}
 }
 
@@ -928,6 +1222,13 @@ func TestCatalogMatchesProductionWiringAndDocumentation(t *testing.T) {
 	if err := CompareRuntimeCatalog(entries, discovered); err != nil {
 		t.Fatalf("CompareRuntimeCatalog: %v", err)
 	}
+	doubles, err := DiscoverRuntimeProviderDoubles(filepath.Join(root, "internal/runtime"))
+	if err != nil {
+		t.Fatalf("DiscoverRuntimeProviderDoubles: %v", err)
+	}
+	if err := CompareReusableDoubles(entries, doubles); err != nil {
+		t.Fatalf("CompareReusableDoubles: %v", err)
+	}
 	if err := ValidateSourceRefs(root, entries); err != nil {
 		t.Fatalf("ValidateSourceRefs: %v", err)
 	}
@@ -944,6 +1245,7 @@ func TestCatalogReturnsIndependentEntries(t *testing.T) {
 	first := Catalog()
 	first[0].Roles[0] = RoleReusableDouble
 	first[0].Constructors[0].Name = "MutatedConstructor"
+	first[0].DoubleType.Name = "MutatedDouble"
 	first[0].Catalog.Name = "mutated.catalog"
 	first[0].Claims[0].Contract = ContractID("mutated.contract")
 	first[0].Claims[0].Waiver.Owner = "mutated-owner"
@@ -955,6 +1257,9 @@ func TestCatalogReturnsIndependentEntries(t *testing.T) {
 	}
 	if second[0].Constructors[0].Name != "NewFake" {
 		t.Errorf("Catalog() constructor leaked mutation: %q", second[0].Constructors[0].Name)
+	}
+	if second[0].DoubleType == nil || second[0].DoubleType.Name != "Fake" {
+		t.Errorf("Catalog() double type leaked mutation: %v", second[0].DoubleType)
 	}
 	if second[0].Catalog.Name != RuntimeBuiltinCatalog {
 		t.Errorf("Catalog() catalog leaked mutation: %q", second[0].Catalog.Name)
@@ -999,6 +1304,40 @@ func validRuntimeEntry(id, key string, claim ContractClaim) Entry {
 		Catalog:      &CatalogRef{Name: RuntimeBuiltinCatalog, Key: key},
 		Claims:       []ContractClaim{claim},
 	}
+}
+
+func reusableRuntimeEntry(id, key, typeName, constructorName string) Entry {
+	constructor := repoSymbol("internal/runtime", constructorName)
+	entry := validRuntimeEntry(id, key, ContractClaim{
+		Constructor:         constructor,
+		Contract:            ContractRuntimeProvider,
+		Disposition:         DispositionNotApplicable,
+		NotApplicableReason: "fixture",
+	})
+	entry.Roles = append(entry.Roles, RoleReusableDouble)
+	doubleType := repoSymbol("internal/runtime", typeName)
+	entry.DoubleType = &doubleType
+	entry.DoubleBoundary = runtimeDoubleBoundaryPath
+	return entry
+}
+
+func writeRuntimeDoubleFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, source := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func renderReusableDoubles(doubles []ReusableDouble) string {
+	rows := make([]string, 0, len(doubles))
+	for _, double := range doubles {
+		rows = append(rows, renderSymbolRef(double.Type)+"="+renderSymbolRefs(double.Constructors))
+	}
+	return strings.Join(rows, ";")
 }
 
 func renderRegistrations(registrations []RuntimeRegistration) string {


### PR DESCRIPTION
## Summary

- make `internal/runtime/fake.go` the checked reusable `runtime.Provider` double boundary
- discover concrete double types and exact exported constructors with `go/types`, including conforming value returns and canonical aliases
- fail closed on untracked aliases, generics, type errors, stale rows, and constructor/type ownership drift
- document the bounded ledger and explicit follow-up double boundaries in `TESTING.md`

## Verification

- `go test ./internal/testutil/providerledger -count=10`
- `go test -race ./internal/testutil/providerledger -count=3`
- `go vet ./...`
- `make check-docs`
- `LOCAL_TEST_JOBS=2 make test-fast-parallel`
- repository pre-commit and pre-push hooks
- three independent exact-tree council reviews: CLEAR (correctness, honesty, portability)

Tracks `ga-80po0c.1.1`.