### PR TITLE
test: enforce exact Medium resource ownership

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -2,26 +2,37 @@
 
 ## Checked source-level resource ratchets
 
-`test/test-resources.toml` is the P0.4a source call-site ratchet. It scans
-tracked `*_test.go` files through parsed Go syntax and import identity, freezes
-seven process, sleep, environment, CWD, and slow-process call/file totals,
-rejects growth, and requires a baseline reduction whenever source debt falls.
-The Go-owned
-`bootstrapPolicy` pins every row's ceiling, historical totals, owner,
-invariant, resource owner, migration, and expiry. Ordinary source growth fails
-against that ceiling, and TOML-only normalization or metadata edits fail
-against the policy before the live census is compared.
+`test/test-resources.toml` is the checked P0.4 resource ledger. It scans tracked
+Go source through parsed syntax and import identity, while only `*_test.go`
+files contribute resource occurrences. The raw audit and source-debt rows
+freeze process, sleep, environment, CWD, and slow-process call/file totals.
+Exact Medium rows name a repository-relative directory, package clause,
+top-level runnable owner, and resource list. Small-debt rows apply those exact
+owners without weakening the raw anti-growth ratchets.
+
+The Go-owned `bootstrapPolicy` pins every row's ceiling, historical totals,
+owner, invariant, resource owner, migration, and expiry. Ordinary source
+growth fails against that ceiling, and TOML-only normalization, relabeling, or
+metadata edits fail against the policy before the live census is compared.
 
 Changing `bootstrapPolicy` together with the TOML and generated table is an
 explicit policy change that requires the same staged-diff council review as
 other test-infrastructure changes. The guard makes ordinary drift visible; it
 does not claim that self-modifying source can be cryptographically forbidden.
 
-This bootstrap does **not** classify a test as Small, Medium, or Large, infer
-resources recursively through arbitrary helper calls, or claim to be a complete
-inventory of test resources. `ga-80po0c.2.1` owns exact Medium identities,
-package `TestMain` inheritance, and resource lists. `ga-80po0c.2.2` owns the
-listener, tmux, Dolt, and shared-host catalogs. E1 separately owns Large
+The canonical identity is package directory plus package clause plus top-level
+`Test`, `Benchmark`, `Fuzz`, or `TestMain` name. Nested function literals and
+subtests retain that top-level lexical owner. Methods, wrong signatures, and
+helper functions are not runnable owners; resources lexically inside helpers
+remain Small debt even when a Medium test calls the helper. Likewise, a
+`TestMain` row classifies inherited package setup but exempts only matching
+calls inside `TestMain`, never sibling tests.
+
+This bootstrap does **not** infer resources recursively through arbitrary
+helper calls or claim a complete shared-resource inventory. A Medium resource
+may describe a helper-backed runtime cost, but only syntax-owned calls in that
+exact runnable declaration leave Small-debt accounting. `ga-80po0c.2.2` owns
+the listener, tmux, Dolt, and shared-host catalogs. E1 separately owns Large
 journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
@@ -63,17 +74,26 @@ They can be higher because comments and strings matched, or lower where the old
 needle covered only `t.Setenv` or direct `os.Chdir` and the AST census now
 recognizes the full families above. Historical `cmd/gc` needles also included
 build-tagged files; the live `cmd/gc+untagged` ratchets do not.
+`internal/bdflags/freshness_test.go` is integration-tagged because it invokes
+the externally installed `bd` CLI; its process call remains visible in the
+all-source audit while staying outside untagged and Small debt.
 
 <!-- BEGIN CHECKED TEST RESOURCE LEDGER -->
 | Ledger kind | Source scope | Resource baseline | Tracking owner | Invariant / resource owner | Migration | Expiry |
 | --- | --- | --- | --- | --- | --- | --- |
-| Audit baseline | all tracked test source | fixed_sleep: 443 calls / 156 files (historical regex census: 447 / 157) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
+| Audit baseline | all tracked test source | fixed_sleep: 436 calls / 153 files (historical regex census: 447 / 157) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
 | Audit baseline | all tracked test source | subprocess: 491 calls / 136 files (historical regex census: 495 / 135) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
+| Medium owner | `cmd/gc` package `main` | TestMain: environment | ga-80po0c.2.1 | cmd/gc TestMain is the checked package-level Medium owner; only environment calls lexically inside TestMain leave Small debt | P0.4b | 2026-10-01 |
+| Small debt ratchet | `cmd/gc` untagged test source | cwd: 208 calls / 40 files | ga-80po0c.2.1 | untagged Small cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners restore or eliminate every cwd mutation | D5/D6 | 2026-10-01 |
+| Small debt ratchet | `cmd/gc` untagged test source | environment: 4086 calls / 180 files | ga-80po0c.2.1 | untagged Small cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners restore or eliminate every process-environment mutation | D5/D6/E6 | 2026-10-01 |
+| Small debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files | ga-80po0c.2.1 | untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; each non-Medium marked caller retains an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
+| Small debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
+| Small debt ratchet | all untagged test source | subprocess: 374 calls / 97 files | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | cwd: 208 calls / 40 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | environment: 4092 calls / 180 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
-| Source debt ratchet | all untagged test source | fixed_sleep: 291 calls / 113 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
-| Source debt ratchet | all untagged test source | subprocess: 375 calls / 98 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
+| Source debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
+| Source debt ratchet | all untagged test source | subprocess: 374 calls / 97 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->
 
 ## Three tiers, clear boundaries

--- a/internal/api/handler_extmsg_agent_binding_test.go
+++ b/internal/api/handler_extmsg_agent_binding_test.go
@@ -17,6 +17,7 @@ func newExtMsgAgentBindingFixture(t *testing.T) (*fakeState, *Server, *extmsg.Se
 	t.Helper()
 	fs := newSessionFakeState(t)
 	srv := New(fs)
+	t.Cleanup(srv.waitForBackground)
 	services := extmsg.NewServices(fs.cityBeadStore)
 	fs.extmsgSvc = &services
 	registry := extmsg.NewAdapterRegistry()
@@ -151,16 +152,10 @@ func TestHandleExtMsgInboundAgentBoundColdWakesNamedSession(t *testing.T) {
 	}
 
 	// The notify fan-out materializes the bound agent's named session —
-	// the cold-wake. It runs in a background goroutine, so poll briefly.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil && id != "" {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for agent-bound inbound to cold-wake myrig/worker")
-		}
-		time.Sleep(10 * time.Millisecond)
+	// the cold-wake.
+	srv.waitForBackground()
+	if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err != nil || id == "" {
+		t.Fatalf("agent-bound inbound did not cold-wake myrig/worker: id=%q err=%v", id, err)
 	}
 }
 

--- a/internal/api/handler_extmsg_default_route_test.go
+++ b/internal/api/handler_extmsg_default_route_test.go
@@ -53,15 +53,9 @@ func TestHandleExtMsgInboundDefaultRouteBindsAndColdWakes(t *testing.T) {
 	}
 
 	// The notify fan-out cold-wakes the routed agent's named session.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil && id != "" {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for default-routed inbound to cold-wake myrig/worker")
-		}
-		time.Sleep(10 * time.Millisecond)
+	srv.waitForBackground()
+	if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err != nil || id == "" {
+		t.Fatalf("default-routed inbound did not cold-wake myrig/worker: id=%q err=%v", id, err)
 	}
 }
 

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -51,6 +51,7 @@ func (a *testExtMsgAdapter) EnsureChildConversation(context.Context, extmsg.Conv
 func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)
+	t.Cleanup(srv.waitForBackground)
 
 	services := extmsg.NewServices(fs.cityBeadStore)
 	fs.extmsgSvc = &services
@@ -117,16 +118,9 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 	if adapter.publishCalls[0].Text != "hello peers" {
 		t.Fatalf("publish text = %q, want hello peers", adapter.publishCalls[0].Text)
 	}
+	srv.waitForBackground()
 
-	var peerID string
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		peerID, err = session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
-		if err == nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	peerID, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
 	if err != nil {
 		t.Fatalf("ResolveSessionID(myrig/worker): %v", err)
 	}
@@ -138,47 +132,25 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 	if peerSessionName == "" {
 		t.Fatal("materialized peer session missing session_name")
 	}
-	// Materialization commits the session bead before the runtime session is
-	// started (session.Manager create path: bead first, then provider Start),
-	// so a direct store reader can observe the resolvable bead before
-	// IsRunning flips true. Poll for running instead of checking once to avoid
-	// a load-dependent race (see ga-thgf8q).
-	running := false
-	deadline = time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if fs.sp.IsRunning(peerSessionName) {
-			running = true
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if !running {
+	if !fs.sp.IsRunning(peerSessionName) {
 		t.Fatalf("peer session %q should be running after outbound publish", peerSessionName)
 	}
 
 	peerNudges := 0
-	deadline = time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		peerNudges = 0
-		calls := fs.sp.SnapshotCalls()
-		for _, call := range calls {
-			if call.Method != "Nudge" {
-				continue
-			}
-			if call.Name == source.SessionName {
-				t.Fatalf("source session should not receive peer publish nudge; calls=%#v", calls)
-			}
-			if call.Name == peerSessionName && strings.Contains(call.Message, "hello peers") {
-				peerNudges++
-			}
+	calls := fs.sp.SnapshotCalls()
+	for _, call := range calls {
+		if call.Method != "Nudge" {
+			continue
 		}
-		if peerNudges == 1 {
-			break
+		if call.Name == source.SessionName {
+			t.Fatalf("source session should not receive peer publish nudge; calls=%#v", calls)
 		}
-		time.Sleep(10 * time.Millisecond)
+		if call.Name == peerSessionName && strings.Contains(call.Message, "hello peers") {
+			peerNudges++
+		}
 	}
 	if peerNudges != 1 {
-		t.Fatalf("peer nudge count = %d, want 1; calls=%#v", peerNudges, fs.sp.SnapshotCalls())
+		t.Fatalf("peer nudge count = %d, want 1; calls=%#v", peerNudges, calls)
 	}
 }
 
@@ -301,6 +273,7 @@ func TestExtmsgNotifyMembersSuppressesDiscriminatorForRoutedParticipant(t *testi
 func TestHandleExtMsgOutboundNotifiesDeliveredConversationMembers(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)
+	t.Cleanup(srv.waitForBackground)
 
 	services := extmsg.NewServices(fs.cityBeadStore)
 	fs.extmsgSvc = &services
@@ -360,16 +333,9 @@ func TestHandleExtMsgOutboundNotifiesDeliveredConversationMembers(t *testing.T) 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
+	srv.waitForBackground()
 
-	var peerID string
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		peerID, err = session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
-		if err == nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	peerID, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
 	if err != nil {
 		t.Fatalf("ResolveSessionID(myrig/worker): %v", err)
 	}
@@ -383,21 +349,15 @@ func TestHandleExtMsgOutboundNotifiesDeliveredConversationMembers(t *testing.T) 
 	}
 
 	found := false
-	deadline = time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		for _, call := range fs.sp.Calls {
-			if call.Method == "Nudge" && call.Name == peerSessionName && strings.Contains(call.Message, "thread-delivered") {
-				found = true
-				break
-			}
-		}
-		if found {
+	calls := fs.sp.SnapshotCalls()
+	for _, call := range calls {
+		if call.Method == "Nudge" && call.Name == peerSessionName && strings.Contains(call.Message, "thread-delivered") {
+			found = true
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
 	if !found {
-		t.Fatalf("delivered conversation peer nudge not found; calls=%#v", fs.sp.Calls)
+		t.Fatalf("delivered conversation peer nudge not found; calls=%#v", calls)
 	}
 }
 

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -89,7 +89,10 @@ func (s *Server) humaHandleExtMsgInbound(ctx context.Context, input *ExtMsgInbou
 				return nil, apierr.Internal.Msg(handleErr.Error())
 			}
 		}
-		go s.extmsgNotifyInboundMembers(s.backgroundCtx(), *input.Body.Message)
+		message := *input.Body.Message
+		s.runBackground(func(ctx context.Context) {
+			s.extmsgNotifyInboundMembers(ctx, message)
+		})
 		out := &ExtMsgInboundOutput{}
 		if result != nil {
 			out.Body = *result
@@ -167,7 +170,10 @@ func (s *Server) humaHandleExtMsgOutbound(ctx context.Context, input *ExtMsgOutb
 			notifyConversation = result.Receipt.Conversation
 		}
 		sourceDisplay := s.extmsgSessionHandleForSelector(input.Body.SessionID)
-		go s.extmsgNotifyMembers(s.backgroundCtx(), notifyConversation, sourceDisplay, "agent", input.Body.Text, input.Body.SessionID, "")
+		text, sessionID := input.Body.Text, input.Body.SessionID
+		s.runBackground(func(ctx context.Context) {
+			s.extmsgNotifyMembers(ctx, notifyConversation, sourceDisplay, "agent", text, sessionID, "")
+		})
 	}
 	out := &ExtMsgOutboundOutput{}
 	if result != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,22 +20,21 @@ import (
 // lifetimes or block shutdown on a slow downstream.
 const extmsgNotifyTimeout = 30 * time.Second
 
-// backgroundCtx returns a context that is explicitly detached from the
-// request but has a bounded timeout. Use for fire-and-forget work
-// (extmsg member notification, log-write fanouts) so goroutines cannot
-// outlive reasonable bounds. When the server gains a shutdown ctx in
-// the future, derive from that instead.
-//
-// The returned cancel is intentionally captured inside a goroutine that
-// exits on ctx.Done(), so go vet's lostcancel check stays happy while
-// the timeout still prevents unbounded accumulation.
-func (s *Server) backgroundCtx() context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), extmsgNotifyTimeout)
+// runBackground owns one detached, bounded task. The task is visible to
+// waitForBackground so tests and a future server shutdown path can wait for
+// side effects before releasing the state they use.
+func (s *Server) runBackground(run func(context.Context)) {
+	s.backgroundTasks.Add(1)
 	go func() {
-		<-ctx.Done()
-		cancel()
+		defer s.backgroundTasks.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), extmsgNotifyTimeout)
+		defer cancel()
+		run(ctx)
 	}()
-	return ctx
+}
+
+func (s *Server) waitForBackground() {
+	s.backgroundTasks.Wait()
 }
 
 // Server is the per-city handler-host. It owns the per-city State and
@@ -53,6 +52,8 @@ type Server struct {
 	state    State
 	mux      *http.ServeMux
 	readOnly bool // mirrors supervisor's read-only flag for /svc/ enforcement
+
+	backgroundTasks sync.WaitGroup
 
 	// sessionLogSearchPaths overrides the default search paths for Claude
 	// session JSONL files. Nil means use worker.DefaultSearchPaths().

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -3,7 +3,7 @@
 // and the gc lint check that validates bd invocations embedded in prompt
 // templates, so the two call sites cannot drift apart from each other.
 //
-// Sourced from bd <sub> --help output (2026-07-05, bd v1.1.0).
+// Sourced from bd <sub> --help output (2026-07-13, bd v1.1.0).
 package bdflags
 
 import "sort"
@@ -37,7 +37,7 @@ var valueFlagsBySub = map[string]map[string]bool{
 		"--id": true, "-l": true, "--labels": true, "--metadata": true,
 		"--mol-type": true, "--notes": true, "--parent": true, "-p": true,
 		"--priority": true, "--repo": true, "--skills": true, "--spec-id": true,
-		"--title": true, "-t": true, "--type": true, "--waits-for": true,
+		"-s": true, "--status": true, "--title": true, "-t": true, "--type": true, "--waits-for": true,
 		"--waits-for-gate": true, "--wisp-type": true,
 	},
 	"update": {

--- a/internal/bdflags/bdflags_test.go
+++ b/internal/bdflags/bdflags_test.go
@@ -66,6 +66,15 @@ func TestGlobalFlagsPresentOnEverySubcommand(t *testing.T) {
 	}
 }
 
+func TestCreateStatusFlagsConsumeValues(t *testing.T) {
+	value := ValueFlags("create")
+	for _, flag := range []string{"-s", "--status"} {
+		if !value[flag] {
+			t.Errorf("ValueFlags(create)[%q] = false, want true", flag)
+		}
+	}
+}
+
 func TestUpdateFlagSets(t *testing.T) {
 	value := ValueFlags("update")
 	for _, f := range []string{"--assignee", "-a", "--status", "-s", "--priority", "-p", "--set-metadata", "--unset-metadata", "--parent", "--type", "-t"} {

--- a/internal/bdflags/freshness_test.go
+++ b/internal/bdflags/freshness_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package bdflags
 
 import (

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/BurntSushi/toml"
 )
@@ -67,9 +69,11 @@ type baselineKey struct {
 
 // Ledger is the checked source-level test-resource inventory.
 type Ledger struct {
-	Version       int        `toml:"version"`
-	AuditBaseline []Baseline `toml:"audit_baseline"`
-	Debt          []Baseline `toml:"debt"`
+	Version       int           `toml:"version"`
+	AuditBaseline []Baseline    `toml:"audit_baseline"`
+	Debt          []Baseline    `toml:"debt"`
+	Medium        []MediumOwner `toml:"medium"`
+	SmallDebt     []Baseline    `toml:"small_debt"`
 }
 
 // Baseline pins one source-census signal and its migration ownership.
@@ -88,7 +92,7 @@ type Baseline struct {
 }
 
 var bootstrapPolicy = Ledger{
-	Version: 1,
+	Version: 2,
 	AuditBaseline: []Baseline{
 		{
 			Scope:           ScopeAll,
@@ -106,8 +110,8 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeAll,
 			Resource:        ResourceFixedSleep,
-			BaselineCalls:   443,
-			BaselineFiles:   156,
+			BaselineCalls:   436,
+			BaselineFiles:   153,
 			ReportedCalls:   447,
 			ReportedFiles:   157,
 			OwnerBead:       "ga-80po0c.2",
@@ -121,8 +125,8 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeUntagged,
 			Resource:        ResourceSubprocess,
-			BaselineCalls:   375,
-			BaselineFiles:   98,
+			BaselineCalls:   374,
+			BaselineFiles:   97,
 			ReportedCalls:   380,
 			ReportedFiles:   98,
 			OwnerBead:       "ga-80po0c.2",
@@ -134,8 +138,8 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeUntagged,
 			Resource:        ResourceFixedSleep,
-			BaselineCalls:   291,
-			BaselineFiles:   113,
+			BaselineCalls:   284,
+			BaselineFiles:   110,
 			ReportedCalls:   295,
 			ReportedFiles:   114,
 			OwnerBead:       "ga-80po0c.2",
@@ -184,18 +188,103 @@ var bootstrapPolicy = Ledger{
 			Expires:         "2026-10-01",
 		},
 	},
+	Medium: []MediumOwner{
+		{
+			PackageDir:      "cmd/gc",
+			PackageName:     "main",
+			Owner:           "TestMain",
+			Resources:       []Resource{ResourceEnvironment},
+			OwnerBead:       "ga-80po0c.2.1",
+			Invariant:       "cmd/gc TestMain is the checked package-level Medium owner",
+			ResourceOwner:   "only environment calls lexically inside TestMain leave Small debt",
+			MigrationTarget: "P0.4b",
+			Expires:         "2026-10-01",
+		},
+	},
+	SmallDebt: []Baseline{
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceSubprocess,
+			BaselineCalls:   374,
+			BaselineFiles:   97,
+			ReportedCalls:   374,
+			ReportedFiles:   97,
+			OwnerBead:       "ga-80po0c.2.1",
+			Invariant:       "untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners remove or replace each process call site",
+			MigrationTarget: "D1/D2/D5/D6/E6",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceFixedSleep,
+			BaselineCalls:   284,
+			BaselineFiles:   110,
+			ReportedCalls:   284,
+			ReportedFiles:   110,
+			OwnerBead:       "ga-80po0c.2.1",
+			Invariant:       "untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners replace elapsed wall time with lifecycle signals",
+			MigrationTarget: "W1-W5",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeCmdGCUntagged,
+			Resource:        ResourceEnvironment,
+			BaselineCalls:   4086,
+			BaselineFiles:   180,
+			ReportedCalls:   4086,
+			ReportedFiles:   180,
+			OwnerBead:       "ga-80po0c.2.1",
+			Invariant:       "untagged Small cmd/gc environment call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners restore or eliminate every process-environment mutation",
+			MigrationTarget: "D5/D6/E6",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeCmdGCUntagged,
+			Resource:        ResourceCWD,
+			BaselineCalls:   208,
+			BaselineFiles:   40,
+			ReportedCalls:   208,
+			ReportedFiles:   40,
+			OwnerBead:       "ga-80po0c.2.1",
+			Invariant:       "untagged Small cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners restore or eliminate every cwd mutation",
+			MigrationTarget: "D5/D6",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeCmdGCUntagged,
+			Resource:        ResourceSlowProcessGate,
+			BaselineCalls:   77,
+			BaselineFiles:   26,
+			ReportedCalls:   77,
+			ReportedFiles:   26,
+			OwnerBead:       "ga-80po0c.2.1",
+			Invariant:       "untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each non-Medium marked caller retains an explicit process-suite migration owner",
+			MigrationTarget: "D5/D6/E6",
+			Expires:         "2026-10-01",
+		},
+	},
 }
 
 // Occurrence is one syntax-owned resource use.
 type Occurrence struct {
-	Path     string
-	Tagged   bool
-	Resource Resource
+	Path        string
+	PackageDir  string
+	PackageName string
+	Owner       string
+	Runnable    bool
+	Tagged      bool
+	Resource    Resource
 }
 
 // Census is a deterministic collection of resource occurrences.
 type Census struct {
 	Occurrences []Occurrence
+	Runnables   []RunnableOwner
 }
 
 // Count is the call-site and unique-file count for a scope/resource pair.
@@ -277,7 +366,7 @@ type parsedFile struct {
 	packageName string
 	tagged      bool
 	file        *ast.File
-	calls       []*ast.CallExpr
+	calls       []resourceCall
 	bindings    bindingInfo
 }
 
@@ -291,6 +380,12 @@ type bindingInfo struct {
 type packageKey struct {
 	directory   string
 	packageName string
+}
+
+type resourceCall struct {
+	call     *ast.CallExpr
+	owner    string
+	runnable bool
 }
 
 type emptyPackageImporter struct {
@@ -341,6 +436,7 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 	fileSet := token.NewFileSet()
 	importer := newEmptyPackageImporter()
 	var sources []parsedFile
+	var runnables []RunnableOwner
 	packageDeclarations := make(map[packageKey]map[string]struct{})
 	for _, name := range names {
 		data, err := fs.ReadFile(sourceFS, name)
@@ -369,6 +465,7 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		if err := validateImports(file); err != nil {
 			return Census{}, fmt.Errorf("scanning imports in %s: %w", name, err)
 		}
+		runnables = append(runnables, runnableOwners(file, key.directory, key.packageName)...)
 		candidates := resourceCandidateCalls(file)
 		scanned := len(candidates) > 0 || hasSlowHelperDeclarationCandidate(file)
 		if !scanned {
@@ -418,7 +515,7 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		}
 	}
 
-	census := Census{}
+	census := Census{Runnables: uniqueSortedRunnables(runnables)}
 	for _, source := range sources {
 		testingObjects, err := testingParameterObjects(source.file, source.bindings)
 		if err != nil {
@@ -434,55 +531,56 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 				return Census{}, fmt.Errorf("scanning slow-process helper in %s: %w", source.name, err)
 			}
 			if matched {
-				census.add(source, ResourceSlowProcessGate)
+				census.add(source, function.Name.Name, false, ResourceSlowProcessGate)
 			}
 		}
 
-		for _, call := range source.calls {
+		for _, candidate := range source.calls {
+			call := candidate.call
 			matched, err := isImportedCall(call, source.bindings, "os/exec", "Command", "CommandContext")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
-				census.add(source, ResourceSubprocess)
+				census.add(source, candidate.owner, candidate.runnable, ResourceSubprocess)
 			}
 			matched, err = isImportedCall(call, source.bindings, "time", "Sleep")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
-				census.add(source, ResourceFixedSleep)
+				census.add(source, candidate.owner, candidate.runnable, ResourceFixedSleep)
 			}
 			matched, err = isImportedCall(call, source.bindings, "os", "Setenv", "Unsetenv", "Clearenv")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
-				census.add(source, ResourceEnvironment)
+				census.add(source, candidate.owner, candidate.runnable, ResourceEnvironment)
 			}
 			matched, err = isImportedCall(call, source.bindings, "os", "Chdir")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
-				census.add(source, ResourceCWD)
+				census.add(source, candidate.owner, candidate.runnable, ResourceCWD)
 			}
 			matched, err = isTestingCall(call, source.bindings, testingObjects, "Setenv")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
-				census.add(source, ResourceEnvironment)
+				census.add(source, candidate.owner, candidate.runnable, ResourceEnvironment)
 			}
 			matched, err = isTestingCall(call, source.bindings, testingObjects, "Chdir")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
 			if matched {
-				census.add(source, ResourceCWD)
+				census.add(source, candidate.owner, candidate.runnable, ResourceCWD)
 			}
 			if isSlowHelperCall(call, source.bindings, slowHelpers[source.groupKey()]) {
-				census.add(source, ResourceSlowProcessGate)
+				census.add(source, candidate.owner, candidate.runnable, ResourceSlowProcessGate)
 			}
 		}
 	}
@@ -491,6 +589,9 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		left, right := census.Occurrences[i], census.Occurrences[j]
 		if left.Path != right.Path {
 			return left.Path < right.Path
+		}
+		if left.Owner != right.Owner {
+			return left.Owner < right.Owner
 		}
 		return left.Resource < right.Resource
 	})
@@ -501,11 +602,15 @@ func (p parsedFile) groupKey() packageKey {
 	return packageKey{directory: p.directory, packageName: p.packageName}
 }
 
-func (c *Census) add(source parsedFile, resource Resource) {
+func (c *Census) add(source parsedFile, owner string, runnable bool, resource Resource) {
 	c.Occurrences = append(c.Occurrences, Occurrence{
-		Path:     source.name,
-		Tagged:   source.tagged,
-		Resource: resource,
+		Path:        source.name,
+		PackageDir:  source.directory,
+		PackageName: source.packageName,
+		Owner:       owner,
+		Runnable:    runnable,
+		Tagged:      source.tagged,
+		Resource:    resource,
 	})
 }
 
@@ -631,9 +736,22 @@ func validateImports(file *ast.File) error {
 	return nil
 }
 
-func resourceCandidateCalls(file *ast.File) []*ast.CallExpr {
-	var calls []*ast.CallExpr
-	ast.Inspect(file, func(node ast.Node) bool {
+func resourceCandidateCalls(file *ast.File) []resourceCall {
+	aliases := testingImportAliases(file)
+	var calls []resourceCall
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok {
+			calls = appendResourceCandidateCalls(calls, function.Body, function.Name.Name, isRunnableOwner(function, aliases))
+			continue
+		}
+		calls = appendResourceCandidateCalls(calls, declaration, "", false)
+	}
+	return calls
+}
+
+func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner string, runnable bool) []resourceCall {
+	ast.Inspect(node, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -642,16 +760,112 @@ func resourceCandidateCalls(file *ast.File) []*ast.CallExpr {
 		case *ast.SelectorExpr:
 			switch function.Sel.Name {
 			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir":
-				calls = append(calls, call)
+				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		case *ast.Ident:
 			if function.Name == "skipSlowCmdGCTest" {
-				calls = append(calls, call)
+				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		}
 		return true
 	})
 	return calls
+}
+
+func runnableOwners(file *ast.File, packageDir, packageName string) []RunnableOwner {
+	aliases := testingImportAliases(file)
+	var owners []RunnableOwner
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || !isRunnableOwner(function, aliases) {
+			continue
+		}
+		owners = append(owners, RunnableOwner{PackageDir: packageDir, PackageName: packageName, Owner: function.Name.Name})
+	}
+	return owners
+}
+
+func testingImportAliases(file *ast.File) map[string]struct{} {
+	aliases := make(map[string]struct{})
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || importPath != "testing" {
+			continue
+		}
+		if spec.Name == nil {
+			aliases["testing"] = struct{}{}
+			continue
+		}
+		if spec.Name.Name != "." && spec.Name.Name != "_" {
+			aliases[spec.Name.Name] = struct{}{}
+		}
+	}
+	return aliases
+}
+
+func isRunnableOwner(function *ast.FuncDecl, testingAliases map[string]struct{}) bool {
+	if function.Recv != nil || function.Type.TypeParams != nil || function.Type.Params == nil || functionParameterCount(function.Type.Params) != 1 || functionParameterCount(function.Type.Results) != 0 {
+		return false
+	}
+	wantType := ""
+	switch {
+	case function.Name.Name == "TestMain":
+		wantType = "M"
+	case goTestName(function.Name.Name, "Test"):
+		wantType = "T"
+	case goTestName(function.Name.Name, "Benchmark"):
+		wantType = "B"
+	case goTestName(function.Name.Name, "Fuzz"):
+		wantType = "F"
+	default:
+		return false
+	}
+	field := function.Type.Params.List[0]
+	pointer, ok := unparen(field.Type).(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := unparen(pointer.X).(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != wantType {
+		return false
+	}
+	qualifier, ok := unparen(selector.X).(*ast.Ident)
+	if !ok {
+		return false
+	}
+	_, ok = testingAliases[qualifier.Name]
+	return ok
+}
+
+func goTestName(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) == len(prefix) {
+		return true
+	}
+	next, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(next)
+}
+
+func uniqueSortedRunnables(runnables []RunnableOwner) []RunnableOwner {
+	sort.Slice(runnables, func(i, j int) bool {
+		left, right := runnables[i], runnables[j]
+		if left.PackageDir != right.PackageDir {
+			return left.PackageDir < right.PackageDir
+		}
+		if left.PackageName != right.PackageName {
+			return left.PackageName < right.PackageName
+		}
+		return left.Owner < right.Owner
+	})
+	result := runnables[:0]
+	for _, runnable := range runnables {
+		if len(result) == 0 || result[len(result)-1] != runnable {
+			result = append(result, runnable)
+		}
+	}
+	return result
 }
 
 func resolveBindings(fileSet *token.FileSet, file *ast.File, importer types.Importer, packagePath string) bindingInfo {
@@ -968,6 +1182,9 @@ func validateAgainstPolicy(policy, ledger Ledger, census Census, now time.Time) 
 		sort.Strings(problems)
 		return errors.New(strings.Join(problems, "\n"))
 	}
+	if err := validateMediumOwners(ledger.Medium, census, now); err != nil {
+		return err
+	}
 
 	var problems []string
 	for _, baseline := range ledger.AuditBaseline {
@@ -978,6 +1195,9 @@ func validateAgainstPolicy(policy, ledger Ledger, census Census, now time.Time) 
 		prefix := fmt.Sprintf("debt baseline scope=%s resource=%s", debt.Scope, debt.Resource)
 		problems = append(problems, validateBaseline(prefix, debt, census)...)
 	}
+	for _, debt := range ledger.SmallDebt {
+		problems = append(problems, validateSmallBaseline(debt, census, ledger.Medium)...)
+	}
 	if len(problems) == 0 {
 		return nil
 	}
@@ -987,14 +1207,16 @@ func validateAgainstPolicy(policy, ledger Ledger, census Census, now time.Time) 
 
 func validateManifestAgainstPolicy(policy, ledger Ledger, now time.Time) []string {
 	var problems []string
-	if policy.Version != 1 {
-		problems = append(problems, fmt.Sprintf("bootstrap policy version = %d, want 1", policy.Version))
+	if policy.Version != 2 {
+		problems = append(problems, fmt.Sprintf("bootstrap policy version = %d, want 2", policy.Version))
 	}
 	if ledger.Version != policy.Version {
 		problems = append(problems, fmt.Sprintf("ledger version = %d, bootstrap policy requires %d", ledger.Version, policy.Version))
 	}
 	problems = append(problems, validateRowsAgainstPolicy("audit", policy.AuditBaseline, ledger.AuditBaseline, now)...)
 	problems = append(problems, validateRowsAgainstPolicy("debt", policy.Debt, ledger.Debt, now)...)
+	problems = append(problems, validateMediumRowsAgainstPolicy(policy.Medium, ledger.Medium, now)...)
+	problems = append(problems, validateRowsAgainstPolicy("small debt", policy.SmallDebt, ledger.SmallDebt, now)...)
 	return problems
 }
 
@@ -1105,22 +1327,26 @@ func knownScope(scope Scope) bool {
 }
 
 func validateOwnership(prefix string, row Baseline, now time.Time) []string {
+	return validateOwnershipFields(prefix, row.OwnerBead, row.Invariant, row.ResourceOwner, row.MigrationTarget, row.Expires, now)
+}
+
+func validateOwnershipFields(prefix, owner, invariant, resourceOwner, migration, expiryText string, now time.Time) []string {
 	var problems []string
 	for name, value := range map[string]string{
-		"owner_bead":       row.OwnerBead,
-		"invariant":        row.Invariant,
-		"resource_owner":   row.ResourceOwner,
-		"migration_target": row.MigrationTarget,
+		"owner_bead":       owner,
+		"invariant":        invariant,
+		"resource_owner":   resourceOwner,
+		"migration_target": migration,
 	} {
 		if strings.TrimSpace(value) == "" {
 			problems = append(problems, fmt.Sprintf("%s: %s is required", prefix, name))
 		}
 	}
-	expiry, err := time.Parse("2006-01-02", row.Expires)
+	expiry, err := time.Parse("2006-01-02", expiryText)
 	if err != nil {
-		problems = append(problems, fmt.Sprintf("%s: expiry %q must use YYYY-MM-DD", prefix, row.Expires))
+		problems = append(problems, fmt.Sprintf("%s: expiry %q must use YYYY-MM-DD", prefix, expiryText))
 	} else if expiry.Before(day(now)) {
-		problems = append(problems, fmt.Sprintf("%s: expired %s", prefix, row.Expires))
+		problems = append(problems, fmt.Sprintf("%s: expired %s", prefix, expiryText))
 	}
 	return problems
 }
@@ -1156,6 +1382,22 @@ func RenderMarkdown(ledger Ledger) string {
 		}
 	}
 	appendRows("Audit baseline", ledger.AuditBaseline)
+	for _, medium := range ledger.Medium {
+		resources := make([]string, 0, len(medium.Resources))
+		for _, resource := range medium.Resources {
+			resources = append(resources, string(resource))
+		}
+		rows = append(rows, row{
+			kind:      "Medium owner",
+			scope:     fmt.Sprintf("`%s` package `%s`", medium.PackageDir, medium.PackageName),
+			baseline:  medium.Owner + ": " + strings.Join(resources, ", "),
+			owner:     medium.OwnerBead,
+			invariant: medium.Invariant + "; " + medium.ResourceOwner,
+			migration: medium.MigrationTarget,
+			expiry:    medium.Expires,
+		})
+	}
+	appendRows("Small debt ratchet", ledger.SmallDebt)
 	appendRows("Source debt ratchet", ledger.Debt)
 	sort.Slice(rows, func(i, j int) bool {
 		left := rows[i].kind + "\x00" + rows[i].scope + "\x00" + rows[i].baseline

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -1230,7 +1230,7 @@ func TestParseLedgerRejectsUndeclaredFields(t *testing.T) {
 	requireErrorContains(t, err, "unknown ledger field: mystery")
 }
 
-func TestParseLedgerRejectsClassificationFields(t *testing.T) {
+func TestParseLedgerRejectsUndeclaredClassificationFields(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1238,8 +1238,8 @@ func TestParseLedgerRejectsClassificationFields(t *testing.T) {
 		data string
 		want string
 	}{
-		{"medium rows", "version = 1\n[[medium]]\npackage = 'sample'\n", "unknown ledger field: medium"},
-		{"small debt rows", "version = 1\n[[small_debt]]\nscope = 'untagged'\n", "unknown ledger field: small_debt"},
+		{"medium field", "version = 2\n[[medium]]\npackage_dir = 'sample'\nmystery = true\n", "unknown ledger field: medium.mystery"},
+		{"small debt field", "version = 2\n[[small_debt]]\nscope = 'untagged'\nintended_size = 'small'\n", "unknown ledger field: small_debt.intended_size"},
 		{"size field", "version = 1\n[[debt]]\nscope = 'untagged'\nintended_size = 'small'\n", "unknown ledger field: debt.intended_size"},
 	}
 	for _, tt := range tests {
@@ -1254,7 +1254,7 @@ func TestRenderMarkdownIsDeterministic(t *testing.T) {
 	t.Parallel()
 
 	ledger := Ledger{
-		Version: 1,
+		Version: 2,
 		AuditBaseline: []Baseline{
 			validAudit(ScopeAll, ResourceFixedSleep, 4, 2),
 		},
@@ -1262,12 +1262,20 @@ func TestRenderMarkdownIsDeterministic(t *testing.T) {
 			validDebt(ScopeUntagged, ResourceSubprocess, 3, 2),
 			validDebt(ScopeCmdGCUntagged, ResourceCWD, 2, 1),
 		},
+		Medium: []MediumOwner{
+			validMediumOwner("sample", "sample", "TestOwned", ResourceSubprocess),
+		},
+		SmallDebt: []Baseline{
+			validDebt(ScopeUntagged, ResourceFixedSleep, 1, 1),
+		},
 	}
 	got := RenderMarkdown(ledger)
 	want := `<!-- BEGIN CHECKED TEST RESOURCE LEDGER -->
 | Ledger kind | Source scope | Resource baseline | Tracking owner | Invariant / resource owner | Migration | Expiry |
 | --- | --- | --- | --- | --- | --- | --- |
 | Audit baseline | all tracked test source | fixed_sleep: 4 calls / 2 files | P0.4 | source census only; does not classify tests; audit owner | P0.4a | 2026-10-01 |
+| Medium owner | ` + "`sample`" + ` package ` + "`sample`" + ` | TestOwned: subprocess | ga-test | exact runnable owner; lexical declaration | P0.4b | 2026-10-01 |
+| Small debt ratchet | all untagged test source | fixed_sleep: 1 calls / 1 files | P0.4 | existing debt cannot grow; owning test cleanup | D1/D2 | 2026-10-01 |
 | Source debt ratchet | ` + "`cmd/gc`" + ` untagged test source | cwd: 2 calls / 1 files | P0.4 | existing debt cannot grow; owning test cleanup | D5/D6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 3 calls / 2 files | P0.4 | existing debt cannot grow; owning test cleanup | D1/D2 | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->`
@@ -1335,12 +1343,19 @@ func validLedger(census Census) Ledger {
 	cmdGCCWD := census.Count(ScopeCmdGCUntagged, ResourceCWD)
 	cmdGCSlowProcessGate := census.Count(ScopeCmdGCUntagged, ResourceSlowProcessGate)
 	return Ledger{
-		Version: 1,
+		Version: 2,
 		AuditBaseline: []Baseline{
 			validAudit(ScopeAll, ResourceSubprocess, allSubprocess.Calls, allSubprocess.Files),
 			validAudit(ScopeAll, ResourceFixedSleep, allSleep.Calls, allSleep.Files),
 		},
 		Debt: []Baseline{
+			validDebt(ScopeUntagged, ResourceSubprocess, untaggedSubprocess.Calls, untaggedSubprocess.Files),
+			validDebt(ScopeUntagged, ResourceFixedSleep, untaggedSleep.Calls, untaggedSleep.Files),
+			validDebt(ScopeCmdGCUntagged, ResourceEnvironment, cmdGCEnvironment.Calls, cmdGCEnvironment.Files),
+			validDebt(ScopeCmdGCUntagged, ResourceCWD, cmdGCCWD.Calls, cmdGCCWD.Files),
+			validDebt(ScopeCmdGCUntagged, ResourceSlowProcessGate, cmdGCSlowProcessGate.Calls, cmdGCSlowProcessGate.Files),
+		},
+		SmallDebt: []Baseline{
 			validDebt(ScopeUntagged, ResourceSubprocess, untaggedSubprocess.Calls, untaggedSubprocess.Files),
 			validDebt(ScopeUntagged, ResourceFixedSleep, untaggedSleep.Calls, untaggedSleep.Files),
 			validDebt(ScopeCmdGCUntagged, ResourceEnvironment, cmdGCEnvironment.Calls, cmdGCEnvironment.Files),
@@ -1386,6 +1401,11 @@ func cloneLedger(source Ledger) Ledger {
 	clone := source
 	clone.AuditBaseline = append([]Baseline(nil), source.AuditBaseline...)
 	clone.Debt = append([]Baseline(nil), source.Debt...)
+	clone.SmallDebt = append([]Baseline(nil), source.SmallDebt...)
+	clone.Medium = append([]MediumOwner(nil), source.Medium...)
+	for index := range clone.Medium {
+		clone.Medium[index].Resources = append([]Resource(nil), source.Medium[index].Resources...)
+	}
 	return clone
 }
 

--- a/internal/testpolicy/resourcecensus/medium.go
+++ b/internal/testpolicy/resourcecensus/medium.go
@@ -1,0 +1,194 @@
+package resourcecensus
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RunnableOwner is the canonical package plus top-level Go test identity.
+type RunnableOwner struct {
+	PackageDir  string
+	PackageName string
+	Owner       string
+}
+
+// MediumOwner declares the exact runnable owner of a set of Medium resources.
+type MediumOwner struct {
+	PackageDir      string     `toml:"package_dir"`
+	PackageName     string     `toml:"package_name"`
+	Owner           string     `toml:"owner"`
+	Resources       []Resource `toml:"resources"`
+	OwnerBead       string     `toml:"owner_bead"`
+	Invariant       string     `toml:"invariant"`
+	ResourceOwner   string     `toml:"resource_owner"`
+	MigrationTarget string     `toml:"migration_target"`
+	Expires         string     `toml:"expires"`
+}
+
+type runnableKey struct {
+	packageDir  string
+	packageName string
+	owner       string
+}
+
+// SmallCount returns resource calls not owned by an exact Medium declaration.
+func (c Census) SmallCount(scope Scope, resource Resource, medium []MediumOwner) Count {
+	owned := make(map[runnableKey]map[Resource]struct{}, len(medium))
+	for _, row := range medium {
+		key := runnableKey{packageDir: row.PackageDir, packageName: row.PackageName, owner: row.Owner}
+		resources := owned[key]
+		if resources == nil {
+			resources = make(map[Resource]struct{})
+			owned[key] = resources
+		}
+		for _, declared := range row.Resources {
+			resources[declared] = struct{}{}
+		}
+	}
+
+	files := map[string]struct{}{}
+	count := Count{}
+	for _, occurrence := range c.Occurrences {
+		if occurrence.Resource != resource || !scopeContains(scope, occurrence) {
+			continue
+		}
+		if occurrence.Runnable {
+			key := runnableKey{packageDir: occurrence.PackageDir, packageName: occurrence.PackageName, owner: occurrence.Owner}
+			if _, excluded := owned[key][resource]; excluded {
+				continue
+			}
+		}
+		count.Calls++
+		files[occurrence.Path] = struct{}{}
+	}
+	count.Files = len(files)
+	return count
+}
+
+func validateMediumOwners(rows []MediumOwner, census Census, now time.Time) error {
+	runnables := make(map[runnableKey]struct{}, len(census.Runnables))
+	for _, runnable := range census.Runnables {
+		runnables[runnableKey{packageDir: runnable.PackageDir, packageName: runnable.PackageName, owner: runnable.Owner}] = struct{}{}
+	}
+
+	problems := validateMediumDefinitions(rows, now)
+	for _, row := range rows {
+		key := runnableKey{packageDir: row.PackageDir, packageName: row.PackageName, owner: row.Owner}
+		prefix := fmt.Sprintf("medium owner package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner)
+		if _, exists := runnables[key]; !exists {
+			problems = append(problems, prefix+": runnable owner does not exist")
+		}
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	sort.Strings(problems)
+	return errors.New(strings.Join(problems, "\n"))
+}
+
+func validateMediumDefinitions(rows []MediumOwner, now time.Time) []string {
+	seen := make(map[runnableKey]struct{}, len(rows))
+	var problems []string
+	for _, row := range rows {
+		key := runnableKey{packageDir: row.PackageDir, packageName: row.PackageName, owner: row.Owner}
+		prefix := fmt.Sprintf("medium owner package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner)
+		if _, duplicate := seen[key]; duplicate {
+			problems = append(problems, fmt.Sprintf("duplicate medium owner: package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner))
+		}
+		seen[key] = struct{}{}
+		if strings.TrimSpace(row.PackageDir) == "" {
+			problems = append(problems, prefix+": package_dir is required")
+		}
+		if strings.TrimSpace(row.PackageName) == "" {
+			problems = append(problems, prefix+": package_name is required")
+		}
+		if strings.TrimSpace(row.Owner) == "" {
+			problems = append(problems, prefix+": owner is required")
+		}
+		if len(row.Resources) == 0 {
+			problems = append(problems, prefix+": resources must not be empty")
+		}
+		declared := make(map[Resource]struct{}, len(row.Resources))
+		for _, resource := range row.Resources {
+			if _, duplicate := declared[resource]; duplicate {
+				problems = append(problems, fmt.Sprintf("%s: duplicate resource %q", prefix, resource))
+			}
+			declared[resource] = struct{}{}
+			if _, known := knownResources[resource]; !known {
+				problems = append(problems, fmt.Sprintf("%s: unknown resource %q", prefix, resource))
+			}
+		}
+		problems = append(problems, validateOwnershipFields(prefix, row.OwnerBead, row.Invariant, row.ResourceOwner, row.MigrationTarget, row.Expires, now)...)
+	}
+	return problems
+}
+
+func validateMediumRowsAgainstPolicy(policyRows, ledgerRows []MediumOwner, now time.Time) []string {
+	problems := validateMediumDefinitions(policyRows, now)
+	problems = append(problems, validateMediumDefinitions(ledgerRows, now)...)
+	policyByKey := make(map[runnableKey]MediumOwner, len(policyRows))
+	for _, row := range policyRows {
+		policyByKey[runnableKey{packageDir: row.PackageDir, packageName: row.PackageName, owner: row.Owner}] = row
+	}
+	seen := make(map[runnableKey]struct{}, len(ledgerRows))
+	for _, row := range ledgerRows {
+		key := runnableKey{packageDir: row.PackageDir, packageName: row.PackageName, owner: row.Owner}
+		seen[key] = struct{}{}
+		prefix := fmt.Sprintf("medium owner package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner)
+		want, exists := policyByKey[key]
+		if !exists {
+			problems = append(problems, fmt.Sprintf("unexpected medium owner: package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner))
+			continue
+		}
+		if !equalResources(row.Resources, want.Resources) {
+			problems = append(problems, fmt.Sprintf("%s: resources = %v, bootstrap policy requires %v", prefix, row.Resources, want.Resources))
+		}
+		for _, field := range []struct {
+			name      string
+			got, want string
+		}{
+			{"owner_bead", row.OwnerBead, want.OwnerBead},
+			{"invariant", row.Invariant, want.Invariant},
+			{"resource_owner", row.ResourceOwner, want.ResourceOwner},
+			{"migration_target", row.MigrationTarget, want.MigrationTarget},
+			{"expires", row.Expires, want.Expires},
+		} {
+			if field.got != field.want {
+				problems = append(problems, fmt.Sprintf("%s: %s = %q, bootstrap policy requires %q", prefix, field.name, field.got, field.want))
+			}
+		}
+	}
+	for key := range policyByKey {
+		if _, exists := seen[key]; !exists {
+			problems = append(problems, fmt.Sprintf("missing required medium owner: package_dir=%s package_name=%s owner=%s", key.packageDir, key.packageName, key.owner))
+		}
+	}
+	return problems
+}
+
+func equalResources(left, right []Resource) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateSmallBaseline(row Baseline, census Census, medium []MediumOwner) []string {
+	actual := census.SmallCount(row.Scope, row.Resource, medium)
+	switch {
+	case actual.Calls > row.BaselineCalls || actual.Files > row.BaselineFiles:
+		return []string{fmt.Sprintf("Small resource census grew: scope=%s resource=%s calls=%d (baseline %d), files=%d (baseline %d)", row.Scope, row.Resource, actual.Calls, row.BaselineCalls, actual.Files, row.BaselineFiles)}
+	case actual.Calls < row.BaselineCalls || actual.Files < row.BaselineFiles:
+		return []string{fmt.Sprintf("Small resource census baseline is stale: scope=%s resource=%s calls=%d (baseline %d), files=%d (baseline %d); lower the checked baseline to bank the improvement", row.Scope, row.Resource, actual.Calls, row.BaselineCalls, actual.Files, row.BaselineFiles)}
+	default:
+		return nil
+	}
+}

--- a/internal/testpolicy/resourcecensus/medium_test.go
+++ b/internal/testpolicy/resourcecensus/medium_test.go
@@ -1,0 +1,485 @@
+package resourcecensus
+
+import (
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestScanAttributesResourcesToExactRunnableOwners(t *testing.T) {
+	t.Parallel()
+
+	census, err := ScanFS(fstest.MapFS{
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	otherpkg "example.com/testdouble"
+	operating "os"
+	shell "os/exec"
+	testpkg "testing"
+	clock "time"
+)
+
+func TestMain(m *testpkg.M) { operating.Setenv("MAIN", "1") }
+func TestOwned(t *testpkg.T) {
+	operating.Setenv("OWNED", "1")
+	t.Run("nested", func(t *testpkg.T) { operating.Chdir("nested") })
+	helper()
+}
+func BenchmarkOwned(b *testpkg.B) { operating.Unsetenv("BENCH") }
+func FuzzOwned(f *testpkg.F) { operating.Clearenv() }
+
+func helper() {
+	clock.Sleep(1)
+	shell.Command("worker")
+}
+
+type localSuite struct{}
+type localT struct{}
+func (localSuite) TestMethod(t *testpkg.T) { operating.Setenv("METHOD", "1") }
+func Testlowercase(t *testpkg.T) { operating.Setenv("LOWER", "1") }
+func TestWrongSignature() { operating.Setenv("WRONG", "1") }
+func TestWrongPackage(t *otherpkg.T) { operating.Setenv("WRONG_PACKAGE", "1") }
+func TestValueParameter(t testpkg.T) { operating.Setenv("VALUE", "1") }
+func TestLocalParameter(t *localT) { operating.Setenv("LOCAL", "1") }
+func TestWrongTestingType(t *testpkg.M) { operating.Setenv("WRONG_TESTING_TYPE", "1") }
+func TestExtraParameter(t *testpkg.T, extra int) { operating.Setenv("EXTRA", "1") }
+func TestResult(t *testpkg.T) bool {
+	operating.Setenv("RESULT", "1")
+	return false
+}
+func TestGeneric[T any](t *testpkg.T) { operating.Setenv("GENERIC", "1") }
+`)},
+		"sample/production.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	"os"
+	"testing"
+)
+func TestProduction(t *testing.T) { os.Setenv("PRODUCTION", "1") }
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import (
+	"os"
+	"testing"
+)
+func TestTagged(t *testing.T) { os.Setenv("TAGGED", "1") }
+`)},
+	})
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+
+	wantRunnables := []RunnableOwner{
+		{PackageDir: "sample", PackageName: "sample", Owner: "BenchmarkOwned"},
+		{PackageDir: "sample", PackageName: "sample", Owner: "FuzzOwned"},
+		{PackageDir: "sample", PackageName: "sample", Owner: "TestMain"},
+		{PackageDir: "sample", PackageName: "sample", Owner: "TestOwned"},
+		{PackageDir: "sample", PackageName: "sample", Owner: "TestTagged"},
+	}
+	if !reflect.DeepEqual(census.Runnables, wantRunnables) {
+		t.Fatalf("Runnables = %+v, want %+v", census.Runnables, wantRunnables)
+	}
+
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestMain", true, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestOwned", true, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceCWD, "TestOwned", true, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "BenchmarkOwned", true, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "FuzzOwned", true, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceFixedSleep, "helper", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceSubprocess, "helper", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestMethod", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "Testlowercase", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestWrongSignature", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestWrongPackage", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestValueParameter", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestLocalParameter", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestWrongTestingType", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestExtraParameter", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestResult", false, false)
+	assertOccurrenceOwner(t, census, "sample/resources_test.go", ResourceEnvironment, "TestGeneric", false, false)
+	assertOccurrenceOwner(t, census, "sample/tagged_test.go", ResourceEnvironment, "TestTagged", true, true)
+	for _, occurrence := range census.Occurrences {
+		if occurrence.Owner == "TestProduction" {
+			t.Fatalf("production source contributed a resource occurrence: %+v", occurrence)
+		}
+	}
+}
+
+func TestSmallCountExcludesOnlyDeclaredExactOwnerResources(t *testing.T) {
+	t.Parallel()
+
+	census, err := ScanFS(fstest.MapFS{
+		"cmd/gc/resources_test.go": &fstest.MapFile{Data: []byte(`package main
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+func TestMain(m *testing.M) { os.Setenv("MAIN", "1") }
+func TestOwned(t *testing.T) {
+	os.Setenv("OWNED", "1")
+	t.Run("nested", func(t *testing.T) { os.Chdir("nested") })
+	helper()
+}
+func TestOther(t *testing.T) { os.Setenv("OTHER", "1") }
+func helper() {
+	time.Sleep(1)
+	exec.Command("worker")
+}
+`)},
+		"cmd/gc/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package main
+import (
+	"os"
+	"testing"
+)
+func TestTagged(t *testing.T) { os.Setenv("TAGGED", "1") }
+`)},
+	})
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	medium := []MediumOwner{
+		validMediumOwner("cmd/gc", "main", "TestMain", ResourceEnvironment),
+		validMediumOwner("cmd/gc", "main", "TestOwned", ResourceCWD, ResourceSubprocess),
+	}
+
+	assertSmallCount(t, census, medium, ScopeCmdGCUntagged, ResourceEnvironment, 2, 1)
+	assertSmallCount(t, census, medium, ScopeCmdGCUntagged, ResourceCWD, 0, 0)
+	assertSmallCount(t, census, medium, ScopeCmdGCUntagged, ResourceFixedSleep, 1, 1)
+	assertSmallCount(t, census, medium, ScopeCmdGCUntagged, ResourceSubprocess, 1, 1)
+}
+
+func TestValidateMediumOwnersRequiresExactLiveCompleteRows(t *testing.T) {
+	t.Parallel()
+
+	census := Census{
+		Runnables: []RunnableOwner{
+			{PackageDir: "sample", PackageName: "sample", Owner: "TestMain"},
+			{PackageDir: "sample", PackageName: "sample", Owner: "TestOwned"},
+		},
+		Occurrences: []Occurrence{
+			{Path: "sample/main_test.go", PackageDir: "sample", PackageName: "sample", Owner: "TestMain", Runnable: true, Resource: ResourceEnvironment},
+			{Path: "sample/owned_test.go", PackageDir: "sample", PackageName: "sample", Owner: "TestOwned", Runnable: true, Resource: ResourceEnvironment},
+			{Path: "sample/owned_test.go", PackageDir: "sample", PackageName: "sample", Owner: "TestOwned", Runnable: true, Resource: ResourceCWD},
+			{Path: "sample/helper_test.go", PackageDir: "sample", PackageName: "sample", Owner: "helper", Resource: ResourceSubprocess},
+		},
+	}
+	validMain := validMediumOwner("sample", "sample", "TestMain", ResourceEnvironment)
+	validOwned := validMediumOwner("sample", "sample", "TestOwned", ResourceCWD, ResourceEnvironment, ResourceSubprocess)
+	blankPackageName := validMain
+	blankPackageName.PackageName = " "
+	blankMetadata := validMain
+	blankMetadata.OwnerBead = ""
+	expired := validMain
+	expired.Expires = "2026-07-12"
+
+	tests := []struct {
+		name string
+		rows []MediumOwner
+		want string
+	}{
+		{name: "valid", rows: []MediumOwner{validMain, validOwned}},
+		{name: "missing package", rows: []MediumOwner{validMediumOwner("missing", "missing", "TestMain", ResourceEnvironment)}, want: `medium owner package_dir=missing package_name=missing owner=TestMain: runnable owner does not exist`},
+		{name: "missing owner", rows: []MediumOwner{validMediumOwner("sample", "sample", "TestMissing", ResourceEnvironment)}, want: `medium owner package_dir=sample package_name=sample owner=TestMissing: runnable owner does not exist`},
+		{name: "nested subtest is not an owner", rows: []MediumOwner{validMediumOwner("sample", "sample", "TestOwned/nested", ResourceEnvironment)}, want: `medium owner package_dir=sample package_name=sample owner=TestOwned/nested: runnable owner does not exist`},
+		{name: "duplicate row", rows: []MediumOwner{validMain, validMain}, want: `duplicate medium owner: package_dir=sample package_name=sample owner=TestMain`},
+		{name: "empty resources", rows: []MediumOwner{validMediumOwner("sample", "sample", "TestMain")}, want: `medium owner package_dir=sample package_name=sample owner=TestMain: resources must not be empty`},
+		{name: "duplicate resource", rows: []MediumOwner{validMediumOwner("sample", "sample", "TestMain", ResourceEnvironment, ResourceEnvironment)}, want: `medium owner package_dir=sample package_name=sample owner=TestMain: duplicate resource "environment"`},
+		{name: "unknown resource", rows: []MediumOwner{validMediumOwner("sample", "sample", "TestMain", Resource("quantum_vm"))}, want: `medium owner package_dir=sample package_name=sample owner=TestMain: unknown resource "quantum_vm"`},
+		{name: "blank package clause", rows: []MediumOwner{blankPackageName}, want: `package_name is required`},
+		{name: "blank metadata", rows: []MediumOwner{blankMetadata}, want: `owner_bead is required`},
+		{name: "expired", rows: []MediumOwner{expired}, want: `expired 2026-07-12`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateMediumOwners(tt.rows, census, fixedNow())
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("validateMediumOwners: %v", err)
+				}
+				return
+			}
+			requireErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestSmallCountUsesDirectoryPackageClauseAndOwnerIdentity(t *testing.T) {
+	t.Parallel()
+
+	census := Census{Occurrences: []Occurrence{
+		{Path: "owned/a_test.go", PackageDir: "owned", PackageName: "sample", Owner: "TestOwned", Runnable: true, Resource: ResourceSubprocess},
+		{Path: "owned/b_test.go", PackageDir: "owned", PackageName: "sample_test", Owner: "TestOwned", Runnable: true, Resource: ResourceSubprocess},
+		{Path: "elsewhere/a_test.go", PackageDir: "elsewhere", PackageName: "sample", Owner: "TestOwned", Runnable: true, Resource: ResourceSubprocess},
+	}}
+	medium := []MediumOwner{validMediumOwner("owned", "sample", "TestOwned", ResourceSubprocess)}
+
+	assertSmallCount(t, census, medium, ScopeUntagged, ResourceSubprocess, 2, 2)
+}
+
+func TestParseLedgerAcceptsMediumAndSmallDebtRows(t *testing.T) {
+	t.Parallel()
+
+	ledger, err := ParseLedger([]byte(`version = 2
+
+[[medium]]
+package_dir = "sample"
+package_name = "sample"
+owner = "TestOwned"
+resources = ["subprocess"]
+owner_bead = "ga-test"
+invariant = "exact owner"
+resource_owner = "lexical declaration"
+migration_target = "P0.4b"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "subprocess"
+baseline_calls = 1
+baseline_files = 1
+reported_calls = 1
+reported_files = 1
+owner_bead = "ga-test"
+invariant = "small debt cannot grow"
+resource_owner = "owning test cleanup"
+migration_target = "D1"
+expires = "2026-10-01"
+`))
+	if err != nil {
+		t.Fatalf("ParseLedger: %v", err)
+	}
+	if len(ledger.Medium) != 1 || ledger.Medium[0].Owner != "TestOwned" {
+		t.Fatalf("Medium = %+v", ledger.Medium)
+	}
+	if len(ledger.SmallDebt) != 1 || ledger.SmallDebt[0].BaselineCalls != 1 {
+		t.Fatalf("SmallDebt = %+v", ledger.SmallDebt)
+	}
+}
+
+func TestValidateUsesRawAuditAndExactMediumFilteredSmallDebt(t *testing.T) {
+	t.Parallel()
+
+	census := Census{
+		Runnables: []RunnableOwner{{PackageDir: "sample", PackageName: "sample", Owner: "TestOwned"}},
+		Occurrences: []Occurrence{
+			{Path: "sample/a_test.go", PackageDir: "sample", PackageName: "sample", Owner: "TestOwned", Runnable: true, Resource: ResourceSubprocess},
+			{Path: "sample/b_test.go", PackageDir: "sample", PackageName: "sample", Owner: "helper", Resource: ResourceSubprocess},
+		},
+	}
+	medium := validMediumOwner("sample", "sample", "TestOwned", ResourceSubprocess)
+	policy := Ledger{
+		Version:       2,
+		AuditBaseline: []Baseline{validAudit(ScopeAll, ResourceSubprocess, 2, 2)},
+		Debt:          []Baseline{validDebt(ScopeUntagged, ResourceSubprocess, 2, 2)},
+		Medium:        []MediumOwner{medium},
+		SmallDebt:     []Baseline{validDebt(ScopeUntagged, ResourceSubprocess, 1, 1)},
+	}
+	if err := validateAgainstPolicy(policy, cloneLedger(policy), census, fixedNow()); err != nil {
+		t.Fatalf("validateAgainstPolicy: %v", err)
+	}
+
+	t.Run("audit remains raw", func(t *testing.T) {
+		grown := cloneLedger(policy)
+		grown.AuditBaseline[0].BaselineCalls = 1
+		grown.AuditBaseline[0].BaselineFiles = 1
+		err := validateAgainstPolicy(grown, cloneLedger(grown), census, fixedNow())
+		requireErrorContains(t, err, "source resource census grew: scope=all resource=subprocess calls=2 (baseline 1), files=2 (baseline 1)")
+	})
+
+	t.Run("small debt uses exact filter", func(t *testing.T) {
+		grown := cloneLedger(policy)
+		grown.SmallDebt[0].BaselineCalls = 0
+		grown.SmallDebt[0].BaselineFiles = 0
+		err := validateAgainstPolicy(grown, cloneLedger(grown), census, fixedNow())
+		requireErrorContains(t, err, "Small resource census grew: scope=untagged resource=subprocess calls=1 (baseline 0), files=1 (baseline 0)")
+	})
+
+	t.Run("small debt reductions lower the baseline", func(t *testing.T) {
+		stale := cloneLedger(policy)
+		stale.SmallDebt[0].BaselineCalls = 2
+		stale.SmallDebt[0].BaselineFiles = 2
+		err := validateAgainstPolicy(stale, cloneLedger(stale), census, fixedNow())
+		requireErrorContains(t, err, "Small resource census baseline is stale: scope=untagged resource=subprocess calls=1 (baseline 2), files=1 (baseline 2); lower the checked baseline to bank the improvement")
+	})
+}
+
+func TestValidateRejectsMediumPolicyDriftBeforeLiveCensus(t *testing.T) {
+	t.Parallel()
+
+	census := Census{
+		Runnables:   []RunnableOwner{{PackageDir: "sample", PackageName: "sample", Owner: "TestOwned"}},
+		Occurrences: []Occurrence{{Path: "sample/a_test.go", PackageDir: "sample", PackageName: "sample", Owner: "TestOwned", Runnable: true, Resource: ResourceSubprocess}},
+	}
+	policy := Ledger{
+		Version:   2,
+		Medium:    []MediumOwner{validMediumOwner("sample", "sample", "TestOwned", ResourceSubprocess)},
+		SmallDebt: []Baseline{validDebt(ScopeUntagged, ResourceSubprocess, 0, 0)},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*MediumOwner)
+		want   string
+	}{
+		{
+			name: "resources",
+			mutate: func(row *MediumOwner) {
+				row.Resources = []Resource{ResourceCWD}
+			},
+			want: `resources = [cwd], bootstrap policy requires [subprocess]`,
+		},
+		{
+			name: "owner bead",
+			mutate: func(row *MediumOwner) {
+				row.OwnerBead = "ga-other"
+			},
+			want: `owner_bead = "ga-other", bootstrap policy requires "ga-test"`,
+		},
+		{
+			name: "invariant",
+			mutate: func(row *MediumOwner) {
+				row.Invariant = "different invariant"
+			},
+			want: `invariant = "different invariant", bootstrap policy requires "exact runnable owner"`,
+		},
+		{
+			name: "resource owner",
+			mutate: func(row *MediumOwner) {
+				row.ResourceOwner = "different owner"
+			},
+			want: `resource_owner = "different owner", bootstrap policy requires "lexical declaration"`,
+		},
+		{
+			name: "migration target",
+			mutate: func(row *MediumOwner) {
+				row.MigrationTarget = "P9"
+			},
+			want: `migration_target = "P9", bootstrap policy requires "P0.4b"`,
+		},
+		{
+			name: "expiry",
+			mutate: func(row *MediumOwner) {
+				row.Expires = "2026-11-01"
+			},
+			want: `expires = "2026-11-01", bootstrap policy requires "2026-10-01"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ledger := cloneLedger(policy)
+			tt.mutate(&ledger.Medium[0])
+			err := validateAgainstPolicy(policy, ledger, census, fixedNow())
+			requireErrorContains(t, err, tt.want)
+			if strings.Contains(err.Error(), "resource census") {
+				t.Fatalf("live census was compared before Medium policy drift was rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRequiresExactMediumAndSmallDebtRowSets(t *testing.T) {
+	t.Parallel()
+
+	census := Census{
+		Runnables:   []RunnableOwner{{PackageDir: "sample", PackageName: "sample", Owner: "TestOwned"}},
+		Occurrences: []Occurrence{{Path: "sample/a_test.go", PackageDir: "sample", PackageName: "sample", Owner: "TestOwned", Runnable: true, Resource: ResourceSubprocess}},
+	}
+	policy := Ledger{
+		Version:   2,
+		Medium:    []MediumOwner{validMediumOwner("sample", "sample", "TestOwned", ResourceSubprocess)},
+		SmallDebt: []Baseline{validDebt(ScopeUntagged, ResourceSubprocess, 0, 0)},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*Ledger)
+		want   string
+	}{
+		{
+			name: "missing medium",
+			mutate: func(ledger *Ledger) {
+				ledger.Medium = nil
+			},
+			want: "missing required medium owner: package_dir=sample package_name=sample owner=TestOwned",
+		},
+		{
+			name: "unexpected medium",
+			mutate: func(ledger *Ledger) {
+				ledger.Medium = append(ledger.Medium, validMediumOwner("sample", "sample", "TestOther", ResourceSubprocess))
+			},
+			want: "unexpected medium owner: package_dir=sample package_name=sample owner=TestOther",
+		},
+		{
+			name: "duplicate medium",
+			mutate: func(ledger *Ledger) {
+				ledger.Medium = append(ledger.Medium, ledger.Medium[0])
+			},
+			want: "duplicate medium owner: package_dir=sample package_name=sample owner=TestOwned",
+		},
+		{
+			name: "missing small debt",
+			mutate: func(ledger *Ledger) {
+				ledger.SmallDebt = nil
+			},
+			want: "missing required small debt baseline: scope=untagged resource=subprocess",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ledger := cloneLedger(policy)
+			tt.mutate(&ledger)
+			err := validateAgainstPolicy(policy, ledger, census, fixedNow())
+			requireErrorContains(t, err, tt.want)
+			if strings.Contains(err.Error(), "resource census") {
+				t.Fatalf("live census was compared before row-set drift was rejected: %v", err)
+			}
+		})
+	}
+}
+
+func assertOccurrenceOwner(t *testing.T, census Census, sourcePath string, resource Resource, owner string, runnable, tagged bool) {
+	t.Helper()
+	for _, occurrence := range census.Occurrences {
+		if occurrence.Path == sourcePath && occurrence.Resource == resource && occurrence.Owner == owner && occurrence.Tagged == tagged {
+			if occurrence.PackageDir != path.Dir(sourcePath) {
+				t.Fatalf("occurrence package dir = %q, want %q: %+v", occurrence.PackageDir, path.Dir(sourcePath), occurrence)
+			}
+			if occurrence.Runnable != runnable {
+				t.Fatalf("occurrence runnable = %t, want %t: %+v", occurrence.Runnable, runnable, occurrence)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing occurrence path=%s resource=%s owner=%s tagged=%t; got %+v", sourcePath, resource, owner, tagged, census.Occurrences)
+}
+
+func assertSmallCount(t *testing.T, census Census, medium []MediumOwner, scope Scope, resource Resource, wantCalls, wantFiles int) {
+	t.Helper()
+	got := census.SmallCount(scope, resource, medium)
+	if got.Calls != wantCalls || got.Files != wantFiles {
+		t.Fatalf("SmallCount(%s, %s) = %d calls / %d files, want %d / %d; occurrences=%+v",
+			scope, resource, got.Calls, got.Files, wantCalls, wantFiles, census.Occurrences)
+	}
+}
+
+func validMediumOwner(packageDir, packageName, owner string, resources ...Resource) MediumOwner {
+	return MediumOwner{
+		PackageDir:      packageDir,
+		PackageName:     packageName,
+		Owner:           owner,
+		Resources:       resources,
+		OwnerBead:       "ga-test",
+		Invariant:       "exact runnable owner",
+		ResourceOwner:   "lexical declaration",
+		MigrationTarget: "P0.4b",
+		Expires:         "2026-10-01",
+	}
+}

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -1,4 +1,4 @@
-version = 1
+version = 2
 
 # Every field below is pinned by resourcecensus.bootstrapPolicy. Changing this
 # manifest alone fails; an intentional policy change updates the Go policy,
@@ -23,8 +23,8 @@ expires = "2026-10-01"
 [[audit_baseline]]
 scope = "all"
 resource = "fixed_sleep"
-baseline_calls = 443
-baseline_files = 156
+baseline_calls = 436
+baseline_files = 153
 reported_calls = 447
 reported_files = 157
 owner_bead = "ga-80po0c.2"
@@ -38,8 +38,8 @@ expires = "2026-10-01"
 [[debt]]
 scope = "untagged"
 resource = "subprocess"
-baseline_calls = 375
-baseline_files = 98
+baseline_calls = 374
+baseline_files = 97
 reported_calls = 380
 reported_files = 98
 owner_bead = "ga-80po0c.2"
@@ -51,8 +51,8 @@ expires = "2026-10-01"
 [[debt]]
 scope = "untagged"
 resource = "fixed_sleep"
-baseline_calls = 291
-baseline_files = 113
+baseline_calls = 284
+baseline_files = 110
 reported_calls = 295
 reported_files = 114
 owner_bead = "ga-80po0c.2"
@@ -97,5 +97,87 @@ reported_files = 27
 owner_bead = "ga-80po0c.2.3"
 invariant = "untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline"
 resource_owner = "the helper definition and every marked caller retain an explicit process-suite migration owner"
+migration_target = "D5/D6/E6"
+expires = "2026-10-01"
+
+# Exact Medium owners are keyed by source directory, package clause, and
+# top-level Go test identity. Only matching resources lexically inside that
+# declaration leave the Small-debt census; helper bodies and sibling tests do
+# not inherit a source exemption.
+[[medium]]
+package_dir = "cmd/gc"
+package_name = "main"
+owner = "TestMain"
+resources = ["environment"]
+owner_bead = "ga-80po0c.2.1"
+invariant = "cmd/gc TestMain is the checked package-level Medium owner"
+resource_owner = "only environment calls lexically inside TestMain leave Small debt"
+migration_target = "P0.4b"
+expires = "2026-10-01"
+
+# Small-debt rows apply the exact Medium filter while the source-debt rows
+# above retain the raw anti-growth census.
+[[small_debt]]
+scope = "untagged"
+resource = "subprocess"
+baseline_calls = 374
+baseline_files = 97
+reported_calls = 374
+reported_files = 97
+owner_bead = "ga-80po0c.2.1"
+invariant = "untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners remove or replace each process call site"
+migration_target = "D1/D2/D5/D6/E6"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "fixed_sleep"
+baseline_calls = 284
+baseline_files = 110
+reported_calls = 284
+reported_files = 110
+owner_bead = "ga-80po0c.2.1"
+invariant = "untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners replace elapsed wall time with lifecycle signals"
+migration_target = "W1-W5"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "cmd/gc+untagged"
+resource = "environment"
+baseline_calls = 4086
+baseline_files = 180
+reported_calls = 4086
+reported_files = 180
+owner_bead = "ga-80po0c.2.1"
+invariant = "untagged Small cmd/gc environment call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners restore or eliminate every process-environment mutation"
+migration_target = "D5/D6/E6"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "cmd/gc+untagged"
+resource = "cwd"
+baseline_calls = 208
+baseline_files = 40
+reported_calls = 208
+reported_files = 40
+owner_bead = "ga-80po0c.2.1"
+invariant = "untagged Small cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners restore or eliminate every cwd mutation"
+migration_target = "D5/D6"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "cmd/gc+untagged"
+resource = "slow_process_gate"
+baseline_calls = 77
+baseline_files = 26
+reported_calls = 77
+reported_files = 26
+owner_bead = "ga-80po0c.2.1"
+invariant = "untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline"
+resource_owner = "each non-Medium marked caller retains an explicit process-suite migration owner"
 migration_target = "D5/D6/E6"
 expires = "2026-10-01"


### PR DESCRIPTION
## Outcome

- Adds schema v2 exact Medium ownership keyed by repository directory, package clause, top-level runnable, and resource.
- Keeps raw source ratchets untouched by classification and adds a separately checked Small-debt view.
- Classifies cmd/gc TestMain as the exact owner of six environment mutations: raw stays 4092/180 while Small is 4086/180.
- Replaces seven extmsg polling sleeps with tracked background lifecycle completion and fixes the associated TempDir cleanup/data race.
- Moves the live bd flag-manifest subprocess probe to the integration lane while retaining it in the all-source audit; adds the current create --status/-s value flags.

## Honest census deltas

- subprocess all-source audit: 491/136, including the integration-tagged bd probe
- subprocess untagged and Small: 374/97
- fixed sleep all-source: 443/156 to 436/153
- fixed sleep untagged and Small: 291/113 to 284/110

## Verification

- resourcecensus focused gate repeatedly passes in 2.7-3.9s wall time
- go test -race ./internal/api -run Extmsg -count=20
- go test -tags=integration ./internal/bdflags
- make check-docs
- go vet ./...
- make dashboard-check
- LOCAL_TEST_JOBS=2 make test-fast-parallel
- pre-commit hook: format, lint, codegen, vet, docs all pass
- pre-push fast suite: all eight jobs pass with an isolated GOCACHE after the shared fleet cache lost compiler archives

## Review council

Three independent exact-tree delegated reviews returned CLEAR for correctness/concurrency, policy honesty, and architecture/portability on staged tree b6c16db27e60022654f6ffb3e85c3608b8f643e4.

Tracks ga-80po0c.2.1.