### PR TITLE
fix(hook): preserve selected store through claims (v1.3.x backport)

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -317,17 +317,20 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		stores = appendCityHookStore(stores, cityPath, cfg, &a, overrides)
 	}
 
-	runner := func(command, _ string) (string, error) {
-		out, err := firstStoreWithWork(command, stores, shellWorkQueryWithEnv)
-		if err != nil && emitFailureEvent {
-			// A killed/timed-out work query strands the session with no
-			// output and no cause on the event bus; emit one so the
-			// reconciler can escalate instead of skipping it forever
-			// (issues #1496/#1497). Ordinary command errors are ignored
-			// by emitWorkQueryFailure and stay on the stderr path below.
-			emitCityWorkQueryFailure(cityPath, stderr,
-				os.Getenv("GC_SESSION_ID"), failureTemplate, command, err)
+	// emitQueryFailure surfaces a killed/timed-out work query on the event bus
+	// so the reconciler can escalate instead of silently treating the strand as
+	// "no work" (issues #1496/#1497). Ordinary command errors are ignored by
+	// emitCityWorkQueryFailure and stay on the caller's stderr path.
+	emitQueryFailure := func(command string, err error) {
+		if err == nil || !emitFailureEvent {
+			return
 		}
+		emitCityWorkQueryFailure(cityPath, stderr,
+			os.Getenv("GC_SESSION_ID"), failureTemplate, command, err)
+	}
+	runner := func(command, _ string) (string, error) {
+		out, _, err := firstStoreWithWork(command, stores, stores[0], shellWorkQueryWithEnv)
+		emitQueryFailure(command, err)
 		return out, err
 	}
 	if opts.Claim {
@@ -351,9 +354,66 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
 		}
-		return doHookClaim(workQuery, workDir, claimOpts, hookClaimOps{Runner: runner}, stdout, stderr)
+		return claimHookWork(workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}
 	return doHook(workQuery, workDir, false, runner, stdout, stderr)
+}
+
+// claimHookWork claims routed work from the federated store set while keeping
+// each work-query result paired with the store that produced it.
+func claimHookWork(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
+	return claimHookWorkWithRunner(workQuery, workDir, queryEnv, stores, claimOpts, hookClaimOps{}, shellWorkQueryWithEnv, emitFailure, stdout, stderr)
+}
+
+// claimHookWorkWithRunner selects the first store with ready work, re-validates
+// it at claim time, and attempts the claim from the captured rows together with
+// that store's dir and env. If a claim race exhausts one store, it continues
+// across the remaining federated stores before emitting one no-work result.
+func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, ops hookClaimOps, run hookStoreRunner, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
+	ops.applyDefaults()
+	var primary hookStore
+	if len(stores) > 0 {
+		primary = stores[0]
+	}
+	remaining := stores
+	for len(remaining) > 0 {
+		_, selected, err := firstStoreWithWork(workQuery, remaining, primary, run)
+		if err != nil {
+			emitFailure(workQuery, err)
+			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if isZeroHookStore(selected) {
+			break
+		}
+		claimOutput, claimStore, err := claimStoreWithFallback(workQuery, remaining, selected, primary, run)
+		if err != nil {
+			emitFailure(workQuery, err)
+			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if isZeroHookStore(claimStore) {
+			break
+		}
+
+		storeOpts := claimOpts
+		storeOpts.Env = queryEnv
+		if len(claimStore.env) > 0 {
+			storeOpts.Env = claimStore.env
+		}
+		storeDir := workDir
+		if dir := strings.TrimSpace(claimStore.dir); dir != "" {
+			storeDir = dir
+		}
+		storeOps := ops
+		storeOps.Runner = func(string, string) (string, error) { return claimOutput, nil }
+		result := tryHookClaim(workQuery, storeDir, &storeOpts, &storeOps, stdout, stderr)
+		if result.terminal {
+			return result.code
+		}
+		remaining = removeHookStore(remaining, claimStore)
+	}
+	return writeHookClaimNoWork(claimOpts, ops, stdout, stderr)
 }
 
 func hookClaimPrimaryRouteTarget(a *config.Agent) string {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -55,18 +55,71 @@ type hookClaimJSONResult struct {
 	DrainAcknowledged    bool     `json:"drain_acknowledged,omitempty"`
 }
 
+// hookClaimResult is the outcome of attempting a claim against one store's
+// captured work-query output. A non-terminal result has written no output, so a
+// federated caller may try a later store before writing one no-work result.
+type hookClaimResult struct {
+	terminal bool
+	code     int
+}
+
 func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps, stdout, stderr io.Writer) int {
+	result := tryHookClaim(workQuery, dir, &opts, &ops, stdout, stderr)
+	if result.terminal {
+		return result.code
+	}
+	return writeHookClaimNoWork(opts, ops, stdout, stderr)
+}
+
+func tryHookClaim(workQuery, dir string, opts *hookClaimOptions, ops *hookClaimOps, stdout, stderr io.Writer) hookClaimResult {
 	opts.Assignee = strings.TrimSpace(opts.Assignee)
 	opts.IdentityCandidates = hookClaimIdentityCandidates(append([]string{opts.Assignee}, opts.IdentityCandidates...)...)
 	opts.RouteTargets = hookClaimRouteTargets(opts.RouteTargets...)
 	if opts.Assignee == "" {
 		fmt.Fprintln(stderr, "gc hook --claim: assignee not specified (set $GC_SESSION_NAME or $GC_SESSION_ID)") //nolint:errcheck
-		return 1
+		return hookClaimResult{terminal: true, code: 1}
 	}
 	if ops.Runner == nil {
 		fmt.Fprintln(stderr, "gc hook --claim: missing work query runner") //nolint:errcheck
-		return 1
+		return hookClaimResult{terminal: true, code: 1}
 	}
+	ops.applyDefaults()
+	now := time.Now
+	if ops.Now != nil {
+		now = ops.Now
+	}
+
+	output, err := ops.Runner(workQuery, dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck
+		return hookClaimResult{terminal: true, code: 1}
+	}
+
+	normalized := normalizeWorkQueryOutput(strings.TrimSpace(output))
+	normalized = filterUnreadyHookCandidates(normalized, now())
+	if !workQueryHasReadyWork(normalized) {
+		return hookClaimResult{}
+	}
+	candidates, err := decodeHookClaimBeads(normalized)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: requires JSON work_query output to identify claim candidates: %v\n", err) //nolint:errcheck
+		return hookClaimResult{terminal: true, code: 1}
+	}
+	if len(candidates) == 0 {
+		return hookClaimResult{}
+	}
+
+	if result, bead, ok := hookClaimExistingOrAssigned(candidates, *opts); ok {
+		return hookClaimResult{
+			terminal: true,
+			code:     writeHookClaimWorkResultForBead(result, bead, *opts, *ops, dir, stdout, stderr),
+		}
+	}
+
+	return claimFirstEligibleHookCandidate(candidates, *opts, *ops, dir, stdout, stderr)
+}
+
+func (ops *hookClaimOps) applyDefaults() {
 	if ops.Claim == nil {
 		ops.Claim = hookClaimWithBdStore
 	}
@@ -79,35 +132,12 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 	if ops.DrainAck == nil {
 		ops.DrainAck = hookRuntimeDrainAck
 	}
-	now := time.Now
-	if ops.Now != nil {
-		now = ops.Now
-	}
+}
 
-	output, err := ops.Runner(workQuery, dir)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck
-		return 1
-	}
-
-	normalized := normalizeWorkQueryOutput(strings.TrimSpace(output))
-	normalized = filterUnreadyHookCandidates(normalized, now())
-	if !workQueryHasReadyWork(normalized) {
-		return writeHookClaimNoWork(opts, ops, stdout, stderr)
-	}
-	candidates, err := decodeHookClaimBeads(normalized)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc hook --claim: requires JSON work_query output to identify claim candidates: %v\n", err) //nolint:errcheck
-		return 1
-	}
-	if len(candidates) == 0 {
-		return writeHookClaimNoWork(opts, ops, stdout, stderr)
-	}
-
-	if result, bead, ok := hookClaimExistingOrAssigned(candidates, opts); ok {
-		return writeHookClaimWorkResultForBead(result, bead, opts, ops, dir, stdout, stderr)
-	}
-
+// claimFirstEligibleHookCandidate claims the first unassigned, route-matched
+// candidate. It returns a non-terminal result without writing output when no
+// candidate can be claimed, allowing a federated caller to try another store.
+func claimFirstEligibleHookCandidate(candidates []beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stdout, stderr io.Writer) hookClaimResult {
 	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
 	defer cancel()
 	for _, candidate := range candidates {
@@ -119,7 +149,7 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 		claimed, ok, err := ops.Claim(ctx, dir, opts.Env, candidate.ID, opts.Assignee)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc hook --claim: claiming %s: %v\n", candidate.ID, err) //nolint:errcheck
-			return 1
+			return hookClaimResult{terminal: true, code: 1}
 		}
 		if !ok {
 			continue
@@ -143,10 +173,13 @@ func doHookClaim(workQuery, dir string, opts hookClaimOptions, ops hookClaimOps,
 		if result.Assignee == "" {
 			result.Assignee = opts.Assignee
 		}
-		return writeHookClaimWorkResultForBead(result, claimed, opts, ops, dir, stdout, stderr)
+		return hookClaimResult{
+			terminal: true,
+			code:     writeHookClaimWorkResultForBead(result, claimed, opts, ops, dir, stdout, stderr),
+		}
 	}
 
-	return writeHookClaimNoWork(opts, ops, stdout, stderr)
+	return hookClaimResult{}
 }
 
 func hookClaimExistingOrAssigned(candidates []beads.Bead, opts hookClaimOptions) (hookClaimJSONResult, beads.Bead, bool) {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -476,6 +476,183 @@ func TestDoHookClaimDrainAckOnNoWork(t *testing.T) {
 	}
 }
 
+// TestClaimHookWorkClaimsOnlyTheStoreSelectedByDiscovery is the regression for
+// colliding bead IDs across a rig and HQ. The routed-work query selects HQ, so
+// the mutation must use HQ's dir/env even though the agent's default work dir
+// is the rig and the same ID also exists there.
+func TestClaimHookWorkClaimsOnlyTheStoreSelectedByDiscovery(t *testing.T) {
+	stores := []hookStore{
+		{dir: "rig", env: []string{"GC_STORE=rig"}},
+		{dir: "hq", env: []string{"GC_STORE=hq"}},
+	}
+	var queryDirs []string
+	run := func(_, dir string, _ []string) (string, error) {
+		queryDirs = append(queryDirs, dir)
+		if dir == "hq" {
+			return `[{"id":"ac-3iv","status":"open","metadata":{"gc.routed_to":"polecat"}}]`, nil
+		}
+		// The rig also contains ac-3iv, but it is not routed to this polecat,
+		// so its work query correctly does not surface that duplicate.
+		return `[]`, nil
+	}
+	var claimDirs []string
+	var claimEnvs [][]string
+	ops := hookClaimOps{
+		Claim: func(_ context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimDirs = append(claimDirs, dir)
+			claimEnvs = append(claimEnvs, append([]string(nil), env...))
+			// Model the collision: either store would accept this ID. The
+			// orchestration must therefore choose the store, not the ID prefix.
+			return beads.Bead{
+				ID:       beadID,
+				Status:   "in_progress",
+				Assignee: assignee,
+				Metadata: map[string]string{"gc.routed_to": "polecat"},
+			}, true, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "kisakcod/gastown.polecat-1",
+		IdentityCandidates: []string{"kisakcod/gastown.polecat-1"},
+		RouteTargets:       []string{"polecat"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("bd ready --json", "rig", stores[0].env, stores, opts, ops, run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := strings.Join(queryDirs, ","); got != "rig,hq,hq" {
+		t.Fatalf("query dirs = %q, want rig,hq,hq (discovery then HQ re-validation)", got)
+	}
+	if got := strings.Join(claimDirs, ","); got != "hq" {
+		t.Fatalf("claim dirs = %q, want only hq; same-ID rig duplicate must remain untouched", got)
+	}
+	if len(claimEnvs) != 1 || len(claimEnvs[0]) != 1 || claimEnvs[0][0] != "GC_STORE=hq" {
+		t.Fatalf("claim envs = %v, want only [GC_STORE=hq]", claimEnvs)
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID != "ac-3iv" || result.Reason != "claimed" {
+		t.Fatalf("claim result = %+v, want ac-3iv claimed", result)
+	}
+}
+
+func TestClaimHookWorkFallsBackWhenSelectedStoreEmpties(t *testing.T) {
+	stores := []hookStore{
+		{dir: "city", env: []string{"GC_STORE=city"}},
+		{dir: "rig", env: []string{"GC_STORE=rig"}},
+	}
+	cityCalls := 0
+	run := func(_, dir string, _ []string) (string, error) {
+		switch dir {
+		case "city":
+			cityCalls++
+			if cityCalls == 1 {
+				return `[{"id":"city-1","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+			}
+			return `[]`, nil
+		case "rig":
+			return `[{"id":"rig-1","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+		default:
+			t.Fatalf("unexpected store dir %q", dir)
+			return "", nil
+		}
+	}
+	var claimDir string
+	var claimEnv []string
+	ops := hookClaimOps{
+		Claim: func(_ context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimDir = dir
+			claimEnv = append([]string(nil), env...)
+			return beads.Bead{
+				ID:       beadID,
+				Status:   "in_progress",
+				Assignee: assignee,
+				Metadata: map[string]string{"gc.routed_to": "worker"},
+			}, true, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("bd ready --json", "city", stores[0].env, stores, opts, ops, run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if claimDir != "rig" {
+		t.Fatalf("claim dir = %q, want rig fallback", claimDir)
+	}
+	if len(claimEnv) != 1 || claimEnv[0] != "GC_STORE=rig" {
+		t.Fatalf("claim env = %v, want [GC_STORE=rig]", claimEnv)
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID != "rig-1" || result.Reason != "claimed" {
+		t.Fatalf("claim result = %+v, want rig-1 claimed", result)
+	}
+}
+
+func TestClaimHookWorkRetriesLaterStoreAfterLostClaimRace(t *testing.T) {
+	stores := []hookStore{
+		{dir: "city", env: []string{"GC_STORE=city"}},
+		{dir: "rig", env: []string{"GC_STORE=rig"}},
+	}
+	run := func(_, dir string, _ []string) (string, error) {
+		return fmt.Sprintf(
+			`[{"id":"%s-1","status":"open","metadata":{"gc.routed_to":"worker"}}]`,
+			dir,
+		), nil
+	}
+	var claimDirs []string
+	ops := hookClaimOps{
+		Claim: func(_ context.Context, dir string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimDirs = append(claimDirs, dir)
+			if dir == "city" {
+				return beads.Bead{}, false, nil
+			}
+			return beads.Bead{
+				ID:       beadID,
+				Status:   "in_progress",
+				Assignee: assignee,
+				Metadata: map[string]string{"gc.routed_to": "worker"},
+			}, true, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("bd ready --json", "city", stores[0].env, stores, opts, ops, run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := strings.Join(claimDirs, ","); got != "city,rig" {
+		t.Fatalf("claim dirs = %q, want city,rig after lost city race", got)
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.BeadID != "rig-1" || result.Reason != "claimed" {
+		t.Fatalf("claim result = %+v, want rig-1 claimed after city race", result)
+	}
+}
+
 func TestDoHookClaimPreassignsContinuationGroupSiblings(t *testing.T) {
 	var assigned []string
 	runner := func(string, string) (string, error) {

--- a/cmd/gc/cross_store_pipeline_test.go
+++ b/cmd/gc/cross_store_pipeline_test.go
@@ -38,7 +38,7 @@ func TestCrossStorePipeline_ReadThenClaim(t *testing.T) {
 		return `[]`, nil
 	}
 
-	out, err := firstStoreWithWork("fake-query", stores, run)
+	out, _, err := firstStoreWithWork("fake-query", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("firstStoreWithWork: %v", err)
 	}

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -15,6 +15,11 @@ type hookStore struct {
 	env []string
 }
 
+// hookStoreRunner runs a work query against one federated store's dir and env.
+// Injectable so the cross-store selection and claim paths can be tested without
+// a real bd subprocess.
+type hookStoreRunner func(command, dir string, env []string) (string, error)
+
 // hookIdentityEnvKeys are the identity overrides that must stay constant across
 // every federated store attempt — the query always matches the agent's OWN
 // identity (gc.routed_to / assignee == this identity) regardless of which store
@@ -144,32 +149,86 @@ func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
 // normalize + unready-filter that doHook uses, so a store with only
 // deferred/blocked rows is not treated as a hit). run is injectable for tests.
 //
-// When no store has ready work, an error on the agent's OWN store (the first
-// entry) is surfaced so emitCityWorkQueryFailure can classify it — preserving
-// the single-store emit-on-timeout contract (a work-query timeout must reach
-// the reconciler, not be silently downgraded to "no work"). Errors from
-// federated rig stores are best-effort discovery (like appendRigHookStores)
-// and are not surfaced, so one flaky rig store can't wedge the hook.
-func firstStoreWithWork(command string, stores []hookStore, run func(command, dir string, env []string) (string, error)) (string, error) {
+// When no store has ready work, an error on the agent's OWN store (identified by
+// primary, not by slice position) is surfaced so emitCityWorkQueryFailure can
+// classify it — preserving the single-store emit-on-timeout contract (a
+// work-query timeout must reach the reconciler, not be silently downgraded to
+// "no work"). Errors from federated rig stores are best-effort discovery (like
+// appendRigHookStores) and are not surfaced, so one flaky rig store can't wedge
+// the hook. primary is matched by identity rather than position because the
+// federated claim loop reselects over a shrinking store set.
+func firstStoreWithWork(command string, stores []hookStore, primary hookStore, run hookStoreRunner) (string, hookStore, error) {
 	var lastOut string
 	var ownStoreOut string
 	var ownStoreErr error
-	for i, st := range stores {
+	for _, st := range stores {
 		out, err := run(command, st.dir, st.env)
 		if err == nil {
 			ready := filterUnreadyHookCandidates(normalizeWorkQueryOutput(strings.TrimSpace(out)), time.Now())
 			if workQueryHasReadyWork(ready) {
-				return out, nil
+				return out, st, nil
 			}
 			lastOut = out
 			continue
 		}
-		if i == 0 {
+		if sameHookStore(st, primary) {
 			ownStoreOut, ownStoreErr = out, err
 		}
 	}
 	if ownStoreErr != nil {
-		return ownStoreOut, ownStoreErr
+		return ownStoreOut, hookStore{}, ownStoreErr
 	}
-	return lastOut, nil
+	return lastOut, hookStore{}, nil
+}
+
+// claimStoreWithFallback re-validates the discovery-selected store for
+// claim-time freshness, then falls back to federated re-selection when that
+// store has emptied since discovery. The returned output and store are an
+// inseparable pair: the claim mutation must use that store's dir and env.
+func claimStoreWithFallback(command string, stores []hookStore, selected, primary hookStore, run hookStoreRunner) (string, hookStore, error) {
+	selectedOut, err := run(command, selected.dir, selected.env)
+	if err != nil {
+		if sameHookStore(selected, primary) {
+			return "", hookStore{}, err
+		}
+		return firstStoreWithWork(command, stores, primary, run)
+	}
+	ready := filterUnreadyHookCandidates(normalizeWorkQueryOutput(strings.TrimSpace(selectedOut)), time.Now())
+	if workQueryHasReadyWork(ready) {
+		return selectedOut, selected, nil
+	}
+	return firstStoreWithWork(command, stores, primary, run)
+}
+
+// isZeroHookStore reports whether s is the zero hookStore returned when no
+// federated store has ready work.
+func isZeroHookStore(s hookStore) bool {
+	return strings.TrimSpace(s.dir) == "" && len(s.env) == 0
+}
+
+// removeHookStore drops the first entry equal to target. The claim loop uses
+// this after losing a mutation race so the next selection must make progress.
+func removeHookStore(stores []hookStore, target hookStore) []hookStore {
+	out := make([]hookStore, 0, len(stores))
+	removed := false
+	for _, s := range stores {
+		if !removed && sameHookStore(s, target) {
+			removed = true
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func sameHookStore(a, b hookStore) bool {
+	if a.dir != b.dir || len(a.env) != len(b.env) {
+		return false
+	}
+	for i := range a.env {
+		if a.env[i] != b.env[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -77,12 +77,15 @@ func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
 		}
 		return `[]`, nil
 	}
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if out != `[{"id":"va-1"}]` {
 		t.Fatalf("out = %q, want riga work", out)
+	}
+	if gotStore.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga", gotStore.dir)
 	}
 	// Stops at the first store with work — does not query rigb.
 	if len(calls) != 2 || calls[0] != "city" || calls[1] != "riga" {
@@ -93,12 +96,15 @@ func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
 func TestFirstStoreWithWorkReturnsLastWhenNoneHasWork(t *testing.T) {
 	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
 	run := func(_, _ string, _ []string) (string, error) { return `[]`, nil }
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if out != `[]` {
 		t.Fatalf("out = %q, want []", out)
+	}
+	if !isZeroHookStore(gotStore) {
+		t.Fatalf("store = %#v, want zero value when no work is found", gotStore)
 	}
 }
 
@@ -113,7 +119,7 @@ func TestFirstStoreWithWorkSurfacesOwnStoreErrorWhenNoWork(t *testing.T) {
 		}
 		return `[]`, nil
 	}
-	if _, err := firstStoreWithWork("q", stores, run); !errors.Is(err, errTestStoreTimeout) {
+	if _, _, err := firstStoreWithWork("q", stores, stores[0], run); !errors.Is(err, errTestStoreTimeout) {
 		t.Fatalf("own-store error must be surfaced when no store has work; got %v", err)
 	}
 }
@@ -128,12 +134,15 @@ func TestFirstStoreWithWorkIgnoresRigStoreErrorWhenOwnStoreHasNoWork(t *testing.
 		}
 		return "", errTestStoreTimeout
 	}
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("rig-store error must not surface when own store is healthy; got %v", err)
 	}
 	if out != `[]` {
 		t.Fatalf("out = %q, want city store's no-work output", out)
+	}
+	if !isZeroHookStore(gotStore) {
+		t.Fatalf("store = %#v, want zero value when no work is found", gotStore)
 	}
 }
 
@@ -146,11 +155,14 @@ func TestFirstStoreWithWorkSkipsStoreWithOnlyUnreadyRows(t *testing.T) {
 		}
 		return `[{"id":"va-2"}]`, nil
 	}
-	out, err := firstStoreWithWork("q", stores, run)
+	out, gotStore, err := firstStoreWithWork("q", stores, stores[0], run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if out != `[{"id":"va-2"}]` {
 		t.Fatalf("out = %q, want riga work (city row was unready)", out)
+	}
+	if gotStore.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga", gotStore.dir)
 	}
 }


### PR DESCRIPTION
Backport the selected-store provenance and claim-time fallback fixes from
#3783/#3785 to `release/v1.3.0`.

## Problem

v1.3 federates hook work queries across city and rig stores, but
`firstStoreWithWork` returns only the selected store's JSON. `doHookClaim` then
applies the mutation through the agent's default work directory/environment
rather than the store that produced those rows.

When the same bead ID exists in more than one store, discovery and mutation can
therefore address different physical records while still returning a successful
claim receipt. Current `main` carries the corrected behavior; v1.3 does not.

## Change

- return the selected `hookStore` with its captured work-query output;
- revalidate that store immediately before claiming;
- pass the captured rows and exact store directory/environment into
  `doHookClaim`;
- reselect across federated stores if the selected store empties;
- continue to later stores when every eligible mutation in one store loses its
  claim race, then emit one final no-work result; and
- preserve primary-store identity as the candidate set shrinks, so primary
  failures remain visible while secondary failures remain best-effort.

The implementation follows #3785 while adapting it to the v1.3 hook/claim code
shape.

## Regression coverage

The cross-store regression creates colliding IDs in two stores, makes discovery
select the non-default store, and proves the only claim mutation uses that
store's directory and environment.

Additional cases cover:

- a selected store emptying before claim-time revalidation;
- a selected store losing its mutation race and falling back;
- selected-store provenance from `firstStoreWithWork`; and
- primary-store error semantics after candidate-set shrinkage.

## Validation

- focused hook/cross-store regression suite
- `go test ./cmd/gc -count=1`
- `go vet ./cmd/gc/...`
- `go build -buildvcs=false ./cmd/gc/...`
- `git diff --check`

The recurring v1.3 integration bootstrap failures are tracked separately in
#4625; this diff does not touch that path.
