### PR TITLE
fix(doctor): rig-pack-coverage recognizes same-name local pack replacements (#3907)

### DIFF
--- a/internal/doctor/checks_rig_coverage.go
+++ b/internal/doctor/checks_rig_coverage.go
@@ -82,7 +82,7 @@ func (c *RigPackCoverageCheck) Run(_ *CheckContext) *CheckResult {
 
 		var uncovered []string
 		for _, rig := range activeRigs {
-			if !rigHasPackDir(c.cfg.RigPackDirs, rig.Name, packDir) {
+			if !c.rigCoversPack(rig.Name, packDir, packName, sessions) {
 				uncovered = append(uncovered, rig.Name)
 			}
 		}
@@ -179,4 +179,49 @@ func rigHasPackDir(rigPackDirs map[string][]string, rigName, packDir string) boo
 		}
 	}
 	return false
+}
+
+// rigCoversPack reports whether rig rigName satisfies the always-session
+// coverage that packDir/packName declares — either by importing packDir
+// exactly, or by importing a rig-local pack with the same [pack].name
+// that declares at least the same rig-scoped always named_session
+// template(s). A rig-local replacement (a distinct namepool, local
+// prompt/formula changes, and so on) is a deliberate override, not a
+// coverage gap (#3907); exact-dir comparison alone can never recognize
+// one, since a real replacement's whole point is to live at a different
+// path than the pack it replaces.
+func (c *RigPackCoverageCheck) rigCoversPack(rigName, packDir, packName string, want []rigAlwaysSession) bool {
+	if rigHasPackDir(c.cfg.RigPackDirs, rigName, packDir) {
+		return true
+	}
+	for _, dir := range c.cfg.RigPackDirs[rigName] {
+		have, err := rigAlwaysSessions(dir)
+		if err != nil || len(have) == 0 {
+			continue
+		}
+		if have[0].packName != packName {
+			continue
+		}
+		if alwaysSessionTemplatesCovered(want, have) {
+			return true
+		}
+	}
+	return false
+}
+
+// alwaysSessionTemplatesCovered reports whether have declares at least
+// every template want requires. A same-named local replacement may add
+// extra sessions of its own; it just needs to keep the ones the city
+// pack's coverage check is tracking.
+func alwaysSessionTemplatesCovered(want, have []rigAlwaysSession) bool {
+	haveTemplates := make(map[string]bool, len(have))
+	for _, s := range have {
+		haveTemplates[s.template] = true
+	}
+	for _, s := range want {
+		if !haveTemplates[s.template] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/doctor/checks_rig_coverage_test.go
+++ b/internal/doctor/checks_rig_coverage_test.go
@@ -344,6 +344,98 @@ func TestRigPackCoverageCheck_MalformedPackToml(t *testing.T) {
 	}
 }
 
+// TestRigPackCoverageCheck_SameNameLocalReplacementCovers is the
+// regression for #3907: a rig-local pack replacement that shares the
+// city pack's [pack].name and declares the identical rig-scoped always
+// named_session is a deliberate override (a different polecat namepool,
+// local prompt/formula changes, etc.), not a coverage gap. rigHasPackDir
+// used to compare only exact absolute pack directory paths, so a rig
+// importing packs/gastown-dh instead of the city's remote gastown pack
+// always read as uncovered even though it declares the same required
+// session under the same pack name.
+func TestRigPackCoverageCheck_SameNameLocalReplacementCovers(t *testing.T) {
+	dir := t.TempDir()
+	cityPackDir := filepath.Join(dir, "packs", "gastown")
+	writeTestPack(t, cityPackDir, `
+[pack]
+name = "gastown"
+schema = 2
+
+[[named_session]]
+template = "witness"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, cityPackDir, "witness")
+
+	localReplacementDir := filepath.Join(dir, "packs", "gastown-dh")
+	writeTestPack(t, localReplacementDir, `
+[pack]
+name = "gastown"
+schema = 2
+
+[[named_session]]
+template = "witness"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, localReplacementDir, "witness")
+
+	cfg := &config.City{
+		PackDirs: []string{cityPackDir},
+		Rigs:     []config.Rig{{Name: "superlzy-dash"}},
+		RigPackDirs: map[string][]string{
+			"superlzy-dash": {localReplacementDir},
+		},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK (same-name local replacement declares the required session); msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+}
+
+// TestRigPackCoverageCheck_DifferentNameLocalPackStillUncovered guards
+// the #3907 fix's scope: a rig importing an unrelated local pack (a
+// different [pack].name) must still be reported as a genuine coverage
+// gap — the fix only recognizes a same-named replacement, not any local
+// pack at all.
+func TestRigPackCoverageCheck_DifferentNameLocalPackStillUncovered(t *testing.T) {
+	dir := t.TempDir()
+	cityPackDir := filepath.Join(dir, "packs", "gastown")
+	writeTestPack(t, cityPackDir, `
+[pack]
+name = "gastown"
+schema = 2
+
+[[named_session]]
+template = "witness"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, cityPackDir, "witness")
+
+	unrelatedDir := filepath.Join(dir, "packs", "other")
+	writeTestPack(t, unrelatedDir, `
+[pack]
+name = "other"
+schema = 2
+`)
+
+	cfg := &config.City{
+		PackDirs: []string{cityPackDir},
+		Rigs:     []config.Rig{{Name: "myproject"}},
+		RigPackDirs: map[string][]string{
+			"myproject": {unrelatedDir},
+		},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Errorf("status = %d, want Warning (unrelated local pack does not cover gastown's witness session); msg = %s", r.Status, r.Message)
+	}
+}
+
 func writeTestPack(t *testing.T, packDir, content string) {
 	t.Helper()
 	if err := os.MkdirAll(packDir, 0o755); err != nil {


### PR DESCRIPTION
## Summary

\`gc doctor\`'s \`rig-pack-coverage\` check false-positives when a rig deliberately replaces a city-imported pack with a local copy under the same \`[pack].name\`. Reported live from \`superlzy-city\`: the city imports the remote \`gastown\` pack, while two rigs (\`superlzy-dash\`, \`slc\`) each replace it with a local copy — distinct polecat namepool for one, local prompt/formula changes for the other — both declaring the identical rig-scoped always \`witness\` session. Doctor reported both rigs as missing coverage, even though each has an equivalent local pack. "Fixing" it by pointing the rigs back at the remote pack would remove the intended per-rig customization.

Fixes #3907.

## Fix

Root cause exactly as the issue's own analysis: \`internal/doctor/checks_rig_coverage.go\`'s \`rigHasPackDir\` compares only exact absolute pack directory paths — a rig-local replacement's whole point is to live at a *different* path than the pack it replaces, so it can never satisfy that comparison.

Added \`RigPackCoverageCheck.rigCoversPack\`: falls back to exact-dir match first (unchanged fast path), then scans the rig's other imported pack directories for one whose \`[pack].name\` matches the required pack's name and whose own rig-scoped always sessions cover (at least) the same template(s) the required pack declares. A same-named local pack that's missing one of the required sessions is still correctly reported as a gap — this only recognizes an equivalent replacement, not any same-named pack regardless of content. An unrelated local pack (different \`[pack].name\`) still reports as uncovered, unchanged.

## Test plan

Two new tests in \`checks_rig_coverage_test.go\`, RED-confirmed for the first:

- \`TestRigPackCoverageCheck_SameNameLocalReplacementCovers\` — the exact reported scenario (city \`gastown\` pack + a rig importing \`gastown-dh\`, same \`[pack].name = "gastown"\`, same always \`witness\` session). RED: \`Status = Warning\`, detail \`"pack \\"gastown\\" declares rig-scoped named_session \\"witness\\" ... but no rig imports this pack"\`. GREEN after the fix: \`Status = OK\`.
- \`TestRigPackCoverageCheck_DifferentNameLocalPackStillUncovered\` — guards the fix's scope: a rig importing an unrelated pack (different \`[pack].name\`) must still report as a genuine gap, not be swallowed by the new same-name path. Passed even before the fix (confirming it isn't a false negative introduced by loosening the check).

Full existing \`TestRigPackCoverageCheck_*\` suite (11 pre-existing tests covering suspended rigs, on-demand sessions, city-scoped sessions, multiple orphans, partial coverage, malformed pack.toml, etc.) re-run clean — no regressions from the added same-name fallback path.

- [x] Both new tests + full \`TestRigPackCoverageCheck_*\` suite (13 tests total): pass
- [x] Full \`internal/doctor\` package: pass
- [x] \`go test -tags gms_pure_go ./cmd/gc/... -run TestDoctor\`: pass
- [x] \`go build ./...\` (full repo, untagged): clean
- [x] \`go vet -tags gms_pure_go ./internal/doctor/... ./cmd/gc/...\`: clean
- [x] Full untagged pre-commit hook (\`lint-changed\`, spec/client/schema codegen, \`go vet ./...\`) passed clean, no \`--no-verify\`
- [x] Full sharded local test suite — pre-existing sandbox flakiness this run (recurring subprocess/timing/Docker/dolt-version-check failures seen across today's other pushes, including the known \`TestDoctorCheckVersionFloor\` timeout flake) — no \`TestRigPackCoverageCheck_*\` test (the code this change touches) appears in any failing shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGjSaP5EtcXZYqgBafw61m