### PR TITLE
test: accelerate schema exhaustion retries

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -6992,6 +6992,7 @@ func TestGcBeadsBdInitRetriesPlainInitWhenSchemaStillMissingAfterSuccess(t *test
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeExecutable(t, filepath.Join(binDir, "sleep"), "#!/bin/sh\nexit 0\n")
 
 	initCountFile := filepath.Join(t.TempDir(), "bd-init-count")
 	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")
@@ -7138,6 +7139,7 @@ func TestGcBeadsBdInitDropsMetadataBeforeRetryingInitAfterForcedFallback(t *test
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeExecutable(t, filepath.Join(binDir, "sleep"), "#!/bin/sh\nexit 0\n")
 
 	initCountFile := filepath.Join(t.TempDir(), "bd-init-count")
 	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")


### PR DESCRIPTION
## Summary

- Give two synchronous schema-exhaustion tests a PATH-scoped successful `sleep` double.
- Preserve all eight probes, re-exec, both `bd init` attempts, command-shape assertions, and metadata transitions.
- Leave production and the real delayed-visibility/backoff owner unchanged.

## Performance

- Before: 7.20s and 7.24s as standalone package invocations.
- After: 1.69s and 1.80s.
- Removes the exact 4.5s backoff schedule from each owner, about 9s deterministic combined.

## Verification

- Focused owners: 20 repetitions
- Race with delayed-visibility owner: 5 repetitions
- Resource census consistency
- `make test-fast-parallel`
- `go vet ./...` via the commit hook
- Two independent exact-diff reviews approved

Bead: `ga-yrotsuu.16`