### PR TITLE
fix(beads): stop `rig set-endpoint --inherit` stamping a per-rig dolt target

### DIFF
--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -706,8 +706,21 @@ func syncRigEndpointCompatConfig(fs fsys.FS, cityPath string, cfg *config.City, 
 		if !strings.EqualFold(cfg.Rigs[i].Name, rigName) {
 			continue
 		}
-		cfg.Rigs[i].DoltHost = strings.TrimSpace(state.DoltHost)
-		cfg.Rigs[i].DoltPort = strings.TrimSpace(state.DoltPort)
+		// An inherited rig must not carry the deprecated per-rig
+		// dolt_host/dolt_port in city.toml. A stamped target makes the beads
+		// reconciler treat the rig as an explicit override and churn its
+		// .beads/config.yaml back to `explicit` (dropping the inherited
+		// dolt.user) on every city start, and drifts into a hard error if the
+		// city endpoint later changes (validateCanonicalCompatDoltDrift). Clear
+		// it so the rig truly inherits — matching the managed-city path.
+		// Explicit and self targets keep their host/port.
+		if state.EndpointOrigin == contract.EndpointOriginInheritedCity {
+			cfg.Rigs[i].DoltHost = ""
+			cfg.Rigs[i].DoltPort = ""
+		} else {
+			cfg.Rigs[i].DoltHost = strings.TrimSpace(state.DoltHost)
+			cfg.Rigs[i].DoltPort = strings.TrimSpace(state.DoltPort)
+		}
 		return writeCityConfigForEditFS(fs, filepath.Join(cityPath, "city.toml"), cfg)
 	}
 	return fmt.Errorf("rig %q not found in city config", rigName)

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -289,11 +289,16 @@ func TestDoRigSetEndpointInheritMirrorsExternalCity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := cityCfg.Rigs[0].DoltHost; got != "db.example.com" {
-		t.Fatalf("city.toml rig DoltHost = %q, want %q", got, "db.example.com")
+	// An inherited rig must not carry the deprecated per-rig dolt_host/dolt_port
+	// in city.toml (matching the managed-city inherit path). It inherits the city
+	// endpoint through its .beads/config.yaml; a stamped target would churn the
+	// rig config back to explicit on every reconcile and can drift into a hard
+	// error if the city endpoint changes.
+	if got := cityCfg.Rigs[0].DoltHost; got != "" {
+		t.Fatalf("city.toml rig DoltHost = %q, want empty", got)
 	}
-	if got := cityCfg.Rigs[0].DoltPort; got != "3307" {
-		t.Fatalf("city.toml rig DoltPort = %q, want %q", got, "3307")
+	if got := cityCfg.Rigs[0].DoltPort; got != "" {
+		t.Fatalf("city.toml rig DoltPort = %q, want empty", got)
 	}
 	if _, err := os.Stat(filepath.Join(rigDir, ".beads", "dolt-server.port")); !os.IsNotExist(err) {
 		t.Fatalf("expected inherited external rig to remove port file, stat err = %v", err)


### PR DESCRIPTION
## Problem

`gc rig set-endpoint <rig> --inherit` is meant to make a rig inherit the city Dolt endpoint. It writes the rig's `.beads/config.yaml` as `inherited_city` correctly — but `syncRigEndpointCompatConfig` (`cmd/gc/cmd_rig_endpoint.go`) *also* stamps the resolved `dolt_host`/`dolt_port` into that rig's entry in `city.toml`, **unconditionally**:

```go
cfg.Rigs[i].DoltHost = strings.TrimSpace(state.DoltHost)
cfg.Rigs[i].DoltPort = strings.TrimSpace(state.DoltPort)
```

For `--inherit` under an external (`city_canonical`) city, `state` carries the **city's** host/port, so the rig ends up with a per-rig target equal to the city's. The beads reconciler (`desiredRigDoltConfigState`) then treats any rig with a `dolt_host` as an explicit override and rewrites its `.beads/config.yaml` from `inherited_city` back to `explicit` — **dropping the inherited `dolt.user`** — on **every city start**. It can also drift into a hard error (`validateCanonicalCompatDoltDrift`, which itself labels the per-rig target "deprecated") if the city endpoint later changes.

This is the same stamping pattern as `gc beads city use-external`, and is how an ansible-provisioned `--inherit` rig acquires a stale per-rig target.

### Inconsistency

The **managed-city** inherit path already leaves `city.toml` rig `dolt_host` empty (asserted by `TestDoRigSetEndpointInheritWritesManagedInheritedRigConfig`, and *required* empty by the reconcile drift check). Only the **external-city** path stamps — an inconsistency this PR removes.

## Fix

`syncRigEndpointCompatConfig` now clears `dolt_host`/`dolt_port` for `inherited_city` origin (matching the managed-city path); explicit/self targets are unchanged. The rig still inherits the city endpoint through its `.beads/config.yaml`, and consumers (`bd_env`, provider readiness, the drift check) already fall back to the resolved city target when a rig carries no per-rig target (`bd_env.go`: *"Rigs without local endpoint authority inherit the resolved city target"*).

## Test

Updated `TestDoRigSetEndpointInheritMirrorsExternalCity` to assert `city.toml` rig `dolt_host`/`dolt_port` are **empty** after `--inherit` (the rig `.beads` config still mirrors the external city host/port/user). Full `cmd/gc` endpoint / rig / drift / canonical suite green; `go vet` and `gofmt` clean.

## Related

Complements #4443, which hardens the reconciler so a rig whose target merely mirrors the city stays `inherited_city`. This PR removes the stamp at the source (`--inherit`), so `city.toml` is correct even before that defensive path runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
