### PR TITLE
Write stale markers for dirty agent-home worktrees

### DIFF
--- a/cmd/gc/session_worktree_prune.go
+++ b/cmd/gc/session_worktree_prune.go
@@ -20,6 +20,7 @@ import (
 // without standing up real git worktrees.
 type gitProbe interface {
 	IsRepo() bool
+	CurrentBranch() (string, error)
 	HasUncommittedWork() bool
 	HasUnpushedCommitsResult() (bool, error)
 	HasStashesResult() (bool, error)
@@ -29,6 +30,21 @@ type gitProbe interface {
 // newGitProbe returns a gitProbe scoped to the given directory. Indirected
 // through a package-level var so tests can stub the git invocations.
 var newGitProbe = func(workDir string) gitProbe { return git.New(workDir) }
+
+// writeWorktreeStaleMarker records why workerDir was left in place instead of
+// pruned, so cleanupClosedBeadAgentHomeWorktrees (agent_home_worktree_cleanup.go)
+// can later detect when it's safe to reclaim. Best-effort: write failures are
+// logged but never alter the caller's control flow.
+func writeWorktreeStaleMarker(gp gitProbe, workerDir, reason string, stderr io.Writer) {
+	branch, err := gp.CurrentBranch()
+	if err != nil {
+		branch = ""
+	}
+	content := fmt.Sprintf("branch=%s\nreason=%s\n", branch, reason)
+	if err := os.WriteFile(filepath.Join(workerDir, worktreeStaleFileName), []byte(content), 0o644); err != nil {
+		fmt.Fprintf(stderr, "session reconciler: writing %s marker for %s: %v\n", worktreeStaleFileName, workerDir, err) //nolint:errcheck
+	}
+}
 
 // pruneAgentHomeWorktreeIfSafe removes the worktree at the closed session's
 // worker_dir, after applying the same safety gates as doctor's
@@ -80,6 +96,7 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	}
 	if gp.HasUncommittedWork() {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has uncommitted changes\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "uncommitted-work", stderr)
 		return false
 	}
 	hasUnpushed, err := gp.HasUnpushedCommitsResult()
@@ -89,6 +106,7 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	}
 	if hasUnpushed {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has unpushed commits\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "unpushed-commits", stderr)
 		return false
 	}
 	hasStashes, err := gp.HasStashesResult()
@@ -98,6 +116,7 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	}
 	if hasStashes {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has stashed work\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "stashed-work", stderr)
 		return false
 	}
 
@@ -152,6 +171,7 @@ func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg
 	}
 	if gp.HasUncommittedWork() {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has uncommitted changes\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "uncommitted-work", stderr)
 		return
 	}
 	hasUnpushed, err := gp.HasUnpushedCommitsResult()
@@ -161,6 +181,7 @@ func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg
 	}
 	if hasUnpushed {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has unpushed commits\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "unpushed-commits", stderr)
 		return
 	}
 	hasStashes, err := gp.HasStashesResult()
@@ -170,6 +191,7 @@ func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg
 	}
 	if hasStashes {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has stashed work\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "stashed-work", stderr)
 		return
 	}
 

--- a/cmd/gc/session_worktree_prune_info_test.go
+++ b/cmd/gc/session_worktree_prune_info_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// sessionInfo returns a session.Info mirroring fx.sessionBead(), for
+// exercising the session.Info form of the worker_dir auto-prune path
+// (pruneAgentHomeWorktreeIfSafeInfo) against the same fixture.
+func (fx *pruneTestFixture) sessionInfo() sessionpkg.Info {
+	return sessionpkg.Info{
+		ID:                  "session-1",
+		WorkerDir:           fx.workerDir,
+		Template:            "demo/polecat",
+		SessionNameMetadata: "demo/polecat-3",
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_DisabledByConfig(t *testing.T) {
+	fx := newPruneFixture(t)
+	off := false
+	fx.cfg.Daemon.AutoPruneWorkerDir = &off
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called while config disabled prune")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_NoWorkerDir(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	info.WorkerDir = ""
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called with no worker_dir")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_LegacyWorkDirKey(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	info.WorkerDir = ""
+	info.WorkDir = fx.workerDir
+
+	probe := &fakeGitProbe{isRepo: true}
+	fx.setProbe(fx.workerDir, probe)
+	rigProbe := &fakeGitProbe{isRepo: true}
+	fx.setProbe(fx.rigRoot, rigProbe)
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if !rigProbe.removeInvoked || rigProbe.removedPath != fx.workerDir || !rigProbe.removedForce {
+		t.Fatalf("expected WorktreeRemove(%q, true) on rig root; got invoked=%v path=%q force=%v",
+			fx.workerDir, rigProbe.removeInvoked, rigProbe.removedPath, rigProbe.removedForce)
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_OutsideWorktreesTree(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	outside := filepath.Join(fx.cityPath, "elsewhere", "polecat-3")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, ".git"), []byte("gitdir: /fake\n"), 0o644); err != nil {
+		t.Fatalf("write .git: %v", err)
+	}
+	info.WorkerDir = outside
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called for path outside .gc/worktrees")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RejectsWorktreesRoot(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	wtRoot := filepath.Join(fx.cityPath, ".gc", "worktrees")
+	if err := os.WriteFile(filepath.Join(wtRoot, ".git"), []byte("gitdir: /fake\n"), 0o644); err != nil {
+		t.Fatalf("write .git on wtRoot: %v", err)
+	}
+	info.WorkerDir = wtRoot
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called for .gc/worktrees root itself")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RelativeWorkerDir(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	info.WorkerDir = "relative/path"
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called for relative worker_dir")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_MissingDotGit(t *testing.T) {
+	fx := newPruneFixture(t)
+	if err := os.Remove(filepath.Join(fx.workerDir, ".git")); err != nil {
+		t.Fatalf("remove .git: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called with missing .git pointer")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_NotARepo(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: false})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HasUncommitted(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUncommitted: true, currentBranch: "builder/ga-abc123"})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "uncommitted changes") {
+		t.Errorf("expected uncommitted-reason log; got %q", stderr.String())
+	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-abc123", "uncommitted-work")
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HasUnpushed(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUnpushed: true, currentBranch: "builder/ga-def456"})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "unpushed commits") {
+		t.Errorf("expected unpushed-reason log; got %q", stderr.String())
+	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-def456", "unpushed-commits")
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_UnpushedProbeError(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, unpushedErr: errors.New("boom")})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "unpushed probe failed") {
+		t.Errorf("expected unpushed-error log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HasStashes(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasStashes: true, currentBranch: "builder/ga-ghi789"})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "stashed work") {
+		t.Errorf("expected stashes-reason log; got %q", stderr.String())
+	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-ghi789", "stashed-work")
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_StashProbeError(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, stashesErr: errors.New("boom")})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "stash probe failed") {
+		t.Errorf("expected stash-error log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RigPathUnresolved(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.cfg.Rigs = nil
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "rig path unresolved") {
+		t.Errorf("expected rig-unresolved log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RemoveFails(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true})
+	fx.setProbe(fx.rigRoot, &fakeGitProbe{
+		isRepo:         true,
+		worktreeRemove: func(_ string, _ bool) error { return errors.New("locked") },
+	})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "pruning worker_dir") || !strings.Contains(stderr.String(), "locked") {
+		t.Errorf("expected removal-error log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HappyPath(t *testing.T) {
+	fx := newPruneFixture(t)
+	wdProbe := &fakeGitProbe{isRepo: true}
+	rigProbe := &fakeGitProbe{isRepo: true}
+	fx.setProbe(fx.workerDir, wdProbe)
+	fx.setProbe(fx.rigRoot, rigProbe)
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if wdProbe.removeInvoked {
+		t.Error("WorktreeRemove invoked on worker_dir; should be invoked on rig root only")
+	}
+	if !rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove not invoked on rig root")
+	}
+	if rigProbe.removedPath != fx.workerDir {
+		t.Errorf("WorktreeRemove path = %q, want %q", rigProbe.removedPath, fx.workerDir)
+	}
+	if !rigProbe.removedForce {
+		t.Error("WorktreeRemove force flag = false, want true")
+	}
+	if !strings.Contains(stderr.String(), "pruned worker_dir") {
+		t.Errorf("expected success log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_NilConfig(t *testing.T) {
+	fx := newPruneFixture(t)
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, nil, &stderr)
+}
+
+func TestLookupRigRootForSessionInfo(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "demo", Path: "/x/demo"},
+			{Name: "other", Path: "/x/other"},
+		},
+	}
+	cases := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{"qualified match", "demo/polecat", "/x/demo"},
+		{"other rig", "other/refinery", "/x/other"},
+		{"unqualified", "polecat", ""},
+		{"unknown rig", "missing/polecat", ""},
+		{"empty", "", ""},
+		{"leading slash", "/polecat", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info := sessionpkg.Info{Template: c.template}
+			got := lookupRigRootForSessionInfo(info, cfg)
+			if got != c.want {
+				t.Errorf("lookupRigRootForSessionInfo(%q) = %q, want %q", c.template, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_worktree_prune_test.go
+++ b/cmd/gc/session_worktree_prune_test.go
@@ -17,19 +17,24 @@ import (
 // records the (path, force) of every WorktreeRemove invocation so tests
 // can assert which directory the removal targeted.
 type fakeGitProbe struct {
-	isRepo         bool
-	hasUncommitted bool
-	hasUnpushed    bool
-	unpushedErr    error
-	hasStashes     bool
-	stashesErr     error
-	worktreeRemove func(path string, force bool) error
-	removedPath    string
-	removedForce   bool
-	removeInvoked  bool
+	isRepo           bool
+	currentBranch    string
+	currentBranchErr error
+	hasUncommitted   bool
+	hasUnpushed      bool
+	unpushedErr      error
+	hasStashes       bool
+	stashesErr       error
+	worktreeRemove   func(path string, force bool) error
+	removedPath      string
+	removedForce     bool
+	removeInvoked    bool
 }
 
-func (f *fakeGitProbe) IsRepo() bool             { return f.isRepo }
+func (f *fakeGitProbe) IsRepo() bool { return f.isRepo }
+func (f *fakeGitProbe) CurrentBranch() (string, error) {
+	return f.currentBranch, f.currentBranchErr
+}
 func (f *fakeGitProbe) HasUncommittedWork() bool { return f.hasUncommitted }
 func (f *fakeGitProbe) HasUnpushedCommitsResult() (bool, error) {
 	return f.hasUnpushed, f.unpushedErr
@@ -43,6 +48,35 @@ func (f *fakeGitProbe) WorktreeRemove(path string, force bool) error {
 		return f.worktreeRemove(path, force)
 	}
 	return nil
+}
+
+// assertWorktreeStaleMarker fails the test unless workerDir contains a
+// .worktree-stale marker recording the given branch and reason. Shared by
+// both the raw and session.Info test forms.
+func assertWorktreeStaleMarker(t *testing.T, workerDir, wantBranch, wantReason string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(workerDir, worktreeStaleFileName))
+	if err != nil {
+		t.Fatalf("reading %s marker: %v", worktreeStaleFileName, err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "branch="+wantBranch) {
+		t.Errorf("marker content = %q, want to contain %q", content, "branch="+wantBranch)
+	}
+	if !strings.Contains(content, "reason="+wantReason) {
+		t.Errorf("marker content = %q, want to contain %q", content, "reason="+wantReason)
+	}
+}
+
+// assertNoWorktreeStaleMarker fails the test if workerDir contains a
+// .worktree-stale marker.
+func assertNoWorktreeStaleMarker(t *testing.T, workerDir string) {
+	t.Helper()
+	if _, err := os.ReadFile(filepath.Join(workerDir, worktreeStaleFileName)); err == nil {
+		t.Errorf("%s marker unexpectedly present in %s", worktreeStaleFileName, workerDir)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("checking %s marker: %v", worktreeStaleFileName, err)
+	}
 }
 
 // pruneTestFixture wires a temp city directory, a writable worker_dir
@@ -166,6 +200,7 @@ func TestPruneAgentHomeWorktreeIfSafe_LegacyWorkDirKey(t *testing.T) {
 		t.Fatalf("expected WorktreeRemove(%q, true) on rig root; got invoked=%v path=%q force=%v",
 			fx.workerDir, rigProbe.removeInvoked, rigProbe.removedPath, rigProbe.removedForce)
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_OutsideWorktreesTree(t *testing.T) {
@@ -232,11 +267,12 @@ func TestPruneAgentHomeWorktreeIfSafe_NotARepo(t *testing.T) {
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
 		t.Fatal("prune returned true when IsRepo=false")
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HasUncommitted(t *testing.T) {
 	fx := newPruneFixture(t)
-	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUncommitted: true})
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUncommitted: true, currentBranch: "builder/ga-abc123"})
 
 	var stderr bytes.Buffer
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
@@ -245,11 +281,12 @@ func TestPruneAgentHomeWorktreeIfSafe_HasUncommitted(t *testing.T) {
 	if !strings.Contains(stderr.String(), "uncommitted changes") {
 		t.Errorf("expected uncommitted-reason log; got %q", stderr.String())
 	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-abc123", "uncommitted-work")
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HasUnpushed(t *testing.T) {
 	fx := newPruneFixture(t)
-	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUnpushed: true})
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUnpushed: true, currentBranch: "builder/ga-def456"})
 
 	var stderr bytes.Buffer
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
@@ -258,6 +295,7 @@ func TestPruneAgentHomeWorktreeIfSafe_HasUnpushed(t *testing.T) {
 	if !strings.Contains(stderr.String(), "unpushed commits") {
 		t.Errorf("expected unpushed-reason log; got %q", stderr.String())
 	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-def456", "unpushed-commits")
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_UnpushedProbeError(t *testing.T) {
@@ -271,11 +309,12 @@ func TestPruneAgentHomeWorktreeIfSafe_UnpushedProbeError(t *testing.T) {
 	if !strings.Contains(stderr.String(), "unpushed probe failed") {
 		t.Errorf("expected unpushed-error log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HasStashes(t *testing.T) {
 	fx := newPruneFixture(t)
-	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasStashes: true})
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasStashes: true, currentBranch: "builder/ga-ghi789"})
 
 	var stderr bytes.Buffer
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
@@ -284,6 +323,7 @@ func TestPruneAgentHomeWorktreeIfSafe_HasStashes(t *testing.T) {
 	if !strings.Contains(stderr.String(), "stashed work") {
 		t.Errorf("expected stashes-reason log; got %q", stderr.String())
 	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-ghi789", "stashed-work")
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_StashProbeError(t *testing.T) {
@@ -297,6 +337,7 @@ func TestPruneAgentHomeWorktreeIfSafe_StashProbeError(t *testing.T) {
 	if !strings.Contains(stderr.String(), "stash probe failed") {
 		t.Errorf("expected stash-error log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_RigPathUnresolved(t *testing.T) {
@@ -311,6 +352,7 @@ func TestPruneAgentHomeWorktreeIfSafe_RigPathUnresolved(t *testing.T) {
 	if !strings.Contains(stderr.String(), "rig path unresolved") {
 		t.Errorf("expected rig-unresolved log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_RigPathEmpty(t *testing.T) {
@@ -325,6 +367,7 @@ func TestPruneAgentHomeWorktreeIfSafe_RigPathEmpty(t *testing.T) {
 	if !strings.Contains(stderr.String(), "rig path unresolved") {
 		t.Errorf("expected rig-unresolved log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_RemoveFails(t *testing.T) {
@@ -342,6 +385,7 @@ func TestPruneAgentHomeWorktreeIfSafe_RemoveFails(t *testing.T) {
 	if !strings.Contains(stderr.String(), "pruning worker_dir") || !strings.Contains(stderr.String(), "locked") {
 		t.Errorf("expected removal-error log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HappyPath(t *testing.T) {
@@ -370,6 +414,7 @@ func TestPruneAgentHomeWorktreeIfSafe_HappyPath(t *testing.T) {
 	if !strings.Contains(stderr.String(), "pruned worker_dir") {
 		t.Errorf("expected success log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_NilConfig(t *testing.T) {

--- a/release-gates/ga-7qdxe4-worktree-stale-marker-producer-gate.md
+++ b/release-gates/ga-7qdxe4-worktree-stale-marker-producer-gate.md
@@ -1,0 +1,26 @@
+# Release Gate: ga-7qdxe4 worktree-stale marker producer
+
+- Bead: `ga-7qdxe4`
+- Source bead: `ga-vzt5pq.3`
+- Deploy branch: `deploy/ga-7qdxe4-gate`
+- Reviewed deploy SHA: `5538000b7b60d30ee25adf2302d5987edb5a8d45`
+- Base checked: `origin/main` at `bac288647e0bbbbe2e68bdbe588709eb2827f5ee`
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git merge-base origin/main 5538000b7b60d30ee25adf2302d5987edb5a8d45` returned `bac288647e0bbbbe2e68bdbe588709eb2827f5ee` and `git merge-tree --write-tree origin/main 5538000b7b60d30ee25adf2302d5987edb5a8d45` exited 0. |
+| 1 | Review PASS present | PASS | `bd show ga-vzt5pq.3` records `REVIEW VERDICT: PASS`; `bd show ga-7qdxe4` describes the reviewed branch as PASSED and routed for deploy. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `cmd/gc/session_worktree_prune.go`, `cmd/gc/session_worktree_prune_test.go`, and `cmd/gc/session_worktree_prune_info_test.go`. `gitProbe` now exposes `CurrentBranch`; both raw and Info prune paths write `.worktree-stale` with `uncommitted-work`, `unpushed-commits`, or `stashed-work` only after confirmed dirty probes; marker writes are best-effort and do not alter control flow. Focused tests cover marker presence and absence across dirty, no-op, probe-error, and happy paths. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestPruneAgentHomeWorktreeIfSafe\|WorktreeStale\|CurrentBranch' -v` passed in this deploy worktree. `go vet ./...` passed. `make test-fast-parallel` passed all 8 fast jobs from a clean non-nested `/var/tmp` worktree at the deploy SHA. The same fast command in the nested deployer worktree first failed only on `TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior/default`; that targeted failure reproduced on `origin/main` in the same nested worktree and passed in the clean `/var/tmp` worktree, matching the known current-worktree artifact documented on the bead. |
+| 4 | No high-severity review findings open | PASS | Review notes report OWASP no findings. The only review observation is explicitly minor/non-blocking: `CurrentBranch()` errors produce `branch=""` in the advisory marker while the consumer revalidates branch state before acting. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` on `deploy/ga-7qdxe4-gate` showed only `## deploy/ga-7qdxe4-gate`. This gate file is the only deployer-authored change and is committed on top of the reviewed deploy SHA. |
+| 7 | Single feature theme | PASS | Commit range `origin/main..5538000b7b60d30ee25adf2302d5987edb5a8d45` contains the red/green pair for one subsystem: agent-home worktree prune stale-marker production and its symmetric tests. |
+
+## Commit Range
+
+| Commit | Purpose |
+|--------|---------|
+| `926d429ed044218457223cbe10d738122e4bfe8f` | Red tests for `.worktree-stale` marker production on dirty prune skips. |
+| `5538000b7b60d30ee25adf2302d5987edb5a8d45` | Implementation: write best-effort stale markers from raw and Info prune paths. |


### PR DESCRIPTION
## What this changes

When the session reconciler decides not to prune an agent-home worktree because it still has uncommitted work, unpushed commits, or stashed work, it now writes a `.worktree-stale` marker explaining why the worktree was left in place. The existing cleanup consumer can then recognize these intentionally retained worktrees later instead of treating the marker path as orphaned plumbing.

The marker is advisory and best-effort. Cleanup still rechecks the real Git state before removing anything, so a failed marker write does not change the safety behavior and does not block the reconciler.

## Review notes

- Review `cmd/gc/session_worktree_prune.go` for the marker write path and the three dirty-worktree reasons.
- Review the symmetric prune tests for marker presence, marker absence, probe-error behavior, and the happy prune path.
- No config, API, storage schema, or default cleanup policy changes are introduced.

## Test plan

- [x] `go test ./cmd/gc -run 'TestPruneAgentHomeWorktreeIfSafe|WorktreeStale|CurrentBranch' -v`
- [x] `go vet ./...`
- [x] `make test-fast-parallel` from a clean `/var/tmp` worktree
- [x] Release gate: [`release-gates/ga-7qdxe4-worktree-stale-marker-producer-gate.md`](release-gates/ga-7qdxe4-worktree-stale-marker-producer-gate.md)