### PR TITLE
test: make runmap fixtures permission-stable

### DIFF
--- a/cmd/gc/cmd_hook_claim_runmap_dir_test.go
+++ b/cmd/gc/cmd_hook_claim_runmap_dir_test.go
@@ -37,7 +37,7 @@ func proxyReaderPath(dir, affinity string) string {
 // the exact cross-process break attempt-2's blocker flagged when the writer
 // diverged onto a hashed filename.
 func TestWriteRunMapMatchesProxyReaderContract(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	const affinity = "gascity/gc.implementation-worker-1"
 	if err := writeRunMap("run-42", "bead-42", affinity); err != nil {
@@ -64,7 +64,7 @@ func TestWriteRunMapMatchesProxyReaderContract(t *testing.T) {
 // os.Rename fails for it deterministically and uid-independently (not even root
 // renames a file over a directory).
 func TestWriteRunMapErrorsWhenAllPublishesFail(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	if err := os.Mkdir(filepath.Join(dir, runMapFileName("sess")), 0o755); err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func TestWriteRunMapErrorsWhenDirUnwritable(t *testing.T) {
 // best-effort (nil); it is not promoted to an error. One key's target is blocked
 // by a directory (rename fails); the other publishes normally.
 func TestWriteRunMapBestEffortOnPartialFailure(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	if err := os.Mkdir(filepath.Join(dir, runMapFileName("blocked")), 0o755); err != nil {
 		t.Fatal(err)
@@ -144,7 +144,7 @@ func TestWriteRunMapSelfProvisionsOwnerOnlyDir(t *testing.T) {
 // file is published, instead of silently trusting a dir any local user can
 // clobber.
 func TestWriteRunMapRefusesGroupOtherWritableDir(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	unsafe := filepath.Join(dir, "unsafe")
 	if err := os.Mkdir(unsafe, 0o755); err != nil {
 		t.Fatal(err)
@@ -169,7 +169,7 @@ func TestWriteRunMapRefusesGroupOtherWritableDir(t *testing.T) {
 // still honored: a sticky dir owned by this user (the shape a root/self
 // provisioner installs) is trusted and published into.
 func TestWriteRunMapAllowsStickyOwnedDir(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	handoff := filepath.Join(dir, "handoff")
 	if err := os.Mkdir(handoff, 0o755); err != nil {
 		t.Fatal(err)
@@ -194,7 +194,7 @@ func TestWriteRunMapAllowsStickyOwnedDir(t *testing.T) {
 // (or reap in) a shared group/other-writable dir, where an in-process reap is
 // both a no-op and a claim-latency amplifier (CWE-400).
 func TestPruneRunMapSkipsUnsafeDir(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	shared := filepath.Join(dir, "shared")
 	if err := os.Mkdir(shared, 0o755); err != nil {
 		t.Fatal(err)
@@ -224,7 +224,7 @@ func TestPruneRunMapSkipsUnsafeDir(t *testing.T) {
 // size: with more stale files than the budget, one prune leaves at least the
 // overflow behind.
 func TestPruneRunMapBoundedByBudget(t *testing.T) {
-	dir := t.TempDir() // 0o700 → prunable
+	dir := privateRunMapTestDir(t)
 	total := runMapPruneScanBudget + 10
 	old := time.Now().Add(-100 * time.Hour)
 	for i := 0; i < total; i++ {
@@ -271,7 +271,7 @@ func TestDefaultRunMapDirMatchesProxy(t *testing.T) {
 // trust an attacker-editable run_id. The writer must surface an error and neither
 // follow the link (rewriting the attacker's file through it) nor report success.
 func TestWriteRunMapRefusesSymlinkTarget(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	const key = "victim-session"
 	forged := filepath.Join(dir, "attacker-forged.json")
@@ -302,7 +302,7 @@ func TestWriteRunMapRefusesSymlinkTarget(t *testing.T) {
 // publishes cleanly, previously returned a silent nil (published>0) and hid the
 // forgery. The squat must now surface an error even though the clean key lands.
 func TestWriteRunMapSquatForcesErrorDespiteOtherPublish(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	const squatted = "worker-1"    // the proxy-read session name, pre-squatted
 	const clean = "worker-1-actor" // another key that publishes normally
@@ -325,7 +325,7 @@ func TestWriteRunMapSquatForcesErrorDespiteOtherPublish(t *testing.T) {
 // normal refresh: a pre-existing regular file this user owns (a prior claim's
 // publish) is overwritten with the new run id, not refused as a squat.
 func TestWriteRunMapRefreshesOwnRegularFile(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	const key = "sess"
 	if err := os.WriteFile(filepath.Join(dir, runMapFileName(key)), []byte(`{"run_id":"old"}`), 0o644); err != nil {

--- a/cmd/gc/cmd_hook_claim_runmap_test.go
+++ b/cmd/gc/cmd_hook_claim_runmap_test.go
@@ -8,6 +8,15 @@ import (
 	"time"
 )
 
+func privateRunMapTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("make run-map test dir owner-only: %v", err)
+	}
+	return dir
+}
+
 func TestSanitizeRunMapKey(t *testing.T) {
 	cases := map[string]string{
 		"gc__review-synthesizer-mc-1kkqd": "gc__review-synthesizer-mc-1kkqd",
@@ -24,7 +33,7 @@ func TestSanitizeRunMapKey(t *testing.T) {
 }
 
 func TestWriteRunMapWritesPerKeyAtomically(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 
 	// duplicate key ("sess/name" twice), an empty key, and a distinct key
@@ -68,7 +77,7 @@ func TestWriteRunMapWritesPerKeyAtomically(t *testing.T) {
 }
 
 func TestWriteRunMapEmptyRunIDNoOp(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	if err := writeRunMap("", "bead-456", "sess"); err != nil {
 		t.Fatalf("writeRunMap: %v", err)
@@ -80,7 +89,7 @@ func TestWriteRunMapEmptyRunIDNoOp(t *testing.T) {
 }
 
 func TestWriteRunMapHonorsDirOverride(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	sub := filepath.Join(dir, "runmap")
 	t.Setenv("GC_RUNMAP_DIR", sub)
 	if err := writeRunMap("run-9", "bead-9", "only"); err != nil {
@@ -108,7 +117,7 @@ func TestRunMapTTL(t *testing.T) {
 }
 
 func TestPruneRunMapReapsStaleKeepsFresh(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	fresh := filepath.Join(dir, "fresh.json")
 	stale := filepath.Join(dir, "stale.json")
 	notJSON := filepath.Join(dir, "keep.txt") // non-.json is never touched
@@ -140,7 +149,7 @@ func TestPruneRunMapReapsStaleKeepsFresh(t *testing.T) {
 }
 
 func TestWriteRunMapPrunesStaleOnWrite(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	t.Setenv("GC_RUNMAP_DIR", dir)
 	t.Setenv("GC_RUNMAP_TTL", "1h")
 	stale := filepath.Join(dir, "dead-session.json")
@@ -168,7 +177,7 @@ func TestWriteRunMapPrunesStaleOnWrite(t *testing.T) {
 // a dead-write orphan and is reaped; a fresh .tmp (a possible in-flight write) is
 // left untouched.
 func TestPruneRunMapReapsStaleTmpOrphans(t *testing.T) {
-	dir := t.TempDir() // 0o700 → prunable
+	dir := privateRunMapTestDir(t)
 	staleTmp := filepath.Join(dir, "sess.json.1234.tmp")
 	freshTmp := filepath.Join(dir, "live.json.5678.tmp")
 	for _, f := range []string{staleTmp, freshTmp} {
@@ -199,7 +208,7 @@ func TestPruneRunMapReapsStaleTmpOrphans(t *testing.T) {
 // publishes. Before the fix, prune matched any stale ".json"/".tmp" by mtime alone
 // and silently deleted both foreign files.
 func TestWriteRunMapKeepsForeignFilesInExplicitDir(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 
 	foreignJSON := filepath.Join(dir, "config.json") // unrelated app config
 	foreignTmp := filepath.Join(dir, "cache.tmp")    // unrelated temp file
@@ -287,7 +296,7 @@ func TestRunMapTempOrphanName(t *testing.T) {
 //   - the published entry carries only run_id/bead_id/ts — no nonce, signature,
 //     token, or any other integrity/authentication field a consumer could verify.
 func TestRunMapEntryIsUnauthenticatedBestEffortTelemetry(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateRunMapTestDir(t)
 	const key = "sess"
 
 	// A same-uid regular file at the predictable name simulates a co-uid cell's


### PR DESCRIPTION
## Summary

- make runmap test directories explicitly owner-only
- remove dependence on the runner umask when exercising publish and prune safety gates
- keep production runmap permission checks unchanged

## Why

Go testing.TempDir creates numbered child directories with mode 0777 masked by the process umask. On RC runners using umask 002, fixtures became 0775 and were correctly rejected by the production CWE-732 guard, causing unrelated test failures.

## Verification

- go test ./cmd/gc -run RunMap -count=1
- .githooks/pre-commit
- pre-push make test-fast-parallel: all 8 jobs passed
- go vet ./...

Tracking: ga-e0yx5f9

This PR contains test-only RC prework. It does not perform a release.