### PR TITLE
test(fsys): bind Fake to a portable conformance contract

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -575,6 +575,14 @@ the constructor-specific source of truth.
 | `runtime.Provider` | `internal/runtime/runtimetest/conformance.go` | See the checked runtime ledger below |
 | `mail.Provider` | `internal/mail/mailtest/conformance.go` | beadmail, exec |
 | `events.Recorder` | `internal/events/eventstest/conformance.go` | FileRecorder, exec |
+| `fsys.FS` | `internal/fsys/fsystest/conformance.go` | OSFS, Fake |
+
+The `fsys.FS` suite currently proves the portable namespace core: parent and
+file/directory collisions, regular-file copying and modes, `ReadDir` errors,
+file and directory-tree rename, empty/non-empty removal, and chmod. Symlink
+resolution/replacement, atomic-write composition, and operation-scoped fault
+and recording decorators remain follow-up contract slices; do not delete their
+OS-backed coverage based on the namespace suite alone.
 
 Builtin runtime production compositions are source-bound to `cmd/gc`'s
 registry, their constructor-specific contract dispositions, and the table

--- a/cmd/gc/cmd_beads_city_test.go
+++ b/cmd/gc/cmd_beads_city_test.go
@@ -741,6 +741,7 @@ func TestDoBeadsCityUseManagedPreservesCompatOnlyExplicitRigs(t *testing.T) {
 func TestSyncCityEndpointCompatConfigUsesAtomicWrite(t *testing.T) {
 	fs := fsys.NewFake()
 	cityDir := "/city"
+	fs.Dirs[cityDir] = true
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Dolt:      config.DoltConfig{Host: "old-city.example.com", Port: 3306},

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1043,6 +1043,7 @@ func TestRemoveDoltPortFileStrictClearsThroughSymlink(t *testing.T) {
 func TestSyncRigEndpointCompatConfigUsesAtomicWrite(t *testing.T) {
 	fs := fsys.NewFake()
 	cityDir := "/city"
+	fs.Dirs[cityDir] = true
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}, Rigs: []config.Rig{{Name: "frontend", Path: "/city/frontend", Prefix: "fe", DoltHost: "old-db.example.com", DoltPort: "3307"}}}
 	if err := syncRigEndpointCompatConfig(fs, cityDir, cfg, "frontend", contract.ConfigState{DoltHost: "new-db.example.com", DoltPort: "4406"}); err != nil {
 		t.Fatalf("syncRigEndpointCompatConfig: %v", err)
@@ -1064,6 +1065,7 @@ func TestSyncRigEndpointCompatConfigUsesAtomicWrite(t *testing.T) {
 
 func TestRestoreSnapshotUsesAtomicWrite(t *testing.T) {
 	fs := fsys.NewFake()
+	fs.Dirs["/city"] = true
 	snap := fileSnapshot{path: "/city/city.toml", data: []byte("updated = true\n"), exists: true}
 	if err := restoreSnapshot(fs, snap); err != nil {
 		t.Fatalf("restoreSnapshot: %v", err)

--- a/cmd/gc/gitignore_test.go
+++ b/cmd/gc/gitignore_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestEnsureGitignoreEntries_CreatesNewFile(t *testing.T) {
 	f := fsys.NewFake()
+	f.Dirs["/city"] = true
 
 	if err := ensureGitignoreEntries(f, "/city", cityGitignoreEntries); err != nil {
 		t.Fatalf("ensureGitignoreEntries: %v", err)
@@ -36,6 +37,7 @@ func TestEnsureGitignoreEntries_CreatesNewFile(t *testing.T) {
 
 func TestEnsureGitignoreEntries_RigEntriesKeepBeadsRuntimeIgnored(t *testing.T) {
 	f := fsys.NewFake()
+	f.Dirs["/rig"] = true
 
 	if err := ensureGitignoreEntries(f, "/rig", rigGitignoreEntries); err != nil {
 		t.Fatalf("ensureGitignoreEntries: %v", err)
@@ -136,6 +138,7 @@ func TestEnsureGitignoreEntries_SkipsExisting(t *testing.T) {
 
 func TestEnsureGitignoreEntries_Idempotent(t *testing.T) {
 	f := fsys.NewFake()
+	f.Dirs["/city"] = true
 
 	entries := cityGitignoreEntries
 	for i := 0; i < 3; i++ {
@@ -227,6 +230,7 @@ func TestEnsureGitignoreEntries_IdentityTomlNegationPresent(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := fsys.NewFake()
+			f.Dirs[tc.dir] = true
 			if err := ensureGitignoreEntries(f, tc.dir, tc.entries); err != nil {
 				t.Fatalf("ensureGitignoreEntries: %v", err)
 			}
@@ -254,6 +258,7 @@ func TestEnsureGitignoreEntries_IdentityTomlNegationAfterGlob(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := fsys.NewFake()
+			f.Dirs[tc.dir] = true
 			if err := ensureGitignoreEntries(f, tc.dir, tc.entries); err != nil {
 				t.Fatalf("ensureGitignoreEntries: %v", err)
 			}

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -203,6 +203,9 @@ func TestResolveTemplateControlDispatcherSuppressesStartupPrompt(t *testing.T) {
 	cityPath := t.TempDir()
 	fakeFS := fsys.NewFake()
 	promptPath := filepath.Join(cityPath, "prompts", "control-dispatcher.template.md")
+	if err := fakeFS.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("create prompt directory: %v", err)
+	}
 	if err := fakeFS.WriteFile(promptPath, []byte("startup prompt for {{.AgentName}}"), 0o644); err != nil {
 		t.Fatalf("write prompt template: %v", err)
 	}
@@ -254,6 +257,9 @@ func TestResolveTemplateExplicitControlDispatcherKeepsStartupPrompt(t *testing.T
 	cityPath := t.TempDir()
 	fakeFS := fsys.NewFake()
 	promptPath := filepath.Join(cityPath, "prompts", "control-dispatcher.template.md")
+	if err := fakeFS.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("create prompt directory: %v", err)
+	}
 	if err := fakeFS.WriteFile(promptPath, []byte("startup prompt for {{.AgentName}}"), 0o644); err != nil {
 		t.Fatalf("write prompt template: %v", err)
 	}

--- a/internal/fsys/conformance_test.go
+++ b/internal/fsys/conformance_test.go
@@ -1,0 +1,16 @@
+package fsys_test
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/fsys/fsystest"
+)
+
+func TestOSFSConformance(t *testing.T) {
+	fsystest.RunConformance(t, func() fsys.OSFS { return fsys.OSFS{} })
+}
+
+func TestFakeConformance(t *testing.T) {
+	fsystest.RunConformance(t, fsys.NewFake)
+}

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -13,6 +14,8 @@ import (
 // simulates filesystem state (fake). Pre-populate Dirs, Files, Symlinks,
 // and Errors before calling methods. ModTimes is optional unless a test needs
 // exact timestamp control; Stat synthesizes and stores a mod time on demand.
+// A directly seeded descendant implies its parent directories for fixture
+// compatibility, while mutating operations still reject truly missing parents.
 type Fake struct {
 	Dirs     map[string]bool   // pre-populated directories
 	Files    map[string][]byte // pre-populated files
@@ -56,6 +59,144 @@ func (f *Fake) nextModTime() time.Time {
 	return f.clock
 }
 
+type fakeEntryKind uint8
+
+const (
+	fakeEntryMissing fakeEntryKind = iota
+	fakeEntryDirectory
+	fakeEntryFile
+	fakeEntrySymlink
+)
+
+func (f *Fake) entryKind(path string) fakeEntryKind {
+	if _, ok := f.Symlinks[path]; ok {
+		return fakeEntrySymlink
+	}
+	if f.Dirs[path] {
+		return fakeEntryDirectory
+	}
+	if _, ok := f.Files[path]; ok {
+		return fakeEntryFile
+	}
+	if f.directoryExists(path) {
+		return fakeEntryDirectory
+	}
+	return fakeEntryMissing
+}
+
+func (f *Fake) directoryExists(path string) bool {
+	if f.Dirs[path] {
+		return true
+	}
+	clean := filepath.Clean(path)
+	if clean == "." || filepath.Dir(clean) == clean {
+		return true
+	}
+	return f.hasDescendant(path)
+}
+
+func (f *Fake) hasDescendant(path string) bool {
+	for candidate := range f.Dirs {
+		if isDescendant(candidate, path) {
+			return true
+		}
+	}
+	for candidate := range f.Files {
+		if isDescendant(candidate, path) {
+			return true
+		}
+	}
+	for candidate := range f.Symlinks {
+		if isDescendant(candidate, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *Fake) materializeParentDirectories(path string) {
+	var parents []string
+	for parent := filepath.Dir(filepath.Clean(path)); parent != "." && filepath.Dir(parent) != parent; parent = filepath.Dir(parent) {
+		parents = append(parents, parent)
+	}
+	if f.Dirs == nil {
+		f.Dirs = make(map[string]bool)
+	}
+	for i := len(parents) - 1; i >= 0; i-- {
+		parent := parents[i]
+		if f.entryKind(parent) != fakeEntryDirectory {
+			return
+		}
+		f.Dirs[parent] = true
+	}
+}
+
+func isDescendant(candidate, parent string) bool {
+	relative, err := filepath.Rel(filepath.Clean(parent), filepath.Clean(candidate))
+	if err != nil || relative == "." || filepath.IsAbs(relative) {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func immediateChild(parent, candidate string) (path string, direct bool, ok bool) {
+	relative, err := filepath.Rel(filepath.Clean(parent), filepath.Clean(candidate))
+	if err != nil || relative == "." || relative == ".." || filepath.IsAbs(relative) || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false, false
+	}
+	first := relative
+	if separator := strings.IndexRune(relative, filepath.Separator); separator >= 0 {
+		first = relative[:separator]
+	}
+	return filepath.Join(parent, first), first == relative, true
+}
+
+func fakePathError(operation, path string, err error) error {
+	return &os.PathError{Op: operation, Path: path, Err: err}
+}
+
+func rebasedPath(candidate, oldRoot, newRoot string) (string, bool) {
+	if filepath.Clean(candidate) == filepath.Clean(oldRoot) {
+		return newRoot, true
+	}
+	if !isDescendant(candidate, oldRoot) {
+		return "", false
+	}
+	relative, err := filepath.Rel(oldRoot, candidate)
+	if err != nil {
+		return "", false
+	}
+	return filepath.Join(newRoot, relative), true
+}
+
+func moveMapEntries[V any](entries map[string]V, oldRoot, newRoot string) {
+	type move struct {
+		oldPath string
+		newPath string
+		value   V
+	}
+	var moves []move
+	for path, value := range entries {
+		if destination, ok := rebasedPath(path, oldRoot, newRoot); ok {
+			moves = append(moves, move{oldPath: path, newPath: destination, value: value})
+		}
+	}
+	for _, item := range moves {
+		delete(entries, item.oldPath)
+	}
+	for _, item := range moves {
+		entries[item.newPath] = item.value
+	}
+}
+
+func (f *Fake) clearEntry(path string) {
+	delete(f.Dirs, path)
+	delete(f.Files, path)
+	delete(f.Symlinks, path)
+	delete(f.Modes, path)
+	delete(f.ModTimes, path)
+}
+
 // MkdirAll records the call and adds the directory (and parents) to Dirs.
 func (f *Fake) MkdirAll(path string, perm os.FileMode) error {
 	f.Calls = append(f.Calls, Call{Method: "MkdirAll", Path: path})
@@ -68,8 +209,19 @@ func (f *Fake) MkdirAll(path string, perm os.FileMode) error {
 	if f.Modes == nil {
 		f.Modes = make(map[string]os.FileMode)
 	}
-	// Record this directory and all parents.
-	for p := filepath.Clean(path); p != "." && p != "/" && p != string(filepath.Separator); p = filepath.Dir(p) {
+
+	var missing []string
+	for p := filepath.Clean(path); p != "." && filepath.Dir(p) != p; p = filepath.Dir(p) {
+		switch f.entryKind(p) {
+		case fakeEntryDirectory:
+			continue
+		case fakeEntryMissing:
+			missing = append(missing, p)
+		default:
+			return fakePathError("mkdir", path, fs.ErrExist)
+		}
+	}
+	for _, p := range missing {
 		if !f.Dirs[p] {
 			f.Modes[p] = perm.Perm()
 		}
@@ -84,6 +236,13 @@ func (f *Fake) WriteFile(name string, data []byte, perm os.FileMode) error {
 	if err, ok := f.Errors[name]; ok {
 		return err
 	}
+	if f.entryKind(filepath.Dir(name)) != fakeEntryDirectory {
+		return fakePathError("open", name, fs.ErrNotExist)
+	}
+	if f.entryKind(name) == fakeEntryDirectory {
+		return fakePathError("open", name, fs.ErrInvalid)
+	}
+	_, existed := f.Files[name]
 	modTime := f.nextModTime()
 	cp := make([]byte, len(data))
 	copy(cp, data)
@@ -94,7 +253,9 @@ func (f *Fake) WriteFile(name string, data []byte, perm os.FileMode) error {
 		f.Modes = make(map[string]os.FileMode)
 	}
 	f.Files[name] = cp
-	f.Modes[name] = perm.Perm()
+	if !existed {
+		f.Modes[name] = perm.Perm()
+	}
 	f.ModTimes[name] = modTime
 	return nil
 }
@@ -176,6 +337,9 @@ func (f *Fake) Stat(name string) (os.FileInfo, error) {
 		}
 		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(name), id: fakeIdentity(name), hasID: true, modTime: modTime}, nil
 	}
+	if f.directoryExists(name) {
+		return fakeFileInfo{name: filepath.Base(name), dir: true, mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
+	}
 	return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
 }
 
@@ -194,6 +358,9 @@ func (f *Fake) Lstat(name string) (os.FileInfo, error) {
 	}
 	if data, ok := f.Files[name]; ok {
 		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
+	}
+	if f.directoryExists(name) {
+		return fakeFileInfo{name: filepath.Base(name), dir: true, mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
 	}
 	return nil, &os.PathError{Op: "lstat", Path: name, Err: os.ErrNotExist}
 }
@@ -234,59 +401,97 @@ func (f *Fake) ReadDir(name string) ([]os.DirEntry, error) {
 		return nil, err
 	}
 
-	name = filepath.Clean(name)
-	seen := make(map[string]bool)
-	var entries []os.DirEntry
-
-	// Collect direct child directories.
-	for d := range f.Dirs {
-		if filepath.Dir(d) == name && d != name {
-			base := filepath.Base(d)
-			if !seen[base] {
-				seen[base] = true
-				entries = append(entries, fakeDirEntry{name: base, dir: true, mode: f.modeFor(d), id: fakeIdentity(d), hasID: true})
-			}
-		}
-	}
-	// Collect direct child files.
-	for p, data := range f.Files {
-		if filepath.Dir(p) == name {
-			base := filepath.Base(p)
-			if !seen[base] {
-				seen[base] = true
-				entries = append(entries, fakeDirEntry{name: base, size: int64(len(data)), mode: f.modeFor(p), id: fakeIdentity(p), hasID: true})
-			}
-		}
-	}
-	// Collect direct child symlinks.
-	for p := range f.Symlinks {
-		if filepath.Dir(p) == name {
-			base := filepath.Base(p)
-			if !seen[base] {
-				seen[base] = true
-				entries = append(entries, fakeDirEntry{name: base, symlink: true, id: fakeIdentity(p), hasID: true})
-			}
-		}
+	switch f.entryKind(name) {
+	case fakeEntryMissing:
+		return nil, fakePathError("readdir", name, fs.ErrNotExist)
+	case fakeEntryFile, fakeEntrySymlink:
+		return nil, fakePathError("readdir", name, fs.ErrInvalid)
 	}
 
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Name() < entries[j].Name()
-	})
+	entriesByName := make(map[string]os.DirEntry)
+	addImpliedDirectory := func(candidate string) {
+		child, direct, ok := immediateChild(name, candidate)
+		if !ok || direct {
+			return
+		}
+		base := filepath.Base(child)
+		if _, exists := entriesByName[base]; !exists {
+			entriesByName[base] = fakeDirEntry{name: base, dir: true, mode: f.modeFor(child), id: fakeIdentity(child), hasID: true}
+		}
+	}
+	for path := range f.Dirs {
+		addImpliedDirectory(path)
+	}
+	for path := range f.Files {
+		addImpliedDirectory(path)
+	}
+	for path := range f.Symlinks {
+		addImpliedDirectory(path)
+	}
+	for path, data := range f.Files {
+		if child, direct, ok := immediateChild(name, path); ok && direct {
+			base := filepath.Base(child)
+			entriesByName[base] = fakeDirEntry{name: base, size: int64(len(data)), mode: f.modeFor(path), id: fakeIdentity(path), hasID: true}
+		}
+	}
+	for path := range f.Dirs {
+		if child, direct, ok := immediateChild(name, path); ok && direct {
+			base := filepath.Base(child)
+			entriesByName[base] = fakeDirEntry{name: base, dir: true, mode: f.modeFor(path), id: fakeIdentity(path), hasID: true}
+		}
+	}
+	for path := range f.Symlinks {
+		if child, direct, ok := immediateChild(name, path); ok && direct {
+			base := filepath.Base(child)
+			entriesByName[base] = fakeDirEntry{name: base, symlink: true, id: fakeIdentity(path), hasID: true}
+		}
+	}
+
+	entries := make([]os.DirEntry, 0, len(entriesByName))
+	for _, entry := range entriesByName {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 	return entries, nil
 }
 
-// Rename records the call and moves the file in the Files map.
+// Rename records the call and moves a file, symlink, or directory tree.
 func (f *Fake) Rename(oldpath, newpath string) error {
 	f.Calls = append(f.Calls, Call{Method: "Rename", Path: oldpath})
 	if err, ok := f.Errors[oldpath]; ok {
 		return err
 	}
-	if target, ok := f.Symlinks[oldpath]; ok {
+	sourceKind := f.entryKind(oldpath)
+	if sourceKind == fakeEntryMissing {
+		return fakePathError("rename", oldpath, fs.ErrNotExist)
+	}
+	if oldpath == newpath {
+		return nil
+	}
+	if f.entryKind(filepath.Dir(newpath)) != fakeEntryDirectory {
+		return fakePathError("rename", newpath, fs.ErrNotExist)
+	}
+	destinationKind := f.entryKind(newpath)
+
+	switch sourceKind {
+	case fakeEntrySymlink:
+		if destinationKind == fakeEntryDirectory {
+			return fakePathError("rename", newpath, fs.ErrInvalid)
+		}
+		f.materializeParentDirectories(oldpath)
+		target := f.Symlinks[oldpath]
+		f.clearEntry(newpath)
 		f.Symlinks[newpath] = target
 		delete(f.Symlinks, oldpath)
 		return nil
-	}
-	if data, ok := f.Files[oldpath]; ok {
+
+	case fakeEntryFile:
+		if destinationKind == fakeEntryDirectory {
+			return fakePathError("rename", newpath, fs.ErrInvalid)
+		}
+		f.materializeParentDirectories(oldpath)
+		data := f.Files[oldpath]
+		f.clearEntry(newpath)
 		f.Files[newpath] = data
 		delete(f.Files, oldpath)
 		if mode, ok := f.Modes[oldpath]; ok {
@@ -295,7 +500,6 @@ func (f *Fake) Rename(oldpath, newpath string) error {
 			delete(f.Modes, newpath)
 		}
 		delete(f.Modes, oldpath)
-		delete(f.Symlinks, newpath)
 		if modTime, ok := f.ModTimes[oldpath]; ok {
 			f.ModTimes[newpath] = modTime
 			delete(f.ModTimes, oldpath)
@@ -303,32 +507,49 @@ func (f *Fake) Rename(oldpath, newpath string) error {
 			f.ModTimes[newpath] = f.nextModTime()
 		}
 		return nil
+
+	case fakeEntryDirectory:
+		if destinationKind != fakeEntryMissing || isDescendant(newpath, oldpath) {
+			return fakePathError("rename", newpath, fs.ErrInvalid)
+		}
+		f.materializeParentDirectories(oldpath)
+		moveMapEntries(f.Dirs, oldpath, newpath)
+		moveMapEntries(f.Files, oldpath, newpath)
+		moveMapEntries(f.Symlinks, oldpath, newpath)
+		moveMapEntries(f.Modes, oldpath, newpath)
+		moveMapEntries(f.ModTimes, oldpath, newpath)
+		return nil
 	}
-	return &os.PathError{Op: "rename", Path: oldpath, Err: os.ErrNotExist}
+	return fakePathError("rename", oldpath, fs.ErrInvalid)
 }
 
-// Remove records the call and deletes the file from the Files map.
+// Remove records the call and deletes a file, symlink, or empty directory.
 func (f *Fake) Remove(name string) error {
 	f.Calls = append(f.Calls, Call{Method: "Remove", Path: name})
 	if err, ok := f.Errors[name]; ok {
 		return err
 	}
 	if _, ok := f.Symlinks[name]; ok {
-		delete(f.Symlinks, name)
+		f.materializeParentDirectories(name)
+		f.clearEntry(name)
 		return nil
 	}
 	if _, ok := f.Files[name]; ok {
-		delete(f.Files, name)
+		f.materializeParentDirectories(name)
+		f.clearEntry(name)
+		return nil
+	}
+	if f.directoryExists(name) {
+		if f.hasDescendant(name) {
+			return fakePathError("remove", name, fs.ErrInvalid)
+		}
+		f.materializeParentDirectories(name)
+		delete(f.Dirs, name)
 		delete(f.Modes, name)
 		delete(f.ModTimes, name)
 		return nil
 	}
-	if f.Dirs[name] {
-		delete(f.Dirs, name)
-		delete(f.Modes, name)
-		return nil
-	}
-	return &os.PathError{Op: "remove", Path: name, Err: os.ErrNotExist}
+	return fakePathError("remove", name, fs.ErrNotExist)
 }
 
 // Chmod records the call and updates the stored mode.
@@ -347,7 +568,9 @@ func (f *Fake) Chmod(name string, mode os.FileMode) error {
 		f.Modes[name] = mode.Perm()
 		return nil
 	}
-	if f.Dirs[name] {
+	if f.directoryExists(name) {
+		f.materializeParentDirectories(name)
+		f.Dirs[name] = true
 		f.Modes[name] = mode.Perm()
 		return nil
 	}

--- a/internal/fsys/fake_test.go
+++ b/internal/fsys/fake_test.go
@@ -41,6 +41,7 @@ func TestFakeStatDirModeIncludesDirBit(t *testing.T) {
 
 func TestFakeStatFile(t *testing.T) {
 	f := NewFake()
+	f.Dirs["/city"] = true
 	if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -196,6 +197,7 @@ func TestFakeMkdirAllError(t *testing.T) {
 
 func TestFakeWriteFile(t *testing.T) {
 	f := NewFake()
+	f.Dirs["/city"] = true
 
 	data := []byte("# city.toml\n")
 	if err := f.WriteFile("/city/city.toml", data, 0o644); err != nil {
@@ -221,14 +223,14 @@ func TestFakeWriteFile(t *testing.T) {
 func TestFakeWriteFileInitializesNilMaps(t *testing.T) {
 	f := &Fake{}
 
-	if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
+	if err := f.WriteFile("/city.toml", []byte("hello"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	if got := string(f.Files["/city/city.toml"]); got != "hello" {
+	if got := string(f.Files["/city.toml"]); got != "hello" {
 		t.Fatalf("Files content = %q, want %q", got, "hello")
 	}
-	if f.ModTimes["/city/city.toml"].IsZero() {
+	if f.ModTimes["/city.toml"].IsZero() {
 		t.Fatal("expected WriteFile to initialize synthetic mod time")
 	}
 }
@@ -236,11 +238,11 @@ func TestFakeWriteFileInitializesNilMaps(t *testing.T) {
 func TestFakeWriteFileInitializesModes(t *testing.T) {
 	f := &Fake{Files: map[string][]byte{}}
 
-	if err := f.WriteFile("/city/run.sh", []byte("#!/bin/sh\n"), 0o755); err != nil {
+	if err := f.WriteFile("/run.sh", []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if f.Modes["/city/run.sh"] != 0o755 {
-		t.Fatalf("mode = %v, want 0755", f.Modes["/city/run.sh"])
+	if f.Modes["/run.sh"] != 0o755 {
+		t.Fatalf("mode = %v, want 0755", f.Modes["/run.sh"])
 	}
 }
 
@@ -289,8 +291,94 @@ func TestFakeReadDir(t *testing.T) {
 	}
 }
 
+func TestFakeDirectSeededChildrenImplyOnlyComponentParents(t *testing.T) {
+	f := NewFake()
+	f.Files["/city/rigs/alpha/config.toml"] = []byte("alpha")
+
+	info, err := f.Stat("/city/rigs")
+	if err != nil {
+		t.Fatalf("Stat implied parent: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("implied parent mode = %v, want directory", info.Mode())
+	}
+	entries, err := f.ReadDir("/city/rigs")
+	if err != nil {
+		t.Fatalf("ReadDir implied parent: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "alpha" || !entries[0].IsDir() {
+		t.Fatalf("ReadDir implied entries = %+v, want alpha directory", entries)
+	}
+	if err := f.WriteFile("/city/rigs/new.toml", []byte("new"), 0o600); err != nil {
+		t.Fatalf("WriteFile under implied parent: %v", err)
+	}
+
+	prefixOnly := NewFake()
+	prefixOnly.Files["/city/rigs-old/config.toml"] = []byte("old")
+	if _, err := prefixOnly.Stat("/city/rigs"); !os.IsNotExist(err) {
+		t.Fatalf("Stat prefix-only path error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestFakeInferredParentsPersistAfterLastChildRemoval(t *testing.T) {
+	f := NewFake()
+	file := "/city/rig/file"
+	f.Files[file] = []byte("content")
+
+	if err := f.Remove(file); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	for _, path := range []string{"/city", "/city/rig"} {
+		info, err := f.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat(%q): %v", path, err)
+		}
+		if !info.IsDir() {
+			t.Errorf("Stat(%q).Mode() = %v, want directory", path, info.Mode())
+		}
+	}
+}
+
+func TestFakeInferredSourceParentPersistsAfterDirectoryRename(t *testing.T) {
+	f := NewFake()
+	f.Files["/city/source/file"] = []byte("content")
+	f.Dirs["/destination"] = true
+
+	if err := f.Rename("/city/source", "/destination/source"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	info, err := f.Stat("/city")
+	if err != nil {
+		t.Fatalf("Stat source parent: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("source parent mode = %v, want directory", info.Mode())
+	}
+	if got, err := f.ReadFile("/destination/source/file"); err != nil || string(got) != "content" {
+		t.Fatalf("renamed child = %q, %v; want %q, nil", got, err, "content")
+	}
+}
+
+func TestFakeChmodMaterializesInferredDirectory(t *testing.T) {
+	f := NewFake()
+	f.Files["/city/rig/file"] = []byte("content")
+
+	if err := f.Chmod("/city/rig", 0o700); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	delete(f.Files, "/city/rig/file")
+	info, err := f.Stat("/city/rig")
+	if err != nil {
+		t.Fatalf("Stat after removing seeded child: %v", err)
+	}
+	if !info.IsDir() || info.Mode().Perm() != 0o700 {
+		t.Fatalf("materialized directory mode = %v, want directory 0700", info.Mode())
+	}
+}
+
 func TestFakeReadDirInfoReportsTrackedMode(t *testing.T) {
 	f := NewFake()
+	f.Dirs["/city/rigs"] = true
 	if err := f.WriteFile("/city/rigs/run.sh", []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -324,6 +412,7 @@ func TestFakeReadDirError(t *testing.T) {
 
 func TestFakeReadDirEmpty(t *testing.T) {
 	f := NewFake()
+	f.Dirs["/city/rigs"] = true
 
 	entries, err := f.ReadDir("/city/rigs")
 	if err != nil {
@@ -336,6 +425,7 @@ func TestFakeReadDirEmpty(t *testing.T) {
 
 func TestFakeRename(t *testing.T) {
 	f := NewFake()
+	f.Dirs["/city"] = true
 	if err := f.WriteFile("/city/beads.json.tmp", []byte(`{"seq":1}`), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -365,6 +455,7 @@ func TestFakeRenameClearsStaleDestinationMode(t *testing.T) {
 	f := NewFake()
 	f.Files["/city/generated.tmp"] = []byte("new")
 	f.Files["/city/generated"] = []byte("old")
+	f.Modes["/city/generated.tmp"] = 0o600
 	f.Modes["/city/generated"] = 0o644
 
 	if err := f.Rename("/city/generated.tmp", "/city/generated"); err != nil {
@@ -375,8 +466,22 @@ func TestFakeRenameClearsStaleDestinationMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
 	}
-	if info.Mode().Perm() != 0o755 {
-		t.Fatalf("renamed file mode = %v, want default 0755", info.Mode().Perm())
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("renamed file mode = %v, want source mode 0600", info.Mode().Perm())
+	}
+}
+
+func TestFakeRenameWithNilModTimes(t *testing.T) {
+	f := &Fake{Files: map[string][]byte{"/source": []byte("content")}}
+
+	if err := f.Rename("/source", "/destination"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if got := string(f.Files["/destination"]); got != "content" {
+		t.Fatalf("destination content = %q, want %q", got, "content")
+	}
+	if f.ModTimes["/destination"].IsZero() {
+		t.Fatal("destination mod time was not initialized")
 	}
 }
 
@@ -444,6 +549,7 @@ func TestFakeRenameMissing(t *testing.T) {
 func TestFakeRemoveVariants(t *testing.T) {
 	t.Run("file removes modtime", func(t *testing.T) {
 		f := NewFake()
+		f.Dirs["/city"] = true
 		if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
@@ -486,6 +592,7 @@ func TestFakeRemoveVariants(t *testing.T) {
 
 func TestFakeChmodVariants(t *testing.T) {
 	f := NewFake()
+	f.Dirs["/city"] = true
 	if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}

--- a/internal/fsys/fsys.go
+++ b/internal/fsys/fsys.go
@@ -10,12 +10,16 @@ import (
 	"os"
 )
 
-// FS abstracts the filesystem operations used by CLI commands.
+// FS abstracts the filesystem operations used by CLI commands. Implementations
+// share the portable namespace contract in internal/fsys/fsystest.
 type FS interface {
-	// MkdirAll creates a directory path and all parents that do not exist.
+	// MkdirAll creates a directory path and all parents that do not exist. It
+	// returns an error when the path or one of its ancestors is a file.
 	MkdirAll(path string, perm os.FileMode) error
 
-	// WriteFile writes data to the named file, creating it if necessary.
+	// WriteFile writes data to the named file, creating it if necessary. The
+	// parent directory must exist, directories cannot be overwritten, and the
+	// mode of an existing file is preserved.
 	WriteFile(name string, data []byte, perm os.FileMode) error
 
 	// ReadFile reads the named file and returns its contents.
@@ -29,16 +33,18 @@ type FS interface {
 	// the mode's ModeSymlink bit before touching the path.
 	Lstat(name string) (os.FileInfo, error)
 
-	// ReadDir reads the named directory and returns its entries.
+	// ReadDir reads the named directory and returns its entries. Missing paths
+	// and non-directory paths return errors.
 	ReadDir(name string) ([]os.DirEntry, error)
 
-	// Rename renames (moves) oldpath to newpath.
+	// Rename renames (moves) oldpath to newpath. The destination parent must
+	// exist, and moving a directory moves its complete subtree.
 	Rename(oldpath, newpath string) error
 
 	// Remove removes the named file or empty directory.
 	Remove(name string) error
 
-	// Chmod changes the mode of the named file or directory.
+	// Chmod changes the mode of an existing file or directory.
 	Chmod(name string, mode os.FileMode) error
 }
 

--- a/internal/fsys/fsystest/conformance.go
+++ b/internal/fsys/fsystest/conformance.go
@@ -1,0 +1,417 @@
+// Package fsystest provides conformance tests for fsys.FS implementations.
+package fsystest
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// RunConformance exercises the portable namespace contract shared by real
+// filesystems and reusable filesystem doubles. newFS must return a fresh,
+// empty implementation for every call.
+func RunConformance[T fsys.FS](t *testing.T, newFS func() T) {
+	t.Helper()
+
+	t.Run("RegularFileRoundTripUsesDefensiveCopies", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		path := filepath.Join(root, "round-trip.txt")
+		input := []byte("original")
+		if err := filesystem.WriteFile(path, input, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		input[0] = 'X'
+		first := mustReadFile(t, filesystem, path)
+		if !bytes.Equal(first, []byte("original")) {
+			t.Fatalf("content after mutating WriteFile input = %q, want %q", first, "original")
+		}
+
+		first[0] = 'Y'
+		second := mustReadFile(t, filesystem, path)
+		if !bytes.Equal(second, []byte("original")) {
+			t.Fatalf("content after mutating ReadFile result = %q, want %q", second, "original")
+		}
+		info := mustStat(t, filesystem, path)
+		if !info.Mode().IsRegular() {
+			t.Fatalf("mode = %v, want regular file", info.Mode())
+		}
+	})
+
+	t.Run("WriteFileRequiresExistingParent", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		parent := filepath.Join(root, "missing")
+		path := filepath.Join(parent, "file.txt")
+		if err := filesystem.WriteFile(path, []byte("data"), 0o600); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("WriteFile without parent error = %v, want fs.ErrNotExist", err)
+		}
+		assertNotExist(t, filesystem, parent)
+		assertNotExist(t, filesystem, path)
+	})
+
+	t.Run("MkdirAllRejectsFileAncestor", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		ancestor := filepath.Join(root, "ancestor")
+		child := filepath.Join(ancestor, "child")
+		if err := filesystem.WriteFile(ancestor, []byte("file"), 0o600); err != nil {
+			t.Fatalf("WriteFile ancestor: %v", err)
+		}
+		if err := filesystem.MkdirAll(child, 0o700); err == nil {
+			t.Error("MkdirAll through file ancestor succeeded")
+		}
+		if info := mustStat(t, filesystem, ancestor); !info.Mode().IsRegular() {
+			t.Errorf("ancestor mode = %v, want regular file", info.Mode())
+		}
+		if info, err := filesystem.Stat(child); err == nil {
+			t.Errorf("Stat(%q) = (%v, nil), want inaccessible child", child, info)
+		}
+	})
+
+	t.Run("MkdirAllRejectsExistingFile", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		path := filepath.Join(root, "file")
+		if err := filesystem.WriteFile(path, []byte("data"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := filesystem.MkdirAll(path, 0o700); err == nil {
+			t.Error("MkdirAll over existing file succeeded")
+		}
+		if got := mustReadFile(t, filesystem, path); !bytes.Equal(got, []byte("data")) {
+			t.Errorf("file content after MkdirAll = %q, want %q", got, "data")
+		}
+	})
+
+	t.Run("WriteFileRejectsDirectory", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		path := filepath.Join(root, "directory")
+		if err := filesystem.MkdirAll(path, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := filesystem.WriteFile(path, []byte("data"), 0o600); err == nil {
+			t.Error("WriteFile over directory succeeded")
+		}
+		if info := mustStat(t, filesystem, path); !info.IsDir() {
+			t.Errorf("path mode after WriteFile = %v, want directory", info.Mode())
+		}
+		if _, err := filesystem.ReadFile(path); err == nil {
+			t.Error("ReadFile on directory succeeded after rejected WriteFile")
+		}
+	})
+
+	t.Run("WriteFilePreservesExistingMode", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		path := filepath.Join(root, "existing.txt")
+		if err := filesystem.WriteFile(path, []byte("before"), 0o600); err != nil {
+			t.Fatalf("initial WriteFile: %v", err)
+		}
+		if err := filesystem.Chmod(path, 0o600); err != nil {
+			t.Fatalf("initial Chmod: %v", err)
+		}
+		wantMode := mustStat(t, filesystem, path).Mode().Perm()
+		if err := filesystem.WriteFile(path, []byte("after"), 0o644); err != nil {
+			t.Fatalf("replacement WriteFile: %v", err)
+		}
+		if got := mustReadFile(t, filesystem, path); !bytes.Equal(got, []byte("after")) {
+			t.Errorf("content = %q, want %q", got, "after")
+		}
+		if got := mustStat(t, filesystem, path).Mode().Perm(); got != wantMode {
+			t.Errorf("mode = %v, want existing mode %v", got, wantMode)
+		}
+	})
+
+	t.Run("ReadDirRejectsMissingPath", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		path := filepath.Join(root, "missing")
+		if _, err := filesystem.ReadDir(path); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("ReadDir missing error = %v, want fs.ErrNotExist", err)
+		}
+	})
+
+	t.Run("ReadDirRejectsRegularFile", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		path := filepath.Join(root, "file.txt")
+		if err := filesystem.WriteFile(path, []byte("data"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := filesystem.ReadDir(path); err == nil {
+			t.Error("ReadDir on regular file succeeded")
+		}
+		if got := mustReadFile(t, filesystem, path); !bytes.Equal(got, []byte("data")) {
+			t.Errorf("file content after ReadDir = %q, want %q", got, "data")
+		}
+	})
+
+	t.Run("RenameFilePreservesContentAndMode", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		source := filepath.Join(root, "source.txt")
+		destination := filepath.Join(root, "destination.txt")
+		if err := filesystem.WriteFile(source, []byte("data"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := filesystem.Chmod(source, 0o600); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		wantMode := mustStat(t, filesystem, source).Mode().Perm()
+		if err := filesystem.Rename(source, destination); err != nil {
+			t.Fatalf("Rename: %v", err)
+		}
+
+		assertNotExist(t, filesystem, source)
+		if got := mustReadFile(t, filesystem, destination); !bytes.Equal(got, []byte("data")) {
+			t.Errorf("destination content = %q, want %q", got, "data")
+		}
+		if got := mustStat(t, filesystem, destination).Mode().Perm(); got != wantMode {
+			t.Errorf("destination mode = %v, want source mode %v", got, wantMode)
+		}
+	})
+
+	t.Run("RenameMovesDirectoryTree", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		source := filepath.Join(root, "source")
+		sourceChild := filepath.Join(source, "nested", "file.txt")
+		siblingChild := filepath.Join(root, "source-sibling", "keep.txt")
+		destination := filepath.Join(root, "destination")
+		destinationChild := filepath.Join(destination, "nested", "file.txt")
+		if err := filesystem.MkdirAll(filepath.Dir(sourceChild), 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := filesystem.MkdirAll(filepath.Dir(siblingChild), 0o700); err != nil {
+			t.Fatalf("MkdirAll sibling: %v", err)
+		}
+		if err := filesystem.WriteFile(sourceChild, []byte("nested"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := filesystem.WriteFile(siblingChild, []byte("sibling"), 0o600); err != nil {
+			t.Fatalf("WriteFile sibling: %v", err)
+		}
+		if err := filesystem.Chmod(source, 0o750); err != nil {
+			t.Fatalf("Chmod source: %v", err)
+		}
+		if err := filesystem.Chmod(filepath.Dir(sourceChild), 0o710); err != nil {
+			t.Fatalf("Chmod nested directory: %v", err)
+		}
+		sourceMode := mustStat(t, filesystem, source).Mode().Perm()
+		nestedMode := mustStat(t, filesystem, filepath.Dir(sourceChild)).Mode().Perm()
+		if err := filesystem.Rename(source, destination); err != nil {
+			t.Fatalf("Rename directory: %v", err)
+		}
+
+		assertNotExist(t, filesystem, source)
+		if info := mustStat(t, filesystem, destination); !info.IsDir() || info.Mode().Perm() != sourceMode {
+			t.Errorf("renamed directory mode = %v, want directory mode %v", info.Mode(), sourceMode)
+		}
+		if info := mustStat(t, filesystem, filepath.Join(destination, "nested")); !info.IsDir() || info.Mode().Perm() != nestedMode {
+			t.Errorf("renamed child mode = %v, want directory mode %v", info.Mode(), nestedMode)
+		}
+		if got := mustReadFile(t, filesystem, destinationChild); !bytes.Equal(got, []byte("nested")) {
+			t.Errorf("renamed child content = %q, want %q", got, "nested")
+		}
+		if got := mustReadFile(t, filesystem, siblingChild); !bytes.Equal(got, []byte("sibling")) {
+			t.Errorf("prefix-similar sibling content = %q, want %q", got, "sibling")
+		}
+	})
+
+	t.Run("RenameRequiresDestinationParent", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		source := filepath.Join(root, "source.txt")
+		destinationParent := filepath.Join(root, "missing")
+		destination := filepath.Join(destinationParent, "destination.txt")
+		if err := filesystem.WriteFile(source, []byte("data"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := filesystem.Rename(source, destination); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Rename into missing parent error = %v, want fs.ErrNotExist", err)
+		}
+		if got := mustReadFile(t, filesystem, source); !bytes.Equal(got, []byte("data")) {
+			t.Errorf("source content after Rename = %q, want %q", got, "data")
+		}
+		assertNotExist(t, filesystem, destinationParent)
+		assertNotExist(t, filesystem, destination)
+	})
+
+	t.Run("RenameRejectsMissingSource", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		source := filepath.Join(root, "missing.txt")
+		destination := filepath.Join(root, "destination.txt")
+		if err := filesystem.Rename(source, destination); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Rename missing source error = %v, want fs.ErrNotExist", err)
+		}
+		assertNotExist(t, filesystem, source)
+		assertNotExist(t, filesystem, destination)
+	})
+
+	t.Run("RenameRejectsFileDirectoryCollisions", func(t *testing.T) {
+		t.Run("file onto directory", func(t *testing.T) {
+			filesystem, root := newNamespace(t, newFS)
+			file := filepath.Join(root, "file")
+			directory := filepath.Join(root, "directory")
+			if err := filesystem.WriteFile(file, []byte("file"), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if err := filesystem.MkdirAll(directory, 0o700); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := filesystem.Rename(file, directory); err == nil {
+				t.Error("Rename file onto directory succeeded")
+			}
+			if got := mustReadFile(t, filesystem, file); !bytes.Equal(got, []byte("file")) {
+				t.Errorf("source file content = %q, want %q", got, "file")
+			}
+			if info := mustStat(t, filesystem, directory); !info.IsDir() {
+				t.Errorf("destination mode = %v, want directory", info.Mode())
+			}
+		})
+
+		t.Run("directory onto file", func(t *testing.T) {
+			filesystem, root := newNamespace(t, newFS)
+			directory := filepath.Join(root, "directory")
+			child := filepath.Join(directory, "child.txt")
+			file := filepath.Join(root, "file")
+			if err := filesystem.MkdirAll(directory, 0o700); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := filesystem.WriteFile(child, []byte("child"), 0o600); err != nil {
+				t.Fatalf("WriteFile child: %v", err)
+			}
+			if err := filesystem.WriteFile(file, []byte("file"), 0o600); err != nil {
+				t.Fatalf("WriteFile destination: %v", err)
+			}
+			if err := filesystem.Rename(directory, file); err == nil {
+				t.Error("Rename directory onto file succeeded")
+			}
+			if got := mustReadFile(t, filesystem, child); !bytes.Equal(got, []byte("child")) {
+				t.Errorf("source child content = %q, want %q", got, "child")
+			}
+			if got := mustReadFile(t, filesystem, file); !bytes.Equal(got, []byte("file")) {
+				t.Errorf("destination file content = %q, want %q", got, "file")
+			}
+		})
+	})
+
+	t.Run("RemoveRejectsNonEmptyDirectory", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		directory := filepath.Join(root, "directory")
+		child := filepath.Join(directory, "child.txt")
+		if err := filesystem.MkdirAll(directory, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := filesystem.WriteFile(child, []byte("data"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := filesystem.Remove(directory); err == nil {
+			t.Error("Remove non-empty directory succeeded")
+		}
+		if info := mustStat(t, filesystem, directory); !info.IsDir() {
+			t.Errorf("directory mode after Remove = %v, want directory", info.Mode())
+		}
+		if got := mustReadFile(t, filesystem, child); !bytes.Equal(got, []byte("data")) {
+			t.Errorf("child content after Remove = %q, want %q", got, "data")
+		}
+	})
+
+	t.Run("RemoveDeletesFilesAndEmptyDirectories", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		file := filepath.Join(root, "file.txt")
+		directory := filepath.Join(root, "empty")
+		if err := filesystem.WriteFile(file, []byte("data"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := filesystem.MkdirAll(directory, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := filesystem.Remove(file); err != nil {
+			t.Fatalf("Remove file: %v", err)
+		}
+		if err := filesystem.Remove(directory); err != nil {
+			t.Fatalf("Remove empty directory: %v", err)
+		}
+		assertNotExist(t, filesystem, file)
+		assertNotExist(t, filesystem, directory)
+		if err := filesystem.Remove(file); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Remove missing file error = %v, want fs.ErrNotExist", err)
+		}
+	})
+
+	t.Run("ChmodUpdatesFilesAndDirectories", func(t *testing.T) {
+		filesystem, root := newNamespace(t, newFS)
+		file := filepath.Join(root, "file.txt")
+		directory := filepath.Join(root, "directory")
+		if err := filesystem.WriteFile(file, []byte("data"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := filesystem.MkdirAll(directory, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := filesystem.Chmod(file, 0o640); err != nil {
+			t.Fatalf("Chmod file: %v", err)
+		}
+		if err := filesystem.Chmod(directory, 0o750); err != nil {
+			t.Fatalf("Chmod directory: %v", err)
+		}
+		fileInfo := mustStat(t, filesystem, file)
+		if !fileInfo.Mode().IsRegular() {
+			t.Errorf("file mode after Chmod = %v, want regular file", fileInfo.Mode())
+		}
+		directoryInfo := mustStat(t, filesystem, directory)
+		if !directoryInfo.IsDir() {
+			t.Errorf("directory mode after Chmod = %v, want directory", directoryInfo.Mode())
+		}
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+			if got := fileInfo.Mode().Perm(); got != 0o640 {
+				t.Errorf("file mode = %v, want 0640", got)
+			}
+			if got := directoryInfo.Mode().Perm(); got != 0o750 {
+				t.Errorf("directory mode = %v, want 0750", got)
+			}
+		}
+
+		missing := filepath.Join(root, "missing")
+		if err := filesystem.Chmod(missing, 0o600); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Chmod missing error = %v, want fs.ErrNotExist", err)
+		}
+	})
+}
+
+func newNamespace[T fsys.FS](t *testing.T, newFS func() T) (fsys.FS, string) {
+	t.Helper()
+	filesystem := fsys.FS(newFS())
+	root := filepath.Join(t.TempDir(), "namespace")
+	if !filepath.IsAbs(root) {
+		t.Fatalf("test namespace %q is not absolute", root)
+	}
+	if err := filesystem.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("MkdirAll namespace: %v", err)
+	}
+	return filesystem, root
+}
+
+func mustReadFile(t *testing.T, filesystem fsys.FS, path string) []byte {
+	t.Helper()
+	data, err := filesystem.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	return data
+}
+
+func mustStat(t *testing.T, filesystem fsys.FS, path string) os.FileInfo {
+	t.Helper()
+	info, err := filesystem.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	return info
+}
+
+func assertNotExist(t *testing.T, filesystem fsys.FS, path string) {
+	t.Helper()
+	if info, err := filesystem.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("Stat(%q) = (%v, %v), want fs.ErrNotExist", path, info, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add one reusable fsys.FS namespace conformance suite bound to the exact OSFS and Fake constructors
- make Fake honor existing-parent, collision, copy, mode, ReadDir, rename-tree, remove, and chmod semantics
- preserve component-implied fixture parents across destructive mutations
- correct impossible cmd/gc and fsys fixtures exposed by the stricter contract
- document the proven surface and explicit H1b deferrals

## Contract scope
Covered: parent requirements, file/directory collisions, defensive copies, mode preservation, missing/file ReadDir, file and directory-tree rename, prefix-sibling safety, empty/non-empty removal, and chmod.

Deferred: symlink resolution/replacement, atomic-write composition, and operation-scoped fault/recording decorators.

## Verification
- go test -race -count=20 ./internal/fsys/...
- make test-fast-parallel
- make test-cmd-gc-process-parallel
- go vet ./...
- make check-docs
- configured pre-commit and pre-push hooks
- three delegated council lanes, two rounds; all CLEAR after fixing inferred-parent lifetime
- exact range-diff through three mainline rebases

## Portability
Linux executes locally. Darwin compiles in the fast lane; this PR carries needs-mac so TestOSFSConformance executes natively on macOS before merge.