### PR TITLE
ci: scope qualifying PR static checks to affected packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,11 +183,21 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
       - name: CI workflow policy
         run: make test-ci-policy
+      - name: Classify static-analysis scope
+        id: static-scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          scope="$(scripts/ci-static-scope)"
+          printf 'scope=%s\n' "$scope" >> "$GITHUB_OUTPUT"
       - name: go.mod replace guard
         run: make check-gomod-replace
       - name: Native dependency surface guard
@@ -216,13 +226,29 @@ jobs:
           key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-${{ hashFiles('go.sum', '.golangci.yml') }}
           restore-keys: |
             ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-
-      - name: Lint
+      - name: Lint affected packages
+        if: steps.static-scope.outputs.scope == 'changed'
+        env:
+          GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
+          LINT_CHANGED_SCOPE: tracked
+          LINT_CHANGED_REF: ${{ github.event.pull_request.base.sha }}
+        run: make lint-affected
+      - name: Lint full repository
+        if: steps.static-scope.outputs.scope != 'changed'
         env:
           GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
         run: make lint
-      - name: Format
+      - name: Format changed files
+        if: steps.static-scope.outputs.scope == 'changed'
+        env:
+          LINT_CHANGED_SCOPE: tracked
+          LINT_CHANGED_REF: ${{ github.event.pull_request.base.sha }}
+        run: make fmt-check-changed
+      - name: Format full repository
+        if: steps.static-scope.outputs.scope != 'changed'
         run: make fmt-check
       - name: Vet
+        if: steps.static-scope.outputs.scope != 'changed'
         run: make vet
       - name: Docs
         run: make check-docs

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,9 @@ formatters:
     - goimports
 
 linters:
-  # Keep govet explicit for full-repository lint. The changed-scope target
-  # disables this copy and runs the Go tool's vet over the same affected graph.
+  # Keep govet explicit in configured lint. The changed-scope target bounds
+  # both this copy and the Go tool's vet to the same affected graph, preserving
+  # their distinct diagnostics without repeating either across the whole repo.
   # Other default linters (errcheck, ineffassign, staticcheck, unused) remain
   # enabled alongside these configured extras.
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,9 +13,12 @@ formatters:
     - goimports
 
 linters:
-  # Default linters (errcheck, govet, ineffassign, staticcheck, unused)
-  # are always enabled. Add extras here.
+  # Keep govet explicit for full-repository lint. The changed-scope target
+  # disables this copy and runs the Go tool's vet over the same affected graph.
+  # Other default linters (errcheck, ineffassign, staticcheck, unused) remain
+  # enabled alongside these configured extras.
   enable:
+    - govet
     - errorlint
     - misspell
     - gocritic

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-ci-policy test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover check-self-contained install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go dashboard-e2e-play dashboard-e2e
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed lint-affected fmt-check fmt-check-changed fmt vet test test-ci-policy test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover check-self-contained install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go dashboard-e2e-play dashboard-e2e
 .PHONY: check-release-dist-ignore
 
 ## build: compile gc binary with version metadata
@@ -259,6 +259,8 @@ LINT_BASE ?= origin/main
 LINT_CHANGED_REF ?= HEAD
 LINT_CHANGED_SCOPE ?= worktree
 LINT_FLAGS ?=
+CI_STATIC_SELECT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))scripts/ci-static-select
+CI_STATIC_GO ?= go
 
 ## lint: run full-repo golangci-lint
 lint: lint-full
@@ -307,9 +309,17 @@ lint-changed: $(GOLANGCI_LINT)
 	echo "lint-changed: $$(printf '%s\n' "$$pkgs" | tr '\n' ' ')"; \
 	$(GOLANGCI_LINT) run $(LINT_FLAGS) $$pkgs
 
+## lint-affected: lint packages affected by changed Go build inputs or embedded files
+lint-affected: $(GOLANGCI_LINT)
+	@"$(CI_STATIC_SELECT)" lint-affected "$(GOLANGCI_LINT)" "$(CI_STATIC_GO)" $(LINT_FLAGS)
+
 ## fmt-check: fail if formatting would change files
 fmt-check: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) fmt --diff ./...
+
+## fmt-check-changed: fail if formatting would change a regular changed Go file
+fmt-check-changed: $(GOLANGCI_LINT)
+	@"$(CI_STATIC_SELECT)" fmt-check-changed "$(GOLANGCI_LINT)"
 
 ## fmt: auto-fix formatting
 fmt: $(GOLANGCI_LINT)
@@ -385,6 +395,7 @@ test-ci-policy:
 	$(TEST_ENV) PYTHONDONTWRITEBYTECODE=1 python3 -S -m unittest discover -s .github/workflows/scripts -p 'test_runner_policy.py'
 	$(TEST_ENV) PYTHONDONTWRITEBYTECODE=1 python3 -S -m unittest discover -s .github/workflows/scripts -p 'test_ci_suite_coverage.py'
 	$(TEST_ENV) GOFLAGS= GOENV=off GOWORK=off go test -count=1 ./scripts/cipolicy
+	$(TEST_ENV) GOFLAGS= GOENV=off GOWORK=off go test -count=1 -run '^(TestPreflightStaticScopesOrdinaryPRsWithoutWeakeningProtectedRuns|TestFullStaticLintExplicitlyOwnsConfiguredGolangCIGovet|TestChangedStaticTargetsScopeLintAndFormattingToTheDiff|TestCIStaticScopeClassifierFailsClosedOutsideValidatedPullRequestMerge)$$' ./scripts
 
 ## test: run fast unit tests (skip integration-tagged and GC_FAST_UNIT-gated process tests)
 ## The skipped cmd/gc process-backed scenarios remain covered by

--- a/TESTING.md
+++ b/TESTING.md
@@ -275,6 +275,80 @@ Raw `go test` is still appropriate for a focused package or a single failing
 test. Do not use it as the default for full local sweeps when a sharded target
 exists.
 
+#### PR static-check scope
+
+The `preflight-static` job has two fail-safe scopes. Only an effective
+`pull_request` event whose default checkout is validated as GitHub's two-parent
+synthetic merge, with its first parent equal to the event's exact base SHA, may
+use the changed scope. The checkout keeps the default `GITHUB_SHA` and uses
+`fetch-depth: 2` so that validation is local and exact. A missing or different
+base, a non-merge checkout, or an unknown event selects the full scope.
+
+Pushes to `main`, schedules, manual dispatches, and every other non-PR event run
+the full static suite. Reusable workflows inherit their caller's event; the
+reusable call itself grants no changed-scope exemption. An effective
+`pull_request` event may still qualify after the same synthetic-merge
+validation, while an invocation such as the current RC `workflow_dispatch`
+remains full. The classifier never guesses a base from `origin/main` or a
+merge-base calculation.
+
+Even a validated PR merge runs the full scope when its diff touches static
+analysis or build policy:
+
+- `go.mod`, `go.sum`, `go.work`, or `go.work.sum`
+- `.golangci.yml` or `Makefile`
+- `.github/workflows/**`, `.github/actions/**`, or `.githooks/**`
+- `vendor/**` or `scripts/cipolicy/**`
+- `scripts/ci-static-scope` and `scripts/ci-static-select`
+
+The two scopes own different commands:
+
+| Scope | Commands | Selection guarantee |
+| --- | --- | --- |
+| Changed PR | `make lint-affected`, `make fmt-check-changed` | Lint and vet every package owning a changed Go build input or embedded file, plus all transitive reverse dependents; format-check only changed regular `.go` files that still exist. |
+| Full/fail-safe | `make lint`, `make fmt-check`, `make vet` | Analyze and format-check the whole repository, then run standalone `go vet ./...`. |
+
+Affected-package discovery examines every changed path. It selects packages
+for changed Go-tool build inputs (`.go`, `.c`, `.cc`, `.cpp`, `.cxx`, `.m`,
+`.h`, `.hh`, `.hpp`, `.hxx`, `.f`, `.F`, `.for`, `.f90`, `.s`, `.S`, `.sx`,
+`.swig`, `.swigcxx`, and `.syso`) and maps changed embedded files to every
+owning package using `EmbedFiles`, `TestEmbedFiles`, and `XTestEmbedFiles` from
+the canonical records in one complete `go list -test -json ./...` graph.
+Additions, modifications, deletions, and both sides of cross-package moves are
+included. Git rename coalescing is disabled so a move cannot hide the old
+package. An unrelated non-build, non-embedded path remains a no-op.
+
+Reverse dependents are included because analyzers such as `govet` consume
+exported facts, including through test-only imports. If the package graph
+cannot be loaded completely, affected lint fails safe to `./...` instead of
+trusting a partial graph. This includes a deleted required embed input. A
+deleted glob member no longer appears in the current resolved embed inventory,
+so an otherwise-unclassified deletion beneath a package also fails safe to
+full scope. File selection is NUL-delimited. Formatting remains limited to
+changed `.go` paths, excludes deletions and symlinks, accepts only existing
+regular files, and never invokes the formatter with an empty file list.
+
+`lint-affected` is the conservative PR target. It runs the configured
+golangci linters with golangci's `govet` copy disabled, then runs the Go tool's
+`vet` over the exact same affected package closure. That avoids duplicate vet
+analysis without losing standalone-vet diagnostics in generated files or
+unchanged reverse dependents. `lint-changed` remains the faster
+local/pre-commit target and intentionally checks only packages that contain
+changed Go files. Both accept `LINT_CHANGED_SCOPE` and `LINT_CHANGED_REF`; CI
+uses `tracked` and the event's exact PR base SHA.
+
+The golangci configuration still enables `govet` explicitly for full lint.
+Golangci's `govet` execution is not assumed to be semantically equivalent to
+standalone `go vet ./...`: generated-file exclusions and analyzer/configuration
+drift can differ. Full-scope runs therefore retain standalone vet, while the
+changed lane directly invokes standalone vet on its conservative closure.
+
+`make test-ci-policy` runs independently of changed/full static selection and
+always executes the focused workflow-scope, golangci-`govet`, affected-target,
+and fail-closed-classifier contracts. A self-binding test in the existing CI
+policy package rejects any Makefile change that removes this focused Go suite
+from the target.
+
 #### Historical timing summaries
 
 The opt-in timing artifacts produced by `scripts/go-test-observable` can be

--- a/TESTING.md
+++ b/TESTING.md
@@ -313,7 +313,8 @@ for changed Go-tool build inputs (`.go`, `.c`, `.cc`, `.cpp`, `.cxx`, `.m`,
 `.h`, `.hh`, `.hpp`, `.hxx`, `.f`, `.F`, `.for`, `.f90`, `.s`, `.S`, `.sx`,
 `.swig`, `.swigcxx`, and `.syso`) and maps changed embedded files to every
 owning package using `EmbedFiles`, `TestEmbedFiles`, and `XTestEmbedFiles` from
-the canonical records in one complete `go list -test -json ./...` graph.
+the canonical records in one complete
+`go list -mod=readonly -test -json ./...` graph.
 Additions, modifications, deletions, and both sides of cross-package moves are
 included. Git rename coalescing is disabled so a move cannot hide the old
 package. Native compiler include and linker inputs can have recognized or
@@ -329,10 +330,13 @@ exported facts, including through test-only imports. If the package graph
 cannot be loaded completely, affected lint fails safe to `./...` instead of
 trusting a partial graph. This includes a deleted required embed input. A
 deleted glob member no longer appears in the current resolved embed inventory,
-so any deletion beneath a package that has neither a current embed owner nor a
-current direct package owner also fails safe to full scope. This guard runs
-before native shared-input shortcuts, including for recognized headers. File
-selection is NUL-delimited. Formatting remains limited to
+so a deletion that may match any current `EmbedPatterns`, `TestEmbedPatterns`,
+or `XTestEmbedPatterns` entry fails safe even when a nested package still owns
+the deleted build-input directory. Any other deletion beneath a package that
+has neither a current embed owner nor a current direct package owner also fails
+safe to full scope. These guards run before native shared-input shortcuts,
+including for recognized headers. File selection is NUL-delimited. Formatting
+remains limited to
 changed `.go` paths, excludes deletions and symlinks, accepts only existing
 regular files, and never invokes the formatter with an empty file list.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -296,7 +296,7 @@ Even a validated PR merge runs the full scope when its diff touches static
 analysis or build policy:
 
 - `go.mod`, `go.sum`, `go.work`, or `go.work.sum`
-- `.golangci.yml` or `Makefile`
+- any root `.golangci.*` configuration or `Makefile`
 - `.github/workflows/**`, `.github/actions/**`, or `.githooks/**`
 - `vendor/**` or `scripts/cipolicy/**`
 - `scripts/ci-static-scope` and `scripts/ci-static-select`
@@ -305,7 +305,7 @@ The two scopes own different commands:
 
 | Scope | Commands | Selection guarantee |
 | --- | --- | --- |
-| Changed PR | `make lint-affected`, `make fmt-check-changed` | Lint and vet every package owning a changed Go build input or embedded file, plus all transitive reverse dependents; format-check only changed regular `.go` files that still exist. |
+| Changed PR | `make lint-affected`, `make fmt-check-changed` | Lint and vet every package owning a changed Go build input or embedded file, every native package that could consume a changed path, and all transitive reverse dependents; format-check only changed regular `.go` files that still exist. |
 | Full/fail-safe | `make lint`, `make fmt-check`, `make vet` | Analyze and format-check the whole repository, then run standalone `go vet ./...`. |
 
 Affected-package discovery examines every changed path. It selects packages
@@ -316,32 +316,42 @@ owning package using `EmbedFiles`, `TestEmbedFiles`, and `XTestEmbedFiles` from
 the canonical records in one complete `go list -test -json ./...` graph.
 Additions, modifications, deletions, and both sides of cross-package moves are
 included. Git rename coalescing is disabled so a move cannot hide the old
-package. An unrelated non-build, non-embedded path remains a no-op.
+package. Native compiler include and linker inputs can have recognized or
+arbitrary names and may live outside their consuming package. Every changed
+path therefore selects every package with native Go-tool sources, plus their
+reverse dependents. This is the smallest sound scope available without trying
+to duplicate compiler-specific dependency discovery. An unrelated non-build,
+non-embedded path remains a no-op when the graph has no native package that
+could consume it.
 
 Reverse dependents are included because analyzers such as `govet` consume
 exported facts, including through test-only imports. If the package graph
 cannot be loaded completely, affected lint fails safe to `./...` instead of
 trusting a partial graph. This includes a deleted required embed input. A
 deleted glob member no longer appears in the current resolved embed inventory,
-so an otherwise-unclassified deletion beneath a package also fails safe to
-full scope. File selection is NUL-delimited. Formatting remains limited to
+so any deletion beneath a package that has neither a current embed owner nor a
+current direct package owner also fails safe to full scope. This guard runs
+before native shared-input shortcuts, including for recognized headers. File
+selection is NUL-delimited. Formatting remains limited to
 changed `.go` paths, excludes deletions and symlinks, accepts only existing
 regular files, and never invokes the formatter with an empty file list.
 
 `lint-affected` is the conservative PR target. It runs the configured
-golangci linters with golangci's `govet` copy disabled, then runs the Go tool's
-`vet` over the exact same affected package closure. That avoids duplicate vet
-analysis without losing standalone-vet diagnostics in generated files or
-unchanged reverse dependents. `lint-changed` remains the faster
-local/pre-commit target and intentionally checks only packages that contain
-changed Go files. Both accept `LINT_CHANGED_SCOPE` and `LINT_CHANGED_REF`; CI
-uses `tracked` and the event's exact PR base SHA.
+golangci linters, including golangci's `govet`, then runs the Go tool's `vet`
+over the exact same affected package closure. The bounded duplicate preserves
+both tools' distinct diagnostics without repeating either analysis across the
+whole repository. It also retains standalone-vet diagnostics in generated
+files and unchanged reverse dependents. If selection fails, the same pair runs
+over `./...`; fallback never disables configured linters. `lint-changed`
+remains the faster local/pre-commit target and intentionally checks only
+packages that contain changed Go files. Both accept `LINT_CHANGED_SCOPE` and
+`LINT_CHANGED_REF`; CI uses `tracked` and the event's exact PR base SHA.
 
-The golangci configuration still enables `govet` explicitly for full lint.
+The golangci configuration enables `govet` explicitly in both scopes.
 Golangci's `govet` execution is not assumed to be semantically equivalent to
-standalone `go vet ./...`: generated-file exclusions and analyzer/configuration
-drift can differ. Full-scope runs therefore retain standalone vet, while the
-changed lane directly invokes standalone vet on its conservative closure.
+standalone `go vet`: generated-file exclusions and analyzer/configuration drift
+can differ. Full-scope runs therefore retain standalone `go vet ./...`, while
+the changed lane invokes standalone vet on its conservative closure.
 
 `make test-ci-policy` runs independently of changed/full static selection and
 always executes the focused workflow-scope, golangci-`govet`, affected-target,

--- a/engdocs/contributors/testing-pyramid-hardening-plan.md
+++ b/engdocs/contributors/testing-pyramid-hardening-plan.md
@@ -919,6 +919,76 @@ the reference runner.
 
 **Dependencies:** P0.2 timing output. **Estimate:** medium.
 
+#### P0.6 — Scope ordinary-PR static work without weakening full runs
+
+**Change:** Let only a validated effective `pull_request` synthetic merge run
+impact-scoped lint and formatting. Validate the default `GITHUB_SHA` checkout
+against the event's exact base SHA with both merge parents present; never infer
+the base from a mutable ref or a merge-base calculation. Every effective
+non-PR or unknown event, invalid checkout/base, and protected static-policy
+change fails safe to full lint, full formatting, and standalone vet. Reusable
+workflows inherit the caller event and receive no exemption of their own: an
+effective `pull_request` may qualify only after the same validation, while the
+current RC `workflow_dispatch` remains full.
+
+The changed lint scope contains packages affected by added, modified, deleted,
+or moved Go-tool build inputs and packages owning changed embedded files, plus
+all transitive reverse dependents. Build inputs include Go, assembly,
+cgo/C/C++/Objective-C, header, Fortran, SWIG, and syso files. Embed ownership
+comes from the canonical package records and their production, internal-test,
+and external-test resolved embed inventories in one `go list -test -json ./...`
+graph. Multiple owners are retained. The reverse-dependency closure preserves
+analyzer-fact consumers that did not change textually, including test-only
+importers. An incomplete package graph, a deleted required embed input, or an
+otherwise-unclassified deletion beneath a package fails safe to full-repository
+lint instead of using a partial closure. Changed formatting receives only
+exact existing regular, non-symlink `.go` paths, with NUL-safe handling for
+spaces and no empty formatter invocation. Keep `lint-changed` as the smaller
+local/pre-commit target; the PR workflow uses the distinct conservative
+`lint-affected` target. That target disables golangci's `govet` copy and runs
+the Go tool's exact vet over the same closure, preserving generated-file
+diagnostics without duplicate vet analysis.
+
+Protected full-scope paths are the Go module/workspace files,
+`.golangci.yml`, `Makefile`, workflow/action definitions, hooks, vendored code,
+`scripts/cipolicy/**`, `scripts/ci-static-scope`, and
+`scripts/ci-static-select`. Pushes to `main`, schedules, dispatches (including
+the current reusable RC caller), and any unrecognized event also stay full.
+
+**Acceptance:** The workflow runs `lint-affected` and
+`fmt-check-changed` only when the classifier emits `changed`. It uses
+`scope != 'changed'`, rather than equality with a second expected value, for
+full lint, full format, and standalone vet so a missing output cannot skip
+them. Golangci enables `govet` explicitly for full lint. Affected lint disables
+that copy and invokes standalone vet over the identical package arguments;
+every full-scope run retains standalone full-repository vet.
+
+**Verification:** Synthetic-repository contracts cover a valid PR merge,
+wrong/missing base, non-merge checkout, every non-PR/unknown event, protected
+paths, changed/deleted/moved Go files, assembly and other recognized Go-tool
+build inputs, production/internal-test/external-test embedded assets, multiple
+embed owners, a deleted required input and deleted glob member's full-scope
+fallback, unrelated non-build/non-embedded no-op diffs, filenames containing
+spaces, transitive and test-only reverse dependents, a generated
+reverse-dependent diagnostic, and a broken package graph's full-lint fallback.
+Workflow policy tests bind the classifier inputs, exact conditions, checkout
+depth, commands, and explicit `govet` configuration. `make test-ci-policy`
+always runs the four focused static-policy Go contracts, and a self-binding
+contract proves that the Make target cannot silently drop that suite.
+
+**Owner/status:** `ga-80po0c.21`; active implementation slice. The measured
+baseline is PR #4336 Actions run
+[29483623514](https://github.com/gastownhall/gascity/actions/runs/29483623514):
+the static job took 257 seconds, including 120 seconds of full lint, 19 seconds
+of full formatting, and 13 seconds of standalone vet. Qualifying ordinary PRs
+therefore remove 152 seconds of broad static work from the critical path before
+paying the smaller affected-lint/affected-vet/changed-format replacement cost.
+The 61-second native-dependency guard and all other static guards remain. These
+are a current implementation baseline and expected gross saving; they do not
+rewrite the historical #4193 measurements above.
+
+**Dependencies:** P0.1. **Estimate:** small-medium.
+
 #### E1 — Make the E2E/provider manifest executable
 
 **Change:** Encode J1-J4 and provider proofs with owner, system promise,
@@ -1696,7 +1766,7 @@ With P0.1 merged, start four bounded workstreams:
 | Contract truth | H1, H2, H3, H4 | Prevents false confidence before consolidation. |
 | Architectural extraction | D8 and D9, then D4 and D5/D6 | Removes duplicated route policy, makes split-store dispatch testable, then attacks the API and `cmd/gc` compile/global-state centers. |
 | Lifecycle signals | W1 and W3 | Replaces representative process and API polling with reusable patterns. |
-| Measurement/policy | P0.2-P0.5 and E1 | Makes runtime, size, race, skip, and E2E ownership enforceable. |
+| Measurement/policy | P0.2-P0.6 and E1 | Makes runtime, size, race, static scope, skip, and E2E ownership enforceable. |
 
 Start D8 and D9 immediately as bounded high-ROI extractions; add D9's real-
 store composition proof after H3 truth is established. H5 follows the runtime

--- a/engdocs/contributors/testing-pyramid-hardening-plan.md
+++ b/engdocs/contributors/testing-pyramid-hardening-plan.md
@@ -939,18 +939,25 @@ comes from the canonical package records and their production, internal-test,
 and external-test resolved embed inventories in one `go list -test -json ./...`
 graph. Multiple owners are retained. The reverse-dependency closure preserves
 analyzer-fact consumers that did not change textually, including test-only
-importers. An incomplete package graph, a deleted required embed input, or an
-otherwise-unclassified deletion beneath a package fails safe to full-repository
-lint instead of using a partial closure. Changed formatting receives only
+importers. An incomplete package graph, a deleted required embed input, or a
+deletion beneath a package with neither a current embed owner nor a current
+direct package owner fails safe to full-repository lint before native-input
+shortcuts. Changed formatting receives only
 exact existing regular, non-symlink `.go` paths, with NUL-safe handling for
 spaces and no empty formatter invocation. Keep `lint-changed` as the smaller
 local/pre-commit target; the PR workflow uses the distinct conservative
-`lint-affected` target. That target disables golangci's `govet` copy and runs
-the Go tool's exact vet over the same closure, preserving generated-file
-diagnostics without duplicate vet analysis.
+`lint-affected` target. That target runs configured golangci, including its
+`govet` copy, and the Go tool's exact vet over the same closure. The bounded
+duplicate preserves both diagnostic surfaces without repeating either across
+the whole repository. Any selection failure runs both configured lint and
+standalone vet over `./...`; fallback never disables a configured linter.
+Native include and linker inputs can have recognized or arbitrary names and may
+live outside the consuming package, so every changed path selects every package
+with native Go-tool sources plus its reverse dependents.
 
 Protected full-scope paths are the Go module/workspace files,
-`.golangci.yml`, `Makefile`, workflow/action definitions, hooks, vendored code,
+every root `.golangci.*` configuration, `Makefile`, workflow/action definitions,
+hooks, vendored code,
 `scripts/cipolicy/**`, `scripts/ci-static-scope`, and
 `scripts/ci-static-select`. Pushes to `main`, schedules, dispatches (including
 the current reusable RC caller), and any unrecognized event also stay full.
@@ -959,14 +966,17 @@ the current reusable RC caller), and any unrecognized event also stay full.
 `fmt-check-changed` only when the classifier emits `changed`. It uses
 `scope != 'changed'`, rather than equality with a second expected value, for
 full lint, full format, and standalone vet so a missing output cannot skip
-them. Golangci enables `govet` explicitly for full lint. Affected lint disables
-that copy and invokes standalone vet over the identical package arguments;
-every full-scope run retains standalone full-repository vet.
+them. Golangci enables `govet` explicitly in both scopes, and affected lint
+invokes standalone vet over the identical package arguments. Every selection
+fallback and full-scope run retains configured golangci plus standalone
+full-repository vet.
 
 **Verification:** Synthetic-repository contracts cover a valid PR merge,
 wrong/missing base, non-merge checkout, every non-PR/unknown event, protected
 paths, changed/deleted/moved Go files, assembly and other recognized Go-tool
-build inputs, production/internal-test/external-test embedded assets, multiple
+build inputs, arbitrary native include fragments, recognized shared headers,
+and a deleted recognized glob member before native fallback,
+production/internal-test/external-test embedded assets, multiple
 embed owners, a deleted required input and deleted glob member's full-scope
 fallback, unrelated non-build/non-embedded no-op diffs, filenames containing
 spaces, transitive and test-only reverse dependents, a generated

--- a/scripts/ci-static-scope
+++ b/scripts/ci-static-scope
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Classify static analysis as changed-file or full-repository scope."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+PROTECTED_FILES = frozenset(
+    {
+        "go.mod",
+        "go.sum",
+        "go.work",
+        "go.work.sum",
+        ".golangci.yml",
+        "Makefile",
+        "scripts/ci-static-scope",
+        "scripts/ci-static-select",
+    }
+)
+PROTECTED_PREFIXES = (
+    ".github/workflows/",
+    ".github/actions/",
+    ".githooks/",
+    "vendor/",
+    "scripts/cipolicy/",
+)
+
+
+def git_output(*args: str) -> bytes:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    return completed.stdout
+
+
+def changed_scope_is_safe() -> bool:
+    if os.environ.get("EVENT_NAME") != "pull_request":
+        return False
+
+    requested_base = os.environ.get("PR_BASE_SHA", "")
+    if not requested_base:
+        return False
+
+    resolved_base = git_output(
+        "rev-parse", "--verify", "--end-of-options", f"{requested_base}^{{commit}}"
+    ).decode("ascii").strip()
+    if resolved_base != requested_base:
+        return False
+
+    head_and_parents = git_output("rev-list", "--parents", "-n", "1", "HEAD").decode(
+        "ascii"
+    ).split()
+    if len(head_and_parents) != 3 or head_and_parents[1] != resolved_base:
+        return False
+
+    changed = git_output(
+        "diff", "--name-only", "-z", "--no-renames", resolved_base, "HEAD", "--"
+    )
+    paths = changed.split(b"\0")
+    if paths and paths[-1] == b"":
+        paths.pop()
+    for raw_path in paths:
+        path = os.fsdecode(raw_path)
+        if path in PROTECTED_FILES or path.startswith(PROTECTED_PREFIXES):
+            return False
+    return True
+
+
+def main() -> int:
+    try:
+        scope = "changed" if changed_scope_is_safe() else "full"
+    except (OSError, subprocess.SubprocessError, UnicodeError):
+        scope = "full"
+    print(scope)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-static-scope
+++ b/scripts/ci-static-scope
@@ -14,13 +14,13 @@ PROTECTED_FILES = frozenset(
         "go.sum",
         "go.work",
         "go.work.sum",
-        ".golangci.yml",
         "Makefile",
         "scripts/ci-static-scope",
         "scripts/ci-static-select",
     }
 )
 PROTECTED_PREFIXES = (
+    ".golangci.",
     ".github/workflows/",
     ".github/actions/",
     ".githooks/",

--- a/scripts/ci-static-select
+++ b/scripts/ci-static-select
@@ -40,6 +40,19 @@ GO_BUILD_INPUT_SUFFIXES = frozenset(
 
 EMBED_FILE_FIELDS = ("EmbedFiles", "TestEmbedFiles", "XTestEmbedFiles")
 
+NATIVE_SOURCE_FIELDS = (
+    "CgoFiles",
+    "CFiles",
+    "CXXFiles",
+    "MFiles",
+    "HFiles",
+    "FFiles",
+    "SFiles",
+    "SwigFiles",
+    "SwigCXXFiles",
+    "SysoFiles",
+)
+
 
 class SelectionError(Exception):
     """The changed scope could not be selected without losing coverage."""
@@ -186,6 +199,7 @@ def affected_package_args(
     import_by_dir: dict[str, str] = {}
     arg_by_import: dict[str, str] = {}
     embed_owners: dict[str, set[str]] = defaultdict(set)
+    native_imports: set[str] = set()
 
     for package in package_records:
         import_path = package.get("ImportPath")
@@ -217,25 +231,52 @@ def affected_package_args(
             for embedded in string_list(package, field):
                 embed_owners[embedded_repo_path(relative_dir, embedded)].add(import_path)
 
+        native_sources: list[str] = []
+        for field in NATIVE_SOURCE_FIELDS:
+            native_sources.extend(string_list(package, field))
+        ignored_native_sources = (
+            path
+            for path in string_list(package, "IgnoredOtherFiles")
+            if is_go_build_input(path)
+        )
+        if native_sources or any(ignored_native_sources):
+            native_imports.add(import_path)
+
     seeds: set[str] = set()
     for status, path in changed:
         owners = embed_owners.get(path, set())
         seeds.update(owners)
-        if is_go_build_input(path):
+        # Native compilers can consume inputs with arbitrary names and from
+        # shared directories. The Go package inventory does not expose that
+        # dependency graph, so every native package is the smallest safe scope
+        # for every changed path without duplicating compiler discovery.
+        seeds.update(native_imports)
+        build_input = is_go_build_input(path)
+        import_path = None
+        directory = ""
+        if build_input:
             directory = posixpath.dirname(path) or "."
             import_path = import_by_dir.get(directory)
-            if import_path is None:
-                raise SelectionError(
-                    f"changed Go build-input directory {directory!r} has no unique package"
-                )
-            seeds.add(import_path)
-        elif status == "D" and not owners and any(
-            path_is_beneath_package(path, package_dir)
-            for package_dir in import_by_dir
+        if (
+            status == "D"
+            and not owners
+            and (not build_input or import_path is None)
+            and any(
+                path_is_beneath_package(path, package_dir)
+                for package_dir in import_by_dir
+            )
         ):
             raise SelectionError(
                 f"deleted path {path!r} may be absent from the current embed inventory"
             )
+        if build_input:
+            if import_path is None:
+                if native_imports and not path.endswith(".go"):
+                    continue
+                raise SelectionError(
+                    f"changed Go build-input directory {directory!r} has no unique package"
+                )
+            seeds.add(import_path)
 
     if not seeds:
         return []
@@ -276,9 +317,7 @@ def run_static_checks(
     lint_flags: list[str],
     packages: list[str],
 ) -> int:
-    lint_result = run_tool(
-        [lint_tool, "run", "--disable=govet", *lint_flags, *packages]
-    )
+    lint_result = run_tool([lint_tool, "run", *lint_flags, *packages])
     if lint_result != 0:
         return lint_result
     return run_tool([go_tool, "vet", *packages])
@@ -306,7 +345,7 @@ def lint_affected(
     except SelectionError as error:
         return full_static_checks(lint_tool, go_tool, lint_flags, error)
     if not packages:
-        print("lint-affected: no changed Go build inputs or embedded files")
+        print("lint-affected: no changed Go build inputs, embedded files, or native consumers")
         return 0
     print(f"lint-affected: {' '.join(packages)}")
     return run_static_checks(lint_tool, go_tool, lint_flags, packages)

--- a/scripts/ci-static-select
+++ b/scripts/ci-static-select
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Run changed-Go formatting or affected-package static checks without lossy paths."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+import json
+import os
+import posixpath
+import stat
+import subprocess
+import sys
+from typing import Any, Iterable
+
+
+GO_BUILD_INPUT_SUFFIXES = frozenset(
+    {
+        ".go",
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".m",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".f",
+        ".F",
+        ".for",
+        ".f90",
+        ".s",
+        ".S",
+        ".sx",
+        ".swig",
+        ".swigcxx",
+        ".syso",
+    }
+)
+
+EMBED_FILE_FIELDS = ("EmbedFiles", "TestEmbedFiles", "XTestEmbedFiles")
+
+
+class SelectionError(Exception):
+    """The changed scope could not be selected without losing coverage."""
+
+
+def command_output(args: list[str]) -> bytes:
+    try:
+        completed = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as error:
+        raise SelectionError(f"cannot run {args[0]!r}: {error}") from error
+    if completed.returncode != 0:
+        detail = os.fsdecode(completed.stderr).strip()
+        raise SelectionError(detail or f"command failed with exit {completed.returncode}")
+    return completed.stdout
+
+
+def parse_name_status(output: bytes) -> list[tuple[str, str]]:
+    fields = output.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    if len(fields) % 2 != 0:
+        raise SelectionError("git produced a malformed NUL-delimited name-status diff")
+
+    records: list[tuple[str, str]] = []
+    for index in range(0, len(fields), 2):
+        status = os.fsdecode(fields[index])
+        path = os.fsdecode(fields[index + 1])
+        if len(status) != 1 or status not in "ACDMRT":
+            raise SelectionError(f"git produced unsupported status {status!r}")
+        if not path or os.path.isabs(path) or ".." in path.split("/"):
+            raise SelectionError(f"git produced unsafe path {path!r}")
+        records.append((status, path))
+    return records
+
+
+def diff_records() -> list[tuple[str, str]]:
+    scope = os.environ.get("LINT_CHANGED_SCOPE", "worktree")
+    ref = os.environ.get("LINT_CHANGED_REF", "HEAD")
+    common = [
+        "git",
+        "diff",
+        "--name-status",
+        "-z",
+        "--no-renames",
+        "--diff-filter=ACDMRT",
+    ]
+
+    if scope == "staged":
+        return parse_name_status(command_output([*common, "--cached", "--"]))
+    if scope not in {"tracked", "worktree"}:
+        raise SelectionError(
+            f"unknown LINT_CHANGED_SCOPE={scope}; expected staged, tracked, or worktree"
+        )
+
+    resolved_ref = os.fsdecode(
+        command_output(
+            ["git", "rev-parse", "--verify", "--end-of-options", f"{ref}^{{commit}}"]
+        )
+    ).strip()
+    records = parse_name_status(command_output([*common, resolved_ref, "--"]))
+    if scope == "worktree":
+        untracked = command_output(
+            ["git", "ls-files", "--others", "--exclude-standard", "-z", "--"]
+        ).split(b"\0")
+        records.extend(
+            ("A", os.fsdecode(path)) for path in untracked if path
+        )
+    return sorted(set(records), key=lambda record: (record[1], record[0]))
+
+
+def decode_json_stream(raw: bytes) -> list[dict[str, Any]]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise SelectionError(f"go list emitted non-UTF-8 JSON: {error}") from error
+
+    decoder = json.JSONDecoder()
+    packages: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        while offset < len(text) and text[offset].isspace():
+            offset += 1
+        if offset == len(text):
+            return packages
+        try:
+            value, offset = decoder.raw_decode(text, offset)
+        except json.JSONDecodeError as error:
+            raise SelectionError(f"go list emitted malformed JSON: {error}") from error
+        if not isinstance(value, dict):
+            raise SelectionError("go list emitted a non-object package record")
+        packages.append(value)
+
+
+def string_list(package: dict[str, Any], field: str) -> list[str]:
+    value = package.get(field, [])
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise SelectionError(f"go list field {field} is not a string list")
+    return value
+
+
+def is_go_build_input(path: str) -> bool:
+    return any(path.endswith(suffix) for suffix in GO_BUILD_INPUT_SUFFIXES)
+
+
+def embedded_repo_path(relative_dir: str, embedded: str) -> str:
+    if not embedded or posixpath.isabs(embedded):
+        raise SelectionError(f"go list emitted unsafe embedded path {embedded!r}")
+    normalized = posixpath.normpath(embedded)
+    if normalized != embedded or normalized == ".." or normalized.startswith("../"):
+        raise SelectionError(f"go list emitted unsafe embedded path {embedded!r}")
+    if relative_dir == ".":
+        return normalized
+    return posixpath.join(relative_dir, normalized)
+
+
+def path_is_beneath_package(path: str, package_dir: str) -> bool:
+    return package_dir == "." or path.startswith(package_dir + "/")
+
+
+def affected_package_args(
+    records: Iterable[tuple[str, str]], go_tool: str
+) -> list[str]:
+    changed = list(records)
+    if not changed:
+        return []
+
+    raw_graph = command_output([go_tool, "list", "-test", "-json", "./..."])
+    package_records: list[dict[str, Any]] = []
+    for package in decode_json_stream(raw_graph):
+        for_test = package.get("ForTest")
+        if for_test is not None and not isinstance(for_test, str):
+            raise SelectionError("go list field ForTest is not a string")
+        matches = string_list(package, "Match")
+        if for_test or not matches:
+            continue
+        package_records.append(package)
+    if not package_records:
+        raise SelectionError("go list returned no packages for changed paths")
+
+    repo_root = os.path.abspath(
+        os.fsdecode(command_output(["git", "rev-parse", "--show-toplevel"])).strip()
+    )
+    by_import: dict[str, dict[str, Any]] = {}
+    import_by_dir: dict[str, str] = {}
+    arg_by_import: dict[str, str] = {}
+    embed_owners: dict[str, set[str]] = defaultdict(set)
+
+    for package in package_records:
+        import_path = package.get("ImportPath")
+        directory = package.get("Dir")
+        if not isinstance(import_path, str) or not import_path:
+            raise SelectionError("go list package is missing ImportPath")
+        if not isinstance(directory, str) or not directory:
+            raise SelectionError(f"go list package {import_path!r} is missing Dir")
+        if package.get("Error") or package.get("DepsErrors") or package.get("Incomplete"):
+            raise SelectionError(f"go list reported an incomplete graph at {import_path}")
+        if import_path in by_import:
+            raise SelectionError(f"go list returned duplicate import path {import_path}")
+
+        absolute_dir = os.path.abspath(directory)
+        try:
+            if os.path.commonpath([repo_root, absolute_dir]) != repo_root:
+                raise SelectionError(f"package {import_path} is outside the repository")
+        except ValueError as error:
+            raise SelectionError(f"package {import_path} is outside the repository") from error
+        relative_dir = os.path.relpath(absolute_dir, repo_root).replace(os.sep, "/")
+        if relative_dir in import_by_dir:
+            raise SelectionError(f"multiple packages map to directory {relative_dir}")
+
+        by_import[import_path] = package
+        import_by_dir[relative_dir] = import_path
+        arg_by_import[import_path] = "." if relative_dir == "." else f"./{relative_dir}"
+
+        for field in EMBED_FILE_FIELDS:
+            for embedded in string_list(package, field):
+                embed_owners[embedded_repo_path(relative_dir, embedded)].add(import_path)
+
+    seeds: set[str] = set()
+    for status, path in changed:
+        owners = embed_owners.get(path, set())
+        seeds.update(owners)
+        if is_go_build_input(path):
+            directory = posixpath.dirname(path) or "."
+            import_path = import_by_dir.get(directory)
+            if import_path is None:
+                raise SelectionError(
+                    f"changed Go build-input directory {directory!r} has no unique package"
+                )
+            seeds.add(import_path)
+        elif status == "D" and not owners and any(
+            path_is_beneath_package(path, package_dir)
+            for package_dir in import_by_dir
+        ):
+            raise SelectionError(
+                f"deleted path {path!r} may be absent from the current embed inventory"
+            )
+
+    if not seeds:
+        return []
+
+    reverse: dict[str, set[str]] = defaultdict(set)
+    for importer, package in by_import.items():
+        imports = set(
+            string_list(package, "Imports")
+            + string_list(package, "TestImports")
+            + string_list(package, "XTestImports")
+        )
+        for imported in imports:
+            if imported in by_import:
+                reverse[imported].add(importer)
+
+    affected = set(seeds)
+    pending = deque(sorted(seeds))
+    while pending:
+        imported = pending.popleft()
+        for importer in sorted(reverse[imported]):
+            if importer not in affected:
+                affected.add(importer)
+                pending.append(importer)
+    return sorted(arg_by_import[import_path] for import_path in affected)
+
+
+def run_tool(args: list[str]) -> int:
+    try:
+        return subprocess.run(args).returncode
+    except OSError as error:
+        print(f"ci-static-select: cannot run {args[0]!r}: {error}", file=sys.stderr)
+        return 127
+
+
+def run_static_checks(
+    lint_tool: str,
+    go_tool: str,
+    lint_flags: list[str],
+    packages: list[str],
+) -> int:
+    lint_result = run_tool(
+        [lint_tool, "run", "--disable=govet", *lint_flags, *packages]
+    )
+    if lint_result != 0:
+        return lint_result
+    return run_tool([go_tool, "vet", *packages])
+
+
+def full_static_checks(
+    lint_tool: str, go_tool: str, lint_flags: list[str], reason: Exception
+) -> int:
+    print(f"lint-affected: selecting full repository: {reason}", file=sys.stderr)
+    return run_static_checks(lint_tool, go_tool, lint_flags, ["./..."])
+
+
+def lint_affected(
+    lint_tool: str, go_tool: str, lint_flags: list[str]
+) -> int:
+    try:
+        records = diff_records()
+    except SelectionError as error:
+        return full_static_checks(lint_tool, go_tool, lint_flags, error)
+    if not records:
+        print("lint-affected: no changed paths")
+        return 0
+    try:
+        packages = affected_package_args(records, go_tool)
+    except SelectionError as error:
+        return full_static_checks(lint_tool, go_tool, lint_flags, error)
+    if not packages:
+        print("lint-affected: no changed Go build inputs or embedded files")
+        return 0
+    print(f"lint-affected: {' '.join(packages)}")
+    return run_static_checks(lint_tool, go_tool, lint_flags, packages)
+
+
+def fmt_check_changed(tool: str) -> int:
+    try:
+        records = diff_records()
+        paths = sorted(
+            path
+            for status, path in records
+            if status != "D" and path.endswith(".go") and is_regular_file(path)
+        )
+    except SelectionError as error:
+        print(f"fmt-check-changed: selecting full repository: {error}", file=sys.stderr)
+        return run_tool([tool, "fmt", "--diff", "./..."])
+    if not paths:
+        print("fmt-check-changed: no changed existing Go files")
+        return 0
+    return run_tool([tool, "fmt", "--diff", "--", *paths])
+
+
+def is_regular_file(path: str) -> bool:
+    try:
+        mode = os.lstat(path).st_mode
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise SelectionError(f"cannot inspect changed Go path {path!r}: {error}") from error
+    return stat.S_ISREG(mode)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3 or argv[1] not in {"lint-affected", "fmt-check-changed"}:
+        print(
+            "usage: ci-static-select {lint-affected|fmt-check-changed} "
+            "GOLANGCI_LINT [GO [LINT_FLAG ...]]",
+            file=sys.stderr,
+        )
+        return 2
+    mode = argv[1]
+    lint_tool = argv[2]
+    if mode == "fmt-check-changed":
+        if len(argv) != 3:
+            print("fmt-check-changed only accepts GOLANGCI_LINT", file=sys.stderr)
+            return 2
+        return fmt_check_changed(lint_tool)
+    if len(argv) < 4:
+        print("lint-affected requires GOLANGCI_LINT and GO", file=sys.stderr)
+        return 2
+    return lint_affected(lint_tool, argv[3], argv[4:])
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/ci-static-select
+++ b/scripts/ci-static-select
@@ -39,6 +39,7 @@ GO_BUILD_INPUT_SUFFIXES = frozenset(
 )
 
 EMBED_FILE_FIELDS = ("EmbedFiles", "TestEmbedFiles", "XTestEmbedFiles")
+EMBED_PATTERN_FIELDS = ("EmbedPatterns", "TestEmbedPatterns", "XTestEmbedPatterns")
 
 NATIVE_SOURCE_FIELDS = (
     "CgoFiles",
@@ -168,6 +169,23 @@ def embedded_repo_path(relative_dir: str, embedded: str) -> str:
     return posixpath.join(relative_dir, normalized)
 
 
+def embedded_repo_pattern(relative_dir: str, pattern: str) -> str:
+    if pattern.startswith("all:"):
+        pattern = pattern.removeprefix("all:")
+    return embedded_repo_path(relative_dir, pattern)
+
+
+def deleted_path_may_match_embed_pattern(path: str, pattern: str) -> bool:
+    meta_index = next(
+        (index for index, character in enumerate(pattern) if character in "*?[\\"),
+        len(pattern),
+    )
+    literal_prefix = pattern[:meta_index]
+    if meta_index == len(pattern):
+        return path == pattern or path.startswith(pattern + "/")
+    return path.startswith(literal_prefix)
+
+
 def path_is_beneath_package(path: str, package_dir: str) -> bool:
     return package_dir == "." or path.startswith(package_dir + "/")
 
@@ -179,7 +197,9 @@ def affected_package_args(
     if not changed:
         return []
 
-    raw_graph = command_output([go_tool, "list", "-test", "-json", "./..."])
+    raw_graph = command_output(
+        [go_tool, "list", "-mod=readonly", "-test", "-json", "./..."]
+    )
     package_records: list[dict[str, Any]] = []
     for package in decode_json_stream(raw_graph):
         for_test = package.get("ForTest")
@@ -199,6 +219,7 @@ def affected_package_args(
     import_by_dir: dict[str, str] = {}
     arg_by_import: dict[str, str] = {}
     embed_owners: dict[str, set[str]] = defaultdict(set)
+    embed_patterns: list[str] = []
     native_imports: set[str] = set()
 
     for package in package_records:
@@ -230,6 +251,9 @@ def affected_package_args(
         for field in EMBED_FILE_FIELDS:
             for embedded in string_list(package, field):
                 embed_owners[embedded_repo_path(relative_dir, embedded)].add(import_path)
+        for field in EMBED_PATTERN_FIELDS:
+            for pattern in string_list(package, field):
+                embed_patterns.append(embedded_repo_pattern(relative_dir, pattern))
 
         native_sources: list[str] = []
         for field in NATIVE_SOURCE_FIELDS:
@@ -246,6 +270,13 @@ def affected_package_args(
     for status, path in changed:
         owners = embed_owners.get(path, set())
         seeds.update(owners)
+        if status == "D" and any(
+            deleted_path_may_match_embed_pattern(path, pattern)
+            for pattern in embed_patterns
+        ):
+            raise SelectionError(
+                f"deleted path {path!r} may be absent from the current embed inventory"
+            )
         # Native compilers can consume inputs with arbitrary names and from
         # shared directories. The Go package inventory does not expose that
         # dependency graph, so every native package is the smallest safe scope

--- a/scripts/ci_critical_path_test.go
+++ b/scripts/ci_critical_path_test.go
@@ -46,6 +46,7 @@ type ciCriticalPathNeeds []string
 
 type ciCriticalPathStep struct {
 	Name            string            `yaml:"name"`
+	ID              string            `yaml:"id"`
 	If              string            `yaml:"if"`
 	Run             string            `yaml:"run"`
 	Uses            string            `yaml:"uses"`
@@ -437,6 +438,146 @@ func TestStaticChecksUseOnlyTheGoToolchain(t *testing.T) {
 	}
 	if !hasSetupGo {
 		t.Error("static checks must install the pinned Go toolchain")
+	}
+}
+
+func TestPreflightStaticScopesOrdinaryPRsWithoutWeakeningProtectedRuns(t *testing.T) {
+	wf := readCriticalPathWorkflow(t, "ci.yml")
+	job, ok := wf.Jobs["preflight-static"]
+	if !ok {
+		t.Fatal("CI workflow has no preflight-static job")
+	}
+
+	checkoutIndex := -1
+	classifierIndex := -1
+	var checkout, classifier ciCriticalPathStep
+	runCounts := make(map[string]int)
+	stepsByRun := make(map[string]struct {
+		index int
+		step  ciCriticalPathStep
+	})
+	for i, step := range job.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			checkoutIndex = i
+			checkout = step
+		}
+		if step.ID == "static-scope" {
+			classifierIndex = i
+			classifier = step
+		}
+		if run := strings.TrimSpace(step.Run); run != "" {
+			runCounts[run]++
+			stepsByRun[run] = struct {
+				index int
+				step  ciCriticalPathStep
+			}{index: i, step: step}
+		}
+	}
+
+	if checkoutIndex < 0 {
+		t.Error("preflight-static must check out the synthetic merge commit")
+	} else {
+		if got := checkout.With["fetch-depth"]; got != "2" {
+			t.Errorf("preflight-static checkout fetch-depth = %q, want 2 so the synthetic merge base parent is present", got)
+		}
+		if ref := strings.TrimSpace(checkout.With["ref"]); ref != "" {
+			t.Errorf("preflight-static checkout ref = %q, want the default GITHUB_SHA synthetic merge", ref)
+		}
+	}
+
+	if classifierIndex < 0 {
+		t.Error("preflight-static must have a static-scope classifier step")
+	} else {
+		if classifierIndex <= checkoutIndex {
+			t.Errorf("static-scope classifier step %d must follow checkout step %d", classifierIndex, checkoutIndex)
+		}
+		wantEnv := map[string]string{
+			"EVENT_NAME":  "${{ github.event_name }}",
+			"PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+		}
+		for name, want := range wantEnv {
+			if got := classifier.Env[name]; got != want {
+				t.Errorf("static-scope %s = %q, want %q", name, got, want)
+			}
+		}
+		for _, marker := range []string{"scripts/ci-static-scope", "GITHUB_OUTPUT", "scope"} {
+			if !strings.Contains(classifier.Run, marker) {
+				t.Errorf("static-scope classifier must contain %q", marker)
+			}
+		}
+		for _, unsafeBase := range []string{"origin/main", "github.base_ref", "pull_request.head.sha", "merge-base"} {
+			if strings.Contains(classifier.Run, unsafeBase) {
+				t.Errorf("static-scope classifier uses unsafe PR base %q instead of the exact base SHA", unsafeBase)
+			}
+		}
+	}
+
+	changedCondition := "steps.static-scope.outputs.scope == 'changed'"
+	fullCondition := "steps.static-scope.outputs.scope != 'changed'"
+	for _, step := range job.Steps {
+		run := strings.TrimSpace(step.Run)
+		if strings.Contains(run, "make vet") || strings.Contains(run, "go vet") {
+			if got := strings.TrimSpace(step.If); got != fullCondition {
+				t.Errorf("vet step %q condition = %q, want full scope so ordinary PRs do not duplicate full-repository vet", step.Name, step.If)
+			}
+		}
+	}
+	for _, tc := range []struct {
+		run       string
+		condition string
+		changed   bool
+	}{
+		{run: "make lint-affected", condition: changedCondition, changed: true},
+		{run: "make fmt-check-changed", condition: changedCondition, changed: true},
+		{run: "make lint", condition: fullCondition},
+		{run: "make fmt-check", condition: fullCondition},
+		{run: "make vet", condition: fullCondition},
+	} {
+		if got := runCounts[tc.run]; got != 1 {
+			t.Errorf("preflight-static %q step count = %d, want exactly 1", tc.run, got)
+		}
+		entry, ok := stepsByRun[tc.run]
+		if !ok {
+			t.Errorf("preflight-static has no %q step", tc.run)
+			continue
+		}
+		if classifierIndex >= 0 && entry.index <= classifierIndex {
+			t.Errorf("%q step %d must follow static-scope classifier step %d", tc.run, entry.index, classifierIndex)
+		}
+		if got := strings.TrimSpace(entry.step.If); got != tc.condition {
+			t.Errorf("%q condition = %q, want %q", tc.run, entry.step.If, tc.condition)
+		}
+		if tc.changed {
+			if got := entry.step.Env["LINT_CHANGED_SCOPE"]; got != "tracked" {
+				t.Errorf("%q LINT_CHANGED_SCOPE = %q, want tracked", tc.run, got)
+			}
+			if got := entry.step.Env["LINT_CHANGED_REF"]; got != "${{ github.event.pull_request.base.sha }}" {
+				t.Errorf("%q LINT_CHANGED_REF = %q, want exact pull-request base SHA", tc.run, got)
+			}
+		}
+	}
+}
+
+func TestFullStaticLintExplicitlyOwnsConfiguredGolangCIGovet(t *testing.T) {
+	path := filepath.Join(repoRoot(t), ".golangci.yml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var cfg struct {
+		Linters struct {
+			Enable  []string `yaml:"enable"`
+			Disable []string `yaml:"disable"`
+		} `yaml:"linters"`
+	}
+	if err := yaml.Unmarshal(body, &cfg); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	if !slices.Contains(cfg.Linters.Enable, "govet") {
+		t.Fatalf(".golangci.yml linters.enable = %v, want explicit govet ownership for full static lint", cfg.Linters.Enable)
+	}
+	if slices.Contains(cfg.Linters.Disable, "govet") {
+		t.Fatalf(".golangci.yml disables govet for full static lint")
 	}
 }
 

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -20,7 +20,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "bab4008d67e315b905124072af244a2dd265a3ce01583bd4ea3a6297e68195fc"
+	expectedCIExecutionHash      = "5f808af12283745f8a84116039b5ece82aa963c10b51cda9d955a1929feb5705"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "80575ca368f28ba9f8b14bf72ce5767a7877ffe4dcadc136854ab4b0b5f1377a"
 	expectedSetupActionHash      = "b7864038195cd054aee7fccfa903cab335b375bcab1a35239c17c5da7d32c07e"

--- a/scripts/cipolicy/policy_test.go
+++ b/scripts/cipolicy/policy_test.go
@@ -23,6 +23,30 @@ func TestCurrentWorkflowsMatchPolicy(t *testing.T) {
 	}
 }
 
+func TestMakeTestCIPolicyRunsStaticScopeContracts(t *testing.T) {
+	const want = "\t$(TEST_ENV) GOFLAGS= GOENV=off GOWORK=off go test -count=1 -run '^(TestPreflightStaticScopesOrdinaryPRsWithoutWeakeningProtectedRuns|TestFullStaticLintExplicitlyOwnsConfiguredGolangCIGovet|TestChangedStaticTargetsScopeLintAndFormattingToTheDiff|TestCIStaticScopeClassifierFailsClosedOutsideValidatedPullRequestMerge)$$' ./scripts"
+
+	makefilePath := filepath.Join("..", "..", "Makefile")
+	body, err := os.ReadFile(makefilePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", makefilePath, err)
+	}
+	_, rest, ok := strings.Cut(string(body), "\ntest-ci-policy:\n")
+	if !ok {
+		t.Fatal("Makefile has no test-ci-policy target")
+	}
+	recipe, _, _ := strings.Cut(rest, "\n\n")
+	matches := 0
+	for _, line := range strings.Split(recipe, "\n") {
+		if line == want {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("test-ci-policy recipe must run the focused static-scope contracts with the exact hermetic command:\n%s", want)
+	}
+}
+
 func TestDisplayLabelsDoNotAffectPolicy(t *testing.T) {
 	docs := loadPolicyDocuments(t)
 	docs.ci["name"] = "Renamed workflow"

--- a/scripts/makefile_cgo_test.go
+++ b/scripts/makefile_cgo_test.go
@@ -330,7 +330,11 @@ print-cgo-flags:
 }
 
 func makeCommand(args ...string) *exec.Cmd {
-	return exec.Command("make", args...)
+	return testCommand("make", args...)
+}
+
+func testCommand(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
 }
 
 func filteredMakefileCGOTestEnv() []string {

--- a/scripts/pr_static_scope_contract_test.go
+++ b/scripts/pr_static_scope_contract_test.go
@@ -178,6 +178,30 @@ import _ "example.com/static-scope/missing"
 		fixture.requireNoCalls(t)
 	})
 
+	t.Run("deleted nested Go file beneath ancestor embed falls back to full", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": `package alpha
+
+import "embed"
+
+//go:embed child/**
+var Data embed.FS
+`,
+			"alpha/child/delete.go": "package child\n\nfunc Delete() {}\n",
+			"alpha/child/keep.go":   "package child\n\nfunc Keep() {}\n",
+		})
+		if err := os.Remove(filepath.Join(fixture.repoRoot, "alpha", "child", "delete.go")); err != nil {
+			t.Fatalf("delete nested embedded Go file: %v", err)
+		}
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected did not fail closed for a deleted nested embedded Go file: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "./..."})
+		fixture.requireGoCalls(t, []string{"vet", "./..."})
+	})
+
 	t.Run("cross-package rename with a spaced file name", func(t *testing.T) {
 		const movedBody = `
 func Moved() int {
@@ -390,6 +414,49 @@ var Data string
 		fixture.resetCalls(t)
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected failed for an embedded-file diff: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "./alpha"})
+		fixture.requireGoCalls(t, []string{"vet", "./alpha"})
+	})
+
+	t.Run("package discovery requests read-only module mode", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "alpha.go"), "package alpha\n\nfunc Value() int { return 2 }\n")
+
+		strictGo := filepath.Join(t.TempDir(), "go")
+		writeExecutable(t, strictGo, `#!/bin/sh
+set -eu
+: "${STATIC_SCOPE_GO_LOG:?}"
+: "${STATIC_SCOPE_REAL_GO:?}"
+if [ "${1-}" = "list" ]; then
+  readonly=0
+  for arg in "$@"; do
+    if [ "$arg" = "-mod=readonly" ]; then
+      readonly=1
+    fi
+  done
+  if [ "$readonly" -ne 1 ]; then
+    echo "go list did not request -mod=readonly" >&2
+    exit 97
+  fi
+  exec "$STATIC_SCOPE_REAL_GO" "$@"
+fi
+if [ "${1-}" = "vet" ]; then
+  printf 'CALL\000' >> "$STATIC_SCOPE_GO_LOG"
+  for arg in "$@"; do
+    printf 'ARG\000%s\000' "$arg" >> "$STATIC_SCOPE_GO_LOG"
+  done
+  printf 'END\000' >> "$STATIC_SCOPE_GO_LOG"
+  exit 0
+fi
+exec "$STATIC_SCOPE_REAL_GO" "$@"
+`)
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTargetWithGo("lint-affected", strictGo); err != nil {
+			t.Errorf("lint-affected failed with a read-only go list guard: %v\n%s", err, output)
 		}
 		fixture.requireCalls(t, []string{"run", "./alpha"})
 		fixture.requireGoCalls(t, []string{"vet", "./alpha"})

--- a/scripts/pr_static_scope_contract_test.go
+++ b/scripts/pr_static_scope_contract_test.go
@@ -1,0 +1,965 @@
+package scripts_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestChangedStaticTargetsScopeLintAndFormattingToTheDiff(t *testing.T) {
+	t.Run("Go build-input suffix contract", func(t *testing.T) {
+		want := []string{
+			".go", ".c", ".cc", ".cpp", ".cxx", ".m", ".h", ".hh", ".hpp", ".hxx",
+			".f", ".F", ".for", ".f90", ".s", ".S", ".sx", ".swig", ".swigcxx", ".syso",
+		}
+		selector := filepath.Join(repoRoot(t), "scripts", "ci-static-select")
+		code := `import runpy
+import sys
+
+module = runpy.run_path(sys.argv[1], run_name="ci_static_select_contract")
+want = frozenset(sys.argv[2:])
+got = module["GO_BUILD_INPUT_SUFFIXES"]
+classify = module["is_go_build_input"]
+if got != want:
+    raise SystemExit(f"build-input suffixes = {sorted(got)!r}, want {sorted(want)!r}")
+if not all(classify("pkg/input" + suffix) for suffix in want):
+    raise SystemExit("a required build-input suffix was not classified")
+if any(classify(path) for path in ("README.md", "pkg/input.go.bak", "pkg/header.H")):
+    raise SystemExit("a non-build input was classified")
+`
+		args := append([]string{"-c", code, selector}, want...)
+		cmd := testCommand("python3", args...)
+		cmd.Env = append(os.Environ(), "PYTHONDONTWRITEBYTECODE=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("verify Go build-input suffix contract: %v\n%s", err, output)
+		}
+	})
+
+	t.Run("changed Go file", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go":     "package alpha\n\nfunc Value() int { return 1 }\n",
+			"alpha/unchanged.go": "package alpha\n\nfunc Unchanged() {}\n",
+			"beta/beta.go":       "package beta\n\nfunc Value() int { return 1 }\n",
+			"consumer/consumer.go": `package consumer
+
+import "example.com/static-scope/alpha"
+
+func Value() int { return alpha.Value() }
+`,
+			"README.md": "baseline\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "alpha.go"), "package alpha\n\nfunc Value() int { return 2 }\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-changed"); err != nil {
+			t.Errorf("lint-changed failed for one changed Go file: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "./alpha"})
+		fixture.requireGoCalls(t)
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for one changed Go file: %v\n%s", err, output)
+		}
+		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./alpha", "./consumer")
+		fixture.requireGoCalls(t, []string{"vet", "./alpha", "./consumer"})
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("fmt-check-changed"); err != nil {
+			t.Errorf("fmt-check-changed failed for one changed Go file: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"fmt", "--diff", "--", "alpha/alpha.go"})
+		fixture.requireGoCalls(t)
+	})
+
+	t.Run("transitive and test-only reverse dependents", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+			"middle/middle.go": `package middle
+
+import "example.com/static-scope/alpha"
+
+func Value() int { return alpha.Value() }
+`,
+			"consumer/consumer.go": `package consumer
+
+import "example.com/static-scope/middle"
+
+func Value() int { return middle.Value() }
+`,
+			"internaltest/internaltest.go": "package internaltest\n\nfunc Value() int { return 1 }\n",
+			"internaltest/internaltest_test.go": `package internaltest
+
+import (
+	"testing"
+
+	"example.com/static-scope/alpha"
+)
+
+func TestValue(t *testing.T) { _ = alpha.Value() }
+`,
+			"externaltest/externaltest.go": "package externaltest\n\nfunc Value() int { return 1 }\n",
+			"externaltest/externaltest_test.go": `package externaltest_test
+
+import (
+	"testing"
+
+	"example.com/static-scope/alpha"
+)
+
+func TestValue(t *testing.T) { _ = alpha.Value() }
+`,
+			"unrelated/unrelated.go": "package unrelated\n\nfunc Value() int { return 1 }\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "alpha.go"), "package alpha\n\nfunc Value() int { return 2 }\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for reverse-dependent graph: %v\n%s", err, output)
+		}
+		fixture.requireSingleRunCallWithUnorderedTail(t,
+			"--disable=govet",
+			"./alpha",
+			"./consumer",
+			"./externaltest",
+			"./internaltest",
+			"./middle",
+		)
+		fixture.requireGoCalls(t, []string{
+			"vet",
+			"./alpha",
+			"./consumer",
+			"./externaltest",
+			"./internaltest",
+			"./middle",
+		})
+	})
+
+	t.Run("broken package graph falls back to full lint", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+			"broken/broken.go": `package broken
+
+import _ "example.com/static-scope/missing"
+`,
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "alpha.go"), "package alpha\n\nfunc Value() int { return 2 }\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected did not fail closed for a broken package graph: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireGoCalls(t, []string{"vet", "./..."})
+	})
+
+	t.Run("deleted Go file", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/delete.go": "package alpha\n\nfunc Deleted() {}\n",
+			"alpha/keep.go":   "package alpha\n\nfunc Keep() {}\n",
+		})
+		if err := os.Remove(filepath.Join(fixture.repoRoot, "alpha", "delete.go")); err != nil {
+			t.Fatalf("delete tracked Go file: %v", err)
+		}
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for a deleted Go file: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+		fixture.requireGoCalls(t, []string{"vet", "./alpha"})
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("fmt-check-changed"); err != nil {
+			t.Errorf("fmt-check-changed failed for a deleted Go file: %v\n%s", err, output)
+		}
+		fixture.requireNoCalls(t)
+	})
+
+	t.Run("cross-package rename with a spaced file name", func(t *testing.T) {
+		const movedBody = `
+func Moved() int {
+	total := 0
+	for i := 0; i < 10; i++ {
+		total += i
+	}
+	return total
+}
+`
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"oldpkg/keep.go":       "package oldpkg\n\nfunc Keep() {}\n",
+			"oldpkg/moved file.go": "package oldpkg\n" + movedBody,
+		})
+		newPath := filepath.Join(fixture.repoRoot, "newpkg", "moved file.go")
+		if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+			t.Fatalf("create renamed package: %v", err)
+		}
+		if err := os.Rename(filepath.Join(fixture.repoRoot, "oldpkg", "moved file.go"), newPath); err != nil {
+			t.Fatalf("rename tracked Go file across packages: %v", err)
+		}
+		writeTestFile(t, newPath, "package newpkg\n"+movedBody)
+		runGitFixtureCommands(t, fixture.repoRoot, fixture.commandEnv(), "git add -A")
+		status := runGitFixtureCommands(t, fixture.repoRoot, fixture.commandEnv(), "git diff --name-status -M HEAD --")
+		if !strings.Contains(status, "R") || !strings.Contains(status, "oldpkg/moved file.go") || !strings.Contains(status, "newpkg/moved file.go") {
+			t.Fatalf("fixture is not an across-package Git rename:\n%s", status)
+		}
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for a cross-package rename: %v\n%s", err, output)
+		}
+		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./newpkg", "./oldpkg")
+		fixture.requireGoCalls(t, []string{"vet", "./newpkg", "./oldpkg"})
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("fmt-check-changed"); err != nil {
+			t.Errorf("fmt-check-changed failed for a cross-package rename: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"fmt", "--diff", "--", "newpkg/moved file.go"})
+		fixture.requireGoCalls(t)
+	})
+
+	t.Run("newline in changed file name", func(t *testing.T) {
+		const name = "alpha/line\nbreak.go"
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			name: "package alpha\n\nfunc Value() int { return 1 }\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, name), "package alpha\n\nfunc Value() int { return 2 }\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("fmt-check-changed"); err != nil {
+			t.Errorf("fmt-check-changed failed for a newline-containing file name: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"fmt", "--diff", "--", name})
+		fixture.requireGoCalls(t)
+	})
+
+	t.Run("invalid ref falls back to full static checks", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "alpha.go"), "package alpha\n\nfunc Value() int { return 2 }\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTargetWithRef("lint-affected", "refs/heads/missing-static-base"); err != nil {
+			t.Errorf("lint-affected did not fail closed for an invalid ref: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireGoCalls(t, []string{"vet", "./..."})
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTargetWithRef("fmt-check-changed", "refs/heads/missing-static-base"); err != nil {
+			t.Errorf("fmt-check-changed did not fail closed for an invalid ref: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"fmt", "--diff", "./..."})
+		fixture.requireGoCalls(t)
+	})
+
+	t.Run("affected vet checks unchanged generated reverse dependent", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": `package alpha
+
+func Printf(string, ...any) {}
+`,
+			"consumer/generated.go": `// Code generated by static-scope fixture. DO NOT EDIT.
+
+package consumer
+
+import "example.com/static-scope/alpha"
+
+func Use() { alpha.Printf("%d", "not-an-int") }
+`,
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "alpha.go"), `package alpha
+
+import "fmt"
+
+func Printf(format string, args ...any) { fmt.Printf(format, args...) }
+`)
+
+		fixture.resetCalls(t)
+		output, err := fixture.runMakeTargetWithGo("lint-affected", fixture.realGo)
+		if err == nil {
+			t.Fatalf("lint-affected passed despite a new vet diagnostic in an unchanged generated reverse dependent:\n%s", output)
+		}
+		for _, marker := range []string{"consumer/generated.go", "format %d"} {
+			if !strings.Contains(output, marker) {
+				t.Errorf("affected vet output missing %q:\n%s", marker, output)
+			}
+		}
+		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./alpha", "./consumer")
+		fixture.requireGoCalls(t)
+	})
+
+	t.Run("assembly-only diff selects its package", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value()\n",
+			"alpha/value.s":  "#include \"textflag.h\"\n\nTEXT ·Value(SB), NOSPLIT, $0-0\n\tRET\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "value.s"), "#include \"textflag.h\"\n\n// changed\nTEXT ·Value(SB), NOSPLIT, $0-0\n\tRET\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for an assembly-only diff: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+		fixture.requireGoCalls(t, []string{"vet", "./alpha"})
+	})
+
+	t.Run("embedded file diff selects its package", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": `package alpha
+
+import _ "embed"
+
+//go:embed data.txt
+var Data string
+`,
+			"alpha/data.txt": "before\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "data.txt"), "after\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for an embedded-file diff: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+		fixture.requireGoCalls(t, []string{"vet", "./alpha"})
+	})
+
+	for _, testPackage := range []struct {
+		name        string
+		packageName string
+		fileName    string
+		dataName    string
+	}{
+		{name: "internal test embed", packageName: "alpha", fileName: "alpha_internal_test.go", dataName: "internal.txt"},
+		{name: "external test embed", packageName: "alpha_test", fileName: "alpha_external_test.go", dataName: "external.txt"},
+	} {
+		t.Run(testPackage.name, func(t *testing.T) {
+			fixture := newPRStaticScopeFixture(t, map[string]string{
+				"alpha/alpha.go": "package alpha\n",
+				filepath.Join("alpha", testPackage.fileName): "package " + testPackage.packageName + `
+
+import _ "embed"
+
+//go:embed testdata/` + testPackage.dataName + `
+var data string
+`,
+				filepath.Join("alpha", "testdata", testPackage.dataName): "before\n",
+			})
+			writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "testdata", testPackage.dataName), "after\n")
+
+			fixture.resetCalls(t)
+			if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+				t.Errorf("lint-affected failed for a %s diff: %v\n%s", testPackage.name, err, output)
+			}
+			fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+			fixture.requireGoCalls(t, []string{"vet", "./alpha"})
+		})
+	}
+
+	t.Run("embedded file selects every owning package", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": `package alpha
+
+import _ "embed"
+
+//go:embed child/data.txt
+var Data string
+`,
+			"alpha/child/child.go": `package child
+
+import _ "embed"
+
+//go:embed data.txt
+var Data string
+`,
+			"alpha/child/data.txt": "before\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "child", "data.txt"), "after\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for a multiply owned embedded file: %v\n%s", err, output)
+		}
+		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./alpha", "./alpha/child")
+		fixture.requireGoCalls(t, []string{"vet", "./alpha", "./alpha/child"})
+	})
+
+	t.Run("deleted required embedded file falls back to full", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": `package alpha
+
+import _ "embed"
+
+//go:embed data.txt
+var Data string
+`,
+			"alpha/data.txt": "before\n",
+		})
+		if err := os.Remove(filepath.Join(fixture.repoRoot, "alpha", "data.txt")); err != nil {
+			t.Fatalf("delete embedded fixture: %v", err)
+		}
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected did not fail closed for a missing embedded file: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireGoCalls(t, []string{"vet", "./..."})
+	})
+
+	t.Run("deleted embedded glob member falls back to full", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": `package alpha
+
+import "embed"
+
+//go:embed data/*.txt
+var Data embed.FS
+`,
+			"alpha/data/first.txt":  "first\n",
+			"alpha/data/second.txt": "second\n",
+		})
+		if err := os.Remove(filepath.Join(fixture.repoRoot, "alpha", "data", "first.txt")); err != nil {
+			t.Fatalf("delete embedded glob member: %v", err)
+		}
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected did not fail closed for a deleted embed glob member: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireGoCalls(t, []string{"vet", "./..."})
+	})
+
+	t.Run("changed Go symlink is not formatted", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+		})
+		outside := filepath.Join(t.TempDir(), "outside.go")
+		writeTestFile(t, outside, "package outside\n")
+		path := filepath.Join(fixture.repoRoot, "alpha", "alpha.go")
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("replace Go file with symlink: %v", err)
+		}
+		if err := os.Symlink(outside, path); err != nil {
+			t.Fatalf("create Go symlink: %v", err)
+		}
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("fmt-check-changed"); err != nil {
+			t.Errorf("fmt-check-changed failed for a Go symlink: %v\n%s", err, output)
+		}
+		fixture.requireNoCalls(t)
+	})
+
+	t.Run("non-Go diff", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+			"README.md":      "baseline\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "README.md"), "documentation only\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for a non-Go diff: %v\n%s", err, output)
+		}
+		fixture.requireNoCalls(t)
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("fmt-check-changed"); err != nil {
+			t.Errorf("fmt-check-changed failed for a non-Go diff: %v\n%s", err, output)
+		}
+		fixture.requireNoCalls(t)
+
+		if err := os.Remove(filepath.Join(fixture.repoRoot, "README.md")); err != nil {
+			t.Fatalf("delete non-Go fixture: %v", err)
+		}
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for a deleted non-build, non-embedded file: %v\n%s", err, output)
+		}
+		fixture.requireNoCalls(t)
+	})
+}
+
+func TestCIStaticScopeClassifierFailsClosedOutsideValidatedPullRequestMerge(t *testing.T) {
+	classifier := filepath.Join(repoRoot(t), "scripts", "ci-static-scope")
+	body, err := os.ReadFile(classifier)
+	if err != nil {
+		t.Fatalf("read executable static-scope classifier: %v", err)
+	}
+	info, err := os.Stat(classifier)
+	if err != nil {
+		t.Fatalf("stat executable static-scope classifier: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("static-scope classifier mode = %o, want executable", info.Mode().Perm())
+	}
+	for _, protected := range []string{
+		"go.mod",
+		"go.sum",
+		"go.work",
+		"go.work.sum",
+		".golangci.yml",
+		"Makefile",
+		".github/workflows/",
+		".github/actions/",
+		".githooks/",
+		"vendor/",
+		"scripts/cipolicy/",
+		"scripts/ci-static-scope",
+		"scripts/ci-static-select",
+	} {
+		if !strings.Contains(string(body), protected) {
+			t.Errorf("static-scope protected paths must explicitly include %q", protected)
+		}
+	}
+	for _, unsafeBase := range []string{"origin/main", "merge-base"} {
+		if strings.Contains(string(body), unsafeBase) {
+			t.Errorf("static-scope classifier uses %q instead of validating the exact synthetic-merge base parent", unsafeBase)
+		}
+	}
+
+	t.Run("ordinary synthetic pull request merge", func(t *testing.T) {
+		fixture, baseSHA := newSyntheticPRStaticScopeFixture(t, "")
+		fixture.requireClassification(t, classifier, "pull_request", baseSHA, "changed")
+	})
+
+	t.Run("protected configuration paths", func(t *testing.T) {
+		for _, protectedPath := range []string{
+			"go.mod",
+			"go.sum",
+			".github/actions/static-scope/action.yml",
+			".github/workflows/ci.yml",
+			".githooks/pre-commit",
+			".golangci.yml",
+			"Makefile",
+			"go.work",
+			"go.work.sum",
+			"scripts/cipolicy/policy.go",
+			"vendor/example.com/dependency/file.go",
+			"scripts/ci-static-scope",
+			"scripts/ci-static-select",
+		} {
+			t.Run(strings.ReplaceAll(protectedPath, "/", "_"), func(t *testing.T) {
+				fixture, baseSHA := newSyntheticPRStaticScopeFixture(t, protectedPath)
+				fixture.requireClassification(t, classifier, "pull_request", baseSHA, "full")
+			})
+		}
+	})
+
+	t.Run("deleted protected path", func(t *testing.T) {
+		fixture, baseSHA := newSyntheticPRStaticScopeFixtureWithMutation(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+			".golangci.yml":  "version: '2'\n",
+		}, func(t *testing.T, root string) {
+			if err := os.Remove(filepath.Join(root, ".golangci.yml")); err != nil {
+				t.Fatalf("delete protected fixture: %v", err)
+			}
+		})
+		fixture.requireClassification(t, classifier, "pull_request", baseSHA, "full")
+	})
+
+	t.Run("missing and wrong base", func(t *testing.T) {
+		fixture, baseSHA := newSyntheticPRStaticScopeFixture(t, "")
+		fixture.requireClassification(t, classifier, "pull_request", "", "full")
+		fixture.requireClassification(t, classifier, "pull_request", strings.Repeat("0", 40), "full")
+		wrongBase := strings.TrimSpace(runGitFixtureCommands(t, fixture.repoRoot, fixture.commandEnv(), "git rev-parse HEAD^2"))
+		if wrongBase == baseSHA {
+			t.Fatalf("wrong-base fixture unexpectedly equals synthetic merge base %s", baseSHA)
+		}
+		fixture.requireClassification(t, classifier, "pull_request", wrongBase, "full")
+	})
+
+	t.Run("missing shallow history", func(t *testing.T) {
+		fixture, baseSHA := newSyntheticPRStaticScopeFixture(t, "")
+		cloneRoot := filepath.Join(t.TempDir(), "shallow")
+		cmd := testCommand("git", "clone", "-q", "--depth=1", "file://"+fixture.repoRoot, cloneRoot)
+		cmd.Dir = fixture.repoRoot
+		cmd.Env = fixture.commandEnv()
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("clone shallow fixture: %v\n%s", err, output)
+		}
+		shallow := fixture
+		shallow.repoRoot = cloneRoot
+		shallow.requireClassification(t, classifier, "pull_request", baseSHA, "full")
+	})
+
+	t.Run("pull request without a synthetic merge", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+		})
+		baseSHA := strings.TrimSpace(runGitFixtureCommands(t, fixture.repoRoot, fixture.commandEnv(), "git rev-parse HEAD"))
+		fixture.requireClassification(t, classifier, "pull_request", baseSHA, "full")
+	})
+
+	t.Run("non-pull-request and unknown events", func(t *testing.T) {
+		fixture, baseSHA := newSyntheticPRStaticScopeFixture(t, "")
+		for _, event := range []string{"push", "workflow_dispatch", "schedule", "unknown", ""} {
+			t.Run(eventNameForTest(event), func(t *testing.T) {
+				fixture.requireClassification(t, classifier, event, baseSHA, "full")
+			})
+		}
+	})
+}
+
+func newSyntheticPRStaticScopeFixture(t *testing.T, protectedPath string) (prStaticScopeFixture, string) {
+	t.Helper()
+	return newSyntheticPRStaticScopeFixtureWithMutation(t, map[string]string{
+		"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+		"README.md":      "baseline\n",
+	}, func(t *testing.T, root string) {
+		t.Helper()
+		if protectedPath == "" {
+			writeTestFile(t, filepath.Join(root, "alpha", "alpha.go"), "package alpha\n\nfunc Value() int { return 2 }\n")
+		} else {
+			writeTestFile(t, filepath.Join(root, protectedPath), "name: static-scope fixture\n")
+		}
+	})
+}
+
+func newSyntheticPRStaticScopeFixtureWithMutation(
+	t *testing.T,
+	files map[string]string,
+	mutate func(*testing.T, string),
+) (prStaticScopeFixture, string) {
+	t.Helper()
+	fixture := newPRStaticScopeFixture(t, files)
+	baseSHA := strings.TrimSpace(runGitFixtureCommands(t, fixture.repoRoot, fixture.commandEnv(), "git rev-parse HEAD"))
+	runGitFixtureCommands(t, fixture.repoRoot, fixture.commandEnv(), "git checkout -qb feature")
+	mutate(t, fixture.repoRoot)
+	runGitFixtureCommands(t, fixture.repoRoot, fixture.commandEnv(),
+		"git add -A",
+		"git commit -qm feature",
+		"git checkout -q main",
+		"git merge -q --no-ff feature -m synthetic-merge",
+	)
+	return fixture, baseSHA
+}
+
+func (f prStaticScopeFixture) requireClassification(t *testing.T, classifier, event, baseSHA, want string) {
+	t.Helper()
+	driver := filepath.Join(t.TempDir(), "classify.mk")
+	writeTestFile(t, driver, `.PHONY: classify
+classify:
+	@"$(CLASSIFIER)"
+`)
+	cmd := makeCommand(
+		"--no-print-directory",
+		"-f", driver,
+		"CLASSIFIER="+classifier,
+		"classify",
+	)
+	cmd.Dir = f.repoRoot
+	cmd.Env = append(f.commandEnv(), "EVENT_NAME="+event, "PR_BASE_SHA="+baseSHA)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("classify event %q base %q: %v\n%s", event, baseSHA, err, output)
+	}
+	if got := strings.TrimSpace(string(output)); got != want {
+		t.Fatalf("classify event %q base %q = %q, want %q", event, baseSHA, got, want)
+	}
+}
+
+func eventNameForTest(event string) string {
+	if event == "" {
+		return "empty"
+	}
+	return event
+}
+
+type prStaticScopeFixture struct {
+	repoRoot           string
+	productionMakefile string
+	fakeLint           string
+	fakeGo             string
+	lintLog            string
+	goLog              string
+	realGo             string
+	homeDir            string
+}
+
+func newPRStaticScopeFixture(t *testing.T, files map[string]string) prStaticScopeFixture {
+	t.Helper()
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("create temporary repository: %v", err)
+	}
+	writeTestFile(t, filepath.Join(repo, "go.mod"), "module example.com/static-scope\n\ngo 1.23\n")
+	for name, content := range files {
+		writeTestFile(t, filepath.Join(repo, name), content)
+	}
+
+	toolDir := t.TempDir()
+	lintLog := filepath.Join(toolDir, "golangci.calls")
+	goLog := filepath.Join(toolDir, "go.calls")
+	fakeLint := filepath.Join(toolDir, "golangci-lint")
+	writeExecutable(t, fakeLint, `#!/bin/sh
+set -eu
+: "${STATIC_SCOPE_LINT_LOG:?}"
+printf 'CALL\000' >> "$STATIC_SCOPE_LINT_LOG"
+for arg in "$@"; do
+  printf 'ARG\000%s\000' "$arg" >> "$STATIC_SCOPE_LINT_LOG"
+done
+printf 'END\000' >> "$STATIC_SCOPE_LINT_LOG"
+`)
+	realGo := "go"
+	fakeGo := filepath.Join(toolDir, "go")
+	writeExecutable(t, fakeGo, `#!/bin/sh
+set -eu
+: "${STATIC_SCOPE_GO_LOG:?}"
+: "${STATIC_SCOPE_REAL_GO:?}"
+if [ "${1-}" = "vet" ]; then
+  printf 'CALL\000' >> "$STATIC_SCOPE_GO_LOG"
+  for arg in "$@"; do
+    printf 'ARG\000%s\000' "$arg" >> "$STATIC_SCOPE_GO_LOG"
+  done
+  printf 'END\000' >> "$STATIC_SCOPE_GO_LOG"
+  exit 0
+fi
+exec "$STATIC_SCOPE_REAL_GO" "$@"
+`)
+
+	fixture := prStaticScopeFixture{
+		repoRoot:           repo,
+		productionMakefile: filepath.Join(repoRoot(t), "Makefile"),
+		fakeLint:           fakeLint,
+		fakeGo:             fakeGo,
+		lintLog:            lintLog,
+		goLog:              goLog,
+		realGo:             realGo,
+		homeDir:            t.TempDir(),
+	}
+	setupMakefile := filepath.Join(t.TempDir(), "git-init.mk")
+	writeTestFile(t, setupMakefile, `.PHONY: init
+init:
+	@git init -q -b main
+	@git config user.email static-scope@example.invalid
+	@git config user.name static-scope-test
+	@git add .
+	@git commit -qm baseline
+`)
+	cmd := makeCommand("--no-print-directory", "-C", repo, "-f", setupMakefile, "init")
+	cmd.Env = fixture.commandEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("initialize temporary Git repository: %v\n%s", err, output)
+	}
+	return fixture
+}
+
+func (f prStaticScopeFixture) runMakeTarget(target string) (string, error) {
+	return f.runMakeTargetWithOptions(target, "HEAD", f.fakeGo)
+}
+
+func (f prStaticScopeFixture) runMakeTargetWithRef(target, ref string) (string, error) {
+	return f.runMakeTargetWithOptions(target, ref, f.fakeGo)
+}
+
+func (f prStaticScopeFixture) runMakeTargetWithGo(target, goTool string) (string, error) {
+	return f.runMakeTargetWithOptions(target, "HEAD", goTool)
+}
+
+func (f prStaticScopeFixture) runMakeTargetWithOptions(target, ref, goTool string) (string, error) {
+	cmd := makeCommand(
+		"--no-print-directory",
+		"-f", f.productionMakefile,
+		"GOLANGCI_LINT="+f.fakeLint,
+		"CI_STATIC_GO="+goTool,
+		"LINT_CHANGED_SCOPE=tracked",
+		"LINT_CHANGED_REF="+ref,
+		"LINT_FLAGS=",
+		"SYS_USR_CGO_FALLBACK=0",
+		target,
+	)
+	cmd.Dir = f.repoRoot
+	cmd.Env = f.commandEnv()
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func (f prStaticScopeFixture) commandEnv() []string {
+	env := make([]string, 0, len(os.Environ())+7)
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if name == "HOME" ||
+			name == "STATIC_SCOPE_LINT_LOG" ||
+			name == "STATIC_SCOPE_GO_LOG" ||
+			name == "STATIC_SCOPE_REAL_GO" ||
+			name == "SYS_USR_CGO_FALLBACK" ||
+			name == "EVENT_NAME" ||
+			name == "PR_BASE_SHA" ||
+			name == "GOFLAGS" ||
+			name == "GOENV" ||
+			name == "GOWORK" ||
+			name == "LINT_FLAGS" ||
+			name == "GIT_CONFIG" ||
+			strings.HasPrefix(name, "GIT_CONFIG_") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"HOME="+f.homeDir,
+		"STATIC_SCOPE_LINT_LOG="+f.lintLog,
+		"STATIC_SCOPE_GO_LOG="+f.goLog,
+		"STATIC_SCOPE_REAL_GO="+f.realGo,
+		"SYS_USR_CGO_FALLBACK=0",
+		"GOFLAGS=-mod=readonly",
+		"GOENV=off",
+		"GOWORK=off",
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+	)
+}
+
+func (f prStaticScopeFixture) resetCalls(t *testing.T) {
+	t.Helper()
+	for label, path := range map[string]string{"golangci": f.lintLog, "go": f.goLog} {
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			t.Fatalf("reset fake %s log: %v", label, err)
+		}
+	}
+}
+
+func (f prStaticScopeFixture) calls(t *testing.T) [][]string {
+	t.Helper()
+	return readFramedCalls(t, f.lintLog, "golangci")
+}
+
+func (f prStaticScopeFixture) goCalls(t *testing.T) [][]string {
+	t.Helper()
+	return readFramedCalls(t, f.goLog, "go")
+}
+
+func readFramedCalls(t *testing.T, path, label string) [][]string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read fake %s log: %v", label, err)
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	fields := bytes.Split(body, []byte{0})
+	if len(fields) > 0 && len(fields[len(fields)-1]) == 0 {
+		fields = fields[:len(fields)-1]
+	}
+	calls := make([][]string, 0)
+	for index := 0; index < len(fields); {
+		if string(fields[index]) != "CALL" {
+			t.Fatalf("malformed fake %s log token %q at %d", label, fields[index], index)
+		}
+		index++
+		call := make([]string, 0)
+		for {
+			if index >= len(fields) {
+				t.Fatalf("unterminated fake %s call", label)
+			}
+			switch string(fields[index]) {
+			case "END":
+				index++
+				calls = append(calls, call)
+				goto nextCall
+			case "ARG":
+				if index+1 >= len(fields) {
+					t.Fatalf("missing fake %s argument after token %d", label, index)
+				}
+				call = append(call, string(fields[index+1]))
+				index += 2
+			default:
+				t.Fatalf("malformed fake %s call token %q at %d", label, fields[index], index)
+			}
+		}
+	nextCall:
+		continue
+	}
+	return calls
+}
+
+func (f prStaticScopeFixture) requireCalls(t *testing.T, want ...[]string) {
+	t.Helper()
+	got := f.calls(t)
+	if len(got) != len(want) {
+		t.Errorf("golangci calls = %v, want %v", got, want)
+		return
+	}
+	for i := range want {
+		if !slices.Equal(got[i], want[i]) {
+			t.Errorf("golangci call %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func (f prStaticScopeFixture) requireNoCalls(t *testing.T) {
+	t.Helper()
+	if got := f.calls(t); len(got) != 0 {
+		t.Errorf("golangci calls = %v, want no-op", got)
+	}
+	if got := f.goCalls(t); len(got) != 0 {
+		t.Errorf("go calls = %v, want no-op", got)
+	}
+}
+
+func (f prStaticScopeFixture) requireGoCalls(t *testing.T, want ...[]string) {
+	t.Helper()
+	got := f.goCalls(t)
+	if len(got) != len(want) {
+		t.Errorf("go calls = %v, want %v", got, want)
+		return
+	}
+	for i := range want {
+		if !slices.Equal(got[i], want[i]) {
+			t.Errorf("go call %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func (f prStaticScopeFixture) requireSingleRunCallWithUnorderedTail(t *testing.T, wantTail ...string) {
+	t.Helper()
+	got := f.calls(t)
+	if len(got) != 1 || len(got[0]) == 0 {
+		t.Errorf("golangci calls = %v, want one run call with %v", got, wantTail)
+		return
+	}
+	if got[0][0] != "run" {
+		t.Errorf("golangci call = %v, want leading argument %q", got[0], "run")
+		return
+	}
+	gotTail := slices.Clone(got[0][1:])
+	wantSorted := slices.Clone(wantTail)
+	slices.Sort(gotTail)
+	slices.Sort(wantSorted)
+	if !slices.Equal(gotTail, wantSorted) {
+		t.Errorf("golangci run arguments = %v, want %v", got[0][1:], wantTail)
+	}
+}
+
+func runGitFixtureCommands(t *testing.T, repo string, env []string, commands ...string) string {
+	t.Helper()
+	makefile := filepath.Join(t.TempDir(), "git-fixture.mk")
+	var body strings.Builder
+	body.WriteString(".PHONY: run\nrun:\n")
+	for _, command := range commands {
+		body.WriteString("\t@")
+		body.WriteString(command)
+		body.WriteByte('\n')
+	}
+	writeTestFile(t, makefile, body.String())
+	cmd := makeCommand("--no-print-directory", "-C", repo, "-f", makefile, "run")
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run Git fixture command: %v\n%s", err, output)
+	}
+	return string(output)
+}

--- a/scripts/pr_static_scope_contract_test.go
+++ b/scripts/pr_static_scope_contract_test.go
@@ -64,7 +64,7 @@ func Value() int { return alpha.Value() }
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected failed for one changed Go file: %v\n%s", err, output)
 		}
-		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./alpha", "./consumer")
+		fixture.requireSingleRunCallWithUnorderedTail(t, "./alpha", "./consumer")
 		fixture.requireGoCalls(t, []string{"vet", "./alpha", "./consumer"})
 
 		fixture.resetCalls(t)
@@ -121,7 +121,6 @@ func TestValue(t *testing.T) { _ = alpha.Value() }
 			t.Errorf("lint-affected failed for reverse-dependent graph: %v\n%s", err, output)
 		}
 		fixture.requireSingleRunCallWithUnorderedTail(t,
-			"--disable=govet",
 			"./alpha",
 			"./consumer",
 			"./externaltest",
@@ -152,7 +151,7 @@ import _ "example.com/static-scope/missing"
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected did not fail closed for a broken package graph: %v\n%s", err, output)
 		}
-		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireCalls(t, []string{"run", "./..."})
 		fixture.requireGoCalls(t, []string{"vet", "./..."})
 	})
 
@@ -169,7 +168,7 @@ import _ "example.com/static-scope/missing"
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected failed for a deleted Go file: %v\n%s", err, output)
 		}
-		fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+		fixture.requireCalls(t, []string{"run", "./alpha"})
 		fixture.requireGoCalls(t, []string{"vet", "./alpha"})
 
 		fixture.resetCalls(t)
@@ -211,7 +210,7 @@ func Moved() int {
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected failed for a cross-package rename: %v\n%s", err, output)
 		}
-		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./newpkg", "./oldpkg")
+		fixture.requireSingleRunCallWithUnorderedTail(t, "./newpkg", "./oldpkg")
 		fixture.requireGoCalls(t, []string{"vet", "./newpkg", "./oldpkg"})
 
 		fixture.resetCalls(t)
@@ -247,7 +246,7 @@ func Moved() int {
 		if output, err := fixture.runMakeTargetWithRef("lint-affected", "refs/heads/missing-static-base"); err != nil {
 			t.Errorf("lint-affected did not fail closed for an invalid ref: %v\n%s", err, output)
 		}
-		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireCalls(t, []string{"run", "./..."})
 		fixture.requireGoCalls(t, []string{"vet", "./..."})
 
 		fixture.resetCalls(t)
@@ -290,7 +289,7 @@ func Printf(format string, args ...any) { fmt.Printf(format, args...) }
 				t.Errorf("affected vet output missing %q:\n%s", marker, output)
 			}
 		}
-		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./alpha", "./consumer")
+		fixture.requireSingleRunCallWithUnorderedTail(t, "./alpha", "./consumer")
 		fixture.requireGoCalls(t)
 	})
 
@@ -305,9 +304,75 @@ func Printf(format string, args ...any) { fmt.Printf(format, args...) }
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected failed for an assembly-only diff: %v\n%s", err, output)
 		}
-		fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+		fixture.requireCalls(t, []string{"run", "./alpha"})
 		fixture.requireGoCalls(t, []string{"vet", "./alpha"})
 	})
+
+	t.Run("native include fragment selects its package and reverse dependents", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": "package alpha\n\nfunc Value()\n",
+			"alpha/value.s":  "#include \"../shared/defs.inc\"\n\nTEXT ·Value(SB), $0-0\n\tRET\n",
+			"consumer/consumer.go": `package consumer
+
+import "example.com/static-scope/alpha"
+
+func Value() { alpha.Value() }
+`,
+			"unrelated/unrelated.go": "package unrelated\n",
+			"shared/defs.inc":        "#define VALUE 1\n",
+		})
+		writeTestFile(t, filepath.Join(fixture.repoRoot, "shared", "defs.inc"), "#define VALUE 2\n")
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected failed for a native include fragment: %v\n%s", err, output)
+		}
+		fixture.requireSingleRunCallWithUnorderedTail(t, "./alpha", "./consumer")
+		fixture.requireGoCalls(t, []string{"vet", "./alpha", "./consumer"})
+	})
+
+	for _, testCase := range []struct {
+		name          string
+		sharedPackage bool
+		wantPackages  []string
+	}{
+		{
+			name:          "recognized shared native header beside a Go package",
+			sharedPackage: true,
+			wantPackages:  []string{"./alpha", "./consumer", "./shared"},
+		},
+		{
+			name:         "recognized package-less shared native header",
+			wantPackages: []string{"./alpha", "./consumer"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			files := map[string]string{
+				"alpha/alpha.go": "package alpha\n\nfunc Value()\n",
+				"alpha/value.s":  "#include \"../shared/defs.h\"\n\nTEXT ·Value(SB), $0-0\n\tRET\n",
+				"consumer/consumer.go": `package consumer
+
+import "example.com/static-scope/alpha"
+
+func Value() { alpha.Value() }
+`,
+				"shared/defs.h":          "#define VALUE 1\n",
+				"unrelated/unrelated.go": "package unrelated\n",
+			}
+			if testCase.sharedPackage {
+				files["shared/shared.go"] = "package shared\n"
+			}
+			fixture := newPRStaticScopeFixture(t, files)
+			writeTestFile(t, filepath.Join(fixture.repoRoot, "shared", "defs.h"), "#define VALUE 2\n")
+
+			fixture.resetCalls(t)
+			if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+				t.Errorf("lint-affected failed for a recognized shared native header: %v\n%s", err, output)
+			}
+			fixture.requireSingleRunCallWithUnorderedTail(t, testCase.wantPackages...)
+			fixture.requireGoCalls(t, append([]string{"vet"}, testCase.wantPackages...))
+		})
+	}
 
 	t.Run("embedded file diff selects its package", func(t *testing.T) {
 		fixture := newPRStaticScopeFixture(t, map[string]string{
@@ -326,7 +391,7 @@ var Data string
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected failed for an embedded-file diff: %v\n%s", err, output)
 		}
-		fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+		fixture.requireCalls(t, []string{"run", "./alpha"})
 		fixture.requireGoCalls(t, []string{"vet", "./alpha"})
 	})
 
@@ -357,7 +422,7 @@ var data string
 			if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 				t.Errorf("lint-affected failed for a %s diff: %v\n%s", testPackage.name, err, output)
 			}
-			fixture.requireCalls(t, []string{"run", "--disable=govet", "./alpha"})
+			fixture.requireCalls(t, []string{"run", "./alpha"})
 			fixture.requireGoCalls(t, []string{"vet", "./alpha"})
 		})
 	}
@@ -386,7 +451,7 @@ var Data string
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected failed for a multiply owned embedded file: %v\n%s", err, output)
 		}
-		fixture.requireSingleRunCallWithUnorderedTail(t, "--disable=govet", "./alpha", "./alpha/child")
+		fixture.requireSingleRunCallWithUnorderedTail(t, "./alpha", "./alpha/child")
 		fixture.requireGoCalls(t, []string{"vet", "./alpha", "./alpha/child"})
 	})
 
@@ -409,7 +474,7 @@ var Data string
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected did not fail closed for a missing embedded file: %v\n%s", err, output)
 		}
-		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireCalls(t, []string{"run", "./..."})
 		fixture.requireGoCalls(t, []string{"vet", "./..."})
 	})
 
@@ -433,7 +498,39 @@ var Data embed.FS
 		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
 			t.Errorf("lint-affected did not fail closed for a deleted embed glob member: %v\n%s", err, output)
 		}
-		fixture.requireCalls(t, []string{"run", "--disable=govet", "./..."})
+		fixture.requireCalls(t, []string{"run", "./..."})
+		fixture.requireGoCalls(t, []string{"vet", "./..."})
+	})
+
+	t.Run("deleted recognized embedded glob member falls back before native shortcut", func(t *testing.T) {
+		fixture := newPRStaticScopeFixture(t, map[string]string{
+			"alpha/alpha.go": `package alpha
+
+import "embed"
+
+//go:embed data/*.h
+var Data embed.FS
+`,
+			"alpha/data/first.h":  "#define FIRST 1\n",
+			"alpha/data/second.h": "#define SECOND 2\n",
+			"consumer/consumer.go": `package consumer
+
+import "example.com/static-scope/alpha"
+
+var Data = alpha.Data
+`,
+			"native/native.go": "package native\n\nfunc Value()\n",
+			"native/value.s":   "TEXT ·Value(SB), $0-0\n\tRET\n",
+		})
+		if err := os.Remove(filepath.Join(fixture.repoRoot, "alpha", "data", "first.h")); err != nil {
+			t.Fatalf("delete recognized embedded glob member: %v", err)
+		}
+
+		fixture.resetCalls(t)
+		if output, err := fixture.runMakeTarget("lint-affected"); err != nil {
+			t.Errorf("lint-affected did not fail closed before the native shortcut: %v\n%s", err, output)
+		}
+		fixture.requireCalls(t, []string{"run", "./..."})
 		fixture.requireGoCalls(t, []string{"vet", "./..."})
 	})
 
@@ -506,7 +603,7 @@ func TestCIStaticScopeClassifierFailsClosedOutsideValidatedPullRequestMerge(t *t
 		"go.sum",
 		"go.work",
 		"go.work.sum",
-		".golangci.yml",
+		".golangci.",
 		"Makefile",
 		".github/workflows/",
 		".github/actions/",
@@ -535,10 +632,13 @@ func TestCIStaticScopeClassifierFailsClosedOutsideValidatedPullRequestMerge(t *t
 		for _, protectedPath := range []string{
 			"go.mod",
 			"go.sum",
+			".golangci.json",
+			".golangci.toml",
+			".golangci.yaml",
+			".golangci.yml",
 			".github/actions/static-scope/action.yml",
 			".github/workflows/ci.yml",
 			".githooks/pre-commit",
-			".golangci.yml",
 			"Makefile",
 			"go.work",
 			"go.work.sum",


### PR DESCRIPTION
## Summary

- Scope lint and formatting only for qualifying pull-request synthetic merges.
- Lint and vet changed Go build-input or embedded-file owners plus transitive production and test reverse dependents.
- Keep protected, invalid, unknown, and incomplete-graph cases on full-repository lint, formatting, and standalone vet.
- Run focused static-policy contracts on every preflight, independent of the selected scope.

## Safety model

Changed scope is allowed only when the checkout is an exact two-parent synthetic merge whose first parent matches the event base SHA. Module files, static configuration, workflows, hooks, vendored code, and the selector or classifier force full scope.

Affected selection is NUL-safe and covers Go, assembly, cgo-related inputs, production/test/external-test embeds, multiple embed owners, deletions, moves, and transitive reverse dependents. Missing or ambiguous ownership fails closed to `./...`. The affected lane disables the golangci `govet` copy and runs standalone `go vet` over the identical package closure.

Formatting receives only changed existing regular `.go` files and never follows symlinks.

## Performance

Baseline evidence is [Actions run 29483623514](https://github.com/gastownhall/gascity/actions/runs/29483623514):

- Static job: 257s
- Broad lint + format + vet removed from qualifying PRs: 152s
- Measured replacement: 6.91s affected lint/vet + 0.86s changed formatting
- New always-run focused policy suite: about 11.9s
- Expected net saving: about 132s
- Projected qualifying static job: about 125s
- Projected protected/full static job: about 269s

These are measured local and observed CI inputs, not an SLA. The 61s native dependency guard remains unchanged.

## Verification

- `go test -count=1 ./scripts`
- `make test-ci-policy`
- `make check-docs`
- `actionlint`
- `make fmt-check lint vet`
- `make test-fast-parallel`
- `.githooks/pre-commit`
- Pre-push fast-suite gate
- Three independent delegated council reviews: zero P0/P1 findings

Tracking: `ga-80po0c.21`