### PR TITLE
fix(orders): expose per-tick order dispatch cap as orders.max_dispatches_per_tick

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -440,6 +440,11 @@ func newMemoryOrderDispatcher(routes *storageRoutes, aa []orders.Order, cityPath
 		ep = p
 	}
 
+	maxDispatchesPerTick := defaultMaxOrderDispatchesPerTick
+	if cfg.Orders.MaxDispatchesPerTick != nil && *cfg.Orders.MaxDispatchesPerTick > 0 {
+		maxDispatchesPerTick = *cfg.Orders.MaxDispatchesPerTick
+	}
+
 	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
 	return &memoryOrderDispatcher{
 		aa: aa,
@@ -456,7 +461,7 @@ func newMemoryOrderDispatcher(routes *storageRoutes, aa []orders.Order, cityPath
 		rec:                  rec,
 		stderr:               lockedStderr(stderr),
 		maxTimeout:           cfg.Orders.MaxTimeoutDuration(),
-		maxDispatchesPerTick: defaultMaxOrderDispatchesPerTick,
+		maxDispatchesPerTick: maxDispatchesPerTick,
 		cfg:                  cfg,
 		cityName:             loadedCityName(cfg, cityPath),
 		cityPath:             cityPath,

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -10320,3 +10320,55 @@ func TestCountClosedOrderTrackingRetentionEligible(t *testing.T) {
 		}
 	})
 }
+
+func TestOrderDispatchMaxDispatchesPerTickConfig(t *testing.T) {
+	aa := []orders.Order{{
+		Name:         "cap-order",
+		Trigger:      "cooldown",
+		Interval:     "1m",
+		Formula:      "test-formula",
+		Pool:         "worker",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+
+	// Unset (zero) preserves the historical default of 4.
+	cfgDefault := &config.City{}
+	adDefault := buildOrderDispatcherFromOrderSet(nil, t.TempDir(), cfgDefault, aa, events.Discard, &bytes.Buffer{})
+	mDefault, ok := adDefault.(*memoryOrderDispatcher)
+	if !ok {
+		t.Fatalf("expected *memoryOrderDispatcher, got %T", adDefault)
+	}
+	if mDefault.maxDispatchesPerTick != defaultMaxOrderDispatchesPerTick {
+		t.Errorf("default maxDispatchesPerTick = %d, want %d", mDefault.maxDispatchesPerTick, defaultMaxOrderDispatchesPerTick)
+	}
+
+	// Configured value of 1 overrides the default.
+	one := 1
+	cfgOne := &config.City{}
+	cfgOne.Orders.MaxDispatchesPerTick = &one
+	adOne := buildOrderDispatcherFromOrderSet(nil, t.TempDir(), cfgOne, aa, events.Discard, &bytes.Buffer{})
+	mOne, ok := adOne.(*memoryOrderDispatcher)
+	if !ok {
+		t.Fatalf("expected *memoryOrderDispatcher, got %T", adOne)
+	}
+	if mOne.maxDispatchesPerTick != 1 {
+		t.Errorf("configured maxDispatchesPerTick = %d, want 1", mOne.maxDispatchesPerTick)
+	}
+
+	// Zero or negative values fall back to the default rather than passing
+	// through: inside the dispatch loop a cap <= 0 means UNCAPPED, so honoring
+	// them would silently disable the cap entirely.
+	for _, bad := range []int{0, -3} {
+		v := bad
+		cfgBad := &config.City{}
+		cfgBad.Orders.MaxDispatchesPerTick = &v
+		adBad := buildOrderDispatcherFromOrderSet(nil, t.TempDir(), cfgBad, aa, events.Discard, &bytes.Buffer{})
+		mBad, ok := adBad.(*memoryOrderDispatcher)
+		if !ok {
+			t.Fatalf("expected *memoryOrderDispatcher, got %T", adBad)
+		}
+		if mBad.maxDispatchesPerTick != defaultMaxOrderDispatchesPerTick {
+			t.Errorf("maxDispatchesPerTick with configured %d = %d, want default %d", bad, mBad.maxDispatchesPerTick, defaultMaxOrderDispatchesPerTick)
+		}
+	}
+}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -597,6 +597,7 @@ OrdersConfig holds order settings for orders discovered from flat TOML files (on
 |-------|------|----------|---------|-------------|
 | `skip` | []string |  |  | Skip lists order names to exclude from scanning. |
 | `max_timeout` | string |  |  | MaxTimeout is an operator hard cap on the per-order dispatch timeout: no order's dispatched exec/formula runs longer than this. Go duration string (e.g., "60s"). Empty means uncapped (no override). This bounds the dispatch timeout only; a condition trigger's check_timeout is a separate probe deadline and is not capped here. |
+| `max_dispatches_per_tick` | integer |  |  | MaxDispatchesPerTick caps how many orders the supervisor dispatches per tick. Unset keeps the built-in default of 4; set to 1 to drain overdue cooldown orders one-per-tick at cold start instead of firing several concurrent goroutines at once. |
 | `overrides` | []OrderOverride |  |  | Overrides apply per-order field overrides after scanning. Each override targets an order by name and optionally by rig. |
 
 ## PackDefaults

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -2099,6 +2099,10 @@
           "type": "string",
           "description": "MaxTimeout is an operator hard cap on the per-order dispatch timeout: no\norder's dispatched exec/formula runs longer than this. Go duration string\n(e.g., \"60s\"). Empty means uncapped (no override). This bounds the dispatch\ntimeout only; a condition trigger's check_timeout is a separate probe\ndeadline and is not capped here."
         },
+        "max_dispatches_per_tick": {
+          "type": "integer",
+          "description": "MaxDispatchesPerTick caps how many orders the supervisor dispatches\nper tick. Unset keeps the built-in default of 4; set to 1 to drain\noverdue cooldown orders one-per-tick at cold start instead of firing\nseveral concurrent goroutines at once."
+        },
         "overrides": {
           "items": {
             "$ref": "#/$defs/OrderOverride"

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -2099,6 +2099,10 @@
           "type": "string",
           "description": "MaxTimeout is an operator hard cap on the per-order dispatch timeout: no\norder's dispatched exec/formula runs longer than this. Go duration string\n(e.g., \"60s\"). Empty means uncapped (no override). This bounds the dispatch\ntimeout only; a condition trigger's check_timeout is a separate probe\ndeadline and is not capped here."
         },
+        "max_dispatches_per_tick": {
+          "type": "integer",
+          "description": "MaxDispatchesPerTick caps how many orders the supervisor dispatches\nper tick. Unset keeps the built-in default of 4; set to 1 to drain\noverdue cooldown orders one-per-tick at cold start instead of firing\nseveral concurrent goroutines at once."
+        },
         "overrides": {
           "items": {
             "$ref": "#/$defs/OrderOverride"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2088,6 +2088,16 @@ type OrdersConfig struct {
 	// timeout only; a condition trigger's check_timeout is a separate probe
 	// deadline and is not capped here.
 	MaxTimeout string `toml:"max_timeout,omitempty"`
+
+	// *int rather than int so an unset value stays out of marshaled config:
+	// BurntSushi's omitempty does not drop a zero int, so a plain int would
+	// emit max_dispatches_per_tick = 0 into every marshaled city.toml.
+
+	// MaxDispatchesPerTick caps how many orders the supervisor dispatches
+	// per tick. Unset keeps the built-in default of 4; set to 1 to drain
+	// overdue cooldown orders one-per-tick at cold start instead of firing
+	// several concurrent goroutines at once.
+	MaxDispatchesPerTick *int `toml:"max_dispatches_per_tick,omitempty"`
 	// Overrides apply per-order field overrides after scanning.
 	// Each override targets an order by name and optionally by rig.
 	Overrides []OrderOverride `toml:"overrides,omitempty"`


### PR DESCRIPTION
## Summary

At city cold start (or rig resume), every overdue cooldown order is eligible at once and the supervisor dispatches up to `defaultMaxOrderDispatchesPerTick = 4` of them concurrently — each a forking goroutine chain (`gc`/`bd` execs). On a small host this is a thundering herd: on a 6-core/8GB Mac mini we watched load1 climb 4 → 49 within ~3 minutes of a rig resume, driven by short-lived fork fan-out rather than CPU saturation. The cap that governs this is hardcoded, so an operator has no way to soften cold start. Related to the tick-starvation problems in #2604 (order dispatch dominating the tick).

## Root cause

`newMemoryOrderDispatcher` (cmd/gc/order_dispatch.go) sets `maxDispatchesPerTick: defaultMaxOrderDispatchesPerTick` unconditionally — the per-tick dispatch cap is a compile-time constant with no config surface.

## Fix

Add an optional `orders.max_dispatches_per_tick` field to `OrdersConfig` and honor it in `newMemoryOrderDispatcher`:

```toml
[orders]
max_dispatches_per_tick = 1
```

- Unset (or ≤ 0) keeps the built-in default of 4 — behavior is unchanged for existing configs.
- The field is `*int` rather than `int`: BurntSushi/toml's `omitempty` does not drop a zero int, so a plain `int` would emit `max_dispatches_per_tick = 0` into every marshalled city.toml (and break `TestMarshalDefaultCityFormat`). A pointer keeps unset values out of marshalled config and matches the existing pointer-for-optional pattern (`OrderOverride`) in the same struct.
- Reference docs (`docs/reference/config.md`, city schema) regenerated via `cmd/genschema`.

## Tests

- `TestOrderDispatchMaxDispatchesPerTickConfig` — unset config preserves the historical default of 4; a configured value of 1 overrides it; zero/negative values fall back to the default (inside the dispatch loop a cap <= 0 means uncapped, so passing them through would silently disable the cap).
- `go test ./internal/config/` (1839 passed, incl. `TestMarshalDefaultCityFormat` proving unset stays out of marshalled config) and `go test ./cmd/gc/ -run TestOrderDispatch` (91 passed); `go vet` clean.

## Validation

Dogfooded on the city that hit the herd: running a patched build with `max_dispatches_per_tick = 1` on the supervisor host. Overdue cooldown orders drain one per tick at cold start instead of four concurrent fork chains, and the supervisor stayed healthy through a subsequent load event on the same box (a separate rig-level bringup storm — session respawn, not order dispatch — which this cap correctly does not paper over). No consumers are mutated: the change only parameterizes an existing in-memory cap; nothing persisted changes shape.

Refs #2604

🤖 Generated with [Claude Code](https://claude.com/claude-code)
