### PR TITLE
test: make Docker cancellation proof event-triggered

### DIFF
--- a/scripts/docker_session_protocol_test.go
+++ b/scripts/docker_session_protocol_test.go
@@ -17,9 +17,13 @@ import (
 
 	gcruntime "github.com/gastownhall/gascity/internal/runtime"
 	runtimeexec "github.com/gastownhall/gascity/internal/runtime/exec"
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
-const dockerProtocolContainerID = "fake-container-id"
+const (
+	dockerProtocolContainerID         = "fake-container-id"
+	dockerProtocolObservationInterval = 10 * time.Millisecond
+)
 
 func TestDockerSessionProtocol(t *testing.T) {
 	root := repoRoot(t)
@@ -170,24 +174,42 @@ func TestDockerSessionProtocol(t *testing.T) {
 		fixture.writeState(t, "prompt-output", "not ready >\n")
 
 		provider := runtimeexec.NewProvider(fixture.adapterWrapper(t, adapter))
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		err := provider.Start(ctx, fixture.containerName, gcruntime.Config{
-			Command:           "sleep infinity",
-			WorkDir:           fixture.workDir,
-			ReadyPromptPrefix: "> ",
-			Env: map[string]string{
-				"GC_DOCKER_HOME_MOUNT": "false",
-				"GC_DOCKER_IMAGE":      "gc-protocol-test:latest",
-			},
-		})
-		if err == nil {
-			t.Fatal("start succeeded when prompt appeared only mid-line")
+		startResult := make(chan error, 1)
+		go func() {
+			startResult <- provider.Start(ctx, fixture.containerName, gcruntime.Config{
+				Command:           "sleep infinity",
+				WorkDir:           fixture.workDir,
+				ReadyPromptPrefix: "> ",
+				Env: map[string]string{
+					"GC_DOCKER_HOME_MOUNT": "false",
+					"GC_DOCKER_IMAGE":      "gc-protocol-test:latest",
+				},
+			})
+		}()
+
+		captureCall := dockerProtocolCaptureCall(fixture.containerName, 120)
+		observationCtx, stopObservation := context.WithTimeout(context.Background(), testutil.ExecRaceTimeout)
+		waitForDockerProtocolCall(observationCtx, t, fixture, captureCall)
+		stopObservation()
+		cancel()
+
+		completionCtx, stopCompletion := context.WithTimeout(context.Background(), testutil.ExecRaceTimeout)
+		defer stopCompletion()
+		var err error
+		select {
+		case err = <-startResult:
+		case <-completionCtx.Done():
+			t.Fatalf("Start did not return within %s after cancellation", testutil.ExecRaceTimeout)
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Start error = %v, want context.Canceled", err)
 		}
 
 		calls := fixture.calls(t)
-		if dockerProtocolCallCount(calls, dockerProtocolCaptureCall(fixture.containerName, 120)) == 0 {
-			t.Fatalf("context expired before prompt observation; calls:\n%s", formatDockerProtocolCalls(calls))
+		if dockerProtocolCallCount(calls, captureCall) == 0 {
+			t.Fatalf("cancellation started before prompt observation; calls:\n%s", formatDockerProtocolCalls(calls))
 		}
 		if fixture.containerExists() {
 			t.Errorf("container %q remains after start context cancellation; calls:\n%s",
@@ -196,84 +218,6 @@ func TestDockerSessionProtocol(t *testing.T) {
 		cleanup := dockerProtocolCleanupCallsAfterRun(calls)
 		if len(cleanup) != 1 || !reflect.DeepEqual(cleanup[0], []string{"rm", "-f", dockerProtocolContainerID}) {
 			t.Errorf("immutable-ID cleanup calls = %v, want a single force-remove; calls:\n%s",
-				cleanup, formatDockerProtocolCalls(calls))
-		}
-	})
-
-	t.Run("start_cancellation_removes_container_despite_stalled_stop", func(t *testing.T) {
-		fixture := newDockerProtocolFixture(t, fakeSource)
-		fixture.allowImage(t)
-		fixture.writeState(t, "prompt-output", "not ready >\n")
-		// A graceful "docker stop" that waits out its timeout outruns the exec
-		// provider's ~2s cancellation grace. If rollback ever regressed to
-		// "stop -t 10" before "rm -f", the adapter would be force-killed
-		// mid-stop and the container would leak. Rollback must go straight to
-		// "rm -f", so this stall is never triggered on the fixed path.
-		fixture.writeState(t, "stop-stall-seconds", "5\n")
-
-		provider := runtimeexec.NewProvider(fixture.adapterWrapper(t, adapter))
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		err := provider.Start(ctx, fixture.containerName, gcruntime.Config{
-			Command:           "sleep infinity",
-			WorkDir:           fixture.workDir,
-			ReadyPromptPrefix: "> ",
-			Env: map[string]string{
-				"GC_DOCKER_HOME_MOUNT": "false",
-				"GC_DOCKER_IMAGE":      "gc-protocol-test:latest",
-			},
-		})
-		if err == nil {
-			t.Fatal("start succeeded when prompt appeared only mid-line")
-		}
-
-		calls := fixture.calls(t)
-		if fixture.containerExists() {
-			t.Errorf("container %q leaked after cancellation with a stalled stop; calls:\n%s",
-				fixture.containerName, formatDockerProtocolCalls(calls))
-		}
-		cleanup := dockerProtocolCleanupCallsAfterRun(calls)
-		if len(cleanup) != 1 || !reflect.DeepEqual(cleanup[0], []string{"rm", "-f", dockerProtocolContainerID}) {
-			t.Errorf("cancellation cleanup = %v, want a single force-remove that never blocks on stop; calls:\n%s",
-				cleanup, formatDockerProtocolCalls(calls))
-		}
-	})
-
-	t.Run("start_cancellation_during_ready_delay_removes_container", func(t *testing.T) {
-		fixture := newDockerProtocolFixture(t, fakeSource)
-		fixture.allowImage(t)
-
-		// With no ready_prompt_prefix, start takes the ready_delay_ms fallback: a
-		// single foreground `sleep` far longer than the exec provider's ~2s
-		// cancellation grace. A plain foreground sleep would keep the shell from
-		// running its rollback trap until the sleep returned, so the provider
-		// would force-kill the shell mid-delay and leak the just-created
-		// container. The cooperative interrupt must reach that foreground child
-		// so the trap force-removes the container inside the grace window.
-		provider := runtimeexec.NewProvider(fixture.adapterWrapper(t, adapter))
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		err := provider.Start(ctx, fixture.containerName, gcruntime.Config{
-			Command:      "sleep infinity",
-			WorkDir:      fixture.workDir,
-			ReadyDelayMs: 5000,
-			Env: map[string]string{
-				"GC_DOCKER_HOME_MOUNT": "false",
-				"GC_DOCKER_IMAGE":      "gc-protocol-test:latest",
-			},
-		})
-		if err == nil {
-			t.Fatal("start succeeded despite cancellation during the readiness delay")
-		}
-
-		calls := fixture.calls(t)
-		if fixture.containerExists() {
-			t.Errorf("container %q leaked after cancellation during ready_delay_ms; calls:\n%s",
-				fixture.containerName, formatDockerProtocolCalls(calls))
-		}
-		cleanup := dockerProtocolCleanupCallsAfterRun(calls)
-		if len(cleanup) != 1 || !reflect.DeepEqual(cleanup[0], []string{"rm", "-f", dockerProtocolContainerID}) {
-			t.Errorf("ready-delay cancellation cleanup = %v, want a single immutable-ID force-remove; calls:\n%s",
 				cleanup, formatDockerProtocolCalls(calls))
 		}
 	})
@@ -515,6 +459,26 @@ func dockerProtocolCallCount(calls [][]string, want []string) int {
 		}
 	}
 	return count
+}
+
+func waitForDockerProtocolCall(ctx context.Context, t *testing.T, fixture *dockerProtocolFixture, want []string) {
+	t.Helper()
+	ticker := time.NewTicker(dockerProtocolObservationInterval)
+	defer ticker.Stop()
+
+	var calls [][]string
+	for {
+		calls = fixture.calls(t)
+		if dockerProtocolCallCount(calls, want) > 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for exact Docker call %q: %v; last calls:\n%s",
+				want, ctx.Err(), formatDockerProtocolCalls(calls))
+		case <-ticker.C:
+		}
+	}
 }
 
 // dockerProtocolCleanupCallsAfterRun returns the immutable-ID cleanup calls

--- a/scripts/testdata/docker-session/docker
+++ b/scripts/testdata/docker-session/docker
@@ -24,12 +24,14 @@ fi
 call_number=$((call_number + 1))
 printf '%d\n' "$call_number" > "$state_dir/call-counter"
 call_path=$(printf '%s/%08d.argv' "$calls_dir" "$call_number")
+call_tmp_path="$call_path.tmp.$$"
 {
     printf '%d\n' "$#"
     if [[ $# -gt 0 ]]; then
         printf '%s\0' "$@"
     fi
-} > "$call_path"
+} > "$call_tmp_path"
+mv -f -- "$call_tmp_path" "$call_path"
 
 unsupported() {
     printf 'fake docker: unsupported argv:' >&2
@@ -217,16 +219,6 @@ fi
 if [[ $# -eq 4 && "$1" == "stop" && "$2" == "-t" && "$3" == "10" ]]; then
     target="$4"
     cname=$(resolve_container_name "$target") || unsupported
-    # Simulate a graceful stop that outruns the caller's cancellation grace: a
-    # container whose PID 1 ignores SIGTERM makes "docker stop" block until its
-    # timeout. Tests inject this to prove failed-start rollback removes the
-    # container without first waiting on a slow stop.
-    if [[ -r "$state_dir/stop-stall-seconds" ]]; then
-        IFS= read -r stall_seconds < "$state_dir/stop-stall-seconds" || true
-        if [[ "$stall_seconds" =~ ^[0-9]+$ ]]; then
-            sleep "$stall_seconds"
-        fi
-    fi
     if [[ -e "$containers_dir/$cname" ]]; then
         printf 'stopped\n' > "$containers_dir/$cname"
     fi


### PR DESCRIPTION
## Outcome

Replaces elapsed-time cancellation with a fact-driven Docker protocol proof: the test waits for the strict fake to record the exact 120-line `capture-pane` call, then cancels explicitly. Fake call records are atomically published so concurrent observation cannot read partial argv.

Two redundant two-second variants are retired. Production runtime and Docker adapter behavior are unchanged.

## Timing

| Proof | Before | After |
| --- | ---: | ---: |
| Full `TestDockerSessionProtocol` | 8.03s | 2.52s |
| Retained cancellation owner | 2.03s | 0.30s |
| Fixed cancellation delay across three variants | 6.07s | ~0.30s |

This saves about 5.51s, or 69%, in the core fast lane.

## Assertion ownership

| Retired edge | Retained owner |
| --- | --- |
| Slow `stop -t 10` must never precede rollback | Failed-start and retained cancellation proofs require exactly one immutable-ID `rm -f`; any stop call fails the contract |
| Cancellation must reach a foreground readiness child | `TestProvider_StartCancellationInterruptsForegroundChild` in `internal/runtime/exec` |
| Real Docker `ready_delay_ms` composition | `scripts/test-docker-session` |
| Exec-provider to Docker-adapter cancellation composition | Retained `context_cancellation_rolls_back_created_container` proof |

## Failure evidence

The old test passed in isolation but failed the saturated eight-lane fast suite twice, after prompt observation and before cleanup. The event-triggered version passed 20 focused repeats, five race-enabled repeats, and the same full eight-lane pre-push suite.

## Verification

- retained cancellation, `-count=20`
- retained cancellation with race detector, `-count=5`
- full Docker protocol owner with per-subtest timing
- retained exec foreground-child owner
- resource-census binding
- ShellCheck and `bash -n`
- changed-package lint and `go vet ./...`
- full pre-commit hook
- eight-lane fast pre-push suite
- two independent exact-hash council reviews

Bead: `ga-yrotsuu.1`