### PR TITLE
fix(gc): make pinned session restart requests fail loud

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/gastownhall/gascity/internal/api"
@@ -183,7 +184,7 @@ func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdo
 
 	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	return waitForControllerRestart(sigCtx, dops, current.sessionName, "gc handoff",
+	return waitForControllerRestart(sigCtx, dops, sp, current.sessionName, "gc handoff",
 		controllerRestartPollInterval, controllerRestartTimeout(cfg), stderr)
 }
 
@@ -258,7 +259,7 @@ func doHandoffWithOutcome(store, sessStore beads.Store, rec events.Recorder, dop
 		return handoffOutcome{code: 1}
 	}
 
-	restartable, err := sessionRestartableByController(sessStore, sessionName)
+	restartable, pinned, err := sessionRestartableByController(sessStore, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
 		return handoffOutcome{code: 1}
@@ -276,9 +277,23 @@ func doHandoffWithOutcome(store, sessStore beads.Store, rec events.Recorder, dop
 		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
 		return handoffOutcome{code: 1}
 	}
-	// Also persist the request through the worker boundary so it survives
-	// tmux session death. Non-fatal: the runtime flag above is primary.
-	if persistRestart != nil {
+	// Pinned named sessions are kill-protected by the reconciler unless an
+	// explicit controller reset (continuation_reset_pending) is persisted
+	// through the worker boundary: without it, the reconciler's collateral-skip
+	// clears the runtime flag set above and leaves the session running
+	// indefinitely. Persisting is therefore mandatory for pinned sessions; for
+	// everything else the runtime flag is primary and the bead write stays
+	// best-effort backup.
+	if pinned {
+		if persistRestart == nil {
+			fmt.Fprintf(stderr, "gc handoff: pinned session %q has no restart persistence available; not requesting restart\n", sessionName) //nolint:errcheck // best-effort stderr
+			return handoffOutcome{code: 1}
+		}
+		if err := persistRestart(); err != nil {
+			fmt.Fprintf(stderr, "gc handoff: could not persist restart marker for pinned session %q; not requesting restart: %v\n", sessionName, err) //nolint:errcheck // best-effort stderr
+			return handoffOutcome{code: 1}
+		}
+	} else if persistRestart != nil {
 		if err := persistRestart(); err != nil {
 			fmt.Fprintf(stderr, "gc handoff: setting bead restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
@@ -358,25 +373,33 @@ func createHandoffMail(store, sessStore beads.Store, rec events.Recorder, sender
 	return msg, true
 }
 
-func sessionRestartableByController(sessStore beads.Store, sessionName string) (bool, error) {
+// sessionRestartableByController reports whether the controller is willing to
+// restart the named session (restartable) and whether it is a pinned,
+// kill-protected named session (pinned). pinned mirrors the reconciler's own
+// pinnedConfiguredNamedSessionKillProtected predicate (isNamedSessionInfo &&
+// pin_awake == "true") so callers can predict whether the reconciler will
+// refuse a collateral kill absent an explicit controller reset. Both facts
+// come off the single bead read so callers needing both (gc handoff) do not
+// pay for a second store round-trip.
+func sessionRestartableByController(sessStore beads.Store, sessionName string) (restartable, pinned bool, err error) {
 	if sessStore == nil || sessionName == "" {
-		return true, nil
+		return true, false, nil
 	}
 	id, err := resolveSessionID(sessStore, sessionName)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
-			return true, nil
+			return true, false, nil
 		}
-		return false, fmt.Errorf("resolving session %q: %w", sessionName, err)
+		return false, false, fmt.Errorf("resolving session %q: %w", sessionName, err)
 	}
 	b, err := sessStore.Get(id)
 	if err != nil {
-		return false, fmt.Errorf("loading session %q: %w", id, err)
+		return false, false, fmt.Errorf("loading session %q: %w", id, err)
 	}
 	if !isNamedSessionBead(b) {
-		return true, nil
+		return true, false, nil
 	}
-	return namedSessionMode(b) == "always", nil
+	return namedSessionMode(b) == "always", strings.TrimSpace(b.Metadata["pin_awake"]) == "true", nil
 }
 
 func clearRestartRequest(sessStore beads.Store, dops drainOps, sessionName string) error {
@@ -419,7 +442,7 @@ func doHandoffRemote(store, sessStore beads.Store, rec events.Recorder, sp runti
 		return 1
 	}
 
-	restartable, err := sessionRestartableByController(sessStore, sessionName)
+	restartable, _, err := sessionRestartableByController(sessStore, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -140,7 +140,7 @@ func TestWaitForControllerRestartHandoffFlagCleared(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	code := waitForControllerRestart(context.Background(), dops, "worker", "gc handoff",
+	code := waitForControllerRestart(context.Background(), dops, runtime.NewFake(), "worker", "gc handoff",
 		10*time.Millisecond, 5*time.Second, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0 when flag cleared; stderr: %s", code, stderr.String())
@@ -153,6 +153,33 @@ func TestWaitForControllerRestartHandoffFlagCleared(t *testing.T) {
 	}
 }
 
+// TestWaitForControllerRestartHandoffFlagClearedButSessionStillRunning covers
+// Fix 2: the reconciler's pinned-session collateral-skip clears
+// GC_RESTART_REQUESTED without stopping the session (see
+// pinnedConfiguredNamedSessionKillProtected in session_reconciler.go), so a
+// cleared flag alone must not be reported as success while the session is
+// still running.
+func TestWaitForControllerRestartHandoffFlagClearedButSessionStillRunning(t *testing.T) {
+	dops := &drainOpsWithCountdown{fakeDrainOps: newFakeDrainOps(), remaining: 2}
+	if err := dops.setRestartRequested("worker"); err != nil {
+		t.Fatalf("setRestartRequested: %v", err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	code := waitForControllerRestart(context.Background(), dops, sp, "worker", "gc handoff",
+		10*time.Millisecond, 50*time.Millisecond, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 (flag cleared but session still running is not success); stderr: %s", code, stderr.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "gc handoff: controller did not act within") {
+		t.Errorf("stderr = %q, want handoff timeout diagnostic", got)
+	}
+}
+
 func TestWaitForControllerRestartHandoffTimeout(t *testing.T) {
 	dops := newFakeDrainOps()
 	if err := dops.setRestartRequested("worker"); err != nil {
@@ -160,7 +187,7 @@ func TestWaitForControllerRestartHandoffTimeout(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	code := waitForControllerRestart(context.Background(), dops, "worker", "gc handoff",
+	code := waitForControllerRestart(context.Background(), dops, runtime.NewFake(), "worker", "gc handoff",
 		10*time.Millisecond, 25*time.Millisecond, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1 on timeout", code)
@@ -181,7 +208,7 @@ func TestWaitForControllerRestartHandoffTimeoutReportsLastPollError(t *testing.T
 	dops.restartReadErr = errors.New("metadata read failed")
 
 	var stderr bytes.Buffer
-	code := waitForControllerRestart(context.Background(), dops, "worker", "gc handoff",
+	code := waitForControllerRestart(context.Background(), dops, runtime.NewFake(), "worker", "gc handoff",
 		10*time.Millisecond, 25*time.Millisecond, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1 on timeout", code)
@@ -202,7 +229,7 @@ func TestWaitForControllerRestartHandoffContextCancel(t *testing.T) {
 
 	done := make(chan int, 1)
 	go func() {
-		done <- waitForControllerRestart(ctx, dops, "worker", "gc handoff",
+		done <- waitForControllerRestart(ctx, dops, runtime.NewFake(), "worker", "gc handoff",
 			10*time.Millisecond, 30*time.Second, &stderr)
 	}()
 
@@ -562,6 +589,67 @@ func TestDoHandoff_NamedAlwaysSessionRequestsRestart(t *testing.T) {
 	}
 	if rec.Events[1].Type != events.SessionDraining {
 		t.Fatalf("event[1].Type = %q, want %q", rec.Events[1].Type, events.SessionDraining)
+	}
+}
+
+// TestDoHandoff_PinnedAlwaysSessionRequiresPersistRestart covers Fix 1: a
+// pinned named session (pin_awake == "true") is kill-protected by the
+// reconciler unless an explicit controller reset is persisted, so
+// persistRestart is mandatory rather than best-effort for pinned sessions.
+// When it is unavailable or fails, doHandoffWithOutcome must report failure
+// and must not promise a restart it cannot guarantee.
+func TestDoHandoff_PinnedAlwaysSessionRequiresPersistRestart(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		persistRestart func() error
+	}{
+		{name: "nil persistRestart"},
+		{name: "persistRestart error", persistRestart: func() error { return errors.New("worker boundary unavailable") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			rec := events.NewFake()
+			dops := newFakeDrainOps()
+			var stdout, stderr bytes.Buffer
+
+			b, err := store.Create(beads.Bead{
+				Type:   sessionBeadType,
+				Labels: []string{"gc:session"},
+			})
+			if err != nil {
+				t.Fatalf("seeding session bead: %v", err)
+			}
+			if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
+				t.Fatalf("set session_name: %v", err)
+			}
+			if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
+				t.Fatalf("set configured_named_session: %v", err)
+			}
+			if err := store.SetMetadata(b.ID, "configured_named_mode", "always"); err != nil {
+				t.Fatalf("set configured_named_mode: %v", err)
+			}
+			if err := store.SetMetadata(b.ID, "pin_awake", "true"); err != nil {
+				t.Fatalf("set pin_awake: %v", err)
+			}
+
+			outcome := doHandoffWithOutcome(store, store, rec, dops, tc.persistRestart, "mayor", "mayor",
+				[]string{"HANDOFF: context full"}, &stdout, &stderr)
+			if outcome.code != 1 {
+				t.Fatalf("code = %d, want 1; stderr: %s", outcome.code, stderr.String())
+			}
+			if outcome.restartRequested {
+				t.Fatal("restartRequested = true, want false when persistRestart is unavailable for a pinned session")
+			}
+			if strings.Contains(stdout.String(), "requesting restart") {
+				t.Errorf("stdout = %q, must not promise a restart when persistRestart is unavailable for a pinned session", stdout.String())
+			}
+			if len(rec.Events) != 1 {
+				t.Fatalf("got %d events, want 1 (mail only, no SessionDraining); events=%v", len(rec.Events), rec.Events)
+			}
+			if rec.Events[0].Type != events.MailSent {
+				t.Fatalf("event[0].Type = %q, want %q", rec.Events[0].Type, events.MailSent)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -568,9 +568,14 @@ func cmdRuntimeRequestRestart(stdout, stderr io.Writer) int {
 			return handle.Reset(context.Background())
 		}
 	}
+	_, pinned, err := sessionRestartableByController(sessStore, current.sessionName)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc runtime request-restart: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	return doRuntimeRequestRestart(sigCtx, dops, persistRestart, rec, current.display, current.sessionName,
+	return doRuntimeRequestRestart(sigCtx, dops, sp, persistRestart, pinned, rec, current.display, current.sessionName,
 		controllerRestartPollInterval, controllerRestartTimeout(cfg), stdout, stderr)
 }
 
@@ -598,16 +603,31 @@ func controllerRestartTimeout(cfg *config.City) time.Duration {
 // doRuntimeRequestRestart sets the restart-requested flag then polls until the
 // controller accepts the stop handoff (exit 0), the context is canceled by a
 // signal (exit 0), or the bounded timeout expires (exit 1 with diagnostic).
-func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart func() error, rec events.Recorder,
+//
+// pinned marks a kill-protected named session (pin_awake == "true"): the
+// reconciler refuses to collaterally kill such a session on a bare runtime
+// restart-requested flag, so for pinned sessions persistRestart (which lands
+// continuation_reset_pending, the explicit-reset escape hatch) is mandatory
+// rather than best-effort. See sessionRestartableByController.
+func doRuntimeRequestRestart(ctx context.Context, dops drainOps, sp runtime.Provider, persistRestart func() error, pinned bool, rec events.Recorder,
 	targetName, sn string, pollInterval, timeout time.Duration, stdout, stderr io.Writer,
 ) int {
 	if err := dops.setRestartRequested(sn); err != nil {
 		fmt.Fprintf(stderr, "gc runtime request-restart: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	// Also persist the request through the worker boundary so it survives
-	// tmux session death. Non-fatal: the runtime flag above is primary.
-	if persistRestart != nil {
+	if pinned {
+		if persistRestart == nil {
+			fmt.Fprintf(stderr, "gc runtime request-restart: pinned session %q has no restart persistence available; not requesting restart\n", sn) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if err := persistRestart(); err != nil {
+			fmt.Fprintf(stderr, "gc runtime request-restart: could not persist restart marker for pinned session %q; not requesting restart: %v\n", sn, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	} else if persistRestart != nil {
+		// Also persist the request through the worker boundary so it survives
+		// tmux session death. Non-fatal here: the runtime flag above is primary.
 		if err := persistRestart(); err != nil {
 			fmt.Fprintf(stderr, "gc runtime request-restart: setting bead restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
@@ -620,10 +640,20 @@ func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart 
 	})
 	fmt.Fprintf(stdout, "Restart requested. Waiting up to %s for controller to stop this session...\n", timeout) //nolint:errcheck // best-effort stdout
 
-	return waitForControllerRestart(ctx, dops, sn, "gc runtime request-restart", pollInterval, timeout, stderr)
+	return waitForControllerRestart(ctx, dops, sp, sn, "gc runtime request-restart", pollInterval, timeout, stderr)
 }
 
-func waitForControllerRestart(ctx context.Context, dops drainOps, sn, command string, pollInterval, timeout time.Duration, stderr io.Writer) int {
+// waitForControllerRestart polls until the controller accepts the stop
+// handoff (exit 0), the context is canceled by a signal (exit 0), or the
+// bounded timeout expires (exit 1 with diagnostic).
+//
+// A cleared GC_RESTART_REQUESTED flag alone is not proof the controller acted:
+// the reconciler's pinned-session collateral-skip clears the very same flag
+// without killing the session (see pinnedConfiguredNamedSessionKillProtected
+// in session_reconciler.go). sp confirms the session actually stopped before
+// this reports success; while the flag is clear but the session is still
+// running, polling continues until the deadline instead of returning early.
+func waitForControllerRestart(ctx context.Context, dops drainOps, sp runtime.Provider, sn, command string, pollInterval, timeout time.Duration, stderr io.Writer) int {
 	deadline := time.Now().Add(timeout)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
@@ -640,7 +670,7 @@ func waitForControllerRestart(ctx context.Context, dops drainOps, sn, command st
 			switch {
 			case err != nil:
 				lastPollErr = err
-			case !requested:
+			case !requested && !sp.IsRunning(sn):
 				// The controller accepted the stop handoff or the runtime is already gone.
 				return 0
 			default:

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -963,7 +963,7 @@ func TestDoRuntimeRequestRestartError(t *testing.T) {
 	dops := newFakeDrainOps()
 	dops.err = errors.New("tmux borked")
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+	code := doRuntimeRequestRestart(context.Background(), dops, runtime.NewFake(), nil, false, events.Discard, "worker", "worker",
 		time.Millisecond, time.Second, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
@@ -973,11 +973,43 @@ func TestDoRuntimeRequestRestartError(t *testing.T) {
 	}
 }
 
+// TestDoRuntimeRequestRestart_PinnedRequiresPersistRestart covers Fix 1 for
+// the gc runtime request-restart path: a pinned session (pin_awake ==
+// "true") is kill-protected by the reconciler unless an explicit controller
+// reset is persisted, so persistRestart is mandatory rather than best-effort
+// when pinned is true. Mirrors TestDoHandoff_PinnedAlwaysSessionRequiresPersistRestart.
+func TestDoRuntimeRequestRestart_PinnedRequiresPersistRestart(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		persistRestart func() error
+	}{
+		{name: "nil persistRestart"},
+		{name: "persistRestart error", persistRestart: func() error { return errors.New("worker boundary unavailable") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dops := newFakeDrainOps()
+			rec := events.NewFake()
+			var stdout, stderr bytes.Buffer
+			code := doRuntimeRequestRestart(context.Background(), dops, runtime.NewFake(), tc.persistRestart, true, rec, "mayor", "mayor",
+				10*time.Millisecond, time.Second, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("code = %d, want 1; stderr: %s", code, stderr.String())
+			}
+			if got := stdout.String(); strings.Contains(got, "Restart requested") {
+				t.Errorf("stdout = %q, must not promise a restart when persistRestart is unavailable for a pinned session", got)
+			}
+			if len(rec.Events) != 0 {
+				t.Fatalf("got %d events, want 0 (must not record SessionDraining without a real restart request); events=%v", len(rec.Events), rec.Events)
+			}
+		})
+	}
+}
+
 func TestDoRuntimeRequestRestartFlagCleared(t *testing.T) {
 	dops := &drainOpsWithCountdown{fakeDrainOps: newFakeDrainOps(), remaining: 2}
 
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+	code := doRuntimeRequestRestart(context.Background(), dops, runtime.NewFake(), nil, false, events.Discard, "worker", "worker",
 		10*time.Millisecond, 5*time.Second, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0 when flag cleared; stderr: %s", code, stderr.String())
@@ -997,7 +1029,7 @@ func TestDoRuntimeRequestRestartTimeout(t *testing.T) {
 	dops := newFakeDrainOps()
 
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+	code := doRuntimeRequestRestart(context.Background(), dops, runtime.NewFake(), nil, false, events.Discard, "worker", "worker",
 		10*time.Millisecond, 25*time.Millisecond, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1 on timeout", code)
@@ -1015,7 +1047,7 @@ func TestDoRuntimeRequestRestartTimeoutReportsLastPollError(t *testing.T) {
 	dops.restartReadErr = errors.New("metadata read failed")
 
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+	code := doRuntimeRequestRestart(context.Background(), dops, runtime.NewFake(), nil, false, events.Discard, "worker", "worker",
 		10*time.Millisecond, 25*time.Millisecond, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1 on timeout", code)
@@ -1033,7 +1065,7 @@ func TestDoRuntimeRequestRestartContextCancel(t *testing.T) {
 
 	done := make(chan int, 1)
 	go func() {
-		done <- doRuntimeRequestRestart(ctx, dops, nil, events.Discard, "worker", "worker",
+		done <- doRuntimeRequestRestart(ctx, dops, runtime.NewFake(), nil, false, events.Discard, "worker", "worker",
 			10*time.Millisecond, 30*time.Second, &stdout, &stderr)
 	}()
 
@@ -1145,7 +1177,7 @@ func TestDoRuntimeRequestRestartProceedsAndPendsOnCancel(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	done := make(chan int, 1)
 	go func() {
-		done <- doRuntimeRequestRestart(ctx, dops, persistRestart, events.Discard, "mayor", "mayor",
+		done <- doRuntimeRequestRestart(ctx, dops, runtime.NewFake(), persistRestart, false, events.Discard, "mayor", "mayor",
 			10*time.Millisecond, 30*time.Second, &stdout, &stderr)
 	}()
 

--- a/cmd/gc/repro_ga_rble9w_test.go
+++ b/cmd/gc/repro_ga_rble9w_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestRepro_ga_rble9w_PinnedMayorHandoffNeverCyclesAndFalselyReportsSuccess(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "mayor", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "mayor", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "mayor")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:          "true",
+		SessionName:      sessionName,
+		TemplateName:     "mayor",
+		ResolvedProvider: &config.ResolvedProvider{SessionIDFlag: "--session-id"},
+	}
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "mayor",
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"pin_awake":                  "true",
+		// no restart_requested and no continuation_reset_pending: models
+		// persistRestart() not landing the marker
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_RESTART_REQUESTED", "1"); err != nil { // gc handoff's tmux flag
+		t.Fatalf("SetMeta(GC_RESTART_REQUESTED): %v", err)
+	}
+	dops := newDrainOps(env.sp)
+	env.reconcileWithPoolDesiredAndDrainOps([]beads.Bead{session}, map[string]int{"mayor": 1}, dops)
+
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatalf("expected repro: pinned mayor still running (bug), but it was cycled")
+	}
+	flag, err := env.sp.GetMeta(sessionName, "GC_RESTART_REQUESTED")
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	if strings.TrimSpace(flag) != "" {
+		t.Fatalf("GC_RESTART_REQUESTED = %q; repro expects reconciler to have cleared it without cycling", flag)
+	}
+	if got := env.stderr.String(); !strings.Contains(got, "skipping abrupt restart-requested kill for pinned named session") {
+		t.Fatalf("stderr = %q, want pinned collateral-skip diagnostic", got)
+	}
+	// Fixed behavior: the flag was cleared by the reconciler's collateral-skip
+	// above, but the pinned mayor session is still actually running, so
+	// waitForControllerRestart must not report success — it polls to the
+	// timeout and returns 1, instead of the pre-fix false success (0).
+	var waitErr bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	code := waitForControllerRestart(ctx, dops, env.sp, sessionName, "gc handoff", 10*time.Millisecond, 100*time.Millisecond, &waitErr)
+	if code != 1 {
+		t.Fatalf("waitForControllerRestart code = %d, want 1 (still running, not a false success); stderr=%q", code, waitErr.String())
+	}
+}

--- a/cmd/gc/session_reconciler_restart_request_test.go
+++ b/cmd/gc/session_reconciler_restart_request_test.go
@@ -783,3 +783,87 @@ func TestReconcileSessionBeads_RestartRequestAllowsExplicitResetForPinnedNamedSe
 		t.Fatalf("continuation_reset_pending = %q, want true until next start", got.Metadata["continuation_reset_pending"])
 	}
 }
+
+// TestDoHandoff_PinnedAlwaysSessionPersistsResetAndReconcilerStopsSession
+// covers Fix 1 end-to-end: doHandoffWithOutcome on a pinned always-mode
+// session with a working persistRestart must land continuation_reset_pending
+// on the session bead, and that persisted state must be exactly what lets the
+// reconciler's explicit-reset escape hatch actually stop the pinned session
+// on its next pass (mirrors
+// TestReconcileSessionBeads_RestartRequestAllowsExplicitResetForPinnedNamedSession,
+// but drives the persisted state through the CLI instead of setting it
+// directly).
+func TestDoHandoff_PinnedAlwaysSessionPersistsResetAndReconcilerStopsSession(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "mayor", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "mayor", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "mayor")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "mayor",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "mayor",
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"pin_awake":                  "true",
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	dops := newDrainOps(env.sp)
+	persistCalled := false
+	persistRestart := func() error {
+		persistCalled = true
+		// Stands in for Manager.RequestFreshRestart (out of scope here):
+		// what doHandoffWithOutcome actually depends on is that a working
+		// persistRestart lands continuation_reset_pending on the bead.
+		return env.store.SetMetadata(session.ID, "continuation_reset_pending", "true")
+	}
+
+	var stdout, stderr bytes.Buffer
+	outcome := doHandoffWithOutcome(env.store, env.store, env.rec, dops, persistRestart,
+		sessionName, sessionName, []string{"HANDOFF: context full"}, &stdout, &stderr)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	if !outcome.restartRequested {
+		t.Fatal("restartRequested = false, want true for pinned always-mode session with working persistRestart")
+	}
+	if !persistCalled {
+		t.Fatal("persistRestart was not called for pinned always-mode session")
+	}
+	if !strings.Contains(stdout.String(), "requesting restart") {
+		t.Errorf("stdout = %q, want restart-requested confirmation", stdout.String())
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true after successful pinned handoff", got.Metadata["continuation_reset_pending"])
+	}
+
+	// The reconciler is the end-to-end oracle: with continuation_reset_pending
+	// now landed, its explicit-reset escape hatch must actually stop the
+	// pinned session on the next reconcile pass.
+	env.reconcileWithPoolDesiredAndDrainOps([]beads.Bead{got}, map[string]int{"mayor": 1}, dops)
+	if env.sp.IsRunning(sessionName) {
+		t.Fatalf("pinned session %q still running after reconcile; persisted restart should have let the reconciler stop it", sessionName)
+	}
+}

--- a/release-gates/ga-pms9ox-pinned-mayor-handoff-noop-gate.md
+++ b/release-gates/ga-pms9ox-pinned-mayor-handoff-noop-gate.md
@@ -1,0 +1,28 @@
+# Release Gate: pinned mayor handoff no-op
+
+- Bead: ga-pms9ox
+- Source fix bead: ga-fedwpf
+- Review bead: ga-sj15c9
+- Deploy source SHA: `75b7395905b7d172d9e80ed4403d09e29235b0dd`
+- Deploy branch: `deploy/ga-pms9ox-gate`
+- Base checked: `origin/main` at `2861a4fd5ef8717781fb665ea486edf75e7d03ef`
+- Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout; gate criteria are the deployer prompt criteria.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git merge-tree --write-tree origin/main 75b7395905b7d172d9e80ed4403d09e29235b0dd` exited 0 and produced tree `1e5c880d77664c4cbe4349bb2ab249935e162534`; `git diff --check origin/main...HEAD` exited 0. |
+| 1 | Review PASS present | PASS | `bd show ga-sj15c9` contains `Review verdict: PASS` for commit `75b739590`, with no blocking findings. |
+| 2 | Acceptance criteria met | PASS | Code inspection confirmed pinned always-mode sessions now require `persistRestart()` before promising a restart in both `gc handoff` and `gc runtime request-restart`; failures return 1 and suppress false restart messaging. `waitForControllerRestart` now returns success only when the restart flag is clear and `sp.IsRunning(sn)` is false. Regression and unit coverage exists in `cmd/gc/repro_ga_rble9w_test.go`, `cmd/gc/cmd_handoff_test.go`, `cmd/gc/cmd_runtime_drain_test.go`, and `cmd/gc/session_reconciler_restart_request_test.go`. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestDoHandoff_PinnedAlwaysSessionRequiresPersistRestart|TestDoRuntimeRequestRestart_PinnedRequiresPersistRestart|TestDoHandoff_PinnedAlwaysSessionPersistsResetAndReconcilerStopsSession|TestRepro_ga_rble9w_PinnedMayorHandoffNeverCyclesAndFalselyReportsSuccess|TestWaitForControllerRestartHandoffFlagClearedButSessionStillRunning'` passed. `make test-fast-parallel` passed all 8 fast jobs. `go vet ./...` passed. `go build ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for ga-sj15c9 record PASS. The only follow-up, ga-e17tpz, is explicitly non-blocking and pre-existing: `gc handoff --target` direct-kill behavior is outside this fix's self-handoff/request-restart scope. |
+| 5 | Final branch is clean | PASS | Isolated worktree `/var/tmp/codex-gascity-ga-pms9ox-gate-3554070` was clean before this gate file; after the gate commit, `git status --short --branch` is expected to show only `## deploy/ga-pms9ox-gate`. |
+| 7 | Single feature theme | PASS | Single commit touches only `cmd/gc` handoff/runtime restart behavior and adjacent tests: `cmd_handoff.go`, `cmd_runtime_drain.go`, and related `cmd/gc` tests. No independent subsystem or unrelated user-facing behavior is bundled. |
+
+## Acceptance Detail
+
+- Pinned self-handoff no longer claims success when the persistent restart marker is unavailable.
+- `gc runtime request-restart` follows the same pinned-session requirement.
+- A cleared `GC_RESTART_REQUESTED` flag is no longer treated as proof of restart while the session is still running.
+- Non-pinned restart behavior remains best-effort for the persisted bead marker and is covered by the existing passing command tests.


### PR DESCRIPTION
## What this changes

`gc handoff` and `gc runtime request-restart` now fail loudly for pinned, always-mode named sessions when the CLI cannot persist the restart marker that the reconciler requires. Previously those commands could print `requesting restart`, exit 0, and leave a pinned mayor/HQ-style session running.

The restart wait logic also checks runtime liveness, so a cleared `GC_RESTART_REQUESTED` flag is not treated as success while the same session is still alive.

## Review notes

- Scope is CLI handoff/runtime request-restart plus adjacent `cmd/gc` tests.
- Non-pinned restart behavior keeps the prior best-effort persisted bead marker path.
- Direct `gc handoff --target` behavior is unchanged and tracked separately.

## Test plan

- [x] `go test ./cmd/gc -run 'TestDoHandoff_PinnedAlwaysSessionRequiresPersistRestart|TestDoRuntimeRequestRestart_PinnedRequiresPersistRestart|TestDoHandoff_PinnedAlwaysSessionPersistsResetAndReconcilerStopsSession|TestRepro_ga_rble9w_PinnedMayorHandoffNeverCyclesAndFalselyReportsSuccess|TestWaitForControllerRestartHandoffFlagClearedButSessionStillRunning'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] Release gate: [`release-gates/ga-pms9ox-pinned-mayor-handoff-noop-gate.md`](release-gates/ga-pms9ox-pinned-mayor-handoff-noop-gate.md)