### PR TITLE
docs(contributors): document hold/blocked label conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -501,6 +501,7 @@ bd close <id>         # Complete work
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 - For controller or session reconciler incidents, use `gc trace` and follow `engdocs/contributors/reconciler-debugging.md` for the artifact collection workflow.
+- When a bead needs to pause on a specific actor or condition, only `hold:mayor` and `hold:external` are canonical (set via `bd set-state <id> hold=mayor|external --reason "..."`) — never invent a new ad hoc hold/blocked label. See `engdocs/contributors/hold-label-conventions.md`.
 
 ## Session Completion
 

--- a/engdocs/contributors/hold-label-conventions.md
+++ b/engdocs/contributors/hold-label-conventions.md
@@ -1,0 +1,113 @@
+---
+title: Hold and Blocked Label Conventions
+description: The canonical hold/blocked label taxonomy for this project's own bd tracker — which label to use, when to use status or a dependency edge instead, and what happened to the old ad hoc labels.
+---
+
+## Why this exists
+
+Before 2026-07-14 this repo's bd tracker had accumulated at least 8 overlapping
+ad hoc "hold"-family labels with unclear, possibly inconsistent semantics
+(`arch-hold`, `blocked`, `blocked-by-operator`, `blocked-on-external`,
+`blocked-on-upstream`, `blocked-prereq`, `human-hold`/`human`, `on-hold`),
+alongside the one label that already followed the sanctioned convention,
+`hold:mayor`. `ga-tug8ry` audited and consolidated them down to two canonical
+values; `ga-tug8ry.2` migrated every live bead onto the result. This page is
+the durable reference so nobody reinvents another ad hoc hold label — if
+you're about to pause a bead and reach for a new label name, stop and use one
+of the two values below instead.
+
+Full rationale and the live census this decision was based on:
+`bd show ga-tug8ry.1` (the decision) and `bd show ga-tug8ry.2` (the
+migration record, including before/after counts).
+
+## Three orthogonal "not ready" mechanisms
+
+A bead can be "not simply ready to work" for three structurally different
+reasons. Pick the mechanism that matches *why* you're pausing it, not just
+"it's blocked":
+
+| Mechanism | How to set it | Meaning |
+|---|---|---|
+| Dependency edge | `bd dep add <a> <b>` | Bead A cannot start until bd-tracked bead B closes. Gates `bd ready`. Computed from real edges, not a manual claim. |
+| Bead status | `bd update <id> --status blocked` | "I cannot currently proceed," with no further structure about why or who must act. |
+| `hold:<value>` label | `bd set-state <id> hold=<value> --reason "..."` | "I am paused pending a specific actor or condition." Structured, audited (files an event bead), and names the *who*. |
+
+These are orthogonal and combine freely — a bead can be `status=blocked`
+**and** `hold:external` at the same time. Use a dependency edge when the
+blocker is itself a bd bead; use `status=blocked` when nothing more specific
+applies; use `hold:<value>` only when a specific actor or external condition
+is the actual reason you're paused.
+
+## Canonical `hold:<value>` values
+
+Only two values are canonical. Don't introduce a third without a new
+architecture decision — see `ga-tug8ry.1` for the reasoning that narrowed
+the taxonomy to these two.
+
+- **`hold:mayor`** — the required next actor is the mayor. Covers both
+  mayor-initiated pauses and automation-escalated-to-mayor cases; both are
+  the same operational state ("nothing proceeds until the mayor acts") and
+  share one value rather than being split in two.
+- **`hold:external`** — the required next actor or condition is outside this
+  bd instance's control (an external repo's maintainers, an upstream PR
+  merge, etc.). Established by `ga-h7hnpt`.
+
+Set either with the sanctioned command — never with a plain `bd label add`:
+
+```bash
+bd set-state <id> hold=mayor --reason "why, and who/what unblocks it"
+bd set-state <id> hold=external --reason "why, and who/what unblocks it"
+```
+
+`bd set-state` removes any existing label in the `hold:` dimension, adds the
+new one, and files an audit event bead. It does **not** touch `status`,
+`owner`, or `metadata` — update those separately (or add a dependency edge)
+if they also need to change.
+
+## Retired labels
+
+These labels are legacy. If you see one on a live bead, treat it as drift
+worth a bug report, not a pattern to follow.
+
+| Legacy label | Replace with | Notes |
+|---|---|---|
+| `blocked-by-operator` | `hold:mayor` | "Operator" meant the human operator/mayor seat. |
+| `blocked-on-upstream` | `hold:mayor` | Means "next step in our own merge pipeline," not an external repo — despite the name, this is not a `hold:external` synonym. |
+| `human-hold`, bare `human` | `hold:mayor` | Both named the same "next actor is mayor" state as a bare label. Caution: a bare `human` label can also appear alone for an unrelated reason (a human merge/PR action needed) that is not a hold state at all — check the bead's own context before assuming `human` implies a hold. |
+| `blocked-on-external` | `hold:external` | Direct predecessor of `hold:external`; carry forward any `blocker_scope`/`external_blocker`/`external_pr`/`pr`/`repo` metadata unchanged. |
+| `blocked` | none — use native `status=blocked` | Redundant with the bead's own `Status` field; keeping both invites drift between them. |
+| `arch-hold` | none — owned by the `maintainer-pr-review` pack | Not a generic bd hold; it's that pack's own gate, cleared via `gc maintainer-pr-review clear-hold`. It only looked like one of ours because it lacks the `mpr-` prefix its sibling `mpr-human-hold` carries. |
+| `blocked-prereq` | none today; if it recurs, use a dependency edge (prerequisite is a bd bead) or `hold:external` with PR numbers recorded in metadata (prerequisite is bare GitHub PR numbers) | Historical: blocked on specific GitHub PRs merging first, with no corresponding bd bead. |
+| `on-hold` | none — already superseded | Any bead needing this should already carry the canonical `hold:mayor`/`hold:external` in its place. |
+
+**Explicitly out of scope — do not migrate these, they mean something
+different:**
+
+- `mpr-human-hold` and other `mpr-*` labels — owned end-to-end by the
+  `maintainer-pr-review` pack, with its own metadata namespace and its own
+  clearing tool. Not a generic bd hold label.
+- `build-blocker`, `ci-blocker`, `pre-push-blocker`, `push-blocking`,
+  `test-blocker` — a different semantic axis ("pipeline stage X is red
+  because of me"), not "I am waiting on decision-maker Y."
+- `needs-mayor` / `needs-mayor-decision` — a routing/queue-placement label
+  (parallel to `needs-architecture`, `needs-design`, `needs-pm`,
+  `ready-to-build`), not a pause-state label. It may legitimately co-occur
+  with `hold:mayor`.
+
+## This is a data convention, not SDK behavior
+
+Nothing in this page requires or implies special-casing any role name in Go.
+`hold:mayor` and `hold:external` are plain label values in this project's own
+bd data, chosen and enforced by convention — this document, PR review, and
+`bd set-state`'s dimension semantics — not by SDK code. Gas City's "ZERO
+hardcoded roles" invariant is unaffected: nothing under `internal/` or
+`cmd/gc/` branches on the literal label value `hold:mayor` or `hold:external`.
+
+## See also
+
+- `bd show ga-tug8ry.1` — the architecture decision: full live census,
+  per-label disposition rationale, and a label-flow diagram.
+- `bd show ga-tug8ry.2` — the migration record: before/after counts and the
+  beads intentionally skipped (bare `human` used for an unrelated reason).
+- [Beads architecture](../architecture/beads.md) — the generic `Label` and
+  `Store` mechanism this convention is built on.

--- a/engdocs/contributors/index.md
+++ b/engdocs/contributors/index.md
@@ -15,6 +15,9 @@ description: The shortest path for new contributors to get productive in Gas Cit
 - [Huma Usage Notes](huma-usage.md) when touching `internal/api/`,
   OpenAPI generation, or SSE registration
 - [Excalidraw Setup](excalidraw-setup.md) when authoring diagrams for the docs
+- [Hold and Blocked Label Conventions](hold-label-conventions.md) when a bead
+  needs to pause on a specific actor or condition — only `hold:mayor` and
+  `hold:external` are canonical
 - [`CONTRIBUTING.md`](https://github.com/gastownhall/gascity/blob/main/CONTRIBUTING.md)
 - [`TESTING.md`](https://github.com/gastownhall/gascity/blob/main/TESTING.md)
 

--- a/release-gates/ga-y8xzok-hold-blocked-label-taxonomy-gate.md
+++ b/release-gates/ga-y8xzok-hold-blocked-label-taxonomy-gate.md
@@ -1,0 +1,57 @@
+# Release Gate: ga-y8xzok hold/blocked label taxonomy docs
+
+Bead: `ga-y8xzok`
+Branch: `gc-builder-3-y8xzok-v2`
+Candidate commit: `b8f782b8ac1c723e5312bd347e376e20b90d633c`
+Base: `origin/main` at `d1b7c04262e44a4eaef160feafb6c74675991022`
+Gate evaluated: 2026-07-16
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate
+uses the deployer release criteria from the role prompt and the bead's own
+acceptance criteria.
+
+## Result
+
+PASS.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git fetch origin main` succeeded. `git rev-list --left-right --count origin/main...origin/gc-builder-3-y8xzok-v2` returned `0 1`. `git merge-tree --write-tree origin/main origin/gc-builder-3-y8xzok-v2` exited 0 with tree `1a246ea3da4809e711712da2f0460af87d4866c0`. |
+| 1 | Review PASS present | PASS | Review bead `ga-h3h0c2` is closed with `REVIEW VERDICT: PASS` and states no actionable defects were found. |
+| 2 | Acceptance criteria met | PASS | The new `engdocs/contributors/hold-label-conventions.md` names the allowed hold labels, explains dependency edges vs. blocked status vs. hold labels, lists retired labels with replacement/no-op rules, includes `hold:external` and `hold:mayor`, and explicitly states this is a data convention rather than SDK behavior. `git grep` found no `hold:mayor`, `hold:external`, or retired hold-label literals in non-test Go under `cmd/gc` or `internal`. |
+| 3 | Tests pass | PASS | `make check-docs` passed (`go test ./test/docsync`). `go vet ./...` passed. `HOME=/home/jaword make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-h3h0c2` records PASS, OWASP/security N/A for docs-only content, and no actionable defects. No high-severity finding remains open in the review notes. |
+| 5 | Final branch is clean | PASS | Scratch worktree started clean at candidate commit. `git diff --check origin/main...HEAD` passed before adding this gate file. |
+| 7 | Single feature theme | PASS | Single commit and three-file docs-only diff: `AGENTS.md`, `engdocs/contributors/index.md`, and `engdocs/contributors/hold-label-conventions.md`, all for the hold/blocked label taxonomy documentation. |
+
+## Diff Scope
+
+```text
+AGENTS.md                                      |   1 +
+engdocs/contributors/hold-label-conventions.md | 113 +++++++++++++++++++++++++
+engdocs/contributors/index.md                  |   3 +
+3 files changed, 117 insertions(+)
+```
+
+## Test Log Summary
+
+```text
+make check-docs
+ok  	github.com/gastownhall/gascity/test/docsync	5.019s
+
+go vet ./...
+PASS
+
+HOME=/home/jaword make test-fast-parallel
+[fsys-darwin-compile] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-core] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+All fast jobs passed
+```


### PR DESCRIPTION
## What this changes

This adds a contributor reference for the project's canonical hold/blocked label taxonomy. It documents when to use dependency edges, blocked status, or the structured `hold:<value>` state, and narrows the canonical hold values to `hold:mayor` and `hold:external`.

The contributor index now links to the new guide, and `AGENTS.md` points future agents to the rule before inventing another hold-family label.

## Review notes

- Docs-only change under `engdocs/contributors/` plus one `AGENTS.md` pointer.
- No Go code, runtime behavior, SDK primitive, or role-specific branching changes.
- The document explicitly frames `hold:mayor` and `hold:external` as project data conventions, not SDK behavior.

## Test plan

- [x] `make check-docs`
- [x] `go vet ./...`
- [x] `HOME=/home/jaword make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-y8xzok-hold-blocked-label-taxonomy-gate.md`](release-gates/ga-y8xzok-hold-blocked-label-taxonomy-gate.md)
