### PR TITLE
test: isolate runtime preflight store opening

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1212,6 +1212,7 @@ func TestNewCityRuntimePreflightsManagedDoltPublicationBeforeStartupStoreWork(t 
 
 func TestNewCityRuntimePreflightUsesResolvableProviderStateByDefault(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
+	stubManagedDoltStoreOpeners(t)
 
 	healthCalls := 0
 	cityPath := t.TempDir()


### PR DESCRIPTION
## Summary

- Use the existing conformance-tested `MemStore` opener stub for unrelated runtime-startup store work.
- Keep the real provider-state listener, nil-port default resolver, ownership check, and health-suppression assertion.
- Leave production plus the ordering and startup-sweep composition owners unchanged.

## Performance

- Before: 4.80s test body.
- After: 0.59s.
- Speedup: about 8.1x, saving 4.21s per run.

## Verification

- Target: 20 repetitions
- Target plus retained ordering/sweep owners: 10 repetitions
- Race with tick-path sibling: 5 repetitions
- Existing `MemStore` conformance suites
- Resource census consistency
- `make test-fast-parallel`
- `go vet ./...` via the commit hook
- Two independent exact-diff reviews approved

Bead: `ga-yrotsuu.17`