### PR TITLE
fix(cmd/gc): gc hook --claim never adopts mail message beads as work (#4419)

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -276,6 +276,9 @@ func reportHookClaimRejected(candidate, claimed beads.Bead, opts hookClaimOption
 
 func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions) (hookClaimJSONResult, beads.Bead, bool) {
 	for _, candidate := range candidates {
+		if hookClaimCandidateIsMessage(candidate) {
+			continue
+		}
 		if strings.EqualFold(strings.TrimSpace(candidate.Status), "in_progress") &&
 			hookClaimHasIdentity(candidate.Assignee, opts.IdentityCandidates) {
 			result := hookClaimJSONResult{
@@ -292,6 +295,9 @@ func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions)
 		}
 	}
 	for _, candidate := range candidates {
+		if hookClaimCandidateIsMessage(candidate) {
+			continue
+		}
 		if strings.EqualFold(strings.TrimSpace(candidate.Status), "open") &&
 			hookClaimHasIdentity(candidate.Assignee, opts.IdentityCandidates) {
 			result := hookClaimJSONResult{
@@ -308,6 +314,18 @@ func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions)
 		}
 	}
 	return hookClaimJSONResult{}, beads.Bead{}, false
+}
+
+// hookClaimCandidateIsMessage reports whether candidate is a mail message
+// bead (issue_type="message"). Mail is read, not claimed as work: a message
+// bead addressed to this session's identity has the same
+// assignee-matches-identity shape as a real existing/ready assignment, so
+// without this check it was returned by hookClaimExistingOrAssigned as work
+// ahead of any real routed work waiting in the same batch (#4419) -- not by
+// race, by construction, since this function runs before
+// claimFirstEligibleHookCandidate ever sees the routed candidates.
+func hookClaimCandidateIsMessage(candidate beads.Bead) bool {
+	return strings.EqualFold(strings.TrimSpace(candidate.Type), "message")
 }
 
 func writeHookClaimWorkResultForBead(result hookClaimJSONResult, bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -1737,6 +1737,62 @@ func TestPoolWorkerIdentityCandidatesExcludeBareTemplate(t *testing.T) {
 	}
 }
 
+// TestHookClaimSkipsMessageBeadsAheadOfRoutedWork guards against #4419:
+// hookClaimExistingOrAssigned matched any OPEN candidate whose Assignee
+// equaled one of the session's identity strings, with no type check. A mail
+// message bead (issue_type="message") addressed to this session has exactly
+// that shape, so it was returned as "ready_assignment" work ahead of real
+// routed work waiting in the same work-query batch -- not by race, by
+// construction: the message-bead-matching loop runs before
+// claimFirstEligibleHookCandidate ever sees the routed work. A build lane
+// that consumed the response would attempt to execute a mail wisp instead
+// of its actual task.
+func TestHookClaimSkipsMessageBeadsAheadOfRoutedWork(t *testing.T) {
+	const (
+		identity = "builder"
+		mailID   = "ra-wisp-qgcfg1"
+		workID   = "ga-real-work"
+	)
+	runner := func(string, string) (string, error) {
+		return `[
+			{"id":"` + mailID + `","status":"open","issue_type":"message","assignee":"` + identity + `"},
+			{"id":"` + workID + `","status":"open","issue_type":"task","assignee":"","metadata":{"gc.routed_to":"` + identity + `"}}
+		]`, nil
+	}
+	claimed := false
+	ops := hookClaimOps{
+		Runner: runner,
+		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
+			if id != workID {
+				t.Fatalf("store.Claim called for %q, want the routed work bead %q (a mail bead must never reach the claim mutation)", id, workID)
+			}
+			claimed = true
+			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Type: "task"}, true, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           identity,
+		IdentityCandidates: hookClaimIdentityCandidates(identity, "", identity, identity, identity),
+		RouteTargets:       hookClaimRouteTargets(identity, identity),
+		JSON:               true,
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr)
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID == mailID {
+		t.Fatalf("REGRESSION #4419: hook returned mail bead %q as work instead of routed work %q (%+v)", mailID, workID, result)
+	}
+	if result.Action != "work" || result.Reason != "claimed" || result.BeadID != workID {
+		t.Fatalf("want claimed routed work %q, got action=%q reason=%q bead=%q code=%d", workID, result.Action, result.Reason, result.BeadID, code)
+	}
+	if !claimed {
+		t.Fatal("store.Claim was never called for the routed work bead")
+	}
+}
+
 func TestHookInjectAlwaysExitsZero(t *testing.T) {
 	// Even on command failure, inject mode exits 0.
 	runner := func(string, string) (string, error) { return "", fmt.Errorf("command failed") }


### PR DESCRIPTION
## Summary
- `hookClaimExistingOrAssigned` matched any OPEN/in_progress candidate whose `Assignee` equals one of the session's identity strings, with no type check.
- A mail message bead (`issue_type="message"`) addressed to a session's identity has exactly that shape (Assignee = recipient address), so it was returned as work ahead of any real routed work waiting in the same batch — not a race, this function runs before `claimFirstEligibleHookCandidate` ever sees the routed candidates.
- Fix: skip `issue_type=="message"` candidates in both loops of `hookClaimExistingOrAssigned`, matching the issue's own proposed fix location.

Deliberately out of scope (per the issue body): Defect 2 (bare agent name as a single-session mail address) is flagged by the issue author as a design question needing a maintainer call, no patch proposed. Also left `internal/config/workquery.go` untouched — the issue explicitly warns that jq string is a stability contract shared with the reconciler's `scale_check`.

Fixes #4419

## Test plan
- [x] Added `TestHookClaimSkipsMessageBeadsAheadOfRoutedWork`, confirmed RED against unfixed code (reproduces the exact bug), GREEN after the fix
- [x] Full `TestCmdHook*`/`TestHookClaim*`/`TestPoolWorker*` sweep (24 tests): PASS, zero regressions
- [x] `go build` + `go vet` clean on full `cmd/gc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)