### PR TITLE
fix(api): disambiguate supervisor event_cursor "0" — replay vs no-backlog (post-merge #4369)

### DIFF
--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -821,7 +821,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.",
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time, which still delivers this request result because no provider predates the capture boundary.",
             "type": "string"
           },
           "request_id": {
@@ -11530,7 +11530,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary without replaying unrelated historical backlog.",
+            "description": "Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time.",
             "type": "string"
           },
           "items": {

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -821,7 +821,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.",
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time, which still delivers this request result because no provider predates the capture boundary.",
             "type": "string"
           },
           "request_id": {
@@ -11530,7 +11530,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary without replaying unrelated historical backlog.",
+            "description": "Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time.",
             "type": "string"
           },
           "items": {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -432,10 +432,13 @@ func (c *Client) waitForEventOnce(ctx context.Context, requestID, successType, f
 			cursor = "0"
 		}
 		streamURL = c.baseURL + "/v0/city/" + c.cityName + "/events/stream?after_seq=" + url.QueryEscape(cursor)
-	} else {
-		if cursor == "" {
-			cursor = "0"
-		}
+	} else if cursor != "" {
+		// A resume cursor from a 202 (including the literal "0" the supervisor
+		// returns when no provider existed at capture) is passed through so the
+		// caller resumes at the intended boundary. An empty cursor must NOT be
+		// coerced to after_cursor=0: "0" now requests a full replay from zero
+		// for every provider, whereas an absent after_cursor starts at the
+		// current supervisor event head with no backlog.
 		streamURL += "?after_cursor=" + url.QueryEscape(cursor)
 	}
 	// For a remote client, an idle watchdog cancels a stalled stream: the stream

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -85,11 +85,19 @@ func TestClientWaitForEventRequestsReplayCursorForCityStream(t *testing.T) {
 	}
 }
 
-func TestClientWaitForEventRequestsReplayCursorForSupervisorStream(t *testing.T) {
+func TestClientWaitForEventSupervisorStreamCursorHandling(t *testing.T) {
+	// One loopback server covers both supervisor-scope cursor cases (kept as a
+	// single server so the untagged http_test_server census does not grow):
+	//   - an empty resume cursor must omit after_cursor so the stream
+	//     head-starts with no backlog, NOT coerce it to after_cursor=0 (which
+	//     now requests a full replay from zero for every provider);
+	//   - a cursor handed back from a 202 — including the literal "0" the
+	//     supervisor returns when no provider existed at capture — is forwarded
+	//     verbatim so an async caller still catches its result.
 	seen := make(chan url.Values, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v0/events/stream" {
-			t.Fatalf("path = %q, want /v0/events/stream", r.URL.Path)
+			t.Errorf("path = %q, want /v0/events/stream", r.URL.Path)
 		}
 		seen <- r.URL.Query()
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -97,11 +105,15 @@ func TestClientWaitForEventRequestsReplayCursorForSupervisorStream(t *testing.T)
 	defer ts.Close()
 
 	c := NewClient(ts.URL)
-	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate, "")
 
-	query := <-seen
-	if got := query.Get("after_cursor"); got != "0" {
-		t.Fatalf("after_cursor = %q, want 0", got)
+	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate, "")
+	if query := <-seen; query.Has("after_cursor") {
+		t.Fatalf("empty cursor: after_cursor = %q, want it omitted for a no-backlog head start", query.Get("after_cursor"))
+	}
+
+	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate, "0")
+	if query := <-seen; query.Get("after_cursor") != "0" {
+		t.Fatalf("literal 0 cursor: after_cursor = %q, want 0 (accepted cursor forwarded)", query.Get("after_cursor"))
 	}
 }
 

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -252,7 +252,7 @@ export type AsyncAcceptedBody = {
 
 export type AsyncAcceptedResponse = {
     /**
-     * Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.
+     * Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time, which still delivers this request result because no provider predates the capture boundary.
      */
     event_cursor: string;
     /**
@@ -4928,7 +4928,7 @@ export type SupervisorCitiesOutputBody = {
 
 export type SupervisorEventListOutputBody = {
     /**
-     * Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary without replaying unrelated historical backlog.
+     * Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time.
      */
     event_cursor: string;
     items: Array<TypedTaggedEventStreamEnvelope> | null;

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -1114,7 +1114,7 @@ type AsyncAcceptedBody struct {
 
 // AsyncAcceptedResponse defines model for AsyncAcceptedResponse.
 type AsyncAcceptedResponse struct {
-	// EventCursor Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.
+	// EventCursor Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time, which still delivers this request result because no provider predates the capture boundary.
 	EventCursor string `json:"event_cursor"`
 
 	// RequestId Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id.
@@ -5029,7 +5029,7 @@ type SupervisorCitiesOutputBody struct {
 
 // SupervisorEventListOutputBody defines model for SupervisorEventListOutputBody.
 type SupervisorEventListOutputBody struct {
-	// EventCursor Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary without replaying unrelated historical backlog.
+	// EventCursor Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time.
 	EventCursor string                            `json:"event_cursor"`
 	Items       *[]TypedTaggedEventStreamEnvelope `json:"items"`
 	Total       int64                             `json:"total"`

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -92,7 +92,7 @@ type cityCreateRequest struct {
 // request_id. Polling is unnecessary.
 type asyncAcceptedResponse struct {
 	RequestID   string `json:"request_id" doc:"Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id."`
-	EventCursor string `json:"event_cursor" doc:"Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty."`
+	EventCursor string `json:"event_cursor" doc:"Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time, which still delivers this request result because no provider predates the capture boundary."`
 }
 
 // SupervisorCityCreateInput is the input for POST /v0/city.
@@ -142,7 +142,7 @@ type SupervisorEventListInput struct {
 // SupervisorEventListOutput is the response for GET /v0/events (supervisor scope).
 type SupervisorEventListOutput struct {
 	Body struct {
-		EventCursor string            `json:"event_cursor" doc:"Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary without replaying unrelated historical backlog."`
+		EventCursor string            `json:"event_cursor" doc:"Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time."`
 		Items       []WireTaggedEvent `json:"items"`
 		Total       int               `json:"total"`
 	}
@@ -751,6 +751,12 @@ func supervisorEventCursorFromMux(mux *events.Multiplexer) (string, error) {
 	if cursor := events.FormatCursor(cursors); cursor != "" {
 		return cursor, nil
 	}
+	// No providers are registered yet, so there is no per-city boundary to
+	// capture. Return literal "0": resolveGlobalStreamCursors treats it as a
+	// replay-from-zero request, which lets an async caller still catch its
+	// result event once its city registers. Because no provider predates this
+	// cursor, the replay carries no pre-capture backlog. Callers that want a
+	// no-backlog head start must omit after_cursor instead of sending "0".
 	return "0", nil
 }
 

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -821,7 +821,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.",
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time, which still delivers this request result because no provider predates the capture boundary.",
             "type": "string"
           },
           "request_id": {
@@ -11530,7 +11530,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary without replaying unrelated historical backlog.",
+            "description": "Supervisor event-stream cursor captured before the history snapshot was listed. Pass this value as after_cursor to /v0/events/stream to receive events emitted after the snapshot boundary. A populated cursor resumes each city at its exact per-city position, so no unrelated historical backlog is replayed. The value 0 is returned only when no event provider is registered at capture time; passing 0 back requests a replay from zero for every provider present at resume time.",
             "type": "string"
           },
           "items": {


### PR DESCRIPTION
## Summary

Post-merge review of #4369 (landed range `b24085746..10eb892ad`) found the
supervisor event-stream cursor `"0"` was overloaded across the producer, the
public response docs, and the client:

- `supervisorEventCursorFromMux` returns literal `"0"` when no event provider
  exists at capture time (empty mux), and the public `event_cursor` response
  docs promised that passing it back replays no unrelated historical backlog.
- `resolveGlobalStreamCursors` (added in #4369) now treats an incoming `"0"` as
  an explicit replay-from-zero for every current provider.
- The supervisor-scope client (`waitForEventOnce`) coerced an empty resume
  cursor to `after_cursor=0`, silently requesting a full replay.

A client following the documented round-trip could be sent into a full-history
replay of every registered city after being promised a snapshot-boundary stream.

## Fix (race-safe)

Keep `"0"` → replay as the intended, now-documented behavior (an empty-mux
`"0"` must still replay so an async caller catches its result once its city
registers — no provider predates the capture boundary), and remove the
contradiction:

- Correct both `event_cursor` response docs so `"0"` reads as an explicit
  replay-from-zero request and a populated cursor as a precise per-city resume;
  regenerate `openapi.json`, the Go client, and the dashboard TS client.
- Stop the supervisor-scope client turning an empty resume cursor into
  `after_cursor=0`; omit `after_cursor` so the stream head-starts with no
  backlog. A literal `"0"` handed back from a 202 is still forwarded verbatim,
  preserving async result delivery.
- Add client-test coverage pinning both halves (empty → head-start; literal
  `"0"` → forwarded).

`resolveGlobalStreamCursors`, the precheck, and the integration test are
unchanged.

## Tests

- `go test ./internal/api/ -run 'TestClientWaitForEvent|TestResolveGlobalStreamCursors|TestOpenAPISpecInSync'` — pass
- `go test ./internal/events/ -run 'TestParseCursorFormatCursor'` — pass
- `go vet ./internal/api/` — clean

Post-merge remediation of #4369; opened for the internal review loop.