### PR TITLE
fix(pack): pin recursive commands to invoking gc

### DIFF
--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -283,6 +283,8 @@ func readDiscoveredHelp(entry config.DiscoveredCommand) string {
 	return strings.TrimSpace(string(data))
 }
 
+var resolveInvokingExecutable = os.Executable
+
 func discoveredHelpRequested(args []string) bool {
 	for _, arg := range args {
 		if arg == "--" {
@@ -318,7 +320,11 @@ func runDiscoveredCommand(entry config.DiscoveredCommand, cityPath, cityName str
 	// Pack commands are extensions of this exact gc process. Pin recursive
 	// calls to the invoking executable instead of inheriting an ambient GC_BIN
 	// (or falling back to a different `gc` on PATH).
-	exe, _ := os.Executable()
+	exe, err := resolveInvokingExecutable()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc %s %s: resolving invoking gc executable: %v\n", entry.BindingName, strings.Join(entry.Command, " "), err) //nolint:errcheck
+		return 1
+	}
 	cmd.Env = pinInvokingGCBinary(cmd.Env, exe)
 	cmd.Env = mergeCanonicalScopeDoltEnv(cmd.Env, cityPath)
 	disableProductMetricsForChild(cmd)

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -315,6 +315,11 @@ func runDiscoveredCommand(entry config.DiscoveredCommand, cityPath, cityName str
 		"GC_PACK_NAME="+entry.PackName,
 		"GC_CITY_NAME="+cityName,
 	)
+	// Pack commands are extensions of this exact gc process. Pin recursive
+	// calls to the invoking executable instead of inheriting an ambient GC_BIN
+	// (or falling back to a different `gc` on PATH).
+	exe, _ := os.Executable()
+	cmd.Env = pinInvokingGCBinary(cmd.Env, exe)
 	cmd.Env = mergeCanonicalScopeDoltEnv(cmd.Env, cityPath)
 	disableProductMetricsForChild(cmd)
 
@@ -327,6 +332,14 @@ func runDiscoveredCommand(entry config.DiscoveredCommand, cityPath, cityName str
 		return 1
 	}
 	return 0
+}
+
+func pinInvokingGCBinary(env []string, executable string) []string {
+	env = removeEnvKey(env, "GC_BIN")
+	if executable == "" {
+		return env
+	}
+	return append(env, "GC_BIN="+executable)
 }
 
 // mergeCanonicalScopeDoltEnv projects the city's canonical Dolt

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -152,6 +152,38 @@ func TestPinInvokingGCBinary_ReplacesAmbientValue(t *testing.T) {
 	}
 }
 
+func TestRunDiscoveredCommand_FailsClosedWhenInvokingExecutableCannotBeResolved(t *testing.T) {
+	old := resolveInvokingExecutable
+	resolveInvokingExecutable = func() (string, error) {
+		return "", errors.New("executable unavailable")
+	}
+	t.Cleanup(func() { resolveInvokingExecutable = old })
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "must-not-run.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho ran\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entry := config.DiscoveredCommand{
+		BindingName: "test",
+		Command:     []string{"status"},
+		RunScript:   scriptPath,
+		SourceDir:   dir,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDiscoveredCommand(entry, dir, "testcity", nil, strings.NewReader(""), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want child command not to run", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "resolving invoking gc executable: executable unavailable") {
+		t.Fatalf("stderr = %q, want executable resolution error", got)
+	}
+}
+
 const packCommandProcessHelperArg = "pack-command-process-helper"
 
 type packCommandProcessInvocation struct {

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -128,6 +128,30 @@ echo "otel=$OTEL_SERVICE_NAME"
 	}
 }
 
+func TestPinInvokingGCBinary_ReplacesAmbientValue(t *testing.T) {
+	env := []string{"PATH=/bin", "GC_BIN=/tmp/stale-installed-gc", "HOME=/tmp/home"}
+	got := pinInvokingGCBinary(env, "/tmp/current-gc")
+
+	values := make(map[string][]string)
+	for _, entry := range got {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = append(values[key], value)
+		}
+	}
+	if values := values["GC_BIN"]; len(values) != 1 || values[0] != "/tmp/current-gc" {
+		t.Fatalf("GC_BIN values = %q, want [%q]", values, "/tmp/current-gc")
+	}
+	if values := values["PATH"]; len(values) != 1 || values[0] != "/bin" {
+		t.Fatalf("PATH values = %q, want [%q]", values, "/bin")
+	}
+	for _, entry := range pinInvokingGCBinary(env, "") {
+		if strings.HasPrefix(entry, "GC_BIN=") {
+			t.Fatalf("empty executable retained ambient GC_BIN in %q", entry)
+		}
+	}
+}
+
 const packCommandProcessHelperArg = "pack-command-process-helper"
 
 type packCommandProcessInvocation struct {


### PR DESCRIPTION
## Summary

- Set GC_BIN for discovered pack commands to the exact executable running the command.
- Remove any stale ambient GC_BIN before adding the canonical value.
- Fail closed when os.Executable is unavailable instead of retaining a stale binary path.

Discovered commands are extensions of the invoking gc process. In a mixed installation, inheriting an older GC_BIN can make a recursive pack command jump to a different build than the one that loaded the pack.

## Regression proof

On unchanged upstream main at 7f3dcbc00, a test-only reproduction failed because the child environment retained /tmp/stale-installed-gc instead of the invoking test executable. The production change makes the focused regression test pass.

## Tests

- [x] go test ./cmd/gc -run '^TestPinInvokingGCBinary_ReplacesAmbientValue$' -count=1
- [x] go test -count=1 ./internal/testpolicy/resourcecensus -run '^TestRepositoryLedgerMatchesCensusAndDocumentation$'
- [x] make build
- [x] formatting, full lint, and vet stages from make check
- [ ] make check fully green on this macOS checkout

make check reached the repository test stage. Existing macOS failures in cmd/gc, internal/api, internal/beads/contract, internal/productmetrics, and internal/runtime/tmux reproduced on pristine 7f3dcbc00 without this production change. This remains a draft while that repository-wide baseline is disclosed rather than reported as green.