### PR TITLE
test: make session wait composition hermetic

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -37,8 +37,12 @@ resources absent from the catalog remain manual-review boundaries. In
 particular, `TestPrepareWaitWakeState_ResolvesRigDependencyBeads` and
 `TestDoSessionWake_PokesManagedControllerAfterStateChange` have reviewed
 hermetic bodies but still run as Medium because `cmd/gc` owns a process-mutating
-`TestMain`. `TestCmdSessionWait_AllowsRigDependencyBeads` remains the singular
-real managed-provider composition proof for wait, and
+`TestMain`. `TestDoSessionWait_RegistersReadyWaitForRigDependency` has the same
+reviewed-hermetic guarantee for the wait-registration use case.
+`TestCmdSessionWait_AllowsRigDependencyBeads` remains the singular
+CLI/config/file-store split-store composition proof for wait, while
+`TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind` owns the real
+managed-provider hard-kill/port-rebind boundary. Likewise,
 `TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart` remains the
 singular CLI/config/file-store/controller-socket composition proof for wake.
 Body review is not a reason to remove either boundary test.
@@ -147,6 +151,7 @@ all-source audit while staying outside untagged and Small debt.
 
 | Reviewed hermetic body | Effective runnable size | Medium reason | Retained real composition owner |
 | --- | --- | --- | --- |
+| `cmd/gc` package `main` — TestDoSessionWait_RegistersReadyWaitForRigDependency | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWait_AllowsRigDependencyBeads |
 | `cmd/gc` package `main` — TestDoSessionWake_PokesManagedControllerAfterStateChange | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart |
 | `cmd/gc` package `main` — TestPrepareWaitWakeState_ResolvesRigDependencyBeads | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWait_AllowsRigDependencyBeads |
 <!-- END CHECKED TEST RESOURCE LEDGER -->

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -43,6 +43,14 @@ type waitSetStateResult struct {
 	RetriedFrom string
 }
 
+type sessionWaitDeps struct {
+	sessions         *sessionpkg.Store
+	dependencies     waitDependencyReader
+	now              func() time.Time
+	createdBySession string
+	pokeController   func() error
+}
+
 type waitDependencyReader interface {
 	Get(string) (beads.Bead, error)
 }
@@ -264,8 +272,27 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		fmt.Fprintf(stderr, "gc session wait: %v\n", err) //nolint:errcheck
 		return 1
 	}
+	dependencies := waitDependencyReaderFunc(func(depID string) (beads.Bead, error) {
+		return loadWaitDependencyBead(cityPath, store, depID)
+	})
+	return doSessionWait(sessionID, depIDs, matchAny, note, sleep, stdout, stderr, sessionWaitDeps{
+		sessions:         sessFront,
+		dependencies:     dependencies,
+		now:              time.Now,
+		createdBySession: os.Getenv("GC_SESSION_ID"),
+		pokeController: func() error {
+			resolvedCityPath, err := resolveCity()
+			if err != nil {
+				return nil
+			}
+			return pokeController(resolvedCityPath)
+		},
+	})
+}
+
+func doSessionWait(sessionID string, depIDs []string, matchAny bool, note string, sleep bool, stdout, stderr io.Writer, deps sessionWaitDeps) int {
 	for _, depID := range depIDs {
-		if _, err := loadWaitDependencyBead(cityPath, store, depID); err != nil {
+		if _, err := deps.dependencies.Get(depID); err != nil {
 			fmt.Fprintf(stderr, "gc session wait: dependency %s: %v\n", depID, err) //nolint:errcheck
 			return 1
 		}
@@ -274,30 +301,30 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 	if matchAny {
 		depMode = "any"
 	}
-	now := time.Now().UTC()
-	wait, err := sessFront.CreateWait(sessionpkg.WaitSpec{
+	now := deps.now().UTC()
+	wait, err := deps.sessions.CreateWait(sessionpkg.WaitSpec{
 		SessionID:        sessionID,
 		Kind:             "deps",
 		DepIDs:           depIDs,
 		DepMode:          depMode,
 		Note:             note,
-		CreatedBySession: os.Getenv("GC_SESSION_ID"),
+		CreatedBySession: deps.createdBySession,
 		Now:              now,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session wait: creating wait: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	ready, depErr := depsWaitReadyDetailedForCity(cityPath, store, wait)
+	ready, depErr := depsWaitReadyDetailedFrom(deps.dependencies, wait)
 	if depErr != nil {
-		if err := sessFront.FailWait(wait.ID, now, depErr.Error()); err != nil {
+		if err := deps.sessions.FailWait(wait.ID, now, depErr.Error()); err != nil {
 			fmt.Fprintf(stderr, "gc session wait: setting failed state: %v\n", err) //nolint:errcheck
 		}
 		fmt.Fprintf(stderr, "gc session wait: dependency state check: %v\n", depErr) //nolint:errcheck
 		return 1
 	}
 	if ready {
-		if err := sessFront.MarkWaitReady(wait.ID, now); err != nil {
+		if err := deps.sessions.MarkWaitReady(wait.ID, now); err != nil {
 			fmt.Fprintf(stderr, "gc session wait: setting ready state: %v\n", err) //nolint:errcheck
 			return 1
 		}
@@ -305,18 +332,16 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		return 0
 	}
 	if sleep {
-		if err := sessFront.ApplyPatch(sessionID, map[string]string{
+		if err := deps.sessions.ApplyPatch(sessionID, map[string]string{
 			"wait_hold":    "true",
 			"sleep_intent": "wait-hold",
 		}); err != nil {
 			fmt.Fprintf(stderr, "gc session wait: setting wait hold: %v\n", err) //nolint:errcheck
 			return 1
 		}
-		if cityPath, err := resolveCity(); err == nil {
-			if err := pokeController(cityPath); err != nil {
-				fmt.Fprintf(stderr, "gc session wait: poking controller: %v\n", err) //nolint:errcheck
-				return 1
-			}
+		if err := deps.pokeController(); err != nil {
+			fmt.Fprintf(stderr, "gc session wait: poking controller: %v\n", err) //nolint:errcheck
+			return 1
 		}
 		fmt.Fprintf(stdout, "Registered wait %s for session %s.\nSession %s draining to sleep.\n", wait.ID, sessionID, sessionID) //nolint:errcheck
 		return 0
@@ -881,12 +906,6 @@ func depsWaitReady(store beads.Store, wait sessionpkg.WaitInfo) bool {
 
 func depsWaitReadyDetailed(store beads.Store, wait sessionpkg.WaitInfo) (bool, error) {
 	return depsWaitReadyDetailedFrom(store, wait)
-}
-
-func depsWaitReadyDetailedForCity(cityPath string, store beads.Store, wait sessionpkg.WaitInfo) (bool, error) {
-	return depsWaitReadyDetailedFrom(waitDependencyReaderFunc(func(depID string) (beads.Bead, error) {
-		return loadWaitDependencyBead(cityPath, store, depID)
-	}), wait)
 }
 
 func depsWaitReadyDetailedFrom(dependencies waitDependencyReader, wait sessionpkg.WaitInfo) (bool, error) {

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -2394,8 +2394,130 @@ start_command = "true"
 	}
 }
 
+func TestDoSessionWait_RegistersReadyWaitForRigDependency(t *testing.T) {
+	const (
+		sessionID = "gcg-session-1"
+		depID     = "ga-dep-1"
+		originID  = "gcg-origin-1"
+	)
+	now := time.Date(2026, time.July, 16, 6, 30, 0, 0, time.UTC)
+	cityStore := waitPrefixedStore{
+		Store: beads.NewMemStoreFrom(1, []beads.Bead{{
+			ID:        sessionID,
+			Title:     "worker session",
+			Type:      sessionBeadType,
+			Status:    "open",
+			Labels:    []string{sessionBeadLabel},
+			CreatedAt: now.Add(-time.Minute),
+			UpdatedAt: now.Add(-time.Minute),
+			Revision:  1,
+			Metadata: map[string]string{
+				"session_name":       "worker",
+				"continuation_epoch": "1",
+			},
+		}}, nil),
+		prefix: "gcg",
+	}
+	rigStore := waitPrefixedStore{
+		Store: beads.NewMemStoreFrom(1, []beads.Bead{{
+			ID:        depID,
+			Title:     "rig dependency",
+			Type:      "task",
+			Status:    "closed",
+			CreatedAt: now.Add(-time.Minute),
+			UpdatedAt: now.Add(-time.Minute),
+			Revision:  1,
+		}}, nil),
+		prefix: "ga",
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doSessionWait(sessionID, []string{depID}, false, "block", false, &stdout, &stderr, sessionWaitDeps{
+		sessions:         sessionFrontDoor(cityStore),
+		dependencies:     newWaitDependencyStoreSet(cityStore, map[string]beads.Store{"frontend": rigStore}),
+		now:              func() time.Time { return now },
+		createdBySession: originID,
+	})
+	if code != 0 {
+		t.Fatalf("doSessionWait() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "already ready") {
+		t.Fatalf("stdout = %q, want already-ready result", got)
+	}
+
+	waits, err := cityStore.ListByLabel("session:"+sessionID, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel(wait): %v", err)
+	}
+	if len(waits) != 1 {
+		t.Fatalf("wait count = %d, want 1", len(waits))
+	}
+	wait := waits[0]
+	if wait.Status != "open" {
+		t.Fatalf("wait status = %q, want open", wait.Status)
+	}
+	for key, want := range map[string]string{
+		"state":              waitStateReady,
+		"created_at":         now.Format(time.RFC3339),
+		"ready_at":           now.Format(time.RFC3339),
+		"dep_ids":            depID,
+		"dep_mode":           "all",
+		"created_by_session": originID,
+	} {
+		if got := wait.Metadata[key]; got != want {
+			t.Fatalf("wait metadata[%q] = %q, want %q", key, got, want)
+		}
+	}
+	if wait.Description != "block" {
+		t.Fatalf("wait description = %q, want block", wait.Description)
+	}
+}
+
 func TestCmdSessionWait_AllowsRigDependencyBeads(t *testing.T) {
-	cityPath, rigPath := setupManagedBdWaitTestCity(t)
+	setWaitTestFileBeads(t)
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
+	cityFlag = ""
+	rigFlag = ""
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
+	})
+
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	cityToml := `[workspace]
+name = "gascity"
+prefix = "gc"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	cityFlag = cityPath
+	if err := ensureScopedFileStoreLayout(cityPath); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityPath); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigPath); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(rig): %v", err)
+	}
+	dep := beads.Bead{ID: "fe-1", Title: "rig dep", Status: "closed", Type: "task"}
+	writeTestFileStoreBeads(t, rigPath, []beads.Bead{dep})
 
 	cityStore, err := openCityStoreAt(cityPath)
 	if err != nil {
@@ -2417,15 +2539,12 @@ func TestCmdSessionWait_AllowsRigDependencyBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create session bead: %v", err)
 	}
-	dep, err := rigStore.Create(beads.Bead{Title: "rig dep"})
+	gotDep, err := rigStore.Get(dep.ID)
 	if err != nil {
-		t.Fatalf("create rig dep bead: %v", err)
+		t.Fatalf("get rig dep bead: %v", err)
 	}
-	if err := rigStore.Close(dep.ID); err != nil {
-		t.Fatalf("close rig dep bead: %v", err)
-	}
-	if got := beadPrefix(nil, dep.ID); got != "fe" {
-		t.Fatalf("rig dep prefix = %q, want %q", got, "fe")
+	if gotDep.Status != "closed" {
+		t.Fatalf("rig dep status = %q, want closed", gotDep.Status)
 	}
 
 	var stdout, stderr bytes.Buffer

--- a/cmd/gc/frontdoor_di_guard_test.go
+++ b/cmd/gc/frontdoor_di_guard_test.go
@@ -323,9 +323,10 @@ func TestMetadataInfoOnlyFilesStayOnInfoSnapshot(t *testing.T) {
 // doWaitInspectFallback — derive sessStore := cliSessionStore(store, cfg, cityPath)
 // and route the SESSION/wait bead access (wait-bead CRUD, session-bead lookups,
 // wait_hold clears, cap-diagnostic stamps) through it, while dependency-bead reads
-// (loadWaitDependencyBead / depsWaitReadyDetailedForCity) deliberately stay on the
-// plain WORK store (dep beads are work class, federated across rig scopes) and the
-// wait-nudge shadow lookups ride a NudgesStore over the same work store (nudges class,
+// (loadWaitDependencyBead, injected into doSessionWait's waitDependencyReader)
+// deliberately stay on the plain WORK store (dep beads are work class, federated
+// across rig scopes), and wait-nudge shadow lookups ride a NudgesStore over the same
+// work store (nudges class,
 // its own E1.2 routing). The positive cliSessionStore( tripwire protects the routed
 // arm; as a non-front-door router (most session reads go through store args) this
 // guard is a regression canary for the file, not a completeness proof — the

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -308,6 +308,13 @@ var bootstrapPolicy = Ledger{
 		{
 			PackageDir:    "cmd/gc",
 			PackageName:   "main",
+			Owner:         "TestDoSessionWait_RegistersReadyWaitForRigDependency",
+			EffectiveSize: "medium",
+			MediumReason:  "package TestMain mutates process state",
+		},
+		{
+			PackageDir:    "cmd/gc",
+			PackageName:   "main",
 			Owner:         "TestDoSessionWake_PokesManagedControllerAfterStateChange",
 			EffectiveSize: "medium",
 			MediumReason:  "package TestMain mutates process state",

--- a/internal/testpolicy/resourcecensus/hermetic.go
+++ b/internal/testpolicy/resourcecensus/hermetic.go
@@ -76,6 +76,18 @@ var retainedRealOwners = []retainedRealOwner{
 		reviewed: runnableKey{
 			packageDir:  "cmd/gc",
 			packageName: "main",
+			owner:       "TestDoSessionWait_RegistersReadyWaitForRigDependency",
+		},
+		retained: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
+			owner:       "TestCmdSessionWait_AllowsRigDependencyBeads",
+		},
+	},
+	{
+		reviewed: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
 			owner:       "TestDoSessionWake_PokesManagedControllerAfterStateChange",
 		},
 		retained: runnableKey{

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -209,6 +209,13 @@ expires = "2026-10-01"
 [[reviewed_hermetic_body]]
 package_dir = "cmd/gc"
 package_name = "main"
+owner = "TestDoSessionWait_RegistersReadyWaitForRigDependency"
+effective_size = "medium"
+medium_reason = "package TestMain mutates process state"
+
+[[reviewed_hermetic_body]]
+package_dir = "cmd/gc"
+package_name = "main"
 owner = "TestDoSessionWake_PokesManagedControllerAfterStateChange"
 effective_size = "medium"
 medium_reason = "package TestMain mutates process state"


### PR DESCRIPTION
## Summary

- extract `doSessionWait` behind injected session storage, dependency reads, clock, creator identity, and controller poke while keeping validation and ambient construction in `cmdSessionWait`
- replace duplicate managed-Dolt setup with a deterministic MemStore use-case proof and one thin CLI/config/FileStore split-store composition proof
- ratchet the MemStore test as a reviewed-hermetic body without raising any resource baseline
- retain `TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind` as the exact managed-provider hard-kill/rebind owner

## Performance

| Measurement | Before | After |
| --- | ---: | ---: |
| Fresh file-composition test body | 54.61s | 0.42s median |
| Retained CI test body | 25.67s | 0.42s median |
| Latest Blacksmith observation | 23.86s | 0.42s median |

The replacement is approximately 57–130× faster depending on the baseline. The required fast suite completed in 213.11s, and the process shard containing the retained FileStore composition proof completed in 107.83s.

## Test ownership

- `TestDoSessionWait_RegistersReadyWaitForRigDependency`: wait-registration behavior with distinct in-memory city and rig stores
- `TestCmdSessionWait_AllowsRigDependencyBeads`: production CLI/config/prefix/FileStore composition and city-store persistence
- `TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind`: unchanged native managed-provider recovery boundary

## Verification

- focused wait and front-door guard tests
- `go test -race -count=20 ./cmd/gc -run '^TestDoSessionWait_RegistersReadyWaitForRigDependency$'`
- `go test -race -count=1 ./internal/testpolicy/resourcecensus`
- `make test-fast-parallel` — 213.11s, all jobs passed
- process shard 8/12 — 107.83s, passed
- `go vet ./...`
- repository pre-commit and pre-push hooks
- exact-diff council: correctness CLEAR, maintainability CLEAR, testing-policy CLEAR

## Local environment notes

- process shard 7/12 reached 155.10s but hit an unrelated existing test that invokes the host's CGO-disabled `bd`
- the unchanged managed-rebind integration owner cannot execute against this host's schema-v55 `bd` with the branch's schema-v53 native library; CI's pinned provider lane remains the authoritative owner

Bead: `ga-80po0c.19`
