### PR TITLE
Harden Dashboard SPA Playwright Chromium install against cold-cache timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1283,15 +1283,33 @@ jobs:
       # @playwright/test version (from the lockfile-pinned install above). A cache
       # hit skips the ~150 MB Chromium download; --with-deps in the install step
       # below still runs (system libs aren't cached), so a hit is safe.
-      - name: Cache Playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      # Restore/save are split (rather than the combined actions/cache) so the
+      # save step can run with if: always() — a completed download still gets
+      # cached even if a later step in this job fails.
+      - name: Restore Playwright browsers cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: npm run test:e2e:install:ci
+        timeout-minutes: 12
+        run: |
+          for attempt in 1 2 3; do
+            if npm run test:e2e:install:ci; then
+              exit 0
+            fi
+            if [ "$attempt" = "3" ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
         working-directory: internal/api/dashboardspa/web/frontend
-        timeout-minutes: 5
+      - name: Save Playwright browsers cache
+        if: always()
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
       - name: Playwright render smoke (Layer B)
         run: npm run test:e2e
         working-directory: internal/api/dashboardspa/web/frontend

--- a/release-gates/ga-xb94fi-playwright-chromium-cache-timeout-gate.md
+++ b/release-gates/ga-xb94fi-playwright-chromium-cache-timeout-gate.md
@@ -1,0 +1,59 @@
+# Release Gate: Playwright Chromium cold-cache timeout hardening
+
+Bead: `ga-xb94fi`
+Source bead: `ga-bt679z`
+Deploy branch: `deploy/ga-xb94fi-gate`
+Deploy source: `de92acf33a5a4782ecbda75fa875bf75f06acf39`
+
+Result: PASS
+
+Note: the deploy bead description still names the stale pre-rebase source
+`ebd23371b`. The bead notes contain a verified builder handoff updating the
+deploy source to `de92acf33a5a4782ecbda75fa875bf75f06acf39`; this gate was run
+against that updated source.
+
+## Evaluation Order
+
+Criterion 6 was evaluated first per deployer instructions.
+
+- `git fetch origin main`: PASS.
+- `git rev-parse origin/main`: `7e6ad17b311ba3776b4273471d0b51c70e8a6863`.
+- `git merge-base origin/main de92acf33a5a4782ecbda75fa875bf75f06acf39`:
+  `cdb1b4260f962519b2313a3e495a1cc158f893e2`.
+- `git merge-tree --write-tree origin/main de92acf33a5a4782ecbda75fa875bf75f06acf39`:
+  `b9bb2cb2aa3f4adde5b000c2a1da8b07a5e3743d`, with no conflict diagnostics.
+
+No bounded self-rebase was needed.
+
+## Scope
+
+Commit set:
+
+- `868cccd19` - `fix(ci): harden Playwright Chromium install against cold-cache timeouts`
+- `de92acf33` - `chore(cipolicy): update pinned CI execution hash for Playwright cache fix`
+
+Changed paths:
+
+- `.github/workflows/ci.yml`
+- `scripts/cipolicy/policy.go`
+
+`git diff --stat origin/main...HEAD` reports exactly 2 files changed, 23
+insertions, 5 deletions.
+
+## Gate Checklist
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git merge-tree --write-tree origin/main de92acf33a5a4782ecbda75fa875bf75f06acf39` returned tree `b9bb2cb2aa3f4adde5b000c2a1da8b07a5e3743d` with no conflicts. |
+| 1 | Review PASS present | PASS | `bd show ga-bt679z` contains `Reviewer re-review verdict: PASS`; source bead `ga-bt679z` is closed with reason `pass`; deploy bead `ga-xb94fi` records reviewer PASSED status. |
+| 2 | Acceptance criteria met | PASS | `ci.yml` splits Playwright cache restore/save, uses `actions/cache/restore` before install and `actions/cache/save` with `if: always()` after install, preserves the same pinned cache SHA and key, wraps install in a 3-attempt retry with 10s/20s backoff, raises install timeout from 5 to 12 minutes, and updates the CI policy execution hash. Follow-up `ga-8e0ukr` tracks the out-of-scope cache-quota root cause. |
+| 3 | Tests pass | PASS | `python3 yaml.safe_load` on `.github/workflows/ci.yml` PASS; `go test ./scripts/cipolicy/...` PASS; `go test ./scripts/... -run TestPushOwnershipGuard -v` PASS; `make test-ci-policy` PASS; `go build ./cmd/gc/` PASS; `make test-fast-parallel` PASS (`All fast jobs passed`); `go vet ./...` PASS. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes say all done-when criteria are met with no outstanding blockers; `bd search "ga-bt679z HIGH"`, `bd search "ga-xb94fi HIGH"`, and `bd search "Playwright Chromium high severity"` returned no matching issues. |
+| 5 | Final branch is clean | PASS | Before committing this gate file, `git status --short --branch` showed only `?? release-gates/ga-xb94fi-playwright-chromium-cache-timeout-gate.md`; final clean status is rechecked after the gate commit before push. |
+| 7 | Single feature theme | PASS | The two-commit set touches one subsystem/theme: Dashboard SPA CI Playwright Chromium install hardening and the corresponding CI policy hash update. |
+
+## Manifest Note
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so no additional
+repo-specific release criteria were available from that path. The gate used the
+deployer release criteria and the repo testing guidance in `TESTING.md`.

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -20,7 +20,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "9728769fbae6867ea2977adfe109127b17d4fc2a4bfbac2dece3383b3ff84a74"
+	expectedCIExecutionHash      = "917fdf8ac535519725f709422d1bf4b650ae7e5c4a61a350c25227cc3f2e0fe9"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "80575ca368f28ba9f8b14bf72ce5767a7877ffe4dcadc136854ab4b0b5f1377a"
 	expectedSetupActionHash      = "b7864038195cd054aee7fccfa903cab335b375bcab1a35239c17c5da7d32c07e"


### PR DESCRIPTION
## What this changes

The Dashboard SPA CI job now handles Playwright Chromium installs as a cold-cache operation instead of assuming the browser cache is already warm. The workflow restores the Playwright browser cache before install, retries the Chromium install command up to three times, gives the install step a 12 minute timeout, and saves the browser cache even if a later render-smoke step fails.

The CI policy hash is updated to approve that intentional workflow execution change.

## Review notes

- `.github/workflows/ci.yml`: the Playwright cache step is split into restore and save, using the existing pinned `actions/cache` SHA and the same cache key.
- `.github/workflows/ci.yml`: the save step uses `if: always()` and runs before the Playwright render smoke so completed browser downloads can populate the cache for later same-scope runs.
- `scripts/cipolicy/policy.go`: only the expected CI execution hash changes.
- This is CI-only; it does not change runtime behavior or dashboard source code.

## Test plan

- [x] `python3 yaml.safe_load` on `.github/workflows/ci.yml`
- [x] `go test ./scripts/cipolicy/...`
- [x] `go test ./scripts/... -run TestPushOwnershipGuard -v`
- [x] `make test-ci-policy`
- [x] `go build ./cmd/gc/`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-xb94fi-playwright-chromium-cache-timeout-gate.md`](release-gates/ga-xb94fi-playwright-chromium-cache-timeout-gate.md)

Internal tracking: ga-xb94fi.