### PR TITLE
fix(orders/nudge-on-route): match flat bead.updated payload so routed nudges deliver

### DIFF
--- a/internal/bootstrap/packs/core/assets/scripts/nudge-on-route.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/nudge-on-route.sh
@@ -87,10 +87,15 @@ EVENTS="$(gc events --type bead.updated --since "$LOOKBACK" 2>/dev/null)" || exi
 
 # Reduce to unique "<bead_id>\t<routed_to>" pairs. Only events that actually
 # carry a non-empty gc.routed_to target are considered.
+#
+# The bead.updated payload is flat — .payload.id and .payload.metadata — not
+# the nested .payload.bead.{id,metadata} an earlier schema exposed. The nested
+# paths match nothing against the current event shape, so every routed bead was
+# silently dropped and no nudge was ever delivered.
 PAIRS="$(printf '%s\n' "$EVENTS" \
-    | jq -r 'select(.payload.bead.metadata."gc.routed_to" != null
-                    and .payload.bead.metadata."gc.routed_to" != "")
-             | [.payload.bead.id, .payload.bead.metadata."gc.routed_to"] | @tsv' 2>/dev/null \
+    | jq -r 'select(.payload.metadata."gc.routed_to" != null
+                    and .payload.metadata."gc.routed_to" != "")
+             | [.payload.id, .payload.metadata."gc.routed_to"] | @tsv' 2>/dev/null \
     | sort -u)" || PAIRS=""
 [ -n "$PAIRS" ] || exit 0
 


### PR DESCRIPTION
## Problem

The `nudge-on-route` core order (the shipped workaround for #1129 — wake a warm-idle worker the moment a bead is routed to it) never delivers a nudge against the current event schema. Every routed bead is silently dropped.

## Root cause

`internal/bootstrap/packs/core/assets/scripts/nudge-on-route.sh` decodes `bead.updated` events with jq to find beads carrying a `gc.routed_to` target:

```
select(.payload.bead.metadata."gc.routed_to" != null ...)
| [.payload.bead.id, .payload.bead.metadata."gc.routed_to"] | @tsv
```

But the `bead.updated` payload is **flat** — there is no `.payload.bead` node. The routing target lives at `.payload.metadata."gc.routed_to"` and the id at `.payload.id`. Both the metadata path and the id path read the stale nested shape, so the selector matches nothing and no `(bead, routed_to)` pairs are produced. `[ -n "$PAIRS" ] || exit 0` then exits cleanly, so the failure is silent — warm-idle workers miss work routed to them, the exact regression #1129's workaround exists to prevent.

## Fix

Read the flat paths:

```
select(.payload.metadata."gc.routed_to" != null ...)
| [.payload.id, .payload.metadata."gc.routed_to"] | @tsv
```

One file, jq selector only.

## Evidence

Verified against live `bead.updated` events, both directions:

- **Stock (nested) selector** → **0 pairs** (the bug): `select(.payload.bead.metadata."gc.routed_to" != null) | [.payload.bead.id, ...]` produces nothing.
- **Fixed (flat) selector** → real pairs: `ra-3nekt → perrin`, `ra-4uuui → smiths`, `ra-5h9k6 → novices`, `ra-7rxbh → egwene`, … i.e. the actual routed beads with their targets.

A real event payload for reference has top-level keys `[assignee, created_at, id, issue_type, metadata, status, title]` under `.payload` — no `bead` sub-object — with `.payload.metadata."gc.routed_to"` holding the target.

## Scope

Selector paths only; no behavior change beyond making the existing match work against the current schema.
