### PR TITLE
feat(beads): fence bump-on-transition in native in-memory stores

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -110,6 +110,18 @@ type Bead struct {
 	// backing store until reconcile or CAS-failure eviction; callers read it only
 	// through ConditionalWriter (equality-only; see the revision contract).
 	Revision int64 `json:"-"`
+	// ClaimFence is the store-internal ownership fence: a monotonic counter
+	// bumped ONLY on ownership transitions — a claim/unclaim/release, an
+	// assignee change, or a reopen (closed→open) — never by content mutations
+	// (title, notes, metadata) or a close. It mirrors beads' claim_fence column
+	// (migration 0055) so GC-side guarded-release paths and their unit tests are
+	// non-vacuous: a guarded release compares it (bd --if-fence) and a stale
+	// incarnation holding an old fence gets a typed conflict instead of
+	// unclaiming a bead a fresh owner already re-claimed. Like Revision it is
+	// json:"-" (off every HTTP/SSE wire path); the native Mem/File stores
+	// maintain it per bead and FileStore persists it out of band. A bd-backed
+	// store leaves it 0 until the pinned bd emits claim_fence.
+	ClaimFence int64 `json:"-"`
 }
 
 // UpdateOpts specifies which fields to change. Nil pointers are skipped.

--- a/internal/beads/beadstest/fence_conformance.go
+++ b/internal/beads/beadstest/fence_conformance.go
@@ -1,0 +1,243 @@
+package beadstest
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// RunFenceConformance exercises the ownership-fence bump contract that GC's
+// native in-memory stores (MemStore, FileStore) must satisfy so guarded-release
+// unit tests are non-vacuous. It mirrors the beads-side behavioral fence tests
+// (internal/storage/dolt/fence_test.go): ClaimFence is a monotonic counter
+// bumped ONLY on ownership transitions — a claim/unclaim (assignee change) or a
+// reopen (closed→open) — and NEVER by content mutations or a close.
+//
+// It is exercised only against the native Mem/File stores. A bd-backed store
+// leaves ClaimFence at 0 until the pinned bd emits claim_fence, so running this
+// against BdStore/NativeDoltStore would be vacuous (every read returns 0).
+//
+// newStore must return a fresh, empty store for each call.
+func RunFenceConformance(t *testing.T, newStore func() beads.Store) {
+	t.Helper()
+
+	fenceOf := func(t *testing.T, s beads.Store, id string) int64 {
+		t.Helper()
+		b, err := s.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", id, err)
+		}
+		return b.ClaimFence
+	}
+	create := func(t *testing.T, s beads.Store) string {
+		t.Helper()
+		b, err := s.Create(beads.Bead{Title: "fence subject"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		return b.ID
+	}
+	str := func(v string) *string { return &v }
+
+	t.Run("CreateStartsFenceAtZero", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if got := fenceOf(t, s, id); got != 0 {
+			t.Errorf("fresh bead ClaimFence = %d, want 0", got)
+		}
+	})
+
+	t.Run("ClaimBumpsFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != 1 {
+			t.Errorf("after claim ClaimFence = %d, want 1", got)
+		}
+	})
+
+	t.Run("SameOwnerReclaimDoesNotBumpFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		f1 := fenceOf(t, s, id)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != f1 {
+			t.Errorf("re-claim by the same owner bumped ClaimFence %d→%d; a no-op ownership write must not bump", f1, got)
+		}
+	})
+
+	t.Run("UnclaimBumpsFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		f1 := fenceOf(t, s, id)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("")}); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != f1+1 {
+			t.Errorf("after unclaim ClaimFence = %d, want %d", got, f1+1)
+		}
+	})
+
+	t.Run("AssigneeChangeBumpsFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-a")}); err != nil {
+			t.Fatal(err)
+		}
+		f1 := fenceOf(t, s, id)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-b")}); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != f1+1 {
+			t.Errorf("after owner handoff ClaimFence = %d, want %d", got, f1+1)
+		}
+	})
+
+	t.Run("PlainUpdateDoesNotBumpFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		f1 := fenceOf(t, s, id)
+		if err := s.Update(id, beads.UpdateOpts{Title: str("renamed")}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Update(id, beads.UpdateOpts{Metadata: map[string]string{"note": "x"}}); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != f1 {
+			t.Errorf("content-only update bumped ClaimFence %d→%d; only ownership transitions bump", f1, got)
+		}
+	})
+
+	t.Run("CloseDoesNotBumpFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		f1 := fenceOf(t, s, id)
+		if err := s.Close(id); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != f1 {
+			t.Errorf("close bumped ClaimFence %d→%d; close is not an ownership transition", f1, got)
+		}
+	})
+
+	t.Run("ReopenBumpsFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Close(id); err != nil {
+			t.Fatal(err)
+		}
+		f := fenceOf(t, s, id) // close did not bump
+		if err := s.Reopen(id); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != f+1 {
+			t.Errorf("after reopen ClaimFence = %d, want %d (closed→open starts a new ownership generation)", got, f+1)
+		}
+	})
+
+	t.Run("InProgressToOpenKeepsFence", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1"), Status: str("in_progress")}); err != nil {
+			t.Fatal(err)
+		}
+		f1 := fenceOf(t, s, id)
+		// in_progress→open KEEPING the assignee is not a transition: the row stays
+		// claimable only by the same owner, and the eventual release bumps at the
+		// real ownership boundary.
+		if err := s.Update(id, beads.UpdateOpts{Status: str("open")}); err != nil {
+			t.Fatal(err)
+		}
+		if got := fenceOf(t, s, id); got != f1 {
+			t.Errorf("in_progress→open (same owner) bumped ClaimFence %d→%d; only closed→open is a transition", f1, got)
+		}
+	})
+
+	t.Run("FenceIsMonotonicAcrossTransitions", func(t *testing.T) {
+		s := newStore()
+		id := create(t, s)
+		prev := fenceOf(t, s, id)
+		ops := []beads.UpdateOpts{
+			{Assignee: str("a")}, // claim
+			{Assignee: str("b")}, // handoff
+			{Assignee: str("")},  // unclaim
+			{Assignee: str("c")}, // reclaim
+		}
+		for i, op := range ops {
+			if err := s.Update(id, op); err != nil {
+				t.Fatal(err)
+			}
+			cur := fenceOf(t, s, id)
+			if cur <= prev {
+				t.Errorf("op %d: ClaimFence did not advance (%d→%d); ownership transitions must be strictly monotonic", i, prev, cur)
+			}
+			prev = cur
+		}
+	})
+
+	// The guarded-write path (UpdateIfMatch on ConditionalWriter) is the exact
+	// entry point the fence exists to protect. It shares applyUpdateLocked with
+	// Update, but a direct assertion keeps a future refactor of the CAS path from
+	// silently dropping the bump.
+	t.Run("ConditionalWriteBumpsFenceOnOwnershipChange", func(t *testing.T) {
+		s := newStore()
+		w, ok := beads.ConditionalWriterFor(s)
+		if !ok {
+			t.Skip("store has no ConditionalWriter")
+		}
+		id := create(t, s)
+		b, err := s.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f0 := b.ClaimFence
+		if err := w.UpdateIfMatch(id, b.Revision, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatalf("UpdateIfMatch(claim): %v", err)
+		}
+		if got := fenceOf(t, s, id); got != f0+1 {
+			t.Errorf("guarded-write claim ClaimFence = %d, want %d", got, f0+1)
+		}
+	})
+
+	t.Run("ConditionalWriteDoesNotBumpFenceOnContentChange", func(t *testing.T) {
+		s := newStore()
+		w, ok := beads.ConditionalWriterFor(s)
+		if !ok {
+			t.Skip("store has no ConditionalWriter")
+		}
+		id := create(t, s)
+		if err := s.Update(id, beads.UpdateOpts{Assignee: str("worker-1")}); err != nil {
+			t.Fatal(err)
+		}
+		b, err := s.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f1 := b.ClaimFence
+		if err := w.UpdateIfMatch(id, b.Revision, beads.UpdateOpts{Title: str("renamed via CAS")}); err != nil {
+			t.Fatalf("UpdateIfMatch(content): %v", err)
+		}
+		if got := fenceOf(t, s, id); got != f1 {
+			t.Errorf("content-only guarded write bumped ClaimFence %d→%d", f1, got)
+		}
+	})
+}

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -31,6 +31,44 @@ type fileData struct {
 	// any counter a prior writer could have issued (see
 	// applyBeadRevisionsSealed).
 	RevisionsSealed bool `json:"revisions_sealed,omitempty"`
+	// Fences persists each bead's ClaimFence out of band, because
+	// Bead.ClaimFence is json:"-" and never survives the on-disk []Bead. Without
+	// it every reloadFromDisk would reset all fences to 0, so a guarded release
+	// holding an older fence could no longer match. Unlike Revisions this needs
+	// no sealed/floor re-seed: a fence bumps only on ownership transitions (not
+	// on every write), so a legacy binary dropping the map resets fences to 0,
+	// which is FAIL-SAFE — a stale guard sees a mismatch and refuses, never
+	// wrongly succeeds. Absent (legacy files) ≡ all zero.
+	Fences map[string]int64 `json:"fences,omitempty"`
+}
+
+// beadFences extracts the out-of-band ClaimFence map for persistence. Zero
+// fences are omitted (absent ≡ 0 on reload), so legacy files round-trip.
+func beadFences(beads []Bead) map[string]int64 {
+	fences := make(map[string]int64, len(beads))
+	for _, b := range beads {
+		if b.ClaimFence != 0 {
+			fences[b.ID] = b.ClaimFence
+		}
+	}
+	if len(fences) == 0 {
+		return nil
+	}
+	return fences
+}
+
+// applyBeadFences stamps persisted fences back onto beads decoded from disk,
+// whose ClaimFence fields are all 0 because of the json:"-" tag. Beads with no
+// entry keep fence 0, matching files that predate the fences map.
+func applyBeadFences(beads []Bead, fences map[string]int64) {
+	if len(fences) == 0 {
+		return
+	}
+	for i := range beads {
+		if f, ok := fences[beads[i].ID]; ok {
+			beads[i].ClaimFence = f
+		}
+	}
 }
 
 // beadRevisions extracts the out-of-band revision map for persistence. Zero
@@ -165,6 +203,7 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
 	applyBeadRevisionsSealed(&fd)
+	applyBeadFences(fd.Beads, fd.Fences)
 	store := &FileStore{
 		MemStore: NewMemStoreFrom(fd.Seq, fd.Beads, fd.Deps),
 		fs:       fs,
@@ -202,6 +241,7 @@ func (fs *FileStore) reloadFromDisk() error {
 		return fmt.Errorf("reloading file store: %w", err)
 	}
 	applyBeadRevisionsSealed(&fd)
+	applyBeadFences(fd.Beads, fd.Fences)
 	fs.restoreFrom(fd.Seq, fd.Beads, fd.Deps)
 	return nil
 }
@@ -658,7 +698,7 @@ func (fs *FileStore) save() error {
 	seq, beads, deps := fs.snapshot()
 	fs.mu.Unlock()
 
-	fd := fileData{Seq: seq, Beads: beads, Deps: deps, Revisions: beadRevisions(beads), RevisionsSealed: true}
+	fd := fileData{Seq: seq, Beads: beads, Deps: deps, Revisions: beadRevisions(beads), RevisionsSealed: true, Fences: beadFences(beads)}
 	data, err := json.MarshalIndent(fd, "", "  ")
 	if err != nil {
 		return fmt.Errorf("saving file store: %w", err)

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -91,6 +91,7 @@ func TestFileStore(t *testing.T) {
 	beadstest.RunCreationOrderTests(t, factory)
 	beadstest.RunDepTests(t, factory)
 	beadstest.RunMetadataTests(t, factory)
+	beadstest.RunFenceConformance(t, factory)
 }
 
 func TestFileStoreConditionalWriterConformance(t *testing.T) {
@@ -189,6 +190,135 @@ func TestFileStoreRevisionSurvivesReopen(t *testing.T) {
 	staleTitle := "v-stale"
 	if err := w.UpdateIfMatch(bumped.ID, afterBumped.Revision, beads.UpdateOpts{Title: &staleTitle}); !beads.IsPreconditionFailed(err) {
 		t.Fatalf("UpdateIfMatch at now-stale revision: got %v, want PreconditionFailed", err)
+	}
+}
+
+// TestFileStoreFenceSurvivesReopen proves the ownership fence round-trips
+// through disk — ClaimFence is json:"-" on Bead, so it only survives via the
+// out-of-band Fences map. reloadFromDisk runs before every write, so a dropped
+// fence would reset to 0 mid-session in cross-process mode and silently defeat a
+// guarded release. Two beads (one transitioned, one never claimed) catch
+// per-bead persistence bugs: a reload that resets a fenced bead to 0, or a
+// persist that spuriously writes a fence for an untouched fence-0 bead.
+func TestFileStoreFenceSurvivesReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fenced, err := s1.Create(beads.Bead{Title: "fenced"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Three ownership transitions: claim → handoff → unclaim (fence → 3).
+	for _, a := range []string{"worker-a", "worker-b", ""} {
+		assignee := a
+		if err := s1.Update(fenced.ID, beads.UpdateOpts{Assignee: &assignee}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	untouched, err := s1.Create(beads.Bead{Title: "untouched"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeFenced, err := s1.Get(fenced.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if beforeFenced.ClaimFence != 3 {
+		t.Fatalf("after 3 transitions ClaimFence = %d, want 3", beforeFenced.ClaimFence)
+	}
+
+	// Reopen from disk in a fresh handle (a second process).
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterFenced, err := s2.Get(fenced.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterFenced.ClaimFence != beforeFenced.ClaimFence {
+		t.Fatalf("fence did not survive reopen: %d -> %d", beforeFenced.ClaimFence, afterFenced.ClaimFence)
+	}
+	afterUntouched, err := s2.Get(untouched.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterUntouched.ClaimFence != 0 {
+		t.Fatalf("never-claimed bead came back with ClaimFence %d, want 0", afterUntouched.ClaimFence)
+	}
+}
+
+// TestFileStoreReleaseIfCurrentFenceSurvivesReopen covers the marquee
+// guarded-release round-trip: a release through ReleaseIfCurrent (the
+// ConditionalAssignmentReleaser path, NOT on the base Store interface, so the
+// interface-typed fence conformance cannot reach it) must bump the fence AND
+// persist it across a fresh handle. Deleting the save from
+// FileStore.ReleaseIfCurrent ships green without this test.
+func TestFileStoreReleaseIfCurrentFenceSurvivesReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s1.Create(beads.Bead{Title: "work"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Claim and set in_progress so ReleaseIfCurrent applies.
+	if err := s1.Update(b.ID, beads.UpdateOpts{Assignee: ptr("worker-1"), Status: ptr("in_progress")}); err != nil {
+		t.Fatal(err)
+	}
+	released, err := s1.ReleaseIfCurrent(b.ID, "worker-1")
+	if err != nil || !released {
+		t.Fatalf("ReleaseIfCurrent released=%v err=%v", released, err)
+	}
+	before, err := s1.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.ClaimFence == 0 {
+		t.Fatalf("ReleaseIfCurrent did not bump ClaimFence: %+v", before)
+	}
+
+	// Reopen from disk in a fresh handle (a second process).
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := s2.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.ClaimFence != before.ClaimFence {
+		t.Fatalf("released fence did not survive reopen: %d -> %d", before.ClaimFence, after.ClaimFence)
+	}
+	if after.Status != "open" || after.Assignee != "" {
+		t.Fatalf("released bead after reopen = %+v, want open/unassigned", after)
+	}
+}
+
+// TestFileStoreLegacyFileHasZeroFence pins the fence downgrade fail-safe: a file
+// written by a fence-unaware binary carries beads but no "fences" map, and must
+// load with ClaimFence 0 (absent ≡ 0) — never a spurious re-seed. This is the
+// fence analog of TestFileStoreConditionalWriteLegacyFileNoRevisions.
+func TestFileStoreLegacyFileHasZeroFence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+	legacy := `{"seq":1,"beads":[{"id":"gc-1","title":"legacy","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}]}`
+	if err := (fsys.OSFS{}).WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get("gc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ClaimFence != 0 {
+		t.Fatalf("legacy file with no fences map loaded ClaimFence = %d, want 0", got.ClaimFence)
 	}
 }
 

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -94,7 +94,8 @@ func (m *MemStore) Create(b Bead) (Bead, error) {
 	}
 	b.CreatedAt = time.Now()
 	b.UpdatedAt = b.CreatedAt
-	b.Revision = 1 // first version; every subsequent mutation bumps it
+	b.Revision = 1   // first version; every subsequent mutation bumps it
+	b.ClaimFence = 0 // no ownership history yet; the first claim bumps it to 1
 
 	stored := cloneBead(b)
 	m.beads = append(m.beads, stored)
@@ -128,10 +129,36 @@ func (m *MemStore) indexOfLocked(id string) int {
 	return -1
 }
 
+// isOwnershipTransition reports whether an update changes a bead's ownership
+// context — an assignee change, or a reopen (closed→open, after which a fresh
+// claim starts a new ownership generation). It mirrors beads'
+// issueops.IsOwnershipTransition so the ClaimFence bump discipline matches the
+// bd-backed store. Deliberate exclusions: a close is not a transition (guarded
+// verbs reject closed rows anyway, and bumping on close would invalidate a
+// legitimate ownership snapshot for no gain); an in_progress→open change that
+// keeps the assignee is not one either — the row stays claimable only by the
+// same owner, and the eventual release bumps at the real boundary.
+func isOwnershipTransition(oldStatus, oldAssignee string, opts UpdateOpts) bool {
+	if opts.Assignee != nil && *opts.Assignee != oldAssignee {
+		return true
+	}
+	// A reopen is closed→a real non-closed status. An empty status string is not
+	// a status write beads recognizes (its IsOwnershipTransition short-circuits
+	// on statusStr == ""), so exclude it here too to keep the predicates literally
+	// aligned.
+	if opts.Status != nil && *opts.Status != "" && oldStatus == "closed" && *opts.Status != "closed" {
+		return true
+	}
+	return false
+}
+
 // applyUpdateLocked applies the non-nil fields of opts to the bead at index i,
-// stamps UpdatedAt, and bumps the revision. The caller must hold m.mu. It is
-// shared by Update and UpdateIfMatch so both bump identically.
+// stamps UpdatedAt, bumps the revision, and — when the update is an ownership
+// transition (assignee change or reopen) — bumps the ownership fence. The
+// caller must hold m.mu. It is shared by Update and UpdateIfMatch so both bump
+// identically.
 func (m *MemStore) applyUpdateLocked(i int, opts UpdateOpts) {
+	oldStatus, oldAssignee := m.beads[i].Status, m.beads[i].Assignee
 	if opts.Title != nil {
 		m.beads[i].Title = *opts.Title
 	}
@@ -179,6 +206,9 @@ func (m *MemStore) applyUpdateLocked(i int, opts UpdateOpts) {
 	}
 	m.beads[i].UpdatedAt = time.Now()
 	m.beads[i].Revision++
+	if isOwnershipTransition(oldStatus, oldAssignee, opts) {
+		m.beads[i].ClaimFence++
+	}
 }
 
 // Update modifies fields of an existing bead. Only non-nil fields in opts
@@ -210,6 +240,7 @@ func (m *MemStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
 		m.beads[i].Assignee = ""
 		m.beads[i].UpdatedAt = time.Now()
 		m.beads[i].Revision++
+		m.beads[i].ClaimFence++ // clearing an owner is an ownership transition
 		return true, nil
 	}
 	return false, nil
@@ -244,9 +275,16 @@ func (m *MemStore) Reopen(id string) error {
 			if m.beads[i].Status == "open" {
 				return nil
 			}
+			wasClosed := m.beads[i].Status == "closed"
 			m.beads[i].Status = "open"
 			m.beads[i].UpdatedAt = time.Now()
 			m.beads[i].Revision++
+			if wasClosed {
+				// closed→open starts a new ownership generation; an
+				// in_progress→open reopen keeps the same owner and is not a
+				// transition.
+				m.beads[i].ClaimFence++
+			}
 			return nil
 		}
 	}

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -17,6 +17,7 @@ func TestMemStore(t *testing.T) {
 	beadstest.RunCreationOrderTests(t, factory)
 	beadstest.RunDepTests(t, factory)
 	beadstest.RunMetadataTests(t, factory)
+	beadstest.RunFenceConformance(t, factory)
 }
 
 func TestMemStoreConditionalWriterConformance(t *testing.T) {
@@ -79,6 +80,9 @@ func TestMemStoreReleaseIfCurrent(t *testing.T) {
 	if got.Status != "in_progress" || got.Assignee != "worker-1" {
 		t.Fatalf("wrong-assignee release mutated bead: %+v", got)
 	}
+	if got.ClaimFence != 0 {
+		t.Errorf("no-op release bumped ClaimFence to %d, want 0", got.ClaimFence)
+	}
 
 	released, err = s.ReleaseIfCurrent(b.ID, "worker-1")
 	if err != nil {
@@ -93,6 +97,9 @@ func TestMemStoreReleaseIfCurrent(t *testing.T) {
 	}
 	if got.Status != "open" || got.Assignee != "" {
 		t.Fatalf("released bead = %+v, want open and unassigned", got)
+	}
+	if got.ClaimFence != 1 {
+		t.Errorf("ReleaseIfCurrent did not bump ClaimFence: got %d, want 1 (release is an ownership transition)", got.ClaimFence)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a store-internal ownership fence (`ClaimFence int64`, `json:"-"`) to Gas
City's native in-memory bead stores (`MemStore`, `FileStore`), mirroring beads'
`claim_fence` column (migration 0055). It is a monotonic counter bumped ONLY on
ownership transitions — a claim/unclaim/release (assignee change) or a reopen
(closed→open) — and never by content mutations or a close. It parallels the
existing `Revision` (whole-row CAS) counter but with transition-only semantics
via `isOwnershipTransition`, which mirrors beads' `issueops.IsOwnershipTransition`.

**Why:** this is the pure-GC prerequisite that makes the planned
ownership-fenced-release unit tests (plan A-G2b, epic `ga-furrj5`) non-vacuous.
When GC's release paths start choosing `bd unclaim --if-fence` over an owner-blind
update, their unit tests run against these in-memory stores — which must bump the
fence on transitions for the guard assertions to mean anything. **There is no
runtime consumer of `ClaimFence` yet**; a bd-backed store leaves it 0 until the
pinned bd emits `claim_fence`.

### Design notes

- **No `row_lock`.** The GC stores are mutex-guarded and single-process;
  `row_lock` exists in beads only to defeat Dolt's cell-merge of concurrent
  monotonic bumps, which cannot happen here.
- **FileStore persistence** via a `Fences` map in `fileData` (mirroring
  `Revisions`), because `json:"-"` keeps the fence off the on-disk `[]Bead`.
  Unlike `Revisions` it needs no sealed/floor re-seed: a fence bumps only on
  transitions, so a legacy-binary rewrite that drops the map resets fences to
  0 — **fail-safe** (a stale guard mismatches and refuses), never fail-open.

### Tests

`RunFenceConformance` mirrors beads' `fence_test.go` behavioral cases
(claim/unclaim/handoff/reopen bump; same-owner-reclaim/content/close/
in_progress→open don't) and runs against the MemStore and FileStore suites — not
the bd-backed NativeDolt suite where it would read a vacuous 0. Plus:
`ReleaseIfCurrent` fence assertions, a FileStore `ReleaseIfCurrent`
fence-survives-reopen round-trip (kills a `skip-fs.save` regression a
single-handle test cannot see), the guarded-write `UpdateIfMatch` path, and a
legacy-file zero-fence downgrade test.

An adversarial red-team pass (4 confirmed findings, 2 proven by mutation testing)
is folded: the empty-status predicate-fidelity guard, plus the `ReleaseIfCurrent`
round-trip, `UpdateIfMatch`, and legacy-fence coverage gaps.

## Testing

- [x] `make check` (pre-commit: doc-gen, `go vet ./...`); pre-push
  `make test-fast-parallel`
- [x] `go test ./internal/beads/ ./internal/beads/beadstest/` — full suites green
- [x] `golangci-lint run ./internal/beads/...` — 0 issues
- [x] Mutation-verified: deleting `fs.save()` from `FileStore.ReleaseIfCurrent`,
  and dropping the fence bump from the `UpdateIfMatch` path, both now fail a test
- [ ] `make test-integration` — N/A (no runtime/controller/workflow behavior
  changed; no runtime consumer yet)

## Checklist

- [x] Linked an issue — bead `ga-c48fb9` (epic `ga-furrj5`)
- [x] Added or updated tests for behavior changes
- [x] No user-facing docs (internal store field, `json:"-"`, off every wire path)
- [x] No breaking changes — additive `json:"-"` field defaulting to 0
