### PR TITLE
fix(mail): reply to a removed message is not-found, not a resend

### DIFF
--- a/contrib/mail-scripts/gc-mail-mcp-agent-mail
+++ b/contrib/mail-scripts/gc-mail-mcp-agent-mail
@@ -660,10 +660,20 @@ case "$op" in
       --arg registration_token "$registration_token" \
       '{project_key: $project, agent_name: $name, include_bodies: true, registration_token: $registration_token}')")
 
-    reply_to=""
+    # Confirm the original still exists in the recipient's inbox. The recipient
+    # cache can be stale: if the message was archived, deleted, or purged
+    # server-side out of band, fetch_inbox no longer returns it. Replying to a
+    # removed message must be a not-found, not a fresh send to the cached
+    # recipient. Mirrors the read/get removal checks above.
+    orig=""
     if [ -n "$result" ] && [ "$result" != "null" ] && [ "$result" != "[]" ]; then
-      reply_to=$(echo "$result" | jq -r --arg tid "$id" '[.[] | select((.id | tostring) == $tid)] | .[0].from // empty')
+      orig=$(echo "$result" | jq --arg tid "$id" '[.[] | select((.id | tostring) == $tid)] | .[0] // empty')
     fi
+    if [ -z "$orig" ] || [ "$orig" = "null" ]; then
+      message_not_found "$id"
+    fi
+
+    reply_to=$(echo "$orig" | jq -r '.from // empty')
     if [ -z "$reply_to" ]; then
       reply_to="$recipient"
     fi

--- a/internal/mail/exec/mcp_conformance_test.go
+++ b/internal/mail/exec/mcp_conformance_test.go
@@ -1,6 +1,7 @@
 package exec //nolint:revive // internal package, always imported with alias
 
 import (
+	"errors"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -56,6 +57,90 @@ func TestMCPMailConformance(t *testing.T) {
 
 		return NewProvider(wrapperPath)
 	})
+}
+
+// TestMCPMailReplyMissingOriginalIsNotFound is a regression guard for the mail
+// removal contract on the reply path. The recipient cache (msg-agent/<id>) can
+// outlive the message on the server: the original can be archived, deleted, or
+// purged out of band so that fetch_inbox no longer returns it, while the local
+// archived-state cache (msg-read/<id>) was never set. In that stale-cache
+// window, replying to the removed id must surface mail.ErrNotFound and must NOT
+// fall back to the cached recipient and deliver a fresh message.
+//
+// The generic runRemovalVisibilityContract does not cover this case because it
+// removes the target through the provider's own Archive/Delete, which sets the
+// local archived-state cache and short-circuits the reply path before it ever
+// consults fetch_inbox.
+func TestMCPMailReplyMissingOriginalIsNotFound(t *testing.T) {
+	if _, err := osexec.LookPath("jq"); err != nil {
+		t.Skip("jq not on PATH")
+	}
+	scriptPath, err := findMCPScript()
+	if err != nil {
+		t.Skipf("MCP mail script not found: %v", err)
+	}
+
+	dir := t.TempDir()
+
+	stateDir := filepath.Join(dir, "state")
+	for _, sub := range []string{"agents", "messages", "contacts"} {
+		if err := os.MkdirAll(filepath.Join(stateDir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "next_id"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte(mcpMockCurl(stateDir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapperPath := filepath.Join(dir, "mail-provider")
+	if err := os.WriteFile(wrapperPath, []byte(mcpWrapper(binDir, scriptPath, stateDir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := NewProvider(wrapperPath)
+
+	// Deliver a message so the bridge caches its recipient (msg-agent/<id>).
+	target, err := p.Send("alice", "bob", "original", "please reply later")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	messagesDir := filepath.Join(stateDir, "messages")
+
+	// Drop the message from the mock server WITHOUT going through the provider's
+	// archive/delete, so the local archived-state cache is never written but the
+	// recipient cache still points at bob and fetch_inbox now omits the id.
+	if err := os.Remove(filepath.Join(messagesDir, target.ID+".json")); err != nil {
+		t.Fatalf("remove server-side message: %v", err)
+	}
+
+	before := countMockMessages(t, messagesDir)
+
+	if _, err := p.Reply(target.ID, "bob", "too late", "must not create"); !errors.Is(err, mail.ErrNotFound) {
+		t.Errorf("Reply(missing original) error = %v, want mail.ErrNotFound", err)
+	}
+
+	if after := countMockMessages(t, messagesDir); after != before {
+		t.Errorf("Reply(missing original) delivered %d new message(s); want 0", after-before)
+	}
+}
+
+// countMockMessages counts the stored message files in the mock server state
+// directory, used to assert that a rejected reply delivers nothing.
+func countMockMessages(t *testing.T, messagesDir string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(messagesDir, "*.json"))
+	if err != nil {
+		t.Fatalf("glob mock messages: %v", err)
+	}
+	return len(matches)
 }
 
 // TestMCPMailBridgeSourceable verifies the bridge script is safely


### PR DESCRIPTION
Post-merge remediation for #4350 (`test(mail): make archive semantics executable`).

The landed range for #4350 was reviewed after merge. A post-merge review found a
correctness gap on the MCP mail bridge reply path.

## Problem
`gc-mail-mcp-agent-mail reply <id>` fell back to the cached recipient and delivered a
fresh message when the original was no longer returned by `fetch_inbox` — e.g. the
message was archived, deleted, or purged server-side while the local `msg-agent`
recipient cache was stale and the archived-state cache was never set. That violates the
mail removal contract that `Get`/`Read` already honor and that the shared provider
conformance suite asserts for `Reply` (a removed message must return `mail.ErrNotFound`
and deliver nothing).

## Fix
- **`contrib/mail-scripts/gc-mail-mcp-agent-mail`** — in the `reply` branch, select the
  original message from `fetch_inbox` and emit `message_not_found` before any
  `send_message`, mirroring the existing `read`/`get` removal checks. The existing
  `.from`-empty fallback to the cached recipient is preserved for a present-but-senderless
  original.
- **`internal/mail/exec/mcp_conformance_test.go`** — add an MCP-wrapper regression that
  seeds a delivered message, drops it from the mock server out of band (recipient cache
  intact, archived-state cache untouched), then asserts `Provider.Reply` returns
  `mail.ErrNotFound` and delivers no new message. The test fails before the fix (reply
  returns `nil` and delivers a message) and passes after.

## Tests
- `go test ./internal/mail/...` — pass (includes the full MCP conformance suite)
- `go vet ./internal/mail/...` — clean
- `bash -n contrib/mail-scripts/gc-mail-mcp-agent-mail` — clean
- full fast suite (`make test-fast-parallel`) via pre-push — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
