### PR TITLE
test(tmux-sweep): post-merge #4254 — require PID separator + defer socket-parent cleanup on panic

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -248,6 +248,18 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	tmuxSocketAliveSentinel = tmuxSentinel
+	// testscript.Main below exits via os.Exit, which skips defers, so the
+	// normal path removes the tmux socket parent through cleanupTestingM. A
+	// setup panic before testscript.Main is reached still unwinds through
+	// defers, so cover that window here or it leaks /tmp/gct-<pid>-* until a
+	// later aged sweep. cmdGCTmuxSocketRoot returns an empty cleanup root when
+	// it fell back to a dir under TMPDIR (swept separately), so only the real
+	// /tmp parent is removed here.
+	defer func() {
+		if tmuxSocketCleanupRoot != "" {
+			_ = os.RemoveAll(tmuxSocketCleanupRoot)
+		}
+	}()
 	if err := tmuxtest.ConfigureProcessEnv(tmuxSocketRoot); err != nil {
 		panic(err)
 	}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -114,10 +114,19 @@ func TestMain(m *testing.M) {
 	// stay referenced for the process lifetime: the runtime finalizes
 	// unreachable os.Files, which would close the descriptor and release
 	// the lock, letting a concurrent sibling's sweep reclaim this still-
-	// active directory (ga-djbcqt). Cleanup below is explicit, not deferred:
-	// every exit path in this function calls os.Exit, which skips defers.
+	// active directory (ga-djbcqt). Normal and skip exits call os.Exit, which
+	// skips defers, so those paths remove the parent explicitly below; the
+	// deferred removal here additionally covers a setup panic (which unwinds
+	// through defers) so it cannot leak the parent until a later aged sweep.
 	tmuxSocketParent, tmuxSentinel, tmuxParentErr := tmuxtest.NewSocketParentDir("/tmp")
 	tmuxSocketAliveSentinel = tmuxSentinel
+	defer func() {
+		// Re-read tmuxSocketParent so the MkdirAll-failure path that clears it
+		// below is honored and this never double-removes on a normal exit.
+		if tmuxSocketParent != "" {
+			_ = os.RemoveAll(tmuxSocketParent)
+		}
+	}()
 	tmuxSocketRoot := filepath.Join(tmpDir, "tmux")
 	if tmuxParentErr == nil {
 		tmuxSocketRoot = filepath.Join(tmuxSocketParent, "tmux")

--- a/test/tmuxtest/orphan_sweep.go
+++ b/test/tmuxtest/orphan_sweep.go
@@ -79,6 +79,14 @@ func aliveSentinelHeld(dir string) (exists, held bool) {
 	return true, false
 }
 
+// pidFromPrefixedDirName parses the owner PID out of a socket-parent dir name
+// of the form "<prefix><PID>-<random>" -- the shape NewSocketParentDir creates
+// via os.MkdirTemp(root, "<prefix><PID>-*"). The "-" separator after the PID is
+// required: a bare all-digit "<prefix><digits>" name is a legacy directory left
+// by the pre-sweep harness (os.MkdirTemp(root, prefix)), whose trailing digits
+// are a random suffix, not an owner PID. Parsing that random number as a PID
+// could reap a still-live legacy sibling once it aged past the sweep guard, so
+// such names are rejected here and left for a dedicated opt-in cleanup path.
 func pidFromPrefixedDirName(name, prefix string) (int, bool) {
 	if !strings.HasPrefix(name, prefix) {
 		return 0, false
@@ -91,7 +99,7 @@ func pidFromPrefixedDirName(name, prefix string) (int, bool) {
 	if end == 0 {
 		return 0, false
 	}
-	if end < len(suffix) && suffix[end] != '-' {
+	if end >= len(suffix) || suffix[end] != '-' {
 		return 0, false
 	}
 	pid, err := strconv.Atoi(suffix[:end])
@@ -110,10 +118,12 @@ func pidFromPrefixedDirName(name, prefix string) (int, bool) {
 // Liveness is decided by the alive sentinel flock when present: flock state
 // is visible across PID namespaces, whereas raw PID liveness reports every
 // host PID as dead from inside a bwrap --unshare-pid sandbox that shares
-// the host /tmp (ga-djbcqt). PID liveness is only a fallback for dirs
-// without a sentinel -- e.g. ones leaked before this sweep existed. Dirs
-// younger than socketParentSweepMinAge are never touched, covering the
-// window before a sibling run's sentinel exists.
+// the host /tmp (ga-djbcqt). PID liveness is only a fallback for a
+// "<prefix><PID>-<random>" dir that crashed between MkdirTemp and
+// HoldAliveSentinel; legacy pre-sweep names with no "-" after the PID are
+// rejected by pidFromPrefixedDirName and never swept here. Dirs younger than
+// socketParentSweepMinAge are never touched, covering the window before a
+// sibling run's sentinel exists.
 func SweepOrphanPIDPrefixedDirs(root, prefix string) {
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -144,13 +154,14 @@ func SweepOrphanPIDPrefixedDirs(root, prefix string) {
 			// Sentinel present but unlocked: the creator is gone. Remove.
 			reason = "free sentinel"
 		default:
-			// No sentinel at all: either leaked before this sweep existed,
-			// or crashed between MkdirTemp and HoldAliveSentinel. Fall back
-			// to PID liveness.
+			// A "<prefix><PID>-<random>" dir with no sentinel: its creator
+			// crashed between MkdirTemp and HoldAliveSentinel. Fall back to
+			// PID liveness. (Legacy no-"-" names are rejected by
+			// pidFromPrefixedDirName and never reach here.)
 			if pidutil.Alive(pid) {
 				continue
 			}
-			reason = "legacy: pid dead, no sentinel"
+			reason = "pid dead, no sentinel"
 		}
 		// Name each removal so a recurrence of ga-djbcqt is attributable
 		// from run logs instead of gate-log forensics.

--- a/test/tmuxtest/orphan_sweep_test.go
+++ b/test/tmuxtest/orphan_sweep_test.go
@@ -166,3 +166,49 @@ func TestNewSocketParentDirReapsOrphanedSibling(t *testing.T) {
 		t.Errorf("freshly created dir missing: %v", err)
 	}
 }
+
+func TestSweepOrphanPIDPrefixedDirsPreservesLegacyNoDashDir(t *testing.T) {
+	root := t.TempDir()
+	// The pre-sweep harness created its socket parent with
+	// os.MkdirTemp(root, "pfx-"), yielding an all-digit "pfx-<random>" name
+	// with no "-" separator and no alive sentinel. Those trailing digits are a
+	// MkdirTemp random suffix, not an owner PID -- parsing them as a (dead) PID
+	// would let the sweep reap a still-live legacy sibling. Even backdated past
+	// the age guard and with digits that look like a dead PID, the missing
+	// separator must keep the dir out of the sweep.
+	legacy := filepath.Join(root, "pfx-"+strconv.Itoa(nonLivePID(t)))
+	if err := os.Mkdir(legacy, 0o700); err != nil {
+		t.Fatalf("Mkdir(%s): %v", legacy, err)
+	}
+	backdatePastSweepAge(t, legacy)
+
+	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+
+	if _, err := os.Stat(legacy); err != nil {
+		t.Errorf("legacy no-separator dir was removed by sweep: %v", err)
+	}
+}
+
+func TestPIDFromPrefixedDirName(t *testing.T) {
+	const prefix = "gct-"
+	cases := []struct {
+		name    string
+		wantPID int
+		wantOK  bool
+	}{
+		{"gct-1234-0007", 1234, true}, // canonical <prefix><PID>-<random>
+		{"gct-1234-", 1234, true},     // separator present, empty random suffix
+		{"gct-1234", 0, false},        // legacy no-separator name: rejected
+		{"gct-", 0, false},            // no digits
+		{"gct-abc", 0, false},         // non-digit suffix
+		{"gct-12ab-3", 0, false},      // digits not terminated by "-"
+		{"other-1234-5", 0, false},    // wrong prefix
+	}
+	for _, tc := range cases {
+		gotPID, gotOK := pidFromPrefixedDirName(tc.name, prefix)
+		if gotPID != tc.wantPID || gotOK != tc.wantOK {
+			t.Errorf("pidFromPrefixedDirName(%q, %q) = (%d, %v), want (%d, %v)",
+				tc.name, prefix, gotPID, gotOK, tc.wantPID, tc.wantOK)
+		}
+	}
+}


### PR DESCRIPTION
## Post-merge remediation for #4254

A post-merge review of #4254 (landed range `9ddbea5c0..fd8bddf68`, the tmux
socket-parent cleanup hardening) surfaced two correctness issues in the new
`test/tmuxtest` sweep and the migrated `TestMain`s. This PR fixes both with
scoped test-only changes.

### 1. Sweep could reap a still-live legacy sibling
`tmuxtest.pidFromPrefixedDirName` accepted a bare all-digit `"<prefix><digits>"`
name as PID-owned. The pre-sweep harness created its socket parent with
`os.MkdirTemp(root, "gct-")`, which yields a no-separator `gct-<random>` name
whose trailing digits are a MkdirTemp random suffix, **not** an owner PID. Once
such a directory aged past the one-hour guard, the sweep could parse that random
number as a (dead) PID and remove the directory — reaping a **live** old-harness
sibling's socket parent.

Fix: require the `-` separator after the parsed PID, so only the
`"<prefix><PID>-<random>"` names the sweep documents ownership of are eligible.
Legacy no-`-` names are left untouched for a dedicated opt-in cleanup path.
Adds a regression test that a backdated, no-sentinel legacy directory is
preserved, plus a table test pinning the parser contract.

### 2. Setup panic leaked the tmux socket parent
The `test/integration` and `cmd/gc` `TestMain`s removed `/tmp/gct-<pid>-*` only
on their explicit `os.Exit` paths. A setup panic between `NewSocketParentDir`
and those exits unwinds through **defers** — which the `os.Exit` paths
intentionally skip — leaking the parent directory until a later aged sweep.

Fix: add a `defer`-backed removal immediately after `NewSocketParentDir`
succeeds to cover panic paths, while keeping the explicit `os.Exit`-path cleanup
for normal/skip exits. The integration closure re-reads `tmuxSocketParent` so the
`MkdirAll`-failure path that clears it is honored (no double removal).

### Scope
`cmd/gc`'s own sweep parser is intentionally left accepting `"<prefix><PID>"`:
that is its documented contract (bare per-PID roots) and it is additionally
guarded by an active-root marker, so it is not subject to this finding. The
duplicated sweep/sentinel algorithm is a separate, non-blocking follow-up.

### Verification
- `go test ./test/tmuxtest/` — all pass, including the two new regression tests.
- Integration + `cmd/gc` test binaries compile (`go test -c`), `go vet` clean.
- `golangci-lint` on changed packages: 0 issues; `go vet ./...` clean (pre-commit).
