### PR TITLE
fix(session): keep task artifacts out of worker cwd (v1.3.x)

### DIFF
--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -511,26 +511,3 @@ func TestFirstOpenAssignedWorkBeadIncludesAssignedWisp(t *testing.T) {
 		t.Fatalf("first assigned work ID = %q, want %q", got.ID, wisp.ID)
 	}
 }
-
-func TestResolveTaskWorkDirIncludesAssignedWisp(t *testing.T) {
-	workDir := t.TempDir()
-	store := beads.NewMemStore()
-	wisp, err := store.Create(beads.Bead{
-		Title:     "active workflow step",
-		Type:      "task",
-		Assignee:  "worker-session",
-		Metadata:  map[string]string{"work_dir": workDir},
-		Ephemeral: true,
-	})
-	if err != nil {
-		t.Fatalf("Create wisp work: %v", err)
-	}
-	inProgress := "in_progress"
-	if err := store.Update(wisp.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
-		t.Fatalf("mark wisp in progress: %v", err)
-	}
-
-	if got := resolveTaskWorkDir(store, "worker-session"); got != workDir {
-		t.Fatalf("resolveTaskWorkDir = %q, want assigned wisp work_dir %q", got, workDir)
-	}
-}

--- a/cmd/gc/per_dispatch_model_test.go
+++ b/cmd/gc/per_dispatch_model_test.go
@@ -185,7 +185,7 @@ func TestResolveTaskOptionOverrides_InvalidValueIgnoredPerKey(t *testing.T) {
 	candidate := newOptionSessionCandidate(t, store, map[string]string{"model": "definitely-not-a-choice", "effort": "high"}, nil)
 
 	want := map[string]string{"effort": "high"}
-	if got := resolveTaskOptionOverrides(store, optionSchemaProvider(), taskWorkDirAssignees(candidate, &config.City{})...); !reflect.DeepEqual(got, want) {
+	if got := resolveTaskOptionOverrides(store, optionSchemaProvider(), taskOptionOverrideAssignees(candidate, &config.City{})...); !reflect.DeepEqual(got, want) {
 		t.Fatalf("resolveTaskOptionOverrides = %v, want %v", got, want)
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
@@ -260,12 +261,9 @@ type startExecutionOptions struct {
 	asyncTracker     *asyncStartTracker
 	asyncStopTracker *asyncStartTracker
 	maxSessionAgeTr  maxSessionAgeTracker
-	workDirResolver  taskWorkDirResolver
 }
 
 type startExecutionOption func(*startExecutionOptions)
-
-type taskWorkDirResolver func(startCandidate, *config.City) string
 
 func withAsyncStartExecution() startExecutionOption {
 	return func(opts *startExecutionOptions) {
@@ -302,12 +300,6 @@ func withAsyncDrainAckStopTracker(tracker *asyncStartTracker) startExecutionOpti
 func withMaxSessionAgeTracker(tr maxSessionAgeTracker) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.maxSessionAgeTr = tr
-	}
-}
-
-func withTaskWorkDirResolver(resolver taskWorkDirResolver) startExecutionOption {
-	return func(opts *startExecutionOptions) {
-		opts.workDirResolver = resolver
 	}
 }
 
@@ -703,7 +695,7 @@ func prepareStartCandidate(
 	store beads.Store,
 	clk clock.Clock,
 ) (*preparedStart, error) {
-	return prepareStartCandidateForCity(candidate, "", "", cfg, nil, store, clk, io.Discard, nil)
+	return prepareStartCandidateForCity(candidate, "", "", cfg, nil, store, clk, io.Discard)
 }
 
 func prepareStartCandidateForCity(
@@ -715,7 +707,6 @@ func prepareStartCandidateForCity(
 	store beads.Store,
 	clk clock.Clock,
 	stderr io.Writer,
-	workDirResolver taskWorkDirResolver,
 ) (*preparedStart, error) {
 	session := candidate.session
 	if session != nil && strings.TrimSpace(session.ID) != "" && store != nil {
@@ -734,7 +725,7 @@ func prepareStartCandidateForCity(
 		return nil, err
 	}
 	candidate = refreshConfiguredNamedStartCandidate(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
-	return buildPreparedStartWithWorkDirResolver(candidate, cfg, store, workDirResolver)
+	return buildPreparedStart(candidate, cfg, store)
 }
 
 func refreshConfiguredNamedStartCandidate(
@@ -776,15 +767,6 @@ func buildPreparedStart(
 	cfg *config.City,
 	store beads.Store,
 ) (*preparedStart, error) {
-	return buildPreparedStartWithWorkDirResolver(candidate, cfg, store, nil)
-}
-
-func buildPreparedStartWithWorkDirResolver(
-	candidate startCandidate,
-	cfg *config.City,
-	store beads.Store,
-	workDirResolver taskWorkDirResolver,
-) (*preparedStart, error) {
 	session := candidate.session
 	tp := candidate.tp
 	agentCfg := templateParamsToConfig(tp)
@@ -807,7 +789,7 @@ func buildPreparedStartWithWorkDirResolver(
 	// "effort". Apply them after core/live hash calculation because they are
 	// dispatch inputs from the current work bead, not durable session config.
 	// Explicit session template_overrides still win per key.
-	dispatchOptions := resolveTaskOptionOverrides(store, tp.ResolvedProvider, taskWorkDirAssignees(candidate, cfg)...)
+	dispatchOptions := resolveTaskOptionOverrides(store, tp.ResolvedProvider, taskOptionOverrideAssignees(candidate, cfg)...)
 	if len(dispatchOptions) > 0 {
 		launchOverrides := make(map[string]string, len(dispatchOptions))
 		for k, v := range dispatchOptions {
@@ -819,9 +801,9 @@ func buildPreparedStartWithWorkDirResolver(
 		applySchemaOptionOverridesForLaunch(&agentCfg, &tp, session.ID, launchOverrides)
 	}
 
-	if wd := resolvePreparedTaskWorkDir(candidate, cfg, store, workDirResolver); wd != "" {
-		agentCfg.WorkDir = wd
-	} else if wd := session.Metadata["work_dir"]; wd != "" {
+	// Process cwd belongs to the session/worker lifecycle contract. Task and
+	// molecule artifact metadata must never redirect the provider process.
+	if wd := contract.WorkerDirFromMetadata(session.Metadata); wd != "" {
 		agentCfg.WorkDir = wd
 	}
 	// Pre-flight stale-resume guard: if the bead carries a session_key whose
@@ -1000,21 +982,7 @@ func applySchemaOptionOverridesForLaunch(agentCfg *runtime.Config, tp *TemplateP
 	}
 }
 
-func resolvePreparedTaskWorkDir(
-	candidate startCandidate,
-	cfg *config.City,
-	store beads.Store,
-	workDirResolver taskWorkDirResolver,
-) string {
-	if workDirResolver != nil {
-		if workDir := workDirResolver(candidate, cfg); workDir != "" {
-			return workDir
-		}
-	}
-	return resolveTaskWorkDir(store, taskWorkDirAssignees(candidate, cfg)...)
-}
-
-func taskWorkDirAssignees(candidate startCandidate, cfg *config.City) []string {
+func taskOptionOverrideAssignees(candidate startCandidate, cfg *config.City) []string {
 	if candidate.session == nil {
 		return nil
 	}
@@ -2221,7 +2189,7 @@ func executePlannedStartsTraced(
 						}
 					}
 				}
-				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr, startOpts.workDirResolver)
+				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
 				if err != nil {
 					clearPendingStartInFlightLease(candidate.session, store, stderr)
 					if release != nil {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -65,18 +65,6 @@ func (s *failSetMetadataStore) SetMetadata(id, key, value string) error {
 	return s.MemStore.SetMetadata(id, key, value)
 }
 
-type taskWorkDirLiveListCountingStore struct {
-	beads.Store
-	liveInProgressAssigneeLists int
-}
-
-func (s *taskWorkDirLiveListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if query.Live && query.Status == "in_progress" && query.Assignee != "" {
-		s.liveInProgressAssigneeLists++
-	}
-	return s.Store.List(query)
-}
-
 type panicMetadataBatchStore struct {
 	*beads.MemStore
 }
@@ -694,116 +682,111 @@ func TestReconcileSessionBeads_FailedDependencyBlocksDependentButNotSibling(t *t
 	}
 }
 
-func TestPrepareStartCandidate_UsesSessionIDForTaskWorkDir(t *testing.T) {
-	store := beads.NewMemStore()
-	session, err := store.Create(beads.Bead{
-		Title:  "worker",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel, "agent:frontend/worker-1"},
-		Metadata: map[string]string{
-			"template":     "worker",
-			"session_name": "custom-worker-1",
-			"pool_slot":    "1",
+func TestPrepareStartCandidate_WorkDirUsesSessionMetadataOnly(t *testing.T) {
+	tests := []struct {
+		name            string
+		sessionMetadata map[string]string
+		taskMetadata    map[string]string
+		wantSource      string
+	}{
+		{
+			name:         "canonical task artifact dir cannot redirect cwd",
+			taskMetadata: map[string]string{"artifact_dir": "task"},
+			wantSource:   "template",
 		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	workDir := t.TempDir()
-	task, err := store.Create(beads.Bead{
-		Title: "task",
-		Metadata: map[string]string{
-			"work_dir": workDir,
+		{
+			name:         "legacy task work dir cannot redirect cwd",
+			taskMetadata: map[string]string{"work_dir": "task"},
+			wantSource:   "template",
 		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	assignee := session.ID
-	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
-		t.Fatal(err)
-	}
-	if info, err := os.Stat(workDir); err != nil || !info.IsDir() {
-		t.Fatalf("temp workDir not available: %v", err)
+		{
+			name: "canonical session worker dir wins over legacy session alias and task",
+			sessionMetadata: map[string]string{
+				"worker_dir": "canonical-session",
+				"work_dir":   "legacy-session",
+			},
+			taskMetadata: map[string]string{
+				"artifact_dir": "task",
+				"work_dir":     "legacy-task",
+			},
+			wantSource: "canonical-session",
+		},
+		{
+			name:            "legacy session work dir remains a worker alias",
+			sessionMetadata: map[string]string{"work_dir": "legacy-session"},
+			taskMetadata:    map[string]string{"artifact_dir": "task"},
+			wantSource:      "legacy-session",
+		},
 	}
 
-	prepared, err := prepareStartCandidate(startCandidate{
-		session: &session,
-		tp: TemplateParams{
-			TemplateName: "frontend/worker",
-			SessionName:  "custom-worker-1",
-		},
-		order: 0,
-	}, &config.City{
-		Agents: []config.Agent{
-			{Name: "worker", Dir: "frontend", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
-		},
-	}, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)})
-	if err != nil {
-		t.Fatalf("prepareStartCandidate: %v", err)
-	}
-	if prepared.cfg.WorkDir != workDir {
-		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, workDir)
-	}
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			templateDir := t.TempDir()
+			taskDir := t.TempDir()
+			canonicalSessionDir := t.TempDir()
+			legacySessionDir := t.TempDir()
+			sourceDirs := map[string]string{
+				"template":          templateDir,
+				"task":              taskDir,
+				"canonical-session": canonicalSessionDir,
+				"legacy-session":    legacySessionDir,
+				"legacy-task":       taskDir,
+			}
 
-func TestPrepareStartCandidate_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing.T) {
-	base := beads.NewMemStore()
-	store := &taskWorkDirLiveListCountingStore{Store: base}
-	session, err := store.Create(beads.Bead{
-		Title:  "worker",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel, "agent:frontend/worker-1"},
-		Metadata: map[string]string{
-			"template":     "worker",
-			"session_name": "custom-worker-1",
-			"pool_slot":    "1",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	workDir := t.TempDir()
-	task, err := store.Create(beads.Bead{
-		Title: "task",
-		Metadata: map[string]string{
-			"work_dir": workDir,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	assignee := session.ID
-	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
-		t.Fatal(err)
-	}
-	task, err = store.Get(task.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
+			store := beads.NewMemStore()
+			sessionMetadata := map[string]string{
+				"template":     "worker",
+				"session_name": "custom-worker-1",
+				"pool_slot":    "1",
+			}
+			for key, source := range tc.sessionMetadata {
+				sessionMetadata[key] = sourceDirs[source]
+			}
+			session, err := store.Create(beads.Bead{
+				Title:    "worker",
+				Type:     sessionBeadType,
+				Labels:   []string{sessionBeadLabel, "agent:frontend/worker-1"},
+				Metadata: sessionMetadata,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	prepared, err := prepareStartCandidateForCity(startCandidate{
-		session: &session,
-		tp: TemplateParams{
-			TemplateName: "frontend/worker",
-			SessionName:  "custom-worker-1",
-		},
-		order: 0,
-	}, "", "", &config.City{
-		Agents: []config.Agent{
-			{Name: "worker", Dir: "frontend", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
-		},
-	}, nil, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}, nil, newAssignedTaskWorkDirResolver([]beads.Bead{task}))
-	if err != nil {
-		t.Fatalf("prepareStartCandidateForCity: %v", err)
-	}
-	if prepared.cfg.WorkDir != workDir {
-		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists != 0 {
-		t.Fatalf("live in-progress assignee List calls = %d, want 0 with snapshot resolver", store.liveInProgressAssigneeLists)
+			taskMetadata := make(map[string]string, len(tc.taskMetadata))
+			for key, source := range tc.taskMetadata {
+				taskMetadata[key] = sourceDirs[source]
+			}
+			task, err := store.Create(beads.Bead{Title: "task", Metadata: taskMetadata})
+			if err != nil {
+				t.Fatal(err)
+			}
+			status := "in_progress"
+			assignee := session.ID
+			if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+				t.Fatal(err)
+			}
+
+			prepared, err := prepareStartCandidate(startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					TemplateName: "frontend/worker",
+					SessionName:  "custom-worker-1",
+					WorkDir:      templateDir,
+				},
+				order: 0,
+			}, &config.City{
+				Agents: []config.Agent{{
+					Name: "worker",
+					Dir:  "frontend",
+				}},
+			}, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)})
+			if err != nil {
+				t.Fatalf("prepareStartCandidate: %v", err)
+			}
+			if want := sourceDirs[tc.wantSource]; prepared.cfg.WorkDir != want {
+				t.Fatalf("prepared.cfg.WorkDir = %q, want %s dir %q", prepared.cfg.WorkDir, tc.wantSource, want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -957,10 +956,6 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if apply != nil {
 			apply(&reconcileOpts)
 		}
-	}
-	effectiveStartOptions := startOptions
-	if !storeQueryPartial && reconcileOpts.workDirResolver == nil && len(assignedWorkBeads) > 0 {
-		effectiveStartOptions = append(append([]startExecutionOption(nil), startOptions...), withTaskWorkDirResolver(newAssignedTaskWorkDirResolver(assignedWorkBeads)))
 	}
 	if startupTimeout <= 0 && cfg != nil {
 		startupTimeout = cfg.Session.StartupTimeoutDuration()
@@ -2534,7 +2529,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
 		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
-		effectiveStartOptions...,
+		startOptions...,
 	)
 	recordPhase(TraceSiteSessionReconcileStartExecution, "session_reconcile.execute_planned_starts", phaseStart, map[string]any{
 		"start_candidate_count": len(startCandidates),
@@ -3715,44 +3710,6 @@ func clearMissingIdleProbes(dt *drainTracker, beadByID map[string]*beads.Bead) {
 	}
 }
 
-// resolveTaskWorkDir checks the agent's assigned task beads for a work_dir
-// metadata field. If a task bead has work_dir set and the directory exists
-// on disk, that path is returned. This lets the reconciler start the agent
-// in the worktree that the previous session (or this session's prior run)
-// created, without any prompt-side logic.
-func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
-	if store == nil {
-		return ""
-	}
-	seen := make(map[string]bool, len(assignees))
-	for _, assignee := range assignees {
-		assignee = strings.TrimSpace(assignee)
-		if assignee == "" || seen[assignee] {
-			continue
-		}
-		seen[assignee] = true
-		assigned, err := store.List(beads.ListQuery{
-			Assignee: assignee,
-			Status:   "in_progress",
-			Live:     true,
-			TierMode: beads.TierBoth,
-			Sort:     beads.SortCreatedDesc,
-		})
-		if err != nil {
-			continue
-		}
-		for _, b := range assigned {
-			wd := strings.TrimSpace(b.Metadata["work_dir"])
-			if wd != "" {
-				if info, err := os.Stat(wd); err == nil && info.IsDir() {
-					return wd
-				}
-			}
-		}
-	}
-	return ""
-}
-
 const dispatchOptionMetadataPrefix = "opt_"
 
 func dispatchOptionMetadataKey(key string) string {
@@ -3820,47 +3777,6 @@ func workBeadOptionOverrides(b beads.Bead, rp *config.ResolvedProvider) (map[str
 		overrides[opt.Key] = value
 	}
 	return overrides, sawOptions
-}
-
-type assignedTaskWorkDir struct {
-	path      string
-	createdAt time.Time
-}
-
-// newAssignedTaskWorkDirResolver resolves work_dir values from the
-// reconciler's snapshot; misses intentionally fall back to the live lookup.
-func newAssignedTaskWorkDirResolver(assignedWorkBeads []beads.Bead) taskWorkDirResolver {
-	index := make(map[string]assignedTaskWorkDir)
-	for _, bead := range assignedWorkBeads {
-		if bead.Status != "in_progress" {
-			continue
-		}
-		assignee := strings.TrimSpace(bead.Assignee)
-		if assignee == "" {
-			continue
-		}
-		workDir := strings.TrimSpace(bead.Metadata["work_dir"])
-		if workDir == "" {
-			continue
-		}
-		info, err := os.Stat(workDir)
-		if err != nil || !info.IsDir() {
-			continue
-		}
-		current, ok := index[assignee]
-		if ok && !bead.CreatedAt.After(current.createdAt) {
-			continue
-		}
-		index[assignee] = assignedTaskWorkDir{path: workDir, createdAt: bead.CreatedAt}
-	}
-	return func(candidate startCandidate, cfg *config.City) string {
-		for _, assignee := range taskWorkDirAssignees(candidate, cfg) {
-			if workDir := index[strings.TrimSpace(assignee)].path; workDir != "" {
-				return workDir
-			}
-		}
-		return ""
-	}
 }
 
 // truncateHashForLog returns a short representation of a fingerprint hash

--- a/cmd/gc/session_reconciler_drift_resume_test.go
+++ b/cmd/gc/session_reconciler_drift_resume_test.go
@@ -77,7 +77,7 @@ func TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinua
 
 	prepared, err := prepareStartCandidateForCity(
 		startCandidate{session: &got, tp: tp, order: 0},
-		"", "", cfg, env.sp, env.store, clk, io.Discard, nil,
+		"", "", cfg, env.sp, env.store, clk, io.Discard,
 	)
 	if err != nil {
 		t.Fatalf("prepareStartCandidateForCity: %v", err)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -388,22 +388,23 @@ func (e *reconcilerTestEnv) reconcileWithPoolDesiredAndDrainOps(sessions []beads
 	)
 }
 
-func TestReconcileSessionBeads_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing.T) {
+func TestReconcileSessionBeads_TaskMetadataCannotOverrideSessionWorkerDir(t *testing.T) {
 	env := newReconcilerTestEnv()
-	base := beads.NewMemStore()
-	store := &taskWorkDirLiveListCountingStore{Store: base}
-	env.store = store
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
 	env.addDesired("worker", "worker", false)
 	session := env.createSessionBead("worker", "worker")
 	env.markSessionCreating(&session)
+	sessionDir := t.TempDir()
+	env.setSessionMetadata(&session, map[string]string{"worker_dir": sessionDir})
 
-	workDir := t.TempDir()
+	taskArtifactDir := t.TempDir()
+	taskLegacyWorkDir := t.TempDir()
 	task, err := env.store.Create(beads.Bead{
 		Title: "assigned task",
 		Type:  "task",
 		Metadata: map[string]string{
-			"work_dir": workDir,
+			"artifact_dir": taskArtifactDir,
+			"work_dir":     taskLegacyWorkDir,
 		},
 	})
 	if err != nil {
@@ -451,141 +452,15 @@ func TestReconcileSessionBeads_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing
 	if startCfg == nil {
 		t.Fatal("worker was not started")
 	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
+	if startCfg.WorkDir != sessionDir {
+		t.Fatalf(
+			"started WorkDir = %q, want session worker_dir %q (task artifact_dir=%q, task work_dir=%q)",
+			startCfg.WorkDir,
+			sessionDir,
+			taskArtifactDir,
+			taskLegacyWorkDir,
+		)
 	}
-	if store.liveInProgressAssigneeLists != 0 {
-		t.Fatalf("live in-progress assignee List calls = %d, want 0 with complete assigned-work snapshot", store.liveInProgressAssigneeLists)
-	}
-}
-
-func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWithoutAssignedWorkSnapshot(t *testing.T) {
-	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
-	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, nil, false)
-	if woken != 1 {
-		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
-	}
-	startCfg := env.sp.LastStartConfig("worker")
-	if startCfg == nil {
-		t.Fatal("worker was not started")
-	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists == 0 {
-		t.Fatal("live in-progress assignee List calls = 0, want live fallback without assigned-work snapshot")
-	}
-}
-
-func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWhenAssignedWorkSnapshotPartial(t *testing.T) {
-	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
-	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, nil, true)
-	if woken != 1 {
-		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
-	}
-	startCfg := env.sp.LastStartConfig("worker")
-	if startCfg == nil {
-		t.Fatal("worker was not started")
-	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists == 0 {
-		t.Fatal("live in-progress assignee List calls = 0, want live fallback when assigned-work snapshot is partial")
-	}
-}
-
-func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWhenAssignedWorkSnapshotMisses(t *testing.T) {
-	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
-	unrelatedWorkDir := t.TempDir()
-	unrelatedTask := createInProgressTaskWithWorkDir(t, env.store, "other-worker", unrelatedWorkDir)
-	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, []beads.Bead{unrelatedTask}, false)
-	if woken != 1 {
-		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
-	}
-	startCfg := env.sp.LastStartConfig("worker")
-	if startCfg == nil {
-		t.Fatal("worker was not started")
-	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists == 0 {
-		t.Fatal("live in-progress assignee List calls = 0, want live fallback when assigned-work snapshot misses")
-	}
-}
-
-func newReconcilerTaskWorkDirTest(t *testing.T) (*reconcilerTestEnv, *taskWorkDirLiveListCountingStore, beads.Bead, string) {
-	t.Helper()
-	env := newReconcilerTestEnv()
-	base := beads.NewMemStore()
-	store := &taskWorkDirLiveListCountingStore{Store: base}
-	env.store = store
-	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
-	env.addDesired("worker", "worker", false)
-	session := env.createSessionBead("worker", "worker")
-	env.markSessionCreating(&session)
-	workDir := t.TempDir()
-	createInProgressTaskWithWorkDir(t, env.store, session.ID, workDir)
-	return env, store, session, workDir
-}
-
-func createInProgressTaskWithWorkDir(t *testing.T, store beads.Store, assignee, workDir string) beads.Bead {
-	t.Helper()
-	task, err := store.Create(beads.Bead{
-		Title: "assigned task",
-		Type:  "task",
-		Metadata: map[string]string{
-			"work_dir": workDir,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Create(task): %v", err)
-	}
-	status := "in_progress"
-	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
-		t.Fatalf("Update(task): %v", err)
-	}
-	task, err = store.Get(task.ID)
-	if err != nil {
-		t.Fatalf("Get(task): %v", err)
-	}
-	return task
-}
-
-func reconcileSessionBeadsWithTaskWorkDirSnapshot(
-	t *testing.T,
-	env *reconcilerTestEnv,
-	session beads.Bead,
-	assignedWorkBeads []beads.Bead,
-	storeQueryPartial bool,
-) int {
-	t.Helper()
-	cfgNames := configuredSessionNames(env.cfg, "", env.store)
-	return reconcileSessionBeads(
-		context.Background(),
-		[]beads.Bead{session},
-		env.desiredState,
-		cfgNames,
-		env.cfg,
-		env.sp,
-		env.store,
-		nil,
-		assignedWorkBeads,
-		nil,
-		env.dt,
-		map[string]int{"worker": 1},
-		storeQueryPartial,
-		nil,
-		"",
-		nil,
-		env.clk,
-		env.rec,
-		0,
-		0,
-		&env.stdout,
-		&env.stderr,
-	)
 }
 
 func waitForProviderStopped(t *testing.T, sp runtime.Provider, name string) {

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -573,7 +573,7 @@ func TestResolveTemplateHeadlessAgentStaysMouseOff(t *testing.T) {
 // TestTemplateParamsToConfigInteractiveSessionEnablesMouse locks ga-c4w finding
 // #1 for the MANAGED `gc session new` deferred-start path: the reconciler starts
 // a session_origin=manual bead through templateParamsToConfig (see
-// buildPreparedStartWithWorkDirResolver). A manual session must resolve
+// buildPreparedStart). A manual session must resolve
 // MouseOn=true even when the agent config sets no mouse_mode, while ephemeral
 // pool agents stay MouseOn=false (controller-poll safety). This is the seam the
 // original API-only fix missed: MouseOn for `gc session new` never flowed through

--- a/internal/beads/contract/metadata.go
+++ b/internal/beads/contract/metadata.go
@@ -11,9 +11,8 @@ import (
 //
 // The legacy `work_dir` key was overloaded: it meant "agent process cwd"
 // when written on session beads and "work artifact directory" when
-// written on task/molecule beads. resolveTaskWorkDir in
-// cmd/gc/session_reconciler.go silently bridged the two semantics. The
-// new keys split the meaning:
+// written on task/molecule beads. The former reconciler task-work-dir lookup
+// silently bridged the two semantics. The new keys split the meaning:
 //
 //	WorkerDirKey ("worker_dir")     — agent process cwd. Session beads.
 //	ArtifactDirKey ("artifact_dir") — work artifact directory.


### PR DESCRIPTION
## Summary

- backport the focused session-owned provider-cwd correction to v1.3.x
- prevent task `artifact_dir` and legacy task `work_dir` metadata from redirecting provider cwd
- retain canonical session `worker_dir`, the session-only legacy `work_dir` fallback, and task-scoped provider options

## Scope

This is only the v1.3.x read-path backport of #4591. It intentionally excludes the session-home pruning and closed-bead reaper changes that were present in the prior branch.

This PR remains draft and deferred until the main-targeted change is accepted.

## Validation

- focused task-cwd/session-worker-dir and provider-option regressions pass
- `go vet ./cmd/gc` passes
- `go build ./cmd/gc` passes
- `git diff --check upstream/release/v1.3.0...HEAD` passes
- the local full `go test ./cmd/gc -count=1` run was infrastructure-inconclusive after host `/tmp` quota exhaustion at 294.990s; no candidate-specific failure appeared before the simultaneous fixture-write failures

## Hosted CI

CI run
[`30212215007`](https://github.com/gastownhall/gascity/actions/runs/30212215007)
tested current exact head
`246cbab3c3e4618528aae845cc3c95be1a5ed136`.

Its two deterministic leaf failures are outside this diff:

- `rest-full-2-of-16` fails in `TestGCLiveContract_BeadsAndEvents` on the
  release-line dirty-schema bootstrap defect tracked by #4625.
- The live pack-registry gate fails three consecutive attempts because the
  current `runtime-cloudflare/pack.toml` uses
  `runtimes.cloudflare{,.command,.protocol}`, fields this v1.3 parser does not
  support.

`rest-smoke-1-of-2` reached the exact 15-minute workflow limit and was
cancelled; `CI / integration` and `CI / required` are derived summaries. No
candidate-specific hosted failure was found. Rerunning this unchanged draft
would not address the two deterministic baselines.
