### PR TITLE
Add clone-local Store metadata

### DIFF
--- a/cmd/gc/error_store.go
+++ b/cmd/gc/error_store.go
@@ -32,6 +32,8 @@ func (s unavailableStore) ListByMetadata(map[string]string, int, ...beads.QueryO
 }
 func (s unavailableStore) SetMetadata(string, string, string) error         { return s.err }
 func (s unavailableStore) SetMetadataBatch(string, map[string]string) error { return s.err }
+func (s unavailableStore) SetLocalString(string, string, string) error      { return s.err }
+func (s unavailableStore) GetLocalString(string, string) (string, error)    { return "", s.err }
 func (s unavailableStore) Tx(string, func(beads.Tx) error) error            { return s.err }
 func (s unavailableStore) Delete(string) error                              { return s.err }
 func (s unavailableStore) Ping() error                                      { return s.err }

--- a/cmd/gc/session_local_metadata_composition_test.go
+++ b/cmd/gc/session_local_metadata_composition_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// These tests demonstrate (not merely assert) that beads.Store's clone-local
+// SetLocalString/GetLocalString compose cleanly with the durable PendingCreateLease
+// and SetMarker machinery: same underlying store, same session bead id, disjoint
+// storage, no shared production call sites today.
+
+// TestReconcileSessionBeads_SetLocalStringDoesNotAffectPendingCreateLease exercises
+// the actual production reconciler (not a unit-tested predicate in isolation) with
+// a deliberately adversarial setup: SetLocalString is called with the exact same
+// key names (last_woke_at, pending_create_claim) the durable PendingCreateLease
+// logic reads out of Bead.Metadata, on the same bead id. If SetLocalString ever
+// leaked into, or shadowed, durable metadata, this session would be closed as an
+// orphan or lose its lease. It is not and does not: the two APIs write to
+// disjoint storage, so the collision is a no-op for production behavior.
+func TestReconcileSessionBeads_SetLocalStringDoesNotAffectPendingCreateLease(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	session := env.createSessionBead("s-gc-local", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "creating",
+		"manual_session":       "true",
+		"pending_create_claim": "true",
+	})
+	session.CreatedAt = env.clk.Now().Add(-30 * time.Second)
+
+	if err := env.store.SetLocalString(session.ID, "last_woke_at", "clone-local-value"); err != nil {
+		t.Fatalf("SetLocalString last_woke_at: %v", err)
+	}
+	if err := env.store.SetLocalString(session.ID, "pending_create_claim", "false"); err != nil {
+		t.Fatalf("SetLocalString pending_create_claim: %v", err)
+	}
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 without desired-state membership", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("pending-create session was closed as orphan despite colliding SetLocalString writes: %+v", got)
+	}
+	if got.Metadata["state"] == "orphaned" {
+		t.Fatalf("pending-create session was marked orphaned despite colliding SetLocalString writes: %+v", got.Metadata)
+	}
+	if got.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("durable pending_create_claim = %q, want unaffected by same-key SetLocalString write", got.Metadata["pending_create_claim"])
+	}
+
+	localVal, err := env.store.GetLocalString(session.ID, "last_woke_at")
+	if err != nil {
+		t.Fatalf("GetLocalString last_woke_at: %v", err)
+	}
+	if localVal != "clone-local-value" {
+		t.Fatalf("GetLocalString(last_woke_at) = %q, want the clone-local value preserved independently of durable metadata", localVal)
+	}
+}
+
+// TestReconcileSessionBeads_SetMarkerAndSetLocalStringCoexistOnSameSessionBead
+// demonstrates the non-adversarial, realistic composition: session.Store's
+// SetMarker front door (the durable path SetMarker/last_woke_at production call
+// sites use) and beads.Store.SetLocalString are both called on the same session
+// bead id with distinct keys. Both writes succeed independently: the durable
+// write surfaces through Get/Bead.Metadata, the local write does not, and is only
+// visible through GetLocalString.
+func TestReconcileSessionBeads_SetMarkerAndSetLocalStringCoexistOnSameSessionBead(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("s-gc-coexist", "worker")
+
+	infoStore := sessionpkg.NewStore(beads.SessionStore{Store: env.store})
+	if err := infoStore.SetMarker(session.ID, "throttle_marker", "queued"); err != nil {
+		t.Fatalf("SetMarker: %v", err)
+	}
+	if err := env.store.SetLocalString(session.ID, "synced_at", "2026-07-14T00:00:00Z"); err != nil {
+		t.Fatalf("SetLocalString: %v", err)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["throttle_marker"] != "queued" {
+		t.Fatalf("durable throttle_marker = %q, want SetMarker's durable write intact", got.Metadata["throttle_marker"])
+	}
+	if _, ok := got.Metadata["synced_at"]; ok {
+		t.Fatalf("durable Metadata leaked the clone-local synced_at key: %+v", got.Metadata)
+	}
+
+	localVal, err := env.store.GetLocalString(session.ID, "synced_at")
+	if err != nil {
+		t.Fatalf("GetLocalString: %v", err)
+	}
+	if localVal != "2026-07-14T00:00:00Z" {
+		t.Fatalf("GetLocalString(synced_at) = %q, want the clone-local value", localVal)
+	}
+}

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -256,6 +256,14 @@ func (s *prefixedAliasStore) SetMetadataBatch(id string, kvs map[string]string) 
 	return s.base.SetMetadataBatch(s.aliasToBase(id), kvs)
 }
 
+func (s *prefixedAliasStore) SetLocalString(id, key, value string) error {
+	return s.base.SetLocalString(s.aliasToBase(id), key, value)
+}
+
+func (s *prefixedAliasStore) GetLocalString(id, key string) (string, error) {
+	return s.base.GetLocalString(s.aliasToBase(id), key)
+}
+
 func (s *prefixedAliasStore) Tx(commitMsg string, fn func(beads.Tx) error) error {
 	if fn == nil {
 		return s.base.Tx(commitMsg, nil)

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -320,6 +320,8 @@ type BdStore struct {
 	// mode plus the once-per-store degrade latch, under its own mutex
 	// (disjoint from condWriteMu's capability state; no nesting).
 	condWritesStamp
+
+	localStrings *localSidecar // clone-local data; see Store.SetLocalString
 }
 
 const (
@@ -348,13 +350,27 @@ func NewBdStore(dir string, runner CommandRunner, opts ...BdStoreOption) *BdStor
 
 // NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
 func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string, opts ...BdStoreOption) *BdStore {
-	s := &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix)}
+	s := &BdStore{
+		dir:          dir,
+		runner:       runner,
+		idPrefix:     normalizeIDPrefix(idPrefix),
+		localStrings: newLocalSidecar(bdLocalSidecarPath(dir)),
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(s)
 		}
 	}
 	return s
+}
+
+// bdLocalSidecarPath returns the path of the clone-local sidecar file for a
+// BdStore rooted at dir, or "" (in-memory-only) if dir is unset.
+func bdLocalSidecarPath(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, ".beads", "local-strings.json")
 }
 
 // IDPrefix returns the bead ID prefix owned by this store, without trailing "-".
@@ -1551,6 +1567,29 @@ func (s *BdStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	return nil
 }
 
+// SetLocalString sets a clone-local string value for a bead. See
+// Store.SetLocalString. Persisted to a sidecar JSON file under this store's
+// .beads/ directory rather than routed through the bd subprocess: unlike
+// SetMetadata, this never invokes bd and so never touches Dolt sync or bd's
+// on_update hook. Does not validate that id refers to an existing bead — see
+// the interface doc comment for why.
+func (s *BdStore) SetLocalString(id, key, value string) error {
+	if err := s.localStrings.Set(id, key, value); err != nil {
+		return fmt.Errorf("setting local string on %q: %w", id, err)
+	}
+	return nil
+}
+
+// GetLocalString returns the clone-local string value for a bead. See
+// Store.GetLocalString.
+func (s *BdStore) GetLocalString(id, key string) (string, error) {
+	value, err := s.localStrings.Get(id, key)
+	if err != nil {
+		return "", fmt.Errorf("getting local string on %q: %w", id, err)
+	}
+	return value, nil
+}
+
 // Tx executes fn against a staged BdStore transaction. BdStore reads each bead
 // on first touch, applies callback writes to that snapshot, and reasserts the
 // staged fields when fn returns; concurrent edits to the same bead fields made
@@ -2189,6 +2228,9 @@ func (s *BdStore) Delete(id string) error {
 			return fmt.Errorf("deleting bead %q: %w", id, ErrNotFound)
 		}
 		return fmt.Errorf("deleting bead %q: %w", id, err)
+	}
+	if sidecarErr := s.localStrings.DeleteBead(id); sidecarErr != nil {
+		return fmt.Errorf("deleting bead %q: cleaning up local strings: %w", id, sidecarErr)
 	}
 	return nil
 }

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3168,6 +3168,127 @@ func TestBdStoreSetMetadataError(t *testing.T) {
 	}
 }
 
+// --- SetLocalString / GetLocalString ---
+
+func TestBdStoreSetLocalStringRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		t.Fatalf("unexpected bd invocation: %s %s", name, strings.Join(args, " "))
+		return nil, nil
+	}
+	s := beads.NewBdStore(dir, runner)
+
+	if err := s.SetLocalString("bd-1", "last_woke_at", "2026-07-14T00:00:00Z"); err != nil {
+		t.Fatalf("SetLocalString: %v", err)
+	}
+	got, err := s.GetLocalString("bd-1", "last_woke_at")
+	if err != nil {
+		t.Fatalf("GetLocalString: %v", err)
+	}
+	if got != "2026-07-14T00:00:00Z" {
+		t.Errorf("GetLocalString = %q, want persisted value", got)
+	}
+}
+
+func TestBdStoreGetLocalStringUnsetReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		t.Fatalf("unexpected bd invocation: %s %s", name, strings.Join(args, " "))
+		return nil, nil
+	}
+	s := beads.NewBdStore(dir, runner)
+
+	got, err := s.GetLocalString("bd-1", "never_set")
+	if err != nil {
+		t.Fatalf("GetLocalString: %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetLocalString unset = %q, want empty", got)
+	}
+}
+
+// TestBdStoreLocalStringNeverInvokesCommandRunner asserts the property
+// documented on BdStore.SetLocalString: clone-local writes are persisted to
+// a sidecar JSON file and never shell out to bd, so they never touch Dolt
+// sync or bd's on_update hook. The runner fails the test immediately if
+// invoked at all.
+func TestBdStoreLocalStringNeverInvokesCommandRunner(t *testing.T) {
+	dir := t.TempDir()
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		t.Fatalf("SetLocalString/GetLocalString must never invoke bd, got: %s %s", name, strings.Join(args, " "))
+		return nil, nil
+	}
+	s := beads.NewBdStore(dir, runner)
+
+	if err := s.SetLocalString("bd-1", "k1", "v1"); err != nil {
+		t.Fatalf("SetLocalString k1: %v", err)
+	}
+	if err := s.SetLocalString("bd-1", "k2", "v2"); err != nil {
+		t.Fatalf("SetLocalString k2: %v", err)
+	}
+	if _, err := s.GetLocalString("bd-1", "k1"); err != nil {
+		t.Fatalf("GetLocalString k1: %v", err)
+	}
+	if _, err := s.GetLocalString("bd-1", "k2"); err != nil {
+		t.Fatalf("GetLocalString k2: %v", err)
+	}
+	if err := s.SetLocalString("bd-1", "k1", ""); err != nil {
+		t.Fatalf("SetLocalString clear k1: %v", err)
+	}
+}
+
+func TestBdStoreSetLocalStringPersistsAcrossNewInstanceSameDir(t *testing.T) {
+	dir := t.TempDir()
+	failRunner := func(_, name string, args ...string) ([]byte, error) {
+		t.Fatalf("unexpected bd invocation: %s %s", name, strings.Join(args, " "))
+		return nil, nil
+	}
+
+	first := beads.NewBdStore(dir, failRunner)
+	if err := first.SetLocalString("bd-1", "last_woke_at", "2026-07-14T00:00:00Z"); err != nil {
+		t.Fatalf("SetLocalString: %v", err)
+	}
+
+	// A fresh *BdStore at the same dir simulates a new process/session
+	// opening the same clone; clone-local data must survive that restart.
+	second := beads.NewBdStore(dir, failRunner)
+	got, err := second.GetLocalString("bd-1", "last_woke_at")
+	if err != nil {
+		t.Fatalf("GetLocalString from fresh instance: %v", err)
+	}
+	if got != "2026-07-14T00:00:00Z" {
+		t.Errorf("GetLocalString from fresh instance at same dir = %q, want persisted value", got)
+	}
+}
+
+func TestBdStoreDeleteRemovesLocalStrings(t *testing.T) {
+	dir := t.TempDir()
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			return nil, fmt.Errorf("unexpected command name %q", name)
+		}
+		if len(args) == 0 || args[0] != "delete" {
+			return nil, fmt.Errorf("unexpected command: bd %s", strings.Join(args, " "))
+		}
+		return nil, nil
+	}
+	s := beads.NewBdStore(dir, runner)
+
+	if err := s.SetLocalString("bd-1", "k", "v"); err != nil {
+		t.Fatalf("SetLocalString: %v", err)
+	}
+	if err := s.Delete("bd-1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got, err := s.GetLocalString("bd-1", "k")
+	if err != nil {
+		t.Fatalf("GetLocalString after Delete: %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetLocalString after Delete = %q, want empty (sidecar entry removed)", got)
+	}
+}
+
 func TestBdStoreSetMetadataBatchRetriesDoltSerializationFailure(t *testing.T) {
 	calls := 0
 	runner := func(_, _ string, _ ...string) ([]byte, error) {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -627,6 +627,38 @@ type Store interface {
 	// Returns ErrNotFound if the bead does not exist.
 	SetMetadataBatch(id string, kvs map[string]string) error
 
+	// SetLocalString sets a clone-local string value for a bead, keyed by an
+	// arbitrary string key. Unlike SetMetadata, values written here are never
+	// synced through Dolt/git and are never visible in Bead.Metadata — they
+	// live only in this store's local clone (in-memory, or a local sidecar
+	// file for on-disk stores). Use this for ephemeral, high-churn, or
+	// clone-specific data where cross-clone durability is unnecessary or
+	// actively undesirable (e.g. synced_at, last_woke_at,
+	// pending_create_claim — illustrative examples, not an exhaustive list).
+	// Setting value to "" clears the key. Writing here never touches the
+	// bead's UpdatedAt, since that field is Dolt-synced and a clone-local
+	// write must not appear as a durable change to other clones.
+	//
+	// Implementations that already hold the bead set in process (MemStore,
+	// FileStore) return ErrNotFound for an unknown id, matching SetMetadata.
+	// Implementations backed by an external process (BdStore, NativeDoltStore)
+	// do not perform that check here: doing so would require exactly the
+	// synchronous round-trip this method exists to avoid for high-churn
+	// writes. Callers must not rely on this method to validate bead
+	// existence; validate via Get first if that matters.
+	SetLocalString(id, key, value string) error
+
+	// GetLocalString returns the clone-local string value previously set by
+	// SetLocalString for the given bead and key, scoped to this store's
+	// local clone. Returns "" with a nil error if the key was never set, was
+	// cleared, or was set by a different clone — not ErrNotFound — mirroring
+	// the empty-string-means-absent convention SetLocalString uses for
+	// clearing. As with SetLocalString, only in-process implementations
+	// additionally return ErrNotFound for an unknown bead id; external-store
+	// implementations return "", nil instead. Callers must not rely on this
+	// method to validate bead existence.
+	GetLocalString(id, key string) (string, error)
+
 	// Tx executes fn inside a single logical transaction identified by
 	// commitMsg. Implementations without native transaction support may execute
 	// writes sequentially or stage them until fn returns; outside observers

--- a/internal/beads/beadstest/conformance.go
+++ b/internal/beads/beadstest/conformance.go
@@ -842,6 +842,116 @@ func RunStoreTestsWithOptions(t *testing.T, newStore func() beads.Store, opts Op
 			t.Errorf("both tier titles = %v, want [tier-ephemeral tier-history tier-no-history]", got)
 		}
 	})
+
+	// SetLocalString/GetLocalString cover only behavior common to every Store
+	// implementation. Unknown-bead-id handling is deliberately excluded here:
+	// in-process stores validate and return ErrNotFound while external-process
+	// stores (BdStore, NativeDoltStore, exec.Store) do not, by design (see the
+	// Store interface doc comment) — that asymmetry, if tested at all, belongs
+	// in each implementation's own test file, not this shared suite.
+	t.Run("SetLocalStringRoundTrip", func(t *testing.T) {
+		s := newStore()
+		b, err := s.Create(beads.Bead{Title: "local-string"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetLocalString(b.ID, "last_woke_at", "2026-07-14T00:00:00Z"); err != nil {
+			t.Fatalf("SetLocalString: %v", err)
+		}
+		got, err := s.GetLocalString(b.ID, "last_woke_at")
+		if err != nil {
+			t.Fatalf("GetLocalString: %v", err)
+		}
+		if got != "2026-07-14T00:00:00Z" {
+			t.Errorf("GetLocalString = %q, want 2026-07-14T00:00:00Z", got)
+		}
+	})
+
+	t.Run("GetLocalStringUnsetReturnsEmpty", func(t *testing.T) {
+		s := newStore()
+		b, err := s.Create(beads.Bead{Title: "local-string-unset"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := s.GetLocalString(b.ID, "never_set")
+		if err != nil {
+			t.Fatalf("GetLocalString: %v", err)
+		}
+		if got != "" {
+			t.Errorf("GetLocalString unset = %q, want empty", got)
+		}
+	})
+
+	t.Run("SetLocalStringEmptyClears", func(t *testing.T) {
+		s := newStore()
+		b, err := s.Create(beads.Bead{Title: "local-string-clear"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetLocalString(b.ID, "k", "v"); err != nil {
+			t.Fatalf("SetLocalString: %v", err)
+		}
+		if err := s.SetLocalString(b.ID, "k", ""); err != nil {
+			t.Fatalf("SetLocalString empty: %v", err)
+		}
+		got, err := s.GetLocalString(b.ID, "k")
+		if err != nil {
+			t.Fatalf("GetLocalString: %v", err)
+		}
+		if got != "" {
+			t.Errorf("GetLocalString after clear = %q, want empty", got)
+		}
+	})
+
+	t.Run("SetLocalStringNotInDurableMetadata", func(t *testing.T) {
+		s := newStore()
+		b, err := s.Create(beads.Bead{Title: "local-string-not-durable"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetLocalString(b.ID, "clone_local_key", "v"); err != nil {
+			t.Fatalf("SetLocalString: %v", err)
+		}
+		got, err := s.Get(b.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if _, ok := got.Metadata["clone_local_key"]; ok {
+			t.Error("SetLocalString leaked into durable Metadata, want clone-local key absent from Metadata")
+		}
+	})
+
+	t.Run("SetLocalStringPerBeadIsolation", func(t *testing.T) {
+		s := newStore()
+		a, err := s.Create(beads.Bead{Title: "local-string-bead-a"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := s.Create(beads.Bead{Title: "local-string-bead-b"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetLocalString(a.ID, "k", "a-value"); err != nil {
+			t.Fatalf("SetLocalString a: %v", err)
+		}
+		if err := s.SetLocalString(b.ID, "k", "b-value"); err != nil {
+			t.Fatalf("SetLocalString b: %v", err)
+		}
+		gotA, err := s.GetLocalString(a.ID, "k")
+		if err != nil {
+			t.Fatalf("GetLocalString a: %v", err)
+		}
+		if gotA != "a-value" {
+			t.Errorf("GetLocalString a = %q, want a-value", gotA)
+		}
+		gotB, err := s.GetLocalString(b.ID, "k")
+		if err != nil {
+			t.Fatalf("GetLocalString b: %v", err)
+		}
+		if gotB != "b-value" {
+			t.Errorf("GetLocalString b = %q, want b-value", gotB)
+		}
+	})
 }
 
 // RunMetadataTests runs conformance tests for metadata absent-vs-empty

--- a/internal/beads/beadstest/recording_store.go
+++ b/internal/beads/beadstest/recording_store.go
@@ -14,8 +14,8 @@ import (
 // writes to the raw bead op it replaces.
 type RecordedCall struct {
 	// Op is the Store method that was invoked: "Create", "Update", "Close",
-	// "Reopen", "CloseAll", "SetMetadata", "SetMetadataBatch", "Delete",
-	// "DepAdd", or "DepRemove".
+	// "Reopen", "CloseAll", "SetMetadata", "SetMetadataBatch", "SetLocalString",
+	// "Delete", "DepAdd", or "DepRemove".
 	Op string
 
 	// ID is the target bead id for ops that address a single bead. For Create
@@ -186,6 +186,13 @@ func (r *RecordingStore) SetMetadata(id, key, value string) error {
 func (r *RecordingStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	r.record(RecordedCall{Op: "SetMetadataBatch", ID: id, Metadata: cloneMeta(kvs)})
 	return r.Store.SetMetadataBatch(id, kvs)
+}
+
+// SetLocalString records the clone-local write then delegates. GetLocalString
+// is a read and, like Get, is passed straight through unrecorded.
+func (r *RecordingStore) SetLocalString(id, key, value string) error {
+	r.record(RecordedCall{Op: "SetLocalString", ID: id, Key: key, Value: value})
+	return r.Store.SetLocalString(id, key, value)
 }
 
 // Delete records the delete then delegates.

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -466,6 +466,20 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 	return nil
 }
 
+// SetLocalString delegates directly to the backing store. Clone-local data
+// is never cached or notified: it isn't part of Bead.Metadata, so there is
+// no cached Bead field to keep in sync, and (unlike SetMetadata) writing it
+// never invokes bd's subprocess/hook path, so there is no idempotence check
+// to save a redundant call.
+func (c *CachingStore) SetLocalString(id, key, value string) error {
+	return c.backing.SetLocalString(id, key, value)
+}
+
+// GetLocalString delegates directly to the backing store. See SetLocalString.
+func (c *CachingStore) GetLocalString(id, key string) (string, error) {
+	return c.backing.GetLocalString(id, key)
+}
+
 func (c *CachingStore) refreshBeadAfterWrite(id, op string) (Bead, bool) {
 	fresh, err := c.backing.Get(id)
 	if err != nil {

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -26,6 +27,14 @@ type Store struct {
 	script  string
 	timeout time.Duration
 	env     map[string]string
+
+	// localMu and localStrings back SetLocalString/GetLocalString. Clone-local
+	// data is kept in process only, never routed through the script: unlike
+	// every other operation, it must not depend on script latency, since the
+	// whole point is cheap high-churn writes. It does not survive process
+	// restart, which is an accepted limitation for this delegating store.
+	localMu      sync.Mutex
+	localStrings map[string]map[string]string
 }
 
 // SetEnv sets environment variables passed to the script process.
@@ -468,6 +477,36 @@ func (s *Store) SetMetadataBatch(id string, kvs map[string]string) error {
 	return nil
 }
 
+// SetLocalString sets a clone-local string value for a bead. See
+// [beads.Store.SetLocalString]. Kept in an in-process map rather than
+// delegated to the script, so it never pays script-invocation latency and
+// never validates that id refers to an existing bead — see the interface
+// doc comment for why.
+func (s *Store) SetLocalString(id, key, value string) error {
+	s.localMu.Lock()
+	defer s.localMu.Unlock()
+	if value == "" {
+		delete(s.localStrings[id], key)
+		return nil
+	}
+	if s.localStrings == nil {
+		s.localStrings = make(map[string]map[string]string)
+	}
+	if s.localStrings[id] == nil {
+		s.localStrings[id] = make(map[string]string)
+	}
+	s.localStrings[id][key] = value
+	return nil
+}
+
+// GetLocalString returns the clone-local string value for a bead. See
+// [beads.Store.GetLocalString].
+func (s *Store) GetLocalString(id, key string) (string, error) {
+	s.localMu.Lock()
+	defer s.localMu.Unlock()
+	return s.localStrings[id][key], nil
+}
+
 // Tx executes fn sequentially against the exec store.
 func (s *Store) Tx(_ string, fn func(beads.Tx) error) error {
 	if fn == nil {
@@ -478,8 +517,13 @@ func (s *Store) Tx(_ string, fn func(beads.Tx) error) error {
 
 // Delete permanently removes a bead by calling the "delete" subcommand.
 func (s *Store) Delete(id string) error {
-	_, err := s.run(nil, "delete", "--force", id)
-	return err
+	if _, err := s.run(nil, "delete", "--force", id); err != nil {
+		return err
+	}
+	s.localMu.Lock()
+	delete(s.localStrings, id)
+	s.localMu.Unlock()
+	return nil
 }
 
 // Ping verifies the store script is accessible by running a list operation.

--- a/internal/beads/local_sidecar.go
+++ b/internal/beads/local_sidecar.go
@@ -1,0 +1,129 @@
+package beads
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// localSidecar persists clone-local key-value data (see Store.SetLocalString)
+// to a JSON file on disk, keyed by bead ID then key. It backs both BdStore
+// and NativeDoltStore, the two Store implementations whose durable state
+// lives in an external process/DB rather than an in-process slice, so
+// neither can simply keep an unexported map next to its beads the way
+// MemStore does. The sidecar never participates in Dolt sync or the bd
+// subprocess path; it is read and written independently of both.
+//
+// A zero-value path means "in-memory only, never persisted" — used by
+// test-only constructors that have no workdir to anchor a file under.
+type localSidecar struct {
+	path string
+
+	mu     sync.Mutex
+	data   map[string]map[string]string
+	loaded bool
+}
+
+// newLocalSidecar returns a sidecar backed by the JSON file at path. The
+// file is read lazily on first use, not at construction. An empty path
+// makes the sidecar in-memory-only.
+func newLocalSidecar(path string) *localSidecar {
+	return &localSidecar{path: path}
+}
+
+func (l *localSidecar) ensureLoadedLocked() error {
+	if l.loaded {
+		return nil
+	}
+	l.loaded = true
+	if l.path == "" {
+		l.data = make(map[string]map[string]string)
+		return nil
+	}
+	raw, err := os.ReadFile(l.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			l.data = make(map[string]map[string]string)
+			return nil
+		}
+		return fmt.Errorf("loading local sidecar %q: %w", l.path, err)
+	}
+	data := make(map[string]map[string]string)
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return fmt.Errorf("parsing local sidecar %q: %w", l.path, err)
+		}
+	}
+	l.data = data
+	return nil
+}
+
+// Set stores value under (id, key), or clears it when value is "". Mirrors
+// Store.SetLocalString and, like that method, never validates that id
+// refers to an existing bead.
+func (l *localSidecar) Set(id, key, value string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureLoadedLocked(); err != nil {
+		return err
+	}
+	if value == "" {
+		if l.data[id] == nil {
+			return nil
+		}
+		delete(l.data[id], key)
+		if len(l.data[id]) == 0 {
+			delete(l.data, id)
+		}
+	} else {
+		if l.data[id] == nil {
+			l.data[id] = make(map[string]string)
+		}
+		l.data[id][key] = value
+	}
+	return l.saveLocked()
+}
+
+// Get returns the value stored under (id, key), or "" if unset.
+func (l *localSidecar) Get(id, key string) (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureLoadedLocked(); err != nil {
+		return "", err
+	}
+	return l.data[id][key], nil
+}
+
+// DeleteBead removes all clone-local data for id. Callers should invoke this
+// when the bead itself is deleted, so the sidecar doesn't accumulate entries
+// for beads that no longer exist.
+func (l *localSidecar) DeleteBead(id string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureLoadedLocked(); err != nil {
+		return err
+	}
+	if _, ok := l.data[id]; !ok {
+		return nil
+	}
+	delete(l.data, id)
+	return l.saveLocked()
+}
+
+func (l *localSidecar) saveLocked() error {
+	if l.path == "" {
+		return nil
+	}
+	raw, err := json.MarshalIndent(l.data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling local sidecar %q: %w", l.path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
+		return fmt.Errorf("creating local sidecar dir for %q: %w", l.path, err)
+	}
+	return fsys.WriteFileAtomic(fsys.OSFS{}, l.path, raw, 0o644)
+}

--- a/internal/beads/local_sidecar_test.go
+++ b/internal/beads/local_sidecar_test.go
@@ -1,0 +1,158 @@
+package beads
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalSidecarSetGetRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local-strings.json")
+	s := newLocalSidecar(path)
+
+	if err := s.Set("gc-1", "last_woke_at", "2026-07-14T00:00:00Z"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := s.Get("gc-1", "last_woke_at")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "2026-07-14T00:00:00Z" {
+		t.Fatalf("Get = %q, want persisted value", got)
+	}
+}
+
+func TestLocalSidecarGetUnsetReturnsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local-strings.json")
+	s := newLocalSidecar(path)
+
+	got, err := s.Get("gc-1", "never_set")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("Get unset = %q, want empty", got)
+	}
+}
+
+func TestLocalSidecarSetEmptyClears(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local-strings.json")
+	s := newLocalSidecar(path)
+
+	if err := s.Set("gc-1", "k", "v"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := s.Set("gc-1", "k", ""); err != nil {
+		t.Fatalf("Set empty: %v", err)
+	}
+	got, err := s.Get("gc-1", "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("Get after clear = %q, want empty", got)
+	}
+}
+
+func TestLocalSidecarMultipleKeysPerBead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local-strings.json")
+	s := newLocalSidecar(path)
+
+	if err := s.Set("gc-1", "k1", "v1"); err != nil {
+		t.Fatalf("Set k1: %v", err)
+	}
+	if err := s.Set("gc-1", "k2", "v2"); err != nil {
+		t.Fatalf("Set k2: %v", err)
+	}
+	if got, _ := s.Get("gc-1", "k1"); got != "v1" {
+		t.Fatalf("Get k1 = %q, want v1", got)
+	}
+	if got, _ := s.Get("gc-1", "k2"); got != "v2" {
+		t.Fatalf("Get k2 = %q, want v2", got)
+	}
+}
+
+func TestLocalSidecarPersistsAcrossFreshInstance(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local-strings.json")
+
+	first := newLocalSidecar(path)
+	if err := first.Set("gc-1", "k", "v"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	second := newLocalSidecar(path)
+	got, err := second.Get("gc-1", "k")
+	if err != nil {
+		t.Fatalf("Get from fresh instance: %v", err)
+	}
+	if got != "v" {
+		t.Fatalf("Get from fresh instance at same path = %q, want v", got)
+	}
+}
+
+func TestLocalSidecarEmptyPathIsMemoryOnlyNotShared(t *testing.T) {
+	first := newLocalSidecar("")
+	if err := first.Set("gc-1", "k", "v"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := first.Get("gc-1", "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "v" {
+		t.Fatalf("Get from same instance = %q, want v", got)
+	}
+
+	second := newLocalSidecar("")
+	got2, err := second.Get("gc-1", "k")
+	if err != nil {
+		t.Fatalf("Get from second instance: %v", err)
+	}
+	if got2 != "" {
+		t.Fatalf("Get from second in-memory-only instance = %q, want empty (no persistence, no shared state)", got2)
+	}
+}
+
+func TestLocalSidecarDeleteBeadScopesToSingleBead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local-strings.json")
+	s := newLocalSidecar(path)
+
+	if err := s.Set("gc-1", "k", "v1"); err != nil {
+		t.Fatalf("Set gc-1: %v", err)
+	}
+	if err := s.Set("gc-2", "k", "v2"); err != nil {
+		t.Fatalf("Set gc-2: %v", err)
+	}
+	if err := s.DeleteBead("gc-1"); err != nil {
+		t.Fatalf("DeleteBead: %v", err)
+	}
+
+	if got, err := s.Get("gc-1", "k"); err != nil || got != "" {
+		t.Fatalf("Get gc-1 after DeleteBead = (%q, %v), want empty, nil", got, err)
+	}
+	if got, err := s.Get("gc-2", "k"); err != nil || got != "v2" {
+		t.Fatalf("Get gc-2 after deleting gc-1 = (%q, %v), want v2, nil (untouched)", got, err)
+	}
+}
+
+func TestLocalSidecarWritesJSONFileToDisk(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local-strings.json")
+	s := newLocalSidecar(path)
+
+	if err := s.Set("gc-1", "k", "v"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var data map[string]map[string]string
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if data["gc-1"]["k"] != "v" {
+		t.Fatalf("on-disk data = %+v, want gc-1.k=v", data)
+	}
+}

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -27,6 +27,11 @@ type MemStore struct {
 	// against a store that reports incapable at runtime (no interface-stripping
 	// wrapper — see the class_store optional-capability lesson).
 	DisableConditionalWrites bool
+
+	// localStrings holds clone-local key-value data set via SetLocalString,
+	// keyed by bead ID then key. Deliberately excluded from
+	// restoreFrom/snapshot so FileStore's disk persistence never touches it.
+	localStrings map[string]map[string]string
 }
 
 var _ ConditionalAssignmentReleaser = (*MemStore)(nil)
@@ -544,6 +549,49 @@ func (m *MemStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	return fmt.Errorf("setting metadata batch on %q: %w", id, ErrNotFound)
 }
 
+// beadExistsLocked reports whether id is present. Caller must hold m.mu.
+func (m *MemStore) beadExistsLocked(id string) bool {
+	for _, b := range m.beads {
+		if b.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// SetLocalString sets a clone-local string value for a bead. See
+// Store.SetLocalString. Never touches Bead.Metadata or UpdatedAt.
+func (m *MemStore) SetLocalString(id, key, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.beadExistsLocked(id) {
+		return fmt.Errorf("setting local string on %q: %w", id, ErrNotFound)
+	}
+	if value == "" {
+		delete(m.localStrings[id], key)
+		return nil
+	}
+	if m.localStrings == nil {
+		m.localStrings = make(map[string]map[string]string)
+	}
+	if m.localStrings[id] == nil {
+		m.localStrings[id] = make(map[string]string)
+	}
+	m.localStrings[id][key] = value
+	return nil
+}
+
+// GetLocalString returns the clone-local string value for a bead. See
+// Store.GetLocalString.
+func (m *MemStore) GetLocalString(id, key string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.beadExistsLocked(id) {
+		return "", fmt.Errorf("getting local string on %q: %w", id, ErrNotFound)
+	}
+	return m.localStrings[id][key], nil
+}
+
 // Tx executes fn sequentially against the MemStore.
 func (m *MemStore) Tx(_ string, fn func(Tx) error) error {
 	return runSequentialTx(m, fn)
@@ -556,6 +604,7 @@ func (m *MemStore) Delete(id string) error {
 	for i, b := range m.beads {
 		if b.ID == id {
 			m.beads = append(m.beads[:i], m.beads[i+1:]...)
+			delete(m.localStrings, id)
 			return nil
 		}
 	}

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -310,6 +310,8 @@ type NativeDoltStore struct {
 	// currently makes impossible. internal/beads/metadata_cas.go carries the
 	// full reasoning and the narrow interface's own resolution path.
 	condWritesStamp
+
+	localStrings *localSidecar // clone-local data; see Store.SetLocalString
 }
 
 // NativeStorage is the upstream beads storage handle a NativeDoltStore wraps.
@@ -346,7 +348,7 @@ func newNativeDoltStoreWithStorage(storage beadslib.Storage, actor string) *Nati
 	if actor == "" {
 		actor = nativeDoltStoreActor
 	}
-	return &NativeDoltStore{storage: storage, actor: actor}
+	return &NativeDoltStore{storage: storage, actor: actor, localStrings: newLocalSidecar("")}
 }
 
 func newNativeDoltStoreWithStorageAndPrefix(storage beadslib.Storage, actor, idPrefix string) *NativeDoltStore {
@@ -371,6 +373,7 @@ func newNativeDoltStoreAt(parent context.Context, scopeRoot string, env map[stri
 		return nil, err
 	}
 	store := newNativeDoltStoreWithStorageAndPrefix(storage, nativeDoltStoreActor, prefix)
+	store.localStrings = newLocalSidecar(filepath.Join(scopeRoot, ".beads", "local-strings.json"))
 	for _, opt := range opts {
 		opt(store)
 	}
@@ -1475,6 +1478,28 @@ func isNativeDoltSerializationConflict(err error) bool {
 		strings.Contains(msg, "this transaction conflicts with a committed transaction")
 }
 
+// SetLocalString sets a clone-local string value for a bead. See
+// Store.SetLocalString. Persisted to a sidecar JSON file under this store's
+// .beads/ directory rather than through Dolt storage: unlike SetMetadata,
+// this never touches the Dolt DB or commits. Does not validate that id
+// refers to an existing bead — see the interface doc comment for why.
+func (s *NativeDoltStore) SetLocalString(id, key, value string) error {
+	if err := s.localStrings.Set(id, key, value); err != nil {
+		return fmt.Errorf("setting local string on %q: %w", id, err)
+	}
+	return nil
+}
+
+// GetLocalString returns the clone-local string value for a bead. See
+// Store.GetLocalString.
+func (s *NativeDoltStore) GetLocalString(id, key string) (string, error) {
+	value, err := s.localStrings.Get(id, key)
+	if err != nil {
+		return "", fmt.Errorf("getting local string on %q: %w", id, err)
+	}
+	return value, nil
+}
+
 // Tx executes fn inside a single native Dolt transaction so every write in the
 // callback shares one DOLT_COMMIT. This is the coalescing path that lets a
 // caller (e.g. an extmsg bind) issue several bead writes at the cost of one
@@ -1539,7 +1564,13 @@ func (s *NativeDoltStore) Delete(id string) error {
 	defer release()
 	ctx, cancel := nativeDoltOperationContext(context.TODO())
 	defer cancel()
-	return nativeStoreError(id, storage.DeleteIssue(ctx, id))
+	if err := nativeStoreError(id, storage.DeleteIssue(ctx, id)); err != nil {
+		return err
+	}
+	if sidecarErr := s.localStrings.DeleteBead(id); sidecarErr != nil {
+		return fmt.Errorf("deleting bead %q: cleaning up local strings: %w", id, sidecarErr)
+	}
+	return nil
 }
 
 // Ping verifies that the upstream storage is reachable.

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -1680,6 +1680,50 @@ func TestOpenNativeDoltStoreAtProjectsScopedEnvDuringOpen(t *testing.T) {
 	}
 }
 
+// TestOpenNativeDoltStoreAtPersistsLocalStringsAcrossReopen exercises the
+// real newNativeDoltStoreAt wiring (not the in-memory-only default used by
+// newNativeDoltStoreForTest / the conformance factory): it swaps only the
+// external Dolt-open seam and proves SetLocalString/GetLocalString survive a
+// second open of the same scopeRoot, i.e. clone-local data really lives on
+// disk at <scopeRoot>/.beads/local-strings.json rather than in process memory.
+func TestOpenNativeDoltStoreAtPersistsLocalStringsAcrossReopen(t *testing.T) {
+	scopeRoot := filepath.Join(t.TempDir(), "scope")
+	oldOpen := nativeDoltOpenBestAvailable
+	t.Cleanup(func() {
+		nativeDoltOpenBestAvailable = oldOpen
+	})
+	nativeDoltOpenBestAvailable = func(context.Context, string) (beadslib.Storage, error) {
+		return &nativeDoltStorageSpy{
+			getConfig: func(context.Context, string) (string, error) { return "gc", nil },
+		}, nil
+	}
+
+	store, err := OpenNativeDoltStoreAt(context.Background(), scopeRoot, nil)
+	if err != nil {
+		t.Fatalf("OpenNativeDoltStoreAt (first open): %v", err)
+	}
+	if err := store.SetLocalString("gc-1", "last_woke_at", "2026-07-14T00:00:00Z"); err != nil {
+		t.Fatalf("SetLocalString: %v", err)
+	}
+
+	sidecarPath := filepath.Join(scopeRoot, ".beads", "local-strings.json")
+	if _, err := os.Stat(sidecarPath); err != nil {
+		t.Fatalf("expected sidecar file at %s: %v", sidecarPath, err)
+	}
+
+	reopened, err := OpenNativeDoltStoreAt(context.Background(), scopeRoot, nil)
+	if err != nil {
+		t.Fatalf("OpenNativeDoltStoreAt (reopen): %v", err)
+	}
+	got, err := reopened.GetLocalString("gc-1", "last_woke_at")
+	if err != nil {
+		t.Fatalf("GetLocalString after reopen: %v", err)
+	}
+	if got != "2026-07-14T00:00:00Z" {
+		t.Fatalf("GetLocalString after reopen = %q, want persisted value", got)
+	}
+}
+
 func TestProcessEnvSnapshotWaitsForNativeDoltOpenEnvRestore(t *testing.T) {
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "ambient.example.com")
 	restoreEnv, err := withNativeDoltOpenEnv(map[string]string{

--- a/release-gates/ga-xy1ssk-clone-local-metadata-gate.md
+++ b/release-gates/ga-xy1ssk-clone-local-metadata-gate.md
@@ -1,0 +1,29 @@
+# Release Gate: ga-xy1ssk clone-local metadata
+
+Bead: ga-xy1ssk
+Feature branch: builder/ga-igcny0.1.2-clone-local-metadata
+Candidate commit: 0c22519085e771f65b81d336f2116e78156eba36
+Base: origin/main at 4fda5a28445f42d6e789fc7f5751645ac4fecd19
+Gate result: PASS
+
+Release criteria source: docs/PROJECT_MANIFEST.md is not present in this
+worktree (`rg --files` found no PROJECT_MANIFEST.md). This gate applies the
+deployer prompt's release-gate criteria table.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git ls-remote origin refs/heads/main refs/heads/builder/ga-igcny0.1.2-clone-local-metadata` matched local refs. `git rev-list --left-right --count origin/main...origin/builder/ga-igcny0.1.2-clone-local-metadata` returned `0 1`; `git merge-base --is-ancestor origin/main origin/builder/ga-igcny0.1.2-clone-local-metadata` exited 0; `git merge-tree --write-tree origin/main origin/builder/ga-igcny0.1.2-clone-local-metadata` exited 0 with tree `16a11af03ec4406adb419324010f59a4b1431f50`. |
+| 1 | Review PASS present | PASS | Source review bead `ga-igcny0.1.2.2` is closed with `REVIEW VERDICT: PASS`. Reviewer evidence includes build, vet, gofmt, golangci-lint, `make test-fast-parallel`, targeted Store/local-sidecar tests, reconciler composition tests, full `internal/api`, and OWASP walk-through with no findings. |
+| 2 | Acceptance criteria met | PASS | The branch adds `Store.SetLocalString` / `Store.GetLocalString`, implements them across Store implementations and wrappers, adds shared Store conformance coverage, persists BdStore/NativeDoltStore clone-local data via `localSidecar`, keeps MemStore/FileStore/exec.Store clone-local behavior local, and adds reconciler composition tests proving clone-local keys do not leak into durable metadata or interfere with `SetMarker` / pending-create metadata. No relationship to `ga-yufa.4` is introduced. |
+| 3 | Tests pass | PASS | Ran on scratch worktree `/var/tmp/gascity-deployer-ga-xy1ssk-gate.RsuWo6`: `go build ./...`; `go vet ./...`; `gofmt -l .` (empty); `go test ./internal/beads/...`; `go test ./cmd/gc/... -run 'LocalString|LocalMetadata'`; `go test ./internal/api/...`; `make test-fast-parallel` (all 8 fast jobs passed); `make dashboard-check` (dashboard build, typecheck, test targets passed). |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for `ga-igcny0.1.2.2` report no security findings and only two non-blocking observations. `bd search "ga-igcny0.1.2.2 HIGH" --json` returned `[]`. |
+| 5 | Final branch is clean | PASS | Scratch candidate worktree was clean before adding this gate file: `git status --short --branch` returned only `## HEAD (no branch)` after moving the temporary deploy log outside the checkout. This gate file is the only release-gate addition to commit. |
+| 7 | Single feature theme | PASS | Single commit `0c2251908` touches one subsystem theme: clone-local Store metadata plumbing and tests. Touched files are limited to Store implementations/wrappers, local sidecar tests, reconciler composition tests, and one API test wrapper update required by the Store interface. No independent user-facing feature is bundled. |
+
+## Notes
+
+- `gh auth status` passed for account `quad341`.
+- `gh pr list --head builder/ga-igcny0.1.2-clone-local-metadata --state all --json number,url,state,author,title,headRefOid` returned `[]`; no existing PR was touched.
+- `docs/PROJECT_MANIFEST.md` and any `PROJECT_MANIFEST.md` were absent from this worktree, so no additional project-manifest release criteria could be evaluated.


### PR DESCRIPTION
## What this changes

This adds clone-local string metadata to the beads Store interface through `SetLocalString` and `GetLocalString`. Store implementations can now keep high-churn session lifecycle values, such as wake or sync bookkeeping, outside durable bead metadata so those values do not pollute Dolt-backed history or cross-clone state.

The change implements the new Store methods across the in-memory, file-backed, BdStore, NativeDoltStore, exec, caching, recording, and API test wrapper paths. BdStore and NativeDoltStore persist clone-local data in a sidecar JSON file under the local `.beads` area; in-memory-style stores keep the values process-local.

## Review notes

- This is Store plumbing only; it does not migrate production session keys such as `last_woke_at` or `pending_create_claim` to the clone-local path yet.
- Empty string clears a clone-local value, matching the existing metadata convention.
- Clone-local values intentionally do not validate bead existence, avoiding a durable store round trip for high-churn local state.
- The main persistence surface to inspect is `internal/beads/local_sidecar.go` and its BdStore/NativeDoltStore integration.
- Reconciler composition tests cover same-key collisions with durable metadata and coexistence with `SetMarker` on the same session bead.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./internal/beads/...`
- [x] `go test ./cmd/gc/... -run 'LocalString|LocalMetadata'`
- [x] `go test ./internal/api/...`
- [x] `make test-fast-parallel`
- [x] `make dashboard-check`
- [x] Release gate: [`release-gates/ga-xy1ssk-clone-local-metadata-gate.md`](release-gates/ga-xy1ssk-clone-local-metadata-gate.md)

Rollup/deploy bead: ga-xy1ssk