### PR TITLE
fix(controller): count city-store routed demand for warm rig pools, not only cold

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -668,17 +668,35 @@ func buildDesiredStateWithSessionBeads(
 		if store != nil && !hasCustomScaleCheck {
 			ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
 			defaultScaleTargets = append(defaultScaleTargets, ownTarget)
-			// Cross-store cold-wake (FR-S0.1 / vp-s37): a cold rig pool's routed
-			// demand may live in the city store (vp-kvp cross-store delivery),
-			// which the own-rig probe above cannot see while the pool sleeps —
-			// so a sleeping rig pool would never wake to discover it. Add a
-			// city-store probe for cold rig pools so their demand reflects
-			// routed work in either store. No clamp: unlike a custom-scale_check
-			// pool — where the probe is clamped so it cannot override the custom
-			// count (see coldWakeTemplates below) — the default probe IS the
+			// Cross-store demand (FR-S0.1 / vp-s37): a rig pool's routed demand
+			// may live in the city store (vp-kvp cross-store delivery), which
+			// the own-rig probe above cannot see. Add a city-store probe so the
+			// pool's demand reflects routed work in either store — matching the
+			// claim path, where a rig agent's work_query already federates
+			// across stores and claims city-delivered work.
+			//
+			// NOT gated on isCold. This probe began as a cold-wake assist (a
+			// sleeping pool can't discover city-store demand), but gating it on
+			// isCold left a WARM rig pool structurally blind to the same
+			// demand: its count stayed pinned at the rig-store total while
+			// routed beads sat unclaimed in the city store, and a pool at the
+			// warm/cold boundary oscillated pool_desired N↔0 (cold ticks
+			// glimpsed city demand and spawned; warm ticks went blind and the
+			// reconciler orphan-drained the sessions it had just started).
+			// Observed in production: a warm worker pool pinned at
+			// poolDesired=1 against 1 rig-store + 9 city-store routed beads,
+			// serializing every live workflow behind one session and starving
+			// all dep-downstream control beads. Demand a pool can claim is
+			// demand it must be able to count, warm or cold.
+			//
+			// No clamp: unlike a custom-scale_check pool — where the probe is
+			// clamped so it cannot override the custom count (see
+			// coldWakeTemplates below) — the default probe IS the
 			// authoritative count, so it scales to total routed demand (bounded
 			// by max_active and the daemon's max_wakes_per_tick), matching the
-			// retired cold-pool-spawner's scale-to-want. A city-scoped pool's
+			// retired cold-pool-spawner's scale-to-want. Counts sum across
+			// store groups and the beads are distinct per store, so probing
+			// both yields the correct union demand. A city-scoped pool's
 			// own target is already the city store, so it needs no extra probe.
 			//
 			// Gated on a healthy own rig store: when the rig store is missing or
@@ -696,7 +714,7 @@ func buildDesiredStateWithSessionBeads(
 			// Control dispatchers are deliberately store-scoped: a rig copy cannot
 			// claim a route from the city store. Keep their cold-wake probe on the
 			// owning store instead of applying generic cross-store pool delivery.
-			if isCold && !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
+			if !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 				defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTarget{template: template, store: store, storeKey: "city"})
 			}
 			continue

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -632,14 +632,20 @@ func buildDesiredStateWithSessionBeads(
 					namedOnDemandTemplates[template] = true
 				}
 				defaultNamedScaleTargets = append(defaultNamedScaleTargets, ownTarget)
-				// Cross-store cold-wake for named-backing pools (vp-cl4): mirror the
-				// generic-pool guard (vp-s37 / #3078 line ~598). A cold rig pool that
-				// backs a named session and has no custom scale_check must also probe
-				// the city store so that routed demand delivered there (vp-kvp) can
-				// wake the pool. Same guard conditions apply: healthy own rig store,
-				// not city-aliased, not city-scoped. The named-session target list
+				// Cross-store demand for named-backing pools (vp-cl4): mirror the
+				// generic-pool guard (vp-s37 / #3078 below). A rig pool that backs
+				// a named session and has no custom scale_check must also probe
+				// the city store so that routed demand delivered there (vp-kvp)
+				// counts, warm or cold — like the generic-pool probe below, this
+				// is NOT gated on isCold: a warm named-backing pool that only
+				// probed its rig store would drop to zero demand between city
+				// beads and be orphan-drained, then re-glimpse city demand on the
+				// next cold tick and respawn (the same spawn/drain treadmill,
+				// amplitude clamped to 1 by the namedOnDemandTemplates clamp).
+				// Same guard conditions apply: healthy own rig store, not
+				// city-aliased, not city-scoped. The named-session target list
 				// mirrors these probes only for partial-query retention bookkeeping.
-				if isCold && !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
+				if !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 					cityTarget := defaultScaleCheckTarget{template: template, store: store, storeKey: "city"}
 					if namedSessionMode != "always" {
 						defaultScaleTargets = append(defaultScaleTargets, cityTarget)
@@ -719,6 +725,13 @@ func buildDesiredStateWithSessionBeads(
 			}
 			continue
 		}
+		// Custom-scale_check pools deliberately KEEP the cold-only probe (unlike
+		// the default-probe branches above, which count cross-store demand warm
+		// or cold): the custom check is the authoritative count while the pool
+		// is awake, and this probe is clamped to 1 (coldWakeTemplates) so it can
+		// only wake a sleeping pool, never override the custom count. A custom
+		// scale_check that should scale on cross-store routed demand must count
+		// it itself, or the pool will churn at the warm/cold boundary.
 		if store != nil && isCold && !storeScopedControlDispatcher {
 			for _, source := range activeStores {
 				defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTarget{template: template, store: source.store, storeKey: source.ref})
@@ -1572,6 +1585,16 @@ func defaultScaleCheckCountsAndDemand(targets []defaultScaleCheckTarget, caches 
 		group.templates[template] = struct{}{}
 	}
 
+	// countedBeads dedups counted bead IDs per template ACROSS store groups.
+	// Bead IDs are unique within a deployment, so a legitimate cross-store
+	// union never collides — but when a rig store aliases the city store as a
+	// distinct Store object (pointer inequality passes: a legacy unscoped
+	// file-store layout, or a rig dir whose missing .beads resolves bd's
+	// walk-up to the city DB), the same beads appear in both the "rig:<name>"
+	// and "city" groups and would double the template's demand. With the city
+	// probe no longer cold-gated, that double-count would be a persistent
+	// warm condition rather than a one-tick wake overshoot, so dedup by ID.
+	countedBeads := make(map[string]map[string]struct{})
 	for key, group := range groups {
 		// Ready()/CachedReady() iteration surfaces actionable work
 		// matched against gc.routed_to/gc.run_target. Formula orders that
@@ -1594,6 +1617,15 @@ func defaultScaleCheckCountsAndDemand(targets []defaultScaleCheckTarget, caches 
 			if _, ok := group.templates[template]; !ok {
 				continue
 			}
+			seen := countedBeads[template]
+			if seen == nil {
+				seen = make(map[string]struct{})
+				countedBeads[template] = seen
+			}
+			if _, dup := seen[b.ID]; dup {
+				continue
+			}
+			seen[b.ID] = struct{}{}
 			counts[template]++
 			entry := demand[template]
 			entry.Count++

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -711,12 +711,17 @@ func buildDesiredStateWithSessionBeads(
 			// unreachable, and the partial flag must keep suppressing drain
 			// decisions rather than be overridden by a spurious city-store wake.
 			//
-			// ownTarget.store != store guards the case where the rig store
-			// aliases the city store (an unbound rig falling back to the city
-			// scope): a separate "city" group over the same store would
-			// double-count the same beads, since defaultScaleCheckCounts dedups
-			// per group, not across groups. Current store-map builders skip
-			// such rigs, so this is defense-in-depth against future callers.
+			// ownTarget.store != store is a same-pointer optimization: it skips
+			// appending a "city" probe when the rig store IS the identical Store
+			// object as the city store (which would re-probe one store, not form
+			// a real cross-store union). It is NOT the alias-safety guard — a rig
+			// store that aliases the city store as a DISTINCT Store value (an
+			// unbound rig falling back to the city scope) passes this inequality,
+			// so the "city" group can still surface the same beads. countedBeads
+			// dedups those per template ACROSS store groups by bead ID (see its
+			// definition below), and is the load-bearing defense now that the
+			// city probe is no longer cold-gated. Current store-map builders skip
+			// such rigs, so today this is defense-in-depth against future callers.
 			// Control dispatchers are deliberately store-scoped: a rig copy cannot
 			// claim a route from the city store. Keep their cold-wake probe on the
 			// owning store instead of applying generic cross-store pool delivery.

--- a/cmd/gc/build_desired_state_warm_crossstore_test.go
+++ b/cmd/gc/build_desired_state_warm_crossstore_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand: cross-store
+// delivery (vp-kvp) routes molecule steps for rig pools into the CITY store,
+// so city-store routed demand is legitimate demand for a rig pool at all
+// times — not only while the pool sleeps. The city-store probe used to be
+// gated on isCold, leaving a WARM rig pool structurally blind to city-store
+// routed work: demand pinned at the rig-store count while routed beads sat
+// unclaimed in the city store, and pools at the warm/cold boundary oscillated
+// pool_desired N↔0 (cold ticks glimpsed city demand, warm ticks went blind)
+// and were mass orphan-drained every flip (maintainer-city freeze,
+// 2026-07-16: implementation-worker pinned at poolDesired=1 with 1 rig-store
+// and 9 city-store routed beads, serializing every live molecule and starving
+// all downstream control beads).
+func TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "gascity")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// A live pool-managed session bead makes the pool WARM (isCold=false):
+	// runningSessions counts open, awake, pool-managed session beads across
+	// the city + rig stores, no process probe involved.
+	if _, err := cityStore.Create(beads.Bead{
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"session_name": "gc__worker-1",
+			"template":     "gascity/worker",
+			"state":        "active",
+			"pool_managed": "true",
+		},
+	}); err != nil {
+		t.Fatalf("create warm session bead: %v", err)
+	}
+
+	// Routed demand delivered cross-store into the CITY store; the rig store
+	// stays empty. Before the fix the warm pool probed only the rig store and
+	// read 0 here.
+	for i := 0; i < 3; i++ {
+		if _, err := cityStore.Create(beads.Bead{
+			Title:    "cross-store routed work",
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{"gc.routed_to": "gascity/worker"},
+		}); err != nil {
+			t.Fatalf("create routed city bead %d: %v", i, err)
+		}
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gc"},
+		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "gascity",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+	)
+
+	if got := dsResult.ScaleCheckCounts["gascity/worker"]; got != 3 {
+		t.Fatalf("ScaleCheckCounts[gascity/worker] = %d, want 3: a WARM rig pool must count "+
+			"city-store routed demand (cross-store delivery), not just its own rig store — "+
+			"gating the city probe on isCold leaves warm rig pools blind to routed work and "+
+			"pins pool demand at the rig-store count (full ScaleCheckCounts=%v, partial=%v)",
+			got, dsResult.ScaleCheckCounts, dsResult.PoolScaleCheckPartialTemplates)
+	}
+}
+
+// TestBuildDesiredState_WarmRigPoolCityProbeDoesNotDoubleCountRigDemand: the
+// warm city probe is a UNION with the rig-store probe, not a duplicate — a
+// bead routed to the pool in the RIG store must be counted exactly once when
+// both probes run.
+func TestBuildDesiredState_WarmRigPoolCityProbeDoesNotDoubleCountRigDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "gascity")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	if _, err := cityStore.Create(beads.Bead{
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"session_name": "gc__worker-1",
+			"template":     "gascity/worker",
+			"state":        "active",
+			"pool_managed": "true",
+		},
+	}); err != nil {
+		t.Fatalf("create warm session bead: %v", err)
+	}
+
+	// One routed bead in EACH store: expect a count of exactly 2 (1+1), not 3+.
+	if _, err := rigStore.Create(beads.Bead{
+		Title:    "rig-store routed work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gascity/worker"},
+	}); err != nil {
+		t.Fatalf("create routed rig bead: %v", err)
+	}
+	if _, err := cityStore.Create(beads.Bead{
+		Title:    "city-store routed work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gascity/worker"},
+	}); err != nil {
+		t.Fatalf("create routed city bead: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gc"},
+		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "gascity",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+	)
+
+	if got := dsResult.ScaleCheckCounts["gascity/worker"]; got != 2 {
+		t.Fatalf("ScaleCheckCounts[gascity/worker] = %d, want 2 (1 rig + 1 city, no double count; full=%v)",
+			got, dsResult.ScaleCheckCounts)
+	}
+}

--- a/cmd/gc/build_desired_state_warm_crossstore_test.go
+++ b/cmd/gc/build_desired_state_warm_crossstore_test.go
@@ -12,58 +12,15 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
-// TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand: cross-store
-// delivery (vp-kvp) routes molecule steps for rig pools into the CITY store,
-// so city-store routed demand is legitimate demand for a rig pool at all
-// times — not only while the pool sleeps. The city-store probe used to be
-// gated on isCold, leaving a WARM rig pool structurally blind to city-store
-// routed work: demand pinned at the rig-store count while routed beads sat
-// unclaimed in the city store, and pools at the warm/cold boundary oscillated
-// pool_desired N↔0 (cold ticks glimpsed city demand, warm ticks went blind)
-// and were mass orphan-drained every flip (maintainer-city freeze,
-// 2026-07-16: implementation-worker pinned at poolDesired=1 with 1 rig-store
-// and 9 city-store routed beads, serializing every live molecule and starving
-// all downstream control beads).
-func TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand(t *testing.T) {
-	cityPath := t.TempDir()
+// warmCrossStoreCfg builds the shared fixture: a rig-scoped default-probe pool
+// agent ("gascity/worker") on rig "gascity" under cityPath.
+func warmCrossStoreCfg(t *testing.T, cityPath string) *config.City {
+	t.Helper()
 	rigPath := filepath.Join(cityPath, "gascity")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cityStore := beads.NewMemStore()
-	rigStore := beads.NewMemStore()
-
-	// A live pool-managed session bead makes the pool WARM (isCold=false):
-	// runningSessions counts open, awake, pool-managed session beads across
-	// the city + rig stores, no process probe involved.
-	if _, err := cityStore.Create(beads.Bead{
-		Status: "open",
-		Type:   sessionBeadType,
-		Metadata: map[string]string{
-			"session_name": "gc__worker-1",
-			"template":     "gascity/worker",
-			"state":        "active",
-			"pool_managed": "true",
-		},
-	}); err != nil {
-		t.Fatalf("create warm session bead: %v", err)
-	}
-
-	// Routed demand delivered cross-store into the CITY store; the rig store
-	// stays empty. Before the fix the warm pool probed only the rig store and
-	// read 0 here.
-	for i := 0; i < 3; i++ {
-		if _, err := cityStore.Create(beads.Bead{
-			Title:    "cross-store routed work",
-			Type:     "task",
-			Status:   "open",
-			Metadata: map[string]string{"gc.routed_to": "gascity/worker"},
-		}); err != nil {
-			t.Fatalf("create routed city bead %d: %v", i, err)
-		}
-	}
-
-	cfg := &config.City{
+	return &config.City{
 		Workspace: config.Workspace{Name: "gc"},
 		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
 		Agents: []config.Agent{{
@@ -74,10 +31,92 @@ func TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand(t *testing.T) {
 			MaxActiveSessions: intPtr(5),
 		}},
 	}
+}
+
+// createWarmSessionBead makes the pool WARM the way the reconciler sees it: an
+// open, awake, pool-managed session bead. isCold is computed from session
+// BEADS (no process probe), so this is exactly the input that flips the
+// warm/cold gate.
+func createWarmSessionBead(t *testing.T, store beads.Store, template string) {
+	t.Helper()
+	if _, err := store.Create(beads.Bead{
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"session_name": "gc__worker-1",
+			"template":     template,
+			"state":        "active",
+			"pool_managed": "true",
+		},
+	}); err != nil {
+		t.Fatalf("create warm session bead: %v", err)
+	}
+}
+
+// requireWarm asserts the fixture actually registers as WARM using the same
+// predicates the reconciler's isCold computation uses
+// (collectAllOpenSessionInfos + isPoolManagedSessionInfo +
+// poolSessionIsLiveInfo + template identity equivalence). Without this the
+// tests could silently pin the cold path and pass for the wrong reason.
+func requireWarm(t *testing.T, cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, template string) {
+	t.Helper()
+	infos, err := collectAllOpenSessionInfos(cfg, cityStore, rigStores, nil)
+	if err != nil {
+		t.Fatalf("collectAllOpenSessionInfos: %v", err)
+	}
+	running := 0
+	for _, si := range infos {
+		if isPoolManagedSessionInfo(si) && poolSessionIsLiveInfo(si) &&
+			agentTemplateIdentitiesEquivalent(cfg, si.Template, template) {
+			running++
+		}
+	}
+	if running == 0 {
+		t.Fatalf("fixture is not WARM: no live pool-managed session info matched template %q (infos=%d) — the test would exercise the cold path instead", template, len(infos))
+	}
+}
+
+func createRoutedBead(t *testing.T, store beads.Store, template, title string) {
+	t.Helper()
+	if _, err := store.Create(beads.Bead{
+		Title:    title,
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": template},
+	}); err != nil {
+		t.Fatalf("create routed bead %q: %v", title, err)
+	}
+}
+
+// TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand: cross-store
+// delivery (vp-kvp) routes work for rig pools into the CITY store, so
+// city-store routed demand is legitimate demand for a rig pool at all times —
+// not only while the pool sleeps. The city-store probe used to be gated on
+// isCold, leaving a WARM rig pool structurally blind to city-store routed
+// work: demand pinned at the rig-store count while routed beads sat unclaimed
+// in the city store, and pools at the warm/cold boundary oscillated
+// pool_desired N↔0 (cold ticks glimpsed city demand, warm ticks went blind)
+// and were mass orphan-drained every flip.
+func TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := warmCrossStoreCfg(t, cityPath)
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"gascity": rigStore}
+
+	createWarmSessionBead(t, cityStore, "gascity/worker")
+	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+
+	// Routed demand delivered cross-store into the CITY store; the rig store
+	// stays empty. Before the fix the warm pool probed only the rig store and
+	// read 0 here.
+	for i := 0; i < 3; i++ {
+		createRoutedBead(t, cityStore, "gascity/worker", "cross-store routed work")
+	}
 
 	dsResult := buildDesiredStateWithSessionBeads(
 		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
-		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+		cityStore, rigStores, nil, nil, io.Discard,
 	)
 
 	if got := dsResult.ScaleCheckCounts["gascity/worker"]; got != 3 {
@@ -95,63 +134,134 @@ func TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand(t *testing.T) {
 // both probes run.
 func TestBuildDesiredState_WarmRigPoolCityProbeDoesNotDoubleCountRigDemand(t *testing.T) {
 	cityPath := t.TempDir()
-	rigPath := filepath.Join(cityPath, "gascity")
-	if err := os.MkdirAll(rigPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	cfg := warmCrossStoreCfg(t, cityPath)
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"gascity": rigStore}
 
-	if _, err := cityStore.Create(beads.Bead{
-		Status: "open",
-		Type:   sessionBeadType,
-		Metadata: map[string]string{
-			"session_name": "gc__worker-1",
-			"template":     "gascity/worker",
-			"state":        "active",
-			"pool_managed": "true",
-		},
-	}); err != nil {
-		t.Fatalf("create warm session bead: %v", err)
-	}
+	createWarmSessionBead(t, cityStore, "gascity/worker")
+	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
 
 	// One routed bead in EACH store: expect a count of exactly 2 (1+1), not 3+.
-	if _, err := rigStore.Create(beads.Bead{
-		Title:    "rig-store routed work",
-		Type:     "task",
-		Status:   "open",
-		Metadata: map[string]string{"gc.routed_to": "gascity/worker"},
-	}); err != nil {
-		t.Fatalf("create routed rig bead: %v", err)
-	}
-	if _, err := cityStore.Create(beads.Bead{
-		Title:    "city-store routed work",
-		Type:     "task",
-		Status:   "open",
-		Metadata: map[string]string{"gc.routed_to": "gascity/worker"},
-	}); err != nil {
-		t.Fatalf("create routed city bead: %v", err)
-	}
-
-	cfg := &config.City{
-		Workspace: config.Workspace{Name: "gc"},
-		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
-		Agents: []config.Agent{{
-			Name:              "worker",
-			Dir:               "gascity",
-			StartCommand:      "true",
-			MinActiveSessions: intPtr(0),
-			MaxActiveSessions: intPtr(5),
-		}},
-	}
+	createRoutedBead(t, rigStore, "gascity/worker", "rig-store routed work")
+	createRoutedBead(t, cityStore, "gascity/worker", "city-store routed work")
 
 	dsResult := buildDesiredStateWithSessionBeads(
 		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
-		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+		cityStore, rigStores, nil, nil, io.Discard,
 	)
 
 	if got := dsResult.ScaleCheckCounts["gascity/worker"]; got != 2 {
 		t.Fatalf("ScaleCheckCounts[gascity/worker] = %d, want 2 (1 rig + 1 city, no double count; full=%v)",
 			got, dsResult.ScaleCheckCounts)
+	}
+}
+
+// aliasStore wraps a beads.Store in a distinct interface value so the
+// pointer-inequality alias guard (ownTarget.store != store) cannot detect
+// that both "stores" share the same backing — modeling a legacy unscoped
+// file-store layout or a rig dir whose missing .beads resolves a walk-up to
+// the city DB.
+type aliasStore struct{ beads.Store }
+
+// TestBuildDesiredState_WarmAliasedRigStoreDoesNotDoubleCountDemand: when the
+// rig "store" is a distinct object over the SAME backing as the city store,
+// the rig-group and city-group probes both see the same beads. The
+// cross-group per-template bead-ID dedup must keep the count at real demand
+// (1), not 2 — with the city probe no longer cold-gated, a double count here
+// would be a persistent warm 2x-demand condition, not a one-tick overshoot.
+func TestBuildDesiredState_WarmAliasedRigStoreDoesNotDoubleCountDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := warmCrossStoreCfg(t, cityPath)
+	cityStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"gascity": aliasStore{cityStore}}
+
+	createWarmSessionBead(t, cityStore, "gascity/worker")
+	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+
+	createRoutedBead(t, cityStore, "gascity/worker", "shared-backing routed work")
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, rigStores, nil, nil, io.Discard,
+	)
+
+	if got := dsResult.ScaleCheckCounts["gascity/worker"]; got != 1 {
+		t.Fatalf("ScaleCheckCounts[gascity/worker] = %d, want 1: rig store aliasing the city "+
+			"backing behind a distinct Store value must not double-count the same bead "+
+			"across the rig and city probe groups (full=%v)", got, dsResult.ScaleCheckCounts)
+	}
+}
+
+// TestBuildDesiredState_WarmRigPoolMissingRigStoreStaysPartialNoCityProbe:
+// the unhealthy-own-store contract is unchanged by the warm city probe. When
+// the rig store is missing/errored, the pool must stay PARTIAL (retaining
+// sessions, suppressing drains) and must NOT be woken/scaled by a spurious
+// city-store probe — a rig executor cannot work while its rig store is
+// unreachable.
+func TestBuildDesiredState_WarmRigPoolMissingRigStoreStaysPartialNoCityProbe(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := warmCrossStoreCfg(t, cityPath)
+	cityStore := beads.NewMemStore()
+	// No rig store entry: the pool's own target is errored/unavailable.
+	rigStores := map[string]beads.Store{}
+
+	createWarmSessionBead(t, cityStore, "gascity/worker")
+	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+
+	createRoutedBead(t, cityStore, "gascity/worker", "city routed work while rig store down")
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, rigStores, nil, nil, io.Discard,
+	)
+
+	if got, ok := dsResult.ScaleCheckCounts["gascity/worker"]; ok && got > 0 {
+		t.Fatalf("ScaleCheckCounts[gascity/worker] = %d, want absent/0: an unhealthy rig store must not "+
+			"gain a city probe (spurious wake while the executor cannot reach its own store)", got)
+	}
+	if !dsResult.ScaleCheckPartialTemplates["gascity/worker"] {
+		t.Fatalf("ScaleCheckPartialTemplates missing gascity/worker: unhealthy own store must keep the "+
+			"template partial so session retention still suppresses drains (got %v)",
+			dsResult.ScaleCheckPartialTemplates)
+	}
+}
+
+// TestBuildDesiredState_WarmNamedBackingRigPoolSeesCityStoreRoutedDemand: the
+// named-session-backing branch has its own copy of the city probe with the
+// same warm-blindness: an on_demand named-backing rig pool that was WARM
+// stopped counting city-store routed demand, dropping to zero between city
+// beads and getting orphan-drained (amplitude clamped to 1 by the
+// namedOnDemandTemplates clamp, but the same spawn/drain treadmill). The
+// clamp keeps the counted demand at 1 regardless of queue depth; the point
+// pinned here is nonzero-ness while WARM.
+func TestBuildDesiredState_WarmNamedBackingRigPoolSeesCityStoreRoutedDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := warmCrossStoreCfg(t, cityPath)
+	cfg.NamedSessions = []config.NamedSession{{
+		Template: "worker",
+		Dir:      "gascity",
+		Mode:     "on_demand",
+	}}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"gascity": rigStore}
+
+	createWarmSessionBead(t, cityStore, "gascity/worker")
+	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+
+	for i := 0; i < 3; i++ {
+		createRoutedBead(t, cityStore, "gascity/worker", "cross-store routed work")
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, rigStores, nil, nil, io.Discard,
+	)
+
+	if got := dsResult.ScaleCheckCounts["gascity/worker"]; got != 1 {
+		t.Fatalf("ScaleCheckCounts[gascity/worker] = %d, want 1 (namedOnDemandTemplates clamp): a WARM "+
+			"named-backing rig pool must still count city-store routed demand or it churns at "+
+			"the warm/cold boundary (full=%v)", got, dsResult.ScaleCheckCounts)
 	}
 }

--- a/cmd/gc/build_desired_state_warm_crossstore_test.go
+++ b/cmd/gc/build_desired_state_warm_crossstore_test.go
@@ -33,18 +33,22 @@ func warmCrossStoreCfg(t *testing.T, cityPath string) *config.City {
 	}
 }
 
+// warmWorkerTemplate is the single pool template every fixture in this file
+// exercises.
+const warmWorkerTemplate = "gascity/worker"
+
 // createWarmSessionBead makes the pool WARM the way the reconciler sees it: an
 // open, awake, pool-managed session bead. isCold is computed from session
 // BEADS (no process probe), so this is exactly the input that flips the
 // warm/cold gate.
-func createWarmSessionBead(t *testing.T, store beads.Store, template string) {
+func createWarmSessionBead(t *testing.T, store beads.Store) {
 	t.Helper()
 	if _, err := store.Create(beads.Bead{
 		Status: "open",
 		Type:   sessionBeadType,
 		Metadata: map[string]string{
 			"session_name": "gc__worker-1",
-			"template":     template,
+			"template":     warmWorkerTemplate,
 			"state":        "active",
 			"pool_managed": "true",
 		},
@@ -58,7 +62,7 @@ func createWarmSessionBead(t *testing.T, store beads.Store, template string) {
 // (collectAllOpenSessionInfos + isPoolManagedSessionInfo +
 // poolSessionIsLiveInfo + template identity equivalence). Without this the
 // tests could silently pin the cold path and pass for the wrong reason.
-func requireWarm(t *testing.T, cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, template string) {
+func requireWarm(t *testing.T, cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store) {
 	t.Helper()
 	infos, err := collectAllOpenSessionInfos(cfg, cityStore, rigStores, nil)
 	if err != nil {
@@ -67,22 +71,22 @@ func requireWarm(t *testing.T, cfg *config.City, cityStore beads.Store, rigStore
 	running := 0
 	for _, si := range infos {
 		if isPoolManagedSessionInfo(si) && poolSessionIsLiveInfo(si) &&
-			agentTemplateIdentitiesEquivalent(cfg, si.Template, template) {
+			agentTemplateIdentitiesEquivalent(cfg, si.Template, warmWorkerTemplate) {
 			running++
 		}
 	}
 	if running == 0 {
-		t.Fatalf("fixture is not WARM: no live pool-managed session info matched template %q (infos=%d) — the test would exercise the cold path instead", template, len(infos))
+		t.Fatalf("fixture is not WARM: no live pool-managed session info matched template %q (infos=%d) — the test would exercise the cold path instead", warmWorkerTemplate, len(infos))
 	}
 }
 
-func createRoutedBead(t *testing.T, store beads.Store, template, title string) {
+func createRoutedBead(t *testing.T, store beads.Store, title string) {
 	t.Helper()
 	if _, err := store.Create(beads.Bead{
 		Title:    title,
 		Type:     "task",
 		Status:   "open",
-		Metadata: map[string]string{"gc.routed_to": template},
+		Metadata: map[string]string{"gc.routed_to": warmWorkerTemplate},
 	}); err != nil {
 		t.Fatalf("create routed bead %q: %v", title, err)
 	}
@@ -104,14 +108,14 @@ func TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand(t *testing.T) {
 	rigStore := beads.NewMemStore()
 	rigStores := map[string]beads.Store{"gascity": rigStore}
 
-	createWarmSessionBead(t, cityStore, "gascity/worker")
-	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+	createWarmSessionBead(t, cityStore)
+	requireWarm(t, cfg, cityStore, rigStores)
 
 	// Routed demand delivered cross-store into the CITY store; the rig store
 	// stays empty. Before the fix the warm pool probed only the rig store and
 	// read 0 here.
 	for i := 0; i < 3; i++ {
-		createRoutedBead(t, cityStore, "gascity/worker", "cross-store routed work")
+		createRoutedBead(t, cityStore, "cross-store routed work")
 	}
 
 	dsResult := buildDesiredStateWithSessionBeads(
@@ -139,12 +143,12 @@ func TestBuildDesiredState_WarmRigPoolCityProbeDoesNotDoubleCountRigDemand(t *te
 	rigStore := beads.NewMemStore()
 	rigStores := map[string]beads.Store{"gascity": rigStore}
 
-	createWarmSessionBead(t, cityStore, "gascity/worker")
-	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+	createWarmSessionBead(t, cityStore)
+	requireWarm(t, cfg, cityStore, rigStores)
 
 	// One routed bead in EACH store: expect a count of exactly 2 (1+1), not 3+.
-	createRoutedBead(t, rigStore, "gascity/worker", "rig-store routed work")
-	createRoutedBead(t, cityStore, "gascity/worker", "city-store routed work")
+	createRoutedBead(t, rigStore, "rig-store routed work")
+	createRoutedBead(t, cityStore, "city-store routed work")
 
 	dsResult := buildDesiredStateWithSessionBeads(
 		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
@@ -176,10 +180,10 @@ func TestBuildDesiredState_WarmAliasedRigStoreDoesNotDoubleCountDemand(t *testin
 	cityStore := beads.NewMemStore()
 	rigStores := map[string]beads.Store{"gascity": aliasStore{cityStore}}
 
-	createWarmSessionBead(t, cityStore, "gascity/worker")
-	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+	createWarmSessionBead(t, cityStore)
+	requireWarm(t, cfg, cityStore, rigStores)
 
-	createRoutedBead(t, cityStore, "gascity/worker", "shared-backing routed work")
+	createRoutedBead(t, cityStore, "shared-backing routed work")
 
 	dsResult := buildDesiredStateWithSessionBeads(
 		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
@@ -206,10 +210,10 @@ func TestBuildDesiredState_WarmRigPoolMissingRigStoreStaysPartialNoCityProbe(t *
 	// No rig store entry: the pool's own target is errored/unavailable.
 	rigStores := map[string]beads.Store{}
 
-	createWarmSessionBead(t, cityStore, "gascity/worker")
-	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+	createWarmSessionBead(t, cityStore)
+	requireWarm(t, cfg, cityStore, rigStores)
 
-	createRoutedBead(t, cityStore, "gascity/worker", "city routed work while rig store down")
+	createRoutedBead(t, cityStore, "city routed work while rig store down")
 
 	dsResult := buildDesiredStateWithSessionBeads(
 		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
@@ -247,11 +251,11 @@ func TestBuildDesiredState_WarmNamedBackingRigPoolSeesCityStoreRoutedDemand(t *t
 	rigStore := beads.NewMemStore()
 	rigStores := map[string]beads.Store{"gascity": rigStore}
 
-	createWarmSessionBead(t, cityStore, "gascity/worker")
-	requireWarm(t, cfg, cityStore, rigStores, "gascity/worker")
+	createWarmSessionBead(t, cityStore)
+	requireWarm(t, cfg, cityStore, rigStores)
 
 	for i := 0; i < 3; i++ {
-		createRoutedBead(t, cityStore, "gascity/worker", "cross-store routed work")
+		createRoutedBead(t, cityStore, "cross-store routed work")
 	}
 
 	dsResult := buildDesiredStateWithSessionBeads(


### PR DESCRIPTION
## Problem

The default pool-demand probe for a rig-scoped agent reads only the rig's own store while the pool is **warm**; the city-store probe (FR-S0.1 / vp-s37 cross-store cold-wake) is gated on `isCold`. But vp-kvp cross-store delivery routes work for rig pools into the **city** store, and the claim path (`work_query` / `gc hook --claim`) already federates across stores — so a warm rig pool can **claim** city-delivered work but never **count** it as demand. The scale signal and the claim signal disagree about what work exists (the `scale_check ↔ work_query` mismatch class).

Observed in production (maintainer-city, 2026-07-16):
- a warm worker pool pinned at `poolDesired=1` against 1 rig-store + **9 city-store** routed beads — one session serializing every live workflow, starving all dep-downstream control beads (scope-check/retry/workflow-finalize never became ready, freezing review pipelines end-to-end);
- pools at the warm/cold boundary oscillated `pool_desired` N↔0 on a ~3-tick period (cold ticks glimpsed city demand and spawned; warm ticks read 0 and the reconciler **orphan-drained the sessions it had just started**) — a spawn/drain treadmill with ~0 throughput, confirmed in the reconciler trace while 20×-loop reads of both underlying stores were byte-stable.

## Fix

Drop the `isCold` gate: the city probe runs for every rig pool whose own store is healthy and distinct from the city store, warm or cold. Demand a pool can claim is demand it must be able to count.

- Counts sum across store groups and beads are distinct per store → correct union demand.
- The existing `ownTarget.store != store` guard still prevents double-counting when an unbound rig aliases the city store.
- Store-scoped control dispatchers remain excluded by design (a rig copy cannot claim a city route).
- The unhealthy-rig-store path is unchanged: errored own-store still marks the template partial and does **not** add a city probe.
- Layout-agnostic: no dependency on any particular store backend or split; the fix and tests use plain in-memory stores.

## Tests (TDD)

- `TestBuildDesiredState_WarmRigPoolSeesCityStoreRoutedDemand` — **fails on the old code** with `ScaleCheckCounts=map[]` (the exact production signature) and passes with the fix.
- `TestBuildDesiredState_WarmRigPoolCityProbeDoesNotDoubleCountRigDemand` — pins 1 rig + 1 city = 2 union semantics.
- Demand/desired-state regression sweep (`TestBuildDesiredState* / TestDefaultScaleCheck* / TestComputePoolDesired* / TestPoolDesired* / TestScaleCheck* / TestCollectAllOpenSessionInfos / TestEvaluatePendingPools*`) green; `go vet` clean.

## Verification in production

Deployed to the live maintainer-city controller: `scaleCheck: gascity/gc.implementation-worker` went **1 → 10** on the first post-restart tick, the worker fleet spawned to match, and the frozen review pipeline resumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Adversarial review (fable workflow: 4 dimensions → per-finding refutation) — all findings addressed

- **[major] Named-backing branch parity** — the named-session-backing pool's city probe had the identical `isCold` gate (same treadmill, amplitude 1) and its "mirror the generic-pool guard" comment had gone stale → un-gated with the same guards + comment rewritten + warm test added.
- **[major] Alias double-count** — pointer-only `ownTarget.store != store` misses a rig store that is a distinct object over the same backing; with the warm probe that's a persistent 2× demand → cross-group per-template bead-ID dedup + test (fails at 2 without it).
- **[minor] Tests didn't pin warmth** → all tests now assert WARM via the reconciler's own predicates.
- **[nit] Custom-scale_check residual** → documented: custom-check pools deliberately keep the clamped cold-only probe; a custom check must count cross-store demand itself.
- **[nit] Warm unhealthy-rig-store case** → test added: stays partial, no spurious city probe.
- **[minor, follow-up — out of scope]** Assigned-work/resume accounting remains rig-scoped while the claim path federates: a city bead claimed by a warm rig session can vanish from resume/keep-awake demand. Same store-scope disease, different organ (also session_reconciler.go:1934 drain-guard variant); tracked for a separate PR rather than expanding this one.

Refuted findings (2) discarded after adversarial verification.
