### PR TITLE
fix(packs): avoid full bundled cache walk on reload

### DIFF
--- a/internal/packman/install.go
+++ b/internal/packman/install.go
@@ -108,11 +108,13 @@ func InstallLocked(cityRoot string) (*Lockfile, error) {
 }
 
 // EnsureBundledPacksCurrent repairs any bundled pack synthetic caches that were
-// written by a different binary version. Each call to EnsureRepoInCache for a
-// bundled source validates the cache against the running binary's embedded
-// content and re-materializes it when the hashes differ. This prevents the
-// config loader's strict content-hash check from failing after a binary upgrade
-// where the running controller and the most-recently-installed binary differ.
+// written by a different binary version. A matching marker is enough on this
+// controller hot path: it binds the cache to the running binary's embedded
+// content hash and canonical commit without walking the materialized file set.
+// A missing or stale marker falls through to EnsureRepoInCache, which performs
+// full validation under the shared cache lock and re-materializes when needed.
+// This prevents binary-upgrade skew without serializing every config reload on
+// a full walk of the bundled repository.
 //
 // Callers that need to ensure all packs (including remote git clones) are
 // present should use InstallLocked instead.
@@ -134,6 +136,13 @@ func EnsureBundledPacksCurrent(cityRoot string) error {
 	for _, source := range sources {
 		pack := lock.Packs[source]
 		if pack.Commit == "" {
+			continue
+		}
+		cachePath, err := RepoCachePath(source, pack.Commit)
+		if err != nil {
+			return err
+		}
+		if builtinpacks.ValidateSyntheticRepoFast(cachePath, pack.Commit) == nil {
 			continue
 		}
 		if _, err := EnsureRepoInCache(cityRoot, source, pack.Commit); err != nil {

--- a/internal/packman/install_test.go
+++ b/internal/packman/install_test.go
@@ -800,6 +800,24 @@ content_hash = "sha256:000000000000000000000000000000000000000000000000000000000
 	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err != nil {
 		t.Fatalf("ValidateSyntheticRepo after repair: %v", err)
 	}
+
+	// An unrelated file makes the full integrity walk fail while leaving the
+	// binary/commit marker valid. The reload hot path must trust that marker and
+	// avoid re-materializing the entire shared cache.
+	sentinel := filepath.Join(cacheDir, "reload-fast-path-sentinel")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("WriteFile(sentinel): %v", err)
+	}
+	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err == nil {
+		t.Fatal("expected full validation to reject the unrelated sentinel")
+	}
+
+	if err := EnsureBundledPacksCurrent(city); err != nil {
+		t.Fatalf("EnsureBundledPacksCurrent: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("marker fast path re-materialized the cache: %v", err)
+	}
 }
 
 func TestEnsureBundledPacksCurrentSkipsNonBundledPacks(t *testing.T) {


### PR DESCRIPTION
## Summary

Use the synthetic-repository marker fast path before running full bundled-cache validation in EnsureBundledPacksCurrent.

A valid marker binds the cache to the running binary content and canonical commit. Missing or stale markers still fall through to EnsureRepoInCache for locked full validation and repair. This keeps binary-upgrade self-healing while avoiding a full materialized-tree walk on every controller reload.

This complements #3874, which applies the same fast validator to other warm pack-preflight paths.

## Regression proof

On unchanged upstream main at 7f3dcbc00, a test-only reproduction added an unrelated sentinel to a marker-valid synthetic cache. EnsureBundledPacksCurrent re-materialized the cache and removed the sentinel, proving it performed the full walk. The regression test now proves a valid marker preserves the cache while the existing stale-marker assertions still prove repair.

## Tests

- [x] go test ./internal/packman ./internal/config ./internal/builtinpacks -count=1
- [x] go test -count=1 ./internal/testpolicy/resourcecensus -run '^TestRepositoryLedgerMatchesCensusAndDocumentation$'
- [x] make build
- [x] make fmt-check
- [x] make lint-changed
- [x] ICU-aware go vet ./internal/packman ./internal/config ./internal/builtinpacks
- [ ] make check

The full repository gate is intentionally left open on this draft. A same-base run on the sibling focused fix passes build, format, full lint, and vet, then encounters existing macOS test failures that reproduce on pristine upstream source.