### PR TITLE
test: ratchet httptest server resource debt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -5,7 +5,8 @@
 `test/test-resources.toml` is the checked P0.4 resource ledger. It scans tracked
 Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
-freeze process, sleep, environment, CWD, and slow-process call/file totals.
+freeze process, sleep, environment, CWD, slow-process, and HTTP test-server
+call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
 owners without weakening the raw anti-growth ratchets.
@@ -29,14 +30,18 @@ remain Small debt even when a Medium test calls the helper. Likewise, a
 calls inside `TestMain`, never sibling tests.
 
 This bootstrap does **not** infer resources recursively through arbitrary
-helper calls or claim a complete shared-resource inventory. A Medium resource
+helper calls or claim a complete shared-resource inventory. P0.4c's first
+slice covers the three `net/http/httptest` constructors that open loopback
+servers; direct `net` listeners, tmux, Dolt, and other shared-host resources
+remain explicit follow-up catalogs. A Medium resource
 may describe a helper-backed runtime cost, but only syntax-owned calls in that
 exact runnable declaration leave Small-debt accounting. `ga-80po0c.2.2` owns
 the listener, tmux, Dolt, and shared-host catalogs. E1 separately owns Large
 journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
-`time.Sleep`; `os.Setenv`, `os.Unsetenv`, `os.Clearenv`, and `os.Chdir`; and
+`time.Sleep`; `net/http/httptest.NewServer`, `NewTLSServer`, and
+`NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`, `os.Clearenv`, and `os.Chdir`; and
 `Setenv` or `Chdir` on function parameters typed exactly as `*testing.T` or
 `testing.TB`. It also recognizes the receiverless
 `skipSlowCmdGCTest(*testing.T, string)` definition and its same-package calls.
@@ -47,9 +52,10 @@ directory and package so cross-file shadows do not masquerade as resources.
 Local shadows and wrong signatures do not count. Parenthesized call
 expressions retain the same ownership.
 
-Targeted dot imports of `os/exec`, `time`, `os`, or `testing` are rejected with
-file and import context because their resources cannot be attributed safely;
-blank imports remain harmless. Explicit constraints follow Go's leading-header
+Targeted dot imports of `os/exec`, `time`, `os`, `testing`, or
+`net/http/httptest` are rejected with file and import context because their
+resources cannot be attributed safely; blank imports remain harmless.
+Explicit constraints follow Go's leading-header
 rules: a pre-package `//go:build` line is effective, while a legacy
 `// +build` line must live in a leading `//` comment block separated from the
 package clause by a blank line.
@@ -88,11 +94,13 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | `cmd/gc` untagged test source | environment: 4086 calls / 180 files | ga-80po0c.2.1 | untagged Small cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners restore or eliminate every process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files | ga-80po0c.2.1 | untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; each non-Medium marked caller retains an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
+| Small debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 374 calls / 97 files | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | cwd: 208 calls / 40 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | environment: 4092 calls / 180 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
+| Source debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 374 calls / 97 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->
 

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -40,6 +40,8 @@ const (
 	ResourceCWD Resource = "cwd"
 	// ResourceSlowProcessGate counts the cmd/gc slow-process helper and calls.
 	ResourceSlowProcessGate Resource = "slow_process_gate"
+	// ResourceHTTPTestServer counts loopback servers opened by net/http/httptest.
+	ResourceHTTPTestServer Resource = "http_test_server"
 )
 
 var knownResources = map[Resource]struct{}{
@@ -48,6 +50,7 @@ var knownResources = map[Resource]struct{}{
 	ResourceEnvironment:     {},
 	ResourceCWD:             {},
 	ResourceSlowProcessGate: {},
+	ResourceHTTPTestServer:  {},
 }
 
 // Scope selects the source population counted by a ledger row.
@@ -187,6 +190,19 @@ var bootstrapPolicy = Ledger{
 			MigrationTarget: "D5/D6/E6",
 			Expires:         "2026-10-01",
 		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceHTTPTestServer,
+			BaselineCalls:   255,
+			BaselineFiles:   56,
+			ReportedCalls:   255,
+			ReportedFiles:   56,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test closes its loopback server and removes duplicate server-backed coverage",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
 	},
 	Medium: []MediumOwner{
 		{
@@ -265,6 +281,19 @@ var bootstrapPolicy = Ledger{
 			Invariant:       "untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "each non-Medium marked caller retains an explicit process-suite migration owner",
 			MigrationTarget: "D5/D6/E6",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceHTTPTestServer,
+			BaselineCalls:   255,
+			BaselineFiles:   56,
+			ReportedCalls:   255,
+			ReportedFiles:   56,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener",
+			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
 	},
@@ -537,7 +566,14 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 
 		for _, candidate := range source.calls {
 			call := candidate.call
-			matched, err := isImportedCall(call, source.bindings, "os/exec", "Command", "CommandContext")
+			matched, err := isImportedCall(call, source.bindings, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, candidate.owner, candidate.runnable, ResourceHTTPTestServer)
+			}
+			matched, err = isImportedCall(call, source.bindings, "os/exec", "Command", "CommandContext")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
@@ -728,7 +764,7 @@ func validateImports(file *ast.File) error {
 			continue
 		}
 		if spec.Name != nil && spec.Name.Name == "." {
-			if importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "testing" {
+			if importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "testing" || importPath == "net/http/httptest" {
 				return fmt.Errorf("targeted dot import %q cannot be counted safely", importPath)
 			}
 		}
@@ -759,7 +795,7 @@ func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner str
 		switch function := unparen(call.Fun).(type) {
 		case *ast.SelectorExpr:
 			switch function.Sel.Name {
-			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir":
+			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "NewServer", "NewTLSServer", "NewUnstartedServer":
 				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		case *ast.Ident:

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -98,6 +98,78 @@ func TestLocalNamesAreNotStdlibCalls() {
 	assertCount(t, got, ScopeUntagged, ResourceFixedSleep, 1, 1)
 }
 
+func TestScanCountsHTTPTestServerConstructorsByImportIdentity(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	foreign "example.test/httptest"
+	servers "net/http/httptest"
+	"testing"
+)
+
+type localServers struct{}
+func (localServers) NewServer(any) {}
+func (localServers) NewTLSServer(any) {}
+func (localServers) NewUnstartedServer(any) {}
+
+func TestHTTPTestServers(t *testing.T) {
+	_ = ((servers.NewServer))(nil)
+	_ = (((servers)).NewTLSServer)(nil)
+	t.Run("nested", func(t *testing.T) {
+		_ = ((servers.NewUnstartedServer))(nil)
+	})
+
+	local := localServers{}
+	local.NewServer(nil)
+	local.NewTLSServer(nil)
+	local.NewUnstartedServer(nil)
+	foreign.NewServer(nil)
+	foreign.NewTLSServer(nil)
+	foreign.NewUnstartedServer(nil)
+	_ = "servers.NewServer(nil); servers.NewTLSServer(nil); servers.NewUnstartedServer(nil)"
+	// servers.NewServer(nil)
+	// servers.NewTLSServer(nil)
+	// servers.NewUnstartedServer(nil)
+}
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import (
+	"net/http/httptest"
+	"testing"
+)
+func TestTaggedHTTPTestServer(t *testing.T) {
+	_ = httptest.NewServer(nil)
+}
+`)},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeAll, ResourceHTTPTestServer, 4, 2)
+	assertCount(t, got, ScopeUntagged, ResourceHTTPTestServer, 3, 1)
+
+	for _, occurrence := range got.Occurrences {
+		if occurrence.Resource != ResourceHTTPTestServer {
+			continue
+		}
+		wantOwner := "TestHTTPTestServers"
+		wantTagged := false
+		if occurrence.Path == "sample/tagged_test.go" {
+			wantOwner = "TestTaggedHTTPTestServer"
+			wantTagged = true
+		}
+		if occurrence.PackageDir != "sample" || occurrence.PackageName != "sample" || occurrence.Owner != wantOwner || !occurrence.Runnable || occurrence.Tagged != wantTagged {
+			t.Errorf("HTTP test server occurrence = %+v, want package sample/sample owner=%s runnable=true tagged=%t", occurrence, wantOwner, wantTagged)
+		}
+	}
+}
+
 func TestScanCountsCmdGCProcessGlobalsByLexicalOwnership(t *testing.T) {
 	t.Parallel()
 
@@ -697,6 +769,15 @@ import . "testing"
 func TestResource(t *T) { t.Setenv("KEY", "value") }
 `,
 		},
+		{
+			name:       "net http httptest",
+			path:       "sample/dot_httptest_test.go",
+			importPath: "net/http/httptest",
+			source: `package sample
+import . "net/http/httptest"
+func TestResource() { _ = NewServer(nil) }
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -715,6 +796,7 @@ func TestScanAllowsBlankImportsOfTargetedPackages(t *testing.T) {
 	files := fstest.MapFS{
 		"sample/blank_import_test.go": &fstest.MapFile{Data: []byte(`package sample
 import (
+	_ "net/http/httptest"
 	_ "os"
 	_ "os/exec"
 	_ "testing"
@@ -1118,6 +1200,17 @@ func TestValidateUsesCodeOwnedBootstrapPolicy(t *testing.T) {
 	requireErrorContains(t, err, `owner_bead = "ga-rewritten", bootstrap policy requires "ga-80po0c.2"`)
 	if strings.Contains(err.Error(), "source resource census") {
 		t.Fatalf("live census was compared before code-owned policy drift was rejected: %v", err)
+	}
+}
+
+func TestBootstrapPolicyOwnsHTTPTestServerDebt(t *testing.T) {
+	t.Parallel()
+
+	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
+		row := findRow(t, rows, ScopeUntagged, ResourceHTTPTestServer)
+		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
+			t.Fatalf("HTTP test server owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		}
 	}
 }
 

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -100,6 +100,19 @@ resource_owner = "the helper definition and every marked caller retain an explic
 migration_target = "D5/D6/E6"
 expires = "2026-10-01"
 
+[[debt]]
+scope = "untagged"
+resource = "http_test_server"
+baseline_calls = 255
+baseline_files = 56
+reported_calls = 255
+reported_files = 56
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test closes its loopback server and removes duplicate server-backed coverage"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
 # Exact Medium owners are keyed by source directory, package clause, and
 # top-level Go test identity. Only matching resources lexically inside that
 # declaration leave the Small-debt census; helper bodies and sibling tests do
@@ -180,4 +193,17 @@ owner_bead = "ga-80po0c.2.1"
 invariant = "untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline"
 resource_owner = "each non-Medium marked caller retains an explicit process-suite migration owner"
 migration_target = "D5/D6/E6"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "http_test_server"
+baseline_calls = 255
+baseline_files = 56
+reported_calls = 255
+reported_files = 56
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener"
+migration_target = "P0.4c"
 expires = "2026-10-01"


### PR DESCRIPTION
## Summary

- recognize `net/http/httptest` server constructors by exact import identity
- freeze the current untagged raw and Small debt at 255 calls across 56 files
- preserve exact runnable ownership for future evidence-backed Medium migration
- document this as the first P0.4c slice; direct sockets, tmux, Dolt, and Large ownership remain follow-ups

## Verification

- `go test -count=10 ./internal/testpolicy/resourcecensus`
- `go test -race -count=3 ./internal/testpolicy/resourcecensus`
- `make check-docs`
- `go vet ./...`
- `.githooks/pre-commit`
- capped pre-push `make test-fast-parallel`
- three independent delegated council reviews: CLEAR

An earlier 192-job local sweep exposed the pre-existing 25 ms scheduler-sensitive assertion in `TestCachingStoreHandlesCachedReadUsesActiveSnapshotDuringRunningFullPrimeAfterPrimeActive`; its exact stress and race probes pass, and the capped mandatory pre-push suite passed. That test hardening is isolated as a separate follow-up.