### PR TITLE
test(productmetrics): build deep-purge fixtures fd-relative to fit darwin PATH_MAX

### DIFF
--- a/internal/productmetrics/spool_unix_test.go
+++ b/internal/productmetrics/spool_unix_test.go
@@ -5575,6 +5575,56 @@ type quarantineCollisionFixture struct {
 	namespaceMutations int
 }
 
+// mkdirDeepAt builds depth nested directories under parent and returns an open
+// descriptor for the deepest one, which the caller closes. It descends with
+// mkdirat/openat one component at a time, mirroring the traversal the purge code
+// under test performs. Building the same tree from a growing absolute path is
+// bounded by PATH_MAX (1024 on darwin, 4096 on linux) and cannot represent the
+// depths these fixtures need; fd-relative descent is bounded by NAME_MAX per
+// component instead. Only two descriptors are held at once so the tree stays
+// buildable under the low RLIMIT_NOFILE fixtures.
+func mkdirDeepAt(t *testing.T, parent string, depth int, mode uint32) int {
+	t.Helper()
+	current, err := unix.Open(parent, unixDirectoryOpenFlags, 0)
+	if err != nil {
+		t.Fatalf("open deep fixture parent %s: %v", parent, err)
+	}
+	for level := 0; level < depth; level++ {
+		name := fmt.Sprintf("d%03d", level)
+		if err := unix.Mkdirat(current, name, mode); err != nil {
+			_ = unix.Close(current)
+			t.Fatalf("mkdirat deep fixture level %d: %v", level, err)
+		}
+		next, err := unix.Openat(current, name, unixDirectoryOpenFlags, 0)
+		if err != nil {
+			_ = unix.Close(current)
+			t.Fatalf("openat deep fixture level %d: %v", level, err)
+		}
+		if err := unix.Close(current); err != nil {
+			_ = unix.Close(next)
+			t.Fatalf("close deep fixture level %d: %v", level, err)
+		}
+		current = next
+	}
+	return current
+}
+
+// writeFileAt creates name under directoryFD, for leaves too deep to address by path.
+func writeFileAt(t *testing.T, directoryFD int, name string, data []byte, mode uint32) {
+	t.Helper()
+	fd, err := unix.Openat(directoryFD, name, unix.O_CREAT|unix.O_WRONLY|unix.O_TRUNC|unix.O_CLOEXEC, mode)
+	if err != nil {
+		t.Fatalf("openat deep fixture file %s: %v", name, err)
+	}
+	if _, err := unix.Write(fd, data); err != nil {
+		_ = unix.Close(fd)
+		t.Fatalf("write deep fixture file %s: %v", name, err)
+	}
+	if err := unix.Close(fd); err != nil {
+		t.Fatalf("close deep fixture file %s: %v", name, err)
+	}
+}
+
 func newQuarantineCollisionFixture(t *testing.T, kind string) *quarantineCollisionFixture {
 	t.Helper()
 	home, _, _ := newRecordServiceFixture(t, testEventIDThree)
@@ -5617,15 +5667,10 @@ func newQuarantineCollisionFixture(t *testing.T, kind string) *quarantineCollisi
 		t.Fatal(err)
 	}
 	if kind == "deep-directory" || kind == "lax-deep-directory" {
-		path := blockerPath
-		for depth := 0; depth < 513; depth++ {
-			path = filepath.Join(path, fmt.Sprintf("d%03d", depth))
-			if err := os.Mkdir(path, 0o700); err != nil {
-				t.Fatal(err)
-			}
-		}
-		if err := os.WriteFile(filepath.Join(path, "payload"), []byte("x"), 0o600); err != nil {
-			t.Fatal(err)
+		leaf := mkdirDeepAt(t, blockerPath, 513, 0o700)
+		writeFileAt(t, leaf, "payload", []byte("x"), 0o600)
+		if err := unix.Close(leaf); err != nil {
+			t.Fatalf("close deep fixture leaf: %v", err)
 		}
 	}
 	if kind == "lax-empty-directory" || kind == "lax-deep-directory" {
@@ -8064,20 +8109,18 @@ func TestSpoolDeepPurgeConvergesUnderLowFileDescriptorLimit(t *testing.T) {
 	if err := os.MkdirAll(deep, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	for depth := 0; depth < 300; depth++ {
-		deep = filepath.Join(deep, fmt.Sprintf("d%03d", depth))
-		if err := os.Mkdir(deep, 0o700); err != nil {
-			t.Fatal(err)
+	deepLeaf := mkdirDeepAt(t, deep, 300, 0o700)
+	defer func() {
+		if err := unix.Close(deepLeaf); err != nil {
+			t.Errorf("close deep fixture leaf: %v", err)
 		}
-	}
-	if err := os.WriteFile(filepath.Join(deep, "payload"), []byte("deep"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	}()
+	writeFileAt(t, deepLeaf, "payload", []byte("deep"), 0o600)
 	sentinel := filepath.Join(t.TempDir(), "outside-sentinel")
 	if err := os.WriteFile(sentinel, []byte("outside"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink(sentinel, filepath.Join(deep, "outside-link")); err != nil {
+	if err := unix.Symlinkat(sentinel, deepLeaf, "outside-link"); err != nil {
 		t.Fatal(err)
 	}
 	plainRoot := mustOpenMutableRoot(t, home)
@@ -10870,10 +10913,20 @@ func hasStrongFailClosedSpoolEvidence(root *storageRoot) bool {
 	return quotaErr == nil && present && quota == markers || activeErr == nil || retiredErr == nil || fallbackCursorErr == nil
 }
 
+// filesystemStateFingerprint walks root through os.Root, which resolves each
+// component fd-relative. Walking by absolute path instead is bounded by PATH_MAX
+// (1024 on darwin, 4096 on linux) and cannot fingerprint the deep trees the purge
+// fixtures build. Entries keep lstat semantics, so symbolic links are recorded
+// rather than followed.
 func filesystemStateFingerprint(t *testing.T, root string) string {
 	t.Helper()
+	opened, err := os.OpenRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
 	var entries []string
-	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+	err = fs.WalkDir(opened.FS(), ".", func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -10881,11 +10934,7 @@ func filesystemStateFingerprint(t *testing.T, root string) string {
 		if err != nil {
 			return err
 		}
-		relative, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		entries = append(entries, fmt.Sprintf("%s|%v|%d|%d", relative, info.Mode(), info.Size(), info.ModTime().UnixNano()))
+		entries = append(entries, fmt.Sprintf("%s|%v|%d|%d", path, info.Mode(), info.Size(), info.ModTime().UnixNano()))
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Problem

Two tests in `internal/productmetrics` fail deterministically on macOS during
fixture setup, before the code under test runs:

- `TestPurgeQuarantineCollisionChainMakesBoundedMonotonicProgress` (subtests
  `deep-directory`, `lax-deep-directory`)
- `TestSpoolDeepPurgeConvergesUnderLowFileDescriptorLimit`

The failure is `ENAMETOOLONG`:

```
mkdir …/queue/.orphan-…/d000/d001/…/d176: file name too long
```

Both fixtures build a deep tree from a **growing absolute path** — depth 513
(~2565 bytes) and depth 300 (~1500 bytes). That fits under Linux `PATH_MAX`
(4096) but exceeds darwin `PATH_MAX` (1024), so the tree cannot be represented
by absolute path on macOS at all. CI here is Linux-only, so the assumption has
been invisible.

## Why the production code is not at fault

The purge code traverses fd-relative (`unix.Openat` / `unix.Mkdirat` /
`unix.Unlinkat` in `storage_unix.go`), one component at a time relative to a
directory fd — bounded by `NAME_MAX` (255) per component, **not** `PATH_MAX`.
So production handles arbitrarily deep trees on macOS correctly; the fixtures
simply never got far enough to exercise it. This is confirmed: with the
fixture-only change here, the 513-deep purge path runs and passes on macOS.

## The fix (test-only)

Build and inspect the fixtures the same fd-relative way the code under test
walks them:

- `mkdirDeepAt` / `writeFileAt` descend with `mkdirat`/`openat`, holding O(1)
  descriptors at a time — required because `TestSpoolDeepPurgeConverges…`
  deliberately runs under a low `RLIMIT_NOFILE`.
- `filesystemStateFingerprint` walks via `os.Root`, which resolves each path
  component fd-relative and preserves `lstat` semantics (`Root.FS()` implements
  `fs.ReadLinkFS`), so the planted escaping symlink is still **recorded, not
  followed**, and the fingerprint format is byte-identical.

Depths (**513**, **300**) and `maximumCleanupDirectories` (**512**) are
unchanged — the fixture depth is `512 + 1` on purpose, to force purge past its
per-pass directory budget and prove *bounded, monotonic, multi-pass* progress.
Reducing the depth to fit `PATH_MAX` would leave the test green while dropping
that coverage, so the depths are held and the construction is made portable
instead.

## Verification

- `go test ./internal/productmetrics/ -run 'TestPurgeQuarantineCollisionChainMakesBoundedMonotonicProgress|TestSpoolDeepPurgeConvergesUnderLowFileDescriptorLimit'`
  passes on darwin/arm64 (Go 1.26.5). `TestSpoolDeepPurgeConverges…` goes from
  ~0.06s (dying in setup) to ~20s (actually running the convergence loop).
- `GOOS=linux GOARCH=amd64 go vet ./internal/productmetrics/` clean.
- `gofmt` clean. Diff is a single `_test.go` file, +73/−24. No production code
  changed.

## Suggested follow-up (not in this PR)

A macOS CI runner would catch this bug class at the source — any fixture that
builds a deep tree from an absolute path is silently Linux-only today. Happy to
open that separately if it's of interest.
