### PR TITLE
fix(usage): keep the first durable idempotent fact

### DIFF
--- a/internal/usage/recent_reader.go
+++ b/internal/usage/recent_reader.go
@@ -32,7 +32,9 @@ const (
 // and report.Truncated is set. At most recentFactMaxRecords non-empty records
 // are decoded, newest first, bounding both Fact storage and de-duplication state
 // even when the byte tail contains millions of tiny lines. Facts are returned
-// in input order and de-duplicated by idempotency key (newest occurrence wins).
+// in input order and de-duplicated by idempotency key (first durable occurrence
+// wins). A retry must not move an already-recorded fact into a later accounting
+// window or replace its original measurement.
 // Missing files are an empty, available reading.
 func ReadRecentFacts(path string, maxBytes int64) ([]Fact, RecentReadReport, error) {
 	if maxBytes <= 0 {
@@ -68,7 +70,6 @@ func ReadRecentFacts(path string, maxBytes int64) ([]Fact, RecentReadReport, err
 		data = data[newline+1:]
 	}
 
-	seen := make(map[string]struct{})
 	facts := make([]Fact, 0, min(recentFactMaxRecords, len(data)/64))
 	processed := 0
 	end := len(data)
@@ -103,14 +104,6 @@ func ReadRecentFacts(path string, maxBytes int64) ([]Fact, RecentReadReport, err
 			report.Malformed++
 			continue
 		}
-		if fact.IdempotencyKey == "" {
-			facts = append(facts, fact)
-			continue
-		}
-		if _, duplicate := seen[fact.IdempotencyKey]; duplicate {
-			continue
-		}
-		seen[fact.IdempotencyKey] = struct{}{}
 		facts = append(facts, fact)
 	}
 	if processed == recentFactMaxRecords && len(bytes.TrimSpace(data[:end])) > 0 {
@@ -119,5 +112,18 @@ func ReadRecentFacts(path string, maxBytes int64) ([]Fact, RecentReadReport, err
 	for left, right := 0, len(facts)-1; left < right; left, right = left+1, right-1 {
 		facts[left], facts[right] = facts[right], facts[left]
 	}
+	seen := make(map[string]struct{}, len(facts))
+	retained := 0
+	for _, fact := range facts {
+		if fact.IdempotencyKey != "" {
+			if _, duplicate := seen[fact.IdempotencyKey]; duplicate {
+				continue
+			}
+			seen[fact.IdempotencyKey] = struct{}{}
+		}
+		facts[retained] = fact
+		retained++
+	}
+	facts = facts[:retained]
 	return facts, report, nil
 }

--- a/internal/usage/recent_reader_test.go
+++ b/internal/usage/recent_reader_test.go
@@ -79,6 +79,36 @@ func TestReadRecentFactsDeduplicatesWithinTheObservedWindow(t *testing.T) {
 	}
 }
 
+func TestReadRecentFactsKeepsTheFirstDurableOccurrenceOfAnIdempotencyKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage.jsonl")
+	first := factLine(t, Fact{
+		Kind:           KindCompute,
+		At:             100,
+		WallSeconds:    10,
+		IdempotencyKey: "same",
+	})
+	retry := factLine(t, Fact{
+		Kind:           KindCompute,
+		At:             200,
+		WallSeconds:    1_000,
+		IdempotencyKey: "same",
+	})
+	if err := os.WriteFile(path, []byte(first+"\n"+retry+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	facts, _, err := ReadRecentFacts(path, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("facts = %+v, want one deduplicated fact", facts)
+	}
+	if facts[0].At != 100 || facts[0].WallSeconds != 10 {
+		t.Fatalf("fact = %+v, want the first durable occurrence", facts[0])
+	}
+}
+
 func TestReadRecentFactsSkipsAnOversizedRecordAndContinues(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "usage.jsonl")
 	valid := factLine(t, Fact{Kind: KindModel, InputTokens: 7, IdempotencyKey: "valid"})


### PR DESCRIPTION
## Summary

- make the bounded HTTP usage reader keep the first observed durable occurrence of an idempotency key
- preserve original timestamps and measurements when a later retry repeats the same fact
- align dashboard/API aggregation with the CLI `ReadFacts` contract

## Verification

- RED on `origin/main`: later retry replaced the original fact
- `go test -mod=readonly ./internal/usage ./internal/api`
- `.githooks/pre-commit`
- repository pre-push fast suite
- three-lane `gpt-5.6-sol` council: unanimous APPROVE, zero P0/P1/P2