### PR TITLE
feat(mail): send through remote city contexts

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1398,6 +1398,7 @@ func newMailSendCmd(stdout, stderr io.Writer) *cobra.Command {
 	var subject string
 	var message string
 	var jsonOut bool
+	var idempotencyKey string
 	cmd := &cobra.Command{
 		Use:   "send [<to>] [<body>]",
 		Short: "Send a message to a session alias or human",
@@ -1419,8 +1420,8 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			code := 0
-			if jsonOut {
-				code = cmdMailSendJSON(args, notify, all, from, to, subject, message, true, stdout, stderr)
+			if jsonOut || idempotencyKey != "" {
+				code = cmdMailSendWithIdempotencyJSON(args, notify, all, from, to, subject, message, idempotencyKey, jsonOut, stdout, stderr)
 			} else {
 				code = cmdMailSend(args, notify, all, from, to, subject, message, stdout, stderr)
 			}
@@ -1438,6 +1439,7 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
 	cmd.Flags().StringVar(&to, "to", "", "recipient address (alternative to positional argument)")
 	cmd.Flags().StringVarP(&subject, "subject", "s", "", "message subject line")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "message body text")
+	cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "idempotency key for safe remote retries")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
 	cmd.MarkFlagsMutuallyExclusive("to", "all")
 	return cmd
@@ -1653,6 +1655,46 @@ The recipient defaults to $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human".`,
 	return cmd
 }
 
+var resolveMailSendWriteTarget = resolveWriteTarget
+
+func prepareMailSendArgs(args []string, all bool, to, subject, message string, stderr io.Writer) ([]string, bool) {
+	if to != "" && !all {
+		args = append([]string{to}, args...)
+	}
+	if subject == "" && message == "" {
+		return args, true
+	}
+	if all {
+		allBody := message
+		if allBody == "" && len(args) > 0 {
+			allBody = args[0]
+		}
+		return []string{subject, allBody}, true
+	}
+	if len(args) < 1 {
+		fmt.Fprintln(stderr, "gc mail send: missing recipient") //nolint:errcheck // best-effort stderr
+		return nil, false
+	}
+	body := message
+	if body == "" && len(args) > 1 {
+		body = strings.Join(args[1:], " ")
+	}
+	return []string{args[0], subject, body}, true
+}
+
+func hasWhitespace(s string) bool {
+	return strings.IndexFunc(s, unicode.IsSpace) >= 0
+}
+
+func remoteMailSenderValid(sender string) bool {
+	if sender != strings.TrimSpace(sender) {
+		return false
+	}
+	parts := strings.Split(sender, "/")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != "" &&
+		!hasWhitespace(parts[0]) && !hasWhitespace(parts[1])
+}
+
 // cmdMailSend is the CLI entry point for sending mail. It opens the provider,
 // resolves session mailbox identities, and delegates to doMailSend.
 // The to parameter is the --to flag value (empty if not set).
@@ -1661,6 +1703,31 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 }
 
 func cmdMailSendJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, jsonOut bool, stdout, stderr io.Writer) int {
+	return cmdMailSendWithIdempotencyJSON(args, notify, all, from, to, subject, message, "", jsonOut, stdout, stderr)
+}
+
+func cmdMailSendWithIdempotencyJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, idempotencyKey string, jsonOut bool, stdout, stderr io.Writer) int {
+	prepared, ok := prepareMailSendArgs(args, all, to, subject, message, stderr)
+	if !ok {
+		return 1
+	}
+	remoteC, isRemote, _, resolveErr := resolveMailSendWriteTarget()
+	if resolveErr != nil {
+		selection := readRemoteSelection()
+		allowStorelessLocal := !isRemote && !selection.hasExplicitRemote() && strings.HasPrefix(os.Getenv("GC_MAIL"), "exec:")
+		if !allowStorelessLocal {
+			fmt.Fprintf(stderr, "gc mail send: %v\n", resolveErr) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	}
+	if isRemote {
+		return cmdMailSendRemoteJSON(remoteC, prepared, notify, all, from, idempotencyKey, jsonOut, stdout, stderr)
+	}
+	if idempotencyKey != "" {
+		fmt.Fprintln(stderr, "gc mail send: --idempotency-key requires a remote city target (--context/--city-url)") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	args = prepared
 	mp, code := openCityMailProvider(stderr, "gc mail send")
 	if mp == nil {
 		return code
@@ -1719,31 +1786,6 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 		nf = newMailNudgeFunc(sender)
 	}
 
-	// When --to is set, prepend it to args so doMailSend sees [to, body].
-	if to != "" && !all {
-		args = append([]string{to}, args...)
-	}
-
-	// When -s/-m flags provide subject/body, use them.
-	if subject != "" || message != "" {
-		if all {
-			allBody := message
-			if allBody == "" && len(args) > 0 {
-				allBody = args[0]
-			}
-			args = []string{subject, allBody}
-		} else {
-			if len(args) < 1 {
-				fmt.Fprintln(stderr, "gc mail send: missing recipient") //nolint:errcheck // best-effort stderr
-				return 1
-			}
-			body := message
-			if body == "" && len(args) > 1 {
-				body = strings.Join(args[1:], " ")
-			}
-			args = []string{args[0], subject, body}
-		}
-	}
 	if !all && len(args) > 0 && store != nil {
 		canonicalTo, err := resolveMailRecipientIdentityCached(cityPath, cfg, store, args[0], idCache)
 		if err != nil {
@@ -1763,6 +1805,55 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 
 	rec := openCityRecorder(stderr)
 	return doMailSendJSON(mp, rec, validRecipients, sender, args, nf, jsonOut, stdout, stderr)
+}
+
+func cmdMailSendRemoteJSON(client *api.Client, args []string, notify, all bool, sender, idempotencyKey string, jsonOut bool, stdout, stderr io.Writer) int {
+	if notify {
+		fmt.Fprintln(stderr, "gc mail send: --notify is not supported for remote mail send") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if all {
+		fmt.Fprintln(stderr, "gc mail send: --all is not supported for remote mail send") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if sender == "" {
+		fmt.Fprintln(stderr, "gc mail send: remote mail send requires --from <town>/<agent>") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !remoteMailSenderValid(sender) {
+		fmt.Fprintln(stderr, "gc mail send: remote --from must be a town-qualified internal identity (<town>/<agent>)") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if len(args) < 2 {
+		fmt.Fprintln(stderr, "gc mail send: usage: gc mail send <to> <body>  OR  gc mail send <to> -s <subject> [-m <body>]") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	recipient := args[0]
+	var subject, body string
+	if len(args) >= 3 {
+		subject = args[1]
+		body = args[2]
+	} else {
+		body = strings.Join(args[1:], " ")
+		if subject == "" {
+			subject = body
+		}
+	}
+	msg, err := client.SendMail(sender, recipient, subject, body, idempotencyKey)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return renderMailSendResult(msg, msg.To, false, jsonOut, stdout, stderr)
+}
+
+func renderMailSendResult(msg mail.Message, recipient string, notified, jsonOut bool, stdout, stderr io.Writer) int {
+	if !jsonOut {
+		fmt.Fprintf(stdout, "Sent message %s to %s\n", msg.ID, recipient) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	summary := summarizeMailMessage(msg)
+	return writeCLIJSONLineOrExit(stdout, stderr, "gc mail send", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.send", Action: "send", ID: msg.ID, Message: &summary, Messages: []mailMessageSummary{summary}, Count: intRef(1), Notified: notified})
 }
 
 // doMailSend creates a message addressed to a recipient. args is [to, subject, body]
@@ -1807,9 +1898,6 @@ func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[s
 		Message: to,
 		Payload: mailEventPayload(&m),
 	})
-	if !jsonOut {
-		fmt.Fprintf(stdout, "Sent message %s to %s\n", m.ID, to) //nolint:errcheck // best-effort stdout
-	}
 
 	// Nudge recipient if requested and recipient is not human.
 	notified := false
@@ -1820,11 +1908,7 @@ func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[s
 			notified = true
 		}
 	}
-	if jsonOut {
-		summary := summarizeMailMessage(m)
-		return writeCLIJSONLineOrExit(stdout, stderr, "gc mail send", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.send", Action: "send", ID: m.ID, Message: &summary, Messages: []mailMessageSummary{summary}, Count: intRef(1), Notified: notified})
-	}
-	return 0
+	return renderMailSendResult(m, to, notified, jsonOut, stdout, stderr)
 }
 
 // doMailSendAll broadcasts a message to all live session mailboxes (excluding the

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -239,6 +239,221 @@ func TestMailSendAgentToAgent(t *testing.T) {
 	}
 }
 
+func TestCmdMailSendRemoteUsesAPIWithoutLocalFallback(t *testing.T) {
+	var requests int
+	var gotIdempotencyKey string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		gotIdempotencyKey = r.Header.Get("Idempotency-Key")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"msg-remote","from":"alex/dalinar","to":"myrig/worker","subject":"Status","body":"Build is green","created_at":"2026-07-17T00:00:00Z","read":false}`))
+	}))
+	defer srv.Close()
+	client := api.NewCityScopedClient(srv.URL, "remote-city")
+	oldResolve := resolveMailSendWriteTarget
+	resolveMailSendWriteTarget = func() (*api.Client, bool, *remoteTarget, error) {
+		return client, true, nil, nil
+	}
+	t.Cleanup(func() { resolveMailSendWriteTarget = oldResolve })
+	t.Setenv("GC_MAIL", "fail")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSendWithIdempotencyJSON([]string{"worker"}, false, false, "alex/dalinar", "", "Status", "Build is green", "mail-cli-1", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr=%q", code, stderr.String())
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	if gotIdempotencyKey != "mail-cli-1" {
+		t.Fatalf("Idempotency-Key = %q, want mail-cli-1", gotIdempotencyKey)
+	}
+	if gotBody["from"] != "alex/dalinar" || gotBody["to"] != "worker" {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+	if got := stdout.String(); got != "Sent message msg-remote to myrig/worker\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNewMailSendCmdRemoteIdempotencyFlagAndJSONShape(t *testing.T) {
+	var gotIdempotencyKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIdempotencyKey = r.Header.Get("Idempotency-Key")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"msg-json","from":"alex/dalinar","to":"myrig/worker","subject":"Status","body":"Build is green","created_at":"2026-07-17T00:00:00Z","read":false}`))
+	}))
+	defer srv.Close()
+	client := api.NewCityScopedClient(srv.URL, "remote-city")
+	oldResolve := resolveMailSendWriteTarget
+	resolveMailSendWriteTarget = func() (*api.Client, bool, *remoteTarget, error) {
+		return client, true, nil, nil
+	}
+	t.Cleanup(func() { resolveMailSendWriteTarget = oldResolve })
+
+	var stdout, stderr bytes.Buffer
+	cmd := newMailSendCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"myrig/worker", "--from", "alex/dalinar", "--subject", "Status", "--message", "Build is green", "--idempotency-key", "mail-json-1", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v; stderr=%q", err, stderr.String())
+	}
+	if gotIdempotencyKey != "mail-json-1" {
+		t.Fatalf("Idempotency-Key = %q, want mail-json-1", gotIdempotencyKey)
+	}
+	var got mailActionResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v; %q", err, stdout.String())
+	}
+	if !got.OK || got.Command != "mail.send" || got.ID != "msg-json" || got.Count == nil || *got.Count != 1 || got.Notified {
+		t.Fatalf("result = %+v", got)
+	}
+}
+
+func TestCmdMailSendRemotePositionalBodySuppliesRequiredSubject(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"msg-positional","from":"alex/dalinar","to":"myrig/worker","subject":"hello","body":"hello","created_at":"2026-07-17T00:00:00Z","read":false}`))
+	}))
+	defer srv.Close()
+	client := api.NewCityScopedClient(srv.URL, "remote-city")
+	oldResolve := resolveMailSendWriteTarget
+	resolveMailSendWriteTarget = func() (*api.Client, bool, *remoteTarget, error) { return client, true, nil, nil }
+	t.Cleanup(func() { resolveMailSendWriteTarget = oldResolve })
+
+	var stderr bytes.Buffer
+	if code := cmdMailSendWithIdempotencyJSON([]string{"worker", "hello"}, false, false, "alex/dalinar", "", "", "", "", false, &bytes.Buffer{}, &stderr); code != 0 {
+		t.Fatalf("code = %d, stderr=%q", code, stderr.String())
+	}
+	if gotBody["subject"] != "hello" || gotBody["body"] != "hello" {
+		t.Fatalf("request body = %#v, want positional body promoted to required subject", gotBody)
+	}
+}
+
+func TestCmdMailSendStorelessExecProviderOutsideCityStillWorks(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_CITY_CONTEXT", "")
+	t.Setenv("GC_CITY_URL", "")
+	t.Setenv("GC_MAIL", "exec:"+writeExecSendScript(t))
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend([]string{"human", "hello"}, false, false, "human", "", "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); got != "Sent message exec-send-1 to human\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func writeExecSendScript(t *testing.T) string {
+	t.Helper()
+	script := filepath.Join(t.TempDir(), "mail-send-exec")
+	data := `#!/bin/sh
+case "$1" in
+  ensure-running)
+    exit 0
+    ;;
+  send)
+    cat >/dev/null
+    printf '%s\n' '{"id":"exec-send-1","from":"human","to":"human","subject":"","body":"hello","created_at":"2026-07-17T00:00:00Z","read":false}'
+    exit 0
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(script, []byte(data), 0o755); err != nil {
+		t.Fatalf("WriteFile(exec script): %v", err)
+	}
+	return script
+}
+
+func TestCmdMailSendStorelessExecProviderWithExplicitNonCityPathStillWorks(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_CITY_CONTEXT", "")
+	t.Setenv("GC_CITY_URL", "")
+	t.Setenv("GC_MAIL", "exec:"+writeExecSendScript(t))
+	oldCityFlag := cityFlag
+	cityFlag = t.TempDir()
+	t.Cleanup(func() { cityFlag = oldCityFlag })
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend([]string{"human", "hello"}, false, false, "human", "", "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestCmdMailSendRemoteErrorDoesNotFallBackLocally(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"title":"Not Found","status":404,"detail":"mail_recipient_not_found: missing recipient"}`))
+	}))
+	defer srv.Close()
+	client := api.NewCityScopedClient(srv.URL, "remote-city")
+	oldResolve := resolveMailSendWriteTarget
+	resolveMailSendWriteTarget = func() (*api.Client, bool, *remoteTarget, error) {
+		return client, true, nil, nil
+	}
+	t.Cleanup(func() { resolveMailSendWriteTarget = oldResolve })
+	t.Setenv("GC_MAIL", "fail")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSendWithIdempotencyJSON([]string{"missing", "hello"}, false, false, "alex/dalinar", "", "", "", "", false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "mail_recipient_not_found: missing recipient") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestCmdMailSendRemoteRejectsUnsupportedModesAndUnqualifiedSender(t *testing.T) {
+	client := api.NewCityScopedClient("http://127.0.0.1:1", "remote-city")
+	oldResolve := resolveMailSendWriteTarget
+	resolveMailSendWriteTarget = func() (*api.Client, bool, *remoteTarget, error) {
+		return client, true, nil, nil
+	}
+	t.Cleanup(func() { resolveMailSendWriteTarget = oldResolve })
+
+	tests := []struct {
+		name   string
+		notify bool
+		all    bool
+		from   string
+		want   string
+	}{
+		{name: "notify", notify: true, from: "alex/dalinar", want: "--notify is not supported for remote mail send"},
+		{name: "all", all: true, from: "alex/dalinar", want: "--all is not supported for remote mail send"},
+		{name: "missing from", from: "", want: "remote mail send requires --from"},
+		{name: "whitespace from", from: " alex/dalinar ", want: "town-qualified"},
+		{name: "unqualified from", from: "dalinar", want: "town-qualified"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			code := cmdMailSendWithIdempotencyJSON([]string{"myrig/worker", "hello"}, tt.notify, tt.all, tt.from, "", "", "", "", false, &bytes.Buffer{}, &stderr)
+			if code != 1 || !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("code=%d stderr=%q, want %q", code, stderr.String(), tt.want)
+			}
+		})
+	}
+}
+
 func TestDefaultMailIdentityPrefersSessionIDOverGCAgentFallback(t *testing.T) {
 	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "mayor")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2400,6 +2400,7 @@ gc mail send --all "Status update: tests passing"
 |------|------|---------|-------------|
 | `--all` | bool |  | broadcast to all live sessions (excludes sender and human) |
 | `--from` | string |  | sender identity (default: $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human") |
+| `--idempotency-key` | string |  | idempotency key for safe remote retries |
 | `--json` | bool |  | emit JSONL result |
 | `-m`, `--message` | string |  | message body text |
 | `--notify` | bool |  | nudge the recipient about this message, even if earlier mail is still unread |

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,7 +3,7 @@
 // This file is a thin adapter over the generated client in
 // internal/api/genclient. The adapter preserves the small surface that
 // CLI commands depend on (Client, NewClient, NewCityScopedClient, the
-// 14 mutation/lookup methods, ShouldFallback, IsConnError) while pushing
+// 15 mutation/lookup methods, ShouldFallback, IsConnError) while pushing
 // all wire-level work (request construction, JSON serialization, URL
 // escaping, Problem Details parsing) into the generated client.
 //
@@ -1092,15 +1092,62 @@ func (c *Client) GetStatus() (CachedRead[StatusView], error) {
 	}, nil
 }
 
+// SendMail sends one message through the existing per-city mail endpoint.
+// idempotencyKey is optional; when set, same-process replays return the first
+// created message without persisting a duplicate.
+func (c *Client) SendMail(from, to, subject, body, idempotencyKey string) (mail.Message, error) {
+	if err := c.requireCityScope(); err != nil {
+		return mail.Message{}, err
+	}
+	params := &genclient.SendMailParams{XGCRequest: "true"}
+	if idempotencyKey != "" {
+		params.IdempotencyKey = &idempotencyKey
+	}
+	request := genclient.SendMailJSONRequestBody{
+		From:    &from,
+		To:      to,
+		Subject: subject,
+		Body:    &body,
+	}
+	resp, err := c.cw.SendMailWithResponse(context.Background(), c.cityName, params, request)
+	if mutationErr := checkMutation(resp, err); mutationErr != nil {
+		return mail.Message{}, mutationErr
+	}
+	if resp.JSON201 == nil {
+		return mail.Message{}, fmt.Errorf("API returned %d without a mail message", resp.StatusCode())
+	}
+	wire := resp.JSON201
+	result := mail.Message{
+		ID:        wire.Id,
+		From:      wire.From,
+		To:        wire.To,
+		Subject:   wire.Subject,
+		Body:      wire.Body,
+		CreatedAt: wire.CreatedAt,
+		Read:      wire.Read,
+	}
+	if wire.ThreadId != nil {
+		result.ThreadID = *wire.ThreadId
+	}
+	if wire.ReplyTo != nil {
+		result.ReplyTo = *wire.ReplyTo
+	}
+	if wire.Priority != nil {
+		result.Priority = int(*wire.Priority)
+	}
+	if wire.Cc != nil {
+		result.CC = append([]string(nil), (*wire.Cc)...)
+	}
+	if wire.Rig != nil {
+		result.Rig = *wire.Rig
+	}
+	return result, nil
+}
+
 // ListMailInbox fetches unread messages for the given agent recipient via
 // GET /v0/city/{cityName}/mail. An empty agent lets the server choose the
-// default caller identity (same resolution path the CLI would take locally).
-// rig narrows the query to a single rig's provider when set. The returned
-// MailListView preserves partial aggregate-read metadata so callers do not
-// silently treat a degraded all-rig read as authoritative. The
-// CachedRead.AgeSeconds field carries the supervisor CachingStore age so
-// callers can surface _cache_age_s on --json output and a staleness banner
-// on human output.
+// default caller identity. rig narrows the query to one provider. The result
+// preserves partial-read metadata and the supervisor cache age.
 func (c *Client) ListMailInbox(agent, rig string) (CachedRead[MailListView], error) {
 	if err := c.requireCityScope(); err != nil {
 		return CachedRead[MailListView]{}, err

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -64,6 +64,80 @@ func TestClientSuspendCity(t *testing.T) {
 	}
 }
 
+func TestClientSendMailReturnsCreatedMessageAndForwardsIdempotencyKey(t *testing.T) {
+	var gotBody map[string]any
+	var gotIdempotencyKey string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIdempotencyKey = r.Header.Get("Idempotency-Key")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"msg-1","from":"alex/dalinar","to":"myrig/worker","subject":"Status","body":"Build is green","created_at":"2026-07-17T00:00:00Z","read":false}`))
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	msg, err := c.SendMail("alex/dalinar", "myrig/worker", "Status", "Build is green", "mail-1")
+	if err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+	if msg.ID != "msg-1" || msg.From != "alex/dalinar" || msg.To != "myrig/worker" {
+		t.Fatalf("message = %+v", msg)
+	}
+	if gotIdempotencyKey != "mail-1" {
+		t.Fatalf("Idempotency-Key = %q, want mail-1", gotIdempotencyKey)
+	}
+	if gotBody["from"] != "alex/dalinar" || gotBody["to"] != "myrig/worker" || gotBody["subject"] != "Status" || gotBody["body"] != "Build is green" {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+}
+
+func TestClientSendMailReturnsTypedAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"title":"Not Found","status":404,"detail":"mail_recipient_not_found: missing recipient"}`))
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	_, err := c.SendMail("alex/dalinar", "missing", "Status", "Build is green", "")
+	if err == nil {
+		t.Fatal("SendMail succeeded, want typed API error")
+	}
+	if got := err.Error(); got != "API error: mail_recipient_not_found: missing recipient" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestClientSendMailIdempotentReplayCreatesOneMessage(t *testing.T) {
+	state := newFakeState(t)
+	ts := httptest.NewServer(newTestCityHandler(t, state))
+	defer ts.Close()
+	c := NewCityScopedClient(ts.URL, state.CityName())
+
+	first, err := c.SendMail("alex/dalinar", "myrig/worker", "Status", "Build is green", "mail-replay-1")
+	if err != nil {
+		t.Fatalf("first SendMail: %v", err)
+	}
+	second, err := c.SendMail("alex/dalinar", "myrig/worker", "Status", "Build is green", "mail-replay-1")
+	if err != nil {
+		t.Fatalf("second SendMail: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("replay ID = %q, want %q", second.ID, first.ID)
+	}
+	messages, err := state.cityMailProv.Inbox("myrig/worker")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want one idempotent send", len(messages))
+	}
+}
+
 func TestClientWaitForEventRequestsReplayCursorForCityStream(t *testing.T) {
 	seen := make(chan url.Values, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Implements the minimal native-mail slice from DESIGN-078 using the existing `POST /v0/city/{cityName}/mail` endpoint and generated client.

- Adds `internal/api.Client.SendMail`, including typed 201 response conversion and Problem Details errors.
- Routes remote `gc --context <name> mail send` through `resolveWriteTarget` before opening any local provider.
- Adds `--idempotency-key` and forwards it to the existing `Idempotency-Key` header; same-process replay persists one message.
- Preserves the existing local provider path and byte-compatible human/JSON result shape.
- Keeps remote errors non-fallbackable; remote `--notify` and `--all` fail explicitly.
- Requires an asserted town-qualified remote sender (`--from <town>/<agent>`) and rejects whitespace-bearing/non-qualified identities.
- Keeps the advertised positional `<to> <body>` form usable remotely by promoting the body to the endpoint's required subject while retaining it as the body.
- Preserves storeless local `exec:` mail sends outside a city and with an explicit non-city `--city` path.

No endpoint, handler, DTO, OpenAPI, or generated-client change is included.

## Verification

- `go test ./internal/api -run '^TestClientSendMail' -count=1`
- `go test ./cmd/gc -run 'Test(MailSend|CmdMailSend|NewMailSendCmdRemote)' -count=1`
- `go vet ./internal/api ./cmd/gc`
- `.githooks/pre-commit` (lint-changed, spec/client/schema generation, `go vet ./...`)
- Independent final review: READY, no findings (0.96 confidence).

Coverage includes typed 201/errors, idempotency header and replay, remote human/JSON output, server-resolved recipient rendering, positional body translation, no local fallback on remote errors, unsupported mode errors, sender validation, and local storeless compatibility.