### PR TITLE
fix: preserve Olivia triage transactions

### DIFF
--- a/.github/workflows/remove-needs-triage.yml
+++ b/.github/workflows/remove-needs-triage.yml
@@ -12,6 +12,8 @@ jobs:
   # pull_request_target is safe here because this job never checks out or runs
   # pull request code; it only removes labels from the issue/PR metadata.
   remove-triage-label:
+    # Olivia owns label, comment, and inbox removal as one recoverable transaction.
+    if: github.event.sender.login != 'gascityinc-olivia[bot]'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/scripts/test_remove_needs_triage_policy.py
+++ b/.github/workflows/scripts/test_remove_needs_triage_policy.py
@@ -1,0 +1,19 @@
+import pathlib
+import unittest
+
+
+WORKFLOW = pathlib.Path(__file__).parents[1] / "remove-needs-triage.yml"
+
+
+class RemoveNeedsTriagePolicyTests(unittest.TestCase):
+    def test_olivia_label_events_do_not_run_the_automatic_removal_job(self) -> None:
+        lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+
+        self.assertIn(
+            "    if: github.event.sender.login != 'gascityinc-olivia[bot]'",
+            lines,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip the legacy needs-triage remover for label events authored by `gascityinc-olivia[bot]`
- keep Olivia’s label, public verdict comment, and inbox-label removal in one recoverable transaction
- add a workflow-policy regression test for the sender guard

## Verification
- `python3 -m unittest discover -s .github/workflows/scripts -p "test_*.py"` (32 passed)
- `actionlint .github/workflows/remove-needs-triage.yml`
- `git diff --check`

The full Go pre-push fan-out was attempted twice but the execution harness interrupted both during `cmd/gc` test discovery; this change contains no Go files.