### PR TITLE
fix(nudge): loud-fail guard for drained/terminated session wakes — send-time UNDELIVERABLE + drain-time dead-letter (#4534)

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1834,6 +1834,11 @@ type nudgeMaintenanceStore struct {
 	opened   bool
 	store    beads.NudgesStore
 	front    *nudgequeue.Store
+
+	// sessProbe is the session-lifecycle probe the stranded-nudge sweep uses,
+	// built once (sessProbeBuilt) over the same store handle frontForState opened.
+	sessProbe      managedWakeUnreachableProbe
+	sessProbeBuilt bool
 }
 
 // frontForState returns the front-door handle to use for the maintenance passes
@@ -1861,6 +1866,41 @@ func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 		}
 	}
 	return m.store
+}
+
+// managedWakeUnreachableProbe reports whether the target session of a queued nudge
+// has reached a terminal/stranding lifecycle state and can therefore no longer
+// consume it. It is session.Store.ManagedWakeUnreachable as a method value; a nil
+// probe (no backed session front door) disables the stranded-nudge sweep.
+type managedWakeUnreachableProbe func(sessionID string, now time.Time) (string, bool, error)
+
+// strandProbe returns the session-lifecycle probe pruneStrandedQueuedNudges uses,
+// built lazily over the same underlying store handle frontForState opened (so the
+// idle/empty-queue tick never opens a store or loads config just to build it). It
+// returns nil — disabling the sweep for this pass — when the store was never
+// opened or the session front door is not backed. The one-shot session store is
+// routed through cliSessionFrontDoor so a [beads.classes.sessions] relocation is
+// honored the same way the running controller honors it.
+func (m *nudgeMaintenanceStore) strandProbe() managedWakeUnreachableProbe {
+	if m.sessProbeBuilt {
+		return m.sessProbe
+	}
+	m.sessProbeBuilt = true
+	if !m.opened || m.store.Store == nil {
+		return nil
+	}
+	// cfg drives only [beads.classes.sessions] relocation routing and is nil-safe at
+	// the single-store backend (resolveClassStore ignores it). Load it so a relocated
+	// session store is honored the same way the controller honors it, but fall back
+	// to nil rather than disable the sweep when config is unreadable (e.g. a bare
+	// test city) — the sweep is far too valuable to silently skip over a config read.
+	cfg, _ := loadCityConfig(m.cityPath)
+	front := cliSessionFrontDoor(m.store.Store, cfg, m.cityPath)
+	if front == nil || !front.Backed() {
+		return nil
+	}
+	m.sessProbe = front.ManagedWakeUnreachable
+	return m.sessProbe
 }
 
 // close releases the store this frame opened (if any). It never touches a
@@ -1899,6 +1939,9 @@ func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(que
 			return err
 		}
 		if err := pruneDeadQueuedNudges(state, front, now, deadline); err != nil {
+			return err
+		}
+		if err := pruneStrandedQueuedNudges(state, front, maint.strandProbe(), now, deadline); err != nil {
 			return err
 		}
 		pending := state.Pending[:0]
@@ -1941,6 +1984,9 @@ func listQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge,
 		if err := pruneDeadQueuedNudges(state, front, now, deadline); err != nil {
 			return err
 		}
+		if err := pruneStrandedQueuedNudges(state, front, maint.strandProbe(), now, deadline); err != nil {
+			return err
+		}
 		for _, item := range state.Pending {
 			if item.Agent == agentName {
 				pending = append(pending, item)
@@ -1977,6 +2023,9 @@ func listQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Tim
 			return err
 		}
 		if err := pruneDeadQueuedNudges(state, front, now, deadline); err != nil {
+			return err
+		}
+		if err := pruneStrandedQueuedNudges(state, front, maint.strandProbe(), now, deadline); err != nil {
 			return err
 		}
 		for _, item := range state.Pending {
@@ -2414,6 +2463,68 @@ func pruneExpiredQueuedNudges(state *nudgeQueueState, front *nudgequeue.Store, n
 		filtered = append(filtered, item)
 	}
 	state.Pending = filtered
+	sortQueuedNudges(state)
+	return nil
+}
+
+// pruneStrandedQueuedNudges dead-letters queued nudges whose TARGET SESSION has
+// terminated (closed / closing / archived-without-continuity) or stranded
+// (drained / stopped) and will therefore never consume them — the drain-time-race
+// half of the sc-875uie loud-fail guard. The send-time guard (half a,
+// nudgeManagedWakeStrands) blocks a NEW managed wake to an already-drained target;
+// this sweep covers the RACE the send-time guard cannot: a nudge queued to a live
+// or asleep session that THEN terminates before consuming it. Left unswept the
+// orphan lingers in Pending/InFlight until its retired session fence stops matching,
+// at which point `gc nudge status` reads 0/0/0 with zero trace and the sender never
+// learns delivery failed (the measured bug). Moving it to Dead surfaces it in
+// status and leaves a durable terminal bead.
+//
+// It is deliberately session-keyed: an item with no target SessionID (an
+// agent-broadcast nudge bound to no specific session) is left untouched — this fix
+// targets the measured session-directed evaporation only. A probe error (a
+// transient session-store read) KEEPS the item (fail-closed) rather than
+// dead-letter a possibly-live target. A nil probe or front (idle/empty queue never
+// opened the store) makes the whole pass a no-op.
+func pruneStrandedQueuedNudges(state *nudgeQueueState, front *nudgequeue.Store, probe managedWakeUnreachableProbe, now, deadline time.Time) error {
+	if probe == nil || front == nil {
+		return nil
+	}
+	var stranded []queuedNudge
+	sweep := func(items []queuedNudge) []queuedNudge {
+		kept := items[:0]
+		for i, item := range items {
+			if time.Now().After(deadline) {
+				kept = append(kept, items[i:]...)
+				break
+			}
+			if strings.TrimSpace(item.SessionID) == "" {
+				kept = append(kept, item)
+				continue
+			}
+			reason, unreachable, err := probe(item.SessionID, now)
+			if err != nil || !unreachable {
+				kept = append(kept, item)
+				continue
+			}
+			item.DeadAt = now.UTC()
+			item.ClaimedAt = time.Time{}
+			item.LeaseUntil = time.Time{}
+			if strings.TrimSpace(item.LastError) == "" {
+				item.LastError = "session " + reason
+			}
+			stranded = append(stranded, item)
+		}
+		return kept
+	}
+	state.Pending = sweep(state.Pending)
+	state.InFlight = sweep(state.InFlight)
+	for _, item := range stranded {
+		// Best-effort: mark the backing bead terminal even if the write fails, so a
+		// store hiccup cannot trap the item back in Pending/InFlight (mirrors the
+		// expired-prune contract). pruneDeadQueuedNudges repairs any missed terminal.
+		_ = front.Terminalize(item, "failed", item.LastError, "", now)
+	}
+	state.Dead = append(state.Dead, stranded...)
 	sortQueuedNudges(state)
 	return nil
 }

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -772,6 +772,21 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 		return 1
 	}
 	if queueManagedWake {
+		// Send-time loud-fail guard (sc-875uie): shouldQueueManagedNudgeWake chose to
+		// queue purely on !obs.Running, which cannot tell a resumable (asleep) session
+		// from one that has DRAINED. A drained session is not a wake conflict, so
+		// WakeSession accepts the wake and returns success — but the reconciler spawns
+		// a fresh worker instead of resuming it, so nothing ever consumes the queued
+		// nudge; it lingers until its retired fence stops matching and gc nudge status
+		// reads 0/0/0, having handed the sender a false "queued" success. Detect that
+		// silent-strand case here and fail undeliverable BEFORE enqueuing. (Terminal
+		// and gone targets are NOT diverted here — WakeSession already rejects them and
+		// the enqueue→rollback path dead-letters them loudly.) A probe error
+		// (transient/store) is non-fatal: fall through to the existing enqueue+wake
+		// path rather than block a legitimate nudge.
+		if reason, wouldStrand, probeErr := nudgeManagedWakeStrands(target, store); probeErr == nil && wouldStrand {
+			return writeUndeliverableSessionNudgeResult(target, mode, reason, jsonOutput, stdout, stderr)
+		}
 		return queueManagedSessionNudgeWake(target, store, message, mode, jsonOutput, stdout, stderr)
 	}
 	// A wait-idle nudge to a RUNNING-but-busy target must not block the caller in
@@ -892,6 +907,20 @@ func queueManagedSessionNudgeWake(target nudgeTarget, store beads.Store, message
 		fmt.Fprintf(stderr, "gc session nudge: warning: poke failed: %v\n", err) //nolint:errcheck
 	}
 	return writeQueuedSessionNudgeResult(target, mode, jsonOutput, stdout, stderr)
+}
+
+// nudgeManagedWakeStrands reports whether queuing a managed nudge-wake for the
+// target would silently strand it (a drained/stopped session WakeSession accepts
+// but never resumes), via the session front door's read-only ManagedWakeWouldStrand
+// probe. When the front door is unbacked or the target carries no session id it
+// cannot classify, so it reports wouldStrand=false to preserve the pre-existing
+// enqueue behavior.
+func nudgeManagedWakeStrands(target nudgeTarget, store beads.Store) (string, bool, error) {
+	front := cliSessionFrontDoor(store, target.cfg, target.cityPath)
+	if !front.Backed() || target.sessionID == "" {
+		return "", false, nil
+	}
+	return front.ManagedWakeWouldStrand(target.sessionID, time.Now().UTC())
 }
 
 func enqueueManagedNudgeThenWake(target nudgeTarget, store beads.Store, item queuedNudge) error {
@@ -1083,6 +1112,34 @@ func writeQueuedSessionNudgeResult(target nudgeTarget, mode nudgeDeliveryMode, j
 	}
 	fmt.Fprintf(stdout, "Queued nudge for %s\n", target.agentKey()) //nolint:errcheck
 	return 0
+}
+
+// writeUndeliverableSessionNudgeResult reports a nudge that was NOT queued
+// because the target session would silently strand a managed wake (drained/
+// stopped — see nudgeManagedWakeStrands). It is the loud-fail counterpart to
+// writeQueuedSessionNudgeResult: the command exits non-zero and, in JSON mode,
+// emits queued=false / outcome="undeliverable" with the reason, so a caller
+// (human or script) gets a real failure signal instead of a false "queued"
+// success that later evaporates (sc-875uie).
+func writeUndeliverableSessionNudgeResult(target nudgeTarget, mode nudgeDeliveryMode, reason string, jsonOutput bool, stdout, stderr io.Writer) int {
+	if jsonOutput {
+		if code := writeCLIJSONLineOrExit(stdout, stderr, "gc session nudge", sessionNudgeJSON{
+			SchemaVersion: "1",
+			OK:            false,
+			Target:        target.agentKey(),
+			SessionID:     target.sessionID,
+			SessionName:   target.sessionName,
+			Delivery:      string(mode),
+			Queued:        false,
+			Outcome:       "undeliverable",
+			Reason:        reason,
+		}); code != 0 {
+			return code
+		}
+		return 1
+	}
+	fmt.Fprintf(stderr, "gc session nudge: undeliverable — target session %s is %s and will not be resumed; nudge not queued\n", target.agentKey(), reason) //nolint:errcheck
+	return 1
 }
 
 func sendMailNotify(target nudgeTarget, sender string) error {

--- a/cmd/gc/cmd_nudge_strand_sweep_test.go
+++ b/cmd/gc/cmd_nudge_strand_sweep_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/worker"
+)
+
+// TestPruneStrandedQueuedNudgesDrainTimeRaceIsDeadLettered pins half (a2) of the
+// sc-875uie loud-fail guard end to end: a managed nudge queued to a live/asleep
+// session that THEN drains before consuming it is dead-lettered by the maintenance
+// sweep and becomes VISIBLE in `gc nudge status` (Dead: 1), instead of lingering in
+// Pending until its retired fence stops matching and status reads 0/0/0 with zero
+// trace. The send-time guard (half a) cannot catch this race — the target was
+// perfectly resumable when the nudge was queued; only a later observation over the
+// now-terminal session lifecycle can. The same observation while the target is
+// still asleep must NOT sweep the nudge (no false positive on a resumable target).
+func TestPruneStrandedQueuedNudgesDrainTimeRaceIsDeadLettered(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "claude", WorkDir: dir, Provider: "claude", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Asleep (suspended) — a genuinely resumable target. A managed wake queued here
+	// is legitimate: the session would consume it on resume. This is the pre-race
+	// state; the drain happens AFTER the nudge is already queued.
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	prevManaged := nudgeCityUsesManagedReconciler
+	prevPoke := nudgePokeController
+	prevObserve := nudgeObserveTarget
+	pokes := 0
+	nudgeCityUsesManagedReconciler = func(cityPath string) bool { return cityPath == dir }
+	nudgePokeController = func(string) error {
+		pokes++
+		return nil
+	}
+	nudgeObserveTarget = func(nudgeTarget, beads.Store, runtime.Provider) (worker.LiveObservation, error) {
+		return worker.LiveObservation{Running: false}, nil
+	}
+	t.Cleanup(func() {
+		nudgeCityUsesManagedReconciler = prevManaged
+		nudgePokeController = prevPoke
+		nudgeObserveTarget = prevObserve
+	})
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		cfg:         &config.City{Agents: []config.Agent{{Name: "worker", Provider: "claude"}}},
+		sessionID:   info.ID,
+		sessionName: info.SessionName,
+		identity:    "worker",
+		agent:       config.Agent{Name: "worker", Provider: "claude"},
+	}
+
+	// Queue the managed wake to the asleep session — the normal, successful path.
+	var stdout, stderr bytes.Buffer
+	if code := deliverSessionNudgeWithWorker(target, store, fake, "resume: mayor ruling", nudgeDeliveryImmediate, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("deliverSessionNudgeWithWorker = %d (%q), want 0 (queued to a resumable session)", code, stderr.String())
+	}
+	if pokes != 1 {
+		t.Fatalf("pokes = %d, want 1 (managed wake enqueued + controller poked)", pokes)
+	}
+
+	// Observation #1, target still ASLEEP: the sweep runs but must NOT touch a
+	// resumable target — the nudge stays Pending.
+	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget (asleep): %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("asleep pending/inFlight/dead = %d/%d/%d, want 1/0/0 (no false sweep of a resumable target)", len(pending), len(inFlight), len(dead))
+	}
+	if pending[0].SessionID != info.ID {
+		t.Fatalf("queued nudge SessionID = %q, want %q (item must carry its target session for the sweep to classify it)", pending[0].SessionID, info.ID)
+	}
+
+	// The race: the target DRAINS after the nudge was queued. A drained session
+	// projects to BaseStateDrained — the reconciler spawns a fresh worker rather
+	// than resuming it, so nothing will ever consume the queued wake.
+	if err := store.SetMetadata(info.ID, "state", "drained"); err != nil {
+		t.Fatalf("SetMetadata(state=drained): %v", err)
+	}
+
+	// Observation #2, target now DRAINED: the sweep dead-letters the orphan. This
+	// is the fix — status now shows a real Dead trace instead of 0/0/0.
+	pending, inFlight, dead, err = listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget (drained): %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 1 {
+		t.Fatalf("drained pending/inFlight/dead = %d/%d/%d, want 0/0/1 (queued-then-drained nudge dead-lettered, not evaporated)", len(pending), len(inFlight), len(dead))
+	}
+	if !strings.Contains(dead[0].LastError, "drained") {
+		t.Fatalf("dead LastError = %q, want it to name the terminal session state (drained)", dead[0].LastError)
+	}
+	if dead[0].DeadAt.IsZero() {
+		t.Fatalf("dead nudge DeadAt is zero, want it stamped at sweep time")
+	}
+
+	// Idempotent: a subsequent observation does not re-sweep or duplicate the Dead
+	// entry — the item is already terminal.
+	pending, inFlight, dead, err = listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget (re-observe): %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 1 {
+		t.Fatalf("re-observe pending/inFlight/dead = %d/%d/%d, want 0/0/1 (sweep is idempotent)", len(pending), len(inFlight), len(dead))
+	}
+}

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -857,6 +857,107 @@ func TestDeliverSessionNudgeWithWorkerManagedWakeFailureRollsBackQueuedNudge(t *
 	}
 }
 
+// TestDeliverSessionNudgeWithWorkerManagedDrainedTargetIsUndeliverable pins the
+// sc-875uie send-time guard end to end: a managed nudge to a DRAINED session is
+// reported undeliverable synchronously and NOT enqueued, so the sender gets a real
+// failure signal instead of the false "queued" success that used to evaporate
+// (gc nudge status 0/0/0, zero trace). Contrast the closing-session case above,
+// which WakeSession rejects and the enqueue→rollback path dead-letters (dead==1);
+// a drained session is not a wake conflict, so absent the guard the wake would
+// silently "succeed" and strand the nudge.
+func TestDeliverSessionNudgeWithWorkerManagedDrainedTargetIsUndeliverable(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "claude", WorkDir: dir, Provider: "claude", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+	// A drained pool worker: state=drained projects to BaseStateDrained, which is
+	// NOT a wake conflict — WakeSession would accept a wake and report success. That
+	// is the exact silent-strand the send-time guard intercepts.
+	if err := store.SetMetadata(info.ID, "state", "drained"); err != nil {
+		t.Fatalf("SetMetadata(state): %v", err)
+	}
+
+	prevManaged := nudgeCityUsesManagedReconciler
+	prevPoke := nudgePokeController
+	prevObserve := nudgeObserveTarget
+	pokes := 0
+	nudgeCityUsesManagedReconciler = func(cityPath string) bool { return cityPath == dir }
+	nudgePokeController = func(string) error {
+		pokes++
+		return nil
+	}
+	nudgeObserveTarget = func(nudgeTarget, beads.Store, runtime.Provider) (worker.LiveObservation, error) {
+		return worker.LiveObservation{Running: false}, nil
+	}
+	t.Cleanup(func() {
+		nudgeCityUsesManagedReconciler = prevManaged
+		nudgePokeController = prevPoke
+		nudgeObserveTarget = prevObserve
+	})
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		cfg:         &config.City{Agents: []config.Agent{{Name: "worker", Provider: "claude"}}},
+		sessionID:   info.ID,
+		sessionName: info.SessionName,
+		identity:    "worker",
+		agent:       config.Agent{Name: "worker", Provider: "claude"},
+	}
+
+	// Text mode: undeliverable → exit 1, message on stderr, and NOTHING enqueued.
+	var stdout, stderr bytes.Buffer
+	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryImmediate, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("deliverSessionNudgeWithWorker = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "undeliverable") || !strings.Contains(stderr.String(), "drained") {
+		t.Fatalf("stderr = %q, want undeliverable/drained", stderr.String())
+	}
+	if pokes != 0 {
+		t.Fatalf("pokes = %d, want 0 (guard fires before the enqueue/poke)", pokes)
+	}
+	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 0/0/0 (nothing enqueued — no evaporation and no dead-letter)", len(pending), len(inFlight), len(dead))
+	}
+	// The read-only probe must not have stamped a wake request on the session.
+	updated, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got := updated.Metadata["wake_request"]; got != "" {
+		t.Fatalf("wake_request = %q, want empty (probe is read-only)", got)
+	}
+
+	// JSON mode: a structured failure signal — ok=false, queued=false,
+	// outcome="undeliverable", with the state carried in reason.
+	var jstdout, jstderr bytes.Buffer
+	jcode := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryImmediate, true, &jstdout, &jstderr)
+	if jcode != 1 {
+		t.Fatalf("deliverSessionNudgeWithWorker(json) = %d, want 1", jcode)
+	}
+	for _, want := range []string{`"ok":false`, `"queued":false`, `"outcome":"undeliverable"`, `"reason":"drained"`} {
+		if !strings.Contains(jstdout.String(), want) {
+			t.Fatalf("json stdout = %q, want substring %q", jstdout.String(), want)
+		}
+	}
+}
+
 func TestDeliverSessionNudgeWithWorkerManagedWaitNudgeWithdrawFailureKeepsQueuedNudge(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2596,6 +2596,7 @@ type sessionNudgeJSON struct {
 	Delivery      string `json:"delivery"`
 	Queued        bool   `json:"queued"`
 	Outcome       string `json:"outcome"`
+	Reason        string `json:"reason,omitempty"`
 }
 
 // cmdSessionNudge is the CLI entry point for "gc session nudge".

--- a/internal/session/wait_store.go
+++ b/internal/session/wait_store.go
@@ -612,3 +612,49 @@ func (s *Store) wakeSessionFromBead(sessionBead beads.Bead, now time.Time) ([]st
 	}
 	return nudgeIDs, nil
 }
+
+// ManagedWakeWouldStrand reports, via a read-only lifecycle projection (it never
+// mutates the session, unlike WakeSession), whether enqueuing a managed nudge-wake
+// for session id would SILENTLY STRAND it: WakeSession would accept the wake with
+// no error, yet the reconciler never brings the session back to running to consume
+// the queued nudge, so the item lingers until its retired fence stops matching and
+// `gc nudge status` reads 0/0/0 while the sender was handed a false "queued"
+// success (the measured sc-875uie bug).
+//
+// This is deliberately NARROW — the completed/stopped states drained and stopped:
+//   - drained: the session finished its drain; the reconciler spawns a FRESH
+//     worker rather than resuming it, so a queued wake is never consumed. This is
+//     exactly the measured case (a nudge queued to a worker as it drained).
+//   - stopped: stopped outside normal sleep semantics — same "won't be resumed to
+//     consume" property.
+//
+// It intentionally does NOT cover the terminal (closed / closing /
+// archived-without-continuity) or gone (missing bead) cases: WakeSession already
+// rejects those with a WakeConflictError / ErrNotFound, so the existing
+// enqueue→wake→rollback path dead-letters them loudly (code 1 + a DEAD trace).
+// Scoping the send-time guard to only the states WakeSession misses keeps this fix
+// off the core session-wake semantics and preserves that established behavior.
+//
+// state is a short diagnostic label ("drained"/"stopped") the caller surfaces as
+// its failure signal. A store lookup error other than not-found is returned bare
+// so the caller can fall back to the existing path rather than misclassify.
+func (s *Store) ManagedWakeWouldStrand(id string, now time.Time) (state string, wouldStrand bool, err error) {
+	b, err := s.store.Get(id)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return "", false, nil // gone → WakeSession errors → existing rollback path handles it
+		}
+		return "", false, err
+	}
+	if !IsSessionBeadOrRepairable(b) {
+		return "", false, nil
+	}
+	RepairEmptyType(s.store.Store, &b)
+	lcInput := LifecycleInputFromMetadata(b.Status, b.Metadata)
+	lcInput.Now = now
+	switch base := ProjectLifecycle(lcInput).BaseState; base {
+	case BaseStateDrained, BaseStateStopped:
+		return string(base), true, nil
+	}
+	return "", false, nil
+}

--- a/internal/session/wait_store.go
+++ b/internal/session/wait_store.go
@@ -658,3 +658,49 @@ func (s *Store) ManagedWakeWouldStrand(id string, now time.Time) (state string, 
 	}
 	return "", false, nil
 }
+
+// ManagedWakeUnreachable reports, via a read-only lifecycle projection (it never
+// mutates the session), whether a nudge ALREADY QUEUED for session id can no longer
+// be consumed because the target session has reached a terminal or stranding
+// lifecycle state. It is the maintenance-time superset of ManagedWakeWouldStrand:
+// the send-time strand probe deliberately covers only the drained/stopped states
+// WakeSession would silently accept, leaving the terminal states to WakeSession's
+// own enqueue-time rejection. The drain-time dead-letter sweep, by contrast, runs
+// AFTER the raced session has often progressed all the way to closed (the
+// reconciler closes a drained pool worker), so it must treat BOTH the terminal
+// wake-conflict states (closed / closing / archived-without-continuity) AND the
+// stranding states (drained / stopped) as unreachable. Archived-WITH-continuity and
+// every live/resumable state (asleep, suspended, active, start-pending) return
+// unreachable=false — those genuinely still consume a queued nudge, so sweeping
+// them would drop a live delivery.
+//
+// A missing session bead (ErrNotFound) returns unreachable=false: at sweep time a
+// freshly-queued nudge can momentarily race ahead of a slow session read, so
+// treating a transient not-found as terminal would drop a legitimate nudge; a
+// genuinely retention-swept bead is caught by the fence-mismatch dead-letter path
+// on the next delivery attempt instead. Any other store error is returned bare so
+// the caller keeps the item rather than misclassify a live target as unreachable.
+func (s *Store) ManagedWakeUnreachable(id string, now time.Time) (state string, unreachable bool, err error) {
+	b, err := s.store.Get(id)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if !IsSessionBeadOrRepairable(b) {
+		return "", false, nil
+	}
+	RepairEmptyType(s.store.Store, &b)
+	lcInput := LifecycleInputFromMetadata(b.Status, b.Metadata)
+	lcInput.Now = now
+	view := ProjectLifecycle(lcInput)
+	if st, conflict := lifecycleWakeConflictState(view); conflict {
+		return st, true, nil
+	}
+	switch view.BaseState {
+	case BaseStateDrained, BaseStateStopped:
+		return string(view.BaseState), true, nil
+	}
+	return "", false, nil
+}

--- a/internal/session/wait_store_managed_wake_strand_test.go
+++ b/internal/session/wait_store_managed_wake_strand_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestManagedWakeWouldStrand_FlagsDrainedAndStoppedOnly pins the send-time
+// loud-fail classification behind the sc-875uie guard. Only the completed/stopped
+// states silently strand a managed nudge-wake (WakeSession accepts them with no
+// conflict, yet the reconciler never resumes them). Live/resumable states keep
+// the queue-a-wake behavior, and terminal/gone states are deliberately left to
+// WakeSession's own conflict/not-found rejection (the enqueue→rollback→dead-letter
+// path), so they must report wouldStrand=false here.
+func TestManagedWakeWouldStrand_FlagsDrainedAndStoppedOnly(t *testing.T) {
+	cases := []struct {
+		name            string
+		seedID          string // "" => do not seed the store (probe a missing id)
+		status          string
+		meta            map[string]string
+		probeID         string
+		wantWouldStrand bool
+		wantState       string // asserted only when wantWouldStrand is true
+	}{
+		{
+			name:            "drained-via-sleep-reason strands (the measured sc-875uie case)",
+			seedID:          "s-drained-sr",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep", "sleep_reason": "drained"},
+			probeID:         "s-drained-sr",
+			wantWouldStrand: true,
+			wantState:       "drained",
+		},
+		{
+			name:            "drained-via-state strands",
+			seedID:          "s-drained",
+			status:          "open",
+			meta:            map[string]string{"state": "drained"},
+			probeID:         "s-drained",
+			wantWouldStrand: true,
+			wantState:       "drained",
+		},
+		{
+			name:            "stopped strands",
+			seedID:          "s-stopped",
+			status:          "open",
+			meta:            map[string]string{"state": "stopped"},
+			probeID:         "s-stopped",
+			wantWouldStrand: true,
+			wantState:       "stopped",
+		},
+		{
+			name:            "asleep does not strand (resumable — keep queuing)",
+			seedID:          "s-asleep",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep"},
+			probeID:         "s-asleep",
+			wantWouldStrand: false,
+		},
+		{
+			name:            "active does not strand",
+			seedID:          "s-active",
+			status:          "open",
+			meta:            map[string]string{"state": "active"},
+			probeID:         "s-active",
+			wantWouldStrand: false,
+		},
+		{
+			name:            "closed is left to WakeSession's conflict rejection",
+			seedID:          "s-closed",
+			status:          "closed",
+			meta:            map[string]string{"state": "closed"},
+			probeID:         "s-closed",
+			wantWouldStrand: false,
+		},
+		{
+			name:            "missing bead is left to WakeSession's not-found rejection",
+			probeID:         "s-missing",
+			wantWouldStrand: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seeds []beads.Bead
+			if tc.seedID != "" {
+				seeds = append(seeds, sessionBeadFixture(tc.seedID, tc.status, tc.meta))
+			}
+			s, _ := recordingWaitStore(t, seeds...)
+			state, wouldStrand, err := s.ManagedWakeWouldStrand(tc.probeID, waitStoreNow)
+			if err != nil {
+				t.Fatalf("ManagedWakeWouldStrand(%q): unexpected error %v", tc.probeID, err)
+			}
+			if wouldStrand != tc.wantWouldStrand {
+				t.Fatalf("ManagedWakeWouldStrand(%q) wouldStrand = %v, want %v (state=%q)", tc.probeID, wouldStrand, tc.wantWouldStrand, state)
+			}
+			if tc.wantWouldStrand && state != tc.wantState {
+				t.Fatalf("ManagedWakeWouldStrand(%q) state = %q, want %q", tc.probeID, state, tc.wantState)
+			}
+		})
+	}
+}
+
+// TestManagedWakeWouldStrand_IsReadOnly asserts the probe never mutates the
+// session — unlike WakeSession, which stamps wake metadata via SetMetadataBatch.
+// Probing a drained session must emit zero writes.
+func TestManagedWakeWouldStrand_IsReadOnly(t *testing.T) {
+	s, rec := recordingWaitStore(t, sessionBeadFixture("s-drained", "open", map[string]string{"state": "asleep", "sleep_reason": "drained"}))
+	if _, _, err := s.ManagedWakeWouldStrand("s-drained", waitStoreNow); err != nil {
+		t.Fatalf("ManagedWakeWouldStrand: %v", err)
+	}
+	if writes := rec.CallsForOp("SetMetadataBatch"); len(writes) != 0 {
+		t.Fatalf("ManagedWakeWouldStrand emitted %d SetMetadataBatch writes, want 0 (must be read-only)", len(writes))
+	}
+}

--- a/internal/session/wait_store_managed_wake_unreachable_test.go
+++ b/internal/session/wait_store_managed_wake_unreachable_test.go
@@ -1,0 +1,124 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestManagedWakeUnreachable_FlagsTerminalAndStranding pins the drain-time
+// dead-letter classification behind the sc-875uie sweep. Unlike the send-time
+// ManagedWakeWouldStrand probe (drained/stopped only), the maintenance-time sweep
+// runs after the raced session has often already reached closed, so it must flag
+// BOTH the terminal wake-conflict states (closed / archived-without-continuity) AND
+// the stranding states (drained / stopped) as unreachable — while still leaving a
+// genuinely resumable session (asleep / active / archived-with-continuity) alone so
+// a queued nudge it will still consume is never dropped.
+func TestManagedWakeUnreachable_FlagsTerminalAndStranding(t *testing.T) {
+	cases := []struct {
+		name            string
+		seedID          string // "" => do not seed the store (probe a missing id)
+		status          string
+		meta            map[string]string
+		probeID         string
+		wantUnreachable bool
+		wantState       string // asserted only when wantUnreachable is true
+	}{
+		{
+			name:            "closed is unreachable (the drained pool worker the reconciler closed)",
+			seedID:          "s-closed",
+			status:          "closed",
+			meta:            map[string]string{"state": "closed"},
+			probeID:         "s-closed",
+			wantUnreachable: true,
+			wantState:       "closed",
+		},
+		{
+			name:            "drained is unreachable (the measured sc-875uie race)",
+			seedID:          "s-drained",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep", "sleep_reason": "drained"},
+			probeID:         "s-drained",
+			wantUnreachable: true,
+			wantState:       "drained",
+		},
+		{
+			name:            "stopped is unreachable",
+			seedID:          "s-stopped",
+			status:          "open",
+			meta:            map[string]string{"state": "stopped"},
+			probeID:         "s-stopped",
+			wantUnreachable: true,
+			wantState:       "stopped",
+		},
+		{
+			name:            "archived-without-continuity is unreachable",
+			seedID:          "s-arch-no",
+			status:          "open",
+			meta:            map[string]string{"state": "archived", "continuity_eligible": "false"},
+			probeID:         "s-arch-no",
+			wantUnreachable: true,
+			wantState:       "archived",
+		},
+		{
+			name:            "archived-with-continuity stays reachable (still resumable)",
+			seedID:          "s-arch-yes",
+			status:          "open",
+			meta:            map[string]string{"state": "archived", "continuity_eligible": "true"},
+			probeID:         "s-arch-yes",
+			wantUnreachable: false,
+		},
+		{
+			name:            "asleep stays reachable (a queued nudge is still consumed on wake)",
+			seedID:          "s-asleep",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep"},
+			probeID:         "s-asleep",
+			wantUnreachable: false,
+		},
+		{
+			name:            "active stays reachable",
+			seedID:          "s-active",
+			status:          "open",
+			meta:            map[string]string{"state": "active"},
+			probeID:         "s-active",
+			wantUnreachable: false,
+		},
+		{
+			name:            "missing bead is not swept (transient-race safe; left to the fence-mismatch path)",
+			probeID:         "s-missing",
+			wantUnreachable: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seeds []beads.Bead
+			if tc.seedID != "" {
+				seeds = append(seeds, sessionBeadFixture(tc.seedID, tc.status, tc.meta))
+			}
+			s, _ := recordingWaitStore(t, seeds...)
+			state, unreachable, err := s.ManagedWakeUnreachable(tc.probeID, waitStoreNow)
+			if err != nil {
+				t.Fatalf("ManagedWakeUnreachable(%q): unexpected error %v", tc.probeID, err)
+			}
+			if unreachable != tc.wantUnreachable {
+				t.Fatalf("ManagedWakeUnreachable(%q) unreachable = %v, want %v (state=%q)", tc.probeID, unreachable, tc.wantUnreachable, state)
+			}
+			if tc.wantUnreachable && state != tc.wantState {
+				t.Fatalf("ManagedWakeUnreachable(%q) state = %q, want %q", tc.probeID, state, tc.wantState)
+			}
+		})
+	}
+}
+
+// TestManagedWakeUnreachable_IsReadOnly asserts the sweep probe never mutates the
+// session it classifies — probing a terminal session must emit zero writes.
+func TestManagedWakeUnreachable_IsReadOnly(t *testing.T) {
+	s, rec := recordingWaitStore(t, sessionBeadFixture("s-closed", "closed", map[string]string{"state": "closed"}))
+	if _, _, err := s.ManagedWakeUnreachable("s-closed", waitStoreNow); err != nil {
+		t.Fatalf("ManagedWakeUnreachable: %v", err)
+	}
+	if writes := rec.CallsForOp("SetMetadataBatch"); len(writes) != 0 {
+		t.Fatalf("ManagedWakeUnreachable emitted %d SetMetadataBatch writes, want 0 (must be read-only)", len(writes))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4534.

A managed nudge (`gc session nudge`, and the `gc mail --notify` wake path) sent to a
session that has **drained or terminated** was silently accepted. The send path routed to
the queued-wake branch purely on `!obs.Running`, which cannot tell a dormant/resumable
session apart from one that has ended: `WakeSession` accepts the wake, the sender is handed
a `queued` success, and nothing ever consumes it — so `gc nudge status` later reads
`0 pending / 0 in-flight / 0 dead`. Zero delivery signal, zero failure signal. (Measured on
a real coordinator→worker resume-nudge that evaporated for 25+ minutes before a human caught
it.)

This is the *adjacency-as-delivery* failure class: a queued wake sitting next to a dead
session was presented as delivery. The fix makes both the send path and the maintenance
path derive delivery-failure from the target session's **real lifecycle state**, so the
nudge fails loudly instead of evaporating. Two complementary halves:

### (a) Send-time UNDELIVERABLE guard
`deliverSessionNudgeWithWorker`, before enqueuing a managed wake, now probes the target's
lifecycle via a new read-only `session.Store.ManagedWakeWouldStrand(id, now)`. If the target
is in a state `WakeSession` *accepts but never actually resumes* (`drained`, `stopped`), the
send returns `exit 1` with structured `{ok:false, queued:false, outcome:"undeliverable",
reason:…}` JSON instead of queuing a wake into the void. Probe errors fail **open** (fall
through to the normal enqueue) so a transient store hiccup can't block a legitimate nudge.
Terminal states (`closed`/`closing`/`archived-without-continuity`) and missing beads are
deliberately left to the existing `WakeSession` reject → rollback path, which already
dead-letters them loudly (`exit 1` + a `Dead` trace) and is heavily tested — narrowing to
the genuinely-silent gap keeps this off core wake semantics and regresses nothing.

### (a2) Drain-time dead-letter sweep
Closes the **race** the send-time guard cannot catch: a nudge queued to a live/asleep
session that *then* terminates before consuming it. Rather than hooking every reconciler
close branch (multi-observer, would need duplicate-bounce guards on each), a new
`pruneStrandedQueuedNudges` runs in the existing nudge-maintenance passes (status /
agent-list / claim-poll) and moves any Pending/InFlight item whose target session is now
unreachable — via read-only `session.Store.ManagedWakeUnreachable(id, now)`, the
maintenance-time superset of the send-time probe — to `state.Dead` with a
`session terminated` reason, terminalizing the backing bead. It is session-keyed
(agent-broadcast items are left alone), fail-closed on probe error, and never opens a Dolt
store on an idle/empty queue (the dial-skip guarantee holds; probe stays nil until the queue
has work).

**Net effect:** a nudge to a drained session now fails **UNDELIVERABLE at send time**, and a
queued-then-drained nudge surfaces as a real **Dead** trace in `gc nudge status` instead of
reading `0/0/0`.

Comment-to-closed is intentionally left as the existing **WARN** tripwire (not hard-blocked):
record-comments on closed beads are legitimate and a hard block there would fight every
attest/receipt flow. This PR touches no comment-handling code.

## Testing

- [x] `go build ./...`
- [x] `go vet ./cmd/gc/... ./internal/session/...` + `gofmt` clean on all changed files
- [x] `go test ./internal/session/ -run 'Strand|Unreachable|ManagedWake'`
- [x] `go test ./cmd/gc/ -run 'Nudge|Managed|Deliver|SessionNudge|SendMailNotify|Strand|Unreachable'`
- [ ] `make check` — full gate deferred to CI on this PR
- [ ] `make check-docs` — n/a, no docs/navigation/links changed
- [ ] `make test-integration` — n/a, no controller/workflow control-flow changed (nudge delivery only)

New tests:
- `TestManagedWakeWouldStrand_FlagsDrainedAndStoppedOnly` / `_IsReadOnly` — send-time probe flags exactly `drained`/`stopped`, mutates nothing
- `TestDeliverSessionNudgeWithWorkerManagedDrainedTargetIsUndeliverable` — end-to-end: `exit 1`, nothing enqueued (0/0/0), structured `undeliverable` JSON, no `wake_request` stamped
- `TestManagedWakeUnreachable_FlagsTerminalAndStranding` / `_IsReadOnly` — maintenance probe superset flags terminal + stranding, mutates nothing
- `TestPruneStrandedQueuedNudgesDrainTimeRaceIsDeadLettered` — deliver → drain → sweep dead-letters and stays visible; NOT swept while asleep (no false positive); idempotent

## Checklist

- [x] Linked issue #4534
- [x] Added tests for behavior changes
- [x] No user-facing docs change needed
- [x] No breaking changes — the added `reason` field is additive (`omitempty`); the guard is narrowed to the previously-silent `drained`/`stopped` gap, leaving existing terminal/gone dead-letter paths unchanged

## Proof — demonstrated before/after

Both binaries were built locally and driven through the **real** `gc session nudge` /
`gc nudge status` CLI paths (no behavior stubbed — `deliverSessionNudgeWithWorker` +
`ManagedWakeWouldStrand` for the send-time guard, and `pruneStrandedQueuedNudges` +
`ManagedWakeUnreachable` for the drain-time sweep, all run as shipped):

- **NEW** = this branch `fix/nudge-loud-fail-guard-4534` @ `a7b5cf53c`
- **OLD** = its parent `c2538d42b` — the branch **minus only the two nudge commits**
  (`a1a0a442e` send-time guard + `a7b5cf53c` drain-time sweep), so the two binaries
  differ by *exactly* this fix and nothing else.

Harness: a throwaway isolated city on the in-memory runtime. The `drained` / `closed`
session lifecycle states are induced directly in the store — exactly as the unit tests
do (`store.SetMetadata(id, "state", "drained")`) — to stand in for a drained pool
worker without spinning real agents.

### (a) Send-time guard — `gc session nudge` to a drained session

```
# OLD (pre-fix): the sender is handed a false "queued" success — zero delivery
# signal, zero failure signal; the wake is accepted but the drained worker is
# never resumed, so the nudge is never consumed.
$ gc session nudge <drained-session> "deploy status?" --json
{"schema_version":"1","ok":true,"target":"gc-18",...,"delivery":"wait-idle","queued":true,"outcome":"queued"}
  → exit 0

# NEW: fails UNDELIVERABLE at send time, structured JSON, nothing enqueued.
$ gc session nudge <drained-session> "deploy status?" --json
{"schema_version":"1","ok":false,"target":"gc-19",...,"delivery":"wait-idle","queued":false,"outcome":"undeliverable","reason":"drained"}
  → exit 1
```

### (b) Drain-time sweep — a nudge queued to a live session that then terminates

The race the send-time guard cannot catch: the nudge queues fine while the target is
alive/asleep, then the reconciler closes the (drained) worker before it is consumed.

```
# OLD (pre-fix): after the session terminates, the queued nudge is silently
# STRANDED — never dead-lettered, no failure signal. This repro captures the
# strand immediately (1 pending / 0 dead, below); in the #4534 field incident
# that same strand went on to evaporate fully to 0/0/0 ~25 min later, once the
# session's retired fence stopped matching.
$ gc nudge status <session>
AGENT  PENDING  IN_FLIGHT  DEAD  SESSION
gc-21  1        0          0     claude-adhoc-8599680773
pending  nudge-dfab9347d34e  due=now  source=session  check deploy
  → exit 0

# NEW: the drain-time sweep DEAD-LETTERS it — a real, visible Dead trace.
$ gc nudge status <session>
AGENT  PENDING  IN_FLIGHT  DEAD  SESSION
gc-23  0        0          1     claude-adhoc-3f283cc346
dead     nudge-6ef545378f3d  reason=session closed  source=session  check deploy
  → exit 0
```

**Net:** a *managed* nudge to a drained session — the default live / wait-idle route —
now fails **undeliverable at send time** (`exit 1`, `outcome:"undeliverable"`) instead of
returning a false `queued` success (a transient probe error still fails **open** to the
existing enqueue, and an explicit `--delivery=queue` is deliberately still honored), and a
queued-then-terminated nudge surfaces as a real **`dead`** trace in `gc nudge status`
instead of silently stranding — matching the two unit tests
(`TestDeliverSessionNudgeWithWorkerManagedDrainedTargetIsUndeliverable`,
`TestPruneStrandedQueuedNudgesDrainTimeRaceIsDeadLettered`) at the CLI level.
