### PR TITLE
fix(cmd/gc): validate explicit city path before scanning registry rig bindings (#4364)

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -744,10 +744,19 @@ func resolveContextFromPath(path string) (resolvedContext, error) {
 	// must not abort resolution of a perfectly healthy explicit target
 	// (#4364) -- this mirrors resolveCityNameContext's f.localIsCity-first
 	// ordering for named refs.
-	if cityPath, err := validateCityPath(abs); err == nil {
+	//
+	// Deliberately narrower than validateCityPath: only a real city.toml
+	// qualifies here, not validateCityPath's HasRuntimeRoot fallback. A rig
+	// directory can carry a leftover ".gc/" runtime artifact with no
+	// city.toml of its own (the same shape resolveContextFromDir's step-7
+	// comment already guards against for a different code path); accepting
+	// that shape here would misread the rig dir as its own city and
+	// short-circuit before rig resolution ever runs, silently losing the
+	// real city+rig binding.
+	if citylayout.HasCityConfig(abs) {
 		return resolvedContext{
-			CityPath: cityPath,
-			RigName:  rigFromCwdDir(cityPath, abs),
+			CityPath: abs,
+			RigName:  rigFromCwdDir(abs, abs),
 		}, nil
 	}
 	ctx, ok, err := resolveRigPathToContext(abs)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -739,18 +739,23 @@ func resolveContextFromPath(path string) (resolvedContext, error) {
 	if err != nil {
 		return resolvedContext{}, err
 	}
+	// Validate the explicit target directly before scanning the registry for
+	// rig bindings. An unrelated registered city with a broken/stale config
+	// must not abort resolution of a perfectly healthy explicit target
+	// (#4364) -- this mirrors resolveCityNameContext's f.localIsCity-first
+	// ordering for named refs.
+	if cityPath, err := validateCityPath(abs); err == nil {
+		return resolvedContext{
+			CityPath: cityPath,
+			RigName:  rigFromCwdDir(cityPath, abs),
+		}, nil
+	}
 	ctx, ok, err := resolveRigPathToContext(abs)
 	if err != nil {
 		return resolvedContext{}, err
 	}
 	if ok {
 		return ctx, nil
-	}
-	if cityPath, err := validateCityPath(abs); err == nil {
-		return resolvedContext{
-			CityPath: cityPath,
-			RigName:  rigFromCwdDir(cityPath, abs),
-		}, nil
 	}
 	cityPath, err := findCity(abs)
 	if err != nil {

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1930,6 +1930,37 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		assertSameTestPath(t, ctx.CityPath, targetCity)
 	})
 
+	// Regression: a rig directory that carries a leftover ".gc/" runtime
+	// artifact but no city.toml of its own (the exact shape
+	// resolveContextFromDir's step-7 comment already warns about for a
+	// different code path) must still resolve through its registered rig
+	// binding, not get misread as a city in its own right by the #4364
+	// city-first check. The city-first branch only accepts a target that
+	// has a real city.toml (citylayout.HasCityConfig) -- it deliberately
+	// does not fall back to HasRuntimeRoot the way validateCityPath's other
+	// callers do, so a bare ".gc/" rig dir falls through to rig resolution
+	// exactly as it did before #4364.
+	t.Run("path_argument_rig_dir_with_leftover_gc_runtime_root_resolves_via_rig_binding", func(t *testing.T) {
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		goodCity := setupCity(t, "leftover-gc-good")
+		rigDir := filepath.Join(t.TempDir(), "leftover-gc-rig")
+		if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		registerRigBindingForResolution(t, gcHome, goodCity, "leftover-gc-good", "leftover-gc-rig", rigDir)
+
+		ctx, err := resolveContextFromPath(rigDir)
+		if err != nil {
+			t.Fatalf("resolveContextFromPath error: %v (want success via the registered rig binding)", err)
+		}
+		assertSameTestPath(t, ctx.CityPath, goodCity)
+		if ctx.RigName != "leftover-gc-rig" {
+			t.Errorf("RigName = %q, want %q (rig dir must not be misread as its own city)", ctx.RigName, "leftover-gc-rig")
+		}
+	})
+
 	// Regression: gc stop (and other commands that scan registered rig
 	// bindings) must not abort when a sibling city's directory has been
 	// deleted out from under the registry. Resolution still succeeds on

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1903,6 +1903,33 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 	})
 
+	// Regression (#4364): an explicit path argument that is itself a valid
+	// city must resolve successfully even when an unrelated registered
+	// sibling city has a broken .gc/site.toml. Before the fix,
+	// resolveContextFromPath always scanned every registered rig binding
+	// first (fail-closed), so one broken sibling aborted resolution of a
+	// perfectly healthy explicit target before validateCityPath ever got a
+	// chance to try it directly -- surfacing as a misleading "run gc init
+	// <path> first" hint on a city that already exists and needs no init.
+	t.Run("path_argument_valid_city_succeeds_despite_broken_sibling_binding", func(t *testing.T) {
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		targetCity := setupCity(t, "valid-target")
+
+		badCity := setupCity(t, "broken-sibling")
+		if err := os.WriteFile(config.SiteBindingPath(badCity), []byte("[[rig]\nname = \"broken\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		registerCityForRigResolution(t, gcHome, badCity, "broken-sibling")
+
+		ctx, err := resolveContextFromPath(targetCity)
+		if err != nil {
+			t.Fatalf("resolveContextFromPath error: %v (want success on the valid explicit target despite an unrelated broken sibling)", err)
+		}
+		assertSameTestPath(t, ctx.CityPath, targetCity)
+	})
+
 	// Regression: gc stop (and other commands that scan registered rig
 	// bindings) must not abort when a sibling city's directory has been
 	// deleted out from under the registry. Resolution still succeeds on


### PR DESCRIPTION
## Summary

Fixes #4364. `resolveContextFromPath` (`cmd/gc/main.go`) scanned the entire registry for rig bindings before validating whether the explicit path argument was itself a valid city. `registeredRigBindings` loads every registered city's config and, with `failOnLoadError=true`, fails the whole resolution the moment any one of them can't parse — so `gc start <healthy-city>` aborted with a misleading "run `gc init` first" hint whenever an unrelated registered sibling city had stale or broken config, even though the explicit target city was completely healthy and needed no init.

## Fix

Reordered `resolveContextFromPath` to validate the explicit target path first, falling through to the registry-wide rig scan only when that fails, then to the upward `findCity` walk as the final fallback. Mirrors the existing `f.localIsCity`-first ordering already used by `resolveCityNameContext` (`cmd/gc/city_arg_resolve.go`) for named refs. No change to the registry-wide rig-anywhere scan itself, its stale-sibling skip-and-warn machinery, or its fail-closed behavior when a *rig* lookup genuinely needs the registry — all still covered by their own existing tests.

Single file, single function, ~12-line reorder.

## Tests

Added `path_argument_valid_city_succeeds_despite_broken_sibling_binding` to `TestRigAnywhere_ResolveRigToContext`, reproducing the issue's exact repro shape: one registered sibling city with a malformed `.gc/site.toml`, one separate, valid, unregistered target city passed as an explicit path. TDD RED (failed pre-fix with the same `loading registered city rig bindings: ...` error the issue reports) → GREEN post-fix.

Full `TestRigAnywhere_ResolveRigToContext` (29 subtests, including the pre-existing `path_argument_fails_closed_on_binding_load_error`, `stale_sibling_directory_is_skipped_with_warning`, `stale_sibling_city_toml_missing_hits_load_path` regression coverage) + `TestRigAnywhere_ResolveContext` (16 subtests): all green. `go build ./...`, `go vet ./cmd/gc/...`, `gofmt -l` on both changed files: clean.

## Scope notes

Only the "resolve the explicit valid target before scanning" half of the issue's acceptance criteria is addressed here. The other bullets (warn once about a *skipped* stale city during a genuine rig-anywhere scan; don't mutate the stale city; a genuinely uninitialized directory still gets an accurate `gc init` hint) were already covered by existing, still-passing tests before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)