### PR TITLE
test(policy): ratchet ListenConfig listener debt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -6,8 +6,8 @@
 Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
 freeze process, sleep, environment, CWD, slow-process, HTTP test-server, and
-package-level `net.Listen`, `net.ListenUnixgram`, and direct `syscall.Listen`
-call/file totals.
+package-level `net.Listen`, `net.ListenConfig.Listen`, `net.ListenUnixgram`,
+and direct `syscall.Listen` call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
 owners without weakening the raw anti-growth ratchets.
@@ -33,20 +33,24 @@ calls inside `TestMain`, never sibling tests.
 This bootstrap does **not** infer resources recursively through arbitrary
 helper calls or claim a complete shared-resource inventory. P0.4c currently
 covers the three `net/http/httptest` constructors that open loopback servers
-and the exact package-level `net.Listen` and `net.ListenUnixgram`
-constructors plus direct `syscall.Listen`. The next listener family is
-`net.ListenConfig.Listen`; direct `syscall.Socket`/`Bind` setup calls, typed and
+and the exact package-level `net.Listen` and `net.ListenUnixgram` constructors,
+`net.ListenConfig.Listen` on lexically identified receivers, and direct
+`syscall.Listen`. Direct `syscall.Socket`/`Bind` setup calls, typed and
 packet-specific `net` constructors, helper-backed listeners whose constructors
 live outside test source, tmux, Dolt, and other shared-host resources remain
 explicit follow-up catalogs. A Medium resource may describe a helper-backed
 runtime cost, but only syntax-owned calls in that exact runnable declaration
-leave Small-debt accounting.
+leave Small-debt accounting. The `ListenConfig` matcher uses lexical Go types
+to follow same-file values, pointers, parameters, aliases, and typed factory
+results rooted in the imported `net.ListenConfig` type; it does not load
+cross-file package bodies or host toolchain export data.
 `ga-80po0c.2.2` owns the listener, tmux, Dolt, and shared-host catalogs. E1
 separately owns Large journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
 `time.Sleep`; package-level `net.Listen` and `net.ListenUnixgram`;
-direct `syscall.Listen`; `net/http/httptest.NewServer`,
+`net.ListenConfig.Listen` on identified receivers; direct `syscall.Listen`;
+`net/http/httptest.NewServer`,
 `NewTLSServer`, and `NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`,
 `os.Clearenv`, and `os.Chdir`; and
 `Setenv` or `Chdir` on function parameters typed exactly as `*testing.T` or
@@ -103,6 +107,7 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
+| Small debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 374 calls / 97 files | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
@@ -112,6 +117,7 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | all untagged test source | fixed_sleep: 284 calls / 110 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | http_test_server: 255 calls / 56 files | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
+| Source debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its configured listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 374 calls / 97 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged syscall.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listening file descriptor and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -46,6 +46,8 @@ const (
 	ResourceNetListen Resource = "net_listen"
 	// ResourceNetListenUnixgram counts direct Unix datagram listeners opened by net.ListenUnixgram.
 	ResourceNetListenUnixgram Resource = "net_listen_unixgram"
+	// ResourceNetListenConfig counts direct listeners opened through net.ListenConfig.Listen.
+	ResourceNetListenConfig Resource = "net_listen_config"
 	// ResourceSyscallListen counts direct calls that put sockets into listening state through syscall.Listen.
 	ResourceSyscallListen Resource = "syscall_listen"
 )
@@ -58,6 +60,7 @@ var knownResources = map[Resource]struct{}{
 	ResourceSlowProcessGate:   {},
 	ResourceHTTPTestServer:    {},
 	ResourceNetListen:         {},
+	ResourceNetListenConfig:   {},
 	ResourceNetListenUnixgram: {},
 	ResourceSyscallListen:     {},
 }
@@ -227,6 +230,19 @@ var bootstrapPolicy = Ledger{
 		},
 		{
 			Scope:           ScopeUntagged,
+			Resource:        ResourceNetListenConfig,
+			BaselineCalls:   1,
+			BaselineFiles:   1,
+			ReportedCalls:   1,
+			ReportedFiles:   1,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test closes its configured listener and removes duplicate listener-backed coverage",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
 			Resource:        ResourceNetListenUnixgram,
 			BaselineCalls:   3,
 			BaselineFiles:   2,
@@ -354,6 +370,19 @@ var bootstrapPolicy = Ledger{
 			OwnerBead:       "ga-80po0c.2.2",
 			Invariant:       "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener",
+			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceNetListenConfig,
+			BaselineCalls:   1,
+			BaselineFiles:   1,
+			ReportedCalls:   1,
+			ReportedFiles:   1,
+			OwnerBead:       "ga-80po0c.2.2",
+			Invariant:       "untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener",
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
@@ -489,6 +518,7 @@ type parsedFile struct {
 type bindingInfo struct {
 	defs                       map[*ast.Ident]types.Object
 	uses                       map[*ast.Ident]types.Object
+	expressionTypes            map[ast.Expr]types.TypeAndValue
 	packageDeclarations        map[string]struct{}
 	unresolvedImportQualifiers map[string]struct{}
 }
@@ -517,6 +547,14 @@ func (importer *emptyPackageImporter) Import(importPath string) (*types.Package,
 		return imported, nil
 	}
 	imported := types.NewPackage(importPath, path.Base(importPath))
+	if importPath == "net" {
+		// Seed only the receiver type the census needs so go/types can carry
+		// ListenConfig identity through pointers and aliases without loading
+		// host toolchain export data.
+		name := types.NewTypeName(token.NoPos, imported, "ListenConfig", nil)
+		types.NewNamed(name, types.NewStruct(nil, nil), nil)
+		imported.Scope().Insert(name)
+	}
 	imported.MarkComplete()
 	importer.packages[importPath] = imported
 	return imported, nil
@@ -659,6 +697,13 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 			}
 			if matched {
 				census.add(source, candidate.owner, candidate.runnable, ResourceNetListen)
+			}
+			matched, err = isNetListenConfigCall(call, source.bindings)
+			if err != nil {
+				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
+			}
+			if matched {
+				census.add(source, candidate.owner, candidate.runnable, ResourceNetListenConfig)
 			}
 			matched, err = isImportedCall(call, source.bindings, "net", "ListenUnixgram")
 			if err != nil {
@@ -1014,8 +1059,14 @@ func uniqueSortedRunnables(runnables []RunnableOwner) []RunnableOwner {
 
 func resolveBindings(fileSet *token.FileSet, file *ast.File, importer types.Importer, packagePath string) bindingInfo {
 	info := bindingInfo{
-		defs: make(map[*ast.Ident]types.Object),
-		uses: make(map[*ast.Ident]types.Object),
+		defs:            make(map[*ast.Ident]types.Object),
+		uses:            make(map[*ast.Ident]types.Object),
+		expressionTypes: make(map[ast.Expr]types.TypeAndValue),
+	}
+	receivers := netListenReceiverExpressions(file)
+	var checkedExpressionTypes map[ast.Expr]types.TypeAndValue
+	if len(receivers) > 0 {
+		checkedExpressionTypes = make(map[ast.Expr]types.TypeAndValue)
 	}
 	config := types.Config{
 		Importer:                 importer,
@@ -1023,8 +1074,45 @@ func resolveBindings(fileSet *token.FileSet, file *ast.File, importer types.Impo
 		IgnoreFuncBodies:         false,
 		Error:                    func(error) {},
 	}
-	_, _ = config.Check(packagePath, fileSet, []*ast.File{file}, &types.Info{Defs: info.defs, Uses: info.uses})
+	_, _ = config.Check(packagePath, fileSet, []*ast.File{file}, &types.Info{
+		Defs:  info.defs,
+		Uses:  info.uses,
+		Types: checkedExpressionTypes,
+	})
+	for _, receiver := range receivers {
+		if typeAndValue, ok := checkedExpressionTypes[receiver]; ok {
+			info.expressionTypes[receiver] = typeAndValue
+		}
+	}
 	return info
+}
+
+func netListenReceiverExpressions(file *ast.File) []ast.Expr {
+	hasNetImport := false
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err == nil && importPath == "net" && (spec.Name == nil || spec.Name.Name != "_") {
+			hasNetImport = true
+			break
+		}
+	}
+	if !hasNetImport {
+		return nil
+	}
+
+	var receivers []ast.Expr
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := unparen(call.Fun).(*ast.SelectorExpr)
+		if ok && selector.Sel.Name == "Listen" {
+			receivers = append(receivers, unparen(selector.X))
+		}
+		return true
+	})
+	return receivers
 }
 
 func recordPackageDeclarations(file *ast.File, declarations map[string]struct{}) {
@@ -1141,6 +1229,71 @@ func testingParameterObjects(file *ast.File, bindings bindingInfo) (map[types.Ob
 		return true
 	})
 	return objects, inspectErr
+}
+
+func isNetListenConfigType(expression ast.Expr, bindings bindingInfo) (bool, error) {
+	if expression == nil {
+		return false, nil
+	}
+	expression = unparen(expression)
+	if pointer, ok := expression.(*ast.StarExpr); ok {
+		expression = pointer.X
+	}
+	return isImportedType(expression, bindings, "net", "ListenConfig")
+}
+
+func isNetListenConfigValue(expression ast.Expr, bindings bindingInfo) (bool, error) {
+	expression = unparen(expression)
+	if address, ok := expression.(*ast.UnaryExpr); ok && address.Op == token.AND {
+		expression = unparen(address.X)
+	}
+	composite, ok := expression.(*ast.CompositeLit)
+	if !ok {
+		return false, nil
+	}
+	return isNetListenConfigType(composite.Type, bindings)
+}
+
+func isNetListenConfigCall(call *ast.CallExpr, bindings bindingInfo) (bool, error) {
+	selector, ok := unparen(call.Fun).(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Listen" {
+		return false, nil
+	}
+	receiver := unparen(selector.X)
+	if typeAndValue, ok := bindings.expressionTypes[receiver]; ok && typeAndValue.Type != nil {
+		return isNetListenConfigObjectType(typeAndValue.Type), nil
+	}
+	direct, err := isNetListenConfigValue(receiver, bindings)
+	if err != nil || direct {
+		return direct, err
+	}
+	identifier, ok := receiver.(*ast.Ident)
+	if !ok {
+		return false, nil
+	}
+	object := bindings.uses[identifier]
+	if object == nil {
+		if _, declared := bindings.packageDeclarations[identifier.Name]; declared {
+			return false, nil
+		}
+		if _, imported := bindings.unresolvedImportQualifiers[identifier.Name]; imported {
+			return false, nil
+		}
+		return false, fmt.Errorf("net.ListenConfig receiver %q has no lexical binding", identifier.Name)
+	}
+	return isNetListenConfigObjectType(object.Type()), nil
+}
+
+func isNetListenConfigObjectType(objectType types.Type) bool {
+	objectType = types.Unalias(objectType)
+	if pointer, ok := objectType.(*types.Pointer); ok {
+		objectType = types.Unalias(pointer.Elem())
+	}
+	named, ok := objectType.(*types.Named)
+	if !ok || named.Obj().Pkg() == nil {
+		return false
+	}
+	return named.Obj().Name() == "ListenConfig" && named.Obj().Pkg().Path() == "net"
 }
 
 func isTestingParameterType(expression ast.Expr, bindings bindingInfo) (bool, error) {

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -3,6 +3,7 @@ package resourcecensus
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"io/fs"
@@ -372,6 +373,143 @@ func TestSiblingShadow() {
 	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceSyscallListen, "TestSyscallListen", true, false)
 	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceSyscallListen, "helper", false, false)
 	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceSyscallListen, "TestTaggedSyscallListen", true, true)
+}
+
+func TestScanCountsNetListenConfigByReceiverIdentityAndRunnableOwnership(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	foreign "example.test/net"
+	sockets "net"
+	"testing"
+)
+
+type localListenConfig struct{}
+func (localListenConfig) Listen(any, string, string) (any, error) { return nil, nil }
+func newListenConfig() sockets.ListenConfig { return sockets.ListenConfig{} }
+func newListenConfigPointer() *sockets.ListenConfig { return &sockets.ListenConfig{} }
+type listenConfigAlias = sockets.ListenConfig
+
+func TestNetListenConfig(t *testing.T) {
+	value := sockets.ListenConfig{}
+	_, _ = ((value.Listen))(nil, "tcp", "127.0.0.1:0")
+	pointer := &sockets.ListenConfig{}
+	_, _ = pointer.Listen(nil, "tcp", "127.0.0.1:0")
+	var typed sockets.ListenConfig
+	_, _ = typed.Listen(nil, "tcp", "127.0.0.1:0")
+	var typedPointer *sockets.ListenConfig
+	_, _ = typedPointer.Listen(nil, "tcp", "127.0.0.1:0")
+	alias := value
+	_, _ = alias.Listen(nil, "tcp", "127.0.0.1:0")
+	factory := newListenConfig()
+	_, _ = factory.Listen(nil, "tcp", "127.0.0.1:0")
+	_, _ = newListenConfigPointer().Listen(nil, "tcp", "127.0.0.1:0")
+	_, _ = new(sockets.ListenConfig).Listen(nil, "tcp", "127.0.0.1:0")
+	holder := struct{ Config sockets.ListenConfig }{}
+	_, _ = holder.Config.Listen(nil, "tcp", "127.0.0.1:0")
+	configs := []sockets.ListenConfig{{}}
+	_, _ = configs[0].Listen(nil, "tcp", "127.0.0.1:0")
+	_, _ = (&listenConfigAlias{}).Listen(nil, "tcp", "127.0.0.1:0")
+	_, _ = (&sockets.ListenConfig{}).Listen(nil, "tcp", "127.0.0.1:0")
+
+	local := localListenConfig{}
+	_, _ = local.Listen(nil, "tcp", "local shadow")
+	foreignConfig := foreign.ListenConfig{}
+	_, _ = foreignConfig.Listen(nil, "tcp", "foreign package")
+	_, _ = value.ListenPacket(nil, "udp", "127.0.0.1:0")
+	_, _ = sockets.Listen("tcp", "127.0.0.1:0")
+	_ = "value.Listen(nil, \"tcp\", \"string literal\")"
+	// value.Listen(nil, "tcp", "comment")
+}
+
+func helper(config sockets.ListenConfig) {
+	_, _ = config.Listen(nil, "tcp", "127.0.0.1:0")
+}
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import (
+	sockets "net"
+	"testing"
+)
+func TestTaggedNetListenConfig(t *testing.T) {
+	config := sockets.ListenConfig{}
+	_, _ = config.Listen(nil, "tcp", "127.0.0.1:0")
+}
+`)},
+		"shadow/shadow.go": &fstest.MapFile{Data: []byte(`package shadow
+type localListenConfig struct{}
+func (localListenConfig) Listen(any, string, string) (any, error) { return nil, nil }
+var config localListenConfig
+`)},
+		"shadow/resources_test.go": &fstest.MapFile{Data: []byte(`package shadow
+func TestSiblingShadow() {
+	_, _ = config.Listen(nil, "tcp", "cross-file shadow")
+}
+`)},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeAll, ResourceNetListenConfig, 14, 2)
+	assertCount(t, got, ScopeUntagged, ResourceNetListenConfig, 13, 1)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenConfig, "TestNetListenConfig", true, false)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenConfig, "helper", false, false)
+	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListenConfig, "TestTaggedNetListenConfig", true, true)
+}
+
+func TestResolveBindingsRetainsOnlyNetListenReceiverTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{
+			name: "net Listen receiver only",
+			source: `package sample
+import sockets "net"
+func exercise() {
+	config := sockets.ListenConfig{}
+	_ = 1 + 2
+	_, _ = config.Listen(nil, "tcp", "127.0.0.1:0")
+}
+`,
+			want: 1,
+		},
+		{
+			name: "no net import",
+			source: `package sample
+type localConfig struct{}
+func (localConfig) Listen(any, string, string) (any, error) { return nil, nil }
+func exercise() {
+	config := localConfig{}
+	_ = 1 + 2
+	_, _ = config.Listen(nil, "tcp", "local")
+}
+`,
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileSet := token.NewFileSet()
+			file, err := parser.ParseFile(fileSet, "sample/resources_test.go", tt.source, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("ParseFile: %v", err)
+			}
+			bindings := resolveBindings(fileSet, file, newEmptyPackageImporter(), "resourcecensus.local/test")
+			if got := len(bindings.expressionTypes); got != tt.want {
+				t.Fatalf("retained expression types = %d, want %d", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestScanCountsCmdGCProcessGlobalsByLexicalOwnership(t *testing.T) {
@@ -1448,6 +1586,20 @@ func TestBootstrapPolicyOwnsNetListenDebt(t *testing.T) {
 		}
 		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
 			t.Fatalf("net.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		}
+	}
+}
+
+func TestBootstrapPolicyOwnsNetListenConfigDebt(t *testing.T) {
+	t.Parallel()
+
+	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
+		row := findRow(t, rows, ScopeUntagged, ResourceNetListenConfig)
+		if row.BaselineCalls != 1 || row.BaselineFiles != 1 {
+			t.Fatalf("net.ListenConfig.Listen baseline = %d/%d, want 1/1", row.BaselineCalls, row.BaselineFiles)
+		}
+		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
+			t.Fatalf("net.ListenConfig.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
 		}
 	}
 }

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -128,6 +128,19 @@ expires = "2026-10-01"
 
 [[debt]]
 scope = "untagged"
+resource = "net_listen_config"
+baseline_calls = 1
+baseline_files = 1
+reported_calls = 1
+reported_files = 1
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test closes its configured listener and removes duplicate listener-backed coverage"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[debt]]
+scope = "untagged"
 resource = "net_listen_unixgram"
 baseline_calls = 3
 baseline_files = 2
@@ -257,6 +270,19 @@ reported_files = 34
 owner_bead = "ga-80po0c.2.2"
 invariant = "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener"
+migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "net_listen_config"
+baseline_calls = 1
+baseline_files = 1
+reported_calls = 1
+reported_files = 1
+owner_bead = "ga-80po0c.2.2"
+invariant = "untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener"
 migration_target = "P0.4c"
 expires = "2026-10-01"
 


### PR DESCRIPTION
## Summary
- add an exact repository census for net.ListenConfig.Listen calls
- lock the current baseline at one call in one file
- document the listener ownership policy in TESTING.md

## Verification
- focused resource-census tests and repeated/race runs
- repository census and real Dolt health tests
- make test-fast-parallel
- go vet ./...
- Darwin and Windows cross-compilation
- delegated three-lane correctness, policy, and performance review: clear