### PR TITLE
test: ratchet cmd/gc process-global resource debt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -4,8 +4,9 @@
 
 `test/test-resources.toml` is the P0.4a source call-site ratchet. It scans
 tracked `*_test.go` files through parsed Go syntax and import identity, freezes
-four subprocess and fixed-sleep call/file totals, rejects growth, and requires
-a baseline reduction whenever source debt falls. The Go-owned
+seven process, sleep, environment, CWD, and slow-process call/file totals,
+rejects growth, and requires a baseline reduction whenever source debt falls.
+The Go-owned
 `bootstrapPolicy` pins every row's ceiling, historical totals, owner,
 invariant, resource owner, migration, and expiry. Ordinary source growth fails
 against that ceiling, and TOML-only normalization or metadata edits fail
@@ -17,18 +18,30 @@ other test-infrastructure changes. The guard makes ordinary drift visible; it
 does not claim that self-modifying source can be cryptographically forbidden.
 
 This bootstrap does **not** classify a test as Small, Medium, or Large, infer
-runtime ownership through helper calls, or claim to be a complete inventory of
-test resources. The next source-resource scope is owned by `ga-80po0c.2.3`.
-E1 separately owns Large journey and provider entries.
+resources recursively through arbitrary helper calls, or claim to be a complete
+inventory of test resources. `ga-80po0c.2.1` owns exact Medium identities,
+package `TestMain` inheritance, and resource lists. `ga-80po0c.2.2` owns the
+listener, tmux, Dolt, and shared-host catalogs. E1 separately owns Large
+journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
-`time.Sleep`, including import aliases and parenthesized call expressions.
-Import matches use lexical object identity, so local shadows do not count.
-Targeted dot imports of `os/exec` or `time` are rejected with file and import
-context because their calls cannot be attributed safely; blank imports remain
-harmless. Explicit constraints follow Go's leading-header rules: a pre-package
-`//go:build` line is effective, while a legacy `// +build` line must live in a
-leading `//` comment block separated from the package clause by a blank line.
+`time.Sleep`; `os.Setenv`, `os.Unsetenv`, `os.Clearenv`, and `os.Chdir`; and
+`Setenv` or `Chdir` on function parameters typed exactly as `*testing.T` or
+`testing.TB`. It also recognizes the receiverless
+`skipSlowCmdGCTest(*testing.T, string)` definition and its same-package calls.
+An unresolved cross-file call counts only when that directory and package own
+the canonical helper. Import, parameter, and same-file helper matches use
+lexical object identity; top-level sibling declarations are indexed by
+directory and package so cross-file shadows do not masquerade as resources.
+Local shadows and wrong signatures do not count. Parenthesized call
+expressions retain the same ownership.
+
+Targeted dot imports of `os/exec`, `time`, `os`, or `testing` are rejected with
+file and import context because their resources cannot be attributed safely;
+blank imports remain harmless. Explicit constraints follow Go's leading-header
+rules: a pre-package `//go:build` line is effective, while a legacy
+`// +build` line must live in a leading `//` comment block separated from the
+package clause by a blank line.
 Misplaced and directive-like comments do not tag a file. An untagged scope
 means the source file has neither an effective explicit constraint nor a
 recognized `_GOOS`, `_GOARCH`, or `_GOOS_GOARCH` filename suffix. Implicit
@@ -36,7 +49,8 @@ filename constraints use the portion before the first dot, matching Go's
 filename semantics. The code-owned platform set mirrors the Go standard
 library's [`internal/syslist.KnownOS` and `KnownArch`](https://go.dev/src/internal/syslist/syslist.go):
 the past, present, and future values Go owns for filename matching. Scanning
-does not invoke the Go tool or network.
+does not invoke the Go tool or network. The `cmd/gc+untagged` scope additionally
+requires the source path to be beneath `cmd/gc/`.
 
 Run the focused check with:
 
@@ -45,14 +59,19 @@ go test -count=1 ./internal/testpolicy/resourcecensus -run '^TestRepositoryLedge
 ```
 
 The historical regex totals remain visible as point-in-time audit evidence.
-They can differ because comments and strings matched, while the AST census
-counts only recognized calls.
+They can be higher because comments and strings matched, or lower where the old
+needle covered only `t.Setenv` or direct `os.Chdir` and the AST census now
+recognizes the full families above. Historical `cmd/gc` needles also included
+build-tagged files; the live `cmd/gc+untagged` ratchets do not.
 
 <!-- BEGIN CHECKED TEST RESOURCE LEDGER -->
 | Ledger kind | Source scope | Resource baseline | Tracking owner | Invariant / resource owner | Migration | Expiry |
 | --- | --- | --- | --- | --- | --- | --- |
 | Audit baseline | all tracked test source | fixed_sleep: 443 calls / 156 files (historical regex census: 447 / 157) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
 | Audit baseline | all tracked test source | subprocess: 490 calls / 135 files (historical regex census: 495 / 135) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
+| Source debt ratchet | `cmd/gc` untagged test source | cwd: 208 calls / 40 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
+| Source debt ratchet | `cmd/gc` untagged test source | environment: 4092 calls / 180 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
+| Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | fixed_sleep: 291 calls / 113 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 374 calls / 97 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -32,11 +32,20 @@ const (
 	ResourceSubprocess Resource = "subprocess"
 	// ResourceFixedSleep counts direct time.Sleep calls.
 	ResourceFixedSleep Resource = "fixed_sleep"
+	// ResourceEnvironment counts recognized process-environment mutations.
+	ResourceEnvironment Resource = "environment"
+	// ResourceCWD counts recognized process working-directory mutations.
+	ResourceCWD Resource = "cwd"
+	// ResourceSlowProcessGate counts the cmd/gc slow-process helper and calls.
+	ResourceSlowProcessGate Resource = "slow_process_gate"
 )
 
 var knownResources = map[Resource]struct{}{
-	ResourceSubprocess: {},
-	ResourceFixedSleep: {},
+	ResourceSubprocess:      {},
+	ResourceFixedSleep:      {},
+	ResourceEnvironment:     {},
+	ResourceCWD:             {},
+	ResourceSlowProcessGate: {},
 }
 
 // Scope selects the source population counted by a ledger row.
@@ -47,6 +56,8 @@ const (
 	ScopeAll Scope = "all"
 	// ScopeUntagged excludes explicitly and implicitly constrained files.
 	ScopeUntagged Scope = "untagged"
+	// ScopeCmdGCUntagged selects untagged test files beneath cmd/gc.
+	ScopeCmdGCUntagged Scope = "cmd/gc+untagged"
 )
 
 type baselineKey struct {
@@ -133,6 +144,45 @@ var bootstrapPolicy = Ledger{
 			MigrationTarget: "W1-W5",
 			Expires:         "2026-10-01",
 		},
+		{
+			Scope:           ScopeCmdGCUntagged,
+			Resource:        ResourceEnvironment,
+			BaselineCalls:   4092,
+			BaselineFiles:   180,
+			ReportedCalls:   3960,
+			ReportedFiles:   184,
+			OwnerBead:       "ga-80po0c.2.3",
+			Invariant:       "untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "cmd/gc callers restore or eliminate every recognized process-environment mutation",
+			MigrationTarget: "D5/D6/E6",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeCmdGCUntagged,
+			Resource:        ResourceCWD,
+			BaselineCalls:   208,
+			BaselineFiles:   40,
+			ReportedCalls:   98,
+			ReportedFiles:   13,
+			OwnerBead:       "ga-80po0c.2.3",
+			Invariant:       "untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "cmd/gc callers restore or eliminate every recognized cwd mutation",
+			MigrationTarget: "D5/D6",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeCmdGCUntagged,
+			Resource:        ResourceSlowProcessGate,
+			BaselineCalls:   77,
+			BaselineFiles:   26,
+			ReportedCalls:   78,
+			ReportedFiles:   27,
+			OwnerBead:       "ga-80po0c.2.3",
+			Invariant:       "untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "the helper definition and every marked caller retain an explicit process-suite migration owner",
+			MigrationTarget: "D5/D6/E6",
+			Expires:         "2026-10-01",
+		},
 	},
 }
 
@@ -175,17 +225,20 @@ func scopeContains(scope Scope, occurrence Occurrence) bool {
 		return true
 	case ScopeUntagged:
 		return !occurrence.Tagged
+	case ScopeCmdGCUntagged:
+		return !occurrence.Tagged && strings.HasPrefix(occurrence.Path, "cmd/gc/")
 	default:
 		return false
 	}
 }
 
-// ScanRepository scans the repository's tracked Go test files.
+// ScanRepository scans the repository's tracked Go test files. Tracked sibling
+// Go source supplies package-level declaration context but is never counted.
 func ScanRepository(root string) (Census, error) {
-	cmd := exec.Command("git", "-C", root, "ls-files", "-z", "--", "*_test.go")
+	cmd := exec.Command("git", "-C", root, "ls-files", "-z", "--", "*.go")
 	out, err := cmd.Output()
 	if err != nil {
-		return Census{}, fmt.Errorf("listing tracked Go tests: %w", err)
+		return Census{}, fmt.Errorf("listing tracked Go source: %w", err)
 	}
 	parts := strings.Split(string(out), "\x00")
 	files := make([]string, 0, len(parts))
@@ -197,16 +250,17 @@ func ScanRepository(root string) (Census, error) {
 	return scanFiles(os.DirFS(root), files)
 }
 
-// ScanFS scans every *_test.go file in sourceFS. It is intended for hermetic
-// policy fixtures; repository checks use ScanRepository so untracked files do
-// not perturb the checked baseline.
+// ScanFS scans every *_test.go file in sourceFS. Sibling Go source supplies
+// package-level declaration context but is never counted. ScanFS is intended
+// for hermetic policy fixtures; repository checks use ScanRepository so
+// untracked files do not perturb the checked baseline.
 func ScanFS(sourceFS fs.FS) (Census, error) {
 	var files []string
 	err := fs.WalkDir(sourceFS, ".", func(name string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !entry.IsDir() && strings.HasSuffix(name, "_test.go") {
+		if !entry.IsDir() && strings.HasSuffix(name, ".go") {
 			files = append(files, filepath.ToSlash(name))
 		}
 		return nil
@@ -218,12 +272,25 @@ func ScanFS(sourceFS fs.FS) (Census, error) {
 }
 
 type parsedFile struct {
-	name   string
-	tagged bool
+	name        string
+	directory   string
+	packageName string
+	tagged      bool
+	file        *ast.File
+	calls       []*ast.CallExpr
+	bindings    bindingInfo
 }
 
 type bindingInfo struct {
-	uses map[*ast.Ident]types.Object
+	defs                       map[*ast.Ident]types.Object
+	uses                       map[*ast.Ident]types.Object
+	packageDeclarations        map[string]struct{}
+	unresolvedImportQualifiers map[string]struct{}
+}
+
+type packageKey struct {
+	directory   string
+	packageName string
 }
 
 type emptyPackageImporter struct {
@@ -271,17 +338,29 @@ var knownGOARCH = map[string]struct{}{
 
 func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 	sort.Strings(names)
-	census := Census{}
+	fileSet := token.NewFileSet()
 	importer := newEmptyPackageImporter()
-	for index, name := range names {
+	var sources []parsedFile
+	packageDeclarations := make(map[packageKey]map[string]struct{})
+	for _, name := range names {
 		data, err := fs.ReadFile(sourceFS, name)
 		if err != nil {
 			return Census{}, fmt.Errorf("reading %s: %w", name, err)
 		}
-		fileSet := token.NewFileSet()
 		file, err := parser.ParseFile(fileSet, name, data, parser.ParseComments|parser.SkipObjectResolution)
 		if err != nil {
 			return Census{}, fmt.Errorf("parsing %s: %w", name, err)
+		}
+		normalized := filepath.ToSlash(name)
+		key := packageKey{directory: path.Dir(normalized), packageName: file.Name.Name}
+		declarations := packageDeclarations[key]
+		if declarations == nil {
+			declarations = make(map[string]struct{})
+			packageDeclarations[key] = declarations
+		}
+		recordPackageDeclarations(file, declarations)
+		if !strings.HasSuffix(name, "_test.go") {
+			continue
 		}
 		tagged, err := parsedBuildConstraint(data)
 		if err != nil {
@@ -290,30 +369,120 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		if err := validateImports(file); err != nil {
 			return Census{}, fmt.Errorf("scanning imports in %s: %w", name, err)
 		}
-		source := parsedFile{
-			name:   filepath.ToSlash(name),
-			tagged: tagged || hasImplicitPlatformConstraint(name),
-		}
 		candidates := resourceCandidateCalls(file)
-		if len(candidates) == 0 {
+		scanned := len(candidates) > 0 || hasSlowHelperDeclarationCandidate(file)
+		if !scanned {
 			continue
 		}
-		bindings := resolveBindings(fileSet, file, importer, fmt.Sprintf("resourcecensus.local/file%d", index))
-		for _, call := range candidates {
-			matched, err := isImportedCall(call, bindings, "os/exec", "Command", "CommandContext")
+		sources = append(sources, parsedFile{
+			name:        normalized,
+			directory:   key.directory,
+			packageName: key.packageName,
+			tagged:      tagged || hasImplicitPlatformConstraint(name),
+			file:        file,
+			calls:       candidates,
+		})
+	}
+
+	for index := range sources {
+		source := &sources[index]
+		bindings := resolveBindings(fileSet, source.file, importer, fmt.Sprintf("resourcecensus.local/file%d", index))
+		bindings.packageDeclarations = packageDeclarations[source.groupKey()]
+		bindings.unresolvedImportQualifiers = unresolvedDefaultImportQualifiers(source.file)
+		source.bindings = bindings
+	}
+
+	slowHelpers := make(map[packageKey]types.Object)
+	for _, source := range sources {
+		for _, declaration := range source.file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			matched, err := isSlowHelperDeclaration(function, source.bindings)
 			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", name, err)
+				return Census{}, fmt.Errorf("scanning slow-process helper in %s: %w", source.name, err)
+			}
+			if !matched {
+				continue
+			}
+			key := source.groupKey()
+			if _, exists := slowHelpers[key]; exists {
+				return Census{}, fmt.Errorf("scanning slow-process helper in %s: package %s has multiple canonical declarations", source.name, source.packageName)
+			}
+			object := source.bindings.defs[function.Name]
+			if object == nil {
+				return Census{}, fmt.Errorf("scanning slow-process helper in %s: declaration has no lexical binding", source.name)
+			}
+			slowHelpers[key] = object
+		}
+	}
+
+	census := Census{}
+	for _, source := range sources {
+		testingObjects, err := testingParameterObjects(source.file, source.bindings)
+		if err != nil {
+			return Census{}, fmt.Errorf("scanning testing parameters in %s: %w", source.name, err)
+		}
+		for _, declaration := range source.file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			matched, err := isSlowHelperDeclaration(function, source.bindings)
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning slow-process helper in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, ResourceSlowProcessGate)
+			}
+		}
+
+		for _, call := range source.calls {
+			matched, err := isImportedCall(call, source.bindings, "os/exec", "Command", "CommandContext")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
 				census.add(source, ResourceSubprocess)
-				continue
 			}
-			matched, err = isImportedCall(call, bindings, "time", "Sleep")
+			matched, err = isImportedCall(call, source.bindings, "time", "Sleep")
 			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", name, err)
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
 				census.add(source, ResourceFixedSleep)
+			}
+			matched, err = isImportedCall(call, source.bindings, "os", "Setenv", "Unsetenv", "Clearenv")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, ResourceEnvironment)
+			}
+			matched, err = isImportedCall(call, source.bindings, "os", "Chdir")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, ResourceCWD)
+			}
+			matched, err = isTestingCall(call, source.bindings, testingObjects, "Setenv")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, ResourceEnvironment)
+			}
+			matched, err = isTestingCall(call, source.bindings, testingObjects, "Chdir")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, ResourceCWD)
+			}
+			if isSlowHelperCall(call, source.bindings, slowHelpers[source.groupKey()]) {
+				census.add(source, ResourceSlowProcessGate)
 			}
 		}
 	}
@@ -326,6 +495,10 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		return left.Resource < right.Resource
 	})
 	return census, nil
+}
+
+func (p parsedFile) groupKey() packageKey {
+	return packageKey{directory: p.directory, packageName: p.packageName}
 }
 
 func (c *Census) add(source parsedFile, resource Resource) {
@@ -450,7 +623,7 @@ func validateImports(file *ast.File) error {
 			continue
 		}
 		if spec.Name != nil && spec.Name.Name == "." {
-			if importPath == "os/exec" || importPath == "time" {
+			if importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "testing" {
 				return fmt.Errorf("targeted dot import %q cannot be counted safely", importPath)
 			}
 		}
@@ -465,13 +638,16 @@ func resourceCandidateCalls(file *ast.File) []*ast.CallExpr {
 		if !ok {
 			return true
 		}
-		selector, ok := unparen(call.Fun).(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		switch selector.Sel.Name {
-		case "Command", "CommandContext", "Sleep":
-			calls = append(calls, call)
+		switch function := unparen(call.Fun).(type) {
+		case *ast.SelectorExpr:
+			switch function.Sel.Name {
+			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir":
+				calls = append(calls, call)
+			}
+		case *ast.Ident:
+			if function.Name == "skipSlowCmdGCTest" {
+				calls = append(calls, call)
+			}
 		}
 		return true
 	})
@@ -479,15 +655,226 @@ func resourceCandidateCalls(file *ast.File) []*ast.CallExpr {
 }
 
 func resolveBindings(fileSet *token.FileSet, file *ast.File, importer types.Importer, packagePath string) bindingInfo {
-	info := bindingInfo{uses: make(map[*ast.Ident]types.Object)}
+	info := bindingInfo{
+		defs: make(map[*ast.Ident]types.Object),
+		uses: make(map[*ast.Ident]types.Object),
+	}
 	config := types.Config{
 		Importer:                 importer,
 		DisableUnusedImportCheck: true,
 		IgnoreFuncBodies:         false,
 		Error:                    func(error) {},
 	}
-	_, _ = config.Check(packagePath, fileSet, []*ast.File{file}, &types.Info{Uses: info.uses})
+	_, _ = config.Check(packagePath, fileSet, []*ast.File{file}, &types.Info{Defs: info.defs, Uses: info.uses})
 	return info
+}
+
+func recordPackageDeclarations(file *ast.File, declarations map[string]struct{}) {
+	for _, declaration := range file.Decls {
+		switch declaration := declaration.(type) {
+		case *ast.FuncDecl:
+			if declaration.Recv == nil {
+				declarations[declaration.Name.Name] = struct{}{}
+			}
+		case *ast.GenDecl:
+			for _, spec := range declaration.Specs {
+				switch spec := spec.(type) {
+				case *ast.TypeSpec:
+					declarations[spec.Name.Name] = struct{}{}
+				case *ast.ValueSpec:
+					for _, name := range spec.Names {
+						declarations[name.Name] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+}
+
+// unresolvedDefaultImportQualifiers returns common versioned-import package
+// names that the hermetic path.Base importer cannot derive.
+func unresolvedDefaultImportQualifiers(file *ast.File) map[string]struct{} {
+	qualifiers := make(map[string]struct{})
+	for _, spec := range file.Imports {
+		if spec.Name != nil {
+			continue
+		}
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		base := path.Base(importPath)
+		if isVersionSegment(base) {
+			qualifier := path.Base(path.Dir(importPath))
+			if token.IsIdentifier(qualifier) {
+				qualifiers[qualifier] = struct{}{}
+			}
+			continue
+		}
+		if index := strings.LastIndex(base, ".v"); index > 0 && isVersionSegment(base[index+1:]) {
+			qualifier := base[:index]
+			if token.IsIdentifier(qualifier) {
+				qualifiers[qualifier] = struct{}{}
+			}
+		}
+	}
+	return qualifiers
+}
+
+func isVersionSegment(value string) bool {
+	if len(value) < 2 || value[0] != 'v' {
+		return false
+	}
+	for _, character := range value[1:] {
+		if character < '0' || character > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func hasSlowHelperDeclarationCandidate(file *ast.File) bool {
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Name.Name == "skipSlowCmdGCTest" {
+			return true
+		}
+	}
+	return false
+}
+
+func testingParameterObjects(file *ast.File, bindings bindingInfo) (map[types.Object]bool, error) {
+	objects := make(map[types.Object]bool)
+	var inspectErr error
+	ast.Inspect(file, func(node ast.Node) bool {
+		if inspectErr != nil {
+			return false
+		}
+		var function *ast.FuncType
+		switch node := node.(type) {
+		case *ast.FuncDecl:
+			function = node.Type
+		case *ast.FuncLit:
+			function = node.Type
+		default:
+			return true
+		}
+		if function.Params == nil {
+			return true
+		}
+		for _, field := range function.Params.List {
+			matched, err := isTestingParameterType(field.Type, bindings)
+			if err != nil {
+				inspectErr = err
+				return false
+			}
+			if !matched {
+				continue
+			}
+			for _, name := range field.Names {
+				object := bindings.defs[name]
+				if object == nil {
+					inspectErr = fmt.Errorf("testing parameter %q has no lexical binding", name.Name)
+					return false
+				}
+				objects[object] = true
+			}
+		}
+		return true
+	})
+	return objects, inspectErr
+}
+
+func isTestingParameterType(expression ast.Expr, bindings bindingInfo) (bool, error) {
+	expression = unparen(expression)
+	if pointer, ok := expression.(*ast.StarExpr); ok {
+		return isImportedType(pointer.X, bindings, "testing", "T")
+	}
+	return isImportedType(expression, bindings, "testing", "TB")
+}
+
+func isImportedType(expression ast.Expr, bindings bindingInfo, importPath, typeName string) (bool, error) {
+	selector, ok := unparen(expression).(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != typeName {
+		return false, nil
+	}
+	identifier, ok := unparen(selector.X).(*ast.Ident)
+	if !ok {
+		return false, nil
+	}
+	return isImportedQualifier(identifier, bindings, importPath)
+}
+
+func isTestingCall(call *ast.CallExpr, bindings bindingInfo, testingObjects map[types.Object]bool, method string) (bool, error) {
+	selector, ok := unparen(call.Fun).(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != method {
+		return false, nil
+	}
+	identifier, ok := unparen(selector.X).(*ast.Ident)
+	if !ok {
+		return false, nil
+	}
+	object := bindings.uses[identifier]
+	if object == nil {
+		if _, declared := bindings.packageDeclarations[identifier.Name]; declared {
+			return false, nil
+		}
+		if _, imported := bindings.unresolvedImportQualifiers[identifier.Name]; imported {
+			return false, nil
+		}
+		return false, fmt.Errorf("testing resource receiver %q has no lexical binding", identifier.Name)
+	}
+	return testingObjects[object], nil
+}
+
+func isSlowHelperDeclaration(function *ast.FuncDecl, bindings bindingInfo) (bool, error) {
+	if function.Recv != nil || function.Name.Name != "skipSlowCmdGCTest" || function.Type.Params == nil {
+		return false, nil
+	}
+	if functionParameterCount(function.Type.Results) != 0 || functionParameterCount(function.Type.Params) != 2 || len(function.Type.Params.List) != 2 {
+		return false, nil
+	}
+	firstType := unparen(function.Type.Params.List[0].Type)
+	pointer, ok := firstType.(*ast.StarExpr)
+	if !ok {
+		return false, nil
+	}
+	first, err := isImportedType(pointer.X, bindings, "testing", "T")
+	if err != nil || !first {
+		return false, err
+	}
+	second, ok := unparen(function.Type.Params.List[1].Type).(*ast.Ident)
+	if !ok || bindings.uses[second] != types.Universe.Lookup("string") {
+		return false, nil
+	}
+	return true, nil
+}
+
+func functionParameterCount(fields *ast.FieldList) int {
+	if fields == nil {
+		return 0
+	}
+	count := 0
+	for _, field := range fields.List {
+		if len(field.Names) == 0 {
+			count++
+		} else {
+			count += len(field.Names)
+		}
+	}
+	return count
+}
+
+func isSlowHelperCall(call *ast.CallExpr, bindings bindingInfo, ownership types.Object) bool {
+	if ownership == nil || len(call.Args) != 2 {
+		return false
+	}
+	identifier, ok := unparen(call.Fun).(*ast.Ident)
+	if !ok || identifier.Name != "skipSlowCmdGCTest" {
+		return false
+	}
+	object := bindings.uses[identifier]
+	return object == nil || object == ownership
 }
 
 func isImportedCall(call *ast.CallExpr, bindings bindingInfo, importPath string, names ...string) (bool, error) {
@@ -509,8 +896,18 @@ func isImportedCall(call *ast.CallExpr, bindings bindingInfo, importPath string,
 	if !matchedName {
 		return false, nil
 	}
+	return isImportedQualifier(identifier, bindings, importPath)
+}
+
+func isImportedQualifier(identifier *ast.Ident, bindings bindingInfo, importPath string) (bool, error) {
 	binding, ok := bindings.uses[identifier]
 	if !ok || binding == nil {
+		if _, declared := bindings.packageDeclarations[identifier.Name]; declared {
+			return false, nil
+		}
+		if _, imported := bindings.unresolvedImportQualifiers[identifier.Name]; imported {
+			return false, nil
+		}
 		return false, fmt.Errorf("resource candidate qualifier %q has no lexical binding", identifier.Name)
 	}
 	packageName, ok := binding.(*types.PkgName)
@@ -704,7 +1101,7 @@ func validateBaseline(prefix string, row Baseline, census Census) []string {
 }
 
 func knownScope(scope Scope) bool {
-	return scope == ScopeAll || scope == ScopeUntagged
+	return scope == ScopeAll || scope == ScopeUntagged || scope == ScopeCmdGCUntagged
 }
 
 func validateOwnership(prefix string, row Baseline, now time.Time) []string {
@@ -784,6 +1181,8 @@ func renderedSourceScope(scope Scope) string {
 		return "all tracked test source"
 	case ScopeUntagged:
 		return "all untagged test source"
+	case ScopeCmdGCUntagged:
+		return "`cmd/gc` untagged test source"
 	default:
 		return string(scope)
 	}

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -1,6 +1,7 @@
 package resourcecensus
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -95,6 +96,351 @@ func TestLocalNamesAreNotStdlibCalls() {
 	assertCount(t, got, ScopeUntagged, ResourceSubprocess, 2, 1)
 	assertCount(t, got, ScopeAll, ResourceFixedSleep, 3, 3)
 	assertCount(t, got, ScopeUntagged, ResourceFixedSleep, 1, 1)
+}
+
+func TestScanCountsCmdGCProcessGlobalsByLexicalOwnership(t *testing.T) {
+	t.Parallel()
+
+	const resources = `package main
+
+import (
+	operating "os"
+	testpkg "testing"
+)
+
+type localOS struct{}
+func (localOS) Setenv(string, string) {}
+func (localOS) Unsetenv(string) {}
+func (localOS) Clearenv() {}
+func (localOS) Chdir(string) {}
+
+type localTesting struct{}
+func (localTesting) Setenv(string, string) {}
+func (localTesting) Chdir(string) {}
+
+func skipSlowCmdGCTest(t *testpkg.T, reason string) {}
+
+func TestResources(t *testpkg.T) {
+	((t)).Setenv("KEY", "value")
+	t.Chdir("testing-dir")
+	((operating).Setenv)("DIRECT", "value")
+	operating.Unsetenv("DIRECT")
+	operating.Clearenv()
+	operating.Chdir("elsewhere")
+	((skipSlowCmdGCTest))(t, "process-backed")
+	func(inner *testpkg.T) {
+		inner.Setenv("INNER", "value")
+		inner.Chdir("inner-dir")
+	}(t)
+	func(tb testpkg.TB) {
+		tb.Setenv("TB", "value")
+		tb.Chdir("tb-dir")
+	}(t)
+	func(value testpkg.T) {
+		value.Setenv("VALUE", "does not count")
+		value.Chdir("does-not-count")
+	}(testpkg.T{})
+	func(pointer *testpkg.TB) {
+		pointer.Setenv("POINTER", "does not count")
+		pointer.Chdir("does-not-count")
+	}(nil)
+	{
+		operating := localOS{}
+		operating.Setenv("SHADOW", "value")
+		operating.Unsetenv("SHADOW")
+		operating.Clearenv()
+		operating.Chdir("shadow-dir")
+		t := localTesting{}
+		t.Setenv("SHADOW", "value")
+		t.Chdir("shadow-dir")
+		skipSlowCmdGCTest := func(*testpkg.T, string) {}
+		skipSlowCmdGCTest(nil, "shadow")
+	}
+	_ = "os.Setenv and t.Chdir in strings do not count"
+}
+	`
+	taggedResources := strings.Replace(resources, "func skipSlowCmdGCTest(t *testpkg.T, reason string) {}\n\n", "", 1)
+	files := fstest.MapFS{
+		"cmd/gc/resources_test.go": &fstest.MapFile{Data: []byte(resources)},
+		"cmd/gc/tagged_test.go":    &fstest.MapFile{Data: []byte("//go:build integration\n\n" + taggedResources)},
+		"other/resources_test.go":  &fstest.MapFile{Data: []byte(strings.Replace(resources, "package main", "package other", 1))},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+
+	assertCount(t, got, ScopeAll, ResourceEnvironment, 18, 3)
+	assertCount(t, got, ScopeUntagged, ResourceEnvironment, 12, 2)
+	assertCount(t, got, ScopeCmdGCUntagged, ResourceEnvironment, 6, 1)
+	assertCount(t, got, ScopeAll, ResourceCWD, 12, 3)
+	assertCount(t, got, ScopeUntagged, ResourceCWD, 8, 2)
+	assertCount(t, got, ScopeCmdGCUntagged, ResourceCWD, 4, 1)
+	assertCount(t, got, ScopeAll, ResourceSlowProcessGate, 5, 3)
+	assertCount(t, got, ScopeUntagged, ResourceSlowProcessGate, 4, 2)
+	assertCount(t, got, ScopeCmdGCUntagged, ResourceSlowProcessGate, 2, 1)
+}
+
+func TestScanRecognizesOnlyExactTestingParameterTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		parameter string
+		want      int
+	}{
+		{name: "pointer testing T", parameter: "*testpkg.T", want: 1},
+		{name: "testing TB", parameter: "testpkg.TB", want: 1},
+		{name: "testing T value", parameter: "testpkg.T", want: 0},
+		{name: "pointer testing TB", parameter: "*testpkg.TB", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := fmt.Sprintf(`package sample
+import testpkg "testing"
+func exercise(t %s) {
+	t.Setenv("KEY", "value")
+	t.Chdir("work")
+}
+`, tt.parameter)
+			got, err := ScanFS(fstest.MapFS{
+				"sample/resources_test.go": &fstest.MapFile{Data: []byte(source)},
+			})
+			if err != nil {
+				t.Fatalf("ScanFS: %v", err)
+			}
+			assertCount(t, got, ScopeUntagged, ResourceEnvironment, tt.want, tt.want)
+			assertCount(t, got, ScopeUntagged, ResourceCWD, tt.want, tt.want)
+		})
+	}
+}
+
+func TestScanCountsEachDirectOSProcessGlobalMutation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		call     string
+		resource Resource
+	}{
+		{name: "setenv", call: `operating.Setenv("KEY", "value")`, resource: ResourceEnvironment},
+		{name: "unsetenv", call: `operating.Unsetenv("KEY")`, resource: ResourceEnvironment},
+		{name: "clearenv", call: `operating.Clearenv()`, resource: ResourceEnvironment},
+		{name: "chdir", call: `operating.Chdir("work")`, resource: ResourceCWD},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := fmt.Sprintf(`package sample
+import operating "os"
+func exercise() { %s }
+`, tt.call)
+			got, err := ScanFS(fstest.MapFS{
+				"sample/resources_test.go": &fstest.MapFile{Data: []byte(source)},
+			})
+			if err != nil {
+				t.Fatalf("ScanFS: %v", err)
+			}
+			assertCount(t, got, ScopeUntagged, tt.resource, 1, 1)
+		})
+	}
+}
+
+func TestScanResolvesProcessGlobalShadowsFromSiblingSource(t *testing.T) {
+	t.Parallel()
+
+	got, err := ScanFS(fstest.MapFS{
+		"sample/shadow.go": &fstest.MapFile{Data: []byte(`package sample
+import "os"
+type localProcess struct{}
+func (localProcess) Setenv(string, string) {}
+func (localProcess) Chdir(string) {}
+var process localProcess
+func productionMutationIsContextOnly() { os.Setenv("KEY", "value") }
+`)},
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+func TestResources() {
+	process.Setenv("KEY", "value")
+	process.Chdir("work")
+}
+`)},
+	})
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	if len(got.Occurrences) != 0 {
+		t.Fatalf("cross-file local receivers counted as resources: %+v", got.Occurrences)
+	}
+}
+
+func TestScanAllowsVersionedDefaultImportWhosePackageNameDiffersFromPathBase(t *testing.T) {
+	t.Parallel()
+
+	for _, importPath := range []string{"example.test/process/v2", "gopkg.in/process.v2"} {
+		importPath := importPath
+		t.Run(importPath, func(t *testing.T) {
+			t.Parallel()
+			source := fmt.Sprintf(`package sample
+import %q
+func TestResources() {
+	process.Setenv("KEY", "value")
+	process.Chdir("work")
+}
+	`, importPath)
+			got, err := ScanFS(fstest.MapFS{
+				"sample/resources_test.go": &fstest.MapFile{Data: []byte(source)},
+			})
+			if err != nil {
+				t.Fatalf("ScanFS: %v", err)
+			}
+			if len(got.Occurrences) != 0 {
+				t.Fatalf("non-target default import counted as resources: %+v", got.Occurrences)
+			}
+		})
+	}
+}
+
+func TestScanSlowHelperUsesLexicalObjectsAndCrossFileOwnership(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"owned/helper_test.go": &fstest.MapFile{Data: []byte(`package owned
+import "testing"
+func skipSlowCmdGCTest(t *testing.T, reason string) {}
+func TestSameFile(t *testing.T) { skipSlowCmdGCTest(t, "same file") }
+`)},
+		"owned/cross_file_test.go": &fstest.MapFile{Data: []byte(`package owned
+import "testing"
+func TestCrossFile(t *testing.T) { skipSlowCmdGCTest(t, "cross file") }
+`)},
+		"owned/shadow_test.go": &fstest.MapFile{Data: []byte(`package owned
+import "testing"
+func TestShadows(t *testing.T) {
+	skipSlowCmdGCTest := func(*testing.T, string) {}
+	skipSlowCmdGCTest(t, "local variable")
+	func(skipSlowCmdGCTest func(*testing.T, string)) {
+		skipSlowCmdGCTest(t, "parameter")
+	}(skipSlowCmdGCTest)
+}
+`)},
+		"wrong/helper_test.go": &fstest.MapFile{Data: []byte(`package wrong
+func skipSlowCmdGCTest() {}
+`)},
+		"wrong/cross_file_test.go": &fstest.MapFile{Data: []byte(`package wrong
+func TestWrongSignature() { skipSlowCmdGCTest() }
+`)},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeUntagged, ResourceSlowProcessGate, 3, 2)
+}
+
+func TestSlowHelperOwnershipRequiresDirectoryAndPackage(t *testing.T) {
+	t.Parallel()
+
+	got, err := ScanFS(fstest.MapFS{
+		"owned/helper_test.go": &fstest.MapFile{Data: []byte(`package shared
+import "testing"
+func skipSlowCmdGCTest(t *testing.T, reason string) {}
+`)},
+		"elsewhere/call_test.go": &fstest.MapFile{Data: []byte(`package shared
+import "testing"
+func TestDifferentDirectory(t *testing.T) { skipSlowCmdGCTest(t, "not owned") }
+`)},
+		"owned/external_test.go": &fstest.MapFile{Data: []byte(`package shared_test
+import "testing"
+func TestDifferentPackage(t *testing.T) { skipSlowCmdGCTest(t, "not owned") }
+`)},
+	})
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeUntagged, ResourceSlowProcessGate, 1, 1)
+}
+
+func TestSlowHelperRequiresReceiverlessExactSignature(t *testing.T) {
+	t.Parallel()
+
+	got, err := ScanFS(fstest.MapFS{
+		"receiver/helper_test.go": &fstest.MapFile{Data: []byte(`package receiver
+import "testing"
+type helper struct{}
+func (helper) skipSlowCmdGCTest(t *testing.T, reason string) {}
+`)},
+		"wrong_type/helper_test.go": &fstest.MapFile{Data: []byte(`package wrongtype
+import "testing"
+func skipSlowCmdGCTest(t *testing.T, reason int) {}
+func TestWrongType(t *testing.T) { skipSlowCmdGCTest(t, 1) }
+`)},
+		"wrong_first/helper_test.go": &fstest.MapFile{Data: []byte(`package wrongfirst
+type localT struct{}
+func skipSlowCmdGCTest(t *localT, reason string) {}
+func TestWrongFirstType() { skipSlowCmdGCTest(nil, "not owned") }
+`)},
+		"result/helper_test.go": &fstest.MapFile{Data: []byte(`package result
+import "testing"
+func skipSlowCmdGCTest(t *testing.T, reason string) bool { return false }
+func TestResult(t *testing.T) { skipSlowCmdGCTest(t, "not owned") }
+`)},
+		"arity/helper_test.go": &fstest.MapFile{Data: []byte(`package arity
+import "testing"
+func skipSlowCmdGCTest(t *testing.T, reason string) {}
+func TestWrongArity(t *testing.T) { skipSlowCmdGCTest(t) }
+`)},
+	})
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeUntagged, ResourceSlowProcessGate, 1, 1)
+}
+
+func TestScanDoesNotCountUnownedSlowHelperName(t *testing.T) {
+	t.Parallel()
+
+	got, err := ScanFS(fstest.MapFS{
+		"sample/sample_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestUnresolvedName(t *testing.T) {
+	skipSlowCmdGCTest(t, "there is no package helper")
+}
+`)},
+	})
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeUntagged, ResourceSlowProcessGate, 0, 0)
+}
+
+func TestScanRejectsMultipleCanonicalSlowHelpersPerPackage(t *testing.T) {
+	t.Parallel()
+
+	_, err := ScanFS(fstest.MapFS{
+		"sample/first_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func skipSlowCmdGCTest(t *testing.T, reason string) {}
+`)},
+		"sample/second_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func skipSlowCmdGCTest(t *testing.T, reason string) {}
+`)},
+	})
+	requireErrorContains(t, err, "package sample has multiple canonical declarations")
+}
+
+func TestCmdGCUntaggedScopeRequiresExactPathSegment(t *testing.T) {
+	t.Parallel()
+
+	census := Census{Occurrences: []Occurrence{
+		{Path: "cmd/gc/owned_test.go", Resource: ResourceEnvironment},
+		{Path: "cmd/gc-extra/not_owned_test.go", Resource: ResourceEnvironment},
+		{Path: "cmd/gc/tagged_test.go", Tagged: true, Resource: ResourceEnvironment},
+	}}
+	assertCount(t, census, ScopeCmdGCUntagged, ResourceEnvironment, 1, 1)
 }
 
 func TestScanTreatsImplicitPlatformFilenameConstraintsAsTagged(t *testing.T) {
@@ -210,7 +556,15 @@ func TestScanFailsClosedWhenCandidateQualifierBindingIsMissing(t *testing.T) {
 
 	_, err := ScanFS(fstest.MapFS{
 		"sample/unresolved_test.go": &fstest.MapFile{Data: []byte(`package sample
-func TestResource() { missing.Command("worker") }
+import (
+	"example.test/process/v2"
+	"fmt"
+)
+func TestResource() {
+	_ = fmt.Sprint
+	process.Setenv("KEY", "value")
+	missing.Command("worker")
+}
 `)},
 	})
 	requireErrorContains(t, err, `resource candidate qualifier "missing" has no lexical binding`)
@@ -325,6 +679,24 @@ import . "time"
 func TestResource() { Sleep(1) }
 `,
 		},
+		{
+			name:       "os",
+			path:       "sample/dot_os_test.go",
+			importPath: "os",
+			source: `package sample
+import . "os"
+func TestResource() { Setenv("KEY", "value") }
+`,
+		},
+		{
+			name:       "testing",
+			path:       "sample/dot_testing_test.go",
+			importPath: "testing",
+			source: `package sample
+import . "testing"
+func TestResource(t *T) { t.Setenv("KEY", "value") }
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -343,7 +715,9 @@ func TestScanAllowsBlankImportsOfTargetedPackages(t *testing.T) {
 	files := fstest.MapFS{
 		"sample/blank_import_test.go": &fstest.MapFile{Data: []byte(`package sample
 import (
+	_ "os"
 	_ "os/exec"
+	_ "testing"
 	_ "time"
 )
 func TestResource() {}
@@ -353,8 +727,9 @@ func TestResource() {}
 	if err != nil {
 		t.Fatalf("ScanFS: %v", err)
 	}
-	assertCount(t, got, ScopeAll, ResourceSubprocess, 0, 0)
-	assertCount(t, got, ScopeAll, ResourceFixedSleep, 0, 0)
+	if len(got.Occurrences) != 0 {
+		t.Fatalf("blank imports produced resource occurrences: %+v", got.Occurrences)
+	}
 }
 
 func TestScanMatchesGoLeadingBuildHeaderPlacement(t *testing.T) {
@@ -606,6 +981,44 @@ func TestValidateAllowsHistoricalNeedleToDifferFromASTCensus(t *testing.T) {
 	}
 }
 
+func TestValidateAllowsNarrowerHistoricalCmdGCNeedle(t *testing.T) {
+	t.Parallel()
+
+	census := Census{Occurrences: []Occurrence{
+		{Path: "cmd/gc/a_test.go", Resource: ResourceEnvironment},
+		{Path: "cmd/gc/b_test.go", Resource: ResourceEnvironment},
+	}}
+	policy := validLedger(census)
+	row := findRow(t, policy.Debt, ScopeCmdGCUntagged, ResourceEnvironment)
+	row.ReportedCalls = 1
+	row.ReportedFiles = 1
+	ledger := cloneLedger(policy)
+
+	if err := validateAgainstPolicy(policy, ledger, census, fixedNow()); err != nil {
+		t.Fatalf("Validate rejected narrower historical cmd/gc source needle: %v", err)
+	}
+}
+
+func TestValidateRejectsCoordinatedCmdGCCensusAndManifestGrowth(t *testing.T) {
+	t.Parallel()
+
+	policy := validLedger(Census{})
+	ledger := cloneLedger(policy)
+	row := findRow(t, ledger.Debt, ScopeCmdGCUntagged, ResourceEnvironment)
+	row.BaselineCalls = 1
+	row.BaselineFiles = 1
+	census := Census{Occurrences: []Occurrence{{
+		Path:     "cmd/gc/new_test.go",
+		Resource: ResourceEnvironment,
+	}}}
+
+	err := validateAgainstPolicy(policy, ledger, census, fixedNow())
+	requireErrorContains(t, err, "baseline_calls = 1, bootstrap policy requires 0")
+	if strings.Contains(err.Error(), "source resource census") {
+		t.Fatalf("live census was compared before cmd/gc policy drift was rejected: %v", err)
+	}
+}
+
 func TestValidateRejectsBootstrapPolicyDriftBeforeLiveCensus(t *testing.T) {
 	t.Parallel()
 
@@ -711,6 +1124,16 @@ func TestValidateUsesCodeOwnedBootstrapPolicy(t *testing.T) {
 func TestValidateRequiresTheExactBootstrapRowSet(t *testing.T) {
 	t.Parallel()
 
+	removeDebt := func(scope Scope, resource Resource) func(*Ledger) {
+		return func(ledger *Ledger) {
+			for index, row := range ledger.Debt {
+				if row.Scope == scope && row.Resource == resource {
+					ledger.Debt = append(ledger.Debt[:index], ledger.Debt[index+1:]...)
+					return
+				}
+			}
+		}
+	}
 	tests := []struct {
 		name   string
 		mutate func(*Ledger)
@@ -729,6 +1152,21 @@ func TestValidateRequiresTheExactBootstrapRowSet(t *testing.T) {
 				ledger.Debt = ledger.Debt[1:]
 			},
 			want: `missing required debt baseline: scope=untagged resource=subprocess`,
+		},
+		{
+			name:   "missing cmd gc environment row",
+			mutate: removeDebt(ScopeCmdGCUntagged, ResourceEnvironment),
+			want:   `missing required debt baseline: scope=cmd/gc+untagged resource=environment`,
+		},
+		{
+			name:   "missing cmd gc cwd row",
+			mutate: removeDebt(ScopeCmdGCUntagged, ResourceCWD),
+			want:   `missing required debt baseline: scope=cmd/gc+untagged resource=cwd`,
+		},
+		{
+			name:   "missing cmd gc slow-process row",
+			mutate: removeDebt(ScopeCmdGCUntagged, ResourceSlowProcessGate),
+			want:   `missing required debt baseline: scope=cmd/gc+untagged resource=slow_process_gate`,
 		},
 		{
 			name: "unexpected audit row",
@@ -822,6 +1260,7 @@ func TestRenderMarkdownIsDeterministic(t *testing.T) {
 		},
 		Debt: []Baseline{
 			validDebt(ScopeUntagged, ResourceSubprocess, 3, 2),
+			validDebt(ScopeCmdGCUntagged, ResourceCWD, 2, 1),
 		},
 	}
 	got := RenderMarkdown(ledger)
@@ -829,6 +1268,7 @@ func TestRenderMarkdownIsDeterministic(t *testing.T) {
 | Ledger kind | Source scope | Resource baseline | Tracking owner | Invariant / resource owner | Migration | Expiry |
 | --- | --- | --- | --- | --- | --- | --- |
 | Audit baseline | all tracked test source | fixed_sleep: 4 calls / 2 files | P0.4 | source census only; does not classify tests; audit owner | P0.4a | 2026-10-01 |
+| Source debt ratchet | ` + "`cmd/gc`" + ` untagged test source | cwd: 2 calls / 1 files | P0.4 | existing debt cannot grow; owning test cleanup | D5/D6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 3 calls / 2 files | P0.4 | existing debt cannot grow; owning test cleanup | D1/D2 | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->`
 	if got != want {
@@ -891,6 +1331,9 @@ func validLedger(census Census) Ledger {
 	allSleep := census.Count(ScopeAll, ResourceFixedSleep)
 	untaggedSubprocess := census.Count(ScopeUntagged, ResourceSubprocess)
 	untaggedSleep := census.Count(ScopeUntagged, ResourceFixedSleep)
+	cmdGCEnvironment := census.Count(ScopeCmdGCUntagged, ResourceEnvironment)
+	cmdGCCWD := census.Count(ScopeCmdGCUntagged, ResourceCWD)
+	cmdGCSlowProcessGate := census.Count(ScopeCmdGCUntagged, ResourceSlowProcessGate)
 	return Ledger{
 		Version: 1,
 		AuditBaseline: []Baseline{
@@ -900,6 +1343,9 @@ func validLedger(census Census) Ledger {
 		Debt: []Baseline{
 			validDebt(ScopeUntagged, ResourceSubprocess, untaggedSubprocess.Calls, untaggedSubprocess.Files),
 			validDebt(ScopeUntagged, ResourceFixedSleep, untaggedSleep.Calls, untaggedSleep.Files),
+			validDebt(ScopeCmdGCUntagged, ResourceEnvironment, cmdGCEnvironment.Calls, cmdGCEnvironment.Files),
+			validDebt(ScopeCmdGCUntagged, ResourceCWD, cmdGCCWD.Calls, cmdGCCWD.Files),
+			validDebt(ScopeCmdGCUntagged, ResourceSlowProcessGate, cmdGCSlowProcessGate.Calls, cmdGCSlowProcessGate.Files),
 		},
 	}
 }
@@ -919,6 +1365,10 @@ func validAudit(scope Scope, resource Resource, calls, files int) Baseline {
 }
 
 func validDebt(scope Scope, resource Resource, calls, files int) Baseline {
+	migration := "D1/D2"
+	if scope == ScopeCmdGCUntagged {
+		migration = "D5/D6"
+	}
 	return Baseline{
 		Scope:           scope,
 		Resource:        resource,
@@ -927,7 +1377,7 @@ func validDebt(scope Scope, resource Resource, calls, files int) Baseline {
 		OwnerBead:       "P0.4",
 		Invariant:       "existing debt cannot grow",
 		ResourceOwner:   "owning test cleanup",
-		MigrationTarget: "D1/D2",
+		MigrationTarget: migration,
 		Expires:         "2026-10-01",
 	}
 }

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -60,3 +60,42 @@ invariant = "untagged fixed-sleep call/file totals cannot grow; reductions must 
 resource_owner = "each owning test replaces elapsed wall time with its lifecycle signal"
 migration_target = "W1-W5"
 expires = "2026-10-01"
+
+[[debt]]
+scope = "cmd/gc+untagged"
+resource = "environment"
+baseline_calls = 4092
+baseline_files = 180
+reported_calls = 3960
+reported_files = 184
+owner_bead = "ga-80po0c.2.3"
+invariant = "untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "cmd/gc callers restore or eliminate every recognized process-environment mutation"
+migration_target = "D5/D6/E6"
+expires = "2026-10-01"
+
+[[debt]]
+scope = "cmd/gc+untagged"
+resource = "cwd"
+baseline_calls = 208
+baseline_files = 40
+reported_calls = 98
+reported_files = 13
+owner_bead = "ga-80po0c.2.3"
+invariant = "untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "cmd/gc callers restore or eliminate every recognized cwd mutation"
+migration_target = "D5/D6"
+expires = "2026-10-01"
+
+[[debt]]
+scope = "cmd/gc+untagged"
+resource = "slow_process_gate"
+baseline_calls = 77
+baseline_files = 26
+reported_calls = 78
+reported_files = 27
+owner_bead = "ga-80po0c.2.3"
+invariant = "untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline"
+resource_owner = "the helper definition and every marked caller retain an explicit process-suite migration owner"
+migration_target = "D5/D6/E6"
+expires = "2026-10-01"


### PR DESCRIPTION
## Summary

- add syntax-aware cmd/gc+untagged ratchets for environment, CWD, and the canonical slow-process gate
- preserve exact lexical ownership across local, sibling-test, and sibling-production shadows without package-wide type checking
- pin live and historical ceilings plus ownership metadata in code, TOML, and the generated TESTING.md ledger

## Testing

- [ ] make check (used the documented parallel equivalents below)
- [x] make check-docs
- [ ] make test-integration (not applicable: test-policy-only change)
- [x] GOFLAGS=-mod=readonly go vet ./...
- [x] GOFLAGS=-mod=readonly LOCAL_TEST_JOBS=2 make test-fast-parallel
- [x] resourcecensus package x10 and race x3
- [x] focused repository ledger gate: 2.6-3.2s wall across independent runs
- [x] pre-commit and pre-push hooks
- [x] three independent exact-tree council reviews: CLEAR, zero P0/P1

## Checklist

- [x] Linked work item: ga-80po0c.2.3
- [x] Added or updated tests for behavior changes
- [x] Updated contributor testing documentation
- [x] No breaking changes or migration required