### PR TITLE
test(runtime): contract exec production composition

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -813,21 +813,24 @@ construction boundary because that is the wrapper returned directly by the
 runtime registry. This ledger does not recursively claim the wrapper's internal
 tmux, K8s, or hybrid constructors.
 
-`runtime.NewFake`, `auto.New`, `subprocess.NewSeamBackedWithDir`, and
-`acp.NewSeamBackedWithDir` are source-bound to the shared runtime contract
-below. The auto proof runs the exact production composition once with two
-fresh in-memory fakes and owns no subprocess or listener; focused auto tests
-retain base-versus-ACP routing and optional-capability coverage instead of
-duplicating the full suite for each route. The seam-backed proofs are the only
-full subprocess and ACP runtime contracts: the duplicate raw subprocess
-invocation is removed, and the existing ACP owner is converted in place so its
-fake server is still built once. Focused raw provider and seam tests remain for
-both packages, including legacy overlap that later consolidation may remove
-case by case. The default subprocess constructor remains a separate H5-owned
-gap because its reachable empty-city-path branch uses shared temporary state.
-The default ACP constructor is also an H5-owned gap because it always uses shared
-`os.TempDir()/gc-acp` state. E1 (`ga-80po0c.6`) owns the Large provider/E2E
-manifest and required lane/cadence execution; it does not own
+`runtime.NewFake`, `auto.New`, `exec.NewSeamBacked`,
+`subprocess.NewSeamBackedWithDir`, and `acp.NewSeamBackedWithDir` are
+source-bound to the shared runtime contract below. The auto proof runs the
+exact production composition once with two fresh in-memory fakes and owns no
+subprocess or listener; focused auto tests retain base-versus-ACP routing and
+optional-capability coverage instead of duplicating the full suite for each
+route. The seam-backed proofs are the only full exec, subprocess, and ACP
+runtime contracts: duplicate raw contracts are avoided, and parent-owned
+fixtures are reused while each contract case receives a fresh production
+wrapper. `TestSeamBackedCapabilitiesParity` separately guards exec's
+handshake-derived stream and TTY flags because the shared contract does not
+assert optional capability fidelity. Focused raw provider and seam tests remain
+for these packages, including legacy overlap that later consolidation may
+remove case by case. The default subprocess constructor remains a separate
+H5-owned gap because its reachable empty-city-path branch uses shared temporary
+state. The default ACP constructor is also an H5-owned gap because it always
+uses shared `os.TempDir()/gc-acp` state. E1 (`ga-80po0c.6`) owns the Large
+provider/E2E manifest and required lane/cadence execution; it does not own
 constructor-to-contract source binding.
 
 <!-- BEGIN CHECKED RUNTIME PROVIDER LEDGER -->
@@ -837,7 +840,7 @@ This table is rendered from `internal/testutil/providerledger` and checked by `g
 |---|---|---|---|---|---|---|---|
 | `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBacked` | runtime.builtin/exact:acp | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: NewSeamBacked always uses shared os.TempDir()/gc-acp state; the WithDir proof does not exercise that composition |
 | `runtime.builtin.acp` | production_provider | — | `runtime.Provider` | `internal/runtime/acp.NewSeamBackedWithDir` | runtime.builtin/exact:acp | `runtime.Provider` | proved by internal/runtime/acp/conformance_test.go#TestACPConformance |
-| `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/exec.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: full conformance covers the raw exec provider, not the production seam-backed prefix composition |
+| `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/exec.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | proved by internal/runtime/exec/exec_test.go#TestExecConformance |
 | `runtime.builtin.exec` | production_provider | — | `runtime.Provider` | `internal/runtime/t3bridge.NewSeamBacked` | runtime.builtin/prefix:exec: | `runtime.Provider` | waived by ga-80po0c.3 through 2026-08-12: the legacy gc-session-t3 prefix branch selects the T3 bridge composition, which has no full shared runtime contract |
 | `runtime.builtin.fail` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFailFake` | runtime.builtin/exact:fail; reusable: internal/runtime/fake.go | `runtime.Provider` | not applicable: intentional faulting double: a successful lifecycle cannot be exercised, so the successful-provider contract is not applicable |
 | `runtime.builtin.fake` | production_provider, reusable_double | `internal/runtime.Fake` | `runtime.Provider` | `internal/runtime.NewFake` | runtime.builtin/exact:fake; reusable: internal/runtime/fake.go | `runtime.Provider` | proved by internal/runtime/fake_conformance_test.go#TestFakeConformance |

--- a/internal/runtime/exec/cutover.go
+++ b/internal/runtime/exec/cutover.go
@@ -58,3 +58,9 @@ func (s *seamBackedProvider) CheckImage(image string) error {
 func (s *seamBackedProvider) Relaunch(ctx context.Context, name string, cfg runtime.Config) error {
 	return s.raw.Relaunch(ctx, name, cfg)
 }
+
+// Capabilities preserves the raw provider's complete handshake-derived
+// capability set through the production seam-backed composition.
+func (s *seamBackedProvider) Capabilities() runtime.ProviderCapabilities {
+	return s.raw.Capabilities()
+}

--- a/internal/runtime/exec/cutover_test.go
+++ b/internal/runtime/exec/cutover_test.go
@@ -1,0 +1,25 @@
+package exec
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSeamBackedCapabilitiesParity(t *testing.T) {
+	dir := t.TempDir()
+	counterFile := filepath.Join(dir, "protocol-calls")
+	handshake := `{"version":0,"capabilities":["report-attachment","report-activity","proc.stream","tty.attach"]}`
+	script := writeScript(t, dir, protocolScript(handshake, counterFile))
+
+	raw := NewProvider(script)
+	want := raw.Capabilities()
+	if !want.CanStream || !want.CanAttachTTY {
+		t.Fatalf("raw provider must declare stream+tty for this test; got %+v", want)
+	}
+
+	seam := NewSeamBacked(script)
+	got := seam.Capabilities()
+	if got != want {
+		t.Fatalf("seam-backed Capabilities = %+v, want parity with raw %+v", got, want)
+	}
+}

--- a/internal/runtime/exec/exec_test.go
+++ b/internal/runtime/exec/exec_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1574,20 +1575,52 @@ esac
 `
 }
 
-func TestExecConformance(t *testing.T) {
-	stateDir := t.TempDir()
-	dir := t.TempDir()
-	script := writeScript(t, dir, mockProviderScript(stateDir))
-	p := NewProvider(script)
-	p.timeout = 5 * time.Second
-	p.startTimeout = 5 * time.Second
+type execConformanceFixture struct {
+	once   sync.Once
+	script string
+	err    error
+}
 
+func execConformanceScript(caseT, ownerT *testing.T, fixture *execConformanceFixture) string {
+	caseT.Helper()
+	fixture.once.Do(func() {
+		fixtureRoot, err := os.MkdirTemp("", "gc-exec-conformance-")
+		if err != nil {
+			fixture.err = fmt.Errorf("create exec conformance fixture: %w", err)
+			return
+		}
+		ownerT.Cleanup(func() {
+			if err := os.RemoveAll(fixtureRoot); err != nil {
+				ownerT.Errorf("remove exec conformance fixture %q: %v", fixtureRoot, err)
+			}
+		})
+
+		stateDir := filepath.Join(fixtureRoot, "state")
+		if err := os.Mkdir(stateDir, 0o755); err != nil {
+			fixture.err = fmt.Errorf("create exec conformance state: %w", err)
+			return
+		}
+
+		fixture.script = filepath.Join(fixtureRoot, "provider")
+		content := "#!/bin/sh\n" + mockProviderScript(stateDir)
+		if err := os.WriteFile(fixture.script, []byte(content), 0o755); err != nil {
+			fixture.err = fmt.Errorf("write exec conformance provider: %w", err)
+		}
+	})
+	if fixture.err != nil {
+		caseT.Fatal(fixture.err)
+	}
+	return fixture.script
+}
+
+func TestExecConformance(t *testing.T) {
+	var fixture execConformanceFixture
 	var counter int64
 
-	runtimetest.RunProviderTests(t, func(t *testing.T) (runtime.Provider, runtime.Config, string) {
-		id := atomic.AddInt64(&counter, 1)
-		name := fmt.Sprintf("exec-conform-%d", id)
-		return p, runtime.Config{WorkDir: t.TempDir()}, name
+	runtimetest.RunProviderTests(t, func(caseT *testing.T) (runtime.Provider, runtime.Config, string) {
+		return NewSeamBacked(execConformanceScript(caseT, t, &fixture)),
+			runtime.Config{WorkDir: caseT.TempDir()},
+			fmt.Sprintf("exec-conform-%06d", atomic.AddInt64(&counter, 1))
 	})
 }
 

--- a/internal/testutil/providerledger/ledger.go
+++ b/internal/testutil/providerledger/ledger.go
@@ -220,9 +220,13 @@ func Catalog() []Entry {
 		),
 		builtin(
 			"exec", "prefix:exec:", nil,
-			waivedRuntime(
+			provedRuntime(
 				repoSymbol("internal/runtime/exec", "NewSeamBacked"),
-				"full conformance covers the raw exec provider, not the production seam-backed prefix composition",
+				"internal/runtime/exec/exec_test.go",
+				"TestExecConformance",
+				SymbolRef{ImportPath: "fmt", Name: "Sprintf"},
+				repoSymbol("internal/runtime/exec", "execConformanceScript"),
+				SymbolRef{ImportPath: "sync/atomic", Name: "AddInt64"},
 			),
 			waivedRuntime(
 				repoSymbol("internal/runtime/t3bridge", "NewSeamBacked"),

--- a/internal/testutil/providerledger/ledger_test.go
+++ b/internal/testutil/providerledger/ledger_test.go
@@ -608,6 +608,44 @@ func TestCatalogBindsACPWithDirAndDefersDefaultConstructor(t *testing.T) {
 	}
 }
 
+func TestCatalogBindsExecCompositionToSeamBackedContract(t *testing.T) {
+	var proof *ProofRef
+	var t3Waiver *Waiver
+
+	for _, entry := range Catalog() {
+		if entry.ID != "runtime.builtin.exec" {
+			continue
+		}
+		for _, claim := range entry.Claims {
+			switch claim.Constructor {
+			case repoSymbol("internal/runtime/exec", "NewSeamBacked"):
+				if claim.Disposition != DispositionProved {
+					t.Errorf("exec seam-backed disposition = %q, want %q", claim.Disposition, DispositionProved)
+				}
+				proof = claim.Proof
+			case repoSymbol("internal/runtime/t3bridge", "NewSeamBacked"):
+				if claim.Disposition != DispositionWaived {
+					t.Errorf("legacy T3 exec-prefix disposition = %q, want %q", claim.Disposition, DispositionWaived)
+				}
+				t3Waiver = claim.Waiver
+			}
+		}
+	}
+
+	if proof == nil {
+		t.Fatal("exec.NewSeamBacked proof is missing")
+	}
+	if proof.File != "internal/runtime/exec/exec_test.go" || proof.Test != "TestExecConformance" {
+		t.Errorf("exec.NewSeamBacked proof = %s#%s, want exec conformance entrypoint", proof.File, proof.Test)
+	}
+	if got, want := renderSymbolRefs(proof.AllowedCalls), "fmt.Sprintf, internal/runtime/exec.execConformanceScript, sync/atomic.AddInt64"; got != want {
+		t.Errorf("exec.NewSeamBacked allowed calls = %q, want %q", got, want)
+	}
+	if t3Waiver == nil || t3Waiver.Owner != "ga-80po0c.3" {
+		t.Errorf("legacy T3 exec-prefix waiver = %+v, want ga-80po0c.3 ownership", t3Waiver)
+	}
+}
+
 func TestCatalogBindsAutoCompositionToConformantFakes(t *testing.T) {
 	var proof *ProofRef
 


### PR DESCRIPTION
## Summary

- Preserve the raw exec provider's complete handshake-derived capabilities through the production `NewSeamBacked` composition.
- Move the sole 34-case exec conformance owner from raw `NewProvider` to fresh production `NewSeamBacked` wrappers backed by one parent-owned protocol fixture.
- Ratchet the exact production constructor in the provider ledger and documentation while preserving the separate legacy T3 waiver.

## Why

The generic seam adapter can represent reporting capabilities, but not exec's `CanStream` and `CanAttachTTY` handshake flags. The production wrapper therefore dropped those flags even though the raw provider reported them. The full shared contract also exercised only the raw constructor, leaving production composition unproved.

This converts the existing contract owner in place instead of adding a duplicate 34-case subprocess suite.

## TDD evidence

The focused regression failed before the implementation:

```text
seam-backed Capabilities = {CanReportAttachment:true CanReportActivity:true CanStream:false CanAttachTTY:false},
want parity with raw {CanReportAttachment:true CanReportActivity:true CanStream:true CanAttachTTY:true}
```

After the pass-through fix, the focused guard passes 20 consecutive runs. The catalog ratchet also failed first with `exec.NewSeamBacked` still waived, then passed after the production contract binding landed.

## Performance

| Measurement | Before | After |
| --- | ---: | ---: |
| Go-reported conformance time | 0.557–0.581s | 0.716–0.765s |
| Warm external wall time | 0.89–0.91s | 1.08–1.16s |
| Race run | ~2.67s reference | 1.802s |
| Full exec package | ~16s reference | 12.294s |

The exact production path adds about 0.24s at the warm median. Converting the owner in place avoids a second duplicate suite, which would add roughly another 0.57s Go time / 0.91s wall time on every run.

## Verification

- `go test -count=20 ./internal/runtime/exec -run '^TestSeamBackedCapabilitiesParity$'`
- `go test -count=10 ./internal/runtime/exec -run '^TestExecConformance$' -timeout=2m`
- `go test -race ./internal/runtime/exec -run '^TestExecConformance$' -timeout=3m`
- `go test -count=1 ./internal/testutil/providerledger`
- `go test -count=1 ./internal/testpolicy/resourcecensus -run '^TestRepositoryLedgerMatchesCensusAndDocumentation$'`
- `go test -count=1 ./internal/runtime/exec -timeout=2m`
- `make test-fast-parallel`
- `go vet ./...`

Both atomic slices received three independent delegated reviews before commit. One review found an ignored fixture-cleanup error; it was fixed, retested, and approved by all three reviewers before the second commit.
