### PR TITLE
fix(dolt): scope wisp index migration commit

### DIFF
--- a/cmd/gc/dolt_wisp_query_index.go
+++ b/cmd/gc/dolt_wisp_query_index.go
@@ -2,14 +2,27 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"database/sql"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 )
 
-// wispQueryIndexes lists the CREATE INDEX statements applied by
-// applyWispQueryIndexes. Each entry is idempotent (IF NOT EXISTS).
+type wispQueryIndexSpec struct {
+	table      string
+	name       string
+	columns    []string
+	createStmt string
+	addStmt    string
+}
+
+// wispQueryIndexes lists the indexes applied by applyWispQueryIndexes. The
+// CREATE statements are idempotent, and each add statement names exactly one
+// table. Never replace the named adds with DOLT_ADD('.'): a managed database
+// may legitimately contain unrelated WORKING changes.
 //
 // Background: the beads library's SearchIssuesWithCountsInTx generates SQL
 // with full-table subquery aggregations for wisp_labels and wisp_dependencies
@@ -26,10 +39,27 @@ import (
 //
 // These belong upstream in the beads schema migrations; this gc-side guard
 // applies them immediately without waiting for a beads version bump.
-var wispQueryIndexStatements = []string{
-	"CREATE INDEX IF NOT EXISTS idx_wisp_labels_issue_id ON wisp_labels(issue_id)",
-	"CREATE INDEX IF NOT EXISTS idx_wisps_status_type ON wisps(status, issue_type)",
+var wispQueryIndexes = []wispQueryIndexSpec{
+	{
+		table:      "wisp_labels",
+		name:       "idx_wisp_labels_issue_id",
+		columns:    []string{"issue_id"},
+		createStmt: "CREATE INDEX IF NOT EXISTS idx_wisp_labels_issue_id ON wisp_labels(issue_id)",
+		addStmt:    "CALL DOLT_ADD('wisp_labels')",
+	},
+	{
+		table:      "wisps",
+		name:       "idx_wisps_status_type",
+		columns:    []string{"status", "issue_type"},
+		createStmt: "CREATE INDEX IF NOT EXISTS idx_wisps_status_type ON wisps(status, issue_type)",
+		addStmt:    "CALL DOLT_ADD('wisps')",
+	},
 }
+
+const (
+	wispQueryIndexBeginStatement  = "START TRANSACTION"
+	wispQueryIndexCommitStatement = "CALL DOLT_COMMIT('-m', 'gc: add wisp-query performance indexes (gcy-0m1)', '--author', 'gascity-builder <builder@gascity.local>', '--skip-empty')"
+)
 
 // applyWispQueryIndexes creates the missing wisp query performance indexes on
 // the managed Dolt server. It is idempotent and fail-open: any error is logged
@@ -57,11 +87,36 @@ func (cr *CityRuntime) applyWispQueryIndexes(ctx context.Context) {
 	}
 }
 
+type wispQueryDoltStatus struct {
+	table  string
+	staged bool
+	status string
+}
+
 // applyWispQueryIndexesToDB is the testable core of applyWispQueryIndexes.
-// It opens a short-lived MySQL connection, applies each index statement, and
-// closes. Errors from individual statements are logged but do not abort the
-// loop so a partial success still improves query performance.
+//
+// Safety contract:
+//   - pre-existing staged changes anywhere cause the migration to skip;
+//   - pre-existing WORKING changes to either target table cause it to skip;
+//   - unrelated WORKING changes are allowed and are never staged;
+//   - inspection, index creation, staging, and commit share one explicit SQL
+//     transaction, isolating this migration from concurrent client writes; and
+//   - immediately before commit, the staged set must contain only schema-only
+//     changes to target tables whose expected indexes have exact definitions.
+//
+// GET_LOCK serializes cooperating gc controllers. The SQL transaction is the
+// Dolt-supported boundary that keeps a non-cooperating client's concurrent
+// WORKING changes out of this client's DOLT_COMMIT.
 func applyWispQueryIndexesToDB(ctx context.Context, port, database string, stderr io.Writer) error {
+	return applyWispQueryIndexesToDBWithHook(ctx, port, database, stderr, nil)
+}
+
+func applyWispQueryIndexesToDBWithHook(
+	ctx context.Context,
+	port, database string,
+	stderr io.Writer,
+	beforeCommit func(),
+) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -71,32 +126,307 @@ func applyWispQueryIndexesToDB(ctx context.Context, port, database string, stder
 	}
 	defer db.Close() //nolint:errcheck
 
-	if err := db.PingContext(ctx); err != nil {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("reserve dolt connection: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck
+	if err := conn.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping dolt: %w", err)
 	}
 
-	for _, stmt := range wispQueryIndexStatements {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			// Non-fatal: log and continue. Some statements may fail if the
-			// table doesn't exist yet (fresh install before first bd init).
-			fmt.Fprintf(stderr, "wisp-query-index: %s: %v\n", stmt, err) //nolint:errcheck // best-effort stderr
+	lockDigest := sha256.Sum256([]byte(database))
+	lockName := fmt.Sprintf("gc-wisp-query-index:%x", lockDigest[:12])
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&acquired); err != nil {
+		return fmt.Errorf("acquire migration advisory lock: %w", err)
+	}
+	if !acquired.Valid || acquired.Int64 != 1 {
+		fmt.Fprintln(stderr, "wisp-query-index: migration already active; skipping") //nolint:errcheck
+		return nil
+	}
+	defer func() {
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer releaseCancel()
+		if _, releaseErr := conn.ExecContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName); releaseErr != nil {
+			fmt.Fprintf(stderr, "wisp-query-index: release advisory lock: %v\n", releaseErr) //nolint:errcheck
+		}
+	}()
+
+	if _, err := conn.ExecContext(ctx, wispQueryIndexBeginStatement); err != nil {
+		return fmt.Errorf("begin migration transaction: %w", err)
+	}
+	transactionActive := true
+	defer func() {
+		if !transactionActive {
+			return
+		}
+		rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer rollbackCancel()
+		if _, rollbackErr := conn.ExecContext(rollbackCtx, "ROLLBACK"); rollbackErr != nil {
+			fmt.Fprintf(stderr, "wisp-query-index: rollback migration transaction: %v\n", rollbackErr) //nolint:errcheck
+		}
+	}()
+
+	var targetTableCount int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT table_name)
+		FROM information_schema.tables
+		WHERE table_schema = DATABASE()
+		  AND table_name IN ('wisp_labels', 'wisps')`,
+	).Scan(&targetTableCount); err != nil {
+		return fmt.Errorf("inspect target tables: %w", err)
+	}
+	if targetTableCount != len(wispQueryIndexes) {
+		fmt.Fprintln(stderr, "wisp-query-index: target tables are not initialized; skipping") //nolint:errcheck
+		return nil
+	}
+
+	status, err := readWispQueryDoltStatus(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("inspect pre-migration status: %w", err)
+	}
+	if reason := wispQueryIndexUnsafeBaseline(status); reason != "" {
+		fmt.Fprintf(stderr, "wisp-query-index: %s; skipping\n", reason) //nolint:errcheck
+		return nil
+	}
+
+	for _, index := range wispQueryIndexes {
+		if _, err := conn.ExecContext(ctx, index.createStmt); err != nil {
+			// A missing or not-yet-migrated table is non-fatal. Exact index
+			// verification below prevents a partial or conflicting definition
+			// from being staged.
+			fmt.Fprintf(stderr, "wisp-query-index: %s: %v\n", index.createStmt, err) //nolint:errcheck
 		}
 	}
 
-	// Persist the schema change so the indexes survive reset/sync, matching
-	// the schemas/wisps-composite-index migration convention. Fail-open:
-	// "nothing to commit" (idempotent re-run) and any other commit error are
-	// logged, never returned.
-	for _, stmt := range []string{
-		"CALL DOLT_ADD('.')",
-		"CALL DOLT_COMMIT('-m', 'gc: add wisp-query performance indexes (gcy-0m1)', '--author', 'gascity-builder <builder@gascity.local>')",
-	} {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			if strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
-				break
-			}
-			fmt.Fprintf(stderr, "wisp-query-index commit: %s: %v\n", stmt, err) //nolint:errcheck
+	exactIndexes := make(map[string]bool, len(wispQueryIndexes))
+	for _, index := range wispQueryIndexes {
+		exact, err := wispQueryIndexDefinitionIsExact(ctx, conn, index)
+		if err != nil {
+			return fmt.Errorf("verify index %s: %w", index.name, err)
 		}
+		exactIndexes[index.table] = exact
+		if !exact {
+			fmt.Fprintf(stderr, "wisp-query-index: index %s is absent or has an unexpected definition\n", index.name) //nolint:errcheck
+		}
+	}
+
+	status, err = readWispQueryDoltStatus(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("inspect post-create status: %w", err)
+	}
+	changedTargets, reason := wispQueryIndexChangesReadyToStage(status, exactIndexes)
+	if reason != "" {
+		fmt.Fprintf(stderr, "wisp-query-index: %s; leaving intended schema changes unstaged\n", reason) //nolint:errcheck
+		return nil
+	}
+	if len(changedTargets) == 0 {
+		return nil
+	}
+	if err := validateWispQueryIndexDiff(ctx, conn, "WORKING", changedTargets); err != nil {
+		fmt.Fprintf(stderr, "wisp-query-index: %v; leaving intended schema changes unstaged\n", err) //nolint:errcheck
+		return nil
+	}
+
+	for _, index := range wispQueryIndexes {
+		if !changedTargets[index.table] {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, index.addStmt); err != nil {
+			fmt.Fprintf(stderr, "wisp-query-index stage: %s: %v\n", index.addStmt, err) //nolint:errcheck
+			return nil
+		}
+	}
+
+	status, err = readWispQueryDoltStatus(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("inspect staged status: %w", err)
+	}
+	if reason := wispQueryIndexUnsafeStagedSet(status, changedTargets); reason != "" {
+		fmt.Fprintf(stderr, "wisp-query-index: %s; refusing to commit\n", reason) //nolint:errcheck
+		return nil
+	}
+	if err := validateWispQueryIndexDiff(ctx, conn, "STAGED", changedTargets); err != nil {
+		fmt.Fprintf(stderr, "wisp-query-index: %v; refusing to commit\n", err) //nolint:errcheck
+		return nil
+	}
+	if beforeCommit != nil {
+		beforeCommit()
+	}
+
+	// DOLT_COMMIT implicitly commits the surrounding SQL transaction. Keep it
+	// adjacent to the final staged-set validation.
+	if _, err := conn.ExecContext(ctx, wispQueryIndexCommitStatement); err != nil {
+		fmt.Fprintf(stderr, "wisp-query-index commit: %v\n", err) //nolint:errcheck
+		return nil
+	}
+	transactionActive = false
+	return nil
+}
+
+func readWispQueryDoltStatus(ctx context.Context, conn *sql.Conn) ([]wispQueryDoltStatus, error) {
+	rows, err := conn.QueryContext(ctx, "SELECT table_name, staged, status FROM dolt_status ORDER BY table_name, staged")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var status []wispQueryDoltStatus
+	for rows.Next() {
+		var entry wispQueryDoltStatus
+		if err := rows.Scan(&entry.table, &entry.staged, &entry.status); err != nil {
+			return nil, err
+		}
+		status = append(status, entry)
+	}
+	return status, rows.Err()
+}
+
+func wispQueryIndexUnsafeBaseline(status []wispQueryDoltStatus) string {
+	for _, entry := range status {
+		if entry.staged {
+			return fmt.Sprintf("pre-existing staged change on %s", entry.table)
+		}
+		if wispQueryIndexTarget(entry.table) {
+			return fmt.Sprintf("pre-existing WORKING change on target table %s", entry.table)
+		}
+	}
+	return ""
+}
+
+func wispQueryIndexChangesReadyToStage(status []wispQueryDoltStatus, exactIndexes map[string]bool) (map[string]bool, string) {
+	changed := make(map[string]bool, len(wispQueryIndexes))
+	for _, entry := range status {
+		if entry.staged {
+			return nil, fmt.Sprintf("a staged change appeared on %s", entry.table)
+		}
+		if !wispQueryIndexTarget(entry.table) {
+			continue
+		}
+		if entry.status != "modified" {
+			return nil, fmt.Sprintf("unexpected target status %s=%s", entry.table, entry.status)
+		}
+		if !exactIndexes[entry.table] {
+			return nil, fmt.Sprintf("target %s changed without its exact expected index", entry.table)
+		}
+		changed[entry.table] = true
+	}
+	return changed, ""
+}
+
+func wispQueryIndexUnsafeStagedSet(status []wispQueryDoltStatus, expected map[string]bool) string {
+	seen := make(map[string]bool, len(expected))
+	for _, entry := range status {
+		if entry.staged {
+			if !expected[entry.table] {
+				return fmt.Sprintf("unexpected staged change on %s", entry.table)
+			}
+			seen[entry.table] = true
+			continue
+		}
+		if expected[entry.table] {
+			return fmt.Sprintf("target %s still has an unstaged change", entry.table)
+		}
+	}
+	for table := range expected {
+		if !seen[table] {
+			return fmt.Sprintf("target %s is missing from the staged set", table)
+		}
+	}
+	return ""
+}
+
+func wispQueryIndexTarget(table string) bool {
+	for _, index := range wispQueryIndexes {
+		if table == index.table {
+			return true
+		}
+	}
+	return false
+}
+
+func wispQueryIndexDefinitionIsExact(ctx context.Context, conn *sql.Conn, index wispQueryIndexSpec) (bool, error) {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT column_name, non_unique, index_type, sub_part
+		FROM information_schema.statistics
+		WHERE table_schema = DATABASE()
+		  AND table_name = ?
+		  AND index_name = ?
+		ORDER BY seq_in_index`, index.table, index.name)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var columns []string
+	for rows.Next() {
+		var column, indexType string
+		var nonUnique int
+		var subPart sql.NullInt64
+		if err := rows.Scan(&column, &nonUnique, &indexType, &subPart); err != nil {
+			return false, err
+		}
+		if nonUnique != 1 || !strings.EqualFold(indexType, "BTREE") || subPart.Valid {
+			return false, nil
+		}
+		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	if len(columns) != len(index.columns) {
+		return false, nil
+	}
+	for i := range columns {
+		if columns[i] != index.columns[i] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func validateWispQueryIndexDiff(ctx context.Context, conn *sql.Conn, revision string, expected map[string]bool) error {
+	if revision != "WORKING" && revision != "STAGED" {
+		return fmt.Errorf("unsupported diff revision %q", revision)
+	}
+	query := fmt.Sprintf(`
+		SELECT COALESCE(to_table_name, from_table_name), data_change, schema_change
+		FROM dolt_diff_summary('HEAD', '%s')`, revision)
+	rows, err := conn.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("inspect %s diff: %w", strings.ToLower(revision), err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	seen := make(map[string]bool, len(expected))
+	for rows.Next() {
+		var table string
+		var dataChange, schemaChange bool
+		if err := rows.Scan(&table, &dataChange, &schemaChange); err != nil {
+			return fmt.Errorf("scan %s diff: %w", strings.ToLower(revision), err)
+		}
+		if !expected[table] {
+			continue
+		}
+		if dataChange || !schemaChange {
+			return fmt.Errorf("target %s has a non-schema-only %s diff", table, strings.ToLower(revision))
+		}
+		seen[table] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read %s diff: %w", strings.ToLower(revision), err)
+	}
+
+	var missing []string
+	for table := range expected {
+		if !seen[table] {
+			missing = append(missing, table)
+		}
+	}
+	if len(missing) != 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("expected schema diff missing for %s in %s", strings.Join(missing, ", "), revision)
 	}
 	return nil
 }

--- a/cmd/gc/dolt_wisp_query_index_test.go
+++ b/cmd/gc/dolt_wisp_query_index_test.go
@@ -3,8 +3,28 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"strings"
 	"testing"
 )
+
+const wispQueryIndexTestSchema = `
+	CREATE TABLE wisps (
+		id VARCHAR(64) PRIMARY KEY,
+		status VARCHAR(64),
+		issue_type VARCHAR(64)
+	);
+	CREATE TABLE wisp_labels (
+		issue_id VARCHAR(64),
+		label VARCHAR(64)
+	);
+	CREATE TABLE unrelated (
+		id INT PRIMARY KEY,
+		value VARCHAR(64)
+	);
+	CALL DOLT_ADD('wisps', 'wisp_labels', 'unrelated');
+	CALL DOLT_COMMIT('-m', 'test: seed wisp index schema');
+`
 
 func TestApplyWispQueryIndexesToDB_ReturnsErrorOnUnreachableServer(t *testing.T) {
 	var stderr bytes.Buffer
@@ -23,12 +43,208 @@ func TestApplyWispQueryIndexesToDB_ContextCancellation(_ *testing.T) {
 }
 
 func TestWispQueryIndexStatements_AllHaveCreateIndex(t *testing.T) {
-	if len(wispQueryIndexStatements) == 0 {
-		t.Fatal("wispQueryIndexStatements must not be empty")
+	if len(wispQueryIndexes) == 0 {
+		t.Fatal("wispQueryIndexes must not be empty")
 	}
-	for _, stmt := range wispQueryIndexStatements {
-		if len(stmt) < 20 {
-			t.Errorf("statement too short to be a valid DDL: %q", stmt)
+	for _, index := range wispQueryIndexes {
+		if len(index.createStmt) < 20 {
+			t.Errorf("statement too short to be a valid DDL: %q", index.createStmt)
 		}
+	}
+}
+
+func TestWispQueryIndexAddStatementsAreTableScoped(t *testing.T) {
+	want := map[string]string{
+		"wisp_labels": "CALL DOLT_ADD('wisp_labels')",
+		"wisps":       "CALL DOLT_ADD('wisps')",
+	}
+	for _, index := range wispQueryIndexes {
+		if index.addStmt != want[index.table] {
+			t.Errorf("add statement for %s = %q, want %q", index.table, index.addStmt, want[index.table])
+		}
+		if strings.Contains(index.addStmt, "'.'") {
+			t.Errorf("add statement for %s bulk-stages the database: %q", index.table, index.addStmt)
+		}
+	}
+}
+
+func TestWispQueryIndexesCommitOnlyIndexesAndPreserveUnrelatedWorkingChange(t *testing.T) {
+	port, cleanup := startProjectIDTestServer(t, wispQueryIndexTestSchema)
+	defer cleanup()
+	db := openWispQueryIndexTestDB(t, port)
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec("INSERT INTO unrelated VALUES (1, 'keep working')"); err != nil {
+		t.Fatalf("insert unrelated WORKING row: %v", err)
+	}
+	headBefore := wispQueryIndexTestHead(t, db)
+
+	var stderr bytes.Buffer
+	if err := applyWispQueryIndexesToDB(context.Background(), port, "hq", &stderr); err != nil {
+		t.Fatalf("applyWispQueryIndexesToDB: %v", err)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("migration stderr = %q, want empty", got)
+	}
+	headAfter := wispQueryIndexTestHead(t, db)
+	if headAfter == headBefore {
+		t.Fatal("HEAD did not advance for index migration")
+	}
+
+	assertWispQueryIndexTestSchema(t, db, "wisps", "HEAD", "KEY `idx_wisps_status_type` (`status`,`issue_type`)", true)
+	assertWispQueryIndexTestSchema(t, db, "wisp_labels", "HEAD", "KEY `idx_wisp_labels_issue_id` (`issue_id`)", true)
+	assertWispQueryIndexTestRowCount(t, db, "SELECT COUNT(*) FROM unrelated AS OF 'HEAD'", 0)
+	assertWispQueryIndexTestRowCount(t, db, "SELECT COUNT(*) FROM unrelated", 1)
+	assertWispQueryIndexTestModifiedStatus(t, db, "unrelated", false)
+
+	// Idempotence must not create another commit, even while the unrelated
+	// WORKING row remains present.
+	if err := applyWispQueryIndexesToDB(context.Background(), port, "hq", &stderr); err != nil {
+		t.Fatalf("second applyWispQueryIndexesToDB: %v", err)
+	}
+	if got := wispQueryIndexTestHead(t, db); got != headAfter {
+		t.Fatalf("idempotent migration moved HEAD from %s to %s", headAfter, got)
+	}
+}
+
+func TestWispQueryIndexesTransactionPreservesConcurrentTargetWorkingChange(t *testing.T) {
+	port, cleanup := startProjectIDTestServer(t, wispQueryIndexTestSchema)
+	defer cleanup()
+	db := openWispQueryIndexTestDB(t, port)
+	defer func() { _ = db.Close() }()
+
+	headBefore := wispQueryIndexTestHead(t, db)
+	var stderr bytes.Buffer
+	err := applyWispQueryIndexesToDBWithHook(context.Background(), port, "hq", &stderr, func() {
+		if _, err := db.Exec("INSERT INTO wisps VALUES ('concurrent', 'open', 'message')"); err != nil {
+			t.Fatalf("insert concurrent target WORKING row: %v", err)
+		}
+	})
+	if err != nil {
+		t.Fatalf("applyWispQueryIndexesToDBWithHook: %v", err)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("migration stderr = %q, want empty", got)
+	}
+	headAfter := wispQueryIndexTestHead(t, db)
+	if headAfter == headBefore {
+		t.Fatal("HEAD did not advance for index migration")
+	}
+
+	assertWispQueryIndexTestSchema(t, db, "wisps", "HEAD", "KEY `idx_wisps_status_type` (`status`,`issue_type`)", true)
+	assertWispQueryIndexTestSchema(t, db, "wisp_labels", "HEAD", "KEY `idx_wisp_labels_issue_id` (`issue_id`)", true)
+	assertWispQueryIndexTestRowCount(t, db, "SELECT COUNT(*) FROM wisps AS OF 'HEAD' WHERE id = 'concurrent'", 0)
+	assertWispQueryIndexTestRowCount(t, db, "SELECT COUNT(*) FROM wisps WHERE id = 'concurrent'", 1)
+	assertWispQueryIndexTestModifiedStatus(t, db, "wisps", false)
+}
+
+func TestWispQueryIndexesSkipPreexistingStagedChange(t *testing.T) {
+	port, cleanup := startProjectIDTestServer(t, wispQueryIndexTestSchema)
+	defer cleanup()
+	db := openWispQueryIndexTestDB(t, port)
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec("INSERT INTO unrelated VALUES (1, 'already staged')"); err != nil {
+		t.Fatalf("insert unrelated row: %v", err)
+	}
+	if _, err := db.Exec("CALL DOLT_ADD('unrelated')"); err != nil {
+		t.Fatalf("stage unrelated row: %v", err)
+	}
+	headBefore := wispQueryIndexTestHead(t, db)
+
+	var stderr bytes.Buffer
+	if err := applyWispQueryIndexesToDB(context.Background(), port, "hq", &stderr); err != nil {
+		t.Fatalf("applyWispQueryIndexesToDB: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "pre-existing staged change on unrelated; skipping") {
+		t.Fatalf("migration stderr = %q, want staged-change skip", stderr.String())
+	}
+	if got := wispQueryIndexTestHead(t, db); got != headBefore {
+		t.Fatalf("skipped migration moved HEAD from %s to %s", headBefore, got)
+	}
+	assertWispQueryIndexTestSchema(t, db, "wisps", "WORKING", "idx_wisps_status_type", false)
+	assertWispQueryIndexTestSchema(t, db, "wisp_labels", "WORKING", "idx_wisp_labels_issue_id", false)
+	assertWispQueryIndexTestModifiedStatus(t, db, "unrelated", true)
+}
+
+func TestWispQueryIndexesSkipDirtyTargetTable(t *testing.T) {
+	port, cleanup := startProjectIDTestServer(t, wispQueryIndexTestSchema)
+	defer cleanup()
+	db := openWispQueryIndexTestDB(t, port)
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec("INSERT INTO wisps VALUES ('w1', 'open', 'message')"); err != nil {
+		t.Fatalf("insert target WORKING row: %v", err)
+	}
+	headBefore := wispQueryIndexTestHead(t, db)
+
+	var stderr bytes.Buffer
+	if err := applyWispQueryIndexesToDB(context.Background(), port, "hq", &stderr); err != nil {
+		t.Fatalf("applyWispQueryIndexesToDB: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "pre-existing WORKING change on target table wisps; skipping") {
+		t.Fatalf("migration stderr = %q, want dirty-target skip", stderr.String())
+	}
+	if got := wispQueryIndexTestHead(t, db); got != headBefore {
+		t.Fatalf("skipped migration moved HEAD from %s to %s", headBefore, got)
+	}
+	assertWispQueryIndexTestSchema(t, db, "wisps", "WORKING", "idx_wisps_status_type", false)
+	assertWispQueryIndexTestModifiedStatus(t, db, "wisps", false)
+}
+
+func openWispQueryIndexTestDB(t *testing.T, port string) *sql.DB {
+	t.Helper()
+	db, err := managedDoltOpenDatabase("127.0.0.1", port, "root", "hq")
+	if err != nil {
+		t.Fatalf("managedDoltOpenDatabase: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		t.Fatalf("ping test Dolt: %v", err)
+	}
+	return db
+}
+
+func wispQueryIndexTestHead(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var head string
+	if err := db.QueryRow("SELECT DOLT_HASHOF('HEAD')").Scan(&head); err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	return head
+}
+
+func assertWispQueryIndexTestSchema(t *testing.T, db *sql.DB, table, revision, fragment string, present bool) {
+	t.Helper()
+	var gotTable, createStmt string
+	query := "SHOW CREATE TABLE " + table + " AS OF '" + revision + "'"
+	if err := db.QueryRow(query).Scan(&gotTable, &createStmt); err != nil {
+		t.Fatalf("%s: %v", query, err)
+	}
+	if got := strings.Contains(createStmt, fragment); got != present {
+		t.Fatalf("%s schema contains %q = %t, want %t\n%s", table, fragment, got, present, createStmt)
+	}
+}
+
+func assertWispQueryIndexTestRowCount(t *testing.T, db *sql.DB, query string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(query).Scan(&got); err != nil {
+		t.Fatalf("%s: %v", query, err)
+	}
+	if got != want {
+		t.Fatalf("%s = %d, want %d", query, got, want)
+	}
+}
+
+func assertWispQueryIndexTestModifiedStatus(t *testing.T, db *sql.DB, table string, wantStaged bool) {
+	t.Helper()
+	var staged bool
+	var status string
+	if err := db.QueryRow("SELECT staged, status FROM dolt_status WHERE table_name = ?", table).Scan(&staged, &status); err != nil {
+		t.Fatalf("read dolt_status for %s: %v", table, err)
+	}
+	if staged != wantStaged || status != "modified" {
+		t.Fatalf("dolt_status[%s] = staged:%t status:%s, want staged:%t status:modified", table, staged, status, wantStaged)
 	}
 }


### PR DESCRIPTION
## Summary

- replace `DOLT_ADD('.')` with exact table-scoped staging for the wisp index migration
- reject pre-staged changes, dirty target tables, unexpected staged paths, and non-schema target diffs
- run validation, index creation, staging, and `DOLT_COMMIT` on one reserved connection in an explicit SQL transaction
- roll back every skip/error path while retaining the advisory lock for cooperating controllers

## Why

The startup migration currently stages the entire working set, so legitimate unrelated changes can be swept into its commit. Table locks are not a viable boundary in Dolt: [`LOCK TABLES` is parsed but does not prevent concurrent access](https://www.dolthub.com/docs/sql-reference/sql-support/supported-statements/). Dolt's documented concurrency pattern is an explicit SQL transaction ending in `DOLT_COMMIT`, which isolates each client's writes ([Dolt concurrency guidance](https://www.dolthub.com/blog/2026-02-17-dolt-concurrency/)).

## Safety properties

- unrelated working changes remain unstaged
- any pre-existing staged change causes a safe skip
- dirty migration target tables cause a safe skip
- the final staged set must exactly match the expected target schema changes
- a deterministic second-client race test proves concurrent target-row changes stay in `WORKING` while the index commit advances `HEAD`

## Residual limits

- the existing 10-second migration timeout remains fail-open, so an unusually large database can skip index creation and retry on a later startup
- the advisory lock coordinates SQL clients using this migration path; raw filesystem-level Dolt manipulation remains outside that cooperation model

## Testing

- `go test -count=1 -run '^Test(ApplyWispQueryIndexesToDB|WispQueryIndex)' ./cmd/gc`
- `go test -count=10 -run '^TestWispQueryIndexesTransactionPreservesConcurrentTargetWorkingChange$' ./cmd/gc`
- `go test -count=1 ./cmd/gc`
- repository pre-commit lint/generation checks and `go vet ./...`

## Local environment note

The repository-wide `make check` reached two unrelated host/worktree failures after the static gates and changed package passed: the negative tooling test sees system-installed `/usr/bin/gc` and `/usr/bin/bd` (also reproducible on unmodified `main`), and the worker sandbox cannot obtain VCS status from a `/tmp` worktree. The worker package passes with VCS stamping disabled. CI remains the clean-environment broad-suite authority.
