### PR TITLE
fix(sling): tolerate unrelated workflow store scan failures

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1533,131 +1533,194 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 }
 
 func collectSourceWorkflowMatchesFromStores(cfg *config.City, cityPath, sourceBeadID, sourceStoreRef string, stores []convoyStoreView, skips []sourceWorkflowStoreSkip) ([]sourceWorkflowStoreMatch, []sourceWorkflowStoreSkip, error) {
-	matchesByLabel := map[string]sourceWorkflowStoreMatch{}
-	visited := map[string]struct{}{}
-	failedStores := map[int]struct{}{}
-	anyStoreScanned := false
 	cityName := loadedCityName(cfg, cityPath)
-	if selectedRef := sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef); selectedRef != "" {
-		selectedPresent := slices.ContainsFunc(stores, func(info convoyStoreView) bool {
-			return info.store != nil &&
-				sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(info.path, cityPath, cityName, cfg)) == selectedRef
-		})
-		if !selectedPresent {
-			for _, skip := range skips {
-				skipRef := sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(skip.path, cityPath, cityName, cfg))
-				if skipRef == selectedRef && skip.err != nil {
-					return nil, skips, fmt.Errorf("selected source workflow store %s is unavailable to scan: %w", selectedRef, skip.err)
-				}
-			}
-			return nil, skips, fmt.Errorf("selected source workflow store %s is unavailable to scan", selectedRef)
-		}
-	}
-	var firstScanErr error
-	recordScanFailure := func(index int, info convoyStoreView, currentSourceStoreRef, operation string, scanErr error) error {
-		wrapped := fmt.Errorf("%s in %s: %w", operation, workflowDeleteStoreLabel(cfg, cityPath, info.path), scanErr)
-		if firstScanErr == nil {
-			firstScanErr = wrapped
-		}
-		failedStores[index] = struct{}{}
-		skips = append(skips, sourceWorkflowStoreSkip{path: info.path, err: wrapped})
-
-		rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cityName, cfg)
-		selectedStore := strings.TrimSpace(currentSourceStoreRef) != "" &&
-			sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) == sourceworkflow.NormalizeSourceStoreRef(currentSourceStoreRef)
-		if selectedStore {
-			return wrapped
-		}
-		return nil
-	}
-
-	var collect func(string, string) error
-	collect = func(currentSourceID, currentSourceStoreRef string) error {
-		currentSourceID = strings.TrimSpace(currentSourceID)
-		if currentSourceID == "" {
-			return nil
-		}
-		for i, info := range stores {
-			if info.store == nil {
-				continue
-			}
-			if _, failed := failedStores[i]; failed {
-				continue
-			}
-			rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cityName, cfg)
-			// Downward delete-source walks key by root store plus source
-			// identity. The upward finalize walk in internal/dispatch only
-			// needs source store plus bead ID because each hop has one parent.
-			visitKey := rootStoreRef + "\x00" + currentSourceStoreRef + "\x00" + currentSourceID
-			if _, ok := visited[visitKey]; ok {
-				continue
-			}
-			visited[visitKey] = struct{}{}
-			roots, err := sourceworkflow.ListLiveRoots(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
-			if err != nil {
-				if strictErr := recordScanFailure(i, info, currentSourceStoreRef, "listing live source workflows", err); strictErr != nil {
-					return strictErr
-				}
-				continue
-			}
-			if len(roots) > 0 {
-				beadSet := make([]beads.Bead, 0, len(roots))
-				var beadScanErr error
-				for _, root := range roots {
-					workflowBeads, err := findWorkflowBeadsFromRoot(info.store, root)
-					if err != nil {
-						beadScanErr = err
-						break
-					}
-					beadSet = append(beadSet, workflowBeads...)
-				}
-				if beadScanErr != nil {
-					if strictErr := recordScanFailure(i, info, currentSourceStoreRef, "listing source workflow beads", beadScanErr); strictErr != nil {
-						return strictErr
-					}
-					continue
-				}
-				mergeSourceWorkflowMatch(matchesByLabel, sourceWorkflowStoreMatch{
-					label:  workflowDeleteStoreLabel(cfg, cityPath, info.path),
-					store:  info.store,
-					roots:  roots,
-					beads:  uniqueBeads(beadSet),
-					path:   info.path,
-					runner: workflowDeleteRunnerForPath(cfg, cityPath, info.path),
-				})
-			}
-			children, err := sourceWorkflowChildSources(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
-			if err != nil {
-				if strictErr := recordScanFailure(i, info, currentSourceStoreRef, "listing source workflow children", err); strictErr != nil {
-					return strictErr
-				}
-				continue
-			}
-			anyStoreScanned = true
-			for _, child := range children {
-				if err := collect(child.ID, rootStoreRef); err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	}
-	if err := collect(sourceBeadID, sourceStoreRef); err != nil {
+	if err := ensureSelectedSourceStorePresent(cfg, cityPath, cityName, sourceStoreRef, stores, skips); err != nil {
 		return nil, skips, err
 	}
-	if !anyStoreScanned {
-		if firstScanErr != nil {
-			return nil, skips, firstScanErr
-		}
-		return nil, skips, fmt.Errorf("no source workflow stores were available to scan")
+	c := &sourceWorkflowMatchCollector{
+		cfg:            cfg,
+		cityPath:       cityPath,
+		cityName:       cityName,
+		stores:         stores,
+		skips:          skips,
+		matchesByLabel: map[string]sourceWorkflowStoreMatch{},
+		visited:        map[string]struct{}{},
+		failedStores:   map[int]struct{}{},
 	}
-	matches := make([]sourceWorkflowStoreMatch, 0, len(matchesByLabel))
-	for _, match := range matchesByLabel {
+	if err := c.collect(sourceBeadID, sourceStoreRef); err != nil {
+		return nil, c.skips, err
+	}
+	if !c.anyStoreScanned {
+		if c.firstScanErr != nil {
+			return nil, c.skips, c.firstScanErr
+		}
+		return nil, c.skips, fmt.Errorf("no source workflow stores were available to scan")
+	}
+	return c.matches(), c.skips, nil
+}
+
+// ensureSelectedSourceStorePresent fails when a specific source store was
+// selected but is absent from the opened stores. The selected store is always
+// strict, so its absence — or a recorded open failure for it — must abort the
+// walk rather than silently degrade singleton coverage.
+func ensureSelectedSourceStorePresent(cfg *config.City, cityPath, cityName, sourceStoreRef string, stores []convoyStoreView, skips []sourceWorkflowStoreSkip) error {
+	selectedRef := sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef)
+	if selectedRef == "" {
+		return nil
+	}
+	present := slices.ContainsFunc(stores, func(info convoyStoreView) bool {
+		return info.store != nil &&
+			sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(info.path, cityPath, cityName, cfg)) == selectedRef
+	})
+	if present {
+		return nil
+	}
+	for _, skip := range skips {
+		skipRef := sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(skip.path, cityPath, cityName, cfg))
+		if skipRef == selectedRef && skip.err != nil {
+			return fmt.Errorf("selected source workflow store %s is unavailable to scan: %w", selectedRef, skip.err)
+		}
+	}
+	return fmt.Errorf("selected source workflow store %s is unavailable to scan", selectedRef)
+}
+
+// sourceWorkflowMatchCollector walks the source-workflow graph across every
+// candidate store for a delete/reopen-source operation. It tolerates unrelated
+// (non-selected) store scan failures — recording them as skips — while keeping
+// the selected source store strict, and carries the shared walk state so each
+// step reads as a small, single-purpose method.
+type sourceWorkflowMatchCollector struct {
+	cfg      *config.City
+	cityPath string
+	cityName string
+	stores   []convoyStoreView
+
+	matchesByLabel  map[string]sourceWorkflowStoreMatch
+	visited         map[string]struct{}
+	failedStores    map[int]struct{}
+	skips           []sourceWorkflowStoreSkip
+	anyStoreScanned bool
+	firstScanErr    error
+}
+
+// collect walks every store for currentSourceID, then recurses into each child
+// source discovered under it. A tolerated per-store scan failure yields no
+// children and no error so the walk continues; a selected-store failure aborts.
+func (c *sourceWorkflowMatchCollector) collect(currentSourceID, currentSourceStoreRef string) error {
+	currentSourceID = strings.TrimSpace(currentSourceID)
+	if currentSourceID == "" {
+		return nil
+	}
+	for i, info := range c.stores {
+		children, err := c.scanStore(i, info, currentSourceID, currentSourceStoreRef)
+		if err != nil {
+			return err
+		}
+		rootStoreRef := workflowStoreRefForDir(info.path, c.cityPath, c.cityName, c.cfg)
+		for _, child := range children {
+			if err := c.collect(child.ID, rootStoreRef); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// scanStore walks a single candidate store for one source identity and returns
+// the child source beads to recurse into. Nil, already-failed, or
+// already-visited stores yield no children. A ListLiveRoots, bead, or child
+// scan failure is classified by recordScanFailure: a tolerated failure returns
+// (nil, nil) so the caller skips the store; a selected-store failure returns the
+// wrapped error to abort.
+func (c *sourceWorkflowMatchCollector) scanStore(index int, info convoyStoreView, currentSourceID, currentSourceStoreRef string) ([]beads.Bead, error) {
+	if info.store == nil {
+		return nil, nil
+	}
+	if _, failed := c.failedStores[index]; failed {
+		return nil, nil
+	}
+	rootStoreRef := workflowStoreRefForDir(info.path, c.cityPath, c.cityName, c.cfg)
+	// Downward delete-source walks key by root store plus source identity. The
+	// upward finalize walk in internal/dispatch only needs source store plus
+	// bead ID because each hop has one parent.
+	visitKey := rootStoreRef + "\x00" + currentSourceStoreRef + "\x00" + currentSourceID
+	if _, ok := c.visited[visitKey]; ok {
+		return nil, nil
+	}
+	c.visited[visitKey] = struct{}{}
+
+	roots, err := sourceworkflow.ListLiveRoots(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
+	if err != nil {
+		return nil, c.recordScanFailure(index, info, currentSourceStoreRef, "listing live source workflows", err)
+	}
+	if err := c.mergeRootMatches(info, roots); err != nil {
+		return nil, c.recordScanFailure(index, info, currentSourceStoreRef, "listing source workflow beads", err)
+	}
+	children, err := sourceWorkflowChildSources(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
+	if err != nil {
+		return nil, c.recordScanFailure(index, info, currentSourceStoreRef, "listing source workflow children", err)
+	}
+	c.anyStoreScanned = true
+	return children, nil
+}
+
+// mergeRootMatches gathers every workflow bead under the given roots in one
+// store and merges them into the match set. It returns the first bead-scan
+// error (leaving the match set unmerged) so the caller can classify it as a
+// tolerated or strict scan failure.
+func (c *sourceWorkflowMatchCollector) mergeRootMatches(info convoyStoreView, roots []beads.Bead) error {
+	if len(roots) == 0 {
+		return nil
+	}
+	beadSet := make([]beads.Bead, 0, len(roots))
+	for _, root := range roots {
+		workflowBeads, err := findWorkflowBeadsFromRoot(info.store, root)
+		if err != nil {
+			return err
+		}
+		beadSet = append(beadSet, workflowBeads...)
+	}
+	mergeSourceWorkflowMatch(c.matchesByLabel, sourceWorkflowStoreMatch{
+		label:  workflowDeleteStoreLabel(c.cfg, c.cityPath, info.path),
+		store:  info.store,
+		roots:  roots,
+		beads:  uniqueBeads(beadSet),
+		path:   info.path,
+		runner: workflowDeleteRunnerForPath(c.cfg, c.cityPath, info.path),
+	})
+	return nil
+}
+
+// recordScanFailure records a store whose scan failed: it remembers the first
+// error, marks the store failed and skipped, and returns the wrapped error only
+// when the failed store is the strict selected source store (so the caller
+// aborts). Otherwise it returns nil so the walk tolerates the failure.
+func (c *sourceWorkflowMatchCollector) recordScanFailure(index int, info convoyStoreView, currentSourceStoreRef, operation string, scanErr error) error {
+	wrapped := fmt.Errorf("%s in %s: %w", operation, workflowDeleteStoreLabel(c.cfg, c.cityPath, info.path), scanErr)
+	if c.firstScanErr == nil {
+		c.firstScanErr = wrapped
+	}
+	c.failedStores[index] = struct{}{}
+	c.skips = append(c.skips, sourceWorkflowStoreSkip{path: info.path, err: wrapped})
+
+	rootStoreRef := workflowStoreRefForDir(info.path, c.cityPath, c.cityName, c.cfg)
+	selectedStore := strings.TrimSpace(currentSourceStoreRef) != "" &&
+		sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) == sourceworkflow.NormalizeSourceStoreRef(currentSourceStoreRef)
+	if selectedStore {
+		return wrapped
+	}
+	return nil
+}
+
+// matches finalizes the deduplicated per-store match set.
+func (c *sourceWorkflowMatchCollector) matches() []sourceWorkflowStoreMatch {
+	matches := make([]sourceWorkflowStoreMatch, 0, len(c.matchesByLabel))
+	for _, match := range c.matchesByLabel {
 		match.roots = uniqueBeads(match.roots)
 		match.beads = uniqueBeads(match.beads)
 		matches = append(matches, match)
 	}
-	return matches, skips, nil
+	return matches
 }
 
 func mergeSourceWorkflowMatch(matches map[string]sourceWorkflowStoreMatch, next sourceWorkflowStoreMatch) {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -1528,9 +1529,47 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 	if err != nil {
 		return nil, skips, err
 	}
+	return collectSourceWorkflowMatchesFromStores(cfg, cityPath, sourceBeadID, sourceStoreRef, stores, skips)
+}
+
+func collectSourceWorkflowMatchesFromStores(cfg *config.City, cityPath, sourceBeadID, sourceStoreRef string, stores []convoyStoreView, skips []sourceWorkflowStoreSkip) ([]sourceWorkflowStoreMatch, []sourceWorkflowStoreSkip, error) {
 	matchesByLabel := map[string]sourceWorkflowStoreMatch{}
 	visited := map[string]struct{}{}
+	failedStores := map[int]struct{}{}
+	anyStoreScanned := false
 	cityName := loadedCityName(cfg, cityPath)
+	if selectedRef := sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef); selectedRef != "" {
+		selectedPresent := slices.ContainsFunc(stores, func(info convoyStoreView) bool {
+			return info.store != nil &&
+				sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(info.path, cityPath, cityName, cfg)) == selectedRef
+		})
+		if !selectedPresent {
+			for _, skip := range skips {
+				skipRef := sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(skip.path, cityPath, cityName, cfg))
+				if skipRef == selectedRef && skip.err != nil {
+					return nil, skips, fmt.Errorf("selected source workflow store %s is unavailable to scan: %w", selectedRef, skip.err)
+				}
+			}
+			return nil, skips, fmt.Errorf("selected source workflow store %s is unavailable to scan", selectedRef)
+		}
+	}
+	var firstScanErr error
+	recordScanFailure := func(index int, info convoyStoreView, currentSourceStoreRef, operation string, scanErr error) error {
+		wrapped := fmt.Errorf("%s in %s: %w", operation, workflowDeleteStoreLabel(cfg, cityPath, info.path), scanErr)
+		if firstScanErr == nil {
+			firstScanErr = wrapped
+		}
+		failedStores[index] = struct{}{}
+		skips = append(skips, sourceWorkflowStoreSkip{path: info.path, err: wrapped})
+
+		rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cityName, cfg)
+		selectedStore := strings.TrimSpace(currentSourceStoreRef) != "" &&
+			sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) == sourceworkflow.NormalizeSourceStoreRef(currentSourceStoreRef)
+		if selectedStore {
+			return wrapped
+		}
+		return nil
+	}
 
 	var collect func(string, string) error
 	collect = func(currentSourceID, currentSourceStoreRef string) error {
@@ -1538,7 +1577,13 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 		if currentSourceID == "" {
 			return nil
 		}
-		for _, info := range stores {
+		for i, info := range stores {
+			if info.store == nil {
+				continue
+			}
+			if _, failed := failedStores[i]; failed {
+				continue
+			}
 			rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cityName, cfg)
 			// Downward delete-source walks key by root store plus source
 			// identity. The upward finalize walk in internal/dispatch only
@@ -1550,12 +1595,27 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 			visited[visitKey] = struct{}{}
 			roots, err := sourceworkflow.ListLiveRoots(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
 			if err != nil {
-				return err
+				if strictErr := recordScanFailure(i, info, currentSourceStoreRef, "listing live source workflows", err); strictErr != nil {
+					return strictErr
+				}
+				continue
 			}
 			if len(roots) > 0 {
 				beadSet := make([]beads.Bead, 0, len(roots))
+				var beadScanErr error
 				for _, root := range roots {
-					beadSet = append(beadSet, findWorkflowBeads(info.store, root.ID)...)
+					workflowBeads, err := findWorkflowBeadsFromRoot(info.store, root)
+					if err != nil {
+						beadScanErr = err
+						break
+					}
+					beadSet = append(beadSet, workflowBeads...)
+				}
+				if beadScanErr != nil {
+					if strictErr := recordScanFailure(i, info, currentSourceStoreRef, "listing source workflow beads", beadScanErr); strictErr != nil {
+						return strictErr
+					}
+					continue
 				}
 				mergeSourceWorkflowMatch(matchesByLabel, sourceWorkflowStoreMatch{
 					label:  workflowDeleteStoreLabel(cfg, cityPath, info.path),
@@ -1568,8 +1628,12 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 			}
 			children, err := sourceWorkflowChildSources(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
 			if err != nil {
-				return err
+				if strictErr := recordScanFailure(i, info, currentSourceStoreRef, "listing source workflow children", err); strictErr != nil {
+					return strictErr
+				}
+				continue
 			}
+			anyStoreScanned = true
 			for _, child := range children {
 				if err := collect(child.ID, rootStoreRef); err != nil {
 					return err
@@ -1580,6 +1644,12 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 	}
 	if err := collect(sourceBeadID, sourceStoreRef); err != nil {
 		return nil, skips, err
+	}
+	if !anyStoreScanned {
+		if firstScanErr != nil {
+			return nil, skips, firstScanErr
+		}
+		return nil, skips, fmt.Errorf("no source workflow stores were available to scan")
 	}
 	matches := make([]sourceWorkflowStoreMatch, 0, len(matchesByLabel))
 	for _, match := range matchesByLabel {
@@ -1672,7 +1742,7 @@ func countOpenMatchedBeads(matches []sourceWorkflowStoreMatch) (int, error) {
 }
 
 // sourceWorkflowStoreSkip records a candidate store that could not be opened
-// during a source-workflow singleton scan. Tolerating unopenable stores
+// or queried during a source-workflow singleton scan. Tolerating unavailable stores
 // avoids turning a rig-local problem into a city-wide outage, but the
 // silent skip creates a correctness hole: a cross-store live root living
 // in the broken rig is invisible to the singleton check. Callers MUST
@@ -1695,10 +1765,29 @@ func formatSourceWorkflowStoreSkips(skips []sourceWorkflowStoreSkip) string {
 		parts = append(parts, fmt.Sprintf("%s (%v)", skip.path, skip.err))
 	}
 	return fmt.Sprintf(
-		"source-workflow singleton scan skipped %d unopenable store(s); cross-store roots in those stores are invisible: %s",
+		"source-workflow singleton scan skipped %d unavailable store(s); cross-store roots in those stores are invisible: %s",
 		len(skips),
 		strings.Join(parts, "; "),
 	)
+}
+
+func unscannedSourceWorkflowStoreSkips(cfg *config.City, cityPath, selectedStoreRef string, skips []sourceWorkflowStoreSkip) ([]sourceWorkflowStoreSkip, bool) {
+	selectedStoreRef = sourceworkflow.NormalizeSourceStoreRef(selectedStoreRef)
+	if selectedStoreRef == "" || len(skips) == 0 {
+		return skips, false
+	}
+	cityName := loadedCityName(cfg, cityPath)
+	unscanned := make([]sourceWorkflowStoreSkip, 0, len(skips))
+	selectedRecovered := false
+	for _, skip := range skips {
+		skipRef := sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(skip.path, cityPath, cityName, cfg))
+		if skipRef == selectedStoreRef {
+			selectedRecovered = true
+			continue
+		}
+		unscanned = append(unscanned, skip)
+	}
+	return unscanned, selectedRecovered
 }
 
 // openSourceWorkflowStores opens every candidate bead store used for
@@ -1878,6 +1967,20 @@ func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
 		}
 	}
 	return result
+}
+
+func findWorkflowBeadsFromRoot(store beads.Store, root beads.Bead) ([]beads.Bead, error) {
+	if store == nil || root.ID == "" {
+		return nil, nil
+	}
+	descendants, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+		IncludeClosed: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing descendants of workflow %s: %w", root.ID, err)
+	}
+	return uniqueBeads(append([]beads.Bead{root}, descendants...)), nil
 }
 
 func workflowBeadIDs(bb []beads.Bead) []string {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -131,6 +131,210 @@ func TestOpenSourceWorkflowStoresFailsOnlyWhenEverythingBroken(t *testing.T) {
 	}
 }
 
+type sourceWorkflowScanFailStore struct {
+	beads.Store
+	err error
+}
+
+func (s sourceWorkflowScanFailStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, s.err
+}
+
+type sourceWorkflowDescendantScanFailStore struct {
+	beads.Store
+	err error
+}
+
+func (s sourceWorkflowDescendantScanFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Metadata[beadmeta.RootBeadIDMetadataKey] != "" {
+		return nil, s.err
+	}
+	return s.Store.List(query)
+}
+
+func TestCollectSourceWorkflowMatchesSkipsNonSourceListFailure(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "healthy", Path: "rigs/healthy"},
+			{Name: "stale", Path: "rigs/stale"},
+		},
+	}
+	cityStore := beads.NewMemStore()
+	healthyStore := beads.NewMemStore()
+	root, err := healthyStore.Create(beads.Bead{
+		ID:     "wf-existing",
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:           beadmeta.KindWorkflow,
+			beadmeta.SourceBeadIDMetadataKey:   "mc-source",
+			beadmeta.SourceStoreRefMetadataKey: "city:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	staleErr := errors.New("issues.revision is missing")
+	stores := []convoyStoreView{
+		{path: cityPath, store: cityStore},
+		{path: filepath.Join(cityPath, "rigs/stale"), store: sourceWorkflowScanFailStore{Store: beads.NewMemStore(), err: staleErr}},
+		{path: filepath.Join(cityPath, "rigs/healthy"), store: healthyStore},
+	}
+
+	matches, skips, err := collectSourceWorkflowMatchesFromStores(cfg, cityPath, "mc-source", "city:test", stores, nil)
+	if err != nil {
+		t.Fatalf("collectSourceWorkflowMatchesFromStores: %v", err)
+	}
+	if len(matches) != 1 || len(matches[0].roots) != 1 || matches[0].roots[0].ID != root.ID {
+		t.Fatalf("matches = %#v, want healthy root %s", matches, root.ID)
+	}
+	if len(skips) != 1 || !strings.Contains(skips[0].path, "rigs/stale") || !errors.Is(skips[0].err, staleErr) {
+		t.Fatalf("skips = %#v, want stale rig list failure", skips)
+	}
+	if warning := formatSourceWorkflowStoreSkips(skips); !strings.Contains(warning, "revision") || !strings.Contains(warning, "invisible") {
+		t.Fatalf("warning = %q, want scan failure and degraded-coverage context", warning)
+	}
+}
+
+func TestCollectSourceWorkflowMatchesSurfacesDescendantScanFailure(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs:      []config.Rig{{Name: "stale", Path: "rigs/stale"}},
+	}
+	staleBacking := beads.NewMemStore()
+	root, err := staleBacking.Create(beads.Bead{
+		ID:     "wf-stale",
+		Title:  "stale workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:           beadmeta.KindWorkflow,
+			beadmeta.SourceBeadIDMetadataKey:   "mc-source",
+			beadmeta.SourceStoreRefMetadataKey: "city:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	descendantErr := errors.New("descendant query failed")
+	stores := []convoyStoreView{
+		{path: cityPath, store: beads.NewMemStore()},
+		{path: filepath.Join(cityPath, "rigs/stale"), store: sourceWorkflowDescendantScanFailStore{Store: staleBacking, err: descendantErr}},
+	}
+
+	matches, skips, err := collectSourceWorkflowMatchesFromStores(cfg, cityPath, "mc-source", "city:test", stores, nil)
+	if err != nil {
+		t.Fatalf("collectSourceWorkflowMatchesFromStores: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("matches = %#v, want incomplete store %s excluded", matches, root.ID)
+	}
+	if len(skips) != 1 || !errors.Is(skips[0].err, descendantErr) {
+		t.Fatalf("skips = %#v, want descendant query failure", skips)
+	}
+}
+
+func TestCollectSourceWorkflowMatchesKeepsSelectedStoreListFailureStrict(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	selectedErr := errors.New("selected store read failed")
+	stores := []convoyStoreView{
+		{path: cityPath, store: sourceWorkflowScanFailStore{Store: beads.NewMemStore(), err: selectedErr}},
+		{path: filepath.Join(cityPath, "rigs/healthy"), store: beads.NewMemStore()},
+	}
+
+	_, skips, err := collectSourceWorkflowMatchesFromStores(cfg, cityPath, "mc-source", "city:test", stores, nil)
+	if !errors.Is(err, selectedErr) {
+		t.Fatalf("collectSourceWorkflowMatchesFromStores error = %v, want selected store error %v", err, selectedErr)
+	}
+	if len(skips) != 1 || !errors.Is(skips[0].err, selectedErr) {
+		t.Fatalf("skips = %#v, want selected store failure recorded", skips)
+	}
+}
+
+func TestCollectSourceWorkflowMatchesFailsWhenSelectedStoreIsMissing(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs:      []config.Rig{{Name: "healthy", Path: "rigs/healthy"}},
+	}
+	stores := []convoyStoreView{
+		{path: filepath.Join(cityPath, "rigs/healthy"), store: beads.NewMemStore()},
+	}
+	selectedErr := errors.New("selected store reopen failed")
+	skips := []sourceWorkflowStoreSkip{{path: cityPath, err: selectedErr}}
+
+	_, _, err := collectSourceWorkflowMatchesFromStores(cfg, cityPath, "mc-source", "city:test", stores, skips)
+	if err == nil || !strings.Contains(err.Error(), "city:test") {
+		t.Fatalf("collectSourceWorkflowMatchesFromStores error = %v, want missing selected-store failure", err)
+	}
+	if !errors.Is(err, selectedErr) {
+		t.Fatalf("collectSourceWorkflowMatchesFromStores error = %v, want wrapped selected open error %v", err, selectedErr)
+	}
+}
+
+func TestUnscannedSourceWorkflowStoreSkipsExcludesRecoveredSelectedStore(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs:      []config.Rig{{Name: "stale", Path: "rigs/stale"}},
+	}
+	skips := []sourceWorkflowStoreSkip{
+		{path: cityPath, err: errors.New("selected reopen failed")},
+		{path: filepath.Join(cityPath, "rigs/stale"), err: errors.New("stale rig failed")},
+	}
+
+	unscanned, selectedRecovered := unscannedSourceWorkflowStoreSkips(cfg, cityPath, "city:test", skips)
+	if !selectedRecovered {
+		t.Fatal("selectedRecovered = false, want already-open selected store to repair its reopen skip")
+	}
+	if len(unscanned) != 1 || !strings.Contains(unscanned[0].path, "rigs/stale") {
+		t.Fatalf("unscanned skips = %#v, want only stale non-selected rig", unscanned)
+	}
+}
+
+func TestCollectSourceWorkflowMatchesFailsWhenNoStoreCanBeScanned(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "stale-a", Path: "rigs/stale-a"},
+			{Name: "stale-b", Path: "rigs/stale-b"},
+		},
+	}
+	firstErr := errors.New("first store failed")
+	stores := []convoyStoreView{
+		{path: filepath.Join(cityPath, "rigs/stale-a"), store: sourceWorkflowScanFailStore{Store: beads.NewMemStore(), err: firstErr}},
+		{path: filepath.Join(cityPath, "rigs/stale-b"), store: sourceWorkflowScanFailStore{Store: beads.NewMemStore(), err: errors.New("second store failed")}},
+	}
+
+	_, skips, err := collectSourceWorkflowMatchesFromStores(cfg, cityPath, "mc-source", "", stores, nil)
+	if !errors.Is(err, firstErr) {
+		t.Fatalf("collectSourceWorkflowMatchesFromStores error = %v, want first scan error %v", err, firstErr)
+	}
+	if len(skips) != 2 {
+		t.Fatalf("len(skips) = %d, want both failed stores recorded: %#v", len(skips), skips)
+	}
+}
+
+func TestCollectSourceWorkflowMatchesFailsWhenNoStoreIsAvailable(t *testing.T) {
+	_, _, err := collectSourceWorkflowMatchesFromStores(
+		&config.City{Workspace: config.Workspace{Name: "test"}},
+		"/city",
+		"mc-source",
+		"",
+		[]convoyStoreView{{path: "/city/rigs/nil"}},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "no source workflow stores") {
+		t.Fatalf("collectSourceWorkflowMatchesFromStores error = %v, want no-usable-store failure", err)
+	}
+}
+
 func TestWorkflowFinalizeRetriesWhenSourceWorkflowStoreScanSkipsLiveRoot(t *testing.T) {
 	cityPath := "/city"
 	cfg := &config.City{

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -490,6 +490,7 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 			return shellSlingRunner(dir, command, merged)
 		}
 	}
+	sourceWorkflowScanWarnings := make(map[string]struct{})
 	deps := slingDeps{
 		CityName: cityName,
 		CityPath: cityPath,
@@ -504,15 +505,16 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 			}, func(dir string) (beads.Store, error) {
 				return openAuthoritativeStoreAtForCity(dir, cityPath)
 			})
-			if err != nil {
+			unscannedSkips, selectedRecovered := unscannedSourceWorkflowStoreSkips(cfg, cityPath, storeRef, skips)
+			if err != nil && !selectedRecovered {
 				return nil, err
 			}
-			if len(skips) > 0 {
+			if len(unscannedSkips) > 0 {
 				// The sling callback cannot push into SlingResult from
 				// this depth, but stderr is the only channel operators
 				// look at; silence here means singleton coverage can
 				// degrade without any breadcrumb.
-				fmt.Fprintln(stderr, "warning:", formatSourceWorkflowStoreSkips(skips)) //nolint:errcheck
+				fmt.Fprintln(stderr, "warning:", formatSourceWorkflowStoreSkips(unscannedSkips)) //nolint:errcheck
 			}
 			out := make([]sling.SourceWorkflowStore, 0, len(stores))
 			for _, storeView := range stores {
@@ -522,6 +524,17 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 				})
 			}
 			return out, nil
+		},
+		SourceWorkflowStoreScanWarning: func(storeRef string, scanErr error) {
+			key := strings.TrimSpace(storeRef)
+			if _, warned := sourceWorkflowScanWarnings[key]; warned {
+				return
+			}
+			sourceWorkflowScanWarnings[key] = struct{}{}
+			fmt.Fprintln(stderr, "warning:", formatSourceWorkflowStoreSkips([]sourceWorkflowStoreSkip{{ //nolint:errcheck
+				path: storeRef,
+				err:  scanErr,
+			}}))
 		},
 	}
 

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -102,6 +102,19 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		message := fmt.Sprintf("bead prefix store %s is not registered; cannot verify bead %q", storeRef, storeBeadID)
 		return nil, http.StatusBadRequest, "missing_bead", message, nil
 	}
+	// Mirror the CLI's tolerant source-workflow scan: a non-source rig store
+	// whose live-root scan fails degrades to an operator-visible warning
+	// instead of aborting the sling. Without this sink the domain keeps every
+	// non-source scan failure fatal (internal/sling/sling_core.go), so a single
+	// schema-skewed rig store would abort every workflow-launching sling that
+	// routes through a running city. Dedup per store ref so one degraded rig
+	// warns once per request, and collect the ordered messages so they surface
+	// to the caller in the response `warnings` field, not only the server log: a
+	// running-city sling routes through this handler, so the invoking human or
+	// agent sees only the JSON response and would otherwise be blind to the
+	// degraded cross-store conflict coverage.
+	sourceWorkflowScanWarnings := make(map[string]struct{})
+	var sourceWorkflowScanMessages []string
 	deps := sling.SlingDeps{
 		CityName: s.state.CityName(),
 		CityPath: s.state.CityPath(),
@@ -111,6 +124,18 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		StoreRef: storeRef,
 		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
 			return s.sourceWorkflowStores(), nil
+		},
+		SourceWorkflowStoreScanWarning: func(scanStoreRef string, scanErr error) {
+			key := strings.TrimSpace(scanStoreRef)
+			if _, warned := sourceWorkflowScanWarnings[key]; warned {
+				return
+			}
+			sourceWorkflowScanWarnings[key] = struct{}{}
+			message := fmt.Sprintf(
+				"source-workflow singleton scan skipped unavailable store %s (%v); cross-store roots in that store are invisible",
+				scanStoreRef, scanErr)
+			sourceWorkflowScanMessages = append(sourceWorkflowScanMessages, message)
+			fmt.Fprintf(apiSlingStderr(), "warning: %s\n", message) //nolint:errcheck
 		},
 		Runner:   s.slingRunner(),
 		Router:   apiBeadRouter{server: s, store: store},
@@ -207,12 +232,20 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		return nil, http.StatusBadRequest, "invalid", err.Error(), nil
 	}
 
+	// Surface both the domain's non-fatal metadata errors and the tolerated
+	// source-workflow scan warnings to the caller. The scan messages reach only
+	// the server log otherwise, leaving a remote caller blind to degraded
+	// cross-store conflict coverage.
+	warnings := result.MetadataErrors
+	if len(sourceWorkflowScanMessages) > 0 {
+		warnings = append(append([]string(nil), result.MetadataErrors...), sourceWorkflowScanMessages...)
+	}
 	resp := &slingResponse{
 		Status:   "slung",
 		Target:   body.Target,
 		Bead:     body.Bead,
 		Mode:     mode,
-		Warnings: result.MetadataErrors,
+		Warnings: warnings,
 	}
 	if !workflowLaunch {
 		return resp, http.StatusOK, "", "", nil

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -717,6 +717,117 @@ title = "Do work"
 	}
 }
 
+// listFailBeadStore fails every List call, modeling a schema-skewed rig store
+// whose live-root scan errors lazily — the exact failure the tolerant
+// source-workflow scan is meant to survive.
+type listFailBeadStore struct {
+	beads.Store
+	err error
+}
+
+func (s listFailBeadStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, s.err
+}
+
+// TestSlingToleratesDegradedNonSourceStoreScan proves the API sling path wires
+// SourceWorkflowStoreScanWarning so a running city's sling degrades a
+// non-source rig store's failed live-root scan to a warning instead of aborting
+// the launch. The domain keeps every non-source scan failure fatal when the
+// sink is nil (internal/sling/sling_core.go), so before the fix this graph.v2
+// launch failed on the skewed "rig:stale" store — the dominant production path,
+// since a running city routes `gc sling` through this API handler rather than
+// the CLI's local sling.
+func TestSlingToleratesDegradedNonSourceStoreScan(t *testing.T) {
+	// Same compile-time flag choreography as
+	// TestSlingGraphV2RejectsLegacySourceWorkflowConflict: flip the shared
+	// FormulaV2 + graph-apply flags only after New() has run so syncFeatureFlags
+	// cannot stomp them back.
+	setFormulaV2 := formulatest.LockV2ForTest(t)
+	prevGraphApply := molecule.IsGraphApplyEnabled()
+	t.Cleanup(func() {
+		molecule.SetGraphApplyEnabled(prevGraphApply)
+	})
+
+	var capturedStderr bytes.Buffer
+	origStderr := apiSlingStderr
+	apiSlingStderr = func() io.Writer { return &capturedStderr }
+	t.Cleanup(func() { apiSlingStderr = origStderr })
+
+	srv, state := newSlingTestServer(t)
+	setFormulaV2(true)
+	molecule.SetGraphApplyEnabled(true)
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+	state.cfg.Agents = append(state.cfg.Agents,
+		config.Agent{Name: config.ControlDispatcherAgentName, MaxActiveSessions: intPtr(1)},
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "myrig", MaxActiveSessions: intPtr(1)},
+	)
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := state.stores["myrig"]
+	source, err := store.Create(beads.Bead{ID: "BL-42", Title: "test task", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A second, schema-skewed rig store that fails its live-root scan. It is not
+	// the selected source store (rig:myrig holds the source bead), so a wired
+	// sink must skip it with a warning rather than abort the singleton check.
+	scanErr := errors.New("schema v54 has no revision")
+	state.stores["stale"] = listFailBeadStore{Store: beads.NewMemStore(), err: scanErr}
+
+	body := `{"target":"myrig/worker","formula":"graph-work","attached_bead_id":"` + source.ID + `"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (a degraded non-source store must not abort the sling); body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Status     string   `json:"status"`
+		WorkflowID string   `json:"workflow_id"`
+		Warnings   []string `json:"warnings"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "slung" {
+		t.Fatalf("status = %q, want slung", resp.Status)
+	}
+	if resp.WorkflowID == "" {
+		t.Fatal("workflow_id empty, want graph.v2 launch to mint a run root despite the degraded store")
+	}
+	warning := capturedStderr.String()
+	if !strings.Contains(warning, "rig:stale") || !strings.Contains(warning, "revision") {
+		t.Fatalf("scan warning = %q, want an operator warning naming the skipped rig:stale store and its scan error", warning)
+	}
+	// The degraded-scan warning must also reach the API caller through the
+	// response `warnings` field, not only the server log: a running city routes
+	// `gc sling` through this handler, so the invoking human/agent sees only the
+	// JSON response and would otherwise be blind to the coverage degradation.
+	var respWarning string
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "rig:stale") {
+			respWarning = w
+			break
+		}
+	}
+	if respWarning == "" {
+		t.Fatalf("response warnings = %v, want an entry naming the skipped rig:stale store", resp.Warnings)
+	}
+	if !strings.Contains(respWarning, "revision") {
+		t.Fatalf("response warning = %q, want it to name the rig:stale scan error", respWarning)
+	}
+}
+
 // TestQualifySlingTarget covers the rig-aware target qualification
 // helper. Given a rigContext (derived from scope_ref for UI dispatches
 // or body.Rig for dashboard dispatches), the helper rewrites a bare

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -130,7 +130,11 @@ type SlingDeps struct {
 	// SourceWorkflowStores lists every bead store that may contain workflow
 	// roots for source-workflow singleton checks and recovery.
 	SourceWorkflowStores func() ([]SourceWorkflowStore, error)
-	Tracer               func(format string, args ...any)
+	// SourceWorkflowStoreScanWarning reports a non-source store whose live-root
+	// scan failed and was skipped. When nil, scan failures remain fatal. The
+	// source store identified by StoreRef is always strict and is never skipped.
+	SourceWorkflowStoreScanWarning func(storeRef string, err error)
+	Tracer                         func(format string, args ...any)
 
 	// Narrow interfaces (matches established internal package patterns).
 	Resolver AgentResolver  // agent name resolution

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -705,95 +705,172 @@ type workflowRestoreState struct {
 func listSourceWorkflowRoots(deps SlingDeps, sourceBeadID string) ([]sourceWorkflowRoot, error) {
 	sourceStoreRef := strings.TrimSpace(deps.StoreRef)
 	if deps.SourceWorkflowStores == nil {
-		roots, err := sourceworkflow.ListLiveRoots(deps.Store, sourceBeadID, sourceStoreRef, sourceStoreRef)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]sourceWorkflowRoot, 0, len(roots))
-		for _, root := range roots {
-			out = append(out, sourceWorkflowRoot{
-				root:     root,
-				store:    deps.Store,
-				storeRef: sourceStoreRef,
-			})
-		}
-		return out, nil
+		return singleStoreSourceWorkflowRoots(deps.Store, sourceBeadID, sourceStoreRef)
 	}
 	stores, err := deps.SourceWorkflowStores()
 	if err != nil {
 		return nil, err
 	}
-	if sourceStoreRef != "" {
-		selectedPresent := slices.ContainsFunc(stores, func(info SourceWorkflowStore) bool {
-			return info.Store != nil &&
-				sourceworkflow.NormalizeSourceStoreRef(info.StoreRef) == sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef)
-		})
-		if !selectedPresent {
-			if deps.Store == nil {
-				return nil, fmt.Errorf("source workflow store %s is unavailable to scan", sourceStoreRef)
-			}
-			stores = append([]SourceWorkflowStore{{Store: deps.Store, StoreRef: sourceStoreRef}}, stores...)
-		}
+	stores, err = ensureSelectedSourceWorkflowStorePresent(stores, deps.Store, sourceStoreRef)
+	if err != nil {
+		return nil, err
 	}
-	roots := make([]sourceWorkflowRoot, 0)
-	seen := make(map[string]struct{}, len(stores))
-	scanned := 0
-	var firstScanErr error
+	c := &sourceWorkflowRootCollector{
+		deps:           deps,
+		sourceBeadID:   sourceBeadID,
+		sourceStoreRef: sourceStoreRef,
+		seen:           make(map[string]struct{}, len(stores)),
+	}
 	for i, info := range stores {
-		if info.Store == nil {
-			continue
-		}
-		rootStoreRef := strings.TrimSpace(info.StoreRef)
-		matches, err := sourceworkflow.ListLiveRoots(info.Store, sourceBeadID, sourceStoreRef, rootStoreRef)
-		if err != nil {
-			storeLabel := rootStoreRef
-			if storeLabel == "" {
-				storeLabel = fmt.Sprintf("store#%d", i)
-			}
-			wrapped := fmt.Errorf("listing live workflows in %s: %w", storeLabel, err)
-			if firstScanErr == nil {
-				firstScanErr = wrapped
-			}
-			selectedStore := sourceStoreRef != "" &&
-				rootStoreRef != "" &&
-				sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) == sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef)
-			if deps.SourceWorkflowStoreScanWarning == nil || sourceStoreRef == "" || rootStoreRef == "" || selectedStore {
-				return nil, wrapped
-			}
-			deps.SourceWorkflowStoreScanWarning(rootStoreRef, err)
-			continue
-		}
-		scanned++
-		for _, root := range matches {
-			keyScope := rootStoreRef
-			if keyScope == "" {
-				keyScope = fmt.Sprintf("store#%d", i)
-			}
-			key := keyScope + "\x00" + root.ID
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			roots = append(roots, sourceWorkflowRoot{
-				root:     root,
-				store:    info.Store,
-				storeRef: rootStoreRef,
-			})
+		if err := c.scanStore(i, info); err != nil {
+			return nil, err
 		}
 	}
-	if scanned == 0 {
-		if firstScanErr != nil {
-			return nil, firstScanErr
+	return c.result()
+}
+
+// singleStoreSourceWorkflowRoots lists live source-workflow roots when the deps
+// expose only one store (no cross-store SourceWorkflowStores enumerator). Every
+// scan failure is fatal here because there is no non-selected store to tolerate.
+func singleStoreSourceWorkflowRoots(store beads.Store, sourceBeadID, sourceStoreRef string) ([]sourceWorkflowRoot, error) {
+	roots, err := sourceworkflow.ListLiveRoots(store, sourceBeadID, sourceStoreRef, sourceStoreRef)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]sourceWorkflowRoot, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, sourceWorkflowRoot{
+			root:     root,
+			store:    store,
+			storeRef: sourceStoreRef,
+		})
+	}
+	return out, nil
+}
+
+// ensureSelectedSourceWorkflowStorePresent guarantees the selected source store
+// is scanned. When a specific source store ref was requested but is absent from
+// the enumerated stores, it prepends the deps store — the selected store is
+// always strict — or fails when no such store is available to scan.
+func ensureSelectedSourceWorkflowStorePresent(stores []SourceWorkflowStore, fallback beads.Store, sourceStoreRef string) ([]SourceWorkflowStore, error) {
+	if sourceStoreRef == "" {
+		return stores, nil
+	}
+	selectedPresent := slices.ContainsFunc(stores, func(info SourceWorkflowStore) bool {
+		return info.Store != nil &&
+			sourceworkflow.NormalizeSourceStoreRef(info.StoreRef) == sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef)
+	})
+	if selectedPresent {
+		return stores, nil
+	}
+	if fallback == nil {
+		return nil, fmt.Errorf("source workflow store %s is unavailable to scan", sourceStoreRef)
+	}
+	return append([]SourceWorkflowStore{{Store: fallback, StoreRef: sourceStoreRef}}, stores...), nil
+}
+
+// sourceWorkflowRootCollector accumulates live source-workflow roots across every
+// candidate store for a running sling. It tolerates unrelated (non-selected)
+// store scan failures — warning through the deps sink — while keeping the
+// selected source store strict, and dedups roots by store scope and root ID.
+type sourceWorkflowRootCollector struct {
+	deps           SlingDeps
+	sourceBeadID   string
+	sourceStoreRef string
+
+	roots        []sourceWorkflowRoot
+	seen         map[string]struct{}
+	scanned      int
+	firstScanErr error
+}
+
+// scanStore scans one candidate store for live source-workflow roots. A nil
+// store is ignored. A tolerated non-selected scan failure warns and returns nil
+// so the walk continues; a selected-store (or otherwise non-tolerable) failure
+// returns the wrapped error to abort.
+func (c *sourceWorkflowRootCollector) scanStore(index int, info SourceWorkflowStore) error {
+	if info.Store == nil {
+		return nil
+	}
+	rootStoreRef := strings.TrimSpace(info.StoreRef)
+	matches, err := sourceworkflow.ListLiveRoots(info.Store, c.sourceBeadID, c.sourceStoreRef, rootStoreRef)
+	if err != nil {
+		return c.recordScanFailure(index, rootStoreRef, err)
+	}
+	c.scanned++
+	c.appendRoots(index, info.Store, rootStoreRef, matches)
+	return nil
+}
+
+// recordScanFailure remembers the first scan error and decides whether the
+// failure may be tolerated. A tolerable failure is warned through the deps sink
+// and returns nil so the store is skipped; every other failure returns the
+// wrapped error so the caller aborts.
+func (c *sourceWorkflowRootCollector) recordScanFailure(index int, rootStoreRef string, scanErr error) error {
+	storeLabel := rootStoreRef
+	if storeLabel == "" {
+		storeLabel = fmt.Sprintf("store#%d", index)
+	}
+	wrapped := fmt.Errorf("listing live workflows in %s: %w", storeLabel, scanErr)
+	if c.firstScanErr == nil {
+		c.firstScanErr = wrapped
+	}
+	if !c.toleratesScanFailure(rootStoreRef) {
+		return wrapped
+	}
+	c.deps.SourceWorkflowStoreScanWarning(rootStoreRef, scanErr)
+	return nil
+}
+
+// toleratesScanFailure reports whether a scan failure on the given store may be
+// skipped instead of aborting the walk. Tolerance requires a configured warning
+// sink, resolved source and store refs, and a store that is not the strict
+// selected source store — so a degraded scan is never silently swallowed.
+func (c *sourceWorkflowRootCollector) toleratesScanFailure(rootStoreRef string) bool {
+	if c.deps.SourceWorkflowStoreScanWarning == nil || c.sourceStoreRef == "" || rootStoreRef == "" {
+		return false
+	}
+	return sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) !=
+		sourceworkflow.NormalizeSourceStoreRef(c.sourceStoreRef)
+}
+
+// appendRoots merges the live roots from one store into the result set, skipping
+// duplicates keyed by store scope and root ID.
+func (c *sourceWorkflowRootCollector) appendRoots(index int, store beads.Store, rootStoreRef string, matches []beads.Bead) {
+	keyScope := rootStoreRef
+	if keyScope == "" {
+		keyScope = fmt.Sprintf("store#%d", index)
+	}
+	for _, root := range matches {
+		key := keyScope + "\x00" + root.ID
+		if _, ok := c.seen[key]; ok {
+			continue
+		}
+		c.seen[key] = struct{}{}
+		c.roots = append(c.roots, sourceWorkflowRoot{
+			root:     root,
+			store:    store,
+			storeRef: rootStoreRef,
+		})
+	}
+}
+
+// result finalizes the sorted root set, applying the fail-closed fallback when
+// no store could be scanned.
+func (c *sourceWorkflowRootCollector) result() ([]sourceWorkflowRoot, error) {
+	if c.scanned == 0 {
+		if c.firstScanErr != nil {
+			return nil, c.firstScanErr
 		}
 		return nil, fmt.Errorf("no source workflow stores were available to scan")
 	}
-	slices.SortFunc(roots, func(a, b sourceWorkflowRoot) int {
+	slices.SortFunc(c.roots, func(a, b sourceWorkflowRoot) int {
 		if cmp := strings.Compare(a.storeRef, b.storeRef); cmp != 0 {
 			return cmp
 		}
 		return strings.Compare(a.root.ID, b.root.ID)
 	})
-	return roots, nil
+	return c.roots, nil
 }
 
 func pendingGraphWorkflowLaunch(rootID, sourceBeadID string, a config.Agent, method, formulaName string, deps SlingDeps) pendingSourceWorkflowLaunch {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -723,8 +723,22 @@ func listSourceWorkflowRoots(deps SlingDeps, sourceBeadID string) ([]sourceWorkf
 	if err != nil {
 		return nil, err
 	}
+	if sourceStoreRef != "" {
+		selectedPresent := slices.ContainsFunc(stores, func(info SourceWorkflowStore) bool {
+			return info.Store != nil &&
+				sourceworkflow.NormalizeSourceStoreRef(info.StoreRef) == sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef)
+		})
+		if !selectedPresent {
+			if deps.Store == nil {
+				return nil, fmt.Errorf("source workflow store %s is unavailable to scan", sourceStoreRef)
+			}
+			stores = append([]SourceWorkflowStore{{Store: deps.Store, StoreRef: sourceStoreRef}}, stores...)
+		}
+	}
 	roots := make([]sourceWorkflowRoot, 0)
 	seen := make(map[string]struct{}, len(stores))
+	scanned := 0
+	var firstScanErr error
 	for i, info := range stores {
 		if info.Store == nil {
 			continue
@@ -732,8 +746,24 @@ func listSourceWorkflowRoots(deps SlingDeps, sourceBeadID string) ([]sourceWorkf
 		rootStoreRef := strings.TrimSpace(info.StoreRef)
 		matches, err := sourceworkflow.ListLiveRoots(info.Store, sourceBeadID, sourceStoreRef, rootStoreRef)
 		if err != nil {
-			return nil, err
+			storeLabel := rootStoreRef
+			if storeLabel == "" {
+				storeLabel = fmt.Sprintf("store#%d", i)
+			}
+			wrapped := fmt.Errorf("listing live workflows in %s: %w", storeLabel, err)
+			if firstScanErr == nil {
+				firstScanErr = wrapped
+			}
+			selectedStore := sourceStoreRef != "" &&
+				rootStoreRef != "" &&
+				sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) == sourceworkflow.NormalizeSourceStoreRef(sourceStoreRef)
+			if deps.SourceWorkflowStoreScanWarning == nil || sourceStoreRef == "" || rootStoreRef == "" || selectedStore {
+				return nil, wrapped
+			}
+			deps.SourceWorkflowStoreScanWarning(rootStoreRef, err)
+			continue
 		}
+		scanned++
 		for _, root := range matches {
 			keyScope := rootStoreRef
 			if keyScope == "" {
@@ -750,6 +780,12 @@ func listSourceWorkflowRoots(deps SlingDeps, sourceBeadID string) ([]sourceWorkf
 				storeRef: rootStoreRef,
 			})
 		}
+	}
+	if scanned == 0 {
+		if firstScanErr != nil {
+			return nil, firstScanErr
+		}
+		return nil, fmt.Errorf("no source workflow stores were available to scan")
 	}
 	slices.SortFunc(roots, func(a, b sourceWorkflowRoot) int {
 		if cmp := strings.Compare(a.storeRef, b.storeRef); cmp != 0 {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -2816,6 +2817,181 @@ func TestSourceWorkflowLockScopeUsesStorePath(t *testing.T) {
 		Cfg:      cfg,
 	}); got != wantShared {
 		t.Fatalf("rig scope = %q, want shared helper scope %q", got, wantShared)
+	}
+}
+
+type sourceWorkflowListFailStore struct {
+	beads.Store
+	err error
+}
+
+func (s sourceWorkflowListFailStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, s.err
+}
+
+func TestListSourceWorkflowRootsSkipsNonSourceListFailureAndKeepsSingletonGuard(t *testing.T) {
+	sourceStore := beads.NewMemStore()
+	healthyStore := beads.NewMemStore()
+	root, err := healthyStore.Create(beads.Bead{
+		ID:     "wf-existing",
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:           beadmeta.KindWorkflow,
+			beadmeta.SourceBeadIDMetadataKey:   "mc-source",
+			beadmeta.SourceStoreRefMetadataKey: "city:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+
+	var warnings []string
+	deps := SlingDeps{
+		Store:    sourceStore,
+		StoreRef: "city:test",
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{
+				{Store: sourceStore, StoreRef: "city:test"},
+				{Store: sourceWorkflowListFailStore{Store: beads.NewMemStore(), err: errors.New("schema v54 has no revision")}, StoreRef: "rig:stale"},
+				{Store: healthyStore, StoreRef: "rig:healthy"},
+			}, nil
+		},
+		SourceWorkflowStoreScanWarning: func(storeRef string, err error) {
+			warnings = append(warnings, storeRef+": "+err.Error())
+		},
+	}
+
+	err = checkLegacySourceWorkflowConflict(deps, "mc-source")
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("checkLegacySourceWorkflowConflict error = %v, want ConflictError", err)
+	}
+	if !slices.Equal(conflictErr.WorkflowIDs, []string{root.ID}) {
+		t.Fatalf("conflicting workflow IDs = %v, want [%s]", conflictErr.WorkflowIDs, root.ID)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "rig:stale") || !strings.Contains(warnings[0], "revision") {
+		t.Fatalf("scan warnings = %q, want one warning for rig:stale revision failure", warnings)
+	}
+}
+
+func TestListSourceWorkflowRootsKeepsSourceStoreListFailureStrict(t *testing.T) {
+	readErr := errors.New("source store read failed")
+	var warned bool
+	deps := SlingDeps{
+		Store:    sourceWorkflowListFailStore{Store: beads.NewMemStore(), err: readErr},
+		StoreRef: "city:test",
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{
+				{Store: sourceWorkflowListFailStore{Store: beads.NewMemStore(), err: readErr}, StoreRef: "city:test"},
+				{Store: beads.NewMemStore(), StoreRef: "rig:healthy"},
+			}, nil
+		},
+		SourceWorkflowStoreScanWarning: func(string, error) { warned = true },
+	}
+
+	_, err := listSourceWorkflowRoots(deps, "mc-source")
+	if !errors.Is(err, readErr) {
+		t.Fatalf("listSourceWorkflowRoots error = %v, want source store error %v", err, readErr)
+	}
+	if warned {
+		t.Fatal("source store failure was downgraded to a warning")
+	}
+}
+
+func TestListSourceWorkflowRootsScansAlreadyOpenSourceStoreWhenListerOmitsIt(t *testing.T) {
+	sourceStore := beads.NewMemStore()
+	root, err := sourceStore.Create(beads.Bead{
+		ID:     "wf-selected",
+		Title:  "selected-store workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:           beadmeta.KindWorkflow,
+			beadmeta.SourceBeadIDMetadataKey:   "mc-source",
+			beadmeta.SourceStoreRefMetadataKey: "city:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	deps := SlingDeps{
+		Store:    sourceStore,
+		StoreRef: "city:test",
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{{Store: beads.NewMemStore(), StoreRef: "rig:healthy"}}, nil
+		},
+		SourceWorkflowStoreScanWarning: func(string, error) {},
+	}
+
+	err = checkLegacySourceWorkflowConflict(deps, "mc-source")
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("checkLegacySourceWorkflowConflict error = %v, want ConflictError from already-open source store", err)
+	}
+	if !slices.Equal(conflictErr.WorkflowIDs, []string{root.ID}) {
+		t.Fatalf("conflicting workflow IDs = %v, want [%s]", conflictErr.WorkflowIDs, root.ID)
+	}
+}
+
+func TestListSourceWorkflowRootsKeepsNonSourceFailureStrictWithoutWarningSink(t *testing.T) {
+	readErr := errors.New("unreported stale store")
+	deps := SlingDeps{
+		Store:    beads.NewMemStore(),
+		StoreRef: "city:test",
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{
+				{Store: beads.NewMemStore(), StoreRef: "city:test"},
+				{Store: sourceWorkflowListFailStore{Store: beads.NewMemStore(), err: readErr}, StoreRef: "rig:stale"},
+			}, nil
+		},
+	}
+
+	_, err := listSourceWorkflowRoots(deps, "mc-source")
+	if !errors.Is(err, readErr) {
+		t.Fatalf("listSourceWorkflowRoots error = %v, want unreported scan failure %v", err, readErr)
+	}
+}
+
+func TestListSourceWorkflowRootsFailsWhenSelectedAndNonSourceScansFail(t *testing.T) {
+	selectedErr := errors.New("selected store failed")
+	var warnings []string
+	deps := SlingDeps{
+		Store:    sourceWorkflowListFailStore{Store: beads.NewMemStore(), err: selectedErr},
+		StoreRef: "city:test",
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{
+				{Store: sourceWorkflowListFailStore{Store: beads.NewMemStore(), err: errors.New("stale store failed")}, StoreRef: "rig:stale"},
+				{Store: sourceWorkflowListFailStore{Store: beads.NewMemStore(), err: selectedErr}, StoreRef: "city:test"},
+			}, nil
+		},
+		SourceWorkflowStoreScanWarning: func(storeRef string, _ error) {
+			warnings = append(warnings, storeRef)
+		},
+	}
+
+	_, err := listSourceWorkflowRoots(deps, "mc-source")
+	if !errors.Is(err, selectedErr) {
+		t.Fatalf("listSourceWorkflowRoots error = %v, want selected scan error %v", err, selectedErr)
+	}
+	if !slices.Equal(warnings, []string{"rig:stale"}) {
+		t.Fatalf("scan warnings = %v, want only the skipped non-source store", warnings)
+	}
+}
+
+func TestListSourceWorkflowRootsFailsWhenListerHasNoUsableStores(t *testing.T) {
+	deps := SlingDeps{
+		Store: beads.NewMemStore(),
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{{StoreRef: "rig:nil"}}, nil
+		},
+		SourceWorkflowStoreScanWarning: func(string, error) {},
+	}
+
+	_, err := listSourceWorkflowRoots(deps, "mc-source")
+	if err == nil || !strings.Contains(err.Error(), "no source workflow stores") {
+		t.Fatalf("listSourceWorkflowRoots error = %v, want no-usable-store failure", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extend the existing cross-store open-failure policy to stores that open lazily but fail their first `List`.
- Keep the selected/source store strict, including when the independently reopened candidate list omits it; fail closed when no store can be scanned.
- Seed cleanup from the already-resolved workflow root, then perform one strict descendant `List`; this replaces the prior `Get` plus two `List` calls.

## Failure mode

`BdStore` opens lazily. A stale unrelated rig can therefore appear open, then fail the singleton scan when its `bd list` query references a newer column such as `issues.revision`. Before this change, one stale unrelated rig could abort `gc sling` and source-workflow cleanup/recovery scans across the city.

Non-selected failures now continue only when the caller provides an operator-visible warning sink. The selected store, missing-store cases, and dispatch finalization remain fail-closed. Lazy `List` warnings from `gc sling` are deduplicated per store reference.

## Testing

- [x] Focused regression tests, repeated three times (`internal/sling`, `cmd/gc`)
- [x] `make test-fast-parallel` after rebasing onto current `main`
- [x] Pre-push fast shard gate (all eight jobs passed independently)
- [x] `go vet ./...`
- [x] `.githooks/pre-commit`
- Integration shards: not run. This boundary-only change is covered by hermetic in-memory store tests plus the full fast baseline.

## Review council

- Semantic correctness: approved after selected-store omission and strict descendant-enumeration fixes.
- Failure policy: approved after preserving the selected open error with `%w` and suppressing false warnings for recovered selected stores.
- Performance/test efficiency: approved. Healthy paths add no `List`; each failed store is queried at most once per recursive collection; cleanup for each matched root drops from `Get` plus two `List` calls to one descendant `List`.

## Checklist

- [x] Tracked by bead `ga-icvsu3`
- [x] Added tests for happy paths and failure boundaries
- [x] No CLI syntax, persisted-schema, documentation, or migration changes
