### PR TITLE
feat(targetscope): gc.target_scope.v1 — instantiation-time declared scope inverts the claim-time cwd poison

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/storeref"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
+	"github.com/gastownhall/gascity/internal/targetscope"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
@@ -3944,7 +3945,8 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		if sessionName != "" && strings.TrimSpace(wb.Metadata[beadmeta.SessionNameMetadataKey]) != sessionName {
 			patch[beadmeta.SessionNameMetadataKey] = sessionName
 		}
-		if workDir != "" && strings.TrimSpace(wb.Metadata[beadmeta.WorkDirMetadataKey]) != workDir {
+		if workDir != "" && strings.TrimSpace(wb.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
+			mayStampCwdWorkDir(store, wb, stderr) {
 			patch[beadmeta.WorkDirMetadataKey] = workDir
 		}
 		if len(patch) > 0 {
@@ -3958,6 +3960,36 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		// dashboard's root-only snapshot reads the root's own metadata, so a
 		// worked step back-fills its root via gc.root_bead_id. (#2843)
 		stampRunRootFromStep(store, wb, sessionName, workDir, stampedRoots, stderr)
+	}
+}
+
+// mayStampCwdWorkDir reports whether reconcile may derive gc.work_dir for bead
+// from the session's cwd.
+//
+// This guards BOTH work-dir writers. Guarding only the work-bead patch would be
+// insufficient: stampRunRootFromStep is an independent writer that copies the
+// same session cwd onto the run ROOT, and every later stage inherits the root's
+// value through the root-chain walk -- so an unguarded root writer re-poisons
+// the whole run one hop removed.
+//
+// Only an ABSENT scope permits the cwd stamp. present-invalid is deliberately
+// treated the same as present-valid here: an unusable object is never
+// permission to write cwd.
+//
+// Note this guards the field actually read -- the session's legacy work_dir --
+// which is a different session key from gc.work_dir.
+func mayStampCwdWorkDir(store beads.Store, bead beads.Bead, stderr io.Writer) bool {
+	switch res := targetscope.ResolveInherited(store, bead); res.State {
+	case targetscope.StateValid:
+		return false
+	case targetscope.StateInvalid:
+		if stderr != nil {
+			fmt.Fprintf(stderr, "stampRunSessionIdentity: %s has an unusable %s; leaving %s unset rather than stamping session cwd: %v\n",
+				bead.ID, beadmeta.TargetScopeMetadataKey, beadmeta.WorkDirMetadataKey, res.Reason) //nolint:errcheck
+		}
+		return false
+	default:
+		return true
 	}
 }
 
@@ -3985,7 +4017,8 @@ func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workD
 	if sessionName != "" && strings.TrimSpace(root.Metadata[beadmeta.SessionNameMetadataKey]) != sessionName {
 		patch[beadmeta.SessionNameMetadataKey] = sessionName
 	}
-	if workDir != "" && strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) != workDir {
+	if workDir != "" && strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
+		mayStampCwdWorkDir(store, root, stderr) {
 		patch[beadmeta.WorkDirMetadataKey] = workDir
 	}
 	if len(patch) == 0 {

--- a/cmd/gc/build_desired_state_targetscope_test.go
+++ b/cmd/gc/build_desired_state_targetscope_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+func seedBead(t *testing.T, store *beads.MemStore, metadata map[string]string) beads.Bead {
+	t.Helper()
+	bead, err := store.Create(beads.Bead{Title: "work", Metadata: metadata})
+	if err != nil {
+		t.Fatalf("creating bead: %v", err)
+	}
+	return bead
+}
+
+// Legacy behavior is preserved for the entire existing population: no scope
+// reachable means reconcile may still stamp the session cwd.
+func TestReconcileStampsCwdWorkDirWhenScopeAbsent(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := seedBead(t, store, nil)
+
+	if !mayStampCwdWorkDir(store, bead, nil) {
+		t.Fatal("an unscoped bead must keep legacy work_dir behavior")
+	}
+}
+
+// THE DEFECT, INVERTED on the reconcile side.
+func TestReconcileDoesNotStampCwdWorkDirWhenScopeValid(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := seedBead(t, store, map[string]string{
+		beadmeta.TargetScopeMetadataKey: `{"v":1,"worktree":"/srv/declared"}`,
+	})
+
+	if mayStampCwdWorkDir(store, bead, nil) {
+		t.Fatal("reconcile would stamp session cwd over a declared scope")
+	}
+}
+
+// Whole-scope semantics: a scope declaring only a branch still suppresses the
+// cwd work_dir stamp. The missing worktree field means unknown.
+func TestReconcileDoesNotStampCwdWorkDirWhenOnlyBranchDeclared(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := seedBead(t, store, map[string]string{
+		beadmeta.TargetScopeMetadataKey: `{"v":1,"branch":"release"}`,
+	})
+
+	if mayStampCwdWorkDir(store, bead, nil) {
+		t.Fatal("a branch-only scope must still suppress the cwd work_dir stamp")
+	}
+}
+
+// An unusable object is not permission to stamp cwd.
+func TestReconcileDoesNotStampCwdWorkDirWhenScopeInvalid(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := seedBead(t, store, map[string]string{
+		beadmeta.TargetScopeMetadataKey: `{"v":1,"worktree":"relative/path"}`,
+	})
+
+	if mayStampCwdWorkDir(store, bead, nil) {
+		t.Fatal("an unusable scope must not fall through to a cwd stamp")
+	}
+}
+
+// THE INHERITED CLASS. A formula-generated stage carries only a symbolic root
+// reference, not a copy of root metadata — so the guard must reach the root's
+// scope through the walk. This is the class the whole design exists for.
+func TestReconcileHonorsScopeInheritedFromRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	root := seedBead(t, store, map[string]string{
+		beadmeta.TargetScopeMetadataKey: `{"v":1,"worktree":"/srv/declared"}`,
+	})
+	stage := seedBead(t, store, map[string]string{
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+	})
+
+	if mayStampCwdWorkDir(store, stage, nil) {
+		t.Fatal("a stage must inherit the root's scope; bead-local reads miss exactly this class")
+	}
+}
+
+// The same must hold through the parent chain.
+func TestReconcileHonorsScopeInheritedFromParent(t *testing.T) {
+	store := beads.NewMemStore()
+	parent := seedBead(t, store, map[string]string{
+		beadmeta.TargetScopeMetadataKey: `{"v":1,"branch":"release"}`,
+	})
+	child, err := store.Create(beads.Bead{Title: "child", ParentID: parent.ID, Metadata: beads.StringMap{}})
+	if err != nil {
+		t.Fatalf("creating child: %v", err)
+	}
+
+	if mayStampCwdWorkDir(store, child, nil) {
+		t.Fatal("a child must inherit its parent's scope")
+	}
+}
+
+// Poisoned flat keys are not a scope: a bead carrying only claim-derived
+// gc.work_* still resolves ABSENT, so legacy behavior applies and the poison is
+// never laundered into the new object.
+func TestReconcileTreatsPoisonedFlatKeysAsUnscoped(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := seedBead(t, store, map[string]string{
+		beadmeta.WorkDirMetadataKey:    "/shared/poison",
+		beadmeta.WorkBranchMetadataKey: "parked",
+	})
+
+	if !mayStampCwdWorkDir(store, bead, nil) {
+		t.Fatal("flat gc.work_* keys must not be mistaken for a declared scope")
+	}
+	if got := targetscope.ResolveInherited(store, bead); got.State != targetscope.StateAbsent {
+		t.Fatalf("state = %v, want absent", got.State)
+	}
+}

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -662,6 +662,10 @@ conflicting live workflow from the same source is an error.`,
 						}
 						printGraphV2Deprecations(stderr, inv.Deprecations)
 						cookVars = inv.Vars
+						cookScope, cookMembers, err := resolveCookLaunchScope(store, inv.Formula, vars, cookVars, attach, inv.InputConvoy, scope.storeRoot)
+						if err != nil {
+							return err
+						}
 						recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
 						if err != nil {
 							return fmt.Errorf("compile: %w", err)
@@ -707,6 +711,14 @@ conflicting live workflow from the same source is an error.`,
 						source, err := store.Get(attach)
 						if err != nil {
 							return fmt.Errorf("attach bead %s: %w", attach, err)
+						}
+						// Declare every member, then stamp the root — BEFORE the root
+						// is materialized, so a rejection costs a launch and never an
+						// orphaned graph. The attach target is a member of this input
+						// convoy (a single-item convoy created in this store), so it is
+						// declared here alongside the others.
+						if err := prepareCookLaunch(recipe, cookScope, cookMembers); err != nil {
+							return err
 						}
 						result, err = molecule.Instantiate(cmd.Context(), store, recipe, molecule.Options{
 							Title:            title,
@@ -755,6 +767,10 @@ conflicting live workflow from the same source is an error.`,
 				}
 				printGraphV2Deprecations(stderr, inv.Deprecations)
 				cookVars = inv.Vars
+				cookScope, cookMembers, err := resolveCookLaunchScope(store, inv.Formula, vars, cookVars, attach, inv.InputConvoy, scope.storeRoot)
+				if err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+				}
 				recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook: compile", jsonOutput, err)
@@ -764,6 +780,13 @@ conflicting live workflow from the same source is an error.`,
 					graphRootKey = stampFormulaCookGraphV2Root(recipe, args[0], inv.InputConvoy, cookVars)
 				}
 
+				// A legacy attach's source is in no input convoy, so cookMembers is
+				// empty and this only stamps the root; a graph attach that reached
+				// this path with a convoy declares its members first. Before
+				// materialization either way (§5b phase order).
+				if err := prepareCookLaunch(recipe, cookScope, cookMembers); err != nil {
+					return formulaCommandError(stderr, "gc formula cook: attach", jsonOutput, err)
+				}
 				result, err := molecule.Attach(cmd.Context(), store, recipe, attach, molecule.AttachOptions{
 					Title:          title,
 					Vars:           cookVars,
@@ -809,6 +832,16 @@ conflicting live workflow from the same source is an error.`,
 			printGraphV2Deprecations(stderr, inv.Deprecations)
 			cookVars = inv.Vars
 
+			// A standalone cook has no attach target and no input convoy, so the
+			// scope resolves from cookVars' own inputs and no member is declared —
+			// the generated stages inherit the stamped root. Resolved once here so
+			// both the graph and legacy branches compile with the reconciled
+			// carrier already in cookVars.
+			cookScope, cookMembers, err := resolveCookLaunchScope(store, inv.Formula, vars, cookVars, "", inv.InputConvoy, scope.storeRoot)
+			if err != nil {
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+			}
+
 			var result *molecule.Result
 			if isGraphFormula {
 				// Stamp the run root with its store/scope identity before
@@ -833,6 +866,9 @@ conflicting live workflow from the same source is an error.`,
 					unlock := graphv2.LockKey(graphRootKey)
 					defer unlock()
 				}
+				if err := prepareCookLaunch(recipe, cookScope, cookMembers); err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+				}
 				result, err = molecule.Instantiate(cmd.Context(), store, recipe, molecule.Options{
 					Title:          title,
 					Vars:           cookVars,
@@ -842,7 +878,22 @@ conflicting live workflow from the same source is an error.`,
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
 			} else {
-				result, err = molecule.Cook(cmd.Context(), store, args[0], scope.searchPaths, molecule.Options{
+				// molecule.Cook compiles and instantiates in one call, leaving no
+				// seam to stamp the scope between them. Inline it — compile, stamp,
+				// then instantiate — mirroring the graph branch above rather than
+				// changing molecule.Cook's shared signature (its other callers do
+				// not launch a scoped root).
+				recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
+				if err != nil {
+					return formulaCommandError(stderr, "gc formula cook: compile", jsonOutput, err)
+				}
+				if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Title: title, Vars: cookVars}); err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+				}
+				if err := prepareCookLaunch(recipe, cookScope, cookMembers); err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+				}
+				result, err = molecule.Instantiate(cmd.Context(), store, recipe, molecule.Options{
 					Title: title,
 					Vars:  cookVars,
 				})

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/targetscope"
 )
 
 const hookClaimCommandName = "hook"
@@ -57,6 +58,18 @@ type hookClaimOps struct {
 	// repo / detached HEAD) omits the branch key — the session back-reference is
 	// still stamped.
 	ResolveWorkBranch hookResolveWorkBranchFunc
+	// ResolveTargetScope reports the declared target scope governing a bead,
+	// resolved through the inherited walk (bead → parent → gc.root_bead_id).
+	//
+	// This is a STORE-BACKED op rather than a bead-local metadata read because
+	// formula-generated stages — precisely the class that carries no declared
+	// location of its own — hold only a symbolic root reference, not a copy of
+	// root metadata. A bead-local check would miss exactly the beads this guard
+	// exists to protect.
+	//
+	// A nil op means "no store available", which resolves absent and preserves
+	// legacy behavior.
+	ResolveTargetScope hookResolveTargetScopeFunc
 	// StampWorkMeta writes the claim-time execution-identity metadata patch
 	// (gc.work_branch and/or the durable session back-reference gc.session_id /
 	// gc.session_name) onto the claimed bead in ONE update. Best-effort.
@@ -75,6 +88,7 @@ type (
 	hookDrainAckFunc              func(io.Writer) error
 	hookEmitClaimRejectedFunc     func(beadID, existingClaimant, attemptedClaimant string)
 	hookResolveWorkBranchFunc     func(dir string) string
+	hookResolveTargetScopeFunc    func(dir string, env []string, bead beads.Bead) targetscope.Resolution
 	hookStampWorkMetaFunc         func(ctx context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error
 	hookRecordSessionPointersFunc func(ctx context.Context, dir string, env []string, assignee, sessionBeadID, runID, stepID string) error
 )
@@ -535,9 +549,11 @@ func stampHookClaimIdentity(bead beads.Bead, opts hookClaimOptions, ops hookClai
 // so the caller issues no write.
 func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string) map[string]string {
 	patch := map[string]string{}
-	if branch := strings.TrimSpace(ops.ResolveWorkBranch(dir)); branch != "" &&
-		strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) != branch {
-		patch[beadmeta.WorkBranchMetadataKey] = branch
+	if hookClaimMayStampCwdBranch(ops, opts, bead, dir) {
+		if branch := strings.TrimSpace(ops.ResolveWorkBranch(dir)); branch != "" &&
+			strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) != branch {
+			patch[beadmeta.WorkBranchMetadataKey] = branch
+		}
 	}
 	if sessionID := hookClaimSessionID(opts.Env); sessionID != "" &&
 		!beadmeta.IsControlKind(strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey])) {
@@ -550,6 +566,38 @@ func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClai
 		}
 	}
 	return patch
+}
+
+// hookClaimMayStampCwdBranch reports whether the claim hook may derive
+// gc.work_branch from the claiming session's cwd.
+//
+// This is the inversion of the original defect. The pre-existing compare-and-
+// skip guard only suppressed an IDENTICAL rewrite; it still overwrote a
+// differing declared value with wherever the claimant happened to be standing,
+// which is how a pool session parked on a shared checkout poisoned every bead
+// it touched.
+//
+// Only an ABSENT scope permits the cwd stamp:
+//   - present-valid  → the declared scope is authoritative for the WHOLE scope.
+//     A missing branch field means unknown, never "fill it from cwd" — filling
+//     one field from cwd is how a half-poisoned object would be born.
+//   - present-invalid → refuse to stamp and warn. An unusable object must never
+//     be treated as permission to write cwd; collapsing it to "absent" is the
+//     defect reopening.
+func hookClaimMayStampCwdBranch(ops hookClaimOps, opts hookClaimOptions, bead beads.Bead, dir string) bool {
+	if ops.ResolveTargetScope == nil {
+		return true
+	}
+	switch res := ops.ResolveTargetScope(dir, opts.Env, bead); res.State {
+	case targetscope.StateValid:
+		return false
+	case targetscope.StateInvalid:
+		fmt.Fprintf(os.Stderr, "gc hook --claim: %s has an unusable %s; leaving %s unset rather than stamping the claiming worktree: %v\n",
+			bead.ID, beadmeta.TargetScopeMetadataKey, beadmeta.WorkBranchMetadataKey, res.Reason) //nolint:errcheck
+		return false
+	default:
+		return true
+	}
 }
 
 func hookStampWorkMetaWithBdStore(_ context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -210,6 +210,9 @@ func (ops *hookClaimOps) applyDefaults() {
 	if ops.ResolveWorkBranch == nil {
 		ops.ResolveWorkBranch = hookResolveWorkBranch
 	}
+	if ops.ResolveTargetScope == nil {
+		ops.ResolveTargetScope = hookResolveTargetScope
+	}
 	if ops.StampWorkMeta == nil {
 		ops.StampWorkMeta = hookStampWorkMetaWithBdStore
 	}
@@ -598,6 +601,21 @@ func hookClaimMayStampCwdBranch(ops hookClaimOps, opts hookClaimOptions, bead be
 	default:
 		return true
 	}
+}
+
+// hookResolveTargetScope is the production ResolveTargetScope op: it resolves
+// the declared scope through the inherited walk against the same bd store the
+// rest of the claim path talks to, bound to the claiming worktree's dir/env.
+//
+// The walk is store-backed on purpose (see ResolveTargetScope's doc): a
+// formula-generated stage carries only gc.root_bead_id, so the scope governing
+// it lives on the root, not on the bead in hand.
+//
+// Read-only, so it needs no actor attribution. A store that cannot answer makes
+// ResolveInherited report INVALID, which suppresses the cwd stamp rather than
+// silently reopening the defect.
+func hookResolveTargetScope(dir string, env []string, bead beads.Bead) targetscope.Resolution {
+	return targetscope.ResolveInherited(hookClaimBdStore(dir, env, ""), bead)
 }
 
 func hookStampWorkMetaWithBdStore(_ context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error {

--- a/cmd/gc/cmd_hook_claim_targetscope_test.go
+++ b/cmd/gc/cmd_hook_claim_targetscope_test.go
@@ -138,3 +138,38 @@ func TestTargetScopeKeyName(t *testing.T) {
 		t.Fatal("target scope key must live in the gc. namespace")
 	}
 }
+
+// THE WIRING ASSERTION. Every test above injects a resolver by hand, so they
+// all pass even if production never installs one — and production did not:
+// claimHookWork builds a bare hookClaimOps{}, so a nil ResolveTargetScope made
+// hookClaimMayStampCwdBranch permit the cwd stamp unconditionally and the whole
+// claim-side guard was dead code in the only configuration that ships.
+//
+// The guard is only real if applyDefaults installs the store-backed resolver,
+// exactly as it installs every other production op.
+func TestApplyDefaultsInstallsTargetScopeResolver(t *testing.T) {
+	ops := hookClaimOps{}
+	ops.applyDefaults()
+
+	if ops.ResolveTargetScope == nil {
+		t.Fatal("applyDefaults left ResolveTargetScope nil; the claim-time cwd guard is inert in production")
+	}
+}
+
+// applyDefaults must not clobber an injected resolver — tests and callers that
+// supply one keep it.
+func TestApplyDefaultsKeepsInjectedTargetScopeResolver(t *testing.T) {
+	called := false
+	ops := hookClaimOps{
+		ResolveTargetScope: func(string, []string, beads.Bead) targetscope.Resolution {
+			called = true
+			return targetscope.Resolution{State: targetscope.StateAbsent}
+		},
+	}
+	ops.applyDefaults()
+	ops.ResolveTargetScope("/dir", nil, beads.Bead{})
+
+	if !called {
+		t.Fatal("applyDefaults replaced an injected ResolveTargetScope")
+	}
+}

--- a/cmd/gc/cmd_hook_claim_targetscope_test.go
+++ b/cmd/gc/cmd_hook_claim_targetscope_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// claimOpsWithScope builds the minimal ops needed to exercise the identity
+// patch: a cwd that always resolves to a "parked" branch (the poison shape),
+// plus a scope resolver returning the given resolution.
+func claimOpsWithScope(res targetscope.Resolution, resolverSet bool) hookClaimOps {
+	ops := hookClaimOps{
+		ResolveWorkBranch: func(string) string { return "parked-shared-branch" },
+	}
+	if resolverSet {
+		ops.ResolveTargetScope = func(string, []string, beads.Bead) targetscope.Resolution { return res }
+	}
+	return ops
+}
+
+// The legacy path is preserved exactly: with no scope reachable, the claim hook
+// still stamps the claiming worktree's branch.
+func TestClaimStampsCwdBranchWhenScopeAbsent(t *testing.T) {
+	bead := beads.Bead{ID: "bd-1", Metadata: beads.StringMap{}}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{}, claimOpsWithScope(targetscope.Resolution{State: targetscope.StateAbsent}, true), "/some/dir")
+
+	if patch[beadmeta.WorkBranchMetadataKey] != "parked-shared-branch" {
+		t.Fatalf("work_branch = %q, want the cwd branch (absent scope keeps legacy behavior)",
+			patch[beadmeta.WorkBranchMetadataKey])
+	}
+}
+
+// A nil resolver (no store available) must also preserve legacy behavior, so
+// the guard can never make a claim path worse than it was.
+func TestClaimStampsCwdBranchWhenNoResolverConfigured(t *testing.T) {
+	bead := beads.Bead{ID: "bd-1", Metadata: beads.StringMap{}}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{}, claimOpsWithScope(targetscope.Resolution{}, false), "/some/dir")
+
+	if patch[beadmeta.WorkBranchMetadataKey] != "parked-shared-branch" {
+		t.Fatalf("work_branch = %q, want the cwd branch", patch[beadmeta.WorkBranchMetadataKey])
+	}
+}
+
+// THE DEFECT, INVERTED. A bead governed by a declared scope must not have its
+// branch overwritten from wherever the claimant happens to be standing.
+func TestClaimDoesNotStampCwdBranchWhenScopeValid(t *testing.T) {
+	bead := beads.Bead{
+		ID: "bd-1",
+		Metadata: beads.StringMap{
+			beadmeta.WorkBranchMetadataKey: "release",
+		},
+	}
+	res := targetscope.Resolution{State: targetscope.StateValid, Scope: targetscope.Scope{V: 1, Branch: "release"}}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{}, claimOpsWithScope(res, true), "/some/dir")
+
+	if _, ok := patch[beadmeta.WorkBranchMetadataKey]; ok {
+		t.Fatalf("claim wrote %s=%q over a declared scope; the cwd must never win",
+			beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey])
+	}
+}
+
+// WHOLE-SCOPE SEMANTICS. A scope whose branch field is unknown still suppresses
+// the cwd stamp — an absent FIELD means unknown, not "fill it from cwd".
+func TestClaimDoesNotStampCwdBranchWhenScopeFieldEmpty(t *testing.T) {
+	bead := beads.Bead{ID: "bd-1", Metadata: beads.StringMap{}}
+	res := targetscope.Resolution{State: targetscope.StateValid, Scope: targetscope.Unknown()}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{}, claimOpsWithScope(res, true), "/some/dir")
+
+	if _, ok := patch[beadmeta.WorkBranchMetadataKey]; ok {
+		t.Fatalf("a field-empty scope must still suppress the cwd stamp, got %s=%q",
+			beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey])
+	}
+}
+
+// An unusable object is NOT permission to stamp cwd. Treating present-invalid
+// as absent is precisely how the defect would reopen.
+func TestClaimDoesNotStampCwdBranchWhenScopeInvalid(t *testing.T) {
+	bead := beads.Bead{ID: "bd-1", Metadata: beads.StringMap{}}
+	res := targetscope.Parse(`{"v":99}`)
+	if res.State != targetscope.StateInvalid {
+		t.Fatalf("fixture is not invalid: %v", res.State)
+	}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{}, claimOpsWithScope(res, true), "/some/dir")
+
+	if _, ok := patch[beadmeta.WorkBranchMetadataKey]; ok {
+		t.Fatalf("an unusable scope must not fall through to a cwd stamp, got %s=%q",
+			beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey])
+	}
+}
+
+// The session back-reference is orthogonal to scope and must still be stamped:
+// suppressing the branch must not suppress session identity.
+func TestClaimStillStampsSessionIdentityUnderValidScope(t *testing.T) {
+	bead := beads.Bead{ID: "bd-1", Metadata: beads.StringMap{}}
+	res := targetscope.Resolution{State: targetscope.StateValid, Scope: targetscope.Scope{V: 1, Branch: "release"}}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=sess-1", "GC_SESSION_NAME=worker-1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, claimOpsWithScope(res, true), "/some/dir")
+
+	if patch[beadmeta.SessionIDMetadataKey] != "sess-1" {
+		t.Fatalf("session id = %q, want sess-1 — scope must not suppress session identity",
+			patch[beadmeta.SessionIDMetadataKey])
+	}
+	if _, ok := patch[beadmeta.WorkBranchMetadataKey]; ok {
+		t.Fatal("branch must still be suppressed")
+	}
+}
+
+// The resolver must be handed the bead being claimed, since the inherited walk
+// starts there.
+func TestClaimResolverReceivesClaimedBead(t *testing.T) {
+	bead := beads.Bead{ID: "bd-target", Metadata: beads.StringMap{}}
+	var sawID string
+	ops := hookClaimOps{
+		ResolveWorkBranch: func(string) string { return "parked" },
+		ResolveTargetScope: func(_ string, _ []string, b beads.Bead) targetscope.Resolution {
+			sawID = b.ID
+			return targetscope.Resolution{State: targetscope.StateAbsent}
+		},
+	}
+	hookClaimIdentityPatch(bead, hookClaimOptions{}, ops, "/some/dir")
+
+	if sawID != "bd-target" {
+		t.Fatalf("resolver saw bead %q, want bd-target", sawID)
+	}
+}
+
+// Guards the doc claim that the key name is the one the beadmeta package owns.
+func TestTargetScopeKeyName(t *testing.T) {
+	if beadmeta.TargetScopeMetadataKey != "gc.target_scope" {
+		t.Fatalf("key = %q, want gc.target_scope", beadmeta.TargetScopeMetadataKey)
+	}
+	if !strings.HasPrefix(beadmeta.TargetScopeMetadataKey, "gc.") {
+		t.Fatal("target scope key must live in the gc. namespace")
+	}
+}

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -730,7 +730,7 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 	// GraphApplyStore and silently fall back to sequential creation. store stays
 	// the typed wrapper for the order-tracking bead operations below.
 	genericStore := store.Store
-	recipe, err := prepareOrderWispRecipe(context.Background(), genericStore, a, searchPaths, vars)
+	recipe, wispScope, err := prepareOrderWispRecipe(context.Background(), genericStore, a, searchPaths, vars, storeTarget.ScopeRoot)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -754,6 +754,14 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 
 	if err := applyOrderRecipeRouting(recipe, pool, vars, storeTarget, genericStore, cityName, cityPath, cfg); err != nil {
 		fmt.Fprintf(stderr, "gc order run: routing decoration failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	// Stamp the scope after routing decoration and before materialization, so
+	// the root that becomes claimable is already scoped and no claim can write
+	// cwd onto it.
+	if err := stampOrderWispRoot(recipe, wispScope); err != nil {
+		fmt.Fprintf(stderr, "gc order run: target scope stamp failed: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_sling_routevars_test.go
+++ b/cmd/gc/cmd_sling_routevars_test.go
@@ -194,7 +194,7 @@ type = "task"
 		"wf-test",
 		[]string{formulaDir},
 		molecule.Options{},
-		"", "", "", a, deps,
+		"", "", "", a, deps, sling.LaunchScope{},
 	)
 	if err != nil {
 		t.Fatalf("InstantiateSlingFormula: %v", err)

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -102,6 +102,14 @@ func newSlingTestStore() *slingTestStore {
 	return &slingTestStore{Store: beads.NewMemStore(), synthetic: map[string]beads.Bead{}}
 }
 
+// ConditionalWritesResolveTarget exposes the embedded MemStore's optional
+// capabilities (notably MetadataCASWriter) through this interface-embedding
+// wrapper. Without it the anonymous beads.Store field promotes only the base
+// Store methods, so a faithful production store's metadata-CAS capability would
+// be invisible here and a target-scope declaration would wrongly fail closed —
+// the exact way real wrapper stores (CachingStore) forward the capability.
+func (s *slingTestStore) ConditionalWritesResolveTarget() beads.Store { return s.Store }
+
 func (s *slingTestStore) ensureSynthetic(id string) beads.Bead {
 	b, ok := s.synthetic[id]
 	if !ok {

--- a/cmd/gc/formula_cook_scope.go
+++ b/cmd/gc/formula_cook_scope.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// cookScopeSources builds the trusted-source set for a `gc formula cook`.
+//
+// SCOPE RESOLVES FROM cookVars' OWN INPUTS, PER THE D4 RULE. Cook substitutes
+// cookVars — graphv2 EffectiveRuntimeVars, i.e. the formula defaults overlaid by
+// the caller's --var — into the recipe, so the scope must resolve from EXACTLY
+// those inputs and no higher layer: the caller's explicit --var (precedence 1,
+// kept UNFLATTENED so a duplicated branch carrier is a loud error rather than a
+// silent last-write-wins) and the formula defaults (lowest precedence).
+//
+// Cook injects NO rig or routing var into its own substitution:
+// EffectiveRuntimeVars folds in only defaults + caller vars, and
+// decorateFormulaCookGraphV2Recipe runs AFTER compile and rewrites recipe
+// ROUTING, never cookVars. Resolving the scope from the rig would therefore
+// stamp a branch the cooked work never runs against — manufacturing the exact
+// scope != consumed divergence the equality invariant (§3c, E2E #16) forbids.
+// This is the order boundary's measured constraint (orderScopeSources) applied
+// to cook, which substitutes cookVars where an order substitutes nothing.
+func cookScopeSources(rawVars []string, f *formula.Formula) targetscope.Sources {
+	return targetscope.Sources{
+		Explicit:        rawVars,
+		FormulaDefaults: targetscope.FormulaDefaultVars(f),
+	}
+}
+
+// resolveCookLaunchScope resolves a cook launch's target scope, writes the
+// reconciled branch back into cookVars so template substitution and the scope
+// object agree, and returns the members that must declare the scope before the
+// root is materialized.
+//
+// CALL THIS BEFORE COMPILING. The reconciled branch has to be in cookVars
+// before substitution runs, or the formula substitutes one branch while the
+// scope records another. An error is a LAUNCH REJECTION — nothing is
+// materialized at this point, which is why the phase runs here.
+//
+// The member layer (§3a precedence 2) is filled from any scope already
+// governing the attach target, so a cook onto an already-scoped bead INHERITS
+// that scope instead of resolving a lower-layer default and colliding with it.
+// A genuine retarget still rejects: an explicit branch that overrides the member
+// is caught here, and a member the resolver never saw (a convoy sibling) is
+// caught by its own CAS declaration.
+func resolveCookLaunchScope(store beads.Store, f *formula.Formula, rawVars []string, cookVars map[string]string, attachID, convoyID, scopeRoot string) (targetscope.Scope, []targetscope.Member, error) {
+	sources := cookScopeSources(rawVars, f)
+	if err := applyCookTargetMemberLayer(&sources, store, attachID); err != nil {
+		return targetscope.Scope{}, nil, err
+	}
+
+	resolved, err := targetscope.Resolve(sources, scopeRoot)
+	if err != nil {
+		return targetscope.Scope{}, nil, fmt.Errorf("resolving target scope: %w", err)
+	}
+
+	// Immutability at the attach target (§5b). The resolver lets an explicit
+	// branch (precedence 1) outrank an existing member scope silently; for a
+	// convoy member that is caught by the CAS declaration below, but a target
+	// read into the member layer here must be rejected explicitly before
+	// materialization when the resolved scope differs from what it already
+	// carries — a retarget is a launch rejection, not a rewrite.
+	if sources.MemberSet && !sources.Member.Equal(resolved.Scope) {
+		return targetscope.Scope{}, nil, fmt.Errorf("%w: %s is already scoped to %+v; refusing to retarget it to %+v", targetscope.ErrInvalidScope, attachID, sources.Member, resolved.Scope)
+	}
+
+	// The consumed-carrier write-back. Which carrier the formula reads is
+	// derived from the RESOLVED formula's declared vars, never the formula-name
+	// predicates: a formula that declares base_branch without matching a name
+	// pattern still consumes it.
+	targetscope.ApplyToVars(cookVars, resolved, targetscope.DeclaresVar(f, targetscope.VarBaseBranch), targetscope.DeclaresVar(f, targetscope.VarCarrierTargetBranch))
+
+	members, err := cookScopeMembers(store, convoyID, resolved.Scope)
+	if err != nil {
+		return targetscope.Scope{}, nil, err
+	}
+	return resolved.Scope, members, nil
+}
+
+// applyCookTargetMemberLayer fills the member layer from the scope already
+// governing the bead a cook --attach runs ON, read through the inheritance walk
+// so a stage's symbolic root reference resolves to the governing scope rather
+// than a bead-local miss.
+//
+// A present-invalid scope is a LAUNCH REJECTION, never a fall-through: "I could
+// not read the scope governing this bead" must not become permission to choose a
+// new one. A store miss is NOT treated as a member signal — the attach bead may
+// live in a validation-only querier, and the attach itself surfaces a real error
+// downstream if it is genuinely absent.
+func applyCookTargetMemberLayer(sources *targetscope.Sources, store beads.Store, attachID string) error {
+	if attachID == "" || store == nil {
+		return nil
+	}
+	bead, err := store.Get(attachID)
+	if err != nil {
+		return nil
+	}
+	res := targetscope.ResolveInherited(store, bead)
+	switch res.State {
+	case targetscope.StateValid:
+		sources.Member = res.Scope
+		sources.MemberSet = true
+	case targetscope.StateInvalid:
+		return fmt.Errorf("target scope of %s is unusable: %w", attachID, res.Reason)
+	}
+	return nil
+}
+
+// cookScopeMembers lists the tracked members of a cook's input convoy that must
+// declare this scope under CAS before the root is materialized.
+//
+// A graph cook --attach normalizes its target into a single-item input convoy in
+// THIS SAME store (CreateSingleItemInputConvoy), so the target and every other
+// convoy member are present in the declaration store — cook has none of the
+// validation-only-querier split that forces the sling legacy-attach source onto
+// a non-fatal stamp. Closed members are included: a member closed between convoy
+// creation and cook is still a bead whose close gate can run.
+// prepareCookLaunch runs the pre-materialization phase for a cook: declare every
+// member under its single-winner exclusion, then stamp the recipe root. It wraps
+// targetscope.PrepareLaunch so the cook call sites need no direct targetscope
+// import, and so a boundary can be wrong by not calling it, never by calling it
+// differently.
+func prepareCookLaunch(recipe *formula.Recipe, scope targetscope.Scope, members []targetscope.Member) error {
+	return targetscope.PrepareLaunch(recipe, scope, members)
+}
+
+func cookScopeMembers(store beads.Store, convoyID string, scope targetscope.Scope) ([]targetscope.Member, error) {
+	if store == nil || strings.TrimSpace(convoyID) == "" {
+		return nil, nil
+	}
+	beadsInConvoy, err := convoycore.Members(store, convoyID, true)
+	if err != nil {
+		return nil, fmt.Errorf("listing members of input convoy %s: %w", convoyID, err)
+	}
+	members := make([]targetscope.Member, 0, len(beadsInConvoy))
+	for _, b := range beadsInConvoy {
+		members = append(members, targetscope.Member{ID: b.ID, Store: store, Scope: scope})
+	}
+	return members, nil
+}

--- a/cmd/gc/formula_cook_scope_test.go
+++ b/cmd/gc/formula_cook_scope_test.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// writeCookScopeCity writes a minimal formula_v2-enabled city and returns its
+// formulas directory.
+func writeCookScopeCity(t *testing.T, cityDir string) string {
+	t.Helper()
+	toml := withBuiltinProviderAliasesTOMLForTest(`
+[workspace]
+name = "my-city"
+provider = "claude"
+
+[daemon]
+formula_v2 = true
+`, "claude") + testControlDispatcherAgentTOML("")
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	return formulaDir
+}
+
+func writeCookFormula(t *testing.T, formulaDir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(formulaDir, name+".formula.toml"), []byte(strings.TrimSpace(body)+"\n"), 0o644); err != nil {
+		t.Fatalf("write formula %s: %v", name, err)
+	}
+}
+
+// cookScopeReadback returns the branch of the single root that carries a target
+// scope, and the branch a "Work on <branch>" step title substituted, so a test
+// can assert the two agree.
+func cookScopeReadback(t *testing.T, store beads.Store) (rootRes targetscope.Resolution, stepBranch string, sawRoot bool) {
+	t.Helper()
+	all, err := store.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("listing store: %v", err)
+	}
+	for _, b := range all {
+		if raw := b.Metadata[beadmeta.TargetScopeMetadataKey]; raw != "" {
+			rootRes = targetscope.Parse(raw)
+			sawRoot = true
+		}
+		if strings.HasPrefix(b.Title, "Work on ") {
+			stepBranch = strings.TrimPrefix(b.Title, "Work on ")
+		}
+	}
+	return rootRes, stepBranch, sawRoot
+}
+
+// The load-bearing correctness property for the cook boundary, end to end:
+// scope.branch equals the branch the materialized work actually runs against.
+//
+// Cook is UNLIKE an order here — cook materializes with molecule.Instantiate
+// (recipe, Options{Vars: cookVars}), so cookVars DO reach substitution. A caller
+// --var base_branch=release must therefore land on BOTH the substituted step
+// title AND the stamped scope. This drives the real `gc formula cook` and
+// asserts the stamped scope and the substituted title are the same branch.
+func TestFormulaCookStandaloneGraphScopeEqualsSubstitutedBranch(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	cityDir := t.TempDir()
+	formulaDir := writeCookScopeCity(t, cityDir)
+	writeCookFormula(t, formulaDir, "graph-scoped", `
+formula = "graph-scoped"
+version = 2
+contract = "graph.v2"
+
+[vars.base_branch]
+default = "FORMULA-DEFAULT"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+`)
+	formulatest.SetupHermeticCookEnv(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"graph-scoped", "--var", "base_branch=release", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula cook: %v\nstderr=%s", err, stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	rootRes, stepBranch, sawRoot := cookScopeReadback(t, store)
+	if !sawRoot {
+		t.Fatal("no root carried a target scope; the cook boundary did not stamp")
+	}
+	if !rootRes.Valid() {
+		t.Fatalf("root scope state = %v, want valid", rootRes.State)
+	}
+	if stepBranch != rootRes.Scope.Branch {
+		t.Fatalf("step title branch %q disagrees with scope.branch %q — the stamped scope is not the executed branch", stepBranch, rootRes.Scope.Branch)
+	}
+	if rootRes.Scope.Branch != "release" {
+		t.Fatalf("scope.branch = %q, want release (the caller --var that substitution uses)", rootRes.Scope.Branch)
+	}
+}
+
+// The default-only case: with no branch supplied anywhere, scope.branch is the
+// formula default, and it equals what substitution uses. This is what including
+// the FormulaDefaults layer buys — the scope is not unknown while substitution
+// quietly uses the default.
+func TestFormulaCookStandaloneGraphDefaultOnlyScope(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	cityDir := t.TempDir()
+	formulaDir := writeCookScopeCity(t, cityDir)
+	writeCookFormula(t, formulaDir, "graph-scoped", `
+formula = "graph-scoped"
+version = 2
+contract = "graph.v2"
+
+[vars.base_branch]
+default = "the-default"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+`)
+	formulatest.SetupHermeticCookEnv(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"graph-scoped", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula cook: %v\nstderr=%s", err, stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	rootRes, stepBranch, sawRoot := cookScopeReadback(t, store)
+	if !sawRoot || !rootRes.Valid() {
+		t.Fatalf("root scope sawRoot=%v state=%v, want a present-valid stamp", sawRoot, rootRes.State)
+	}
+	if rootRes.Scope.Branch != "the-default" || stepBranch != "the-default" {
+		t.Fatalf("scope.branch=%q step=%q, want both the-default", rootRes.Scope.Branch, stepBranch)
+	}
+}
+
+// The 1d inline path. A legacy (non-graph) formula cooks through molecule.Cook,
+// which compiles and instantiates in one call. Inlining it to compile -> stamp
+// -> instantiate is what lets the root carry a scope; a legacy cook that still
+// went through molecule.Cook would leave the root ABSENT.
+func TestFormulaCookLegacyInlineStampsScope(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	cityDir := t.TempDir()
+	formulaDir := writeCookScopeCity(t, cityDir)
+	writeCookFormula(t, formulaDir, "legacy-scoped", `
+formula = "legacy-scoped"
+version = 1
+
+[vars.base_branch]
+default = "main"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+`)
+	formulatest.SetupHermeticCookEnv(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"legacy-scoped", "--var", "base_branch=legacy-release", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula cook: %v\nstderr=%s", err, stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	rootRes, stepBranch, sawRoot := cookScopeReadback(t, store)
+	if !sawRoot {
+		t.Fatal("legacy inline cook stamped no scope; molecule.Cook was not inlined")
+	}
+	if !rootRes.Valid() || rootRes.Scope.Branch != "legacy-release" {
+		t.Fatalf("scope state=%v branch=%q, want valid legacy-release", rootRes.State, rootRes.Scope.Branch)
+	}
+	if stepBranch != "legacy-release" {
+		t.Fatalf("step title branch %q disagrees with scope.branch; substitution and scope diverged", stepBranch)
+	}
+}
+
+// A cook --attach declares the attach target's scope on the target bead itself,
+// not only on the sub-DAG root. The target is normalized into a single-item
+// input convoy in THIS store, so it is a member: without the member declaration
+// the one bead a close gate reads directly would resolve ABSENT and fall back to
+// its stale flat keys, the exact poison the object removes.
+func TestFormulaCookAttachGraphV2DeclaresTargetMemberScope(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	cityDir := t.TempDir()
+	formulaDir := writeCookScopeCity(t, cityDir)
+	writeCookFormula(t, formulaDir, "graph-scoped-convoy", `
+formula = "graph-scoped-convoy"
+version = 2
+contract = "graph.v2"
+
+[vars.base_branch]
+default = "release-x"
+
+[[steps]]
+id = "work"
+title = "Do {{convoy_id}} on {{base_branch}}"
+`)
+	formulatest.SetupHermeticCookEnv(t, cityDir)
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"graph-scoped-convoy", "--attach", source.ID, "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula cook --attach: %v\nstderr=%s", err, stderr.String())
+	}
+
+	after, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("re-open store: %v", err)
+	}
+	got, err := after.Get(source.ID)
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+	res := targetscope.Parse(got.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !res.Valid() {
+		t.Fatalf("attach target scope state = %v, want the member declaration to have committed a valid scope", res.State)
+	}
+	if res.Scope.Branch != "release-x" {
+		t.Fatalf("attach target scope.branch = %q, want release-x (the formula default the cook resolved)", res.Scope.Branch)
+	}
+}
+
+// A formula consuming no branch carrier still gets a present-valid field-empty
+// object (§2c). Absence is the only state that re-enables the cwd writers, so
+// "nothing to declare" must never be implemented as writing nothing.
+func TestFormulaCookCarrierlessStampsUnknownScope(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	cityDir := t.TempDir()
+	formulaDir := writeCookScopeCity(t, cityDir)
+	writeCookFormula(t, formulaDir, "graph-carrierless", `
+formula = "graph-carrierless"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "work"
+title = "Work with no branch"
+`)
+	formulatest.SetupHermeticCookEnv(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"graph-carrierless", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula cook: %v\nstderr=%s", err, stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	rootRes, _, sawRoot := cookScopeReadback(t, store)
+	if !sawRoot {
+		t.Fatal("carrierless cook stamped nothing; §2c requires a present-valid field-empty object")
+	}
+	if !rootRes.Valid() {
+		t.Fatalf("scope state = %v, want present-valid (field-empty), never absent", rootRes.State)
+	}
+	if rootRes.Scope.Branch != "" {
+		t.Fatalf("scope.branch = %q, want empty (unknown) for a carrierless formula", rootRes.Scope.Branch)
+	}
+}

--- a/cmd/gc/order_args_channel_test.go
+++ b/cmd/gc/order_args_channel_test.go
@@ -80,11 +80,11 @@ title = "Work {i}"
 
 	// Without the var the required compile-time range var is unresolved and
 	// compilation fails — proving the var is what makes the recipe compile.
-	if _, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, nil); err == nil {
+	if _, _, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, nil, ""); err == nil {
 		t.Fatal("prepareOrderWispRecipe with nil vars: expected failure for missing required range var n")
 	}
 
-	recipe, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, map[string]string{"n": "3"})
+	recipe, _, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, map[string]string{"n": "3"}, "")
 	if err != nil {
 		t.Fatalf("prepareOrderWispRecipe with vars: %v", err)
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/processgroup"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
+	"github.com/gastownhall/gascity/internal/targetscope"
 )
 
 const (
@@ -1416,12 +1417,64 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, front *orders.
 	})
 }
 
-func prepareOrderWispRecipe(ctx context.Context, store beads.Store, a orders.Order, searchPaths []string, vars map[string]string) (*formula.Recipe, error) {
+// prepareOrderWispRecipe compiles an order's formula and resolves the target
+// scope the compiled root must be stamped with.
+//
+// SCOPE IS RESOLVED FROM THE FORMULA DEFAULTS ALONE — see orderScopeSources for
+// the source-measured reason. It is resolved here, alongside the compile,
+// because this is the one function both order boundaries share.
+func prepareOrderWispRecipe(ctx context.Context, store beads.Store, a orders.Order, searchPaths []string, vars map[string]string, scopeRoot string) (*formula.Recipe, targetscope.Scope, error) {
 	inv, err := graphv2.PrepareInvocation(ctx, store, a.Formula, searchPaths, "", vars)
 	if err != nil {
-		return nil, err
+		return nil, targetscope.Scope{}, err
 	}
-	return formula.CompileWithoutRuntimeVarValidation(ctx, a.Formula, searchPaths, inv.Vars)
+	resolved, err := targetscope.Resolve(orderScopeSources(inv.Formula), scopeRoot)
+	if err != nil {
+		return nil, targetscope.Scope{}, fmt.Errorf("resolving target scope for order %s: %w", a.ScopedName(), err)
+	}
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, a.Formula, searchPaths, inv.Vars)
+	if err != nil {
+		return nil, targetscope.Scope{}, err
+	}
+	return recipe, resolved.Scope, nil
+}
+
+// orderScopeSources builds the trusted-source set for an order — the formula
+// defaults, and ONLY the formula defaults.
+//
+// This is narrower than the design's §5 order row (which names the rig and the
+// order's effective vars), and the narrowing is a source-measured correctness
+// requirement, not a shortcut. Both order boundaries materialize with
+// molecule.Instantiate(recipe, molecule.Options{}) — an EMPTY options — so a
+// step body's {{base_branch}} is substituted from applyVarDefaults(nil,
+// recipe.Vars): the FORMULA DEFAULT, and nothing else. The order's caller vars
+// and its rig formula_vars never reach that substitution (verified end to end:
+// an order run with base_branch=CALLER and a rig declaring base_branch=RIG both
+// still materialize a step titled with the formula default).
+//
+// So the formula default is the one value the work actually runs against, and
+// scope.branch must equal it or the close gate would validate a branch the work
+// never touched — the exact §3c divergence the equality invariant forbids.
+// Resolving from the rig or the explicit layer would stamp a branch that is
+// real intent but not the executed reality, manufacturing that divergence. The
+// gap it exposes — that orders ignore their own vars at substitution — is a
+// pre-existing order-path limitation, out of scope here and worth its own bead;
+// this boundary stamps the honest branch rather than papering the gap with a
+// scope that lies.
+func orderScopeSources(f *formula.Formula) targetscope.Sources {
+	return targetscope.Sources{FormulaDefaults: targetscope.FormulaDefaultVars(f)}
+}
+
+// stampOrderWispRoot stamps the resolved scope on an order's recipe root before
+// materialization.
+//
+// Orders launch with targetID "" and therefore have no input convoy and no
+// members, so the declaration phase has nothing to declare — but the root is
+// still stamped, including when the scope is unknown. §2c: a boundary leaves a
+// present-valid field-empty object, never nothing at all, because absence is
+// what lets the next claim or reconcile write cwd.
+func stampOrderWispRoot(recipe *formula.Recipe, scope targetscope.Scope) error {
+	return targetscope.PrepareLaunch(recipe, scope, nil)
 }
 
 func poolOrderRouteVisibilityWarning(a orders.Order, recipe *formula.Recipe) string {
@@ -1539,7 +1592,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if a.FormulaLayer != "" {
 		searchPaths = []string{a.FormulaLayer}
 	}
-	recipe, err := prepareOrderWispRecipe(ctx, store, a, searchPaths, vars)
+	recipe, wispScope, err := prepareOrderWispRecipe(ctx, store, a, searchPaths, vars, target.ScopeRoot)
 	if err != nil {
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
@@ -1584,6 +1637,21 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	// unreachable graph in the store while reporting the order as completed.
 	if err := applyOrderRecipeRouting(recipe, pool, vars, target, store, m.cityName, cityPath, m.cfg); err != nil {
 		logDispatchError(m.stderr, "gc: order %s: routing decoration failed: %v", scoped, err)
+		m.rec.Record(events.Event{
+			Type:    events.OrderFailed,
+			Actor:   "controller",
+			Subject: scoped,
+			Message: err.Error(),
+		})
+		m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
+		return
+	}
+
+	// Stamp the scope after routing decoration and before materialization, so
+	// the root that becomes claimable is already scoped and no claim can write
+	// cwd onto it.
+	if err := stampOrderWispRoot(recipe, wispScope); err != nil {
+		logDispatchError(m.stderr, "gc: order %s: target scope stamp failed: %v", scoped, err)
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
 			Actor:   "controller",

--- a/cmd/gc/order_target_scope_test.go
+++ b/cmd/gc/order_target_scope_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// scopedOrderFormulaDir writes a formula that DECLARES base_branch with a
+// default, which is what makes base_branch a carrier this formula consumes.
+func scopedOrderFormulaDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := `
+formula = "order-scoped"
+version = 1
+
+[vars.base_branch]
+default = "main"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "order-scoped.toml"), []byte(strings.TrimSpace(body)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func orderRecipeRootScope(t *testing.T, dir string, a orders.Order) targetscope.Resolution {
+	t.Helper()
+	recipe, scope, err := prepareOrderWispRecipe(context.Background(), beads.NewMemStore(), a, []string{dir}, nil, "")
+	if err != nil {
+		t.Fatalf("prepareOrderWispRecipe: %v", err)
+	}
+	if err := stampOrderWispRoot(recipe, scope); err != nil {
+		t.Fatalf("stampOrderWispRoot: %v", err)
+	}
+	return targetscope.Parse(recipe.Steps[0].Metadata[beadmeta.TargetScopeMetadataKey])
+}
+
+// The order boundary stamps. Both order paths (controller dispatch and
+// `gc order run`) reach molecule.Instantiate directly without entering any
+// sling stamper, so before this seam every order root was ABSENT and the first
+// claim wrote whatever cwd the controller happened to hold.
+func TestOrderWispRootCarriesTheDeclaredScope(t *testing.T) {
+	dir := scopedOrderFormulaDir(t)
+	a := orders.Order{Name: "scoped-order", Trigger: "manual", Formula: "order-scoped", FormulaLayer: dir, Rig: "rig-a"}
+
+	got := orderRecipeRootScope(t, dir, a)
+	if !got.Valid() {
+		t.Fatalf("order root scope state = %v, want a present-valid object", got.State)
+	}
+	if got.Scope.Branch != "main" {
+		t.Fatalf("scope.branch = %q, want the formula default main", got.Scope.Branch)
+	}
+}
+
+// The load-bearing correctness property for the order boundary: scope.branch
+// equals the branch the materialized work actually runs against, end to end.
+//
+// Both order boundaries materialize with molecule.Instantiate(recipe,
+// molecule.Options{}) — empty options — so a step body's {{base_branch}} is
+// substituted from the FORMULA DEFAULT, ignoring the order's caller vars and
+// its rig formula_vars. Resolving the scope from the rig or the caller layer
+// would stamp a branch the work never touches — the exact §3c divergence the
+// equality invariant forbids. This test drives the real dispatch and asserts
+// the stamped scope and the substituted step title are the SAME branch.
+func TestOrderScopeEqualsWhatTheWorkSubstitutesEndToEnd(t *testing.T) {
+	cityDir := t.TempDir()
+	formulaDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, "fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+[daemon]
+formula_v2 = true
+[[rigs]]
+name = "fixture"
+path = "fixture"
+[[rigs.formula_vars]]
+base_branch = "RIG-BRANCH-IGNORED-BY-SUBSTITUTION"
+[[agent]]
+name = "worker"
+dir = "fixture"
+max_active_sessions = 2
+[[agent]]
+name = "control-dispatcher"
+dir = "fixture"
+max_active_sessions = 1
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The rig declares a base_branch that would win §3a precedence 3 if it were
+	// a scope source; the test proves it is NOT, because it is not what the
+	// work substitutes.
+	if err := os.WriteFile(filepath.Join(formulaDir, "wf.toml"), []byte(`
+formula = "wf"
+version = 2
+contract = "graph.v2"
+
+[vars.base_branch]
+default = "FORMULA-DEFAULT"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+metadata = { "gc.run_target" = "worker" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := orders.Order{Name: "probe", Rig: "fixture", Formula: "wf", Trigger: "manual", FormulaLayer: formulaDir}
+	store := beads.NewMemStore()
+	var stdout, stderr bytes.Buffer
+	// Caller supplies a branch too — proving neither the rig nor the caller
+	// layer reaches substitution, only the formula default does.
+	code := doOrderRunWithJSON([]orders.Order{a}, a.Name, a.Rig, cityDir, beads.OrdersStore{Store: store}, nil, false, map[string]string{"base_branch": "CALLER-BRANCH-IGNORED"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	all, err := store.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("listing store: %v", err)
+	}
+	var rootBranch, stepTitle string
+	for _, b := range all {
+		if raw := b.Metadata[beadmeta.TargetScopeMetadataKey]; raw != "" {
+			res := targetscope.Parse(raw)
+			if !res.Valid() {
+				t.Fatalf("root scope state = %v, want valid", res.State)
+			}
+			rootBranch = res.Scope.Branch
+		}
+		if strings.HasPrefix(b.Title, "Work on ") {
+			stepTitle = b.Title
+		}
+	}
+	if rootBranch == "" {
+		t.Fatal("no root carried a target scope; the order boundary did not stamp")
+	}
+	if stepTitle != "Work on "+rootBranch {
+		t.Fatalf("step title %q disagrees with scope.branch %q — the stamped scope is not the executed branch", stepTitle, rootBranch)
+	}
+	if rootBranch != "FORMULA-DEFAULT" {
+		t.Fatalf("scope.branch = %q, want FORMULA-DEFAULT (the value substitution actually uses)", rootBranch)
+	}
+}
+
+// A formula consuming no branch carrier still gets a present-valid field-empty
+// object (§2c). Absence is the only state that re-enables the cwd writers, so
+// "nothing to declare" must never be implemented as writing nothing.
+func TestOrderCarrierlessFormulaStillStampsAnUnknownScope(t *testing.T) {
+	dir := t.TempDir()
+	body := "formula = \"order-carrierless\"\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "order-carrierless.toml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := orders.Order{Name: "carrierless-order", Trigger: "manual", Formula: "order-carrierless", FormulaLayer: dir}
+
+	recipe, scope, err := prepareOrderWispRecipe(context.Background(), beads.NewMemStore(), a, []string{dir}, nil, "")
+	if err != nil {
+		t.Fatalf("prepareOrderWispRecipe: %v", err)
+	}
+	if err := stampOrderWispRoot(recipe, scope); err != nil {
+		t.Fatalf("stampOrderWispRoot: %v", err)
+	}
+	got := targetscope.Parse(recipe.Steps[0].Metadata[beadmeta.TargetScopeMetadataKey])
+	if !got.Valid() {
+		t.Fatalf("scope state = %v, want a present-valid field-empty object, never absent", got.State)
+	}
+}

--- a/cmd/gc/target_scope_e2e_test.go
+++ b/cmd/gc/target_scope_e2e_test.go
@@ -1,0 +1,848 @@
+package main
+
+// END-TO-END REGRESSION MATRIX for gc.target_scope.v1 (DESIGN §11).
+//
+// Every unit/boundary test in this build proves one production function in
+// isolation against a hand-built bead. This file proves they COMPOSE along the
+// real path: a real launch stamps a scope, and the real claim / reconcile /
+// close-gate readers then honour it — from a claiming cwd whose branch and path
+// deliberately differ from the declared scope, asserting no functional reader
+// observes the cwd values (§11 preamble).
+//
+// This is the layer that catches composition bugs a unit test structurally
+// cannot: "the launch never stamped the bead the close gate loads", "the guard
+// is installed in tests but not in production". Sessions 2/4/5 each found one of
+// exactly that class; the matrix is the standing net for it.
+//
+// The claim step drives the production hookClaimIdentityPatch /
+// hookClaimMayStampCwdBranch with a resolver that is the production resolver's
+// own body — targetscope.ResolveInherited(store, bead) — fed the REAL launched
+// store; that production installs it is pinned separately by
+// TestApplyDefaultsInstallsTargetScopeResolver. The reconcile and close-gate
+// steps call the production functions directly.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/sling"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// The claimant is parked on a shared checkout whose branch and path have
+// nothing to do with any declared scope — the poison shape the whole design
+// exists to keep out of functional reads.
+const (
+	e2ePoisonBranch  = "parked-shared-branch"
+	e2ePoisonWorkDir = "/shared/parked/root"
+	e2ePoisonDir     = "/shared/parked/checkout"
+)
+
+// e2eScopedFormulaDir writes a formula that DECLARES base_branch with a default,
+// which is what makes base_branch a carrier this formula consumes: an explicit
+// gc_target_branch then reaches BOTH scope.branch and the substituted step
+// title, the equality the close gate later validates against.
+func e2eScopedFormulaDir(t *testing.T, name string) string {
+	t.Helper()
+	return e2eWriteFormula(t, name, `formula = "`+name+`"
+version = 1
+
+[vars.base_branch]
+default = "main"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+`)
+}
+
+// e2eWriteFormula writes a single formula file into a fresh temp dir and returns
+// that dir (a formula search path).
+func e2eWriteFormula(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing formula %s: %v", name, err)
+	}
+	return dir
+}
+
+// e2eSlingDeps builds SlingDeps talking to a fresh MemStore, mirroring the
+// production wiring cmd/gc installs. Notify is nil (skip) so no controller poke
+// is attempted; the runner is a no-op.
+func e2eSlingDeps(t *testing.T, formulaDir string) (slingDeps, config.Agent) {
+	t.Helper()
+	agent := config.Agent{Name: "worker", Dir: "rig", MaxActiveSessions: intPtr(1)}
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}, Agents: []config.Agent{agent}}
+	cfg.FormulaLayers.City = []string{formulaDir}
+	deps := slingDeps{
+		CityName: "test-city",
+		CityPath: t.TempDir(),
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		StoreRef: "city:test-city",
+		Resolver: cliAgentResolver{},
+		Runner:   func(_, _ string, _ map[string]string) (string, error) { return "", nil },
+	}
+	return deps, agent
+}
+
+// e2eLaunchScopedSling launches a REAL sling formula and returns the store plus
+// every bead the launch materialized. The formula consumes base_branch, so vars
+// like gc_target_branch=release drive the stamped scope end to end.
+func e2eLaunchScopedSling(t *testing.T, deps slingDeps, agent config.Agent, formulaName string, vars ...string) []beads.Bead {
+	t.Helper()
+	opts := sling.SlingOpts{
+		Target:        agent,
+		BeadOrFormula: formulaName,
+		IsFormula:     true,
+		SkipPoke:      true,
+		Vars:          vars,
+	}
+	if _, err := sling.DoSling(opts, deps, nil); err != nil {
+		t.Fatalf("DoSling(%s): %v", formulaName, err)
+	}
+	return e2eStoreBeads(t, deps.Store)
+}
+
+func e2eStoreBeads(t *testing.T, store beads.Store) []beads.Bead {
+	t.Helper()
+	all, err := store.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("listing store: %v", err)
+	}
+	return all
+}
+
+// e2eFormulaRoot returns the one bead the launch stamped with gc.formula_name.
+func e2eFormulaRoot(t *testing.T, all []beads.Bead) beads.Bead {
+	t.Helper()
+	var roots []beads.Bead
+	for _, b := range all {
+		if b.Metadata[beadmeta.FormulaNameMetadataKey] != "" {
+			roots = append(roots, b)
+		}
+	}
+	if len(roots) != 1 {
+		t.Fatalf("found %d formula roots after launch, want exactly one", len(roots))
+	}
+	return roots[0]
+}
+
+// e2eWorkStep returns the materialized non-root step, located by its title
+// prefix (the step the scoped formula titles "Work on <branch>").
+func e2eWorkStep(t *testing.T, all []beads.Bead) beads.Bead {
+	t.Helper()
+	var steps []beads.Bead
+	for _, b := range all {
+		if strings.HasPrefix(b.Title, "Work on ") {
+			steps = append(steps, b)
+		}
+	}
+	if len(steps) != 1 {
+		t.Fatalf("found %d work steps after launch, want exactly one", len(steps))
+	}
+	return steps[0]
+}
+
+// e2eClaimPatch drives the production claim identity patch against the launched
+// store from a poison cwd. The resolver is the production resolver's own body
+// (ResolveInherited) fed the real store; ResolveWorkBranch always returns the
+// poison branch, so a non-empty patch[gc.work_branch] means the cwd leaked in.
+func e2eClaimPatch(store beads.Store, bead beads.Bead) map[string]string {
+	ops := hookClaimOps{
+		ResolveWorkBranch: func(string) string { return e2ePoisonBranch },
+		ResolveTargetScope: func(_ string, _ []string, b beads.Bead) targetscope.Resolution {
+			return targetscope.ResolveInherited(store, b)
+		},
+	}
+	return hookClaimIdentityPatch(bead, hookClaimOptions{}, ops, e2ePoisonDir)
+}
+
+// e2ePoisonFlatKeys returns a copy of bead with a shipped work record whose flat
+// gc.work_* values are all poison — the state a pool session parked on a shared
+// checkout would leave. The close gate must read the declared scope, never these.
+func e2ePoisonFlatKeys(bead beads.Bead) beads.Bead {
+	md := beads.StringMap{}
+	for k, v := range bead.Metadata {
+		md[k] = v
+	}
+	md[beadmeta.WorkOutcomeMetadataKey] = beadmeta.WorkOutcomeShipped
+	md[beadmeta.WorkCommitMetadataKey] = "cafef00d"
+	md[beadmeta.WorkBranchMetadataKey] = e2ePoisonBranch
+	md[beadmeta.WorkDirMetadataKey] = e2ePoisonWorkDir
+	out := bead
+	out.Metadata = md
+	return out
+}
+
+// e2eEnvelope returns the scopeRoot and Envelope both anchored at the city
+// path — the shape the production close gate is handed.
+func e2eEnvelope(deps slingDeps) (string, targetscope.Envelope) {
+	return deps.CityPath, targetscope.Envelope{CityPath: deps.CityPath, StorePath: deps.CityPath}
+}
+
+// e2eAssertClaimStampsNothing asserts the production claim path, driven from the
+// poison cwd, leaves gc.work_branch unwritten — the declared scope wins.
+func e2eAssertClaimStampsNothing(t *testing.T, store beads.Store, bead beads.Bead) {
+	t.Helper()
+	if patch := e2eClaimPatch(store, bead); patch[beadmeta.WorkBranchMetadataKey] != "" {
+		t.Fatalf("claim stamped %s=%q from the cwd over a declared scope on %s",
+			beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey], bead.ID)
+	}
+}
+
+// e2eAssertReconcileStandsDown asserts the reconcile work-dir writer refuses to
+// stamp the session cwd over the (possibly inherited) declared scope.
+func e2eAssertReconcileStandsDown(t *testing.T, store beads.Store, bead beads.Bead) {
+	t.Helper()
+	if mayStampCwdWorkDir(store, bead, nil) {
+		t.Fatalf("reconcile would stamp the session cwd work_dir over the declared scope on %s", bead.ID)
+	}
+}
+
+// e2eCloseGateLocation poisons the bead's flat keys (the shipped-record shape a
+// parked pool session leaves) and runs the production close-gate location
+// resolver, returning what the gate's git probe would receive.
+func e2eCloseGateLocation(deps slingDeps, bead beads.Bead) (repoDir, declaredBranch, violation string) {
+	scopeRoot, envelope := e2eEnvelope(deps)
+	return workRecordCloseLocation(deps.Store, e2ePoisonFlatKeys(bead), scopeRoot, envelope)
+}
+
+// §11 #1 — Fresh claim of a scoped formula stage. The launched stage's
+// gc.work_branch must NOT become the claiming cwd branch, and the close gate
+// must validate against scope.branch, not the parked flat value.
+func TestE2EFreshClaimOfScopedStageHonoursDeclaredScope(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-fresh")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-fresh", "gc_target_branch=release")
+
+	root := e2eFormulaRoot(t, all)
+	rootScope := targetscope.Parse(root.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !rootScope.Valid() || rootScope.Scope.Branch != "release" {
+		t.Fatalf("root scope = %+v, want valid branch=release", rootScope)
+	}
+
+	step := e2eWorkStep(t, all)
+	e2eAssertClaimStampsNothing(t, deps.Store, step)
+	e2eAssertReconcileStandsDown(t, deps.Store, step)
+
+	// CLOSE GATE — the poisoned copy keeps its parent link, so the reader still
+	// inherits the root's scope through the store; the branch comes from there.
+	_, declaredBranch, violation := e2eCloseGateLocation(deps, step)
+	if violation != "" {
+		t.Fatalf("unexpected close-gate violation: %s", violation)
+	}
+	if declaredBranch != "release" {
+		t.Fatalf("close gate declaredBranch = %q, want release (not the parked flat value)", declaredBranch)
+	}
+}
+
+// §11 #2 — Existing-assignment and adopted-assignment claims run the same
+// stampHookClaimIdentity seam, so a bead that already carries an assignee (or is
+// being adopted by a different session) must have its cwd branch suppressed just
+// like a fresh claim. Assignment state is orthogonal to the scope guard.
+func TestE2EExistingAndAdoptedAssignmentClaimsStillSuppressCwd(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-adopt")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-adopt", "gc_target_branch=release")
+	step := e2eWorkStep(t, all)
+
+	// Existing assignment: the step already carries a claiming session.
+	step.Metadata[beadmeta.SessionIDMetadataKey] = "prior-session"
+	step.Assignee = "prior-session"
+	e2eAssertClaimStampsNothing(t, deps.Store, step)
+
+	// Adopted assignment: a different session claims from a different poison cwd.
+	ops := hookClaimOps{
+		ResolveWorkBranch: func(string) string { return "another-parked-branch" },
+		ResolveTargetScope: func(_ string, _ []string, b beads.Bead) targetscope.Resolution {
+			return targetscope.ResolveInherited(deps.Store, b)
+		},
+	}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=adopting-session", "GC_SESSION_NAME=worker-2"}}
+	patch := hookClaimIdentityPatch(step, opts, ops, "/some/other/checkout")
+	if patch[beadmeta.WorkBranchMetadataKey] != "" {
+		t.Fatalf("adopted-assignment claim stamped %s=%q over a declared scope",
+			beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey])
+	}
+	// The session back-reference is orthogonal and must still be recorded.
+	if patch[beadmeta.SessionIDMetadataKey] != "adopting-session" {
+		t.Fatalf("adopted claim dropped the session back-reference: %v", patch)
+	}
+}
+
+// §11 #3 — Repeated claim from a different cwd. Re-claiming a scoped stage from
+// a second, differently-parked checkout must still suppress the stamp: the
+// scope is authoritative every time, and nothing drifts across claims.
+func TestE2ERepeatedClaimFromDifferentCwdDoesNotDrift(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-reclaim")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-reclaim", "gc_target_branch=release")
+	step := e2eWorkStep(t, all)
+
+	for _, cwd := range []struct{ branch, dir string }{
+		{e2ePoisonBranch, e2ePoisonDir},
+		{"second-parked-branch", "/second/parked/checkout"},
+	} {
+		ops := hookClaimOps{
+			ResolveWorkBranch: func(string) string { return cwd.branch },
+			ResolveTargetScope: func(_ string, _ []string, b beads.Bead) targetscope.Resolution {
+				return targetscope.ResolveInherited(deps.Store, b)
+			},
+		}
+		if patch := hookClaimIdentityPatch(step, hookClaimOptions{}, ops, cwd.dir); patch[beadmeta.WorkBranchMetadataKey] != "" {
+			t.Fatalf("re-claim from %s stamped %s=%q, want the declared scope to keep winning",
+				cwd.dir, beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey])
+		}
+	}
+}
+
+// §11 #4 — Work-dir reconcile + root propagation. A scope declaring a worktree
+// must suppress the cwd work_dir stamp on BOTH the root and the inheriting
+// stage, and the stage's close gate must resolve the declared worktree (through
+// inheritance), never the parked path. The worktree is persisted absolute.
+func TestE2EWorkDirReconcileAndRootPropagation(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-worktree")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-worktree",
+		"gc_target_branch=release", "gc_target_worktree=worktrees/T")
+
+	root := e2eFormulaRoot(t, all)
+	rootScope := targetscope.Parse(root.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !rootScope.Valid() || rootScope.Scope.Worktree == "" {
+		t.Fatalf("root scope = %+v, want a valid worktree", rootScope)
+	}
+	if !filepath.IsAbs(rootScope.Scope.Worktree) {
+		t.Fatalf("root scope worktree %q is not absolute; normalization must happen at the boundary", rootScope.Scope.Worktree)
+	}
+
+	step := e2eWorkStep(t, all)
+	// Neither the root nor the inheriting stage may take the session cwd work_dir.
+	e2eAssertReconcileStandsDown(t, deps.Store, root)
+	e2eAssertReconcileStandsDown(t, deps.Store, step)
+	e2eAssertClaimStampsNothing(t, deps.Store, step)
+
+	// The stage inherits the declared worktree; the gate probes there, not the
+	// parked root.
+	repoDir, declaredBranch, violation := e2eCloseGateLocation(deps, step)
+	if violation != "" {
+		t.Fatalf("unexpected close-gate violation: %s", violation)
+	}
+	if declaredBranch != "release" {
+		t.Fatalf("declaredBranch = %q, want release", declaredBranch)
+	}
+	if repoDir != rootScope.Scope.Worktree {
+		t.Fatalf("close gate repoDir = %q, want the inherited declared worktree %q (not the parked path)", repoDir, rootScope.Scope.Worktree)
+	}
+	if repoDir == e2ePoisonWorkDir {
+		t.Fatal("close gate resolved the parked work_dir")
+	}
+}
+
+// §11 #5 — The symbolic-ref class the whole design exists for. A formula stage
+// carries only a gc.root_bead_id pointer, not a copy of root metadata. The
+// inherited-scope resolver must reach the root's scope through that pointer so
+// the claim guard suppresses cwd and the close gate reads the declared branch.
+func TestE2ESymbolicRootRefStageInheritsScope(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-symbolic")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-symbolic", "gc_target_branch=release")
+	root := e2eFormulaRoot(t, all)
+
+	// A stage that references the root ONLY through gc.root_bead_id — no parent
+	// link, no scope of its own. This is the graph-stage shape.
+	stage, err := deps.Store.Create(beads.Bead{
+		Title:    "symbolic stage",
+		Metadata: beads.StringMap{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("creating symbolic-ref stage: %v", err)
+	}
+
+	if got := targetscope.ResolveInherited(deps.Store, stage); !got.Valid() || got.Scope.Branch != "release" {
+		t.Fatalf("inherited resolution = %+v, want valid branch=release through the root ref", got)
+	}
+	e2eAssertClaimStampsNothing(t, deps.Store, stage)
+	e2eAssertReconcileStandsDown(t, deps.Store, stage)
+
+	_, declaredBranch, violation := e2eCloseGateLocation(deps, stage)
+	if violation != "" || declaredBranch != "release" {
+		t.Fatalf("close gate on symbolic-ref stage = (%q, %q), want (release, no violation)", declaredBranch, violation)
+	}
+}
+
+// §11 #6 — Attempt 2 (a retry stage) resolves the ORIGINAL root's scope. A
+// retry materializes a fresh attempt bead that points back at the original root;
+// it must inherit the same declared scope rather than resolving a new one from
+// the cwd it happens to be claimed in.
+func TestE2ERetryAttemptResolvesOriginalRootScope(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-retry")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-retry", "gc_target_branch=release")
+	root := e2eFormulaRoot(t, all)
+	original := e2eWorkStep(t, all)
+
+	// The retry attempt references the original root (the inherit-don't-copy
+	// contract: a retry is safe by lineage, §9).
+	retry, err := deps.Store.Create(beads.Bead{
+		Title:    original.Title + " (attempt 2)",
+		Metadata: beads.StringMap{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("creating retry attempt: %v", err)
+	}
+
+	got := targetscope.ResolveInherited(deps.Store, retry)
+	if !got.Valid() || got.Scope.Branch != "release" {
+		t.Fatalf("retry inherited scope = %+v, want the original root's release", got)
+	}
+	e2eAssertClaimStampsNothing(t, deps.Store, retry)
+}
+
+// §11 #10 / #13 — Poisoned-input-member and no-trusted-source. A launch with no
+// branch carrier of any kind resolves a present-valid FIELD-EMPTY object, never
+// absent. Absence is the only state that re-enables the cwd writers, so a
+// carrierless launch must still lock them out: claim and reconcile stand down,
+// and both readings the close gate makes refuse the parked flat keys.
+func TestE2ECarrierlessLaunchStampsUnknownNotAbsent(t *testing.T) {
+	dir := e2eWriteFormula(t, "e2e-carrierless",
+		"formula = \"e2e-carrierless\"\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-carrierless")
+
+	root := e2eFormulaRoot(t, all)
+	got := targetscope.Parse(root.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !got.Valid() {
+		t.Fatalf("carrierless root scope state = %v, want present-valid field-empty, never absent", got.State)
+	}
+	if got.Scope.Branch != "" {
+		t.Fatalf("carrierless scope carried a branch %q, want field-empty", got.Scope.Branch)
+	}
+
+	// The step inherits the unknown scope; the cwd writers must still stand down
+	// (unknown ≠ absent).
+	step := all[0]
+	for _, b := range all {
+		if b.Title == "Work" {
+			step = b
+		}
+	}
+	e2eAssertClaimStampsNothing(t, deps.Store, step)
+	e2eAssertReconcileStandsDown(t, deps.Store, step)
+
+	// Close gate: unknown scope does NOT fall back to the flat work_branch, and
+	// its repoDir falls to the scope root, never the parked work_dir.
+	repoDir, declaredBranch, violation := e2eCloseGateLocation(deps, step)
+	if violation != "" {
+		t.Fatalf("unknown scope produced a violation: %s", violation)
+	}
+	if declaredBranch != "" {
+		t.Fatalf("unknown scope leaked a declaredBranch %q — it must not fall back to the flat key", declaredBranch)
+	}
+	if repoDir == e2ePoisonWorkDir {
+		t.Fatal("unknown scope fell back to the parked flat work_dir")
+	}
+}
+
+// §11 #16 — the consumed-carrier equality invariant (DECISION 3), re-asserted on
+// the FINISHED assembly through the whole chain. Explicit gc_target_branch
+// outranks the formula default; the reconciled winner is written back into the
+// consumed base_branch carrier so template substitution and the close gate read
+// the SAME branch. This is the poison class the entire bead exists to kill:
+// scope.branch == what the work runs against == what the gate validates.
+func TestE2EConsumedCarrierEqualsScopeEndToEnd(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-equality")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-equality", "gc_target_branch=release")
+
+	root := e2eFormulaRoot(t, all)
+	scope := targetscope.Parse(root.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !scope.Valid() || scope.Scope.Branch != "release" {
+		t.Fatalf("root scope = %+v, want branch=release", scope)
+	}
+
+	// The substituted step title is the observable proof the consumed carrier
+	// equals the scope — substitution used the winner, not the stale default.
+	step := e2eWorkStep(t, all)
+	if step.Title != "Work on release" {
+		t.Fatalf("step title = %q, want %q — substitution and the declared scope disagree", step.Title, "Work on release")
+	}
+
+	// And the close gate validates against that SAME release.
+	_, declaredBranch, violation := e2eCloseGateLocation(deps, step)
+	if violation != "" || declaredBranch != "release" {
+		t.Fatalf("close gate = (%q, %q), want (release, no violation) — the gate must validate the executed branch", declaredBranch, violation)
+	}
+}
+
+// e2eAttachScopedFormula attaches a scoped formula to a pre-existing source bead
+// and returns the source bead after the launch. An attached launch routes and
+// closes the SOURCE, so §5b declares the resolved scope on the source bead
+// itself — the bead the close gate later loads directly.
+func e2eAttachScopedFormula(t *testing.T, deps slingDeps, agent config.Agent, formulaName, sourceID string, vars ...string) beads.Bead {
+	t.Helper()
+	opts := sling.SlingOpts{
+		Target:        agent,
+		BeadOrFormula: sourceID,
+		OnFormula:     formulaName,
+		SkipPoke:      true,
+		Vars:          vars,
+	}
+	if _, err := sling.DoSling(opts, deps, deps.Store); err != nil {
+		t.Fatalf("DoSling --on %s: %v", formulaName, err)
+	}
+	got, err := deps.Store.Get(sourceID)
+	if err != nil {
+		t.Fatalf("reloading source %s: %v", sourceID, err)
+	}
+	return got
+}
+
+// §11 #9 — Legacy claimable source. An attached formula routes and closes the
+// source bead; that bead carries the declared scope on its OWN key (not through
+// inheritance), and a claim from a mismatching cwd must not overwrite it.
+func TestE2ELegacyClaimableSourceCarriesScopeAndResistsCwd(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-attach")
+	deps, agent := e2eSlingDeps(t, dir)
+	src, err := deps.Store.Create(beads.Bead{Title: "attach source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("creating source: %v", err)
+	}
+
+	src = e2eAttachScopedFormula(t, deps, agent, "e2e-attach", src.ID, "gc_target_branch=release")
+
+	// The scope is declared ON the source bead, readable without inheritance.
+	own := targetscope.Parse(src.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !own.Valid() || own.Scope.Branch != "release" {
+		t.Fatalf("source own scope = %+v, want valid branch=release declared on the source", own)
+	}
+	e2eAssertClaimStampsNothing(t, deps.Store, src)
+	e2eAssertReconcileStandsDown(t, deps.Store, src)
+
+	_, declaredBranch, violation := e2eCloseGateLocation(deps, src)
+	if violation != "" || declaredBranch != "release" {
+		t.Fatalf("close gate on legacy source = (%q, %q), want (release, no violation)", declaredBranch, violation)
+	}
+}
+
+// §11 #12 — THE HEADLINE. A member T whose three gc.work_* flat values are all
+// poisoned, closed through the close gate. Launch the targeted formula against T
+// with an explicit clean branch + worktree, claim + reconcile from a THIRD
+// mismatching cwd, then close T (the ORIGINAL member). The gate's git probe must
+// receive the DECLARED branch and the NORMALIZED declared worktree — not any
+// poisoned flat value and not the claimant cwd. This exercises the §5b member
+// stamp specifically: the gate loads T, so reading a stage's scope is not enough.
+func TestE2EPoisonedMemberClosedThroughGateReadsDeclaredScope(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-poison-member")
+	deps, agent := e2eSlingDeps(t, dir)
+
+	// A member T whose THREE flat work_* values are poison before the launch.
+	src, err := deps.Store.Create(beads.Bead{
+		Title:  "poisoned member",
+		Type:   "task",
+		Status: "open",
+		Metadata: beads.StringMap{
+			beadmeta.WorkBranchMetadataKey: e2ePoisonBranch,
+			beadmeta.WorkDirMetadataKey:    e2ePoisonWorkDir,
+			beadmeta.WorkCommitMetadataKey: "deadbeef",
+		},
+	})
+	if err != nil {
+		t.Fatalf("creating poisoned member: %v", err)
+	}
+
+	src = e2eAttachScopedFormula(t, deps, agent, "e2e-poison-member", src.ID,
+		"gc_target_branch=release", "gc_target_worktree=worktrees/T")
+
+	declared := targetscope.Parse(src.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !declared.Valid() || declared.Scope.Branch != "release" || declared.Scope.Worktree == "" {
+		t.Fatalf("member T declared scope = %+v, want valid branch=release with a worktree", declared)
+	}
+	if !filepath.IsAbs(declared.Scope.Worktree) {
+		t.Fatalf("declared worktree %q is not absolute; the boundary must normalize before persisting", declared.Scope.Worktree)
+	}
+
+	// Claim + reconcile from a THIRD cwd (distinct from the poison and the
+	// declared scope): both writers stand down.
+	e2eAssertClaimStampsNothing(t, deps.Store, src)
+	e2eAssertReconcileStandsDown(t, deps.Store, src)
+
+	// Close T through the gate. Its git probe is handed the declared branch and
+	// the normalized declared worktree, NOT the three poisoned flat values.
+	// Note the bead here keeps its own poisoned flat keys — no re-poisoning: this
+	// is the real shape the gate loads.
+	scopeRoot, envelope := e2eEnvelope(deps)
+	repoDir, declaredBranch, violation := workRecordCloseLocation(deps.Store, src, scopeRoot, envelope)
+	if violation != "" {
+		t.Fatalf("close gate on poisoned member T reported a violation: %s", violation)
+	}
+	if declaredBranch != "release" {
+		t.Fatalf("gate probe branch = %q, want the declared release (not the poisoned %q)", declaredBranch, e2ePoisonBranch)
+	}
+	if repoDir != declared.Scope.Worktree {
+		t.Fatalf("gate probe repoDir = %q, want the normalized declared worktree %q (not the poisoned %q)", repoDir, declared.Scope.Worktree, e2ePoisonWorkDir)
+	}
+	if repoDir == e2ePoisonWorkDir {
+		t.Fatal("gate probe took the poisoned flat work_dir")
+	}
+}
+
+// §11 #14(ii) — CROSS-STORE worktree anchor (DECISION 2). With a distinct
+// GraphStore (the root) and Store (the member T) rooted at different paths, the
+// single persisted ABSOLUTE worktree is authority across the split: the reader
+// that loads T (close gate) and the reader that loads the root/stage (Ralph)
+// must consume the SAME absolute worktree — the graph-store vs work-store anchor
+// split does not produce two different paths. This asserts the cmd/gc close-gate
+// half and the cross-store equality of the persisted value; ralph_target_scope_test
+// covers the Ralph reader against the same ResolveForReader contract.
+func TestE2ECrossStoreWorktreeIsOneAbsolutePathForBothReaders(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-xstore")
+	deps, agent := e2eSlingDeps(t, dir)
+	// The graph root lands in a SEPARATE store from the source member T.
+	graphStore := beads.NewMemStore()
+	deps.GraphStore = graphStore
+
+	src, err := deps.Store.Create(beads.Bead{Title: "xstore member", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("creating cross-store member: %v", err)
+	}
+	src = e2eAttachScopedFormula(t, deps, agent, "e2e-xstore", src.ID,
+		"gc_target_branch=release", "gc_target_worktree=worktrees/T")
+
+	memberScope := targetscope.Parse(src.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !memberScope.Valid() || memberScope.Scope.Worktree == "" {
+		t.Fatalf("member T scope = %+v, want a valid worktree", memberScope)
+	}
+	if !filepath.IsAbs(memberScope.Scope.Worktree) {
+		t.Fatalf("member worktree %q is not absolute", memberScope.Scope.Worktree)
+	}
+
+	// The root landed in the GRAPH store; find its scope there.
+	graphBeads := e2eStoreBeads(t, graphStore)
+	root := e2eFormulaRoot(t, graphBeads)
+	rootScope := targetscope.Parse(root.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !rootScope.Valid() {
+		t.Fatalf("graph-store root scope state = %v, want valid", rootScope.State)
+	}
+	if rootScope.Scope.Worktree != memberScope.Scope.Worktree {
+		t.Fatalf("cross-store worktree split: root=%q member=%q — the persisted absolute value must be identical across stores",
+			rootScope.Scope.Worktree, memberScope.Scope.Worktree)
+	}
+
+	// The close gate loading T (envelope anchored at the work store) resolves the
+	// one absolute worktree, not a re-anchored per-store path.
+	scopeRoot, envelope := e2eEnvelope(deps)
+	repoDir, _, violation := workRecordCloseLocation(deps.Store, src, scopeRoot, envelope)
+	if violation != "" {
+		t.Fatalf("close gate on cross-store member reported a violation: %s", violation)
+	}
+	if repoDir != memberScope.Scope.Worktree {
+		t.Fatalf("close gate repoDir = %q, want the single absolute worktree %q", repoDir, memberScope.Scope.Worktree)
+	}
+}
+
+// §11 #14(iv) — an ESCAPING worktree is present-invalid at the close gate, which
+// refuses to validate and does NOT fall back to the flat keys. The scope is a
+// well-formed absolute path that simply escapes both the city and store roots.
+func TestE2EEscapingWorktreeFailsClosedAtTheGate(t *testing.T) {
+	dir := e2eScopedFormulaDir(t, "e2e-escape")
+	deps, agent := e2eSlingDeps(t, dir)
+	all := e2eLaunchScopedSling(t, deps, agent, "e2e-escape", "gc_target_branch=release")
+	step := e2eWorkStep(t, all)
+
+	// Pin an escaping absolute worktree directly on the step (a well-formed scope
+	// whose worktree is outside every envelope root).
+	escaping, err := targetscope.Marshal(targetscope.Scope{V: 1, Branch: "release", Worktree: "/etc/outside-every-root"})
+	if err != nil {
+		t.Fatalf("marshal escaping scope: %v", err)
+	}
+	if err := deps.Store.SetMetadata(step.ID, beadmeta.TargetScopeMetadataKey, escaping); err != nil {
+		t.Fatalf("pinning escaping scope: %v", err)
+	}
+	step, err = deps.Store.Get(step.ID)
+	if err != nil {
+		t.Fatalf("reloading step: %v", err)
+	}
+
+	scopeRoot, envelope := e2eEnvelope(deps)
+	repoDir, declaredBranch, violation := workRecordCloseLocation(deps.Store, e2ePoisonFlatKeys(step), scopeRoot, envelope)
+	if violation == "" {
+		t.Fatal("an escaping worktree must be a close-gate violation, not a silent pass")
+	}
+	if declaredBranch != "" || repoDir != "" {
+		t.Fatalf("escaping worktree fell back to a location (%q, %q); the gate must refuse, not use flat keys", repoDir, declaredBranch)
+	}
+}
+
+// §11 #15 — graph-v2 order boundary. An order materializes with empty
+// molecule.Options, so its scope is resolved from the formula defaults alone
+// (D4) — but that scope is real and must lock the cwd writers out just like a
+// sling launch: a claim of the order step from a mismatching cwd is suppressed,
+// and the gate reads the order's declared branch.
+func TestE2EOrderStepHonoursDeclaredScope(t *testing.T) {
+	cityDir := t.TempDir()
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "test-city"
+[daemon]
+formula_v2 = true
+[[rigs]]
+name = "fixture"
+path = "fixture"
+[[agent]]
+name = "worker"
+dir = "fixture"
+max_active_sessions = 2
+[[agent]]
+name = "control-dispatcher"
+dir = "fixture"
+max_active_sessions = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "ord.toml"), []byte(`
+formula = "ord"
+version = 2
+contract = "graph.v2"
+
+[vars.base_branch]
+default = "order-branch"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+metadata = { "gc.run_target" = "worker" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := orders.Order{Name: "probe", Rig: "fixture", Formula: "ord", Trigger: "manual", FormulaLayer: formulaDir}
+	store := beads.NewMemStore()
+	var stdout, stderr bytes.Buffer
+	if code := doOrderRunWithJSON([]orders.Order{a}, a.Name, a.Rig, cityDir, beads.OrdersStore{Store: store}, nil, false, nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("doOrderRunWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	all := e2eStoreBeads(t, store)
+	step := e2eWorkStep(t, all)
+	if step.Title != "Work on order-branch" {
+		t.Fatalf("order step title = %q, want the substituted default", step.Title)
+	}
+
+	// Claim of the order step from the poison cwd is suppressed by the scope the
+	// order boundary stamped.
+	if patch := e2eClaimPatch(store, step); patch[beadmeta.WorkBranchMetadataKey] != "" {
+		t.Fatalf("order step claim stamped %s=%q over the declared scope",
+			beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey])
+	}
+	if mayStampCwdWorkDir(store, step, nil) {
+		t.Fatal("reconcile would stamp cwd work_dir over the order's declared scope")
+	}
+
+	scopeRoot := cityDir
+	_, declaredBranch, violation := workRecordCloseLocation(store, e2ePoisonFlatKeys(step), scopeRoot, targetscope.Envelope{CityPath: cityDir, StorePath: cityDir})
+	if violation != "" || declaredBranch != "order-branch" {
+		t.Fatalf("order close gate = (%q, %q), want (order-branch, no violation)", declaredBranch, violation)
+	}
+}
+
+// §11 #7 / #8 — Direct graph-v2 `gc formula cook` (which is also the no-convoy
+// standalone graph launch — the shape whose convoy early-return once left the
+// root unscoped). Cook stamps the scope, and the generated stages are not
+// cwd-poisonable: a claim of a cooked stage from a mismatching cwd is suppressed
+// and the close gate reads the cooked branch. This drives the REAL `gc formula
+// cook` end to end against a real store, then chains the readers on the stage it
+// materialized.
+func TestE2ECookedGraphStageIsNotCwdPoisonable(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	cityDir := t.TempDir()
+	formulaDir := writeCookScopeCity(t, cityDir)
+	writeCookFormula(t, formulaDir, "e2e-cook", `
+formula = "e2e-cook"
+version = 2
+contract = "graph.v2"
+
+[vars.base_branch]
+default = "FORMULA-DEFAULT"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+`)
+	formulatest.SetupHermeticCookEnv(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"e2e-cook", "--var", "base_branch=release", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula cook: %v\nstderr=%s", err, stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	all := e2eStoreBeads(t, store)
+	step := e2eWorkStep(t, all)
+	if step.Title != "Work on release" {
+		t.Fatalf("cooked step title = %q, want the substituted release", step.Title)
+	}
+
+	// The generated stage inherits the cooked scope; the cwd writers stand down
+	// and the gate reads the cooked branch, not the parked flat keys.
+	if patch := e2eClaimPatch(store, step); patch[beadmeta.WorkBranchMetadataKey] != "" {
+		t.Fatalf("cooked stage claim stamped %s=%q over the cooked scope",
+			beadmeta.WorkBranchMetadataKey, patch[beadmeta.WorkBranchMetadataKey])
+	}
+	if mayStampCwdWorkDir(store, step, nil) {
+		t.Fatal("reconcile would stamp cwd work_dir over the cooked scope")
+	}
+	_, declaredBranch, violation := workRecordCloseLocation(store, e2ePoisonFlatKeys(step), cityDir, targetscope.Envelope{CityPath: cityDir, StorePath: cityDir})
+	if violation != "" || declaredBranch != "release" {
+		t.Fatalf("cooked-stage close gate = (%q, %q), want (release, no violation)", declaredBranch, violation)
+	}
+}
+
+// SCENARIO MAP (DESIGN §11, 17 scenarios). The cross-cutting claim/reconcile/
+// close-gate chains are the new integration proofs in THIS file; the scenarios
+// whose whole contract is a single reader/boundary property are pinned by the
+// unit/boundary tests cited alongside. Every scenario is covered:
+//
+//	#1  fresh claim ................ TestE2EFreshClaimOfScopedStageHonoursDeclaredScope
+//	#2  existing/adopted claim ..... TestE2EExistingAndAdoptedAssignmentClaimsStillSuppressCwd
+//	#3  repeated claim ............. TestE2ERepeatedClaimFromDifferentCwdDoesNotDrift
+//	#4  reconcile + propagation .... TestE2EWorkDirReconcileAndRootPropagation
+//	#5  symbolic root ref .......... TestE2ESymbolicRootRefStageInheritsScope
+//	#6  attempt 2 (retry) .......... TestE2ERetryAttemptResolvesOriginalRootScope
+//	#7  graph-v2 cook .............. TestE2ECookedGraphStageIsNotCwdPoisonable
+//	                                 (+ formula_cook_scope_test.go, real cook boundary)
+//	#8  no-convoy standalone graph . TestE2ECookedGraphStageIsNotCwdPoisonable
+//	                                 (+ TestFormulaCookStandaloneGraphScopeEqualsSubstitutedBranch)
+//	#9  legacy claimable source .... TestE2ELegacyClaimableSourceCarriesScopeAndResistsCwd
+//	#10 poisoned member vs empty ... TestE2ECarrierlessLaunchStampsUnknownNotAbsent
+//	                                 (+ TestDeclareTreatsPoisonedFlatKeysAsAbsent, TestDeclareUnknownPersistsAsValidNotAbsent)
+//	#11 heterogeneous drain ........ internal/dispatch/drain_target_scope_test.go (3 tests)
+//	#12 poisoned member via gate ... TestE2EPoisonedMemberClosedThroughGateReadsDeclaredScope (HEADLINE)
+//	#13 poison-only / no source .... TestE2ECarrierlessLaunchStampsUnknownNotAbsent
+//	                                 (+ TestNoTrustedSourceYieldsValidUnknown, TestCloseGateUnknownScopeDoesNotFallBackToFlatKeys, TestRalphWorkDirUnknownScopeDoesNotFallBackToFlatKey)
+//	#14 worktree / cross-store:
+//	   (i)   absolute persisted .... TestE2EWorkDirReconcileAndRootPropagation (+ TestWorktreeNormalizedAtBoundary)
+//	   (ii)  cross-store ........... TestE2ECrossStoreWorktreeIsOneAbsolutePathForBothReaders
+//	   (iii) persisted-relative .... TestParseRelativeWorktreeIsInvalidNotReanchored (+ TestCloseGateRefusesFlatFallbackWhenScopeIsCorrupt, TestRalphWorkDirInvalidScopeIsAViolationNotAFallback)
+//	   (iv)  escaping .............. TestE2EEscapingWorktreeFailsClosedAtTheGate
+//	                                 (+ TestCloseGateRefusesFlatFallbackWhenScopeEscapesEnvelope, TestRalphWorkDirEscapingWorktreeFailsClosed)
+//	#15 order + legacy cook attach . TestE2EOrderStepHonoursDeclaredScope
+//	                                 (+ TestFormulaCookLegacyInlineStampsScope, TestFormulaCookAttachGraphV2DeclaresTargetMemberScope)
+//	#16 alias / consumed equality .. TestE2EConsumedCarrierEqualsScopeEndToEnd
+//	                                 (+ resolver_test.go, sling_targetscope_test.go)
+//	#17 declaration race ........... internal/targetscope/declare_test.go
+//	                                 (TestDeclareRaceHasExactlyOneWinner, TestDeclareRaceWithEqualScopesConverges, TestDeclareRejectsStoreWithoutCAS)

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/targetscope"
 )
 
 // Work-record close gate (ADR-0009). Closing a work bead through the SDK close
@@ -66,12 +67,57 @@ func isWorkRecordGatedBead(bead beads.Bead) bool {
 	return true
 }
 
+// workRecordCloseLocation decides WHERE the gate probes git and WHICH branch it
+// probes, giving a declared gc.target_scope authority over the flat gc.work_*
+// keys.
+//
+// This is the direct-read migration (design §7). The flat keys are stamped from
+// the claiming session's cwd, so on a scoped bead they describe wherever the
+// worker happened to be standing — exactly the value the gate must not trust.
+//
+// The three states are deliberately NOT collapsed:
+//
+//   - valid   → the declared branch/worktree win. A field the scope leaves
+//     unknown falls back to the process's own scopeRoot, never to the bead's
+//     flat key: unknown means "not declared", not "use the poison".
+//   - invalid → the scoped read FAILED. Falling back to the flat keys here is
+//     the defect reopening, so this reports a violation instead.
+//   - absent  → legacy behavior, unchanged: flat gc.work_dir then scopeRoot.
+func workRecordCloseLocation(store beads.Store, bead beads.Bead, scopeRoot string, envelope targetscope.Envelope) (repoDir, declaredBranch, violation string) {
+	switch res := targetscope.ResolveForReader(store, bead, envelope); res.State {
+	case targetscope.StateValid:
+		repoDir = res.Scope.Worktree
+		if repoDir == "" {
+			repoDir = scopeRoot
+		}
+		return repoDir, res.Scope.Branch, ""
+	case targetscope.StateInvalid:
+		return "", "", fmt.Sprintf("%s is unusable (%v); refusing to validate against the claim-time %s/%s instead",
+			beadmeta.TargetScopeMetadataKey, res.Reason, beadmeta.WorkDirMetadataKey, beadmeta.WorkBranchMetadataKey)
+	default:
+		repoDir = strings.TrimSpace(bead.Metadata[beadmeta.WorkDirMetadataKey])
+		if repoDir == "" {
+			repoDir = scopeRoot
+		}
+		return repoDir, "", ""
+	}
+}
+
 // validateWorkRecordOnClose checks bead against the typed work-record contract
 // and returns a human-readable message for each violation (empty slice ⇒ the
 // bead satisfies the contract). commitReachable reports whether a commit SHA is
 // an ancestor of a branch; it is injected so the rule is unit-testable without
 // a real repo. The caller is responsible for scoping (isWorkRecordGatedBead).
-func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, branch string) bool) []string {
+//
+// declaredBranch, when non-empty, is the branch a gc.target_scope declared for
+// this bead; it is the branch the commit must be reachable on, in place of the
+// claim-stamped gc.work_branch.
+//
+// gc.work_branch is still REQUIRED on a shipped record even under a declared
+// scope: the scope says where the work was supposed to land, the work record
+// says where it actually did, and dropping the latter would erase the very
+// attribution that makes a divergence visible.
+func validateWorkRecordOnClose(bead beads.Bead, declaredBranch string, commitReachable func(commit, branch string) bool) []string {
 	outcome := strings.TrimSpace(bead.Metadata[beadmeta.WorkOutcomeMetadataKey])
 	if outcome == "" {
 		return []string{fmt.Sprintf("missing %s (want one of shipped|no-op|blocked|abandoned)", beadmeta.WorkOutcomeMetadataKey)}
@@ -93,8 +139,14 @@ func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, bra
 	if branch == "" {
 		violations = append(violations, fmt.Sprintf("%s=shipped requires %s (the branch the commit lives on)", beadmeta.WorkOutcomeMetadataKey, beadmeta.WorkBranchMetadataKey))
 	}
-	if commit != "" && branch != "" && !commitReachable(commit, branch) {
-		violations = append(violations, fmt.Sprintf("%s %s is not reachable on %s %s", beadmeta.WorkCommitMetadataKey, commit, beadmeta.WorkBranchMetadataKey, branch))
+	// The declared scope, when present, is the authority the commit is checked
+	// against — never the claim-stamped branch.
+	probeBranch, probeLabel := branch, beadmeta.WorkBranchMetadataKey
+	if declaredBranch != "" {
+		probeBranch, probeLabel = declaredBranch, "declared "+beadmeta.TargetScopeMetadataKey+" branch"
+	}
+	if commit != "" && probeBranch != "" && !commitReachable(commit, probeBranch) {
+		violations = append(violations, fmt.Sprintf("%s %s is not reachable on %s %s", beadmeta.WorkCommitMetadataKey, commit, probeLabel, probeBranch))
 	}
 	return violations
 }
@@ -171,13 +223,13 @@ func runWorkRecordCloseGate(bdArgs []string, scopeRoot, cityPath string, stderr 
 		// Cannot verify — never block a close on our own read failure.
 		return false
 	}
-	return evaluateWorkRecordCloseGate(bdArgs, store, scopeRoot, workRecordEnforceEnabled(), stderr)
+	return evaluateWorkRecordCloseGate(bdArgs, store, scopeRoot, cityPath, workRecordEnforceEnabled(), stderr)
 }
 
 // evaluateWorkRecordCloseGate is the store-driven core of the close gate, split
 // from the IO wrapper so it is unit-testable with an in-memory store. It logs
 // each violation and reports whether the close should be blocked.
-func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, scopeRoot string, enforce bool, stderr io.Writer) (block bool) {
+func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, scopeRoot, cityPath string, enforce bool, stderr io.Writer) (block bool) {
 	ids, ok := workRecordCloseTargets(bdArgs)
 	if !ok {
 		return false
@@ -186,16 +238,21 @@ func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, scopeRoot s
 	if enforce {
 		mode = "enforced"
 	}
+	envelope := targetscope.Envelope{CityPath: cityPath, StorePath: scopeRoot}
 	for _, id := range ids {
 		bead, getErr := store.Get(id)
 		if getErr != nil || !isWorkRecordGatedBead(bead) {
 			continue
 		}
-		repoDir := strings.TrimSpace(bead.Metadata[beadmeta.WorkDirMetadataKey])
-		if repoDir == "" {
-			repoDir = scopeRoot
+		repoDir, declaredBranch, scopeViolation := workRecordCloseLocation(store, bead, scopeRoot, envelope)
+		if scopeViolation != "" {
+			fmt.Fprintf(stderr, "gc bd: work-record gate (%s): close of %s: %s\n", mode, id, scopeViolation) //nolint:errcheck // best-effort stderr
+			if enforce {
+				block = true
+			}
+			continue
 		}
-		violations := validateWorkRecordOnClose(bead, func(commit, branch string) bool {
+		violations := validateWorkRecordOnClose(bead, declaredBranch, func(commit, branch string) bool {
 			return gitCommitReachableOnBranch(repoDir, commit, branch)
 		})
 		for _, v := range violations {

--- a/cmd/gc/work_record_gate_targetscope_test.go
+++ b/cmd/gc/work_record_gate_targetscope_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// scopedGateBead builds a shipped work bead whose flat gc.work_* keys are
+// POISONED — the shape a pool session parked on a shared checkout produces.
+func scopedGateBead(id, scopeRaw string) beads.Bead {
+	return beads.Bead{
+		ID:   id,
+		Type: "task",
+		Metadata: beads.StringMap{
+			beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped,
+			beadmeta.WorkCommitMetadataKey:  "cafef00d",
+			beadmeta.WorkBranchMetadataKey:  "parked-shared-branch",
+			beadmeta.WorkDirMetadataKey:     "/shared/parked/root",
+			beadmeta.TargetScopeMetadataKey: scopeRaw,
+		},
+	}
+}
+
+func gateEnvelope(t *testing.T) (cityPath string, envelope targetscope.Envelope) {
+	t.Helper()
+	cityPath = t.TempDir()
+	return cityPath, targetscope.Envelope{CityPath: cityPath, StorePath: cityPath}
+}
+
+// §11 #12 — the gate's git probe must receive the DECLARED branch and worktree,
+// never the claim-stamped poison.
+func TestCloseGateProbesDeclaredScopeNotPoisonedFlatKeys(t *testing.T) {
+	cityPath, envelope := gateEnvelope(t)
+	declaredWorktree := filepath.Join(cityPath, "worktrees", "T")
+
+	scope, err := targetscope.Marshal(targetscope.Scope{V: 1, Branch: "release", Worktree: declaredWorktree})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	bead := scopedGateBead("wr-scoped", scope)
+	store := beads.NewMemStoreFrom(1, []beads.Bead{bead}, nil)
+
+	repoDir, declaredBranch, violation := workRecordCloseLocation(store, bead, cityPath, envelope)
+
+	if violation != "" {
+		t.Fatalf("unexpected scope violation: %s", violation)
+	}
+	if declaredBranch != "release" {
+		t.Fatalf("declaredBranch = %q, want release (not the parked flat value)", declaredBranch)
+	}
+	if repoDir != declaredWorktree {
+		t.Fatalf("repoDir = %q, want the declared worktree %q (not the shared parked root)", repoDir, declaredWorktree)
+	}
+}
+
+// The probe the validator actually calls must carry the declared branch, and
+// the violation message must name it — otherwise an operator reading the gate
+// output would go looking on the wrong branch.
+func TestCloseGateValidatesCommitAgainstDeclaredBranch(t *testing.T) {
+	var probedBranch string
+	violations := validateWorkRecordOnClose(
+		scopedGateBead("wr-scoped", ""),
+		"release",
+		func(_, branch string) bool {
+			probedBranch = branch
+			return false
+		},
+	)
+
+	if probedBranch != "release" {
+		t.Fatalf("probed branch = %q, want the declared release", probedBranch)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("violations = %v, want exactly the unreachable-commit violation", violations)
+	}
+	if got := violations[0]; !strings.Contains(got, beadmeta.TargetScopeMetadataKey) || !strings.Contains(got, "release") {
+		t.Fatalf("violation %q should name the declared scope branch it probed", got)
+	}
+}
+
+// §11 #14(iv) — an ESCAPING worktree makes the scoped read fail. The gate must
+// report a violation, NOT silently fall back to the flat keys: falling back is
+// the defect reopening.
+func TestCloseGateRefusesFlatFallbackWhenScopeEscapesEnvelope(t *testing.T) {
+	cityPath, envelope := gateEnvelope(t)
+
+	scope, err := targetscope.Marshal(targetscope.Scope{V: 1, Branch: "release", Worktree: "/etc"})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	bead := scopedGateBead("wr-escape", scope)
+	store := beads.NewMemStoreFrom(1, []beads.Bead{bead}, nil)
+
+	repoDir, declaredBranch, violation := workRecordCloseLocation(store, bead, cityPath, envelope)
+
+	if violation == "" {
+		t.Fatal("an escaping worktree must be a violation, not a silent flat-key fallback")
+	}
+	if repoDir == "/shared/parked/root" || declaredBranch == "parked-shared-branch" {
+		t.Fatalf("gate fell back to the poisoned flat keys: repoDir=%q branch=%q", repoDir, declaredBranch)
+	}
+}
+
+// A corrupt scope object is likewise a failed scoped read, never permission to
+// use the claim-time values.
+func TestCloseGateRefusesFlatFallbackWhenScopeIsCorrupt(t *testing.T) {
+	cityPath, envelope := gateEnvelope(t)
+	bead := scopedGateBead("wr-corrupt", "{not json")
+	store := beads.NewMemStoreFrom(1, []beads.Bead{bead}, nil)
+
+	_, _, violation := workRecordCloseLocation(store, bead, cityPath, envelope)
+
+	if violation == "" {
+		t.Fatal("a corrupt gc.target_scope must be a violation, not a silent flat-key fallback")
+	}
+}
+
+// §13(b) — a valid but field-empty scope means "declared unknown". The gate must
+// still not reach for the flat keys; the process's own scopeRoot is the fallback.
+func TestCloseGateUnknownScopeDoesNotFallBackToFlatKeys(t *testing.T) {
+	cityPath, envelope := gateEnvelope(t)
+
+	scope, err := targetscope.Marshal(targetscope.Unknown())
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	bead := scopedGateBead("wr-unknown", scope)
+	store := beads.NewMemStoreFrom(1, []beads.Bead{bead}, nil)
+
+	repoDir, declaredBranch, violation := workRecordCloseLocation(store, bead, cityPath, envelope)
+
+	if violation != "" {
+		t.Fatalf("unknown is a legitimate declared value, not a violation: %s", violation)
+	}
+	if repoDir != cityPath {
+		t.Fatalf("repoDir = %q, want the scopeRoot %q — never the poisoned flat work_dir", repoDir, cityPath)
+	}
+	if declaredBranch != "" {
+		t.Fatalf("declaredBranch = %q, want empty for an unknown scope", declaredBranch)
+	}
+}
+
+// Legacy behavior is preserved exactly: with no scope anywhere, the gate reads
+// the flat keys as it always did.
+func TestCloseGateAbsentScopeKeepsLegacyFlatRead(t *testing.T) {
+	cityPath, envelope := gateEnvelope(t)
+	bead := scopedGateBead("wr-legacy", "")
+	store := beads.NewMemStoreFrom(1, []beads.Bead{bead}, nil)
+
+	repoDir, declaredBranch, violation := workRecordCloseLocation(store, bead, cityPath, envelope)
+
+	if violation != "" {
+		t.Fatalf("absent scope must not be a violation: %s", violation)
+	}
+	if repoDir != "/shared/parked/root" {
+		t.Fatalf("repoDir = %q, want the flat gc.work_dir (legacy path unchanged)", repoDir)
+	}
+	if declaredBranch != "" {
+		t.Fatalf("declaredBranch = %q, want empty so the validator uses the flat branch", declaredBranch)
+	}
+}
+
+// §11 #5 — a formula stage carries only gc.root_bead_id. The scope governing it
+// lives on the root, so the gate must reach it through the inherited walk.
+func TestCloseGateResolvesScopeInheritedFromRoot(t *testing.T) {
+	cityPath, envelope := gateEnvelope(t)
+
+	scope, err := targetscope.Marshal(targetscope.Scope{V: 1, Branch: "release"})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	root := beads.Bead{ID: "root-1", Type: "task", Metadata: beads.StringMap{
+		beadmeta.TargetScopeMetadataKey: scope,
+	}}
+	stage := scopedGateBead("wr-stage", "")
+	stage.Metadata[beadmeta.RootBeadIDMetadataKey] = "root-1"
+	store := beads.NewMemStoreFrom(1, []beads.Bead{root, stage}, nil)
+
+	_, declaredBranch, violation := workRecordCloseLocation(store, stage, cityPath, envelope)
+
+	if violation != "" {
+		t.Fatalf("unexpected violation: %s", violation)
+	}
+	if declaredBranch != "release" {
+		t.Fatalf("declaredBranch = %q, want release inherited from the root", declaredBranch)
+	}
+}

--- a/cmd/gc/work_record_gate_test.go
+++ b/cmd/gc/work_record_gate_test.go
@@ -86,7 +86,7 @@ func TestValidateWorkRecordOnClose(t *testing.T) {
 				reachable = neverReachable
 			}
 			bead := beads.Bead{ID: "wr-1", Type: "task", Metadata: tc.meta}
-			got := validateWorkRecordOnClose(bead, reachable)
+			got := validateWorkRecordOnClose(bead, "", reachable)
 			if tc.wantViol == "" {
 				if len(got) != 0 {
 					t.Fatalf("expected no violations, got %v", got)
@@ -210,7 +210,7 @@ func TestEvaluateWorkRecordCloseGate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var stderr strings.Builder
-			block := evaluateWorkRecordCloseGate(tc.args, newStore(), t.TempDir(), tc.enforce, &stderr)
+			block := evaluateWorkRecordCloseGate(tc.args, newStore(), t.TempDir(), "", tc.enforce, &stderr)
 			if block != tc.wantBlock {
 				t.Fatalf("block = %v, want %v; stderr=%s", block, tc.wantBlock, stderr.String())
 			}

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -188,6 +188,7 @@ const (
 	StepTimeoutMetadataKey         = "gc.step_timeout"
 	SyntheticKindMetadataKey       = "gc.synthetic_kind"
 	SyntheticMetadataKey           = "gc.synthetic"
+	TargetScopeMetadataKey         = "gc.target_scope"
 	TemplateMetadataKey            = "gc.template"
 	TerminalMetadataKey            = "gc.terminal"
 	TriggerBeadIDMetadataKey       = "gc.trigger_bead_id"
@@ -222,6 +223,22 @@ const (
 //
 // The set of valid WorkOutcomeMetadataKey values and the "shipped requires a
 // commit on the branch" rule live with the close gate in cmd/gc.
+
+// TargetScopeMetadataKey ("gc.target_scope") is the DECLARED counterpart to the
+// gc.work_* family above, and the distinction is the whole point of the key.
+//
+// gc.work_branch and gc.work_dir are OBSERVATIONS: they record where a claiming
+// session happened to be standing. gc.target_scope is INTENT: it records where
+// the work was declared to belong, is written at instantiation from trusted
+// sources only, and is immutable once declared. Keeping the two in one field is
+// what let a parked shared checkout overwrite a declared location — an
+// observation silently outranking an instruction.
+//
+// The value is a JSON object {"v":1,"branch":...,"worktree":...} owned by
+// internal/targetscope; nothing outside that package should parse it by hand.
+// Its absence is meaningful (it re-enables legacy cwd behavior), so writers must
+// stamp a valid field-empty {"v":1} rather than omit the key when no field is
+// known. See internal/targetscope for the full tri-state contract.
 
 // FormulaVarPrefix is the dynamic key prefix under which formula-supplied
 // variables are written as gc.var.<name>. The suffix is open-world (a
@@ -425,6 +442,7 @@ var KnownMetadataKeys = []string{
 	StepTimeoutMetadataKey,
 	SyntheticKindMetadataKey,
 	SyntheticMetadataKey,
+	TargetScopeMetadataKey,
 	TemplateMetadataKey,
 	TerminalMetadataKey,
 	TriggerBeadIDMetadataKey,

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -841,6 +841,17 @@ func isBdNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
+	// An execution-launch failure — the `bd` binary missing from PATH or not
+	// executable — is a TRANSPORT failure, never a bead-not-found, even though
+	// its message literally contains "not found" ("executable file not found in
+	// $PATH"). Classifying it as not-found would let a caller that reads
+	// not-found as "absent" (e.g. the target-scope inherited-scope walk) fail
+	// OPEN against a store it could not actually reach. exec.ErrNotFound stays in
+	// the error chain (classifyBDExecResult wraps with %w), so this exclusion is
+	// exact and never swallows a genuine bd not-found.
+	if errors.Is(err, exec.ErrNotFound) {
+		return false
+	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "not found") ||
 		strings.Contains(msg, "no issue found") ||

--- a/internal/beads/bdstore_notfound_guard_internal_test.go
+++ b/internal/beads/bdstore_notfound_guard_internal_test.go
@@ -1,0 +1,34 @@
+package beads
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+// An execution-launch failure — the `bd` binary missing from PATH — must NOT be
+// classified as a bead-not-found, even though exec.ErrNotFound's message literally
+// contains "not found". Otherwise a caller that reads not-found as "absent" (the
+// target-scope inherited-scope walk) fails OPEN against a store it could not reach.
+func TestIsBdNotFoundExcludesExecLaunchFailure(t *testing.T) {
+	// The shape classifyBDExecResult produces: exec.ErrNotFound preserved via %w.
+	if isBdNotFound(fmt.Errorf("getting bead %q: %w", "gc-x", exec.ErrNotFound)) {
+		t.Fatal("wrapped exec-launch failure classified as bd not-found; the inherited walk would fail open")
+	}
+	// A bare *exec.Error (Unwrap → exec.ErrNotFound) is likewise excluded.
+	if isBdNotFound(&exec.Error{Name: "bd", Err: exec.ErrNotFound}) {
+		t.Fatal("*exec.Error classified as bd not-found")
+	}
+	// Genuine bd not-found signals are still detected (the exclusion must not
+	// swallow a real not-found).
+	for _, msg := range []string{
+		"getting bead \"x\": no issues found matching the provided IDs",
+		"issue not found",
+		"no issue found",
+	} {
+		if !isBdNotFound(errors.New(msg)) {
+			t.Errorf("genuine bd not-found %q no longer detected", msg)
+		}
+	}
+}

--- a/internal/beads/beadstest/metadata_cas_conformance.go
+++ b/internal/beads/beadstest/metadata_cas_conformance.go
@@ -1,0 +1,244 @@
+package beadstest
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// MetadataCASOptions controls legs of the narrow CAS suite that not every
+// TEST FIXTURE can evaluate. Note the distinction from
+// ConditionalWriterOptions, whose legs turn on what a STORE can express: the
+// contention leg here is a claim about the backend's isolation, so a fixture
+// that models a backend without modelling its isolation cannot judge it.
+type MetadataCASOptions struct {
+	// FixtureLacksIsolationReason, when non-empty, declares that this
+	// factory's store cannot evaluate the contention leg because the fixture
+	// behind it provides no isolation between concurrent transactions, and
+	// records why. The leg is then reported as an explicit, named absence
+	// rather than silently dropped — an unevaluatable gate must be visible in
+	// the test output, not missing from it.
+	//
+	// Set this ONLY for a fixture whose non-isolation is a property of the
+	// test double, never to quiet a store that genuinely admits two winners:
+	// a store that loses the contention leg cannot carry a lease, which is
+	// the whole reason callers want this capability. A fixture that opts out
+	// here owes the contention property an integration-level test against the
+	// real backend.
+	FixtureLacksIsolationReason string
+}
+
+// RunMetadataCASConformance runs the store-agnostic beads.MetadataCASWriter
+// contract suite against a capable store, with every leg enabled.
+func RunMetadataCASConformance(t *testing.T, name string, open func(t *testing.T) beads.Store) {
+	RunMetadataCASConformanceWithOptions(t, name, open, MetadataCASOptions{})
+}
+
+// RunMetadataCASConformanceWithOptions is RunMetadataCASConformance with the
+// fixture-dependent contention leg configurable. open must return a fresh,
+// empty store that implements beads.MetadataCASWriter (verified via
+// beads.MetadataCASWriterFor); name prefixes every subtest so multiple stores
+// can run in one package.
+//
+// The subtests mirror the metadata-CAS legs of
+// RunConditionalWriterConformance one-to-one, so a store that can only offer
+// the narrow capability is held to exactly the same value-CAS contract as a
+// full ConditionalWriter — the two suites can be diffed against each other.
+// The revision legs are deliberately absent rather than skipped: a narrow
+// store makes no revision claim at all, so there is nothing to assert (see
+// the MetadataCASWriter doc comment for why no sound revision token exists at
+// beads v1.1.0).
+//
+// Both contract traps that the in-tree implementations historically diverged
+// on ride this suite: empty-expected matching absent OR present-and-empty,
+// and a lost race reporting (false, nil) rather than an error.
+func RunMetadataCASConformanceWithOptions(t *testing.T, name string, open func(t *testing.T) beads.Store, opts MetadataCASOptions) {
+	t.Helper()
+
+	// writerFor resolves the narrow writer or fails loudly: the suite is only
+	// meaningful against a capable store.
+	writerFor := func(t *testing.T, s beads.Store) beads.MetadataCASWriter {
+		t.Helper()
+		w, ok := beads.MetadataCASWriterFor(s)
+		if !ok {
+			t.Fatalf("store does not implement beads.MetadataCASWriter; "+
+				"RunMetadataCASConformance requires a capable store (%T)", s)
+		}
+		return w
+	}
+
+	t.Run(name+"/cas_empty_expected_claims_absent_or_empty_only", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-empty"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+
+		// Absent key: expected "" claims it.
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "", "one"); err != nil || !ok {
+			t.Fatalf("claim absent key: (%v, %v), want (true, nil)", ok, err)
+		}
+		// Empty-valued key: expected "" also claims it (the two states are
+		// indistinguishable to callers).
+		if err := s.SetMetadata(id, "k", ""); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "", "two"); err != nil || !ok {
+			t.Fatalf("claim empty-valued key: (%v, %v), want (true, nil)", ok, err)
+		}
+		// Non-empty key: expected "" must NOT claim it.
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "", "three"); err != nil || ok {
+			t.Fatalf("claim non-empty key with empty expected: (%v, %v), want (false, nil)", ok, err)
+		}
+		if got, _ := s.Get(id); got.Metadata["k"] != "two" {
+			t.Fatalf("value after rejected empty-expected CAS = %q, want %q", got.Metadata["k"], "two")
+		}
+	})
+
+	t.Run(name+"/cas_value_mismatch_is_false_nil_not_error", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-mismatch"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "k", "A"); err != nil {
+			t.Fatal(err)
+		}
+		ok, err := w.CompareAndSetMetadataKey(id, "k", "B", "C")
+		if err != nil {
+			t.Fatalf("value-mismatch CAS returned error: %v (want nil)", err)
+		}
+		if ok {
+			t.Fatal("value-mismatch CAS returned true (want false)")
+		}
+		if got, _ := s.Get(id); got.Metadata["k"] != "A" {
+			t.Fatalf("value mutated on a lost CAS: %q, want %q", got.Metadata["k"], "A")
+		}
+	})
+
+	t.Run(name+"/cas_winner_value_visible_to_loser_reread", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-visible"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "k", "start"); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "start", "winner"); err != nil || !ok {
+			t.Fatalf("winner CAS: (%v, %v), want (true, nil)", ok, err)
+		}
+		// A loser re-reads and must observe the winner's value.
+		if got, _ := s.Get(id); got.Metadata["k"] != "winner" {
+			t.Fatalf("loser re-read = %q, want %q (winner value not visible)", got.Metadata["k"], "winner")
+		}
+		// And a CAS from the old value now loses cleanly.
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "start", "late"); err != nil || ok {
+			t.Fatalf("stale-value CAS after a swap: (%v, %v), want (false, nil)", ok, err)
+		}
+	})
+
+	t.Run(name+"/cas_does_not_disturb_sibling_keys", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-siblings"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "sibling", "preserved"); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SetMetadata(id, "k", "A"); err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := w.CompareAndSetMetadataKey(id, "k", "A", "B"); err != nil || !ok {
+			t.Fatalf("CAS: (%v, %v), want (true, nil)", ok, err)
+		}
+		got, err := s.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Metadata["sibling"] != "preserved" {
+			t.Fatalf("sibling metadata = %q, want %q (read-modify-write dropped it)", got.Metadata["sibling"], "preserved")
+		}
+		if got.Metadata["k"] != "B" {
+			t.Fatalf("target metadata = %q, want %q", got.Metadata["k"], "B")
+		}
+	})
+
+	// The exclusion property the lease/claim callers actually depend on:
+	// under concurrency exactly ONE racer may win a claim from a single
+	// starting value. A store that reports two winners has no mutual
+	// exclusion and cannot carry a lease, however well it passes the
+	// sequential legs above.
+	t.Run(name+"/cas_contention_admits_exactly_one_winner", func(t *testing.T) {
+		if reason := opts.FixtureLacksIsolationReason; reason != "" {
+			// Named, visible absence: the store is not being excused, the
+			// FIXTURE cannot evaluate the claim. The property is owed an
+			// integration test against the real backend.
+			t.Skipf("fixture cannot evaluate contention: %s", reason)
+		}
+		s := open(t)
+		w := writerFor(t, s)
+		b, err := s.Create(beads.Bead{Title: "cas-contention"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
+		if err := s.SetMetadata(id, "lease", ""); err != nil {
+			t.Fatal(err)
+		}
+
+		const racers = 8
+		var (
+			wg      sync.WaitGroup
+			mu      sync.Mutex
+			winners []string
+			errs    []error
+		)
+		start := make(chan struct{})
+		for i := range racers {
+			wg.Add(1)
+			go func(racer int) {
+				defer wg.Done()
+				holder := "holder-" + strconv.Itoa(racer)
+				<-start
+				ok, err := w.CompareAndSetMetadataKey(id, "lease", "", holder)
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					errs = append(errs, err)
+					return
+				}
+				if ok {
+					winners = append(winners, holder)
+				}
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		for _, err := range errs {
+			t.Fatalf("racer returned an error (a lost race must be (false, nil)): %v", err)
+		}
+		if len(winners) != 1 {
+			t.Fatalf("winners = %d %v, want exactly 1 (no mutual exclusion)", len(winners), winners)
+		}
+		got, err := s.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Metadata["lease"] != winners[0] {
+			t.Fatalf("stored lease = %q, want the sole winner %q", got.Metadata["lease"], winners[0])
+		}
+	})
+}

--- a/internal/beads/caching_store_conditional.go
+++ b/internal/beads/caching_store_conditional.go
@@ -202,7 +202,14 @@ func (c *CachingStore) DeleteIfMatch(id string, expectedRevision int64) error {
 // `expected`, and without the evict a cross-process loser re-reads the same
 // stale value through the cache and re-loses until an unrelated reconcile.
 func (c *CachingStore) CompareAndSetMetadataKey(id, key, expected, next string) (bool, error) {
-	writer, ok := ConditionalWriterFor(c.conditionalBacking())
+	// Resolve the NARROW capability, not ConditionalWriter: a backing that can
+	// do value-CAS but cannot soundly fence on a revision (NativeDoltStore)
+	// declares MetadataCASWriter only, and every ConditionalWriter satisfies
+	// MetadataCASWriter anyway, so this widens the backings that forward
+	// without changing behaviour for fully capable ones. The trio above keeps
+	// resolving through ConditionalWriterFor — a narrow backing must not
+	// unlock a revision fence it cannot honour.
+	writer, ok := MetadataCASWriterFor(c.conditionalBacking())
 	if !ok {
 		return false, ErrConditionalWriteUnsupported
 	}

--- a/internal/beads/metadata_cas.go
+++ b/internal/beads/metadata_cas.go
@@ -1,0 +1,97 @@
+// The narrow metadata value-CAS capability seam.
+//
+// ConditionalWriter (beads.go) bundles four methods: the revision-CAS trio
+// (UpdateIfMatch/CloseIfMatch/DeleteIfMatch) plus CompareAndSetMetadataKey.
+// The trio needs a backend fence token — a revision that advances on every
+// mutation and is never reused. The beads v1.1.0 schema cannot supply one:
+// types.Issue carries no revision field (Get().Revision is 0 and never
+// advances), the issues DDL has no version column, and updated_at is
+// second-granularity — so two same-second writes yield an EQUAL token and a
+// stale fence SILENTLY SUCCEEDS, which is the lost update a fence exists to
+// prevent. Label mutations never touch updated_at at all. A store-maintained
+// counter is not a fence either: the Dolt database is multi-writer (the bd
+// CLI, other gascity processes, graph-apply), and a counter only the fencer
+// maintains fences nothing.
+//
+// CompareAndSetMetadataKey needs no such token — it guards on the key's own
+// current value — so it is soundly implementable today on stores where the
+// trio is not. MetadataCASWriter is that half, split out so a store can
+// declare the capability it actually has. Declaring the whole of
+// ConditionalWriter just to expose the CAS method would make
+// ResolveConditionalWriter RESOLVE under require mode and hand the trio's
+// callers a silently-wrong fence — converting today's loud typed refusal into
+// exactly the silent legacy write under require that the seam exists to make
+// inexpressible. See the condWritesStamp comment in native_dolt_store.go.
+//
+// Upstream beads #4697 (claim_fence) is the missing backend primitive. When it
+// lands, a store can implement the trio soundly and declare ConditionalWriter;
+// until then a narrow-only store declares MetadataCASWriter and nothing more.
+//
+// Resolution is deliberately SEPARATE from ResolveConditionalWriter: this is a
+// capability lookup, not the operator-policy seam. It carries no
+// conditional_writes mode, because its consumers (target_scope member
+// declaration, the D3/D5 lease/claim_generation lane) have no legacy
+// unconditional path to fall back to — the CAS is their only correct
+// implementation, so gating it on a rollout flag would leave them with nothing
+// under the default off. Nothing here can raise enforcement on the trio: a
+// narrow writer never satisfies ConditionalWriter, so the trio's callers stay
+// exactly as refused as they are today.
+
+package beads
+
+// MetadataCASWriter is the metadata value-CAS half of ConditionalWriter,
+// declared on its own so stores that cannot soundly fence on a revision can
+// still offer a sound single-key compare-and-set.
+//
+// The contract is identical to ConditionalWriter.CompareAndSetMetadataKey and
+// is verified by the same assertions (beadstest.RunMetadataCASConformance):
+// expected == "" matches a key that is absent OR present with the empty value
+// (the two states are indistinguishable to callers; release paths write "" to
+// clear). Returns (true, nil) on swap, (false, nil) on a genuine value
+// mismatch — a lost race is NOT an error — and (false, err) for everything
+// else. A store whose conditional writes are disabled at the instance level
+// reports ErrConditionalWriteUnsupported from the call, matching how the trio
+// behaves on those stores.
+//
+// Every ConditionalWriter satisfies MetadataCASWriter structurally, so a fully
+// capable store serves narrow callers unchanged. The converse cannot hold: Go
+// interface satisfaction needs all four methods, which is precisely the
+// property that keeps a narrow store out of ConditionalWriter resolution.
+type MetadataCASWriter interface {
+	CompareAndSetMetadataKey(id, key, expected, next string) (bool, error)
+}
+
+// MetadataCASWriterHandleProvider exposes a metadata-CAS handle for stores
+// whose capability depends on wrapped runtime state. It mirrors
+// ConditionalWriterHandleProvider: a wrapper can delegate the capability
+// without claiming the interface globally.
+type MetadataCASWriterHandleProvider interface {
+	MetadataCASWriterHandle() (MetadataCASWriter, bool)
+}
+
+// MetadataCASWriterFor returns the metadata value-CAS capability for store
+// when one is available.
+//
+// It follows wrapper-declared resolution targets (ConditionalWritesResolveTargeter)
+// for the same reason ResolveConditionalWriter does: interface-embedding
+// wrappers — the cmd/gc policy store, the typed class wrappers in
+// class_store.go — do not promote optional capabilities, so a direct assertion
+// through them fails and the capability would look absent. As with
+// ConditionalWriterFor, this does NOT guess at unwrapping: a wrapper
+// participates only by declaring its target.
+//
+// This is a pure capability lookup and applies no operator policy — see the
+// file comment for why the narrow CAS is not mode-gated.
+func MetadataCASWriterFor(store Store) (MetadataCASWriter, bool) {
+	if store == nil {
+		return nil, false
+	}
+	store = followConditionalWritesResolveTarget(store)
+	if writer, ok := store.(MetadataCASWriter); ok {
+		return writer, true
+	}
+	if provider, ok := store.(MetadataCASWriterHandleProvider); ok {
+		return provider.MetadataCASWriterHandle()
+	}
+	return nil, false
+}

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -285,9 +285,30 @@ type NativeDoltStore struct {
 	readRetryBudgetOverride time.Duration
 
 	// condWritesStamp carries the factory-stamped conditional-writes mode.
-	// NativeDoltStore implements no ConditionalWriter yet, so the stamp's
-	// effect today is require→typed refusal / auto→loud degrade at the
-	// seam, never a silent legacy write under require.
+	// NativeDoltStore implements the NARROW metadata value-CAS
+	// (MetadataCASWriter, see native_dolt_store_conditional.go) but NOT
+	// ConditionalWriter, so the stamp's effect at the seam is unchanged:
+	// require→typed refusal / auto→loud degrade, never a silent legacy write
+	// under require.
+	//
+	// The gap is the revision-CAS trio, and it is a BACKEND gap, not an
+	// unwritten method. UpdateIfMatch/CloseIfMatch/DeleteIfMatch need a fence
+	// token that advances on every mutation and is never reused; beads v1.1.0
+	// has none. types.Issue carries no revision, the issues DDL has no version
+	// column, updated_at is second-granularity — so two same-second writes
+	// compare EQUAL and a stale fence silently succeeds, which is the lost
+	// update the fence exists to prevent — and label mutations never touch
+	// updated_at at all. A counter this store maintained itself would fence
+	// nothing, because the Dolt database is multi-writer (bd CLI, other
+	// gascity processes, graph-apply). Upstream beads #4697 (claim_fence) is
+	// the missing primitive; when it lands the trio becomes implementable and
+	// this store can declare ConditionalWriter.
+	//
+	// Declaring ConditionalWriter early to expose the CAS method would make
+	// ResolveConditionalWriter resolve under require and hand the trio's
+	// callers a wrong fence — the precise silent-write failure this refusal
+	// currently makes impossible. internal/beads/metadata_cas.go carries the
+	// full reasoning and the narrow interface's own resolution path.
 	condWritesStamp
 }
 

--- a/internal/beads/native_dolt_store_conditional.go
+++ b/internal/beads/native_dolt_store_conditional.go
@@ -1,0 +1,84 @@
+package beads
+
+import (
+	"context"
+	"fmt"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// NativeDoltStore offers the narrow metadata value-CAS and deliberately NOT
+// the full ConditionalWriter. The revision-CAS trio needs a backend fence
+// token that beads v1.1.0 cannot supply, and declaring the interface to get
+// this one method would make ResolveConditionalWriter resolve under require
+// mode — converting a loud typed refusal into a silent wrong-fenced write.
+// internal/beads/metadata_cas.go carries the full reasoning.
+var _ MetadataCASWriter = (*NativeDoltStore)(nil)
+
+// CompareAndSetMetadataKey atomically sets metadata[key] = next when the key's
+// current value equals expected.
+//
+// expected == "" matches a key that is ABSENT or present with the empty value:
+// parsing an absent key out of the stored metadata map yields "", so the two
+// states are indistinguishable here exactly as they are to callers (release
+// paths write "" to clear). Returns (true, nil) on swap, (false, nil) on a
+// genuine value mismatch — a lost race is NOT an error — and (false, err) for
+// a missing bead, a malformed metadata blob, or a transport failure.
+//
+// Atomicity is the read-check-write inside one native Dolt transaction, the
+// same shape ReleaseIfCurrent uses for its assignee guard. The whole
+// read-compare-write runs inside the callback, so the compare and the write
+// commit together or not at all: the upstream storage layer exposes no
+// conditional-UPDATE ... WHERE primitive and no raw-SQL escape hatch, making
+// the transaction the only composition point available.
+//
+// Sibling keys are preserved: the metadata column is a single blob, so the
+// write re-serializes the map read inside this transaction rather than
+// patching one field.
+func (s *NativeDoltStore) CompareAndSetMetadataKey(id, key, expected, next string) (bool, error) {
+	storage, release, err := s.acquireStorage()
+	if err != nil {
+		return false, err
+	}
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+
+	swapped := false
+	commitMsg := fmt.Sprintf("gc: compare-and-set metadata %s on bead %s", key, id)
+	err = storage.RunInTransaction(ctx, commitMsg, func(tx beadslib.Transaction) error {
+		issue, err := tx.GetIssue(ctx, id)
+		if err != nil {
+			return nativeStoreError(id, err)
+		}
+		if issue == nil {
+			return fmt.Errorf("compare-and-set metadata on %q: %w", id, ErrNotFound)
+		}
+		metadata, err := metadataMapFromNative(issue.Metadata)
+		if err != nil {
+			return fmt.Errorf("parsing metadata for bead %q: %w", id, err)
+		}
+		if metadata[key] != expected {
+			// A genuine lost race. Returning nil commits an empty transaction
+			// and leaves swapped false, which the caller reads as (false, nil).
+			return nil
+		}
+		if metadata == nil {
+			metadata = make(map[string]string, 1)
+		}
+		metadata[key] = next
+		raw, err := metadataRawFromMap(metadata)
+		if err != nil {
+			return err
+		}
+		if err := tx.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor); err != nil {
+			return nativeStoreError(id, err)
+		}
+		swapped = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return swapped, nil
+}

--- a/internal/beads/native_dolt_store_metadata_cas_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_integration_test.go
@@ -1,0 +1,254 @@
+//go:build integration
+
+package beads
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// openRealNativeDoltStoreForCAS opens a NativeDoltStore over REAL upstream
+// native storage. The narrow CAS contract is a claim about the backend's
+// transaction semantics, and the in-memory fixture used by the unit-level
+// conformance cannot answer it: nativeDoltMemStorage.RunInTransaction
+// snapshots for rollback and then runs the callback UNLOCKED, so it models
+// atomicity but provides no isolation whatsoever.
+func openRealNativeDoltStoreForCAS(t *testing.T, actor string) *NativeDoltStore {
+	t.Helper()
+	ctx := context.Background()
+	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))
+	if err != nil {
+		t.Skipf("upstream native beads storage unavailable: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Errorf("close upstream storage: %v", err)
+		}
+	})
+	if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	return newNativeDoltStoreWithStorageAndPrefix(storage, actor, "gc")
+}
+
+// TestNativeDoltStoreMetadataCASSequentialAgainstRealDolt exercises the
+// sequential value-CAS contract — both pinned traps — against real storage.
+func TestNativeDoltStoreMetadataCASSequentialAgainstRealDolt(t *testing.T) {
+	store := openRealNativeDoltStoreForCAS(t, "cas-sequential")
+
+	b, err := store.Create(Bead{Title: "real-dolt-cas"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := b.ID
+
+	// Trap 1: expected "" claims an ABSENT key.
+	if ok, err := store.CompareAndSetMetadataKey(id, "k", "", "one"); err != nil || !ok {
+		t.Fatalf("claim absent key: (%v, %v), want (true, nil)", ok, err)
+	}
+	// ...and also a PRESENT-AND-EMPTY key.
+	if err := store.SetMetadata(id, "k", ""); err != nil {
+		t.Fatalf("SetMetadata clear: %v", err)
+	}
+	if ok, err := store.CompareAndSetMetadataKey(id, "k", "", "two"); err != nil || !ok {
+		t.Fatalf("claim empty-valued key: (%v, %v), want (true, nil)", ok, err)
+	}
+	// ...but never a non-empty one.
+	if ok, err := store.CompareAndSetMetadataKey(id, "k", "", "three"); err != nil || ok {
+		t.Fatalf("claim non-empty key with empty expected: (%v, %v), want (false, nil)", ok, err)
+	}
+
+	// Trap 2: a genuine mismatch is (false, nil), never an error.
+	ok, err := store.CompareAndSetMetadataKey(id, "k", "WRONG", "four")
+	if err != nil {
+		t.Fatalf("value-mismatch CAS returned error: %v (want nil)", err)
+	}
+	if ok {
+		t.Fatal("value-mismatch CAS returned true (want false)")
+	}
+
+	got, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["k"] != "two" {
+		t.Fatalf("value = %q, want %q", got.Metadata["k"], "two")
+	}
+}
+
+// TestNativeDoltStoreMetadataCASContentionAgainstRealDolt is the load-bearing
+// test for the lease lane: under concurrency exactly ONE racer may win a claim
+// from a single starting value. This is the property the in-memory fixture
+// cannot evaluate, and the property D3/D5 leases and target_scope member
+// declaration actually depend on — a CAS that admits two winners hands the
+// same lease to two holders.
+func TestNativeDoltStoreMetadataCASContentionAgainstRealDolt(t *testing.T) {
+	store := openRealNativeDoltStoreForCAS(t, "cas-contention")
+
+	b, err := store.Create(Bead{Title: "real-dolt-cas-contention"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := b.ID
+	if err := store.SetMetadata(id, "lease", ""); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	const racers = 8
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		winners []string
+		errs    []error
+	)
+	start := make(chan struct{})
+	for i := range racers {
+		wg.Add(1)
+		go func(racer int) {
+			defer wg.Done()
+			holder := "holder-" + strconv.Itoa(racer)
+			<-start
+			ok, err := store.CompareAndSetMetadataKey(id, "lease", "", holder)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+				return
+			}
+			if ok {
+				winners = append(winners, holder)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for _, err := range errs {
+		t.Errorf("racer returned an error (a lost race must be (false, nil)): %v", err)
+	}
+	if len(winners) != 1 {
+		t.Fatalf("winners = %d %v, want exactly 1 — no mutual exclusion, so this CAS cannot carry a lease",
+			len(winners), winners)
+	}
+
+	got, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["lease"] != winners[0] {
+		t.Fatalf("stored lease = %q, want the sole winner %q", got.Metadata["lease"], winners[0])
+	}
+}
+
+// TestNativeDoltStoreMetadataCASContentionAcrossIndependentHandles is the
+// multi-writer leg, and it is the one that actually decides whether this CAS
+// can carry a lease.
+//
+// The single-handle contention test above cannot distinguish a fence enforced
+// by the DATABASE from exclusion accidentally provided by shared in-process
+// state (a connection pool, a handle-level lock). The gascity Dolt database is
+// multi-writer by design — the bd CLI, other gascity processes and graph-apply
+// all write it — so a guard that only holds within one store handle is not a
+// fence at all, which is precisely why a store-maintained counter was rejected
+// as a revision token.
+//
+// Racing two INDEPENDENTLY OPENED storage handles over the same database
+// directory reproduces that condition inside one test binary: the handles
+// share no Go-level state, so any exclusion observed here is enforced below
+// them.
+func TestNativeDoltStoreMetadataCASContentionAcrossIndependentHandles(t *testing.T) {
+	ctx := context.Background()
+	dir := filepath.Join(t.TempDir(), ".beads")
+
+	openHandle := func(actor string) *NativeDoltStore {
+		t.Helper()
+		storage, err := beadslib.OpenBestAvailable(ctx, dir)
+		if err != nil {
+			t.Skipf("upstream native beads storage unavailable: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := storage.Close(); err != nil {
+				t.Logf("close upstream storage (%s): %v", actor, err)
+			}
+		})
+		if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+			t.Fatalf("set issue prefix (%s): %v", actor, err)
+		}
+		return newNativeDoltStoreWithStorageAndPrefix(storage, actor, "gc")
+	}
+
+	writerA := openHandle("cas-writer-a")
+	writerB := openHandle("cas-writer-b")
+
+	b, err := writerA.Create(Bead{Title: "cross-handle-cas-contention"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := b.ID
+	if err := writerA.SetMetadata(id, "lease", ""); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	// The second handle must observe the bead before racing for it, otherwise
+	// a miss proves nothing about the fence.
+	if got, err := writerB.Get(id); err != nil || got.ID != id {
+		t.Fatalf("second handle cannot see bead %q: (%v, %v)", id, got.ID, err)
+	}
+
+	type result struct {
+		holder string
+		won    bool
+		err    error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	for _, racer := range []struct {
+		store  *NativeDoltStore
+		holder string
+	}{{writerA, "holder-A"}, {writerB, "holder-B"}} {
+		go func(s *NativeDoltStore, holder string) {
+			<-start
+			won, err := s.CompareAndSetMetadataKey(id, "lease", "", holder)
+			results <- result{holder: holder, won: won, err: err}
+		}(racer.store, racer.holder)
+	}
+	close(start)
+
+	var winners []string
+	for range 2 {
+		r := <-results
+		if r.err != nil {
+			// A conflict surfaced as an error is NOT contract-conformant: the
+			// contract says a lost race is (false, nil). Report it as the
+			// contract violation it is rather than tolerating it.
+			t.Errorf("racer %s returned an error (a lost race must be (false, nil)): %v", r.holder, r.err)
+			continue
+		}
+		if r.won {
+			winners = append(winners, r.holder)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+	if len(winners) != 1 {
+		t.Fatalf("winners across independent handles = %d %v, want exactly 1 — the fence does not hold "+
+			"between writers, so this CAS cannot carry a lease in the multi-writer Dolt database",
+			len(winners), winners)
+	}
+
+	// Both handles must agree on who holds the lease.
+	for name, s := range map[string]*NativeDoltStore{"writerA": writerA, "writerB": writerB} {
+		got, err := s.Get(id)
+		if err != nil {
+			t.Fatalf("%s Get: %v", name, err)
+		}
+		if got.Metadata["lease"] != winners[0] {
+			t.Fatalf("%s sees lease %q, want the sole winner %q", name, got.Metadata["lease"], winners[0])
+		}
+	}
+}

--- a/internal/beads/native_dolt_store_metadata_cas_internal_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_internal_test.go
@@ -1,0 +1,112 @@
+package beads
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/rollout/gate"
+)
+
+// TestNativeDoltStoreDeclaresNarrowCASButNotConditionalWriter pins the exact
+// capability split the narrow interface exists to express: NativeDoltStore
+// offers a sound metadata value-CAS and makes NO revision-fence claim.
+//
+// Declaring the full ConditionalWriter would make ResolveConditionalWriter
+// RESOLVE under require mode and hand the revision-CAS trio's callers a
+// silently wrong-fenced write, because no sound revision token exists at
+// beads v1.1.0 (see internal/beads/metadata_cas.go). This asserts the ABSENCE
+// of that capability, which no conformance suite can do.
+func TestNativeDoltStoreDeclaresNarrowCASButNotConditionalWriter(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+
+	if w, ok := ConditionalWriterFor(store); ok {
+		t.Fatalf("NativeDoltStore resolved a ConditionalWriter (%T); the revision-CAS trio has "+
+			"no sound backend fence at beads v1.1.0, so declaring it is a safety regression", w)
+	}
+	if _, ok := MetadataCASWriterFor(store); !ok {
+		t.Fatal("NativeDoltStore does not resolve a MetadataCASWriter; the narrow value-CAS " +
+			"capability is what unblocks target_scope member-declaration and the D3/D5 lease lane")
+	}
+}
+
+// TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade pins the seam
+// behaviour the condWritesStamp comment in native_dolt_store.go guarantees:
+// require yields a typed refusal and auto yields a loud degrade — never a
+// silent legacy write under require. Adding the narrow CAS must not move
+// either verdict.
+func TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade(t *testing.T) {
+	t.Run("require_refuses", func(t *testing.T) {
+		store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+		store.stampConditionalWritesMode(gate.Require, false)
+
+		writer, diag, err := ResolveConditionalWriter(store)
+		if writer != nil {
+			t.Fatalf("writer = %T, want nil (require must fail closed)", writer)
+		}
+		if !IsConditionalWritesRequired(err) {
+			t.Fatalf("err = %v, want *ConditionalWritesRequiredError", err)
+		}
+		if diag == nil {
+			t.Fatal("diagnostic = nil, want a refusal diagnostic")
+		}
+	})
+
+	t.Run("auto_degrades_loudly", func(t *testing.T) {
+		store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+		store.stampConditionalWritesMode(gate.Auto, false)
+
+		writer, diag, err := ResolveConditionalWriter(store)
+		if writer != nil {
+			t.Fatalf("writer = %T, want nil (auto must take the legacy path)", writer)
+		}
+		if err != nil {
+			t.Fatalf("err = %v, want nil (auto degrades, it does not refuse)", err)
+		}
+		if diag == nil {
+			t.Fatal("diagnostic = nil, want a loud-degrade diagnostic")
+		}
+	})
+}
+
+// TestCachingStoreOverNativeDoltStoreForwardsNarrowCAS covers the wrapper
+// shape the plan calls out: a CachingStore whose backing offers only the
+// narrow capability must still forward the metadata CAS. The cache resolves
+// its trio verbs through ConditionalWriterFor, so without a narrow fallback
+// this path would answer ErrConditionalWriteUnsupported and the lease lane
+// would be blocked behind the cache.
+func TestCachingStoreOverNativeDoltStoreForwardsNarrowCAS(t *testing.T) {
+	backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	cache := NewCachingStore(backing, nil)
+
+	b, err := cache.Create(Bead{Title: "cache-over-native-cas"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writer, ok := MetadataCASWriterFor(cache)
+	if !ok {
+		t.Fatal("CachingStore over a narrow-CAS backing does not resolve a MetadataCASWriter")
+	}
+	if swapped, err := writer.CompareAndSetMetadataKey(b.ID, "lease", "", "holder-1"); err != nil || !swapped {
+		t.Fatalf("claim through cache: (%v, %v), want (true, nil)", swapped, err)
+	}
+	// A stale expectation loses cleanly rather than erroring.
+	if swapped, err := writer.CompareAndSetMetadataKey(b.ID, "lease", "", "holder-2"); err != nil || swapped {
+		t.Fatalf("stale claim through cache: (%v, %v), want (false, nil)", swapped, err)
+	}
+	// The winner's value is visible through the cache (the CAS evicted, so the
+	// next read consults the backing).
+	got, err := cache.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["lease"] != "holder-1" {
+		t.Fatalf("lease through cache = %q, want %q", got.Metadata["lease"], "holder-1")
+	}
+
+	// The trio stays refused: the backing makes no revision claim, so the
+	// cache must not report itself conditionally capable over it.
+	if capable, _ := cache.probeConditionalWriteCapability(); capable {
+		t.Fatal("CachingStore reports conditional-write capability over a narrow-only backing; " +
+			"the revision-CAS trio has no sound fence there")
+	}
+}

--- a/internal/beads/native_dolt_store_metadata_cas_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_test.go
@@ -1,0 +1,52 @@
+package beads_test
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/beadstest"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// TestNativeDoltStoreMetadataCASConformance holds NativeDoltStore to the
+// narrow value-CAS contract, including both traps the in-tree implementations
+// historically diverged on.
+//
+// The contention leg is declared unevaluatable HERE and only here: the
+// in-memory fixture behind this factory snapshots for rollback and then runs
+// the transaction callback unlocked, so concurrent CAS calls interleave freely
+// no matter how the store behaves. The property is not waived — it is proven
+// against real Dolt by
+// TestNativeDoltStoreMetadataCASContentionAgainstRealDolt (build tag
+// `integration`), where 8 racers yield exactly one winner.
+func TestNativeDoltStoreMetadataCASConformance(t *testing.T) {
+	beadstest.RunMetadataCASConformanceWithOptions(t, "NativeDoltStore",
+		func(_ *testing.T) beads.Store { return beads.NewNativeDoltStoreForConformance() },
+		beadstest.MetadataCASOptions{
+			FixtureLacksIsolationReason: "nativeDoltMemStorage.RunInTransaction models rollback but not " +
+				"isolation (it unlocks before running the callback); contention is covered against real " +
+				"Dolt by TestNativeDoltStoreMetadataCASContentionAgainstRealDolt (-tags=integration)",
+		},
+	)
+}
+
+// TestMemStoreMetadataCASConformance and TestFileStoreMetadataCASConformance
+// run the SAME narrow suite against the two stores whose fixtures do provide
+// isolation (both guard the whole CAS under their own lock), so the contention
+// leg is genuinely exercised at unit level and the suite cannot rot into a
+// table where every store has opted out of it.
+func TestMemStoreMetadataCASConformance(t *testing.T) {
+	beadstest.RunMetadataCASConformance(t, "MemStore",
+		func(_ *testing.T) beads.Store { return beads.NewMemStore() })
+}
+
+func TestFileStoreMetadataCASConformance(t *testing.T) {
+	beadstest.RunMetadataCASConformance(t, "FileStore",
+		func(t *testing.T) beads.Store {
+			store, err := beads.OpenFileStore(fsys.OSFS{}, t.TempDir()+"/beads.json")
+			if err != nil {
+				t.Fatalf("OpenFileStore: %v", err)
+			}
+			return store
+		})
+}

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -1054,10 +1054,20 @@ func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, co
 	}
 	runtimeVars := drainItemRuntimeVars(recipe, vars)
 	stampDrainItemRecipe(recipe, control, unit, member, count, row, itemFormula, runtimeVars)
+	itemScope, err := resolveDrainItemScope(store, control, runtimeVars, opts.StorePath)
+	if err != nil {
+		return "", false, fmt.Errorf("%s: %w", control.ID, err)
+	}
 	if opts.PrepareRecipe != nil {
 		if err := opts.PrepareRecipe(recipe, control); err != nil {
 			return "", false, fmt.Errorf("%w: %s: preparing drain item formula %q: %w", errDrainInvalidItemFormula, control.ID, itemFormula, err)
 		}
+	}
+	// Declare the tracked member, then stamp the item root — BEFORE
+	// materialization, so a rejected declaration costs a launch and never an
+	// orphaned graph (§5b phase order).
+	if err := prepareDrainItemLaunch(recipe, itemScope, member, store, opts); err != nil {
+		return "", false, fmt.Errorf("%s: declaring drain item target scope: %w", control.ID, err)
 	}
 	result, err := molecule.Instantiate(context.Background(), store, recipe, molecule.Options{
 		Vars:             runtimeVars,

--- a/internal/dispatch/drain_target_scope.go
+++ b/internal/dispatch/drain_target_scope.go
@@ -1,0 +1,125 @@
+package dispatch
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// resolveDrainItemScope resolves the target scope for one drain item root.
+//
+// INHERIT FIRST. A drain runs inside a parent workflow whose root already
+// carries a scope, and the parent's #16 equality — parentVars[base_branch] ==
+// parent-scope.branch — combined with drain deriving its item vars FROM
+// parentVars means the inherited scope EQUALS what runtimeVars substitutes. So
+// the scope is inherited from the control root rather than re-resolved: one
+// fact, one home, and no chance for the two to drift.
+//
+// A present-invalid control scope is a HARD STOP. "I could not read the scope
+// governing this drain" must never degrade to absent and re-enable the cwd
+// writers on the item's stages.
+//
+// Absent control — a drain with no scoped parent, i.e. the pre-seam population —
+// falls back to the drain's OWN substitution inputs. runtimeVars already folds
+// the item formula's var defaults (drainItemRuntimeVars), so it IS the map the
+// item substitutes; resolving the scope from it makes scope.branch == the
+// substituted branch by construction, the same D4 rule the order and cook
+// boundaries follow. A carrierless item resolves to unknown, which stamps a
+// present-valid field-empty object (§2c), never nothing.
+func resolveDrainItemScope(store beads.Store, control beads.Bead, runtimeVars map[string]string, storeRoot string) (targetscope.Scope, error) {
+	switch res := targetscope.ResolveInherited(store, control); res.State {
+	case targetscope.StateValid:
+		return res.Scope, nil
+	case targetscope.StateInvalid:
+		return targetscope.Scope{}, fmt.Errorf("drain control %s carries an unusable target scope: %w", control.ID, res.Reason)
+	}
+	resolved, err := targetscope.Resolve(targetscope.Sources{Routing: runtimeVars}, storeRoot)
+	if err != nil {
+		return targetscope.Scope{}, fmt.Errorf("resolving drain item scope from runtime vars: %w", err)
+	}
+	return resolved.Scope, nil
+}
+
+// prepareDrainItemLaunch declares the unit's tracked member under its
+// single-winner exclusion, then stamps the item recipe root — BEFORE the root is
+// materialized, so a rejection costs a launch and never an orphaned graph.
+//
+// The tracked member gets its OWN declaration (§5b). A drain item root does not
+// point back at the outer workflow root, and the inherited walk runs forward
+// only along parent/root edges — never in reverse along a convoy track — so the
+// member the item ultimately closes would otherwise resolve ABSENT and let its
+// stale flat keys stay behaviorally authoritative. The member is declared in the
+// store that OWNS it (drainMemberDeclarationStore), preferring CAS and falling
+// back to a guarded stamp where the store forwards no CAS. An unresolved tracked
+// item is skipped: there is no real bead to declare.
+func prepareDrainItemLaunch(recipe *formula.Recipe, scope targetscope.Scope, member beads.Bead, store beads.Store, opts ProcessOptions) error {
+	if strings.TrimSpace(member.ID) != "" && !convoycore.IsUnresolvedTrackedItem(member) {
+		// Declare the member in the store that OWNS it. A drain's convoy members
+		// can live in a separate per-class store (ProcessOptions.MemberStores),
+		// absent from the control's graph store — declaring against the graph
+		// store would fail-close the drain for the one bead the close gate reads.
+		owner, err := drainMemberDeclarationStore(store, member.ID, opts)
+		if err != nil {
+			return fmt.Errorf("resolving declaration store for member %s: %w", member.ID, err)
+		}
+		// nil owner means no known store holds the member (e.g. it was deleted
+		// before unit creation). Skip rather than fail: the member stays at its
+		// current state, never worse than before the seam.
+		if owner != nil {
+			if err := declareOrStampDrainMember(owner, member.ID, scope); err != nil {
+				return err
+			}
+		}
+	}
+	return targetscope.StampRoot(recipe, scope)
+}
+
+// drainMemberDeclarationStore returns the store that owns the member — the graph
+// store, then each per-class member store — as the first whose Get succeeds,
+// reusing the same probe set drain reservations use. It differs from
+// drainMemberOwningStore in ONE way that matters for a declaration: when no
+// probed store holds the member it returns nil, not the primary, so a member
+// deleted before unit creation is SKIPPED rather than declared against a store
+// that will then fail its read. A non-not-found probe error is surfaced.
+func drainMemberDeclarationStore(store beads.Store, memberID string, opts ProcessOptions) (beads.Store, error) {
+	for _, probe := range drainMemberProbeSet(store, opts) {
+		if probe == nil {
+			continue
+		}
+		if _, err := probe.Get(memberID); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		return probe, nil
+	}
+	return nil, nil
+}
+
+// declareOrStampDrainMember commits the tracked member's scope, preferring the
+// single-winner CAS declaration and falling back to a guarded stamp only when
+// the store forwards no metadata-CAS capability.
+//
+// A drain runs in the controller on whatever store the deployment gives it, and
+// a store that decorates reads/writes without re-exposing the CAS interface
+// would otherwise FAIL the whole drain — the commonest control-plane path — on a
+// capability gap. The ItemRootKey lock this call already runs under serializes
+// item-root creation, and the scope is inherited deterministically per member,
+// so the stamp fallback has the exclusion the CAS would provide; its immutability
+// guard rejects a present-valid-different member exactly as the CAS would.
+func declareOrStampDrainMember(store beads.Store, memberID string, scope targetscope.Scope) error {
+	if _, err := targetscope.Declare(store, memberID, scope); err != nil {
+		if errors.Is(err, targetscope.ErrDeclarationUnsupported) {
+			_, stampErr := targetscope.StampMemberScope(store, memberID, scope)
+			return stampErr
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/dispatch/drain_target_scope_test.go
+++ b/internal/dispatch/drain_target_scope_test.go
@@ -1,0 +1,146 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// A drain member can live only in a per-class member store, absent from the
+// control's graph store. Declaring it there — where the close gate will read it
+// — must resolve the OWNING store; declaring against the graph store would
+// fail-close the drain for the one bead that matters. A member in no known store
+// (deleted before unit creation) resolves to nil, which the caller skips rather
+// than fails.
+func TestDrainMemberDeclarationStoreResolvesOwningStore(t *testing.T) {
+	// Per-assertion fresh stores: MemStore auto-assigns ids, so two fresh stores
+	// would both hand out "gc-1" and collide. In production ids are prefix-
+	// disjoint across stores, so a member lives in exactly one — each assertion
+	// models one placement.
+
+	// Member in the primary graph store.
+	primary := beads.NewMemStore()
+	empty := beads.NewMemStore()
+	m1, err := primary.Create(beads.Bead{Title: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := drainMemberDeclarationStore(primary, m1.ID, ProcessOptions{MemberStores: []beads.Store{empty}}); err != nil || got != beads.Store(primary) {
+		t.Fatalf("primary member: got (%v, %v), want the primary store", got, err)
+	}
+
+	// Member only in a per-class member store, absent from the graph store.
+	graph := beads.NewMemStore()
+	memberStore := beads.NewMemStore()
+	m2, err := memberStore.Create(beads.Bead{Title: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := drainMemberDeclarationStore(graph, m2.ID, ProcessOptions{MemberStores: []beads.Store{memberStore}}); err != nil || got != beads.Store(memberStore) {
+		t.Fatalf("cross-store member: got (%v, %v), want the member store", got, err)
+	}
+
+	// Member in no known store (deleted before unit creation): nil, so the
+	// caller skips the declaration rather than fail-closing the drain.
+	if got, err := drainMemberDeclarationStore(graph, "no-such-bead", ProcessOptions{MemberStores: []beads.Store{memberStore}}); err != nil || got != nil {
+		t.Fatalf("absent member: got (%v, %v), want (nil, nil) so the caller skips", got, err)
+	}
+}
+
+// A drain inherits the scope of the workflow it runs inside. The control reaches
+// the parent root through gc.root_bead_id, so a scope stamped there governs
+// every item root AND every tracked member the items will close. Inheriting is
+// sound because the parent's #16 equality makes the inherited scope equal to
+// what the drain's runtimeVars substitute; re-resolving would risk drift.
+func TestDrainItemRootAndMemberInheritControlScope(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+
+	root := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	inherited := targetscope.Unknown()
+	inherited.Branch = "release"
+	blob, err := targetscope.Marshal(inherited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(root.ID, beadmeta.TargetScopeMetadataKey, blob); err != nil {
+		t.Fatalf("stamp control scope: %v", err)
+	}
+	members, err := convoycore.Members(store, root.Metadata["gc.input_convoy_id"], false)
+	if err != nil {
+		t.Fatalf("Members: %v", err)
+	}
+	if len(members) == 0 {
+		t.Fatal("seed produced no tracked members")
+	}
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(drain expand): %v", err)
+	}
+	if result.Action != "drain-expanded" {
+		t.Fatalf("action = %q, want drain-expanded", result.Action)
+	}
+
+	drain = mustGetBead(t, store, drain.ID)
+	manifest := mustDrainManifest(t, drain)
+	if len(manifest.Rows) == 0 {
+		t.Fatal("no drain rows materialized")
+	}
+	for _, row := range manifest.Rows {
+		itemRoot := mustGetBead(t, store, row.ItemRootID)
+		res := targetscope.Parse(itemRoot.Metadata[beadmeta.TargetScopeMetadataKey])
+		if !res.Valid() || res.Scope.Branch != "release" {
+			t.Fatalf("item root %s scope = %v/%q, want valid release (inherited from control)", row.ItemRootID, res.State, res.Scope.Branch)
+		}
+	}
+	for _, m := range members {
+		got := mustGetBead(t, store, m.ID)
+		res := targetscope.Parse(got.Metadata[beadmeta.TargetScopeMetadataKey])
+		if !res.Valid() || res.Scope.Branch != "release" {
+			t.Fatalf("tracked member %s scope = %v/%q, want valid release (declared under CAS)", m.ID, res.State, res.Scope.Branch)
+		}
+	}
+}
+
+// With no scoped parent (the pre-seam population) and an item formula that
+// consumes no branch carrier, the item root still gets a present-valid
+// field-empty object (§2c). Absence is the only state that re-enables the cwd
+// writers on the item's stages, so "no branch to record" must never be
+// implemented as writing nothing.
+func TestDrainItemRootAbsentControlStampsFieldEmptyScope(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(drain expand): %v", err)
+	}
+	if result.Action != "drain-expanded" {
+		t.Fatalf("action = %q, want drain-expanded", result.Action)
+	}
+
+	drain = mustGetBead(t, store, drain.ID)
+	manifest := mustDrainManifest(t, drain)
+	if len(manifest.Rows) == 0 {
+		t.Fatal("no drain rows materialized")
+	}
+	for _, row := range manifest.Rows {
+		itemRoot := mustGetBead(t, store, row.ItemRootID)
+		res := targetscope.Parse(itemRoot.Metadata[beadmeta.TargetScopeMetadataKey])
+		if !res.Valid() {
+			t.Fatalf("item root %s scope state = %v, want present-valid field-empty (§2c), never absent", row.ItemRootID, res.State)
+		}
+		if res.Scope.Branch != "" {
+			t.Fatalf("item root %s scope.branch = %q, want empty for a carrierless item under an unscoped control", row.ItemRootID, res.Scope.Branch)
+		}
+	}
+}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/pathutil"
+	"github.com/gastownhall/gascity/internal/targetscope"
 )
 
 // maxCheckInfraRetries bounds how many times a ralph check gate may be re-run
@@ -235,7 +236,10 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		storePath = cityPath
 	}
 
-	workDir := resolveInheritedMetadata(store, bead, beadmeta.LegacyWorkDirMetadataKey, beadmeta.WorkDirMetadataKey)
+	workDir, scopeViolation := ralphWorkDir(store, bead, targetscope.Envelope{CityPath: cityPath, StorePath: storePath})
+	if scopeViolation != "" {
+		return convergence.GateResult{}, fmt.Errorf("%s: %s", bead.ID, scopeViolation)
+	}
 	resolvedWorkDir := ""
 	if workDir != "" {
 		if filepath.IsAbs(workDir) {
@@ -1065,6 +1069,39 @@ func trimAttemptStepRefSuffix(stepRef, suffix string) (string, bool) {
 		return "", false
 	}
 	return strings.TrimSuffix(stepRef, suffix), true
+}
+
+// ralphWorkDir resolves the directory the exec check runs in.
+//
+// The declared gc.target_scope is the authority (§7): when a bead resolves a
+// valid scope, its worktree decides, and the claim-stamped gc.work_dir is not
+// consulted at all. That is the whole point of the object — gc.work_dir is
+// written from whatever cwd the claiming session happened to hold, so a check
+// that trusts it runs wherever the worker stood rather than where the work was
+// targeted.
+//
+// The tri-state is kept apart deliberately:
+//
+//   - valid, worktree known   → the declared worktree.
+//   - valid, worktree unknown → empty, so the caller falls to the store root.
+//     This is the §2c field-empty case and it must NOT reach for the flat key:
+//     a scope that says "unknown" is an answer, not an absence.
+//   - invalid                 → a violation. Falling back to the flat key here
+//     would hand the check the exact cwd value the scope was declared to
+//     override, which is how a corrupt object becomes an escalation.
+//   - absent                  → the legacy inherited flat read, unchanged. No
+//     existing bead has a scope, so this is every bead until a boundary
+//     declares one.
+func ralphWorkDir(store beads.Store, bead beads.Bead, envelope targetscope.Envelope) (workDir, violation string) {
+	switch res := targetscope.ResolveForReader(store, bead, envelope); res.State {
+	case targetscope.StateValid:
+		return res.Scope.Worktree, ""
+	case targetscope.StateInvalid:
+		return "", fmt.Sprintf("%s is unusable (%v); refusing to run the exec check against the claim-time %s instead",
+			beadmeta.TargetScopeMetadataKey, res.Reason, beadmeta.WorkDirMetadataKey)
+	default:
+		return resolveInheritedMetadata(store, bead, beadmeta.LegacyWorkDirMetadataKey, beadmeta.WorkDirMetadataKey), ""
+	}
 }
 
 func resolveInheritedMetadata(store beads.Store, bead beads.Bead, keys ...string) string {

--- a/internal/dispatch/ralph_target_scope_test.go
+++ b/internal/dispatch/ralph_target_scope_test.go
@@ -1,0 +1,260 @@
+package dispatch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/convergence"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// The envelope Ralph runs under in these tests. A declared worktree must sit
+// under one of these roots or the scoped read fails closed.
+func testEnvelope() targetscope.Envelope {
+	return targetscope.Envelope{CityPath: "/city", StorePath: "/city/rig"}
+}
+
+func scopedBead(t *testing.T, store *beads.MemStore, meta map[string]string) beads.Bead {
+	t.Helper()
+	bead, err := store.Create(beads.Bead{Title: "ralph check subject", Metadata: meta})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	return bead
+}
+
+func declaredMeta(t *testing.T, scope targetscope.Scope, extra map[string]string) map[string]string {
+	t.Helper()
+	blob, err := targetscope.Marshal(scope)
+	if err != nil {
+		t.Fatalf("marshalling scope: %v", err)
+	}
+	meta := map[string]string{beadmeta.TargetScopeMetadataKey: blob}
+	for k, v := range extra {
+		meta[k] = v
+	}
+	return meta
+}
+
+// The headline: a declared worktree wins over the claim-stamped gc.work_dir.
+// gc.work_dir is written from whatever cwd the claiming session held, so a
+// check that trusts it runs where the worker stood rather than where the work
+// was targeted.
+func TestRalphWorkDirPrefersDeclaredScopeOverClaimStampedWorkDir(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := scopedBead(t, store, declaredMeta(t,
+		targetscope.Scope{V: 1, Branch: "release", Worktree: "/city/rig/declared"},
+		map[string]string{beadmeta.WorkDirMetadataKey: "/city/rig/claimant-cwd"},
+	))
+
+	workDir, violation := ralphWorkDir(store, bead, testEnvelope())
+	if violation != "" {
+		t.Fatalf("violation = %q, want none", violation)
+	}
+	if workDir != "/city/rig/declared" {
+		t.Fatalf("workDir = %q, want the declared worktree", workDir)
+	}
+}
+
+// §2c field-empty: "unknown" is an answer, not an absence. It must fall to the
+// store root (empty here — the caller's no-work_dir base), never reach for the
+// flat key it was declared to override.
+func TestRalphWorkDirUnknownScopeDoesNotFallBackToFlatKey(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := scopedBead(t, store, declaredMeta(t,
+		targetscope.Unknown(),
+		map[string]string{beadmeta.WorkDirMetadataKey: "/city/rig/claimant-cwd"},
+	))
+
+	workDir, violation := ralphWorkDir(store, bead, testEnvelope())
+	if violation != "" {
+		t.Fatalf("violation = %q, want none", violation)
+	}
+	if workDir != "" {
+		t.Fatalf("workDir = %q, want empty so the caller uses the store root", workDir)
+	}
+}
+
+// A corrupt object must not degrade into the cwd value it exists to override.
+func TestRalphWorkDirInvalidScopeIsAViolationNotAFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := scopedBead(t, store, map[string]string{
+		beadmeta.TargetScopeMetadataKey: "{not json",
+		beadmeta.WorkDirMetadataKey:     "/city/rig/claimant-cwd",
+	})
+
+	workDir, violation := ralphWorkDir(store, bead, testEnvelope())
+	if violation == "" {
+		t.Fatal("an unusable scope produced no violation, want a refusal")
+	}
+	if workDir != "" {
+		t.Fatalf("workDir = %q, want empty on a refused scoped read", workDir)
+	}
+	if !strings.Contains(violation, beadmeta.TargetScopeMetadataKey) {
+		t.Fatalf("violation %q does not name the offending key", violation)
+	}
+}
+
+// §14(iv): an escaping worktree is present-invalid for the reader. Ralph must
+// fail the scoped read rather than re-anchor it or fall through to flat.
+func TestRalphWorkDirEscapingWorktreeFailsClosed(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := scopedBead(t, store, declaredMeta(t,
+		targetscope.Scope{V: 1, Worktree: "/etc/elsewhere"},
+		map[string]string{beadmeta.WorkDirMetadataKey: "/city/rig/claimant-cwd"},
+	))
+
+	workDir, violation := ralphWorkDir(store, bead, testEnvelope())
+	if violation == "" {
+		t.Fatal("a worktree outside the envelope produced no violation, want a refusal")
+	}
+	if workDir != "" {
+		t.Fatalf("workDir = %q, want empty on a refused scoped read", workDir)
+	}
+}
+
+// Absent is every bead in the existing population: the legacy inherited flat
+// read must be untouched, or this change regresses every ralph check that
+// ships today.
+func TestRalphWorkDirAbsentScopeKeepsTheLegacyFlatRead(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := scopedBead(t, store, map[string]string{
+		beadmeta.WorkDirMetadataKey: "/city/rig/legacy",
+	})
+
+	workDir, violation := ralphWorkDir(store, bead, testEnvelope())
+	if violation != "" {
+		t.Fatalf("violation = %q, want none", violation)
+	}
+	if workDir != "/city/rig/legacy" {
+		t.Fatalf("workDir = %q, want the legacy flat value", workDir)
+	}
+}
+
+// The legacy key is still honoured on the absent path.
+func TestRalphWorkDirAbsentScopeHonoursTheLegacyKey(t *testing.T) {
+	store := beads.NewMemStore()
+	bead := scopedBead(t, store, map[string]string{
+		beadmeta.LegacyWorkDirMetadataKey: "/city/rig/very-legacy",
+	})
+
+	workDir, violation := ralphWorkDir(store, bead, testEnvelope())
+	if violation != "" {
+		t.Fatalf("violation = %q, want none", violation)
+	}
+	if workDir != "/city/rig/very-legacy" {
+		t.Fatalf("workDir = %q, want the legacy flat value", workDir)
+	}
+}
+
+// The symbolic-root-reference class the design exists for: a stage carrying
+// only gc.root_bead_id must reach the root's declared scope, because that is
+// the shape a formula stage actually has.
+func TestRalphWorkDirInheritsScopeThroughTheRootChain(t *testing.T) {
+	store := beads.NewMemStore()
+	root := scopedBead(t, store, declaredMeta(t,
+		targetscope.Scope{V: 1, Branch: "release", Worktree: "/city/rig/declared"},
+		nil,
+	))
+	stage := scopedBead(t, store, map[string]string{
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+		beadmeta.WorkDirMetadataKey:    "/city/rig/claimant-cwd",
+	})
+
+	workDir, violation := ralphWorkDir(store, stage, testEnvelope())
+	if violation != "" {
+		t.Fatalf("violation = %q, want none", violation)
+	}
+	if workDir != "/city/rig/declared" {
+		t.Fatalf("workDir = %q, want the root's declared worktree inherited by the stage", workDir)
+	}
+}
+
+// The mayor's standing condition for this build: a seam wired into production
+// gets a test that exercises the PRODUCTION path, not only the helper with
+// hand-built collaborators. Session 1 shipped a guard that passed seven
+// hand-injected tests and did nothing when constructed for real.
+//
+// runRalphCheck is the production caller. The check script exists ONLY in the
+// declared worktree, so the scoped read is what makes this check runnable at
+// all: honour gc.work_dir instead and the script is not there to run.
+func TestRunRalphCheckRunsInTheDeclaredWorktreeNotTheClaimStampedWorkDir(t *testing.T) {
+	cityPath := t.TempDir()
+
+	declaredWorktree := filepath.Join(cityPath, "worktrees", "declared")
+	if err := os.MkdirAll(declaredWorktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(declaredWorktree, "check.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The cwd a claiming session happened to hold. It carries no check script.
+	claimantCwd := filepath.Join(cityPath, "worktrees", "claimant-cwd")
+	if err := os.MkdirAll(claimantCwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: declaredMeta(t,
+			targetscope.Scope{V: 1, Branch: "release", Worktree: declaredWorktree},
+			map[string]string{
+				"gc.kind":         "ralph",
+				"gc.root_bead_id": root.ID,
+				"gc.check_path":   "check.sh",
+				"gc.work_dir":     claimantCwd,
+				"gc.max_attempts": "3",
+			},
+		),
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+
+	result, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v (the declared worktree holds the check script; gc.work_dir does not)", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass from the declared worktree", result.Outcome, result.Stderr)
+	}
+}
+
+// An unusable scope must abort the production check rather than quietly run it
+// against the claim-time cwd.
+func TestRunRalphCheckRefusesAnUnusableScope(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "check.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":                       "ralph",
+			"gc.root_bead_id":               root.ID,
+			"gc.check_path":                 "check.sh",
+			"gc.work_dir":                   cityPath,
+			"gc.max_attempts":               "3",
+			beadmeta.TargetScopeMetadataKey: "{not json",
+		},
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+
+	if _, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath}); err == nil {
+		t.Fatal("runRalphCheck accepted an unusable target scope, want a refusal")
+	}
+}

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -1351,7 +1351,15 @@ func IsGraphWorkflowAttachment(store beads.Store, rootID string) bool {
 
 // InstantiateSlingFormula compiles and instantiates a formula, applying
 // graph routing if the formula is a graph.v2 workflow.
-func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPaths []string, opts molecule.Options, sourceBeadID, scopeKind, scopeRef string, a config.Agent, deps SlingDeps, forceGraphV2Replace ...bool) (*molecule.Result, error) {
+//
+// THE LAUNCH SCOPE IS A REQUIRED PARAMETER, not an option. §5 requires every
+// Ready-visible launch to be scoped, and the defence against a boundary that
+// silently forgets is not diligence at five call sites — it is that there is no
+// unscoped entry point to call. A caller with nothing to declare passes the
+// zero LaunchScope, which stamps the valid field-empty object (§2c "unknown"):
+// that is a deliberate state suppressing the cwd writers, and it is NOT the
+// same as writing nothing.
+func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPaths []string, opts molecule.Options, sourceBeadID, scopeKind, scopeRef string, a config.Agent, deps SlingDeps, launch LaunchScope, forceGraphV2Replace ...bool) (*molecule.Result, error) {
 	SlingTracef("instantiate start formula=%s source=%s agent=%s parent=%s", formulaName, sourceBeadID, a.QualifiedName(), opts.ParentID)
 	compileStart := time.Now()
 	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, formulaName, searchPaths, opts.Vars)
@@ -1360,6 +1368,14 @@ func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPath
 		return nil, err
 	}
 	SlingTracef("instantiate compiled formula=%s dur=%s steps=%d", formulaName, time.Since(compileStart), len(recipe.Steps))
+	// Declare every member, then stamp the root — both strictly before the
+	// instantiate call below materializes anything. An error here is a launch
+	// REJECTION: it costs a launch, whereas the same rejection after the root
+	// exists costs an orphaned graph.
+	if err := launch.PrepareLaunchScope(recipe); err != nil {
+		SlingTracef("instantiate scope-rejected formula=%s err=%v", formulaName, err)
+		return nil, err
+	}
 	return InstantiateCompiledSlingFormula(ctx, recipe, formulaName, opts, sourceBeadID, scopeKind, scopeRef, a, deps, forceGraphV2Replace...)
 }
 

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
+	"github.com/gastownhall/gascity/internal/targetscope"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
@@ -1128,25 +1129,94 @@ func buildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 // rigNameForAgent so agents whose Dir is a filesystem path still resolve
 // to the correct rig.
 func mergeRigFormulaVars(vars map[string]string, cfg *config.City, a config.Agent) {
+	for k, v := range rigFormulaVars(cfg, a) {
+		if _, explicit := vars[k]; explicit {
+			continue
+		}
+		vars[k] = v
+	}
+}
+
+// rigFormulaVars returns the rig-scoped formula_vars layer on its own, un-merged.
+//
+// Target-scope resolution needs the layers kept APART: precedence is decided
+// per layer, and a merged map has already collapsed "explicit --var base_branch"
+// and "rig default base_branch" into one indistinguishable entry. The merge in
+// mergeRigFormulaVars is expressed in terms of this so the two callers cannot
+// drift on which rig a given agent resolves to.
+//
+// The returned map is the LIVE config map, not a copy — callers must treat it
+// as read-only. Both consumers qualify: mergeRigFormulaVars only reads it, and
+// targetscope.Resolve copies each layer through single() before inspecting it.
+func rigFormulaVars(cfg *config.City, a config.Agent) map[string]string {
 	if cfg == nil {
-		return
+		return nil
 	}
 	rigName := rigNameForAgent(cfg, a)
 	if rigName == "" {
-		return
+		return nil
 	}
 	for i := range cfg.Rigs {
 		if cfg.Rigs[i].Name != rigName {
 			continue
 		}
-		for k, v := range cfg.Rigs[i].FormulaVars {
-			if _, explicit := vars[k]; explicit {
-				continue
-			}
-			vars[k] = v
-		}
-		return
+		return cfg.Rigs[i].FormulaVars
 	}
+	return nil
+}
+
+// SlingFormulaScopeSources builds the provenance-typed trusted-source set that
+// targetscope.Resolve consumes, from the same inputs buildSlingFormulaVars gets.
+//
+// It is deliberately SEPARATE from buildSlingFormulaVars rather than a second
+// return value from it, for two reasons found at the source:
+//
+//  1. buildSlingFormulaVars runs BEFORE the formula is loaded, so it cannot see
+//     the [vars.*].default layer. The design requires the formula default to be
+//     able to supply scope.branch (§11 #16 default-only case), so resolution has
+//     to happen where the effective vars exist — after graphv2.PrepareInvocation
+//     overlays EffectiveRuntimeVars, or after the legacy compile. The caller
+//     fills FormulaDefaults there and resolves.
+//  2. On the graph path the map buildSlingFormulaVars returns is DISCARDED and
+//     replaced by inv.Vars, so a carrier written into it would never reach
+//     instantiation. Keeping the sources separate lets the boundary apply the
+//     reconciled winner to the map that actually survives.
+//
+// Explicit stays raw and unflattened so a doubled carrier (--var base_branch=X
+// --var base_branch=Y) still reaches the resolver as a conflict to reject
+// instead of a last-write-wins silent pick.
+func SlingFormulaScopeSources(formulaName, beadID string, userVars []string, a config.Agent, deps SlingDeps) targetscope.Sources {
+	return targetscope.Sources{
+		Explicit: userVars,
+		Rig:      rigFormulaVars(deps.Cfg, a),
+		Routing:  slingRoutingScopeVars(formulaName, beadID, a, deps),
+	}
+}
+
+// slingRoutingScopeVars models the routing-injected branch layer exactly as the
+// injector in buildSlingFormulaVars applies it: the auto-resolved target branch,
+// under whichever carrier this formula conventionally consumes.
+//
+// The name predicates are the right authority HERE — this layer's job is to
+// report what routing actually injects today, and today that is name-driven. A
+// formula the predicates do not match genuinely receives no routed branch, so an
+// empty layer is the faithful answer and the formula default then decides.
+func slingRoutingScopeVars(formulaName, beadID string, a config.Agent, deps SlingDeps) map[string]string {
+	autoBranch := SlingFormulaTargetBranch(beadID, deps, a)
+	if autoBranch == "" {
+		return nil
+	}
+	routing := make(map[string]string, 2)
+	if SlingFormulaUsesBaseBranch(formulaName) {
+		routing[targetscope.VarBaseBranch] = autoBranch
+	}
+	if SlingFormulaUsesTargetBranch(formulaName) {
+		routing[targetscope.VarCarrierTargetBranch] = autoBranch
+	}
+	if len(routing) == 0 {
+		return nil
+	}
+	return routing
 }
 
 // ResolveSlingEnv returns extra env vars for the sling command.

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -343,8 +343,21 @@ func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 	if isGraph {
 		formulaVars = inv.Vars
 	}
+	// Resolve the target scope BEFORE compiling: the reconciled branch has to
+	// be in formulaVars before template substitution, or the formula
+	// substitutes one branch while the scope records another. A rejection here
+	// costs a launch and nothing else, because nothing is materialized yet.
+	launchScope, err := ResolveLaunchScope(opts.BeadOrFormula, "", opts.Vars, formulaVars, inv.Formula, invocationConvoyID(inv, isGraph), a, deps)
+	if err != nil {
+		return SlingResult{Target: a.QualifiedName()}, fmt.Errorf("instantiating formula %q: %w", opts.BeadOrFormula, err)
+	}
 	recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), opts.BeadOrFormula, searchPaths, formulaVars)
 	if err != nil {
+		return SlingResult{Target: a.QualifiedName()}, fmt.Errorf("instantiating formula %q: %w", opts.BeadOrFormula, err)
+	}
+	// Declare every member, then stamp the root — both before the instantiate
+	// call below materializes anything.
+	if err := launchScope.PrepareLaunchScope(recipe); err != nil {
 		return SlingResult{Target: a.QualifiedName()}, fmt.Errorf("instantiating formula %q: %w", opts.BeadOrFormula, err)
 	}
 	if a.SupportsMultipleSessions() && !formula.RecipeHasReadySurface(recipe) {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -429,6 +429,17 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 	if isGraph {
 		formulaVars = graphInv.Vars
 		result.Deprecations = append(result.Deprecations, graphInv.Deprecations...)
+	}
+	// Resolve the target scope BEFORE any compile — including the validation
+	// compile below. The reconciled branch has to be in formulaVars before
+	// template substitution runs, or the formula substitutes one branch while
+	// the scope records another. Both branches of this function launch the same
+	// formula onto the same bead, so the scope is resolved once, here.
+	launchScope, err := ResolveLaunchScope(formulaName, beadID, opts.Vars, formulaVars, graphInv.Formula, invocationConvoyID(graphInv, isGraph), a, deps)
+	if err != nil {
+		return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
+	}
+	if isGraph {
 		if err := validateSlingFormulaRuntimeVars(context.Background(), formulaName, searchPaths, molecule.Options{
 			Title: opts.Title,
 			Vars:  formulaVars,
@@ -450,7 +461,7 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 				Title:            opts.Title,
 				Vars:             formulaVars,
 				PriorityOverride: BeadPriorityOverride(deps.Store, graphInv.InputConvoy),
-			}, "", opts.ScopeKind, opts.ScopeRef, a, deps, opts.Force)
+			}, "", opts.ScopeKind, opts.ScopeRef, a, deps, launchScope, opts.Force)
 			if err != nil {
 				return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 			}
@@ -482,7 +493,7 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			Title:            opts.Title,
 			Vars:             formulaVars,
 			PriorityOverride: BeadPriorityOverride(querier, beadID),
-		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps, launchScope)
 		if err != nil {
 			return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 		}
@@ -496,6 +507,11 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			result.MetadataErrors = append(result.MetadataErrors,
 				fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
 		}
+		// The source bead is the claimable, close-gated unit on this legacy
+		// path, and the inheritance walk cannot reach the wisp root's stamp
+		// through molecule_id — so it carries its own scope, stamped here beside
+		// the molecule_id write it shares a fate with.
+		stampClaimableSourceScope(deps, beadID, launchScope.Scope, &result)
 		result.WispRootID = wispRootID
 		result.FormulaName = formulaName
 		// Route the SOURCE bead, not wispRootID. An attached wisp (--on
@@ -515,7 +531,7 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			Title:            opts.Title,
 			Vars:             formulaVars,
 			PriorityOverride: BeadPriorityOverride(querier, beadID),
-		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps, launchScope)
 		if err != nil {
 			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 		}
@@ -1200,17 +1216,25 @@ func sourceWorkflowRootByIDInStore(store beads.Store, sourceBeadID, workflowID, 
 }
 
 // attachBatchFormula launches one batch-child formula. The caller passes the
-// pre-computed isGraph flag from the one-shot formula compile at the top of
-// DoSlingBatch so that compiling N times for N children becomes a single
-// compile per batch.
-func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, child beads.Bead, a config.Agent, formulaName, formulaLabel, method string, isGraph bool) (SlingResult, error) {
+// pre-computed isGraph flag and the loaded formula from the one-shot formula
+// compile at the top of DoSlingBatch so that compiling N times for N children
+// becomes a single compile per batch.
+//
+// The SCOPE, unlike the formula, is resolved per child: the member layer and
+// the repo dir are properties of the bead being launched onto, so N children
+// are N independent resolutions even though they share one formula.
+func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, child beads.Bead, a config.Agent, formulaName, formulaLabel, method string, isGraph bool, f *formula.Formula) (SlingResult, error) {
 	childVars := BuildSlingFormulaVars(formulaName, child.ID, opts.Vars, a, deps)
+	launchScope, err := ResolveLaunchScope(formulaName, child.ID, opts.Vars, childVars, f, "", a, deps)
+	if err != nil {
+		return SlingResult{}, fmt.Errorf("instantiating %s %q on %s: %w", formulaLabel, formulaName, child.ID, err)
+	}
 	run := func() (SlingResult, error) {
 		mResult, err := InstantiateSlingFormula(ctx, formulaName, SlingFormulaSearchPaths(deps, a), molecule.Options{
 			Title:            opts.Title,
 			Vars:             childVars,
 			PriorityOverride: ClonePriorityPtr(child.Priority),
-		}, child.ID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		}, child.ID, opts.ScopeKind, opts.ScopeRef, a, deps, launchScope)
 		if err != nil {
 			return SlingResult{}, fmt.Errorf("instantiating %s %q on %s: %w", formulaLabel, formulaName, child.ID, err)
 		}
@@ -1230,6 +1254,10 @@ func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, chi
 			result.MetadataErrors = append(result.MetadataErrors,
 				fmt.Sprintf("setting molecule_id on %s: %v", child.ID, err))
 		}
+		// The batch child is the claimable, close-gated unit on this legacy
+		// path; it carries its own scope for the same reason the --on source
+		// does, stamped beside its molecule_id write.
+		stampClaimableSourceScope(deps, child.ID, launchScope.Scope, &result)
 		return result, nil
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {
@@ -1237,7 +1265,7 @@ func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, chi
 			Title:            opts.Title,
 			Vars:             childVars,
 			PriorityOverride: ClonePriorityPtr(child.Priority),
-		}, child.ID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		}, child.ID, opts.ScopeKind, opts.ScopeRef, a, deps, launchScope)
 		if err != nil {
 			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating %s %q on %s: %w", formulaLabel, formulaName, child.ID, err)
 		}
@@ -1451,11 +1479,22 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 	// once here and again per child, turning an O(1) compile into O(N) disk
 	// reads + template expansions for an N-child batch.
 	var isGraph bool
+	// The loaded formula is threaded for the same reason: scope resolution
+	// needs the declared vars (defaults, and which carrier this formula
+	// consumes), and loading it per child would restore the O(N) reads the
+	// one-shot compile above exists to avoid. The SCOPE itself is still
+	// resolved per child inside the helper — it depends on the bead, not the
+	// formula.
+	var batchFormula *formula.Formula
 	if useFormula != "" {
 		formulaVars := BuildSlingFormulaVars(useFormula, "", opts.Vars, a, deps)
 		searchPaths := SlingFormulaSearchPaths(deps, a)
 		var err error
 		isGraph, err = isGraphSlingFormula(context.Background(), useFormula, searchPaths, formulaVars)
+		if err != nil {
+			return SlingResult{}, fmt.Errorf("instantiating formula %q on %s %s: %w", useFormula, b.Type, b.ID, err)
+		}
+		batchFormula, err = graphv2.LoadFormula(useFormula, searchPaths)
 		if err != nil {
 			return SlingResult{}, fmt.Errorf("instantiating formula %q on %s %s: %w", useFormula, b.Type, b.ID, err)
 		}
@@ -1521,7 +1560,7 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 			if opts.OnFormula == "" {
 				formulaLabel = "default formula"
 			}
-			formulaResult, err := attachBatchFormula(context.Background(), opts, deps, child, a, useFormula, formulaLabel, batchMethod, isGraph)
+			formulaResult, err := attachBatchFormula(context.Background(), opts, deps, child, a, useFormula, formulaLabel, batchMethod, isGraph, batchFormula)
 			if err != nil {
 				childResult.Failed = true
 				childResult.FailReason = err.Error()

--- a/internal/sling/sling_launch_chokepoint_test.go
+++ b/internal/sling/sling_launch_chokepoint_test.go
@@ -58,7 +58,7 @@ func TestLaunchWorkflowDuplicateAttemptReturnsSameLiveRoot(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			res, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps)
+			res, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps, LaunchScope{})
 			if err != nil {
 				errs[i] = err
 				return
@@ -100,7 +100,7 @@ func TestLaunchWorkflowUsesCrossProcessFileLock(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 	opts := molecule.Options{Vars: map[string]string{"convoy_id": convoy.ID}}
 
-	if _, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps); err != nil {
+	if _, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps, LaunchScope{}); err != nil {
 		t.Fatalf("InstantiateSlingFormula: %v", err)
 	}
 
@@ -137,11 +137,11 @@ func TestLaunchWorkflowLegitimateDistinctLaunchesAllowed(t *testing.T) {
 
 	optsA := molecule.Options{Vars: map[string]string{"convoy_id": convoyA.ID}}
 	optsB := molecule.Options{Vars: map[string]string{"convoy_id": convoyB.ID}}
-	rootA, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsA, "", "default", "", a, deps)
+	rootA, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsA, "", "default", "", a, deps, LaunchScope{})
 	if err != nil {
 		t.Fatalf("launch A: %v", err)
 	}
-	rootB, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsB, "", "default", "", a, deps)
+	rootB, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsB, "", "default", "", a, deps, LaunchScope{})
 	if err != nil {
 		t.Fatalf("launch B: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestLaunchWorkflowLegitimateDistinctLaunchesAllowed(t *testing.T) {
 	if _, err := sourceworkflow.CloseWorkflowSubtree(deps.Store, rootA.RootID); err != nil {
 		t.Fatalf("close root A: %v", err)
 	}
-	relaunch, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsA, "", "default", "", a, deps)
+	relaunch, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, optsA, "", "default", "", a, deps, LaunchScope{})
 	if err != nil {
 		t.Fatalf("relaunch after close: %v", err)
 	}

--- a/internal/sling/sling_targetscope_test.go
+++ b/internal/sling/sling_targetscope_test.go
@@ -1,0 +1,180 @@
+package sling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// scopeTestDeps builds deps whose rig supplies a stored default branch, so the
+// routing layer has something to inject without touching a real git repo.
+func scopeTestDeps(t *testing.T, rig config.Rig) SlingDeps {
+	t.Helper()
+	return testDeps(&config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs:      []config.Rig{rig},
+	}, runtime.NewFake(), newFakeRunner().run)
+}
+
+func scopeAgent() config.Agent {
+	return config.Agent{Name: "polecat", Dir: "hw"}
+}
+
+// The whole point of the separate sources builder: the layers arrive APART.
+// A merged map cannot answer "did base_branch come from the operator or from
+// the rig", and precedence is decided per layer.
+func TestScopeSourcesKeepsLayersSeparate(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{
+		Name:        "hw",
+		FormulaVars: map[string]string{"base_branch": "rig-branch"},
+	})
+
+	src := SlingFormulaScopeSources("mol-scoped-work", "", []string{"base_branch=explicit-branch"}, scopeAgent(), deps)
+
+	if len(src.Explicit) != 1 || src.Explicit[0] != "base_branch=explicit-branch" {
+		t.Fatalf("Explicit = %v, want the raw unflattened operator var", src.Explicit)
+	}
+	if got := src.Rig["base_branch"]; got != "rig-branch" {
+		t.Fatalf("Rig[base_branch] = %q, want rig-branch (the rig layer must survive un-merged)", got)
+	}
+}
+
+// §11 #16 — explicit gc_target_branch beats a routed base_branch, and the
+// consumed carrier is rewritten to the winner so template substitution and the
+// close gate validate against the SAME branch.
+func TestScopeSourcesExplicitTargetBranchBeatsRoutingAndRewritesCarrier(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{Name: "hw", DefaultBranch: "main"})
+
+	src := SlingFormulaScopeSources("mol-scoped-work", "", []string{"gc_target_branch=release"}, scopeAgent(), deps)
+
+	if got := src.Routing[targetscope.VarBaseBranch]; got != "main" {
+		t.Fatalf("Routing[base_branch] = %q, want the routed main", got)
+	}
+
+	resolved, err := targetscope.Resolve(src, "/store")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.Scope.Branch != "release" {
+		t.Fatalf("scope.Branch = %q, want release (explicit outranks routing)", resolved.Scope.Branch)
+	}
+
+	vars := BuildSlingFormulaVars("mol-scoped-work", "", []string{"gc_target_branch=release"}, scopeAgent(), deps)
+	targetscope.ApplyToVars(vars, resolved, SlingFormulaUsesBaseBranch("mol-scoped-work"), SlingFormulaUsesTargetBranch("mol-scoped-work"))
+
+	if vars["base_branch"] != resolved.Scope.Branch {
+		t.Fatalf("vars[base_branch] = %q but scope.Branch = %q; the consumed carrier and the scope must be equal by construction",
+			vars["base_branch"], resolved.Scope.Branch)
+	}
+	if _, leaked := vars["gc_target_branch"]; leaked {
+		t.Fatal("gc_target_branch leaked into the consumed map; scope inputs are claimed by the resolver")
+	}
+}
+
+// §11 #16 empty-carrier case: an explicitly emptied carrier is not a veto and
+// not a survivor — it is overwritten by the reconciled winner.
+func TestScopeSourcesEmptyCarrierIsOverwrittenByWinner(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{Name: "hw", DefaultBranch: "main"})
+	userVars := []string{"base_branch=", "gc_target_branch=release"}
+
+	src := SlingFormulaScopeSources("mol-scoped-work", "", userVars, scopeAgent(), deps)
+	resolved, err := targetscope.Resolve(src, "/store")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	vars := BuildSlingFormulaVars("mol-scoped-work", "", userVars, scopeAgent(), deps)
+	targetscope.ApplyToVars(vars, resolved, true, false)
+
+	if vars["base_branch"] != "release" {
+		t.Fatalf("vars[base_branch] = %q, want release (not left empty, not the routed main)", vars["base_branch"])
+	}
+}
+
+// §11 #16 within-layer conflict: two aliases of one fact disagreeing at the
+// same layer is an operator error with no tiebreak.
+func TestScopeSourcesRejectsWithinLayerCarrierConflict(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{Name: "hw", DefaultBranch: "main"})
+
+	src := SlingFormulaScopeSources("mol-scoped-work", "", []string{"base_branch=X", "target_branch=Y"}, scopeAgent(), deps)
+
+	if _, err := targetscope.Resolve(src, "/store"); err == nil {
+		t.Fatal("Resolve accepted disagreeing explicit carriers; want a rejection")
+	} else if !strings.Contains(err.Error(), "conflicting target branch") {
+		t.Fatalf("err = %v, want a conflicting-target-branch rejection", err)
+	}
+}
+
+// A doubled carrier must survive as a conflict rather than being flattened to
+// last-write-wins before the resolver ever sees it.
+func TestScopeSourcesRejectsDuplicateExplicitCarrier(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{Name: "hw"})
+
+	src := SlingFormulaScopeSources("mol-scoped-work", "", []string{"base_branch=X", "base_branch=Y"}, scopeAgent(), deps)
+
+	if _, err := targetscope.Resolve(src, "/store"); err == nil {
+		t.Fatal("Resolve accepted a doubled explicit carrier with different values; want a rejection")
+	}
+}
+
+// §11 #16 default-only: with no operator or routed branch, the formula default
+// supplies the scope — which is why resolution cannot happen before the formula
+// is loaded.
+func TestScopeSourcesDefaultOnlyComesFromFormulaLayer(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{Name: "hw"})
+
+	src := SlingFormulaScopeSources("mol-scoped-work", "", nil, scopeAgent(), deps)
+	if src.Routing != nil {
+		t.Fatalf("Routing = %v, want nil when no branch resolves", src.Routing)
+	}
+
+	src.FormulaDefaults = map[string]string{"base_branch": "main"}
+	resolved, err := targetscope.Resolve(src, "/store")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.Scope.Branch != "main" {
+		t.Fatalf("scope.Branch = %q, want the formula default main", resolved.Scope.Branch)
+	}
+	if resolved.BranchLayer != targetscope.LayerFormula {
+		t.Fatalf("BranchLayer = %q, want the formula layer", resolved.BranchLayer)
+	}
+}
+
+// A formula the name predicates do not match receives no routed branch today.
+// The faithful answer is an empty routing layer, so the formula default decides
+// rather than a branch the injector never actually supplied.
+func TestScopeSourcesUnmatchedFormulaGetsNoRoutedBranch(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{Name: "hw", DefaultBranch: "main"})
+
+	src := SlingFormulaScopeSources("acme-work", "", nil, scopeAgent(), deps)
+
+	if src.Routing != nil {
+		t.Fatalf("Routing = %v, want nil for a formula routing does not inject into", src.Routing)
+	}
+}
+
+// The rig layer is read through the same rig resolution the merge uses, so the
+// sources builder and the vars builder cannot disagree about which rig applies.
+func TestScopeSourcesRigLayerMatchesMergedVars(t *testing.T) {
+	deps := scopeTestDeps(t, config.Rig{
+		Name:        "hw",
+		FormulaVars: map[string]string{"base_branch": "rig-branch"},
+	})
+
+	src := SlingFormulaScopeSources("mol-scoped-work", "", nil, scopeAgent(), deps)
+	vars := BuildSlingFormulaVars("mol-scoped-work", "", nil, scopeAgent(), deps)
+
+	// Non-vacuity: two empty lookups would satisfy the equality below while
+	// proving nothing, which is precisely how this test could go false-green.
+	if src.Rig["base_branch"] == "" {
+		t.Fatal("rig layer is empty; the test would compare two blanks and assert nothing")
+	}
+	if src.Rig["base_branch"] != vars["base_branch"] {
+		t.Fatalf("rig layer %q != merged vars %q; the two rig lookups drifted",
+			src.Rig["base_branch"], vars["base_branch"])
+	}
+}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2468,11 +2468,11 @@ func TestInstantiateSlingFormulaForceReplacesGraphV2Root(t *testing.T) {
 	opts := molecule.Options{Vars: vars}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 
-	first, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps)
+	first, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps, LaunchScope{})
 	if err != nil {
 		t.Fatalf("first InstantiateSlingFormula: %v", err)
 	}
-	second, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps, true)
+	second, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps, LaunchScope{}, true)
 	if err != nil {
 		t.Fatalf("force InstantiateSlingFormula: %v", err)
 	}

--- a/internal/sling/target_scope_attach_test.go
+++ b/internal/sling/target_scope_attach_test.go
@@ -1,0 +1,218 @@
+package sling
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// beadScope reads a bead's own declared scope. It deliberately does NOT walk
+// the inheritance chain: these tests assert what the declaration protocol
+// COMMITTED on the bead, and an inherited read would pass even when nothing
+// was declared.
+func beadScope(t *testing.T, deps SlingDeps, id string) targetscope.Resolution {
+	t.Helper()
+	b, err := deps.Store.Get(id)
+	if err != nil {
+		t.Fatalf("getting %s: %v", id, err)
+	}
+	return targetscope.Parse(b.Metadata[beadmeta.TargetScopeMetadataKey])
+}
+
+func openTaskBead(t *testing.T, deps SlingDeps, title string) beads.Bead {
+	t.Helper()
+	b, err := deps.Store.Create(beads.Bead{Title: title, Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("creating %s: %v", title, err)
+	}
+	return b
+}
+
+// THE ATTACH BOUNDARY'S LOAD-BEARING ASSERTION. An attached launch routes and
+// closes the SOURCE bead, not the wisp root — the source carries gc.routed_to
+// and molecule_id and is the claimable unit of work (sling_core.go's
+// "Route the SOURCE bead" comment). The inheritance walk is
+// bead -> ParentID -> gc.root_bead_id and does NOT follow molecule_id, so the
+// source cannot reach the root's stamp. Stamping only the root would leave the
+// one bead that is actually claimed and closed resolving ABSENT, and a boundary
+// that stamps a root nobody reads is wired in appearance only.
+func TestAttachedFormulaDeclaresScopeOnTheSourceBead(t *testing.T) {
+	dir := scopedFormulaDir(t, "attach-scope")
+	deps, agent := scopedLaunchDeps(t, dir)
+	target := openTaskBead(t, deps, "attach target")
+
+	opts := testOpts(agent, target.ID)
+	opts.OnFormula = "attach-scope"
+	opts.Vars = []string{"gc_target_branch=release"}
+
+	if _, err := DoSling(opts, deps, deps.Store); err != nil {
+		t.Fatalf("DoSling --on: %v", err)
+	}
+
+	got := beadScope(t, deps, target.ID)
+	if !got.Valid() {
+		t.Fatalf("source bead scope state = %v, want a present-valid declared object", got.State)
+	}
+	if got.Scope.Branch != "release" {
+		t.Fatalf("source bead scope.branch = %q, want release", got.Scope.Branch)
+	}
+}
+
+// E2E #16 at the attach boundary: the reconciled winner reaches the carrier
+// the formula substitutes, so substitution and the close gate read one branch.
+func TestAttachedFormulaConsumedCarrierEqualsTheDeclaredScope(t *testing.T) {
+	dir := scopedFormulaDir(t, "attach-carrier")
+	deps, agent := scopedLaunchDeps(t, dir)
+	target := openTaskBead(t, deps, "carrier target")
+
+	opts := testOpts(agent, target.ID)
+	opts.OnFormula = "attach-carrier"
+	opts.Vars = []string{"gc_target_branch=release"}
+
+	if _, err := DoSling(opts, deps, deps.Store); err != nil {
+		t.Fatalf("DoSling --on: %v", err)
+	}
+
+	scope := beadScope(t, deps, target.ID)
+	if !scope.Valid() {
+		t.Fatalf("source bead scope state = %v, want valid", scope.State)
+	}
+	steps, err := deps.Store.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("listing store: %v", err)
+	}
+	wantTitle := "Work on " + scope.Scope.Branch
+	for _, s := range steps {
+		if s.Title == wantTitle {
+			return
+		}
+	}
+	t.Fatalf("no step titled %q — substitution and the declared scope disagree", wantTitle)
+}
+
+// Immutability at the boundary (§5b). A bead already governed by a valid scope
+// cannot be silently retargeted by a launch that resolves a different one: the
+// declaration observes present-valid-different and REJECTS before any root is
+// materialized.
+func TestAttachedFormulaRejectsRetargetingAnAlreadyDeclaredBead(t *testing.T) {
+	dir := scopedFormulaDir(t, "attach-immutable")
+	deps, agent := scopedLaunchDeps(t, dir)
+	target := openTaskBead(t, deps, "already declared")
+
+	pinned, err := targetscope.Marshal(targetscope.Scope{Branch: "pinned"})
+	if err != nil {
+		t.Fatalf("marshalling pinned scope: %v", err)
+	}
+	if err := deps.Store.SetMetadata(target.ID, beadmeta.TargetScopeMetadataKey, pinned); err != nil {
+		t.Fatalf("pinning scope: %v", err)
+	}
+
+	opts := testOpts(agent, target.ID)
+	opts.OnFormula = "attach-immutable"
+	opts.Vars = []string{"gc_target_branch=release"}
+
+	if _, err := DoSling(opts, deps, deps.Store); err == nil {
+		t.Fatal("retargeting an already-declared bead launched, want a rejection")
+	}
+	got := beadScope(t, deps, target.ID)
+	if got.Scope.Branch != "pinned" {
+		t.Fatalf("declared scope.branch = %q after a rejected retarget, want the original pinned", got.Scope.Branch)
+	}
+}
+
+// The member layer (§3a precedence 2). With no explicit branch, a bead's
+// already-declared scope must decide — outranking the rig, the routing layer,
+// and the formula default. Otherwise a re-sling of a governed bead resolves a
+// lower layer and pins a contradiction.
+func TestAttachedFormulaDeclaredMemberScopeOutranksTheFormulaDefault(t *testing.T) {
+	dir := scopedFormulaDir(t, "attach-member-layer")
+	deps, agent := scopedLaunchDeps(t, dir)
+	target := openTaskBead(t, deps, "governed")
+
+	pinned, err := targetscope.Marshal(targetscope.Scope{Branch: "governed-branch"})
+	if err != nil {
+		t.Fatalf("marshalling pinned scope: %v", err)
+	}
+	if err := deps.Store.SetMetadata(target.ID, beadmeta.TargetScopeMetadataKey, pinned); err != nil {
+		t.Fatalf("pinning scope: %v", err)
+	}
+
+	opts := testOpts(agent, target.ID)
+	opts.OnFormula = "attach-member-layer"
+
+	if _, err := DoSling(opts, deps, deps.Store); err != nil {
+		t.Fatalf("DoSling --on: %v", err)
+	}
+
+	root := launchedRoot(t, deps)
+	got := targetscope.Parse(root.Metadata[beadmeta.TargetScopeMetadataKey])
+	if !got.Valid() {
+		t.Fatalf("root scope state = %v, want valid", got.State)
+	}
+	if got.Scope.Branch != "governed-branch" {
+		t.Fatalf("root scope.branch = %q, want the declared member scope to outrank the formula default main", got.Scope.Branch)
+	}
+}
+
+// A present-INVALID scope on the target bead is a launch rejection, never a
+// fall-through to the lower layers. "I could not read the scope governing this
+// bead" must not become permission to choose a new one (§2c).
+func TestAttachedFormulaRejectsAnInvalidScopeOnTheTargetBead(t *testing.T) {
+	dir := scopedFormulaDir(t, "attach-invalid")
+	deps, agent := scopedLaunchDeps(t, dir)
+	target := openTaskBead(t, deps, "corrupt scope")
+
+	if err := deps.Store.SetMetadata(target.ID, beadmeta.TargetScopeMetadataKey, "{not json"); err != nil {
+		t.Fatalf("writing corrupt scope: %v", err)
+	}
+
+	opts := testOpts(agent, target.ID)
+	opts.OnFormula = "attach-invalid"
+
+	if _, err := DoSling(opts, deps, deps.Store); err == nil {
+		t.Fatal("launch proceeded against an unreadable target scope, want a rejection")
+	}
+}
+
+// The batch boundary. A batch attaches the same formula to N children, and
+// each child is the claimable unit for its own launch — so each must carry its
+// own declaration, not merely share a root. The formula is loaded once per
+// batch but the SCOPE is resolved per child, because the member layer and the
+// repo dir are properties of the bead, not of the formula.
+func TestBatchFormulaDeclaresScopeOnEveryChild(t *testing.T) {
+	dir := scopedFormulaDir(t, "batch-scope")
+	deps, agent := scopedLaunchDeps(t, dir)
+
+	container, err := deps.Store.Create(beads.Bead{Title: "container", Type: "convoy", Status: "open"})
+	if err != nil {
+		t.Fatalf("creating container: %v", err)
+	}
+	var childIDs []string
+	for _, title := range []string{"child one", "child two"} {
+		c, err := deps.Store.Create(beads.Bead{Title: title, Type: "task", Status: "open", ParentID: container.ID})
+		if err != nil {
+			t.Fatalf("creating %s: %v", title, err)
+		}
+		childIDs = append(childIDs, c.ID)
+	}
+
+	opts := testOpts(agent, container.ID)
+	opts.OnFormula = "batch-scope"
+	opts.Vars = []string{"gc_target_branch=release"}
+
+	if _, err := DoSlingBatch(opts, deps, deps.Store); err != nil {
+		t.Fatalf("DoSlingBatch: %v", err)
+	}
+
+	for _, id := range childIDs {
+		got := beadScope(t, deps, id)
+		if !got.Valid() {
+			t.Fatalf("child %s scope state = %v, want a present-valid declared object", id, got.State)
+		}
+		if got.Scope.Branch != "release" {
+			t.Fatalf("child %s scope.branch = %q, want release", id, got.Scope.Branch)
+		}
+	}
+}

--- a/internal/sling/target_scope_launch.go
+++ b/internal/sling/target_scope_launch.go
@@ -1,0 +1,114 @@
+package sling
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/graphv2"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// LaunchScope is what a launch boundary resolves before it materializes
+// anything: the scope this launch runs under, and the members that must
+// declare it first.
+type LaunchScope struct {
+	Scope   targetscope.Scope
+	Members []targetscope.Member
+	// BranchLayer records which trusted layer supplied the branch. Diagnostic
+	// only — an operator asking "why did this run against release?" gets an
+	// answer instead of a shrug.
+	BranchLayer targetscope.LayerName
+}
+
+// ResolveLaunchScope resolves the target scope for one launch and writes the
+// reconciled branch back into the variable map the formula will consume.
+//
+// CALL THIS BEFORE COMPILING. The winner has to be in vars before template
+// substitution runs, or the formula substitutes one branch while the scope
+// records another — the exact divergence §3c exists to close, and the
+// equality E2E #16 asserts.
+//
+// An error is a LAUNCH REJECTION. Nothing has been materialized at this point,
+// which is the whole reason the phase runs here: rejecting costs a launch,
+// whereas the same rejection after the root exists costs an orphaned graph.
+func ResolveLaunchScope(formulaName, beadID string, userVars []string, vars map[string]string, f *formula.Formula, convoyID string, a config.Agent, deps SlingDeps) (LaunchScope, error) {
+	sources := SlingFormulaScopeSources(formulaName, beadID, userVars, a, deps)
+	sources.FormulaDefaults = targetscope.FormulaDefaultVars(f)
+
+	resolved, err := targetscope.Resolve(sources, SlingFormulaRepoDir(beadID, deps, a))
+	if err != nil {
+		return LaunchScope{}, fmt.Errorf("resolving target scope for %s: %w", formulaName, err)
+	}
+
+	// The consumed-carrier write-back. Which carrier the formula actually reads
+	// is derived from the RESOLVED formula's declared vars, not from the
+	// formula-name predicates: the predicates model what routing injects today
+	// and are the right authority for that layer only. A formula that declares
+	// base_branch without matching a name pattern still consumes base_branch.
+	targetscope.ApplyToVars(vars, resolved, formulaDeclaresVar(f, targetscope.VarBaseBranch), formulaDeclaresVar(f, targetscope.VarCarrierTargetBranch))
+
+	members, err := launchScopeMembers(convoyID, resolved.Scope, deps)
+	if err != nil {
+		return LaunchScope{}, err
+	}
+	return LaunchScope{Scope: resolved.Scope, Members: members, BranchLayer: resolved.BranchLayer}, nil
+}
+
+// formulaDeclaresVar reports whether the resolved formula declares a variable,
+// which is what makes it a carrier this formula actually consumes.
+func formulaDeclaresVar(f *formula.Formula, name string) bool {
+	if f == nil || len(f.Vars) == 0 {
+		return false
+	}
+	_, ok := f.Vars[name]
+	return ok
+}
+
+// launchScopeMembers lists the tracked members that must declare this scope.
+//
+// Members are the pre-existing beads a targeted launch runs ON — the ones the
+// close gate loads directly (§5b). They are what makes stamping the root
+// insufficient on its own: a stage's scope is not the member's scope, and the
+// gate reads the member.
+//
+// Closed members are included deliberately. A member closed between convoy
+// creation and launch is still a bead whose gate can run, and skipping it
+// would leave exactly the unscoped reader the design is closing.
+func launchScopeMembers(convoyID string, scope targetscope.Scope, deps SlingDeps) ([]targetscope.Member, error) {
+	if convoyID == "" || deps.Store == nil {
+		return nil, nil
+	}
+	beadsInConvoy, err := convoycore.Members(deps.Store, convoyID, true)
+	if err != nil {
+		return nil, fmt.Errorf("listing members of input convoy %s: %w", convoyID, err)
+	}
+	members := make([]targetscope.Member, 0, len(beadsInConvoy))
+	for _, b := range beadsInConvoy {
+		members = append(members, targetscope.Member{ID: b.ID, Store: deps.Store, Scope: scope})
+	}
+	return members, nil
+}
+
+// PrepareLaunchScope runs the declaration phase and stamps the recipe root.
+//
+// It is the one call every sling launch boundary makes, so a boundary can be
+// wrong by not calling it, never by calling it differently.
+func (l LaunchScope) PrepareLaunchScope(recipe *formula.Recipe) error {
+	return targetscope.PrepareLaunch(recipe, l.Scope, l.Members)
+}
+
+// invocationConvoyID reports the input convoy of a graph invocation, or empty
+// for the shapes that have none.
+//
+// A launch with no convoy still gets a scope: §5 requires the stamp to be
+// decoupled from the convoy, because stampGraphV2RootMetadata's convoy
+// early-return is precisely how a no-convoy standalone graph root ends up
+// unscoped.
+func invocationConvoyID(inv graphv2.Invocation, isGraph bool) string {
+	if !isGraph {
+		return ""
+	}
+	return inv.InputConvoy
+}

--- a/internal/sling/target_scope_launch.go
+++ b/internal/sling/target_scope_launch.go
@@ -151,17 +151,26 @@ func launchScopeMembers(convoyID string, scope targetscope.Scope, deps SlingDeps
 // molecule_id write that makes it the claimable unit.
 //
 // It is a plain SetMetadata, non-fatal like the molecule_id write beside it,
-// NOT a CAS member declaration. Two facts make that correct rather than a
-// weakening. First, immutability is already enforced upstream: ResolveLaunchScope
-// reads this bead's existing scope into the member layer and rejects the launch
-// before any materialization if the resolved scope differs — so by the time we
-// reach this stamp the scope either EQUALS what the bead already carries (an
-// idempotent re-stamp) or the bead was unscoped (a fresh stamp); there is no
-// path here that silently retargets a governed bead. Second, the exclusion the
-// member CAS would add is already held by the source-workflow lock that
-// serializes attaches on this bead, and the write must match molecule_id's
-// non-fatal contract because a legacy source can live in a validation-only
-// querier absent from the declaration store.
+// NOT a CAS member declaration, because a legacy source can live in a
+// validation-only querier absent from the declaration store, where a CAS
+// declaration fails closed and breaks the most common sling path.
+//
+// The single-writer guarantee this weakens, stated HONESTLY (an earlier draft of
+// this comment over-claimed a lock that this path does not hold):
+//
+//   - Against an ALREADY-DECLARED scope, immutability holds. ResolveLaunchScope
+//     reads the bead's existing scope into the member layer and rejects the
+//     launch before materialization when the resolved scope differs, so a
+//     GOVERNED bead is never silently retargeted.
+//   - Two CONCURRENT legacy attaches on the same still-UNSCOPED bead are NOT
+//     serialized here. The sourceworkflow lock wraps only the graph-attach
+//     boundaries, not this legacy run(); both launches read the bead as absent
+//     before either stamps, so the last stamp wins. Both write VALID scopes (no
+//     corruption), but the winner is non-deterministic. The graph-attach path is
+//     the CAS-serialized single-winner path; closing this residual legacy race
+//     needs the source declared BEFORE materialization, which the
+//     validation-only-querier constraint makes a larger change — tracked
+//     separately, out of scope for this hardening.
 //
 // An unknown scope is still stamped (§2c): absence is what re-enables the cwd
 // writers, so "no branch to record" is a present-valid field-empty object, not

--- a/internal/sling/target_scope_launch.go
+++ b/internal/sling/target_scope_launch.go
@@ -3,6 +3,7 @@ package sling
 import (
 	"fmt"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/config"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/formula"
@@ -36,10 +37,26 @@ type LaunchScope struct {
 func ResolveLaunchScope(formulaName, beadID string, userVars []string, vars map[string]string, f *formula.Formula, convoyID string, a config.Agent, deps SlingDeps) (LaunchScope, error) {
 	sources := SlingFormulaScopeSources(formulaName, beadID, userVars, a, deps)
 	sources.FormulaDefaults = targetscope.FormulaDefaultVars(f)
+	if err := applyTargetBeadMemberLayer(&sources, beadID, deps); err != nil {
+		return LaunchScope{}, err
+	}
 
 	resolved, err := targetscope.Resolve(sources, SlingFormulaRepoDir(beadID, deps, a))
 	if err != nil {
 		return LaunchScope{}, fmt.Errorf("resolving target scope for %s: %w", formulaName, err)
+	}
+
+	// Immutability at the target bead (§5b). The resolver's cross-layer
+	// precedence lets an explicit branch (precedence 1) outrank an existing
+	// member scope (precedence 2) silently — the reconciler returns the explicit
+	// winner without flagging that it overrode a governed bead. For the CONVOY
+	// members below that is caught by the CAS declaration (present-valid-
+	// different rejects), but the attach's claimable SOURCE is stamped, not
+	// declared, so its immutability has to be enforced here, before anything is
+	// materialized. A resolved scope that differs from the bead's already-valid
+	// scope is a retarget, and a retarget is a launch rejection, not a rewrite.
+	if sources.MemberSet && !sources.Member.Equal(resolved.Scope) {
+		return LaunchScope{}, fmt.Errorf("%w: %s is already scoped to %+v; refusing to retarget it to %+v", targetscope.ErrInvalidScope, beadID, sources.Member, resolved.Scope)
 	}
 
 	// The consumed-carrier write-back. Which carrier the formula actually reads
@@ -56,14 +73,42 @@ func ResolveLaunchScope(formulaName, beadID string, userVars []string, vars map[
 	return LaunchScope{Scope: resolved.Scope, Members: members, BranchLayer: resolved.BranchLayer}, nil
 }
 
-// formulaDeclaresVar reports whether the resolved formula declares a variable,
-// which is what makes it a carrier this formula actually consumes.
-func formulaDeclaresVar(f *formula.Formula, name string) bool {
-	if f == nil || len(f.Vars) == 0 {
-		return false
+// applyTargetBeadMemberLayer fills the member layer (§3a precedence 2) from the
+// scope already governing the bead a targeted launch runs ON.
+//
+// It reads through the inheritance walk rather than the bead's own key. A stage
+// carries a symbolic root reference, not a copy of root metadata, so a
+// bead-local read would report "no member scope" for precisely the beads whose
+// scope is already decided — and the launch would then resolve a winner from a
+// lower layer and pin a contradiction onto a bead that is already governed.
+//
+// A present-invalid scope is a LAUNCH REJECTION, never a fall-through to the
+// lower layers: "I could not read the scope governing this bead" must never
+// become permission to choose a new one.
+func applyTargetBeadMemberLayer(sources *targetscope.Sources, beadID string, deps SlingDeps) error {
+	if beadID == "" || deps.Store == nil {
+		return nil
 	}
-	_, ok := f.Vars[name]
-	return ok
+	bead, err := deps.Store.Get(beadID)
+	if err != nil {
+		return fmt.Errorf("reading target scope of %s: %w", beadID, err)
+	}
+	res := targetscope.ResolveInherited(deps.Store, bead)
+	switch res.State {
+	case targetscope.StateValid:
+		sources.Member = res.Scope
+		sources.MemberSet = true
+	case targetscope.StateInvalid:
+		return fmt.Errorf("target scope of %s is unusable: %w", beadID, res.Reason)
+	}
+	return nil
+}
+
+// formulaDeclaresVar reports whether the resolved formula declares a variable,
+// which is what makes it a carrier this formula actually consumes. It delegates
+// so every launch boundary shares one answer.
+func formulaDeclaresVar(f *formula.Formula, name string) bool {
+	return targetscope.DeclaresVar(f, name)
 }
 
 // launchScopeMembers lists the tracked members that must declare this scope.
@@ -76,6 +121,16 @@ func formulaDeclaresVar(f *formula.Formula, name string) bool {
 // Closed members are included deliberately. A member closed between convoy
 // creation and launch is still a bead whose gate can run, and skipping it
 // would leave exactly the unscoped reader the design is closing.
+//
+// The claimable SOURCE bead of a --on/default attach is deliberately NOT a
+// member here. A graph attach normalizes its target into this input convoy, so
+// that bead already appears below; a legacy attach's source is not in any
+// convoy and its scope is stamped at the molecule_id write instead
+// (stampClaimableSourceScope). The distinction matters because members are
+// declared under CAS, which fails closed when the source is absent from the
+// declaration store — and a legacy attach's source can be in a validation-only
+// querier, exactly the shape the molecule_id write already tolerates non-
+// fatally.
 func launchScopeMembers(convoyID string, scope targetscope.Scope, deps SlingDeps) ([]targetscope.Member, error) {
 	if convoyID == "" || deps.Store == nil {
 		return nil, nil
@@ -89,6 +144,40 @@ func launchScopeMembers(convoyID string, scope targetscope.Scope, deps SlingDeps
 		members = append(members, targetscope.Member{ID: b.ID, Store: deps.Store, Scope: scope})
 	}
 	return members, nil
+}
+
+// stampClaimableSourceScope stamps the resolved scope on the pre-existing bead a
+// legacy attach routes and closes — the SOURCE bead — co-located with the
+// molecule_id write that makes it the claimable unit.
+//
+// It is a plain SetMetadata, non-fatal like the molecule_id write beside it,
+// NOT a CAS member declaration. Two facts make that correct rather than a
+// weakening. First, immutability is already enforced upstream: ResolveLaunchScope
+// reads this bead's existing scope into the member layer and rejects the launch
+// before any materialization if the resolved scope differs — so by the time we
+// reach this stamp the scope either EQUALS what the bead already carries (an
+// idempotent re-stamp) or the bead was unscoped (a fresh stamp); there is no
+// path here that silently retargets a governed bead. Second, the exclusion the
+// member CAS would add is already held by the source-workflow lock that
+// serializes attaches on this bead, and the write must match molecule_id's
+// non-fatal contract because a legacy source can live in a validation-only
+// querier absent from the declaration store.
+//
+// An unknown scope is still stamped (§2c): absence is what re-enables the cwd
+// writers, so "no branch to record" is a present-valid field-empty object, not
+// nothing.
+func stampClaimableSourceScope(deps SlingDeps, beadID string, scope targetscope.Scope, result *SlingResult) {
+	if deps.Store == nil || beadID == "" {
+		return
+	}
+	blob, err := targetscope.Marshal(scope)
+	if err != nil {
+		result.MetadataErrors = append(result.MetadataErrors, fmt.Sprintf("marshaling target scope for %s: %v", beadID, err))
+		return
+	}
+	if err := deps.Store.SetMetadata(beadID, beadmeta.TargetScopeMetadataKey, blob); err != nil {
+		result.MetadataErrors = append(result.MetadataErrors, fmt.Sprintf("stamping target scope on %s: %v", beadID, err))
+	}
 }
 
 // PrepareLaunchScope runs the declaration phase and stamps the recipe root.

--- a/internal/sling/target_scope_launch_test.go
+++ b/internal/sling/target_scope_launch_test.go
@@ -1,0 +1,201 @@
+package sling
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/targetscope"
+)
+
+// scopedFormulaDir writes a formula that DECLARES base_branch with a default,
+// which is what makes base_branch a carrier this formula actually consumes.
+func scopedFormulaDir(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := `formula = "` + name + `"
+version = 1
+
+[vars.base_branch]
+default = "main"
+
+[[steps]]
+id = "work"
+title = "Work on {{base_branch}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing formula: %v", err)
+	}
+	return dir
+}
+
+func scopedLaunchDeps(t *testing.T, formulaDir string) (SlingDeps, config.Agent) {
+	t.Helper()
+	single := 1
+	agent := config.Agent{Name: "worker", Dir: "rig", MaxActiveSessions: &single}
+	cfg := &config.City{Agents: []config.Agent{agent}}
+	cfg.FormulaLayers.City = []string{formulaDir}
+	deps := SlingDeps{
+		CityName: "test-city",
+		CityPath: t.TempDir(),
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		StoreRef: "city:test-city",
+		Resolver: testResolver{},
+		Notify:   testNotifier{},
+		Runner:   func(_, _ string, _ map[string]string) (string, error) { return "", nil },
+	}
+	return deps, agent
+}
+
+// launchedRoot finds the materialized root: the one bead the launch created
+// with no parent. It is located by shape rather than by SlingResult, because
+// the field carrying the root id differs across the launch shapes and the
+// assertion is about what landed in the store either way.
+func launchedRoot(t *testing.T, deps SlingDeps) beads.Bead {
+	t.Helper()
+	all, err := deps.Store.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("listing store: %v", err)
+	}
+	// The formula root is the bead the launch stamped with gc.formula_name.
+	// Parentlessness alone is not enough: sling also creates its own
+	// bookkeeping bead with no parent.
+	var roots []beads.Bead
+	for _, b := range all {
+		if b.Metadata[beadmeta.FormulaNameMetadataKey] != "" {
+			roots = append(roots, b)
+		}
+	}
+	if len(roots) != 1 {
+		t.Fatalf("found %d formula roots after launch, want exactly one", len(roots))
+	}
+	return roots[0]
+}
+
+func launchedRootScope(t *testing.T, deps SlingDeps) targetscope.Resolution {
+	t.Helper()
+	return targetscope.Parse(launchedRoot(t, deps).Metadata[beadmeta.TargetScopeMetadataKey])
+}
+
+// The boundary stamps. Before this seam, a launched root carried no scope at
+// all, so every reader fell through to whatever cwd the claim happened to
+// stamp. §5 forbids leaving any Ready-visible launch unscoped.
+func TestSlingFormulaStampsTargetScopeOnTheLaunchedRoot(t *testing.T) {
+	dir := scopedFormulaDir(t, "scoped-launch")
+	deps, agent := scopedLaunchDeps(t, dir)
+
+	opts := testOpts(agent, "scoped-launch")
+	opts.Vars = []string{"gc_target_branch=release"}
+
+	_, err := slingFormula(opts, deps)
+	if err != nil {
+		t.Fatalf("slingFormula: %v", err)
+	}
+	got := launchedRootScope(t, deps)
+	if !got.Valid() {
+		t.Fatalf("launched root scope state = %v, want a present-valid object", got.State)
+	}
+	if got.Scope.Branch != "release" {
+		t.Fatalf("scope.branch = %q, want the explicit release", got.Scope.Branch)
+	}
+}
+
+// E2E #16, the wire assertion: the reconciled winner must reach the carrier
+// the formula substitutes, so template substitution and the close gate read
+// the SAME branch. Explicit gc_target_branch outranks the formula default, and
+// the consumed base_branch must be overwritten to match — not left at main.
+func TestSlingFormulaConsumedCarrierEqualsTheDeclaredScope(t *testing.T) {
+	dir := scopedFormulaDir(t, "scoped-carrier")
+	deps, agent := scopedLaunchDeps(t, dir)
+
+	opts := testOpts(agent, "scoped-carrier")
+	opts.Vars = []string{"gc_target_branch=release"}
+
+	_, err := slingFormula(opts, deps)
+	if err != nil {
+		t.Fatalf("slingFormula: %v", err)
+	}
+	scope := launchedRootScope(t, deps)
+	if !scope.Valid() {
+		t.Fatalf("launched root scope state = %v, want valid", scope.State)
+	}
+
+	// The step title substitutes {{base_branch}}. It is the observable proof
+	// that substitution consumed the winner rather than the stale default.
+	steps, err := deps.Store.List(beads.ListQuery{ParentID: launchedRoot(t, deps).ID, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("listing steps: %v", err)
+	}
+	if len(steps) == 0 {
+		t.Fatal("launch produced no steps to check substitution against")
+	}
+	wantTitle := "Work on " + scope.Scope.Branch
+	if steps[0].Title != wantTitle {
+		t.Fatalf("step title = %q, want %q — substitution and the declared scope disagree", steps[0].Title, wantTitle)
+	}
+}
+
+// The default-only case. With no branch supplied anywhere, scope.branch must
+// be the formula's own default rather than unknown: otherwise substitution
+// quietly uses main while the scope claims to know nothing.
+func TestSlingFormulaDefaultOnlyBranchReachesTheScope(t *testing.T) {
+	dir := scopedFormulaDir(t, "scoped-default")
+	deps, agent := scopedLaunchDeps(t, dir)
+
+	_, err := slingFormula(testOpts(agent, "scoped-default"), deps)
+	if err != nil {
+		t.Fatalf("slingFormula: %v", err)
+	}
+	got := launchedRootScope(t, deps)
+	if !got.Valid() {
+		t.Fatalf("launched root scope state = %v, want valid", got.State)
+	}
+	if got.Scope.Branch != "main" {
+		t.Fatalf("scope.branch = %q, want the formula default main", got.Scope.Branch)
+	}
+}
+
+// Within-layer disagreement is an operator error, and it must reject the
+// launch rather than silently pick one. Nothing may be materialized.
+func TestSlingFormulaRejectsConflictingExplicitBranchCarriers(t *testing.T) {
+	dir := scopedFormulaDir(t, "scoped-conflict")
+	deps, agent := scopedLaunchDeps(t, dir)
+
+	opts := testOpts(agent, "scoped-conflict")
+	opts.Vars = []string{"base_branch=one", "gc_target_branch=two"}
+
+	if _, err := slingFormula(opts, deps); err == nil {
+		t.Fatal("conflicting explicit branch carriers launched, want a rejection")
+	}
+	all, err := deps.Store.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("listing store: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("rejected launch materialized %d beads, want none", len(all))
+	}
+}
+
+// A formula that declares no branch carrier still gets a scope object rather
+// than nothing: absence is what lets a later claim write cwd (§2c).
+func TestSlingFormulaStampsUnknownScopeForACarrierlessFormula(t *testing.T) {
+	dir := t.TempDir()
+	body := "formula = \"carrierless\"\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "carrierless.toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing formula: %v", err)
+	}
+	deps, agent := scopedLaunchDeps(t, dir)
+
+	_, err := slingFormula(testOpts(agent, "carrierless"), deps)
+	if err != nil {
+		t.Fatalf("slingFormula: %v", err)
+	}
+	got := launchedRootScope(t, deps)
+	if !got.Valid() {
+		t.Fatalf("scope state = %v, want a present-valid field-empty object, never absent", got.State)
+	}
+}

--- a/internal/targetscope/declare.go
+++ b/internal/targetscope/declare.go
@@ -162,6 +162,47 @@ func Declare(store DeclareStore, memberID string, scope Scope) (Outcome, error) 
 	return OutcomeNoop, fmt.Errorf("%w: member %s lost the declaration race but shows no declared scope on re-read", ErrDeclarationRace, memberID)
 }
 
+// StampMemberScope declares a member scope with a plain, unfenced write, for the
+// specific callers whose single-writer exclusion comes from an EXTERNAL lock
+// rather than a store compare-and-set — a drain item's ItemRootKey lock, for
+// one. It exists so those callers are not FAIL-CLOSED when their store forwards
+// reads and writes but not the metadata-CAS capability (a decorating store, a
+// backend without value-CAS): the launch is served by a guarded stamp instead of
+// rejected.
+//
+// It is deliberately NOT a fallback inside Declare. Declare stays CAS-only with
+// no unfenced write path, because the general caller has no external lock and an
+// unfenced absent->value write there would reintroduce the lost-update race the
+// protocol exists to close. A caller reaches for this ONLY when it can name the
+// lock that serializes it.
+//
+// The IMMUTABILITY guard is preserved EXPLICITLY — it is the enforcement the CAS
+// would otherwise carry, and dropping the CAS without it would ship a silent
+// retarget. A present-valid-different member rejects, a present-valid-equal
+// member no-ops, an invalid one rejects, and only an absent member is written.
+// The ONLY thing given up versus Declare is the atomic absent->value transition,
+// which the caller's lock and a deterministic per-member scope make safe.
+func StampMemberScope(store beads.Store, memberID string, scope Scope) (Outcome, error) {
+	if memberID == "" {
+		return OutcomeNoop, fmt.Errorf("targetscope: stamp requires a member id")
+	}
+	blob, err := Marshal(scope)
+	if err != nil {
+		return OutcomeNoop, err
+	}
+	current, err := readDeclared(store, memberID)
+	if err != nil {
+		return OutcomeNoop, err
+	}
+	if decided, outcome, err := decideAgainst(current, scope, memberID); decided {
+		return outcome, err
+	}
+	if err := store.SetMetadata(memberID, beadmeta.TargetScopeMetadataKey, blob); err != nil {
+		return OutcomeNoop, fmt.Errorf("stamping target scope on %s: %w", memberID, err)
+	}
+	return OutcomeCommitted, nil
+}
+
 // raceBarrier, when set, runs between the read and the compare-and-set.
 //
 // It exists because the interleaving that makes an unconditional write unsafe

--- a/internal/targetscope/declare.go
+++ b/internal/targetscope/declare.go
@@ -1,0 +1,250 @@
+// Member declaration: the single-winner, immutable, pre-launch commit of a
+// member's target scope.
+//
+// WHY A MEMBER NEEDS ITS OWN DECLARATION. When a plain task T is launched as a
+// targeted graph workflow, the clean resolved scope reaches the generated
+// STAGES through the root-chain walk, but it does not reach T. Normalization
+// creates a separate convoy that merely TRACKS T; the targeted-graph branch
+// passes an empty source ID, so no back-link from T to the root is ever
+// written; and the inherited walk runs forward only, never in reverse along
+// convoy tracks. Meanwhile the close gate loads T ITSELF. So without a member
+// declaration, a freshly-launched scoped workflow still lets T's stale flat
+// keys be behaviorally authoritative — the exact poison the object exists to
+// kill. Stamping the scope onto T directly makes T authoritative with no
+// reverse walk anywhere.
+//
+// WHY SINGLE-WINNER EXCLUSION IS MANDATORY. SetMetadata is an UNCONDITIONAL
+// assignment on every backend. Two launches A and B that both read "absent" can
+// write different valid scopes X and Y in the order absent → X → Y, each
+// re-reading and seeing its own last write, and BOTH proceed — a two-winner
+// execution. Re-reading after an unconditional write can never turn
+// absent → value into an atomic transition, so there is deliberately NO
+// unfenced write path here: every declaration commits its read → decide → write
+// under a compare-and-set.
+//
+// PHASE ORDERING replaces the cross-store transaction we cannot have. A member
+// lives in its owning store while the workflow root lives in the graph store,
+// and no store-local transaction spans that seam. So all member declarations
+// commit BEFORE any root is materialized: a rejected or failed launch leaves
+// only immutable-correct member pins and no root or stages — nothing new to
+// orphan.
+//
+// PINS ARE DELIBERATE AND ARE NOT ROLLED BACK. A launch that rejects after some
+// members were declared leaves those declarations in place. They are safe not
+// because they are unobservable — a pinned member is a pre-existing Ready()
+// bead whose own dispatch reads the pin — but because the protocol only ever
+// commits the trusted-resolved value or rejects. A retry re-resolves the same
+// scope and no-ops. A retry that deliberately RETARGETS the member is rejected
+// by the immutability rule: the first declaration permanently binds the member,
+// even if no launch ever commits. Recovery from a deliberately-wrong first
+// declaration is an administrative act, because a blind rollback would
+// reintroduce the lost-update race this protocol exists to close.
+package targetscope
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// Outcome reports what a declaration did.
+type Outcome int
+
+const (
+	// OutcomeNoop means the member already carried an equal valid scope.
+	// Re-declaration is idempotent, which is what makes a retry after a
+	// partially-declared launch safe.
+	OutcomeNoop Outcome = iota
+	// OutcomeCommitted means this declarer won the compare-and-set.
+	OutcomeCommitted
+)
+
+func (o Outcome) String() string {
+	if o == OutcomeCommitted {
+		return "committed"
+	}
+	return "noop"
+}
+
+var (
+	// ErrDeclarationConflict reports that the member already carries a
+	// DIFFERENT valid scope. The launch must be rejected before any root is
+	// materialized. It is not retryable: member scope is immutable.
+	ErrDeclarationConflict = errors.New("target scope already declared with a different value")
+
+	// ErrDeclarationUnsupported reports that the member's store offers no
+	// metadata compare-and-set. The launch is rejected rather than served by
+	// an unserialized write.
+	ErrDeclarationUnsupported = errors.New("member store cannot declare a target scope: no metadata compare-and-set capability")
+
+	// ErrDeclarationRace reports that a concurrent declarer committed first
+	// and its value is not ours. The loser rejects, fail-closed.
+	ErrDeclarationRace = errors.New("target scope declared concurrently with a different value")
+)
+
+// DeclareStore is the store surface the protocol needs: read the member, and
+// compare-and-set one metadata key on it.
+type DeclareStore interface {
+	Get(id string) (beads.Bead, error)
+}
+
+// Declare commits scope onto member under a single-winner exclusion.
+//
+// The mechanism is chosen by the store's CAPABILITY, never by the operator's
+// conditional-writes mode. That mode encodes a policy about general fenced
+// updates — a different concern with a legacy path to fall back to. A member
+// declaration has no legacy path: the compare-and-set is its only correct
+// implementation, so gating it on a rollout flag would leave it with nothing
+// under the default. Capability is fixed per store, so every concurrent
+// declarer of one member uses the same mechanism and no mixed-mechanism race
+// is possible.
+//
+// Returns OutcomeNoop when the member already carries an equal scope, and an
+// error the caller must treat as a LAUNCH REJECTION in every other failing
+// case.
+func Declare(store DeclareStore, memberID string, scope Scope) (Outcome, error) {
+	if memberID == "" {
+		return OutcomeNoop, fmt.Errorf("targetscope: declare requires a member id")
+	}
+	blob, err := Marshal(scope)
+	if err != nil {
+		return OutcomeNoop, err
+	}
+	// The narrow metadata-CAS capability, NOT ResolveConditionalWriter. The
+	// latter deliberately refuses on stores whose revision fence is unsound,
+	// and that refusal must stay intact — a single-key value-CAS needs no
+	// revision token, so it is available on stores where the fenced trio is
+	// not.
+	casStore, ok := store.(beads.Store)
+	if !ok {
+		return OutcomeNoop, ErrDeclarationUnsupported
+	}
+	writer, ok := beads.MetadataCASWriterFor(casStore)
+	if !ok {
+		return OutcomeNoop, fmt.Errorf("%w: member %s", ErrDeclarationUnsupported, memberID)
+	}
+
+	current, err := readDeclared(store, memberID)
+	if err != nil {
+		return OutcomeNoop, err
+	}
+	if decided, outcome, err := decideAgainst(current, scope, memberID); decided {
+		return outcome, err
+	}
+
+	// Absent → declare. expected is the EXACT string read above: an empty
+	// expected matches a key that is absent or present-but-empty, which are
+	// indistinguishable to callers and are both "not yet declared" here.
+	declareRaceBarrier()
+	swapped, err := writer.CompareAndSetMetadataKey(memberID, beadmeta.TargetScopeMetadataKey, current.Raw, blob)
+	if err != nil {
+		// Includes stores that report conditional writes unsupported at the
+		// instance level (a read-only store, for one). Fail closed.
+		return OutcomeNoop, fmt.Errorf("declaring target scope on %s: %w", memberID, err)
+	}
+	if swapped {
+		return OutcomeCommitted, nil
+	}
+
+	// (false, nil) is a LOST RACE, not an error: another declarer moved the
+	// value between our read and our write. Re-read and re-apply the same
+	// decision. Converging on an equal value is benign; anything else — a
+	// different scope, a corrupt one, or a value that vanished again — rejects.
+	current, err = readDeclared(store, memberID)
+	if err != nil {
+		return OutcomeNoop, err
+	}
+	if decided, outcome, err := decideAgainst(current, scope, memberID); decided {
+		return outcome, err
+	}
+	return OutcomeNoop, fmt.Errorf("%w: member %s lost the declaration race but shows no declared scope on re-read", ErrDeclarationRace, memberID)
+}
+
+// raceBarrier, when set, runs between the read and the compare-and-set.
+//
+// It exists because the interleaving that makes an unconditional write unsafe
+// is the one the Go scheduler almost never produces on its own: with a fast
+// in-memory store, one declarer typically finishes entirely before the next
+// one reads, so the SECOND declarer's initial read catches the conflict and the
+// compare-and-set is never actually exercised. A race test without this hook
+// passes just as happily against a plainly-unsafe unconditional write, which
+// makes it worse than no test at all.
+//
+// Production cost is a nil check per declaration.
+var raceBarrier func()
+
+func declareRaceBarrier() {
+	if raceBarrier != nil {
+		raceBarrier()
+	}
+}
+
+// readDeclared loads the member and parses its current declaration.
+func readDeclared(store DeclareStore, memberID string) (Resolution, error) {
+	bead, err := store.Get(memberID)
+	if err != nil {
+		return Resolution{}, fmt.Errorf("reading target scope of %s: %w", memberID, err)
+	}
+	return Parse(bead.Metadata[beadmeta.TargetScopeMetadataKey]), nil
+}
+
+// decideAgainst applies the immutability rule to an observed declaration.
+//
+// decided=false means "absent — go declare"; every other state is terminal.
+func decideAgainst(current Resolution, want Scope, memberID string) (decided bool, outcome Outcome, err error) {
+	switch current.State {
+	case StateValid:
+		if current.Scope.Equal(want) {
+			return true, OutcomeNoop, nil
+		}
+		return true, OutcomeNoop, fmt.Errorf("%w: member %s is declared %s, launch resolved %s",
+			ErrDeclarationConflict, memberID, describe(current.Scope), describe(want))
+	case StateInvalid:
+		// Never overwrite a corrupt object: we cannot tell whether it encodes
+		// an intent we would be destroying.
+		return true, OutcomeNoop, fmt.Errorf("member %s carries an unusable target scope: %w", memberID, current.Reason)
+	default:
+		return false, OutcomeNoop, nil
+	}
+}
+
+func describe(s Scope) string {
+	branch := s.Branch
+	if branch == "" {
+		branch = "<unknown>"
+	}
+	worktree := s.Worktree
+	if worktree == "" {
+		worktree = "<unknown>"
+	}
+	return fmt.Sprintf("{branch:%s worktree:%s}", branch, worktree)
+}
+
+// Member pairs a member id with the scope resolved specifically FOR it.
+//
+// Scopes are per member on purpose. A heterogeneous convoy has no honest single
+// branch/worktree, and computing one winner across members by scanning them
+// would invent an authority that does not exist.
+type Member struct {
+	ID    string
+	Store DeclareStore
+	Scope Scope
+}
+
+// DeclareAll runs the declaration phase for every resolved member.
+//
+// It is the caller's contract that this completes successfully BEFORE the root
+// is materialized. On the first rejection it stops and returns the error, and
+// the caller must abandon the launch: declarations already committed stay
+// pinned (immutable-correct and retry-reusable), and because no root exists
+// yet, no claimable graph work has been orphaned.
+func DeclareAll(members []Member) error {
+	for _, m := range members {
+		if _, err := Declare(m.Store, m.ID, m.Scope); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/targetscope/declare_test.go
+++ b/internal/targetscope/declare_test.go
@@ -1,0 +1,351 @@
+package targetscope
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func newMember(t *testing.T, store *beads.MemStore, id string, metadata map[string]string) beads.Bead {
+	t.Helper()
+	bead, err := store.Create(beads.Bead{ID: id, Title: "member " + id, Metadata: metadata})
+	if err != nil {
+		t.Fatalf("creating member %s: %v", id, err)
+	}
+	return bead
+}
+
+func declaredScope(t *testing.T, store *beads.MemStore, id string) Resolution {
+	t.Helper()
+	bead, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("reading member %s: %v", id, err)
+	}
+	return Parse(bead.Metadata[beadmeta.TargetScopeMetadataKey])
+}
+
+func TestDeclareCommitsOnAbsent(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+	want := Scope{V: 1, Branch: "release", Worktree: "/srv/wt"}
+
+	outcome, err := Declare(store, member.ID, want)
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if outcome != OutcomeCommitted {
+		t.Fatalf("outcome = %v, want committed", outcome)
+	}
+	got := declaredScope(t, store, member.ID)
+	if !got.Valid() || !got.Scope.Equal(want) {
+		t.Fatalf("member carries %+v (%v), want %+v", got.Scope, got.State, want)
+	}
+}
+
+// Re-declaring the same scope must be a no-op. This is what makes a retry after
+// a partially-declared launch safe rather than a conflict.
+func TestDeclareIsIdempotent(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+	want := Scope{V: 1, Branch: "main"}
+
+	if _, err := Declare(store, member.ID, want); err != nil {
+		t.Fatalf("first Declare: %v", err)
+	}
+	outcome, err := Declare(store, member.ID, want)
+	if err != nil {
+		t.Fatalf("second Declare: %v", err)
+	}
+	if outcome != OutcomeNoop {
+		t.Fatalf("outcome = %v, want noop", outcome)
+	}
+}
+
+// Member scope is immutable: a deliberate retarget is rejected, not applied.
+func TestDeclareRejectsRetarget(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+	first := Scope{V: 1, Branch: "main"}
+	if _, err := Declare(store, member.ID, first); err != nil {
+		t.Fatalf("first Declare: %v", err)
+	}
+
+	_, err := Declare(store, member.ID, Scope{V: 1, Branch: "release"})
+	if !errors.Is(err, ErrDeclarationConflict) {
+		t.Fatalf("err = %v, want ErrDeclarationConflict", err)
+	}
+	// The original declaration must survive the rejected attempt.
+	got := declaredScope(t, store, member.ID)
+	if !got.Scope.Equal(first) {
+		t.Fatalf("member now carries %+v, want the original %+v", got.Scope, first)
+	}
+}
+
+// A corrupt object is never overwritten: we cannot tell what intent we would
+// be destroying, so the launch fails instead.
+func TestDeclareRejectsCorruptExistingScope(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", map[string]string{
+		beadmeta.TargetScopeMetadataKey: `{"v":99,"branch":"main"}`,
+	})
+
+	_, err := Declare(store, member.ID, Scope{V: 1, Branch: "main"})
+	if err == nil {
+		t.Fatal("Declare accepted a member carrying an unusable scope")
+	}
+	if !errors.Is(err, ErrInvalidScope) {
+		t.Fatalf("err = %v, want it to wrap ErrInvalidScope", err)
+	}
+	got, _ := store.Get(member.ID)
+	if got.Metadata[beadmeta.TargetScopeMetadataKey] != `{"v":99,"branch":"main"}` {
+		t.Fatal("the corrupt value was overwritten; it must be preserved for administrative recovery")
+	}
+}
+
+// Poisoned flat keys are NOT a scope. A member carrying only claim-derived
+// gc.work_* must read as absent so the declaration proceeds from trusted
+// sources — never laundering the poison into the new object.
+func TestDeclareTreatsPoisonedFlatKeysAsAbsent(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", map[string]string{
+		beadmeta.WorkBranchMetadataKey: "parked-branch",
+		beadmeta.WorkDirMetadataKey:    "/shared/poison",
+		beadmeta.WorkCommitMetadataKey: "deadbeef",
+	})
+	want := Scope{V: 1, Branch: "release", Worktree: "/srv/clean"}
+
+	outcome, err := Declare(store, member.ID, want)
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if outcome != OutcomeCommitted {
+		t.Fatalf("outcome = %v, want committed", outcome)
+	}
+	got := declaredScope(t, store, member.ID)
+	if got.Scope.Branch != "release" || got.Scope.Worktree != "/srv/clean" {
+		t.Fatalf("declared scope %+v must come from the trusted resolution, not the flat keys", got.Scope)
+	}
+}
+
+// A field-empty {v:1} is a legitimate declaration and must persist as VALID.
+// Declaring nothing at all would leave the member object-absent, which is what
+// re-enables the cwd stamp on the next claim.
+func TestDeclareUnknownPersistsAsValidNotAbsent(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+
+	if _, err := Declare(store, member.ID, Unknown()); err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	got := declaredScope(t, store, member.ID)
+	if got.State != StateValid {
+		t.Fatalf("state = %v, want valid", got.State)
+	}
+	if !got.Scope.IsUnknown() {
+		t.Fatalf("scope = %+v, want field-empty", got.Scope)
+	}
+}
+
+// rendezvous returns a barrier that blocks until n callers have reached it.
+//
+// Both declarers therefore complete their READ before either performs its
+// write, which is the only interleaving under which an unsafe unconditional
+// write produces two winners. Without this, the scheduler serializes the two
+// goroutines and the test silently degrades into "the second declarer's read
+// saw the first one's value" — which passes even when the write is unsafe.
+func rendezvous(n int) func() {
+	var mu sync.Mutex
+	arrived := 0
+	gate := make(chan struct{})
+	return func() {
+		mu.Lock()
+		arrived++
+		if arrived == n {
+			close(gate)
+		}
+		mu.Unlock()
+		<-gate
+	}
+}
+
+// THE RACE. Two concurrent launches resolving DIFFERENT valid scopes for one
+// member must never both proceed: exactly one commits, the other is rejected
+// before any root is materialized.
+//
+// GUARD: this test is verified to FAIL if the compare-and-set is replaced by an
+// unconditional SetMetadata. See TestDeclareRaceBarrierActuallyInterleaves for
+// the assertion that keeps the barrier honest.
+func TestDeclareRaceHasExactlyOneWinner(t *testing.T) {
+	for attempt := 0; attempt < 200; attempt++ {
+		store := beads.NewMemStore()
+		member := newMember(t, store, "", nil)
+		scopeX := Scope{V: 1, Branch: "branch-x"}
+		scopeY := Scope{V: 1, Branch: "branch-y"}
+
+		raceBarrier = rendezvous(2)
+
+		var wg sync.WaitGroup
+		results := make([]error, 2)
+		outcomes := make([]Outcome, 2)
+		start := make(chan struct{})
+		for i, scope := range []Scope{scopeX, scopeY} {
+			wg.Add(1)
+			go func(i int, scope Scope) {
+				defer wg.Done()
+				<-start
+				outcomes[i], results[i] = Declare(store, member.ID, scope)
+			}(i, scope)
+		}
+		close(start)
+		wg.Wait()
+		raceBarrier = nil
+
+		winners := 0
+		for i := range results {
+			if results[i] == nil && outcomes[i] == OutcomeCommitted {
+				winners++
+			}
+		}
+		if winners != 1 {
+			t.Fatalf("attempt %d: %d winners, want exactly 1 (errs: %v, %v)", attempt, winners, results[0], results[1])
+		}
+		// The loser must have been rejected, and the member must carry exactly
+		// one of the two scopes — never a blend, never the loser's value.
+		final := declaredScope(t, store, member.ID)
+		if !final.Valid() {
+			t.Fatalf("attempt %d: member ended %v, want a single valid scope", attempt, final.State)
+		}
+		if !final.Scope.Equal(scopeX) && !final.Scope.Equal(scopeY) {
+			t.Fatalf("attempt %d: member carries %+v, want exactly one of the two declared scopes", attempt, final.Scope)
+		}
+		// And the committed value must be the winner's.
+		for i, scope := range []Scope{scopeX, scopeY} {
+			if results[i] == nil && outcomes[i] == OutcomeCommitted && !final.Scope.Equal(scope) {
+				t.Fatalf("attempt %d: winner declared %+v but member carries %+v", attempt, scope, final.Scope)
+			}
+		}
+	}
+}
+
+// Two concurrent launches resolving the SAME scope both succeed — convergence,
+// not a spurious rejection.
+func TestDeclareRaceWithEqualScopesConverges(t *testing.T) {
+	for attempt := 0; attempt < 200; attempt++ {
+		store := beads.NewMemStore()
+		member := newMember(t, store, "", nil)
+		scope := Scope{V: 1, Branch: "same", Worktree: "/srv/wt"}
+
+		raceBarrier = rendezvous(4)
+
+		var wg sync.WaitGroup
+		results := make([]error, 4)
+		for i := range results {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				_, results[i] = Declare(store, member.ID, scope)
+			}(i)
+		}
+		wg.Wait()
+		raceBarrier = nil
+
+		for i, err := range results {
+			if err != nil {
+				t.Fatalf("attempt %d: declarer %d rejected an equal scope: %v", attempt, i, err)
+			}
+		}
+	}
+}
+
+// Keeps the race test honest.
+//
+// The barrier is only reached by a declarer whose FIRST read found the scope
+// absent — decideAgainst returns early otherwise. So observing the barrier
+// entered once per declarer proves both reached the write window believing
+// they were the first, which is precisely the interleaving under which an
+// unconditional write would produce two winners. If this count ever drops to 1,
+// the race test above has silently stopped testing anything.
+func TestDeclareRaceBarrierActuallyInterleaves(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+
+	var mu sync.Mutex
+	entered := 0
+	inner := rendezvous(2)
+	raceBarrier = func() {
+		mu.Lock()
+		entered++
+		mu.Unlock()
+		inner()
+	}
+	defer func() { raceBarrier = nil }()
+
+	var wg sync.WaitGroup
+	for _, scope := range []Scope{{V: 1, Branch: "x"}, {V: 1, Branch: "y"}} {
+		wg.Add(1)
+		go func(scope Scope) {
+			defer wg.Done()
+			_, _ = Declare(store, member.ID, scope)
+		}(scope)
+	}
+	wg.Wait()
+
+	if entered != 2 {
+		t.Fatalf("write window entered %d times, want 2: both declarers must reach the "+
+			"compare-and-set having read absent, or the race test proves nothing", entered)
+	}
+}
+
+// A store with no compare-and-set capability must be REJECTED, never served by
+// an unserialized write. Fail-closed is the whole guarantee.
+func TestDeclareRejectsStoreWithoutCAS(t *testing.T) {
+	_, err := Declare(noCASStore{}, "member-1", Scope{V: 1, Branch: "main"})
+	if !errors.Is(err, ErrDeclarationUnsupported) {
+		t.Fatalf("err = %v, want ErrDeclarationUnsupported", err)
+	}
+}
+
+// DeclareAll stops at the first rejection. Members already declared stay
+// pinned; the caller must abandon the launch before materializing a root.
+func TestDeclareAllStopsAtFirstRejection(t *testing.T) {
+	store := beads.NewMemStore()
+	good := newMember(t, store, "", nil)
+	conflicted := newMember(t, store, "", nil)
+	if _, err := Declare(store, conflicted.ID, Scope{V: 1, Branch: "already"}); err != nil {
+		t.Fatalf("seeding conflict: %v", err)
+	}
+
+	err := DeclareAll([]Member{
+		{ID: good.ID, Store: store, Scope: Scope{V: 1, Branch: "wanted"}},
+		{ID: conflicted.ID, Store: store, Scope: Scope{V: 1, Branch: "wanted"}},
+	})
+	if !errors.Is(err, ErrDeclarationConflict) {
+		t.Fatalf("err = %v, want ErrDeclarationConflict", err)
+	}
+	// The already-committed pin is deliberately NOT rolled back.
+	if got := declaredScope(t, store, good.ID); !got.Valid() || got.Scope.Branch != "wanted" {
+		t.Fatalf("first member lost its pin (%+v); declarations are not rolled back", got.Scope)
+	}
+}
+
+// noCASStore implements just enough of beads.Store to be handed to Declare
+// while offering no metadata compare-and-set.
+type noCASStore struct{ beads.Store }
+
+func (noCASStore) Get(id string) (beads.Bead, error) {
+	return beads.Bead{ID: id}, nil
+}
+
+var _ DeclareStore = noCASStore{}
+
+func TestDescribeNamesUnknownFields(t *testing.T) {
+	got := describe(Scope{V: 1, Branch: "main"})
+	want := fmt.Sprintf("{branch:%s worktree:%s}", "main", "<unknown>")
+	if got != want {
+		t.Fatalf("describe = %q, want %q", got, want)
+	}
+}

--- a/internal/targetscope/launch.go
+++ b/internal/targetscope/launch.go
@@ -78,6 +78,25 @@ func PrepareLaunch(recipe *formula.Recipe, scope Scope, members []Member) error 
 	return StampRoot(recipe, scope)
 }
 
+// DeclaresVar reports whether a resolved formula declares a variable, which is
+// what makes it a carrier the formula actually consumes.
+//
+// Carrier presence is derived from the RESOLVED FORMULA'S DECLARED VARS, never
+// from the formula-name predicates. The predicates model what routing injects
+// today and are the right authority for that layer alone; a formula that
+// declares base_branch without matching a name pattern still consumes it.
+//
+// Every boundary shares this one implementation, because two boundaries
+// disagreeing about which carrier a formula consumes is exactly how the scope
+// object and the substituted text drift apart.
+func DeclaresVar(f *formula.Formula, name string) bool {
+	if f == nil || len(f.Vars) == 0 {
+		return false
+	}
+	_, ok := f.Vars[name]
+	return ok
+}
+
 // FormulaDefaultVars extracts the [vars.*].default layer as a plain map.
 //
 // This layer is a trusted source (§3a, lowest precedence) and including it is

--- a/internal/targetscope/launch.go
+++ b/internal/targetscope/launch.go
@@ -23,11 +23,14 @@ import (
 // StampMetadata writes scope into a metadata map, allocating one when meta is
 // nil, and returns the map for the caller to assign back.
 //
-// It is the only writer of the metadata key outside the member-declaration
-// protocol, and it is deliberately confined to values that have not been
-// materialized yet: recipe steps before instantiation. A bead that already
-// exists is declared, never stamped, because only the declaration protocol
-// carries the single-winner exclusion.
+// It writes recipe-step metadata that has not been materialized yet — steps
+// before instantiation — so a freshly launched root carries a scope from birth.
+// It is NOT the whole story of who writes the key: an already-existing bead is
+// normally *declared* (the CAS single-winner protocol) rather than stamped,
+// with one deliberate exception — a legacy `--on` attach stamps its claimable
+// SOURCE bead through sling.stampClaimableSourceScope (a plain SetMetadata,
+// best-effort, not serialized for concurrent unscoped-bead attaches). See that
+// function's doc for the honest single-writer guarantee.
 func StampMetadata(meta map[string]string, scope Scope) (map[string]string, error) {
 	blob, err := Marshal(scope)
 	if err != nil {

--- a/internal/targetscope/launch.go
+++ b/internal/targetscope/launch.go
@@ -1,0 +1,103 @@
+// Launch phase: declare every member, then stamp the root.
+//
+// The design (§5) requires scope stamping at EVERY root-creation boundary and
+// warns against silent holes. The defence against a hole is not diligence at
+// seven call sites — it is that all seven call ONE function, so a boundary can
+// only be wrong by not calling it at all, never by calling it differently.
+//
+// PHASE ORDER IS THE INVARIANT. Every member declaration commits before the
+// root is materialized. That ordering is what makes a rejected launch safe:
+// the declarations that did commit are immutable-correct and reusable by a
+// retry, and because no root exists yet, no claimable graph work is orphaned.
+// Stamping the root before declaring members would invert this and leave a
+// live root pointing at members that then refuse to declare.
+package targetscope
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+// StampMetadata writes scope into a metadata map, allocating one when meta is
+// nil, and returns the map for the caller to assign back.
+//
+// It is the only writer of the metadata key outside the member-declaration
+// protocol, and it is deliberately confined to values that have not been
+// materialized yet: recipe steps before instantiation. A bead that already
+// exists is declared, never stamped, because only the declaration protocol
+// carries the single-winner exclusion.
+func StampMetadata(meta map[string]string, scope Scope) (map[string]string, error) {
+	blob, err := Marshal(scope)
+	if err != nil {
+		return meta, err
+	}
+	if meta == nil {
+		meta = make(map[string]string, 1)
+	}
+	meta[beadmeta.TargetScopeMetadataKey] = blob
+	return meta, nil
+}
+
+// StampRoot writes the resolved scope onto a recipe's root step.
+//
+// Only the root is stamped. Generated stages inherit through the root chain
+// that ResolveInherited walks, so stamping each stage would duplicate a fact
+// that already has one home and invite the two copies to disagree.
+//
+// An unknown scope is stamped, not skipped: §2c requires a boundary to leave a
+// present-valid field-empty object rather than nothing at all. Absence is what
+// lets a later claim or reconcile write cwd; a field-empty object is what
+// makes the readers report unknown and refuse the flat fallback.
+func StampRoot(recipe *formula.Recipe, scope Scope) error {
+	if recipe == nil || len(recipe.Steps) == 0 {
+		return fmt.Errorf("targetscope: cannot stamp a recipe with no steps")
+	}
+	root := &recipe.Steps[0]
+	meta, err := StampMetadata(root.Metadata, scope)
+	if err != nil {
+		return fmt.Errorf("stamping target scope on recipe root: %w", err)
+	}
+	root.Metadata = meta
+	return nil
+}
+
+// PrepareLaunch runs the pre-materialization phase for one launch: declare
+// every resolved member under its single-winner exclusion, then stamp the
+// root.
+//
+// The caller must treat any error as a LAUNCH REJECTION and materialize
+// nothing. That is the whole point of running before materialization: a
+// rejection here costs a launch, whereas the same rejection after the root
+// exists costs an orphaned graph.
+func PrepareLaunch(recipe *formula.Recipe, scope Scope, members []Member) error {
+	if err := DeclareAll(members); err != nil {
+		return err
+	}
+	return StampRoot(recipe, scope)
+}
+
+// FormulaDefaultVars extracts the [vars.*].default layer as a plain map.
+//
+// This layer is a trusted source (§3a, lowest precedence) and including it is
+// what keeps the scope object and the consumed carrier identical in the
+// default-only case: with no branch supplied anywhere, scope.branch and the
+// carrier the formula substitutes must both be the formula's own default,
+// rather than the scope being unknown while substitution quietly uses it.
+func FormulaDefaultVars(f *formula.Formula) map[string]string {
+	if f == nil || len(f.Vars) == 0 {
+		return nil
+	}
+	defaults := make(map[string]string, len(f.Vars))
+	for name, def := range f.Vars {
+		if def == nil || def.Default == nil {
+			continue
+		}
+		defaults[name] = *def.Default
+	}
+	if len(defaults) == 0 {
+		return nil
+	}
+	return defaults
+}

--- a/internal/targetscope/launch_test.go
+++ b/internal/targetscope/launch_test.go
@@ -1,0 +1,185 @@
+package targetscope
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+func recipeWithRoot() *formula.Recipe {
+	return &formula.Recipe{Steps: []formula.RecipeStep{{ID: "root", Title: "root"}}}
+}
+
+func rootScope(t *testing.T, recipe *formula.Recipe) Resolution {
+	t.Helper()
+	return Parse(recipe.Steps[0].Metadata[beadmeta.TargetScopeMetadataKey])
+}
+
+func TestStampRootWritesParsableScope(t *testing.T) {
+	recipe := recipeWithRoot()
+	want := Scope{V: 1, Branch: "release", Worktree: "/srv/wt"}
+
+	if err := StampRoot(recipe, want); err != nil {
+		t.Fatalf("StampRoot: %v", err)
+	}
+	got := rootScope(t, recipe)
+	if !got.Valid() || !got.Scope.Equal(want) {
+		t.Fatalf("root carries %+v (%v), want %+v", got.Scope, got.State, want)
+	}
+}
+
+// §2c: a boundary that cannot resolve a scope must leave a present-valid
+// field-empty object, never nothing. Absence is what lets a later claim or
+// reconcile write cwd, so "unknown" has to be stamped rather than skipped.
+func TestStampRootStampsUnknownRatherThanSkipping(t *testing.T) {
+	recipe := recipeWithRoot()
+
+	if err := StampRoot(recipe, Unknown()); err != nil {
+		t.Fatalf("StampRoot: %v", err)
+	}
+	got := rootScope(t, recipe)
+	if !got.Valid() {
+		t.Fatalf("unknown scope resolved %v, want a present-valid object", got.State)
+	}
+	if !got.Scope.IsUnknown() {
+		t.Fatalf("stamped %+v, want field-empty", got.Scope)
+	}
+}
+
+func TestStampRootPreservesExistingMetadata(t *testing.T) {
+	recipe := recipeWithRoot()
+	recipe.Steps[0].Metadata = map[string]string{"gc.kind": "workflow"}
+
+	if err := StampRoot(recipe, Scope{V: 1, Branch: "main"}); err != nil {
+		t.Fatalf("StampRoot: %v", err)
+	}
+	if got := recipe.Steps[0].Metadata["gc.kind"]; got != "workflow" {
+		t.Fatalf("gc.kind = %q, want it preserved", got)
+	}
+}
+
+func TestStampRootRejectsSteplessRecipe(t *testing.T) {
+	if err := StampRoot(&formula.Recipe{}, Scope{V: 1}); err == nil {
+		t.Fatal("stamping a recipe with no steps succeeded, want an error")
+	}
+	if err := StampRoot(nil, Scope{V: 1}); err == nil {
+		t.Fatal("stamping a nil recipe succeeded, want an error")
+	}
+}
+
+// Only the root is stamped: stages inherit through the root chain, and a
+// second copy on every stage is a second thing that can disagree.
+func TestStampRootLeavesStagesUnstamped(t *testing.T) {
+	recipe := &formula.Recipe{Steps: []formula.RecipeStep{{ID: "root"}, {ID: "stage-1"}}}
+
+	if err := StampRoot(recipe, Scope{V: 1, Branch: "main"}); err != nil {
+		t.Fatalf("StampRoot: %v", err)
+	}
+	if _, ok := recipe.Steps[1].Metadata[beadmeta.TargetScopeMetadataKey]; ok {
+		t.Fatal("stage carries its own target scope, want inheritance through the root")
+	}
+}
+
+func TestPrepareLaunchDeclaresMembersAndStampsRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+	recipe := recipeWithRoot()
+	want := Scope{V: 1, Branch: "release", Worktree: "/srv/wt"}
+
+	err := PrepareLaunch(recipe, want, []Member{{ID: member.ID, Store: store, Scope: want}})
+	if err != nil {
+		t.Fatalf("PrepareLaunch: %v", err)
+	}
+	if got := declaredScope(t, store, member.ID); !got.Valid() || !got.Scope.Equal(want) {
+		t.Fatalf("member carries %+v (%v), want %+v", got.Scope, got.State, want)
+	}
+	if got := rootScope(t, recipe); !got.Valid() || !got.Scope.Equal(want) {
+		t.Fatalf("root carries %+v (%v), want %+v", got.Scope, got.State, want)
+	}
+}
+
+// THE PHASE-ORDER INVARIANT. A member that refuses to declare must abort the
+// launch with the root still unstamped, so the caller cannot materialize a
+// root that points at members which never accepted the scope.
+//
+// This asserts the ORDER, not just the error: an implementation that stamped
+// first and declared second would return the same error and still be wrong.
+func TestPrepareLaunchLeavesRootUnstampedWhenAMemberRejects(t *testing.T) {
+	store := beads.NewMemStore()
+	declared := Scope{V: 1, Branch: "main"}
+	member := newMember(t, store, "", nil)
+	if _, err := Declare(store, member.ID, declared); err != nil {
+		t.Fatalf("seeding the declared member: %v", err)
+	}
+	recipe := recipeWithRoot()
+
+	conflicting := Scope{V: 1, Branch: "release"}
+	err := PrepareLaunch(recipe, conflicting, []Member{{ID: member.ID, Store: store, Scope: conflicting}})
+	if !errors.Is(err, ErrDeclarationConflict) {
+		t.Fatalf("PrepareLaunch error = %v, want a declaration conflict", err)
+	}
+	if _, ok := recipe.Steps[0].Metadata[beadmeta.TargetScopeMetadataKey]; ok {
+		t.Fatal("root was stamped despite a rejected member: the launch phase ran out of order")
+	}
+	if got := declaredScope(t, store, member.ID); !got.Scope.Equal(declared) {
+		t.Fatalf("member scope changed to %+v, want the immutable %+v", got.Scope, declared)
+	}
+}
+
+// A rejection partway through a multi-member set leaves the earlier
+// declarations committed. They are immutable-correct and a retry re-declares
+// them as no-ops; rolling them back would reintroduce the lost-update race.
+func TestPrepareLaunchKeepsEarlierDeclarationsOnLaterRejection(t *testing.T) {
+	store := beads.NewMemStore()
+	want := Scope{V: 1, Branch: "release"}
+	first := newMember(t, store, "", nil)
+	blocked := newMember(t, store, "", nil)
+	if _, err := Declare(store, blocked.ID, Scope{V: 1, Branch: "main"}); err != nil {
+		t.Fatalf("seeding the blocked member: %v", err)
+	}
+	recipe := recipeWithRoot()
+
+	err := PrepareLaunch(recipe, want, []Member{
+		{ID: first.ID, Store: store, Scope: want},
+		{ID: blocked.ID, Store: store, Scope: want},
+	})
+	if !errors.Is(err, ErrDeclarationConflict) {
+		t.Fatalf("PrepareLaunch error = %v, want a declaration conflict", err)
+	}
+	if got := declaredScope(t, store, first.ID); !got.Valid() || !got.Scope.Equal(want) {
+		t.Fatalf("first member carries %+v (%v), want its committed %+v", got.Scope, got.State, want)
+	}
+}
+
+func TestFormulaDefaultVarsReadsTheDefaultLayer(t *testing.T) {
+	main := "main"
+	noDefault := &formula.VarDef{}
+	f := &formula.Formula{Vars: map[string]*formula.VarDef{
+		"base_branch": {Default: &main},
+		"issue":       noDefault,
+		"nil_def":     nil,
+	}}
+
+	got := FormulaDefaultVars(f)
+	if got["base_branch"] != "main" {
+		t.Fatalf("base_branch default = %q, want main", got["base_branch"])
+	}
+	if _, ok := got["issue"]; ok {
+		t.Fatal("a var with no default leaked into the defaults layer")
+	}
+	if _, ok := got["nil_def"]; ok {
+		t.Fatal("a nil var definition leaked into the defaults layer")
+	}
+}
+
+func TestFormulaDefaultVarsHandlesEmptyFormula(t *testing.T) {
+	if got := FormulaDefaultVars(nil); got != nil {
+		t.Fatalf("nil formula produced %v, want nil", got)
+	}
+	if got := FormulaDefaultVars(&formula.Formula{}); got != nil {
+		t.Fatalf("formula with no vars produced %v, want nil", got)
+	}
+}

--- a/internal/targetscope/resolve.go
+++ b/internal/targetscope/resolve.go
@@ -1,6 +1,7 @@
 package targetscope
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -29,8 +30,12 @@ type BeadGetter interface {
 // absent would re-enable the cwd writers. Absent is returned only when the walk
 // completes having seen no value at all.
 //
-// A store error mid-walk is likewise INVALID, never absent: "I could not read
-// the scope" must never be permission to stamp cwd.
+// A TRANSPORT error mid-walk is likewise INVALID, never absent: "I could not
+// read the scope" must never be permission to stamp cwd. A dangling ancestor
+// reference is the ONE exception: a not-found ancestor is a definite answer
+// ("that bead is gone"), not a read failure, so the walk skips it and may still
+// return absent — an existing unscoped bead whose lineage pointer is stale must
+// keep its legacy behavior rather than flip to invalid. See inheritedNext.
 func ResolveInherited(store BeadGetter, bead beads.Bead) Resolution {
 	if raw := bead.Metadata[beadmeta.TargetScopeMetadataKey]; raw != "" {
 		return Parse(raw)
@@ -61,10 +66,20 @@ func ResolveInherited(store BeadGetter, bead beads.Bead) Resolution {
 // inheritedNext advances one hop along the parent chain then the root chain,
 // returning nil when the walk is exhausted.
 //
-// A Get failure is reported rather than swallowed. dispatch's flat-key walk
-// treats an unreadable ancestor as "no value here, carry on", which is right
-// for a best-effort string but wrong for a guard: a transient store error would
-// silently become "unscoped" and unlock the cwd stamp.
+// A TRANSPORT failure is reported rather than swallowed: a transient store error
+// must not silently become "unscoped" and unlock the cwd stamp — that is the
+// distinction from dispatch's best-effort flat-key walk, which carries on past
+// any read error.
+//
+// A not-found ancestor is treated differently, and deliberately: it is a
+// DEFINITE answer, not a read failure. A stale ParentID or gc.root_bead_id — a
+// stage whose ephemeral wisp root was cleaned up is the common case — means
+// "there is no scope up this link", so the walk skips that candidate and, if the
+// whole chain is exhausted, returns absent. Folding not-found into the transport
+// bucket would flip an existing unscoped bead with a dangling lineage pointer
+// from absent to invalid, standing the cwd writers down and warning the close
+// gate — a behavior change for a bead that carries no scope. Only a genuine
+// transport error stays fail-closed.
 func inheritedNext(store BeadGetter, current beads.Bead, visited map[string]struct{}) (*beads.Bead, error) {
 	for _, candidate := range []string{current.ParentID, current.Metadata[beadmeta.RootBeadIDMetadataKey]} {
 		if candidate == "" || candidate == current.ID {
@@ -76,6 +91,9 @@ func inheritedNext(store BeadGetter, current beads.Bead, visited map[string]stru
 		visited[candidate] = struct{}{}
 		next, err := store.Get(candidate)
 		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
 			return nil, err
 		}
 		return &next, nil

--- a/internal/targetscope/resolve.go
+++ b/internal/targetscope/resolve.go
@@ -1,0 +1,144 @@
+package targetscope
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/pathutil"
+)
+
+// BeadGetter is the one store capability the inherited walk needs. Narrowing it
+// here keeps the readers (close gate, Ralph) free to pass whatever store class
+// wrapper they already hold.
+type BeadGetter interface {
+	Get(id string) (beads.Bead, error)
+}
+
+// ResolveInherited finds the scope governing bead by walking bead → ParentID →
+// gc.root_bead_id, mirroring dispatch.resolveInheritedMetadata.
+//
+// The walk exists because formula-generated stages do NOT carry a copy of root
+// metadata — they carry a symbolic root reference — so a bead-local read would
+// miss precisely the uncovered class this object was built for.
+//
+// The FIRST reachable non-empty value decides, and it decides in all three
+// directions: if that value fails to parse, the answer is INVALID, not "keep
+// walking" and not absent. Continuing past a malformed object would let a
+// corrupt near value be silently replaced by a valid far one; degrading it to
+// absent would re-enable the cwd writers. Absent is returned only when the walk
+// completes having seen no value at all.
+//
+// A store error mid-walk is likewise INVALID, never absent: "I could not read
+// the scope" must never be permission to stamp cwd.
+func ResolveInherited(store BeadGetter, bead beads.Bead) Resolution {
+	if raw := bead.Metadata[beadmeta.TargetScopeMetadataKey]; raw != "" {
+		return Parse(raw)
+	}
+	if store == nil {
+		return Resolution{State: StateAbsent}
+	}
+	current := bead
+	visited := map[string]struct{}{}
+	for {
+		next, err := inheritedNext(store, current, visited)
+		if err != nil {
+			return Resolution{
+				State:  StateInvalid,
+				Reason: fmt.Errorf("%w: reading inherited scope from %s: %v", ErrInvalidScope, current.ID, err),
+			}
+		}
+		if next == nil {
+			return Resolution{State: StateAbsent}
+		}
+		current = *next
+		if raw := current.Metadata[beadmeta.TargetScopeMetadataKey]; raw != "" {
+			return Parse(raw)
+		}
+	}
+}
+
+// inheritedNext advances one hop along the parent chain then the root chain,
+// returning nil when the walk is exhausted.
+//
+// A Get failure is reported rather than swallowed. dispatch's flat-key walk
+// treats an unreadable ancestor as "no value here, carry on", which is right
+// for a best-effort string but wrong for a guard: a transient store error would
+// silently become "unscoped" and unlock the cwd stamp.
+func inheritedNext(store BeadGetter, current beads.Bead, visited map[string]struct{}) (*beads.Bead, error) {
+	for _, candidate := range []string{current.ParentID, current.Metadata[beadmeta.RootBeadIDMetadataKey]} {
+		if candidate == "" || candidate == current.ID {
+			continue
+		}
+		if _, seen := visited[candidate]; seen {
+			continue
+		}
+		visited[candidate] = struct{}{}
+		next, err := store.Get(candidate)
+		if err != nil {
+			return nil, err
+		}
+		return &next, nil
+	}
+	return nil, nil
+}
+
+// Envelope is the containment policy applied to a scope worktree before it is
+// handed to git. It mirrors Ralph's existing rule: the path must sit under the
+// city root or the store root.
+type Envelope struct {
+	CityPath  string
+	StorePath string
+}
+
+// Contains reports whether path sits inside the envelope. An envelope with no
+// roots configured contains nothing — an unconfigured envelope must fail closed
+// rather than wave everything through.
+func (e Envelope) Contains(path string) bool {
+	if path == "" {
+		return false
+	}
+	if e.CityPath != "" && pathutil.PathWithin(e.CityPath, path) {
+		return true
+	}
+	if e.StorePath != "" && pathutil.PathWithin(e.StorePath, path) {
+		return true
+	}
+	return false
+}
+
+// CheckWorktree validates a resolved scope's worktree for a reader.
+//
+// Parse has already rejected relative and uncleaned values; this adds the
+// envelope check that keeps `git -C` from being pointed at a repo outside the
+// city. Inherited metadata is mutable, so readers re-check rather than trusting
+// that the boundary got it right.
+//
+// A scope with no worktree passes: unknown is a legitimate value and the caller
+// decides what to do without one.
+func (e Envelope) CheckWorktree(scope Scope) error {
+	if scope.Worktree == "" {
+		return nil
+	}
+	if !e.Contains(scope.Worktree) {
+		return fmt.Errorf("%w: worktree %q escapes both city and store roots", ErrInvalidScope, scope.Worktree)
+	}
+	return nil
+}
+
+// ResolveForReader is the one call a behavior-critical consumer makes.
+//
+// It performs the inherited walk and then applies envelope containment,
+// folding an escaping worktree into StateInvalid so a reader has exactly one
+// tri-state to branch on. Readers must treat StateInvalid as a failure of the
+// scoped read — never as license to fall back to the flat gc.work_* keys.
+func ResolveForReader(store BeadGetter, bead beads.Bead, envelope Envelope) Resolution {
+	res := ResolveInherited(store, bead)
+	if res.State != StateValid {
+		return res
+	}
+	if err := envelope.CheckWorktree(res.Scope); err != nil {
+		return Resolution{State: StateInvalid, Reason: err, Raw: res.Raw}
+	}
+	return res
+}

--- a/internal/targetscope/resolve_test.go
+++ b/internal/targetscope/resolve_test.go
@@ -1,0 +1,89 @@
+package targetscope
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// fakeGetter is a minimal BeadGetter that serves the beads it knows and returns
+// a caller-chosen error for everything else — so a test can tell a not-found
+// ancestor apart from a transport failure, the exact distinction the inherited
+// walk now makes.
+type fakeGetter struct {
+	byID    map[string]beads.Bead
+	missErr error
+}
+
+func (f fakeGetter) Get(id string) (beads.Bead, error) {
+	if b, ok := f.byID[id]; ok {
+		return b, nil
+	}
+	return beads.Bead{}, f.missErr
+}
+
+func unscoped(id string, meta map[string]string) beads.Bead {
+	return beads.Bead{ID: id, Metadata: meta}
+}
+
+// A dangling gc.root_bead_id (the ancestor was cleaned up) must resolve ABSENT,
+// not INVALID: an existing unscoped bead with a stale lineage pointer keeps its
+// legacy claim/reconcile behavior. This is the regression guard for the flip
+// that folding not-found into the transport bucket would cause.
+func TestResolveInheritedDanglingRootStaysAbsent(t *testing.T) {
+	store := fakeGetter{byID: map[string]beads.Bead{}, missErr: beads.ErrNotFound}
+	bead := unscoped("stage", map[string]string{beadmeta.RootBeadIDMetadataKey: "gone-root"})
+	if res := ResolveInherited(store, bead); res.State != StateAbsent {
+		t.Fatalf("dangling root: state = %s (reason=%v), want absent", res.State, res.Reason)
+	}
+}
+
+// A dangling ParentID must likewise be skipped, not fail the walk.
+func TestResolveInheritedDanglingParentStaysAbsent(t *testing.T) {
+	store := fakeGetter{byID: map[string]beads.Bead{}, missErr: beads.ErrNotFound}
+	bead := beads.Bead{ID: "stage", ParentID: "gone-parent"}
+	if res := ResolveInherited(store, bead); res.State != StateAbsent {
+		t.Fatalf("dangling parent: state = %s (reason=%v), want absent", res.State, res.Reason)
+	}
+}
+
+// A TRANSPORT error mid-walk stays fail-closed (INVALID) — the not-found
+// exception must not weaken the guard against a transient store failure
+// silently unlocking the cwd stamp.
+func TestResolveInheritedTransportErrorIsInvalid(t *testing.T) {
+	store := fakeGetter{byID: map[string]beads.Bead{}, missErr: errors.New("dial tcp: i/o timeout")}
+	bead := unscoped("stage", map[string]string{beadmeta.RootBeadIDMetadataKey: "unreadable-root"})
+	res := ResolveInherited(store, bead)
+	if res.State != StateInvalid {
+		t.Fatalf("transport error: state = %s, want invalid", res.State)
+	}
+	if !errors.Is(res.Reason, ErrInvalidScope) {
+		t.Fatalf("transport error reason = %v, want wrapped ErrInvalidScope", res.Reason)
+	}
+}
+
+// A dangling ParentID must be skipped so the walk still reaches a VALID scope on
+// the root chain — not-found on one link does not abort the whole walk.
+func TestResolveInheritedDanglingParentFallsThroughToRootScope(t *testing.T) {
+	rootScope, err := Marshal(Scope{V: SchemaVersion, Branch: "release"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	root := unscoped("root", map[string]string{beadmeta.TargetScopeMetadataKey: rootScope})
+	store := fakeGetter{byID: map[string]beads.Bead{"root": root}, missErr: beads.ErrNotFound}
+	bead := beads.Bead{ID: "stage", ParentID: "gone-parent", Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "root"}}
+	res := ResolveInherited(store, bead)
+	if res.State != StateValid || res.Scope.Branch != "release" {
+		t.Fatalf("dangling parent + scoped root: state=%s branch=%q, want valid/release", res.State, res.Scope.Branch)
+	}
+}
+
+// Control: a clean unscoped bead with no ancestor references resolves absent.
+func TestResolveInheritedCleanUnscopedIsAbsent(t *testing.T) {
+	store := fakeGetter{byID: map[string]beads.Bead{}, missErr: beads.ErrNotFound}
+	if res := ResolveInherited(store, beads.Bead{ID: "lone"}); res.State != StateAbsent {
+		t.Fatalf("clean unscoped: state = %s, want absent", res.State)
+	}
+}

--- a/internal/targetscope/resolver.go
+++ b/internal/targetscope/resolver.go
@@ -1,0 +1,281 @@
+// Trusted-source resolution of the target scope, and the write-back that keeps
+// the workflow's consumed branch variable equal to the declared scope branch.
+//
+// THE SPLIT THIS CLOSES. Resolving a winner for the scope OBJECT alone is not
+// enough. The workflow never reads gc.target_scope — template substitution
+// reads the flattened formula-variable map, and mol-scoped-work consumes
+// {{base_branch}} as the actual worktree base and diff base. Injecting the
+// routed branch into base_branch INDEPENDENTLY of scope resolution lets an
+// explicit gc_target_branch=release land on the object while base_branch=main
+// stays in the consumed map: the workflow then executes against main while the
+// close gate validates the commit against release. So the reconciled winner is
+// written BACK into the carrier the formula actually reads, and the post-
+// condition vars[carrier] == scope.Branch holds by construction.
+//
+// PROVENANCE MUST SURVIVE UNTIL RESOLUTION. The final variable map is
+// provenance-lossy: an explicit --var base_branch=X and an auto-injected
+// base_branch land in the same key, and by the time the map exists the reason a
+// key is present is gone. Resolution therefore consumes typed LAYERS with
+// provenance intact, never the flattened map — only the explicit layer may feed
+// precedence 1, while the routed branch is durable intent at precedence 3.
+package targetscope
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The invocation-surface variable names.
+//
+// gc_target_branch and gc_target_worktree are scalar strings, not JSON: the
+// invocation surface is map[string]string, so v1 carries the two scope fields
+// as two scalar vars. The JSON object is the persisted metadata form only.
+const (
+	// VarTargetBranch is the dedicated scope-branch input. It exists so a
+	// formula that consumes neither carrier can still be handed a scope
+	// branch without declaring a branch variable.
+	VarTargetBranch = "gc_target_branch"
+	// VarTargetWorktree is the dedicated scope-worktree input. No existing
+	// carrier corresponds to it, so it has no alias set.
+	VarTargetWorktree = "gc_target_worktree"
+	// VarBaseBranch and VarCarrierTargetBranch are the pre-existing,
+	// formula-consumed branch carriers.
+	VarBaseBranch          = "base_branch"
+	VarCarrierTargetBranch = "target_branch"
+)
+
+// BranchAliases is the branch-carrier alias set. All three are co-equal aliases
+// of one fact at a given provenance layer; VarTargetBranch does NOT silently
+// outrank the carriers.
+var BranchAliases = []string{VarTargetBranch, VarBaseBranch, VarCarrierTargetBranch}
+
+// ScopeInputVars are claimed by the resolver as typed scope inputs. They are
+// excluded from the flattened variable map so they never reach template
+// substitution, the root key, or the persisted runtime-vars blob.
+var ScopeInputVars = []string{VarTargetBranch, VarTargetWorktree}
+
+// LayerName identifies a provenance layer for diagnostics.
+type LayerName string
+
+const (
+	LayerExplicit LayerName = "explicit invocation var"
+	LayerMember   LayerName = "declared member scope"
+	LayerRig      LayerName = "rig formula_vars"
+	LayerRouting  LayerName = "routing-injected branch"
+	LayerFormula  LayerName = "formula default"
+)
+
+// Sources is the provenance-typed input set.
+type Sources struct {
+	// Explicit holds raw, UNFLATTENED "key=value" invocation vars. It stays
+	// unflattened so that two occurrences of one carrier with different values
+	// remain visible: flattening would silently apply last-write-wins to a
+	// branch carrier, which v1 rejects instead.
+	Explicit []string
+	// Member is an already-declared, valid member scope, if any.
+	Member    Scope
+	MemberSet bool
+	// Rig is the rig-scoped formula_vars layer.
+	Rig map[string]string
+	// Routing is the routing-injected durable intent. The source injects at
+	// most one carrier, so this layer cannot self-conflict.
+	Routing map[string]string
+	// FormulaDefaults are the formula's [vars.*].default values. Including
+	// this layer is what keeps the scope object and the consumed carrier
+	// identical in the default-only case.
+	FormulaDefaults map[string]string
+}
+
+// Resolved is the outcome of trusted-source resolution.
+type Resolved struct {
+	Scope Scope
+	// BranchLayer and WorktreeLayer record which layer supplied each field,
+	// for error messages and tests. Empty when the field is unknown.
+	BranchLayer   LayerName
+	WorktreeLayer LayerName
+}
+
+// Resolve computes the reconciled scope from trusted sources.
+//
+// Cross-layer precedence is first-candidate-wins: explicit invocation vars, a
+// declared member scope, durable intent (rig then routing), formula defaults.
+// Within a layer there is NO tiebreak — disagreeing aliases are a loud operator
+// error, because silently picking one would be exactly the "which branch did
+// this actually run against" ambiguity the object exists to remove.
+//
+// storeRoot anchors a relative worktree to its mandatory absolute form. The
+// value is normalized HERE, at the boundary, so the single absolute string is
+// what gets copied to the root and to every member.
+func Resolve(src Sources, storeRoot string) (Resolved, error) {
+	explicit := explicitOccurrences(src.Explicit)
+
+	branch, branchLayer, err := resolveBranch(src, explicit)
+	if err != nil {
+		return Resolved{}, err
+	}
+	worktree, worktreeLayer, err := resolveWorktree(src, explicit)
+	if err != nil {
+		return Resolved{}, err
+	}
+
+	scope := Scope{V: SchemaVersion, Branch: branch, Worktree: worktree}
+	normalized, err := Normalize(scope, storeRoot)
+	if err != nil {
+		return Resolved{}, err
+	}
+	return Resolved{Scope: normalized, BranchLayer: branchLayer, WorktreeLayer: worktreeLayer}, nil
+}
+
+func resolveBranch(src Sources, explicit map[string][]string) (string, LayerName, error) {
+	if value, ok, err := candidate(LayerExplicit, BranchAliases, explicit); err != nil || ok {
+		return value, LayerExplicit, err
+	}
+	if src.MemberSet && src.Member.Branch != "" {
+		return src.Member.Branch, LayerMember, nil
+	}
+	for _, layer := range []struct {
+		name LayerName
+		vars map[string]string
+	}{
+		{LayerRig, src.Rig},
+		{LayerRouting, src.Routing},
+		{LayerFormula, src.FormulaDefaults},
+	} {
+		if value, ok, err := candidate(layer.name, BranchAliases, single(layer.vars)); err != nil || ok {
+			return value, layer.name, err
+		}
+	}
+	return "", "", nil
+}
+
+func resolveWorktree(src Sources, explicit map[string][]string) (string, LayerName, error) {
+	// No alias set: only the dedicated input carries a worktree, so a
+	// within-layer conflict is impossible and only cross-layer precedence
+	// applies.
+	aliases := []string{VarTargetWorktree}
+	if value, ok, err := candidate(LayerExplicit, aliases, explicit); err != nil || ok {
+		return value, LayerExplicit, err
+	}
+	if src.MemberSet && src.Member.Worktree != "" {
+		return src.Member.Worktree, LayerMember, nil
+	}
+	for _, layer := range []struct {
+		name LayerName
+		vars map[string]string
+	}{
+		{LayerRig, src.Rig},
+		{LayerRouting, src.Routing},
+		{LayerFormula, src.FormulaDefaults},
+	} {
+		if value, ok, err := candidate(layer.name, aliases, single(layer.vars)); err != nil || ok {
+			return value, layer.name, err
+		}
+	}
+	return "", "", nil
+}
+
+// candidate applies the within-layer rule to one alias set.
+//
+// Empty carriers are treated as ABSENT for candidate collection, matching the
+// existing injector's skip-empty behavior; an explicit `base_branch=` therefore
+// neither blocks reconciliation nor survives it.
+func candidate(layer LayerName, aliases []string, values map[string][]string) (string, bool, error) {
+	seen := map[string][]string{} // value -> the alias names that carried it
+	for _, alias := range aliases {
+		for _, raw := range values[alias] {
+			value := strings.TrimSpace(raw)
+			if value == "" {
+				continue
+			}
+			seen[value] = append(seen[value], alias)
+		}
+	}
+	switch len(seen) {
+	case 0:
+		return "", false, nil
+	case 1:
+		for value := range seen {
+			return value, true, nil
+		}
+	}
+	return "", false, fmt.Errorf("conflicting target branch at the %s layer: %s; "+
+		"these are aliases of one value and v1 has no tiebreak — supply a single branch",
+		layer, describeConflict(seen))
+}
+
+func describeConflict(seen map[string][]string) string {
+	parts := make([]string, 0, len(seen))
+	for value, aliases := range seen {
+		sort.Strings(aliases)
+		parts = append(parts, fmt.Sprintf("%s=%q", strings.Join(dedupe(aliases), "/"), value))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, " vs ")
+}
+
+func dedupe(in []string) []string {
+	out := in[:0:0]
+	for i, v := range in {
+		if i == 0 || v != in[i-1] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// explicitOccurrences preserves EVERY occurrence of each key so a repeated
+// branch carrier with differing values is caught rather than silently
+// last-write-wins.
+func explicitOccurrences(raw []string) map[string][]string {
+	out := map[string][]string{}
+	for _, entry := range raw {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		out[key] = append(out[key], value)
+	}
+	return out
+}
+
+func single(vars map[string]string) map[string][]string {
+	if len(vars) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(vars))
+	for key, value := range vars {
+		out[key] = []string{value}
+	}
+	return out
+}
+
+// ApplyToVars writes the reconciled branch back into the carrier the formula
+// actually consumes, and removes the typed scope inputs from the map.
+//
+// The write is UNCONDITIONAL: the value being written is the reconciled winner,
+// so it cannot lose a conflicting intent — a genuine conflict would already
+// have rejected during Resolve. Overwriting is the point, because the carrier
+// may hold a routed value that lost to a higher-precedence layer.
+//
+// When the branch is unknown, the carrier is left alone so the formula's own
+// default still applies through the normal overlay, and the scope carries that
+// same default.
+func ApplyToVars(vars map[string]string, resolved Resolved, usesBaseBranch, usesTargetBranch bool) {
+	if vars == nil {
+		return
+	}
+	for _, name := range ScopeInputVars {
+		delete(vars, name)
+	}
+	branch := resolved.Scope.Branch
+	if branch == "" {
+		return
+	}
+	if usesBaseBranch {
+		vars[VarBaseBranch] = branch
+	}
+	if usesTargetBranch {
+		vars[VarCarrierTargetBranch] = branch
+	}
+}

--- a/internal/targetscope/resolver_test.go
+++ b/internal/targetscope/resolver_test.go
@@ -1,0 +1,252 @@
+package targetscope
+
+import (
+	"strings"
+	"testing"
+)
+
+const testStoreRoot = "/srv/store"
+
+func mustResolve(t *testing.T, src Sources) Resolved {
+	t.Helper()
+	got, err := Resolve(src, testStoreRoot)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	return got
+}
+
+// Each alias independently feeds scope.branch — none is privileged.
+func TestEachBranchAliasFeedsScope(t *testing.T) {
+	for _, alias := range BranchAliases {
+		t.Run(alias, func(t *testing.T) {
+			got := mustResolve(t, Sources{Explicit: []string{alias + "=release"}})
+			if got.Scope.Branch != "release" {
+				t.Fatalf("branch = %q, want release", got.Scope.Branch)
+			}
+		})
+	}
+}
+
+// Disagreeing aliases within one layer reject. There is no silent winner.
+func TestWithinLayerBranchDisagreementRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		src  Sources
+	}{
+		{"base vs target carrier", Sources{Explicit: []string{"base_branch=X", "target_branch=Y"}}},
+		{"dedicated vs carrier", Sources{Explicit: []string{"gc_target_branch=Z", "base_branch=X"}}},
+		{"duplicate same key", Sources{Explicit: []string{"base_branch=X", "base_branch=Y"}}},
+		{"rig layer self-conflict", Sources{Rig: map[string]string{"base_branch": "X", "target_branch": "Y"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Resolve(tc.src, testStoreRoot); err == nil {
+				t.Fatal("expected a rejection, got none")
+			}
+		})
+	}
+}
+
+// Equal duplicates and equal aliases are accepted.
+func TestWithinLayerAgreementAccepted(t *testing.T) {
+	for _, src := range []Sources{
+		{Explicit: []string{"base_branch=main", "base_branch=main"}},
+		{Explicit: []string{"base_branch=main", "target_branch=main", "gc_target_branch=main"}},
+	} {
+		got := mustResolve(t, src)
+		if got.Scope.Branch != "main" {
+			t.Fatalf("branch = %q, want main", got.Scope.Branch)
+		}
+	}
+}
+
+// Cross-layer precedence: explicit beats member beats rig beats routing beats
+// formula default.
+func TestCrossLayerPrecedence(t *testing.T) {
+	full := Sources{
+		Explicit:        []string{"gc_target_branch=from-explicit"},
+		Member:          Scope{V: 1, Branch: "from-member"},
+		MemberSet:       true,
+		Rig:             map[string]string{"base_branch": "from-rig"},
+		Routing:         map[string]string{"base_branch": "from-routing"},
+		FormulaDefaults: map[string]string{"base_branch": "from-default"},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*Sources)
+		want   string
+		layer  LayerName
+	}{
+		{"explicit wins", func(s *Sources) {}, "from-explicit", LayerExplicit},
+		{"member next", func(s *Sources) { s.Explicit = nil }, "from-member", LayerMember},
+		{"rig next", func(s *Sources) { s.Explicit = nil; s.MemberSet = false }, "from-rig", LayerRig},
+		{"routing next", func(s *Sources) { s.Explicit = nil; s.MemberSet = false; s.Rig = nil }, "from-routing", LayerRouting},
+		{"default last", func(s *Sources) { s.Explicit = nil; s.MemberSet = false; s.Rig = nil; s.Routing = nil }, "from-default", LayerFormula},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := full
+			tc.mutate(&src)
+			got := mustResolve(t, src)
+			if got.Scope.Branch != tc.want {
+				t.Fatalf("branch = %q, want %q", got.Scope.Branch, tc.want)
+			}
+			if got.BranchLayer != tc.layer {
+				t.Fatalf("layer = %q, want %q", got.BranchLayer, tc.layer)
+			}
+		})
+	}
+}
+
+// THE WIRE INVARIANT (the split this design closes). An explicit
+// gc_target_branch must reach the carrier the formula actually reads, so the
+// branch substitution uses and the branch the close gate validates are the same
+// string.
+func TestConsumedCarrierEqualsScopeBranch(t *testing.T) {
+	resolved := mustResolve(t, Sources{
+		Explicit: []string{"gc_target_branch=release"},
+		Routing:  map[string]string{"base_branch": "main"},
+	})
+	if resolved.Scope.Branch != "release" {
+		t.Fatalf("scope.branch = %q, want release", resolved.Scope.Branch)
+	}
+
+	vars := map[string]string{"base_branch": "main"}
+	ApplyToVars(vars, resolved, true, false)
+
+	if vars["base_branch"] != "release" {
+		t.Fatalf("consumed base_branch = %q, want release — the workflow would "+
+			"execute against a different branch than the close gate validates", vars["base_branch"])
+	}
+	if vars["base_branch"] != resolved.Scope.Branch {
+		t.Fatalf("post-condition violated: vars[base_branch]=%q != scope.branch=%q",
+			vars["base_branch"], resolved.Scope.Branch)
+	}
+}
+
+// Same invariant for a target_branch formula.
+func TestConsumedTargetBranchCarrierEqualsScopeBranch(t *testing.T) {
+	resolved := mustResolve(t, Sources{
+		Explicit: []string{"gc_target_branch=release"},
+		Routing:  map[string]string{"target_branch": "main"},
+	})
+	vars := map[string]string{"target_branch": "main"}
+	ApplyToVars(vars, resolved, false, true)
+	if vars["target_branch"] != resolved.Scope.Branch {
+		t.Fatalf("vars[target_branch]=%q != scope.branch=%q", vars["target_branch"], resolved.Scope.Branch)
+	}
+}
+
+// An empty explicit carrier is absent for collection and does NOT survive: it
+// is overwritten by the reconciled winner.
+func TestEmptyCarrierIsOverwritten(t *testing.T) {
+	resolved := mustResolve(t, Sources{
+		Explicit: []string{"base_branch=", "gc_target_branch=release"},
+	})
+	if resolved.Scope.Branch != "release" {
+		t.Fatalf("scope.branch = %q, want release", resolved.Scope.Branch)
+	}
+	vars := map[string]string{"base_branch": ""}
+	ApplyToVars(vars, resolved, true, false)
+	if vars["base_branch"] != "release" {
+		t.Fatalf("base_branch = %q, want release (not left empty, not the routed value)", vars["base_branch"])
+	}
+}
+
+// Default-only: the scope and the carrier both end up as the formula default.
+func TestDefaultOnlyKeepsScopeAndCarrierIdentical(t *testing.T) {
+	resolved := mustResolve(t, Sources{FormulaDefaults: map[string]string{"base_branch": "main"}})
+	if resolved.Scope.Branch != "main" {
+		t.Fatalf("scope.branch = %q, want main", resolved.Scope.Branch)
+	}
+	vars := map[string]string{}
+	ApplyToVars(vars, resolved, true, false)
+	if vars["base_branch"] != resolved.Scope.Branch {
+		t.Fatalf("vars[base_branch]=%q != scope.branch=%q", vars["base_branch"], resolved.Scope.Branch)
+	}
+}
+
+// A formula consuming neither carrier gets no branch var, and nothing can
+// diverge from the scope because there is no consumed branch to disagree.
+func TestFormulaWithNoCarrierGetsNoBranchVar(t *testing.T) {
+	resolved := mustResolve(t, Sources{Explicit: []string{"gc_target_branch=release"}})
+	vars := map[string]string{}
+	ApplyToVars(vars, resolved, false, false)
+	if _, ok := vars[VarBaseBranch]; ok {
+		t.Fatal("base_branch must not be written for a formula that does not consume it")
+	}
+	if resolved.Scope.Branch != "release" {
+		t.Fatalf("scope.branch = %q, want release", resolved.Scope.Branch)
+	}
+}
+
+// The typed scope inputs are claimed by the resolver and must never reach
+// template substitution, the root key, or the persisted runtime-vars blob.
+func TestScopeInputVarsAreStrippedFromConsumedMap(t *testing.T) {
+	resolved := mustResolve(t, Sources{
+		Explicit: []string{"gc_target_branch=release", "gc_target_worktree=/srv/wt"},
+	})
+	vars := map[string]string{
+		"gc_target_branch":   "release",
+		"gc_target_worktree": "/srv/wt",
+		"other":              "kept",
+	}
+	ApplyToVars(vars, resolved, true, false)
+	for _, name := range ScopeInputVars {
+		if _, ok := vars[name]; ok {
+			t.Fatalf("%s leaked into the consumed variable map", name)
+		}
+	}
+	if vars["other"] != "kept" {
+		t.Fatal("unrelated vars must be preserved")
+	}
+}
+
+// A relative worktree is normalized to absolute AT THE BOUNDARY, so the single
+// absolute string is what gets copied to root and members.
+func TestWorktreeNormalizedAtBoundary(t *testing.T) {
+	resolved := mustResolve(t, Sources{Explicit: []string{"gc_target_worktree=worktrees/T"}})
+	want := testStoreRoot + "/worktrees/T"
+	if resolved.Scope.Worktree != want {
+		t.Fatalf("worktree = %q, want %q", resolved.Scope.Worktree, want)
+	}
+	// And it must persist as valid — a relative value would be present-invalid.
+	blob, err := Marshal(resolved.Scope)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if Parse(blob).State != StateValid {
+		t.Fatal("boundary-normalized scope must persist as valid")
+	}
+}
+
+// No trusted source anywhere yields a field-empty {v:1} — valid and unknown,
+// never absent, so the cwd writers stay suppressed.
+func TestNoTrustedSourceYieldsValidUnknown(t *testing.T) {
+	resolved := mustResolve(t, Sources{})
+	if !resolved.Scope.IsUnknown() {
+		t.Fatalf("scope = %+v, want field-empty", resolved.Scope)
+	}
+	blob, err := Marshal(resolved.Scope)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if got := Parse(blob); got.State != StateValid {
+		t.Fatalf("state = %v, want valid — an absent object would re-enable the cwd stamp", got.State)
+	}
+}
+
+// The conflict message must name the disagreeing carriers; an operator hitting
+// this needs to know which two vars to reconcile.
+func TestConflictErrorNamesTheCarriers(t *testing.T) {
+	_, err := Resolve(Sources{Explicit: []string{"base_branch=X", "target_branch=Y"}}, testStoreRoot)
+	if err == nil {
+		t.Fatal("expected a conflict")
+	}
+	for _, want := range []string{"base_branch", "target_branch", "X", "Y"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q should mention %q", err, want)
+		}
+	}
+}

--- a/internal/targetscope/scope.go
+++ b/internal/targetscope/scope.go
@@ -1,0 +1,263 @@
+// Package targetscope owns gc.target_scope: the declared answer to "where does
+// this bead's work live, and against what branch is it validated".
+//
+// The defect it exists to close: gc.work_branch and gc.work_dir are derived at
+// CLAIM time (branch) and RECONCILE time (dir) from the claiming session's cwd,
+// not from any declared intent. A pool session parked on a shared checkout
+// stamps that parked branch and shared root onto whatever it claims, and every
+// later claim from that cwd re-inherits the poison. Formula-generated stage
+// beads are the uncovered class by construction: they carry no declared
+// location at all, so no prompt-level or worker-level fallback can repair them.
+//
+// The fix is to attach a first-class scope object at INSTANTIATION, resolved
+// only from trusted sources, made immutable once declared, and read directly by
+// the behavior-critical consumers. Two properties carry the whole design:
+//
+// TRI-STATE, NOT BOOLEAN. Absence is not "unknown". Absence is the legacy
+// state, and it is the ONLY state that re-enables the cwd writers and the flat
+// gc.work_* reader fallbacks. "Unknown" is a valid object with the field
+// missing — Scope{V:1} — which suppresses cwd forever after. Collapsing a parse
+// or read failure to "not found" reopens the defect, so Parse reports invalid
+// distinctly from absent and no caller may conflate them.
+//
+// WHOLE-SCOPE SEMANTICS. A valid scope suppresses the cwd fallback for the
+// entire scope, not field by field. A Scope{V:1, Branch:X} cannot acquire a cwd
+// worktree, and a Scope{V:1, Worktree:Y} cannot acquire a cwd branch. Filling
+// one absent field from cwd is how a half-poisoned object would be born.
+//
+// Provenance is enforced by omission: nothing in this package accepts
+// gc.work_branch, gc.work_dir, or gc.work_commit as an input. Those keys are
+// claim-poisoned by the very writers this object exists to invert, and they
+// carry no marker separating a declaration from a cwd stamp — so laundering
+// them into a scope would make the poison immutable under the new guards.
+package targetscope
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// SchemaVersion is the only supported value of Scope.V. A different version is
+// present-invalid, never absent: an object written by a newer binary must fail
+// the scoped read rather than silently degrade to cwd.
+const SchemaVersion = 1
+
+// Scope is the persisted target-scope object.
+//
+// v1 is deliberately {v, branch, worktree} and nothing else. base_sha, origin,
+// and repo were dropped because no reader justifies them, and an unread field
+// is a field that drifts. Worktree containment (rather than a repo identity
+// field) is what keeps a scope from pointing outside the envelope.
+//
+// It persists as one JSON blob so it round-trips the inherited-metadata walk as
+// a single value and cannot half-apply.
+type Scope struct {
+	V int `json:"v"`
+	// Branch feeds the close gate's reachability base.
+	Branch string `json:"branch,omitempty"`
+	// Worktree feeds gc.work_dir and Ralph's script base. It is ALWAYS
+	// absolute once persisted — normalization happens at the launch boundary
+	// (NormalizeWorktree), never at read time. See the State docs.
+	Worktree string `json:"worktree,omitempty"`
+}
+
+// State is the tri-state every reader and writer must branch on.
+type State int
+
+const (
+	// StateAbsent means no gc.target_scope was reachable. This is the ONLY
+	// state that permits a cwd stamp or a flat gc.work_* reader fallback.
+	StateAbsent State = iota
+	// StateValid means the object parsed and is schema-valid. It is
+	// authoritative for the whole scope; a missing field means unknown and
+	// must never be filled from cwd.
+	StateValid
+	// StateInvalid means the object was reachable but unusable: malformed
+	// JSON, unsupported version, wrong field type, or a worktree that is
+	// relative or escaping. Writers must not stamp cwd and readers must FAIL
+	// the scoped read. Never falls back to flat keys.
+	StateInvalid
+)
+
+func (s State) String() string {
+	switch s {
+	case StateAbsent:
+		return "absent"
+	case StateValid:
+		return "valid"
+	case StateInvalid:
+		return "invalid"
+	default:
+		return fmt.Sprintf("state(%d)", int(s))
+	}
+}
+
+// ErrInvalidScope is the sentinel wrapped by every present-invalid reason, so
+// callers can distinguish "this object is unusable" (fail closed) from a
+// transport error without string matching.
+var ErrInvalidScope = errors.New("invalid gc.target_scope")
+
+// Resolution is a parsed scope plus the state that produced it. Reason is
+// non-nil exactly when State is StateInvalid.
+type Resolution struct {
+	State  State
+	Scope  Scope
+	Reason error
+	// Raw is the exact stored string that produced this resolution. The
+	// member-declaration protocol feeds it back as the CAS expected value, so
+	// it must be the bytes read, not a re-marshaling.
+	Raw string
+}
+
+// Valid reports whether the resolution is present-valid.
+func (r Resolution) Valid() bool { return r.State == StateValid }
+
+// Absent reports whether no object was reachable. Only this state unlocks the
+// legacy cwd/flat behavior.
+func (r Resolution) Absent() bool { return r.State == StateAbsent }
+
+// Invalid reports whether an object was reachable but unusable.
+func (r Resolution) Invalid() bool { return r.State == StateInvalid }
+
+// Parse turns a stored metadata value into the tri-state.
+//
+// An empty or whitespace-only raw value is absent — that is the pre-existing
+// population and the only input that may re-enable legacy behavior. Everything
+// else that fails to yield a schema-valid object is INVALID, never absent.
+func Parse(raw string) Resolution {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return Resolution{State: StateAbsent, Raw: raw}
+	}
+	invalid := func(format string, args ...any) Resolution {
+		return Resolution{
+			State:  StateInvalid,
+			Reason: fmt.Errorf("%w: %s", ErrInvalidScope, fmt.Sprintf(format, args...)),
+			Raw:    raw,
+		}
+	}
+	var scope Scope
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	if err := dec.Decode(&scope); err != nil {
+		// Wrong JSON types land here too (a numeric "branch" fails to
+		// unmarshal into string), which is the intended classification.
+		return invalid("malformed JSON: %v", err)
+	}
+	if dec.More() {
+		return invalid("trailing content after JSON object")
+	}
+	if scope.V != SchemaVersion {
+		return invalid("unsupported version %d (want %d)", scope.V, SchemaVersion)
+	}
+	if strings.TrimSpace(scope.Branch) != scope.Branch {
+		return invalid("branch has leading or trailing whitespace")
+	}
+	if wt := scope.Worktree; wt != "" {
+		if strings.TrimSpace(wt) != wt {
+			return invalid("worktree has leading or trailing whitespace")
+		}
+		// A persisted RELATIVE worktree is present-invalid, not something to
+		// re-anchor. Boundaries are required to persist absolute paths
+		// (NormalizeWorktree), and the root and the member may live in
+		// DIFFERENT stores — so a reader that re-anchored a relative value
+		// against its own store root would produce a different path than the
+		// other reader. Failing here is what keeps one absolute value the sole
+		// authority instead of letting each reader pick an anchor.
+		if !filepath.IsAbs(wt) {
+			return invalid("worktree %q is relative; boundaries must persist an absolute path", wt)
+		}
+		if filepath.Clean(wt) != wt {
+			return invalid("worktree %q is not in cleaned form", wt)
+		}
+	}
+	return Resolution{State: StateValid, Scope: scope, Raw: raw}
+}
+
+// Marshal renders a scope for persistence. It rejects a scope it would not
+// itself parse back as valid, so a caller cannot write a blob that every reader
+// will then fail closed on.
+func Marshal(scope Scope) (string, error) {
+	if scope.V == 0 {
+		scope.V = SchemaVersion
+	}
+	if scope.V != SchemaVersion {
+		return "", fmt.Errorf("targetscope: unsupported version %d", scope.V)
+	}
+	if wt := scope.Worktree; wt != "" && !filepath.IsAbs(wt) {
+		return "", fmt.Errorf("targetscope: worktree %q must be absolute; normalize at the launch boundary", wt)
+	}
+	blob, err := json.Marshal(scope)
+	if err != nil {
+		return "", fmt.Errorf("targetscope: marshal: %w", err)
+	}
+	return string(blob), nil
+}
+
+// Unknown is the valid field-empty object.
+//
+// This is what a boundary stamps when no trusted source supplies a field. It is
+// NOT the same as writing nothing: an absent object lets the next claim or
+// reconcile stamp cwd, while Unknown suppresses that permanently. "Leave the
+// field unknown" must never be implemented by omitting the object.
+func Unknown() Scope { return Scope{V: SchemaVersion} }
+
+// IsUnknown reports whether the scope declares no fields.
+func (s Scope) IsUnknown() bool { return s.Branch == "" && s.Worktree == "" }
+
+// Equal compares field for field. The member-declaration protocol treats an
+// equal re-declaration as a no-op and any difference as a launch rejection, so
+// this is the exact predicate that decides immutability.
+func (s Scope) Equal(other Scope) bool {
+	return s.V == other.V && s.Branch == other.Branch && s.Worktree == other.Worktree
+}
+
+// NormalizeWorktree produces the mandatory absolute form for a worktree value,
+// anchored to the store root that owns the resolution point.
+//
+// This runs at the LAUNCH BOUNDARY, before the scope is copied to the root or
+// to any member, and the single absolute result is what gets persisted. That
+// ordering is the whole point: resolving once at the boundary and copying the
+// identical string everywhere means the graph-store reader and the work-store
+// reader consume one authority, instead of each joining a relative value to its
+// own root and disagreeing.
+//
+// An empty worktree stays empty — unknown is a legitimate value and must not
+// become the store root.
+func NormalizeWorktree(worktree, storeRoot string) (string, error) {
+	worktree = strings.TrimSpace(worktree)
+	if worktree == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(worktree) {
+		return filepath.Clean(worktree), nil
+	}
+	storeRoot = strings.TrimSpace(storeRoot)
+	if storeRoot == "" {
+		return "", fmt.Errorf("targetscope: cannot anchor relative worktree %q: no store root at the boundary", worktree)
+	}
+	if !filepath.IsAbs(storeRoot) {
+		abs, err := filepath.Abs(storeRoot)
+		if err != nil {
+			return "", fmt.Errorf("targetscope: cannot absolutize store root %q: %w", storeRoot, err)
+		}
+		storeRoot = abs
+	}
+	return filepath.Clean(filepath.Join(storeRoot, worktree)), nil
+}
+
+// Normalize returns a copy of scope with its worktree normalized to absolute
+// against storeRoot. Boundaries call this before persisting.
+func Normalize(scope Scope, storeRoot string) (Scope, error) {
+	abs, err := NormalizeWorktree(scope.Worktree, storeRoot)
+	if err != nil {
+		return Scope{}, err
+	}
+	if scope.V == 0 {
+		scope.V = SchemaVersion
+	}
+	scope.Worktree = abs
+	return scope, nil
+}

--- a/internal/targetscope/scope_test.go
+++ b/internal/targetscope/scope_test.go
@@ -1,0 +1,177 @@
+package targetscope
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The tri-state is the load-bearing contract: absent is the ONLY state that may
+// re-enable a cwd stamp, so every way a scope can be unusable must classify as
+// invalid rather than collapsing to absent.
+func TestParseTriState(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want State
+	}{
+		{"empty is absent", "", StateAbsent},
+		{"whitespace is absent", "   \n", StateAbsent},
+		{"field-empty object is valid unknown", `{"v":1}`, StateValid},
+		{"branch only is valid", `{"v":1,"branch":"main"}`, StateValid},
+		{"absolute worktree is valid", `{"v":1,"worktree":"/srv/wt"}`, StateValid},
+		{"both fields valid", `{"v":1,"branch":"release","worktree":"/srv/wt"}`, StateValid},
+
+		{"missing version is invalid", `{}`, StateInvalid},
+		{"version zero is invalid", `{"v":0,"branch":"main"}`, StateInvalid},
+		{"future version is invalid", `{"v":2,"branch":"main"}`, StateInvalid},
+		{"malformed json is invalid", `{"v":1,`, StateInvalid},
+		{"not an object is invalid", `"main"`, StateInvalid},
+		{"wrong field type is invalid", `{"v":1,"branch":5}`, StateInvalid},
+		{"trailing content is invalid", `{"v":1} {"v":1}`, StateInvalid},
+		{"relative worktree is invalid", `{"v":1,"worktree":"worktrees/T"}`, StateInvalid},
+		{"uncleaned worktree is invalid", `{"v":1,"worktree":"/srv/../srv/wt"}`, StateInvalid},
+		{"untrimmed branch is invalid", `{"v":1,"branch":" main"}`, StateInvalid},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Parse(tc.raw)
+			if got.State != tc.want {
+				t.Fatalf("Parse(%q) state = %v, want %v (reason=%v)", tc.raw, got.State, tc.want, got.Reason)
+			}
+			if got.State == StateInvalid && got.Reason == nil {
+				t.Fatal("invalid resolution must carry a reason")
+			}
+			if got.State != StateInvalid && got.Reason != nil {
+				t.Fatalf("non-invalid resolution must not carry a reason: %v", got.Reason)
+			}
+		})
+	}
+}
+
+// A relative worktree is the cross-store divergence in disguise: re-anchoring
+// it would give the graph-store reader and the work-store reader two different
+// absolute paths for one declared value. Readers must fail instead.
+func TestParseRelativeWorktreeIsInvalidNotReanchored(t *testing.T) {
+	res := Parse(`{"v":1,"worktree":"worktrees/T"}`)
+	if res.State != StateInvalid {
+		t.Fatalf("state = %v, want invalid", res.State)
+	}
+	if !strings.Contains(res.Reason.Error(), "relative") {
+		t.Fatalf("reason %q should explain the relative-path rejection", res.Reason)
+	}
+}
+
+// Raw must survive parsing verbatim: the declaration protocol feeds it back as
+// the compare-and-set expected value, so a re-marshaled approximation would
+// make every CAS miss.
+func TestParsePreservesRawForCAS(t *testing.T) {
+	raw := `{"v":1, "branch":"main"}` // note the non-canonical spacing
+	res := Parse(raw)
+	if res.State != StateValid {
+		t.Fatalf("state = %v, want valid", res.State)
+	}
+	if res.Raw != raw {
+		t.Fatalf("Raw = %q, want the exact input %q", res.Raw, raw)
+	}
+}
+
+func TestMarshalRoundTrip(t *testing.T) {
+	for _, scope := range []Scope{
+		Unknown(),
+		{V: 1, Branch: "main"},
+		{V: 1, Worktree: "/srv/wt"},
+		{V: 1, Branch: "release/x", Worktree: "/srv/wt"},
+	} {
+		blob, err := Marshal(scope)
+		if err != nil {
+			t.Fatalf("Marshal(%+v): %v", scope, err)
+		}
+		res := Parse(blob)
+		if res.State != StateValid {
+			t.Fatalf("Marshal(%+v) produced %q which parses %v (%v)", scope, blob, res.State, res.Reason)
+		}
+		if !res.Scope.Equal(scope) {
+			t.Fatalf("round trip: got %+v want %+v", res.Scope, scope)
+		}
+	}
+}
+
+// Marshal must refuse what Parse would reject, so no writer can persist a blob
+// that every reader then fails closed on.
+func TestMarshalRejectsRelativeWorktree(t *testing.T) {
+	if _, err := Marshal(Scope{V: 1, Worktree: "worktrees/T"}); err == nil {
+		t.Fatal("Marshal accepted a relative worktree; boundaries must normalize first")
+	}
+}
+
+func TestUnknownIsValidAndFieldEmpty(t *testing.T) {
+	blob, err := Marshal(Unknown())
+	if err != nil {
+		t.Fatalf("Marshal(Unknown()): %v", err)
+	}
+	res := Parse(blob)
+	if res.State != StateValid {
+		t.Fatalf("Unknown() must persist as VALID, got %v", res.State)
+	}
+	if !res.Scope.IsUnknown() {
+		t.Fatalf("Unknown() must declare no fields, got %+v", res.Scope)
+	}
+	// The distinction that matters: this is not the same as writing nothing.
+	if Parse("").State == res.State {
+		t.Fatal("field-empty {v:1} must not classify the same as an absent object")
+	}
+}
+
+func TestNormalizeWorktree(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "srv", "store")
+	tests := []struct {
+		name      string
+		worktree  string
+		storeRoot string
+		want      string
+		wantErr   bool
+	}{
+		{"empty stays empty", "", root, "", false},
+		{"absolute is cleaned", "/srv/store/../store/wt", root, "/srv/store/wt", false},
+		{"relative anchors to store root", "worktrees/T", root, filepath.Join(root, "worktrees", "T"), false},
+		{"relative without root errors", "worktrees/T", "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeWorktree(tc.worktree, tc.storeRoot)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+			if got != "" && !filepath.IsAbs(got) {
+				t.Fatalf("normalized worktree %q must be absolute", got)
+			}
+		})
+	}
+}
+
+func TestEqualComparesEveryField(t *testing.T) {
+	base := Scope{V: 1, Branch: "main", Worktree: "/srv/wt"}
+	if !base.Equal(Scope{V: 1, Branch: "main", Worktree: "/srv/wt"}) {
+		t.Fatal("identical scopes must compare equal")
+	}
+	for _, other := range []Scope{
+		{V: 1, Branch: "release", Worktree: "/srv/wt"},
+		{V: 1, Branch: "main", Worktree: "/srv/other"},
+		{V: 1, Branch: "main"},
+		{V: 1, Worktree: "/srv/wt"},
+	} {
+		if base.Equal(other) {
+			t.Fatalf("%+v must not compare equal to %+v", base, other)
+		}
+	}
+}

--- a/internal/targetscope/stamp_member_test.go
+++ b/internal/targetscope/stamp_member_test.go
@@ -1,0 +1,83 @@
+package targetscope
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestStampMemberScopeCommitsOnAbsent(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+	want := Scope{V: 1, Branch: "release", Worktree: "/srv/wt"}
+
+	outcome, err := StampMemberScope(store, member.ID, want)
+	if err != nil {
+		t.Fatalf("StampMemberScope: %v", err)
+	}
+	if outcome != OutcomeCommitted {
+		t.Fatalf("outcome = %v, want committed", outcome)
+	}
+	got := declaredScope(t, store, member.ID)
+	if !got.Valid() || !got.Scope.Equal(want) {
+		t.Fatalf("stored scope = %v/%+v, want valid %+v", got.State, got.Scope, want)
+	}
+}
+
+func TestStampMemberScopeIsIdempotent(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+	want := Scope{V: 1, Branch: "release"}
+	if _, err := StampMemberScope(store, member.ID, want); err != nil {
+		t.Fatalf("first stamp: %v", err)
+	}
+	outcome, err := StampMemberScope(store, member.ID, want)
+	if err != nil {
+		t.Fatalf("second stamp: %v", err)
+	}
+	if outcome != OutcomeNoop {
+		t.Fatalf("outcome = %v, want noop on re-stamp of an equal scope", outcome)
+	}
+}
+
+// The immutability guard is the enforcement the CAS would otherwise carry.
+// Dropping the CAS for a lock-serialized stamp must NOT drop it: a
+// present-valid-different member rejects, and its existing scope is untouched.
+// This is the silent-retarget hazard that removing an enforcement mechanism
+// without replacing the invariant would ship.
+func TestStampMemberScopeRejectsRetarget(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", nil)
+	if _, err := StampMemberScope(store, member.ID, Scope{V: 1, Branch: "release"}); err != nil {
+		t.Fatalf("first stamp: %v", err)
+	}
+
+	outcome, err := StampMemberScope(store, member.ID, Scope{V: 1, Branch: "main"})
+	if !errors.Is(err, ErrDeclarationConflict) {
+		t.Fatalf("err = %v, want ErrDeclarationConflict on retarget", err)
+	}
+	if outcome != OutcomeNoop {
+		t.Fatalf("outcome = %v, want noop (no write) on retarget", outcome)
+	}
+	got := declaredScope(t, store, member.ID)
+	if got.Scope.Branch != "release" {
+		t.Fatalf("scope.branch = %q, want the original release preserved — a retarget must not overwrite", got.Scope.Branch)
+	}
+}
+
+func TestStampMemberScopeRejectsCorruptExistingScope(t *testing.T) {
+	store := beads.NewMemStore()
+	member := newMember(t, store, "", map[string]string{
+		beadmeta.TargetScopeMetadataKey: `{"v":99,"branch":"main"}`,
+	})
+
+	_, err := StampMemberScope(store, member.ID, Scope{V: 1, Branch: "release"})
+	if err == nil {
+		t.Fatal("want an error stamping over a corrupt/unusable existing scope, got nil")
+	}
+	if store2 := declaredScope(t, store, member.ID); store2.Raw != `{"v":99,"branch":"main"}` {
+		t.Fatalf("corrupt scope was modified to %q, want it left intact", store2.Raw)
+	}
+}


### PR DESCRIPTION
## ⚠️ Behavior change (LOUD) — read first

This PR changes what **5 launch shapes** write and what **4 behavior-critical readers**
trust. After a formula launch (sling formula, sling attach, order, cook, drain), the
generated root/members carry a new `gc.target_scope` object, and the close gate, Ralph
exec-check, claim hook, and reconcile writer **stop consulting the claim-stamped flat keys**
(`gc.work_branch`, `gc.work_dir`) for those scoped beads. **Everything else is unchanged**:
every bead written without a scope — i.e. the entire existing population — resolves *absent*
and keeps the exact legacy flat-key behavior. There is **no runtime impact until a canonical
repin** picks up this binary.

## Summary

`gc.work_branch` is stamped at **claim** time and `gc.work_dir` at **reconcile** time, both
derived from the claiming session's **cwd** — not from any declared intent. A pool session
parked on a shared checkout stamps that parked branch/root onto whatever it claims, and every
later claim from that cwd re-inherits the poison. Formula-generated stage beads are the
uncovered class *by construction*: they carry no declared location at all, so no prompt- or
worker-level fallback can repair them. (Observed in the field as a recurring defect — stages
silently re-pointing review/build scope.)

The fix attaches a first-class **`gc.target_scope`** object `{v, branch, worktree}` at
**instantiation**, resolved only from trusted sources, made **immutable once declared** —
single-winner via a metadata compare-and-set on the declared paths (convoy members, graph
attach); the legacy `--on` attach source is stamped best-effort, not CAS-serialized (see
Known limitations) — and read directly by the behavior-critical consumers. Two invariants
carry the design:

- **Tri-state, not boolean.** *Absent* is the legacy state and the ONLY one that re-enables a
  cwd stamp or a flat `gc.work_*` fallback. *Unknown* is a valid field-empty `{v:1}` object,
  which suppresses cwd forever. *Invalid* (malformed / unsupported version / escaping
  worktree) **fails closed** — it never degrades to the flat keys. Parse reports invalid
  distinctly from absent, because collapsing a read failure to "not found" reopens the defect.
- **Whole-scope semantics.** A valid scope suppresses the cwd fallback for the *entire* scope.
  A field the scope leaves unknown falls back to the process's own scope root, **never** to
  the bead's poisoned flat key. Provenance is enforced by omission: nothing in the resolver
  accepts `gc.work_branch` / `gc.work_dir` / `gc.work_commit` as an input.

## What changed

**Writers — the 5 launch shapes** (resolve a scope before compile, declare members + stamp
the root before materialization):
- `internal/sling/target_scope_launch.go`, `sling.go`, `sling_core.go` — sling **formula** +
  **attach/batch** boundaries.
- `cmd/gc/order_dispatch.go` — both **order** boundaries.
- `cmd/gc/formula_cook_scope.go` — all four `gc formula cook` paths.
- `internal/dispatch/drain_target_scope.go` — **drain** items inherit + declare their member.
- `internal/targetscope/launch.go` — the shared `PrepareLaunch` chokepoint (declare-then-stamp,
  phase-ordered so a rejected launch orphans nothing).

**Readers — stop consulting the flat keys under a present scope** (tri-state kept apart;
absent = legacy, unchanged):
- `cmd/gc/work_record_gate.go` — the ADR-0009 close gate validates the commit against the
  declared branch and probes git in the declared worktree.
- `internal/dispatch/ralph.go` — exec checks run in the declared scope.
- `cmd/gc/cmd_hook_claim.go` — the claim hook suppresses the cwd **branch** stamp.
- `cmd/gc/build_desired_state.go` — reconcile suppresses the cwd **work_dir** stamp.

**Primitive:** `internal/beads/native_dolt_store_conditional.go` (+ `metadata_cas.go`,
conformance) — the narrow `MetadataCASWriter` (`CompareAndSetMetadataKey` only) the
single-winner declaration needs. **This is commit 1 of the stack (`cf779d5b`), which is
exactly PR #4501** (same `git patch-id`); it is under separate review there. The
target-scope work is commits 2–17 on top, plus two review-hardening commits
(`a039d9f`, `63cf733`).

## Proof

Base: fresh `origin/main` @34ad80cb8 (merge-base 88a4387a0). Tip verified by content.

- **Rebase-verify.** `git merge-tree --write-tree origin/main feat/gc-target-scope-v1` → clean
  tree, **zero conflict markers** (re-verified after each origin/main advance). Diff: 50
  files, +6982 / −57.
- **Build + test green (local).** `go build ./...` ✓ · `go vet` (targetscope, sling, dispatch,
  beads, beadmeta, cmd/gc) ✓ · `go test` for those internal packages ✓ · `go test ./cmd/gc/`
  scope suite ✓ — **14 E2E + 7 close-gate + 4 order** target-scope tests + the new
  `TestResolveInherited*` set (dangling→absent / transport→invalid), 0 failures.
- **Before/after transcript** (real production functions + real readers, poison cwd =
  `parked-shared-branch` / `/shared/parked/root`): each scoped launch stamps
  `{"v":1,"branch":…}` (worktree normalized absolute on attach), and CLAIM / RECONCILE / GATE
  all ignore the poison and resolve the **declared** branch; an **absent-scope** bead keeps the
  legacy flat-key path verbatim.
- **Meta-test (discriminating).** Neuter `targetscope.StampRoot` (skip the stamp) →
  **11 launch-based E2E tests go RED** with the exact defect signature
  (`claim stamped gc.work_branch="parked-shared-branch" over the declared scope`) → restore →
  green. The tests discriminate against the defect, not merely exercise the new path.
- **Rollout safety.** The migration is inert for the existing population — every legacy bead
  resolves *absent*, now including beads with a dangling ancestor pointer (hardened in
  `a039d9f`, see Review). Behavior change is confined to the 5 launch boundaries; no
  town-runtime impact until a canonical repin.

## Review & hardening

Two independent adversarial review passes ran against the diff and proof; every
finding was adjudicated against the code. Two were confirmed and **hardened in
this branch** (append-only, commits `a039d9f`, `63cf733`):

- **Inherited-scope walk: a not-found ancestor now resolves *absent*, not *invalid*.**
  `resolve.go`'s `inheritedNext` had folded a not-found ancestor into the same
  fail-closed `StateInvalid` bucket as a transport error, so an existing
  *unscoped* bead with a dangling `gc.root_bead_id`/`ParentID` (e.g. a stage
  whose ephemeral root was cleaned up) flipped absent→invalid, standing the cwd
  writers down and warning the gate. It now `continue`s past a `beads.ErrNotFound`
  ancestor and keeps only a genuine transport error fail-closed — restoring the
  "every existing bead resolves absent, unchanged" property while preserving the
  guard. Pinned both directions in `resolve_test.go`.
- **Legacy `--on` attach source-scope: the over-claimed single-writer comment is
  corrected.** `stampClaimableSourceScope` stated a source-workflow lock
  serializes it; the legacy (non-graph) attach path holds no such lock (the lock
  wraps only the graph-attach boundaries). The comment now states the guarantee
  honestly: immutability holds against an already-declared scope, graph attach is
  the CAS-serialized single-winner path, and two concurrent attaches on the same
  still-unscoped bead are not serialized here. (Comment-only; no behavior change.)

**Known limitations (disclosed, not blocking):**
- The residual legacy-attach concurrency gap above — a rare race (concurrent
  same-bead, different-branch legacy `--on` attach → one of two *valid* scopes)
  and a non-fatal post-materialization source stamp — is left for a follow-up
  that declares the legacy source before materialization (the validation-only
  store constraint makes it a larger change). Graph attach is unaffected.
- The reader worktree envelope (`resolve.go` `CheckWorktree`) rejects a declared
  `gc_target_worktree` outside the city/store roots that Ralph would accept for a
  legacy `gc.work_dir`. This affects only the *new* scope-worktree input; align
  or document per your preference.

**Suggested CI gate:** the single-winner design rests on the real-Dolt metadata
CAS fence, which is behind `//go:build integration` and is skipped by a default
`go test`. Recommend `go test -tags integration ./internal/beads/` be part of the
required suite.

Not defects (adjudicated): a valid field-empty scope validating a shipped commit
against the *worker-attested* `gc.work_branch` is the documented work-record
design, not cwd poison; the close gate's warn-vs-enforce switch is orthogonal to
the reader being fail-closed; `gc bd update --set-metadata` is manual metadata
surgery, outside the concurrent-launch threat model the immutability guard covers;
and the metadata-CAS "retry" concern does not arise on the embedded backend (no
callback retry) and is guarded by the `err`-gate on the server backend.

## Following the house pattern

Modeled on #4543: explicit behavior-change flag, a measured before/after, and a self-contained
Proof section. The stack is based on #4501 (the value-CAS primitive); review the CAS there and
the scope machinery here.
