### PR TITLE
fix(sling): --nudge falls back to a running named session for instance-expandable agents (#3412)

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1527,6 +1527,19 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 				deliverSlingNudge(target, sp, rawStore, cityPath, stdout, stderr)
 				return true
 			}
+			// No running pool/worker session ref matched -- an
+			// instance-expandable agent can also be fronted by a running
+			// NAMED session bound to its own template (e.g. an always-on
+			// wake_mode=resume session), which is not among the pool refs
+			// above. Fall back to the same lookup the fixed-agent branch
+			// below uses before giving up on this store (#3412).
+			if sn := lookupSessionNameOrLegacy(sessStore, cityName, a.QualifiedName(), st); sn != "" {
+				if running, err := workerSessionTargetRunningWithConfig(cityPath, sessStore, sp, cfg, sn); err == nil && running {
+					target := buildSlingNudgeTarget(*a, cityName, cityPath, cfg, sessStore, sn)
+					deliverSlingNudge(target, sp, rawStore, cityPath, stdout, stderr)
+					return true
+				}
+			}
 			return false
 		}
 		if tryNudgeStore(store) {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1346,6 +1346,54 @@ func TestDoSlingNudgePoolNoMembers(t *testing.T) {
 	}
 }
 
+// TestDoSlingNudgeInstanceExpandableAgentWithRunningNamedSession is the
+// regression for #3412: an instance-expandable agent (SupportsInstanceExpansion)
+// resolves nudge targets from pool/worker session refs only. When the same
+// agent is instead fronted by a running NAMED session (e.g. an always-on
+// session bound to its own template, not a pool instance), that session is
+// not among the pool refs, so nudge fell through to "No running sessions"
+// and poked the controller — a no-op for an already-awake named session,
+// with a misleading message. The fixed-agent branch already handles this
+// correctly via lookupSessionNameOrLegacy; the instance-expansion branch
+// must fall back to the same lookup before giving up.
+func TestDoSlingNudgeInstanceExpandableAgentWithRunningNamedSession(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	// The named session is registered under the agent's own bare qualified
+	// name (the legacy/no-explicit-template convention lookupSessionNameOrLegacy
+	// falls back to) — no pool instance running.
+	_ = sp.Start(context.Background(), "polecat", runtime.Config{})
+	sp.Calls = nil
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{
+		Name:              "polecat",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3),
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+	prev := startNudgePoller
+	startNudgePoller = func(_, _, _ string) error { return nil }
+	t.Cleanup(func() { startNudgePoller = prev })
+	opts := testOpts(a, "BL-1")
+	opts.Nudge = true
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "No running sessions") {
+		t.Errorf("stdout = %q, want the named session nudged, not the no-running-sessions poke fallback", stdout.String())
+	}
+	pending, _, dead, err := listQueuedNudges(deps.CityPath, "polecat", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 1 || len(dead) != 0 {
+		t.Fatalf("pending=%d dead=%d, want 1/0 (named session should have been nudged)", len(pending), len(dead))
+	}
+}
+
 // TestBuiltInSlingSlotSuffixedTargetNormalizesRoutedTo is the write-side guard
 // for #2592: resolving and slinging a slot-suffixed pool target ("saitoc/polecat-2")
 // must record the base pool qualified name in gc.routed_to, so the pool's


### PR DESCRIPTION
## Summary

`gc sling <agent> <bead> --nudge`, for an agent that `SupportsInstanceExpansion()`, resolves nudge targets by looking at pool/worker session refs only. If that same agent is instead fronted by a running **named** session (e.g. an always-on `wake_mode=resume` session bound to its own template — a common shape, not a pool instance), it's never matched: the command falls through to `pokeController` and prints a misleading `No running sessions for "X" — poked controller for wake`, even though a session for that exact agent is actively running.

Addresses #3412.

## Fix

`doSlingNudge` (`cmd/gc/cmd_sling.go`) — the `SupportsInstanceExpansion()` branch's `tryNudgeStore` closure iterates `resolvePoolSessionRefs(...)` and nudges the first running pool ref; a named session bound to the same agent/template is not among those refs, so the loop fell through with nothing found. The fixed-agent branch just below it already handled the named-session case correctly via `lookupSessionNameOrLegacy`.

Added the same fallback inside `tryNudgeStore`, right after the pool-refs loop exhausts without a match: resolve `lookupSessionNameOrLegacy(sessStore, cityName, a.QualifiedName(), st)`, check whether that session is actually running via the same `workerSessionTargetRunningWithConfig` helper the pool-ref loop already uses, and if so nudge it via `buildSlingNudgeTarget(*a, ...)` — the identical delivery call the fixed-agent branch uses. Only falls through to the poke-controller message when genuinely nothing (no pool ref, no named session) is running, in either the rig or city store.

## Test plan

- [x] New test `TestDoSlingNudgeInstanceExpandableAgentWithRunningNamedSession` (RED: `pending=0 dead=0, want 1/0`, matching the reported bug exactly; GREEN after the fix)
- [x] Full existing `TestDoSlingNudge*` suite (9 tests): PASS, no regressions — critically `TestDoSlingNudgePoolNoMembers` (an agent with genuinely no session of any kind running) still correctly falls through to the poke-controller message, so the new fallback doesn't over-match
- [x] `go test -tags gms_pure_go ./cmd/gc/... -run "TestOnFormula|TestBuiltInSling|TestDoSling"`: PASS
- [x] `go build ./...` (full repo, untagged): clean
- [x] `go vet -tags gms_pure_go ./cmd/gc/...`: clean
- [x] Full untagged pre-commit hook (lint-changed, spec/client/schema codegen, `go vet ./...`): passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGjSaP5EtcXZYqgBafw61m