### PR TITLE
fix(dispatch): revision-fence workflow finalize close against concurrent run-cancel

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -1755,6 +1755,13 @@ func updateMetadataAndClose(store beads.Store, beadID string, metadata map[strin
 	}); err != nil {
 		return err
 	}
+	return verifyClosed(store, beadID)
+}
+
+// verifyClosed re-reads beadID and, if the store did not honor a Status:closed
+// write inline, closes it explicitly. Shared by updateMetadataAndClose and its
+// revision-fenced sibling so both agree on the close-confirmation tail.
+func verifyClosed(store beads.Store, beadID string) error {
 	bead, err := store.Get(beadID)
 	if err != nil {
 		return fmt.Errorf("verifying close of %s: %w", beadID, err)
@@ -1763,6 +1770,109 @@ func updateMetadataAndClose(store beads.Store, beadID string, metadata map[strin
 		return nil
 	}
 	return store.Close(beadID)
+}
+
+// fencedCloseMaxAttempts bounds the re-read loop in fencedUpdateMetadataAndClose.
+// Only benign revision churn (e.g. a denormalized is_blocked recompute bumping
+// the row) forces a retry; a concurrent terminal close is resolved by preserve,
+// not retry. A handful of attempts is far more than any real interleave needs.
+const fencedCloseMaxAttempts = 8
+
+// fencedUpdateMetadataAndClose closes beadID and stamps metadata, but refuses to
+// overwrite a DIFFERENT outcome another writer already recorded terminally. It is
+// the revision-fenced sibling of updateMetadataAndClose, used on the shared
+// workflow finalize close path where a concurrent POST /runs/{id}/cancel can
+// close the run root as canceled between the finalizer's outcome read and its
+// close (the cancel-vs-finalize TOCTOU). preserved is true only when a foreign
+// terminal outcome was left intact and the requested overwrite was skipped;
+// callers gate follow-on outcome propagation (e.g. closeSourceBeadChain) on it.
+//
+// Idempotent retry vs foreign preserve: processWorkflowFinalize closes the root
+// before the finalizer specifically so a crash between those two closes retries
+// cleanly. On that retry the root is already closed with the SAME outcome this
+// pass recomputes — that is our own prior write, not a competing one, so it
+// returns preserved=false and the caller still runs its post-close cleanup. Only
+// a recorded outcome that DIFFERS from the requested one (canceled vs pass|fail)
+// is a genuine foreign preserve.
+//
+// Policy: the fence is obtained through beads.ResolveConditionalWriter, the
+// single sanctioned composition point of operator policy (the factory-stamped
+// beads.conditional_writes mode) and per-store capability — the same seam
+// syncControlEpochToAttempt and the drain reservations use. At resolve time,
+// require mode over an incapable store fails closed (propagates the resolve
+// error); off mode (today's default) and auto mode over an incapable store
+// return a nil writer and take the unconditional close, still guarded by the
+// pre-write terminal re-read, which narrows — does not eliminate — the residual
+// race window. A mid-flight ErrConditionalWriteUnsupported latch (capability lost
+// after resolve) is NOT downgraded to an unconditional write here: it propagates
+// as a transient error so the finalizer retries and the next resolve re-applies
+// policy, so require mode is never silently bypassed.
+//
+// The requested outcome is reused verbatim across retries rather than recomputed:
+// the only writer that competes for a workflow root here is run-cancel (resolved
+// by preserve), and the finalize outcome is derived from already-terminal
+// blocker steps, so no reachable interleave changes it.
+func fencedUpdateMetadataAndClose(store beads.Store, beadID string, metadata map[string]string) (preserved bool, err error) {
+	writer, _, resolveErr := beads.ResolveConditionalWriter(store)
+	if resolveErr != nil {
+		return false, fmt.Errorf("fenced close of %s: %w", beadID, resolveErr)
+	}
+	requested := strings.TrimSpace(metadata[beadmeta.OutcomeMetadataKey])
+	var lastRevision int64
+	for attempt := 0; attempt < fencedCloseMaxAttempts; attempt++ {
+		bead, err := store.Get(beadID)
+		if err != nil {
+			return false, err
+		}
+		lastRevision = bead.Revision
+		// The preserve/idempotent decision is keyed on gc.outcome, so it only
+		// applies when the caller actually requested one. A caller that closes
+		// with other metadata (requested == "") must never be short-circuited by
+		// an unrelated recorded outcome; it falls through to a normal fenced write.
+		if requested != "" && bead.Status == "closed" {
+			if recorded := strings.TrimSpace(bead.Metadata[beadmeta.OutcomeMetadataKey]); recorded != "" {
+				if recorded != requested {
+					// A different terminal outcome (e.g. a concurrent run-cancel)
+					// already won — preserve it instead of overwriting.
+					return true, nil
+				}
+				// Our own outcome from a crashed prior attempt — idempotent
+				// retry, not a foreign preserve. Report false so the caller still
+				// completes its post-close cleanup (spec sidecars, source chain).
+				return false, nil
+			}
+		}
+		if writer == nil {
+			// off mode, or auto over an incapable store: the pre-write terminal
+			// check above still refuses to overwrite a foreign outcome; this
+			// narrows — does not eliminate — the residual race window.
+			return false, updateMetadataAndClose(store, beadID, metadata)
+		}
+		status := "closed"
+		switch err := writer.UpdateIfMatch(beadID, bead.Revision, beads.UpdateOpts{
+			Status:   &status,
+			Metadata: metadata,
+		}); {
+		case err == nil:
+			return false, verifyClosed(store, beadID)
+		case beads.IsPreconditionFailed(err):
+			continue // revision moved; re-read and re-evaluate
+		default:
+			// Every other error propagates, including a mid-flight
+			// ErrConditionalWriteUnsupported latch: it must NOT fall back to an
+			// unconditional close here, or require mode would be silently
+			// violated. It is classified transient (IsTransientControllerError),
+			// so the finalizer stays open and the next resolve applies policy —
+			// auto degrades to the legacy path, require refuses fail-closed. This
+			// matches the syncControlEpochToAttempt precedent, which likewise
+			// propagates non-precondition CAS errors rather than downgrading.
+			return false, err
+		}
+	}
+	// Persistent revision churn kept us from a clean fenced shot. This is a
+	// level-triggered re-entry class (recognized by IsTransientControllerError),
+	// not a terminal disposition: the finalizer stays open and retries next cycle.
+	return false, &beads.CASRetriesExhaustedError{ID: beadID, Key: beadmeta.OutcomeMetadataKey, Attempts: fencedCloseMaxAttempts, LastRevision: lastRevision}
 }
 
 // Note: listByWorkflowRoot, setOutcomeAndClose, propagateRetrySubjectMetadata,

--- a/internal/dispatch/finalize_cancel_toctou_helper_test.go
+++ b/internal/dispatch/finalize_cancel_toctou_helper_test.go
@@ -1,0 +1,265 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/rollout/gate"
+)
+
+// TestFencedUpdateMetadataAndClosePreservesTerminalOutcome exercises the fenced
+// close primitive directly: an already-terminal bead carrying a recorded outcome
+// is left intact and the caller is told it was preserved.
+func TestFencedUpdateMetadataAndClosePreservesTerminalOutcome(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "root"})
+	closed := "closed"
+	if err := store.Update(root.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeCanceled},
+	}); err != nil {
+		t.Fatalf("close root as canceled: %v", err)
+	}
+
+	preserved, err := fencedUpdateMetadataAndClose(store, root.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose: %v", err)
+	}
+	if !preserved {
+		t.Fatal("preserved = false, want true (an existing terminal outcome must survive)")
+	}
+	if got := mustGet(t, store, root.ID).Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomeCanceled {
+		t.Fatalf("outcome = %q, want canceled", got)
+	}
+}
+
+// TestFencedUpdateMetadataAndCloseHappyPath: with no concurrent close, an open
+// bead is closed and stamped with the requested outcome, and preserved is false.
+func TestFencedUpdateMetadataAndCloseHappyPath(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "root",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+
+	preserved, err := fencedUpdateMetadataAndClose(store, root.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose: %v", err)
+	}
+	if preserved {
+		t.Fatal("preserved = true, want false (an open bead must be closed)")
+	}
+	got := mustGet(t, store, root.ID)
+	if got.Status != "closed" || got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("root = {status:%q outcome:%q}, want {closed pass}", got.Status, got.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+}
+
+// TestFencedUpdateMetadataAndCloseFallbackHappyPath drives the
+// ErrConditionalWriteUnsupported fallback (a store that cannot fence): an open
+// bead is still closed and stamped, via the narrowed unconditional path.
+func TestFencedUpdateMetadataAndCloseFallbackHappyPath(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	store.DisableConditionalWrites = true // force the unsupported→fallback branch
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "root",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+
+	preserved, err := fencedUpdateMetadataAndClose(store, root.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose: %v", err)
+	}
+	if preserved {
+		t.Fatal("preserved = true, want false")
+	}
+	got := mustGet(t, store, root.ID)
+	if got.Status != "closed" || got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("root = {status:%q outcome:%q}, want {closed pass}", got.Status, got.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+}
+
+// TestFencedUpdateMetadataAndCloseFallbackPreservesTerminalOutcome: even without
+// conditional-write support, the pre-write terminal re-read must still refuse to
+// overwrite an already-recorded FOREIGN outcome.
+func TestFencedUpdateMetadataAndCloseFallbackPreservesTerminalOutcome(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	store.DisableConditionalWrites = true
+	root := mustCreate(t, store, beads.Bead{Title: "root"})
+	closed := "closed"
+	if err := store.Update(root.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeCanceled},
+	}); err != nil {
+		t.Fatalf("close root as canceled: %v", err)
+	}
+
+	preserved, err := fencedUpdateMetadataAndClose(store, root.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose: %v", err)
+	}
+	if !preserved {
+		t.Fatal("preserved = false, want true (fallback must honor an existing terminal outcome)")
+	}
+	if got := mustGet(t, store, root.ID).Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomeCanceled {
+		t.Fatalf("outcome = %q, want canceled", got)
+	}
+}
+
+// TestFencedUpdateMetadataAndCloseIdempotentRetryNotPreserved guards the
+// crash-retry idempotency contract: a bead already closed with the SAME outcome
+// this pass requests is our own prior write, not a competing one. It must report
+// preserved=false so the caller still runs its post-close cleanup — otherwise a
+// dispatcher crash between the root close and the source-chain close would
+// permanently orphan the parent source beads.
+func TestFencedUpdateMetadataAndCloseIdempotentRetryNotPreserved(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "root"})
+	closed := "closed"
+	if err := store.Update(root.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass},
+	}); err != nil {
+		t.Fatalf("pre-close root as pass: %v", err)
+	}
+
+	preserved, err := fencedUpdateMetadataAndClose(store, root.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose: %v", err)
+	}
+	if preserved {
+		t.Fatal("preserved = true, want false (re-recording our own outcome is idempotent, not a foreign preserve)")
+	}
+}
+
+// TestFencedUpdateMetadataAndCloseNoOutcomeCallerStillWrites guards the helper
+// against a caller that closes with metadata carrying no gc.outcome: the
+// preserve/idempotent decision is keyed on gc.outcome, so with none requested it
+// must apply the write, not mistake an unrelated recorded outcome for a foreign
+// preserve and silently skip it.
+func TestFencedUpdateMetadataAndCloseNoOutcomeCallerStillWrites(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "root"})
+	closed := "closed"
+	if err := store.Update(root.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass},
+	}); err != nil {
+		t.Fatalf("pre-close root as pass: %v", err)
+	}
+
+	// metadata with no gc.outcome key — requested == "".
+	preserved, err := fencedUpdateMetadataAndClose(store, root.ID,
+		map[string]string{"gc.some_other_key": "v"})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose: %v", err)
+	}
+	if preserved {
+		t.Fatal("preserved = true, want false (no gc.outcome requested; the write must not be skipped)")
+	}
+	got := mustGet(t, store, root.ID)
+	if got.Metadata["gc.some_other_key"] != "v" {
+		t.Fatalf("gc.some_other_key = %q, want \"v\" (the caller's write was silently skipped)", got.Metadata["gc.some_other_key"])
+	}
+	if got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("gc.outcome = %q, want pass (existing outcome must be untouched)", got.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+}
+
+// midFlightUnsupportedStore embeds a conditional-writes-capable MemStore but its
+// UpdateIfMatch always latches ErrConditionalWriteUnsupported — simulating a
+// store that passes the resolve-time capability probe, then loses the capability
+// mid-write (a bd probe-miss). MemStore is not a ConditionalWritesResolveTargeter,
+// so ResolveConditionalWriter resolves to this wrapper and exercises its
+// UpdateIfMatch rather than the embedded store's.
+type midFlightUnsupportedStore struct {
+	*beads.MemStore
+}
+
+func (s *midFlightUnsupportedStore) UpdateIfMatch(string, int64, beads.UpdateOpts) error {
+	return beads.ErrConditionalWriteUnsupported
+}
+
+// TestFencedUpdateMetadataAndCloseMidFlightUnsupportedPropagates: a store that
+// resolves to a live conditional writer but then latches
+// ErrConditionalWriteUnsupported mid-write must PROPAGATE the error, not fall
+// back to an unconditional close. Falling back would silently violate require
+// mode; propagating (a transient class) keeps the finalizer open so the next
+// resolve re-applies policy (auto degrades, require refuses fail-closed).
+func TestFencedUpdateMetadataAndCloseMidFlightUnsupportedPropagates(t *testing.T) {
+	t.Parallel()
+	store := &midFlightUnsupportedStore{MemStore: newStampedDrainStore(t, gate.Require)}
+	root := mustCreate(t, store, beads.Bead{Title: "root"})
+
+	preserved, err := fencedUpdateMetadataAndClose(store, root.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err == nil {
+		t.Fatal("err = nil, want a propagated ErrConditionalWriteUnsupported (must not fall back to an unconditional close under require)")
+	}
+	if !beads.IsConditionalWriteUnsupported(err) {
+		t.Fatalf("err = %v, want IsConditionalWriteUnsupported", err)
+	}
+	if preserved {
+		t.Fatal("preserved = true, want false")
+	}
+	if got := mustGet(t, store, root.ID); got.Status == "closed" {
+		t.Fatal("root was closed via an unconditional fallback; require mode must stay open (fail closed)")
+	}
+}
+
+// TestFencedUpdateMetadataAndCloseCASFencePreservesForeignOutcome exercises the
+// real conditional-write (CAS) fence path via a factory-stamped store, rather
+// than the off-mode fallback the bare MemStore takes: a foreign terminal outcome
+// is preserved, and the ordinary open→pass close still works.
+func TestFencedUpdateMetadataAndCloseCASFencePreservesForeignOutcome(t *testing.T) {
+	t.Parallel()
+	store := newStampedDrainStore(t, gate.Require) // ResolveConditionalWriter → live CAS writer
+
+	// Foreign preserve.
+	canceled := mustCreate(t, store, beads.Bead{Title: "canceled root"})
+	closed := "closed"
+	if err := store.Update(canceled.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeCanceled},
+	}); err != nil {
+		t.Fatalf("close root as canceled: %v", err)
+	}
+	preserved, err := fencedUpdateMetadataAndClose(store, canceled.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose (foreign): %v", err)
+	}
+	if !preserved {
+		t.Fatal("preserved = false, want true (CAS path must preserve a foreign outcome)")
+	}
+	if got := mustGet(t, store, canceled.ID).Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomeCanceled {
+		t.Fatalf("outcome = %q, want canceled", got)
+	}
+
+	// Happy path over the CAS fence.
+	open := mustCreate(t, store, beads.Bead{Title: "open root"})
+	preserved, err = fencedUpdateMetadataAndClose(store, open.ID,
+		map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass})
+	if err != nil {
+		t.Fatalf("fencedUpdateMetadataAndClose (happy): %v", err)
+	}
+	if preserved {
+		t.Fatal("preserved = true, want false")
+	}
+	got := mustGet(t, store, open.ID)
+	if got.Status != "closed" || got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("root = {status:%q outcome:%q}, want {closed pass}", got.Status, got.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+}

--- a/internal/dispatch/finalize_cancel_toctou_test.go
+++ b/internal/dispatch/finalize_cancel_toctou_test.go
@@ -1,0 +1,173 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// buildCanceledRootFinalizeScenario builds the exact interleave the
+// cancel-vs-finalize TOCTOU produces: POST /runs/{id}/cancel has already closed
+// the workflow root as canceled, and only afterwards does the control-dispatcher
+// run the (still-open) finalizer over its passing step. It returns the root and
+// finalizer IDs.
+func buildCanceledRootFinalizeScenario(t *testing.T, store beads.Store) (rootID, finalizerID string) {
+	t.Helper()
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow root",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	// Cancel won the race: the root is already terminal, recorded canceled.
+	closed := "closed"
+	if err := store.Update(root.ID, beads.UpdateOpts{
+		Status: &closed,
+		Metadata: map[string]string{
+			beadmeta.OutcomeMetadataKey:         beadmeta.OutcomeCanceled,
+			beadmeta.CancelRequestedMetadataKey: "true",
+		},
+	}); err != nil {
+		t.Fatalf("close root as canceled: %v", err)
+	}
+	step := mustCreate(t, store, beads.Bead{
+		Title: "work step",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+			beadmeta.OutcomeMetadataKey:    beadmeta.OutcomePass,
+		},
+	})
+	mustClose(t, store, step.ID)
+	finalizer := mustCreate(t, store, beads.Bead{
+		Title: "workflow finalize",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindWorkflowFinalize,
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	mustDep(t, store, finalizer.ID, step.ID, "blocks")
+	return root.ID, finalizer.ID
+}
+
+// TestProcessWorkflowFinalizePreservesCanceledRoot is the regression guard for
+// the cancel-vs-finalize TOCTOU: a root that a concurrent run-cancel already
+// closed as canceled must NOT be overwritten with gc.outcome=pass|fail when the
+// finalizer subsequently runs. The finalizer itself must still close cleanly.
+func TestProcessWorkflowFinalizePreservesCanceledRoot(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	rootID, finalizerID := buildCanceledRootFinalizeScenario(t, store)
+
+	if _, err := processWorkflowFinalize(store, mustGet(t, store, finalizerID), ProcessOptions{}); err != nil {
+		t.Fatalf("processWorkflowFinalize: %v", err)
+	}
+
+	root := mustGet(t, store, rootID)
+	if got := root.Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomeCanceled {
+		t.Fatalf("root gc.outcome = %q, want %q (finalize overwrote a concurrent cancel)", got, beadmeta.OutcomeCanceled)
+	}
+	if root.Status != "closed" {
+		t.Fatalf("root status = %q, want closed", root.Status)
+	}
+	if fin := mustGet(t, store, finalizerID); fin.Status != "closed" {
+		t.Fatalf("finalizer status = %q, want closed (cleanup must still complete)", fin.Status)
+	}
+}
+
+// TestProcessWorkflowFinalizeHappyPathClosesRootPass locks in that the fenced
+// close leaves the ordinary (no concurrent cancel) finalize path unchanged: an
+// open root over a passing step closes pass, and the finalizer closes pass.
+func TestProcessWorkflowFinalizeHappyPathClosesRootPass(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow root",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	step := mustCreate(t, store, beads.Bead{
+		Title: "work step",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+			beadmeta.OutcomeMetadataKey:    beadmeta.OutcomePass,
+		},
+	})
+	mustClose(t, store, step.ID)
+	finalizer := mustCreate(t, store, beads.Bead{
+		Title: "workflow finalize",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindWorkflowFinalize,
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	mustDep(t, store, finalizer.ID, step.ID, "blocks")
+
+	if _, err := processWorkflowFinalize(store, mustGet(t, store, finalizer.ID), ProcessOptions{}); err != nil {
+		t.Fatalf("processWorkflowFinalize: %v", err)
+	}
+	gotRoot := mustGet(t, store, root.ID)
+	if gotRoot.Status != "closed" || gotRoot.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("root = {status:%q outcome:%q}, want {closed pass}", gotRoot.Status, gotRoot.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+	if fin := mustGet(t, store, finalizer.ID); fin.Status != "closed" || fin.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("finalizer = {status:%q outcome:%q}, want {closed pass}", fin.Status, fin.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+}
+
+// TestProcessWorkflowFinalizeCrashRetryClosesSourceChain guards the crash-retry
+// idempotency contract. processWorkflowFinalize closes the root before the
+// finalizer so a dispatcher crash between those closes retries cleanly; on that
+// retry the root is already closed with the same outcome. The finalizer's
+// source-bead chain close (which makes "Adopt PR"-style parent beads disappear)
+// must still run — the fenced close must NOT mistake our own prior outcome for a
+// foreign cancel and skip it, or the parents orphan forever.
+func TestProcessWorkflowFinalizeCrashRetryClosesSourceChain(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	parent := mustCreate(t, store, beads.Bead{Title: "adopt pr parent (source)"})
+	root := mustCreate(t, store, beads.Bead{
+		Title: "workflow root",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         beadmeta.KindWorkflow,
+			beadmeta.SourceBeadIDMetadataKey: parent.ID,
+		},
+	})
+	// Simulate a prior finalize pass that closed the root pass, then crashed
+	// before closing the source chain and the finalizer.
+	closed := "closed"
+	if err := store.Update(root.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass},
+	}); err != nil {
+		t.Fatalf("pre-close root as pass: %v", err)
+	}
+	step := mustCreate(t, store, beads.Bead{
+		Title: "work step",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+			beadmeta.OutcomeMetadataKey:    beadmeta.OutcomePass,
+		},
+	})
+	mustClose(t, store, step.ID)
+	finalizer := mustCreate(t, store, beads.Bead{
+		Title: "workflow finalize",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindWorkflowFinalize,
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	mustDep(t, store, finalizer.ID, step.ID, "blocks")
+
+	if _, err := processWorkflowFinalize(store, mustGet(t, store, finalizer.ID), ProcessOptions{}); err != nil {
+		t.Fatalf("processWorkflowFinalize: %v", err)
+	}
+
+	if got := mustGet(t, store, parent.ID); got.Status != "closed" {
+		t.Fatalf("parent source bead status = %q, want closed (crash-retry must still close the source chain)", got.Status)
+	}
+	if fin := mustGet(t, store, finalizer.ID); fin.Status != "closed" {
+		t.Fatalf("finalizer status = %q, want closed", fin.Status)
+	}
+}
+
+// Fenced-helper unit tests live in finalize_cancel_toctou_helper_test.go, added
+// alongside the fencedUpdateMetadataAndClose implementation.

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -832,9 +832,10 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	// next serve cycle will retry. Source-chain propagation is preflighted first
 	// so retryable scan failures keep the root live for singleton scans, but
 	// source beads are not mutated until the root is durably closed.
-	if err := setOutcomeAndClose(store, rootID, outcome); err != nil {
+	rootOutcomePreserved, err := fencedSetOutcomeAndClose(store, rootID, outcome)
+	if err != nil {
 		if errors.Is(err, beads.ErrNotFound) {
-			if closeErr := setOutcomeAndClose(store, bead.ID, beadmeta.OutcomeMissingRoot); closeErr != nil {
+			if _, closeErr := fencedSetOutcomeAndClose(store, bead.ID, beadmeta.OutcomeMissingRoot); closeErr != nil {
 				return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing orphaned finalizer (root %s missing): %w", bead.ID, rootID, closeErr))
 			}
 			return ControlResult{Processed: true, Action: "workflow-missing_root"}, nil
@@ -844,12 +845,17 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	if _, err := sourceworkflow.CloseSpecSidecarsForRoot(store, rootID, sourceworkflow.WorkflowSpecSidecarClosedReason); err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing workflow spec sidecars: %w", rootID, err))
 	}
-	if outcome == beadmeta.OutcomePass {
+	// Skip pass-propagation to parent source beads when a concurrent run-cancel
+	// already recorded the root as terminal: the authoritative run outcome is not
+	// this finalizer's pass, so closing the "Adopt PR"-style parents would leave a
+	// canceled run looking merged. A clean cancel leaves those parents open; the
+	// raced path must match it.
+	if outcome == beadmeta.OutcomePass && !rootOutcomePreserved {
 		if err := closeSourceBeadChain(store, rootID, opts); err != nil {
 			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing source bead chain: %w", rootID, err))
 		}
 	}
-	if err := setOutcomeAndClose(store, bead.ID, beadmeta.OutcomePass); err != nil {
+	if _, err := fencedSetOutcomeAndClose(store, bead.ID, beadmeta.OutcomePass); err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow finalizer: %w", bead.ID, err))
 	}
 
@@ -1509,6 +1515,15 @@ func findScopeBody(all []beads.Bead, rootID, scopeRef string) (beads.Bead, bool)
 
 func setOutcomeAndClose(store beads.Store, beadID, outcome string) error {
 	return updateMetadataAndClose(store, beadID, map[string]string{beadmeta.OutcomeMetadataKey: outcome})
+}
+
+// fencedSetOutcomeAndClose is the revision-fenced sibling of setOutcomeAndClose,
+// used on the shared workflow finalize close path so a concurrent run-cancel that
+// already closed the target as canceled is not overwritten. preserved is true
+// when an existing terminal outcome was left intact. See
+// fencedUpdateMetadataAndClose for the mechanism.
+func fencedSetOutcomeAndClose(store beads.Store, beadID, outcome string) (preserved bool, err error) {
+	return fencedUpdateMetadataAndClose(store, beadID, map[string]string{beadmeta.OutcomeMetadataKey: outcome})
 }
 
 // ReconcileClosedScopeMember re-reads a just-closed bead and delegates to


### PR DESCRIPTION

## Problem

`processWorkflowFinalize` reads a workflow root's terminal status once, then closes the root through `updateMetadataAndClose`, an unconditional `store.Update({status: closed, metadata: {gc.outcome}})`. If a concurrent `POST /runs/{id}/cancel` closes the same root as `gc.outcome=canceled` between that read and the close, the finalize close silently overwrites it with `pass` or `fail`, and the run reports as passed or failed instead of canceled.

This is a pre-existing TOCTOU on the shared orchestrated finalize close path (introduced in ae78c33185, predating the RootOnly gate). #4310 exposed the path to RootOnly graph.v2 workflows, which is how it surfaced.

## Fix

Fence the root and finalizer closes through the existing optimistic-concurrency seam, `beads.ResolveConditionalWriter` then `UpdateIfMatch` on the revision read at the start of the close. This is the same seam `syncControlEpochToAttempt` and the drain reservations already use.

- A recorded terminal `gc.outcome` that differs from the requested one (canceled vs pass or fail) is preserved, not overwritten.
- A recorded outcome equal to the requested one is this finalizer's own prior write from a crash-interrupted pass, so it is an idempotent retry: `closeSourceBeadChain` still runs and parent source beads are not orphaned.
- `require` mode over an incapable store fails closed at resolve. `off` mode (the default) and `auto` over an incapable store take the unconditional close, still guarded by a pre-write terminal re-read that narrows the residual window. A mid-flight `ErrConditionalWriteUnsupported` latch propagates as a transient error rather than downgrading to an unconditional write, so `require` mode is never bypassed and the next resolve re-applies policy.
- `closeSourceBeadChain` is skipped only when the root outcome was preserved by a foreign cancel, matching a clean cancel, which never touches the source chain.
- Persistent revision churn returns a transient `CASRetriesExhaustedError`, so the finalizer stays open and retries rather than recording a hard failure.

The happy path, with no concurrent close, is unchanged.

## Test plan

New tests in `internal/dispatch`:

- a concurrent cancel that closed the root `canceled` survives a subsequent finalize (outcome stays `canceled`, finalizer still closes cleanly);
- a crash-interrupted retry still closes the source-bead chain;
- the ordinary open-root finalize still closes root and finalizer `pass`;
- the CAS fence preserves a foreign outcome on a conditional-writes-capable store;
- a mid-flight `ErrConditionalWriteUnsupported` latch propagates instead of falling back;
- off-mode fallback preserves a foreign outcome and closes the happy path.

`make build` and `make check` pass.
