### PR TITLE
test: isolate doctor import-state edges

### DIFF
--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -512,12 +511,8 @@ source = ".gc/system/packs/gastown"
 	}
 }
 
-func TestDoDoctorRegistersImportStateCheck(t *testing.T) {
-	clearGCEnv(t)
+func TestImportStateDoctorCheckReportsMissingLockfile(t *testing.T) {
 	cityDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
 	writePackToml(t, cityDir, `[pack]
 name = "demo"
@@ -528,114 +523,38 @@ source = "https://example.com/tools.git"
 version = "^1.0"
 `)
 
-	prevCityFlag := cityFlag
-	prevCheck := checkInstalledImports
-	prevCityDoltCheck := newDoctorDoltServerCheck
-	prevRigDoltCheck := newDoctorRigDoltServerCheck
-	t.Cleanup(func() {
-		cityFlag = prevCityFlag
-		checkInstalledImports = prevCheck
-		newDoctorDoltServerCheck = prevCityDoltCheck
-		newDoctorRigDoltServerCheck = prevRigDoltCheck
-	})
-	cityFlag = cityDir
-	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
-		return &packman.CheckReport{
-			Issues: []packman.CheckIssue{{
-				Severity:   packman.CheckSeverityError,
-				Code:       "missing-lockfile",
-				RepairHint: `run "gc import install"`,
-			}},
-		}, nil
+	result := newImportStateDoctorCheck(cityDir).Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want Error; result=%#v", result.Status, result)
 	}
-	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
-		return doctor.NewDoltServerCheck(cityPath, true)
+	if result.Name != "packv2-import-state" {
+		t.Fatalf("name = %q, want packv2-import-state", result.Name)
 	}
-	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
-		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
+	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "missing-lockfile") {
+		t.Fatalf("details = %#v, want one missing-lockfile detail", result.Details)
 	}
-
-	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
-	out := stdout.String() + stderr.String()
-	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, `gc import install`) {
-		t.Fatalf("doctor output missing import state check:\n%s", out)
+	if !strings.Contains(result.FixHint, `gc doctor --fix`) || !strings.Contains(result.FixHint, `gc import install`) {
+		t.Fatalf("fix hint = %q, want doctor-fix and import-install commands", result.FixHint)
 	}
 }
 
-func TestDoDoctorRunsImportStateCheckWhenImportInstallStateBroken(t *testing.T) {
-	clearGCEnv(t)
+func TestBuildDoctorChecksSkipsImportStateCheckWhenCityConfigInvalid(t *testing.T) {
 	cityDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
-	writePackToml(t, cityDir, `[pack]
-name = "demo"
-schema = 1
-
-[imports.tools]
-source = "https://example.com/tools.git"
-version = "^1.0"
-`)
-
-	prevCityFlag := cityFlag
-	prevCityDoltCheck := newDoctorDoltServerCheck
-	prevRigDoltCheck := newDoctorRigDoltServerCheck
-	t.Cleanup(func() {
-		cityFlag = prevCityFlag
-		newDoctorDoltServerCheck = prevCityDoltCheck
-		newDoctorRigDoltServerCheck = prevRigDoltCheck
-	})
-	cityFlag = cityDir
-	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
-		return doctor.NewDoltServerCheck(cityPath, true)
-	}
-	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
-		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
-	}
-
-	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
-	out := stdout.String() + stderr.String()
-	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, "missing-lockfile") {
-		t.Fatalf("doctor output missing import-state failure for broken install state:\n%s", out)
-	}
-	if !strings.Contains(out, `gc import install`) {
-		t.Fatalf("doctor output missing install hint:\n%s", out)
-	}
-}
-
-func TestDoDoctorSkipsImportStateCheckWhenCityConfigInvalid(t *testing.T) {
-	clearGCEnv(t)
-	cityDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\nname = \"demo\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	prevCityFlag := cityFlag
-	prevCheck := checkInstalledImports
-	t.Cleanup(func() {
-		cityFlag = prevCityFlag
-		checkInstalledImports = prevCheck
-	})
-	cityFlag = cityDir
-	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
-		t.Fatal("import state check should not run when city.toml cannot load")
-		return nil, nil
+	names := doctorCheckNames(buildDoctorChecks(cityDir, nil, os.ErrInvalid, buildDoctorChecksOpts{
+		ControllerRunning:    false,
+		SupervisorRunning:    false,
+		SkipCityDoltCheck:    true,
+		SkipManagedDoltCheck: true,
+	}))
+	if got := doctorCheckIndex(names, "packv2-import-state"); got >= 0 {
+		t.Fatalf("packv2-import-state registered at %d, want absent; names=%v", got, names)
 	}
-
-	var stdout, stderr bytes.Buffer
-	_ = doDoctor(false, true, false, false, 0, &stdout, &stderr)
-	out := stdout.String() + stderr.String()
-	if strings.Contains(out, "packv2-import-state") {
-		t.Fatalf("doctor output included import state check for invalid config:\n%s", out)
-	}
-	if !strings.Contains(out, "city-config") {
-		t.Fatalf("doctor output missing city config failure:\n%s", out)
+	if got := doctorCheckIndex(names, "city-config"); got < 0 {
+		t.Fatalf("city-config missing from core checks; names=%v", names)
 	}
 }
 


### PR DESCRIPTION
## Outcome

Move the import-state missing-lock and invalid-config assertions to their smallest owning seams, and remove a redundant full-doctor registration journey.

This is behavior-neutral and test-only: one file changes, with no production, policy, ledger, or dependency edits.

## Assertion migration

| Retired assertion | Smallest owner after this change | Retained composition owner |
| --- | --- | --- |
| Import-state check is registered for a valid city | `TestBuildDoctorChecks_NameSetUnchanged` plus `doctor_check_names.golden` containing `packv2-import-state` | Existing `doDoctor` compositions and `internal/doctor` register/run/render tests |
| Missing `packs.lock` reports the import-state error and both repair commands | `TestImportStateDoctorCheckReportsMissingLockfile`, through the real read-only `packman.CheckInstalled` path | `TestDoDoctorFixConvergesWave1CityRootImportsThroughImportState` |
| Malformed `city.toml` excludes the import-state check while retaining the core config check | `TestBuildDoctorChecksSkipsImportStateCheckWhenCityConfigInvalid` | Core `city-config` run/render coverage |

The existing `TestImportStateDoctorCheckReportsInstallHint` continues to own detailed result and repair-hint formatting with an injected report. The new missing-lock owner deliberately does not stub `checkInstalledImports`, so the production integration with `packman.CheckInstalled` remains covered.

## Measurements

CI baselines come from run `29697921488`; the three old journeys landed on separate `cmd/gc process` shards.

| Edge | Before | After |
| --- | ---: | ---: |
| Valid registration journey | 7.22 s | removed as duplicate |
| Real missing-lock state | 6.90 s | 0.00–0.01 s |
| Invalid-config registration gate | 6.99 s | 0.00–0.01 s |

The two new owners passed 10 repetitions in 2.52 s total package time, including `cmd/gc` TestMain overhead. The change removes about 21.1 seconds of aggregate CI test work and roughly 7 seconds from each affected shard.

## Verification

- new direct owners, 10 repetitions: pass
- retained `TestBuildDoctorChecks_NameSetUnchanged`: pass
- broader import-state and builder slice: pass
- retained full `doDoctor` convergence composition: pass
- poisoned GC/BEADS path run: pass
- resource census: pass, unchanged
- `git diff --check`: pass
- pre-commit lint, generated-doc checks, and `go vet ./...`: pass
- two independent read-only council approvals on effective diff `02a3935e3586b66b69d08d5e340ed487523c95b87c70ff51a74c43511c0bf916`

A pre-change local full-doctor measurement activated the host managed-Dolt leak guard, so the before table uses the successful like-for-like CI timing artifact rather than presenting that contaminated local run as a benchmark.
