### PR TITLE
test: persist normalized timing history cohorts

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -274,7 +274,8 @@ SHA of the final successful observation in canonical artifact-identity order;
 schema v1 has no trustworthy timestamp, so this field is deterministic but not
 a claim about chronological recency.
 
-Schema v1 does not record the event, ref, or workflow conclusion, so the tool
+Timing artifact schema v1 does not record the event, ref, or workflow
+conclusion, so the tool
 cannot prove protected-branch provenance. The caller must supply artifacts
 from successful `main` push runs. The JSON snapshot is workflow-neutral input,
 not a protected store or planner decision. An observed p75 with fewer than five
@@ -283,7 +284,38 @@ planner-authoritative. The seven-day artifact retention window is not a
 protected historical timing database, and this one-shot builder does not prune
 observations. Renamed tests remain separate histories.
 
-In schema v1, `commit_sha` is the exact Git revision checked out and tested
+The storage-boundary mutation mode persists caller-authenticated cohorts
+without merging report snapshots:
+
+```bash
+go run ./scripts/test-timing-summary.go \
+  --update-history timing-history-db-v1.json \
+  --run-envelope trusted-run-v1.json \
+  --retain-runs 50 \
+  --format=json \
+  /path/to/this-run-artifacts > timing-history-v1.json
+```
+
+All three mutation flags are required together, and retention has no hidden
+default. The versioned run envelope names the repository, event, ref, workflow,
+run ID, run attempt, tested SHA, conclusion, and RFC3339 completion time. The
+database stores each envelope and artifact once, then stores normalized
+pass/fail/skip samples by artifact reference. Replaying identical artifacts is
+therefore a byte-for-byte no-op; conflicting copies or envelope metadata fail
+before the existing database changes. Retention removes whole oldest cohorts
+by parsed completion time and recomputes snapshot statistics and the 5/20
+authority thresholds from the retained evidence. Publication uses a synced
+temporary sibling and atomic rename.
+
+This command validates envelope shape and checks each timing artifact's
+`workflow`, `run_id`, `run_attempt`, and `tested_sha` against it. It does not
+authenticate who supplied the envelope, prove that the cohort contains every
+expected shard, serialize multiple writers, publish `ci-metrics`, or make the
+result planner-authoritative. Those are responsibilities of the later trusted
+default-branch workflow. Until that workflow lands, use the database as
+deterministic storage-boundary evidence only.
+
+In timing artifact schema v1, `commit_sha` is the exact Git revision checked out and tested
 (`GITHUB_SHA`). On `pull_request` runs, GitHub sets it to the synthetic merge
 commit, not the contributor branch head. Consumers must not interpret it as
 source/head identity. A future schema that needs both identities must add

--- a/internal/testpolicy/timingsummary/historydb.go
+++ b/internal/testpolicy/timingsummary/historydb.go
@@ -1,0 +1,665 @@
+package timingsummary
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// HistoryDatabaseSchema is the current normalized timing-history database schema.
+	HistoryDatabaseSchema = 1
+	// RunEnvelopeSchema is the current trusted-run envelope schema.
+	RunEnvelopeSchema = 1
+)
+
+// RunEnvelope identifies the trusted workflow run that produced a cohort of
+// timing artifacts. The storage layer validates its shape and artifact
+// agreement; the caller is responsible for authenticating its provenance.
+type RunEnvelope struct {
+	Schema      int    `json:"schema"`
+	Repository  string `json:"repository"`
+	Event       string `json:"event"`
+	Ref         string `json:"ref"`
+	Workflow    string `json:"workflow"`
+	RunID       string `json:"run_id"`
+	RunAttempt  string `json:"run_attempt"`
+	TestedSHA   string `json:"tested_sha"`
+	Conclusion  string `json:"conclusion"`
+	CompletedAt string `json:"completed_at"`
+}
+
+// HistoryDatabase stores normalized timing evidence. Persisted indexes are a
+// compact wire representation only; merge and retention decisions use stable
+// run and artifact identities.
+type HistoryDatabase struct {
+	Schema    int               `json:"schema"`
+	Runs      []RunEnvelope     `json:"runs"`
+	Artifacts []HistoryArtifact `json:"artifacts"`
+	Units     []HistoryUnit     `json:"units"`
+}
+
+// HistoryArtifact records the run-local identity and runner profile shared by
+// all samples captured in one schema-v1 artifact.
+type HistoryArtifact struct {
+	RunIndex int           `json:"run_index"`
+	Job      string        `json:"job"`
+	ShardID  string        `json:"shard_id"`
+	Variant  string        `json:"variant"`
+	Runner   HistoryRunner `json:"runner"`
+}
+
+// HistoryRunner retains the complete schema-v1 runner evidence, including the
+// ephemeral name used to detect conflicting copies of one artifact.
+type HistoryRunner struct {
+	Label    string `json:"label"`
+	Name     string `json:"name"`
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	CPUCount int    `json:"cpu_count"`
+}
+
+// HistoryUnit stores one stable unit identity and all retained samples for it.
+type HistoryUnit struct {
+	UnitID  string          `json:"unit_id"`
+	Kind    string          `json:"kind"`
+	Package string          `json:"package"`
+	Test    string          `json:"test"`
+	Subtest string          `json:"subtest"`
+	Samples []HistorySample `json:"samples"`
+}
+
+// HistorySample references the artifact that supplied one terminal unit row.
+// Duplicate rows inside an artifact remain distinct samples.
+type HistorySample struct {
+	ArtifactIndex   int     `json:"artifact_index"`
+	Outcome         string  `json:"outcome"`
+	DurationSeconds float64 `json:"duration_seconds"`
+}
+
+type historyRunKey struct {
+	Repository string
+	Workflow   string
+	RunID      string
+	RunAttempt string
+}
+
+type historyArtifactKey struct {
+	Run     historyRunKey
+	Job     string
+	ShardID string
+	Variant string
+}
+
+type historyArtifactEvidence struct {
+	key      historyArtifactKey
+	artifact artifact
+}
+
+type historyUnitIdentity struct {
+	UnitID  string
+	Kind    string
+	Package string
+	Test    string
+	Subtest string
+}
+
+type historyUnitAccumulator struct {
+	identity historyUnitIdentity
+	samples  []HistorySample
+}
+
+// UpdateHistory merges one run's validated schema-v1 artifacts into a
+// normalized database, retains the newest retainRuns whole cohorts, publishes
+// the database atomically, and returns the existing Snapshot projection of the
+// retained evidence.
+func UpdateHistory(databasePath string, envelope RunEnvelope, retainRuns int, roots []string) (Snapshot, error) {
+	if strings.TrimSpace(databasePath) == "" {
+		return Snapshot{}, errors.New("history database path is required")
+	}
+	if retainRuns <= 0 {
+		return Snapshot{}, errors.New("retain-runs must be a positive integer")
+	}
+	if len(roots) == 0 {
+		return Snapshot{}, errors.New("at least one artifact root is required")
+	}
+
+	normalizedEnvelope, _, err := normalizeRunEnvelope(envelope)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("validate run envelope: %w", err)
+	}
+	existingBytes, runs, evidence, err := loadHistoryDatabase(databasePath)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if len(runs) > 0 && runs[0].Repository != normalizedEnvelope.Repository {
+		return Snapshot{}, fmt.Errorf("history database repository %q does not match run envelope repository %q",
+			runs[0].Repository, normalizedEnvelope.Repository)
+	}
+
+	incoming, _, err := loadArtifacts(roots)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	for index := range incoming {
+		incoming[index] = canonicalHistoryArtifact(incoming[index])
+		if err := validateArtifactEnvelope(incoming[index], normalizedEnvelope); err != nil {
+			return Snapshot{}, fmt.Errorf("validate incoming artifact %s: %w", formatArtifactIdentity(incoming[index]), err)
+		}
+	}
+
+	runsByKey := make(map[historyRunKey]RunEnvelope, len(runs)+1)
+	for _, run := range runs {
+		runsByKey[runEnvelopeKey(run)] = run
+	}
+	incomingRunKey := runEnvelopeKey(normalizedEnvelope)
+	if previous, ok := runsByKey[incomingRunKey]; ok {
+		if !reflect.DeepEqual(previous, normalizedEnvelope) {
+			return Snapshot{}, fmt.Errorf("conflicting run envelope for %s", formatHistoryRunKey(incomingRunKey))
+		}
+	} else {
+		runsByKey[incomingRunKey] = normalizedEnvelope
+	}
+
+	evidenceByKey := make(map[historyArtifactKey]artifact, len(evidence)+len(incoming))
+	for _, stored := range evidence {
+		evidenceByKey[stored.key] = stored.artifact
+	}
+	for _, item := range incoming {
+		key := historyArtifactKeyFor(normalizedEnvelope, item)
+		if previous, ok := evidenceByKey[key]; ok {
+			if !reflect.DeepEqual(previous, item) {
+				return Snapshot{}, fmt.Errorf("conflicting artifact for %s", formatHistoryArtifactKey(key))
+			}
+			continue
+		}
+		evidenceByKey[key] = item
+	}
+
+	retainedRuns, retainedKeys, err := retainHistoryRuns(runsByKey, retainRuns)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	retainedEvidence := make([]historyArtifactEvidence, 0, len(evidenceByKey))
+	for key, item := range evidenceByKey {
+		if _, keep := retainedKeys[key.Run]; keep {
+			retainedEvidence = append(retainedEvidence, historyArtifactEvidence{key: key, artifact: item})
+		}
+	}
+
+	database, artifacts, err := materializeHistoryDatabase(retainedRuns, retainedEvidence)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot, err := buildSnapshot(artifacts, 0)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("build retained snapshot: %w", err)
+	}
+	encoded, err := encodeHistoryDatabase(database)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if bytes.Equal(existingBytes, encoded) {
+		return snapshot, nil
+	}
+	if err := writeHistoryDatabaseAtomically(databasePath, encoded); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func normalizeRunEnvelope(envelope RunEnvelope) (RunEnvelope, time.Time, error) {
+	if envelope.Schema != RunEnvelopeSchema {
+		return RunEnvelope{}, time.Time{}, fmt.Errorf("unsupported schema %d", envelope.Schema)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "repository", value: envelope.Repository},
+		{name: "event", value: envelope.Event},
+		{name: "ref", value: envelope.Ref},
+		{name: "workflow", value: envelope.Workflow},
+		{name: "run_id", value: envelope.RunID},
+		{name: "run_attempt", value: envelope.RunAttempt},
+		{name: "tested_sha", value: envelope.TestedSHA},
+		{name: "conclusion", value: envelope.Conclusion},
+		{name: "completed_at", value: envelope.CompletedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return RunEnvelope{}, time.Time{}, fmt.Errorf("%s is required", field.name)
+		}
+	}
+	completedAt, err := time.Parse(time.RFC3339Nano, envelope.CompletedAt)
+	if err != nil {
+		return RunEnvelope{}, time.Time{}, fmt.Errorf("completed_at must be RFC3339: %w", err)
+	}
+	if completedAt.IsZero() {
+		return RunEnvelope{}, time.Time{}, errors.New("completed_at must not be zero")
+	}
+	envelope.CompletedAt = completedAt.UTC().Format(time.RFC3339Nano)
+	return envelope, completedAt.UTC(), nil
+}
+
+func validateArtifactEnvelope(item artifact, envelope RunEnvelope) error {
+	for _, field := range []struct {
+		name     string
+		artifact string
+		envelope string
+	}{
+		{name: "workflow", artifact: item.Workflow, envelope: envelope.Workflow},
+		{name: "run_id", artifact: item.RunID, envelope: envelope.RunID},
+		{name: "run_attempt", artifact: item.RunAttempt, envelope: envelope.RunAttempt},
+		{name: "tested_sha", artifact: item.CommitSHA, envelope: envelope.TestedSHA},
+	} {
+		if field.artifact != field.envelope {
+			return fmt.Errorf("%s %q does not match run envelope %q", field.name, field.artifact, field.envelope)
+		}
+	}
+	return nil
+}
+
+func loadHistoryDatabase(path string) ([]byte, []RunEnvelope, []historyArtifactEvidence, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("read history database %q: %w", path, err)
+	}
+
+	var header struct {
+		Schema *int `json:"schema"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return nil, nil, nil, fmt.Errorf("decode history database schema %q: %w", path, err)
+	}
+	if header.Schema == nil {
+		return nil, nil, nil, fmt.Errorf("validate history database %q: schema is required", path)
+	}
+	if *header.Schema != HistoryDatabaseSchema {
+		return nil, nil, nil, fmt.Errorf("validate history database %q: unsupported schema %d", path, *header.Schema)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var database HistoryDatabase
+	if err := decoder.Decode(&database); err != nil {
+		return nil, nil, nil, fmt.Errorf("decode history database %q: %w", path, err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return nil, nil, nil, fmt.Errorf("decode history database %q: %w", path, err)
+	}
+	runs, evidence, err := validateStoredHistory(database)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("validate history database %q: %w", path, err)
+	}
+	return data, runs, evidence, nil
+}
+
+func validateStoredHistory(database HistoryDatabase) ([]RunEnvelope, []historyArtifactEvidence, error) {
+	if database.Schema != HistoryDatabaseSchema {
+		return nil, nil, fmt.Errorf("unsupported schema %d", database.Schema)
+	}
+	if database.Runs == nil || database.Artifacts == nil || database.Units == nil {
+		return nil, nil, errors.New("runs, artifacts, and units must be JSON arrays")
+	}
+	if len(database.Runs) == 0 {
+		return nil, nil, errors.New("runs must not be empty")
+	}
+
+	runs := make([]RunEnvelope, len(database.Runs))
+	runKeys := make(map[historyRunKey]struct{}, len(database.Runs))
+	repository := ""
+	for index, raw := range database.Runs {
+		run, _, err := normalizeRunEnvelope(raw)
+		if err != nil {
+			return nil, nil, fmt.Errorf("runs[%d]: %w", index, err)
+		}
+		if repository == "" {
+			repository = run.Repository
+		} else if run.Repository != repository {
+			return nil, nil, fmt.Errorf("runs[%d]: repository %q does not match database repository %q", index, run.Repository, repository)
+		}
+		key := runEnvelopeKey(run)
+		if _, exists := runKeys[key]; exists {
+			return nil, nil, fmt.Errorf("duplicate run %s", formatHistoryRunKey(key))
+		}
+		runKeys[key] = struct{}{}
+		runs[index] = run
+	}
+
+	evidence := make([]historyArtifactEvidence, len(database.Artifacts))
+	artifactKeys := make(map[historyArtifactKey]struct{}, len(database.Artifacts))
+	artifactsPerRun := make([]int, len(runs))
+	for index, stored := range database.Artifacts {
+		if stored.RunIndex < 0 || stored.RunIndex >= len(runs) {
+			return nil, nil, fmt.Errorf("artifacts[%d]: run_index %d is out of range", index, stored.RunIndex)
+		}
+		run := runs[stored.RunIndex]
+		item := artifact{
+			Schema: timingArtifactSchema, ShardID: stored.ShardID, Variant: stored.Variant,
+			CommitSHA: run.TestedSHA, Workflow: run.Workflow, RunID: run.RunID,
+			RunAttempt: run.RunAttempt, Job: stored.Job,
+			Runner: artifactRunner{
+				Label: stored.Runner.Label, Name: stored.Runner.Name, OS: stored.Runner.OS,
+				Arch: stored.Runner.Arch, CPUCount: stored.Runner.CPUCount,
+			},
+			Units: make([]artifactUnit, 0),
+		}
+		key := historyArtifactKeyFor(run, item)
+		if _, exists := artifactKeys[key]; exists {
+			return nil, nil, fmt.Errorf("duplicate artifact %s", formatHistoryArtifactKey(key))
+		}
+		artifactKeys[key] = struct{}{}
+		artifactsPerRun[stored.RunIndex]++
+		evidence[index] = historyArtifactEvidence{key: key, artifact: item}
+	}
+	for index, count := range artifactsPerRun {
+		if count == 0 {
+			return nil, nil, fmt.Errorf("runs[%d]: run has no artifacts", index)
+		}
+	}
+
+	unitIDs := make(map[string]historyUnitIdentity, len(database.Units))
+	for unitIndex, stored := range database.Units {
+		identity := historyUnitIdentity{
+			UnitID: stored.UnitID, Kind: stored.Kind, Package: stored.Package,
+			Test: stored.Test, Subtest: stored.Subtest,
+		}
+		if previous, exists := unitIDs[identity.UnitID]; exists {
+			return nil, nil, fmt.Errorf("units[%d]: duplicate unit %q conflicts with %s", unitIndex, identity.UnitID, formatHistoryUnitIdentity(previous))
+		}
+		unitIDs[identity.UnitID] = identity
+		if len(stored.Samples) == 0 {
+			return nil, nil, fmt.Errorf("units[%d]: samples must not be empty", unitIndex)
+		}
+		for sampleIndex, sample := range stored.Samples {
+			if sample.ArtifactIndex < 0 || sample.ArtifactIndex >= len(evidence) {
+				return nil, nil, fmt.Errorf("units[%d].samples[%d]: artifact_index %d is out of range", unitIndex, sampleIndex, sample.ArtifactIndex)
+			}
+			unit := artifactUnit{
+				UnitID: identity.UnitID, Kind: identity.Kind, Package: identity.Package,
+				Test: identity.Test, Subtest: identity.Subtest, Outcome: sample.Outcome,
+				DurationSeconds: canonicalFloat(sample.DurationSeconds),
+			}
+			if err := validateUnit(unit); err != nil {
+				return nil, nil, fmt.Errorf("units[%d].samples[%d]: %w", unitIndex, sampleIndex, err)
+			}
+			evidence[sample.ArtifactIndex].artifact.Units = append(evidence[sample.ArtifactIndex].artifact.Units, unit)
+		}
+	}
+	for index := range evidence {
+		evidence[index].artifact = canonicalHistoryArtifact(evidence[index].artifact)
+		if err := validateArtifact(evidence[index].artifact); err != nil {
+			return nil, nil, fmt.Errorf("artifacts[%d]: %w", index, err)
+		}
+	}
+	return runs, evidence, nil
+}
+
+func retainHistoryRuns(runsByKey map[historyRunKey]RunEnvelope, retainRuns int) ([]RunEnvelope, map[historyRunKey]struct{}, error) {
+	type completedRun struct {
+		key       historyRunKey
+		envelope  RunEnvelope
+		completed time.Time
+	}
+	runs := make([]completedRun, 0, len(runsByKey))
+	for key, envelope := range runsByKey {
+		normalized, completed, err := normalizeRunEnvelope(envelope)
+		if err != nil {
+			return nil, nil, fmt.Errorf("validate retained run %s: %w", formatHistoryRunKey(key), err)
+		}
+		runs = append(runs, completedRun{key: key, envelope: normalized, completed: completed})
+	}
+	sort.Slice(runs, func(i, j int) bool {
+		if !runs[i].completed.Equal(runs[j].completed) {
+			return runs[i].completed.Before(runs[j].completed)
+		}
+		return compareHistoryRunKey(runs[i].key, runs[j].key) < 0
+	})
+	if len(runs) > retainRuns {
+		runs = runs[len(runs)-retainRuns:]
+	}
+	retained := make(map[historyRunKey]struct{}, len(runs))
+	result := make([]RunEnvelope, 0, len(runs))
+	for _, run := range runs {
+		retained[run.key] = struct{}{}
+		result = append(result, run.envelope)
+	}
+	return result, retained, nil
+}
+
+func materializeHistoryDatabase(runs []RunEnvelope, evidence []historyArtifactEvidence) (HistoryDatabase, []artifact, error) {
+	sort.Slice(runs, func(i, j int) bool {
+		return compareHistoryRunKey(runEnvelopeKey(runs[i]), runEnvelopeKey(runs[j])) < 0
+	})
+	runIndexes := make(map[historyRunKey]int, len(runs))
+	for index, run := range runs {
+		runIndexes[runEnvelopeKey(run)] = index
+	}
+	sort.Slice(evidence, func(i, j int) bool {
+		return compareHistoryArtifactKey(evidence[i].key, evidence[j].key) < 0
+	})
+
+	storedArtifacts := make([]HistoryArtifact, 0, len(evidence))
+	artifacts := make([]artifact, 0, len(evidence))
+	units := make(map[string]*historyUnitAccumulator)
+	for artifactIndex, stored := range evidence {
+		runIndex, ok := runIndexes[stored.key.Run]
+		if !ok {
+			return HistoryDatabase{}, nil, fmt.Errorf("artifact %s references a pruned run", formatHistoryArtifactKey(stored.key))
+		}
+		item := canonicalHistoryArtifact(stored.artifact)
+		storedArtifacts = append(storedArtifacts, HistoryArtifact{
+			RunIndex: runIndex, Job: item.Job, ShardID: item.ShardID, Variant: item.Variant,
+			Runner: HistoryRunner{
+				Label: item.Runner.Label, Name: item.Runner.Name, OS: item.Runner.OS,
+				Arch: item.Runner.Arch, CPUCount: item.Runner.CPUCount,
+			},
+		})
+		artifacts = append(artifacts, item)
+		for _, unit := range item.Units {
+			identity := historyUnitIdentity{
+				UnitID: unit.UnitID, Kind: unit.Kind, Package: unit.Package,
+				Test: unit.Test, Subtest: unit.Subtest,
+			}
+			accumulator := units[unit.UnitID]
+			if accumulator == nil {
+				accumulator = &historyUnitAccumulator{identity: identity, samples: make([]HistorySample, 0)}
+				units[unit.UnitID] = accumulator
+			} else if accumulator.identity != identity {
+				return HistoryDatabase{}, nil, fmt.Errorf("conflicting identity for unit %q: %s != %s",
+					unit.UnitID, formatHistoryUnitIdentity(accumulator.identity), formatHistoryUnitIdentity(identity))
+			}
+			accumulator.samples = append(accumulator.samples, HistorySample{
+				ArtifactIndex: artifactIndex, Outcome: unit.Outcome,
+				DurationSeconds: canonicalFloat(unit.DurationSeconds),
+			})
+		}
+	}
+
+	unitIDs := make([]string, 0, len(units))
+	for unitID := range units {
+		unitIDs = append(unitIDs, unitID)
+	}
+	sort.Strings(unitIDs)
+	storedUnits := make([]HistoryUnit, 0, len(unitIDs))
+	for _, unitID := range unitIDs {
+		accumulator := units[unitID]
+		sort.SliceStable(accumulator.samples, func(i, j int) bool {
+			left, right := accumulator.samples[i], accumulator.samples[j]
+			if left.ArtifactIndex != right.ArtifactIndex {
+				return left.ArtifactIndex < right.ArtifactIndex
+			}
+			if left.Outcome != right.Outcome {
+				return left.Outcome < right.Outcome
+			}
+			return left.DurationSeconds < right.DurationSeconds
+		})
+		storedUnits = append(storedUnits, HistoryUnit{
+			UnitID: accumulator.identity.UnitID, Kind: accumulator.identity.Kind,
+			Package: accumulator.identity.Package, Test: accumulator.identity.Test,
+			Subtest: accumulator.identity.Subtest, Samples: accumulator.samples,
+		})
+	}
+	return HistoryDatabase{
+		Schema: HistoryDatabaseSchema, Runs: runs, Artifacts: storedArtifacts, Units: storedUnits,
+	}, artifacts, nil
+}
+
+func canonicalHistoryArtifact(item artifact) artifact {
+	item.Units = append([]artifactUnit(nil), item.Units...)
+	for index := range item.Units {
+		item.Units[index].DurationSeconds = canonicalFloat(item.Units[index].DurationSeconds)
+	}
+	sort.SliceStable(item.Units, func(i, j int) bool {
+		left, right := item.Units[i], item.Units[j]
+		leftFields := []string{left.UnitID, left.Kind, left.Package, left.Test, left.Subtest, left.Outcome}
+		rightFields := []string{right.UnitID, right.Kind, right.Package, right.Test, right.Subtest, right.Outcome}
+		for index := range leftFields {
+			if leftFields[index] != rightFields[index] {
+				return leftFields[index] < rightFields[index]
+			}
+		}
+		return left.DurationSeconds < right.DurationSeconds
+	})
+	return item
+}
+
+func encodeHistoryDatabase(database HistoryDatabase) ([]byte, error) {
+	data, err := json.Marshal(database)
+	if err != nil {
+		return nil, fmt.Errorf("encode history database: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func writeHistoryDatabaseAtomically(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create history database directory %q: %w", dir, err)
+	}
+	temporary, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary history database beside %q: %w", path, err)
+	}
+	temporaryPath := temporary.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o644); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("chmod temporary history database: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write temporary history database: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync temporary history database: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary history database: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish history database %q: %w", path, err)
+	}
+	cleanup = false
+	return nil
+}
+
+func decodeRunEnvelope(path string) (RunEnvelope, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return RunEnvelope{}, fmt.Errorf("read run envelope %q: %w", path, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var envelope RunEnvelope
+	if err := decoder.Decode(&envelope); err != nil {
+		return RunEnvelope{}, fmt.Errorf("decode run envelope %q: %w", path, err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return RunEnvelope{}, fmt.Errorf("decode run envelope %q: %w", path, err)
+	}
+	normalized, _, err := normalizeRunEnvelope(envelope)
+	if err != nil {
+		return RunEnvelope{}, fmt.Errorf("validate run envelope %q: %w", path, err)
+	}
+	return normalized, nil
+}
+
+func runEnvelopeKey(envelope RunEnvelope) historyRunKey {
+	return historyRunKey{
+		Repository: envelope.Repository, Workflow: envelope.Workflow,
+		RunID: envelope.RunID, RunAttempt: envelope.RunAttempt,
+	}
+}
+
+func historyArtifactKeyFor(envelope RunEnvelope, item artifact) historyArtifactKey {
+	return historyArtifactKey{
+		Run: runEnvelopeKey(envelope), Job: item.Job, ShardID: item.ShardID, Variant: item.Variant,
+	}
+}
+
+func compareHistoryRunKey(left, right historyRunKey) int {
+	leftFields := []string{left.Repository, left.Workflow, left.RunID, left.RunAttempt}
+	rightFields := []string{right.Repository, right.Workflow, right.RunID, right.RunAttempt}
+	for index := range leftFields {
+		if leftFields[index] < rightFields[index] {
+			return -1
+		}
+		if leftFields[index] > rightFields[index] {
+			return 1
+		}
+	}
+	return 0
+}
+
+func compareHistoryArtifactKey(left, right historyArtifactKey) int {
+	if result := compareHistoryRunKey(left.Run, right.Run); result != 0 {
+		return result
+	}
+	leftFields := []string{left.Job, left.ShardID, left.Variant}
+	rightFields := []string{right.Job, right.ShardID, right.Variant}
+	for index := range leftFields {
+		if leftFields[index] < rightFields[index] {
+			return -1
+		}
+		if leftFields[index] > rightFields[index] {
+			return 1
+		}
+	}
+	return 0
+}
+
+func formatHistoryRunKey(key historyRunKey) string {
+	return fmt.Sprintf("repository=%q workflow=%q run=%q attempt=%q", key.Repository, key.Workflow, key.RunID, key.RunAttempt)
+}
+
+func formatHistoryArtifactKey(key historyArtifactKey) string {
+	return fmt.Sprintf("%s job=%q shard=%q variant=%q", formatHistoryRunKey(key.Run), key.Job, key.ShardID, key.Variant)
+}
+
+func formatArtifactIdentity(item artifact) string {
+	return formatIdentity(ArtifactIdentity{
+		Workflow: item.Workflow, RunID: item.RunID, RunAttempt: item.RunAttempt,
+		Job: item.Job, ShardID: item.ShardID, Variant: item.Variant,
+	})
+}
+
+func formatHistoryUnitIdentity(identity historyUnitIdentity) string {
+	return fmt.Sprintf("kind=%q package=%q test=%q subtest=%q", identity.Kind, identity.Package, identity.Test, identity.Subtest)
+}

--- a/internal/testpolicy/timingsummary/historydb_test.go
+++ b/internal/testpolicy/timingsummary/historydb_test.go
@@ -1,0 +1,666 @@
+package timingsummary
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestUpdateHistoryCreateCanonical(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	envelope := historyRunEnvelope("10", "sha-10", "2026-07-15T10:00:00Z")
+	item := historyArtifact(envelope, "cmd-gc-process-1-of-12", []timingUnit{
+		{UnitID: "internal/example:TestWarm/child", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestWarm", Subtest: "child", Outcome: "pass", DurationSeconds: 2},
+		{UnitID: "internal/example:TestSkipped", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestSkipped", Outcome: "skip", DurationSeconds: 0},
+		{UnitID: "github.com/gastownhall/gascity/internal/example", Kind: "package", Package: "github.com/gastownhall/gascity/internal/example", Outcome: "pass", DurationSeconds: 9},
+		{UnitID: "internal/example:TestWarm", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestWarm", Outcome: "pass", DurationSeconds: 1.5},
+		{UnitID: "internal/example:TestCold", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestCold", Outcome: "fail", DurationSeconds: 3},
+	})
+	writeArtifact(t, root, "shuffled.json", item)
+
+	snapshot, err := UpdateHistory(databasePath, envelope, 10, []string{root})
+	if err != nil {
+		t.Fatalf("UpdateHistory: %v", err)
+	}
+	got, err := os.ReadFile(databasePath)
+	if err != nil {
+		t.Fatalf("read history database: %v", err)
+	}
+	const want = `{"schema":1,"runs":[{"schema":1,"repository":"gastownhall/gascity","event":"push","ref":"refs/heads/main","workflow":"CI","run_id":"10","run_attempt":"1","tested_sha":"sha-10","conclusion":"success","completed_at":"2026-07-15T10:00:00Z"}],` +
+		`"artifacts":[{"run_index":0,"job":"cmd-gc-process","shard_id":"cmd-gc-process-1-of-12","variant":"linux-default","runner":{"label":"blacksmith-32vcpu","name":"ephemeral-10-cmd-gc-process-1-of-12","os":"Linux","arch":"X64","cpu_count":32}}],` +
+		`"units":[{"unit_id":"github.com/gastownhall/gascity/internal/example","kind":"package","package":"github.com/gastownhall/gascity/internal/example","test":"","subtest":"","samples":[{"artifact_index":0,"outcome":"pass","duration_seconds":9}]},` +
+		`{"unit_id":"internal/example:TestCold","kind":"test","package":"github.com/gastownhall/gascity/internal/example","test":"TestCold","subtest":"","samples":[{"artifact_index":0,"outcome":"fail","duration_seconds":3}]},` +
+		`{"unit_id":"internal/example:TestSkipped","kind":"test","package":"github.com/gastownhall/gascity/internal/example","test":"TestSkipped","subtest":"","samples":[{"artifact_index":0,"outcome":"skip","duration_seconds":0}]},` +
+		`{"unit_id":"internal/example:TestWarm","kind":"test","package":"github.com/gastownhall/gascity/internal/example","test":"TestWarm","subtest":"","samples":[{"artifact_index":0,"outcome":"pass","duration_seconds":1.5}]},` +
+		`{"unit_id":"internal/example:TestWarm/child","kind":"test","package":"github.com/gastownhall/gascity/internal/example","test":"TestWarm","subtest":"child","samples":[{"artifact_index":0,"outcome":"pass","duration_seconds":2}]}]}` + "\n"
+	if string(got) != want {
+		t.Fatalf("canonical history database changed\ngot:  %q\nwant: %q", got, want)
+	}
+
+	profile := findHistoryProfile(t, snapshot, 32)
+	if len(profile.Units) != 3 {
+		t.Fatalf("derived snapshot top-level units = %d, want 3: %+v", len(profile.Units), profile.Units)
+	}
+	warm := findHistoryUnit(t, profile, "internal/example:TestWarm")
+	if warm.Passes != 1 || warm.Failures != 0 || warm.Skips != 0 || historyFloat(t, warm.DurationSecondsP95) != 1.5 {
+		t.Fatalf("derived warm history = %+v, want one 1.5s pass", warm)
+	}
+	cold := findHistoryUnit(t, profile, "internal/example:TestCold")
+	if cold.Passes != 0 || cold.Failures != 1 || cold.SuccessfulObservations == nil || len(cold.SuccessfulObservations) != 0 {
+		t.Fatalf("derived cold history = %+v, want one retained failure and [] successes", cold)
+	}
+}
+
+func TestUpdateHistoryIsIdempotentForOverlappingPassFailSkipArtifacts(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	envelope := historyRunEnvelope("20", "sha-20", "2026-07-15T11:00:00Z")
+	initialRoot := t.TempDir()
+	firstArtifact := historyArtifact(envelope, "shard-a", []timingUnit{
+		{UnitID: "internal/example:TestPass", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestPass", Outcome: "pass", DurationSeconds: 1},
+		{UnitID: "internal/example:TestFail", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestFail", Outcome: "fail", DurationSeconds: 2},
+	})
+	secondArtifact := historyArtifact(envelope, "shard-b", []timingUnit{
+		{UnitID: "internal/example:TestSkip", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example", Test: "TestSkip", Outcome: "skip", DurationSeconds: 0},
+	})
+	writeArtifact(t, initialRoot, "b.json", secondArtifact)
+	writeArtifact(t, initialRoot, "a.json", firstArtifact)
+
+	firstSnapshot, err := UpdateHistory(databasePath, envelope, 10, []string{initialRoot})
+	if err != nil {
+		t.Fatalf("first UpdateHistory: %v", err)
+	}
+	before, err := os.ReadFile(databasePath)
+	if err != nil {
+		t.Fatalf("read first history database: %v", err)
+	}
+
+	overlapRoot := t.TempDir()
+	writeArtifact(t, overlapRoot, "copies/second.json", secondArtifact)
+	writeArtifact(t, overlapRoot, "copies/first.json", firstArtifact)
+	secondSnapshot, err := UpdateHistory(databasePath, envelope, 10, []string{overlapRoot})
+	if err != nil {
+		t.Fatalf("overlapping UpdateHistory: %v", err)
+	}
+	after, err := os.ReadFile(databasePath)
+	if err != nil {
+		t.Fatalf("read replayed history database: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("idempotent replay changed database\nbefore: %s\nafter:  %s", before, after)
+	}
+	if !reflect.DeepEqual(secondSnapshot, firstSnapshot) {
+		t.Fatalf("idempotent replay changed derived snapshot\nbefore: %+v\nafter:  %+v", firstSnapshot, secondSnapshot)
+	}
+
+	database := decodeHistoryDatabase(t, after)
+	if len(database.Runs) != 1 || len(database.Artifacts) != 2 || len(database.Units) != 3 {
+		t.Fatalf("normalized replay cardinality = runs %d artifacts %d units %d, want 1/2/3",
+			len(database.Runs), len(database.Artifacts), len(database.Units))
+	}
+	gotOutcomes := make([]string, 0, 3)
+	for _, unit := range database.Units {
+		if len(unit.Samples) != 1 {
+			t.Fatalf("unit %q samples = %d, want exactly one after replay: %+v", unit.UnitID, len(unit.Samples), unit.Samples)
+		}
+		gotOutcomes = append(gotOutcomes, unit.Samples[0].Outcome)
+	}
+	sort.Strings(gotOutcomes)
+	if !reflect.DeepEqual(gotOutcomes, []string{"fail", "pass", "skip"}) {
+		t.Fatalf("retained replay outcomes = %q, want one pass/fail/skip", gotOutcomes)
+	}
+	if twoSnapshots := 2 * len(mustJSON(t, firstSnapshot)); len(after) >= twoSnapshots {
+		t.Fatalf("normalized database size = %d, want smaller than two concatenated %d-byte snapshots", len(after), len(mustJSON(t, firstSnapshot)))
+	}
+}
+
+func TestUpdateHistoryPreservesDuplicateRowsWithinOneArtifact(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	envelope := historyRunEnvelope("25", "sha-25", "2026-07-15T11:30:00Z")
+	duplicate := timingUnit{
+		UnitID: "internal/example:TestRepeated", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example", Test: "TestRepeated",
+		Outcome: "pass", DurationSeconds: 1.25,
+	}
+	root := t.TempDir()
+	writeArtifact(t, root, "run.json", historyArtifact(envelope, "shard-a", []timingUnit{duplicate, duplicate}))
+
+	firstSnapshot, err := UpdateHistory(databasePath, envelope, 10, []string{root})
+	if err != nil {
+		t.Fatalf("first UpdateHistory: %v", err)
+	}
+	before, err := os.ReadFile(databasePath)
+	if err != nil {
+		t.Fatalf("read first history database: %v", err)
+	}
+	database := decodeHistoryDatabase(t, before)
+	if len(database.Units) != 1 || len(database.Units[0].Samples) != 2 {
+		t.Fatalf("stored duplicate-row samples = %+v, want two samples", database.Units)
+	}
+	unit := findHistoryUnit(t, findHistoryProfile(t, firstSnapshot, 32), duplicate.UnitID)
+	if unit.Passes != 2 || len(unit.SuccessfulObservations) != 2 {
+		t.Fatalf("derived duplicate-row history = %+v, want two successful observations", unit)
+	}
+
+	secondSnapshot, err := UpdateHistory(databasePath, envelope, 10, []string{root})
+	if err != nil {
+		t.Fatalf("replay UpdateHistory: %v", err)
+	}
+	after, err := os.ReadFile(databasePath)
+	if err != nil {
+		t.Fatalf("read replayed history database: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) || !reflect.DeepEqual(secondSnapshot, firstSnapshot) {
+		t.Fatalf("duplicate-row replay changed retained evidence\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestUpdateHistoryRejectsConflictsAndEnvelopeMismatchesAtomically(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		mutate       func(RunEnvelope, timingArtifactFixture) (RunEnvelope, timingArtifactFixture)
+		wantEvidence string
+	}{
+		{
+			name: "stored artifact conflict",
+			mutate: func(envelope RunEnvelope, item timingArtifactFixture) (RunEnvelope, timingArtifactFixture) {
+				item.Units[0].DurationSeconds = 99
+				return envelope, item
+			},
+			wantEvidence: "conflicting artifact",
+		},
+		{
+			name: "workflow mismatch",
+			mutate: func(envelope RunEnvelope, item timingArtifactFixture) (RunEnvelope, timingArtifactFixture) {
+				envelope.Workflow = "Other CI"
+				return envelope, item
+			},
+			wantEvidence: "workflow",
+		},
+		{
+			name: "run ID mismatch",
+			mutate: func(envelope RunEnvelope, item timingArtifactFixture) (RunEnvelope, timingArtifactFixture) {
+				envelope.RunID = "different-run"
+				return envelope, item
+			},
+			wantEvidence: "run_id",
+		},
+		{
+			name: "run attempt mismatch",
+			mutate: func(envelope RunEnvelope, item timingArtifactFixture) (RunEnvelope, timingArtifactFixture) {
+				envelope.RunAttempt = "2"
+				return envelope, item
+			},
+			wantEvidence: "run_attempt",
+		},
+		{
+			name: "tested SHA mismatch",
+			mutate: func(envelope RunEnvelope, item timingArtifactFixture) (RunEnvelope, timingArtifactFixture) {
+				envelope.TestedSHA = "different-sha"
+				return envelope, item
+			},
+			wantEvidence: "tested_sha",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+			envelope := historyRunEnvelope("30", "sha-30", "2026-07-15T12:00:00Z")
+			item := historyArtifact(envelope, "shard-a", []timingUnit{{
+				UnitID: "internal/example:TestAtomic", Kind: "test",
+				Package: "github.com/gastownhall/gascity/internal/example", Test: "TestAtomic",
+				Outcome: "pass", DurationSeconds: 3,
+			}})
+			seedRoot := t.TempDir()
+			writeArtifact(t, seedRoot, "seed.json", item)
+			if _, err := UpdateHistory(databasePath, envelope, 10, []string{seedRoot}); err != nil {
+				t.Fatalf("seed UpdateHistory: %v", err)
+			}
+			before, err := os.ReadFile(databasePath)
+			if err != nil {
+				t.Fatalf("read seeded database: %v", err)
+			}
+
+			mutatedEnvelope, mutatedArtifact := tc.mutate(envelope, item)
+			badRoot := t.TempDir()
+			writeArtifact(t, badRoot, "bad.json", mutatedArtifact)
+			_, err = UpdateHistory(databasePath, mutatedEnvelope, 10, []string{badRoot})
+			if err == nil || !strings.Contains(err.Error(), tc.wantEvidence) {
+				t.Fatalf("UpdateHistory error = %v, want contextual evidence %q", err, tc.wantEvidence)
+			}
+			after, readErr := os.ReadFile(databasePath)
+			if readErr != nil {
+				t.Fatalf("read database after rejected update: %v", readErr)
+			}
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("rejected update changed database\nbefore: %s\nafter:  %s", before, after)
+			}
+		})
+	}
+}
+
+func TestUpdateHistoryRejectsCrossRepositoryUpdateAtomically(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	envelope := historyRunEnvelope("35", "sha-35", "2026-07-15T12:30:00Z")
+	item := historyArtifact(envelope, "shard-a", []timingUnit{{
+		UnitID: "internal/example:TestRepository", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example", Test: "TestRepository",
+		Outcome: "pass", DurationSeconds: 1,
+	}})
+	seedRoot := t.TempDir()
+	writeArtifact(t, seedRoot, "seed.json", item)
+	if _, err := UpdateHistory(databasePath, envelope, 10, []string{seedRoot}); err != nil {
+		t.Fatalf("seed UpdateHistory: %v", err)
+	}
+	before, err := os.ReadFile(databasePath)
+	if err != nil {
+		t.Fatalf("read seeded database: %v", err)
+	}
+
+	otherRepository := envelope
+	otherRepository.Repository = "example/other"
+	_, err = UpdateHistory(databasePath, otherRepository, 10, []string{seedRoot})
+	if err == nil || !strings.Contains(err.Error(), "does not match run envelope repository") {
+		t.Fatalf("cross-repository UpdateHistory error = %v, want repository mismatch", err)
+	}
+	after, readErr := os.ReadFile(databasePath)
+	if readErr != nil {
+		t.Fatalf("read database after rejected update: %v", readErr)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("cross-repository rejection changed database\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestUpdateHistoryRejectsStoredEnvelopeMetadataChangesAtomically(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*RunEnvelope)
+	}{
+		{name: "event", mutate: func(envelope *RunEnvelope) { envelope.Event = "workflow_dispatch" }},
+		{name: "ref", mutate: func(envelope *RunEnvelope) { envelope.Ref = "refs/heads/release" }},
+		{name: "tested SHA", mutate: func(envelope *RunEnvelope) { envelope.TestedSHA = "different-sha" }},
+		{name: "conclusion", mutate: func(envelope *RunEnvelope) { envelope.Conclusion = "failure" }},
+		{name: "completion time", mutate: func(envelope *RunEnvelope) { envelope.CompletedAt = "2026-07-15T12:59:00Z" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+			envelope := historyRunEnvelope("36", "sha-36", "2026-07-15T12:45:00Z")
+			seedRoot := t.TempDir()
+			writeArtifact(t, seedRoot, "seed.json", historyArtifact(envelope, "shard-a", []timingUnit{{
+				UnitID: "internal/example:TestEnvelope", Kind: "test",
+				Package: "github.com/gastownhall/gascity/internal/example", Test: "TestEnvelope",
+				Outcome: "pass", DurationSeconds: 1,
+			}}))
+			if _, err := UpdateHistory(databasePath, envelope, 10, []string{seedRoot}); err != nil {
+				t.Fatalf("seed UpdateHistory: %v", err)
+			}
+			before, err := os.ReadFile(databasePath)
+			if err != nil {
+				t.Fatalf("read seeded database: %v", err)
+			}
+
+			changed := envelope
+			tc.mutate(&changed)
+			incomingRoot := t.TempDir()
+			writeArtifact(t, incomingRoot, "changed.json", historyArtifact(changed, "shard-a", []timingUnit{{
+				UnitID: "internal/example:TestEnvelope", Kind: "test",
+				Package: "github.com/gastownhall/gascity/internal/example", Test: "TestEnvelope",
+				Outcome: "pass", DurationSeconds: 1,
+			}}))
+			_, err = UpdateHistory(databasePath, changed, 10, []string{incomingRoot})
+			if err == nil || !strings.Contains(err.Error(), "conflicting run envelope") {
+				t.Fatalf("changed-envelope UpdateHistory error = %v, want stored-envelope conflict", err)
+			}
+			after, readErr := os.ReadFile(databasePath)
+			if readErr != nil {
+				t.Fatalf("read database after rejected update: %v", readErr)
+			}
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("changed-envelope rejection changed database\nbefore: %s\nafter:  %s", before, after)
+			}
+		})
+	}
+}
+
+func TestUpdateHistoryRejectsInvalidStoredDatabaseWithoutRewriting(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		mutate       func(*testing.T, []byte) []byte
+		wantEvidence string
+	}{
+		{
+			name: "unknown field",
+			mutate: func(t *testing.T, data []byte) []byte {
+				t.Helper()
+				return []byte(strings.Replace(string(data), `"schema":1`, `"schema":1,"unexpected":true`, 1))
+			},
+			wantEvidence: "unknown field",
+		},
+		{
+			name: "trailing JSON value",
+			mutate: func(t *testing.T, data []byte) []byte {
+				t.Helper()
+				return append(append([]byte(nil), data...), []byte("{}\n")...)
+			},
+			wantEvidence: "decode history database schema",
+		},
+		{
+			name: "invalid artifact reference",
+			mutate: func(t *testing.T, data []byte) []byte {
+				t.Helper()
+				database := decodeHistoryDatabase(t, data)
+				database.Units[0].Samples[0].ArtifactIndex = len(database.Artifacts)
+				return mustJSON(t, database)
+			},
+			wantEvidence: "artifact_index",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+			envelope := historyRunEnvelope("37", "sha-37", "2026-07-15T12:50:00Z")
+			root := t.TempDir()
+			writeArtifact(t, root, "run.json", historyArtifact(envelope, "shard-a", []timingUnit{{
+				UnitID: "internal/example:TestStoredDatabase", Kind: "test",
+				Package: "github.com/gastownhall/gascity/internal/example", Test: "TestStoredDatabase",
+				Outcome: "pass", DurationSeconds: 1,
+			}}))
+			if _, err := UpdateHistory(databasePath, envelope, 10, []string{root}); err != nil {
+				t.Fatalf("seed UpdateHistory: %v", err)
+			}
+			valid, err := os.ReadFile(databasePath)
+			if err != nil {
+				t.Fatalf("read seeded database: %v", err)
+			}
+			invalid := tc.mutate(t, valid)
+			if err := os.WriteFile(databasePath, invalid, 0o600); err != nil {
+				t.Fatalf("write invalid history database: %v", err)
+			}
+
+			_, err = UpdateHistory(databasePath, envelope, 10, []string{root})
+			if err == nil || !strings.Contains(err.Error(), tc.wantEvidence) {
+				t.Fatalf("UpdateHistory error = %v, want evidence %q", err, tc.wantEvidence)
+			}
+			after, readErr := os.ReadFile(databasePath)
+			if readErr != nil {
+				t.Fatalf("read rejected database: %v", readErr)
+			}
+			if !reflect.DeepEqual(after, invalid) {
+				t.Fatalf("invalid stored database was rewritten\nbefore: %s\nafter:  %s", invalid, after)
+			}
+		})
+	}
+}
+
+func TestUpdateHistoryPrunesWholeCohortsByCompletedAtNotLexicalRunID(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	runs := []RunEnvelope{
+		historyRunEnvelope("999", "sha-oldest", "2026-07-15T01:00:00Z"),
+		historyRunEnvelope("100", "sha-middle", "2026-07-15T02:00:00Z"),
+		historyRunEnvelope("010", "sha-newest", "2026-07-15T03:00:00Z"),
+	}
+	var snapshot Snapshot
+	for _, envelope := range runs {
+		root := t.TempDir()
+		writeArtifact(t, root, "z.json", historyArtifact(envelope, "shard-z", []timingUnit{{
+			UnitID: "internal/example:TestZ", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+			Test: "TestZ", Outcome: "pass", DurationSeconds: 2,
+		}}))
+		writeArtifact(t, root, "a.json", historyArtifact(envelope, "shard-a", []timingUnit{{
+			UnitID: "internal/example:TestA", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+			Test: "TestA", Outcome: "fail", DurationSeconds: 1,
+		}}))
+		var err error
+		snapshot, err = UpdateHistory(databasePath, envelope, 2, []string{root})
+		if err != nil {
+			t.Fatalf("UpdateHistory run %q: %v", envelope.RunID, err)
+		}
+	}
+
+	data, err := os.ReadFile(databasePath)
+	if err != nil {
+		t.Fatalf("read retained database: %v", err)
+	}
+	database := decodeHistoryDatabase(t, data)
+	gotRunIDs := make([]string, 0, len(database.Runs))
+	for _, run := range database.Runs {
+		gotRunIDs = append(gotRunIDs, run.RunID)
+	}
+	sort.Strings(gotRunIDs)
+	if !reflect.DeepEqual(gotRunIDs, []string{"010", "100"}) {
+		t.Fatalf("retained run IDs = %q, want middle and newest completion cohorts [010 100]", gotRunIDs)
+	}
+
+	artifactsPerRun := make(map[string]int)
+	for index, artifact := range database.Artifacts {
+		if artifact.RunIndex < 0 || artifact.RunIndex >= len(database.Runs) {
+			t.Fatalf("artifact %d has orphan run index %d for %d runs", index, artifact.RunIndex, len(database.Runs))
+		}
+		artifactsPerRun[database.Runs[artifact.RunIndex].RunID]++
+	}
+	if artifactsPerRun["010"] != 2 || artifactsPerRun["100"] != 2 || len(artifactsPerRun) != 2 {
+		t.Fatalf("retained whole-cohort artifact counts = %v, want two artifacts for each retained run", artifactsPerRun)
+	}
+	for _, unit := range database.Units {
+		if len(unit.Samples) != 2 {
+			t.Fatalf("retained unit %q samples = %d, want one per retained cohort: %+v", unit.UnitID, len(unit.Samples), unit.Samples)
+		}
+		for _, sample := range unit.Samples {
+			if sample.ArtifactIndex < 0 || sample.ArtifactIndex >= len(database.Artifacts) {
+				t.Fatalf("unit %q has orphan artifact index %d for %d artifacts", unit.UnitID, sample.ArtifactIndex, len(database.Artifacts))
+			}
+		}
+	}
+	unit := findHistoryUnit(t, findHistoryProfile(t, snapshot, 32), "internal/example:TestZ")
+	if unit.Passes != 2 {
+		t.Fatalf("derived retained passes = %d, want two whole retained cohorts: %+v", unit.Passes, unit)
+	}
+}
+
+func TestUpdateHistoryRetainsColdUnitAbsentFromNewestCohort(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	runs := []struct {
+		envelope RunEnvelope
+		cold     bool
+	}{
+		{envelope: historyRunEnvelope("700", "sha-oldest", "2026-07-15T04:00:00Z"), cold: true},
+		{envelope: historyRunEnvelope("200", "sha-middle", "2026-07-15T05:00:00Z"), cold: true},
+		{envelope: historyRunEnvelope("001", "sha-newest", "2026-07-15T06:00:00Z"), cold: false},
+	}
+	var snapshot Snapshot
+	for _, run := range runs {
+		units := []timingUnit{{
+			UnitID: "internal/example:TestHot", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+			Test: "TestHot", Outcome: "pass", DurationSeconds: 1,
+		}}
+		if run.cold {
+			units = append(units, timingUnit{
+				UnitID: "internal/example:TestCold", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+				Test: "TestCold", Outcome: "pass", DurationSeconds: 5,
+			})
+		}
+		root := t.TempDir()
+		writeArtifact(t, root, "run.json", historyArtifact(run.envelope, "shard-a", units))
+		var err error
+		snapshot, err = UpdateHistory(databasePath, run.envelope, 2, []string{root})
+		if err != nil {
+			t.Fatalf("UpdateHistory run %q: %v", run.envelope.RunID, err)
+		}
+	}
+
+	cold := findHistoryUnit(t, findHistoryProfile(t, snapshot, 32), "internal/example:TestCold")
+	if cold.Passes != 1 || len(cold.SuccessfulObservations) != 1 || cold.LastSuccessSHA == nil || *cold.LastSuccessSHA != "sha-middle" {
+		t.Fatalf("cold retained unit = %+v, want the middle cohort's one success despite absence from newest", cold)
+	}
+}
+
+func TestUpdateHistoryRetainsAndRecomputesFiveAndTwentySampleAuthority(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	var snapshot Snapshot
+	for run := 1; run <= 20; run++ {
+		envelope := historyRunEnvelope(fmt.Sprintf("%03d", run), fmt.Sprintf("sha-%02d", run), fmt.Sprintf("2026-07-15T00:%02d:00Z", run))
+		units := []timingUnit{{
+			UnitID: "internal/example:TestP95", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+			Test: "TestP95", Outcome: "pass", DurationSeconds: float64(run),
+		}}
+		if run <= 5 {
+			units = append(units, timingUnit{
+				UnitID: "internal/example:TestP75", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+				Test: "TestP75", Outcome: "pass", DurationSeconds: float64(run),
+			})
+		}
+		root := t.TempDir()
+		writeArtifact(t, root, "run.json", historyArtifact(envelope, "shard-a", units))
+		var err error
+		snapshot, err = UpdateHistory(databasePath, envelope, 20, []string{root})
+		if err != nil {
+			t.Fatalf("UpdateHistory run %d: %v", run, err)
+		}
+	}
+
+	profile := findHistoryProfile(t, snapshot, 32)
+	p75 := findHistoryUnit(t, profile, "internal/example:TestP75")
+	p95 := findHistoryUnit(t, profile, "internal/example:TestP95")
+	if p75.Passes != 5 || !p75.P75Authoritative || p75.P95Authoritative {
+		t.Fatalf("five-sample authority before pruning = %+v, want p75 only", p75)
+	}
+	if p95.Passes != 20 || !p95.P75Authoritative || !p95.P95Authoritative {
+		t.Fatalf("twenty-sample authority before pruning = %+v, want p75 and p95", p95)
+	}
+
+	newest := historyRunEnvelope("999-new", "sha-new", "2026-07-15T00:21:30Z")
+	root := t.TempDir()
+	writeArtifact(t, root, "run.json", historyArtifact(newest, "shard-a", []timingUnit{{
+		UnitID: "internal/example:TestNewest", Kind: "test", Package: "github.com/gastownhall/gascity/internal/example",
+		Test: "TestNewest", Outcome: "pass", DurationSeconds: 1,
+	}}))
+	var err error
+	snapshot, err = UpdateHistory(databasePath, newest, 20, []string{root})
+	if err != nil {
+		t.Fatalf("UpdateHistory pruning threshold cohort: %v", err)
+	}
+
+	profile = findHistoryProfile(t, snapshot, 32)
+	p75 = findHistoryUnit(t, profile, "internal/example:TestP75")
+	p95 = findHistoryUnit(t, profile, "internal/example:TestP95")
+	if p75.Passes != 4 || p75.P75Authoritative || p75.P95Authoritative {
+		t.Fatalf("five-sample authority after oldest-cohort pruning = %+v, want four cold samples and no authority", p75)
+	}
+	if p95.Passes != 19 || !p95.P75Authoritative || p95.P95Authoritative {
+		t.Fatalf("twenty-sample authority after oldest-cohort pruning = %+v, want 19 samples and p75 only", p95)
+	}
+}
+
+func historyRunEnvelope(runID, testedSHA, completedAt string) RunEnvelope {
+	return RunEnvelope{
+		Schema: 1, Repository: "gastownhall/gascity", Event: "push", Ref: "refs/heads/main",
+		Workflow: "CI", RunID: runID, RunAttempt: "1", TestedSHA: testedSHA,
+		Conclusion: "success", CompletedAt: completedAt,
+	}
+}
+
+func historyArtifact(envelope RunEnvelope, shardID string, units []timingUnit) timingArtifactFixture {
+	item := timingArtifact(envelope.RunID, defaultRunner("ephemeral-"+envelope.RunID+"-"+shardID), units)
+	item.Workflow = envelope.Workflow
+	item.RunAttempt = envelope.RunAttempt
+	item.CommitSHA = envelope.TestedSHA
+	item.ShardID = shardID
+	return item
+}
+
+type historyDatabaseWire struct {
+	Schema    int                   `json:"schema"`
+	Runs      []historyRunWire      `json:"runs"`
+	Artifacts []historyArtifactWire `json:"artifacts"`
+	Units     []historyUnitWire     `json:"units"`
+}
+
+type historyRunWire struct {
+	Schema      int    `json:"schema"`
+	Repository  string `json:"repository"`
+	Event       string `json:"event"`
+	Ref         string `json:"ref"`
+	Workflow    string `json:"workflow"`
+	RunID       string `json:"run_id"`
+	RunAttempt  string `json:"run_attempt"`
+	TestedSHA   string `json:"tested_sha"`
+	Conclusion  string `json:"conclusion"`
+	CompletedAt string `json:"completed_at"`
+}
+
+type historyArtifactWire struct {
+	RunIndex int               `json:"run_index"`
+	Job      string            `json:"job"`
+	ShardID  string            `json:"shard_id"`
+	Variant  string            `json:"variant"`
+	Runner   historyRunnerWire `json:"runner"`
+}
+
+type historyRunnerWire struct {
+	Label    string `json:"label"`
+	Name     string `json:"name"`
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	CPUCount int    `json:"cpu_count"`
+}
+
+type historyUnitWire struct {
+	UnitID  string              `json:"unit_id"`
+	Kind    string              `json:"kind"`
+	Package string              `json:"package"`
+	Test    string              `json:"test"`
+	Subtest string              `json:"subtest"`
+	Samples []historySampleWire `json:"samples"`
+}
+
+type historySampleWire struct {
+	ArtifactIndex   int     `json:"artifact_index"`
+	Outcome         string  `json:"outcome"`
+	DurationSeconds float64 `json:"duration_seconds"`
+}
+
+func decodeHistoryDatabase(t *testing.T, data []byte) historyDatabaseWire {
+	t.Helper()
+	var database historyDatabaseWire
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&database); err != nil {
+		t.Fatalf("decode history database: %v\n%s", err, data)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		t.Fatalf("decode history database trailing data: %v\n%s", err, data)
+	}
+	return database
+}

--- a/internal/testpolicy/timingsummary/summary.go
+++ b/internal/testpolicy/timingsummary/summary.go
@@ -13,10 +13,14 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 )
 
-const summaryLimit = 10
+const (
+	timingArtifactSchema = 1
+	summaryLimit         = 10
+)
 
 type outputFormat uint8
 
@@ -24,6 +28,18 @@ const (
 	formatMarkdown outputFormat = iota
 	formatJSON
 )
+
+type runOptions struct {
+	format          outputFormat
+	roots           []string
+	historyPath     string
+	runEnvelopePath string
+	retainRuns      int
+	formatSet       bool
+	historySet      bool
+	envelopeSet     bool
+	retentionSet    bool
+}
 
 type artifact struct {
 	Schema     int            `json:"schema"`
@@ -59,23 +75,33 @@ type artifactUnit struct {
 // Run loads timing artifacts from args, writes a deterministic Markdown or
 // JSON summary to stdout, and returns a process-style exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
-	format, roots, err := parseRunArgs(args)
+	options, err := parseRunArgs(args)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "timing summary: %v\n", err)
 		return 2
 	}
-	if len(roots) == 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: test-timing-summary <artifact-root> [<artifact-root> ...]")
+	if len(options.roots) == 0 {
+		_, _ = fmt.Fprintln(stderr, "usage: test-timing-summary [options] <artifact-root> [<artifact-root> ...]")
 		return 2
 	}
 
-	snapshot, err := BuildSnapshot(roots)
+	var snapshot Snapshot
+	if options.historySet {
+		envelope, decodeErr := decodeRunEnvelope(options.runEnvelopePath)
+		if decodeErr != nil {
+			err = decodeErr
+		} else {
+			snapshot, err = UpdateHistory(options.historyPath, envelope, options.retainRuns, options.roots)
+		}
+	} else {
+		snapshot, err = BuildSnapshot(options.roots)
+	}
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "timing summary: %v\n", err)
 		return 1
 	}
 
-	if format == formatJSON {
+	if options.format == formatJSON {
 		if err := json.NewEncoder(stdout).Encode(snapshot); err != nil {
 			_, _ = fmt.Fprintf(stderr, "timing summary: write output: %v\n", err)
 			return 1
@@ -89,40 +115,99 @@ func Run(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func parseRunArgs(args []string) (outputFormat, []string, error) {
-	format := formatMarkdown
-	roots := make([]string, 0, len(args))
-	formatSet := false
+func parseRunArgs(args []string) (runOptions, error) {
+	options := runOptions{format: formatMarkdown, roots: make([]string, 0, len(args))}
 	for index := 0; index < len(args); index++ {
 		argument := args[index]
-		var value string
-		switch {
-		case argument == "--format":
-			if index+1 >= len(args) {
-				return 0, nil, errors.New("--format requires a value")
-			}
-			index++
-			value = args[index]
-		case strings.HasPrefix(argument, "--format="):
-			value = strings.TrimPrefix(argument, "--format=")
-		default:
-			roots = append(roots, argument)
+		name, value, recognized, consumedNext, err := parseRunFlag(args, index)
+		if err != nil {
+			return runOptions{}, err
+		}
+		if !recognized {
+			options.roots = append(options.roots, argument)
 			continue
 		}
-		if formatSet {
-			return 0, nil, errors.New("--format may be specified only once")
+		if consumedNext {
+			index++
 		}
-		formatSet = true
-		switch value {
-		case "markdown":
-			format = formatMarkdown
-		case "json":
-			format = formatJSON
-		default:
-			return 0, nil, fmt.Errorf("unsupported format %q", value)
+		switch name {
+		case "--format":
+			if options.formatSet {
+				return runOptions{}, errors.New("--format may be specified only once")
+			}
+			options.formatSet = true
+			switch value {
+			case "markdown":
+				options.format = formatMarkdown
+			case "json":
+				options.format = formatJSON
+			default:
+				return runOptions{}, fmt.Errorf("unsupported format %q", value)
+			}
+		case "--update-history":
+			if options.historySet {
+				return runOptions{}, errors.New("--update-history may be specified only once")
+			}
+			options.historySet = true
+			options.historyPath = value
+		case "--run-envelope":
+			if options.envelopeSet {
+				return runOptions{}, errors.New("--run-envelope may be specified only once")
+			}
+			options.envelopeSet = true
+			options.runEnvelopePath = value
+		case "--retain-runs":
+			if options.retentionSet {
+				return runOptions{}, errors.New("--retain-runs may be specified only once")
+			}
+			options.retentionSet = true
+			retainRuns, parseErr := strconv.Atoi(value)
+			if parseErr != nil || retainRuns <= 0 {
+				return runOptions{}, errors.New("--retain-runs must be a positive integer")
+			}
+			options.retainRuns = retainRuns
 		}
 	}
-	return format, roots, nil
+	mutationFlags := 0
+	for _, set := range []bool{options.historySet, options.envelopeSet, options.retentionSet} {
+		if set {
+			mutationFlags++
+		}
+	}
+	if mutationFlags != 0 && mutationFlags != 3 {
+		return runOptions{}, errors.New("--update-history, --run-envelope, and --retain-runs must be specified together")
+	}
+	return options, nil
+}
+
+func parseRunFlag(args []string, index int) (name, value string, recognized, consumedNext bool, err error) {
+	argument := args[index]
+	for _, candidate := range []string{"--format", "--update-history", "--run-envelope", "--retain-runs"} {
+		if argument == candidate {
+			if index+1 >= len(args) || args[index+1] == "" || isRunFlag(args[index+1]) {
+				return "", "", true, false, fmt.Errorf("%s requires a value", candidate)
+			}
+			return candidate, args[index+1], true, true, nil
+		}
+		prefix := candidate + "="
+		if strings.HasPrefix(argument, prefix) {
+			value := strings.TrimPrefix(argument, prefix)
+			if value == "" {
+				return "", "", true, false, fmt.Errorf("%s requires a value", candidate)
+			}
+			return candidate, value, true, false, nil
+		}
+	}
+	return "", "", false, false, nil
+}
+
+func isRunFlag(argument string) bool {
+	for _, candidate := range []string{"--format", "--update-history", "--run-envelope", "--retain-runs"} {
+		if argument == candidate || strings.HasPrefix(argument, candidate+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 func loadArtifacts(roots []string) ([]artifact, int, error) {
@@ -203,7 +288,7 @@ func decodeArtifact(path string) (artifact, error) {
 	if envelope.Schema == nil {
 		return artifact{}, fmt.Errorf("validate %s: schema is required", path)
 	}
-	if *envelope.Schema != 1 {
+	if *envelope.Schema != timingArtifactSchema {
 		return artifact{}, fmt.Errorf("validate %s: unsupported schema %d", path, *envelope.Schema)
 	}
 

--- a/internal/testpolicy/timingsummary/summary_test.go
+++ b/internal/testpolicy/timingsummary/summary_test.go
@@ -330,6 +330,176 @@ func TestRunRejectsInvalidFormatArguments(t *testing.T) {
 	}
 }
 
+func TestRunRequiresMutationArgumentsTogether(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "update history only", args: []string{"--update-history", "history.json", "artifacts"}},
+		{name: "run envelope only", args: []string{"--run-envelope", "run.json", "artifacts"}},
+		{name: "retention only", args: []string{"--retain-runs", "5", "artifacts"}},
+		{name: "missing retention", args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "artifacts"}},
+		{name: "missing run envelope", args: []string{"--update-history", "history.json", "--retain-runs", "5", "artifacts"}},
+		{name: "missing update history", args: []string{"--run-envelope", "run.json", "--retain-runs", "5", "artifacts"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runSummary(tc.args...)
+			if exitCode != 2 || stdout != "" {
+				t.Fatalf("Run(%q) = stdout %q stderr %q exit %d", tc.args, stdout, stderr, exitCode)
+			}
+			for _, want := range []string{"--update-history", "--run-envelope", "--retain-runs", "must be specified together"} {
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("Run(%q) stderr does not contain %q: %s", tc.args, want, stderr)
+				}
+			}
+		})
+	}
+}
+
+func TestRunRejectsRepeatedMutationArguments(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "update history",
+			args: []string{"--update-history", "history.json", "--update-history=other.json", "--run-envelope", "run.json", "--retain-runs", "5", "artifacts"},
+			want: "--update-history may be specified only once",
+		},
+		{
+			name: "run envelope",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "--run-envelope=other.json", "--retain-runs", "5", "artifacts"},
+			want: "--run-envelope may be specified only once",
+		},
+		{
+			name: "retention",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "--retain-runs", "5", "--retain-runs=10", "artifacts"},
+			want: "--retain-runs may be specified only once",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runSummary(tc.args...)
+			if exitCode != 2 || stdout != "" || !strings.Contains(stderr, tc.want) {
+				t.Fatalf("Run(%q) = stdout %q stderr %q exit %d; want stderr containing %q", tc.args, stdout, stderr, exitCode, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunRejectsInvalidRetainRunsArguments(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing value",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "artifacts", "--retain-runs"},
+			want: "--retain-runs requires a value",
+		},
+		{
+			name: "empty value",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "--retain-runs=", "artifacts"},
+			want: "--retain-runs requires a value",
+		},
+		{
+			name: "zero",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "--retain-runs", "0", "artifacts"},
+			want: "--retain-runs must be a positive integer",
+		},
+		{
+			name: "negative",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "--retain-runs=-1", "artifacts"},
+			want: "--retain-runs must be a positive integer",
+		},
+		{
+			name: "fractional",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "--retain-runs", "1.5", "artifacts"},
+			want: "--retain-runs must be a positive integer",
+		},
+		{
+			name: "non-numeric",
+			args: []string{"--update-history", "history.json", "--run-envelope", "run.json", "--retain-runs", "many", "artifacts"},
+			want: "--retain-runs must be a positive integer",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runSummary(tc.args...)
+			if exitCode != 2 || stdout != "" || !strings.Contains(stderr, tc.want) {
+				t.Fatalf("Run(%q) = stdout %q stderr %q exit %d; want stderr containing %q", tc.args, stdout, stderr, exitCode, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunRejectsRecognizedOptionAsSpaceFormValue(t *testing.T) {
+	t.Parallel()
+
+	args := []string{
+		"--update-history", "--format=json",
+		"--run-envelope", "run.json",
+		"--retain-runs", "5",
+		"missing-artifacts",
+	}
+	stdout, stderr, exitCode := runSummary(args...)
+	if exitCode != 2 || stdout != "" || !strings.Contains(stderr, "--update-history requires a value") {
+		t.Fatalf("Run(%q) = stdout %q stderr %q exit %d; want a usage error for an option used as a value", args, stdout, stderr, exitCode)
+	}
+}
+
+func TestRunMutationRequiresArtifactRoot(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"--update-history", "history.json", "--run-envelope", "run.json", "--retain-runs", "5"}
+	stdout, stderr, exitCode := runSummary(args...)
+	if exitCode != 2 || stdout != "" || !strings.Contains(stderr, "usage:") {
+		t.Fatalf("Run(%q) = stdout %q stderr %q exit %d", args, stdout, stderr, exitCode)
+	}
+}
+
+func TestRunUpdatesHistoryFromEnvelopeFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	databasePath := filepath.Join(t.TempDir(), "timing-history.json")
+	envelopePath := filepath.Join(t.TempDir(), "run-envelope.json")
+	envelope := historyRunEnvelope("50", "sha-50", "2026-07-15T13:00:00Z")
+	writeArtifact(t, root, "timing.json", historyArtifact(envelope, "shard-a", []timingUnit{{
+		UnitID: "internal/example:TestCLI", Kind: "test",
+		Package: "github.com/gastownhall/gascity/internal/example", Test: "TestCLI",
+		Outcome: "pass", DurationSeconds: 1.25,
+	}}))
+	if err := os.WriteFile(envelopePath, mustJSON(t, envelope), 0o600); err != nil {
+		t.Fatalf("write run envelope: %v", err)
+	}
+
+	stdout, stderr, exitCode := runSummary(
+		"--update-history", databasePath,
+		"--run-envelope="+envelopePath,
+		"--retain-runs", "10",
+		"--format=json",
+		root,
+	)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("Run mutation = stdout %q stderr %q exit %d", stdout, stderr, exitCode)
+	}
+	snapshot := decodeHistorySnapshot(t, stdout)
+	unit := findHistoryUnit(t, findHistoryProfile(t, snapshot, 32), "internal/example:TestCLI")
+	if unit.Passes != 1 || historyFloat(t, unit.DurationSecondsP95) != 1.25 {
+		t.Fatalf("mutated snapshot unit = %+v, want one 1.25s pass", unit)
+	}
+	if _, err := os.Stat(databasePath); err != nil {
+		t.Fatalf("history database was not published: %v", err)
+	}
+}
+
 type timingArtifactFixture struct {
 	Schema     int          `json:"schema"`
 	ShardID    string       `json:"shard_id"`


### PR DESCRIPTION
## Summary

- Persist normalized timing evidence by run, artifact, unit, and outcome.
- Merge identical artifacts idempotently and reject conflicts before changing stored bytes.
- Retain whole run cohorts by parsed completion time and rebuild the existing snapshot after pruning.
- Add an explicit mutation CLI mode without changing byte-exact read-only Markdown or JSON output.

## Why

The reporting snapshot intentionally collapses failed and skipped observations into counts. That makes overlapping snapshots unsafe to merge and would double-count evidence. This storage boundary retains artifact identity for pass, fail, and skip rows so later default-branch automation can build trustworthy timing history for shard planning.

## Trust boundary

This change validates the run-envelope shape and checks each artifact's workflow, run ID, run attempt, and tested SHA. It deliberately does not:

- authenticate the supplied envelope;
- prove that every expected shard is present;
- serialize concurrent writers;
- publish a protected ci-metrics branch; or
- activate timing-based shard planning.

Those responsibilities remain in the follow-up trusted workflow.

## Performance evidence

- One real 12-artifact cohort with 14,795 rows: 0.78s update, 62 MB peak RSS, 4.56 MB database.
- Fifty retained cohorts: 3.19s latest update, 49.2 MB database, 586 MB peak RSS.
- The focused timing-summary test package completes in about 0.06s.
- No required-check topology or PR-path test selection changes in this PR.

## Verification

- go test ./internal/testpolicy/timingsummary -count=20
- go test -race ./internal/testpolicy/timingsummary -count=1
- go test ./scripts -count=1
- go test ./test/docsync -count=1
- make test-ci-policy
- go vet ./...
- make test-fast-parallel
- .githooks/pre-commit
- Three independent delegated reviewers unanimously approved frozen diff fb5f9f55967aa5c11d5c4c0a007e7b6a16abb7f833b2ea52d79d96cbdba98c61

## Tracking

Bead: ga-80po0c.4.2
