### PR TITLE
fix(docs): correct five core-skill-pack doc defects (fixes #4488)

### DIFF
--- a/internal/bootstrap/packs/core/skills/gc-dashboard/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dashboard/SKILL.md
@@ -10,8 +10,10 @@ convoys, agents, mail, rigs, sessions, and events in real time.
 
 ## Prerequisites
 
-The dashboard is a separate web server. It needs a GC API server to talk to,
-but it no longer has to be launched from inside a city directory.
+The dashboard SPA is embedded in the `gc` binary and served same-origin by a
+GC API server — it is no longer a separate static server. It needs a GC API
+server to talk to, but it no longer has to be launched from inside a city
+directory.
 
 ### Standalone city mode
 
@@ -25,7 +27,9 @@ port = 9443
 ```
 
 Then start the city normally with `gc start`. The API server starts with the
-controller on that port.
+controller on that port. This `[api]` port is the CITY's API server, not a
+dashboard port — the dashboard itself has no port flag (see below); it only
+needs to know which API server to talk to.
 
 ### Supervisor mode
 
@@ -43,12 +47,16 @@ routes requests through `/v0/city/{name}/...`.
 ## Starting the dashboard
 
 ```
-gc dashboard                               # Supervisor-only view from anywhere
-gc dashboard --port 3000                  # Same, custom dashboard port
-gc dashboard serve                        # Explicit subcommand; same discovery
+gc dashboard                               # Resolve + open the dashboard in your browser
+gc dashboard --no-open                    # Print the dashboard URL instead of opening a browser
+gc dashboard serve                        # Print where the web dashboard is served
 gc dashboard --city /path/to/city         # Optional city context for standalone discovery
-gc dashboard --api http://127.0.0.1:8372 # Optional override
+gc dashboard --api http://127.0.0.1:8372 # Optional API server override
 ```
+
+There is no `--port` flag: the dashboard SPA is embedded in the `gc` binary and
+served same-origin by the API server (supervisor or standalone), not by a
+separate server with its own port.
 
 `gc dashboard` auto-discovers the right API server in this order:
 

--- a/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
@@ -153,6 +153,20 @@ don't sling these manually:
 - **mol-digest-generate** — Periodic activity digest mailed to the mayor
 - **mol-shutdown-dance** — Due process for stuck agents (interrogate → execute → epitaph)
 
+### Core pack formulas (other)
+
+These ship in the core pack alongside the formulas above but are not part of
+the built-in work-lifecycle or patrol-loop groups:
+
+- **mol-prompt-synth** — Generates an agent prompt template from a pre-rendered
+  meta-prompt; the formula side of `gc prompt synth --writer-agent <name>`.
+- **mol-review-quorum** — Review quorum scaffold: fans out read-only reviewer
+  lanes (variable-configured providers/models/targets) and routes a synthesis
+  agent over their durable structured outputs.
+- **mol-scoped-work** — Graph-first worktree lifecycle: an explicit work DAG
+  with a durable body scope bead, first-class independently-routable step
+  beads, and continuation metadata for same-session execution.
+
 ## Convoys (grouped work)
 
 ```
@@ -163,9 +177,9 @@ gc convoy list                                        # List active convoys
 gc convoy status <id>                                 # Show convoy progress + metadata
 gc convoy add <id> <bead-ids...>                      # Add beads to convoy
 gc convoy close <id>                                  # Close convoy
-gc convoy check <id>                                  # Check if all beads done
+gc convoy check                                       # MUTATES: scan all open convoys city-wide and auto-close any where all children are resolved
 gc convoy stranded                                    # Find convoys with no progress
-gc convoy autoclose                                   # Close convoys where all beads done
+gc convoy autoclose <bead-id>                         # Auto-close completed convoys for one closed bead (scoped)
 ```
 
 Migration note:
@@ -177,6 +191,6 @@ Migration note:
 gc order list                     # List order rules
 gc order show <name>              # Show order definition
 gc order run <name>               # Manually trigger an order
-gc order check <name>             # Check if trigger conditions are met
+gc order check                    # Evaluate trigger conditions for ALL orders, show which are due
 gc order history <name>           # Show order run history
 ```

--- a/internal/bootstrap/packs/core/skills/gc-mail/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-mail/SKILL.md
@@ -30,9 +30,17 @@ gc mail thread <id>                    # Show full conversation thread
 ## Managing
 
 ```
-gc mail archive <id>                   # Archive a message
+gc mail archive <id>                   # PERMANENTLY DELETES the message bead — not reversible
 gc mail mark-read <id>                 # Mark as read without displaying
 gc mail mark-unread <id>              # Mark as unread
-gc mail delete <id>                    # Delete a message
+gc mail delete <id>                    # Alias for archive — also PERMANENTLY DELETES, despite
+                                        # its own --help text saying it works "by closing the
+                                        # beads": both archive and delete call the store's Delete,
+                                        # not Close, on the message bead. A closed bead stays
+                                        # readable; a deleted one does not.
 gc mail check                          # Check for new mail (used in hooks)
 ```
+
+`archive` and `delete` are the same operation and both are irrecoverable. If
+you want a message gone from view but still readable later, close its bead
+instead (e.g. `gc bd close <id>`) rather than archiving or deleting it.

--- a/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
@@ -47,8 +47,8 @@ gc bd show <id>                           # Show bead details
 ```
 gc bd update <id> --claim                 # Claim a bead (sets assignee + in_progress)
 gc bd update <id> --status in_progress    # Update status
-gc bd update <id> --label <key>=<value>   # Add/update labels
-gc bd update <id> --note "progress..."    # Add a note
+gc bd update <id> --add-label <value>     # Add a label
+gc bd update <id> --append-notes "progress..."  # Append a note (--notes REPLACES the whole field)
 ```
 
 ## Closing work
@@ -61,6 +61,5 @@ gc bd close <id> --reason "done"          # Close with reason
 ## Hooks
 
 ```
-gc hook show <agent>                   # Show what's on an agent's hook
-gc agent claim <agent> <id>            # Put a bead on an agent's hook
+gc hook --claim --json                 # Atomically claim one routed work item for the current session
 ```


### PR DESCRIPTION
## Summary

Implements the five documentation defects reported in #4488, all in
`internal/bootstrap/packs/core/skills/`. One of them is dangerous, so lead
with it:

1. **`gc-dispatch/SKILL.md:166-168`** — `gc convoy check` and
   `gc convoy autoclose` were documented backwards. `check` takes no id and
   is a city-wide mutation (auto-closes every eligible convoy); `autoclose`
   is the scoped one and requires `<bead-id>`. The realistic path to harm
   isn't copying the doc verbatim (the bogus `<id>` errors out) — it's a
   reader "fixing" that error by dropping the argument, which the adjacent
   line explicitly models. Swapped the descriptions and fixed the arg
   placeholders.
2. **`gc-work/SKILL.md:64-65`** — `gc hook show <agent>` and
   `gc agent claim <agent> <id>` are not real subcommands (verified: neither
   `--help` invocation emits a Usage line naming itself). Replaced with the
   real claim path, `gc hook --claim --json`. Also fixed two dead flags in
   the same section (`--label` → `--add-label`, `--note` → `--append-notes`).
3. **Dead/wrong flags** — `gc order check <name>` (takes no name; evaluates
   all orders) and `gc dashboard --port` (no such flag — the dashboard SPA
   is embedded in the binary and served by the API server, not a separate
   server with its own port) corrected in place.
4. **`gc-dashboard/SKILL.md`** — the file contradicted itself: the
   Standalone-mode section presents an `[api] port = 9443` premise as if it
   configures the dashboard, while the Supervisor-mode section says per-city
   `[api]` ports are ignored, and the command reference showed a `--port`
   flag that does not exist. Clarified that `[api]` configures the city's
   API server (not a dashboard port), and updated the command list to match
   `gc dashboard --help` (`--no-open`, `--api`, `serve`).
5. **`gc-mail/SKILL.md:33,36`** — `archive` and `delete` were listed as
   routine operations with no indication they're destructive. Both call the
   message bead store's `Delete`, not `Close` — a closed bead stays
   readable, a deleted one does not — and `delete`'s own `--help` text
   describes it as "closing the beads," which reads as the safer,
   reversible operation to a careful reader who checks `--help` first before
   running something destructive. Added a warning and pointed at
   `gc bd close <id>` as the actual non-destructive path.
6. **`gc-dispatch/SKILL.md`** — three core-pack formulas
   (`mol-prompt-synth`, `mol-review-quorum`, `mol-scoped-work`) ship in the
   same pack as the skill that catalogs formulas, but weren't listed. Added
   minimal one-paragraph descriptions for each, sourced from their own
   formula `description` fields.

## Verification

Every hunk was re-checked against the running binary's `--help` output
immediately before this PR, not just against the issue text:

```
$ go version -m $(which gc)
	mod	github.com/gastownhall/gascity
	build	vcs.revision=730c9b2e0a99e29dc9aefc1ec58b14d8da1b36ef
	build	vcs.modified=false
```

(Same revision the issue was filed against — binary hasn't moved.)

```
$ gc convoy check --help | head -8
Scan open convoys and auto-close any where all child issues are resolved.
...
Usage:
  gc convoy check [flags]

$ gc convoy autoclose --help | head -5
Auto-close completed convoys for a closed bead
Usage:
  gc convoy autoclose <bead-id> [flags]

$ gc hook show --help    # prints `gc hook`'s help (positional agent arg), not its own usage
$ gc agent claim --help  # prints `gc agent`'s help, same tell

$ bd update --help | grep -E 'label|note'
      --add-label strings    Add labels (repeatable)
      --append-notes string  Append to existing notes (with newline separator)
      --notes string         Additional notes

$ gc order check somename
gc: unknown command "somename" for "gc order check"

$ gc dashboard --port
gc: unknown flag: --port

$ gc mail delete --help | head -3
Delete one or more messages by closing the beads. Same effect as archive
but with different user intent.
```

Source confirms the "closing the beads" description is wrong —
`internal/mail/beadmail/beadmail.go`:
```
:507   // Delete is an alias for Archive.
:508   func (p *Provider) Delete(id string) error { ... return p.Archive(id) ... }
:345   func (p *Provider) Archive(id string) error {
:357       if err := p.store.Delete(id); err != nil {   // both branches
:365       if err := p.store.Delete(id); err != nil {   // call store.Delete
:825   // ... Provider.Archive/Provider.Delete mean eager delete
```

And confirmed the three undocumented formulas ship in the core pack:
```
$ ls internal/bootstrap/packs/core/formulas/ | grep -E 'mol-prompt-synth|mol-review-quorum|mol-scoped-work'
mol-prompt-synth.toml
mol-review-quorum.toml
mol-scoped-work.toml
```

This is a docs-only change (no Go source touched), so no build/test suite
applies beyond the manual `--help`/source verification above. Happy to
rework the shape of any fix per maintainer direction — this PR is a concrete
proposal per #4488, not a final word on wording.

Fixes gastownhall/gascity#4488.
