### PR TITLE
test: recognize dynamic force-with-lease wiring

### DIFF
--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -512,15 +512,18 @@ test_pre_push_hook_sources_and_calls_guard() {
 
 test_rebase_lib_calls_guard_before_force_with_lease() {
     local rebase_lib="$REPO_ROOT/scripts/rebase-resolve-lib.sh"
-    local guard_line push_line
-    guard_line="$(grep -n "assert_bead_still_claimed" "$rebase_lib" 2>/dev/null | tail -1 | cut -d: -f1)"
+    local guard_line lease_line push_line
+    guard_line="$(grep -nF "assert_bead_still_claimed" "$rebase_lib" 2>/dev/null | tail -1 | cut -d: -f1)"
     # SC2016 intentional: literal-text search of rebase-resolve-lib.sh source.
     # shellcheck disable=SC2016
-    push_line="$(grep -n 'git push --force-with-lease origin "\$branch"' "$rebase_lib" 2>/dev/null | tail -1 | cut -d: -f1)"
-    if [[ -n "$guard_line" && -n "$push_line" && "$guard_line" -lt "$push_line" ]]; then
+    lease_line="$(grep -nF 'lease_arg="--force-with-lease=$branch:$expected_remote_sha"' "$rebase_lib" 2>/dev/null | tail -1 | cut -d: -f1)"
+    # shellcheck disable=SC2016
+    push_line="$(grep -nF 'git push "$lease_arg" origin "$branch"' "$rebase_lib" 2>/dev/null | tail -1 | cut -d: -f1)"
+    if [[ -n "$guard_line" && -n "$lease_line" && -n "$push_line" \
+        && "$guard_line" -lt "$lease_line" && "$lease_line" -lt "$push_line" ]]; then
         record_pass "wiring/rebase-lib-calls-guard-before-force-with-lease"
     else
-        record_fail "wiring/rebase-lib-calls-guard-before-force-with-lease" "guard_line=$guard_line push_line=$push_line (guard must precede the push)"
+        record_fail "wiring/rebase-lib-calls-guard-before-force-with-lease" "guard_line=$guard_line lease_line=$lease_line push_line=$push_line (guard must precede lease construction and guarded push)"
     fi
 }
 


### PR DESCRIPTION
## Summary

- Update the push-ownership wiring owner for the dynamic `lease_arg` form introduced by #4536.
- Require the ownership guard, explicit expected-SHA force-with-lease construction, and guarded push to appear in that order.
- Leave production behavior unchanged.

## Why

Current `main` deterministically fails `TestPushOwnershipGuard` because the test still searches for the retired inline push literal. That base failure blocks otherwise-green PRs, including #4559.

## Verification

- `scripts/test-push-ownership-guard.sh` — 19/19 passed
- `scripts/test-rebase-resolve.sh` — 23/23 passed
- `GOFLAGS=-mod=readonly go test ./scripts -run ^TestPushOwnershipGuard$ -count=1`
- `shellcheck scripts/test-push-ownership-guard.sh`
- `bash -n scripts/test-push-ownership-guard.sh`
- Full six-shard fast pre-push suite
- Mutation probes: removing the guard, lease construction, or quoted lease consumption fails the wiring owner

## Review

Two independent delegated reviewers approved staged diff hash `4d2798a280d3c68beb71697638e97908d515ebc9bc508bcf19e54e4ef4ecba11` with no findings.

Bead: `ga-yrotsuu.24`
Prerequisite for #4559.