### PR TITLE
test: parallelize hermetic Dolt compact scenarios

### DIFF
--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -114,8 +114,21 @@ type compactScriptFixture struct {
 	port          int
 }
 
+const compactScriptTestParallelism = 8
+
+// compactScriptTestSlots bounds real shell fan-out on high-core test hosts.
+var compactScriptTestSlots = make(chan struct{}, compactScriptTestParallelism)
+
+// newCompactScriptFixture runs its hermetic shell scenario in parallel while
+// holding one bounded process slot for the lifetime of the test.
 func newCompactScriptFixture(t *testing.T) compactScriptFixture {
 	t.Helper()
+	t.Parallel()
+	compactScriptTestSlots <- struct{}{}
+	t.Cleanup(func() {
+		<-compactScriptTestSlots
+	})
+
 	root := repoRoot(t)
 	port, cleanup := startReachableTCPListener(t)
 	t.Cleanup(cleanup)


### PR DESCRIPTION
## Why

`examples/bd/dolt` was the fast suite's critical package: 111 compact-script fixture constructions ran serially even though each scenario owns a temporary city, fake binaries, logs, state files, and a unique listener. The focused package took 317.815 seconds.

## What changed

- Mark compact-script scenarios parallel at their shared fixture boundary.
- Bound real shell fan-out to eight concurrent scenarios, independent of host CPU count.
- Release the process slot through `t.Cleanup` for every success and failure path.
- Keep production scripts, assertions, fixtures, and the tagged real-Dolt proof unchanged.

## Results

| Measurement | Before | After |
| --- | ---: | ---: |
| Focused `examples/bd/dolt` package | 317.815s | 81.958s |
| Package improvement | — | 74.2% lower / 3.88x faster |
| Race-enabled package | — | 82.413s |
| Warm `make test-fast-parallel` observation | 422.84s | 262.84s |

A post-rebase/cold-contention run completed successfully in 367.24s. That variance exposed the next critical path—`internal/api` at 191.178s plus cold compilation—so this PR is one measured test-runtime slice, not a claim that every cold run is already below five minutes.

## Verification

- `go test -count=1 ./examples/bd/dolt`
- `go test -count=1 -race ./examples/bd/dolt`
- `make test-fast-parallel`
- focused resource-ledger test
- `go vet ./...`
- `.githooks/pre-commit`
- mandatory pre-push fast suite

Three delegated reviewers unanimously approved the exact staged diff (`36f170e070af328b220c38e8d991b85e85ad7043c84a27df689581857b5c2690`) for isolation, correctness, test-pyramid fit, performance, and maintainability.
