### PR TITLE
fix(hooks): install provider-family hooks for agents without install_agent_hooks

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -4632,12 +4633,41 @@ func prepareTemplateResolution(bp *agentBuildParams, cfgAgent *config.Agent, qua
 	}
 	rigName := sessionSetupContextForAgent(bp.cityPath, bp.cityName, qualifiedName, cfgAgent, bp.rigs).Rig
 	materializeProviderOverlaysBeforeFingerprint(bp, cfgAgent, resolved, qualifiedName, rigName, workDir, stderr)
-	if ih := config.ResolveInstallHooks(cfgAgent, bp.workspace); len(ih) > 0 {
+	ih := ensureFamilyInstallHooks(config.ResolveInstallHooks(cfgAgent, bp.workspace), resolved)
+	if len(ih) > 0 {
 		resolver := func(name string) string { return config.BuiltinFamily(name, bp.providers) }
 		if hErr := hooks.InstallWithResolver(bp.fs, bp.cityPath, workDir, ih, resolver); hErr != nil {
 			fmt.Fprintf(stderr, "agent %q: hooks: %v\n", qualifiedName, hErr) //nolint:errcheck
 		}
 	}
+}
+
+// ensureFamilyInstallHooks returns installHooks with the resolved provider's
+// launch family appended when that family ships managed workdir hook files.
+// stageHookFiles only re-stages hook files that already exist in the agent
+// workdir, and pack overlay staging only materializes them when an imported
+// pack ships a per-provider/<family>/ overlay — so without this an agent on
+// a hooks-bearing family (pi, opencode, ...) whose config never sets
+// install_agent_hooks is created with no lifecycle hook at all: the provider
+// boots without its session_start hook, never registers a session key, and
+// the session churns in "creating" until the start deadline reaps it.
+// Claude is excluded because resolveTemplate already projects managed Claude
+// settings via ensureClaudeSettingsArgs (see the dedup note on
+// installAgentSideEffects).
+func ensureFamilyInstallHooks(installHooks []string, resolved *config.ResolvedProvider) []string {
+	family := resolvedProviderLaunchFamily(resolved)
+	if family == "" || family == "claude" {
+		return installHooks
+	}
+	if !slices.Contains(hooks.SupportedProviders(), family) {
+		return installHooks
+	}
+	if slices.Contains(installHooks, family) {
+		return installHooks
+	}
+	out := make([]string, 0, len(installHooks)+1)
+	out = append(out, installHooks...)
+	return append(out, family)
 }
 
 func materializeProviderOverlaysBeforeFingerprint(
@@ -4731,7 +4761,7 @@ func installAgentSideEffects(bp *agentBuildParams, cfgAgent *config.Agent, tp Te
 	// already projected the settings upstream in resolveTemplate, so
 	// drop the explicit "claude" entry here to avoid duplicating the
 	// filesystem write on every reconciler tick.
-	ih := config.ResolveInstallHooks(cfgAgent, bp.workspace)
+	ih := ensureFamilyInstallHooks(config.ResolveInstallHooks(cfgAgent, bp.workspace), tp.ResolvedProvider)
 	if tp.ResolvedProvider != nil {
 		family := resolvedProviderLaunchFamily(tp.ResolvedProvider)
 		if family == "claude" || tp.ResolvedProvider.Name == "claude" {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2941,6 +2941,85 @@ func TestPrepareTemplateResolution_MaterializesFamilyOverlayForCustomProvider(t 
 	}
 }
 
+// TestPrepareTemplateResolution_InstallsFamilyHooksWithoutOverlayOrConfig
+// guards hook-file creation for agents whose provider family ships managed
+// workdir hooks. A city-scoped agent runs a custom provider "pi-glm"
+// (base="builtin:pi") with NO pack/rig overlay dirs and NO
+// install_agent_hooks. Pack overlay staging has no per-provider source to
+// copy and stageHookFiles only re-stages hook files that already exist, so
+// before the fix nothing ever created .pi/extensions/gc-hooks.js: the
+// session launched pi without its session_start hook, never registered a
+// session key, and churned in "creating" until the start deadline reaped
+// it. prepareTemplateResolution must install the launch family's managed
+// hooks from the embedded config so the workdir is viable before
+// resolveTemplate fingerprints CopyFiles.
+func TestPrepareTemplateResolution_InstallsFamilyHooksWithoutOverlayOrConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	workDir := filepath.Join(cityDir, ".gc", "agents", "tester")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workDir): %v", err)
+	}
+
+	base := "builtin:pi"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:     "tester",
+			Provider: "pi-glm",
+			Scope:    "city",
+			WorkDir:  filepath.Join(".gc", "agents", "tester"),
+			// Intentionally no InstallAgentHooks and no overlay dirs of any
+			// kind: creation must come from the embedded managed hook config.
+		}},
+		Providers: map[string]config.ProviderSpec{
+			// Explicit command so resolution does not depend on a real `pi`
+			// binary on PATH; base still yields BuiltinAncestor=pi.
+			"pi-glm": {Base: &base, Command: "/bin/echo"},
+		},
+	}
+
+	bp := newAgentBuildParams("test-city", cityDir, cfg, runtime.NewFake(), time.Now().UTC(), nil, io.Discard)
+	prepareTemplateResolution(bp, &cfg.Agents[0], "tester", io.Discard)
+
+	installed := filepath.Join(workDir, ".pi", "extensions", "gc-hooks.js")
+	content, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatalf("family pi hooks not installed for custom pi-glm provider without overlay dirs or install_agent_hooks: %v", err)
+	}
+	if !strings.Contains(string(content), "GC_PI_HOOK_VERSION") {
+		t.Fatalf("installed hook file is not the managed pi hook (len=%d)", len(content))
+	}
+}
+
+func TestEnsureFamilyInstallHooks(t *testing.T) {
+	resolvedFor := func(name, ancestor string) *config.ResolvedProvider {
+		return &config.ResolvedProvider{Name: name, BuiltinAncestor: ancestor}
+	}
+
+	cases := []struct {
+		name     string
+		hooks    []string
+		resolved *config.ResolvedProvider
+		want     []string
+	}{
+		{name: "nil resolved leaves hooks unchanged", hooks: nil, resolved: nil, want: nil},
+		{name: "pi family appended for wrapped custom provider", hooks: nil, resolved: resolvedFor("pi-glm", "pi"), want: []string{"pi"}},
+		{name: "family not duplicated when configured", hooks: []string{"pi"}, resolved: resolvedFor("pi-glm", "pi"), want: []string{"pi"}},
+		{name: "configured hooks preserved and family appended", hooks: []string{"codex"}, resolved: resolvedFor("pi-glm", "pi"), want: []string{"codex", "pi"}},
+		{name: "claude family excluded (settings projected separately)", hooks: nil, resolved: resolvedFor("claude", ""), want: nil},
+		{name: "wrapped claude alias excluded", hooks: nil, resolved: resolvedFor("claude-max", "claude"), want: nil},
+		{name: "unsupported family left alone", hooks: nil, resolved: resolvedFor("custom-tool", ""), want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ensureFamilyInstallHooks(tc.hooks, tc.resolved)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ensureFamilyInstallHooks(%v) = %v, want %v", tc.hooks, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildDesiredState_IncludesImportedAlwaysNamedSessions(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "repo")


### PR DESCRIPTION
Fixes #4375.

### Problem

An agent whose provider family ships managed workdir lifecycle hooks (`pi`, `opencode`, ...) but whose config never sets `install_agent_hooks` is created with no hook file at all:

- `hooks.InstallWithResolver` — the only unconditional creator of the managed hook files — is gated on `config.ResolveInstallHooks` returning non-empty, and that resolves only agent-/workspace-level `install_agent_hooks` (nothing scaffolds or defaults it).
- `stageHookFiles` only re-stages hook files that **already exist** in the workdir (`os.Stat` gate).
- Pack overlay staging materializes them only when an imported pack ships a `per-provider/<family>/` overlay.

The provider then boots without its `session_start` hook, never registers a session key, and the session churns in `creating` until the start deadline reaps it (observed live on a v1.3.4 city: `outcome=deadline_exceeded duration=1m4.028s`, retried indefinitely, for a city-scoped convention agent on `pi-glm` base=`builtin:pi`). Existing agents mask the bug because their hook files were created by older code paths and are preserved — only newly added agents die.

### Fix

Derive the effective install-hooks list from the resolved provider's launch family in `prepareTemplateResolution` and `installAgentSideEffects`: append the family when it is a hooks-supported non-claude provider, so `hooks.InstallWithResolver` materializes the managed hook files from the embedded config regardless of overlay plumbing. The file then exists before `stageHookFiles` fingerprints CopyFiles.

- Claude stays excluded, matching the existing `ensureClaudeSettingsArgs` dedup.
- Managed writes remain version-gated (`writeEmbeddedManaged`), so the added per-tick cost is a stat of an existing file.
- User-configured `install_agent_hooks` is preserved verbatim; the family is appended only when absent.

### Testing

- `TestPrepareTemplateResolution_InstallsFamilyHooksWithoutOverlayOrConfig` — encodes the real-world repro (city-scoped agent, wrapped custom pi provider, no overlay dirs, no `install_agent_hooks`); fails without the fix, passes with it.
- `TestEnsureFamilyInstallHooks` — table-driven: family appended for wrapped providers, no duplication, configured hooks preserved, claude and wrapped-claude excluded, unsupported families untouched.
- Existing `TestPrepareTemplateResolution_MaterializesFamilyOverlayForCustomProvider` (gc-6bw8o guard) still passes; full `./cmd/gc`, `./internal/hooks/...`, `./internal/config/...`, `./internal/runtime/...` suites green.
- Validated e2e on a live city: the same agent that churned `deadline_exceeded` under stock v1.3.4 gets `.pi/extensions/gc-hooks.js` installed and reaches `active` in ~75s under a patched build (cherry-picked onto v1.3.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)