### PR TITLE
test(policy): enforce exact tmux resource ownership

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -14,7 +14,7 @@ not describe a target as an existing gate.
 
 | Policy area | Mechanical status today |
 |---|---|
-| Sleep/process/listener/env/CWD growth | Checked by the source-resource ledger below |
+| Sleep/process/listener/tmux/env/CWD growth | Checked by the source-resource ledger below |
 | Runtime constructor and `runtime.Fake` conformance binding | Checked by the runtime provider ledger below; several explicit waivers remain |
 | Other provider conformance | Shared suites exist, but exact production-constructor coverage is still a manual audit with known gaps |
 | Sub-five-minute PR feedback and timing ratchets | Target; current Go timing artifacts measure test execution, not workflow queue/bootstrap/graph time (`ga-80po0c.4`) |
@@ -269,7 +269,7 @@ Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
 freeze process, sleep, environment, CWD, slow-process, HTTP test-server, and
 package-level `net.Listen`, `net.ListenConfig.Listen`, `net.ListenUnixgram`,
-and direct `syscall.Listen` call/file totals.
+direct `syscall.Listen`, and typed or literal tmux dependency call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
 owners without weakening the raw anti-growth ratchets.
@@ -334,16 +334,28 @@ helper calls or claim a complete shared-resource inventory. P0.4c currently
 covers the three `net/http/httptest` constructors that open loopback servers
 and the exact package-level `net.Listen` and `net.ListenUnixgram` constructors,
 `net.ListenConfig.Listen` on lexically identified receivers, and direct
-`syscall.Listen`. Direct `syscall.Socket`/`Bind` setup calls, typed and
+`syscall.Listen`. The tmux catalog recognizes canonical `test/tmuxtest`
+namespace/lifecycle helpers, imported `internal/runtime/tmux` production
+constructors, and literal `os/exec` tmux commands and probes. Its untagged
+source census is 6 calls in 2 files, all owned by exact Medium `TestMain`
+rows; build-tagged calls remain E1 Large inventory rather than being relabeled
+Medium. `NewSocketParentDir`, `HoldAliveSentinel`, and the PID-directory
+helpers remain part of the separate shared-host resource tail. Direct
+`syscall.Socket`/`Bind` setup calls, typed and
 packet-specific `net` constructors, helper-backed listeners whose constructors
-live outside test source, tmux, Dolt, and other shared-host resources remain
+live outside test source, Dolt, and other shared-host resources remain
 explicit follow-up catalogs. A Medium resource may describe a helper-backed
 runtime cost, but only syntax-owned calls in that exact runnable declaration
 leave Small-debt accounting. The `ListenConfig` matcher uses lexical Go types
 to follow same-file values, pointers, parameters, aliases, and typed factory
 results rooted in the imported `net.ListenConfig` type; it does not load
 cross-file package bodies or host toolchain export data.
-`ga-80po0c.2.2` owns the listener, tmux, Dolt, and shared-host catalogs. E1
+The tmux helper match is an explicit dependency/namespace proxy; it does not
+claim a recursive inventory of the helper's environment mutations. Function
+aliases and wrappers, variable or absolute command names, `sh -c`, `exec.Cmd`
+literals, `Guard` methods, and same-package bare constructors remain deliberate
+manual-review boundaries. `ga-80po0c.2.2` owns the listener, tmux, Dolt, and
+shared-host catalogs. E1
 separately owns Large journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
@@ -353,7 +365,13 @@ The scanner recognizes direct calls to `os/exec.Command{,Context}` and
 `NewTLSServer`, and `NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`,
 `os.Clearenv`, and `os.Chdir`; and
 `Setenv` or `Chdir` on function parameters typed exactly as `*testing.T` or
-`testing.TB`. It also recognizes the receiverless
+`testing.TB`. For tmux it recognizes `ConfigureProcessEnv`,
+`KillAllTestSessions`, `NewGuard`, `NewGuardWithSocket`, and `RequireTmux` from
+`test/tmuxtest`; `NewProvider`, `NewProviderWithConfig`,
+`NewSeamBackedWithConfig`, `NewTmux`, and `NewTmuxWithConfig` from
+`internal/runtime/tmux`; and literal `os/exec.Command("tmux", ...)`,
+`CommandContext(ctx, "tmux", ...)`, and `LookPath("tmux")` calls. It also
+recognizes the receiverless
 `skipSlowCmdGCTest(*testing.T, string)` definition and its same-package calls.
 An unresolved cross-file call counts only when that directory and package own
 the canonical helper. Import, parameter, and same-file helper matches use
@@ -363,8 +381,9 @@ Local shadows and wrong signatures do not count. Parenthesized call
 expressions retain the same ownership.
 
 Targeted dot imports of `net`, `os/exec`, `time`, `os`, `syscall`, `testing`,
-or `net/http/httptest` are rejected with file and import context because their
-resources cannot be attributed safely; blank imports remain harmless.
+`net/http/httptest`, `internal/runtime/tmux`, or `test/tmuxtest` are rejected
+with file and import context because their resources cannot be attributed
+safely; blank imports remain harmless.
 Explicit constraints follow Go's leading-header
 rules: a pre-package `//go:build` line is effective, while a legacy
 `// +build` line must live in a leading `//` comment block separated from the
@@ -399,8 +418,9 @@ all-source audit while staying outside untagged and Small debt.
 | --- | --- | --- | --- | --- | --- | --- |
 | Audit baseline | all tracked test source | fixed_sleep: 427 calls / 156 files (historical regex census: 447 / 157) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
 | Audit baseline | all tracked test source | subprocess: 529 calls / 162 files (historical regex census: 495 / 135) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
-| Medium owner | `cmd/gc` package `main` | TestMain: environment | ga-80po0c.2.1 | cmd/gc TestMain is the checked package-level Medium owner; only environment calls lexically inside TestMain leave Small debt | P0.4b | 2026-10-01 |
+| Medium owner | `cmd/gc` package `main` | TestMain: environment, tmux | ga-80po0c.2.1 | cmd/gc TestMain is the checked package-level Medium owner for process environment and tmux namespace setup; only declared environment and tmux calls lexically inside TestMain leave Small debt | P0.4b/P0.4c-tmux | 2026-10-01 |
 | Medium owner | `internal/api` package `api` | TestEveryEmittedErrorCodeIsRegistered: subprocess | ga-80po0c.2.1 | internal/api tracked-source error URN guard is a checked Medium owner; only the git ls-files call lexically inside TestEveryEmittedErrorCodeIsRegistered leaves Small debt | P0.4b | 2026-10-01 |
+| Medium owner | `internal/runtime/tmux` package `tmux` | TestMain: environment, tmux | ga-80po0c.2.2.1 | runtime tmux TestMain is the checked Medium owner for isolated tmux process and socket cleanup; only declared environment and tmux calls lexically inside TestMain leave Small debt | P0.4c-tmux | 2026-10-01 |
 | Medium owner | `scripts` package `scripts_test` | TestDockerSessionProtocol: subprocess | ga-80po0c.23.1 | Docker session adapter protocol proof is a checked Medium owner; the one adapter subprocess is confined to TestDockerSessionProtocol and Docker itself is a strict PATH-injected fake | W6 | 2026-10-01 |
 | Medium owner | `scripts` package `scripts_test` | TestProviderOverridesAndSuiteContractsCrossMakeIsolation: subprocess | ga-80po0c.2.1 | Make/provider and suite-contract proof is a checked Medium owner; the six isolated Make invocations are confined to TestProviderOverridesAndSuiteContractsCrossMakeIsolation | P0.1 | 2026-10-01 |
 | Small debt ratchet | `cmd/gc` untagged test source | cwd: 285 calls / 43 files (historical regex census: 284 / 43) | ga-80po0c.2.1 | untagged Small cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners restore or eliminate every cwd mutation | D5/D6 | 2026-10-01 |
@@ -413,6 +433,7 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 391 calls / 110 files (historical regex census: 394 / 105) | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
+| Small debt ratchet | all untagged test source | tmux: 0 calls / 0 files | ga-80po0c.2.2.1 | untagged Small tmux dependency call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace tmux with a fake executor or declare exact isolated ownership | P0.4c-tmux | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | cwd: 285 calls / 43 files (historical regex census: 98 / 13) | ga-80po0c.2.3 | untagged cmd/gc cwd call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized cwd mutation | D5/D6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | environment: 4326 calls / 203 files (historical regex census: 3960 / 184) | ga-80po0c.2.3 | untagged cmd/gc environment call/file totals cannot grow; reductions must lower this baseline; cmd/gc callers restore or eliminate every recognized process-environment mutation | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 57 calls / 24 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
@@ -423,6 +444,7 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 394 calls / 112 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged syscall.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listening file descriptor and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
+| Source debt ratchet | all untagged test source | tmux: 6 calls / 2 files | ga-80po0c.2.2.1 | untagged tmux dependency call/file totals cannot grow; reductions must lower this baseline; each owning test confines tmux processes and sockets to its isolated namespace and cleanup | P0.4c-tmux | 2026-10-01 |
 
 | Reviewed hermetic body | Effective runnable size | Medium reason | Retained real composition owner |
 | --- | --- | --- | --- |

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -50,6 +50,8 @@ const (
 	ResourceNetListenConfig Resource = "net_listen_config"
 	// ResourceSyscallListen counts direct calls that put sockets into listening state through syscall.Listen.
 	ResourceSyscallListen Resource = "syscall_listen"
+	// ResourceTmux counts typed tmux test helpers, production constructors, and literal tmux process calls.
+	ResourceTmux Resource = "tmux"
 )
 
 var knownResources = map[Resource]struct{}{
@@ -63,6 +65,7 @@ var knownResources = map[Resource]struct{}{
 	ResourceNetListenConfig:   {},
 	ResourceNetListenUnixgram: {},
 	ResourceSyscallListen:     {},
+	ResourceTmux:              {},
 }
 
 // Scope selects the source population counted by a ledger row.
@@ -268,6 +271,19 @@ var bootstrapPolicy = Ledger{
 			MigrationTarget: "P0.4c",
 			Expires:         "2026-10-01",
 		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceTmux,
+			BaselineCalls:   6,
+			BaselineFiles:   2,
+			ReportedCalls:   6,
+			ReportedFiles:   2,
+			OwnerBead:       "ga-80po0c.2.2.1",
+			Invariant:       "untagged tmux dependency call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test confines tmux processes and sockets to its isolated namespace and cleanup",
+			MigrationTarget: "P0.4c-tmux",
+			Expires:         "2026-10-01",
+		},
 	},
 	Medium: []MediumOwner{
 		{
@@ -285,11 +301,22 @@ var bootstrapPolicy = Ledger{
 			PackageDir:      "cmd/gc",
 			PackageName:     "main",
 			Owner:           "TestMain",
-			Resources:       []Resource{ResourceEnvironment},
+			Resources:       []Resource{ResourceEnvironment, ResourceTmux},
 			OwnerBead:       "ga-80po0c.2.1",
-			Invariant:       "cmd/gc TestMain is the checked package-level Medium owner",
-			ResourceOwner:   "only environment calls lexically inside TestMain leave Small debt",
-			MigrationTarget: "P0.4b",
+			Invariant:       "cmd/gc TestMain is the checked package-level Medium owner for process environment and tmux namespace setup",
+			ResourceOwner:   "only declared environment and tmux calls lexically inside TestMain leave Small debt",
+			MigrationTarget: "P0.4b/P0.4c-tmux",
+			Expires:         "2026-10-01",
+		},
+		{
+			PackageDir:      "internal/runtime/tmux",
+			PackageName:     "tmux",
+			Owner:           "TestMain",
+			Resources:       []Resource{ResourceEnvironment, ResourceTmux},
+			OwnerBead:       "ga-80po0c.2.2.1",
+			Invariant:       "runtime tmux TestMain is the checked Medium owner for isolated tmux process and socket cleanup",
+			ResourceOwner:   "only declared environment and tmux calls lexically inside TestMain leave Small debt",
+			MigrationTarget: "P0.4c-tmux",
 			Expires:         "2026-10-01",
 		},
 		{
@@ -474,6 +501,19 @@ var bootstrapPolicy = Ledger{
 			Invariant:       "untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener",
 			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceTmux,
+			BaselineCalls:   0,
+			BaselineFiles:   0,
+			ReportedCalls:   0,
+			ReportedFiles:   0,
+			OwnerBead:       "ga-80po0c.2.2.1",
+			Invariant:       "untagged Small tmux dependency call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners replace tmux with a fake executor or declare exact isolated ownership",
+			MigrationTarget: "P0.4c-tmux",
 			Expires:         "2026-10-01",
 		},
 	},
@@ -933,7 +973,7 @@ func validateImports(file *ast.File) error {
 			continue
 		}
 		if spec.Name != nil && spec.Name.Name == "." {
-			if importPath == "net" || importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "syscall" || importPath == "testing" || importPath == "net/http/httptest" {
+			if importPath == "net" || importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "syscall" || importPath == "testing" || importPath == "net/http/httptest" || importPath == "github.com/gastownhall/gascity/internal/runtime/tmux" || importPath == "github.com/gastownhall/gascity/test/tmuxtest" {
 				return fmt.Errorf("targeted dot import %q cannot be counted safely", importPath)
 			}
 		}
@@ -964,7 +1004,7 @@ func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner str
 		switch function := unparen(call.Fun).(type) {
 		case *ast.SelectorExpr:
 			switch function.Sel.Name {
-			case "Command", "CommandContext", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "ListenUnixgram", "NewServer", "NewTLSServer", "NewUnstartedServer":
+			case "Command", "CommandContext", "ConfigureProcessEnv", "KillAllTestSessions", "LookPath", "NewGuard", "NewGuardWithSocket", "NewProvider", "NewProviderWithConfig", "NewSeamBackedWithConfig", "NewServer", "NewTLSServer", "NewTmux", "NewTmuxWithConfig", "NewUnstartedServer", "RequireTmux", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "ListenUnixgram":
 				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		case *ast.Ident:

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -99,6 +99,103 @@ func TestLocalNamesAreNotStdlibCalls() {
 	assertCount(t, got, ScopeUntagged, ResourceFixedSleep, 1, 1)
 }
 
+func TestScanCountsTmuxDependenciesByImportIdentityAndLiteralCommand(t *testing.T) {
+	t.Parallel()
+
+	files := fstest.MapFS{
+		"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import (
+	"context"
+	foreign "example.test/tmuxtest"
+	runtimetmux "github.com/gastownhall/gascity/internal/runtime/tmux"
+	tmuxtest "github.com/gastownhall/gascity/test/tmuxtest"
+	shell "os/exec"
+	"testing"
+)
+
+type localTmuxTest struct{}
+func (localTmuxTest) NewGuard(any) {}
+func (localTmuxTest) RequireTmux(any) {}
+
+func TestTmuxResources(t *testing.T) {
+	_ = tmuxtest.NewGuard(t)
+	_ = tmuxtest.NewGuardWithSocket(t, "isolated")
+	tmuxtest.RequireTmux(t)
+	tmuxtest.KillAllTestSessions(t)
+	_ = tmuxtest.ConfigureProcessEnv(t.TempDir())
+	_ = ((shell.Command))(("tmux"), "-V")
+	_ = shell.CommandContext(context.Background(), "tmux", "-V")
+	_, _ = shell.LookPath("tmux")
+	_ = runtimetmux.NewProvider()
+	_ = runtimetmux.NewProviderWithConfig(runtimetmux.DefaultConfig())
+	_ = runtimetmux.NewSeamBackedWithConfig(runtimetmux.DefaultConfig())
+	_ = runtimetmux.NewTmux()
+	_ = runtimetmux.NewTmuxWithConfig(runtimetmux.DefaultConfig())
+
+	// Shared-host socket-parent and PID helpers are a separate resource tail.
+	_, _, _ = tmuxtest.NewSocketParentDir("", nil)
+	_, _ = tmuxtest.HoldAliveSentinel("")
+	_ = tmuxtest.PIDPrefixedTempPattern("")
+	tmuxtest.SweepOrphanPIDPrefixedDirs("", "", nil)
+
+	local := localTmuxTest{}
+	local.NewGuard(t)
+	local.RequireTmux(t)
+	_ = foreign.NewGuard(t)
+	_ = shell.Command("printf", "tmux")
+	_ = shell.CommandContext(context.Background(), "printf", "tmux")
+	command := "tmux"
+	_ = shell.Command(command, "-V")
+	_ = "tmuxtest.NewGuard(t); exec.Command(\"tmux\")"
+	// tmuxtest.NewGuard(t)
+}
+
+func helper(t *testing.T) {
+	tmuxtest.RequireTmux(t)
+}
+`)},
+		"sample/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package sample
+import (
+	tmuxtest "github.com/gastownhall/gascity/test/tmuxtest"
+	"testing"
+)
+func TestTaggedTmux(t *testing.T) {
+	_ = tmuxtest.NewGuard(t)
+}
+`)},
+	}
+
+	got, err := ScanFS(files)
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	assertCount(t, got, ScopeAll, ResourceTmux, 15, 2)
+	assertCount(t, got, ScopeUntagged, ResourceTmux, 14, 1)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceTmux, "TestTmuxResources", true, false)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceTmux, "helper", false, false)
+	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceTmux, "TestTaggedTmux", true, true)
+}
+
+func TestScanRejectsTmuxResourceDotImports(t *testing.T) {
+	t.Parallel()
+
+	for _, importPath := range []string{
+		"github.com/gastownhall/gascity/internal/runtime/tmux",
+		"github.com/gastownhall/gascity/test/tmuxtest",
+	} {
+		importPath := importPath
+		t.Run(importPath, func(t *testing.T) {
+			t.Parallel()
+			_, err := ScanFS(fstest.MapFS{
+				"sample/resources_test.go": &fstest.MapFile{Data: []byte("package sample\nimport . \"" + importPath + "\"\nfunc TestTmux() {}\n")},
+			})
+			requireErrorContains(t, err, `targeted dot import "`+importPath+`" cannot be counted safely`)
+		})
+	}
+}
+
 func TestScanCountsHTTPTestServerConstructorsByImportIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -1629,6 +1726,48 @@ func TestBootstrapPolicyOwnsSyscallListenDebt(t *testing.T) {
 		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
 			t.Fatalf("syscall.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
 		}
+	}
+}
+
+func TestBootstrapPolicyOwnsTmuxDebtAndExactMediumSetup(t *testing.T) {
+	t.Parallel()
+
+	debt := findRow(t, bootstrapPolicy.Debt, ScopeUntagged, ResourceTmux)
+	if debt.BaselineCalls != 6 || debt.BaselineFiles != 2 {
+		t.Fatalf("tmux source baseline = %d/%d, want 6/2", debt.BaselineCalls, debt.BaselineFiles)
+	}
+	smallDebt := findRow(t, bootstrapPolicy.SmallDebt, ScopeUntagged, ResourceTmux)
+	if smallDebt.BaselineCalls != 0 || smallDebt.BaselineFiles != 0 {
+		t.Fatalf("tmux Small baseline = %d/%d, want 0/0", smallDebt.BaselineCalls, smallDebt.BaselineFiles)
+	}
+	for _, row := range []*Baseline{debt, smallDebt} {
+		if row.OwnerBead != "ga-80po0c.2.2.1" || row.MigrationTarget != "P0.4c-tmux" {
+			t.Fatalf("tmux owner = %q/%q, want ga-80po0c.2.2.1/P0.4c-tmux", row.OwnerBead, row.MigrationTarget)
+		}
+	}
+
+	wantOwners := map[string]map[Resource]bool{
+		"cmd/gc|main|TestMain":                {ResourceEnvironment: true, ResourceTmux: true},
+		"internal/runtime/tmux|tmux|TestMain": {ResourceEnvironment: true, ResourceTmux: true},
+	}
+	for _, row := range bootstrapPolicy.Medium {
+		key := row.PackageDir + "|" + row.PackageName + "|" + row.Owner
+		want, ok := wantOwners[key]
+		if !ok {
+			continue
+		}
+		if len(row.Resources) != len(want) {
+			t.Fatalf("medium owner %s resources = %v, want environment and tmux", key, row.Resources)
+		}
+		for _, resource := range row.Resources {
+			if !want[resource] {
+				t.Fatalf("medium owner %s unexpected resource %q in %v", key, resource, row.Resources)
+			}
+		}
+		delete(wantOwners, key)
+	}
+	if len(wantOwners) != 0 {
+		t.Fatalf("missing exact tmux Medium owners: %v", wantOwners)
 	}
 }
 

--- a/internal/testpolicy/resourcecensus/hermetic.go
+++ b/internal/testpolicy/resourcecensus/hermetic.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"go/types"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -616,6 +617,39 @@ func matchedResourcesForCall(call *ast.CallExpr, bindings bindingInfo, testingOb
 	if err := appendImported(ResourceSubprocess, "os/exec", "Command", "CommandContext"); err != nil {
 		return nil, err
 	}
+	for _, callFamily := range []struct {
+		importPath string
+		names      []string
+	}{
+		{
+			importPath: "github.com/gastownhall/gascity/test/tmuxtest",
+			names:      []string{"ConfigureProcessEnv", "KillAllTestSessions", "NewGuard", "NewGuardWithSocket", "RequireTmux"},
+		},
+		{
+			importPath: "github.com/gastownhall/gascity/internal/runtime/tmux",
+			names:      []string{"NewProvider", "NewProviderWithConfig", "NewSeamBackedWithConfig", "NewTmux", "NewTmuxWithConfig"},
+		},
+	} {
+		if err := appendImported(ResourceTmux, callFamily.importPath, callFamily.names...); err != nil {
+			return nil, err
+		}
+	}
+	for _, command := range []struct {
+		name     string
+		argument int
+	}{
+		{name: "Command", argument: 0},
+		{name: "CommandContext", argument: 1},
+		{name: "LookPath", argument: 0},
+	} {
+		matched, err := isImportedCallWithLiteralArgument(call, bindings, "os/exec", command.argument, "tmux", command.name)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			resources = append(resources, ResourceTmux)
+		}
+	}
 	if err := appendImported(ResourceFixedSleep, "time", "Sleep"); err != nil {
 		return nil, err
 	}
@@ -643,4 +677,20 @@ func matchedResourcesForCall(call *ast.CallExpr, bindings bindingInfo, testingOb
 		resources = append(resources, ResourceSlowProcessGate)
 	}
 	return resources, nil
+}
+
+func isImportedCallWithLiteralArgument(call *ast.CallExpr, bindings bindingInfo, importPath string, argument int, want string, names ...string) (bool, error) {
+	matched, err := isImportedCall(call, bindings, importPath, names...)
+	if err != nil || !matched || argument >= len(call.Args) {
+		return false, err
+	}
+	literal, ok := unparen(call.Args[argument]).(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return false, nil
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return false, fmt.Errorf("decoding resource command literal %s: %w", literal.Value, err)
+	}
+	return value == want, nil
 }

--- a/internal/testpolicy/resourcecensus/hermetic_test.go
+++ b/internal/testpolicy/resourcecensus/hermetic_test.go
@@ -141,6 +141,7 @@ func TestValidateReviewedHermeticBodiesRejectsDirectKnownResources(t *testing.T)
 		{name: "net listen config", imports: `"net"`, body: `_, _ = (net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")`, resource: ResourceNetListenConfig},
 		{name: "net listen unixgram", imports: `"net"`, body: `_, _ = net.ListenUnixgram("unixgram", nil)`, resource: ResourceNetListenUnixgram},
 		{name: "syscall listen", imports: `"syscall"`, body: `_ = syscall.Listen(0, 0)`, resource: ResourceSyscallListen},
+		{name: "tmux", imports: `tmuxtest "github.com/gastownhall/gascity/test/tmuxtest"`, body: `_ = tmuxtest.NewGuard(t)`, resource: ResourceTmux},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -165,6 +165,19 @@ resource_owner = "each owning test closes its listening file descriptor and remo
 migration_target = "P0.4c"
 expires = "2026-10-01"
 
+[[debt]]
+scope = "untagged"
+resource = "tmux"
+baseline_calls = 6
+baseline_files = 2
+reported_calls = 6
+reported_files = 2
+owner_bead = "ga-80po0c.2.2.1"
+invariant = "untagged tmux dependency call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test confines tmux processes and sockets to its isolated namespace and cleanup"
+migration_target = "P0.4c-tmux"
+expires = "2026-10-01"
+
 # Exact Medium owners are keyed by source directory, package clause, and
 # top-level Go test identity. Only matching resources lexically inside that
 # declaration leave the Small-debt census; helper bodies and sibling tests do
@@ -184,11 +197,22 @@ expires = "2026-10-01"
 package_dir = "cmd/gc"
 package_name = "main"
 owner = "TestMain"
-resources = ["environment"]
+resources = ["environment", "tmux"]
 owner_bead = "ga-80po0c.2.1"
-invariant = "cmd/gc TestMain is the checked package-level Medium owner"
-resource_owner = "only environment calls lexically inside TestMain leave Small debt"
-migration_target = "P0.4b"
+invariant = "cmd/gc TestMain is the checked package-level Medium owner for process environment and tmux namespace setup"
+resource_owner = "only declared environment and tmux calls lexically inside TestMain leave Small debt"
+migration_target = "P0.4b/P0.4c-tmux"
+expires = "2026-10-01"
+
+[[medium]]
+package_dir = "internal/runtime/tmux"
+package_name = "tmux"
+owner = "TestMain"
+resources = ["environment", "tmux"]
+owner_bead = "ga-80po0c.2.2.1"
+invariant = "runtime tmux TestMain is the checked Medium owner for isolated tmux process and socket cleanup"
+resource_owner = "only declared environment and tmux calls lexically inside TestMain leave Small debt"
+migration_target = "P0.4c-tmux"
 expires = "2026-10-01"
 
 [[medium]]
@@ -375,4 +399,17 @@ owner_bead = "ga-80po0c.2.2"
 invariant = "untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener"
 migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "tmux"
+baseline_calls = 0
+baseline_files = 0
+reported_calls = 0
+reported_files = 0
+owner_bead = "ga-80po0c.2.2.1"
+invariant = "untagged Small tmux dependency call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners replace tmux with a fake executor or declare exact isolated ownership"
+migration_target = "P0.4c-tmux"
 expires = "2026-10-01"


### PR DESCRIPTION
## Summary

- Classify explicit tmux dependencies by Go import identity and literal `tmux` commands.
- Assign all six untagged uses to the exact `cmd/gc` and `internal/runtime/tmux` `TestMain` owners.
- Ratchet tmux source debt at 6 calls / 2 files and Small debt at 0 / 0.
- Keep build-tagged real-tmux journeys under E1 and keep shared-host PID/socket helpers outside the tmux catalog.

## Why

P0.4c already checks several listener resources, but tmux ownership remained prose-only. A new untagged real-tmux dependency could therefore enter the suite without failing the test-resource policy.

This slice adds bounded syntax-aware ownership without changing production behavior or test execution behavior.

## Invariant map

| Invariant | Before | After |
| --- | --- | --- |
| Untagged explicit tmux dependencies | Unchecked | Checked at 6 calls / 2 files |
| Small tmux debt | Unchecked | Checked at 0 / 0 after exact Medium subtraction |
| Build-tagged real-tmux journeys | E1-owned | Still E1-owned; not relabeled Medium |
| Shared-host socket/PID helpers | Separate follow-up | Still separate; explicit negative fixtures |
| Runtime behavior | Unchanged | Unchanged |

## Verification

- TDD RED: focused tests failed with `ResourceTmux` undefined before implementation.
- Focused tmux tests passed with `-count=10` and under `-race`.
- Full `internal/testpolicy/resourcecensus` package passed.
- Live ledger/docs synchronization confirmed 6 calls / 2 files and Small debt 0 / 0.
- `make test-ci-policy`, `make check-docs`, and `go vet ./...` passed.
- Commit and pre-push hooks passed; the final eight-way `make test-fast-parallel` run was fully green.
- Three independent delegated review lanes approved exact tree `84a02d01765c711120f01e513cd803c862a0c7b1`.
- Five repository-census runs were effectively flat: 15.57s candidate vs 15.46s clean base.

Bead: `ga-80po0c.2.2.1`
