### PR TITLE
fix(config): hint the bare local name when a pack patch targets a qualified agent name (#4525)

### DIFF
--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2361,6 +2361,13 @@ func applyPackAgentPatches(agents []Agent, patches []AgentPatch) error {
 			}
 		}
 		if !found {
+			if p.Dir == "" {
+				for j := range agents {
+					if agents[j].BindingQualifiedName() == p.Name {
+						return fmt.Errorf("patches.agent[%d]: agent %q not found in pack (patches match local names — did you mean %q?)", i, target, agents[j].Name)
+					}
+				}
+			}
 			return fmt.Errorf("patches.agent[%d]: agent %q not found in pack", i, target)
 		}
 	}

--- a/internal/config/pack_agent_patches_test.go
+++ b/internal/config/pack_agent_patches_test.go
@@ -1,0 +1,63 @@
+package config
+
+import "testing"
+
+// #4525: [[patches.agent]] must target an imported agent's bare local
+// name, not its binding-qualified name — even though pack-spec §2.5
+// says imported agents are addressed by binding-qualified name
+// everywhere else. When a pack author uses the qualified form here, the
+// error should say so instead of leaving them to guess.
+func TestApplyPackAgentPatchesQualifiedNameHint(t *testing.T) {
+	agents := []Agent{
+		{Name: "requirements-planner", BindingName: "roles"},
+	}
+	patches := []AgentPatch{
+		{Name: "roles.requirements-planner"},
+	}
+
+	err := applyPackAgentPatches(agents, patches)
+	if err == nil {
+		t.Fatal("expected error for qualified-name patch target, got nil")
+	}
+
+	const want = `patches.agent[0]: agent "roles.requirements-planner" not found in pack (patches match local names — did you mean "requirements-planner"?)`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestApplyPackAgentPatchesBareNameStillMatches(t *testing.T) {
+	agents := []Agent{
+		{Name: "requirements-planner", BindingName: "roles"},
+	}
+	suspended := true
+	patches := []AgentPatch{
+		{Name: "requirements-planner", Suspended: &suspended},
+	}
+
+	if err := applyPackAgentPatches(agents, patches); err != nil {
+		t.Fatalf("bare-name patch should match: %v", err)
+	}
+	if !agents[0].Suspended {
+		t.Error("patch fields were not applied to the matched agent")
+	}
+}
+
+func TestApplyPackAgentPatchesUnrelatedNameNoHint(t *testing.T) {
+	agents := []Agent{
+		{Name: "requirements-planner", BindingName: "roles"},
+	}
+	patches := []AgentPatch{
+		{Name: "totally-unknown"},
+	}
+
+	err := applyPackAgentPatches(agents, patches)
+	if err == nil {
+		t.Fatal("expected error for unmatched patch target, got nil")
+	}
+
+	const want = `patches.agent[0]: agent "totally-unknown" not found in pack`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q (no hint should be added when nothing qualifies)", err.Error(), want)
+	}
+}


### PR DESCRIPTION
## Summary

A pack's `[[patches.agent]]` block must target an imported agent by its **bare local name**, even though pack-spec §2.5 documents imported agents as addressed by **binding-qualified name** everywhere else. A pack author following §2.5's own convention (`name = "roles.requirements-planner"`) hits `agent "roles.requirements-planner" not found in pack` — a dead end, since the error gives no hint that the bare form (`requirements-planner`) is what actually works.

Root cause: `applyPackAgentPatches` (`internal/config/pack.go`) matches patch targets against `agents[j].Name` (bare) only when `p.Dir == ""`. A qualified `p.Name` can never match, so it falls straight through to the generic "not found" error — correct behavior, just an unhelpful message.

## Fix

Adds a not-found fallback check: if no bare match was found, look for an agent whose `BindingQualifiedName()` (existing helper: `BindingName + "." + Name`) equals the unmatched target, and if so, name the working bare form in the error. No matching-logic change — only the error path grows one extra lookup.

Fixes #4525.

## Test plan

Three new tests in a new file (`internal/config/pack_agent_patches_test.go`, no direct unit test previously covered this function):

- `TestApplyPackAgentPatchesQualifiedNameHint` — RED: error lacked the hint; GREEN after the fix: error now ends `(patches match local names — did you mean "requirements-planner"?)`.
- `TestApplyPackAgentPatchesBareNameStillMatches` — guard: the working bare-name form still matches and applies patch fields (unaffected by the change).
- `TestApplyPackAgentPatchesUnrelatedNameNoHint` — guard: a target matching nothing at all (not even qualified) gets the plain error with no hint, so the new fallback doesn't fire spuriously.

- [x] All 3 new tests pass
- [x] `go test -tags gms_pure_go ./internal/config/...` (full package) — pass, no regressions
- [x] `go vet -tags gms_pure_go ./internal/config/...` — clean
- [x] `golangci-lint run --build-tags gms_pure_go ./internal/config/...` — 0 issues
- [x] Full sharded local test suite run — heavy pre-existing sandbox flakiness this run (subprocess/timing/lsof/Docker/dolt-startup, across `internal/api`, `internal/beads`, `internal/convergence`, `internal/dispatch`, `internal/productmetrics`, `internal/runtime/exec`, `internal/session`, `internal/sling`, `internal/usage`, `scripts`) — `internal/config` itself passed clean (`ok`), no overlap with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGjSaP5EtcXZYqgBafw61m