### PR TITLE
fix(ci): prevent stale golangci-lint cache inheritance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,9 +223,13 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/golangci-lint
+          # Exact-key-only restore (no restore-keys fallback): a broad prefix
+          # let a partial/incompatible cache (missing testing.T.Fatal no-return
+          # facts) be inherited across differing keys and re-saved forward,
+          # repeatedly re-poisoning the cache with a SA5011 false-positive
+          # storm (ga-35qn7i, ga-v7x9vk, ga-l14mnf, ga-ndx34y). A miss now
+          # forces a fully fresh, never-poisoned recompute.
           key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-${{ hashFiles('go.sum', '.golangci.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-
       - name: Lint affected packages
         if: steps.static-scope.outputs.scope == 'changed'
         env:

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -152,9 +152,13 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/golangci-lint
+          # Exact-key-only restore (no restore-keys fallback): a broad prefix
+          # let a partial/incompatible cache (missing testing.T.Fatal no-return
+          # facts) be inherited across differing keys and re-saved forward,
+          # repeatedly re-poisoning the cache with a SA5011 false-positive
+          # storm (ga-35qn7i, ga-v7x9vk, ga-l14mnf, ga-ndx34y). A miss now
+          # forces a fully fresh, never-poisoned recompute.
           key: ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-${{ hashFiles('go.sum', '.golangci.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-golangci-lint-${{ steps.glint-version.outputs.version }}-${{ steps.glint-version.outputs.goversion }}-
       - name: Lint
         env:
           GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION := 2.9.0
+GOLANGCI_LINT_VERSION := 2.12.0
 BUILDX_VERSION := 0.21.2
 
 # Detect OS and arch for binary download.

--- a/internal/api/structured_leakage_test.go
+++ b/internal/api/structured_leakage_test.go
@@ -235,7 +235,7 @@ func TestStructuredWireTypesHaveNoMapFields(t *testing.T) {
 // firstMapField returns the dotted path to the first map-typed field reachable
 // from t, or "" if none exists.
 func firstMapField(t reflect.Type, seen map[reflect.Type]struct{}, path string) string {
-	for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
+	for t.Kind() == reflect.Pointer || t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 		t = t.Elem()
 	}
 	if t.Kind() == reflect.Map {

--- a/internal/config/field_sync_test.go
+++ b/internal/config/field_sync_test.go
@@ -562,7 +562,7 @@ func TestAgentCloneIsDeep(t *testing.T) {
 			m := reflect.MakeMapWithSize(f.Type(), 1)
 			m.SetMapIndex(reflect.New(f.Type().Key()).Elem(), reflect.New(f.Type().Elem()).Elem())
 			f.Set(m)
-		case reflect.Ptr:
+		case reflect.Pointer:
 			f.Set(reflect.New(f.Type().Elem()))
 		}
 	}
@@ -578,7 +578,7 @@ func TestAgentCloneIsDeep(t *testing.T) {
 		name := tp.Field(i).Name
 		cf := cv.Field(i)
 		switch f.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr:
+		case reflect.Slice, reflect.Map, reflect.Pointer:
 			if cf.IsNil() {
 				t.Errorf("Agent.Clone left reference field %q nil — add a deep copy in Clone()", name)
 				continue

--- a/internal/worker/structured_wire.go
+++ b/internal/worker/structured_wire.go
@@ -77,7 +77,7 @@ func NeutralWireKeys(t reflect.Type) map[string]struct{} {
 }
 
 func collectNeutralWireKeys(t reflect.Type, out map[string]struct{}, seen map[reflect.Type]struct{}) {
-	for t.Kind() == reflect.Ptr || t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
+	for t.Kind() == reflect.Pointer || t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {

--- a/internal/worker/workertest/structured_conformance.go
+++ b/internal/worker/workertest/structured_conformance.go
@@ -54,7 +54,7 @@ func StructuredNoNativeLeakResult(profile ProfileID, history *worker.HistorySnap
 }
 
 func scanStructuredCarrier(profile ProfileID, carrier any, allowed map[string]struct{}) Result {
-	if value := reflect.ValueOf(carrier); !value.IsValid() || (value.Kind() == reflect.Ptr && value.IsNil()) {
+	if value := reflect.ValueOf(carrier); !value.IsValid() || (value.Kind() == reflect.Pointer && value.IsNil()) {
 		return Pass(profile, RequirementStructuredNoNativeLeak, "no carrier")
 	}
 	wire, err := json.Marshal(carrier)

--- a/release-gates/sa5011-lint-cache-poisoning-gate.md
+++ b/release-gates/sa5011-lint-cache-poisoning-gate.md
@@ -1,0 +1,78 @@
+# Release Gate: SA5011 lint-cache poisoning fix
+
+Bead: `ga-i2s8h4`
+Source review bead: `ga-pmswi7`
+Candidate commit: `0e64d5db79c405b02499a209cc7f99fe48e544ca`
+Planned deploy branch: `deploy/ga-i2s8h4-gate`
+Base: `origin/main` at `146abca78d1446d1ab227f258cb213ac12d8b133`
+Gate evaluated: `2026-07-21T01:49:08Z`
+Gate refreshed: `2026-07-21T02:21:07Z`
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate
+uses the deployer release criteria from the role prompt, plus the bead's
+assignment-specific build-and-smoke requirement.
+
+## Result
+
+PASS.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git fetch origin main` succeeded. `origin/main` is `146abca78d1446d1ab227f258cb213ac12d8b133`. `git merge-tree --write-tree origin/main 0e64d5db79c405b02499a209cc7f99fe48e544ca` exited 0 and returned tree `5b3fe01ef02d62c38207e502b72f5d748265e190`; refreshed `git merge-tree --write-tree origin/main HEAD` on the deploy branch exited 0 and returned tree `574848f6a24e2f28c7cecca747983477661e0fbc`. |
+| 1 | Review PASS present | PASS | Review bead `ga-pmswi7` is closed with `REVIEW VERDICT: PASS` for commit `0e64d5db79c405b02499a209cc7f99fe48e544ca`, with no blocking findings. |
+| 2 | Acceptance criteria met | PASS | `Makefile` pins `GOLANGCI_LINT_VERSION := 2.12.0`; both lint workflow files derive the version from `Makefile`. `rg '^[[:space:]]*restore-keys:' .github/workflows/ci.yml .github/workflows/mac-regression.yml` returned no YAML keys. `git grep 'reflect\.Ptr' -- '*.go'` returned no matches. `make test-ci-policy` passed, including the Go cipolicy hash check. A full `GOLANGCI_LINT_CACHE=$(mktemp -d) make lint-full` run passed with `0 issues`, proving a fresh cache is clean under 2.12.0. |
+| 3 | Tests pass | PASS | `make build` passed, producing `bin/gc` from the deploy branch. Built binary smoke `bin/gc version` exited 0 and printed `dev`. `go vet ./...` passed. `make test-integration-huma` passed twice (`54.581s`, refreshed `58.545s`). `make test-ci-policy` passed: Python workflow-policy suites, Go `scripts/cipolicy`, and static-scope policy tests all green. Fresh-cache `make lint-full` passed with `0 issues`. `go test ./internal/api/... ./internal/config/... ./internal/worker/...` passed. |
+| 4 | No high-severity review findings open | PASS | Review bead `ga-pmswi7` records PASS and "No blocking findings"; no HIGH or actionable finding is open in the review notes. |
+| 5 | Final branch is clean | PASS | Deploy worktree was clean before the gate rerun. `git diff --check origin/main...0e64d5db79c405b02499a209cc7f99fe48e544ca` passed before updating this gate file; the deploy branch contains only the reviewed commit plus this committed gate checklist. |
+| 7 | Single feature theme | PASS | Single commit with one coherent CI/lint theme: golangci-lint version, exact-key-only lint cache restore, CI execution policy hash, and mechanical `reflect.Ptr` to `reflect.Pointer` fallout required by the lint version bump. |
+
+## Diff Scope
+
+```text
+.github/workflows/ci.yml                             | 8 ++++++--
+.github/workflows/mac-regression.yml                 | 8 ++++++--
+Makefile                                             | 2 +-
+internal/api/structured_leakage_test.go              | 2 +-
+internal/config/field_sync_test.go                   | 4 ++--
+internal/worker/structured_wire.go                   | 2 +-
+internal/worker/workertest/structured_conformance.go | 2 +-
+scripts/cipolicy/policy.go                           | 2 +-
+8 files changed, 19 insertions(+), 11 deletions(-)
+```
+
+## Test Log Summary
+
+```text
+make build
+go build ... -o bin/gc ./cmd/gc
+PASS
+
+bin/gc version
+dev
+PASS
+
+go vet ./...
+PASS
+
+make test-integration-huma
+ok  	github.com/gastownhall/gascity/test/integration	54.581s
+
+make test-ci-policy
+Python test_runner_policy: 5 tests OK
+Python test_ci_suite_coverage: 15 tests OK
+go test ./scripts/cipolicy: ok
+go test ./scripts static-scope policy subset: ok
+
+GOLANGCI_LINT_CACHE=$(mktemp -d) make lint-full
+0 issues.
+PASS
+
+go test ./internal/api/... ./internal/config/... ./internal/worker/...
+ok  	github.com/gastownhall/gascity/internal/api	70.102s
+ok  	github.com/gastownhall/gascity/internal/config	1.783s
+ok  	github.com/gastownhall/gascity/internal/worker	23.620s
+ok  	github.com/gastownhall/gascity/internal/worker/workertest	11.977s
+PASS
+```

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -20,7 +20,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "5f808af12283745f8a84116039b5ece82aa963c10b51cda9d955a1929feb5705"
+	expectedCIExecutionHash      = "5acb65e22a4b8fce662f0ed97d6dc4ef406293b262c4c3ed474dbbd499bbfdde"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "80575ca368f28ba9f8b14bf72ce5767a7877ffe4dcadc136854ab4b0b5f1377a"
 	expectedSetupActionHash      = "b7864038195cd054aee7fccfa903cab335b375bcab1a35239c17c5da7d32c07e"


### PR DESCRIPTION
## What this changes

This upgrades the repository's golangci-lint gate to 2.12.0 and changes the CI lint cache restore behavior so misses use an exact cache key only. A stale or partial cache can no longer be inherited through a broad restore prefix and then re-propagated into later PR lint runs.

The change also updates the mac regression lint cache in the same way, refreshes the CI execution-policy hash, and replaces the deprecated `reflect.Ptr` alias with `reflect.Pointer` in the spots surfaced by the newer linter. The alias change is mechanical; it does not change runtime behavior.

## Review notes

- `.github/workflows/ci.yml` and `.github/workflows/mac-regression.yml` intentionally have no `restore-keys` fallback for the golangci-lint cache.
- `Makefile` remains the single source for `GOLANGCI_LINT_VERSION`, now set to `2.12.0`.
- `scripts/cipolicy/policy.go` changes because the CI workflow execution shape changed; `make test-ci-policy` verifies that hash.
- The Go source changes are limited to `reflect.Ptr` to `reflect.Pointer` cleanup required for the lint version bump.

## Test plan

- [x] `make build`
- [x] `make test-integration-huma`
- [x] `make test-ci-policy`
- [x] `go vet ./...`
- [x] `GOLANGCI_LINT_CACHE=$(mktemp -d) make lint-full`
- [x] `go test ./internal/api/... ./internal/config/... ./internal/worker/...`
- [x] Pre-push fast gate: `./scripts/test-local-parallel fast`
- [x] Release gate: [`release-gates/sa5011-lint-cache-poisoning-gate.md`](release-gates/sa5011-lint-cache-poisoning-gate.md)