### PR TITLE
fix(beads): scale native graph-apply deadline with plan size

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -99,6 +99,25 @@ func nativeDoltOperationContext(parent context.Context) (context.Context, contex
 	return context.WithTimeout(parent, bdCommandTimeout)
 }
 
+// nativeGraphApplyDeadline scales the graph-apply transaction budget with plan
+// size. The library's AddDependency runs a recursive cycle-reachability query
+// per blocking edge, so a large molecule (67 nodes / ~100 edges on the
+// mol-adopt-pr-v2 shape) cannot finish inside the flat per-command budget: the
+// batch died at the 120s deadline mid-edges, retried into the same wall, and
+// fell back to per-bead creates — turning a single atomic pour into ~9 minutes
+// of partial work (2026-07-17 code red). Until the per-edge check is replaced
+// by one whole-graph CycleThroughEdges pass (needs a beads-side export of
+// DependencyAddOptions), give each node and edge a slice of budget on top of
+// the flat floor so the atomic path completes instead of falling back.
+func nativeGraphApplyDeadline(plan *GraphApplyPlan) time.Duration {
+	d := bdCommandTimeout
+	if plan == nil {
+		return d
+	}
+	const perItem = 2 * time.Second
+	return d + time.Duration(len(plan.Nodes)+len(plan.Edges))*perItem
+}
+
 func nativeDoltCleanupContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), bdCommandTimeout)
 }
@@ -667,7 +686,10 @@ func (s *NativeDoltStore) ApplyGraphPlanWithStorage(parent context.Context, plan
 	}
 	defer release()
 
-	ctx, cancel := nativeDoltOperationContext(parent)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, nativeGraphApplyDeadline(plan))
 	defer cancel()
 
 	keyToID := make(map[string]string, len(plan.Nodes))

--- a/internal/beads/native_dolt_store_graph_deadline_test.go
+++ b/internal/beads/native_dolt_store_graph_deadline_test.go
@@ -1,0 +1,30 @@
+package beads
+
+import (
+	"testing"
+	"time"
+)
+
+// A large molecule pour must get more transaction budget than a single bd
+// command: the per-edge cycle checks made a 67-node plan blow the flat 120s
+// deadline mid-transaction and fall back to per-bead creates (2026-07-17).
+func TestNativeGraphApplyDeadlineScalesWithPlanSize(t *testing.T) {
+	t.Parallel()
+
+	if got := nativeGraphApplyDeadline(nil); got != bdCommandTimeout {
+		t.Fatalf("nil plan deadline = %v, want flat %v", got, bdCommandTimeout)
+	}
+	small := &GraphApplyPlan{Nodes: make([]GraphApplyNode, 1)}
+	if got := nativeGraphApplyDeadline(small); got <= bdCommandTimeout {
+		t.Fatalf("small plan deadline = %v, want > flat %v", got, bdCommandTimeout)
+	}
+	big := &GraphApplyPlan{
+		Nodes: make([]GraphApplyNode, 67),
+		Edges: make([]GraphApplyEdge, 100),
+	}
+	got := nativeGraphApplyDeadline(big)
+	want := bdCommandTimeout + 167*2*time.Second
+	if got != want {
+		t.Fatalf("67-node/100-edge plan deadline = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Molecule pours fell out of the atomic graph-apply path: the library runs a recursive cycle-reachability query per blocking edge, so a 67-node / ~100-edge plan cannot finish inside the flat 120s per-command budget. The batch died at the deadline mid-edges, retried into the same wall (another 120s), then fell back to per-bead creates — one pour took **541s**, reproduced under `GC_SLING_TRACE`:

```
graph-apply enter recipe=mol-adopt-pr-v2 applier=*main.beadPolicyGraphStore
graph-apply apply-error ... adding edge ...: failed to check for dependency cycle: context deadline exceeded   (t+120s)
graph-apply transient-error retry ...
graph-apply apply-error ... (t+240s)
graph-apply transient-error fallback ...
```

## Fix
`nativeGraphApplyDeadline` gives each node and edge a 2s slice on top of the flat floor, so the atomic transaction completes instead of falling back. Regression test pins the scaling.

## Real fix, follow-up
The Transaction interface already has the designed answer (`AddDependencyWithOptions{SkipCycleCheck}` + one `CycleThroughEdges` whole-graph pass, bd-6dnrw.8), but `DependencyAddOptions` is not exported from the beads root package, so gascity cannot name it. Beads-side one-line alias + switching this path over drops the per-edge cost entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)