### PR TITLE
test: make session wake use case hermetic

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -34,11 +34,14 @@ files in the same package, and terminates safely on cycles.
 This is intentionally not a universal hermeticity proof. Cross-package calls,
 method and interface dispatch, package-level callback indirection, and
 resources absent from the catalog remain manual-review boundaries. In
-particular, `TestPrepareWaitWakeState_ResolvesRigDependencyBeads` has a reviewed
-hermetic body but still runs as Medium because `cmd/gc` owns a process-mutating
+particular, `TestPrepareWaitWakeState_ResolvesRigDependencyBeads` and
+`TestDoSessionWake_PokesManagedControllerAfterStateChange` have reviewed
+hermetic bodies but still run as Medium because `cmd/gc` owns a process-mutating
 `TestMain`. `TestCmdSessionWait_AllowsRigDependencyBeads` remains the singular
-real managed-provider composition proof; the body review is not a reason to
-remove that boundary test.
+real managed-provider composition proof for wait, and
+`TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart` remains the
+singular CLI/config/file-store/controller-socket composition proof for wake.
+Body review is not a reason to remove either boundary test.
 
 The canonical identity is package directory plus package clause plus top-level
 `Test`, `Benchmark`, `Fuzz`, or `TestMain` name. Nested function literals and
@@ -126,7 +129,7 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 74 calls / 25 files (historical regex census: 75 / 25) | ga-80po0c.2.1 | untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; each non-Medium marked caller retains an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | fixed_sleep: 289 calls / 114 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | http_test_server: 300 calls / 66 files | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
-| Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
+| Small debt ratchet | all untagged test source | net_listen: 91 calls / 34 files (historical regex census: 92 / 34) | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 394 calls / 105 files | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
@@ -136,7 +139,7 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 74 calls / 25 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | fixed_sleep: 289 calls / 114 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | http_test_server: 300 calls / 66 files (historical regex census: 255 / 56) | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
-| Source debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
+| Source debt ratchet | all untagged test source | net_listen: 91 calls / 34 files (historical regex census: 92 / 34) | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its configured listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 396 calls / 106 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
@@ -144,6 +147,7 @@ all-source audit while staying outside untagged and Small debt.
 
 | Reviewed hermetic body | Effective runnable size | Medium reason | Retained real composition owner |
 | --- | --- | --- | --- |
+| `cmd/gc` package `main` — TestDoSessionWake_PokesManagedControllerAfterStateChange | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart |
 | `cmd/gc` package `main` — TestPrepareWaitWakeState_ResolvesRigDependencyBeads | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWait_AllowsRigDependencyBeads |
 <!-- END CHECKED TEST RESOURCE LEDGER -->
 

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -41,6 +41,17 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 	return cmd
 }
 
+type sessionWakeDeps struct {
+	store                     beads.Store
+	cfg                       *config.City
+	cityPath                  string
+	cityResolved              bool
+	now                       func() time.Time
+	withdrawQueuedWaitNudges  func(string, []string) error
+	cityUsesManagedReconciler func(string) bool
+	pokeController            func(string) error
+}
+
 // cmdSessionWake is the CLI entry point for "gc session wake".
 func cmdSessionWake(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
 	asJSON := sessionJSONRequested(jsonOutput)
@@ -54,15 +65,28 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 	if cityErr == nil {
 		cfg, _ = loadCityConfig(cityPath, stderr)
 	}
-	sessStore := cliSessionStore(store, cfg, cityPath)
-	id, err := resolveSessionIDMaterializingNamed(cityPath, cfg, sessStore, args[0])
+	return doSessionWake(args[0], stdout, stderr, asJSON, sessionWakeDeps{
+		store:                     store,
+		cfg:                       cfg,
+		cityPath:                  cityPath,
+		cityResolved:              cityErr == nil,
+		now:                       time.Now,
+		withdrawQueuedWaitNudges:  withdrawQueuedWaitNudges,
+		cityUsesManagedReconciler: cityUsesManagedReconciler,
+		pokeController:            pokeController,
+	})
+}
+
+func doSessionWake(target string, stdout, stderr io.Writer, asJSON bool, deps sessionWakeDeps) int {
+	sessStore := cliSessionStore(deps.store, deps.cfg, deps.cityPath)
+	id, err := resolveSessionIDMaterializingNamed(deps.cityPath, deps.cfg, sessStore, target)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session wake: %v\n", err) //nolint:errcheck
 		return 1
 	}
 
 	sessFront := sessionFrontDoor(sessStore)
-	res, err := sessFront.WakeSession(id, time.Now().UTC(), session.WakeOpts{})
+	res, err := sessFront.WakeSession(id, deps.now().UTC(), session.WakeOpts{})
 	if err != nil {
 		if state, conflict := session.WakeConflictState(err); conflict {
 			fmt.Fprintf(stderr, "gc session wake: session %s is %s\n", id, state) //nolint:errcheck
@@ -79,7 +103,7 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		return 1
 	}
 	nudgeIDs := res.NudgeIDs
-	hasRunnableTemplate := sessionWakeHasRunnableTemplateInfo(res.Info, cfg)
+	hasRunnableTemplate := sessionWakeHasRunnableTemplateInfo(res.Info, deps.cfg)
 	if !hasRunnableTemplate && sessionWakeRequestedCreateInfo(res.Info) {
 		if err := sessFront.ApplyPatch(id, map[string]string{
 			"state":                     string(session.StateAsleep),
@@ -93,12 +117,12 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 			return 1
 		}
 	}
-	if cityErr == nil {
-		if err := withdrawQueuedWaitNudges(cityPath, nudgeIDs); err != nil {
+	if deps.cityResolved {
+		if err := deps.withdrawQueuedWaitNudges(deps.cityPath, nudgeIDs); err != nil {
 			fmt.Fprintf(stderr, "gc session wake: warning: withdrawing queued wait nudges: %v\n", err) //nolint:errcheck
 		}
-		if cityUsesManagedReconciler(cityPath) {
-			if err := pokeController(cityPath); err != nil {
+		if deps.cityUsesManagedReconciler(deps.cityPath) {
+			if err := deps.pokeController(deps.cityPath); err != nil {
 				fmt.Fprintf(stderr, "gc session wake: warning: poke failed: %v\n", err) //nolint:errcheck
 			}
 		}

--- a/cmd/gc/cmd_session_wake_test.go
+++ b/cmd/gc/cmd_session_wake_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
@@ -131,13 +133,8 @@ func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
 	}
 }
 
-func TestCmdSessionWake_ManagedBdPokesControllerAndMovesSuspendedToAsleep(t *testing.T) {
-	cityDir, _ := setupManagedBdWaitTestCity(t)
-
-	store, err := openCityStoreAt(cityDir)
-	if err != nil {
-		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
-	}
+func TestDoSessionWake_PokesManagedControllerAfterStateChange(t *testing.T) {
+	store := beads.NewMemStore()
 	sessionBead, err := store.Create(beads.Bead{
 		Title:  "managed wake session",
 		Type:   session.BeadType,
@@ -146,7 +143,7 @@ func TestCmdSessionWake_ManagedBdPokesControllerAndMovesSuspendedToAsleep(t *tes
 			"session_name": "s-gc-managed",
 			"template":     "worker",
 			"state":        "suspended",
-			"held_until":   time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			"held_until":   "2026-07-16T01:00:00Z",
 			"sleep_reason": "user-hold",
 		},
 	})
@@ -154,79 +151,62 @@ func TestCmdSessionWake_ManagedBdPokesControllerAndMovesSuspendedToAsleep(t *tes
 		t.Fatalf("store.Create(session bead): %v", err)
 	}
 
-	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
-	lis, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatalf("Listen(%q): %v", sockPath, err)
+	var calls []string
+	deps := sessionWakeDeps{
+		store:        store,
+		cityPath:     "/city",
+		cityResolved: true,
+		now: func() time.Time {
+			return time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+		},
+		withdrawQueuedWaitNudges: func(cityPath string, nudgeIDs []string) error {
+			if cityPath != "/city" {
+				t.Fatalf("withdraw cityPath = %q, want /city", cityPath)
+			}
+			if len(nudgeIDs) != 0 {
+				t.Fatalf("withdraw nudge IDs = %v, want none", nudgeIDs)
+			}
+			calls = append(calls, "withdraw")
+			return nil
+		},
+		cityUsesManagedReconciler: func(cityPath string) bool {
+			if cityPath != "/city" {
+				t.Fatalf("managed-reconciler cityPath = %q, want /city", cityPath)
+			}
+			calls = append(calls, "managed")
+			return true
+		},
+		pokeController: func(cityPath string) error {
+			if cityPath != "/city" {
+				t.Fatalf("poke cityPath = %q, want /city", cityPath)
+			}
+			updated, getErr := store.Get(sessionBead.ID)
+			if getErr != nil {
+				t.Fatalf("store.Get(%s) during poke: %v", sessionBead.ID, getErr)
+			}
+			if got := updated.Metadata["state"]; got != "asleep" {
+				t.Fatalf("state during poke = %q, want asleep", got)
+			}
+			if got := updated.Metadata["wake_requested_at"]; got != "2026-07-16T00:00:00Z" {
+				t.Fatalf("wake_requested_at during poke = %q, want injected time", got)
+			}
+			calls = append(calls, "poke")
+			return nil
+		},
 	}
-	defer lis.Close() //nolint:errcheck
-
-	commands := make(chan string, 2)
-	errCh := make(chan error, 1)
-	go func() {
-		defer close(commands)
-		for range 2 {
-			conn, err := lis.Accept()
-			if err != nil {
-				errCh <- err
-				return
-			}
-			buf := make([]byte, 64)
-			n, err := conn.Read(buf)
-			if err != nil {
-				conn.Close() //nolint:errcheck
-				errCh <- err
-				return
-			}
-			cmd := string(buf[:n])
-			commands <- cmd
-			reply := "ok\n"
-			if cmd == "ping\n" {
-				reply = "123\n"
-			}
-			if _, err := conn.Write([]byte(reply)); err != nil {
-				conn.Close() //nolint:errcheck
-				errCh <- err
-				return
-			}
-			conn.Close() //nolint:errcheck
-		}
-	}()
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionWake([]string{sessionBead.ID}, &stdout, &stderr); code != 0 {
-		t.Fatalf("cmdSessionWake() = %d, want 0; stderr=%s", code, stderr.String())
+	if code := doSessionWake(sessionBead.ID, &stdout, &stderr, false, deps); code != 0 {
+		t.Fatalf("doSessionWake() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := strings.Join(calls, ","); got != "withdraw,managed,poke" {
+		t.Fatalf("effect calls = %q, want withdraw,managed,poke", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "wake requested") {
+		t.Fatalf("stdout = %q, want wake requested", got)
 	}
 
-	gotCommands := make([]string, 0, 2)
-	deadline := time.After(2 * time.Second)
-	for len(gotCommands) < 2 {
-		select {
-		case err := <-errCh:
-			if err != nil {
-				t.Fatalf("controller socket: %v", err)
-			}
-		case cmd, ok := <-commands:
-			if !ok {
-				t.Fatalf("controller commands = %v, want ping plus poke", gotCommands)
-			}
-			gotCommands = append(gotCommands, cmd)
-		case <-deadline:
-			t.Fatalf("timed out waiting for controller commands, got %v", gotCommands)
-		}
-	}
-	wantCommands := []string{"ping\n", "poke\n"}
-	for i, want := range wantCommands {
-		if gotCommands[i] != want {
-			t.Fatalf("controller command %d = %q, want %q", i, gotCommands[i], want)
-		}
-	}
-
-	freshStore, err := openCityStoreAt(cityDir)
-	if err != nil {
-		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
-	}
-	updated, err := freshStore.Get(sessionBead.ID)
+	updated, err := store.Get(sessionBead.ID)
 	if err != nil {
 		t.Fatalf("store.Get(%s): %v", sessionBead.ID, err)
 	}
@@ -241,6 +221,99 @@ func TestCmdSessionWake_ManagedBdPokesControllerAndMovesSuspendedToAsleep(t *tes
 	}
 }
 
+func TestDoSessionWake_DoesNotPokeWithoutManagedController(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"template": "worker",
+			"state":    "suspended",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+
+	poked := false
+	deps := sessionWakeDeps{
+		store:        store,
+		cityPath:     "/city",
+		cityResolved: true,
+		now: func() time.Time {
+			return time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+		},
+		withdrawQueuedWaitNudges: func(string, []string) error {
+			return nil
+		},
+		cityUsesManagedReconciler: func(string) bool {
+			return false
+		},
+		pokeController: func(string) error {
+			poked = true
+			return nil
+		},
+	}
+
+	if code := doSessionWake(sessionBead.ID, &bytes.Buffer{}, &bytes.Buffer{}, false, deps); code != 0 {
+		t.Fatalf("doSessionWake() = %d, want 0", code)
+	}
+	if poked {
+		t.Fatal("pokeController called for a city without a managed reconciler")
+	}
+}
+
+func TestDoSessionWake_PokeFailureWarnsWithoutFailingWake(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"template": "worker",
+			"state":    "suspended",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+
+	deps := sessionWakeDeps{
+		store:        store,
+		cityPath:     "/city",
+		cityResolved: true,
+		now: func() time.Time {
+			return time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+		},
+		withdrawQueuedWaitNudges: func(string, []string) error {
+			return nil
+		},
+		cityUsesManagedReconciler: func(string) bool {
+			return true
+		},
+		pokeController: func(string) error {
+			return errors.New("dial failed")
+		},
+	}
+
+	var stderr bytes.Buffer
+	if code := doSessionWake(sessionBead.ID, &bytes.Buffer{}, &stderr, false, deps); code != 0 {
+		t.Fatalf("doSessionWake() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "warning: poke failed: dial failed") {
+		t.Fatalf("stderr = %q, want poke failure warning", got)
+	}
+	updated, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", sessionBead.ID, err)
+	}
+	if got := updated.Metadata["state"]; got != "asleep" {
+		t.Fatalf("state = %q, want asleep", got)
+	}
+}
+
+// This is the single real CLI/config/file-store/controller-socket composition
+// proof for session wake. Lower-level wake behavior belongs in doSessionWake
+// unit tests; managed-Dolt consistency has its own provider boundary owner.
 func TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")
@@ -314,7 +387,7 @@ func TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart(t *testi
 	}
 
 	gotCommands := make([]string, 0, 2)
-	deadline := time.After(2 * time.Second)
+	deadline := time.After(testutil.GoroutineRaceTimeout)
 	for len(gotCommands) < 2 {
 		select {
 		case err := <-errCh:

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -219,7 +219,7 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeUntagged,
 			Resource:        ResourceNetListen,
-			BaselineCalls:   92,
+			BaselineCalls:   91,
 			BaselineFiles:   34,
 			ReportedCalls:   92,
 			ReportedFiles:   34,
@@ -305,6 +305,13 @@ var bootstrapPolicy = Ledger{
 		},
 	},
 	ReviewedHermeticBody: []ReviewedHermeticBody{
+		{
+			PackageDir:    "cmd/gc",
+			PackageName:   "main",
+			Owner:         "TestDoSessionWake_PokesManagedControllerAfterStateChange",
+			EffectiveSize: "medium",
+			MediumReason:  "package TestMain mutates process state",
+		},
 		{
 			PackageDir:    "cmd/gc",
 			PackageName:   "main",
@@ -395,7 +402,7 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeUntagged,
 			Resource:        ResourceNetListen,
-			BaselineCalls:   92,
+			BaselineCalls:   91,
 			BaselineFiles:   34,
 			ReportedCalls:   92,
 			ReportedFiles:   34,

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -1581,8 +1581,8 @@ func TestBootstrapPolicyOwnsNetListenDebt(t *testing.T) {
 
 	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
 		row := findRow(t, rows, ScopeUntagged, ResourceNetListen)
-		if row.BaselineCalls != 92 || row.BaselineFiles != 34 {
-			t.Fatalf("net.Listen baseline = %d/%d, want 92/34", row.BaselineCalls, row.BaselineFiles)
+		if row.BaselineCalls != 91 || row.BaselineFiles != 34 {
+			t.Fatalf("net.Listen baseline = %d/%d, want 91/34", row.BaselineCalls, row.BaselineFiles)
 		}
 		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
 			t.Fatalf("net.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)

--- a/internal/testpolicy/resourcecensus/hermetic.go
+++ b/internal/testpolicy/resourcecensus/hermetic.go
@@ -76,6 +76,18 @@ var retainedRealOwners = []retainedRealOwner{
 		reviewed: runnableKey{
 			packageDir:  "cmd/gc",
 			packageName: "main",
+			owner:       "TestDoSessionWake_PokesManagedControllerAfterStateChange",
+		},
+		retained: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
+			owner:       "TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart",
+		},
+	},
+	{
+		reviewed: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
 			owner:       "TestPrepareWaitWakeState_ResolvesRigDependencyBeads",
 		},
 		retained: runnableKey{

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -116,7 +116,7 @@ expires = "2026-10-01"
 [[debt]]
 scope = "untagged"
 resource = "net_listen"
-baseline_calls = 92
+baseline_calls = 91
 baseline_files = 34
 reported_calls = 92
 reported_files = 34
@@ -209,6 +209,13 @@ expires = "2026-10-01"
 [[reviewed_hermetic_body]]
 package_dir = "cmd/gc"
 package_name = "main"
+owner = "TestDoSessionWake_PokesManagedControllerAfterStateChange"
+effective_size = "medium"
+medium_reason = "package TestMain mutates process state"
+
+[[reviewed_hermetic_body]]
+package_dir = "cmd/gc"
+package_name = "main"
 owner = "TestPrepareWaitWakeState_ResolvesRigDependencyBeads"
 effective_size = "medium"
 medium_reason = "package TestMain mutates process state"
@@ -296,7 +303,7 @@ expires = "2026-10-01"
 [[small_debt]]
 scope = "untagged"
 resource = "net_listen"
-baseline_calls = 92
+baseline_calls = 91
 baseline_files = 34
 reported_calls = 92
 reported_files = 34


### PR DESCRIPTION
## Summary

- Replace the duplicate managed-Dolt `gc session wake` command proof with three deterministic `MemStore` use-case tests.
- Retain one file-backed CLI/config/controller-socket composition test for production wiring.
- Ratchet checked `net.Listen` debt from 92 to 91 and register the fast use case as a reviewed hermetic body.

## Performance

| Measurement | Before | After |
| --- | ---: | ---: |
| Managed-Dolt duplicate | 32.780s measured CI baseline; 20.619s mean across 14 CI samples | Removed |
| In-memory use cases | — | 0.00s each |
| Retained wake composition | 0.26s mean in CI timing audit | Retained |

Estimated savings for the affected shard: approximately 20–33 seconds.

## Test ownership

| Invariant | Dedicated owner |
| --- | --- |
| Wake transition and metadata semantics | `TestSessionWake_StateTransitionsAndMetadata` |
| State and injected timestamp are durable before poke | `TestDoSessionWake_PokesManagedControllerAfterStateChange` |
| Managed/unmanaged and warning behavior | `TestDoSessionWake_DoesNotPokeWithoutManagedController`, `TestDoSessionWake_PokeFailureWarnsWithoutFailingWake` |
| CLI/config/file-store/controller wire composition | `TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart` |
| Real managed-store consistency and rebind recovery | `TestManagedBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore`, `TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind` |

## Verification

- `make test-fast-parallel`
- `go vet ./...`
- `go test -race -count=20 ./cmd/gc -run '^TestDoSessionWake_'`
- `go test -count=1 ./internal/session`
- `go test -count=1 ./internal/testpolicy/resourcecensus`
- `.githooks/pre-commit`
- Three independent delegated council approvals against the frozen diff

The full local `cmd/gc` process sweep passed four of six shards. The remaining three failures are unrelated `bd init` fixture failures caused by the locally installed CGO-disabled `bd`; all three reproduce unchanged on the base revision.
