### PR TITLE
fix(session): fail closed when pruning worktrees

### DIFF
--- a/cmd/gc/bead_worktree_reaper.go
+++ b/cmd/gc/bead_worktree_reaper.go
@@ -7,12 +7,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/git"
+	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/sling"
 )
 
@@ -22,6 +24,7 @@ import (
 type beadWorktreeGitProbe interface {
 	IsRepo() bool
 	CurrentBranch() (string, error)
+	WorktreeList() ([]git.Worktree, error)
 	HasUncommittedWork() bool
 	HasUnpushedCommitsResult() (bool, error)
 	HasStashesResult() (bool, error)
@@ -81,15 +84,31 @@ func reapClosedBeadWorktrees(
 			continue
 		}
 		rigWorktreeDir := filepath.Join(wtRoot, rigName)
-		scanDirs := []string{
-			rigWorktreeDir,
-			filepath.Join(rigWorktreeDir, "artifacts", "worktrees"),
+		resolvedRigWorktreeDir, err := resolveRigWorktreeDir(resolvedWtRoot, rigName, rigWorktreeDir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				fmt.Fprintf(stderr, "reapClosedBeadWorktrees: resolving rig worktree directory %s: %v\n", rigWorktreeDir, err) //nolint:errcheck
+			}
+			continue
+		}
+		scanDirs := []struct {
+			path     string
+			expected string
+		}{
+			{
+				path:     rigWorktreeDir,
+				expected: resolvedRigWorktreeDir,
+			},
+			{
+				path:     filepath.Join(rigWorktreeDir, "artifacts", "worktrees"),
+				expected: filepath.Join(resolvedRigWorktreeDir, "artifacts", "worktrees"),
+			},
 		}
 		for _, scanDir := range scanDirs {
-			resolvedScanDir, err := resolveWorktreeScanDir(resolvedWtRoot, scanDir)
+			resolvedScanDir, err := resolveWorktreeScanDir(resolvedWtRoot, scanDir.expected, scanDir.path)
 			if err != nil {
 				if !os.IsNotExist(err) {
-					fmt.Fprintf(stderr, "reapClosedBeadWorktrees: resolving scan directory %s: %v\n", scanDir, err) //nolint:errcheck
+					fmt.Fprintf(stderr, "reapClosedBeadWorktrees: resolving scan directory %s: %v\n", scanDir.path, err) //nolint:errcheck
 				}
 				continue
 			}
@@ -141,6 +160,29 @@ func reapClosedBeadWorktrees(
 				wg := newBeadWorktreeGitProbe(worktreePath)
 				if !wg.IsRepo() {
 					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, "not a git repository")
+					continue
+				}
+				worktrees, err := wg.WorktreeList()
+				if err != nil {
+					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, "descendant worktree probe failed: "+err.Error())
+					continue
+				}
+				hasRegisteredDescendant := false
+				for _, wt := range worktrees {
+					if pathutil.PathWithin(worktreePath, wt.Path) && !pathutil.SamePath(worktreePath, wt.Path) {
+						recordBeadWorktreeReapSkip(
+							rec,
+							stderr,
+							beadID,
+							rigName,
+							worktreePath,
+							"contains registered descendant worktree "+wt.Path,
+						)
+						hasRegisteredDescendant = true
+						break
+					}
+				}
+				if hasRegisteredDescendant {
 					continue
 				}
 				hasUncommitted := wg.HasUncommittedWork()
@@ -254,7 +296,30 @@ func resolveWorktreeRoot(cityPath, wtRoot string) (string, error) {
 	return resolvedWtRoot, nil
 }
 
-func resolveWorktreeScanDir(resolvedWtRoot, scanDir string) (string, error) {
+func resolveRigWorktreeDir(resolvedWtRoot, rigName, rigWorktreeDir string) (string, error) {
+	if rigName == "" || rigName == "." || rigName == ".." || filepath.IsAbs(rigName) || filepath.Base(rigName) != rigName {
+		return "", fmt.Errorf("invalid rig name %q for worktree scan", rigName)
+	}
+	resolvedRigWorktreeDir, err := filepath.EvalSymlinks(rigWorktreeDir)
+	if err != nil {
+		return "", err
+	}
+	resolvedRigWorktreeDir = filepath.Clean(resolvedRigWorktreeDir)
+	expectedRigWorktreeDir := filepath.Clean(filepath.Join(resolvedWtRoot, rigName))
+	if !isStrictlyUnderDir(resolvedWtRoot, resolvedRigWorktreeDir) {
+		return "", fmt.Errorf("resolved rig worktree directory %s escapes worktree root %s", resolvedRigWorktreeDir, resolvedWtRoot)
+	}
+	if resolvedRigWorktreeDir != expectedRigWorktreeDir {
+		return "", fmt.Errorf(
+			"resolved rig worktree directory %s retargets expected rig worktree directory %s",
+			resolvedRigWorktreeDir,
+			expectedRigWorktreeDir,
+		)
+	}
+	return resolvedRigWorktreeDir, nil
+}
+
+func resolveWorktreeScanDir(resolvedWtRoot, expectedScanDir, scanDir string) (string, error) {
 	resolvedScanDir, err := filepath.EvalSymlinks(scanDir)
 	if err != nil {
 		return "", err
@@ -262,6 +327,14 @@ func resolveWorktreeScanDir(resolvedWtRoot, scanDir string) (string, error) {
 	resolvedScanDir = filepath.Clean(resolvedScanDir)
 	if !isStrictlyUnderDir(resolvedWtRoot, resolvedScanDir) {
 		return "", fmt.Errorf("resolved scan directory %s escapes worktree root %s", resolvedScanDir, resolvedWtRoot)
+	}
+	expectedScanDir = filepath.Clean(expectedScanDir)
+	if resolvedScanDir != expectedScanDir {
+		return "", fmt.Errorf(
+			"resolved scan directory %s retargets expected scan directory %s",
+			resolvedScanDir,
+			expectedScanDir,
+		)
 	}
 	return resolvedScanDir, nil
 }
@@ -271,13 +344,19 @@ func resolveWorktreeScanDir(resolvedWtRoot, scanDir string) (string, error) {
 // Duplicate rows are ambiguous even when they currently agree, so cleanup
 // fails closed until the routing/store inconsistency is resolved.
 func closedBeadForWorktreeReap(cityStore, rigStore beads.Store, beadID string) (bool, string) {
+	if cityStore == nil {
+		return false, "HQ store unavailable"
+	}
+	if rigStore == nil {
+		return false, "rig store unavailable"
+	}
 	stores := []struct {
 		name  string
 		store beads.Store
 	}{
 		{name: "HQ", store: cityStore},
 	}
-	if rigStore != cityStore {
+	if !sameComparableBeadStore(rigStore, cityStore) {
 		stores = append(stores, struct {
 			name  string
 			store beads.Store
@@ -286,10 +365,11 @@ func closedBeadForWorktreeReap(cityStore, rigStore beads.Store, beadID string) (
 
 	var found []beads.Bead
 	for _, candidate := range stores {
-		if candidate.store == nil {
-			continue
+		live := beads.HandlesFor(candidate.store).Live
+		if live == nil {
+			return false, candidate.name + " live store handle unavailable"
 		}
-		bead, err := candidate.store.Get(beadID)
+		bead, err := live.Get(beadID)
 		switch {
 		case err == nil:
 			found = append(found, bead)
@@ -308,11 +388,31 @@ func closedBeadForWorktreeReap(cityStore, rigStore beads.Store, beadID string) (
 	return true, ""
 }
 
+// sameComparableBeadStore reports identity only when comparing the two Store
+// interface values cannot panic. Store implementations are not required to
+// have comparable concrete types, so an unconditional interface comparison
+// can panic the reconciler. Treat non-comparable wrappers as distinct; probing
+// both then conservatively turns a shared row into duplicate-store ambiguity.
+func sameComparableBeadStore(left, right beads.Store) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+	if leftValue.Type() != rightValue.Type() || !leftValue.Comparable() || !rightValue.Comparable() {
+		return false
+	}
+	return left == right
+}
+
 // extractBeadIDFromWorktreeName scans dash-separated substrings in name for
-// one that LooksLikeConfiguredBeadID. For each starting segment it keeps the
-// longest valid candidate, so configured hyphenated prefixes are not
-// truncated to a shorter prefix match. Returns the first positional match, or
-// "" if none. Handles names like "builder-ga-34q3ss-pr2738" → "ga-34q3ss",
+// one that LooksLikeConfiguredBeadID. For each starting segment it prefers the
+// candidate with the longest configured prefix, while retaining the shortest
+// candidate for that prefix. The latter matters for hierarchical IDs:
+// LooksLikeConfiguredBeadID intentionally ignores text after the first dot,
+// so a legacy suffix such as "-pr2738" must not become part of "ga-abc.1".
+// Returns the first positional match, or "" if none. Handles names like
+// "builder-ga-34q3ss-pr2738" → "ga-34q3ss",
 // "builder-agent-diagnostics-hnn" → "agent-diagnostics-hnn", and bare
 // "ga-06kfi6" → "ga-06kfi6".
 func extractBeadIDFromWorktreeName(cfg *config.City, name string) string {
@@ -321,15 +421,21 @@ func extractBeadIDFromWorktreeName(cfg *config.City, name string) string {
 	}
 	parts := strings.Split(name, "-")
 	for start := 0; start+1 < len(parts); start++ {
-		longest := ""
+		best := ""
+		bestPrefixLen := 0
 		for end := start + 2; end <= len(parts); end++ {
 			candidate := strings.Join(parts[start:end], "-")
-			if sling.LooksLikeConfiguredBeadID(cfg, candidate) && len(candidate) > len(longest) {
-				longest = candidate
+			if !sling.LooksLikeConfiguredBeadID(cfg, candidate) {
+				continue
+			}
+			prefixLen := len(sling.BeadPrefixForCity(cfg, candidate))
+			if prefixLen > bestPrefixLen {
+				best = candidate
+				bestPrefixLen = prefixLen
 			}
 		}
-		if longest != "" {
-			return longest
+		if best != "" {
+			return best
 		}
 	}
 	return ""

--- a/cmd/gc/bead_worktree_reaper.go
+++ b/cmd/gc/bead_worktree_reaper.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,14 +16,33 @@ import (
 	"github.com/gastownhall/gascity/internal/sling"
 )
 
+// beadWorktreeGitProbe is the subset of git.Git used while deciding whether
+// a closed bead's worktree can be removed. Keeping the probes behind an
+// interface lets tests verify that any inconclusive result fails closed.
+type beadWorktreeGitProbe interface {
+	IsRepo() bool
+	CurrentBranch() (string, error)
+	HasUncommittedWork() bool
+	HasUnpushedCommitsResult() (bool, error)
+	HasStashesResult() (bool, error)
+	WorktreeRemove(path string, force bool) error
+}
+
+var newBeadWorktreeGitProbe = func(workDir string) beadWorktreeGitProbe {
+	return git.New(workDir)
+}
+
 // reapClosedBeadWorktrees scans per-bead git worktrees under
-// cityPath/.gc/worktrees/<rig>/ and removes any that are associated with a
-// closed bead and pass all safety gates (no uncommitted work, no unpushed
-// commits, no stashes). Named session home directories are never removed.
-// Returns the number of worktrees successfully removed.
+// both the legacy cityPath/.gc/worktrees/<rig>/ layout and the canonical
+// cityPath/.gc/worktrees/<rig>/artifacts/worktrees/ layout. It removes any
+// worktrees associated with a closed bead that pass all safety gates (valid
+// git repository, no uncommitted work, no unpushed commits, and no stashes).
+// Named session home directories are never removed. Returns the number of
+// worktrees successfully removed.
 func reapClosedBeadWorktrees(
 	cityPath string,
 	cfg *config.City,
+	cityBeadStore beads.Store,
 	rigBeadStores map[string]beads.Store,
 	rec events.Recorder,
 	stderr io.Writer,
@@ -47,6 +67,13 @@ func reapClosedBeadWorktrees(
 	}
 
 	wtRoot := filepath.Join(cityPath, ".gc", "worktrees")
+	resolvedWtRoot, err := resolveWorktreeRoot(cityPath, wtRoot)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "reapClosedBeadWorktrees: resolving worktree root %s: %v\n", wtRoot, err) //nolint:errcheck
+		}
+		return 0
+	}
 	reaped := 0
 
 	for rigName, store := range rigBeadStores {
@@ -54,119 +81,255 @@ func reapClosedBeadWorktrees(
 			continue
 		}
 		rigWorktreeDir := filepath.Join(wtRoot, rigName)
-		entries, err := os.ReadDir(rigWorktreeDir)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				fmt.Fprintf(stderr, "reapClosedBeadWorktrees: reading %s: %v\n", rigWorktreeDir, err) //nolint:errcheck
-			}
-			continue
+		scanDirs := []string{
+			rigWorktreeDir,
+			filepath.Join(rigWorktreeDir, "artifacts", "worktrees"),
 		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
+		for _, scanDir := range scanDirs {
+			resolvedScanDir, err := resolveWorktreeScanDir(resolvedWtRoot, scanDir)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					fmt.Fprintf(stderr, "reapClosedBeadWorktrees: resolving scan directory %s: %v\n", scanDir, err) //nolint:errcheck
+				}
 				continue
 			}
-			name := entry.Name()
-
-			// Session home guard: never touch agent template directories.
-			if sessionHomes[name] {
+			entries, err := os.ReadDir(resolvedScanDir)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					fmt.Fprintf(stderr, "reapClosedBeadWorktrees: reading %s: %v\n", resolvedScanDir, err) //nolint:errcheck
+				}
 				continue
 			}
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				name := entry.Name()
 
-			// Extract a bead ID candidate from the directory name.
-			beadID := extractBeadIDFromWorktreeName(cfg, name)
-			if beadID == "" {
-				continue
-			}
+				// Session home guard: never touch agent template directories.
+				if sessionHomes[name] {
+					continue
+				}
 
-			// Confirm the bead exists and is closed in this rig's store.
-			bead, err := store.Get(beadID)
-			if err != nil || bead.Status != "closed" {
-				// ErrNotFound, transient error, or bead not yet closed — skip.
-				continue
-			}
+				// Extract a bead ID candidate from the directory name.
+				beadID := extractBeadIDFromWorktreeName(cfg, name)
+				if beadID == "" {
+					continue
+				}
 
-			worktreePath := filepath.Join(rigWorktreeDir, name)
+				// Routed work can live in the HQ store even when its executor is
+				// rig-scoped. Require exactly one authoritative row across the
+				// HQ and owning-rig stores before treating the bead as closed.
+				closed, lookupReason := closedBeadForWorktreeReap(cityBeadStore, store, beadID)
+				if !closed {
+					if lookupReason != "" {
+						recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, filepath.Join(resolvedScanDir, name), lookupReason)
+					}
+					continue
+				}
 
-			// Scope gate: only act on paths strictly under the worktree root.
-			if !isStrictlyUnderDir(wtRoot, worktreePath) {
-				continue
-			}
+				worktreePath := filepath.Join(resolvedScanDir, name)
 
-			// Safety checks: run from the worktree directory so git status
-			// and stash list apply to the worktree's branch.
-			wg := git.New(worktreePath)
-			hasUncommitted := wg.HasUncommittedWork()
-			hasUnpushed, _ := wg.HasUnpushedCommitsResult()
-			hasStashes, _ := wg.HasStashesResult()
+				// Scope gate: only act on paths strictly under the scanned
+				// worktree directory and the city-wide worktree root.
+				if !isStrictlyUnderDir(resolvedScanDir, worktreePath) || !isStrictlyUnderDir(resolvedWtRoot, worktreePath) {
+					continue
+				}
 
-			if hasUncommitted || hasUnpushed || hasStashes {
-				reason := fmt.Sprintf("uncommitted=%v unpushed=%v stashes=%v", hasUncommitted, hasUnpushed, hasStashes)
+				// Safety checks run from the candidate worktree. Every probe
+				// must positively succeed before removal.
+				wg := newBeadWorktreeGitProbe(worktreePath)
+				if !wg.IsRepo() {
+					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, "not a git repository")
+					continue
+				}
+				hasUncommitted := wg.HasUncommittedWork()
+				hasUnpushed, err := wg.HasUnpushedCommitsResult()
+				if err != nil {
+					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, "unpushed probe failed: "+err.Error())
+					continue
+				}
+				hasStashes, err := wg.HasStashesResult()
+				if err != nil {
+					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, "stash probe failed: "+err.Error())
+					continue
+				}
+
+				if hasUncommitted || hasUnpushed || hasStashes {
+					reason := fmt.Sprintf("uncommitted=%v unpushed=%v stashes=%v", hasUncommitted, hasUnpushed, hasStashes)
+					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, reason)
+					continue
+				}
+
+				// Capture branch before removal — the worktree dir will be gone
+				// after. An inconclusive branch probe also holds the gate shut.
+				branch, err := wg.CurrentBranch()
+				if err != nil {
+					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, "branch probe failed: "+err.Error())
+					continue
+				}
+
+				// Remove from the configured rig repository, not from the city
+				// root or the worktree being removed.
+				rigRepo := configuredRigRepoPath(cityPath, cfg, rigName)
+				if rigRepo == "" {
+					recordBeadWorktreeReapSkip(rec, stderr, beadID, rigName, worktreePath, "configured rig repository unresolved")
+					continue
+				}
+				if err := newBeadWorktreeGitProbe(rigRepo).WorktreeRemove(worktreePath, false); err != nil {
+					fmt.Fprintf(stderr, "reapClosedBeadWorktrees: removing %s: %v\n", worktreePath, err) //nolint:errcheck
+					continue
+				}
 				fmt.Fprintf(stderr, //nolint:errcheck
-					"reapClosedBeadWorktrees: skipping %s (bead %s closed but unsafe: %s)\n",
-					worktreePath, beadID, reason,
+					"reapClosedBeadWorktrees: removed worktree %s for closed bead %s\n",
+					worktreePath, beadID,
 				)
-				if raw, err := json.Marshal(events.BeadWorktreeReapSkippedPayload{
+				if raw, err := json.Marshal(events.BeadWorktreeReapedPayload{
 					BeadID: beadID,
 					Path:   worktreePath,
 					Rig:    rigName,
-					Reason: reason,
+					Branch: branch,
 				}); err == nil {
 					rec.Record(events.Event{
-						Type:    events.BeadWorktreeReapSkipped,
+						Type:    events.BeadWorktreeReaped,
 						Actor:   "gc",
 						Subject: beadID,
 						Payload: raw,
 					})
 				}
-				continue
+				reaped++
 			}
-
-			// Capture branch before removal — the worktree dir will be gone after.
-			branch, _ := wg.CurrentBranch()
-
-			// Remove the worktree. git worktree remove must be run from the
-			// main repo root, not from within the worktree being removed.
-			mainRepo := git.New(cityPath)
-			if err := mainRepo.WorktreeRemove(worktreePath, false); err != nil {
-				fmt.Fprintf(stderr, "reapClosedBeadWorktrees: removing %s: %v\n", worktreePath, err) //nolint:errcheck
-				continue
-			}
-			fmt.Fprintf(stderr, //nolint:errcheck
-				"reapClosedBeadWorktrees: removed worktree %s for closed bead %s\n",
-				worktreePath, beadID,
-			)
-			if raw, err := json.Marshal(events.BeadWorktreeReapedPayload{
-				BeadID: beadID,
-				Path:   worktreePath,
-				Rig:    rigName,
-				Branch: branch,
-			}); err == nil {
-				rec.Record(events.Event{
-					Type:    events.BeadWorktreeReaped,
-					Actor:   "gc",
-					Subject: beadID,
-					Payload: raw,
-				})
-			}
-			reaped++
 		}
 	}
 	return reaped
 }
 
-// extractBeadIDFromWorktreeName scans consecutive dash-separated segment pairs
-// in name for one that LooksLikeConfiguredBeadID. Returns the first match, or
-// "" if none. Handles names like "builder-ga-34q3ss-pr2738" → "ga-34q3ss" and
-// bare "ga-06kfi6" → "ga-06kfi6".
+func recordBeadWorktreeReapSkip(
+	rec events.Recorder,
+	stderr io.Writer,
+	beadID, rigName, worktreePath, reason string,
+) {
+	fmt.Fprintf(stderr, //nolint:errcheck
+		"reapClosedBeadWorktrees: skipping %s (bead %s: %s)\n",
+		worktreePath, beadID, reason,
+	)
+	if raw, err := json.Marshal(events.BeadWorktreeReapSkippedPayload{
+		BeadID: beadID,
+		Path:   worktreePath,
+		Rig:    rigName,
+		Reason: reason,
+	}); err == nil {
+		rec.Record(events.Event{
+			Type:    events.BeadWorktreeReapSkipped,
+			Actor:   "gc",
+			Subject: beadID,
+			Payload: raw,
+		})
+	}
+}
+
+func configuredRigRepoPath(cityPath string, cfg *config.City, rigName string) string {
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name == rigName && strings.TrimSpace(cfg.Rigs[i].Path) != "" {
+			return resolveStoreScopeRoot(cityPath, cfg.Rigs[i].Path)
+		}
+	}
+	return ""
+}
+
+func resolveWorktreeRoot(cityPath, wtRoot string) (string, error) {
+	resolvedCity, err := filepath.EvalSymlinks(cityPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving city path: %w", err)
+	}
+	resolvedWtRoot, err := filepath.EvalSymlinks(wtRoot)
+	if err != nil {
+		return "", err
+	}
+	resolvedCity = filepath.Clean(resolvedCity)
+	resolvedWtRoot = filepath.Clean(resolvedWtRoot)
+	if !isStrictlyUnderDir(resolvedCity, resolvedWtRoot) {
+		return "", fmt.Errorf("resolved worktree root %s escapes city %s", resolvedWtRoot, resolvedCity)
+	}
+	return resolvedWtRoot, nil
+}
+
+func resolveWorktreeScanDir(resolvedWtRoot, scanDir string) (string, error) {
+	resolvedScanDir, err := filepath.EvalSymlinks(scanDir)
+	if err != nil {
+		return "", err
+	}
+	resolvedScanDir = filepath.Clean(resolvedScanDir)
+	if !isStrictlyUnderDir(resolvedWtRoot, resolvedScanDir) {
+		return "", fmt.Errorf("resolved scan directory %s escapes worktree root %s", resolvedScanDir, resolvedWtRoot)
+	}
+	return resolvedScanDir, nil
+}
+
+// closedBeadForWorktreeReap returns true only when exactly one authoritative
+// bead row exists across the HQ and owning-rig stores and that row is closed.
+// Duplicate rows are ambiguous even when they currently agree, so cleanup
+// fails closed until the routing/store inconsistency is resolved.
+func closedBeadForWorktreeReap(cityStore, rigStore beads.Store, beadID string) (bool, string) {
+	stores := []struct {
+		name  string
+		store beads.Store
+	}{
+		{name: "HQ", store: cityStore},
+	}
+	if rigStore != cityStore {
+		stores = append(stores, struct {
+			name  string
+			store beads.Store
+		}{name: "rig", store: rigStore})
+	}
+
+	var found []beads.Bead
+	for _, candidate := range stores {
+		if candidate.store == nil {
+			continue
+		}
+		bead, err := candidate.store.Get(beadID)
+		switch {
+		case err == nil:
+			found = append(found, bead)
+		case errors.Is(err, beads.ErrNotFound):
+			continue
+		default:
+			return false, fmt.Sprintf("%s store probe failed: %v", candidate.name, err)
+		}
+	}
+	if len(found) > 1 {
+		return false, "duplicate bead rows found in HQ and rig stores"
+	}
+	if len(found) == 0 || found[0].Status != "closed" {
+		return false, ""
+	}
+	return true, ""
+}
+
+// extractBeadIDFromWorktreeName scans dash-separated substrings in name for
+// one that LooksLikeConfiguredBeadID. For each starting segment it keeps the
+// longest valid candidate, so configured hyphenated prefixes are not
+// truncated to a shorter prefix match. Returns the first positional match, or
+// "" if none. Handles names like "builder-ga-34q3ss-pr2738" → "ga-34q3ss",
+// "builder-agent-diagnostics-hnn" → "agent-diagnostics-hnn", and bare
+// "ga-06kfi6" → "ga-06kfi6".
 func extractBeadIDFromWorktreeName(cfg *config.City, name string) string {
 	if name == "" || cfg == nil {
 		return ""
 	}
 	parts := strings.Split(name, "-")
-	for i := 0; i+1 < len(parts); i++ {
-		candidate := parts[i] + "-" + parts[i+1]
-		if sling.LooksLikeConfiguredBeadID(cfg, candidate) {
-			return candidate
+	for start := 0; start+1 < len(parts); start++ {
+		longest := ""
+		for end := start + 2; end <= len(parts); end++ {
+			candidate := strings.Join(parts[start:end], "-")
+			if sling.LooksLikeConfiguredBeadID(cfg, candidate) && len(candidate) > len(longest) {
+				longest = candidate
+			}
+		}
+		if longest != "" {
+			return longest
 		}
 	}
 	return ""

--- a/cmd/gc/bead_worktree_reaper_test.go
+++ b/cmd/gc/bead_worktree_reaper_test.go
@@ -1,15 +1,330 @@
 package main
 
 import (
+	"bytes"
+	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 )
+
+type fakeBeadWorktreeGitProbe struct {
+	isRepo         bool
+	branch         string
+	branchErr      error
+	hasUncommitted bool
+	hasUnpushed    bool
+	unpushedErr    error
+	hasStashes     bool
+	stashesErr     error
+	removeErr      error
+	removeInvoked  bool
+	removedPath    string
+	removedForce   bool
+}
+
+func (f *fakeBeadWorktreeGitProbe) IsRepo() bool { return f.isRepo }
+func (f *fakeBeadWorktreeGitProbe) CurrentBranch() (string, error) {
+	return f.branch, f.branchErr
+}
+
+func (f *fakeBeadWorktreeGitProbe) HasUncommittedWork() bool {
+	return f.hasUncommitted
+}
+
+func (f *fakeBeadWorktreeGitProbe) HasUnpushedCommitsResult() (bool, error) {
+	return f.hasUnpushed, f.unpushedErr
+}
+
+func (f *fakeBeadWorktreeGitProbe) HasStashesResult() (bool, error) {
+	return f.hasStashes, f.stashesErr
+}
+
+func (f *fakeBeadWorktreeGitProbe) WorktreeRemove(path string, force bool) error {
+	f.removeInvoked = true
+	f.removedPath = path
+	f.removedForce = force
+	return f.removeErr
+}
+
+type beadWorktreeEventRecorder struct {
+	events []events.Event
+}
+
+func (r *beadWorktreeEventRecorder) Record(event events.Event) {
+	r.events = append(r.events, event)
+}
 
 func gaConfig() *config.City {
 	return &config.City{
 		Workspace: config.Workspace{Name: "test", Prefix: "ga"},
+	}
+}
+
+func TestReapClosedBeadWorktreesFindsCanonicalArtifactLayout(t *testing.T) {
+	cityPath := t.TempDir()
+	rigRepo := filepath.Join(cityPath, "repos", "mrig")
+	worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "mrig", "artifacts", "worktrees", "ga-abc123")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("creating canonical worktree path: %v", err)
+	}
+	if err := os.MkdirAll(rigRepo, 0o755); err != nil {
+		t.Fatalf("creating rig repo path: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: filepath.Join("repos", "mrig")}}
+	cityStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	rigStore := beads.NewMemStore()
+	worktreeProbe := &fakeBeadWorktreeGitProbe{
+		isRepo: true,
+		branch: "polecat/ga-abc123",
+	}
+	rigProbe := &fakeBeadWorktreeGitProbe{isRepo: true}
+
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(workDir string) beadWorktreeGitProbe {
+		switch filepath.Clean(workDir) {
+		case filepath.Clean(worktreePath):
+			return worktreeProbe
+		case filepath.Clean(rigRepo):
+			return rigProbe
+		default:
+			return &fakeBeadWorktreeGitProbe{}
+		}
+	}
+
+	var stderr bytes.Buffer
+	rec := &beadWorktreeEventRecorder{}
+	got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		rec,
+		&stderr,
+	)
+	if got != 1 {
+		t.Fatalf("reapClosedBeadWorktrees = %d, want 1; stderr=%s", got, stderr.String())
+	}
+	if !rigProbe.removeInvoked {
+		t.Fatal("configured rig repository did not remove canonical artifact worktree")
+	}
+	if rigProbe.removedPath != worktreePath {
+		t.Errorf("WorktreeRemove path = %q, want %q", rigProbe.removedPath, worktreePath)
+	}
+	if rigProbe.removedForce {
+		t.Error("WorktreeRemove force = true, want false")
+	}
+	if worktreeProbe.removeInvoked {
+		t.Fatal("WorktreeRemove was invoked from the candidate worktree")
+	}
+	if len(rec.events) != 1 || rec.events[0].Type != events.BeadWorktreeReaped {
+		t.Fatalf("events = %+v, want one %s event", rec.events, events.BeadWorktreeReaped)
+	}
+}
+
+func TestReapClosedBeadWorktreesDuplicateStoreRowsFailClosed(t *testing.T) {
+	cityPath := t.TempDir()
+	rigRepo := filepath.Join(cityPath, "repos", "mrig")
+	worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "mrig", "artifacts", "worktrees", "ga-abc123")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("creating canonical worktree path: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: rigRepo}}
+	cityStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	rigStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "open",
+	}}, nil)
+	worktreeProbe := &fakeBeadWorktreeGitProbe{
+		isRepo: true,
+		branch: "polecat/ga-abc123",
+	}
+	rigProbe := &fakeBeadWorktreeGitProbe{isRepo: true}
+
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(workDir string) beadWorktreeGitProbe {
+		if filepath.Clean(workDir) == filepath.Clean(worktreePath) {
+			return worktreeProbe
+		}
+		if filepath.Clean(workDir) == filepath.Clean(rigRepo) {
+			return rigProbe
+		}
+		return &fakeBeadWorktreeGitProbe{}
+	}
+
+	var stderr bytes.Buffer
+	rec := &beadWorktreeEventRecorder{}
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		rec,
+		&stderr,
+	); got != 0 {
+		t.Fatalf("reapClosedBeadWorktrees = %d with duplicate rows, want 0", got)
+	}
+	if worktreeProbe.removeInvoked || rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove invoked despite duplicate HQ/rig bead rows")
+	}
+	if !strings.Contains(stderr.String(), "duplicate bead rows") {
+		t.Fatalf("stderr = %q, want duplicate-row reason", stderr.String())
+	}
+	if len(rec.events) != 1 || rec.events[0].Type != events.BeadWorktreeReapSkipped {
+		t.Fatalf("events = %+v, want one %s event", rec.events, events.BeadWorktreeReapSkipped)
+	}
+}
+
+func TestReapClosedBeadWorktreesProbeErrorsFailClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		probe      *fakeBeadWorktreeGitProbe
+		wantReason string
+	}{
+		{
+			name: "unpushed",
+			probe: &fakeBeadWorktreeGitProbe{
+				isRepo:      true,
+				unpushedErr: errors.New("upstream unavailable"),
+			},
+			wantReason: "unpushed probe failed",
+		},
+		{
+			name: "stashes",
+			probe: &fakeBeadWorktreeGitProbe{
+				isRepo:     true,
+				stashesErr: errors.New("stash metadata unreadable"),
+			},
+			wantReason: "stash probe failed",
+		},
+		{
+			name: "branch",
+			probe: &fakeBeadWorktreeGitProbe{
+				isRepo:    true,
+				branchErr: errors.New("head unreadable"),
+			},
+			wantReason: "branch probe failed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			rigRepo := filepath.Join(cityPath, "repos", "mrig")
+			worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "mrig", "artifacts", "worktrees", "ga-abc123")
+			if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+				t.Fatalf("creating canonical worktree path: %v", err)
+			}
+
+			cfg := gaConfig()
+			cfg.Rigs = []config.Rig{{Name: "mrig", Path: rigRepo}}
+			cityStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+				ID:     "ga-abc123",
+				Status: "closed",
+			}}, nil)
+			rigStore := beads.NewMemStore()
+			rigProbe := &fakeBeadWorktreeGitProbe{isRepo: true}
+
+			originalFactory := newBeadWorktreeGitProbe
+			t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+			newBeadWorktreeGitProbe = func(workDir string) beadWorktreeGitProbe {
+				if filepath.Clean(workDir) == filepath.Clean(worktreePath) {
+					return tc.probe
+				}
+				if filepath.Clean(workDir) == filepath.Clean(rigRepo) {
+					return rigProbe
+				}
+				return &fakeBeadWorktreeGitProbe{}
+			}
+
+			var stderr bytes.Buffer
+			rec := &beadWorktreeEventRecorder{}
+			if got := reapClosedBeadWorktrees(
+				cityPath,
+				cfg,
+				cityStore,
+				map[string]beads.Store{"mrig": rigStore},
+				rec,
+				&stderr,
+			); got != 0 {
+				t.Fatalf("reapClosedBeadWorktrees = %d after probe error, want 0", got)
+			}
+			if rigProbe.removeInvoked {
+				t.Fatal("WorktreeRemove invoked after inconclusive safety probe")
+			}
+			if !strings.Contains(stderr.String(), tc.wantReason) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantReason)
+			}
+			if len(rec.events) != 1 || rec.events[0].Type != events.BeadWorktreeReapSkipped {
+				t.Fatalf("events = %+v, want one %s event", rec.events, events.BeadWorktreeReapSkipped)
+			}
+		})
+	}
+}
+
+func TestReapClosedBeadWorktreesRejectsCanonicalScanSymlinkEscape(t *testing.T) {
+	cityPath := t.TempDir()
+	rigWorktreeDir := filepath.Join(cityPath, ".gc", "worktrees", "mrig")
+	if err := os.MkdirAll(rigWorktreeDir, 0o755); err != nil {
+		t.Fatalf("creating rig worktree path: %v", err)
+	}
+	outsideArtifacts := filepath.Join(t.TempDir(), "artifacts")
+	outsideWorktree := filepath.Join(outsideArtifacts, "worktrees", "ga-abc123")
+	if err := os.MkdirAll(outsideWorktree, 0o755); err != nil {
+		t.Fatalf("creating outside worktree path: %v", err)
+	}
+	if err := os.Symlink(outsideArtifacts, filepath.Join(rigWorktreeDir, "artifacts")); err != nil {
+		t.Fatalf("creating canonical artifacts symlink: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: filepath.Join(cityPath, "repos", "mrig")}}
+	cityStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	rigStore := beads.NewMemStore()
+
+	probeInvoked := false
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(string) beadWorktreeGitProbe {
+		probeInvoked = true
+		return &fakeBeadWorktreeGitProbe{isRepo: true}
+	}
+
+	var stderr bytes.Buffer
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		events.Discard,
+		&stderr,
+	); got != 0 {
+		t.Fatalf("reapClosedBeadWorktrees = %d for escaping canonical scan path, want 0", got)
+	}
+	if probeInvoked {
+		t.Fatal("git probe invoked for worktree reached through escaping artifacts symlink")
+	}
+	if !strings.Contains(stderr.String(), "escapes worktree root") {
+		t.Fatalf("stderr = %q, want realpath-containment rejection", stderr.String())
 	}
 }
 
@@ -26,6 +341,18 @@ func TestExtractBeadIDFromWorktreeNameCompound(t *testing.T) {
 	got := extractBeadIDFromWorktreeName(cfg, "builder-ga-34q3ss")
 	if got != "ga-34q3ss" {
 		t.Errorf("got %q, want %q", got, "ga-34q3ss")
+	}
+}
+
+func TestExtractBeadIDFromWorktreeNameHyphenatedConfiguredPrefix(t *testing.T) {
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{
+		Name:   "diagnostics",
+		Prefix: "agent-diagnostics",
+	}}
+	got := extractBeadIDFromWorktreeName(cfg, "builder-agent-diagnostics-hnn-pr2738")
+	if got != "agent-diagnostics-hnn" {
+		t.Errorf("got %q, want %q", got, "agent-diagnostics-hnn")
 	}
 }
 

--- a/cmd/gc/bead_worktree_reaper_test.go
+++ b/cmd/gc/bead_worktree_reaper_test.go
@@ -11,26 +11,33 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 type fakeBeadWorktreeGitProbe struct {
-	isRepo         bool
-	branch         string
-	branchErr      error
-	hasUncommitted bool
-	hasUnpushed    bool
-	unpushedErr    error
-	hasStashes     bool
-	stashesErr     error
-	removeErr      error
-	removeInvoked  bool
-	removedPath    string
-	removedForce   bool
+	isRepo          bool
+	branch          string
+	branchErr       error
+	worktrees       []git.Worktree
+	worktreeListErr error
+	hasUncommitted  bool
+	hasUnpushed     bool
+	unpushedErr     error
+	hasStashes      bool
+	stashesErr      error
+	removeErr       error
+	removeInvoked   bool
+	removedPath     string
+	removedForce    bool
 }
 
 func (f *fakeBeadWorktreeGitProbe) IsRepo() bool { return f.isRepo }
 func (f *fakeBeadWorktreeGitProbe) CurrentBranch() (string, error) {
 	return f.branch, f.branchErr
+}
+
+func (f *fakeBeadWorktreeGitProbe) WorktreeList() ([]git.Worktree, error) {
+	return f.worktrees, f.worktreeListErr
 }
 
 func (f *fakeBeadWorktreeGitProbe) HasUncommittedWork() bool {
@@ -58,6 +65,37 @@ type beadWorktreeEventRecorder struct {
 
 func (r *beadWorktreeEventRecorder) Record(event events.Event) {
 	r.events = append(r.events, event)
+}
+
+type beadWorktreeTieredStore struct {
+	beads.Store
+	live beads.LiveReader
+}
+
+func (s beadWorktreeTieredStore) Handles() beads.StoreHandles {
+	return beads.StoreHandles{
+		Cached: s.Store,
+		Live:   s.live,
+		Writer: s.Store,
+	}
+}
+
+type beadWorktreeGetErrorReader struct {
+	beads.LiveReader
+	err error
+}
+
+func (r beadWorktreeGetErrorReader) Get(string) (beads.Bead, error) {
+	return beads.Bead{}, r.err
+}
+
+type beadWorktreeNonComparableStore struct {
+	beads.Store
+	marker []string
+}
+
+type beadWorktreeNestedInterfaceStore struct {
+	beads.Store
 }
 
 func gaConfig() *config.City {
@@ -133,6 +171,213 @@ func TestReapClosedBeadWorktreesFindsCanonicalArtifactLayout(t *testing.T) {
 	}
 }
 
+func TestReapClosedBeadWorktreesFindsLegacyArtifactLayout(t *testing.T) {
+	cityPath := t.TempDir()
+	rigRepo := filepath.Join(cityPath, "repos", "mrig")
+	worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "mrig", "builder-ga-abc123-pr2738")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("creating legacy worktree path: %v", err)
+	}
+	if err := os.MkdirAll(rigRepo, 0o755); err != nil {
+		t.Fatalf("creating rig repo path: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: rigRepo}}
+	cityStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	rigStore := beads.NewMemStore()
+	worktreeProbe := &fakeBeadWorktreeGitProbe{
+		isRepo: true,
+		branch: "polecat/ga-abc123",
+	}
+	rigProbe := &fakeBeadWorktreeGitProbe{isRepo: true}
+
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(workDir string) beadWorktreeGitProbe {
+		switch filepath.Clean(workDir) {
+		case filepath.Clean(worktreePath):
+			return worktreeProbe
+		case filepath.Clean(rigRepo):
+			return rigProbe
+		default:
+			return &fakeBeadWorktreeGitProbe{}
+		}
+	}
+
+	var stderr bytes.Buffer
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		events.Discard,
+		&stderr,
+	); got != 1 {
+		t.Fatalf("reapClosedBeadWorktrees = %d for legacy layout, want 1; stderr=%s", got, stderr.String())
+	}
+	if !rigProbe.removeInvoked || rigProbe.removedPath != worktreePath {
+		t.Fatalf("legacy WorktreeRemove: invoked=%v path=%q, want true and %q",
+			rigProbe.removeInvoked, rigProbe.removedPath, worktreePath)
+	}
+	if rigProbe.removedForce {
+		t.Fatal("legacy WorktreeRemove force = true, want false")
+	}
+}
+
+func TestReapClosedBeadWorktreesUsesLiveAuthority(t *testing.T) {
+	cityPath := t.TempDir()
+	worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "mrig", "artifacts", "worktrees", "ga-abc123")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("creating canonical worktree path: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: filepath.Join(cityPath, "repos", "mrig")}}
+	staleClosed := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	liveOpen := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "open",
+	}}, nil)
+	cityStore := beadWorktreeTieredStore{
+		Store: staleClosed,
+		live:  liveOpen,
+	}
+	rigStore := beads.NewMemStore()
+
+	probeInvoked := false
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(string) beadWorktreeGitProbe {
+		probeInvoked = true
+		return &fakeBeadWorktreeGitProbe{isRepo: true}
+	}
+
+	var stderr bytes.Buffer
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		events.Discard,
+		&stderr,
+	); got != 0 {
+		t.Fatalf("reapClosedBeadWorktrees = %d with live-open bead, want 0", got)
+	}
+	if probeInvoked {
+		t.Fatal("git probe invoked from stale cached closed state despite authoritative live-open row")
+	}
+}
+
+func TestReapClosedBeadWorktreesNilHQStoreFailsClosed(t *testing.T) {
+	cityPath := t.TempDir()
+	worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "mrig", "artifacts", "worktrees", "ga-abc123")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("creating canonical worktree path: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: filepath.Join(cityPath, "repos", "mrig")}}
+	rigStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+
+	probeInvoked := false
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(string) beadWorktreeGitProbe {
+		probeInvoked = true
+		return &fakeBeadWorktreeGitProbe{isRepo: true}
+	}
+
+	var stderr bytes.Buffer
+	rec := &beadWorktreeEventRecorder{}
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		nil,
+		map[string]beads.Store{"mrig": rigStore},
+		rec,
+		&stderr,
+	); got != 0 {
+		t.Fatalf("reapClosedBeadWorktrees = %d with nil HQ store, want 0", got)
+	}
+	if probeInvoked {
+		t.Fatal("git probe invoked without an authoritative HQ store")
+	}
+	if !strings.Contains(stderr.String(), "HQ store unavailable") {
+		t.Fatalf("stderr = %q, want unavailable-HQ reason", stderr.String())
+	}
+	if len(rec.events) != 1 || rec.events[0].Type != events.BeadWorktreeReapSkipped {
+		t.Fatalf("events = %+v, want one %s event", rec.events, events.BeadWorktreeReapSkipped)
+	}
+}
+
+func TestClosedBeadForWorktreeReapUnavailableLiveStoreFailsClosed(t *testing.T) {
+	base := beads.NewMemStore()
+	cityStore := beadWorktreeTieredStore{
+		Store: base,
+		live: beadWorktreeGetErrorReader{
+			LiveReader: base,
+			err:        errors.New("backing store unavailable"),
+		},
+	}
+
+	closed, reason := closedBeadForWorktreeReap(cityStore, beads.NewMemStore(), "ga-abc123")
+	if closed {
+		t.Fatal("closedBeadForWorktreeReap authorized cleanup after authoritative live-store failure")
+	}
+	if !strings.Contains(reason, "HQ store probe failed") || !strings.Contains(reason, "backing store unavailable") {
+		t.Fatalf("reason = %q, want authoritative HQ probe failure", reason)
+	}
+}
+
+func TestClosedBeadForWorktreeReapNonComparableStoresFailClosedWithoutPanic(t *testing.T) {
+	base := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	store := beadWorktreeNonComparableStore{
+		Store:  base,
+		marker: []string{"non-comparable"},
+	}
+
+	closed, reason := closedBeadForWorktreeReap(store, store, "ga-abc123")
+	if closed {
+		t.Fatal("closedBeadForWorktreeReap authorized cleanup through ambiguous non-comparable stores")
+	}
+	if !strings.Contains(reason, "duplicate bead rows") {
+		t.Fatalf("reason = %q, want duplicate-store ambiguity", reason)
+	}
+}
+
+func TestClosedBeadForWorktreeReapNestedNonComparableStoresFailClosedWithoutPanic(t *testing.T) {
+	base := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	inner := beadWorktreeNonComparableStore{
+		Store:  base,
+		marker: []string{"non-comparable"},
+	}
+	store := beadWorktreeNestedInterfaceStore{Store: inner}
+
+	closed, reason := closedBeadForWorktreeReap(store, store, "ga-abc123")
+	if closed {
+		t.Fatal("closedBeadForWorktreeReap authorized cleanup through nested non-comparable stores")
+	}
+	if !strings.Contains(reason, "duplicate bead rows") {
+		t.Fatalf("reason = %q, want duplicate-store ambiguity", reason)
+	}
+}
+
 func TestReapClosedBeadWorktreesDuplicateStoreRowsFailClosed(t *testing.T) {
 	cityPath := t.TempDir()
 	rigRepo := filepath.Join(cityPath, "repos", "mrig")
@@ -198,6 +443,14 @@ func TestReapClosedBeadWorktreesProbeErrorsFailClosed(t *testing.T) {
 		probe      *fakeBeadWorktreeGitProbe
 		wantReason string
 	}{
+		{
+			name: "descendant worktree list",
+			probe: &fakeBeadWorktreeGitProbe{
+				isRepo:          true,
+				worktreeListErr: errors.New("worktree registry unreadable"),
+			},
+			wantReason: "descendant worktree probe failed",
+		},
 		{
 			name: "unpushed",
 			probe: &fakeBeadWorktreeGitProbe{
@@ -278,6 +531,68 @@ func TestReapClosedBeadWorktreesProbeErrorsFailClosed(t *testing.T) {
 	}
 }
 
+func TestReapClosedBeadWorktreesRegisteredDescendantFailsClosed(t *testing.T) {
+	cityPath := t.TempDir()
+	rigRepo := filepath.Join(cityPath, "repos", "mrig")
+	worktreePath := filepath.Join(cityPath, ".gc", "worktrees", "mrig", "artifacts", "worktrees", "ga-abc123")
+	descendantPath := filepath.Join(worktreePath, "worktrees", "child")
+	if err := os.MkdirAll(descendantPath, 0o755); err != nil {
+		t.Fatalf("creating nested worktree paths: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: rigRepo}}
+	cityStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	rigStore := beads.NewMemStore()
+	worktreeProbe := &fakeBeadWorktreeGitProbe{
+		isRepo: true,
+		branch: "polecat/ga-abc123",
+		worktrees: []git.Worktree{
+			{Path: worktreePath},
+			{Path: descendantPath},
+		},
+	}
+	rigProbe := &fakeBeadWorktreeGitProbe{isRepo: true}
+
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(workDir string) beadWorktreeGitProbe {
+		switch filepath.Clean(workDir) {
+		case filepath.Clean(worktreePath):
+			return worktreeProbe
+		case filepath.Clean(rigRepo):
+			return rigProbe
+		default:
+			return &fakeBeadWorktreeGitProbe{}
+		}
+	}
+
+	var stderr bytes.Buffer
+	rec := &beadWorktreeEventRecorder{}
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		rec,
+		&stderr,
+	); got != 0 {
+		t.Fatalf("reapClosedBeadWorktrees = %d with registered descendant, want 0", got)
+	}
+	if worktreeProbe.removeInvoked || rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove invoked despite registered descendant worktree")
+	}
+	if !strings.Contains(stderr.String(), "contains registered descendant worktree") {
+		t.Fatalf("stderr = %q, want registered-descendant reason", stderr.String())
+	}
+	if len(rec.events) != 1 || rec.events[0].Type != events.BeadWorktreeReapSkipped {
+		t.Fatalf("events = %+v, want one %s event", rec.events, events.BeadWorktreeReapSkipped)
+	}
+}
+
 func TestReapClosedBeadWorktreesRejectsCanonicalScanSymlinkEscape(t *testing.T) {
 	cityPath := t.TempDir()
 	rigWorktreeDir := filepath.Join(cityPath, ".gc", "worktrees", "mrig")
@@ -328,6 +643,100 @@ func TestReapClosedBeadWorktreesRejectsCanonicalScanSymlinkEscape(t *testing.T) 
 	}
 }
 
+func TestReapClosedBeadWorktreesRejectsSameRootCrossRigSymlink(t *testing.T) {
+	cityPath := t.TempDir()
+	wtRoot := filepath.Join(cityPath, ".gc", "worktrees")
+	rigWorktreeDir := filepath.Join(wtRoot, "mrig")
+	otherArtifacts := filepath.Join(wtRoot, "other", "artifacts")
+	outsideAuthorityWorktree := filepath.Join(otherArtifacts, "worktrees", "ga-abc123")
+	if err := os.MkdirAll(rigWorktreeDir, 0o755); err != nil {
+		t.Fatalf("creating named rig worktree path: %v", err)
+	}
+	if err := os.MkdirAll(outsideAuthorityWorktree, 0o755); err != nil {
+		t.Fatalf("creating other-rig worktree path: %v", err)
+	}
+	if err := os.Symlink(otherArtifacts, filepath.Join(rigWorktreeDir, "artifacts")); err != nil {
+		t.Fatalf("creating cross-rig artifacts symlink: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: filepath.Join(cityPath, "repos", "mrig")}}
+	cityStore := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     "ga-abc123",
+		Status: "closed",
+	}}, nil)
+	rigStore := beads.NewMemStore()
+
+	probeInvoked := false
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(string) beadWorktreeGitProbe {
+		probeInvoked = true
+		return &fakeBeadWorktreeGitProbe{isRepo: true}
+	}
+
+	var stderr bytes.Buffer
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		events.Discard,
+		&stderr,
+	); got != 0 {
+		t.Fatalf("reapClosedBeadWorktrees = %d for same-root cross-rig symlink, want 0", got)
+	}
+	if probeInvoked {
+		t.Fatal("git probe invoked for worktree reached through same-root cross-rig symlink")
+	}
+	if !strings.Contains(stderr.String(), "retargets expected scan directory") {
+		t.Fatalf("stderr = %q, want named-rig retarget rejection", stderr.String())
+	}
+}
+
+func TestReapClosedBeadWorktreesRejectsRetargetedRigRoot(t *testing.T) {
+	cityPath := t.TempDir()
+	wtRoot := filepath.Join(cityPath, ".gc", "worktrees")
+	otherRigDir := filepath.Join(wtRoot, "other")
+	if err := os.MkdirAll(otherRigDir, 0o755); err != nil {
+		t.Fatalf("creating other-rig worktree path: %v", err)
+	}
+	if err := os.Symlink(otherRigDir, filepath.Join(wtRoot, "mrig")); err != nil {
+		t.Fatalf("creating retargeted rig-root symlink: %v", err)
+	}
+
+	cfg := gaConfig()
+	cfg.Rigs = []config.Rig{{Name: "mrig", Path: filepath.Join(cityPath, "repos", "mrig")}}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	probeInvoked := false
+	originalFactory := newBeadWorktreeGitProbe
+	t.Cleanup(func() { newBeadWorktreeGitProbe = originalFactory })
+	newBeadWorktreeGitProbe = func(string) beadWorktreeGitProbe {
+		probeInvoked = true
+		return &fakeBeadWorktreeGitProbe{isRepo: true}
+	}
+
+	var stderr bytes.Buffer
+	if got := reapClosedBeadWorktrees(
+		cityPath,
+		cfg,
+		cityStore,
+		map[string]beads.Store{"mrig": rigStore},
+		events.Discard,
+		&stderr,
+	); got != 0 {
+		t.Fatalf("reapClosedBeadWorktrees = %d for retargeted rig root, want 0", got)
+	}
+	if probeInvoked {
+		t.Fatal("git probe invoked through retargeted rig root")
+	}
+	if !strings.Contains(stderr.String(), "retargets expected rig worktree directory") {
+		t.Fatalf("stderr = %q, want rig-root retarget rejection", stderr.String())
+	}
+}
+
 func TestExtractBeadIDFromWorktreeNameBareID(t *testing.T) {
 	cfg := gaConfig()
 	got := extractBeadIDFromWorktreeName(cfg, "ga-n0oafq")
@@ -353,6 +762,14 @@ func TestExtractBeadIDFromWorktreeNameHyphenatedConfiguredPrefix(t *testing.T) {
 	got := extractBeadIDFromWorktreeName(cfg, "builder-agent-diagnostics-hnn-pr2738")
 	if got != "agent-diagnostics-hnn" {
 		t.Errorf("got %q, want %q", got, "agent-diagnostics-hnn")
+	}
+}
+
+func TestExtractBeadIDFromWorktreeNameHierarchicalLegacySuffix(t *testing.T) {
+	cfg := gaConfig()
+	got := extractBeadIDFromWorktreeName(cfg, "builder-ga-abc.1-pr2738")
+	if got != "ga-abc.1" {
+		t.Errorf("got %q, want %q", got, "ga-abc.1")
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1151,7 +1151,7 @@ func (cr *CityRuntime) tick(
 	}
 	if cr.cfg.Daemon.AutoReapClosedBeadWorktreesEnabled() {
 		phaseStart = time.Now()
-		beadWorktreesReaped := reapClosedBeadWorktrees(cr.cityPath, cr.cfg, cr.rigBeadStores(), cr.rec, cr.stderr)
+		beadWorktreesReaped := reapClosedBeadWorktrees(cr.cityPath, cr.cfg, cr.cityBeadStore(), cr.rigBeadStores(), cr.rec, cr.stderr)
 		recordPhase(TraceSiteControllerTickPhase, "reap_closed_bead_worktrees", phaseStart, map[string]any{"reaped": beadWorktreesReaped})
 		phaseStart = time.Now()
 		agentHomesReset := cleanupClosedBeadAgentHomeWorktrees(cr.cityPath, cr.cfg, cr.rigBeadStores(), cr.stderr)

--- a/cmd/gc/session_worktree_prune.go
+++ b/cmd/gc/session_worktree_prune.go
@@ -20,6 +20,7 @@ import (
 // without standing up real git worktrees.
 type gitProbe interface {
 	IsRepo() bool
+	WorktreeList() ([]git.Worktree, error)
 	HasUncommittedWork() bool
 	HasUnpushedCommitsResult() (bool, error)
 	HasStashesResult() (bool, error)
@@ -56,7 +57,35 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	if cfg == nil || !cfg.Daemon.AutoPruneWorkerDirEnabled() {
 		return false
 	}
-	workerDir := strings.TrimSpace(contract.WorkerDirFromMetadata(session.Metadata))
+	return pruneWorkerDirIfSafe(
+		strings.TrimSpace(contract.WorkerDirFromMetadata(session.Metadata)),
+		lookupRigRootForSession(session, cfg),
+		session.Metadata["session_name"],
+		cityPath,
+		stderr,
+	)
+}
+
+// pruneAgentHomeWorktreeIfSafeInfo is the session.Info form of
+// pruneAgentHomeWorktreeIfSafe. Both metadata projections route through the
+// same safety implementation so a new fail-closed gate cannot accidentally be
+// added to only one reconciliation path.
+func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg *config.City, stderr io.Writer) {
+	if cfg == nil || !cfg.Daemon.AutoPruneWorkerDirEnabled() {
+		return
+	}
+	pruneWorkerDirIfSafe(
+		strings.TrimSpace(sessionpkg.WorkerDirFromInfo(info)),
+		lookupRigRootForSessionInfo(info, cfg),
+		info.SessionNameMetadata,
+		cityPath,
+		stderr,
+	)
+}
+
+// pruneWorkerDirIfSafe applies the common fail-closed worktree safety gates
+// used by both raw-bead and typed-session reconciliation paths.
+func pruneWorkerDirIfSafe(workerDir, rigRoot, sessionName, cityPath string, stderr io.Writer) bool {
 	if workerDir == "" {
 		return false
 	}
@@ -77,6 +106,17 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	gp := newGitProbe(workerDir)
 	if !gp.IsRepo() {
 		return false
+	}
+	worktrees, err := gp.WorktreeList()
+	if err != nil {
+		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: descendant worktree probe failed: %v\n", workerDir, err) //nolint:errcheck
+		return false
+	}
+	for _, wt := range worktrees {
+		if pathutil.PathWithin(workerDir, wt.Path) && !pathutil.SamePath(workerDir, wt.Path) {
+			fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: contains registered descendant worktree %s\n", workerDir, wt.Path) //nolint:errcheck
+			return false
+		}
 	}
 	if gp.HasUncommittedWork() {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has uncommitted changes\n", workerDir) //nolint:errcheck
@@ -105,7 +145,6 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	// worktree being removed: git refuses to remove a worktree whose path
 	// equals cwd in some configurations, and operating from cwd of a
 	// directory we are about to delete is fragile in general.
-	rigRoot := lookupRigRootForSession(session, cfg)
 	if rigRoot == "" {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: rig path unresolved\n", workerDir) //nolint:errcheck
 		return false
@@ -114,75 +153,8 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 		fmt.Fprintf(stderr, "session reconciler: pruning worker_dir %s: %v\n", workerDir, err) //nolint:errcheck
 		return false
 	}
-	fmt.Fprintf(stderr, "session reconciler: pruned worker_dir %s (session %s)\n", workerDir, session.Metadata["session_name"]) //nolint:errcheck
+	fmt.Fprintf(stderr, "session reconciler: pruned worker_dir %s (session %s)\n", workerDir, sessionName) //nolint:errcheck
 	return true
-}
-
-// pruneAgentHomeWorktreeIfSafeInfo is the session.Info form of
-// pruneAgentHomeWorktreeIfSafe: the worker_dir read routes through
-// session.WorkerDirFromInfo (the canonical→legacy Info fallback equivalent to
-// contract.WorkerDirFromMetadata), the rig-root lookup reads Info.Template via
-// lookupRigRootForSessionInfo, and the log line reads Info.SessionNameMetadata —
-// every safety gate and the removal itself are unchanged. Byte-identical to the
-// raw form, which survives for its test callers.
-func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg *config.City, stderr io.Writer) {
-	if cfg == nil || !cfg.Daemon.AutoPruneWorkerDirEnabled() {
-		return
-	}
-	workerDir := strings.TrimSpace(sessionpkg.WorkerDirFromInfo(info))
-	if workerDir == "" {
-		return
-	}
-	if !filepath.IsAbs(workerDir) {
-		return
-	}
-
-	wtRoot := filepath.Join(cityPath, ".gc", "worktrees")
-	if !pathutil.PathWithin(wtRoot, workerDir) || pathutil.SamePath(wtRoot, workerDir) {
-		return
-	}
-
-	if _, err := os.Stat(filepath.Join(workerDir, ".git")); err != nil {
-		return
-	}
-
-	gp := newGitProbe(workerDir)
-	if !gp.IsRepo() {
-		return
-	}
-	if gp.HasUncommittedWork() {
-		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has uncommitted changes\n", workerDir) //nolint:errcheck
-		return
-	}
-	hasUnpushed, err := gp.HasUnpushedCommitsResult()
-	if err != nil {
-		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: unpushed probe failed: %v\n", workerDir, err) //nolint:errcheck
-		return
-	}
-	if hasUnpushed {
-		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has unpushed commits\n", workerDir) //nolint:errcheck
-		return
-	}
-	hasStashes, err := gp.HasStashesResult()
-	if err != nil {
-		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: stash probe failed: %v\n", workerDir, err) //nolint:errcheck
-		return
-	}
-	if hasStashes {
-		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has stashed work\n", workerDir) //nolint:errcheck
-		return
-	}
-
-	rigRoot := lookupRigRootForSessionInfo(info, cfg)
-	if rigRoot == "" {
-		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: rig path unresolved\n", workerDir) //nolint:errcheck
-		return
-	}
-	if err := newGitProbe(rigRoot).WorktreeRemove(workerDir, true); err != nil {
-		fmt.Fprintf(stderr, "session reconciler: pruning worker_dir %s: %v\n", workerDir, err) //nolint:errcheck
-		return
-	}
-	fmt.Fprintf(stderr, "session reconciler: pruned worker_dir %s (session %s)\n", workerDir, info.SessionNameMetadata) //nolint:errcheck
 }
 
 // lookupRigRootForSession returns the filesystem path of the rig that owns

--- a/cmd/gc/session_worktree_prune.go
+++ b/cmd/gc/session_worktree_prune.go
@@ -47,6 +47,7 @@ var newGitProbe = func(workDir string) gitProbe { return git.New(workDir) }
 //   - the session bead has no worker_dir metadata
 //   - the worker_dir does not live under cityPath/.gc/worktrees/
 //   - the worker_dir is missing on disk or has no .git pointer
+//   - the worker_dir contains a registered descendant worktree
 //   - the worktree has uncommitted changes, unpushed commits, or stashes
 //   - the rig that owns the session cannot be resolved to a filesystem path
 //
@@ -149,7 +150,9 @@ func pruneWorkerDirIfSafe(workerDir, rigRoot, sessionName, cityPath string, stde
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: rig path unresolved\n", workerDir) //nolint:errcheck
 		return false
 	}
-	if err := newGitProbe(rigRoot).WorktreeRemove(workerDir, true); err != nil {
+	// Keep Git's own clean-worktree refusal as a final defense against state
+	// changing after the probes above.
+	if err := newGitProbe(rigRoot).WorktreeRemove(workerDir, false); err != nil {
 		fmt.Fprintf(stderr, "session reconciler: pruning worker_dir %s: %v\n", workerDir, err) //nolint:errcheck
 		return false
 	}

--- a/cmd/gc/session_worktree_prune_test.go
+++ b/cmd/gc/session_worktree_prune_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 // fakeGitProbe is a hand-rolled gitProbe stub. Each field controls one
@@ -17,19 +18,24 @@ import (
 // records the (path, force) of every WorktreeRemove invocation so tests
 // can assert which directory the removal targeted.
 type fakeGitProbe struct {
-	isRepo         bool
-	hasUncommitted bool
-	hasUnpushed    bool
-	unpushedErr    error
-	hasStashes     bool
-	stashesErr     error
-	worktreeRemove func(path string, force bool) error
-	removedPath    string
-	removedForce   bool
-	removeInvoked  bool
+	isRepo          bool
+	hasUncommitted  bool
+	hasUnpushed     bool
+	unpushedErr     error
+	hasStashes      bool
+	stashesErr      error
+	worktrees       []git.Worktree
+	worktreeListErr error
+	worktreeRemove  func(path string, force bool) error
+	removedPath     string
+	removedForce    bool
+	removeInvoked   bool
 }
 
-func (f *fakeGitProbe) IsRepo() bool             { return f.isRepo }
+func (f *fakeGitProbe) IsRepo() bool { return f.isRepo }
+func (f *fakeGitProbe) WorktreeList() ([]git.Worktree, error) {
+	return f.worktrees, f.worktreeListErr
+}
 func (f *fakeGitProbe) HasUncommittedWork() bool { return f.hasUncommitted }
 func (f *fakeGitProbe) HasUnpushedCommitsResult() (bool, error) {
 	return f.hasUnpushed, f.unpushedErr
@@ -231,6 +237,83 @@ func TestPruneAgentHomeWorktreeIfSafe_NotARepo(t *testing.T) {
 	var stderr bytes.Buffer
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
 		t.Fatal("prune returned true when IsRepo=false")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafe_RegisteredDescendantWorktree(t *testing.T) {
+	fx := newPruneFixture(t)
+	nested := filepath.Join(fx.workerDir, "worktrees", "task-1")
+	fx.setProbe(fx.workerDir, &fakeGitProbe{
+		isRepo: true,
+		worktrees: []git.Worktree{
+			{Path: fx.workerDir},
+			{Path: nested},
+		},
+	})
+
+	var stderr bytes.Buffer
+	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
+		t.Fatal("prune returned true with a registered descendant worktree")
+	}
+	if !strings.Contains(stderr.String(), "contains registered descendant worktree") {
+		t.Errorf("expected descendant-worktree reason; got %q", stderr.String())
+	}
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called despite registered descendant worktree")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafe_DescendantProbeError(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{
+		isRepo:          true,
+		worktreeListErr: errors.New("cannot list worktrees"),
+	})
+
+	var stderr bytes.Buffer
+	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
+		t.Fatal("prune returned true after descendant worktree probe error")
+	}
+	if !strings.Contains(stderr.String(), "descendant worktree probe failed") {
+		t.Errorf("expected descendant-probe reason; got %q", stderr.String())
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RegisteredDescendantWorktree(t *testing.T) {
+	fx := newPruneFixture(t)
+	nested := filepath.Join(fx.workerDir, "worktrees", "task-1")
+	fx.setProbe(fx.workerDir, &fakeGitProbe{
+		isRepo: true,
+		worktrees: []git.Worktree{
+			{Path: fx.workerDir},
+			{Path: nested},
+		},
+	})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(seedSessionInfo(fx.sessionBead()), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "contains registered descendant worktree") {
+		t.Errorf("expected typed path to enforce descendant-worktree gate; got %q", stderr.String())
+	}
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("typed path called WorktreeRemove despite registered descendant worktree")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_DescendantProbeError(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{
+		isRepo:          true,
+		worktreeListErr: errors.New("cannot list worktrees"),
+	})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(seedSessionInfo(fx.sessionBead()), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "descendant worktree probe failed") {
+		t.Errorf("expected typed path to fail closed after descendant probe error; got %q", stderr.String())
+	}
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("typed path called WorktreeRemove after descendant probe error")
 	}
 }
 

--- a/cmd/gc/session_worktree_prune_test.go
+++ b/cmd/gc/session_worktree_prune_test.go
@@ -168,8 +168,8 @@ func TestPruneAgentHomeWorktreeIfSafe_LegacyWorkDirKey(t *testing.T) {
 	if !pruneAgentHomeWorktreeIfSafe(session, fx.cityPath, fx.cfg, &stderr) {
 		t.Fatalf("prune returned false on legacy work_dir; stderr=%s", stderr.String())
 	}
-	if !rigProbe.removeInvoked || rigProbe.removedPath != fx.workerDir || !rigProbe.removedForce {
-		t.Fatalf("expected WorktreeRemove(%q, true) on rig root; got invoked=%v path=%q force=%v",
+	if !rigProbe.removeInvoked || rigProbe.removedPath != fx.workerDir || rigProbe.removedForce {
+		t.Fatalf("expected WorktreeRemove(%q, false) on rig root; got invoked=%v path=%q force=%v",
 			fx.workerDir, rigProbe.removeInvoked, rigProbe.removedPath, rigProbe.removedForce)
 	}
 }
@@ -447,8 +447,8 @@ func TestPruneAgentHomeWorktreeIfSafe_HappyPath(t *testing.T) {
 	if rigProbe.removedPath != fx.workerDir {
 		t.Errorf("WorktreeRemove path = %q, want %q", rigProbe.removedPath, fx.workerDir)
 	}
-	if !rigProbe.removedForce {
-		t.Error("WorktreeRemove force flag = false, want true")
+	if rigProbe.removedForce {
+		t.Error("WorktreeRemove force flag = true, want false")
 	}
 	if !strings.Contains(stderr.String(), "pruned worker_dir") {
 		t.Errorf("expected success log; got %q", stderr.String())


### PR DESCRIPTION
## Withdrawn

This broad two-commit branch should not be merged or rebased as-is. Its cleanup model predates and substantially overlaps merged #4598, #4601, and #4655.

Two narrower fail-closed gaps remain:

- protect registered descendant worktrees and use non-force removal during session worker-home pruning
- protect registered descendants and treat reaper Git-probe errors as authorization failures

Those changes have been isolated independently and should receive broader validation as separate PRs. No part of this branch should be merged as a combined change.
