### PR TITLE
test: emit canonical timing history snapshots

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -240,6 +240,14 @@ go run ./scripts/test-timing-summary.go /path/to/downloaded-artifacts \
   >> "$GITHUB_STEP_SUMMARY"
 ```
 
+Use the same strict parser to emit the versioned machine-readable history
+snapshot:
+
+```bash
+go run ./scripts/test-timing-summary.go --format=json \
+  /path/to/downloaded-artifacts > timing-history-v1.json
+```
+
 The summarizer recursively reads schema-v1 JSON artifacts, deduplicates
 identical downloads, and rejects conflicting artifacts with the same workflow,
 run, attempt, job, shard, and variant identity. It emits the ten slowest
@@ -252,12 +260,28 @@ is ranked. Statistics use successful durations only while retaining failure
 and skip counts. Percentiles use the empirical nearest-rank method, variance
 is population variance in seconds squared, and samples are not trimmed.
 
+The JSON snapshot groups units by that same comparable profile and preserves
+every successful observation with its exact artifact identity and tested SHA.
+Profiles and units have canonical ordering. Observations compare the raw string
+tuple `(workflow, run_id, run_attempt, job, shard_id, variant)` lexically, then
+tested SHA and duration; run IDs and attempts are opaque strings, so `002`,
+`10`, and `2` remain distinct and sort in that order. Identical artifact
+downloads increment `duplicate_artifact_count` without duplicating samples.
+Units that have only failed or skipped remain present with empty successful
+observations and `null` statistics. `p75_authoritative` becomes true at five
+successful samples and `p95_authoritative` at twenty. `last_success_sha` is the
+SHA of the final successful observation in canonical artifact-identity order;
+schema v1 has no trustworthy timestamp, so this field is deterministic but not
+a claim about chronological recency.
+
 Schema v1 does not record the event, ref, or workflow conclusion, so the tool
 cannot prove protected-branch provenance. The caller must supply artifacts
-from successful `main` push runs. An observed p95 with fewer than 20 successful
-samples is diagnostic, not planner-authoritative, and the seven-day artifact
-retention window is not a protected historical timing database. Renamed tests
-remain separate histories.
+from successful `main` push runs. The JSON snapshot is workflow-neutral input,
+not a protected store or planner decision. An observed p75 with fewer than five
+successful samples and p95 with fewer than twenty are diagnostic, not
+planner-authoritative. The seven-day artifact retention window is not a
+protected historical timing database, and this one-shot builder does not prune
+observations. Renamed tests remain separate histories.
 
 In schema v1, `commit_sha` is the exact Git revision checked out and tested
 (`GITHUB_SHA`). On `pull_request` runs, GitHub sets it to the synthetic merge

--- a/internal/testpolicy/timingsummary/history.go
+++ b/internal/testpolicy/timingsummary/history.go
@@ -1,0 +1,286 @@
+package timingsummary
+
+import (
+	"cmp"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// SnapshotSchema is the current machine-readable timing-history schema.
+	SnapshotSchema = 1
+
+	p75AuthoritativeSamples = 5
+	p95AuthoritativeSamples = 20
+)
+
+// Snapshot is a deterministic timing-history projection of validated
+// schema-v1 artifacts. It does not assert protected-branch provenance.
+type Snapshot struct {
+	Schema                 int       `json:"schema"`
+	UniqueArtifactCount    int       `json:"unique_artifact_count"`
+	DuplicateArtifactCount int       `json:"duplicate_artifact_count"`
+	Profiles               []Profile `json:"profiles"`
+}
+
+// Profile groups histories measured on comparable jobs and runners.
+type Profile struct {
+	Job     string        `json:"job"`
+	Variant string        `json:"variant"`
+	Runner  RunnerProfile `json:"runner"`
+	Units   []UnitHistory `json:"units"`
+}
+
+// RunnerProfile contains stable runner properties. Ephemeral runner names are
+// intentionally excluded so equivalent observations remain comparable.
+type RunnerProfile struct {
+	Label    string `json:"label"`
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	CPUCount int    `json:"cpu_count"`
+}
+
+// UnitHistory contains the outcome counts and successful observations for one
+// runnable top-level test within a comparable profile.
+type UnitHistory struct {
+	UnitID                            string                  `json:"unit_id"`
+	Package                           string                  `json:"package"`
+	Test                              string                  `json:"test"`
+	Subtest                           string                  `json:"subtest"`
+	Passes                            int                     `json:"passes"`
+	Failures                          int                     `json:"failures"`
+	Skips                             int                     `json:"skips"`
+	DurationSecondsP50                *float64                `json:"duration_seconds_p50"`
+	DurationSecondsP75                *float64                `json:"duration_seconds_p75"`
+	DurationSecondsP95                *float64                `json:"duration_seconds_p95"`
+	DurationSecondsPopulationVariance *float64                `json:"duration_seconds_population_variance"`
+	P75Authoritative                  bool                    `json:"p75_authoritative"`
+	P95Authoritative                  bool                    `json:"p95_authoritative"`
+	LastSuccessSHA                    *string                 `json:"last_success_sha"`
+	SuccessfulObservations            []SuccessfulObservation `json:"successful_observations"`
+}
+
+// SuccessfulObservation records one successful duration and the exact
+// schema-v1 artifact that supplied it.
+type SuccessfulObservation struct {
+	ArtifactIdentity ArtifactIdentity `json:"artifact_identity"`
+	TestedSHA        string           `json:"tested_sha"`
+	DurationSeconds  float64          `json:"duration_seconds"`
+}
+
+// ArtifactIdentity is the schema-v1 artifact uniqueness key.
+type ArtifactIdentity struct {
+	Workflow   string `json:"workflow"`
+	RunID      string `json:"run_id"`
+	RunAttempt string `json:"run_attempt"`
+	Job        string `json:"job"`
+	ShardID    string `json:"shard_id"`
+	Variant    string `json:"variant"`
+}
+
+type profileKey struct {
+	Job      string
+	Variant  string
+	Label    string
+	OS       string
+	Arch     string
+	CPUCount int
+}
+
+type unitIdentity struct {
+	UnitID  string
+	Package string
+	Test    string
+	Subtest string
+}
+
+type unitAccumulator struct {
+	identity     unitIdentity
+	failures     int
+	skips        int
+	observations []SuccessfulObservation
+}
+
+// BuildSnapshot loads and validates timing artifacts below roots and returns
+// their canonical machine-readable history projection.
+func BuildSnapshot(roots []string) (Snapshot, error) {
+	artifacts, duplicateCount, err := loadArtifacts(roots)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return buildSnapshot(artifacts, duplicateCount)
+}
+
+func buildSnapshot(artifacts []artifact, duplicateCount int) (Snapshot, error) {
+	byProfile := make(map[profileKey]map[string]*unitAccumulator)
+	identities := make(map[string]unitIdentity)
+	for _, item := range artifacts {
+		profile := profileKey{
+			Job: item.Job, Variant: item.Variant, Label: item.Runner.Label,
+			OS: item.Runner.OS, Arch: item.Runner.Arch, CPUCount: item.Runner.CPUCount,
+		}
+		units := byProfile[profile]
+		if units == nil {
+			units = make(map[string]*unitAccumulator)
+			byProfile[profile] = units
+		}
+		for _, unit := range item.Units {
+			if unit.Kind != "test" || unit.Subtest != "" {
+				continue
+			}
+			identity := unitIdentity{
+				UnitID: unit.UnitID, Package: unit.Package, Test: unit.Test, Subtest: unit.Subtest,
+			}
+			if previous, ok := identities[unit.UnitID]; ok && previous != identity {
+				return Snapshot{}, fmt.Errorf("conflicting identity for unit %q: %s != %s",
+					unit.UnitID, formatUnitIdentity(previous), formatUnitIdentity(identity))
+			}
+			identities[unit.UnitID] = identity
+			stats := units[unit.UnitID]
+			if stats == nil {
+				stats = &unitAccumulator{
+					identity:     identity,
+					observations: make([]SuccessfulObservation, 0),
+				}
+				units[unit.UnitID] = stats
+			}
+
+			switch unit.Outcome {
+			case "pass":
+				stats.observations = append(stats.observations, SuccessfulObservation{
+					ArtifactIdentity: ArtifactIdentity{
+						Workflow: item.Workflow, RunID: item.RunID, RunAttempt: item.RunAttempt,
+						Job: item.Job, ShardID: item.ShardID, Variant: item.Variant,
+					},
+					TestedSHA:       item.CommitSHA,
+					DurationSeconds: canonicalFloat(unit.DurationSeconds),
+				})
+			case "fail":
+				stats.failures++
+			case "skip":
+				stats.skips++
+			}
+		}
+	}
+
+	profileKeys := make([]profileKey, 0, len(byProfile))
+	for profile := range byProfile {
+		profileKeys = append(profileKeys, profile)
+	}
+	sort.Slice(profileKeys, func(i, j int) bool {
+		return compareProfileKey(profileKeys[i], profileKeys[j]) < 0
+	})
+
+	profiles := make([]Profile, 0, len(profileKeys))
+	for _, profile := range profileKeys {
+		accumulated := byProfile[profile]
+		unitIDs := make([]string, 0, len(accumulated))
+		for unitID := range accumulated {
+			unitIDs = append(unitIDs, unitID)
+		}
+		sort.Strings(unitIDs)
+
+		units := make([]UnitHistory, 0, len(unitIDs))
+		for _, unitID := range unitIDs {
+			stats := accumulated[unitID]
+			observations := append([]SuccessfulObservation(nil), stats.observations...)
+			sort.Slice(observations, func(i, j int) bool {
+				return compareSuccessfulObservation(observations[i], observations[j]) < 0
+			})
+			if observations == nil {
+				observations = make([]SuccessfulObservation, 0)
+			}
+
+			unit := UnitHistory{
+				UnitID: stats.identity.UnitID, Package: stats.identity.Package,
+				Test: stats.identity.Test, Subtest: stats.identity.Subtest,
+				Passes: len(observations), Failures: stats.failures, Skips: stats.skips,
+				P75Authoritative:       len(observations) >= p75AuthoritativeSamples,
+				P95Authoritative:       len(observations) >= p95AuthoritativeSamples,
+				SuccessfulObservations: observations,
+			}
+			if len(observations) > 0 {
+				durations := make([]float64, len(observations))
+				for index, observation := range observations {
+					durations[index] = observation.DurationSeconds
+				}
+				sort.Float64s(durations)
+				variance, err := populationVariance(durations)
+				if err != nil {
+					return Snapshot{}, fmt.Errorf("aggregate %q: %w", unitID, err)
+				}
+				unit.DurationSecondsP50 = floatPointer(nearestRank(durations, 0.50))
+				unit.DurationSecondsP75 = floatPointer(nearestRank(durations, 0.75))
+				unit.DurationSecondsP95 = floatPointer(nearestRank(durations, 0.95))
+				unit.DurationSecondsPopulationVariance = floatPointer(variance)
+				lastSuccessSHA := observations[len(observations)-1].TestedSHA
+				unit.LastSuccessSHA = &lastSuccessSHA
+			}
+			units = append(units, unit)
+		}
+
+		profiles = append(profiles, Profile{
+			Job: profile.Job, Variant: profile.Variant,
+			Runner: RunnerProfile{
+				Label: profile.Label, OS: profile.OS, Arch: profile.Arch, CPUCount: profile.CPUCount,
+			},
+			Units: units,
+		})
+	}
+
+	return Snapshot{
+		Schema: SnapshotSchema, UniqueArtifactCount: len(artifacts),
+		DuplicateArtifactCount: duplicateCount, Profiles: profiles,
+	}, nil
+}
+
+func compareProfileKey(left, right profileKey) int {
+	leftFields := []string{left.Job, left.Variant, left.Label, left.OS, left.Arch}
+	rightFields := []string{right.Job, right.Variant, right.Label, right.OS, right.Arch}
+	for index := range leftFields {
+		if result := strings.Compare(leftFields[index], rightFields[index]); result != 0 {
+			return result
+		}
+	}
+	return cmp.Compare(left.CPUCount, right.CPUCount)
+}
+
+func compareSuccessfulObservation(left, right SuccessfulObservation) int {
+	leftFields := []string{
+		left.ArtifactIdentity.Workflow, left.ArtifactIdentity.RunID, left.ArtifactIdentity.RunAttempt,
+		left.ArtifactIdentity.Job, left.ArtifactIdentity.ShardID, left.ArtifactIdentity.Variant, left.TestedSHA,
+	}
+	rightFields := []string{
+		right.ArtifactIdentity.Workflow, right.ArtifactIdentity.RunID, right.ArtifactIdentity.RunAttempt,
+		right.ArtifactIdentity.Job, right.ArtifactIdentity.ShardID, right.ArtifactIdentity.Variant, right.TestedSHA,
+	}
+	for index := range leftFields {
+		if result := strings.Compare(leftFields[index], rightFields[index]); result != 0 {
+			return result
+		}
+	}
+	if left.DurationSeconds < right.DurationSeconds {
+		return -1
+	}
+	if left.DurationSeconds > right.DurationSeconds {
+		return 1
+	}
+	return 0
+}
+
+func formatUnitIdentity(identity unitIdentity) string {
+	return fmt.Sprintf("package=%q test=%q subtest=%q", identity.Package, identity.Test, identity.Subtest)
+}
+
+func canonicalFloat(value float64) float64 {
+	if value == 0 {
+		return 0
+	}
+	return value
+}
+
+func floatPointer(value float64) *float64 {
+	value = canonicalFloat(value)
+	return &value
+}

--- a/internal/testpolicy/timingsummary/history_test.go
+++ b/internal/testpolicy/timingsummary/history_test.go
@@ -1,0 +1,414 @@
+package timingsummary
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBuildSnapshotJSONIsDeterministicAndRetainsSuccessfulObservations(t *testing.T) {
+	t.Parallel()
+
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+	const unitID = "internal/example:TestHistory"
+
+	artifactFor := func(runID, testedSHA, outcome string, duration float64) timingArtifactFixture {
+		item := timingArtifact(runID, defaultRunner("ephemeral-"+runID), []timingUnit{{
+			UnitID: unitID, Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+			Test: "TestHistory", Outcome: outcome, DurationSeconds: duration,
+		}})
+		item.CommitSHA = testedSHA
+		return item
+	}
+
+	oldest := artifactFor("100", "sha-oldest", "pass", 1)
+	writeArtifact(t, firstRoot, "z-oldest.json", oldest)
+	writeArtifact(t, secondRoot, "duplicate/oldest.json", oldest)
+	writeArtifact(t, secondRoot, "middle-1.json", artifactFor("200", "sha-middle-1", "pass", 2))
+	writeArtifact(t, firstRoot, "middle-2.json", artifactFor("250", "sha-middle-2", "pass", 3))
+	writeArtifact(t, secondRoot, "outlier.json", artifactFor("300", "sha-outlier", "pass", 900))
+	writeArtifact(t, firstRoot, "a-newest-success.json", artifactFor("400", "sha-newest-success", "pass", 4))
+	laterFailure := artifactFor("500", "sha-failure", "fail", 5)
+	laterFailure.Units = append(laterFailure.Units, timingUnit{
+		UnitID: "internal/example:TestOnlyFails", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example", Test: "TestOnlyFails",
+		Outcome: "fail", DurationSeconds: 6,
+	})
+	writeArtifact(t, firstRoot, "later-failure.json", laterFailure)
+	laterSkip := artifactFor("600", "sha-skip", "skip", 0)
+	laterSkip.Units = append(laterSkip.Units, timingUnit{
+		UnitID: "internal/example:TestOnlyFails", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example", Test: "TestOnlyFails",
+		Outcome: "skip", DurationSeconds: 0,
+	})
+	writeArtifact(t, secondRoot, "later-skip.json", laterSkip)
+
+	otherProfile := artifactFor("700", "sha-other-profile", "pass", 10)
+	otherProfile.Runner = timingRunner{
+		Label: "blacksmith-64vcpu", Name: "ephemeral-other", OS: "Linux", Arch: "X64", CPUCount: 64,
+	}
+	writeArtifact(t, secondRoot, "other-profile.json", otherProfile)
+
+	forwardOutput := runJSONHistory(t, firstRoot, secondRoot)
+	reverseOutput := runJSONHistory(t, secondRoot, firstRoot)
+	if forwardOutput != reverseOutput {
+		t.Fatalf("JSON history depends on artifact-root order\nforward:\n%s\nreverse:\n%s", forwardOutput, reverseOutput)
+	}
+
+	snapshot := decodeHistorySnapshot(t, forwardOutput)
+	if snapshot.Schema != 1 {
+		t.Fatalf("snapshot schema = %d, want 1", snapshot.Schema)
+	}
+	if snapshot.UniqueArtifactCount != 8 || snapshot.DuplicateArtifactCount != 1 {
+		t.Fatalf("snapshot artifact counts = unique %d duplicate %d, want 8/1",
+			snapshot.UniqueArtifactCount, snapshot.DuplicateArtifactCount)
+	}
+	if len(snapshot.Profiles) != 2 {
+		t.Fatalf("snapshot profiles = %d, want 2: %+v", len(snapshot.Profiles), snapshot.Profiles)
+	}
+
+	profile32 := findHistoryProfile(t, snapshot, 32)
+	if profile32.Job != "cmd-gc-process" || profile32.Variant != "linux-default" ||
+		profile32.Runner != (RunnerProfile{Label: "blacksmith-32vcpu", OS: "Linux", Arch: "X64", CPUCount: 32}) {
+		t.Fatalf("32-CPU profile identity = %+v, want canonical cmd/gc Linux profile", profile32)
+	}
+	if len(profile32.Units) != 2 {
+		t.Fatalf("32-CPU profile units = %d, want 2: %+v", len(profile32.Units), profile32.Units)
+	}
+	unit := findHistoryUnit(t, profile32, unitID)
+	if unit.Package != "github.com/gastownhall/gascity/internal/example" || unit.Test != "TestHistory" || unit.Subtest != "" {
+		t.Fatalf("history unit identity = %+v", unit)
+	}
+	if unit.Passes != 5 || unit.Failures != 1 || unit.Skips != 1 {
+		t.Fatalf("history outcomes = pass %d fail %d skip %d, want 5/1/1", unit.Passes, unit.Failures, unit.Skips)
+	}
+	if historyFloat(t, unit.DurationSecondsP50) != 3 || historyFloat(t, unit.DurationSecondsP75) != 4 || historyFloat(t, unit.DurationSecondsP95) != 900 {
+		t.Fatalf("history percentiles = p50 %v p75 %v p95 %v, want 3/4/900", unit.DurationSecondsP50, unit.DurationSecondsP75, unit.DurationSecondsP95)
+	}
+	if got := historyFloat(t, unit.DurationSecondsPopulationVariance); math.Abs(got-128882) > 1e-9 {
+		t.Fatalf("history population variance = %.6f, want 128882", got)
+	}
+	if !unit.P75Authoritative || unit.P95Authoritative {
+		t.Fatalf("history authority = p75 %t p95 %t, want true/false", unit.P75Authoritative, unit.P95Authoritative)
+	}
+	if unit.LastSuccessSHA == nil || *unit.LastSuccessSHA != "sha-newest-success" {
+		t.Fatalf("last success SHA = %v, want canonical final success %q", unit.LastSuccessSHA, "sha-newest-success")
+	}
+	if len(unit.SuccessfulObservations) != 5 {
+		t.Fatalf("successful history observations = %d, want 5 after identical duplicate deduplication: %+v", len(unit.SuccessfulObservations), unit.SuccessfulObservations)
+	}
+
+	wantRunIDs := []string{"100", "200", "250", "300", "400"}
+	wantSHAs := []string{"sha-oldest", "sha-middle-1", "sha-middle-2", "sha-outlier", "sha-newest-success"}
+	gotRunIDs := make([]string, 0, len(unit.SuccessfulObservations))
+	for index, observation := range unit.SuccessfulObservations {
+		gotRunIDs = append(gotRunIDs, observation.ArtifactIdentity.RunID)
+		wantIdentity := ArtifactIdentity{
+			Workflow: "CI", RunID: wantRunIDs[index], RunAttempt: "1", Job: "cmd-gc-process",
+			ShardID: "cmd-gc-process-1-of-12", Variant: "linux-default",
+		}
+		if observation.ArtifactIdentity != wantIdentity || observation.TestedSHA != wantSHAs[index] {
+			t.Fatalf("successful observation %d = %+v, want identity %+v and SHA %q",
+				index, observation, wantIdentity, wantSHAs[index])
+		}
+	}
+	if !reflect.DeepEqual(gotRunIDs, wantRunIDs) {
+		t.Fatalf("observation run order = %v, want stable artifact-identity order %v", gotRunIDs, wantRunIDs)
+	}
+
+	if got := unit.SuccessfulObservations[3].DurationSeconds; got != 900 {
+		t.Fatalf("outlier observation duration = %.3f, want retained 900", got)
+	}
+
+	onlyFails := findHistoryUnit(t, profile32, "internal/example:TestOnlyFails")
+	if onlyFails.Passes != 0 || onlyFails.Failures != 1 || onlyFails.Skips != 1 ||
+		onlyFails.DurationSecondsP50 != nil || onlyFails.DurationSecondsP75 != nil ||
+		onlyFails.DurationSecondsP95 != nil || onlyFails.DurationSecondsPopulationVariance != nil ||
+		onlyFails.P75Authoritative || onlyFails.P95Authoritative || onlyFails.LastSuccessSHA != nil ||
+		onlyFails.SuccessfulObservations == nil || len(onlyFails.SuccessfulObservations) != 0 {
+		t.Fatalf("zero-success unit must retain outcomes with null statistics and [] observations: %+v", onlyFails)
+	}
+
+	profile64 := findHistoryProfile(t, snapshot, 64)
+	otherUnit := findHistoryUnit(t, profile64, unitID)
+	if len(profile64.Units) != 1 || otherUnit.Passes != 1 || len(otherUnit.SuccessfulObservations) != 1 || historyFloat(t, otherUnit.DurationSecondsP95) != 10 {
+		t.Fatalf("64-CPU profile was mixed with 32-CPU history: %+v", otherUnit)
+	}
+}
+
+func TestBuildSnapshotJSONMarksPercentileAuthorityAtSampleThresholds(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	tests := []struct {
+		name      string
+		successes int
+	}{
+		{name: "TestP75Cold", successes: 4},
+		{name: "TestP75Warm", successes: 5},
+		{name: "TestP95Cold", successes: 19},
+		{name: "TestP95Warm", successes: 20},
+	}
+	for run := 0; run < 20; run++ {
+		units := make([]timingUnit, 0, len(tests))
+		for _, tc := range tests {
+			if run >= tc.successes {
+				continue
+			}
+			units = append(units, timingUnit{
+				UnitID: "internal/example:" + tc.name, Kind: "test",
+				Package: "github.com/gastownhall/gascity/internal/example", Test: tc.name,
+				Outcome: "pass", DurationSeconds: float64(run + 1),
+			})
+		}
+		item := timingArtifact(fmt.Sprintf("%03d", 800+run), defaultRunner(fmt.Sprintf("ephemeral-%02d", run)), units)
+		item.CommitSHA = fmt.Sprintf("sha-%02d", run)
+		writeArtifact(t, root, fmt.Sprintf("run-%02d.json", 19-run), item)
+	}
+
+	snapshot := decodeHistorySnapshot(t, runJSONHistory(t, root))
+	profile := findHistoryProfile(t, snapshot, 32)
+	assertAuthority := func(name string, passes int, p75, p95 bool) UnitHistory {
+		t.Helper()
+		unit := findHistoryUnit(t, profile, "internal/example:"+name)
+		if unit.Passes != passes || unit.P75Authoritative != p75 || unit.P95Authoritative != p95 {
+			t.Fatalf("%s = passes %d p75-authoritative %t p95-authoritative %t, want %d/%t/%t",
+				name, unit.Passes, unit.P75Authoritative, unit.P95Authoritative, passes, p75, p95)
+		}
+		return unit
+	}
+
+	assertAuthority("TestP75Cold", 4, false, false)
+	p75Warm := assertAuthority("TestP75Warm", 5, true, false)
+	assertAuthority("TestP95Cold", 19, true, false)
+	p95Warm := assertAuthority("TestP95Warm", 20, true, true)
+	if got := historyFloat(t, p75Warm.DurationSecondsP75); got != 4 {
+		t.Fatalf("five-sample p75 = %.3f, want nearest-rank 4", got)
+	}
+	if got := historyFloat(t, p95Warm.DurationSecondsP95); got != 19 {
+		t.Fatalf("twenty-sample p95 = %.3f, want nearest-rank 19", got)
+	}
+}
+
+func TestBuildSnapshotJSONOrdersOpaqueRunIDsLexically(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	runIDs := []string{"2", "10", "002"}
+	for index, runID := range runIDs {
+		item := timingArtifact(runID, defaultRunner("ephemeral-"+runID), []timingUnit{{
+			UnitID: "internal/example:TestOpaqueID", Kind: "test",
+			Package: "github.com/gastownhall/gascity/internal/example", Test: "TestOpaqueID",
+			Outcome: "pass", DurationSeconds: float64(index + 1),
+		}})
+		item.CommitSHA = "sha-" + runID
+		writeArtifact(t, root, fmt.Sprintf("input-%d.json", index), item)
+	}
+
+	snapshot := decodeHistorySnapshot(t, runJSONHistory(t, root))
+	unit := findHistoryUnit(t, findHistoryProfile(t, snapshot, 32), "internal/example:TestOpaqueID")
+	gotRunIDs := make([]string, 0, len(unit.SuccessfulObservations))
+	for _, observation := range unit.SuccessfulObservations {
+		gotRunIDs = append(gotRunIDs, observation.ArtifactIdentity.RunID)
+	}
+	wantRunIDs := []string{"002", "10", "2"}
+	if !reflect.DeepEqual(gotRunIDs, wantRunIDs) {
+		t.Fatalf("opaque run ID order = %q, want raw lexical order %q", gotRunIDs, wantRunIDs)
+	}
+	if unit.LastSuccessSHA == nil || *unit.LastSuccessSHA != "sha-2" {
+		t.Fatalf("last success SHA = %v, want final raw-lexical observation sha-2", unit.LastSuccessSHA)
+	}
+}
+
+func TestBuildSnapshotJSONRejectsConflictingDuplicate(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	valid := timingArtifact("900", defaultRunner("ephemeral"), []timingUnit{{
+		UnitID: "internal/example:TestConflict", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example", Test: "TestConflict",
+		Outcome: "pass", DurationSeconds: 1,
+	}})
+	writeArtifact(t, root, "first.json", valid)
+	writeArtifact(t, root, "second.json", withFirstDuration(valid, 2))
+
+	stdout, stderr, exitCode := runSummary("--format=json", root)
+	if exitCode != 1 || stdout != "" || !strings.Contains(stderr, "conflicting duplicate artifact") {
+		t.Fatalf("Run conflicting JSON history = stdout %q stderr %q exit %d", stdout, stderr, exitCode)
+	}
+}
+
+func TestBuildSnapshotJSONRejectsConflictingStableUnitIdentity(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	first := timingArtifact("910", defaultRunner("ephemeral-a"), []timingUnit{{
+		UnitID: "internal/example:TestStable", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+		Test: "TestStable", Outcome: "pass", DurationSeconds: 1,
+	}})
+	second := timingArtifact("911", defaultRunner("ephemeral-b"), []timingUnit{{
+		UnitID: "internal/example:TestStable", Kind: "test", Package: "github.com/gastownhall/gascity/internal/other",
+		Test: "TestStable", Outcome: "pass", DurationSeconds: 2,
+	}})
+	second.Runner.Label = "blacksmith-64vcpu"
+	second.Runner.CPUCount = 64
+	writeArtifact(t, root, "first.json", first)
+	writeArtifact(t, root, "second.json", second)
+
+	stdout, stderr, exitCode := runSummary("--format=json", root)
+	if exitCode != 1 || stdout != "" || !strings.Contains(stderr, "conflicting identity for unit") {
+		t.Fatalf("Run conflicting unit identity = stdout %q stderr %q exit %d", stdout, stderr, exitCode)
+	}
+}
+
+func TestBuildSnapshotJSONPreservesHostileMetadataAsData(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	item := timingArtifact("920", defaultRunner("ephemeral"), []timingUnit{{
+		UnitID: "internal/example:TestJSON\"\\\n", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example|quoted", Test: "TestJSON\"\\\n",
+		Outcome: "pass", DurationSeconds: 1,
+	}})
+	item.Job = "cmd/gc\"\njob"
+	item.Variant = "linux\\variant"
+	item.Runner.Label = "runner\"\nlabel"
+	item.Runner.OS = "Linux|row"
+	item.Runner.Arch = "X64</script>"
+	writeArtifact(t, root, "hostile.json", item)
+
+	snapshot := decodeHistorySnapshot(t, runJSONHistory(t, root))
+	profile := findHistoryProfile(t, snapshot, 32)
+	if profile.Job != item.Job || profile.Variant != item.Variant ||
+		profile.Runner.Label != item.Runner.Label || profile.Runner.OS != item.Runner.OS || profile.Runner.Arch != item.Runner.Arch {
+		t.Fatalf("profile metadata changed across JSON round trip: got %+v want %+v", profile, item)
+	}
+	unit := findHistoryUnit(t, profile, item.Units[0].UnitID)
+	if unit.Package != item.Units[0].Package || unit.Test != item.Units[0].Test || unit.Subtest != "" {
+		t.Fatalf("unit metadata changed across JSON round trip: got %+v want %+v", unit, item.Units[0])
+	}
+}
+
+func TestBuildSnapshotJSONWireIsByteExact(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	item := timingArtifact("940", defaultRunner("ephemeral"), []timingUnit{
+		{UnitID: "internal/example:TestWarm", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestWarm", Outcome: "pass", DurationSeconds: 1.5},
+		{UnitID: "internal/example:TestCold", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestCold", Outcome: "fail", DurationSeconds: 2},
+	})
+	item.CommitSHA = "sha-warm"
+	writeArtifact(t, root, "wire.json", item)
+
+	got := runJSONHistory(t, root)
+	want := `{"schema":1,"unique_artifact_count":1,"duplicate_artifact_count":0,"profiles":[` +
+		`{"job":"cmd-gc-process","variant":"linux-default","runner":{"label":"blacksmith-32vcpu","os":"Linux","arch":"X64","cpu_count":32},"units":[` +
+		`{"unit_id":"internal/example:TestCold","package":"github.com/gastownhall/gascity/internal/example","test":"TestCold","subtest":"","passes":0,"failures":1,"skips":0,` +
+		`"duration_seconds_p50":null,"duration_seconds_p75":null,"duration_seconds_p95":null,"duration_seconds_population_variance":null,"p75_authoritative":false,"p95_authoritative":false,"last_success_sha":null,"successful_observations":[]},` +
+		`{"unit_id":"internal/example:TestWarm","package":"github.com/gastownhall/gascity/internal/example","test":"TestWarm","subtest":"","passes":1,"failures":0,"skips":0,` +
+		`"duration_seconds_p50":1.5,"duration_seconds_p75":1.5,"duration_seconds_p95":1.5,"duration_seconds_population_variance":0,"p75_authoritative":false,"p95_authoritative":false,"last_success_sha":"sha-warm","successful_observations":[` +
+		`{"artifact_identity":{"workflow":"CI","run_id":"940","run_attempt":"1","job":"cmd-gc-process","shard_id":"cmd-gc-process-1-of-12","variant":"linux-default"},"tested_sha":"sha-warm","duration_seconds":1.5}]}]}]}` + "\n"
+	if got != want {
+		t.Fatalf("JSON wire changed\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestBuildSnapshotDefaultMarkdownRemainsByteForByte(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeArtifact(t, root, "one.json", timingArtifact("930", defaultRunner("ephemeral"), []timingUnit{{
+		UnitID: "internal/example:TestOne", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example", Test: "TestOne",
+		Outcome: "pass", DurationSeconds: 1,
+	}}))
+
+	stdout, stderr, exitCode := runSummary(root)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("default Markdown Run = stdout %q stderr %q exit %d", stdout, stderr, exitCode)
+	}
+	const want = "# Go test timing summary\n\n" +
+		"Analyzed 1 unique schema-v1 artifact; 0 duplicate downloads ignored.\n\n" +
+		"Rankings use successful durations from top-level tests only. Package totals and nested subtests are excluded. Profiles are never mixed.\n\n" +
+		"## Profile 1\n\n" +
+		"| Job | Variant | Runner label | OS | Arch | CPUs |\n" +
+		"| --- | --- | --- | --- | --- | ---: |\n" +
+		"| `cmd-gc-process` | `linux-default` | `blacksmith-32vcpu` | `Linux` | `X64` | 32 |\n\n" +
+		"Top-level outcomes: 1 pass, 0 fail, 0 skip.\n\n" +
+		"### Ten slowest top-level tests\n\n" +
+		"| Runnable unit | Pass | Fail | Skip | p50 | p75 | p95 |\n" +
+		"| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n" +
+		"| `internal/example:TestOne` | 1 | 0 | 0 | 1.000s | 1.000s | 1.000s |\n\n" +
+		"### Ten highest-variance top-level tests\n\n" +
+		"| Runnable unit | Pass | Fail | Skip | Population variance (s²) | p95 |\n" +
+		"| --- | ---: | ---: | ---: | ---: | ---: |\n" +
+		"| _At least two successful samples are required_ | 0 | 0 | 0 | — | — |\n\n"
+	if stdout != want {
+		t.Fatalf("default Markdown changed\ngot:\n%s\nwant:\n%s", stdout, want)
+	}
+	explicit, explicitStderr, explicitExitCode := runSummary("--format=markdown", root)
+	if explicitExitCode != 0 || explicitStderr != "" || explicit != want {
+		t.Fatalf("explicit Markdown = stdout %q stderr %q exit %d", explicit, explicitStderr, explicitExitCode)
+	}
+}
+
+func runJSONHistory(t *testing.T, roots ...string) string {
+	t.Helper()
+	args := append([]string{"--format=json"}, roots...)
+	stdout, stderr, exitCode := runSummary(args...)
+	if exitCode != 0 {
+		t.Fatalf("Run(--format=json) exit = %d, stderr:\n%s", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("Run(--format=json) wrote stderr on success: %s", stderr)
+	}
+	return stdout
+}
+
+func decodeHistorySnapshot(t *testing.T, output string) Snapshot {
+	t.Helper()
+	var snapshot Snapshot
+	decoder := json.NewDecoder(strings.NewReader(output))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&snapshot); err != nil {
+		t.Fatalf("decode JSON history snapshot: %v\n%s", err, output)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		t.Fatalf("decode JSON history snapshot trailing data: %v\n%s", err, output)
+	}
+	return snapshot
+}
+
+func historyFloat(t *testing.T, value *float64) float64 {
+	t.Helper()
+	if value == nil {
+		t.Fatal("history statistic is null, want a finite value")
+	}
+	return *value
+}
+
+func findHistoryProfile(t *testing.T, snapshot Snapshot, cpuCount int) Profile {
+	t.Helper()
+	for _, profile := range snapshot.Profiles {
+		if profile.Runner.CPUCount == cpuCount {
+			return profile
+		}
+	}
+	t.Fatalf("history has no %d-CPU profile: %+v", cpuCount, snapshot.Profiles)
+	return Profile{}
+}
+
+func findHistoryUnit(t *testing.T, profile Profile, unitID string) UnitHistory {
+	t.Helper()
+	for _, unit := range profile.Units {
+		if unit.UnitID == unitID {
+			return unit
+		}
+	}
+	t.Fatalf("profile has no unit %q: %+v", unitID, profile.Units)
+	return UnitHistory{}
+}

--- a/internal/testpolicy/timingsummary/summary.go
+++ b/internal/testpolicy/timingsummary/summary.go
@@ -12,12 +12,18 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"sort"
 	"strings"
 )
 
 const summaryLimit = 10
+
+type outputFormat uint8
+
+const (
+	formatMarkdown outputFormat = iota
+	formatJSON
+)
 
 type artifact struct {
 	Schema     int            `json:"schema"`
@@ -50,74 +56,73 @@ type artifactUnit struct {
 	DurationSeconds float64 `json:"duration_seconds"`
 }
 
-type artifactIdentity struct {
-	Workflow   string
-	RunID      string
-	RunAttempt string
-	Job        string
-	ShardID    string
-	Variant    string
-}
-
-type profileKey struct {
-	Job      string
-	Variant  string
-	Label    string
-	OS       string
-	Arch     string
-	CPUCount int
-}
-
-type unitAccumulator struct {
-	passes   []float64
-	failures int
-	skips    int
-}
-
-type unitSummary struct {
-	unitID   string
-	passes   int
-	failures int
-	skips    int
-	p50      float64
-	p75      float64
-	p95      float64
-	variance float64
-}
-
-type profileSummary struct {
-	profile  profileKey
-	units    []unitSummary
-	passes   int
-	failures int
-	skips    int
-}
-
-// Run loads timing artifacts from args, writes a deterministic Markdown
-// summary to stdout, and returns a process-style exit code.
+// Run loads timing artifacts from args, writes a deterministic Markdown or
+// JSON summary to stdout, and returns a process-style exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
-	if len(args) == 0 {
+	format, roots, err := parseRunArgs(args)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "timing summary: %v\n", err)
+		return 2
+	}
+	if len(roots) == 0 {
 		_, _ = fmt.Fprintln(stderr, "usage: test-timing-summary <artifact-root> [<artifact-root> ...]")
 		return 2
 	}
 
-	artifacts, duplicateCount, err := loadArtifacts(args)
+	snapshot, err := BuildSnapshot(roots)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "timing summary: %v\n", err)
 		return 1
 	}
 
-	profiles, err := aggregate(artifacts)
-	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "timing summary: %v\n", err)
-		return 1
+	if format == formatJSON {
+		if err := json.NewEncoder(stdout).Encode(snapshot); err != nil {
+			_, _ = fmt.Fprintf(stderr, "timing summary: write output: %v\n", err)
+			return 1
+		}
+		return 0
 	}
-	output := renderMarkdown(profiles, len(artifacts), duplicateCount)
-	if _, err := io.WriteString(stdout, output); err != nil {
+	if _, err := io.WriteString(stdout, renderMarkdown(snapshot)); err != nil {
 		_, _ = fmt.Fprintf(stderr, "timing summary: write output: %v\n", err)
 		return 1
 	}
 	return 0
+}
+
+func parseRunArgs(args []string) (outputFormat, []string, error) {
+	format := formatMarkdown
+	roots := make([]string, 0, len(args))
+	formatSet := false
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		var value string
+		switch {
+		case argument == "--format":
+			if index+1 >= len(args) {
+				return 0, nil, errors.New("--format requires a value")
+			}
+			index++
+			value = args[index]
+		case strings.HasPrefix(argument, "--format="):
+			value = strings.TrimPrefix(argument, "--format=")
+		default:
+			roots = append(roots, argument)
+			continue
+		}
+		if formatSet {
+			return 0, nil, errors.New("--format may be specified only once")
+		}
+		formatSet = true
+		switch value {
+		case "markdown":
+			format = formatMarkdown
+		case "json":
+			format = formatJSON
+		default:
+			return 0, nil, fmt.Errorf("unsupported format %q", value)
+		}
+	}
+	return format, roots, nil
 }
 
 func loadArtifacts(roots []string) ([]artifact, int, error) {
@@ -129,8 +134,8 @@ func loadArtifacts(roots []string) ([]artifact, int, error) {
 		return nil, 0, errors.New("no JSON timing artifacts found")
 	}
 
-	seen := make(map[artifactIdentity]artifact, len(paths))
-	seenPath := make(map[artifactIdentity]string, len(paths))
+	seen := make(map[ArtifactIdentity]artifact, len(paths))
+	seenPath := make(map[ArtifactIdentity]string, len(paths))
 	artifacts := make([]artifact, 0, len(paths))
 	duplicateCount := 0
 	for _, path := range paths {
@@ -138,7 +143,7 @@ func loadArtifacts(roots []string) ([]artifact, int, error) {
 		if err != nil {
 			return nil, 0, err
 		}
-		identity := artifactIdentity{
+		identity := ArtifactIdentity{
 			Workflow: item.Workflow, RunID: item.RunID, RunAttempt: item.RunAttempt,
 			Job: item.Job, ShardID: item.ShardID, Variant: item.Variant,
 		}
@@ -293,85 +298,9 @@ func validateUnit(unit artifactUnit) error {
 	return nil
 }
 
-func formatIdentity(identity artifactIdentity) string {
+func formatIdentity(identity ArtifactIdentity) string {
 	return fmt.Sprintf("workflow=%q run=%q attempt=%q job=%q shard=%q variant=%q",
 		identity.Workflow, identity.RunID, identity.RunAttempt, identity.Job, identity.ShardID, identity.Variant)
-}
-
-func aggregate(artifacts []artifact) ([]profileSummary, error) {
-	byProfile := make(map[profileKey]map[string]*unitAccumulator)
-	for _, item := range artifacts {
-		profile := profileKey{
-			Job: item.Job, Variant: item.Variant, Label: item.Runner.Label,
-			OS: item.Runner.OS, Arch: item.Runner.Arch, CPUCount: item.Runner.CPUCount,
-		}
-		units := byProfile[profile]
-		if units == nil {
-			units = make(map[string]*unitAccumulator)
-			byProfile[profile] = units
-		}
-		for _, unit := range item.Units {
-			if unit.Kind != "test" || unit.Subtest != "" {
-				continue
-			}
-			stats := units[unit.UnitID]
-			if stats == nil {
-				stats = &unitAccumulator{}
-				units[unit.UnitID] = stats
-			}
-			switch unit.Outcome {
-			case "pass":
-				stats.passes = append(stats.passes, unit.DurationSeconds)
-			case "fail":
-				stats.failures++
-			case "skip":
-				stats.skips++
-			}
-		}
-	}
-
-	profileKeys := make([]profileKey, 0, len(byProfile))
-	for profile := range byProfile {
-		profileKeys = append(profileKeys, profile)
-	}
-	sort.Slice(profileKeys, func(i, j int) bool { return compareProfile(profileKeys[i], profileKeys[j]) < 0 })
-
-	profiles := make([]profileSummary, 0, len(profileKeys))
-	for _, profile := range profileKeys {
-		accumulated := byProfile[profile]
-		units := make([]unitSummary, 0, len(accumulated))
-		var totalPasses, totalFailures, totalSkips int
-		unitIDs := make([]string, 0, len(accumulated))
-		for unitID := range accumulated {
-			unitIDs = append(unitIDs, unitID)
-		}
-		sort.Strings(unitIDs)
-		for _, unitID := range unitIDs {
-			stats := accumulated[unitID]
-			totalPasses += len(stats.passes)
-			totalFailures += stats.failures
-			totalSkips += stats.skips
-			if len(stats.passes) == 0 {
-				units = append(units, unitSummary{unitID: unitID, failures: stats.failures, skips: stats.skips})
-				continue
-			}
-			passes := slices.Clone(stats.passes)
-			sort.Float64s(passes)
-			variance, err := populationVariance(passes)
-			if err != nil {
-				return nil, fmt.Errorf("aggregate %q: %w", unitID, err)
-			}
-			units = append(units, unitSummary{
-				unitID: unitID, passes: len(passes), failures: stats.failures, skips: stats.skips,
-				p50: nearestRank(passes, 0.50), p75: nearestRank(passes, 0.75),
-				p95: nearestRank(passes, 0.95), variance: variance,
-			})
-		}
-		profiles = append(profiles, profileSummary{
-			profile: profile, units: units, passes: totalPasses, failures: totalFailures, skips: totalSkips,
-		})
-	}
-	return profiles, nil
 }
 
 func nearestRank(sortedSamples []float64, percentile float64) float64 {
@@ -418,56 +347,56 @@ func finite(value float64) bool {
 	return !math.IsNaN(value) && !math.IsInf(value, 0)
 }
 
-func compareProfile(left, right profileKey) int {
-	leftFields := []string{left.Job, left.Variant, left.Label, left.OS, left.Arch}
-	rightFields := []string{right.Job, right.Variant, right.Label, right.OS, right.Arch}
-	for index := range leftFields {
-		if result := strings.Compare(leftFields[index], rightFields[index]); result != 0 {
-			return result
-		}
-	}
-	return left.CPUCount - right.CPUCount
-}
-
-func renderMarkdown(profiles []profileSummary, artifactCount, duplicateCount int) string {
+func renderMarkdown(snapshot Snapshot) string {
 	var output strings.Builder
 	output.WriteString("# Go test timing summary\n\n")
 	fmt.Fprintf(&output, "Analyzed %d unique schema-v1 %s; %d duplicate %s ignored.\n\n",
-		artifactCount, plural(artifactCount, "artifact", "artifacts"), duplicateCount,
-		plural(duplicateCount, "download", "downloads"))
+		snapshot.UniqueArtifactCount, plural(snapshot.UniqueArtifactCount, "artifact", "artifacts"), snapshot.DuplicateArtifactCount,
+		plural(snapshot.DuplicateArtifactCount, "download", "downloads"))
 	output.WriteString("Rankings use successful durations from top-level tests only. Package totals and nested subtests are excluded. Profiles are never mixed.\n\n")
 
-	for index, summary := range profiles {
+	for index, profile := range snapshot.Profiles {
 		fmt.Fprintf(&output, "## Profile %d\n\n", index+1)
 		output.WriteString("| Job | Variant | Runner label | OS | Arch | CPUs |\n")
 		output.WriteString("| --- | --- | --- | --- | --- | ---: |\n")
 		fmt.Fprintf(&output, "| %s | %s | %s | %s | %s | %d |\n\n",
-			codeCell(summary.profile.Job), codeCell(summary.profile.Variant), codeCell(summary.profile.Label),
-			codeCell(summary.profile.OS), codeCell(summary.profile.Arch), summary.profile.CPUCount)
+			codeCell(profile.Job), codeCell(profile.Variant), codeCell(profile.Runner.Label),
+			codeCell(profile.Runner.OS), codeCell(profile.Runner.Arch), profile.Runner.CPUCount)
+		passes, failures, skips := profileOutcomeCounts(profile.Units)
 		fmt.Fprintf(&output, "Top-level outcomes: %d pass, %d fail, %d skip.\n\n",
-			summary.passes, summary.failures, summary.skips)
+			passes, failures, skips)
 
-		writeSlowestTable(&output, summary.units)
-		writeVarianceTable(&output, summary.units)
+		writeSlowestTable(&output, profile.Units)
+		writeVarianceTable(&output, profile.Units)
 	}
 	return output.String()
 }
 
-func writeSlowestTable(output *strings.Builder, units []unitSummary) {
+func profileOutcomeCounts(units []UnitHistory) (int, int, int) {
+	var passes, failures, skips int
+	for _, unit := range units {
+		passes += unit.Passes
+		failures += unit.Failures
+		skips += unit.Skips
+	}
+	return passes, failures, skips
+}
+
+func writeSlowestTable(output *strings.Builder, units []UnitHistory) {
 	output.WriteString("### Ten slowest top-level tests\n\n")
 	output.WriteString("| Runnable unit | Pass | Fail | Skip | p50 | p75 | p95 |\n")
 	output.WriteString("| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n")
-	ordered := make([]unitSummary, 0, len(units))
+	ordered := make([]UnitHistory, 0, len(units))
 	for _, unit := range units {
-		if unit.passes > 0 {
+		if unit.Passes > 0 {
 			ordered = append(ordered, unit)
 		}
 	}
 	sort.Slice(ordered, func(i, j int) bool {
-		if ordered[i].p95 != ordered[j].p95 {
-			return ordered[i].p95 > ordered[j].p95
+		if *ordered[i].DurationSecondsP95 != *ordered[j].DurationSecondsP95 {
+			return *ordered[i].DurationSecondsP95 > *ordered[j].DurationSecondsP95
 		}
-		return ordered[i].unitID < ordered[j].unitID
+		return ordered[i].UnitID < ordered[j].UnitID
 	})
 	if len(ordered) == 0 {
 		output.WriteString("| _No top-level tests with successful samples_ | 0 | 0 | 0 | — | — | — |\n\n")
@@ -475,26 +404,27 @@ func writeSlowestTable(output *strings.Builder, units []unitSummary) {
 	}
 	for _, unit := range ordered[:min(summaryLimit, len(ordered))] {
 		fmt.Fprintf(output, "| `%s` | %d | %d | %d | %.3fs | %.3fs | %.3fs |\n",
-			escapeCode(unit.unitID), unit.passes, unit.failures, unit.skips, unit.p50, unit.p75, unit.p95)
+			escapeCode(unit.UnitID), unit.Passes, unit.Failures, unit.Skips,
+			*unit.DurationSecondsP50, *unit.DurationSecondsP75, *unit.DurationSecondsP95)
 	}
 	output.WriteByte('\n')
 }
 
-func writeVarianceTable(output *strings.Builder, units []unitSummary) {
+func writeVarianceTable(output *strings.Builder, units []UnitHistory) {
 	output.WriteString("### Ten highest-variance top-level tests\n\n")
 	output.WriteString("| Runnable unit | Pass | Fail | Skip | Population variance (s²) | p95 |\n")
 	output.WriteString("| --- | ---: | ---: | ---: | ---: | ---: |\n")
-	eligible := make([]unitSummary, 0, len(units))
+	eligible := make([]UnitHistory, 0, len(units))
 	for _, unit := range units {
-		if unit.passes >= 2 {
+		if unit.Passes >= 2 {
 			eligible = append(eligible, unit)
 		}
 	}
 	sort.Slice(eligible, func(i, j int) bool {
-		if eligible[i].variance != eligible[j].variance {
-			return eligible[i].variance > eligible[j].variance
+		if *eligible[i].DurationSecondsPopulationVariance != *eligible[j].DurationSecondsPopulationVariance {
+			return *eligible[i].DurationSecondsPopulationVariance > *eligible[j].DurationSecondsPopulationVariance
 		}
-		return eligible[i].unitID < eligible[j].unitID
+		return eligible[i].UnitID < eligible[j].UnitID
 	})
 	if len(eligible) == 0 {
 		output.WriteString("| _At least two successful samples are required_ | 0 | 0 | 0 | — | — |\n\n")
@@ -502,7 +432,8 @@ func writeVarianceTable(output *strings.Builder, units []unitSummary) {
 	}
 	for _, unit := range eligible[:min(summaryLimit, len(eligible))] {
 		fmt.Fprintf(output, "| `%s` | %d | %d | %d | %.6f | %.3fs |\n",
-			escapeCode(unit.unitID), unit.passes, unit.failures, unit.skips, unit.variance, unit.p95)
+			escapeCode(unit.UnitID), unit.Passes, unit.Failures, unit.Skips,
+			*unit.DurationSecondsPopulationVariance, *unit.DurationSecondsP95)
 	}
 	output.WriteByte('\n')
 }

--- a/internal/testpolicy/timingsummary/summary_test.go
+++ b/internal/testpolicy/timingsummary/summary_test.go
@@ -309,6 +309,27 @@ func TestRunRequiresArtifactRoots(t *testing.T) {
 	}
 }
 
+func TestRunRejectsInvalidFormatArguments(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing", args: []string{"--format"}, want: "--format requires a value"},
+		{name: "unsupported", args: []string{"--format=yaml"}, want: `unsupported format "yaml"`},
+		{name: "repeated", args: []string{"--format=json", "--format=markdown"}, want: "--format may be specified only once"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runSummary(tc.args...)
+			if exitCode != 2 || stdout != "" || !strings.Contains(stderr, tc.want) {
+				t.Fatalf("Run(%q) = stdout %q stderr %q exit %d", tc.args, stdout, stderr, exitCode)
+			}
+		})
+	}
+}
+
 type timingArtifactFixture struct {
 	Schema     int          `json:"schema"`
 	ShardID    string       `json:"shard_id"`


### PR DESCRIPTION
## Summary

- Add a versioned, deterministic JSON timing-history snapshot through `test-timing-summary --format=json`.
- Reuse the existing strict schema-v1 loader, duplicate detector, runner-profile partitioning, and statistical calculations.
- Preserve the default Markdown report byte-for-byte through the same canonical snapshot model.

## Why

Historical shard planning needs a machine-readable contract before protected persistence or planner activation. Without one, the next phase would need a second parser or prose scraping, splitting timing policy across implementations.

## Contract

- Groups top-level runnable tests by comparable job, variant, runner label, OS, architecture, and CPU count.
- Retains every successful observation with tested SHA and exact artifact identity while keeping failure and skip counts.
- Emits p50, p75, p95, population variance, and explicit authority thresholds: p75 at 5 successes and p95 at 20.
- Keeps zero-success units with `null` statistics and `successful_observations: []`.
- Sorts opaque run IDs and attempts as raw strings in a documented canonical tuple.
- Rejects duplicate conflicts and unit-identity conflicts, including conflicts across runner profiles.

## Compatibility and scope

- Default Markdown output is locked by an exact golden assertion.
- Schema v1 cannot prove event, ref, conclusion, or chronological recency; the documentation states those limits explicitly.
- This snapshot is workflow-neutral input. It does not add CI permissions, protected persistence, retention, aliases, shard selection, or planner authority.

## Performance

- Affected package wall time: 0.40s after versus 0.36s baseline.
- Isolated fast suite: 235.17s, under the 5-minute policy target.
- Push hook: all eight machine-aware fast jobs passed.
- Resource-census ratchets remain unchanged.

## Verification

- `go test ./internal/testpolicy/timingsummary -run TestBuildSnapshot -count=20`
- `go test -race ./internal/testpolicy/timingsummary -count=1`
- `go test ./scripts -count=1`
- `go test -count=1 ./internal/testpolicy/resourcecensus -run ^TestRepositoryLedgerMatchesCensusAndDocumentation$`
- `go test ./test/docsync -count=1`
- `make test-ci-policy`
- `go vet ./...`
- `make test-fast-parallel`
- Three delegated council reviewers unanimously approved exact binary diff SHA-256 `90a1ecebc660ad7090c41beecfc999eeb2704ee4b69fb6123318e4082ff137db`.

Tracker: `ga-80po0c.4.1`