### PR TITLE
fix(formula): finalize Ralph retries by logical control

### DIFF
--- a/internal/formula/graph.go
+++ b/internal/formula/graph.go
@@ -156,7 +156,9 @@ func graphSinkStepIDs(steps []*Step) []string {
 		return nil
 	}
 	referenced := make(map[string]struct{}, len(allSteps))
+	stepByID := make(map[string]*Step, len(allSteps))
 	for _, step := range allSteps {
+		stepByID[step.ID] = step
 		for _, id := range step.DependsOn {
 			referenced[id] = struct{}{}
 		}
@@ -166,6 +168,14 @@ func graphSinkStepIDs(steps []*Step) []string {
 	}
 
 	sinks := make([]string, 0)
+	sinkSet := make(map[string]struct{}, len(allSteps))
+	appendSink := func(id string) {
+		if _, exists := sinkSet[id]; exists {
+			return
+		}
+		sinkSet[id] = struct{}{}
+		sinks = append(sinks, id)
+	}
 	for _, step := range allSteps {
 		if step == nil {
 			continue
@@ -174,15 +184,40 @@ func graphSinkStepIDs(steps []*Step) []string {
 		case "workflow-finalize", "spec":
 			continue
 		case "scope":
+			// A retry-managed scope is a physical attempt, not an
+			// authoritative workflow result. Substitute its logical control as a
+			// mandatory sink so a failed loop cannot be hidden by passing
+			// downstream work, and so iteration 1 cannot remain as a stale failed
+			// blocker after a later attempt passes.
+			control := stepByID[step.Metadata[beadmeta.ControlForMetadataKey]]
+			attemptStepID := step.Metadata[beadmeta.StepIDMetadataKey]
+			if step.Metadata[beadmeta.AttemptMetadataKey] != "" && control != nil &&
+				attemptStepID != "" && attemptStepID == control.Metadata[beadmeta.StepIDMetadataKey] &&
+				(control.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindRetry ||
+					control.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindRalph) {
+				// Nested attempt scopes roll up through their enclosing scope. Only
+				// an outermost attempt contributes its logical control directly;
+				// otherwise an inner control from an old outer attempt would become
+				// another stale workflow blocker.
+				scopeRef := step.Metadata[beadmeta.ScopeRefMetadataKey]
+				if scopeRef == "" {
+					appendSink(control.ID)
+					continue
+				}
+				enclosing := stepByID[scopeRef]
+				if enclosing != nil && enclosing.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindScope {
+					continue
+				}
+			}
 			// Scope bodies are terminal latches even when referenced by teardown
 			// steps. Workflow finalization must see their pass/fail outcome.
-			sinks = append(sinks, step.ID)
+			appendSink(step.ID)
 			continue
 		}
 		if _, ok := referenced[step.ID]; ok {
 			continue
 		}
-		sinks = append(sinks, step.ID)
+		appendSink(step.ID)
 	}
 	return sinks
 }

--- a/internal/formula/graph_test.go
+++ b/internal/formula/graph_test.go
@@ -161,6 +161,179 @@ func TestApplyGraphControlsRalphOnCompleteOnlyControlsLogicalStep(t *testing.T) 
 	}
 }
 
+func TestApplyGraphControlsFinalizerExcludesRalphIterationScope(t *testing.T) {
+	t.Parallel()
+
+	f := &Formula{
+		Steps: []*Step{
+			{
+				ID:    "review-loop",
+				Title: "Review loop",
+				Ralph: &RalphSpec{
+					MaxAttempts: 3,
+					Check: &RalphCheckSpec{
+						Mode: "exec",
+						Path: ".gascity/checks/review.sh",
+					},
+				},
+				Children: []*Step{
+					{ID: "review", Title: "Review", Type: "task"},
+					{ID: "synthesize", Title: "Synthesize", Type: "task", Needs: []string{"review"}},
+				},
+			},
+			{
+				ID:    "publish",
+				Title: "Publish",
+				Type:  "task",
+				Needs: []string{"review-loop"},
+			},
+		},
+	}
+
+	expanded, err := ApplyRalph(f.Steps)
+	if err != nil {
+		t.Fatalf("ApplyRalph failed: %v", err)
+	}
+	f.Steps = expanded
+	ApplyGraphControls(f)
+
+	finalizer := findGraphStepByID(collectGraphSteps(f.Steps), "workflow-finalize")
+	if finalizer == nil {
+		t.Fatal("missing workflow-finalize")
+	}
+	if !containsString(finalizer.Needs, "review-loop") {
+		t.Fatalf("workflow-finalize needs = %v, want logical Ralph control even when referenced downstream", finalizer.Needs)
+	}
+	if !containsString(finalizer.Needs, "publish") {
+		t.Fatalf("workflow-finalize needs = %v, want downstream sink", finalizer.Needs)
+	}
+	if containsString(finalizer.Needs, "review-loop.iteration.1") {
+		t.Fatalf("workflow-finalize needs = %v, must not include physical Ralph iteration", finalizer.Needs)
+	}
+	logicalCount := 0
+	for _, id := range finalizer.Needs {
+		if id == "review-loop" {
+			logicalCount++
+		}
+	}
+	if logicalCount != 1 {
+		t.Fatalf("workflow-finalize needs = %v, want logical Ralph control exactly once", finalizer.Needs)
+	}
+}
+
+func TestApplyGraphControlsFinalizerExcludesNestedRalphAttemptLineage(t *testing.T) {
+	t.Parallel()
+
+	f := &Formula{
+		Steps: []*Step{
+			{
+				ID:    "outer-loop",
+				Title: "Outer loop",
+				Ralph: &RalphSpec{
+					MaxAttempts: 3,
+					Check:       &RalphCheckSpec{Mode: "exec", Path: ".gascity/checks/outer.sh"},
+				},
+				Children: []*Step{
+					{
+						ID:    "inner-loop",
+						Title: "Inner loop",
+						Ralph: &RalphSpec{
+							MaxAttempts: 2,
+							Check:       &RalphCheckSpec{Mode: "exec", Path: ".gascity/checks/inner.sh"},
+						},
+						Children: []*Step{{ID: "review", Title: "Review", Type: "task"}},
+					},
+				},
+			},
+			{ID: "publish", Title: "Publish", Type: "task", Needs: []string{"outer-loop"}},
+		},
+	}
+
+	expanded, err := ApplyRalph(f.Steps)
+	if err != nil {
+		t.Fatalf("ApplyRalph failed: %v", err)
+	}
+	f.Steps = expanded
+	ApplyGraphControls(f)
+
+	finalizer := findGraphStepByID(collectGraphSteps(f.Steps), "workflow-finalize")
+	if finalizer == nil {
+		t.Fatal("missing workflow-finalize")
+	}
+	for _, required := range []string{"outer-loop", "publish"} {
+		if !containsString(finalizer.Needs, required) {
+			t.Fatalf("workflow-finalize needs = %v, want %q", finalizer.Needs, required)
+		}
+	}
+	for _, stale := range []string{
+		"outer-loop.iteration.1",
+		"outer-loop.iteration.1.inner-loop",
+		"outer-loop.iteration.1.inner-loop.iteration.1",
+	} {
+		if containsString(finalizer.Needs, stale) {
+			t.Fatalf("workflow-finalize needs = %v, must not include nested physical lineage %q", finalizer.Needs, stale)
+		}
+	}
+}
+
+func TestGraphSinkStepIDsFailsClosedForInvalidAttemptControl(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name             string
+		includeControl   bool
+		controlKind      string
+		attemptStepID    string
+		controlStepID    string
+		scopeRef         string
+		includeEnclosing bool
+		enclosingKind    string
+	}{
+		{name: "missing control", attemptStepID: "loop"},
+		{name: "non-control target", includeControl: true, controlKind: beadmeta.KindTask, attemptStepID: "loop", controlStepID: "loop"},
+		{name: "missing attempt step ID", includeControl: true, controlKind: beadmeta.KindRalph, controlStepID: "loop"},
+		{name: "missing control step ID", includeControl: true, controlKind: beadmeta.KindRalph, attemptStepID: "loop"},
+		{name: "mismatched step IDs", includeControl: true, controlKind: beadmeta.KindRalph, attemptStepID: "loop", controlStepID: "other-loop"},
+		{name: "dangling enclosing scope", includeControl: true, controlKind: beadmeta.KindRalph, attemptStepID: "loop", controlStepID: "loop", scopeRef: "missing"},
+		{name: "wrong-kind enclosing scope", includeControl: true, controlKind: beadmeta.KindRalph, attemptStepID: "loop", controlStepID: "loop", scopeRef: "enclosing", includeEnclosing: true, enclosingKind: beadmeta.KindTask},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			steps := []*Step{
+				{
+					ID: "iteration",
+					Metadata: map[string]string{
+						beadmeta.KindMetadataKey:       beadmeta.KindScope,
+						beadmeta.AttemptMetadataKey:    "1",
+						beadmeta.ControlForMetadataKey: "logical",
+						beadmeta.StepIDMetadataKey:     tc.attemptStepID,
+						beadmeta.ScopeRefMetadataKey:   tc.scopeRef,
+					},
+				},
+			}
+			if tc.includeControl {
+				steps = append(steps, &Step{
+					ID:    "logical",
+					Needs: []string{"iteration"},
+					Metadata: map[string]string{
+						beadmeta.KindMetadataKey:   tc.controlKind,
+						beadmeta.StepIDMetadataKey: tc.controlStepID,
+					},
+				})
+			}
+			if tc.includeEnclosing {
+				steps = append(steps, &Step{
+					ID:       "enclosing",
+					Metadata: map[string]string{beadmeta.KindMetadataKey: tc.enclosingKind},
+				})
+			}
+
+			if sinks := graphSinkStepIDs(steps); !containsString(sinks, "iteration") {
+				t.Fatalf("graphSinkStepIDs = %v, want physical scope retained for invalid lineage", sinks)
+			}
+		})
+	}
+}
+
 func TestApplyGraphControlsSimpleRalphInsideScopeDoesNotCreateRunScopeCheck(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- replace physical retry-managed scope sinks with their authoritative logical retry/Ralph control
- retain downstream sinks and deduplicate the substituted logical control
- roll nested retry attempts through a validated enclosing scope so historical inner controls cannot become stale blockers
- fail closed to the physical scope when lineage metadata is missing, mismatched, dangling, or points at the wrong kind

## RCA

Supported-pack Compound canary run 29371748697 produced a valid review artifact but closed its workflow root fail after a fail/fail/pass Ralph sequence. Artifact 8326696954 showed the workflow finalizer fi-cng had direct blocks edges to failed physical iteration 1 fi-jz4 and passing logical Ralph fi-taz. The terminal abort descendant query returned zero candidates.

graphSinkStepIDs treated every gc.kind=scope as a mandatory workflow sink, including Ralph iteration scopes. The failed first physical attempt therefore outvoted the later passing logical control. This is deterministic graph construction, not dispatcher flakiness.

Later runtime attempts lacking gc.logical_bead_id are a separate metadata invariant gap; they were not on this failure path and are intentionally not masked by this change.

## Tests

TDD regression evidence on the previous implementation:

- terminal case: finalizer needs were [review-loop review-loop.iteration.1]
- downstream case: finalizer needs were [publish], omitting the failed logical control
- nested case: finalizer included stale inner control outer-loop.iteration.1.inner-loop
- malformed lineage cases incorrectly dropped the physical scope

Verification:

- go test ./internal/formula -count=1
- go test ./internal/dispatch/... -count=1
- make test-fast-parallel
- go vet ./...
- make lint-changed
- git diff --check
- repository pre-commit and pre-push hooks
- independent five-axis review: approved with no required findings
