### PR TITLE
test: factor eager-lazy control matrix

### DIFF
--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -889,44 +889,189 @@ func TestE1PackCommandTreeRequestBooleanHelpGrammar(t *testing.T) {
 		want packCommandTreePreparation
 	}{
 		{
-			name: "long true scans city",
-			args: []string{"backstage", "--help=true", "--city", "/city"},
-			want: packCommandTreePreparation{binding: "backstage", city: "/city", citySet: true, scopeCount: 1},
+			name: "root help before binding",
+			args: []string{"--help", "backstage", "hello"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				preLeafHelpKind:     packCommandPreLeafHelpTrue,
+				preLeafHelpIndex:    0,
+				preLeafCommandIndex: 2,
+			},
 		},
 		{
-			name: "short false scans rig",
-			args: []string{"backstage", "repo", "-h=false", "--rig=rig-a"},
-			want: packCommandTreePreparation{binding: "backstage", rig: "rig-a", rigSet: true, scopeCount: 1},
+			name: "uppercase true before leaf",
+			args: []string{"backstage", "--help=TRUE", "--city", "/city", "hello"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpTrue,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 4,
+			},
 		},
 		{
-			name: "long one scans city",
-			args: []string{"backstage", "--help=1", "--city=/city"},
-			want: packCommandTreePreparation{binding: "backstage", city: "/city", citySet: true, scopeCount: 1},
+			name: "uppercase false before leaf",
+			args: []string{"backstage", "--help=FALSE", "--city", "/city", "hello", "payload"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpFalse,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 4,
+			},
 		},
 		{
-			name: "short zero scans rig",
-			args: []string{"backstage", "repo", "-h=0", "--rig", "rig-a"},
-			want: packCommandTreePreparation{binding: "backstage", rig: "rig-a", rigSet: true, scopeCount: 1},
+			name: "short T before leaf",
+			args: []string{"backstage", "-h=T", "--rig", "rig-a", "hello"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				rig:                 "rig-a",
+				rigSet:              true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpTrue,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 4,
+			},
 		},
 		{
-			name: "invalid long still scans city for fail closed guard",
-			args: []string{"backstage", "--help=maybe", "--city", "/city"},
-			want: packCommandTreePreparation{binding: "backstage", city: "/city", citySet: true, scopeCount: 1},
+			name: "short F before leaf",
+			args: []string{"backstage", "-h=F", "--rig", "rig-a", "hello", "payload"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				rig:                 "rig-a",
+				rigSet:              true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpFalse,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 4,
+			},
 		},
 		{
-			name: "invalid short still scans rig for fail closed guard",
-			args: []string{"backstage", "repo", "-h=maybe", "--rig=rig-a"},
-			want: packCommandTreePreparation{binding: "backstage", rig: "rig-a", rigSet: true, scopeCount: 1},
+			name: "last help true",
+			args: []string{"backstage", "--help=false", "--help", "--city", "/city", "hello"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpTrue,
+				preLeafHelpIndex:    2,
+				preLeafCommandIndex: 5,
+			},
 		},
 		{
-			name: "selected leaf owns valued help and city",
-			args: []string{"backstage", "hello", "--help=true", "--city", "/city"},
+			name: "last help false",
+			args: []string{"backstage", "--help", "--help=false", "--city", "/city", "hello", "payload"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpFalse,
+				preLeafHelpIndex:    2,
+				preLeafCommandIndex: 5,
+			},
+		},
+		{
+			name: "invalid help remains first error",
+			args: []string{"backstage", "--help=bad", "--help=false", "--city", "/city", "hello"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpInvalid,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 5,
+			},
+		},
+		{
+			name: "unknown flag stops before scope",
+			args: []string{"backstage", "--unknown", "--city", "/city", "hello"},
+			want: packCommandTreePreparation{binding: "backstage"},
+		},
+		{
+			name: "known group unknown child keeps scanning inherited scope",
+			args: []string{"backstage", "repo", "missing", "--city", "/city"},
+			want: packCommandTreePreparation{
+				binding:    "backstage",
+				city:       "/city",
+				citySet:    true,
+				scopeCount: 1,
+			},
+		},
+		{
+			name: "schema before scope",
+			args: []string{"backstage", "--json-schema", "result", "--city", "/city", "hello"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafCommandIndex: 5,
+			},
+		},
+		{
+			name: "schema after scope",
+			args: []string{"backstage", "--city", "/city", "--json-schema", "result", "hello"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafCommandIndex: 5,
+			},
+		},
+		{
+			name: "terminator owns later controls",
+			args: []string{"backstage", "--", "--help=true", "--rig=rig-a"},
+			want: packCommandTreePreparation{binding: "backstage"},
+		},
+		{
+			name: "leaf owns bare long help",
+			args: []string{"backstage", "hello", "--help"},
 			want: packCommandTreePreparation{binding: "backstage", preLeafCommandIndex: 1},
 		},
 		{
-			name: "terminator owns valued help and rig",
-			args: []string{"backstage", "--", "--help=true", "--rig=rig-a"},
-			want: packCommandTreePreparation{binding: "backstage"},
+			name: "leaf owns valued long help",
+			args: []string{"backstage", "hello", "--help=true"},
+			want: packCommandTreePreparation{binding: "backstage", preLeafCommandIndex: 1},
+		},
+		{
+			name: "leaf owns bare short help",
+			args: []string{"backstage", "hello", "-h"},
+			want: packCommandTreePreparation{binding: "backstage", preLeafCommandIndex: 1},
+		},
+		{
+			name: "leaf owns valued short help",
+			args: []string{"backstage", "hello", "-h=true"},
+			want: packCommandTreePreparation{binding: "backstage", preLeafCommandIndex: 1},
+		},
+		{
+			name: "pre-leaf city stops before child-owned city",
+			args: []string{"backstage", "--city", "/selected", "hello", "--city", "/child", "payload"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/selected",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafCommandIndex: 3,
+			},
+		},
+		{
+			name: "pre-leaf rig stops before child-owned rig",
+			args: []string{"backstage", "--rig", "selected-rig", "hello", "--rig", "child-rig", "payload"},
+			want: packCommandTreePreparation{
+				binding:             "backstage",
+				rig:                 "selected-rig",
+				rigSet:              true,
+				scopeCount:          1,
+				preLeafCommandIndex: 3,
+			},
 		},
 	}
 
@@ -935,6 +1080,138 @@ func TestE1PackCommandTreeRequestBooleanHelpGrammar(t *testing.T) {
 			got, ok := packCommandTreeRequest(root, test.args)
 			if !ok || got != test.want {
 				t.Fatalf("packCommandTreeRequest(%q) = (%+v, %v), want (%+v, true)", test.args, got, ok, test.want)
+			}
+		})
+	}
+}
+
+func TestPackCommandHelpArgKindBooleanGrammar(t *testing.T) {
+	flags := []struct {
+		name string
+		arg  string
+	}{
+		{name: "long", arg: "--help"},
+		{name: "short", arg: "-h"},
+	}
+	trueValues := []string{"1", "t", "T", "TRUE", "true", "True"}
+	falseValues := []string{"0", "f", "F", "FALSE", "false", "False"}
+
+	for _, flag := range flags {
+		t.Run(flag.name, func(t *testing.T) {
+			if got, ok := packCommandHelpArgKind(flag.arg); !ok || got != packCommandPreLeafHelpTrue {
+				t.Fatalf("packCommandHelpArgKind(%q) = (%v, %v), want (%v, true)", flag.arg, got, ok, packCommandPreLeafHelpTrue)
+			}
+			for _, value := range trueValues {
+				arg := flag.arg + "=" + value
+				if got, ok := packCommandHelpArgKind(arg); !ok || got != packCommandPreLeafHelpTrue {
+					t.Errorf("packCommandHelpArgKind(%q) = (%v, %v), want (%v, true)", arg, got, ok, packCommandPreLeafHelpTrue)
+				}
+			}
+			for _, value := range falseValues {
+				arg := flag.arg + "=" + value
+				if got, ok := packCommandHelpArgKind(arg); !ok || got != packCommandPreLeafHelpFalse {
+					t.Errorf("packCommandHelpArgKind(%q) = (%v, %v), want (%v, true)", arg, got, ok, packCommandPreLeafHelpFalse)
+				}
+			}
+			for _, value := range []string{"", "maybe", "true=false"} {
+				arg := flag.arg + "=" + value
+				if got, ok := packCommandHelpArgKind(arg); !ok || got != packCommandPreLeafHelpInvalid {
+					t.Errorf("packCommandHelpArgKind(%q) = (%v, %v), want (%v, true)", arg, got, ok, packCommandPreLeafHelpInvalid)
+				}
+			}
+		})
+	}
+
+	for _, arg := range []string{"", "help", "--helpful", "-H", "--city", "-help", "--help:true"} {
+		if got, ok := packCommandHelpArgKind(arg); ok || got != packCommandPreLeafHelpNone {
+			t.Errorf("packCommandHelpArgKind(%q) = (%v, %v), want (%v, false)", arg, got, ok, packCommandPreLeafHelpNone)
+		}
+	}
+}
+
+func TestPreparePackCommandArgsOwnsPreLeafHelpAndScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		request packCommandTreePreparation
+		want    []string
+	}{
+		{
+			name: "false removes help and pre-leaf scope",
+			args: []string{"backstage", "--help=false", "--city", "/city", "hello", "payload"},
+			request: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpFalse,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 4,
+			},
+			want: []string{"backstage", "hello", "payload"},
+		},
+		{
+			name: "true canonicalizes help and retains pre-leaf scope",
+			args: []string{"backstage", "--help=true", "--city", "/city", "hello", "payload"},
+			request: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpTrue,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 4,
+			},
+			want: []string{"backstage", "--help", "--city", "/city", "hello", "payload"},
+		},
+		{
+			name: "last true occurrence wins",
+			args: []string{"backstage", "--help=false", "-h=T", "--city", "/city", "hello", "payload"},
+			request: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpTrue,
+				preLeafHelpIndex:    2,
+				preLeafCommandIndex: 5,
+			},
+			want: []string{"backstage", "--help", "--city", "/city", "hello", "payload"},
+		},
+		{
+			name: "last false occurrence wins",
+			args: []string{"backstage", "--help", "-h=F", "--city", "/city", "hello", "payload"},
+			request: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpFalse,
+				preLeafHelpIndex:    2,
+				preLeafCommandIndex: 5,
+			},
+			want: []string{"backstage", "hello", "payload"},
+		},
+		{
+			name: "invalid first occurrence truncates at its token",
+			args: []string{"backstage", "--help=bad", "--help=false", "--city", "/city", "hello", "payload"},
+			request: packCommandTreePreparation{
+				binding:             "backstage",
+				city:                "/city",
+				citySet:             true,
+				scopeCount:          1,
+				preLeafHelpKind:     packCommandPreLeafHelpInvalid,
+				preLeafHelpIndex:    1,
+				preLeafCommandIndex: 5,
+			},
+			want: []string{"backstage", "--help=bad"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := preparePackCommandArgs(test.args, test.request); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("preparePackCommandArgs(%q, %+v) = %q, want %q", test.args, test.request, got, test.want)
 			}
 		})
 	}
@@ -1528,7 +1805,7 @@ func TestE1LazyMissingTreeMatchesEagerFlagOwnership(t *testing.T) {
 
 func TestE1EagerLazyControlDifferentialMatrix(t *testing.T) {
 	t.Setenv("OTEL_SDK_DISABLED", "true")
-	cityA, cityB, targetRig := setupE1PreLeafHelpFixture(t)
+	cityA, cityB, _ := setupE1PreLeafHelpFixture(t)
 	oldWD, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -1542,34 +1819,26 @@ func TestE1EagerLazyControlDifferentialMatrix(t *testing.T) {
 		name       string
 		args       []string
 		noPackExec bool
+		want       *packCommandProcessResult
 	}{
-		{name: "root help before binding", args: []string{"--help", "backstage", "hello"}, noPackExec: true},
-		{name: "root false help before binding", args: []string{"--help=false", "backstage", "hello", "payload"}},
-		{name: "uppercase true before leaf", args: []string{"backstage", "--help=TRUE", "--city", cityB, "hello"}, noPackExec: true},
-		{name: "uppercase false before leaf", args: []string{"backstage", "--help=FALSE", "--city", cityB, "hello", "payload"}},
-		{name: "short T before leaf", args: []string{"backstage", "-h=T", "--rig", targetRig, "hello"}, noPackExec: true},
-		{name: "short F before leaf", args: []string{"backstage", "-h=F", "--rig", targetRig, "hello", "payload"}},
-		{name: "last help true", args: []string{"backstage", "--help=false", "--help", "--city", cityB, "hello"}, noPackExec: true},
-		{name: "last help false", args: []string{"backstage", "--help", "--help=false", "--city", cityB, "hello", "payload"}},
-		{name: "invalid help remains first error", args: []string{"backstage", "--help=bad", "--help=false", "--city", cityB, "hello"}, noPackExec: true},
-		{name: "unknown flag before scope", args: []string{"backstage", "--unknown", "--city", cityB, "hello"}, noPackExec: true},
-		{name: "unknown group child before scope", args: []string{"backstage", "repo", "missing", "--city", cityB}, noPackExec: true},
+		{
+			name: "root false help before binding",
+			args: []string{"--help=false", "backstage", "hello", "payload"},
+			want: &packCommandProcessResult{
+				exitCode: 0,
+				stdout:   "ambient-hello args:<payload>\n",
+			},
+		},
 		{name: "schema before scope", args: []string{"backstage", "--json-schema", "result", "--city", cityB, "hello"}, noPackExec: true},
-		{name: "scope before schema", args: []string{"backstage", "--city", cityB, "--json-schema", "result", "hello"}, noPackExec: true},
-		{name: "terminator before child", args: []string{"backstage", "--", "--city", cityB, "hello"}, noPackExec: true},
-		{name: "leaf bare long help", args: []string{"backstage", "hello", "--help"}, noPackExec: true},
-		{name: "leaf valued long help is child owned", args: []string{"backstage", "hello", "--help=true"}},
-		{name: "leaf bare short help", args: []string{"backstage", "hello", "-h"}, noPackExec: true},
-		{name: "leaf valued short help is child owned", args: []string{"backstage", "hello", "-h=true"}},
-		{name: "preleaf city with later child-owned city", args: []string{"backstage", "--city", cityB, "hello", "--city", cityA, "payload"}},
-		{name: "preleaf rig with later child-owned rig", args: []string{"backstage", "--rig", targetRig, "hello", "--rig", "child-rig", "payload"}},
 	}
 
+	rootExecutions := 0
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			results := make(map[string]packCommandProcessResult, 2)
 			for _, scenario := range []string{"eager", "lazy"} {
 				var stdout, stderr bytes.Buffer
+				rootExecutions++
 				results[scenario] = packCommandProcessResult{
 					exitCode: runPackCommandScenario(t, scenario, test.args, &stdout, &stderr),
 					stdout:   stdout.String(),
@@ -1581,6 +1850,9 @@ func TestE1EagerLazyControlDifferentialMatrix(t *testing.T) {
 			if eager != lazy {
 				t.Fatalf("eager/lazy drift for %q:\neager=%+v\nlazy=%+v", test.args, eager, lazy)
 			}
+			if test.want != nil && eager != *test.want {
+				t.Fatalf("dispatch outcome = %+v, want %+v", eager, *test.want)
+			}
 			if test.noPackExec {
 				combined := eager.stdout + eager.stderr
 				for _, sentinel := range []string{"ambient-hello args:", "ambient-sync args:", "selected-hello args:", "selected-sync args:", "pack-before-exit"} {
@@ -1590,6 +1862,9 @@ func TestE1EagerLazyControlDifferentialMatrix(t *testing.T) {
 				}
 			}
 		})
+	}
+	if rootExecutions != 4 {
+		t.Fatalf("real command-root executions = %d, want 4", rootExecutions)
 	}
 }
 
@@ -2550,27 +2825,52 @@ func TestResolveDiscoveredCommandFallbackPreclassifiesBeforeExecution(t *testing
 }
 
 func TestResolveDiscoveredLeafActionClassifiesHelpWithoutExecutingChild(t *testing.T) {
-	cmd := &cobra.Command{Use: "private-command", Long: "Private pack help."}
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	invoked := false
+	tests := []struct {
+		name       string
+		args       []string
+		wantInvoke bool
+	}{
+		{name: "bare long help", args: []string{"--help"}},
+		{name: "bare short help", args: []string{"-h"}},
+		{name: "valued long help", args: []string{"--help=true"}, wantInvoke: true},
+		{name: "valued short help", args: []string{"-h=false"}, wantInvoke: true},
+		{name: "malformed valued help", args: []string{"--help=maybe"}, wantInvoke: true},
+		{name: "help after terminator", args: []string{"--", "--help"}, wantInvoke: true},
+	}
+	wantResolved := packCommandOutcome{handled: true, classification: packCommandClassification, exitCode: 0}
 
-	action := resolveDiscoveredLeafAction(cmd, []string{"--help"}, func() int {
-		invoked = true
-		return 42
-	})
-	want := packCommandOutcome{handled: true, classification: packCommandClassification, exitCode: 0}
-	if action.outcome != want {
-		t.Fatalf("resolved help outcome = %+v, want %+v", action.outcome, want)
-	}
-	if got := action.execute(); got != want {
-		t.Fatalf("executed help outcome = %+v, want %+v", got, want)
-	}
-	if invoked {
-		t.Fatal("help action executed pack child")
-	}
-	if !strings.Contains(stdout.String(), "Private pack help.") {
-		t.Fatalf("help stdout = %q, want long help", stdout.String())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "private-command", Long: "Private pack help."}
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			invoked := false
+
+			action := resolveDiscoveredLeafAction(cmd, test.args, func() int {
+				invoked = true
+				return 42
+			})
+			if action.outcome != wantResolved {
+				t.Fatalf("resolved outcome = %+v, want %+v", action.outcome, wantResolved)
+			}
+			wantExecuted := wantResolved
+			if test.wantInvoke {
+				wantExecuted.exitCode = 42
+			}
+			if got := action.execute(); got != wantExecuted {
+				t.Fatalf("executed outcome = %+v, want %+v", got, wantExecuted)
+			}
+			if invoked != test.wantInvoke {
+				t.Fatalf("pack child invoked = %v, want %v", invoked, test.wantInvoke)
+			}
+			if test.wantInvoke {
+				if stdout.Len() != 0 {
+					t.Fatalf("child invocation rendered help stdout = %q, want empty", stdout.String())
+				}
+			} else if !strings.Contains(stdout.String(), "Private pack help.") {
+				t.Fatalf("help stdout = %q, want long help", stdout.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reduce `TestE1EagerLazyControlDifferentialMatrix` from 40 full command-root executions to exactly 4.
- Retain two real eager/lazy compositions for dispatch and early-control behavior.
- Move boolean grammar, help precedence, request placement, scope ownership, terminator, and leaf-help policy to direct pure-function owners.
- Keep the surrounding focused integration tests as the composition owners for malformed help, Cobra parity, scoped schema, and child argument pass-through.

## Performance

- Before: 15.52s mean
- After: 1.52s mean
- Result: **10.2x faster**, saving about 14.0s per run (90.2%)

## Verification

- Focused test: 10 consecutive passes
- Race detector: focused and retained eager/lazy boundaries
- Nine retained integration-owner tests
- CI-shaped process shard 3/12: 64.187s
- Resource census, formatting, vet, and repository hooks
- Repository pre-push fast baseline: all 8 jobs passed
- Two independent delegated reviews approved exact staged hash `aea64181f41bf999659c61865d0cdff00a3bd324666a0825d82928e671401c91`

Tracks `ga-yrotsuu.20`.
