### PR TITLE
test: retire duplicate Phase-2 Claude transport proof

### DIFF
--- a/cmd/gc/phase2_real_transport_test.go
+++ b/cmd/gc/phase2_real_transport_test.go
@@ -41,35 +41,6 @@ func TestPhase2WorkerCoreRealTransportProof(t *testing.T) {
 	}
 }
 
-func TestPhase2HookEnabledClaudeLaunchPromptDeliveryProof(t *testing.T) {
-	tmuxtest.RequireTmux(t)
-
-	tc := phase2ProviderCaseForFamily(t, "claude")
-	tp := resolvePhase2Template(t, tc)
-	if !tp.HookEnabled {
-		t.Fatal("HookEnabled = false, want true for Claude phase2 profile")
-	}
-	if tp.ResolvedProvider == nil {
-		t.Fatal("ResolvedProvider = nil, want Claude provider metadata")
-	}
-	if !tp.ResolvedProvider.SupportsHooks {
-		t.Fatal("SupportsHooks = false, want true for Claude phase2 profile")
-	}
-
-	materialized := templateParamsToConfig(tp)
-	run := launchPhase2RealTransportSession(t, tc, materialized)
-
-	if run.ErrorStage != "" {
-		t.Fatalf("%s failed: %s", run.ErrorStage, run.Error)
-	}
-	if got, want := run.ObservedStartupPrompt, run.ExpectedStartupPrompt; got != want {
-		t.Fatalf("startup prompt = %q, want %q", got, want)
-	}
-	if !run.AutonomousStarted {
-		t.Fatal("launch prompt marker = missing, want command-line startup prompt matched before any explicit rescue nudge")
-	}
-}
-
 type phase2RealTransportRun struct {
 	Transport                string
 	SocketName               string

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -108,7 +108,6 @@ cmd_gc_integration_tests=(
   TestCapstoneIntegrationRealMinter
   TestControllerDiscoversAddedCronOrderWithoutRestart
   TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind
-  TestPhase2HookEnabledClaudeLaunchPromptDeliveryProof
   TestPhase2WorkerCoreRealTransportProof
 )
 

--- a/scripts/test_integration_shard_test.go
+++ b/scripts/test_integration_shard_test.go
@@ -25,7 +25,6 @@ func TestCmdGCIntegrationShardRunsOnlyIntegrationManifest(t *testing.T) {
 		"TestCapstoneIntegrationRealMinter",
 		"TestControllerDiscoversAddedCronOrderWithoutRestart",
 		"TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind",
-		"TestPhase2HookEnabledClaudeLaunchPromptDeliveryProof",
 		"TestPhase2WorkerCoreRealTransportProof",
 	} {
 		if !strings.Contains(invocation, testName) {
@@ -69,7 +68,6 @@ func newIntegrationShardFixture(t *testing.T, extraTaggedTests []string) integra
 		"TestCapstoneIntegrationRealMinter",
 		"TestControllerDiscoversAddedCronOrderWithoutRestart",
 		"TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind",
-		"TestPhase2HookEnabledClaudeLaunchPromptDeliveryProof",
 		"TestPhase2WorkerCoreRealTransportProof",
 	}, extraTaggedTests...)
 	var taggedOutput strings.Builder


### PR DESCRIPTION
## Outcome

Removes TestPhase2HookEnabledClaudeLaunchPromptDeliveryProof, which repeats the Claude slice already exercised by the seven-profile real-transport owner.

Production behavior and retained test semantics are unchanged.

## Timing

| Proof contribution | Before | After | Saving |
| --- | ---: | ---: | ---: |
| Duplicate Claude real-transport proof | 3.2–5.1s | 0s | 3.2–5.1s |

These are diagnostic wall-time observations, not an authoritative p95.

## Assertion ownership

| Retired assertion | Retained owner |
| --- | --- |
| Claude is hook-enabled and supports hooks | TestPhase2HookEnabledClaudeFirstTurnStartupPayload |
| Hook-enabled providers keep the startup payload on the launch command | TestTemplateParamsToConfigHookEnabledProviderStillUsesLaunchPrompt |
| Claude startup prompt reaches real tmux unchanged | TestPhase2WorkerCoreRealTransportProof/claude/tmux-cli |
| Autonomous startup occurs before explicit nudge | TestPhase2WorkerCoreRealTransportProof/claude/tmux-cli |
| All supported profiles satisfy the real-transport contract | TestPhase2WorkerCoreRealTransportProof across seven profiles |

The integration manifest and fixture census shrink in lockstep, while the retained owner remains required.

## Verification

- Seven-profile retained real-transport owner
- Claude hook-enabled first-turn unit owner
- Integration manifest/profile and source-resource censuses
- Changed-package lint and go vet ./...
- Pre-commit and saturated eight-lane pre-push gates
- Two independent reviews of exact patch 28a450493752d6b0b728987444480e7470ad83e419781a8dddacf54a3b328676
- Conflict-free rebase over main at 2861a4fd5

Bead: ga-yrotsuu.2
