### PR TITLE
test(policy): ratchet listener-owning helpers

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -269,7 +269,8 @@ Go source through parsed syntax and import identity, while only `*_test.go`
 files contribute resource occurrences. The raw audit and source-debt rows
 freeze process, sleep, environment, CWD, slow-process, HTTP test-server, and
 package-level `net` stream/packet listeners, `net.ListenConfig` listeners,
-direct `syscall.Listen`, and typed or literal tmux dependency call/file totals.
+direct `syscall.Listen`, explicit listener-owning helper identities, and typed
+or literal tmux dependency call/file totals.
 Exact Medium rows name a repository-relative directory, package clause,
 top-level runnable owner, and resource list. Small-debt rows apply those exact
 owners without weakening the raw anti-growth ratchets.
@@ -343,10 +344,28 @@ source census is 6 calls in 2 files, all owned by exact Medium `TestMain`
 rows; build-tagged calls remain E1 Large inventory rather than being relabeled
 Medium. `NewSocketParentDir`, `HoldAliveSentinel`, and the PID-directory
 helpers remain part of the separate shared-host resource tail. Direct
-`syscall.Socket`/`Bind` setup calls, `net.FileListener`/`FilePacketConn`
-descriptor duplication, helper-backed listeners whose constructors live
-outside test source, Dolt, and other shared-host resources remain explicit
-follow-up catalogs. A Medium resource may describe a helper-backed runtime
+`syscall.Socket`/`Bind` setup calls remain outside this catalog.
+
+The listener-helper catalog is an explicit function-identity proxy, not
+recursive call-graph inference. It recognizes same-package calls to the
+`cmd/gc` package `main` helpers `runSupervisor`, `startControllerSocket`,
+`runController`, `registryBrowserLogin`,
+`managedDoltPortAvailableForHost`, and `startNudgeWakeListener`; the
+`test/dashport` package `dashport_test` helper `newHarness`; and same-package
+or import-identified calls to `internal/runtime/runtimecapability.Run` and
+`test/acceptance/helpers.WriteSupervisorConfig`. Same-package identity requires
+the exact directory, package clause, receiverless function declaration, and
+name; lexical shadows, same-named function values, wrong directories/packages,
+and foreign imports do not count. Its untagged source and Small-debt census is
+38 calls in 13 files. The 20 tagged calls in 10 files stay in E1 Large
+inventory, with no Medium exemption, for 58 calls in 23 files across all
+tracked test source.
+
+`net.FileListener`/`FilePacketConn` descriptor duplication, method-backed
+`acp.(*Provider).Start` and `subprocess.(*Provider).Start` listeners,
+conditional `cliauth.Client.Login` and `supervisor.LoadConfig` listener paths,
+Dolt, and other shared-host resources remain explicit follow-up catalogs. A
+Medium resource may describe a helper-backed runtime
 cost, but only syntax-owned calls in that exact runnable declaration
 leave Small-debt accounting. The `ListenConfig` matcher uses lexical Go types
 to follow same-file values, pointers, parameters, aliases, and typed factory
@@ -375,7 +394,7 @@ receivers; direct `syscall.Listen`;
 `NewSeamBackedWithConfig`, `NewTmux`, and `NewTmuxWithConfig` from
 `internal/runtime/tmux`; and literal `os/exec.Command("tmux", ...)`,
 `CommandContext(ctx, "tmux", ...)`, and `LookPath("tmux")` calls. It also
-recognizes the receiverless
+recognizes the listener-helper identities listed above and the receiverless
 `skipSlowCmdGCTest(*testing.T, string)` definition and its same-package calls.
 An unresolved cross-file call counts only when that directory and package own
 the canonical helper. Import, parameter, and same-file helper matches use
@@ -385,9 +404,10 @@ Local shadows and wrong signatures do not count. Parenthesized call
 expressions retain the same ownership.
 
 Targeted dot imports of `net`, `os/exec`, `time`, `os`, `syscall`, `testing`,
-`net/http/httptest`, `internal/runtime/tmux`, or `test/tmuxtest` are rejected
-with file and import context because their resources cannot be attributed
-safely; blank imports remain harmless.
+`net/http/httptest`, `internal/runtime/runtimecapability`,
+`internal/runtime/tmux`, `test/acceptance/helpers`, or `test/tmuxtest` are
+rejected with file and import context because their resources cannot be
+attributed safely; blank imports remain harmless.
 Explicit constraints follow Go's leading-header
 rules: a pre-package `//go:build` line is effective, while a legacy
 `// +build` line must live in a leading `//` comment block separated from the
@@ -421,6 +441,7 @@ all-source audit while staying outside untagged and Small debt.
 | Ledger kind | Source scope | Resource baseline | Tracking owner | Invariant / resource owner | Migration | Expiry |
 | --- | --- | --- | --- | --- | --- | --- |
 | Audit baseline | all tracked test source | fixed_sleep: 427 calls / 156 files (historical regex census: 447 / 157) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
+| Audit baseline | all tracked test source | listener_helper: 58 calls / 23 files | ga-80po0c.2.2.3 | all-source listener-helper call/file totals cannot drift without an explicit checked policy update; ga-80po0c.2.2.3 owns this all-source audit; tagged calls stay Large and receive no Medium exemption | P0.4c-listener-helper | 2026-10-01 |
 | Audit baseline | all tracked test source | subprocess: 531 calls / 163 files (historical regex census: 495 / 135) | ga-80po0c.2 | tracked test source totals remain visible as audit evidence; ga-80po0c.2 owns this point-in-time source census | P0.4a | 2026-10-01 |
 | Medium owner | `cmd/gc` package `main` | TestMain: environment, tmux | ga-80po0c.2.1 | cmd/gc TestMain is the checked package-level Medium owner for process environment and tmux namespace setup; only declared environment and tmux calls lexically inside TestMain leave Small debt | P0.4b/P0.4c-tmux | 2026-10-01 |
 | Medium owner | `internal/api` package `api` | TestEveryEmittedErrorCodeIsRegistered: subprocess | ga-80po0c.2.1 | internal/api tracked-source error URN guard is a checked Medium owner; only the git ls-files call lexically inside TestEveryEmittedErrorCodeIsRegistered leaves Small debt | P0.4b | 2026-10-01 |
@@ -435,6 +456,7 @@ all-source audit while staying outside untagged and Small debt.
 | Small debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 57 calls / 24 files (historical regex census: 75 / 25) | ga-80po0c.2.1 | untagged Small cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; each non-Medium marked caller retains an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | fixed_sleep: 288 calls / 111 files (historical regex census: 287 / 113) | ga-80po0c.2.1 | untagged Small fixed-sleep call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace elapsed wall time with lifecycle signals | W1-W5 | 2026-10-01 |
 | Small debt ratchet | all untagged test source | http_test_server: 317 calls / 66 files (historical regex census: 300 / 66) | ga-80po0c.2.2 | untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener | P0.4c | 2026-10-01 |
+| Small debt ratchet | all untagged test source | listener_helper: 38 calls / 13 files | ga-80po0c.2.2.3 | untagged Small listener-helper call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners replace helper-backed listeners or declare exact isolated ownership | P0.4c-listener-helper | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen: 92 calls / 34 files | ga-80po0c.2.2.2 | untagged Small stream-listener call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move stream-listener tests to exact Medium ownership or replace the listener | P0.4c-listener | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2.2 | untagged Small net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move ListenConfig-backed tests to exact Medium ownership or replace the listener | P0.4c-listener | 2026-10-01 |
 | Small debt ratchet | all untagged test source | net_listen_packet: 3 calls / 2 files | ga-80po0c.2.2.2 | untagged Small packet-listener call/file totals cannot grow; reductions must lower this baseline; non-Medium lexical owners move packet-listener tests to exact Medium ownership or replace the listener | P0.4c-listener | 2026-10-01 |
@@ -446,6 +468,7 @@ all-source audit while staying outside untagged and Small debt.
 | Source debt ratchet | `cmd/gc` untagged test source | slow_process_gate: 57 calls / 24 files (historical regex census: 78 / 27) | ga-80po0c.2.3 | untagged cmd/gc slow-process marker totals cannot grow; reductions must lower this baseline; the helper definition and every marked caller retain an explicit process-suite migration owner | D5/D6/E6 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | fixed_sleep: 288 calls / 111 files (historical regex census: 295 / 114) | ga-80po0c.2 | untagged fixed-sleep call/file totals cannot grow; reductions must lower this baseline; each owning test replaces elapsed wall time with its lifecycle signal | W1-W5 | 2026-10-01 |
 | Source debt ratchet | all untagged test source | http_test_server: 317 calls / 66 files (historical regex census: 255 / 56) | ga-80po0c.2.2 | untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline; each owning test closes its loopback server and removes duplicate server-backed coverage | P0.4c | 2026-10-01 |
+| Source debt ratchet | all untagged test source | listener_helper: 38 calls / 13 files | ga-80po0c.2.2.3 | untagged listener-helper call/file totals cannot grow; reductions must lower this baseline; each owning test replaces helper-backed listeners or moves the retained boundary to exact Medium ownership | P0.4c-listener-helper | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen: 94 calls / 35 files (historical regex census: 92 / 34) | ga-80po0c.2.2.2 | untagged stream-listener call/file totals cannot grow; reductions must lower this baseline; each owning test closes its stream listener and removes duplicate listener-backed coverage | P0.4c-listener | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen_config: 1 calls / 1 files | ga-80po0c.2.2.2 | untagged net.ListenConfig listener call/file totals cannot grow; reductions must lower this baseline; each owning test closes its configured listener and removes duplicate listener-backed coverage | P0.4c-listener | 2026-10-01 |
 | Source debt ratchet | all untagged test source | net_listen_packet: 3 calls / 2 files | ga-80po0c.2.2.2 | untagged packet-listener call/file totals cannot grow; reductions must lower this baseline; each owning test closes its packet listener and removes duplicate listener-backed coverage | P0.4c-listener | 2026-10-01 |

--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -42,6 +42,9 @@ const (
 	ResourceSlowProcessGate Resource = "slow_process_gate"
 	// ResourceHTTPTestServer counts loopback servers opened by net/http/httptest.
 	ResourceHTTPTestServer Resource = "http_test_server"
+	// ResourceListenerHelper counts calls to the explicit catalog of helpers
+	// whose implementation owns a network listener.
+	ResourceListenerHelper Resource = "listener_helper"
 	// ResourceNetListen counts direct stream listeners opened by package-level
 	// net constructors.
 	ResourceNetListen Resource = "net_listen"
@@ -64,6 +67,7 @@ var knownResources = map[Resource]struct{}{
 	ResourceCWD:             {},
 	ResourceSlowProcessGate: {},
 	ResourceHTTPTestServer:  {},
+	ResourceListenerHelper:  {},
 	ResourceNetListen:       {},
 	ResourceNetListenConfig: {},
 	ResourceNetListenPacket: {},
@@ -140,6 +144,19 @@ var bootstrapPolicy = Ledger{
 			Invariant:       "tracked test source totals remain visible as audit evidence",
 			ResourceOwner:   "ga-80po0c.2 owns this point-in-time source census",
 			MigrationTarget: "P0.4a",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeAll,
+			Resource:        ResourceListenerHelper,
+			BaselineCalls:   58,
+			BaselineFiles:   23,
+			ReportedCalls:   58,
+			ReportedFiles:   23,
+			OwnerBead:       "ga-80po0c.2.2.3",
+			Invariant:       "all-source listener-helper call/file totals cannot drift without an explicit checked policy update",
+			ResourceOwner:   "ga-80po0c.2.2.3 owns this all-source audit; tagged calls stay Large and receive no Medium exemption",
+			MigrationTarget: "P0.4c-listener-helper",
 			Expires:         "2026-10-01",
 		},
 	},
@@ -220,6 +237,19 @@ var bootstrapPolicy = Ledger{
 			Invariant:       "untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline",
 			ResourceOwner:   "each owning test closes its loopback server and removes duplicate server-backed coverage",
 			MigrationTarget: "P0.4c",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
+			Resource:        ResourceListenerHelper,
+			BaselineCalls:   38,
+			BaselineFiles:   13,
+			ReportedCalls:   38,
+			ReportedFiles:   13,
+			OwnerBead:       "ga-80po0c.2.2.3",
+			Invariant:       "untagged listener-helper call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "each owning test replaces helper-backed listeners or moves the retained boundary to exact Medium ownership",
+			MigrationTarget: "P0.4c-listener-helper",
 			Expires:         "2026-10-01",
 		},
 		{
@@ -489,6 +519,19 @@ var bootstrapPolicy = Ledger{
 		},
 		{
 			Scope:           ScopeUntagged,
+			Resource:        ResourceListenerHelper,
+			BaselineCalls:   38,
+			BaselineFiles:   13,
+			ReportedCalls:   38,
+			ReportedFiles:   13,
+			OwnerBead:       "ga-80po0c.2.2.3",
+			Invariant:       "untagged Small listener-helper call/file totals cannot grow; reductions must lower this baseline",
+			ResourceOwner:   "non-Medium lexical owners replace helper-backed listeners or declare exact isolated ownership",
+			MigrationTarget: "P0.4c-listener-helper",
+			Expires:         "2026-10-01",
+		},
+		{
+			Scope:           ScopeUntagged,
 			Resource:        ResourceNetListen,
 			BaselineCalls:   92,
 			BaselineFiles:   34,
@@ -669,12 +712,61 @@ type bindingInfo struct {
 	uses                       map[*ast.Ident]types.Object
 	expressionTypes            map[ast.Expr]types.TypeAndValue
 	packageDeclarations        map[string]struct{}
+	packageFunctions           map[string]struct{}
 	unresolvedImportQualifiers map[string]struct{}
 }
 
 type packageKey struct {
 	directory   string
 	packageName string
+}
+
+type listenerHelperPackageIdentity struct {
+	importPath string
+	key        packageKey
+	names      []string
+}
+
+var listenerHelperPackageIdentities = []listenerHelperPackageIdentity{
+	{
+		key: packageKey{directory: "cmd/gc", packageName: "main"},
+		names: []string{
+			"managedDoltPortAvailableForHost",
+			"registryBrowserLogin",
+			"runController",
+			"runSupervisor",
+			"startControllerSocket",
+			"startNudgeWakeListener",
+		},
+	},
+	{
+		importPath: "github.com/gastownhall/gascity/internal/runtime/runtimecapability",
+		key:        packageKey{directory: "internal/runtime/runtimecapability", packageName: "runtimecapability"},
+		names:      []string{"Run"},
+	},
+	{
+		importPath: "github.com/gastownhall/gascity/test/acceptance/helpers",
+		key:        packageKey{directory: "test/acceptance/helpers", packageName: "acceptancehelpers"},
+		names:      []string{"WriteSupervisorConfig"},
+	},
+	{
+		key:   packageKey{directory: "test/dashport", packageName: "dashport_test"},
+		names: []string{"newHarness"},
+	},
+}
+
+var targetedDotImportPaths = map[string]struct{}{
+	"github.com/gastownhall/gascity/internal/runtime/runtimecapability": {},
+	"github.com/gastownhall/gascity/internal/runtime/tmux":              {},
+	"github.com/gastownhall/gascity/test/acceptance/helpers":            {},
+	"github.com/gastownhall/gascity/test/tmuxtest":                      {},
+	"net":               {},
+	"net/http/httptest": {},
+	"os":                {},
+	"os/exec":           {},
+	"syscall":           {},
+	"testing":           {},
+	"time":              {},
 }
 
 type resourceCall struct {
@@ -695,7 +787,14 @@ func (importer *emptyPackageImporter) Import(importPath string) (*types.Package,
 	if imported, ok := importer.packages[importPath]; ok {
 		return imported, nil
 	}
-	imported := types.NewPackage(importPath, path.Base(importPath))
+	packageName := path.Base(importPath)
+	for _, identity := range listenerHelperPackageIdentities {
+		if importPath == identity.importPath {
+			packageName = identity.key.packageName
+			break
+		}
+	}
+	imported := types.NewPackage(importPath, packageName)
 	if importPath == "net" {
 		// Seed only the receiver type the census needs so go/types can carry
 		// ListenConfig identity through pointers and aliases without loading
@@ -742,6 +841,7 @@ func scanFiles(sourceFS fs.FS, names []string, hermeticPackages map[packageKey]s
 	var hermeticSources []parsedFile
 	var runnables []RunnableOwner
 	packageDeclarations := make(map[packageKey]map[string]struct{})
+	packageFunctions := make(map[packageKey]map[string]struct{})
 	for _, name := range names {
 		data, err := fs.ReadFile(sourceFS, name)
 		if err != nil {
@@ -759,6 +859,15 @@ func scanFiles(sourceFS fs.FS, names []string, hermeticPackages map[packageKey]s
 			packageDeclarations[key] = declarations
 		}
 		recordPackageDeclarations(file, declarations)
+		listenerHelperNames := listenerHelperPackageNames(key)
+		if len(listenerHelperNames) > 0 {
+			functions := packageFunctions[key]
+			if functions == nil {
+				functions = make(map[string]struct{})
+				packageFunctions[key] = functions
+			}
+			recordPackageFunctionDeclarations(file, functions, listenerHelperNames)
+		}
 		source := parsedFile{
 			name:        normalized,
 			directory:   key.directory,
@@ -781,7 +890,7 @@ func scanFiles(sourceFS fs.FS, names []string, hermeticPackages map[packageKey]s
 			return Census{}, fmt.Errorf("scanning imports in %s: %w", name, err)
 		}
 		runnables = append(runnables, runnableOwners(file, key.directory, key.packageName)...)
-		candidates := resourceCandidateCalls(file)
+		candidates := resourceCandidateCalls(file, key)
 		source.tagged = tagged || hasImplicitPlatformConstraint(name)
 		source.calls = candidates
 		if retainHermeticSource {
@@ -798,6 +907,7 @@ func scanFiles(sourceFS fs.FS, names []string, hermeticPackages map[packageKey]s
 		source := &sources[index]
 		bindings := resolveBindings(fileSet, source.file, importer, fmt.Sprintf("resourcecensus.local/file%d", index))
 		bindings.packageDeclarations = packageDeclarations[source.groupKey()]
+		bindings.packageFunctions = packageFunctions[source.groupKey()]
 		bindings.unresolvedImportQualifiers = unresolvedDefaultImportQualifiers(source.file)
 		source.bindings = bindings
 	}
@@ -834,6 +944,7 @@ func scanFiles(sourceFS fs.FS, names []string, hermeticPackages map[packageKey]s
 			fileSet:             fileSet,
 			files:               hermeticSources,
 			packageDeclarations: packageDeclarations,
+			packageFunctions:    packageFunctions,
 		},
 	}
 	for _, source := range sources {
@@ -856,7 +967,7 @@ func scanFiles(sourceFS fs.FS, names []string, hermeticPackages map[packageKey]s
 		}
 
 		for _, candidate := range source.calls {
-			resources, err := matchedResourcesForCall(candidate.call, source.bindings, testingObjects, slowHelpers[source.groupKey()])
+			resources, err := matchedResourcesForCall(candidate.call, source.groupKey(), source.bindings, testingObjects, slowHelpers[source.groupKey()])
 			if err != nil {
 				return Census{}, fmt.Errorf("scanning resource calls in %s: %w", source.name, err)
 			}
@@ -1009,7 +1120,7 @@ func validateImports(file *ast.File) error {
 			continue
 		}
 		if spec.Name != nil && spec.Name.Name == "." {
-			if importPath == "net" || importPath == "os/exec" || importPath == "time" || importPath == "os" || importPath == "syscall" || importPath == "testing" || importPath == "net/http/httptest" || importPath == "github.com/gastownhall/gascity/internal/runtime/tmux" || importPath == "github.com/gastownhall/gascity/test/tmuxtest" {
+			if _, targeted := targetedDotImportPaths[importPath]; targeted {
 				return fmt.Errorf("targeted dot import %q cannot be counted safely", importPath)
 			}
 		}
@@ -1017,21 +1128,23 @@ func validateImports(file *ast.File) error {
 	return nil
 }
 
-func resourceCandidateCalls(file *ast.File) []resourceCall {
+func resourceCandidateCalls(file *ast.File, key packageKey) []resourceCall {
 	aliases := testingImportAliases(file)
+	listenerHelperSelectors := listenerHelperSelectorCandidates(file)
+	samePackageHelperNames := listenerHelperPackageNames(key)
 	var calls []resourceCall
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if ok {
-			calls = appendResourceCandidateCalls(calls, function.Body, function.Name.Name, isRunnableOwner(function, aliases))
+			calls = appendResourceCandidateCalls(calls, function.Body, function.Name.Name, isRunnableOwner(function, aliases), listenerHelperSelectors, samePackageHelperNames)
 			continue
 		}
-		calls = appendResourceCandidateCalls(calls, declaration, "", false)
+		calls = appendResourceCandidateCalls(calls, declaration, "", false, listenerHelperSelectors, samePackageHelperNames)
 	}
 	return calls
 }
 
-func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner string, runnable bool) []resourceCall {
+func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner string, runnable bool, listenerHelperSelectors map[string]struct{}, listenerHelperPackageNames []string) []resourceCall {
 	ast.Inspect(node, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -1043,14 +1156,56 @@ func appendResourceCandidateCalls(calls []resourceCall, node ast.Node, owner str
 			case "Command", "CommandContext", "ConfigureProcessEnv", "KillAllTestSessions", "LookPath", "NewGuard", "NewGuardWithSocket", "NewProvider", "NewProviderWithConfig", "NewSeamBackedWithConfig", "NewServer", "NewTLSServer", "NewTmux", "NewTmuxWithConfig", "NewUnstartedServer", "RequireTmux", "Sleep", "Setenv", "Unsetenv", "Clearenv", "Chdir", "Listen", "ListenIP", "ListenMulticastUDP", "ListenPacket", "ListenTCP", "ListenUDP", "ListenUnix", "ListenUnixgram":
 				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
+			if _, candidate := listenerHelperSelectors[function.Sel.Name]; candidate {
+				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
+			}
 		case *ast.Ident:
-			if function.Name == "skipSlowCmdGCTest" {
+			if function.Name == "skipSlowCmdGCTest" || containsString(listenerHelperPackageNames, function.Name) {
 				calls = append(calls, resourceCall{call: call, owner: owner, runnable: runnable})
 			}
 		}
 		return true
 	})
 	return calls
+}
+
+func listenerHelperSelectorCandidates(file *ast.File) map[string]struct{} {
+	candidates := make(map[string]struct{})
+	for _, spec := range file.Imports {
+		if spec.Name != nil && spec.Name.Name == "_" {
+			continue
+		}
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		for _, identity := range listenerHelperPackageIdentities {
+			if importPath == identity.importPath {
+				for _, name := range identity.names {
+					candidates[name] = struct{}{}
+				}
+			}
+		}
+	}
+	return candidates
+}
+
+func listenerHelperPackageNames(key packageKey) []string {
+	for _, identity := range listenerHelperPackageIdentities {
+		if key == identity.key {
+			return identity.names
+		}
+	}
+	return nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func runnableOwners(file *ast.File, packageDir, packageName string) []RunnableOwner {
@@ -1225,6 +1380,15 @@ func recordPackageDeclarations(file *ast.File, declarations map[string]struct{})
 					}
 				}
 			}
+		}
+	}
+}
+
+func recordPackageFunctionDeclarations(file *ast.File, functions map[string]struct{}, catalogNames []string) {
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Recv == nil && containsString(catalogNames, function.Name.Name) {
+			functions[function.Name.Name] = struct{}{}
 		}
 	}
 }
@@ -1466,6 +1630,33 @@ func functionParameterCount(fields *ast.FieldList) int {
 		}
 	}
 	return count
+}
+
+func isListenerHelperPackageCall(call *ast.CallExpr, key packageKey, bindings bindingInfo) bool {
+	identifier, ok := unparen(call.Fun).(*ast.Ident)
+	if !ok {
+		return false
+	}
+	for _, identity := range listenerHelperPackageIdentities {
+		if key != identity.key {
+			continue
+		}
+		for _, helperName := range identity.names {
+			if identifier.Name != helperName {
+				continue
+			}
+			if _, declared := bindings.packageFunctions[helperName]; !declared {
+				return false
+			}
+			object := bindings.uses[identifier]
+			if object == nil {
+				return true
+			}
+			function, ok := object.(*types.Func)
+			return ok && function.Pkg() != nil && function.Pkg().Name() == key.packageName && function.Parent() == function.Pkg().Scope()
+		}
+	}
+	return false
 }
 
 func isSlowHelperCall(call *ast.CallExpr, bindings bindingInfo, ownership types.Object) bool {

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -574,6 +574,211 @@ func TestSiblingShadow() {
 	assertOccurrenceOwner(t, got, "sample/tagged_test.go", ResourceNetListenConfig, "TestTaggedNetListenConfig", true, true)
 }
 
+func TestScanCountsListenerHelpersByExactPackageAndImportIdentity(t *testing.T) {
+	t.Parallel()
+	listenerHelper := ResourceListenerHelper
+
+	t.Run("cataloged helpers retain lexical ownership", func(t *testing.T) {
+		t.Parallel()
+		files := fstest.MapFS{
+			"cmd/gc/helpers.go": &fstest.MapFile{Data: []byte(`package main
+func runSupervisor() {}
+func startControllerSocket() {}
+func runController() {}
+func registryBrowserLogin() {}
+func managedDoltPortAvailableForHost() {}
+func startNudgeWakeListener() {}
+func uncatalogedListenerHelper() {}
+`)},
+			"cmd/gc/resources_test.go": &fstest.MapFile{Data: []byte(`package main
+import (
+	capability "github.com/gastownhall/gascity/internal/runtime/runtimecapability"
+	acceptance "github.com/gastownhall/gascity/test/acceptance/helpers"
+	foreigncap "example.test/internal/runtime/runtimecapability"
+	foreignacceptance "example.test/acceptance/helpers"
+	"testing"
+)
+func TestListenerHelpers(t *testing.T) {
+	((runSupervisor))()
+	startControllerSocket()
+	runController()
+	registryBrowserLogin()
+	managedDoltPortAvailableForHost()
+	startNudgeWakeListener()
+	((capability.Run))()
+	((acceptance.WriteSupervisorConfig))()
+	foreigncap.Run()
+	foreignacceptance.WriteSupervisorConfig()
+	uncatalogedListenerHelper()
+	_ = "runSupervisor()"
+	// startControllerSocket()
+	{
+		runSupervisor := func() {}
+		runSupervisor()
+	}
+}
+func listenerHelper() { runController() }
+`)},
+			"cmd/gc/tagged_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package main
+import "testing"
+func TestTaggedListenerHelper(t *testing.T) { registryBrowserLogin() }
+`)},
+			"cmd/gc/wrong_package_test.go": &fstest.MapFile{Data: []byte(`package main_test
+import "testing"
+func runSupervisor() {}
+func TestWrongPackage(t *testing.T) { runSupervisor() }
+`)},
+			"test/dashport/harness.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package dashport_test
+func newHarness() {}
+`)},
+			"test/dashport/projection_test.go": &fstest.MapFile{Data: []byte(`//go:build integration
+
+package dashport_test
+import "testing"
+func TestDashportHarness(t *testing.T) { ((newHarness))() }
+`)},
+		}
+
+		got, err := ScanFS(files)
+		if err != nil {
+			t.Fatalf("ScanFS: %v", err)
+		}
+		assertCount(t, got, ScopeAll, listenerHelper, 11, 3)
+		assertCount(t, got, ScopeUntagged, listenerHelper, 9, 1)
+		assertOccurrenceOwner(t, got, "cmd/gc/resources_test.go", listenerHelper, "TestListenerHelpers", true, false)
+		assertOccurrenceOwner(t, got, "cmd/gc/resources_test.go", listenerHelper, "listenerHelper", false, false)
+		assertOccurrenceOwner(t, got, "cmd/gc/tagged_test.go", listenerHelper, "TestTaggedListenerHelper", true, true)
+		assertOccurrenceOwner(t, got, "test/dashport/projection_test.go", listenerHelper, "TestDashportHarness", true, true)
+	})
+
+	t.Run("default imported helper uses its declared package name", func(t *testing.T) {
+		t.Parallel()
+		got, err := ScanFS(fstest.MapFS{
+			"sample/resources_test.go": &fstest.MapFile{Data: []byte(`package sample
+import "github.com/gastownhall/gascity/test/acceptance/helpers"
+func TestDefaultImport() { acceptancehelpers.WriteSupervisorConfig() }
+`)},
+		})
+		if err != nil {
+			t.Fatalf("ScanFS: %v", err)
+		}
+		assertCount(t, got, ScopeAll, listenerHelper, 1, 1)
+		assertCount(t, got, ScopeUntagged, listenerHelper, 1, 1)
+	})
+
+	t.Run("same-package exported helpers reject lexical shadows", func(t *testing.T) {
+		t.Parallel()
+		got, err := ScanFS(fstest.MapFS{
+			"internal/runtime/runtimecapability/runner.go": &fstest.MapFile{Data: []byte(`package runtimecapability
+func Run() {}
+`)},
+			"internal/runtime/runtimecapability/runner_test.go": &fstest.MapFile{Data: []byte(`package runtimecapability
+import "testing"
+func TestRuntimeCapability(t *testing.T) {
+	((Run))()
+	{
+		Run := func() {}
+		Run()
+	}
+}
+`)},
+			"test/acceptance/helpers/env.go": &fstest.MapFile{Data: []byte(`package acceptancehelpers
+func WriteSupervisorConfig() {}
+`)},
+			"test/acceptance/helpers/env_test.go": &fstest.MapFile{Data: []byte(`package acceptancehelpers
+import "testing"
+func TestSupervisorConfig(t *testing.T) {
+	((WriteSupervisorConfig))()
+	{
+		WriteSupervisorConfig := func() {}
+		WriteSupervisorConfig()
+	}
+}
+`)},
+		})
+		if err != nil {
+			t.Fatalf("ScanFS: %v", err)
+		}
+		assertCount(t, got, ScopeAll, listenerHelper, 2, 2)
+		assertCount(t, got, ScopeUntagged, listenerHelper, 2, 2)
+		assertOccurrenceOwner(t, got, "internal/runtime/runtimecapability/runner_test.go", listenerHelper, "TestRuntimeCapability", true, false)
+		assertOccurrenceOwner(t, got, "test/acceptance/helpers/env_test.go", listenerHelper, "TestSupervisorConfig", true, false)
+	})
+
+	t.Run("same package name in a different directory is not the helper package", func(t *testing.T) {
+		t.Parallel()
+		got, err := ScanFS(fstest.MapFS{
+			"other/helpers.go": &fstest.MapFile{Data: []byte(`package main
+func runSupervisor() {}
+`)},
+			"other/helpers_test.go": &fstest.MapFile{Data: []byte(`package main
+import "testing"
+func TestWrongDirectory(t *testing.T) { runSupervisor() }
+`)},
+		})
+		if err != nil {
+			t.Fatalf("ScanFS: %v", err)
+		}
+		assertCount(t, got, ScopeAll, listenerHelper, 0, 0)
+		assertCount(t, got, ScopeUntagged, listenerHelper, 0, 0)
+	})
+
+	t.Run("cross-file package function value is not a helper declaration", func(t *testing.T) {
+		t.Parallel()
+		got, err := ScanFS(fstest.MapFS{
+			"cmd/gc/helpers.go": &fstest.MapFile{Data: []byte(`package main
+var runSupervisor = func() {}
+`)},
+			"cmd/gc/helpers_test.go": &fstest.MapFile{Data: []byte(`package main
+import "testing"
+func TestFunctionValue(t *testing.T) { runSupervisor() }
+`)},
+		})
+		if err != nil {
+			t.Fatalf("ScanFS: %v", err)
+		}
+		assertCount(t, got, ScopeAll, listenerHelper, 0, 0)
+		assertCount(t, got, ScopeUntagged, listenerHelper, 0, 0)
+	})
+
+	t.Run("same-package method is not a helper declaration", func(t *testing.T) {
+		t.Parallel()
+		got, err := ScanFS(fstest.MapFS{
+			"cmd/gc/method.go": &fstest.MapFile{Data: []byte(`package main
+type helperReceiver struct{}
+func (helperReceiver) runSupervisor() {}
+`)},
+			"cmd/gc/method_test.go": &fstest.MapFile{Data: []byte(`package main
+func TestMethod() { helperReceiver{}.runSupervisor() }
+`)},
+		})
+		if err != nil {
+			t.Fatalf("ScanFS: %v", err)
+		}
+		assertCount(t, got, ScopeAll, listenerHelper, 0, 0)
+		assertCount(t, got, ScopeUntagged, listenerHelper, 0, 0)
+	})
+
+	t.Run("same-package helper requires a package declaration", func(t *testing.T) {
+		t.Parallel()
+		got, err := ScanFS(fstest.MapFS{
+			"cmd/gc/missing_test.go": &fstest.MapFile{Data: []byte(`package main
+import "testing"
+func TestMissingListenerHelper(t *testing.T) { runSupervisor() }
+`)},
+		})
+		if err != nil {
+			t.Fatalf("ScanFS: %v", err)
+		}
+		assertCount(t, got, ScopeAll, listenerHelper, 0, 0)
+		assertCount(t, got, ScopeUntagged, listenerHelper, 0, 0)
+	})
+}
+
 func TestResolveBindingsRetainsOnlyNetListenReceiverTypes(t *testing.T) {
 	t.Parallel()
 
@@ -1241,6 +1446,24 @@ func TestResource() { _ = NewServer(nil) }
 `,
 		},
 		{
+			name:       "runtime capability helper",
+			path:       "sample/dot_runtimecapability_test.go",
+			importPath: "github.com/gastownhall/gascity/internal/runtime/runtimecapability",
+			source: `package sample
+import . "github.com/gastownhall/gascity/internal/runtime/runtimecapability"
+func TestResource() { Run() }
+`,
+		},
+		{
+			name:       "acceptance listener helper",
+			path:       "sample/dot_acceptance_helpers_test.go",
+			importPath: "github.com/gastownhall/gascity/test/acceptance/helpers",
+			source: `package sample
+import . "github.com/gastownhall/gascity/test/acceptance/helpers"
+func TestResource() { WriteSupervisorConfig() }
+`,
+		},
+		{
 			name:       "syscall",
 			path:       "sample/dot_syscall_test.go",
 			importPath: "syscall",
@@ -1683,6 +1906,28 @@ func TestBootstrapPolicyOwnsHTTPTestServerDebt(t *testing.T) {
 		row := findRow(t, rows, ScopeUntagged, ResourceHTTPTestServer)
 		if row.OwnerBead != "ga-80po0c.2.2" || row.MigrationTarget != "P0.4c" {
 			t.Fatalf("HTTP test server owner = %q/%q, want ga-80po0c.2.2/P0.4c", row.OwnerBead, row.MigrationTarget)
+		}
+	}
+}
+
+func TestBootstrapPolicyOwnsListenerHelperDebt(t *testing.T) {
+	t.Parallel()
+
+	audit := findRow(t, bootstrapPolicy.AuditBaseline, ScopeAll, ResourceListenerHelper)
+	if audit.BaselineCalls != 58 || audit.BaselineFiles != 23 || audit.ReportedCalls != 58 || audit.ReportedFiles != 23 {
+		t.Fatalf("all-source listener-helper baseline/reported = %d/%d, %d/%d; want 58/23, 58/23", audit.BaselineCalls, audit.BaselineFiles, audit.ReportedCalls, audit.ReportedFiles)
+	}
+	if audit.OwnerBead != "ga-80po0c.2.2.3" || audit.MigrationTarget != "P0.4c-listener-helper" {
+		t.Fatalf("all-source listener-helper owner = %q/%q, want ga-80po0c.2.2.3/P0.4c-listener-helper", audit.OwnerBead, audit.MigrationTarget)
+	}
+
+	for _, rows := range [][]Baseline{bootstrapPolicy.Debt, bootstrapPolicy.SmallDebt} {
+		row := findRow(t, rows, ScopeUntagged, ResourceListenerHelper)
+		if row.BaselineCalls != 38 || row.BaselineFiles != 13 || row.ReportedCalls != 38 || row.ReportedFiles != 13 {
+			t.Fatalf("listener-helper baseline/reported = %d/%d, %d/%d; want 38/13, 38/13", row.BaselineCalls, row.BaselineFiles, row.ReportedCalls, row.ReportedFiles)
+		}
+		if row.OwnerBead != "ga-80po0c.2.2.3" || row.MigrationTarget != "P0.4c-listener-helper" {
+			t.Fatalf("listener-helper owner = %q/%q, want ga-80po0c.2.2.3/P0.4c-listener-helper", row.OwnerBead, row.MigrationTarget)
 		}
 	}
 }

--- a/internal/testpolicy/resourcecensus/hermetic.go
+++ b/internal/testpolicy/resourcecensus/hermetic.go
@@ -28,6 +28,7 @@ type hermeticSourceIndex struct {
 	fileSet             *token.FileSet
 	files               []parsedFile
 	packageDeclarations map[packageKey]map[string]struct{}
+	packageFunctions    map[packageKey]map[string]struct{}
 }
 
 type hermeticFile struct {
@@ -48,6 +49,7 @@ type hermeticAnalyzer struct {
 	fileSet             *token.FileSet
 	importer            *emptyPackageImporter
 	packageDeclarations map[packageKey]map[string]struct{}
+	packageFunctions    map[packageKey]map[string]struct{}
 	functions           map[packageKey]map[string][]*hermeticFunction
 	slowHelpers         map[packageKey]types.Object
 }
@@ -269,14 +271,23 @@ func newHermeticAnalyzer(sourceIndex *hermeticSourceIndex, rows []ReviewedHermet
 	})
 
 	declarations := sourceIndex.packageDeclarations
+	functionDeclarations := sourceIndex.packageFunctions
 	if declarations == nil {
 		declarations = make(map[packageKey]map[string]struct{})
+		functionDeclarations = make(map[packageKey]map[string]struct{})
 		for _, source := range files {
 			key := source.groupKey()
 			if declarations[key] == nil {
 				declarations[key] = make(map[string]struct{})
 			}
 			recordPackageDeclarations(source.file, declarations[key])
+			catalogNames := listenerHelperPackageNames(key)
+			if len(catalogNames) > 0 {
+				if functionDeclarations[key] == nil {
+					functionDeclarations[key] = make(map[string]struct{})
+				}
+				recordPackageFunctionDeclarations(source.file, functionDeclarations[key], catalogNames)
+			}
 		}
 	}
 
@@ -284,6 +295,7 @@ func newHermeticAnalyzer(sourceIndex *hermeticSourceIndex, rows []ReviewedHermet
 		fileSet:             sourceIndex.fileSet,
 		importer:            newEmptyPackageImporter(),
 		packageDeclarations: declarations,
+		packageFunctions:    functionDeclarations,
 		functions:           make(map[packageKey]map[string][]*hermeticFunction),
 		slowHelpers:         make(map[packageKey]types.Object),
 	}
@@ -344,6 +356,7 @@ func (a *hermeticAnalyzer) resolveFile(file *hermeticFile) error {
 	}
 	bindings := resolveBindings(a.fileSet, file.source.file, a.importer, fmt.Sprintf("resourcecensus.hermetic/file%d", file.index))
 	bindings.packageDeclarations = a.packageDeclarations[file.source.groupKey()]
+	bindings.packageFunctions = a.packageFunctions[file.source.groupKey()]
 	bindings.unresolvedImportQualifiers = unresolvedDefaultImportQualifiers(file.source.file)
 	testingObjects, err := testingParameterObjects(file.source.file, bindings)
 	if err != nil {
@@ -477,7 +490,7 @@ func (a *hermeticAnalyzer) analyzeFunction(key packageKey, function *hermeticFun
 			return false
 		}
 		if call, ok := node.(*ast.CallExpr); ok {
-			matched, err := matchedResourcesForCall(call, function.file.bindings, function.file.testingObjects, a.slowHelpers[key])
+			matched, err := matchedResourcesForCall(call, key, function.file.bindings, function.file.testingObjects, a.slowHelpers[key])
 			if err != nil {
 				inspectErr = fmt.Errorf("%s: %w", function.file.source.name, err)
 				return false
@@ -583,7 +596,7 @@ func nonValueIdentifier(identifier *ast.Ident, parent ast.Node) bool {
 
 // matchedResourcesForCall is the single mapping from a syntax-owned call to
 // the resource identities recognized by both the census and hermetic review.
-func matchedResourcesForCall(call *ast.CallExpr, bindings bindingInfo, testingObjects map[types.Object]bool, slowHelperObject types.Object) ([]Resource, error) {
+func matchedResourcesForCall(call *ast.CallExpr, key packageKey, bindings bindingInfo, testingObjects map[types.Object]bool, slowHelperObject types.Object) ([]Resource, error) {
 	var resources []Resource
 	appendImported := func(resource Resource, importPath string, names ...string) error {
 		matched, err := isImportedCall(call, bindings, importPath, names...)
@@ -613,6 +626,17 @@ func matchedResourcesForCall(call *ast.CallExpr, bindings bindingInfo, testingOb
 	}
 	if err := appendImported(ResourceHTTPTestServer, "net/http/httptest", "NewServer", "NewTLSServer", "NewUnstartedServer"); err != nil {
 		return nil, err
+	}
+	for _, identity := range listenerHelperPackageIdentities {
+		if identity.importPath == "" {
+			continue
+		}
+		if err := appendImported(ResourceListenerHelper, identity.importPath, identity.names...); err != nil {
+			return nil, err
+		}
+	}
+	if isListenerHelperPackageCall(call, key, bindings) {
+		resources = append(resources, ResourceListenerHelper)
 	}
 	if err := appendImported(ResourceSubprocess, "os/exec", "Command", "CommandContext"); err != nil {
 		return nil, err

--- a/internal/testpolicy/resourcecensus/hermetic_test.go
+++ b/internal/testpolicy/resourcecensus/hermetic_test.go
@@ -158,6 +158,28 @@ func TestValidateReviewedHermeticBodiesRejectsDirectKnownResources(t *testing.T)
 	}
 }
 
+func TestValidateReviewedHermeticBodiesRejectsDirectListenerHelper(t *testing.T) {
+	t.Parallel()
+
+	census := scanHermeticFixture(t, fstest.MapFS{
+		"cmd/gc/helpers.go": &fstest.MapFile{Data: []byte(`package main
+func runSupervisor() {}
+`)},
+		"cmd/gc/resource_test.go": &fstest.MapFile{Data: []byte(`package main
+import "testing"
+func TestHermetic(t *testing.T) { ((runSupervisor))() }
+`)},
+	})
+	row := ReviewedHermeticBody{
+		PackageDir:    "cmd/gc",
+		PackageName:   "main",
+		Owner:         "TestHermetic",
+		EffectiveSize: "medium",
+		MediumReason:  "package TestMain mutates process state",
+	}
+	requireErrorContains(t, validateReviewedHermeticBodies([]ReviewedHermeticBody{row}, census), "listener_helper")
+}
+
 func TestValidateReviewedHermeticBodiesFollowsHelpersWithoutShadowFalseMatches(t *testing.T) {
 	t.Parallel()
 

--- a/test/test-resources.toml
+++ b/test/test-resources.toml
@@ -33,6 +33,19 @@ resource_owner = "ga-80po0c.2 owns this point-in-time source census"
 migration_target = "P0.4a"
 expires = "2026-10-01"
 
+[[audit_baseline]]
+scope = "all"
+resource = "listener_helper"
+baseline_calls = 58
+baseline_files = 23
+reported_calls = 58
+reported_files = 23
+owner_bead = "ga-80po0c.2.2.3"
+invariant = "all-source listener-helper call/file totals cannot drift without an explicit checked policy update"
+resource_owner = "ga-80po0c.2.2.3 owns this all-source audit; tagged calls stay Large and receive no Medium exemption"
+migration_target = "P0.4c-listener-helper"
+expires = "2026-10-01"
+
 # Debt rows ratchet source call sites only. They are not test-size entries and
 # do not exempt or reclassify any test.
 [[debt]]
@@ -111,6 +124,19 @@ owner_bead = "ga-80po0c.2.2"
 invariant = "untagged HTTP test server call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "each owning test closes its loopback server and removes duplicate server-backed coverage"
 migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[debt]]
+scope = "untagged"
+resource = "listener_helper"
+baseline_calls = 38
+baseline_files = 13
+reported_calls = 38
+reported_files = 13
+owner_bead = "ga-80po0c.2.2.3"
+invariant = "untagged listener-helper call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "each owning test replaces helper-backed listeners or moves the retained boundary to exact Medium ownership"
+migration_target = "P0.4c-listener-helper"
 expires = "2026-10-01"
 
 [[debt]]
@@ -380,6 +406,19 @@ owner_bead = "ga-80po0c.2.2"
 invariant = "untagged Small HTTP test server call/file totals cannot grow; reductions must lower this baseline"
 resource_owner = "non-Medium lexical owners move server-backed tests to exact Medium ownership or replace the listener"
 migration_target = "P0.4c"
+expires = "2026-10-01"
+
+[[small_debt]]
+scope = "untagged"
+resource = "listener_helper"
+baseline_calls = 38
+baseline_files = 13
+reported_calls = 38
+reported_files = 13
+owner_bead = "ga-80po0c.2.2.3"
+invariant = "untagged Small listener-helper call/file totals cannot grow; reductions must lower this baseline"
+resource_owner = "non-Medium lexical owners replace helper-backed listeners or declare exact isolated ownership"
+migration_target = "P0.4c-listener-helper"
 expires = "2026-10-01"
 
 [[small_debt]]


### PR DESCRIPTION
## Summary

- add one explicit `listener_helper` resource to the test-resource census
- recognize only reviewed listener-owning helper identities; do not infer recursive call graphs
- ratchet both the untagged Small debt and the complete tagged/untagged inventory
- document the matcher contract and remaining listener boundaries in `TESTING.md`

## Exact helper catalog

| Package identity | Helpers |
| --- | --- |
| `cmd/gc` package `main` | `runSupervisor`, `startControllerSocket`, `runController`, `registryBrowserLogin`, `managedDoltPortAvailableForHost`, `startNudgeWakeListener` |
| `test/dashport` package `dashport_test` | `newHarness` |
| `internal/runtime/runtimecapability` | `Run` |
| `test/acceptance/helpers` | `WriteSupervisorConfig` |

Same-package calls require the exact directory and package clause, a receiverless package-function declaration, and lexical package binding. Imported calls require the exact import path. Tests reject local shadows, methods, function values, wrong directories/packages, foreign imports, missing declarations, comments, and strings.

This is deliberately an explicit dependency proxy. It does not claim completeness across arbitrary helper graphs or method/interface dispatch.

## Checked inventory

| Scope | Calls | Files | Policy |
| --- | ---: | ---: | --- |
| Untagged source | 38 | 13 | source-debt ratchet |
| Untagged Small debt | 38 | 13 | Small-debt ratchet |
| Tagged Large inventory | 20 | 10 | no Medium exemption |
| All tracked test source | 58 | 23 | checked audit ratchet |

The all-source audit was added after delegated review caught four tagged `newHarness` calls that landed after the original implementation. Future tagged drift now fails unless the Go policy, TOML ledger, and generated `TESTING.md` table are intentionally updated together.

## Behavior and performance

No helper implementation, listener lifecycle, build tag, test body, or production/runtime behavior changes. Scanner work remains bounded to one existing AST walk plus a constant-size catalog and declaration maps; there is no graph traversal.

Five-run resource-census timing was effectively flat:

- base: 16.04s
- candidate: 15.27s

This is evidence of no measurable regression, not a speedup claim.

## Verification

- TDD RED: `ResourceListenerHelper` was undefined before implementation
- TDD RED for review correction: missing `scope=all resource=listener_helper`
- focused listener-helper, hermetic, bootstrap-policy, repository-ledger, and documentation checks
- `go test -count=1 ./internal/testpolicy/resourcecensus`
- focused tests with `-count=10`
- `go test -race -count=1 ./internal/testpolicy/resourcecensus`
- `go test -count=1 ./test/docsync`
- `make test-fast-parallel` — all eight shards green in 208.45s
- `go vet ./...`
- `.githooks/pre-commit`
- `git diff --cached --check`

Three independent delegated review lanes approved exact staged tree `76b5d26ab1e64d7907144b1daf92888ab0275a6f` for:

1. matcher and hermetic correctness
2. Go/TOML/`TESTING.md` ledger integrity
3. maintainability, behavior neutrality, and bounded performance

Tracking bead: `ga-80po0c.2.2.3`
