### PR TITLE
test: ratchet reviewed hermetic test bodies

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -22,6 +22,24 @@ explicit policy change that requires the same staged-diff council review as
 other test-infrastructure changes. The guard makes ordinary drift visible; it
 does not claim that self-modifying source can be cryptographically forbidden.
 
+`[[reviewed_hermetic_body]]` rows record a narrower fact than a Small-test
+classification: the exact untagged top-level test body and every statically
+resolved receiverless helper in the same package contain none of the resource
+identities cataloged below. A row is exact, code-owned, and stale-checked; it
+cannot use a wildcard, silently move to another test, or claim an effective
+Small size while package setup remains Medium. The checked call graph follows
+direct helper calls and references used as local function aliases across Go
+files in the same package, and terminates safely on cycles.
+
+This is intentionally not a universal hermeticity proof. Cross-package calls,
+method and interface dispatch, package-level callback indirection, and
+resources absent from the catalog remain manual-review boundaries. In
+particular, `TestPrepareWaitWakeState_ResolvesRigDependencyBeads` has a reviewed
+hermetic body but still runs as Medium because `cmd/gc` owns a process-mutating
+`TestMain`. `TestCmdSessionWait_AllowsRigDependencyBeads` remains the singular
+real managed-provider composition proof; the body review is not a reason to
+remove that boundary test.
+
 The canonical identity is package directory plus package clause plus top-level
 `Test`, `Benchmark`, `Fuzz`, or `TestMain` name. Nested function literals and
 subtests retain that top-level lexical owner. Methods, wrong signatures, and
@@ -123,6 +141,10 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 396 calls / 106 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged syscall.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listening file descriptor and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
+
+| Reviewed hermetic body | Effective runnable size | Medium reason | Retained real composition owner |
+| --- | --- | --- | --- |
+| `cmd/gc` package `main` — TestPrepareWaitWakeState_ResolvesRigDependencyBeads | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWait_AllowsRigDependencyBeads |
 <!-- END CHECKED TEST RESOURCE LEDGER -->
 
 ## Three tiers, clear boundaries

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -84,11 +84,12 @@ type baselineKey struct {
 
 // Ledger is the checked source-level test-resource inventory.
 type Ledger struct {
-	Version       int           `toml:"version"`
-	AuditBaseline []Baseline    `toml:"audit_baseline"`
-	Debt          []Baseline    `toml:"debt"`
-	Medium        []MediumOwner `toml:"medium"`
-	SmallDebt     []Baseline    `toml:"small_debt"`
+	Version              int                    `toml:"version"`
+	AuditBaseline        []Baseline             `toml:"audit_baseline"`
+	Debt                 []Baseline             `toml:"debt"`
+	Medium               []MediumOwner          `toml:"medium"`
+	ReviewedHermeticBody []ReviewedHermeticBody `toml:"reviewed_hermetic_body"`
+	SmallDebt            []Baseline             `toml:"small_debt"`
 }
 
 // Baseline pins one source-census signal and its migration ownership.
@@ -303,6 +304,15 @@ var bootstrapPolicy = Ledger{
 			Expires:         "2026-10-01",
 		},
 	},
+	ReviewedHermeticBody: []ReviewedHermeticBody{
+		{
+			PackageDir:    "cmd/gc",
+			PackageName:   "main",
+			Owner:         "TestPrepareWaitWakeState_ResolvesRigDependencyBeads",
+			EffectiveSize: "medium",
+			MediumReason:  "package TestMain mutates process state",
+		},
+	},
 	SmallDebt: []Baseline{
 		{
 			Scope:           ScopeUntagged,
@@ -450,8 +460,9 @@ type Occurrence struct {
 
 // Census is a deterministic collection of resource occurrences.
 type Census struct {
-	Occurrences []Occurrence
-	Runnables   []RunnableOwner
+	Occurrences    []Occurrence
+	Runnables      []RunnableOwner
+	hermeticSource *hermeticSourceIndex
 }
 
 // Count is the call-site and unique-file count for a scope/resource pair.
@@ -503,7 +514,7 @@ func ScanRepository(root string) (Census, error) {
 			files = append(files, filepath.ToSlash(name))
 		}
 	}
-	return scanFiles(os.DirFS(root), files)
+	return scanFiles(os.DirFS(root), files, reviewedHermeticPackages(bootstrapPolicy.ReviewedHermeticBody))
 }
 
 // ScanFS scans every *_test.go file in sourceFS. Sibling Go source supplies
@@ -524,7 +535,15 @@ func ScanFS(sourceFS fs.FS) (Census, error) {
 	if err != nil {
 		return Census{}, fmt.Errorf("walking test source: %w", err)
 	}
-	return scanFiles(sourceFS, files)
+	return scanFiles(sourceFS, files, nil)
+}
+
+func reviewedHermeticPackages(rows []ReviewedHermeticBody) map[packageKey]struct{} {
+	packages := make(map[packageKey]struct{}, len(rows))
+	for _, row := range rows {
+		packages[packageKey{directory: row.PackageDir, packageName: row.PackageName}] = struct{}{}
+	}
+	return packages
 }
 
 type parsedFile struct {
@@ -607,11 +626,12 @@ var knownGOARCH = map[string]struct{}{
 	"wasm": {},
 }
 
-func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
+func scanFiles(sourceFS fs.FS, names []string, hermeticPackages map[packageKey]struct{}) (Census, error) {
 	sort.Strings(names)
 	fileSet := token.NewFileSet()
 	importer := newEmptyPackageImporter()
 	var sources []parsedFile
+	var hermeticSources []parsedFile
 	var runnables []RunnableOwner
 	packageDeclarations := make(map[packageKey]map[string]struct{})
 	for _, name := range names {
@@ -631,7 +651,18 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 			packageDeclarations[key] = declarations
 		}
 		recordPackageDeclarations(file, declarations)
+		source := parsedFile{
+			name:        normalized,
+			directory:   key.directory,
+			packageName: key.packageName,
+			file:        file,
+		}
+		_, retainHermeticSource := hermeticPackages[key]
+		retainHermeticSource = hermeticPackages == nil || retainHermeticSource
 		if !strings.HasSuffix(name, "_test.go") {
+			if retainHermeticSource {
+				hermeticSources = append(hermeticSources, source)
+			}
 			continue
 		}
 		tagged, err := parsedBuildConstraint(data)
@@ -643,18 +674,16 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		}
 		runnables = append(runnables, runnableOwners(file, key.directory, key.packageName)...)
 		candidates := resourceCandidateCalls(file)
+		source.tagged = tagged || hasImplicitPlatformConstraint(name)
+		source.calls = candidates
+		if retainHermeticSource {
+			hermeticSources = append(hermeticSources, source)
+		}
 		scanned := len(candidates) > 0 || hasSlowHelperDeclarationCandidate(file)
 		if !scanned {
 			continue
 		}
-		sources = append(sources, parsedFile{
-			name:        normalized,
-			directory:   key.directory,
-			packageName: key.packageName,
-			tagged:      tagged || hasImplicitPlatformConstraint(name),
-			file:        file,
-			calls:       candidates,
-		})
+		sources = append(sources, source)
 	}
 
 	for index := range sources {
@@ -691,7 +720,14 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		}
 	}
 
-	census := Census{Runnables: uniqueSortedRunnables(runnables)}
+	census := Census{
+		Runnables: uniqueSortedRunnables(runnables),
+		hermeticSource: &hermeticSourceIndex{
+			fileSet:             fileSet,
+			files:               hermeticSources,
+			packageDeclarations: packageDeclarations,
+		},
+	}
 	for _, source := range sources {
 		testingObjects, err := testingParameterObjects(source.file, source.bindings)
 		if err != nil {
@@ -712,86 +748,12 @@ func scanFiles(sourceFS fs.FS, names []string) (Census, error) {
 		}
 
 		for _, candidate := range source.calls {
-			call := candidate.call
-			matched, err := isImportedCall(call, source.bindings, "net", "Listen")
+			resources, err := matchedResourcesForCall(candidate.call, source.bindings, testingObjects, slowHelpers[source.groupKey()])
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceNetListen)
-			}
-			matched, err = isNetListenConfigCall(call, source.bindings)
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceNetListenConfig)
-			}
-			matched, err = isImportedCall(call, source.bindings, "net", "ListenUnixgram")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceNetListenUnixgram)
-			}
-			matched, err = isImportedCall(call, source.bindings, "syscall", "Listen")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceSyscallListen)
-			}
-			matched, err = isImportedCall(call, source.bindings, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceHTTPTestServer)
-			}
-			matched, err = isImportedCall(call, source.bindings, "os/exec", "Command", "CommandContext")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceSubprocess)
-			}
-			matched, err = isImportedCall(call, source.bindings, "time", "Sleep")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceFixedSleep)
-			}
-			matched, err = isImportedCall(call, source.bindings, "os", "Setenv", "Unsetenv", "Clearenv")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceEnvironment)
-			}
-			matched, err = isImportedCall(call, source.bindings, "os", "Chdir")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceCWD)
-			}
-			matched, err = isTestingCall(call, source.bindings, testingObjects, "Setenv")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceEnvironment)
-			}
-			matched, err = isTestingCall(call, source.bindings, testingObjects, "Chdir")
-			if err != nil {
-				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
-			}
-			if matched {
-				census.add(source, candidate.owner, candidate.runnable, ResourceCWD)
-			}
-			if isSlowHelperCall(call, source.bindings, slowHelpers[source.groupKey()]) {
-				census.add(source, candidate.owner, candidate.runnable, ResourceSlowProcessGate)
+			for _, resource := range resources {
+				census.add(source, candidate.owner, candidate.runnable, resource)
 			}
 		}
 	}
@@ -1504,6 +1466,9 @@ func validateAgainstPolicy(policy, ledger Ledger, census Census, now time.Time) 
 	if err := validateMediumOwners(ledger.Medium, census, now); err != nil {
 		return err
 	}
+	if err := validateReviewedHermeticBodies(ledger.ReviewedHermeticBody, census); err != nil {
+		return err
+	}
 
 	var problems []string
 	for _, baseline := range ledger.AuditBaseline {
@@ -1535,6 +1500,7 @@ func validateManifestAgainstPolicy(policy, ledger Ledger, now time.Time) []strin
 	problems = append(problems, validateRowsAgainstPolicy("audit", policy.AuditBaseline, ledger.AuditBaseline, now)...)
 	problems = append(problems, validateRowsAgainstPolicy("debt", policy.Debt, ledger.Debt, now)...)
 	problems = append(problems, validateMediumRowsAgainstPolicy(policy.Medium, ledger.Medium, now)...)
+	problems = append(problems, validateReviewedHermeticRowsAgainstPolicy(policy.ReviewedHermeticBody, ledger.ReviewedHermeticBody)...)
 	problems = append(problems, validateRowsAgainstPolicy("small debt", policy.SmallDebt, ledger.SmallDebt, now)...)
 	return problems
 }
@@ -1731,6 +1697,24 @@ func RenderMarkdown(ledger Ledger) string {
 	for _, row := range rows {
 		fmt.Fprintf(&output, "| %s | %s | %s | %s | %s | %s | %s |\n",
 			row.kind, row.scope, row.baseline, row.owner, row.invariant, row.migration, row.expiry)
+	}
+	if len(ledger.ReviewedHermeticBody) > 0 {
+		reviewed := append([]ReviewedHermeticBody(nil), ledger.ReviewedHermeticBody...)
+		sort.Slice(reviewed, func(i, j int) bool {
+			left := reviewed[i].PackageDir + "\x00" + reviewed[i].PackageName + "\x00" + reviewed[i].Owner
+			right := reviewed[j].PackageDir + "\x00" + reviewed[j].PackageName + "\x00" + reviewed[j].Owner
+			return left < right
+		})
+		output.WriteString("\n| Reviewed hermetic body | Effective runnable size | Medium reason | Retained real composition owner |\n")
+		output.WriteString("| --- | --- | --- | --- |\n")
+		for _, body := range reviewed {
+			retained := "—"
+			if owner, exists := retainedRealOwnerFor(reviewedHermeticBodyKey(body)); exists {
+				retained = fmt.Sprintf("`%s` package `%s` — %s", owner.packageDir, owner.packageName, owner.owner)
+			}
+			fmt.Fprintf(&output, "| `%s` package `%s` — %s | %s | %s | %s |\n",
+				body.PackageDir, body.PackageName, body.Owner, body.EffectiveSize, body.MediumReason, retained)
+		}
 	}
 	output.WriteString(markdownEnd)
 	return output.String()

--- a/internal/testpolicy/resourcecensus/hermetic.go
+++ b/internal/testpolicy/resourcecensus/hermetic.go
@@ -1,0 +1,610 @@
+package resourcecensus
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+	"strings"
+)
+
+// ReviewedHermeticBody records a manually reviewed test body whose effective
+// runnable size remains explicit.
+type ReviewedHermeticBody struct {
+	PackageDir    string `toml:"package_dir"`
+	PackageName   string `toml:"package_name"`
+	Owner         string `toml:"owner"`
+	EffectiveSize string `toml:"effective_size"`
+	MediumReason  string `toml:"medium_reason"`
+}
+
+// hermeticSourceIndex retains parsed Go files for packages eligible for a
+// reviewed body. The ordinary census counts resources only in test source, but
+// a reviewed body must also inspect same-package production helpers.
+type hermeticSourceIndex struct {
+	fileSet             *token.FileSet
+	files               []parsedFile
+	packageDeclarations map[packageKey]map[string]struct{}
+}
+
+type hermeticFile struct {
+	source         parsedFile
+	index          int
+	bindings       bindingInfo
+	testingObjects map[types.Object]bool
+	resolved       bool
+	resolveErr     error
+}
+
+type hermeticFunction struct {
+	file        *hermeticFile
+	declaration *ast.FuncDecl
+}
+
+type hermeticAnalyzer struct {
+	fileSet             *token.FileSet
+	importer            *emptyPackageImporter
+	packageDeclarations map[packageKey]map[string]struct{}
+	functions           map[packageKey]map[string][]*hermeticFunction
+	slowHelpers         map[packageKey]types.Object
+}
+
+type hermeticResourceUse struct {
+	resource Resource
+	position token.Pos
+}
+
+type hermeticFunctionAnalysis struct {
+	resources []hermeticResourceUse
+	callees   []*hermeticFunction
+}
+
+type hermeticQueueEntry struct {
+	function *hermeticFunction
+	chain    []string
+}
+
+type retainedRealOwner struct {
+	reviewed runnableKey
+	retained runnableKey
+}
+
+var retainedRealOwners = []retainedRealOwner{
+	{
+		reviewed: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
+			owner:       "TestPrepareWaitWakeState_ResolvesRigDependencyBeads",
+		},
+		retained: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
+			owner:       "TestCmdSessionWait_AllowsRigDependencyBeads",
+		},
+	},
+}
+
+func retainedRealOwnerFor(key runnableKey) (runnableKey, bool) {
+	for _, pair := range retainedRealOwners {
+		if pair.reviewed == key {
+			return pair.retained, true
+		}
+	}
+	return runnableKey{}, false
+}
+
+func validateReviewedHermeticBodies(rows []ReviewedHermeticBody, census Census) error {
+	problems := validateReviewedHermeticBodyDefinitions(rows)
+	if len(rows) == 0 {
+		return problemsError(problems)
+	}
+
+	analyzer, err := newHermeticAnalyzer(census.hermeticSource, rows)
+	if err != nil {
+		problems = append(problems, fmt.Sprintf("building reviewed hermetic body source index: %v", err))
+		return problemsError(problems)
+	}
+	for _, row := range rows {
+		if !validHermeticIdentity(row) {
+			continue
+		}
+		problems = append(problems, analyzer.validate(row)...)
+	}
+	return problemsError(problems)
+}
+
+func validateReviewedHermeticRowsAgainstPolicy(policyRows, ledgerRows []ReviewedHermeticBody) []string {
+	problems := validateReviewedHermeticBodyDefinitions(policyRows)
+	problems = append(problems, validateReviewedHermeticBodyDefinitions(ledgerRows)...)
+
+	policyByKey := make(map[runnableKey]ReviewedHermeticBody, len(policyRows))
+	for _, row := range policyRows {
+		policyByKey[reviewedHermeticBodyKey(row)] = row
+	}
+	seen := make(map[runnableKey]struct{}, len(ledgerRows))
+	for _, row := range ledgerRows {
+		key := reviewedHermeticBodyKey(row)
+		seen[key] = struct{}{}
+		want, exists := policyByKey[key]
+		if !exists {
+			problems = append(problems, fmt.Sprintf("unexpected reviewed hermetic body: package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner))
+			continue
+		}
+		prefix := reviewedHermeticBodyPrefix(row)
+		if row.EffectiveSize != want.EffectiveSize {
+			problems = append(problems, fmt.Sprintf("%s: effective_size = %q, bootstrap policy requires %q", prefix, row.EffectiveSize, want.EffectiveSize))
+		}
+		if row.MediumReason != want.MediumReason {
+			problems = append(problems, fmt.Sprintf("%s: medium_reason = %q, bootstrap policy requires %q", prefix, row.MediumReason, want.MediumReason))
+		}
+	}
+	for key := range policyByKey {
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		problems = append(problems, fmt.Sprintf("missing required reviewed hermetic body: package_dir=%s package_name=%s owner=%s", key.packageDir, key.packageName, key.owner))
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+func validateReviewedHermeticBodyDefinitions(rows []ReviewedHermeticBody) []string {
+	seen := make(map[runnableKey]struct{}, len(rows))
+	var problems []string
+	for _, row := range rows {
+		key := reviewedHermeticBodyKey(row)
+		prefix := reviewedHermeticBodyPrefix(row)
+		if _, duplicate := seen[key]; duplicate {
+			problems = append(problems, fmt.Sprintf("duplicate reviewed hermetic body: package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner))
+		}
+		seen[key] = struct{}{}
+		if strings.TrimSpace(row.PackageDir) == "" {
+			problems = append(problems, prefix+": package_dir is required")
+		}
+		if strings.TrimSpace(row.PackageName) == "" {
+			problems = append(problems, prefix+": package_name is required")
+		}
+		if strings.TrimSpace(row.Owner) == "" {
+			problems = append(problems, prefix+": owner is required")
+		}
+		if strings.ContainsAny(row.PackageDir, "*?[") || strings.ContainsAny(row.PackageName, "*?[") || strings.ContainsAny(row.Owner, "*?[") {
+			problems = append(problems, prefix+": wildcard identities are not allowed")
+		}
+		if row.EffectiveSize != "medium" {
+			problems = append(problems, fmt.Sprintf("%s: effective_size = %q, want %q", prefix, row.EffectiveSize, "medium"))
+		}
+		if strings.TrimSpace(row.MediumReason) == "" {
+			problems = append(problems, prefix+": medium_reason is required")
+		}
+	}
+	return problems
+}
+
+func validHermeticIdentity(row ReviewedHermeticBody) bool {
+	return strings.TrimSpace(row.PackageDir) != "" &&
+		strings.TrimSpace(row.PackageName) != "" &&
+		strings.TrimSpace(row.Owner) != "" &&
+		!strings.ContainsAny(row.PackageDir, "*?[") &&
+		!strings.ContainsAny(row.PackageName, "*?[") &&
+		!strings.ContainsAny(row.Owner, "*?[")
+}
+
+func reviewedHermeticBodyKey(row ReviewedHermeticBody) runnableKey {
+	return runnableKey{packageDir: row.PackageDir, packageName: row.PackageName, owner: row.Owner}
+}
+
+func reviewedHermeticBodyPrefix(row ReviewedHermeticBody) string {
+	return fmt.Sprintf("reviewed hermetic body package_dir=%s package_name=%s owner=%s", row.PackageDir, row.PackageName, row.Owner)
+}
+
+func problemsError(problems []string) error {
+	if len(problems) == 0 {
+		return nil
+	}
+	sort.Strings(problems)
+	return errors.New(strings.Join(problems, "\n"))
+}
+
+func newHermeticAnalyzer(sourceIndex *hermeticSourceIndex, rows []ReviewedHermeticBody) (*hermeticAnalyzer, error) {
+	if sourceIndex == nil || sourceIndex.fileSet == nil {
+		return nil, errors.New("source file set is unavailable")
+	}
+	selectedPackages := make(map[packageKey]struct{}, len(rows))
+	for _, row := range rows {
+		selectedPackages[packageKey{directory: row.PackageDir, packageName: row.PackageName}] = struct{}{}
+	}
+	files := make([]parsedFile, 0)
+	for _, source := range sourceIndex.files {
+		if _, selected := selectedPackages[source.groupKey()]; selected {
+			files = append(files, source)
+		}
+	}
+	sort.SliceStable(files, func(i, j int) bool {
+		if files[i].name != files[j].name {
+			return files[i].name < files[j].name
+		}
+		if files[i].packageName != files[j].packageName {
+			return files[i].packageName < files[j].packageName
+		}
+		return files[i].file.Pos() < files[j].file.Pos()
+	})
+
+	declarations := sourceIndex.packageDeclarations
+	if declarations == nil {
+		declarations = make(map[packageKey]map[string]struct{})
+		for _, source := range files {
+			key := source.groupKey()
+			if declarations[key] == nil {
+				declarations[key] = make(map[string]struct{})
+			}
+			recordPackageDeclarations(source.file, declarations[key])
+		}
+	}
+
+	analyzer := &hermeticAnalyzer{
+		fileSet:             sourceIndex.fileSet,
+		importer:            newEmptyPackageImporter(),
+		packageDeclarations: declarations,
+		functions:           make(map[packageKey]map[string][]*hermeticFunction),
+		slowHelpers:         make(map[packageKey]types.Object),
+	}
+	indexedFiles := make([]hermeticFile, len(files))
+	for index, source := range files {
+		indexedFiles[index] = hermeticFile{source: source, index: index}
+	}
+	for index := range indexedFiles {
+		file := &indexedFiles[index]
+		key := file.source.groupKey()
+		if analyzer.functions[key] == nil {
+			analyzer.functions[key] = make(map[string][]*hermeticFunction)
+		}
+		for _, declaration := range file.source.file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Recv != nil {
+				continue
+			}
+			analyzer.functions[key][function.Name.Name] = append(analyzer.functions[key][function.Name.Name], &hermeticFunction{
+				file:        file,
+				declaration: function,
+			})
+		}
+	}
+	for key, functions := range analyzer.functions {
+		for _, function := range functions["skipSlowCmdGCTest"] {
+			if err := analyzer.resolveFile(function.file); err != nil {
+				return nil, err
+			}
+			matched, err := isSlowHelperDeclaration(function.declaration, function.file.bindings)
+			if err != nil {
+				return nil, fmt.Errorf("scanning slow-process helper in %s: %w", function.file.source.name, err)
+			}
+			if !matched {
+				continue
+			}
+			if _, exists := analyzer.slowHelpers[key]; exists {
+				return nil, fmt.Errorf("scanning slow-process helper in %s: package %s has multiple canonical declarations", function.file.source.name, function.file.source.packageName)
+			}
+			object := function.file.bindings.defs[function.declaration.Name]
+			if object == nil {
+				return nil, fmt.Errorf("scanning slow-process helper in %s: declaration has no lexical binding", function.file.source.name)
+			}
+			analyzer.slowHelpers[key] = object
+		}
+	}
+	return analyzer, nil
+}
+
+func (a *hermeticAnalyzer) resolveFile(file *hermeticFile) error {
+	if file.resolved {
+		return file.resolveErr
+	}
+	file.resolved = true
+	if err := validateImports(file.source.file); err != nil {
+		file.resolveErr = fmt.Errorf("scanning imports in %s: %w", file.source.name, err)
+		return file.resolveErr
+	}
+	bindings := resolveBindings(a.fileSet, file.source.file, a.importer, fmt.Sprintf("resourcecensus.hermetic/file%d", file.index))
+	bindings.packageDeclarations = a.packageDeclarations[file.source.groupKey()]
+	bindings.unresolvedImportQualifiers = unresolvedDefaultImportQualifiers(file.source.file)
+	testingObjects, err := testingParameterObjects(file.source.file, bindings)
+	if err != nil {
+		file.resolveErr = fmt.Errorf("scanning testing parameters in %s: %w", file.source.name, err)
+		return file.resolveErr
+	}
+	file.bindings = bindings
+	file.testingObjects = testingObjects
+	return nil
+}
+
+func (a *hermeticAnalyzer) validate(row ReviewedHermeticBody) []string {
+	rowKey := reviewedHermeticBodyKey(row)
+	root, rootProblem := a.exactUntaggedTest(rowKey)
+	prefix := reviewedHermeticBodyPrefix(row)
+	if rootProblem != "" {
+		return []string{prefix + ": " + rootProblem}
+	}
+
+	var problems []string
+	if retained, exists := retainedRealOwnerFor(rowKey); exists {
+		if _, problem := a.exactUntaggedTest(retained); problem != "" {
+			problems = append(problems, fmt.Sprintf(
+				"%s: retained real composition owner package_dir=%s package_name=%s owner=%s: %s",
+				prefix, retained.packageDir, retained.packageName, retained.owner, problem,
+			))
+		}
+	}
+
+	key := packageKey{directory: row.PackageDir, packageName: row.PackageName}
+	uses, err := a.reachableResources(key, root)
+	if err != nil {
+		problems = append(problems, fmt.Sprintf("%s: scanning reachable helpers: %v", prefix, err))
+		return problems
+	}
+	resources := make([]Resource, 0, len(uses))
+	for resource := range uses {
+		resources = append(resources, resource)
+	}
+	sort.Slice(resources, func(i, j int) bool { return resources[i] < resources[j] })
+	for _, resource := range resources {
+		use := uses[resource]
+		position := a.fileSet.Position(use.position)
+		problems = append(problems, fmt.Sprintf("%s: %s is reachable through %s (%s:%d)", prefix, resource, strings.Join(use.chain, " -> "), position.Filename, position.Line))
+	}
+	return problems
+}
+
+func (a *hermeticAnalyzer) exactUntaggedTest(key runnableKey) (*hermeticFunction, string) {
+	packageKey := packageKey{directory: key.packageDir, packageName: key.packageName}
+	declarations := a.functions[packageKey][key.owner]
+	var roots []*hermeticFunction
+	for _, function := range declarations {
+		if !strings.HasSuffix(function.file.source.name, "_test.go") || !goTestName(function.declaration.Name.Name, "Test") || function.declaration.Name.Name == "TestMain" {
+			continue
+		}
+		if isRunnableOwner(function.declaration, testingImportAliases(function.file.source.file)) {
+			roots = append(roots, function)
+		}
+	}
+	switch {
+	case len(roots) == 0:
+		return nil, "runnable owner does not exist"
+	case len(declarations) != 1 || len(roots) != 1:
+		return nil, "runnable owner is not unique"
+	case roots[0].file.source.tagged:
+		return nil, "runnable owner must be untagged"
+	}
+	return roots[0], ""
+}
+
+type hermeticReachableUse struct {
+	chain    []string
+	position token.Pos
+}
+
+func (a *hermeticAnalyzer) reachableResources(key packageKey, root *hermeticFunction) (map[Resource]hermeticReachableUse, error) {
+	queue := []hermeticQueueEntry{{function: root, chain: []string{root.declaration.Name.Name}}}
+	visited := make(map[*ast.FuncDecl]struct{})
+	uses := make(map[Resource]hermeticReachableUse)
+	for len(queue) > 0 {
+		entry := queue[0]
+		queue = queue[1:]
+		if _, seen := visited[entry.function.declaration]; seen {
+			continue
+		}
+		visited[entry.function.declaration] = struct{}{}
+		analysis, err := a.analyzeFunction(key, entry.function)
+		if err != nil {
+			return nil, err
+		}
+		for _, use := range analysis.resources {
+			if _, reported := uses[use.resource]; reported {
+				continue
+			}
+			uses[use.resource] = hermeticReachableUse{chain: append([]string(nil), entry.chain...), position: use.position}
+		}
+		for _, callee := range analysis.callees {
+			if _, seen := visited[callee.declaration]; seen {
+				continue
+			}
+			chain := append(append([]string(nil), entry.chain...), callee.declaration.Name.Name)
+			queue = append(queue, hermeticQueueEntry{function: callee, chain: chain})
+		}
+	}
+	return uses, nil
+}
+
+func (a *hermeticAnalyzer) analyzeFunction(key packageKey, function *hermeticFunction) (hermeticFunctionAnalysis, error) {
+	if function.declaration.Body == nil {
+		return hermeticFunctionAnalysis{}, nil
+	}
+	if err := a.resolveFile(function.file); err != nil {
+		return hermeticFunctionAnalysis{}, err
+	}
+	resources := make(map[Resource]token.Pos)
+	callees := make(map[*ast.FuncDecl]*hermeticFunction)
+	var inspectErr error
+	var parents []ast.Node
+	ast.Inspect(function.declaration.Body, func(node ast.Node) bool {
+		if node == nil {
+			parents = parents[:len(parents)-1]
+			return true
+		}
+		var parent ast.Node
+		if len(parents) > 0 {
+			parent = parents[len(parents)-1]
+		}
+		parents = append(parents, node)
+		if inspectErr != nil {
+			return false
+		}
+		if call, ok := node.(*ast.CallExpr); ok {
+			matched, err := matchedResourcesForCall(call, function.file.bindings, function.file.testingObjects, a.slowHelpers[key])
+			if err != nil {
+				inspectErr = fmt.Errorf("%s: %w", function.file.source.name, err)
+				return false
+			}
+			for _, resource := range matched {
+				if _, exists := resources[resource]; !exists {
+					resources[resource] = call.Pos()
+				}
+			}
+		}
+		identifier, ok := node.(*ast.Ident)
+		if !ok || !isHermeticFunctionReference(identifier, parent, function.file.bindings, a.functions[key]) {
+			return true
+		}
+		for _, callee := range a.functions[key][identifier.Name] {
+			callees[callee.declaration] = callee
+		}
+		return true
+	})
+	if inspectErr != nil {
+		return hermeticFunctionAnalysis{}, inspectErr
+	}
+
+	result := hermeticFunctionAnalysis{
+		resources: make([]hermeticResourceUse, 0, len(resources)),
+		callees:   make([]*hermeticFunction, 0, len(callees)),
+	}
+	for resource, position := range resources {
+		result.resources = append(result.resources, hermeticResourceUse{resource: resource, position: position})
+	}
+	sort.Slice(result.resources, func(i, j int) bool {
+		if result.resources[i].position != result.resources[j].position {
+			return result.resources[i].position < result.resources[j].position
+		}
+		return result.resources[i].resource < result.resources[j].resource
+	})
+	for _, callee := range callees {
+		result.callees = append(result.callees, callee)
+	}
+	sort.Slice(result.callees, func(i, j int) bool {
+		left, right := result.callees[i], result.callees[j]
+		if left.declaration.Name.Name != right.declaration.Name.Name {
+			return left.declaration.Name.Name < right.declaration.Name.Name
+		}
+		if left.file.source.name != right.file.source.name {
+			return left.file.source.name < right.file.source.name
+		}
+		return left.declaration.Pos() < right.declaration.Pos()
+	})
+	return result, nil
+}
+
+func isHermeticFunctionReference(identifier *ast.Ident, parent ast.Node, bindings bindingInfo, functions map[string][]*hermeticFunction) bool {
+	targets := functions[identifier.Name]
+	if len(targets) == 0 || bindings.defs[identifier] != nil || nonValueIdentifier(identifier, parent) {
+		return false
+	}
+	object := bindings.uses[identifier]
+	if object == nil || object.Parent() == types.Universe {
+		return true
+	}
+	for _, target := range targets {
+		if target.file.bindings.defs[target.declaration.Name] == object {
+			return true
+		}
+	}
+	return false
+}
+
+func nonValueIdentifier(identifier *ast.Ident, parent ast.Node) bool {
+	switch parent := parent.(type) {
+	case *ast.SelectorExpr:
+		return parent.Sel == identifier
+	case *ast.KeyValueExpr:
+		return parent.Key == identifier
+	case *ast.BranchStmt:
+		return parent.Label == identifier
+	case *ast.LabeledStmt:
+		return parent.Label == identifier
+	case *ast.ImportSpec:
+		return parent.Name == identifier
+	case *ast.File:
+		return parent.Name == identifier
+	case *ast.FuncDecl:
+		return parent.Name == identifier
+	case *ast.TypeSpec:
+		return parent.Name == identifier
+	case *ast.ValueSpec:
+		for _, name := range parent.Names {
+			if name == identifier {
+				return true
+			}
+		}
+	case *ast.Field:
+		for _, name := range parent.Names {
+			if name == identifier {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matchedResourcesForCall is the single mapping from a syntax-owned call to
+// the resource identities recognized by both the census and hermetic review.
+func matchedResourcesForCall(call *ast.CallExpr, bindings bindingInfo, testingObjects map[types.Object]bool, slowHelperObject types.Object) ([]Resource, error) {
+	var resources []Resource
+	appendImported := func(resource Resource, importPath string, names ...string) error {
+		matched, err := isImportedCall(call, bindings, importPath, names...)
+		if err != nil {
+			return err
+		}
+		if matched {
+			resources = append(resources, resource)
+		}
+		return nil
+	}
+	if err := appendImported(ResourceNetListen, "net", "Listen"); err != nil {
+		return nil, err
+	}
+	matched, err := isNetListenConfigCall(call, bindings)
+	if err != nil {
+		return nil, err
+	}
+	if matched {
+		resources = append(resources, ResourceNetListenConfig)
+	}
+	if err := appendImported(ResourceNetListenUnixgram, "net", "ListenUnixgram"); err != nil {
+		return nil, err
+	}
+	if err := appendImported(ResourceSyscallListen, "syscall", "Listen"); err != nil {
+		return nil, err
+	}
+	if err := appendImported(ResourceHTTPTestServer, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer"); err != nil {
+		return nil, err
+	}
+	if err := appendImported(ResourceSubprocess, "os/exec", "Command", "CommandContext"); err != nil {
+		return nil, err
+	}
+	if err := appendImported(ResourceFixedSleep, "time", "Sleep"); err != nil {
+		return nil, err
+	}
+	if err := appendImported(ResourceEnvironment, "os", "Setenv", "Unsetenv", "Clearenv"); err != nil {
+		return nil, err
+	}
+	if err := appendImported(ResourceCWD, "os", "Chdir"); err != nil {
+		return nil, err
+	}
+	matched, err = isTestingCall(call, bindings, testingObjects, "Setenv")
+	if err != nil {
+		return nil, err
+	}
+	if matched {
+		resources = append(resources, ResourceEnvironment)
+	}
+	matched, err = isTestingCall(call, bindings, testingObjects, "Chdir")
+	if err != nil {
+		return nil, err
+	}
+	if matched {
+		resources = append(resources, ResourceCWD)
+	}
+	if isSlowHelperCall(call, bindings, slowHelperObject) {
+		resources = append(resources, ResourceSlowProcessGate)
+	}
+	return resources, nil
+}

--- a/internal/testpolicy/resourcecensus/hermetic_test.go
+++ b/internal/testpolicy/resourcecensus/hermetic_test.go
@@ -1,0 +1,369 @@
+package resourcecensus
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+func TestValidateReviewedHermeticBodiesRequiresExactUniqueUntaggedTest(t *testing.T) {
+	t.Parallel()
+
+	census := scanHermeticFixture(t, fstest.MapFS{
+		"sample/owned_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestOwned(t *testing.T) {}
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import "testing"
+func TestTagged(t *testing.T) {}
+`)},
+	})
+	valid := validReviewedHermeticBody("TestOwned")
+	if err := validateReviewedHermeticBodies([]ReviewedHermeticBody{valid}, census); err != nil {
+		t.Fatalf("validateReviewedHermeticBodies(valid): %v", err)
+	}
+
+	tests := []struct {
+		name string
+		rows []ReviewedHermeticBody
+		want string
+	}{
+		{name: "missing identity", rows: []ReviewedHermeticBody{{EffectiveSize: "medium", MediumReason: "package TestMain mutates process state"}}, want: "package_dir is required"},
+		{name: "stale owner", rows: []ReviewedHermeticBody{withHermeticOwner(valid, "TestRemoved")}, want: "runnable owner does not exist"},
+		{name: "duplicate row", rows: []ReviewedHermeticBody{valid, valid}, want: "duplicate reviewed hermetic body"},
+		{name: "tagged owner", rows: []ReviewedHermeticBody{withHermeticOwner(valid, "TestTagged")}, want: "must be untagged"},
+		{name: "wildcard owner", rows: []ReviewedHermeticBody{withHermeticOwner(valid, "Test*")}, want: "wildcard"},
+		{name: "dishonest small effective size", rows: []ReviewedHermeticBody{withHermeticSize(valid, "small")}, want: "effective_size"},
+		{name: "missing effective size", rows: []ReviewedHermeticBody{withHermeticSize(valid, "")}, want: "effective_size"},
+		{name: "missing medium reason", rows: []ReviewedHermeticBody{withHermeticReason(valid, " \t")}, want: "medium_reason is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			requireErrorContains(t, validateReviewedHermeticBodies(tt.rows, census), tt.want)
+		})
+	}
+}
+
+func TestValidateReviewedHermeticRowsAgainstPolicyRequiresExactRows(t *testing.T) {
+	t.Parallel()
+
+	want := validReviewedHermeticBody("TestOwned")
+	for _, tt := range []struct {
+		name   string
+		rows   []ReviewedHermeticBody
+		mutate func(*ReviewedHermeticBody)
+		match  string
+	}{
+		{name: "missing", match: "missing required reviewed hermetic body"},
+		{name: "unexpected", rows: []ReviewedHermeticBody{validReviewedHermeticBody("TestOther")}, match: "unexpected reviewed hermetic body"},
+		{name: "duplicate", rows: []ReviewedHermeticBody{want, want}, match: "duplicate reviewed hermetic body"},
+		{name: "package dir drift", rows: []ReviewedHermeticBody{want}, mutate: func(row *ReviewedHermeticBody) { row.PackageDir = "other" }, match: "package_dir"},
+		{name: "package name drift", rows: []ReviewedHermeticBody{want}, mutate: func(row *ReviewedHermeticBody) { row.PackageName = "other" }, match: "package_name"},
+		{name: "owner drift", rows: []ReviewedHermeticBody{want}, mutate: func(row *ReviewedHermeticBody) { row.Owner = "TestOther" }, match: "owner"},
+		{name: "effective size drift", rows: []ReviewedHermeticBody{want}, mutate: func(row *ReviewedHermeticBody) { row.EffectiveSize = "small" }, match: "effective_size"},
+		{name: "medium reason drift", rows: []ReviewedHermeticBody{want}, mutate: func(row *ReviewedHermeticBody) { row.MediumReason = "other setup" }, match: "medium_reason"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rows := append([]ReviewedHermeticBody(nil), tt.rows...)
+			if tt.mutate != nil {
+				tt.mutate(&rows[0])
+			}
+			requireErrorContains(t, errorsFromProblems(validateReviewedHermeticRowsAgainstPolicy([]ReviewedHermeticBody{want}, rows)), tt.match)
+		})
+	}
+}
+
+func TestValidateAgainstPolicyWiresReviewedHermeticPolicyAndSourceChecks(t *testing.T) {
+	t.Parallel()
+
+	row := validReviewedHermeticBody("TestOwned")
+	policy := Ledger{Version: 2, ReviewedHermeticBody: []ReviewedHermeticBody{row}}
+	clean := scanHermeticFixture(t, fstest.MapFS{
+		"sample/owned_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestOwned(t *testing.T) {}
+`)},
+	})
+
+	t.Run("manifest drift is rejected before source validation", func(t *testing.T) {
+		ledger := policy
+		ledger.ReviewedHermeticBody = append([]ReviewedHermeticBody(nil), policy.ReviewedHermeticBody...)
+		ledger.ReviewedHermeticBody[0].EffectiveSize = "small"
+		err := validateAgainstPolicy(policy, ledger, clean, time.Time{})
+		requireErrorContains(t, err, `bootstrap policy requires "medium"`)
+	})
+
+	t.Run("reachable resource is rejected through production wiring", func(t *testing.T) {
+		withResource := scanHermeticFixture(t, fstest.MapFS{
+			"sample/owned_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	"testing"
+	"time"
+)
+func TestOwned(t *testing.T) { helper() }
+func helper() { time.Sleep(0) }
+`)},
+		})
+		err := validateAgainstPolicy(policy, policy, withResource, time.Time{})
+		requireErrorContains(t, err, string(ResourceFixedSleep))
+	})
+}
+
+func TestValidateReviewedHermeticBodiesRejectsDirectKnownResources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		imports      string
+		declarations string
+		body         string
+		resource     Resource
+	}{
+		{name: "subprocess", imports: `"os/exec"`, body: `_ = exec.Command("worker")`, resource: ResourceSubprocess},
+		{name: "fixed sleep", imports: `"time"`, body: `time.Sleep(0)`, resource: ResourceFixedSleep},
+		{name: "environment", body: `t.Setenv("KEY", "value")`, resource: ResourceEnvironment},
+		{name: "cwd", body: `t.Chdir("work")`, resource: ResourceCWD},
+		{
+			name:         "slow process gate",
+			declarations: `func skipSlowCmdGCTest(t *testing.T, reason string) {}`,
+			body:         `skipSlowCmdGCTest(t, "process-backed")`,
+			resource:     ResourceSlowProcessGate,
+		},
+		{name: "HTTP test server", imports: `"net/http/httptest"`, body: `_ = httptest.NewServer(nil)`, resource: ResourceHTTPTestServer},
+		{name: "net listen", imports: `"net"`, body: `_, _ = net.Listen("tcp", "127.0.0.1:0")`, resource: ResourceNetListen},
+		{name: "net listen config", imports: `"net"`, body: `_, _ = (net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")`, resource: ResourceNetListenConfig},
+		{name: "net listen unixgram", imports: `"net"`, body: `_, _ = net.ListenUnixgram("unixgram", nil)`, resource: ResourceNetListenUnixgram},
+		{name: "syscall listen", imports: `"syscall"`, body: `_ = syscall.Listen(0, 0)`, resource: ResourceSyscallListen},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := fmt.Sprintf("package sample\nimport (\n\t\"testing\"\n\t%s\n)\n%s\nfunc resourceHelper(t *testing.T) { %s }\nfunc TestHermetic(t *testing.T) { resourceHelper(t) }\n", tt.imports, tt.declarations, tt.body)
+			census := scanHermeticFixture(t, fstest.MapFS{
+				"sample/resource_test.go": &fstest.MapFile{Data: []byte(source)},
+			})
+			err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census)
+			requireErrorContains(t, err, string(tt.resource))
+		})
+	}
+}
+
+func TestValidateReviewedHermeticBodiesFollowsHelpersWithoutShadowFalseMatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("helper chain cycle reports resource once", func(t *testing.T) {
+		census := scanHermeticFixture(t, fstest.MapFS{
+			"sample/resource_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	"testing"
+	"time"
+)
+func TestHermetic(t *testing.T) { helperA() }
+func helperA() { helperB() }
+func helperB() { time.Sleep(0); helperA() }
+`)},
+		})
+		err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census)
+		requireErrorContains(t, err, string(ResourceFixedSleep))
+		if got := strings.Count(err.Error(), string(ResourceFixedSleep)); got != 1 {
+			t.Fatalf("fixed_sleep reports = %d, want 1; err=%v", got, err)
+		}
+	})
+
+	t.Run("local shadow does not reach package helper", func(t *testing.T) {
+		census := scanHermeticFixture(t, fstest.MapFS{
+			"sample/helper_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "time"
+func helper() { time.Sleep(0) }
+`)},
+			"sample/owned_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestHermetic(t *testing.T) {
+	helper := func() {}
+	helper()
+}
+`)},
+		})
+		if err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census); err != nil {
+			t.Fatalf("validateReviewedHermeticBodies(local shadow): %v", err)
+		}
+	})
+
+	t.Run("clean cross-file helper passes", func(t *testing.T) {
+		census := scanHermeticFixture(t, fstest.MapFS{
+			"sample/helper_test.go": &fstest.MapFile{Data: []byte(`package sample
+func helper() { nested() }
+func nested() {}
+`)},
+			"sample/owned_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestHermetic(t *testing.T) { helper() }
+`)},
+		})
+		if err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census); err != nil {
+			t.Fatalf("validateReviewedHermeticBodies(clean helper): %v", err)
+		}
+	})
+
+	t.Run("cross-file helper reports deterministic call chain", func(t *testing.T) {
+		fixture := func() fstest.MapFS {
+			return fstest.MapFS{
+				"sample/helper.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	"os/exec"
+	"time"
+)
+func helper() {
+	nestedProcess()
+	nestedSleep()
+}
+func nestedProcess() { _ = exec.Command("worker") }
+func nestedSleep() { time.Sleep(0) }
+`)},
+				"sample/owned_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestHermetic(t *testing.T) { helper() }
+`)},
+			}
+		}
+		const want = "reviewed hermetic body package_dir=sample package_name=sample owner=TestHermetic: fixed_sleep is reachable through TestHermetic -> helper -> nestedSleep (sample/helper.go:11)\n" +
+			"reviewed hermetic body package_dir=sample package_name=sample owner=TestHermetic: subprocess is reachable through TestHermetic -> helper -> nestedProcess (sample/helper.go:10)"
+		for iteration := 0; iteration < 2; iteration++ {
+			census := scanHermeticFixture(t, fixture())
+			err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census)
+			if err == nil || err.Error() != want {
+				t.Fatalf("iteration %d error = %v, want exact:\n%s", iteration, err, want)
+			}
+		}
+	})
+
+	t.Run("cross-file helper shadows predeclared identifier", func(t *testing.T) {
+		census := scanHermeticFixture(t, fstest.MapFS{
+			"sample/helper.go": &fstest.MapFile{Data: []byte(`package sample
+import "time"
+func clear() { time.Sleep(0) }
+`)},
+			"sample/owned_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestHermetic(t *testing.T) { clear() }
+`)},
+		})
+		err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census)
+		requireErrorContains(t, err, "TestHermetic -> clear")
+	})
+
+	t.Run("function alias still reaches helper", func(t *testing.T) {
+		census := scanHermeticFixture(t, fstest.MapFS{
+			"sample/resource_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	"testing"
+	"time"
+)
+func TestHermetic(t *testing.T) {
+	alias := helper
+	_ = func() { alias() }
+}
+func helper() { time.Sleep(0) }
+`)},
+		})
+		err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census)
+		requireErrorContains(t, err, "TestHermetic -> helper")
+	})
+
+	t.Run("duplicate runnable declaration fails closed", func(t *testing.T) {
+		census := scanHermeticFixture(t, fstest.MapFS{
+			"sample/first_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestHermetic(t *testing.T) {}
+`)},
+			"sample/second_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "testing"
+func TestHermetic(t *testing.T) {}
+`)},
+		})
+		err := validateReviewedHermeticBodies([]ReviewedHermeticBody{validReviewedHermeticBody("TestHermetic")}, census)
+		requireErrorContains(t, err, "runnable owner is not unique")
+	})
+}
+
+func TestValidateReviewedHermeticBodiesRequiresRetainedRealOwner(t *testing.T) {
+	t.Parallel()
+
+	row := seedReviewedHermeticBody()
+	missing := scanHermeticFixture(t, fstest.MapFS{
+		"cmd/gc/owned_test.go": &fstest.MapFile{Data: []byte(`package main
+import "testing"
+func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {}
+`)},
+	})
+	requireErrorContains(t, validateReviewedHermeticBodies([]ReviewedHermeticBody{row}, missing), "retained real composition owner")
+
+	complete := scanHermeticFixture(t, fstest.MapFS{
+		"cmd/gc/owned_test.go": &fstest.MapFile{Data: []byte(`package main
+import "testing"
+func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {}
+func TestCmdSessionWait_AllowsRigDependencyBeads(t *testing.T) {}
+`)},
+	})
+	if err := validateReviewedHermeticBodies([]ReviewedHermeticBody{row}, complete); err != nil {
+		t.Fatalf("validateReviewedHermeticBodies(retained owner): %v", err)
+	}
+}
+
+func errorsFromProblems(problems []string) error {
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", strings.Join(problems, "\n"))
+}
+
+func scanHermeticFixture(t *testing.T, files fstest.MapFS) Census {
+	t.Helper()
+	census, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	return census
+}
+
+func validReviewedHermeticBody(owner string) ReviewedHermeticBody {
+	return ReviewedHermeticBody{
+		PackageDir:    "sample",
+		PackageName:   "sample",
+		Owner:         owner,
+		EffectiveSize: "medium",
+		MediumReason:  "package TestMain mutates process state",
+	}
+}
+
+func seedReviewedHermeticBody() ReviewedHermeticBody {
+	return ReviewedHermeticBody{
+		PackageDir:    "cmd/gc",
+		PackageName:   "main",
+		Owner:         "TestPrepareWaitWakeState_ResolvesRigDependencyBeads",
+		EffectiveSize: "medium",
+		MediumReason:  "package TestMain mutates process state",
+	}
+}
+
+func withHermeticOwner(row ReviewedHermeticBody, owner string) ReviewedHermeticBody {
+	row.Owner = owner
+	return row
+}
+
+func withHermeticSize(row ReviewedHermeticBody, size string) ReviewedHermeticBody {
+	row.EffectiveSize = size
+	return row
+}
+
+func withHermeticReason(row ReviewedHermeticBody, reason string) ReviewedHermeticBody {
+	row.MediumReason = reason
+	return row
+}

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -202,6 +202,17 @@ resource_owner = "the six isolated Make invocations are confined to TestProvider
 migration_target = "P0.1"
 expires = "2026-10-01"
 
+# A reviewed-hermetic-body row is narrower than a Small test declaration. It
+# proves that the exact untagged test body and statically reachable
+# receiverless same-package helpers contain none of the cataloged resources.
+# Package-level setup still determines the effective runnable size.
+[[reviewed_hermetic_body]]
+package_dir = "cmd/gc"
+package_name = "main"
+owner = "TestPrepareWaitWakeState_ResolvesRigDependencyBeads"
+effective_size = "medium"
+medium_reason = "package TestMain mutates process state"
+
 # Small-debt rows apply the exact Medium filter while the source-debt rows
 # above retain the raw anti-growth census.
 [[small_debt]]


### PR DESCRIPTION
## Summary

- Add an exact `reviewed_hermetic_body` policy row for a test whose body is resource-free but whose package setup remains Medium.
- Traverse statically reachable receiverless helpers across same-package Go files, including function aliases and cross-file helpers that shadow predeclared identifiers.
- Fail closed on missing, stale, duplicate, tagged, wildcard, or ambiguous owners and on any of the 10 cataloged resources.
- Stale-check the retained real managed-provider composition proof instead of duplicating it in the fast body test.

## Why

PR #4309 replaced an 80.68-second managed-Dolt setup with in-memory stores, reducing the package from 82.28 seconds to 1.94 seconds. The optimized body is hermetic, but `cmd/gc` still has a process-mutating `TestMain`, so labeling the runnable Small would be false. This policy records both facts and prevents the body from silently regressing back to process, sleep, environment, CWD, or listener dependencies.

## Static-analysis boundary

The check follows direct calls and function references to receiverless helpers in the same package. Cross-package calls, method/interface dispatch, package-level callback indirection, and uncataloged resources remain explicit manual-review boundaries.

## Verification

- `go test ./internal/testpolicy/resourcecensus -count=1`
- `go test -race ./internal/testpolicy/resourcecensus -count=1`
- `go test -race -count=20 ./cmd/gc -run ^TestPrepareWaitWakeState_ResolvesRigDependencyBeads$`
- `make test-fast-parallel`
- `go vet ./...`
- `.githooks/pre-commit`
- Two exact-diff three-reviewer councils; final verdict 3/3 approve

## Performance

- Policy package: 3.78 seconds staged versus 3.91 seconds on unchanged main in the same warm-cache environment.
- The reviewed test body remains effectively zero-duration outside package/TestMain overhead.
- No product behavior changes.

Bead: `ga-80po0c.2.4`