### PR TITLE
test(cmd_hook): resolve "true" via LookPath instead of hardcoding /bin/true (#4454)

### DIFF
--- a/cmd/gc/cmd_hook_stdin_drain_test.go
+++ b/cmd/gc/cmd_hook_stdin_drain_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -32,10 +33,12 @@ func (t *trackingReader) Read(p []byte) (int, error) {
 //
 // gc hook run must fully consume its stdin so the provider's write always
 // completes, regardless of whether the wrapped command reads it. The wrapped
-// executable here is /bin/true, which exits 0 without reading stdin.
+// executable here is "true" (resolved via LookPath — its absolute path
+// differs by platform, e.g. /usr/bin/true on macOS vs /bin/true on Linux),
+// which exits 0 without reading stdin.
 func TestHookRunConsumesStdinWhenWrappedCommandIgnoresIt(t *testing.T) {
 	orig := hookRunExecutable
-	hookRunExecutable = func() (string, error) { return "/bin/true", nil }
+	hookRunExecutable = func() (string, error) { return exec.LookPath("true") }
 	t.Cleanup(func() { hookRunExecutable = orig })
 
 	payload := strings.Repeat("x", 8192)
@@ -85,7 +88,7 @@ func (b *blockingReader) Read(p []byte) (int, error) {
 // configured timeout instead of wedging before it spawns the child.
 func TestHookRunReturnsWithinTimeoutWhenStdinNeverEOFs(t *testing.T) {
 	orig := hookRunExecutable
-	hookRunExecutable = func() (string, error) { return "/bin/true", nil }
+	hookRunExecutable = func() (string, error) { return exec.LookPath("true") }
 	t.Cleanup(func() { hookRunExecutable = orig })
 
 	release := make(chan struct{})
@@ -129,7 +132,8 @@ func TestHookRunReturnsWithinTimeoutWhenStdinNeverEOFs(t *testing.T) {
 // A PTY master from /dev/ptmx is the terminal proxy: it is a char-device
 // *os.File whose Read blocks forever with no EOF while no slave writes to it,
 // which is exactly the shape of os.Stdin on a real terminal. The wrapped
-// executable is /bin/true, which exits 0 without reading stdin.
+// executable is "true" (resolved via LookPath), which exits 0 without
+// reading stdin.
 func TestHookRunSkipsStdinDrainForTerminal(t *testing.T) {
 	tty, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
 	if err != nil {
@@ -144,7 +148,7 @@ func TestHookRunSkipsStdinDrainForTerminal(t *testing.T) {
 	}
 
 	orig := hookRunExecutable
-	hookRunExecutable = func() (string, error) { return "/bin/true", nil }
+	hookRunExecutable = func() (string, error) { return exec.LookPath("true") }
 	t.Cleanup(func() { hookRunExecutable = orig })
 
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
## Problem

Three tests in `cmd/gc/cmd_hook_stdin_drain_test.go` hardcode
`/bin/true` as a zero-cost, stdin-ignoring command. That path doesn't
exist on macOS (only `/usr/bin/true` does), so every push from a Mac
fails the pre-push hook's fast suite:

```
fork/exec /bin/true: no such file or directory
```

Confirmed reproducing locally before this fix.

## Fix

Swapped all three `hookRunExecutable = func() (string, error) { return
"/bin/true", nil }` closures for `exec.LookPath("true")`:

- `TestHookRunConsumesStdinWhenWrappedCommandIgnoresIt`
- `TestHookRunReturnsWithinTimeoutWhenStdinNeverEOFs`
- `TestHookRunSkipsStdinDrainForTerminal`

This matches the existing convention already used elsewhere in this
package (`cmd_session_test.go:941`,
`internal/api/handler_session_chat_test.go`) — resolve `true` via
`LookPath` so it works wherever the binary actually lives, rather than
hardcoding a Linux-only path. Test semantics are unchanged: all three
only need a command that exits 0 without reading stdin. Updated two
adjacent comments for accuracy.

**One correction to the issue's own claim:** it also names
`TestRunProviderOp_error*` as an affected sibling. That's not accurate —
those tests generate their own `#!/bin/sh` temp script rather than
hardcoding a path, and already pass on macOS unmodified. Noting it here
so it isn't repeated as fact.

## Testing

- All three fixed tests: confirmed failing on `/bin/true` before the
  fix, passing after
- Full `cmd_hook*`/`TestHookRun*` sweep: pass, 24s
- `go build -tags gms_pure_go ./cmd/gc/...`: clean
- `go vet -tags gms_pure_go ./cmd/gc/...`: clean

Closes #4454