### PR TITLE
test: make mail inbox coverage hermetic

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -45,7 +45,13 @@ CLI/config/file-store split-store composition proof for wait, while
 managed-provider hard-kill/port-rebind boundary. Likewise,
 `TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart` remains the
 singular CLI/config/file-store/controller-socket composition proof for wake.
-Body review is not a reason to remove either boundary test.
+`TestDoMailInbox_RendersMessagesFromReader` owns inbox rendering through the
+consumer's one-method reader port, while
+`TestCmdMailInbox_ManagedExecLifecycleProviderReadsInbox` remains the singular
+CLI/mail/`exec:gc-beads-bd` managed-city composition proof. Managed-provider
+recovery stays with the exact provider-store owner instead of being repeated by
+each command consumer. Body review is not a reason to remove a retained
+boundary test.
 
 The canonical identity is package directory plus package clause plus top-level
 `Test`, `Benchmark`, `Fuzz`, or `TestMain` name. Nested function literals and
@@ -123,7 +129,7 @@ all-source audit while staying outside untagged and Small debt.
 <!-- BEGIN CHECKED TEST RESOURCE LEDGER -->
 | Ledger kind | Source scope | Resource baseline | Tracking owner | Invariant / resource owner | Migration | Expiry |
 | --- | --- | --- | --- | --- | --- | --- |
-| Audit baseline | all tracked test source | fixed_sleep: 443 calls / 159 files (historical regex census: 447 / 157) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
+| Audit baseline | all tracked test source | fixed_sleep: 441 calls / 158 files (historical regex census: 447 / 157) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
 | Audit baseline | all tracked test source | subprocess: 528 calls / 154 files (historical regex census: 495 / 135) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
 | Medium owner | `cmd/gc` package `main` | TestMain: environment | ga-80po0c.2.1 | cmd/gc TestMain is the checked package-level Medium owner; only environment calls lexically inside TestMain leave Small debt | P0.4b | 2026-10-01 |
 | Medium owner | `internal/api` package `api` | TestEveryEmittedErrorCodeIsRegistered: subprocess | ga-80po0c.2.1 | internal/api tracked-source error URN guard is a checked Medium owner; only the git ls-files call lexically inside TestEveryEmittedErrorCodeIsRegistered leaves Small debt | P0.4b | 2026-10-01 |
@@ -131,7 +137,7 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | `cmd/gc` untagged test source | cwd: 284 calls / 43 files | ga-80po0c.2.1 | untagged Small cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners restore or eliminate every cwd mutation | D5/D6 | 2026-10-01 |
 | Small debt ratchet | `cmd/gc` untagged test source | environment: 4326 calls / 200 files (historical regex census: 4339 / 199) | ga-80po0c.2.1 | untagged Small cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners restore or eliminate every process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 74 calls / 25 files (historical regex census: 75 / 25) | ga-80po0c.2.1 | untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; each non-Medium marked caller retains an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
-| Small debt ratchet | all untagged test source | fixed_sleep: 289 calls / 114 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
+| Small debt ratchet | all untagged test source | fixed_sleep: 287 calls / 113 files | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | http_test_server: 300 calls / 66 files | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
@@ -141,7 +147,7 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | `cmd/gc` untagged test source | cwd: 284 calls / 43 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | environment: 4332 calls / 200 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 74 calls / 25 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
-| Source debt ratchet | all untagged test source | fixed_sleep: 289 calls / 114 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
+| Source debt ratchet | all untagged test source | fixed_sleep: 287 calls / 113 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | http_test_server: 300 calls / 66 files (historical regex census: 255 / 56) | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its configured listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
@@ -151,6 +157,7 @@ all-source audit while staying outside untagged and Small debt.
 
 | Reviewed hermetic body | Effective runnable size | Medium reason | Retained real composition owner |
 | --- | --- | --- | --- |
+| `cmd/gc` package `main` — TestDoMailInbox_RendersMessagesFromReader | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdMailInbox_ManagedExecLifecycleProviderReadsInbox |
 | `cmd/gc` package `main` — TestDoSessionWait_RegistersReadyWaitForRigDependency | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWait_AllowsRigDependencyBeads |
 | `cmd/gc` package `main` — TestDoSessionWake_PokesManagedControllerAfterStateChange | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart |
 | `cmd/gc` package `main` — TestPrepareWaitWakeState_ResolvesRigDependencyBeads | medium | package TestMain mutates process state | `cmd/gc` package `main` — TestCmdSessionWait_AllowsRigDependencyBeads |

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1915,16 +1915,20 @@ func cmdMailInboxWithJSON(args []string, jsonOut bool, stdout, stderr io.Writer)
 	return doMailInboxTargetWithJSON(mp, target, jsonOut, stdout, stderr)
 }
 
+type mailInboxReader interface {
+	Inbox(recipient string) ([]mail.Message, error)
+}
+
 // doMailInbox lists unread messages for a recipient.
-func doMailInbox(mp mail.Provider, recipient string, stdout, stderr io.Writer) int {
+func doMailInbox(mp mailInboxReader, recipient string, stdout, stderr io.Writer) int {
 	return doMailInboxTarget(mp, resolvedMailTarget{display: recipient, recipients: []string{recipient}}, stdout, stderr)
 }
 
-func doMailInboxTarget(mp mail.Provider, target resolvedMailTarget, stdout, stderr io.Writer) int {
+func doMailInboxTarget(mp mailInboxReader, target resolvedMailTarget, stdout, stderr io.Writer) int {
 	return doMailInboxTargetWithJSON(mp, target, false, stdout, stderr)
 }
 
-func doMailInboxTargetWithJSON(mp mail.Provider, target resolvedMailTarget, jsonOut bool, stdout, stderr io.Writer) int {
+func doMailInboxTargetWithJSON(mp mailInboxReader, target resolvedMailTarget, jsonOut bool, stdout, stderr io.Writer) int {
 	messages, err := collectMailMessages(mp.Inbox, target.recipients)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc mail inbox: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -1415,6 +1414,16 @@ func TestResolveMailRecipientIdentity_BareRigScopedNamedRejectsAmbiguousLiveConf
 
 // --- gc mail inbox ---
 
+type recordingMailInboxReader struct {
+	inbox map[string][]mail.Message
+	calls []string
+}
+
+func (r *recordingMailInboxReader) Inbox(recipient string) ([]mail.Message, error) {
+	r.calls = append(r.calls, recipient)
+	return r.inbox[recipient], nil
+}
+
 func TestCmdMailInbox_ManagedExecLifecycleProviderReadsInbox(t *testing.T) {
 	cityDir, _ := setupManagedBdWaitTestCity(t)
 
@@ -1456,75 +1465,6 @@ func TestCmdMailInbox_ManagedExecLifecycleProviderReadsInbox(t *testing.T) {
 	}
 }
 
-func TestCmdMailInbox_ManagedExecLifecycleProviderRecoversAfterHardKillPortRebind(t *testing.T) {
-	cityDir, _ := setupManagedBdWaitTestCity(t)
-
-	store, err := openCityStoreAt(cityDir)
-	if err != nil {
-		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
-	}
-	if _, err := store.Create(beads.Bead{
-		Title:  "managed exec session",
-		Type:   session.BeadType,
-		Labels: []string{session.LabelSession},
-		Metadata: map[string]string{
-			"session_name": "city-worker",
-			"alias":        "city-worker",
-			"template":     "worker",
-			"state":        "asleep",
-		},
-	}); err != nil {
-		t.Fatalf("store.Create(session bead): %v", err)
-	}
-	mp := beadmail.New(store)
-	if _, err := mp.Send("human", "city-worker", "status", "hello after managed rebind"); err != nil {
-		t.Fatalf("mp.Send(): %v", err)
-	}
-
-	before, err := readDoltRuntimeStateFile(managedDoltStatePath(cityDir))
-	if err != nil {
-		t.Fatalf("readDoltRuntimeStateFile(before): %v", err)
-	}
-	if before.PID <= 0 || before.Port <= 0 {
-		t.Fatalf("unexpected managed runtime before fault: %+v", before)
-	}
-	if err := syscall.Kill(before.PID, syscall.SIGKILL); err != nil {
-		t.Fatalf("Kill(%d): %v", before.PID, err)
-	}
-	deadline := time.Now().Add(10 * time.Second)
-	for pidAlive(before.PID) && time.Now().Before(deadline) {
-		time.Sleep(25 * time.Millisecond)
-	}
-
-	occupyManagedDoltPort(t, before.Port)
-
-	var stdout, stderr bytes.Buffer
-	if code := cmdMailInbox([]string{"city-worker"}, &stdout, &stderr); code != 0 {
-		t.Fatalf("cmdMailInbox() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-	if out := stdout.String(); !strings.Contains(out, "hello after managed rebind") {
-		t.Fatalf("stdout missing recovered mail:\n%s", out)
-	}
-
-	var after doltRuntimeState
-	deadline = time.Now().Add(20 * time.Second)
-	for time.Now().Before(deadline) {
-		state, err := readDoltRuntimeStateFile(managedDoltStatePath(cityDir))
-		if err == nil && state.Running && state.Port > 0 && state.Port != before.Port && state.PID > 0 && pidAlive(state.PID) {
-			after = state
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if after.Port == 0 {
-		after, err = readDoltRuntimeStateFile(managedDoltStatePath(cityDir))
-		if err != nil {
-			t.Fatalf("readDoltRuntimeStateFile(after): %v", err)
-		}
-		t.Fatalf("managed Dolt did not rebind after gc mail inbox recovery; before=%+v after=%+v", before, after)
-	}
-}
-
 func TestMailInboxEmpty(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)
@@ -1539,16 +1479,21 @@ func TestMailInboxEmpty(t *testing.T) {
 	}
 }
 
-func TestMailInboxShowsMessages(t *testing.T) {
-	store := beads.NewMemStore()
-	mp := beadmail.New(store)
-	mp.Send("human", "mayor", "", "hey there") //nolint:errcheck
-	mp.Send("worker", "mayor", "", "status?")  //nolint:errcheck
+func TestDoMailInbox_RendersMessagesFromReader(t *testing.T) {
+	reader := &recordingMailInboxReader{inbox: map[string][]mail.Message{
+		"mayor": {
+			{ID: "gc-1", From: "human", To: "mayor", Body: "hey there"},
+			{ID: "gc-2", From: "worker", To: "mayor", Body: "status?"},
+		},
+	}}
 
 	var stdout, stderr bytes.Buffer
-	code := doMailInbox(mp, "mayor", &stdout, &stderr)
+	code := doMailInbox(reader, "mayor", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doMailInbox = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if got := strings.Join(reader.calls, ","); got != "mayor" {
+		t.Fatalf("Inbox calls = %q, want mayor", got)
 	}
 
 	out := stdout.String()

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -126,8 +126,8 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeAll,
 			Resource:        ResourceFixedSleep,
-			BaselineCalls:   443,
-			BaselineFiles:   159,
+			BaselineCalls:   441,
+			BaselineFiles:   158,
 			ReportedCalls:   447,
 			ReportedFiles:   157,
 			OwnerBead:       "ga-80po0c.2",
@@ -154,8 +154,8 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeUntagged,
 			Resource:        ResourceFixedSleep,
-			BaselineCalls:   289,
-			BaselineFiles:   114,
+			BaselineCalls:   287,
+			BaselineFiles:   113,
 			ReportedCalls:   295,
 			ReportedFiles:   114,
 			OwnerBead:       "ga-80po0c.2",
@@ -326,6 +326,13 @@ var bootstrapPolicy = Ledger{
 			EffectiveSize: "medium",
 			MediumReason:  "package TestMain mutates process state",
 		},
+		{
+			PackageDir:    "cmd/gc",
+			PackageName:   "main",
+			Owner:         "TestDoMailInbox_RendersMessagesFromReader",
+			EffectiveSize: "medium",
+			MediumReason:  "package TestMain mutates process state",
+		},
 	},
 	SmallDebt: []Baseline{
 		{
@@ -344,10 +351,10 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeUntagged,
 			Resource:        ResourceFixedSleep,
-			BaselineCalls:   289,
-			BaselineFiles:   114,
-			ReportedCalls:   289,
-			ReportedFiles:   114,
+			BaselineCalls:   287,
+			BaselineFiles:   113,
+			ReportedCalls:   287,
+			ReportedFiles:   113,
 			OwnerBead:       "ga-80po0c.2.1",
 			Invariant:       "untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "non-Medium lexical owners replace elapsed wall time with lifecycle signals",

--- a/internal/testpolicy/resourcecensus/hermetic.go
+++ b/internal/testpolicy/resourcecensus/hermetic.go
@@ -108,6 +108,18 @@ var retainedRealOwners = []retainedRealOwner{
 			owner:       "TestCmdSessionWait_AllowsRigDependencyBeads",
 		},
 	},
+	{
+		reviewed: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
+			owner:       "TestDoMailInbox_RendersMessagesFromReader",
+		},
+		retained: runnableKey{
+			packageDir:  "cmd/gc",
+			packageName: "main",
+			owner:       "TestCmdMailInbox_ManagedExecLifecycleProviderReadsInbox",
+		},
+	},
 }
 
 func retainedRealOwnerFor(key runnableKey) (runnableKey, bool) {

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -23,8 +23,8 @@ expires = "2026-10-01"
 [[audit_baseline]]
 scope = "all"
 resource = "fixed_sleep"
-baseline_calls = 443
-baseline_files = 159
+baseline_calls = 441
+baseline_files = 158
 reported_calls = 447
 reported_files = 157
 owner_bead = "ga-80po0c.2"
@@ -51,8 +51,8 @@ expires = "2026-10-01"
 [[debt]]
 scope = "untagged"
 resource = "fixed_sleep"
-baseline_calls = 289
-baseline_files = 114
+baseline_calls = 287
+baseline_files = 113
 reported_calls = 295
 reported_files = 114
 owner_bead = "ga-80po0c.2"
@@ -227,6 +227,13 @@ owner = "TestPrepareWaitWakeState_ResolvesRigDependencyBeads"
 effective_size = "medium"
 medium_reason = "package TestMain mutates process state"
 
+[[reviewed_hermetic_body]]
+package_dir = "cmd/gc"
+package_name = "main"
+owner = "TestDoMailInbox_RendersMessagesFromReader"
+effective_size = "medium"
+medium_reason = "package TestMain mutates process state"
+
 # Small-debt rows apply the exact Medium filter while the source-debt rows
 # above retain the raw anti-growth census.
 [[small_debt]]
@@ -245,10 +252,10 @@ expires = "2026-10-01"
 [[small_debt]]
 scope = "untagged"
 resource = "fixed_sleep"
-baseline_calls = 289
-baseline_files = 114
-reported_calls = 289
-reported_files = 114
+baseline_calls = 287
+baseline_files = 113
+reported_calls = 287
+reported_files = 113
 owner_bead = "ga-80po0c.2.1"
 invariant = "untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners replace elapsed wall time with lifecycle signals"


### PR DESCRIPTION
## Summary

- Narrow the mail inbox rendering path to a private, consumer-owned `mailInboxReader` with one method.
- Replace storage-backed rendering coverage with a deterministic recording reader and remove the duplicate managed-Dolt hard-kill/rebind mail test.
- Keep the unique real `gc mail inbox` → `exec:gc-beads-bd` composition proof and the exact provider/command recovery owners.
- Ratchet the checked fixed-sleep census and document the ownership split.

## Invariant map

| Invariant | Owner after this change |
| --- | --- |
| Inbox requests the exact recipient and renders message fields | `TestDoMailInbox_RendersMessagesFromReader` |
| CLI/config/mail composes through the managed exec beads provider | `TestCmdMailInbox_ManagedExecLifecycleProviderReadsInbox` |
| A stale native store reconnects after managed Dolt hard-kill/rebind | `TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind` |
| A real `gc bd` command recovers across managed hard-kill/rebind | `TestGcBdRigListRecoversAfterManagedHardKillPortRebind` |
| Reviewed hermetic coverage retains a real composition owner | resource-census ownership checks |

## Performance

- Removed test body measured on Blacksmith: **29.12s**.
- Replacement reader test: **0.00s**.
- Fixed sleeps: all tracked source **443/159 → 441/158** calls/files; untagged and Small debt **289/114 → 287/113**.

The 29.12s is aggregate test-body work removed, not a guaranteed 29.12s reduction in parallel shard wall time.

## Testing

- [x] TDD red: the recording reader initially failed to compile against the broad `mail.Provider` contract
- [x] Focused mail inbox tests
- [x] Focused race run, 20 repetitions
- [x] Full resource-census package
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `make check-docs`
- [x] `.githooks/pre-commit`
- [x] `.githooks/pre-push`
- [x] cmd/gc process shard 4/12, including the retained exec-mail proof
- [x] Three-lane delegated exact-diff council: correctness, maintainability, and test policy all clear with no P0-P2 findings

## Checklist

- [x] Tracks `ga-80po0c.20`
- [x] Behavior is unchanged; only test ownership and dependency width change
- [x] No user-facing documentation or migration is required
