### PR TITLE
fix(release): prevent false dirty version stamps

### DIFF
--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -382,11 +382,20 @@ jobs:
           dolt-version: ${{ env.DOLT_VERSION }}
           bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "false"
+      - name: Verify release output is ignored
+        run: make check-release-dist-ignore
       - name: Run GoReleaser snapshot
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           version: "~> v2"
           args: release --snapshot --clean
+      - name: Verify release binary metadata
+        run: |
+          set -euo pipefail
+          expected_commit="$(git rev-parse HEAD)"
+          scripts/verify-release-binary-metadata.sh \
+            dist/gascity_linux_amd64_v1/gc \
+            "$expected_commit"
       - name: Upload GoReleaser dist
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Verify release tag is stable
         run: make check-version-tag
 
+      - name: Verify release output is ignored
+        run: make check-release-dist-ignore
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
@@ -52,6 +55,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+
+      - name: Verify release binary metadata
+        run: |
+          set -euo pipefail
+          expected_commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+          scripts/verify-release-binary-metadata.sh \
+            dist/gascity_linux_amd64_v1/gc \
+            "$expected_commit" \
+            "${GITHUB_REF_NAME#v}"
 
   attest-release:
     name: Attest release

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.noncmdgc.txt
 coverage.cmdgc.*.txt
 cmd/gc/.runtime/
 /bin/
+/dist/
 /gc
 /genschema
 /bd

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ endif
 endif
 
 .PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go
+.PHONY: check-release-dist-ignore
 
 ## build: compile gc binary with version metadata
 build:
@@ -109,7 +110,22 @@ clean:
 	rm -f $(BUILD_DIR)/$(BINARY)
 
 ## check: run fast quality gates (pre-commit: unit tests only)
-check: fmt-check lint vet check-routed-test-rows test
+check: fmt-check lint vet check-release-dist-ignore check-routed-test-rows test
+
+## check-release-dist-ignore: keep GoReleaser output from marking release builds dirty
+check-release-dist-ignore:
+	@ tracked=$$(git ls-files -- dist); \
+	if [ -n "$$tracked" ]; then \
+		echo "ERROR: release output is tracked:" >&2; \
+		echo "$$tracked" >&2; \
+		exit 1; \
+	fi; \
+	if git check-ignore --no-index -q dist/metadata.json; then \
+		echo "check-release-dist-ignore: OK (/dist/ is ignored)"; \
+	else \
+		echo "ERROR: dist/metadata.json is not ignored; GoReleaser builds will report vcs.modified=true" >&2; \
+		exit 1; \
+	fi
 
 ## check-routed-test-rows: enforce the six-row matrix on read-path routed tests
 ## Prevents per-file read-path migrations (ga-h6w) from regressing below the
@@ -179,7 +195,7 @@ check-version-tag:
 	exit 1
 
 ## check-all: run all quality gates including integration tests (CI)
-check-all: fmt-check lint vet check-bd check-dolt check-docker test-integration check-docs
+check-all: fmt-check lint vet check-release-dist-ignore check-bd check-dolt check-docker test-integration check-docs
 
 LINT_BASE ?= origin/main
 LINT_CHANGED_REF ?= HEAD

--- a/scripts/ci_critical_path_test.go
+++ b/scripts/ci_critical_path_test.go
@@ -618,6 +618,98 @@ func TestPackGateAddsOnlyParallelPackCoverage(t *testing.T) {
 	}
 }
 
+func TestGoReleaserOutputCannotDirtyReleaseBuilds(t *testing.T) {
+	gitignorePath := filepath.Join(repoRoot(t), ".gitignore")
+	body, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", gitignorePath, err)
+	}
+
+	var ignoresRootDist bool
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.TrimSpace(line) == "/dist/" {
+			ignoresRootDist = true
+			break
+		}
+	}
+	if !ignoresRootDist {
+		t.Fatal("root .gitignore must contain anchored /dist/ so GoReleaser metadata cannot set vcs.modified=true")
+	}
+}
+
+func TestReleasePipelinesVerifyExactBinaryMetadata(t *testing.T) {
+	tests := []struct {
+		name               string
+		workflow           string
+		job                string
+		wantCommitResolver string
+		wantVersionArg     string
+	}{
+		{
+			name:               "release",
+			workflow:           "release.yml",
+			job:                "release",
+			wantCommitResolver: `git rev-parse "${GITHUB_REF_NAME}^{commit}"`,
+			wantVersionArg:     `"${GITHUB_REF_NAME#v}"`,
+		},
+		{
+			name:               "rc gate snapshot",
+			workflow:           "rc-gate.yml",
+			job:                "ubuntu_goreleaser_snapshot",
+			wantCommitResolver: "git rev-parse HEAD",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := readCriticalPathWorkflow(t, tt.workflow)
+			job, ok := wf.Jobs[tt.job]
+			if !ok {
+				t.Fatalf("workflow %s has no %s job", tt.workflow, tt.job)
+			}
+
+			goreleaserIndex := -1
+			ignoreCheckIndex := -1
+			metadataCheckIndex := -1
+			var metadataCheck ciCriticalPathStep
+			for i, step := range job.Steps {
+				if strings.HasPrefix(step.Uses, "goreleaser/goreleaser-action@") {
+					goreleaserIndex = i
+				}
+				if strings.Contains(step.Run, "make check-release-dist-ignore") {
+					ignoreCheckIndex = i
+				}
+				if step.Name == "Verify release binary metadata" {
+					metadataCheckIndex = i
+					metadataCheck = step
+				}
+			}
+
+			if goreleaserIndex < 0 {
+				t.Fatal("GoReleaser step not found")
+			}
+			if ignoreCheckIndex < 0 || ignoreCheckIndex >= goreleaserIndex {
+				t.Fatalf("release-output ignore check index = %d, want before GoReleaser index %d", ignoreCheckIndex, goreleaserIndex)
+			}
+			if metadataCheckIndex <= goreleaserIndex {
+				t.Fatalf("binary metadata check index = %d, want after GoReleaser index %d", metadataCheckIndex, goreleaserIndex)
+			}
+			if metadataCheck.ContinueOnError {
+				t.Fatal("binary metadata verification must block release progression")
+			}
+			if !strings.Contains(metadataCheck.Run, "scripts/verify-release-binary-metadata.sh") {
+				t.Fatal("binary metadata verification must use the shared checker")
+			}
+			if !strings.Contains(metadataCheck.Run, tt.wantCommitResolver) {
+				t.Errorf("binary metadata verification does not resolve the expected commit with %q", tt.wantCommitResolver)
+			}
+			if tt.wantVersionArg != "" && !strings.Contains(metadataCheck.Run, tt.wantVersionArg) {
+				t.Errorf("binary metadata verification does not require release version %s", tt.wantVersionArg)
+			}
+		})
+	}
+}
+
 func readCriticalPathWorkflow(t *testing.T, name string) ciCriticalPathWorkflow {
 	t.Helper()
 

--- a/scripts/release_binary_metadata_test.go
+++ b/scripts/release_binary_metadata_test.go
@@ -1,0 +1,140 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyReleaseBinaryMetadata(t *testing.T) {
+	const (
+		expectedCommit  = "0123456789abcdef0123456789abcdef01234567"
+		expectedVersion = "1.2.3"
+	)
+
+	cleanBuildInfo := strings.Join([]string{
+		"/tmp/gc: go1.26.5",
+		"\tpath\tgithub.com/gastownhall/gascity/cmd/gc",
+		"\tmod\tgithub.com/gastownhall/gascity\tv1.2.3",
+		"\tbuild\tvcs.revision=" + expectedCommit,
+		"\tbuild\tvcs.modified=false",
+	}, "\n")
+
+	tests := []struct {
+		name        string
+		versionJSON string
+		buildInfo   string
+		wantErr     string
+	}{
+		{
+			name:        "clean release",
+			versionJSON: `{"commit":"` + expectedCommit + `","version":"1.2.3"}`,
+			buildInfo:   cleanBuildInfo,
+		},
+		{
+			name:        "dirty CLI commit",
+			versionJSON: `{"commit":"` + expectedCommit + `-dirty","version":"1.2.3"}`,
+			buildInfo:   cleanBuildInfo,
+			wantErr:     "release binary reports a dirty commit",
+		},
+		{
+			name:        "dirty VCS setting",
+			versionJSON: `{"commit":"` + expectedCommit + `","version":"1.2.3"}`,
+			buildInfo:   strings.Replace(cleanBuildInfo, "vcs.modified=false", "vcs.modified=true", 1),
+			wantErr:     "embedded vcs.modified is true, expected false",
+		},
+		{
+			name:        "missing VCS modified setting",
+			versionJSON: `{"commit":"` + expectedCommit + `","version":"1.2.3"}`,
+			buildInfo:   strings.Replace(cleanBuildInfo, "\n\tbuild\tvcs.modified=false", "", 1),
+			wantErr:     "embedded vcs.modified is missing, expected false",
+		},
+		{
+			name:        "VCS revision mismatch",
+			versionJSON: `{"commit":"` + expectedCommit + `","version":"1.2.3"}`,
+			buildInfo:   strings.Replace(cleanBuildInfo, expectedCommit, "89abcdef0123456789abcdef0123456789abcdef", 1),
+			wantErr:     "embedded vcs.revision is 89abcdef0123456789abcdef0123456789abcdef",
+		},
+		{
+			name:        "missing VCS revision",
+			versionJSON: `{"commit":"` + expectedCommit + `","version":"1.2.3"}`,
+			buildInfo:   strings.Replace(cleanBuildInfo, "\n\tbuild\tvcs.revision="+expectedCommit, "", 1),
+			wantErr:     "embedded vcs.revision is missing",
+		},
+		{
+			name:        "dirty module version",
+			versionJSON: `{"commit":"` + expectedCommit + `","version":"1.2.3"}`,
+			buildInfo:   strings.Replace(cleanBuildInfo, "v1.2.3", "v1.2.3+dirty", 1),
+			wantErr:     "embedded module version is dirty",
+		},
+		{
+			name:        "release version mismatch",
+			versionJSON: `{"commit":"` + expectedCommit + `","version":"9.9.9"}`,
+			buildInfo:   cleanBuildInfo,
+			wantErr:     "release binary version is 9.9.9, expected 1.2.3",
+		},
+		{
+			name:        "missing JSON commit",
+			versionJSON: `{"version":"1.2.3"}`,
+			buildInfo:   cleanBuildInfo,
+			wantErr:     "missing commit",
+		},
+		{
+			name:        "malformed JSON",
+			versionJSON: `{"commit":`,
+			buildInfo:   cleanBuildInfo,
+			wantErr:     "parse error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			binDir := filepath.Join(tmp, "bin")
+			if err := os.Mkdir(binDir, 0o755); err != nil {
+				t.Fatalf("create bin directory: %v", err)
+			}
+
+			binary := filepath.Join(tmp, "gc")
+			writeExecutable(t, binary, `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$GC_TEST_VERSION_JSON"
+`)
+			writeExecutable(t, filepath.Join(binDir, "go"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$GC_TEST_BUILD_INFO"
+`)
+
+			env := os.Environ()
+			env = replaceScriptEnv(env, "PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			env = replaceScriptEnv(env, "GC_TEST_VERSION_JSON", tt.versionJSON)
+			env = replaceScriptEnv(env, "GC_TEST_BUILD_INFO", tt.buildInfo)
+
+			cmd := scriptCommand(
+				repoRoot(t),
+				"verify-release-binary-metadata.sh",
+				binary,
+				expectedCommit,
+				expectedVersion,
+			)
+			cmd.Env = env
+			output, err := cmd.CombinedOutput()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("verify clean release metadata: %v\n%s", err, output)
+				}
+				if !strings.Contains(string(output), "release binary metadata: OK") {
+					t.Fatalf("success output = %q", output)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("verification succeeded, want error containing %q\n%s", tt.wantErr, output)
+			}
+			if !strings.Contains(string(output), tt.wantErr) {
+				t.Fatalf("error output = %q, want substring %q", output, tt.wantErr)
+			}
+		})
+	}
+}

--- a/scripts/verify-release-binary-metadata.sh
+++ b/scripts/verify-release-binary-metadata.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <gc-binary> <expected-commit> [expected-version]" >&2
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  usage
+  exit 2
+fi
+
+binary=$1
+expected_commit=$2
+expected_version=${3:-}
+
+if [[ ! -x "$binary" ]]; then
+  echo "ERROR: release binary is not executable: $binary" >&2
+  exit 1
+fi
+if [[ -z "$expected_commit" ]]; then
+  echo "ERROR: expected commit must not be empty" >&2
+  exit 1
+fi
+
+version_json=$("$binary" version --json --long)
+actual_commit=$(jq -er \
+  '.commit | if type == "string" and length > 0 then . else error("missing commit") end' \
+  <<<"$version_json")
+actual_version=$(jq -er \
+  '.version | if type == "string" and length > 0 then . else error("missing version") end' \
+  <<<"$version_json")
+
+if [[ "$actual_commit" == *-dirty ]]; then
+  echo "ERROR: release binary reports a dirty commit: $actual_commit" >&2
+  exit 1
+fi
+if [[ "$actual_commit" != "$expected_commit" ]]; then
+  echo "ERROR: release binary commit is $actual_commit, expected $expected_commit" >&2
+  exit 1
+fi
+if [[ -n "$expected_version" && "$actual_version" != "$expected_version" ]]; then
+  echo "ERROR: release binary version is $actual_version, expected $expected_version" >&2
+  exit 1
+fi
+
+build_info=$(go version -m "$binary")
+vcs_revision=$(awk '
+  $1 == "build" && $2 ~ /^vcs\.revision=/ {
+    sub(/^vcs\.revision=/, "", $2)
+    print $2
+    exit
+  }
+' <<<"$build_info")
+vcs_modified=$(awk '
+  $1 == "build" && $2 ~ /^vcs\.modified=/ {
+    sub(/^vcs\.modified=/, "", $2)
+    print $2
+    exit
+  }
+' <<<"$build_info")
+module_version=$(awk '$1 == "mod" { print $3; exit }' <<<"$build_info")
+
+if [[ "$vcs_revision" != "$expected_commit" ]]; then
+  echo "ERROR: embedded vcs.revision is ${vcs_revision:-missing}, expected $expected_commit" >&2
+  exit 1
+fi
+if [[ "$vcs_modified" != "false" ]]; then
+  echo "ERROR: embedded vcs.modified is ${vcs_modified:-missing}, expected false" >&2
+  exit 1
+fi
+if [[ "$module_version" == *+dirty ]]; then
+  echo "ERROR: embedded module version is dirty: $module_version" >&2
+  exit 1
+fi
+
+echo "release binary metadata: OK (version=$actual_version commit=$actual_commit vcs.modified=false)"


### PR DESCRIPTION
## Summary

- ignore root `/dist/` so GoReleaser metadata cannot contaminate Go VCS stamping
- fail RC and stable-release preflight if release output becomes tracked or unignored
- verify the built binary's runtime commit/version and embedded `vcs.revision`, `vcs.modified`, and module version
- cover workflow ordering plus clean and negative verifier paths

## Root cause

GoReleaser validates a clean checkout, then writes `dist/metadata.json` and `dist/config.yaml` before invoking `go build`. Because root `dist/` was not ignored, Go embedded `vcs.modified=true`; `gc version --long` consequently appended `-dirty` even though the injected commit and provenance were exact.

## Verification

- reproduced on current `origin/main` in a normal clone: runtime `-dirty`, module `+dirty`, `vcs.modified=true`
- rebuilt after the ignore rule: exact commit, clean module version, `vcs.modified=false`
- confirmed a genuine tracked-file edit still reports `-dirty` and is rejected
- `make test-fast-parallel`
- `go vet ./...`
- `make lint`
- `make fmt-check`
- `go test ./scripts -count=1`
- resource-census policy test
- `goreleaser check`, `actionlint`, and `shellcheck`

Bead: `ga-asbls5`
