### PR TITLE
Wrap session lifecycle terminal writes in Store.Tx

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -409,11 +409,6 @@ func reopenClosedConfiguredNamedSessionBead(
 			fmt.Fprintf(stderr, "session beads: session_name %q for %s unavailable during reopen: %v\n", sessionName, identity, err) //nolint:errcheck
 			return nil
 		}
-		if err := sessionFrontDoor(store).SetStatusOpen(bead.ID); err != nil {
-			fmt.Fprintf(stderr, "session beads: reopening configured named session %q: %v\n", identity, err) //nolint:errcheck
-			return nil
-		}
-		bead.Status = "open"
 		pendingCreateClaim := ""
 		if state != "active" {
 			pendingCreateClaim = "true"
@@ -466,17 +461,30 @@ func reopenClosedConfiguredNamedSessionBead(
 		for k, v := range extraMeta {
 			batch[k] = v
 		}
-		if setMetaBatch(sessionFrontDoor(store), bead.ID, batch, stderr) == nil {
-			// S19 Stage 3 shadow: record the legacy priming-marker clears so the
-			// converge comparator can attribute this owned-key delta (no-op unless
-			// the shadow harness is enabled).
-			recordLegacyCompareWrites(bead.ID, "syncSessionBeads.reclaim", batch)
-			if bead.Metadata == nil {
-				bead.Metadata = make(map[string]string, len(batch))
+		// The status flip and the terminal metadata batch land inside one
+		// Tx: a bead that comes back "open" must also carry the reopen
+		// metadata, never one without the other (ga-igcny0.1.1).
+		open := "open"
+		txErr := store.Tx("gc: reopen configured named session "+bead.ID, func(tx beads.Tx) error {
+			if err := tx.Update(bead.ID, beads.UpdateOpts{Status: &open}); err != nil {
+				return err
 			}
-			for k, v := range batch {
-				bead.Metadata[k] = v
-			}
+			return tx.SetMetadataBatch(bead.ID, batch)
+		})
+		if txErr != nil {
+			fmt.Fprintf(stderr, "session beads: reopening configured named session %q: %v\n", identity, txErr) //nolint:errcheck
+			return nil
+		}
+		// S19 Stage 3 shadow: record the legacy priming-marker clears so the
+		// converge comparator can attribute this owned-key delta (no-op unless
+		// the shadow harness is enabled).
+		recordLegacyCompareWrites(bead.ID, "syncSessionBeads.reclaim", batch)
+		bead.Status = "open"
+		if bead.Metadata == nil {
+			bead.Metadata = make(map[string]string, len(batch))
+		}
+		for k, v := range batch {
+			bead.Metadata[k] = v
 		}
 		reopened = bead
 		return nil
@@ -2365,16 +2373,30 @@ func setMetaBatch(sessFront *session.Store, id string, batch map[string]string, 
 	return nil
 }
 
-func closeFailedCreateBead(sessFront *session.Store, id string, now time.Time, stderr io.Writer) bool {
+// closeFailedCreateBeadInTx performs the failed-create terminal metadata
+// batch and Close as a single Tx-callback step. Shared by closeFailedCreateBead
+// and rollbackPendingCreate so the latter can fold this close into its own
+// larger transaction instead of nesting a second store.Tx call.
+func closeFailedCreateBeadInTx(tx beads.Tx, id string, now time.Time) error {
 	patch := session.ClosePatch(now.UTC(), string(session.StateFailedCreate))
 	patch["pending_create_claim"] = ""
 	patch["pending_create_started_at"] = ""
 	patch["sleep_intent"] = ""
-	if setMetaBatch(sessFront, id, patch, stderr) != nil {
-		return false
+	if err := tx.SetMetadataBatch(id, patch); err != nil {
+		return err
 	}
-	if err := sessFront.CloseWithoutReason(id); err != nil {
-		fmt.Fprintf(stderr, "session beads: closing failed-create bead %s: %v\n", id, err) //nolint:errcheck
+	return tx.Close(id)
+}
+
+func closeFailedCreateBead(sessFront *session.Store, id string, now time.Time, stderr io.Writer) bool {
+	// The terminal metadata batch and the Close land inside one Tx: a bead
+	// that reports closed must also carry its failed-create terminal state,
+	// never one without the other (ga-igcny0.1.1).
+	txErr := sessFront.Store().Tx("gc: close failed-create session "+id, func(tx beads.Tx) error {
+		return closeFailedCreateBeadInTx(tx, id, now)
+	})
+	if txErr != nil {
+		fmt.Fprintf(stderr, "session beads: closing failed-create bead %s: %v\n", id, txErr) //nolint:errcheck
 		return false
 	}
 	// Defense in depth: a startup race between bead creation and an early
@@ -2945,11 +2967,17 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 	if reason == string(session.StateFailedCreate) {
 		return closeFailedCreateBead(sessionFrontDoor(store), id, now, stderr)
 	}
-	if setMetaBatch(sessionFrontDoor(store), id, session.ClosePatch(now, reason), stderr) != nil {
-		return false
-	}
-	if err := sessionFrontDoor(store).CloseWithoutReason(id); err != nil {
-		fmt.Fprintf(stderr, "session beads: closing %s: %v\n", id, err) //nolint:errcheck
+	// The terminal metadata batch and the Close land inside one Tx: a bead
+	// that reports closed must also carry its terminal state, never one
+	// without the other (ga-igcny0.1.1).
+	txErr := store.Tx("gc: close session "+id, func(tx beads.Tx) error {
+		if err := tx.SetMetadataBatch(id, session.ClosePatch(now, reason)); err != nil {
+			return err
+		}
+		return tx.Close(id)
+	})
+	if txErr != nil {
+		fmt.Fprintf(stderr, "session beads: closing %s: %v\n", id, txErr) //nolint:errcheck
 		return false
 	}
 	// Cascade extmsg cleanup. Pool retirement funnels through closeBead;

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -461,15 +461,17 @@ func reopenClosedConfiguredNamedSessionBead(
 		for k, v := range extraMeta {
 			batch[k] = v
 		}
-		// The status flip and the terminal metadata batch land inside one
-		// Tx: a bead that comes back "open" must also carry the reopen
-		// metadata, never one without the other (ga-igcny0.1.1).
+		// The status flip and the terminal metadata are a single recoverable
+		// store write: UpdateOpts carries both Status and Metadata, so every
+		// backing store commits them together (native Dolt folds both into one
+		// UpdateIssue; MemStore/FileStore apply them under one lock). A failed
+		// write leaves the bead closed with its prior metadata intact -- the
+		// "open without its reopen metadata" split cannot occur, even on a store
+		// whose Tx executes callbacks sequentially without rollback
+		// (ga-igcny0.1.1). The Tx wrapper is kept only for the labeled commit.
 		open := "open"
 		txErr := store.Tx("gc: reopen configured named session "+bead.ID, func(tx beads.Tx) error {
-			if err := tx.Update(bead.ID, beads.UpdateOpts{Status: &open}); err != nil {
-				return err
-			}
-			return tx.SetMetadataBatch(bead.ID, batch)
+			return tx.Update(bead.ID, beads.UpdateOpts{Status: &open, Metadata: batch})
 		})
 		if txErr != nil {
 			fmt.Fprintf(stderr, "session beads: reopening configured named session %q: %v\n", identity, txErr) //nolint:errcheck
@@ -2389,9 +2391,15 @@ func closeFailedCreateBeadInTx(tx beads.Tx, id string, now time.Time) error {
 }
 
 func closeFailedCreateBead(sessFront *session.Store, id string, now time.Time, stderr io.Writer) bool {
-	// The terminal metadata batch and the Close land inside one Tx: a bead
-	// that reports closed must also carry its failed-create terminal state,
-	// never one without the other (ga-igcny0.1.1).
+	// The terminal metadata batch and the Close land inside one Tx. On an
+	// atomic backing (the production Dolt/DoltLite store) a bead that reports
+	// closed always carries its failed-create terminal state, never one without
+	// the other (ga-igcny0.1.1). The metadata batch is ordered before the Close
+	// on purpose: on a store whose Tx is not atomic the claim/marker clears
+	// still land even if the Close then fails, because a stale claim on a
+	// still-open bead would ping-pong the reconciler
+	// (TestCloseBeadClearsPendingCreateClaimEvenWhenCloseFails). The helper
+	// reports failure either way, so the reconciler re-runs the close.
 	txErr := sessFront.Store().Tx("gc: close failed-create session "+id, func(tx beads.Tx) error {
 		return closeFailedCreateBeadInTx(tx, id, now)
 	})
@@ -2967,9 +2975,12 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 	if reason == string(session.StateFailedCreate) {
 		return closeFailedCreateBead(sessionFrontDoor(store), id, now, stderr)
 	}
-	// The terminal metadata batch and the Close land inside one Tx: a bead
-	// that reports closed must also carry its terminal state, never one
-	// without the other (ga-igcny0.1.1).
+	// The terminal metadata batch and the Close land inside one Tx. On an
+	// atomic backing (the production Dolt/DoltLite store) a bead that reports
+	// closed always carries its terminal state, never one without the other
+	// (ga-igcny0.1.1). On a non-atomic Tx the metadata (ordered first) may land
+	// while the Close fails; the helper then reports failure and the reconciler
+	// re-runs the close next tick, so no bead is durably left half-closed.
 	txErr := store.Tx("gc: close session "+id, func(tx beads.Tx) error {
 		if err := tx.SetMetadataBatch(id, session.ClosePatch(now, reason)); err != nil {
 			return err

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -168,6 +168,38 @@ func (s *failingCloseStore) Tx(_ string, fn func(beads.Tx) error) error {
 	return fn(s)
 }
 
+// failingReopenWriteStore fails the single status+metadata Update the reopen
+// path issues (and any standalone metadata batch), so a test can prove a failed
+// reopen leaves the bead untouched -- still closed, prior terminal metadata
+// intact -- rather than flipped open without its reopen metadata. Failing both
+// write shapes also pins the single-write structure: a regression back to a
+// separate status-only Update plus SetMetadataBatch would flip the status via
+// the (metadata-less, so un-failed) status Update and trip the status assertion.
+type failingReopenWriteStore struct {
+	*beads.MemStore
+	fail bool
+}
+
+func (s *failingReopenWriteStore) Update(id string, opts beads.UpdateOpts) error {
+	if s.fail && len(opts.Metadata) > 0 {
+		return errors.New("status+metadata update failed")
+	}
+	return s.MemStore.Update(id, opts)
+}
+
+func (s *failingReopenWriteStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if s.fail {
+		return errors.New("metadata batch failed")
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+// Tx passes s (the wrapper) into the callback so the injected write failures are
+// observed inside the Tx; the embedded MemStore.Tx would bind the raw store.
+func (s *failingReopenWriteStore) Tx(_ string, fn func(beads.Tx) error) error {
+	return fn(s)
+}
+
 func (p *stopHookProvider) Stop(name string) error {
 	if p.beforeStop != nil {
 		p.beforeStop(name)
@@ -1398,12 +1430,16 @@ func TestReopenClosedConfiguredNamedSessionBeadUsesSingleTransactionForStatusAnd
 }
 
 // TestReopenClosedConfiguredNamedSessionBeadFailsWhenMetadataBatchFails pins
-// ga-igcny0.1.1's partial-success fix: if the status flip succeeds but the
-// terminal metadata batch then fails, the function must report failure —
-// not a bead that looks "open" but is missing its reopen metadata.
+// ga-igcny0.1.1's partial-success fix. The reopen writes the status flip and the
+// terminal metadata as ONE recoverable Update, so when that write fails the
+// function must report failure AND leave the bead untouched -- still closed,
+// still carrying its prior terminal metadata -- never a bead that looks "open"
+// but is missing its reopen metadata. This holds even on a store whose Tx runs
+// callbacks sequentially without rollback, because a single Update is atomic on
+// every backing store.
 func TestReopenClosedConfiguredNamedSessionBeadFailsWhenMetadataBatchFails(t *testing.T) {
 	cityPath := t.TempDir()
-	store := &failingMetadataBatchStore{MemStore: beads.NewMemStore()}
+	store := &failingReopenWriteStore{MemStore: beads.NewMemStore()}
 	now := time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
@@ -1436,17 +1472,35 @@ func TestReopenClosedConfiguredNamedSessionBeadFailsWhenMetadataBatchFails(t *te
 	if err := store.Close(closed.ID); err != nil {
 		t.Fatalf("close canonical bead: %v", err)
 	}
-	store.failBatch = true
+	store.fail = true
 
 	var stderr bytes.Buffer
 	_, _, ok := reopenClosedConfiguredNamedSessionBead(
 		cityPath, store, cfg, "test-city", "refinery", sessionName, "active", now, nil, &stderr,
 	)
 	if ok {
-		t.Fatal("reopenClosedConfiguredNamedSessionBead returned true, want false when the metadata batch fails")
+		t.Fatal("reopenClosedConfiguredNamedSessionBead returned true, want false when the reopen write fails")
 	}
 	if stderr.Len() == 0 {
-		t.Fatal("expected a diagnostic on stderr when the metadata batch fails")
+		t.Fatal("expected a diagnostic on stderr when the reopen write fails")
+	}
+	// The single status+metadata Update is all-or-nothing on every store, so a
+	// failed reopen must leave the bead exactly as it was: closed, carrying its
+	// prior terminal metadata, with none of the reopen batch applied. A
+	// regression to a separate status flip plus metadata batch would surface
+	// here as an "open" bead (or one whose terminal state was overwritten).
+	got, err := store.Get(closed.ID)
+	if err != nil {
+		t.Fatalf("get bead after failed reopen: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed: a failed single-write reopen must not flip the bead open", got.Status)
+	}
+	if got.Metadata["state"] != "suspended" {
+		t.Fatalf("state = %q, want suspended: the reopen sets state=active, so the old terminal state must survive a failed write", got.Metadata["state"])
+	}
+	if got.Metadata["close_reason"] != "suspended" {
+		t.Fatalf("close_reason = %q, want suspended: the reopen clears close_reason, so it must survive a failed write", got.Metadata["close_reason"])
 	}
 }
 

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -160,6 +160,14 @@ func (s *failingCloseStore) Close(_ string) error {
 	return errors.New("close failed")
 }
 
+// Tx overrides the promoted *beads.MemStore.Tx so the callback observes the
+// injected Close failure. Without this override, the embedded MemStore.Tx
+// passes the raw *MemStore (not s) into fn, silently bypassing the failure
+// once production code routes writes through store.Tx(...).
+func (s *failingCloseStore) Tx(_ string, fn func(beads.Tx) error) error {
+	return fn(s)
+}
+
 func (p *stopHookProvider) Stop(name string) error {
 	if p.beforeStop != nil {
 		p.beforeStop(name)
@@ -204,6 +212,16 @@ func (s *failingPoolSessionNameStore) Close(_ string) error {
 	return errors.New("close failed")
 }
 
+// Tx forwards fn(s) rather than delegating to the promoted MemStore.Tx (which
+// would pass the embedded *MemStore itself into fn, silently bypassing the
+// Close/SetMetadata overrides above). Without this override, any close path
+// that moved from a raw store.Close call to store.Tx(...) would stop
+// observing the injected "close failed" fault, since MemStore.Tx's callback
+// argument is bound to the embedded store, not to whatever wraps it.
+func (s *failingPoolSessionNameStore) Tx(_ string, fn func(beads.Tx) error) error {
+	return fn(s)
+}
+
 func citySessionIdentifierLockHeld(cityPath, identifier string) (bool, error) {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(identifier)))
 	lockPath := filepath.Join(citylayout.SessionNameLocksDir(cityPath), hex.EncodeToString(sum[:])+".lock")
@@ -240,6 +258,56 @@ func (s *countingMetadataStore) SetMetadataBatch(id string, kvs map[string]strin
 func (s *sessionGetSpyStore) Get(id string) (beads.Bead, error) {
 	s.getIDs = append(s.getIDs, id)
 	return s.Store.Get(id)
+}
+
+// txSpyStore counts store.Tx(...) invocations plus separate "direct"
+// counters for SetMetadataBatch/Close/Update calls made OUTSIDE any Tx
+// callback. Its own Tx passes the concrete embedded *beads.MemStore (not
+// itself) into fn, so writes issued from inside the callback land on
+// MemStore directly and never touch these overrides — only calls made
+// through the txSpyStore handle itself (i.e., not yet moved inside a Tx
+// boundary) bump the direct counters.
+type txSpyStore struct {
+	*beads.MemStore
+	txCalls                int
+	directSetMetadataBatch int
+	directSetMetadata      int
+	directClose            int
+	directUpdate           int
+}
+
+func newTxSpyStore() *txSpyStore {
+	return &txSpyStore{MemStore: beads.NewMemStore()}
+}
+
+func (s *txSpyStore) Tx(msg string, fn func(beads.Tx) error) error {
+	s.txCalls++
+	return s.MemStore.Tx(msg, fn)
+}
+
+func (s *txSpyStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	s.directSetMetadataBatch++
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+// SetMetadata is the single-key write path (session.InfoStore.SetMarker ->
+// setMetadataValue). It is not part of the Tx interface, so any call to it
+// necessarily happens outside a Tx boundary — tracking it catches writes
+// like rollbackPendingCreate's pre-ga-igcny0.1.1 last_woke_at/session_name
+// clears that the SetMetadataBatch counter alone would miss.
+func (s *txSpyStore) SetMetadata(id, key, value string) error {
+	s.directSetMetadata++
+	return s.MemStore.SetMetadata(id, key, value)
+}
+
+func (s *txSpyStore) Close(id string) error {
+	s.directClose++
+	return s.MemStore.Close(id)
+}
+
+func (s *txSpyStore) Update(id string, opts beads.UpdateOpts) error {
+	s.directUpdate++
+	return s.MemStore.Update(id, opts)
 }
 
 // allConfiguredDS builds configuredNames from a desiredState map.
@@ -1268,6 +1336,117 @@ func TestReopenClosedConfiguredNamedSessionBeadClearsStaleStartMarkersWhenRecrea
 		if got := reopened.Metadata[key]; got != "0" {
 			t.Fatalf("%s = %q, want %q on recreate", key, got, "0")
 		}
+	}
+}
+
+// TestReopenClosedConfiguredNamedSessionBeadUsesSingleTransactionForStatusAndMetadata
+// pins ga-igcny0.1.1: the status flip to "open" and the terminal reopen
+// metadata batch must land inside exactly one store.Tx call, not two
+// independent direct writes.
+func TestReopenClosedConfiguredNamedSessionBeadUsesSingleTransactionForStatusAndMetadata(t *testing.T) {
+	cityPath := t.TempDir()
+	store := newTxSpyStore()
+	now := time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "refinery", StartCommand: "true", MaxActiveSessions: intPtr(2)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "refinery", Mode: "on_demand"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, "refinery")
+	closed, err := store.Create(beads.Bead{
+		Title:  "refinery",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "refinery",
+			"template":                   "refinery",
+			"state":                      "suspended",
+			"close_reason":               "suspended",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "refinery",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed canonical bead: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("close canonical bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	_, _, ok := reopenClosedConfiguredNamedSessionBead(
+		cityPath, store, cfg, "test-city", "refinery", sessionName, "active", now, nil, &stderr,
+	)
+	if !ok {
+		t.Fatalf("reopenClosedConfiguredNamedSessionBead failed: %s", stderr.String())
+	}
+	if store.txCalls != 1 {
+		t.Fatalf("txCalls = %d, want 1", store.txCalls)
+	}
+	if store.directUpdate != 0 {
+		t.Fatalf("directUpdate = %d, want 0 (status flip must happen inside the Tx)", store.directUpdate)
+	}
+	if store.directSetMetadataBatch != 0 {
+		t.Fatalf("directSetMetadataBatch = %d, want 0 (metadata write must happen inside the Tx)", store.directSetMetadataBatch)
+	}
+}
+
+// TestReopenClosedConfiguredNamedSessionBeadFailsWhenMetadataBatchFails pins
+// ga-igcny0.1.1's partial-success fix: if the status flip succeeds but the
+// terminal metadata batch then fails, the function must report failure —
+// not a bead that looks "open" but is missing its reopen metadata.
+func TestReopenClosedConfiguredNamedSessionBeadFailsWhenMetadataBatchFails(t *testing.T) {
+	cityPath := t.TempDir()
+	store := &failingMetadataBatchStore{MemStore: beads.NewMemStore()}
+	now := time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "refinery", StartCommand: "true", MaxActiveSessions: intPtr(2)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "refinery", Mode: "on_demand"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, "refinery")
+	closed, err := store.Create(beads.Bead{
+		Title:  "refinery",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "refinery",
+			"template":                   "refinery",
+			"state":                      "suspended",
+			"close_reason":               "suspended",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "refinery",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed canonical bead: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("close canonical bead: %v", err)
+	}
+	store.failBatch = true
+
+	var stderr bytes.Buffer
+	_, _, ok := reopenClosedConfiguredNamedSessionBead(
+		cityPath, store, cfg, "test-city", "refinery", sessionName, "active", now, nil, &stderr,
+	)
+	if ok {
+		t.Fatal("reopenClosedConfiguredNamedSessionBead returned true, want false when the metadata batch fails")
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("expected a diagnostic on stderr when the metadata batch fails")
 	}
 }
 
@@ -2836,6 +3015,68 @@ func TestCloseBeadClearsPendingCreateClaimEvenWhenCloseFails(t *testing.T) {
 	}
 	if want := session.CanonicalCloseReason(string(session.StateFailedCreate)); got.Metadata["close_reason"] != want {
 		t.Fatalf("close_reason = %q, want %q", got.Metadata["close_reason"], want)
+	}
+}
+
+// TestCloseBeadUsesSingleTransactionForMetadataAndClose pins ga-igcny0.1.1:
+// the terminal metadata batch and the Close must land inside exactly one
+// store.Tx call, not as two independent direct writes.
+func TestCloseBeadUsesSingleTransactionForMetadataAndClose(t *testing.T) {
+	store := newTxSpyStore()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !closeBead(store, b.ID, string(session.StateAwake), now, ioDiscard{}) {
+		t.Fatal("closeBead returned false, want true")
+	}
+	if store.txCalls != 1 {
+		t.Fatalf("txCalls = %d, want 1", store.txCalls)
+	}
+	if store.directSetMetadataBatch != 0 {
+		t.Fatalf("directSetMetadataBatch = %d, want 0 (metadata write must happen inside the Tx)", store.directSetMetadataBatch)
+	}
+	if store.directClose != 0 {
+		t.Fatalf("directClose = %d, want 0 (close must happen inside the Tx)", store.directClose)
+	}
+}
+
+// TestCloseFailedCreateBeadUsesSingleTransactionForMetadataAndClose pins
+// ga-igcny0.1.1 for the failed-create close path specifically: the claim
+// clears and the terminal Close must be one atomic unit, not two direct
+// writes that could observably split under a real transactional backend.
+func TestCloseFailedCreateBeadUsesSingleTransactionForMetadataAndClose(t *testing.T) {
+	store := newTxSpyStore()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"pending_create_claim": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !closeFailedCreateBead(sessionFrontDoor(store), b.ID, now, ioDiscard{}) {
+		t.Fatal("closeFailedCreateBead returned false, want true")
+	}
+	if store.txCalls != 1 {
+		t.Fatalf("txCalls = %d, want 1", store.txCalls)
+	}
+	if store.directSetMetadataBatch != 0 {
+		t.Fatalf("directSetMetadataBatch = %d, want 0 (metadata write must happen inside the Tx)", store.directSetMetadataBatch)
+	}
+	if store.directClose != 0 {
+		t.Fatalf("directClose = %d, want 0 (close must happen inside the Tx)", store.directClose)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -2454,13 +2454,37 @@ func rollbackPendingCreate(info sessionpkg.Info, sessFront *sessionpkg.Store, no
 	if strings.TrimSpace(info.ID) == "" || sessFront == nil {
 		return nil
 	}
-	batch := clearPendingStartInFlightLease(info.ID, sessFront, stderr)
-	if strings.TrimSpace(info.SessionNameExplicit) == "true" {
-		if setMeta(sessFront, info.ID, "session_name", "", stderr) == nil {
-			batch = mergeMetadataPatch(batch, map[string]string{"session_name": ""})
-		}
+	store := sessFront.Store()
+	// Idempotence: mirrors closeBead's already-closed guard. Once the Tx
+	// below folds the failed-create close into the same transaction as the
+	// metadata clears, that guard is no longer reached through a closeBead
+	// call — so it must be checked explicitly here, gating the clears too,
+	// or a retried rollback against a terminal bead would keep clearing
+	// last_woke_at/session_name on every tick (ga-igcny0.1.1).
+	if snapshot, err := store.Get(info.ID); err == nil && snapshot.Status == "closed" {
+		return nil
 	}
-	closeBead(sessFront.Store().Store, info.ID, string(sessionpkg.StateFailedCreate), now, stderr)
+
+	clearSessionName := strings.TrimSpace(info.SessionNameExplicit) == "true"
+
+	// The in-flight-lease clear, the conditional session_name clear, and the
+	// failed-create terminal close land inside one Tx: this is one logical
+	// rollback transition, not three independent writes (ga-igcny0.1.1).
+	batch := map[string]string{"last_woke_at": ""}
+	if clearSessionName {
+		batch["session_name"] = ""
+	}
+	txErr := store.Tx("gc: rollback pending-create session "+info.ID, func(tx beads.Tx) error {
+		if err := tx.SetMetadataBatch(info.ID, batch); err != nil {
+			return err
+		}
+		return closeFailedCreateBeadInTx(tx, info.ID, now)
+	})
+	if txErr != nil {
+		fmt.Fprintf(stderr, "session beads: rolling back pending-create session %s: %v\n", info.ID, txErr) //nolint:errcheck
+		return nil
+	}
+	cancelStateAssignedToRetiredSessionBead(store.Store, info.ID, now, stderr)
 	return batch
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1717,18 +1717,17 @@ func asyncStartPreparedCommandStaleInfo(prepared preparedStart, current sessionp
 	return preparedCommand != "" && currentCommand != "" && preparedCommand != currentCommand
 }
 
-// clearPendingStartInFlightLease clears last_woke_at for the session handle.
-// Returns the {"last_woke_at":""} batch when the clear persisted, nil otherwise,
-// so the rollback callers can fold it onto the typed snapshot (Step 6d
-// write-returns-Info). Most callers discard the return.
-func clearPendingStartInFlightLease(handle string, sessFront *sessionpkg.Store, stderr io.Writer) map[string]string {
+// clearPendingStartInFlightLease clears last_woke_at for the session handle so a
+// stale in-flight start lease does not survive a rollback or abandoned start.
+// Fire-and-forget: setMeta logs on failure and the next reconciler tick
+// re-attempts. The transactional rollback siblings now clear last_woke_at inside
+// their own store.Tx (rollbackPendingCreateClears), so this helper no longer
+// returns a fold batch.
+func clearPendingStartInFlightLease(handle string, sessFront *sessionpkg.Store, stderr io.Writer) {
 	if strings.TrimSpace(handle) == "" || sessFront == nil {
-		return nil
+		return
 	}
-	if setMeta(sessFront, handle, "last_woke_at", "", stderr) == nil {
-		return map[string]string{"last_woke_at": ""}
-	}
-	return nil
+	setMeta(sessFront, handle, "last_woke_at", "", stderr) //nolint:errcheck
 }
 
 func stopStaleAsyncStartRuntime(result startResult, sp runtime.Provider, stderr io.Writer) {
@@ -2443,6 +2442,93 @@ func runningSessionMatchesPendingCreateInfo(info sessionpkg.Info, sessionName st
 	return expectedToken != "" && liveToken == expectedToken
 }
 
+// rollbackPendingCreateClears folds the failed-create terminal close and the
+// pre/post-close metadata clears (last_woke_at, plus session_name when the
+// session name was explicit) into one store.Tx: one logical rollback transition,
+// not N independent writes (ga-igcny0.1.1). It is the shared transaction body for
+// both pending-create rollback siblings so they can never diverge on the
+// transaction boundary; each wraps it and decides which mirrored batch to fold
+// onto the typed snapshot.
+//
+// On an atomic backing (the production Dolt/DoltLite store) every write commits
+// or rolls back together, so write order is invisible. The order below is what
+// keeps each invariant correct on a store whose Tx executes callbacks
+// sequentially WITHOUT rollback:
+//
+//   - last_woke_at (the in-flight-lease marker) clears BEFORE the close, so it
+//     lands even if the close then fails and the next reconciler tick can retry
+//     (TestCommitStartResult_RollbackPendingErrorClearsInFlightLeaseWhenCloseFails).
+//   - pending_create_claim clears inside closeFailedCreateBeadInTx, before its
+//     close, for the same retry/ping-pong reason
+//     (TestCloseBeadClearsPendingCreateClaimEvenWhenCloseFails).
+//   - session_name (the runtime identity) clears only AFTER the close has
+//     succeeded, so a failed close never strands an OPEN bead with its runtime
+//     name cleared; a closed bead's stale name is inert (closed beads are
+//     skipped for name reuse).
+//
+// When a non-atomic Tx persists the close but then fails the post-close write,
+// the txErr branch re-reads the bead and runs retired-session cleanup if it is
+// already closed, so a partial close cannot strand the session's waits/extmsg
+// bindings — the next reconciler tick would otherwise short-circuit on the
+// already-closed guard above and return before that cleanup ran.
+//
+// It returns the applied clears and true on success, or (nil, false) when the
+// bead was already closed (an idempotent no-op) or the transaction failed.
+func rollbackPendingCreateClears(info sessionpkg.Info, sessFront *sessionpkg.Store, now time.Time, commitMsg string, stderr io.Writer) (map[string]string, bool) {
+	store := sessFront.Store()
+	// Idempotence: mirrors closeBead's already-closed guard. Folding the
+	// failed-create close into the same Tx as the metadata clears bypasses the
+	// guard closeBead/closeFailedCreateBead would otherwise apply — so it must
+	// be checked explicitly here, gating the clears too, or a retried rollback
+	// against a terminal bead would keep clearing last_woke_at/session_name on
+	// every tick (ga-igcny0.1.1).
+	if snapshot, err := store.Get(info.ID); err == nil && snapshot.Status == "closed" {
+		return nil, false
+	}
+
+	preCloseClears := map[string]string{"last_woke_at": ""}
+	var postCloseClears map[string]string
+	if strings.TrimSpace(info.SessionNameExplicit) == "true" {
+		postCloseClears = map[string]string{"session_name": ""}
+	}
+	txErr := store.Tx(commitMsg, func(tx beads.Tx) error {
+		if err := tx.SetMetadataBatch(info.ID, preCloseClears); err != nil {
+			return err
+		}
+		if err := closeFailedCreateBeadInTx(tx, info.ID, now); err != nil {
+			return err
+		}
+		if len(postCloseClears) == 0 {
+			return nil
+		}
+		return tx.SetMetadataBatch(info.ID, postCloseClears)
+	})
+	if txErr != nil {
+		fmt.Fprintf(stderr, "session beads: %s: %v\n", commitMsg, txErr) //nolint:errcheck
+		// On a non-atomic Store.Tx backend (FileStore, or BdStore whose apply()
+		// splits the callback into separate bd writes) the pre-close clear and
+		// the failed-create Close can persist before the post-close session_name
+		// clear fails, leaving the bead genuinely closed. The next reconciler
+		// rollback tick would then short-circuit on the already-closed guard
+		// above and return before retired-session cleanup, stranding the closed
+		// session's waits and extmsg bindings. Run that cleanup here when the
+		// close did land. On the atomic production store a failed Tx rolls the
+		// close back, so the bead reads not-closed and this is skipped — the
+		// existing whole-rollback retry path stays unchanged.
+		if snapshot, err := store.Get(info.ID); err == nil && snapshot.Status == "closed" {
+			cancelStateAssignedToRetiredSessionBead(store.Store, info.ID, now, stderr)
+		}
+		return nil, false
+	}
+	cancelStateAssignedToRetiredSessionBead(store.Store, info.ID, now, stderr)
+	// Mirror the union of both clears onto the typed snapshot.
+	batch := map[string]string{"last_woke_at": ""}
+	for k, v := range postCloseClears {
+		batch[k] = v
+	}
+	return batch, true
+}
+
 // rollbackPendingCreate returns the metadata batch it mirrored onto the raw bead
 // (last_woke_at="" + conditional session_name="") so the reconciler can fold it
 // onto the typed snapshot (Step 6d write-returns-Info). NOTE: closeBead is
@@ -2454,37 +2540,10 @@ func rollbackPendingCreate(info sessionpkg.Info, sessFront *sessionpkg.Store, no
 	if strings.TrimSpace(info.ID) == "" || sessFront == nil {
 		return nil
 	}
-	store := sessFront.Store()
-	// Idempotence: mirrors closeBead's already-closed guard. Once the Tx
-	// below folds the failed-create close into the same transaction as the
-	// metadata clears, that guard is no longer reached through a closeBead
-	// call — so it must be checked explicitly here, gating the clears too,
-	// or a retried rollback against a terminal bead would keep clearing
-	// last_woke_at/session_name on every tick (ga-igcny0.1.1).
-	if snapshot, err := store.Get(info.ID); err == nil && snapshot.Status == "closed" {
+	batch, ok := rollbackPendingCreateClears(info, sessFront, now, "gc: rollback pending-create session "+info.ID, stderr)
+	if !ok {
 		return nil
 	}
-
-	clearSessionName := strings.TrimSpace(info.SessionNameExplicit) == "true"
-
-	// The in-flight-lease clear, the conditional session_name clear, and the
-	// failed-create terminal close land inside one Tx: this is one logical
-	// rollback transition, not three independent writes (ga-igcny0.1.1).
-	batch := map[string]string{"last_woke_at": ""}
-	if clearSessionName {
-		batch["session_name"] = ""
-	}
-	txErr := store.Tx("gc: rollback pending-create session "+info.ID, func(tx beads.Tx) error {
-		if err := tx.SetMetadataBatch(info.ID, batch); err != nil {
-			return err
-		}
-		return closeFailedCreateBeadInTx(tx, info.ID, now)
-	})
-	if txErr != nil {
-		fmt.Fprintf(stderr, "session beads: rolling back pending-create session %s: %v\n", info.ID, txErr) //nolint:errcheck
-		return nil
-	}
-	cancelStateAssignedToRetiredSessionBead(store.Store, info.ID, now, stderr)
 	return batch
 }
 
@@ -2492,22 +2551,22 @@ func rollbackPendingCreate(info sessionpkg.Info, sessFront *sessionpkg.Store, no
 // failed-create ClosePatch metadata + claim clears mirrored onto the raw bead
 // when the store-only close succeeds. Returns the full mirrored batch (again with
 // NO Closed change — closeFailedCreateBead is store-only, so *session.Status stays
-// open) for the snapshot fold.
+// open) for the snapshot fold. It shares rollbackPendingCreateClears' single Tx,
+// so the pre-close clears and the failed-create close roll back together on
+// failure (ga-igcny0.1.1) instead of leaving an open creating bead with its
+// runtime name already cleared.
 func rollbackPendingCreateClearingClaim(info sessionpkg.Info, sessFront *sessionpkg.Store, now time.Time, stderr io.Writer) map[string]string {
 	if strings.TrimSpace(info.ID) == "" || sessFront == nil {
 		return nil
 	}
-	batch := clearPendingStartInFlightLease(info.ID, sessFront, stderr)
-	if strings.TrimSpace(info.SessionNameExplicit) == "true" {
-		if setMeta(sessFront, info.ID, "session_name", "", stderr) == nil {
-			batch = mergeMetadataPatch(batch, map[string]string{"session_name": ""})
-		}
+	batch, ok := rollbackPendingCreateClears(info, sessFront, now, "gc: rollback pending-create session clearing claim "+info.ID, stderr)
+	if !ok {
+		return nil
 	}
-	if !closeFailedCreateBead(sessFront, info.ID, now, stderr) {
-		return batch
-	}
-	closePatch := sessionpkg.ClosePatch(now.UTC(), string(sessionpkg.StateFailedCreate))
-	batch = mergeMetadataPatch(batch, closePatch)
+	// The store received the failed-create ClosePatch and claim clears via
+	// closeFailedCreateBeadInTx; mirror them onto the snapshot too (still NO
+	// Closed change — the close is store-only).
+	batch = mergeMetadataPatch(batch, sessionpkg.ClosePatch(now.UTC(), string(sessionpkg.StateFailedCreate)))
 	batch = mergeMetadataPatch(batch, map[string]string{"pending_create_claim": "", "pending_create_started_at": ""})
 	return batch
 }

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -41,6 +41,14 @@ func (s *failingMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]s
 	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
+// Tx overrides the promoted *beads.MemStore.Tx so callbacks observe the
+// injected batch failure. Without this override, the embedded MemStore.Tx
+// passes the raw *MemStore (not s) into fn, silently bypassing failBatch
+// for any write routed through store.Tx(...).
+func (s *failingMetadataBatchStore) Tx(_ string, fn func(beads.Tx) error) error {
+	return fn(s)
+}
+
 type failNthMetadataBatchStore struct {
 	*beads.MemStore
 	failOn int
@@ -3121,6 +3129,117 @@ func TestAsyncStartSessionStillCurrent_RollbackPendingCreateStillWorksWhenNotAct
 	}
 	if asyncStartSessionStillCurrentInfo(prepared, current) {
 		t.Fatal("pcc cleared while state still creating must be treated as rollback (stale)")
+	}
+}
+
+// TestRollbackPendingCreateUsesSingleTransactionForAllWrites pins ga-igcny0.1.1:
+// the last_woke_at clear, the conditional session_name clear, and the
+// failed-create terminal close must land inside exactly one store.Tx call,
+// not as three independent direct writes that could observably split under
+// a real transactional backend.
+func TestRollbackPendingCreateUsesSingleTransactionForAllWrites(t *testing.T) {
+	store := newTxSpyStore()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":          "worker",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"last_woke_at":          now.Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info := sessionpkg.Info{ID: b.ID, SessionNameExplicit: b.Metadata["session_name_explicit"]}
+	batch := rollbackPendingCreate(info, sessionFrontDoor(store), now, ioDiscard{})
+
+	if store.txCalls != 1 {
+		t.Fatalf("txCalls = %d, want 1", store.txCalls)
+	}
+	if store.directSetMetadataBatch != 0 {
+		t.Fatalf("directSetMetadataBatch = %d, want 0 (all metadata writes must happen inside the Tx)", store.directSetMetadataBatch)
+	}
+	if store.directSetMetadata != 0 {
+		t.Fatalf("directSetMetadata = %d, want 0 (last_woke_at/session_name clears must happen inside the Tx, not via a direct single-key write)", store.directSetMetadata)
+	}
+	if store.directClose != 0 {
+		t.Fatalf("directClose = %d, want 0 (close must happen inside the Tx)", store.directClose)
+	}
+	if store.directUpdate != 0 {
+		t.Fatalf("directUpdate = %d, want 0", store.directUpdate)
+	}
+
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("Status = %q, want closed", got.Status)
+	}
+	if got.Metadata["state"] != string(sessionpkg.StateFailedCreate) {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], sessionpkg.StateFailedCreate)
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared", got.Metadata["last_woke_at"])
+	}
+	if got.Metadata["session_name"] != "" {
+		t.Fatalf("session_name = %q, want cleared", got.Metadata["session_name"])
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+
+	if batch["last_woke_at"] != "" {
+		t.Fatalf("returned batch last_woke_at = %q, want cleared", batch["last_woke_at"])
+	}
+	if batch["session_name"] != "" {
+		t.Fatalf("returned batch session_name = %q, want cleared", batch["session_name"])
+	}
+}
+
+// TestRollbackPendingCreateIsNoopOnAlreadyClosedBead pins ga-igcny0.1.1: once
+// closeFailedCreateBeadInTx is folded directly into rollbackPendingCreate's
+// own Tx, the implicit already-closed guard closeBead used to provide is no
+// longer reached through — so rollbackPendingCreate must carry its own
+// upfront guard, or a retried rollback against a terminal bead would still
+// clear last_woke_at/session_name on every tick.
+func TestRollbackPendingCreateIsNoopOnAlreadyClosedBead(t *testing.T) {
+	store := newTxSpyStore()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	wokeAt := now.Format(time.RFC3339)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name_explicit": "true",
+			"last_woke_at":          wokeAt,
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MemStore.Close(b.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	info := sessionpkg.Info{ID: b.ID, SessionNameExplicit: b.Metadata["session_name_explicit"]}
+	rollbackPendingCreate(info, sessionFrontDoor(store), now, ioDiscard{})
+
+	if store.txCalls != 0 {
+		t.Fatalf("txCalls = %d, want 0 (already-closed bead must be a no-op)", store.txCalls)
+	}
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["last_woke_at"] != wokeAt {
+		t.Fatalf("last_woke_at = %q, want unchanged %q (guard must fire before any writes)", got.Metadata["last_woke_at"], wokeAt)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -63,6 +63,30 @@ func (s *failNthMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]s
 	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
+// failPostCloseSessionNameStore models a non-atomic Store.Tx backend
+// (FileStore, or BdStore whose apply() splits the callback into separate bd
+// writes) that fails ONLY the post-close session_name clear. The pre-close
+// last_woke_at clear and the failed-create Close persist first, so the bead is
+// genuinely left closed when the post-close SetMetadataBatch fails — the exact
+// partial-close window rollbackPendingCreateClears must still clean up after.
+type failPostCloseSessionNameStore struct {
+	*beads.MemStore
+}
+
+func (s *failPostCloseSessionNameStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if _, ok := kvs["session_name"]; ok {
+		return errors.New("post-close session_name batch failed")
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+// Tx passes s (the wrapper) into the callback so the injected post-close
+// failure is observed inside the Tx; the embedded MemStore.Tx would bind the
+// raw store and bypass the override.
+func (s *failPostCloseSessionNameStore) Tx(_ string, fn func(beads.Tx) error) error {
+	return fn(s)
+}
+
 type failSetMetadataStore struct {
 	*beads.MemStore
 	failKey string
@@ -3240,6 +3264,313 @@ func TestRollbackPendingCreateIsNoopOnAlreadyClosedBead(t *testing.T) {
 	}
 	if got.Metadata["last_woke_at"] != wokeAt {
 		t.Fatalf("last_woke_at = %q, want unchanged %q (guard must fire before any writes)", got.Metadata["last_woke_at"], wokeAt)
+	}
+}
+
+// TestRollbackPendingCreateClearingClaimUsesSingleTransactionForAllWrites pins
+// ga-igcny0.1.1 for the clearing-claim sibling (the configured-named-session
+// rollback path reached via clearClaim=true). Its last_woke_at clear, the
+// conditional session_name clear, and the failed-create terminal close must land
+// inside exactly one store.Tx call, matching rollbackPendingCreate — never as
+// independent direct writes that could leave an open creating bead with its
+// runtime name already cleared when the close fails.
+func TestRollbackPendingCreateClearingClaimUsesSingleTransactionForAllWrites(t *testing.T) {
+	store := newTxSpyStore()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":          "worker",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"last_woke_at":          now.Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info := sessionpkg.Info{ID: b.ID, SessionNameExplicit: b.Metadata["session_name_explicit"]}
+	batch := rollbackPendingCreateClearingClaim(info, sessionFrontDoor(store), now, ioDiscard{})
+
+	if store.txCalls != 1 {
+		t.Fatalf("txCalls = %d, want 1", store.txCalls)
+	}
+	if store.directSetMetadataBatch != 0 {
+		t.Fatalf("directSetMetadataBatch = %d, want 0 (all metadata writes must happen inside the Tx)", store.directSetMetadataBatch)
+	}
+	if store.directSetMetadata != 0 {
+		t.Fatalf("directSetMetadata = %d, want 0 (last_woke_at/session_name clears must happen inside the Tx, not via a direct single-key write)", store.directSetMetadata)
+	}
+	if store.directClose != 0 {
+		t.Fatalf("directClose = %d, want 0 (close must happen inside the Tx)", store.directClose)
+	}
+	if store.directUpdate != 0 {
+		t.Fatalf("directUpdate = %d, want 0", store.directUpdate)
+	}
+
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("Status = %q, want closed", got.Status)
+	}
+	if got.Metadata["state"] != string(sessionpkg.StateFailedCreate) {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], sessionpkg.StateFailedCreate)
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared", got.Metadata["last_woke_at"])
+	}
+	if got.Metadata["session_name"] != "" {
+		t.Fatalf("session_name = %q, want cleared", got.Metadata["session_name"])
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+
+	// The clearing-claim sibling additionally folds the failed-create ClosePatch
+	// and claim clears onto the snapshot (Step 6d write-returns-Info), matching
+	// what closeFailedCreateBeadInTx wrote to the store.
+	if batch["last_woke_at"] != "" {
+		t.Fatalf("returned batch last_woke_at = %q, want cleared", batch["last_woke_at"])
+	}
+	if batch["session_name"] != "" {
+		t.Fatalf("returned batch session_name = %q, want cleared", batch["session_name"])
+	}
+	if batch["state"] != string(sessionpkg.StateFailedCreate) {
+		t.Fatalf("returned batch state = %q, want %q (ClosePatch fold missing)", batch["state"], sessionpkg.StateFailedCreate)
+	}
+	if _, ok := batch["closed_at"]; !ok {
+		t.Fatal("returned batch missing closed_at (ClosePatch fold missing)")
+	}
+	if v, ok := batch["pending_create_claim"]; !ok || v != "" {
+		t.Fatalf("returned batch pending_create_claim = %q present=%v, want empty-string clear", v, ok)
+	}
+	if v, ok := batch["pending_create_started_at"]; !ok || v != "" {
+		t.Fatalf("returned batch pending_create_started_at = %q present=%v, want empty-string clear", v, ok)
+	}
+}
+
+// TestRollbackPendingCreateClearingClaimIsNoopOnAlreadyClosedBead pins
+// ga-igcny0.1.1: the clearing-claim sibling now shares rollbackPendingCreate's
+// upfront already-closed guard, so a retried rollback against a terminal bead
+// performs no Tx and leaves last_woke_at/session_name untouched instead of
+// re-clearing them every tick.
+func TestRollbackPendingCreateClearingClaimIsNoopOnAlreadyClosedBead(t *testing.T) {
+	store := newTxSpyStore()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	wokeAt := now.Format(time.RFC3339)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":          "worker",
+			"session_name_explicit": "true",
+			"last_woke_at":          wokeAt,
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MemStore.Close(b.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	info := sessionpkg.Info{ID: b.ID, SessionNameExplicit: b.Metadata["session_name_explicit"]}
+	batch := rollbackPendingCreateClearingClaim(info, sessionFrontDoor(store), now, ioDiscard{})
+
+	if batch != nil {
+		t.Fatalf("returned batch = %v, want nil (already-closed bead must be a no-op)", batch)
+	}
+	if store.txCalls != 0 {
+		t.Fatalf("txCalls = %d, want 0 (already-closed bead must be a no-op)", store.txCalls)
+	}
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["last_woke_at"] != wokeAt {
+		t.Fatalf("last_woke_at = %q, want unchanged %q (guard must fire before any writes)", got.Metadata["last_woke_at"], wokeAt)
+	}
+	if got.Metadata["session_name"] != "worker" {
+		t.Fatalf("session_name = %q, want unchanged %q (guard must fire before any writes)", got.Metadata["session_name"], "worker")
+	}
+}
+
+// TestRollbackPendingCreateClearingClaimReturnsNilWhenTxFails pins
+// ga-igcny0.1.1's partial-failure contract for the clearing-claim sibling: when
+// the in-Tx metadata batch fails, the rollback reports failure (nil fold and a
+// diagnostic) and does not report the bead closed, rather than mirroring a
+// partial rollback whose still-open bead has its runtime name already cleared.
+func TestRollbackPendingCreateClearingClaimReturnsNilWhenTxFails(t *testing.T) {
+	store := &failingMetadataBatchStore{MemStore: beads.NewMemStore()}
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":          "worker",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"last_woke_at":          now.Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.failBatch = true
+
+	var stderr bytes.Buffer
+	info := sessionpkg.Info{ID: b.ID, SessionNameExplicit: b.Metadata["session_name_explicit"]}
+	batch := rollbackPendingCreateClearingClaim(info, sessionFrontDoor(store), now, &stderr)
+
+	if batch != nil {
+		t.Fatalf("returned batch = %v, want nil when the Tx metadata batch fails", batch)
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("expected a diagnostic on stderr when the Tx fails")
+	}
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == "closed" {
+		t.Fatal("bead must not be reported closed when the rollback Tx failed")
+	}
+}
+
+// TestRollbackPendingCreateClearingClaimKeepsSessionNameWhenCloseFails proves the
+// non-atomic-store safety the adoption review asked for (ga-igcny0.1.1): the
+// session_name clear is ordered AFTER the failed-create close, so when the close
+// itself fails on a store whose Tx runs callbacks sequentially without rollback
+// (here a failingCloseStore over a MemStore), the bead is never left OPEN with
+// its runtime name cleared. The pending_create_claim clear still lands -- it
+// rides inside closeFailedCreateBeadInTx before the close -- so a stale claim
+// cannot ping-pong the reconciler.
+func TestRollbackPendingCreateClearingClaimKeepsSessionNameWhenCloseFails(t *testing.T) {
+	store := &failingCloseStore{MemStore: beads.NewMemStore()}
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":          "worker",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"last_woke_at":          now.Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	info := sessionpkg.Info{ID: b.ID, SessionNameExplicit: b.Metadata["session_name_explicit"]}
+	batch := rollbackPendingCreateClearingClaim(info, sessionFrontDoor(store), now, &stderr)
+	if batch != nil {
+		t.Fatalf("returned batch = %v, want nil when the failed-create close fails", batch)
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("expected a diagnostic on stderr when the close fails")
+	}
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == "closed" {
+		t.Fatal("bead must not be reported closed when the close failed")
+	}
+	if got.Metadata["session_name"] != "worker" {
+		t.Fatalf("session_name = %q, want \"worker\": a failed close must not strand an open bead with its runtime name cleared (ga-igcny0.1.1)", got.Metadata["session_name"])
+	}
+	// The claim clear rides inside the close (before it), so it lands even when
+	// the close then fails -- preventing reconciler ping-pong, matching
+	// TestCloseBeadClearsPendingCreateClaimEvenWhenCloseFails.
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared even on close failure", got.Metadata["pending_create_claim"])
+	}
+}
+
+// TestRollbackPendingCreateClearingClaimRunsRetiredCleanupWhenPostCloseFails
+// proves the non-atomic-store cleanup safety the attempt-3 adoption review asked
+// for. On a store whose Tx runs callbacks sequentially without rollback, the
+// pre-close last_woke_at clear and the failed-create Close can persist and then
+// the post-close session_name clear can fail, leaving the bead genuinely closed.
+// The failing tick must still run retired-session cleanup for that now-closed
+// bead: the next rollback tick short-circuits on the already-closed guard and
+// would otherwise leave the closed session's waits (and extmsg bindings)
+// stranded. On the atomic production store a failed Tx rolls the close back, so
+// the bead reads not-closed and this cleanup is correctly skipped there.
+func TestRollbackPendingCreateClearingClaimRunsRetiredCleanupWhenPostCloseFails(t *testing.T) {
+	store := &failPostCloseSessionNameStore{MemStore: beads.NewMemStore()}
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":          "worker",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"last_woke_at":          now.Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A pending wait attached to the session bead. Retired-session cleanup must
+	// cancel it even though the rollback Tx reported failure.
+	wait, err := store.Create(beads.Bead{
+		Title:  "wait",
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + b.ID},
+		Metadata: map[string]string{
+			"session_id": b.ID,
+			"state":      waitStatePending,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	info := sessionpkg.Info{ID: b.ID, SessionNameExplicit: b.Metadata["session_name_explicit"]}
+	batch := rollbackPendingCreateClearingClaim(info, sessionFrontDoor(store), now, &stderr)
+	if batch != nil {
+		t.Fatalf("returned batch = %v, want nil when the post-close write fails", batch)
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("expected a diagnostic on stderr when the post-close write fails")
+	}
+
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The non-atomic partial close: the failed-create Close landed (bead closed)
+	// but the post-close session_name clear did not.
+	if got.Status != "closed" {
+		t.Fatalf("bead status = %q, want closed: the failed-create Close persists on a non-atomic store", got.Status)
+	}
+	if got.Metadata["session_name"] != "worker" {
+		t.Fatalf("session_name = %q, want \"worker\": the post-close clear failed", got.Metadata["session_name"])
+	}
+	// The key assertion: retired-session cleanup ran for the now-closed bead, so
+	// the pending wait was canceled rather than stranded. Without the txErr-branch
+	// cleanup this wait stays pending because the next rollback tick returns on
+	// the already-closed guard before cleanup.
+	gotWait, err := store.Get(wait.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotWait.Status != "closed" || gotWait.Metadata["state"] != waitStateCanceled {
+		t.Fatalf("wait status/state = %q/%q, want closed/%s: retired-session cleanup must run after a partial non-atomic close", gotWait.Status, gotWait.Metadata["state"], waitStateCanceled)
 	}
 }
 

--- a/release-gates/ga-ey4tcs-store-tx-gate.md
+++ b/release-gates/ga-ey4tcs-store-tx-gate.md
@@ -1,0 +1,67 @@
+# Release Gate: ga-ey4tcs Store.Tx session lifecycle writes
+
+Gate evaluated: 2026-07-14T04:05:22Z
+
+Bead: `ga-ey4tcs` - needs-deploy: Wrap closeBead/rollbackPendingCreate/reopen in Store.Tx
+
+Source review bead: `ga-23a84u` - Review verdict: PASS
+
+Branch: `builder/ga-ey4tcs-store-tx-rebuild-v3`
+
+Base: `origin/main` at `5e2fa2872a6dc0de996397f6face30893a4c14da`
+
+Head before gate commit: `afdf84fbe0e65c1542816bc55dee23c6b451d220`
+
+Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this repository at this head, so the gate uses the deployer prompt criteria and the local `TESTING.md` guidance.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-23a84u` contains `REVIEW VERDICT: PASS`, closes with reason `pass`, and states "No blocking findings." |
+| 2 | Acceptance criteria met | PASS | The single commit wraps the requested session lifecycle write groups in `Store.Tx`: `closeBead`, `closeFailedCreateBead`, `rollbackPendingCreate`, and `reopenClosedConfiguredNamedSessionBead`. The diff keeps cascade cleanup outside the transaction, adds the explicit already-closed rollback guard, and pins the behavior with transaction/failure/idempotence tests. |
+| 3 | Tests pass | PASS | `gofmt -l` on the 4 touched files produced no output. `go build ./...` passed. `go vet ./...` passed. Targeted `go test -count=1 ./cmd/gc -run ...` passed. `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-23a84u` reports no blocking findings and no high-severity open findings in notes. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` showed `## builder/ga-ey4tcs-store-tx-rebuild-v3...origin/builder/ga-ey4tcs-store-tx-rebuild-v3` with no dirty paths before writing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | After `git fetch origin main`, `git merge-base --is-ancestor origin/main HEAD` exited 0, `git rev-list --left-right --count origin/main...HEAD` returned `0 1`, and `git merge-tree` reported clean. |
+| 7 | Single feature theme | PASS | The branch is one commit ahead of main and touches only `cmd/gc/session_beads.go`, `cmd/gc/session_beads_test.go`, `cmd/gc/session_lifecycle_parallel.go`, and `cmd/gc/session_lifecycle_parallel_test.go` for one session lifecycle atomic-write theme. |
+
+## Test Evidence
+
+```text
+gofmt -l cmd/gc/session_beads.go cmd/gc/session_beads_test.go cmd/gc/session_lifecycle_parallel.go cmd/gc/session_lifecycle_parallel_test.go
+# no output
+
+go build ./...
+# exit 0
+
+go vet ./...
+# exit 0
+
+go test -count=1 ./cmd/gc -run 'Test(ReopenClosedConfiguredNamedSessionBead(ClearsPendingCreateStartedAtWhenActive|ClearsStaleStartMarkersWhenRecreating|UsesSingleTransactionForStatusAndMetadata|FailsWhenMetadataBatchFails)|CloseBead(ClearsPendingCreateClaimEvenWhenCloseFails|UsesSingleTransactionForMetadataAndClose|ReleasesWorkAssignedBySessionName|ClearsSessionAffinityOnRelease|ReleasesWorkAssignedByBeadID|ReleasesWorkAssignedByNamedIdentity|LeavesUnrelatedWorkAlone|ReleasesWorkAssignedByAlias|DoesNotDuplicateOwnershipGuard|IsNoopOnAlreadyClosedBead|CascadesExtmsgState)|CloseFailedCreateBead(UsesSingleTransactionForMetadataAndClose|CascadesExtmsgState)|RollbackPendingCreate(UsesSingleTransactionForAllWrites|IsNoopOnAlreadyClosedBead)|AsyncStartSessionStillCurrent_RollbackPendingCreateStillWorksWhenNotActive|CommitStartResult_(RollbackPendingErrorClearsInFlightLeaseWhenCloseFails|AtomicBatchFailureLeavesClaimIntact|AtomicBatchLandsStateAndClaimClearTogether))$'
+ok  	github.com/gastownhall/gascity/cmd/gc	0.437s
+
+make test-fast-parallel
+[fsys-darwin-compile] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-core] ok
+All fast jobs passed
+```
+
+## Branch Evidence
+
+```text
+git diff --name-only origin/main..HEAD
+cmd/gc/session_beads.go
+cmd/gc/session_beads_test.go
+cmd/gc/session_lifecycle_parallel.go
+cmd/gc/session_lifecycle_parallel_test.go
+
+git log --oneline --left-right --cherry-pick origin/main...HEAD
+> afdf84fbe fix(session): wrap closeBead/rollbackPendingCreate/reopen in Store.Tx
+```


### PR DESCRIPTION
## What this changes

Session lifecycle close, failed-create rollback, and configured named-session reopen paths now commit their status and metadata transitions through `Store.Tx`. Operators should no longer see session beads in split states such as closed without terminal metadata, failed-create rollback with only part of the cleanup applied, or reopened without the matching pending-create metadata.

`rollbackPendingCreate` also has an explicit already-closed guard because it now folds the failed-create close into its own transaction instead of reaching `closeBead`'s guard indirectly.

## Review notes

- Focus on `cmd/gc/session_beads.go` and `cmd/gc/session_lifecycle_parallel.go`; the change is intentionally limited to session bead lifecycle writes.
- Cascade cleanup remains outside the transaction boundaries as best-effort follow-up work.
- No API, dashboard, schema, config, or dependency changes are intended.

## Test plan

- [x] `gofmt -l cmd/gc/session_beads.go cmd/gc/session_beads_test.go cmd/gc/session_lifecycle_parallel.go cmd/gc/session_lifecycle_parallel_test.go`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Targeted `go test -count=1 ./cmd/gc -run ...` for close, failed-create, rollback, reopen, and commit-start transaction behavior
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-ey4tcs-store-tx-gate.md`](release-gates/ga-ey4tcs-store-tx-gate.md)