### PR TITLE
fix(dispatch): tolerate torn-down worktree in ralph check gate (recurring finalize-stall)

### DIFF
--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -276,6 +277,25 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		// original work_dir error is preserved when the fallback also misses.
 		if fallbackPath, fallbackErr := convergence.ResolveConditionPath(cityPath, storePath, checkPath); fallbackErr == nil {
 			scriptPath, err = fallbackPath, nil
+		} else if resolvedWorkDir != "" {
+			// Both the worktree-relative and store-relative resolutions missed:
+			// the gate script only ever lived under the per-step worktree.
+			// Distinguish two cases (gastownhall/gascity recurring
+			// finalize-stall bug): the worktree directory itself no longer
+			// exists on disk, meaning it was legitimately reaped after its
+			// step completed — tolerate the gate as satisfied instead of
+			// hard-erroring into quarantine. If the worktree directory is
+			// still present, the script is simply missing/misconfigured and
+			// must keep failing loudly.
+			if _, statErr := os.Stat(resolvedWorkDir); errors.Is(statErr, fs.ErrNotExist) {
+				return convergence.GateResult{
+					Outcome: convergence.GatePass,
+					Stdout: fmt.Sprintf(
+						"%s: gate check_path %q unresolved: per-step worktree %s was torn down after step completion; tolerating gate as satisfied",
+						bead.ID, checkPath, resolvedWorkDir,
+					),
+				}, nil
+			}
 		}
 	}
 	if err != nil {

--- a/internal/dispatch/ralph_test.go
+++ b/internal/dispatch/ralph_test.go
@@ -248,6 +248,85 @@ func TestRunRalphCheckWorkDirRelativeCheckPathKeepsPrecedence(t *testing.T) {
 	}
 }
 
+// TestRunRalphCheckTolerantOfTornDownWorkDir covers the recurring
+// finalize-stall bug: a control gate's gc.work_dir points at a per-step
+// worktree that was legitimately cleaned up after the step completed. The
+// gc.check_path never existed anywhere except that worktree, so both the
+// work_dir-relative join and the #3008 store-root fallback miss. Because the
+// worktree DIRECTORY itself is gone (not merely the script inside it), this
+// must be tolerated as a satisfied gate rather than a hard error that
+// quarantines the control bead.
+func TestRunRalphCheckTolerantOfTornDownWorkDir(t *testing.T) {
+	cityPath := t.TempDir()
+	// workDir is never created on disk: it stands in for a worktree that was
+	// torn down after its step completed.
+	workDir := filepath.Join(cityPath, "worktrees", "reaped-task")
+	checkRel := "check.sh"
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.check_path":   checkRel,
+			"gc.work_dir":     workDir,
+			"gc.max_attempts": "3",
+		},
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+
+	result, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v (a torn-down worktree should be tolerated, not hard-error)", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stdout=%q), want tolerated pass for torn-down worktree", result.Outcome, result.Stdout)
+	}
+}
+
+// TestRunRalphCheckStillErrorsOnMissingScriptInLiveWorkDir guards that the
+// torn-down-worktree tolerance does not over-reach: when gc.work_dir still
+// exists on disk but simply lacks the check script (a real misconfiguration,
+// not a reaped worktree), resolution must still hard-error so the mistake is
+// surfaced instead of silently swallowed.
+func TestRunRalphCheckStillErrorsOnMissingScriptInLiveWorkDir(t *testing.T) {
+	cityPath := t.TempDir()
+	workDir := filepath.Join(cityPath, "worktrees", "live-task")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	checkRel := "check.sh"
+	// Deliberately do not create checkRel anywhere - neither under workDir
+	// nor under cityPath.
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.check_path":   checkRel,
+			"gc.work_dir":     workDir,
+			"gc.max_attempts": "3",
+		},
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+
+	_, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err == nil {
+		t.Fatal("runRalphCheck: want error for a genuinely missing check script under a live worktree, got nil")
+	}
+}
+
 // TestRunRalphCheckEnvTracksSubject pins gastownhall/gascity#2558 review
 // feedback: GC_BEAD_ID and the molecule/artifact dirs must describe the SAME
 // bead. The per-attempt agent runs on the subject (attempt) bead and writes


### PR DESCRIPTION
## Problem

When a workflow step completes and its per-step git worktree is reaped, the `check` control gate can still be dispatched afterwards. `runRalphCheck` resolves the gate's `check_path` **relative to that per-step worktree**; once the worktree is gone, `convergence.ResolveConditionPath` hard-errors on `os.Stat`/`filepath.EvalSymlinks`. That error is not classified transient, so the control-dispatcher quarantines the control bead — which strands the workflow root `in_progress` (the recurring "finalize-stall" that has to be force-closed by hand).

## Fix

In `runRalphCheck`, after the existing #3008 fallbacks (work-dir-relative, then store-root-relative) both miss, stat the per-step worktree directory itself:

- If the worktree directory **no longer exists** (`fs.ErrNotExist`) — i.e. it was legitimately reaped after its step completed — return `GateResult{Outcome: GatePass}` instead of hard-erroring into quarantine.
- If the worktree directory **is still present** but the script is missing, keep hard-erroring — a genuine misconfiguration is not masked.

This mirrors the existing "missing root ⇒ finalize-able" tolerance already present in `processWorkflowFinalize`.

## Tests

- `TestRunRalphCheckTolerantOfTornDownWorkDir` — torn-down worktree ⇒ gate tolerated (pass, no quarantine).
- `TestRunRalphCheckStillErrorsOnMissingScriptInLiveWorkDir` — live worktree, missing script ⇒ still errors.

Both pass against current `main`; `go vet ./internal/dispatch/` clean.

## Scope

Minimal and isolated: `internal/dispatch/ralph.go` (+20), `internal/dispatch/ralph_test.go` (+79). No behavior change for gates whose worktree is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
