### PR TITLE
test(ci): capture normalized Go timing artifacts

### DIFF
--- a/scripts/go-test-observable
+++ b/scripts/go-test-observable
@@ -19,6 +19,50 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
+timing_file="${OBSERVABLE_TIMING_FILE:-}"
+timing_variant="${OBSERVABLE_VARIANT:-default}"
+timing_shard_id="${OBSERVABLE_SHARD_ID:-$name}"
+timing_commit_sha="${OBSERVABLE_COMMIT_SHA:-}"
+timing_workflow="${OBSERVABLE_WORKFLOW:-}"
+timing_run_id="${OBSERVABLE_RUN_ID:-}"
+timing_run_attempt="${OBSERVABLE_RUN_ATTEMPT:-}"
+timing_job="${OBSERVABLE_JOB:-}"
+timing_runner_label="${OBSERVABLE_RUNNER_LABEL:-}"
+timing_runner_name="${OBSERVABLE_RUNNER_NAME:-}"
+timing_runner_os="${OBSERVABLE_RUNNER_OS:-}"
+timing_runner_arch="${OBSERVABLE_RUNNER_ARCH:-}"
+timing_runner_cpu_count="${OBSERVABLE_RUNNER_CPU_COUNT:-}"
+
+# Capture metadata at this wrapper boundary, then keep the product test's
+# environment unchanged. OBSERVABLE_TEST_LOG predates timing capture and is
+# intentionally left alone for compatibility.
+unset OBSERVABLE_TIMING_FILE OBSERVABLE_VARIANT OBSERVABLE_SHARD_ID
+unset OBSERVABLE_COMMIT_SHA OBSERVABLE_WORKFLOW OBSERVABLE_RUN_ID
+unset OBSERVABLE_RUN_ATTEMPT OBSERVABLE_JOB OBSERVABLE_RUNNER_LABEL
+unset OBSERVABLE_RUNNER_NAME OBSERVABLE_RUNNER_OS OBSERVABLE_RUNNER_ARCH
+unset OBSERVABLE_RUNNER_CPU_COUNT
+
+if [ -n "$timing_file" ] && ! rm -f "$timing_file"; then
+  echo "observable go test: warning: cannot remove stale timing artifact $timing_file; capture disabled" >&2
+  timing_file=""
+fi
+
+timing_module_path=""
+if [ -n "$timing_file" ]; then
+  if [ -z "$timing_runner_cpu_count" ] && command -v getconf >/dev/null 2>&1; then
+    timing_runner_cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+  fi
+  case "$timing_runner_cpu_count" in
+    ''|*[!0-9]*) timing_runner_cpu_count=0 ;;
+  esac
+  if detected_module="$(go list -m -f '{{.Path}}' 2>/dev/null)" && [ -n "$detected_module" ]; then
+    timing_module_path="$detected_module"
+  else
+    echo "observable go test: warning: module path unavailable; timing capture disabled" >&2
+    timing_file=""
+  fi
+fi
+
 if [ -n "${OBSERVABLE_TEST_LOG:-}" ]; then
   log="$OBSERVABLE_TEST_LOG"
   rm -f "$log"
@@ -35,6 +79,11 @@ print_failure_details() {
     return
   fi
   if [ ! -s "$log" ]; then
+    return
+  fi
+
+  if ! jq -e . "$log" >/dev/null 2>&1; then
+    echo "observable go test: raw JSON log is malformed; failure details unavailable" >&2
     return
   fi
 
@@ -61,31 +110,161 @@ print_failure_details() {
   jq -r 'select(.Action == "output" and .Output != null) | .Output' "$log" | tail -n "$failure_lines" >&2
 }
 
-if command -v jq >/dev/null 2>&1; then
-  set +e
-  go test -json "$@" \
-    | tee "$log" \
-    | jq -r '
+write_timing_artifact() {
+  if [ -z "$timing_file" ]; then
+    return
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "observable go test: warning: jq not found; timing capture unavailable" >&2
+    return
+  fi
+  if [ ! -s "$log" ]; then
+    echo "observable go test: warning: raw timing log is empty; no artifact written" >&2
+    return
+  fi
+
+  timing_dir="$(dirname "$timing_file")"
+  if [ ! -d "$timing_dir" ]; then
+    echo "observable go test: warning: timing directory does not exist: $timing_dir" >&2
+    return
+  fi
+  if ! timing_tmp="$(mktemp "${timing_file}.tmp.XXXXXX")"; then
+    echo "observable go test: warning: cannot create timing artifact beside $timing_file" >&2
+    return
+  fi
+
+  if ! jq -s -e \
+    --arg module "$timing_module_path" \
+    --arg shard_id "$timing_shard_id" \
+    --arg variant "$timing_variant" \
+    --arg commit_sha "$timing_commit_sha" \
+    --arg workflow "$timing_workflow" \
+    --arg run_id "$timing_run_id" \
+    --arg run_attempt "$timing_run_attempt" \
+    --arg job "$timing_job" \
+    --arg runner_label "$timing_runner_label" \
+    --arg runner_name "$timing_runner_name" \
+    --arg runner_os "$timing_runner_os" \
+    --arg runner_arch "$timing_runner_arch" \
+    --argjson runner_cpu_count "$timing_runner_cpu_count" \
+    '
+      def relative_package($module):
+        if $module == "" then .
+        elif . == $module then "."
+        elif startswith($module + "/") then .[($module | length) + 1:]
+        else .
+        end;
+
+      [.[] | select(.Action == "pass" or .Action == "fail" or .Action == "skip")] as $terminal
+      | if ($terminal | length) == 0 then
+          error("no terminal package or test timing events")
+        elif (($terminal | all(.[];
+          ((.Package | type) == "string" and (.Package | length) > 0) and
+          ((.Elapsed | type) == "number" and .Elapsed >= 0) and
+          (.Test == null or ((.Test | type) == "string" and (.Test | length) > 0))
+        )) | not) then
+          error("terminal timing event has an invalid package, test, or elapsed value")
+        else
+          $terminal
+        end
+      | map(
+          . as $event
+          | ($event.Package | relative_package($module)) as $package_id
+          | if $event.Test == null then
+              {
+                unit_id: $package_id,
+                kind: "package",
+                package: $event.Package,
+                test: "",
+                subtest: "",
+                outcome: $event.Action,
+                duration_seconds: $event.Elapsed
+              }
+            else
+              ($event.Test | split("/")) as $parts
+              | {
+                  unit_id: ($package_id + ":" + $event.Test),
+                  kind: "test",
+                  package: $event.Package,
+                  test: $parts[0],
+                  subtest: ($parts[1:] | join("/")),
+                  outcome: $event.Action,
+                  duration_seconds: $event.Elapsed
+                }
+            end
+        )
+      | sort_by([.unit_id, .kind, .outcome, .duration_seconds]) as $units
+      | {
+          schema: 1,
+          shard_id: $shard_id,
+          variant: $variant,
+          commit_sha: $commit_sha,
+          workflow: $workflow,
+          run_id: $run_id,
+          run_attempt: $run_attempt,
+          job: $job,
+          runner: {
+            label: $runner_label,
+            name: $runner_name,
+            os: $runner_os,
+            arch: $runner_arch,
+            cpu_count: $runner_cpu_count
+          },
+          units: $units
+        }
+    ' "$log" >"$timing_tmp"; then
+    rm -f "$timing_tmp"
+    echo "observable go test: warning: raw timing log is malformed or incomplete; no artifact written" >&2
+    return
+  fi
+
+  if ! mv -f "$timing_tmp" "$timing_file"; then
+    rm -f "$timing_tmp"
+    echo "observable go test: warning: cannot publish timing artifact $timing_file" >&2
+    return
+  fi
+	echo "observable go test: timing=$timing_file" >&2
+}
+
+print_progress() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "observable go test: jq not found; printing raw JSON progress" >&2
+    cat "$log"
+    return
+  fi
+  jq -r '
       select(
         .Action == "run" or
         .Action == "fail" or
         .Action == "skip" or
         (.Action == "pass" and (.Test == null or (.Elapsed // 0) >= 1))
       ) |
-      "\(.Time // "") \(.Action) \(.Test // .Package)"'
-  status=${PIPESTATUS[0]}
-  set -e
-else
-  echo "observable go test: jq not found; printing raw JSON progress" >&2
-  set +e
-  go test -json "$@" | tee "$log"
-  status=${PIPESTATUS[0]}
-  set -e
+      "\(.Time // "") \(.Action) \(.Test // .Package)"' "$log"
+}
+
+# Capture the product process directly so a failed renderer can never close a
+# downstream pipe and replace the product exit with SIGPIPE. Rendering after
+# completion trades live progress for exact, deterministic status ownership.
+set +e
+go test -json "$@" >"$log"
+status=$?
+set -e
+
+if ! print_progress; then
+  echo "observable go test: warning: progress rendering failed; product result is unchanged" >&2
+fi
+
+# Timing is advisory in this capture-only phase. A missing or malformed
+# scratch artifact must not change the product test result in either direction.
+if ! write_timing_artifact; then
+  echo "observable go test: warning: timing capture failed unexpectedly; product result is unchanged" >&2
 fi
 
 if [ "$status" -ne 0 ]; then
   echo "observable go test: FAIL status=$status log=$log" >&2
-  print_failure_details
+  if ! print_failure_details; then
+    echo "observable go test: warning: failure-detail rendering failed; product result is unchanged" >&2
+  fi
 else
   echo "observable go test: PASS log=$log" >&2
 fi

--- a/scripts/go_test_observable_test.go
+++ b/scripts/go_test_observable_test.go
@@ -1,13 +1,48 @@
 package scripts_test
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
+
+type observableTimingArtifact struct {
+	Schema     int                    `json:"schema"`
+	ShardID    string                 `json:"shard_id"`
+	Variant    string                 `json:"variant"`
+	CommitSHA  string                 `json:"commit_sha"`
+	Workflow   string                 `json:"workflow"`
+	RunID      string                 `json:"run_id"`
+	RunAttempt string                 `json:"run_attempt"`
+	Job        string                 `json:"job"`
+	Runner     observableTimingRunner `json:"runner"`
+	Units      []observableTimingUnit `json:"units"`
+}
+
+type observableTimingRunner struct {
+	Label    string `json:"label"`
+	Name     string `json:"name"`
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	CPUCount int    `json:"cpu_count"`
+}
+
+type observableTimingUnit struct {
+	UnitID          string  `json:"unit_id"`
+	Kind            string  `json:"kind"`
+	Package         string  `json:"package"`
+	Test            string  `json:"test"`
+	Subtest         string  `json:"subtest"`
+	Outcome         string  `json:"outcome"`
+	DurationSeconds float64 `json:"duration_seconds"`
+}
 
 func TestGoTestObservableDefaultLogPathIsUnique(t *testing.T) {
 	repoRoot := repoRoot(t)
@@ -33,11 +68,290 @@ func TestGoTestObservableDefaultLogPathIsUnique(t *testing.T) {
 	}
 }
 
+func TestGoTestObservableCaptureDisabledSkipsMetadataProbes(t *testing.T) {
+	repoRoot := repoRoot(t)
+	tmpDir := t.TempDir()
+	realGo, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("find go: %v", err)
+	}
+
+	fakeBin := filepath.Join(tmpDir, "bin")
+	if err := os.Mkdir(fakeBin, 0o755); err != nil {
+		t.Fatalf("create fake bin: %v", err)
+	}
+	probeLog := filepath.Join(tmpDir, "metadata-probes")
+	fakeGo := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "list" ]; then
+  printf 'go-list\n' >> %q
+fi
+exec %q "$@"
+`, probeLog, realGo)
+	if err := os.WriteFile(filepath.Join(fakeBin, "go"), []byte(fakeGo), 0o755); err != nil {
+		t.Fatalf("write fake go: %v", err)
+	}
+	fakeGetconf := fmt.Sprintf("#!/bin/sh\nprintf 'getconf\\n' >> %q\nexit 1\n", probeLog)
+	if err := os.WriteFile(filepath.Join(fakeBin, "getconf"), []byte(fakeGetconf), 0o755); err != nil {
+		t.Fatalf("write fake getconf: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	logPath := runObservableTestLogPath(t, repoRoot, tmpDir)
+	t.Cleanup(func() { _ = os.Remove(logPath) })
+	if probes, err := os.ReadFile(probeLog); err == nil {
+		t.Fatalf("capture-disabled wrapper ran metadata probes:\n%s", probes)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("inspect metadata probes: %v", err)
+	}
+}
+
+func TestGoTestObservableWritesDeterministicNormalizedTiming(t *testing.T) {
+	t.Parallel()
+
+	events := strings.Join([]string{
+		`{"Time":"2026-07-14T00:00:01Z","Action":"run","Package":"github.com/gastownhall/gascity/internal/example","Test":"TestZulu"}`,
+		`{"Time":"2026-07-14T00:00:04Z","Action":"pass","Package":"github.com/gastownhall/gascity/internal/example","Test":"TestZulu","Elapsed":0.2}`,
+		`{"Time":"2026-07-14T00:00:02Z","Action":"skip","Package":"github.com/gastownhall/gascity/internal/example","Test":"TestAlpha/case","Elapsed":0.1}`,
+		`{"Time":"2026-07-14T00:00:05Z","Action":"pass","Package":"github.com/gastownhall/gascity/internal/example","Elapsed":0.5}`,
+		`{"Time":"2026-07-14T00:00:03Z","Action":"pass","Package":"github.com/gastownhall/gascity/internal/example","Test":"TestAlpha","Elapsed":0.3}`,
+	}, "\n") + "\n"
+
+	first, firstOutput := runObservableWithFakeGo(t, events, 0)
+	second, _ := runObservableWithFakeGo(t, events, 0)
+	if !slices.Equal(first, second) {
+		t.Fatalf("normalized timing is not deterministic\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	for _, want := range []string{
+		"2026-07-14T00:00:01Z run TestZulu\n",
+		"2026-07-14T00:00:02Z skip TestAlpha/case\n",
+		"2026-07-14T00:00:05Z pass github.com/gastownhall/gascity/internal/example\n",
+	} {
+		if !strings.Contains(string(firstOutput), want) {
+			t.Fatalf("observable output does not contain %q:\n%s", want, firstOutput)
+		}
+	}
+
+	var artifact observableTimingArtifact
+	if err := json.Unmarshal(first, &artifact); err != nil {
+		t.Fatalf("decode timing artifact: %v\n%s", err, first)
+	}
+	if artifact.Schema != 1 || artifact.ShardID != "cmd-gc-process-1-of-12" || artifact.Variant != "default" {
+		t.Fatalf("artifact identity = schema %d shard %q variant %q", artifact.Schema, artifact.ShardID, artifact.Variant)
+	}
+	if artifact.CommitSHA != "deadbeef" || artifact.Workflow != "CI" || artifact.RunID != "42" || artifact.RunAttempt != "3" || artifact.Job != "cmd-gc-process" {
+		t.Fatalf("artifact run metadata = %+v", artifact)
+	}
+	if artifact.Runner != (observableTimingRunner{Label: "blacksmith-32vcpu", Name: "runner-7", OS: "Linux", Arch: "X64", CPUCount: 32}) {
+		t.Fatalf("runner metadata = %+v", artifact.Runner)
+	}
+	wantUnits := []observableTimingUnit{
+		{UnitID: "internal/example", Kind: "package", Package: "github.com/gastownhall/gascity/internal/example", Outcome: "pass", DurationSeconds: 0.5},
+		{UnitID: "internal/example:TestAlpha", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestAlpha", Outcome: "pass", DurationSeconds: 0.3},
+		{UnitID: "internal/example:TestAlpha/case", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestAlpha", Subtest: "case", Outcome: "skip", DurationSeconds: 0.1},
+		{UnitID: "internal/example:TestZulu", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestZulu", Outcome: "pass", DurationSeconds: 0.2},
+	}
+	if !slices.Equal(artifact.Units, wantUnits) {
+		t.Fatalf("timing units = %+v, want %+v", artifact.Units, wantUnits)
+	}
+}
+
+func TestGoTestObservableRecordsValidFailureWithoutChangingProductStatus(t *testing.T) {
+	t.Parallel()
+
+	events := strings.Join([]string{
+		`{"Action":"fail","Package":"github.com/gastownhall/gascity/internal/example","Test":"TestBroken","Elapsed":0.4}`,
+		`{"Action":"fail","Package":"github.com/gastownhall/gascity/internal/example","Elapsed":0.7}`,
+	}, "\n") + "\n"
+	data, output := runObservableWithFakeGo(t, events, 17)
+	for _, want := range []string{
+		" fail TestBroken\n",
+		" fail github.com/gastownhall/gascity/internal/example\n",
+	} {
+		if !strings.Contains(string(output), want) {
+			t.Fatalf("observable output does not contain %q:\n%s", want, output)
+		}
+	}
+
+	var artifact observableTimingArtifact
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		t.Fatalf("decode timing artifact: %v\n%s", err, data)
+	}
+	wantUnits := []observableTimingUnit{
+		{UnitID: "internal/example", Kind: "package", Package: "github.com/gastownhall/gascity/internal/example", Outcome: "fail", DurationSeconds: 0.7},
+		{UnitID: "internal/example:TestBroken", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestBroken", Outcome: "fail", DurationSeconds: 0.4},
+	}
+	if !slices.Equal(artifact.Units, wantUnits) {
+		t.Fatalf("timing units = %+v, want %+v", artifact.Units, wantUnits)
+	}
+}
+
+func TestGoTestObservableSkipsTimingWhenModuleIdentityIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	timingFile := filepath.Join(tmpDir, "timing.json")
+	events := `{"Action":"pass","Package":"github.com/gastownhall/gascity/internal/example","Test":"TestAlpha","Elapsed":0.3}` + "\n"
+	status, output := runObservableCommandWithModuleStatus(t, tmpDir, timingFile, events, 0, 23)
+	if status != 0 {
+		t.Fatalf("observable exit = %d, want product exit 0:\n%s", status, output)
+	}
+	if _, err := os.Stat(timingFile); !os.IsNotExist(err) {
+		t.Fatalf("missing module identity left a timing artifact: err=%v", err)
+	}
+	if !strings.Contains(string(output), "module path unavailable; timing capture disabled") {
+		t.Fatalf("observable output did not explain disabled timing capture:\n%s", output)
+	}
+}
+
+func TestGoTestObservableCaptureFailureNeverChangesProductStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name                string
+		output              string
+		productRun          int
+		wantProgressWarning bool
+	}{
+		{name: "malformed passing output", output: "{not-json\n", productRun: 0, wantProgressWarning: true},
+		{name: "truncated passing output", output: `{"Action":"pass"`, productRun: 0, wantProgressWarning: true},
+		{name: "missing passing output", output: "", productRun: 0},
+		{name: "terminal event missing elapsed", output: `{"Action":"pass","Package":"github.com/gastownhall/gascity/internal/example","Test":"TestIncomplete"}` + "\n", productRun: 0},
+		{name: "malformed failing output", output: "{not-json\n", productRun: 17, wantProgressWarning: true},
+		{name: "large malformed failing output", output: strings.Repeat("{not-json\n", 1<<18), productRun: 17, wantProgressWarning: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			timingFile, status, output := runObservableCaptureFailure(t, tt.output, tt.productRun)
+			if status != tt.productRun {
+				t.Fatalf("observable exit = %d, want product exit %d", status, tt.productRun)
+			}
+			if got := strings.Contains(string(output), "progress rendering failed; product result is unchanged"); got != tt.wantProgressWarning {
+				t.Fatalf("progress warning present = %t, want %t:\n%s", got, tt.wantProgressWarning, output)
+			}
+			if _, err := os.Stat(timingFile); !os.IsNotExist(err) {
+				t.Fatalf("invalid capture left a timing artifact: err=%v", err)
+			}
+		})
+	}
+}
+
+func runObservableWithFakeGo(t *testing.T, output string, productStatus int) ([]byte, []byte) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	timingFile := filepath.Join(tmpDir, "timing.json")
+	status, combined := runObservableCommand(t, tmpDir, timingFile, output, productStatus)
+	if status != productStatus {
+		t.Fatalf("observable exit = %d, want %d\n%s", status, productStatus, combined)
+	}
+	data, err := os.ReadFile(timingFile)
+	if err != nil {
+		t.Fatalf("read timing artifact: %v\n%s", err, combined)
+	}
+	return data, combined
+}
+
+func runObservableCaptureFailure(t *testing.T, output string, productStatus int) (string, int, []byte) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	timingFile := filepath.Join(tmpDir, "timing.json")
+	if err := os.WriteFile(timingFile, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("seed stale timing artifact: %v", err)
+	}
+	status, combined := runObservableCommand(t, tmpDir, timingFile, output, productStatus)
+	return timingFile, status, combined
+}
+
+func runObservableCommand(t *testing.T, tmpDir, timingFile, output string, productStatus int) (int, []byte) {
+	t.Helper()
+	return runObservableCommandWithModuleStatus(t, tmpDir, timingFile, output, productStatus, 0)
+}
+
+func runObservableCommandWithModuleStatus(t *testing.T, tmpDir, timingFile, output string, productStatus, moduleStatus int) (int, []byte) {
+	t.Helper()
+	repoRoot := repoRoot(t)
+	fakeBin := filepath.Join(tmpDir, "bin")
+	if err := os.Mkdir(fakeBin, 0o755); err != nil {
+		t.Fatalf("create fake bin: %v", err)
+	}
+	eventsFile := filepath.Join(tmpDir, "events.jsonl")
+	if err := os.WriteFile(eventsFile, []byte(output), 0o600); err != nil {
+		t.Fatalf("write fake events: %v", err)
+	}
+	fakeGo := filepath.Join(fakeBin, "go")
+	fakeGoScript := fmt.Sprintf(`#!/bin/sh
+set -e
+if [ "$1" = "list" ] && [ "$2" = "-m" ]; then
+  if [ %d -eq 0 ]; then
+    printf '%%s\n' 'github.com/gastownhall/gascity'
+  fi
+  exit %d
+fi
+if [ "$1" = "test" ] && [ "$2" = "-json" ]; then
+	cat %q
+	exit %d
+fi
+exit 99
+`, moduleStatus, moduleStatus, eventsFile, productStatus)
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatalf("write fake go: %v", err)
+	}
+
+	cmd := scriptCommand(repoRoot, "go-test-observable", "cmd-gc-process-1-of-12", "--", "./internal/example")
+	cmd.Dir = repoRoot
+	env := goTestScriptEnv(t, tmpDir)
+	env = replaceScriptEnv(env, "PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for key, value := range map[string]string{
+		"GC_TEST_NO_SLICE":            "1",
+		"OBSERVABLE_TEST_LOG":         filepath.Join(tmpDir, "raw.jsonl"),
+		"OBSERVABLE_TIMING_FILE":      timingFile,
+		"OBSERVABLE_VARIANT":          "default",
+		"OBSERVABLE_COMMIT_SHA":       "deadbeef",
+		"OBSERVABLE_WORKFLOW":         "CI",
+		"OBSERVABLE_RUN_ID":           "42",
+		"OBSERVABLE_RUN_ATTEMPT":      "3",
+		"OBSERVABLE_JOB":              "cmd-gc-process",
+		"OBSERVABLE_RUNNER_LABEL":     "blacksmith-32vcpu",
+		"OBSERVABLE_RUNNER_NAME":      "runner-7",
+		"OBSERVABLE_RUNNER_OS":        "Linux",
+		"OBSERVABLE_RUNNER_ARCH":      "X64",
+		"OBSERVABLE_RUNNER_CPU_COUNT": "32",
+	} {
+		env = replaceScriptEnv(env, key, value)
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, out
+	}
+	exitErr := &exec.ExitError{}
+	ok := errors.As(err, &exitErr)
+	if !ok {
+		t.Fatalf("run observable: %v\n%s", err, out)
+	}
+	return exitErr.ExitCode(), out
+}
+
+func replaceScriptEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	result := env[:0]
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			result = append(result, entry)
+		}
+	}
+	return append(result, key+"="+value)
+}
+
+func scriptCommand(repoRoot, name string, args ...string) *exec.Cmd {
+	return exec.Command(filepath.Join(repoRoot, "scripts", name), args...)
+}
+
 func runObservableTestLogPath(t *testing.T, repoRoot, tmpDir string) string {
 	t.Helper()
 
-	cmd := exec.Command(
-		filepath.Join(repoRoot, "scripts", "go-test-observable"),
+	cmd := scriptCommand(
+		repoRoot,
+		"go-test-observable",
 		"observable-log-test",
 		"--",
 		"./internal/shellquote",


### PR DESCRIPTION
Summary
- add opt-in schema-v1 package, test, and subtest timing artifacts to go-test-observable
- preserve product-test exit status across malformed JSON, renderer failures, and artifact failures
- publish only complete module-relative artifacts through same-directory temp plus rename
- keep capture-disabled runs free of module and CPU metadata probes

The wrapper now captures JSONL directly and renders progress after the product process exits. This intentionally gives exact status ownership and prevents a failed renderer from SIGPIPEing the test process. A 2.6 MiB regression fixture proves the former pipeline returned 141 instead of the intended 17.

Scope
- collector foundation only
- no shard or workflow wiring in this PR
- no protected timing database, planner, or PR summary yet

Verification
- focused observable tests repeated 5x
- focused race tests repeated 2x
- full go test ./scripts
- go vet ./scripts
- bash syntax and ShellCheck
- resource-census gate
- real go test JSON timing smoke
- repository pre-commit and pre-push fast suite
- three independent delegated council lanes CLEAR on the final tree and the hook-adjusted tree