### PR TITLE
Fix bounded self-rebase force-with-lease on restricted fetch refspecs

### DIFF
--- a/release-gates/ga-dl57j2-force-with-lease-refspec-gate.md
+++ b/release-gates/ga-dl57j2-force-with-lease-refspec-gate.md
@@ -1,0 +1,51 @@
+# Release Gate: attempt_bounded_self_rebase force-with-lease refspec fix
+
+- Bead: `ga-dl57j2`
+- Source bead: `ga-ggsux3`
+- Reviewed deploy commit: `e42ef16c0d9c8d445529e520637968aef43aa3b7`
+- Deploy branch: `deploy/ga-dl57j2-gate`
+- Source branch: `builder/ga-ggsux3-force-with-lease-refspec-fix` (provenance only; not used as a deploy push target)
+- Gate worktree: `/var/tmp/codex-gc-deployer-ga-dl57j2-20260721140719`
+- Base: `origin/main` at `c2538d42bfa4b10444764a4695736cdc5340ed1a`
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate applies the active deployer prompt release criteria plus the repo guidance in `TESTING.md`.
+
+## Summary
+
+PASS on 2026-07-22.
+
+This gate evaluated the reviewed source commit directly. The change is a single shared script fix plus its direct shell regression coverage:
+
+- `scripts/rebase-resolve-lib.sh`
+- `scripts/test-rebase-resolve.sh`
+
+## Criterion 6: Branch Diverges Cleanly From Main
+
+PASS. Evaluated first.
+
+Evidence:
+
+- `git merge-tree --write-tree origin/main e42ef16c0`: `7bec7fdd0aeb79e803abf43bceef262d862cb5f2` (exit 0)
+- `git diff --name-only origin/main...e42ef16c0`: only `scripts/rebase-resolve-lib.sh` and `scripts/test-rebase-resolve.sh`
+- No bounded self-rebase was needed for this gate.
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source bead `ga-ggsux3` is closed with notes containing `REVIEWER VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | The library now captures `refs/remotes/origin/$branch` before rebase and uses `--force-with-lease=$branch:$expected_remote_sha` when pushing the rebased branch. The smoke suite includes and passes `bounded/restricted-fetch-refspec-still-pushes`, reproducing the restricted-fetch-refspec production failure and confirming rc=0 with the fix. Static guard `push/bounded-rebase-force-with-lease` also passes. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc/` passed. `go vet ./...` passed. `make test-fast-parallel` passed. `shellcheck scripts/rebase-resolve-lib.sh scripts/test-rebase-resolve.sh` passed. `scripts/test-rebase-resolve.sh` passed with `pass=23 fail=0`. `go test ./scripts/... -run RebaseResolve -v` passed. `git diff --check origin/main...HEAD` passed. |
+| 4 | No high-severity review findings open | PASS | Source bead review notes contain only two low-severity, non-blocking awareness notes and no HIGH or CRITICAL findings. |
+| 5 | Final branch is clean | PASS | Gate worktrees were clean before writing this checklist. This gate file is the only deploy-branch delta on top of the reviewed source commit and is committed separately. |
+| 6 | Branch diverges cleanly from main | PASS | See dedicated criterion 6 section above. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: deployer bounded self-rebase push safety and its direct regression tests. No independent feature theme is bundled. |
+
+## Test Log Summary
+
+- `go build ./cmd/gc/`: PASS
+- `go vet ./...`: PASS
+- `make test-fast-parallel`: PASS (`All fast jobs passed`)
+- `shellcheck scripts/rebase-resolve-lib.sh scripts/test-rebase-resolve.sh`: PASS
+- `scripts/test-rebase-resolve.sh`: PASS (`pass=23 fail=0`)
+- `go test ./scripts/... -run RebaseResolve -v`: PASS
+- `git diff --check origin/main...HEAD`: PASS

--- a/scripts/rebase-resolve-lib.sh
+++ b/scripts/rebase-resolve-lib.sh
@@ -383,6 +383,18 @@ attempt_bounded_self_rebase() {
     local before_sha
     before_sha="$(git rev-parse HEAD 2>/dev/null)" || return 10
 
+    # Snapshot our local knowledge of the remote branch's tip now, before any
+    # rebase. Bare --force-with-lease resolves its expected value through the
+    # remote's configured fetch refspec; when <branch> isn't covered by that
+    # refspec (true for on-demand branches like this one — only base_ref and
+    # validator refs are configured), git can reject the push as stale even
+    # though this tracking ref is verified fresh. Passing the SHA explicitly
+    # below sidesteps that refspec-mapping lookup while keeping the same
+    # lease semantics: a genuine concurrent push still invalidates this
+    # captured value and the push is still correctly rejected.
+    local expected_remote_sha
+    expected_remote_sha="$(git rev-parse --verify -q "refs/remotes/origin/$branch" 2>/dev/null)" || expected_remote_sha=""
+
     # Already on top of base? Then criterion 6's FAIL was stale — nothing to
     # rebase, no push needed.
     if git merge-base --is-ancestor "origin/$base_ref" HEAD 2>/dev/null; then
@@ -429,8 +441,15 @@ attempt_bounded_self_rebase() {
     fi
 
     # Force-push the rebased branch. --force-with-lease (NOT --force) keeps
-    # us from clobbering a concurrent push to this same branch.
-    if ! GIT_TERMINAL_PROMPT=0 git push --force-with-lease origin "$branch" >/dev/null 2>&1; then
+    # us from clobbering a concurrent push to this same branch, using the
+    # SHA captured above as the explicit expected value (see above).
+    local lease_arg
+    if [[ -n "$expected_remote_sha" ]]; then
+        lease_arg="--force-with-lease=$branch:$expected_remote_sha"
+    else
+        lease_arg="--force-with-lease=$branch"
+    fi
+    if ! GIT_TERMINAL_PROMPT=0 git push "$lease_arg" origin "$branch" >/dev/null 2>&1; then
         return 13
     fi
 

--- a/scripts/test-rebase-resolve.sh
+++ b/scripts/test-rebase-resolve.sh
@@ -388,10 +388,11 @@ test_push_never_bare_force() {
 test_bounded_rebase_uses_force_with_lease() {
     # SC2016 intentional: literal-text search of rebase-resolve-lib.sh source.
     # shellcheck disable=SC2016
-    if grep -qE 'git push --force-with-lease origin "\$branch"' "$LIB"; then
+    if grep -qE 'git push "\$lease_arg" origin "\$branch"' "$LIB" \
+        && grep -qE '^\s*lease_arg="--force-with-lease=\$branch:\$expected_remote_sha"' "$LIB"; then
         record_pass "push/bounded-rebase-force-with-lease"
     else
-        record_fail "push/bounded-rebase-force-with-lease" "attempt_bounded_self_rebase's push is not --force-with-lease"
+        record_fail "push/bounded-rebase-force-with-lease" "attempt_bounded_self_rebase's push is not the explicit-value --force-with-lease form"
     fi
 }
 
@@ -705,6 +706,65 @@ test_bounded_rebase_stale_lease_returns_13() {
     rm -rf "$remote" "$work" "$seed" "$intruder"
 }
 
+# Reproduces the real-world false-rejection this fix addresses: <branch> is
+# not covered by the remote's configured fetch refspec (only base_ref is,
+# matching deployer worktrees whose remote.origin.fetch is restricted to
+# main/validator refs). The tracking ref for <branch> exists locally (via a
+# one-off fetch, as the real workflow performs) and is verified fresh, but
+# bare --force-with-lease still rejects it as stale because it resolves its
+# expected value through the refspec mapping rather than the ref itself.
+test_bounded_rebase_restricted_fetch_refspec_still_pushes() {
+    local remote work seed
+    remote="$(new_bare_remote)"
+    seed="$(mktemp -d "${TMPDIR:-/tmp}/gc-deployer-rebase-seed.XXXXXX")"
+    git clone -q "$remote" "$seed" 2>/dev/null
+    (
+        cd "$seed" || exit 1
+        git config commit.gpgsign false
+        printf 'base\n' > f.txt; git add -A; git commit -qm base
+        git push -q origin main
+        git checkout -q -b feature
+        printf 'feature file\n' > feature.txt; git add -A; git commit -qm "feature adds feature.txt"
+        git push -q origin feature
+        git checkout -q main
+        printf 'main file\n' > main-only.txt; git add -A; git commit -qm "main adds main-only.txt"
+        git push -q origin main
+    )
+
+    work="$(mktemp -d "${TMPDIR:-/tmp}/gc-deployer-rebase-work.XXXXXX")"
+    git clone -q "$remote" "$work"
+    (
+        cd "$work" || exit 1
+        git config commit.gpgsign false
+        # Restrict to main-only, like the real deployer worktrees this bug
+        # was found in — `feature` is deliberately NOT a configured refspec.
+        git config --unset-all remote.origin.fetch
+        git config --add remote.origin.fetch '+refs/heads/main:refs/remotes/origin/main'
+        # One-off fetch of the branch itself, as the real workflow does,
+        # populating the tracking ref outside the configured refspec.
+        git fetch -q origin refs/heads/feature:refs/remotes/origin/feature
+        git checkout -q -B feature refs/remotes/origin/feature
+    )
+
+    local before_local output rc
+    before_local="$(git -C "$work" rev-parse HEAD)"
+    output="$(cd "$work" && attempt_bounded_self_rebase feature main 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]]; then
+        record_fail "bounded/restricted-fetch-refspec-still-pushes" "expected rc=0, got rc=$rc, output: $output"
+        rm -rf "$remote" "$work" "$seed"; return
+    fi
+    local after_sha remote_after
+    after_sha="$(printf '%s\n' "$output" | sed -n 's/^AFTER_SHA=//p')"
+    remote_after="$(remote_sha "$remote" refs/heads/feature)"
+    if [[ "$before_local" != "" && -n "$after_sha" && "$remote_after" == "$after_sha" ]]; then
+        record_pass "bounded/restricted-fetch-refspec-still-pushes (rc=0, pushed despite refspec restriction)"
+    else
+        record_fail "bounded/restricted-fetch-refspec-still-pushes" \
+            "before_local=$before_local after_sha=$after_sha remote_after=$remote_after"
+    fi
+    rm -rf "$remote" "$work" "$seed"
+}
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -732,6 +792,7 @@ run_all() {
     test_bounded_rebase_trivial_conflict_resolves_and_succeeds
     test_bounded_rebase_real_conflict_refused_untouched
     test_bounded_rebase_stale_lease_returns_13
+    test_bounded_rebase_restricted_fetch_refspec_still_pushes
 
     echo
     echo "pass=$pass fail=$fail"


### PR DESCRIPTION
## What this changes

`attempt_bounded_self_rebase` now snapshots the expected remote branch SHA before rebasing and passes that value explicitly to `git push --force-with-lease=<branch>:<sha>`.

That avoids false stale-lease rejections in deployer and builder worktrees whose `remote.origin.fetch` only maps `main` and validator refs. The branch is still protected from genuine concurrent pushes because Git compares the explicit expected SHA against the remote tip at push time.

## Review notes

- Scope is limited to `scripts/rebase-resolve-lib.sh` and `scripts/test-rebase-resolve.sh`.
- The bounded self-rebase return codes are unchanged.
- The existing fallback behavior remains for worktrees without a local tracking SHA, matching the current caller precondition.

## Test plan

- [x] `scripts/test-rebase-resolve.sh`
- [x] `go test ./scripts/... -run RebaseResolve -v`
- [x] `shellcheck scripts/rebase-resolve-lib.sh scripts/test-rebase-resolve.sh`
- [x] `go build ./cmd/gc/`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-dl57j2-force-with-lease-refspec-gate.md`](release-gates/ga-dl57j2-force-with-lease-refspec-gate.md)