### PR TITLE
fix(status): restore store_health via hydration-free bead counting (#1896 follow-up)

### DIFF
--- a/internal/api/store_health.go
+++ b/internal/api/store_health.go
@@ -113,17 +113,34 @@ func statusStoreHealthFromDomain(h storehealth.Health) *StatusStoreHealth {
 // countBeadStoreRows returns the number of retained beads in store, including
 // open and closed beads. A nil store and measurement failures are returned as
 // errors so callers do not mistake an unavailable denominator for zero.
-// The closed-inclusive query is never answerable from the in-memory cache,
-// so this path always hydrates; counting closed history without
-// hydration needs backend support (#1896 follow-up). Because it always
-// hydrates, this is the store-health block's exposure to ga-cdmx6x's
-// bd-child leak; statusListStoreWithTimeout's state.ScopedStoreLike wiring
-// covers it the same way as the work-count fallback.
+// The closed-inclusive query is never answerable from the in-memory cache, so
+// the count prefers the hydration-free beads.Counter path (the #1896
+// follow-up): hydrating tens of thousands of closed rows cannot finish inside
+// statusStoreReadTimeout on a long-lived city, which left store_health
+// permanently absent. The hydrating List fallback remains for stores without
+// a Counter and for shapes Count reports as unsupported; that path is the
+// store-health block's exposure to ga-cdmx6x's bd-child leak, covered by
+// statusListStoreWithTimeout's state.ScopedStoreLike wiring the same way as
+// the work-count fallback.
 func countBeadStoreRows(ctx context.Context, state State, store beads.Store) (int, error) {
 	if store == nil {
 		return 0, errors.New("counting retained bead rows: store unavailable")
 	}
-	list, err := statusListStoreWithTimeout(ctx, state, store, beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	query := beads.ListQuery{AllowScan: true, IncludeClosed: true}
+	if counter, ok := store.(beads.Counter); ok {
+		// cachedStoreHealth strips the request deadline, so bound the count
+		// here the same way the status handler bounds its store reads.
+		reqCtx, cancel := context.WithTimeout(ctx, statusStoreReadTimeout)
+		n, err := counter.Count(reqCtx, query)
+		cancel()
+		if err == nil {
+			return n, nil
+		}
+		if !errors.Is(err, beads.ErrCountUnsupported) {
+			return 0, fmt.Errorf("counting retained bead rows: %w", err)
+		}
+	}
+	list, err := statusListStoreWithTimeout(ctx, state, store, query)
 	if err != nil {
 		return 0, fmt.Errorf("counting retained bead rows: %w", err)
 	}

--- a/internal/api/store_health_test.go
+++ b/internal/api/store_health_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -457,6 +458,79 @@ func TestCountBeadStoreRowsIncludesClosedBeads(t *testing.T) {
 	}
 	if got != 2 {
 		t.Fatalf("countBeadStoreRows = %d, want 2 including closed bead %s and open bead %s", got, closed.ID, open.ID)
+	}
+}
+
+type storeHealthCounterStore struct {
+	beads.Store
+	count     int
+	countErr  error
+	gotQuery  *beads.ListQuery
+	listCalls int
+}
+
+func (s *storeHealthCounterStore) Count(_ context.Context, query beads.ListQuery, _ ...string) (int, error) {
+	s.gotQuery = &query
+	return s.count, s.countErr
+}
+
+func (s *storeHealthCounterStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls++
+	return s.Store.List(query)
+}
+
+func TestCountBeadStoreRowsPrefersCounterWithoutHydration(t *testing.T) {
+	store := &storeHealthCounterStore{Store: beads.NewMemStore(), count: 41252}
+
+	got, err := countBeadStoreRows(context.Background(), newFakeState(t), store)
+	if err != nil {
+		t.Fatalf("countBeadStoreRows: %v", err)
+	}
+	if got != 41252 {
+		t.Fatalf("countBeadStoreRows = %d, want Counter result 41252", got)
+	}
+	if store.listCalls != 0 {
+		t.Fatalf("List called %d times, want 0 (Counter path must not hydrate)", store.listCalls)
+	}
+	if store.gotQuery == nil || !store.gotQuery.IncludeClosed || !store.gotQuery.AllowScan {
+		t.Fatalf("Count query = %+v, want AllowScan and IncludeClosed set", store.gotQuery)
+	}
+}
+
+func TestCountBeadStoreRowsFallsBackWhenCountUnsupported(t *testing.T) {
+	store := &storeHealthCounterStore{
+		Store:    beads.NewMemStore(),
+		countErr: fmt.Errorf("counting beads: %w", beads.ErrCountUnsupported),
+	}
+	if _, err := store.Create(beads.Bead{Title: "x"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := countBeadStoreRows(context.Background(), newFakeState(t), store)
+	if err != nil {
+		t.Fatalf("countBeadStoreRows: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("countBeadStoreRows = %d, want 1 from List fallback", got)
+	}
+	if store.listCalls == 0 {
+		t.Fatal("List never called, want hydrating fallback on ErrCountUnsupported")
+	}
+}
+
+func TestCountBeadStoreRowsReturnsCounterError(t *testing.T) {
+	wantErr := errors.New("store health count failed")
+	store := &storeHealthCounterStore{Store: beads.NewMemStore(), countErr: wantErr}
+
+	got, err := countBeadStoreRows(context.Background(), newFakeState(t), store)
+	if got != 0 {
+		t.Errorf("countBeadStoreRows = %d, want zero value on Counter error", got)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("countBeadStoreRows error = %v, want %v", err, wantErr)
+	}
+	if store.listCalls != 0 {
+		t.Fatalf("List called %d times after non-unsupported Counter error, want 0", store.listCalls)
 	}
 }
 

--- a/internal/beads/native_dolt_store_count.go
+++ b/internal/beads/native_dolt_store_count.go
@@ -1,0 +1,98 @@
+package beads
+
+import (
+	"context"
+	"fmt"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// Count implements the optional Counter capability with the pinned beads
+// library's CountIssues: a hydration-free SELECT COUNT(*) over the durable
+// issues table merged with the wisps tier, mirroring SearchIssues' merge
+// semantics (upstream GH#4387 — the wisps undercount that previously kept
+// this store Counter-less is fixed there). This answers the closed-inclusive
+// shapes the CachingStore can never serve from its open-bead cache — most
+// importantly the store-health denominator, whose hydrating List fallback
+// cannot finish inside the status read timeout on a long-lived city (#1896
+// follow-up).
+//
+// Count answers only shapes whose ListQuery→IssueFilter translation is
+// exact, so the backend count equals List's post-ApplyListQuery cardinality;
+// everything else reports ErrCountUnsupported and callers fall back to the
+// hydrating List, exactly as the Counter contract specifies. See
+// nativeDoltCountSupported for the shape-by-shape rationale. Known parity
+// gap: rows whose metadata JSON fails to parse are dropped by List but
+// counted here — that state is store corruption, and counting such a row
+// beats reporting no count at all.
+func (s *NativeDoltStore) Count(ctx context.Context, query ListQuery, excludeTypes ...string) (int, error) {
+	if err := query.Validate(); err != nil {
+		return 0, err
+	}
+	if !query.HasFilter() && !query.AllowScan {
+		return 0, fmt.Errorf("counting beads: %w", ErrQueryRequiresScan)
+	}
+	if !nativeDoltCountSupported(query, excludeTypes) {
+		return 0, fmt.Errorf("counting beads: %w", ErrCountUnsupported)
+	}
+	var n int
+	err := s.withReadRetry(func(readCtx context.Context, storage beadslib.Storage) error {
+		// The Counter contract promises the caller's ctx cancels the backing
+		// query, but withReadRetry runs fn under its own retry-budget context.
+		// Derive a context canceled by either, and surface the caller's
+		// cancellation as the context error itself so the retry loop treats
+		// it as terminal instead of reconnect-worthy.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		countCtx, cancel := context.WithCancel(readCtx)
+		defer cancel()
+		stop := context.AfterFunc(ctx, cancel)
+		defer stop()
+		total, err := storage.CountIssues(countCtx, "", nativeIssueFilterFromListQuery(query))
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return err
+		}
+		n = int(total)
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("counting beads: %w", err)
+	}
+	return n, nil
+}
+
+// nativeDoltCountSupported reports whether Count can answer query with
+// List-cardinality parity. Rejected shapes and why:
+//   - excludeTypes: the upstream IssueFilter has no type-exclusion
+//     predicate; List's callers apply it post-hydration.
+//   - non-default tiers: nativeIssueFilterFromListQuery defers the wisp
+//     tier filter to ApplyListQuery, so the backend result is a superset.
+//   - Status "open": translated to an exclude-list (closed, in_progress)
+//     while Matches requires status == "open" exactly, so beads in any
+//     other non-excluded status would be overcounted.
+//   - Assignees / ParentIDs / SeekAfter / UpdatedBefore: not translated
+//     into the filter at all; List narrows them Go-side.
+//   - Metadata / CreatedBefore / ParentID: translated, but List re-applies
+//     them through Matches with Go-side semantics (exact metadata match vs
+//     the backend's own predicate, Before() precision, the parent
+//     projection) a bare COUNT cannot be proven to reproduce — the same
+//     over-conservative gate the DoltLite Counter applies.
+//   - Limit: the Counter contract is List cardinality, including List's
+//     post-sort limit cap.
+func nativeDoltCountSupported(query ListQuery, excludeTypes []string) bool {
+	return len(excludeTypes) == 0 &&
+		query.TierMode == TierIssues &&
+		query.Status != "open" &&
+		len(query.Assignees) == 0 &&
+		len(query.ParentIDs) == 0 &&
+		query.SeekAfter == nil &&
+		query.UpdatedBefore.IsZero() &&
+		len(query.Metadata) == 0 &&
+		query.CreatedBefore.IsZero() &&
+		query.ParentID == "" &&
+		query.Limit == 0
+}

--- a/internal/beads/native_dolt_store_count.go
+++ b/internal/beads/native_dolt_store_count.go
@@ -83,9 +83,20 @@ func (s *NativeDoltStore) Count(ctx context.Context, query ListQuery, excludeTyp
 //     over-conservative gate the DoltLite Counter applies.
 //   - Limit: the Counter contract is List cardinality, including List's
 //     post-sort limit cap.
+//
+// TierBoth is supported alongside TierIssues: it is the one tier with no
+// narrowing anywhere — no SQL ephemeral predicate (nativeIssueFilterFromListQuery
+// emits no tier filter) and no Go-side re-filter (matchesTier returns true
+// unconditionally) — so CountIssues' SearchIssues-mirroring merge is already
+// the exact List cardinality. This matters in practice: beadPolicyStore
+// expands every TierIssues read to TierBoth, so a TierIssues-only gate makes
+// policy-wrapped cities (any city with bead policies, e.g. order_tracking
+// retention) silently lose the Counter fast path and fall back to hydration.
+// TierWisps stays unsupported: its ephemeral||no-history membership is
+// resolved Go-side and has no exact filter translation.
 func nativeDoltCountSupported(query ListQuery, excludeTypes []string) bool {
 	return len(excludeTypes) == 0 &&
-		query.TierMode == TierIssues &&
+		(query.TierMode == TierIssues || query.TierMode == TierBoth) &&
 		query.Status != "open" &&
 		len(query.Assignees) == 0 &&
 		len(query.ParentIDs) == 0 &&

--- a/internal/beads/native_dolt_store_count_test.go
+++ b/internal/beads/native_dolt_store_count_test.go
@@ -1,17 +1,187 @@
 package beads
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
 
-// NativeDoltStore must NOT implement Counter. The pinned beads library's
-// CountIssues counts only the issues table, while SearchIssues (the List
-// path) also merges the wisps table — no-history and ephemeral rows — so
-// a backend COUNT undercounts open work relative to List (#1896 review).
-// Hydration-free counting happens at the caching layer instead; when the
-// cache cannot answer, CachingStore.Count reports ErrCountUnsupported and
-// callers fall back to the hydrating List path, which is exact.
-func TestNativeDoltStoreDoesNotImplementCounter(t *testing.T) {
+	beadslib "github.com/steveyegge/beads"
+)
+
+// NativeDoltStore implements Counter through the pinned beads library's
+// CountIssues, which merges the wisps tier with the same semantics as
+// SearchIssues (GH#4387) — the wisps undercount that previously pinned this
+// store as Counter-less is fixed upstream. The supported-shape gate keeps
+// the parity contract: only queries whose ListQuery→IssueFilter translation
+// is exact are answered; everything else reports ErrCountUnsupported so
+// callers fall back to the hydrating List.
+
+func TestNativeDoltStoreImplementsCounter(t *testing.T) {
 	var store any = &NativeDoltStore{}
-	if _, ok := store.(Counter); ok {
-		t.Fatal("NativeDoltStore implements Counter; the backing CountIssues misses wisps-table rows (no-history/ephemeral), undercounting vs List (#1896)")
+	if _, ok := store.(Counter); !ok {
+		t.Fatal("NativeDoltStore does not implement Counter; the closed-inclusive store-health count needs the hydration-free CountIssues path")
+	}
+}
+
+func TestNativeDoltStoreCountDelegatesToCountIssues(t *testing.T) {
+	var gotFilter *beadslib.IssueFilter
+	searchCalls := 0
+	storage := &nativeDoltStorageSpy{
+		countIssues: func(_ context.Context, query string, filter beadslib.IssueFilter) (int64, error) {
+			if query != "" {
+				t.Fatalf("CountIssues search text = %q, want empty (same as List)", query)
+			}
+			gotFilter = &filter
+			return 19342, nil
+		},
+		searchIssues: func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			searchCalls++
+			return nil, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	got, err := store.Count(context.Background(), ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != 19342 {
+		t.Fatalf("Count = %d, want 19342", got)
+	}
+	if searchCalls != 0 {
+		t.Fatalf("SearchIssues called %d times, want 0 (Count must not hydrate)", searchCalls)
+	}
+	if gotFilter == nil {
+		t.Fatal("CountIssues was never called")
+	}
+	// The filter must be the same translation List uses: closed rows
+	// included (no status exclusion) and the default tier's ephemeral
+	// exclusion applied backend-side.
+	if len(gotFilter.ExcludeStatus) != 0 {
+		t.Fatalf("filter.ExcludeStatus = %v, want none for IncludeClosed", gotFilter.ExcludeStatus)
+	}
+	if gotFilter.Ephemeral == nil || *gotFilter.Ephemeral {
+		t.Fatalf("filter.Ephemeral = %v, want &false for the default tier", gotFilter.Ephemeral)
+	}
+	if gotFilter.Limit != 0 {
+		t.Fatalf("filter.Limit = %d, want 0", gotFilter.Limit)
+	}
+}
+
+func TestNativeDoltStoreCountTranslatesExactFilterShapes(t *testing.T) {
+	var gotFilter *beadslib.IssueFilter
+	storage := &nativeDoltStorageSpy{
+		countIssues: func(_ context.Context, _ string, filter beadslib.IssueFilter) (int64, error) {
+			gotFilter = &filter
+			return 7, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	got, err := store.Count(context.Background(), ListQuery{
+		Status:        "closed",
+		Type:          "task",
+		Assignee:      "gascity/builder",
+		Label:         "sweep",
+		AllowScan:     true,
+		IncludeClosed: true,
+	})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != 7 {
+		t.Fatalf("Count = %d, want 7", got)
+	}
+	if gotFilter == nil {
+		t.Fatal("CountIssues was never called")
+	}
+	if gotFilter.Status == nil || *gotFilter.Status != beadslib.StatusClosed {
+		t.Fatalf("filter.Status = %v, want closed", gotFilter.Status)
+	}
+	if gotFilter.IssueType == nil || *gotFilter.IssueType != beadslib.IssueType("task") {
+		t.Fatalf("filter.IssueType = %v, want task", gotFilter.IssueType)
+	}
+	if gotFilter.Assignee == nil || *gotFilter.Assignee != "gascity/builder" {
+		t.Fatalf("filter.Assignee = %v, want gascity/builder", gotFilter.Assignee)
+	}
+	if len(gotFilter.Labels) != 1 || gotFilter.Labels[0] != "sweep" {
+		t.Fatalf("filter.Labels = %v, want [sweep]", gotFilter.Labels)
+	}
+}
+
+// TestNativeDoltStoreCountUnsupportedShapes asserts Count reports
+// ErrCountUnsupported for every shape List narrows Go-side, so callers fall
+// back to the hydrating path instead of receiving a superset count.
+func TestNativeDoltStoreCountUnsupportedShapes(t *testing.T) {
+	cases := []struct {
+		name         string
+		query        ListQuery
+		excludeTypes []string
+	}{
+		{name: "excludeTypes", query: ListQuery{AllowScan: true, IncludeClosed: true}, excludeTypes: []string{"message"}},
+		{name: "status open exclude-list translation", query: ListQuery{Status: "open", AllowScan: true}},
+		{name: "wisps tier filtered Go-side", query: ListQuery{AllowScan: true, TierMode: TierWisps}},
+		{name: "both tiers filtered Go-side", query: ListQuery{AllowScan: true, TierMode: TierBoth}},
+		{name: "metadata re-filtered Go-side", query: ListQuery{AllowScan: true, Metadata: map[string]string{"gc.rig": "fc"}}},
+		{name: "assignees not translated", query: ListQuery{AllowScan: true, Assignees: []string{"a", "b"}}},
+		{name: "parentID Go-side projection", query: ListQuery{AllowScan: true, ParentID: "ga-parent"}},
+		{name: "parentIDs not translated", query: ListQuery{AllowScan: true, ParentIDs: []string{"ga-parent"}}},
+		{name: "createdBefore precision", query: ListQuery{AllowScan: true, CreatedBefore: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)}},
+		{name: "updatedBefore not translated", query: ListQuery{AllowScan: true, UpdatedBefore: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)}},
+		{name: "limit cap is List-side", query: ListQuery{AllowScan: true, Limit: 5}},
+		{name: "seekAfter resolved Go-side", query: ListQuery{AllowScan: true, Sort: SortCreatedAsc, SeekAfter: &SeekBoundary{ID: "ga-1"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{
+				countIssues: func(context.Context, string, beadslib.IssueFilter) (int64, error) {
+					t.Error("CountIssues called for an unsupported shape")
+					return 0, nil
+				},
+			})
+			_, err := store.Count(context.Background(), tc.query, tc.excludeTypes...)
+			if !errors.Is(err, ErrCountUnsupported) {
+				t.Fatalf("Count err = %v, want ErrCountUnsupported", err)
+			}
+		})
+	}
+}
+
+func TestNativeDoltStoreCountRequiresFilterOrScan(t *testing.T) {
+	store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
+	if _, err := store.Count(context.Background(), ListQuery{}); !errors.Is(err, ErrQueryRequiresScan) {
+		t.Fatalf("Count err = %v, want ErrQueryRequiresScan", err)
+	}
+}
+
+func TestNativeDoltStoreCountHonorsCallerCancellation(t *testing.T) {
+	store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{
+		countIssues: func(context.Context, string, beadslib.IssueFilter) (int64, error) {
+			t.Error("CountIssues called after the caller's context was canceled")
+			return 0, nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := store.Count(ctx, ListQuery{AllowScan: true, IncludeClosed: true})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Count err = %v, want context.Canceled", err)
+	}
+}
+
+func TestNativeDoltStoreCountPropagatesBackendError(t *testing.T) {
+	wantErr := errors.New("count blew up")
+	store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{
+		countIssues: func(context.Context, string, beadslib.IssueFilter) (int64, error) {
+			return 0, wantErr
+		},
+	})
+	got, err := store.Count(context.Background(), ListQuery{AllowScan: true, IncludeClosed: true})
+	if got != 0 {
+		t.Errorf("Count = %d, want zero value on error", got)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Count err = %v, want %v", err, wantErr)
 	}
 }

--- a/internal/beads/native_dolt_store_count_test.go
+++ b/internal/beads/native_dolt_store_count_test.go
@@ -110,6 +110,32 @@ func TestNativeDoltStoreCountTranslatesExactFilterShapes(t *testing.T) {
 	}
 }
 
+// TestNativeDoltStoreCountBothTiersSupported asserts the TierBoth shape —
+// what beadPolicyStore expands every TierIssues read into — is served by
+// CountIssues with no ephemeral predicate. TierBoth has no narrowing on
+// either side (no SQL tier filter, matchesTier always true), so the merged
+// backend count is exact; gating it out silently cost policy-wrapped cities
+// the store-health fast path.
+func TestNativeDoltStoreCountBothTiersSupported(t *testing.T) {
+	var gotFilter beadslib.IssueFilter
+	store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{
+		countIssues: func(_ context.Context, _ string, filter beadslib.IssueFilter) (int64, error) {
+			gotFilter = filter
+			return 20641, nil
+		},
+	})
+	n, err := store.Count(context.Background(), ListQuery{AllowScan: true, IncludeClosed: true, TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("Count(TierBoth) err = %v, want nil", err)
+	}
+	if n != 20641 {
+		t.Fatalf("Count(TierBoth) = %d, want 20641", n)
+	}
+	if gotFilter.Ephemeral != nil {
+		t.Fatalf("filter.Ephemeral = %v, want nil (no tier predicate for TierBoth)", *gotFilter.Ephemeral)
+	}
+}
+
 // TestNativeDoltStoreCountUnsupportedShapes asserts Count reports
 // ErrCountUnsupported for every shape List narrows Go-side, so callers fall
 // back to the hydrating path instead of receiving a superset count.
@@ -122,7 +148,6 @@ func TestNativeDoltStoreCountUnsupportedShapes(t *testing.T) {
 		{name: "excludeTypes", query: ListQuery{AllowScan: true, IncludeClosed: true}, excludeTypes: []string{"message"}},
 		{name: "status open exclude-list translation", query: ListQuery{Status: "open", AllowScan: true}},
 		{name: "wisps tier filtered Go-side", query: ListQuery{AllowScan: true, TierMode: TierWisps}},
-		{name: "both tiers filtered Go-side", query: ListQuery{AllowScan: true, TierMode: TierBoth}},
 		{name: "metadata re-filtered Go-side", query: ListQuery{AllowScan: true, Metadata: map[string]string{"gc.rig": "fc"}}},
 		{name: "assignees not translated", query: ListQuery{AllowScan: true, Assignees: []string{"a", "b"}}},
 		{name: "parentID Go-side projection", query: ListQuery{AllowScan: true, ParentID: "ga-parent"}},

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -1870,6 +1870,7 @@ type nativeDoltStorageSpy struct {
 	closeIssue                  func(context.Context, string, string, string, string) error
 	deleteIssue                 func(context.Context, string) error
 	searchIssues                func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error)
+	countIssues                 func(context.Context, string, beadslib.IssueFilter) (int64, error)
 	getReadyWork                func(context.Context, beadslib.WorkFilter) ([]*beadslib.Issue, error)
 	addLabel                    func(context.Context, string, string, string) error
 	removeLabel                 func(context.Context, string, string, string) error
@@ -1948,6 +1949,13 @@ func (s *nativeDoltStorageSpy) SearchIssues(ctx context.Context, query string, f
 		return nil, nil
 	}
 	return s.searchIssues(ctx, query, filter)
+}
+
+func (s *nativeDoltStorageSpy) CountIssues(ctx context.Context, query string, filter beadslib.IssueFilter) (int64, error) {
+	if s.countIssues == nil {
+		return 0, nil
+	}
+	return s.countIssues(ctx, query, filter)
 }
 
 func (s *nativeDoltStorageSpy) GetReadyWork(ctx context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {


### PR DESCRIPTION
## Problem

On a long-lived city (~20k retained beads), `/v0/status` permanently reports

```
store health: counting retained bead rows: list timed out: context deadline exceeded
```

and omits the `store_health` block, so the dashboard loses the Dolt-noms trend. `countBeadStoreRows` counts the closed-inclusive denominator by **hydrating every bead** through the store client under the 1s `statusStoreReadTimeout` — unfinishable at that size, while a bare `COUNT(*)` on the same table is milliseconds. The code already pointed at the fix: *"counting closed history without hydration needs backend support (#1896 follow-up)"*.

## Why the backend support was missing

`NativeDoltStore` deliberately does not implement `Counter` — pinned by `TestNativeDoltStoreDoesNotImplementCounter`, whose rationale is that the beads library's `CountIssues` counts only the issues table and undercounts vs the wisps-merging `SearchIssues`. That rationale is **stale**: the pinned beads v1.1.0 merges the wisps tier in `CountIssuesInTx` with `SearchIssues`' exact semantics (steveyegge/beads GH#4387), as a hydration-free `SELECT COUNT(*)` per table.

## Fix (3 commits)

1. **api**: `countBeadStoreRows` prefers the hydration-free `beads.Counter` path, falling back to the hydrating `List` only for stores without a `Counter` or shapes `Count` reports unsupported (mirrors the existing `cmd/gc` store-health pattern).
2. **beads**: `NativeDoltStore` implements `Counter` by delegating to `storage.CountIssues` with the same `nativeIssueFilterFromListQuery` translation `List` uses. A supported-shape gate keeps the Counter contract (List-cardinality parity): anything `List` narrows Go-side (`Assignees`, `ParentIDs`, `SeekAfter`, `UpdatedBefore`), anything with Go-side re-filter semantics a COUNT can't provably reproduce (`Metadata`, `CreatedBefore`, `ParentID`), `Status "open"` (translated to a broader exclude-list), non-default tiers, `Limit`, and `excludeTypes` return `ErrCountUnsupported` so callers keep their fallback. The stale pinned test is replaced with delegation / supported-shape / caller-cancellation / error-propagation tests.
3. **beads**: the gate also accepts `TierBoth` — `beadPolicyStore` expands every TierIssues read to TierBoth, so on any city with bead policies a TierIssues-only gate silently loses the fast path. TierBoth is the one tier with no narrowing on either side (no SQL ephemeral predicate, `matchesTier` unconditionally true), so `CountIssues`' merge is already the exact List cardinality. TierWisps stays unsupported.

Known parity gap, documented in the code: rows whose metadata JSON fails to parse are dropped by `List` but counted here — that state is store corruption, and counting such a row beats reporting no denominator at all.

## Verification

- `go test ./internal/beads` (default and `-tags gascity_native_beads`), `./internal/api`, `./cmd/gc` store-health/policy tests, vet, golangci-lint — green.
- Verified live on a real deployment with ~20.6k retained rows: `store_health` block restored (count in milliseconds), `partial_errors` gone, dashboard store tile healthy, and `gc status` CLI shows Store health through the policy-wrapped TierBoth path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)