### PR TITLE
test: make split-store wait readiness proof in-memory

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2261,7 +2261,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	phaseStart = time.Now()
 	cfgNames := configuredSessionNamesWithSnapshot(cr.cfg, cityName, sessionBeads)
 
-	readyWaitSet, err := prepareWaitWakeStateForCityWithSnapshot(cr.cityPath, sessionpkg.NewStore(sessStore), store, cr.nudgesBeadStore(), time.Now(), sessionBeads)
+	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(sessionpkg.NewStore(sessStore), newWaitDependencyStoreSet(store, rigStores), cr.nudgesBeadStore(), time.Now(), sessionBeads)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: preparing waits: %v\n", cr.logPrefix, err) //nolint:errcheck
 		readyWaitSet = nil

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
 	"github.com/spf13/cobra"
 )
 
@@ -40,6 +41,40 @@ type waitSetStateResult struct {
 	ReadyWaitID string
 	Retried     bool
 	RetriedFrom string
+}
+
+type waitDependencyReader interface {
+	Get(string) (beads.Bead, error)
+}
+
+type waitDependencyReaderFunc func(string) (beads.Bead, error)
+
+func (f waitDependencyReaderFunc) Get(id string) (beads.Bead, error) {
+	return f(id)
+}
+
+type waitDependencyStoreSet []beads.Store
+
+func (s waitDependencyStoreSet) Get(id string) (beads.Bead, error) {
+	return storeref.Resolve(id, []beads.Store(s))
+}
+
+func newWaitDependencyStoreSet(cityStore beads.Store, rigStores map[string]beads.Store) waitDependencyStoreSet {
+	stores := make(waitDependencyStoreSet, 0, 1+len(rigStores))
+	if cityStore != nil {
+		stores = append(stores, cityStore)
+	}
+	rigNames := make([]string, 0, len(rigStores))
+	for name := range rigStores {
+		rigNames = append(rigNames, name)
+	}
+	sort.Strings(rigNames)
+	for _, name := range rigNames {
+		if store := rigStores[name]; store != nil {
+			stores = append(stores, store)
+		}
+	}
+	return stores
 }
 
 func newWaitCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -845,10 +880,16 @@ func depsWaitReady(store beads.Store, wait sessionpkg.WaitInfo) bool {
 }
 
 func depsWaitReadyDetailed(store beads.Store, wait sessionpkg.WaitInfo) (bool, error) {
-	return depsWaitReadyDetailedForCity("", store, wait)
+	return depsWaitReadyDetailedFrom(store, wait)
 }
 
 func depsWaitReadyDetailedForCity(cityPath string, store beads.Store, wait sessionpkg.WaitInfo) (bool, error) {
+	return depsWaitReadyDetailedFrom(waitDependencyReaderFunc(func(depID string) (beads.Bead, error) {
+		return loadWaitDependencyBead(cityPath, store, depID)
+	}), wait)
+}
+
+func depsWaitReadyDetailedFrom(dependencies waitDependencyReader, wait sessionpkg.WaitInfo) (bool, error) {
 	depIDs := wait.DepIDs
 	if len(depIDs) == 0 {
 		return false, nil
@@ -858,7 +899,7 @@ func depsWaitReadyDetailedForCity(cityPath string, store beads.Store, wait sessi
 	foundAny := false
 	var missingErr error
 	for _, depID := range depIDs {
-		dep, err := loadWaitDependencyBead(cityPath, store, depID)
+		dep, err := dependencies.Get(depID)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				if mode != "any" {
@@ -941,10 +982,13 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 	if strings.TrimSpace(cityPath) != "" {
 		cfg, _ = loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 	}
-	return prepareWaitWakeStateForCityWithSnapshot(cityPath, cliSessionFrontDoor(store, cfg, cityPath), store, beads.NudgesStore{Store: store}, now, nil)
+	dependencies := waitDependencyReaderFunc(func(depID string) (beads.Bead, error) {
+		return loadWaitDependencyBead(cityPath, store, depID)
+	})
+	return prepareWaitWakeStateWithSnapshot(cliSessionFrontDoor(store, cfg, cityPath), dependencies, beads.NudgesStore{Store: store}, now, nil)
 }
 
-func prepareWaitWakeStateForCityWithSnapshot(cityPath string, sessFront *sessionpkg.Store, workStore beads.Store, nudges beads.NudgesStore, now time.Time, sessionBeads *sessionBeadSnapshot) (map[string]bool, error) {
+func prepareWaitWakeStateWithSnapshot(sessFront *sessionpkg.Store, dependencies waitDependencyReader, nudges beads.NudgesStore, now time.Time, sessionBeads *sessionBeadSnapshot) (map[string]bool, error) {
 	if sessionBeads == nil {
 		var err error
 		sessionBeads, err = loadSessionBeadSnapshot(sessFront.Store().Store)
@@ -1029,8 +1073,9 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, sessFront *session
 		if wait.Kind != "deps" {
 			continue
 		}
-		// Dependency beads are WORK class — read them from the work store.
-		ready, depErr := depsWaitReadyDetailedForCity(cityPath, workStore, wait)
+		// Dependency beads are WORK class and may live in a different scope
+		// from the session/wait coordination store.
+		ready, depErr := depsWaitReadyDetailedFrom(dependencies, wait)
 		if depErr != nil {
 			if errors.Is(depErr, beads.ErrNotFound) {
 				if err := sessFront.FailWait(wait.ID, now, depErr.Error()); err != nil {

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -39,6 +39,25 @@ type waitGetSpyStore struct {
 	getIDs []string
 }
 
+type waitPrefixedStore struct {
+	beads.Store
+	prefix string
+}
+
+func (s waitPrefixedStore) IDPrefix() string { return s.prefix }
+
+type waitDependencyGetErrorStore struct {
+	beads.Store
+	prefix string
+	err    error
+}
+
+func (s waitDependencyGetErrorStore) IDPrefix() string { return s.prefix }
+
+func (s waitDependencyGetErrorStore) Get(string) (beads.Bead, error) {
+	return beads.Bead{}, s.err
+}
+
 type waitListQueryCaptureStore struct {
 	beads.Store
 	queries []beads.ListQuery
@@ -2434,77 +2453,125 @@ func TestCmdSessionWait_AllowsRigDependencyBeads(t *testing.T) {
 }
 
 func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {
-	cityPath, rigPath := setupManagedBdWaitTestCity(t)
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	hardErr := errors.New("rig store unavailable")
 
-	cityStore, err := openCityStoreAt(cityPath)
-	if err != nil {
-		t.Fatalf("openCityStoreAt: %v", err)
-	}
-	rigStore, err := openStoreAtForCity(rigPath, cityPath)
-	if err != nil {
-		t.Fatalf("openStoreAtForCity(rig): %v", err)
-	}
-	sessionBead, err := cityStore.Create(beads.Bead{
-		Title:  "worker session",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel},
-		Metadata: map[string]string{
-			"session_name":       "worker",
-			"continuation_epoch": "1",
-		},
-	})
-	if err != nil {
-		t.Fatalf("create session bead: %v", err)
-	}
-	dep, err := rigStore.Create(beads.Bead{Title: "rig dep"})
-	if err != nil {
-		t.Fatalf("create rig dep bead: %v", err)
-	}
-	wait, err := cityStore.Create(beads.Bead{
-		Title:  "wait:worker session",
-		Type:   waitBeadType,
-		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
-		Metadata: map[string]string{
-			"session_id":       sessionBead.ID,
-			"session_name":     "worker",
-			"kind":             "deps",
-			"state":            waitStatePending,
-			"dep_ids":          dep.ID,
-			"dep_mode":         "all",
-			"registered_epoch": "1",
-			"delivery_attempt": "1",
-		},
-	})
-	if err != nil {
-		t.Fatalf("create wait bead: %v", err)
-	}
-	if err := rigStore.Close(dep.ID); err != nil {
-		t.Fatalf("close rig dep bead: %v", err)
-	}
-	if got := beadPrefix(nil, dep.ID); got != "fe" {
-		t.Fatalf("rig dep prefix = %q, want %q", got, "fe")
-	}
-	cityStore, err = openCityStoreAt(cityPath)
-	if err != nil {
-		t.Fatalf("openCityStoreAt(reload): %v", err)
-	}
+	for _, tc := range []struct {
+		name       string
+		depStatus  string
+		missing    bool
+		readErr    error
+		wantReady  bool
+		wantState  string
+		wantStatus string
+	}{
+		{name: "closed rig dependency becomes ready", depStatus: "closed", wantReady: true, wantState: waitStateReady, wantStatus: "open"},
+		{name: "open rig dependency remains pending", depStatus: "open", wantState: waitStatePending, wantStatus: "open"},
+		{name: "missing rig dependency fails the wait", missing: true, wantState: waitStateFailed, wantStatus: "closed"},
+		{name: "hard rig read error is preserved", readErr: hardErr, wantState: waitStatePending, wantStatus: "open"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const (
+				sessionID = "gcg-session-1"
+				waitID    = "gcg-wait-1"
+				depID     = "ga-dep-1"
+			)
+			cityStore := waitPrefixedStore{
+				Store: beads.NewMemStoreFrom(2, []beads.Bead{
+					{
+						ID:        sessionID,
+						Title:     "worker session",
+						Type:      sessionBeadType,
+						Status:    "open",
+						Labels:    []string{sessionBeadLabel},
+						CreatedAt: now.Add(-time.Minute),
+						UpdatedAt: now.Add(-time.Minute),
+						Revision:  1,
+						Metadata: map[string]string{
+							"session_name":       "worker",
+							"agent_name":         "worker",
+							"continuation_epoch": "1",
+						},
+					},
+					{
+						ID:        waitID,
+						Title:     "wait:worker session",
+						Type:      waitBeadType,
+						Status:    "open",
+						Labels:    []string{waitBeadLabel, "session:" + sessionID},
+						CreatedAt: now.Add(-time.Minute),
+						UpdatedAt: now.Add(-time.Minute),
+						Revision:  1,
+						Metadata: map[string]string{
+							"session_id":       sessionID,
+							"session_name":     "worker",
+							"kind":             "deps",
+							"state":            waitStatePending,
+							"dep_ids":          depID,
+							"dep_mode":         "all",
+							"registered_epoch": "1",
+							"delivery_attempt": "1",
+						},
+					},
+				}, nil),
+				prefix: "gcg",
+			}
 
-	readyWaitSet, err := prepareWaitWakeStateForCity(cityPath, cityStore, time.Now().UTC())
-	if err != nil {
-		t.Fatalf("prepareWaitWakeStateForCity: %v", err)
-	}
-	if !readyWaitSet[sessionBead.ID] {
-		t.Fatalf("readyWaitSet missing session %s", sessionBead.ID)
-	}
-	updatedWait, err := cityStore.Get(wait.ID)
-	if err != nil {
-		t.Fatalf("store.Get(wait): %v", err)
-	}
-	if got := updatedWait.Metadata["state"]; got != waitStateReady {
-		t.Fatalf("wait state = %q, want %q", got, waitStateReady)
-	}
-	if updatedWait.Metadata["ready_at"] == "" {
-		t.Fatal("ready_at was not recorded")
+			var rigBeads []beads.Bead
+			if !tc.missing {
+				rigBeads = []beads.Bead{{
+					ID:        depID,
+					Title:     "rig dependency",
+					Type:      "task",
+					Status:    tc.depStatus,
+					CreatedAt: now.Add(-time.Minute),
+					UpdatedAt: now.Add(-time.Minute),
+					Revision:  1,
+				}}
+			}
+			var rigStore beads.Store = waitPrefixedStore{
+				Store:  beads.NewMemStoreFrom(len(rigBeads), rigBeads, nil),
+				prefix: "ga",
+			}
+			if tc.readErr != nil {
+				rigStore = waitDependencyGetErrorStore{Store: rigStore, prefix: "ga", err: tc.readErr}
+			}
+
+			readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
+				sessionFrontDoor(cityStore),
+				newWaitDependencyStoreSet(cityStore, map[string]beads.Store{"frontend": rigStore}),
+				beads.NudgesStore{Store: cityStore},
+				now,
+				nil,
+			)
+			if tc.readErr != nil {
+				if !errors.Is(err, tc.readErr) {
+					t.Fatalf("prepareWaitWakeStateWithSnapshot error = %v, want %v", err, tc.readErr)
+				}
+			} else if err != nil {
+				t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
+			}
+			if got := readyWaitSet[sessionID]; got != tc.wantReady {
+				t.Fatalf("readyWaitSet[%s] = %v, want %v", sessionID, got, tc.wantReady)
+			}
+
+			updatedWait, getErr := cityStore.Get(waitID)
+			if getErr != nil {
+				t.Fatalf("store.Get(wait): %v", getErr)
+			}
+			if got := updatedWait.Metadata["state"]; got != tc.wantState {
+				t.Fatalf("wait state = %q, want %q", got, tc.wantState)
+			}
+			if updatedWait.Status != tc.wantStatus {
+				t.Fatalf("wait status = %q, want %q", updatedWait.Status, tc.wantStatus)
+			}
+			if tc.wantState == waitStateReady && updatedWait.Metadata["ready_at"] == "" {
+				t.Fatal("ready_at was not recorded")
+			}
+			if tc.wantState == waitStateFailed && updatedWait.Metadata["last_error"] == "" {
+				t.Fatal("last_error was not recorded")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

`TestPrepareWaitWakeState_ResolvesRigDependencyBeads` was paying for a complete managed-Dolt city and rig even though its responsibility is wait-readiness behavior. Its baseline test body took **80.68s**.

This change moves that behavior proof onto explicit in-memory city and rig stores. One separate test still owns the real managed-Dolt composition boundary.

## What changed

- Added a narrow, read-only dependency seam owned by the wait consumer.
- Routed controller wait reads through the existing `storeref.Resolve` split-store resolver.
- Supplied the controller's already-open city and rig stores directly and deterministically.
- Rewrote the behavior test around distinct `gcg-*` city IDs and `ga-*` rig IDs.
- Covered closed, open, missing, and hard-read-error outcomes without filesystem, process, network, polling, or wall-clock dependencies.

## Test ownership

| Invariant | Owner after this change |
| --- | --- |
| Split-store dependency routing and readiness behavior | `TestPrepareWaitWakeState_ResolvesRigDependencyBeads` using `MemStore` |
| Closed/open/missing/hard-error policy | The same small table-driven test |
| Managed-Dolt provider composition across city and rig stores | Existing `TestCmdSessionWait_AllowsRigDependencyBeads` |

## Measured impact

| Measurement | Before | After |
| --- | ---: | ---: |
| Test body | 80.68s | 0.00s reported |
| Package test time | 82.282s | 1.937s |
| Focused command wall time | 130.19s | 42.55s |

The focused command still pays the large `cmd/gc` compile/link cost; the behavioral test itself no longer starts managed Dolt. The retained real-provider composition test took 70.47s and remains intentionally singular.

## TDD evidence

- **RED:** the focused compile failed before production code existed for `prepareWaitWakeStateWithSnapshot` and `waitDependencyStoreSet`.
- **GREEN:** all four in-memory cases pass, including `-race -count=20`.
- **REFACTOR:** controller composition now passes explicit stores through the same narrow seam exercised by the small test.

## Verification

- [x] Focused wait tests
- [x] New behavior test with `-race -count=20`
- [x] `internal/storeref` with `-race -count=20`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `.githooks/pre-commit`
- [x] Three independent delegated reviewers approved the exact patch hash

The broader process sweep passed shards 1, 2, and 4. Shards 3, 5, and 6 reached an unrelated host-tool limitation: `/home/ubuntu/.local/bin/bd` was built with `CGO_ENABLED=0` and cannot initialize embedded Dolt. The deterministic failure evidence is in `/data/tmp/gc-local-tests.YVN5YA`; retrying it would not validate this patch.
