### PR TITLE
test: isolate tmux cleanup diagnostics from command stderr

### DIFF
--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -11,8 +11,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/test/tmuxtest"
 	"github.com/spf13/cobra"
 )
 
@@ -267,6 +269,10 @@ type packCommandProcessResult struct {
 }
 
 func runPackCommandProcess(t *testing.T, cityPath, scenario string, args ...string) packCommandProcessResult {
+	return runPackCommandProcessWithEnv(t, cityPath, scenario, nil, args...)
+}
+
+func runPackCommandProcessWithEnv(t *testing.T, cityPath, scenario string, extraEnv []string, args ...string) packCommandProcessResult {
 	t.Helper()
 	afterRun := filepath.Join(t.TempDir(), "after-run")
 	commandArgs := []string{
@@ -279,7 +285,7 @@ func runPackCommandProcess(t *testing.T, cityPath, scenario string, args ...stri
 	commandArgs = append(commandArgs, args...)
 	cmd := exec.Command(os.Args[0], commandArgs...)
 	cmd.Dir = cityPath
-	cmd.Env = packCommandProcessEnv()
+	cmd.Env = packCommandProcessEnv(extraEnv...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -296,6 +302,34 @@ func runPackCommandProcess(t *testing.T, cityPath, scenario string, args ...stri
 		t.Fatalf("post-run marker = %q, err=%v; run did not return through deferred lifecycle", got, err)
 	}
 	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stderr.String()}
+}
+
+const testTmuxSocketParentRootEnv = "GC_TEST_TMUX_SOCKET_PARENT_ROOT"
+
+func createAgedFreeTmuxSocketParent(t *testing.T) (string, string) {
+	t.Helper()
+	const fakePID = 2147483647 // Above the Linux and Darwin process-ID ranges.
+	root, err := os.MkdirTemp("/tmp", "gctroot-*")
+	if err != nil {
+		t.Fatalf("create isolated tmux socket-parent root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	dir, err := os.MkdirTemp(root, fmt.Sprintf("%s%d-*", tmuxtest.SocketParentDirPrefix, fakePID))
+	if err != nil {
+		t.Fatalf("create orphaned tmux socket parent: %v", err)
+	}
+	sentinel, err := tmuxtest.HoldAliveSentinel(dir)
+	if err != nil {
+		t.Fatalf("hold orphaned tmux socket sentinel: %v", err)
+	}
+	if err := sentinel.Close(); err != nil {
+		t.Fatalf("release orphaned tmux socket sentinel: %v", err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatalf("backdate orphaned tmux socket parent: %v", err)
+	}
+	return root, dir
 }
 
 func setupPackExitCity(t *testing.T) string {
@@ -2289,7 +2323,13 @@ func TestPackCommandExitReturnsThroughRun(t *testing.T) {
 
 	for _, scenario := range []string{"eager", "lazy"} {
 		t.Run(scenario, func(t *testing.T) {
-			result := runPackCommandProcess(t, cityPath, scenario, "backstage", "hello")
+			root, orphan := createAgedFreeTmuxSocketParent(t)
+			result := runPackCommandProcessWithEnv(t, cityPath, scenario, []string{
+				testTmuxSocketParentRootEnv + "=" + root,
+			}, "backstage", "hello")
+			if _, err := os.Stat(orphan); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("child TestMain did not remove eligible tmux socket parent %q: %v", orphan, err)
+			}
 			if result.exitCode != 42 {
 				t.Fatalf("helper exit code = %d, want 42; stdout=%q stderr=%q", result.exitCode, result.stdout, result.stderr)
 			}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -243,7 +243,11 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv("TMPDIR", testTempRoot); err != nil {
 		panic(err)
 	}
-	tmuxSocketRoot, tmuxSocketCleanupRoot, tmuxSentinel, err := cmdGCTmuxSocketRoot(testTempRoot)
+	tmuxSocketParentRoot := os.Getenv(testTmuxSocketParentRootEnv)
+	if tmuxSocketParentRoot == "" {
+		tmuxSocketParentRoot = "/tmp"
+	}
+	tmuxSocketRoot, tmuxSocketCleanupRoot, tmuxSentinel, err := cmdGCTmuxSocketRoot(testTempRoot, tmuxSocketParentRoot)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -33,15 +33,16 @@ func shortSocketTempDir(t *testing.T, prefix string) string {
 	return testutil.ShortTempDir(t, prefix)
 }
 
-// cmdGCTmuxSocketRoot returns a short-path tmux socket root under /tmp (not
-// testTempRoot, which can be an arbitrarily long macOS $TMPDIR path that
-// blows Unix socket path limits), plus the parent dir to remove at teardown
-// and the *os.File holding its alive sentinel. The sentinel must stay
-// referenced by the caller for the process lifetime so a concurrent sibling
-// run's orphan sweep (tmuxtest.SweepOrphanPIDPrefixedDirs, invoked inside
-// NewSocketParentDir) does not reclaim this still-active directory.
-func cmdGCTmuxSocketRoot(testTempRoot string) (string, string, *os.File, error) {
-	parent, sentinel, err := tmuxtest.NewSocketParentDir("/tmp")
+// cmdGCTmuxSocketRoot returns a tmux socket root under socketParentRoot.
+// TestMain normally supplies /tmp rather than testTempRoot, which can be an
+// arbitrarily long macOS $TMPDIR path that blows Unix socket path limits. It
+// also returns the parent dir to remove at teardown and the *os.File holding
+// its alive sentinel. The sentinel must stay referenced by the caller for the
+// process lifetime so a concurrent sibling run's orphan sweep
+// (tmuxtest.SweepOrphanPIDPrefixedDirs, invoked inside NewSocketParentDir)
+// does not reclaim this still-active directory.
+func cmdGCTmuxSocketRoot(testTempRoot, socketParentRoot string) (string, string, *os.File, error) {
+	parent, sentinel, err := tmuxtest.NewSocketParentDir(socketParentRoot, io.Discard)
 	if err != nil {
 		root := filepath.Join(testTempRoot, "tmux")
 		if err := os.MkdirAll(root, 0o700); err != nil {

--- a/cmd/gc/test_orphan_sweep_branches_test.go
+++ b/cmd/gc/test_orphan_sweep_branches_test.go
@@ -70,7 +70,7 @@ func TestCmdGCTestTempRootPrefixUsesShardPrefix(t *testing.T) {
 func TestCmdGCTmuxSocketRootUsesShortPath(t *testing.T) {
 	longMacRoot := filepath.Join("/private/var/folders/pm/cmklcsfj60nd7nfc79g8xmbc0000gn/T", "gcx12345-1234567890")
 
-	root, cleanupRoot, sentinel, err := cmdGCTmuxSocketRoot(longMacRoot)
+	root, cleanupRoot, sentinel, err := cmdGCTmuxSocketRoot(longMacRoot, "/tmp")
 	if err != nil {
 		t.Fatalf("cmdGCTmuxSocketRoot: %v", err)
 	}

--- a/internal/runtime/tmux/main_test.go
+++ b/internal/runtime/tmux/main_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +25,7 @@ func TestMain(m *testing.M) {
 	// unreachable os.Files, which would close the descriptor and release
 	// the lock, letting a concurrent sibling's sweep reclaim this still-
 	// active directory (ga-djbcqt).
-	tmuxSocketParent, sentinel, err := tmuxtest.NewSocketParentDir("/tmp")
+	tmuxSocketParent, sentinel, err := tmuxtest.NewSocketParentDir("/tmp", io.Discard)
 	if err != nil {
 		panic("tmux tests: creating socket parent: " + err.Error())
 	}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -118,7 +118,7 @@ func TestMain(m *testing.M) {
 	// skips defers, so those paths remove the parent explicitly below; the
 	// deferred removal here additionally covers a setup panic (which unwinds
 	// through defers) so it cannot leak the parent until a later aged sweep.
-	tmuxSocketParent, tmuxSentinel, tmuxParentErr := tmuxtest.NewSocketParentDir("/tmp")
+	tmuxSocketParent, tmuxSentinel, tmuxParentErr := tmuxtest.NewSocketParentDir("/tmp", io.Discard)
 	tmuxSocketAliveSentinel = tmuxSentinel
 	defer func() {
 		// Re-read tmuxSocketParent so the MkdirAll-failure path that clears it

--- a/test/tmuxtest/orphan_sweep.go
+++ b/test/tmuxtest/orphan_sweep.go
@@ -2,6 +2,7 @@ package tmuxtest
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -123,8 +124,12 @@ func pidFromPrefixedDirName(name, prefix string) (int, bool) {
 // HoldAliveSentinel; legacy pre-sweep names with no "-" after the PID are
 // rejected by pidFromPrefixedDirName and never swept here. Dirs younger than
 // socketParentSweepMinAge are never touched, covering the window before a
-// sibling run's sentinel exists.
-func SweepOrphanPIDPrefixedDirs(root, prefix string) {
+// sibling run's sentinel exists. Each removal is described on diagnostics;
+// callers that do not surface cleanup logs should pass io.Discard.
+func SweepOrphanPIDPrefixedDirs(root, prefix string, diagnostics io.Writer) {
+	if diagnostics == nil {
+		diagnostics = io.Discard
+	}
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		return
@@ -165,7 +170,7 @@ func SweepOrphanPIDPrefixedDirs(root, prefix string) {
 		}
 		// Name each removal so a recurrence of ga-djbcqt is attributable
 		// from run logs instead of gate-log forensics.
-		fmt.Fprintf(os.Stderr, "tmuxtest: removing orphaned socket parent %s (%s)\n", path, reason)
+		_, _ = fmt.Fprintf(diagnostics, "tmuxtest: removing orphaned socket parent %s (%s)\n", path, reason)
 		_ = os.RemoveAll(path)
 	}
 }
@@ -175,9 +180,10 @@ func SweepOrphanPIDPrefixedDirs(root, prefix string) {
 // fresh one plus the *os.File holding its alive sentinel. The caller must
 // keep the returned file referenced for as long as dir must stay protected
 // from a concurrent sibling's sweep -- the runtime finalizes unreachable
-// os.Files, which releases the flock.
-func NewSocketParentDir(root string) (dir string, sentinel *os.File, err error) {
-	SweepOrphanPIDPrefixedDirs(root, SocketParentDirPrefix)
+// os.Files, which releases the flock. Sweep removal messages are written to
+// diagnostics.
+func NewSocketParentDir(root string, diagnostics io.Writer) (dir string, sentinel *os.File, err error) {
+	SweepOrphanPIDPrefixedDirs(root, SocketParentDirPrefix, diagnostics)
 	dir, err = os.MkdirTemp(root, PIDPrefixedTempPattern(SocketParentDirPrefix))
 	if err != nil {
 		return "", nil, err

--- a/test/tmuxtest/orphan_sweep_sigkill_test.go
+++ b/test/tmuxtest/orphan_sweep_sigkill_test.go
@@ -3,6 +3,7 @@ package tmuxtest
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -123,7 +124,7 @@ func TestSweepOrphanReapsRealSIGKILLedProcess(t *testing.T) {
 		t.Fatalf("orphaned dirs before sweep = %d, want 1", got)
 	}
 
-	SweepOrphanPIDPrefixedDirs(root, prefix)
+	SweepOrphanPIDPrefixedDirs(root, prefix, io.Discard)
 
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Errorf("SIGKILL'd process's socket parent dir survived sweep: %s", dir)
@@ -134,7 +135,7 @@ func TestSweepOrphanReapsRealSIGKILLedProcess(t *testing.T) {
 
 	// A subsequent legitimate creation must succeed and leave the leak
 	// count tightly bounded at exactly the one dir it owns.
-	newDir, sentinel, err := NewSocketParentDir(root)
+	newDir, sentinel, err := NewSocketParentDir(root, io.Discard)
 	if err != nil {
 		t.Fatalf("NewSocketParentDir after reap: %v", err)
 	}

--- a/test/tmuxtest/orphan_sweep_test.go
+++ b/test/tmuxtest/orphan_sweep_test.go
@@ -1,6 +1,9 @@
 package tmuxtest
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -39,12 +42,12 @@ func pidPrefixedTestDir(t *testing.T, root, prefix string, pid int) string {
 	return dir
 }
 
-func TestSweepOrphanPIDPrefixedDirsRemovesStaleDeadPID(t *testing.T) {
+func TestSweepOrphanPIDPrefixedDirsRemovesStaleDeadPIDWithNilDiagnostics(t *testing.T) {
 	root := t.TempDir()
 	dir := pidPrefixedTestDir(t, root, "pfx-", nonLivePID(t))
 	backdatePastSweepAge(t, dir)
 
-	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+	SweepOrphanPIDPrefixedDirs(root, "pfx-", nil)
 
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Errorf("stale dead-PID dir survived sweep: %s", dir)
@@ -62,7 +65,7 @@ func TestSweepOrphanPIDPrefixedDirsPreservesHeldSentinel(t *testing.T) {
 	}
 	defer func() { _ = sentinel.Close() }()
 
-	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+	SweepOrphanPIDPrefixedDirs(root, "pfx-", io.Discard)
 
 	if _, err := os.Stat(dir); err != nil {
 		t.Errorf("dir with held sentinel was removed by sweep: %v", err)
@@ -81,10 +84,15 @@ func TestSweepOrphanPIDPrefixedDirsRemovesFreeSentinel(t *testing.T) {
 
 	backdatePastSweepAge(t, dir)
 
-	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+	var diagnostics bytes.Buffer
+	SweepOrphanPIDPrefixedDirs(root, "pfx-", &diagnostics)
 
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Errorf("dir with free sentinel survived sweep: %s", dir)
+	}
+	wantDiagnostics := fmt.Sprintf("tmuxtest: removing orphaned socket parent %s (free sentinel)\n", dir)
+	if got := diagnostics.String(); got != wantDiagnostics {
+		t.Errorf("diagnostics = %q, want %q", got, wantDiagnostics)
 	}
 }
 
@@ -93,7 +101,7 @@ func TestSweepOrphanPIDPrefixedDirsSkipsYoungDir(t *testing.T) {
 	dir := pidPrefixedTestDir(t, root, "pfx-", nonLivePID(t))
 	// No backdate: dir is fresh, inside the min-age window.
 
-	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+	SweepOrphanPIDPrefixedDirs(root, "pfx-", io.Discard)
 
 	if _, err := os.Stat(dir); err != nil {
 		t.Errorf("young dir was removed by sweep despite age guard: %v", err)
@@ -105,7 +113,7 @@ func TestSweepOrphanPIDPrefixedDirsSkipsSelfPID(t *testing.T) {
 	dir := pidPrefixedTestDir(t, root, "pfx-", os.Getpid())
 	backdatePastSweepAge(t, dir)
 
-	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+	SweepOrphanPIDPrefixedDirs(root, "pfx-", io.Discard)
 
 	if _, err := os.Stat(dir); err != nil {
 		t.Errorf("sweep removed a dir carrying its own PID: %v", err)
@@ -118,7 +126,7 @@ func TestSweepOrphanPIDPrefixedDirsSkipsNonDirectories(t *testing.T) {
 	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+	SweepOrphanPIDPrefixedDirs(root, "pfx-", io.Discard)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Error("SweepOrphanPIDPrefixedDirs removed a non-directory file")
 	}
@@ -127,7 +135,7 @@ func TestSweepOrphanPIDPrefixedDirsSkipsNonDirectories(t *testing.T) {
 func TestNewSocketParentDirCreatesSentinelHeldDir(t *testing.T) {
 	root := t.TempDir()
 
-	dir, sentinel, err := NewSocketParentDir(root)
+	dir, sentinel, err := NewSocketParentDir(root, io.Discard)
 	if err != nil {
 		t.Fatalf("NewSocketParentDir: %v", err)
 	}
@@ -152,7 +160,8 @@ func TestNewSocketParentDirReapsOrphanedSibling(t *testing.T) {
 	orphan := pidPrefixedTestDir(t, root, SocketParentDirPrefix, nonLivePID(t))
 	backdatePastSweepAge(t, orphan)
 
-	dir, sentinel, err := NewSocketParentDir(root)
+	var diagnostics bytes.Buffer
+	dir, sentinel, err := NewSocketParentDir(root, &diagnostics)
 	if err != nil {
 		t.Fatalf("NewSocketParentDir: %v", err)
 	}
@@ -164,6 +173,10 @@ func TestNewSocketParentDirReapsOrphanedSibling(t *testing.T) {
 	}
 	if _, err := os.Stat(dir); err != nil {
 		t.Errorf("freshly created dir missing: %v", err)
+	}
+	wantDiagnostics := fmt.Sprintf("tmuxtest: removing orphaned socket parent %s (pid dead, no sentinel)\n", orphan)
+	if got := diagnostics.String(); got != wantDiagnostics {
+		t.Errorf("diagnostics = %q, want %q", got, wantDiagnostics)
 	}
 }
 
@@ -182,7 +195,7 @@ func TestSweepOrphanPIDPrefixedDirsPreservesLegacyNoDashDir(t *testing.T) {
 	}
 	backdatePastSweepAge(t, legacy)
 
-	SweepOrphanPIDPrefixedDirs(root, "pfx-")
+	SweepOrphanPIDPrefixedDirs(root, "pfx-", io.Discard)
 
 	if _, err := os.Stat(legacy); err != nil {
 		t.Errorf("legacy no-separator dir was removed by sweep: %v", err)


### PR DESCRIPTION
## Summary

- Route tmux orphan-sweep diagnostics through an explicit harness-owned writer.
- Keep command and integration harness cleanup out of application stderr.
- Add a deterministic child-process regression using a private per-invocation socket-parent root.

## Root cause

Recursive `cmd/gc` helpers execute package `TestMain` before the command under test. Its orphan sweep wrote cleanup messages directly to process `os.Stderr`, so exact CLI stderr assertions depended on whether hour-old `/tmp/gct-*` directories happened to exist.

## Behavior and proof

This does not change product behavior or orphan-selection policy. The one-hour age guard, sentinel/PID liveness checks, removal reasons, and best-effort cleanup remain unchanged.

- RED: the private stale fixture survived before the child root seam was wired.
- GREEN: eager and lazy command paths remove that fixture and retain exact empty stderr.
- Mutation: restoring ambient `os.Stderr` makes both regression cases fail on the cleanup diagnostic.
- `go test -race -count=1 ./test/tmuxtest`
- affected process tests, resource census, Linux and Darwin compilation
- `make test-fast-parallel`
- `go vet ./...`
- repository pre-commit hook
- two independent exact-hash reviews

Tracks `ga-yrotsuu.8`.
