### PR TITLE
fix(runtime): secure overlong subprocess socket fallbacks

### DIFF
--- a/internal/runtime/subprocess/subprocess.go
+++ b/internal/runtime/subprocess/subprocess.go
@@ -43,9 +43,19 @@ type Provider struct {
 	dir      string                  // socket/meta file directory
 	procs    map[string]*sessionConn // in-process tracking
 	workDirs map[string]string       // session name → workDir (for CopyTo)
+	ops      providerOps
 }
 
-const socketPathLimit = 100
+type providerOps struct {
+	start func(*exec.Cmd) error
+}
+
+const (
+	socketPathLimit       = 100
+	fallbackSocketDirName = "gascity-subprocess"
+	shortSocketTempRoot   = "/tmp"
+	nativeSocketPathLimit = len(syscall.RawSockaddrUnix{}.Path) - 1
+)
 
 // sessionConn tracks a running child process and its control socket.
 type sessionConn struct {
@@ -56,8 +66,9 @@ type sessionConn struct {
 
 // Compile-time check.
 var (
-	_ runtime.Provider            = (*Provider)(nil)
-	_ runtime.ProcessTableScanner = (*Provider)(nil)
+	errPrivateSocketDirValidation                             = errors.New("private socket directory validation failed")
+	_                             runtime.Provider            = (*Provider)(nil)
+	_                             runtime.ProcessTableScanner = (*Provider)(nil)
 )
 
 // NewProvider returns a subprocess [Provider] that stores socket files in
@@ -65,14 +76,25 @@ var (
 func NewProvider() *Provider {
 	dir := filepath.Join(os.TempDir(), "gc-subprocess")
 	_ = os.MkdirAll(dir, 0o755)
-	return &Provider{dir: dir, procs: make(map[string]*sessionConn), workDirs: make(map[string]string)}
+	return newProvider(dir)
 }
 
 // NewProviderWithDir returns a subprocess [Provider] that stores socket files
 // in the given directory. Useful for tests that need isolated state.
 func NewProviderWithDir(dir string) *Provider {
 	_ = os.MkdirAll(dir, 0o755)
-	return &Provider{dir: dir, procs: make(map[string]*sessionConn), workDirs: make(map[string]string)}
+	return newProvider(dir)
+}
+
+func newProvider(dir string) *Provider {
+	return &Provider{
+		dir:      dir,
+		procs:    make(map[string]*sessionConn),
+		workDirs: make(map[string]string),
+		ops: providerOps{
+			start: (*exec.Cmd).Start,
+		},
+	}
 }
 
 // Start spawns a child process for the given session name and config.
@@ -82,6 +104,7 @@ func NewProviderWithDir(dir string) *Provider {
 func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	euid := os.Geteuid()
 
 	// Check in-memory tracking first.
 	if existing, ok := p.procs[name]; ok {
@@ -92,7 +115,7 @@ func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) err
 	}
 
 	// Check socket for cross-process case.
-	if p.socketAlive(name) {
+	if p.socketAliveAt(name, euid) {
 		return fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name)
 	}
 
@@ -146,7 +169,15 @@ func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) err
 	}
 	cmd.Env = env
 
-	if err := cmd.Start(); err != nil {
+	// Validate immediately before process creation so hostile pre-creation
+	// fails without spawning a child or touching stale socket artifacts.
+	socketDir := p.socketDirForEUID(euid)
+	if err := p.ensureSocketDir(socketDir, euid); err != nil {
+		_ = nullFile.Close()
+		clearWorkDir()
+		return fmt.Errorf("preparing control socket for %q: %w", name, err)
+	}
+	if err := p.ops.start(cmd); err != nil {
 		_ = nullFile.Close()
 		clearWorkDir()
 		return fmt.Errorf("starting session %q: %w", name, err)
@@ -155,7 +186,7 @@ func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) err
 
 	// Create control socket for cross-process discovery.
 	done := make(chan struct{})
-	lis, err := p.startControlSocket(name, cmd, done)
+	lis, err := p.startControlSocket(name, cmd, done, socketDir, euid)
 	if err != nil {
 		// Socket creation failed — kill the process and bail.
 		_ = cmd.Process.Kill()
@@ -165,8 +196,7 @@ func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) err
 	}
 	if err := p.persistStartMetadata(name, cfg.Env); err != nil {
 		lis.Close() //nolint:errcheck
-		_ = os.Remove(p.sockPath(name))
-		_ = os.Remove(p.sockNamePath(name))
+		_ = p.removeSocketArtifactsAt(name, socketDir, euid)
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 		clearWorkDir()
@@ -177,9 +207,8 @@ func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) err
 		_ = cmd.Wait()
 		// Clean up socket before signaling done so ListRunning
 		// never sees a stale socket after Stop returns.
-		lis.Close()                 //nolint:errcheck
-		os.Remove(p.sockPath(name)) //nolint:errcheck
-		_ = os.Remove(p.sockNamePath(name))
+		lis.Close() //nolint:errcheck
+		_ = p.removeSocketArtifactsAt(name, socketDir, euid)
 		p.clearSessionMeta(name)
 		close(done)
 	}()
@@ -191,6 +220,7 @@ func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) err
 // Stop terminates the named session. Returns nil if it doesn't exist
 // (idempotent). Sends SIGTERM first, then SIGKILL after a grace period.
 func (p *Provider) Stop(name string) error {
+	euid := os.Geteuid()
 	p.mu.Lock()
 	sc, ok := p.procs[name]
 	if ok {
@@ -207,12 +237,13 @@ func (p *Provider) Stop(name string) error {
 	}
 
 	// Fall back to socket (cross-process case: gc stop after gc start).
-	return p.stopBySocket(name)
+	return p.stopBySocketAt(name, euid)
 }
 
 // Interrupt sends SIGINT to the named session's process.
 // Best-effort: returns nil if the session doesn't exist.
 func (p *Provider) Interrupt(name string) error {
+	euid := os.Geteuid()
 	p.mu.Lock()
 	sc, ok := p.procs[name]
 	p.mu.Unlock()
@@ -220,18 +251,18 @@ func (p *Provider) Interrupt(name string) error {
 		return runtime.SignalProcessGroup(sc.cmd, syscall.SIGINT)
 	}
 
-	// Fall back to socket (cross-process case).
-	// Swallow connection errors — if the socket doesn't exist the session
-	// is dead, which is the same as "interrupt succeeded" (idempotent).
-	err := p.sendSocketCommand(name, "interrupt", 2*time.Second)
-	if err != nil {
-		return nil // session not running — best-effort
+	// Fall back to socket (cross-process case). A missing socket is the same
+	// as "interrupt succeeded"; validation failures must remain visible.
+	err := p.sendSocketCommandAt(name, "interrupt", 2*time.Second, euid)
+	if errors.Is(err, errPrivateSocketDirValidation) {
+		return err
 	}
 	return nil
 }
 
 // IsRunning reports whether the named session has a live process.
 func (p *Provider) IsRunning(name string) bool {
+	euid := os.Geteuid()
 	p.mu.Lock()
 	sc, ok := p.procs[name]
 	p.mu.Unlock()
@@ -241,7 +272,7 @@ func (p *Provider) IsRunning(name string) bool {
 	}
 
 	// Fall back to socket liveness check.
-	return p.socketAlive(name)
+	return p.socketAliveAt(name, euid)
 }
 
 // IsAttached always returns false — subprocess has no terminal concept.
@@ -405,13 +436,20 @@ func (p *Provider) CopyTo(name, src, relDst string) error {
 // ListRunning returns the names of all running sessions whose names
 // match the given prefix, discovered via socket files.
 func (p *Provider) ListRunning(prefix string) ([]string, error) {
+	euid := os.Geteuid()
 	dirs := []string{p.dir}
-	if fallback := p.fallbackDir(); fallback != p.dir {
+	if fallback := p.fallbackDirForEUID(euid); fallback != p.dir {
 		dirs = append(dirs, fallback)
 	}
 	seen := make(map[string]bool)
 	var names []string
 	for _, dir := range dirs {
+		if err := p.validateSocketDir(dir, euid); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
 		entries, err := os.ReadDir(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -428,7 +466,7 @@ func (p *Provider) ListRunning(prefix string) ([]string, error) {
 			if !strings.HasPrefix(sn, prefix) || seen[sn] {
 				continue
 			}
-			if p.socketAlive(sn) {
+			if p.socketAliveAt(sn, euid) {
 				seen[sn] = true
 				names = append(names, sn)
 			}
@@ -472,16 +510,96 @@ func (p *Provider) sockKey(name string) string {
 }
 
 func (p *Provider) fallbackDir() string {
+	return p.fallbackDirForEUID(os.Geteuid())
+}
+
+func (p *Provider) fallbackDirForEUID(euid int) string {
+	legacy := filepath.Join(os.TempDir(), fallbackSocketDirName, p.fallbackLeaf())
+	probe := filepath.Join(legacy, p.sockKey("probe")+".sock")
+	if len(probe) <= nativeSocketPathLimit {
+		return legacy
+	}
+	return p.privateFallbackDir(euid)
+}
+
+func (p *Provider) fallbackLeaf() string {
 	sum := sha256.Sum256([]byte(filepath.Clean(p.dir)))
-	return filepath.Join(os.TempDir(), "gascity-subprocess", hex.EncodeToString(sum[:8]))
+	return hex.EncodeToString(sum[:8])
+}
+
+func privateFallbackRoot(euid int) string {
+	return filepath.Join(shortSocketTempRoot, fmt.Sprintf("%s-%d", fallbackSocketDirName, euid))
+}
+
+func (p *Provider) privateFallbackDir(euid int) string {
+	return filepath.Join(privateFallbackRoot(euid), p.fallbackLeaf())
+}
+
+func (p *Provider) isPrivateFallbackDir(dir string, euid int) bool {
+	return dir == p.privateFallbackDir(euid)
+}
+
+func validatePrivateSocketDir(path string, euid int) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("private socket directory %q is not a directory", path)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		return fmt.Errorf("private socket directory %q has mode %04o, want 0700", path, got)
+	}
+	if special := info.Mode() & (os.ModeSetuid | os.ModeSetgid | os.ModeSticky); special != 0 {
+		return fmt.Errorf("private socket directory %q has special mode bits %v", path, special)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("private socket directory %q has unsupported ownership metadata", path)
+	}
+	if got, want := stat.Uid, uint32(euid); got != want {
+		return fmt.Errorf("private socket directory %q is owned by uid %d, want %d", path, got, want)
+	}
+	return nil
+}
+
+func ensurePrivateSocketDir(path string, euid int) error {
+	if err := os.Mkdir(path, 0o700); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("creating private socket directory %q: %w", path, err)
+	}
+	return validatePrivateSocketDir(path, euid)
+}
+
+func (p *Provider) ensureSocketDir(dir string, euid int) error {
+	if !p.isPrivateFallbackDir(dir, euid) {
+		return os.MkdirAll(dir, 0o755)
+	}
+	if err := ensurePrivateSocketDir(filepath.Dir(dir), euid); err != nil {
+		return err
+	}
+	return ensurePrivateSocketDir(dir, euid)
+}
+
+func (p *Provider) validateSocketDir(dir string, euid int) error {
+	if !p.isPrivateFallbackDir(dir, euid) {
+		return nil
+	}
+	if err := validatePrivateSocketDir(filepath.Dir(dir), euid); err != nil {
+		return err
+	}
+	return validatePrivateSocketDir(dir, euid)
 }
 
 func (p *Provider) socketDir() string {
+	return p.socketDirForEUID(os.Geteuid())
+}
+
+func (p *Provider) socketDirForEUID(euid int) string {
 	candidate := filepath.Join(p.dir, p.sockKey("probe")+".sock")
 	if len(candidate) <= socketPathLimit {
 		return p.dir
 	}
-	return p.fallbackDir()
+	return p.fallbackDirForEUID(euid)
 }
 
 func (p *Provider) sockPath(name string) string {
@@ -490,6 +608,19 @@ func (p *Provider) sockPath(name string) string {
 
 func (p *Provider) sockNamePath(name string) string {
 	return filepath.Join(p.socketDir(), p.sockKey(name)+".name")
+}
+
+func (p *Provider) removeSocketArtifactsAt(name, dir string, euid int) error {
+	if err := p.validateSocketDir(dir, euid); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	key := p.sockKey(name)
+	_ = os.Remove(filepath.Join(dir, key+".sock"))
+	_ = os.Remove(filepath.Join(dir, key+".name"))
+	return nil
 }
 
 func (p *Provider) socketNameForEntry(dir, key string) string {
@@ -510,12 +641,13 @@ func (p *Provider) socketNameForEntry(dir, key string) string {
 //   - "interrupt" — SIGINT to the whole session process group; replies "ok"
 //   - "ping" — replies "ok"
 //   - "pid" — replies with the PID (diagnostics)
-func (p *Provider) startControlSocket(name string, cmd *exec.Cmd, done <-chan struct{}) (net.Listener, error) {
-	sp := p.sockPath(name)
-	namePath := p.sockNamePath(name)
-	if err := os.MkdirAll(filepath.Dir(sp), 0o755); err != nil {
+func (p *Provider) startControlSocket(name string, cmd *exec.Cmd, done <-chan struct{}, dir string, euid int) (net.Listener, error) {
+	if err := p.ensureSocketDir(dir, euid); err != nil {
 		return nil, err
 	}
+	key := p.sockKey(name)
+	sp := filepath.Join(dir, key+".sock")
+	namePath := filepath.Join(dir, key+".name")
 	// Remove stale socket from a previous crash.
 	os.Remove(sp) //nolint:errcheck
 	_ = os.Remove(namePath)
@@ -524,7 +656,7 @@ func (p *Provider) startControlSocket(name string, cmd *exec.Cmd, done <-chan st
 	}
 	lis, err := net.Listen("unix", sp)
 	if err != nil {
-		os.Remove(namePath) //nolint:errcheck
+		_ = os.Remove(namePath)
 		return nil, err
 	}
 	go func() {
@@ -563,18 +695,41 @@ func handleSessionConn(conn net.Conn, cmd *exec.Cmd, done <-chan struct{}) {
 
 // socketAlive checks if a session is alive by pinging its control socket.
 func (p *Provider) socketAlive(name string) bool {
-	return p.sendSocketCommand(name, "ping", 500*time.Millisecond) == nil
+	return p.socketAliveAt(name, os.Geteuid())
+}
+
+func (p *Provider) socketAliveAt(name string, euid int) bool {
+	return p.sendSocketCommandAt(name, "ping", 500*time.Millisecond, euid) == nil
 }
 
 // sendSocketCommand connects to the session's control socket, sends a
 // command, and waits for "ok". Returns nil on success.
 func (p *Provider) sendSocketCommand(name, command string, timeout time.Duration) error {
+	return p.sendSocketCommandAt(name, command, timeout, os.Geteuid())
+}
+
+func (p *Provider) sendSocketCommandAt(name, command string, timeout time.Duration, euid int) error {
+	socketDir := p.socketDirForEUID(euid)
 	var (
 		lastErr            error
 		firstActionableErr error
 	)
+	canonicalAvailable := true
+	if err := p.validateSocketDir(socketDir, euid); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("%w: %w", errPrivateSocketDirValidation, err)
+		}
+		canonicalAvailable = false
+		lastErr = err
+	}
 	legacyPath := p.legacySockPath(name)
-	for _, sp := range []string{p.sockPath(name), legacyPath} {
+	canonicalPath := filepath.Join(socketDir, p.sockKey(name)+".sock")
+	paths := make([]string, 0, 2)
+	if canonicalAvailable {
+		paths = append(paths, canonicalPath)
+	}
+	paths = append(paths, legacyPath)
+	for _, sp := range paths {
 		err := func(sockPath string) error {
 			conn, err := net.DialTimeout("unix", sockPath, timeout)
 			if err != nil {
@@ -600,7 +755,7 @@ func (p *Provider) sendSocketCommand(name, command string, timeout time.Duration
 		// The canonical hashed path above is always addressable. An older
 		// name-based path can exceed sockaddr_un and cannot contain a live
 		// compatibility socket; retain the canonical result in that case.
-		if sp == legacyPath && len(legacyPath) > socketPathLimit && errors.Is(err, syscall.EINVAL) {
+		if sp == legacyPath && len(legacyPath) > nativeSocketPathLimit && errors.Is(err, syscall.EINVAL) {
 			continue
 		}
 		if !isUnavailableSocketError(err) && firstActionableErr == nil {
@@ -616,14 +771,16 @@ func (p *Provider) sendSocketCommand(name, command string, timeout time.Duration
 
 // stopBySocket connects to a session's control socket and asks it to stop.
 func (p *Provider) stopBySocket(name string) error {
-	err := p.sendSocketCommand(name, "stop", 7*time.Second)
+	return p.stopBySocketAt(name, os.Geteuid())
+}
+
+func (p *Provider) stopBySocketAt(name string, euid int) error {
+	err := p.sendSocketCommandAt(name, "stop", 7*time.Second, euid)
 	if err != nil {
 		if isUnavailableSocketError(err) {
 			// Socket doesn't exist or can't connect — session is dead (idempotent).
 			// Clean up stale socket file if it exists.
-			os.Remove(p.sockPath(name)) //nolint:errcheck
-			_ = os.Remove(p.sockNamePath(name))
-			return nil
+			return p.removeSocketArtifactsAt(name, p.socketDirForEUID(euid), euid)
 		}
 		return err
 	}

--- a/internal/runtime/subprocess/subprocess_test.go
+++ b/internal/runtime/subprocess/subprocess_test.go
@@ -3,8 +3,10 @@ package subprocess
 import (
 	"bufio"
 	"context"
+	"errors"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // shortTempDir returns a temp directory short enough for Unix socket paths
@@ -30,6 +33,64 @@ func shortTempDir(t *testing.T) string {
 func newTestProvider(t *testing.T) *Provider {
 	t.Helper()
 	return NewProviderWithDir(filepath.Join(shortTempDir(t), "socks"))
+}
+
+func requirePrivateSocketDirectory(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat(%q): %v", path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%q mode = %v, want directory", path, info.Mode())
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("%q permissions = %04o, want 0700", path, got)
+	}
+	if special := info.Mode() & (os.ModeSetuid | os.ModeSetgid | os.ModeSticky); special != 0 {
+		t.Fatalf("%q special mode bits = %v, want none", path, special)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("%q ownership metadata = %T, want *syscall.Stat_t", path, info.Sys())
+	}
+	if got, want := stat.Uid, uint32(os.Geteuid()); got != want {
+		t.Fatalf("%q uid = %d, want %d", path, got, want)
+	}
+}
+
+func ensurePrivateFallbackRootForTest(t *testing.T) string {
+	t.Helper()
+	root := privateFallbackRoot(os.Geteuid())
+	if err := os.Mkdir(root, 0o700); err != nil && !os.IsExist(err) {
+		t.Fatalf("Mkdir private fallback root: %v", err)
+	}
+	requirePrivateSocketDirectory(t, root)
+	return root
+}
+
+func requirePrivateFallbackRejected(t *testing.T, p *Provider, name string) {
+	t.Helper()
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "Stop", run: func() error { return p.Stop(name) }},
+		{name: "Interrupt", run: func() error { return p.Interrupt(name) }},
+		{name: "ListRunning", run: func() error {
+			_, err := p.ListRunning("")
+			return err
+		}},
+		{name: "sendSocketCommand", run: func() error {
+			return p.sendSocketCommand(name, "ping", testutil.ExecRaceTimeout)
+		}},
+	}
+	for _, check := range checks {
+		err := check.run()
+		if err == nil || !strings.Contains(err.Error(), "private socket directory") {
+			t.Errorf("%s error = %v, want private socket directory validation", check.name, err)
+		}
+	}
 }
 
 func TestStartCreatesProcess(t *testing.T) {
@@ -127,6 +188,7 @@ func TestStartVeryLongSocketDirFallsBackToTempDir(t *testing.T) {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	t.Setenv("TMPDIR", root)
 
 	longDir := filepath.Join(root, strings.Repeat("p", 120), "runtime", "gc", "subprocess", "hash")
 	if err := os.MkdirAll(longDir, 0o755); err != nil {
@@ -162,6 +224,293 @@ func TestStartVeryLongSocketDirFallsBackToTempDir(t *testing.T) {
 	if len(got) != 1 || got[0] != name {
 		t.Fatalf("ListRunning = %#v, want [%q]", got, name)
 	}
+}
+
+func TestFallbackKeepsBindableLegacyTempPathPastConservativeLimit(t *testing.T) {
+	root := shortTempDir(t)
+	longDir := filepath.Join(root, strings.Repeat("p", socketPathLimit+32))
+	owner := NewProviderWithDir(longDir)
+	observer := NewProviderWithDir(longDir)
+	const name = "bindable-legacy-fallback"
+
+	var bindableTemp string
+	for length := 1; length <= socketPathLimit; length++ {
+		candidate := filepath.Join(root, strings.Repeat("t", length))
+		probe := filepath.Join(candidate, fallbackSocketDirName, owner.fallbackLeaf(), owner.sockKey(name)+".sock")
+		if len(probe) > socketPathLimit && len(probe) <= nativeSocketPathLimit {
+			bindableTemp = candidate
+			break
+		}
+	}
+	if bindableTemp == "" {
+		t.Fatalf("could not construct fallback path in (%d, %d]", socketPathLimit, nativeSocketPathLimit)
+	}
+	if err := os.MkdirAll(bindableTemp, 0o700); err != nil {
+		t.Fatalf("MkdirAll bindable TMPDIR: %v", err)
+	}
+	t.Setenv("TMPDIR", bindableTemp)
+
+	fallback := owner.fallbackDir()
+	wantFallback := filepath.Join(bindableTemp, fallbackSocketDirName, owner.fallbackLeaf())
+	if fallback != wantFallback {
+		t.Fatalf("fallback = %q, want legacy path %q", fallback, wantFallback)
+	}
+	if got := len(owner.sockPath(name)); got <= socketPathLimit || got > nativeSocketPathLimit {
+		t.Fatalf("legacy fallback socket length = %d, want (%d, %d]", got, socketPathLimit, nativeSocketPathLimit)
+	}
+	t.Cleanup(func() {
+		_ = owner.Stop(name)
+		_ = observer.Stop(name)
+		_ = syscall.Rmdir(fallback)
+	})
+
+	if err := owner.Start(context.Background(), name, runtime.Config{Command: "sleep 300"}); err != nil {
+		t.Fatalf("Start on native-addressable legacy fallback: %v", err)
+	}
+	if _, err := os.Lstat(owner.sockPath(name)); err != nil {
+		t.Fatalf("Lstat legacy fallback socket: %v", err)
+	}
+	if !observer.IsRunning(name) {
+		t.Fatal("native-addressable legacy fallback is not visible through another provider")
+	}
+	if err := observer.Stop(name); err != nil {
+		t.Fatalf("cross-provider Stop on native-addressable legacy fallback: %v", err)
+	}
+}
+
+func TestLegacySocketRemainsVisibleWhenPrivateFallbackIsMissing(t *testing.T) {
+	root := shortTempDir(t)
+	longTemp := filepath.Join(root, strings.Repeat("t", nativeSocketPathLimit+32))
+	if err := os.MkdirAll(longTemp, 0o700); err != nil {
+		t.Fatalf("MkdirAll long TMPDIR: %v", err)
+	}
+	t.Setenv("TMPDIR", longTemp)
+	const name = "x"
+
+	var legacyDir string
+	for length := 1; length <= socketPathLimit; length++ {
+		candidate := filepath.Join(root, strings.Repeat("p", length))
+		canonicalProbe := filepath.Join(candidate, "s00000000.sock")
+		legacyPath := filepath.Join(candidate, name+".sock")
+		if len(canonicalProbe) > socketPathLimit && len(legacyPath) <= nativeSocketPathLimit {
+			legacyDir = candidate
+			break
+		}
+	}
+	if legacyDir == "" {
+		t.Fatal("could not construct addressable legacy path with fallback canonical path")
+	}
+	p := NewProviderWithDir(legacyDir)
+	privateLeaf := p.fallbackDir()
+	if filepath.Dir(privateLeaf) != privateFallbackRoot(os.Geteuid()) {
+		t.Fatalf("fallback = %q, want private root", privateLeaf)
+	}
+	if _, err := os.Lstat(privateLeaf); !os.IsNotExist(err) {
+		t.Fatalf("private fallback before discovery: %v, want not exist", err)
+	}
+
+	gotCommand := startRecordingControlSocket(t, p.legacySockPath(name), "ok\n", 5)
+	t.Cleanup(func() { _ = syscall.Rmdir(privateLeaf) })
+
+	startCalls := 0
+	p.ops.start = func(*exec.Cmd) error {
+		startCalls++
+		return errors.New("process start must not be reached")
+	}
+	if !p.IsRunning(name) {
+		t.Fatal("IsRunning missed addressable legacy socket")
+	}
+	names, err := p.ListRunning("")
+	if err != nil {
+		t.Fatalf("ListRunning legacy socket: %v", err)
+	}
+	if len(names) != 1 || names[0] != name {
+		t.Fatalf("ListRunning = %#v, want [%q]", names, name)
+	}
+	if err := p.Interrupt(name); err != nil {
+		t.Fatalf("Interrupt legacy socket: %v", err)
+	}
+	if err := p.Stop(name); err != nil {
+		t.Fatalf("Stop legacy socket: %v", err)
+	}
+	err = p.Start(context.Background(), name, runtime.Config{Command: "sleep 300"})
+	if !errors.Is(err, runtime.ErrSessionExists) {
+		t.Fatalf("Start error = %v, want ErrSessionExists from legacy socket", err)
+	}
+	if startCalls != 0 {
+		t.Fatalf("process start calls = %d, want 0", startCalls)
+	}
+	for _, want := range []string{"ping", "ping", "interrupt", "stop", "ping"} {
+		select {
+		case got := <-gotCommand:
+			if got != want {
+				t.Fatalf("legacy socket command = %q, want %q", got, want)
+			}
+		case <-time.After(testutil.ExecRaceTimeout):
+			t.Fatalf("timed out waiting for legacy socket command %q", want)
+		}
+	}
+}
+
+func TestOverlongTempDirUsesPrivateFallbackAcrossProviders(t *testing.T) {
+	root := shortTempDir(t)
+	longTemp := filepath.Join(root, strings.Repeat("t", nativeSocketPathLimit+32))
+	if err := os.MkdirAll(longTemp, 0o700); err != nil {
+		t.Fatalf("MkdirAll long TMPDIR: %v", err)
+	}
+	t.Setenv("TMPDIR", longTemp)
+
+	longDir := filepath.Join(root, strings.Repeat("p", socketPathLimit+32))
+	owner := NewProviderWithDir(longDir)
+	observer := NewProviderWithDir(longDir)
+	const name = "private-fallback-lifecycle"
+	fallback := owner.fallbackDir()
+	privateRoot := privateFallbackRoot(os.Geteuid())
+	sentinel := filepath.Join(privateRoot, owner.fallbackLeaf()+".sentinel")
+	t.Cleanup(func() {
+		_ = owner.Stop(name)
+		_ = observer.Stop(name)
+		_ = os.Remove(sentinel)
+		if err := syscall.Rmdir(fallback); err != nil && !os.IsNotExist(err) {
+			t.Errorf("Rmdir private fallback leaf: %v", err)
+		}
+	})
+
+	legacySocket := filepath.Join(longTemp, fallbackSocketDirName, owner.fallbackLeaf(), owner.sockKey(name)+".sock")
+	if len(legacySocket) <= nativeSocketPathLimit {
+		t.Fatalf("legacy fallback socket length = %d, want greater than %d", len(legacySocket), nativeSocketPathLimit)
+	}
+	if got, want := fallback, filepath.Join(privateRoot, owner.fallbackLeaf()); got != want {
+		t.Fatalf("fallback = %q, want private path %q", got, want)
+	}
+	if err := owner.Start(context.Background(), name, runtime.Config{Command: "sleep 300"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	requirePrivateSocketDirectory(t, privateRoot)
+	requirePrivateSocketDirectory(t, fallback)
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("WriteFile private-root sentinel: %v", err)
+	}
+
+	if !observer.IsRunning(name) {
+		t.Fatal("private fallback session is not visible through another provider")
+	}
+	names, err := observer.ListRunning("")
+	if err != nil {
+		t.Fatalf("cross-provider ListRunning: %v", err)
+	}
+	if len(names) != 1 || names[0] != name {
+		t.Fatalf("cross-provider ListRunning = %#v, want [%q]", names, name)
+	}
+	if err := observer.Stop(name); err != nil {
+		t.Fatalf("cross-provider Stop: %v", err)
+	}
+
+	requirePrivateSocketDirectory(t, fallback)
+	if contents, err := os.ReadFile(sentinel); err != nil || string(contents) != "keep" {
+		t.Fatalf("private-root sentinel after Stop: contents=%q err=%v", contents, err)
+	}
+	if info, err := os.Stat(longDir); err != nil || !info.IsDir() {
+		t.Fatalf("caller-owned directory after Stop: info=%v err=%v", info, err)
+	}
+}
+
+func TestPrivateFallbackRejectsHostilePrecreation(t *testing.T) {
+	root := shortTempDir(t)
+	longTemp := filepath.Join(root, strings.Repeat("t", nativeSocketPathLimit+32))
+	if err := os.MkdirAll(longTemp, 0o700); err != nil {
+		t.Fatalf("MkdirAll long TMPDIR: %v", err)
+	}
+	t.Setenv("TMPDIR", longTemp)
+	privateRoot := ensurePrivateFallbackRootForTest(t)
+
+	t.Run("symlink leaf", func(t *testing.T) {
+		longDir := filepath.Join(root, "symlink-state", strings.Repeat("p", socketPathLimit+32))
+		p := NewProviderWithDir(longDir)
+		const name = "hostile-symlink-fallback"
+		fallback := p.fallbackDir()
+		if filepath.Dir(fallback) != privateRoot {
+			t.Fatalf("fallback parent = %q, want %q", filepath.Dir(fallback), privateRoot)
+		}
+
+		target := shortTempDir(t)
+		socketTarget := filepath.Join(target, p.sockKey(name)+".sock")
+		nameTarget := filepath.Join(target, p.sockKey(name)+".name")
+		for path, contents := range map[string]string{socketTarget: "keep-socket", nameTarget: "keep-name"} {
+			if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+				t.Fatalf("WriteFile hostile target %q: %v", path, err)
+			}
+		}
+		if err := os.Symlink(target, fallback); err != nil {
+			t.Fatalf("Symlink fallback leaf: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(fallback) })
+
+		startCalls := 0
+		p.ops.start = func(*exec.Cmd) error {
+			startCalls++
+			return errors.New("process start must not be reached")
+		}
+		err := p.Start(context.Background(), name, runtime.Config{Command: "sleep 300"})
+		if err == nil || !strings.Contains(err.Error(), "private socket directory") {
+			t.Fatalf("Start error = %v, want private socket directory validation", err)
+		}
+		if startCalls != 0 {
+			t.Fatalf("process start calls = %d, want 0", startCalls)
+		}
+		requirePrivateFallbackRejected(t, p, name)
+		for path, want := range map[string]string{socketTarget: "keep-socket", nameTarget: "keep-name"} {
+			contents, err := os.ReadFile(path)
+			if err != nil || string(contents) != want {
+				t.Errorf("hostile target %q: contents=%q err=%v, want %q", path, contents, err, want)
+			}
+		}
+	})
+
+	t.Run("permissive leaf", func(t *testing.T) {
+		longDir := filepath.Join(root, "permissive-state", strings.Repeat("p", socketPathLimit+32))
+		p := NewProviderWithDir(longDir)
+		const name = "hostile-permissive-fallback"
+		fallback := p.fallbackDir()
+		if err := os.Mkdir(fallback, 0o755); err != nil {
+			t.Fatalf("Mkdir permissive fallback leaf: %v", err)
+		}
+		if err := os.Chmod(fallback, 0o755); err != nil {
+			t.Fatalf("Chmod permissive fallback leaf: %v", err)
+		}
+		socketTarget := filepath.Join(fallback, p.sockKey(name)+".sock")
+		nameTarget := filepath.Join(fallback, p.sockKey(name)+".name")
+		for path, contents := range map[string]string{socketTarget: "keep-socket", nameTarget: "keep-name"} {
+			if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+				t.Fatalf("WriteFile hostile target %q: %v", path, err)
+			}
+		}
+		t.Cleanup(func() {
+			_ = os.Remove(socketTarget)
+			_ = os.Remove(nameTarget)
+			_ = syscall.Rmdir(fallback)
+		})
+
+		startCalls := 0
+		p.ops.start = func(*exec.Cmd) error {
+			startCalls++
+			return errors.New("process start must not be reached")
+		}
+		err := p.Start(context.Background(), name, runtime.Config{Command: "sleep 300"})
+		if err == nil || !strings.Contains(err.Error(), "private socket directory") {
+			t.Fatalf("Start error = %v, want private socket directory validation", err)
+		}
+		if startCalls != 0 {
+			t.Fatalf("process start calls = %d, want 0", startCalls)
+		}
+		requirePrivateFallbackRejected(t, p, name)
+		for path, want := range map[string]string{socketTarget: "keep-socket", nameTarget: "keep-name"} {
+			contents, err := os.ReadFile(path)
+			if err != nil || string(contents) != want {
+				t.Errorf("hostile target %q: contents=%q err=%v, want %q", path, contents, err, want)
+			}
+		}
+	})
 }
 
 func TestStopUnknownSessionWithVeryLongSocketDirIsIdempotent(t *testing.T) {
@@ -603,8 +952,9 @@ func TestStopBySocket_PreservesCanonicalErrorWhenLegacyPathIsTooLong(t *testing.
 	if got := len(p.legacySockPath(name)); got <= socketPathLimit {
 		t.Fatalf("legacy socket path length = %d, want greater than %d", got, socketPathLimit)
 	}
-	if err := os.MkdirAll(filepath.Dir(p.sockPath(name)), 0o755); err != nil {
-		t.Fatalf("MkdirAll canonical socket directory: %v", err)
+	euid := os.Geteuid()
+	if err := p.ensureSocketDir(p.socketDirForEUID(euid), euid); err != nil {
+		t.Fatalf("ensure canonical socket directory: %v", err)
 	}
 	_ = startRejectingControlSocket(t, p.sockPath(name))
 
@@ -615,6 +965,10 @@ func TestStopBySocket_PreservesCanonicalErrorWhenLegacyPathIsTooLong(t *testing.
 }
 
 func startRejectingControlSocket(t *testing.T, path string) <-chan string {
+	return startRecordingControlSocket(t, path, "nope\n", 1)
+}
+
+func startRecordingControlSocket(t *testing.T, path, response string, commandBuffer int) <-chan string {
 	t.Helper()
 	lis, err := net.Listen("unix", path)
 	if err != nil {
@@ -626,19 +980,20 @@ func startRejectingControlSocket(t *testing.T, path string) <-chan string {
 		_ = os.Remove(filepath.Dir(path))
 	})
 
-	gotCommand := make(chan string, 1)
+	gotCommand := make(chan string, commandBuffer)
 	go func() {
-		conn, acceptErr := lis.Accept()
-		if acceptErr != nil {
-			return
+		for {
+			conn, acceptErr := lis.Accept()
+			if acceptErr != nil {
+				return
+			}
+			line, readErr := bufio.NewReader(conn).ReadString('\n')
+			if readErr == nil {
+				gotCommand <- strings.TrimSpace(line)
+			}
+			_, _ = conn.Write([]byte(response))
+			_ = conn.Close()
 		}
-		defer conn.Close() //nolint:errcheck
-
-		line, readErr := bufio.NewReader(conn).ReadString('\n')
-		if readErr == nil {
-			gotCommand <- strings.TrimSpace(line)
-		}
-		_, _ = conn.Write([]byte("nope\n"))
 	}()
 	return gotCommand
 }
@@ -786,6 +1141,24 @@ func TestCrossProcessInterruptBySocket(t *testing.T) {
 
 	// sleep may or may not die on SIGINT depending on shell;
 	// just verify the interrupt was sent without error.
+}
+
+func TestInterruptPreservesBestEffortForNormalSocketProtocolError(t *testing.T) {
+	p := newTestProvider(t)
+	const name = "reject-interrupt"
+	gotCommand := startRejectingControlSocket(t, p.sockPath(name))
+
+	if err := p.Interrupt(name); err != nil {
+		t.Fatalf("Interrupt returned ordinary socket protocol error: %v", err)
+	}
+	select {
+	case got := <-gotCommand:
+		if got != "interrupt" {
+			t.Fatalf("socket command = %q, want interrupt", got)
+		}
+	case <-time.After(testutil.ExecRaceTimeout):
+		t.Fatal("timed out waiting for interrupt command")
+	}
 }
 
 func TestIsRunningViaSocket(t *testing.T) {


### PR DESCRIPTION
## What changed

- Preserve the historical TMPDIR fallback through the platform's real AF_UNIX path capacity (107 bytes on Linux, 103 on Darwin).
- Relocate only unbindable fallback paths to an EUID-scoped `/tmp/gascity-subprocess-<uid>/<hash>` tree.
- Require the private root and leaf to be real, EUID-owned `0700` directories with no special mode bits.
- Fail closed on hostile symlink or permissive precreation before starting a process or unlinking socket state.
- Preserve discovery and control of addressable legacy name-based sockets when the new private leaf is absent.
- Capture EUID once per public operation and retain historical best-effort `Interrupt` behavior for ordinary transport/protocol failures.

This is the secure/addressable Slice A for `ga-80po0c.1.2`. Failed-Start cleanup seams and empty-leaf cleanup/retry remain separate follow-up slices.

## Why

The old fallback used a conservative 100-byte threshold and could still construct an unbindable socket beneath a long TMPDIR. Moving every path above 100 bytes would break existing sessions that are valid through the native platform limit. The new selection preserves compatible paths and uses a validated private namespace only when relocation is necessary.

## TDD evidence

- A conservative-limit mutant abandoned a native-bindable legacy path and failed the real-socket compatibility proof.
- The old overlong fallback created `0755` state and failed the private-directory contract.
- Symlink and permissive-precreation mutants followed or accepted hostile state and failed target-preservation/zero-start assertions.
- Returning early when the private leaf was missing failed legacy `Start`, `IsRunning`, `ListRunning`, `Interrupt`, and `Stop` interoperability.
- Surfacing ordinary socket protocol errors from `Interrupt` failed the compatibility regression.
- The listener fixture was generalized instead of raising the checked `net.Listen` debt baseline (`92` calls / `34` files).

## Verification

- Focused fallback/security race tests, 30 repetitions
- Full subprocess package under race, 3 repetitions
- Raw and seam conformance under race, 10 repetitions
- Full subprocess package with an externally overlong TMPDIR
- Darwin/arm64 cross-compilation
- `make test-fast-parallel`
- `./scripts/test-integration-shard packages-core-4-of-4`
- `go vet ./...`
- `make check-docs`
- Checked resource census
- Three delegated council lanes CLEAR on frozen diff hash `33527cbdf3991996f2c8d6212b90f3765fde635ac650410e2ac45de56407d282`
