### PR TITLE
test(runtime): contract ACP production composition

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -806,13 +806,17 @@ construction boundary because that is the wrapper returned directly by the
 runtime registry. This ledger does not recursively claim the wrapper's internal
 tmux, K8s, or hybrid constructors.
 
-`runtime.NewFake` and `subprocess.NewSeamBackedWithDir` are source-bound to the
-shared runtime contract below. The seam-backed proof is the only full
-subprocess runtime contract; the duplicate raw full-contract invocation is
-removed. Focused raw subprocess tests remain, including legacy overlap that
-later consolidation may remove case by case. The default subprocess constructor
-remains a separate H5-owned gap because its reachable empty-city-path branch
-uses shared temporary state. E1 (`ga-80po0c.6`) owns the Large provider/E2E
+`runtime.NewFake`, `subprocess.NewSeamBackedWithDir`, and
+`acp.NewSeamBackedWithDir` are source-bound to the shared runtime contract
+below. The seam-backed proofs are the only full subprocess and ACP runtime
+contracts: the duplicate raw subprocess invocation is removed, and the
+existing ACP owner is converted in place so its fake server is still built
+once. Focused raw provider and seam tests remain for both packages, including
+legacy overlap that later consolidation may remove case by case. The default
+subprocess constructor remains a separate H5-owned gap because its reachable
+empty-city-path branch uses shared temporary state. The default ACP constructor
+is also an H5-owned gap because it always uses shared
+`os.TempDir()/gc-acp` state. E1 (`ga-80po0c.6`) owns the Large provider/E2E
 manifest and required lane/cadence execution; it does not own
 constructor-to-contract source binding.
 
@@ -821,8 +825,8 @@ This table is rendered from `internal/testutil/providerledger` and checked by `g
 
 | Provider path | Roles | Reusable type | Port | Constructor | Discovery | Contract | Status |
 |---|---|---|---|---|---|---|---|
-| `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBacked` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw ACP provider, not the NewSeamBacked production composition |
-| `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBackedWithDir` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw ACP provider, not the NewSeamBackedWithDir production composition |
+| `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBacked` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: NewSeamBacked always uses shared os.TempDir()/gc-acp state; the WithDir proof does not exercise that composition |
+| `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBackedWithDir` | runtime.builtin/exact:acp | `runtime.Provider` | proved by internal/runtime/acp/conformance_test.go#TestACPConformance |
 | `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/exec.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw exec provider, not the production seam-backed prefix composition |
 | `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/t3bridge.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the legacy gc-session-t3 prefix branch selects the T3 bridge composition, which has no full shared runtime contract |
 | `runtime.builtin.fail` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFailFake` | runtime.builtin/exact:fail; reusable: internal/runtime/fake.go | `runtime.Provider` | not applicable: intentional faulting double: a successful lifecycle cannot be exercised, so the successful-provider contract is not applicable |

--- a/internal/runtime/acp/conformance_test.go
+++ b/internal/runtime/acp/conformance_test.go
@@ -7,59 +7,97 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/runtime/runtimetest"
-	"github.com/gastownhall/gascity/internal/testutil"
 )
 
-func TestACPConformance(t *testing.T) {
-	// Build the fake ACP server binary.
-	binDir := t.TempDir()
-	binPath := filepath.Join(binDir, "fakeacp")
-	cmd := exec.Command("go", "build", "-o", binPath, "./testdata/fakeacp")
-	cmd.Dir = filepath.Join(mustModRoot(t), "internal", "runtime", "acp")
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("building fakeacp: %v", err)
-	}
+type acpConformanceFixture struct {
+	once    sync.Once
+	dir     string
+	command string
+	err     error
+}
 
-	// Unix socket paths are capped at 104 bytes on macOS (vs 108 on
-	// Linux). The default t.TempDir() on Darwin lives under
-	// /var/folders/.../T/ which already eats ~60 chars — a few more
-	// directory levels plus the hashed "s<8hex>.sock" filename puts
-	// us over the limit. testutil.ShortTempDir roots the directory
-	// under /tmp on Darwin to keep the socket path small.
-	dir := filepath.Join(testutil.ShortTempDir(t, "acp-conform"), "acp")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir %q: %v", dir, err)
-	}
-	p := NewProviderWithDir(dir, Config{})
+func TestACPConformance(t *testing.T) {
+	var fixture acpConformanceFixture
 	var counter int64
 
-	runtimetest.RunProviderTests(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
-		id := atomic.AddInt64(&counter, 1)
-		name := fmt.Sprintf("gc-acp-conform-%d", id)
-		return p, runtime.Config{
-			Command: binPath,
-			WorkDir: t.TempDir(),
-		}, name
+	runtimetest.RunProviderTests(t, func(caseT *testing.T) (runtime.Provider, runtime.Config, string) {
+		return NewSeamBackedWithDir(acpConformanceDir(caseT, t, &fixture), Config{}), runtime.Config{
+			Command: acpConformanceCommand(caseT, t, &fixture),
+			WorkDir: caseT.TempDir(),
+		}, fmt.Sprintf("gc-acp-conform-%d", atomic.AddInt64(&counter, 1))
 	})
 }
 
-// mustModRoot returns the module root directory.
-func mustModRoot(t *testing.T) string {
-	t.Helper()
+func acpConformanceDir(caseT, ownerT *testing.T, fixture *acpConformanceFixture) string {
+	caseT.Helper()
+	if err := prepareACPConformanceFixture(ownerT, fixture); err != nil {
+		caseT.Fatal(err)
+	}
+	return fixture.dir
+}
+
+func acpConformanceCommand(caseT, ownerT *testing.T, fixture *acpConformanceFixture) string {
+	caseT.Helper()
+	if err := prepareACPConformanceFixture(ownerT, fixture); err != nil {
+		caseT.Fatal(err)
+	}
+	return fixture.command
+}
+
+func prepareACPConformanceFixture(ownerT *testing.T, fixture *acpConformanceFixture) error {
+	fixture.once.Do(func() {
+		// Unix socket paths are capped at 104 bytes on macOS (vs 108 on
+		// Linux), so root the fixture directly under /tmp on Darwin.
+		root := os.TempDir()
+		if goruntime.GOOS == "darwin" {
+			root = "/tmp"
+		}
+		fixtureRoot, err := os.MkdirTemp(root, "acp-conform")
+		if err != nil {
+			fixture.err = fmt.Errorf("create ACP conformance fixture: %w", err)
+			return
+		}
+		ownerT.Cleanup(func() { _ = os.RemoveAll(fixtureRoot) })
+
+		fixture.dir = filepath.Join(fixtureRoot, "acp")
+		if err := os.MkdirAll(fixture.dir, 0o755); err != nil {
+			fixture.err = fmt.Errorf("mkdir %q: %w", fixture.dir, err)
+			return
+		}
+
+		modRoot, err := moduleRoot()
+		if err != nil {
+			fixture.err = err
+			return
+		}
+		fixture.command = filepath.Join(fixtureRoot, "fakeacp")
+		cmd := exec.Command("go", "build", "-o", fixture.command, "./testdata/fakeacp")
+		cmd.Dir = filepath.Join(modRoot, "internal", "runtime", "acp")
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fixture.err = fmt.Errorf("building fakeacp: %w", err)
+		}
+	})
+	return fixture.err
+}
+
+func moduleRoot() (string, error) {
 	cmd := exec.Command("go", "env", "GOMOD")
 	out, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("go env GOMOD: %v", err)
+		return "", fmt.Errorf("go env GOMOD: %w", err)
 	}
-	mod := string(out)
+	mod := strings.TrimSpace(string(out))
 	if mod == "" || mod == "/dev/null" {
-		t.Fatal("not in a Go module")
+		return "", fmt.Errorf("not in a Go module")
 	}
-	return filepath.Dir(filepath.Clean(mod[:len(mod)-1])) // trim trailing newline
+	return filepath.Dir(filepath.Clean(mod)), nil
 }

--- a/internal/testutil/providerledger/ledger.go
+++ b/internal/testutil/providerledger/ledger.go
@@ -171,11 +171,16 @@ func Catalog() []Entry {
 			"acp", "exact:acp", nil,
 			waivedRuntime(
 				repoSymbol("internal/runtime/acp", "NewSeamBacked"),
-				"full conformance covers the raw ACP provider, not the NewSeamBacked production composition",
+				"NewSeamBacked always uses shared os.TempDir()/gc-acp state; the WithDir proof does not exercise that composition",
 			),
-			waivedRuntime(
+			provedRuntime(
 				repoSymbol("internal/runtime/acp", "NewSeamBackedWithDir"),
-				"full conformance covers the raw ACP provider, not the NewSeamBackedWithDir production composition",
+				"internal/runtime/acp/conformance_test.go",
+				"TestACPConformance",
+				SymbolRef{ImportPath: "fmt", Name: "Sprintf"},
+				repoSymbol("internal/runtime/acp", "acpConformanceCommand"),
+				repoSymbol("internal/runtime/acp", "acpConformanceDir"),
+				SymbolRef{ImportPath: "sync/atomic", Name: "AddInt64"},
 			),
 		),
 		builtin(

--- a/internal/testutil/providerledger/ledger_test.go
+++ b/internal/testutil/providerledger/ledger_test.go
@@ -570,6 +570,44 @@ func TestCatalogBindsFakeAndSubprocessWithDirAndDefersDefaultConstructor(t *test
 	}
 }
 
+func TestCatalogBindsACPWithDirAndDefersDefaultConstructor(t *testing.T) {
+	var withDirProof *ProofRef
+	var defaultWaiver *Waiver
+
+	for _, entry := range Catalog() {
+		if entry.ID != "runtime.builtin.acp" {
+			continue
+		}
+		for _, claim := range entry.Claims {
+			switch claim.Constructor {
+			case repoSymbol("internal/runtime/acp", "NewSeamBackedWithDir"):
+				if claim.Disposition != DispositionProved {
+					t.Errorf("ACP WithDir disposition = %q, want %q", claim.Disposition, DispositionProved)
+				}
+				withDirProof = claim.Proof
+			case repoSymbol("internal/runtime/acp", "NewSeamBacked"):
+				if claim.Disposition != DispositionWaived {
+					t.Errorf("ACP default disposition = %q, want %q", claim.Disposition, DispositionWaived)
+				}
+				defaultWaiver = claim.Waiver
+			}
+		}
+	}
+
+	if withDirProof == nil {
+		t.Fatal("acp.NewSeamBackedWithDir proof is missing")
+	}
+	if withDirProof.File != "internal/runtime/acp/conformance_test.go" || withDirProof.Test != "TestACPConformance" {
+		t.Errorf("ACP WithDir proof = %s#%s, want ACP conformance entrypoint", withDirProof.File, withDirProof.Test)
+	}
+	if got, want := renderSymbolRefs(withDirProof.AllowedCalls), "fmt.Sprintf, internal/runtime/acp.acpConformanceCommand, internal/runtime/acp.acpConformanceDir, sync/atomic.AddInt64"; got != want {
+		t.Errorf("ACP WithDir allowed calls = %q, want %q", got, want)
+	}
+	if defaultWaiver == nil || defaultWaiver.Owner != "ga-80po0c.3" {
+		t.Errorf("ACP default waiver = %+v, want ga-80po0c.3 ownership", defaultWaiver)
+	}
+}
+
 func TestDiscoverRuntimeProviderDoublesUsesDeclaredPortIdentity(t *testing.T) {
 	dir := writeRuntimeDoubleFixture(t, map[string]string{
 		"runtime.go": `package runtime


### PR DESCRIPTION
## Summary

- Run the sole full ACP provider contract through the production `NewSeamBackedWithDir` composition.
- Build `fakeacp` once per top-level conformance run while returning a fresh production wrapper for each contract case.
- Ratchet the provider ledger so the `WithDir` constructor is proved and the distinct shared-default constructor remains explicitly waived.
- Keep production code, focused raw-provider tests, and resource-census counts unchanged.

## Why

The existing full contract exercised `NewProviderWithDir` directly. That proved the raw adapter but not the seam-backed composition selected by production. Adding a second suite would duplicate the expensive fake-server process work, so this converts the existing owner in place.

The lazy fixture is local to `TestACPConformance`: the parent test owns the shared directory and cleanup, while the active subtest reports preparation failures. This preserves `go test -count=N` isolation and avoids calling `FailNow` on a parent test from a child.

## TDD evidence

1. Added `TestCatalogBindsACPWithDirAndDefersDefaultConstructor`.
2. Captured RED: `ACP WithDir disposition = "waived", want "proved"`.
3. Changed the ledger and captured the source-proof RED: only zero-value declarations may precede the contract runner.
4. Converted the existing conformance owner and captured the checked-documentation RED.
5. Updated the generated ledger block; all focused and broad gates are GREEN.

## Performance

Three warm focused samples on the same checkout and host:

| Version | Samples | Median |
|---|---:|---:|
| Before | 1.06s, 1.03s, 1.05s | 1.05s |
| After final amendment | 1.02s, 1.02s, 1.00s | 1.02s |

This is a no-regression result; the ~30ms difference is normal measurement noise and is not claimed as a meaningful speedup. The suite still performs one nested `go build`, one full contract invocation, and 31 fake-server executions.

## Verification

- `go test -tags=integration -count=2 ./internal/runtime/acp -run '^TestACPConformance$'`
- `go test -tags=integration -race -count=1 ./internal/runtime/acp -run '^TestACPConformance$'`
- Forced missing-`go` negative probe: child failure, no parent-`FailNow` panic
- `go test -count=1 ./internal/testutil/providerledger -run '^(TestCatalogBindsACPWithDirAndDefersDefaultConstructor|TestCatalogMatchesProductionWiringAndDocumentation)$'`
- `go test -count=1 ./internal/testpolicy/resourcecensus -run '^TestRepositoryLedgerMatchesCensusAndDocumentation$'`
- `./scripts/test-integration-shard packages-core-1-of-4`
- `make test-fast-parallel`
- `make check-docs`
- `go vet ./...`
- `go vet -tags=integration ./internal/runtime/acp`
- Pre-commit and pre-push hooks

## Review

Three delegated reviewers independently approved the final byte-identical diff for:

- semantic correctness and behavior neutrality;
- provider-ledger/source-proof and testing-policy integrity;
- process count, cleanup, error attribution, and runtime efficiency.

Their two substantive findings—accurate default-directory wording and child-safe setup error reporting—were fixed and re-reviewed before commit.

Tracking: `ga-80po0c.3.1`