### PR TITLE
fix(config): bind the Gas City pack as gc

### DIFF
--- a/cmd/gc/cmd_init_gascity_test.go
+++ b/cmd/gc/cmd_init_gascity_test.go
@@ -73,8 +73,8 @@ func TestDoInitDefaultTemplateImportsGascityPack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing pack.toml: %v", err)
 	}
-	if _, ok := packCfg.Imports["gascity"]; !ok {
-		t.Fatalf("default pack.toml imports = %v, want gascity entry:\n%s", packCfg.Imports, packData)
+	if _, ok := packCfg.Imports["gc"]; !ok {
+		t.Fatalf("default pack.toml imports = %v, want gc entry:\n%s", packCfg.Imports, packData)
 	}
 }
 
@@ -92,8 +92,8 @@ func TestDoInitExplicitMinimalTemplateDoesNotImportGascityPack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing pack.toml: %v", err)
 	}
-	if _, ok := packCfg.Imports["gascity"]; ok {
-		t.Fatalf("explicit minimal pack.toml imports gascity unexpectedly:\n%s", packData)
+	if _, ok := packCfg.Imports["gc"]; ok {
+		t.Fatalf("explicit minimal pack.toml imports gc unexpectedly:\n%s", packData)
 	}
 }
 
@@ -119,15 +119,15 @@ func TestDoInitWithGascityTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing pack.toml: %v", err)
 	}
-	imp, ok := packCfg.Imports["gascity"]
+	imp, ok := packCfg.Imports["gc"]
 	if !ok {
-		t.Fatalf("pack.toml imports = %v, want gascity entry:\n%s", packCfg.Imports, packData)
+		t.Fatalf("pack.toml imports = %v, want gc entry:\n%s", packCfg.Imports, packData)
 	}
 	if imp.Source != config.PublicGascityPackSource {
-		t.Errorf("gascity import source = %q, want %q", imp.Source, config.PublicGascityPackSource)
+		t.Errorf("gc import source = %q, want %q", imp.Source, config.PublicGascityPackSource)
 	}
 	if imp.Version != config.PublicGascityPackVersion {
-		t.Errorf("gascity import version = %q, want %q", imp.Version, config.PublicGascityPackVersion)
+		t.Errorf("gc import version = %q, want %q", imp.Version, config.PublicGascityPackVersion)
 	}
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2846,7 +2846,7 @@ version = "` + config.BundledPackImportVersion + `"
 [imports.core]
 source = "https://github.com/gastownhall/gascity/tree/main/internal/bootstrap/packs/core"
 version = "` + config.BundledPackImportVersion + `"
-[imports.gascity]
+[imports.gc]
 source = "https://github.com/gastownhall/gascity-packs/tree/main/gascity"
 version = "` + config.PublicGascityPackVersion + `"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4305,7 +4305,7 @@ func GastownCity(name, provider, startCommand string) City {
 
 // GascityCityWithProviders returns a minimal managed city that imports the
 // public gascity planning/implementation skills pack: a single mayor agent
-// plus [imports.gascity] (skills and formulas) pinned to the registry release.
+// plus [imports.gc] (skills, formulas, and commands) pinned to the registry release.
 // The gascity formulas route their steps to role agents (gc.run-operator,
 // gc.requirements-planner, ...) that ship in the separate gc-roles subpack, so
 // the template also seeds that pack as a default rig import bound "gc" — every
@@ -4315,7 +4315,7 @@ func GastownCity(name, provider, startCommand string) City {
 func GascityCityWithProviders(name, defaultProvider string, providers []string) City {
 	city := WizardCityWithProviders(name, defaultProvider, providers)
 	city.Imports = map[string]Import{
-		"gascity": {
+		"gc": {
 			Source:  PublicGascityPackSource,
 			Version: PublicGascityPackVersion,
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1206,9 +1206,10 @@ func TestGastownCity(t *testing.T) {
 func TestGascityCitySeedsRolesDefaultRigImport(t *testing.T) {
 	c := GascityCityWithProviders("bright-lights", "claude", []string{"claude"})
 
-	// City-scope formulas/skills import is unchanged.
-	if len(c.Imports) != 1 || c.Imports["gascity"].Source != PublicGascityPackSource || c.Imports["gascity"].Version != PublicGascityPackVersion {
-		t.Errorf("Imports = %v, want gascity=%s %s", c.Imports, PublicGascityPackSource, PublicGascityPackVersion)
+	// City-scope formulas, skills, and commands use the gc binding expected by
+	// role prompts such as `gc gc claim`.
+	if len(c.Imports) != 1 || c.Imports["gc"].Source != PublicGascityPackSource || c.Imports["gc"].Version != PublicGascityPackVersion {
+		t.Errorf("Imports = %v, want gc=%s %s", c.Imports, PublicGascityPackSource, PublicGascityPackVersion)
 	}
 
 	// Roles ride along as a default rig import, bound "gc" so the formula's


### PR DESCRIPTION
## Summary
- Generated city configuration imports the public Gas City pack as `gascity` instead of its canonical `gc` binding.
- The import key was hard-coded as `gascity`; generate `gc` instead and update the init and configuration regression coverage.

## Testing
- Passed: `go test ./internal/config ./cmd/gc -run "TestDoInit(DefaultTemplateImportsGascityPack|ExplicitMinimalTemplateDoesNotImportGascityPack|WithGascityTemplate)|TestGascity"`

## Checklist
- [x] No issue needed — targeted bug fix.
- [x] Tests pass.
- [ ] Documentation updated.
- [ ] Breaking changes.