### PR TITLE
perf(cli): skip builtin-pack refresh in registry rig-binding scan (sys-s3pd)

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -900,7 +900,9 @@ func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool, error) {
 }
 
 func localCityRigBindings(cityPath string) ([]registeredRigBinding, error) {
-	cfg, err := loadCityConfig(cityPath, io.Discard)
+	// Rig binding enumeration reads only cfg.Rigs; skip the builtin-pack
+	// refresh (see registeredRigBindings, sys-s3pd).
+	cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 	if err != nil {
 		if _, ok := missingRootCityTOML(err, cityPath); ok {
 			return nil, nil
@@ -987,7 +989,10 @@ func rigFromCwd(cityPath string) string {
 
 // rigFromCwdDir matches cwd against registered rigs in a city's config.
 func rigFromCwdDir(cityPath, cwd string) string {
-	cfg, err := loadCityConfig(cityPath, io.Discard)
+	// Rig resolution only reads cfg.Rigs; it never needs builtin packs
+	// materialized on disk. Skip the ~400ms per-city builtin-pack refresh
+	// (see registeredRigBindings for the full rationale, sys-s3pd).
+	cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 	if err != nil {
 		return ""
 	}
@@ -1069,7 +1074,17 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 	var matched []registeredRigBinding
 	var loadErrors []string
 	for _, c := range cities {
-		cfg, err := loadCityConfig(c.Path, io.Discard)
+		// Enumerating rig bindings only reads cfg.Rigs (via
+		// siteBoundRigBindings). It does NOT need each registered city's
+		// builtin packs materialized on disk — that runtime-asset prep
+		// (ensureBuiltinPacksForConfigLoad) is ~400ms per city and is the
+		// dominant cost of resolveContext's registry scan on every
+		// city-needing gc invocation (sys-s3pd, follow-up to sys-ro2a).
+		// The command that actually resolves to and operates a city still
+		// performs its own full loadCityConfig (with refresh) via its RunE,
+		// so skipping it here never skips it where it is needed. LoadWithIncludes
+		// is retained, so fragment/include-declared rigs are still enumerated.
+		cfg, err := loadCityConfigWithoutBuiltinPackRefresh(c.Path, io.Discard)
 		if err != nil {
 			// Tolerate stale registry entries whose city.toml has been
 			// deleted out from under the registry, but keep missing includes

--- a/cmd/gc/resolve_context_no_builtin_refresh_test.go
+++ b/cmd/gc/resolve_context_no_builtin_refresh_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRigBindingScanSkipsBuiltinPackRefresh guards the sys-s3pd fix: enumerating
+// registered rig bindings (the registry scan on resolveContext's city-needing
+// hot path) must read cfg.Rigs WITHOUT materializing each city's builtin packs.
+//
+// The builtin-pack refresh (ensureBuiltinPacksForConfigLoad → EnsureBuiltinRuntimeAssets)
+// is ~400ms per city and is pure runtime-asset prep for *operating* a city — it
+// has no bearing on which rigs a city declares. A default-provider city uses the
+// bd store contract, so a full loadCityConfig-with-refresh would write the
+// gc-beads-bd shim. Asserting that shim is absent after a name-based rig-binding
+// scan proves the scan took the cheaper no-refresh path.
+func TestRigBindingScanSkipsBuiltinPackRefresh(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "epsilon")
+	rigDir := filepath.Join(t.TempDir(), "svc")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registerRigBindingForResolution(t, gcHome, cityPath, "epsilon", "svc", rigDir)
+
+	// The shim marker is only meaningful when the city uses the bd store
+	// contract (the default), since only then does the refresh write it.
+	if !cityUsesBdStoreContract(cityPath) {
+		t.Skip("test city does not use the bd store contract; shim marker unavailable")
+	}
+	shim := gcBeadsBdScriptPath(cityPath)
+	if _, err := os.Stat(shim); err == nil {
+		t.Fatalf("precondition failed: shim %s already present before scan", shim)
+	}
+
+	// Resolve the rig binding by name — this is the registry-scan path
+	// (registeredRigBindings) that resolveContext/resolveRigToContext use.
+	matches, _, err := registeredRigBindingsByName("svc", false)
+	if err != nil {
+		t.Fatalf("registeredRigBindingsByName error: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Rig.Name != "svc" {
+		t.Fatalf("rig binding not resolved correctly: %#v", matches)
+	}
+
+	// The scan must NOT have triggered builtin-pack materialization.
+	if _, err := os.Stat(shim); err == nil {
+		t.Fatalf("registry rig-binding scan materialized builtin-pack shim %s; "+
+			"the scan must not refresh builtin packs (sys-s3pd)", shim)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to the cold-start work in the `resolveContext` chain. Enumerating registered rig bindings — the registry scan on `resolveContext`'s city-needing hot path (`resolveCity`/`resolveCommandCity`, `resolveRigToContext`, `lookupRigFromCwd`) — loaded **every** candidate city's config with the full builtin-pack refresh (`ensureBuiltinPacksForConfigLoad` → `EnsureBuiltinRuntimeAssets`) purely to read `cfg.Rigs`. That refresh is ~400 ms per city and dominates the scan; it is runtime-asset preparation for *operating* a city and has no bearing on which rigs a city declares.

## Root cause (measured, not inferred)

Instrumented timing of the real gc-town city load (`/Users/jonesy/Developer/gc`, the single registered city on the box):

| Stage | avg |
|---|---|
| `loadCityConfig` FULL (cold) | **588 ms** |
| `ensureBuiltinPacksForConfigLoad` | **394 ms** ← dominates |
| `LoadWithIncludes` only | 37 ms |
| `loadCityConfig` **without builtin refresh** | **41 ms** (~14×) |
| `LoadSiteBinding` | 72 µs |

`resolveRigToContext` runs the scan up to twice and `resolveContextFromDir` can also call `rigFromCwdDir`, each re-paying the refresh — so a single city-needing invocation from a plain shell (no `GC_CITY`/`GC_RIG` in env) paid ~0.6–1.2 s before doing any work.

## Fix

Switch the three rig-*enumeration* reads on the resolution path from `loadCityConfig` (with builtin-pack refresh) to the existing `loadCityConfigWithoutBuiltinPackRefresh`:

- `registeredRigBindings` (the registry-wide scan)
- `rigFromCwdDir`
- `localCityRigBindings`

`LoadWithIncludes` is retained, so **fragment/include-declared rigs are still enumerated** (`compose.go` appends `fragment.Rigs`; a root-only city.toml parse would silently drop them — verified and rejected as unsafe). The command that actually resolves to and then *operates* a city still performs its own full `loadCityConfig` (with refresh) via its `RunE`, so the refresh is never skipped where it is actually needed. Mirrors the existing completion-path precedent (`loadCityConfigWithoutBuiltinPackRefreshFS`), which already accepts "briefly stale builtin-pack content until a normal command refreshes."

## Tests

`TestRigBindingScanSkipsBuiltinPackRefresh` (new): registers a default-provider city (bd store contract) and asserts a name-based rig-binding scan resolves the binding **and** does not materialize the `gc-beads-bd` shim that a full refresh would write.

TDD: **RED** before the fix — the scan wrote the shim, test failed with the exact assertion message. **GREEN** after. Existing `TestRigAnywhere_ResolveContext` + `TestRigAnywhere_ResolveRigToContext` (regression: fragment rigs still resolve) remain green. `go vet ./cmd/gc/` clean.

## Dogfood

Real gc binary, city-needing command (`gc rig list`) from a plain shell against the real registry — see PR thread for before/after wall-clock.

## Scope

Complementary to #4384 (which reorders `resolveContextFromPath` for a *correctness* misfire and explicitly leaves the scan itself unchanged). This PR makes the scan itself cheap; no overlap.

### Dogfood numbers

`gc rig list` from the town root, env stripped of `GC_CITY`/`GC_RIG`/`GC_DIR`, real registry:

| binary | real (median of 3) |
|---|---|
| installed r7 (no fix) | ~4.0 s |
| **fixed (this PR)** | **~2.68 s** |

(`rig list` routes to the supervisor API, which adds seconds of variable latency — the controlled per-load micro-benchmark above isolates the ~588 ms → ~41 ms resolution win precisely.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
