### PR TITLE
Stamp workflow work_dir release hint on pass

### DIFF
--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -196,6 +196,7 @@ const (
 	WorkBranchMetadataKey          = "gc.work_branch"
 	WorkCommitMetadataKey          = "gc.work_commit"
 	WorkDirMetadataKey             = "gc.work_dir"
+	WorkDirReleasedAtMetadataKey   = "gc.work_dir_released_at"
 	WorkOutcomeMetadataKey         = "gc.work_outcome"
 	WorkVerificationMetadataKey    = "gc.work_verification"
 	WorkflowIDMetadataKey          = "gc.workflow_id"
@@ -222,6 +223,12 @@ const (
 //
 // The set of valid WorkOutcomeMetadataKey values and the "shipped requires a
 // commit on the branch" rule live with the close gate in cmd/gc.
+
+// WorkDirReleasedAtMetadataKey ("gc.work_dir_released_at") is a best-effort
+// RFC3339 timestamp stamped onto a workflow root by workflow-finalize when the
+// workflow's outcome is Pass and the root carries WorkDirMetadataKey. It is a
+// voluntary end-of-use hint for the borrow-veto reaper scan, never
+// authoritative on its own — a write failure here must not abort finalize.
 
 // FormulaVarPrefix is the dynamic key prefix under which formula-supplied
 // variables are written as gc.var.<name>. The suffix is open-world (a
@@ -433,6 +440,7 @@ var KnownMetadataKeys = []string{
 	WorkBranchMetadataKey,
 	WorkCommitMetadataKey,
 	WorkDirMetadataKey,
+	WorkDirReleasedAtMetadataKey,
 	WorkOutcomeMetadataKey,
 	WorkVerificationMetadataKey,
 	WorkflowIDMetadataKey,

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -841,6 +841,9 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 		}
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow head: %w", rootID, err))
 	}
+	if outcome == beadmeta.OutcomePass {
+		stampWorkDirReleasedAt(store, rootID, opts)
+	}
 	if _, err := sourceworkflow.CloseSpecSidecarsForRoot(store, rootID, sourceworkflow.WorkflowSpecSidecarClosedReason); err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing workflow spec sidecars: %w", rootID, err))
 	}
@@ -1509,6 +1512,26 @@ func findScopeBody(all []beads.Bead, rootID, scopeRef string) (beads.Bead, bool)
 
 func setOutcomeAndClose(store beads.Store, beadID, outcome string) error {
 	return updateMetadataAndClose(store, beadID, map[string]string{beadmeta.OutcomeMetadataKey: outcome})
+}
+
+// stampWorkDirReleasedAt best-effort-marks a workflow root's work directory as
+// voluntarily released once its workflow finalizes with a Pass outcome. This
+// is a non-authoritative optimization hint only — the borrow-veto reaper scan
+// remains the authoritative check before any worktree is reclaimed — so a
+// read or write failure here is traced and swallowed rather than propagated;
+// it must never abort finalize.
+func stampWorkDirReleasedAt(store beads.Store, rootID string, opts ProcessOptions) {
+	root, err := store.Get(rootID)
+	if err != nil {
+		opts.tracef("workflow-finalize root=%s work-dir-released-at-get-err=%v", rootID, err)
+		return
+	}
+	if strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) == "" {
+		return
+	}
+	if err := store.SetMetadata(rootID, beadmeta.WorkDirReleasedAtMetadataKey, time.Now().Format(time.RFC3339)); err != nil {
+		opts.tracef("workflow-finalize root=%s work-dir-released-at-set-err=%v", rootID, err)
+	}
 }
 
 // ReconcileClosedScopeMember re-reads a just-closed bead and delegates to

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -9846,6 +9847,212 @@ func TestProcessWorkflowFinalize_PurgeOnMissingDir(t *testing.T) {
 	}
 	if !result.Processed {
 		t.Fatalf("result = %+v, want processed", result)
+	}
+}
+
+// TestProcessWorkflowFinalizeStampsWorkDirReleasedAtOnPass verifies FR-6
+// (ga-vzt5pq.2): on a Pass outcome, processWorkflowFinalize best-effort
+// stamps gc.work_dir_released_at (RFC3339) onto the workflow root bead that
+// carries gc.work_dir, signaling voluntary end-of-use for the (separately
+// owned) borrow-veto reaper scan to later consult as an optimization.
+func TestProcessWorkflowFinalizeStampsWorkDirReleasedAtOnPass(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.work_dir":         "/home/jaword/projects/gascity/worktrees/demo",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	stamp := rootAfter.Metadata["gc.work_dir_released_at"]
+	if stamp == "" {
+		t.Fatalf("gc.work_dir_released_at not stamped on root bead; metadata = %+v", rootAfter.Metadata)
+	}
+	released, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		t.Fatalf("gc.work_dir_released_at = %q is not a valid RFC3339 timestamp: %v", stamp, err)
+	}
+	if age := time.Since(released); age < -2*time.Second || age > time.Minute {
+		t.Fatalf("gc.work_dir_released_at = %v is not a fresh timestamp (age = %v)", released, age)
+	}
+}
+
+// TestProcessWorkflowFinalizeDoesNotStampWorkDirReleasedAtOnFailure verifies
+// the FR-6 release hint is Pass-only: a workflow that finalizes with
+// outcome=fail must not stamp gc.work_dir_released_at, since a failed
+// workflow's worktree is not being voluntarily released -- a human or a
+// retry may still need it.
+func TestProcessWorkflowFinalizeDoesNotStampWorkDirReleasedAtOnFailure(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.work_dir":         "/home/jaword/projects/gascity/worktrees/demo",
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "cleanup",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "fail",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("result = %+v, want processed workflow-fail", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if stamp, ok := rootAfter.Metadata["gc.work_dir_released_at"]; ok {
+		t.Fatalf("gc.work_dir_released_at = %q, want unset on a failed workflow", stamp)
+	}
+}
+
+// TestProcessWorkflowFinalizeSkipsWorkDirReleasedAtWhenNoWorkDir verifies
+// the FR-6 release hint is a no-op when the root bead carries no gc.work_dir:
+// there is nothing to release, so finalize must not invent a stamp (and must
+// not error).
+func TestProcessWorkflowFinalizeSkipsWorkDirReleasedAtWhenNoWorkDir(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if stamp, ok := rootAfter.Metadata["gc.work_dir_released_at"]; ok {
+		t.Fatalf("gc.work_dir_released_at = %q, want unset when root has no gc.work_dir", stamp)
+	}
+}
+
+// failWorkDirReleaseStore injects a metadata-write failure whenever the
+// FR-6 release-hint key is written, whether via a single SetMetadata call or
+// batched through SetMetadataBatch. It lets tests prove the stamp is
+// genuinely best-effort per its exit contract: never authoritative, so its
+// own failure must not propagate.
+type failWorkDirReleaseStore struct {
+	beads.Store
+}
+
+func (s *failWorkDirReleaseStore) SetMetadata(id, key, value string) error {
+	if key == "gc.work_dir_released_at" {
+		return errors.New("injected work_dir_released_at metadata failure")
+	}
+	return s.Store.SetMetadata(id, key, value)
+}
+
+func (s *failWorkDirReleaseStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if _, ok := kvs["gc.work_dir_released_at"]; ok {
+		return errors.New("injected work_dir_released_at metadata batch failure")
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+// TestProcessWorkflowFinalizeWorkDirReleaseStampFailureDoesNotAbortFinalize
+// verifies the FR-6 stamp is best-effort per its exit contract: a failure
+// writing gc.work_dir_released_at must not fail or abort the finalize step
+// itself -- the hint is an optimization, never authoritative (the borrow-veto
+// scan in the sibling FR-1/FR-2 bead remains the sole authoritative gate).
+func TestProcessWorkflowFinalizeWorkDirReleaseStampFailureDoesNotAbortFinalize(t *testing.T) {
+	t.Parallel()
+
+	store := &failWorkDirReleaseStore{Store: beads.NewMemStore()}
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.work_dir":         "/home/jaword/projects/gascity/worktrees/demo",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v, want finalize to succeed despite injected release-hint failure", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if rootAfter.Status != "closed" {
+		t.Fatalf("workflow status = %q, want closed despite injected release-hint failure", rootAfter.Status)
 	}
 }
 

--- a/release-gates/ga-gcdmcv-work-dir-release-hint-gate.md
+++ b/release-gates/ga-gcdmcv-work-dir-release-hint-gate.md
@@ -1,0 +1,49 @@
+# Release Gate: workflow-finalize work_dir release hint
+
+Bead: `ga-gcdmcv`
+Implementation bead: `ga-vzt5pq.2`
+Provenance branch: `builder/ga-vzt5pq.2`
+Reviewed commit: `fe0d831ce9df79bc811fd117cd0815b04b72e2c0`
+Base: `origin/main` at `bac288647e0bbbbe2e68bdbe588709eb2827f5ee`
+
+The prompted `docs/PROJECT_MANIFEST.md` path is not present in this Gas City
+checkout. No `PROJECT_MANIFEST.md` or `SOFTWARE_FACTORY_MANIFEST.md` was found
+within the repository, so this gate uses the deployer release criteria from
+the role prompt and the repository testing guidance in `TESTING.md`.
+
+## Diff Scope
+
+`git diff --name-status origin/main...fe0d831ce9df79bc811fd117cd0815b04b72e2c0`:
+
+```text
+M	internal/beadmeta/keys.go
+M	internal/dispatch/runtime.go
+M	internal/dispatch/runtime_test.go
+```
+
+This is one release unit: workflow finalization now writes a best-effort
+`gc.work_dir_released_at` RFC3339 timestamp only when a workflow finalizes
+with a Pass outcome and the workflow root carries `gc.work_dir`.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-vzt5pq.2` records `REVIEWER VERDICT: PASS`; `bd show ga-gcdmcv` is the deploy bead created from that reviewer PASS and records the reviewed commit `fe0d831ce9df79bc811fd117cd0815b04b72e2c0`. |
+| 2 | Acceptance criteria met | PASS | The implementation adds `beadmeta.WorkDirReleasedAtMetadataKey`, registers it in `KnownMetadataKeys`, calls `stampWorkDirReleasedAt` only when `processWorkflowFinalize` computes `beadmeta.OutcomePass`, skips roots without `gc.work_dir`, and traces/swallow read or write failures so the optional hint cannot abort workflow finalization. Tests cover Pass stamping, failure-outcome non-stamping, missing-work-dir no-op, and injected metadata-write failure. |
+| 3 | Tests pass | PASS | Focused acceptance passed: `go test ./internal/dispatch/... ./internal/beadmeta/... -count=1 -timeout=10m`. Static checks passed: `go vet ./...` and `git diff --check origin/main...HEAD`. `make test-fast-parallel` passed 7 of 8 fast jobs; `unit-cmd-gc-3-of-6` failed only `TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior/default`. The exact failing test failed deterministically on this branch and reproduced identically on `origin/main` at `bac288647e0bbbbe2e68bdbe588709eb2827f5ee`; this diff touches no `cmd/gc` files, so the fast-suite red is a pre-existing baseline failure, not a branch regression. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for `ga-vzt5pq.2` report OWASP/security walk with no findings and no HIGH/blocker findings. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --porcelain=v1 -b` on `deploy/ga-gcdmcv-gate` returned only `## deploy/ga-gcdmcv-gate`; after the gate commit, cleanliness is rechecked before push. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git merge-tree --write-tree origin/main fe0d831ce9df79bc811fd117cd0815b04b72e2c0` exited 0 and produced tree `4c81294555f69b0524fe5265cb5c4389bc8b90a0`; no bounded self-rebase was required. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and behavior: optional workflow-finalize metadata used as a non-authoritative worktree release hint. The changes are limited to dispatch runtime behavior, metadata-key registration, and directly owning tests. |
+
+## Branch Isolation Note
+
+The deploy source is the bead-recorded reviewed commit, not the provenance
+branch tip. The prompt-advertised `resolve_deploy_branch_target` and
+`assert_safe_push_target` functions are not present in the current
+`scripts/rebase-resolve-lib.sh`; the isolated branch was therefore set
+mechanically to `deploy/ga-gcdmcv-gate` at the reviewed SHA and guarded against
+shared `gc-*` worktree branch naming before push.
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

When a formulas v2 workflow finalizes successfully, the control dispatcher now best-effort stamps `gc.work_dir_released_at` on the workflow root bead when that root already carries `gc.work_dir`. The timestamp is an RFC3339 hint that downstream worktree cleanup can consult as a voluntary end-of-use signal.

Failed workflows and workflow roots without `gc.work_dir` are unchanged. The hint is intentionally non-authoritative; the borrow-veto cleanup scan remains the safety gate before any worktree is reclaimed.

## Review notes

- Metadata-only change: adds `gc.work_dir_released_at` to the canonical metadata-key list.
- The stamp write is best-effort: read/write failures are traced and do not abort `workflow-finalize`.
- No API, dashboard, schema, command, or reaper behavior changes are included here.

## Test plan

- [x] `go test ./internal/dispatch/... ./internal/beadmeta/... -count=1 -timeout=10m`
- [x] `go vet ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] `make test-fast-parallel` showed no branch regression: 7/8 fast jobs passed; the only red test, `TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior/default`, reproduced identically on `origin/main`.
- [x] Release gate: [`release-gates/ga-gcdmcv-work-dir-release-hint-gate.md`](release-gates/ga-gcdmcv-work-dir-release-hint-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4492 — adds a best-effort, voluntary end-of-use hint (gc.work_dir_released_at) stamped on passing workflow finalize, one small piece of that issue's "end-of-use is explicit" direction; it does not implement the borrow-veto reaper scan, the worktree-creation-root convergence, or the reaper defect fixes, which remain open

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->