### PR TITLE
fix(runtime): keep long-path subprocess stop idempotent

### DIFF
--- a/internal/runtime/subprocess/subprocess.go
+++ b/internal/runtime/subprocess/subprocess.go
@@ -573,7 +573,8 @@ func (p *Provider) sendSocketCommand(name, command string, timeout time.Duration
 		lastErr            error
 		firstActionableErr error
 	)
-	for _, sp := range []string{p.sockPath(name), p.legacySockPath(name)} {
+	legacyPath := p.legacySockPath(name)
+	for _, sp := range []string{p.sockPath(name), legacyPath} {
 		err := func(sockPath string) error {
 			conn, err := net.DialTimeout("unix", sockPath, timeout)
 			if err != nil {
@@ -595,6 +596,12 @@ func (p *Provider) sendSocketCommand(name, command string, timeout time.Duration
 		}(sp)
 		if err == nil {
 			return nil
+		}
+		// The canonical hashed path above is always addressable. An older
+		// name-based path can exceed sockaddr_un and cannot contain a live
+		// compatibility socket; retain the canonical result in that case.
+		if sp == legacyPath && len(legacyPath) > socketPathLimit && errors.Is(err, syscall.EINVAL) {
+			continue
 		}
 		if !isUnavailableSocketError(err) && firstActionableErr == nil {
 			firstActionableErr = err

--- a/internal/runtime/subprocess/subprocess_test.go
+++ b/internal/runtime/subprocess/subprocess_test.go
@@ -164,6 +164,22 @@ func TestStartVeryLongSocketDirFallsBackToTempDir(t *testing.T) {
 	}
 }
 
+func TestStopUnknownSessionWithVeryLongSocketDirIsIdempotent(t *testing.T) {
+	longDir := filepath.Join(t.TempDir(), strings.Repeat("p", 120))
+	p := NewProviderWithDir(longDir)
+	const name = "never-started-conformance-session"
+
+	if got := len(p.legacySockPath(name)); got <= socketPathLimit {
+		t.Fatalf("legacy socket path length = %d, want greater than %d", got, socketPathLimit)
+	}
+	if p.socketDir() == p.dir {
+		t.Fatal("test setup did not select the short fallback socket directory")
+	}
+	if err := p.Stop(name); err != nil {
+		t.Fatalf("Stop unknown session with overlong legacy socket path: %v", err)
+	}
+}
+
 func TestStartDuplicateNameFails(t *testing.T) {
 	p := newTestProvider(t)
 	if err := p.Start(context.Background(), "dup", runtime.Config{Command: "sleep 3600"}); err != nil {
@@ -559,29 +575,9 @@ func TestStopBySocket_ReturnsErrorWhenSocketRejectsStop(t *testing.T) {
 	if err := os.WriteFile(p.sockNamePath(name), []byte(name), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+	gotCommand := startRejectingControlSocket(t, p.sockPath(name))
 
-	lis, err := net.Listen("unix", p.sockPath(name))
-	if err != nil {
-		t.Fatalf("Listen: %v", err)
-	}
-	t.Cleanup(func() { _ = lis.Close() })
-
-	gotCommand := make(chan string, 1)
-	go func() {
-		conn, acceptErr := lis.Accept()
-		if acceptErr != nil {
-			return
-		}
-		defer conn.Close() //nolint:errcheck
-
-		line, readErr := bufio.NewReader(conn).ReadString('\n')
-		if readErr == nil {
-			gotCommand <- strings.TrimSpace(line)
-		}
-		_, _ = conn.Write([]byte("nope\n"))
-	}()
-
-	err = p.stopBySocket(name)
+	err := p.stopBySocket(name)
 	if err == nil {
 		t.Fatal("stopBySocket succeeded, want error")
 	}
@@ -597,6 +593,54 @@ func TestStopBySocket_ReturnsErrorWhenSocketRejectsStop(t *testing.T) {
 	if _, statErr := os.Stat(p.sockNamePath(name)); statErr != nil {
 		t.Fatalf("socket name path err = %v, want socket name preserved after failed stop", statErr)
 	}
+}
+
+func TestStopBySocket_PreservesCanonicalErrorWhenLegacyPathIsTooLong(t *testing.T) {
+	longDir := filepath.Join(t.TempDir(), strings.Repeat("p", 120))
+	p := NewProviderWithDir(longDir)
+	const name = "reject-stop"
+
+	if got := len(p.legacySockPath(name)); got <= socketPathLimit {
+		t.Fatalf("legacy socket path length = %d, want greater than %d", got, socketPathLimit)
+	}
+	if err := os.MkdirAll(filepath.Dir(p.sockPath(name)), 0o755); err != nil {
+		t.Fatalf("MkdirAll canonical socket directory: %v", err)
+	}
+	_ = startRejectingControlSocket(t, p.sockPath(name))
+
+	err := p.stopBySocket(name)
+	if err == nil || !strings.Contains(err.Error(), "unexpected response") {
+		t.Fatalf("stopBySocket error = %v, want canonical unexpected-response error", err)
+	}
+}
+
+func startRejectingControlSocket(t *testing.T, path string) <-chan string {
+	t.Helper()
+	lis, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("Listen %q: %v", path, err)
+	}
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(path)
+		_ = os.Remove(filepath.Dir(path))
+	})
+
+	gotCommand := make(chan string, 1)
+	go func() {
+		conn, acceptErr := lis.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck
+
+		line, readErr := bufio.NewReader(conn).ReadString('\n')
+		if readErr == nil {
+			gotCommand <- strings.TrimSpace(line)
+		}
+		_, _ = conn.Write([]byte("nope\n"))
+	}()
+	return gotCommand
 }
 
 func TestStopBySocket_FallsBackToLegacySocketWhenCanonicalRejectsStop(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve the canonical subprocess socket result when an overlong legacy compatibility path cannot be dialed
- keep Stop idempotent for unknown sessions with long state directories
- consolidate rejecting-socket fixtures so the checked net.Listen debt does not grow

## Test evidence

- focused regression failed before the production fix with EINVAL
- continue-to-return-nil mutant was rejected by the canonical-error regression
- race count 20 across long-path, actionable-error, and legacy-fallback cases
- full subprocess package and integration-tagged provider conformance
- make test-fast-parallel
- go vet ./...
- make check-docs
- three delegated correctness/architecture/test council lanes: CLEAR