### PR TITLE
fix(reconcile): preserve live retry worktree affinity

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2932,12 +2932,25 @@ func computePoolTriggerBindingPatch(info session.Info, request SessionRequest, w
 	if workspace := packWorkspaceSlug(request); strings.TrimSpace(info.PackWorkspace) != workspace {
 		metadata[beadmeta.PackWorkspaceMetadataKey] = workspace
 	}
+	// Only use a newly derived work dir when the binding is new or re-pointed.
+	// Resume and wake requests for the same trigger may omit WorkBeadTitle; in
+	// that case re-derivation drops the title suffix from the path the launcher
+	// actually created. Preserve the recorded canonical path and keep the legacy
+	// twin synchronized with it.
 	if workDir != "" {
-		if strings.TrimSpace(info.WorkDirCanonical) != workDir {
-			metadata[beadmeta.WorkDirMetadataKey] = workDir
+		targetWorkDir := workDir
+		existingWorkDir := strings.TrimSpace(info.WorkDirCanonical)
+		if existingWorkDir == "" {
+			existingWorkDir = strings.TrimSpace(info.WorkDir)
 		}
-		if strings.TrimSpace(info.WorkDir) != workDir {
-			metadata[beadmeta.LegacyWorkDirMetadataKey] = workDir
+		if oldWorkBeadID == workBeadID && existingWorkDir != "" {
+			targetWorkDir = existingWorkDir
+		}
+		if strings.TrimSpace(info.WorkDirCanonical) != targetWorkDir {
+			metadata[beadmeta.WorkDirMetadataKey] = targetWorkDir
+		}
+		if strings.TrimSpace(info.WorkDir) != targetWorkDir {
+			metadata[beadmeta.LegacyWorkDirMetadataKey] = targetWorkDir
 		}
 	}
 	return metadata

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2932,18 +2932,28 @@ func computePoolTriggerBindingPatch(info session.Info, request SessionRequest, w
 	if workspace := packWorkspaceSlug(request); strings.TrimSpace(info.PackWorkspace) != workspace {
 		metadata[beadmeta.PackWorkspaceMetadataKey] = workspace
 	}
-	// Only use a newly derived work dir when the binding is new or re-pointed.
-	// Resume and wake requests for the same trigger may omit WorkBeadTitle; in
-	// that case re-derivation drops the title suffix from the path the launcher
-	// actually created. Preserve the recorded canonical path and keep the legacy
-	// twin synchronized with it.
+	// Same-trigger reconciles may omit the title suffix the launcher used, so
+	// preserve the recorded path. A live resume-mode session can also claim a
+	// retry bead without restarting; in that case the process remains in its
+	// existing cwd even though the trigger changes. The concrete session id and
+	// durable current-bead marker distinguish that continuation from an asleep,
+	// fresh, or otherwise reusable session that will start in a newly derived
+	// worktree.
 	if workDir != "" {
 		targetWorkDir := workDir
 		existingWorkDir := strings.TrimSpace(info.WorkDirCanonical)
 		if existingWorkDir == "" {
 			existingWorkDir = strings.TrimSpace(info.WorkDir)
 		}
-		if oldWorkBeadID == workBeadID && existingWorkDir != "" {
+		currentWorkBeadID := strings.TrimSpace(info.CurrentlyProcessingBeadID)
+		liveResumeContinuation := oldWorkBeadID != workBeadID &&
+			request.Tier == "resume" &&
+			request.SessionBeadID == info.ID &&
+			info.State == session.StateActive &&
+			info.WakeMode != "fresh" &&
+			currentWorkBeadID != "" &&
+			(currentWorkBeadID == oldWorkBeadID || currentWorkBeadID == workBeadID)
+		if existingWorkDir != "" && (oldWorkBeadID == workBeadID || liveResumeContinuation) {
 			targetWorkDir = existingWorkDir
 		}
 		if strings.TrimSpace(info.WorkDirCanonical) != targetWorkDir {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4141,6 +4141,88 @@ func TestRealizePoolDesiredSessionsRebindUpdatesPackWorkspaceMetadata(t *testing
 	}
 }
 
+func TestRealizePoolDesiredSessionsLiveRetryPreservesLauncherWorkDir(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentBeadID string
+	}{
+		{name: "worker marker still names prior attempt", currentBeadID: "fi-old"},
+		{name: "worker marker already names retry attempt", currentBeadID: "fi-new"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			launcherWorkDir := filepath.Join(t.TempDir(), "fi-old-write-review-report")
+			reusable, err := store.Create(beads.Bead{
+				Title:  "worker live retry",
+				Type:   sessionBeadType,
+				Status: "open",
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"template":                              "worker",
+					"agent_name":                            "worker-1",
+					"alias":                                 "worker-1",
+					"session_name":                          "worker-live-retry",
+					"state":                                 string(sessionpkg.StateAwake),
+					"pool_slot":                             "1",
+					poolManagedMetadataKey:                  boolMetadata(true),
+					sessionpkg.CurrentBeadIDKey:             tt.currentBeadID,
+					beadmeta.TriggerBeadIDMetadataKey:       "fi-old",
+					beadmeta.WorkDirMetadataKey:             launcherWorkDir,
+					beadmeta.LegacyWorkDirMetadataKey:       launcherWorkDir,
+					beadmeta.TriggerBeadStoreRefMetadataKey: "rig:fixture",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cfg := &config.City{
+				Workspace: config.Workspace{Name: "test-city"},
+				Agents: []config.Agent{{
+					Name:              "worker",
+					StartCommand:      "true",
+					WorkDir:           ".gc/workspaces/{{.AgentBase}}",
+					MinActiveSessions: intPtr(0),
+					MaxActiveSessions: intPtr(1),
+				}},
+			}
+			snapshot := &sessionBeadSnapshot{}
+			snapshot.addInfo(sessiontest.SeedBead(t, reusable))
+			var stderr bytes.Buffer
+			bp := newAgentBuildParams("test-city", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+			bp.sessionBeads = snapshot
+
+			retry := workBead("fi-new", "worker", reusable.ID, "in_progress", 1)
+			states := ComputePoolDesiredStates(cfg, []beads.Bead{retry}, snapshot.OpenInfos(), nil)
+			if len(states) != 1 || len(states[0].Requests) != 1 {
+				t.Fatalf("retry desired state = %#v, want one request", states)
+			}
+			request := states[0].Requests[0]
+			if request.Tier != "resume" || request.SessionBeadID != reusable.ID || request.WorkBeadID != retry.ID {
+				t.Fatalf("retry request = %#v, want concrete resume of %s for %s", request, reusable.ID, retry.ID)
+			}
+
+			realizePoolDesiredSessions(bp, &cfg.Agents[0], states[0], map[string]TemplateParams{}, &stderr)
+
+			stored, err := store.Get(reusable.ID)
+			if err != nil {
+				t.Fatalf("Get(session): %v", err)
+			}
+			if got := stored.Metadata[beadmeta.TriggerBeadIDMetadataKey]; got != retry.ID {
+				t.Fatalf("trigger bead metadata = %q, want %q", got, retry.ID)
+			}
+			if got := stored.Metadata[beadmeta.WorkDirMetadataKey]; got != launcherWorkDir {
+				t.Fatalf("gc.work_dir = %q, want live launcher path %q", got, launcherWorkDir)
+			}
+			if got := stored.Metadata[beadmeta.LegacyWorkDirMetadataKey]; got != launcherWorkDir {
+				t.Fatalf("work_dir = %q, want live launcher path %q", got, launcherWorkDir)
+			}
+		})
+	}
+}
+
 func TestRealizePoolDesiredSessionsBudgetExhaustionStillAllowsLaterReuse(t *testing.T) {
 	maxWakes := 1
 	store := beads.NewMemStore()

--- a/cmd/gc/build_desired_state_worktree_record_test.go
+++ b/cmd/gc/build_desired_state_worktree_record_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestBindPoolSessionTriggerBead_PreservesLauncherWorktreePath is the
+// regression guard for sc-s5mfl3: the recorded gc.work_dir must match the
+// worktree the launcher actually created, including the work-bead title slug
+// suffix (e.g. "dip-<bead>-implement-compound-work-item").
+//
+// The launcher derives the worktree name from the work bead's id+title slug
+// when the session is first created ("new" tier, title known). On a subsequent
+// reconcile the same session is re-bound to the same trigger bead via a
+// resume/wake request that does NOT carry the title (WorkBeadTitle == ""). The
+// pre-fix code unconditionally re-derived the work_dir from the incomplete
+// request, producing the suffix-less "dip-<bead>" form and clobbering the
+// launcher-created path that was already recorded. The build-artifact-valid
+// gate then chdirs into a path that never existed.
+//
+// The fix makes the recorded launcher path the single source of truth: for an
+// unchanged trigger bead, the already-recorded work_dir is preserved rather
+// than re-derived from a request that may be missing the title.
+func TestBindPoolSessionTriggerBead_PreservesLauncherWorktreePath(t *testing.T) {
+	const (
+		workBead = "dip-42"
+		title    = "implement compound work item"
+	)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "dip"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			WorkDir:           ".gc/workspaces/{{.AgentBase}}",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+	var stderr bytes.Buffer
+	store := beads.NewMemStore()
+	bp := newAgentBuildParams("dip", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+
+	// The base workspace root the launcher joins the trigger slug under.
+	base := filepath.Join(bp.cityPath, ".gc", "workspaces", "worker")
+	// What the launcher actually creates the first time, title in hand.
+	launcherCreated := filepath.Join(base, "dip-42-implement-compound-work-item")
+
+	// 1. First bind: "new" tier carries the title. This mirrors the launcher's
+	//    own path derivation, so the recorded work_dir == the created worktree.
+	created, err := store.Create(beads.Bead{ID: "sess-1", Type: "session"})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	info, err := sessionFrontDoor(store).Get(created.ID)
+	if err != nil {
+		t.Fatalf("get session info: %v", err)
+	}
+	bound, err := bindPoolSessionTriggerBead(bp, &cfg.Agents[0], "worker", info, SessionRequest{
+		Tier:          "new",
+		WorkBeadID:    workBead,
+		WorkBeadTitle: title,
+	})
+	if err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+	recorded := bound.WorkDirCanonical
+	if recorded != launcherCreated {
+		t.Fatalf("first-bind work_dir = %q, want launcher-created %q", recorded, launcherCreated)
+	}
+
+	// 2. Re-bind on the next reconcile: a resume/wake request for the SAME
+	//    trigger bead, but WITHOUT the title (the resume/wake tiers never
+	//    populate WorkBeadTitle). The recorded launcher path must survive.
+	reBound, err := bindPoolSessionTriggerBead(bp, &cfg.Agents[0], "worker", bound, SessionRequest{
+		Tier:       "wake-known-identity",
+		WorkBeadID: workBead,
+		// WorkBeadTitle intentionally empty.
+	})
+	if err != nil {
+		t.Fatalf("re-bind: %v", err)
+	}
+
+	got := reBound.WorkDirCanonical
+	if got != launcherCreated {
+		t.Fatalf("re-bind dropped the title suffix:\n  recorded = %q\n  created  = %q\nrecorded path never existed", got, launcherCreated)
+	}
+	if reBound.WorkDir != launcherCreated {
+		t.Fatalf("re-bind legacy work_dir = %q, want %q", reBound.WorkDir, launcherCreated)
+	}
+
+	// The store copy must agree with the returned bead.
+	persisted, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got := persisted.Metadata[beadmeta.WorkDirMetadataKey]; got != launcherCreated {
+		t.Fatalf("persisted work_dir = %q, want %q", got, launcherCreated)
+	}
+	if got := persisted.Metadata[beadmeta.LegacyWorkDirMetadataKey]; got != launcherCreated {
+		t.Fatalf("persisted legacy work_dir = %q, want %q", got, launcherCreated)
+	}
+}

--- a/cmd/gc/session_w3_split_equiv_test.go
+++ b/cmd/gc/session_w3_split_equiv_test.go
@@ -207,11 +207,19 @@ func rawPoolTriggerBindingPatchRef(sb beads.Bead, request SessionRequest, workDi
 		metadata[beadmeta.PackWorkspaceMetadataKey] = workspace
 	}
 	if workDir != "" {
-		if strings.TrimSpace(sb.Metadata[beadmeta.WorkDirMetadataKey]) != workDir {
-			metadata[beadmeta.WorkDirMetadataKey] = workDir
+		targetWorkDir := workDir
+		existingWorkDir := strings.TrimSpace(sb.Metadata[beadmeta.WorkDirMetadataKey])
+		if existingWorkDir == "" {
+			existingWorkDir = strings.TrimSpace(sb.Metadata[beadmeta.LegacyWorkDirMetadataKey])
 		}
-		if strings.TrimSpace(sb.Metadata[beadmeta.LegacyWorkDirMetadataKey]) != workDir {
-			metadata[beadmeta.LegacyWorkDirMetadataKey] = workDir
+		if oldWorkBeadID == workBeadID && existingWorkDir != "" {
+			targetWorkDir = existingWorkDir
+		}
+		if strings.TrimSpace(sb.Metadata[beadmeta.WorkDirMetadataKey]) != targetWorkDir {
+			metadata[beadmeta.WorkDirMetadataKey] = targetWorkDir
+		}
+		if strings.TrimSpace(sb.Metadata[beadmeta.LegacyWorkDirMetadataKey]) != targetWorkDir {
+			metadata[beadmeta.LegacyWorkDirMetadataKey] = targetWorkDir
 		}
 	}
 	return metadata

--- a/cmd/gc/session_w3_split_equiv_test.go
+++ b/cmd/gc/session_w3_split_equiv_test.go
@@ -265,3 +265,82 @@ func TestComputePoolTriggerBindingPatchMatchesRaw(t *testing.T) {
 		}
 	}
 }
+
+func TestComputePoolTriggerBindingPatchPreservesRecordedWorkDirForSameTrigger(t *testing.T) {
+	tests := []struct {
+		name      string
+		metadata  map[string]string
+		request   SessionRequest
+		derived   string
+		wantPatch map[string]string
+	}{
+		{
+			name: "canonical path heals missing legacy twin",
+			metadata: map[string]string{
+				beadmeta.TriggerBeadIDMetadataKey: "wb-same",
+				beadmeta.WorkDirMetadataKey:       "/work/wb-same-with-title",
+			},
+			request: SessionRequest{WorkBeadID: "wb-same"},
+			derived: "/work/wb-same",
+			wantPatch: map[string]string{
+				beadmeta.LegacyWorkDirMetadataKey: "/work/wb-same-with-title",
+			},
+		},
+		{
+			name: "legacy path heals missing canonical twin",
+			metadata: map[string]string{
+				beadmeta.TriggerBeadIDMetadataKey: "wb-same",
+				beadmeta.LegacyWorkDirMetadataKey: "/work/wb-same-with-title",
+			},
+			request: SessionRequest{WorkBeadID: "wb-same"},
+			derived: "/work/wb-same",
+			wantPatch: map[string]string{
+				beadmeta.WorkDirMetadataKey: "/work/wb-same-with-title",
+			},
+		},
+		{
+			name: "canonical path wins over divergent legacy twin",
+			metadata: map[string]string{
+				beadmeta.TriggerBeadIDMetadataKey: "wb-same",
+				beadmeta.WorkDirMetadataKey:       "/work/wb-same-with-title",
+				beadmeta.LegacyWorkDirMetadataKey: "/work/wb-same",
+			},
+			request: SessionRequest{WorkBeadID: "wb-same"},
+			derived: "/work/wb-same",
+			wantPatch: map[string]string{
+				beadmeta.LegacyWorkDirMetadataKey: "/work/wb-same-with-title",
+			},
+		},
+		{
+			name: "different trigger receives newly derived path",
+			metadata: map[string]string{
+				beadmeta.TriggerBeadIDMetadataKey: "wb-old",
+				beadmeta.WorkDirMetadataKey:       "/work/wb-old-with-title",
+				beadmeta.LegacyWorkDirMetadataKey: "/work/wb-old-with-title",
+			},
+			request: SessionRequest{WorkBeadID: "wb-new"},
+			derived: "/work/wb-new-with-title",
+			wantPatch: map[string]string{
+				beadmeta.TriggerBeadIDMetadataKey: "wb-new",
+				beadmeta.WorkDirMetadataKey:       "/work/wb-new-with-title",
+				beadmeta.LegacyWorkDirMetadataKey: "/work/wb-new-with-title",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := sessiontest.SeedBead(t, beads.Bead{
+				ID:       "session-1",
+				Type:     session.BeadType,
+				Status:   "open",
+				Labels:   []string{session.LabelSession},
+				Metadata: tt.metadata,
+			})
+			got := computePoolTriggerBindingPatch(info, tt.request, tt.derived)
+			if !reflect.DeepEqual(map[string]string(got), tt.wantPatch) {
+				t.Fatalf("patch = %#v, want %#v", got, tt.wantPatch)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_w3_split_equiv_test.go
+++ b/cmd/gc/session_w3_split_equiv_test.go
@@ -167,10 +167,9 @@ func TestSessionBeadHasAssignedWorkInfo(t *testing.T) {
 }
 
 // rawPoolTriggerBindingPatchRef is an independent reimplementation of the
-// trigger/pack/workspace/work-dir key-diff that bindPoolSessionTriggerBead
-// computed inline against sessionBead.Metadata, kept in the test as the ground
-// truth computePoolTriggerBindingPatch must match. It reads the RAW bead
-// metadata directly so the oracle proves the Info projection is byte-identical.
+// trigger/pack/workspace/work-dir key-diff against raw bead metadata. It is the
+// ground truth computePoolTriggerBindingPatch must match, proving the typed
+// Info projection preserves both ordinary rebinds and live retry continuations.
 func rawPoolTriggerBindingPatchRef(sb beads.Bead, request SessionRequest, workDir string) session.MetadataPatch {
 	workBeadID := strings.TrimSpace(request.WorkBeadID)
 	metadata := session.MetadataPatch{}
@@ -212,7 +211,22 @@ func rawPoolTriggerBindingPatchRef(sb beads.Bead, request SessionRequest, workDi
 		if existingWorkDir == "" {
 			existingWorkDir = strings.TrimSpace(sb.Metadata[beadmeta.LegacyWorkDirMetadataKey])
 		}
-		if oldWorkBeadID == workBeadID && existingWorkDir != "" {
+		currentWorkBeadID := strings.TrimSpace(sb.Metadata[session.CurrentBeadIDKey])
+		rawState := session.State(sb.Metadata["state"])
+		if rawState == session.StateAwake {
+			rawState = session.StateActive
+		}
+		if sb.Status == "closed" {
+			rawState = session.StateNone
+		}
+		liveResumeContinuation := oldWorkBeadID != workBeadID &&
+			request.Tier == "resume" &&
+			request.SessionBeadID == sb.ID &&
+			rawState == session.StateActive &&
+			sb.Metadata["wake_mode"] != "fresh" &&
+			currentWorkBeadID != "" &&
+			(currentWorkBeadID == oldWorkBeadID || currentWorkBeadID == workBeadID)
+		if existingWorkDir != "" && (oldWorkBeadID == workBeadID || liveResumeContinuation) {
 			targetWorkDir = existingWorkDir
 		}
 		if strings.TrimSpace(sb.Metadata[beadmeta.WorkDirMetadataKey]) != targetWorkDir {
@@ -241,6 +255,17 @@ func TestComputePoolTriggerBindingPatchMatchesRaw(t *testing.T) {
 			beadmeta.WorkDirMetadataKey:             "/gc/old",
 			beadmeta.LegacyWorkDirMetadataKey:       "/old",
 		}},
+		"live-retry": {ID: "s-live", Type: session.BeadType, Status: "open", Labels: []string{session.LabelSession}, Metadata: map[string]string{
+			"state":                                 string(session.StateAwake),
+			session.CurrentBeadIDKey:                "wb-old",
+			beadmeta.TriggerBeadIDMetadataKey:       "wb-old",
+			beadmeta.TriggerBeadStoreRefMetadataKey: "rig-old",
+			beadmeta.BrainParentSIDMetadataKey:      "brain-old",
+			beadmeta.PackMetadataKey:                "pack-old",
+			beadmeta.PackWorkspaceMetadataKey:       "ws-old",
+			beadmeta.WorkDirMetadataKey:             "/gc/old-with-title",
+			beadmeta.LegacyWorkDirMetadataKey:       "/gc/old-with-title",
+		}},
 	}
 	requests := map[string]SessionRequest{
 		"clear":             {WorkBeadID: ""},
@@ -250,6 +275,7 @@ func TestComputePoolTriggerBindingPatchMatchesRaw(t *testing.T) {
 		"store-ref":         {WorkBeadID: "wb-new", WorkStoreRef: "rig-new"},
 		"pack":              {WorkBeadID: "wb-new", WorkPack: "pack-new"},
 		"workspace":         {WorkBeadID: "wb-new", WorkPack: "pack-new", WorkWorkspace: "ws-new"},
+		"live-retry":        {Tier: "resume", SessionBeadID: "s-live", WorkBeadID: "wb-new"},
 	}
 	workDirs := []string{"", "/gc/old", "/gc/new"}
 	for bn, sb := range bases {
@@ -340,6 +366,136 @@ func TestComputePoolTriggerBindingPatchPreservesRecordedWorkDirForSameTrigger(t 
 			got := computePoolTriggerBindingPatch(info, tt.request, tt.derived)
 			if !reflect.DeepEqual(map[string]string(got), tt.wantPatch) {
 				t.Fatalf("patch = %#v, want %#v", got, tt.wantPatch)
+			}
+		})
+	}
+}
+
+func TestComputePoolTriggerBindingPatchPreservesLiveRetryWorkDir(t *testing.T) {
+	type testCase struct {
+		name      string
+		state     session.State
+		wakeMode  string
+		currentID string
+		request   SessionRequest
+		wantDir   string
+	}
+	tests := []testCase{
+		{
+			name:      "awake retry with prior-attempt marker",
+			state:     session.StateAwake,
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "resume", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-old-with-title",
+		},
+		{
+			name:      "active retry with new-attempt marker",
+			state:     session.StateActive,
+			currentID: "wb-new",
+			request:   SessionRequest{Tier: "resume", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-old-with-title",
+		},
+		{
+			name:    "missing current-bead marker derives",
+			state:   session.StateActive,
+			request: SessionRequest{Tier: "resume", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir: "/work/wb-new-with-title",
+		},
+		{
+			name:      "unrelated current-bead marker derives",
+			state:     session.StateActive,
+			currentID: "wb-unrelated",
+			request:   SessionRequest{Tier: "resume", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-new-with-title",
+		},
+		{
+			name:      "anonymous resume request derives",
+			state:     session.StateActive,
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "resume", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-new-with-title",
+		},
+		{
+			name:      "resume request for another session derives",
+			state:     session.StateActive,
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "resume", SessionBeadID: "session-2", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-new-with-title",
+		},
+		{
+			name:      "new tier derives",
+			state:     session.StateActive,
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "new", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-new-with-title",
+		},
+		{
+			name:      "wake-known-identity tier derives",
+			state:     session.StateActive,
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "wake-known-identity", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-new-with-title",
+		},
+		{
+			name:      "fresh wake mode derives",
+			state:     session.StateActive,
+			wakeMode:  "fresh",
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "resume", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-new-with-title",
+		},
+		{
+			name:      "noncanonical wake mode follows resume lifecycle",
+			state:     session.StateActive,
+			wakeMode:  " fresh ",
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "resume", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-old-with-title",
+		},
+	}
+
+	for _, dormantState := range []session.State{
+		session.StateAsleep,
+		session.StateStartPending,
+		session.StateCreating,
+		session.StateDraining,
+		session.StateDrained,
+		session.StateSuspended,
+		session.StateArchived,
+		session.StateQuarantined,
+	} {
+		tests = append(tests, testCase{
+			name:      string(dormantState) + " session derives before restart",
+			state:     dormantState,
+			currentID: "wb-old",
+			request:   SessionRequest{Tier: "resume", SessionBeadID: "session-1", WorkBeadID: "wb-new"},
+			wantDir:   "/work/wb-new-with-title",
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := sessiontest.SeedBead(t, beads.Bead{
+				ID:     "session-1",
+				Type:   session.BeadType,
+				Status: "open",
+				Labels: []string{session.LabelSession},
+				Metadata: map[string]string{
+					"state":                           string(tt.state),
+					"wake_mode":                       tt.wakeMode,
+					session.CurrentBeadIDKey:          tt.currentID,
+					beadmeta.TriggerBeadIDMetadataKey: "wb-old",
+					beadmeta.WorkDirMetadataKey:       "/work/wb-old-with-title",
+					beadmeta.LegacyWorkDirMetadataKey: "/work/wb-old-with-title",
+				},
+			})
+			got := computePoolTriggerBindingPatch(info, tt.request, "/work/wb-new-with-title")
+			updated := info.ApplyPatch(got)
+			if updated.WorkDirCanonical != tt.wantDir {
+				t.Fatalf("gc.work_dir = %q, want %q; patch=%#v", updated.WorkDirCanonical, tt.wantDir, got)
+			}
+			if updated.WorkDir != tt.wantDir {
+				t.Fatalf("work_dir = %q, want %q; patch=%#v", updated.WorkDir, tt.wantDir, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Preserve the launcher-created worktree when the same active resume-mode pool session claims a retry bead without restarting.
- Keep ordinary, dormant, fresh-mode, new-tier, and wake-known-identity rebinds deriving the next worktree, preserving the pack-routing contract from #3617.
- Carry Chris Sauer's original same-trigger title-suffix fix from #4116 (also folded into #4021) unchanged as the first commit, preserving author credit. This PR does not supersede #4021's separate durable-root check fix.

The gascity-packs nightly canary exposed the second failure mode: the same provider session claimed retry `fi-6gz` while its process remained in the `fi-6se-write-review-report` cwd, but reconciliation rewrote `gc.work_dir` to an unmaterialized `fi-6gz` path. The artifact gate then failed before it could inspect the valid report.

## Testing

- [x] Focused `cmd/gc` regression suite for same-trigger, live-retry, and ordinary rebind behavior
- [x] `LOCAL_TEST_JOBS=4 CMD_GC_FAST_TOTAL=6 make test-fast-parallel` (all 8 jobs passed)
- [x] `go vet ./...`
- [x] `make lint` (`0 issues`)
- [x] Push hook reran the fast suite (all 8 jobs passed)
- [ ] `make test-integration` — the originating workflow is covered by the gascity-packs inference canary and will be rerun against this PR

## Checklist

- [x] No separate issue: regression was isolated from gascity-packs nightly run 29300440024
- [x] Added regression coverage for both current-bead update orderings and all negative lifecycle/tier cases
- [x] No user-facing documentation change
- [x] No breaking change or migration
