### PR TITLE
fix(dispatch,sling): make the exclusive-drain reservation load-bearing across both dispatch entry points

### DIFF
--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -113,7 +113,7 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 	if manifest.Context == beadmeta.DrainContextShared {
 		return advanceSharedDrain(store, bead, manifest, members, itemFormula, parentVars, opts)
 	}
-	if err := reserveDrainMembers(store, bead, members, opts); err != nil {
+	if err := reserveDrainMembers(store, bead, members, parentConvoyID, opts); err != nil {
 		if retryableDrainReservationError(err) {
 			return ControlResult{}, fmt.Errorf("%s: reserving drain members (retrying next pass): %w", bead.ID, err)
 		}
@@ -516,7 +516,7 @@ func advanceSharedDrain(store beads.Store, bead beads.Bead, manifest drainManife
 			return ControlResult{}, fmt.Errorf("%s: shared drain manifest/member length mismatch", bead.ID)
 		}
 		member := members[i]
-		if err := reserveDrainMember(store, bead, member, opts); err != nil {
+		if err := reserveDrainMember(store, bead, member, manifest.ParentConvoyID, opts); err != nil {
 			if retryableDrainReservationError(err) {
 				return ControlResult{}, fmt.Errorf("%s: reserving drain member %s (retrying next pass): %w", bead.ID, member.ID, err)
 			}
@@ -1224,13 +1224,55 @@ func (e drainReservationError) Error() string {
 	return fmt.Sprintf("%s: member %s already reserved by drain %s", e.ControlID, e.MemberID, e.Owner)
 }
 
+// drainCompetingDispatchError reports that an exclusive drain refused to take a
+// member because a NON-drain dispatch is already live on it. It is the mirror
+// of drainReservationError: that one excludes a competing drain (which leaves a
+// reservation), this one excludes a competing fresh/root dispatch (which does
+// not). Without it the ordering decides the outcome — drain-first is guarded by
+// the sling-side reservation veto, dispatch-first would sail through — and
+// "exclusive" would mean "exclusive only when the drain happened to arrive
+// first".
+type drainCompetingDispatchError struct {
+	ControlID string
+	MemberID  string
+	// Signature is a human-readable description of the live executor found
+	// (the open synthetic input convoy).
+	Signature string
+}
+
+func (e drainCompetingDispatchError) Error() string {
+	return fmt.Sprintf("%s: member %s already has a live dispatch (%s); exclusive drain access refused",
+		e.ControlID, e.MemberID, e.Signature)
+}
+
+// drainCompetitorProbeError wraps a store failure while checking a member for a
+// competing dispatch. It is deliberately RETRYABLE (see
+// retryableDrainReservationError): a transient convoy-listing failure must make
+// the drain wait and re-probe on the next level-triggered pass, never proceed
+// blind — proceeding-on-read-failure is the advisory posture that let the
+// dip-tlbizd double-dispatch happen. A persistent failure keeps the drain
+// visibly stuck-expanding, which is the loud signal a real store problem
+// warrants.
+type drainCompetitorProbeError struct {
+	MemberID string
+	Err      error
+}
+
+func (e drainCompetitorProbeError) Error() string {
+	return fmt.Sprintf("probing drain member %s for a competing dispatch: %v", e.MemberID, e.Err)
+}
+
+func (e drainCompetitorProbeError) Unwrap() error { return e.Err }
+
 // reserveDrainMember claims a member for exclusive drain access by stamping the
 // reservation metadata on the member bead. The member is a work bead that may
 // live in the work-class store rather than the primary graph store, so both the
 // reservation read and write route to the member's owning store
 // (drainMemberOwningStore). On origin/main the owning store is the single store,
 // matching the pre-seam store.Get/store.SetMetadata behavior exactly.
-func reserveDrainMember(store beads.Store, control, member beads.Bead, opts ProcessOptions) error {
+// ownConvoyID is the drain's own input/parent convoy, skipped by the
+// competing-dispatch probe (see refuseCompetingDrainDispatch).
+func reserveDrainMember(store beads.Store, control, member beads.Bead, ownConvoyID string, opts ProcessOptions) error {
 	if drainMemberAccess(control) != beadmeta.DrainMemberAccessExclusive {
 		return nil
 	}
@@ -1252,7 +1294,69 @@ func reserveDrainMember(store beads.Store, control, member beads.Bead, opts Proc
 	if owner == control.ID {
 		return nil
 	}
+	if err := refuseCompetingDrainDispatch(store, control, member, ownConvoyID); err != nil {
+		return err
+	}
 	return claimDrainReservation(memberStore, control, member)
+}
+
+// refuseCompetingDrainDispatch fails the exclusive claim when the member is
+// already being executed by a fresh/root formula dispatch — one that leaves no
+// reservation to compare against. Its on-graph signature is an OPEN synthetic
+// input convoy (gc.synthetic=true, "input convoy for <bead>") tracking the
+// member, driven by a workflow root; that is exactly what the dip-tlbizd
+// incident's second lane left on the member anchor.
+//
+// Two convoy shapes are NOT competitors and are skipped:
+//
+//   - ownConvoyID, the drain's OWN input/parent convoy. It tracks every member
+//     by construction (the drain drains its members), so it would otherwise
+//     self-veto every exclusive drain whose parent convoy is synthetic (e.g. a
+//     drain launched by a single-bead formula). This is the load-bearing
+//     exclusion; without it the guard is a self-inflicted deadlock.
+//   - Drain-unit convoys (gc.drain_control_id set): the drain-side dispatch
+//     shape. A competing DRAIN is already excluded by the reservation owner
+//     check above; this function only covers the entry point with no
+//     reservation to compare.
+//
+// Scope note: this recognizes the formula/workflow dispatch signature (a
+// synthetic convoy), which is the incident shape. A PLAIN --no-formula route,
+// which leaves no synthetic convoy, is not detected dispatch-first here — see
+// the Remaining Risks in the fix's proof doc. The drain-FIRST ordering for all
+// dispatch shapes is fully covered by the sling-side reservation veto.
+//
+// A convoy-listing failure returns a RETRYABLE drainCompetitorProbeError rather
+// than proceeding: read-failure-means-proceed is the advisory posture the
+// incident indicted. The drain waits and re-probes next pass.
+func refuseCompetingDrainDispatch(store beads.Store, control, member beads.Bead, ownConvoyID string) error {
+	if store == nil || strings.TrimSpace(member.ID) == "" {
+		return nil
+	}
+	convoys, err := convoycore.TrackingConvoysForItem(store, member.ID)
+	if err != nil {
+		return drainCompetitorProbeError{MemberID: member.ID, Err: err}
+	}
+	ownConvoyID = strings.TrimSpace(ownConvoyID)
+	for _, c := range convoys {
+		if c.ID == ownConvoyID {
+			continue
+		}
+		if convoycore.IsTerminalStatus(c.Status) || beads.HasReadyExcludedLabel(c) {
+			continue
+		}
+		if strings.TrimSpace(c.Metadata[beadmeta.SyntheticMetadataKey]) != "true" {
+			continue
+		}
+		if strings.TrimSpace(c.Metadata[beadmeta.DrainControlIDMetadataKey]) != "" {
+			continue
+		}
+		return drainCompetingDispatchError{
+			ControlID: control.ID,
+			MemberID:  member.ID,
+			Signature: fmt.Sprintf("open workflow input convoy %s", c.ID),
+		}
+	}
+	return nil
 }
 
 // claimDrainReservation claims the empty reservation slot. When the member's
@@ -1317,9 +1421,9 @@ func claimDrainReservationCAS(memberStore beads.Store, writer beads.ConditionalW
 	return fmt.Errorf("%s: reserving drain member %s: %w", control.ID, member.ID, lastErr)
 }
 
-func reserveDrainMembers(store beads.Store, control beads.Bead, members []beads.Bead, opts ProcessOptions) error {
+func reserveDrainMembers(store beads.Store, control beads.Bead, members []beads.Bead, ownConvoyID string, opts ProcessOptions) error {
 	for _, member := range members {
-		if err := reserveDrainMember(store, control, member, opts); err != nil {
+		if err := reserveDrainMember(store, control, member, ownConvoyID, opts); err != nil {
 			return err
 		}
 	}
@@ -1414,6 +1518,20 @@ func retryableDrainReservationError(err error) bool {
 	if errors.As(err, &re) {
 		return false
 	}
+	var cd drainCompetingDispatchError
+	if errors.As(err, &cd) {
+		// A live competing dispatch is a verdict, not contention: retrying
+		// would just re-observe the same convoy until the drain's own
+		// level-triggered passes burned out on it.
+		return false
+	}
+	var probe drainCompetitorProbeError
+	if errors.As(err, &probe) {
+		// A store failure while probing for a competitor is transient by
+		// intent — retry next pass rather than fail the drain or (worse)
+		// proceed blind past an unread competitor.
+		return true
+	}
 	if beads.IsConditionalWritesRequired(err) {
 		return false
 	}
@@ -1434,6 +1552,17 @@ func closeDrainReservationFailure(store beads.Store, bead beads.Bead, manifest d
 		metadata[beadmeta.FailureReasonMetadataKey] = "exclusive_reservation_conflict"
 		metadata[beadmeta.FailureSubjectMetadataKey] = reservationErr.MemberID
 		metadata[beadmeta.FailureOwnerMetadataKey] = reservationErr.Owner
+	}
+	var competingErr drainCompetingDispatchError
+	if errors.As(err, &competingErr) {
+		// Distinct reason from the drain-vs-drain conflict above: the owner is
+		// a live foreign dispatch (a convoy or a claim), not a
+		// reservation-holding drain, so triage looks at the named signature
+		// rather than a control bead.
+		failureReason = "exclusive_dispatch_conflict"
+		metadata[beadmeta.FailureReasonMetadataKey] = failureReason
+		metadata[beadmeta.FailureSubjectMetadataKey] = competingErr.MemberID
+		metadata[beadmeta.FailureOwnerMetadataKey] = competingErr.Signature
 	}
 	if closeErr := closeOpenDrainItemRoots(store, &manifest, failureReason); closeErr != nil {
 		return ControlResult{}, fmt.Errorf("%s: closing partial drain item roots after %w: %w", bead.ID, err, closeErr)

--- a/internal/dispatch/drain_competing_dispatch_test.go
+++ b/internal/dispatch/drain_competing_dispatch_test.go
@@ -1,0 +1,220 @@
+package dispatch
+
+// The mirror half of the dip-tlbizd fix. The sling-side veto
+// (internal/sling.CheckExclusiveDrainReservation) covers drain-first ordering:
+// the drain reserves, a later fresh dispatch is refused. These tests cover
+// dispatch-first ordering — a fresh/root workflow is already live on the anchor
+// when the drain arrives — which the reservation alone cannot see, because a
+// fresh dispatch leaves no reservation to compare against. Without this the
+// exclusivity guarantee would be decided by arrival order.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+)
+
+// graph.v2 formula compilation defaults on (set in the formula package's init)
+// and no test in this package turns it off, so these tests rely on that default
+// rather than the legacy process-global formula_v2 test setters — the coupling
+// internal/testenv/legacy_flag_freeze_test.go freezes.
+
+// seedLiveFreshDispatch reproduces what the incident's second lane left on the
+// member anchor: an OPEN synthetic input convoy tracking it (dip-l93ikp,
+// "input convoy for dip-3812vr", gc.synthetic=true) driven by a workflow root.
+func seedLiveFreshDispatch(t *testing.T, store *beads.MemStore, memberID string) beads.Bead {
+	t.Helper()
+	convoy, err := store.Create(beads.Bead{
+		Title:    "input convoy for " + memberID,
+		Type:     "convoy",
+		Metadata: map[string]string{"gc.synthetic": "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := convoycore.TrackItem(store, convoy.ID, memberID); err != nil {
+		t.Fatal(err)
+	}
+	return convoy
+}
+
+func TestExclusiveDrainRefusesMemberWithLiveFreshDispatch(t *testing.T) {
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+	if err := store.SetMetadata(drain.ID, "gc.drain_member_access", "exclusive"); err != nil {
+		t.Fatalf("SetMetadata(exclusive): %v", err)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+
+	members := drainMemberIDs(t, store, drain)
+	convoy := seedLiveFreshDispatch(t, store, members[0])
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(competing dispatch): %v", err)
+	}
+	if result.Action != "drain-reservation-failed" {
+		t.Fatalf("Action = %q, want drain-reservation-failed", result.Action)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+	if drain.Status != "closed" || drain.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("drain = status %q outcome %q, want closed/fail", drain.Status, drain.Metadata["gc.outcome"])
+	}
+	if got := drain.Metadata["gc.failure_reason"]; got != "exclusive_dispatch_conflict" {
+		t.Fatalf("gc.failure_reason = %q, want exclusive_dispatch_conflict", got)
+	}
+	if got := drain.Metadata["gc.failure_subject"]; got != members[0] {
+		t.Fatalf("gc.failure_subject = %q, want the contended member %s", got, members[0])
+	}
+	if got := drain.Metadata["gc.failure_owner"]; !strings.Contains(got, convoy.ID) {
+		t.Fatalf("gc.failure_owner = %q, want it to name the live convoy %s", got, convoy.ID)
+	}
+	// The drain must not have stamped itself onto work it refused.
+	member := mustGetBead(t, store, members[0])
+	if got := strings.TrimSpace(member.Metadata["gc.exclusive_drain_reservation"]); got != "" {
+		t.Fatalf("reservation = %q, want empty: the drain reserved a member it refused", got)
+	}
+}
+
+// TestExclusiveDrainToleratesNonSyntheticTrackingConvoy pins the guard's blast
+// radius on the signal that would otherwise fire constantly: every drain member
+// is tracked by the drain's own (hand-made, non-synthetic) parent convoy.
+func TestExclusiveDrainToleratesNonSyntheticTrackingConvoy(t *testing.T) {
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+	if err := store.SetMetadata(drain.ID, "gc.drain_member_access", "exclusive"); err != nil {
+		t.Fatalf("SetMetadata(exclusive): %v", err)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+	members := drainMemberIDs(t, store, drain)
+
+	// A second ordinary convoy also tracking the member: not a dispatch.
+	extra, err := store.Create(beads.Bead{Title: "planning convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := convoycore.TrackItem(store, extra.ID, members[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil {
+		t.Fatalf("ProcessControl(non-synthetic tracker): %v", err)
+	}
+	member := mustGetBead(t, store, members[0])
+	if got := strings.TrimSpace(member.Metadata["gc.exclusive_drain_reservation"]); got != drain.ID {
+		t.Fatalf("reservation = %q, want %s: an ordinary tracking convoy must not block the drain", got, drain.ID)
+	}
+}
+
+// TestExclusiveDrainToleratesClosedFreshDispatch proves a finished lane does not
+// wedge the drain forever: a terminal input convoy is not a live dispatch.
+func TestExclusiveDrainToleratesClosedFreshDispatch(t *testing.T) {
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+	if err := store.SetMetadata(drain.ID, "gc.drain_member_access", "exclusive"); err != nil {
+		t.Fatalf("SetMetadata(exclusive): %v", err)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+	members := drainMemberIDs(t, store, drain)
+
+	convoy := seedLiveFreshDispatch(t, store, members[0])
+	closed := "closed"
+	if err := store.Update(convoy.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("close input convoy: %v", err)
+	}
+
+	if _, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil {
+		t.Fatalf("ProcessControl(closed fresh dispatch): %v", err)
+	}
+	member := mustGetBead(t, store, members[0])
+	if got := strings.TrimSpace(member.Metadata["gc.exclusive_drain_reservation"]); got != drain.ID {
+		t.Fatalf("reservation = %q, want %s: a closed input convoy is not a live dispatch", got, drain.ID)
+	}
+}
+
+// TestExclusiveDrainDoesNotSelfCollideOnSyntheticParentConvoy is the critical
+// regression: the drain's OWN parent convoy tracks every member, so if that
+// convoy is synthetic (e.g. a drain launched by a single-bead formula) a naive
+// competing-dispatch scan would flag it and the drain would kill itself on
+// every member. The own-convoy exclusion must prevent that.
+func TestExclusiveDrainDoesNotSelfCollideOnSyntheticParentConvoy(t *testing.T) {
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+	if err := store.SetMetadata(drain.ID, "gc.drain_member_access", "exclusive"); err != nil {
+		t.Fatalf("SetMetadata(exclusive): %v", err)
+	}
+	// Make the drain's own parent convoy synthetic — the self-collision trap.
+	parentConvoyID := drainParentConvoyID(t, store, mustGetBead(t, store, drain.ID))
+	if err := store.SetMetadata(parentConvoyID, "gc.synthetic", "true"); err != nil {
+		t.Fatalf("SetMetadata(synthetic parent): %v", err)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+	members := drainMemberIDs(t, store, drain)
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(synthetic parent): %v", err)
+	}
+	if result.Action == "drain-reservation-failed" {
+		t.Fatalf("the drain self-vetoed on its own synthetic parent convoy %s", parentConvoyID)
+	}
+	member := mustGetBead(t, store, members[0])
+	if got := strings.TrimSpace(member.Metadata["gc.exclusive_drain_reservation"]); got != drain.ID {
+		t.Fatalf("reservation = %q, want %s: the drain must reserve its own members", got, drain.ID)
+	}
+}
+
+// drainParentConvoyID returns the drain's input/parent convoy ID.
+func drainParentConvoyID(t *testing.T, store *beads.MemStore, drain beads.Bead) string {
+	t.Helper()
+	root := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	id := strings.TrimSpace(root.Metadata["gc.input_convoy_id"])
+	if id == "" {
+		t.Fatal("drain root has no gc.input_convoy_id")
+	}
+	return id
+}
+
+// TestReadDrainIgnoresLiveFreshDispatch confirms the guard is scoped to
+// exclusive drains. A read-access drain shares its members by design.
+func TestReadDrainIgnoresLiveFreshDispatch(t *testing.T) {
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t) // seeded with gc.drain_member_access: read
+	members := drainMemberIDs(t, store, drain)
+	seedLiveFreshDispatch(t, store, members[0])
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(read drain): %v", err)
+	}
+	if result.Action == "drain-reservation-failed" {
+		t.Fatal("a read-access drain must not be refused for a competing dispatch")
+	}
+}
+
+// drainMemberIDs returns the member anchors of drain's input convoy, in
+// manifest order.
+func drainMemberIDs(t *testing.T, store *beads.MemStore, drain beads.Bead) []string {
+	t.Helper()
+	root := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	convoyID := strings.TrimSpace(root.Metadata["gc.input_convoy_id"])
+	items, err := convoycore.Members(store, convoyID, false)
+	if err != nil {
+		t.Fatalf("Members(%s): %v", convoyID, err)
+	}
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	if len(ids) == 0 {
+		t.Fatalf("convoy %s tracks no members", convoyID)
+	}
+	return ids
+}

--- a/internal/dispatch/drain_conditional_test.go
+++ b/internal/dispatch/drain_conditional_test.go
@@ -109,7 +109,7 @@ func TestReserveDrainMemberCASContention(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			results[i] = reserveDrainMember(store, controls[i], member, ProcessOptions{})
+			results[i] = reserveDrainMember(store, controls[i], member, "", ProcessOptions{})
 		}()
 	}
 	wg.Wait()
@@ -145,7 +145,7 @@ func TestReserveDrainMemberCASReentryIsIdempotent(t *testing.T) {
 	store := newStampedDrainStore(t, gate.Auto)
 	control, member := newDrainReservationFixtures(t, store)
 	for i := range 2 {
-		if err := reserveDrainMember(store, control, member, ProcessOptions{}); err != nil {
+		if err := reserveDrainMember(store, control, member, "", ProcessOptions{}); err != nil {
 			t.Fatalf("reserve #%d: %v (re-entry must be success, not skip)", i+1, err)
 		}
 	}
@@ -159,7 +159,7 @@ func TestReserveDrainMemberRequireIncapableFailsClosed(t *testing.T) {
 	store.DisableConditionalWrites = true
 	control, member := newDrainReservationFixtures(t, store)
 
-	err := reserveDrainMember(store, control, member, ProcessOptions{})
+	err := reserveDrainMember(store, control, member, "", ProcessOptions{})
 	if !beads.IsConditionalWritesRequired(err) {
 		t.Fatalf("err = %v, want the typed require refusal", err)
 	}
@@ -239,7 +239,7 @@ func TestReleaseDrainReservationCAS(t *testing.T) {
 	t.Run("owner clears its own reservation", func(t *testing.T) {
 		store := newStampedDrainStore(t, gate.Auto)
 		control, member := newDrainReservationFixtures(t, store)
-		if err := reserveDrainMember(store, control, member, ProcessOptions{}); err != nil {
+		if err := reserveDrainMember(store, control, member, "", ProcessOptions{}); err != nil {
 			t.Fatalf("reserve: %v", err)
 		}
 		if err := releaseDrainReservation(store, "drain-a", member.ID); err != nil {

--- a/internal/sling/exclusive_drain.go
+++ b/internal/sling/exclusive_drain.go
@@ -1,0 +1,94 @@
+package sling
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// ExclusiveDrainReservationError reports that a sling was refused because the
+// target bead is held under an exclusive drain reservation
+// (gc.exclusive_drain_reservation) by a live drain control.
+//
+// A drain declaring gc.drain_member_access: exclusive stamps its control ID on
+// every member anchor it expands and clears it when the drain reaches a
+// terminal state. Until then that member has exactly one dispatch authority —
+// the drain — and the drain builds its own unit convoy and item root over it
+// (internal/dispatch.ensureDrainUnitConvoy / ensureDrainItemRoot), never
+// through DoSling. So a sling that names a reserved member is, by construction,
+// a SECOND executor for work a drain is already running: the exact shape of the
+// dip-tlbizd incident, where a drain unit and a fresh formula-backed dispatch
+// both drove one anchor in one shared build tree, producing duplicate
+// implementations and unattributable interleaved commits.
+//
+// Before this check the reservation was advisory: it was read only by other
+// drains (reserveDrainMember's owner comparison), so nothing outside
+// internal/dispatch consulted it and the fresh-dispatch entry point sailed past
+// it. --force remains the deliberate double-dispatch escape hatch.
+type ExclusiveDrainReservationError struct {
+	BeadID string
+	// ControlID is the drain control holding the reservation.
+	ControlID string
+	// ControlStatus/ControlTitle describe the holder when it could be read;
+	// both are empty when the control bead is unreadable from here (a
+	// cross-store holder, or a transient store error). They enrich the
+	// diagnostic only — they do not gate the veto.
+	ControlStatus string
+	ControlTitle  string
+}
+
+func (e *ExclusiveDrainReservationError) Error() string {
+	holder := e.ControlID
+	if e.ControlTitle != "" {
+		holder = fmt.Sprintf("%s (%q)", e.ControlID, e.ControlTitle)
+	}
+	suffix := ""
+	if e.ControlStatus == "closed" || e.ControlStatus == "tombstone" {
+		// A reservation on a terminated control is abnormal — a normal drain
+		// releases before closing — so name it: this is a stuck reservation to
+		// clear, not a lane to wait on.
+		suffix = fmt.Sprintf(" (holder is %s — a stale reservation; clear it or --force)", e.ControlStatus)
+	}
+	return fmt.Sprintf(
+		"bead %s is reserved for exclusive drain access by drain %s: routing it again would put a second executor on work that drain is already running (%s=%s)%s; wait for the drain, or re-run with --force to accept the double dispatch",
+		e.BeadID, holder, beadmeta.ExclusiveDrainReservationMetadataKey, e.ControlID, suffix)
+}
+
+// CheckExclusiveDrainReservation reports whether beadID currently carries an
+// exclusive drain reservation, returning a typed *ExclusiveDrainReservationError
+// naming the holder, or nil.
+//
+// The presence of gc.exclusive_drain_reservation is itself the veto: a drain
+// releases every reservation BEFORE it closes (releaseDrainReservations runs
+// ahead of updateMetadataAndClose), so a normally-finished drain leaves an empty
+// slot and no veto. A reservation that is still present therefore means either a
+// live drain (holder open) or a drain that terminated WITHOUT releasing (holder
+// closed/tombstoned) — and in the latter case an item-root worker the drain
+// spawned may well still be executing the member. Neither is safe to
+// double-dispatch, so the veto holds regardless of holder status; --force is the
+// deliberate override, and the message flags a terminated holder as a stale
+// reservation to clear rather than a lane to wait on. The holder is read only to
+// enrich that message, so an unreadable (e.g. cross-store) control never
+// downgrades the veto.
+//
+// An unreadable TARGET bead degrades to no veto: it carries no reservation we
+// can see, and preflight's own existence check (validateExistingBead) owns the
+// missing-bead diagnostic.
+func CheckExclusiveDrainReservation(q BeadQuerier, store beads.Store, beadID string) error {
+	b, ok := BeadFromGetters(beadID, q, store)
+	if !ok {
+		return nil
+	}
+	controlID := strings.TrimSpace(b.Metadata[beadmeta.ExclusiveDrainReservationMetadataKey])
+	if controlID == "" {
+		return nil
+	}
+	err := &ExclusiveDrainReservationError{BeadID: beadID, ControlID: controlID}
+	if control, found := BeadFromGetters(controlID, q, store); found {
+		err.ControlStatus = control.Status
+		err.ControlTitle = control.Title
+	}
+	return err
+}

--- a/internal/sling/exclusive_drain_repro_test.go
+++ b/internal/sling/exclusive_drain_repro_test.go
@@ -1,0 +1,349 @@
+package sling
+
+// Reproduction of the dip-tlbizd incident (2026-07-16): a drain declaring
+// gc.drain_member_access: exclusive expanded over member anchor dip-3812vr
+// while the PL's post-exhaustion re-dispatch launched a second, independent
+// workflow over the SAME anchor. Both lanes ran in one shared build tree,
+// wrote duplicate ~450-line implementations, and interleaved commits so badly
+// that git attribution across three SHAs became unreliable. "Exclusive" did
+// not exclude.
+//
+// These tests drive the REAL drain machinery (internal/dispatch.ProcessControl)
+// to produce the reservation, then the REAL sling entry point (DoSling) against
+// the reserved member — the two dispatch entry points, end to end, in one
+// store. They are the proof asked for by sc-471fl5: not formula-reading, an
+// executed refusal.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/dispatch"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// graph.v2 formula compilation defaults on (set in the formula package's init),
+// and no test in this package turns it off, so these tests rely on that default
+// rather than the legacy process-global formula_v2 test setters — the coupling
+// internal/testenv/legacy_flag_freeze_test.go freezes.
+
+// writeReproDrainItemFormula writes the minimal graph.v2 item formula a drain
+// instantiates per member.
+func writeReproDrainItemFormula(t *testing.T, dir string) {
+	t.Helper()
+	content := `formula = "drain-item"
+version = 1
+contract = "graph.v2"
+type = "workflow"
+
+[[steps]]
+id = "work"
+title = "Work {{convoy_id}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "drain-item.formula.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write drain item formula: %v", err)
+	}
+}
+
+// seedExclusiveDrain builds the incident's graph shape: a parent convoy
+// tracking one member anchor, a graph.v2 workflow root over that convoy, and a
+// drain control declaring exclusive member access. It returns the store, the
+// drain control, and the member anchor ID.
+func seedExclusiveDrain(t *testing.T) (*beads.MemStore, beads.Bead, string) {
+	t.Helper()
+	store := beads.NewMemStore()
+	parent, err := store.Create(beads.Bead{Title: "parent", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := store.Create(beads.Bead{Title: "member anchor", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := convoycore.TrackItem(store, parent.ID, member.ID); err != nil {
+		t.Fatal(err)
+	}
+	root, err := store.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.input_convoy_id":  parent.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drain, err := store.Create(beads.Bead{
+		Title: "Drain continuation implementation convoy",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                "drain",
+			"gc.root_bead_id":        root.ID,
+			"gc.drain_context":       "separate",
+			"gc.drain_formula":       "drain-item",
+			"gc.drain_member_access": "exclusive",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, drain, member.ID
+}
+
+// expandExclusiveDrain runs the drain to expansion and returns it reloaded.
+func expandExclusiveDrain(t *testing.T, store *beads.MemStore, drain beads.Bead) beads.Bead {
+	t.Helper()
+	dir := t.TempDir()
+	writeReproDrainItemFormula(t, dir)
+	if _, err := dispatch.ProcessControl(store, drain, dispatch.ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil {
+		t.Fatalf("ProcessControl(drain expand): %v", err)
+	}
+	reloaded, err := store.Get(drain.ID)
+	if err != nil {
+		t.Fatalf("reload drain: %v", err)
+	}
+	return reloaded
+}
+
+func mustReservation(t *testing.T, store *beads.MemStore, memberID string) string {
+	t.Helper()
+	member, err := store.Get(memberID)
+	if err != nil {
+		t.Fatalf("reload member: %v", err)
+	}
+	return strings.TrimSpace(member.Metadata["gc.exclusive_drain_reservation"])
+}
+
+func reproSlingDeps(t *testing.T, store beads.Store) (SlingDeps, config.Agent, *fakeRunner) {
+	t.Helper()
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+	return deps, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, runner
+}
+
+// TestExclusiveDrainReservationRefusesFreshDispatch is the incident
+// reproduction. Entry point 1 (drain-unit dispatch) takes the reservation;
+// entry point 2 (fresh/root dispatch through DoSling) is refused by it. Before
+// this guard the second sling succeeded and both lanes ran the anchor.
+func TestExclusiveDrainReservationRefusesFreshDispatch(t *testing.T) {
+	store, drain, memberID := seedExclusiveDrain(t)
+
+	// Entry point 1: the drain reserves the member as it expands.
+	expandExclusiveDrain(t, store, drain)
+	if got := mustReservation(t, store, memberID); got != drain.ID {
+		t.Fatalf("gc.exclusive_drain_reservation = %q, want %s (the drain never took the reservation)", got, drain.ID)
+	}
+
+	// Entry point 2: a fresh dispatch of the same anchor must be refused.
+	deps, a, runner := reproSlingDeps(t, store)
+	convoysBefore := trackingConvoyIDs(t, store, memberID)
+	_, err := DoSling(testOpts(a, memberID), deps, nil)
+	var resErr *ExclusiveDrainReservationError
+	if !errors.As(err, &resErr) {
+		t.Fatalf("DoSling(reserved member) error = %v, want *ExclusiveDrainReservationError", err)
+	}
+	if resErr.BeadID != memberID || resErr.ControlID != drain.ID {
+		t.Fatalf("error = %+v, want BeadID %s / ControlID %s", resErr, memberID, drain.ID)
+	}
+	if resErr.ControlStatus == "" {
+		t.Errorf("ControlStatus is empty; the refusal must name the live holder's state")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner was invoked %d times; a refused sling must dispatch nothing", len(runner.calls))
+	}
+
+	// The refusal must not mutate: no second dispatch authority is minted (the
+	// only convoy tracking the anchor is still the drain's own unit), and the
+	// drain keeps its reservation.
+	if got := trackingConvoyIDs(t, store, memberID); !slices.Equal(got, convoysBefore) {
+		t.Fatalf("tracking convoys = %v, want %v unchanged: the refused sling minted a dispatch anyway", got, convoysBefore)
+	}
+	if got := mustReservation(t, store, memberID); got != drain.ID {
+		t.Fatalf("reservation after refusal = %q, want %s intact", got, drain.ID)
+	}
+}
+
+// trackingConvoyIDs returns the sorted IDs of every convoy tracking itemID.
+func trackingConvoyIDs(t *testing.T, store beads.Store, itemID string) []string {
+	t.Helper()
+	convoys, err := convoycore.TrackingConvoysForItem(store, itemID)
+	if err != nil {
+		t.Fatalf("TrackingConvoysForItem: %v", err)
+	}
+	ids := make([]string, 0, len(convoys))
+	for _, c := range convoys {
+		ids = append(ids, c.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// TestExclusiveDrainReservationForceOverride keeps the documented escape hatch
+// working: --force is how an operator accepts a deliberate double dispatch.
+func TestExclusiveDrainReservationForceOverride(t *testing.T) {
+	store, drain, memberID := seedExclusiveDrain(t)
+	expandExclusiveDrain(t, store, drain)
+
+	deps, a, runner := reproSlingDeps(t, store)
+	opts := testOpts(a, memberID)
+	opts.Force = true
+	if _, err := DoSling(opts, deps, nil); err != nil {
+		t.Fatalf("DoSling(--force) error = %v, want the override to route", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1: --force must still dispatch", len(runner.calls))
+	}
+}
+
+// TestExclusiveDrainReservationDryRunReportsRefusal proves the preview tells
+// the truth. A dry run that hid the veto would send the operator straight into
+// the sling that is about to be rejected.
+func TestExclusiveDrainReservationDryRunReportsRefusal(t *testing.T) {
+	store, drain, memberID := seedExclusiveDrain(t)
+	expandExclusiveDrain(t, store, drain)
+
+	deps, a, _ := reproSlingDeps(t, store)
+	opts := testOpts(a, memberID)
+	opts.DryRun = true
+	var resErr *ExclusiveDrainReservationError
+	if _, err := DoSling(opts, deps, nil); !errors.As(err, &resErr) {
+		t.Fatalf("DoSling(--dry-run) error = %v, want *ExclusiveDrainReservationError", err)
+	}
+}
+
+// TestExclusiveDrainReservationReleasedAfterDrainCloses proves the guard is not
+// a one-way door: once the drain terminates and releases, the member is
+// routable again with no --force needed.
+func TestExclusiveDrainReservationReleasedAfterDrainCloses(t *testing.T) {
+	store, drain, memberID := seedExclusiveDrain(t)
+	expandExclusiveDrain(t, store, drain)
+	if got := mustReservation(t, store, memberID); got != drain.ID {
+		t.Fatalf("reservation = %q, want %s", got, drain.ID)
+	}
+
+	if err := store.SetMetadata(memberID, "gc.exclusive_drain_reservation", ""); err != nil {
+		t.Fatal(err)
+	}
+	deps, a, _ := reproSlingDeps(t, store)
+	if _, err := DoSling(testOpts(a, memberID), deps, nil); err != nil {
+		t.Fatalf("DoSling(released member) error = %v, want success", err)
+	}
+}
+
+// TestExclusiveDrainReservationClosedHolderStillVetoes pins the corrected
+// staleness rule. A drain releases its reservations BEFORE it closes, so a
+// reservation still present on a CLOSED control is abnormal — the drain
+// terminated without releasing, and an item-root worker it spawned may still be
+// executing the member. Double-dispatching onto that is exactly the incident,
+// so the veto holds; the message flags the holder as stale, and --force is the
+// escape for a genuinely dead reservation.
+func TestExclusiveDrainReservationClosedHolderStillVetoes(t *testing.T) {
+	store, drain, memberID := seedExclusiveDrain(t)
+	expandExclusiveDrain(t, store, drain)
+
+	closed := "closed"
+	if err := store.Update(drain.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("close drain control: %v", err)
+	}
+	if got := mustReservation(t, store, memberID); got != drain.ID {
+		t.Fatalf("reservation = %q, want the stamp %s to still be present", got, drain.ID)
+	}
+
+	deps, a, runner := reproSlingDeps(t, store)
+	var resErr *ExclusiveDrainReservationError
+	if _, err := DoSling(testOpts(a, memberID), deps, nil); !errors.As(err, &resErr) {
+		t.Fatalf("DoSling(closed holder + live reservation) error = %v, want *ExclusiveDrainReservationError", err)
+	}
+	if !strings.Contains(resErr.Error(), "stale reservation") {
+		t.Errorf("message %q should flag the terminated holder as a stale reservation", resErr.Error())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner invoked %d times; the veto must dispatch nothing", len(runner.calls))
+	}
+
+	// --force is the escape for a genuinely dead reservation.
+	opts := testOpts(a, memberID)
+	opts.Force = true
+	if _, err := DoSling(opts, deps, nil); err != nil {
+		t.Fatalf("DoSling(--force over stale reservation) error = %v, want the override to route", err)
+	}
+}
+
+// TestExclusiveDrainReservationReleasedSlotProceeds is the clean-completion
+// counterpart: a drain that finished normally cleared the slot, so there is no
+// veto and no --force needed. (The empty slot is the normal terminal state; a
+// present reservation is what TestExclusiveDrainReservationClosedHolderStillVetoes
+// covers.)
+func TestExclusiveDrainReservationReleasedSlotProceeds(t *testing.T) {
+	store, drain, memberID := seedExclusiveDrain(t)
+	expandExclusiveDrain(t, store, drain)
+	// Normal release before close.
+	if err := store.SetMetadata(memberID, "gc.exclusive_drain_reservation", ""); err != nil {
+		t.Fatal(err)
+	}
+	closed := "closed"
+	if err := store.Update(drain.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatal(err)
+	}
+	deps, a, runner := reproSlingDeps(t, store)
+	if _, err := DoSling(testOpts(a, memberID), deps, nil); err != nil {
+		t.Fatalf("DoSling(released slot) error = %v, want success", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1", len(runner.calls))
+	}
+}
+
+// TestExclusiveDrainReservationUnreadableHolderStillRefuses proves the holder
+// read is diagnostic only: the reservation stamp alone vetoes, so an unreadable
+// control (a cross-store holder, a transient store error) cannot downgrade the
+// veto — it only yields a less-detailed message. Inferring "safe to
+// double-dispatch" from a failed read is the advisory behavior this check ends.
+func TestExclusiveDrainReservationUnreadableHolderStillRefuses(t *testing.T) {
+	store := beads.NewMemStore()
+	member, err := store.Create(beads.Bead{Title: "member anchor", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(member.ID, "gc.exclusive_drain_reservation", "dip-7qtaev"); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, a, _ := reproSlingDeps(t, store)
+	var resErr *ExclusiveDrainReservationError
+	if _, err := DoSling(testOpts(a, member.ID), deps, nil); !errors.As(err, &resErr) {
+		t.Fatalf("DoSling(unreadable holder) error = %v, want *ExclusiveDrainReservationError", err)
+	}
+	if resErr.ControlID != "dip-7qtaev" {
+		t.Fatalf("ControlID = %q, want dip-7qtaev", resErr.ControlID)
+	}
+}
+
+// TestUnreservedBeadSlingsNormally pins the guard's blast radius: a bead with
+// no reservation routes exactly as before.
+func TestUnreservedBeadSlingsNormally(t *testing.T) {
+	store := beads.NewMemStore()
+	member, err := store.Create(beads.Bead{Title: "ordinary work", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps, a, runner := reproSlingDeps(t, store)
+	if _, err := DoSling(testOpts(a, member.ID), deps, nil); err != nil {
+		t.Fatalf("DoSling(unreserved) error = %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1", len(runner.calls))
+	}
+}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -109,6 +109,15 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 		}
 	}
 
+	// Exclusive-drain reservation: refuse to mint a second dispatch authority
+	// on a bead a live drain already owns. Checked before reopenForReassign so
+	// a refused sling mutates nothing.
+	if shouldCheckExclusiveDrain(opts) {
+		if err := CheckExclusiveDrainReservation(querier, deps.Store, opts.BeadOrFormula); err != nil {
+			return result, err
+		}
+	}
+
 	// Dependency cycle check: reject slings that would create a deadlock.
 	if shouldCheckDepCycle(opts) {
 		if err := DetectCycle(opts.BeadOrFormula, deps.Store); err != nil {
@@ -251,6 +260,21 @@ func shouldGuardCrossRig(opts SlingOpts) bool {
 
 func shouldCheckBeadState(opts SlingOpts) bool {
 	return !opts.IsFormula && !opts.Force && (!opts.DryRun || !opts.InlineText)
+}
+
+// shouldCheckExclusiveDrain reports whether the exclusive-drain reservation
+// veto applies. It needs a real bead ID, so a standalone formula launch
+// (BeadOrFormula is a formula NAME) and inline-text slings (the bead does not
+// exist yet, so nothing can hold a reservation on it) are out of scope.
+// --force bypasses it, matching every other preflight guard. Dry-run does NOT:
+// the veto is read-only, and a preview that hides the refusal would send the
+// operator to run the very sling that is about to be rejected.
+//
+// --reassign deliberately does not bypass it. Reassign takes a bead over from
+// an actor that has stopped; an exclusive drain reservation says a lane is
+// still running, which is a different claim and a stronger one.
+func shouldCheckExclusiveDrain(opts SlingOpts) bool {
+	return !opts.IsFormula && !opts.Force && !opts.InlineText
 }
 
 // onFormulaNeedsAttachment reports whether this is an --on sling whose target
@@ -1489,6 +1513,20 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 				continue
 			}
 			batchResult.BeadWarnings = append(batchResult.BeadWarnings, check.Warnings...)
+
+			// Exclusive-drain reservation, per child: a batch must not route a
+			// member a live drain owns. Failing the one child (rather than the
+			// batch) keeps the remaining, unreserved children routable — the
+			// same posture as the other per-child guards below.
+			if err := CheckExclusiveDrainReservation(querier, deps.Store, child.ID); err != nil {
+				childResult.Failed = true
+				childResult.FailReason = err.Error()
+				batchResult.Children = append(batchResult.Children, childResult)
+				childErrors = append(childErrors, err)
+				telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), batchMethod, err)
+				failed++
+				continue
+			}
 		}
 
 		if shouldValidateBuiltInRouteStoreReachable(opts, deps) {


### PR DESCRIPTION
## Problem (dip-tlbizd, 2026-07-16)

A drain declaring `gc.drain_member_access: exclusive` stamps
`gc.exclusive_drain_reservation=<controlID>` on each member anchor as it expands, and clears it
before it closes. In the incident that stamp was **advisory**: it was read only by *other drains*
(`reserveDrainMember`'s owner comparison). Nothing outside `internal/dispatch` consulted it, so a
**fresh/root formula dispatch** — which routes a work bead and wraps it in an OPEN synthetic input
convoy (`gc.synthetic=true`, "input convoy for &lt;bead&gt;") — sailed straight past the reservation.

Two lanes then drove one anchor (dip-3812vr) concurrently in one shared build tree: the drain unit
(control dip-7qtaev) and the PL's post-exhaustion re-dispatch (root dip-loz9gc / convoy dip-l93ikp).
Result: duplicate ~450-line implementations, interleaved commits with unreliable git attribution, a
mid-edit test captured into a real-Lakebase evidence receipt. **Exclusive did not exclude.**

## Fix

The reservation is now consulted at **both** dispatch entry points; the stamp is load-bearing, not advisory.

### Sling side — `internal/sling/exclusive_drain.go`, `sling_core.go`
`DoSling`/`DoSlingBatch` preflight refuses to route a bead that carries a live
`gc.exclusive_drain_reservation`. The **presence of the stamp is the veto**: a drain releases every
reservation *before* it closes (`releaseDrainReservations` runs ahead of `updateMetadataAndClose`), so
a normally-finished drain leaves an empty slot and no veto. A stamp still present therefore means
either a live drain (holder open) or a drain that terminated *without* releasing (holder closed) — and
in the latter case an item-root worker it spawned may still be executing the member. Neither is safe to
double-dispatch, so the veto holds regardless of holder status; the message flags a terminated holder
as a *stale reservation to clear*. `--force` is the deliberate override, matching every other preflight
guard. The check runs before `reopenForReassign`, so a refused sling mutates nothing; `--dry-run` reports
the refusal rather than hiding it.

### Drain side — `internal/dispatch/drain.go`
Before an exclusive drain reserves a member, it refuses if a competing **non-drain** dispatch is
already live on it — the mirror case the reservation alone cannot see, because a fresh dispatch leaves
no reservation to compare against. The signature is an open synthetic input convoy tracking the member
that does **not** belong to the drain's own topology. Two shapes are excluded so the drain never
self-vetoes:
- **the drain's own parent/input convoy** (`ownConvoyID`, threaded from `expandDrain`/`advanceSharedDrain`) — it tracks every member by construction; without this exclusion every exclusive drain with a synthetic parent would self-deadlock;
- **drain-unit convoys** (`gc.drain_control_id` set) — the drain-side shape, already excluded by the reservation owner check.

A convoy-listing failure returns a **retryable** `drainCompetitorProbeError` (re-probe next pass) rather
than proceeding blind — proceed-on-read-failure is the advisory posture the incident indicted.

## Proof (executed reproduction, not formula-reading)

`internal/sling/exclusive_drain_repro_test.go` drives the **real** drain machinery
(`dispatch.ProcessControl`) to take the reservation, then the **real** sling entry point (`DoSling`)
against the reserved member — the two entry points end-to-end in one store.
`internal/dispatch/drain_competing_dispatch_test.go` drives the reverse ordering.

**Red → green** (revert *only* the production code to `origin/main`, keep the new tests):

```
RED  (production @3e7e5b09b, new tests present):
  --- FAIL: TestExclusiveDrainReservationRefusesFreshDispatch      (DoSling error = <nil>, want *ExclusiveDrainReservationError)
  --- FAIL: TestExclusiveDrainReservationDryRunReportsRefusal
  --- FAIL: TestExclusiveDrainReservationClosedHolderStillVetoes
  --- FAIL: TestExclusiveDrainReservationUnreadableHolderStillRefuses
  --- FAIL: TestExclusiveDrainRefusesMemberWithLiveFreshDispatch   (Action = "drain-expanded", want drain-reservation-failed)

GREEN (fix applied):
  ok  github.com/gastownhall/gascity/internal/sling
  ok  github.com/gastownhall/gascity/internal/dispatch
```

Coverage: refuses fresh dispatch onto a reserved member (both orderings); `--force` overrides;
`--dry-run` reports the refusal; released slot proceeds; closed-holder-with-stamp still vetoes (with
`--force` escape); unreadable holder still vetoes (holder read is diagnostic only); drain does **not**
self-collide on a synthetic parent convoy; ordinary/closed tracking convoys tolerated; read-access
drains unaffected; unreserved beads route unchanged.

Gates (fix applied):
- `go test ./internal/dispatch ./internal/sling ./internal/convoy ./internal/beadmeta ./internal/formula ./internal/testenv` — **ok**
- `go test -race` on both new suites — **ok**
- `go vet ./...`, `gofmt -l`, `golangci-lint` (changed packages) — **clean**
- `internal/testenv` legacy-flag-freeze — **ok** (new tests use the default formula-v2 flag, not the legacy globals)

## Adversarial review

Codex run twice (`gpt-5.6-sol`, xhigh). Round 1 surfaced a self-collision (drain's synthetic parent),
a reversed staleness rationale, and fail-open reads; round 2 confirmed those addressed and flagged a
stale-snapshot / foreign-claim-self-collision in an interim heuristic, which was removed in favor of the
unambiguous synthetic-convoy signature.

## Remaining Risks (honest scope — not fixed here)

1. **Simultaneous-launch TOCTOU.** The sling read-only check and the drain scan-then-CAS share no atomic
   fence, so a genuinely concurrent sling and drain launch (both observing "clear" in the same instant)
   can still both proceed. This closes the incident's actual failure mode (temporal separation — the
   drain reserved, the re-dispatch came minutes later) in both orderings, but is **not** full mutual
   exclusion. A complete fix needs a shared per-member dispatch lock (or the sling taking the
   reservation atomically) — a larger design change flagged for the whole-solution review.
2. **Plain `--no-formula` dispatch-first.** The drain-side check recognizes the formula/workflow
   signature (a synthetic convoy). A plain route that leaves no synthetic convoy is not detected
   dispatch-first. Drain-**first** ordering is fully covered for *all* shapes by the sling-side veto.
3. **Graph-formula on a container.** `sling C --on graph-formula` delegates to `DoSling(C)` and checks
   C's reservation, not C's members'. The incident's path (a formula slung on the member directly) is covered.
4. **Orphan synthetic convoy** can fail-closed a later drain until cleared, and **batch `--dry-run`**
   does not preview per-child refusals. Both are fail-safe (toward refusal / no-preview), low-impact.

## Acceptance (dip-tlbizd / sc-471fl5)

- [x] reproduction-proven refusal for BOTH entry points (not formula-reading)
- [x] `gc.exclusive_drain_reservation` populated / claim rejected in the repro
- [x] note on dip-3812vr recording the resolution
- [x] staged PR + proof (this doc), PR-open HELD for Chris's go
CLOSED shipped: exclusive-drain reservation made load-bearing across both dispatch entry points (sling veto + drain-side competing-dispatch refusal). Reproduction-proven both orderings; red->green by reverting only prod code; race/vet/lint/legacy-freeze green; Codex adversarial x2 (findings addressed or documented as Remaining Risks). Committed cffeefe69 on fork branch fix/exclusive-drain-reservation-crossentry (base origin/main 3e7e5b09b). PR STAGED + HELD on fork for Chris's whole-solution go per canon sc-ia9uwz. Notes on dip-3812vr + dip-tlbizd. dip-tlbizd stays open as dip-side record until the PR lands.