### PR TITLE
fix(beads): tolerate non-string bead metadata on decode (#3857) — v1.3.x cherry-pick

### DIFF
--- a/cmd/gc/cmd_hook_claim_metadata_test.go
+++ b/cmd/gc/cmd_hook_claim_metadata_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+// TestDecodeHookClaimBeadsToleratesNonStringMetadata pins the fix for the
+// rig-wide claim outage (gcw-d95): the external `bd` CLI type-infers
+// `--set-metadata key=true` as a JSON boolean (and numbers as JSON numbers),
+// so a single bead carrying such a value used to poison the whole work_query
+// decode with "cannot unmarshal bool into Go struct field Bead.metadata of
+// type string" — failing decodeHookClaimBeads for the entire batch and
+// blocking every worker in the rig from claiming any work.
+//
+// The decoder must tolerate non-string metadata values by coercing them to
+// their string form, exactly as beads.StringMap already does on the bd list
+// path.
+func TestDecodeHookClaimBeadsToleratesNonStringMetadata(t *testing.T) {
+	output := `[{"id":"gcw-1","metadata":{"refinery_reviewed":true,"count":42,"note":"ok"}}]`
+
+	got, err := decodeHookClaimBeads(output)
+	if err != nil {
+		t.Fatalf("decodeHookClaimBeads returned error on non-string metadata: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("decoded %d beads, want 1", len(got))
+	}
+
+	meta := got[0].Metadata
+	for _, tc := range []struct{ key, want string }{
+		{"refinery_reviewed", "true"},
+		{"count", "42"},
+		{"note", "ok"},
+	} {
+		if meta[tc.key] != tc.want {
+			t.Errorf("metadata[%q] = %q, want %q", tc.key, meta[tc.key], tc.want)
+		}
+	}
+}
+
+// TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch proves the batch-level
+// invariant that was the actual outage: a boolean-metadata bead sitting next to
+// ordinary beads must not drop the good beads from the claim candidate set.
+func TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch(t *testing.T) {
+	output := `[{"id":"a","metadata":{"note":"fine"}},{"id":"b","metadata":{"gc.parked":true}},{"id":"c"}]`
+
+	got, err := decodeHookClaimBeads(output)
+	if err != nil {
+		t.Fatalf("decodeHookClaimBeads returned error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("decoded %d beads, want 3 (one bool-metadata bead must not drop the batch)", len(got))
+	}
+	if got[1].Metadata["gc.parked"] != "true" {
+		t.Errorf("metadata[gc.parked] = %q, want %q", got[1].Metadata["gc.parked"], "true")
+	}
+}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -55,16 +55,24 @@ type Bead struct {
 	Priority  *int      `json:"priority,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	// UpdatedAt is zero for legacy beads; UpdatedBefore falls back to CreatedAt.
-	UpdatedAt    time.Time         `json:"updated_at,omitempty,omitzero"`
-	Assignee     string            `json:"assignee,omitempty"`
-	From         string            `json:"from,omitempty"`
-	ParentID     string            `json:"parent,omitempty"`      // step → molecule; matches bd wire format
-	Ref          string            `json:"ref,omitempty"`         // formula step ID or formula name
-	Needs        []string          `json:"needs,omitempty"`       // dependency step refs
-	Description  string            `json:"description,omitempty"` // step instructions
-	Labels       []string          `json:"labels,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	Dependencies []Dep             `json:"dependencies,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty,omitzero"`
+	Assignee    string    `json:"assignee,omitempty"`
+	From        string    `json:"from,omitempty"`
+	ParentID    string    `json:"parent,omitempty"`      // step → molecule; matches bd wire format
+	Ref         string    `json:"ref,omitempty"`         // formula step ID or formula name
+	Needs       []string  `json:"needs,omitempty"`       // dependency step refs
+	Description string    `json:"description,omitempty"` // step instructions
+	Labels      []string  `json:"labels,omitempty"`
+	// Metadata uses StringMap (not map[string]string) so decode tolerates the
+	// non-string JSON values the external bd CLI emits — `--set-metadata
+	// key=true` is type-inferred to a JSON boolean, and a strict decode of a
+	// single such bead used to poison the whole `gc hook --claim` work_query
+	// batch, blocking every worker in the rig from claiming. StringMap coerces
+	// bool/number values to their string form on decode and its underlying type
+	// is map[string]string, so every read/write call site is unaffected and the
+	// marshaled wire form is unchanged (still string-valued).
+	Metadata     StringMap `json:"metadata,omitempty"`
+	Dependencies []Dep     `json:"dependencies,omitempty"`
 	// Ephemeral routes the bead to the wisps tier on Create. Wisps live in
 	// a separate Dolt table, are not git-synced, and are eligible for TTL
 	// garbage collection. Reads must opt in via ListQuery.TierMode (or the


### PR DESCRIPTION
## Summary

Cherry-pick of `c02b3be84` (`fix(beads): tolerate non-string bead metadata on decode (#3857)`) onto `release/v1.3.0`.

**Why it matters on 1.3.x:** the bug reproduces on a fresh v1.3.5 deployment. `bd --set-metadata key=true` persists a JSON **boolean**, and `Bead.Metadata` being `map[string]string` makes one such bead fail the **whole** `work_query` batch decode (`json: cannot unmarshal bool into Go struct field Bead.metadata of type string`) — every worker sharing that query is blocked from claiming. Worse, `gc hook --claim` reports the failure only on stderr with exit 1 and empty stdout, which wrappers and worker prompts read as "no work", so rigs idle silently. Keys observed in the wild on 1.3.5: `branch_ready`.

## Changes

- `internal/beads/beads.go` — `Bead.Metadata` changed to `beads.StringMap` (byte-identical to the main commit).
- `cmd/gc/cmd_hook_claim_metadata_test.go` — regression tests from the main commit (new file, byte-identical).
- **Not carried over:** the main commit's edits to `internal/nudgequeue/store_test.go` and `internal/session/create_test.go`. Those test files do not exist on `release/v1.3.0` (modify/delete conflict), and the edits were trivial `map[string]string` → `beads.StringMap` type adjustments for main-only tests. Dropping them keeps this pick minimal; the core fix is untouched.

## Testing

- [x] `go build ./...` — clean on `release/v1.3.0`
- [x] `go vet ./cmd/gc ./internal/beads` — clean
- [x] `go test ./internal/beads -count=1` — pass
- [x] `go test ./cmd/gc -run Hook -count=1` — pass, including `TestDecodeHookClaimBeadsToleratesNonStringMetadata` and `TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch`

## Checklist

- [x] Linked an issue, or explained why one is not needed — #3857 (closed on main; this PR carries the fix to the stable line)
- [x] Added or updated tests for behavior changes — regression tests included in the original commit
- [x] Updated docs for user-facing changes — N/A (wire form unchanged; StringMap marshals identically)
- [x] Called out breaking changes or migration notes — deviation from byte-identical documented above
