### PR TITLE
test(doctor): stop managed Dolt servers in import-state tests

### DIFF
--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -515,6 +515,7 @@ source = ".gc/system/packs/gastown"
 func TestDoDoctorRegistersImportStateCheck(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
+	cleanupManagedDoltTestCity(t, cityDir)
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -566,6 +567,7 @@ version = "^1.0"
 func TestDoDoctorRunsImportStateCheckWhenImportInstallStateBroken(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
+	cleanupManagedDoltTestCity(t, cityDir)
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -609,6 +611,7 @@ version = "^1.0"
 func TestDoDoctorSkipsImportStateCheckWhenCityConfigInvalid(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
+	cleanupManagedDoltTestCity(t, cityDir)
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Three `doDoctor` tests create temporary cities whose default beads provider starts a managed `dolt sql-server`, but the tests did not register the established managed-Dolt test cleanup. Each test passed individually while leaving its server for the package leak guard to catch.

Register `cleanupManagedDoltTestCity` in the three owning tests. Cleanup remains at the existing lifecycle seam; this adds no sleeps, process allowlists, blanket kills, or production behavior changes.

## Verification

- Reproduced RED before the fix: all three tests reported PASS, then `TestMain` failed with exactly three leaked Dolt servers.
- `GC_FAST_UNIT=0 go test -count=1 -timeout 20m ./cmd/gc -run '^TestDoDoctor(RegistersImportStateCheck|RunsImportStateCheckWhenImportInstallStateBroken|SkipsImportStateCheckWhenCityConfigInvalid)$'`
- `make build`
- serialized `make -j1 check`
- pre-push `scripts/test-local-parallel fast` (all 8 jobs passed)

## Review

Formal `gascity-ship` pipeline passed at `0aafee689e2986b7b21f2573a4e0310d92d99fe4`:

- Claude: approve
- Codex: approve
- blocker/major findings: 0
- 29-rule contributor audit: pass
- Design capture: N/A (test-lifecycle point fix)
- Performance: N/A

This PR is intentionally limited to the baseline test-process leak that was blocking formal verification of several unrelated orchestration fixes.
