### PR TITLE
Fix push guard parsing for nested bead IDs

### DIFF
--- a/release-gates/push-ownership-guard-multi-level-bead-id-gate.md
+++ b/release-gates/push-ownership-guard-multi-level-bead-id-gate.md
@@ -1,0 +1,38 @@
+# Release Gate: push-ownership-guard multi-level bead ID
+
+Status: PASS
+
+Source bead: ga-nnjcuc.2
+Deploy bead: ga-jzrl1m
+Branch: deploy/ga-jzrl1m-gate
+Reviewed commit: 7af0671436ba10f2e0f275e3ef627393806651ef
+Reviewed commits: d877d93e5643f829dcd584b2de0f7cfba661e223, 7af0671436ba10f2e0f275e3ef627393806651ef
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses
+the deployer role's release criteria table plus the repo testing policy in
+`TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-nnjcuc.2` contains `REVIEWER VERDICT: PASS` for branch `builder/ga-nnjcuc.2` at commit `7af0671436ba10f2e0f275e3ef627393806651ef`. |
+| 2 | Acceptance criteria met | PASS | Candidate confirms the fix was not already on `origin/main`: `origin/main:scripts/push-ownership-guard.sh` still uses `ga-[0-9a-z]{6}(\.[0-9]+)?`, while this branch uses `ga-[0-9a-z]{6}(\.[0-9]+)*`. The branch changes only `scripts/push-ownership-guard.sh` and `scripts/test-push-ownership-guard.sh`, adds a regression for `ga-o3ko1j.4.3`, and excludes the unrelated dead-assignee fallback theme. |
+| 3 | Tests pass | PASS | `bash scripts/test-push-ownership-guard.sh` passed 20/20; `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh` passed; `go build ./...` passed; `go vet ./...` passed; after adding this gate file, `go test ./test/docsync/...` passed. A pre-push dry-run from this live city worktree failed `cmd/gc` shard 5 at `TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior/default` with ambient native-store schema mismatch; the same focused test passed in clean temporary worktrees for both `origin/main` and this deploy branch, so it is environment-specific to the live city worktree, not introduced by this shell-only diff. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report no security findings and no HIGH or CRITICAL findings. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` reported `## deploy/ga-jzrl1m-gate` with no file changes. The final branch is clean after committing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first: `git merge-tree --write-tree origin/main 7af0671436ba10f2e0f275e3ef627393806651ef` exited 0 and produced merged tree `949a286481ced522c123ee393cefacfac47ce674`. |
+| 7 | Single feature theme | PASS | `git diff --name-status origin/main..7af0671436ba10f2e0f275e3ef627393806651ef` lists only `scripts/push-ownership-guard.sh` and `scripts/test-push-ownership-guard.sh`; both commits are the regression test and fix for full multi-level dotted bead ID resolution. |
+
+## Acceptance Evidence
+
+- `_pog_resolve_bead_id` now extracts repeated dotted suffixes from branch names
+  with `ga-[0-9a-z]{6}(\.[0-9]+)*`, so `builder/ga-o3ko1j.4.3-*` resolves to
+  `ga-o3ko1j.4.3` instead of truncating to `ga-o3ko1j.4`.
+- `scripts/test-push-ownership-guard.sh` adds
+  `test_bead_id_branch_resolves_multi_level_subbead_id`, which forces the
+  branch resolver to expose the full grandchild bead ID in the branch-vs-fallback
+  warning and passes under the fixed regex.
+- The branch is a two-commit extraction from `origin/main`: red test
+  `d877d93e5643f829dcd584b2de0f7cfba661e223` followed by green fix
+  `7af0671436ba10f2e0f275e3ef627393806651ef`.

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -67,12 +67,17 @@ _pog_timeout() {
 
 # _pog_resolve_bead_id: prints the bead id this push should be checked
 # against; prints nothing if none can be resolved. Resolution order:
-#   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)? —
-#      the bead's own id format, extended with an optional sub-bead suffix
-#      because this repo's real branch convention is
-#      builder/<bead-id>-<slug> and sub-beads (e.g. ga-fip9ps.1) are
-#      routine; the literal 6-char-only pattern would misresolve to the
-#      parent bead on a sub-bead's own branch.
+#   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)* —
+#      the bead's own id format, extended with zero or more repeated
+#      sub-bead suffixes because this repo's real branch convention is
+#      builder/<bead-id>-<slug> and sub-beads are routine at any nesting
+#      depth: a single-level sub-bead (e.g. ga-fip9ps.1) as well as a
+#      grandchild (e.g. ga-o3ko1j.4.3). The suffix group must repeat (`*`),
+#      not just appear once (`?`) — a single optional group truncates a
+#      grandchild id after its first dotted segment, misresolving to the
+#      wrong (and possibly closed) parent/child bead instead of the actual
+#      grandchild bead the branch is for. The literal 6-char-only pattern
+#      would misresolve to the root bead on any sub-bead's own branch.
 #   2. Falls back to this session's single in-progress assignment
 #      (bd list --assignee="$GC_AGENT" --status=in_progress --json) when
 #      the branch name doesn't match.
@@ -107,7 +112,7 @@ _pog_resolve_bead_id() {
 
     local branch_id=""
     if [[ -n "$branch" ]]; then
-        branch_id="$(grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)?' <<<"$branch" | head -1 || true)"
+        branch_id="$(grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)*' <<<"$branch" | head -1 || true)"
     fi
 
     local assignee_id=""

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -344,6 +344,30 @@ test_bead_id_branch_wins_and_warns_on_disagreement() {
     rm -rf "$repo" "$fbd"
 }
 
+# Regression: a branch encoding a multi-level sub-bead id (a grandchild bead,
+# e.g. ga-o3ko1j.4.3) must resolve to the FULL id, not truncate after the
+# first dotted segment. Caught live: builder/ga-o3ko1j.4.3's push resolved to
+# ga-o3ko1j.4 (a different, already-closed parent bead), blocking a healthy
+# in-progress push as "stale". Forces the assignee-fallback to disagree so
+# the resolver's warning names the id it actually picked — the only
+# observable signal for resolution output (see the sibling
+# branch-wins-warns-on-disagreement test above for the same technique).
+test_bead_id_branch_resolves_multi_level_subbead_id() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-o3ko1j.4.3-dead-assignee-fallback")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    printf '[{"id":"ga-other01.9"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-o3ko1j.4.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]] && grep -q "ga-o3ko1j.4.3" <<<"$out"; then
+        record_pass "resolve/branch-resolves-full-multi-level-subbead-id (rc=0, full id ga-o3ko1j.4.3 named, not truncated to ga-o3ko1j.4)"
+    else
+        record_fail "resolve/branch-resolves-full-multi-level-subbead-id" "expected rc=0 with full id ga-o3ko1j.4.3 in the resolver's warning, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
 test_bead_id_fallback_used_when_branch_no_match() {
     local repo fbd out rc
     repo="$(new_repo_with_branch "chore/unrelated-cleanup")"
@@ -543,6 +567,7 @@ run_all() {
     test_block_on_bd_unreachable
     test_block_on_bd_timeout
     test_bead_id_branch_wins_and_warns_on_disagreement
+    test_bead_id_branch_resolves_multi_level_subbead_id
     test_bead_id_fallback_used_when_branch_no_match
     test_allow_when_no_bead_id_resolvable
     test_fallback_cannot_detect_staleness_after_status_leaves_in_progress


### PR DESCRIPTION
## What this changes

The pre-push ownership guard now resolves branch names with nested dotted bead IDs as the full bead ID instead of stopping after the first dotted suffix. That prevents a healthy push from being blocked as stale when a branch belongs to a deeper sub-bead.

The change is intentionally narrow: it only updates the branch-ID extraction regex and adds a shell regression test that exercises the nested dotted branch-name case.

## Review notes

- Shell-only change under `scripts/`; no `cmd/gc` runtime code changes.
- The regex now repeats the dotted numeric suffix group, so single-level and deeper sub-bead IDs follow the same path.
- The live deploy worktree's pre-push fast suite hits an ambient `cmd/gc` provider-factory failure tied to local city schema state; the gate file documents clean-worktree comparison checks and the manual ownership-guard verification used before push.

## Test plan

- [x] `bash scripts/test-push-ownership-guard.sh`
- [x] `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./test/docsync/...`
- [x] Release gate: [`release-gates/push-ownership-guard-multi-level-bead-id-gate.md`](release-gates/push-ownership-guard-multi-level-bead-id-gate.md)
