### PR TITLE
test(dashboard): assert populated render across all remaining dashboard surfaces

### DIFF
--- a/internal/api/dashboardspa/web/frontend/e2e/fixtures/expected.ts
+++ b/internal/api/dashboardspa/web/frontend/e2e/fixtures/expected.ts
@@ -73,6 +73,58 @@ export const MAIL_SUBJECT = 'seeded handoff';
 /** The seeded agent name (from the corpus config). */
 export const AGENT_NAME = 'builder';
 
+/**
+ * The seeded live agent's slug — the {slug} segment on /agents/:slug. It equals
+ * AGENT_NAME (the session's alias === session_name === agent name), so the agent
+ * detail route resolves the seeded session bead. Mirrors corpus.AgentSessionSlug.
+ */
+export const AGENT_SESSION_SLUG = AGENT_NAME;
+
+/**
+ * The runtime state the seeded (non-live) session projects — the StatusBadge label
+ * on the agent-detail header. The corpus persists state "active", but the fake
+ * runtime provider backs no live process, so the sessions read overlays it to
+ * "asleep"; that is the deterministic rendered badge.
+ */
+export const AGENT_SESSION_STATE = 'asleep';
+
+/**
+ * The seeded session's template ("<rig>/<agent>"). The agent-detail AgentMetadata
+ * rig is parsed from it, and it renders verbatim as the header template code.
+ * Mirrors corpus.AgentSessionTemplate.
+ */
+export const AGENT_SESSION_TEMPLATE = 'demo/builder';
+
+/**
+ * The in-progress bead assigned to the seeded agent (assignee === AGENT_NAME). It
+ * is the real in-flight assignment the agent-detail AgentBeadsAssigned panel
+ * renders. Its id is the run anchor's preflight step; its title is the button
+ * label. Mirrors corpus.AnchorStepID / corpus.AnchorStepTitle.
+ */
+export const AGENT_ASSIGNED_BEAD_ID = 'run-anchor.preflight';
+export const AGENT_ASSIGNED_BEAD_TITLE = 'preflight';
+
+/**
+ * The two-message operator↔agent thread. It backs BOTH the mail thread-detail
+ * render (both bodies in one thread) and the agent-detail Chat pane (messages
+ * between the operator alias and the seeded agent). Mirror corpus.OperatorMailSubject
+ * / corpus.OperatorMailBody / corpus.AgentReplyBody.
+ */
+export const OPERATOR_MAIL_SUBJECT = 'adopt PR #42';
+export const OPERATOR_MAIL_BODY =
+  'Please take the seeded adopt-pr run to completion and report back here.';
+export const AGENT_REPLY_BODY =
+  'On it. The preflight step is running now; I will report when the review step opens.';
+
+/**
+ * The seeded bead whose detail modal shows a populated BeadDependencies section:
+ * REVIEW_BEAD_ID "needs" REVIEW_DEP_TARGET_ID, so the modal renders a single
+ * upstream dependency line. Mirror corpus.AnchorReviewStepID / corpus.AnchorStepID.
+ */
+export const REVIEW_BEAD_ID = 'run-anchor.review';
+export const REVIEW_BEAD_TITLE = 'review';
+export const REVIEW_DEP_TARGET_ID = 'run-anchor.preflight';
+
 /** Base path for the seeded city's client routes (BrowserRouter basename). */
 export const CITY_BASE = `/city/${CITY_NAME}`;
 

--- a/internal/api/dashboardspa/web/frontend/e2e/render-smoke.spec.ts
+++ b/internal/api/dashboardspa/web/frontend/e2e/render-smoke.spec.ts
@@ -1,5 +1,11 @@
 import {
+  AGENT_ASSIGNED_BEAD_ID,
+  AGENT_ASSIGNED_BEAD_TITLE,
   AGENT_NAME,
+  AGENT_REPLY_BODY,
+  AGENT_SESSION_SLUG,
+  AGENT_SESSION_STATE,
+  AGENT_SESSION_TEMPLATE,
   ANCHOR_FORMULA,
   ANCHOR_RUN_ID,
   CITY_BASE,
@@ -9,6 +15,11 @@ import {
   COMPLETED_RUN_ID,
   COMPLETED_STEP_APPROVE,
   MAIL_SUBJECT,
+  OPERATOR_MAIL_BODY,
+  OPERATOR_MAIL_SUBJECT,
+  REVIEW_BEAD_ID,
+  REVIEW_BEAD_TITLE,
+  REVIEW_DEP_TARGET_ID,
   RIG_NAME,
   WORK_BEAD_ID,
   WORK_BEAD_TITLE,
@@ -35,21 +46,42 @@ import { expect, test } from './support/fixtures';
 // so a stray substring elsewhere in the DOM cannot satisfy them.
 
 test.describe('dashboard render smoke over the seeded corpus', () => {
-  test('ambient home renders with seeded status', async ({ page }) => {
+  test('cockpit home renders populated instruments and canonical-state sections', async ({
+    page,
+  }) => {
     await gotoCityRoute(page, CITY_BASE, '');
     await expect(page.getByRole('heading', { name: 'Home', level: 1 })).toBeVisible();
     // The h1 "Home" renders identically in the loading, error, and
     // runs-source-error branches, so assert seeded synopsis content that appears
-    // ONLY once the home data loaded: the city name + the census-derived active
-    // run count ("1 running" = the one in-progress anchor run), and the
-    // runs-in-flight tile carrying the same count.
+    // ONLY once the home data loaded: the city name + the status-derived active
+    // session count ("1 active sessions" = the one seeded session bead) and the
+    // census-derived running-run count ("1 running" = the in-progress anchor run).
     await expect(
-      page.getByText('dashport-city · 0 active sessions · 1 running', { exact: false }),
+      page.getByText('dashport-city · 1 active sessions · 1 running', { exact: false }),
     ).toBeVisible();
+    // Dial grid: the "active sessions" instrument carries the SAME status-derived
+    // count (1). The dial-grid renders identically empty when the home data fails,
+    // so a populated instrument value proves the census/status reads wired through.
+    const dials = page.getByTestId('dial-grid');
+    await expect(dials).toBeVisible();
+    await expect(dials.getByRole('link', { name: 'active sessions: 1' })).toBeVisible();
+    // runs-in-flight canonical-state section carries the same run count.
     await expect(
       page
         .getByRole('region', { name: 'runs in flight · canonical state' })
         .getByRole('link', { name: 'running: 1' }),
+    ).toBeVisible();
+    // formula-run-progress section names the seeded run's formula — a run-summary
+    // derived instrument, empty unless the run projected.
+    await expect(
+      page
+        .getByRole('region', { name: 'formula run progress' })
+        .getByRole('link', { name: new RegExp(ANCHOR_FORMULA) }),
+    ).toBeVisible();
+    // systems section's mail lamp carries the seeded unread count (3 seeded
+    // messages), proving the status read reached the lamps.
+    await expect(
+      page.getByRole('region', { name: 'systems' }).getByRole('link', { name: /3 unread/ }),
     ).toBeVisible();
     // A healthy home shows no alert; the error branches render one.
     await expect(page.getByRole('alert')).toHaveCount(0);
@@ -122,18 +154,60 @@ test.describe('dashboard render smoke over the seeded corpus', () => {
     await expect(eventsTable.getByText('bead.created', { exact: true }).first()).toBeVisible();
   });
 
-  test('health renders the system/local-tools widgets', async ({ page }) => {
+  test('health renders all six tile sources per their empirical branch', async ({ page }) => {
     await gotoCityRoute(page, CITY_BASE, '/health');
     await expect(page.getByRole('heading', { name: 'Health', level: 1 })).toBeVisible();
-    // The synopsis is derived from the seeded city's /health projection
-    // ("Supervisor healthy on <city>, uptime ..."), so the seeded city name in
-    // it proves the health read wired through — a static header would not carry
-    // it. The "Tool versions" section is a real widget the local-tools plane
-    // fills, confirming the BFF health plane rendered too.
+
+    // Source 1 — Supervisor tile (typed /v0/city/{c}/health). POPULATED: the
+    // synopsis carries the seeded city name, proving the supervisor health read
+    // wired through (a static header would not carry it).
     await expect(
       page.getByText(`Supervisor healthy on ${CITY_NAME}`, { exact: false }),
     ).toBeVisible();
-    await expect(page.getByText('Tool versions', { exact: false }).first()).toBeVisible();
+
+    // Source 2 — Host + Admin tiles (/api/health/system). These read the SERVING
+    // HOST (/proc + the Go process), so exact values are host-dependent and NOT
+    // asserted. A bare CI runner still exposes every /proc metric and NumCPU, so
+    // the tile always renders its rows — assert STRUCTURE (heading + row labels),
+    // which holds on both a dev box and a CI runner.
+    await expect(page.getByRole('heading', { name: 'Host', level: 2 })).toBeVisible();
+    await expect(page.getByText('CPUs', { exact: true })).toBeVisible();
+    await expect(page.getByText('Load (1m, 5m, 15m)')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Admin process', level: 2 })).toBeVisible();
+    await expect(page.getByText('Node', { exact: true })).toBeVisible();
+
+    // Source 3 — Tool versions (/api/health/local-tools). Probes the host PATH for
+    // gc/bd/dolt; a CI runner may report every tool "unavailable", but the table
+    // ALWAYS renders one row per tool, so assert the row STRUCTURE (data-tool-version-row),
+    // never a version value. Holds on both a dev box (versions) and CI (unavailable).
+    await expect(page.getByRole('heading', { name: 'Tool versions' })).toBeVisible();
+    await expect(page.locator('[data-tool-version-row="gc"]')).toBeVisible();
+    await expect(page.locator('[data-tool-version-row="bd"]')).toBeVisible();
+    await expect(page.locator('[data-tool-version-row="dolt"]')).toBeVisible();
+
+    // Source 4 — Diagnostics / Beads usage (/api/city/{c}/supervisor-status). The
+    // sampler needs the loopback base URL AND a completed background refresh; the
+    // fake supervisor wires the base URL and pre-warms the sampler at boot, so the
+    // tile projects the seeded work counts rather than the cold "warming up" copy.
+    // POPULATED: the Beads-usage rows render, and the warming-up copy is ABSENT —
+    // the negative assertion is the proof the sampler read reached the tile.
+    await expect(page.getByRole('heading', { name: 'Beads usage' })).toBeVisible();
+    await expect(page.getByText('In progress', { exact: true })).toBeVisible();
+    await expect(page.getByText(/sample is warming up/)).toHaveCount(0);
+
+    // Source 5 — Bead stores · per rig (/api/city/{c}/rig-store-health). The seeded
+    // rig ("demo") has no on-disk .beads store, so the sampler probes it and the
+    // tile renders the rig row in its DESIGNED unreachable state — a populated row
+    // (the seeded rig is present) carrying the designed degraded note.
+    await expect(page.getByRole('heading', { name: 'Bead stores · per rig' })).toBeVisible();
+    await expect(page.getByText('.beads store not found on disk')).toBeVisible();
+
+    // Source 6 — Dolt-noms · 24 h (/api/city/{c}/dolt-noms/trend). The seeded
+    // status reports a store_health.size_bytes, so the sampler appends a trend
+    // sample and the tile renders its sparkline. POPULATED: the sparkline figure
+    // is present (its aria-label is the stable handle).
+    await expect(page.getByRole('heading', { name: 'Dolt-noms · 24 h' })).toBeVisible();
+    await expect(page.locator('[aria-label="24 hour dolt-noms size trend"]')).toBeVisible();
   });
 
   // Close-side scenario (the completed run "run-done"): the corpus seeds a
@@ -202,5 +276,126 @@ test.describe('dashboard render smoke over the seeded corpus', () => {
     await expect(eventsTable.getByText('bead.closed', { exact: true }).first()).toBeVisible();
     await expect(eventsTable.getByText('molecule.resolved', { exact: true }).first()).toBeVisible();
     await expect(eventsTable.getByText(COMPLETED_RUN_ID, { exact: true }).first()).toBeVisible();
+  });
+
+  // Remaining surfaces (ga-r375m2): every dashboard view either renders POPULATED
+  // seeded content or its DESIGNED degraded/empty state — never a blank pane, dead
+  // spinner, or error boundary. Each spec below probes one surface the earlier
+  // rounds left presence-only or unseeded.
+
+  test('mail thread detail renders both message bodies of the seeded thread', async ({ page }) => {
+    await gotoCityRoute(page, CITY_BASE, '/mail');
+    await expect(page.getByRole('heading', { name: 'Mail', level: 1 })).toBeVisible();
+    // The seeded operator↔agent thread carries two messages (a handoff and the
+    // agent's reply). Open it from the "All" box (the operator-scoped Inbox hides
+    // the agent-addressed rows), then assert BOTH bodies render in the thread
+    // modal — proof the /mail/thread/{id} read projected the whole thread, not a
+    // single row. Both thread rows share the subject, so click the first.
+    await page.getByRole('button', { name: 'All', exact: true }).click();
+    await page
+      .getByRole('row', { name: new RegExp(OPERATOR_MAIL_SUBJECT) })
+      .first()
+      .click();
+    const thread = page.getByRole('dialog');
+    await expect(thread.getByRole('heading', { name: OPERATOR_MAIL_SUBJECT })).toBeVisible();
+    await expect(thread.getByText(OPERATOR_MAIL_BODY)).toBeVisible();
+    await expect(thread.getByText(AGENT_REPLY_BODY)).toBeVisible();
+  });
+
+  test('agent detail renders metadata, the assigned bead, chat, and idle live-peek', async ({
+    page,
+  }) => {
+    await gotoCityRoute(page, CITY_BASE, `/agents/${AGENT_SESSION_SLUG}`);
+    // Header + StatusBadge: the seeded session resolves the slug, so the detail
+    // page (not its not-found shell) renders — the h1 is the agent alias and the
+    // badge carries the (runtime-overlaid) session state.
+    await expect(page.getByRole('heading', { name: AGENT_SESSION_SLUG, level: 1 })).toBeVisible();
+    await expect(page.getByText(AGENT_SESSION_STATE, { exact: false })).toBeVisible();
+    // AgentMetadata: real values from the seeded session — the resolved provider
+    // and the rig-encoding template. A not-found/loading shell carries neither.
+    await expect(page.getByText('test-agent', { exact: false })).toBeVisible();
+    await expect(page.getByText(AGENT_SESSION_TEMPLATE, { exact: false })).toBeVisible();
+    // AgentBeadsAssigned: the in-progress bead assigned to this agent's alias. The
+    // button's title anchors it to the exact bead so a stray "preflight" elsewhere
+    // cannot satisfy it; its visible text is the bead title.
+    const assigned = page.locator(`[title="Open ${AGENT_ASSIGNED_BEAD_ID}"]`);
+    await expect(assigned).toBeVisible();
+    await expect(assigned).toHaveText(AGENT_ASSIGNED_BEAD_TITLE);
+    // Chat thread: the two operator↔agent messages render their bodies (the
+    // builder→reviewer handoff is NOT between operator and agent, so it is
+    // correctly absent from this pane).
+    await expect(page.getByText(OPERATOR_MAIL_BODY)).toBeVisible();
+    await expect(page.getByText(AGENT_REPLY_BODY)).toBeVisible();
+    // Live-peek pane: the seeded stack backs no live runtime, so no transcript is
+    // streamed. Assert the pane's DESIGNED idle/empty state (its explicit copy),
+    // not a blank pane — the "renders a designed empty state" branch of the bar.
+    await expect(page.getByText('No turns in this session yet.')).toBeVisible();
+  });
+
+  test('run detail diff tab renders its designed unavailable state', async ({ page }) => {
+    await gotoCityRoute(page, CITY_BASE, `/runs/${ANCHOR_RUN_ID}`);
+    // The Diff tab is the default-active run-evidence view. Exercise it (re-select)
+    // and assert the panel. The seeded run records no work_dir, so a real seeded
+    // city cannot produce a diff — assert the DESIGNED unavailable state, not a
+    // blank panel. The tab is genuinely exercised: it is selected and its panel
+    // renders its own copy.
+    const diffTab = page.getByRole('tab', { name: 'Diff' });
+    await expect(diffTab).toHaveAttribute('aria-selected', 'true');
+    await diffTab.click();
+    const panel = page.getByRole('tabpanel');
+    await expect(panel.getByText('No diff available for this run.')).toBeVisible();
+    await expect(panel.getByText(/did not record a work_dir/)).toBeVisible();
+  });
+
+  test('activity commits and deploys render their designed empty states', async ({ page }) => {
+    await gotoCityRoute(page, CITY_BASE, '/activity');
+    await expect(page.getByRole('heading', { name: 'Activity', level: 1 })).toBeVisible();
+    // Commits and Deploys read HOST-scoped sources (the admin git repo and the
+    // deploy log), which the seeded city does not provide — the fake supervisor
+    // pins both to its empty scratch root, so each renders its DESIGNED empty
+    // state. Exercise each mode via its nav link, then assert the empty row scoped
+    // to the named table so a stray "No … in this window." cannot leak in.
+    await page.getByRole('link', { name: 'Commits' }).click();
+    const commits = page.getByRole('table', { name: 'Git commits' });
+    await expect(commits).toBeVisible();
+    await expect(commits.getByText('No commits in this window.')).toBeVisible();
+
+    await page.getByRole('link', { name: 'Deploys' }).click();
+    const deploys = page.getByRole('table', { name: 'Deploy history' });
+    await expect(deploys).toBeVisible();
+    await expect(deploys.getByText('No deploy records in this window.')).toBeVisible();
+  });
+
+  test('bead detail modal renders dependencies and closes cleanly', async ({ page }) => {
+    await gotoCityRoute(page, CITY_BASE, '/beads');
+    await expect(page.getByRole('heading', { name: 'Beads', level: 1 })).toBeVisible();
+    // Open the seeded review step, which "needs" the preflight step. Its row button
+    // is anchored by title so the click is unambiguous.
+    await page.locator(`[title="Select ${REVIEW_BEAD_ID}"]`).click();
+    const modal = page.getByRole('dialog');
+    await expect(modal.getByRole('heading', { name: REVIEW_BEAD_TITLE })).toBeVisible();
+    // POPULATED BeadDependencies: the modal renders the single upstream dependency
+    // built client-side from the bead's needs edge. Assert the section heading and
+    // the resolved dependency target (id + title) — proof the edge projected, not
+    // the "No dependencies." empty branch.
+    await expect(modal.getByRole('heading', { name: 'Dependencies' })).toBeVisible();
+    await expect(modal.getByText(REVIEW_DEP_TARGET_ID, { exact: false })).toBeVisible();
+    // Closes cleanly — the modal leaves the DOM, no leaked error boundary. Both
+    // the header "×" (aria-label Close) and the footer "Close" action dismiss it;
+    // the header handle is first in the DOM.
+    await modal.getByRole('button', { name: 'Close' }).first().click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+
+  test('runs view SSE indicator reaches its live/connected state', async ({ page }) => {
+    await gotoCityRoute(page, CITY_BASE, '/runs');
+    // The Runs view opens an EventSource over /v0/city/{c}/events/stream; the
+    // SseIndicator flips to its connected badge once the stream is live. Proving it
+    // reaches "live" exercises the browser EventSource path end-to-end (not just a
+    // one-shot fetch). The badge's title is the stable handle; its label reads
+    // "live" in the open state.
+    const live = page.getByTitle('SSE stream: open');
+    await expect(live).toBeVisible({ timeout: 15_000 });
+    await expect(live).toHaveText(/live/);
   });
 });

--- a/test/dashport/cmd/fakesupervisor/main.go
+++ b/test/dashport/cmd/fakesupervisor/main.go
@@ -20,10 +20,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -63,6 +65,18 @@ func run() error {
 		return fmt.Errorf("create city path: %w", err)
 	}
 	defer os.RemoveAll(cityPath) //nolint:errcheck
+
+	// Pin the two HOST-scoped Activity data sources to the empty scratch city so
+	// the Deploys and Commits panes render their designed empty states
+	// deterministically on every host, independent of the dev box's real $HOME or
+	// git checkout. The dashboard BFF reads deploy history from $HOME/.dev-deploy-log
+	// (dashboardbff/builds.go) — absent under this empty root — and git commits from
+	// $ADMIN_GIT_REPO (dashboardbff/git.go), a non-git directory here, so `git log`
+	// yields no commits. Neither source is derived from the seeded city, so the
+	// designed empty state is the truthful branch; pinning them just makes it
+	// reproducible rather than dependent on the operator's home directory.
+	_ = os.Setenv("HOME", cityPath)
+	_ = os.Setenv("ADMIN_GIT_REPO", cityPath)
 
 	fx, err := corpus.Load(resolvedData, cityPath)
 	if err != nil {
@@ -105,10 +119,6 @@ func run() error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
-	// Announce the bound address on stdout so the Playwright webServer / shell
-	// harness can read the port when -addr used port 0.
-	fmt.Printf("listening on %s\n", baseURL)
-
 	serveErr := make(chan error, 1)
 	go func() {
 		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -117,6 +127,23 @@ func run() error {
 		}
 		serveErr <- nil
 	}()
+
+	// Warm the Health-view background samplers before announcing readiness. The
+	// supervisor-status / rig-store-health / dolt-noms samplers start lazily on
+	// first request and publish their first snapshot only after a background
+	// refresh completes; the SPA fetches each once on mount and does not refetch
+	// for 30s, so a browser that loads /health in that cold window renders the
+	// "sample is warming up" state instead of the populated tiles. Touching the
+	// endpoints here starts the samplers at boot and blocks (bounded) until
+	// supervisor-status reports available, so the Playwright render smoke — which
+	// launches its browser well after this returns — always sees populated tiles.
+	// This mirrors a real supervisor, whose samplers have long since warmed by the
+	// time an operator opens the dashboard.
+	warmHealthSamplers(ctx, baseURL, fx.CityName)
+
+	// Announce the bound address on stdout so the Playwright webServer / shell
+	// harness can read the port when -addr used port 0.
+	fmt.Printf("listening on %s\n", baseURL)
 
 	select {
 	case <-ctx.Done():
@@ -129,4 +156,52 @@ func run() error {
 	case err := <-serveErr:
 		return err
 	}
+}
+
+// warmHealthSamplers triggers the per-city Health-view samplers over the just-
+// bound loopback listener and blocks (bounded) until the supervisor-status
+// sampler publishes an available snapshot. Each GET starts the corresponding
+// lazily-initialized sampler; the supervisor-status poll then waits for its first
+// background refresh (a loopback /v0 status read, sub-second) to land so the tile
+// renders populated rather than "warming up". It is best-effort: on ctx
+// cancellation or a bounded timeout it returns quietly and lets the samplers warm
+// on their own cadence — the render smoke's browser launch already lags this by
+// seconds, so a partial warm still resolves before the first fetch.
+func warmHealthSamplers(ctx context.Context, baseURL, cityName string) {
+	client := &http.Client{Timeout: 3 * time.Second}
+	base := baseURL + "/api/city/" + cityName
+	// Touch the rig-store and dolt-noms samplers once so they start alongside
+	// supervisor-status; their first snapshots follow the same refresh.
+	for _, path := range []string{"/rig-store-health", "/dolt-noms/trend"} {
+		drain(client, base+path)
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return
+		}
+		if body, ok := drain(client, base+"/supervisor-status"); ok &&
+			bytes.Contains(body, []byte(`"available":true`)) {
+			// Re-touch the other two so their first ring/probe is published too.
+			drain(client, base+"/rig-store-health")
+			drain(client, base+"/dolt-noms/trend")
+			return
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// drain GETs url and returns its body, discarding transport errors — the caller
+// only needs the side effect of starting a sampler and the optional body.
+func drain(client *http.Client, url string) ([]byte, bool) {
+	resp, err := client.Get(url) //nolint:noctx // bounded by client.Timeout
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
 }

--- a/test/dashport/corpus/corpus.go
+++ b/test/dashport/corpus/corpus.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/mail/beadmail"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 // Well-known ids/values the corpus seeds. Both layers assert against these, so
@@ -50,6 +51,22 @@ const (
 
 	// AnchorStepID is the seeded in-progress step bead under the run root.
 	AnchorStepID = "run-anchor.preflight"
+
+	// AnchorStepTitle is AnchorStepID's title (its beads.json Title). It is the
+	// assigned-bead title the agent-detail AgentBeadsAssigned panel renders and
+	// the dependency-line title the bead-detail modal renders for the edge into
+	// this step.
+	AnchorStepTitle = "preflight"
+
+	// AnchorReviewStepID is the second step under the run root, an OPEN task that
+	// "needs" AnchorStepID. The bead-detail modal renders that single upstream
+	// dependency ("Needs 1" → AnchorStepID · AnchorStepTitle), so it is the seeded
+	// bead whose modal proves the populated BeadDependencies branch.
+	AnchorReviewStepID = "run-anchor.review"
+
+	// AnchorReviewStepTitle is AnchorReviewStepID's title; it is the bead-detail
+	// modal heading when that bead's row is opened.
+	AnchorReviewStepTitle = "review"
 
 	// AnchorFormula is the seeded run's formula name; it is the run-detail
 	// title the run view renders.
@@ -106,6 +123,43 @@ const (
 	// MailFrom and MailTo are the seeded mail message's participants.
 	MailFrom = "builder"
 	MailTo   = "reviewer"
+
+	// AgentSessionSlug is the seeded session's alias AND session_name; it is the
+	// {slug} segment the agent-detail route resolves against (session_name → alias
+	// → id, in that order). It equals AgentName so the pool agent and its live
+	// session share one identity, and it matches the assignee on AnchorStepID so
+	// AgentBeadsAssigned renders that in-progress bead.
+	AgentSessionSlug = AgentName
+
+	// AgentSessionTemplate is the seeded session's template ("<rig>/<agent>"). The
+	// session-response rig is parsed from it (config.ParseQualifiedName), so the
+	// agent-detail AgentMetadata block renders Rig = RigName from this value.
+	AgentSessionTemplate = RigName + "/" + AgentName
+
+	// AgentSessionState is the seeded session's runtime state; it is the
+	// StatusBadge label the agent-detail header renders. "active" is the in-flight
+	// presentation state (a non-closed session with work on its hook).
+	AgentSessionState = "active"
+
+	// OperatorMailSubject is the subject of the seeded operator↔agent thread (two
+	// messages: an operator handoff and the agent's reply). It drives BOTH the
+	// mail thread-detail view (a two-message thread body render) and the
+	// agent-detail Chat thread pane (messages between the operator alias and the
+	// seeded agent). Distinct from MailSubject so each thread is individually
+	// addressable.
+	OperatorMailSubject = "adopt PR #42"
+
+	// OperatorMailFrom is the operator wire alias the dashboard treats as "me"
+	// (OperatorConfig.operatorWireAlias default). The agent-detail chat pane only
+	// surfaces messages between this alias (or "operator") and the agent, so the
+	// seeded thread uses it as the operator participant.
+	OperatorMailFrom = "human"
+
+	// OperatorMailBody and AgentReplyBody are the two message bodies in the
+	// operator↔agent thread; both the mail thread-detail render and the
+	// agent-detail chat pane assert these verbatim.
+	OperatorMailBody = "Please take the seeded adopt-pr run to completion and report back here."
+	AgentReplyBody   = "On it. The preflight step is running now; I will report when the review step opens."
 )
 
 // Fixtures is the loaded, seeded corpus plus the stores and providers a harness
@@ -156,6 +210,9 @@ type corpusBeads struct {
 func Load(dataDir, cityPath string) (*Fixtures, error) {
 	store, err := seedBeadStore(dataDir)
 	if err != nil {
+		return nil, err
+	}
+	if err := seedSession(store); err != nil {
 		return nil, err
 	}
 	rec, closeRec, err := seedEventLog(dataDir, cityPath)
@@ -259,12 +316,52 @@ func seedEventLog(dataDir, cityPath string) (events.Provider, func() error, erro
 	return rec, rec.Close, nil
 }
 
-// seedMail sends one message through the city bead store's mail provider so the
-// /mail feed and a thread read project a real message bead.
+// seedSession creates one active session bead in the city store so the sessions
+// list projects a live agent the agent-detail view (/agents/{slug}) can resolve.
+// Without a matching session, that route renders only its not-found shell.
+//
+// The session's alias/session_name is AgentSessionSlug (== AgentName), which is
+// both the route slug and the assignee on the in-progress AnchorStepID bead, so
+// AgentBeadsAssigned renders a real in-flight assignment. Its template encodes
+// the rig (config.ParseQualifiedName → RigName) for the AgentMetadata block, and
+// the operator↔agent thread seedMail sends drives the chat pane.
+func seedSession(store beads.Store) error {
+	sessStore := session.NewStore(beads.SessionStore{Store: store})
+	if _, err := sessStore.CreateSessionInfo(session.CreateSpec{
+		Title:     AgentName,
+		AgentName: AgentName,
+		Metadata: map[string]string{
+			"alias":        AgentSessionSlug,
+			"session_name": AgentSessionSlug,
+			"template":     AgentSessionTemplate,
+			"provider":     "test-agent",
+			"state":        AgentSessionState,
+		},
+	}); err != nil {
+		return fmt.Errorf("seed session: %w", err)
+	}
+	return nil
+}
+
+// seedMail sends messages through the city bead store's mail provider so the
+// /mail feed, a thread read, and the agent-detail chat pane project real message
+// beads. Two threads are seeded:
+//   - a single builder→reviewer handoff (MailSubject), the mail-list row; and
+//   - a two-message operator↔agent thread (OperatorMailSubject): an operator
+//     handoff plus the agent's reply, sharing one thread label. The pair backs
+//     the mail thread-detail render (both bodies) and the agent-detail chat pane
+//     (messages between the operator alias and the seeded agent).
 func seedMail(store beads.Store) (*beadmail.Provider, error) {
 	mp := beadmail.New(store)
 	if _, err := mp.Send(MailFrom, MailTo, MailSubject, "please adopt the seeded PR"); err != nil {
 		return nil, fmt.Errorf("seed mail: %w", err)
+	}
+	handoff, err := mp.Send(OperatorMailFrom, AgentSessionSlug, OperatorMailSubject, OperatorMailBody)
+	if err != nil {
+		return nil, fmt.Errorf("seed operator handoff mail: %w", err)
+	}
+	if _, err := mp.Reply(handoff.ID, AgentSessionSlug, OperatorMailSubject, AgentReplyBody); err != nil {
+		return nil, fmt.Errorf("seed agent reply mail: %w", err)
 	}
 	return mp, nil
 }

--- a/test/dashport/fixtures.go
+++ b/test/dashport/fixtures.go
@@ -29,6 +29,14 @@ const (
 	corpusWorkBeadID   = corpus.WorkBeadID
 	corpusWorkBeadName = corpus.WorkBeadTitle
 	corpusMailSubject  = corpus.MailSubject
+
+	anchorStepTitle       = corpus.AnchorStepTitle
+	anchorReviewStepID    = corpus.AnchorReviewStepID
+	corpusAgentSlug       = corpus.AgentSessionSlug
+	corpusAgentTemplate   = corpus.AgentSessionTemplate
+	corpusOperatorSubject = corpus.OperatorMailSubject
+	corpusOperatorBody    = corpus.OperatorMailBody
+	corpusAgentReplyBody  = corpus.AgentReplyBody
 )
 
 // loadFixtures seeds a city from testdata/dashport via the shared corpus loader

--- a/test/dashport/projection_test.go
+++ b/test/dashport/projection_test.go
@@ -303,6 +303,148 @@ func TestMailView(t *testing.T) {
 	}
 }
 
+// TestMailThreadProjection is the wire-level guard for the mail thread-detail
+// render: the seeded operator↔agent thread must project TWO messages (an
+// operator handoff and the agent's reply) with their real bodies through the
+// /mail/thread/{id} read the SPA opens a thread with. A regression that collapses
+// a thread to one message or drops a body fails here even though /mail still 200s.
+func TestMailThreadProjection(t *testing.T) {
+	h := newHarness(t)
+
+	var list genclient.MailListBody
+	h.getJSON(h.cityURL("/mail"), &list)
+	if list.Items == nil {
+		t.Fatal("mail list empty; operator thread not projected")
+	}
+	threadID := ""
+	for _, m := range *list.Items {
+		if m.Subject == corpusOperatorSubject && m.ThreadId != nil {
+			threadID = *m.ThreadId
+			break
+		}
+	}
+	if threadID == "" {
+		t.Fatalf("no seeded operator thread with subject %q carried a thread_id", corpusOperatorSubject)
+	}
+
+	var thread genclient.MailListBody
+	h.getJSON(h.cityURL("/mail/thread/"+threadID), &thread)
+	if thread.Items == nil || len(*thread.Items) != 2 {
+		got := 0
+		if thread.Items != nil {
+			got = len(*thread.Items)
+		}
+		t.Fatalf("thread %q projected %d messages, want 2 (handoff + reply)", threadID, got)
+	}
+	gotHandoff, gotReply := false, false
+	for _, m := range *thread.Items {
+		switch m.Body {
+		case corpusOperatorBody:
+			gotHandoff = true
+		case corpusAgentReplyBody:
+			gotReply = true
+		}
+	}
+	if !gotHandoff || !gotReply {
+		t.Errorf("thread bodies incomplete: handoff=%v reply=%v", gotHandoff, gotReply)
+	}
+}
+
+// TestAgentSessionProjection guards the data the agent-detail view (/agents/{slug})
+// resolves against: the seeded session must project into the sessions list with
+// its alias/rig/template, and the in-progress AnchorStepID bead must project as
+// assigned to that agent's alias — the assignment the AgentBeadsAssigned panel
+// renders. Without the session the detail page has only its not-found shell, and
+// without the assignment its beads panel is empty; both are load-bearing.
+func TestAgentSessionProjection(t *testing.T) {
+	h := newHarness(t)
+
+	var sessions genclient.ListBodySessionResponse
+	h.getJSON(h.cityURL("/sessions"), &sessions)
+	if sessions.Items == nil || len(*sessions.Items) == 0 {
+		t.Fatal("sessions list empty; seeded session not projected")
+	}
+	var seeded *genclient.SessionResponse
+	for i := range *sessions.Items {
+		s := &(*sessions.Items)[i]
+		if s.Alias != nil && *s.Alias == corpusAgentSlug {
+			seeded = s
+			break
+		}
+	}
+	if seeded == nil {
+		t.Fatalf("sessions list missing seeded session with alias %q", corpusAgentSlug)
+	}
+	if seeded.Rig == nil || *seeded.Rig != corpusRigName {
+		t.Errorf("seeded session rig = %v, want %q", seeded.Rig, corpusRigName)
+	}
+	if seeded.Template != corpusAgentTemplate {
+		t.Errorf("seeded session template = %q, want %q", seeded.Template, corpusAgentTemplate)
+	}
+	if seeded.State == "" {
+		t.Error("seeded session projected an empty state; agent-detail StatusBadge would be blank")
+	}
+
+	var assigned genclient.ListBodyBead
+	h.getJSON(h.cityURL("/beads?assignee="+corpusAgentSlug+"&all=true&limit=200"), &assigned)
+	if !beadWithStatus(assigned, anchorStepID, "in_progress") {
+		t.Errorf("assigned-beads read missing in-progress %q for agent %q", anchorStepID, corpusAgentSlug)
+	}
+}
+
+// TestBeadDependencyProjection guards the edge the bead-detail modal renders as
+// its populated BeadDependencies branch: AnchorReviewStepID must project a "needs"
+// edge onto AnchorStepID. The dashboard builds the dependency graph client-side
+// from the bead's needs field, so a projection that drops needs leaves the modal
+// showing "No dependencies." even though the beads list still 200s.
+func TestBeadDependencyProjection(t *testing.T) {
+	h := newHarness(t)
+
+	var list genclient.ListBodyBead
+	h.getJSON(h.cityURL("/beads?all=true"), &list)
+	if list.Items == nil {
+		t.Fatal("beads list empty; dependency edge not projected")
+	}
+	var review *genclient.Bead
+	for i := range *list.Items {
+		b := &(*list.Items)[i]
+		if b.Id == anchorReviewStepID {
+			review = b
+			break
+		}
+	}
+	if review == nil {
+		t.Fatalf("beads list missing %q", anchorReviewStepID)
+	}
+	if review.Needs == nil || !contains(*review.Needs, anchorStepID) {
+		t.Errorf("%q needs = %v, want to include %q", anchorReviewStepID, review.Needs, anchorStepID)
+	}
+}
+
+// beadWithStatus reports whether the list contains a bead with the given id AND
+// status, proving a real row (not merely a matching id at some other status).
+func beadWithStatus(list genclient.ListBodyBead, id, status string) bool {
+	if list.Items == nil {
+		return false
+	}
+	for _, b := range *list.Items {
+		if b.Id == id {
+			return b.Status == status
+		}
+	}
+	return false
+}
+
+// contains reports whether s is in xs.
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
 // TestAgentsRigsStatusView asserts the config-projection views surface the
 // seeded agent, rig, and city status.
 func TestAgentsRigsStatusView(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #4398 (squash-merged): extends the dashboard Playwright render smoke from 12 → **18 specs** so **every UI surface on main is validated as useful** — each surface either renders populated content derived from seeded city data, or renders its designed degraded state (never a blank pane, dead spinner, or error boundary). Closes bead ga-r375m2.

New/strengthened coverage (every selector grounded against the live rendered DOM; every populated assertion re-proven load-bearing by breaking its seed):

- **Mail thread detail**: seeded two-message operator↔agent thread; both message bodies assert in the thread modal.
- **Agent detail** (`/agents/:slug`): seeded session bead makes the `builder` agent real — header, status badge, metadata (rig/template), assigned in-flight bead, both chat bodies; live-peek pane asserts its designed idle state.
- **Run diff tab**: exercised; asserts the designed unavailable state (seeded runs record no `work_dir` — a real workspace-less run behaves identically).
- **Health tiles**: `fakesupervisor` now pre-warms the status samplers at boot so tiles populate deterministically; per-tile assertions — supervisor status and beads usage populated (with an explicit no-"warming up" negative), host/admin/tool-versions structural (host-dependent values), rig store and dolt-noms per their designed states.
- **Activity Deploys/Commits modes**: `HOME`/`ADMIN_GIT_REPO` pinned to the scratch city so both modes render their designed empty states deterministically on any host.
- **Cockpit home depth**: dial-grid instruments (`active sessions: 1`), formula-run-progress section naming the seeded formula, systems mail lamp (`3 unread`).
- **SSE liveness**: the `/runs` indicator must reach `SSE stream: open` — proving the browser EventSource path over `/v0/city/:c/events/stream` end-to-end.
- **Bead detail modal**: opens with the bead's dependencies section resolving a seeded `needs` edge; clean close.

Layer A parity: `TestMailThreadProjection`, `TestAgentSessionProjection`, `TestBeadDependencyProjection` guard the new seeds at the wire; corpus constants and `expected.ts` remain in lockstep.

**Dead-code finding (vendored SPA, reported not fixed):** `routes/AmbientHome.tsx` + `components/ambient/*` are unmounted on main (no route, no registry entry; only self-referencing tests) — tracked for upstream removal.

## Validation

- Layer A `go test -tags integration ./test/dashport/...` — ok
- Layer B — 18/18 (cold-boot server, the CI path; independently re-run via `make dashboard-e2e-play`)
- `npm run typecheck:e2e`, `make dashboard-check`, resource-census ledger — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
