### PR TITLE
feat(prime): inject unread mail on promptless SessionStart wake

### DIFF
--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -645,6 +645,102 @@ prompt_template = "prompts/worker.md"
 	}
 }
 
+// TestDoPrimeWithHook_SuppressedSessionStartInjectsUnreadMail drives the full
+// SessionStart hook payload (doPrimeWithHookFormat) on the suppressed-startup-
+// prompt path — the promptless-wake shape (dip-bj7pgj) where the rendered
+// startup prompt is delivered out of band, so only hook-only context survives.
+// With unread mail waiting for the self-recipient, the mail <system-reminder>
+// block must land in additionalContext alongside the beacon (and after the
+// suppressed prompt), for both the codex and gemini hook formats.
+func TestDoPrimeWithHook_SuppressedSessionStartInjectsUnreadMail(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
+	cityDir := t.TempDir()
+	promptDir := filepath.Join(cityDir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	const promptContent = "launch-only startup prompt\n"
+	if err := os.WriteFile(filepath.Join(promptDir, "worker.md"), []byte(promptContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "gastown"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.md"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	for _, hookFormat := range []string{hookOutputFormatCodex, hookOutputFormatGemini} {
+		hookFormat := hookFormat
+		t.Run(hookFormat, func(t *testing.T) {
+			t.Setenv("GC_CITY", cityDir)
+			t.Setenv("GC_AGENT", "worker")
+			t.Setenv("GC_ALIAS", "worker")
+			t.Setenv("GC_TEMPLATE", "worker")
+			t.Setenv("GC_SESSION_NAME", "gastown--worker")
+			sessionID := createPrimeHookSession(t, cityDir, "gastown--worker", "worker")
+			t.Setenv("GC_SESSION_ID", sessionID)
+			t.Setenv(managedSessionHookEnv, "1")
+			t.Setenv("GC_HOOK_SOURCE", "startup")
+			t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+			t.Setenv(startupPromptDeliveredEnv, "1")
+			withPrimeHookStdin(t)
+
+			// Seed unread mail for the self-recipient (worker) through the real
+			// city provider so the SessionStart injection path is exercised end
+			// to end.
+			mp, code := openCityMailProvider(io.Discard, "test seed")
+			if mp == nil {
+				t.Fatalf("openCityMailProvider returned nil (code=%d)", code)
+			}
+			if _, err := mp.Send("boss", "worker", "restart handoff", "resume the migration"); err != nil {
+				t.Fatalf("seed Send: %v", err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			if got := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookFormat, false); got != 0 {
+				t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", got, stderr.String())
+			}
+
+			var out struct {
+				HookSpecificOutput struct {
+					AdditionalContext string `json:"additionalContext"`
+				} `json:"hookSpecificOutput"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+				t.Fatalf("hook output is not JSON: %v; stdout=%q", err, stdout.String())
+			}
+			context := out.HookSpecificOutput.AdditionalContext
+			if strings.Contains(context, promptContent) {
+				t.Fatalf("additionalContext = %q, want no repeated startup prompt", context)
+			}
+			if !strings.Contains(context, "[gastown] worker") {
+				t.Fatalf("additionalContext = %q, want hook beacon", context)
+			}
+			if !strings.Contains(context, "<system-reminder>") {
+				t.Fatalf("additionalContext = %q, want mail system-reminder block", context)
+			}
+			if !strings.Contains(context, "unread message(s)") {
+				t.Fatalf("additionalContext = %q, want unread-mail count", context)
+			}
+			if !strings.Contains(context, "resume the migration") {
+				t.Fatalf("additionalContext = %q, want seeded mail body", context)
+			}
+			// Ordering: the mail block folds in after the beacon (which carries
+			// the suppressed prompt slot), matching writePrimePromptWithFormat.
+			if strings.Index(context, "[gastown] worker") > strings.Index(context, "<system-reminder>") {
+				t.Fatalf("additionalContext = %q, want beacon before mail block", context)
+			}
+		})
+	}
+}
+
 // mustCreateInProgressStore creates a bead in a beads.Store and transitions it
 // to in_progress. It mirrors the MemStore helper in wisp_step_inject_test.go
 // but works against the concrete city store opened on disk.

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,6 +177,52 @@ schema = 2
 	}
 	if got := stdout.String(); got != "Agent: ada\n" {
 		t.Fatalf("stdout = %q, want %q", got, "Agent: ada\n")
+	}
+}
+
+// TestPrimeInjectMailContentSurfacesUnreadMailForPromptlessWake covers the
+// prime-inject-mail patch (dip-bj7pgj): an autonomous/promptless restart runs
+// the SessionStart prime hook but NOT the UserPromptSubmit mail hook, so gc
+// prime must fold unread mail into the SessionStart payload itself. With no
+// unread mail the injection is empty (never noises up a prime); once mail is
+// waiting for the self-recipient, prime surfaces the same <system-reminder>
+// block the check path produces.
+func TestPrimeInjectMailContentSurfacesUnreadMailForPromptlessWake(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+
+	// No unread mail yet: a promptless wake must inject nothing.
+	if got := primeInjectMailContent(); got != "" {
+		t.Fatalf("primeInjectMailContent with an empty inbox = %q, want empty", got)
+	}
+
+	// Seed unread mail for the self-recipient (mayor) through the real city
+	// provider so the read path is exercised end to end.
+	mp, code := openCityMailProvider(io.Discard, "test seed")
+	if mp == nil {
+		t.Fatalf("openCityMailProvider returned nil (code=%d)", code)
+	}
+	if _, err := mp.Send("worker", "mayor", "PR ready", "please review the auth PR"); err != nil {
+		t.Fatalf("seed Send: %v", err)
+	}
+
+	got := primeInjectMailContent()
+	if !strings.Contains(got, "<system-reminder>") || !strings.Contains(got, "</system-reminder>") {
+		t.Fatalf("prime mail injection missing system-reminder wrapper:\n%s", got)
+	}
+	if !strings.Contains(got, "unread message(s)") {
+		t.Fatalf("prime mail injection missing unread count:\n%s", got)
+	}
+	if !strings.Contains(got, "please review the auth PR") {
+		t.Fatalf("prime mail injection missing the seeded message body:\n%s", got)
 	}
 }
 

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -869,8 +869,13 @@ provider = "exec:/not-used-by-auto-handoff"
 					t.Fatalf("additionalContext = %q, want auto-handoff substring %q", context, want)
 				}
 			}
+			// This city configures an exec: ordinary-mail provider, so the
+			// ordinary-mail read contributes nothing to the SessionStart payload
+			// while beadmail-backed auto-handoff still does. (The beadmail-backed
+			// ordinary case — where unread mail *is* injected — is pinned by
+			// TestDoPrimeWithHook_SessionStartDedupsAutoHandoffAndKeepsOrdinaryMailOpen.)
 			if strings.Contains(context, ordinary.ID) || strings.Contains(context, ordinary.Body) {
-				t.Fatalf("additionalContext = %q, must not inject ordinary mail %q at SessionStart", context, ordinary.ID)
+				t.Fatalf("additionalContext = %q, want no ordinary mail %q from the exec: provider at SessionStart", context, ordinary.ID)
 			}
 			if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
 				t.Fatalf("auto-handoff should be archived after SessionStart injection, got err=%v", err)
@@ -894,6 +899,103 @@ provider = "exec:/not-used-by-auto-handoff"
 				t.Fatalf("auto-handoff must remain durable when SessionStart output fails: %v", err)
 			}
 		})
+	}
+}
+
+// TestDoPrimeWithHook_SessionStartDedupsAutoHandoffAndKeepsOrdinaryMailOpen is
+// the beadmail-backed counterpart to
+// TestDoPrimeWithHook_DeliveredStartupPromptKeepsStepReminder: with no [mail]
+// provider configured, beadmail backs ordinary mail too, so the SessionStart
+// ordinary-unread read (dip-bj7pgj) sees the auto-handoff as well. It pins the
+// three properties that shape depends on: the auto-handoff is rendered exactly
+// once (the dedup branch actually filters), ordinary unread mail *is* surfaced,
+// and the ordinary read is non-destructive — the message is still in the store
+// after the hook run, so the later UserPromptSubmit delivery is not consumed.
+func TestDoPrimeWithHook_SessionStartDedupsAutoHandoffAndKeepsOrdinaryMailOpen(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	promptDir := filepath.Join(cityDir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "worker.md"), []byte("launch-only startup prompt\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+	// No [mail] provider: beadmail backs ordinary mail, so the ordinary read
+	// and the auto-handoff read hit the same store.
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "gastown"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.md"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_AGENT", "worker")
+	t.Setenv("GC_ALIAS", "worker")
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_SESSION_NAME", "gastown--worker")
+	sessionID := createPrimeHookSession(t, cityDir, "gastown--worker", "worker")
+	auto, ok := createHandoffMail(store, store, events.Discard, sessionID, sessionID,
+		[]string{"context cycle", "continue the durable task"}, "context cycle",
+		[]string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel}, &bytes.Buffer{})
+	if !ok {
+		t.Fatal("createHandoffMail(auto) failed")
+	}
+	ordinary, err := beadmail.New(store).Send("human", sessionID, "ordinary", "review the auth PR")
+	if err != nil {
+		t.Fatalf("Send ordinary mail: %v", err)
+	}
+	t.Setenv("GC_SESSION_ID", sessionID)
+	t.Setenv(managedSessionHookEnv, "1")
+	t.Setenv("GC_HOOK_SOURCE", "startup")
+	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+	t.Setenv(startupPromptDeliveredEnv, "1")
+	withPrimeHookStdin(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatCodex, false); code != 0 {
+		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	var got struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("hook output is not JSON: %v; stdout=%q", err, stdout.String())
+	}
+	context := got.HookSpecificOutput.AdditionalContext
+
+	// The auto-handoff is rendered by sessionStartAutoHandoffInjection and must
+	// NOT be rendered a second time by the ordinary-mail block.
+	if n := strings.Count(context, auto.ID); n != 1 {
+		t.Fatalf("additionalContext contains auto-handoff %q %d time(s), want exactly 1:\n%s", auto.ID, n, context)
+	}
+	// Ordinary unread mail is surfaced at SessionStart so a promptless wake is
+	// not blind to it.
+	for _, want := range []string{ordinary.ID, ordinary.Body} {
+		if !strings.Contains(context, want) {
+			t.Fatalf("additionalContext = %q, want ordinary-mail substring %q", context, want)
+		}
+	}
+	// ...and surfacing it is read-only: it stays in the store for the
+	// UserPromptSubmit delivery that archives it.
+	if _, err := store.Get(ordinary.ID); err != nil {
+		t.Fatalf("ordinary mail must remain open after a SessionStart injection: %v", err)
 	}
 }
 

--- a/cmd/gc/prime_auto_handoff_inject.go
+++ b/cmd/gc/prime_auto_handoff_inject.go
@@ -83,9 +83,11 @@ func primeUnreadMailInjection(skip map[string]bool) string {
 }
 
 // primeUnreadMailMessages returns the current agent's unread ordinary mail via
-// the configured city mail provider, resolving the self-recipient exactly as the
-// check path does (GC_SESSION_ID/GC_ALIAS/GC_AGENT via
-// defaultMailIdentityCandidates). It is read-only and returns nil on any error.
+// the configured city mail provider, using the same identity candidates as the
+// check path (GC_SESSION_ID/GC_ALIAS/GC_AGENT via defaultMailIdentityCandidates)
+// but resolved by the provider's own recipient routing rather than by
+// resolveMailTargetsWithConfig — so this reads the union of those candidates,
+// not the first-resolving target. It is read-only and returns nil on any error.
 func primeUnreadMailMessages() []mail.Message {
 	mp, _ := openCityMailProvider(io.Discard, "gc prime")
 	if mp == nil {

--- a/cmd/gc/prime_auto_handoff_inject.go
+++ b/cmd/gc/prime_auto_handoff_inject.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/mail/beadmail"
 )
 
@@ -27,23 +28,86 @@ func primeHookContextSuffix(cityPath string, hookMode bool, hookContext primeHoo
 	}
 	injection := primeHookContextInjection{text: wispStepInjectionContent(cityPath)}
 	if primeHookSessionStart(hookContext) {
-		autoHandoff := sessionStartAutoHandoffInjection(stderr)
+		autoHandoff, autoHandoffIDs := sessionStartAutoHandoffInjection(stderr)
 		injection.text += autoHandoff.text
 		if consumeHandoff {
 			injection.afterDelivery = autoHandoff.afterDelivery
 		}
+		// dip-bj7pgj: an autonomous/promptless restart runs this SessionStart
+		// hook but never the UserPromptSubmit mail hook, so also surface ordinary
+		// unread mail here so such a wake is not blind to it (including a
+		// priority:1 message that was not sent as an auto-handoff). This block is
+		// READ-ONLY — it never archives, so it can never consume/hide a message —
+		// and it excludes the auto-handoff messages already rendered above so a
+		// beadmail-backed ordinary provider does not double-render them.
+		injection.text += primeUnreadMailInjection(autoHandoffIDs)
 	}
 	return injection
 }
 
+// primeInjectMailContent returns the unread-mail <system-reminder> block that
+// `gc mail check --inject` produces for the current agent, or "" when there is
+// no unread mail or the read fails. It is defense-in-depth for the promptless-
+// wake gap (gastownhall/gascity dip-bj7pgj): an autonomous/promptless restart
+// runs the SessionStart prime hook but NOT the UserPromptSubmit mail hook, so
+// without it such a wake starts blind to unread mail — including priority:1
+// restart handoffs. It is the standalone (no-exclusion) form of the ordinary-
+// mail injection folded into the SessionStart hook context; see
+// primeUnreadMailInjection.
+func primeInjectMailContent() string {
+	return primeUnreadMailInjection(nil)
+}
+
+// primeUnreadMailInjection renders the current agent's ordinary unread mail as a
+// priority-sorted <system-reminder> block (the same shape the check path emits),
+// excluding any message IDs in skip — the auto-handoff messages already rendered
+// by sessionStartAutoHandoffInjection, so a beadmail-backed ordinary provider
+// does not double-render them. It is READ-ONLY: unlike the check path it never
+// archives/mutates mail (so the SessionStart preview cannot consume/hide a
+// message), and any error degrades silently to "" so a prime is never blocked.
+func primeUnreadMailInjection(skip map[string]bool) string {
+	messages := primeUnreadMailMessages()
+	if len(skip) > 0 {
+		kept := make([]mail.Message, 0, len(messages))
+		for _, m := range messages {
+			if !skip[m.ID] {
+				kept = append(kept, m)
+			}
+		}
+		messages = kept
+	}
+	if len(messages) == 0 {
+		return ""
+	}
+	return formatInjectOutput(messages)
+}
+
+// primeUnreadMailMessages returns the current agent's unread ordinary mail via
+// the configured city mail provider, resolving the self-recipient exactly as the
+// check path does (GC_SESSION_ID/GC_ALIAS/GC_AGENT via
+// defaultMailIdentityCandidates). It is read-only and returns nil on any error.
+func primeUnreadMailMessages() []mail.Message {
+	mp, _ := openCityMailProvider(io.Discard, "gc prime")
+	if mp == nil {
+		return nil
+	}
+	messages, err := collectMailMessages(mp.Check, defaultMailIdentityCandidates())
+	if err != nil {
+		return nil
+	}
+	return messages
+}
+
 // sessionStartAutoHandoffInjection returns only durable auto-handoff mail for
-// the current managed session. It intentionally constructs beadmail directly:
-// gc handoff persists this continuation class through beadmail regardless of
-// any separately configured ordinary-mail provider.
-func sessionStartAutoHandoffInjection(stderr io.Writer) primeHookContextInjection {
+// the current managed session, along with the set of auto-handoff message IDs it
+// rendered (so the ordinary-unread-mail block can dedup against them). It
+// intentionally constructs beadmail directly: gc handoff persists this
+// continuation class through beadmail regardless of any separately configured
+// ordinary-mail provider.
+func sessionStartAutoHandoffInjection(stderr io.Writer) (primeHookContextInjection, map[string]bool) {
 	store, cityPath, code := openCityStoreWithPath(io.Discard, "gc prime")
 	if store == nil || code != 0 {
-		return primeHookContextInjection{}
+		return primeHookContextInjection{}, nil
 	}
 	cfg, _ := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 	msgStore := resolveMailMessagesStore(store, cfg, cityPath, nil)
@@ -53,15 +117,19 @@ func sessionStartAutoHandoffInjection(stderr io.Writer) primeHookContextInjectio
 	target, err := resolveMailTargetsWithConfig(cityPath, cfg, sessStore, sessionID)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc prime: resolving auto-handoff mailbox: %v\n", err) //nolint:errcheck // best-effort hook diagnostics
-		return primeHookContextInjection{}
+		return primeHookContextInjection{}, nil
 	}
 	messages, err := mp.CheckAutoHandoffs(target.recipients)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc prime: checking auto-handoff mail: %v\n", err) //nolint:errcheck // best-effort hook diagnostics
-		return primeHookContextInjection{}
+		return primeHookContextInjection{}, nil
 	}
 	if len(messages) == 0 {
-		return primeHookContextInjection{}
+		return primeHookContextInjection{}, nil
+	}
+	ids := make(map[string]bool, len(messages))
+	for _, m := range messages {
+		ids[m.ID] = true
 	}
 	injectedMessages := sortMailByPriority(messages)
 	if len(injectedMessages) > mailInjectMaxMessages {
@@ -72,5 +140,5 @@ func sessionStartAutoHandoffInjection(stderr io.Writer) primeHookContextInjectio
 		afterDelivery: func() {
 			archiveInjectedAutoHandoffMessages(mp, injectedMessages, stderr)
 		},
-	}
+	}, ids
 }


### PR DESCRIPTION
## What

An autonomous/promptless restart runs the SessionStart prime hook but **not** the UserPromptSubmit mail hook, so it starts blind to unread mail (including `priority:1` restart handoffs). This folds unread mail into the SessionStart payload via `primeInjectMailContent`, reusing the check path's provider open, self-recipient resolution (`defaultMailIdentityCandidates`), and `formatInjectOutput` (the same priority sort as the companion priority-sort PR).

## Safety

Defense-in-depth and read-only: it never archives/mutates mail (that stays the check path's job) and degrades silently to `""` on any error or an empty inbox, so a prime is never blocked.

## LOC breakdown

| Category | +/− |
|---|---|
| Production (`cmd_prime.go`) | +30 / 0 |
| Tests (`cmd_prime_test.go`) | +47 / 0 |
| Docs | 0 |
| Generated | 0 |

Bead: `dip-bj7pgj`
