### PR TITLE
fix(hook): treat leaked routed_to="null" literal as unrouted

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -1287,11 +1287,27 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 	return false
 }
 
+// hookClaimRoutedTo reads gc.routed_to and normalizes a leaked JSON-null literal
+// ("null", any case) to an ABSENT route. A raw metadata write (e.g. a manual
+// `bd update --set-metadata gc.routed_to=null`) or a serialization round-trip can
+// store the string "null" instead of clearing the key; left as a literal route
+// target it matches no session and strands the bead unclaimable forever (a
+// contributor to the zero-claim/starvation class). No legitimate route target is
+// ever named "null", so treating it as "" restores the intended "unrouted"
+// meaning and lets the bead re-enter the draw.
+func hookClaimRoutedTo(candidate beads.Bead) string {
+	routedTo := strings.TrimSpace(candidate.Metadata[beadmeta.RoutedToMetadataKey])
+	if strings.EqualFold(routedTo, "null") {
+		return ""
+	}
+	return routedTo
+}
+
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {
 	if len(routeTargets) == 0 {
 		return false
 	}
-	routedTo := strings.TrimSpace(candidate.Metadata[beadmeta.RoutedToMetadataKey])
+	routedTo := hookClaimRoutedTo(candidate)
 	runTarget := strings.TrimSpace(candidate.Metadata[beadmeta.RunTargetMetadataKey])
 	kind := strings.TrimSpace(candidate.Metadata[beadmeta.KindMetadataKey])
 	for _, target := range routeTargets {
@@ -1310,7 +1326,7 @@ func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {
 }
 
 func hookClaimRoute(candidate beads.Bead) string {
-	if routedTo := strings.TrimSpace(candidate.Metadata[beadmeta.RoutedToMetadataKey]); routedTo != "" {
+	if routedTo := hookClaimRoutedTo(candidate); routedTo != "" {
 		return routedTo
 	}
 	if strings.TrimSpace(candidate.Metadata[beadmeta.KindMetadataKey]) == beadmeta.KindWorkflow {

--- a/cmd/gc/cmd_hook_claim_routed_null_test.go
+++ b/cmd/gc/cmd_hook_claim_routed_null_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// A gc.routed_to that leaked the literal JSON-null string "null" (a clear that
+// did not clear — e.g. a raw `bd update --set-metadata gc.routed_to=null` or a
+// serialization round-trip) must be treated as UNROUTED, not as a concrete route
+// target named "null". Left as a literal target it matches no session and
+// strands the bead unclaimable forever (a contributor to the zero-claim /
+// starvation class). No legitimate route target is ever named "null".
+func TestHookClaimRoutedToNullLiteralTreatedAsUnrouted(t *testing.T) {
+	// Workflow root: unrouted work is claimable via its run target, so a "null"
+	// routed_to must fall through to the run-target match.
+	workflow := beads.Bead{
+		ID: "b-workflow",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey:  "null",
+			beadmeta.KindMetadataKey:      beadmeta.KindWorkflow,
+			beadmeta.RunTargetMetadataKey: "rig/worker",
+		},
+	}
+	if !hookClaimMatchesRoute(workflow, []string{"rig/worker"}) {
+		t.Fatalf(`routed_to="null" workflow-root should be treated as unrouted and match its run target "rig/worker", but did not`)
+	}
+	if got := hookClaimRoute(workflow); got != "rig/worker" {
+		t.Fatalf(`hookClaimRoute with routed_to="null" workflow-root: got %q, want run target "rig/worker"`, got)
+	}
+
+	// Plain bead: routed_to="null" is simply unrouted (empty display route), and
+	// must not falsely match a real route target.
+	plain := beads.Bead{
+		ID:       "b-plain",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "null"},
+	}
+	if got := hookClaimRoute(plain); got != "" {
+		t.Fatalf(`hookClaimRoute with plain routed_to="null": got %q, want "" (unrouted)`, got)
+	}
+	if hookClaimMatchesRoute(plain, []string{"null"}) {
+		t.Fatalf(`a bead with routed_to="null" must NOT match a route target literally named "null" — "null" means unrouted`)
+	}
+
+	// Regression guard: a genuine route still matches exactly as before.
+	routed := beads.Bead{
+		ID:       "b-routed",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "rig/worker"},
+	}
+	if !hookClaimMatchesRoute(routed, []string{"rig/worker"}) {
+		t.Fatalf("a genuinely routed bead must still match its target")
+	}
+}


### PR DESCRIPTION
## What this changes

A `gc.routed_to` holding the literal JSON-null string `"null"` — from a clear that did not clear (e.g. a raw `bd update --set-metadata gc.routed_to=null`, or a serialization round-trip) — was treated as a **concrete route target named "null"**. No live session matches `"null"`, so the bead became **unclaimable forever**.

This is a direct contributor to the **zero-claim / starvation class** (#4114): a routed bead that no spawned agent can ever claim, keeping controller demand standing.

`hookClaimRoutedTo()` normalizes a `"null"` literal (any case) to an **absent** route in both the claim-match path (`hookClaimMatchesRoute`) and the route-display path (`hookClaimRoute`), restoring the intended "unrouted" meaning so the bead re-enters the draw. No legitimate route target is ever named `"null"`.

## Why the literal can land

The write-boundary fencing gap in #4437 is one way a raw client write deposits a bad `routed_to`. This change is defensive normalization at the read/claim boundary — it does not replace fencing, it stops one already-observed strand.

## Relationship to #3963

#3963 centralizes `routed_to` identity resolution. This fix is intentionally minimal and orthogonal (null-literal → unrouted); if #3963 lands first, the normalization is a one-line move into `RoutedToIdentity`. Kept standalone so the starvation fix isn't gated on the larger refactor.

## Test plan

- [x] New `cmd/gc/cmd_hook_claim_routed_null_test.go` — **fails before, passes after** (compiles on base; the failure is behavioral, not a compile artifact): a `routed_to="null"` workflow-root now falls through to its run target; a plain `routed_to="null"` bead reads as unrouted and does **not** match a route target literally named `"null"`; a genuinely-routed bead still matches (regression guard).
- [x] `go test ./cmd/gc/ -run 'HookClaim|Route|Claim'` — green
- [x] `go vet ./cmd/gc/` — clean

Relates to #4114, #4437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)