### PR TITLE
feat(reap): actively reap detached nudge pollers on session close and reconcile tick

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2373,6 +2373,79 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		nudgeStalledPoolClaims(cr.sp, cr.cfg, sessStore, stalledPoolBeads, assignedWorkBeads, time.Now(), cr.stdout)
 	}
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.nudge_stalled_pool_claims", phaseStart, nil)
+
+	// Reap detached nudge pollers whose session is gone or long-drained.
+	// Pollers are their own process-group leaders, so session teardown never
+	// reaches them; without this they poll the store every cycle forever.
+	// Skipped on a partial snapshot: an incomplete keep set must not kill
+	// live pollers (a missed reap self-corrects next tick; a wrong kill is
+	// healed only by the next nudge send). bootReconcile skips for parity
+	// with the other deferred boot sweeps.
+	if !bootReconcile && !result.SessionQueryPartial && !result.StoreQueryPartial {
+		phaseStart = time.Now()
+		cr.reapOrphanedNudgePollersTick(sessionBeads)
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.reap_orphaned_nudge_pollers", phaseStart, nil)
+	}
+}
+
+// reapOrphanedNudgePollersTick reaps detached nudge pollers whose owning
+// session is closed/absent from the open session set, or has sat drained past
+// pollerDrainReapGrace. A reaped poller self-heals on demand: the next nudge
+// send to its session re-spawns it via maybeStartNudgePoller.
+func (cr *CityRuntime) reapOrphanedNudgePollersTick(sessionBeads *sessionBeadSnapshot) {
+	if sessionBeads == nil || cr.cityPath == "" {
+		return
+	}
+	now := time.Now()
+	keep := make(map[string]bool)
+	for _, info := range sessionBeads.OpenInfos() {
+		if info.Closed || strings.TrimSpace(info.MetadataState) == string(sessionpkg.BaseStateClosed) {
+			continue
+		}
+		sn := strings.TrimSpace(info.SessionName)
+		if sn == "" {
+			sn = strings.TrimSpace(info.SessionNameMetadata)
+		}
+		if sn == "" {
+			continue
+		}
+		if cr.sessionDrainedPastPollerGrace(info, now) {
+			continue
+		}
+		keep[sn] = true
+	}
+	reaped := reapLiveNudgePollers(cr.cityPath, func(sessionName, _ string) bool {
+		return keep[sessionName]
+	}, cr.stderr)
+	for _, target := range reaped {
+		fmt.Fprintf(cr.stderr, "%s: reaped orphaned nudge poller %s (session closed or drained past grace)\n", cr.logPrefix, target) //nolint:errcheck
+	}
+}
+
+// sessionDrainedPastPollerGrace reports whether info has been drained longer
+// than pollerDrainReapGrace. The in-memory drain clock is preferred; the
+// bead's last-activity timestamp is the durable fallback so long-drained
+// sessions stay covered across controller restarts. Unknown age keeps the
+// poller (conservative).
+func (cr *CityRuntime) sessionDrainedPastPollerGrace(info sessionpkg.Info, now time.Time) bool {
+	drained := strings.TrimSpace(info.MetadataState) == string(sessionpkg.BaseStateDrained) ||
+		strings.TrimSpace(info.SleepReason) == "drained"
+	if !drained {
+		return false
+	}
+	if cr.sessionDrains != nil {
+		if ds := cr.sessionDrains.get(info.ID); ds != nil {
+			return now.Sub(ds.startedAt) > pollerDrainReapGrace
+		}
+	}
+	since := info.LastActive
+	if since.IsZero() {
+		since = info.CreatedAt
+	}
+	if since.IsZero() {
+		return false
+	}
+	return now.Sub(since) > pollerDrainReapGrace
 }
 
 // recordReconcileTraceInputs records the per-template baseline, the cycle input

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1800,6 +1800,18 @@ func cmdSessionClose(args []string, stdout, stderr io.Writer, jsonOutput ...bool
 	}
 	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, closedSessionBead, "", stderr)
 
+	// Reap the closed session's detached nudge pollers immediately. They are
+	// their own process-group leaders (Setpgid at spawn), so the runtime
+	// teardown above structurally never signals them — left alone they keep
+	// polling the store every cycle forever. The reconcile tick has the same
+	// reap as a backstop; doing it here means close takes effect now.
+	if cityErr == nil {
+		closedName := strings.TrimSpace(closedSessionBead.Metadata["session_name"])
+		for _, target := range reapNudgePollersForClosedSession(cityPath, closedName, stderr) {
+			fmt.Fprintf(stderr, "gc session close: reaped nudge poller %s\n", target) //nolint:errcheck // best-effort stderr
+		}
+	}
+
 	if asJSON {
 		if err := writeSessionActionJSON(stdout, sessionActionResult{
 			Action:              "close",

--- a/cmd/gc/nudge_poller_reap.go
+++ b/cmd/gc/nudge_poller_reap.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/nudgepoller"
+	"github.com/gastownhall/gascity/internal/pidutil"
+)
+
+// Nudge pollers are spawned as their own process-group leaders (Setpgid in
+// ensureSessionSubmitPoller/ensureNudgePoller) and released, so session
+// teardown — which signals the session's process group — structurally never
+// reaches them. Without an active reap they outlive their session and keep
+// polling the store every cycle forever. reapLiveNudgePollers is that reap:
+// unlike reapStaleNudgePollers (dead-pidfile cleanup only), it signals live,
+// identity-verified pollers whose target the caller no longer wants polled.
+// A reaped target self-heals: the next nudge send to that session re-spawns
+// its poller via maybeStartNudgePoller.
+
+// pollerDrainReapGrace is how long a session may sit drained before the
+// reconcile tick considers its nudge poller orphaned and reaps it.
+const pollerDrainReapGrace = 15 * time.Minute
+
+// pollerReapKillWait is how long a reap waits after SIGTERM before SIGKILL.
+const pollerReapKillWait = 2 * time.Second
+
+// reapLiveNudgePollers scans the city's poller pidfiles and reaps every live
+// poller whose (sessionName, agentName) target keep() rejects. Dead or
+// unparseable pidfiles are removed exactly like reapStaleNudgePollers. A live
+// PID is only ever signalled after its own argv has been identity-verified as
+// a nudge poller for this city AND the pidfile has been confirmed to be the
+// stem for that argv's target — a recycled PID can never be killed by mistake.
+// Best-effort: per-file errors are reported to stderr and do not abort the
+// sweep. Returns the reaped "session/agent" targets.
+func reapLiveNudgePollers(cityPath string, keep func(sessionName, agentName string) bool, stderr io.Writer) []string {
+	pollersDir := citylayout.RuntimePath(cityPath, "nudges", "pollers")
+	entries, err := os.ReadDir(pollersDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "reapLiveNudgePollers: %v\n", err) //nolint:errcheck // best-effort stderr
+		return nil
+	}
+	var reaped []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pid") {
+			continue
+		}
+		pidPath := filepath.Join(pollersDir, entry.Name())
+		target, err := reapLiveNudgePollerPIDFile(pidPath, cityPath, keep)
+		if err != nil {
+			fmt.Fprintf(stderr, "reapLiveNudgePollers: %s: %v\n", entry.Name(), err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		if target != "" {
+			reaped = append(reaped, target)
+		}
+	}
+	return reaped
+}
+
+// reapLiveNudgePollerPIDFile handles a single pidfile under the same per-file
+// lock the lease path uses, so it cannot race a concurrently starting poller.
+// It returns the reaped "session/agent" target, or "" when nothing was killed.
+func reapLiveNudgePollerPIDFile(pidPath, cityPath string, keep func(sessionName, agentName string) bool) (string, error) {
+	var reapedTarget string
+	err := withNudgePollerPIDLock(pidPath, func() error {
+		data, err := os.ReadFile(pidPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read nudge poller pid %q: %w", pidPath, err)
+		}
+		var pid int
+		if n, parseErr := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &pid); parseErr != nil || n != 1 || pid <= 0 {
+			return removeNudgePollerPIDFile(pidPath)
+		}
+		argv, cmdErr := pidutil.Cmdline(pid)
+		if cmdErr != nil || len(argv) == 0 {
+			if !pidutil.Alive(pid) {
+				return removeNudgePollerPIDFile(pidPath)
+			}
+			// Alive but cmdline unreadable: identity cannot be verified, so
+			// the PID must not be signalled. Leave it for a later pass.
+			return nil
+		}
+		sessionName, agentName, ok := nudgepoller.TargetFromArgv(cityPath, argv)
+		if !ok {
+			// Live PID that is not a poller for this city — the pidfile is a
+			// leftover pointing at a recycled PID. Remove the file, never the
+			// process.
+			return removeNudgePollerPIDFile(pidPath)
+		}
+		// Ownership check: this pidfile must be the stem for the target the
+		// process itself claims via argv. A mismatch means the file describes
+		// some other tuple; leave both alone.
+		if nudgePollerPIDPath(cityPath, sessionName, agentName) != pidPath {
+			return nil
+		}
+		if keep(sessionName, agentName) {
+			return nil
+		}
+		matcher := nudgepoller.CmdlineMatcher(cityPath, sessionName, agentName)
+		_ = syscall.Kill(pid, syscall.SIGTERM) //nolint:errcheck // re-checked below
+		deadline := time.Now().Add(pollerReapKillWait)
+		for time.Now().Before(deadline) && pidutil.AliveWithCmdline(pid, matcher) {
+			time.Sleep(50 * time.Millisecond)
+		}
+		if pidutil.AliveWithCmdline(pid, matcher) {
+			_ = syscall.Kill(pid, syscall.SIGKILL) //nolint:errcheck // best-effort escalation
+		}
+		reapedTarget = sessionName + "/" + agentName
+		return removeNudgePollerPIDFile(pidPath)
+	})
+	return reapedTarget, err
+}
+
+// removeNudgePollerPIDFile removes ONLY the .pid file. The sibling .pid.lock
+// is deliberately left in place — it is the stable per-key flock mutex inode
+// (see reapStaleNudgePoller for why removing it would break mutual exclusion).
+func removeNudgePollerPIDFile(pidPath string) error {
+	if err := os.Remove(pidPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove nudge poller pid %q: %w", pidPath, err)
+	}
+	return nil
+}
+
+// reapNudgePollersForClosedSession reaps every live poller polling for the
+// given (now closed) session name. Used by the session close path so the reap
+// takes effect immediately instead of waiting for the next reconcile tick.
+func reapNudgePollersForClosedSession(cityPath, closedSessionName string, stderr io.Writer) []string {
+	closedSessionName = strings.TrimSpace(closedSessionName)
+	if cityPath == "" || closedSessionName == "" {
+		return nil
+	}
+	return reapLiveNudgePollers(cityPath, func(sessionName, _ string) bool {
+		return sessionName != closedSessionName
+	}, stderr)
+}

--- a/cmd/gc/nudge_poller_reap_test.go
+++ b/cmd/gc/nudge_poller_reap_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/pidutil"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// TestHelperProcessNudgePollerHang is not a real test: it is exec'd by the
+// reap tests as a stand-in nudge poller. Its argv tail carries the real
+// poller command shape ("nudge poll --city ... --session ... <agent>") so
+// pidutil.Cmdline-based identity checks see a genuine poller cmdline. It
+// hangs until killed.
+func TestHelperProcessNudgePollerHang(_ *testing.T) {
+	if os.Getenv("GO_WANT_NUDGE_POLLER_HELPER") != "1" {
+		return
+	}
+	time.Sleep(5 * time.Minute)
+	os.Exit(0)
+}
+
+// spawnFakePoller launches a helper process whose cmdline matches a nudge
+// poller for (cityPath, sessionName, agentName) and writes its pidfile the
+// way acquireNudgePollerLease would. Returns the PID.
+func spawnFakePoller(t *testing.T, cityPath, sessionName, agentName string) int {
+	t.Helper()
+	cmd := exec.Command(os.Args[0],
+		"-test.run=TestHelperProcessNudgePollerHang", "--",
+		"nudge", "poll", "--city", cityPath, "--session", sessionName, agentName)
+	cmd.Env = append(os.Environ(), "GO_WANT_NUDGE_POLLER_HELPER=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake poller: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	// Reap the child on exit so the kill assertions below see a dead process,
+	// not a zombie parked on our un-Wait()ed handle.
+	go func() { _, _ = cmd.Process.Wait() }()
+
+	pidPath := nudgePollerPIDPath(cityPath, sessionName, agentName)
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("mkdir pollers dir: %v", err)
+	}
+	if err := writeNudgePollerPID(pidPath, pid); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+	// The helper's argv must actually pass the matcher before the test
+	// proceeds, or a slow exec would make the reap see an unverifiable PID.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if argv, err := pidutil.Cmdline(pid); err == nil && len(argv) > 0 {
+			return pid
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("fake poller cmdline never became readable")
+	return 0
+}
+
+func waitForDeath(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !pidutil.Alive(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pid %d still alive after reap", pid)
+}
+
+func TestReapLiveNudgePollersKillsRejectedTarget(t *testing.T) {
+	cityPath := t.TempDir()
+	pid := spawnFakePoller(t, cityPath, "dead-session", "agent-1")
+
+	reaped := reapLiveNudgePollers(cityPath, func(sessionName, _ string) bool {
+		return sessionName != "dead-session"
+	}, os.Stderr)
+
+	if len(reaped) != 1 || reaped[0] != "dead-session/agent-1" {
+		t.Fatalf("reaped = %v, want [dead-session/agent-1]", reaped)
+	}
+	waitForDeath(t, pid)
+	pidPath := nudgePollerPIDPath(cityPath, "dead-session", "agent-1")
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("pidfile still present after reap: %v", err)
+	}
+}
+
+func TestReapLiveNudgePollersKeepsAcceptedTarget(t *testing.T) {
+	cityPath := t.TempDir()
+	pid := spawnFakePoller(t, cityPath, "live-session", "agent-1")
+
+	reaped := reapLiveNudgePollers(cityPath, func(string, string) bool { return true }, os.Stderr)
+
+	if len(reaped) != 0 {
+		t.Fatalf("reaped = %v, want none", reaped)
+	}
+	if !pidutil.Alive(pid) {
+		t.Fatalf("kept poller was killed")
+	}
+	pidPath := nudgePollerPIDPath(cityPath, "live-session", "agent-1")
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("kept poller's pidfile removed: %v", err)
+	}
+}
+
+func TestReapLiveNudgePollersCleansDeadPIDFile(t *testing.T) {
+	cityPath := t.TempDir()
+	// Spawn and immediately kill so the pidfile points at a dead PID.
+	pid := spawnFakePoller(t, cityPath, "gone-session", "agent-1")
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	waitForDeath(t, pid)
+
+	reaped := reapLiveNudgePollers(cityPath, func(string, string) bool { return false }, os.Stderr)
+
+	if len(reaped) != 0 {
+		t.Fatalf("reaped = %v, want none (dead pid is cleanup, not a reap)", reaped)
+	}
+	pidPath := nudgePollerPIDPath(cityPath, "gone-session", "agent-1")
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("dead pidfile not cleaned: %v", err)
+	}
+}
+
+func TestReapLiveNudgePollersLeavesForeignLivePIDAlone(t *testing.T) {
+	cityPath := t.TempDir()
+	// A pidfile pointing at a live process that is NOT a poller for this
+	// city (this test process): the file goes, the process stays.
+	pidPath := nudgePollerPIDPath(cityPath, "recycled-session", "agent-1")
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writeNudgePollerPID(pidPath, os.Getpid()); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+
+	reaped := reapLiveNudgePollers(cityPath, func(string, string) bool { return false }, os.Stderr)
+
+	if len(reaped) != 0 {
+		t.Fatalf("reaped = %v, want none", reaped)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("stale pidfile for recycled PID not removed: %v", err)
+	}
+}
+
+func TestReapNudgePollersForClosedSessionScopesToSession(t *testing.T) {
+	cityPath := t.TempDir()
+	closedPID := spawnFakePoller(t, cityPath, "closing-session", "agent-1")
+	livePID := spawnFakePoller(t, cityPath, "other-session", "agent-2")
+
+	reaped := reapNudgePollersForClosedSession(cityPath, "closing-session", os.Stderr)
+
+	if len(reaped) != 1 || reaped[0] != "closing-session/agent-1" {
+		t.Fatalf("reaped = %v, want [closing-session/agent-1]", reaped)
+	}
+	waitForDeath(t, closedPID)
+	if !pidutil.Alive(livePID) {
+		t.Fatalf("unrelated session's poller was killed")
+	}
+	if got := reapNudgePollersForClosedSession(cityPath, "", os.Stderr); got != nil {
+		t.Fatalf("empty session name must be a no-op, got %v", got)
+	}
+}
+
+func TestSessionDrainedPastPollerGraceFallsBackToLastActive(t *testing.T) {
+	cr := &CityRuntime{sessionDrains: newDrainTracker()}
+	now := time.Now()
+
+	mk := func(state, sleepReason string, lastActive time.Time) sessionpkg.Info {
+		return sessionpkg.Info{MetadataState: state, SleepReason: sleepReason, LastActive: lastActive}
+	}
+	cases := []struct {
+		name string
+		in   sessionpkg.Info
+		want bool
+	}{
+		{"active session never reaped", mk("active", "", now.Add(-24*time.Hour)), false},
+		{"freshly drained kept", mk("drained", "", now.Add(-time.Minute)), false},
+		{"long drained reaped", mk("drained", "", now.Add(-time.Hour)), true},
+		{"sleep-reason drained reaped", mk("asleep", "drained", now.Add(-time.Hour)), true},
+		{"unknown age kept", mk("drained", "", time.Time{}), false},
+	}
+	for _, tc := range cases {
+		if got := cr.sessionDrainedPastPollerGrace(tc.in, now); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+
+	// In-memory drain clock takes precedence over LastActive.
+	info := mk("drained", "", now.Add(-time.Hour))
+	info.ID = "gc-wisp-test"
+	cr.sessionDrains.set("gc-wisp-test", &drainState{startedAt: now.Add(-time.Minute)})
+	if cr.sessionDrainedPastPollerGrace(info, now) {
+		t.Errorf("fresh in-memory drain clock must outrank stale LastActive")
+	}
+	cr.sessionDrains.set("gc-wisp-test", &drainState{startedAt: now.Add(-time.Hour)})
+	if !cr.sessionDrainedPastPollerGrace(info, now) {
+		t.Errorf("old in-memory drain clock must trigger the reap grace")
+	}
+}
+

--- a/internal/nudgepoller/poller.go
+++ b/internal/nudgepoller/poller.go
@@ -43,6 +43,13 @@ func CmdlineMatcher(cityPath, sessionName, agentName string) func([]string) bool
 }
 
 func argvHasPollTarget(argv []string, expected string) bool {
+	return pollTargetFromArgv(argv) == expected && expected != ""
+}
+
+// pollTargetFromArgv returns the positional poll target of a nudge poller
+// argv, or "" when argv is not a poller command / carries no target. Flag
+// skipping mirrors argvHasPollTarget's historical rules exactly.
+func pollTargetFromArgv(argv []string) string {
 	for i := 0; i+1 < len(argv); i++ {
 		if argv[i] != "nudge" || argv[i+1] != "poll" {
 			continue
@@ -61,12 +68,36 @@ func argvHasPollTarget(argv []string, expected string) bool {
 					j++
 				}
 			default:
-				return arg == expected
+				return arg
 			}
 		}
-		return false
+		return ""
 	}
-	return false
+	return ""
+}
+
+// TargetFromArgv extracts the (sessionName, agentName) tuple a nudge poller
+// argv is polling for, returning ok=false unless argv is a well-formed poller
+// command for cityPath. The extracted tuple is validated back through
+// CmdlineMatcher, so a true result carries exactly the same identity guarantee
+// the matcher gives: reapers can trust it before signalling the PID.
+func TargetFromArgv(cityPath string, argv []string) (sessionName, agentName string, ok bool) {
+	for i := 0; i < len(argv); i++ {
+		switch {
+		case argv[i] == sessionFlag && i+1 < len(argv):
+			sessionName = argv[i+1]
+		case strings.HasPrefix(argv[i], sessionFlag+"="):
+			sessionName = strings.TrimPrefix(argv[i], sessionFlag+"=")
+		}
+	}
+	agentName = pollTargetFromArgv(argv)
+	if strings.TrimSpace(sessionName) == "" || strings.TrimSpace(agentName) == "" {
+		return "", "", false
+	}
+	if !CmdlineMatcher(cityPath, sessionName, agentName)(argv) {
+		return "", "", false
+	}
+	return sessionName, agentName, true
 }
 
 // PollerFileStem returns the filesystem-safe stem for poller PID and log

--- a/internal/nudgepoller/target_from_argv_test.go
+++ b/internal/nudgepoller/target_from_argv_test.go
@@ -1,0 +1,41 @@
+package nudgepoller
+
+import "testing"
+
+func TestTargetFromArgv(t *testing.T) {
+	city := "/tmp/city"
+	cases := []struct {
+		name        string
+		argv        []string
+		wantSession string
+		wantAgent   string
+		wantOK      bool
+	}{
+		{
+			"canonical poller argv",
+			append([]string{"gc"}, CommandArgs(city, "s-gc-wisp-abc", "gc-wisp-abc")...),
+			"s-gc-wisp-abc", "gc-wisp-abc", true,
+		},
+		{
+			"equals-form flags",
+			[]string{"gc", "nudge", "poll", "--city=" + city, "--session=mayor", "gc-wisp-wdg"},
+			"mayor", "gc-wisp-wdg", true,
+		},
+		{
+			"test-binary prefix still matches",
+			[]string{"gc.test", "-test.run=TestHelper", "--", "nudge", "poll", "--city", city, "--session", "s1", "agent1"},
+			"s1", "agent1", true,
+		},
+		{"wrong city", append([]string{"gc"}, CommandArgs("/tmp/other", "s1", "a1")...), "", "", false},
+		{"not a poller", []string{"gc", "mail", "check", "s1"}, "", "", false},
+		{"missing target", []string{"gc", "nudge", "poll", "--city", city, "--session", "s1"}, "", "", false},
+		{"empty argv", nil, "", "", false},
+	}
+	for _, tc := range cases {
+		gotSession, gotAgent, gotOK := TargetFromArgv(city, tc.argv)
+		if gotSession != tc.wantSession || gotAgent != tc.wantAgent || gotOK != tc.wantOK {
+			t.Errorf("%s: TargetFromArgv() = (%q, %q, %v), want (%q, %q, %v)",
+				tc.name, gotSession, gotAgent, gotOK, tc.wantSession, tc.wantAgent, tc.wantOK)
+		}
+	}
+}

--- a/internal/pidutil/cmdline_darwin.go
+++ b/internal/pidutil/cmdline_darwin.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package pidutil
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// platformCmdline reads a PID's argv on macOS via the kern.procargs2 sysctl —
+// the darwin equivalent of /proc/<pid>/cmdline. The raw buffer layout is:
+// int32 argc, exec_path NUL-terminated, NUL padding, then argc NUL-terminated
+// argv strings. Reads are limited to same-UID processes; a refused read
+// surfaces as an error and callers decide how to degrade.
+func platformCmdline(pid int) (argv []string, err error, handled bool) {
+	raw, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return nil, fmt.Errorf("kern.procargs2 for pid %d: %w", pid, err), true
+	}
+	if len(raw) < 4 {
+		return nil, fmt.Errorf("kern.procargs2 for pid %d: short read (%d bytes)", pid, len(raw)), true
+	}
+	argc := int(binary.LittleEndian.Uint32(raw[:4]))
+	if argc <= 0 {
+		return nil, fmt.Errorf("kern.procargs2 for pid %d: argc %d", pid, argc), true
+	}
+	rest := raw[4:]
+	// Skip exec_path and its NUL padding to reach argv[0].
+	execEnd := bytes.IndexByte(rest, 0)
+	if execEnd < 0 {
+		return nil, fmt.Errorf("kern.procargs2 for pid %d: unterminated exec path", pid), true
+	}
+	rest = rest[execEnd:]
+	for len(rest) > 0 && rest[0] == 0 {
+		rest = rest[1:]
+	}
+	out := make([]string, 0, argc)
+	for len(out) < argc && len(rest) > 0 {
+		end := bytes.IndexByte(rest, 0)
+		if end < 0 {
+			out = append(out, string(rest))
+			rest = nil
+			break
+		}
+		out = append(out, string(rest[:end]))
+		rest = rest[end+1:]
+	}
+	if len(out) < argc {
+		return nil, fmt.Errorf("kern.procargs2 for pid %d: truncated argv (%d of %d)", pid, len(out), argc), true
+	}
+	return NormalizeArgv(out), nil, true
+}

--- a/internal/pidutil/cmdline_other.go
+++ b/internal/pidutil/cmdline_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package pidutil
+
+// platformCmdline reports handled=false on platforms without a native argv
+// read; Cmdline then falls through to the /proc path.
+func platformCmdline(int) (argv []string, err error, handled bool) {
+	return nil, nil, false
+}

--- a/internal/pidutil/pidutil.go
+++ b/internal/pidutil/pidutil.go
@@ -109,14 +109,25 @@ func AliveWithCmdline(pid int, match func([]string) bool) bool {
 	if match == nil {
 		return false
 	}
-	if runtime.GOOS != "linux" {
+	switch runtime.GOOS {
+	case "linux":
+		argv, err := Cmdline(pid)
+		if err != nil {
+			return false
+		}
+		return match(argv)
+	case "darwin":
+		// kern.procargs2 gives real argv for same-UID processes. A refused
+		// read (foreign UID, racing exit) preserves the historical darwin
+		// degradation: alive counts as matching.
+		argv, err := Cmdline(pid)
+		if err != nil {
+			return true
+		}
+		return match(argv)
+	default:
 		return true
 	}
-	argv, err := Cmdline(pid)
-	if err != nil {
-		return false
-	}
-	return match(argv)
 }
 
 // ArgvContainsSequence reports whether argv contains seq contiguously.
@@ -159,10 +170,13 @@ func ArgvHasFlagValue(argv []string, flag, value string) bool {
 	return false
 }
 
-// Cmdline returns a PID's command line from /proc, normalized through
-// NormalizeArgv. It returns an error on hosts without /proc cmdline support
-// or when the process record is unreadable.
+// Cmdline returns a PID's command line, normalized through NormalizeArgv:
+// from kern.procargs2 on darwin, from /proc elsewhere. It returns an error on
+// hosts without either mechanism or when the process record is unreadable.
 func Cmdline(pid int) ([]string, error) {
+	if argv, err, handled := platformCmdline(pid); handled {
+		return argv, err
+	}
 	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

Nudge pollers are spawned as their own process-group leaders (`Setpgid` in `ensureSessionSubmitPoller`/`ensureNudgePoller`) and `Release()`'d, so session teardown — which signals the **session's** process group (`processgroup.Terminate`) — structurally never reaches them. They outlive their session and keep opening the store every poll cycle forever. The only existing 'reap' (`reapStaleNudgePollers`) removes pidfiles of already-dead PIDs and runs only on poller spawn; neither `gc session close` nor the drain path nor the reconcile loop touches a live orphan.

Observed in a production city (macOS host, dolt-backed store): a session that sat drained for ~20h kept its poller alive and polling; N leaked pollers serialized on the per-database migration GET_LOCK and materially degraded the shared store (see also beads #4804).

## Fix

- `internal/nudgepoller.TargetFromArgv`: extract + matcher-validate the (session, agent) tuple from a live poller argv, so reapers can trust identity before signalling.
- `reapLiveNudgePollers`: pidfile sweep under the existing per-file flock; identity-verified SIGTERM (SIGKILL after 2s); dead-pidfile cleanup preserved; a live non-poller PID loses its stale pidfile but is never signalled. Reaped targets self-heal via `maybeStartNudgePoller` on the next nudge send.
- `gc session close` reaps its session's pollers synchronously.
- `beadReconcileTick` reaps pollers for closed/absent sessions and for sessions drained past a 15m grace (drainTracker clock, `LastActive` as the durable fallback across controller restarts). Skipped on partial snapshots so an incomplete keep set can never kill live pollers.

## Latent bug found on the way

`pidutil.Cmdline` was /proc-only and `AliveWithCmdline` **degraded to plain `Alive()` on non-Linux** — on darwin every cmdline identity check in gc was a tautology: any live PID 'matched'. This PR adds `kern.procargs2`-based argv reads for darwin; `AliveWithCmdline` now matches real argv there, degrading only when the kernel refuses the read (foreign-UID PID, racing exit).

## Tests

Real-process kill-path tests (helper-process pattern): rejected target killed + pidfile removed; accepted target untouched; dead pidfile cleaned without a 'reap'; live non-poller PID keeps running while its stale pidfile is removed; close-path reap scopes to its session; drain-grace clock precedence (in-memory over LastActive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)