### PR TITLE
fix(reconciler): warm rig pools must probe the city/graph store for routed demand (upstream 180ad7dd8)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -632,14 +632,19 @@ func buildDesiredStateWithSessionBeads(
 					namedOnDemandTemplates[template] = true
 				}
 				defaultNamedScaleTargets = append(defaultNamedScaleTargets, ownTarget)
-				// Cross-store cold-wake for named-backing pools (vp-cl4): mirror the
-				// generic-pool guard (vp-s37 / #3078 line ~598). A cold rig pool that
+				// Cross-store probe for named-backing pools (vp-cl4): mirror the
+				// generic-pool guard (vp-s37 / #3078 line ~598). A rig pool that
 				// backs a named session and has no custom scale_check must also probe
-				// the city store so that routed demand delivered there (vp-kvp) can
-				// wake the pool. Same guard conditions apply: healthy own rig store,
-				// not city-aliased, not city-scoped. The named-session target list
-				// mirrors these probes only for partial-query retention bookkeeping.
-				if isCold && !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
+				// the city store so that routed demand delivered there (vp-kvp) is
+				// visible. Like the generic-pool probe below, this is UNCONDITIONAL
+				// (not gated on isCold): a warm tick that cannot see the routed
+				// demand computes 0, drops the just-woken session from desiredState,
+				// and drains it before it can claim (the spawn/drain treadmill).
+				// Same guard conditions apply: healthy own rig store, not
+				// city-aliased, not city-scoped, not a store-scoped control
+				// dispatcher. The named-session target list mirrors these probes
+				// only for partial-query retention bookkeeping.
+				if !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 					cityTarget := defaultScaleCheckTarget{template: template, store: store, storeKey: "city"}
 					if namedSessionMode != "always" {
 						defaultScaleTargets = append(defaultScaleTargets, cityTarget)
@@ -668,14 +673,28 @@ func buildDesiredStateWithSessionBeads(
 		if store != nil && !hasCustomScaleCheck {
 			ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
 			defaultScaleTargets = append(defaultScaleTargets, ownTarget)
-			// Cross-store cold-wake (FR-S0.1 / vp-s37): a cold rig pool's routed
-			// demand may live in the city store (vp-kvp cross-store delivery),
-			// which the own-rig probe above cannot see while the pool sleeps —
-			// so a sleeping rig pool would never wake to discover it. Add a
-			// city-store probe for cold rig pools so their demand reflects
-			// routed work in either store. No clamp: unlike a custom-scale_check
-			// pool — where the probe is clamped so it cannot override the custom
-			// count (see coldWakeTemplates below) — the default probe IS the
+			// Cross-store probe (FR-S0.1 / vp-s37): a rig pool's routed demand
+			// may live in the city store (vp-kvp cross-store delivery) — the
+			// leading store the reconciler is handed, where routed graph-class
+			// molecule steps land — which the own-rig probe above cannot see.
+			// Add a city-store probe for rig pools so their demand reflects
+			// routed work in either store. This probe is UNCONDITIONAL, not
+			// gated on isCold: gating it on runningSessions == 0 caused a live
+			// spawn/drain treadmill — a cold tick saw the routed city-store
+			// demand and spawned, the next (warm) tick could not see it,
+			// pool_desired collapsed to 0, and every just-spawned session was
+			// drained as "orphaned" one patrol tick later, before the agent
+			// could claim (pool_desired cycling 5,0,0 on the live trace); a
+			// pool kept warm by even one resume-tier session never re-probed
+			// the city store, so fresh routed steps sat unassigned until the
+			// pool happened to go cold. The count-form
+			// stays leak-safe warm: defaultScaleCheckCounts counts only
+			// unassigned beads whose gc.routed_to resolves to THIS template, so
+			// a rig pool cannot scale on unrelated city work, and all rig pools
+			// share one "city" store group (one extra Ready() probe pair per
+			// tick, not per pool). No clamp: unlike a custom-scale_check pool —
+			// where the probe is clamped so it cannot override the custom count
+			// (see coldWakeTemplates below) — the default probe IS the
 			// authoritative count, so it scales to total routed demand (bounded
 			// by max_active and the daemon's max_wakes_per_tick), matching the
 			// retired cold-pool-spawner's scale-to-want. A city-scoped pool's
@@ -694,9 +713,9 @@ func buildDesiredStateWithSessionBeads(
 			// per group, not across groups. Current store-map builders skip
 			// such rigs, so this is defense-in-depth against future callers.
 			// Control dispatchers are deliberately store-scoped: a rig copy cannot
-			// claim a route from the city store. Keep their cold-wake probe on the
+			// claim a route from the city store. Keep their demand probe on the
 			// owning store instead of applying generic cross-store pool delivery.
-			if isCold && !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
+			if !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 				defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTarget{template: template, store: store, storeKey: "city"})
 			}
 			continue

--- a/cmd/gc/split_store_city_pool_demand_verify_test.go
+++ b/cmd/gc/split_store_city_pool_demand_verify_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// newCityPoolCity wires a CITY-scoped (no Dir) default-probe pool agent named
+// implementation-worker — the exact shape the graph-demand federation bug
+// cites: a molecule's routed worker step lands on a city-scoped pool, not a
+// rig pool. It is the city-scoped sibling of newNoScaleCheckRigPoolCity; it
+// takes no rig so the pool's own demand target is the leading (city) store.
+func newCityPoolCity() (*config.City, beads.Store, string) {
+	maxSess, minSess := 5, 0
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "implementation-worker",
+			MaxActiveSessions: &maxSess,
+			MinActiveSessions: &minSess,
+			Provider:          "mock",
+		}},
+		Providers: map[string]config.ProviderSpec{"mock": {Command: "true"}},
+	}
+	return cfg, beads.NewMemStore(), cfg.Agents[0].QualifiedName()
+}
+
+// TestSplitCityDemand_CityPoolSeesGraphRoutedStep is the load-bearing
+// verification for the graph-demand federation fix. It stages the exact bug
+// shape from the incident: an OPEN, UNASSIGNED, graph-class (type=task) worker
+// step routed to a CITY-scoped pool (implementation-worker), resident in the
+// leading city store. A fresh reconciler tick must count it as pool demand so
+// a worker spawns to run it — otherwise the step strands when its in-session
+// operator is lost.
+func TestSplitCityDemand_CityPoolSeesGraphRoutedStep(t *testing.T) {
+	cfg, store, qualified := newCityPoolCity()
+	mintGraphRoutedStep(t, store, qualified, "")
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		store, nil, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got < 1 {
+		t.Fatalf("pool demand for city-scoped %s = %d, want >= 1 (open unassigned graph-class step routed to the city pool must be discoverable as demand)", qualified, got)
+	}
+}
+
+// TestSplitCityDemand_CityPoolGraphStepNoDoubleCount pins that counting
+// city-pool demand does NOT double-count a routed step: the city pool's own
+// demand target IS the leading city store, so the cross-store city arm must
+// not add a second demand source over the same store (the ownTarget.storeKey
+// != "city" half of the guard). Exactly one routed step must yield exactly
+// one unit of demand.
+func TestSplitCityDemand_CityPoolGraphStepNoDoubleCount(t *testing.T) {
+	cfg, store, qualified := newCityPoolCity()
+	mintGraphRoutedStep(t, store, qualified, "")
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		store, nil, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 1 {
+		t.Fatalf("pool demand for city-scoped %s = %d, want exactly 1 (a single routed graph step must not be double-counted)", qualified, got)
+	}
+}

--- a/cmd/gc/split_store_hook_graph_demand_verify_test.go
+++ b/cmd/gc/split_store_hook_graph_demand_verify_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestSplitCityHookDiscoversGraphRoutedStep is the hook-side load-bearing
+// verification for the graph-demand federation fix. A fresh worker's hook work
+// query must discover a graph-class routed step that lives in the city store,
+// or the step strands when its molecule loses its in-session operator.
+//
+// The mechanism upstream is store-list federation (cmd_hook.go): a rig-scoped
+// agent's hook chain is [own rig store (primary), own env, city store
+// (appendCityHookStore, appended LAST)], and firstStoreWithWork surfaces the
+// first store that reports ready work. This test pins that end-to-end through
+// the real firstStoreWithWork plumbing: the runner returns the graph-routed
+// step ONLY for the city entry (modeling a step resident in the city store)
+// and empty for the rig store.
+func TestSplitCityHookDiscoversGraphRoutedStep(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := t.TempDir()
+	cfg := &config.City{Rigs: []config.Rig{{Name: "rig-A", Path: rigPath}}}
+	agent := &config.Agent{Name: "implementation-worker", Dir: "rig-A"}
+
+	// The wiring half: a rig-scoped identity resolves to its rig, and the city
+	// store is appended to its chain — without that entry no store in a
+	// rig-bound agent's chain reaches the city-resident step.
+	if rig := rigScopedHookRig(cfg, "rig-A/implementation-worker"); rig != "rig-A" {
+		t.Fatalf("rigScopedHookRig = %q, want %q", rig, "rig-A")
+	}
+	rigEntry := hookStore{dir: rigPath}
+	stores := appendCityHookStore([]hookStore{rigEntry}, cityPath, cfg, agent, nil)
+	if len(stores) != 2 {
+		t.Fatalf("appendCityHookStore produced %d entries, want 2 (rig primary + city)", len(stores))
+	}
+	if stores[0].dir != rigPath {
+		t.Fatalf("primary hook entry dir = %q, want the rig store %q (city is best-effort, appended last)", stores[0].dir, rigPath)
+	}
+	if stores[1].dir != cityPath {
+		t.Fatalf("city hook entry dir = %q, want %q", stores[1].dir, cityPath)
+	}
+
+	// The discovery half: only the city entry can see the graph-class step.
+	const graphStep = `[{"id":"gcg-wisp-0042","issue_type":"task","status":"open"}]`
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == cityPath {
+			return graphStep, nil
+		}
+		return `[]`, nil
+	}
+
+	out, gotStore, err := firstStoreWithWork("bd ready --json", stores, rigEntry, run)
+	if err != nil {
+		t.Fatalf("firstStoreWithWork: %v", err)
+	}
+	if out != graphStep {
+		t.Fatalf("hook did not surface the graph-routed step: out=%q, want %q", out, graphStep)
+	}
+	if gotStore.dir != cityPath {
+		t.Fatalf("hook selected store %q, want the city store %q", gotStore.dir, cityPath)
+	}
+}
+
+// TestSplitCityHookRigStoreStaysPrimary is the byte-identity guard for the
+// federation: the rig store stays the PRIMARY entry, so when the agent's OWN
+// store has ready work the hook takes it from there — the appended city entry
+// is best-effort discovery for city-resident steps, not a takeover of the
+// rig-scoped hook's historical own-store-first behavior (and the primary
+// keeps firstStoreWithWork's emit-on-timeout contract).
+func TestSplitCityHookRigStoreStaysPrimary(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := t.TempDir()
+
+	rigEntry := hookStore{dir: rigPath}
+	stores := []hookStore{rigEntry, {dir: cityPath}}
+
+	const rigWork = `[{"id":"ra-101","issue_type":"task","status":"open"}]`
+	const cityWork = `[{"id":"gcg-wisp-0042","issue_type":"task","status":"open"}]`
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == rigPath {
+			return rigWork, nil
+		}
+		return cityWork, nil
+	}
+
+	out, gotStore, err := firstStoreWithWork("bd ready --json", stores, rigEntry, run)
+	if err != nil {
+		t.Fatalf("firstStoreWithWork: %v", err)
+	}
+	if out != rigWork {
+		t.Fatalf("hook output = %q, want the rig store's own work %q", out, rigWork)
+	}
+	if gotStore.dir != rigPath {
+		t.Fatalf("hook selected store %q, want the primary rig store %q", gotStore.dir, rigPath)
+	}
+}

--- a/cmd/gc/split_store_treadmill_test.go
+++ b/cmd/gc/split_store_treadmill_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// This file covers the spawn/drain treadmill (mc-wisp-orphan RCA): routed
+// orchestration work delivered at city scope (vp-kvp cross-store delivery)
+// lives in the LEADING city store, but a rig pool's default demand probe
+// scanned only its own rig store while the pool was warm — the city-store
+// probe was appended only under isCold (runningSessions == 0).
+//
+// Driver: the cross-store demand probe was gated on isCold, so the first WARM
+// tick after a cold spawn computed demand=0, dropped every just-spawned
+// session from desiredState, and drained them ~45s post-spawn — before the
+// ~2min agent boot could claim. pool_desired cycled 5,0,0 for hours on the
+// live trace, and a pool kept warm by even one resume-tier session never saw
+// fresh routed steps at all. The probe must be unconditional.
+
+// newWarmPoolSessionBead returns a live, pool-managed session bead for the
+// given qualified template, shaped the way the runningSessions counter and the
+// pool-reuse selection recognize it (type=session, gc:session label, active
+// state, session_name + pool_slot identity).
+func newWarmPoolSessionBead(qualified, sessionName, poolSlot string) beads.Bead {
+	return beads.Bead{
+		Title:  sessionName,
+		Type:   "session",
+		Labels: []string{"gc:session"},
+		Metadata: map[string]string{
+			"template":     qualified,
+			"session_name": sessionName,
+			"pool_managed": "true",
+			"pool_slot":    poolSlot,
+			"state":        "active",
+		},
+	}
+}
+
+// TestBuildDesiredState_WarmTick_RoutedDemandInLeadingStoreCounts is the T1
+// driver regression: a rig-scoped default-probe pool with a RUNNING session
+// (warm tick) must still count routed demand that lives only in the leading
+// city store. Before the fix the cross-store probe was appended only under
+// isCold, so this demand read 0 on every warm tick.
+func TestBuildDesiredState_WarmTick_RoutedDemandInLeadingStoreCounts(t *testing.T) {
+	cfg, store, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	// One live pool session → runningSessions > 0 → NOT cold.
+	sess, err := store.Create(newWarmPoolSessionBead(qualified, "executor-1", "1"))
+	if err != nil {
+		t.Fatalf("create warm session bead: %v", err)
+	}
+
+	// Routed demand ONLY in the leading (city) store.
+	if _, err := store.Create(beads.Bead{
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": qualified},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		store, rigStores, newSessionBeadSnapshot([]beads.Bead{sess}), nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 1 {
+		t.Errorf("warm-tick cross-store demand = %d, want 1 (routed demand in the leading store must stay visible while sessions run)", got)
+	}
+}
+
+// TestBuildDesiredState_WarmTick_TreadmillSessionsStayDesired is the T2
+// treadmill regression, driven through the production spawn path: a cold tick
+// materializes pool sessions for routed leading-store demand; on the next
+// (warm) tick — with the work still open and unclaimed — the desired state
+// must KEEP those sessions instead of dropping them to zero (which the
+// reconciler then drains as "orphaned" before the agent can claim).
+func TestBuildDesiredState_WarmTick_TreadmillSessionsStayDesired(t *testing.T) {
+	cfg, store, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+	cityPath := t.TempDir()
+
+	for i := 0; i < 2; i++ {
+		if _, err := store.Create(beads.Bead{
+			Status:    "open",
+			Type:      "task",
+			Ephemeral: true,
+			Metadata:  map[string]string{"gc.routed_to": qualified},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Cold tick: demand=2 spawns two pool session beads through the production
+	// create path.
+	cold := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now(), cfg, &localMockProvider{},
+		store, rigStores, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+	if len(cold.State) != 2 {
+		t.Fatalf("cold tick desired sessions = %d, want 2", len(cold.State))
+	}
+	spawned, err := session.ListAllSessionBeads(store, beads.ListQuery{})
+	if err != nil {
+		t.Fatalf("list spawned session beads: %v", err)
+	}
+	if len(spawned) != 2 {
+		t.Fatalf("spawned session beads = %d, want 2", len(spawned))
+	}
+
+	// Warm tick: sessions exist and are live, the routed beads are STILL
+	// open/unclaimed (the agents have not booted far enough to claim). The
+	// sessions must not fall out of desiredState.
+	snap, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("load session snapshot: %v", err)
+	}
+	warm := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now(), cfg, &localMockProvider{},
+		store, rigStores, snap, nil, os.Stderr,
+	)
+	if got := warm.ScaleCheckCounts[qualified]; got != 2 {
+		t.Errorf("warm tick demand = %d, want 2 (treadmill: demand collapsed while work was still unclaimed)", got)
+	}
+	if len(warm.State) != 2 {
+		t.Errorf("warm tick desired sessions = %d, want 2 (treadmill: just-spawned sessions fell out of desiredState)", len(warm.State))
+	}
+	// The warm tick must reuse the spawned sessions, not mint replacements.
+	after, err := session.ListAllSessionBeads(store, beads.ListQuery{})
+	if err != nil {
+		t.Fatalf("list session beads after warm tick: %v", err)
+	}
+	if len(after) != 2 {
+		t.Errorf("session beads after warm tick = %d, want 2 (warm tick must reuse spawned sessions, not create new ones)", len(after))
+	}
+}
+
+// TestBuildDesiredState_WarmTick_UnrelatedLeadingStoreWorkDoesNotScaleRigPool
+// is the leak-safety guard for the unconditional cross-store probe: routed
+// demand for OTHER templates (or unrouted work) in the leading store must not
+// scale this rig pool on warm ticks. The count-form filters on
+// gc.routed_to=<template>, so rig pools cannot scale on unrelated city work.
+func TestBuildDesiredState_WarmTick_UnrelatedLeadingStoreWorkDoesNotScaleRigPool(t *testing.T) {
+	cfg, store, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	sess, err := store.Create(newWarmPoolSessionBead(qualified, "executor-1", "1"))
+	if err != nil {
+		t.Fatalf("create warm session bead: %v", err)
+	}
+
+	// Unrelated work in the leading store: routed elsewhere, and unrouted.
+	if _, err := store.Create(beads.Bead{
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": "other-rig/other-agent"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Status: "open",
+		Type:   "task",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		store, rigStores, newSessionBeadSnapshot([]beads.Bead{sess}), nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 0 {
+		t.Errorf("warm-tick demand = %d, want 0 (rig pool must not scale on unrelated leading-store work)", got)
+	}
+}
+
+// TestBuildDesiredState_WarmTick_NamedBackingPoolSeesLeadingStoreDemand covers
+// the named-backing sibling of the driver (build_desired_state.go's named
+// branch): an on_demand named-backing pool with a running session must still
+// see routed leading-store demand on a warm tick, clamped to 1 as always.
+func TestBuildDesiredState_WarmTick_NamedBackingPoolSeesLeadingStoreDemand(t *testing.T) {
+	cfg, store, rigStores, identity := newNoScaleCheckNamedBackingCity(t)
+
+	sess, err := store.Create(newWarmPoolSessionBead(identity, "planner-1", "1"))
+	if err != nil {
+		t.Fatalf("create warm session bead: %v", err)
+	}
+
+	if _, err := store.Create(beads.Bead{
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": identity},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		store, rigStores, newSessionBeadSnapshot([]beads.Bead{sess}), nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[identity]; got != 1 {
+		t.Errorf("warm-tick named-backing demand = %d, want 1 (on_demand clamp, but visible)", got)
+	}
+}

--- a/cmd/gc/split_store_warm_rig_pool_demand_verify_test.go
+++ b/cmd/gc/split_store_warm_rig_pool_demand_verify_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// This file pins the WARM rig-pool half of the graph-demand federation fix,
+// in the incident's exact shape (maintainer-city, 2026-07: template
+// gascity/gc.implementation-worker, step gcg-wisp-xqsan6 invisible for 40+
+// minutes while one session, mc-rtg7n, held resume-tier work). The city-pool
+// half lives in split_store_city_pool_demand_verify_test.go.
+//
+// The invariant under test: a rig pool's default scale-check demand = own rig
+// store + city (leading) store, dedup'd — UNCONDITIONALLY, not only when the
+// pool is cold. Routed graph-class molecule steps are delivered at city scope
+// (vp-kvp cross-store delivery), which the rig pool's own-store probe cannot
+// see. When the city-store arm was gated on isCold (runningSessions == 0 &&
+// min == 0), a pool kept warm by even ONE resume-tier session never probed
+// the city store: fresh molecule steps produced zero new-demand every warm
+// tick and sat unassigned for 20min-3h until the pool happened to go cold.
+// The gate was dropped in the treadmill fix (build_desired_state.go, both the
+// generic-pool and named-backing arms); these tests hold that line with the
+// pool warm the way production pools are warm — holding claimed work.
+
+// mintGraphRoutedStep stages one graph-shaped routed molecule step (the wisp
+// shape production materialization mints: type task, gc.kind=wisp) in store.
+// A non-empty assignee stages the claimed, in-flight state via post-create
+// mutation, exactly as production claims are.
+func mintGraphRoutedStep(t *testing.T, store beads.Store, routedTo, assignee string) {
+	t.Helper()
+	created, err := store.Create(beads.Bead{
+		Title: "routed graph step",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:     beadmeta.KindWisp,
+			beadmeta.RoutedToMetadataKey: routedTo,
+		},
+	})
+	if err != nil {
+		t.Fatalf("minting routed step: %v", err)
+	}
+	if assignee == "" {
+		return
+	}
+	status := "in_progress"
+	if err := store.Update(created.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("staging claimed step %s: %v", created.ID, err)
+	}
+}
+
+// TestSplitCityDemand_WarmRigPoolSeesGraphRoutedStep stages the live incident:
+// a rig-scoped default-probe pool whose one live session HOLDS a claimed
+// routed step (the resume-tier accept that kept the pool warm), plus a fresh
+// OPEN, UNASSIGNED graph-class step routed to the same pool, resident in the
+// leading city store. The warm tick's demand count MUST include the fresh
+// step — exactly once: the claimed step is resume work, not new demand, and
+// the own-store + city probes must not double-count across store groups.
+func TestSplitCityDemand_WarmRigPoolSeesGraphRoutedStep(t *testing.T) {
+	cfg, store, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	sess, err := store.Create(newWarmPoolSessionBead(qualified, "executor-1", "1"))
+	if err != nil {
+		t.Fatalf("create warm pool session bead: %v", err)
+	}
+	// The warmth source: claimed, in-flight routed work held by the live
+	// session. The pool is warm BECAUSE of resume work, and that resume work
+	// must neither hide the fresh step nor leak into the new-demand count.
+	mintGraphRoutedStep(t, store, qualified, sess.ID)
+	// The fresh unassigned routed step (gcg-wisp-xqsan6 shape).
+	mintGraphRoutedStep(t, store, qualified, "")
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		store, rigStores, newSessionBeadSnapshot([]beads.Bead{sess}), nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 1 {
+		t.Fatalf("warm rig-pool demand for %s = %d, want exactly 1 (the fresh unassigned routed step must be counted once on a WARM tick — 0 is the isCold-gate blindness that stranded steps for 20min-3h live; 2+ is a double-count across the rig/city store groups)", qualified, got)
+	}
+}
+
+// TestSplitCityDemand_WarmAliasedRigStoreNoDoubleCount is the identity case
+// for the now-unconditional probe: a rig whose store aliases the city store
+// (an unbound rig falling back to the city scope — rigStores maps the rig
+// name to the SAME handle the reconciler leads with). The ownTarget.store !=
+// store guard must skip the extra city arm, so one routed step counts exactly
+// once. The cold flavor of the aliased-store defense predates this fix; this
+// is the warm flavor, which only exists now that the probe is no longer
+// cold-gated — defaultScaleCheckCounts dedups per storeKey group, not across
+// groups, so a second "city" group over the same physical store would count
+// the same bead twice on every warm tick.
+func TestSplitCityDemand_WarmAliasedRigStoreNoDoubleCount(t *testing.T) {
+	cfg, store, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	// Slot 2 (not 1): a pool whose first slot drained earlier is a valid warm
+	// state, and the demand invariant must not key on slot numbering.
+	sess, err := store.Create(newWarmPoolSessionBead(qualified, "executor-2", "2"))
+	if err != nil {
+		t.Fatalf("create warm pool session bead: %v", err)
+	}
+	// Alias the rig store to the leading store the reconciler is handed.
+	rigStores["rig-A"] = store
+	mintGraphRoutedStep(t, store, qualified, "")
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		store, rigStores, newSessionBeadSnapshot([]beads.Bead{sess}), nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 1 {
+		t.Fatalf("warm aliased-rig demand for %s = %d, want exactly 1 (rig store == city store must yield one demand unit per step, not one per store group)", qualified, got)
+	}
+}


### PR DESCRIPTION
## The bug

A rig pool's default scale-check demand probe reads its own rig store unconditionally, but the **city-store probe arm was gated on `isCold`** (`runningSessions == 0 && min == 0`) in both the generic-pool arm and the named-session-backing arm of `cmd/gc/build_desired_state.go`. Routed graph-class molecule steps are delivered at city scope (vp-kvp cross-store delivery), so a pool kept warm by even **one** session holding resume-tier work never re-probes the city store: fresh routed steps produce zero new-demand on every warm tick and sit unassigned for **20 minutes to 3 hours** until the pool happens to go cold — engagement in stop-bursts. The cold flavor of the same gate also drove a spawn/drain treadmill: cold tick sees the demand and spawns N sessions, the next (warm) tick computes demand 0, the just-spawned sessions fall out of `desiredState` and are drained as "orphaned" ~45–60s post-spawn — before the ~2min agent boot can claim — and the pool goes cold again (`pool_desired` cycling `5,0,0` every ~2:20 for hours; 376+28 bare launch beads accumulated).

The gate was cold-wake scoping, not leak protection. Leak protection lives in the count-form and is preserved: `defaultScaleCheckCounts` counts only **unassigned** beads whose `gc.routed_to` resolves to **this** template, all rig pools share one `"city"` store group (one extra `Ready()` probe pair per pass, not per pool), and over-spawn during boot stays bounded by the existing chain (unassigned-only demand, in-flight new-request slots, session-bead reuse, per-tick caps). All other guard conditions are kept: `!storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store`.

## Live evidence

A trace-armed reconciler on the production city showed **zero tier:new accepts and zero scale-check demand for a ready routed step (`gcg-wisp-xqsan6`) across 40 minutes** while one session (`mc-rtg7n`) held resume-tier work that kept the pool warm. The step was open, unassigned, and routed to the pool's template the whole time; the warm ticks simply never probed the store it lived in.

## History

The fix landed on the deploy branch on **Jul 11** (`180ad7dd8`, plus a follow-up) but never reached `main`, so this morning's main-lineage release regressed production back to the cold-gated probe. This PR upstreams it:

- **Commit 1** (cherry-picked from `180ad7dd8`, conflicts resolved against main): drop `isCold` from the city-target append in both arms. The follow-up's `!storeScopedControlDispatcher` exclusion is **already on main** via #4175, so the resulting guard here matches the deploy branch's end state exactly. The original commit's three split-store reachability siblings are gated on the fork's domain/infra store split (`cityHasInfraStore`), which doesn't exist upstream, and are omitted; its warm-tick regression tests are carried over, adapted to the upstream single-store fixtures.
- **Commit 2**: three regression suites, ported from the fork's verification files — the warm-rig-pool incident shape (fresh routed step counted exactly once on a warm tick, claimed resume work neither hides it nor inflates it, plus the warm aliased-rig-store no-double-count identity case), city-pool demand (seen, and counted exactly once), and hook-side federation (a rig-scoped agent's chain includes the city store and `firstStoreWithWork` surfaces a graph step only the city entry can see, with the rig store kept primary).

Red-verified: restoring the `isCold` gate makes the incident-shape test read demand = 0 — the exact production blindness.

## Verification

- `GOCACHE=$(mktemp -d) go build ./cmd/gc/ ./internal/...` — clean cold build
- `go vet ./cmd/gc/` — clean
- `go test ./cmd/gc/ -run 'Split|Demand|ScaleCheck|Cold|Wake' -count=1` — ok
- `go test ./internal/testpolicy/... -run Census -count=1` — ok (`TestRepositoryLedgerMatchesCensusAndDocumentation` passes; the new tests add no tracked resource call sites, so no census bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
