### PR TITLE
test(gc): virtualize graceful shutdown coordination

### DIFF
--- a/cmd/gc/session_lifecycle_hang_test.go
+++ b/cmd/gc/session_lifecycle_hang_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -21,23 +22,42 @@ type hangingProvider struct {
 	mu       sync.Mutex
 	released bool
 	releaseC chan struct{}
+	attempts map[string]map[string]int
 }
 
 func newHangingProvider() *hangingProvider {
 	return &hangingProvider{
 		Fake:     runtime.NewFake(),
 		releaseC: make(chan struct{}),
+		attempts: make(map[string]map[string]int),
 	}
 }
 
 func (p *hangingProvider) Stop(name string) error {
+	p.recordAttempt("Stop", name)
 	<-p.releaseC
 	return p.Fake.Stop(name)
 }
 
 func (p *hangingProvider) Interrupt(name string) error {
+	p.recordAttempt("Interrupt", name)
 	<-p.releaseC
 	return p.Fake.Interrupt(name)
+}
+
+func (p *hangingProvider) recordAttempt(method, name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.attempts[method] == nil {
+		p.attempts[method] = make(map[string]int)
+	}
+	p.attempts[method][name]++
+}
+
+func (p *hangingProvider) attemptCount(method, name string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.attempts[method][name]
 }
 
 func (p *hangingProvider) release() {
@@ -105,27 +125,23 @@ func TestExecuteTargetWave_BoundedByPerTargetTimeout(t *testing.T) {
 // forever. Without per-target timeouts the goroutines that run them never
 // signal completion and the wave drainer hangs indefinitely.
 func TestGracefulStopAll_HangingProviderDoesNotWedge(t *testing.T) {
-	origStop := stopPerTargetTimeoutDefault
-	stopPerTargetTimeoutDefault = 200 * time.Millisecond
-	t.Cleanup(func() { stopPerTargetTimeoutDefault = origStop })
+	synctest.Test(t, func(t *testing.T) {
+		sp := newHangingProvider()
+		defer sp.release()
 
-	sp := newHangingProvider()
-	t.Cleanup(sp.release)
-
-	for _, name := range []string{"alpha", "bravo", "charlie"} {
-		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
-			t.Fatal(err)
+		names := []string{"alpha", "bravo", "charlie"}
+		for _, name := range names {
+			if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+				t.Fatal(err)
+			}
 		}
-	}
-	cfg := &config.City{
-		Daemon: config.DaemonConfig{ShutdownTimeout: "50ms"},
-	}
+		cfg := &config.City{
+			Daemon: config.DaemonConfig{ShutdownTimeout: "50ms"},
+		}
 
-	var stdout, stderr bytes.Buffer
-	done := make(chan struct{})
-	go func() {
+		var stdout, stderr bytes.Buffer
 		gracefulStopAll(
-			[]string{"alpha", "bravo", "charlie"},
+			names,
 			sp,
 			cfg.Daemon.ShutdownTimeoutDuration(),
 			events.Discard,
@@ -134,14 +150,33 @@ func TestGracefulStopAll_HangingProviderDoesNotWedge(t *testing.T) {
 			&stdout,
 			&stderr,
 		)
-		close(done)
-	}()
 
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("gracefulStopAll did not return within 5s — unbounded wait regression")
-	}
+		for _, operation := range []struct {
+			method string
+			logOp  string
+		}{
+			{method: "Interrupt", logOp: "interrupt"},
+			{method: "Stop", logOp: "stop"},
+		} {
+			for _, name := range names {
+				if got := sp.attemptCount(operation.method, name); got != 1 {
+					t.Errorf("%s attempts for %q = %d, want 1", operation.method, name, got)
+				}
+				matched := 0
+				for _, line := range strings.Split(stderr.String(), "\n") {
+					if strings.Contains(line, "session lifecycle:") &&
+						strings.Contains(line, "op="+operation.logOp+" ") &&
+						strings.Contains(line, "session="+name+" ") &&
+						strings.Contains(line, "outcome=timed_out") {
+						matched++
+					}
+				}
+				if matched != 1 {
+					t.Errorf("%s timed_out outcomes for %q = %d, want 1; stderr:\n%s", operation.logOp, name, matched, stderr.String())
+				}
+			}
+		}
+	})
 }
 
 // TestInterruptTargetsBounded_PoolManagedStopDoesNotWedge verifies that


### PR DESCRIPTION
## Summary

- Runs the real graceful-shutdown timeout schedule under `testing/synctest` instead of shortening production deadlines.
- Records each provider attempt before its intentional block and proves every Interrupt and Stop times out for all three sessions.
- Releases abandoned provider goroutines before bubble exit and keeps the narrow real-clock timeout owner unchanged.

## Result

2.70s to about 0.001s for the target body: roughly 2,700x faster.

## Verification

- Focused target: 100 repetitions
- Race target: 10 repetitions
- Three-test hang group: 20 repetitions
- `make test-fast-parallel`
- `go vet ./...`
- Two delegated exact-diff reviews: approved

Tracks `ga-yrotsuu.13`.