### PR TITLE
test(policy): ratchet direct net listener debt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -5,8 +5,8 @@
 `test/test-resources.toml` is the checked P0.4 resource ledger. It scans tracked
 Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
-freeze process, sleep, environment, CWD, slow-process, and HTTP test-server
-call/file totals.
+freeze process, sleep, environment, CWD, slow-process, HTTP test-server, and
+package-level `net.Listen` call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
 owners without weakening the raw anti-growth ratchets.
@@ -30,18 +30,22 @@ remain Small debt even when a Medium test calls the helper. Likewise, a
 calls inside `TestMain`, never sibling tests.
 
 This bootstrap does **not** infer resources recursively through arbitrary
-helper calls or claim a complete shared-resource inventory. P0.4c's first
-slice covers the three `net/http/httptest` constructors that open loopback
-servers; direct `net` listeners, tmux, Dolt, and other shared-host resources
-remain explicit follow-up catalogs. A Medium resource
-may describe a helper-backed runtime cost, but only syntax-owned calls in that
-exact runnable declaration leave Small-debt accounting. `ga-80po0c.2.2` owns
-the listener, tmux, Dolt, and shared-host catalogs. E1 separately owns Large
-journey and provider entries.
+helper calls or claim a complete shared-resource inventory. P0.4c currently
+covers the three `net/http/httptest` constructors that open loopback servers
+and the exact package-level `net.Listen` constructor. The next listener
+families are `net.ListenUnixgram`, `net.ListenConfig.Listen`, and raw
+`syscall.Socket`/`Bind`/`Listen`; typed and packet-specific `net` constructors,
+helper-backed listeners whose constructors live outside test source, tmux,
+Dolt, and other shared-host resources remain explicit follow-up catalogs. A
+Medium resource may describe a helper-backed runtime cost, but only syntax-owned
+calls in that exact runnable declaration leave Small-debt accounting.
+`ga-80po0c.2.2` owns the listener, tmux, Dolt, and shared-host catalogs. E1
+separately owns Large journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
-`time.Sleep`; `net/http/httptest.NewServer`, `NewTLSServer`, and
-`NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`, `os.Clearenv`, and `os.Chdir`; and
+`time.Sleep`; package-level `net.Listen`; `net/http/httptest.NewServer`,
+`NewTLSServer`, and `NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`,
+`os.Clearenv`, and `os.Chdir`; and
 `Setenv` or `Chdir` on function parameters typed exactly as `*testing.T` or
 `testing.TB`. It also recognizes the receiverless
 `skipSlowCmdGCTest(*testing.T, string)` definition and its same-package calls.
@@ -52,7 +56,7 @@ directory and package so cross-file shadows do not masquerade as resources.
 Local shadows and wrong signatures do not count. Parenthesized call
 expressions retain the same ownership.
 
-Targeted dot imports of `os/exec`, `time`, `os`, `testing`, or
+Targeted dot imports of `net`, `os/exec`, `time`, `os`, `testing`, or
 `net/http/httptest` are rejected with file and import context because their
 resources cannot be attributed safely; blank imports remain harmless.
 Explicit constraints follow Go's leading-header
@@ -95,12 +99,14 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files | ga-80po0c.2.1 | untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; each non-Medium marked caller retains an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
+| Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 374 calls / 97 files | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | cwd: 208 calls / 40 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | environment: 4092 calls / 180 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
+| Source debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 374 calls / 97 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->
 

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -42,6 +42,8 @@ const (
 	ResourceSlowProcessGate Resource = "slow_process_gate"
 	// ResourceHTTPTestServer counts loopback servers opened by net/http/httptest.
 	ResourceHTTPTestServer Resource = "http_test_server"
+	// ResourceNetListen counts direct listeners opened by net.Listen.
+	ResourceNetListen Resource = "net_listen"
 )
 
 var knownResources = map[Resource]struct{}{
@@ -51,6 +53,7 @@ var knownResources = map[Resource]struct{}{
 	ResourceCWD:             {},
 	ResourceSlowProcessGate: {},
 	ResourceHTTPTestServer:  {},
+	ResourceNetListen:       {},
 }
 
 // Scope selects the source population counted by a ledger row.
@@ -203,6 +206,19 @@ var bootstrapPolicy = Ledger{
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceNetListen,
+			BaselineCalls:   92,
+			BaselineFiles:   34,
+			ReportedCalls:   92,
+			ReportedFiles:   34,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged net.Listen call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test closes its listener and removes duplicate listener-backed coverage",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
 	},
 	Medium: []MediumOwner{
 		{
@@ -293,6 +309,19 @@ var bootstrapPolicy = Ledger{
 			OwnerBead:       "ga-80po0c.2.2",
 			Invariant:       "untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceNetListen,
+			BaselineCalls:   92,
+			BaselineFiles:   34,
+			ReportedCalls:   92,
+			ReportedFiles:   34,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener",
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
@@ -566,7 +595,14 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 
 		for _, candidate := range source.calls {
 			call := candidate.call
-			matched, err := isImportedCall(call, source.bindings, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer")
+			matched, err := isImportedCall(call, source.bindings, "net", "Listen")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, candidate.owner, candidate.runnable, ResourceNetListen)
+			}
+			matched, err = isImportedCall(call, source.bindings, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
@@ -764,7 +800,7 @@ func validateImports(file *ast.File) error {
 			continue
 		}
 		if spec.Name != nil && spec.Name.Name == "." {
-			if importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "testing" || importPath == "net/http/httptest" {
+			if importPath == "net" || importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "testing" || importPath == "net/http/httptest" {
 				return fmt.Errorf("targeted dot import %q cannot be counted safely", importPath)
 			}
 		}
@@ -795,7 +831,7 @@ func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner str
 		switch function := unparen(call.Fun).(type) {
 		case *ast.SelectorExpr:
 			switch function.Sel.Name {
-			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "NewServer", "NewTLSServer", "NewUnstartedServer":
+			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "NewServer", "NewTLSServer", "NewUnstartedServer":
 				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		case *ast.Ident:

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -170,6 +170,74 @@ func TestTaggedHTTPTestServer(t *testing.T) {
 	}
 }
 
+func TestScanCountsNetListenByImportIdentityAndRunnableOwnership(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	foreign "example.test/net"
+	sockets "net"
+	"testing"
+)
+
+type localNet struct{}
+func (localNet) Listen(string, string) (any, error) { return nil, nil }
+
+func TestNetListen(t *testing.T) {
+	_, _ = ((sockets.Listen))("tcp", "127.0.0.1:0")
+	t.Run("nested", func(t *testing.T) {
+		_, _ = (((sockets)).Listen)("unix", "socket")
+	})
+
+	local := localNet{}
+	_, _ = local.Listen("tcp", "local shadow")
+	_, _ = foreign.Listen("tcp", "foreign package")
+	lc := sockets.ListenConfig{}
+	_, _ = lc.Listen(t.Context(), "tcp", "listen config method")
+	_, _ = sockets.ListenTCP("tcp", nil)
+	_ = "sockets.Listen(\"tcp\", \"string literal\")"
+	// sockets.Listen("tcp", "comment")
+}
+
+func helper() {
+	_, _ = sockets.Listen("tcp", "127.0.0.1:0")
+}
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import (
+	sockets "net"
+	"testing"
+)
+func TestTaggedNetListen(t *testing.T) {
+	_, _ = sockets.Listen("tcp", "127.0.0.1:0")
+}
+`)},
+		"shadow/shadow.go": &fstest.MapFile{Data: []byte(`package shadow
+type localNet struct{}
+func (localNet) Listen(string, string) (any, error) { return nil, nil }
+var sockets localNet
+`)},
+		"shadow/resources_test.go": &fstest.MapFile{Data: []byte(`package shadow
+func TestSiblingShadow() {
+	_, _ = sockets.Listen("tcp", "cross-file shadow")
+}
+`)},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeAll, ResourceNetListen, 4, 2)
+	assertCount(t, got, ScopeUntagged, ResourceNetListen, 3, 1)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListen, "TestNetListen", true, false)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListen, "helper", false, false)
+	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListen, "TestTaggedNetListen", true, true)
+}
+
 func TestScanCountsCmdGCProcessGlobalsByLexicalOwnership(t *testing.T) {
 	t.Parallel()
 
@@ -770,6 +838,15 @@ func TestResource(t *T) { t.Setenv("KEY", "value") }
 `,
 		},
 		{
+			name:       "net",
+			path:       "sample/dot_net_test.go",
+			importPath: "net",
+			source: `package sample
+import . "net"
+func TestResource() { _, _ = Listen("tcp", "127.0.0.1:0") }
+`,
+		},
+		{
 			name:       "net http httptest",
 			path:       "sample/dot_httptest_test.go",
 			importPath: "net/http/httptest",
@@ -796,6 +873,7 @@ func TestScanAllowsBlankImportsOfTargetedPackages(t *testing.T) {
 	files := fstest.MapFS{
 		"sample/blank_import_test.go": &fstest.MapFile{Data: []byte(`package sample
 import (
+	_ "net"
 	_ "net/http/httptest"
 	_ "os"
 	_ "os/exec"
@@ -1210,6 +1288,20 @@ func TestBootstrapPolicyOwnsHTTPTestServerDebt(t *testing.T) {
 		row := findRow(t, rows, ScopeUntagged, ResourceHTTPTestServer)
 		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
 			t.Fatalf("HTTP test server owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		}
+	}
+}
+
+func TestBootstrapPolicyOwnsNetListenDebt(t *testing.T) {
+	t.Parallel()
+
+	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
+		row := findRow(t, rows, ScopeUntagged, ResourceNetListen)
+		if row.BaselineCalls != 92 || row.BaselineFiles != 34 {
+			t.Fatalf("net.Listen baseline = %d/%d, want 92/34", row.BaselineCalls, row.BaselineFiles)
+		}
+		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
+			t.Fatalf("net.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
 		}
 	}
 }

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -113,6 +113,19 @@ resource_owner = "each owning test closes its loopback server and removes duplic
 migration_target = "P0.4c"
 expires = "2026-10-01"
 
+[[debt]]
+scope = "untagged"
+resource = "net_listen"
+baseline_calls = 92
+baseline_files = 34
+reported_calls = 92
+reported_files = 34
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged net.Listen call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test closes its listener and removes duplicate listener-backed coverage"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
 # Exact Medium owners are keyed by source directory, package clause, and
 # top-level Go test identity. Only matching resources lexically inside that
 # declaration leave the Small-debt census; helper bodies and sibling tests do
@@ -205,5 +218,18 @@ reported_files = 56
 owner_bead = "ga-80po0c.2.2"
 invariant = "untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "net_listen"
+baseline_calls = 92
+baseline_files = 34
+reported_calls = 92
+reported_files = 34
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener"
 migration_target = "P0.4c"
 expires = "2026-10-01"


### PR DESCRIPTION
## Summary
- classify direct package-level `net.Listen` resource ownership in the test-resource ledger
- add an import-aware AST census that excludes shadows and other listener APIs
- ratchet the current inventory at 99 calls / 41 files, with 92 / 34 remaining untagged Small debt

## Verification
- focused scanner, policy, import, and repository-ledger tests
- pre-commit hook
- pre-push `./scripts/test-local-parallel fast` (all 8 jobs)
- three independent delegated council reviews on tree `f126e26c87b489a3ed74f0407a3be7ab15ff3106`: CLEAR

Behavior-neutral test-policy slice; no production runtime path changes.