### PR TITLE
feat(beads): narrow MetadataCASWriter on NativeDoltStore (value-CAS only)

### DIFF
--- a/internal/beads/beadstest/metadata_cas_conformance.go
+++ b/internal/beads/beadstest/metadata_cas_conformance.go
@@ -1,0 +1,244 @@
+package beadstest
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// MetadataCASOptions controls legs of the narrow CAS suite that not every
+// TEST FIXTURE can evaluate. Note the distinction from
+// ConditionalWriterOptions, whose legs turn on what a STORE can express: the
+// contention leg here is a claim about the backend's isolation, so a fixture
+// that models a backend without modelling its isolation cannot judge it.
+type MetadataCASOptions struct {
+	// FixtureLacksIsolationReason, when non-empty, declares that this
+	// factory's store cannot evaluate the contention leg because the fixture
+	// behind it provides no isolation between concurrent transactions, and
+	// records why. The leg is then reported as an explicit, named absence
+	// rather than silently dropped — an unevaluatable gate must be visible in
+	// the test output, not missing from it.
+	//
+	// Set this ONLY for a fixture whose non-isolation is a property of the
+	// test double, never to quiet a store that genuinely admits two winners:
+	// a store that loses the contention leg cannot carry a lease, which is
+	// the whole reason callers want this capability. A fixture that opts out
+	// here owes the contention property an integration-level test against the
+	// real backend.
+	FixtureLacksIsolationReason string
+}
+
+// RunMetadataCASConformance runs the store-agnostic beads.MetadataCASWriter
+// contract suite against a capable store, with every leg enabled.
+func RunMetadataCASConformance(t *testing.T, name string, open func(t *testing.T) beads.Store) {
+	RunMetadataCASConformanceWithOptions(t, name, open, MetadataCASOptions{})
+}
+
+// RunMetadataCASConformanceWithOptions is RunMetadataCASConformance with the
+// fixture-dependent contention leg configurable. open must return a fresh,
+// empty store that implements beads.MetadataCASWriter (verified via
+// beads.MetadataCASWriterFor); name prefixes every subtest so multiple stores
+// can run in one package.
+//
+// The subtests mirror the metadata-CAS legs of
+// RunConditionalWriterConformance one-to-one, so a store that can only offer
+// the narrow capability is held to exactly the same value-CAS contract as a
+// full ConditionalWriter — the two suites can be diffed against each other.
+// The revision legs are deliberately absent rather than skipped: a narrow
+// store makes no revision claim at all, so there is nothing to assert (see
+// the MetadataCASWriter doc comment for why no sound revision token exists at
+// beads v1.1.0).
+//
+// Both contract traps that the in-tree implementations historically diverged
+// on ride this suite: empty-expected matching absent OR present-and-empty,
+// and a lost race reporting (false, nil) rather than an error.
+func RunMetadataCASConformanceWithOptions(t *testing.T, name string, open func(t *testing.T) beads.Store, opts MetadataCASOptions) {
+	t.Helper()
+
+	// writerFor resolves the narrow writer or fails loudly: the suite is only
+	// meaningful against a capable store.
+	writerFor := func(t *testing.T, s beads.Store) beads.MetadataCASWriter {
+		t.Helper()
+		w, ok := beads.MetadataCASWriterFor(s)
+		if !ok {
+			t.Fatalf("store does not implement beads.MetadataCASWriter; "+
+				"RunMetadataCASConformance requires a capable store (%T)", s)
+		}
+		return w
+	}
+
+	t.Run(name+"/cas_empty_expected_claims_absent_or_empty_only", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-empty"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+
+		// Absent key: expected "" claims it.
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "", "one"); err != nil || !ok {
+			t.Fatalf("claim absent key: (%v, %v), want (true, nil)", ok, err)
+		}
+		// Empty-valued key: expected "" also claims it (the two states are
+		// indistinguishable to callers).
+		if err := s.SetMetadata(id, "k", ""); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "", "two"); err != nil || !ok {
+			t.Fatalf("claim empty-valued key: (%v, %v), want (true, nil)", ok, err)
+		}
+		// Non-empty key: expected "" must NOT claim it.
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "", "three"); err != nil || ok {
+			t.Fatalf("claim non-empty key with empty expected: (%v, %v), want (false, nil)", ok, err)
+		}
+		if got, _ := s.Get(id); got.Metadata["k"] != "two" {
+			t.Fatalf("value after rejected empty-expected CAS = %q, want %q", got.Metadata["k"], "two")
+		}
+	})
+
+	t.Run(name+"/cas_value_mismatch_is_false_nil_not_error", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-mismatch"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "k", "A"); err != nil {
+			t.Fatal(err)
+		}
+		ok, err := w.CompareAndSetMetadataKey(id, "k", "B", "C")
+		if err != nil {
+			t.Fatalf("value-mismatch CAS returned error: %v (want nil)", err)
+		}
+		if ok {
+			t.Fatal("value-mismatch CAS returned true (want false)")
+		}
+		if got, _ := s.Get(id); got.Metadata["k"] != "A" {
+			t.Fatalf("value mutated on a lost CAS: %q, want %q", got.Metadata["k"], "A")
+		}
+	})
+
+	t.Run(name+"/cas_winner_value_visible_to_loser_reread", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-visible"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "k", "start"); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "start", "winner"); err != nil || !ok {
+			t.Fatalf("winner CAS: (%v, %v), want (true, nil)", ok, err)
+		}
+		// A loser re-reads and must observe the winner's value.
+		if got, _ := s.Get(id); got.Metadata["k"] != "winner" {
+			t.Fatalf("loser re-read = %q, want %q (winner value not visible)", got.Metadata["k"], "winner")
+		}
+		// And a CAS from the old value now loses cleanly.
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "start", "late"); err != nil || ok {
+			t.Fatalf("stale-value CAS after a swap: (%v, %v), want (false, nil)", ok, err)
+		}
+	})
+
+	t.Run(name+"/cas_does_not_disturb_sibling_keys", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-siblings"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "sibling", "preserved"); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetMetadata(id, "k", "A"); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "A", "B"); err != nil || !ok {
+			t.Fatalf("CAS: (%v, %v), want (true, nil)", ok, err)
+		}
+		got, err := s.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Metadata["sibling"] != "preserved" {
+			t.Fatalf("sibling metadata = %q, want %q (read-modify-write dropped it)", got.Metadata["sibling"], "preserved")
+		}
+		if got.Metadata["k"] != "B" {
+			t.Fatalf("target metadata = %q, want %q", got.Metadata["k"], "B")
+		}
+	})
+
+	// The exclusion property the lease/claim callers actually depend on:
+	// under concurrency exactly ONE racer may win a claim from a single
+	// starting value. A store that reports two winners has no mutual
+	// exclusion and cannot carry a lease, however well it passes the
+	// sequential legs above.
+	t.Run(name+"/cas_contention_admits_exactly_one_winner", func(t *testing.T) {
+		if reason := opts.FixtureLacksIsolationReason; reason != "" {
+			// Named, visible absence: the store is not being excused, the
+			// FIXTURE cannot evaluate the claim. The property is owed an
+			// integration test against the real backend.
+			t.Skipf("fixture cannot evaluate contention: %s", reason)
+		}
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-contention"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "lease", ""); err != nil {
+			t.Fatal(err)
+		}
+
+		const racers = 8
+		var (
+			wg      sync.WaitGroup
+			mu      sync.Mutex
+			winners []string
+			errs    []error
+		)
+		start := make(chan struct{})
+		for i := range racers {
+			wg.Add(1)
+			go func(racer int) {
+				defer wg.Done()
+				holder := "holder-" + strconv.Itoa(racer)
+				<-start
+				ok, err := w.CompareAndSetMetadataKey(id, "lease", "", holder)
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					errs = append(errs, err)
+					return
+				}
+				if ok {
+					winners = append(winners, holder)
+				}
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		for _, err := range errs {
+			t.Fatalf("racer returned an error (a lost race must be (false, nil)): %v", err)
+		}
+		if len(winners) != 1 {
+			t.Fatalf("winners = %d %v, want exactly 1 (no mutual exclusion)", len(winners), winners)
+		}
+		got, err := s.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Metadata["lease"] != winners[0] {
+			t.Fatalf("stored lease = %q, want the sole winner %q", got.Metadata["lease"], winners[0])
+		}
+	})
+}

--- a/internal/beads/beadstest/metadata_cas_conformance.go
+++ b/internal/beads/beadstest/metadata_cas_conformance.go
@@ -12,7 +12,7 @@ import (
 // TEST FIXTURE can evaluate. Note the distinction from
 // ConditionalWriterOptions, whose legs turn on what a STORE can express: the
 // contention leg here is a claim about the backend's isolation, so a fixture
-// that models a backend without modelling its isolation cannot judge it.
+// that models a backend without modeling its isolation cannot judge it.
 type MetadataCASOptions struct {
 	// FixtureLacksIsolationReason, when non-empty, declares that this
 	// factory's store cannot evaluate the contention leg because the fixture

--- a/internal/beads/caching_store_conditional.go
+++ b/internal/beads/caching_store_conditional.go
@@ -202,7 +202,14 @@ func (c *CachingStore) DeleteIfMatch(id string, expectedRevision int64) error {
 // `expected`, and without the evict a cross-process loser re-reads the same
 // stale value through the cache and re-loses until an unrelated reconcile.
 func (c *CachingStore) CompareAndSetMetadataKey(id, key, expected, next string) (bool, error) {
-	writer, ok := ConditionalWriterFor(c.conditionalBacking())
+	// Resolve the NARROW capability, not ConditionalWriter: a backing that can
+	// do value-CAS but cannot soundly fence on a revision (NativeDoltStore)
+	// declares MetadataCASWriter only, and every ConditionalWriter satisfies
+	// MetadataCASWriter anyway, so this widens the backings that forward
+	// without changing behaviour for fully capable ones. The trio above keeps
+	// resolving through ConditionalWriterFor — a narrow backing must not
+	// unlock a revision fence it cannot honour.
+	writer, ok := MetadataCASWriterFor(c.conditionalBacking())
 	if !ok {
 		return false, ErrConditionalWriteUnsupported
 	}

--- a/internal/beads/caching_store_conditional.go
+++ b/internal/beads/caching_store_conditional.go
@@ -206,9 +206,9 @@ func (c *CachingStore) CompareAndSetMetadataKey(id, key, expected, next string) 
 	// do value-CAS but cannot soundly fence on a revision (NativeDoltStore)
 	// declares MetadataCASWriter only, and every ConditionalWriter satisfies
 	// MetadataCASWriter anyway, so this widens the backings that forward
-	// without changing behaviour for fully capable ones. The trio above keeps
+	// without changing behavior for fully capable ones. The trio above keeps
 	// resolving through ConditionalWriterFor — a narrow backing must not
-	// unlock a revision fence it cannot honour.
+	// unlock a revision fence it cannot honor.
 	writer, ok := MetadataCASWriterFor(c.conditionalBacking())
 	if !ok {
 		return false, ErrConditionalWriteUnsupported

--- a/internal/beads/metadata_cas.go
+++ b/internal/beads/metadata_cas.go
@@ -1,0 +1,97 @@
+// The narrow metadata value-CAS capability seam.
+//
+// ConditionalWriter (beads.go) bundles four methods: the revision-CAS trio
+// (UpdateIfMatch/CloseIfMatch/DeleteIfMatch) plus CompareAndSetMetadataKey.
+// The trio needs a backend fence token — a revision that advances on every
+// mutation and is never reused. The beads v1.1.0 schema cannot supply one:
+// types.Issue carries no revision field (Get().Revision is 0 and never
+// advances), the issues DDL has no version column, and updated_at is
+// second-granularity — so two same-second writes yield an EQUAL token and a
+// stale fence SILENTLY SUCCEEDS, which is the lost update a fence exists to
+// prevent. Label mutations never touch updated_at at all. A store-maintained
+// counter is not a fence either: the Dolt database is multi-writer (the bd
+// CLI, other gascity processes, graph-apply), and a counter only the fencer
+// maintains fences nothing.
+//
+// CompareAndSetMetadataKey needs no such token — it guards on the key's own
+// current value — so it is soundly implementable today on stores where the
+// trio is not. MetadataCASWriter is that half, split out so a store can
+// declare the capability it actually has. Declaring the whole of
+// ConditionalWriter just to expose the CAS method would make
+// ResolveConditionalWriter RESOLVE under require mode and hand the trio's
+// callers a silently-wrong fence — converting today's loud typed refusal into
+// exactly the silent legacy write under require that the seam exists to make
+// inexpressible. See the condWritesStamp comment in native_dolt_store.go.
+//
+// Upstream beads #4697 (claim_fence) is the missing backend primitive. When it
+// lands, a store can implement the trio soundly and declare ConditionalWriter;
+// until then a narrow-only store declares MetadataCASWriter and nothing more.
+//
+// Resolution is deliberately SEPARATE from ResolveConditionalWriter: this is a
+// capability lookup, not the operator-policy seam. It carries no
+// conditional_writes mode, because its consumers (target_scope member
+// declaration, the D3/D5 lease/claim_generation lane) have no legacy
+// unconditional path to fall back to — the CAS is their only correct
+// implementation, so gating it on a rollout flag would leave them with nothing
+// under the default off. Nothing here can raise enforcement on the trio: a
+// narrow writer never satisfies ConditionalWriter, so the trio's callers stay
+// exactly as refused as they are today.
+
+package beads
+
+// MetadataCASWriter is the metadata value-CAS half of ConditionalWriter,
+// declared on its own so stores that cannot soundly fence on a revision can
+// still offer a sound single-key compare-and-set.
+//
+// The contract is identical to ConditionalWriter.CompareAndSetMetadataKey and
+// is verified by the same assertions (beadstest.RunMetadataCASConformance):
+// expected == "" matches a key that is absent OR present with the empty value
+// (the two states are indistinguishable to callers; release paths write "" to
+// clear). Returns (true, nil) on swap, (false, nil) on a genuine value
+// mismatch — a lost race is NOT an error — and (false, err) for everything
+// else. A store whose conditional writes are disabled at the instance level
+// reports ErrConditionalWriteUnsupported from the call, matching how the trio
+// behaves on those stores.
+//
+// Every ConditionalWriter satisfies MetadataCASWriter structurally, so a fully
+// capable store serves narrow callers unchanged. The converse cannot hold: Go
+// interface satisfaction needs all four methods, which is precisely the
+// property that keeps a narrow store out of ConditionalWriter resolution.
+type MetadataCASWriter interface {
+	CompareAndSetMetadataKey(id, key, expected, next string) (bool, error)
+}
+
+// MetadataCASWriterHandleProvider exposes a metadata-CAS handle for stores
+// whose capability depends on wrapped runtime state. It mirrors
+// ConditionalWriterHandleProvider: a wrapper can delegate the capability
+// without claiming the interface globally.
+type MetadataCASWriterHandleProvider interface {
+	MetadataCASWriterHandle() (MetadataCASWriter, bool)
+}
+
+// MetadataCASWriterFor returns the metadata value-CAS capability for store
+// when one is available.
+//
+// It follows wrapper-declared resolution targets (ConditionalWritesResolveTargeter)
+// for the same reason ResolveConditionalWriter does: interface-embedding
+// wrappers — the cmd/gc policy store, the typed class wrappers in
+// class_store.go — do not promote optional capabilities, so a direct assertion
+// through them fails and the capability would look absent. As with
+// ConditionalWriterFor, this does NOT guess at unwrapping: a wrapper
+// participates only by declaring its target.
+//
+// This is a pure capability lookup and applies no operator policy — see the
+// file comment for why the narrow CAS is not mode-gated.
+func MetadataCASWriterFor(store Store) (MetadataCASWriter, bool) {
+	if store == nil {
+		return nil, false
+	}
+	store = followConditionalWritesResolveTarget(store)
+	if writer, ok := store.(MetadataCASWriter); ok {
+		return writer, true
+	}
+	if provider, ok := store.(MetadataCASWriterHandleProvider); ok {
+		return provider.MetadataCASWriterHandle()
+	}
+	return nil, false
+}

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -285,9 +285,30 @@ type NativeDoltStore struct {
 	readRetryBudgetOverride time.Duration
 
 	// condWritesStamp carries the factory-stamped conditional-writes mode.
-	// NativeDoltStore implements no ConditionalWriter yet, so the stamp's
-	// effect today is require→typed refusal / auto→loud degrade at the
-	// seam, never a silent legacy write under require.
+	// NativeDoltStore implements the NARROW metadata value-CAS
+	// (MetadataCASWriter, see native_dolt_store_conditional.go) but NOT
+	// ConditionalWriter, so the stamp's effect at the seam is unchanged:
+	// require→typed refusal / auto→loud degrade, never a silent legacy write
+	// under require.
+	//
+	// The gap is the revision-CAS trio, and it is a BACKEND gap, not an
+	// unwritten method. UpdateIfMatch/CloseIfMatch/DeleteIfMatch need a fence
+	// token that advances on every mutation and is never reused; beads v1.1.0
+	// has none. types.Issue carries no revision, the issues DDL has no version
+	// column, updated_at is second-granularity — so two same-second writes
+	// compare EQUAL and a stale fence silently succeeds, which is the lost
+	// update the fence exists to prevent — and label mutations never touch
+	// updated_at at all. A counter this store maintained itself would fence
+	// nothing, because the Dolt database is multi-writer (bd CLI, other
+	// gascity processes, graph-apply). Upstream beads #4697 (claim_fence) is
+	// the missing primitive; when it lands the trio becomes implementable and
+	// this store can declare ConditionalWriter.
+	//
+	// Declaring ConditionalWriter early to expose the CAS method would make
+	// ResolveConditionalWriter resolve under require and hand the trio's
+	// callers a wrong fence — the precise silent-write failure this refusal
+	// currently makes impossible. internal/beads/metadata_cas.go carries the
+	// full reasoning and the narrow interface's own resolution path.
 	condWritesStamp
 }
 

--- a/internal/beads/native_dolt_store_conditional.go
+++ b/internal/beads/native_dolt_store_conditional.go
@@ -1,0 +1,84 @@
+package beads
+
+import (
+	"context"
+	"fmt"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// NativeDoltStore offers the narrow metadata value-CAS and deliberately NOT
+// the full ConditionalWriter. The revision-CAS trio needs a backend fence
+// token that beads v1.1.0 cannot supply, and declaring the interface to get
+// this one method would make ResolveConditionalWriter resolve under require
+// mode — converting a loud typed refusal into a silent wrong-fenced write.
+// internal/beads/metadata_cas.go carries the full reasoning.
+var _ MetadataCASWriter = (*NativeDoltStore)(nil)
+
+// CompareAndSetMetadataKey atomically sets metadata[key] = next when the key's
+// current value equals expected.
+//
+// expected == "" matches a key that is ABSENT or present with the empty value:
+// parsing an absent key out of the stored metadata map yields "", so the two
+// states are indistinguishable here exactly as they are to callers (release
+// paths write "" to clear). Returns (true, nil) on swap, (false, nil) on a
+// genuine value mismatch — a lost race is NOT an error — and (false, err) for
+// a missing bead, a malformed metadata blob, or a transport failure.
+//
+// Atomicity is the read-check-write inside one native Dolt transaction, the
+// same shape ReleaseIfCurrent uses for its assignee guard. The whole
+// read-compare-write runs inside the callback, so the compare and the write
+// commit together or not at all: the upstream storage layer exposes no
+// conditional-UPDATE ... WHERE primitive and no raw-SQL escape hatch, making
+// the transaction the only composition point available.
+//
+// Sibling keys are preserved: the metadata column is a single blob, so the
+// write re-serializes the map read inside this transaction rather than
+// patching one field.
+func (s *NativeDoltStore) CompareAndSetMetadataKey(id, key, expected, next string) (bool, error) {
+	storage, release, err := s.acquireStorage()
+	if err != nil {
+		return false, err
+	}
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+
+	swapped := false
+	commitMsg := fmt.Sprintf("gc: compare-and-set metadata %s on bead %s", key, id)
+	err = storage.RunInTransaction(ctx, commitMsg, func(tx beadslib.Transaction) error {
+		issue, err := tx.GetIssue(ctx, id)
+		if err != nil {
+			return nativeStoreError(id, err)
+		}
+		if issue == nil {
+			return fmt.Errorf("compare-and-set metadata on %q: %w", id, ErrNotFound)
+		}
+		metadata, err := metadataMapFromNative(issue.Metadata)
+		if err != nil {
+			return fmt.Errorf("parsing metadata for bead %q: %w", id, err)
+		}
+		if metadata[key] != expected {
+			// A genuine lost race. Returning nil commits an empty transaction
+			// and leaves swapped false, which the caller reads as (false, nil).
+			return nil
+		}
+		if metadata == nil {
+			metadata = make(map[string]string, 1)
+		}
+		metadata[key] = next
+		raw, err := metadataRawFromMap(metadata)
+		if err != nil {
+			return err
+		}
+		if err := tx.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor); err != nil {
+			return nativeStoreError(id, err)
+		}
+		swapped = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return swapped, nil
+}

--- a/internal/beads/native_dolt_store_metadata_cas_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_integration_test.go
@@ -1,0 +1,254 @@
+//go:build integration
+
+package beads
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// openRealNativeDoltStoreForCAS opens a NativeDoltStore over REAL upstream
+// native storage. The narrow CAS contract is a claim about the backend's
+// transaction semantics, and the in-memory fixture used by the unit-level
+// conformance cannot answer it: nativeDoltMemStorage.RunInTransaction
+// snapshots for rollback and then runs the callback UNLOCKED, so it models
+// atomicity but provides no isolation whatsoever.
+func openRealNativeDoltStoreForCAS(t *testing.T, actor string) *NativeDoltStore {
+	t.Helper()
+	ctx := context.Background()
+	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))
+	if err != nil {
+		t.Skipf("upstream native beads storage unavailable: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Errorf("close upstream storage: %v", err)
+		}
+	})
+	if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	return newNativeDoltStoreWithStorageAndPrefix(storage, actor, "gc")
+}
+
+// TestNativeDoltStoreMetadataCASSequentialAgainstRealDolt exercises the
+// sequential value-CAS contract — both pinned traps — against real storage.
+func TestNativeDoltStoreMetadataCASSequentialAgainstRealDolt(t *testing.T) {
+	store := openRealNativeDoltStoreForCAS(t, "cas-sequential")
+
+	b, err := store.Create(Bead{Title: "real-dolt-cas"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := b.ID
+
+	// Trap 1: expected "" claims an ABSENT key.
+	if ok, err := store.CompareAndSetMetadataKey(id, "k", "", "one"); err != nil || !ok {
+		t.Fatalf("claim absent key: (%v, %v), want (true, nil)", ok, err)
+	}
+	// ...and also a PRESENT-AND-EMPTY key.
+	if err := store.SetMetadata(id, "k", ""); err != nil {
+		t.Fatalf("SetMetadata clear: %v", err)
+	}
+	if ok, err := store.CompareAndSetMetadataKey(id, "k", "", "two"); err != nil || !ok {
+		t.Fatalf("claim empty-valued key: (%v, %v), want (true, nil)", ok, err)
+	}
+	// ...but never a non-empty one.
+	if ok, err := store.CompareAndSetMetadataKey(id, "k", "", "three"); err != nil || ok {
+		t.Fatalf("claim non-empty key with empty expected: (%v, %v), want (false, nil)", ok, err)
+	}
+
+	// Trap 2: a genuine mismatch is (false, nil), never an error.
+	ok, err := store.CompareAndSetMetadataKey(id, "k", "WRONG", "four")
+	if err != nil {
+		t.Fatalf("value-mismatch CAS returned error: %v (want nil)", err)
+	}
+	if ok {
+		t.Fatal("value-mismatch CAS returned true (want false)")
+	}
+
+	got, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["k"] != "two" {
+		t.Fatalf("value = %q, want %q", got.Metadata["k"], "two")
+	}
+}
+
+// TestNativeDoltStoreMetadataCASContentionAgainstRealDolt is the load-bearing
+// test for the lease lane: under concurrency exactly ONE racer may win a claim
+// from a single starting value. This is the property the in-memory fixture
+// cannot evaluate, and the property D3/D5 leases and target_scope member
+// declaration actually depend on — a CAS that admits two winners hands the
+// same lease to two holders.
+func TestNativeDoltStoreMetadataCASContentionAgainstRealDolt(t *testing.T) {
+	store := openRealNativeDoltStoreForCAS(t, "cas-contention")
+
+	b, err := store.Create(Bead{Title: "real-dolt-cas-contention"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := b.ID
+	if err := store.SetMetadata(id, "lease", ""); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	const racers = 8
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		winners []string
+		errs    []error
+	)
+	start := make(chan struct{})
+	for i := range racers {
+		wg.Add(1)
+		go func(racer int) {
+			defer wg.Done()
+			holder := "holder-" + strconv.Itoa(racer)
+			<-start
+			ok, err := store.CompareAndSetMetadataKey(id, "lease", "", holder)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+				return
+			}
+			if ok {
+				winners = append(winners, holder)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for _, err := range errs {
+		t.Errorf("racer returned an error (a lost race must be (false, nil)): %v", err)
+	}
+	if len(winners) != 1 {
+		t.Fatalf("winners = %d %v, want exactly 1 — no mutual exclusion, so this CAS cannot carry a lease",
+			len(winners), winners)
+	}
+
+	got, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["lease"] != winners[0] {
+		t.Fatalf("stored lease = %q, want the sole winner %q", got.Metadata["lease"], winners[0])
+	}
+}
+
+// TestNativeDoltStoreMetadataCASContentionAcrossIndependentHandles is the
+// multi-writer leg, and it is the one that actually decides whether this CAS
+// can carry a lease.
+//
+// The single-handle contention test above cannot distinguish a fence enforced
+// by the DATABASE from exclusion accidentally provided by shared in-process
+// state (a connection pool, a handle-level lock). The gascity Dolt database is
+// multi-writer by design — the bd CLI, other gascity processes and graph-apply
+// all write it — so a guard that only holds within one store handle is not a
+// fence at all, which is precisely why a store-maintained counter was rejected
+// as a revision token.
+//
+// Racing two INDEPENDENTLY OPENED storage handles over the same database
+// directory reproduces that condition inside one test binary: the handles
+// share no Go-level state, so any exclusion observed here is enforced below
+// them.
+func TestNativeDoltStoreMetadataCASContentionAcrossIndependentHandles(t *testing.T) {
+	ctx := context.Background()
+	dir := filepath.Join(t.TempDir(), ".beads")
+
+	openHandle := func(actor string) *NativeDoltStore {
+		t.Helper()
+		storage, err := beadslib.OpenBestAvailable(ctx, dir)
+		if err != nil {
+			t.Skipf("upstream native beads storage unavailable: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := storage.Close(); err != nil {
+				t.Logf("close upstream storage (%s): %v", actor, err)
+			}
+		})
+		if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+			t.Fatalf("set issue prefix (%s): %v", actor, err)
+		}
+		return newNativeDoltStoreWithStorageAndPrefix(storage, actor, "gc")
+	}
+
+	writerA := openHandle("cas-writer-a")
+	writerB := openHandle("cas-writer-b")
+
+	b, err := writerA.Create(Bead{Title: "cross-handle-cas-contention"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := b.ID
+	if err := writerA.SetMetadata(id, "lease", ""); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	// The second handle must observe the bead before racing for it, otherwise
+	// a miss proves nothing about the fence.
+	if got, err := writerB.Get(id); err != nil || got.ID != id {
+		t.Fatalf("second handle cannot see bead %q: (%v, %v)", id, got.ID, err)
+	}
+
+	type result struct {
+		holder string
+		won    bool
+		err    error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	for _, racer := range []struct {
+		store  *NativeDoltStore
+		holder string
+	}{{writerA, "holder-A"}, {writerB, "holder-B"}} {
+		go func(s *NativeDoltStore, holder string) {
+			<-start
+			won, err := s.CompareAndSetMetadataKey(id, "lease", "", holder)
+			results <- result{holder: holder, won: won, err: err}
+		}(racer.store, racer.holder)
+	}
+	close(start)
+
+	var winners []string
+	for range 2 {
+		r := <-results
+		if r.err != nil {
+			// A conflict surfaced as an error is NOT contract-conformant: the
+			// contract says a lost race is (false, nil). Report it as the
+			// contract violation it is rather than tolerating it.
+			t.Errorf("racer %s returned an error (a lost race must be (false, nil)): %v", r.holder, r.err)
+			continue
+		}
+		if r.won {
+			winners = append(winners, r.holder)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+	if len(winners) != 1 {
+		t.Fatalf("winners across independent handles = %d %v, want exactly 1 — the fence does not hold "+
+			"between writers, so this CAS cannot carry a lease in the multi-writer Dolt database",
+			len(winners), winners)
+	}
+
+	// Both handles must agree on who holds the lease.
+	for name, s := range map[string]*NativeDoltStore{"writerA": writerA, "writerB": writerB} {
+		got, err := s.Get(id)
+		if err != nil {
+			t.Fatalf("%s Get: %v", name, err)
+		}
+		if got.Metadata["lease"] != winners[0] {
+			t.Fatalf("%s sees lease %q, want the sole winner %q", name, got.Metadata["lease"], winners[0])
+		}
+	}
+}

--- a/internal/beads/native_dolt_store_metadata_cas_internal_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_internal_test.go
@@ -1,0 +1,112 @@
+package beads
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/rollout/gate"
+)
+
+// TestNativeDoltStoreDeclaresNarrowCASButNotConditionalWriter pins the exact
+// capability split the narrow interface exists to express: NativeDoltStore
+// offers a sound metadata value-CAS and makes NO revision-fence claim.
+//
+// Declaring the full ConditionalWriter would make ResolveConditionalWriter
+// RESOLVE under require mode and hand the revision-CAS trio's callers a
+// silently wrong-fenced write, because no sound revision token exists at
+// beads v1.1.0 (see internal/beads/metadata_cas.go). This asserts the ABSENCE
+// of that capability, which no conformance suite can do.
+func TestNativeDoltStoreDeclaresNarrowCASButNotConditionalWriter(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+
+	if w, ok := ConditionalWriterFor(store); ok {
+		t.Fatalf("NativeDoltStore resolved a ConditionalWriter (%T); the revision-CAS trio has "+
+			"no sound backend fence at beads v1.1.0, so declaring it is a safety regression", w)
+	}
+	if _, ok := MetadataCASWriterFor(store); !ok {
+		t.Fatal("NativeDoltStore does not resolve a MetadataCASWriter; the narrow value-CAS " +
+			"capability is what unblocks target_scope member-declaration and the D3/D5 lease lane")
+	}
+}
+
+// TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade pins the seam
+// behaviour the condWritesStamp comment in native_dolt_store.go guarantees:
+// require yields a typed refusal and auto yields a loud degrade — never a
+// silent legacy write under require. Adding the narrow CAS must not move
+// either verdict.
+func TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade(t *testing.T) {
+	t.Run("require_refuses", func(t *testing.T) {
+		store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+		store.stampConditionalWritesMode(gate.Require, false)
+
+		writer, diag, err := ResolveConditionalWriter(store)
+		if writer != nil {
+			t.Fatalf("writer = %T, want nil (require must fail closed)", writer)
+		}
+		if !IsConditionalWritesRequired(err) {
+			t.Fatalf("err = %v, want *ConditionalWritesRequiredError", err)
+		}
+		if diag == nil {
+			t.Fatal("diagnostic = nil, want a refusal diagnostic")
+		}
+	})
+
+	t.Run("auto_degrades_loudly", func(t *testing.T) {
+		store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+		store.stampConditionalWritesMode(gate.Auto, false)
+
+		writer, diag, err := ResolveConditionalWriter(store)
+		if writer != nil {
+			t.Fatalf("writer = %T, want nil (auto must take the legacy path)", writer)
+		}
+		if err != nil {
+			t.Fatalf("err = %v, want nil (auto degrades, it does not refuse)", err)
+		}
+		if diag == nil {
+			t.Fatal("diagnostic = nil, want a loud-degrade diagnostic")
+		}
+	})
+}
+
+// TestCachingStoreOverNativeDoltStoreForwardsNarrowCAS covers the wrapper
+// shape the plan calls out: a CachingStore whose backing offers only the
+// narrow capability must still forward the metadata CAS. The cache resolves
+// its trio verbs through ConditionalWriterFor, so without a narrow fallback
+// this path would answer ErrConditionalWriteUnsupported and the lease lane
+// would be blocked behind the cache.
+func TestCachingStoreOverNativeDoltStoreForwardsNarrowCAS(t *testing.T) {
+	backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	cache := NewCachingStore(backing, nil)
+
+	b, err := cache.Create(Bead{Title: "cache-over-native-cas"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writer, ok := MetadataCASWriterFor(cache)
+	if !ok {
+		t.Fatal("CachingStore over a narrow-CAS backing does not resolve a MetadataCASWriter")
+	}
+	if swapped, err := writer.CompareAndSetMetadataKey(b.ID, "lease", "", "holder-1"); err != nil || !swapped {
+		t.Fatalf("claim through cache: (%v, %v), want (true, nil)", swapped, err)
+	}
+	// A stale expectation loses cleanly rather than erroring.
+	if swapped, err := writer.CompareAndSetMetadataKey(b.ID, "lease", "", "holder-2"); err != nil || swapped {
+		t.Fatalf("stale claim through cache: (%v, %v), want (false, nil)", swapped, err)
+	}
+	// The winner's value is visible through the cache (the CAS evicted, so the
+	// next read consults the backing).
+	got, err := cache.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["lease"] != "holder-1" {
+		t.Fatalf("lease through cache = %q, want %q", got.Metadata["lease"], "holder-1")
+	}
+
+	// The trio stays refused: the backing makes no revision claim, so the
+	// cache must not report itself conditionally capable over it.
+	if capable, _ := cache.probeConditionalWriteCapability(); capable {
+		t.Fatal("CachingStore reports conditional-write capability over a narrow-only backing; " +
+			"the revision-CAS trio has no sound fence there")
+	}
+}

--- a/internal/beads/native_dolt_store_metadata_cas_internal_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_internal_test.go
@@ -29,7 +29,7 @@ func TestNativeDoltStoreDeclaresNarrowCASButNotConditionalWriter(t *testing.T) {
 }
 
 // TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade pins the seam
-// behaviour the condWritesStamp comment in native_dolt_store.go guarantees:
+// behavior the condWritesStamp comment in native_dolt_store.go guarantees:
 // require yields a typed refusal and auto yields a loud degrade — never a
 // silent legacy write under require. Adding the narrow CAS must not move
 // either verdict.

--- a/internal/beads/native_dolt_store_metadata_cas_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_test.go
@@ -1,0 +1,52 @@
+package beads_test
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/beadstest"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// TestNativeDoltStoreMetadataCASConformance holds NativeDoltStore to the
+// narrow value-CAS contract, including both traps the in-tree implementations
+// historically diverged on.
+//
+// The contention leg is declared unevaluatable HERE and only here: the
+// in-memory fixture behind this factory snapshots for rollback and then runs
+// the transaction callback unlocked, so concurrent CAS calls interleave freely
+// no matter how the store behaves. The property is not waived — it is proven
+// against real Dolt by
+// TestNativeDoltStoreMetadataCASContentionAgainstRealDolt (build tag
+// `integration`), where 8 racers yield exactly one winner.
+func TestNativeDoltStoreMetadataCASConformance(t *testing.T) {
+	beadstest.RunMetadataCASConformanceWithOptions(t, "NativeDoltStore",
+		func(_ *testing.T) beads.Store { return beads.NewNativeDoltStoreForConformance() },
+		beadstest.MetadataCASOptions{
+			FixtureLacksIsolationReason: "nativeDoltMemStorage.RunInTransaction models rollback but not " +
+				"isolation (it unlocks before running the callback); contention is covered against real " +
+				"Dolt by TestNativeDoltStoreMetadataCASContentionAgainstRealDolt (-tags=integration)",
+		},
+	)
+}
+
+// TestMemStoreMetadataCASConformance and TestFileStoreMetadataCASConformance
+// run the SAME narrow suite against the two stores whose fixtures do provide
+// isolation (both guard the whole CAS under their own lock), so the contention
+// leg is genuinely exercised at unit level and the suite cannot rot into a
+// table where every store has opted out of it.
+func TestMemStoreMetadataCASConformance(t *testing.T) {
+	beadstest.RunMetadataCASConformance(t, "MemStore",
+		func(_ *testing.T) beads.Store { return beads.NewMemStore() })
+}
+
+func TestFileStoreMetadataCASConformance(t *testing.T) {
+	beadstest.RunMetadataCASConformance(t, "FileStore",
+		func(t *testing.T) beads.Store {
+			store, err := beads.OpenFileStore(fsys.OSFS{}, t.TempDir()+"/beads.json")
+			if err != nil {
+				t.Fatalf("OpenFileStore: %v", err)
+			}
+			return store
+		})
+}


### PR DESCRIPTION
## Scope

`NativeDoltStore` gains **`MetadataCASWriter`** — `CompareAndSetMetadataKey` only — with its own resolver (`MetadataCASWriterFor`), separate from the `ResolveConditionalWriter` policy seam.

`ConditionalWriter` is **deliberately not declared**. Today the store's require-mode behavior at that seam is a typed refusal / loud degrade (see the long-standing comment at `native_dolt_store.go:288`), and that refusal is a safety property: declaring the full interface with an unsound fence would convert a loud refusal into silent wrong-fenced writes. A regression test now asserts the trio stays refused. The `:288` comment is updated to record why the trio is absent and that the narrow CAS is present.

Motivating consumers: metadata-key CAS is exactly the primitive needed for scope member-declaration and lease/claim-generation flows (a lease claim *is* a metadata-key compare-and-swap). Those paths do not need the revision-CAS trio.

## Why the narrow scope is deliberate, not an omission

No sound revision token exists at beads v1.1.0 for `UpdateIfMatch` / `CloseIfMatch` / `DeleteIfMatch`:

- the issue row has no revision/version column (`Get().Revision` is 0 and never advances);
- `updated_at` has second granularity, so two writes in the same second yield an equal token and a stale fence **silently succeeds** — the exact lost-update the fence exists to prevent;
- label writes never bump `updated_at` (`issueops/labels.go` writes only the labels/events tables), so a fence-holder misses concurrent label mutations;
- a store-maintained counter is not a fence in a multi-writer database (bd CLI and other processes write the same DB) — external writes leave it stale and let doomed writes through.

The trio is therefore deferred until the row carries a real fence — #4697 (bd-core ownership layer, `claim_fence`) is the natural unlock. Because Go interface satisfaction requires all four methods, the narrow interface structurally cannot leak the trio into `ConditionalWriter` resolution.

## Implementation

- Atomicity is read-check-write inside `RunInTransaction` (same shape as the existing `ReleaseIfCurrent`).
- Contract details pinned by the shared conformance suite:
  - `expected == ""` matches a key that is **absent or present-and-empty** (indistinguishable to callers; release paths write `""` to clear);
  - a genuine lost race returns `(false, nil)` — never an error.
- `CachingStore.CompareAndSetMetadataKey` now resolves the narrow capability, so cache-over-`NativeDoltStore` forwards CAS instead of answering `ErrConditionalWriteUnsupported`. The trio still resolves through `ConditionalWriterFor` and stays refused over a narrow backing (asserted).

## Evidence

- **Red first**: 5/5 narrow conformance subtests failed against the unimplemented store (plus capability + cache forwarding); the refusal test already passed — that is the property being preserved.
- **Green**: narrow conformance green for `NativeDoltStore`, `MemStore`, `FileStore`; `./internal/beads/...` green under `-race`; `go vet` clean module-wide and with `-tags=integration`; consumer packages green (api, dispatch, beadmail, molecule, t3bridge, session, sling).
- **Multi-writer fence proven, not assumed**: a contention leg races **two independently opened storage handles** over one database — 15/15 exactly one winner (single-handle 12/12 under `-race`). A single-handle test cannot distinguish a database fence from accidental in-process serialization; this one can. (`acquireStorage` takes only an `RLock`, so exclusion is enforced below the Go layer.)
- **One honest skip, scoped to a fixture**: the in-memory `nativeDoltMemStorage` fixture models rollback but not isolation (it unlocks before running the callback), so the contention leg is a named skip **on that fixture only**, with the reason in test output. The property is carried by the real-Dolt integration tests, and the MemStore/FileStore fixtures genuinely run the leg, so the suite cannot rot into a table where every store opts out.

## Note for reviewers

`cmd/gc` shows 33 failing tests on the development box — all pre-existing supervisor-socket environment failures. A clean `origin/main` baseline worktree produces a byte-identical failure set (33 vs 33, zero difference either direction), i.e. zero regressions from this change; please don't gate on that suite here.

Follow-up validation evidence (additional real-Dolt integration runs, race repetitions, baseline re-diffs) will be posted as comments as it accumulates.
