### PR TITLE
fix(gc): drain the --since window on gc events instead of capping at one page

### DIFF
--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -566,7 +566,7 @@ func doEvents(scope eventsAPIScope, typeFilter, sinceFlag string, payloadMatch m
 		return printJSONLines(items, stdout, stderr)
 	}
 
-	items, err := fetchCityEvents(ctx, client, scope.cityName, typeFilter, sinceFlag)
+	items, err := fetchCityEvents(ctx, client, scope.cityName, typeFilter, sinceFlag, stderr)
 	if err != nil {
 		if fallback, ok, fallbackErr := readLocalCityEvents(scope, err, typeFilter, sinceFlag, stderr); ok {
 			if fallbackErr != nil {
@@ -868,7 +868,7 @@ func doEventsWatch(scope eventsAPIScope, typeFilter string, payloadMatch map[str
 
 	resumeSeq := afterSeq
 	if resumeSeq > 0 {
-		items, err := fetchCityEvents(ctx, client, scope.cityName, "", "")
+		items, err := fetchCityEvents(ctx, client, scope.cityName, "", "", io.Discard)
 		if err != nil {
 			if shouldUseLocalCityEventsFallback(scope, err) {
 				printStreamingCityAPIRequirement("--watch", stderr)
@@ -1013,40 +1013,77 @@ func probeCityEventsReachable(ctx context.Context, client *genclient.ClientWithR
 	return eventsListError(resp.StatusCode(), resp.Body)
 }
 
-// fetchCityEvents fetches the newest page of city events (up to 500). It
-// deliberately does NOT follow next_cursor: gc events means "recent
-// activity", and a full descending drain of a large city's event history
-// (100 MB+ logs) would blow the command timeout for no user benefit. The
-// API serves the page seq-DESC (newest first); gc events prints
-// chronologically, so the page is re-sorted ascending.
-func fetchCityEvents(ctx context.Context, client *genclient.ClientWithResponses, cityName, typeFilter, sinceFlag string) ([]cliWireEvent, error) {
-	limit := int64(500)
-	params := &genclient.GetV0CityByCityNameEventsParams{
-		Limit: &limit,
-	}
-	if strings.TrimSpace(typeFilter) != "" {
-		params.Type = &typeFilter
-	}
-	if strings.TrimSpace(sinceFlag) != "" {
-		params.Since = &sinceFlag
-	}
-	resp, err := client.GetV0CityByCityNameEventsWithResponse(ctx, cityName, params)
-	if err != nil {
-		return nil, &eventsAPITransportError{err: err}
-	}
-	if err := eventsListError(resp.StatusCode(), resp.Body); err != nil {
-		return nil, err
-	}
-	if resp.JSON200 == nil || resp.JSON200.Items == nil {
-		return nil, nil
-	}
-	all := make([]cliWireEvent, 0, len(*resp.JSON200.Items))
-	for _, item := range *resp.JSON200.Items {
-		wire, err := cityWireEventFromTyped(item)
-		if err != nil {
-			return nil, fmt.Errorf("decoding city event list item: %w", err)
+// cityEventsPageLimit bounds one page of the city event list. The endpoint
+// serves seq-DESC pages and mints next_cursor when more matching rows exist
+// strictly below the page's oldest seq (#4194).
+const cityEventsPageLimit = int64(500)
+
+// fetchCityEvents fetches city events matching the type/since filter and
+// returns them chronologically (ascending seq). The endpoint is a keyset,
+// seq-DESC (newest first) paginated list; a truncated page carries a
+// next_cursor pointing strictly below the page's oldest seq.
+//
+// A bounded --since window is drained across pages so the requested window is
+// reported in full — otherwise any window holding more than one page of events
+// silently under-reports (the bug this fixes). Without --since the request is
+// unbounded, so the fetch stays a single page: gc events means "recent
+// activity", and a full descending drain of a 100 MB+ event history would blow
+// the command timeout for no user benefit. In that single-page case, when the
+// server signals more via next_cursor, an explicit truncation notice is written
+// to warn rather than silently dropping the older matches.
+func fetchCityEvents(ctx context.Context, client *genclient.ClientWithResponses, cityName, typeFilter, sinceFlag string, warn io.Writer) ([]cliWireEvent, error) {
+	paginate := strings.TrimSpace(sinceFlag) != ""
+	var all []cliWireEvent
+	cursor := ""
+	for {
+		limit := cityEventsPageLimit
+		params := &genclient.GetV0CityByCityNameEventsParams{
+			Limit: &limit,
 		}
-		all = append(all, wire)
+		if strings.TrimSpace(typeFilter) != "" {
+			params.Type = &typeFilter
+		}
+		if strings.TrimSpace(sinceFlag) != "" {
+			params.Since = &sinceFlag
+		}
+		if cursor != "" {
+			params.Cursor = &cursor
+		}
+		resp, err := client.GetV0CityByCityNameEventsWithResponse(ctx, cityName, params)
+		if err != nil {
+			return nil, &eventsAPITransportError{err: err}
+		}
+		if err := eventsListError(resp.StatusCode(), resp.Body); err != nil {
+			return nil, err
+		}
+		if resp.JSON200 == nil || resp.JSON200.Items == nil {
+			break
+		}
+		for _, item := range *resp.JSON200.Items {
+			wire, err := cityWireEventFromTyped(item)
+			if err != nil {
+				return nil, fmt.Errorf("decoding city event list item: %w", err)
+			}
+			all = append(all, wire)
+		}
+		next := ""
+		if resp.JSON200.NextCursor != nil {
+			next = strings.TrimSpace(*resp.JSON200.NextCursor)
+		}
+		if next == "" {
+			break // window (or the whole history) exhausted
+		}
+		if !paginate {
+			fmt.Fprintf(warn, "gc events: showing the newest %d events; older matching events were omitted. Use --since <duration> to fetch a full time window.\n", len(all)) //nolint:errcheck
+			break
+		}
+		if next == cursor {
+			// Defensive: a conforming server advances the keyset boundary
+			// strictly downward each page, so the cursor never repeats. Bail
+			// rather than spin forever on a misbehaving server.
+			break
+		}
+		cursor = next
 	}
 	sort.Slice(all, func(i, j int) bool { return all[i].Seq < all[j].Seq })
 	return all, nil

--- a/cmd/gc/cmd_events_test.go
+++ b/cmd/gc/cmd_events_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1458,7 +1459,8 @@ func TestFetchCityEventsSinglePageChronological(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}
-	got, err := fetchCityEvents(context.Background(), client, "mc-city", "", "")
+	var warn bytes.Buffer
+	got, err := fetchCityEvents(context.Background(), client, "mc-city", "", "", &warn)
 	if err != nil {
 		t.Fatalf("fetchCityEvents: %v", err)
 	}
@@ -1469,5 +1471,98 @@ func TestFetchCityEventsSinglePageChronological(t *testing.T) {
 		if item.Seq != int64(i+4) {
 			t.Fatalf("event[%d].Seq = %d, want %d (chronological ascending)", i, item.Seq, i+4)
 		}
+	}
+	// The unbounded (no --since) fetch stays single-page, but a present
+	// next_cursor must surface an explicit truncation notice, never a silent drop.
+	if !strings.Contains(warn.String(), "omitted") {
+		t.Fatalf("expected truncation notice on stderr, got %q", warn.String())
+	}
+}
+
+// pagedCityEventsHandler serves allDesc (events in seq-DESC order) as keyset
+// pages of at most pageSize, honoring the opaque `cursor` query param the same
+// way the #4194 server does: the cursor is the seq boundary and each page
+// returns events strictly below it, minting next_cursor (the page's oldest seq
+// as a decimal string) whenever more matching rows remain below the page.
+func pagedCityEventsHandler(t *testing.T, allDesc []cliWireEvent, pageSize int) func(http.ResponseWriter, *http.Request) {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		boundary := int64(-1) // -1 = no boundary (first page)
+		if c := r.URL.Query().Get("cursor"); c != "" {
+			v, err := strconv.ParseInt(c, 10, 64)
+			if err != nil {
+				t.Errorf("bad cursor %q: %v", c, err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			boundary = v
+		}
+		page := make([]cliWireEvent, 0, pageSize)
+		for _, e := range allDesc {
+			if boundary >= 0 && e.Seq >= boundary {
+				continue
+			}
+			if len(page) == pageSize {
+				break
+			}
+			page = append(page, e)
+		}
+		body := cityEventsListResponse(t, page)
+		body.Total = int64(len(allDesc))
+		if len(page) > 0 {
+			oldest := page[len(page)-1].Seq
+			// More below this page?
+			for _, e := range allDesc {
+				if e.Seq < oldest {
+					next := strconv.FormatInt(oldest, 10)
+					body.NextCursor = &next
+					break
+				}
+			}
+		}
+		w.Header().Set("X-GC-Index", strconv.FormatInt(allDesc[0].Seq, 10))
+		writeJSONResponse(t, w, body)
+	}
+}
+
+// TestFetchCityEventsPaginatesSinceWindow pins the bug fix (workspace-l9a2): a
+// bounded --since request drains every page of the requested window, not just
+// the newest 500. Regression guard for `gc events --since <window>` silently
+// hard-capping at one page.
+func TestFetchCityEventsPaginatesSinceWindow(t *testing.T) {
+	const total = 1200 // 3 keyset pages of 500/500/200
+	allDesc := make([]cliWireEvent, 0, total)
+	for seq := total; seq >= 1; seq-- {
+		allDesc = append(allDesc, cliWireEvent{
+			Actor: "gc", Seq: int64(seq), Type: "e.t",
+			Ts: time.Unix(1700000000+int64(seq), 0).UTC(),
+		})
+	}
+	server := newEventsTestServer(t, testEventRoutes{
+		cityEvents: pagedCityEventsHandler(t, allDesc, 500),
+	})
+	defer server.Close()
+
+	client, err := genclient.NewClientWithResponses(server.URL)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	var warn bytes.Buffer
+	got, err := fetchCityEvents(context.Background(), client, "mc-city", "", "24h", &warn)
+	if err != nil {
+		t.Fatalf("fetchCityEvents: %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("got %d events, want %d (full window drained across pages)", len(got), total)
+	}
+	// Chronological ascending, contiguous, no gaps/dups across page seams.
+	for i, item := range got {
+		if item.Seq != int64(i+1) {
+			t.Fatalf("event[%d].Seq = %d, want %d (ascending, contiguous)", i, item.Seq, i+1)
+		}
+	}
+	// A drained window is complete, so no truncation notice.
+	if warn.Len() != 0 {
+		t.Fatalf("unexpected truncation notice for a fully drained window: %q", warn.String())
 	}
 }


### PR DESCRIPTION
## Problem

`gc events --since <window>` silently returns only the newest page (500 events),
under-reporting any window that holds more than one page. Three different window
sizes against a live store all return an identical hard 500:

```
gc events --since 1h   -> 500 rows
gc events --since 6h   -> 500 rows
gc events --since 24h  -> 500 rows   (24h span was 500 *contiguous* seqs — a tail, not a match set)
```

Any rate or volume derived from `--since` row counts under-reports every window
with >500 events, with no error or warning. (Reported downstream while building
event-rate alarms; a "397 bead.updated/6h" reading turned out to be a truncation
artifact.)

## Root cause — CLI, not the server

The city event list is keyset-paginated, seq-DESC: a truncated page mints
`next_cursor` pointing strictly below the page's oldest seq (#4194). But
`fetchCityEvents` (cmd/gc/cmd_events.go) issued a **single** `limit=500` request
and **dropped `next_cursor`**, so every window larger than one page was silently
truncated to the newest 500.

The server side is already correct and archive-aware post-#4194 (the tail fast
path falls through to the archive-aware sequential reader, and truncated pages
always carry `next_cursor`). This was purely the CLI never following that cursor.

`TestFetchCityEventsSinglePageChronological` documented the old single-page
behavior as deliberate — *"a full descending drain of a 100 MB+ event history
would blow the command timeout."* That reasoning holds for an **unbounded** (bare)
`gc events`, but a `--since` window is **bounded** and must be reported in full.

## Fix

- `fetchCityEvents` follows `next_cursor` to drain the full window **when
  `--since` is set** — bounded by the window; the #4194 keyset guarantees no
  skip/dup across page seams.
- The unbounded (no `--since`) fetch **stays single-page** (preserving the
  deliberate timeout-safety decision), but a present `next_cursor` now emits an
  explicit truncation notice on stderr instead of a silent drop:
  `gc events: showing the newest N events; older matching events were omitted.
  Use --since <duration> to fetch a full time window.`

## Verification

- **New regression test** `TestFetchCityEventsPaginatesSinceWindow`: a
  cursor-aware fake server (faithful to the #4194 keyset wire contract) serves
  1200 events across 3 pages (500/500/200); `--since` now returns all 1200,
  contiguous and ascending with no gaps/dups across page seams. Confirmed the
  test **fails without the fix** (got 500, want 1200).
- `TestFetchCityEventsSinglePageChronological` extended to assert the unbounded
  path stays single-page **and** now surfaces the truncation notice.
- Full `cmd/gc` event suite green; `go vet` / `gofmt` clean.
- **Backward-compatible**, checked against a live pre-#4194 (v1.3.5) server: it
  returns no `next_cursor`, so the loop stops after one page exactly as before —
  no error, no spurious notice, `--seq` unaffected. The fix only activates once
  the server is ≥#4194.

## Refs

Refs #4167 (events list tail fast path archive-blindness / truncation). The
archive-aware walk + cursor minting landed in #4194; this closes the remaining
CLI-side gap that left `gc events --since` capped at one page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
