### PR TITLE
fix(session): keep task artifacts out of worker cwd

### DIFF
--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -663,26 +663,3 @@ func TestFirstOpenAssignedWorkBeadIncludesAssignedWisp(t *testing.T) {
 		t.Fatalf("first assigned work ID = %q, want %q", got.ID, wisp.ID)
 	}
 }
-
-func TestResolveTaskWorkDirIncludesAssignedWisp(t *testing.T) {
-	workDir := t.TempDir()
-	store := beads.NewMemStore()
-	wisp, err := store.Create(beads.Bead{
-		Title:     "active workflow step",
-		Type:      "task",
-		Assignee:  "worker-session",
-		Metadata:  map[string]string{"work_dir": workDir},
-		Ephemeral: true,
-	})
-	if err != nil {
-		t.Fatalf("Create wisp work: %v", err)
-	}
-	inProgress := "in_progress"
-	if err := store.Update(wisp.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
-		t.Fatalf("mark wisp in progress: %v", err)
-	}
-
-	if got := resolveTaskWorkDir("", store, "worker-session"); got != workDir {
-		t.Fatalf("resolveTaskWorkDir = %q, want assigned wisp work_dir %q", got, workDir)
-	}
-}

--- a/cmd/gc/per_dispatch_model_test.go
+++ b/cmd/gc/per_dispatch_model_test.go
@@ -186,7 +186,7 @@ func TestResolveTaskOptionOverrides_InvalidValueIgnoredPerKey(t *testing.T) {
 	candidate := newOptionSessionCandidate(t, store, map[string]string{"model": "definitely-not-a-choice", "effort": "high"}, nil)
 
 	want := map[string]string{"effort": "high"}
-	if got := resolveTaskOptionOverrides(store, optionSchemaProvider(), taskWorkDirAssignees(candidate, &config.City{})...); !reflect.DeepEqual(got, want) {
+	if got := resolveTaskOptionOverrides(store, optionSchemaProvider(), taskOptionOverrideAssignees(candidate, &config.City{})...); !reflect.DeepEqual(got, want) {
 		t.Fatalf("resolveTaskOptionOverrides = %v, want %v", got, want)
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -299,7 +299,6 @@ type startExecutionOptions struct {
 	asyncTracker                   *asyncStartTracker
 	asyncStopTracker               *asyncStartTracker
 	maxSessionAgeTr                maxSessionAgeTracker
-	workDirResolver                taskWorkDirResolver
 	stabilityWaiter                startStabilityWaiter
 	sessionStaleKeyDetectionWaiter sessionpkg.StaleKeyDetectionWaiter
 	// deferSessionClosesOnBoot suppresses the per-session orphan/failed-create
@@ -315,8 +314,6 @@ type startExecutionOptions struct {
 }
 
 type startExecutionOption func(*startExecutionOptions)
-
-type taskWorkDirResolver func(startCandidate, *config.City) string
 
 func withAsyncStartExecution() startExecutionOption {
 	return func(opts *startExecutionOptions) {
@@ -353,12 +350,6 @@ func withAsyncDrainAckStopTracker(tracker *asyncStartTracker) startExecutionOpti
 func withMaxSessionAgeTracker(tr maxSessionAgeTracker) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.maxSessionAgeTr = tr
-	}
-}
-
-func withTaskWorkDirResolver(resolver taskWorkDirResolver) startExecutionOption {
-	return func(opts *startExecutionOptions) {
-		opts.workDirResolver = resolver
 	}
 }
 
@@ -809,7 +800,7 @@ func prepareStartCandidate(
 	store beads.Store,
 	clk clock.Clock,
 ) (*preparedStart, error) {
-	return prepareStartCandidateForCity(candidate, "", "", cfg, nil, store, clk, io.Discard, nil)
+	return prepareStartCandidateForCity(candidate, "", "", cfg, nil, store, clk, io.Discard)
 }
 
 func prepareStartCandidateForCity(
@@ -821,7 +812,6 @@ func prepareStartCandidateForCity(
 	store beads.Store,
 	clk clock.Clock,
 	stderr io.Writer,
-	workDirResolver taskWorkDirResolver,
 ) (*preparedStart, error) {
 	if id := strings.TrimSpace(candidate.info.ID); id != "" && store != nil {
 		if err := sessionpkg.WithSessionMutationLock(id, func() error {
@@ -866,7 +856,7 @@ func prepareStartCandidateForCity(
 	// recordWakeFailure's session_key/started_config_hash) read that folded twin. The
 	// partial-Info second return is only load-bearing for recoverRunningPendingCreate's
 	// abort residue; here the prepared already carries it, so it is discarded.
-	prepared, _, err := buildPreparedStartWithWorkDirResolver(candidate, cityPath, cfg, store, workDirResolver)
+	prepared, _, err := buildPreparedStartForCity(candidate, cityPath, cfg, store)
 	return prepared, err
 }
 
@@ -909,10 +899,10 @@ func buildPreparedStart(
 	cfg *config.City,
 	store beads.Store,
 ) (*preparedStart, sessionpkg.Info, error) {
-	return buildPreparedStartWithWorkDirResolver(candidate, "", cfg, store, nil)
+	return buildPreparedStartForCity(candidate, "", cfg, store)
 }
 
-// buildPreparedStartWithWorkDirResolver builds the prepared start for a candidate,
+// buildPreparedStartForCity builds the prepared start for a candidate,
 // persisting a few start-prep mutations (stale-resume clear, session_key /
 // instance_token mints) through the session front door and folding each onto the
 // local candidate.info the moment it lands. It returns that (possibly partially
@@ -923,12 +913,11 @@ func buildPreparedStart(
 // pendingCreateResidueFold from this store-coherent Info so its infoByID snapshot
 // matches the persisted state (WI-6 R4: the former raw-bead mirror carried this
 // coherence).
-func buildPreparedStartWithWorkDirResolver(
+func buildPreparedStartForCity(
 	candidate startCandidate,
 	cityPath string,
 	cfg *config.City,
 	store beads.Store,
-	workDirResolver taskWorkDirResolver,
 ) (*preparedStart, sessionpkg.Info, error) {
 	tp := candidate.tp
 	agentCfg, delivery := templateParamsToConfigWithDelivery(tp)
@@ -957,7 +946,7 @@ func buildPreparedStartWithWorkDirResolver(
 	// "effort". Apply them after core/live hash calculation because they are
 	// dispatch inputs from the current work bead, not durable session config.
 	// Explicit session template_overrides still win per key.
-	dispatchOptions := resolveTaskOptionOverrides(store, tp.ResolvedProvider, taskWorkDirAssignees(candidate, cfg)...)
+	dispatchOptions := resolveTaskOptionOverrides(store, tp.ResolvedProvider, taskOptionOverrideAssignees(candidate, cfg)...)
 	if len(dispatchOptions) > 0 {
 		launchOverrides := make(map[string]string, len(dispatchOptions))
 		for k, v := range dispatchOptions {
@@ -970,16 +959,16 @@ func buildPreparedStartWithWorkDirResolver(
 	}
 
 	preOverrideWorkDir := agentCfg.WorkDir
-	if wd := resolvePreparedTaskWorkDir(candidate, cityPath, cfg, store, workDirResolver); wd != "" {
-		agentCfg.WorkDir = wd
-	} else if wd := candidate.info.WorkDir; wd != "" {
+	// Process cwd belongs to the session/worker lifecycle contract. Task and
+	// molecule artifact metadata must never redirect the provider process.
+	if wd := sessionpkg.WorkerDirFromInfo(candidate.info); wd != "" {
 		agentCfg.WorkDir = resolveWorkDirAgainstCity(cityPath, wd)
 	}
-	// The task work_dir override above can replace agentCfg.WorkDir after
-	// template resolution already rendered PreStart commands (materialize-
-	// skills, MCP projection) against the pre-override directory. Retarget
-	// those already-rendered strings so scaffold staging lands next to the
-	// session it actually launches into, not the directory templating assumed.
+	// Session metadata can replace agentCfg.WorkDir after template resolution
+	// already rendered PreStart commands (materialize-skills, MCP projection)
+	// against the pre-override directory. Retarget those already-rendered
+	// strings so scaffold staging lands next to the session it actually
+	// launches into, not the directory templating assumed.
 	agentCfg.PreStart = retargetPreStartWorkDir(agentCfg.PreStart, preOverrideWorkDir, agentCfg.WorkDir)
 	// Pre-flight stale-resume guard: if the bead carries a session_key whose
 	// keyed transcript is no longer on disk (provider session retention
@@ -1233,21 +1222,6 @@ func applySchemaOptionOverridesForLaunch(agentCfg *runtime.Config, tp *TemplateP
 	}
 }
 
-func resolvePreparedTaskWorkDir(
-	candidate startCandidate,
-	cityPath string,
-	cfg *config.City,
-	store beads.Store,
-	workDirResolver taskWorkDirResolver,
-) string {
-	if workDirResolver != nil {
-		if workDir := workDirResolver(candidate, cfg); workDir != "" {
-			return workDir
-		}
-	}
-	return resolveTaskWorkDir(cityPath, store, taskWorkDirAssignees(candidate, cfg)...)
-}
-
 // generatedPreStartPrefixes are the exact command prefixes
 // appendMaterializeSkillsPreStart and appendProjectMCPPreStart emit. Only a
 // PreStart entry starting with one of these is eligible for retargeting —
@@ -1268,8 +1242,8 @@ func isGeneratedPreStartCommand(cmd string) bool {
 
 // retargetPreStartWorkDir rewrites the engine-generated PreStart command
 // strings rendered against oldWorkDir so they instead reference newWorkDir.
-// A no-op when the task work_dir override left WorkDir unchanged, which is
-// the common case.
+// A no-op when session metadata left WorkDir unchanged, which is the common
+// case.
 //
 // The generated materialize-skills and project-mcp PreStart commands embed the
 // workdir as a shell-quoted token (see appendMaterializeSkillsPreStart and
@@ -1302,7 +1276,7 @@ func retargetPreStartWorkDir(preStart []string, oldWorkDir, newWorkDir string) [
 	return retargeted
 }
 
-func taskWorkDirAssignees(candidate startCandidate, cfg *config.City) []string {
+func taskOptionOverrideAssignees(candidate startCandidate, cfg *config.City) []string {
 	if strings.TrimSpace(candidate.info.ID) == "" {
 		return nil
 	}
@@ -2805,7 +2779,7 @@ func executePlannedStartsTraced(
 						}
 					}
 				}
-				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr, startOpts.workDirResolver)
+				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
 				if err != nil {
 					clearPendingStartInFlightLease(candidate.info.ID, sessFront, stderr)
 					if release != nil {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -99,18 +99,6 @@ func (s *failSetMetadataStore) SetMetadata(id, key, value string) error {
 	return s.MemStore.SetMetadata(id, key, value)
 }
 
-type taskWorkDirLiveListCountingStore struct {
-	beads.Store
-	liveInProgressAssigneeLists int
-}
-
-func (s *taskWorkDirLiveListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if query.Live && query.Status == "in_progress" && query.Assignee != "" {
-		s.liveInProgressAssigneeLists++
-	}
-	return s.Store.List(query)
-}
-
 type panicMetadataBatchStore struct {
 	*beads.MemStore
 }
@@ -717,116 +705,111 @@ func TestReconcileSessionBeads_FailedDependencyBlocksDependentButNotSibling(t *t
 	}
 }
 
-func TestPrepareStartCandidate_UsesSessionIDForTaskWorkDir(t *testing.T) {
-	store := beads.NewMemStore()
-	session, err := store.Create(beads.Bead{
-		Title:  "worker",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel, "agent:frontend/worker-1"},
-		Metadata: map[string]string{
-			"template":     "worker",
-			"session_name": "custom-worker-1",
-			"pool_slot":    "1",
+func TestPrepareStartCandidate_WorkDirUsesSessionMetadataOnly(t *testing.T) {
+	tests := []struct {
+		name            string
+		sessionMetadata map[string]string
+		taskMetadata    map[string]string
+		wantSource      string
+	}{
+		{
+			name:         "canonical task artifact dir cannot redirect cwd",
+			taskMetadata: map[string]string{"artifact_dir": "task"},
+			wantSource:   "template",
 		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	workDir := t.TempDir()
-	task, err := store.Create(beads.Bead{
-		Title: "task",
-		Metadata: map[string]string{
-			"work_dir": workDir,
+		{
+			name:         "legacy task work dir cannot redirect cwd",
+			taskMetadata: map[string]string{"work_dir": "task"},
+			wantSource:   "template",
 		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	assignee := session.ID
-	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
-		t.Fatal(err)
-	}
-	if info, err := os.Stat(workDir); err != nil || !info.IsDir() {
-		t.Fatalf("temp workDir not available: %v", err)
+		{
+			name: "canonical session worker dir wins over legacy session alias and task",
+			sessionMetadata: map[string]string{
+				"worker_dir": "canonical-session",
+				"work_dir":   "legacy-session",
+			},
+			taskMetadata: map[string]string{
+				"artifact_dir": "task",
+				"work_dir":     "legacy-task",
+			},
+			wantSource: "canonical-session",
+		},
+		{
+			name:            "legacy session work dir remains a worker alias",
+			sessionMetadata: map[string]string{"work_dir": "legacy-session"},
+			taskMetadata:    map[string]string{"artifact_dir": "task"},
+			wantSource:      "legacy-session",
+		},
 	}
 
-	prepared, err := prepareStartCandidate(startCandidate{
-		info: sessiontest.SeedBead(t, session),
-		tp: TemplateParams{
-			TemplateName: "frontend/worker",
-			SessionName:  "custom-worker-1",
-		},
-		order: 0,
-	}, &config.City{
-		Agents: []config.Agent{
-			{Name: "worker", Dir: "frontend", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
-		},
-	}, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)})
-	if err != nil {
-		t.Fatalf("prepareStartCandidate: %v", err)
-	}
-	if prepared.cfg.WorkDir != workDir {
-		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, workDir)
-	}
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			templateDir := t.TempDir()
+			taskDir := t.TempDir()
+			canonicalSessionDir := t.TempDir()
+			legacySessionDir := t.TempDir()
+			sourceDirs := map[string]string{
+				"template":          templateDir,
+				"task":              taskDir,
+				"canonical-session": canonicalSessionDir,
+				"legacy-session":    legacySessionDir,
+				"legacy-task":       taskDir,
+			}
 
-func TestPrepareStartCandidate_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing.T) {
-	base := beads.NewMemStore()
-	store := &taskWorkDirLiveListCountingStore{Store: base}
-	session, err := store.Create(beads.Bead{
-		Title:  "worker",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel, "agent:frontend/worker-1"},
-		Metadata: map[string]string{
-			"template":     "worker",
-			"session_name": "custom-worker-1",
-			"pool_slot":    "1",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	workDir := t.TempDir()
-	task, err := store.Create(beads.Bead{
-		Title: "task",
-		Metadata: map[string]string{
-			"work_dir": workDir,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	assignee := session.ID
-	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
-		t.Fatal(err)
-	}
-	task, err = store.Get(task.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
+			store := beads.NewMemStore()
+			sessionMetadata := map[string]string{
+				"template":     "worker",
+				"session_name": "custom-worker-1",
+				"pool_slot":    "1",
+			}
+			for key, source := range tc.sessionMetadata {
+				sessionMetadata[key] = sourceDirs[source]
+			}
+			session, err := store.Create(beads.Bead{
+				Title:    "worker",
+				Type:     sessionBeadType,
+				Labels:   []string{sessionBeadLabel, "agent:frontend/worker-1"},
+				Metadata: sessionMetadata,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	prepared, err := prepareStartCandidateForCity(startCandidate{
-		info: sessiontest.SeedBead(t, session),
-		tp: TemplateParams{
-			TemplateName: "frontend/worker",
-			SessionName:  "custom-worker-1",
-		},
-		order: 0,
-	}, "", "", &config.City{
-		Agents: []config.Agent{
-			{Name: "worker", Dir: "frontend", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
-		},
-	}, nil, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}, nil, newAssignedTaskWorkDirResolver("", []beads.Bead{task}))
-	if err != nil {
-		t.Fatalf("prepareStartCandidateForCity: %v", err)
-	}
-	if prepared.cfg.WorkDir != workDir {
-		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists != 0 {
-		t.Fatalf("live in-progress assignee List calls = %d, want 0 with snapshot resolver", store.liveInProgressAssigneeLists)
+			taskMetadata := make(map[string]string, len(tc.taskMetadata))
+			for key, source := range tc.taskMetadata {
+				taskMetadata[key] = sourceDirs[source]
+			}
+			task, err := store.Create(beads.Bead{Title: "task", Metadata: taskMetadata})
+			if err != nil {
+				t.Fatal(err)
+			}
+			status := "in_progress"
+			assignee := session.ID
+			if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+				t.Fatal(err)
+			}
+
+			prepared, err := prepareStartCandidate(startCandidate{
+				info: sessiontest.SeedBead(t, session),
+				tp: TemplateParams{
+					TemplateName: "frontend/worker",
+					SessionName:  "custom-worker-1",
+					WorkDir:      templateDir,
+				},
+				order: 0,
+			}, &config.City{
+				Agents: []config.Agent{{
+					Name: "worker",
+					Dir:  "frontend",
+				}},
+			}, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)})
+			if err != nil {
+				t.Fatalf("prepareStartCandidate: %v", err)
+			}
+			if want := sourceDirs[tc.wantSource]; prepared.cfg.WorkDir != want {
+				t.Fatalf("prepared.cfg.WorkDir = %q, want %s dir %q", prepared.cfg.WorkDir, tc.wantSource, want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
@@ -1342,10 +1341,6 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if apply != nil {
 			apply(&reconcileOpts)
 		}
-	}
-	effectiveStartOptions := startOptions
-	if !storeQueryPartial && reconcileOpts.workDirResolver == nil && len(assignedWorkBeads) > 0 {
-		effectiveStartOptions = append(append([]startExecutionOption(nil), startOptions...), withTaskWorkDirResolver(newAssignedTaskWorkDirResolver(cityPath, assignedWorkBeads)))
 	}
 	if startupTimeout <= 0 && cfg != nil {
 		startupTimeout = cfg.Session.StartupTimeoutDuration()
@@ -3724,7 +3719,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
 		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
-		effectiveStartOptions...,
+		startOptions...,
 	)
 	startedThisTick = plannedWakes
 	recordPhase(TraceSiteSessionReconcileStartExecution, "session_reconcile.execute_planned_starts", phaseStart, map[string]any{
@@ -5259,58 +5254,15 @@ func clearMissingIdleProbes(dt *drainTracker, infoByID map[string]sessionpkg.Inf
 	}
 }
 
-// resolveWorkDirAgainstCity anchors a bead-stored work_dir value to the city
-// root. Worktree-per-bead dispatch stores this metadata city-relative (e.g.
-// ".gc/worktrees/gascity/builder/<slug>") so the value stays valid across
-// machines with different absolute city paths; resolving it with os.Stat
-// directly would instead resolve against the calling process's cwd, which is
-// how scaffold staging leaked into shared long-lived worktrees (ga-ajw1no).
-// Already-absolute values (the legacy convention) pass through unchanged.
+// resolveWorkDirAgainstCity anchors a session-stored worker directory to the
+// city root. Relative metadata stays valid across machines with different
+// absolute city paths instead of resolving against the controller's cwd.
+// Already-absolute values pass through unchanged.
 func resolveWorkDirAgainstCity(cityPath, workDir string) string {
 	if workDir == "" || cityPath == "" || filepath.IsAbs(workDir) {
 		return workDir
 	}
 	return filepath.Join(cityPath, workDir)
-}
-
-// resolveTaskWorkDir checks the agent's assigned task beads for a work_dir
-// metadata field. If a task bead has work_dir set and the directory exists
-// on disk, that path is returned. This lets the reconciler start the agent
-// in the worktree that the previous session (or this session's prior run)
-// created, without any prompt-side logic.
-func resolveTaskWorkDir(cityPath string, store beads.Store, assignees ...string) string {
-	if store == nil {
-		return ""
-	}
-	seen := make(map[string]bool, len(assignees))
-	for _, assignee := range assignees {
-		assignee = strings.TrimSpace(assignee)
-		if assignee == "" || seen[assignee] {
-			continue
-		}
-		seen[assignee] = true
-		assigned, err := store.List(beads.ListQuery{
-			Assignee: assignee,
-			Status:   "in_progress",
-			Live:     true,
-			TierMode: beads.TierBoth,
-			Sort:     beads.SortCreatedDesc,
-		})
-		if err != nil {
-			continue
-		}
-		for _, b := range assigned {
-			wd := strings.TrimSpace(b.Metadata["work_dir"])
-			if wd == "" {
-				continue
-			}
-			resolved := resolveWorkDirAgainstCity(cityPath, wd)
-			if info, err := os.Stat(resolved); err == nil && info.IsDir() {
-				return resolved
-			}
-		}
-	}
-	return ""
 }
 
 // dispatchOptionMetadataKey returns the bead-metadata key carrying a
@@ -5380,48 +5332,6 @@ func workBeadOptionOverrides(b beads.Bead, rp *config.ResolvedProvider) (map[str
 		overrides[opt.Key] = value
 	}
 	return overrides, sawOptions
-}
-
-type assignedTaskWorkDir struct {
-	path      string
-	createdAt time.Time
-}
-
-// newAssignedTaskWorkDirResolver resolves work_dir values from the
-// reconciler's snapshot; misses intentionally fall back to the live lookup.
-func newAssignedTaskWorkDirResolver(cityPath string, assignedWorkBeads []beads.Bead) taskWorkDirResolver {
-	index := make(map[string]assignedTaskWorkDir)
-	for _, bead := range assignedWorkBeads {
-		if bead.Status != "in_progress" {
-			continue
-		}
-		assignee := strings.TrimSpace(bead.Assignee)
-		if assignee == "" {
-			continue
-		}
-		workDir := strings.TrimSpace(bead.Metadata["work_dir"])
-		if workDir == "" {
-			continue
-		}
-		workDir = resolveWorkDirAgainstCity(cityPath, workDir)
-		info, err := os.Stat(workDir)
-		if err != nil || !info.IsDir() {
-			continue
-		}
-		current, ok := index[assignee]
-		if ok && !bead.CreatedAt.After(current.createdAt) {
-			continue
-		}
-		index[assignee] = assignedTaskWorkDir{path: workDir, createdAt: bead.CreatedAt}
-	}
-	return func(candidate startCandidate, cfg *config.City) string {
-		for _, assignee := range taskWorkDirAssignees(candidate, cfg) {
-			if workDir := index[strings.TrimSpace(assignee)].path; workDir != "" {
-				return workDir
-			}
-		}
-		return ""
-	}
 }
 
 // truncateHashForLog returns a short representation of a fingerprint hash
@@ -5559,7 +5469,7 @@ func relaunchAgentForLaunchDrift(
 		return false, nil
 	}
 	// Capture whether the bead already tracked a resumable conversation BEFORE
-	// buildPreparedStart runs. An empty session_key means any key the preparation
+	// buildPreparedStartForCity runs. An empty session_key means any key the preparation
 	// mints below (for a SessionIDFlag provider) is speculative: it names a
 	// conversation the relaunch has not created yet. Such a speculative key must
 	// never be executed as `--resume` and must never survive into the full-restart
@@ -5568,15 +5478,14 @@ func relaunchAgentForLaunchDrift(
 	// execution, and relaunchAbortResidueFold clears the key on every abort path.
 	hadResumeKeyBeforePrepare := strings.TrimSpace(info.SessionKey) != ""
 	// Derive the executable config exactly as the fresh-start / pending-create
-	// recovery paths do. cityPath resolves the session's work_dir against the city;
-	// the nil work-dir resolver is correct because both call sites sit behind the
-	// no-open-assigned-work / not-active deferral guards. Deliberately
-	// buildPreparedStart*, NOT prepareStartCandidateForCity — the session is alive,
+	// recovery paths do. cityPath resolves a relative session worker directory
+	// against the city. Deliberately
+	// buildPreparedStartForCity, NOT prepareStartCandidateForCity — the session is alive,
 	// not waking, so no preWakeCommit / named-template refresh. The SECOND return
 	// value is the fold-coherent Info: every start-prep mutation (stale-resume
 	// clear, session_key / instance_token mint) is folded onto it the moment it
 	// persists, so it is the post-prepare state on the success AND the error return.
-	prepared, preparedInfo, err := buildPreparedStartWithWorkDirResolver(startCandidate{info: info, tp: tp}, cityPath, cfg, store, nil)
+	prepared, preparedInfo, err := buildPreparedStartForCity(startCandidate{info: info, tp: tp}, cityPath, cfg, store)
 	if err != nil {
 		fmt.Fprintf(stderr, "session reconciler: preparing relaunch config for %s: %v; falling back to full restart\n", name, err) //nolint:errcheck
 		return false, relaunchAbortResidueFold(preparedInfo, sessFront, hadResumeKeyBeforePrepare)
@@ -5670,7 +5579,7 @@ func relaunchAgentForLaunchDrift(
 // speculatively-minted resume key from surviving the fallback.
 //
 // When the bead carried no session_key before preparation,
-// buildPreparedStartWithWorkDirResolver minted one (persisting it to the store
+// buildPreparedStartForCity minted one (persisting it to the store
 // via SetMarker) so it could build the relaunch command. That key names a
 // conversation the aborted relaunch never created. Left in place,
 // resetConfiguredNamedSessionForConfigDrift would see a non-empty session_key
@@ -5744,7 +5653,7 @@ func rebaselineLaunchDriftHashesWithBatch(id string, sessFront *sessionpkg.Store
 // subsequent wake (firstStart=false) the fork branch is skipped and the forked
 // child resumes via its own key. wake_mode=fresh still mints a new conversation
 // via SessionIDFlag. Fork preconditions (provider support, parent staleness,
-// wake_mode) are validated upstream in buildPreparedStartWithWorkDirResolver,
+// wake_mode) are validated upstream in buildPreparedStartForCity,
 // which fails loud rather than ever silently degrading a fork to a fresh start.
 func resolveSessionCommand(command, sessionKey, parentSID string, rp *config.ResolvedProvider, firstStart, forceFresh bool) string {
 	// forceFresh is part of the fork guard so this branch is self-contained: a

--- a/cmd/gc/session_reconciler_drift_resume_test.go
+++ b/cmd/gc/session_reconciler_drift_resume_test.go
@@ -77,7 +77,7 @@ func TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinua
 
 	prepared, err := prepareStartCandidateForCity(
 		startCandidate{info: env.sessionInfo(got.ID), tp: tp, order: 0},
-		"", "", cfg, env.sp, env.store, clk, io.Discard, nil,
+		"", "", cfg, env.sp, env.store, clk, io.Discard,
 	)
 	if err != nil {
 		t.Fatalf("prepareStartCandidateForCity: %v", err)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -505,22 +505,23 @@ func TestReconcileSessionBeadsHealFailureStopsSamePassEffects(t *testing.T) {
 	}
 }
 
-func TestReconcileSessionBeads_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing.T) {
+func TestReconcileSessionBeads_TaskMetadataCannotOverrideSessionWorkerDir(t *testing.T) {
 	env := newReconcilerTestEnv()
-	base := beads.NewMemStore()
-	store := &taskWorkDirLiveListCountingStore{Store: base}
-	env.store = store
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
 	env.addDesired("worker", "worker", false)
 	session := env.createSessionBead("worker", "worker")
 	env.markSessionCreating(&session)
+	sessionDir := t.TempDir()
+	env.setSessionMetadata(&session, map[string]string{"worker_dir": sessionDir})
 
-	workDir := t.TempDir()
+	taskArtifactDir := t.TempDir()
+	taskLegacyWorkDir := t.TempDir()
 	task, err := env.store.Create(beads.Bead{
 		Title: "assigned task",
 		Type:  "task",
 		Metadata: map[string]string{
-			"work_dir": workDir,
+			"artifact_dir": taskArtifactDir,
+			"work_dir":     taskLegacyWorkDir,
 		},
 	})
 	if err != nil {
@@ -568,141 +569,15 @@ func TestReconcileSessionBeads_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing
 	if startCfg == nil {
 		t.Fatal("worker was not started")
 	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
+	if startCfg.WorkDir != sessionDir {
+		t.Fatalf(
+			"started WorkDir = %q, want session worker_dir %q (task artifact_dir=%q, task work_dir=%q)",
+			startCfg.WorkDir,
+			sessionDir,
+			taskArtifactDir,
+			taskLegacyWorkDir,
+		)
 	}
-	if store.liveInProgressAssigneeLists != 0 {
-		t.Fatalf("live in-progress assignee List calls = %d, want 0 with complete assigned-work snapshot", store.liveInProgressAssigneeLists)
-	}
-}
-
-func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWithoutAssignedWorkSnapshot(t *testing.T) {
-	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
-	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, nil, false)
-	if woken != 1 {
-		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
-	}
-	startCfg := env.sp.LastStartConfig("worker")
-	if startCfg == nil {
-		t.Fatal("worker was not started")
-	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists == 0 {
-		t.Fatal("live in-progress assignee List calls = 0, want live fallback without assigned-work snapshot")
-	}
-}
-
-func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWhenAssignedWorkSnapshotPartial(t *testing.T) {
-	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
-	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, nil, true)
-	if woken != 1 {
-		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
-	}
-	startCfg := env.sp.LastStartConfig("worker")
-	if startCfg == nil {
-		t.Fatal("worker was not started")
-	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists == 0 {
-		t.Fatal("live in-progress assignee List calls = 0, want live fallback when assigned-work snapshot is partial")
-	}
-}
-
-func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWhenAssignedWorkSnapshotMisses(t *testing.T) {
-	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
-	unrelatedWorkDir := t.TempDir()
-	unrelatedTask := createInProgressTaskWithWorkDir(t, env.store, "other-worker", unrelatedWorkDir)
-	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, []beads.Bead{unrelatedTask}, false)
-	if woken != 1 {
-		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
-	}
-	startCfg := env.sp.LastStartConfig("worker")
-	if startCfg == nil {
-		t.Fatal("worker was not started")
-	}
-	if startCfg.WorkDir != workDir {
-		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
-	}
-	if store.liveInProgressAssigneeLists == 0 {
-		t.Fatal("live in-progress assignee List calls = 0, want live fallback when assigned-work snapshot misses")
-	}
-}
-
-func newReconcilerTaskWorkDirTest(t *testing.T) (*reconcilerTestEnv, *taskWorkDirLiveListCountingStore, beads.Bead, string) {
-	t.Helper()
-	env := newReconcilerTestEnv()
-	base := beads.NewMemStore()
-	store := &taskWorkDirLiveListCountingStore{Store: base}
-	env.store = store
-	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
-	env.addDesired("worker", "worker", false)
-	session := env.createSessionBead("worker", "worker")
-	env.markSessionCreating(&session)
-	workDir := t.TempDir()
-	createInProgressTaskWithWorkDir(t, env.store, session.ID, workDir)
-	return env, store, session, workDir
-}
-
-func createInProgressTaskWithWorkDir(t *testing.T, store beads.Store, assignee, workDir string) beads.Bead {
-	t.Helper()
-	task, err := store.Create(beads.Bead{
-		Title: "assigned task",
-		Type:  "task",
-		Metadata: map[string]string{
-			"work_dir": workDir,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Create(task): %v", err)
-	}
-	status := "in_progress"
-	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
-		t.Fatalf("Update(task): %v", err)
-	}
-	task, err = store.Get(task.ID)
-	if err != nil {
-		t.Fatalf("Get(task): %v", err)
-	}
-	return task
-}
-
-func reconcileSessionBeadsWithTaskWorkDirSnapshot(
-	t *testing.T,
-	env *reconcilerTestEnv,
-	session beads.Bead,
-	assignedWorkBeads []beads.Bead,
-	storeQueryPartial bool,
-) int {
-	t.Helper()
-	cfgNames := configuredSessionNames(env.cfg, "", env.store)
-	return reconcileSessionBeads(
-		context.Background(),
-		[]beads.Bead{session},
-		env.desiredState,
-		cfgNames,
-		env.cfg,
-		env.sp,
-		env.store,
-		nil,
-		assignedWorkBeads,
-		nil,
-		env.dt,
-		map[string]int{"worker": 1},
-		storeQueryPartial,
-		nil,
-		"",
-		nil,
-		env.clk,
-		env.rec,
-		0,
-		0,
-		&env.stdout,
-		&env.stderr,
-	)
 }
 
 func waitForProviderStopped(t *testing.T, sp runtime.Provider, name string) {

--- a/cmd/gc/session_scaffold_staging_test.go
+++ b/cmd/gc/session_scaffold_staging_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
-func TestPrepareStartCandidateStagesScaffoldInResolvedTaskWorkDirWhenCWDIsSharedWorktree(t *testing.T) {
+func TestPrepareStartCandidateStagesScaffoldInResolvedSessionWorkerDirWhenCWDIsSharedWorktree(t *testing.T) {
 	root := t.TempDir()
 	cityPath := filepath.Join(root, "city")
 	sharedWorktree := filepath.Join(root, "shared-builder")
@@ -46,23 +46,10 @@ func TestPrepareStartCandidateStagesScaffoldInResolvedTaskWorkDirWhenCWDIsShared
 		Metadata: map[string]string{
 			"template":     "builder",
 			"session_name": "builder-ga-ajw1no",
+			"worker_dir":   relativeTargetWorkDir,
 		},
 	})
 	if err != nil {
-		t.Fatal(err)
-	}
-	task, err := store.Create(beads.Bead{
-		Title: "task",
-		Metadata: map[string]string{
-			"work_dir": relativeTargetWorkDir,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	assignee := session.ID
-	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -92,13 +79,13 @@ func TestPrepareStartCandidateStagesScaffoldInResolvedTaskWorkDirWhenCWDIsShared
 				MaxActiveSessions: intPtrScaffoldRegression(2),
 			},
 		},
-	}, nil, store, &clock.Fake{Time: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}, io.Discard, nil)
+	}, nil, store, &clock.Fake{Time: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}, io.Discard)
 	if err != nil {
 		t.Fatalf("prepareStartCandidateForCity: %v", err)
 	}
 
 	if prepared.cfg.WorkDir != targetWorkDir {
-		t.Errorf("prepared.cfg.WorkDir = %q, want resolved task work_dir %q", prepared.cfg.WorkDir, targetWorkDir)
+		t.Errorf("prepared.cfg.WorkDir = %q, want resolved session worker_dir %q", prepared.cfg.WorkDir, targetWorkDir)
 	}
 	if prepared.cfg.Env["GC_DIR"] != targetWorkDir {
 		t.Errorf("prepared.cfg.Env[GC_DIR] = %q, want %q", prepared.cfg.Env["GC_DIR"], targetWorkDir)
@@ -156,7 +143,7 @@ func intPtrScaffoldRegression(n int) *int {
 
 // TestRetargetPreStartWorkDirPreservesShellQuoting proves that retargeting a
 // generated materialize-skills / project-mcp PreStart command onto a resolved
-// task work_dir keeps the `--workdir` argument shell-safe. The generators emit
+// session worker_dir keeps the `--workdir` argument shell-safe. The generators emit
 // the workdir as a shell-quoted token; a resolved work_dir that contains a
 // space (macOS "/Users/First Last/...") or a shell metacharacter must not be
 // spliced in raw, or the rendered `sh -c` command breaks argument boundaries or

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -818,7 +818,7 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 // promptDelivery result it computed. The launch path (buildPreparedStart) needs
 // the Delivered decision to stamp the S19 priming markers, but it must NOT infer
 // delivery from cfg.Env[GC_STARTUP_PROMPT_DELIVERED]: the resume override in
-// buildPreparedStartWithWorkDirResolver re-sets that env marker to "1" for hook
+// buildPreparedStartForCity re-sets that env marker to "1" for hook
 // consumption even when nothing is delivered that incarnation. Threading the
 // result avoids that trap. templateParamsToConfig is the wrapper that discards
 // the second value; all other call sites are unchanged.

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -579,7 +579,7 @@ func TestResolveTemplateHeadlessAgentStaysMouseOff(t *testing.T) {
 // TestTemplateParamsToConfigInteractiveSessionEnablesMouse locks ga-c4w finding
 // #1 for the MANAGED `gc session new` deferred-start path: the reconciler starts
 // a session_origin=manual bead through templateParamsToConfig (see
-// buildPreparedStartWithWorkDirResolver). A manual session must resolve
+// buildPreparedStartForCity). A manual session must resolve
 // MouseOn=true even when the agent config sets no mouse_mode, while ephemeral
 // pool agents stay MouseOn=false (controller-poll safety). This is the seam the
 // original API-only fix missed: MouseOn for `gc session new` never flowed through

--- a/internal/beads/contract/metadata.go
+++ b/internal/beads/contract/metadata.go
@@ -11,9 +11,8 @@ import (
 //
 // The legacy `work_dir` key was overloaded: it meant "agent process cwd"
 // when written on session beads and "work artifact directory" when
-// written on task/molecule beads. resolveTaskWorkDir in
-// cmd/gc/session_reconciler.go silently bridged the two semantics. The
-// new keys split the meaning:
+// written on task/molecule beads. The former reconciler task-work-dir lookup
+// silently bridged the two semantics. The new keys split the meaning:
 //
 //	WorkerDirKey ("worker_dir")     — agent process cwd. Session beads.
 //	ArtifactDirKey ("artifact_dir") — work artifact directory.


### PR DESCRIPTION
## Summary

- remove the reconciler's legacy task `work_dir` lookup from provider startup
- source provider cwd only from session lifecycle metadata (`worker_dir`, with a session-only legacy `work_dir` fallback)
- preserve city-relative session paths, generated PreStart retargeting, warm relaunch behavior, and task-scoped provider options
- replace obsolete task-cwd expectations with regressions proving assigned task metadata cannot redirect fresh or reconciled sessions

## Why

Task artifacts and provider homes have different owners and lifetimes. Letting an assigned task redirect provider cwd can put persistent session state inside a task worktree, or task work inside a prunable provider home.

The session bead already owns the provider cwd contract. This change makes that boundary explicit on `main`.

## Scope

This is the focused mainline read-path correction for #1251. It does not claim to complete #1251; canonical writes, doctor and creation-time validation, and deprecation lint remain separate.

The v1.3.x backport is #4589 and remains draft pending acceptance of this mainline change.

## Validation

- focused task-cwd/session-worker-dir and reconciler regressions
- `go test ./cmd/gc -count=1 -parallel=4` (PASS, 242.824s on the final rebased head)
- `go vet ./cmd/gc`
- `go build ./cmd/gc`
- `git diff --check`

Fresh upstream CI is otherwise green. Its sole failing job is an unrelated, load-sensitive product-metrics testhook: a best-effort recording was dropped inside the metrics path's 50 ms decision budget. This PR does not touch metrics code; the same head's preceding CI invocation passed that job, and the exact contract passed 100 repeated runs on both this head and current `main`.
