### PR TITLE
test: exercise pool-death reconciliation directly

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -922,6 +922,50 @@ func convergenceStartupComplete(cr *CityRuntime) bool {
 	return true
 }
 
+// reconcilePoolDeaths detects pool instances that stopped since the prior
+// reconciliation and runs their configured death hooks.
+func (cr *CityRuntime) reconcilePoolDeaths(prevPoolRunning *map[string]bool) {
+	if len(cr.poolDeathHandlers) == 0 {
+		return
+	}
+	currentRunning, listErr := cr.sp.ListRunning("")
+	if listErr != nil {
+		if runtime.IsPartialListError(listErr) {
+			fmt.Fprintf(cr.stderr, "%s: pool death check skipped due to partial session listing: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
+		} else {
+			fmt.Fprintf(cr.stderr, "%s: pool death check skipped while listing sessions: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
+		}
+		return
+	}
+	currentSet := make(map[string]bool, len(currentRunning))
+	for _, name := range currentRunning {
+		currentSet[name] = true
+	}
+	if *prevPoolRunning != nil {
+		for sn, info := range cr.poolDeathHandlers {
+			if (*prevPoolRunning)[sn] && !currentSet[sn] {
+				out, err := shellRunHook(info.Command, info.Dir, info.Env)
+				if err != nil {
+					fmt.Fprintf(cr.stderr, "on_death %s: %v\n", sn, err) //nolint:errcheck // best-effort stderr
+				}
+				// Surface only the DEFAULT hook's gc-recovery diagnostic for
+				// a bd release it could not complete (the loop exits 0 even
+				// when a bd write fails, so this is the only signal). A user
+				// on_death override carries no marker and is left alone.
+				if strings.Contains(out, config.RecoveryHookMarker) {
+					fmt.Fprintf(cr.stderr, "on_death %s: %s\n", sn, strings.TrimSpace(out)) //nolint:errcheck // best-effort stderr
+				}
+			}
+		}
+	}
+	*prevPoolRunning = make(map[string]bool)
+	for sn := range cr.poolDeathHandlers {
+		if currentSet[sn] {
+			(*prevPoolRunning)[sn] = true
+		}
+	}
+}
+
 // tick performs one reconciliation tick: pool death detection, config
 // reload (if dirty), agent reconciliation, wisp GC, and order
 // dispatch.
@@ -954,45 +998,7 @@ func (cr *CityRuntime) tick(
 			trace.end(completion, traceRecordPayload{"phase": "tick", "trigger": traceTrigger})
 		}
 	}()
-	// Detect pool instance deaths since last tick.
-	if len(cr.poolDeathHandlers) > 0 {
-		currentRunning, listErr := cr.sp.ListRunning("")
-		if listErr != nil {
-			if runtime.IsPartialListError(listErr) {
-				fmt.Fprintf(cr.stderr, "%s: pool death check skipped due to partial session listing: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
-			} else {
-				fmt.Fprintf(cr.stderr, "%s: pool death check skipped while listing sessions: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
-			}
-		} else {
-			currentSet := make(map[string]bool, len(currentRunning))
-			for _, name := range currentRunning {
-				currentSet[name] = true
-			}
-			if *prevPoolRunning != nil {
-				for sn, info := range cr.poolDeathHandlers {
-					if (*prevPoolRunning)[sn] && !currentSet[sn] {
-						out, err := shellRunHook(info.Command, info.Dir, info.Env)
-						if err != nil {
-							fmt.Fprintf(cr.stderr, "on_death %s: %v\n", sn, err) //nolint:errcheck // best-effort stderr
-						}
-						// Surface only the DEFAULT hook's gc-recovery diagnostic for
-						// a bd release it could not complete (the loop exits 0 even
-						// when a bd write fails, so this is the only signal). A user
-						// on_death override carries no marker and is left alone.
-						if strings.Contains(out, config.RecoveryHookMarker) {
-							fmt.Fprintf(cr.stderr, "on_death %s: %s\n", sn, strings.TrimSpace(out)) //nolint:errcheck // best-effort stderr
-						}
-					}
-				}
-			}
-			*prevPoolRunning = make(map[string]bool)
-			for sn := range cr.poolDeathHandlers {
-				if currentSet[sn] {
-					(*prevPoolRunning)[sn] = true
-				}
-			}
-		}
-	}
+	cr.reconcilePoolDeaths(prevPoolRunning)
 
 	var manualReload *reloadRequest
 	var manualReply reloadControlReply

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3756,9 +3756,7 @@ func TestCityRuntimeTickRunsOnDeathWithCanonicalRigEnv(t *testing.T) {
 		},
 	}
 
-	dirty := &atomic.Bool{}
-	var lastProviderName string
-	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+	cr.reconcilePoolDeaths(&prevPoolRunning)
 
 	data, err := os.ReadFile(outFile)
 	if err != nil {
@@ -3802,9 +3800,7 @@ func TestCityRuntimeTickSkipsOnDeathWhenSessionListingIsPartial(t *testing.T) {
 		},
 	}
 
-	dirty := &atomic.Bool{}
-	var lastProviderName string
-	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+	cr.reconcilePoolDeaths(&prevPoolRunning)
 
 	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("on_death output err = %v, want no hook execution", err)


### PR DESCRIPTION
## Summary

- extract the existing pool-death phase into `CityRuntime.reconcilePoolDeaths`
- keep the `tick` call at the exact original position
- let the two pool-death policy tests exercise that phase directly instead of traversing unrelated config reload, reconciliation, and store-opening work

## Performance

- focused pair before: about 7.32s
- focused pair after: about 0.01s
- improvement: roughly 730x

The extraction is mechanical and changes no production ordering, retry policy, error handling, hook behavior, or state transitions.

## Preserved edges

- canonical rig environment reaches the death hook
- partial session listings skip hook execution and preserve prior state
- full `tick` coordination remains covered by the existing tick test inventory

## Validation

- focused pair and five-run timing
- test resource-census guard
- `make test-fast-parallel`
- `go vet ./...`
- active pre-commit hook
- two independent delegated reviews: approved with no required findings

## Scope

One reconciliation phase and its two focused tests. No broader controller refactor.