### PR TITLE
fix(beads): stop NativeDoltStore.Ready() from surfacing blocked/pinned/hooked beads

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -60,14 +60,21 @@ func repairIDDefault(db *sql.DB, table string) error {
 
 const nativeDoltStoreActor = "gascity"
 
+// nativeDoltOpenReadyStatuses lists the upstream bd statuses Ready() queries
+// GetReadyWork for. This must match IsReadyCandidateForTier's contract of
+// "open status ... and no future defer_until": only StatusOpen (bd's own
+// status-category table marks it the sole "active" category status) and
+// StatusDeferred (kept only because IsDeferred independently re-checks
+// DeferUntil, so an expired deferral must still resurface) belong here.
+// blocked/hooked are bd's "wip" category and pinned is "frozen" — bd's own
+// ready semantics already exclude them, and Gas City has no analogous
+// re-check for them the way it does for deferred, so querying for them let
+// dependency-blocked beads erase their status to "open" via mapBdStatus and
+// pass IsReadyCandidateForTier's status gate. See ga-3mv5d3 bead notes for
+// the full investigation.
 var nativeDoltOpenReadyStatuses = []beadslib.Status{
 	beadslib.StatusOpen,
-	beadslib.StatusBlocked,
 	beadslib.StatusDeferred,
-	beadslib.Status("pinned"),
-	beadslib.Status("hooked"),
-	beadslib.Status("review"),
-	beadslib.Status("testing"),
 }
 
 var (

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -330,7 +330,16 @@ func TestNativeDoltStoreListStatusOpenExcludesClosedBeadsFromUpstreamDrift(t *te
 	}
 }
 
-func TestNativeDoltStoreReadyIncludesOpenNormalizedUpstreamStatuses(t *testing.T) {
+func TestNativeDoltStoreReadyOnlyIncludesOpenAndDeferredUpstreamStatuses(t *testing.T) {
+	// bd's own status-category table (vendored beads internal/types.
+	// BuiltInStatusCategory) marks blocked/hooked as "wip" and pinned as
+	// "frozen" — both excluded from bd's own ready semantics. Only "open"
+	// (category active) and deferred (once DeferUntil has passed, handled
+	// via IsReadyCandidateForTier's IsDeferred check) belong here. This
+	// issue set intentionally includes a blocked bead whose dependency
+	// graph the spy treats as fully satisfied (it is returned unconditionally
+	// whenever queried by status), to prove Ready() must never surface it
+	// even when GetReadyWork would happily return it if asked.
 	issues := []*beadslib.Issue{
 		{ID: "gc-open", Title: "open", Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2},
 		{ID: "gc-blocked", Title: "blocked", Status: beadslib.StatusBlocked, IssueType: beadslib.TypeTask, Priority: 2},
@@ -361,15 +370,14 @@ func TestNativeDoltStoreReadyIncludesOpenNormalizedUpstreamStatuses(t *testing.T
 	}
 
 	wantIDs := map[string]bool{
-		"gc-open": true, "gc-blocked": true, "gc-deferred": true,
-		"gc-pinned": true, "gc-hooked": true, "gc-review": true,
+		"gc-open": true, "gc-deferred": true,
 	}
 	if len(got) != len(wantIDs) {
 		t.Fatalf("Ready len = %d, want %d; got %+v", len(got), len(wantIDs), got)
 	}
 	for _, bead := range got {
 		if !wantIDs[bead.ID] {
-			t.Fatalf("Ready returned unexpected bead %q from %+v", bead.ID, got)
+			t.Fatalf("Ready returned unexpected bead %q from %+v — blocked/pinned/hooked/review must never surface as ready even when their dependency graph is satisfied", bead.ID, got)
 		}
 		if bead.Status != "open" {
 			t.Fatalf("Ready bead %q status = %q, want normalized open", bead.ID, bead.Status)

--- a/release-gates/ga-nxmzl5-ready-status-filter-gate.md
+++ b/release-gates/ga-nxmzl5-ready-status-filter-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: NativeDoltStore Ready status filter
+
+Bead: `ga-nxmzl5`
+Implementation bead: `ga-3mv5d3`
+Branch: `builder/ga-3mv5d3-ready-status-filter`
+PR: https://github.com/gastownhall/gascity/pull/4347
+Reviewed commit: `2684ac560c730bf2e89092e669c31881b854d0c5`
+Base: `origin/main` at `4fda5a28445f42d6e789fc7f5751645ac4fecd19`
+
+The prompted `docs/PROJECT_MANIFEST.md` path is not present in this Gas City
+checkout. No `PROJECT_MANIFEST.md` or `SOFTWARE_FACTORY_MANIFEST.md` was found
+with `rg --files -g '*MANIFEST*.md' -g '!ga-*'`, so this gate uses the deployer
+release criteria from the role prompt and the repository testing guidance in
+`TESTING.md`.
+
+## Diff Scope
+
+`git diff --name-status origin/main...HEAD`:
+
+```text
+M	internal/beads/native_dolt_store.go
+M	internal/beads/native_dolt_store_test.go
+```
+
+This is one release unit: `NativeDoltStore.Ready()` now queries only upstream
+statuses that can legitimately become dispatch candidates, and the matching
+regression test proves blocked/pinned/hooked/review/testing statuses do not
+surface as ready work after bd-status normalization.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-nxmzl5` records `Reviewed-by: gascity/reviewer, verdict PASS`; the implementation bead `ga-3mv5d3` is closed with the fix summary and verification notes. |
+| 2 | Acceptance criteria met | PASS | The regression test `TestNativeDoltStoreReadyOnlyIncludesOpenAndDeferredUpstreamStatuses` covers open, blocked, deferred, pinned, hooked, review, and testing upstream statuses. `nativeDoltOpenReadyStatuses` now contains only `beadslib.StatusOpen` and `beadslib.StatusDeferred`. The diff is limited to `internal/beads/native_dolt_store.go` and `internal/beads/native_dolt_store_test.go`, so the public `Bead.Status` wire enum, OpenAPI schema, and dashboard generated types are untouched. The implementation bead notes document the status-category investigation. |
+| 3 | Tests pass | PASS | `go test ./internal/beads -run TestNativeDoltStoreReadyOnlyIncludesOpenAndDeferredUpstreamStatuses -count=1` passed. `go test ./internal/beads/...` passed. `gofmt -l internal/beads/native_dolt_store.go internal/beads/native_dolt_store_test.go` returned no files. `go vet ./...` passed. `make test-fast-parallel` passed all 8 fast jobs. `gh pr checks 4347` was green at reviewed commit `2684ac560c730bf2e89092e669c31881b854d0c5` before adding this gate file. |
+| 4 | No high-severity review findings open | PASS | The deploy bead records reviewer PASS and no blocker/HIGH findings. PR #4347 has no comments or reviews from external contributors. |
+| 5 | Final branch is clean | PASS | Detached gate worktree at `/var/tmp/gc-deployer-ga-nxmzl5-pass-20260716-4eYigT` started clean at `origin/builder/ga-3mv5d3-ready-status-filter`; `git status --short --branch` returned only `## HEAD (no branch)` before this gate file was added. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main origin/builder/ga-3mv5d3-ready-status-filter` passed. `git merge-base origin/main origin/builder/ga-3mv5d3-ready-status-filter` returned `4fda5a28445f42d6e789fc7f5751645ac4fecd19`. `git merge-tree --write-tree origin/main origin/builder/ga-3mv5d3-ready-status-filter` succeeded with tree `34b5ba7dbc8f8b7efe7df1a5f4496464634b15fc`. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and behavior: native Dolt-backed bead readiness filtering for non-dispatchable upstream statuses. |
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

Native Dolt-backed readiness now preserves explicit non-dispatchable bead states. `NativeDoltStore.Ready()` no longer asks bd for `blocked`, `pinned`, `hooked`, `review`, or `testing` statuses before Gas City's readiness gate runs, so work parked by status will not be normalized back to `open` and dispatched just because its dependency graph is satisfied.

The change is intentionally local to the native Dolt beads backend. It does not change the public `Bead.Status` wire enum, OpenAPI schema, dashboard generated types, or the behavior of other bead-store providers.

## Review notes

- Main behavior change: `internal/beads/native_dolt_store.go` narrows `nativeDoltOpenReadyStatuses` to `open` and `deferred`.
- Regression coverage: `internal/beads/native_dolt_store_test.go` proves blocked/pinned/hooked/review/testing upstream statuses are excluded from ready work.
- Deferred stays in the query list because Gas City has an independent `defer_until` check that can make an expired deferral dispatchable.

## Test plan

- [x] `go test ./internal/beads -run TestNativeDoltStoreReadyOnlyIncludesOpenAndDeferredUpstreamStatuses -count=1`
- [x] `go test ./internal/beads/...`
- [x] `gofmt -l internal/beads/native_dolt_store.go internal/beads/native_dolt_store_test.go` returned no files
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-nxmzl5-ready-status-filter-gate.md`](release-gates/ga-nxmzl5-ready-status-filter-gate.md)
