### PR TITLE
fix: scrub CLI login callback fragment

### DIFF
--- a/internal/cliauth/client.go
+++ b/internal/cliauth/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -303,6 +304,12 @@ func browserLoginHandler(state string, resultCh chan<- browserLoginResult) http.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Content-Security-Policy", browserCallbackContentSecurityPolicy())
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
 		_, _ = io.WriteString(w, browserCallbackHTML())
 	})
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
@@ -333,32 +340,47 @@ func browserLoginHandler(state string, resultCh chan<- browserLoginResult) http.
 	return mux
 }
 
+const browserCallbackScript = `
+const status = document.getElementById("status");
+const params = new URLSearchParams(window.location.hash.slice(1));
+const token = params.get("token");
+const service = params.get("service");
+const state = params.get("state");
+history.replaceState(null, "", window.location.pathname + window.location.search);
+
+if (!token || !service || !state) {
+  status.textContent = "Login failed. Return to your terminal and try again.";
+} else {
+  fetch("/token", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({token, service, state}),
+    cache: "no-store",
+    credentials: "omit"
+  }).then((response) => {
+    status.textContent = response.ok ? "Login complete. You can return to your terminal." : "Login failed. Return to your terminal and try again.";
+  }).catch(() => {
+    status.textContent = "Login failed. Return to your terminal and try again.";
+  });
+}
+`
+
+func browserCallbackContentSecurityPolicy() string {
+	digest := sha256.Sum256([]byte(browserCallbackScript))
+	scriptSource := "'sha256-" + base64.StdEncoding.EncodeToString(digest[:]) + "'"
+	return "default-src 'none'; script-src " + scriptSource + "; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+}
+
 func browserCallbackHTML() string {
 	return `<!doctype html>
 <html lang="en">
 <head><meta charset="utf-8"><title>Gas City CLI Login</title></head>
 <body>
-<main style="font-family: system-ui, sans-serif; max-width: 48rem; margin: 3rem auto; line-height: 1.5;">
+<main>
 <h1>Completing Gas City CLI login</h1>
 <p id="status">Sending credentials to the local CLI callback.</p>
 </main>
-<script>
-const status = document.getElementById("status");
-const params = new URLSearchParams(window.location.hash.slice(1));
-fetch("/token", {
-  method: "POST",
-  headers: {"Content-Type": "application/json"},
-  body: JSON.stringify({
-    token: params.get("token") || "",
-    service: params.get("service") || "",
-    state: params.get("state") || ""
-  })
-}).then((response) => {
-  status.textContent = response.ok ? "Login complete. You can return to your terminal." : "Login failed. Return to your terminal and try again.";
-}).catch(() => {
-  status.textContent = "Login failed. Return to your terminal and try again.";
-});
-</script>
+<script>` + browserCallbackScript + `</script>
 </body>
 </html>`
 }

--- a/internal/cliauth/client_test.go
+++ b/internal/cliauth/client_test.go
@@ -3,6 +3,8 @@ package cliauth
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -95,6 +97,90 @@ func TestBrowserLoginRoundTrip(t *testing.T) {
 	}
 	if token != "tok-abc" {
 		t.Fatalf("token = %q; want tok-abc", token)
+	}
+}
+
+func TestBrowserCallbackPageScrubsFragmentBeforeTokenHandoff(t *testing.T) {
+	resultCh := make(chan browserLoginResult, 1)
+	recorder := httptest.NewRecorder()
+	browserLoginHandler("expected-state", resultCh).ServeHTTP(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "http://127.0.0.1/callback", nil),
+	)
+
+	response := recorder.Result()
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read callback page: %v", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want %d", response.StatusCode, http.StatusOK)
+	}
+	if got := response.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q; want no-store", got)
+	}
+	if got := response.Header.Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Pragma = %q; want no-cache", got)
+	}
+	if got := response.Header.Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy = %q; want no-referrer", got)
+	}
+	if got := response.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q; want nosniff", got)
+	}
+	if got := response.Header.Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options = %q; want DENY", got)
+	}
+
+	page := string(body)
+	const scriptOpen = "<script>"
+	const scriptClose = "</script>"
+	scriptStart := strings.Index(page, scriptOpen)
+	scriptEnd := strings.Index(page, scriptClose)
+	if scriptStart < 0 || scriptEnd <= scriptStart {
+		t.Fatalf("callback page does not contain one inline script")
+	}
+	script := page[scriptStart+len(scriptOpen) : scriptEnd]
+	scriptHash := sha256.Sum256([]byte(script))
+	wantScriptSource := "'sha256-" + base64.StdEncoding.EncodeToString(scriptHash[:]) + "'"
+	csp := response.Header.Get("Content-Security-Policy")
+	for _, directive := range []string{
+		"default-src 'none'",
+		"script-src " + wantScriptSource,
+		"connect-src 'self'",
+		"base-uri 'none'",
+		"form-action 'none'",
+		"frame-ancestors 'none'",
+	} {
+		if !strings.Contains(csp, directive) {
+			t.Fatalf("Content-Security-Policy = %q; missing %q", csp, directive)
+		}
+	}
+	if strings.Contains(csp, "'unsafe-inline'") {
+		t.Fatalf("Content-Security-Policy = %q; must not allow unsafe inline content", csp)
+	}
+
+	orderedSteps := []string{
+		`new URLSearchParams(window.location.hash.slice(1))`,
+		`const token = params.get("token")`,
+		`const service = params.get("service")`,
+		`const state = params.get("state")`,
+		`history.replaceState(null, "", window.location.pathname + window.location.search)`,
+		`if (!token || !service || !state)`,
+		`fetch("/token"`,
+	}
+	previous := -1
+	for _, step := range orderedSteps {
+		index := strings.Index(script, step)
+		if index < 0 {
+			t.Fatalf("callback script is missing %q", step)
+		}
+		if index <= previous {
+			t.Fatalf("callback script step %q occurs out of order", step)
+		}
+		previous = index
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the bearer fragment from browser history before exchanging the callback
- serve the callback with no-store and a hash-pinned CSP
- preserve the existing one-shot loopback token handoff

## Verification
- focused callback tests
- race tests
- go vet
- repository pre-commit and pre-push suites
- correctness, security, and operability council reviews approved

Tracks the human CLI bearer login edge rollout.