### PR TITLE
Normalize routed work instance names in assigned-work reachability

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -153,6 +153,7 @@ func filterAssignedWorkBeadsForPoolDemand(
 		if template == "" {
 			continue
 		}
+		template = agentutil.NormalizePoolRouteTarget(cfg, template)
 		agentCfg := findAgentByTemplate(cfg, template)
 		if agentCfg == nil {
 			continue

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -197,6 +197,54 @@ func TestFilterAssignedWorkBeadsForPoolDemandKeepsPersistedBoundRoute(t *testing
 	}
 }
 
+func TestFilterAssignedWorkBeadsForPoolDemandNormalizesInstanceSuffixedRouteTarget(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			MinActiveSessions: intPtr(1),
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+	work := []beads.Bead{{
+		ID:       "instance-routed",
+		Status:   "in_progress",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker-1",
+		},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+
+	if len(got) != 1 || got[0].ID != "instance-routed" {
+		t.Fatalf("filtered work = %#v, want instance-suffixed route target normalized to the base template and kept", got)
+	}
+}
+
+func TestFilterAssignedWorkBeadsForPoolDemandLeavesUnmatchedInstanceSuffixAlone(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			MinActiveSessions: intPtr(1),
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+	work := []beads.Bead{{
+		ID:       "out-of-range-routed",
+		Status:   "in_progress",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker-99",
+		},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+
+	if len(got) != 0 {
+		t.Fatalf("filtered work = %#v, want out-of-range instance suffix left unmatched and dropped", got)
+	}
+}
+
 func TestFilterAssignedWorkBeadsForPoolDemandDropsDirectAssigneeFromUnreachableStore(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "riga")

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -174,7 +175,7 @@ func computePoolDesiredStates(
 					routedTo = cfg.Agents[0].QualifiedName()
 				}
 			}
-			routedTo = normalizeAgentTemplateIdentity(cfg, routedTo)
+			routedTo = normalizeAgentTemplateIdentity(cfg, agentutil.NormalizePoolRouteTarget(cfg, routedTo))
 			if sessionBeadID != "" {
 				sessionTemplate := strings.TrimSpace(sessionBeadTemplate[sessionBeadID])
 				if sessionTemplate != "" && routedTo != "" && !agentTemplateIdentitiesEquivalent(cfg, routedTo, sessionTemplate) {

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -302,6 +302,59 @@ func TestComputePoolDesiredStates_ResumeUsesLegacyWorkflowRunTarget(t *testing.T
 	}
 }
 
+func TestComputePoolDesiredStates_ResumesInstanceSuffixedRouteTarget(t *testing.T) {
+	// A writer that stamps gc.routed_to with a live instance suffix directly
+	// (e.g. `bd update --set-metadata gc.routed_to=rig/claude-1`), bypassing gc
+	// sling's write-side normalization (agentutil.NormalizePoolRouteTarget,
+	// applied in doSling), must not strand the resume-tier match: the raw
+	// instance name has to resolve back to the base template before comparing
+	// against `template`, or the live session backing this work looks
+	// unrouted and never resumes.
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(3), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "rig/claude-1", "sess-1", "in_progress", 5),
+	}
+	sessions := []beads.Bead{sessionBead("sess-1", "open")}
+
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 1 {
+		t.Fatalf("len(requests) = %d, want 1 resume for instance-suffixed route target", len(reqs))
+	}
+	if reqs[0].Tier != "resume" || reqs[0].SessionBeadID != "sess-1" {
+		t.Fatalf("request = %+v, want resume for sess-1", reqs[0])
+	}
+}
+
+func TestComputePoolDesiredStates_LeavesUnmatchedInstanceSuffixAlone(t *testing.T) {
+	// Guard against over-normalization: an instance number outside the
+	// agent's configured capacity is not a pool instance identity and must
+	// not be rewritten or matched against the base template.
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(3), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "rig/claude-99", "sess-1", "in_progress", 5),
+	}
+	sessions := []beads.Bead{sessionBead("sess-1", "open")}
+
+	result := ComputePoolDesiredStates(cfg, work, sessionInfosFromBeads(sessions), nil)
+
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0 (out-of-range instance suffix must not resolve to the base template)", total)
+	}
+}
+
 func TestComputePoolDesiredStates_ResumeResolvesAssigneeByAliasHistory(t *testing.T) {
 	// Regression: alias rotation preserves prior aliases in alias_history.
 	// Work assigned under a prior alias must still resolve to its owning

--- a/release-gates/ga-40msgm-gate.md
+++ b/release-gates/ga-40msgm-gate.md
@@ -1,0 +1,33 @@
+# Release Gate: ga-40msgm
+
+Bead: ga-40msgm
+Source bead: ga-o3ko1j.6
+Reviewed commit: 314c5779fa66c048cd7cb6a9f2a2d8761051d11a
+Deploy branch: deploy/ga-40msgm-gate
+Deploy source commit: 314c5779fa66c048cd7cb6a9f2a2d8761051d11a
+Base checked: origin/main d5fbb58c983251bfe9df8c53be1b86ab6bef6408
+Project manifest: docs/PROJECT_MANIFEST.md not present in this repository checkout; evaluated against the deployer prompt's gate table, TESTING.md, and the Makefile fast-suite target.
+
+Stable patch-id for the feature files:
+
+`0df7861bd7ab0079738d0c5b819b6586ffc8c10c`
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `6957bffad5d4b5f6f8f2b4d919668ee36c55672c`. |
+| 1 | Review PASS present | PASS | Source bead ga-o3ko1j.6 notes contain `=== REVIEW VERDICT: PASS (gascity/reviewer) ===` for reviewed commit `314c5779f`; deploy metadata resolves that to `314c5779fa66c048cd7cb6a9f2a2d8761051d11a`. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `cmd/gc/assigned_work_scope.go`, `cmd/gc/assigned_work_scope_test.go`, `cmd/gc/pool_desired_state.go`, and `cmd/gc/pool_desired_state_test.go`. Tests cover instance-suffixed `gc.routed_to` normalization for pool-demand filtering and resume-tier requests, plus unmatched suffix guards. Scope notes confirm `findAgentByTemplate`, `config.AgentMatchesIdentity`, session-wake filtering, `openControlDispatcherDemand`, and the already-fixed cold-start demand matcher are unchanged. |
+| 3 | Tests pass | PASS | `go vet ./...` exit 0; `go build ./cmd/gc/` exit 0; focused `go test ./cmd/gc -run 'TestFilterAssignedWorkBeadsForPoolDemand\|TestComputePoolDesiredStates' -count=1 -v` passed; `make test-fast-parallel` passed with all 8 fast jobs green. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report no OWASP-relevant findings, scope discipline clean, and coverage present; no unresolved HIGH findings found in the bead notes. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v2 --branch` was clean before writing this gate file. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem: assigned-work reachability and pool resume demand for `gc.routed_to` instance-suffix normalization. |
+
+## Commands
+
+- `git merge-tree --write-tree origin/main HEAD`
+- `git diff --stat origin/main...HEAD`
+- `git patch-id --stable < <(git show HEAD -- cmd/gc/assigned_work_scope.go cmd/gc/assigned_work_scope_test.go cmd/gc/pool_desired_state.go cmd/gc/pool_desired_state_test.go)`
+- `go vet ./...`
+- `go build ./cmd/gc/`
+- `go test ./cmd/gc -run 'TestFilterAssignedWorkBeadsForPoolDemand|TestComputePoolDesiredStates' -count=1 -v`
+- `make test-fast-parallel`


### PR DESCRIPTION
## What this changes

Assigned work now remains reachable when its `gc.routed_to` metadata names a pool instance instead of the base pool template. A bead routed as `gascity/builder-1`, for example, is normalized to the `gascity/builder` template before assigned-work pool demand and resume-tier checks decide whether the session should stay alive or be resumed.

This is the assigned-work companion to the routed-demand normalization path: route metadata is made robust at the read sites that consume it, without changing the shared identity matcher or broadening unrelated session-wake semantics.

## Review notes

- Main logic is in `cmd/gc/assigned_work_scope.go` and `cmd/gc/pool_desired_state.go`.
- Tests are in the adjacent `assigned_work_scope_test.go` and `pool_desired_state_test.go` files.
- `findAgentByTemplate`, `config.AgentMatchesIdentity`, session-wake filtering, `openControlDispatcherDemand`, and the cold-start demand matcher are intentionally unchanged.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./cmd/gc/`
- [x] `go test ./cmd/gc -run 'TestFilterAssignedWorkBeadsForPoolDemand|TestComputePoolDesiredStates' -count=1 -v`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-40msgm-gate.md`](release-gates/ga-40msgm-gate.md)
