### PR TITLE
fix(gc): reap closed-bead worktrees from the rig root, fail closed on probe errors (#4492)

### DIFF
--- a/cmd/gc/bead_worktree_reaper.go
+++ b/cmd/gc/bead_worktree_reaper.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
-	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/sling"
 )
 
@@ -53,6 +52,7 @@ func reapClosedBeadWorktrees(
 		if store == nil {
 			continue
 		}
+		rigRoot := rigRootForName(rigName, cfg.Rigs)
 		rigWorktreeDir := filepath.Join(wtRoot, rigName)
 		entries, err := os.ReadDir(rigWorktreeDir)
 		if err != nil {
@@ -93,14 +93,19 @@ func reapClosedBeadWorktrees(
 			}
 
 			// Safety checks: run from the worktree directory so git status
-			// and stash list apply to the worktree's branch.
-			wg := git.New(worktreePath)
+			// and stash list apply to the worktree's branch. A probe error
+			// is treated the same as an unsafe result (fail closed) — an
+			// unreadable probe gives no evidence the tree is safe to reap.
+			wg := newGitProbe(worktreePath)
 			hasUncommitted := wg.HasUncommittedWork()
-			hasUnpushed, _ := wg.HasUnpushedCommitsResult()
-			hasStashes, _ := wg.HasStashesResult()
+			hasUnpushed, unpushedErr := wg.HasUnpushedCommitsResult()
+			hasStashes, stashesErr := wg.HasStashesResult()
 
-			if hasUncommitted || hasUnpushed || hasStashes {
-				reason := fmt.Sprintf("uncommitted=%v unpushed=%v stashes=%v", hasUncommitted, hasUnpushed, hasStashes)
+			if hasUncommitted || hasUnpushed || hasStashes || unpushedErr != nil || stashesErr != nil {
+				reason := fmt.Sprintf(
+					"uncommitted=%v unpushed=%v (err=%v) stashes=%v (err=%v)",
+					hasUncommitted, hasUnpushed, unpushedErr, hasStashes, stashesErr,
+				)
 				fmt.Fprintf(stderr, //nolint:errcheck
 					"reapClosedBeadWorktrees: skipping %s (bead %s closed but unsafe: %s)\n",
 					worktreePath, beadID, reason,
@@ -124,10 +129,19 @@ func reapClosedBeadWorktrees(
 			// Capture branch before removal — the worktree dir will be gone after.
 			branch, _ := wg.CurrentBranch()
 
+			if rigRoot == "" {
+				fmt.Fprintf(stderr, //nolint:errcheck
+					"reapClosedBeadWorktrees: skipping %s (bead %s closed but rig %q path unresolved)\n",
+					worktreePath, beadID, rigName,
+				)
+				continue
+			}
+
 			// Remove the worktree. git worktree remove must be run from the
-			// main repo root, not from within the worktree being removed.
-			mainRepo := git.New(cityPath)
-			if err := mainRepo.WorktreeRemove(worktreePath, false); err != nil {
+			// rig's own repo root, not from the city root — a rig is an
+			// external repository with its own .git, distinct from the
+			// city's (mirrors session_worktree_prune.go's rig-root pattern).
+			if err := newGitProbe(rigRoot).WorktreeRemove(worktreePath, false); err != nil {
 				fmt.Fprintf(stderr, "reapClosedBeadWorktrees: removing %s: %v\n", worktreePath, err) //nolint:errcheck
 				continue
 			}
@@ -154,19 +168,25 @@ func reapClosedBeadWorktrees(
 	return reaped
 }
 
-// extractBeadIDFromWorktreeName scans consecutive dash-separated segment pairs
-// in name for one that LooksLikeConfiguredBeadID. Returns the first match, or
-// "" if none. Handles names like "builder-ga-34q3ss-pr2738" → "ga-34q3ss" and
-// bare "ga-06kfi6" → "ga-06kfi6".
+// extractBeadIDFromWorktreeName scans dash-separated segment windows in name,
+// growing from each start position, for one that LooksLikeConfiguredBeadID.
+// Returns the first match, or "" if none. A configured rig prefix may itself
+// be hyphenated (e.g. rig "agent-diagnostics"), so a fixed two-segment window
+// is not enough — the window must grow to cover multi-segment prefixes.
+// Handles names like "builder-ga-34q3ss-pr2738" → "ga-34q3ss",
+// "agent-diagnostics-h1" → "agent-diagnostics-h1" (hyphenated rig prefix),
+// and bare "ga-06kfi6" → "ga-06kfi6".
 func extractBeadIDFromWorktreeName(cfg *config.City, name string) string {
 	if name == "" || cfg == nil {
 		return ""
 	}
 	parts := strings.Split(name, "-")
-	for i := 0; i+1 < len(parts); i++ {
-		candidate := parts[i] + "-" + parts[i+1]
-		if sling.LooksLikeConfiguredBeadID(cfg, candidate) {
-			return candidate
+	for i := 0; i < len(parts); i++ {
+		for j := i + 1; j < len(parts); j++ {
+			candidate := strings.Join(parts[i:j+1], "-")
+			if sling.LooksLikeConfiguredBeadID(cfg, candidate) {
+				return candidate
+			}
 		}
 	}
 	return ""

--- a/cmd/gc/bead_worktree_reaper_test.go
+++ b/cmd/gc/bead_worktree_reaper_test.go
@@ -1,16 +1,27 @@
 package main
 
 import (
+	"bytes"
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 )
 
 func gaConfig() *config.City {
 	return &config.City{
 		Workspace: config.Workspace{Name: "test", Prefix: "ga"},
 	}
+}
+
+func gaConfigWithRig(rigName, rigPrefix string) *config.City {
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: rigName, Prefix: rigPrefix}}
+	return cfg
 }
 
 func TestExtractBeadIDFromWorktreeNameBareID(t *testing.T) {
@@ -59,6 +70,26 @@ func TestExtractBeadIDFromWorktreeNameEmptyName(t *testing.T) {
 	}
 }
 
+// TestExtractBeadIDFromWorktreeNameHyphenatedRigPrefixBare covers a rig
+// whose configured prefix is itself hyphenated (e.g. "agent-diagnostics"),
+// per #4492: a fixed two-segment window never forms the 3-segment
+// candidate, so such worktrees were silently never recognized.
+func TestExtractBeadIDFromWorktreeNameHyphenatedRigPrefixBare(t *testing.T) {
+	cfg := gaConfigWithRig("diag", "agent-diagnostics")
+	got := extractBeadIDFromWorktreeName(cfg, "agent-diagnostics-h1")
+	if got != "agent-diagnostics-h1" {
+		t.Errorf("got %q, want %q", got, "agent-diagnostics-h1")
+	}
+}
+
+func TestExtractBeadIDFromWorktreeNameHyphenatedRigPrefixCompound(t *testing.T) {
+	cfg := gaConfigWithRig("diag", "agent-diagnostics")
+	got := extractBeadIDFromWorktreeName(cfg, "worker-agent-diagnostics-h1")
+	if got != "agent-diagnostics-h1" {
+		t.Errorf("got %q, want %q", got, "agent-diagnostics-h1")
+	}
+}
+
 func TestIsStrictlyUnderDirSubpath(t *testing.T) {
 	dir := filepath.Join("a", "b")
 	path := filepath.Join("a", "b", "c")
@@ -87,5 +118,142 @@ func TestIsStrictlyUnderDirDeepSubpath(t *testing.T) {
 	path := filepath.Join("root", "worktrees", "gascity", "builder")
 	if !isStrictlyUnderDir(dir, path) {
 		t.Errorf("isStrictlyUnderDir(%q, %q) = false, want true", dir, path)
+	}
+}
+
+// reapTestFixture wires a temp city directory with one closed-bead worktree
+// under .gc/worktrees/<rig>/, plus a config pointing that rig at a separate
+// "rig root" directory — mirroring pruneTestFixture's shape so both use the
+// same fakeGitProbe/newGitProbe injection.
+type reapTestFixture struct {
+	t            *testing.T
+	cityPath     string
+	rigRoot      string
+	worktreePath string
+	cfg          *config.City
+	stores       map[string]beads.Store
+	probesByWD   map[string]*fakeGitProbe
+}
+
+func newReapFixture(t *testing.T) *reapTestFixture {
+	t.Helper()
+	cityPath := t.TempDir()
+	rigRoot := filepath.Join(cityPath, "repos", "ga-rig")
+	worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "ga-rig", "ga-abc123")
+
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatalf("mkdir rigRoot: %v", err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("mkdir worktreePath: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "ga-rig", Path: rigRoot}}
+
+	store := beads.NewMemStoreFrom(1, []beads.Bead{{ID: "ga-abc123", Status: "closed"}}, nil)
+
+	fx := &reapTestFixture{
+		t:            t,
+		cityPath:     cityPath,
+		rigRoot:      rigRoot,
+		worktreePath: worktreePath,
+		cfg:          cfg,
+		stores:       map[string]beads.Store{"ga-rig": store},
+		probesByWD:   make(map[string]*fakeGitProbe),
+	}
+
+	orig := newGitProbe
+	t.Cleanup(func() { newGitProbe = orig })
+	newGitProbe = func(workDir string) gitProbe {
+		probe, ok := fx.probesByWD[workDir]
+		if !ok {
+			probe = &fakeGitProbe{isRepo: true}
+			fx.probesByWD[workDir] = probe
+		}
+		return probe
+	}
+
+	return fx
+}
+
+func (fx *reapTestFixture) setProbe(workDir string, probe *fakeGitProbe) {
+	fx.probesByWD[workDir] = probe
+}
+
+type recordingRecorder struct {
+	types []string
+}
+
+func (r *recordingRecorder) Record(e events.Event) { r.types = append(r.types, e.Type) }
+
+func TestReapClosedBeadWorktrees_RemovesFromRigRootNotCityPath(t *testing.T) {
+	fx := newReapFixture(t)
+
+	var stderr bytes.Buffer
+	reaped := reapClosedBeadWorktrees(fx.cityPath, fx.cfg, fx.stores, nil, &stderr)
+
+	if reaped != 1 {
+		t.Fatalf("reaped = %d, want 1; stderr=%s", reaped, stderr.String())
+	}
+	cityProbe := fx.probesByWD[fx.cityPath]
+	if cityProbe != nil && cityProbe.removeInvoked {
+		t.Fatal("WorktreeRemove invoked against cityPath — should target the rig root")
+	}
+	rigProbe := fx.probesByWD[fx.rigRoot]
+	if rigProbe == nil || !rigProbe.removeInvoked {
+		t.Fatal("expected WorktreeRemove invoked against the rig root")
+	}
+	if rigProbe.removedPath != fx.worktreePath {
+		t.Fatalf("removedPath = %q, want %q", rigProbe.removedPath, fx.worktreePath)
+	}
+}
+
+func TestReapClosedBeadWorktrees_RigRootUnresolvedSkipsRemoval(t *testing.T) {
+	fx := newReapFixture(t)
+	fx.cfg.Rigs = nil // no rig configured — root can't be resolved
+
+	var stderr bytes.Buffer
+	reaped := reapClosedBeadWorktrees(fx.cityPath, fx.cfg, fx.stores, nil, &stderr)
+
+	if reaped != 0 {
+		t.Fatalf("reaped = %d, want 0 (rig root unresolved)", reaped)
+	}
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove invoked despite unresolved rig root")
+	}
+}
+
+func TestReapClosedBeadWorktrees_UnpushedProbeErrorSkipsReap(t *testing.T) {
+	fx := newReapFixture(t)
+	fx.setProbe(fx.worktreePath, &fakeGitProbe{isRepo: true, unpushedErr: errors.New("probe failed")})
+
+	rec := &recordingRecorder{}
+	var stderr bytes.Buffer
+	reaped := reapClosedBeadWorktrees(fx.cityPath, fx.cfg, fx.stores, rec, &stderr)
+
+	if reaped != 0 {
+		t.Fatalf("reaped = %d, want 0 (unpushed probe errored)", reaped)
+	}
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove invoked despite unpushed probe error")
+	}
+	if len(rec.types) != 1 || rec.types[0] != events.BeadWorktreeReapSkipped {
+		t.Fatalf("recorded events = %v, want exactly one BeadWorktreeReapSkipped", rec.types)
+	}
+}
+
+func TestReapClosedBeadWorktrees_StashProbeErrorSkipsReap(t *testing.T) {
+	fx := newReapFixture(t)
+	fx.setProbe(fx.worktreePath, &fakeGitProbe{isRepo: true, stashesErr: errors.New("probe failed")})
+
+	var stderr bytes.Buffer
+	reaped := reapClosedBeadWorktrees(fx.cityPath, fx.cfg, fx.stores, nil, &stderr)
+
+	if reaped != 0 {
+		t.Fatalf("reaped = %d, want 0 (stash probe errored)", reaped)
+	}
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove invoked despite stash probe error")
 	}
 }

--- a/cmd/gc/session_worktree_prune.go
+++ b/cmd/gc/session_worktree_prune.go
@@ -24,6 +24,7 @@ type gitProbe interface {
 	HasUnpushedCommitsResult() (bool, error)
 	HasStashesResult() (bool, error)
 	WorktreeRemove(path string, force bool) error
+	CurrentBranch() (string, error)
 }
 
 // newGitProbe returns a gitProbe scoped to the given directory. Indirected

--- a/cmd/gc/session_worktree_prune_test.go
+++ b/cmd/gc/session_worktree_prune_test.go
@@ -17,16 +17,18 @@ import (
 // records the (path, force) of every WorktreeRemove invocation so tests
 // can assert which directory the removal targeted.
 type fakeGitProbe struct {
-	isRepo         bool
-	hasUncommitted bool
-	hasUnpushed    bool
-	unpushedErr    error
-	hasStashes     bool
-	stashesErr     error
-	worktreeRemove func(path string, force bool) error
-	removedPath    string
-	removedForce   bool
-	removeInvoked  bool
+	isRepo           bool
+	hasUncommitted   bool
+	hasUnpushed      bool
+	unpushedErr      error
+	hasStashes       bool
+	stashesErr       error
+	currentBranch    string
+	currentBranchErr error
+	worktreeRemove   func(path string, force bool) error
+	removedPath      string
+	removedForce     bool
+	removeInvoked    bool
 }
 
 func (f *fakeGitProbe) IsRepo() bool             { return f.isRepo }
@@ -35,6 +37,10 @@ func (f *fakeGitProbe) HasUnpushedCommitsResult() (bool, error) {
 	return f.hasUnpushed, f.unpushedErr
 }
 func (f *fakeGitProbe) HasStashesResult() (bool, error) { return f.hasStashes, f.stashesErr }
+func (f *fakeGitProbe) CurrentBranch() (string, error) {
+	return f.currentBranch, f.currentBranchErr
+}
+
 func (f *fakeGitProbe) WorktreeRemove(path string, force bool) error {
 	f.removeInvoked = true
 	f.removedPath = path


### PR DESCRIPTION
## Summary

Fixes part 3 of #4492 — three independently-scoped defects in `reapClosedBeadWorktrees` (`cmd/gc/bead_worktree_reaper.go`), each with an existing correct pattern already living next door in `session_worktree_prune.go`:

1. **Wrong-repo removal.** The reaper ran `git worktree remove` against the city root instead of the rig's own repo root. A rig is an external repository with its own `.git` — worktree removal must happen against the repo that owns it. Fixed by reusing the existing `rigRootForName` helper and the file-local `gitProbe` interface (extended with `CurrentBranch()`), so the reaper goes through the same injectable probe as its sibling.
2. **Fail-open probe errors.** `HasUnpushedCommitsResult`/`HasStashesResult` discarded their errors, so a probe failure silently read as "safe to reap." Both errors are now checked and treated as unsafe (skip), matching `pruneAgentHomeWorktreeIfSafe`'s existing per-probe error handling.
3. **Hyphenated-prefix ID parsing.** `extractBeadIDFromWorktreeName` only tested adjacent two-segment windows, but `LooksLikeConfiguredBeadID` explicitly supports multi-segment rig prefixes (e.g. `agent-diagnostics-hnn`). Fixed by growing the window per start position instead of a fixed pair.

Parts 1–2 of #4492 (worktree creation-path convergence in a separate repo, and the end-of-use/borrow-veto reaper-semantics redesign) are out of scope for this PR — design-level / cross-repo work, left to the reporter/maintainers. This PR is a partial fix, not a claim of full closure.

## Test plan

- 6 new tests added, all confirmed RED first (by temporarily reverting each fix in place), then GREEN after restore.
- All pre-existing reaper/prune/extract tests pass (`TestReapClosedBeadWorktrees*`, `TestExtractBeadIDFromWorktreeName*`, `TestIsStrictlyUnderDir*`, `TestPruneAgentHomeWorktreeIfSafe*`, `TestLookupRigRootForSession*`).
- `go build` / `go vet` clean.
- Full sharded `cmd/gc` suite run twice (local dev + pre-push hook); all failures across both runs are pre-existing local-sandbox subprocess/timing flakiness (managed-Dolt startup timing, process-group-kill timeouts, Docker session protocol, etc.) — confirmed none of the 6 new tests or any reaper/worktree-prune test appears in any failure list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)