### PR TITLE
test: make pre-push concurrency machine-aware

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,13 +2,11 @@
 set -euo pipefail
 
 # Heavy `go test` fan-out runs here, at push time, instead of on every commit
-# (#3628). pre-commit was invoking `make test-fast-parallel`, whose
-# `xargs -P<nproc>` runner compiles ~2.8 GB test binaries per shard — on an
-# N-core host that is N concurrent compiles (~17 GB pressure, load >100,
-# I/O/compile storms and occasional livelocks on WSL) on EVERY commit.
-# GOFLAGS=-p=2 bounds build parallelism within one `go test` but not the outer
-# fan-out. Running the suite at push time fires it far less often, and only when
-# Go sources actually change.
+# (#3628). pre-commit previously invoked `make test-fast-parallel` on every
+# commit. Its outer shard fan-out can compile ~2.8 GiB test binaries per job,
+# so the canonical runner now derives concurrency from both CPU and available
+# memory while preserving an explicit LOCAL_TEST_JOBS override. Running the
+# suite at push time also fires it only when Go sources actually change.
 #
 # git feeds "<local ref> <local sha> <remote ref> <remote sha>" per pushed ref
 # on stdin (see githooks(5)).
@@ -35,7 +33,6 @@ if [ "$go_changed" -eq 0 ]; then
   exit 0
 fi
 
-# Bound the local fan-out by default so the suite stays friendly on developer
-# machines; an explicit LOCAL_TEST_JOBS (and CI's Makefile default) still wins.
-export LOCAL_TEST_JOBS="${LOCAL_TEST_JOBS:-3}"
+# The Makefile and direct sharded runner share scripts/test-local-job-count as
+# their default policy. Do not shadow it here; an explicit override still wins.
 exec make test-fast-parallel

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ MAC_UNIT_PKGS = $(shell go list ./... | grep -v '/cmd/gc$$')
 test-mac: test-fsys-darwin-compile
 	$(TEST_ENV) GC_FAST_UNIT=1 scripts/go-test-observable test-mac -- -p=4 -count=1 -timeout 15m $(MAC_UNIT_PKGS)
 
-LOCAL_TEST_JOBS ?= $(shell nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
+LOCAL_TEST_JOBS ?= $(shell ./scripts/test-local-job-count)
 
 ## test-fast-parallel: run the default fast suite with cmd/gc sharded locally
 test-fast-parallel:

--- a/TESTING.md
+++ b/TESTING.md
@@ -195,7 +195,10 @@ make test-integration-shards-parallel
 make test-local-full-parallel
 ```
 
-On large local machines, tune parallelism explicitly:
+By default, the local runners bound concurrency by both detected CPUs and
+available memory, budgeting 4 GiB per job and capping automatic fan-out at 16.
+If memory cannot be detected, they use three jobs. An explicit override always
+wins:
 
 ```bash
 LOCAL_TEST_JOBS=48 CMD_GC_PROCESS_TOTAL=12 make test-local-full-parallel

--- a/scripts/precommit_contract_test.go
+++ b/scripts/precommit_contract_test.go
@@ -56,20 +56,138 @@ printf '\n'
 	}
 }
 
-func TestTestFastParallelUsesSanitizedEnvironment(t *testing.T) {
+func TestTestFastParallelUsesSanitizedEnvironmentAndMachineAwareConcurrency(t *testing.T) {
 	repoRoot := repoRoot(t)
-	cmd := exec.Command("make", "-n", "test-fast-parallel")
-	cmd.Dir = repoRoot
-	out, err := cmd.CombinedOutput()
+	baseEnv := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "LOCAL_TEST_JOBS=") ||
+			strings.HasPrefix(entry, "GC_TEST_LOCAL_CPUS=") ||
+			strings.HasPrefix(entry, "GC_TEST_LOCAL_MEMORY_KIB=") ||
+			strings.HasPrefix(entry, "GC_TEST_LOCAL_MEMINFO=") ||
+			strings.HasPrefix(entry, "GC_TEST_LOCAL_PROC_CGROUP=") ||
+			strings.HasPrefix(entry, "GC_TEST_LOCAL_CGROUP_ROOT=") {
+			continue
+		}
+		baseEnv = append(baseEnv, entry)
+	}
+	tests := []struct {
+		name      string
+		cpus      string
+		memoryKiB string
+		makeArgs  []string
+		wantJobs  string
+		cgroup    string
+		limit     string
+		current   string
+	}{
+		{name: "large host uses automatic ceiling", cpus: "192", memoryKiB: "536870912", wantJobs: "16"},
+		{name: "memory constrains fanout", cpus: "16", memoryKiB: "12582912", wantJobs: "3"},
+		{name: "cpu constrains fanout", cpus: "2", memoryKiB: "67108864", wantJobs: "2"},
+		{name: "small machine still runs one job", cpus: "8", memoryKiB: "2097152", wantJobs: "1"},
+		{name: "unknown memory preserves safe fallback", cpus: "64", memoryKiB: "0", wantJobs: "3"},
+		{name: "nested cgroup v2 ancestor constrains fanout", cpus: "16", wantJobs: "3", cgroup: "v2", limit: "12884901888", current: "0"},
+		{name: "nested cgroup v1 ancestor constrains fanout", cpus: "16", wantJobs: "2", cgroup: "v1", limit: "8589934592", current: "0"},
+		{name: "hybrid cgroup falls through to v1 memory controller", cpus: "16", wantJobs: "3", cgroup: "hybrid", limit: "12884901888", current: "0"},
+		{name: "exhausted cgroup forces one job", cpus: "16", wantJobs: "1", cgroup: "v2", limit: "4294967296", current: "4294967296"},
+		{name: "explicit override wins", cpus: "192", memoryKiB: "536870912", makeArgs: []string{"LOCAL_TEST_JOBS=7"}, wantJobs: "7"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"-n"}, tt.makeArgs...)
+			args = append(args, "test-fast-parallel")
+			cmd := exec.Command("make", args...)
+			cmd.Dir = repoRoot
+			cmd.Env = append(append([]string(nil), baseEnv...), "GC_TEST_LOCAL_CPUS="+tt.cpus)
+			if tt.memoryKiB != "" {
+				cmd.Env = append(cmd.Env, "GC_TEST_LOCAL_MEMORY_KIB="+tt.memoryKiB)
+			}
+			if tt.cgroup != "" {
+				cmd.Env = append(cmd.Env, localTestCgroupEnv(t, tt.cgroup, tt.limit, tt.current)...)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("make -n test-fast-parallel failed: %v\n%s", err, out)
+			}
+			command := string(out)
+			if !strings.Contains(command, "env -i") {
+				t.Fatalf("test-fast-parallel recipe should use TEST_ENV env -i wrapper:\n%s", command)
+			}
+			if !strings.Contains(command, "./scripts/test-local-parallel fast") {
+				t.Fatalf("test-fast-parallel recipe should still dispatch the sharded fast runner:\n%s", command)
+			}
+			wantJobAssignment := " LOCAL_TEST_JOBS=" + tt.wantJobs + " CMD_GC_PROCESS_TOTAL="
+			if !strings.Contains(command, wantJobAssignment) {
+				t.Fatalf("test-fast-parallel job count should be %s:\n%s", tt.wantJobs, command)
+			}
+		})
+	}
+}
+
+func localTestCgroupEnv(t *testing.T, version, limit, current string) []string {
+	t.Helper()
+	root := t.TempDir()
+	cgroupRoot := filepath.Join(root, "cgroup")
+	procCgroup := filepath.Join(root, "proc-self-cgroup")
+	meminfo := filepath.Join(root, "meminfo")
+	writeTestFile(t, meminfo, "MemAvailable: 67108864 kB\n")
+
+	var controllerRoot, procLine, limitFile, currentFile string
+	switch version {
+	case "v2":
+		controllerRoot = cgroupRoot
+		procLine = "0::/parent/child\n"
+		limitFile = "memory.max"
+		currentFile = "memory.current"
+	case "v1":
+		controllerRoot = filepath.Join(cgroupRoot, "memory")
+		procLine = "5:memory:/parent/child\n"
+		limitFile = "memory.limit_in_bytes"
+		currentFile = "memory.usage_in_bytes"
+	case "hybrid":
+		controllerRoot = filepath.Join(cgroupRoot, "memory")
+		procLine = "0::/unified/child\n5:memory:/parent/child\n"
+		limitFile = "memory.limit_in_bytes"
+		currentFile = "memory.usage_in_bytes"
+	default:
+		t.Fatalf("unsupported cgroup fixture version %q", version)
+	}
+
+	writeTestFile(t, procCgroup, procLine)
+	if err := os.MkdirAll(filepath.Join(controllerRoot, "parent", "child"), 0o755); err != nil {
+		t.Fatalf("create nested cgroup fixture: %v", err)
+	}
+	writeTestFile(t, filepath.Join(controllerRoot, "parent", limitFile), limit+"\n")
+	writeTestFile(t, filepath.Join(controllerRoot, "parent", currentFile), current+"\n")
+
+	return []string{
+		"GC_TEST_LOCAL_MEMINFO=" + meminfo,
+		"GC_TEST_LOCAL_PROC_CGROUP=" + procCgroup,
+		"GC_TEST_LOCAL_CGROUP_ROOT=" + cgroupRoot,
+	}
+}
+
+func TestPrePushUsesCanonicalMachineAwareConcurrency(t *testing.T) {
+	repoRoot := repoRoot(t)
+	script, err := os.ReadFile(filepath.Join(repoRoot, ".githooks", "pre-push"))
 	if err != nil {
-		t.Fatalf("make -n test-fast-parallel failed: %v\n%s", err, out)
+		t.Fatalf("read pre-push hook: %v", err)
 	}
-	command := string(out)
-	if !strings.Contains(command, "env -i") {
-		t.Fatalf("test-fast-parallel recipe should use TEST_ENV env -i wrapper:\n%s", command)
+	content := string(script)
+	if strings.Contains(content, `LOCAL_TEST_JOBS="${LOCAL_TEST_JOBS:-3}"`) {
+		t.Fatal("pre-push hook must not replace the canonical machine-aware default with a fixed three-job cap")
 	}
-	if !strings.Contains(command, "./scripts/test-local-parallel fast") {
-		t.Fatalf("test-fast-parallel recipe should still dispatch the sharded fast runner:\n%s", command)
+	if !strings.Contains(content, "exec make test-fast-parallel") {
+		t.Fatal("pre-push hook must continue delegating the unchanged fast-suite inventory to make test-fast-parallel")
+	}
+	for _, path := range []string{"Makefile", filepath.Join("scripts", "test-local-parallel")} {
+		content, err := os.ReadFile(filepath.Join(repoRoot, path))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(content), "scripts/test-local-job-count") {
+			t.Fatalf("%s must use the canonical machine-aware job detector", path)
+		}
 	}
 }
 
@@ -133,5 +251,15 @@ func writeExecutable(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/scripts/test-local-job-count
+++ b/scripts/test-local-job-count
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# A fast-suite shard can build a roughly 2.8 GiB test binary. Budget 4 GiB per
+# concurrent shard for compiler/linker headroom, cap automatic fan-out at 16,
+# and preserve the former three-job safety default when memory is unknowable.
+readonly job_memory_kib=$((4 * 1024 * 1024))
+readonly max_auto_jobs=16
+readonly unknown_memory_jobs=3
+
+fail() {
+  echo "test-local-job-count: $*" >&2
+  exit 1
+}
+
+detect_cpus() {
+  if [[ -n "${GC_TEST_LOCAL_CPUS:-}" ]]; then
+    [[ "$GC_TEST_LOCAL_CPUS" =~ ^[0-9]+$ && "$GC_TEST_LOCAL_CPUS" -gt 0 ]] ||
+      fail "GC_TEST_LOCAL_CPUS must be a positive integer"
+    printf '%s\n' "$GC_TEST_LOCAL_CPUS"
+    return
+  fi
+
+  nproc 2>/dev/null ||
+    getconf _NPROCESSORS_ONLN 2>/dev/null ||
+    sysctl -n hw.ncpu 2>/dev/null ||
+    printf '8\n'
+}
+
+cgroup_remaining_kib() {
+  local root="${1%/}" relative="${2#/}" limit_file="$3" current_file="$4"
+  local dir limit current remaining_kib best=0 found=0
+
+  [[ -n "$root" ]] || root=/
+  dir="$root"
+  if [[ -n "$relative" ]]; then
+    dir="$root/$relative"
+  fi
+
+  # A leaf may be unlimited while an ancestor enforces the real budget. Walk
+  # the process cgroup and every ancestor up to the controller mount.
+  while [[ "$dir" == "$root" || "$dir" == "$root/"* ]]; do
+    if [[ -r "$dir/$limit_file" && -r "$dir/$current_file" ]]; then
+      read -r limit < "$dir/$limit_file" || true
+      read -r current < "$dir/$current_file" || true
+      if [[ "$limit" =~ ^[0-9]+$ && "$current" =~ ^[0-9]+$ ]]; then
+        found=1
+        if [[ "$current" -ge "$limit" ]]; then
+          remaining_kib=1
+        else
+          remaining_kib=$(((limit - current + 1023) / 1024))
+          if [[ "$remaining_kib" -lt 1 ]]; then
+            remaining_kib=1
+          fi
+        fi
+        if [[ "$best" -eq 0 || "$remaining_kib" -lt "$best" ]]; then
+          best="$remaining_kib"
+        fi
+      fi
+    fi
+
+    [[ "$dir" == "$root" ]] && break
+    dir="${dir%/*}"
+  done
+
+  [[ "$found" -eq 1 ]] || return 1
+  printf '%s\n' "$best"
+}
+
+detect_cgroup_memory_kib() {
+  local proc_cgroup="${GC_TEST_LOCAL_PROC_CGROUP:-/proc/self/cgroup}"
+  local cgroup_root="${GC_TEST_LOCAL_CGROUP_ROOT:-/sys/fs/cgroup}"
+  local relative
+
+  [[ -r "$proc_cgroup" ]] || return 1
+
+  relative="$(awk -F: '$1 == "0" && $2 == "" { print $3; exit }' "$proc_cgroup" 2>/dev/null || true)"
+  if [[ -n "$relative" ]] &&
+    cgroup_remaining_kib "$cgroup_root" "$relative" memory.max memory.current; then
+    return
+  fi
+
+  relative="$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$proc_cgroup" 2>/dev/null || true)"
+  [[ -n "$relative" ]] || return 1
+  cgroup_remaining_kib "$cgroup_root/memory" "$relative" memory.limit_in_bytes memory.usage_in_bytes
+}
+
+detect_memory_kib() {
+  if [[ -n "${GC_TEST_LOCAL_MEMORY_KIB+x}" ]]; then
+    [[ "$GC_TEST_LOCAL_MEMORY_KIB" =~ ^[0-9]+$ ]] ||
+      fail "GC_TEST_LOCAL_MEMORY_KIB must be a non-negative integer"
+    if [[ "$GC_TEST_LOCAL_MEMORY_KIB" -gt 0 ]]; then
+      printf '%s\n' "$GC_TEST_LOCAL_MEMORY_KIB"
+      return
+    fi
+    return 1
+  fi
+
+  local meminfo="${GC_TEST_LOCAL_MEMINFO:-/proc/meminfo}"
+  local best=0 candidate total_bytes total_kib
+  if [[ -r "$meminfo" ]]; then
+    candidate="$(awk '/^MemAvailable:/ { print $2; exit }' "$meminfo" 2>/dev/null || true)"
+    if [[ "$candidate" =~ ^[0-9]+$ && "$candidate" -gt 0 ]]; then
+      best="$candidate"
+    fi
+  fi
+
+  # Container or systemd-scope limits can be lower than host MemAvailable.
+  # Resolve the process's cgroup path and take its tightest ancestor budget.
+  candidate="$(detect_cgroup_memory_kib || true)"
+  if [[ "$candidate" =~ ^[0-9]+$ && "$candidate" -gt 0 ]]; then
+    if [[ "$best" -eq 0 || "$candidate" -lt "$best" ]]; then
+      best="$candidate"
+    fi
+  fi
+
+  # macOS exposes total rather than readily available memory. Reserve 4 GiB
+  # for the OS and interactive work before applying the per-shard budget.
+  if [[ "$best" -eq 0 ]]; then
+    total_bytes="$(sysctl -n hw.memsize 2>/dev/null || true)"
+    if [[ "$total_bytes" =~ ^[0-9]+$ && "$total_bytes" -gt 0 ]]; then
+      total_kib=$((total_bytes / 1024))
+      if [[ "$total_kib" -gt "$job_memory_kib" ]]; then
+        best=$((total_kib - job_memory_kib))
+      else
+        best=$((total_kib / 2))
+      fi
+    fi
+  fi
+
+  [[ "$best" -gt 0 ]] || return 1
+  printf '%s\n' "$best"
+}
+
+cpus="$(detect_cpus)"
+memory_kib="$(detect_memory_kib || true)"
+jobs="$cpus"
+
+if [[ -n "$memory_kib" ]]; then
+  memory_jobs=$((memory_kib / job_memory_kib))
+  if [[ "$memory_jobs" -lt 1 ]]; then
+    memory_jobs=1
+  fi
+  if [[ "$memory_jobs" -lt "$jobs" ]]; then
+    jobs="$memory_jobs"
+  fi
+elif [[ "$jobs" -gt "$unknown_memory_jobs" ]]; then
+  jobs="$unknown_memory_jobs"
+fi
+
+if [[ "$jobs" -gt "$max_auto_jobs" ]]; then
+  jobs="$max_auto_jobs"
+fi
+
+printf '%s\n' "$jobs"

--- a/scripts/test-local-parallel
+++ b/scripts/test-local-parallel
@@ -7,7 +7,7 @@ usage() {
 usage: scripts/test-local-parallel <fast|cmd-gc-process|integration|full>
 
 Environment:
-  LOCAL_TEST_JOBS        max concurrent jobs (default: detected CPU count)
+  LOCAL_TEST_JOBS        max concurrent jobs (default: CPU-and-memory-aware)
   CMD_GC_PROCESS_TOTAL  cmd/gc shard count (default: 6)
 USAGE
 }
@@ -33,14 +33,7 @@ gc_test_slice_reexec "$repo_root/scripts/test-local-parallel" "$@"
 # these vars at test-binary init in every covered package.
 unset GC_DOLT_PORT BEADS_DOLT_SERVER_PORT
 
-detect_cpus() {
-  nproc 2>/dev/null ||
-    getconf _NPROCESSORS_ONLN 2>/dev/null ||
-    sysctl -n hw.ncpu 2>/dev/null ||
-    printf '8\n'
-}
-
-local_jobs="${LOCAL_TEST_JOBS:-$(detect_cpus)}"
+local_jobs="${LOCAL_TEST_JOBS:-$("$repo_root/scripts/test-local-job-count")}"
 cmd_gc_total="${CMD_GC_PROCESS_TOTAL:-6}"
 
 if ! [[ "$local_jobs" =~ ^[0-9]+$ && "$local_jobs" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Replace the pre-push hook's fixed three-job cap with one canonical machine-aware concurrency policy.
- Use the same policy from `make test-fast-parallel` and direct `scripts/test-local-parallel` runs.
- Preserve explicit `LOCAL_TEST_JOBS` overrides and the complete fast-suite inventory.

## Policy

- Automatic jobs are bounded by detected CPUs, 4 GiB of available memory per job, and a ceiling of 16.
- Linux uses `MemAvailable` plus the tightest finite cgroup v1/v2 ancestor budget, including hybrid v2-to-v1 fallback.
- macOS reserves 4 GiB before calculating capacity.
- Unknown memory falls back to three jobs; exhausted memory still permits one job.

## Performance

| Gate | Wall time | Result |
| --- | ---: | --- |
| Fixed three-job pre-push baseline | ~383s | Over five minutes |
| Final uncached machine-aware suite | 231.55s | 3m51.55s, all eight jobs passed |

That removes about 151 seconds from the gate, a roughly 40% improvement. No tests were removed, skipped, or reclassified.

## Verification

- Actual `.githooks/pre-push`: all eight jobs passed with `LOCAL_TEST_JOBS=16`
- `go test ./scripts -count=1`
- `go test ./internal/testpolicy/resourcecensus -run TestRepositoryLedgerMatchesCensusAndDocumentation -count=1`
- Resource ratchets unchanged at 523 / 396 / 394 subprocess call sites
- `make test-ci-policy`
- `go test ./test/docsync -count=1`
- `go vet ./...`
- Bash syntax and ShellCheck
- Three-reviewer delegated council unanimously approved staged hash `073bfdda7821933af3f504662c4d6b4af7e8d1662d3948fc619de15bd618165e`

Tracker: `ga-80po0c.9`