### PR TITLE
test: keep supervisor scope proof off kill fallback

### DIFF
--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -1763,9 +1763,21 @@ func TestInstallSupervisorSystemdWarmRefreshLeavesUnregisteredWorkspaceServices(
 
 	oldRun := supervisorSystemctlRun
 	oldActive := supervisorSystemctlActive
-	supervisorSystemctlRun = func(_ ...string) error { return nil }
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
 	supervisorSystemctlActive = func(service string) bool {
-		return service == unitName
+		if service != unitName {
+			return false
+		}
+		for _, call := range calls {
+			if call == "--user kill --kill-who=main --signal=SIGTERM "+unitName {
+				return false
+			}
+		}
+		return true
 	}
 	stubSupervisorRunningPreserveSignalReady(t, true)
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

- Keep the warm-refresh scope test focused on registered-versus-unregistered service cleanup.
- Make its systemd fake report the supervisor inactive after the expected SIGTERM.
- Leave production timeouts and the dedicated SIGKILL-fallback and cleanup-order owners unchanged.

## Performance

- Before: 5.13s.
- After: 0.13s.
- Speedup: about 39x, saving about 5.0s per run.

## Verification

- Focused owner: 20 repetitions
- Race: 5 repetitions
- Adjacent fallback and ordering owners: 10 repetitions; byte-identical
- `make test-fast-parallel`
- `go vet ./...` via the commit hook
- Two independent exact-diff reviews approved

Bead: `ga-yrotsuu.15`