### PR TITLE
fix(orders): give a never-run cron order one bounded catch-up chance (#3947)

### DIFF
--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -227,30 +227,43 @@ func checkCron(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult {
 	// may have elapsed since lastRun without an evaluation landing on it. Scan
 	// minute-by-minute from just after lastRun up to now; any match is a missed
 	// occurrence that is now due. Bounded lookback so a very old lastRun cannot
-	// spin (it is overdue regardless). Skipped when lastRun is zero (never run):
-	// such an order fires only on an exact match, never back-filling history.
-	if !last.IsZero() {
-		const maxCatchupLookback = 366 * 24 * time.Hour
-		start := last.Truncate(time.Minute).Add(time.Minute)
-		if floor := now.Add(-maxCatchupLookback).Truncate(time.Minute); start.Before(floor) {
-			start = floor
+	// spin (it is overdue regardless).
+	//
+	// A never-run order (lastRun zero) gets the same scan bounded to a much
+	// shorter lookback instead of being skipped entirely: without it, a
+	// narrow-window order (e.g. one specific minute/day) that never happens to
+	// be evaluated on its exact scheduled minute could never fire at all — no
+	// lastRun exists to catch up from, and no restart recovers it (#3947, a
+	// residual cold-start gap in the warm-order catch-up above). The short
+	// floor keeps a freshly-enabled order from firing for an occurrence that
+	// elapsed long before it existed, unlike the year-long lookback a warm
+	// order's lastRun-anchored catch-up gets.
+	const maxCatchupLookback = 366 * 24 * time.Hour
+	const neverRunCatchupLookback = 25 * time.Hour
+	lookback := maxCatchupLookback
+	start := last.Truncate(time.Minute).Add(time.Minute)
+	if last.IsZero() {
+		lookback = neverRunCatchupLookback
+		start = now.Add(-neverRunCatchupLookback).Truncate(time.Minute)
+	}
+	if floor := now.Add(-lookback).Truncate(time.Minute); start.Before(floor) {
+		start = floor
+	}
+	prev := start.Add(-time.Minute)
+	for t := start; !t.After(now); t = t.Add(time.Minute) {
+		// Spring-forward: one absolute minute stepped over a wall-clock
+		// gap (e.g. 01:59 → 03:00). Schedule minutes inside the gap can
+		// never match a real instant, so evaluate the skipped wall-clock
+		// readings and fire at this first real minute after the jump.
+		_, prevOff := prev.Zone()
+		_, tOff := t.Zone()
+		if tOff > prevOff && matchesInWallGap(matchesAt, prev, t) {
+			return TriggerResult{Due: true, Reason: "cron: caught up occurrence skipped by DST spring-forward", LastRun: last}
 		}
-		prev := start.Add(-time.Minute)
-		for t := start; !t.After(now); t = t.Add(time.Minute) {
-			// Spring-forward: one absolute minute stepped over a wall-clock
-			// gap (e.g. 01:59 → 03:00). Schedule minutes inside the gap can
-			// never match a real instant, so evaluate the skipped wall-clock
-			// readings and fire at this first real minute after the jump.
-			_, prevOff := prev.Zone()
-			_, tOff := t.Zone()
-			if tOff > prevOff && matchesInWallGap(matchesAt, prev, t) {
-				return TriggerResult{Due: true, Reason: "cron: caught up occurrence skipped by DST spring-forward", LastRun: last}
-			}
-			if matchesAt(t) && !sameWallMinute(last, t) {
-				return TriggerResult{Due: true, Reason: "cron: caught up missed occurrence", LastRun: last}
-			}
-			prev = t
+		if matchesAt(t) && !sameWallMinute(last, t) {
+			return TriggerResult{Due: true, Reason: "cron: caught up missed occurrence", LastRun: last}
 		}
+		prev = t
 	}
 
 	return TriggerResult{Due: false, Reason: "cron: schedule not matched", LastRun: last}

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -82,11 +82,18 @@ func TestCheckTriggerCronEveryMinuteStepMatched(t *testing.T) {
 
 func TestCheckTriggerCronNotMatched(t *testing.T) {
 	a := Order{Name: "cleanup", Trigger: "cron", Schedule: "0 3 * * *"}
-	// 12:00 UTC — should not match.
+	// 12:00 UTC — should not match. Uses a warm lastRun (a minute ago, not a
+	// scheduled boundary) rather than neverRan: since #3947's fix, a never-run
+	// order's own bounded catch-up window would otherwise legitimately find
+	// today's already-elapsed 03:00 occurrence and correctly report Due — this
+	// test isolates the plain "off-schedule minute, nothing to catch up"
+	// case instead of confounding it with that separate cold-start path.
 	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)
-	result := CheckTrigger(a, now, neverRan, nil, nil)
+	lastRun := now.Add(-1 * time.Minute)
+	lastRunFn := func(_ string) (time.Time, error) { return lastRun, nil }
+	result := CheckTrigger(a, now, lastRunFn, nil, nil)
 	if result.Due {
-		t.Errorf("Due = true, want false (schedule doesn't match 12:00)")
+		t.Errorf("Due = true, want false (schedule doesn't match 12:00, nothing to catch up since lastRun)")
 	}
 }
 
@@ -104,6 +111,43 @@ func TestCheckTriggerCronCatchesUpMissedBoundary(t *testing.T) {
 	result := CheckTrigger(a, now, lastRunFn, nil, nil)
 	if !result.Due {
 		t.Errorf("Due = false, want true (catch up the missed 04:00 occurrence); reason=%q", result.Reason)
+	}
+}
+
+// TestCheckTriggerCronNeverRunCatchesUpRecentMissedBoundary is the
+// regression for #3947: the catch-up scan added by the fix above was
+// gated on a non-zero lastRun, so a freshly-installed narrow-window order
+// (e.g. a daily-once schedule) that never happens to be evaluated on its
+// exact scheduled minute could never fire at all — not even once — since
+// there was no lastRun to catch up from and no restart recovers it either.
+func TestCheckTriggerCronNeverRunCatchesUpRecentMissedBoundary(t *testing.T) {
+	a := Order{Name: "janitor-worktree-gc", Trigger: "cron", Schedule: "20 4 * * *"}
+	// Scheduled minute (04:20) elapsed less than an hour ago; the
+	// controller's coarse eval cadence never landed on it exactly.
+	now := time.Date(2026, 7, 5, 5, 0, 0, 0, time.UTC)
+	result := CheckTrigger(a, now, neverRan, nil, nil)
+	if !result.Due {
+		t.Errorf("Due = false, want true (never-run order should catch up its recent missed 04:20 occurrence); reason=%q", result.Reason)
+	}
+}
+
+// TestCheckTriggerCronNeverRunDoesNotCatchUpAncientOccurrence guards the
+// #3947 fix's own safety bound: a never-run order must not reach back
+// through its full history and fire for a schedule occurrence that
+// elapsed long before it was even installed — only the warm (non-zero
+// lastRun) catch-up path gets the full year-long lookback. A daily
+// schedule's most recent occurrence is always <=24h before now, so this
+// needs a weekly schedule to construct a "most recent occurrence is
+// clearly outside the never-run bootstrap window" case.
+func TestCheckTriggerCronNeverRunDoesNotCatchUpAncientOccurrence(t *testing.T) {
+	a := Order{Name: "weekly-report", Trigger: "cron", Schedule: "0 4 * * 0"} // Sundays 04:00
+	// 2026-07-05 is a Sunday; evaluating three days later, the most recent
+	// occurrence (07-05 04:00) is ~74h in the past — well outside any
+	// reasonable never-run bootstrap window, and next Sunday hasn't come yet.
+	now := time.Date(2026, 7, 8, 6, 0, 0, 0, time.UTC)
+	result := CheckTrigger(a, now, neverRan, nil, nil)
+	if result.Due {
+		t.Errorf("Due = true, want false (never-run bootstrap window must not reach back days); reason=%q", result.Reason)
 	}
 }
 


### PR DESCRIPTION
## Summary

A cron order that has never fired can never bootstrap. `checkCron`'s catch-up scan (added by #2721 specifically to stop a scheduled occurrence being silently dropped when the controller's coarse eval cadence doesn't land on the exact minute) was gated on a non-zero `lastRun`. A freshly-installed narrow-window order (one specific minute/day) with no prior run had no `lastRun` to catch up from — it could only ever fire on an exact-minute coincidence, and if that never happens, no restart helps either, since `lastRun` stays zero forever. #2721's own comment named this skip explicitly as the corner it left open — an exceptionally well-documented issue, filed with two candidate fixes, explicit trade-off analysis, and the author's own recommendation.

Observed live: `janitor-worktree-gc` (`schedule = "20 4 * * *"`) missed both its first two daily 04:20 windows after install, zero order history, until a manual `gc order run` established a first `lastRun` and it self-healed from there.

Fixes #3947.

## Fix

Followed the issue's own recommended "fix candidate A" (smallest change, stays entirely inside `checkCron`) over candidate B (seed a durable install timestamp at registration — bigger blast radius, no such field exists today).

`internal/orders/triggers.go` `checkCron`: the `if !last.IsZero() { ... }` guard around the minute-by-minute catch-up scan is gone. A never-run order now gets the identical scan, but bounded to a new `25h` lookback (`neverRunCatchupLookback`) instead of the `366`-day `maxCatchupLookback` warm orders get — picking the issue's own suggested example floor. The short bound is deliberate: a freshly-enabled order must not reach back through ancient history and fire for an occurrence that elapsed long before it existed, which is exactly why the warm and cold-start paths now share the scan logic but not the lookback constant.

## Test plan

Two new tests, RED-confirmed for the first:

- `TestCheckTriggerCronNeverRunCatchesUpRecentMissedBoundary` — a never-run daily-at-04:20 order evaluated at 05:00 the same day. RED: `Due = false, reason = "cron: schedule not matched"`. GREEN after the fix.
- `TestCheckTriggerCronNeverRunDoesNotCatchUpAncientOccurrence` — guards the bound itself: a never-run **weekly** order (Sunday 04:00) evaluated 3 days later must NOT catch up (its most recent occurrence is ~74h back, outside the 25h floor). Needed a weekly schedule for this guard specifically — a daily schedule's most recent occurrence is always ≤24h before `now`, so it can't construct an "outside the never-run window" case at all once the fix lands.

Caught a real regression from a pre-existing test along the way: `TestCheckTriggerCronNotMatched` used `neverRan` + a daily schedule to test "the exact current minute doesn't match" in isolation — but once never-run orders get their own catch-up window, that exact fixture (daily schedule, more than a few hours since the last occurrence, never run) now *correctly* becomes Due per the fix's own intent, so the old assertion (`Due == false`) broke. Fixed by giving that test an explicit warm `lastRun` (1 minute before `now`, not a scheduled boundary) instead of `neverRan`, isolating the "off-schedule minute, nothing new to catch up" case it actually intends to test from the newly-extended cold-start path.

- [x] All cron trigger tests (18 test functions/subtests in `triggers_test.go`, including every DST/timezone/multi-day-gap edge case already covered): pass, no other regressions
- [x] Full `internal/orders` package: pass
- [x] `go test -tags gms_pure_go ./cmd/gc/... -run TestOrder` and `./internal/api/... -run TestOrder`: pass (order-dispatch and API consumers of `CheckTrigger`)
- [x] `go build ./...` (full repo, untagged): clean
- [x] `go vet -tags gms_pure_go ./internal/orders/... ./cmd/gc/... ./internal/api/...`: clean
- [x] Full untagged pre-commit hook (`lint-changed`, spec/client/schema codegen, `go vet ./...`) passed clean, no `--no-verify`
- [x] Full sharded local test suite — one run hit a `[build failed]` in `internal/doctor`, traced to a concurrent in-progress edit on a separate, unrelated fix (#3907) in the shared dev worktree at push time, not this change; no `TestOrder`/`TestCheckTriggerCron`/`internal/orders` test failed in any run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGjSaP5EtcXZYqgBafw61m