### PR TITLE
test(api): replace structured stream timeout with readiness event

### DIFF
--- a/internal/api/session_structured_providers_test.go
+++ b/internal/api/session_structured_providers_test.go
@@ -1681,7 +1681,7 @@ func TestHandleSessionStreamStructuredResumeEmitsInclusiveTailUpsert(t *testing.
 		t.Fatalf("Create: %v", err)
 	}
 	writeNamedSessionJSONL(t, searchBase, workDir, info.SessionKey+".jsonl",
-		`{"uuid":"m1","parentUuid":"","type":"assistant","message":"{\"role\":\"assistant\",\"content\":\"first\"}","timestamp":"2025-01-01T00:00:00Z"}`,
+		`{"uuid":"m1","parentUuid":"","type":"user","message":"{\"role\":\"user\",\"content\":\"first\"}","timestamp":"2025-01-01T00:00:00Z"}`,
 	)
 
 	restRec := httptest.NewRecorder()
@@ -1709,8 +1709,8 @@ func TestHandleSessionStreamStructuredResumeEmitsInclusiveTailUpsert(t *testing.
 		close(done)
 	}()
 	initialBody := waitForRecorderSubstring(t, rec, "event: activity", 10*time.Second)
-	if strings.Contains(initialBody, "event: structured") {
-		t.Fatalf("stream replayed exact initial snapshot: %s", initialBody)
+	if !strings.Contains(initialBody, "event: activity") {
+		t.Fatalf("stream readiness activity did not arrive: %s", initialBody)
 	}
 
 	logPath := filepath.Join(searchBase, sessionlog.ProjectSlug(workDir), info.SessionKey+".jsonl")


### PR DESCRIPTION
## Summary

- Synchronize the structured-resume handler test on its existing `activity` frame.
- Seed the initial user turn that guarantees that readiness signal.
- Keep the real JSONL append, fsnotify wake, and inclusive `[m1, m2]` upsert proof.

## Measured impact

| Focused test | Before | After |
| --- | ---: | ---: |
| `TestHandleSessionStreamStructuredResumeEmitsInclusiveTailUpsert` | 10.06s | 0.06s |

That removes the silent 10-second timeout (~168x faster). Five uncached repetitions completed in 0.06-0.07s.

## Coverage retained

- Exact-resume suppression remains directly owned by its unit and handler tests.
- Inclusive-tail calculation remains directly owned by its unit test.
- This test still appends through the real filesystem watcher and requires the first structured frame to be an `upsert` containing `[m1, m2]`.

## Verification

- TDD RED: the new readiness assertion failed after 10.05s with the old assistant-only fixture.
- Focused owner set passed five repetitions; targeted race run passed three repetitions.
- `make test-fast-parallel`
- `go vet ./...`
- Pre-commit and pre-push hooks
- Two independent delegated reviews of patch `ce20951b0929e6914432e7b75b9bf096f4999fa4c74cb48f2bd835f89e7c0ba5`

Tracks `ga-yrotsuu.11`.
