### PR TITLE
fix(api): fail closed on rig-provision manifest persist; fence IPv6 transitional SSRF forms

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1637,7 +1637,7 @@ func (cs *controllerState) CreateRig(r config.Rig) error {
 // The config.Rig result is consumed across the StateMutator boundary by
 // spawnRigProvision; unparam only sees cmd/gc's error-path test call sites,
 // which discard it, hence the directive.
-func (cs *controllerState) ProvisionRigFromGit(ctx context.Context, r config.Rig, gitURL string, onStep func(step, detail string, warn bool), onManifest func(api.RigProvisionManifest)) (config.Rig, error) { //nolint:unparam
+func (cs *controllerState) ProvisionRigFromGit(ctx context.Context, r config.Rig, gitURL string, onStep func(step, detail string, warn bool), onManifest func(api.RigProvisionManifest) error) (config.Rig, error) { //nolint:unparam
 	gitURL = strings.TrimSpace(gitURL)
 	if gitURL == "" {
 		return config.Rig{}, fmt.Errorf("%w: git_url is required", configedit.ErrValidation)
@@ -1689,9 +1689,16 @@ func (cs *controllerState) ProvisionRigFromGit(ctx context.Context, r config.Rig
 
 	// Record-then-create (C4c §2.2): manifest the dir we are about to create
 	// BEFORE the clone, so a crash mid-clone still leaves the debris findable by
-	// the boot sweep and a runtime failure tears down the partial clone.
+	// the boot sweep and a runtime failure tears down the partial clone. This
+	// persist is fail-closed: if the durable write does not land we must NOT
+	// clone, or the created directory would be un-manifested and neither the
+	// boot sweep nor a re-clone pre-drop could discover it — wedging the
+	// request_id/name on every retry. No resource has been created yet, so
+	// aborting here leaves clean ground.
 	if onManifest != nil {
-		onManifest(api.RigProvisionManifest{RigName: r.Name, CreatedDir: r.Path})
+		if err := onManifest(api.RigProvisionManifest{RigName: r.Name, CreatedDir: r.Path}); err != nil {
+			return config.Rig{}, fmt.Errorf("recording rig-provision manifest before clone: %w", err)
+		}
 	}
 
 	if onStep != nil {
@@ -1719,13 +1726,21 @@ func (cs *controllerState) ProvisionRigFromGit(ctx context.Context, r config.Rig
 	}
 
 	// Provision succeeded: extend the manifest with the managed Dolt database
-	// this add minted (if any), so the rollback path can drop it.
+	// this add minted (if any), so the rollback path can drop it. Unlike the
+	// pre-clone checkpoint, a persist failure here is NOT fatal: the rig is now
+	// fully provisioned, so if the process crashes before the durable succeeded
+	// write the boot sweep's completeness probe reconciles it FORWARD (never
+	// tears it down), and the runtime rollback path uses the in-memory manifest.
+	// Failing a healthy provision on a transient metadata write would destroy a
+	// good rig, so log and continue.
 	if onManifest != nil {
-		onManifest(api.RigProvisionManifest{
+		if err := onManifest(api.RigProvisionManifest{
 			RigName:    r.Name,
 			CreatedDir: r.Path,
 			DoltDB:     cs.provisionedManagedDoltDatabase(r.Path),
-		})
+		}); err != nil {
+			log.Printf("api: rig %q provisioned but persisting the post-init manifest failed (non-fatal; forward-reconciled on retry/sweep): %v", r.Name, err)
+		}
 	}
 	return provisioned, nil
 }

--- a/cmd/gc/api_state_rig_rollback_test.go
+++ b/cmd/gc/api_state_rig_rollback_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/configedit"
+	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/rig"
 	"github.com/gastownhall/gascity/internal/ssrf"
 )
@@ -176,7 +177,7 @@ func TestProvisionRigFromGitRejectsPreexistingPath(t *testing.T) {
 		config.Rig{Name: "taken", Path: existing},
 		"https://example.com/r.git",
 		nil,
-		func(api.RigProvisionManifest) { manifested = true },
+		func(api.RigProvisionManifest) error { manifested = true; return nil },
 	)
 	if err == nil || !errors.Is(err, configedit.ErrValidation) {
 		t.Fatalf("ProvisionRigFromGit preexisting = %v, want a validation error", err)
@@ -202,7 +203,7 @@ func TestProvisionRigFromGitManifestsThenWrapsCloneError(t *testing.T) {
 		config.Rig{Name: "httpfail"},
 		"http://myhost.example/repo.git", // scheme-rejected by git.Clone, no network
 		nil,
-		func(m api.RigProvisionManifest) { manifests = append(manifests, m) },
+		func(m api.RigProvisionManifest) error { manifests = append(manifests, m); return nil },
 	)
 	if err == nil || !errors.Is(err, rig.ErrCloneFailed) {
 		t.Fatalf("ProvisionRigFromGit clone-fail = %v, want wrapped rig.ErrCloneFailed", err)
@@ -210,6 +211,43 @@ func TestProvisionRigFromGitManifestsThenWrapsCloneError(t *testing.T) {
 	// The dir was manifested (record-then-create) before the clone failure.
 	if len(manifests) != 1 || manifests[0].CreatedDir == "" || manifests[0].RigName != "httpfail" {
 		t.Fatalf("manifests = %+v, want one created_dir entry before the clone", manifests)
+	}
+}
+
+// TestProvisionRigFromGitAbortsWhenPreCloneManifestPersistFails locks the C4c
+// fail-closed contract for record-then-create: if durably persisting the
+// created_dir manifest fails BEFORE the clone, ProvisionRigFromGit must abort
+// without cloning. The pre-fix behavior logged the persist error and cloned
+// anyway, creating an un-manifested rig directory that neither the boot sweep
+// nor a re-clone pre-drop could discover — wedging the request_id/name on every
+// retry. The clone is stubbed so no network is touched and the assertion is
+// purely "did we reach the clone".
+func TestProvisionRigFromGitAbortsWhenPreCloneManifestPersistFails(t *testing.T) {
+	origResolver := ssrf.HostResolver
+	ssrf.HostResolver = func(string) ([]net.IP, error) { return []net.IP{net.ParseIP("140.82.112.3")}, nil }
+	defer func() { ssrf.HostResolver = origResolver }()
+
+	cloneCalled := false
+	origClone := rigCloneGit
+	rigCloneGit = func(context.Context, string, string, git.CloneOptions) error {
+		cloneCalled = true
+		return nil
+	}
+	defer func() { rigCloneGit = origClone }()
+
+	cs := &controllerState{cityPath: t.TempDir()}
+	persistErr := errors.New("SetMetadataBatch failed")
+	_, err := cs.ProvisionRigFromGit(context.Background(),
+		config.Rig{Name: "wedge"},
+		"https://example.com/repo.git",
+		nil,
+		func(api.RigProvisionManifest) error { return persistErr },
+	)
+	if err == nil || !errors.Is(err, persistErr) {
+		t.Fatalf("ProvisionRigFromGit with a failing pre-clone manifest = %v, want the persist error", err)
+	}
+	if cloneCalled {
+		t.Fatal("clone ran after the pre-clone manifest persist failed (an un-manifested dir could wedge the name)")
 	}
 }
 
@@ -268,7 +306,7 @@ func TestProvisionRigFromGitRejectsEscapingRelativePath(t *testing.T) {
 		config.Rig{Name: "evil", Path: "../../etc/evil"},
 		"https://example.com/r.git",
 		nil,
-		func(api.RigProvisionManifest) { manifested = true },
+		func(api.RigProvisionManifest) error { manifested = true; return nil },
 	)
 	if err == nil || !errors.Is(err, configedit.ErrValidation) {
 		t.Fatalf("escaping relative path = %v, want a validation error", err)
@@ -310,7 +348,7 @@ func TestProvisionRigFromGitRejectsSymlinkedParent(t *testing.T) {
 		config.Rig{Name: "rig", Path: "link/rig"},
 		"https://example.com/r.git",
 		nil,
-		func(api.RigProvisionManifest) { manifested = true },
+		func(api.RigProvisionManifest) error { manifested = true; return nil },
 	)
 	if err == nil || !errors.Is(err, configedit.ErrValidation) {
 		t.Fatalf("symlinked-parent path = %v, want a validation error", err)

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -358,10 +358,12 @@ func (f *fakeMutatorState) CreateRig(r config.Rig) error {
 // clone/SSRF and just appends the rig (emitting synthetic progress) so handler
 // tests can exercise the 202 flow without a network. If onStep is set it emits
 // a clone + done step. onManifest is invoked record-then-create with the
-// created dir so persistence/rollback wiring is exercised. When provisionFailN
-// is set it returns provisionErr after the manifest is reported (a failure once
-// the dir exists), without appending the rig.
-func (f *fakeMutatorState) ProvisionRigFromGit(ctx context.Context, r config.Rig, gitURL string, onStep func(step, detail string, warn bool), onManifest func(RigProvisionManifest)) (config.Rig, error) {
+// created dir so persistence/rollback wiring is exercised; mirroring the real
+// path, a pre-clone onManifest error is fail-closed (abort before appending the
+// rig) while the post-init one is best-effort. When provisionFailN is set it
+// returns provisionErr after the manifest is reported (a failure once the dir
+// exists), without appending the rig.
+func (f *fakeMutatorState) ProvisionRigFromGit(ctx context.Context, r config.Rig, gitURL string, onStep func(step, detail string, warn bool), onManifest func(RigProvisionManifest) error) (config.Rig, error) {
 	_, hasDeadline := ctx.Deadline()
 	f.provisionMu.Lock()
 	f.provisionCtxHadDeadline = hasDeadline
@@ -381,9 +383,13 @@ func (f *fakeMutatorState) ProvisionRigFromGit(ctx context.Context, r config.Rig
 	if r.Path == "" {
 		r.Path = "rigs/" + r.Name
 	}
-	// Record-then-create: manifest the dir before "cloning".
+	// Record-then-create: manifest the dir before "cloning". A pre-clone persist
+	// failure is fail-closed (mirror the real ProvisionRigFromGit): abort before
+	// appending the rig so no un-manifested rig is created.
 	if onManifest != nil {
-		onManifest(RigProvisionManifest{RigName: r.Name, CreatedDir: r.Path})
+		if err := onManifest(RigProvisionManifest{RigName: r.Name, CreatedDir: r.Path}); err != nil {
+			return config.Rig{}, err
+		}
 	}
 
 	f.provisionMu.Lock()
@@ -399,8 +405,11 @@ func (f *fakeMutatorState) ProvisionRigFromGit(ctx context.Context, r config.Rig
 	}
 
 	f.cfg.Rigs = append(f.cfg.Rigs, r)
+	// Post-init manifest is best-effort in the real path (a complete rig is
+	// forward-reconciled, never torn down), so a persist error here does not fail
+	// the provision.
 	if onManifest != nil {
-		onManifest(RigProvisionManifest{RigName: r.Name, CreatedDir: r.Path})
+		_ = onManifest(RigProvisionManifest{RigName: r.Name, CreatedDir: r.Path})
 	}
 	if onStep != nil {
 		onStep("done", "Rig added.", false)

--- a/internal/api/huma_handlers_rigs.go
+++ b/internal/api/huma_handlers_rigs.go
@@ -306,14 +306,20 @@ func (s *Server) spawnRigProvision(sm StateMutator, city string, entry *liveProv
 
 	// Manifest sink: record-then-create. Each checkpoint persists the created
 	// resource onto the durable record (crash recovery) AND updates the captured
-	// manifest the rollback path tears down (runtime recovery). Persist errors
-	// are logged, not fatal — a missed persist only widens the boot-sweep's job.
+	// manifest the rollback path tears down (runtime recovery). The persist error
+	// is returned to ProvisionRigFromGit, which fails closed at the pre-clone
+	// checkpoint (a missed created_dir persist would leave an un-manifested clone
+	// the boot sweep and re-clone pre-drop cannot discover, wedging the name) and
+	// treats the post-init checkpoint as non-fatal. The reqID-tagged log stays for
+	// operability regardless of which checkpoint the caller is at.
 	var manifest RigProvisionManifest
-	onManifest := func(m RigProvisionManifest) {
+	onManifest := func(m RigProvisionManifest) error {
 		manifest = m
 		if err := persistManifest(store, entry.beadID, m); err != nil {
 			log.Printf("api: rig create %s: %v", reqID, err)
+			return err
 		}
+		return nil
 	}
 
 	rigCfg := config.Rig{

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -319,10 +319,15 @@ type StateMutator interface {
 	// when non-nil, is called record-then-create at each resource-creation
 	// checkpoint (before the clone with CreatedDir set; after init with any
 	// minted DoltDB) so the caller can persist the G14 rollback manifest and
-	// capture it for teardown. It returns the provisioned rig so the caller can
-	// report its resolved prefix/branch. This is the async server-side rig-add
-	// path (C4b/C4c); the sync CreateRig stays git-blind.
-	ProvisionRigFromGit(ctx context.Context, r config.Rig, gitURL string, onStep func(step, detail string, warn bool), onManifest func(RigProvisionManifest)) (config.Rig, error)
+	// capture it for teardown. onManifest's error is load-bearing at the
+	// pre-clone checkpoint: if durable persistence of CreatedDir fails there,
+	// ProvisionRigFromGit MUST abort before cloning (fail closed) rather than
+	// create an unmanifested directory the boot sweep and re-clone pre-drop
+	// cannot discover — leaving it would wedge the request_id/name. It returns
+	// the provisioned rig so the caller can report its resolved prefix/branch.
+	// This is the async server-side rig-add path (C4b/C4c); the sync CreateRig
+	// stays git-blind.
+	ProvisionRigFromGit(ctx context.Context, r config.Rig, gitURL string, onStep func(step, detail string, warn bool), onManifest func(RigProvisionManifest) error) (config.Rig, error)
 
 	// TeardownPartialRig removes the created rig working tree and drops the
 	// managed Dolt database named in the manifest (best-effort), then repairs

--- a/internal/ssrf/ssrf.go
+++ b/internal/ssrf/ssrf.go
@@ -207,8 +207,74 @@ func IsInternalIP(ip net.IP) bool {
 				return true
 			}
 		}
+		return false
+	}
+	// A non-v4-mapped IPv6 address may still carry an embedded IPv4 destination
+	// the host's transition machinery ultimately routes to. To4() above unwraps
+	// only ::ffff:a.b.c.d, so decode the NAT64 (64:ff9b::/96), 6to4 (2002::/16),
+	// and deprecated IPv4-compatible (::/96) forms and re-classify the embedded
+	// address — otherwise a git URL naming e.g. 64:ff9b::a00:1 or 2002:0a00:0001::
+	// reaches an RFC1918/internal IPv4 after the fence classifies it public. The
+	// same prefixes wrapping a public IPv4 (NAT64/6to4 legitimately do) stay
+	// allowed, because the re-classification runs on the decoded address.
+	if embedded := embeddedTransitionIPv4(ip); embedded != nil {
+		return IsInternalIP(embedded)
 	}
 	return false
+}
+
+// embeddedTransitionIPv4 returns the IPv4 address an IPv6 transition literal
+// embeds, or nil when ip is not one of the decoded forms. It recognizes the
+// RFC 6052 well-known NAT64 prefix 64:ff9b::/96 and the deprecated
+// IPv4-compatible ::/96 form (embedded IPv4 in the low 32 bits), and the 6to4
+// prefix 2002::/16 (embedded IPv4 in bits 16..48). The v4-mapped ::ffff:a.b.c.d
+// form is intentionally NOT handled here — IsInternalIP's To4() already unwraps
+// it — so a v4 or v4-mapped input returns nil and the classifier never recurses
+// on it. Teredo and ORCHID are out of scope: they do not encode a routable
+// embedded IPv4 destination the fence must re-classify.
+func embeddedTransitionIPv4(ip net.IP) net.IP {
+	v6 := ip.To16()
+	if v6 == nil || ip.To4() != nil {
+		return nil
+	}
+	switch {
+	case isNAT64WellKnown(v6):
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+	case v6[0] == 0x20 && v6[1] == 0x02: // 6to4 2002::/16
+		return net.IPv4(v6[2], v6[3], v6[4], v6[5])
+	case isIPv4Compatible(v6):
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+	}
+	return nil
+}
+
+// isNAT64WellKnown reports whether the 16-byte IPv6 v6 falls in the RFC 6052
+// well-known NAT64 prefix 64:ff9b::/96, whose low 32 bits carry the embedded
+// IPv4.
+func isNAT64WellKnown(v6 net.IP) bool {
+	if v6[0] != 0x00 || v6[1] != 0x64 || v6[2] != 0xff || v6[3] != 0x9b {
+		return false
+	}
+	for _, b := range v6[4:12] {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// isIPv4Compatible reports whether the 16-byte IPv6 v6 is a deprecated
+// IPv4-compatible address (::/96, RFC 4291 §2.5.5.1). The ::ffff: v4-mapped form
+// carries 0xff at bytes 10-11 and is excluded here (To4() handles it); the ::
+// and ::1 forms are already classified by IsUnspecified/IsLoopback before this
+// is reached, so any surviving match embeds a non-trivial IPv4 to re-classify.
+func isIPv4Compatible(v6 net.IP) bool {
+	for _, b := range v6[0:12] {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // ParseLooseIPv4 decodes the legacy inet_aton host forms that net.ParseIP

--- a/internal/ssrf/ssrf.go
+++ b/internal/ssrf/ssrf.go
@@ -212,11 +212,12 @@ func IsInternalIP(ip net.IP) bool {
 	// A non-v4-mapped IPv6 address may still carry an embedded IPv4 destination
 	// the host's transition machinery ultimately routes to. To4() above unwraps
 	// only ::ffff:a.b.c.d, so decode the NAT64 (64:ff9b::/96), 6to4 (2002::/16),
-	// and deprecated IPv4-compatible (::/96) forms and re-classify the embedded
-	// address — otherwise a git URL naming e.g. 64:ff9b::a00:1 or 2002:0a00:0001::
-	// reaches an RFC1918/internal IPv4 after the fence classifies it public. The
-	// same prefixes wrapping a public IPv4 (NAT64/6to4 legitimately do) stay
-	// allowed, because the re-classification runs on the decoded address.
+	// IPv4-translated (::ffff:0:0:0/96), and deprecated IPv4-compatible (::/96)
+	// forms and re-classify the embedded address — otherwise a git URL naming
+	// e.g. 64:ff9b::a00:1, 2002:0a00:0001::, or ::ffff:0:10.0.0.1 reaches an
+	// RFC1918/internal IPv4 after the fence classifies it public. The same
+	// prefixes wrapping a public IPv4 (NAT64/6to4 legitimately do) stay allowed,
+	// because the re-classification runs on the decoded address.
 	if embedded := embeddedTransitionIPv4(ip); embedded != nil {
 		return IsInternalIP(embedded)
 	}
@@ -225,13 +226,14 @@ func IsInternalIP(ip net.IP) bool {
 
 // embeddedTransitionIPv4 returns the IPv4 address an IPv6 transition literal
 // embeds, or nil when ip is not one of the decoded forms. It recognizes the
-// RFC 6052 well-known NAT64 prefix 64:ff9b::/96 and the deprecated
-// IPv4-compatible ::/96 form (embedded IPv4 in the low 32 bits), and the 6to4
-// prefix 2002::/16 (embedded IPv4 in bits 16..48). The v4-mapped ::ffff:a.b.c.d
-// form is intentionally NOT handled here — IsInternalIP's To4() already unwraps
-// it — so a v4 or v4-mapped input returns nil and the classifier never recurses
-// on it. Teredo and ORCHID are out of scope: they do not encode a routable
-// embedded IPv4 destination the fence must re-classify.
+// RFC 6052 well-known NAT64 prefix 64:ff9b::/96, the IPv4-translated
+// ::ffff:0:0:0/96 form, and the deprecated IPv4-compatible ::/96 form (all with
+// the embedded IPv4 in the low 32 bits), plus the 6to4 prefix 2002::/16
+// (embedded IPv4 in bits 16..48). The v4-mapped ::ffff:a.b.c.d form is
+// intentionally NOT handled here — IsInternalIP's To4() already unwraps it — so
+// a v4 or v4-mapped input returns nil and the classifier never recurses on it.
+// Teredo and ORCHID are out of scope: they do not encode a routable embedded
+// IPv4 destination the fence must re-classify.
 func embeddedTransitionIPv4(ip net.IP) net.IP {
 	v6 := ip.To16()
 	if v6 == nil || ip.To4() != nil {
@@ -242,6 +244,8 @@ func embeddedTransitionIPv4(ip net.IP) net.IP {
 		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
 	case v6[0] == 0x20 && v6[1] == 0x02: // 6to4 2002::/16
 		return net.IPv4(v6[2], v6[3], v6[4], v6[5])
+	case isIPv4Translated(v6):
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
 	case isIPv4Compatible(v6):
 		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
 	}
@@ -261,6 +265,22 @@ func isNAT64WellKnown(v6 net.IP) bool {
 		}
 	}
 	return true
+}
+
+// isIPv4Translated reports whether the 16-byte IPv6 v6 is an IPv4-translated
+// address (::ffff:0:0:0/96, RFC 6052 §2.1), whose low 32 bits carry the embedded
+// IPv4. The prefix is eight zero bytes, then 0xffff at bytes 8-9 and zero at
+// bytes 10-11 — distinct from the v4-mapped ::ffff:a.b.c.d form (0xffff at bytes
+// 10-11), which To4() unwraps and IsInternalIP handles before this is reached.
+// Without this decode a literal such as ::ffff:0:10.0.0.1 embeds an RFC1918
+// destination yet To4() returns nil, so the classifier would treat it as public.
+func isIPv4Translated(v6 net.IP) bool {
+	for _, b := range v6[0:8] {
+		if b != 0 {
+			return false
+		}
+	}
+	return v6[8] == 0xff && v6[9] == 0xff && v6[10] == 0 && v6[11] == 0
 }
 
 // isIPv4Compatible reports whether the 16-byte IPv6 v6 is a deprecated

--- a/internal/ssrf/ssrf_cidr_test.go
+++ b/internal/ssrf/ssrf_cidr_test.go
@@ -41,3 +41,51 @@ func TestIsInternalIPCoversNonGoClassifierRanges(t *testing.T) {
 		}
 	}
 }
+
+// TestIsInternalIPCoversIPv6TransitionalForms pins the IPv6 transition prefixes
+// that embed a 32-bit IPv4 destination the host's transition machinery routes
+// to. Go's To4() unwraps only the v4-mapped ::ffff:a.b.c.d form, so without the
+// embedded-IPv4 decode a git URL naming NAT64 (64:ff9b::/96), 6to4 (2002::/16),
+// or the deprecated IPv4-compatible (::/96) literal of an internal IPv4 slips
+// past the fence as "public". Classification re-runs on the embedded address, so
+// the same prefixes wrapping a PUBLIC IPv4 stay allowed (NAT64/6to4 legitimately
+// carry public v4).
+func TestIsInternalIPCoversIPv6TransitionalForms(t *testing.T) {
+	internal := []string{
+		"64:ff9b::a00:1",     // NAT64 well-known embedding 10.0.0.1 (RFC1918)
+		"64:ff9b::7f00:1",    // NAT64 embedding 127.0.0.1 (loopback)
+		"64:ff9b::a9fe:a9fe", // NAT64 embedding 169.254.169.254 (cloud metadata)
+		"64:ff9b::6440:1",    // NAT64 embedding 100.64.0.1 (CGNAT)
+		"2002:a00:1::",       // 6to4 embedding 10.0.0.1
+		"2002:c0a8:1::1",     // 6to4 embedding 192.168.0.1
+		"2002:a9fe:a9fe::",   // 6to4 embedding 169.254.169.254
+		"::a00:1",            // IPv4-compatible embedding 10.0.0.1 (deprecated)
+		"::7f00:1",           // IPv4-compatible embedding 127.0.0.1
+	}
+	for _, s := range internal {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("bad test IP %q", s)
+		}
+		if !IsInternalIP(ip) {
+			t.Errorf("IsInternalIP(%s) = false, want true (embeds an internal IPv4)", s)
+		}
+	}
+
+	public := []string{
+		"64:ff9b::808:808",     // NAT64 embedding 8.8.8.8 (legitimate public v4-over-NAT64)
+		"64:ff9b::5db8:d822",   // NAT64 embedding 93.184.216.34
+		"2002:808:808::",       // 6to4 embedding 8.8.8.8
+		"::808:808",            // IPv4-compatible embedding 8.8.8.8
+		"2001:4860:4860::8888", // ordinary global-unicast IPv6 (no embedded internal v4)
+	}
+	for _, s := range public {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("bad test IP %q", s)
+		}
+		if IsInternalIP(ip) {
+			t.Errorf("IsInternalIP(%s) = true, want false (embeds a public IPv4)", s)
+		}
+	}
+}

--- a/internal/ssrf/ssrf_cidr_test.go
+++ b/internal/ssrf/ssrf_cidr_test.go
@@ -46,21 +46,23 @@ func TestIsInternalIPCoversNonGoClassifierRanges(t *testing.T) {
 // that embed a 32-bit IPv4 destination the host's transition machinery routes
 // to. Go's To4() unwraps only the v4-mapped ::ffff:a.b.c.d form, so without the
 // embedded-IPv4 decode a git URL naming NAT64 (64:ff9b::/96), 6to4 (2002::/16),
-// or the deprecated IPv4-compatible (::/96) literal of an internal IPv4 slips
-// past the fence as "public". Classification re-runs on the embedded address, so
-// the same prefixes wrapping a PUBLIC IPv4 stay allowed (NAT64/6to4 legitimately
-// carry public v4).
+// the IPv4-translated (::ffff:0:0:0/96) form, or the deprecated IPv4-compatible
+// (::/96) literal of an internal IPv4 slips past the fence as "public".
+// Classification re-runs on the embedded address, so the same prefixes wrapping
+// a PUBLIC IPv4 stay allowed (NAT64/6to4 legitimately carry public v4).
 func TestIsInternalIPCoversIPv6TransitionalForms(t *testing.T) {
 	internal := []string{
-		"64:ff9b::a00:1",     // NAT64 well-known embedding 10.0.0.1 (RFC1918)
-		"64:ff9b::7f00:1",    // NAT64 embedding 127.0.0.1 (loopback)
-		"64:ff9b::a9fe:a9fe", // NAT64 embedding 169.254.169.254 (cloud metadata)
-		"64:ff9b::6440:1",    // NAT64 embedding 100.64.0.1 (CGNAT)
-		"2002:a00:1::",       // 6to4 embedding 10.0.0.1
-		"2002:c0a8:1::1",     // 6to4 embedding 192.168.0.1
-		"2002:a9fe:a9fe::",   // 6to4 embedding 169.254.169.254
-		"::a00:1",            // IPv4-compatible embedding 10.0.0.1 (deprecated)
-		"::7f00:1",           // IPv4-compatible embedding 127.0.0.1
+		"64:ff9b::a00:1",           // NAT64 well-known embedding 10.0.0.1 (RFC1918)
+		"64:ff9b::7f00:1",          // NAT64 embedding 127.0.0.1 (loopback)
+		"64:ff9b::a9fe:a9fe",       // NAT64 embedding 169.254.169.254 (cloud metadata)
+		"64:ff9b::6440:1",          // NAT64 embedding 100.64.0.1 (CGNAT)
+		"2002:a00:1::",             // 6to4 embedding 10.0.0.1
+		"2002:c0a8:1::1",           // 6to4 embedding 192.168.0.1
+		"2002:a9fe:a9fe::",         // 6to4 embedding 169.254.169.254
+		"::ffff:0:10.0.0.1",        // IPv4-translated embedding 10.0.0.1 (RFC1918)
+		"::ffff:0:169.254.169.254", // IPv4-translated embedding 169.254.169.254 (cloud metadata)
+		"::a00:1",                  // IPv4-compatible embedding 10.0.0.1 (deprecated)
+		"::7f00:1",                 // IPv4-compatible embedding 127.0.0.1
 	}
 	for _, s := range internal {
 		ip := net.ParseIP(s)
@@ -76,6 +78,7 @@ func TestIsInternalIPCoversIPv6TransitionalForms(t *testing.T) {
 		"64:ff9b::808:808",     // NAT64 embedding 8.8.8.8 (legitimate public v4-over-NAT64)
 		"64:ff9b::5db8:d822",   // NAT64 embedding 93.184.216.34
 		"2002:808:808::",       // 6to4 embedding 8.8.8.8
+		"::ffff:0:8.8.8.8",     // IPv4-translated embedding 8.8.8.8 (legitimate public)
 		"::808:808",            // IPv4-compatible embedding 8.8.8.8
 		"2001:4860:4860::8888", // ordinary global-unicast IPv6 (no embedded internal v4)
 	}


### PR DESCRIPTION
## Post-merge remediation for #4053

Follows up the landed **remote control plane** change (PR #4053, reviewed range `6896197..303ab8d`) after a post-merge review found two actionable correctness/security issues. Both are fixed here with locking regression tests. The branch is based on the current `main`, not the older reviewed head.

### 1. Rig-provision manifest persistence — fail closed before clone
The async `git_url` rig-add persisted its record-then-create manifest (`created_dir`) best-effort: a durable-write failure at the pre-clone checkpoint was only logged, and `ProvisionRigFromGit` cloned anyway. That created a rig working tree neither the boot sweep nor the re-clone pre-drop could discover (both read the manifest), wedging the same `request_id`/name on every retry.

`onManifest` now returns an error. The **pre-clone** checkpoint fails closed — if the durable write does not land, provisioning aborts before the clone, so nothing is created and the ground stays clean. The **post-init** `dolt_db` checkpoint stays best-effort: a fully-provisioned rig is forward-reconciled by the boot sweep (never torn down), so failing it would only destroy a healthy rig.

Lock: `TestProvisionRigFromGitAbortsWhenPreCloneManifestPersistFails` — stubs the clone and asserts a failing pre-clone manifest aborts without cloning.

### 2. SSRF fence — IPv6 transitional forms embedding an internal IPv4
`ssrf.IsInternalIP` unwrapped only the v4-mapped `::ffff:a.b.c.d` form (`To4()`), so a git URL naming a NAT64 (`64:ff9b::/96`), 6to4 (`2002::/16`), or deprecated IPv4-compatible (`::/96`) literal that embeds an RFC1918/loopback/metadata IPv4 was classified public and could reach the internal target on a host with such reachability.

`IsInternalIP` now decodes the embedded IPv4 from those three prefixes and re-runs classification. Forms embedding an internal IPv4 are fenced; the same prefixes wrapping a public IPv4 (which NAT64/6to4 legitimately carry) stay allowed.

Lock: `TestIsInternalIPCoversIPv6TransitionalForms` — internal and public embedded-IPv4 table cases.

### Verification
- `go test ./internal/ssrf/ ./internal/api/` pass; `go vet ./...` clean; pre-push fast suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
