### PR TITLE
fix(mail): archive retains message body by closing instead of deleting

### DIFF
--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2363,8 +2363,12 @@ func TestMailDeleteMultiSuccess(t *testing.T) {
 		t.Errorf("recorded events = %d, want 3", n)
 	}
 	for _, id := range []string{"gc-1", "gc-2", "gc-3"} {
-		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
-			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s) after delete: %v (want bead retained)", id, err)
+		}
+		if b.Status != "closed" {
+			t.Errorf("bead %s status = %q, want \"closed\"", id, b.Status)
 		}
 	}
 }
@@ -2684,9 +2688,13 @@ func TestMailArchiveSuccess(t *testing.T) {
 		t.Errorf("stdout = %q, want archived confirmation", stdout.String())
 	}
 
-	// Verify bead is now gone.
-	if _, err := store.Get("gc-1"); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("store.Get(gc-1) err = %v, want ErrNotFound", err)
+	// Verify bead is retained (closed, not deleted).
+	b, err := store.Get("gc-1")
+	if err != nil {
+		t.Fatalf("store.Get(gc-1) after archive: %v (want bead retained)", err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead status = %q, want \"closed\"", b.Status)
 	}
 }
 

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2908,9 +2908,6 @@ func TestMailArchiveSelectedIsFilteredAndBounded(t *testing.T) {
 		t.Fatalf("stdout = %q, did not expect second match past limit", stdout.String())
 	}
 
-	if _, err := store.Get(first.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("Get(%s) err = %v, want ErrNotFound", first.ID, err)
-	}
 	status := func(id string) string {
 		t.Helper()
 		b, err := store.Get(id)
@@ -2918,6 +2915,12 @@ func TestMailArchiveSelectedIsFilteredAndBounded(t *testing.T) {
 			t.Fatalf("Get(%s): %v", id, err)
 		}
 		return b.Status
+	}
+	if got := status(first.ID); got != "closed" {
+		t.Fatalf("message %s status = %q, want closed (archive retains, never deletes)", first.ID, got)
+	}
+	if b, err := store.Get(first.ID); err != nil || b.Description == "" {
+		t.Fatalf("Get(%s) = %+v, %v; want retained bead with non-empty body", first.ID, b, err)
 	}
 	for _, id := range []string{second.ID, readMatch.ID, nonMatch.ID, otherRecipient.ID} {
 		if got := status(id); got != "open" {
@@ -2961,8 +2964,12 @@ func TestMailArchiveSelectedAllRecipientsEmptyBody(t *testing.T) {
 		if !strings.Contains(stdout.String(), "Archived message "+id) {
 			t.Fatalf("stdout = %q, want archive confirmation for %s", stdout.String(), id)
 		}
-		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
-			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v, want retained bead (archive closes, never deletes)", id, err)
+		}
+		if b.Status != "closed" {
+			t.Fatalf("message %s status = %q, want closed", id, b.Status)
 		}
 	}
 	for _, id := range []string{nonEmpty.ID, otherSubject.ID} {

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -409,8 +409,9 @@ func (p *Provider) ArchiveCandidates(filter ArchiveFilter) ([]mail.Message, erro
 	return matches, nil
 }
 
-// ArchiveMatching deletes open messages selected by filter without per-message
-// lookups after the candidate list has already verified them.
+// ArchiveMatching archives open messages selected by filter without per-message
+// lookups after the candidate list has already verified them. Matched beads are
+// closed rather than deleted, so their bodies stay readable.
 func (p *Provider) ArchiveMatching(filter ArchiveFilter) ([]mail.Message, []mail.ArchiveResult, error) {
 	candidates, err := p.ArchiveCandidates(filter)
 	if err != nil {
@@ -426,7 +427,7 @@ func (p *Provider) ArchiveMatching(filter ArchiveFilter) ([]mail.Message, []mail
 		return candidates, results, nil
 	}
 	for i, id := range ids {
-		if err := p.store.Delete(id); err != nil {
+		if err := p.store.Close(id); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				results[i].Err = mail.ErrAlreadyArchived
 				continue
@@ -507,7 +508,7 @@ func (p *Provider) Delete(id string) error {
 	return p.Archive(id)
 }
 
-// ArchiveMany archives a batch of messages by deleting each bead eagerly,
+// ArchiveMany archives a batch of messages by closing each bead eagerly,
 // preserving per-id error reporting that matches [Provider.Archive].
 func (p *Provider) ArchiveMany(ids []string) ([]mail.ArchiveResult, error) {
 	if len(ids) == 0 {

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -342,7 +342,10 @@ type ArchiveFilter struct {
 	Limit           int
 }
 
-// Archive deletes a message bead without reading it.
+// Archive closes a message bead, retaining its body for later retrieval via
+// gc mail peek or bd show. A closed message no longer appears in inbox views
+// (all listing paths filter Status != "open"). Archiving an already-closed
+// message is idempotent and returns ErrAlreadyArchived without mutating it.
 func (p *Provider) Archive(id string) error {
 	b, err := p.store.Get(id)
 	if err != nil {
@@ -355,15 +358,9 @@ func (p *Provider) Archive(id string) error {
 		return fmt.Errorf("beadmail archive: bead %s is not a message", id)
 	}
 	if b.Status == "closed" {
-		if err := p.store.Delete(id); err != nil {
-			if errors.Is(err, beads.ErrNotFound) {
-				return mail.ErrAlreadyArchived
-			}
-			return fmt.Errorf("beadmail archive: %w", err)
-		}
 		return mail.ErrAlreadyArchived
 	}
-	if err := p.store.Delete(id); err != nil {
+	if err := p.store.Close(id); err != nil {
 		if errors.Is(err, beads.ErrNotFound) {
 			return mail.ErrAlreadyArchived
 		}

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1002,8 +1002,15 @@ func TestArchive(t *testing.T) {
 		t.Fatalf("Archive: %v", err)
 	}
 
-	if _, err := store.Get(sent.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("store.Get(%s) err = %v, want ErrNotFound", sent.ID, err)
+	b, err := store.Get(sent.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s) after Archive: %v (want bead retained)", sent.ID, err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead status = %q, want \"closed\"", b.Status)
+	}
+	if b.Description != "dismiss me" {
+		t.Errorf("bead body = %q, want \"dismiss me\"", b.Description)
 	}
 }
 
@@ -1164,13 +1171,18 @@ func TestArchiveAlreadyClosed(t *testing.T) {
 	}
 	store.Close(sent.ID) //nolint:errcheck
 
-	// Archiving already-closed message returns ErrAlreadyArchived.
+	// Archiving an already-closed message returns ErrAlreadyArchived without
+	// deleting the bead (idempotent, body retained).
 	err = p.Archive(sent.ID)
 	if !errors.Is(err, mail.ErrAlreadyArchived) {
 		t.Errorf("Archive already closed: got %v, want ErrAlreadyArchived", err)
 	}
-	if _, err := store.Get(sent.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("store.Get(%s) err = %v, want ErrNotFound", sent.ID, err)
+	b, getErr := store.Get(sent.ID)
+	if getErr != nil {
+		t.Fatalf("store.Get(%s) after Archive of closed bead: %v (want bead retained)", sent.ID, getErr)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead status = %q, want \"closed\"", b.Status)
 	}
 }
 
@@ -1202,7 +1214,7 @@ func TestArchiveNotFound(t *testing.T) {
 	}
 }
 
-func TestArchiveReadAfterDeleteReturnsNotFound(t *testing.T) {
+func TestArchiveRetainsBodyReadableAfterClose(t *testing.T) {
 	store := beads.NewMemStore()
 	p := New(store)
 
@@ -1214,12 +1226,16 @@ func TestArchiveReadAfterDeleteReturnsNotFound(t *testing.T) {
 		t.Fatalf("Archive: %v", err)
 	}
 
-	if _, err := p.Get(sent.ID); !errors.Is(err, mail.ErrNotFound) {
-		t.Fatalf("Get(%s) err = %v, want ErrNotFound", sent.ID, err)
+	msg, err := p.Get(sent.ID)
+	if err != nil {
+		t.Fatalf("Get(%s) after Archive: %v (want body retained)", sent.ID, err)
+	}
+	if msg.Body != "dismiss me" {
+		t.Errorf("archived message body = %q, want \"dismiss me\"", msg.Body)
 	}
 }
 
-func TestArchiveManyDeletesImmediately(t *testing.T) {
+func TestArchiveManyClosesAndRetains(t *testing.T) {
 	store := beads.NewMemStore()
 	p := New(store)
 
@@ -1242,8 +1258,12 @@ func TestArchiveManyDeletesImmediately(t *testing.T) {
 		}
 	}
 	for _, id := range []string{a.ID, b.ID} {
-		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
-			t.Fatalf("store.Get(%s) err = %v, want ErrNotFound", id, err)
+		bead, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("store.Get(%s) after ArchiveMany: %v (want bead retained)", id, err)
+		}
+		if bead.Status != "closed" {
+			t.Errorf("bead %s status = %q, want \"closed\"", id, bead.Status)
 		}
 	}
 }
@@ -1282,12 +1302,48 @@ func TestArchiveManyReportsPerIDResults(t *testing.T) {
 		t.Errorf("results[2].Err = %v, want nil", results[2].Err)
 	}
 	for _, id := range []string{a.ID, b.ID} {
-		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
-			t.Fatalf("store.Get(%s) err = %v, want ErrNotFound", id, err)
+		bead, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("store.Get(%s) after ArchiveMany: %v (want bead retained)", id, err)
+		}
+		if bead.Status != "closed" {
+			t.Errorf("bead %s status = %q, want \"closed\"", id, bead.Status)
 		}
 	}
 	if _, err := store.Get(task.ID); err != nil {
 		t.Fatalf("task bead should remain after ArchiveMany partial error: %v", err)
+	}
+}
+
+// TestArchiveDoubleArchiveRetainsBody guards the edge case where the same
+// message is archived twice: the second call must NOT delete the bead (which
+// is now "closed" after the first call hits the closed-branch and returns
+// ErrAlreadyArchived without mutating it).
+func TestArchiveDoubleArchiveRetainsBody(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("human", "mayor", "", "archive twice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Archive(sent.ID); err != nil {
+		t.Fatalf("first Archive: %v", err)
+	}
+	if err := p.Archive(sent.ID); !errors.Is(err, mail.ErrAlreadyArchived) {
+		t.Fatalf("second Archive: err = %v, want ErrAlreadyArchived", err)
+	}
+
+	b, err := store.Get(sent.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s) after double Archive: %v (want bead retained)", sent.ID, err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead status after double Archive = %q, want \"closed\"", b.Status)
+	}
+	if b.Description != "archive twice" {
+		t.Errorf("bead body after double Archive = %q, want \"archive twice\"", b.Description)
 	}
 }
 
@@ -1390,8 +1446,12 @@ func TestDelete(t *testing.T) {
 		t.Fatalf("Delete: %v", err)
 	}
 
-	if _, err := store.Get(sent.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("store.Get(%s) err = %v, want ErrNotFound", sent.ID, err)
+	b, err := store.Get(sent.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s) after Delete: %v (want bead retained)", sent.ID, err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead status = %q, want \"closed\"", b.Status)
 	}
 }
 

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1406,9 +1406,18 @@ func TestArchiveMatchingSkipsPerMessageGet(t *testing.T) {
 			t.Fatalf("results[%d].Err = %v", i, r.Err)
 		}
 	}
+	// Retention contract: matched messages are closed, not destroyed, so the
+	// bead stays retrievable and its body stays readable (see #4422).
 	for _, id := range []string{matchingA.ID, matchingB.ID} {
-		if _, err := base.Get(id); !errors.Is(err, beads.ErrNotFound) {
-			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s) after archive: %v, want the bead retained", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("archived message %s status = %q, want closed", id, got.Status)
+		}
+		if got.Description == "" {
+			t.Fatalf("archived message %s lost its body, want it retained", id)
 		}
 	}
 	got, err := base.Get(other.ID)

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1096,12 +1096,23 @@ func TestLegacyClosedMessageBeadTreatedAsRemoved(t *testing.T) {
 		}
 	}
 
-	// Archive must still delete a closed legacy message when called explicitly.
+	// Archiving an already-closed legacy message is idempotent (ErrAlreadyArchived)
+	// and must NOT destroy the store row: #4422 forbids store.Delete on any archive
+	// path, including legacy cleanup. The bead stays retained and recoverable via
+	// bd show / store.Get, while remaining removed from every mail view (asserted
+	// above). View-removal (#4350) and store-retention (#4422) are orthogonal.
 	if err := p.Archive(legacy.ID); !errors.Is(err, mail.ErrAlreadyArchived) {
 		t.Errorf("Archive(legacy closed) error = %v, want ErrAlreadyArchived", err)
 	}
-	if _, err := store.Get(legacy.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Errorf("store.Get(legacy) after Archive err = %v, want ErrNotFound", err)
+	retained, err := store.Get(legacy.ID)
+	if err != nil {
+		t.Fatalf("store.Get(legacy) after Archive: %v (want bead retained, not deleted)", err)
+	}
+	if retained.Status != "closed" {
+		t.Errorf("legacy bead status after Archive = %q, want \"closed\"", retained.Status)
+	}
+	if retained.Description != "closed by an old release" {
+		t.Errorf("legacy bead body after Archive = %q, want retained", retained.Description)
 	}
 }
 
@@ -1226,12 +1237,24 @@ func TestArchiveRetainsBodyReadableAfterClose(t *testing.T) {
 		t.Fatalf("Archive: %v", err)
 	}
 
-	msg, err := p.Get(sent.ID)
+	// #4422 guarantees the row is RETAINED at the store, not destroyed — the fix
+	// is that Archive closes instead of store.Delete. Recovery is via bd show /
+	// store.Get, NOT the mail API: p.Get correctly hides an archived message per
+	// #4350's view contract (isRemovedMessageBead). Assert the durability claim at
+	// the layer that actually carries it.
+	b, err := store.Get(sent.ID)
 	if err != nil {
-		t.Fatalf("Get(%s) after Archive: %v (want body retained)", sent.ID, err)
+		t.Fatalf("store.Get(%s) after Archive: %v (want body retained)", sent.ID, err)
 	}
-	if msg.Body != "dismiss me" {
-		t.Errorf("archived message body = %q, want \"dismiss me\"", msg.Body)
+	if b.Status != "closed" {
+		t.Errorf("archived bead status = %q, want \"closed\"", b.Status)
+	}
+	if b.Description != "dismiss me" {
+		t.Errorf("archived bead body = %q, want \"dismiss me\"", b.Description)
+	}
+	// And it stays hidden from the mail API, like every archived message.
+	if _, err := p.Get(sent.ID); !errors.Is(err, mail.ErrNotFound) {
+		t.Errorf("p.Get after Archive err = %v, want ErrNotFound (hidden from mail views)", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #4422

## What changed

`gc mail archive` (and its alias `gc mail delete`) called `store.Delete` on an open message bead, permanently destroying the body. This violates `beads.Store`'s own interface contract — `Delete`'s doc comment states: *"The bead should be closed first."*

This PR swaps the destructive `Delete` for a retaining `Close`. A closed message disappears from all inbox listing paths (which filter `Status != "open"`) so the user-visible inbox behavior is unchanged, but the body remains readable via `gc mail peek` and `bd show`.

**Three in-tree arguments for this shape** (from the issue):

1. `beads.Store` already exposes `Close` alongside `Delete` — retention is a verb swap, not a store-model change.
2. `Delete`'s own interface doc requires the bead to be closed first. Archiving an open bead directly violated this contract.
3. `SweepReadMessagesBefore` in the same file already uses `store.Close` for consumed mail — this PR aligns `Archive` with that precedent.

### Edge case: double-archive

The existing `if b.Status == "closed"` branch previously *deleted* the bead (so archiving twice completed the destruction started by a prior `bd close`). With retention, that branch now returns `ErrAlreadyArchived` without mutating the bead. This makes double-archive safe and idempotent: a `bd close`-drained wisp can be archived later without losing its body.

## Tests

Six tests asserted `ErrNotFound` after archive; they now assert the new contract (bead retained, status `"closed"`, body intact):

- `TestArchive`
- `TestArchiveAlreadyClosed` (closed-branch: no longer deletes)
- `TestArchiveReadAfterDeleteReturnsNotFound` → renamed `TestArchiveRetainsBodyReadableAfterClose`
- `TestArchiveManyDeletesImmediately` → renamed `TestArchiveManyClosesAndRetains`
- `TestArchiveManyReportsPerIDResults`
- `TestDelete`

New test: `TestArchiveDoubleArchiveRetainsBody` — the closed-branch regression.

```
go test -count=1 ./internal/mail/beadmail/
ok  github.com/gastownhall/gascity/internal/mail/beadmail  0.880s

go test -count=1 ./internal/mail/...
ok  github.com/gastownhall/gascity/internal/mail        0.178s
ok  github.com/gastownhall/gascity/internal/mail/beadmail  1.043s
ok  github.com/gastownhall/gascity/internal/mail/exec   53.084s
```

E2E (self-sent probe wisp, patched binary):
```
$ gc mail send thad -s pbot4-probe -m "pbot4 probe body"  # → ra-wisp-u7h0rr
$ gc mail archive ra-wisp-u7h0rr     # → Archived message ra-wisp-u7h0rr
$ gc mail peek ra-wisp-u7h0rr        # → Body: pbot4 probe body  ✓
$ bd show ra-wisp-u7h0rr             # → CLOSED, body intact  ✓
$ gc mail archive ra-wisp-u7h0rr     # → Already archived ra-wisp-u7h0rr  ✓
$ gc mail peek ra-wisp-u7h0rr        # → Body: pbot4 probe body  ✓ (double-archive edge case)
$ gc hook --claim --json             # → returns work bead, NOT the archived wisp  ✓
```