### PR TITLE
Fix push ownership guard fallback for closed branch beads

### DIFF
--- a/release-gates/ga-j7y8e3-push-ownership-guard-assignee-fallback-gate.md
+++ b/release-gates/ga-j7y8e3-push-ownership-guard-assignee-fallback-gate.md
@@ -1,0 +1,52 @@
+# Release Gate: Push Ownership Guard Assignee Fallback
+
+Deploy bead: ga-j7y8e3
+Reviewed work bead: ga-fip9ps.3
+Reviewed source commit: 6a85f186a5daf0711882d5fd202325a9e14c9033
+Deploy branch: deploy/ga-j7y8e3-gate
+Base checked: origin/main at 98c30c2fe1fab09291685300198a37e7a4e4ab92
+
+Note: docs/PROJECT_MANIFEST.md is not present in this checkout; the deployer
+prompt release-gate criteria were applied.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first against the reviewed source commit with `git merge-tree --write-tree origin/main 6a85f186a5daf0711882d5fd202325a9e14c9033`; re-verified after the gate commit with `git merge-tree --write-tree origin/main HEAD`, which exited 0 with no conflicts. |
+| 1 | Review PASS present | PASS | `bd show ga-fip9ps.3` contains `Automated review (gascity/reviewer) - VERDICT: PASS` for commit `6a85f186a5daf0711882d5fd202325a9e14c9033`. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `scripts/push-ownership-guard.sh` and `scripts/test-push-ownership-guard.sh`. The guard now retries the full claim check against the session assignee bead only when the branch-encoded bead is terminal/closed; reassigned, rerouted, held, unreachable, timeout, and unparseable cases remain fail-closed. The fake `bd show` harness now supports id-specific responses for branch-vs-assignee fallback tests. |
+| 3 | Tests pass | PASS | `scripts/test-push-ownership-guard.sh` passed 21/21. `go test ./scripts/...` passed. `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh` passed. `gofmt -l scripts/` returned no files. `go vet ./...` passed. `make test-fast-parallel` passed all 8 fast shards. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list only two informational non-blocking observations and state no security defects found. Unresolved HIGH finding count: 0. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` in `/var/tmp/codex-gascity-ga-j7y8e3.mFa5R6` showed a clean `deploy/ga-j7y8e3-gate` worktree at the reviewed commit. Final clean status is checked after committing this gate file. |
+| 7 | Single feature theme | PASS | Single commit touches one subsystem: the push ownership guard and its dedicated test harness. No independent feature themes are bundled. |
+
+## Acceptance Checks
+
+- New fallback allow case is covered by `test_allow_fallback_when_branch_bead_closed_but_assignee_bead_valid`.
+- Invalid fallback candidate still blocks via `test_block_when_branch_bead_closed_and_assignee_bead_also_invalid`.
+- Existing stale-claim protections remain covered by the closed, reassigned, rerouted, hold, bd-unreachable, timeout, and hook push tests.
+- Branch mismatch behavior remains warning-only, while branch-name resolution still wins unless the branch bead specifically fails due to terminal status.
+
+## Command Evidence
+
+```text
+scripts/test-push-ownership-guard.sh
+pass=21 fail=0
+
+go test ./scripts/...
+ok  	github.com/gastownhall/gascity/scripts	15.850s
+ok  	github.com/gastownhall/gascity/scripts/cipolicy	(cached)
+
+shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh
+PASS
+
+gofmt -l scripts/
+PASS (no output)
+
+go vet ./...
+PASS
+
+make test-fast-parallel
+All fast jobs passed
+```

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -65,83 +65,66 @@ _pog_timeout() {
     fi
 }
 
-# _pog_resolve_bead_id: prints the bead id this push should be checked
-# against; prints nothing if none can be resolved. Resolution order:
-#   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)? —
-#      the bead's own id format, extended with an optional sub-bead suffix
-#      because this repo's real branch convention is
-#      builder/<bead-id>-<slug> and sub-beads (e.g. ga-fip9ps.1) are
-#      routine; the literal 6-char-only pattern would misresolve to the
-#      parent bead on a sub-bead's own branch.
-#   2. Falls back to this session's single in-progress assignment
-#      (bd list --assignee="$GC_AGENT" --status=in_progress --json) when
-#      the branch name doesn't match.
-# If both resolve and disagree, the branch match wins (it's the more
-# specific signal) and a warning goes to stderr — this is a best-effort
-# cross-check, not a hard failure, since branch-naming habits can
-# legitimately drift from bd's bookkeeping.
-#
-# KNOWN LIMITATION of path 2 (confirmed by manual repro, not yet filed as
-# its own bead): the fallback query itself filters on --status=in_progress,
-# so it cannot find a bead that has already left in_progress (e.g. closed
-# by the exact mayor ruling this guard exists to catch) by the time the
-# fallback runs. In that narrow intersection — branch name doesn't encode
-# the bead id AND the status flip lands before this resolves — no id
-# resolves at all, and assert_bead_still_claimed's "nothing to check"
-# branch below allows the push. This does NOT affect path 1: this repo's
-# real branch convention (builder/<bead-id>-<slug>) always encodes the
-# bead id, so the primary path is unaffected by a bead's status changing
-# out from under it — confirmed via manual repro, see
-# test_fallback_cannot_detect_staleness_after_status_leaves_in_progress in
-# scripts/test-push-ownership-guard.sh. The fallback query shape matches
-# ga-fip9ps.1's own spec verbatim; widening it (e.g. dropping the status
-# filter) trades this gap for ambiguous multi-match resolution against an
-# agent's whole bead history, which is a real design decision for whoever
-# owns that tradeoff, not a mechanical fix — left for a follow-up bead.
-# Prints nothing (not an error) when neither resolves — the caller treats
-# that as "nothing to check," which is what lets Layer A wire this in
-# unconditionally without blocking every push in the repo.
-_pog_resolve_bead_id() {
+# _pog_branch_bead_id: prints the bead id parsed from the current branch
+# name, matched against ga-[0-9a-z]{6}(\.[0-9]+)? — the bead's own id
+# format, extended with an optional sub-bead suffix because this repo's
+# real branch convention is builder/<bead-id>-<slug> and sub-beads (e.g.
+# ga-fip9ps.1) are routine; the literal 6-char-only pattern would
+# misresolve to the parent bead on a sub-bead's own branch. Prints nothing
+# if the branch doesn't match.
+_pog_branch_bead_id() {
     local branch=""
     branch="$(git symbolic-ref --short HEAD 2>/dev/null || git branch --show-current 2>/dev/null || true)"
-
-    local branch_id=""
     if [[ -n "$branch" ]]; then
-        branch_id="$(grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)?' <<<"$branch" | head -1 || true)"
+        grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)?' <<<"$branch" | head -1 || true
     fi
+}
 
-    local assignee_id=""
+# _pog_assignee_bead_id: prints this session's single in-progress bd
+# assignment (bd list --assignee="$GC_AGENT" --status=in_progress --json).
+# Prints nothing if none resolves.
+#
+# KNOWN LIMITATION (confirmed by manual repro, not yet filed as its own
+# bead): this query filters on --status=in_progress, so it cannot find a
+# bead that has already left that status (e.g. closed by the exact mayor
+# ruling this guard exists to catch) by the time it runs. When
+# _pog_branch_bead_id also doesn't resolve, that means no id resolves at
+# all and assert_bead_still_claimed's "nothing to check" branch allows the
+# push — see test_fallback_cannot_detect_staleness_after_status_leaves_in_progress
+# in scripts/test-push-ownership-guard.sh. This does NOT affect the branch
+# path: this repo's real branch convention (builder/<bead-id>-<slug>)
+# always encodes the bead id. Widening this query (e.g. dropping the status
+# filter) trades this gap for ambiguous multi-match resolution against an
+# agent's whole bead history — a real design decision, not a mechanical
+# fix — left for a follow-up bead.
+_pog_assignee_bead_id() {
     if [[ -n "${GC_AGENT:-}" ]] && command -v bd >/dev/null 2>&1; then
         local list_json
         list_json="$(_pog_timeout "$POG_TIMEOUT_SECONDS" bd list --assignee="$GC_AGENT" --status=in_progress --json 2>/dev/null || true)"
         if [[ -n "$list_json" ]]; then
-            assignee_id="$(jq -r '.[0].id // empty' <<<"$list_json" 2>/dev/null || true)"
+            jq -r '.[0].id // empty' <<<"$list_json" 2>/dev/null || true
         fi
-    fi
-
-    if [[ -n "$branch_id" && -n "$assignee_id" && "$branch_id" != "$assignee_id" ]]; then
-        echo "push-ownership-guard: WARNING branch name resolves to $branch_id but this session's in-progress assignment is $assignee_id; using $branch_id (branch name wins)" >&2
-    fi
-
-    if [[ -n "$branch_id" ]]; then
-        printf '%s' "$branch_id"
-    else
-        printf '%s' "$assignee_id"
     fi
 }
 
-# assert_bead_still_claimed: the exported guard. Returns 0 to allow the
-# push, non-zero to block it. See file header for the full contract.
-assert_bead_still_claimed() {
-    if [[ "${POG_DISABLE:-0}" == "1" ]]; then
-        return 0
-    fi
-
-    local id
-    id="$(_pog_resolve_bead_id)"
-    if [[ -z "$id" ]]; then
-        return 0  # nothing to check
-    fi
+# _pog_check_bead_claimed <id>: the core ownership/staleness check against
+# one resolved bead id. Prints a BLOCKED explanation to stderr and returns
+# non-zero if the check fails, 0 if it passes.
+#   Return codes:
+#     0 — claim confirmed, still valid.
+#     2 — blocked because the bead's status is terminal (not
+#         in_progress/open). This is the ONLY failure mode
+#         assert_bead_still_claimed treats as retryable against a fallback
+#         id, since a branch-encoded bead closing via a normal handoff
+#         looks identical, from here, to one closed out from under this
+#         push — the caller distinguishes them by whether a separate,
+#         still-valid assignment exists.
+#     1 — blocked for any other reason (bd unreachable, timed out,
+#         unparseable, reassigned, rerouted, held). Not retryable: these
+#         mean this session's specific claim was actively superseded, which
+#         a fallback id must never paper over.
+_pog_check_bead_claimed() {
+    local id="$1"
 
     if ! command -v bd >/dev/null 2>&1; then
         echo "push-ownership-guard: BLOCKED — bd is not on PATH, cannot verify $id is still claimed. Bypass with: git push --no-verify" >&2
@@ -166,7 +149,7 @@ assert_bead_still_claimed() {
 
     if [[ "$status" != "in_progress" && "$status" != "open" ]]; then
         echo "push-ownership-guard: BLOCKED — $id status is '$status', not in_progress/open; the claim behind this push is stale. Bypass with: git push --no-verify" >&2
-        return 1
+        return 2
     fi
 
     # A session-run claim sets bead.assignee from the first non-empty of
@@ -207,4 +190,62 @@ assert_bead_still_claimed() {
     fi
 
     return 0
+}
+
+# assert_bead_still_claimed: the exported guard. Returns 0 to allow the
+# push, non-zero to block it. See file header for the full contract.
+#
+# Resolves branch_id and assignee_id separately (rather than collapsing to
+# one winner up front) because it needs both: branch_id is checked first
+# (it's the more specific signal — see _pog_branch_bead_id), but when
+# branch_id's bead has legitimately closed (e.g. ga-hilw2y — a builder's
+# branch still names the bead that originally spawned it after that bead
+# closed normally into a separate deploy-tracking bead), this retries the
+# full check against assignee_id rather than treating an ordinary handoff
+# as staleness. If both resolve and disagree, a warning goes to stderr
+# either way — a best-effort cross-check, not a hard failure, since
+# branch-naming habits can legitimately drift from bd's bookkeeping.
+assert_bead_still_claimed() {
+    if [[ "${POG_DISABLE:-0}" == "1" ]]; then
+        return 0
+    fi
+
+    local branch_id assignee_id
+    branch_id="$(_pog_branch_bead_id)"
+    assignee_id="$(_pog_assignee_bead_id)"
+
+    if [[ -n "$branch_id" && -n "$assignee_id" && "$branch_id" != "$assignee_id" ]]; then
+        echo "push-ownership-guard: WARNING branch name resolves to $branch_id but this session's in-progress assignment is $assignee_id; using $branch_id (branch name wins)" >&2
+    fi
+
+    local id="$branch_id"
+    [[ -z "$id" ]] && id="$assignee_id"
+    if [[ -z "$id" ]]; then
+        return 0  # nothing to check
+    fi
+
+    _pog_check_bead_claimed "$id"
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        return 0
+    fi
+
+    # Retry against the assignee bead ONLY when the branch-encoded bead
+    # specifically failed on terminal status (rc=2) and a distinct
+    # assignee bead exists — e.g. ga-hilw2y, where the branch still names
+    # the bead that originally spawned it after that bead closed normally
+    # into a separate deploy-tracking bead. Any other block reason
+    # (reassigned/rerouted/held, rc=1) is NOT retried: those mean this
+    # session's specific claim was actively superseded, which must keep
+    # blocking exactly as before even though branch_id's bead is still
+    # in_progress/open.
+    if [[ $rc -eq 2 && "$id" == "$branch_id" && -n "$assignee_id" && "$assignee_id" != "$branch_id" ]]; then
+        echo "push-ownership-guard: $branch_id is closed but this session's own in-progress assignment is $assignee_id; retrying against it before blocking" >&2
+        if _pog_check_bead_claimed "$assignee_id"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    return 1
 }

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -2,7 +2,7 @@
 #
 # test-push-ownership-guard.sh — unit tests for the pre-push bead
 # ownership/staleness guard (bead ga-fip9ps.1; guards the race described in
-# ga-fip9ps). Three layers:
+# ga-fip9ps). Four layers:
 #
 #   1. assert_bead_still_claimed (scripts/push-ownership-guard.sh) exercised
 #      directly against real temp git repos with a fake `bd` on PATH: allow
@@ -14,8 +14,13 @@
 #      neither resolves (nothing to check — required for Layer A to be
 #      wired in unconditionally without blocking unrelated pushes). Also
 #      pins a known limitation of that fallback — see the KNOWN LIMITATION
-#      comment on _pog_resolve_bead_id in push-ownership-guard.sh.
-#   3. Hook wiring: a real .githooks/pre-push, installed into a real temp
+#      comment on _pog_assignee_bead_id in push-ownership-guard.sh.
+#   3. Fallback-to-assignee retry (ga-fip9ps.3, ga-hilw2y): when the
+#      branch-encoded bead has closed via a legitimate handoff rather than
+#      being reassigned/rerouted/held out from under this session, retries
+#      the full check against this session's own in-progress assignment
+#      before blocking.
+#   4. Hook wiring: a real .githooks/pre-push, installed into a real temp
 #      repo pushing to a real bare remote, actually rejects a stale-claim
 #      push, actually allows a clean one, and `--no-verify` actually
 #      bypasses the guard end to end.
@@ -82,8 +87,16 @@ remote_sha() {
 # Fake `bd`: behavior driven by state files, so each test writes exactly the
 # response it needs without a combinatorial helper signature.
 #
+#   <dir>/fake-bd-state/show-json-<id> -- `bd show <id> --json` echoes this
+#                                       verbatim (exit 0) when present —
+#                                       checked before the generic file below,
+#                                       so a test can give two different ids
+#                                       two different responses (needed for
+#                                       the branch-bead-closed/assignee-bead-
+#                                       fallback tests).
 #   <dir>/fake-bd-state/show-json   -- `bd show <any-id> --json` echoes this
-#                                       verbatim (exit 0).
+#                                       verbatim (exit 0) when no id-specific
+#                                       file matches.
 #   <dir>/fake-bd-state/show-exit   -- if present, `bd show` exits with this
 #                                       code instead (no output) — simulates
 #                                       bd/Dolt unreachable.
@@ -109,6 +122,10 @@ case "$1" in
     if [ -f "$state/show-exit" ]; then
       exit "$(cat "$state/show-exit")"
     fi
+    if [ -f "$state/show-json-$2" ]; then
+      cat "$state/show-json-$2"
+      exit 0
+    fi
     if [ -f "$state/show-json" ]; then
       cat "$state/show-json"
       exit 0
@@ -132,11 +149,20 @@ FAKE
 }
 
 # write_show_json <fake-bd-dir> <id> <status> <assignee> <routed_to> [labels-json-array]
+#
+# Writes both the generic show-json fallback AND an id-specific
+# show-json-<id> file, so tests that only ever query one id behave exactly
+# as before (last writer of the generic file, which is also the one
+# id-specific file that matters), while tests that query two distinct ids
+# (e.g. a closed branch-bead and a valid assignee-bead) can call this twice
+# with different ids and get independently correct responses.
 write_show_json() {
     local fbd="$1" id="$2" status="$3" assignee="$4" routed_to="$5" labels="${6:-[]}"
     mkdir -p "$fbd/fake-bd-state"
     printf '[{"id":"%s","status":"%s","assignee":"%s","metadata":{"gc.routed_to":"%s"},"labels":%s}]' \
         "$id" "$status" "$assignee" "$routed_to" "$labels" > "$fbd/fake-bd-state/show-json"
+    printf '[{"id":"%s","status":"%s","assignee":"%s","metadata":{"gc.routed_to":"%s"},"labels":%s}]' \
+        "$id" "$status" "$assignee" "$routed_to" "$labels" > "$fbd/fake-bd-state/show-json-$id"
 }
 
 # run_guard <repo> <fake-bd-dir> <gc-agent> <gc-template> [pog-timeout-seconds] [gc-session-id] [gc-session-name]
@@ -324,6 +350,55 @@ test_block_on_bd_timeout() {
 }
 
 # ---------------------------------------------------------------------------
+# Fallback to the assignee bead when the branch-encoded bead closed via a
+# legitimate handoff (ga-hilw2y: a builder's branch still names the bead
+# that originally spawned it — e.g. ga-zogqc1.1 — after that bead closed
+# normally into a separate deploy-tracking bead; the guard must not treat
+# that ordinary handoff as staleness when this session's own in-progress
+# assignment is a different, still-valid bead).
+# ---------------------------------------------------------------------------
+
+test_allow_fallback_when_branch_bead_closed_but_assignee_bead_valid() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    # Branch-encoded bead closed via a normal handoff...
+    write_show_json "$fbd" "ga-abc123.1" "closed" "agent-x" "tmpl-x" "[]"
+    # ...but this session's own in-progress assignment is a distinct,
+    # still-valid bead.
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-fallbk.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]] && grep -q "ga-fallbk.3" <<<"$out"; then
+        record_pass "fallback/allow-when-branch-bead-closed-but-assignee-bead-valid (rc=0, names the fallback id)"
+    else
+        record_fail "fallback/allow-when-branch-bead-closed-but-assignee-bead-valid" "expected rc=0 naming ga-fallbk.3, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_block_when_branch_bead_closed_and_assignee_bead_also_invalid() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    write_show_json "$fbd" "ga-abc123.1" "closed" "agent-x" "tmpl-x" "[]"
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    # The fallback candidate is ALSO invalid (closed) — the fallback must be
+    # fully re-validated, not a blanket allow just because a distinct
+    # assignee id exists.
+    write_show_json "$fbd" "ga-fallbk.3" "closed" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]] && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "fallback/block-when-branch-bead-closed-and-assignee-bead-also-invalid (rc=$rc, still blocks)"
+    else
+        record_fail "fallback/block-when-branch-bead-closed-and-assignee-bead-also-invalid" "expected non-zero rc mentioning --no-verify, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# ---------------------------------------------------------------------------
 # Bead-id resolution.
 # ---------------------------------------------------------------------------
 
@@ -380,7 +455,7 @@ test_allow_when_no_bead_id_resolvable() {
 # --status=in_progress, so it cannot find a bead that has already left that
 # status (e.g. closed by the exact mayor ruling this guard exists to catch)
 # by the time the fallback runs. See the KNOWN LIMITATION comment on
-# _pog_resolve_bead_id in push-ownership-guard.sh — this pins the current,
+# _pog_assignee_bead_id in push-ownership-guard.sh — this pins the current,
 # spec-compliant behavior so a change to the fallback algorithm is a
 # deliberate, visible decision, not a silent regression either direction.
 # Confirmed against a real bd via manual repro (ga-fip9ps.1 bead notes);
@@ -539,6 +614,8 @@ run_all() {
     test_block_on_hold_external
     test_block_on_bd_unreachable
     test_block_on_bd_timeout
+    test_allow_fallback_when_branch_bead_closed_but_assignee_bead_valid
+    test_block_when_branch_bead_closed_and_assignee_bead_also_invalid
     test_bead_id_branch_wins_and_warns_on_disagreement
     test_bead_id_fallback_used_when_branch_no_match
     test_allow_when_no_bead_id_resolvable


### PR DESCRIPTION
## What this changes

The pre-push ownership guard now allows the normal handoff case where the branch name still points at a bead that has already closed, but the current deployer session has a separate valid in-progress assignee bead. This prevents legitimate deploy pushes from being blocked only because branch names are stable across pipeline handoffs.

The stale-push protections remain fail-closed for the important race cases: if the branch bead is still open or in progress but has been reassigned, rerouted, held, timed out, or cannot be read, the guard still blocks the push.

## Review notes

- `scripts/push-ownership-guard.sh` now resolves branch and assignee bead IDs separately and only falls back on terminal branch-bead status.
- `scripts/test-push-ownership-guard.sh` extends the fake `bd show` harness so tests can model different branch and assignee beads.
- No config, API, schema, or migration behavior changes.

## Test plan

- [x] `scripts/test-push-ownership-guard.sh` - 21/21 checks pass
- [x] `go test ./scripts/...`
- [x] `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh`
- [x] `gofmt -l scripts/`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-j7y8e3-push-ownership-guard-assignee-fallback-gate.md`](release-gates/ga-j7y8e3-push-ownership-guard-assignee-fallback-gate.md)