### PR TITLE
fix(scale): a live named-session must not also spawn a pool duplicate

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -396,9 +396,11 @@ func buildDesiredStateWithSessionBeads(
 			continue
 		}
 		namedSessionMode := ""
+		namedIdentity := ""
 		for j := range cfg.NamedSessions {
 			if cfg.NamedSessions[j].TemplateQualifiedName() == cfg.Agents[i].QualifiedName() {
 				namedSessionMode = cfg.NamedSessions[j].ModeOrDefault()
+				namedIdentity = cfg.NamedSessions[j].QualifiedName()
 				break
 			}
 		}
@@ -458,15 +460,35 @@ func buildDesiredStateWithSessionBeads(
 			// work below; defaultNamedScaleTargets only preserves partial-query
 			// retention for configured named-session beads.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
+			// residentLive: the on_demand named session already has a LIVE canonical
+			// session. In that case pool demand for gc.routed_to work would spawn a
+			// {name}-N phantom BESIDE the resident (the crew-duplicate bug) — the live
+			// resident already claims routed work via its own hook. Suppress pool demand
+			// when resident, i.e. behave like 'always'. Only when the singleton is
+			// asleep do we register the one pool slot that wakes it (namedWorkReady
+			// covers only Assignee beads, not gc.routed_to).
+			residentLive := false
+			if namedSessionMode != "always" && namedIdentity != "" {
+				if spec, ok := findNamedSessionSpec(cfg, cityName, namedIdentity); ok {
+					// Must be present AND actually LIVE (not merely an open bead): an
+					// asleep/drained canonical session must still be woken by pool
+					// demand — poolSessionIsLiveInfo is the generic Info liveness check.
+					if info, has := findCanonicalNamedSessionInfo(bp.sessionBeads, spec); has && poolSessionIsLiveInfo(info) {
+						residentLive = true
+					}
+				}
+			}
 			if store != nil && !hasCustomScaleCheck {
 				ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
 				// mode='always': named session is unconditionally desired by the named
 				// pass; pool demand is redundant and creates {name}-N phantoms when N
 				// routed beads arrive. mode='on_demand': pool demand wakes the sleeping
 				// singleton (namedWorkReady covers only direct Assignee beads, not
-				// gc.routed_to). Leave defaultNamedScaleTargets unchanged for both modes
-				// (partial-query retention).
-				if namedSessionMode != "always" {
+				// gc.routed_to) — but ONLY when no resident is live (residentLive guard,
+				// else the {name}-N phantom spawns beside the resident). Leave
+				// defaultNamedScaleTargets unchanged for both modes (partial-query
+				// retention).
+				if namedSessionMode != "always" && !residentLive {
 					defaultScaleTargets = append(defaultScaleTargets, ownTarget)
 					namedOnDemandTemplates[template] = true
 				}
@@ -486,7 +508,7 @@ func buildDesiredStateWithSessionBeads(
 				// mirrors these probes only for partial-query retention bookkeeping.
 				if !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 					cityTarget := defaultScaleCheckTarget{template: template, store: store, storeKey: "city"}
-					if namedSessionMode != "always" {
+					if namedSessionMode != "always" && !residentLive {
 						defaultScaleTargets = append(defaultScaleTargets, cityTarget)
 					}
 					defaultNamedScaleTargets = append(defaultNamedScaleTargets, cityTarget)

--- a/cmd/gc/build_desired_state_crew_dup_test.go
+++ b/cmd/gc/build_desired_state_crew_dup_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// TestBuildDesiredState_RoutedToLiveNamedSession_NoPoolDuplicate is the crew-duplicate
+// repro. A bead routed (gc.routed_to) at an on_demand [[named_session]] agent whose
+// canonical named session is ALREADY LIVE must NOT register pool demand — otherwise a
+// `<name>-1` pool slot spawns beside the resident (double burn, two agents in one rig).
+// The live resident claims the routed bead via its own hook. When the resident is
+// ASLEEP the pool slot still wakes it (preserved by the sibling scale-from-zero tests).
+//
+// MUST fail on current code (ScaleCheckCounts==1) and pass after the fix.
+func TestBuildDesiredState_RoutedToLiveNamedSession_NoPoolDuplicate(t *testing.T) {
+	cfg, cityStore, rigStores, identity := newNoScaleCheckNamedBackingCity(t)
+
+	// Routed, unassigned work in the city store (the demand that spawns the -1).
+	if _, err := cityStore.Create(beads.Bead{
+		ID:       "bead-city-1",
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": identity},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A LIVE canonical named session for that identity (the resident crew role).
+	liveNamed := beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Status: "open",
+		Metadata: map[string]string{
+			"configured_named_session":  "true",
+			"configured_named_identity": identity,
+			"configured_named_mode":     "on_demand",
+		},
+	}
+	snap := newSessionBeadSnapshot([]beads.Bead{liveNamed})
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, snap, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[identity]; got != 0 {
+		t.Fatalf("routed-to-LIVE-named-session registered pool demand = %d, want 0 "+
+			"(a live resident claims the bead via its hook; registering demand spawns the "+
+			"%s-1 duplicate)", got, identity)
+	}
+	for key, tp := range result.State {
+		if tp.TemplateName == identity && tp.Alias != "" && tp.Alias != identity {
+			t.Fatalf("spawned pool duplicate %q (alias=%s) beside the live named session %q",
+				key, tp.Alias, identity)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
A bead with `gc.routed_to=<agent>` registers pool demand. When the target is an `on_demand` `[[named_session]]` whose canonical session is already **live**, `buildDesiredState` still registered that demand, so a `<name>-1` pool slot spawned **beside the resident** — a duplicate that double-claims one unit of work (double burn; two agents in one rig's store). Reproduces for any resident "one-seat" role (crew/coordinator/planner) that receives routed work while awake.

## Fix
In the `backsNamedSession` branch of `build_desired_state.go`, suppress pool demand for an on_demand named-backing template when its canonical named session is present **and live** (`poolSessionIsLiveInfo`): the live resident already claims routed work via its own hook, so the extra slot is a phantom. When the singleton is **asleep**, behavior is unchanged — the one pool slot still wakes it (`namedWorkReady` covers only `Assignee` beads, not `gc.routed_to`).

## Tests
- New `TestBuildDesiredState_RoutedToLiveNamedSession_NoPoolDuplicate` (red before / green after): routed bead + live canonical named session ⇒ `ScaleCheckCounts==0`, no `-1`.
- Preserved: `TestReconcileSessionBeads_OnDemandNamedSessionWakesFromSingletonPoolDemand...` and the `ScaleFromZero_NoScaleCheck` named-path tests (asleep singleton still wakes). Full desired-state/scale/pool/reconcile suite green; `go vet` clean.

Companion to #4514 (same fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)