### PR TITLE
fix(cli): skip pack discovery for private helpers

### DIFF
--- a/cmd/gc/root_argv.go
+++ b/cmd/gc/root_argv.go
@@ -13,11 +13,26 @@ type rootCommandOptions struct {
 
 func rootCommandOptionsForArgs(args []string) rootCommandOptions {
 	command, ok := firstRootCommand(args)
-	discoverPackCommands := !ok || command != "metrics"
+	discoverPackCommands := !ok || !rootCommandSkipsPackDiscovery(command)
 	return rootCommandOptions{
 		invocationArgs:            append([]string(nil), args...),
 		discoverPackCommands:      discoverPackCommands,
 		eagerPackCommandDiscovery: discoverPackCommands,
+	}
+}
+
+// rootCommandSkipsPackDiscovery identifies built-in helper surfaces that must
+// stay independent of pack config loading. The Beads provider calls the Dolt
+// helpers while a controller reload is itself refreshing and composing packs;
+// rediscovering pack commands there contends on the same cache and can turn a
+// small scope initialization into a minutes-long reload. These commands are
+// native-only and can never resolve to a pack binding.
+func rootCommandSkipsPackDiscovery(command string) bool {
+	switch command {
+	case "metrics", "git-credential", "dolt-state", "dolt-config", "bd-store-bridge":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/cmd/gc/root_argv_test.go
+++ b/cmd/gc/root_argv_test.go
@@ -60,7 +60,7 @@ func TestFirstRootCommandMatchesPersistentScopeGrammar(t *testing.T) {
 	}
 }
 
-func TestRootCommandOptionsSkipPackDiscoveryOnlyForMetrics(t *testing.T) {
+func TestRootCommandOptionsSkipPackDiscoveryForPrivateHelpersAndMetrics(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -72,6 +72,10 @@ func TestRootCommandOptionsSkipPackDiscoveryOnlyForMetrics(t *testing.T) {
 		{name: "scoped metrics", args: []string{"--city", "/tmp/city", "--rig=tower", "metrics", "status"}, skip: true},
 		{name: "remote context metrics", args: []string{"--context=prod", "metrics", "status"}, skip: true},
 		{name: "remote URL metrics", args: []string{"--city-url", "https://city.example", "--city-name=remote", "metrics", "status"}, skip: true},
+		{name: "credential helper", args: []string{"git-credential", "get"}, skip: true},
+		{name: "dolt state helper", args: []string{"dolt-state", "allocate-port", "--city", "/tmp/city"}, skip: true},
+		{name: "scoped dolt config helper", args: []string{"--city", "/tmp/city", "dolt-config", "normalize-scope"}, skip: true},
+		{name: "beads store bridge helper", args: []string{"bd-store-bridge", "--dir", "/tmp/rig", "list"}, skip: true},
 		{name: "ordinary", args: []string{"status"}},
 		{name: "metrics is city value", args: []string{"--city", "metrics", "status"}},
 		{name: "after terminator", args: []string{"--", "metrics"}},


### PR DESCRIPTION
## Summary

Keep native private helper commands independent of pack-command discovery:

- git-credential
- dolt-state
- dolt-config
- bd-store-bridge

These helpers are invoked by the Beads provider while controller reload can itself be composing and refreshing packs. Rediscovering pack commands from those native-only paths re-enters config loading and can contend on the same cache.

## Regression proof

On unchanged upstream main at 7f3dcbc00, a test-only reproduction showed all four helper commands enabling pack discovery. The focused table test now proves they skip discovery while ordinary commands still discover packs.

## Tests

- [x] go test ./cmd/gc -run '^TestRootCommandOptionsSkipPackDiscoveryForPrivateHelpersAndMetrics$' -count=1
- [x] go test -count=1 ./internal/testpolicy/resourcecensus -run '^TestRepositoryLedgerMatchesCensusAndDocumentation$'
- [x] make build
- [x] make fmt-check
- [x] make lint-changed
- [x] ICU-aware go vet ./cmd/gc
- [ ] make check

The full repository gate is intentionally left open on this draft. A same-base run on the sibling focused fix passes build, format, full lint, and vet, then encounters existing macOS test failures that reproduce on pristine upstream source.