### PR TITLE
fix(supervisor): back off structural init failures far longer than transient ones (#4484)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1627,6 +1627,44 @@ type initFailRecord struct {
 
 const staleCityDirAbsentThreshold = 3
 
+// structuralInitFailureBackoff is the retry interval for init failures
+// classified as structural (see isStructuralInitFailureMessage) -- far
+// longer than the transient-failure ceiling, since retrying sooner cannot
+// help: the failure requires an out-of-band fix no in-city action can
+// trigger (#4484).
+const structuralInitFailureBackoff = time.Hour
+
+// isStructuralInitFailureMessage reports whether msg indicates an init
+// failure that no amount of retrying -- or editing city.toml -- can ever
+// resolve, e.g. a bd schema-version gate ("database is at vN, binary
+// knows up to vM"), which requires an out-of-band bd binary upgrade.
+// Mirrors runtime.IsSessionGone's message-substring classification style
+// for external-subprocess errors with no typed sentinel available.
+func isStructuralInitFailureMessage(msg string) bool {
+	return strings.Contains(msg, "schema version mismatch")
+}
+
+// initFailureBackoffDelay computes the retry backoff for the count-th
+// consecutive init failure. Transient failures use capped exponential
+// backoff (10s doubling to a 5-minute ceiling, unchanged from before
+// #4484); structural failures (see isStructuralInitFailureMessage) back
+// off to structuralInitFailureBackoff immediately, since the standard
+// escalation cannot help a failure retrying will never resolve.
+func initFailureBackoffDelay(count int, msg string) time.Duration {
+	if isStructuralInitFailureMessage(msg) {
+		return structuralInitFailureBackoff
+	}
+	exp := count - 1
+	if exp > 5 {
+		exp = 5
+	}
+	delay := time.Duration(10<<exp) * time.Second
+	if delay > 5*time.Minute {
+		delay = 5 * time.Minute
+	}
+	return delay
+}
+
 // reconcileCities compares the registry against running cities and
 // starts/stops as needed. All state access goes through the cityRegistry.
 func reconcileCities(
@@ -1893,18 +1931,15 @@ func reconcileCities(
 				}
 				ifrec.count++
 				ifrec.dirAbsent = 0
-				exp := ifrec.count - 1
-				if exp > 5 {
-					exp = 5
-				}
-				delay := time.Duration(10<<exp) * time.Second
-				if delay > 5*time.Minute {
-					delay = 5 * time.Minute
-				}
+				delay := initFailureBackoffDelay(ifrec.count, msg)
 				ifrec.backoff = time.Now().Add(delay)
 				ifrec.configMod = configMod
 				ifrec.lastError = msg
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': init failure #%d, next retry in %s\n", cityName, ifrec.count, delay) //nolint:errcheck
+				if isStructuralInitFailureMessage(msg) {
+					fmt.Fprintf(stderr, "gc supervisor: city '%s': STRUCTURAL init failure (retrying cannot resolve this — needs an out-of-band fix), next check in %s\n", cityName, delay) //nolint:errcheck
+				} else {
+					fmt.Fprintf(stderr, "gc supervisor: city '%s': init failure #%d, next retry in %s\n", cityName, ifrec.count, delay) //nolint:errcheck
+				}
 			})
 		}
 

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -2911,3 +2911,50 @@ func TestNormalizeRegisteredCityPathResolvesSymlinks(t *testing.T) {
 		t.Fatalf("normalizeRegisteredCityPath(%q) = %q, want %q", link, got, want)
 	}
 }
+
+// TestIsStructuralInitFailureMessageDetectsSchemaVersionGate pins #4484:
+// a bd schema-version gate ("database is at vN, binary knows up to vM")
+// is a structural failure -- no retry, and no city.toml edit, can ever
+// resolve it, since the fix is an out-of-band bd binary upgrade. Ordinary
+// transient failures (a lock held, a socket busy) must not match.
+func TestIsStructuralInitFailureMessageDetectsSchemaVersionGate(t *testing.T) {
+	structural := `init: beads lifecycle: init city beads: bd list: exit status 1: { "error": "schema version mismatch: database is at v53, binary knows up to v49 (4 migrations ahead)", "schema_skew": {"current_version":53,"delta":4,"required_version":49}, "schema_version": 1 }`
+	if !isStructuralInitFailureMessage(structural) {
+		t.Errorf("isStructuralInitFailureMessage(%q) = false, want true", structural)
+	}
+
+	transient := "controller lock: lock held by another process"
+	if isStructuralInitFailureMessage(transient) {
+		t.Errorf("isStructuralInitFailureMessage(%q) = true, want false", transient)
+	}
+}
+
+// TestInitFailureBackoffDelayEscalatesStructuralFailuresBeyondTransientCeiling
+// pins #4484: gc supervisor previously applied the same capped exponential
+// backoff (10s doubling to a 5-minute ceiling) to every init failure,
+// including a structural schema-version gate that retrying can never
+// resolve -- observed live retrying at the 5-minute ceiling for ~6 days
+// straight. A structural failure must back off to a far longer interval
+// immediately (not escalate gradually like a transient one), while
+// ordinary transient failures keep their existing behavior unchanged.
+func TestInitFailureBackoffDelayEscalatesStructuralFailuresBeyondTransientCeiling(t *testing.T) {
+	structuralMsg := `init: bd list: exit status 1: schema version mismatch: database is at v53, binary knows up to v49 (4 migrations ahead)`
+
+	if got := initFailureBackoffDelay(1, structuralMsg); got != structuralInitFailureBackoff {
+		t.Errorf("initFailureBackoffDelay(1, structural) = %s, want %s (should not use the transient ceiling even on the first failure)", got, structuralInitFailureBackoff)
+	}
+	if got := initFailureBackoffDelay(27, structuralMsg); got != structuralInitFailureBackoff {
+		t.Errorf("initFailureBackoffDelay(27, structural) = %s, want %s", got, structuralInitFailureBackoff)
+	}
+
+	transientMsg := "controller lock: lock held by another process"
+	if got, want := initFailureBackoffDelay(1, transientMsg), 10*time.Second; got != want {
+		t.Errorf("initFailureBackoffDelay(1, transient) = %s, want %s (unchanged transient behavior)", got, want)
+	}
+	if got, want := initFailureBackoffDelay(7, transientMsg), 5*time.Minute; got != want {
+		t.Errorf("initFailureBackoffDelay(7, transient) = %s, want %s (transient ceiling unchanged)", got, want)
+	}
+	if got := initFailureBackoffDelay(7, transientMsg); got == structuralInitFailureBackoff {
+		t.Errorf("initFailureBackoffDelay(7, transient) = %s, must not equal the structural backoff by coincidence", got)
+	}
+}


### PR DESCRIPTION
## Problem

`gc supervisor`'s init-failure backoff (`recordInitFailure` in
`cmd/gc/cmd_supervisor.go`) applies the same capped exponential backoff
(10s doubling to a 5-minute ceiling) and the same single reset trigger
(`city.toml` mtime advancing) to every init failure, regardless of
cause.

That's correct for transient failures. It's wrong for a **structural**
failure like a `bd` schema-version gate (`schema version mismatch:
database is at vN, binary knows up to vM`) — no `city.toml` edit can
ever resolve that; the only real fix is an out-of-band `bd` binary
upgrade. Observed locally: 27+ identical failures over ~6 days, stuck
at the 5-minute retry ceiling the whole time, with no change in log
format or severity to signal this failure class needs a human to act
outside `gc` entirely.

## Fix

Two new pure, testable helpers:

- `isStructuralInitFailureMessage(msg string) bool` — classifies a
  failure by substring match on bd's stable `"schema version mismatch"`
  error text, mirroring `runtime.IsSessionGone`'s existing style for
  external-subprocess errors with no typed sentinel available.
- `initFailureBackoffDelay(count int, msg string) time.Duration` —
  returns the existing capped-exponential delay for transient failures
  unchanged, or a flat 1-hour backoff for structural ones, immediately
  rather than escalating gradually.

`recordInitFailure` now uses `initFailureBackoffDelay` for the actual
delay and emits a distinctly labeled log line — "STRUCTURAL init
failure (retrying cannot resolve this — needs an out-of-band fix)" —
instead of the generic `(skipping)` repeat, so an operator scanning
supervisor logs sees immediately that this failure class needs external
action, not more waiting.

## Testing

- `TestIsStructuralInitFailureMessageDetectsSchemaVersionGate`
- `TestInitFailureBackoffDelayEscalatesStructuralFailuresBeyondTransientCeiling`

Both confirmed RED by temporarily neutering the structural check — the
test reproduced the exact prior behavior (10s first failure, capping at
5m0s, the same symptom observed live for ~6 days) — restored, GREEN.

- Broader supervisor sweep (`TestSupervisor*`, `TestReconcileCities*`,
  `TestRegisterCityWithSupervisor*`, `TestUnregisterCityFromSupervisor*`,
  `TestInitFail*`): pass, 30.5s
- `go build -tags gms_pure_go ./cmd/gc/...`: clean
- `go vet -tags gms_pure_go ./cmd/gc/...`: clean

Closes #4484