### PR TITLE
test: keep Codex transcript fixtures off host history

### DIFF
--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -902,15 +902,23 @@ func TestHandleSessionListUsesCachedSessionBeadsWhenAvailable(t *testing.T) {
 	}
 }
 
-func TestHandleSessionListSkipsWorkdirOnlyCodexTranscriptDiscovery(t *testing.T) {
-	fs := newSessionFakeState(t)
+// newHermeticCodexSessionSearchPath keeps Codex's always-merged default root
+// inside test-owned HOME while preserving a separate configured search path.
+func newHermeticCodexSessionSearchPath(t *testing.T) string {
+	t.Helper()
+
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("GC_HOME", filepath.Join(home, ".gc"))
 	if err := os.MkdirAll(filepath.Join(home, ".codex", "sessions"), 0o755); err != nil {
 		t.Fatalf("MkdirAll default codex sessions: %v", err)
 	}
-	searchBase := t.TempDir()
+	return t.TempDir()
+}
+
+func TestHandleSessionListSkipsWorkdirOnlyCodexTranscriptDiscovery(t *testing.T) {
+	fs := newSessionFakeState(t)
+	searchBase := newHermeticCodexSessionSearchPath(t)
 	srv := New(fs)
 	srv.sessionLogSearchPaths = []string{searchBase}
 	h := newTestCityHandlerWith(t, fs, srv)
@@ -960,13 +968,7 @@ func TestHandleSessionListSkipsWorkdirOnlyCodexTranscriptDiscovery(t *testing.T)
 
 func TestHandleSessionGetAllowsWorkdirOnlyCodexTranscriptDiscovery(t *testing.T) {
 	fs := newSessionFakeState(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("GC_HOME", filepath.Join(home, ".gc"))
-	if err := os.MkdirAll(filepath.Join(home, ".codex", "sessions"), 0o755); err != nil {
-		t.Fatalf("MkdirAll default codex sessions: %v", err)
-	}
-	searchBase := t.TempDir()
+	searchBase := newHermeticCodexSessionSearchPath(t)
 	srv := New(fs)
 	srv.sessionLogSearchPaths = []string{searchBase}
 	h := newTestCityHandlerWith(t, fs, srv)
@@ -6999,7 +7001,7 @@ func TestHandleSessionTranscriptRawIncludesAllTypes(t *testing.T) {
 
 func TestHandleSessionTranscriptRawIncludesCodexCustomToolCalls(t *testing.T) {
 	fs := newSessionFakeState(t)
-	searchBase := t.TempDir()
+	searchBase := newHermeticCodexSessionSearchPath(t)
 	srv := New(fs)
 	h := newTestCityHandlerWith(t, fs, srv)
 	_ = h
@@ -7063,7 +7065,7 @@ func TestHandleSessionTranscriptRawIncludesCodexCustomToolCalls(t *testing.T) {
 
 func TestHandleSessionTranscriptConversationIncludesCodexErrorFrame(t *testing.T) {
 	fs := newSessionFakeState(t)
-	searchBase := t.TempDir()
+	searchBase := newHermeticCodexSessionSearchPath(t)
 	srv := New(fs)
 	h := newTestCityHandlerWith(t, fs, srv)
 	_ = h
@@ -7121,7 +7123,7 @@ func TestHandleSessionTranscriptConversationIncludesCodexErrorFrame(t *testing.T
 
 func TestHandleSessionStreamConversationIncludesCodexErrorFrame(t *testing.T) {
 	fs := newSessionFakeState(t)
-	searchBase := t.TempDir()
+	searchBase := newHermeticCodexSessionSearchPath(t)
 	srv := New(fs)
 	srv.sessionLogSearchPaths = []string{searchBase}
 


### PR DESCRIPTION
## Summary

- Add one shared hermetic Codex session-path fixture for API tests.
- Redirect the always-merged default `HOME/.codex/sessions` root into test-owned storage.
- Preserve a distinct configured search path and every existing HTTP, transcript, parser, and SSE assertion.
- Leave production discovery behavior, timeouts, and coverage unchanged.

## Root cause

Codex transcript discovery intentionally merges the default session root with configured search paths. Three API fixtures supplied a temporary configured root but inherited the real host default. On this shared host that meant scanning an 814 MB tree with 6,250 rollout files and eight account symlinks. The stream request had a 500 ms context timeout, but synchronous filesystem discovery could not observe that cancellation and consumed 146 seconds.

## Measurements

| Scope | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Stream error-frame test body | 146.17s | 0.50s | 99.7% lower; 292x faster |
| `internal/api` package | 215.381s | 70.301s | 67.4% lower; 3.06x faster |
| Machine-aware fast suite sample | 367.24s | 247.48s | 32.6% lower; 1.48x faster |

The broad fast-suite sample is now 4m07s, leaving about 52 seconds of margin under the five-minute feedback target. It is one observed sample, not a p95 claim.

## Validation

- All five Codex API fixtures: 0.695s
- Focused Codex API fixtures with `-race`: pass
- Full `internal/api`: pass
- Resource-census policy: pass
- CI topology policy: pass
- `go vet ./...`: pass
- `make test-fast-parallel`: pass in 247.48s
- Active pre-commit and pre-push hooks: pass
- Three-reviewer delegated council: unanimous approval of staged SHA-256 `6b88a769c1b094baa405adda851a136ef7ede09e43d58258a57f1a8af9f45e34`

## Non-goals

- No production transcript-search semantic changes.
- No skipped assertions, shortened waits, or timeout masking.
- No real provider or end-to-end coverage moved into the fast lane.

Tracking: `ga-80po0c.8`.