### PR TITLE
fix(runproj): resolve pool-step sessions — stamp gc.session_id at claim + trust it in run-detail

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -42,10 +42,13 @@ type hookClaimOps struct {
 	EmitClaimRejected hookEmitClaimRejectedFunc
 	// ResolveWorkBranch returns the git branch of the worker's worktree (dir),
 	// stamped onto the bead as gc.work_branch at claim time. Empty result (no
-	// repo / detached HEAD) skips the stamp.
+	// repo / detached HEAD) omits the branch key — the session back-reference is
+	// still stamped.
 	ResolveWorkBranch hookResolveWorkBranchFunc
-	// StampWorkBranch writes gc.work_branch onto the claimed bead. Best-effort.
-	StampWorkBranch hookStampWorkBranchFunc
+	// StampWorkMeta writes the claim-time execution-identity metadata patch
+	// (gc.work_branch and/or the durable session back-reference gc.session_id /
+	// gc.session_name) onto the claimed bead in ONE update. Best-effort.
+	StampWorkMeta hookStampWorkMetaFunc
 	// RecordSessionPointers writes the session bead's current-pointers — gc.current_run_id
 	// AND gc.active_work_bead (the claimed work bead's gc.step_id) — in ONE update, so
 	// the (run, step) tuple stays atomically consistent. Best-effort.
@@ -60,7 +63,7 @@ type (
 	hookDrainAckFunc              func(io.Writer) error
 	hookEmitClaimRejectedFunc     func(beadID, existingClaimant, attemptedClaimant string)
 	hookResolveWorkBranchFunc     func(dir string) string
-	hookStampWorkBranchFunc       func(ctx context.Context, dir string, env []string, beadID, assignee, branch string) error
+	hookStampWorkMetaFunc         func(ctx context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error
 	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
 )
 
@@ -179,8 +182,8 @@ func (ops *hookClaimOps) applyDefaults() {
 	if ops.ResolveWorkBranch == nil {
 		ops.ResolveWorkBranch = hookResolveWorkBranch
 	}
-	if ops.StampWorkBranch == nil {
-		ops.StampWorkBranch = hookStampWorkBranchWithBdStore
+	if ops.StampWorkMeta == nil {
+		ops.StampWorkMeta = hookStampWorkMetaWithBdStore
 	}
 	if ops.RecordSessionPointers == nil {
 		ops.RecordSessionPointers = hookRecordSessionPointersWithBdStore
@@ -311,7 +314,7 @@ func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions)
 }
 
 func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) int {
-	stampHookWorkBranch(bead, opts, ops, dir, stderr)
+	stampHookClaimIdentity(bead, opts, ops, dir, stderr)
 	recordHookClaimSessionPointers(bead, opts, ops, dir, stderr)
 	assigned, err := preassignHookContinuationGroup(bead, opts, ops, dir)
 	if err != nil {
@@ -420,29 +423,64 @@ func hookClaimWithBdStore(_ context.Context, dir string, env []string, beadID, a
 	return claimed, true, nil
 }
 
-// stampHookWorkBranch records the claiming worker's git branch on the bead as
-// gc.work_branch — the durable handle from the bead to its work that the close
-// gate later reads (ADR-0009). Idempotent (skips when already current) and
-// best-effort: a missing repo, detached HEAD, or write error never blocks the
-// claim.
-func stampHookWorkBranch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) {
-	branch := strings.TrimSpace(ops.ResolveWorkBranch(dir))
-	if branch == "" {
-		return
-	}
-	if strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) == branch {
+// stampHookClaimIdentity records the claiming worker's execution identity on the
+// claimed bead in ONE metadata write: gc.work_branch (the durable handle from the
+// bead to its work that the close gate later reads, ADR-0009) plus the durable
+// session back-reference gc.session_id / gc.session_name (#2843) so the dashboard
+// run-detail can resolve which session executed a pool step after the transient
+// Assignee is cleared on close. graphroute leaves pool steps unbound at route time,
+// deferring the session binding to this claim (graphroute.go:200-203).
+//
+// The patch is compare-and-skipped against the bead's current metadata and the
+// write is issued only when at least one key actually changes: this runs again on
+// every hook tick via the existing_assignment / ready_assignment adoption paths, so
+// an unconditional write would emit a bead.updated per tick per in-progress bead
+// (the cache-reconcile flood class). Best-effort: a missing repo, detached HEAD,
+// absent session, or write error never blocks the claim.
+func stampHookClaimIdentity(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) {
+	patch := hookClaimIdentityPatch(bead, opts, ops, dir)
+	if len(patch) == 0 {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
 	defer cancel()
-	if err := ops.StampWorkBranch(ctx, dir, opts.Env, bead.ID, opts.Assignee, branch); err != nil {
-		fmt.Fprintf(stderr, "gc hook --claim: stamping work_branch on %s: %v\n", bead.ID, err) //nolint:errcheck
+	if err := ops.StampWorkMeta(ctx, dir, opts.Env, bead.ID, opts.Assignee, patch); err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: stamping execution identity on %s: %v\n", bead.ID, err) //nolint:errcheck
 	}
 }
 
-func hookStampWorkBranchWithBdStore(_ context.Context, dir string, env []string, beadID, assignee, branch string) error {
+// hookClaimIdentityPatch builds the compare-and-skipped claim-time metadata patch.
+// It carries gc.work_branch when the worktree resolves a branch that differs from
+// the bead's, and the session back-reference gc.session_id / gc.session_name when
+// this is a session-run claim (GC_SESSION_ID present) of a non-control bead and the
+// values differ. Session identity is stamped even when the branch is empty — a
+// session with no worktree still needs its back-reference — but never on control
+// beads, which stay session-free by graphroute's design
+// (ApplyGraphControlRouteBinding), even when a control-dispatcher session claims one
+// through this same hook path. An empty result means every key is already current,
+// so the caller issues no write.
+func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string) map[string]string {
+	patch := map[string]string{}
+	if branch := strings.TrimSpace(ops.ResolveWorkBranch(dir)); branch != "" &&
+		strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) != branch {
+		patch[beadmeta.WorkBranchMetadataKey] = branch
+	}
+	if sessionID := hookClaimSessionID(opts.Env); sessionID != "" &&
+		!beadmeta.IsControlKind(strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey])) {
+		if strings.TrimSpace(bead.Metadata[beadmeta.SessionIDMetadataKey]) != sessionID {
+			patch[beadmeta.SessionIDMetadataKey] = sessionID
+		}
+		if sessionName := hookClaimSessionName(opts.Env); sessionName != "" &&
+			strings.TrimSpace(bead.Metadata[beadmeta.SessionNameMetadataKey]) != sessionName {
+			patch[beadmeta.SessionNameMetadataKey] = sessionName
+		}
+	}
+	return patch
+}
+
+func hookStampWorkMetaWithBdStore(_ context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error {
 	store := hookClaimBdStore(dir, env, assignee)
-	return store.Update(beadID, beads.UpdateOpts{Metadata: map[string]string{beadmeta.WorkBranchMetadataKey: branch}})
+	return store.Update(beadID, beads.UpdateOpts{Metadata: patch})
 }
 
 // recordHookClaimRunID records, on the session bead named by GC_SESSION_ID, the
@@ -546,6 +584,21 @@ func hookClaimSessionID(env []string) string {
 		}
 	}
 	return strings.TrimSpace(sessionID)
+}
+
+// hookClaimSessionName returns the session display name (GC_SESSION_NAME) from the
+// claim env — the pool slot's session/tmux name (e.g. "gc__role-mc-xxxxx") — stamped
+// onto the work bead as the durable gc.session_name back-reference so the dashboard's
+// byName index can resolve the step's session even when the raw id fails the
+// resolver's prefix gate. Empty when the env carries no session name.
+func hookClaimSessionName(env []string) string {
+	sessionName := ""
+	for _, entry := range env {
+		if k, v, ok := strings.Cut(entry, "="); ok && k == "GC_SESSION_NAME" {
+			sessionName = v
+		}
+	}
+	return strings.TrimSpace(sessionName)
 }
 
 // hookResolveWorkBranch returns the current git branch of dir, or "" when dir

--- a/cmd/gc/cmd_hook_claim_runid_test.go
+++ b/cmd/gc/cmd_hook_claim_runid_test.go
@@ -42,6 +42,7 @@ func claimOpsForRunID(beadID string, claimedMeta map[string]string, spy *recordR
 			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: claimedMeta}, true, nil
 		},
 		ResolveWorkBranch:     func(string) string { return "" }, // suppress work_branch stamp
+		StampWorkMeta:         noopStampWorkMeta,                 // keep hermetic; identity stamp asserted elsewhere
 		RecordSessionPointers: spy.fn,
 	}
 	opts := hookClaimOptions{
@@ -156,6 +157,7 @@ func TestDoHookClaimRecordsRunIDOnExistingAssignment(t *testing.T) {
 			return beads.Bead{}, false, nil
 		},
 		ResolveWorkBranch:     func(string) string { return "" }, // suppress work_branch stamp
+		StampWorkMeta:         noopStampWorkMeta,                 // keep hermetic; identity stamp asserted elsewhere
 		RecordSessionPointers: spy.fn,
 	}
 	opts := hookClaimOptions{
@@ -195,6 +197,7 @@ func TestDoHookClaimExistingAssignmentMissingSessionBeadStillReturnsWork(t *test
 			return beads.Bead{}, false, nil
 		},
 		ResolveWorkBranch:     func(string) string { return "" },
+		StampWorkMeta:         noopStampWorkMeta, // keep hermetic; identity stamp asserted elsewhere
 		RecordSessionPointers: spy.fn,
 	}
 	opts := hookClaimOptions{

--- a/cmd/gc/cmd_hook_claim_stamp_test.go
+++ b/cmd/gc/cmd_hook_claim_stamp_test.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// stampMetaSpy captures the (beadID, assignee, patch) a claim writes through the
+// StampWorkMeta seam, and lets a test inject a write error to prove the stamp
+// never fails the claim. The patch is copied so the assertion is stable.
+type stampMetaSpy struct {
+	calls    int
+	beadID   string
+	assignee string
+	patch    map[string]string
+	err      error
+}
+
+func (s *stampMetaSpy) fn(_ context.Context, _ string, _ []string, beadID, assignee string, patch map[string]string) error {
+	s.calls++
+	s.beadID, s.assignee = beadID, assignee
+	s.patch = map[string]string{}
+	for k, v := range patch {
+		s.patch[k] = v
+	}
+	return s.err
+}
+
+// noopRecordSessionPointers suppresses the session-bead pointer write so the
+// stamp tests exercise only the work-bead identity stamp.
+func noopRecordSessionPointers(context.Context, string, []string, string, string, string, string) error {
+	return nil
+}
+
+// noopStampWorkMeta suppresses the work-bead identity stamp so claim tests that
+// don't assert on it stay hermetic — the default seam issues a real bd subprocess
+// write, which fires now that a claim stamps session identity whenever GC_SESSION_ID
+// is set.
+func noopStampWorkMeta(context.Context, string, []string, string, string, map[string]string) error {
+	return nil
+}
+
+// poolClaimOps builds the seam for a pool slot claiming an unassigned,
+// route-matched candidate: the runner yields it, Claim returns it owned by us,
+// the branch resolver returns branch, and StampWorkMeta is captured by spy.
+func poolClaimOps(runner string, claimedMeta map[string]string, branch string, spy *stampMetaSpy) hookClaimOps {
+	return hookClaimOps{
+		Runner: func(string, string) (string, error) { return runner, nil },
+		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
+			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: claimedMeta}, true, nil
+		},
+		ResolveWorkBranch:     func(string) string { return branch },
+		StampWorkMeta:         spy.fn,
+		RecordSessionPointers: noopRecordSessionPointers,
+	}
+}
+
+// poolClaimOpts is a pool slot's claim options: assignee is the pool session name
+// and the env carries both GC_SESSION_ID (the session bead id) and
+// GC_SESSION_NAME (the pool session name).
+func poolClaimOpts() hookClaimOptions {
+	return hookClaimOptions{
+		Assignee:           "gc__role-mc-sess1",
+		IdentityCandidates: []string{"gc__role-mc-sess1"},
+		RouteTargets:       []string{"worker"},
+		Env:                []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"},
+		JSON:               true,
+	}
+}
+
+// TestDoHookClaimStampsSessionIdentity is the primary claim-time back-reference
+// test: a fresh pool claim stamps gc.session_id + gc.session_name onto the work
+// bead alongside gc.work_branch, in ONE patch. Fails before the fix, which stamped
+// only the branch.
+func TestDoHookClaimStampsSessionIdentity(t *testing.T) {
+	spy := &stampMetaSpy{}
+	ops := poolClaimOps(
+		`[{"id":"hw-pool","status":"open","metadata":{"gc.routed_to":"worker"}}]`,
+		map[string]string{"gc.routed_to": "worker"},
+		"bd-hw-pool",
+		spy,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", poolClaimOpts(), ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 1 {
+		t.Fatalf("StampWorkMeta calls = %d, want 1", spy.calls)
+	}
+	want := map[string]string{
+		beadmeta.WorkBranchMetadataKey:  "bd-hw-pool",
+		beadmeta.SessionIDMetadataKey:   "mc-sess1",
+		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
+	}
+	if !reflect.DeepEqual(spy.patch, want) {
+		t.Fatalf("patch = %v, want %v", spy.patch, want)
+	}
+	if spy.beadID != "hw-pool" || spy.assignee != "gc__role-mc-sess1" {
+		t.Fatalf("stamp target = bead %q assignee %q, want hw-pool / gc__role-mc-sess1", spy.beadID, spy.assignee)
+	}
+}
+
+// TestDoHookClaimStampsSessionIdentityOnAdoption covers the adoption path: a bead
+// already in_progress and owned by this session (existing_assignment, no fresh
+// Claim) still receives the session back-reference, since the stamp re-runs on
+// every hook tick that adopts the bead.
+func TestDoHookClaimStampsSessionIdentityOnAdoption(t *testing.T) {
+	spy := &stampMetaSpy{}
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) {
+			return `[{"id":"hw-adopt","status":"in_progress","assignee":"gc__role-mc-sess1","metadata":{"gc.routed_to":"worker"}}]`, nil
+		},
+		Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+			t.Error("Claim must not be called on the existing-assignment path")
+			return beads.Bead{}, false, nil
+		},
+		ResolveWorkBranch:     func(string) string { return "" }, // no worktree
+		StampWorkMeta:         spy.fn,
+		RecordSessionPointers: noopRecordSessionPointers,
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", poolClaimOpts(), ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	want := map[string]string{
+		beadmeta.SessionIDMetadataKey:   "mc-sess1",
+		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
+	}
+	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
+		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v}", spy.calls, spy.patch, want)
+	}
+}
+
+// TestDoHookClaimStampsSessionIdentityWithoutWorktree pins sessionVerify #1: when
+// the worktree resolves no branch (no repo / detached HEAD), the session
+// back-reference is STILL stamped — it must not be buried behind the branch
+// early-return.
+func TestDoHookClaimStampsSessionIdentityWithoutWorktree(t *testing.T) {
+	spy := &stampMetaSpy{}
+	ops := poolClaimOps(
+		`[{"id":"hw-nobranch","status":"open","metadata":{"gc.routed_to":"worker"}}]`,
+		map[string]string{"gc.routed_to": "worker"},
+		"", // no branch
+		spy,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", poolClaimOpts(), ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	want := map[string]string{
+		beadmeta.SessionIDMetadataKey:   "mc-sess1",
+		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
+	}
+	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
+		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v} (session id/name even with no worktree)", spy.calls, spy.patch, want)
+	}
+}
+
+// TestDoHookClaimSkipsStampWhenIdentityUnchanged pins the mandatory idempotence
+// guard (sessionVerify #2): a candidate already carrying the current branch AND
+// session identity produces NO write, so the per-tick adoption re-run does not
+// flood bead.updated events.
+func TestDoHookClaimSkipsStampWhenIdentityUnchanged(t *testing.T) {
+	spy := &stampMetaSpy{}
+	current := map[string]string{
+		"gc.routed_to":    "worker",
+		"gc.work_branch":  "bd-hw-idem",
+		"gc.session_id":   "mc-sess1",
+		"gc.session_name": "gc__role-mc-sess1",
+	}
+	ops := poolClaimOps(
+		`[{"id":"hw-idem","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-hw-idem","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1"}}]`,
+		current,
+		"bd-hw-idem",
+		spy,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", poolClaimOpts(), ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if spy.calls != 0 {
+		t.Fatalf("StampWorkMeta calls = %d, want 0 (branch + session identity already current)", spy.calls)
+	}
+}
+
+// TestDoHookClaimStampsOnlyChangedIdentityKeys proves the patch is minimal: a
+// candidate whose session identity is current but whose branch changed writes ONLY
+// the branch, leaving the unchanged session keys out of the patch.
+func TestDoHookClaimStampsOnlyChangedIdentityKeys(t *testing.T) {
+	spy := &stampMetaSpy{}
+	current := map[string]string{
+		"gc.routed_to":    "worker",
+		"gc.work_branch":  "bd-old",
+		"gc.session_id":   "mc-sess1",
+		"gc.session_name": "gc__role-mc-sess1",
+	}
+	ops := poolClaimOps(
+		`[{"id":"hw-partial","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-old","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1"}}]`,
+		current,
+		"bd-new",
+		spy,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", poolClaimOpts(), ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	want := map[string]string{beadmeta.WorkBranchMetadataKey: "bd-new"}
+	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
+		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v} (only the changed key)", spy.calls, spy.patch, want)
+	}
+}
+
+// TestDoHookClaimSkipsSessionIdentityForControlBead pins the control-bead edge
+// policy (sessionVerify #3): a control-dispatcher session claiming a control bead
+// (gc.kind in ControlKinds) must NOT acquire a session back-reference — control
+// steps stay session-free by graphroute's design — while gc.work_branch is still
+// stamped as before.
+func TestDoHookClaimSkipsSessionIdentityForControlBead(t *testing.T) {
+	spy := &stampMetaSpy{}
+	ops := poolClaimOps(
+		`[{"id":"hc-check","status":"open","metadata":{"gc.routed_to":"worker","gc.kind":"check"}}]`,
+		map[string]string{"gc.routed_to": "worker", "gc.kind": "check"},
+		"bd-hc-check",
+		spy,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", poolClaimOpts(), ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	want := map[string]string{beadmeta.WorkBranchMetadataKey: "bd-hc-check"}
+	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
+		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v} (no session keys on a control bead)", spy.calls, spy.patch, want)
+	}
+}
+
+// TestDoHookClaimSkipsSessionIdentityWhenNoSessionID: a non-session run (no
+// GC_SESSION_ID) has no session bead to reference, so neither session key is
+// stamped even when GC_SESSION_NAME happens to be set.
+func TestDoHookClaimSkipsSessionIdentityWhenNoSessionID(t *testing.T) {
+	spy := &stampMetaSpy{}
+	ops := poolClaimOps(
+		`[{"id":"hw-nosess","status":"open","metadata":{"gc.routed_to":"worker"}}]`,
+		map[string]string{"gc.routed_to": "worker"},
+		"bd-hw-nosess",
+		spy,
+	)
+	opts := poolClaimOpts()
+	opts.Env = []string{"GC_SESSION_NAME=gc__role-mc-sess1"} // GC_SESSION_ID absent
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	want := map[string]string{beadmeta.WorkBranchMetadataKey: "bd-hw-nosess"}
+	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
+		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v} (no session id ⇒ no session keys)", spy.calls, spy.patch, want)
+	}
+}
+
+// TestDoHookClaimIdentityStampFailureDoesNotFailClaim proves the stamp is
+// best-effort: a failing StampWorkMeta logs to stderr but the claim still exits 0
+// and reports the claimed bead id.
+func TestDoHookClaimIdentityStampFailureDoesNotFailClaim(t *testing.T) {
+	spy := &stampMetaSpy{err: errors.New("dolt boom")}
+	ops := poolClaimOps(
+		`[{"id":"hw-err","status":"open","metadata":{"gc.routed_to":"worker"}}]`,
+		map[string]string{"gc.routed_to": "worker"},
+		"bd-hw-err",
+		spy,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := doHookClaim("bd ready --json", "/tmp/work", poolClaimOpts(), ops, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0 (stamp error must not fail the claim); stderr=%s", code, stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID != "hw-err" || result.Reason != "claimed" {
+		t.Fatalf("claim result = %+v, want bead hw-err reason claimed", result)
+	}
+}

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -511,8 +511,8 @@ func TestDoHookClaimStampsWorkBranch(t *testing.T) {
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
 		},
 		ResolveWorkBranch: func(string) string { return "bd-hw-stamp" },
-		StampWorkBranch: func(_ context.Context, _ string, _ []string, beadID, assignee, branch string) error {
-			stampedBead, stampedAssignee, stampedBranch = beadID, assignee, branch
+		StampWorkMeta: func(_ context.Context, _ string, _ []string, beadID, assignee string, patch map[string]string) error {
+			stampedBead, stampedAssignee, stampedBranch = beadID, assignee, patch["gc.work_branch"]
 			return nil
 		},
 	}
@@ -546,7 +546,7 @@ func TestDoHookClaimSkipsStampWhenBranchUnchanged(t *testing.T) {
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker", "gc.work_branch": "bd-hw-idem"}}, true, nil
 		},
 		ResolveWorkBranch: func(string) string { return "bd-hw-idem" },
-		StampWorkBranch: func(_ context.Context, _ string, _ []string, _, _, _ string) error {
+		StampWorkMeta: func(_ context.Context, _ string, _ []string, _, _ string, _ map[string]string) error {
 			stampCalls++
 			return nil
 		},

--- a/internal/runproj/detail_sessionlink.go
+++ b/internal/runproj/detail_sessionlink.go
@@ -7,8 +7,20 @@ import (
 )
 
 // sessionIDRe gates a value before it is fed to the supervisor session routes.
-// Port of TS SESSION_ID_RE (session-id.ts) — lowercase-only, case-sensitive.
+// Port of TS SESSION_ID_RE (session-id.ts) — lowercase-only, case-sensitive. It
+// stays strict (gc/td/th or exactly-four-letter prefixes) on the NAME/assignee
+// fallback path, where an id derived from an ambiguous match must not leak.
 var sessionIDRe = regexp.MustCompile(`^(gc|td|th|[a-z]{4})-[a-z0-9-]{1,32}$`)
+
+// sessionBeadIDRe validates a DURABLE session bead id — the value gc hook --claim
+// stamps from GC_SESSION_ID (a real session bead id by provenance) and the value
+// direct routing stamps as gc.session_id. It accepts a short lowercase store prefix
+// (2-4 letters, covering city stores like mc-, ga-, gcy- that sessionIDRe rejects)
+// followed by '-' and a lowercase-alnum/'-' body, while still rejecting empties,
+// whitespace, uppercase, prefixless handles, and over-long pool-name prefixes
+// (e.g. "polecat-…", "mystery-…"). It is applied ONLY to the provenance-trusted
+// durable id, never to a name/assignee-derived value.
+var sessionBeadIDRe = regexp.MustCompile(`^[a-z]{2,4}-[a-z0-9-]{1,40}$`)
 
 // supervisorSessionIDSuffixRe extracts a trailing supervisor id from a
 // pool-qualified handle. Port of the TS suffix match in supervisorSessionIdFrom.
@@ -49,11 +61,37 @@ func buildRunSessionIndex(sessions []DashboardSession) runSessionIndex {
 	return idx
 }
 
-// runSessionLinkFor resolves a bead to a streamable session link, or (zero,
-// false) when none is usable. Port of TS runSessionLinkFor.
+// runSessionLinkFor resolves a bead to a session link, or (zero, false) when none
+// is usable. Port of TS runSessionLinkFor, hardened for durable pool-step
+// attribution.
+//
+// Resolution precedence:
+//
+//  1. Durable stamp (authoritative, INDEX-INDEPENDENT): when the step carries a
+//     gc.session_id stamped by gc hook --claim (or direct routing), that value is
+//     a real session BEAD id by provenance — it identifies the session that ran
+//     the step even after that session CLOSES and drops out of the active-only
+//     session index. It is trusted directly and never overridden by a name/assignee
+//     index match, because pool slot names are deterministic and REUSED: a byName
+//     hit on a recycled slot would mis-resolve a closed step to a DIFFERENT live
+//     session (a wrong transcript/diff link — worse than no link). The id is
+//     format-validated (sessionBeadIDRe) so garbage cannot leak.
+//
+//  2. Legacy / direct fallback (no durable stamp): resolve via the index and keep
+//     the STRICT sessionIDRe gate on the result. Only an exact byID match on the
+//     durable stamp is trusted unconditionally; a name/assignee/template match must
+//     still pass the gate, so a recycled-slot byName collision yields no link rather
+//     than a wrong one.
+//
+// Streamability is decided downstream from the step's own status
+// (detail_instances.go), so a closed step's link is inherently non-streamable
+// regardless of index membership.
 func runSessionLinkFor(bead runSnapshotBead, status string, ctx runSessionLinkContext) (RunSessionLink, bool) {
 	if status == "pending" || status == "ready" {
 		return RunSessionLink{}, false
+	}
+	if stamped := stampedSessionID(bead); stamped != "" && sessionBeadIDRe.MatchString(stamped) {
+		return linkForStampedSessionID(stamped, bead, ctx), true
 	}
 	assignee := nonEmpty(bead.assignee)
 	sessionID := sessionIDFromBead(bead, assignee)
@@ -67,6 +105,48 @@ func runSessionLinkFor(bead runSnapshotBead, status string, ctx runSessionLinkCo
 		return RunSessionLink{}, false
 	}
 	return link, true
+}
+
+// stampedSessionID returns the durable session bead id a step carries in metadata
+// (gc.session_id / its legacy and camelCase aliases), stamped at claim time or by
+// direct routing. Unlike sessionIDFromBead it does NOT fall back to the transient
+// assignee, so an empty result cleanly means "no durable stamp" — the signal that
+// the resolver must use the ambiguous, gated name fallback instead.
+func stampedSessionID(bead runSnapshotBead) string {
+	for _, key := range []string{"session_id", beadmeta.SessionIDMetadataKey, beadmeta.SessionIDCamelMetadataKey} {
+		if v := beadMeta(bead, key); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// stampedSessionName returns the durable session display name a step carries in
+// metadata (gc.session_name / aliases), or "" when absent.
+func stampedSessionName(bead runSnapshotBead) string {
+	for _, key := range []string{"session_name", beadmeta.SessionNameMetadataKey, beadmeta.SessionNameCamelMetadataKey} {
+		if v := beadMeta(bead, key); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// linkForStampedSessionID builds a session link straight from a durable stamped
+// session bead id, independent of the active session index. When that exact id is
+// still live in the index we adopt its display fields; otherwise (the session has
+// closed and left the active-only index) we keep the correct id and fall back to
+// the step's own stamped display fields — so a closed step still resolves to the
+// CORRECT session it ran on.
+func linkForStampedSessionID(sessionID string, bead runSnapshotBead, ctx runSessionLinkContext) RunSessionLink {
+	name := stampedSessionName(bead)
+	assignee := nonEmpty(bead.assignee)
+	if ctx.sessionIndex != nil {
+		if session, ok := ctx.sessionIndex.byID[sessionID]; ok {
+			return linkForSession(session, RunSessionLink{SessionID: sessionID, SessionName: name, Assignee: assignee})
+		}
+	}
+	return rawLinkFrom(sessionID, name, assignee)
 }
 
 // sessionIDFromBead resolves the supervisor session id from a bead. Port of TS
@@ -143,6 +223,10 @@ func supervisorSessionIDFrom(value string) string {
 	return suffix
 }
 
+// resolveRunSessionLink resolves rawLink against the session index for the
+// name/assignee fallback path, returning the enriched link on a match or rawLink
+// unchanged (nil index / no match). The caller always re-applies the strict
+// sessionIDRe gate, so an ambiguous match cannot leak an untrusted id.
 func resolveRunSessionLink(rawLink RunSessionLink, sessionIndex *runSessionIndex) RunSessionLink {
 	if sessionIndex == nil {
 		return rawLink

--- a/internal/runproj/detail_sessionlink_test.go
+++ b/internal/runproj/detail_sessionlink_test.go
@@ -1,6 +1,10 @@
 package runproj
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+)
 
 // TestRunSessionLinkForNormalization ports session-link.test.ts: regression
 // coverage for the rig-store / polecat "invalid session id" bug. A run records
@@ -69,4 +73,97 @@ func TestRunSessionLinkForNormalization(t *testing.T) {
 			t.Errorf("expected no link for a ready node")
 		}
 	})
+}
+
+// TestRunSessionLinkForTrustsDurableStampOverRecycledSlotName is the red-team P1
+// regression: the run-detail session index is ACTIVE-ONLY, so once the session
+// that ran a step CLOSES it leaves the index. If resolution then falls through to
+// byName on the deterministic, REUSED pool slot name, a NEW live session occupying
+// the same slot would be mis-attributed — a WRONG transcript/diff link, worse than
+// no link. The durable gc.session_id stamp must win over the recycled-slot name.
+func TestRunSessionLinkForTrustsDurableStampOverRecycledSlotName(t *testing.T) {
+	// Active-only index: S1 (mc-s1) has CLOSED and is absent; a NEW live session S2
+	// (mc-s2) now occupies the SAME recycled pool slot name gc__worker-1.
+	idx := buildRunSessionIndex([]DashboardSession{
+		{ID: "mc-s2", SessionName: "gc__worker-1", State: "active", Running: true},
+	})
+	ctx := runSessionLinkContext{sessionIndex: &idx}
+
+	// Step B ran on S1 and closed; its Assignee is cleared, so only the durable
+	// gc.session_id / gc.session_name stamp survives.
+	bead := runSnapshotBead{metadata: map[string]string{
+		beadmeta.SessionIDMetadataKey:   "mc-s1",
+		beadmeta.SessionNameMetadataKey: "gc__worker-1",
+	}}
+	link, ok := runSessionLinkFor(bead, "done", ctx)
+	if !ok {
+		t.Fatalf("expected a link from the durable stamp")
+	}
+	if link.SessionID != "mc-s1" {
+		t.Fatalf("sessionID = %q, want mc-s1 (durable stamp); MUST NOT be the recycled-slot session mc-s2", link.SessionID)
+	}
+}
+
+// TestRunSessionLinkForResolvesActiveDurableStamp: an active step stamped with a
+// live session's durable id resolves to that session (short store prefixes that
+// sessionIDRe rejects are accepted for the provenance-trusted durable id).
+func TestRunSessionLinkForResolvesActiveDurableStamp(t *testing.T) {
+	idx := buildRunSessionIndex([]DashboardSession{
+		{ID: "mc-s2", SessionName: "gc__worker-1", State: "active", Running: true},
+	})
+	ctx := runSessionLinkContext{sessionIndex: &idx}
+
+	bead := runSnapshotBead{
+		assignee: "gc__worker-1",
+		metadata: map[string]string{
+			beadmeta.SessionIDMetadataKey:   "mc-s2",
+			beadmeta.SessionNameMetadataKey: "gc__worker-1",
+		},
+	}
+	link, ok := runSessionLinkFor(bead, "working", ctx)
+	if !ok || link.SessionID != "mc-s2" {
+		t.Fatalf("link = {%q ok:%v}, want mc-s2 (live durable stamp)", link.SessionID, ok)
+	}
+}
+
+// TestRunSessionLinkForLegacyNameFallbackStaysGated covers the legacy/direct path
+// (no durable stamp): a step carrying only gc.session_name still resolves via the
+// index byName fallback, but ONLY when the resolved id passes the strict
+// sessionIDRe gate — and a byName hit onto a short-prefix (recycled-prone) session
+// is rejected rather than mis-attributed.
+func TestRunSessionLinkForLegacyNameFallbackStaysGated(t *testing.T) {
+	t.Run("gate-passing byName hit resolves", func(t *testing.T) {
+		idx := buildRunSessionIndex([]DashboardSession{
+			{ID: "gc-legacy", SessionName: "gc__solo", State: "active", Running: true},
+		})
+		ctx := runSessionLinkContext{sessionIndex: &idx}
+		bead := runSnapshotBead{metadata: map[string]string{beadmeta.SessionNameMetadataKey: "gc__solo"}}
+		link, ok := runSessionLinkFor(bead, "done", ctx)
+		if !ok || link.SessionID != "gc-legacy" {
+			t.Fatalf("link = {%q ok:%v}, want gc-legacy via gated byName", link.SessionID, ok)
+		}
+	})
+
+	t.Run("byName hit onto a short-prefix session is gated out (no wrong link)", func(t *testing.T) {
+		idx := buildRunSessionIndex([]DashboardSession{
+			{ID: "mc-live", SessionName: "gc__solo", State: "active", Running: true},
+		})
+		ctx := runSessionLinkContext{sessionIndex: &idx}
+		bead := runSnapshotBead{metadata: map[string]string{beadmeta.SessionNameMetadataKey: "gc__solo"}}
+		if _, ok := runSessionLinkFor(bead, "done", ctx); ok {
+			t.Fatalf("expected no link: a legacy byName hit onto a short-prefix session must stay gated")
+		}
+	})
+}
+
+// TestRunSessionLinkForRejectsGarbageDurableStamp: a malformed gc.session_id
+// (whitespace/uppercase/prefixless) is rejected by the durable validator and never
+// leaks a link, even though the durable path is index-independent.
+func TestRunSessionLinkForRejectsGarbageDurableStamp(t *testing.T) {
+	for _, garbage := range []string{"garbage value", "BOGUS", "nostoreprefix", "mystery-handle"} {
+		bead := runSnapshotBead{metadata: map[string]string{beadmeta.SessionIDMetadataKey: garbage}}
+		if _, ok := runSessionLinkFor(bead, "done", runSessionLinkContext{}); ok {
+			t.Errorf("expected no link for garbage durable session id %q", garbage)
+		}
+	}
 }


### PR DESCRIPTION
The dashboard run-detail showed "session unresolved for this current node" for every step of every pool-routed run (0/524 execution instances resolved on maintainer-city).

## Root cause (two independent defects)
1. **Claim-time stamp never built.** The #2843 design intends every work bead to carry a durable session back-reference so run-detail resolves the executing session after the transient Assignee is cleared on close. graphroute implements this for DIRECT routing but deliberately defers the POOL case to claim time — and `gc hook --claim` only ever stamped `gc.work_branch`, never `gc.session_id`, though `GC_SESSION_ID` is in hand at claim.
2. **Resolver gate rejects real ids.** `sessionIDRe` is a TS-supervisor port accepting only `gc`/`td`/`th`/4-letter prefixes; it rejects real OSS session-bead ids (`mc-`/`ga-`/`gcy-`), so even a live or stamped id resolved to nothing.

## Fix
- `cmd/gc/cmd_hook_claim.go`: stamp `gc.session_id` + `gc.session_name` on the claimed work bead at claim time — one combined, compare-and-skip-idempotent write; stamped even with no worktree; skipped for control beads; best-effort (never fails the claim).
- `internal/runproj/detail_sessionlink.go`: resolve the durable `gc.session_id` **first**, index-independently, so closed steps resolve to the correct session even after it leaves the active-only index; validated by a provenance-trusted `sessionBeadIDRe`. The legacy name/assignee fallback keeps the strict `sessionIDRe` gate, so a recycled pool-slot-name collision yields **no** link, never a wrong one.

## Review
Adversarially red-teamed. A wrong-attribution P1 (recycled-slot byName) was found and fixed (durable-id-first precedence); a follow-up re-verify cleared all four attack angles (sibling-preassign stamps only Assignee; retry-clone staleness self-heals, tracked ga-se3gb5; garbage rejected). RED-confirmed tests for each.

## Validation
`go build ./...`, `go vet`, `go test ./cmd/gc ./internal/runproj`, cold `make test-fast-parallel` (pre-push) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)