### PR TITLE
fix(storehealth): add an absolute-size floor so small cities don't permanently trip maintenance-overdue (#3374)

### DIFF
--- a/internal/storehealth/storehealth.go
+++ b/internal/storehealth/storehealth.go
@@ -24,6 +24,16 @@ import (
 // production (.beads/dolt at ~11 GB with ~64 rows).
 const DefaultThresholdMB = 1.0
 
+// MinWarnSizeBytes is the absolute floor below which the ratio-based
+// warning never fires, regardless of row count. A pure MB-per-row ratio
+// degenerates at small denominators: a healthy young city with only a
+// handful of live rows still carries Dolt's own baseline footprint
+// (oldgen archives, system tables) well into the hundreds of MB, which
+// would otherwise permanently trip the ratio threshold with nothing for
+// maintenance to reclaim -- gc dolt compact's own commit-count gate
+// correctly finds nothing to do, but the warning can never clear (#3374).
+const MinWarnSizeBytes = 1_000_000_000 // 1 GB
+
 // Health summarizes disk and maintenance health of the Dolt bead store.
 // A pointer *Health is included in status payloads so "no data" (e.g.
 // supervisor not running) is representable as nil rather than a
@@ -64,7 +74,7 @@ func Compute(cityPath string, sizeBytes int64, retainedRows int, lastGCAt time.T
 	}
 	if retainedRows > 0 {
 		h.RatioMB = float64(sizeBytes) / (bytesPerMB * float64(retainedRows))
-		h.Warning = sizeBytes > int64(DefaultThresholdMB*bytesPerMB)*int64(retainedRows)
+		h.Warning = sizeBytes > MinWarnSizeBytes && sizeBytes > int64(DefaultThresholdMB*bytesPerMB)*int64(retainedRows)
 	}
 	return h
 }

--- a/internal/storehealth/storehealth_test.go
+++ b/internal/storehealth/storehealth_test.go
@@ -84,7 +84,10 @@ func TestComputeZeroEverything(t *testing.T) {
 func TestComputeBoundary(t *testing.T) {
 	// Exactly at the threshold: size = 1M * rows should NOT warn
 	// (the inequality is strict ">", not ">=").
-	const rows = 10
+	// rows is large enough that the ratio threshold size clears
+	// MinWarnSizeBytes, so this exercises the ratio boundary alone,
+	// not the absolute-size floor (see TestComputeSmallStoreFloor).
+	const rows = 2000
 	h := Compute("/c", int64(DefaultThresholdMB*bytesPerMB)*int64(rows), rows, time.Time{}, "")
 	if h.Warning {
 		t.Fatalf("Warning = true at exact threshold, want false")
@@ -92,6 +95,39 @@ func TestComputeBoundary(t *testing.T) {
 	h = Compute("/c", int64(DefaultThresholdMB*bytesPerMB)*int64(rows)+1, rows, time.Time{}, "")
 	if !h.Warning {
 		t.Fatalf("Warning = false one byte over threshold, want true")
+	}
+}
+
+// TestComputeSmallStoreFloorSuppressesFalsePositive is the regression for
+// #3374: a young/small city with only a handful of live rows still carries
+// Dolt's own baseline footprint (oldgen archives, system tables) well into
+// the hundreds of MB, which permanently trips a pure MB-per-row ratio with
+// nothing for maintenance to reclaim — gc dolt compact's own commit-count
+// gate correctly finds nothing to do, but the warning could never clear.
+// Reproduces the reported numbers exactly: 343 MB at 7 live rows (~49
+// MB/row, far above the 1.0 MB/row ratio threshold) must not warn, since
+// the total size is still well under the absolute floor.
+func TestComputeSmallStoreFloorSuppressesFalsePositive(t *testing.T) {
+	const size = 343_000_000
+	h := Compute("/c", size, 7, time.Time{}, "")
+	if h.Warning {
+		t.Fatalf("Warning = true, want false (343MB/7 rows is below the absolute floor despite a high ratio)")
+	}
+	if h.RatioMB < 48 || h.RatioMB > 50 {
+		t.Fatalf("RatioMB = %v, want ~49 (the ratio itself is still reported for diagnostics)", h.RatioMB)
+	}
+}
+
+// TestComputeLargeStoreStillWarnsAboveFloor guards the fix's scope: the
+// floor only suppresses the false positive on genuinely small stores — the
+// real pathology the ratio check exists to catch (production case: ~11GB
+// at ~64 rows) must still warn once both the ratio AND the absolute floor
+// are exceeded.
+func TestComputeLargeStoreStillWarnsAboveFloor(t *testing.T) {
+	const size = 11_200_000_000
+	h := Compute("/c", size, 221, time.Time{}, "")
+	if !h.Warning {
+		t.Fatalf("Warning = false, want true (11.2GB/221 rows is well above both the ratio threshold and the absolute floor)")
 	}
 }
 


### PR DESCRIPTION
## Summary

\`gc status\`'s store-health "maintenance overdue" warning degenerates at small denominators: the check is a pure ratio (\`size_bytes > 1 MB/row\`), calibrated on a real production pathology (~11 GB at ~64 rows), but a healthy young city with only a handful of live rows still carries Dolt's own baseline footprint (oldgen archives, system tables) well into the hundreds of MB — so the ratio trips permanently even though \`gc order run mol-dog-compactor\` correctly finds nothing to reclaim (commit count far below its own 2000-commit flatten threshold). The warning can never clear, and trains every small-city operator to ignore it from day one — the operator's earliest signal for genuine unbounded growth.

Reported live numbers: 343 MB store, 7 live rows, ratio ~49 MB/row (threshold 1.0), permanent "⚠ maintenance overdue" with nothing to fix it.

Fixes #3374.

## Fix

Root cause confirmed still live and unchanged from the issue's own citation: \`internal/storehealth/storehealth.go\` \`Compute\` computes \`h.Warning = sizeBytes > int64(DefaultThresholdMB*bytesPerMB)*int64(retainedRows)\` with no absolute-size floor at all. Followed the issue's own first suggested direction (AND the ratio with an absolute-size floor) as the narrowest, safest option among its three — it doesn't change the ratio's semantics or touch the genuine pathology case, just gates the actionable warning behind a minimum total size.

Added \`MinWarnSizeBytes = 1_000_000_000\` (1 GB) as an AND'd condition alongside the existing ratio check. \`RatioMB\` is still computed and reported unconditionally (kept for diagnostics — an operator can see the ratio trending even below the floor), only \`Warning\` is gated.

## Test plan

Two new tests, RED-confirmed for the first (stashed the fix, ran, restored):

- \`TestComputeSmallStoreFloorSuppressesFalsePositive\` — reproduces the reported numbers exactly (343 MB / 7 rows, ratio ~49). RED: \`Warning = true\`. GREEN: \`Warning = false\`, \`RatioMB\` still ~49 (diagnostics preserved).
- \`TestComputeLargeStoreStillWarnsAboveFloor\` — guards the fix's scope: the genuine pathology (11.2 GB / 221 rows, the exact production case \`DefaultThresholdMB\` was calibrated on, already covered by the pre-existing \`TestComputeWarningHighRatio\`) must still warn once both the ratio and the floor are cleared.

Had to update the pre-existing \`TestComputeBoundary\`: it exercised the exact ratio-threshold boundary at \`rows=10\` (a 10 MB threshold size), which the new 1 GB floor would swamp regardless of the ratio. Bumped to \`rows=2000\` (2 GB threshold size, comfortably above the floor) so the test isolates the ratio boundary alone, as it always intended to — confirmed this rescaled version still passes against the pre-fix code (the floor addition is what's new, not a change to the boundary semantics).

- [x] Both new tests + full \`internal/storehealth\` package (14 tests): pass, no regressions
- [x] \`go test -tags gms_pure_go ./cmd/gc/... -run "TestStoreHealth|TestStatus"\` and \`./internal/api/... -run "TestStoreHealth|TestStatus"\`: pass (both consumers)
- [x] \`go build ./...\` (full repo, untagged): clean
- [x] \`go vet -tags gms_pure_go ./internal/storehealth/... ./cmd/gc/... ./internal/api/...\`: clean
- [x] Full untagged pre-commit hook (\`lint-changed\`, spec/client/schema codegen, \`go vet ./...\`) passed clean, no \`--no-verify\`
- [x] Full sharded local test suite — pre-existing sandbox flakiness this run (recurring subprocess/timing/Docker/dolt-version-check failures seen across today's other pushes) — no \`internal/storehealth\`/\`TestStoreHealth\`/\`TestStatus\` test appears in any failing shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGjSaP5EtcXZYqgBafw61m