### PR TITLE
feat(nudge): configurable nudge poller cycle interval via [session] nudge_poll_interval

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -301,15 +301,15 @@ func newNudgePollCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long:   "Poll and deliver queued nudges for sessions that need an out-of-band delivery fallback. Used internally.",
 		Args:   cobra.MaximumNArgs(1),
 		Hidden: true,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdNudgePoll(args, sessionName, interval, quiescence, stdout, stderr) != 0 {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmdNudgePoll(args, sessionName, interval, quiescence, cmd.Flags().Changed("interval"), stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&sessionName, "session", "", "runtime session name (defaults to $GC_SESSION_NAME)")
-	cmd.Flags().DurationVar(&interval, "interval", defaultNudgePollInterval, "poll interval")
+	cmd.Flags().DurationVar(&interval, "interval", defaultNudgePollInterval, "poll interval (overrides [session] nudge_poll_interval)")
 	cmd.Flags().DurationVar(&quiescence, "quiescence", defaultNudgePollQuiescence, "minimum inactivity before injecting")
 	return cmd
 }
@@ -609,7 +609,24 @@ func configureNudgePollRuntime(stderr io.Writer) func() {
 	}
 }
 
-func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.Duration, _ io.Writer, stderr io.Writer) int {
+// resolveNudgePollInterval picks the poller cycle interval: an explicitly
+// passed --interval flag wins; otherwise a positive [session]
+// nudge_poll_interval from the city config; otherwise the passed default.
+func resolveNudgePollInterval(cityPath string, flagValue time.Duration, flagExplicit bool) time.Duration {
+	if flagExplicit {
+		return flagValue
+	}
+	cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
+	if err != nil || cfg == nil {
+		return flagValue
+	}
+	if d := cfg.Session.NudgePollIntervalDuration(); d > 0 {
+		return d
+	}
+	return flagValue
+}
+
+func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.Duration, intervalExplicit bool, _ io.Writer, stderr io.Writer) int {
 	targetID := os.Getenv("GC_ALIAS")
 	if targetID == "" {
 		targetID = os.Getenv("GC_SESSION_ID")
@@ -633,6 +650,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		fmt.Fprintln(stderr, "gc nudge poll: session name unavailable") //nolint:errcheck
 		return 1
 	}
+	interval = resolveNudgePollInterval(target.cityPath, interval, intervalExplicit)
 
 	release, err := acquireNudgePollerLease(target.cityPath, target.sessionName, target.pollerKey())
 	if err != nil {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -3026,7 +3026,7 @@ func TestCmdNudgePollSurvivesTransientObserveErrors(t *testing.T) {
 	defer func() { nudgeObserveTarget = origObserve }()
 
 	var stdout, stderr bytes.Buffer
-	code := cmdNudgePoll([]string{created.ID}, "worker-session", time.Millisecond, 0, &stdout, &stderr)
+	code := cmdNudgePoll([]string{created.ID}, "worker-session", time.Millisecond, 0, true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdNudgePoll = %d, want 0 (transient observe error with queued work pending must not kill the poller); stderr=%s", code, stderr.String())
 	}
@@ -5090,4 +5090,50 @@ func TestBlockedQueuedNudgeReason_GetWaitErrorMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveNudgePollInterval(t *testing.T) {
+	writeCity := func(t *testing.T, sessionBlock string) string {
+		t.Helper()
+		dir := t.TempDir()
+		toml := "[workspace]\nname = \"test\"\n" + sessionBlock + "\n[[agent]]\nname = \"a\"\n"
+		if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+			t.Fatalf("write city.toml: %v", err)
+		}
+		return dir
+	}
+
+	t.Run("config knob applies when flag not explicit", func(t *testing.T) {
+		dir := writeCity(t, "[session]\nnudge_poll_interval = \"15s\"\n")
+		if got := resolveNudgePollInterval(dir, defaultNudgePollInterval, false); got != 15*time.Second {
+			t.Fatalf("resolveNudgePollInterval = %v, want 15s", got)
+		}
+	})
+
+	t.Run("explicit flag wins over config", func(t *testing.T) {
+		dir := writeCity(t, "[session]\nnudge_poll_interval = \"15s\"\n")
+		if got := resolveNudgePollInterval(dir, 7*time.Second, true); got != 7*time.Second {
+			t.Fatalf("resolveNudgePollInterval = %v, want 7s (explicit flag)", got)
+		}
+	})
+
+	t.Run("default when config unset", func(t *testing.T) {
+		dir := writeCity(t, "")
+		if got := resolveNudgePollInterval(dir, defaultNudgePollInterval, false); got != defaultNudgePollInterval {
+			t.Fatalf("resolveNudgePollInterval = %v, want default %v", got, defaultNudgePollInterval)
+		}
+	})
+
+	t.Run("default when config invalid", func(t *testing.T) {
+		dir := writeCity(t, "[session]\nnudge_poll_interval = \"banana\"\n")
+		if got := resolveNudgePollInterval(dir, defaultNudgePollInterval, false); got != defaultNudgePollInterval {
+			t.Fatalf("resolveNudgePollInterval = %v, want default %v", got, defaultNudgePollInterval)
+		}
+	})
+
+	t.Run("default when city config unloadable", func(t *testing.T) {
+		if got := resolveNudgePollInterval(t.TempDir(), defaultNudgePollInterval, false); got != defaultNudgePollInterval {
+			t.Fatalf("resolveNudgePollInterval = %v, want default %v", got, defaultNudgePollInterval)
+		}
+	})
 }

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -797,6 +797,7 @@ SessionConfig holds session provider settings.
 | `setup_timeout` | string |  | `10s` | SetupTimeout is the per-command/script timeout for session setup and pre_start commands. Duration string (e.g., "10s", "30s"). Defaults to "10s". |
 | `nudge_ready_timeout` | string |  | `10s` | NudgeReadyTimeout is how long to wait for the agent to be ready before sending nudge text. Duration string. Defaults to "10s". |
 | `nudge_retry_interval` | string |  | `500ms` | NudgeRetryInterval is the retry interval between nudge readiness polls. Duration string. Defaults to "500ms". |
+| `nudge_poll_interval` | string |  | `2s` | NudgePollInterval is the cycle interval for the per-session nudge poller sidecar (`gc nudge poll`). Each cycle observes the session and checks the queued-nudge state, so on hosts running many sessions a longer interval trades nudge-delivery latency for less standing load. Duration string. Unset means the poller's built-in default (2s). |
 | `nudge_lock_timeout` | string |  | `30s` | NudgeLockTimeout is how long to wait to acquire the per-session nudge lock. Duration string. Defaults to "30s". |
 | `debounce_ms` | integer |  | `500` | DebounceMs is the default debounce interval in milliseconds for send-keys. Defaults to 500. |
 | `display_ms` | integer |  | `5000` | DisplayMs is the default display duration in milliseconds for status messages. Defaults to 5000. |

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -2744,6 +2744,11 @@
           "description": "NudgeRetryInterval is the retry interval between nudge readiness polls.\nDuration string. Defaults to \"500ms\".",
           "default": "500ms"
         },
+        "nudge_poll_interval": {
+          "type": "string",
+          "description": "NudgePollInterval is the cycle interval for the per-session nudge\npoller sidecar (`gc nudge poll`). Each cycle observes the session and\nchecks the queued-nudge state, so on hosts running many sessions a\nlonger interval trades nudge-delivery latency for less standing load.\nDuration string. Unset means the poller's built-in default (2s).",
+          "default": "2s"
+        },
         "nudge_lock_timeout": {
           "type": "string",
           "description": "NudgeLockTimeout is how long to wait to acquire the per-session nudge lock.\nDuration string. Defaults to \"30s\".",

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -2744,6 +2744,11 @@
           "description": "NudgeRetryInterval is the retry interval between nudge readiness polls.\nDuration string. Defaults to \"500ms\".",
           "default": "500ms"
         },
+        "nudge_poll_interval": {
+          "type": "string",
+          "description": "NudgePollInterval is the cycle interval for the per-session nudge\npoller sidecar (`gc nudge poll`). Each cycle observes the session and\nchecks the queued-nudge state, so on hosts running many sessions a\nlonger interval trades nudge-delivery latency for less standing load.\nDuration string. Unset means the poller's built-in default (2s).",
+          "default": "2s"
+        },
         "nudge_lock_timeout": {
           "type": "string",
           "description": "NudgeLockTimeout is how long to wait to acquire the per-session nudge lock.\nDuration string. Defaults to \"30s\".",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1555,6 +1555,12 @@ type SessionConfig struct {
 	// NudgeRetryInterval is the retry interval between nudge readiness polls.
 	// Duration string. Defaults to "500ms".
 	NudgeRetryInterval string `toml:"nudge_retry_interval,omitempty" jsonschema:"default=500ms"`
+	// NudgePollInterval is the cycle interval for the per-session nudge
+	// poller sidecar (`gc nudge poll`). Each cycle observes the session and
+	// checks the queued-nudge state, so on hosts running many sessions a
+	// longer interval trades nudge-delivery latency for less standing load.
+	// Duration string. Unset means the poller's built-in default (2s).
+	NudgePollInterval string `toml:"nudge_poll_interval,omitempty" jsonschema:"default=2s"`
 	// NudgeLockTimeout is how long to wait to acquire the per-session nudge lock.
 	// Duration string. Defaults to "30s".
 	NudgeLockTimeout string `toml:"nudge_lock_timeout,omitempty" jsonschema:"default=30s"`
@@ -1635,6 +1641,20 @@ func (s *SessionConfig) NudgeReadyTimeoutDuration() time.Duration {
 // Defaults to 500ms if empty or unparseable.
 func (s *SessionConfig) NudgeRetryIntervalDuration() time.Duration {
 	return durationOr(s.NudgeRetryInterval, 500*time.Millisecond)
+}
+
+// NudgePollIntervalDuration returns the configured nudge poller cycle
+// interval, or 0 when unset, unparseable, or non-positive — 0 means "not
+// configured" and callers fall back to their built-in default.
+func (s *SessionConfig) NudgePollIntervalDuration() time.Duration {
+	if s.NudgePollInterval == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s.NudgePollInterval)
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
 }
 
 // NudgeLockTimeoutDuration returns the nudge lock timeout as a time.Duration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5995,6 +5995,46 @@ name = "a"
 	}
 }
 
+func TestParseSessionNudgePollInterval(t *testing.T) {
+	toml := `
+[workspace]
+name = "test"
+
+[session]
+nudge_poll_interval = "15s"
+
+[[agent]]
+name = "a"
+`
+	cfg, err := Parse([]byte(toml))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := cfg.Session.NudgePollIntervalDuration(); got != 15*time.Second {
+		t.Errorf("NudgePollIntervalDuration() = %v, want 15s", got)
+	}
+}
+
+func TestNudgePollIntervalDurationUnsetOrInvalid(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"unset", ""},
+		{"unparseable", "banana"},
+		{"zero", "0s"},
+		{"negative", "-5s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &SessionConfig{NudgePollInterval: tc.value}
+			if got := s.NudgePollIntervalDuration(); got != 0 {
+				t.Errorf("NudgePollIntervalDuration() = %v, want 0 (unconfigured)", got)
+			}
+		})
+	}
+}
+
 func TestAPIConfigParsing(t *testing.T) {
 	toml := `
 [workspace]

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -53,6 +53,7 @@ func ValidateDurations(cfg *City, source string) []string {
 	check("[session]", "setup_timeout", cfg.Session.SetupTimeout)
 	check("[session]", "nudge_ready_timeout", cfg.Session.NudgeReadyTimeout)
 	check("[session]", "nudge_retry_interval", cfg.Session.NudgeRetryInterval)
+	check("[session]", "nudge_poll_interval", cfg.Session.NudgePollInterval)
 	check("[session]", "nudge_lock_timeout", cfg.Session.NudgeLockTimeout)
 	check("[session]", "startup_timeout", cfg.Session.StartupTimeout)
 	check("[session]", "progress_stall_timeout", cfg.Session.ProgressStallTimeout)


### PR DESCRIPTION
## Summary
Every live session runs a `gc nudge poll` sidecar whose cycle interval is hardcoded to 2s — `nudgepoller.CommandArgs` never passes `--interval`, so no deployment can change the cadence. Each cycle observes the session and checks queued-nudge state; on hosts running many sessions this is a standing CPU-load multiplier. On a 6-core Mac mini control host running 5–7 sessions, the per-session sidecar churn (pollers + helper invocations) saturated the box: sustained load 60–160 while agents were otherwise idle, collapsing to ~2 the moment sessions stopped.

## Root cause
`defaultNudgePollInterval = 2 * time.Second` (cmd/gc/cmd_nudge.go) is the only cadence source: the spawner (`internal/nudgepoller.CommandArgs`) passes no `--interval`, and no config knob exists — `[session]` has `nudge_retry_interval` etc., but nothing for the poller cycle. The memory side of the per-cycle cost is already tracked (gc-3ftcq, bounded by `configureNudgePollRuntime`'s GOMEMLIMIT); the *frequency* side had no lever at all.

## Fix
Adds `[session] nudge_poll_interval` (duration string). The poller resolves its interval at startup: an explicit `--interval` flag wins, then a positive configured value, then the built-in 2s default. Unset / unparseable / non-positive values keep today's behavior exactly. Poller argv is unchanged, so pidfile/CmdlineMatcher identity and the reap paths are unaffected. Trade-off is explicit and operator-chosen: fallback nudge delivery latency rises to at most the configured interval; primary delivery paths are untouched. Docs/schema regenerated via `make generate`.

## Tests
- `TestParseSessionNudgePollInterval` / `TestNudgePollIntervalDurationUnsetOrInvalid` (config parse + unset/invalid/zero/negative → unconfigured)
- `TestResolveNudgePollInterval` (config knob applies; explicit flag wins; default on unset, invalid, unloadable config)
- Written failing-first against the unpatched code; `go test ./internal/config ./cmd/gc -run Nudge` and `go vet` pass.

## Validation
Deployed as a local hotfix (v1.3.5 + this change) on a production city (6-core/8GB macOS control host, ~7 sessions at peak) on 2026-07-15 with `nudge_poll_interval = "15s"`: config resolves through the full compose path (`gc config show`), poller spawns unchanged, reap tests still green with real process kills. Related: #4246 tracks the per-tick store-scan cost itself; this knob is complementary (frequency lever vs per-cycle cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)