### PR TITLE
fix: detach timeout watchdog streams

### DIFF
--- a/cmd/gc/gc_beads_bd_journal_recovery_test.go
+++ b/cmd/gc/gc_beads_bd_journal_recovery_test.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // These tests exercise the journal-corruption auto-recovery helpers from
@@ -128,8 +134,7 @@ func (e journalRecoveryEnv) addDatabase(t *testing.T, name string, corrupt bool,
 	}
 }
 
-func (e journalRecoveryEnv) run(t *testing.T, harness string, extraEnv ...string) (string, error) {
-	t.Helper()
+func (e journalRecoveryEnv) command(harness string, extraEnv ...string) *exec.Cmd {
 	cmd := exec.Command("bash", "-c", harness)
 	cmd.Env = append(os.Environ(),
 		"PATH="+e.binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
@@ -138,8 +143,162 @@ func (e journalRecoveryEnv) run(t *testing.T, harness string, extraEnv ...string
 		"LOG_FILE="+e.logFile,
 	)
 	cmd.Env = append(cmd.Env, extraEnv...)
+	return cmd
+}
+
+func (e journalRecoveryEnv) run(t *testing.T, harness string, extraEnv ...string) (string, error) {
+	t.Helper()
+	cmd := e.command(harness, extraEnv...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func TestRunWithTimeoutCapturedOutputDoesNotWaitForWatchdogSleep(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+
+	root := repoRootForLint(t)
+	scriptBytes, err := os.ReadFile(filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh"))
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	runWithTimeout := extractShellFunction(t, string(scriptBytes), "run_with_timeout")
+
+	newPipe := func(name string) (*os.File, *os.File) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("create %s pipe: %v", name, err)
+		}
+		t.Cleanup(func() {
+			_ = r.Close()
+			_ = w.Close()
+		})
+		return r, w
+	}
+	signalR, signalW := newPipe("sleep-signal")
+	releaseR, releaseW := newPipe("sleep-release")
+	commandGateR, commandGateW := newPipe("command-gate")
+
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "sleep"), `#!/bin/sh
+set -u
+[ "$#" -eq 1 ] && [ "$1" = "120" ] || exit 64
+: "${SLEEP_SIGNAL_FD:?}"
+: "${SLEEP_RELEASE_FD:?}"
+: "${COMMAND_GATE_WRITE_FD:?}"
+printf 'started\n' >&"$SLEEP_SIGNAL_FD"
+printf 'go\n' >&"$COMMAND_GATE_WRITE_FD"
+IFS= read -r release <&"$SLEEP_RELEASE_FD"
+[ "$release" = "release" ] || exit 65
+printf 'finished\n' >&"$SLEEP_SIGNAL_FD"
+`)
+
+	harness := "#!/usr/bin/env bash\nset -u\n" + runWithTimeout + `
+result=$(run_with_timeout 120 sh -c 'IFS= read -r gate <&"$COMMAND_GATE_READ_FD"; [ "$gate" = go ]; printf command-output')
+printf 'result=%s\n' "$result"
+`
+	env := journalRecoveryEnv{binDir: binDir}
+	cmd := env.command(harness,
+		"SLEEP_SIGNAL_FD=3",
+		"SLEEP_RELEASE_FD=4",
+		"COMMAND_GATE_WRITE_FD=5",
+		"COMMAND_GATE_READ_FD=6",
+	)
+	cmd.ExtraFiles = []*os.File{signalW, releaseR, commandGateW, commandGateR}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start run_with_timeout harness: %v", err)
+	}
+	_ = signalW.Close()
+	_ = releaseR.Close()
+	_ = commandGateR.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	controlsReleased := false
+	releaseControls := func() {
+		if controlsReleased {
+			return
+		}
+		controlsReleased = true
+		_, _ = fmt.Fprintln(commandGateW, "go")
+		_ = commandGateW.Close()
+		_, _ = fmt.Fprintln(releaseW, "release")
+		_ = releaseW.Close()
+	}
+	signalReader := bufio.NewReader(signalR)
+	readSignal := func(name, want string) error {
+		if err := signalR.SetReadDeadline(time.Now().Add(testutil.ExecRaceTimeout)); err != nil {
+			return fmt.Errorf("set %s deadline: %w", name, err)
+		}
+		var got string
+		if _, err := fmt.Fscan(signalReader, &got); err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if got != want {
+			return fmt.Errorf("%s = %q, want %q", name, got, want)
+		}
+		return nil
+	}
+	var runErr error
+	doneConsumed := false
+	waitCommand := func() bool {
+		if doneConsumed {
+			return true
+		}
+		timer := time.NewTimer(testutil.ExecRaceTimeout)
+		defer timer.Stop()
+		select {
+		case runErr = <-done:
+			doneConsumed = true
+			return true
+		case <-timer.C:
+			return false
+		}
+	}
+	defer func() {
+		releaseControls()
+		if waitCommand() {
+			return
+		}
+		_ = cmd.Process.Kill()
+		runErr = <-done
+		doneConsumed = true
+	}()
+
+	if err := readSignal("watchdog sleep started signal", "started"); err != nil {
+		t.Fatal(err)
+	}
+
+	completedBeforeRelease := waitCommand()
+	releaseControls()
+	if err := readSignal("watchdog sleep finished signal", "finished"); err != nil {
+		t.Fatal(err)
+	}
+	blockedByWatchdogPipe := !completedBeforeRelease
+	if blockedByWatchdogPipe {
+		if !waitCommand() {
+			t.Fatal("run_with_timeout harness did not finish after releasing the watchdog sleep")
+		}
+	}
+
+	if runErr != nil {
+		t.Errorf("run_with_timeout harness failed: %v\nstderr: %s", runErr, stderr.String())
+	}
+	if got, want := stdout.String(), "result=command-output\n"; got != want {
+		t.Errorf("harness output = %q, want %q", got, want)
+	}
+	if got := stderr.String(); got != "" {
+		t.Errorf("harness stderr = %q, want empty", got)
+	}
+	if blockedByWatchdogPipe {
+		t.Fatal("run_with_timeout command substitution stayed blocked after the watchdog sleep released the timed command because the sleep retained the substitution output pipe")
+	}
 }
 
 func prodRepoState(backupDir string) string {

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -208,7 +208,7 @@ run_with_timeout() {
     (
         sleep "$timeout_seconds" 2>/dev/null || sleep 1
         kill "$cmd_pid" 2>/dev/null || true
-    ) &
+    ) </dev/null >/dev/null 2>&1 &
     local watchdog_pid=$!
     local status=0
     wait "$cmd_pid" || status=$?
@@ -2028,10 +2028,9 @@ log_tail_has_journal_corruption() {
 # database_journal_corrupt probes one database directory offline and reports
 # whether dolt refuses to load it with a journal-corruption error. Only safe
 # while the managed server is down — offline dolt commands contend with a
-# running server's file locks. Probe output is spooled to a temp file rather
-# than captured via command substitution: the run_with_timeout watchdog's
-# sleep child inherits a substitution pipe and would hold it open for the
-# full timeout, turning every healthy-database probe into a 30s stall.
+# running server's file locks. Probe output is spooled to a temp file so stdout
+# and stderr can be scanned together without retaining the diagnostic stream
+# in a shell variable.
 database_journal_corrupt() {
     local probe_db_dir="$1" probe_out probe_hit=1
     probe_out=$(mktemp) || {


### PR DESCRIPTION
## Summary

- Detach the timeout watchdog subprocess from standard input, output, and error so its surviving `sleep` child cannot retain a command-substitution pipe.
- Add a deterministic regression that executes the real materialized `run_with_timeout` function and controls watchdog/command progress with explicit pipe events.
- Replace the obsolete journal-probe workaround explanation with the remaining reason for spooling diagnostics.

## Regression edge

A command invoked through `run_with_timeout` inside command substitution must return its captured output while the watchdog sleep is deliberately still alive and blocked. Releasing that sleep afterward must produce clean shutdown.

The test confirms watchdog startup before allowing the timed command to complete. Elapsed time is only a safety deadline, never the assertion.

## Ownership map

- The new focused test owns watchdog file-descriptor lifetime and command-substitution completion.
- Existing journal-recovery tests retain ownership of corruption detection, backup restore, and healthy-database behavior.
- Existing lifecycle tests retain ownership of real `lsof` process discovery and managed-Dolt restart behavior.
- The resource census is unchanged because the test reuses the existing command helper.

## Timing

| Edge | Before | After |
| --- | ---: | ---: |
| Captured-output regression | fails after 10.01s, blocked by retained pipe | passes in 0.01s |

Repeated lifecycle observations were noisy, so this PR makes no broader end-to-end timing claim.

## Verification

- Focused regression: 50/50 passed.
- Race-enabled regression: 20/20 passed.
- Related journal and embedded/materialization owners passed.
- Resource-census ratchet passed unchanged.
- `bash -n examples/bd/assets/scripts/gc-beads-bd.sh` passed.
- Staged pre-commit gate passed format, lint, generated-artifact checks, and `go vet ./...`.
- Two independent read-only reviewers approved effective diff `0b2f4fa6ec2c77429cd9daa3faed84718d910fdda09559bdb4f5640d18a02165`.

The local pre-push sweep encountered only the known host-umask `TestWriteRunMap*` / `TestPruneRunMap*` failures; affected and neighboring owners above are green.
