### PR TITLE
test: replace real-city mail-check smoke

### DIFF
--- a/cmd/gc/testdata/mail.txtar
+++ b/cmd/gc/testdata/mail.txtar
@@ -13,9 +13,13 @@ env GC_SESSION=fake
 exec gc init $WORK/bright-lights
 cd $WORK/bright-lights
 
+! exec gc mail check mayor
+
 # Human sends a durable message to the configured agent.
 exec gc mail send mayor 'hey, are you still there?'
 stdout 'Sent message gc-1 to mayor'
+
+exec gc mail check mayor
 
 exec gc mail inbox mayor
 stdout 'human'

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -98,7 +98,6 @@ review_formulas_recovery_tests=(
 rest_smoke_tests=(
   TestE2E_WorkspaceDefaults
   TestE2E_Hook_WithWork
-  TestE2E_MailCheck
   TestE2E_MultiAgent_PoolAndFixed
   TestGastown_ControllerStartStop
   TestGastown_PipelineHumanToWorker

--- a/test/integration/e2e_mail_test.go
+++ b/test/integration/e2e_mail_test.go
@@ -25,35 +25,6 @@ func TestE2E_MailSend(t *testing.T) {
 	}
 }
 
-// TestE2E_MailCheck verifies that gc mail check returns 0 when mail exists
-// and 1 when the inbox is empty.
-func TestE2E_MailCheck(t *testing.T) {
-	city := e2eCity{
-		Agents: []e2eAgent{
-			{Name: "checker", StartCommand: e2eSleepScript()},
-		},
-	}
-	cityDir := setupE2ECity(t, nil, city)
-
-	// Empty inbox: should exit non-zero.
-	_, err := gc(cityDir, "mail", "check", "checker")
-	if err == nil {
-		t.Error("mail check should fail when inbox is empty")
-	}
-
-	// Send a message.
-	out, err := gc(cityDir, "mail", "send", "checker", "test mail check")
-	if err != nil {
-		t.Fatalf("gc mail send failed: %v\noutput: %s", err, out)
-	}
-
-	// Non-empty inbox: should exit 0.
-	out, err = gc(cityDir, "mail", "check", "checker")
-	if err != nil {
-		t.Errorf("mail check should succeed with mail: %v\noutput: %s", err, out)
-	}
-}
-
 // TestE2E_MailCheckInject verifies that gc mail check --inject wraps messages
 // in system-reminder tags.
 func TestE2E_MailCheckInject(t *testing.T) {


### PR DESCRIPTION
## Outcome

- Removes the duplicate real-city `TestE2E_MailCheck` journey from PR smoke coverage.
- Preserves empty and non-empty exit behavior in the existing file-backed, cross-process mail testscript.
- Keeps direct command semantics and real-agent mail composition under their existing focused owners.

## Test ownership

| Concern | Authoritative owner |
| --- | --- |
| Empty inbox returns 1; unread mail returns 0 | `TestMailCheckNoMail` / `TestMailCheckHasMail` |
| Separate CLI processes share durable mail state | `cmd/gc/testdata/mail.txtar` |
| Real agent and controller mail composition | `TestGastown_MailRoundTrip` and retained Gas Town mail E2Es |
| FileStore and provider behavior | FileStore and beadmail conformance suites |

## Measurement

| Metric | Before (#4518) | After (#4528) | Delta |
| --- | ---: | ---: | ---: |
| Rest-smoke-1 selected tests | 4 | 3 | -1 |
| Integration test execution | 85.057s | 18.041s | -67.016s (-78.8%) |
| PR open to merge | 4m26s | 4m37s | +11s |

The test payload became dramatically faster. Total job wall rose from 162s to 187s because setup expanded from about 14s to 110s downloading the cold dependency/toolchain set; test execution was not the regression.

## Verification

- Mutation proof: inverting the empty-inbox assertion fails at `mail.txtar:16`.
- Focused direct mail owners: pass.
- Focused `TestTutorial01/mail`: pass.
- Resource-census policy: pass.
- `make test-fast-parallel`: pass.
- `go vet ./...`: pass.
- Pre-commit and pre-push hooks: pass.
- Two independent delegated council reviews approved exact patch hash `4fd414e418c118fd7d257e736019866d633c8a6dd39a7aa53be5cbf4fc0e5135`.
- Representative CI: all required checks passed; squash merge `c2b80186286b8d045e1f75c7105d34f6771bfda9`.

Local broad-process note: three unrelated Dolt fixture tests cannot initialize with the ambient `bd` on this host because it was built with `CGO_ENABLED=0`; every other process shard passed, and CI supplied the representative Dolt toolchain gate.

Tracks `ga-yrotsuu.10`.