### PR TITLE
test(policy): ratchet syscall listener debt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,8 @@
 Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
 freeze process, sleep, environment, CWD, slow-process, HTTP test-server, and
-package-level `net.Listen` and `net.ListenUnixgram` call/file totals.
+package-level `net.Listen`, `net.ListenUnixgram`, and direct `syscall.Listen`
+call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
 owners without weakening the raw anti-growth ratchets.
@@ -33,18 +34,19 @@ This bootstrap does **not** infer resources recursively through arbitrary
 helper calls or claim a complete shared-resource inventory. P0.4c currently
 covers the three `net/http/httptest` constructors that open loopback servers
 and the exact package-level `net.Listen` and `net.ListenUnixgram`
-constructors. The next listener families are `net.ListenConfig.Listen` and raw
-`syscall.Socket`/`Bind`/`Listen`; typed and packet-specific `net` constructors,
-helper-backed listeners whose constructors live outside test source, tmux,
-Dolt, and other shared-host resources remain explicit follow-up catalogs. A
-Medium resource may describe a helper-backed runtime cost, but only syntax-owned
-calls in that exact runnable declaration leave Small-debt accounting.
+constructors plus direct `syscall.Listen`. The next listener family is
+`net.ListenConfig.Listen`; direct `syscall.Socket`/`Bind` setup calls, typed and
+packet-specific `net` constructors, helper-backed listeners whose constructors
+live outside test source, tmux, Dolt, and other shared-host resources remain
+explicit follow-up catalogs. A Medium resource may describe a helper-backed
+runtime cost, but only syntax-owned calls in that exact runnable declaration
+leave Small-debt accounting.
 `ga-80po0c.2.2` owns the listener, tmux, Dolt, and shared-host catalogs. E1
 separately owns Large journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
 `time.Sleep`; package-level `net.Listen` and `net.ListenUnixgram`;
-`net/http/httptest.NewServer`,
+direct `syscall.Listen`; `net/http/httptest.NewServer`,
 `NewTLSServer`, and `NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`,
 `os.Clearenv`, and `os.Chdir`; and
 `Setenv` or `Chdir` on function parameters typed exactly as `*testing.T` or
@@ -57,8 +59,8 @@ directory and package so cross-file shadows do not masquerade as resources.
 Local shadows and wrong signatures do not count. Parenthesized call
 expressions retain the same ownership.
 
-Targeted dot imports of `net`, `os/exec`, `time`, `os`, `testing`, or
-`net/http/httptest` are rejected with file and import context because their
+Targeted dot imports of `net`, `os/exec`, `time`, `os`, `syscall`, `testing`,
+or `net/http/httptest` are rejected with file and import context because their
 resources cannot be attributed safely; blank imports remain harmless.
 Explicit constraints follow Go's leading-header
 rules: a pre-package `//go:build` line is effective, while a legacy
@@ -103,6 +105,7 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 374 calls / 97 files | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
+| Small debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | cwd: 208 calls / 40 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | environment: 4092 calls / 180 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 77 calls / 26 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
@@ -111,6 +114,7 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 374 calls / 97 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
+| Source debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged syscall.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listening file descriptor and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 <!-- END CHECKED TEST RESOURCE LEDGER -->
 
 ## Three tiers, clear boundaries

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -46,6 +46,8 @@ const (
 	ResourceNetListen Resource = "net_listen"
 	// ResourceNetListenUnixgram counts direct Unix datagram listeners opened by net.ListenUnixgram.
 	ResourceNetListenUnixgram Resource = "net_listen_unixgram"
+	// ResourceSyscallListen counts direct calls that put sockets into listening state through syscall.Listen.
+	ResourceSyscallListen Resource = "syscall_listen"
 )
 
 var knownResources = map[Resource]struct{}{
@@ -57,6 +59,7 @@ var knownResources = map[Resource]struct{}{
 	ResourceHTTPTestServer:    {},
 	ResourceNetListen:         {},
 	ResourceNetListenUnixgram: {},
+	ResourceSyscallListen:     {},
 }
 
 // Scope selects the source population counted by a ledger row.
@@ -235,6 +238,19 @@ var bootstrapPolicy = Ledger{
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceSyscallListen,
+			BaselineCalls:   1,
+			BaselineFiles:   1,
+			ReportedCalls:   1,
+			ReportedFiles:   1,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged syscall.Listen call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test closes its listening file descriptor and removes duplicate listener-backed coverage",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
 	},
 	Medium: []MediumOwner{
 		{
@@ -351,6 +367,19 @@ var bootstrapPolicy = Ledger{
 			OwnerBead:       "ga-80po0c.2.2",
 			Invariant:       "untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceSyscallListen,
+			BaselineCalls:   1,
+			BaselineFiles:   1,
+			ReportedCalls:   1,
+			ReportedFiles:   1,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener",
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
@@ -638,6 +667,13 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 			if matched {
 				census.add(source, candidate.owner, candidate.runnable, ResourceNetListenUnixgram)
 			}
+			matched, err = isImportedCall(call, source.bindings, "syscall", "Listen")
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, candidate.owner, candidate.runnable, ResourceSyscallListen)
+			}
 			matched, err = isImportedCall(call, source.bindings, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer")
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
@@ -836,7 +872,7 @@ func validateImports(file *ast.File) error {
 			continue
 		}
 		if spec.Name != nil && spec.Name.Name == "." {
-			if importPath == "net" || importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "testing" || importPath == "net/http/httptest" {
+			if importPath == "net" || importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "syscall" || importPath == "testing" || importPath == "net/http/httptest" {
 				return fmt.Errorf("targeted dot import %q cannot be counted safely", importPath)
 			}
 		}

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -307,6 +307,73 @@ func TestSiblingShadow() {
 	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListenUnixgram, "TestTaggedNetListenUnixgram", true, true)
 }
 
+func TestScanCountsSyscallListenByImportIdentityAndRunnableOwnership(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	foreign "example.test/syscall"
+	calls "syscall"
+	"testing"
+)
+
+type localSyscall struct{}
+func (localSyscall) Listen(int, int) error { return nil }
+
+func TestSyscallListen(t *testing.T) {
+	_ = ((calls.Listen))(1, 1)
+	t.Run("nested", func(t *testing.T) {
+		_ = (((calls)).Listen)(2, 1)
+	})
+
+	local := localSyscall{}
+	_ = local.Listen(3, 1)
+	_ = foreign.Listen(4, 1)
+	_, _ = calls.Socket(calls.AF_UNIX, calls.SOCK_STREAM, 0)
+	_ = calls.Bind(5, nil)
+	_ = "calls.Listen(6, 1)"
+	// calls.Listen(7, 1)
+}
+
+func helper() {
+	_ = calls.Listen(8, 1)
+}
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import (
+	calls "syscall"
+	"testing"
+)
+func TestTaggedSyscallListen(t *testing.T) {
+	_ = calls.Listen(9, 1)
+}
+`)},
+		"shadow/shadow.go": &fstest.MapFile{Data: []byte(`package shadow
+type localSyscall struct{}
+func (localSyscall) Listen(int, int) error { return nil }
+var calls localSyscall
+`)},
+		"shadow/resources_test.go": &fstest.MapFile{Data: []byte(`package shadow
+func TestSiblingShadow() {
+	_ = calls.Listen(10, 1)
+}
+`)},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeAll, ResourceSyscallListen, 4, 2)
+	assertCount(t, got, ScopeUntagged, ResourceSyscallListen, 3, 1)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceSyscallListen, "TestSyscallListen", true, false)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceSyscallListen, "helper", false, false)
+	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceSyscallListen, "TestTaggedSyscallListen", true, true)
+}
+
 func TestScanCountsCmdGCProcessGlobalsByLexicalOwnership(t *testing.T) {
 	t.Parallel()
 
@@ -924,6 +991,15 @@ import . "net/http/httptest"
 func TestResource() { _ = NewServer(nil) }
 `,
 		},
+		{
+			name:       "syscall",
+			path:       "sample/dot_syscall_test.go",
+			importPath: "syscall",
+			source: `package sample
+import . "syscall"
+func TestResource() { _ = Listen(1, 1) }
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -946,6 +1022,7 @@ import (
 	_ "net/http/httptest"
 	_ "os"
 	_ "os/exec"
+	_ "syscall"
 	_ "testing"
 	_ "time"
 )
@@ -1385,6 +1462,20 @@ func TestBootstrapPolicyOwnsNetListenUnixgramDebt(t *testing.T) {
 		}
 		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
 			t.Fatalf("net.ListenUnixgram owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		}
+	}
+}
+
+func TestBootstrapPolicyOwnsSyscallListenDebt(t *testing.T) {
+	t.Parallel()
+
+	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
+		row := findRow(t, rows, ScopeUntagged, ResourceSyscallListen)
+		if row.BaselineCalls != 1 || row.BaselineFiles != 1 {
+			t.Fatalf("syscall.Listen baseline = %d/%d, want 1/1", row.BaselineCalls, row.BaselineFiles)
+		}
+		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
+			t.Fatalf("syscall.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
 		}
 	}
 }

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -139,6 +139,19 @@ resource_owner = "each owning test closes its Unix datagram listener and removes
 migration_target = "P0.4c"
 expires = "2026-10-01"
 
+[[debt]]
+scope = "untagged"
+resource = "syscall_listen"
+baseline_calls = 1
+baseline_files = 1
+reported_calls = 1
+reported_files = 1
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged syscall.Listen call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test closes its listening file descriptor and removes duplicate listener-backed coverage"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
 # Exact Medium owners are keyed by source directory, package clause, and
 # top-level Go test identity. Only matching resources lexically inside that
 # declaration leave the Small-debt census; helper bodies and sibling tests do
@@ -257,5 +270,18 @@ reported_files = 2
 owner_bead = "ga-80po0c.2.2"
 invariant = "untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "syscall_listen"
+baseline_calls = 1
+baseline_files = 1
+reported_calls = 1
+reported_files = 1
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener"
 migration_target = "P0.4c"
 expires = "2026-10-01"


### PR DESCRIPTION
## Summary

- classify direct `syscall.Listen` resource ownership by import identity
- freeze the current untagged and Small debt at 1 call in 1 file
- reject targeted `syscall` dot imports while preserving harmless blank imports
- exclude local and foreign shadows plus adjacent `Socket` and `Bind` setup calls
- keep bootstrap policy, TOML ledger, and generated testing guide in lockstep

## Verification

- RED/GREEN scanner, dot-import, and bootstrap-policy proofs
- full resource-census package and race tests
- real owning `cmd/gc` socket-table test
- repository-ledger/documentation sync test
- `make lint-changed`, `go vet ./...`, and `make test-fast-parallel`
- pre-commit and pre-push hooks
- three delegated council lanes CLEAR on corrected tree `7c1b863eec9267e12578a39e248154cb0f3bf835`

The first council correctly rejected inaccurate raw-socket wording; the revised tree says `syscall.Listen` puts an existing socket into listening state and classifies syscall-backed listener tests.

Behavior-neutral test-policy slice; no production runtime path changes.