### PR TITLE
docs: stop cold-build cache guidance from targeting tmpfs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,14 +404,30 @@ full rebuild, and any that calls `go clean -cache` mid-flight invalidates all
 the others' in-progress caches. The incident (vp-g96b, 2026-06-13) produced
 ~10 cascading cache-miss errors across the executor pool.
 
-**Safe alternative for cold builds:**
+**Just run `go build` / `make` — do NOT set `GOCACHE` yourself.** The host `go`
+shim already routes the default `GOCACHE` to a shared **on-disk** cache
+(`~/.cache/go-build`) and pins compile/link temp to disk
+(`GOTMPDIR=/var/tmp/gotmp`). A warm shared cache is faster and is never
+corrupted by a normal build.
+
+**Never point `GOCACHE` (or `TMPDIR`) at `/tmp`.** `/tmp` is a size-capped
+RAM-backed tmpfs (61G) shared by the whole fleet — including the harness's
+tool-output capture dir. A bare `mktemp -d` (no `-p` dir) resolves against the
+unset `$TMPDIR`, which defaults to `/tmp` — one cold cache built there is
+2-3GB, and a concurrent build wave fills tmpfs and ENOSPCs every agent
+on the host (incident gm-tkz1r / ga-x9k9b9, 2026-07). The shim deliberately
+does **not** relocate a `GOCACHE` you set explicitly, so an explicit `/tmp` path
+defeats it.
+
+**If you truly need an isolated cold build** (a from-scratch compile without
+`go clean -cache`), put the throwaway cache **on disk** and remove it
+unconditionally with a `trap`, and redirect `TMPDIR` to the same dir so the
+linker's own scratch also stays off tmpfs:
 
 ```bash
-GOCACHE=$(mktemp -d) go build ./cmd/gc/
+tmp=$(mktemp -d -p /var/tmp) && trap 'rm -rf "$tmp"' EXIT
+GOCACHE="$tmp" TMPDIR="$tmp" go build ./cmd/gc/
 ```
-
-This isolates the cache to a throwaway directory without touching the shared
-pool. Clean up with `rm -rf` after if disk space matters.
 
 **Exception:** `go clean -testcache` is explicitly allowed. It clears only the
 test-result cache, not the compiled-object cache, and does not corrupt

--- a/release-gates/ga-8duxbh-gocache-tmpfs-gate.md
+++ b/release-gates/ga-8duxbh-gocache-tmpfs-gate.md
@@ -1,0 +1,45 @@
+# Release gate: AGENTS.md GOCACHE tmpfs guidance
+
+Bead: ga-8duxbh
+Source bead: ga-lqzg77
+Review bead: ga-mjy308
+Original reviewed commit: b751bb6ab4f1d20088e42ec3c0a3a540b9c3b959
+Clean deploy commit before this gate file: 5452a1ade
+Branch: deploy/ga-8duxbh-gocache-tmpfs
+Base: origin/main at 85319eb60
+
+## Summary
+
+This gate evaluates the reviewed documentation fix that removes the
+`AGENTS.md` cold-build guidance that sent explicit `GOCACHE` values to `/tmp`.
+The builder branch `gc-builder-2-91e0bf41098b` was not directly reviewable
+against current `origin/main`; its branch diff carried broad unrelated history.
+The reviewed one-file commit was cherry-picked cleanly onto a fresh branch from
+current `origin/main`, producing commit `5452a1ade`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-mjy308` is closed with `REVIEWER VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | `AGENTS.md` no longer contains `GOCACHE=$(mktemp`; repo no longer contains `Safe alternative for cold builds`; `CLAUDE.md` is unchanged from `origin/main`; `AGENTS.md` retains the `go clean -cache` hard ban and `go clean -testcache` exception; new guidance names `/var/tmp`, uses `trap 'rm -rf "$tmp"' EXIT`, and sets both `GOCACHE="$tmp"` and `TMPDIR="$tmp"`. |
+| 3 | Tests pass | PASS | `TMPDIR=/var/tmp/g8.Dv2Iuv make test-fast-parallel` passed all fast jobs. `TMPDIR=/var/tmp/gascity-gate-ga-8duxbh-build.* make build` passed. `TMPDIR=/var/tmp/gascity-gate-ga-8duxbh-vet.* go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes contain no HIGH findings and ended in PASS. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` clean before writing this gate file; final status rechecked after committing gate. |
+| 6 | Branch diverges cleanly from main | PASS | Final branch was cut from current `origin/main` (`85319eb60`), then the reviewed one-file patch was cherry-picked cleanly. |
+| 7 | Single feature theme | PASS | The final diff touches only `AGENTS.md` and is limited to build-cache guidance for avoiding tmpfs exhaustion. |
+
+## Test log notes
+
+An earlier `make test-fast-parallel` run used a verbose TMPDIR path under
+`/var/tmp/gascity-gate-ga-8duxbh-test-persist.MRmkqy`; it failed because several
+Unix socket tests exceeded the platform path length, with `bind: invalid
+argument` and one explicit `sockPath(...) exceeds limit 100`. The gate was
+rerun with the short disk-backed TMPDIR `/var/tmp/g8.Dv2Iuv`, and all fast jobs
+passed.
+
+## Final diff
+
+```text
+M AGENTS.md
+```


### PR DESCRIPTION
## What this changes

`AGENTS.md` no longer tells agents to create isolated Go build caches with a bare `mktemp -d`, which defaults to `/tmp` on this host. That pattern can fill the shared tmpfs during concurrent cold builds and break unrelated agent work.

The build-cache guidance now tells agents to use normal `go build` / `make` with the shared on-disk Go cache. For the rare case that needs an isolated cold build, it puts the throwaway cache under `/var/tmp`, removes it with a trap, and pins `TMPDIR` there too so linker scratch space stays off tmpfs.

## Review notes

- The functional documentation change is limited to `AGENTS.md`.
- `CLAUDE.md` is unchanged from current `main`.
- This does not change host reaper scripts, the local `go` shim, systemd units, or existing hardcoded `/tmp` test paths.
- The release branch is isolated on current `origin/main`; the reviewed one-file patch was cherry-picked cleanly from the original builder branch.

## Test plan

- [x] `make build`
- [x] `go vet ./...`
- [x] `make test-fast-parallel` with short disk-backed `TMPDIR=/var/tmp/g8.Dv2Iuv`
- [x] Pre-push `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-8duxbh-gocache-tmpfs-gate.md`](release-gates/ga-8duxbh-gocache-tmpfs-gate.md)