### PR TITLE
fix(config): store post-validation fingerprint in remote cache memoization

### DIFF
--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -413,7 +413,7 @@ func validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit stri
 		}
 		return err
 	}
-	remoteCacheValidationCache.Store(key, remoteCacheValidationEntry{fingerprint: fp})
+	remoteCacheValidationCache.Store(key, remoteCacheValidationEntry{fingerprint: remoteCacheFingerprint(cacheDir)})
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`validateInstalledRemoteCacheLocked` memoizes successful remote cache
validations via a fingerprint of cacheDir/`.git`/`.git/index` size+mtime.
The fingerprint was computed **before** validation ran, then stored
as-is on success.

`git status --porcelain` (called inside `validateLockedRemoteCache`) updates
the index as a side effect. This means the stored pre-validation fingerprint
never matches the next call's pre-validation fingerprint for the same
cache dir — every call is a cache miss and re-runs two git execs
(`rev-parse HEAD` + `status --porcelain`).

The error-recovery path (`rematerializeAbsentBundledCache`) already called
`remoteCacheFingerprint(cacheDir)` **after** the operation and stored that;
the success path inconsistently did not.

## Fix

Store `remoteCacheFingerprint(cacheDir)` after validation completes so the
next call's pre-validation fingerprint matches the stored post-validation
fingerprint.

## Measurement

City with 16 imports sharing one remote pack source (`gc status`):

| | git calls (gc) | span |
|---|---|---|
| before | 32 (16 pairs) | ~1.5s |
| after  | 2  (1 pair)   | ~0.1s |

Confirmed via `ppid`-tagged PATH shim: all 32 calls had `ppid=<gc pid>`,
all on the same cache dir, confirming sequential per-import re-validation
of an already-valid checkout.

## Tests

`TestValidateInstalledRemoteCacheLockedMemoizesSuccess` covers the
cache-hit path. `go test ./internal/config/...` passes.

Closes: ra-c3jr.2