### PR TITLE
fix(dolt): preserve evidence when compact quarantines a database

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -196,6 +196,35 @@ should treat these strings as the current vocabulary:
 | `post-flatten value hash changed with row-count increase` | The database hash changed after at least one stable-table row-count gain. |
 | `post-flatten value hash changed without row-count increase` | The database hash changed without a row-count gain. |
 
+Quarantine markers also carry structured evidence. New markers include the
+database name, the preflight/flatten/post-verify HEADs, preflight and
+postflight database value hashes when available, `integrity_table_drift` for
+table-level row/hash mismatches, `database_value_hash_drift` for aggregate hash
+drift, and `decision=preserve_marker_manual_review_required`.
+
+Safe marker-clear procedure:
+
+1. Require a clean application worktree: `git status --short` should show no
+   product/config/test changes you have not accounted for.
+2. Confirm the Dolt server is reachable with `gc dolt status` and a live query
+   such as `gc dolt sql --db <database> -q "SELECT COUNT(*) FROM issues"`.
+3. Confirm bead queries are healthy for the affected store, for example
+   `bd list --limit 1` in that rig or `gc bd list --rig <rig> --limit 1`.
+4. Read the marker and retain it if the HEAD/hash/table evidence is incomplete
+   or points at row loss. For table drift, compare the recorded HEADs with
+   `DOLT_DIFF` / `DOLT_DIFF_STAT`; only clear when the diff proves preflight
+   rows are still reachable and no unexpected table disappeared.
+5. When the evidence proves no data loss, remove only that database's marker:
+   `rm .gc/runtime/packs/dolt/compact-quarantine/<database>`.
+6. Retry reclaim with `gc dolt compact --gc-only --only-db <database>`. If the
+   marker returns or health checks fail, preserve the marker and escalate with
+   the marker contents and command output.
+
+`gc dolt compact` and `gc dolt compact --gc-only` refuse databases with
+quarantine markers. The refusal output repeats the marker path, reason, key
+evidence fields, and the clear/retry command so operators have the next action
+without opening this runbook first.
+
 ## When to Escalate
 
 If a recovery GC reduces the store by less than ~10% and `gc doctor` still

--- a/examples/bd/dolt/commands/compact/help.md
+++ b/examples/bd/dolt/commands/compact/help.md
@@ -16,7 +16,8 @@ row preservation, and runs `CALL DOLT_GC('--full')`.
   GC was deferred or never ran, so scheduled compaction skips it forever and the
   disk space is never reclaimed. Unlike a bare working-set GC, `--full` rewrites
   `oldgen`, so the orphaned history is actually freed. Refuses any database that
-  carries an integrity-quarantine marker.
+  carries an integrity-quarantine marker and prints the marker evidence plus the
+  safe clear/retry requirements.
 
 - `--only-db <name>` — Restrict the run to the named database. Repeatable, and
   augments `GC_DOLT_COMPACT_ONLY_DBS`. Use this to reclaim a single stranded
@@ -45,4 +46,5 @@ gc dolt compact --gc-only --dry-run
 ```
 
 See `docs/troubleshooting/dolt-bloat-recovery.md` for the full bloat-recovery
-runbook, including when to stop writers and take a safety backup first.
+runbook, including quarantine marker evidence, the safe marker-clear procedure,
+and when to stop writers and take a safety backup first.

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1041,6 +1041,7 @@ verify_counts() {
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
   verify_counts_failure_guidance=""
+  verify_counts_drift_details=""
   preflight_tables=""
   while IFS= read -r line; do
     [ -n "$line" ] || continue
@@ -1097,6 +1098,7 @@ verify_counts() {
       if [ "$actual" -lt "$expected" ]; then
         printf 'compact: db=%s row count decreased after flatten table=%s before=%s after=%s\n' \
           "$db" "$t" "$expected" "$actual" >&2
+        verify_counts_drift_details="${verify_counts_drift_details};table=$t,before_rows=$expected,after_rows=$actual,before_hash=$expected_hash,after_hash=$actual_hash,category=row_count_decrease"
         verify_counts_saw_row_decrease=1
         table_had_row_decrease=1
         if [ "$fail" -ne 1 ]; then
@@ -1115,6 +1117,7 @@ verify_counts() {
       if [ "$table_gained_rows" = "1" ]; then
         verify_counts_saw_gain_hash_drift=1
         verify_counts_gain_drift_tables="$verify_counts_gain_drift_tables $t"
+        verify_counts_drift_details="${verify_counts_drift_details};table=$t,before_rows=$expected,after_rows=$actual,before_hash=$expected_hash,after_hash=$actual_hash,category=row_count_gain_hash_drift"
         printf 'compact: db=%s table=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         if [ "$fail" -ne 1 ]; then
@@ -1124,9 +1127,11 @@ verify_counts() {
         fi
       elif [ "$table_had_row_decrease" = "1" ]; then
         verify_counts_saw_decrease_hash_drift=1
+        verify_counts_drift_details="${verify_counts_drift_details};table=$t,before_rows=$expected,after_rows=$actual,before_hash=$expected_hash,after_hash=$actual_hash,category=row_count_decrease_hash_drift"
         printf 'compact: db=%s table=%s value hash changed with row-count decrease before=%s after=%s\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
       else
+        verify_counts_drift_details="${verify_counts_drift_details};table=$t,before_rows=$expected,after_rows=$actual,before_hash=$expected_hash,after_hash=$actual_hash,category=same_row_count_hash_drift"
         printf 'compact: db=%s table=%s value hash changed after flatten without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         verify_counts_saw_same_count_hash_drift=1
@@ -1400,6 +1405,52 @@ compact_marker_value() {
   marker=$(compact_marker_path "$dir" "$db")
   [ -f "$marker" ] || return 1
   awk -v prefix="$key=" 'index($0, prefix) == 1 { print substr($0, length(prefix) + 1); exit }' "$marker"
+}
+
+compact_marker_summary_value() {
+  dir="$1"
+  db="$2"
+  key="$3"
+  value=$(compact_marker_value "$dir" "$db" "$key" || true)
+  if [ -n "$value" ]; then
+    printf ' %s=%s' "$key" "$value"
+  fi
+}
+
+print_existing_quarantine_marker() {
+  db="$1"
+  marker="$2"
+  reason="$3"
+  created_at="$4"
+
+  printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s%s%s%s%s%s%s%s — manual intervention required before compaction or GC\n' \
+    "$db" "$marker" "${reason:-<unknown>}" "${created_at:-<unknown>}" \
+    "$(compact_marker_summary_value "$quarantine_dir" "$db" integrity_table_drift)" \
+    "$(compact_marker_summary_value "$quarantine_dir" "$db" database_value_hash_drift)" \
+    "$(compact_marker_summary_value "$quarantine_dir" "$db" flatten_preflight_head)" \
+    "$(compact_marker_summary_value "$quarantine_dir" "$db" flatten_pre_reset_head)" \
+    "$(compact_marker_summary_value "$quarantine_dir" "$db" flatten_head)" \
+    "$(compact_marker_summary_value "$quarantine_dir" "$db" flatten_post_verify_head)" \
+    "$(compact_marker_summary_value "$quarantine_dir" "$db" decision)" >&2
+  printf 'compact: db=%s quarantine recovery: keep marker unless git status is clean, the Dolt server is reachable, live bead queries are healthy, and marker diff/hash evidence proves no data loss; then remove %s and rerun gc dolt compact --gc-only --only-db %s\n' \
+    "$db" "$marker" "$db" >&2
+}
+
+write_quarantine_marker() {
+  db="$1"
+  reason="$2"
+  shift 2
+
+  write_compact_marker "$quarantine_dir" "$db" "$reason" \
+    "flatten_preflight_head=${head:-}" \
+    "flatten_pre_reset_head=${head_before_reset:-}" \
+    "flatten_head=${flatten_head:-}" \
+    "flatten_post_verify_head=${post_verify_head:-}" \
+    "preflight_db_value_hash=${preflight_hash:-}" \
+    "postflight_db_value_hash=${postflight_hash:-}" \
+    "decision=preserve_marker_manual_review_required" \
+    "clear_decision=clear_only_after_clean_worktree_reachable_server_healthy_bead_queries_and_diff_hash_evidence_proves_no_loss" \
+    "$@"
 }
 
 compact_marker_created_at_epoch() {
@@ -1798,8 +1849,12 @@ flatten_database() {
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
   verify_counts_failure_guidance=""
+  head=""
   head_before_reset=""
+  flatten_head=""
   post_verify_head=""
+  preflight_hash=""
+  postflight_hash=""
   writer_race_detected=0
 
   if [ -n "$only_dbs" ]; then
@@ -1816,8 +1871,7 @@ flatten_database() {
     quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
     quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
     quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
-      "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
+    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
     send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
     return 1
   fi
@@ -2203,7 +2257,7 @@ flatten_database() {
   if [ -z "$flatten_head" ]; then
     printf 'compact: db=%s post-flatten HEAD probe failed — quarantine and investigate before GC\n' \
       "$db" >&2
-    write_compact_marker "$quarantine_dir" "$db" "post-flatten HEAD probe failed" || {
+    write_quarantine_marker "$db" "post-flatten HEAD probe failed" || {
       rm -f "$preflight_tmp"
       return 1
     }
@@ -2325,7 +2379,9 @@ flatten_database() {
     fi
     printf 'compact: db=%s post-flatten INTEGRITY check failed — escalate (%s)\n' \
       "$db" "$integrity_guidance" >&2
-    write_compact_marker "$quarantine_dir" "$db" "$integrity_reason" || {
+    write_quarantine_marker "$db" "$integrity_reason" \
+      "integrity_table_drift=${verify_counts_drift_details#;}" \
+      "integrity_failure_guidance=$integrity_guidance" || {
       preserve_head_after_integrity_failure "$db" "$flatten_head" || true
       rm -f "$preflight_tmp"
       return 1
@@ -2338,7 +2394,7 @@ flatten_database() {
   if ! postflight_hash=$(db_value_hash "$db"); then
     printf 'compact: db=%s post-flatten value hash probe failed — quarantine and investigate before GC\n' \
       "$db" >&2
-    write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash probe failed" || {
+    write_quarantine_marker "$db" "post-flatten value hash probe failed" || {
       preserve_head_after_integrity_failure "$db" "$flatten_head" || true
       rm -f "$preflight_tmp"
       return 1
@@ -2350,7 +2406,7 @@ flatten_database() {
   if [ -z "$postflight_hash" ]; then
     printf 'compact: db=%s post-flatten value hash probe returned empty value — quarantine and investigate before GC\n' \
       "$db" >&2
-    write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash probe returned empty value" || {
+    write_quarantine_marker "$db" "post-flatten value hash probe returned empty value" || {
       preserve_head_after_integrity_failure "$db" "$flatten_head" || true
       rm -f "$preflight_tmp"
       return 1
@@ -2420,7 +2476,8 @@ flatten_database() {
       # default here; revisit only if a real incident shows this path reachable.
       printf 'compact: db=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
         "$db" "$preflight_hash" "$postflight_hash" >&2
-      write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed with row-count increase" || {
+      write_quarantine_marker "$db" "post-flatten value hash changed with row-count increase" \
+        "database_value_hash_drift=before=$preflight_hash,after=$postflight_hash,category=row_count_gain_db_hash_drift" || {
         preserve_head_after_integrity_failure "$db" "$flatten_head" || true
         rm -f "$preflight_tmp"
         return 1
@@ -2449,7 +2506,8 @@ flatten_database() {
       fi
       printf 'compact: db=%s value hash changed without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
         "$db" "$preflight_hash" "$postflight_hash" >&2
-      write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed without row-count increase" || {
+      write_quarantine_marker "$db" "post-flatten value hash changed without row-count increase" \
+        "database_value_hash_drift=before=$preflight_hash,after=$postflight_hash,category=same_row_count_db_hash_drift" || {
         preserve_head_after_integrity_failure "$db" "$flatten_head" || true
         rm -f "$preflight_tmp"
         return 1
@@ -2503,8 +2561,7 @@ bare_gc_database() {
     quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
     quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
     quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
-      "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
+    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
     send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
     return 1
   fi
@@ -2561,8 +2618,7 @@ gc_only_database() {
     quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
     quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
     quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
-      "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
+    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
     return 1
   fi
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -262,6 +262,20 @@ func compactMarkerValue(t *testing.T, markerPath, key string) string {
 	return ""
 }
 
+func assertCompactMarkerHasEvidence(t *testing.T, markerPath string, want ...string) {
+	t.Helper()
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read compact marker: %v", err)
+	}
+	text := string(data)
+	for _, fragment := range want {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("compact marker missing evidence %q:\n%s", fragment, text)
+		}
+	}
+}
+
 func rewriteLegacyPendingPushMarker(t *testing.T, markerPath, createdAt string) {
 	t.Helper()
 	if err := os.WriteFile(markerPath, []byte(
@@ -622,6 +636,19 @@ case "$query" in
     exit 0
     ;;
   *"SELECT commit_hash FROM dolt_log ORDER BY date DESC LIMIT 1"*)
+    if [ "$mode" = "second_db_post_flatten_head_empty" ] && [ "$db" = "zed" ]; then
+      calls_file="$state_file.$db-head-calls"
+      calls=0
+      if [ -f "$calls_file" ]; then
+        calls="$(cat "$calls_file")"
+      fi
+      calls=$((calls + 1))
+      printf '%%s\n' "$calls" > "$calls_file"
+      if [ "$calls" -eq 4 ]; then
+        print_cell ""
+        exit 0
+      fi
+    fi
     if [ "$mode" = "writer_race_db_hash_empty_pre_probe" ] && [ "$(current_head)" = "compactcommit" ]; then
       calls_file="$state_file.compact-head-calls"
       calls=0
@@ -2849,6 +2876,16 @@ func TestCompactScriptQuarantinesSameRowCountWriterBeforeFullGC(t *testing.T) {
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("same-row-count value-hash drift should write quarantine marker: %v", err)
 	}
+	assertCompactMarkerHasEvidence(t, marker,
+		"reason=post-flatten table value hash changed without row-count increase",
+		"integrity_table_drift=table=beads,before_rows=10,after_rows=10,before_hash=hash-beads-before,after_hash=hash-beads-after-writer,category=same_row_count_hash_drift",
+		"flatten_preflight_head=headcommit",
+		"flatten_pre_reset_head=headcommit",
+		"flatten_head=compactcommit",
+		"preflight_db_value_hash=hash-before",
+		"decision=preserve_marker_manual_review_required",
+		"clear_decision=clear_only_after_clean_worktree_reachable_server_healthy_bead_queries_and_diff_hash_evidence_proves_no_loss",
+	)
 }
 
 func TestCompactScriptFailsOnEmptyPreflightValueHash(t *testing.T) {
@@ -2916,6 +2953,30 @@ func TestCompactScriptQuarantinesEmptyPostflightValueHashBeforeFullGC(t *testing
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("empty postflight hash should write quarantine marker: %v", err)
+	}
+	assertCompactMarkerHasEvidence(t, marker,
+		"reason=post-flatten value hash probe returned empty value",
+		"flatten_preflight_head=headcommit",
+		"flatten_head=compactcommit",
+		"preflight_db_value_hash=hash-before",
+		"postflight_db_value_hash=",
+		"decision=preserve_marker_manual_review_required",
+	)
+}
+
+func TestCompactScriptDoesNotCarryQuarantineEvidenceAcrossDatabases(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	if err := os.MkdirAll(filepath.Join(fixture.dataDir, "zed", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir second dolt db: %v", err)
+	}
+
+	out, err := fixture.run(t, "second_db_post_flatten_head_empty", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite second database HEAD probe failure:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "zed")
+	if got := compactMarkerValue(t, marker, "postflight_db_value_hash"); got != "" {
+		t.Fatalf("second database marker inherited postflight hash %q from the first database", got)
 	}
 }
 
@@ -3255,6 +3316,10 @@ func TestCompactScriptQuarantineBlocksSecondCycleAfterRowCountDecrease(t *testin
 	if !strings.Contains(secondOut, quarantine) ||
 		!strings.Contains(secondOut, "reason=post-flatten row count decreased") {
 		t.Fatalf("second compact missing quarantine marker details:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "quarantine recovery: keep marker unless git status is clean") ||
+		!strings.Contains(secondOut, "gc dolt compact --gc-only --only-db beads") {
+		t.Fatalf("second compact missing safe recovery guidance:\n%s", secondOut)
 	}
 	logData, err := os.ReadFile(fixture.doltLog)
 	if err != nil {


### PR DESCRIPTION
## Problem

When `gc dolt compact` trips an integrity check and quarantines a database, the marker records only a reason and timestamp. The recovery runbook (`docs/troubleshooting/dolt-bloat-recovery.md`) requires HEAD/hash/table-diff evidence before a marker may be cleared — evidence that no longer exists by the time an operator investigates. Result: **evidence-free markers are permanently uncleareable by the book**, compaction stays disabled forever, and the store only grows. We lived this: two July-10 markers left a city with compaction blocked for eight days and ~30% avoidable store growth, until an operator-risk recovery was performed outside the runbook.

## Change

`examples/bd/dolt/commands/compact/run.sh`: quarantine markers now capture the evidence the runbook needs at quarantine time — preflight/flatten/post-verify HEADs, pre/post database value hashes, `integrity_table_drift` / `database_value_hash_drift` details, and `decision=preserve_marker_manual_review_required`. Runbook updated to document the evidence fields and the safe marker-clear procedure against them; `dog_exec_scripts_test.go` covers the marker format.

## Field context

Running on our fork since 2026-07-11. Rebased onto current main today (clean; complements the hermetic compact scenario tests from #4255/#4292, which exercise the compaction paths but don't capture operator evidence).

Part of a series from production operation: #4447–#4450; previously merged #4068.