### PR TITLE
fix(status): derive ready work from canonical projection

### DIFF
--- a/cmd/gc/bead_policy_store.go
+++ b/cmd/gc/bead_policy_store.go
@@ -97,6 +97,17 @@ func (s *beadPolicyStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error)
 	return s.Store.Ready(expandPolicyReadyQuery(query...))
 }
 
+// ReadyContext preserves the policy-expanded read tier for deadline-sensitive
+// Ready projections. Optional capabilities are hidden by the embedded Store
+// interface, so forward explicitly just like Count.
+func (s *beadPolicyStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	reader, ok := s.Store.(beads.ContextReadyReader)
+	if !ok {
+		return nil, fmt.Errorf("reading ready beads through policy store: %w", beads.ErrReadyContextUnsupported)
+	}
+	return reader.ReadyContext(ctx, expandPolicyReadyQuery(query...))
+}
+
 // Count implements beads.Counter with the same read-tier expansion as List.
 // The embedded Store interface does not promote optional capabilities, so
 // the delegation must be explicit. Inner stores without a Counter report

--- a/cmd/gc/bead_policy_store_conformance_test.go
+++ b/cmd/gc/bead_policy_store_conformance_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -26,6 +27,13 @@ func (s *recordingPolicyReadStore) Ready(query ...beads.ReadyQuery) ([]beads.Bea
 	}
 	s.readyQueries = append(s.readyQueries, q)
 	return s.MemStore.Ready(q)
+}
+
+func (s *recordingPolicyReadStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return s.Ready(query...)
 }
 
 func TestBeadPolicyStoreReadHelperTierConformance(t *testing.T) {
@@ -269,5 +277,21 @@ func TestBeadPolicyStoreHandleReadsArePolicyAware(t *testing.T) {
 				t.Fatalf("handle Ready TierMode = %v, want TierBoth", backing.readyQueries[0].TierMode)
 			}
 		})
+	}
+}
+
+func TestBeadPolicyStoreContextReadyIsPolicyAware(t *testing.T) {
+	backing := &recordingPolicyReadStore{MemStore: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+	reader, ok := store.(beads.ContextReadyReader)
+	if !ok {
+		t.Fatalf("policy store type %T does not preserve ContextReadyReader", store)
+	}
+
+	if _, err := reader.ReadyContext(context.Background()); err != nil {
+		t.Fatalf("ReadyContext: %v", err)
+	}
+	if len(backing.readyQueries) != 1 || backing.readyQueries[0].TierMode != beads.TierBoth {
+		t.Fatalf("ReadyContext queries = %#v, want one TierBoth query", backing.readyQueries)
 	}
 }

--- a/cmd/gc/scoped_store.go
+++ b/cmd/gc/scoped_store.go
@@ -20,7 +20,10 @@ import (
 // to bound. Skips the managed-retry wrapper for the same reason (gascity
 // ga-cdmx6x).
 func scopedBdStoreForCity(ctx context.Context, cityPath string) (*beads.BdStore, error) {
-	env, err := bdRuntimeEnvWithErrorNoRecovery(cityPath)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	env, err := bdRuntimeEnvWithErrorRecoveryContext(ctx, cityPath, false)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +32,10 @@ func scopedBdStoreForCity(ctx context.Context, cityPath string) (*beads.BdStore,
 
 // scopedBdStoreForRig is scopedBdStoreForCity for a rig-scoped store.
 func scopedBdStoreForRig(ctx context.Context, cityPath string, cfg *config.City, rigDir string) (*beads.BdStore, error) {
-	env, err := bdRuntimeEnvForRigWithErrorNoRecovery(cityPath, cfg, rigDir)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	env, err := bdRuntimeEnvForRigWithErrorRecoveryContext(ctx, cityPath, cfg, rigDir, false)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +46,8 @@ func scopedBdStoreForRig(ctx context.Context, cityPath string, cfg *config.City,
 // layers to find the underlying *beads.BdStore. It returns ok=false for
 // stores that aren't bd-CLI-backed (native, file, exec, mem, ...) — those
 // have no subprocess to leak, so ga-cdmx6x's mitigation doesn't apply to
-// them. Bounded to a handful of iterations: real store stacks are at most
-// two layers deep (CachingStore wrapping a beadPolicyStore wrapping the
+// them. Bounded to a handful of iterations: real store stacks are only a few
+// layers deep (normally beadPolicyStore wrapping CachingStore wrapping the
 // raw store); the bound just guards against an unexpected wrap cycle.
 func bdStoreBacking(store beads.Store) (*beads.BdStore, bool) {
 	for range 8 {
@@ -68,6 +74,23 @@ func bdStoreBacking(store beads.Store) (*beads.BdStore, bool) {
 	return nil, false
 }
 
+// beadPolicyConfig finds the policy layer, if any, in the same bounded store
+// stack understood by bdStoreBacking. A scoped clone must retain this layer:
+// policy-aware zero-value List and Ready reads span both logical tiers.
+func beadPolicyConfig(store beads.Store) (*config.City, bool) {
+	for range 8 {
+		if _, policy, ok := unwrapBeadPolicyStore(store); ok {
+			return policy.cfg, true
+		}
+		cached, ok := store.(*beads.CachingStore)
+		if !ok || cached == nil || cached.Backing() == nil {
+			return nil, false
+		}
+		store = cached.Backing()
+	}
+	return nil, false
+}
+
 // scopedStoreLike returns a throwaway, ctx-bound clone of existing when
 // existing is (or wraps, via CachingStore/beadPolicyStore) a bd-CLI-shell
 // backed store: cancellation kills the backend bd subprocess instead of
@@ -75,13 +98,27 @@ func bdStoreBacking(store beads.Store) (*beads.BdStore, bool) {
 // not bd-CLI backed — callers should keep reading through existing
 // directly in that case (gascity ga-cdmx6x).
 func scopedStoreLike(ctx context.Context, cityPath string, cfg *config.City, existing beads.Store) (beads.Store, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	bs, ok := bdStoreBacking(existing)
 	if !ok {
 		return nil, nil
 	}
+	policyCfg, policyWrapped := beadPolicyConfig(existing)
 	dir := bs.Dir()
+	var scoped beads.Store
+	var err error
 	if samePath(dir, cityPath) {
-		return scopedBdStoreForCity(ctx, cityPath)
+		scoped, err = scopedBdStoreForCity(ctx, cityPath)
+	} else {
+		scoped, err = scopedBdStoreForRig(ctx, cityPath, cfg, dir)
 	}
-	return scopedBdStoreForRig(ctx, cityPath, cfg, dir)
+	if err != nil {
+		return nil, err
+	}
+	if policyWrapped {
+		scoped = wrapStoreWithBeadPolicies(scoped, policyCfg)
+	}
+	return scoped, nil
 }

--- a/cmd/gc/scoped_store_test.go
+++ b/cmd/gc/scoped_store_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,11 +38,10 @@ func TestBdStoreBackingUnwrapsCachingStore(t *testing.T) {
 	}
 }
 
-// TestBdStoreBackingUnwrapsCachingAndPolicyLayers mirrors the real
-// production nesting order: openRigStore/openStoreResultAtForCity wrap the
-// raw store with wrapStoreWithBeadPolicies, then buildStores/newControllerState
-// wrap that again with CachingStore. bdStoreBacking must see through both
-// layers to reach the *beads.BdStore whose subprocess ga-cdmx6x is about.
+// TestBdStoreBackingUnwrapsCachingAndPolicyLayers proves unwrapping is
+// order-independent. Production re-applies policy outside the cache, while
+// this inverse stack can still arise in tests and adapters; both must expose
+// the *beads.BdStore whose subprocess ga-cdmx6x is about.
 func TestBdStoreBackingUnwrapsCachingAndPolicyLayers(t *testing.T) {
 	inner := beads.NewBdStore("/city", noopBdRunner())
 	policyWrapped := wrapStoreWithBeadPolicies(inner, &config.City{})
@@ -124,6 +124,45 @@ func TestScopedStoreLikeSelectsRigScopeWhenDirIsARig(t *testing.T) {
 	}
 	if got := bs.Dir(); got != rigDir {
 		t.Fatalf("scoped store Dir() = %q, want rig dir %q", got, rigDir)
+	}
+}
+
+// TestScopedStoreLikePreservesBeadPolicyWrapper pins behavioral equivalence,
+// not just the backing directory. Production stores are policy-wrapped outside
+// the cache; dropping that wrapper from a scoped clone changes zero-value List
+// and Ready reads from TierBoth to TierIssues.
+func TestScopedStoreLikePreservesBeadPolicyWrapper(t *testing.T) {
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+	cfg := &config.City{}
+	backing := beads.NewBdStore(cityDir, noopBdRunner())
+	cached := beads.NewCachingStoreForTest(backing, nil)
+	existing := wrapStoreWithBeadPolicies(cached, cfg)
+
+	scoped, err := scopedStoreLike(context.Background(), cityDir, cfg, existing)
+	if err != nil {
+		t.Fatalf("scopedStoreLike: %v", err)
+	}
+	inner, policy, ok := unwrapBeadPolicyStore(scoped)
+	if !ok {
+		t.Fatalf("scopedStoreLike() = %T, want a policy-wrapped clone", scoped)
+	}
+	if policy.cfg != cfg {
+		t.Fatalf("scoped policy config = %p, want original %p", policy.cfg, cfg)
+	}
+	if _, ok := inner.(*beads.BdStore); !ok {
+		t.Fatalf("scoped policy backing = %T, want *beads.BdStore", inner)
+	}
+}
+
+func TestScopedStoreLikeHonorsCanceledResolutionContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	existing := beads.NewBdStore(t.TempDir(), noopBdRunner())
+
+	_, err := scopedStoreLike(ctx, t.TempDir(), &config.City{}, existing)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("scopedStoreLike error = %v, want context.Canceled", err)
 	}
 }
 

--- a/internal/api/handler_beads_partial_test.go
+++ b/internal/api/handler_beads_partial_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http/httptest"
@@ -44,6 +45,13 @@ func (f *failingBeadStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error
 		return nil, f.readyErr
 	}
 	return f.Store.Ready(query...)
+}
+
+func (f *failingBeadStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return f.Ready(query...)
 }
 
 func (f *failingBeadStore) Update(id string, opts beads.UpdateOpts) error {

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -549,67 +549,187 @@ func (s *Server) statusSessionSnapshot(ctx context.Context) statusSessionSnapsho
 
 // statusWorkResult is one store's contribution to the work counts.
 type statusWorkResult struct {
-	wc   workCounts
-	errs []string
+	wc       workCounts
+	readyIDs []string
+	errs     []string
 }
 
-// statusWorkCounts tallies open/ready/in_progress work across all rig
-// stores. Stores exposing beads.Counter answer without hydrating rows —
-// the caching layer counts matches in memory when its cache is clean
-// (#1896) — with the per-store timeout canceling any delegated backing
-// query instead of leaking a goroutine that pins a connection.
-// Stores without a Counter (or whose Counter cannot answer the query
-// shape) keep the legacy hydrating List path. Stores are queried
-// concurrently; results aggregate in deterministic rig order.
+// statusWorkCounts tallies persisted open/in_progress work across BeadStores
+// and federates canonical Ready work exactly like GET /beads/ready: the city
+// store first, then BeadStores excluding the CityName alias. Stores exposing
+// beads.Counter answer persisted counts without hydrating rows — the caching
+// layer counts matches in memory when its cache is clean (#1896). Stores are
+// queried concurrently; results aggregate in deterministic city/rig order.
 func (s *Server) statusWorkCounts(ctx context.Context) (workCounts, []string) {
 	stores := s.state.BeadStores()
 	// sortedRigNames deduplicates rigs sharing one store instance, so each
-	// store is counted exactly once.
+	// store's persisted statuses are counted exactly once.
 	rigNames := sortedRigNames(stores)
-	results := make([]statusWorkResult, len(rigNames))
+	type workQuery struct {
+		label         string
+		store         beads.Store
+		includeStored bool
+		includeReady  bool
+	}
+	queries := make([]workQuery, 0, len(rigNames)+1)
+	if cityStore := s.state.CityBeadStore(); cityStore != nil {
+		queries = append(queries, workQuery{
+			label:        "city",
+			store:        cityStore,
+			includeReady: true,
+		})
+	}
+	cityName := s.state.CityName()
+	for _, rigName := range rigNames {
+		queries = append(queries, workQuery{
+			label:         "rig " + rigName,
+			store:         stores[rigName],
+			includeStored: true,
+			includeReady:  rigName != cityName,
+		})
+	}
+
+	results := make([]statusWorkResult, len(queries))
 	var wg sync.WaitGroup
-	for i, rigName := range rigNames {
+	for i, query := range queries {
 		wg.Add(1)
-		go func(i int, rigName string, store beads.Store) {
+		go func(i int, query workQuery) {
 			defer wg.Done()
-			results[i] = statusStoreWorkCounts(ctx, s.state, rigName, store)
-		}(i, rigName, stores[rigName])
+			results[i] = statusStoreWorkCountsFor(
+				ctx,
+				s.state,
+				query.label,
+				query.store,
+				query.includeStored,
+				query.includeReady,
+			)
+		}(i, query)
 	}
 	wg.Wait()
 
 	var wc workCounts
 	var errs []string
+	seenReady := make(map[string]bool)
 	for _, r := range results {
 		wc.Open += r.wc.Open
-		wc.Ready += r.wc.Ready
 		wc.InProgress += r.wc.InProgress
+		for _, id := range r.readyIDs {
+			if seenReady[id] {
+				continue
+			}
+			seenReady[id] = true
+			wc.Ready++
+		}
 		errs = append(errs, r.errs...)
 	}
 	return wc, errs
 }
 
-// statusStoreWorkCounts counts one store's work beads, preferring the
-// hydration-free Counter path. Operational count failures (timeouts,
-// connection errors) report a partial error without retrying via List —
-// the List scan would hit the same backend and pay the timeout again.
+// statusStoreWorkCounts counts one store's persisted open/in-progress work
+// and independently derives ready work through the canonical live Ready
+// projection. Both reads share one per-store deadline. Operational Count
+// failures report a partial error without retrying via List — the List scan
+// would hit the same backend — but do not discard a successful Ready result.
 func statusStoreWorkCounts(ctx context.Context, state State, rigName string, store beads.Store) statusWorkResult {
+	return statusStoreWorkCountsFor(ctx, state, "rig "+rigName, store, true, true)
+}
+
+func statusStoreWorkCountsFor(
+	ctx context.Context,
+	state State,
+	label string,
+	store beads.Store,
+	includeStored bool,
+	includeReady bool,
+) statusWorkResult {
+	ctx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
+	defer cancel()
+
+	type storedResult struct {
+		wc  workCounts
+		err error
+	}
+	type readyResult struct {
+		rows []beads.Bead
+		err  error
+	}
+	storedDone := make(chan storedResult, 1)
+	stored := &storedResult{}
+	if includeStored {
+		stored = nil
+		go func() {
+			wc, err := statusStoredWorkCounts(ctx, state, store)
+			storedDone <- storedResult{wc: wc, err: err}
+		}()
+	}
+	ready := &readyResult{}
+	if includeReady {
+		// ContextReadyReader and ScopedStoreLike both guarantee cleanup before
+		// returning after cancellation. Invoke this branch synchronously so the
+		// coordinator cannot return while scoped resolution is still cleaning up.
+		rows, err := statusReadyStoreWithTimeout(ctx, state, store)
+		ready = &readyResult{rows: rows, err: err}
+	}
+
+	for stored == nil {
+		select {
+		case value := <-storedDone:
+			stored = &value
+			storedDone = nil
+		case <-ctx.Done():
+			// Prefer a result that completed at the deadline boundary. The channel
+			// is buffered, so a context-blind legacy operation can finish later
+			// without blocking on its abandoned result send.
+			if stored == nil {
+				select {
+				case value := <-storedDone:
+					stored = &value
+					storedDone = nil
+				default:
+				}
+			}
+			if stored == nil {
+				err := ctx.Err()
+				if errors.Is(err, context.DeadlineExceeded) {
+					err = fmt.Errorf("stored counts timed out: %w", err)
+				}
+				stored = &storedResult{err: err}
+			}
+		}
+	}
+
+	result := statusWorkResult{wc: stored.wc}
+	if stored.err != nil {
+		result.errs = append(result.errs, fmt.Sprintf("%s work: %v", label, stored.err))
+	}
+	if ready.err != nil {
+		result.errs = append(result.errs, fmt.Sprintf("%s work ready: %v", label, ready.err))
+	}
+	if ready.err == nil || (beads.IsPartialResult(ready.err) && len(ready.rows) > 0) {
+		result.wc.Ready = len(ready.rows)
+		result.readyIDs = make([]string, 0, len(ready.rows))
+		for _, row := range ready.rows {
+			result.readyIDs = append(result.readyIDs, row.ID)
+		}
+	}
+	return result
+}
+
+// statusStoredWorkCounts counts the persisted open/in-progress buckets,
+// preferring the hydration-free Counter path and falling back to List only
+// when Count explicitly reports that the query shape is unsupported.
+func statusStoredWorkCounts(ctx context.Context, state State, store beads.Store) (workCounts, error) {
 	if counter, ok := store.(beads.Counter); ok {
 		wc, err := statusCountWork(ctx, counter)
-		if err == nil {
-			return statusWorkResult{wc: wc}
-		}
-		if !errors.Is(err, beads.ErrCountUnsupported) {
-			return statusWorkResult{errs: []string{fmt.Sprintf("rig %s work: %v", rigName, err)}}
+		if err == nil || !errors.Is(err, beads.ErrCountUnsupported) {
+			return wc, err
 		}
 	}
 
 	list, err := statusListStoreWithTimeout(ctx, state, store, beads.ListQuery{AllowScan: true})
-	var result statusWorkResult
-	if err != nil {
-		result.errs = append(result.errs, fmt.Sprintf("rig %s work: %v", rigName, err))
-		if !beads.IsPartialResult(err) || len(list) == 0 {
-			return result
-		}
+	var wc workCounts
+	if err != nil && (!beads.IsPartialResult(err) || len(list) == 0) {
+		return wc, err
 	}
 	for _, b := range list {
 		if slices.Contains(statusWorkExcludedTypes, b.Type) {
@@ -617,37 +737,29 @@ func statusStoreWorkCounts(ctx context.Context, state State, rigName string, sto
 		}
 		switch b.Status {
 		case "in_progress":
-			result.wc.InProgress++
-		case "ready":
-			result.wc.Ready++
+			wc.InProgress++
 		case "open":
-			result.wc.Open++
+			wc.Open++
 		}
 	}
-	return result
+	return wc, err
 }
 
-// statusCountWork fills the work-count buckets via beads.Counter. One
-// shared statusStoreReadTimeout window bounds all three bucket queries —
-// the same per-store budget the legacy single-List path had, though the
-// three queries consume it serially — and derives from ctx, so a slow
-// backend query is canceled (releasing its connection) rather than
-// abandoned.
+// statusCountWork fills the persisted work-count buckets via beads.Counter.
+// Readiness is not a stored status; statusStoreWorkCounts derives it through
+// Ready instead. The caller supplies the shared per-store deadline.
 func statusCountWork(ctx context.Context, counter beads.Counter) (workCounts, error) {
-	ctx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
-	defer cancel()
 	var wc workCounts
 	for _, bucket := range []struct {
 		status string
 		dst    *int
 	}{
 		{"open", &wc.Open},
-		{"ready", &wc.Ready},
 		{"in_progress", &wc.InProgress},
 	} {
 		n, err := counter.Count(ctx, beads.ListQuery{Status: bucket.status, AllowScan: true}, statusWorkExcludedTypes...)
 		if err != nil {
-			return workCounts{}, err
+			return wc, err
 		}
 		*bucket.dst = n
 	}
@@ -667,6 +779,9 @@ func statusListStoreWithTimeout(ctx context.Context, state State, store beads.St
 	}
 	reqCtx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
 	defer cancel()
+	if err := reqCtx.Err(); err != nil {
+		return nil, err
+	}
 	type listResult struct {
 		rows []beads.Bead
 		err  error
@@ -675,7 +790,7 @@ func statusListStoreWithTimeout(ctx context.Context, state State, store beads.St
 	go func() {
 		// Resolve the ctx-bound scoped store INSIDE the timed goroutine so a
 		// slow, ctx-blind resolution (a store mutex held by the reconcile
-		// loop) is bounded by the same time.After as the list instead of
+		// loop) is bounded by the same request deadline as the list instead of
 		// hanging the handler synchronously (gc-08qgn).
 		readStore := store
 		if scoped, err := state.ScopedStoreLike(reqCtx, store); err != nil {
@@ -690,9 +805,63 @@ func statusListStoreWithTimeout(ctx context.Context, state State, store beads.St
 	select {
 	case result := <-done:
 		return result.rows, result.err
-	case <-time.After(statusStoreReadTimeout):
-		return nil, fmt.Errorf("list timed out after %s", statusStoreReadTimeout)
+	case <-reqCtx.Done():
+		if errors.Is(reqCtx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("list timed out: %w", reqCtx.Err())
+		}
+		return nil, reqCtx.Err()
 	}
+}
+
+// statusReadyStoreWithTimeout reads the same live canonical Ready projection
+// as GET /beads/ready. Policy-aware stores retain their tier behavior through
+// ScopedStoreLike; the scoped clone binds bd subprocesses to reqCtx so timeout
+// cancellation cannot leak a child beyond the status request.
+func statusReadyStoreWithTimeout(ctx context.Context, state State, store beads.Store) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, nil
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
+	defer cancel()
+	if err := reqCtx.Err(); err != nil {
+		return nil, err
+	}
+	var capabilityErr error
+	if reader, ok := store.(beads.ContextReadyReader); ok {
+		rows, err := reader.ReadyContext(reqCtx)
+		if !errors.Is(err, beads.ErrReadyContextUnsupported) {
+			return rows, statusReadyError(err)
+		}
+		capabilityErr = err
+	}
+
+	// ScopedStoreLike is part of the context-aware read contract: resolution
+	// must finish its own cleanup before returning after reqCtx cancellation.
+	// Keep it synchronous so the status deadline cannot abandon a resolver
+	// goroutine after the response has returned.
+	scoped, err := state.ScopedStoreLike(reqCtx, store)
+	if err != nil {
+		return nil, statusReadyError(fmt.Errorf("resolving scoped store: %w", err))
+	}
+	if scoped == nil {
+		if capabilityErr == nil {
+			capabilityErr = fmt.Errorf("reading canonical ready projection: %w", beads.ErrReadyContextUnsupported)
+		}
+		return nil, capabilityErr
+	}
+
+	// ScopedStoreLike guarantees the clone and its legacy Ready operation are
+	// bound to reqCtx, including child-process cleanup, so no outer goroutine is
+	// needed to enforce the deadline.
+	rows, err := beads.HandlesFor(scoped).Live.Ready()
+	return rows, statusReadyError(err)
+}
+
+func statusReadyError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("ready timed out: %w", err)
+	}
+	return err
 }
 
 func statusMailCountWithTimeout(mp interface {

--- a/internal/api/handler_status_bench_test.go
+++ b/internal/api/handler_status_bench_test.go
@@ -21,6 +21,10 @@ func (s *benchCounterStore) Count(_ context.Context, query beads.ListQuery, _ ..
 	return s.counts[query.Status], nil
 }
 
+func (s *benchCounterStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return s.Store.(beads.ContextReadyReader).ReadyContext(ctx, query...)
+}
+
 // benchmarkStatusState seeds nStores rig stores with nBeads work beads each.
 // With useCounter the stores expose beads.Counter; otherwise the status
 // handler hydrates every bead through the legacy List path.
@@ -64,6 +68,9 @@ func benchmarkBuildStatusBody(b *testing.B, useCounter bool) {
 		body := s.buildStatusBody(ctx, false)
 		if body.Work.Open == 0 {
 			b.Fatal("Work.Open = 0, want seeded work")
+		}
+		if body.Partial {
+			b.Fatalf("Partial = true, want successful Ready projection; errors: %v", body.PartialErrors)
 		}
 	}
 }

--- a/internal/api/handler_status_count_test.go
+++ b/internal/api/handler_status_count_test.go
@@ -24,10 +24,75 @@ type counterBeadStore struct {
 	countErr      error
 	listForbidden bool
 	gotExcludes   []string
+	gotStatuses   []string
+}
+
+type contextBlockingCounterStore struct {
+	beads.Store
+	t *testing.T
+}
+
+func (s *contextBlockingCounterStore) Count(ctx context.Context, _ beads.ListQuery, _ ...string) (int, error) {
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func (s *contextBlockingCounterStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	s.t.Error("List called after operational Count timeout")
+	return nil, nil
+}
+
+type contextIgnoringCounterStore struct {
+	beads.Store
+	entered chan struct{}
+	release chan struct{}
+	exited  chan struct{}
+}
+
+func (s *contextIgnoringCounterStore) Count(context.Context, beads.ListQuery, ...string) (int, error) {
+	close(s.entered)
+	<-s.release
+	close(s.exited)
+	return 0, errors.New("released context-ignoring Count")
+}
+
+type partialCounterStore struct {
+	beads.Store
+}
+
+func testReadyContext(ctx context.Context, store beads.Store, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return store.Ready(query...)
+}
+
+func (s *counterBeadStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return testReadyContext(ctx, s.Store, query...)
+}
+
+func (s *contextBlockingCounterStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return testReadyContext(ctx, s.Store, query...)
+}
+
+func (s *contextIgnoringCounterStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return testReadyContext(ctx, s.Store, query...)
+}
+
+func (s *partialCounterStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return testReadyContext(ctx, s.Store, query...)
+}
+
+func (s *partialCounterStore) Count(_ context.Context, query beads.ListQuery, _ ...string) (int, error) {
+	if query.Status == "open" {
+		return 7, nil
+	}
+	return 0, errors.New("in-progress count unavailable")
 }
 
 func (s *counterBeadStore) Count(_ context.Context, query beads.ListQuery, excludeTypes ...string) (int, error) {
 	s.gotExcludes = excludeTypes
+	s.gotStatuses = append(s.gotStatuses, query.Status)
 	if s.countErr != nil {
 		return 0, s.countErr
 	}
@@ -66,24 +131,56 @@ func getStatusFrom(t *testing.T, h http.Handler, state *fakeState) statusRespons
 
 func TestHandleStatusWorkCountsUseCounterStores(t *testing.T) {
 	state := newFakeState(t)
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{Type: "task", Title: "ready work"}); err != nil {
+		t.Fatalf("Create ready work: %v", err)
+	}
+	blocker, err := store.Create(beads.Bead{Type: "task", Title: "claimed blocker", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(blocker.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("Update blocker: %v", err)
+	}
+	blocked, err := store.Create(beads.Bead{Type: "task", Title: "blocked work"})
+	if err != nil {
+		t.Fatalf("Create blocked work: %v", err)
+	}
+	if err := store.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+	future := time.Now().UTC().Add(time.Hour)
+	for _, bead := range []beads.Bead{
+		{Type: "message", Title: "infrastructure message"},
+		{Type: "task", Title: "ephemeral work", Ephemeral: true},
+		{Type: "task", Title: "deferred work", DeferUntil: &future},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatalf("Create excluded ready candidate %q: %v", bead.Title, err)
+		}
+	}
 	counter := &counterBeadStore{
-		Store:         beads.NewMemStore(),
+		Store:         store,
 		t:             t,
-		counts:        map[string]int{"open": 2, "in_progress": 1, "ready": 0},
+		counts:        map[string]int{"open": 2, "in_progress": 1, "ready": 99},
 		listForbidden: true,
 	}
 	state.stores["myrig"] = counter
 
 	resp := getStatus(t, state)
 
-	if resp.Work.Open != 2 || resp.Work.InProgress != 1 || resp.Work.Ready != 0 {
-		t.Fatalf("Work = %+v, want open=2 in_progress=1 ready=0", resp.Work)
+	if resp.Work.Open != 2 || resp.Work.InProgress != 1 || resp.Work.Ready != 1 {
+		t.Fatalf("Work = %+v, want open=2 in_progress=1 ready=1", resp.Work)
 	}
 	if resp.Partial {
 		t.Fatalf("Partial = true, want false; errors: %v", resp.PartialErrors)
 	}
 	if !slices.Equal(counter.gotExcludes, statusWorkExcludedTypes) {
 		t.Fatalf("excludeTypes = %v, want %v (infrastructure beads are not work)", counter.gotExcludes, statusWorkExcludedTypes)
+	}
+	if slices.Contains(counter.gotStatuses, "ready") {
+		t.Fatalf("Count statuses = %v, must not query the nonexistent stored status ready", counter.gotStatuses)
 	}
 }
 
@@ -101,18 +198,90 @@ func TestHandleStatusCounterUnsupportedFallsBackToList(t *testing.T) {
 
 	resp := getStatus(t, state)
 
-	if resp.Work.Open != 1 {
-		t.Fatalf("Work.Open = %d, want 1 from List fallback", resp.Work.Open)
+	if resp.Work.Open != 1 || resp.Work.Ready != 1 {
+		t.Fatalf("Work = %+v, want open=1 ready=1 from List and canonical Ready fallbacks", resp.Work)
 	}
 	if resp.Partial {
 		t.Fatalf("Partial = true, want false; errors: %v", resp.PartialErrors)
 	}
 }
 
+func TestHandleStatusReadyDeduplicatesAcrossStoresLikeCanonicalEndpoint(t *testing.T) {
+	state := newFakeState(t)
+	first := beads.NewMemStore()
+	second := beads.NewMemStore()
+	for name, store := range map[string]*beads.MemStore{"alpha": first, "beta": second} {
+		created, err := store.Create(beads.Bead{Type: "task", Title: name + " ready work"})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+		if created.ID != "gc-1" {
+			t.Fatalf("Create(%s) ID = %q, want shared fixture ID gc-1", name, created.ID)
+		}
+	}
+	state.stores = map[string]beads.Store{"alpha": first, "beta": second}
+
+	status := getStatus(t, state)
+	if status.Work.Open != 2 {
+		t.Fatalf("Work.Open = %d, want existing per-store sum 2", status.Work.Open)
+	}
+	if status.Work.Ready != 1 {
+		t.Fatalf("Work.Ready = %d, want shared ready ID deduplicated", status.Work.Ready)
+	}
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/beads/ready"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ready status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var ready struct {
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&ready); err != nil {
+		t.Fatalf("decode ready: %v", err)
+	}
+	if status.Work.Ready != ready.Total {
+		t.Fatalf("status ready = %d, canonical ready total = %d", status.Work.Ready, ready.Total)
+	}
+}
+
+func TestHandleStatusReadyFederatesCityStoreLikeCanonicalEndpoint(t *testing.T) {
+	state := newFakeState(t)
+	state.stores = map[string]beads.Store{}
+	state.cityBeadStore = beads.NewMemStore()
+	if _, err := state.cityBeadStore.Create(beads.Bead{Type: "task", Title: "city-only ready work"}); err != nil {
+		t.Fatalf("Create city ready work: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	status := getStatusFrom(t, h, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/beads/ready"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ready status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var ready struct {
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&ready); err != nil {
+		t.Fatalf("decode ready: %v", err)
+	}
+	if status.Work.Ready != 1 || status.Work.Ready != ready.Total {
+		t.Fatalf("status ready = %d, canonical city-ready total = %d, want both 1", status.Work.Ready, ready.Total)
+	}
+}
+
 func TestHandleStatusCounterFailureReportsPartialWithoutListRetry(t *testing.T) {
 	state := newFakeState(t)
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{Type: "task", Title: "ready survivor"}); err != nil {
+		t.Fatalf("Create ready survivor: %v", err)
+	}
 	state.stores["myrig"] = &counterBeadStore{
-		Store:         beads.NewMemStore(),
+		Store:         store,
 		t:             t,
 		countErr:      errors.New("dolt connection refused"),
 		listForbidden: true, // operational failures must not pay a second 1s timeout on List
@@ -123,6 +292,9 @@ func TestHandleStatusCounterFailureReportsPartialWithoutListRetry(t *testing.T) 
 	if !resp.Partial {
 		t.Fatal("Partial = false, want true for count failure")
 	}
+	if resp.Work.Ready != 1 {
+		t.Fatalf("Work.Ready = %d, want canonical ready survivor despite count failure", resp.Work.Ready)
+	}
 	found := false
 	for _, e := range resp.PartialErrors {
 		if strings.Contains(e, "myrig") && strings.Contains(e, "work") {
@@ -131,6 +303,99 @@ func TestHandleStatusCounterFailureReportsPartialWithoutListRetry(t *testing.T) 
 	}
 	if !found {
 		t.Fatalf("PartialErrors = %v, want rig work error", resp.PartialErrors)
+	}
+}
+
+func TestStatusStoreWorkCountsPreservesReadyWhenCounterTimesOut(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{Type: "task", Title: "ready survivor"}); err != nil {
+		t.Fatalf("Create ready survivor: %v", err)
+	}
+	state := newFakeState(t)
+	result := statusStoreWorkCounts(context.Background(), state, "myrig", &contextBlockingCounterStore{
+		Store: store,
+		t:     t,
+	})
+
+	if result.wc.Ready != 1 {
+		t.Fatalf("Ready = %d, want 1 even when persisted Count consumes the deadline", result.wc.Ready)
+	}
+	if len(result.errs) == 0 {
+		t.Fatal("errors empty, want Count timeout reported as partial")
+	}
+}
+
+func TestStatusStoreWorkCountsBoundsContextIgnoringCounter(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{Type: "task", Title: "ready survivor"}); err != nil {
+		t.Fatalf("Create ready survivor: %v", err)
+	}
+	blocking := &contextIgnoringCounterStore{
+		Store:   store,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		exited:  make(chan struct{}),
+	}
+	released := false
+	defer func() {
+		if !released {
+			close(blocking.release)
+		}
+	}()
+
+	state := newFakeState(t)
+	resultDone := make(chan statusWorkResult, 1)
+	go func() {
+		resultDone <- statusStoreWorkCounts(context.Background(), state, "myrig", blocking)
+	}()
+	select {
+	case <-blocking.entered:
+	case <-time.After(time.Second):
+		t.Fatal("Count was not entered")
+	}
+
+	var result statusWorkResult
+	select {
+	case result = <-resultDone:
+	case <-time.After(time.Second):
+		t.Fatal("statusStoreWorkCounts did not honor its outer deadline")
+	}
+	if result.wc.Ready != 1 {
+		t.Fatalf("Ready = %d, want completed Ready survivor", result.wc.Ready)
+	}
+	if len(result.errs) == 0 {
+		t.Fatal("errors empty, want context-ignoring Count timeout reported")
+	}
+
+	close(blocking.release)
+	released = true
+	select {
+	case <-blocking.exited:
+	case <-time.After(time.Second):
+		t.Fatal("context-ignoring Count goroutine did not exit after release")
+	}
+}
+
+func TestStatusStoreWorkCountsPreservesPartialCounterBuckets(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{Type: "task", Title: "ready survivor"}); err != nil {
+		t.Fatalf("Create ready survivor: %v", err)
+	}
+	result := statusStoreWorkCounts(context.Background(), newFakeState(t), "myrig", &partialCounterStore{Store: store})
+
+	if result.wc.Open != 7 || result.wc.Ready != 1 {
+		t.Fatalf("Work = %+v, want open=7 and ready=1 survivors", result.wc)
+	}
+	if len(result.errs) == 0 {
+		t.Fatal("errors empty, want in-progress Count failure reported")
 	}
 }
 

--- a/internal/api/handler_status_scoped_store_test.go
+++ b/internal/api/handler_status_scoped_store_test.go
@@ -15,6 +15,32 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+type contextBlindReadyStore struct {
+	beads.Store
+	entered chan struct{}
+	release chan struct{}
+}
+
+type legacyReadyStore struct {
+	beads.Store
+}
+
+func (s *contextBlindReadyStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
+	close(s.entered)
+	<-s.release
+	return nil, nil
+}
+
+type countingReadyStore struct {
+	*beads.MemStore
+	readyCalls int
+}
+
+func (s *countingReadyStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	s.readyCalls++
+	return s.MemStore.Ready(query...)
+}
+
 func newSessionBead(sessionName string) beads.Bead {
 	return beads.Bead{
 		Type:   session.BeadType,
@@ -219,6 +245,260 @@ func TestStatusListStoreWithTimeoutSurfacesScopedStoreResolutionError(t *testing
 	}
 }
 
+func TestStatusReadyStoreWithTimeoutUsesScopedStoreWhenAvailable(t *testing.T) {
+	shared := beads.NewMemStore()
+	if _, err := shared.Create(beads.Bead{Type: "task", Title: "shared ready work"}); err != nil {
+		t.Fatalf("Create shared ready work: %v", err)
+	}
+	scoped := beads.NewMemStore()
+	for _, title := range []string{"scoped ready work 1", "scoped ready work 2"} {
+		if _, err := scoped.Create(beads.Bead{Type: "task", Title: title}); err != nil {
+			t.Fatalf("Create %s: %v", title, err)
+		}
+	}
+
+	state := newFakeState(t)
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		return scoped, nil
+	}
+
+	rows, err := statusReadyStoreWithTimeout(context.Background(), state, &legacyReadyStore{Store: shared})
+	if err != nil {
+		t.Fatalf("statusReadyStoreWithTimeout: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2 from the scoped store", len(rows))
+	}
+}
+
+func TestStatusReadyStoreWithTimeoutSurfacesScopedStoreResolutionError(t *testing.T) {
+	state := newFakeState(t)
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		return nil, errors.New("resolving dolt credentials: boom")
+	}
+
+	_, err := statusReadyStoreWithTimeout(context.Background(), state, &legacyReadyStore{Store: beads.NewMemStore()})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("statusReadyStoreWithTimeout error = %v, want it to contain the resolution error", err)
+	}
+}
+
+func TestStatusReadyStoreWithTimeoutHonorsCanceledRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := statusReadyStoreWithTimeout(ctx, newFakeState(t), beads.NewMemStore())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("statusReadyStoreWithTimeout error = %v, want context.Canceled", err)
+	}
+}
+
+func TestStatusReadyStoreWithTimeoutRejectsContextBlindReady(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	store := &contextBlindReadyStore{
+		Store:   beads.NewMemStore(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(func() { close(store.release) })
+
+	_, err := statusReadyStoreWithTimeout(context.Background(), newFakeState(t), store)
+	if err == nil || !strings.Contains(err.Error(), "context-aware ready") {
+		t.Fatalf("statusReadyStoreWithTimeout error = %v, want unsupported context-aware ready error", err)
+	}
+	select {
+	case <-store.entered:
+		t.Fatal("context-blind Ready was launched and abandoned")
+	default:
+	}
+}
+
+func TestStatusReadyStoreWithTimeoutUsesCachingStoreProjection(t *testing.T) {
+	backing := &countingReadyStore{MemStore: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{Type: "task", Title: "cached ready work"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.readyCalls = 0
+	state := newFakeState(t)
+	scopedCalls := 0
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		scopedCalls++
+		return beads.NewMemStore(), nil
+	}
+
+	rows, err := statusReadyStoreWithTimeout(context.Background(), state, cache)
+	if err != nil {
+		t.Fatalf("statusReadyStoreWithTimeout: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1 cached Ready row", len(rows))
+	}
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want cache-only projection", backing.readyCalls)
+	}
+	if scopedCalls != 0 {
+		t.Fatalf("ScopedStoreLike calls = %d, want context-ready cache projection tried first", scopedCalls)
+	}
+}
+
+func TestStatusReadyStoreWithTimeoutDoesNotFallbackWhenCacheUnavailable(t *testing.T) {
+	cache := beads.NewCachingStoreForTest(beads.NewMemStore(), nil)
+	state := newFakeState(t)
+	scopedCalls := 0
+	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
+		scopedCalls++
+		return beads.NewMemStore(), nil
+	}
+
+	rows, err := statusReadyStoreWithTimeout(context.Background(), state, cache)
+	if !errors.Is(err, beads.ErrCacheUnavailable) {
+		t.Fatalf("statusReadyStoreWithTimeout error = %v, want ErrCacheUnavailable", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("rows = %+v, want no rows from an unavailable cache", rows)
+	}
+	if scopedCalls != 0 {
+		t.Fatalf("ScopedStoreLike calls = %d, want none for final cache-unavailable result", scopedCalls)
+	}
+}
+
+func TestStatusReadyStoreWithTimeoutWaitsForScopedResolutionCleanup(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		cleanupStarted := make(chan struct{})
+		releaseCleanup := make(chan struct{})
+		cleanupDone := make(chan struct{})
+		state := newFakeState(t)
+		state.scopedStoreFn = func(ctx context.Context, _ beads.Store) (beads.Store, error) {
+			<-ctx.Done()
+			close(cleanupStarted)
+			<-releaseCleanup
+			close(cleanupDone)
+			return nil, ctx.Err()
+		}
+
+		resultDone := make(chan error, 1)
+		go func() {
+			_, err := statusReadyStoreWithTimeout(context.Background(), state, &legacyReadyStore{Store: beads.NewMemStore()})
+			resultDone <- err
+		}()
+
+		select {
+		case <-cleanupStarted:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("attempt %d: scoped resolution did not observe cancellation", attempt)
+		}
+		select {
+		case err := <-resultDone:
+			close(releaseCleanup)
+			<-cleanupDone
+			t.Fatalf("attempt %d: status returned %v before scoped resolution cleanup completed", attempt, err)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		close(releaseCleanup)
+		select {
+		case <-cleanupDone:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("attempt %d: scoped resolution cleanup did not finish", attempt)
+		}
+		select {
+		case err := <-resultDone:
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("attempt %d: error = %v, want context deadline exceeded", attempt, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("attempt %d: status did not return after scoped resolution cleanup", attempt)
+		}
+	}
+}
+
+func TestStatusStoreWorkCountsWaitsForReadyResolutionCleanup(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	cleanupStarted := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	cleanupDone := make(chan struct{})
+	state := newFakeState(t)
+	state.scopedStoreFn = func(ctx context.Context, _ beads.Store) (beads.Store, error) {
+		<-ctx.Done()
+		close(cleanupStarted)
+		<-releaseCleanup
+		close(cleanupDone)
+		return nil, ctx.Err()
+	}
+
+	resultDone := make(chan statusWorkResult, 1)
+	go func() {
+		resultDone <- statusStoreWorkCountsFor(
+			context.Background(),
+			state,
+			"rig test",
+			&legacyReadyStore{Store: beads.NewMemStore()},
+			false,
+			true,
+		)
+	}()
+
+	select {
+	case <-cleanupStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ready resolution did not observe cancellation")
+	}
+	select {
+	case result := <-resultDone:
+		close(releaseCleanup)
+		<-cleanupDone
+		t.Fatalf("status work count returned %+v before ready resolution cleanup completed", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseCleanup)
+	select {
+	case <-cleanupDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ready resolution cleanup did not finish")
+	}
+	select {
+	case result := <-resultDone:
+		if len(result.errs) == 0 || !strings.Contains(result.errs[0], "timed out") {
+			t.Fatalf("status work count result = %+v, want ready timeout", result)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("status work count did not return after ready resolution cleanup")
+	}
+}
+
+func TestStatusReadyStoreWithTimeoutBoundsSlowScopedStoreResolution(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	state := newFakeState(t)
+	state.scopedStoreFn = cancelableStatusWorkScopedStoreResolution
+
+	start := time.Now()
+	_, err := statusReadyStoreWithTimeout(context.Background(), state, &legacyReadyStore{Store: beads.NewMemStore()})
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("statusReadyStoreWithTimeout blocked %s on scoped-store resolution; want bounded by statusStoreReadTimeout", elapsed)
+	}
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("statusReadyStoreWithTimeout error = %v, want a timed-out error", err)
+	}
+}
+
 // TestStatusListStoreWithTimeoutKillsBdChildOnTimeout is the ga-cdmx6x
 // regression test for the per-rig work-count call site: mirrors
 // TestStatusSessionSnapshotKillsBdChildOnTimeout, but through
@@ -253,14 +533,44 @@ func TestStatusListStoreWithTimeoutKillsBdChildOnTimeout(t *testing.T) {
 	}
 
 	childPid := waitForNonEmptyFileScopedTest(t, pidFile, 5*time.Second)
-	for range 50 {
-		if err := exec.Command("kill", "-0", childPid).Run(); err != nil {
-			return // child is gone
-		}
-		time.Sleep(20 * time.Millisecond)
+	assertStatusWorkReadChildStopped(t, childPid, "statusListStoreWithTimeout")
+}
+
+// TestStatusReadyStoreWithTimeoutKillsBdChildOnTimeout proves canonical
+// readiness uses the request-scoped store too. A Ready read through the shared
+// background-bound store would leave the bd child alive after the status
+// deadline, defeating the scoped-store mitigation.
+func TestStatusReadyStoreWithTimeoutKillsBdChildOnTimeout(t *testing.T) {
+	processgrouptest.RequireRealProcessSignals(t)
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
 	}
-	_ = exec.Command("kill", "-KILL", childPid).Run()
-	t.Fatalf("bd child process %s survived statusListStoreWithTimeout's timeout", childPid)
+
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(binDir, "bd-child.pid")
+	writeExecutableScopedTest(t, filepath.Join(binDir, "bd"), "#!/bin/sh\n"+
+		"sleep 30 &\n"+
+		"echo \"$!\" > "+pidFile+"\n"+
+		"wait\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	state := newFakeState(t)
+	state.scopedStoreFn = func(ctx context.Context, _ beads.Store) (beads.Store, error) {
+		return beads.NewBdStore(t.TempDir(), beads.ExecCommandRunnerWithEnvContext(ctx, nil)), nil
+	}
+
+	start := time.Now()
+	_, _ = statusReadyStoreWithTimeout(context.Background(), state, &legacyReadyStore{Store: beads.NewMemStore()})
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("statusReadyStoreWithTimeout blocked %s; want bounded by statusStoreReadTimeout", elapsed)
+	}
+
+	childPid := waitForNonEmptyFileScopedTest(t, pidFile, 5*time.Second)
+	assertStatusWorkReadChildStopped(t, childPid, "statusReadyStoreWithTimeout")
 }
 
 // TestStatusSessionSnapshotBoundsSlowScopedStoreResolution proves the
@@ -305,10 +615,7 @@ func TestStatusListStoreWithTimeoutBoundsSlowScopedStoreResolution(t *testing.T)
 	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
 
 	state := newFakeState(t)
-	state.scopedStoreFn = func(context.Context, beads.Store) (beads.Store, error) {
-		time.Sleep(3 * time.Second)
-		return nil, nil
-	}
+	state.scopedStoreFn = slowStatusWorkScopedStoreResolution
 
 	start := time.Now()
 	_, err := statusListStoreWithTimeout(context.Background(), state, beads.NewMemStore(), beads.ListQuery{AllowScan: true})
@@ -325,6 +632,32 @@ func writeExecutableScopedTest(t *testing.T, path, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func slowStatusWorkScopedStoreResolution(context.Context, beads.Store) (beads.Store, error) {
+	time.Sleep(3 * time.Second)
+	return nil, nil
+}
+
+func cancelableStatusWorkScopedStoreResolution(ctx context.Context, _ beads.Store) (beads.Store, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(3 * time.Second):
+		return nil, nil
+	}
+}
+
+func assertStatusWorkReadChildStopped(t *testing.T, childPID, caller string) {
+	t.Helper()
+	for range 50 {
+		if err := exec.Command("kill", "-0", childPID).Run(); err != nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = exec.Command("kill", "-KILL", childPID).Run()
+	t.Fatalf("bd child process %s survived %s's timeout", childPID, caller)
 }
 
 func waitForNonEmptyFileScopedTest(t *testing.T, path string, timeout time.Duration) string {

--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -96,18 +96,6 @@ func TestHandleStatusPreservesPartialWorkCountSurvivors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create(open): %v", err)
 	}
-	ready, err := store.Create(beads.Bead{Type: "task", Title: "ready survivor", Status: "ready"})
-	if err != nil {
-		t.Fatalf("Create(ready): %v", err)
-	}
-	readyStatus := "ready"
-	if err := store.Update(ready.ID, beads.UpdateOpts{Status: &readyStatus}); err != nil {
-		t.Fatalf("Update(ready): %v", err)
-	}
-	ready, err = store.Get(ready.ID)
-	if err != nil {
-		t.Fatalf("Get(ready): %v", err)
-	}
 	inProgress, err := store.Create(beads.Bead{Type: "task", Title: "claimed survivor", Status: "in_progress"})
 	if err != nil {
 		t.Fatalf("Create(in_progress): %v", err)
@@ -121,10 +109,15 @@ func TestHandleStatusPreservesPartialWorkCountSurvivors(t *testing.T) {
 		t.Fatalf("Get(in_progress): %v", err)
 	}
 	state.stores["myrig"] = &failingBeadStore{
-		Store:      store,
-		listResult: []beads.Bead{open, ready, inProgress},
+		Store:       store,
+		listResult:  []beads.Bead{open, inProgress},
+		readyResult: []beads.Bead{open},
 		listErr: &beads.PartialResultError{
 			Op:  "bd list",
+			Err: errors.New("skipped 1 corrupt bead"),
+		},
+		readyErr: &beads.PartialResultError{
+			Op:  "bd ready",
 			Err: errors.New("skipped 1 corrupt bead"),
 		},
 	}
@@ -149,6 +142,38 @@ func TestHandleStatusPreservesPartialWorkCountSurvivors(t *testing.T) {
 	}
 	if len(resp.PartialErrors) == 0 {
 		t.Fatalf("PartialErrors empty")
+	}
+}
+
+func TestHandleStatusPreservesStoredCountsWhenReadyFails(t *testing.T) {
+	state := newFakeState(t)
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{Type: "task", Title: "open survivor", Status: "open"}); err != nil {
+		t.Fatalf("Create(open): %v", err)
+	}
+	claimed, err := store.Create(beads.Bead{Type: "task", Title: "claimed survivor", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Create(in_progress): %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(claimed.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("Update(in_progress): %v", err)
+	}
+	state.stores["myrig"] = &failingBeadStore{
+		Store:    store,
+		readyErr: errors.New("ready projection unavailable"),
+	}
+
+	resp := getStatus(t, state)
+
+	if resp.Work.Open != 1 || resp.Work.Ready != 0 || resp.Work.InProgress != 1 {
+		t.Fatalf("Work = %+v, want stored-count survivors open=1 in_progress=1", resp.Work)
+	}
+	if !resp.Partial {
+		t.Fatal("Partial = false, want true for Ready failure")
+	}
+	if joined := strings.Join(resp.PartialErrors, "; "); !strings.Contains(joined, "ready projection unavailable") {
+		t.Fatalf("PartialErrors = %v, want Ready failure", resp.PartialErrors)
 	}
 }
 

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -121,7 +121,8 @@ type State interface {
 	// Read paths with their own short request budget (e.g. GET /status) use
 	// this instead of reading through the shared store so a slow bd command
 	// cannot pin a Dolt connection past the caller's own deadline
-	// (gascity ga-cdmx6x).
+	// (gascity ga-cdmx6x). Implementations must observe ctx during resolution
+	// and finish any work they start before returning after cancellation.
 	ScopedStoreLike(ctx context.Context, existing beads.Store) (beads.Store, error)
 
 	// NudgesBeadStore returns the store backing the nudge-queue shadow beads

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -29,6 +29,10 @@ var ErrMetadataParse = errors.New("bead metadata parse")
 // cannot answer without consulting the backing store.
 var ErrCacheUnavailable = errors.New("bead cache unavailable")
 
+// ErrReadyContextUnsupported reports that a store cannot guarantee a Ready
+// projection stops when the caller's context is canceled.
+var ErrReadyContextUnsupported = errors.New("context-aware ready unsupported")
+
 // ErrStoreClosed is returned when a caller uses a bead store after its backing
 // handle has been closed.
 var ErrStoreClosed = errors.New("bead store closed")
@@ -638,6 +642,14 @@ type Store interface {
 	// query: "down" returns what this bead depends on (default),
 	// "up" returns what depends on this bead.
 	DepList(id, direction string) ([]Dep, error)
+}
+
+// ContextReadyReader is an optional Ready capability for deadline-sensitive
+// callers. Implementations must stop all work started by ReadyContext before
+// returning after ctx cancellation; callers may treat ErrCacheUnavailable as a
+// partial read and ErrReadyContextUnsupported as a capability veto.
+type ContextReadyReader interface {
+	ReadyContext(ctx context.Context, query ...ReadyQuery) ([]Bead, error)
 }
 
 // StorageClass selects the physical bead storage tier for adapters that

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -302,7 +302,7 @@ func (c *CachingStore) cachedReadyLocked(query ReadyQuery) ([]Bead, error) {
 		}
 		openBeads = append(openBeads, cloneBead(b))
 	}
-	return cachedReadyRows(nil, query, statusByID, openBeads, c.deps, c.depsComplete)
+	return cachedReadyRows(context.Background(), query, statusByID, openBeads, c.deps, c.depsComplete)
 }
 
 func cachedReadyRows(
@@ -313,10 +313,11 @@ func cachedReadyRows(
 	depsByID map[string][]Dep,
 	depsComplete bool,
 ) ([]Bead, error) {
+	cancellable := ctx != nil && ctx.Done() != nil
 	// Sort candidates before the limit-bounded loop below: the cache source is
 	// a map, so without this a Limit cuts an arbitrary subset. The context-aware
 	// path remains interruptible throughout this CPU work.
-	if ctx == nil {
+	if !cancellable {
 		sortBeadsReadyOrder(openBeads)
 	} else if err := sortBeadsReadyOrderContext(ctx, openBeads); err != nil {
 		return nil, err
@@ -324,7 +325,7 @@ func cachedReadyRows(
 
 	result := make([]Bead, 0, len(openBeads))
 	for _, b := range openBeads {
-		if ctx != nil {
+		if cancellable {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -231,6 +231,60 @@ func (c *CachingStore) cachedListOnly(query ListQuery) ([]Bead, error) {
 func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	return c.cachedReadyLocked(query)
+}
+
+func (c *CachingStore) cachedReadyCompleteOnly(ctx context.Context, query ReadyQuery) ([]Bead, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// A cache-only deadline-sensitive read must never wait behind a writer
+	// after its caller has returned. A busy cache is a partial observation,
+	// not a reason to abandon a goroutine on RLock.
+	if !c.mu.TryRLock() {
+		return nil, fmt.Errorf("reading complete ready projection from busy cache: %w", ErrCacheUnavailable)
+	}
+	if c.state != cacheLive || !c.depsComplete || c.primePartialErr != nil || len(c.dirty) > 0 {
+		c.mu.RUnlock()
+		return nil, fmt.Errorf("reading complete ready projection from cache: %w", ErrCacheUnavailable)
+	}
+
+	statusByID := make(map[string]string, len(c.beads))
+	openBeads := make([]Bead, 0, len(c.beads))
+	now := time.Now().UTC()
+	for _, b := range c.beads {
+		if err := ctx.Err(); err != nil {
+			c.mu.RUnlock()
+			return nil, err
+		}
+		statusByID[b.ID] = b.Status
+		if !IsReadyCandidateForTier(b, now, query.TierMode) {
+			continue
+		}
+		if query.Assignee != "" && b.Assignee != query.Assignee {
+			continue
+		}
+		openBeads = append(openBeads, cloneBead(b))
+	}
+	depsByID := make(map[string][]Dep, len(openBeads))
+	for _, b := range openBeads {
+		if err := ctx.Err(); err != nil {
+			c.mu.RUnlock()
+			return nil, err
+		}
+		depsByID[b.ID] = cloneDeps(c.deps[b.ID])
+	}
+	c.mu.RUnlock()
+
+	// The maps above are a consistent snapshot, so sorting and dependency
+	// evaluation need not hold the cache lock or delay writers.
+	return cachedReadyRows(ctx, query, statusByID, openBeads, depsByID, true)
+}
+
+func (c *CachingStore) cachedReadyLocked(query ReadyQuery) ([]Bead, error) {
 	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil || len(c.dirty) > 0 {
 		return nil, fmt.Errorf("reading ready beads from cache: %w", ErrCacheUnavailable)
 	}
@@ -248,18 +302,37 @@ func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 		}
 		openBeads = append(openBeads, cloneBead(b))
 	}
-	// Sort candidates before the limit-bounded loop below: c.beads is a map,
-	// so without this a Limit cuts an arbitrary, per-call-different subset —
-	// the #3208 bug class. Canonical ready order matches the SQL-backed
-	// ready readers.
-	sortBeadsReadyOrder(openBeads)
+	return cachedReadyRows(nil, query, statusByID, openBeads, c.deps, c.depsComplete)
+}
+
+func cachedReadyRows(
+	ctx context.Context,
+	query ReadyQuery,
+	statusByID map[string]string,
+	openBeads []Bead,
+	depsByID map[string][]Dep,
+	depsComplete bool,
+) ([]Bead, error) {
+	// Sort candidates before the limit-bounded loop below: the cache source is
+	// a map, so without this a Limit cuts an arbitrary subset. The context-aware
+	// path remains interruptible throughout this CPU work.
+	if ctx == nil {
+		sortBeadsReadyOrder(openBeads)
+	} else if err := sortBeadsReadyOrderContext(ctx, openBeads); err != nil {
+		return nil, err
+	}
 
 	result := make([]Bead, 0, len(openBeads))
 	for _, b := range openBeads {
-		deps, ok := c.deps[b.ID]
+		if ctx != nil {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		deps, ok := depsByID[b.ID]
 		switch {
 		case ok:
-		case c.depsComplete:
+		case depsComplete:
 			deps = nil
 		default:
 			return nil, fmt.Errorf("reading ready deps from cache: %w", ErrCacheUnavailable)

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -14,6 +14,28 @@ import (
 	"time"
 )
 
+func TestCachingStoreReadyContextRejectsIncompleteDependencyProjection(t *testing.T) {
+	cache := NewCachingStoreForTest(NewMemStore(), nil)
+	cache.mu.Lock()
+	cache.state = cacheLive
+	cache.beads = map[string]Bead{
+		"work": {ID: "work", Type: "task", Status: "open", Title: "possibly blocked work"},
+	}
+	cache.deps = map[string][]Dep{
+		"work": {{IssueID: "work", DependsOnID: "missing-blocker", Type: "blocks"}},
+	}
+	cache.depsComplete = false
+	cache.mu.Unlock()
+
+	rows, err := cache.ReadyContext(context.Background())
+	if !errors.Is(err, ErrCacheUnavailable) {
+		t.Fatalf("ReadyContext error = %v, want ErrCacheUnavailable", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("ReadyContext rows = %+v, want no result from incomplete dependency projection", rows)
+	}
+}
+
 func TestCachingStoreRunReconciliationDetectsLabelContentChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -111,19 +111,17 @@ func (c *CachingStore) Count(ctx context.Context, query ListQuery, excludeTypes 
 		return 0, fmt.Errorf("counting beads: %w", ErrCountUnsupported)
 	}
 	if !query.Live && query.ParentID == "" && !query.IncludesClosed() {
-		var n int
-		if err := c.readCacheWithOverlay(c.cacheServableLocked, func(suppressed map[string]struct{}) {
-			n = 0
-			for _, b := range c.beads {
-				if _, gone := suppressed[b.ID]; gone {
-					continue
-				}
-				if query.Matches(b) && !slices.Contains(excludeTypes, b.Type) {
-					n++
-				}
-			}
-		}); err == nil {
+		n, ok, err := c.cachedCountContext(ctx, query, excludeTypes)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
 			return n, nil
+		}
+	}
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return 0, err
 		}
 	}
 	counter, ok := c.backing.(Counter)
@@ -131,6 +129,48 @@ func (c *CachingStore) Count(ctx context.Context, query ListQuery, excludeTypes 
 		return 0, fmt.Errorf("counting beads: backing store: %w", ErrCountUnsupported)
 	}
 	return counter.Count(ctx, liveListQuery(query), excludeTypes...)
+}
+
+// cachedCountContext serves only a clean active snapshot. Dirty overlays use
+// context-blind Store.Get calls, so a deadline-sensitive Count delegates those
+// cases to the backing Counter instead. Lock acquisition and the scan both
+// observe ctx, ensuring a cache writer cannot strand the caller's goroutine.
+func (c *CachingStore) cachedCountContext(ctx context.Context, query ListQuery, excludeTypes []string) (int, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, false, err
+	}
+	if !c.mu.TryRLock() {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for !c.mu.TryRLock() {
+			select {
+			case <-ctx.Done():
+				return 0, false, ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	}
+	defer c.mu.RUnlock()
+
+	if !c.cacheServableLocked() || len(c.dirty) > 0 {
+		return 0, false, nil
+	}
+	var n int
+	for _, b := range c.beads {
+		if err := ctx.Err(); err != nil {
+			return 0, false, err
+		}
+		if query.Matches(b) && !slices.Contains(excludeTypes, b.Type) {
+			n++
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, false, err
+	}
+	return n, true, nil
 }
 
 // CachedList returns query results from the in-memory cache only. The boolean
@@ -468,6 +508,24 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	// match the SQL-backed ready readers (#3208).
 	sortBeadsReadyOrder(result)
 	return result, nil
+}
+
+// ReadyContext answers only from the dependency-complete active cache. It
+// deliberately does not fall back to the context-blind backing Ready method:
+// deadline-sensitive callers must receive ErrCacheUnavailable instead of
+// abandoning database work after their context expires.
+func (c *CachingStore) ReadyContext(ctx context.Context, query ...ReadyQuery) ([]Bead, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	rows, err := c.cachedReadyCompleteOnly(ctx, readyQueryFromArgs(query))
+	if err != nil {
+		return rows, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 // CachedReady returns ready beads from the in-memory active read model.

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -516,6 +517,18 @@ func (fs *FileStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		return nil, err
 	}
 	return fs.MemStore.Ready(query...)
+}
+
+// ReadyContext vetoes ContextReadyReader for FileStore. Refreshing the JSON
+// file is context-blind, so the promoted MemStore method would falsely promise
+// cancellation and would skip the required on-disk refresh entirely.
+func (fs *FileStore) ReadyContext(ctx context.Context, _ ...ReadyQuery) ([]Bead, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("reading ready beads from file store: %w", ErrReadyContextUnsupported)
 }
 
 // Children reloads the on-disk store before listing child beads.

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -317,7 +317,7 @@ func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(query)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.readyLocked(nil, q)
+	return m.readyLocked(context.Background(), q)
 }
 
 // ReadyContext implements ContextReadyReader for the in-memory store. Lock
@@ -346,8 +346,9 @@ func (m *MemStore) ReadyContext(ctx context.Context, query ...ReadyQuery) ([]Bea
 }
 
 func (m *MemStore) readyLocked(ctx context.Context, q ReadyQuery) ([]Bead, error) {
+	cancellable := ctx != nil && ctx.Done() != nil
 	contextErr := func() error {
-		if ctx == nil {
+		if !cancellable {
 			return nil
 		}
 		return ctx.Err()

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -316,15 +317,56 @@ func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(query)
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	return m.readyLocked(nil, q)
+}
+
+// ReadyContext implements ContextReadyReader for the in-memory store. Lock
+// acquisition and the projection scan both observe ctx, so a status request
+// never abandons a goroutine behind a concurrent in-memory writer.
+func (m *MemStore) ReadyContext(ctx context.Context, query ...ReadyQuery) ([]Bead, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !m.mu.TryLock() {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for !m.mu.TryLock() {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	}
+	defer m.mu.Unlock()
+	return m.readyLocked(ctx, readyQueryFromArgs(query))
+}
+
+func (m *MemStore) readyLocked(ctx context.Context, q ReadyQuery) ([]Bead, error) {
+	contextErr := func() error {
+		if ctx == nil {
+			return nil
+		}
+		return ctx.Err()
+	}
 
 	statusByID := make(map[string]string, len(m.beads))
 	for _, bead := range m.beads {
+		if err := contextErr(); err != nil {
+			return nil, err
+		}
 		statusByID[bead.ID] = bead.Status
 	}
 
 	var result []Bead
 	now := time.Now().UTC()
 	for _, b := range m.beads {
+		if err := contextErr(); err != nil {
+			return nil, err
+		}
 		if !IsReadyCandidateForTier(b, now, q.TierMode) {
 			continue
 		}
@@ -333,6 +375,9 @@ func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		}
 		blocked := false
 		for _, dep := range m.deps {
+			if err := contextErr(); err != nil {
+				return nil, err
+			}
 			if dep.IssueID != b.ID {
 				continue
 			}

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -317,7 +317,7 @@ func sortBeadsReadyOrder(items []Bead) {
 // checks inside both comparison and copy work instead of abandoning an
 // uninterruptible sort goroutine when ctx expires.
 func sortBeadsReadyOrderContext(ctx context.Context, items []Bead) error {
-	if ctx == nil {
+	if ctx == nil || ctx.Done() == nil {
 		sortBeadsReadyOrder(items)
 		return nil
 	}

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"context"
 	"errors"
 	"sort"
 	"time"
@@ -307,15 +308,83 @@ func SortBeads(items []Bead, order SortOrder) {
 // which store path served it (#3208).
 func sortBeadsReadyOrder(items []Bead) {
 	sort.Slice(items, func(i, j int) bool {
-		pi, pj := readySortPriority(items[i]), readySortPriority(items[j])
-		if pi != pj {
-			return pi < pj
-		}
-		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
-			return items[i].CreatedAt.Before(items[j].CreatedAt)
-		}
-		return items[i].ID < items[j].ID
+		return beadReadyLess(items[i], items[j])
 	})
+}
+
+// sortBeadsReadyOrderContext is the cancellation-aware form used by
+// deadline-sensitive cache projections. A local merge sort keeps cancellation
+// checks inside both comparison and copy work instead of abandoning an
+// uninterruptible sort goroutine when ctx expires.
+func sortBeadsReadyOrderContext(ctx context.Context, items []Bead) error {
+	if ctx == nil {
+		sortBeadsReadyOrder(items)
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(items) < 2 {
+		return nil
+	}
+
+	scratch := make([]Bead, len(items))
+	var mergeSort func(int, int) error
+	mergeSort = func(lo, hi int) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if hi-lo < 2 {
+			return nil
+		}
+		mid := lo + (hi-lo)/2
+		if err := mergeSort(lo, mid); err != nil {
+			return err
+		}
+		if err := mergeSort(mid, hi); err != nil {
+			return err
+		}
+
+		i, j := lo, mid
+		for k := lo; k < hi; k++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			switch {
+			case i == mid:
+				scratch[k] = items[j]
+				j++
+			case j == hi:
+				scratch[k] = items[i]
+				i++
+			case beadReadyLess(items[j], items[i]):
+				scratch[k] = items[j]
+				j++
+			default:
+				scratch[k] = items[i]
+				i++
+			}
+		}
+		for k := lo; k < hi; k++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			items[k] = scratch[k]
+		}
+		return nil
+	}
+	return mergeSort(0, len(items))
+}
+
+func beadReadyLess(a, b Bead) bool {
+	pa, pb := readySortPriority(a), readySortPriority(b)
+	if pa != pb {
+		return pa < pb
+	}
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.Before(b.CreatedAt)
+	}
+	return a.ID < b.ID
 }
 
 func readySortPriority(b Bead) int {

--- a/internal/beads/ready_context_internal_test.go
+++ b/internal/beads/ready_context_internal_test.go
@@ -18,17 +18,28 @@ type observedErrContext struct {
 	checked chan struct{}
 }
 
-type cancelAfterChecksContext struct {
+type cancelOnErrCheckContext struct {
 	context.Context
+	cancel   context.CancelFunc
 	cancelAt int64
 	checks   atomic.Int64
 }
 
-func (c *cancelAfterChecksContext) Err() error {
+func (c *cancelOnErrCheckContext) Err() error {
 	if c.checks.Add(1) >= c.cancelAt {
-		return context.Canceled
+		c.cancel()
 	}
-	return nil
+	return c.Context.Err()
+}
+
+type countingErrContext struct {
+	context.Context
+	checks atomic.Int64
+}
+
+func (c *countingErrContext) Err() error {
+	c.checks.Add(1)
+	return c.Context.Err()
 }
 
 func TestCachingStoreCountContextCancelsWhileWaitingForLock(t *testing.T) {
@@ -84,11 +95,118 @@ func TestSortBeadsReadyOrderContextStopsAfterCancellation(t *testing.T) {
 		priority := len(rows) - i
 		rows[i] = Bead{ID: fmt.Sprintf("gc-%03d", i), Priority: &priority}
 	}
-	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 8}
+	base, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := &cancelOnErrCheckContext{Context: base, cancel: cancel, cancelAt: 8}
 
 	err := sortBeadsReadyOrderContext(ctx, rows)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("sortBeadsReadyOrderContext error = %v, want context.Canceled", err)
+	}
+	if checks := ctx.checks.Load(); checks < ctx.cancelAt {
+		t.Fatalf("context checks = %d, want at least %d", checks, ctx.cancelAt)
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("context returned cancellation without closing Done")
+	}
+}
+
+func TestSortBeadsReadyOrderBackgroundUsesNonCancellableFastPath(t *testing.T) {
+	rows := make([]Bead, 128)
+	for i := range rows {
+		priority := len(rows) - i
+		rows[i] = Bead{ID: fmt.Sprintf("gc-%03d", i), Priority: &priority}
+	}
+	ctx := &countingErrContext{Context: context.Background()}
+
+	if err := sortBeadsReadyOrderContext(ctx, rows); err != nil {
+		t.Fatalf("sortBeadsReadyOrderContext: %v", err)
+	}
+	if checks := ctx.checks.Load(); checks != 0 {
+		t.Fatalf("uncancellable context checks = %d, want 0", checks)
+	}
+	for i := 1; i < len(rows); i++ {
+		if beadReadyLess(rows[i], rows[i-1]) {
+			t.Fatalf("rows are not sorted at index %d: %+v before %+v", i, rows[i-1], rows[i])
+		}
+	}
+}
+
+func TestCachedReadyRowsBackgroundUsesCanonicalOrderWithoutErrChecks(t *testing.T) {
+	priorityZero, priorityOne := 0, 1
+	created := time.Date(2026, time.July, 15, 9, 0, 0, 0, time.UTC)
+	openBeads := []Bead{
+		{ID: "gc-c", Status: "open", Priority: &priorityOne, CreatedAt: created},
+		{ID: "gc-b", Status: "open", Priority: &priorityZero, CreatedAt: created.Add(time.Minute)},
+		{ID: "gc-a", Status: "open", Priority: &priorityZero, CreatedAt: created},
+	}
+	statusByID := map[string]string{"gc-a": "open", "gc-b": "open", "gc-c": "open"}
+	ctx := &countingErrContext{Context: context.Background()}
+
+	rows, err := cachedReadyRows(ctx, ReadyQuery{Limit: 2}, statusByID, openBeads, nil, true)
+	if err != nil {
+		t.Fatalf("cachedReadyRows: %v", err)
+	}
+	gotIDs := make([]string, len(rows))
+	for i := range rows {
+		gotIDs[i] = rows[i].ID
+	}
+	if len(gotIDs) != 2 || gotIDs[0] != "gc-a" || gotIDs[1] != "gc-b" {
+		t.Fatalf("cachedReadyRows IDs = %v, want [gc-a gc-b]", gotIDs)
+	}
+	if checks := ctx.checks.Load(); checks != 0 {
+		t.Fatalf("uncancellable context checks = %d, want 0", checks)
+	}
+}
+
+func TestMemStoreReadyLockedSkipsChecksForUncancellableContext(t *testing.T) {
+	store := NewMemStore()
+	bead, err := store.Create(Bead{Title: "ready"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	ctx := &countingErrContext{Context: context.Background()}
+
+	store.mu.Lock()
+	rows, err := store.readyLocked(ctx, ReadyQuery{})
+	store.mu.Unlock()
+	if err != nil {
+		t.Fatalf("readyLocked: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != bead.ID {
+		t.Fatalf("readyLocked rows = %+v, want %s", rows, bead.ID)
+	}
+	if checks := ctx.checks.Load(); checks != 0 {
+		t.Fatalf("uncancellable context checks = %d, want 0", checks)
+	}
+}
+
+func TestMemStoreReadyLockedStopsDuringCancellableScan(t *testing.T) {
+	store := NewMemStore()
+	for i := 0; i < 32; i++ {
+		if _, err := store.Create(Bead{Title: fmt.Sprintf("ready-%02d", i)}); err != nil {
+			t.Fatalf("Create bead %d: %v", i, err)
+		}
+	}
+	base, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := &cancelOnErrCheckContext{Context: base, cancel: cancel, cancelAt: 8}
+
+	store.mu.Lock()
+	rows, err := store.readyLocked(ctx, ReadyQuery{})
+	store.mu.Unlock()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("readyLocked error = %v, want context.Canceled (rows = %d)", err, len(rows))
+	}
+	if checks := ctx.checks.Load(); checks < ctx.cancelAt {
+		t.Fatalf("context checks = %d, want at least %d", checks, ctx.cancelAt)
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("context returned cancellation without closing Done")
 	}
 }
 

--- a/internal/beads/ready_context_internal_test.go
+++ b/internal/beads/ready_context_internal_test.go
@@ -1,0 +1,156 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/testutil"
+)
+
+type observedErrContext struct {
+	context.Context
+	once    sync.Once
+	checked chan struct{}
+}
+
+type cancelAfterChecksContext struct {
+	context.Context
+	cancelAt int64
+	checks   atomic.Int64
+}
+
+func (c *cancelAfterChecksContext) Err() error {
+	if c.checks.Add(1) >= c.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestCachingStoreCountContextCancelsWhileWaitingForLock(t *testing.T) {
+	store := NewCachingStoreForTest(NewMemStore(), nil)
+	store.mu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			store.mu.Unlock()
+		}
+	}()
+
+	base, cancel := context.WithCancel(context.Background())
+	ctx := &observedErrContext{Context: base, checked: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() {
+		_, err := store.Count(ctx, ListQuery{Status: "open"})
+		done <- err
+	}()
+
+	select {
+	case <-ctx.checked:
+	case <-time.After(testutil.GoroutineRaceTimeout):
+		store.mu.Unlock()
+		locked = false
+		select {
+		case <-done:
+		case <-time.After(testutil.GoroutineRaceTimeout):
+		}
+		t.Fatal("Count did not check context before waiting for the cache lock")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Count error = %v, want context.Canceled", err)
+		}
+	case <-time.After(testutil.GoroutineRaceTimeout):
+		store.mu.Unlock()
+		locked = false
+		select {
+		case <-done:
+		case <-time.After(testutil.GoroutineRaceTimeout):
+		}
+		t.Fatal("Count waited for the cache lock after context cancellation")
+	}
+}
+
+func TestSortBeadsReadyOrderContextStopsAfterCancellation(t *testing.T) {
+	rows := make([]Bead, 128)
+	for i := range rows {
+		priority := len(rows) - i
+		rows[i] = Bead{ID: fmt.Sprintf("gc-%03d", i), Priority: &priority}
+	}
+	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 8}
+
+	err := sortBeadsReadyOrderContext(ctx, rows)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sortBeadsReadyOrderContext error = %v, want context.Canceled", err)
+	}
+}
+
+func (c *observedErrContext) Err() error {
+	err := c.Context.Err()
+	c.once.Do(func() { close(c.checked) })
+	return err
+}
+
+func TestMemStoreReadyContextCancelsWhileWaitingForLock(t *testing.T) {
+	store := NewMemStore()
+	store.mu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			store.mu.Unlock()
+		}
+	}()
+
+	base, cancel := context.WithCancel(context.Background())
+	ctx := &observedErrContext{Context: base, checked: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() {
+		_, err := store.ReadyContext(ctx)
+		done <- err
+	}()
+	select {
+	case <-ctx.checked: // the first pre-lock context check observed an active context
+	case <-time.After(testutil.GoroutineRaceTimeout):
+		store.mu.Unlock()
+		locked = false
+		select {
+		case <-done:
+		case <-time.After(testutil.GoroutineRaceTimeout):
+		}
+		t.Fatal("ReadyContext did not check context before waiting for the lock")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ReadyContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(testutil.GoroutineRaceTimeout):
+		store.mu.Unlock()
+		locked = false
+		select {
+		case <-done:
+		case <-time.After(testutil.GoroutineRaceTimeout):
+		}
+		t.Fatal("ReadyContext waited for the lock after context cancellation")
+	}
+}
+
+func TestFileStoreReadyContextReportsUnsupported(t *testing.T) {
+	store := &FileStore{MemStore: NewMemStore()}
+	rows, err := store.ReadyContext(context.Background())
+	if !errors.Is(err, ErrReadyContextUnsupported) {
+		t.Fatalf("ReadyContext error = %v, want ErrReadyContextUnsupported", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("ReadyContext rows = %+v, want none for context-blind file refresh", rows)
+	}
+}


### PR DESCRIPTION
## Summary

- Derive `/status` `work.ready` from the same canonical Ready projection as `/beads/ready`, federating the city store and rigs, excluding the city alias, and deduplicating IDs globally.
- Preserve the existing persisted `open` and `in_progress` Counter/List semantics and retain successful partial results when sibling reads fail or time out.
- Add cancellation-aware, cache-first Ready reads that require a live, clean, dependency-complete cache; only capability-unsupported stores fall back to a context-bound scoped bd clone, with policy tier behavior and cleanup preserved.

Coordination classification and split-store changes remain intentionally out of scope.

## Testing

- [x] `make test-fast-parallel` (post-rebase and repository pre-push runs; all eight jobs passed)
- [x] `go test -count=1 ./internal/beads ./internal/api`
- [x] Focused `cmd/gc` policy/scoped-store regressions
- [x] Focused race tests for status, cache, Ready cancellation, and cleanup paths
- [x] `go vet ./...`
- [x] `make dashboard-check`
- [ ] `make check` — not run as a monolith; its relevant static, package, dashboard, and fast-suite gates were run separately
- [ ] `make check-docs` — not run; no docs, navigation, or links changed
- [ ] `make test-integration` — not run; this corrects a read-only status projection, with scoped child cleanup covered by focused tests

## Review

Three pre-commit Sol council lanes—correctness/API semantics, concurrency/performance, and test non-vacuity—reported no P0/P1 findings. The test lane reported no concrete P2 findings. A post-review rebase preserved the stable patch ID exactly.

## Checklist

- [x] Linked an issue, or explained why one is not needed — focused `origin/main` correctness bug found during the status egress audit
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes — no schema or wire-shape change; this aligns the existing field with canonical Ready semantics
- [x] Called out breaking changes or migration notes — none