### PR TITLE
fix(session): back off deferred-singleton alias-conflict re-record

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4539,9 +4539,26 @@ func TestSyncSessionBeads_ReclaimsDeferredSingletonAliasAfterConflictClears(t *t
 		}},
 	}, desired, &buildStderr)
 
+	// Keep the canonical alias holder desired across the persistent-conflict
+	// syncs — in the live scenario the holder is a desired named/pool session,
+	// and the not-in-desired sweep must not close it out from under the
+	// deferred bead.
+	desired["s-refinery-canonical"] = TemplateParams{
+		TemplateName: "cashmaster/refinery",
+		SessionName:  "s-refinery-canonical",
+		Alias:        "cashmaster/refinery",
+	}
+
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "s-refinery-stale", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.Start(context.Background(), "s-refinery-canonical", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
 	var persistentStderr bytes.Buffer
 	persistentClk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 30, 0, 0, time.UTC)}
-	syncSessionBeads(cityPath, store, desired, runtime.NewFake(), allConfiguredDS(desired), cfg, persistentClk, &persistentStderr, false)
+	syncSessionBeads(cityPath, store, desired, sp, allConfiguredDS(desired), cfg, persistentClk, &persistentStderr, false)
 
 	stillConflicted, err := store.Get(stale.ID)
 	if err != nil {
@@ -4557,12 +4574,51 @@ func TestSyncSessionBeads_ReclaimsDeferredSingletonAliasAfterConflictClears(t *t
 		t.Fatalf("persistent-conflict pool_alias_conflict_count = %q, want sync retry increment", got)
 	}
 
+	// A still-standing conflict must NOT re-record on every sync tick: each
+	// re-record is a bead write that emits bead.updated, and a permanent
+	// conflict (e.g. a manual session holding the canonical alias) turns that
+	// into an event firehose. Within the re-record backoff the counter and
+	// timestamp stay untouched.
+	var withinBackoffStderr bytes.Buffer
+	withinBackoffClk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 31, 0, 0, time.UTC)}
+	syncSessionBeads(cityPath, store, desired, sp, allConfiguredDS(desired), cfg, withinBackoffClk, &withinBackoffStderr, false)
+
+	suppressed, err := store.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", stale.ID, err)
+	}
+	if got := suppressed.Metadata[poolAliasConflictCountMetadataKey]; got != "2" {
+		t.Fatalf("within-backoff pool_alias_conflict_count = %q, want re-record suppressed at 2", got)
+	}
+	if got := suppressed.Metadata[poolAliasConflictAtMetadataKey]; got != "2026-05-06T02:30:00Z" {
+		t.Fatalf("within-backoff pool_alias_conflict_at = %q, want unchanged 2026-05-06T02:30:00Z", got)
+	}
+
+	// Once the backoff elapses the retry telemetry advances again.
+	var afterBackoffStderr bytes.Buffer
+	afterBackoffClk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 50, 0, 0, time.UTC)}
+	syncSessionBeads(cityPath, store, desired, sp, allConfiguredDS(desired), cfg, afterBackoffClk, &afterBackoffStderr, false)
+
+	rerecorded, err := store.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", stale.ID, err)
+	}
+	if got := rerecorded.Metadata[poolAliasConflictCountMetadataKey]; got != "3" {
+		t.Fatalf("post-backoff pool_alias_conflict_count = %q, want re-record after backoff", got)
+	}
+	if got := rerecorded.Metadata[poolAliasConflictAtMetadataKey]; got != "2026-05-06T02:50:00Z" {
+		t.Fatalf("post-backoff pool_alias_conflict_at = %q, want re-stamped 2026-05-06T02:50:00Z", got)
+	}
+
 	if err := store.Close(canonical.ID); err != nil {
 		t.Fatalf("Close(%s): %v", canonical.ID, err)
 	}
+	// The holder is gone for good; stop desiring it so sync doesn't create a
+	// replacement bead that would re-claim the canonical alias.
+	delete(desired, "s-refinery-canonical")
 	var syncStderr bytes.Buffer
 	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 3, 0, 0, 0, time.UTC)}
-	syncSessionBeads(cityPath, store, desired, runtime.NewFake(), allConfiguredDS(desired), cfg, clk, &syncStderr, false)
+	syncSessionBeads(cityPath, store, desired, sp, allConfiguredDS(desired), cfg, clk, &syncStderr, false)
 
 	got, err := store.Get(stale.ID)
 	if err != nil {

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -32,6 +32,15 @@ const (
 	poolAliasConflictAtMetadataKey    = "pool_alias_conflict_at"
 )
 
+// deferredSingletonAliasConflictRerecordBackoff bounds how often a deferred
+// canonical-singleton session bead re-records a still-standing alias conflict.
+// The re-record is telemetry only (count + timestamp); the alias acquisition
+// retry itself runs on every sync tick regardless. Without the backoff a
+// permanent conflict — e.g. a manual session holding the canonical alias
+// against the named/pool session — writes the bead every tick, and each write
+// emits a bead.updated event that can dominate the city's event stream.
+const deferredSingletonAliasConflictRerecordBackoff = 15 * time.Minute
+
 // loadSessionBeads returns all open session beads from the store.
 func loadSessionBeads(store beads.Store) ([]beads.Bead, error) {
 	if store == nil {
@@ -2012,9 +2021,19 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					strings.TrimSpace(b.Metadata[poolAliasConflictMetadataKey]) == managedAlias
 			}
 			if strings.TrimSpace(b.Metadata[poolAliasConflictMetadataKey]) == managedAlias &&
-				strings.TrimSpace(b.Metadata[poolAliasConflictCountMetadataKey]) != "" &&
-				!retryDeferredSingleton {
-				return
+				strings.TrimSpace(b.Metadata[poolAliasConflictCountMetadataKey]) != "" {
+				if !retryDeferredSingleton {
+					return
+				}
+				// Deferred-singleton retries advance the counter only on a
+				// backoff. A negative elapsed (conflict stamped in the future,
+				// i.e. clock skew) falls through so the re-record repairs the
+				// timestamp.
+				if at, err := time.Parse(time.RFC3339, strings.TrimSpace(b.Metadata[poolAliasConflictAtMetadataKey])); err == nil {
+					if elapsed := now.Sub(at); elapsed >= 0 && elapsed < deferredSingletonAliasConflictRerecordBackoff {
+						return
+					}
+				}
 			}
 			count := 0
 			if existing, err := strconv.Atoi(strings.TrimSpace(b.Metadata[poolAliasConflictCountMetadataKey])); err == nil && existing > 0 {


### PR DESCRIPTION
## Problem

A deferred canonical-singleton session bead — one whose `alias` is deferred because another session holds the canonical alias — re-records its `pool_alias_conflict` count and timestamp on **every** sync tick. Each re-record is a bead write, and each write emits a `bead.updated` event.

When the conflict is *permanent* (our field case: a manually created mayor session colliding with the configured named session over the same canonical alias, i.e. the #2728 shape), this becomes an event firehose: in our deployment, 96% of all `bead.updated` events were cache-reconcile conflict re-records (`pool_alias_conflict_count` observed climbing 977→982 in real time). The event stream woke the control dispatcher every tick, each wake forked the `bd` CLI, and on a 6-core host the resulting fork storm drove load to ~77 (0.7% idle) and SIGKILLed sessions.

## Root cause

PR #2810 debounced the conflict re-record (record once, return until cleared), but the same commit introduced the `retryDeferredSingleton` bypass in `recordAliasConflict` (`cmd/gc/session_beads.go`), which exempts deferred canonical-singleton beads from that debounce. For those beads the count+timestamp write runs unconditionally each tick, and since the write itself mutates the bead, every reconcile pass re-fires. There is no clear path while the conflict stands: `clearAliasConflict` only runs when alias acquisition succeeds, which never happens while the canonical holder is alive.

The re-record is **telemetry only** — the alias-acquisition retry runs every sync tick regardless of whether the record is written, and nothing reads `pool_alias_conflict_count` for control decisions — so rate-limiting the write cannot change reconciler behavior.

## Fix

Deferred-singleton conflict re-records now honor a 15-minute backoff (`deferredSingletonAliasConflictRerecordBackoff`): a still-standing conflict is re-recorded at most once per window instead of once per tick. A conflict timestamp in the future (clock skew) falls through so the re-record repairs the stamp. Non-singleton behavior (#2810's record-once) is unchanged, as are the alias retry itself and the clear-on-success path.

## Tests

`TestSyncSessionBeads_ReclaimsDeferredSingletonAliasAfterConflictClears` previously pinned increment-every-retry for singletons; it now pins: increment on first sync, **suppressed** within the backoff window, one bounded re-record after the window elapses, and the existing reclaim-on-clear behavior.

While updating it I found the persistent-conflict phase wasn't actually persistent: the canonical alias holder was not in `desired`, so the very first sync closed it (`orphaned: configured agent removed`) and any later sync would have cleared the conflict legitimately. The test now keeps the holder desired across the persistent-conflict syncs (and drops it before the reclaim phase), so the pinned scenario matches the real one.

## Field evidence (patch deployed in production before this PR)

Backported onto our deployed 1.3.6 build and soaked under a deliberately reproduced collision (manual mayor session alongside the configured named session, both live):

- conflict recorded **once** at T+0, counter flat for the full 15m window, exactly one re-record at T+16m, flat after — versus +1/tick before the patch;
- `bead.updated` fell from 96% of the event stream (during the incident) to 6 events across the 21-minute collision window (7.5% of all events);
- no load excursion (load fell 3.5→2.7 during the soak);
- closing the losing session cleaned up normally.

## Relationship to existing work

- #2728 (manual-vs-named canonical alias conflict): this PR does **not** resolve who should own the alias — owner-recognition (e.g. #3884 / `names.go`) remains the fix for the conflict itself. This PR removes the unbounded write amplification the conflict causes meanwhile; the two are independent and compatible.
- #2810: keeps its non-singleton debounce intact; closes the singleton gap it left open.
- #3908 / #3915 cover different guards (ephemeral duplicates / config-level self-collision); no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)