### PR TITLE
test(policy): ratchet Unixgram listener debt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@
 Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
 freeze process, sleep, environment, CWD, slow-process, HTTP test-server, and
-package-level `net.Listen` call/file totals.
+package-level `net.Listen` and `net.ListenUnixgram` call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
 owners without weakening the raw anti-growth ratchets.
@@ -32,8 +32,8 @@ calls inside `TestMain`, never sibling tests.
 This bootstrap does **not** infer resources recursively through arbitrary
 helper calls or claim a complete shared-resource inventory. P0.4c currently
 covers the three `net/http/httptest` constructors that open loopback servers
-and the exact package-level `net.Listen` constructor. The next listener
-families are `net.ListenUnixgram`, `net.ListenConfig.Listen`, and raw
+and the exact package-level `net.Listen` and `net.ListenUnixgram`
+constructors. The next listener families are `net.ListenConfig.Listen` and raw
 `syscall.Socket`/`Bind`/`Listen`; typed and packet-specific `net` constructors,
 helper-backed listeners whose constructors live outside test source, tmux,
 Dolt, and other shared-host resources remain explicit follow-up catalogs. A
@@ -43,7 +43,8 @@ calls in that exact runnable declaration leave Small-debt accounting.
 separately owns Large journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
-`time.Sleep`; package-level `net.Listen`; `net/http/httptest.NewServer`,
+`time.Sleep`; package-level `net.Listen` and `net.ListenUnixgram`;
+`net/http/httptest.NewServer`,
 `NewTLSServer`, and `NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`,
 `os.Clearenv`, and `os.Chdir`; and
 `Setenv` or `Chdir` on function parameters typed exactly as `*testing.T` or
@@ -100,6 +101,7 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
+| Small debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 374 calls / 97 files | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | cwd: 208 calls / 40 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | environment: 4092 calls / 180 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
@@ -107,6 +109,7 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
+| Source debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 374 calls / 97 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->
 

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -44,16 +44,19 @@ const (
 	ResourceHTTPTestServer Resource = "http_test_server"
 	// ResourceNetListen counts direct listeners opened by net.Listen.
 	ResourceNetListen Resource = "net_listen"
+	// ResourceNetListenUnixgram counts direct Unix datagram listeners opened by net.ListenUnixgram.
+	ResourceNetListenUnixgram Resource = "net_listen_unixgram"
 )
 
 var knownResources = map[Resource]struct{}{
-	ResourceSubprocess:      {},
-	ResourceFixedSleep:      {},
-	ResourceEnvironment:     {},
-	ResourceCWD:             {},
-	ResourceSlowProcessGate: {},
-	ResourceHTTPTestServer:  {},
-	ResourceNetListen:       {},
+	ResourceSubprocess:        {},
+	ResourceFixedSleep:        {},
+	ResourceEnvironment:       {},
+	ResourceCWD:               {},
+	ResourceSlowProcessGate:   {},
+	ResourceHTTPTestServer:    {},
+	ResourceNetListen:         {},
+	ResourceNetListenUnixgram: {},
 }
 
 // Scope selects the source population counted by a ledger row.
@@ -219,6 +222,19 @@ var bootstrapPolicy = Ledger{
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceNetListenUnixgram,
+			BaselineCalls:   3,
+			BaselineFiles:   2,
+			ReportedCalls:   3,
+			ReportedFiles:   2,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
 	},
 	Medium: []MediumOwner{
 		{
@@ -322,6 +338,19 @@ var bootstrapPolicy = Ledger{
 			OwnerBead:       "ga-80po0c.2.2",
 			Invariant:       "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceNetListenUnixgram,
+			BaselineCalls:   3,
+			BaselineFiles:   2,
+			ReportedCalls:   3,
+			ReportedFiles:   2,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener",
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
@@ -602,6 +631,13 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 			if matched {
 				census.add(source, candidate.owner, candidate.runnable, ResourceNetListen)
 			}
+			matched, err = isImportedCall(call, source.bindings, "net", "ListenUnixgram")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, candidate.owner, candidate.runnable, ResourceNetListenUnixgram)
+			}
 			matched, err = isImportedCall(call, source.bindings, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
@@ -831,7 +867,7 @@ func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner str
 		switch function := unparen(call.Fun).(type) {
 		case *ast.SelectorExpr:
 			switch function.Sel.Name {
-			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "NewServer", "NewTLSServer", "NewUnstartedServer":
+			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "ListenUnixgram", "NewServer", "NewTLSServer", "NewUnstartedServer":
 				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		case *ast.Ident:

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -238,6 +238,75 @@ func TestSiblingShadow() {
 	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListen, "TestTaggedNetListen", true, true)
 }
 
+func TestScanCountsNetListenUnixgramByImportIdentityAndRunnableOwnership(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	foreign "example.test/net"
+	sockets "net"
+	"testing"
+)
+
+type localNet struct{}
+func (localNet) ListenUnixgram(string, *sockets.UnixAddr) (any, error) { return nil, nil }
+
+func TestNetListenUnixgram(t *testing.T) {
+	_, _ = ((sockets.ListenUnixgram))("unixgram", nil)
+	t.Run("nested", func(t *testing.T) {
+		_, _ = (((sockets)).ListenUnixgram)("unixgram", nil)
+	})
+
+	local := localNet{}
+	_, _ = local.ListenUnixgram("unixgram", nil)
+	_, _ = foreign.ListenUnixgram("unixgram", nil)
+	lc := sockets.ListenConfig{}
+	_, _ = lc.Listen(t.Context(), "unixgram", "listen config method")
+	_, _ = sockets.ListenUnix("unixgram", nil)
+	_, _ = sockets.ListenUDP("udp", nil)
+	_ = "sockets.ListenUnixgram(\"unixgram\", nil)"
+	// sockets.ListenUnixgram("unixgram", nil)
+}
+
+func helper() {
+	_, _ = sockets.ListenUnixgram("unixgram", nil)
+}
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import (
+	sockets "net"
+	"testing"
+)
+func TestTaggedNetListenUnixgram(t *testing.T) {
+	_, _ = sockets.ListenUnixgram("unixgram", nil)
+}
+`)},
+		"shadow/shadow.go": &fstest.MapFile{Data: []byte(`package shadow
+type localNet struct{}
+func (localNet) ListenUnixgram(string, any) (any, error) { return nil, nil }
+var sockets localNet
+`)},
+		"shadow/resources_test.go": &fstest.MapFile{Data: []byte(`package shadow
+func TestSiblingShadow() {
+	_, _ = sockets.ListenUnixgram("unixgram", nil)
+}
+`)},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeAll, ResourceNetListenUnixgram, 4, 2)
+	assertCount(t, got, ScopeUntagged, ResourceNetListenUnixgram, 3, 1)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenUnixgram, "TestNetListenUnixgram", true, false)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenUnixgram, "helper", false, false)
+	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListenUnixgram, "TestTaggedNetListenUnixgram", true, true)
+}
+
 func TestScanCountsCmdGCProcessGlobalsByLexicalOwnership(t *testing.T) {
 	t.Parallel()
 
@@ -1302,6 +1371,20 @@ func TestBootstrapPolicyOwnsNetListenDebt(t *testing.T) {
 		}
 		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
 			t.Fatalf("net.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		}
+	}
+}
+
+func TestBootstrapPolicyOwnsNetListenUnixgramDebt(t *testing.T) {
+	t.Parallel()
+
+	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
+		row := findRow(t, rows, ScopeUntagged, ResourceNetListenUnixgram)
+		if row.BaselineCalls != 3 || row.BaselineFiles != 2 {
+			t.Fatalf("net.ListenUnixgram baseline = %d/%d, want 3/2", row.BaselineCalls, row.BaselineFiles)
+		}
+		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
+			t.Fatalf("net.ListenUnixgram owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
 		}
 	}
 }

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -126,6 +126,19 @@ resource_owner = "each owning test closes its listener and removes duplicate lis
 migration_target = "P0.4c"
 expires = "2026-10-01"
 
+[[debt]]
+scope = "untagged"
+resource = "net_listen_unixgram"
+baseline_calls = 3
+baseline_files = 2
+reported_calls = 3
+reported_files = 2
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
 # Exact Medium owners are keyed by source directory, package clause, and
 # top-level Go test identity. Only matching resources lexically inside that
 # declaration leave the Small-debt census; helper bodies and sibling tests do
@@ -231,5 +244,18 @@ reported_files = 34
 owner_bead = "ga-80po0c.2.2"
 invariant = "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "net_listen_unixgram"
+baseline_calls = 3
+baseline_files = 2
+reported_calls = 3
+reported_files = 2
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener"
 migration_target = "P0.4c"
 expires = "2026-10-01"


### PR DESCRIPTION
## Summary

- classify direct package-level `net.ListenUnixgram` resource ownership by import identity
- freeze the current untagged and Small debt at 3 calls across 2 files
- exclude local and foreign shadows plus adjacent listener APIs
- keep the bootstrap policy, TOML ledger, and generated testing guide in lockstep

## Verification

- RED/GREEN scanner and bootstrap-policy proofs
- full resource-census package and race tests
- repository-ledger/documentation sync test
- `make lint-changed`
- `go vet ./...`
- `make test-fast-parallel`
- pre-commit and pre-push hooks
- three delegated council lanes CLEAR on tree `e65915c8353917da89cd6b8fd542073490ad882b`

Behavior-neutral test-policy slice; no production runtime path changes.