### PR TITLE
test: reuse the test CLI for fresh managed-city setup

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -10965,14 +10965,7 @@ esac
 		t.Fatal(err)
 	}
 
-	testExecutable, err := os.Executable()
-	if err != nil {
-		t.Fatalf("os.Executable: %v", err)
-	}
-	reexecGC := filepath.Join(binDir, "gc")
-	if err := os.Symlink(testExecutable, reexecGC); err != nil {
-		t.Fatalf("Symlink(test executable): %v", err)
-	}
+	reexecGC := reexecGCTestBinaryForTests(t)
 	gcWrapper := filepath.Join(binDir, "gc-wrapper")
 	gcWrapperScript := fmt.Sprintf(`#!/bin/sh
 set -eu

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1423,7 +1423,7 @@ func TestBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore(t *testing.
 }
 
 func TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix(t *testing.T) {
-	cityPath, _ := setupFreshManagedBdWaitTestCity(t)
+	cityPath := setupFreshManagedBdWaitTestCity(t)
 	bdPath := waitTestRealBDPath(t)
 
 	cmd := exec.Command("dolt", "sql", "-q", "show tables")

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -2694,7 +2694,7 @@ func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {
 	}
 }
 
-func setupFreshManagedBdWaitTestCity(t *testing.T) (string, string) {
+func setupFreshManagedBdWaitTestCity(t *testing.T) string {
 	t.Helper()
 	configureIsolatedRuntimeEnv(t)
 
@@ -2715,8 +2715,9 @@ func setupFreshManagedBdWaitTestCity(t *testing.T) (string, string) {
 	t.Setenv("DOLT_ROOT_PATH", homeDir)
 	t.Setenv("PATH", strings.Join([]string{filepath.Dir(bdPath), filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
 
+	reexecGC := reexecGCTestBinaryForTests(t)
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
+	resolveProviderLifecycleGCBinary = func() string { return reexecGC }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
 	prevCityFlag, prevRigFlag := cityFlag, rigFlag
@@ -2728,8 +2729,7 @@ func setupFreshManagedBdWaitTestCity(t *testing.T) (string, string) {
 	})
 
 	cityPath := shortSocketTempDir(t, "gc-bd-city-")
-	rigPath, err := writeManagedBdWaitTestCityScaffold(cityPath)
-	if err != nil {
+	if _, err := writeManagedBdWaitTestCityScaffold(cityPath); err != nil {
 		t.Fatalf("writeManagedBdWaitTestCityScaffold: %v", err)
 	}
 	t.Setenv("GC_CITY", cityPath)
@@ -2744,13 +2744,10 @@ func setupFreshManagedBdWaitTestCity(t *testing.T) (string, string) {
 	if err := initAndHookDir(cityPath, cityPath, "gc"); err != nil {
 		t.Fatalf("initAndHookDir(city): %v", err)
 	}
-	if err := initAndHookDir(cityPath, rigPath, "fe"); err != nil {
-		t.Fatalf("initAndHookDir(rig): %v", err)
-	}
 	if err := publishManagedDoltRuntimeState(cityPath); err != nil {
 		t.Fatalf("publishManagedDoltRuntimeState: %v", err)
 	}
-	return cityPath, rigPath
+	return cityPath
 }
 
 func setupManagedBdWaitTestCity(t *testing.T) (string, string) {

--- a/cmd/gc/test_gc_binary_test.go
+++ b/cmd/gc/test_gc_binary_test.go
@@ -15,6 +15,22 @@ var (
 	testGCBinaryErr  error
 )
 
+// reexecGCTestBinaryForTests returns the current Go test executable through a
+// symlink named gc. TestMain recognizes that basename and dispatches the
+// supplied arguments through the real CLI command tree without rebuilding gc.
+func reexecGCTestBinaryForTests(t *testing.T) string {
+	t.Helper()
+	testExecutable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
+	gcPath := filepath.Join(t.TempDir(), "gc")
+	if err := os.Symlink(testExecutable, gcPath); err != nil {
+		t.Fatalf("symlink test executable as gc: %v", err)
+	}
+	return gcPath
+}
+
 func currentGCBinaryForTests(t *testing.T) string {
 	t.Helper()
 	testGCBinaryOnce.Do(func() {


### PR DESCRIPTION
## Summary

- reuse the current Go test executable as the `gc` CLI instead of rebuilding the binary for this fixture
- remove unused rig initialization from the city-only setup
- preserve real managed Dolt startup, HQ schema verification, raw `bd create`, provider-store creation, runtime publication and cleanup, and both `gc-` prefix assertions

## Performance

- focused local test body: 55.72s -> 22.54s
- reduction: 33.18s, or about 59.5% (2.47x faster)
- historical Blacksmith body: 15.17s

The local environment has a v55 database with v53 code, so it falls back from the native store. These measurements demonstrate wall-time improvement only; they do not claim native-path validation.

## Validation

- focused fresh-city and re-exec tests
- test resource-census guard
- `make test-fast-parallel`
- `go vet ./...`
- active pre-commit and pre-push hooks
- two independent delegated reviews: approved with no blocking findings

## Scope

Test infrastructure only. No production behavior or retry policy changes.