### PR TITLE
fix(runproj): clamp step/stage/lane liveness when the run root is terminal

### DIFF
--- a/internal/api/huma_handlers_runs.go
+++ b/internal/api/huma_handlers_runs.go
@@ -251,7 +251,8 @@ func (s *Server) humaHandleRunSteps(ctx context.Context, input *RunStepsInput) (
 	if !fold.ready {
 		return nil, apierr.ServiceUnavailable.Msg("run projection is warming")
 	}
-	if _, ok := runproj.BuildRunLane(fold.beads, input.RunID); !ok {
+	lane, ok := runproj.BuildRunLane(fold.beads, input.RunID)
+	if !ok {
 		if fold.partial {
 			return nil, apierr.ServiceUnavailable.Msg("run projection is incomplete")
 		}
@@ -262,6 +263,18 @@ func (s *Server) humaHandleRunSteps(ctx context.Context, input *RunStepsInput) (
 	}
 	s.forgetRunProjectionMiss(ctx, input.RunID)
 
+	// Derive the run's canonical lifecycle status exactly as laneToRun/deriveRunStatus
+	// do (root-terminality wins over lingering members), then clamp each step through
+	// it: a completed run must not report a step as eternally active when its close
+	// event was lost. A non-terminal run yields an inactive clamp (raw statuses stand).
+	byID := beadsByID(fold.beads)
+	root, rootFound := byID[input.RunID]
+	var rootPtr *beads.Bead
+	if rootFound {
+		rootPtr = &root
+	}
+	runStatus := runproj.CanonicalRunStatusForLane(lane, rootPtr, countStartedMembers(fold.beads, lane.ID))
+
 	members := runMemberBeads(fold.beads, input.RunID)
 	out := &RunStepsOutput{}
 	out.Body.RunID = input.RunID
@@ -271,10 +284,11 @@ func (s *Server) humaHandleRunSteps(ctx context.Context, input *RunStepsInput) (
 		if m.ID == input.RunID {
 			continue // the root is the run, not a step
 		}
+		status := RunStepStatus(runproj.ClampStepStatusForRun(runStatus, string(deriveRunStepStatus(m))))
 		out.Body.Steps = append(out.Body.Steps, RunStep{
 			ID:       m.ID,
 			Title:    runStepTitle(m),
-			Status:   deriveRunStepStatus(m),
+			Status:   status,
 			Kind:     m.Type,
 			Assignee: strings.TrimSpace(m.Assignee),
 		})

--- a/internal/api/huma_handlers_runs_test.go
+++ b/internal/api/huma_handlers_runs_test.go
@@ -848,6 +848,74 @@ func TestRunStepsEndpoint(t *testing.T) {
 	}
 }
 
+// TestRunStepsClampsCompletedRun proves the typed /steps endpoint honors run
+// terminality: a completed run whose steps lost their close events must report each
+// lingering step terminal (completed / skipped), never eternally active.
+func TestRunStepsClampsCompletedRun(t *testing.T) {
+	root := runRootBead("runc", "mol-adopt-pr-v2", "closed")
+	root.Metadata["gc.outcome"] = "pass"
+	s := newRunServer(t,
+		beadCreatedEvent(1, root),
+		beadCreatedEvent(2, runChildBead("runc.step1", "runc", "closed", map[string]string{"gc.outcome": "pass"})),
+		beadCreatedEvent(3, runChildBead("runc.step2", "runc", "in_progress", nil)), // lost close event
+		beadCreatedEvent(4, runChildBead("runc.step3", "runc", "open", nil)),        // never started
+	)
+	out, err := s.humaHandleRunSteps(context.Background(), &RunStepsInput{
+		CityScope: CityScope{CityName: "test-city"},
+		RunID:     "runc",
+	})
+	if err != nil {
+		t.Fatalf("humaHandleRunSteps error: %v", err)
+	}
+	byID := map[string]RunStep{}
+	for _, st := range out.Body.Steps {
+		byID[st.ID] = st
+	}
+	if byID["runc.step1"].Status != RunStepStatusCompleted {
+		t.Errorf("step1 = %q, want completed", byID["runc.step1"].Status)
+	}
+	if byID["runc.step2"].Status != RunStepStatusCompleted {
+		t.Errorf("lost-close step2 = %q, want completed (run is completed)", byID["runc.step2"].Status)
+	}
+	if byID["runc.step3"].Status != RunStepStatusSkipped {
+		t.Errorf("never-started step3 = %q, want skipped (never started under a completed run)", byID["runc.step3"].Status)
+	}
+}
+
+// TestRunStepsClampsFailedRunToCanceled proves the failure family: a failed run
+// cancels its lingering active steps (rather than completing them) and skips its
+// never-started ones, while a recorded step outcome is preserved.
+func TestRunStepsClampsFailedRunToCanceled(t *testing.T) {
+	root := runRootBead("runx", "mol-adopt-pr-v2", "closed")
+	root.Metadata["gc.outcome"] = "fail"
+	s := newRunServer(t,
+		beadCreatedEvent(1, root),
+		beadCreatedEvent(2, runChildBead("runx.step1", "runx", "in_progress", nil)),                                // lost close
+		beadCreatedEvent(3, runChildBead("runx.step2", "runx", "open", nil)),                                       // never started
+		beadCreatedEvent(4, runChildBead("runx.step3", "runx", "closed", map[string]string{"gc.outcome": "fail"})), // real failure
+	)
+	out, err := s.humaHandleRunSteps(context.Background(), &RunStepsInput{
+		CityScope: CityScope{CityName: "test-city"},
+		RunID:     "runx",
+	})
+	if err != nil {
+		t.Fatalf("humaHandleRunSteps error: %v", err)
+	}
+	byID := map[string]RunStep{}
+	for _, st := range out.Body.Steps {
+		byID[st.ID] = st
+	}
+	if byID["runx.step1"].Status != RunStepStatusCanceled {
+		t.Errorf("lost-close step1 = %q, want canceled (run failed)", byID["runx.step1"].Status)
+	}
+	if byID["runx.step2"].Status != RunStepStatusSkipped {
+		t.Errorf("never-started step2 = %q, want skipped", byID["runx.step2"].Status)
+	}
+	if byID["runx.step3"].Status != RunStepStatusFailed {
+		t.Errorf("recorded-failure step3 = %q, want failed (real outcome preserved)", byID["runx.step3"].Status)
+	}
+}
+
 // TestRunGetBeyondHistoricalCap guards the false-404 defect: with more completed
 // runs than the projection's historical lane cap, every run must still resolve by
 // id (the single-run path bypasses the list cap via BuildRunLane).

--- a/internal/runproj/detail.go
+++ b/internal/runproj/detail.go
@@ -457,6 +457,12 @@ func buildRunningFormulaRun(input runningFormulaRunInput) runningFormulaRun {
 	sessionIndex := buildRunSessionIndex(input.sessions)
 	sessionContext := runSessionLinkContext{sessionIndex: &sessionIndex, scopeRef: input.scopeRef}
 
+	// A terminal run root forces its steps' presentation statuses terminal: once
+	// the root folds terminal, a step still reading non-terminal lost its close
+	// event, so it can no longer be "Running". Inactive for every non-terminal or
+	// root-less run.
+	clamp := rootClampFor(input.root)
+
 	rawNodes := make([]RunDisplayNode, 0, len(groups))
 	for _, group := range groups {
 		latest, hasLatest := latestIterationByLoop[group.loopControlNodeID]
@@ -466,6 +472,7 @@ func buildRunningFormulaRun(input runningFormulaRunInput) runningFormulaRun {
 			latest,
 			hasLatest,
 			sessionContext,
+			clamp,
 		))
 	}
 	edges := buildRunDisplayEdges(input.raw, bg.physicalToSemantic, rawNodes)

--- a/internal/runproj/detail_instances.go
+++ b/internal/runproj/detail_instances.go
@@ -11,11 +11,12 @@ import (
 // buildRunDisplayNode projects one semantic group into a display node, including
 // its execution instances, iteration/attempt summaries, and control badges.
 // Port of TS buildRunDisplayNode (execution-instances.ts). latestLoopIteration's
-// bool mirrors `number | undefined`.
-func buildRunDisplayNode(group runNodeGroup, controlBadges []RunControlBadge, latestLoopIteration int, hasLatestLoopIteration bool, ctx runSessionLinkContext) RunDisplayNode {
+// bool mirrors `number | undefined`. clamp collapses non-terminal step statuses
+// when the run root is terminal (an inactive clamp is a no-op).
+func buildRunDisplayNode(group runNodeGroup, controlBadges []RunControlBadge, latestLoopIteration int, hasLatestLoopIteration bool, ctx runSessionLinkContext, clamp terminalRootClamp) RunDisplayNode {
 	instances := make([]RunExecutionInstance, 0, len(group.beads))
 	for index := range group.beads {
-		instances = append(instances, buildExecutionInstance(group.semanticNodeID, group.beads[index], index, ctx))
+		instances = append(instances, buildExecutionInstance(group.semanticNodeID, group.beads[index], index, ctx, clamp))
 	}
 	sortExecutionInstances(instances)
 
@@ -66,8 +67,15 @@ func buildRunDisplayNode(group runNodeGroup, controlBadges []RunControlBadge, la
 	}
 	visible := &instances[len(instances)-1]
 
-	if controlBadges == nil {
-		controlBadges = []RunControlBadge{}
+	// Clamp each badge status through the same terminal-root clamp: a hidden
+	// construct (finalize / scope-check) whose close event was lost must not read
+	// "running" under a terminal root. Build a FRESH slice — controlBadges aliases
+	// the badgesByTarget map storage and must never be mutated in place. A len-0
+	// make yields the non-nil empty slice the wire expects when there are no badges.
+	clampedBadges := make([]RunControlBadge, len(controlBadges))
+	for i, badge := range controlBadges {
+		badge.Status = clamp.apply(badge.Status)
+		clampedBadges[i] = badge
 	}
 
 	return RunDisplayNode{
@@ -85,7 +93,7 @@ func buildRunDisplayNode(group runNodeGroup, controlBadges []RunControlBadge, la
 		AttemptSummary:             attemptSummaryFor(instances, group.beads),
 		VisibleExecutionInstanceID: visible.ID,
 		ExecutionInstances:         instances,
-		ControlBadges:              controlBadges,
+		ControlBadges:              clampedBadges,
 	}
 }
 
@@ -111,16 +119,21 @@ func latestIterationsByLoop(groups []runNodeGroup) map[string]int {
 }
 
 // buildExecutionInstance projects one physical bead into an execution instance.
-// Port of TS buildExecutionInstance.
-func buildExecutionInstance(semanticNodeID string, bead runSnapshotBead, index int, ctx runSessionLinkContext) RunExecutionInstance {
+// Port of TS buildExecutionInstance, extended with the terminal-root clamp: the
+// session link and session-attachment reason resolve from the bead's REAL recorded
+// status (so a step that ran keeps its transcript link), while the presented
+// Status is the clamped value — a completed run's leftover "active" step reads
+// completed, not eternally running.
+func buildExecutionInstance(semanticNodeID string, bead runSnapshotBead, index int, ctx runSessionLinkContext, clamp terminalRootClamp) RunExecutionInstance {
 	beadID := nonEmpty(bead.id)
 	if beadID == "" {
 		panic("runproj: run node " + semanticNodeID + " has a bead with an empty id")
 	}
 	iteration, hasIteration := iterationFor(bead)
 	attempt, hasAttempt := attemptFor(bead)
-	status := presentationStatus(bead)
-	sessionLink, hasLink := runSessionLinkFor(bead, status, ctx)
+	recordedStatus := presentationStatus(bead)
+	status := clamp.apply(recordedStatus)
+	sessionLink, hasLink := runSessionLinkFor(bead, recordedStatus, ctx)
 
 	id := beadID
 	if id == "" {
@@ -143,7 +156,7 @@ func buildExecutionInstance(semanticNodeID string, bead runSnapshotBead, index i
 		Attempt:          attemptState(attempt, hasAttempt),
 		Label:            instanceLabel(iteration, hasIteration, attempt, hasAttempt),
 		Status:           status,
-		Session:          sessionState(status, sessionLink, hasLink),
+		Session:          sessionState(recordedStatus, sessionLink, hasLink),
 		CurrentIteration: true,
 		Historical:       false,
 	}

--- a/internal/runproj/detail_terminal_clamp.go
+++ b/internal/runproj/detail_terminal_clamp.go
@@ -1,0 +1,91 @@
+package runproj
+
+// terminalRunNodeStatusSet is the membership form of the terminalRunNodeStatuses
+// taxonomy (detail.go). It is derived from that slice — the one
+// TestRunNodeStatusTaxonomyIsExhaustive guards — so a status added to the
+// taxonomy is reflected here without a second edit, keeping the clamp in lockstep
+// with the single terminality source.
+var terminalRunNodeStatusSet = func() map[string]bool {
+	set := make(map[string]bool, len(terminalRunNodeStatuses))
+	for _, status := range terminalRunNodeStatuses {
+		set[status] = true
+	}
+	return set
+}()
+
+// isTerminalRunNodeStatus reports whether status is a terminal run-node status,
+// per the terminalRunNodeStatuses taxonomy.
+func isTerminalRunNodeStatus(status string) bool {
+	return terminalRunNodeStatusSet[status]
+}
+
+// terminalRootClamp captures whether a run's terminal root forces a presentation
+// clamp on its steps. A terminal root cannot have running steps: once the root
+// folds to a terminal status, a step still presenting as non-terminal lost its
+// own close event (a worker-side close that never emitted, or a reaper that
+// deleted the step bead before it did), so the projection presents it as finished
+// rather than eternally "Running". The clamp is presentation-only — the folded
+// bead data is never mutated, so a late-arriving close event re-derives the real
+// status on the next build.
+type terminalRootClamp struct {
+	active bool
+	// nonPendingTarget is the status a non-terminal, non-pending step collapses to:
+	// "completed" under a successful root, "canceled" under a failed/canceled/
+	// skipped root. Only meaningful when active.
+	nonPendingTarget string
+}
+
+// rootClampFor derives the clamp implied by a run's root bead. A nil root (root
+// absent from the fold) or a non-terminal root yields an inactive clamp, so the
+// projection is unchanged for every non-terminal or root-less run.
+func rootClampFor(root *runSnapshotBead) terminalRootClamp {
+	if root == nil {
+		return terminalRootClamp{}
+	}
+	return clampForRootStatus(presentationStatus(*root))
+}
+
+// clampForRootStatus derives the clamp for an already-resolved root presentation
+// status. A non-terminal root yields an inactive clamp.
+func clampForRootStatus(rootStatus string) terminalRootClamp {
+	if !isTerminalRunNodeStatus(rootStatus) {
+		return terminalRootClamp{}
+	}
+	// A successful root (completed/done) collapses its unfinished steps to
+	// "completed"; every other terminal root (failed/canceled/skipped) collapses
+	// them to "canceled". presentationStatus never yields "done", but classifying
+	// it here keeps the mapping total over the terminal taxonomy.
+	target := "canceled"
+	if rootStatus == "completed" || rootStatus == "done" {
+		target = "completed"
+	}
+	return terminalRootClamp{active: true, nonPendingTarget: target}
+}
+
+// ClampStepStatusForRun clamps a single step's presentation status against its
+// run's canonical lifecycle state, keeping the terminal-root clamp as the one
+// terminality source shared by the typed run API and the dashboard projection. A
+// terminal run (completed/failed/canceled/skipped) collapses each non-terminal
+// step exactly as the detail DAG does; a non-terminal run (pending/active/
+// waiting/canceling) yields an inactive clamp and returns the step status
+// unchanged. step is a RunStepStatus-vocabulary value (pending/active/blocked/
+// completed/failed/skipped/canceled).
+func ClampStepStatusForRun(run CanonicalRunStatus, step string) string {
+	return clampForRootStatus(string(run)).apply(step)
+}
+
+// apply clamps one step presentation status under a terminal root. Already-terminal
+// statuses are returned unchanged — they are real recorded outcomes, including the
+// gc.outcome-derived failed/skipped/canceled a closed step carries. A non-terminal
+// pending step (never started) becomes "skipped"; every other non-terminal step
+// (active/running/ready/blocked) becomes the root's terminal target. An inactive
+// clamp returns the status unchanged.
+func (c terminalRootClamp) apply(status string) string {
+	if !c.active || isTerminalRunNodeStatus(status) {
+		return status
+	}
+	if status == "pending" {
+		return "skipped"
+	}
+	return c.nonPendingTarget
+}

--- a/internal/runproj/detail_terminal_clamp_test.go
+++ b/internal/runproj/detail_terminal_clamp_test.go
@@ -1,0 +1,636 @@
+package runproj
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestTerminalRootClampMappings pins the presentation-clamp mapping for every
+// terminal root class against every non-terminal step status, plus the
+// already-terminal preservation rule. This is the direct-mapping oracle the
+// end-to-end tests below exercise through the full pipeline.
+func TestTerminalRootClampMappings(t *testing.T) {
+	cases := []struct {
+		rootStatus string
+		step       string
+		want       string
+	}{
+		// Completed root: unfinished steps complete, never-started steps skip.
+		{"completed", "active", "completed"},
+		{"completed", "running", "completed"},
+		{"completed", "ready", "completed"},
+		{"completed", "blocked", "completed"},
+		{"completed", "pending", "skipped"},
+		// Failed root: unfinished steps cancel, never-started steps skip.
+		{"failed", "active", "canceled"},
+		{"failed", "running", "canceled"},
+		{"failed", "ready", "canceled"},
+		{"failed", "blocked", "canceled"},
+		{"failed", "pending", "skipped"},
+		// Canceled root behaves like failed.
+		{"canceled", "active", "canceled"},
+		{"canceled", "ready", "canceled"},
+		{"canceled", "pending", "skipped"},
+		// Already-terminal step statuses are never altered under any terminal root.
+		{"completed", "completed", "completed"},
+		{"completed", "failed", "failed"},
+		{"completed", "skipped", "skipped"},
+		{"completed", "canceled", "canceled"},
+		{"completed", "done", "done"},
+		{"failed", "completed", "completed"},
+		{"failed", "failed", "failed"},
+		{"canceled", "skipped", "skipped"},
+		// Non-terminal roots never clamp anything.
+		{"active", "active", "active"},
+		{"ready", "pending", "pending"},
+		{"blocked", "active", "active"},
+		{"pending", "ready", "ready"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rootStatus+"/"+tc.step, func(t *testing.T) {
+			got := clampForRootStatus(tc.rootStatus).apply(tc.step)
+			if got != tc.want {
+				t.Errorf("clampForRootStatus(%q).apply(%q) = %q, want %q", tc.rootStatus, tc.step, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTerminalRootClampMappingsCoverTaxonomy proves the mapping is total: every
+// non-terminal step status maps to a terminal status under a completed root, and
+// every terminal step status is preserved — so the clamp can never leave a node in
+// a non-terminal state (and never invents a status outside the taxonomy).
+func TestTerminalRootClampMappingsCoverTaxonomy(t *testing.T) {
+	clamp := clampForRootStatus("completed")
+	for _, status := range allRunNodeStatuses {
+		got := clamp.apply(status)
+		if !isTerminalRunNodeStatus(got) {
+			t.Errorf("apply(%q) = %q, which is not terminal — a terminal root must leave no non-terminal step", status, got)
+		}
+		if isTerminalRunNodeStatus(status) && got != status {
+			t.Errorf("apply(%q) = %q, but an already-terminal status must be preserved", status, got)
+		}
+	}
+}
+
+// TestRootClampForResolvesBeadStatus proves rootClampFor keys off the root bead's
+// presentation status (not its raw status): a closed root activates a completed
+// clamp, a closed+gc.outcome=fail root activates a canceled clamp, an open root
+// stays inactive, and an absent (nil) root stays inactive.
+func TestRootClampForResolvesBeadStatus(t *testing.T) {
+	completed := runSnapshotBead{status: "closed"}
+	if c := rootClampFor(&completed); !c.active || c.nonPendingTarget != "completed" {
+		t.Errorf("closed root: clamp = %+v, want active completed", c)
+	}
+
+	failed := runSnapshotBead{status: "closed", metadata: map[string]string{beadmeta.OutcomeMetadataKey: "fail"}}
+	if c := rootClampFor(&failed); !c.active || c.nonPendingTarget != "canceled" {
+		t.Errorf("closed+outcome=fail root: clamp = %+v, want active canceled", c)
+	}
+
+	open := runSnapshotBead{status: "open"}
+	if c := rootClampFor(&open); c.active {
+		t.Errorf("open root: clamp = %+v, want inactive", c)
+	}
+
+	if c := rootClampFor(nil); c.active {
+		t.Errorf("absent root: clamp = %+v, want inactive (no change)", c)
+	}
+}
+
+// TestBuildRunDetailTerminalClampProductionShape reproduces the reported incident:
+// a completed merge-queue run whose 7 in-progress steps and 1 open step lost their
+// close events. Before the clamp the detail rendered 7 "active" + 1 "pending" step
+// under a completed root (statusCounts {completed:1, active:7, pending:1}); after
+// it, every step reads completed/skipped and the run reports terminal.
+func TestBuildRunDetailTerminalClampProductionShape(t *testing.T) {
+	beadList := []beads.Bead{clampRootBead("runq", "closed", nil)}
+	for i := 1; i <= 7; i++ {
+		beadList = append(beadList, clampStepBead("runq", fmt.Sprintf("runq.%d", i), fmt.Sprintf("s%d", i), "in_progress", nil))
+	}
+	beadList = append(beadList, clampStepBead("runq", "runq.8", "s8", "open", nil))
+
+	detail, err := BuildRunDetail(beadList, "runq", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+
+	statuses := nodeStatusByID(detail)
+	if statuses["runq"] != "completed" {
+		t.Errorf("root node status = %q, want completed", statuses["runq"])
+	}
+	for i := 1; i <= 7; i++ {
+		id := fmt.Sprintf("s%d", i)
+		if statuses[id] != "completed" {
+			t.Errorf("step %q status = %q, want completed (was in_progress under a completed root)", id, statuses[id])
+		}
+	}
+	if statuses["s8"] != "skipped" {
+		t.Errorf("open step s8 status = %q, want skipped (never started under a completed root)", statuses["s8"])
+	}
+
+	// statusCounts is computed post-clamp: root + 7 steps completed, 1 skipped.
+	assertNoLiveStatuses(t, detail)
+	sc := detail.Progress.StatusCounts.counts
+	if sc["completed"] != 8 || sc["skipped"] != 1 || len(sc) != 2 {
+		t.Errorf("progress.statusCounts = %v, want {completed:8, skipped:1}", sc)
+	}
+	if !detail.Progress.Terminal {
+		t.Error("progress.terminal = false, want true — every visible node is terminal after the clamp")
+	}
+}
+
+// TestBuildRunDetailTerminalClampPreservesRecordedOutcomes proves the clamp never
+// overwrites a real recorded step outcome under a completed root: a
+// gc.outcome=fail step stays failed, a skipped step stays skipped, a canceled step
+// stays canceled, while a still-running step collapses to completed.
+func TestBuildRunDetailTerminalClampPreservesRecordedOutcomes(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runp", "closed", nil),
+		clampStepBead("runp", "runp.1", "won", "in_progress", nil),
+		clampStepBead("runp", "runp.2", "lost", "closed", map[string]string{beadmeta.OutcomeMetadataKey: "fail"}),
+		clampStepBead("runp", "runp.3", "dropped", "closed", map[string]string{beadmeta.OutcomeMetadataKey: "skipped"}),
+		clampStepBead("runp", "runp.4", "aborted", "closed", map[string]string{beadmeta.OutcomeMetadataKey: "canceled"}),
+	}
+
+	detail, err := BuildRunDetail(beadList, "runp", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+
+	statuses := nodeStatusByID(detail)
+	want := map[string]string{"won": "completed", "lost": "failed", "dropped": "skipped", "aborted": "canceled"}
+	for id, wantStatus := range want {
+		if statuses[id] != wantStatus {
+			t.Errorf("step %q status = %q, want %q", id, statuses[id], wantStatus)
+		}
+	}
+}
+
+// TestBuildRunDetailTerminalClampCannotResurrectActive proves the instance-level
+// clamp runs before aggregateStatus: a semantic node with several physical
+// instances (one still in_progress) folds to completed, never back to "active".
+func TestBuildRunDetailTerminalClampCannotResurrectActive(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runr", "closed", nil),
+		// Three physical beads share one logical step (a retried loop node).
+		clampStepBead("runr", "runr.1", "loop", "closed", map[string]string{beadmeta.AttemptMetadataKey: "1"}),
+		clampStepBead("runr", "runr.2", "loop", "closed", map[string]string{beadmeta.AttemptMetadataKey: "2"}),
+		clampStepBead("runr", "runr.3", "loop", "in_progress", map[string]string{beadmeta.AttemptMetadataKey: "3"}),
+	}
+
+	detail, err := BuildRunDetail(beadList, "runr", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+
+	node, ok := nodeByID(detail, "loop")
+	if !ok {
+		t.Fatal("loop node not found")
+	}
+	if node.Status != "completed" {
+		t.Errorf("aggregated loop node status = %q, want completed", node.Status)
+	}
+	if len(node.ExecutionInstances) != 3 {
+		t.Fatalf("loop node has %d instances, want 3", len(node.ExecutionInstances))
+	}
+	assertNoLiveStatuses(t, detail)
+	// A terminal run has no running attempt.
+	if node.AttemptSummary.Kind == "tracked" && node.AttemptSummary.Active.Kind == "running" {
+		t.Errorf("attemptSummary.active = running, want idle under a completed root")
+	}
+}
+
+// TestBuildRunDetailFailedRootClampsToCanceled proves a failed root cancels its
+// unfinished steps (rather than completing them) and skips its never-started ones.
+func TestBuildRunDetailFailedRootClampsToCanceled(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runf", "closed", map[string]string{beadmeta.OutcomeMetadataKey: "fail"}),
+		clampStepBead("runf", "runf.1", "midflight", "in_progress", nil),
+		clampStepBead("runf", "runf.2", "never", "open", nil),
+		clampStepBead("runf", "runf.3", "finished", "closed", nil),
+	}
+
+	detail, err := BuildRunDetail(beadList, "runf", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+
+	statuses := nodeStatusByID(detail)
+	want := map[string]string{"runf": "failed", "midflight": "canceled", "never": "skipped", "finished": "completed"}
+	for id, wantStatus := range want {
+		if statuses[id] != wantStatus {
+			t.Errorf("node %q status = %q, want %q", id, statuses[id], wantStatus)
+		}
+	}
+	assertNoLiveStatuses(t, detail)
+}
+
+// TestBuildRunDetailOpenRootDoesNotClamp proves the clamp is inert for a
+// non-terminal root: an open-root run keeps its steps' live statuses, so healthy
+// in-flight runs are unchanged.
+func TestBuildRunDetailOpenRootDoesNotClamp(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runo", "open", nil),
+		clampStepBead("runo", "runo.1", "working", "in_progress", nil),
+		clampStepBead("runo", "runo.2", "waiting", "open", nil),
+	}
+
+	detail, err := BuildRunDetail(beadList, "runo", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+
+	statuses := nodeStatusByID(detail)
+	if statuses["working"] != "active" {
+		t.Errorf("in-progress step under an open root = %q, want active (no clamp)", statuses["working"])
+	}
+	if detail.Progress.Terminal {
+		t.Error("progress.terminal = true, want false — an open root is not terminal")
+	}
+}
+
+// TestBuildRunDetailTerminalClampKeepsSessionLink proves the session interaction:
+// a clamped-completed step keeps the session link it earned while running (the
+// link is resolved from the step's real recorded status), but is not streamable
+// (nothing streams under a terminal root).
+func TestBuildRunDetailTerminalClampKeepsSessionLink(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runs", "closed", nil),
+		clampStepBead("runs", "runs.1", "review", "in_progress", map[string]string{
+			beadmeta.SessionIDMetadataKey:   "gc-sess01",
+			beadmeta.SessionNameMetadataKey: "worker-1",
+		}),
+	}
+
+	detail, err := BuildRunDetail(beadList, "runs", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+
+	node, ok := nodeByID(detail, "review")
+	if !ok {
+		t.Fatal("review node not found")
+	}
+	if node.Status != "completed" {
+		t.Errorf("review node status = %q, want completed", node.Status)
+	}
+	if len(node.ExecutionInstances) != 1 {
+		t.Fatalf("review node has %d instances, want 1", len(node.ExecutionInstances))
+	}
+	inst := node.ExecutionInstances[0]
+	if inst.Session.Kind != "attached" {
+		t.Fatalf("clamped-completed step session kind = %q, want attached (link preserved)", inst.Session.Kind)
+	}
+	if inst.Session.Link.SessionID != "gc-sess01" {
+		t.Errorf("session link id = %q, want gc-sess01", inst.Session.Link.SessionID)
+	}
+	if inst.Session.Streamable {
+		t.Error("clamped-completed step is streamable, want false — a terminal run streams nothing")
+	}
+}
+
+// clampRootBead builds a graph.v2 run root bead for the clamp tests.
+func clampRootBead(id, status string, extra map[string]string) beads.Bead {
+	md := map[string]string{
+		beadmeta.FormulaContractMetadataKey: "graph.v2",
+		beadmeta.KindMetadataKey:            "run",
+		beadmeta.FormulaMetadataKey:         "mol-adopt-pr-v2",
+		beadmeta.RunTargetMetadataKey:       "rig:demo",
+		beadmeta.RootStoreRefMetadataKey:    "rig:demo",
+		beadmeta.ScopeKindMetadataKey:       "rig",
+		beadmeta.ScopeRefMetadataKey:        "demo",
+	}
+	for k, v := range extra {
+		md[k] = v
+	}
+	return beads.Bead{ID: id, Type: "molecule", Status: status, Metadata: md}
+}
+
+// clampStepBead builds a graph.v2 run step bead rooted at rootID.
+func clampStepBead(rootID, id, stepID, status string, extra map[string]string) beads.Bead {
+	md := map[string]string{
+		beadmeta.KindMetadataKey:       "step",
+		beadmeta.RootBeadIDMetadataKey: rootID,
+		beadmeta.StepIDMetadataKey:     stepID,
+		beadmeta.StepRefMetadataKey:    "mol-adopt-pr-v2." + stepID,
+	}
+	for k, v := range extra {
+		md[k] = v
+	}
+	return beads.Bead{ID: id, Type: "task", Status: status, Metadata: md}
+}
+
+// nodeByID finds a display node by its semantic id.
+func nodeByID(detail FormulaRunDetail, id string) (RunDisplayNode, bool) {
+	for _, node := range detail.Nodes {
+		if node.ID == id {
+			return node, true
+		}
+	}
+	return RunDisplayNode{}, false
+}
+
+// nodeStatusByID maps each display node's semantic id to its status.
+func nodeStatusByID(detail FormulaRunDetail) map[string]string {
+	out := make(map[string]string, len(detail.Nodes))
+	for _, node := range detail.Nodes {
+		out[node.ID] = node.Status
+	}
+	return out
+}
+
+// assertNoLiveStatuses fails if any node, execution instance, or control badge
+// still presents as running after a clamp — the invariant a terminal root must
+// guarantee across the whole DAG.
+func assertNoLiveStatuses(t *testing.T, detail FormulaRunDetail) {
+	t.Helper()
+	for _, node := range detail.Nodes {
+		if isRunningStatus(node.Status) {
+			t.Errorf("node %q is %q after clamp, want a terminal status", node.ID, node.Status)
+		}
+		for _, inst := range node.ExecutionInstances {
+			if isRunningStatus(inst.Status) {
+				t.Errorf("instance %q of node %q is %q after clamp, want a terminal status", inst.ID, node.ID, inst.Status)
+			}
+		}
+		for _, badge := range node.ControlBadges {
+			if isRunningStatus(badge.Status) {
+				t.Errorf("control badge %q of node %q is %q after clamp, want a terminal status", badge.ID, node.ID, badge.Status)
+			}
+		}
+	}
+}
+
+// TestMapRunPhaseClosedRootWinsOverLingeringMembers proves root-terminality reaches
+// the phase classifier: a closed root whose members never recorded their closes
+// (one in_progress, one raw-blocked) still maps to phase "complete".
+func TestMapRunPhaseClosedRootWinsOverLingeringMembers(t *testing.T) {
+	issues := []runIssue{
+		{id: "root", title: "mol-adopt-pr-v2", status: "closed", metadata: map[string]string{beadmeta.KindMetadataKey: "run"}},
+		{id: "root.1", status: "in_progress", parent: "root", metadata: map[string]string{beadmeta.StepIDMetadataKey: "review-loop"}},
+		{id: "root.2", status: "blocked", parent: "root", metadata: map[string]string{beadmeta.StepIDMetadataKey: "human-approval"}},
+	}
+	got := mapRunPhase("root", issues)
+	if got.phase != "complete" {
+		t.Errorf("phase = %q, want complete (closed root beats lingering members)", got.phase)
+	}
+	if got.label != "complete" {
+		t.Errorf("label = %q, want complete (no fail outcome)", got.label)
+	}
+}
+
+// TestMapRunPhaseClosedRootFailOutcomeLabelsFailed proves the honest failure label
+// rides a closed root with gc.outcome=fail even while a member lingers open.
+func TestMapRunPhaseClosedRootFailOutcomeLabelsFailed(t *testing.T) {
+	issues := []runIssue{
+		{id: "root", status: "closed", metadata: map[string]string{beadmeta.OutcomeMetadataKey: "fail"}},
+		{id: "root.1", status: "in_progress", parent: "root"},
+	}
+	if got := mapRunPhase("root", issues); got.phase != "complete" || got.label != "failed" {
+		t.Errorf("mapRunPhase = %+v, want phase complete label failed", got)
+	}
+}
+
+// TestMapRunPhaseRootlessGroupUnchanged proves the root-closed branch does not fire
+// when no issue matches rootID: the all-closed fallback still resolves a rootless
+// terminal group, and a rootless in-progress group is not forced terminal.
+func TestMapRunPhaseRootlessGroupUnchanged(t *testing.T) {
+	closedRootless := []runIssue{
+		{id: "orphan.1", status: "closed"},
+		{id: "orphan.2", status: "closed"},
+	}
+	if got := mapRunPhase("missing-root", closedRootless); got.phase != "complete" {
+		t.Errorf("rootless all-closed phase = %q, want complete (allClosed fallback)", got.phase)
+	}
+	openRootless := []runIssue{
+		{id: "orphan.1", status: "in_progress", metadata: map[string]string{beadmeta.StepIDMetadataKey: "preflight"}},
+	}
+	if got := mapRunPhase("missing-root", openRootless); got.phase == "complete" {
+		t.Errorf("rootless in-progress phase = %q, want non-complete (unchanged)", got.phase)
+	}
+}
+
+// TestBuildRunDetailTerminalRootPhaseAndStagesComplete proves the detail payload is
+// internally consistent under the incident shape: a closed root reports phase
+// "complete" with NO stage reading active or blocked, so Phase/Stages no longer
+// contradict the clamped DAG.
+func TestBuildRunDetailTerminalRootPhaseAndStagesComplete(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runq", "closed", nil),
+		clampStepBead("runq", "runq.1", "preflight", "closed", nil),
+		clampStepBead("runq", "runq.2", "review-loop", "in_progress", nil),
+		clampStepBead("runq", "runq.3", "human-approval", "blocked", nil),
+		clampStepBead("runq", "runq.4", "finalize", "open", nil),
+	}
+	detail, err := BuildRunDetail(beadList, "runq", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	if detail.Phase != "complete" {
+		t.Errorf("detail.Phase = %q, want complete (closed root)", detail.Phase)
+	}
+	if len(detail.Stages) == 0 {
+		t.Fatal("detail.Stages is empty; expected the adopt-pr ladder")
+	}
+	for _, st := range detail.Stages {
+		if st.Status == "active" || st.Status == "blocked" {
+			t.Errorf("stage %q status = %q, want no active/blocked stage under a closed root", st.Key, st.Status)
+		}
+	}
+	if !detail.Progress.Terminal {
+		t.Error("progress.terminal = false, want true")
+	}
+}
+
+// TestBuildRunSummaryClosedRootBucketsHistorical proves the runs LIST no longer
+// strands a lost-close terminal run in the active/blocked buckets, and its lane
+// progress no longer reports active_step.
+func TestBuildRunSummaryClosedRootBucketsHistorical(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runh", "closed", nil),
+		clampStepBead("runh", "runh.1", "preflight", "closed", nil),
+		clampStepBead("runh", "runh.2", "review-loop", "in_progress", nil), // lost close
+	}
+	summary := BuildRunSummary(beadList)
+
+	if laneInGroup(summary.Lanes, "runh") || laneInGroup(summary.BlockedLanes, "runh") {
+		t.Error("closed-root run appears in the active/blocked buckets, want historical")
+	}
+	lane, ok := findLaneInGroup(summary.HistoricalLanes, "runh")
+	if !ok {
+		t.Fatal("closed-root run not found in historical lanes")
+	}
+	if lane.Phase != "complete" {
+		t.Errorf("historical lane phase = %q, want complete", lane.Phase)
+	}
+	if lane.Progress.Status == "active_step" {
+		t.Errorf("historical lane progress = active_step, want a non-active status under a closed root")
+	}
+}
+
+// TestBuildRunDetailClampsControlBadges proves R2: a run-finalize hidden construct
+// still reading in_progress attaches a badge to the root node, and under a closed
+// root that badge clamps to completed instead of rendering "running".
+func TestBuildRunDetailClampsControlBadges(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runb", "closed", nil),
+		clampStepBead("runb", "runb.1", "preflight", "closed", nil),
+		clampStepBead("runb", "runb.fin", "finalize", "in_progress", map[string]string{beadmeta.KindMetadataKey: "run-finalize"}),
+	}
+	detail, err := BuildRunDetail(beadList, "runb", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	root, ok := nodeByID(detail, "runb")
+	if !ok {
+		t.Fatal("root node runb not found")
+	}
+	badge, ok := badgeByLabel(root.ControlBadges, "finalize")
+	if !ok {
+		t.Fatalf("finalize badge not attached to root; badges=%+v", root.ControlBadges)
+	}
+	if badge.Status != "completed" {
+		t.Errorf("finalize badge status = %q, want completed (clamped under a closed root)", badge.Status)
+	}
+	assertNoLiveStatuses(t, detail)
+}
+
+// TestBuildRunDetailControlBadgeClampInactiveNoOp proves the badge clamp is a strict
+// no-op under an open (non-terminal) root: the finalize badge keeps its live status.
+func TestBuildRunDetailControlBadgeClampInactiveNoOp(t *testing.T) {
+	beadList := []beads.Bead{
+		clampRootBead("runc", "open", nil),
+		clampStepBead("runc", "runc.1", "preflight", "in_progress", nil),
+		clampStepBead("runc", "runc.fin", "finalize", "in_progress", map[string]string{beadmeta.KindMetadataKey: "run-finalize"}),
+	}
+	detail, err := BuildRunDetail(beadList, "runc", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	root, ok := nodeByID(detail, "runc")
+	if !ok {
+		t.Fatal("root node runc not found")
+	}
+	badge, ok := badgeByLabel(root.ControlBadges, "finalize")
+	if !ok {
+		t.Fatalf("finalize badge not attached to root; badges=%+v", root.ControlBadges)
+	}
+	if badge.Status != "active" {
+		t.Errorf("finalize badge status = %q, want active (inactive clamp is a strict no-op)", badge.Status)
+	}
+}
+
+// TestTerminalStageLadderKeepsUnmaterializedStagesPending proves D1: a terminal
+// run's stage ladder marks only the stages that RAN complete. An all-closed run
+// that exited early keeps its never-materialized trailing stages pending (no false
+// "Human approval / Merge-ready complete"), while a started-but-lost-close stage
+// still reads complete.
+func TestTerminalStageLadderKeepsUnmaterializedStagesPending(t *testing.T) {
+	// mol-bug-report-flow-v2 closed at classify: intake/repro/audit/classify ran to
+	// close; approval/publish/dispatch never materialized.
+	early := []beads.Bead{
+		clampRootBead("runm", "closed", map[string]string{beadmeta.FormulaMetadataKey: "mol-bug-report-flow-v2"}),
+		clampStepBead("runm", "runm.1", "bootstrap-run", "closed", nil),     // intake
+		clampStepBead("runm", "runm.2", "main-repro", "closed", nil),        // repro
+		clampStepBead("runm", "runm.3", "code-path-audit", "closed", nil),   // audit
+		clampStepBead("runm", "runm.4", "normalize-outcome", "closed", nil), // classify
+	}
+	detail, err := BuildRunDetail(early, "runm", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	byKey := stageStatusByKey(detail.Stages)
+	for _, key := range []string{"intake", "repro", "audit", "classify"} {
+		if byKey[key] != "complete" {
+			t.Errorf("stage %q = %q, want complete (it ran)", key, byKey[key])
+		}
+	}
+	for _, key := range []string{"approval", "publish", "dispatch"} {
+		if byKey[key] != "pending" {
+			t.Errorf("stage %q = %q, want pending (never materialized in an early-exit run)", key, byKey[key])
+		}
+	}
+
+	// Counterpart: a started-but-lost-close stage stays complete under a terminal
+	// root (review-loop went in_progress then lost its close event).
+	incident := []beads.Bead{
+		clampRootBead("runi", "closed", nil), // mol-adopt-pr-v2
+		clampStepBead("runi", "runi.1", "preflight", "closed", nil),
+		clampStepBead("runi", "runi.2", "review-loop", "in_progress", nil),
+	}
+	incidentDetail, err := BuildRunDetail(incident, "runi", 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail incident: %v", err)
+	}
+	incByKey := stageStatusByKey(incidentDetail.Stages)
+	if incByKey["review"] != "complete" {
+		t.Errorf("review stage (started, lost close) = %q, want complete", incByKey["review"])
+	}
+	if incByKey["cleanup"] != "pending" {
+		t.Errorf("cleanup stage (never ran) = %q, want pending", incByKey["cleanup"])
+	}
+}
+
+// TestBuildRunSummaryClosedRootHidesLiveFields proves D2: a closed-root lane must
+// not leak lost-close liveness — StatusCounts presents every member closed and
+// ActiveAssignees is empty, so a historical LaneCard never reads "on <assignee> ·
+// N in progress" for a finished run.
+func TestBuildRunSummaryClosedRootHidesLiveFields(t *testing.T) {
+	step2 := clampStepBead("runl", "runl.2", "review-loop", "in_progress", nil)
+	step2.Assignee = "worker-7"
+	beadList := []beads.Bead{
+		clampRootBead("runl", "closed", nil),
+		clampStepBead("runl", "runl.1", "preflight", "closed", nil),
+		step2,
+	}
+	summary := BuildRunSummary(beadList)
+	lane, ok := findLaneInGroup(summary.HistoricalLanes, "runl")
+	if !ok {
+		t.Fatal("closed-root run not in historical lanes")
+	}
+	sc := lane.StatusCounts.counts
+	if len(sc) != 1 || sc["closed"] != 3 {
+		t.Errorf("StatusCounts = %v, want {closed:3} (every member presented closed)", sc)
+	}
+	if len(lane.ActiveAssignees) != 0 {
+		t.Errorf("ActiveAssignees = %v, want empty (no one is assigned to a finished run)", lane.ActiveAssignees)
+	}
+}
+
+// stageStatusByKey maps each stage key to its status.
+func stageStatusByKey(stages []RunStage) map[string]string {
+	out := make(map[string]string, len(stages))
+	for _, s := range stages {
+		out[s.Key] = s.Status
+	}
+	return out
+}
+
+// findLaneInGroup locates a lane by id within one summary bucket.
+func findLaneInGroup(lanes []RunLane, id string) (RunLane, bool) {
+	for _, l := range lanes {
+		if l.ID == id {
+			return l, true
+		}
+	}
+	return RunLane{}, false
+}
+
+func laneInGroup(lanes []RunLane, id string) bool {
+	_, ok := findLaneInGroup(lanes, id)
+	return ok
+}
+
+// badgeByLabel finds a control badge by its display label.
+func badgeByLabel(badges []RunControlBadge, label string) (RunControlBadge, bool) {
+	for _, b := range badges {
+		if b.Label == label {
+			return b, true
+		}
+	}
+	return RunControlBadge{}, false
+}

--- a/internal/runproj/phasemapping.go
+++ b/internal/runproj/phasemapping.go
@@ -41,6 +41,14 @@ type phaseMapping struct {
 // stays "complete" (the RunPhase union has no failed member, and complete is
 // what routes the lane to history).
 func mapRunPhase(rootID string, issues []runIssue) phaseMapping {
+	// Root-terminality wins (mirrors CanonicalRunStatusForLane): a closed root is
+	// history even when a member lingers in_progress or blocked because its own
+	// close event never landed. The RunPhase union has no failed member, so the
+	// honest failure rides the label while the phase stays "complete" — which
+	// routes the lane to history and collapses the stage ladder.
+	if root, ok := findIssue(issues, rootID); ok && strings.TrimSpace(root.status) == "closed" {
+		return phaseMapping{phase: "complete", label: terminalRunLabel(root)}
+	}
 	if len(issues) > 0 {
 		allClosed := true
 		for _, i := range issues {
@@ -50,18 +58,9 @@ func mapRunPhase(rootID string, issues []runIssue) phaseMapping {
 			}
 		}
 		if allClosed {
-			label := "complete"
-			for _, i := range issues {
-				if i.id != rootID {
-					continue
-				}
-				outcome := strings.ToLower(stringValue(i.metadata[beadmeta.OutcomeMetadataKey]))
-				if outcome == "fail" || outcome == "failed" {
-					label = "failed"
-				}
-				break
-			}
-			return phaseMapping{phase: "complete", label: label}
+			// Rootless (dangling-root) fallback: no root issue to consult, so the
+			// label defaults to "complete".
+			return phaseMapping{phase: "complete", label: terminalRunLabelByID(rootID, issues)}
 		}
 	}
 
@@ -78,6 +77,29 @@ func mapRunPhase(rootID string, issues []runIssue) phaseMapping {
 	}
 
 	return fallbackPhase(issues)
+}
+
+// terminalRunLabel returns the honest phase label for a run whose root bead
+// closed: "failed" when the ROOT recorded a fail outcome, else "complete". Only
+// the root outcome speaks for the run — a failed-then-retried attempt bead leaves
+// outcome=fail on the attempt, not the root. Shared by the root-closed and
+// all-closed branches of mapRunPhase.
+func terminalRunLabel(root runIssue) string {
+	outcome := strings.ToLower(stringValue(root.metadata[beadmeta.OutcomeMetadataKey]))
+	if outcome == "fail" || outcome == "failed" {
+		return "failed"
+	}
+	return "complete"
+}
+
+// terminalRunLabelByID resolves the terminal label for the root identified by
+// rootID, defaulting to "complete" when no such issue is present (a rootless
+// all-closed group).
+func terminalRunLabelByID(rootID string, issues []runIssue) string {
+	if root, ok := findIssue(issues, rootID); ok {
+		return terminalRunLabel(root)
+	}
+	return "complete"
 }
 
 // structuredPhase derives the phase from the run's current step.
@@ -413,6 +435,14 @@ var runStages = [][2]string{
 func stageProgress(phase phaseMapping, formula string, hasFormula bool, issues []runIssue) []RunStage {
 	formulaStages := stagesForFormula(formula, hasFormula)
 	if len(formulaStages) > 0 {
+		if phase.phase == "complete" {
+			// Terminal root: present the ladder without ever re-deriving active or
+			// blocked from lingering raw member statuses. A stage that ran is
+			// complete; a stage that never materialized (a run that exited early)
+			// stays pending — collapsing every stage to complete would falsely show
+			// a preflight-failed run finishing Human approval and Merge-ready.
+			return formulaStageProgressTerminal(formulaStages, issues)
+		}
 		return formulaStageProgress(formulaStages, issues)
 	}
 
@@ -557,6 +587,45 @@ func formulaStageProgress(stages []formulaStage, issues []runIssue) []RunStage {
 			Label:  stage.label,
 			Status: formulaStageStatus(idx, activeIndex, furthestClosedIndex, stage, primary),
 		}
+	}
+	return out
+}
+
+// formulaStageProgressTerminal renders the stage ladder for a terminal run
+// without emitting active or blocked. A stage is complete iff it RAN — carries a
+// step that reached closed/in_progress/blocked — or precedes the furthest-run
+// stage; a stage that never materialized (a run that exited early) stays pending.
+// This matches formulaStageProgress's own no-active-step derivation for a fully
+// closed run, so a preflight-failed run keeps its trailing stages pending instead
+// of falsely reporting Human approval and Merge-ready complete.
+func formulaStageProgressTerminal(stages []formulaStage, issues []runIssue) []RunStage {
+	primary := primaryStepIssues(issues)
+	ran := make([]bool, len(stages))
+	furthest := -1
+	for idx, s := range stages {
+		for _, step := range s.steps {
+			for _, i := range stepIssues(primary, step) {
+				if i.status == "closed" || i.status == "in_progress" || i.status == "blocked" {
+					ran[idx] = true
+					break
+				}
+			}
+			if ran[idx] {
+				break
+			}
+		}
+		if ran[idx] {
+			furthest = idx
+		}
+	}
+
+	out := make([]RunStage, len(stages))
+	for idx, s := range stages {
+		status := "pending"
+		if ran[idx] || idx < furthest {
+			status = "complete"
+		}
+		out[idx] = RunStage{Key: s.key, Label: s.label, Status: status}
 	}
 	return out
 }

--- a/internal/runproj/summary.go
+++ b/internal/runproj/summary.go
@@ -234,10 +234,16 @@ func runLane(rootID string, issues []runIssue, feedScopes map[string]RunFeedScop
 		}
 	}
 
+	// A terminal root (phase "complete") has no active step even if a member bead
+	// still reads in_progress because its close event was lost: suppress the
+	// active-step scan so the lane's progress matches the terminal phase and the
+	// clamped DAG instead of reporting active_step under a completed run.
 	var primaryInProgress []runIssue
-	for _, i := range issues {
-		if isPrimaryStepIssue(i) && i.status == "in_progress" {
-			primaryInProgress = append(primaryInProgress, i)
+	if phase.phase != "complete" {
+		for _, i := range issues {
+			if isPrimaryStepIssue(i) && i.status == "in_progress" {
+				primaryInProgress = append(primaryInProgress, i)
+			}
 		}
 	}
 	activeStepID, hasActiveStep := latestStepID(primaryInProgress)
@@ -265,6 +271,21 @@ func runLane(rootID string, issues []runIssue, feedScopes map[string]RunFeedScop
 		phaseLabel = stages[foundStageIndex].Label
 	}
 
+	// A terminal root's lane must not expose live-work fields derived from members
+	// whose close events were lost: present every member as closed and drop the
+	// stale assignee so a historical LaneCard never reads "on <assignee> · N in
+	// progress" for a finished run. Gated identically to the active-step scan above.
+	counts := statusCounts(issues)
+	assignees := activeAssignees(issues)
+	if phase.phase == "complete" {
+		var terminal StatusCounts
+		for range issues {
+			terminal.inc("closed")
+		}
+		counts = terminal
+		assignees = []string{}
+	}
+
 	return RunLane{
 		ID:                   rootID,
 		Title:                displayTitle(rootID, issues),
@@ -273,8 +294,8 @@ func runLane(rootID string, issues []runIssue, feedScopes map[string]RunFeedScop
 		External:             externalReference(issues),
 		Phase:                phase.phase,
 		PhaseLabel:           phaseLabel,
-		StatusCounts:         statusCounts(issues),
-		ActiveAssignees:      activeAssignees(issues),
+		StatusCounts:         counts,
+		ActiveAssignees:      assignees,
 		UpdatedAt:            updatedAt,
 		Stages:               stages,
 		Progress:             progress,


### PR DESCRIPTION
## Problem

A fully-merged merge-queue run rendered **every step "Running" forever** (reported live: `factory.gascity.com/city/maintainer-city/runs/gcg-98633350`, the adopt-pr-v2 run for beads#4911 — root `completed`, all 13 step nodes `active`, `statusCounts {completed:1, active:7, pending:1}`).

The run projection is event-sourced from `.gc/events.jsonl`. On the deployed fork, worker-side step closes never reached the event log (fixed separately on the fork integration branch), and the wisp reaper then deleted the beads — freezing the fold at `in_progress` with no possible repair from the store: the stale "Running" was permanent.

## Fix: the projection never asserts liveness a terminal root contradicts

Nothing can be running in a run whose root is terminal. At build time:

- **Detail nodes/instances** — non-terminal statuses clamp: completed root ⇒ started→`completed`, pending→`skipped`; failed/canceled root ⇒ started→`canceled`, pending→`skipped`. Recorded terminal outcomes (`gc.outcome`) are never altered. Instances clamp **before** `aggregateStatus` so a clamped node can't re-derive "active"; session links resolve from the recorded status (clamped-completed steps keep transcript links, non-streamable).
- **Control badges** — clamped through the same rule (fresh slice; the incoming slice aliases `badgesByTarget` storage).
- **Phase/stages** — `mapRunPhase` gains a root-closed branch (mirrors the root-terminality-wins doctrine in `CanonicalRunStatusForLane`); the formula stage ladder marks a stage complete iff it **ran or precedes the furthest-run stage**, so never-materialized stages stay `pending` (consistent with `skipped` nodes) instead of falsely complete.
- **Summary lanes** — closed-root lanes bucket historical and stop reporting `active_step`, raw `in_progress` StatusCounts, and ActiveAssignees.
- **Typed `/steps` endpoint** — derives the run's canonical status exactly as `laneToRun` and clamps each step via the exported `ClampStepStatusForRun`, keeping a single terminality source.

The clamp is **inactive** for any non-terminal or absent root — live runs untouched; all-closed runs output-identical to before. This retroactively repairs every already-frozen run (their root-close events are in the log). No new status strings; no wire-shape changes.

## Review process

Implementation was adversarially reviewed pre-PR (5 lenses + per-finding refutation verifiers, 25 agents total): 11 confirmed findings fixed (root-terminality pushed into phase/stage/summary seams, badge clamping, /steps), then a second focused pass caught and fixed a stage-ladder over-collapse regression (early-exit runs keep trailing stages pending) and residual raw liveness on closed-root lanes. The ready/blocked→completed mapping question was adjudicated (refuted twice: those statuses have no producer in the fold).

## Tests

- `internal/runproj`: clamp mapping table (24 cases) + taxonomy-lockstep guard, the exact production incident shape, recorded-outcome preservation, aggregate-resurrection guard, badge clamp + inactive no-op, root-closed phase/stage tests incl. early-exit ladder pinning, closed-root summary-lane tests, session-link retention.
- `internal/api`: `/steps` clamp for completed and failed runs.
- Gates: runproj + api + dashboardbff suites, `go vet`, build, gofmt all green; golden/parity/`TestSummaryDetailPhaseStageConsistency` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)