### PR TITLE
Add retired hold-label convention doctor check

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -358,6 +358,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 
 	// Custom types check — city store.
 	register(doctor.NewCustomTypesCheck(cityPath, "city"))
+	register(newHoldLabelConventionsCheck(cityPath, "city", storeFactory))
 
 	// Per-rig checks. Skip effectively-suspended rigs — opening their
 	// bead store triggers bd auto-start of orphan Dolt servers (ga-wzk).
@@ -378,6 +379,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 			register(newDoctorRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || gcDoltSkip()))
 			// Custom types check — rig store.
 			register(doctor.NewCustomTypesCheck(rig.Path, rig.Name))
+			register(newHoldLabelConventionsCheck(rig.Path, rig.Name, storeFactory))
 			// Dolt-backup registration catches the silent gap left by
 			// `gc rig add` before the rig is eligible for mol-dog backup
 			// automation. Gated to match the sibling dolt-server check:

--- a/cmd/gc/doctor_hold_label_conventions.go
+++ b/cmd/gc/doctor_hold_label_conventions.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// retiredHoldLabels are hold/blocked labels retired by the canonical hold
+// taxonomy decided in ga-tug8ry.1. Only hold:mayor and hold:external remain
+// sanctioned; any live (non-closed) bead still carrying one of these is
+// convention drift.
+var retiredHoldLabels = []string{
+	"arch-hold",
+	"blocked",
+	"blocked-by-operator",
+	"blocked-on-external",
+	"blocked-on-upstream",
+	"blocked-prereq",
+	"human-hold",
+	"human",
+	"on-hold",
+}
+
+// holdLabelConventionsFixHint mirrors ga-tug8ry.1's disposition table.
+// engdocs/contributors/hold-label-conventions.md does not exist on
+// origin/main yet, so the hint must stand on its own rather than point at it.
+const holdLabelConventionsFixHint = "Retired hold/blocked label in use (ga-tug8ry.1 taxonomy): " +
+	"arch-hold and blocked-prereq retire with no migration; blocked retires in favor of the " +
+	"native status field; blocked-by-operator, blocked-on-upstream, human-hold, and human " +
+	"migrate to hold:mayor; blocked-on-external migrates to hold:external; on-hold retires as " +
+	"already-superseded. Set a sanctioned hold label with " +
+	"'bd set-state <id> hold=mayor|external --reason \"...\"'."
+
+// holdLabelConventionsCheck flags live use of retired hold/blocked labels
+// within a single bead store scope (a city or a rig). It classifies bead
+// content through the typed beads.Store interface, so it lives in cmd/gc
+// alongside backlogDepthCheck rather than in internal/doctor.
+type holdLabelConventionsCheck struct {
+	dir      string
+	label    string
+	newStore func(string) (beads.Store, error)
+}
+
+func newHoldLabelConventionsCheck(dir, label string, newStore func(string) (beads.Store, error)) *holdLabelConventionsCheck {
+	return &holdLabelConventionsCheck{dir: dir, label: label, newStore: newStore}
+}
+
+func (c *holdLabelConventionsCheck) Name() string { return "hold-label-conventions:" + c.label }
+
+func (c *holdLabelConventionsCheck) CanFix() bool { return false }
+
+// Fix is a no-op: retired labels disperse to different remediation targets
+// (several to hold:mayor, one to hold:external, several retire with no
+// migration, bare "blocked" moves to the native status field), so no single
+// mechanical fix applies uniformly.
+func (c *holdLabelConventionsCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+func (c *holdLabelConventionsCheck) WarmupEligible() bool { return false }
+
+func (c *holdLabelConventionsCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	res := &doctor.CheckResult{Name: c.Name(), Severity: doctor.SeverityAdvisory}
+
+	if c.newStore == nil || strings.TrimSpace(c.dir) == "" {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("hold-label conventions unknown for %s: no bead store configured", c.label)
+		return res
+	}
+
+	store, err := c.newStore(c.dir)
+	if err != nil {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("hold-label conventions unknown for %s: opening bead store: %v", c.label, err)
+		return res
+	}
+
+	var details []string
+	var queryErrs []string
+	for _, label := range retiredHoldLabels {
+		found, err := store.ListByLabel(label, 0)
+		if err != nil {
+			queryErrs = append(queryErrs, fmt.Sprintf("querying label %q: %v", label, err))
+			continue
+		}
+		for _, b := range found {
+			details = append(details, fmt.Sprintf("retired label %q on %s %q", label, b.ID, b.Title))
+		}
+	}
+	sort.Strings(details)
+	sort.Strings(queryErrs)
+
+	switch {
+	case len(details) > 0:
+		res.Status = doctor.StatusError
+		res.Message = fmt.Sprintf("%d retired hold/blocked label use(s) found in %s", len(details), c.label)
+		details = append(details, queryErrs...)
+		res.Details = details
+		res.FixHint = holdLabelConventionsFixHint
+	case len(queryErrs) > 0:
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("hold-label conventions check for %s hit %d label-query error(s)", c.label, len(queryErrs))
+		res.Details = queryErrs
+	default:
+		res.Status = doctor.StatusOK
+		res.Message = fmt.Sprintf("no retired hold/blocked labels found in %s", c.label)
+	}
+
+	return res
+}

--- a/cmd/gc/doctor_hold_label_conventions_test.go
+++ b/cmd/gc/doctor_hold_label_conventions_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestHoldLabelConventionsCheckCleanState(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "H-1", Title: "mayor hold", Type: "task", Status: "open", Labels: []string{"hold:mayor"}},
+		{ID: "H-2", Title: "external hold", Type: "task", Status: "open", Labels: []string{"hold:external"}},
+		{ID: "H-3", Title: "no hold labels at all", Type: "task", Status: "open"},
+	}, nil)
+
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK: %#v", res.Status, res)
+	}
+	if res.Severity != doctor.SeverityAdvisory {
+		t.Fatalf("Severity = %v, want Advisory", res.Severity)
+	}
+	if len(res.Details) != 0 {
+		t.Errorf("Details = %v, want empty", res.Details)
+	}
+}
+
+func TestHoldLabelConventionsCheckFlagsRetiredLabels(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "R-1", Title: "old style block", Type: "task", Status: "open", Labels: []string{"blocked"}},
+		{ID: "R-2", Title: "arch blocker", Type: "task", Status: "open", Labels: []string{"arch-hold"}},
+		{ID: "H-1", Title: "fine", Type: "task", Status: "open", Labels: []string{"hold:mayor"}},
+	}, nil)
+
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusError {
+		t.Fatalf("Status = %v, want Error: %#v", res.Status, res)
+	}
+	if res.Severity != doctor.SeverityAdvisory {
+		t.Fatalf("Severity = %v, want Advisory", res.Severity)
+	}
+	details := strings.Join(res.Details, "\n")
+	for _, want := range []string{"R-1", "blocked", "R-2", "arch-hold"} {
+		if !strings.Contains(details, want) {
+			t.Errorf("Details missing %q:\n%s", want, details)
+		}
+	}
+	if strings.Contains(details, "H-1") {
+		t.Errorf("Details should not flag hold:mayor bead H-1:\n%s", details)
+	}
+	if res.FixHint == "" {
+		t.Error("FixHint should be set when retired labels are found")
+	}
+	if strings.Contains(res.FixHint, "hold-label-conventions.md") {
+		t.Errorf("FixHint should not reference the not-yet-merged doc file: %q", res.FixHint)
+	}
+}
+
+func TestHoldLabelConventionsCheckOutOfScopeLabelsExactMatchOnly(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "O-1", Title: "build blocker", Type: "task", Status: "open", Labels: []string{"build-blocker"}},
+		{ID: "O-2", Title: "pre push blocker", Type: "task", Status: "open", Labels: []string{"pre-push-blocker"}},
+		{ID: "O-3", Title: "ci blocker", Type: "task", Status: "open", Labels: []string{"ci-blocker"}},
+		{ID: "O-4", Title: "test blocker", Type: "task", Status: "open", Labels: []string{"test-blocker"}},
+		{ID: "O-5", Title: "push blocking", Type: "task", Status: "open", Labels: []string{"push-blocking"}},
+		{ID: "O-6", Title: "needs mayor", Type: "task", Status: "open", Labels: []string{"needs-mayor"}},
+		{ID: "O-7", Title: "needs mayor decision", Type: "task", Status: "open", Labels: []string{"needs-mayor-decision"}},
+		{ID: "O-8", Title: "mpr human hold", Type: "task", Status: "open", Labels: []string{"mpr-human-hold"}},
+	}, nil)
+
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK (out-of-scope labels must never false-positive): %#v", res.Status, res)
+	}
+	if len(res.Details) != 0 {
+		t.Errorf("Details = %v, want empty", res.Details)
+	}
+}
+
+func TestHoldLabelConventionsCheckMixedLabelsFlagsOnlyRetired(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "M-1", Title: "mixed labels", Type: "task", Status: "open", Labels: []string{"blocked", "build-blocker"}},
+	}, nil)
+
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusError {
+		t.Fatalf("Status = %v, want Error: %#v", res.Status, res)
+	}
+	if len(res.Details) != 1 {
+		t.Fatalf("Details = %v, want exactly 1 entry (only the retired label)", res.Details)
+	}
+	if !strings.Contains(res.Details[0], "blocked") || strings.Contains(res.Details[0], "build-blocker") {
+		t.Errorf("Details[0] = %q, want to name retired label 'blocked' only, not out-of-scope 'build-blocker'", res.Details[0])
+	}
+}
+
+func TestHoldLabelConventionsCheckIgnoresClosedBeads(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "C-1", Title: "closed with retired label", Type: "task", Status: "closed", Labels: []string{"human-hold"}},
+	}, nil)
+
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK (closed beads must not be flagged): %#v", res.Status, res)
+	}
+	if len(res.Details) != 0 {
+		t.Errorf("Details = %v, want empty", res.Details)
+	}
+}
+
+func TestHoldLabelConventionsCheckStoreErrorIsGraceful(t *testing.T) {
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) {
+		return nil, fmt.Errorf("store unreachable")
+	})
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("Status = %v, want Warning on store error: %#v", res.Status, res)
+	}
+	if res.Severity != doctor.SeverityAdvisory {
+		t.Fatalf("Severity = %v, want Advisory", res.Severity)
+	}
+	if check.CanFix() {
+		t.Errorf("CanFix = true, want false (no single mechanical fix applies)")
+	}
+}

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -76,4 +76,5 @@ bd-backup-freshness
 worktree-disk-size
 nested-worktree-prune
 custom-types:city
+hold-label-conventions:city
 worktrees

--- a/release-gates/ga-hju8ar-hold-label-conventions-gate.md
+++ b/release-gates/ga-hju8ar-hold-label-conventions-gate.md
@@ -1,0 +1,38 @@
+# Release Gate: retired hold-label convention doctor check
+
+- Bead: ga-hju8ar
+- Source bead: ga-tug8ry.5.1
+- Review bead: ga-xikkj2
+- Feature branch: gc-builder-2-c722b7dbf407
+- Candidate commit: 4b492edfa9c77cbba0843047dfd5a6c0f2fc5a86
+- Base: origin/main d1b7c04262e44a4eaef160feafb6c74675991022
+- Evaluated: 2026-07-16T12:19:34Z
+
+Note: ga-hju8ar metadata.commit still lists dbd070c6d49ca1d2c4e6226f3ebb874419f2bbb1, but the remote branch tip is 4b492edfa9c77cbba0843047dfd5a6c0f2fc5a86. This gate evaluates the branch tip that will be pushed and opened as the PR head.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | `git rev-list --left-right --count origin/main...HEAD` returned `0 1`; merge-base is `origin/main` d1b7c04262e44a4eaef160feafb6c74675991022; `git merge-tree --write-tree origin/main HEAD` completed successfully. |
+| 1 | Review PASS present | PASS | Review bead ga-xikkj2 is closed and its notes begin with `REVIEW: PASS`. |
+| 2 | Acceptance criteria met | PASS | The diff implements the retired-label doctor check, exact-match retired-label queries, closed-bead exclusion, store-error warning behavior, and city plus per-rig registration. Tests cover all seven acceptance criteria from ga-tug8ry.5.1. |
+| 3 | Tests pass | PASS | `HOME=/home/jaword LOCAL_TEST_JOBS=16 make test-fast-parallel` completed with all 8 fast jobs passed. `HOME=/home/jaword go vet ./...` completed with no output. |
+| 4 | No high-severity review findings open | PASS | Review notes include OWASP/security review with no findings; search found no HIGH or request-changes finding in ga-xikkj2 notes. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short` was empty and `git diff --check origin/main...HEAD` was clean. This gate file is committed as the only deployer change. |
+| 7 | Single feature theme | PASS | Commit set is one commit touching only the `gc doctor` check registration, hold-label-convention check implementation, its tests, and the doctor check-name golden fixture. |
+
+## Diff Scope
+
+```text
+cmd/gc/cmd_doctor.go
+cmd/gc/doctor_hold_label_conventions.go
+cmd/gc/doctor_hold_label_conventions_test.go
+cmd/gc/testdata/doctor_check_names.golden
+```
+
+## Commit Set
+
+```text
+4b492edfa feat(doctor): flag retired hold/blocked labels (ga-tug8ry.5.1)
+```


### PR DESCRIPTION
## What this changes

`gc doctor` now reports advisory failures when open beads still carry retired hold or blocked labels such as `blocked`, `human-hold`, or `blocked-on-upstream`. The sanctioned labels `hold:mayor` and `hold:external` remain clean.

The check runs at both city and per-rig scope, queries the bead store by exact label, ignores closed beads, and reports store-open problems as warnings instead of panics.

## Review notes

- The check is advisory only: `CanFix()` is false because the retired labels map to different remediation paths.
- The implementation is confined to `cmd/gc` doctor registration plus dedicated tests and the doctor check-name golden fixture.
- No API, dashboard, schema, or migration surface changes.

## Test plan

- [x] `HOME=/home/jaword LOCAL_TEST_JOBS=16 make test-fast-parallel`
- [x] `HOME=/home/jaword go vet ./...`
- [x] Release gate: [`release-gates/ga-hju8ar-hold-label-conventions-gate.md`](release-gates/ga-hju8ar-hold-label-conventions-gate.md)
