### PR TITLE
fix(runtime): treat a gone session as drain-acked (#4448)

### DIFF
--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -106,6 +106,15 @@ func (o *providerDrainOps) setDrainAck(sessionName string) error {
 func (o *providerDrainOps) isDrainAcked(sessionName string) (bool, error) {
 	val, err := o.sp.GetMeta(sessionName, "GC_DRAIN_ACK")
 	if err != nil {
+		if runtime.IsSessionGone(err) {
+			// The session called drain-ack and exited before this read —
+			// the ack lives only in ephemeral runtime metadata that died
+			// with the process. Treat a gone session as acked so the
+			// reconciler's drain-ack fast path still closes the bead
+			// instead of leaving a dead session counted toward pool
+			// demand (#4448).
+			return true, nil
+		}
 		return false, fmt.Errorf("reading GC_DRAIN_ACK: %w", err)
 	}
 	return val == "1", nil

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -1103,6 +1103,27 @@ func TestProviderDrainOpsIsRestartRequestedTreatsGoneSessionAsCleared(t *testing
 	}
 }
 
+// TestProviderDrainOpsIsDrainAckedTreatsGoneSessionAsAcked pins issue #4448:
+// a session that calls "gc runtime drain-ack" and then exits before the
+// reconciler's next tick leaves GC_DRAIN_ACK unreadable (the metadata dies
+// with the process). isDrainAcked must treat that as acked — mirroring
+// isRestartRequested's existing gone-session handling — so the reconciler's
+// drain-ack fast path still closes the bead instead of silently skipping it
+// and leaving a dead session counted toward pool demand.
+func TestProviderDrainOpsIsDrainAckedTreatsGoneSessionAsAcked(t *testing.T) {
+	dops := newDrainOps(&getMetaErrorProvider{
+		Fake: runtime.NewFake(),
+		err:  runtime.ErrSessionNotFound,
+	})
+	acked, err := dops.isDrainAcked("worker")
+	if err != nil {
+		t.Fatalf("isDrainAcked returned gone-session error: %v", err)
+	}
+	if !acked {
+		t.Fatal("isDrainAcked = false, want true for gone session")
+	}
+}
+
 func TestRequestRestartAcceptsNoArgs(t *testing.T) {
 	// Verify the cobra command accepts no args.
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
## Problem

Drained pool sessions were not being reaped: their open session bead
silently starved pool demand at cap. Reported state showed
`STATE=active` 14+ minutes after `drain-ack`, with the reconciler stuck
at a frozen `desired_count=1 open_count=1`.

## Root cause

`gc runtime drain-ack` writes its ack (`GC_DRAIN_ACK=1`) as ephemeral
runtime-provider metadata on the exiting session, not durably on the
bead. Agents typically call drain-ack right before their process exits,
so by the time the reconciler's next tick reads it back, the session is
commonly already gone and `GetMeta` fails.

`isDrainAcked` (`cmd/gc/cmd_runtime_drain.go`) had no special-casing for
that failure mode — unlike its sibling `isRestartRequested`, which
already treats a gone session as "not requested, no error." So the read
silently returned `acked=false`, the reconciler's drain-ack fast path
(`finalizeDrainAckStoppedSession`) never ran, and the bead sat open,
uncounted as drained.

## Fix

`isDrainAcked` now mirrors `isRestartRequested`'s existing
`runtime.IsSessionGone(err)` handling — treats a gone session as acked.

## Testing

Added `TestProviderDrainOpsIsDrainAckedTreatsGoneSessionAsAcked`,
mirroring the existing sibling test
`TestProviderDrainOpsIsRestartRequestedTreatsGoneSessionAsCleared` and
reusing its `getMetaErrorProvider` fixture.

- New test: confirmed RED first (reproduced
  `isDrainAcked returned gone-session error: reading GC_DRAIN_ACK:
  session not found`), GREEN after the fix
- Sibling `isRestartRequested` test: still passes
- Full drain/reconciler sweep (`TestSessionReconciler*`, `TestRuntime*`,
  `TestDrain*`, `TestProviderDrainOps*`): pass
- `go build -tags gms_pure_go ./cmd/gc/...`: clean
- `go vet -tags gms_pure_go ./cmd/gc/...`: clean

Closes #4448