### PR TITLE
test: avoid redundant cmd/gc integration discovery builds

### DIFF
--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -102,8 +102,8 @@ rest_smoke_tests=(
 )
 
 # These are the top-level tests contributed only when cmd/gc is built with the
-# integration tag. Keep this manifest exact: validate_cmd_gc_integration_tests
-# compares it with Go's tagged and untagged discovery before executing it.
+# integration tag. Keep this manifest exact; scripts tests compare it with the
+# canonical linux/amd64 shard's tagged source declarations.
 cmd_gc_integration_tests=(
   TestCapstoneIntegrationRealMinter
   TestControllerDiscoversAddedCronOrderWithoutRestart
@@ -173,61 +173,6 @@ validate_modulo_shard() {
 
 list_integration_tests() {
   run_go_test -tags integration -list '^Test' "$pkg" | grep '^Test'
-}
-
-list_package_tests() {
-  local test_pkg="$1"
-  shift
-  local output line found
-
-  if ! output="$(run_go_test "$@" -list '^Test' "$test_pkg" 2>&1)"; then
-    echo "go test -list failed for ${test_pkg}; output:" >&2
-    printf '%s\n' "$output" >&2
-    return 1
-  fi
-  found=0
-  while IFS= read -r line; do
-    [[ "$line" == Test* ]] || continue
-    printf '%s\n' "$line"
-    found=1
-  done <<< "$output"
-  if [[ $found -eq 0 ]]; then
-    echo "no tests discovered for ${test_pkg}; go test -list output:" >&2
-    printf '%s\n' "$output" >&2
-    return 1
-  fi
-}
-
-validate_cmd_gc_integration_tests() {
-  local untagged tagged actual expected test_name drift
-
-  untagged="$(list_package_tests ./cmd/gc)"
-  tagged="$(list_package_tests ./cmd/gc -tags integration)"
-  actual="$(
-    comm -13 \
-      <(printf '%s\n' "$untagged" | LC_ALL=C sort -u) \
-      <(printf '%s\n' "$tagged" | LC_ALL=C sort -u)
-  )"
-  expected="$(printf '%s\n' "${cmd_gc_integration_tests[@]}" | LC_ALL=C sort -u)"
-  drift=0
-
-  while IFS= read -r test_name; do
-    [[ -n "$test_name" ]] || continue
-    if ! printf '%s\n' "$expected" | grep -Fxq -- "$test_name"; then
-      echo "unassigned cmd/gc integration test: ${test_name}" >&2
-      drift=1
-    fi
-  done <<< "$actual"
-  for test_name in "${cmd_gc_integration_tests[@]}"; do
-    if ! printf '%s\n' "$actual" | grep -Fxq -- "$test_name"; then
-      echo "cmd/gc integration manifest entry is not integration-only: ${test_name}" >&2
-      drift=1
-    fi
-  done
-  if [[ $drift -ne 0 ]]; then
-    echo "update cmd_gc_integration_tests in scripts/test-integration-shard" >&2
-    return 1
-  fi
 }
 
 validate_selected_tests() {
@@ -406,7 +351,6 @@ case "$shard" in
     run_packages_shard
     ;;
   packages-cmd-gc-integration)
-    validate_cmd_gc_integration_tests
     run_pkg_tests ./cmd/gc "${cmd_gc_integration_tests[@]}"
     ;;
   review-formulas)

--- a/scripts/test_integration_shard_test.go
+++ b/scripts/test_integration_shard_test.go
@@ -1,15 +1,24 @@
 package scripts_test
 
 import (
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"unicode"
+	"unicode/utf8"
 )
 
 func TestCmdGCIntegrationShardRunsOnlyIntegrationManifest(t *testing.T) {
-	fixture := newIntegrationShardFixture(t, nil)
+	repo := repoRoot(t)
+	manifest := parseCmdGCIntegrationManifest(t, filepath.Join(repo, "scripts", "test-integration-shard"))
+	fixture := newIntegrationShardFixture(t)
 
 	out, err := fixture.run(t)
 	if err != nil {
@@ -20,32 +29,293 @@ func TestCmdGCIntegrationShardRunsOnlyIntegrationManifest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read captured go invocation: %v", err)
 	}
-	invocation := string(captured)
-	for _, testName := range []string{
-		"TestCapstoneIntegrationRealMinter",
-		"TestControllerDiscoversAddedCronOrderWithoutRestart",
-		"TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind",
-		"TestPhase2WorkerCoreRealTransportProof",
-	} {
-		if !strings.Contains(invocation, testName) {
-			t.Errorf("final go test invocation missing %s:\n%s", testName, invocation)
-		}
+	encodedInvocations := strings.TrimSuffix(string(captured), "\x00\x00")
+	invocations := strings.Split(encodedInvocations, "\x00\x00")
+	if len(invocations) != 1 {
+		t.Fatalf("go test invoked %d times, want only the final tagged manifest command:\n%s", len(invocations), captured)
 	}
-	if strings.Contains(invocation, "TestOrdinaryUnit") {
-		t.Fatalf("final go test invocation includes ordinary unit test:\n%s", invocation)
+	got := strings.Split(invocations[0], "\x00")
+	want := []string{
+		"test",
+		"-tags", "integration",
+		"-timeout", "17s",
+		"./cmd/gc",
+		"-run", "^(" + strings.Join(manifest, "|") + ")$",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("go test argv = %q, want exact tagged manifest command %q", got, want)
 	}
 }
 
-func TestCmdGCIntegrationShardRejectsUnassignedTaggedTest(t *testing.T) {
-	fixture := newIntegrationShardFixture(t, []string{"TestNewIntegrationProof"})
+func TestCmdGCIntegrationManifestMatchesTaggedDeclarations(t *testing.T) {
+	repo := repoRoot(t)
+	manifest := parseCmdGCIntegrationManifest(t, filepath.Join(repo, "scripts", "test-integration-shard"))
+	declared := discoverCmdGCIntegrationTests(t, filepath.Join(repo, "cmd", "gc"))
 
-	out, err := fixture.run(t)
-	if err == nil {
-		t.Fatalf("test-integration-shard succeeded with an unassigned tagged test:\n%s", out)
+	if drift := cmdGCIntegrationManifestDrift(manifest, declared); len(drift) != 0 {
+		t.Fatalf("cmd/gc integration manifest drift:\n%s\nupdate cmd_gc_integration_tests in scripts/test-integration-shard", strings.Join(drift, "\n"))
 	}
-	if !strings.Contains(string(out), "unassigned cmd/gc integration test: TestNewIntegrationProof") {
-		t.Fatalf("failure does not identify manifest drift:\n%s", out)
+}
+
+func TestCmdGCIntegrationManifestDriftDiagnosesBothDirections(t *testing.T) {
+	manifest := []string{"TestKept", "TestStale", "TestStale"}
+	declared := []string{"TestKept", "TestNew"}
+	want := []string{
+		"duplicate cmd/gc integration manifest entry: TestStale",
+		"unassigned cmd/gc integration test: TestNew",
+		"cmd/gc integration manifest entry is not integration-only: TestStale",
 	}
+
+	if got := cmdGCIntegrationManifestDrift(manifest, declared); !slices.Equal(got, want) {
+		t.Fatalf("manifest drift diagnostics = %q, want %q", got, want)
+	}
+}
+
+func TestCmdGCIntegrationDiscoveryUsesCanonicalLinuxPlatform(t *testing.T) {
+	context := canonicalCmdGCIntegrationBuildContext()
+	if context.GOOS != "linux" || context.GOARCH != "amd64" {
+		t.Fatalf("cmd/gc integration build target = %s/%s, want linux/amd64", context.GOOS, context.GOARCH)
+	}
+
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "linux_integration_test.go"), `//go:build integration && linux
+
+package fixture
+
+import "testing"
+
+func TestLinux(t *testing.T) {}
+`)
+	writeTestFile(t, filepath.Join(dir, "darwin_integration_test.go"), `//go:build integration && darwin
+
+package fixture
+
+import "testing"
+
+func TestDarwin(t *testing.T) {}
+`)
+
+	if got, want := discoverCmdGCIntegrationTests(t, dir), []string{"TestLinux"}; !slices.Equal(got, want) {
+		t.Fatalf("canonical linux/amd64 integration tests = %q, want %q", got, want)
+	}
+}
+
+func TestCmdGCIntegrationDiscoveryDistinguishesTestMainHarness(t *testing.T) {
+	t.Run("ordinary test", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestFile(t, filepath.Join(dir, "ordinary_integration_test.go"), `//go:build integration
+
+package fixture
+
+import "testing"
+
+func TestMain(*testing.T) {}
+`)
+
+		if got, want := discoverCmdGCIntegrationTests(t, dir), []string{"TestMain"}; !slices.Equal(got, want) {
+			t.Fatalf("integration tests = %q, want ordinary TestMain included as %q", got, want)
+		}
+	})
+
+	t.Run("test harness", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestFile(t, filepath.Join(dir, "harness_integration_test.go"), `//go:build integration
+
+package fixture
+
+import "testing"
+
+func TestMain(m *testing.M) {}
+func TestOrdinary(t *testing.T) {}
+`)
+
+		if got, want := discoverCmdGCIntegrationTests(t, dir), []string{"TestOrdinary"}; !slices.Equal(got, want) {
+			t.Fatalf("integration tests = %q, want harness excluded and ordinary test %q", got, want)
+		}
+	})
+}
+
+func parseCmdGCIntegrationManifest(t *testing.T, path string) []string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cmd/gc integration manifest: %v", err)
+	}
+
+	const declaration = "cmd_gc_integration_tests=("
+	inManifest := false
+	var tests []string
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if !inManifest {
+			if line == declaration {
+				inManifest = true
+			}
+			continue
+		}
+		if line == ")" {
+			if len(tests) == 0 {
+				t.Fatal("cmd_gc_integration_tests is empty")
+			}
+			return tests
+		}
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 1 {
+			t.Fatalf("unsupported cmd_gc_integration_tests entry %q", rawLine)
+		}
+		testName := strings.Trim(fields[0], "'\"")
+		if !isGoTestName(testName) {
+			t.Fatalf("invalid cmd_gc_integration_tests entry %q", testName)
+		}
+		tests = append(tests, testName)
+	}
+	if !inManifest {
+		t.Fatalf("%s not found in %s", declaration, path)
+	}
+	t.Fatalf("unterminated %s in %s", declaration, path)
+	return nil
+}
+
+func discoverCmdGCIntegrationTests(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read cmd/gc directory: %v", err)
+	}
+
+	withoutIntegration := canonicalCmdGCIntegrationBuildContext()
+	withIntegration := withoutIntegration
+	withIntegration.BuildTags = []string{"integration"}
+
+	fileSet := token.NewFileSet()
+	var tests []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		tagged, err := withIntegration.MatchFile(dir, name)
+		if err != nil {
+			t.Fatalf("match tagged cmd/gc file %s: %v", name, err)
+		}
+		untagged, err := withoutIntegration.MatchFile(dir, name)
+		if err != nil {
+			t.Fatalf("match untagged cmd/gc file %s: %v", name, err)
+		}
+		if !tagged || untagged {
+			continue
+		}
+
+		path := filepath.Join(dir, name)
+		parsed, err := parser.ParseFile(fileSet, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse integration-only cmd/gc file %s: %v", name, err)
+		}
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if ok && function.Recv == nil && isGoTestName(function.Name.Name) && isGoTestFunc(function, "T") {
+				tests = append(tests, function.Name.Name)
+			}
+		}
+	}
+	slices.Sort(tests)
+	return tests
+}
+
+func canonicalCmdGCIntegrationBuildContext() build.Context {
+	context := build.Default
+	context.GOOS = "linux"
+	context.GOARCH = "amd64"
+	context.Compiler = "gc"
+	context.CgoEnabled = true
+	context.BuildTags = nil
+	context.ToolTags = nil
+	return context
+}
+
+func isGoTestName(name string) bool {
+	if !strings.HasPrefix(name, "Test") {
+		return false
+	}
+	runeAfterPrefix, _ := utf8.DecodeRuneInString(strings.TrimPrefix(name, "Test"))
+	return !unicode.IsLower(runeAfterPrefix)
+}
+
+func isGoTestFunc(function *ast.FuncDecl, parameterType string) bool {
+	if function.Type.TypeParams != nil && len(function.Type.TypeParams.List) != 0 {
+		return false
+	}
+	if function.Type.Results != nil && len(function.Type.Results.List) != 0 {
+		return false
+	}
+	if function.Type.Params == nil || len(function.Type.Params.List) != 1 {
+		return false
+	}
+	parameter := function.Type.Params.List[0]
+	if len(parameter.Names) > 1 {
+		return false
+	}
+	pointer, ok := parameter.Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	switch target := pointer.X.(type) {
+	case *ast.Ident:
+		return target.Name == parameterType
+	case *ast.SelectorExpr:
+		return target.Sel.Name == parameterType
+	default:
+		return false
+	}
+}
+
+func cmdGCIntegrationManifestDrift(manifest, declared []string) []string {
+	manifestSet := make(map[string]struct{}, len(manifest))
+	var duplicates []string
+	for _, testName := range manifest {
+		if _, exists := manifestSet[testName]; exists {
+			if !slices.Contains(duplicates, testName) {
+				duplicates = append(duplicates, testName)
+			}
+			continue
+		}
+		manifestSet[testName] = struct{}{}
+	}
+	slices.Sort(duplicates)
+	declaredSet := make(map[string]struct{}, len(declared))
+	for _, testName := range declared {
+		declaredSet[testName] = struct{}{}
+	}
+
+	var unassigned []string
+	for testName := range declaredSet {
+		if _, ok := manifestSet[testName]; !ok {
+			unassigned = append(unassigned, testName)
+		}
+	}
+	slices.Sort(unassigned)
+	var stale []string
+	for testName := range manifestSet {
+		if _, ok := declaredSet[testName]; !ok {
+			stale = append(stale, testName)
+		}
+	}
+	slices.Sort(stale)
+
+	drift := make([]string, 0, len(duplicates)+len(unassigned)+len(stale))
+	for _, testName := range duplicates {
+		drift = append(drift, "duplicate cmd/gc integration manifest entry: "+testName)
+	}
+	for _, testName := range unassigned {
+		drift = append(drift, "unassigned cmd/gc integration test: "+testName)
+	}
+	for _, testName := range stale {
+		drift = append(drift, "cmd/gc integration manifest entry is not integration-only: "+testName)
+	}
+	return drift
 }
 
 type integrationShardFixture struct {
@@ -54,7 +324,7 @@ type integrationShardFixture struct {
 	capturePath string
 }
 
-func newIntegrationShardFixture(t *testing.T, extraTaggedTests []string) integrationShardFixture {
+func newIntegrationShardFixture(t *testing.T) integrationShardFixture {
 	t.Helper()
 
 	tmp := t.TempDir()
@@ -63,19 +333,6 @@ func newIntegrationShardFixture(t *testing.T, extraTaggedTests []string) integra
 		t.Fatalf("mkdir fake bin: %v", err)
 	}
 	capturePath := filepath.Join(tmp, "go-test.capture")
-	taggedTests := append([]string{
-		"TestOrdinaryUnit",
-		"TestCapstoneIntegrationRealMinter",
-		"TestControllerDiscoversAddedCronOrderWithoutRestart",
-		"TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind",
-		"TestPhase2WorkerCoreRealTransportProof",
-	}, extraTaggedTests...)
-	var taggedOutput strings.Builder
-	for _, testName := range taggedTests {
-		taggedOutput.WriteString("          echo ")
-		taggedOutput.WriteString(shellQuote(testName))
-		taggedOutput.WriteString("\n")
-	}
 
 	writeExecutable(t, filepath.Join(binDir, "go"), `#!/usr/bin/env bash
 set -euo pipefail
@@ -94,22 +351,14 @@ case "$1" in
     esac
     ;;
   test)
-    is_list=0
-    is_integration=0
-    previous=""
     for arg in "$@"; do
-      [[ "$arg" == "-list" ]] && is_list=1
-      [[ "$previous" == "-tags" && "$arg" == "integration" ]] && is_integration=1
-      previous="$arg"
-    done
-    if [[ "$is_list" == 1 ]]; then
-      if [[ "$is_integration" == 1 ]]; then
-`+taggedOutput.String()+`      else
-        echo TestOrdinaryUnit
+      if [[ "$arg" == "-list" ]]; then
+        echo "go test -list must not run" >&2
+        exit 97
       fi
-      exit 0
-    fi
-    printf '%s\n' "$*" > "$capture_path"
+    done
+    printf '%s\0' "$@" >> "$capture_path"
+    printf '\0' >> "$capture_path"
     ;;
   *)
     echo "unexpected go command: $*" >&2
@@ -138,6 +387,7 @@ func (f integrationShardFixture) run(t *testing.T) ([]byte, error) {
 		"HOME=" + f.homeDir,
 		"GC_TEST_NO_SLICE=1",
 		"SYS_USR_CGO_FALLBACK=0",
+		"GO_TEST_TIMEOUT=17s",
 	}
 	return cmd.CombinedOutput()
 }


### PR DESCRIPTION
## Summary

- Move the `cmd/gc` integration-manifest drift check from the runtime integration shard into the fast `scripts` Go test package.
- Discover integration-only tests from source with a canonical Linux/amd64 build context and Go-compatible `TestMain` handling.
- Keep the runtime shard to one exact `go test -tags integration` invocation over the same four integration journeys.

## Measured bottleneck

Observed on the required `packages-cmd-gc-integration` job in #4510:

| Phase | Time |
| --- | ---: |
| Whole job | 3m38s |
| Setup | 1m58s |
| Two manifest-only discovery builds | 42.716s |
| Four real integration tests | 46.489s |

This removes the observed **42.716s gross validator cost**. The expected job time is roughly **3m38s → 2m55s**, but post-change CI is authoritative because the removed builds may also have warmed Go's compile cache.

## Assertion migration

| Safety property | Before | After |
| --- | --- | --- |
| Exact integration-only inventory | Two runtime `go test -list` builds and a shell set comparison | Fast AST/build-tag guard diagnoses duplicate, unassigned, and stale entries |
| Go discovery edge cases | Implicit in `go test -list` | Signature-aware fixtures include `TestMain(*testing.T)`, exclude `TestMain(*testing.M)`, and accept unnamed test parameters |
| Cross-platform determinism | Depended on the host running validation | Canonical Linux/amd64 inventory with Linux/Darwin-tagged regression fixtures |
| Runtime selection | Substring assertions over a flattened command | NUL-framed argv comparison proves one exact tagged command and exact anchored `-run` expression |
| Integration behavior | Four real tests | The same four real tests, unchanged |

## Verification

- `GOFLAGS=-mod=readonly go test -count=1 ./scripts -run '^TestCmdGCIntegration'` — pass (0.088s)
- `GOFLAGS=-mod=readonly go test -race -count=1 ./scripts -run '^TestCmdGCIntegration'` — pass (1.235s)
- `GOFLAGS=-mod=readonly go test -count=1 ./scripts` — pass (41.792s)
- Resource census — pass (3.157s)
- `make test-fast-parallel` — all eight jobs pass
- `go vet ./scripts`, Bash syntax, and `git diff --check` — pass
- Repository pre-commit and pre-push hooks — pass
- Two independent exact-patch council reviews — approve

The real shard now reaches `Running shard...` immediately instead of performing the two discovery builds. Three unchanged integration owners passed locally in 22.135s of test time. The managed-Dolt owner cannot complete in this checkout because the locally installed `bd` creates schema v55 while the base native library accepts v53; that environment mismatch occurs before this test-only change and CI remains the authoritative managed-Dolt run.

Tracks `ga-yrotsuu.7`.
