### PR TITLE
test(policy): classify typed listener resources

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -268,7 +268,7 @@ change as any other waiver.
 Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
 freeze process, sleep, environment, CWD, slow-process, HTTP test-server, and
-package-level `net.Listen`, `net.ListenConfig.Listen`, `net.ListenUnixgram`,
+package-level `net` stream/packet listeners, `net.ListenConfig` listeners,
 direct `syscall.Listen`, and typed or literal tmux dependency call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
@@ -332,20 +332,22 @@ calls inside `TestMain`, never sibling tests.
 This bootstrap does **not** infer resources recursively through arbitrary
 helper calls or claim a complete shared-resource inventory. P0.4c currently
 covers the three `net/http/httptest` constructors that open loopback servers
-and the exact package-level `net.Listen` and `net.ListenUnixgram` constructors,
-`net.ListenConfig.Listen` on lexically identified receivers, and direct
-`syscall.Listen`. The tmux catalog recognizes canonical `test/tmuxtest`
+and the exact package-level stream constructors `net.Listen`, `net.ListenTCP`,
+and `net.ListenUnix`; packet constructors `net.ListenPacket`, `net.ListenUDP`,
+`net.ListenIP`, `net.ListenUnixgram`, and `net.ListenMulticastUDP`;
+`net.ListenConfig.Listen` and `ListenPacket` on lexically identified receivers;
+and direct `syscall.Listen`. The tmux catalog recognizes canonical `test/tmuxtest`
 namespace/lifecycle helpers, imported `internal/runtime/tmux` production
 constructors, and literal `os/exec` tmux commands and probes. Its untagged
 source census is 6 calls in 2 files, all owned by exact Medium `TestMain`
 rows; build-tagged calls remain E1 Large inventory rather than being relabeled
 Medium. `NewSocketParentDir`, `HoldAliveSentinel`, and the PID-directory
 helpers remain part of the separate shared-host resource tail. Direct
-`syscall.Socket`/`Bind` setup calls, typed and
-packet-specific `net` constructors, helper-backed listeners whose constructors
-live outside test source, Dolt, and other shared-host resources remain
-explicit follow-up catalogs. A Medium resource may describe a helper-backed
-runtime cost, but only syntax-owned calls in that exact runnable declaration
+`syscall.Socket`/`Bind` setup calls, `net.FileListener`/`FilePacketConn`
+descriptor duplication, helper-backed listeners whose constructors live
+outside test source, Dolt, and other shared-host resources remain explicit
+follow-up catalogs. A Medium resource may describe a helper-backed runtime
+cost, but only syntax-owned calls in that exact runnable declaration
 leave Small-debt accounting. The `ListenConfig` matcher uses lexical Go types
 to follow same-file values, pointers, parameters, aliases, and typed factory
 results rooted in the imported `net.ListenConfig` type; it does not load
@@ -359,8 +361,10 @@ shared-host catalogs. E1
 separately owns Large journey and provider entries.
 
 The scanner recognizes direct calls to `os/exec.Command{,Context}` and
-`time.Sleep`; package-level `net.Listen` and `net.ListenUnixgram`;
-`net.ListenConfig.Listen` on identified receivers; direct `syscall.Listen`;
+`time.Sleep`; package-level `net.Listen`, `ListenTCP`, `ListenUnix`,
+`ListenPacket`, `ListenUDP`, `ListenIP`, `ListenUnixgram`, and
+`ListenMulticastUDP`; `net.ListenConfig.Listen` and `ListenPacket` on identified
+receivers; direct `syscall.Listen`;
 `net/http/httptest.NewServer`,
 `NewTLSServer`, and `NewUnstartedServer`; `os.Setenv`, `os.Unsetenv`,
 `os.Clearenv`, and `os.Chdir`; and
@@ -420,6 +424,8 @@ all-source audit while staying outside untagged and Small debt.
 | Audit baseline | all tracked test source | subprocess: 529 calls / 162 files (historical regex census: 495 / 135) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
 | Medium owner | `cmd/gc` package `main` | TestMain: environment, tmux | ga-80po0c.2.1 | cmd/gc TestMain is the checked package-level Medium owner for process environment and tmux namespace setup; only declared environment and tmux calls lexically inside TestMain leave Small debt | P0.4b/P0.4c-tmux | 2026-10-01 |
 | Medium owner | `internal/api` package `api` | TestEveryEmittedErrorCodeIsRegistered: subprocess | ga-80po0c.2.1 | internal/api tracked-source error URN guard is a checked Medium owner; only the git ls-files call lexically inside TestEveryEmittedErrorCodeIsRegistered leaves Small debt | P0.4b | 2026-10-01 |
+| Medium owner | `internal/runtime/herdr` package `herdr` | TestServerAliveDetectsLiveServer: net_listen | ga-80po0c.2.2.2 | herdr live-server liveness regression is a checked Medium stream-listener owner; the Unix stream listener is confined to TestServerAliveDetectsLiveServer and closed by test cleanup | P0.4c-listener | 2026-10-01 |
+| Medium owner | `internal/runtime/herdr` package `herdr` | TestServerAliveRejectsStaleSocket: net_listen | ga-80po0c.2.2.2 | herdr stale-socket liveness regression is a checked Medium stream-listener owner; the Unix stream listener is confined to TestServerAliveRejectsStaleSocket and closed before liveness detection | P0.4c-listener | 2026-10-01 |
 | Medium owner | `internal/runtime/tmux` package `tmux` | TestMain: environment, tmux | ga-80po0c.2.2.1 | runtime tmux TestMain is the checked Medium owner for isolated tmux process and socket cleanup; only declared environment and tmux calls lexically inside TestMain leave Small debt | P0.4c-tmux | 2026-10-01 |
 | Medium owner | `scripts` package `scripts_test` | TestDockerSessionProtocol: subprocess | ga-80po0c.23.1 | Docker session adapter protocol proof is a checked Medium owner; the one adapter subprocess is confined to TestDockerSessionProtocol and Docker itself is a strict PATH-injected fake | W6 | 2026-10-01 |
 | Medium owner | `scripts` package `scripts_test` | TestProviderOverridesAndSuiteContractsCrossMakeIsolation: subprocess | ga-80po0c.2.1 | Make/provider and suite-contract proof is a checked Medium owner; the six isolated Make invocations are confined to TestProviderOverridesAndSuiteContractsCrossMakeIsolation | P0.1 | 2026-10-01 |
@@ -428,9 +434,9 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 57 calls / 24 files (historical regex census: 75 / 25) | ga-80po0c.2.1 | untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; each non-Medium marked caller retains an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | fixed_sleep: 288 calls / 111 files (historical regex census: 287 / 113) | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | http_test_server: 317 calls / 66 files (historical regex census: 300 / 66) | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
-| Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
-| Small debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
-| Small debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
+| Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2.2 | untagged Small stream-listener call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move stream-listener tests to exact Medium ownership or replace the listener | P0.4c-listener | 2026-10-01 |
+| Small debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2.2 | untagged Small net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener | P0.4c-listener | 2026-10-01 |
+| Small debt ratchet | all untagged test source | net_listen_packet: 3 calls / 2 files | ga-80po0c.2.2.2 | untagged Small packet-listener call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move packet-listener tests to exact Medium ownership or replace the listener | P0.4c-listener | 2026-10-01 |
 | Small debt ratchet | all untagged test source | subprocess: 391 calls / 110 files (historical regex census: 394 / 105) | ga-80po0c.2.1 | untagged Small subprocess call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners remove or replace each process call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged Small syscall.Listen call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move syscall-backed listener tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
 | Small debt ratchet | all untagged test source | tmux: 0 calls / 0 files | ga-80po0c.2.2.1 | untagged Small tmux dependency call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace tmux with a fake executor or declare exact isolated ownership | P0.4c-tmux | 2026-10-01 |
@@ -439,9 +445,9 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 57 calls / 24 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | fixed_sleep: 288 calls / 111 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | http_test_server: 317 calls / 66 files (historical regex census: 255 / 56) | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
-| Source debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2 | untagged net.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
-| Source debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2 | untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its configured listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
-| Source debt ratchet | all untagged test source | net_listen_unixgram: 3 calls / 2 files | ga-80po0c.2.2 | untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline; each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
+| Source debt ratchet | all untagged test source | net_listen: 94 calls / 35 files (historical regex census: 92 / 34) | ga-80po0c.2.2.2 | untagged stream-listener call/file totals cannot grow; reductions must lower this baseline; each owning test closes its stream listener and removes duplicate listener-backed coverage | P0.4c-listener | 2026-10-01 |
+| Source debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2.2 | untagged net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline; each owning test closes its configured listener and removes duplicate listener-backed coverage | P0.4c-listener | 2026-10-01 |
+| Source debt ratchet | all untagged test source | net_listen_packet: 3 calls / 2 files | ga-80po0c.2.2.2 | untagged packet-listener call/file totals cannot grow; reductions must lower this baseline; each owning test closes its packet listener and removes duplicate listener-backed coverage | P0.4c-listener | 2026-10-01 |
 | Source debt ratchet | all untagged test source | subprocess: 394 calls / 112 files (historical regex census: 380 / 98) | ga-80po0c.2 | untagged subprocess call/file totals cannot grow; reductions must lower this baseline; each process-owning test removes or replaces its source call site | D1/D2/D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | syscall_listen: 1 calls / 1 files | ga-80po0c.2.2 | untagged syscall.Listen call/file totals cannot grow; reductions must lower this baseline; each owning test closes its listening file descriptor and removes duplicate listener-backed coverage | P0.4c | 2026-10-01 |
 | Source debt ratchet | all untagged test source | tmux: 6 calls / 2 files | ga-80po0c.2.2.1 | untagged tmux dependency call/file totals cannot grow; reductions must lower this baseline; each owning test confines tmux processes and sockets to its isolated namespace and cleanup | P0.4c-tmux | 2026-10-01 |

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -42,11 +42,14 @@ const (
 	ResourceSlowProcessGate Resource = "slow_process_gate"
 	// ResourceHTTPTestServer counts loopback servers opened by net/http/httptest.
 	ResourceHTTPTestServer Resource = "http_test_server"
-	// ResourceNetListen counts direct listeners opened by net.Listen.
+	// ResourceNetListen counts direct stream listeners opened by package-level
+	// net constructors.
 	ResourceNetListen Resource = "net_listen"
-	// ResourceNetListenUnixgram counts direct Unix datagram listeners opened by net.ListenUnixgram.
-	ResourceNetListenUnixgram Resource = "net_listen_unixgram"
-	// ResourceNetListenConfig counts direct listeners opened through net.ListenConfig.Listen.
+	// ResourceNetListenPacket counts direct packet listeners opened by
+	// package-level net constructors.
+	ResourceNetListenPacket Resource = "net_listen_packet"
+	// ResourceNetListenConfig counts direct listeners opened through
+	// net.ListenConfig methods.
 	ResourceNetListenConfig Resource = "net_listen_config"
 	// ResourceSyscallListen counts direct calls that put sockets into listening state through syscall.Listen.
 	ResourceSyscallListen Resource = "syscall_listen"
@@ -55,17 +58,17 @@ const (
 )
 
 var knownResources = map[Resource]struct{}{
-	ResourceSubprocess:        {},
-	ResourceFixedSleep:        {},
-	ResourceEnvironment:       {},
-	ResourceCWD:               {},
-	ResourceSlowProcessGate:   {},
-	ResourceHTTPTestServer:    {},
-	ResourceNetListen:         {},
-	ResourceNetListenConfig:   {},
-	ResourceNetListenUnixgram: {},
-	ResourceSyscallListen:     {},
-	ResourceTmux:              {},
+	ResourceSubprocess:      {},
+	ResourceFixedSleep:      {},
+	ResourceEnvironment:     {},
+	ResourceCWD:             {},
+	ResourceSlowProcessGate: {},
+	ResourceHTTPTestServer:  {},
+	ResourceNetListen:       {},
+	ResourceNetListenConfig: {},
+	ResourceNetListenPacket: {},
+	ResourceSyscallListen:   {},
+	ResourceTmux:            {},
 }
 
 // Scope selects the source population counted by a ledger row.
@@ -222,14 +225,14 @@ var bootstrapPolicy = Ledger{
 		{
 			Scope:           ScopeUntagged,
 			Resource:        ResourceNetListen,
-			BaselineCalls:   92,
-			BaselineFiles:   34,
+			BaselineCalls:   94,
+			BaselineFiles:   35,
 			ReportedCalls:   92,
 			ReportedFiles:   34,
-			OwnerBead:       "ga-80po0c.2.2",
-			Invariant:       "untagged net.Listen call/file totals cannot grow; reductions must lower this baseline",
-			ResourceOwner:   "each owning test closes its listener and removes duplicate listener-backed coverage",
-			MigrationTarget: "P0.4c",
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "untagged stream-listener call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test closes its stream listener and removes duplicate listener-backed coverage",
+			MigrationTarget: "P0.4c-listener",
 			Expires:         "2026-10-01",
 		},
 		{
@@ -239,23 +242,23 @@ var bootstrapPolicy = Ledger{
 			BaselineFiles:   1,
 			ReportedCalls:   1,
 			ReportedFiles:   1,
-			OwnerBead:       "ga-80po0c.2.2",
-			Invariant:       "untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline",
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "untagged net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "each owning test closes its configured listener and removes duplicate listener-backed coverage",
-			MigrationTarget: "P0.4c",
+			MigrationTarget: "P0.4c-listener",
 			Expires:         "2026-10-01",
 		},
 		{
 			Scope:           ScopeUntagged,
-			Resource:        ResourceNetListenUnixgram,
+			Resource:        ResourceNetListenPacket,
 			BaselineCalls:   3,
 			BaselineFiles:   2,
 			ReportedCalls:   3,
 			ReportedFiles:   2,
-			OwnerBead:       "ga-80po0c.2.2",
-			Invariant:       "untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline",
-			ResourceOwner:   "each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage",
-			MigrationTarget: "P0.4c",
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "untagged packet-listener call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test closes its packet listener and removes duplicate listener-backed coverage",
+			MigrationTarget: "P0.4c-listener",
 			Expires:         "2026-10-01",
 		},
 		{
@@ -306,6 +309,28 @@ var bootstrapPolicy = Ledger{
 			Invariant:       "cmd/gc TestMain is the checked package-level Medium owner for process environment and tmux namespace setup",
 			ResourceOwner:   "only declared environment and tmux calls lexically inside TestMain leave Small debt",
 			MigrationTarget: "P0.4b/P0.4c-tmux",
+			Expires:         "2026-10-01",
+		},
+		{
+			PackageDir:      "internal/runtime/herdr",
+			PackageName:     "herdr",
+			Owner:           "TestServerAliveRejectsStaleSocket",
+			Resources:       []Resource{ResourceNetListen},
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "herdr stale-socket liveness regression is a checked Medium stream-listener owner",
+			ResourceOwner:   "the Unix stream listener is confined to TestServerAliveRejectsStaleSocket and closed before liveness detection",
+			MigrationTarget: "P0.4c-listener",
+			Expires:         "2026-10-01",
+		},
+		{
+			PackageDir:      "internal/runtime/herdr",
+			PackageName:     "herdr",
+			Owner:           "TestServerAliveDetectsLiveServer",
+			Resources:       []Resource{ResourceNetListen},
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "herdr live-server liveness regression is a checked Medium stream-listener owner",
+			ResourceOwner:   "the Unix stream listener is confined to TestServerAliveDetectsLiveServer and closed by test cleanup",
+			MigrationTarget: "P0.4c-listener",
 			Expires:         "2026-10-01",
 		},
 		{
@@ -458,10 +483,10 @@ var bootstrapPolicy = Ledger{
 			BaselineFiles:   34,
 			ReportedCalls:   92,
 			ReportedFiles:   34,
-			OwnerBead:       "ga-80po0c.2.2",
-			Invariant:       "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline",
-			ResourceOwner:   "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener",
-			MigrationTarget: "P0.4c",
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "untagged Small stream-listener call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners move stream-listener tests to exact Medium ownership or replace the listener",
+			MigrationTarget: "P0.4c-listener",
 			Expires:         "2026-10-01",
 		},
 		{
@@ -471,23 +496,23 @@ var bootstrapPolicy = Ledger{
 			BaselineFiles:   1,
 			ReportedCalls:   1,
 			ReportedFiles:   1,
-			OwnerBead:       "ga-80po0c.2.2",
-			Invariant:       "untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline",
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "untagged Small net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener",
-			MigrationTarget: "P0.4c",
+			MigrationTarget: "P0.4c-listener",
 			Expires:         "2026-10-01",
 		},
 		{
 			Scope:           ScopeUntagged,
-			Resource:        ResourceNetListenUnixgram,
+			Resource:        ResourceNetListenPacket,
 			BaselineCalls:   3,
 			BaselineFiles:   2,
 			ReportedCalls:   3,
 			ReportedFiles:   2,
-			OwnerBead:       "ga-80po0c.2.2",
-			Invariant:       "untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline",
-			ResourceOwner:   "non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener",
-			MigrationTarget: "P0.4c",
+			OwnerBead:       "ga-80po0c.2.2.2",
+			Invariant:       "untagged Small packet-listener call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners move packet-listener tests to exact Medium ownership or replace the listener",
+			MigrationTarget: "P0.4c-listener",
 			Expires:         "2026-10-01",
 		},
 		{
@@ -1004,7 +1029,7 @@ func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner str
 		switch function := unparen(call.Fun).(type) {
 		case *ast.SelectorExpr:
 			switch function.Sel.Name {
-			case "Command", "CommandContext", "ConfigureProcessEnv", "KillAllTestSessions", "LookPath", "NewGuard", "NewGuardWithSocket", "NewProvider", "NewProviderWithConfig", "NewSeamBackedWithConfig", "NewServer", "NewTLSServer", "NewTmux", "NewTmuxWithConfig", "NewUnstartedServer", "RequireTmux", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "ListenUnixgram":
+			case "Command", "CommandContext", "ConfigureProcessEnv", "KillAllTestSessions", "LookPath", "NewGuard", "NewGuardWithSocket", "NewProvider", "NewProviderWithConfig", "NewSeamBackedWithConfig", "NewServer", "NewTLSServer", "NewTmux", "NewTmuxWithConfig", "NewUnstartedServer", "RequireTmux", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "ListenIP", "ListenMulticastUDP", "ListenPacket", "ListenTCP", "ListenUDP", "ListenUnix", "ListenUnixgram":
 				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		case *ast.Ident:
@@ -1163,7 +1188,7 @@ func netListenReceiverExpressions(file *ast.File) []ast.Expr {
 			return true
 		}
 		selector, ok := unparen(call.Fun).(*ast.SelectorExpr)
-		if ok && selector.Sel.Name == "Listen" {
+		if ok && (selector.Sel.Name == "Listen" || selector.Sel.Name == "ListenPacket") {
 			receivers = append(receivers, unparen(selector.X))
 		}
 		return true
@@ -1312,7 +1337,7 @@ func isNetListenConfigValue(expression ast.Expr, bindings bindingInfo) (bool, er
 
 func isNetListenConfigCall(call *ast.CallExpr, bindings bindingInfo) (bool, error) {
 	selector, ok := unparen(call.Fun).(*ast.SelectorExpr)
-	if !ok || selector.Sel.Name != "Listen" {
+	if !ok || (selector.Sel.Name != "Listen" && selector.Sel.Name != "ListenPacket") {
 		return false, nil
 	}
 	receiver := unparen(selector.X)

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -287,13 +287,14 @@ func TestNetListen(t *testing.T) {
 	t.Run("nested", func(t *testing.T) {
 		_, _ = (((sockets)).Listen)("unix", "socket")
 	})
+	_, _ = sockets.ListenTCP("tcp", nil)
+	_, _ = sockets.ListenUnix("unix", nil)
 
 	local := localNet{}
 	_, _ = local.Listen("tcp", "local shadow")
 	_, _ = foreign.Listen("tcp", "foreign package")
 	lc := sockets.ListenConfig{}
 	_, _ = lc.Listen(t.Context(), "tcp", "listen config method")
-	_, _ = sockets.ListenTCP("tcp", nil)
 	_ = "sockets.Listen(\"tcp\", \"string literal\")"
 	// sockets.Listen("tcp", "comment")
 }
@@ -329,14 +330,14 @@ func TestSiblingShadow() {
 	if err != nil {
 		t.Fatalf("ScanFS: %v", err)
 	}
-	assertCount(t, got, ScopeAll, ResourceNetListen, 4, 2)
-	assertCount(t, got, ScopeUntagged, ResourceNetListen, 3, 1)
+	assertCount(t, got, ScopeAll, ResourceNetListen, 6, 2)
+	assertCount(t, got, ScopeUntagged, ResourceNetListen, 5, 1)
 	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListen, "TestNetListen", true, false)
 	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListen, "helper", false, false)
 	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListen, "TestTaggedNetListen", true, true)
 }
 
-func TestScanCountsNetListenUnixgramByImportIdentityAndRunnableOwnership(t *testing.T) {
+func TestScanCountsNetListenPacketByImportIdentityAndRunnableOwnership(t *testing.T) {
 	t.Parallel()
 
 	files := fstest.MapFS{
@@ -348,23 +349,29 @@ import (
 )
 
 type localNet struct{}
+func (localNet) ListenPacket(string, string) (any, error) { return nil, nil }
+func (localNet) ListenUDP(string, *sockets.UDPAddr) (any, error) { return nil, nil }
 func (localNet) ListenUnixgram(string, *sockets.UnixAddr) (any, error) { return nil, nil }
 
-func TestNetListenUnixgram(t *testing.T) {
-	_, _ = ((sockets.ListenUnixgram))("unixgram", nil)
+func TestNetListenPacket(t *testing.T) {
+	_, _ = ((sockets.ListenPacket))("udp", "127.0.0.1:0")
+	_, _ = sockets.ListenUDP("udp", nil)
+	_, _ = sockets.ListenIP("ip", nil)
 	t.Run("nested", func(t *testing.T) {
 		_, _ = (((sockets)).ListenUnixgram)("unixgram", nil)
 	})
+	_, _ = sockets.ListenMulticastUDP("udp", nil, nil)
 
 	local := localNet{}
+	_, _ = local.ListenPacket("udp", "local shadow")
+	_, _ = local.ListenUDP("udp", nil)
 	_, _ = local.ListenUnixgram("unixgram", nil)
-	_, _ = foreign.ListenUnixgram("unixgram", nil)
+	_, _ = foreign.ListenPacket("udp", "foreign package")
 	lc := sockets.ListenConfig{}
-	_, _ = lc.Listen(t.Context(), "unixgram", "listen config method")
+	_, _ = lc.ListenPacket(t.Context(), "udp", "listen config method")
 	_, _ = sockets.ListenUnix("unixgram", nil)
-	_, _ = sockets.ListenUDP("udp", nil)
-	_ = "sockets.ListenUnixgram(\"unixgram\", nil)"
-	// sockets.ListenUnixgram("unixgram", nil)
+	_ = "sockets.ListenPacket(\"udp\", \"string literal\")"
+	// sockets.ListenUDP("udp", nil)
 }
 
 func helper() {
@@ -378,8 +385,8 @@ import (
 	sockets "net"
 	"testing"
 )
-func TestTaggedNetListenUnixgram(t *testing.T) {
-	_, _ = sockets.ListenUnixgram("unixgram", nil)
+func TestTaggedNetListenPacket(t *testing.T) {
+	_, _ = sockets.ListenUDP("udp", nil)
 }
 `)},
 		"shadow/shadow.go": &fstest.MapFile{Data: []byte(`package shadow
@@ -398,11 +405,11 @@ func TestSiblingShadow() {
 	if err != nil {
 		t.Fatalf("ScanFS: %v", err)
 	}
-	assertCount(t, got, ScopeAll, ResourceNetListenUnixgram, 4, 2)
-	assertCount(t, got, ScopeUntagged, ResourceNetListenUnixgram, 3, 1)
-	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenUnixgram, "TestNetListenUnixgram", true, false)
-	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenUnixgram, "helper", false, false)
-	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListenUnixgram, "TestTaggedNetListenUnixgram", true, true)
+	assertCount(t, got, ScopeAll, ResourceNetListenPacket, 7, 2)
+	assertCount(t, got, ScopeUntagged, ResourceNetListenPacket, 6, 1)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenPacket, "TestNetListenPacket", true, false)
+	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenPacket, "helper", false, false)
+	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListenPacket, "TestTaggedNetListenPacket", true, true)
 }
 
 func TestScanCountsSyscallListenByImportIdentityAndRunnableOwnership(t *testing.T) {
@@ -485,6 +492,7 @@ import (
 
 type localListenConfig struct{}
 func (localListenConfig) Listen(any, string, string) (any, error) { return nil, nil }
+func (localListenConfig) ListenPacket(any, string, string) (any, error) { return nil, nil }
 func newListenConfig() sockets.ListenConfig { return sockets.ListenConfig{} }
 func newListenConfigPointer() *sockets.ListenConfig { return &sockets.ListenConfig{} }
 type listenConfigAlias = sockets.ListenConfig
@@ -513,9 +521,15 @@ func TestNetListenConfig(t *testing.T) {
 
 	local := localListenConfig{}
 	_, _ = local.Listen(nil, "tcp", "local shadow")
+	_, _ = local.ListenPacket(nil, "udp", "local shadow")
 	foreignConfig := foreign.ListenConfig{}
 	_, _ = foreignConfig.Listen(nil, "tcp", "foreign package")
+	_, _ = foreignConfig.ListenPacket(nil, "udp", "foreign package")
 	_, _ = value.ListenPacket(nil, "udp", "127.0.0.1:0")
+	_, _ = newListenConfigPointer().ListenPacket(nil, "udp", "127.0.0.1:0")
+	_, _ = new(sockets.ListenConfig).ListenPacket(nil, "udp", "127.0.0.1:0")
+	_, _ = holder.Config.ListenPacket(nil, "udp", "127.0.0.1:0")
+	_, _ = configs[0].ListenPacket(nil, "udp", "127.0.0.1:0")
 	_, _ = sockets.Listen("tcp", "127.0.0.1:0")
 	_ = "value.Listen(nil, \"tcp\", \"string literal\")"
 	// value.Listen(nil, "tcp", "comment")
@@ -534,7 +548,7 @@ import (
 )
 func TestTaggedNetListenConfig(t *testing.T) {
 	config := sockets.ListenConfig{}
-	_, _ = config.Listen(nil, "tcp", "127.0.0.1:0")
+	_, _ = config.ListenPacket(nil, "udp", "127.0.0.1:0")
 }
 `)},
 		"shadow/shadow.go": &fstest.MapFile{Data: []byte(`package shadow
@@ -553,8 +567,8 @@ func TestSiblingShadow() {
 	if err != nil {
 		t.Fatalf("ScanFS: %v", err)
 	}
-	assertCount(t, got, ScopeAll, ResourceNetListenConfig, 14, 2)
-	assertCount(t, got, ScopeUntagged, ResourceNetListenConfig, 13, 1)
+	assertCount(t, got, ScopeAll, ResourceNetListenConfig, 19, 2)
+	assertCount(t, got, ScopeUntagged, ResourceNetListenConfig, 18, 1)
 	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenConfig, "TestNetListenConfig", true, false)
 	assertOccurrenceOwner(t, got, "sample/resources_test.go", ResourceNetListenConfig, "helper", false, false)
 	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListenConfig, "TestTaggedNetListenConfig", true, true)
@@ -1673,17 +1687,41 @@ func TestBootstrapPolicyOwnsHTTPTestServerDebt(t *testing.T) {
 	}
 }
 
-func TestBootstrapPolicyOwnsNetListenDebt(t *testing.T) {
+func TestBootstrapPolicyOwnsNetListenDebtAndExactMediumOwners(t *testing.T) {
 	t.Parallel()
 
-	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
-		row := findRow(t, rows, ScopeUntagged, ResourceNetListen)
-		if row.BaselineCalls != 92 || row.BaselineFiles != 34 {
-			t.Fatalf("net.Listen baseline = %d/%d, want 92/34", row.BaselineCalls, row.BaselineFiles)
+	debt := findRow(t, bootstrapPolicy.Debt, ScopeUntagged, ResourceNetListen)
+	if debt.BaselineCalls != 94 || debt.BaselineFiles != 35 || debt.ReportedCalls != 92 || debt.ReportedFiles != 34 {
+		t.Fatalf("stream-listener source baseline/reported = %d/%d, %d/%d; want 94/35, 92/34", debt.BaselineCalls, debt.BaselineFiles, debt.ReportedCalls, debt.ReportedFiles)
+	}
+	smallDebt := findRow(t, bootstrapPolicy.SmallDebt, ScopeUntagged, ResourceNetListen)
+	if smallDebt.BaselineCalls != 92 || smallDebt.BaselineFiles != 34 {
+		t.Fatalf("stream-listener Small baseline = %d/%d, want 92/34", smallDebt.BaselineCalls, smallDebt.BaselineFiles)
+	}
+	for _, row := range []*Baseline{debt, smallDebt} {
+		if row.OwnerBead != "ga-80po0c.2.2.2" || row.MigrationTarget != "P0.4c-listener" {
+			t.Fatalf("stream-listener owner = %q/%q, want ga-80po0c.2.2.2/P0.4c-listener", row.OwnerBead, row.MigrationTarget)
 		}
-		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
-			t.Fatalf("net.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+	}
+
+	wantOwners := map[string]bool{
+		"TestServerAliveDetectsLiveServer":  true,
+		"TestServerAliveRejectsStaleSocket": true,
+	}
+	for _, row := range bootstrapPolicy.Medium {
+		if row.PackageDir != "internal/runtime/herdr" || row.PackageName != "herdr" || !wantOwners[row.Owner] {
+			continue
 		}
+		if len(row.Resources) != 1 || row.Resources[0] != ResourceNetListen {
+			t.Fatalf("herdr Medium owner %s resources = %v, want net_listen", row.Owner, row.Resources)
+		}
+		if row.OwnerBead != "ga-80po0c.2.2.2" || row.MigrationTarget != "P0.4c-listener" {
+			t.Fatalf("herdr Medium owner %s policy = %q/%q, want ga-80po0c.2.2.2/P0.4c-listener", row.Owner, row.OwnerBead, row.MigrationTarget)
+		}
+		delete(wantOwners, row.Owner)
+	}
+	if len(wantOwners) != 0 {
+		t.Fatalf("missing exact herdr stream-listener Medium owners: %v", wantOwners)
 	}
 }
 
@@ -1693,24 +1731,24 @@ func TestBootstrapPolicyOwnsNetListenConfigDebt(t *testing.T) {
 	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
 		row := findRow(t, rows, ScopeUntagged, ResourceNetListenConfig)
 		if row.BaselineCalls != 1 || row.BaselineFiles != 1 {
-			t.Fatalf("net.ListenConfig.Listen baseline = %d/%d, want 1/1", row.BaselineCalls, row.BaselineFiles)
+			t.Fatalf("net.ListenConfig listener baseline = %d/%d, want 1/1", row.BaselineCalls, row.BaselineFiles)
 		}
-		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
-			t.Fatalf("net.ListenConfig.Listen owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		if row.OwnerBead != "ga-80po0c.2.2.2" || row.MigrationTarget != "P0.4c-listener" {
+			t.Fatalf("net.ListenConfig listener owner = %q/%q, want ga-80po0c.2.2.2/P0.4c-listener", row.OwnerBead, row.MigrationTarget)
 		}
 	}
 }
 
-func TestBootstrapPolicyOwnsNetListenUnixgramDebt(t *testing.T) {
+func TestBootstrapPolicyOwnsNetListenPacketDebt(t *testing.T) {
 	t.Parallel()
 
 	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
-		row := findRow(t, rows, ScopeUntagged, ResourceNetListenUnixgram)
+		row := findRow(t, rows, ScopeUntagged, ResourceNetListenPacket)
 		if row.BaselineCalls != 3 || row.BaselineFiles != 2 {
-			t.Fatalf("net.ListenUnixgram baseline = %d/%d, want 3/2", row.BaselineCalls, row.BaselineFiles)
+			t.Fatalf("packet-listener baseline = %d/%d, want 3/2", row.BaselineCalls, row.BaselineFiles)
 		}
-		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
-			t.Fatalf("net.ListenUnixgram owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		if row.OwnerBead != "ga-80po0c.2.2.2" || row.MigrationTarget != "P0.4c-listener" {
+			t.Fatalf("packet-listener owner = %q/%q, want ga-80po0c.2.2.2/P0.4c-listener", row.OwnerBead, row.MigrationTarget)
 		}
 	}
 }

--- a/internal/testpolicy/resourcecensus/hermetic.go
+++ b/internal/testpolicy/resourcecensus/hermetic.go
@@ -595,7 +595,7 @@ func matchedResourcesForCall(call *ast.CallExpr, bindings bindingInfo, testingOb
 		}
 		return nil
 	}
-	if err := appendImported(ResourceNetListen, "net", "Listen"); err != nil {
+	if err := appendImported(ResourceNetListen, "net", "Listen", "ListenTCP", "ListenUnix"); err != nil {
 		return nil, err
 	}
 	matched, err := isNetListenConfigCall(call, bindings)
@@ -605,7 +605,7 @@ func matchedResourcesForCall(call *ast.CallExpr, bindings bindingInfo, testingOb
 	if matched {
 		resources = append(resources, ResourceNetListenConfig)
 	}
-	if err := appendImported(ResourceNetListenUnixgram, "net", "ListenUnixgram"); err != nil {
+	if err := appendImported(ResourceNetListenPacket, "net", "ListenPacket", "ListenUDP", "ListenIP", "ListenUnixgram", "ListenMulticastUDP"); err != nil {
 		return nil, err
 	}
 	if err := appendImported(ResourceSyscallListen, "syscall", "Listen"); err != nil {

--- a/internal/testpolicy/resourcecensus/hermetic_test.go
+++ b/internal/testpolicy/resourcecensus/hermetic_test.go
@@ -138,8 +138,10 @@ func TestValidateReviewedHermeticBodiesRejectsDirectKnownResources(t *testing.T)
 		},
 		{name: "HTTP test server", imports: `"net/http/httptest"`, body: `_ = httptest.NewServer(nil)`, resource: ResourceHTTPTestServer},
 		{name: "net listen", imports: `"net"`, body: `_, _ = net.Listen("tcp", "127.0.0.1:0")`, resource: ResourceNetListen},
+		{name: "net typed stream listen", imports: `"net"`, body: `_, _ = net.ListenTCP("tcp", nil)`, resource: ResourceNetListen},
 		{name: "net listen config", imports: `"net"`, body: `_, _ = (net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")`, resource: ResourceNetListenConfig},
-		{name: "net listen unixgram", imports: `"net"`, body: `_, _ = net.ListenUnixgram("unixgram", nil)`, resource: ResourceNetListenUnixgram},
+		{name: "net listen config packet", imports: `"net"`, body: `_, _ = (net.ListenConfig{}).ListenPacket(t.Context(), "udp", "127.0.0.1:0")`, resource: ResourceNetListenConfig},
+		{name: "net packet listen", imports: `"net"`, body: `_, _ = net.ListenUDP("udp", nil)`, resource: ResourceNetListenPacket},
 		{name: "syscall listen", imports: `"syscall"`, body: `_ = syscall.Listen(0, 0)`, resource: ResourceSyscallListen},
 		{name: "tmux", imports: `tmuxtest "github.com/gastownhall/gascity/test/tmuxtest"`, body: `_ = tmuxtest.NewGuard(t)`, resource: ResourceTmux},
 	}

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -116,14 +116,14 @@ expires = "2026-10-01"
 [[debt]]
 scope = "untagged"
 resource = "net_listen"
-baseline_calls = 92
-baseline_files = 34
+baseline_calls = 94
+baseline_files = 35
 reported_calls = 92
 reported_files = 34
-owner_bead = "ga-80po0c.2.2"
-invariant = "untagged net.Listen call/file totals cannot grow; reductions must lower this baseline"
-resource_owner = "each owning test closes its listener and removes duplicate listener-backed coverage"
-migration_target = "P0.4c"
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "untagged stream-listener call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test closes its stream listener and removes duplicate listener-backed coverage"
+migration_target = "P0.4c-listener"
 expires = "2026-10-01"
 
 [[debt]]
@@ -133,23 +133,23 @@ baseline_calls = 1
 baseline_files = 1
 reported_calls = 1
 reported_files = 1
-owner_bead = "ga-80po0c.2.2"
-invariant = "untagged net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline"
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "untagged net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "each owning test closes its configured listener and removes duplicate listener-backed coverage"
-migration_target = "P0.4c"
+migration_target = "P0.4c-listener"
 expires = "2026-10-01"
 
 [[debt]]
 scope = "untagged"
-resource = "net_listen_unixgram"
+resource = "net_listen_packet"
 baseline_calls = 3
 baseline_files = 2
 reported_calls = 3
 reported_files = 2
-owner_bead = "ga-80po0c.2.2"
-invariant = "untagged net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline"
-resource_owner = "each owning test closes its Unix datagram listener and removes duplicate listener-backed coverage"
-migration_target = "P0.4c"
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "untagged packet-listener call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test closes its packet listener and removes duplicate listener-backed coverage"
+migration_target = "P0.4c-listener"
 expires = "2026-10-01"
 
 [[debt]]
@@ -202,6 +202,28 @@ owner_bead = "ga-80po0c.2.1"
 invariant = "cmd/gc TestMain is the checked package-level Medium owner for process environment and tmux namespace setup"
 resource_owner = "only declared environment and tmux calls lexically inside TestMain leave Small debt"
 migration_target = "P0.4b/P0.4c-tmux"
+expires = "2026-10-01"
+
+[[medium]]
+package_dir = "internal/runtime/herdr"
+package_name = "herdr"
+owner = "TestServerAliveRejectsStaleSocket"
+resources = ["net_listen"]
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "herdr stale-socket liveness regression is a checked Medium stream-listener owner"
+resource_owner = "the Unix stream listener is confined to TestServerAliveRejectsStaleSocket and closed before liveness detection"
+migration_target = "P0.4c-listener"
+expires = "2026-10-01"
+
+[[medium]]
+package_dir = "internal/runtime/herdr"
+package_name = "herdr"
+owner = "TestServerAliveDetectsLiveServer"
+resources = ["net_listen"]
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "herdr live-server liveness regression is a checked Medium stream-listener owner"
+resource_owner = "the Unix stream listener is confined to TestServerAliveDetectsLiveServer and closed by test cleanup"
+migration_target = "P0.4c-listener"
 expires = "2026-10-01"
 
 [[medium]]
@@ -356,10 +378,10 @@ baseline_calls = 92
 baseline_files = 34
 reported_calls = 92
 reported_files = 34
-owner_bead = "ga-80po0c.2.2"
-invariant = "untagged Small net.Listen call/file totals cannot grow; reductions must lower this baseline"
-resource_owner = "non-Medium lexical owners move listener-backed tests to exact Medium ownership or replace the listener"
-migration_target = "P0.4c"
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "untagged Small stream-listener call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners move stream-listener tests to exact Medium ownership or replace the listener"
+migration_target = "P0.4c-listener"
 expires = "2026-10-01"
 
 [[small_debt]]
@@ -369,23 +391,23 @@ baseline_calls = 1
 baseline_files = 1
 reported_calls = 1
 reported_files = 1
-owner_bead = "ga-80po0c.2.2"
-invariant = "untagged Small net.ListenConfig.Listen call/file totals cannot grow; reductions must lower this baseline"
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "untagged Small net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener"
-migration_target = "P0.4c"
+migration_target = "P0.4c-listener"
 expires = "2026-10-01"
 
 [[small_debt]]
 scope = "untagged"
-resource = "net_listen_unixgram"
+resource = "net_listen_packet"
 baseline_calls = 3
 baseline_files = 2
 reported_calls = 3
 reported_files = 2
-owner_bead = "ga-80po0c.2.2"
-invariant = "untagged Small net.ListenUnixgram call/file totals cannot grow; reductions must lower this baseline"
-resource_owner = "non-Medium lexical owners move Unix datagram listener-backed tests to exact Medium ownership or replace the listener"
-migration_target = "P0.4c"
+owner_bead = "ga-80po0c.2.2.2"
+invariant = "untagged Small packet-listener call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners move packet-listener tests to exact Medium ownership or replace the listener"
+migration_target = "P0.4c-listener"
 expires = "2026-10-01"
 
 [[small_debt]]


### PR DESCRIPTION
## Summary

- Classify direct typed standard-library listener constructors by lifecycle: stream, packet, and `net.ListenConfig`.
- Recognize `net.Listen`, `ListenTCP`, and `ListenUnix` as stream listeners.
- Recognize `net.ListenPacket`, `ListenUDP`, `ListenIP`, `ListenUnixgram`, and `ListenMulticastUDP` as packet listeners.
- Recognize both `ListenConfig.Listen` and `ListenConfig.ListenPacket` while preserving exact import and receiver identity.
- Add exact Medium ownership for the two existing herdr Unix-listener tests.

## Why

The resource census previously covered only a subset of the standard-library listener boundary. A Small test could bind through a typed constructor without increasing checked debt, and the Unixgram-only category encoded API spelling instead of the shared-host lifecycle.

This behavior-neutral policy slice closes those gaps without changing any test body, socket lifecycle, production code, or existing Small debt ceiling.

## Invariant map

| Boundary | Constructors/methods | Raw census | Effective Small debt |
| --- | --- | ---: | ---: |
| Stream | `net.Listen`, `ListenTCP`, `ListenUnix` | 94 calls / 35 files | 92 / 34 |
| Packet | `net.ListenPacket`, `ListenUDP`, `ListenIP`, `ListenUnixgram`, `ListenMulticastUDP` | 3 / 2 | 3 / 2 |
| ListenConfig | `ListenConfig.Listen`, `ListenConfig.ListenPacket` | 1 / 1 | 1 / 1 |

The raw stream census grows only because two existing herdr tests are now visible. Exact Medium ownership subtracts those calls, so checked Small debt remains 92 / 34.

## TDD evidence

- RED: typed stream fixtures reported 4 / 2 instead of 6 / 2.
- RED: packet fixtures reported 0 / 0 instead of 7 / 2.
- RED: ListenConfig fixtures reported 13 / 1 instead of 19 / 2.
- RED: reviewed-hermetic validation incorrectly accepted all three missing families.
- GREEN: focused matcher, ownership, hermetic, ledger, and documentation tests passed.
- Complex ListenConfig receivers are covered: pointers, factories, selectors, indexes, and composite literals.
- Local and foreign shadows, build tags, and nested runnable ownership are covered explicitly.

## Verification

- Focused resource-census tests passed with `-count=10`.
- Full `go test ./internal/testpolicy/resourcecensus` passed.
- `go test -race ./internal/testpolicy/resourcecensus` passed in 21.917s.
- `make test-fast-parallel` passed all eight jobs.
- `go vet ./...` passed.
- Pre-commit checks and the final pre-push eight-job fast suite passed.
- Paired clean-base and candidate census timings were effectively flat.
- Three independent delegated review lanes approved exact tree `d298898bd8c1ad4a61e17a08eeaa37c6a2ead32b` with no findings.

## Scope exclusions

- Helper-backed listeners remain the next independent slice.
- `FileListener` and `FilePacketConn` remain deferred to the descriptor-resource boundary.
- Large journey/provider ownership remains E1-owned.

Bead: `ga-80po0c.2.2.2`
