### PR TITLE
fix(sling): warn when --on/default-formula attach drops the target bead's description (#3681)

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -389,12 +389,51 @@ func rootOnlyVaporPourHint(formulaName string, recipe *formula.Recipe) string {
 
 // slingOnFormula handles the --on formula attachment path.
 func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
-	return attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", result)
+	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", result)
+	if err == nil {
+		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
+			result.BeadWarnings = append(result.BeadWarnings, hint)
+		}
+	}
+	return result, err
+}
+
+// attachedBeadInstructionsDroppedHint returns a sling-time diagnostic when
+// --on/default-formula attaches a formula to an existing bead whose own
+// description carries real instructions. The formula wisp root's own
+// description is always the FORMULA's own boilerplate
+// (internal/formula/compile.go rootDesc), never the target bead's text, and
+// no formula var exposes the bead's Description either — so a bead's
+// instructions are otherwise silently invisible to the formula's rendered
+// context, unless the caller explicitly carries them in via
+// context_path/requirements_path (#3681). It changes neither routing nor
+// the materialized wisp.
+func attachedBeadInstructionsDroppedHint(querier BeadQuerier, beadID string, userVars []string) string {
+	if querier == nil || beadID == "" {
+		return ""
+	}
+	for _, v := range userVars {
+		key, _, ok := strings.Cut(v, "=")
+		if ok && (key == "context_path" || key == "requirements_path") {
+			return ""
+		}
+	}
+	bead, err := querier.Get(beadID)
+	if err != nil || strings.TrimSpace(bead.Description) == "" {
+		return ""
+	}
+	return fmt.Sprintf("note: bead %s's description is not carried into the formula's rendered context — pass --var context_path=<dir> or --var requirements_path=<doc> to include your instructions, or the formula's brainstorm will not see them.", beadID)
 }
 
 // slingDefaultFormula handles the default formula attachment path.
 func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
-	return attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", result)
+	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", result)
+	if err == nil {
+		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
+			result.BeadWarnings = append(result.BeadWarnings, hint)
+		}
+	}
+	return result, err
 }
 
 // attachFormulaToBead runs the shared formula-attachment pipeline for both the

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2290,6 +2290,90 @@ func TestSlingAttachFormula(t *testing.T) {
 	}
 }
 
+// TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped is the regression
+// for #3681: --on/AttachFormula never carries the target bead's own
+// description into the formula's rendered context — the wisp root's
+// description is always the formula's own boilerplate, and no formula var
+// exposes the bead's text either. A caller relying on the bead's
+// description as the actual build instructions silently gets a brainstorm
+// that never saw them. Warn instead of changing routing/materialization.
+func TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task", Description: "follow ~/rigs/ultimate-brain-mcp patterns"})
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := s.AttachFormula(context.Background(), "code-review", b.ID, a, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	found := false
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "not carried into the formula's rendered context") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("BeadWarnings = %#v, want a hint that the bead's description is dropped", result.BeadWarnings)
+	}
+}
+
+// TestSlingAttachFormulaNoWarningWhenContextPathProvided guards the
+// #3681 hint's scope: a caller who already passes context_path (or
+// requirements_path) has explicitly carried the instructions in some
+// form, so the generic hint would be noise.
+func TestSlingAttachFormulaNoWarningWhenContextPathProvided(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task", Description: "follow ~/rigs/ultimate-brain-mcp patterns"})
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := s.AttachFormula(context.Background(), "code-review", b.ID, a, FormulaOpts{Vars: []string{"context_path=/tmp/spec"}})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "not carried into the formula's rendered context") {
+			t.Errorf("BeadWarnings = %#v, want no drop hint once context_path is explicit", result.BeadWarnings)
+		}
+	}
+}
+
+// TestSlingAttachFormulaNoWarningWhenBeadHasNoDescription guards against
+// noise on the common case: a bare bead with no description text has
+// nothing to lose, so no hint should fire.
+func TestSlingAttachFormulaNoWarningWhenBeadHasNoDescription(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task"})
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := s.AttachFormula(context.Background(), "code-review", b.ID, a, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "not carried into the formula's rendered context") {
+			t.Errorf("BeadWarnings = %#v, want no drop hint for a description-less bead", result.BeadWarnings)
+		}
+	}
+}
+
 func TestSlingAttachFormulaRejectsMissingBead(t *testing.T) {
 	runner := newFakeRunner()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}


### PR DESCRIPTION
## Summary

\`gc sling <target> <bead> --on <formula>\` never carries the target bead's own description into the formula's rendered context. Reported live: a request to build a GCS-backed static-hosting MCP server (real instructions in the bead's description, "follow ~/rigs/ultimate-brain-mcp patterns") produced a plain local HTTP server with no Google Cloud at all, because the brainstorm only ever saw the generic formula-root boilerplate — the bead's actual intent was silently invisible.

The issue offers three fix directions (warn, auto-seed context, or document) without recommending one. Its cited "role-worker contract bars reading the parent bead" doesn't exist anywhere in gascity-src — confirmed by search; it's a prompt-fragment convention in a separate packs repo, so gascity-src itself has no architectural opinion on whether a formula template should reference the bead's text. Given that open design question, went with the safest option: **warn**, not auto-inject — same shape as #4524's fix earlier today (surface the gap, don't decide the semantics).

Fixes #3681.

## Fix

Confirmed the mechanism the issue describes is still exactly live: \`internal/formula/compile.go\`'s \`rootDesc := f.Description\` sources the wisp root's description from the **formula**, never the bead; \`internal/sling/sling.go\`'s \`buildSlingFormulaVars\` sets only the bead **ID** as the \`issue\` var (never Title/Description), and no build-base/compound-build template references \`{{issue}}\` anyway.

\`slingOnFormula\`/\`slingDefaultFormula\` (\`internal/sling/sling_core.go\`) now append a \`SlingResult.BeadWarnings\` hint when: the attach succeeded, the target bead's \`Description\` is non-empty, and the caller passed neither \`context_path\` nor \`requirements_path\` — the two vars that already exist specifically to carry text in (per the issue's own documented workaround). This exactly mirrors the existing \`rootOnlyVaporPourHint\` precedent (a formula-shape diagnostic surfaced the same way, changing neither routing nor the materialized wisp) — reused that established pattern rather than inventing a new one. Applied to both the explicit \`--on <formula>\` path and the implicit default-formula attach path, since both share the identical mechanism.

## Test plan

Three new tests in \`internal/sling/sling_test.go\`, RED-confirmed for the first (stashed the fix, ran, restored):

- \`TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped\` — a bead with a real description, no \`context_path\`/\`requirements_path\`. RED: \`BeadWarnings = nil\`. GREEN: warning present.
- \`TestSlingAttachFormulaNoWarningWhenContextPathProvided\` — guards the hint's scope: passing \`--var context_path=...\` explicitly suppresses it (the caller already carried the instructions in).
- \`TestSlingAttachFormulaNoWarningWhenBeadHasNoDescription\` — guards against noise on the common case: a bare bead with nothing to lose gets no hint.

- [x] All 3 new tests + full \`internal/sling\` package: pass
- [x] \`go test -tags gms_pure_go ./internal/api/... -run TestSling\` and \`./cmd/gc/... -run "TestSling|TestOnFormula|TestDoSling"\`: pass (both consumers of \`AttachFormula\`/the sling entry points)
- [x] \`go build ./...\` (full repo, untagged): clean
- [x] \`go vet -tags gms_pure_go ./internal/sling/... ./internal/api/... ./cmd/gc/...\`: clean
- [x] Full untagged pre-commit hook (\`lint-changed\`, spec/client/schema codegen, \`go vet ./...\`) passed clean, no \`--no-verify\`
- [x] Full sharded local test suite — pre-existing sandbox flakiness this run (recurring subprocess/timing/Docker/dolt-version-check failures seen across today's other pushes) — no \`TestSling*\`/\`TestOnFormula*\`/\`TestDoSling*\` test (the code this change touches) appears in any failing shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGjSaP5EtcXZYqgBafw61m