### PR TITLE
Generalize pool idle-nudge pacing into a shared backstop engine

### DIFF
--- a/cmd/gc/idle_nudge.go
+++ b/cmd/gc/idle_nudge.go
@@ -59,81 +59,79 @@ const (
 //   - Bounded per assignment: observe (grace) → nudge → backoff retries → give
 //     up. It never spams a tick and never loops forever.
 //   - Pool slots only.
+//
+// This is a thin predicate wrapper (poolClaimBackstop) over the shared
+// grace→nudge→backoff→give-up engine in nudge_backstop.go; the pacing,
+// looping, and delivery mechanics live there so a second predicate (e.g. for
+// named/direct startup kickoff) can reuse them without duplicating this state
+// machine.
 func nudgeStalledPoolClaims(
 	sp runtime.Provider,
 	cfg *config.City,
-	sessStore beads.SessionStore,
+	store beads.Store,
 	sessionBeads []beads.Bead,
 	assignedWork []beads.Bead,
 	now time.Time,
 	stdout io.Writer,
 ) {
-	if sp == nil || cfg == nil || sessStore.Store == nil {
+	if sp == nil || cfg == nil || store == nil {
 		return // hot reconcile path: never panic on a half-built dependency
 	}
-	workByID := make(map[string]beads.Bead, len(assignedWork))
-	for _, w := range assignedWork {
-		workByID[w.ID] = w
+	runNudgeBackstop(sp, store, sessionBeads, assignedWork, now, stdout, "idle-claim-nudge", poolClaimBackstop{cfg: cfg})
+}
+
+// poolClaimBackstop is the backstopPredicate for pool-managed slots: it
+// re-delivers the claim nudge to a slot whose assigned trigger bead is still
+// unclaimed. See nudgeStalledPoolClaims for the full rationale and scope.
+type poolClaimBackstop struct {
+	cfg *config.City
+}
+
+func (p poolClaimBackstop) governs(s beads.Bead) bool {
+	return strings.TrimSpace(s.Metadata["pool_managed"]) == "true"
+}
+
+// outstandingID acts only while the trigger bead is genuinely unclaimed. A
+// claimed bead is in_progress (or closed) — either way the slot is doing its
+// job and must not be disturbed. If the bead is absent from the assigned-work
+// snapshot it's been claimed/closed/moved.
+func (p poolClaimBackstop) outstandingID(s beads.Bead, work map[string]beads.Bead, sessName string) (string, bool) {
+	triggerID := strings.TrimSpace(s.Metadata[beadmeta.TriggerBeadIDMetadataKey])
+	if triggerID == "" {
+		return "", false
 	}
-
-	for i := range sessionBeads {
-		s := &sessionBeads[i]
-		if strings.TrimSpace(s.Metadata["pool_managed"]) != "true" {
-			continue // pool slots only
-		}
-		sessName := strings.TrimSpace(s.Metadata["session_name"])
-		if sessName == "" || !sp.IsRunning(sessName) {
-			continue
-		}
-		triggerID := strings.TrimSpace(s.Metadata[beadmeta.TriggerBeadIDMetadataKey])
-		if triggerID == "" {
-			continue
-		}
-
-		// Act only while the trigger bead is genuinely unclaimed. A claimed bead
-		// is in_progress (or closed) — either way the slot is doing its job and
-		// must not be disturbed. If the bead is absent from the assigned-work
-		// snapshot it's been claimed/closed/moved; clear any stale marker.
-		w, ok := workByID[triggerID]
-		if !ok || !isUnclaimedTrigger(w, sessName) {
-			clearIdleClaimMarker(sessStore, s, stdout)
-			continue
-		}
-
-		markedTrigger := strings.TrimSpace(s.Metadata[idleClaimNudgeTriggerKey])
-		attempts := atoiOr0(s.Metadata[idleClaimNudgeCountKey])
-		last := parseRFC3339OrZero(s.Metadata[idleClaimNudgeAtKey])
-
-		// First observation of this assignment: start the grace clock, don't
-		// nudge yet — a normal claim almost always lands within the grace window.
-		if markedTrigger != triggerID {
-			writeIdleClaimMarker(sessStore, s, triggerID, 0, now, stdout)
-			continue
-		}
-		switch {
-		case attempts == 0:
-			if now.Sub(last) < idleClaimNudgeGrace {
-				continue // still inside the observe-first grace
-			}
-		case attempts >= idleClaimNudgeMaxAttempts:
-			continue // gave up; manual re-nudge is the escape hatch
-		default:
-			if now.Sub(last) < idleClaimNudgeBackoff {
-				continue // waiting out the backoff before the next retry
-			}
-		}
-
-		nudge := claimNudgeFor(cfg, *s)
-		if nudge == "" {
-			continue
-		}
-		if err := sp.Nudge(sessName, runtime.TextContent(nudge)); err != nil {
-			fmt.Fprintf(stdout, "idle-claim-nudge: %s failed: %v\n", sessName, err) //nolint:errcheck // best-effort
-			continue
-		}
-		fmt.Fprintf(stdout, "idle-claim-nudge: nudged %s to claim %s (attempt %d/%d)\n", sessName, triggerID, attempts+1, idleClaimNudgeMaxAttempts) //nolint:errcheck // best-effort
-		writeIdleClaimMarker(sessStore, s, triggerID, attempts+1, now, stdout)
+	w, ok := work[triggerID]
+	if !ok || !isUnclaimedTrigger(w, sessName) {
+		return "", false
 	}
+	return triggerID, true
+}
+
+func (p poolClaimBackstop) state(s beads.Bead, id string) (same bool, attempts int, last time.Time) {
+	marked := strings.TrimSpace(s.Metadata[idleClaimNudgeTriggerKey])
+	return marked == id, atoiOr0(s.Metadata[idleClaimNudgeCountKey]), parseRFC3339OrZero(s.Metadata[idleClaimNudgeAtKey])
+}
+
+func (p poolClaimBackstop) content(s beads.Bead) string {
+	return claimNudgeFor(p.cfg, s)
+}
+
+func (p poolClaimBackstop) observe(store beads.Store, s *beads.Bead, id string, now time.Time, stdout io.Writer) {
+	writeIdleClaimMarker(store, s, id, 0, now, stdout)
+}
+
+func (p poolClaimBackstop) record(store beads.Store, s *beads.Bead, id string, attempts int, now time.Time, stdout io.Writer) {
+	writeIdleClaimMarker(store, s, id, attempts, now, stdout)
+}
+
+// exhausted is a deliberate no-op: manual re-nudge remains the pool escape
+// hatch, and leaving the marker untouched at the cap (rather than clearing or
+// rewriting it) is what keeps this predicate silent on every subsequent tick.
+func (p poolClaimBackstop) exhausted(_ beads.Store, _ *beads.Bead, _ io.Writer) {
+}
+
+func (p poolClaimBackstop) clear(store beads.Store, s *beads.Bead, stdout io.Writer) {
+	clearIdleClaimMarker(store, s, stdout)
 }
 
 // isUnclaimedTrigger reports whether the pool slot's trigger bead is still
@@ -166,13 +164,13 @@ func claimNudgeFor(cfg *config.City, session beads.Bead) string {
 // writeIdleClaimMarker persists the backstop state machine onto the session
 // bead and mirrors it into the in-memory snapshot so the rest of this tick
 // reads the just-written values.
-func writeIdleClaimMarker(sessStore beads.SessionStore, s *beads.Bead, triggerID string, attempts int, now time.Time, stdout io.Writer) {
+func writeIdleClaimMarker(store beads.Store, s *beads.Bead, triggerID string, attempts int, now time.Time, stdout io.Writer) {
 	kvs := map[string]string{
 		idleClaimNudgeTriggerKey: triggerID,
 		idleClaimNudgeCountKey:   strconv.Itoa(attempts),
 		idleClaimNudgeAtKey:      now.UTC().Format(time.RFC3339),
 	}
-	if err := sessStore.SetMetadataBatch(s.ID, kvs); err != nil {
+	if err := store.SetMetadataBatch(s.ID, kvs); err != nil {
 		fmt.Fprintf(stdout, "idle-claim-nudge: marking %s failed: %v\n", s.ID, err) //nolint:errcheck // best-effort
 		return
 	}
@@ -187,7 +185,7 @@ func writeIdleClaimMarker(sessStore beads.SessionStore, s *beads.Bead, triggerID
 // clearIdleClaimMarker wipes the marker once the slot no longer has unclaimed
 // work, so the next assignment starts its grace clock fresh. No-op (no store
 // write) when there is nothing to clear, so steady-state ticks stay silent.
-func clearIdleClaimMarker(sessStore beads.SessionStore, s *beads.Bead, stdout io.Writer) {
+func clearIdleClaimMarker(store beads.Store, s *beads.Bead, stdout io.Writer) {
 	if s.Metadata[idleClaimNudgeTriggerKey] == "" &&
 		s.Metadata[idleClaimNudgeCountKey] == "" &&
 		s.Metadata[idleClaimNudgeAtKey] == "" {
@@ -198,7 +196,7 @@ func clearIdleClaimMarker(sessStore beads.SessionStore, s *beads.Bead, stdout io
 		idleClaimNudgeCountKey:   "",
 		idleClaimNudgeAtKey:      "",
 	}
-	if err := sessStore.SetMetadataBatch(s.ID, kvs); err != nil {
+	if err := store.SetMetadataBatch(s.ID, kvs); err != nil {
 		fmt.Fprintf(stdout, "idle-claim-nudge: clearing %s failed: %v\n", s.ID, err) //nolint:errcheck // best-effort
 		return
 	}

--- a/cmd/gc/idle_nudge_test.go
+++ b/cmd/gc/idle_nudge_test.go
@@ -7,129 +7,156 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+const testTriggerBeadIDKey = "gc.trigger_bead_id"
+
 func idleClaimTestCfg() *config.City {
 	return &config.City{Agents: []config.Agent{{
-		Name:  "polecat",
+		Name:  "agent-a",
 		Nudge: "Run gc hook --claim --json now; if it returns work, execute the claimed formula immediately.",
 	}}}
 }
 
 func idleClaimPoolSession() beads.Bead {
 	return beads.Bead{
-		ID:     "s-1",
+		ID:     "session-bead-a",
 		Status: "open",
 		Type:   "session",
 		Metadata: map[string]string{
-			"session_name":                    "worker-1",
-			"pool_managed":                    "true",
-			"template":                        "polecat",
-			beadmeta.TriggerBeadIDMetadataKey: "w-1",
+			"session_name":       "session-a",
+			"pool_managed":       "true",
+			"template":           "agent-a",
+			testTriggerBeadIDKey: "work-a",
 		},
 	}
 }
 
-func runningFake(t *testing.T) *runtime.Fake {
+//nolint:unparam // sessionName is always "session-a" today; kept as a param so new cases can vary it.
+func runningIdleClaimFake(t *testing.T, sessionName string) *runtime.Fake {
 	t.Helper()
 	sp := runtime.NewFake()
-	if err := sp.Start(context.TODO(), "worker-1", runtime.Config{}); err != nil {
+	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
 		t.Fatalf("fake start: %v", err)
 	}
 	return sp
 }
 
-// A slot handed work it never claimed (trigger bead still open) is observed on
-// the first tick (grace), then nudged once the grace elapses.
+func mustGetTestBead(t *testing.T, store beads.Store, id string) beads.Bead {
+	t.Helper()
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", id, err)
+	}
+	return b
+}
+
 func TestNudgeStalledPoolClaims_NudgesAfterGrace(t *testing.T) {
-	sp := runningFake(t)
+	sp := runningIdleClaimFake(t, "session-a")
 	cfg := idleClaimTestCfg()
-	sessions := []beads.Bead{idleClaimPoolSession()}
-	work := []beads.Bead{{ID: "w-1", Status: "open"}} // unclaimed
-	store := beads.SessionStore{Store: beads.NewMemStoreFrom(0, sessions, nil)}
-	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	session := idleClaimPoolSession()
+	work := []beads.Bead{{ID: "work-a", Status: "open"}}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{session}, nil)
+	clk := &clock.Fake{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
 	var out bytes.Buffer
 
-	// First tick: observe only — start the grace clock, no nudge.
-	nudgeStalledPoolClaims(sp, cfg, store, sessions, work, base, &out)
-	if out.Len() != 0 {
-		t.Fatalf("first tick should not nudge (grace): %q", out.String())
+	nudgeStalledPoolClaims(sp, cfg, store, []beads.Bead{session}, work, clk.Now(), &out)
+	if got := sp.CountCalls("Nudge", "session-a"); got != 0 {
+		t.Fatalf("first tick Nudge calls = %d, want 0 inside grace", got)
 	}
-	if got := sessions[0].Metadata[idleClaimNudgeTriggerKey]; got != "w-1" {
-		t.Fatalf("expected marker trigger w-1, got %q", got)
+	session = mustGetTestBead(t, store, session.ID)
+	if got := session.Metadata[idleClaimNudgeTriggerKey]; got != "work-a" {
+		t.Fatalf("idle claim marker trigger = %q, want work-a", got)
 	}
 
-	// Past grace: nudge, and bump the attempt count.
-	nudgeStalledPoolClaims(sp, cfg, store, sessions, work, base.Add(idleClaimNudgeGrace+time.Second), &out)
-	if !bytes.Contains(out.Bytes(), []byte("nudged worker-1 to claim w-1")) {
-		t.Fatalf("expected nudge past grace, got: %q", out.String())
+	clk.Advance(idleClaimNudgeGrace + time.Second)
+	nudgeStalledPoolClaims(sp, cfg, store, []beads.Bead{session}, work, clk.Now(), &out)
+	if got := sp.CountCalls("Nudge", "session-a"); got != 1 {
+		t.Fatalf("Nudge calls = %d, want 1 after grace", got)
 	}
-	if got := sessions[0].Metadata[idleClaimNudgeCountKey]; got != "1" {
-		t.Fatalf("expected attempt count 1, got %q", got)
+	session = mustGetTestBead(t, store, session.ID)
+	if got := session.Metadata[idleClaimNudgeCountKey]; got != "1" {
+		t.Fatalf("idle claim attempt count = %q, want 1", got)
+	}
+	if got := session.Metadata[idleClaimNudgeAtKey]; got != clk.Now().UTC().Format(time.RFC3339) {
+		t.Fatalf("idle claim last nudge at = %q, want %q", got, clk.Now().UTC().Format(time.RFC3339))
 	}
 }
 
-// The instant a slot claims (trigger bead flips to in_progress) it must never be
-// touched — this is the inversion that the reverted #312 nudger got wrong.
 func TestNudgeStalledPoolClaims_NeverTouchesWorkingSlot(t *testing.T) {
-	sp := runningFake(t)
+	sp := runningIdleClaimFake(t, "session-a")
 	cfg := idleClaimTestCfg()
-	sessions := []beads.Bead{idleClaimPoolSession()}
-	work := []beads.Bead{{ID: "w-1", Status: "in_progress", Assignee: "worker-1"}}
-	store := beads.SessionStore{Store: beads.NewMemStoreFrom(0, sessions, nil)}
-	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	session := idleClaimPoolSession()
+	session.Metadata[idleClaimNudgeTriggerKey] = "work-a"
+	session.Metadata[idleClaimNudgeCountKey] = "1"
+	session.Metadata[idleClaimNudgeAtKey] = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	work := []beads.Bead{{ID: "work-a", Status: "in_progress", Assignee: "session-a"}}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{session}, nil)
+	clk := &clock.Fake{Time: time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)}
 	var out bytes.Buffer
 
-	nudgeStalledPoolClaims(sp, cfg, store, sessions, work, base, &out)
-	nudgeStalledPoolClaims(sp, cfg, store, sessions, work, base.Add(time.Hour), &out)
-	if out.Len() != 0 {
-		t.Fatalf("must not nudge a working slot: %q", out.String())
+	nudgeStalledPoolClaims(sp, cfg, store, []beads.Bead{session}, work, clk.Now(), &out)
+	if got := sp.CountCalls("Nudge", "session-a"); got != 0 {
+		t.Fatalf("working slot Nudge calls = %d, want 0", got)
 	}
-	if got := sessions[0].Metadata[idleClaimNudgeTriggerKey]; got != "" {
-		t.Fatalf("marker should stay clear for a claimed bead, got %q", got)
+	session = mustGetTestBead(t, store, session.ID)
+	if got := session.Metadata[idleClaimNudgeTriggerKey]; got != "" {
+		t.Fatalf("idle claim marker trigger = %q, want cleared", got)
+	}
+	if got := session.Metadata[idleClaimNudgeCountKey]; got != "" {
+		t.Fatalf("idle claim marker count = %q, want cleared", got)
+	}
+	if got := session.Metadata[idleClaimNudgeAtKey]; got != "" {
+		t.Fatalf("idle claim marker at = %q, want cleared", got)
 	}
 }
 
-// After the attempt cap is reached the backstop gives up — bounded, never an
-// every-tick loop.
 func TestNudgeStalledPoolClaims_GivesUpAtCap(t *testing.T) {
-	sp := runningFake(t)
+	sp := runningIdleClaimFake(t, "session-a")
 	cfg := idleClaimTestCfg()
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	s := idleClaimPoolSession()
-	s.Metadata[idleClaimNudgeTriggerKey] = "w-1"
-	s.Metadata[idleClaimNudgeCountKey] = strconv.Itoa(idleClaimNudgeMaxAttempts)
-	s.Metadata[idleClaimNudgeAtKey] = base.Format(time.RFC3339)
-	sessions := []beads.Bead{s}
-	work := []beads.Bead{{ID: "w-1", Status: "open"}}
-	store := beads.SessionStore{Store: beads.NewMemStoreFrom(0, sessions, nil)}
+	session := idleClaimPoolSession()
+	session.Metadata[idleClaimNudgeTriggerKey] = "work-a"
+	session.Metadata[idleClaimNudgeCountKey] = strconv.Itoa(idleClaimNudgeMaxAttempts)
+	session.Metadata[idleClaimNudgeAtKey] = base.Format(time.RFC3339)
+	work := []beads.Bead{{ID: "work-a", Status: "open"}}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{session}, nil)
+	clk := &clock.Fake{Time: base.Add(time.Hour)}
 	var out bytes.Buffer
 
-	nudgeStalledPoolClaims(sp, cfg, store, sessions, work, base.Add(time.Hour), &out)
-	if out.Len() != 0 {
-		t.Fatalf("must not nudge past the attempt cap: %q", out.String())
+	nudgeStalledPoolClaims(sp, cfg, store, []beads.Bead{session}, work, clk.Now(), &out)
+	if got := sp.CountCalls("Nudge", "session-a"); got != 0 {
+		t.Fatalf("Nudge calls past cap = %d, want 0", got)
+	}
+	session = mustGetTestBead(t, store, session.ID)
+	if got := session.Metadata[idleClaimNudgeCountKey]; got != strconv.Itoa(idleClaimNudgeMaxAttempts) {
+		t.Fatalf("idle claim attempt count = %q, want cap preserved", got)
 	}
 }
 
-// A non-pool session is ignored entirely.
 func TestNudgeStalledPoolClaims_SkipsNonPool(t *testing.T) {
-	sp := runningFake(t)
+	sp := runningIdleClaimFake(t, "session-a")
 	cfg := idleClaimTestCfg()
-	s := idleClaimPoolSession()
-	delete(s.Metadata, "pool_managed")
-	sessions := []beads.Bead{s}
-	work := []beads.Bead{{ID: "w-1", Status: "open"}}
-	store := beads.SessionStore{Store: beads.NewMemStoreFrom(0, sessions, nil)}
-	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	session := idleClaimPoolSession()
+	delete(session.Metadata, "pool_managed")
+	work := []beads.Bead{{ID: "work-a", Status: "open"}}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{session}, nil)
+	clk := &clock.Fake{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
 	var out bytes.Buffer
 
-	nudgeStalledPoolClaims(sp, cfg, store, sessions, work, base, &out)
-	nudgeStalledPoolClaims(sp, cfg, store, sessions, work, base.Add(time.Hour), &out)
-	if out.Len() != 0 {
-		t.Fatalf("must not touch a non-pool session: %q", out.String())
+	nudgeStalledPoolClaims(sp, cfg, store, []beads.Bead{session}, work, clk.Now(), &out)
+	clk.Advance(time.Hour)
+	session = mustGetTestBead(t, store, session.ID)
+	nudgeStalledPoolClaims(sp, cfg, store, []beads.Bead{session}, work, clk.Now(), &out)
+	if got := sp.CountCalls("Nudge", "session-a"); got != 0 {
+		t.Fatalf("non-pool Nudge calls = %d, want 0", got)
+	}
+	session = mustGetTestBead(t, store, session.ID)
+	if got := session.Metadata[idleClaimNudgeTriggerKey]; got != "" {
+		t.Fatalf("non-pool marker trigger = %q, want empty", got)
 	}
 }

--- a/cmd/gc/nudge_backstop.go
+++ b/cmd/gc/nudge_backstop.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// backstopPredicate adapts the shared nudge-backstop engine (observe → nudge
+// → backoff → give-up, see decideBackstopAction) to one class of session.
+// Each predicate owns its own eligibility test, outstanding-work resolution,
+// nudge content, and persisted-metadata shape; the engine drives only the
+// shared timing decision and the actual runtime.Provider.Nudge delivery.
+//
+// poolClaimBackstop (idle_nudge.go) is the first predicate. A second, for
+// named/direct startup kickoff, is tracked as a separate bead rather than
+// built here — this engine exists because two concrete predicates are now
+// in scope, not speculatively ahead of them.
+type backstopPredicate interface {
+	// governs reports whether this predicate applies to the session bead at
+	// all.
+	governs(s beads.Bead) bool
+
+	// outstandingID resolves the id of the work item sessName is waiting on.
+	// ok is false when nothing is outstanding, in which case clear is
+	// invoked to wipe any persisted state.
+	outstandingID(s beads.Bead, work map[string]beads.Bead, sessName string) (id string, ok bool)
+
+	// state reads the persisted pacing state for id. same is false when id
+	// is an assignment not yet observed, in which case the engine calls
+	// observe to (re)start the grace clock instead of consulting attempts.
+	state(s beads.Bead, id string) (same bool, attempts int, last time.Time)
+
+	// content resolves the text to nudge with, or "" to skip silently.
+	content(s beads.Bead) string
+
+	// observe persists the start of a new assignment's grace window.
+	observe(store beads.Store, s *beads.Bead, id string, now time.Time, stdout io.Writer)
+
+	// record persists a delivered nudge attempt.
+	record(store beads.Store, s *beads.Bead, id string, attempts int, now time.Time, stdout io.Writer)
+
+	// exhausted is invoked once attempts reach the shared max attempts.
+	exhausted(store beads.Store, s *beads.Bead, stdout io.Writer)
+
+	// clear wipes persisted state once nothing is outstanding.
+	clear(store beads.Store, s *beads.Bead, stdout io.Writer)
+}
+
+// backstopAction is the shared timing engine's verdict for one session on one
+// reconcile tick.
+type backstopAction int
+
+const (
+	backstopActionWait backstopAction = iota
+	backstopActionNudge
+	backstopActionExhausted
+)
+
+// decideBackstopAction is the observe(grace) → nudge → backoff → give-up
+// timing rule shared by every backstop predicate, extracted unchanged from
+// nudgeStalledPoolClaims. attempts is the number of nudges already delivered
+// for the current assignment; last is the time of the last attempt, or of
+// first observation when attempts is 0. Pacing reuses the exact constants
+// proven by the pool-claim backstop (idleClaimNudgeGrace/Backoff/MaxAttempts,
+// idle_nudge.go).
+func decideBackstopAction(attempts int, last, now time.Time) backstopAction {
+	switch {
+	case attempts == 0:
+		if now.Sub(last) < idleClaimNudgeGrace {
+			return backstopActionWait // still inside the observe-first grace
+		}
+	case attempts >= idleClaimNudgeMaxAttempts:
+		return backstopActionExhausted // gave up; manual re-nudge is the escape hatch
+	default:
+		if now.Sub(last) < idleClaimNudgeBackoff {
+			return backstopActionWait // waiting out the backoff before the next retry
+		}
+	}
+	return backstopActionNudge
+}
+
+// runNudgeBackstop drives pred over sessionBeads: for each session it governs
+// that is running and has outstanding work, it paces re-delivery of pred's
+// nudge content through the shared grace → nudge → backoff → give-up engine,
+// persisting all state via pred so a controller restart cannot replay it.
+// label prefixes stdout diagnostics so multiple backstops stay distinguishable
+// in logs.
+func runNudgeBackstop(
+	sp runtime.Provider,
+	store beads.Store,
+	sessionBeads []beads.Bead,
+	work []beads.Bead,
+	now time.Time,
+	stdout io.Writer,
+	label string,
+	pred backstopPredicate,
+) {
+	if sp == nil || store == nil {
+		return // hot reconcile path: never panic on a half-built dependency
+	}
+	workByID := make(map[string]beads.Bead, len(work))
+	for _, w := range work {
+		workByID[w.ID] = w
+	}
+
+	for i := range sessionBeads {
+		s := &sessionBeads[i]
+		if !pred.governs(*s) {
+			continue
+		}
+		sessName := strings.TrimSpace(s.Metadata["session_name"])
+		if sessName == "" || !sp.IsRunning(sessName) {
+			continue
+		}
+
+		id, ok := pred.outstandingID(*s, workByID, sessName)
+		if !ok {
+			pred.clear(store, s, stdout)
+			continue
+		}
+
+		same, attempts, last := pred.state(*s, id)
+		if !same {
+			// First observation of this assignment: start the grace clock,
+			// don't nudge yet — a normal claim/confirmation almost always
+			// lands within the grace window.
+			pred.observe(store, s, id, now, stdout)
+			continue
+		}
+
+		switch decideBackstopAction(attempts, last, now) {
+		case backstopActionWait:
+			continue
+		case backstopActionExhausted:
+			pred.exhausted(store, s, stdout)
+			continue
+		case backstopActionNudge:
+			content := pred.content(*s)
+			if content == "" {
+				continue
+			}
+			if err := sp.Nudge(sessName, runtime.TextContent(content)); err != nil {
+				fmt.Fprintf(stdout, "%s: %s failed: %v\n", label, sessName, err) //nolint:errcheck // best-effort
+				continue
+			}
+			fmt.Fprintf(stdout, "%s: nudged %s for %s (attempt %d/%d)\n", label, sessName, id, attempts+1, idleClaimNudgeMaxAttempts) //nolint:errcheck // best-effort
+			pred.record(store, s, id, attempts+1, now, stdout)
+		}
+	}
+}

--- a/release-gates/ga-4an0nc-backstop-engine-gate.md
+++ b/release-gates/ga-4an0nc-backstop-engine-gate.md
@@ -1,0 +1,47 @@
+# Release Gate: Shared nudge backstop engine
+
+Date: 2026-07-19T19:28:13Z
+Deployer: gascity/deployer
+Deploy bead: `ga-4an0nc`
+Source review bead: `ga-3zz4m2`
+Parent feature bead: `ga-zogqc1.2.3`
+
+## Candidate
+
+- PR branch: `release/ga-4an0nc-backstop-engine`
+- Reviewed source commit: `8016aa6f91bb8bcc79cacbc5972b92140e69f8bf`
+- Base checked for mergeability: `origin/main` at `2b9a7d9263e2c3309a0e2997f5c5fd2adca849b9`
+- Reviewer-visible delta:
+  - `cmd/gc/idle_nudge.go`
+  - `cmd/gc/idle_nudge_test.go`
+  - `cmd/gc/nudge_backstop.go`
+
+## Gate Inputs
+
+- `docs/PROJECT_MANIFEST.md` is not present in this worktree; release criteria were evaluated against the deployer role's explicit seven-point release gate.
+- `TESTING.md` was read before selecting the broad local runner; it names `make test-fast-parallel` as the default broad fast-unit baseline.
+- The deploy instruction requested the standard deploy gate: build, smoke, and fast tests.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead `ga-3zz4m2` is closed with `REVIEW VERDICT: PASS` for commit `8016aa6f9`. The deploy bead records the same reviewed branch and commit. |
+| 2 | Acceptance criteria met | PASS | The pool idle-claim pacing state machine is extracted into package-private `backstopPredicate`, `runNudgeBackstop`, and `decideBackstopAction` in `cmd/gc/nudge_backstop.go`. `poolClaimBackstop` in `cmd/gc/idle_nudge.go` preserves the pool-specific eligibility, metadata keys, nudge content, and the 90s grace / 3m backoff / 3-attempt cap. The runtime provider API is unchanged; the engine only calls existing `IsRunning` and `Nudge`. Focused tests cover nudge-after-grace, no nudge for working slots, give-up at cap, and non-pool skip. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc/...` passed. `go test ./cmd/gc -run '^TestNudgeStalledPoolClaims_(NudgesAfterGrace|NeverTouchesWorkingSlot|GivesUpAtCap|SkipsNonPool)$' -count=1` passed. `go vet ./...` passed. `gofmt -l cmd/gc/idle_nudge.go cmd/gc/idle_nudge_test.go cmd/gc/nudge_backstop.go` produced no output. `make test-fast-parallel` passed with all fast shards green and `All fast jobs passed`. |
+| 4 | No high-severity review findings open | PASS | Source review notes list no HIGH findings or blockers. A targeted scan of the deploy and review bead text for `HIGH`, high-severity markers, and request-changes markers produced no open finding evidence. |
+| 5 | Final branch is clean | PASS | Before writing this checklist, `git status --short --branch` reported only `## release/ga-4an0nc-backstop-engine`. This checklist is the only deployer change and is committed as the final branch tip before push. |
+| 6 | Branch diverges cleanly from main | PASS | Checked first, then rechecked after `origin/main` advanced during deploy. `git merge-tree --write-tree origin/main HEAD` completed successfully with no conflicts against `2b9a7d926`, producing tree `4eb241663f4fb956a83292cc86a9f666b141c78e`. No bounded self-rebase was needed. |
+| 7 | Single feature theme | PASS | The commit set contains one feature theme: generalizing pool idle-nudge pacing into a shared in-process backstop engine under `cmd/gc`. The diff is limited to `cmd/gc` idle-nudge code and tests; it does not bundle an unrelated user-facing behavior or package. |
+
+## Validation
+
+- `go build ./cmd/gc/...` - PASS.
+- `go test ./cmd/gc -run '^TestNudgeStalledPoolClaims_(NudgesAfterGrace|NeverTouchesWorkingSlot|GivesUpAtCap|SkipsNonPool)$' -count=1` - PASS.
+- `go vet ./...` - PASS.
+- `gofmt -l cmd/gc/idle_nudge.go cmd/gc/idle_nudge_test.go cmd/gc/nudge_backstop.go` - PASS, no output.
+- `make test-fast-parallel` - PASS, all fast jobs passed.
+
+## Deploy Decision
+
+PASS. Commit this gate checklist to `release/ga-4an0nc-backstop-engine`, push the branch, open a PR, record the PR URL on `ga-4an0nc`, close the deploy bead, and route a merge-request to mayor. Deployer does not merge.


### PR DESCRIPTION
## What this changes

The pool idle-claim nudge backstop now runs through a shared in-process engine instead of carrying its grace/backoff/max-attempt pacing inline. Pool slots keep the same operator-visible behavior: a newly observed unclaimed trigger gets a 90 second grace window, then up to three nudges spaced by a 3 minute backoff, and then the backstop gives up until a manual re-nudge or a new assignment.

This is mainly a refactor for the next startup-kickoff path: the reusable engine owns only timing and delivery, while the pool predicate still owns pool eligibility, outstanding-work lookup, persisted metadata, and nudge content.

## Review notes

- `cmd/gc/nudge_backstop.go` is package-private to `cmd/gc`; it does not introduce a new SDK primitive.
- `cmd/gc/idle_nudge.go` keeps the existing pool metadata keys and pacing constants.
- `runtime.Provider` is unchanged; the engine uses existing `IsRunning` and `Nudge`.
- No new config, endpoint, migration, dependency, or dashboard surface is introduced.

## Test plan

- [x] `go build ./cmd/gc/...`
- [x] `go test ./cmd/gc -run '^TestNudgeStalledPoolClaims_(NudgesAfterGrace|NeverTouchesWorkingSlot|GivesUpAtCap|SkipsNonPool)$' -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-4an0nc-backstop-engine-gate.md`](release-gates/ga-4an0nc-backstop-engine-gate.md)
