### PR TITLE
Normalize routed work instance names in demand matching

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -673,7 +674,7 @@ func buildDesiredStateWithSessionBeads(
 		})
 		if len(defaultScaleTargets) > 0 {
 			subPhaseStart = time.Now()
-			defaultCounts, defaultDemand, partialTemplates, errs := defaultScaleCheckCountsAndDemand(defaultScaleTargets, demandReadyCache)
+			defaultCounts, defaultDemand, partialTemplates, errs := defaultScaleCheckCountsAndDemand(cfg, defaultScaleTargets, demandReadyCache)
 			recordDemandSubPhase(trace, "demand_snapshot.default_scale_demand", subPhaseStart, map[string]any{
 				"targets": len(defaultScaleTargets),
 			})
@@ -1378,13 +1379,17 @@ func defaultScaleCheckTargetForAgent(
 
 // defaultScaleCheckCounts reports ready, unassigned, routed work as fresh
 // generic pool demand. Assigned beads are handled by assigned-work collection
-// and named-session demand so they are intentionally excluded here.
+// and named-session demand so they are intentionally excluded here. It has no
+// production caller that needs gc.routed_to instance-suffix normalization, so
+// it passes a nil cfg through to defaultScaleCheckCountsAndDemand; callers
+// that need normalization should call defaultScaleCheckCountsAndDemand
+// directly with a real *config.City.
 func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int, map[string]bool, []error) {
-	counts, _, partialTemplates, errs := defaultScaleCheckCountsAndDemand(targets)
+	counts, _, partialTemplates, errs := defaultScaleCheckCountsAndDemand(nil, targets)
 	return counts, partialTemplates, errs
 }
 
-func defaultScaleCheckCountsAndDemand(targets []defaultScaleCheckTarget, caches ...*readyDemandCache) (map[string]int, map[string]scaleCheckDemand, map[string]bool, []error) {
+func defaultScaleCheckCountsAndDemand(cfg *config.City, targets []defaultScaleCheckTarget, caches ...*readyDemandCache) (map[string]int, map[string]scaleCheckDemand, map[string]bool, []error) {
 	cache := optionalReadyDemandCache(caches)
 	counts := make(map[string]int, len(targets))
 	demand := make(map[string]scaleCheckDemand, len(targets))
@@ -1457,7 +1462,7 @@ func defaultScaleCheckCountsAndDemand(targets []defaultScaleCheckTarget, caches 
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
-			template := controllerDemandRouteTarget(b, group.templates)
+			template := controllerDemandRouteTarget(cfg, b, group.templates)
 			if _, ok := group.templates[template]; !ok {
 				continue
 			}
@@ -1617,10 +1622,22 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, _ *config.City
 	return demand, partialTemplates, errs
 }
 
-func controllerDemandRouteTarget(b beads.Bead, templates map[string]struct{}) string {
+// controllerDemandRouteTarget matches a work bead's routed-to candidates
+// against the pool's template set. Candidates are normalized through
+// agentutil.NormalizePoolRouteTarget before the membership check so a
+// gc.routed_to value stamped with a live instance suffix (e.g.
+// "hello-world/polecat-1") — whether written by gc sling's own write-side
+// normalization or by any other writer, such as a direct
+// `bd update --set-metadata` — still counts as demand for the base template.
+// Without this, an unnormalized instance-suffixed candidate never matches
+// group.templates (keyed by base template names) and the demand is silently
+// dropped, so the pool never scales up. The returned value is the normalized
+// template name, since callers use it as the counts/demand map key.
+func controllerDemandRouteTarget(cfg *config.City, b beads.Bead, templates map[string]struct{}) string {
 	for _, candidate := range controllerDemandRouteCandidates(b) {
-		if _, ok := templates[candidate]; ok {
-			return candidate
+		normalized := agentutil.NormalizePoolRouteTarget(cfg, candidate)
+		if _, ok := templates[normalized]; ok {
+			return normalized
 		}
 	}
 	return ""

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -869,7 +869,7 @@ func TestDefaultScaleCheckDemandCarriesTriggerBeadID(t *testing.T) {
 		t.Fatalf("create routed bead: %v", err)
 	}
 
-	counts, demand, _, errs := defaultScaleCheckCountsAndDemand([]defaultScaleCheckTarget{{
+	counts, demand, _, errs := defaultScaleCheckCountsAndDemand(nil, []defaultScaleCheckTarget{{
 		template: template,
 		storeKey: "rig:gascity",
 		store:    store,
@@ -894,6 +894,91 @@ func TestDefaultScaleCheckDemandCarriesTriggerBeadID(t *testing.T) {
 	}
 	if got := demand[template].StoreRefs[work.ID]; got != "rig:gascity" {
 		t.Fatalf("StoreRefs[%s] = %q, want rig:gascity", work.ID, got)
+	}
+}
+
+// TestDefaultScaleCheckCountsAndDemandNormalizesInstanceSuffixedRouteTarget
+// reproduces a writer that stamps gc.routed_to with an instance-suffixed pool
+// identity directly (e.g. `bd update --set-metadata gc.routed_to=hello-world/polecat-1`),
+// bypassing gc sling's write-side normalization (agentutil.NormalizePoolRouteTarget,
+// applied in doSling). Without read-side normalization, the raw instance name never
+// matches group.templates (keyed by the base template), so the demand is silently
+// dropped and the pool never scales up.
+func TestDefaultScaleCheckCountsAndDemandNormalizesInstanceSuffixedRouteTarget(t *testing.T) {
+	const template = "hello-world/polecat"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "hello-world", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3)},
+		},
+	}
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:  "directly routed to instance slot",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: template + "-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create instance-routed bead: %v", err)
+	}
+
+	counts, demand, partialTemplates, errs := defaultScaleCheckCountsAndDemand(cfg, []defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:hello-world",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand errs = %v", errs)
+	}
+	if len(partialTemplates) != 0 {
+		t.Fatalf("partialTemplates = %v, want none", partialTemplates)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand[%q] = %d, want 1 for an instance-suffixed gc.routed_to matching the base template", template, got)
+	}
+	if got := demand[template].WorkBeadIDs; !reflect.DeepEqual(got, []string{work.ID}) {
+		t.Fatalf("WorkBeadIDs = %v, want [%s]", got, work.ID)
+	}
+}
+
+// TestDefaultScaleCheckCountsAndDemandLeavesUnmatchedInstanceSuffixAlone guards
+// against over-normalization: an instance number outside the agent's configured
+// capacity, or a suffix on an agent that isn't multi-session, is not a pool
+// instance identity and must not be rewritten or counted against the base
+// template.
+func TestDefaultScaleCheckCountsAndDemandLeavesUnmatchedInstanceSuffixAlone(t *testing.T) {
+	const template = "hello-world/polecat"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "hello-world", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3)},
+		},
+	}
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "routed beyond configured capacity",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: template + "-99",
+		},
+	}); err != nil {
+		t.Fatalf("create out-of-range instance-routed bead: %v", err)
+	}
+
+	counts, _, _, errs := defaultScaleCheckCountsAndDemand(cfg, []defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:hello-world",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand errs = %v", errs)
+	}
+	if got := counts[template]; got != 0 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand[%q] = %d, want 0 for an out-of-range instance suffix", template, got)
 	}
 }
 

--- a/release-gates/ga-803rif-gate.md
+++ b/release-gates/ga-803rif-gate.md
@@ -1,0 +1,33 @@
+# Release Gate: ga-803rif
+
+Bead: ga-803rif
+Source bead: ga-o3ko1j.3
+Reviewed commit: a32971917a5e46ba0bf61cb2d7d5e40cf4bac768
+Deploy branch: deploy/ga-803rif-gate
+Deploy source commit: a32971917a5e46ba0bf61cb2d7d5e40cf4bac768
+Base checked: origin/main d5fbb58c983251bfe9df8c53be1b86ab6bef6408
+Project manifest: docs/PROJECT_MANIFEST.md not present in this repository checkout; evaluated against the deployer prompt's gate table, TESTING.md, and the Makefile fast-suite target.
+
+Stable patch-id for the feature files:
+
+`09a9d148103d45982aaf30def73201cdfe30ca11`
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `dcf2cfc66fb9fd5f404b13bd5ca56ba8da5583ed`. |
+| 1 | Review PASS present | PASS | Source bead ga-o3ko1j.3 notes contain `=== REVIEW VERDICT: PASS (gascity/reviewer) ===` for reviewed commit `a32971917a5e46ba0bf61cb2d7d5e40cf4bac768`. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `cmd/gc/build_desired_state.go` and `cmd/gc/build_desired_state_test.go`; tests cover instance-suffixed `gc.routed_to` demand matching and unmatched suffix behavior. Source notes record that GH #3872 incident #5 is a separate root-cause track deferred to ga-o3ko1j.4.5 rather than assumed fixed here. |
+| 3 | Tests pass | PASS | `go vet ./...` exit 0; `go build ./cmd/gc/` exit 0; focused `go test ./cmd/gc/... -run 'TestDefaultScaleCheckCounts\|TestDefaultScaleCheckDemand\|TestControllerDemandRouteTarget\|TestDefaultScaleCheckCountsAndDemand' -count=1 -v` passed; `make test-fast-parallel` passed with all 8 fast jobs green. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report no OWASP-relevant findings, scope discipline clean, and coverage present; no unresolved HIGH findings found in the bead notes. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v2 --branch` was clean before writing this gate file. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem: controller demand matching in `cmd/gc/build_desired_state*` for `gc.routed_to` instance-suffix normalization. |
+
+## Commands
+
+- `git merge-tree --write-tree origin/main HEAD`
+- `git diff --stat origin/main...HEAD`
+- `git patch-id --stable < <(git show HEAD -- cmd/gc/build_desired_state.go cmd/gc/build_desired_state_test.go)`
+- `go vet ./...`
+- `go build ./cmd/gc/`
+- `go test ./cmd/gc/... -run 'TestDefaultScaleCheckCounts|TestDefaultScaleCheckDemand|TestControllerDemandRouteTarget|TestDefaultScaleCheckCountsAndDemand' -count=1 -v`
+- `make test-fast-parallel`


### PR DESCRIPTION
## What this changes

The controller now normalizes instance-suffixed `gc.routed_to` values on the read side before matching routed work to a pool template. A work item routed by a direct metadata write to an instance name such as `gascity/builder-1` is counted as demand for the `gascity/builder` template instead of being silently ignored when the pool is scaled to zero.

This makes demand computation robust regardless of which writer produced the route metadata. The existing `gc sling` write-side normalization remains in place; this change makes the reader enforce the same invariant for direct `bd update` and graph/formula paths.

## Review notes

- Main logic is in `cmd/gc/build_desired_state.go`; coverage is in `cmd/gc/build_desired_state_test.go`.
- `readyExcludeTypes`, blocking-dependency checks, and control-dispatcher alias handling are intentionally unchanged.
- The graph.v2 drain-unit incident is not claimed fixed by this patch; notes identify it as a separate root-cause track.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./cmd/gc/`
- [x] `go test ./cmd/gc/... -run 'TestDefaultScaleCheckCounts|TestDefaultScaleCheckDemand|TestControllerDemandRouteTarget|TestDefaultScaleCheckCountsAndDemand' -count=1 -v`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-803rif-gate.md`](release-gates/ga-803rif-gate.md)
