### PR TITLE
fix: sweep rig stores from the city control dispatcher

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -4030,6 +4030,111 @@ name = "myrig"
 	}
 }
 
+func TestRunWorkflowServeCityControlDispatcherSweepsRigStores(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "flow-city")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "gas-city"
+
+[daemon]
+formula_v2 = true
+
+[[rigs]]
+name = "flow-city"
+` + testControlDispatcherAgentTOML("")
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", fmt.Sprintf("[[rig]]\nname = \"flow-city\"\npath = %q\n", rigDir))
+	t.Setenv("GC_CITY", cityDir)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	callsByDir := map[string]int{}
+	var sawCityStore bool
+	var sawRigStore bool
+	var rigEnv map[string]string
+	workflowServeList = func(_ string, dir string, env map[string]string) ([]hookBead, error) {
+		key := canonicalTestPath(dir)
+		callsByDir[key]++
+		switch key {
+		case canonicalTestPath(cityDir):
+			sawCityStore = true
+		case canonicalTestPath(rigDir):
+			sawRigStore = true
+			rigEnv = maps.Clone(env)
+			if callsByDir[key] == 1 {
+				return []hookBead{{
+					ID: "fc-s4g0",
+					Metadata: map[string]string{
+						"gc.kind":      "workflow-finalize",
+						"gc.routed_to": "control-dispatcher",
+					},
+				}}, nil
+			}
+		}
+		return nil, nil
+	}
+
+	var gotCityPath, gotStorePath, gotBeadID string
+	controlDispatcherServe = func(cityPath, storePath, beadID string, _ io.Writer, _ io.Writer) error {
+		gotCityPath = cityPath
+		gotStorePath = storePath
+		gotBeadID = beadID
+		return nil
+	}
+
+	if err := runWorkflowServe("control-dispatcher", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+	if !sawCityStore {
+		t.Fatal("city control-dispatcher did not scan the city store")
+	}
+	if !sawRigStore {
+		t.Fatal("city control-dispatcher did not scan the rig store")
+	}
+	if canonicalTestPath(gotCityPath) != canonicalTestPath(cityDir) {
+		t.Fatalf("control cityPath = %q, want %q", gotCityPath, cityDir)
+	}
+	if canonicalTestPath(gotStorePath) != canonicalTestPath(rigDir) {
+		t.Fatalf("control storePath = %q, want rig root %q", gotStorePath, rigDir)
+	}
+	if gotBeadID != "fc-s4g0" {
+		t.Fatalf("control beadID = %q, want fc-s4g0", gotBeadID)
+	}
+	if rigEnv == nil {
+		t.Fatal("missing rig work-query env")
+	}
+	if got := rigEnv["GC_STORE_ROOT"]; canonicalTestPath(got) != canonicalTestPath(rigDir) {
+		t.Fatalf("rig GC_STORE_ROOT = %q, want %q", got, rigDir)
+	}
+	if got := rigEnv["GC_STORE_SCOPE"]; got != "rig" {
+		t.Fatalf("rig GC_STORE_SCOPE = %q, want rig", got)
+	}
+}
+
 func TestOpenControlStoreDisablesAutoExportWithoutSandboxingWrites(t *testing.T) {
 	clearGCEnv(t)
 	disableManagedDoltRecoveryForTest(t)

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -5411,7 +5411,6 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 		t.TempDir(),
 		t.TempDir(),
 		wfcAgent.EffectiveWorkQuery(),
-		nil,
 		io.Discard,
 	)
 	if err == nil || !strings.Contains(err.Error(), "synthetic dispatch failure") {
@@ -5491,7 +5490,7 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	}
 
 	agent := config.Agent{Name: "control-dispatcher"}
-	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), io.Discard)
 	if !errors.Is(err, stopErr) {
 		t.Fatalf("runWorkflowServeFollow error = %v, want %v", err, stopErr)
 	}
@@ -5581,7 +5580,7 @@ func TestRunWorkflowServeFollowDrainsObservedWakeBeforeSurfacingWatcherErr(t *te
 	}
 
 	agent := config.Agent{Name: "control-dispatcher"}
-	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), io.Discard)
 	if !errors.Is(err, watcherErr) {
 		t.Fatalf("runWorkflowServeFollow error = %v, want %v", err, watcherErr)
 	}
@@ -5632,7 +5631,7 @@ func TestRunWorkflowServeFollowSurvivesTransientWorkQueryTimeout(t *testing.T) {
 	}
 
 	agent := config.Agent{Name: "control-dispatcher"}
-	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), io.Discard)
 	if !errors.Is(err, fatalErr) {
 		t.Fatalf("runWorkflowServeFollow err = %v, want fatal error after surviving the transient timeout", err)
 	}
@@ -5676,7 +5675,7 @@ func TestRunWorkflowServeFollowSurvivesDoltCircuitBreakerOutage(t *testing.T) {
 	}
 
 	agent := config.Agent{Name: config.ControlDispatcherAgentName}
-	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), io.Discard)
 	if !errors.Is(err, fatalErr) {
 		t.Fatalf("runWorkflowServeFollow err = %v, want fatal error after surviving the breaker outage", err)
 	}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -4054,14 +4054,13 @@ name = "flow-city"
 		t.Fatal(err)
 	}
 	writeCatalogFile(t, cityDir, ".gc/site.toml", fmt.Sprintf("[[rig]]\nname = \"flow-city\"\npath = %q\n", rigDir))
-	t.Setenv("GC_CITY", cityDir)
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
-	cityFlag = ""
+	cityFlag = cityDir
 	workflowServeIdlePollInterval = 0
 	workflowServeIdlePollAttempts = 0
 	t.Cleanup(func() {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -309,8 +309,7 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	if !ok {
 		return fmt.Errorf("agent %q not found in config", agentName)
 	}
-	workDir := agentCommandDir(cityPath, &agentCfg, cfg.Rigs)
-	workEnv, err := controllerWorkQueryEnv(cityPath, cfg, &agentCfg)
+	scopes, err := workflowServeScopes(cityPath, cfg, &agentCfg)
 	if err != nil {
 		return fmt.Errorf("building work query env: %w", err)
 	}
@@ -322,12 +321,23 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
 		workQuery = workflowServeControlReadyQueryForBeads(agentCfg, cfg.Beads, config.NamedSessionRuntimeName(cityName, cfg.Workspace, agentCfg.QualifiedName()))
 	}
-	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
+	workflowTracef("serve start agent=%s city=%s stores=%s", agentCfg.QualifiedName(), cityPath, workflowServeScopePaths(scopes))
 	if !follow {
-		_, err := drainWorkflowServeWork(agentCfg, cityPath, workDir, workQuery, workEnv, stderr)
+		_, err := drainWorkflowServeScopes(agentCfg, cityPath, scopes, workQuery, stderr)
 		return err
 	}
-	return runWorkflowServeFollow(agentCfg, cityPath, workDir, workQuery, workEnv, stderr)
+	return runWorkflowServeFollowScopes(agentCfg, cityPath, scopes, workQuery, stderr)
+}
+
+func workflowServeScopePaths(scopes []workflowServeScope) string {
+	if len(scopes) == 0 {
+		return ""
+	}
+	paths := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		paths = append(paths, scope.storePath)
+	}
+	return strings.Join(paths, ",")
 }
 
 func requireWorkflowServeFollowSessionEnv() error {
@@ -422,6 +432,96 @@ type workflowServeDrainResult struct {
 	pendingAny   bool
 }
 
+type workflowServeScope struct {
+	storePath string
+	workEnv   map[string]string
+}
+
+func workflowServeScopes(cityPath string, cfg *config.City, agentCfg *config.Agent) ([]workflowServeScope, error) {
+	if agentCfg == nil {
+		return nil, nil
+	}
+	workDir := agentCommandDir(cityPath, agentCfg, cfg.Rigs)
+	workEnv, err := controllerWorkQueryEnv(cityPath, cfg, agentCfg)
+	if err != nil {
+		return nil, err
+	}
+	scopes := []workflowServeScope{{
+		storePath: workDir,
+		workEnv:   workEnv,
+	}}
+	if !workflowServeShouldSweepRigStores(cityPath, cfg, agentCfg) {
+		return scopes, nil
+	}
+	seen := map[string]struct{}{}
+	for _, scope := range scopes {
+		if key := normalizePathForCompare(scope.storePath); key != "" {
+			seen[key] = struct{}{}
+		}
+	}
+	for _, rig := range cfg.Rigs {
+		rigName := strings.TrimSpace(rig.Name)
+		rigRoot := strings.TrimSpace(rig.Path)
+		if rigName == "" || rigRoot == "" {
+			continue
+		}
+		if key := normalizePathForCompare(rigRoot); key != "" {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		rigScopedAgent := *agentCfg
+		rigScopedAgent.Dir = rigName
+		env, err := controllerWorkQueryEnv(cityPath, cfg, &rigScopedAgent)
+		if err != nil {
+			return nil, err
+		}
+		scopes = append(scopes, workflowServeScope{
+			storePath: rigRoot,
+			workEnv:   env,
+		})
+	}
+	return scopes, nil
+}
+
+func workflowServeShouldSweepRigStores(cityPath string, cfg *config.City, agentCfg *config.Agent) bool {
+	if cfg == nil || agentCfg == nil || !isWorkflowServeControlDispatcherAgent(*agentCfg) {
+		return false
+	}
+	return configuredRigName(cityPath, agentCfg, cfg.Rigs) == ""
+}
+
+func drainWorkflowServeScopes(agentCfg config.Agent, cityPath string, scopes []workflowServeScope, workQuery string, stderr io.Writer) (workflowServeDrainResult, error) {
+	if len(scopes) == 0 {
+		return workflowServeDrainResult{}, nil
+	}
+	if len(scopes) == 1 {
+		return drainWorkflowServeWork(agentCfg, cityPath, scopes[0].storePath, workQuery, scopes[0].workEnv, stderr)
+	}
+	combined := workflowServeDrainResult{}
+	for {
+		processedThisSweep := false
+		pendingThisSweep := false
+		for _, scope := range scopes {
+			drainResult, err := drainWorkflowServeWork(agentCfg, cityPath, scope.storePath, workQuery, scope.workEnv, stderr)
+			if err != nil {
+				combined.processedAny = combined.processedAny || drainResult.processedAny
+				combined.pendingAny = combined.pendingAny || drainResult.pendingAny
+				return combined, err
+			}
+			combined.processedAny = combined.processedAny || drainResult.processedAny
+			combined.pendingAny = combined.pendingAny || drainResult.pendingAny
+			processedThisSweep = processedThisSweep || drainResult.processedAny
+			pendingThisSweep = pendingThisSweep || drainResult.pendingAny
+		}
+		if !processedThisSweep {
+			combined.pendingAny = combined.pendingAny || pendingThisSweep
+			return combined, nil
+		}
+	}
+}
+
 // drainWorkflowServeWork runs the control-dispatcher drain loop to completion
 // for a single invocation. Returns whether it advanced a control bead and
 // whether the queue still contains only pending work so the --follow caller
@@ -500,6 +600,10 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 }
 
 func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuery string, workEnv map[string]string, stderr io.Writer) error {
+	return runWorkflowServeFollowScopes(agentCfg, cityPath, []workflowServeScope{{storePath: storePath, workEnv: workEnv}}, workQuery, stderr)
+}
+
+func runWorkflowServeFollowScopes(agentCfg config.Agent, cityPath string, scopes []workflowServeScope, workQuery string, stderr io.Writer) error {
 	ep, err := workflowServeOpenEventsProvider(stderr)
 	if err != nil {
 		return err
@@ -524,7 +628,7 @@ func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuer
 	idleSweeps := 0
 	var pendingWakeErr error
 	for {
-		drainResult, err := drainWorkflowServeWork(agentCfg, cityPath, storePath, workQuery, workEnv, stderr)
+		drainResult, err := drainWorkflowServeScopes(agentCfg, cityPath, scopes, workQuery, stderr)
 		if err != nil {
 			// A transient work-query/store failure — most commonly the
 			// work-query timeout (hookWorkQueryTimeout) when the bead store is

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -599,8 +599,8 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 	}
 }
 
-func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuery string, workEnv map[string]string, stderr io.Writer) error {
-	return runWorkflowServeFollowScopes(agentCfg, cityPath, []workflowServeScope{{storePath: storePath, workEnv: workEnv}}, workQuery, stderr)
+func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuery string, stderr io.Writer) error {
+	return runWorkflowServeFollowScopes(agentCfg, cityPath, []workflowServeScope{{storePath: storePath}}, workQuery, stderr)
 }
 
 func runWorkflowServeFollowScopes(agentCfg config.Agent, cityPath string, scopes []workflowServeScope, workQuery string, stderr io.Writer) error {


### PR DESCRIPTION
## Problem

A city-scoped control dispatcher only swept the city store for claimable control-plane work. Control beads living in **rig** stores (e.g. a rig-scoped workflow-finalize) were invisible to it: molecules stalled at their terminal step, and in the worst case pool workers looped re-claiming finished work because the finalize step never ran (observed in production as a redispatch loop on already-done work).

## Change

`cmd/gc/dispatch_runtime.go`: the city control dispatcher's sweep now iterates configured rig stores in addition to the city store, claiming rig-scoped control beads under the same predicates. Includes a dispatch test covering the rig-store path (`cmd_convoy_dispatch_test.go`).

## Field context

Running in production on our fork since 2026-07-08; the redispatch-loop class has not recurred. Rebased onto current main today (clean). Related tests pass with `-tags=gms_pure_go`; note the local pre-push suite has a pre-existing macOS failure (`/bin/true` path assumption in `cmd_hook_stdin_drain_test.go`) unrelated to this change.

Part of a series from production operation: #4447, #4448, #4449, #4450; previously merged #4068.