### PR TITLE
fix(cmd/gc): only retarget engine-generated PreStart entries, not user-authored literals (#4069)

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1248,9 +1248,28 @@ func resolvePreparedTaskWorkDir(
 	return resolveTaskWorkDir(cityPath, store, taskWorkDirAssignees(candidate, cfg)...)
 }
 
-// retargetPreStartWorkDir rewrites PreStart command strings rendered against
-// oldWorkDir so they instead reference newWorkDir. A no-op when the task
-// work_dir override left WorkDir unchanged, which is the common case.
+// generatedPreStartPrefixes are the exact command prefixes
+// appendMaterializeSkillsPreStart and appendProjectMCPPreStart emit. Only a
+// PreStart entry starting with one of these is eligible for retargeting —
+// see retargetPreStartWorkDir.
+var generatedPreStartPrefixes = []string{
+	`"${GC_BIN:-gc}" internal materialize-skills `,
+	`"${GC_BIN:-gc}" internal project-mcp `,
+}
+
+func isGeneratedPreStartCommand(cmd string) bool {
+	for _, prefix := range generatedPreStartPrefixes {
+		if strings.HasPrefix(cmd, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// retargetPreStartWorkDir rewrites the engine-generated PreStart command
+// strings rendered against oldWorkDir so they instead reference newWorkDir.
+// A no-op when the task work_dir override left WorkDir unchanged, which is
+// the common case.
 //
 // The generated materialize-skills and project-mcp PreStart commands embed the
 // workdir as a shell-quoted token (see appendMaterializeSkillsPreStart and
@@ -1259,6 +1278,13 @@ func resolvePreparedTaskWorkDir(
 // quoting even when the resolved workdir contains spaces or shell
 // metacharacters. Splicing the raw path in would break argument boundaries or
 // open a command-substitution surface.
+//
+// Only entries matching generatedPreStartPrefixes are touched. A
+// user-authored PreStart command that happens to contain the old workdir as
+// a literal path (e.g. a rig root a worktree-setup script deliberately
+// hardcodes, distinct from the per-session dir it's given via $GC_DIR) must
+// never be rewritten — a literal path in config is an explicit user choice,
+// and {{.WorkDir}} already exists for users who want the session dir.
 func retargetPreStartWorkDir(preStart []string, oldWorkDir, newWorkDir string) []string {
 	if oldWorkDir == "" || newWorkDir == "" || oldWorkDir == newWorkDir || len(preStart) == 0 {
 		return preStart
@@ -1267,7 +1293,11 @@ func retargetPreStartWorkDir(preStart []string, oldWorkDir, newWorkDir string) [
 	newToken := shellquote.Join([]string{newWorkDir})
 	retargeted := make([]string, len(preStart))
 	for i, cmd := range preStart {
-		retargeted[i] = strings.ReplaceAll(cmd, oldToken, newToken)
+		if isGeneratedPreStartCommand(cmd) {
+			retargeted[i] = strings.ReplaceAll(cmd, oldToken, newToken)
+		} else {
+			retargeted[i] = cmd
+		}
 	}
 	return retargeted
 }

--- a/cmd/gc/session_scaffold_staging_test.go
+++ b/cmd/gc/session_scaffold_staging_test.go
@@ -230,6 +230,45 @@ func TestRetargetPreStartWorkDirPreservesShellQuoting(t *testing.T) {
 	}
 }
 
+// TestRetargetPreStartWorkDirPreservesUserAuthoredLiterals is the regression
+// for #4069: retargetPreStartWorkDir used to blindly ReplaceAll the
+// pre-override workdir across every PreStart entry, including user-authored
+// commands that reference the rig root as a deliberate hardcoded literal
+// (the canonical case: `git worktree add` must run against the main
+// checkout, not the not-yet-existing per-session directory). Only the
+// engine-generated materialize-skills / project-mcp entries should ever be
+// rewritten; {{.WorkDir}} already exists for users who want the session dir.
+func TestRetargetPreStartWorkDirPreservesUserAuthoredLiterals(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldWorkDir = "/Users/klashesselman/Claude/flow-city"
+		newWorkDir = "/Users/klashesselman/Claude/flow-city/fc-r1xz-load-context-and-verify-assignment"
+	)
+	userCmd := "worktree-setup.sh " + oldWorkDir + " \"$GC_DIR\" gc-worker --sync"
+
+	preStart := []string{userCmd}
+	preStart = appendMaterializeSkillsPreStart(preStart, "gascity/builder", oldWorkDir)
+
+	retargeted := retargetPreStartWorkDir(preStart, oldWorkDir, newWorkDir)
+	if len(retargeted) != 2 {
+		t.Fatalf("retarget produced %d entries, want 2: %v", len(retargeted), retargeted)
+	}
+
+	if retargeted[0] != userCmd {
+		t.Errorf("user-authored literal was rewritten:\n got:  %s\n want: %s", retargeted[0], userCmd)
+	}
+	// newWorkDir is old+suffix here (matching the real-world rig-scoped
+	// per-session worktree naming from the report), so a plain
+	// strings.Contains(retargeted[1], oldWorkDir) check would pass
+	// spuriously even on a correctly-retargeted value. Compare against
+	// what a fresh generation against newWorkDir produces instead.
+	want := appendMaterializeSkillsPreStart(nil, "gascity/builder", newWorkDir)[0]
+	if retargeted[1] != want {
+		t.Errorf("generated materialize-skills entry not retargeted:\n got:  %s\n want: %s", retargeted[1], want)
+	}
+}
+
 // workdirArgFromCommand parses a generated PreStart command with the same
 // POSIX quoting rules the generators use and returns the argument following the
 // final --workdir flag.


### PR DESCRIPTION
## Summary

When a task `work_dir` override replaces an agent's WorkDir, `retargetPreStartWorkDir` (`cmd/gc/session_lifecycle_parallel.go`) blindly `ReplaceAll`s the pre-override workdir across **every** `PreStart` command string — including user-authored commands that reference a path (typically the rig root) as a deliberate hardcoded literal.

Canonical case from the report: a worktree-setup script needs the rig root (`git worktree add` must run against the main checkout), with the per-session dir already available separately via `$GC_DIR` — but the literal rig-root path in the user's own `pre_start` command got silently rewritten to the per-session directory, breaking the script.

Scoped to the reporter's confidently-root-caused primary bug only — the issue's own secondary "suspected `started_config_hash` drain churn" theory is explicitly hedged ("not fully root-caused... suspected... plausible mechanism"), so left untouched.

## Fix

The two engine-generated `PreStart` entries (`appendMaterializeSkillsPreStart`, `appendProjectMCPPreStart`) both emit a stable, recognizable command prefix (`"${GC_BIN:-gc}" internal materialize-skills ` / `"${GC_BIN:-gc}" internal project-mcp `). Added `isGeneratedPreStartCommand` gating on those two prefixes, so only entries matching one of them are eligible for the shell-quoted-token swap; every other entry (including a user literal that happens to contain the old workdir as a substring) passes through untouched.

Fixes #4069.

## Test plan

New test `TestRetargetPreStartWorkDirPreservesUserAuthoredLiterals` (`cmd/gc/session_scaffold_staging_test.go`), RED-confirmed (stashed the production fix, ran, restored):

- RED: the user-authored literal command was rewritten exactly as reported.
- GREEN after the fix, and the pre-existing `TestRetargetPreStartWorkDirPreservesShellQuoting` (proving the generated-entry retarget path still keeps shell-quoting intact) stays green — confirms the change is additive, not a behavior removal on the path that's supposed to keep working.

- [x] New test + all `TestRetarget*`/`TestPreStart*`/`TestScaffold*`/`TestBuildPreparedStart*`/`TestPrepareStartCandidate*` pass
- [x] `go build ./...` (full repo, untagged) — clean
- [x] Full untagged pre-commit hook (lint-changed, spec/client/schema codegen, `go vet ./...`) ran clean on this commit — no bypass needed
- [x] Full sharded local test suite — pre-existing sandbox flakiness this run (recurring subprocess/timing/Docker/dolt-startup failures seen across today's other pushes) — none of `TestRetargetPreStartWorkDir*`, `TestPrepareStartCandidate*`, `TestBuildPreparedStart*`, or `TestScaffold*` (the code this change touches) appear in any failing shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGjSaP5EtcXZYqgBafw61m