### PR TITLE
test: preserve Worker Core report output through cmd/gc TestMain

### DIFF
--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -120,6 +120,7 @@ func TestClearProcessLiveEnvForTestsUnsetsInheritedState(t *testing.T) {
 		"GC_FAST_UNIT",
 		"GC_REAL_PROCESS_SIGNAL_TESTS",
 		"GC_TEST_KEEP",
+		"GC_WORKER_REPORT_DIR",
 	}
 
 	for _, key := range append(cleared, preserved...) {
@@ -189,6 +190,7 @@ func liveEnvKeysForTests() []string {
 func preserveTestControlEnv(key string) bool {
 	return key == "GC_FAST_UNIT" ||
 		key == "GC_REAL_PROCESS_SIGNAL_TESTS" ||
+		key == "GC_WORKER_REPORT_DIR" ||
 		key == managedDoltTestModeEnv ||
 		key == managedDoltTestParentPIDEnv ||
 		key == "GC_DOLT_REAL_BINARY" ||


### PR DESCRIPTION
## Why

`cmd/gc` TestMain scrubbed `GC_WORKER_REPORT_DIR`, so phase-2 tests could pass without emitting three intended reports per profile, including the real-transport evidence.

## What changed

- Preserve only the exact `GC_WORKER_REPORT_DIR` test-control key.
- Pin that exception in the existing environment-scrub regression.
- Keep ordinary `GC_*`, Beads, and Dolt process state scrubbed.

## Verification

- Focused TDD proof: failed before the exception, passed after it.
- Claude, Codex, and Gemini phase-2 runs each emitted exactly 13 passing JSON reports.
- Real-transport reports include `WC-TRANSPORT-001`.
- `make test-fast-parallel`
- `go vet ./...`
- Repository pre-commit and pre-push hooks
- Two independent delegated reviews approved exact diff hash `85dcc11c55d7bded90cdcb833c24579b14a5fd9d8dd57c693d01302b72b74d7e`.

No production behavior changes.

Bead: `ga-yrotsuu.27`