### PR TITLE
fix(molecule): keep a gated workflow-finalize for RootOnly graph.v2 so the dispatcher closes the root

### DIFF
--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -650,6 +650,64 @@ func TestWispAutoclosePreservesOrchestratedWorkflowViaInputConvoyWhenStepsOpen(t
 	}
 }
 
+func TestWispAutocloseDefersGatedFinalizerRootToDispatcher(t *testing.T) {
+	// A RootOnly graph.v2 workflow instantiated after the finalize-gap fix
+	// keeps a gated workflow-finalize control bead (gc.finalize_gate=
+	// input-convoy) attached via gc.root_bead_id. That open finalizer is a
+	// non-terminal descendant, so the input-convoy reap must park the root
+	// and leave the close to processWorkflowFinalize — the canonical
+	// dispatcher path that stamps gc.outcome and closes the source chain.
+	// Only pre-fix stepless roots (no finalizer) still reap here.
+	store := beads.NewMemStore()
+	issue, _ := store.Create(beads.Bead{Title: "work issue", Type: "task"})
+	convoy, _ := store.Create(beads.Bead{
+		Title:    "synthetic input convoy",
+		Type:     "convoy",
+		Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+	})
+	if err := store.DepAdd(convoy.ID, issue.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+	root, _ := store.Create(beads.Bead{
+		Title: "mol-focus-review",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            "workflow",
+			beadmeta.FormulaContractMetadataKey: "graph.v2",
+			beadmeta.InputConvoyIDMetadataKey:   convoy.ID,
+		},
+	})
+	finalizer, _ := store.Create(beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         "workflow-finalize",
+			beadmeta.RootBeadIDMetadataKey:   root.ID,
+			beadmeta.FinalizeGateMetadataKey: beadmeta.FinalizeGateInputConvoy,
+		},
+	})
+
+	_ = store.Close(issue.ID)
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, issue.ID, &stdout)
+
+	rootAfter, err := store.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if rootAfter.Status != "open" {
+		t.Fatalf("gated root status = %q, want open (left for the gated workflow-finalize)", rootAfter.Status)
+	}
+	finalizerAfter, err := store.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("Get(finalizer): %v", err)
+	}
+	if finalizerAfter.Status != "open" {
+		t.Fatalf("finalizer status = %q, want open", finalizerAfter.Status)
+	}
+}
+
 func TestWispAutocloseLeavesLegacyWorkflowRootViaInputConvoy(t *testing.T) {
 	// The input-convoy reap is graph.v2-only by contract: a legacy
 	// gc.kind=workflow root keeps its gc.source_bead_id attachment and is reaped

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -110,6 +110,7 @@ const (
 	FanoutModeMetadataKey                = "gc.fanout_mode"
 	FanoutStateMetadataKey               = "gc.fanout_state"
 	FinalDispositionMetadataKey          = "gc.final_disposition"
+	FinalizeGateMetadataKey              = "gc.finalize_gate"
 	ForEachMetadataKey                   = "gc.for_each"
 	FormulaMetadataKey                   = "gc.formula"
 	FormulaContractMetadataKey           = "gc.formula_contract"
@@ -352,6 +353,7 @@ var KnownMetadataKeys = []string{
 	FanoutModeMetadataKey,
 	FanoutStateMetadataKey,
 	FinalDispositionMetadataKey,
+	FinalizeGateMetadataKey,
 	ForEachMetadataKey,
 	FormulaMetadataKey,
 	FormulaContractMetadataKey,

--- a/internal/beadmeta/values.go
+++ b/internal/beadmeta/values.go
@@ -57,6 +57,14 @@ const (
 	OutcomeMissingRoot = "missing_root"
 )
 
+// FinalizeGateInputConvoy is the FinalizeGateMetadataKey ("gc.finalize_gate")
+// value stamped on the workflow-finalize control of a RootOnly graph.v2
+// workflow. Such a finalizer has no compiled step blockers — the in-session
+// worker owns every formula step — so processWorkflowFinalize instead waits
+// until every member tracked by the root's gc.input_convoy_id is terminal
+// before closing the workflow root.
+const FinalizeGateInputConvoy = "input-convoy"
+
 // Values of WorkOutcomeMetadataKey ("gc.work_outcome"), the typed work-record
 // close disposition (ADR-0009). Deliberately disjoint from the control-plane
 // OutcomeMetadataKey vocabulary above so the two never collide on one key. Only

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -1004,6 +1004,12 @@ func ensureDrainUnitTrack(store beads.Store, controlID, unitConvoyID string, mem
 	return nil
 }
 
+// trackDrainMember keeps the synthetic drain-unit convoy co-resident with its
+// member: an unresolved (cross-store) member is flagged rather than tracked, and
+// a resolved member is tracked in the convoy's own store with no member stores.
+// findFinalizeGateConvoyStore relies on this co-residence to resolve a
+// gc.synthetic convoy without opening the source-workflow stores; tracking a
+// cross-store member here would wedge the finalize gate.
 func trackDrainMember(store beads.Store, unitConvoyID string, member beads.Bead) error {
 	if convoycore.IsUnresolvedTrackedItem(member) {
 		return store.SetMetadata(unitConvoyID, beadmeta.DrainMemberUnresolvedMetadataKey, "true")

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -1634,27 +1634,61 @@ func resolveInputConvoyFinalizeGate(store beads.Store, bead beads.Bead, rootID s
 	return state, nil
 }
 
-// findFinalizeGateConvoyStore locates the store holding the input convoy
-// bead: the finalizer's own store first (convoy, issue, and workflow root are
-// co-resident on every single-store deployment), then each source-workflow
-// store when the caller wired the lister. The remaining stores are returned
-// as member-resolution probes so tracked members that live in a different
-// per-class store still materialize. A nil store with nil error means the
-// convoy was not found anywhere.
+// findFinalizeGateConvoyStore locates the store holding the input convoy bead
+// and the extra stores to probe for its tracked members. It resolves a
+// synthetic input convoy without ever opening the source-workflow stores:
+// CreateSingleItemInputConvoy stamps gc.synthetic and tracks its single member
+// in the same store, so a synthetic convoy is co-resident with a co-resident
+// member and needs no cross-store probes. That short-circuit is a correctness
+// guard, not only a cost one: the production lister errors whenever ANY rig
+// store is unavailable, so calling it unconditionally would wedge an
+// otherwise-complete co-resident finalizer on every serve cycle that an
+// unrelated rig is down. A non-synthetic convoy (a pre-existing convoy passed
+// through NormalizeInputConvoy) may track members in a different per-class
+// store, so it still opens the source-workflow stores: as member-resolution
+// probes when the convoy resolves co-resident, or as the search space when it
+// does not. A nil store with nil error means the convoy was not found anywhere.
+//
+// Invariant the synthetic short-circuit depends on: every gc.synthetic convoy
+// producer tracks its member co-resident with the convoy. The two producers
+// today are CreateSingleItemInputConvoy (internal/graphv2/invocation.go) and
+// ensureDrainUnitConvoy/trackDrainMember (drain.go, which flags an unresolved
+// member instead of tracking it cross-store). A synthetic convoy that tracked
+// a cross-store member would be dropped by the nil member-stores returned here
+// and wedge the gate; a producer that does that must gate on more than
+// gc.synthetic, or drop the short-circuit.
 func findFinalizeGateConvoyStore(store beads.Store, convoyID string, opts ProcessOptions) (beads.Store, []beads.Store, error) {
-	probeStores := []beads.Store{store}
-	if opts.SourceWorkflowStores != nil {
-		sourceStores, err := opts.SourceWorkflowStores()
-		if err != nil {
-			return nil, nil, err
+	primaryConvoy, primaryErr := store.Get(convoyID)
+	if primaryErr != nil && !errors.Is(primaryErr, beads.ErrNotFound) {
+		return nil, nil, primaryErr
+	}
+	if primaryErr == nil && strings.TrimSpace(primaryConvoy.Metadata[beadmeta.SyntheticMetadataKey]) == "true" {
+		return store, nil, nil
+	}
+	if opts.SourceWorkflowStores == nil {
+		if primaryErr == nil {
+			return store, nil, nil
 		}
-		for _, candidate := range sourceStores {
-			if candidate.Store != nil {
-				probeStores = append(probeStores, candidate.Store)
-			}
+		return nil, nil, nil
+	}
+	sourceStores, err := opts.SourceWorkflowStores()
+	if err != nil {
+		return nil, nil, err
+	}
+	probeStores := make([]beads.Store, 0, len(sourceStores)+1)
+	probeStores = append(probeStores, store) // primary at index 0, already probed above; a member probe on the not-found path, excluded on the co-resident path
+	for _, candidate := range sourceStores {
+		if candidate.Store != nil {
+			probeStores = append(probeStores, candidate.Store)
 		}
 	}
-	for i, candidate := range probeStores {
+	if primaryErr == nil {
+		// Non-synthetic convoy resolved co-resident; hand back the other stores
+		// as member-resolution probes for any cross-store tracked member.
+		return store, probeStores[1:], nil
+	}
+	for i := 1; i < len(probeStores); i++ {
+		candidate := probeStores[i]
 		if _, err := candidate.Get(convoyID); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
@@ -809,12 +810,29 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 		return ControlResult{}, fmt.Errorf("%s: missing gc.root_bead_id", bead.ID)
 	}
 
+	gate, err := resolveInputConvoyFinalizeGate(store, bead, rootID, opts)
+	if err != nil {
+		return ControlResult{}, err
+	}
+	if gate.rootTerminal {
+		// The root already reached a terminal state through another close
+		// path (wisp-autoclose reap, run cancel, manual close). Close the
+		// finalizer as cleanup without rewriting the root's recorded outcome.
+		if err := setOutcomeAndClose(store, bead.ID, beadmeta.OutcomePass); err != nil {
+			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow finalizer under closed root %s: %w", bead.ID, rootID, err))
+		}
+		return ControlResult{Processed: true, Action: "workflow-root_closed"}, nil
+	}
+
 	outcome, err := resolveFinalizeOutcome(store, bead)
 	if err != nil {
 		if errors.Is(err, errFinalizePending) {
 			return ControlResult{}, ErrControlPending
 		}
 		return ControlResult{}, fmt.Errorf("%s: resolving workflow outcome: %w", bead.ID, err)
+	}
+	if gate.failed {
+		outcome = beadmeta.OutcomeFail
 	}
 
 	// On success, propagate the closure across the gc.source_bead_id chain so
@@ -1544,6 +1562,111 @@ func matchesScopeRef(bead beads.Bead, scopeRef string) bool {
 	}
 	stepRef := bead.Metadata[beadmeta.StepRefMetadataKey]
 	return stepRef == scopeRef || strings.HasSuffix(stepRef, "."+scopeRef)
+}
+
+// finalizeGateState is resolveInputConvoyFinalizeGate's verdict for a gated
+// workflow-finalize bead that is allowed to proceed.
+type finalizeGateState struct {
+	// rootTerminal reports the workflow root already reached a terminal
+	// status through another close path; the finalizer should close itself
+	// without touching the root.
+	rootTerminal bool
+	// failed reports that a tracked input-convoy member closed with a failure
+	// outcome, which downgrades the workflow outcome to fail.
+	failed bool
+}
+
+// resolveInputConvoyFinalizeGate evaluates the gc.finalize_gate=input-convoy
+// gate on a workflow-finalize bead. Such a finalizer belongs to a RootOnly
+// graph.v2 workflow: the in-session worker owns every formula step, so the
+// finalizer has no compiled step blockers and the only completion signal is
+// the work tracked by the root's synthetic input convoy. The gate returns
+// ErrControlPending until every tracked member is terminal; a missing convoy
+// or a dangling tracked member also stays pending — closing a workflow root
+// on an absent completion signal is the failure mode this gate exists to
+// prevent. Ungated finalizers pass through untouched.
+func resolveInputConvoyFinalizeGate(store beads.Store, bead beads.Bead, rootID string, opts ProcessOptions) (finalizeGateState, error) {
+	if strings.TrimSpace(bead.Metadata[beadmeta.FinalizeGateMetadataKey]) != beadmeta.FinalizeGateInputConvoy {
+		return finalizeGateState{}, nil
+	}
+	root, err := store.Get(rootID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			// Fall through ungated: setOutcomeAndClose's ErrNotFound handling
+			// closes the finalizer as an orphan (workflow-missing_root).
+			return finalizeGateState{}, nil
+		}
+		return finalizeGateState{}, fmt.Errorf("%s: loading gated workflow root %s: %w", bead.ID, rootID, err)
+	}
+	if convoy.IsTerminalStatus(root.Status) {
+		return finalizeGateState{rootTerminal: true}, nil
+	}
+	convoyID := strings.TrimSpace(root.Metadata[beadmeta.InputConvoyIDMetadataKey])
+	if convoyID == "" {
+		opts.tracef("workflow-finalize bead=%s root=%s gate=input-convoy pending reason=missing_input_convoy_id", bead.ID, rootID)
+		return finalizeGateState{}, fmt.Errorf("%w: gated finalizer %s: root %s has no gc.input_convoy_id", ErrControlPending, bead.ID, rootID)
+	}
+	convoyStore, memberStores, err := findFinalizeGateConvoyStore(store, convoyID, opts)
+	if err != nil {
+		return finalizeGateState{}, fmt.Errorf("%s: locating input convoy %s: %w", bead.ID, convoyID, err)
+	}
+	if convoyStore == nil {
+		opts.tracef("workflow-finalize bead=%s root=%s gate=input-convoy pending reason=convoy_not_found convoy=%s", bead.ID, rootID, convoyID)
+		return finalizeGateState{}, fmt.Errorf("%w: gated finalizer %s: input convoy %s not found", ErrControlPending, bead.ID, convoyID)
+	}
+	members, err := convoy.Members(convoyStore, convoyID, true, memberStores...)
+	if err != nil {
+		return finalizeGateState{}, fmt.Errorf("%s: listing input convoy %s members: %w", bead.ID, convoyID, err)
+	}
+	if len(members) == 0 {
+		opts.tracef("workflow-finalize bead=%s root=%s gate=input-convoy pending reason=convoy_empty convoy=%s", bead.ID, rootID, convoyID)
+		return finalizeGateState{}, fmt.Errorf("%w: gated finalizer %s: input convoy %s has no tracked members", ErrControlPending, bead.ID, convoyID)
+	}
+	state := finalizeGateState{}
+	for _, member := range members {
+		if !convoy.IsTerminalStatus(member.Status) {
+			return finalizeGateState{}, fmt.Errorf("%w: gated finalizer %s: tracked member %s is still %s", ErrControlPending, bead.ID, member.ID, member.Status)
+		}
+		if beadOutcomeFailed(member) {
+			state.failed = true
+		}
+	}
+	return state, nil
+}
+
+// findFinalizeGateConvoyStore locates the store holding the input convoy
+// bead: the finalizer's own store first (convoy, issue, and workflow root are
+// co-resident on every single-store deployment), then each source-workflow
+// store when the caller wired the lister. The remaining stores are returned
+// as member-resolution probes so tracked members that live in a different
+// per-class store still materialize. A nil store with nil error means the
+// convoy was not found anywhere.
+func findFinalizeGateConvoyStore(store beads.Store, convoyID string, opts ProcessOptions) (beads.Store, []beads.Store, error) {
+	probeStores := []beads.Store{store}
+	if opts.SourceWorkflowStores != nil {
+		sourceStores, err := opts.SourceWorkflowStores()
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, candidate := range sourceStores {
+			if candidate.Store != nil {
+				probeStores = append(probeStores, candidate.Store)
+			}
+		}
+	}
+	for i, candidate := range probeStores {
+		if _, err := candidate.Get(convoyID); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return nil, nil, err
+		}
+		memberStores := make([]beads.Store, 0, len(probeStores)-1)
+		memberStores = append(memberStores, probeStores[:i]...)
+		memberStores = append(memberStores, probeStores[i+1:]...)
+		return candidate, memberStores, nil
+	}
+	return nil, nil, nil
 }
 
 func resolveFinalizeOutcome(store beads.Store, finalizer beads.Bead) (string, error) {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -10023,3 +10023,269 @@ func TestAbortScopeSharedConvergence(t *testing.T) {
 		}
 	}
 }
+
+// gatedFinalizeFixture creates the bead shape a RootOnly graph.v2 sling
+// leaves behind after the finalize-gap fix: a workflow root stamped with an
+// input convoy, the synthetic single-item convoy tracking a work issue, and a
+// dependency-free workflow-finalize control gated on that convoy.
+type gatedFinalizeFixture struct {
+	root      beads.Bead
+	convoy    beads.Bead
+	issue     beads.Bead
+	finalizer beads.Bead
+}
+
+func newGatedFinalizeFixture(t *testing.T, store beads.Store, issue beads.Bead) gatedFinalizeFixture {
+	t.Helper()
+	createdIssue := mustCreateWorkflowBead(t, store, issue)
+	convoy := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "input convoy for " + createdIssue.ID,
+		Type:     "convoy",
+		Metadata: map[string]string{"gc.synthetic": "true"},
+	})
+	mustDepAdd(t, store, convoy.ID, createdIssue.ID, "tracks")
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.input_convoy_id":  convoy.ID,
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":          "workflow-finalize",
+			"gc.root_bead_id":  root.ID,
+			"gc.finalize_gate": "input-convoy",
+		},
+	})
+	mustDepAdd(t, store, finalizer.ID, root.ID, "tracks")
+	return gatedFinalizeFixture{root: root, convoy: convoy, issue: createdIssue, finalizer: finalizer}
+}
+
+// The gate: while the tracked issue is open the finalizer is pending and the
+// root stays open. This is the engine-side regression test for the graph.v2
+// root-finalize gap (RCA gc-8h5ls): before the fix nothing ever closed the
+// root of a RootOnly graph.v2 workflow.
+func TestProcessWorkflowFinalizeInputConvoyGatePendingWhileIssueOpen(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	fx := newGatedFinalizeFixture(t, store, beads.Bead{Title: "review issue", Type: "task"})
+
+	_, err := ProcessControl(store, fx.finalizer, ProcessOptions{})
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl err = %v, want ErrControlPending", err)
+	}
+	if got := mustGetBead(t, store, fx.root.ID).Status; got != "open" {
+		t.Fatalf("root status = %q, want open (gate must not close early)", got)
+	}
+	if got := mustGetBead(t, store, fx.finalizer.ID).Status; got != "open" {
+		t.Fatalf("finalizer status = %q, want open", got)
+	}
+}
+
+func TestProcessWorkflowFinalizeInputConvoyGateClosesRootOnceIssueCloses(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	fx := newGatedFinalizeFixture(t, store, beads.Bead{Title: "review issue", Type: "task"})
+	if err := store.Close(fx.issue.ID); err != nil {
+		t.Fatalf("close issue: %v", err)
+	}
+
+	result, err := ProcessControl(store, fx.finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", result)
+	}
+	rootAfter := mustGetBead(t, store, fx.root.ID)
+	if rootAfter.Status != "closed" || rootAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("root = status %q outcome %q, want closed/pass", rootAfter.Status, rootAfter.Metadata["gc.outcome"])
+	}
+	finalizerAfter := mustGetBead(t, store, fx.finalizer.ID)
+	if finalizerAfter.Status != "closed" || finalizerAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("finalizer = status %q outcome %q, want closed/pass", finalizerAfter.Status, finalizerAfter.Metadata["gc.outcome"])
+	}
+}
+
+// A tracked member that closed with an explicit gc.outcome=fail fails the
+// workflow root, mirroring resolveBlockedOutcome's blocker aggregation.
+func TestProcessWorkflowFinalizeInputConvoyGateAggregatesMemberFailure(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	fx := newGatedFinalizeFixture(t, store, beads.Bead{
+		Title:    "review issue",
+		Type:     "task",
+		Status:   "closed",
+		Metadata: map[string]string{"gc.outcome": "fail"},
+	})
+
+	result, err := ProcessControl(store, fx.finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("result = %+v, want processed workflow-fail", result)
+	}
+	rootAfter := mustGetBead(t, store, fx.root.ID)
+	if rootAfter.Status != "closed" || rootAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("root = status %q outcome %q, want closed/fail", rootAfter.Status, rootAfter.Metadata["gc.outcome"])
+	}
+}
+
+// Fail-safe: a gated finalizer whose convoy vanished must stay pending, never
+// close the root on a missing completion signal.
+func TestProcessWorkflowFinalizeInputConvoyGatePendingWhenConvoyMissing(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.input_convoy_id":  "gc-gone",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":          "workflow-finalize",
+			"gc.root_bead_id":  root.ID,
+			"gc.finalize_gate": "input-convoy",
+		},
+	})
+
+	_, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl err = %v, want ErrControlPending", err)
+	}
+	if got := mustGetBead(t, store, root.ID).Status; got != "open" {
+		t.Fatalf("root status = %q, want open", got)
+	}
+}
+
+// Fail-safe: a dangling tracks member (target bead deleted) resolves as
+// non-terminal, so the gate stays pending instead of closing the root.
+func TestProcessWorkflowFinalizeInputConvoyGatePendingOnDanglingMember(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	fx := newGatedFinalizeFixture(t, store, beads.Bead{Title: "review issue", Type: "task"})
+	mustDepAdd(t, store, fx.convoy.ID, "gc-deleted-member", "tracks")
+	if err := store.Close(fx.issue.ID); err != nil {
+		t.Fatalf("close issue: %v", err)
+	}
+
+	_, err := ProcessControl(store, fx.finalizer, ProcessOptions{})
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl err = %v, want ErrControlPending", err)
+	}
+	if got := mustGetBead(t, store, fx.root.ID).Status; got != "open" {
+		t.Fatalf("root status = %q, want open", got)
+	}
+}
+
+// An already-terminal root (reaped by wisp autoclose, canceled, or manually
+// closed) short-circuits the gate: the finalizer closes itself as cleanup and
+// must not mutate the root's recorded outcome.
+func TestProcessWorkflowFinalizeInputConvoyGateClosedRootClosesFinalizerOnly(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	fx := newGatedFinalizeFixture(t, store, beads.Bead{Title: "review issue", Type: "task"})
+	if err := store.SetMetadata(fx.root.ID, "gc.outcome", "canceled"); err != nil {
+		t.Fatalf("set root outcome: %v", err)
+	}
+	if err := store.Close(fx.root.ID); err != nil {
+		t.Fatalf("close root: %v", err)
+	}
+
+	result, err := ProcessControl(store, fx.finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-root_closed" {
+		t.Fatalf("result = %+v, want processed workflow-root_closed", result)
+	}
+	rootAfter := mustGetBead(t, store, fx.root.ID)
+	if rootAfter.Metadata["gc.outcome"] != "canceled" {
+		t.Fatalf("root outcome = %q, want canceled preserved", rootAfter.Metadata["gc.outcome"])
+	}
+	finalizerAfter := mustGetBead(t, store, fx.finalizer.ID)
+	if finalizerAfter.Status != "closed" {
+		t.Fatalf("finalizer status = %q, want closed", finalizerAfter.Status)
+	}
+}
+
+// End-to-end over the molecule seam: instantiate the RootOnly graph.v2
+// recipe shape (as the sling leaves it), verify the gated finalizer is
+// pending while the issue is open, then close the issue and verify the
+// dispatcher closes the workflow root. This is the failing-before /
+// passing-after regression for the review-pool spawn-churn wedge.
+func TestRootOnlyGraphWorkflowFinalizeClosesRootEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	issue := mustCreateWorkflowBead(t, store, beads.Bead{Title: "review issue", Type: "task"})
+	convoy := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "input convoy for " + issue.ID,
+		Type:     "convoy",
+		Metadata: map[string]string{"gc.synthetic": "true"},
+	})
+	mustDepAdd(t, store, convoy.ID, issue.ID, "tracks")
+
+	recipe := &formula.Recipe{
+		Name:     "mol-review",
+		RootOnly: true,
+		Steps: []formula.RecipeStep{
+			{ID: "mol-review", Title: "Review", Type: "task", IsRoot: true, Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+				"gc.input_convoy_id":  convoy.ID,
+			}},
+			{ID: "mol-review.work", Title: "Work", Type: "task"},
+			{ID: "mol-review.workflow-finalize", Title: "Finalize workflow", Type: "task", Metadata: map[string]string{"gc.kind": "workflow-finalize"}},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-review.workflow-finalize", DependsOnID: "mol-review.work", Type: "blocks"},
+			{StepID: "mol-review", DependsOnID: "mol-review.workflow-finalize", Type: "blocks"},
+		},
+	}
+	result, err := molecule.Instantiate(context.Background(), store, recipe, molecule.Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	finalizeID := result.IDMapping["mol-review.workflow-finalize"]
+	if finalizeID == "" {
+		t.Fatal("workflow-finalize bead missing; RootOnly graph.v2 must keep its gated finalizer")
+	}
+
+	if _, err := ProcessControl(store, mustGetBead(t, store, finalizeID), ProcessOptions{}); !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl (issue open) err = %v, want ErrControlPending", err)
+	}
+
+	if err := store.Close(issue.ID); err != nil {
+		t.Fatalf("close issue: %v", err)
+	}
+	procResult, err := ProcessControl(store, mustGetBead(t, store, finalizeID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl (issue closed): %v", err)
+	}
+	if !procResult.Processed || procResult.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", procResult)
+	}
+	rootAfter := mustGetBead(t, store, result.RootID)
+	if rootAfter.Status != "closed" || rootAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("root = status %q outcome %q, want closed/pass", rootAfter.Status, rootAfter.Metadata["gc.outcome"])
+	}
+}

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/molecule"
@@ -10064,6 +10065,151 @@ func newGatedFinalizeFixture(t *testing.T, store beads.Store, issue beads.Bead) 
 	})
 	mustDepAdd(t, store, finalizer.ID, root.ID, "tracks")
 	return gatedFinalizeFixture{root: root, convoy: convoy, issue: createdIssue, finalizer: finalizer}
+}
+
+// findFinalizeGateConvoyStore resolves a synthetic input convoy without opening
+// the source-workflow stores (CreateSingleItemInputConvoy stamps gc.synthetic
+// and tracks its member co-resident), and still hands the source stores back as
+// member probes for a non-synthetic convoy that may track a cross-store member.
+func TestFindFinalizeGateConvoyStore(t *testing.T) {
+	t.Parallel()
+
+	syntheticConvoy := func(t *testing.T, store beads.Store) beads.Bead {
+		t.Helper()
+		return mustCreateWorkflowBead(t, store, beads.Bead{
+			Title:    "input convoy",
+			Type:     "convoy",
+			Metadata: map[string]string{"gc.synthetic": "true"},
+		})
+	}
+
+	t.Run("synthetic co-resident convoy skips the source-workflow lister", func(t *testing.T) {
+		primary := beads.NewMemStore()
+		convoy := syntheticConvoy(t, primary)
+		opts := ProcessOptions{SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			t.Fatal("SourceWorkflowStores opened for a synthetic co-resident convoy")
+			return nil, nil
+		}}
+		got, members, err := findFinalizeGateConvoyStore(primary, convoy.ID, opts)
+		if err != nil {
+			t.Fatalf("findFinalizeGateConvoyStore: %v", err)
+		}
+		if got != primary || len(members) != 0 {
+			t.Fatalf("got (store=%v, members=%d), want (primary, 0)", got, len(members))
+		}
+	})
+
+	// Regression for the wedge Codex flagged: the production lister errors when
+	// any unrelated rig is unavailable. A synthetic co-resident convoy must
+	// still resolve rather than propagate that error and stall the finalizer.
+	t.Run("synthetic convoy resolves even when the lister errors", func(t *testing.T) {
+		primary := beads.NewMemStore()
+		convoy := syntheticConvoy(t, primary)
+		opts := ProcessOptions{SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return nil, errors.New("rig unavailable")
+		}}
+		got, members, err := findFinalizeGateConvoyStore(primary, convoy.ID, opts)
+		if err != nil {
+			t.Fatalf("findFinalizeGateConvoyStore returned error for a synthetic convoy: %v", err)
+		}
+		if got != primary || len(members) != 0 {
+			t.Fatalf("got (store=%v, members=%d), want (primary, 0)", got, len(members))
+		}
+	})
+
+	// A non-synthetic convoy may track members in another store, so the fix must
+	// hand back the source stores as member probes and the cross-store member
+	// must still resolve terminal through convoy.Members.
+	t.Run("non-synthetic co-resident convoy keeps cross-store member resolution", func(t *testing.T) {
+		primary := beads.NewMemStore()
+		rig := beads.NewMemStore()
+		convoy := mustCreateWorkflowBead(t, primary, beads.Bead{Title: "input convoy", Type: "convoy"})
+		member := mustCreateWorkflowBead(t, rig, beads.Bead{Title: "tracked", Type: "task"})
+		if err := convoycore.TrackItem(primary, convoy.ID, member.ID, rig); err != nil {
+			t.Fatalf("TrackItem: %v", err)
+		}
+		opts := ProcessOptions{SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{{Store: rig, StoreRef: "rig:test"}}, nil
+		}}
+		got, members, err := findFinalizeGateConvoyStore(primary, convoy.ID, opts)
+		if err != nil {
+			t.Fatalf("findFinalizeGateConvoyStore: %v", err)
+		}
+		if got != primary {
+			t.Fatalf("convoy store = %v, want primary", got)
+		}
+		resolved, err := convoycore.Members(got, convoy.ID, true, members...)
+		if err != nil {
+			t.Fatalf("Members: %v", err)
+		}
+		if len(resolved) != 1 || resolved[0].ID != member.ID {
+			t.Fatalf("resolved members = %+v, want the cross-store member %s", resolved, member.ID)
+		}
+		if resolved[0].Status == "unknown" {
+			t.Fatal("cross-store member unresolved (status unknown); member store was dropped")
+		}
+	})
+
+	t.Run("convoy in a source store resolves with the primary as a member probe", func(t *testing.T) {
+		primary := beads.NewMemStore()
+		source := beads.NewMemStore()
+		convoy := mustCreateWorkflowBead(t, source, beads.Bead{Title: "input convoy", Type: "convoy"})
+		opts := ProcessOptions{SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{{Store: source, StoreRef: "rig:test"}}, nil
+		}}
+		got, members, err := findFinalizeGateConvoyStore(primary, convoy.ID, opts)
+		if err != nil {
+			t.Fatalf("findFinalizeGateConvoyStore: %v", err)
+		}
+		if got != source {
+			t.Fatalf("convoy store = %v, want source", got)
+		}
+		foundPrimary := false
+		for _, m := range members {
+			if m == primary {
+				foundPrimary = true
+			}
+		}
+		if !foundPrimary {
+			t.Fatal("primary store missing from member probes")
+		}
+	})
+
+	t.Run("absent convoy returns nil store", func(t *testing.T) {
+		primary := beads.NewMemStore()
+		opts := ProcessOptions{SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{{Store: beads.NewMemStore(), StoreRef: "rig:test"}}, nil
+		}}
+		got, _, err := findFinalizeGateConvoyStore(primary, "gc-nope", opts)
+		if err != nil {
+			t.Fatalf("findFinalizeGateConvoyStore: %v", err)
+		}
+		if got != nil {
+			t.Fatal("convoy store non-nil for an absent convoy")
+		}
+	})
+
+	// A hard (non-ErrNotFound) primary-store error propagates immediately and
+	// skips both the synthetic check and the lister: a store that cannot answer
+	// must fail the gate, not silently fall through to a cross-store search.
+	t.Run("hard primary-store error propagates before the lister", func(t *testing.T) {
+		primary := getErrorStore{Store: beads.NewMemStore(), failID: "gc-boom", err: errors.New("store unavailable")}
+		listerCalled := false
+		opts := ProcessOptions{SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			listerCalled = true
+			return nil, nil
+		}}
+		got, _, err := findFinalizeGateConvoyStore(primary, "gc-boom", opts)
+		if err == nil {
+			t.Fatal("expected the hard primary-store error to propagate")
+		}
+		if got != nil {
+			t.Fatal("convoy store should be nil on a hard primary-store error")
+		}
+		if listerCalled {
+			t.Fatal("lister opened despite a hard primary-store error")
+		}
+	})
 }
 
 // The gate: while the tracked issue is open the finalizer is pending and the

--- a/internal/graphv2/invocation.go
+++ b/internal/graphv2/invocation.go
@@ -401,6 +401,11 @@ func CreateSingleItemInputConvoy(store beads.Store, target beads.Bead) (beads.Be
 	if err != nil {
 		return beads.Bead{}, fmt.Errorf("creating input convoy for %s: %w", target.ID, err)
 	}
+	// Track the member co-resident (no member stores): the convoy and its one
+	// tracked item live in the same store. dispatch.findFinalizeGateConvoyStore
+	// relies on this — a gc.synthetic convoy is resolved without opening the
+	// source-workflow stores, so a cross-store member here would wedge the
+	// finalize gate. Keep synthetic input convoys co-resident.
 	if err := convoycore.TrackItem(store, created.ID, target.ID); err != nil {
 		return beads.Bead{}, fmt.Errorf("tracking %s from input convoy %s: %w", target.ID, created.ID, err)
 	}

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -227,7 +227,10 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 			// A finalizer kept through a RootOnly drop has no compiled step
 			// blockers; mark it so processWorkflowFinalize gates on the
 			// root's input convoy instead of closing the root immediately.
-			if recipe.RootOnly {
+			// Keyed on the finalize kind, not merely RootOnly: keepRootOnlyGraphStep
+			// only keeps workflow-finalize today, but gating the stamp on kind
+			// keeps the gate metadata off any other survivor if that filter grows.
+			if recipe.RootOnly && step.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflowFinalize {
 				node.Metadata[beadmeta.FinalizeGateMetadataKey] = beadmeta.FinalizeGateInputConvoy
 			}
 			if logicalStepID, ok := logicalRecipeStepID(step); ok {

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -153,8 +153,10 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 	}
 
 	for i, step := range recipe.Steps {
-		if recipe.RootOnly && i > 0 {
-			break
+		// For RootOnly recipes, only create the root bead — plus the gated
+		// workflow-finalize control for graph workflows (keepRootOnlyGraphStep).
+		if recipe.RootOnly && i > 0 && !keepRootOnlyGraphStep(recipe, step) {
+			continue
 		}
 		node, err := recipeStepToGraphNode(step, vars, priorityOverride)
 		if err != nil {
@@ -222,6 +224,12 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				}
 				node.MetadataRefs[beadmeta.RootBeadIDMetadataKey] = rootKey
 			}
+			// A finalizer kept through a RootOnly drop has no compiled step
+			// blockers; mark it so processWorkflowFinalize gates on the
+			// root's input convoy instead of closing the root immediately.
+			if recipe.RootOnly {
+				node.Metadata[beadmeta.FinalizeGateMetadataKey] = beadmeta.FinalizeGateInputConvoy
+			}
 			if logicalStepID, ok := logicalRecipeStepID(step); ok {
 				if node.MetadataRefs == nil {
 					node.MetadataRefs = make(map[string]string, 1)
@@ -266,18 +274,26 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 		included[node.Key] = true
 	}
 
-	for _, dep := range recipe.Deps {
-		if !included[dep.StepID] || !included[dep.DependsOnID] {
-			continue
-		}
-		plan.Edges = append(plan.Edges, beads.GraphApplyEdge{
-			FromKey:  dep.StepID,
-			ToKey:    dep.DependsOnID,
-			Type:     dep.Type,
-			Metadata: dep.Metadata,
-		})
-		if dep.Type == "parent-child" {
-			setNodeParentRef(plan.Nodes, dep.StepID, dep.DependsOnID, "")
+	// RootOnly instantiation carries no recipe dependency edges: the root must
+	// stay unblocked (it IS the claimable work — a blocks edge onto the root
+	// would hide it from ready/hook claim) and the kept finalizer's sink
+	// blockers were dropped with their steps. The graphWorkflow block below
+	// still adds the non-blocking tracks edge to the root for cascade
+	// discovery.
+	if !recipe.RootOnly {
+		for _, dep := range recipe.Deps {
+			if !included[dep.StepID] || !included[dep.DependsOnID] {
+				continue
+			}
+			plan.Edges = append(plan.Edges, beads.GraphApplyEdge{
+				FromKey:  dep.StepID,
+				ToKey:    dep.DependsOnID,
+				Type:     dep.Type,
+				Metadata: dep.Metadata,
+			})
+			if dep.Type == "parent-child" {
+				setNodeParentRef(plan.Nodes, dep.StepID, dep.DependsOnID, "")
+			}
 		}
 	}
 

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -913,7 +913,10 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			// A finalizer kept through a RootOnly drop has no compiled step
 			// blockers; mark it so processWorkflowFinalize gates on the
 			// root's input convoy instead of closing the root immediately.
-			if recipe.RootOnly {
+			// Keyed on the finalize kind, not merely RootOnly: keepRootOnlyGraphStep
+			// only keeps workflow-finalize today, but gating the stamp on kind
+			// keeps the gate metadata off any other survivor if that filter grows.
+			if recipe.RootOnly && b.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflowFinalize {
 				b.Metadata[beadmeta.FinalizeGateMetadataKey] = beadmeta.FinalizeGateInputConvoy
 			}
 

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -808,9 +808,10 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	recipeParentByStep := recipeParentDeps(recipe.Deps)
 
 	for i, step := range recipe.Steps {
-		// For RootOnly recipes, only create the root bead.
-		if recipe.RootOnly && i > 0 {
-			break
+		// For RootOnly recipes, only create the root bead — plus the gated
+		// workflow-finalize control for graph workflows (keepRootOnlyGraphStep).
+		if recipe.RootOnly && i > 0 && !keepRootOnlyGraphStep(recipe, step) {
+			continue
 		}
 
 		b := stepToBead(step, vars, priorityOverride)
@@ -909,6 +910,13 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				}
 			}
 
+			// A finalizer kept through a RootOnly drop has no compiled step
+			// blockers; mark it so processWorkflowFinalize gates on the
+			// root's input convoy instead of closing the root immediately.
+			if recipe.RootOnly {
+				b.Metadata[beadmeta.FinalizeGateMetadataKey] = beadmeta.FinalizeGateInputConvoy
+			}
+
 			// Inline Ralph attempt beads need the actual logical bead ID at runtime.
 			// Stamp it during instantiation while the recipe-step -> bead mapping is live.
 			if logicalStepID, ok := logicalRecipeStepID(step); ok {
@@ -960,8 +968,25 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 
 	}
 
-	// Wire dependencies using the IDMapping.
-	if !recipe.RootOnly {
+	// Wire dependencies using the IDMapping. RootOnly instantiation carries no
+	// recipe dependency edges: the root must stay unblocked (it IS the
+	// claimable work) and the kept finalizer's sink blockers were dropped with
+	// their steps. A non-blocking tracks edge still links each kept bead to
+	// the root so cascade delete discovers it alongside the gc.root_bead_id
+	// metadata (mirroring buildRecipeApplyPlan's root-track edges).
+	if recipe.RootOnly {
+		rootBeadID := idMapping[recipe.Steps[0].ID]
+		for _, step := range recipe.Steps[1:] {
+			beadID := idMapping[step.ID]
+			if beadID == "" {
+				continue // dropped by the RootOnly keep filter
+			}
+			if err := store.DepAdd(beadID, rootBeadID, "tracks"); err != nil {
+				markFailed(store, createdIDs)
+				return nil, fmt.Errorf("wiring root track %s->%s: %w", step.ID, recipe.Steps[0].ID, err)
+			}
+		}
+	} else {
 		for _, dep := range recipe.Deps {
 			fromID, fromOK := idMapping[dep.StepID]
 			toID, toOK := idMapping[dep.DependsOnID]
@@ -1300,6 +1325,26 @@ func preservesGraphActionTypes(recipe *formula.Recipe) bool {
 	return root.Metadata[beadmeta.AttemptMetadataKey] != "" && root.Metadata[beadmeta.StepRefMetadataKey] != ""
 }
 
+// keepRootOnlyGraphStep reports whether a non-root step survives RootOnly
+// instantiation. A RootOnly graph workflow keeps its compiled
+// workflow-finalize control bead when the launch stamped an input convoy on
+// the root: the in-session worker owns every formula step, so the finalizer —
+// gated on that convoy by processWorkflowFinalize — is the only engine-side
+// signal that closes the workflow root once the tracked work completes (the
+// graph.v2 root-finalize gap, RCA gc-8h5ls). Without a convoy there is no
+// completion signal to gate on, and an ungated dependency-free finalizer
+// would close the root the moment the dispatcher saw it, so every other
+// launch shape keeps today's root-only drop.
+func keepRootOnlyGraphStep(recipe *formula.Recipe, step formula.RecipeStep) bool {
+	if step.Metadata[beadmeta.KindMetadataKey] != beadmeta.KindWorkflowFinalize {
+		return false
+	}
+	if !preservesGraphActionTypes(recipe) {
+		return false
+	}
+	return strings.TrimSpace(recipe.Steps[0].Metadata[beadmeta.InputConvoyIDMetadataKey]) != ""
+}
+
 // stepToBead converts a RecipeStep to a Bead with variable substitution.
 func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverride *int) beads.Bead {
 	stepType := step.Type
@@ -1546,8 +1591,8 @@ func unresolvedTitleValidationErrorsWithVars(recipe *formula.Recipe, opts Option
 	vars := applyVarDefaults(providedVars, recipe.Vars)
 	errs := make([]string, 0)
 	for i, step := range recipe.Steps {
-		if recipe.RootOnly && i > 0 {
-			break
+		if recipe.RootOnly && i > 0 && !keepRootOnlyGraphStep(recipe, step) {
+			continue
 		}
 		rawTitle := step.Title
 		if step.IsRoot && opts.Title != "" {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -3439,3 +3439,187 @@ func TestInstantiate_DeferredStepsStayGate(t *testing.T) {
 		t.Errorf("deferred step.Type = %q, want %q", b.Type, "gate")
 	}
 }
+
+// rootOnlyGraphWorkflowRecipe builds a compiled-recipe shape matching a vapor
+// graph.v2 formula after sling stamping: RootOnly with a workflow root, one
+// (dropped) work step, and the compiled workflow-finalize control step.
+// inputConvoyID mirrors stampGraphV2RootMetadata; pass "" for a launch with no
+// input convoy (e.g. a standalone cook).
+func rootOnlyGraphWorkflowRecipe(inputConvoyID string) *formula.Recipe {
+	rootMeta := map[string]string{
+		"gc.kind":             "workflow",
+		"gc.formula_contract": "graph.v2",
+	}
+	if inputConvoyID != "" {
+		rootMeta["gc.input_convoy_id"] = inputConvoyID
+	}
+	return &formula.Recipe{
+		Name:     "mol-review",
+		RootOnly: true,
+		Steps: []formula.RecipeStep{
+			{ID: "mol-review", Title: "Review", Type: "task", IsRoot: true, Metadata: rootMeta},
+			{ID: "mol-review.work", Title: "Work", Type: "task", Metadata: map[string]string{"gc.step_ref": "mol-review.work"}},
+			{ID: "mol-review.workflow-finalize", Title: "Finalize workflow", Type: "task", Metadata: map[string]string{"gc.kind": "workflow-finalize"}},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-review.workflow-finalize", DependsOnID: "mol-review.work", Type: "blocks"},
+			{StepID: "mol-review", DependsOnID: "mol-review.workflow-finalize", Type: "blocks"},
+		},
+	}
+}
+
+// Regression test for the graph.v2 root-finalize gap (gc-8h5ls follow-up):
+// RootOnly instantiation of a graph workflow with a stamped input convoy must
+// keep the compiled workflow-finalize control bead — gated on the input convoy
+// — so processWorkflowFinalize can close the root once the tracked work
+// closes. It must NOT keep any other step, and must NOT block the root (the
+// root IS the claimable work in a root-only wisp).
+func TestInstantiateRootOnlyGraphWorkflowKeepsGatedFinalizer(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := rootOnlyGraphWorkflowRecipe("gc-convoy1")
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if result.Created != 2 {
+		t.Fatalf("Created = %d, want 2 (root + workflow-finalize)", result.Created)
+	}
+	if _, ok := result.IDMapping["mol-review.work"]; ok {
+		t.Fatal("work step was created; RootOnly must drop non-finalize steps")
+	}
+
+	finalizeID := result.IDMapping["mol-review.workflow-finalize"]
+	if finalizeID == "" {
+		t.Fatal("workflow-finalize bead missing from IDMapping")
+	}
+	finalize, err := store.Get(finalizeID)
+	if err != nil {
+		t.Fatalf("Get(finalize): %v", err)
+	}
+	if got := finalize.Metadata["gc.kind"]; got != "workflow-finalize" {
+		t.Fatalf("finalize gc.kind = %q, want workflow-finalize", got)
+	}
+	if got := finalize.Metadata["gc.root_bead_id"]; got != result.RootID {
+		t.Fatalf("finalize gc.root_bead_id = %q, want %q", got, result.RootID)
+	}
+	if got := finalize.Metadata["gc.finalize_gate"]; got != "input-convoy" {
+		t.Fatalf("finalize gc.finalize_gate = %q, want input-convoy", got)
+	}
+
+	// The root must stay unblocked: a blocks dep from the root onto the
+	// finalizer would hide the root from ready/hook claim and wedge dispatch.
+	rootDeps, err := store.DepList(result.RootID, "down")
+	if err != nil {
+		t.Fatalf("DepList(root): %v", err)
+	}
+	for _, dep := range rootDeps {
+		if dep.Type == "blocks" {
+			t.Fatalf("root has blocks dep on %s; RootOnly root must stay claimable", dep.DependsOnID)
+		}
+	}
+
+	// The finalizer must carry no blocks deps (its compiled sink blockers were
+	// dropped with their steps) and a non-blocking tracks edge to the root for
+	// cascade discovery.
+	finalizeDeps, err := store.DepList(finalizeID, "down")
+	if err != nil {
+		t.Fatalf("DepList(finalize): %v", err)
+	}
+	tracksRoot := false
+	for _, dep := range finalizeDeps {
+		if dep.Type == "blocks" {
+			t.Fatalf("finalize has blocks dep on %s; sink blockers must be dropped", dep.DependsOnID)
+		}
+		if dep.Type == "tracks" && dep.DependsOnID == result.RootID {
+			tracksRoot = true
+		}
+	}
+	if !tracksRoot {
+		t.Fatal("finalize missing tracks dep to root")
+	}
+}
+
+// A RootOnly graph workflow with no stamped input convoy keeps today's shape:
+// nothing survives but the root. Without a convoy there is no completion
+// signal to gate on, and an ungated finalizer would close the root instantly.
+func TestInstantiateRootOnlyGraphWorkflowWithoutConvoyDropsFinalizer(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := rootOnlyGraphWorkflowRecipe("")
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if result.Created != 1 {
+		t.Fatalf("Created = %d, want 1 (root only)", result.Created)
+	}
+}
+
+// The graph-apply plan builder must mirror the fallback path: root +
+// gated finalizer nodes, no blocks edges, one tracks edge to the root.
+func TestBuildRecipeApplyPlanRootOnlyGraphWorkflowKeepsGatedFinalizer(t *testing.T) {
+	recipe := rootOnlyGraphWorkflowRecipe("gc-convoy1")
+
+	plan, graphWorkflow, rootKey, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	if !graphWorkflow {
+		t.Fatal("graphWorkflow = false, want true")
+	}
+	if rootKey != "mol-review" {
+		t.Fatalf("rootKey = %q, want mol-review", rootKey)
+	}
+	if len(plan.Nodes) != 2 {
+		keys := make([]string, 0, len(plan.Nodes))
+		for _, n := range plan.Nodes {
+			keys = append(keys, n.Key)
+		}
+		t.Fatalf("plan nodes = %v, want [mol-review mol-review.workflow-finalize]", keys)
+	}
+	var finalizeNode *beads.GraphApplyNode
+	for i := range plan.Nodes {
+		if plan.Nodes[i].Key == "mol-review.workflow-finalize" {
+			finalizeNode = &plan.Nodes[i]
+		}
+	}
+	if finalizeNode == nil {
+		t.Fatal("plan missing workflow-finalize node")
+	}
+	if got := finalizeNode.Metadata["gc.finalize_gate"]; got != "input-convoy" {
+		t.Fatalf("finalize node gc.finalize_gate = %q, want input-convoy", got)
+	}
+	if got := finalizeNode.MetadataRefs["gc.root_bead_id"]; got != "mol-review" {
+		t.Fatalf("finalize node gc.root_bead_id ref = %q, want mol-review", got)
+	}
+	for _, e := range plan.Edges {
+		if e.Type == "blocks" {
+			t.Fatalf("plan has blocks edge %s -> %s%s; RootOnly must carry none", e.FromKey, e.ToKey, e.ToID)
+		}
+	}
+	if !graphApplyPlanHasEdgeFromKeyToTarget(plan.Edges, "mol-review.workflow-finalize", "mol-review", "") {
+		t.Fatal("plan missing tracks edge finalize -> root")
+	}
+}
+
+// A plain RootOnly wisp (no graph workflow) never keeps a finalizer even if
+// its root somehow carries an input convoy stamp.
+func TestInstantiateRootOnlyNonGraphKeepsNothing(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name:     "patrol",
+		RootOnly: true,
+		Steps: []formula.RecipeStep{
+			{ID: "patrol", Title: "Patrol", Type: "task", IsRoot: true, Metadata: map[string]string{"gc.kind": "wisp", "gc.input_convoy_id": "gc-convoy1"}},
+			{ID: "patrol.workflow-finalize", Title: "Finalize workflow", Type: "task", Metadata: map[string]string{"gc.kind": "workflow-finalize"}},
+		},
+	}
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if result.Created != 1 {
+		t.Fatalf("Created = %d, want 1 (root only)", result.Created)
+	}
+}


### PR DESCRIPTION
## Problem

A RootOnly graph.v2 workflow drops every non-root compiled step at
instantiation, and that includes the compiled `workflow-finalize` control
bead, so `processWorkflowFinalize` never runs and the workflow root never
closes. After the tracked work finishes the root stays `in_progress`
indefinitely, and those orphaned roots accumulate: each gets re-routed to
its pool on a timer and re-spawns a no-op worker.

## Fix

For a RootOnly graph.v2 recipe whose root carries a `gc.input_convoy_id`,
instantiation now keeps exactly the compiled `workflow-finalize` step while
every other non-root step still drops. The kept finalizer is stamped
`gc.finalize_gate=input-convoy` and `gc.root_bead_id`, and it gets only a
non-blocking `tracks` edge to the root, never a `blocks` edge, so the root
stays claimable (in a RootOnly wisp the root is the work). Both instantiation
paths, the graph-apply plan builder and the legacy `Instantiate`, plus the
title-validation pass, share one keep-predicate.

`processWorkflowFinalize` gains an input-convoy gate. A finalizer stamped
`gc.finalize_gate=input-convoy` stays pending until every member tracked by
the root's input convoy is terminal. A missing, empty, or not-found convoy
keeps it pending as well, since closing a workflow root on an absent
completion signal is the failure this gate exists to prevent. A tracked
member that closed with a failure outcome downgrades the workflow outcome to
fail. When the root already reached a terminal state through another close
path (a cancel, a manual close, the wisp-autoclose reap), the finalizer
closes itself and leaves the root's recorded outcome intact.

The gate resolves a synthetic input convoy through the finalizer's own store
without opening the source-workflow stores. `CreateSingleItemInputConvoy`
stamps `gc.synthetic` and tracks its single member co-resident, so a synthetic
convoy resolves with a co-resident member and needs no cross-store probes.
That matters for correctness, not only cost: the source-workflow lister errors
whenever any rig store is unavailable, so probing it unconditionally would
wedge an otherwise-complete co-resident finalizer whenever an unrelated rig is
down. A non-synthetic convoy still opens the source stores for cross-store
member resolution.

Orchestrated (non-RootOnly) finalizers carry no gate stamp and take the
existing path with no behavior change.

## Test plan

`make build` and `make check` (fmt-check, lint, vet, test) pass. New coverage:

- both instantiation paths keep exactly the gated finalizer for a RootOnly
  graph.v2 recipe with a convoy, and keep only the root without one or for a
  non-graph wisp;
- the kept finalizer carries no `blocks` edge and one `tracks` edge to the
  root, and no `blocks` edge lands on the root (a blocked root would hide
  from claim);
- the dispatcher gate stays pending while the tracked issue is open, closes
  the root once it closes, aggregates member failure into a failed outcome,
  stays pending on a missing or dangling convoy or member, and closes only
  the finalizer when the root is already terminal;
- the convoy-store lookup resolves a synthetic convoy without the
  source-workflow lister (and still resolves when that lister errors), keeps
  cross-store member resolution for a non-synthetic convoy, and propagates a
  hard primary-store error before falling through;
- end-to-end over the molecule seam: instantiate, confirm pending, close the
  issue, confirm the root closes;
- the wisp-autoclose reaper defers a RootOnly root with an open gated
  finalizer to the dispatcher rather than racing it closed.
