### PR TITLE
test(runtime): bind fake conformance to production constructor

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -590,6 +590,14 @@ below. The auto composition lives outside that registry and is bound to the
 exact production function and `runtime/auto.New` result it returns. A waiver is
 a visible contract gap, not evidence that conformance passes.
 
+A proved row names one runnable test whose final top-level statement invokes
+the declared shared contract with an inline factory. The source guard requires
+that factory to return the row's exact constructor directly, rejects pre-run
+helper gates and direct skip syntax, and permits only named testing operations
+plus explicitly ledgered setup functions. E1 separately proves that
+build-tagged rows execute in their required CI lane; a source-bound proof does
+not claim cadence ownership by itself.
+
 Reusable-double discovery is intentionally bounded, not repository-wide. The
 designated boundary is `internal/runtime/fake.go` for the `runtime.Provider`
 port. The guard type-checks its declared runtime type context, discovers every
@@ -617,12 +625,10 @@ construction boundary because that is the wrapper returned directly by the
 runtime registry. This ledger does not recursively claim the wrapper's internal
 tmux, K8s, or hybrid constructors.
 
-This first ledger slice records only owned, expiring waivers and explicit
-not-applicable dispositions. `ga-80po0c.1.2` owns structural binding of the
-existing Fake/subprocess conformance evidence to these exact production
-constructors and the resulting proof-row upgrades. E1 (`ga-80po0c.6`)
-separately owns the Large provider/E2E manifest and its required lane/cadence
-execution; it does not own these constructor bindings.
+`runtime.NewFake` is source-bound to the shared runtime contract below.
+`ga-80po0c.1.2` still owns the separate subprocess constructor bindings. E1
+(`ga-80po0c.6`) owns the Large provider/E2E manifest and required lane/cadence
+execution; it does not own constructor-to-contract source binding.
 
 <!-- BEGIN CHECKED RUNTIME PROVIDER LEDGER -->
 This table is rendered from `internal/testutil/providerledger` and checked by `go test ./internal/testutil/providerledger`; edit the Go ledger, then use the expected block printed on drift.
@@ -634,7 +640,7 @@ This table is rendered from `internal/testutil/providerledger` and checked by `g
 | `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/exec.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw exec provider, not the production seam-backed prefix composition |
 | `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/t3bridge.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the legacy gc-session-t3 prefix branch selects the T3 bridge composition, which has no full shared runtime contract |
 | `runtime.builtin.fail` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFailFake` | runtime.builtin/exact:fail; reusable: internal/runtime/fake.go | `runtime.Provider` | not applicable: intentional faulting double: a successful lifecycle cannot be exercised, so the successful-provider contract is not applicable |
-| `runtime.builtin.fake` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFake` | runtime.builtin/exact:fake; reusable: internal/runtime/fake.go | `runtime.Provider` | waived by ga-80po0c.1.2 through 2026-08-12: existing full conformance is not yet structurally bound to runtime.NewFake; exact proof binding is deferred to ga-80po0c.1.2 |
+| `runtime.builtin.fake` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFake` | runtime.builtin/exact:fake; reusable: internal/runtime/fake.go | `runtime.Provider` | proved by internal/runtime/fake_conformance_test.go#TestFakeConformance |
 | `runtime.builtin.herdr` | production_provider | — | `runtime.Provider` | `internal/runtime/herdr.New` | runtime.builtin/exact:herdr | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the existing full conformance run skips in short mode or when the herdr executable is absent |
 | `runtime.builtin.hybrid` | production_provider | — | `runtime.Provider` | `cmd/gc.newHybridProvider` | runtime.builtin/exact:hybrid | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: cmd/gc.newHybridProvider is the selected registry construction boundary; its internal tmux, K8s, and hybrid constructors are not claimed here, and the wrapper has no full shared runtime contract |
 | `runtime.builtin.k8s` | production_provider | — | `runtime.Provider` | `internal/runtime/k8s.NewSeamBacked` | runtime.builtin/exact:k8s | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the actual K8s production composition has no full shared runtime contract |

--- a/internal/runtime/fake_conformance_test.go
+++ b/internal/runtime/fake_conformance_test.go
@@ -10,12 +10,9 @@ import (
 )
 
 func TestFakeConformance(t *testing.T) {
-	fp := runtime.NewFake()
 	var counter int64
 
 	runtimetest.RunProviderTests(t, func(_ *testing.T) (runtime.Provider, runtime.Config, string) {
-		id := atomic.AddInt64(&counter, 1)
-		name := fmt.Sprintf("fake-conform-%d", id)
-		return fp, runtime.Config{}, name
+		return runtime.NewFake(), runtime.Config{}, fmt.Sprintf("fake-conform-%d", atomic.AddInt64(&counter, 1))
 	})
 }

--- a/internal/testutil/providerledger/ledger.go
+++ b/internal/testutil/providerledger/ledger.go
@@ -49,11 +49,15 @@ const (
 type Disposition string
 
 const (
+	// DispositionProved records an executable, source-checked contract proof.
+	DispositionProved Disposition = "proved"
 	// DispositionWaived records a temporary, owned contract gap.
 	DispositionWaived Disposition = "waived"
 	// DispositionNotApplicable records why a contract does not apply.
 	DispositionNotApplicable Disposition = "not_applicable"
 )
+
+var runtimeProviderRunner = repoSymbol("internal/runtime/runtimetest", "RunProviderTests")
 
 const (
 	// RuntimeBuiltinCatalog names cmd/gc's static runtime provider registry.
@@ -82,6 +86,16 @@ type SourceRef struct {
 	Reason   string
 }
 
+// ProofRef binds an exact runnable test to its contract runner. AllowedCalls
+// lists pure setup calls permitted inside the inline provider factory; provider
+// construction itself is always bound separately through ContractClaim.
+type ProofRef struct {
+	File         string
+	Test         string
+	Runner       SymbolRef
+	AllowedCalls []SymbolRef
+}
+
 // Waiver is a temporary, owned exception to an applicable contract.
 type Waiver struct {
 	Owner   string
@@ -94,6 +108,7 @@ type ContractClaim struct {
 	Constructor         SymbolRef
 	Contract            ContractID
 	Disposition         Disposition
+	Proof               *ProofRef
 	Waiver              *Waiver
 	NotApplicableReason string
 }
@@ -120,10 +135,12 @@ func Catalog() []Entry {
 	return []Entry{
 		reusableBuiltin(
 			"fake", "exact:fake", repoSymbol("internal/runtime", "Fake"),
-			waivedRuntime(
+			provedRuntime(
 				repoSymbol("internal/runtime", "NewFake"),
-				"ga-80po0c.1.2",
-				"existing full conformance is not yet structurally bound to runtime.NewFake; exact proof binding is deferred to ga-80po0c.1.2",
+				"internal/runtime/fake_conformance_test.go",
+				"TestFakeConformance",
+				SymbolRef{ImportPath: "fmt", Name: "Sprintf"},
+				SymbolRef{ImportPath: "sync/atomic", Name: "AddInt64"},
 			),
 		),
 		reusableBuiltin(
@@ -266,6 +283,20 @@ func reusableBuiltin(id, key string, doubleType SymbolRef, claims ...ContractCla
 	entry.DoubleType = &doubleType
 	entry.DoubleBoundary = runtimeDoubleBoundaryPath
 	return entry
+}
+
+func provedRuntime(constructor SymbolRef, file, test string, allowedCalls ...SymbolRef) ContractClaim {
+	return ContractClaim{
+		Constructor: constructor,
+		Contract:    ContractRuntimeProvider,
+		Disposition: DispositionProved,
+		Proof: &ProofRef{
+			File:         file,
+			Test:         test,
+			Runner:       runtimeProviderRunner,
+			AllowedCalls: append([]SymbolRef(nil), allowedCalls...),
+		},
+	}
 }
 
 func waivedRuntime(constructor SymbolRef, owner, reason string) ContractClaim {
@@ -439,6 +470,9 @@ func hasRole(roles []Role, want Role) bool {
 func validateClaim(prefix string, claim ContractClaim, now time.Time) []string {
 	var problems []string
 	payloads := 0
+	if claim.Proof != nil {
+		payloads++
+	}
 	if claim.Waiver != nil {
 		payloads++
 	}
@@ -446,10 +480,33 @@ func validateClaim(prefix string, claim ContractClaim, now time.Time) []string {
 		payloads++
 	}
 	if payloads != 1 {
-		problems = append(problems, prefix+" requires exactly one of waiver or not-applicable reason")
+		problems = append(problems, prefix+" requires exactly one of proof, waiver, or not-applicable reason")
 	}
 
 	switch claim.Disposition {
+	case DispositionProved:
+		if claim.Proof == nil {
+			problems = append(problems, prefix+" proved claim requires a proof")
+		} else {
+			if strings.TrimSpace(claim.Proof.File) == "" || strings.TrimSpace(claim.Proof.Test) == "" {
+				problems = append(problems, prefix+" proof file and test are required")
+			}
+			if err := validateSymbolRef(claim.Proof.Runner); err != nil {
+				problems = append(problems, fmt.Sprintf("%s proof runner: %v", prefix, err))
+			} else if claim.Contract == ContractRuntimeProvider && claim.Proof.Runner != runtimeProviderRunner {
+				problems = append(problems, fmt.Sprintf("%s proof runner is %s, want %s", prefix, renderSymbolRef(claim.Proof.Runner), renderSymbolRef(runtimeProviderRunner)))
+			}
+			seenAllowed := make(map[SymbolRef]bool)
+			for _, allowed := range claim.Proof.AllowedCalls {
+				if err := validateSymbolRef(allowed); err != nil {
+					problems = append(problems, fmt.Sprintf("%s allowed proof call: %v", prefix, err))
+				}
+				if seenAllowed[allowed] {
+					problems = append(problems, fmt.Sprintf("%s repeats allowed proof call %s", prefix, renderSymbolRef(allowed)))
+				}
+				seenAllowed[allowed] = true
+			}
+		}
 	case DispositionWaived:
 		if claim.Waiver == nil {
 			problems = append(problems, prefix+" waived claim requires a waiver")
@@ -614,6 +671,11 @@ func renderDiscovery(entry Entry) string {
 
 func renderClaim(claim ContractClaim) string {
 	switch claim.Disposition {
+	case DispositionProved:
+		if claim.Proof == nil {
+			return "proved (invalid: no proof)"
+		}
+		return fmt.Sprintf("proved by %s#%s", claim.Proof.File, claim.Proof.Test)
 	case DispositionWaived:
 		if claim.Waiver == nil {
 			return "waived (invalid: no waiver)"

--- a/internal/testutil/providerledger/ledger_test.go
+++ b/internal/testutil/providerledger/ledger_test.go
@@ -15,6 +15,11 @@ func TestValidateRejectsInvalidContractClaims(t *testing.T) {
 		Expires: now.Add(30 * 24 * time.Hour),
 		Reason:  "tracked legacy contract gap",
 	}
+	validProof := &ProofRef{
+		File:   "internal/runtime/fake_conformance_test.go",
+		Test:   "TestFakeConformance",
+		Runner: runtimeProviderRunner,
+	}
 
 	tests := []struct {
 		name  string
@@ -37,7 +42,7 @@ func TestValidateRejectsInvalidContractClaims(t *testing.T) {
 				Waiver:              validWaiver,
 				NotApplicableReason: "faulting provider",
 			},
-			want: "exactly one of waiver or not-applicable reason",
+			want: "exactly one of proof, waiver, or not-applicable reason",
 		},
 		{
 			name: "waiver is expired",
@@ -86,6 +91,27 @@ func TestValidateRejectsInvalidContractClaims(t *testing.T) {
 			want: "not-applicable claim requires a reason",
 		},
 		{
+			name: "proved contract has no proof",
+			claim: ContractClaim{
+				Contract:    ContractRuntimeProvider,
+				Disposition: DispositionProved,
+			},
+			want: "proved claim requires a proof",
+		},
+		{
+			name: "proof uses the wrong contract runner",
+			claim: ContractClaim{
+				Contract:    ContractRuntimeProvider,
+				Disposition: DispositionProved,
+				Proof: &ProofRef{
+					File:   validProof.File,
+					Test:   validProof.Test,
+					Runner: SymbolRef{ImportPath: "example.test/contract", Name: "Run"},
+				},
+			},
+			want: "proof runner is example.test/contract.Run, want internal/runtime/runtimetest.RunProviderTests",
+		},
+		{
 			name: "not applicable also has waiver",
 			claim: ContractClaim{
 				Contract:            ContractRuntimeProvider,
@@ -93,7 +119,17 @@ func TestValidateRejectsInvalidContractClaims(t *testing.T) {
 				Waiver:              validWaiver,
 				NotApplicableReason: "faulting provider",
 			},
-			want: "exactly one of waiver or not-applicable reason",
+			want: "exactly one of proof, waiver, or not-applicable reason",
+		},
+		{
+			name: "not applicable also has proof",
+			claim: ContractClaim{
+				Contract:            ContractRuntimeProvider,
+				Disposition:         DispositionNotApplicable,
+				Proof:               validProof,
+				NotApplicableReason: "faulting provider",
+			},
+			want: "exactly one of proof, waiver, or not-applicable reason",
 		},
 	}
 
@@ -103,6 +139,175 @@ func TestValidateRejectsInvalidContractClaims(t *testing.T) {
 			err := Validate([]Entry{entry}, now)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("Validate() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateProofRefsRequiresDirectUngatedContractFactory(t *testing.T) {
+	const imports = `import (
+	fmtalias "fmt"
+	runtimealias "github.com/gastownhall/gascity/internal/runtime"
+	contractalias "github.com/gastownhall/gascity/internal/runtime/runtimetest"
+	testalias "testing"
+)
+`
+	tests := []struct {
+		name        string
+		packageName string
+		file        string
+		body        string
+		allowed     []SymbolRef
+		want        string
+	}{
+		{
+			name: "direct constructor factory",
+			body: `func TestProof(t *testalias.T) {
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+		},
+		{
+			name: "disconnected constructor",
+			body: `func TestProof(t *testalias.T) {
+	_ = runtimealias.NewFake()
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return nil, nil, "session"
+	})
+}`,
+			want: "only zero-value var declarations may precede the contract runner",
+		},
+		{
+			name: "different constructor",
+			body: `func TestProof(t *testalias.T) {
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFailFake(), nil, "session"
+	})
+}`,
+			want: "factory must return constructor internal/runtime.NewFake directly",
+		},
+		{
+			name:        "external test package local wrapper",
+			packageName: "runtime_test",
+			file:        "internal/runtime/provider_test.go",
+			body: `func NewFake() any { return runtimealias.NewFailFake() }
+func TestProof(t *testalias.T) {
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return NewFake(), nil, "session"
+	})
+}`,
+			want: "factory must return constructor internal/runtime.NewFake directly",
+		},
+		{
+			name: "different runner",
+			body: `func TestProof(t *testalias.T) {
+	contractalias.RunLifecycleTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+			want: "final statement must call contract runner internal/runtime/runtimetest.RunProviderTests",
+		},
+		{
+			name: "missing named proof",
+			body: `func TestOther(t *testalias.T) {
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+			want: "proof test TestProof must appear exactly once",
+		},
+		{
+			name: "generic test is not runnable",
+			body: `func TestProof[T any](t *testalias.T) {
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+			want: "must not declare type parameters",
+		},
+		{
+			name: "pre-run helper gate",
+			body: `func TestProof(t *testalias.T) {
+	requireProvider(t)
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+			want: "only zero-value var declarations may precede the contract runner",
+		},
+		{
+			name: "direct skip",
+			body: `func TestProof(t *testalias.T) {
+	t.Skip("not today")
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+			want: "directly calls t.Skip",
+		},
+		{
+			name: "testing short gate",
+			body: `func TestProof(t *testalias.T) {
+	if testalias.Short() {
+		t.Skip("short")
+	}
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+			want: "directly calls testing.Short",
+		},
+		{
+			name: "unallowed setup call",
+			body: `func TestProof(t *testalias.T) {
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, fmtalias.Sprintf("%s", "session")
+	})
+}`,
+			want: "runner factory callee fmt.Sprintf is not allowed",
+		},
+		{
+			name: "unused allowed setup call",
+			body: `func TestProof(t *testalias.T) {
+	contractalias.RunProviderTests(t, func(_ *testalias.T) (any, any, string) {
+		return runtimealias.NewFake(), nil, "session"
+	})
+}`,
+			allowed: []SymbolRef{{ImportPath: "fmt", Name: "Sprintf"}},
+			want:    "allowed proof call fmt.Sprintf is not used",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			file := tt.file
+			if file == "" {
+				file = "provider_test.go"
+			}
+			packageName := tt.packageName
+			if packageName == "" {
+				packageName = "fixture"
+			}
+			path := filepath.Join(root, file)
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("package "+packageName+"\n"+imports+tt.body+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			entry := proofFixtureEntry(file, "TestProof")
+			entry.Claims[0].Proof.AllowedCalls = tt.allowed
+			err := ValidateProofRefs(root, []Entry{entry})
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("ValidateProofRefs() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateProofRefs() error = %v, want containing %q", err, tt.want)
 			}
 		})
 	}
@@ -316,16 +521,22 @@ func TestValidateRequiresExactlyOneClaimPerConstructorContract(t *testing.T) {
 	})
 }
 
-func TestCatalogDefersExactConstructorContractsToOwnedFollowups(t *testing.T) {
+func TestCatalogBindsFakeAndDefersRemainingExactConstructorContracts(t *testing.T) {
 	want := map[string]bool{
-		"runtime.builtin.fake/internal/runtime.NewFake":                               true,
 		"runtime.builtin.subprocess/internal/runtime/subprocess.NewSeamBacked":        true,
 		"runtime.builtin.subprocess/internal/runtime/subprocess.NewSeamBackedWithDir": true,
 	}
 	got := make(map[string]bool)
+	var fakeProof *ProofRef
 
 	for _, entry := range Catalog() {
 		for _, claim := range entry.Claims {
+			if entry.ID == "runtime.builtin.fake" && claim.Constructor == repoSymbol("internal/runtime", "NewFake") {
+				if claim.Disposition != DispositionProved {
+					t.Errorf("fake disposition = %q, want %q", claim.Disposition, DispositionProved)
+				}
+				fakeProof = claim.Proof
+			}
 			if claim.Waiver == nil || claim.Waiver.Owner != "ga-80po0c.1.2" {
 				continue
 			}
@@ -338,6 +549,12 @@ func TestCatalogDefersExactConstructorContractsToOwnedFollowups(t *testing.T) {
 				t.Errorf("%s contract = %q, want %q", key, claim.Contract, ContractRuntimeProvider)
 			}
 		}
+	}
+	if fakeProof == nil {
+		t.Fatal("runtime.NewFake proof is missing")
+	}
+	if fakeProof.File != "internal/runtime/fake_conformance_test.go" || fakeProof.Test != "TestFakeConformance" {
+		t.Errorf("runtime.NewFake proof = %s#%s, want fake conformance entrypoint", fakeProof.File, fakeProof.Test)
 	}
 
 	if len(got) != len(want) {
@@ -1232,12 +1449,40 @@ func TestCatalogMatchesProductionWiringAndDocumentation(t *testing.T) {
 	if err := ValidateSourceRefs(root, entries); err != nil {
 		t.Fatalf("ValidateSourceRefs: %v", err)
 	}
+	if err := ValidateProofRefs(root, entries); err != nil {
+		t.Fatalf("ValidateProofRefs: %v", err)
+	}
 	doc, err := os.ReadFile(filepath.Join(root, "TESTING.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := CheckMarkdown(string(doc), entries); err != nil {
 		t.Fatalf("CheckMarkdown: %v", err)
+	}
+}
+
+func proofFixtureEntry(file, test string) Entry {
+	constructor := repoSymbol("internal/runtime", "NewFake")
+	return Entry{
+		ID:           "runtime.proof-fixture",
+		Roles:        []Role{RoleProductionProvider},
+		Port:         PortRuntimeProvider,
+		Constructors: []SymbolRef{constructor},
+		Source: &SourceRef{
+			File:     "fixture.go",
+			Function: "newFixture",
+			Reason:   "fixture",
+		},
+		Claims: []ContractClaim{{
+			Constructor: constructor,
+			Contract:    ContractRuntimeProvider,
+			Disposition: DispositionProved,
+			Proof: &ProofRef{
+				File:   file,
+				Test:   test,
+				Runner: runtimeProviderRunner,
+			},
+		}},
 	}
 }
 
@@ -1248,7 +1493,9 @@ func TestCatalogReturnsIndependentEntries(t *testing.T) {
 	first[0].DoubleType.Name = "MutatedDouble"
 	first[0].Catalog.Name = "mutated.catalog"
 	first[0].Claims[0].Contract = ContractID("mutated.contract")
-	first[0].Claims[0].Waiver.Owner = "mutated-owner"
+	first[0].Claims[0].Proof.File = "mutated-proof.go"
+	first[0].Claims[0].Proof.AllowedCalls[0].Name = "MutatedCall"
+	first[2].Claims[0].Waiver.Owner = "mutated-owner"
 	first[len(first)-1].Source.Function = "mutatedSource"
 
 	second := Catalog()
@@ -1267,8 +1514,14 @@ func TestCatalogReturnsIndependentEntries(t *testing.T) {
 	if second[0].Claims[0].Contract != ContractRuntimeProvider {
 		t.Errorf("Catalog() claim leaked mutation: %q", second[0].Claims[0].Contract)
 	}
-	if second[0].Claims[0].Waiver.Owner != "ga-80po0c.1.2" {
-		t.Errorf("Catalog() waiver leaked mutation: %q", second[0].Claims[0].Waiver.Owner)
+	if second[0].Claims[0].Proof == nil || second[0].Claims[0].Proof.File != "internal/runtime/fake_conformance_test.go" {
+		t.Errorf("Catalog() proof leaked mutation: %v", second[0].Claims[0].Proof)
+	}
+	if got := second[0].Claims[0].Proof.AllowedCalls[0].Name; got != "Sprintf" {
+		t.Errorf("Catalog() proof allowed call leaked mutation: %q", got)
+	}
+	if second[2].Claims[0].Waiver.Owner != "ga-80po0c.1.2" {
+		t.Errorf("Catalog() waiver leaked mutation: %q", second[2].Claims[0].Waiver.Owner)
 	}
 	if second[len(second)-1].Source.Function != "resolveSessionTransportProvider" {
 		t.Errorf("Catalog() source leaked mutation: %q", second[len(second)-1].Source.Function)

--- a/internal/testutil/providerledger/proof.go
+++ b/internal/testutil/providerledger/proof.go
@@ -1,0 +1,310 @@
+package providerledger
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ValidateProofRefs verifies that every proved claim names one runnable test
+// whose final top-level statement invokes the declared contract runner with an
+// inline factory that returns the exact constructor directly. The deliberately
+// narrow shape makes pre-run gates and silent skips visible instead of trying
+// to infer arbitrary helper behavior.
+func ValidateProofRefs(root string, entries []Entry) error {
+	var problems []string
+	for _, entry := range entries {
+		for _, claim := range entry.Claims {
+			if claim.Disposition != DispositionProved {
+				continue
+			}
+			if claim.Proof == nil {
+				problems = append(problems, fmt.Sprintf("entry %q contract %s: proved claim has no proof", entry.ID, claim.Contract))
+				continue
+			}
+			if err := validateProofRef(root, claim.Constructor, *claim.Proof); err != nil {
+				problems = append(problems, fmt.Sprintf("entry %q contract %s: %v", entry.ID, claim.Contract, err))
+			}
+		}
+	}
+	return joinProblems(problems)
+}
+
+func validateProofRef(root string, constructor SymbolRef, proof ProofRef) error {
+	clean := filepath.ToSlash(filepath.Clean(proof.File))
+	if filepath.IsAbs(proof.File) || clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("proof file %q must be repository-relative", proof.File)
+	}
+	if !strings.HasSuffix(filepath.Base(proof.File), "_test.go") {
+		return fmt.Errorf("proof file %q must name a _test.go file", proof.File)
+	}
+
+	path := filepath.Join(root, proof.File)
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read proof file %q: %w", proof.File, err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, 0)
+	if err != nil {
+		return fmt.Errorf("parse proof file %q: %w", proof.File, err)
+	}
+	imports, err := importAliases(file)
+	if err != nil {
+		return fmt.Errorf("parse proof imports in %q: %w", proof.File, err)
+	}
+	localImportPath := moduleImportPath
+	if dir := filepath.ToSlash(filepath.Dir(proof.File)); dir != "." {
+		localImportPath += "/" + dir
+	}
+	// Go compiles an external test package under a distinct synthetic import
+	// identity. Preserve that distinction so a package-local wrapper in
+	// runtime_test cannot masquerade as internal/runtime.NewFake.
+	if strings.HasSuffix(file.Name.Name, "_test") {
+		localImportPath += "_test"
+	}
+
+	var matches []*ast.FuncDecl
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == proof.Test {
+			matches = append(matches, fn)
+		}
+	}
+	if len(matches) != 1 {
+		return fmt.Errorf("proof test %s must appear exactly once in %s; found %d", proof.Test, proof.File, len(matches))
+	}
+	return validateProofFunction(matches[0], constructor, proof, imports, localImportPath)
+}
+
+func validateProofFunction(fn *ast.FuncDecl, constructor SymbolRef, proof ProofRef, imports map[string]string, localImportPath string) error {
+	if fn.Recv != nil || fn.Body == nil {
+		return fmt.Errorf("proof %s must be a top-level function with a body", proof.Test)
+	}
+	if !isRunnableProofTestName(fn.Name.Name) {
+		return fmt.Errorf("proof %s is not a runnable Go test name", proof.Test)
+	}
+	if fn.Type.TypeParams != nil && len(fn.Type.TypeParams.List) != 0 {
+		return fmt.Errorf("proof %s must not declare type parameters", proof.Test)
+	}
+	testParam, err := exactProofTestParam(fn.Type.Params, imports, "proof test")
+	if err != nil {
+		return fmt.Errorf("proof %s: %w", proof.Test, err)
+	}
+	if fn.Type.Results != nil && len(fn.Type.Results.List) != 0 {
+		return fmt.Errorf("proof %s must not return results", proof.Test)
+	}
+	if forbidden := forbiddenProofCall(fn.Body, imports, localImportPath); forbidden != "" {
+		return fmt.Errorf("proof %s directly calls %s", proof.Test, forbidden)
+	}
+	if len(fn.Body.List) == 0 {
+		return fmt.Errorf("proof %s has no contract runner call", proof.Test)
+	}
+	for _, stmt := range fn.Body.List[:len(fn.Body.List)-1] {
+		declStmt, ok := stmt.(*ast.DeclStmt)
+		if !ok {
+			return fmt.Errorf("proof %s: only zero-value var declarations may precede the contract runner", proof.Test)
+		}
+		decl, ok := declStmt.Decl.(*ast.GenDecl)
+		if !ok || decl.Tok != token.VAR || proofDeclarationHasValues(decl) {
+			return fmt.Errorf("proof %s: only zero-value var declarations may precede the contract runner", proof.Test)
+		}
+	}
+
+	exprStmt, ok := fn.Body.List[len(fn.Body.List)-1].(*ast.ExprStmt)
+	if !ok {
+		return fmt.Errorf("proof %s final statement must call contract runner %s", proof.Test, renderSymbolRef(proof.Runner))
+	}
+	runner, ok := unparen(exprStmt.X).(*ast.CallExpr)
+	if !ok {
+		return fmt.Errorf("proof %s final statement must call contract runner %s", proof.Test, renderSymbolRef(proof.Runner))
+	}
+	runnerRef, err := resolveProofCallSymbol(runner, imports, localImportPath)
+	if err != nil || runnerRef != proof.Runner {
+		return fmt.Errorf("proof %s final statement must call contract runner %s", proof.Test, renderSymbolRef(proof.Runner))
+	}
+	if len(runner.Args) != 2 {
+		return fmt.Errorf("proof %s contract runner requires the test parameter and one inline factory", proof.Test)
+	}
+	runnerTest, ok := unparen(runner.Args[0]).(*ast.Ident)
+	if !ok || runnerTest.Obj != testParam.Obj {
+		return fmt.Errorf("proof %s contract runner must receive its test parameter directly", proof.Test)
+	}
+	factory, ok := unparen(runner.Args[1]).(*ast.FuncLit)
+	if !ok {
+		return fmt.Errorf("proof %s contract runner factory must be an inline function literal", proof.Test)
+	}
+	return validateProofFactory(factory, constructor, proof, imports, localImportPath)
+}
+
+func validateProofFactory(factory *ast.FuncLit, constructor SymbolRef, proof ProofRef, imports map[string]string, localImportPath string) error {
+	factoryParam, err := exactProofTestParam(factory.Type.Params, imports, "runner factory")
+	if err != nil {
+		return err
+	}
+	if len(factory.Body.List) != 1 {
+		return fmt.Errorf("runner factory must contain exactly one direct return statement")
+	}
+	ret, ok := factory.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) == 0 {
+		return fmt.Errorf("runner factory must contain exactly one direct return statement")
+	}
+	constructorCall, ok := unparen(ret.Results[0]).(*ast.CallExpr)
+	if !ok {
+		return fmt.Errorf("factory must return constructor %s directly", renderSymbolRef(constructor))
+	}
+	constructorRef, err := resolveProofCallSymbol(constructorCall, imports, localImportPath)
+	if err != nil || constructorRef != constructor {
+		return fmt.Errorf("factory must return constructor %s directly", renderSymbolRef(constructor))
+	}
+
+	allowed := map[SymbolRef]bool{constructor: true}
+	for _, call := range proof.AllowedCalls {
+		allowed[call] = true
+	}
+	usedAllowed := make(map[SymbolRef]bool)
+	constructorCalls := 0
+	var callProblem string
+	ast.Inspect(factory.Body, func(node ast.Node) bool {
+		if callProblem != "" {
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if selector, ok := unparen(call.Fun).(*ast.SelectorExpr); ok {
+			if receiver, ok := unparen(selector.X).(*ast.Ident); ok && receiver.Obj == factoryParam.Obj {
+				switch selector.Sel.Name {
+				case "Name", "TempDir":
+					return true
+				default:
+					callProblem = "runner factory test method " + selector.Sel.Name + " is not allowed"
+					return false
+				}
+			}
+		}
+		ref, err := resolveProofCallSymbol(call, imports, localImportPath)
+		if err != nil || !allowed[ref] {
+			callProblem = fmt.Sprintf("runner factory callee %s is not allowed", renderSymbolRef(ref))
+			return false
+		}
+		if ref == constructor {
+			constructorCalls++
+		} else {
+			usedAllowed[ref] = true
+		}
+		return true
+	})
+	if callProblem != "" {
+		return fmt.Errorf("%s", callProblem)
+	}
+	if constructorCalls != 1 {
+		return fmt.Errorf("runner factory must call constructor %s exactly once; found %d", renderSymbolRef(constructor), constructorCalls)
+	}
+	for _, allowedCall := range proof.AllowedCalls {
+		if !usedAllowed[allowedCall] {
+			return fmt.Errorf("allowed proof call %s is not used", renderSymbolRef(allowedCall))
+		}
+	}
+	return nil
+}
+
+func exactProofTestParam(params *ast.FieldList, imports map[string]string, owner string) (*ast.Ident, error) {
+	if params == nil || len(params.List) != 1 || len(params.List[0].Names) != 1 {
+		return nil, fmt.Errorf("%s must have one named testing parameter", owner)
+	}
+	field := params.List[0]
+	ptr, ok := field.Type.(*ast.StarExpr)
+	if !ok {
+		return nil, fmt.Errorf("%s parameter must be exactly *testing.T", owner)
+	}
+	selector, ok := ptr.X.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "T" {
+		return nil, fmt.Errorf("%s parameter must be exactly *testing.T", owner)
+	}
+	qualifier, ok := selector.X.(*ast.Ident)
+	if !ok || imports[qualifier.Name] != "testing" {
+		return nil, fmt.Errorf("%s parameter must be exactly *testing.T", owner)
+	}
+	return field.Names[0], nil
+}
+
+func forbiddenProofCall(root ast.Node, imports map[string]string, localImportPath string) string {
+	var forbidden string
+	ast.Inspect(root, func(node ast.Node) bool {
+		if forbidden != "" {
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if selector, ok := unparen(call.Fun).(*ast.SelectorExpr); ok {
+			switch selector.Sel.Name {
+			case "Skip", "Skipf", "SkipNow":
+				receiver := "<expression>"
+				if ident, ok := unparen(selector.X).(*ast.Ident); ok {
+					receiver = ident.Name
+				}
+				forbidden = receiver + "." + selector.Sel.Name
+				return false
+			}
+		}
+		if ref, err := resolveProofCallSymbol(call, imports, localImportPath); err == nil && ref == (SymbolRef{ImportPath: "testing", Name: "Short"}) {
+			forbidden = "testing.Short"
+			return false
+		}
+		return true
+	})
+	return forbidden
+}
+
+func resolveProofCallSymbol(call *ast.CallExpr, imports map[string]string, localImportPath string) (SymbolRef, error) {
+	switch fun := unparen(call.Fun).(type) {
+	case *ast.Ident:
+		if fun.Obj != nil && fun.Obj.Kind != ast.Fun {
+			return SymbolRef{}, fmt.Errorf("%s resolves to a local %s, not a declared function", fun.Name, fun.Obj.Kind)
+		}
+		return SymbolRef{ImportPath: localImportPath, Name: fun.Name}, nil
+	case *ast.SelectorExpr:
+		qualifier, ok := unparen(fun.X).(*ast.Ident)
+		if !ok || (qualifier.Obj != nil && qualifier.Obj.Kind != ast.Pkg) {
+			return SymbolRef{}, fmt.Errorf("selector receiver is not an imported package")
+		}
+		importPath := imports[qualifier.Name]
+		if importPath == "" {
+			return SymbolRef{}, fmt.Errorf("selector receiver %s is not an imported package", qualifier.Name)
+		}
+		return SymbolRef{ImportPath: importPath, Name: fun.Sel.Name}, nil
+	default:
+		return SymbolRef{}, fmt.Errorf("callee must be a direct function call, got %T", call.Fun)
+	}
+}
+
+func proofDeclarationHasValues(decl *ast.GenDecl) bool {
+	for _, spec := range decl.Specs {
+		values, ok := spec.(*ast.ValueSpec)
+		if !ok || len(values.Values) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func isRunnableProofTestName(name string) bool {
+	if !strings.HasPrefix(name, "Test") {
+		return false
+	}
+	if len(name) == len("Test") {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(name[len("Test"):])
+	return !unicode.IsLower(r)
+}


### PR DESCRIPTION
## Summary

- add a proved contract disposition that binds an exact constructor to one runnable shared-conformance entrypoint
- require the proof test to make the shared runner its final top-level call and return the production constructor directly from a one-statement inline factory
- reject pre-run helper gates, generic or missing tests, direct Skip/testing.Short, shadowed or external-test-package constructor wrappers, unledgered setup calls, and stale unused permissions
- upgrade runtime.NewFake from an expiring waiver to a source-checked RunProviderTests proof
- create a fresh Fake per conformance factory invocation, preserving same-provider multi-session checks while isolating top-level cases

This is P0.3a only. Subprocess constructor binding remains the next bounded slice. Build-tag/cadence ownership remains with E1 and is not falsely claimed by this source proof.

## Invariant map

| Invariant | Old owner | New owner | Size / purpose | Why truthful |
| --- | --- | --- | --- | --- |
| The reusable runtime Fake obeys runtime.Provider | RunProviderTests existed, but the ledger carried only an expiring waiver | internal/runtime/fake_conformance_test.go#TestFakeConformance plus providerledger proof guard | Small conformance contract | the guard connects exact runtime.NewFake dataflow to exact RunProviderTests and rejects gates/skips/wrappers |
| Proof permissions cannot silently broaden | No proved disposition | Exact/minimal AllowedCalls set | Small architecture ratchet | undeclared calls fail and every declared call must actually occur |
| Multi-session behavior uses one provider | Shared Fake across the entire suite | Fresh Fake per factory call; each multi-session case still uses its first returned provider for all concurrent operations | Small conformance isolation | top-level state no longer leaks while concurrency remains same-provider |

## TDD evidence

Initial RED failed because ProofRef, DispositionProved, runtimeProviderRunner, and ValidateProofRefs did not exist.

Council-discovered RED mutants then proved two real bypasses:

- package runtime_test local NewFake wrapper was incorrectly accepted
- an unused AllowedCalls permission was incorrectly accepted

Both now fail for the intended reason. Additional negative fixtures cover disconnected/wrong constructors, alternate runner, missing/generic proof tests, pre-run helper calls, direct Skip, testing.Short, and unallowed setup functions.

## Verification

- go test -count=1 ./internal/testutil/providerledger
- go test -count=1 ./internal/runtime
- go test -race -count=20 focused providerledger proof/catalog owners
- go test -race -count=20 ./internal/runtime -run ^TestFakeConformance$
- make test-fast-parallel
- go vet ./...
- make check-docs
- git diff --check
- repository pre-commit and pre-push hooks

## Review council

Three independent read-only lanes reviewed the final rebased diff SHA-256 292e9e2e93f5f27b126ef47f3f33a1222d23866a5ca354b7bc13779351efad18:

- correctness/security: CLEAR
- architecture/scope: CLEAR
- test non-vacuity/ratchets: CLEAR
