### PR TITLE
Fix raw transcript messages key on empty transcripts

### DIFF
--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -391,7 +391,7 @@ type sessionTranscriptGetResponse struct {
 	ResetReason        string                      `json:"reset_reason,omitempty" doc:"Structured reset reason when operation is reset."`
 	History            *SessionStructuredHistory   `json:"history,omitempty" doc:"Normalized worker-history envelope when format is structured."`
 	Turns              []outputTurn                `json:"turns,omitempty" doc:"Populated for conversation/text formats."`
-	Messages           []SessionRawMessageFrame    `json:"messages,omitempty" doc:"Populated for raw format; provider-native frames emitted verbatim as the provider wrote them."`
+	Messages           *[]SessionRawMessageFrame   `json:"messages,omitempty" doc:"Populated for raw format; provider-native frames emitted verbatim as the provider wrote them."`
 	StructuredMessages *[]SessionStructuredMessage `json:"structured_messages,omitempty" doc:"Populated for structured format; provider-normalized structured messages."`
 	Pagination         *sessionlog.PaginationInfo  `json:"pagination,omitempty"`
 }
@@ -438,11 +438,30 @@ func structuredMessagesField(messages []SessionStructuredMessage) *[]SessionStru
 	return &messages
 }
 
+func nonNilRawMessages(messages []SessionRawMessageFrame) []SessionRawMessageFrame {
+	if messages == nil {
+		return []SessionRawMessageFrame{}
+	}
+	return messages
+}
+
+func rawMessagesField(messages []SessionRawMessageFrame) *[]SessionRawMessageFrame {
+	messages = nonNilRawMessages(messages)
+	return &messages
+}
+
 func structuredTranscriptMessages(response sessionTranscriptGetResponse) []SessionStructuredMessage {
 	if response.StructuredMessages == nil {
 		return nil
 	}
 	return *response.StructuredMessages
+}
+
+func rawTranscriptMessages(response sessionTranscriptGetResponse) []SessionRawMessageFrame {
+	if response.Messages == nil {
+		return nil
+	}
+	return *response.Messages
 }
 
 // Schema publishes session transcript responses as a discriminated union over

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -230,7 +230,7 @@ func (s *Server) humaHandleSessionTranscript(ctx context.Context, input *Session
 					Template:   info.Template,
 					Provider:   info.Provider,
 					Format:     "raw",
-					Messages:   wrapRawFrameBytes(transcript.RawMessages),
+					Messages:   rawMessagesField(wrapRawFrameBytes(transcript.RawMessages)),
 					Pagination: transcript.Session.Pagination,
 				},
 			}, nil
@@ -282,7 +282,7 @@ func (s *Server) humaHandleSessionTranscript(ctx context.Context, input *Session
 				Template: info.Template,
 				Provider: info.Provider,
 				Format:   "raw",
-				Messages: []SessionRawMessageFrame{},
+				Messages: rawMessagesField(nil),
 			},
 		}, nil
 	}

--- a/internal/api/session_structured_schema_test.go
+++ b/internal/api/session_structured_schema_test.go
@@ -32,6 +32,25 @@ func TestSessionTranscriptRuntimeContainerDoesNotCustomizeJSON(t *testing.T) {
 	if strings.Contains(string(raw), `"structured_messages"`) {
 		t.Fatalf("raw response = %s, want structured_messages omitted", raw)
 	}
+
+	rawWithMessages, err := json.Marshal(sessionTranscriptGetResponse{
+		Format:   "raw",
+		Messages: rawMessagesField(nil),
+	})
+	if err != nil {
+		t.Fatalf("marshal raw response with messages field: %v", err)
+	}
+	if !strings.Contains(string(rawWithMessages), `"messages":[]`) {
+		t.Fatalf("raw response = %s, want required empty messages array", rawWithMessages)
+	}
+
+	structuredNoMessages, err := json.Marshal(sessionTranscriptGetResponse{Format: "structured"})
+	if err != nil {
+		t.Fatalf("marshal structured response without messages field: %v", err)
+	}
+	if strings.Contains(string(structuredNoMessages), `"messages"`) {
+		t.Fatalf("structured response = %s, want messages omitted", structuredNoMessages)
+	}
 }
 
 func TestLiveStructuredTranscriptSchemaPublishesNamedDiscriminatedUnions(t *testing.T) {

--- a/internal/api/structured_leakage_test.go
+++ b/internal/api/structured_leakage_test.go
@@ -491,7 +491,7 @@ func TestStructuredRawResponsePreservesProviderNativeFrame(t *testing.T) {
 		Template: "Chat",
 		Provider: "codex",
 		Format:   "raw",
-		Messages: []SessionRawMessageFrame{{Raw: raw}},
+		Messages: rawMessagesField([]SessionRawMessageFrame{{Raw: raw}}),
 	}
 	wire, err := json.Marshal(response)
 	if err != nil {
@@ -576,7 +576,7 @@ func TestStructuredCodexWebSearchOmitsNativeInputAndRawPreservesIt(t *testing.T)
 	}
 	wantRaw := []byte(`{"timestamp":"2026-06-01T00:04:01Z","type":"response_item","payload":{"type":"web_search_call","id":"call-codex-web-search","query":"structured tool result formats","input":{"query":"ignored fallback","scope":"web"},"action":{"type":"search","source":"web"}}}`)
 	foundExact := false
-	for _, frame := range rawResponse.Messages {
+	for _, frame := range rawTranscriptMessages(rawResponse) {
 		if bytes.Equal(frame.Raw, wantRaw) {
 			foundExact = true
 			break

--- a/release-gates/ga-96rgod-gate.md
+++ b/release-gates/ga-96rgod-gate.md
@@ -1,0 +1,41 @@
+# Release Gate: ga-96rgod
+
+Bead: ga-96rgod
+Source bead: ga-u49l9u
+Reviewed commit: 755f53ba16778e9ca592c82ebd42bc363fd20a28
+Deploy branch: deploy/ga-96rgod-gate
+Base: origin/main at 077a2217f612aa00891a38240f9d51a86db425ff
+Gate date: 2026-07-22 UTC (2026-07-22 America/Los_Angeles)
+
+Note: `docs/PROJECT_MANIFEST.md` was not present in this checkout, so the
+gate used the deployer prompt's release-gate criteria plus the repo-specific
+quality gates from `TESTING.md` and `AGENTS.md`.
+
+## Summary
+
+PASS. This is a single-bead release for the raw session transcript response
+schema drift. The reviewed commit keeps the raw transcript `messages` key
+present as an empty array on zero-frame raw transcripts while preserving
+omission for non-raw response shapes.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` succeeded. `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `7e115448bf32ba3d96d7cad869164cf524b40fc8`. Merge base: `b608d3b5c2b6e17da939a5092a612ca7f93e556a`. |
+| 1 | Review PASS present | PASS | `bd show ga-u49l9u` contains `REVIEW VERDICT: PASS`; source bead is closed with reason `pass`. |
+| 2 | Acceptance criteria met | PASS | Commit changes `sessionTranscriptGetResponse.Messages` to pointer semantics with raw-message helpers, updates call sites, and adds tests for raw branch `messages: []` behavior. Direct checks passed: `go test ./internal/api -run 'TestSessionTranscriptRuntimeContainerDoesNotCustomizeJSON|TestOpenAPISpecInSync' -count=1`; `go test -tags integration -run TestGCLiveContract_BeadsAndEvents -count=1 -timeout 10m ./test/integration`. |
+| 3 | Tests pass | PASS | `HOME=/home/jaword make test-fast-parallel` passed all 8 fast jobs. `HOME=/home/jaword go vet ./...` exited 0. `HOME=/home/jaword make dashboard-check` passed dashboard build, TypeScript checks, e2e typecheck, and dashboard API/BFF package tests. Targeted API schema/runtime tests passed in 0.101s. The live contract regression passed in 41.641s. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list style, security, spec compliance, coverage, and CI-fix integrity as PASS/N/A with no high-severity findings. No unresolved HIGH finding is recorded in `ga-u49l9u` or `ga-96rgod` notes. |
+| 5 | Final branch is clean | PASS | Before refreshing this gate artifact, `git status --short --branch` in `/var/tmp/gc-deployer-ga-96rgod-gate-1784668932-895011` printed only `## deploy/ga-96rgod-gate`; the gate commit is amended after this edit and status is rechecked before push. |
+| 7 | Single feature theme | PASS | One commit touches only `internal/api` transcript response serialization and adjacent tests: `huma_handlers_sessions_command.go`, `huma_handlers_sessions_query.go`, `session_structured_schema_test.go`, and `structured_leakage_test.go`. |
+
+## Test Commands
+
+```bash
+HOME=/home/jaword go test ./internal/api -run 'TestSessionTranscriptRuntimeContainerDoesNotCustomizeJSON|TestOpenAPISpecInSync' -count=1
+HOME=/home/jaword make test-fast-parallel
+HOME=/home/jaword go vet ./...
+HOME=/home/jaword make dashboard-check
+HOME=/home/jaword go test -tags integration -run TestGCLiveContract_BeadsAndEvents -count=1 -timeout 10m ./test/integration
+```


### PR DESCRIPTION
## What this changes

`GET /v0/city/{cityName}/session/{id}/transcript?format=raw` now keeps the required `messages` key present as `[]` when a raw transcript has no frames yet. That brings runtime JSON back in line with the OpenAPI raw transcript schema and fixes live-contract validation for newly started sessions.

The fix mirrors the existing structured transcript response pattern: raw responses use a non-nil pointer to an empty slice when the key must be present, while non-raw response shapes still omit raw messages.

## Review notes

- Runtime serialization change only; no OpenAPI schema artifact change is expected.
- Scope is the Huma/city-scoped session transcript route.
- The legacy stdlib transcript route is intentionally unchanged.

## Test plan

- [x] `HOME=/home/jaword go test ./internal/api -run 'TestSessionTranscriptRuntimeContainerDoesNotCustomizeJSON|TestOpenAPISpecInSync' -count=1`
- [x] `HOME=/home/jaword go test -tags integration -run TestGCLiveContract_BeadsAndEvents -count=1 -timeout 10m ./test/integration`
- [x] `HOME=/home/jaword make test-fast-parallel`
- [x] `HOME=/home/jaword go vet ./...`
- [x] `HOME=/home/jaword make dashboard-check`
- [x] Release gate: [`release-gates/ga-96rgod-gate.md`](release-gates/ga-96rgod-gate.md)