### PR TITLE
fix(doctor): bd-backup-freshness reads the active backup pipeline's state

### DIFF
--- a/internal/doctor/checks_bd_backup_freshness.go
+++ b/internal/doctor/checks_bd_backup_freshness.go
@@ -103,7 +103,9 @@ func (c *BdBackupFreshnessCheck) Run(_ *CheckContext) *CheckResult {
 	r.Message = strings.Join(findings, "; ")
 	r.FixHint = "re-enable or repair the bd backup pipeline for the listed scopes " +
 		"(bd backup sync; verify backup.enabled and BD_BACKUP_ENABLED), then confirm " +
-		"bd backup status shows a recent sync"
+		"bd backup status shows a recent sync for the store named in the finding — " +
+		"a 'dolt backup' finding clears via the Dolt Backup: Last sync field, not " +
+		"the legacy Backup: block, which stays frozen after migration"
 	return r
 }
 
@@ -141,10 +143,85 @@ func (c *BdBackupFreshnessCheck) freshnessScanTargets() []bdBackupFreshnessTarge
 	return targets
 }
 
-// scanBackupFreshness reads <beadsDir>/backup/backup_state.json and returns a
-// finding when the last sync is older than maxAge or the timestamp cannot be
-// read. A missing backup_state.json returns ("", false) — not this check's job.
+// scanBackupFreshness reports whether a scope's ACTIVE backup pipeline has
+// stopped syncing.
+//
+// A scope has two possible pipelines and they record their progress in
+// different files, and the two are ORTHOGONAL: registering a Dolt backup
+// destination (.beads/dolt-backup.json) does not disable the legacy
+// embedded-store pipeline, and `bd backup sync` writes only
+// .beads/dolt-backup-state.json (updateDoltBackupState) — never
+// .beads/backup/backup_state.json.
+//
+// So the two files are advanced by two different writers. On a scope where the
+// legacy auto-backup is disabled, its writer never runs, and
+// backup_state.json holds whatever it last recorded — while every BACKUP
+// action the operator can take drives the OTHER pipeline's state file.
+//
+// The state this check did not model is "had a legacy bd backup, THEN gained a
+// Dolt destination". It handles never-had-one (skip) and had-one-that-stopped
+// (warn), but a scope whose legacy file is stale *because the live pipeline
+// moved elsewhere* is reported as a broken backup pipeline while its actual
+// backup is current. The FixHint compounds it by prescribing `bd backup sync`,
+// which drives the Dolt pipeline and so cannot refresh the field being read.
+//
+// Note the warning condition itself implies the legacy pipeline is not
+// running: were it still writing, backup_state.json would be fresh and this
+// check would not fire at all.
+//
+// Note the check is not unclearable in the absolute — removing the legacy
+// .beads/backup directory makes scanBackupFreshness skip the scope entirely.
+// But no BACKUP action clears it: syncing the pipeline that is actually
+// protecting the scope never moves the field this check reads.
+//
+// Reading the Dolt registration here is consistent with the rest of the
+// package rather than novel: checks_bd_backup_state.go already treats
+// .beads/dolt-backup.json as first-class when detecting stale registrations.
+// This check alone ignored it.
+//
+// There is also a correctness stake beyond noise: the stale legacy state
+// advertises a Dolt commit written before the destination was registered, so an
+// incident responder restoring from that pointer recovers a pre-migration
+// snapshot while believing the scope is current.
+//
+// So: prefer the Dolt backup state whenever a Dolt destination is registered,
+// and fall back to the legacy file only for scopes that never migrated. Each
+// finding names the store it describes, so the reader is never left guessing
+// which of the two a message is about. A scope with neither file returns
+// ("", false) — "no backup at all" is DoltBackupCheck's job, not this one's.
 func scanBackupFreshness(label, beadsDir string, now time.Time, maxAge time.Duration) (string, bool) {
+	if _, err := os.Stat(filepath.Join(beadsDir, "dolt-backup.json")); err == nil {
+		return scanDoltBackupFreshness(label, beadsDir, now, maxAge)
+	}
+	return scanLegacyBackupFreshness(label, beadsDir, now, maxAge)
+}
+
+// scanDoltBackupFreshness reads <beadsDir>/dolt-backup-state.json, the file a
+// successful Dolt backup sync stamps. A registered destination with no state
+// file at all is a real finding — it means the backup has never once completed.
+func scanDoltBackupFreshness(label, beadsDir string, now time.Time, maxAge time.Duration) (string, bool) {
+	const store = "dolt backup"
+	path := filepath.Join(beadsDir, "dolt-backup-state.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Sprintf("%s: %s is registered (dolt-backup.json) but has never synced "+
+				"— no dolt-backup-state.json", label, store), true
+		}
+		return fmt.Sprintf("%s: read dolt-backup-state.json: %v", label, err), true
+	}
+	var state struct {
+		LastSync string `json:"last_sync"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Sprintf("%s: dolt-backup-state.json is unparseable: %v", label, err), true
+	}
+	return freshnessFinding(label, store, "dolt-backup-state.json", "last_sync", state.LastSync, now, maxAge)
+}
+
+// scanLegacyBackupFreshness reads <beadsDir>/backup/backup_state.json for scopes
+// that have not migrated to a Dolt backup destination.
+func scanLegacyBackupFreshness(label, beadsDir string, now time.Time, maxAge time.Duration) (string, bool) {
 	path := filepath.Join(beadsDir, "backup", "backup_state.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -159,17 +236,24 @@ func scanBackupFreshness(label, beadsDir string, now time.Time, maxAge time.Dura
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Sprintf("%s: backup_state.json is unparseable: %v", label, err), true
 	}
-	ts := strings.TrimSpace(state.Timestamp)
+	return freshnessFinding(label, "embedded-store backup", "backup_state.json", "timestamp", state.Timestamp, now, maxAge)
+}
+
+// freshnessFinding turns one pipeline's recorded sync timestamp into a finding,
+// naming both the store and the field it came from so the message is traceable
+// back to the file the check actually read.
+func freshnessFinding(label, store, file, field, raw string, now time.Time, maxAge time.Duration) (string, bool) {
+	ts := strings.TrimSpace(raw)
 	if ts == "" {
-		return fmt.Sprintf("%s: backup_state.json has no timestamp", label), true
+		return fmt.Sprintf("%s: %s: %s has no %s", label, store, file, field), true
 	}
 	synced, err := time.Parse(time.RFC3339, ts)
 	if err != nil {
-		return fmt.Sprintf("%s: backup_state.json timestamp %q is unparseable: %v", label, ts, err), true
+		return fmt.Sprintf("%s: %s: %s %s %q is unparseable: %v", label, store, file, field, ts, err), true
 	}
 	if age := now.Sub(synced); age > maxAge {
-		return fmt.Sprintf("%s: last bd backup sync was %s ago (> %s) — backup pipeline may be disabled or broken",
-			label, age.Round(time.Minute), maxAge), true
+		return fmt.Sprintf("%s: %s: last sync was %s ago (> %s) — backup pipeline may be disabled or broken",
+			label, store, age.Round(time.Minute), maxAge), true
 	}
 	return "", false
 }

--- a/internal/doctor/checks_bd_backup_freshness_test.go
+++ b/internal/doctor/checks_bd_backup_freshness_test.go
@@ -167,7 +167,7 @@ func TestBdBackupFreshnessCheck(t *testing.T) {
 		}
 	})
 
-	// Unmigrated scopes must keep their existing behaviour.
+	// Unmigrated scopes must keep their existing behavior.
 	t.Run("unmigrated scope still reads the legacy file", func(t *testing.T) {
 		scope := t.TempDir()
 		writeBackupStateForFreshness(t, scope, now.Add(-72*time.Hour).Format(time.RFC3339Nano))

--- a/internal/doctor/checks_bd_backup_freshness_test.go
+++ b/internal/doctor/checks_bd_backup_freshness_test.go
@@ -20,6 +20,33 @@ func writeBackupStateForFreshness(t *testing.T, scopeRoot, timestamp string) {
 	}
 }
 
+// writeDoltBackupRegistration marks a scope as migrated to a Dolt backup
+// destination, which is what makes the Dolt state file authoritative for it.
+func writeDoltBackupRegistration(t *testing.T, scopeRoot string) {
+	t.Helper()
+	dir := filepath.Join(scopeRoot, ".beads")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	body := `{"backup_url":"file:///tmp/backup-dest","backup_name":"default"}`
+	if err := os.WriteFile(filepath.Join(dir, "dolt-backup.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write dolt-backup.json: %v", err)
+	}
+}
+
+// writeDoltBackupState stamps the file a successful Dolt backup sync writes.
+func writeDoltBackupState(t *testing.T, scopeRoot, lastSync string) {
+	t.Helper()
+	dir := filepath.Join(scopeRoot, ".beads")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	body := `{"last_sync":"` + lastSync + `","duration":"25ms"}`
+	if err := os.WriteFile(filepath.Join(dir, "dolt-backup-state.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write dolt-backup-state.json: %v", err)
+	}
+}
+
 func TestBdBackupFreshnessCheck(t *testing.T) {
 	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	clock := func() time.Time { return now }
@@ -89,6 +116,68 @@ func TestBdBackupFreshnessCheck(t *testing.T) {
 		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{fresh, stale}, maxAge, clock).Run(nil)
 		if r.Status != StatusWarning {
 			t.Fatalf("mixed: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+	})
+
+	// A scope that has migrated to a Dolt backup destination must be judged on
+	// the Dolt state file. Reading the legacy backup_state.json there produces a
+	// warning no operator can clear, because a successful sync never writes it.
+	t.Run("migrated scope is judged on the dolt backup state, not the frozen legacy file", func(t *testing.T) {
+		scope := t.TempDir()
+		// Legacy file frozen at migration time — a week stale, and stays that way.
+		writeBackupStateForFreshness(t, scope, now.Add(-168*time.Hour).Format(time.RFC3339Nano))
+		writeDoltBackupRegistration(t, scope)
+		writeDoltBackupState(t, scope, now.Add(-1*time.Minute).Format(time.RFC3339Nano))
+
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusOK {
+			t.Fatalf("fresh dolt backup alongside frozen legacy state: want StatusOK, got %v (%s)", r.Status, r.Message)
+		}
+	})
+
+	// The falsifiable case: the check must still fire on a genuinely stale Dolt
+	// backup. A check that only ever passes is worse than the false positive it
+	// replaced, so this failing case is what makes the OK above meaningful.
+	t.Run("stale dolt backup still warns", func(t *testing.T) {
+		scope := t.TempDir()
+		writeDoltBackupRegistration(t, scope)
+		writeDoltBackupState(t, scope, now.Add(-72*time.Hour).Format(time.RFC3339Nano))
+
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusWarning {
+			t.Fatalf("stale dolt backup: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "dolt backup") {
+			t.Fatalf("finding must name the store it describes, got %q", r.Message)
+		}
+	})
+
+	// A registered destination that has never completed a sync is a real gap,
+	// not a scope to skip — the absent state file is the only evidence of it.
+	t.Run("registered dolt backup that never synced warns", func(t *testing.T) {
+		scope := t.TempDir()
+		writeDoltBackupRegistration(t, scope) // no dolt-backup-state.json
+
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusWarning {
+			t.Fatalf("never-synced dolt backup: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "never synced") {
+			t.Fatalf("message should say the backup never synced, got %q", r.Message)
+		}
+	})
+
+	// Unmigrated scopes must keep their existing behaviour.
+	t.Run("unmigrated scope still reads the legacy file", func(t *testing.T) {
+		scope := t.TempDir()
+		writeBackupStateForFreshness(t, scope, now.Add(-72*time.Hour).Format(time.RFC3339Nano))
+
+		r := NewBdBackupFreshnessCheckForScopeRoots("", []string{scope}, maxAge, clock).Run(nil)
+		if r.Status != StatusWarning {
+			t.Fatalf("stale legacy backup: want StatusWarning, got %v (%s)", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "embedded-store backup") {
+			t.Fatalf("finding must name the store it describes, got %q", r.Message)
 		}
 	})
 


### PR DESCRIPTION
## Problem

`bd-backup-freshness` (the doctor check) reads `.beads/backup/backup_state.json` for every scope. That file and `.beads/dolt-backup-state.json` are advanced by **two different writers**, and the pipelines are orthogonal: registering a Dolt backup destination (`.beads/dolt-backup.json`) does not disable the legacy embedded-store pipeline, and `bd backup sync` writes only the Dolt state file — never `backup_state.json`.

So on a scope whose legacy auto-backup is disabled, the legacy writer never runs and `backup_state.json` holds whatever it last recorded, while every BACKUP action the operator can take drives the *other* pipeline's state file. The state the check did not model is "had a legacy `bd backup`, **then** gained a Dolt destination": it is reported as a broken backup pipeline while its actual backup is current.

Observed on such a scope: `bd backup sync` succeeded while the reported age went **177h58m → 178h2m** — i.e. health went *backwards* across a successful sync. The FixHint compounds it by prescribing `bd backup sync`, which drives the Dolt pipeline and so cannot refresh the field being read.

## Fix

When a Dolt backup destination is registered (`dolt-backup.json` present), read the Dolt pipeline's state (`dolt-backup-state.json`) via a new `scanDoltBackupFreshness`; otherwise fall back to the legacy scan. The finding now clears via the field the live pipeline actually advances.

Two files: `internal/doctor/checks_bd_backup_freshness.go` (+102/−9) and its test (+89).

## Provenance & re-validation

- Fix authored at commit `ccd729e3b`; this PR replays it (plus a `behaviour`→`behavior` comment lint fix) onto current `main`.
- **Cherry-picks clean onto `main` @ `6ba5a29f1`** (merge-tree, no conflict).
- **Still absent from `main`**: `main`'s `checks_bd_backup_freshness.go` exists but has no `scanDoltBackupFreshness` / `dolt-backup-state.json` path (verified by content; a positive control on the same file confirms the grep is not blind).
- **Lint-clean** under the version CI pins — `golangci-lint 2.12.0`, `run ./internal/doctor/...` → `0 issues` (the repo bumped the pin 2.9.0 → 2.12.0; re-checked under the new version, not the old).
