### PR TITLE
test(api): trigger structured promotion without polling

### DIFF
--- a/internal/api/handler_session_stream.go
+++ b/internal/api/handler_session_stream.go
@@ -856,6 +856,10 @@ func (s *Server) streamSessionPeekStructured(ctx context.Context, w http.Respons
 ) {
 	poll := time.NewTicker(outputStreamPollInterval)
 	defer poll.Stop()
+	pollC := poll.C
+	if s.structuredPeekPoll != nil {
+		pollC = s.structuredPeekPoll
+	}
 	keepalive := time.NewTicker(sseKeepalive)
 	defer keepalive.Stop()
 	workerOps := s.watchSessionWorkerOperationSignals(ctx, info)
@@ -935,7 +939,7 @@ func (s *Server) streamSessionPeekStructured(ctx context.Context, w http.Respons
 		select {
 		case <-ctx.Done():
 			return
-		case <-poll.C:
+		case <-pollC:
 			if promoteToHistory() {
 				return
 			}
@@ -1574,6 +1578,10 @@ func (s *Server) streamSessionPeekStructuredHuma(ctx context.Context, send Strin
 	send = cancelOnStringIDSendError(send, cancel)
 	poll := time.NewTicker(outputStreamPollInterval)
 	defer poll.Stop()
+	pollC := poll.C
+	if s.structuredPeekPoll != nil {
+		pollC = s.structuredPeekPoll
+	}
 	keepalive := time.NewTicker(sseKeepalive)
 	defer keepalive.Stop()
 	workerOps := s.watchSessionWorkerOperationSignals(ctx, info)
@@ -1653,7 +1661,7 @@ func (s *Server) streamSessionPeekStructuredHuma(ctx context.Context, send Strin
 		select {
 		case <-ctx.Done():
 			return
-		case <-poll.C:
+		case <-pollC:
 			if promoteToHistory() {
 				return
 			}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -68,6 +68,10 @@ type Server struct {
 	// session JSONL files. Nil means use worker.DefaultSearchPaths().
 	sessionLogSearchPaths []string
 
+	// structuredPeekPoll overrides the structured fallback stream's periodic
+	// history check in tests. Nil uses outputStreamPollInterval.
+	structuredPeekPoll <-chan time.Time
+
 	// idem caches responses for Idempotency-Key replay on create endpoints.
 	idem *idempotencyCache
 

--- a/internal/api/session_structured_providers_test.go
+++ b/internal/api/session_structured_providers_test.go
@@ -1159,6 +1159,8 @@ func TestSessionStreamStructuredPromotesFallbackToHistoryWithoutReconnect(t *tes
 			fs := newSessionFakeState(t)
 			searchBase := t.TempDir()
 			srv := New(fs)
+			structuredPeekPoll := make(chan time.Time)
+			srv.structuredPeekPoll = structuredPeekPoll
 			humaHandler := newTestCityHandlerWith(t, fs, srv)
 			srv.sessionLogSearchPaths = []string{searchBase}
 
@@ -1205,6 +1207,11 @@ func TestSessionStreamStructuredPromotesFallbackToHistoryWithoutReconnect(t *tes
 			writeNamedSessionJSONL(t, searchBase, workDir, info.SessionKey+".jsonl",
 				`{"uuid":"m1","parentUuid":"","type":"assistant","message":{"role":"assistant","content":"authoritative history"},"timestamp":"2025-01-01T00:00:00Z"}`,
 			)
+			select {
+			case structuredPeekPoll <- time.Now():
+			case <-time.After(testutil.GoroutineRaceTimeout):
+				t.Fatal("structured peek stream did not consume the injected poll tick")
+			}
 
 			body := waitForRecorderSubstring(t, rec, `"reset_reason":"stream_changed"`, 10*time.Second)
 			cancel()


### PR DESCRIPTION
## Summary

- Replaces two production-ticker waits in the structured fallback promotion test with a per-server manual poll signal.
- Leaves the real two-second ticker unchanged whenever the test signal is unset.
- Preserves real JSONL discovery, same-connection promotion, SSE reset framing, message ID, and authoritative-history assertions on both legacy and Huma paths.

## Result

4.09s to 0.11s average: about 37x faster.

## Verification

- `go test ./internal/api -run TestSessionStreamStructuredPromotesFallbackToHistoryWithoutReconnect -count=20`
- `go test -race ./internal/api -run TestSessionStreamStructuredPromotesFallbackToHistoryWithoutReconnect -count=5`
- `make test-fast-parallel`
- `go vet ./...`
- `make dashboard-check`
- Two delegated exact-diff reviews: approved

Tracks `ga-yrotsuu.12`.