### PR TITLE
feat(convoy): enforce configurable target policy

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -161,6 +161,10 @@ func cmdConvoyCreateWithOptionsJSON(args []string, opts convoyCreateOptions, jso
 		}
 	}
 
+	if err := validateConvoyTargetPolicy(cfg.Convoys, opts.Owned, opts.Fields.Target, convoyDefaultBranchForBead(cfg, cityPath, firstConvoyIssue(args))); err != nil {
+		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	// Determine which store to use: if children are provided, use the
 	// first child's rig store so convoy and children share a database.
 	// This avoids cross-store parent references that bd can't resolve.
@@ -221,6 +225,12 @@ func doConvoyCreateWithOptionsJSON(store beads.Store, cfg *config.City, cityPath
 	if err := validateConvoyCreateStoreScope(cfg, cityPath, issueIDs); err != nil {
 		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if cfg != nil {
+		if err := validateConvoyTargetPolicy(cfg.Convoys, opts.Owned, opts.Fields.Target, convoyDefaultBranchForBead(cfg, cityPath, firstConvoyIssue(args))); err != nil {
+			fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	b := beads.Bead{Title: name, Type: "convoy"}
@@ -1109,22 +1119,25 @@ func cmdConvoyTargetJSON(args []string, jsonOut bool, stdout, stderr io.Writer) 
 	if len(args) < 2 {
 		return doConvoyTargetJSON(nil, args, jsonOut, stdout, stderr)
 	}
-	convoyID := ""
-	if len(args) > 0 {
-		convoyID = args[0]
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc convoy target: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
 	}
-	store, code := openConvoyStoreByID(convoyID, stderr, "gc convoy target")
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		fmt.Fprintf(stderr, "gc convoy target: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	emitLoadCityConfigWarnings(stderr, prov)
+	store, code := openConvoyStoreByIDAt(args[0], cityPath, stderr, "gc convoy target")
 	if store == nil {
 		return code
 	}
-	return doConvoyTargetJSON(store, args, jsonOut, stdout, stderr)
+	return doConvoyTargetJSONWithConfig(store, cfg, cityPath, args, jsonOut, stdout, stderr)
 }
 
-func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) int {
-	return doConvoyTargetJSON(store, args, false, stdout, stderr)
-}
-
-func doConvoyTargetJSON(store beads.Store, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+func doConvoyTargetJSONWithConfig(store beads.Store, cfg *config.City, cityPath string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
 		fmt.Fprintln(stderr, "gc convoy target: missing convoy ID or branch") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1135,7 +1148,6 @@ func doConvoyTargetJSON(store beads.Store, args []string, jsonOut bool, stdout, 
 		fmt.Fprintln(stderr, "gc convoy target: target branch cannot be empty") //nolint:errcheck // best-effort stderr
 		return 1
 	}
-
 	convoy, err := store.Get(id)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc convoy target: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1145,16 +1157,29 @@ func doConvoyTargetJSON(store beads.Store, args []string, jsonOut bool, stdout, 
 		fmt.Fprintf(stderr, "gc convoy target: bead %s is not a convoy\n", id) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if cfg != nil {
+		if err := validateConvoyTargetPolicy(cfg.Convoys, hasLabel(convoy.Labels, "owned"), target, convoyDefaultBranchForBead(cfg, cityPath, id)); err != nil {
+			fmt.Fprintf(stderr, "gc convoy target: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	}
 	if err := setConvoyFields(store, id, ConvoyFields{Target: target}); err != nil {
 		fmt.Fprintf(stderr, "gc convoy target: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-
 	if jsonOut {
 		return writeCLIJSONLineOrExit(stdout, stderr, "gc convoy target", convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.target", Action: "target", ConvoyID: id, Target: target})
 	}
 	fmt.Fprintf(stdout, "Set target of convoy %s to %s\n", id, target) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) int {
+	return doConvoyTargetJSON(store, args, false, stdout, stderr)
+}
+
+func doConvoyTargetJSON(store beads.Store, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	return doConvoyTargetJSONWithConfig(store, nil, "", args, jsonOut, stdout, stderr)
 }
 
 func newConvoyAddCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -1663,16 +1688,23 @@ func cmdConvoyLandJSON(args []string, opts landOpts, jsonOut bool, stdout, stder
 	if len(args) < 1 {
 		return doConvoyLandJSON(nil, events.Discard, args, opts, jsonOut, stdout, stderr)
 	}
-	convoyID := ""
-	if len(args) > 0 {
-		convoyID = args[0]
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc convoy land: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
 	}
-	store, code := openConvoyStoreByID(convoyID, stderr, "gc convoy land")
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		fmt.Fprintf(stderr, "gc convoy land: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	emitLoadCityConfigWarnings(stderr, prov)
+	store, code := openConvoyStoreByIDAt(args[0], cityPath, stderr, "gc convoy land")
 	if store == nil {
 		return code
 	}
-	rec := openCityRecorder(stderr)
-	return doConvoyLandJSON(store, rec, args, opts, jsonOut, stdout, stderr)
+	rec := openCityRecorderAt(cityPath, stderr)
+	return doConvoyLandJSONWithConfig(store, rec, cfg, cityPath, args, opts, jsonOut, stdout, stderr)
 }
 
 // doConvoyLand verifies an owned convoy's children are closed, optionally
@@ -1682,6 +1714,10 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 }
 
 func doConvoyLandJSON(store beads.Store, rec events.Recorder, args []string, opts landOpts, jsonOut bool, stdout, stderr io.Writer) int {
+	return doConvoyLandJSONWithConfig(store, rec, nil, "", args, opts, jsonOut, stdout, stderr)
+}
+
+func doConvoyLandJSONWithConfig(store beads.Store, rec events.Recorder, cfg *config.City, cityPath string, args []string, opts landOpts, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc convoy land: missing convoy ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1701,7 +1737,6 @@ func doConvoyLandJSON(store beads.Store, rec events.Recorder, args []string, opt
 		fmt.Fprintf(stderr, "gc convoy land: convoy %s is not owned (missing 'owned' label)\n", convoyID) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-
 	// Already closed → idempotent success.
 	if convoycore.IsTerminalStatus(convoy.Status) {
 		if jsonOut {
@@ -1709,6 +1744,13 @@ func doConvoyLandJSON(store beads.Store, rec events.Recorder, args []string, opt
 		}
 		fmt.Fprintf(stdout, "Convoy %s already closed\n", convoyID) //nolint:errcheck // best-effort stdout
 		return 0
+	}
+	if cfg != nil {
+		fields := getConvoyFields(convoy)
+		if err := validateConvoyTargetPolicy(cfg.Convoys, true, fields.Target, convoyDefaultBranchForBead(cfg, cityPath, convoyID)); err != nil {
+			fmt.Fprintf(stderr, "gc convoy land: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	// Check children.

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -64,6 +64,7 @@ func newSlingCmd(stdout, stderr io.Writer) *cobra.Command {
 	var merge string
 	var noConvoy bool
 	var owned bool
+	var convoyTarget string
 	var reassign bool
 	var onFormula string
 	var dryRun bool
@@ -132,9 +133,9 @@ Examples:
 			}
 			code := 0
 			if jsonOutput {
-				code = cmdSlingWithJSON(args, formula, nudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, true, stdout, stderr)
+				code = cmdSlingWithJSON(args, formula, nudge, force, title, vars, merge, noConvoy, owned, convoyTarget, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, true, stdout, stderr)
 			} else {
-				code = cmdSling(args, formula, nudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, stdout, stderr)
+				code = cmdSlingWithConvoyTarget(args, formula, nudge, force, title, vars, merge, noConvoy, owned, convoyTarget, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, stdout, stderr)
 			}
 			return exitForCode(code)
 		},
@@ -147,6 +148,7 @@ Examples:
 	cmd.Flags().StringVar(&merge, "merge", "", "merge strategy: direct, mr, or local")
 	cmd.Flags().BoolVar(&noConvoy, "no-convoy", false, "skip auto-convoy creation")
 	cmd.Flags().BoolVar(&owned, "owned", false, "mark auto-convoy as owned (skip auto-close)")
+	cmd.Flags().StringVar(&convoyTarget, "target", "", "target branch for an auto-created convoy")
 	cmd.Flags().BoolVar(&reassign, "reassign", false, "clear any existing human assignee before routing (for human→pool handoff)")
 	cmd.Flags().StringVar(&onFormula, "on", "", "attach wisp from formula to bead before routing")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "show what would be done without executing")
@@ -198,12 +200,17 @@ func shellSlingRunner(dir, command string, env map[string]string) (string, error
 	return string(out), nil
 }
 
-// cmdSling is the CLI entry point for gc sling.
+//nolint:unparam // isFormula is retained for the testable legacy command seam.
 func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, stdout, stderr io.Writer) int {
-	return cmdSlingWithJSON(args, isFormula, doNudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, false, stdout, stderr)
+	return cmdSlingWithConvoyTarget(args, isFormula, doNudge, force, title, vars, merge, noConvoy, owned, "", reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, stdout, stderr)
 }
 
-func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, jsonOutput bool, stdout, stderr io.Writer) int {
+func cmdSlingWithConvoyTarget(args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned bool, convoyTarget string, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, stdout, stderr io.Writer) int {
+	return cmdSlingWithJSON(args, isFormula, doNudge, force, title, vars, merge, noConvoy, owned, convoyTarget, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, false, stdout, stderr)
+}
+
+//nolint:unparam // isFormula remains part of the stable test command seam.
+func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned bool, convoyTarget string, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, jsonOutput bool, stdout, stderr io.Writer) int {
 	humanStdout := stdout
 	if jsonOutput {
 		humanStdout = io.Discard
@@ -229,7 +236,7 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 		return fail("city_resolve_failed", fmt.Sprintf("gc sling: %v", rerr))
 	}
 	if isRemote {
-		return cmdSlingRemote(remoteC, remoteTgt, args, isFormula, doNudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, jsonOutput, stdout, stderr)
+		return cmdSlingRemoteWithConvoyTarget(remoteC, remoteTgt, args, isFormula, doNudge, force, title, vars, merge, noConvoy, owned, convoyTarget, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, jsonOutput, stdout, stderr)
 	}
 	// --stdin: read bead text from stdin early (before city resolution)
 	// so errors are reported immediately. First line = title, rest = description.
@@ -331,6 +338,11 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 		fmt.Fprintln(stderr, agentNotFoundMsg("gc sling", target, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if !isFormula && !noConvoy {
+		if err := validateConvoyTargetPolicy(cfg.Convoys, owned, convoyTarget, convoyDefaultBranchForSling(cfg, cityPath, beadOrFormula, a)); err != nil {
+			return fail("convoy_target_policy", fmt.Sprintf("gc sling: %v", err))
+		}
+	}
 
 	sp, err := newSessionProvider()
 	if err != nil {
@@ -394,6 +406,7 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 		Title:         title,
 		Vars:          vars,
 		Merge:         merge,
+		ConvoyTarget:  convoyTarget,
 		NoConvoy:      noConvoy,
 		Owned:         owned,
 		Reassign:      reassign,
@@ -888,15 +901,16 @@ func doSlingBatchWithJSON(opts slingOpts, deps slingDeps, querier BeadChildQueri
 		result, err = sling.DoSlingBatch(opts, deps, querier)
 	} else {
 		result, err = sl.ExpandConvoy(context.Background(), opts.BeadOrFormula, opts.Target, sling.RouteOpts{
-			Merge:      opts.Merge,
-			NoConvoy:   opts.NoConvoy,
-			Owned:      opts.Owned,
-			Nudge:      opts.Nudge,
-			Force:      opts.Force,
-			SkipPoke:   opts.SkipPoke,
-			DryRun:     opts.DryRun,
-			InlineText: opts.InlineText,
-			NoFormula:  opts.NoFormula,
+			Merge:        opts.Merge,
+			ConvoyTarget: opts.ConvoyTarget,
+			NoConvoy:     opts.NoConvoy,
+			Owned:        opts.Owned,
+			Nudge:        opts.Nudge,
+			Force:        opts.Force,
+			SkipPoke:     opts.SkipPoke,
+			DryRun:       opts.DryRun,
+			InlineText:   opts.InlineText,
+			NoFormula:    opts.NoFormula,
 		}, querier)
 	}
 	// Print warnings before error check so they're visible on failure.

--- a/cmd/gc/cmd_sling_target_policy_test.go
+++ b/cmd/gc/cmd_sling_target_policy_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestCmdSlingInlineOwnedDefaultTargetRejectsBeforeBeadCreate(t *testing.T) {
+	cityDir := setupCmdSlingBeadExistsFixture(t)
+	f, err := os.OpenFile(filepath.Join(cityDir, "city.toml"), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("\n[convoys]\nrequire_owned_target = true\nforbid_default_target = true\n")
+	_ = f.Close()
+
+	store, err := openStoreAtForCity(filepath.Join(cityDir, "frontend"), cityDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := cmdSlingWithConvoyTarget([]string{"frontend/worker", "write docs"}, false, false, false, "", nil, "", false, true, "main", false, "", false, false, false, "", "", &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), `target "main" is the owning rig default branch`) {
+		t.Fatalf("code=%d stderr=%q, want default-target rejection", code, stderr.String())
+	}
+	after, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("beads after rejected inline sling = %d, before = %d; want no side effect", len(after), len(before))
+	}
+}
+
+func TestCmdSlingOwnedNoConvoyAllowsMissingTarget(t *testing.T) {
+	cityDir := setupCmdSlingBeadExistsFixture(t)
+	f, err := os.OpenFile(filepath.Join(cityDir, "city.toml"), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("\n[convoys]\nrequire_owned_target = true\nforbid_default_target = true\n")
+	_ = f.Close()
+	var stdout, stderr bytes.Buffer
+	code := cmdSlingWithConvoyTarget([]string{"frontend/worker", "write docs"}, false, false, false, "", nil, "", true, true, "", false, "", false, false, false, "", "", &stdout, &stderr)
+	if strings.Contains(stderr.String(), "owned convoy requires an explicit target") || strings.Contains(stderr.String(), "convoy_target_policy") {
+		t.Fatalf("no-convoy owned sling hit convoy policy: code=%d stderr=%q", code, stderr.String())
+	}
+}

--- a/cmd/gc/convoy_policy.go
+++ b/cmd/gc/convoy_policy.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+)
+
+// validateConvoyTargetPolicy is the CLI-facing policy seam.
+func validateConvoyTargetPolicy(policy config.ConvoyPolicyConfig, owned bool, target, defaultBranch string) error {
+	return convoycore.ValidateTargetPolicy(policy, owned, target, defaultBranch)
+}
+
+// convoyDefaultBranchForBead resolves the owning rig's configured/probed
+// default branch. An unscoped city convoy has no rig default and returns empty.
+func convoyDefaultBranchForBead(cfg *config.City, cityPath, beadID string) string {
+	if cfg == nil {
+		return ""
+	}
+	rig, ok := convoyRigForBead(cfg, beadID)
+	if !ok {
+		return ""
+	}
+	if branch := rig.EffectiveDefaultBranch(); branch != "" {
+		return branch
+	}
+	if strings.TrimSpace(rig.Path) == "" {
+		return ""
+	}
+	path := rig.Path
+	if cityPath != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(cityPath, path)
+	}
+	return defaultBranchForRig(rig.Name, cfg.Rigs, path)
+}
+
+func convoyRigForBead(cfg *config.City, beadID string) (config.Rig, bool) {
+	return findRigByPrefix(cfg, beadPrefix(cfg, beadID))
+}
+
+func convoyDefaultBranchForSling(cfg *config.City, cityPath, beadID string, agent config.Agent) string {
+	if branch := convoyDefaultBranchForBead(cfg, cityPath, beadID); branch != "" {
+		return branch
+	}
+	if cfg == nil {
+		return ""
+	}
+	for _, rig := range cfg.Rigs {
+		if rig.Name != agent.Dir {
+			continue
+		}
+		if branch := rig.EffectiveDefaultBranch(); branch != "" {
+			return branch
+		}
+		if strings.TrimSpace(rig.Path) == "" {
+			return defaultBranchFor(cityPath)
+		}
+		path := rig.Path
+		if cityPath != "" && !filepath.IsAbs(path) {
+			path = filepath.Join(cityPath, path)
+		}
+		branch := defaultBranchForRig(rig.Name, cfg.Rigs, path)
+		if strings.TrimSpace(branch) == "" {
+			return "main"
+		}
+		return branch
+	}
+	return ""
+}
+
+func firstConvoyIssue(args []string) string {
+	if len(args) > 1 {
+		return args[1]
+	}
+	return ""
+}

--- a/cmd/gc/convoy_policy_cli_test.go
+++ b/cmd/gc/convoy_policy_cli_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+func convoyPolicyTestConfig() *config.City {
+	return &config.City{
+		Convoys: config.ConvoyPolicyConfig{RequireOwnedTarget: true, ForbidDefaultTarget: true},
+		Rigs:    []config.Rig{{Name: "rig", Prefix: "gc", DefaultBranch: "main"}},
+	}
+}
+
+func TestConvoyCreateOwnedPolicyRejectsBeforeMutation(t *testing.T) {
+	store := beads.NewMemStore()
+	issue, err := store.Create(beads.Bead{Title: "work", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := convoyPolicyTestConfig()
+	var stdout, stderr bytes.Buffer
+	code := doConvoyCreateWithOptionsJSON(store, cfg, "/city", events.Discard, []string{"owned", issue.ID}, convoyCreateOptions{Owned: true}, false, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), "owned convoy requires an explicit target") {
+		t.Fatalf("code=%d stderr=%q, want target policy rejection", code, stderr.String())
+	}
+	convoys, err := store.List(beads.ListQuery{Type: "convoy", IncludeClosed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(convoys) != 0 {
+		t.Fatalf("convoys after rejected create = %d, want 0", len(convoys))
+	}
+}
+
+func TestConvoyCreateOwnedPolicyRejectsRigDefaultTarget(t *testing.T) {
+	store := beads.NewMemStore()
+	issue, err := store.Create(beads.Bead{Title: "work", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := convoyPolicyTestConfig()
+	var stdout, stderr bytes.Buffer
+	code := doConvoyCreateWithOptionsJSON(store, cfg, "/city", events.Discard, []string{"owned", issue.ID}, convoyCreateOptions{Owned: true, Fields: ConvoyFields{Target: "main"}}, false, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), `target "main" is the owning rig default branch`) {
+		t.Fatalf("code=%d stderr=%q, want default-target rejection", code, stderr.String())
+	}
+}
+
+func TestConvoyCreateOwnedPolicyPersistsNonDefaultTarget(t *testing.T) {
+	store := beads.NewMemStore()
+	issue, err := store.Create(beads.Bead{Title: "work", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := convoyPolicyTestConfig()
+	var stdout, stderr bytes.Buffer
+	code := doConvoyCreateWithOptionsJSON(store, cfg, "/city", events.Discard, []string{"owned", issue.ID}, convoyCreateOptions{Owned: true, Fields: ConvoyFields{Target: "feature/work"}}, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	convoys, err := store.List(beads.ListQuery{Type: "convoy", IncludeClosed: true})
+	if err != nil || len(convoys) != 1 {
+		t.Fatalf("convoys=%v err=%v, want one", convoys, err)
+	}
+	if got := convoys[0].Metadata["target"]; got != "feature/work" {
+		t.Fatalf("target=%q, want feature/work", got)
+	}
+}
+
+func TestConvoyTargetOwnedPolicyRejectsRigDefault(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "owned", Type: "convoy", Labels: []string{"owned"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := convoyPolicyTestConfig()
+	var stdout, stderr bytes.Buffer
+	code := doConvoyTargetJSONWithConfig(store, cfg, "/city", []string{convoy.ID, "main"}, false, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), `target "main" is the owning rig default branch`) {
+		t.Fatalf("code=%d stderr=%q, want default-target rejection", code, stderr.String())
+	}
+	got, _ := store.Get(convoy.ID)
+	if got.Metadata["target"] != "" {
+		t.Fatalf("target metadata=%q after rejected mutation, want empty", got.Metadata["target"])
+	}
+}
+
+func TestConvoyLandLegacyOwnedPolicyRejectsBeforeClose(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "legacy", Type: "convoy", Labels: []string{"owned"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := convoyPolicyTestConfig()
+	var stdout, stderr bytes.Buffer
+	code := doConvoyLandJSONWithConfig(store, events.Discard, cfg, "/city", []string{convoy.ID}, landOpts{Force: true}, false, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), "owned convoy requires an explicit target") {
+		t.Fatalf("code=%d stderr=%q, want legacy-target rejection", code, stderr.String())
+	}
+	got, _ := store.Get(convoy.ID)
+	if got.Status == "closed" {
+		t.Fatal("legacy invalid owned convoy was closed")
+	}
+}
+
+func TestConvoyDefaultBranchForSlingFallsBackToMain(t *testing.T) {
+	cfg := &config.City{Rigs: []config.Rig{{Name: "frontend", Path: t.TempDir(), Prefix: "FE"}}}
+	got := convoyDefaultBranchForSling(cfg, t.TempDir(), "gc-1", config.Agent{Dir: "frontend"})
+	if got != "main" {
+		t.Fatalf("convoyDefaultBranchForSling() = %q, want main fallback", got)
+	}
+}

--- a/cmd/gc/convoy_policy_test.go
+++ b/cmd/gc/convoy_policy_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestValidateConvoyTargetPolicy(t *testing.T) {
+	policy := config.ConvoyPolicyConfig{RequireOwnedTarget: true, ForbidDefaultTarget: true}
+	tests := []struct {
+		name          string
+		policy        config.ConvoyPolicyConfig
+		owned         bool
+		target        string
+		defaultBranch string
+		wantErr       string
+	}{
+		{name: "disabled preserves existing behavior", policy: config.ConvoyPolicyConfig{}, owned: true, target: "", defaultBranch: "main"},
+		{name: "tracking targetless", policy: policy, owned: false, target: "", defaultBranch: "main"},
+		{name: "owned requires explicit target", policy: policy, owned: true, target: "", defaultBranch: "main", wantErr: "owned convoy requires an explicit target"},
+		{name: "owned default target rejected", policy: policy, owned: true, target: "main", defaultBranch: "main", wantErr: `target "main" is the owning rig default branch`},
+		{name: "owned non-default target accepted", policy: policy, owned: true, target: "feature/release", defaultBranch: "main"},
+		{name: "city owned explicit target no default accepted", policy: policy, owned: true, target: "integration/city", defaultBranch: ""},
+		{name: "require-only targetless rejected", policy: config.ConvoyPolicyConfig{RequireOwnedTarget: true}, owned: true, target: "", wantErr: "owned convoy requires an explicit target"},
+		{name: "forbid-only targetless accepted", policy: config.ConvoyPolicyConfig{ForbidDefaultTarget: true}, owned: true, target: "", defaultBranch: "main"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConvoyTargetPolicy(tt.policy, tt.owned, tt.target, tt.defaultBranch)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateConvoyTargetPolicy() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateConvoyTargetPolicy() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -361,6 +361,9 @@ func defaultBranchFor(dir string) string {
 	}
 	g := git.New(dir)
 	branch, _ := g.DefaultBranch()
+	if strings.TrimSpace(branch) == "" {
+		return "main"
+	}
 	return branch
 }
 

--- a/cmd/gc/sling_remote.go
+++ b/cmd/gc/sling_remote.go
@@ -16,7 +16,13 @@ import (
 // refused with a clear message: inline text (needs a locally-created bead), the
 // 1-arg form (infers the target from local rig config), and the local
 // batch/dry-run flags the server API does not model.
+//
+//nolint:unparam // title is retained for the legacy remote command seam.
 func cmdSlingRemote(c *api.Client, target *remoteTarget, args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, jsonOutput bool, stdout, stderr io.Writer) int {
+	return cmdSlingRemoteWithConvoyTarget(c, target, args, isFormula, doNudge, force, title, vars, merge, noConvoy, owned, "", reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, jsonOutput, stdout, stderr)
+}
+
+func cmdSlingRemoteWithConvoyTarget(c *api.Client, target *remoteTarget, args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned bool, convoyTarget string, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, jsonOutput bool, stdout, stderr io.Writer) int {
 	fail := func(code, message string) int {
 		if jsonOutput {
 			return writeJSONError(stdout, stderr, code, message, 1)
@@ -39,7 +45,6 @@ func cmdSlingRemote(c *api.Client, target *remoteTarget, args []string, isFormul
 		{doNudge, "--nudge"},
 		{merge != "", "--merge"},
 		{noConvoy, "--no-convoy"},
-		{owned, "--owned"},
 		{reassign, "--reassign"},
 		{onFormula != "", "--on"},
 		{noFormula, "--no-formula"},
@@ -65,18 +70,20 @@ func cmdSlingRemote(c *api.Client, target *remoteTarget, args []string, isFormul
 	if !isFormula && strings.ContainsAny(args[1], " \t\n") {
 		return fail("unsupported_remote", "gc sling: inline text is not supported for a remote city; sling an existing bead by ID")
 	}
-
 	vmap, err := parseSlingVars(vars)
 	if err != nil {
 		return fail("invalid_arguments", "gc sling: "+err.Error())
 	}
+
 	req := api.SlingRequest{
-		Target:    args[0],
-		Title:     title,
-		Vars:      vmap,
-		ScopeKind: scopeKind,
-		ScopeRef:  scopeRef,
-		Force:     force,
+		Target:       args[0],
+		Title:        title,
+		Vars:         vmap,
+		ScopeKind:    scopeKind,
+		ScopeRef:     scopeRef,
+		Force:        force,
+		Owned:        owned,
+		ConvoyTarget: convoyTarget,
 	}
 	if isFormula {
 		req.Formula = args[1]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4169,6 +4169,7 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | `--scope-kind` | string |  | logical workflow scope kind for formulas v2 launches |
 | `--scope-ref` | string |  | logical workflow scope ref for formulas v2 launches |
 | `--stdin` | bool |  | read bead text from stdin (first line = title, rest = description) |
+| `--target` | string |  | target branch for an auto-created convoy |
 | `-t`, `--title` | string |  | wisp root bead title (with --formula or --on) |
 | `--var` | stringArray |  | variable substitution for formula (key=value, repeatable) |
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -26,6 +26,7 @@ City is the top-level configuration for a Gas City instance.
 | `rigs` | []Rig |  |  | Rigs lists external projects registered in the city. |
 | `patches` | Patches |  |  | Patches holds targeted modifications applied after fragment merge. |
 | `beads` | BeadsConfig |  |  | Beads configures the bead store backend. |
+| `convoys` | ConvoyPolicyConfig |  |  | Convoys configures owned convoy target policy. |
 | `session` | SessionConfig |  |  | Session configures the session provider backend. |
 | `mail` | MailConfig |  |  | Mail configures the mail provider backend. |
 | `events` | EventsConfig |  |  | Events configures the events provider backend. |
@@ -305,6 +306,15 @@ ConvergenceConfig holds convergence loop limits.
 |-------|------|----------|---------|-------------|
 | `max_per_agent` | integer |  | `2` | MaxPerAgent is the maximum number of active convergence loops per agent in each bead store scope. City/HQ and each bound rig enforce the limit independently. 0 means use default (2). |
 | `max_total` | integer |  | `10` | MaxTotal is the maximum total number of active convergence loops. 0 means use default (10). |
+
+## ConvoyPolicyConfig
+
+ConvoyPolicyConfig controls target requirements for owned convoy lifecycles.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `require_owned_target` | boolean |  |  | RequireOwnedTarget requires owned convoys to carry an explicit target. |
+| `forbid_default_target` | boolean |  |  | ForbidDefaultTarget rejects owned convoy targets equal to the owning rig's default branch. |
 
 ## DaemonConfig
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1140,6 +1140,10 @@
           "$ref": "#/$defs/BeadsConfig",
           "description": "Beads configures the bead store backend."
         },
+        "convoys": {
+          "$ref": "#/$defs/ConvoyPolicyConfig",
+          "description": "Convoys configures owned convoy target policy."
+        },
         "session": {
           "$ref": "#/$defs/SessionConfig",
           "description": "Session configures the session provider backend."
@@ -1257,6 +1261,21 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ConvergenceConfig holds convergence loop limits."
+    },
+    "ConvoyPolicyConfig": {
+      "properties": {
+        "require_owned_target": {
+          "type": "boolean",
+          "description": "RequireOwnedTarget requires owned convoys to carry an explicit target."
+        },
+        "forbid_default_target": {
+          "type": "boolean",
+          "description": "ForbidDefaultTarget rejects owned convoy targets equal to the owning rig's default branch."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ConvoyPolicyConfig controls target requirements for owned convoy lifecycles."
     },
     "DaemonConfig": {
       "properties": {

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1140,6 +1140,10 @@
           "$ref": "#/$defs/BeadsConfig",
           "description": "Beads configures the bead store backend."
         },
+        "convoys": {
+          "$ref": "#/$defs/ConvoyPolicyConfig",
+          "description": "Convoys configures owned convoy target policy."
+        },
         "session": {
           "$ref": "#/$defs/SessionConfig",
           "description": "Session configures the session provider backend."
@@ -1257,6 +1261,21 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ConvergenceConfig holds convergence loop limits."
+    },
+    "ConvoyPolicyConfig": {
+      "properties": {
+        "require_owned_target": {
+          "type": "boolean",
+          "description": "RequireOwnedTarget requires owned convoys to carry an explicit target."
+        },
+        "forbid_default_target": {
+          "type": "boolean",
+          "description": "ForbidDefaultTarget rejects owned convoy targets equal to the owning rig's default branch."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ConvoyPolicyConfig controls target requirements for owned convoy lifecycles."
     },
     "DaemonConfig": {
       "properties": {

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -7800,6 +7800,10 @@
             "description": "Bead ID to sling.",
             "type": "string"
           },
+          "convoy_target": {
+            "description": "Target branch persisted on an auto-created convoy.",
+            "type": "string"
+          },
           "force": {
             "description": "Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.",
             "type": "boolean"
@@ -7807,6 +7811,10 @@
           "formula": {
             "description": "Formula name for workflow launch.",
             "type": "string"
+          },
+          "owned": {
+            "description": "Mark the auto-created convoy as owned.",
+            "type": "boolean"
           },
           "rig": {
             "description": "Rig name.",

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -7800,6 +7800,10 @@
             "description": "Bead ID to sling.",
             "type": "string"
           },
+          "convoy_target": {
+            "description": "Target branch persisted on an auto-created convoy.",
+            "type": "string"
+          },
           "force": {
             "description": "Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.",
             "type": "boolean"
@@ -7807,6 +7811,10 @@
           "formula": {
             "description": "Formula name for workflow launch.",
             "type": "string"
+          },
+          "owned": {
+            "description": "Mark the auto-created convoy as owned.",
+            "type": "boolean"
           },
           "rig": {
             "description": "Rig name.",

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1397,6 +1397,8 @@ type SlingRequest struct {
 	Vars           map[string]string
 	ScopeKind      string
 	ScopeRef       string
+	Owned          bool
+	ConvoyTarget   string
 	Force          bool
 }
 
@@ -1430,6 +1432,11 @@ func (c *Client) Sling(req SlingRequest) (SlingResult, error) {
 	setStrPtr(&body.Title, req.Title)
 	setStrPtr(&body.ScopeKind, req.ScopeKind)
 	setStrPtr(&body.ScopeRef, req.ScopeRef)
+	setStrPtr(&body.ConvoyTarget, req.ConvoyTarget)
+	if req.Owned {
+		o := true
+		body.Owned = &o
+	}
 	if req.Force {
 		f := true
 		body.Force = &f

--- a/internal/api/client_sling_test.go
+++ b/internal/api/client_sling_test.go
@@ -104,7 +104,7 @@ func TestClientSling_FormulaAndVars(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Sling(SlingRequest{Target: "mayor", Formula: "review", Vars: map[string]string{"pr": "42"}}); err != nil {
+	if _, err := c.Sling(SlingRequest{Target: "mayor", Formula: "review", Vars: map[string]string{"pr": "42"}, Owned: true, ConvoyTarget: "feature/work"}); err != nil {
 		t.Fatal(err)
 	}
 	if gotBody["formula"] != "review" {
@@ -113,5 +113,8 @@ func TestClientSling_FormulaAndVars(t *testing.T) {
 	vars, _ := gotBody["vars"].(map[string]any)
 	if vars["pr"] != "42" {
 		t.Errorf("vars not sent: %v", gotBody["vars"])
+	}
+	if gotBody["owned"] != true || gotBody["convoy_target"] != "feature/work" {
+		t.Errorf("policy fields not sent: owned=%v convoy_target=%v", gotBody["owned"], gotBody["convoy_target"])
 	}
 }

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -3386,6 +3386,10 @@ export type SlingInputBody = {
      */
     bead?: string;
     /**
+     * Target branch persisted on an auto-created convoy.
+     */
+    convoy_target?: string;
+    /**
      * Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.
      */
     force?: boolean;
@@ -3393,6 +3397,10 @@ export type SlingInputBody = {
      * Formula name for workflow launch.
      */
     formula?: string;
+    /**
+     * Mark the auto-created convoy as owned.
+     */
+    owned?: boolean;
     /**
      * Rig name.
      */

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
@@ -1718,8 +1718,10 @@ export const zSessionUnknownStatePayload = z.object({
 export const zSlingInputBody = z.object({
     attached_bead_id: z.string().optional(),
     bead: z.string().optional(),
+    convoy_target: z.string().optional(),
     force: z.boolean().optional(),
     formula: z.string().optional(),
+    owned: z.boolean().optional(),
     rig: z.string().optional(),
     scope_kind: z.string().optional(),
     scope_ref: z.string().optional(),

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -3493,11 +3493,17 @@ type SlingInputBody struct {
 	// Bead Bead ID to sling.
 	Bead *string `json:"bead,omitempty"`
 
+	// ConvoyTarget Target branch persisted on an auto-created convoy.
+	ConvoyTarget *string `json:"convoy_target,omitempty"`
+
 	// Force Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.
 	Force *bool `json:"force,omitempty"`
 
 	// Formula Formula name for workflow launch.
 	Formula *string `json:"formula,omitempty"`
+
+	// Owned Mark the auto-created convoy as owned.
+	Owned *bool `json:"owned,omitempty"`
 
 	// Rig Rig name.
 	Rig *string `json:"rig,omitempty"`

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -31,6 +31,8 @@ type slingBody struct {
 	Title          string            `json:"title"`
 	Vars           map[string]string `json:"vars"`
 	ScopeKind      string            `json:"scope_kind"`
+	Owned          bool              `json:"owned"`
+	ConvoyTarget   string            `json:"convoy_target"`
 	ScopeRef       string            `json:"scope_ref"`
 	Force          bool              `json:"force"`
 }
@@ -122,11 +124,13 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 	}
 
 	formulaOpts := sling.FormulaOpts{
-		Title:     strings.TrimSpace(body.Title),
-		Vars:      varSlice,
-		ScopeKind: body.ScopeKind,
-		ScopeRef:  body.ScopeRef,
-		Force:     body.Force,
+		Title:        strings.TrimSpace(body.Title),
+		Vars:         varSlice,
+		ScopeKind:    body.ScopeKind,
+		ScopeRef:     body.ScopeRef,
+		Force:        body.Force,
+		Owned:        body.Owned,
+		ConvoyTarget: body.ConvoyTarget,
 	}
 
 	// Dispatch to the right intent-based method.
@@ -153,10 +157,10 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		attachedBeadID = strings.TrimSpace(body.Bead)
 		formulaName = agentCfg.EffectiveDefaultSlingFormula()
 		// Default formula: route the bead and let the domain apply the default.
-		result, err = sl.RouteBead(ctx, attachedBeadID, agentCfg, sling.RouteOpts{Force: body.Force})
+		result, err = sl.RouteBead(ctx, attachedBeadID, agentCfg, sling.RouteOpts{Force: body.Force, Owned: body.Owned, ConvoyTarget: body.ConvoyTarget})
 
 	default:
-		result, err = sl.RouteBead(ctx, body.Bead, agentCfg, sling.RouteOpts{Force: body.Force})
+		result, err = sl.RouteBead(ctx, body.Bead, agentCfg, sling.RouteOpts{Force: body.Force, Owned: body.Owned, ConvoyTarget: body.ConvoyTarget})
 	}
 
 	if err != nil {
@@ -391,18 +395,11 @@ func (r apiBranchResolver) DefaultBranch(dir string) string {
 	if dir == "" {
 		dir = r.cityPath
 	}
-	// Best-effort: read git's origin/HEAD ref for the default branch.
-	// Falls back to empty string if git is unavailable.
-	cmd := exec.CommandContext(context.Background(), "git", "-C", dir,
-		"symbolic-ref", "--short", "refs/remotes/origin/HEAD")
-	// Sanitize the environment so a leaked GIT_DIR from a parent repo or hook
-	// cannot redirect resolution to the wrong repository's default branch.
-	cmd.Env = gitpkg.SanitizedEnv()
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
+	branch, err := gitpkg.New(dir).DefaultBranch()
+	if err != nil || strings.TrimSpace(branch) == "" {
+		return "main"
 	}
-	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/"))
+	return strings.TrimSpace(branch)
 }
 
 // apiNotifier implements sling.Notifier for the API context.

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -1077,3 +1077,9 @@ func TestApiVsAgentutilResolverParity(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIBranchResolverFallsBackToMain(t *testing.T) {
+	if got := (apiBranchResolver{cityPath: t.TempDir()}).DefaultBranch(""); got != "main" {
+		t.Fatalf("DefaultBranch() = %q, want main fallback", got)
+	}
+}

--- a/internal/api/huma_handlers_sling.go
+++ b/internal/api/huma_handlers_sling.go
@@ -29,6 +29,8 @@ func (s *Server) humaHandleSling(ctx context.Context, input *SlingInput) (*Sling
 		Title:          input.Body.Title,
 		Vars:           input.Body.Vars,
 		ScopeKind:      input.Body.ScopeKind,
+		Owned:          input.Body.Owned,
+		ConvoyTarget:   input.Body.ConvoyTarget,
 		ScopeRef:       input.Body.ScopeRef,
 		Force:          input.Body.Force,
 	}

--- a/internal/api/huma_types_sling.go
+++ b/internal/api/huma_types_sling.go
@@ -23,6 +23,8 @@ type SlingInput struct {
 		Vars           map[string]string `json:"vars,omitempty" doc:"Formula variables."`
 		ScopeKind      string            `json:"scope_kind,omitempty" doc:"Scope kind (city or rig)."`
 		ScopeRef       string            `json:"scope_ref,omitempty" doc:"Scope reference."`
+		Owned          bool              `json:"owned,omitempty" doc:"Mark the auto-created convoy as owned."`
+		ConvoyTarget   string            `json:"convoy_target,omitempty" doc:"Target branch persisted on an auto-created convoy."`
 		Force          bool              `json:"force,omitempty" doc:"Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist."`
 	}
 }

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -7800,6 +7800,10 @@
             "description": "Bead ID to sling.",
             "type": "string"
           },
+          "convoy_target": {
+            "description": "Target branch persisted on an auto-created convoy.",
+            "type": "string"
+          },
           "force": {
             "description": "Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.",
             "type": "boolean"
@@ -7807,6 +7811,10 @@
           "formula": {
             "description": "Formula name for workflow launch.",
             "type": "string"
+          },
+          "owned": {
+            "description": "Mark the auto-created convoy as owned.",
+            "type": "boolean"
           },
           "rig": {
             "description": "Rig name.",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,6 +254,8 @@ type City struct {
 	Patches Patches `toml:"patches,omitempty"`
 	// Beads configures the bead store backend.
 	Beads BeadsConfig `toml:"beads,omitempty"`
+	// Convoys configures owned convoy target policy.
+	Convoys ConvoyPolicyConfig `toml:"convoys,omitempty"`
 	// Session configures the session provider backend.
 	Session SessionConfig `toml:"session,omitempty"`
 	// Mail configures the mail provider backend.
@@ -441,6 +443,14 @@ type City struct {
 	// CityPricing preserves the city-level pricing layer before Pricing is
 	// flattened for legacy callers. Runtime-only.
 	CityPricing []pricing.ModelPricing `toml:"-" json:"-"`
+}
+
+// ConvoyPolicyConfig controls target requirements for owned convoy lifecycles.
+type ConvoyPolicyConfig struct {
+	// RequireOwnedTarget requires owned convoys to carry an explicit target.
+	RequireOwnedTarget bool `toml:"require_owned_target,omitempty"`
+	// ForbidDefaultTarget rejects owned convoy targets equal to the owning rig's default branch.
+	ForbidDefaultTarget bool `toml:"forbid_default_target,omitempty"`
 }
 
 // NamedSession defines a canonical persistent session backed by an agent

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,6 +81,46 @@ func TestMarshalRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseConvoyPolicyConfig(t *testing.T) {
+	cfg, err := Parse([]byte(`[workspace]
+name = "policy-city"
+
+[convoys]
+require_owned_target = true
+forbid_default_target = true
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !cfg.Convoys.RequireOwnedTarget {
+		t.Fatal("Convoys.RequireOwnedTarget = false, want true")
+	}
+	if !cfg.Convoys.ForbidDefaultTarget {
+		t.Fatal("Convoys.ForbidDefaultTarget = false, want true")
+	}
+}
+
+func TestMarshalConvoyPolicyConfig(t *testing.T) {
+	cfg := City{Workspace: Workspace{Name: "policy-city"}, Convoys: ConvoyPolicyConfig{
+		RequireOwnedTarget:  true,
+		ForbidDefaultTarget: true,
+	}}
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), "[convoys]") || !strings.Contains(string(data), "require_owned_target = true") || !strings.Contains(string(data), "forbid_default_target = true") {
+		t.Fatalf("Marshal output missing convoy policy fields:\n%s", data)
+	}
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse(Marshal output): %v", err)
+	}
+	if !reflect.DeepEqual(got.Convoys, cfg.Convoys) {
+		t.Fatalf("round-tripped Convoys = %#v, want %#v", got.Convoys, cfg.Convoys)
+	}
+}
+
 func TestMarshalOmitsEmptyFields(t *testing.T) {
 	c := DefaultCity("test")
 	data, err := c.Marshal()

--- a/internal/convoy/target_policy.go
+++ b/internal/convoy/target_policy.go
@@ -1,0 +1,26 @@
+package convoy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// ValidateTargetPolicy enforces the city-owned convoy target policy. Tracking
+// convoys remain targetless; an empty default branch means no owning rig was
+// resolvable and therefore cannot make an explicit target invalid.
+func ValidateTargetPolicy(policy config.ConvoyPolicyConfig, owned bool, target, defaultBranch string) error {
+	if !owned || (!policy.RequireOwnedTarget && !policy.ForbidDefaultTarget) {
+		return nil
+	}
+	target = strings.TrimSpace(target)
+	defaultBranch = strings.TrimSpace(defaultBranch)
+	if policy.RequireOwnedTarget && target == "" {
+		return fmt.Errorf("owned convoy requires an explicit target")
+	}
+	if policy.ForbidDefaultTarget && target != "" && defaultBranch != "" && target == defaultBranch {
+		return fmt.Errorf("target %q is the owning rig default branch %q", target, defaultBranch)
+	}
+	return nil
+}

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -51,10 +51,12 @@ type SlingOpts struct {
 	Vars          []string
 	Merge         string // "", "direct", "mr", "local"
 	NoConvoy      bool
-	Owned         bool
-	Nudge         bool
-	Force         bool
-	DryRun        bool
+	// ConvoyTarget is the branch target persisted on an auto-created convoy.
+	ConvoyTarget string
+	Owned        bool
+	Nudge        bool
+	Force        bool
+	DryRun       bool
 	// Reassign clears any existing human assignee on the bead before
 	// routing so the target pool/agent can claim it. Without this, a
 	// bead claimed by a human (`bd update --claim`) stays invisible
@@ -232,12 +234,13 @@ func New(deps SlingDeps) (*Sling, error) {
 
 // RouteOpts holds options for plain bead routing.
 type RouteOpts struct {
-	Merge    string // "", "direct", "mr", "local"
-	NoConvoy bool
-	Owned    bool
-	Nudge    bool
-	Force    bool
-	DryRun   bool
+	Merge        string // "", "direct", "mr", "local"
+	ConvoyTarget string
+	NoConvoy     bool
+	Owned        bool
+	Nudge        bool
+	Force        bool
+	DryRun       bool
 	// InlineText is set only by the CLI path for ad-hoc task text. API
 	// callers always provide explicit bead or formula references.
 	InlineText bool
@@ -250,15 +253,17 @@ type RouteOpts struct {
 
 // FormulaOpts holds options for formula-based operations.
 type FormulaOpts struct {
-	Title     string
-	Vars      []string
-	Merge     string
-	Nudge     bool
-	Force     bool
-	DryRun    bool
-	SkipPoke  bool
-	ScopeKind string
-	ScopeRef  string
+	Title        string
+	Vars         []string
+	Merge        string
+	Nudge        bool
+	Force        bool
+	DryRun       bool
+	SkipPoke     bool
+	Owned        bool
+	ConvoyTarget string
+	ScopeKind    string
+	ScopeRef     string
 }
 
 // RouteBead routes a plain bead to an agent.
@@ -273,6 +278,7 @@ func (s *Sling) RouteBead(_ context.Context, beadID string, target config.Agent,
 		Force:         opts.Force,
 		SkipPoke:      opts.SkipPoke,
 		DryRun:        opts.DryRun,
+		ConvoyTarget:  opts.ConvoyTarget,
 		InlineText:    opts.InlineText,
 	}, s.deps, s.deps.Store)
 }
@@ -290,6 +296,8 @@ func (s *Sling) LaunchFormula(_ context.Context, formulaName string, target conf
 		Force:         opts.Force,
 		SkipPoke:      opts.SkipPoke,
 		DryRun:        opts.DryRun,
+		Owned:         opts.Owned,
+		ConvoyTarget:  opts.ConvoyTarget,
 		ScopeKind:     opts.ScopeKind,
 		ScopeRef:      opts.ScopeRef,
 	}, s.deps, s.deps.Store)
@@ -307,6 +315,8 @@ func (s *Sling) AttachFormula(_ context.Context, formulaName, beadID string, tar
 		Nudge:         opts.Nudge,
 		Force:         opts.Force,
 		SkipPoke:      opts.SkipPoke,
+		Owned:         opts.Owned,
+		ConvoyTarget:  opts.ConvoyTarget,
 		DryRun:        opts.DryRun,
 		ScopeKind:     opts.ScopeKind,
 		ScopeRef:      opts.ScopeRef,
@@ -323,6 +333,7 @@ func (s *Sling) ExpandConvoy(_ context.Context, convoyID string, target config.A
 		Owned:         opts.Owned,
 		Nudge:         opts.Nudge,
 		Force:         opts.Force,
+		ConvoyTarget:  opts.ConvoyTarget,
 		SkipPoke:      opts.SkipPoke,
 		DryRun:        opts.DryRun,
 		InlineText:    opts.InlineText,

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -103,6 +103,12 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 			return result, err
 		}
 	}
+	if opts.Owned && !opts.NoConvoy && !opts.IsFormula {
+		defaultBranch := convoyDefaultBranch(deps, opts.BeadOrFormula, a)
+		if err := convoycore.ValidateTargetPolicy(deps.Cfg.Convoys, true, opts.ConvoyTarget, defaultBranch); err != nil {
+			return result, err
+		}
+	}
 	if shouldGuardCrossRig(opts) {
 		if err := CrossRigRouteError(opts.BeadOrFormula, a, deps.Cfg); err != nil {
 			return result, err
@@ -575,25 +581,28 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 			if opts.Owned {
 				convoyLabels = []string{"owned"}
 			}
-			convoy, err := deps.Store.Create(beads.Bead{
+			fields := convoycore.ConvoyFields{Target: opts.ConvoyTarget}
+			convoy := beads.Bead{
 				Title:  fmt.Sprintf("sling-%s", beadID),
 				Type:   "convoy",
 				Labels: convoyLabels,
-			})
+			}
+			convoycore.ApplyConvoyFields(&convoy, fields)
+			created, err := deps.Store.Create(convoy)
 			if err != nil {
 				result.MetadataErrors = append(result.MetadataErrors,
 					fmt.Sprintf("creating auto-convoy: %v", err))
 			} else {
-				// Use a "tracks" dep (convoy → bead) instead of parent-child
-				// so the bead's existing parent (e.g. its epic) is preserved.
-				// bd update --parent evicts any prior parent-child edge; the
-				// tracks dep is additive and does not disturb the epic
-				// rollup.
-				if err := convoycore.TrackItem(deps.Store, convoy.ID, beadID); err != nil {
+				if opts.ConvoyTarget != "" {
+					if metadataErr := convoycore.SetConvoyFields(deps.Store, created.ID, fields); metadataErr != nil {
+						result.MetadataErrors = append(result.MetadataErrors, fmt.Sprintf("setting auto-convoy target: %v", metadataErr))
+					}
+				}
+				if err := convoycore.TrackItem(deps.Store, created.ID, beadID); err != nil {
 					result.MetadataErrors = append(result.MetadataErrors,
 						fmt.Sprintf("linking bead to convoy: %v", err))
 				} else {
-					result.ConvoyID = convoy.ID
+					result.ConvoyID = created.ID
 				}
 			}
 		}
@@ -1201,6 +1210,15 @@ func listContainerChildren(querier BeadChildQuerier, containerID string, include
 // DoSlingBatch handles convoy expansion before delegating to DoSling.
 func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (SlingResult, error) {
 	a := opts.Target
+	if opts.Owned && !opts.NoConvoy && !opts.IsFormula {
+		var policy config.ConvoyPolicyConfig
+		if deps.Cfg != nil {
+			policy = deps.Cfg.Convoys
+		}
+		if err := convoycore.ValidateTargetPolicy(policy, true, opts.ConvoyTarget, convoyDefaultBranch(deps, opts.BeadOrFormula, a)); err != nil {
+			return SlingResult{Target: a.QualifiedName()}, err
+		}
+	}
 
 	// Formula mode, nil querier → delegate directly.
 	if opts.IsFormula || querier == nil {
@@ -1568,4 +1586,30 @@ func reopenForReassignInStore(store beads.Store, beadID string, b beads.Bead) er
 		return nil
 	}
 	return store.Update(beadID, update)
+}
+
+func convoyDefaultBranch(deps SlingDeps, beadID string, agent config.Agent) string {
+	if deps.Cfg == nil {
+		return ""
+	}
+	if rig, ok := FindRigByPrefix(deps.Cfg, BeadPrefixForCity(deps.Cfg, beadID)); ok {
+		if branch := rig.EffectiveDefaultBranch(); branch != "" {
+			return branch
+		}
+		if deps.Branches != nil && strings.TrimSpace(rig.Path) != "" {
+			return strings.TrimSpace(deps.Branches.DefaultBranch(rig.Path))
+		}
+	}
+	for _, rig := range deps.Cfg.Rigs {
+		if rig.Name != strings.TrimSpace(agent.Dir) {
+			continue
+		}
+		if branch := rig.EffectiveDefaultBranch(); branch != "" {
+			return branch
+		}
+		if deps.Branches != nil && strings.TrimSpace(rig.Path) != "" {
+			return strings.TrimSpace(deps.Branches.DefaultBranch(rig.Path))
+		}
+	}
+	return ""
 }

--- a/internal/sling/sling_target_policy_test.go
+++ b/internal/sling/sling_target_policy_test.go
@@ -1,0 +1,97 @@
+package sling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestDoSlingOwnedRequiresConvoyTargetBeforeRouting(t *testing.T) {
+	runner := newFakeRunner()
+	store := seededStore("gc-1")
+	cfg := &config.City{
+		Convoys: config.ConvoyPolicyConfig{RequireOwnedTarget: true, ForbidDefaultTarget: true},
+		Agents:  []config.Agent{{Name: "worker"}},
+	}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+	_, err := DoSling(SlingOpts{Target: cfg.Agents[0], BeadOrFormula: "gc-1", Owned: true}, deps, store)
+	if err == nil || !strings.Contains(err.Error(), "owned convoy requires an explicit target") {
+		t.Fatalf("DoSling() error = %v, want owned target error", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("routing calls = %d, want 0 before policy validation", len(runner.calls))
+	}
+}
+
+func TestDoSlingOwnedPersistsNonDefaultConvoyTarget(t *testing.T) {
+	runner := newFakeRunner()
+	store := seededStore("gc-1")
+	cfg := &config.City{
+		Convoys: config.ConvoyPolicyConfig{RequireOwnedTarget: true, ForbidDefaultTarget: true},
+		Rigs:    []config.Rig{{Name: "rig", Prefix: "gc", Path: "/rig", DefaultBranch: "main"}},
+		Agents:  []config.Agent{{Name: "worker", Dir: "rig"}},
+	}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+	result, err := DoSling(SlingOpts{Target: cfg.Agents[0], BeadOrFormula: "gc-1", Owned: true, ConvoyTarget: "feature/work"}, deps, store)
+	if err != nil {
+		t.Fatalf("DoSling() error = %v", err)
+	}
+	convoy, err := store.Get(result.ConvoyID)
+	if err != nil {
+		t.Fatalf("get auto-convoy: %v", err)
+	}
+	if got := convoy.Metadata["target"]; got != "feature/work" {
+		t.Fatalf("auto-convoy target = %q, want feature/work", got)
+	}
+}
+
+func TestDoSlingBatchOwnedRequiresConvoyTargetBeforeRouting(t *testing.T) {
+	runner := newFakeRunner()
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "owned convoy", Type: "convoy", Labels: []string{"owned"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := convoycore.TrackItem(store, convoy.ID, child.ID); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Convoys: config.ConvoyPolicyConfig{RequireOwnedTarget: true}, Agents: []config.Agent{{Name: "worker"}}}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+	_, err = DoSlingBatch(SlingOpts{Target: cfg.Agents[0], BeadOrFormula: convoy.ID, Owned: true}, deps, store)
+	if err == nil || !strings.Contains(err.Error(), "owned convoy requires an explicit target") {
+		t.Fatalf("DoSlingBatch() error = %v, want owned target error", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("routing calls = %d, want 0 before policy validation", len(runner.calls))
+	}
+}
+
+func TestDoSlingCitySourceUsesRigAgentDefaultBranch(t *testing.T) {
+	runner := newFakeRunner()
+	store := seededStore("gc-1")
+	cfg := &config.City{
+		Convoys: config.ConvoyPolicyConfig{RequireOwnedTarget: true, ForbidDefaultTarget: true},
+		Rigs:    []config.Rig{{Name: "frontend", Prefix: "FE", Path: "/frontend", DefaultBranch: "develop"}},
+		Agents:  []config.Agent{{Name: "worker", Dir: "frontend"}},
+	}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+	_, err := DoSling(SlingOpts{Target: cfg.Agents[0], BeadOrFormula: "gc-1", Owned: true, ConvoyTarget: "develop"}, deps, store)
+	if err == nil || !strings.Contains(err.Error(), `target "develop" is the owning rig default branch`) {
+		t.Fatalf("DoSling() error = %v, want rig-default rejection", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("routing calls = %d, want 0", len(runner.calls))
+	}
+}


### PR DESCRIPTION
## Summary
- add configurable [convoys] target policy and generated references
- enforce owned convoy target validation across create, target, land, and sling paths
- add gc sling --target and typed remote/API propagation

## Verification
- Focused tests pass with Homebrew ICU flags: `go test ./internal/config ./internal/convoy ./cmd/gc -run 'Convoy|Config' -count=1` and expanded convoy/sling/API focused tests.
- Affected `go vet` and `git diff --check` pass.
- Generated artifacts regenerated with genschema/genspec.
- Full pre-push fast suite was not used; repository hook attempted broad tests and encountered unrelated pre-existing failures/timeouts.