### PR TITLE
fix(hook): write session pointers to city store

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 const hookClaimCommandName = "hook"
 
 var hookClaimMutationTimeout = 10 * time.Second
+
+var hookClaimCommandRunnerWithEnvContext = beads.ExecCommandRunnerWithEnvContext
 
 type hookClaimOptions struct {
 	Assignee           string
@@ -483,12 +486,53 @@ func recordHookClaimSessionPointers(bead beads.Bead, opts hookClaimOptions, ops 
 	}
 }
 
-func hookRecordSessionPointersWithBdStore(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error {
-	store := hookClaimBdStoreContext(ctx, dir, env, assignee)
+func hookRecordSessionPointersWithBdStore(ctx context.Context, _ string, env []string, assignee, sessionBeadID, runID, stepID string) error {
+	cityDir, cityEnv, err := hookClaimSessionStoreContext(ctx, env)
+	if err != nil {
+		return err
+	}
+	store := hookClaimBdStoreContext(ctx, cityDir, cityEnv, assignee)
 	return store.Update(sessionBeadID, beads.UpdateOpts{Metadata: map[string]string{
 		beadmeta.CurrentRunIDMetadataKey:   runID,
 		beadmeta.ActiveWorkBeadMetadataKey: stepID,
 	}})
+}
+
+// hookClaimSessionStoreContext rebuilds the store environment for the city
+// scope. Claim and continuation mutations use the selected work store, but
+// session beads always live in the city store, including when work was claimed
+// through cross-store federation from a rig.
+func hookClaimSessionStoreContext(ctx context.Context, env []string) (string, []string, error) {
+	cityPath := ""
+	for _, key := range []string{"GC_CITY_PATH", "GC_CITY"} {
+		for _, entry := range env {
+			k, value, ok := strings.Cut(entry, "=")
+			if !ok || k != key {
+				continue
+			}
+			value = strings.TrimSpace(value)
+			if value != "" && filepath.IsAbs(value) {
+				cityPath = filepath.Clean(value)
+				break
+			}
+		}
+		if cityPath != "" {
+			break
+		}
+	}
+	if cityPath == "" {
+		return "", nil, errors.New("resolving city store for session pointers: missing absolute GC_CITY_PATH or GC_CITY")
+	}
+
+	overrides, err := bdRuntimeEnvWithErrorRecoveryContext(ctx, cityPath, true)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolving city store for session pointers: %w", err)
+	}
+	overrides["GC_STORE_ROOT"] = cityPath
+	overrides["GC_STORE_SCOPE"] = "city"
+	overrides["GC_RIG"] = ""
+	overrides["GC_RIG_ROOT"] = ""
+	return cityPath, mergeRuntimeEnv(env, overrides), nil
 }
 
 // hookClaimSessionID returns the session bead id (GC_SESSION_ID) from the claim
@@ -576,7 +620,7 @@ func hookClaimBdStore(dir string, env []string, actor string) *beads.BdStore {
 // so a best-effort claim-time write cannot outlast the caller's deadline even if
 // the underlying bd update stalls.
 func hookClaimBdStoreContext(ctx context.Context, dir string, env []string, actor string) *beads.BdStore {
-	return beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnvContext(ctx, hookClaimEnvMap(env, dir, actor)))
+	return beads.NewBdStore(dir, hookClaimCommandRunnerWithEnvContext(ctx, hookClaimEnvMap(env, dir, actor)))
 }
 
 func hookClaimEnvMap(env []string, dir string, actor string) map[string]string {

--- a/cmd/gc/cmd_hook_claim_test.go
+++ b/cmd/gc/cmd_hook_claim_test.go
@@ -5,11 +5,113 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
+
+func TestHookClaimSessionStoreContextUsesCityScopeAfterRigClaim(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "demo")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+
+	dir, env, err := hookClaimSessionStoreContext(context.Background(), []string{
+		"GC_CITY_PATH=" + cityDir,
+		"GC_CITY=" + cityDir,
+		"GC_STORE_ROOT=" + rigDir,
+		"GC_STORE_SCOPE=rig",
+		"GC_RIG=demo",
+		"GC_RIG_ROOT=" + rigDir,
+		"BEADS_DIR=" + rigBeadsDir,
+		"GC_DOLT_HOST=rig-dolt.example",
+		"GC_DOLT_PORT=3307",
+	})
+	if err != nil {
+		t.Fatalf("hookClaimSessionStoreContext: %v", err)
+	}
+	if dir != cityDir {
+		t.Fatalf("dir = %q, want city dir %q", dir, cityDir)
+	}
+
+	got := envEntriesMap(env)
+	for key, want := range map[string]string{
+		"GC_CITY_PATH":   cityDir,
+		"GC_STORE_ROOT":  cityDir,
+		"GC_STORE_SCOPE": "city",
+		"BEADS_DIR":      filepath.Join(cityDir, ".beads"),
+		"GC_RIG":         "",
+		"GC_RIG_ROOT":    "",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %q, want %q", key, got[key], want)
+		}
+	}
+	if got["GC_DOLT_HOST"] == "rig-dolt.example" || got["GC_DOLT_PORT"] == "3307" {
+		t.Fatalf("rig Dolt endpoint leaked into city session store env: %#v", got)
+	}
+}
+
+func TestHookClaimSessionStoreContextRejectsMissingCityPath(t *testing.T) {
+	_, _, err := hookClaimSessionStoreContext(context.Background(), []string{
+		"GC_RIG_ROOT=/city/rigs/demo",
+		"BEADS_DIR=/city/rigs/demo/.beads",
+	})
+	if err == nil {
+		t.Fatal("hookClaimSessionStoreContext succeeded without a city path")
+	}
+}
+
+func TestHookRecordSessionPointersUsesCityStoreAfterRigClaim(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "demo")
+
+	originalRunner := hookClaimCommandRunnerWithEnvContext
+	t.Cleanup(func() { hookClaimCommandRunnerWithEnvContext = originalRunner })
+	var capturedDir string
+	var capturedEnv map[string]string
+	var capturedName string
+	var capturedArgs []string
+	hookClaimCommandRunnerWithEnvContext = func(_ context.Context, env map[string]string) beads.CommandRunner {
+		capturedEnv = env
+		return func(dir, name string, args ...string) ([]byte, error) {
+			capturedDir = dir
+			capturedName = name
+			capturedArgs = append([]string(nil), args...)
+			return nil, nil
+		}
+	}
+
+	err := hookRecordSessionPointersWithBdStore(
+		context.Background(),
+		rigDir,
+		[]string{
+			"GC_CITY_PATH=" + cityDir,
+			"GC_STORE_ROOT=" + rigDir,
+			"GC_STORE_SCOPE=rig",
+			"GC_RIG=demo",
+			"GC_RIG_ROOT=" + rigDir,
+			"BEADS_DIR=" + filepath.Join(rigDir, ".beads"),
+		},
+		"worker-1", "session-1", "run-1", "step-1",
+	)
+	if err != nil {
+		t.Fatalf("hookRecordSessionPointersWithBdStore: %v", err)
+	}
+
+	if capturedDir != cityDir {
+		t.Fatalf("bd dir = %q, want %q", capturedDir, cityDir)
+	}
+	if capturedEnv["BEADS_DIR"] != filepath.Join(cityDir, ".beads") ||
+		capturedEnv["GC_STORE_SCOPE"] != "city" || capturedEnv["GC_RIG_ROOT"] != "" {
+		t.Fatalf("bd env did not select city scope: %#v", capturedEnv)
+	}
+	if capturedName != "bd" || len(capturedArgs) < 3 ||
+		!reflect.DeepEqual(capturedArgs[:3], []string{"update", "--json", "session-1"}) {
+		t.Fatalf("bd command = %q %#v, want bd update --json session-1", capturedName, capturedArgs)
+	}
+}
 
 func TestDoHookClaimUsesSelectedStoreContextForMutationAndContinuation(t *testing.T) {
 	var claimedDir string


### PR DESCRIPTION
## Summary

- rebuild the canonical city backend environment before claim-time session-pointer updates
- keep claim, work-branch, and continuation mutations on the selected work store
- reject missing city identity instead of silently falling back to a rig store
- cover rig-to-city routing at both the environment and actual `bd update` command-runner seams

Fixes #4304.

## Testing

- [ ] `make check` (formatter passed; local full lint package loading was stopped after an unusually long run)
- [x] `CGO_ENABLED=0 go test ./cmd/gc -run ^TestHookRecordSessionPointersUsesCityStoreAfterRigClaim$ -count=1`
- [x] `CGO_ENABLED=0 go test ./internal/testpolicy/resourcecensus -run ^TestRepositoryLedgerMatchesCensusAndDocumentation$ -count=1`
- [x] First CI rerun confirmed the corrected cmd/gc process shard passed; its resource-census failure was addressed by replacing test PATH mutation with a command-runner seam
- [ ] `make test-integration` (not run locally; upstream CI runs integration coverage)

## Checklist

- [x] Linked issue #4304
- [x] Added tests for the behavior change
- [x] No user-facing documentation change required
- [x] No breaking change or migration required