### PR TITLE
fix(sling): resolve source beads through authoritative stores

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -425,7 +425,13 @@ func doConvoyListFallback(cityPath string, jsonOut bool, stdout, stderr io.Write
 }
 
 func convoyStoreCandidates(cfg *config.City, cityPath, beadID string) []string {
-	if rawBeadsProviderForScope(cityPath, cityPath) == "file" && !fileStoreUsesScopedRoots(cityPath) {
+	return convoyStoreCandidatesWithProvider(cfg, cityPath, beadID, func(scopeRoot string) string {
+		return rawBeadsProviderForScope(scopeRoot, cityPath)
+	})
+}
+
+func convoyStoreCandidatesWithProvider(cfg *config.City, cityPath, beadID string, providerForScope func(string) string) []string {
+	if providerForScope(cityPath) == "file" && !fileStoreUsesScopedRoots(cityPath) {
 		legacyCityOnly := true
 		if cfg != nil {
 			for _, rig := range cfg.Rigs {
@@ -433,7 +439,7 @@ func convoyStoreCandidates(cfg *config.City, cityPath, beadID string) []string {
 					continue
 				}
 				scopeRoot := resolveStoreScopeRoot(cityPath, rig.Path)
-				if rawBeadsProviderForScope(scopeRoot, cityPath) != "file" || (!samePath(scopeRoot, cityPath) && scopeUsesFileStoreContract(scopeRoot)) {
+				if providerForScope(scopeRoot) != "file" || (!samePath(scopeRoot, cityPath) && scopeUsesFileStoreContract(scopeRoot)) {
 					legacyCityOnly = false
 					break
 				}

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1723,7 +1723,13 @@ func openSourceWorkflowStores(cfg *config.City, cityPath, beadID string) ([]conv
 // It takes the store-opening callback explicitly so tests can inject broken
 // rig stores without touching the filesystem.
 func openSourceWorkflowStoresWith(cfg *config.City, cityPath, beadID string, openStore func(string) (beads.Store, error)) ([]convoyStoreView, []sourceWorkflowStoreSkip, error) {
-	candidates := convoyStoreCandidates(cfg, cityPath, beadID)
+	return openSourceWorkflowStoresWithProvider(cfg, cityPath, beadID, func(scopeRoot string) string {
+		return rawBeadsProviderForScope(scopeRoot, cityPath)
+	}, openStore)
+}
+
+func openSourceWorkflowStoresWithProvider(cfg *config.City, cityPath, beadID string, providerForScope func(string) string, openStore func(string) (beads.Store, error)) ([]convoyStoreView, []sourceWorkflowStoreSkip, error) {
+	candidates := convoyStoreCandidatesWithProvider(cfg, cityPath, beadID, providerForScope)
 	var (
 		stores   = make([]convoyStoreView, 0, len(candidates))
 		skips    []sourceWorkflowStoreSkip

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -499,7 +499,9 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 		Store:    store,
 		StoreRef: storeRef,
 		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
-			stores, skips, err := openSourceWorkflowStoresWith(cfg, cityPath, "", func(dir string) (beads.Store, error) {
+			stores, skips, err := openSourceWorkflowStoresWithProvider(cfg, cityPath, "", func(scopeRoot string) string {
+				return authoritativeBeadsProviderForScope(scopeRoot, cityPath)
+			}, func(dir string) (beads.Store, error) {
 				return openAuthoritativeStoreAtForCity(dir, cityPath)
 			})
 			if err != nil {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -499,7 +499,9 @@ func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title strin
 		Store:    store,
 		StoreRef: storeRef,
 		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
-			stores, skips, err := openSourceWorkflowStores(cfg, cityPath, "")
+			stores, skips, err := openSourceWorkflowStoresWith(cfg, cityPath, "", func(dir string) (beads.Store, error) {
+				return openAuthoritativeStoreAtForCity(dir, cityPath)
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -282,7 +282,7 @@ func readSlingStdinBead() (title, description, errCode, errMsg string) {
 // cmdSlingWithJSON. On failure it returns a non-empty (errCode, errMsg) pair.
 func openSlingStore(cfg *config.City, cityPath, beadOrFormula string, sourceBead existingSlingSourceBead, a config.Agent) (storeDir string, store beads.Store, errCode, errMsg string) {
 	if sourceBead.exists {
-		s, err := openStoreAtForCity(sourceBead.storeDir, cityPath)
+		s, err := openAuthoritativeStoreAtForCity(sourceBead.storeDir, cityPath)
 		if err != nil {
 			return "", nil, "store_open_failed", fmt.Sprintf("gc sling: opening store %s: %v", sourceBead.storeDir, err)
 		}
@@ -530,7 +530,7 @@ func loadSlingCityConfig(cityPath string) (*config.City, *config.Provenance, err
 
 func slingStoreEnvWithError(cfg *config.City, cityPath, storeDir string) (map[string]string, error) {
 	storeEnv := map[string]string{}
-	switch provider := rawBeadsProviderForScope(storeDir, cityPath); {
+	switch provider := authoritativeBeadsProviderForScope(storeDir, cityPath); {
 	case provider == "file":
 		// Built-in routing now goes through beads.Store; custom queries own any
 		// provider-specific shell environment when they opt out of that path.
@@ -608,7 +608,7 @@ func resolveSlingStoreRoot(cfg *config.City, cityPath, beadOrFormula string, a c
 
 func openSlingStoreForSource(cfg *config.City, cityPath, beadOrFormula string, a config.Agent) (string, beads.Store, error) {
 	storeDir := resolveSlingStoreRoot(cfg, cityPath, beadOrFormula, a)
-	store, err := openStoreAtForCity(storeDir, cityPath)
+	store, err := openAuthoritativeStoreAtForCity(storeDir, cityPath)
 	if err != nil {
 		return "", nil, fmt.Errorf("opening store %s: %w", storeDir, err)
 	}
@@ -627,7 +627,7 @@ func probeExistingSlingSourceBead(cfg *config.City, cityPath, beadID string) (ex
 	if !ok {
 		return existingSlingSourceBead{}, nil
 	}
-	store, err := openStoreAtForCity(storeDir, cityPath)
+	store, err := openAuthoritativeStoreAtForCity(storeDir, cityPath)
 	if err != nil {
 		return existingSlingSourceBead{}, fmt.Errorf("opening store %s: %w", storeDir, err)
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4886,13 +4886,18 @@ func TestSlingSourceWorkflowStoreCandidatesUseAuthoritativeProviders(t *testing.
 	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ensurePersistedScopeLocalFileStore(rigPath); err != nil {
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"local"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	cfg := &config.City{Rigs: []config.Rig{{Name: "local", Path: rigPath}}}
 	providers := make(map[string]string)
-	stores, _, err := openSourceWorkflowStoresWith(cfg, cityPath, "", func(dir string) (beads.Store, error) {
+	stores, _, err := openSourceWorkflowStoresWithProvider(cfg, cityPath, "", func(scopeRoot string) string {
+		return authoritativeBeadsProviderForScope(scopeRoot, cityPath)
+	}, func(dir string) (beads.Store, error) {
 		providers[dir] = authoritativeBeadsProviderForScope(dir, cityPath)
 		return beads.NewMemStore(), nil
 	})
@@ -4905,8 +4910,8 @@ func TestSlingSourceWorkflowStoreCandidatesUseAuthoritativeProviders(t *testing.
 	if got := providers[cityPath]; got != "bd" {
 		t.Fatalf("city candidate provider = %q, want bd despite ambient GC_BEADS=file", got)
 	}
-	if got := providers[rigPath]; got != "file" {
-		t.Fatalf("rig candidate provider = %q, want file", got)
+	if got := providers[rigPath]; got != "bd" {
+		t.Fatalf("rig candidate provider = %q, want bd despite ambient GC_BEADS=file", got)
 	}
 
 	t.Setenv("GC_BEADS", "")

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4844,7 +4844,7 @@ provider = "file"
 	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("GC_BEADS", "file")
+	setScopedBeadsProviderForTest(t, "", "file")
 
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "bright-lights", Prefix: "hq"},
@@ -4875,8 +4875,7 @@ provider = "file"
 }
 
 func TestSlingSourceWorkflowStoreCandidatesUseAuthoritativeProviders(t *testing.T) {
-	t.Setenv("GC_BEADS", "file")
-	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	setScopedBeadsProviderForTest(t, "", "file")
 
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "rigs", "local")
@@ -4914,7 +4913,7 @@ func TestSlingSourceWorkflowStoreCandidatesUseAuthoritativeProviders(t *testing.
 		t.Fatalf("rig candidate provider = %q, want bd despite ambient GC_BEADS=file", got)
 	}
 
-	t.Setenv("GC_BEADS", "")
+	setScopedBeadsProviderForTest(t, "", "")
 	remoteCity := t.TempDir()
 	if err := os.WriteFile(filepath.Join(remoteCity, "city.toml"), []byte(`[workspace]
 name = "remote"

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4874,6 +4874,64 @@ provider = "file"
 	}
 }
 
+func TestSlingSourceWorkflowStoreCandidatesUseAuthoritativeProviders(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "local")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigPath); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Rigs: []config.Rig{{Name: "local", Path: rigPath}}}
+	providers := make(map[string]string)
+	stores, _, err := openSourceWorkflowStoresWith(cfg, cityPath, "", func(dir string) (beads.Store, error) {
+		providers[dir] = authoritativeBeadsProviderForScope(dir, cityPath)
+		return beads.NewMemStore(), nil
+	})
+	if err != nil {
+		t.Fatalf("openSourceWorkflowStoresWith: %v", err)
+	}
+	if len(stores) != 2 {
+		t.Fatalf("stores = %d, want city and rig candidates", len(stores))
+	}
+	if got := providers[cityPath]; got != "bd" {
+		t.Fatalf("city candidate provider = %q, want bd despite ambient GC_BEADS=file", got)
+	}
+	if got := providers[rigPath]; got != "file" {
+		t.Fatalf("rig candidate provider = %q, want file", got)
+	}
+
+	t.Setenv("GC_BEADS", "")
+	remoteCity := t.TempDir()
+	if err := os.WriteFile(filepath.Join(remoteCity, "city.toml"), []byte(`[workspace]
+name = "remote"
+
+[beads]
+provider = "exec:/tmp/remote-beads"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	remoteProviders := make(map[string]string)
+	_, _, err = openSourceWorkflowStoresWith(&config.City{}, remoteCity, "", func(dir string) (beads.Store, error) {
+		remoteProviders[dir] = authoritativeBeadsProviderForScope(dir, remoteCity)
+		return beads.NewMemStore(), nil
+	})
+	if err != nil {
+		t.Fatalf("openSourceWorkflowStoresWith(remote): %v", err)
+	}
+	if got := remoteProviders[remoteCity]; got != "exec:/tmp/remote-beads" {
+		t.Fatalf("remote candidate provider = %q, want custom exec provider unchanged", got)
+	}
+}
+
 func TestSlingFormulaRepoDirUsesCanonicalRigRoot(t *testing.T) {
 	cityPath := filepath.Join(t.TempDir(), "city")
 	deps := slingDeps{

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4819,6 +4819,60 @@ func TestResolveSlingStoreRootUsesCityRootForHQPrefix(t *testing.T) {
 	}
 }
 
+// TestResolveSlingStoreRootHQPrefixUsesBdProviderFromCityRootMetadata
+// reproduces dr-h6ze end to end at the sling layer: an HQ-prefixed bead
+// (e.g. "dr-h6ze") correctly resolves its store root to the city root, but
+// the city's own root is a Dolt-backed HQ store even though [beads]
+// provider declares "file" as the default for rigs. Source validation,
+// gc.routed_to mutation, and convoy/nudge all open the store via this same
+// (storeDir, cityPath) pair, so the provider resolved here is what every
+// downstream sling step actually talks to -- it must be "bd", not the
+// configured file default, or the bead is silently unroutable.
+func TestResolveSlingStoreRootHQPrefixUsesBdProviderFromCityRootMetadata(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "bright-lights"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "bright-lights", Prefix: "hq"},
+		Rigs: []config.Rig{
+			{Name: "alpha", Path: filepath.Join(cityPath, "rigs", "alpha"), Prefix: "al"},
+		},
+	}
+
+	storeDir := resolveSlingStoreRoot(cfg, cityPath, "hq-123", config.Agent{Dir: "alpha"})
+	if storeDir != cityPath {
+		t.Fatalf("resolveSlingStoreRoot() = %q, want city root %q", storeDir, cityPath)
+	}
+	if got := rawBeadsProviderForScope(storeDir, cityPath); got != "bd" {
+		t.Fatalf("rawBeadsProviderForScope(HQ store root) = %q, want bd (on-disk store identity, not the configured file default)", got)
+	}
+
+	// Regression guard: a normal rig store with no Dolt marker of its own
+	// still resolves through its declared file/bd contract unaffected by
+	// the city-root fix above.
+	rigStoreDir := resolveSlingStoreRoot(cfg, cityPath, "al-1", config.Agent{Dir: "alpha"})
+	wantRigDir := filepath.Join(cityPath, "rigs", "alpha")
+	if rigStoreDir != wantRigDir {
+		t.Fatalf("resolveSlingStoreRoot(rig bead) = %q, want %q", rigStoreDir, wantRigDir)
+	}
+	if got := rawBeadsProviderForScope(rigStoreDir, cityPath); got != "file" {
+		t.Fatalf("rawBeadsProviderForScope(rig store root) = %q, want file (no on-disk marker, city default preserved)", got)
+	}
+}
+
 func TestSlingFormulaRepoDirUsesCanonicalRigRoot(t *testing.T) {
 	cityPath := filepath.Join(t.TempDir(), "city")
 	deps := slingDeps{

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4844,6 +4844,7 @@ provider = "file"
 	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_BEADS", "file")
 
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "bright-lights", Prefix: "hq"},
@@ -4856,8 +4857,8 @@ provider = "file"
 	if storeDir != cityPath {
 		t.Fatalf("resolveSlingStoreRoot() = %q, want city root %q", storeDir, cityPath)
 	}
-	if got := rawBeadsProviderForScope(storeDir, cityPath); got != "bd" {
-		t.Fatalf("rawBeadsProviderForScope(HQ store root) = %q, want bd (on-disk store identity, not the configured file default)", got)
+	if got := authoritativeBeadsProviderForScope(storeDir, cityPath); got != "bd" {
+		t.Fatalf("authoritativeBeadsProviderForScope(HQ store root) = %q, want bd (on-disk store identity, not ambient GC_BEADS=file)", got)
 	}
 
 	// Regression guard: a normal rig store with no Dolt marker of its own
@@ -4868,8 +4869,8 @@ provider = "file"
 	if rigStoreDir != wantRigDir {
 		t.Fatalf("resolveSlingStoreRoot(rig bead) = %q, want %q", rigStoreDir, wantRigDir)
 	}
-	if got := rawBeadsProviderForScope(rigStoreDir, cityPath); got != "file" {
-		t.Fatalf("rawBeadsProviderForScope(rig store root) = %q, want file (no on-disk marker, city default preserved)", got)
+	if got := authoritativeBeadsProviderForScope(rigStoreDir, cityPath); got != "file" {
+		t.Fatalf("authoritativeBeadsProviderForScope(rig store root) = %q, want file (no on-disk marker, city default preserved)", got)
 	}
 }
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1329,7 +1329,15 @@ func openCompatibleFileStore(scopeRoot, cityPath string) (*beads.FileStore, erro
 }
 
 func openStoreAtForCity(storePath, cityPath string) (beads.Store, error) {
-	result, err := openStoreResultAtForCity(storePath, cityPath)
+	return openStoreAtForCityWithAuthority(storePath, cityPath, false)
+}
+
+func openAuthoritativeStoreAtForCity(storePath, cityPath string) (beads.Store, error) {
+	return openStoreAtForCityWithAuthority(storePath, cityPath, true)
+}
+
+func openStoreAtForCityWithAuthority(storePath, cityPath string, authoritative bool) (beads.Store, error) {
+	result, err := openStoreResultAtForCityWithAuthority(storePath, cityPath, gate.ModeUnset, false, authoritative)
 	if err != nil {
 		return nil, err
 	}
@@ -1347,6 +1355,10 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 // store's write discipline mid-process while rig stores keep the boot mode —
 // exactly the mixed-writer state the process latch exists to prevent.
 func openStoreResultAtForCityWithMode(storePath, cityPath string, modeOverride gate.Mode, haveMode bool) (beads.StoreOpenResult, error) {
+	return openStoreResultAtForCityWithAuthority(storePath, cityPath, modeOverride, haveMode, false)
+}
+
+func openStoreResultAtForCityWithAuthority(storePath, cityPath string, modeOverride gate.Mode, haveMode, authoritative bool) (beads.StoreOpenResult, error) {
 	runtimeCityPath := cityPath
 	if runtimeCityPath == "" {
 		runtimeCityPath = cityForStoreDir(storePath)
@@ -1354,6 +1366,9 @@ func openStoreResultAtForCityWithMode(storePath, cityPath string, modeOverride g
 	cfg, _ := loadCityConfig(runtimeCityPath, io.Discard)
 	scopeRoot := resolveStoreScopeRoot(runtimeCityPath, storePath)
 	provider := rawBeadsProviderForScope(scopeRoot, runtimeCityPath)
+	if authoritative {
+		provider = authoritativeBeadsProviderForScope(scopeRoot, runtimeCityPath)
+	}
 	switch strings.TrimSpace(provider) {
 	case "sqlite", "sqlite-cgo", "coordstore":
 		return beads.StoreOpenResult{}, fmt.Errorf(

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -669,17 +669,19 @@ func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
 	if strings.TrimSpace(os.Getenv("GC_BEADS_SCOPE_ROOT")) != "" {
 		provider = rawBeadsProviderFromConfig(runtimeCityPath)
 	}
-	if samePath(resolvedScopeRoot, runtimeCityPath) {
-		return provider
-	}
 	if strings.HasPrefix(provider, "exec:") && !providerUsesBdStoreContract(provider) {
 		return provider
 	}
 	// Mixed-provider workspaces can keep legacy bd-backed rigs under a
 	// file-backed city (and vice versa). Prefer explicit scope-local store
-	// markers over the city default so scoped commands keep talking to the
-	// rig's actual beads backend. The bd routing identity is metadata.json;
-	// config.yaml is a compatibility mirror and can survive migrations.
+	// markers over the configured default so scoped commands keep talking to
+	// the actual beads backend for that scope -- including the city root
+	// itself: a city's HQ store can be Dolt-backed while [beads].provider
+	// declares "file" as the default for rigs, so trusting the config
+	// default for the root unconditionally silently misroutes every HQ
+	// bead to a store that doesn't have it. The bd routing identity is
+	// metadata.json; config.yaml is a compatibility mirror and can survive
+	// migrations.
 	if scopeUsesBdStoreContract(resolvedScopeRoot) {
 		return "bd"
 	}

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -657,12 +657,25 @@ func cityUsesManagedDoltBeadsLifecycle(cityPath string) bool {
 }
 
 func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
+	return resolveRawBeadsProviderForScope(scopeRoot, cityPath, false)
+}
+
+// authoritativeBeadsProviderForScope resolves the provider for a store chosen
+// from an arbitrary bead ID rather than from the caller's current scope. An
+// unscoped GC_BEADS value describes the caller's command context and must not
+// mask the selected store's on-disk identity. Scope-pinned overrides and
+// custom exec providers remain deliberate selections and retain precedence.
+func authoritativeBeadsProviderForScope(scopeRoot, cityPath string) string {
+	return resolveRawBeadsProviderForScope(scopeRoot, cityPath, true)
+}
+
+func resolveRawBeadsProviderForScope(scopeRoot, cityPath string, authoritative bool) string {
 	runtimeCityPath := cityPath
 	if runtimeCityPath == "" {
 		runtimeCityPath = cityForStoreDir(scopeRoot)
 	}
 	resolvedScopeRoot := resolveStoreScopeRoot(runtimeCityPath, scopeRoot)
-	if explicit, ok := scopedBeadsProviderOverride(runtimeCityPath, resolvedScopeRoot); ok {
+	if explicit, ok := scopedBeadsProviderOverride(runtimeCityPath, resolvedScopeRoot); ok && (!authoritative || strings.TrimSpace(os.Getenv("GC_BEADS_SCOPE_ROOT")) != "") {
 		return normalizeRawBeadsProvider(runtimeCityPath, explicit)
 	}
 	provider := rawBeadsProvider(runtimeCityPath)
@@ -672,16 +685,16 @@ func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
 	if strings.HasPrefix(provider, "exec:") && !providerUsesBdStoreContract(provider) {
 		return provider
 	}
+	if !authoritative && samePath(resolvedScopeRoot, runtimeCityPath) {
+		return provider
+	}
 	// Mixed-provider workspaces can keep legacy bd-backed rigs under a
 	// file-backed city (and vice versa). Prefer explicit scope-local store
 	// markers over the configured default so scoped commands keep talking to
-	// the actual beads backend for that scope -- including the city root
-	// itself: a city's HQ store can be Dolt-backed while [beads].provider
-	// declares "file" as the default for rigs, so trusting the config
-	// default for the root unconditionally silently misroutes every HQ
-	// bead to a store that doesn't have it. The bd routing identity is
-	// metadata.json; config.yaml is a compatibility mirror and can survive
-	// migrations.
+	// the actual beads backend for that scope. Authoritative arbitrary-bead
+	// resolution also applies this check at the city root. The bd routing
+	// identity is metadata.json; config.yaml is a compatibility mirror and can
+	// survive migrations.
 	if scopeUsesBdStoreContract(resolvedScopeRoot) {
 		return "bd"
 	}

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -187,6 +187,9 @@ provider = "exec:/tmp/custom-beads"
 	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "exec:/tmp/custom-beads" {
 		t.Fatalf("rawBeadsProviderForScope() = %q, want custom exec provider", got)
 	}
+	if got := authoritativeBeadsProviderForScope(rigDir, cityDir); got != "exec:/tmp/custom-beads" {
+		t.Fatalf("authoritativeBeadsProviderForScope() = %q, want custom exec provider", got)
+	}
 }
 
 func TestRawBeadsProviderForScopeKeepsSessionOverrideScoped(t *testing.T) {
@@ -211,6 +214,9 @@ provider = "file"
 
 	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "bd" {
 		t.Fatalf("rawBeadsProviderForScope(rig) = %q, want bd", got)
+	}
+	if got := authoritativeBeadsProviderForScope(rigDir, cityDir); got != "bd" {
+		t.Fatalf("authoritativeBeadsProviderForScope(rig) = %q, want scope-pinned bd override", got)
 	}
 	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "file" {
 		t.Fatalf("rawBeadsProviderForScope(city) = %q, want file outside scoped override", got)
@@ -279,7 +285,7 @@ provider = "file"
 // default for city-root scope without ever consulting the on-disk store
 // marker -- a bead whose prefix resolves to the city root (e.g. the HQ
 // prefix) was silently pointed at the wrong backend and could never be found.
-func TestRawBeadsProviderForScopeDetectsBdMetadataAtCityRoot(t *testing.T) {
+func TestAuthoritativeBeadsProviderForScopeDetectsBdMetadataAtCityRootDespiteAmbientFile(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
 		t.Fatal(err)
@@ -295,9 +301,13 @@ provider = "file"
 	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_BEADS", "file")
 
-	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "bd" {
-		t.Fatalf("rawBeadsProviderForScope(cityRoot) = %q, want bd metadata to outrank the city's configured file default", got)
+	if got := authoritativeBeadsProviderForScope(cityDir, cityDir); got != "bd" {
+		t.Fatalf("authoritativeBeadsProviderForScope(cityRoot) = %q, want bd metadata to outrank unscoped ambient GC_BEADS=file", got)
+	}
+	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "file" {
+		t.Fatalf("rawBeadsProviderForScope(cityRoot) = %q, want caller-scope GC_BEADS=file semantics preserved", got)
 	}
 }
 

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -301,7 +301,7 @@ provider = "file"
 	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("GC_BEADS", "file")
+	setScopedBeadsProviderForTest(t, "", "file")
 
 	if got := authoritativeBeadsProviderForScope(cityDir, cityDir); got != "bd" {
 		t.Fatalf("authoritativeBeadsProviderForScope(cityRoot) = %q, want bd metadata to outrank unscoped ambient GC_BEADS=file", got)

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -272,6 +272,55 @@ provider = "file"
 	}
 }
 
+// TestRawBeadsProviderForScopeDetectsBdMetadataAtCityRoot reproduces dr-h6ze:
+// a city's own root can host a Dolt-backed HQ store even though [beads]
+// provider declares "file" as the default for rigs. Regression for the
+// samePath(scopeRoot, cityPath) shortcut that returned the configured/ambient
+// default for city-root scope without ever consulting the on-disk store
+// marker -- a bead whose prefix resolves to the city root (e.g. the HQ
+// prefix) was silently pointed at the wrong backend and could never be found.
+func TestRawBeadsProviderForScopeDetectsBdMetadataAtCityRoot(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "hq-demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "bd" {
+		t.Fatalf("rawBeadsProviderForScope(cityRoot) = %q, want bd metadata to outrank the city's configured file default", got)
+	}
+}
+
+// TestRawBeadsProviderForScopeCityRootWithoutMarkersKeepsConfiguredDefault is
+// the regression guard alongside the fix above: a city root that carries no
+// on-disk store marker at all (the common case -- no separate HQ Dolt store)
+// must keep resolving to the configured/ambient default exactly as before.
+func TestRawBeadsProviderForScopeCityRootWithoutMarkersKeepsConfiguredDefault(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "plain-demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "file" {
+		t.Fatalf("rawBeadsProviderForScope(cityRoot) = %q, want configured file default preserved when no store marker exists", got)
+	}
+}
+
 func TestConfiguredACPSessionNames_UsesProvidedSnapshot(t *testing.T) {
 	snapshot := newSessionBeadSnapshot([]beads.Bead{{
 		Type:   sessionBeadType,


### PR DESCRIPTION
## Summary

Fix `gc sling` and workflow-store discovery resolving an arbitrary source bead through the caller's ambient beads provider instead of the selected store's authoritative on-disk identity.

An unscoped `GC_BEADS=file` could therefore make a Dolt-backed city/HQ bead such as `dr-*` appear missing or undispatchable. The same split-store mismatch affected source validation, route mutation, sling runtime environment, workflow-store discovery, and singleton/conflict scans.

## Changes

- add authoritative provider/store resolution for arbitrary source-bead paths
- let city and rig Dolt metadata outrank unrelated unscoped `GC_BEADS=file`
- preserve normal caller-scoped provider semantics and explicit `GC_BEADS_SCOPE_ROOT` overrides
- preserve custom `exec:` providers, file-only stores, and remote forwarding
- use authoritative candidates consistently for workflow scans and convoy/sling paths
- cover Dolt city-root and mixed city/rig store regressions

## Verification

- pre-push `make test-fast-parallel` — pass (all 8 jobs)
- `go vet ./cmd/gc` — pass
- focused authoritative store/sling/provider tests — pass
- resource-census policy test — pass
- `git diff --check` — pass
- independent Go review — APPROVE after three fix rounds

## Operational follow-through

This PR fixes the source defect but is not deployment completion. The city tracker remains open through upstream merge, rebuilt `gc` deployment, and a real `dr-*` sling canary.
