### PR TITLE
fix(session): back off deferred-singleton pool-alias retries instead of spinning

### DIFF
--- a/cmd/gc/build_desired_state_pool_info.go
+++ b/cmd/gc/build_desired_state_pool_info.go
@@ -378,7 +378,11 @@ func normalizeNonExpandingPoolSessionInfo(
 // recordDeferredNonExpandingPoolAliasConflictInfo is the session.Info sibling of
 // recordDeferredNonExpandingPoolAliasConflict. It records the deferred-alias
 // bookkeeping via the SAME bp.beadStore.Update and folds the batch onto the
-// returned Info (ApplyPatch), the authoritative post-write value.
+// returned Info (ApplyPatch), the authoritative post-write value. Writes are
+// throttled by the shared deferredSingletonAliasRetryDue backoff gate (see
+// session_beads.go) keyed off the same pool_alias_conflict_at field the
+// sync-time path reads, so this call site cannot reset that path's clock
+// without also being subject to it.
 func recordDeferredNonExpandingPoolAliasConflictInfo(
 	bp *agentBuildParams,
 	cfgAgent *config.Agent,
@@ -388,6 +392,16 @@ func recordDeferredNonExpandingPoolAliasConflictInfo(
 	count := 0
 	if existing, err := strconv.Atoi(strings.TrimSpace(info.PoolAliasConflictCount)); err == nil && existing > 0 {
 		count = existing
+	}
+	// Canonical singleton pool identity retries share the same unresolvable-
+	// conflict shape as the sync-time path in session_beads.go (a
+	// max_active_sessions=1 agent with two live sessions never releases the
+	// alias), so it must go through the SAME deferredSingletonAliasRetryDue
+	// gate rather than writing on every buildDesiredState call. Do not
+	// duplicate the backoff predicate here -- that duplication is exactly how
+	// this call site went unguarded the first time.
+	if !deferredSingletonAliasRetryDue(info.PoolAliasConflictAt, count, time.Now().UTC()) {
+		return info, nil
 	}
 	metadata := session.UpdatedAliasMetadataFromInfo(info, "")
 	metadata[poolAliasConflictMetadataKey] = canonical

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -32,6 +32,62 @@ const (
 	poolAliasConflictAtMetadataKey    = "pool_alias_conflict_at"
 )
 
+const (
+	// deferredSingletonAliasRetryBase is the shortest interval between two
+	// deferred-singleton alias re-attempts. The first few retries stay brisk so a
+	// conflict that resolves on its own (the previous holder exiting) is picked up
+	// promptly.
+	deferredSingletonAliasRetryBase = 30 * time.Second
+	// deferredSingletonAliasRetryMax caps the backoff. A conflict that has not
+	// resolved in half an hour is structural -- typically two live sessions of a
+	// max_active_sessions=1 agent -- and re-checking it more often than this buys
+	// nothing while writing to the event log every time.
+	deferredSingletonAliasRetryMax = 30 * time.Minute
+)
+
+// deferredSingletonAliasRetryDue reports whether a deferred-singleton alias
+// re-attempt should run now, given when the last attempt was recorded and how
+// many attempts have already happened.
+//
+// The backoff doubles per attempt and saturates at
+// deferredSingletonAliasRetryMax. An unparseable or missing timestamp returns
+// true: without evidence that an attempt happened recently, the safe answer is
+// to retry rather than to stall a conflict that could have resolved.
+func deferredSingletonAliasRetryDue(lastAttempt string, count int, now time.Time) bool {
+	last := strings.TrimSpace(lastAttempt)
+	if last == "" {
+		return true
+	}
+	at, err := time.Parse(time.RFC3339, last)
+	if err != nil {
+		return true
+	}
+	// A timestamp in the future means a clock change or a bad write; treat it as
+	// due rather than letting it suppress retries until the clock catches up.
+	if at.After(now) {
+		return true
+	}
+	return now.Sub(at) >= deferredSingletonAliasRetryBackoff(count)
+}
+
+// deferredSingletonAliasRetryBackoff returns the interval required before the
+// next re-attempt after count prior attempts. Shifting is bounded explicitly:
+// counts observed in production reach five figures, and shifting by that would
+// overflow rather than saturate.
+func deferredSingletonAliasRetryBackoff(count int) time.Duration {
+	if count <= 1 {
+		return deferredSingletonAliasRetryBase
+	}
+	backoff := deferredSingletonAliasRetryBase
+	for i := 1; i < count; i++ {
+		backoff *= 2
+		if backoff >= deferredSingletonAliasRetryMax {
+			return deferredSingletonAliasRetryMax
+		}
+	}
+	return backoff
+}
+
 // loadSessionBeads returns all open session beads from the store.
 func loadSessionBeads(store beads.Store) ([]beads.Bead, error) {
 	if store == nil {
@@ -2019,6 +2075,23 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			count := 0
 			if existing, err := strconv.Atoi(strings.TrimSpace(b.Metadata[poolAliasConflictCountMetadataKey])); err == nil && existing > 0 {
 				count = existing
+			}
+			// A deferred singleton keeps retrying because the alias is expected to
+			// free up when its current holder exits. When that never happens -- two
+			// live sessions of a max_active_sessions=1 agent -- the retry has no
+			// converging condition, and an unthrottled re-attempt rewrites this bead
+			// on EVERY sync tick, forever. Observed in production: one session
+			// reached 15,000+ conflict iterations and became the dominant writer to
+			// the city event log (~68% of events), drowning the events window for
+			// every other reader.
+			//
+			// Back off between attempts so an unresolvable conflict costs a bounded
+			// number of writes instead of one per tick. Recovery is preserved: the
+			// retry still fires, just on a widening interval, so a conflict that CAN
+			// resolve still resolves.
+			if retryDeferredSingleton && !deferredSingletonAliasRetryDue(
+				b.Metadata[poolAliasConflictAtMetadataKey], count, now) {
+				return
 			}
 			// This is a retry counter across build-time normalization and
 			// sync-time alias recovery, not a one-increment-per-tick gauge.

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -8688,3 +8688,75 @@ func TestSyncTailReturnsFreshStoreLoadNotLocalSlice(t *testing.T) {
 		t.Fatalf("returned snapshot open set %v != fresh store load %v", gotIDs, freshIDs)
 	}
 }
+
+// TestDeferredSingletonAliasRetryBackoff covers the livelock fix: an
+// unresolvable deferred-singleton alias conflict must not re-attempt (and
+// therefore rewrite its session bead) on every sync tick.
+func TestDeferredSingletonAliasRetryBackoff(t *testing.T) {
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+
+	t.Run("backoff grows then saturates without overflowing", func(t *testing.T) {
+		if got := deferredSingletonAliasRetryBackoff(1); got != deferredSingletonAliasRetryBase {
+			t.Fatalf("count=1: got %v, want %v", got, deferredSingletonAliasRetryBase)
+		}
+		if got := deferredSingletonAliasRetryBackoff(2); got != 2*deferredSingletonAliasRetryBase {
+			t.Fatalf("count=2: got %v, want %v", got, 2*deferredSingletonAliasRetryBase)
+		}
+		// The production counter reached five figures; a naive 1<<count would
+		// overflow to a negative or tiny duration and silently restore the spin.
+		for _, count := range []int{64, 1000, 15237} {
+			got := deferredSingletonAliasRetryBackoff(count)
+			if got != deferredSingletonAliasRetryMax {
+				t.Fatalf("count=%d: got %v, want saturation at %v", count, got, deferredSingletonAliasRetryMax)
+			}
+		}
+	})
+
+	t.Run("a fresh attempt is not due again immediately", func(t *testing.T) {
+		last := now.Add(-1 * time.Second).Format(time.RFC3339)
+		if deferredSingletonAliasRetryDue(last, 5, now) {
+			t.Fatalf("attempt 1s ago should not be due")
+		}
+	})
+
+	t.Run("an elapsed backoff window is due", func(t *testing.T) {
+		last := now.Add(-31 * time.Minute).Format(time.RFC3339)
+		if !deferredSingletonAliasRetryDue(last, 5, now) {
+			t.Fatalf("attempt 31m ago should be due (max backoff is %v)", deferredSingletonAliasRetryMax)
+		}
+	})
+
+	// THE PRODUCTION STATE. ra-9w9c sat at 15k+ iterations incrementing every
+	// sync tick. At that count the backoff is saturated, so a tick arriving
+	// seconds after the last attempt must be suppressed. This is the assertion
+	// that fails without the fix.
+	t.Run("the observed livelock state is throttled", func(t *testing.T) {
+		last := now.Add(-8 * time.Second).Format(time.RFC3339)
+		if deferredSingletonAliasRetryDue(last, 15237, now) {
+			t.Fatalf("15237 attempts, last 8s ago: must NOT be due — this is the livelock")
+		}
+	})
+
+	t.Run("recovery is preserved: retries still fire after the window", func(t *testing.T) {
+		last := now.Add(-deferredSingletonAliasRetryMax - time.Second).Format(time.RFC3339)
+		if !deferredSingletonAliasRetryDue(last, 15237, now) {
+			t.Fatalf("a saturated conflict must still re-attempt after the max window, or it can never recover")
+		}
+	})
+
+	t.Run("missing or unparseable timestamp retries", func(t *testing.T) {
+		if !deferredSingletonAliasRetryDue("", 5, now) {
+			t.Fatalf("empty timestamp should be due")
+		}
+		if !deferredSingletonAliasRetryDue("not-a-time", 5, now) {
+			t.Fatalf("unparseable timestamp should be due")
+		}
+	})
+
+	t.Run("a future timestamp does not suppress retries", func(t *testing.T) {
+		last := now.Add(1 * time.Hour).Format(time.RFC3339)
+		if !deferredSingletonAliasRetryDue(last, 5, now) {
+			t.Fatalf("future timestamp should be treated as due, not stall until the clock catches up")
+		}
+	})
+}

--- a/cmd/gc/session_wpool_twins_test.go
+++ b/cmd/gc/session_wpool_twins_test.go
@@ -343,6 +343,48 @@ func TestRecordDeferredNonExpandingPoolAliasConflictInfoFold(t *testing.T) {
 	}
 }
 
+// TestRecordDeferredNonExpandingPoolAliasConflictInfoBackoff pins the fix for the
+// livelock in ra-uu78e: recordDeferredNonExpandingPoolAliasConflictInfo is the
+// SECOND, previously ungated, write site for the deferred-singleton alias
+// conflict. When the shared deferredSingletonAliasRetryDue backoff gate says a
+// retry is not yet due, this call must skip the write entirely -- neither the
+// conflict count nor pool_alias_conflict_at may move, because the sync-time path
+// in session_beads.go measures its own backoff off that same stamp. A revert of
+// the gate added at this call site (back to the original unconditional
+// count+1/restamp) makes this test fail.
+func TestRecordDeferredNonExpandingPoolAliasConflictInfoBackoff(t *testing.T) {
+	recentAt := time.Now().UTC().Format(time.RFC3339)
+	seed := func() beads.Bead {
+		return wpoolSessionBead("gm-3", "open", "mayor", nil, map[string]string{
+			"template": "mayor", "agent_name": "mayor", "alias": "mayor", "session_name": "s-3",
+			"pool_managed": "true", "pool_alias_conflict_count": "5",
+			"pool_alias_conflict_at": recentAt, "pool_alias_conflict": "mayor",
+		})
+	}
+	cfgAgent := &config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	infoStore := beads.NewMemStoreFrom(1, []beads.Bead{seed()}, nil)
+	infoBP := &agentBuildParams{beadStore: infoStore}
+
+	foldedInfo, err := recordDeferredNonExpandingPoolAliasConflictInfo(infoBP, cfgAgent, sessiontest.SeedBead(t, seed()))
+	if err != nil {
+		t.Fatalf("info recordDeferred: %v", err)
+	}
+	if foldedInfo.PoolAliasConflictCount != "5" {
+		t.Errorf("backoff must skip the write: count changed to %q, want unchanged 5", foldedInfo.PoolAliasConflictCount)
+	}
+	if foldedInfo.PoolAliasConflictAt != recentAt {
+		t.Errorf("backoff must not restamp pool_alias_conflict_at: got %q, want unchanged %q", foldedInfo.PoolAliasConflictAt, recentAt)
+	}
+
+	persisted, err := session.NewStore(beads.SessionStore{Store: infoStore}).Get("gm-3")
+	if err != nil {
+		t.Fatalf("info store Get: %v", err)
+	}
+	if persisted.PoolAliasConflictCount != "5" {
+		t.Errorf("store must not have been rewritten during backoff: persisted count=%q", persisted.PoolAliasConflictCount)
+	}
+}
+
 // TestSnapshotAddInfoConcurrentAndCoherent reruns the parallel-create add() safety
 // contract (gastownhall/gascity#2319) against the new addInfo: concurrent addInfo
 // calls must not race or drop entries, and after all adds the snapshot's typed half


### PR DESCRIPTION
## Problem

A session that loses the managed pool-alias race records a conflict and retries. For a canonical singleton pool identity the retry deliberately bypasses the stable-conflict guard (`retryDeferredSingleton`), because the alias is expected to free up when its current holder exits.

When it never frees up — two live sessions of a `max_active_sessions=1` agent — that retry has **no converging condition and no throttle**, so it rewrites three metadata fields on the session bead every sync tick, forever.

Observed in production: one session reached **15,237 conflict iterations** still climbing at ~0.13/s, became the dominant writer to the city event log (~68% of recent events, 36% from that one session), grew `events.jsonl` past **109 MB**, and saturated the bounded events window so other readers could not see their own activity. Nothing alarmed — every instrument reported the session healthy.

## Fix

Throttle the re-attempt with an exponential backoff (30s doubling to a **30m ceiling**) keyed off the existing `pool_alias_conflict_at` stamp, so no new state is needed. Recovery is preserved: the retry still fires on a widening interval, so a conflict that *can* resolve still does. A second, previously-unguarded pool-alias-conflict write site is gated the same way.

The backoff saturates explicitly rather than shifting, because the counts this code actually sees reach five figures and a shift by that would overflow and silently restore the spin.

Files: `cmd/gc/session_beads.go` (+73), `cmd/gc/build_desired_state_pool_info.go`, plus two test files (`session_beads_test.go`, `session_wpool_twins_test.go`). +202/−1.

## Provenance & re-validation

- Fix authored at commits `24faf5a9e` + `51b8a52cd`; this PR replays them onto current `main`.
- **Cherry-picks clean onto `main` @ `6ba5a29f1`** (a clean 3-way auto-merge on `build_desired_state_pool_info.go`, no conflict).
- **Still absent from `main`**: `session_beads.go` exists but has no `deferredSingletonAliasRetry` backoff, and `git grep deferredSingletonAliasRetry` on `main` returns nothing anywhere (verified by content; 468-match positive control confirms the grep is not blind).
- **Lint-clean** under the version CI pins — `golangci-lint 2.12.0`, `run ./cmd/gc/...` → `0 issues`.
