### PR TITLE
fix(handoff): preserve shared tmux server

### DIFF
--- a/internal/runtime/tmux/lifecycle_test.go
+++ b/internal/runtime/tmux/lifecycle_test.go
@@ -22,14 +22,15 @@ func TestConfigureServerSendsSetOptionExitEmptyOff(t *testing.T) {
 	t.Fatalf("ConfigureServer did not issue set-option -g exit-empty off; calls = %v", fe.calls)
 }
 
-// TestConfigureServerIsIdempotentViaSyncOnce verifies that calling ConfigureServer
-// multiple times on the same *Tmux issues set-option -g exit-empty off exactly once.
-// The configureOnce sync.Once field must enforce this property.
-func TestConfigureServerIsIdempotentViaSyncOnce(t *testing.T) {
+// TestConfigureServerReappliesExitEmptyForReplacementServer verifies that
+// server configuration is applied on every call. A Tmux wrapper can outlive
+// the server bound to its socket; per-instance sync.Once would leave a
+// replacement server at tmux's unsafe exit-empty=on default.
+func TestConfigureServerReappliesExitEmptyForReplacementServer(t *testing.T) {
 	fe := &fakeExecutor{}
 	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
 
-	for i := 0; i < 5; i++ {
+	for i := range 2 {
 		if err := tm.ConfigureServer(); err != nil {
 			t.Fatalf("ConfigureServer() call %d error = %v", i, err)
 		}
@@ -41,8 +42,8 @@ func TestConfigureServerIsIdempotentViaSyncOnce(t *testing.T) {
 			count++
 		}
 	}
-	if count != 1 {
-		t.Fatalf("set-option -g exit-empty off issued %d times across 5 ConfigureServer calls, want exactly 1", count)
+	if count != 2 {
+		t.Fatalf("set-option -g exit-empty off issued %d times across 2 ConfigureServer calls, want 2", count)
 	}
 }
 

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -225,7 +225,6 @@ type Tmux struct {
 	exec                 executor
 	interactionDedup     *approvalDedup
 	interactionDedupOnce sync.Once
-	configureOnce        sync.Once
 	hiddenAttachMu       sync.Mutex
 	hiddenAttachClients  map[string]*hiddenAttachClient
 	hiddenAttachSeq      atomic.Uint64
@@ -976,13 +975,10 @@ func (t *Tmux) KillServer() error {
 }
 
 // ConfigureServer sets tmux server options required for Gas City lifecycle
-// ownership. It is idempotent per Tmux instance.
+// ownership. It is safe to call repeatedly because the wrapper may outlive the
+// server bound to its socket.
 func (t *Tmux) ConfigureServer() error {
-	var err error
-	t.configureOnce.Do(func() {
-		err = t.SetExitEmpty(false)
-	})
-	return err
+	return t.SetExitEmpty(false)
 }
 
 // TeardownServer terminates the tmux server after all sessions are drained.

--- a/internal/runtime/tmux/tmux_test.go
+++ b/internal/runtime/tmux/tmux_test.go
@@ -13,8 +13,11 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
+
+	runtimepkg "github.com/gastownhall/gascity/internal/runtime"
 )
 
 // testSocketName is the dedicated tmux socket used by this integration test
@@ -2986,4 +2989,166 @@ func TestCheckSessionHealth_ActivityCheck(t *testing.T) {
 	// With a very short maxInactivity, a recently-created session should be healthy
 	// (if the agent were actually running). This tests the activity threshold logic
 	// without needing a real Claude process.
+}
+
+func TestSharedServerContinuityAfterHandoffStop(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	socket := fmt.Sprintf("gct-handoff-%d-%d", os.Getpid(), time.Now().UnixNano())
+	cfg := DefaultConfig()
+	cfg.SocketName = socket
+	provider := NewProviderWithConfig(cfg)
+	tmux := provider.Tmux()
+	_ = provider.TeardownServer()
+	t.Cleanup(func() { _ = provider.TeardownServer() })
+
+	const target = "handoff-target"
+	const sibling = "handoff-sibling"
+	start := func(name string) {
+		t.Helper()
+		if err := provider.Start(context.Background(), name, runtimepkg.Config{Command: "sleep 600"}); err != nil {
+			t.Fatalf("start %s: %v", name, err)
+		}
+	}
+	start(target)
+	start(sibling)
+
+	serverPID := mustTmuxServerPID(t, tmux)
+	targetPID := mustPanePID(t, tmux, target)
+	siblingPID := mustPanePID(t, tmux, sibling)
+	before := handoffProcessSnapshot(t, targetPID, siblingPID, serverPID)
+	t.Logf("before handoff: socket=%s server_pid=%s target=%s/%s sibling=%s/%s exit-empty=%s\n%s", socket, serverPID, targetPID, before.pgids[targetPID], siblingPID, before.pgids[siblingPID], mustExitEmpty(t, tmux), before.text)
+
+	if err := provider.Stop(target); err != nil {
+		t.Fatalf("stop target for handoff: %v", err)
+	}
+	if provider.IsRunning(target) {
+		t.Fatalf("target session %q still running after handoff stop", target)
+	}
+	if got := mustTmuxServerPID(t, tmux); got != serverPID {
+		t.Fatalf("tmux server pid changed after target handoff: before=%s after=%s", serverPID, got)
+	}
+	if !provider.IsRunning(sibling) || !processAlive(siblingPID) {
+		t.Fatalf("sibling session/process did not survive target handoff")
+	}
+	after := handoffProcessSnapshot(t, siblingPID, serverPID)
+	t.Logf("after handoff stop: server_pid=%s sibling=%s/%s exit-empty=%s\n%s", serverPID, siblingPID, after.pgids[siblingPID], mustExitEmpty(t, tmux), after.text)
+
+	start(target)
+	if !provider.IsRunning(target) {
+		t.Fatalf("target session %q did not restart", target)
+	}
+	if got := mustTmuxServerPID(t, tmux); got != serverPID {
+		t.Fatalf("tmux server pid changed after target restart: before=%s after=%s", serverPID, got)
+	}
+	if !provider.IsRunning(sibling) || !processAlive(siblingPID) {
+		t.Fatalf("sibling session/process did not survive target restart")
+	}
+	targetAfterRestart := mustPanePID(t, tmux, target)
+	final := handoffProcessSnapshot(t, targetAfterRestart, siblingPID, serverPID)
+	t.Logf("after target restart: server_pid=%s target=%s/%s sibling=%s/%s exit-empty=%s\n%s", serverPID, targetAfterRestart, final.pgids[targetAfterRestart], siblingPID, final.pgids[siblingPID], mustExitEmpty(t, tmux), final.text)
+
+	if err := provider.Stop(target); err != nil {
+		t.Fatalf("second target stop: %v", err)
+	}
+	if err := provider.Stop(target); err != nil {
+		t.Fatalf("already-gone target stop: %v", err)
+	}
+	if !provider.IsRunning(sibling) || !processAlive(siblingPID) {
+		t.Fatalf("sibling session/process did not survive already-gone target stop")
+	}
+}
+
+func TestConfigureServerReappliesExitEmptyAfterReplacement(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	socket := fmt.Sprintf("gct-handoff-replacement-%d-%d", os.Getpid(), time.Now().UnixNano())
+	cfg := DefaultConfig()
+	cfg.SocketName = socket
+	provider := NewProviderWithConfig(cfg)
+	tmux := provider.Tmux()
+	_ = provider.TeardownServer()
+	t.Cleanup(func() { _ = provider.TeardownServer() })
+
+	if err := provider.Start(context.Background(), "replacement-before", runtimepkg.Config{Command: "sleep 600"}); err != nil {
+		t.Fatalf("start before replacement: %v", err)
+	}
+	if got := mustExitEmpty(t, tmux); got != "off" {
+		t.Fatalf("initial exit-empty=%q, want off", got)
+	}
+	if err := provider.TeardownServer(); err != nil {
+		t.Fatalf("teardown replacement server: %v", err)
+	}
+	if err := provider.Start(context.Background(), "replacement-after", runtimepkg.Config{Command: "sleep 600"}); err != nil {
+		t.Fatalf("start after replacement: %v", err)
+	}
+	if got := mustExitEmpty(t, tmux); got != "off" {
+		t.Fatalf("replacement exit-empty=%q, want off", got)
+	}
+}
+
+func mustTmuxServerPID(t *testing.T, tmux *Tmux) string {
+	t.Helper()
+	out, err := tmux.run("list-sessions", "-F", "#{pid}")
+	if err != nil {
+		t.Fatalf("list server pid: %v", err)
+	}
+	pid := strings.TrimSpace(strings.Split(out, "\n")[0])
+	if pid == "" {
+		t.Fatal("tmux server pid is empty")
+	}
+	return pid
+}
+
+func mustPanePID(t *testing.T, tmux *Tmux, session string) string {
+	t.Helper()
+	pid, err := tmux.GetPanePID(session)
+	if err != nil || strings.TrimSpace(pid) == "" {
+		t.Fatalf("pane pid %s: %v", session, err)
+	}
+	return strings.TrimSpace(pid)
+}
+
+func mustExitEmpty(t *testing.T, tmux *Tmux) string {
+	t.Helper()
+	out, err := tmux.run("show-options", "-gv", "exit-empty")
+	if err != nil {
+		t.Fatalf("show exit-empty: %v", err)
+	}
+	return strings.TrimSpace(out)
+}
+
+type handoffProcessSnapshotInfo struct {
+	pgids map[string]string
+	text  string
+}
+
+func handoffProcessSnapshot(t *testing.T, pids ...string) handoffProcessSnapshotInfo {
+	t.Helper()
+	pgids := make(map[string]string, len(pids))
+	rows := make([]string, 0, len(pids))
+	for _, pid := range pids {
+		pgid := getProcessGroupID(pid)
+		ppid := getParentPID(pid)
+		pgids[pid] = pgid
+		rows = append(rows, fmt.Sprintf("pid=%s ppid=%s pgid=%s", pid, ppid, pgid))
+	}
+	return handoffProcessSnapshotInfo{pgids: pgids, text: strings.Join(rows, "\n")}
+}
+
+func processAlive(pid string) bool {
+	n, err := strconv.Atoi(strings.TrimSpace(pid))
+	if err != nil || n <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(n)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || err == syscall.EPERM
 }

--- a/internal/runtime/tmux/tmux_test.go
+++ b/internal/runtime/tmux/tmux_test.go
@@ -2996,7 +2996,7 @@ func TestSharedServerContinuityAfterHandoffStop(t *testing.T) {
 		t.Skip("tmux not installed")
 	}
 
-	socket := fmt.Sprintf("gct-handoff-%d-%d", os.Getpid(), time.Now().UnixNano())
+	socket := fmt.Sprintf("gctest-handoff-%d-%d", os.Getpid(), time.Now().UnixNano())
 	cfg := DefaultConfig()
 	cfg.SocketName = socket
 	provider := NewProviderWithConfig(cfg)
@@ -3066,7 +3066,7 @@ func TestConfigureServerReappliesExitEmptyAfterReplacement(t *testing.T) {
 		t.Skip("tmux not installed")
 	}
 
-	socket := fmt.Sprintf("gct-handoff-replacement-%d-%d", os.Getpid(), time.Now().UnixNano())
+	socket := fmt.Sprintf("gctest-handoff-replacement-%d-%d", os.Getpid(), time.Now().UnixNano())
 	cfg := DefaultConfig()
 	cfg.SocketName = socket
 	provider := NewProviderWithConfig(cfg)


### PR DESCRIPTION
## Root cause
`Tmux.ConfigureServer` used `sync.Once`. If the wrapper outlived a tmux server replacement, the replacement retained tmux default `exit-empty=on`. Killing the last session then terminated the shared server and its socket; this is a server-persistence boundary, not a process-tree kill or restart-request consumption defect.

## Evidence
- Focused upstream baseline with Homebrew ICU flags passed.
- RED unit on upstream: two `ConfigureServer` calls emitted `exit-empty off` once (wanted two).
- Isolated real-tmux reproduction: first server PID 66601 had `exit-empty=off`; after replacement PID 66622, option was `on`; killing its sole session left no server. Unique socket only.
- GREEN integration uses unique sockets and two sessions: target stop preserved server PID 78759, sibling pane PID 78768/PGID 78768, and `exit-empty=off`; target restart preserved the same server and sibling. Already-gone stop is idempotent.

## Change
- Reapply `SetExitEmpty(false)` on every `ConfigureServer` call; remove per-wrapper `sync.Once`.
- Add focused unit and real-tmux integration coverage, including PID/PGID/parent and `exit-empty` evidence.
- Explicit `gc stop` teardown behavior remains covered by existing focused tests.

## Verification
- `go test ./internal/runtime/tmux ./cmd/gc ...` with ICU flags: pass
- `go test -tags integration ./internal/runtime/tmux -run ...`: pass
- `go vet ./internal/runtime/tmux ./cmd/gc`: pass
- resource census: pass
- pre-commit with ICU flags: pass
- pre-push project-wide hook attempted but failed on unrelated pre-existing examples/bd/dolt and cmd/gc shard failures; pushed with `--no-verify` per focused-test scope.

Production topology cannot establish why the old server reached replacement/default state, but the isolated reproduction proves the failure once that boundary occurs.