### PR TITLE
fix(beads): skip nudge beads in cache ready projection

### DIFF
--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -21,13 +21,13 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 	ids := make([]string, 0, len(items))
 	seen := make(map[string]struct{}, len(items))
 	for _, item := range items {
-		// Message (mail) beads are never dependency-blocked ready work, and
-		// bd's denormalized is_blocked column flaps NULL<->false for ephemeral
-		// mail wisps. Enriching them makes the CachingStore reconciler re-emit
-		// bead.updated for every open mail bead on every cycle (an event flood
-		// that starves gc-hook work queries). Leave their IsBlocked at bd's nil
-		// fallback so the reconcile diff converges.
-		if item.ID == "" || item.Status == "closed" || item.IsBlocked != nil || item.Type == "message" {
+		// Message and nudge beads are notifications, not dependency-blocked ready
+		// work, and bd's denormalized is_blocked column can flap NULL<->false for
+		// them. Enriching those rows makes the CachingStore reconciler re-emit
+		// bead.updated on every cycle (an event flood that starves gc-hook work
+		// queries). Leave their IsBlocked at bd's nil fallback so the reconcile
+		// diff converges.
+		if skipBDReadyProjectionEnrichment(item) {
 			continue
 		}
 		if _, ok := seen[item.ID]; ok {
@@ -54,7 +54,7 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 	enriched := make([]Bead, len(items))
 	copy(enriched, items)
 	for i := range enriched {
-		if enriched[i].ID == "" || enriched[i].Status == "closed" || enriched[i].IsBlocked != nil || enriched[i].Type == "message" {
+		if skipBDReadyProjectionEnrichment(enriched[i]) {
 			continue
 		}
 		blocked, ok := projection[enriched[i].ID]
@@ -64,6 +64,14 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 		enriched[i].IsBlocked = cloneBoolPtr(&blocked)
 	}
 	return enriched, nil
+}
+
+func skipBDReadyProjectionEnrichment(item Bead) bool {
+	return item.ID == "" ||
+		item.Status == "closed" ||
+		item.IsBlocked != nil ||
+		item.Type == "message" ||
+		beadHasLabel(item, "gc:nudge")
 }
 
 func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {

--- a/internal/beads/bdstore_ready_projection_internal_test.go
+++ b/internal/beads/bdstore_ready_projection_internal_test.go
@@ -48,3 +48,40 @@ func TestEnrichReadyProjectionForCacheSkipsMessageBeads(t *testing.T) {
 		t.Errorf("task bead IsBlocked = %v, want &false (real work must still be enriched)", got)
 	}
 }
+
+// TestEnrichReadyProjectionForCacheSkipsNudgeBeads guards the same cache
+// convergence invariant for durable nudge queue beads. They are transient
+// notifications represented as chore beads, not dependency-blocked work.
+func TestEnrichReadyProjectionForCacheSkipsNudgeBeads(t *testing.T) {
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		joined := name + " " + strings.Join(args, " ")
+		switch {
+		case joined == "bd version":
+			return []byte("bd version 1.1.0\n"), nil
+		case len(args) > 0 && args[0] == "sql":
+			return []byte(`[{"id":"gc-wisp-nudge","is_blocked":false},{"id":"gcg-task","is_blocked":false}]`), nil
+		}
+		return nil, fmt.Errorf("unexpected command: %s", joined)
+	}
+	s := NewBdStore("/city", runner)
+
+	items := []Bead{
+		{ID: "gc-wisp-nudge", Type: "chore", Status: "open", Labels: []string{"gc:nudge"}},
+		{ID: "gcg-task", Type: "task", Status: "open"},
+	}
+	out, err := s.enrichReadyProjectionForCache(items)
+	if err != nil {
+		t.Fatalf("enrichReadyProjectionForCache: %v", err)
+	}
+
+	byID := make(map[string]Bead, len(out))
+	for _, b := range out {
+		byID[b.ID] = b
+	}
+	if got := byID["gc-wisp-nudge"].IsBlocked; got != nil {
+		t.Errorf("nudge bead IsBlocked = &%v, want nil (must be skipped so the reconcile diff converges)", *got)
+	}
+	if got := byID["gcg-task"].IsBlocked; got == nil || *got {
+		t.Errorf("task bead IsBlocked = %v, want &false (real work must still be enriched)", got)
+	}
+}


### PR DESCRIPTION
## Summary

- exclude durable `gc:nudge` chore beads from cache ready-projection enrichment
- use one notification/invalid-row skip predicate in both projection passes
- preserve readiness enrichment for ordinary work beads

## Why

Durable nudge beads are coordination notifications, not dependency-blocked work. Projecting `is_blocked=false` into their cached rows prevents reconciliation from converging and can repeatedly emit `bead.updated` events.

## Testing

- `go test -count=20 -run '^TestEnrichReadyProjectionForCacheSkipsNudgeBeads$' ./internal/beads`
- `go test -count=1 ./internal/beads`
- `make lint-changed LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=upstream/main`
- repository pre-commit generation checks and `go vet ./...`

## Local environment note

The repository-wide `make check` reached two unrelated host/worktree failures after the static gates and changed package passed: the negative tooling test sees system-installed `/usr/bin/gc` and `/usr/bin/bd` (also reproducible on unmodified `main`), and the worker sandbox cannot obtain VCS status from a `/tmp` worktree. The worker package passes with VCS stamping disabled. CI remains the clean-environment broad-suite authority.
