### PR TITLE
perf(cli): skip pack discovery for gc bd

### DIFF
--- a/cmd/gc/root_argv.go
+++ b/cmd/gc/root_argv.go
@@ -21,15 +21,13 @@ func rootCommandOptionsForArgs(args []string) rootCommandOptions {
 	}
 }
 
-// rootCommandSkipsPackDiscovery identifies built-in helper surfaces that must
-// stay independent of pack config loading. The Beads provider calls the Dolt
-// helpers while a controller reload is itself refreshing and composing packs;
-// rediscovering pack commands there contends on the same cache and can turn a
-// small scope initialization into a minutes-long reload. These commands are
-// native-only and can never resolve to a pack binding.
+// rootCommandSkipsPackDiscovery identifies built-in commands that cannot
+// resolve to a pack binding. Pack discovery only adds city-config and pack
+// loading work; each command still performs its normal scope and config
+// resolution when it runs.
 func rootCommandSkipsPackDiscovery(command string) bool {
 	switch command {
-	case "metrics", "git-credential", "dolt-state", "dolt-config", "bd-store-bridge":
+	case "metrics", "bd", "git-credential", "dolt-state", "dolt-config", "bd-store-bridge":
 		return true
 	default:
 		return false

--- a/cmd/gc/root_argv_test.go
+++ b/cmd/gc/root_argv_test.go
@@ -60,7 +60,7 @@ func TestFirstRootCommandMatchesPersistentScopeGrammar(t *testing.T) {
 	}
 }
 
-func TestRootCommandOptionsSkipPackDiscoveryForPrivateHelpersAndMetrics(t *testing.T) {
+func TestRootCommandOptionsSkipPackDiscoveryForBuiltinCommands(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -72,14 +72,21 @@ func TestRootCommandOptionsSkipPackDiscoveryForPrivateHelpersAndMetrics(t *testi
 		{name: "scoped metrics", args: []string{"--city", "/tmp/city", "--rig=tower", "metrics", "status"}, skip: true},
 		{name: "remote context metrics", args: []string{"--context=prod", "metrics", "status"}, skip: true},
 		{name: "remote URL metrics", args: []string{"--city-url", "https://city.example", "--city-name=remote", "metrics", "status"}, skip: true},
+		{name: "bd", args: []string{"bd", "show", "example-123"}, skip: true},
+		{name: "scoped bd", args: []string{"--city", "/tmp/city", "--rig=tower", "bd", "list"}, skip: true},
+		{name: "remote context bd", args: []string{"--context=prod", "bd", "ready"}, skip: true},
+		{name: "remote URL bd", args: []string{"--city-url", "https://city.example", "--city-name=remote", "bd", "list"}, skip: true},
 		{name: "credential helper", args: []string{"git-credential", "get"}, skip: true},
 		{name: "dolt state helper", args: []string{"dolt-state", "allocate-port", "--city", "/tmp/city"}, skip: true},
 		{name: "scoped dolt config helper", args: []string{"--city", "/tmp/city", "dolt-config", "normalize-scope"}, skip: true},
 		{name: "beads store bridge helper", args: []string{"bd-store-bridge", "--dir", "/tmp/rig", "list"}, skip: true},
 		{name: "ordinary", args: []string{"status"}},
 		{name: "metrics is city value", args: []string{"--city", "metrics", "status"}},
+		{name: "bd is city value", args: []string{"--city", "bd", "status"}},
 		{name: "after terminator", args: []string{"--", "metrics"}},
+		{name: "bd after terminator", args: []string{"--", "bd"}},
 		{name: "unknown flag", args: []string{"--unknown", "metrics"}},
+		{name: "bd after unknown flag", args: []string{"--unknown", "bd"}},
 	}
 
 	for _, test := range tests {
@@ -198,6 +205,12 @@ func TestRootConstructionUsesInjectedArgsInsteadOfAmbientOSArgs(t *testing.T) {
 			name:        "injected metrics suppresses ordinary ambient discovery",
 			ambientArgs: []string{"version"},
 			injected:    []string{"metrics", "status"},
+			wantPack:    false,
+		},
+		{
+			name:        "injected bd suppresses ordinary ambient discovery",
+			ambientArgs: []string{"version"},
+			injected:    []string{"bd", "list"},
 			wantPack:    false,
 		},
 		{


### PR DESCRIPTION
## Summary

Skip pack-command discovery when the injected root command is the built-in `gc bd` wrapper.

`bd` is already reserved by the built-in Cobra tree, so a pack cannot provide that command. Loading city configuration and materializing pack commands during root construction is therefore unnecessary for every `gc bd ...` invocation.

## Behavior

Given a city with pack commands, when `gc bd ...` is invoked, then the built-in `bd` command is constructed without loading or materializing pack commands.

Given a scoped local, remote-context, or remote-URL `gc bd ...` invocation, when the root grammar identifies `bd`, then the same discovery skip applies.

Given an unknown root flag, `--` terminator, or an argument value that happens to be `bd`, when the pre-scan is ambiguous, then discovery remains enabled.

Given any `gc bd` operation, its normal city/rig scope resolution, argument forwarding, environment construction, and `bd` child-process behavior are unchanged.

## Local benchmark

This is a focused A/B of this PR, not a benchmark of the separate thin-client work. On one pack-configured local city, `gc bd show gc2-z7j83 --json` ran 20 times per arm in randomized interleaved order:

| build | median wall time | p95 wall time |
| --- | ---: | ---: |
| base | 716.7 ms | 823.5 ms |
| this PR | 455.8 ms | 488.2 ms |

That is 260.9 ms, or 36.4%, faster at the median. The JSON output was byte-for-byte identical between the two builds. Results will vary with city and pack configuration; this measurement does not claim an improvement for every `bd` operation.

## Evidence

- Added root-argument cases for bare, scoped, remote-context, and remote-URL `gc bd` invocations, plus conservative parsing cases.
- Added a root-construction regression proving a city pack command is not materialized for injected `gc bd` arguments.
- `go test -count=10 ./cmd/gc -run '^(TestRootCommandOptionsSkipPackDiscoveryForBuiltinCommands|TestRootConstructionUsesInjectedArgsInsteadOfAmbientOSArgs)$'` passed in 4.18s.
- `go build ./cmd/gc` and `go vet ./...` passed.

`make test-fast-parallel` was also attempted locally but did not complete because of unrelated host/baseline failures: two `cmd/gc` stop-test timeouts, macOS path/FD-limit cases, and the existing `/bin/bash` `${path,,}` incompatibility in `scripts/rebase-resolve-lib.sh`.

## Why this is safe

The change affects only eager and fallback registration of pack commands during root construction. It does not alter the built-in `bd` command or its scope resolution. Non-`bd` commands and ambiguous root syntax keep the existing discovery behavior.

## Related work

- #4441 proposes a separate, opt-in thin client for selected hot `bd` reads. This PR does not adopt that design; it removes one unconditional startup step from the current wrapper.
- #1978 tracks the broader per-invocation `bd` process and connection cost. This PR does not change that process or connection model.

## Scope

- `cmd/gc/root_argv.go`
- `cmd/gc/root_argv_test.go`