### PR TITLE
test(gc): pin contextual dispatcher resolution

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -273,12 +273,16 @@ func updateRootPackAgentSuspended(fs fsys.FS, cityPath string, cityCfg *config.C
 
 // resolveAgentIdentity resolves an agent input string to a config.Agent using
 // 3-step resolution:
-//  1. Literal: try the input as-is (e.g., "mayor" or "hello-world/polecat").
-//  2. Contextual: if input has no "/" and currentRigDir is set, try
-//     "{currentRigDir}/{input}" to resolve rig-scoped agents from context.
+//  1. Contextual: if input has no "/" and currentRigDir is set, try
+//     "{currentRigDir}/{input}" first. This includes binding-qualified but
+//     scope-unqualified inputs such as "core.control-dispatcher".
+//  2. Literal: try the input as-is (e.g., "mayor" or "hello-world/polecat").
 //  3. Unambiguous bare name: scan all agents by Name (ignoring Dir).
 //     Succeeds only when exactly one configured agent matches. Pool
 //     members are synthesized when the input uses {name}-{N}.
+//
+// This context sensitivity is for interactive CLI input. Persisted routes such
+// as gc.routed_to must already be canonical and must not be re-resolved here.
 func resolveAgentIdentity(cfg *config.City, input, currentRigDir string) (config.Agent, bool) {
 	// Step 1: contextual rig match (bare name + rig context).
 	// When the user is inside a rig directory and types a bare name like

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -364,6 +364,34 @@ func TestResolveAgentIdentityRejectsCanonicalSingletonPoolSuffix(t *testing.T) {
 	}
 }
 
+func TestResolveAgentIdentityUsesRigContextForScopeUnqualifiedControlDispatcher(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: config.ControlDispatcherAgentName, BindingName: "core"},
+			{Name: config.ControlDispatcherAgentName, BindingName: "core", Dir: "fixture"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		currentRigDir string
+		want          string
+	}{
+		{name: "rig context prefers rig scope", currentRigDir: "fixture", want: "fixture/core.control-dispatcher"},
+		{name: "city context keeps city scope", want: "core.control-dispatcher"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := resolveAgentIdentity(cfg, "core.control-dispatcher", tc.currentRigDir)
+			if !ok {
+				t.Fatal("resolveAgentIdentity() did not find the control dispatcher")
+			}
+			if got.QualifiedName() != tc.want {
+				t.Fatalf("resolveAgentIdentity() = %q, want %q", got.QualifiedName(), tc.want)
+			}
+		})
+	}
+}
+
 func TestEmitLoadCityConfigWarningsFiltersNonMigrationWarnings(t *testing.T) {
 	var stderr bytes.Buffer
 	emitLoadCityConfigWarnings(&stderr, &config.Provenance{


### PR DESCRIPTION
## Summary

- document that slash-free agent identities resolve against the current rig before literal city scope
- call out `core.control-dispatcher` as binding-qualified but scope-unqualified
- distinguish interactive resolution from canonical persisted `gc.routed_to` values
- characterize both rig-context and city-context dispatcher resolution

## Design contract

A graph remains wholly owned by its target store. Rig-owned controls persist `<rig>/core.control-dispatcher`; city-owned controls persist `core.control-dispatcher`. This PR does not change that routing behavior. It pins the separate interactive resolver rule that a slash-free input is scope-relative.

## Self-review

Approved. The change is limited to one stale resolver comment and one table-driven regression test. It changes no runtime logic, API surface, security behavior, or persisted routing.

## Verification

- `go test ./cmd/gc -run ^TestResolveAgentIdentity -count=1`
- `go vet ./...`
- `.githooks/pre-commit`
- `.githooks/pre-push` (`make test-fast-parallel`: all fast shards passed)