### PR TITLE
test(runtime): centralize conformance session cleanup

### DIFF
--- a/internal/runtime/acp/conformance_test.go
+++ b/internal/runtime/acp/conformance_test.go
@@ -42,7 +42,6 @@ func TestACPConformance(t *testing.T) {
 	runtimetest.RunProviderTests(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
 		id := atomic.AddInt64(&counter, 1)
 		name := fmt.Sprintf("gc-acp-conform-%d", id)
-		t.Cleanup(func() { _ = p.Stop(name) })
 		return p, runtime.Config{
 			Command: binPath,
 			WorkDir: t.TempDir(),

--- a/internal/runtime/runtimetest/conformance.go
+++ b/internal/runtime/runtimetest/conformance.go
@@ -23,6 +23,10 @@ import (
 
 // Factory creates a (provider, config, sessionName) tuple for a single test.
 // The provider may be shared across tests; config and name must be unique.
+// The conformance runner reports cleanup failures and stops every successfully
+// started session. Factories should register only teardown that is distinct
+// from Provider.Stop, except for a documented provider whose failed Start can
+// leave partial resources and therefore still needs temporary fallback cleanup.
 type Factory func(t *testing.T) (runtime.Provider, runtime.Config, string)
 
 // Options customizes provider conformance behavior for implementations whose
@@ -53,7 +57,6 @@ func RunProviderTestsWithOptions(t *testing.T, newSession Factory, opts Options)
 	t.Run("SharedSession", func(t *testing.T) {
 		sp, cfg, name := newSession(t)
 		startOrSkip(t, opts, sp, name, cfg, "Start shared session")
-		t.Cleanup(func() { _ = sp.Stop(name) })
 		RunSessionTests(t, sp, cfg, name)
 	})
 }
@@ -77,7 +80,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 	t.Run("Start_CreatesRunningSession", func(t *testing.T) {
 		sp, cfg, name := newSession(t)
 		startOrSkip(t, opts, sp, name, cfg, "Start")
-		t.Cleanup(func() { _ = sp.Stop(name) })
 
 		if !sp.IsRunning(name) {
 			t.Error("IsRunning = false after Start, want true")
@@ -87,9 +89,8 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 	t.Run("Start_DuplicateReturnsError", func(t *testing.T) {
 		sp, cfg, name := newSession(t)
 		startOrSkip(t, opts, sp, name, cfg, "first Start")
-		t.Cleanup(func() { _ = sp.Stop(name) })
 
-		err := sp.Start(context.Background(), name, cfg)
+		err := startWithCleanup(t, sp, name, cfg)
 		if err == nil {
 			t.Error("second Start should return error for duplicate name")
 		}
@@ -101,11 +102,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 		_, cfg3, name3 := newSession(t)
 		names := []string{name1, name2, name3}
 		cfgs := []runtime.Config{cfg1, cfg2, cfg3}
-		for _, name := range names {
-			t.Cleanup(func(n string) func() {
-				return func() { _ = sp.Stop(n) }
-			}(name))
-		}
 		errs := make([]error, len(names))
 		var wg sync.WaitGroup
 		for i := range names {
@@ -116,6 +112,11 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 			}(i)
 		}
 		wg.Wait()
+		for i, err := range errs {
+			if err == nil {
+				registerStopCleanup(t, sp, names[i])
+			}
+		}
 		for i, err := range errs {
 			if err != nil {
 				handleStartError(t, opts, err, fmt.Sprintf("concurrent Start(%s)", names[i]))
@@ -193,9 +194,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 		cfgs := []runtime.Config{cfg1, cfg2, cfg3}
 		for i := range names {
 			startOrSkip(t, opts, sp, names[i], cfgs[i], fmt.Sprintf("Start(%s)", names[i]))
-			t.Cleanup(func(n string) func() {
-				return func() { _ = sp.Stop(n) }
-			}(names[i]))
 		}
 		errs := make([]error, len(names))
 		var wg sync.WaitGroup
@@ -229,9 +227,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 		cfgs := []runtime.Config{cfg1, cfg2, cfg3}
 		for i := range names {
 			startOrSkip(t, opts, sp, names[i], cfgs[i], fmt.Sprintf("Start(%s)", names[i]))
-			t.Cleanup(func(n string) func() {
-				return func() { _ = sp.Stop(n) }
-			}(names[i]))
 		}
 		got := make([]bool, len(names))
 		var wg sync.WaitGroup
@@ -255,11 +250,9 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 	t.Run("ListRunning_FindsSessions", func(t *testing.T) {
 		sp, cfg1, name1 := newSession(t)
 		startOrSkip(t, opts, sp, name1, cfg1, fmt.Sprintf("Start %s", name1))
-		t.Cleanup(func() { _ = sp.Stop(name1) })
 
 		_, cfg2, name2 := newSession(t)
 		startOrSkip(t, opts, sp, name2, cfg2, fmt.Sprintf("Start %s", name2))
-		t.Cleanup(func() { _ = sp.Stop(name2) })
 
 		names, err := sp.ListRunning("")
 		if err != nil {
@@ -276,11 +269,9 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 	t.Run("ListRunning_PrefixFiltering", func(t *testing.T) {
 		sp, cfg1, name1 := newSession(t)
 		startOrSkip(t, opts, sp, name1, cfg1, fmt.Sprintf("Start %s", name1))
-		t.Cleanup(func() { _ = sp.Stop(name1) })
 
 		_, cfg2, name2 := newSession(t)
 		startOrSkip(t, opts, sp, name2, cfg2, fmt.Sprintf("Start %s", name2))
-		t.Cleanup(func() { _ = sp.Stop(name2) })
 
 		// Using the full name as prefix should match only that session.
 		names, err := sp.ListRunning(name1)
@@ -314,7 +305,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 	t.Run("ListRunning_EmptyPrefix", func(t *testing.T) {
 		sp, cfg, name := newSession(t)
 		startOrSkip(t, opts, sp, name, cfg, "Start")
-		t.Cleanup(func() { _ = sp.Stop(name) })
 
 		names, err := sp.ListRunning("")
 		if err != nil {
@@ -333,9 +323,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 		cfgs := []runtime.Config{cfg1, cfg2, cfg3}
 		for i := range names {
 			startOrSkip(t, opts, sp, names[i], cfgs[i], fmt.Sprintf("Start(%s)", names[i]))
-			t.Cleanup(func(n string) func() {
-				return func() { _ = sp.Stop(n) }
-			}(names[i]))
 		}
 		results := make([][]string, len(names))
 		var wg sync.WaitGroup
@@ -364,7 +351,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 	t.Run("ProcessAlive_EmptyNamesReturnsTrue", func(t *testing.T) {
 		sp, cfg, name := newSession(t)
 		startOrSkip(t, opts, sp, name, cfg, "Start")
-		t.Cleanup(func() { _ = sp.Stop(name) })
 
 		if !sp.ProcessAlive(name, nil) {
 			t.Error("ProcessAlive with empty names = false, want true")
@@ -391,9 +377,6 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 		cfgs := []runtime.Config{cfg1, cfg2, cfg3}
 		for i := range names {
 			startOrSkip(t, opts, sp, names[i], cfgs[i], fmt.Sprintf("Start(%s)", names[i]))
-			t.Cleanup(func(n string) func() {
-				return func() { _ = sp.Stop(n) }
-			}(names[i]))
 		}
 		got := make([]bool, len(names))
 		var wg sync.WaitGroup
@@ -416,9 +399,34 @@ func RunLifecycleTestsWithOptions(t *testing.T, newSession Factory, opts Options
 func startOrSkip(t *testing.T, opts Options, sp runtime.Provider, name string, cfg runtime.Config, label string) {
 	t.Helper()
 
-	if err := sp.Start(context.Background(), name, cfg); err != nil {
+	if err := startWithCleanup(t, sp, name, cfg); err != nil {
 		handleStartError(t, opts, err, label)
 	}
+}
+
+func startWithCleanup(t *testing.T, sp runtime.Provider, name string, cfg runtime.Config) error {
+	t.Helper()
+
+	err := sp.Start(context.Background(), name, cfg)
+	if err == nil {
+		registerStopCleanup(t, sp, name)
+	}
+	return err
+}
+
+type cleanupTB interface {
+	Helper()
+	Cleanup(func())
+	Errorf(string, ...any)
+}
+
+func registerStopCleanup(t cleanupTB, sp runtime.Provider, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := sp.Stop(name); err != nil {
+			t.Errorf("Stop(%q) during conformance cleanup: %v", name, err)
+		}
+	})
 }
 
 func handleStartError(t *testing.T, opts Options, err error, label string) {

--- a/internal/runtime/runtimetest/conformance_test.go
+++ b/internal/runtime/runtimetest/conformance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -17,6 +18,199 @@ type startFailProvider struct {
 
 func (p startFailProvider) Start(_ context.Context, _ string, _ runtime.Config) error {
 	return p.err
+}
+
+type cleanupProvider struct {
+	runtime.Provider
+	startErr error
+	stopErr  error
+	started  []string
+	stopped  []string
+}
+
+func (p *cleanupProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	p.started = append(p.started, name)
+	if p.startErr != nil {
+		return p.startErr
+	}
+	return p.Provider.Start(ctx, name, cfg)
+}
+
+func (p *cleanupProvider) Stop(name string) error {
+	p.stopped = append(p.stopped, name)
+	if p.stopErr != nil {
+		return p.stopErr
+	}
+	return p.Provider.Stop(name)
+}
+
+type duplicateSuccessProvider struct {
+	*cleanupProvider
+	startCalls int
+}
+
+func (p *duplicateSuccessProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	p.startCalls++
+	if p.startCalls > 1 {
+		return nil
+	}
+	return p.cleanupProvider.Start(ctx, name, cfg)
+}
+
+type cleanupRecorder struct {
+	cleanups []func()
+	errors   []string
+}
+
+func (*cleanupRecorder) Helper() {}
+
+func (r *cleanupRecorder) Cleanup(cleanup func()) {
+	r.cleanups = append(r.cleanups, cleanup)
+}
+
+func (r *cleanupRecorder) Errorf(format string, args ...any) {
+	r.errors = append(r.errors, fmt.Sprintf(format, args...))
+}
+
+func TestStartOrSkipRegistersCleanup(t *testing.T) {
+	const name = "cleanup-owned-session"
+	provider := &cleanupProvider{Provider: runtime.NewFake()}
+
+	if ok := t.Run("owner", func(t *testing.T) {
+		startOrSkip(t, Options{}, provider, name, runtime.Config{}, "Start")
+		if !provider.IsRunning(name) {
+			t.Fatalf("IsRunning(%q) = false after Start, want true", name)
+		}
+	}); !ok {
+		t.Fatal("cleanup owner subtest failed")
+	}
+
+	if len(provider.stopped) != 1 || provider.stopped[0] != name {
+		t.Fatalf("Stop calls = %v, want [%s]", provider.stopped, name)
+	}
+	if provider.IsRunning(name) {
+		t.Fatalf("IsRunning(%q) = true after owner cleanup", name)
+	}
+}
+
+func TestStartWithCleanupRegistersEverySuccessfulStart(t *testing.T) {
+	const name = "duplicate-success-session"
+	provider := &duplicateSuccessProvider{
+		cleanupProvider: &cleanupProvider{Provider: runtime.NewFake()},
+	}
+
+	if ok := t.Run("owner", func(t *testing.T) {
+		for i := 0; i < 2; i++ {
+			if err := startWithCleanup(t, provider, name, runtime.Config{}); err != nil {
+				t.Fatalf("Start call %d: %v", i+1, err)
+			}
+		}
+	}); !ok {
+		t.Fatal("cleanup owner subtest failed")
+	}
+
+	if len(provider.stopped) != 2 || provider.stopped[0] != name || provider.stopped[1] != name {
+		t.Fatalf("Stop calls = %v, want [%s %s]", provider.stopped, name, name)
+	}
+}
+
+func TestRegisterStopCleanupReportsFailure(t *testing.T) {
+	const name = "cleanup-error-session"
+	stopErr := errors.New("injected stop failure")
+	provider := &cleanupProvider{Provider: runtime.NewFake(), stopErr: stopErr}
+	recorder := &cleanupRecorder{}
+
+	registerStopCleanup(recorder, provider, name)
+	if len(recorder.cleanups) != 1 {
+		t.Fatalf("registered cleanups = %d, want 1", len(recorder.cleanups))
+	}
+	recorder.cleanups[0]()
+
+	if len(recorder.errors) != 1 {
+		t.Fatalf("reported errors = %v, want one", recorder.errors)
+	}
+	if !strings.Contains(recorder.errors[0], name) || !strings.Contains(recorder.errors[0], stopErr.Error()) {
+		t.Fatalf("reported error = %q, want session name and stop error", recorder.errors[0])
+	}
+}
+
+func TestStartOrSkipDoesNotStopSessionAfterClassifiedStartFailure(t *testing.T) {
+	const name = "preexisting-session"
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), name, runtime.Config{}); err != nil {
+		t.Fatalf("seed pre-existing session: %v", err)
+	}
+	t.Cleanup(func() { _ = fake.Stop(name) })
+	provider := &cleanupProvider{Provider: fake, startErr: runtime.ErrSessionExists}
+
+	t.Run("classified failure", func(t *testing.T) {
+		startOrSkip(t, Options{
+			SkipStartError: func(err error) (string, bool) {
+				return "session already exists", errors.Is(err, runtime.ErrSessionExists)
+			},
+		}, provider, name, runtime.Config{}, "Start")
+		t.Fatal("startOrSkip returned after classified Start failure")
+	})
+
+	if len(provider.stopped) != 0 {
+		t.Fatalf("Stop calls = %v, want none for an unowned name", provider.stopped)
+	}
+	if len(provider.started) != 1 || provider.started[0] != name {
+		t.Fatalf("Start calls = %v, want [%s]", provider.started, name)
+	}
+	if !provider.IsRunning(name) {
+		t.Fatalf("pre-existing session %q was stopped after failed Start", name)
+	}
+}
+
+func TestRunLifecycleTestsDoesNotStopUnownedConcurrentStart(t *testing.T) {
+	const preexisting = "preexisting-concurrent-session"
+	providers := make(map[string]*runtime.Fake)
+	factoryCalls := make(map[string]int)
+	var targetProvider *runtime.Fake
+	var counter int64
+
+	if ok := t.Run("suite", func(t *testing.T) {
+		RunLifecycleTestsWithOptions(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
+			testName := t.Name()
+			provider := providers[testName]
+			if provider == nil {
+				provider = runtime.NewFake()
+				providers[testName] = provider
+				if strings.HasSuffix(testName, "/Start_ConcurrentDistinctSessions") {
+					if err := provider.Start(context.Background(), preexisting, runtime.Config{}); err != nil {
+						t.Fatalf("seed pre-existing session: %v", err)
+					}
+					targetProvider = provider
+				}
+			}
+
+			factoryCalls[testName]++
+			name := fmt.Sprintf("conformance-session-%d", atomic.AddInt64(&counter, 1))
+			if strings.HasSuffix(testName, "/Start_ConcurrentDistinctSessions") && factoryCalls[testName] == 2 {
+				name = preexisting
+			}
+			return provider, runtime.Config{}, name
+		}, Options{
+			SkipStartError: func(err error) (string, bool) {
+				return "session already exists", errors.Is(err, runtime.ErrSessionExists)
+			},
+		})
+	}); !ok {
+		t.Fatal("lifecycle conformance subtest failed")
+	}
+
+	if targetProvider == nil {
+		t.Fatal("concurrent-start provider was not exercised")
+	}
+	t.Cleanup(func() { _ = targetProvider.Stop(preexisting) })
+	running, err := targetProvider.ListRunning("")
+	if err != nil {
+		t.Fatalf("ListRunning: %v", err)
+	}
+	if len(running) != 1 || running[0] != preexisting {
+		t.Fatalf("running sessions after cleanup = %v, want [%s]", running, preexisting)
+	}
 }
 
 func TestRunProviderTestsWithOptionsSkipsClassifiedStartErrors(t *testing.T) {

--- a/internal/runtime/subprocess/conformance_test.go
+++ b/internal/runtime/subprocess/conformance_test.go
@@ -19,8 +19,6 @@ func TestSubprocessConformance(t *testing.T) {
 	runtimetest.RunProviderTests(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
 		id := atomic.AddInt64(&counter, 1)
 		name := fmt.Sprintf("gc-subproc-conform-%d", id)
-		// Safety cleanup: stop any lingering process.
-		t.Cleanup(func() { _ = p.Stop(name) })
 		return p, runtime.Config{
 			Command: "sleep 300",
 			WorkDir: t.TempDir(),

--- a/internal/runtime/subprocess/seam_conformance_test.go
+++ b/internal/runtime/subprocess/seam_conformance_test.go
@@ -27,7 +27,6 @@ func TestSubprocessSeamConformance(t *testing.T) {
 	runtimetest.RunProviderTests(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
 		id := atomic.AddInt64(&counter, 1)
 		name := fmt.Sprintf("gc-subproc-seam-%d", id)
-		t.Cleanup(func() { _ = p.Stop(name) })
 		return p, runtime.Config{
 			Command: "sleep 300",
 			WorkDir: t.TempDir(),

--- a/internal/runtime/tmux/adapter_test.go
+++ b/internal/runtime/tmux/adapter_test.go
@@ -40,8 +40,6 @@ func TestTmuxConformance(t *testing.T) {
 	runtimetest.RunProviderTestsWithOptions(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
 		id := atomic.AddInt64(&counter, 1)
 		name := fmt.Sprintf("gc-test-conform-%d", id)
-		// Safety cleanup for orphan prevention.
-		t.Cleanup(func() { _ = p.Stop(name) })
 		return p, runtime.Config{
 			Command: "sleep 300",
 			WorkDir: t.TempDir(),

--- a/test/integration/session_k8s_test.go
+++ b/test/integration/session_k8s_test.go
@@ -38,7 +38,14 @@ func TestK8sSessionConformance(t *testing.T) {
 	runtimetest.RunLifecycleTests(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
 		id := atomic.AddInt64(&counter, 1)
 		name := fmt.Sprintf("gc-k8s-conform-%d", id)
-		t.Cleanup(func() { _ = p.Stop(name) })
+		// The external gc-session-k8s script can leave a partially created pod
+		// when Start fails. Keep this fallback until that script rolls back its
+		// own failed starts; the shared runner owns successful-start cleanup.
+		t.Cleanup(func() {
+			if err := p.Stop(name); err != nil {
+				t.Errorf("Stop(%q) during K8s fallback cleanup: %v", name, err)
+			}
+		})
 		return p, runtime.Config{
 			Command: "sleep 300",
 			WorkDir: "/tmp",


### PR DESCRIPTION
## Summary

Centralizes runtime-session cleanup in the shared provider conformance runner. Each successful `Provider.Start` now registers one corresponding `Provider.Stop`; failed or colliding starts register none.

This gives every test-created session a clear cleanup owner, avoids stopping pre-existing sessions, removes duplicated fixture teardown, and makes cleanup failures visible and attributable.

## Cleanup ownership

| Start outcome | Cleanup behavior |
| --- | --- |
| Successful start | Registers one cleanup callback |
| Concurrent or repeated successful starts | Registers one callback for each successful start |
| Failed or colliding start | Registers no callback and leaves existing sessions untouched |
| Cleanup failure | Fails the test and identifies the affected session |

## Implementation

- `startWithCleanup` registers `Provider.Stop` only after `Provider.Start` succeeds.
- ACP, subprocess, and tmux fixtures no longer duplicate cleanup owned by the shared suite.
- Provider-specific teardown remains where behavior is genuinely distinct:
  - Herdr still tears down its server.
  - Kubernetes keeps its documented fallback because its external script can leave a partially created pod after a failed start.

## TDD evidence

- The concurrent-collision regression initially failed because cleanup stopped a seeded pre-existing session; it passed after cleanup ownership was limited to successful starts.
- The sequential duplicate-success and cleanup-error tests failed before shared registration and error reporting were added.
- Mutants that skipped successful-start registration or swallowed cleanup errors failed the intended assertions.

## Verification

- [x] All eight fast parallel jobs via `./scripts/test-local-parallel fast`
- [x] All four integration shards
- [x] Focused Kubernetes integration coverage
- [x] Repeated race runs for the shared conformance runner, Fake, exec, and tagged subprocess contracts

> [!NOTE]
> The standalone docs-sync check was blocked by unrelated generated worktree Markdown directories present in the test environment.

## Review

Three delegated council lanes returned **CLEAR** on the exact frozen diff.
