### PR TITLE
Create step-dispatch workdir before session spawn

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 	"runtime/debug"
 	"sort"
@@ -981,6 +982,30 @@ func buildPreparedStartWithWorkDirResolver(
 	// those already-rendered strings so scaffold staging lands next to the
 	// session it actually launches into, not the directory templating assumed.
 	agentCfg.PreStart = retargetPreStartWorkDir(agentCfg.PreStart, preOverrideWorkDir, agentCfg.WorkDir)
+	// Step-dispatch (named/direct, non-pool-managed) spawns must not silently
+	// launch into a fallback directory when the resolved per-step workdir does
+	// not exist: effectiveWorkDir (herdr) and the tmux GC_DIR fallback read
+	// both redirect to city root when cfg.WorkDir is missing, bleeding an
+	// unrelated session's cwd/context into this one (ga-zogqc1.1). Create it
+	// here, or fail the spawn loudly, instead of letting that fallback fire
+	// silently downstream. MkdirAll no-ops if the directory already exists and
+	// fails if the path is occupied by a non-directory, so this covers both
+	// the "missing" and "wrong type" cases in one call.
+	//
+	// Pool-managed candidates are exempt: computePoolTriggerBindingPatch
+	// intentionally hands a wisp its per-work-bead directory before the
+	// worktree-per-bead dispatch that creates it has necessarily landed,
+	// relying on this same provider-level fallback as its safety net — gating
+	// on PoolManaged keeps that already-fixed case working unchanged. cityPath
+	// == "" only at the crash-recovery rebuild call (buildPreparedStart from
+	// recoverRunningPendingCreate), which isn't a live spawn; any inconsistency
+	// it finds falls through to a fresh, gated restart via
+	// prepareStartCandidateForCity.
+	if cityPath != "" && !candidate.info.PoolManaged && agentCfg.WorkDir != "" && filepath.IsAbs(agentCfg.WorkDir) {
+		if mkErr := os.MkdirAll(agentCfg.WorkDir, 0o755); mkErr != nil {
+			return nil, candidate.info, fmt.Errorf("creating step-dispatch workdir %q: %w", agentCfg.WorkDir, mkErr)
+		}
+	}
 	// Pre-flight stale-resume guard: if the bead carries a session_key whose
 	// keyed transcript is no longer on disk (provider session retention
 	// disabled, manual cleanup, worktree rebuild), a resume would hard-fail

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -830,6 +830,167 @@ func TestPrepareStartCandidate_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing
 	}
 }
 
+// TestPrepareStartCandidateForCity_CreatesMissingStepDispatchWorkDir covers
+// ga-zogqc1.1: a step-dispatch (named/direct, non-pool-managed) candidate
+// whose resolved workdir (session-bead work_dir metadata, Branch B of the
+// override in buildPreparedStartWithWorkDirResolver) does not exist yet must
+// have it created rather than silently falling through to the provider-level
+// city-root fallback (effectiveWorkDir / tmux GC_DIR read).
+func TestPrepareStartCandidateForCity_CreatesMissingStepDispatchWorkDir(t *testing.T) {
+	cityPath := t.TempDir()
+	relWorkDir := filepath.Join(".gc", "worktrees", "gascity", "builder", "missing-slug")
+	targetWorkDir := filepath.Join(cityPath, relWorkDir)
+
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "builder",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/builder"},
+		Metadata: map[string]string{
+			"template":     "builder",
+			"session_name": "builder-missing-slug",
+			"work_dir":     relWorkDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(targetWorkDir); !os.IsNotExist(err) {
+		t.Fatalf("targetWorkDir %q must not exist before prepare: %v", targetWorkDir, err)
+	}
+
+	prepared, err := prepareStartCandidateForCity(startCandidate{
+		info: sessiontest.SeedBead(t, session),
+		tp: TemplateParams{
+			TemplateName: "gascity/builder",
+			SessionName:  "builder-missing-slug",
+		},
+		order: 0,
+	}, cityPath, "city", &config.City{
+		Agents: []config.Agent{
+			{Name: "builder", Dir: "gascity", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
+		},
+	}, nil, store, &clock.Fake{Time: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareStartCandidateForCity: %v", err)
+	}
+	if prepared.cfg.WorkDir != targetWorkDir {
+		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, targetWorkDir)
+	}
+	st, statErr := os.Stat(targetWorkDir)
+	if statErr != nil {
+		t.Fatalf("stat %q after prepare: %v", targetWorkDir, statErr)
+	}
+	if !st.IsDir() {
+		t.Fatalf("%q exists but is not a directory", targetWorkDir)
+	}
+}
+
+// TestPrepareStartCandidateForCity_FailsLoudlyWhenStepDispatchWorkDirCannotBeCreated
+// covers the "fail loudly" half of ga-zogqc1.1's acceptance criteria: when the
+// resolved workdir path is occupied by a non-directory, MkdirAll cannot
+// recover, so the spawn must fail with a clear, workdir-referencing error
+// instead of silently proceeding to launch against a fallback directory.
+func TestPrepareStartCandidateForCity_FailsLoudlyWhenStepDispatchWorkDirCannotBeCreated(t *testing.T) {
+	cityPath := t.TempDir()
+	relWorkDir := filepath.Join(".gc", "worktrees", "gascity", "builder", "blocked-slug")
+	targetWorkDir := filepath.Join(cityPath, relWorkDir)
+	if err := os.MkdirAll(filepath.Dir(targetWorkDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetWorkDir, []byte("occupied"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "builder",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/builder"},
+		Metadata: map[string]string{
+			"template":     "builder",
+			"session_name": "builder-blocked-slug",
+			"work_dir":     relWorkDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareStartCandidateForCity(startCandidate{
+		info: sessiontest.SeedBead(t, session),
+		tp: TemplateParams{
+			TemplateName: "gascity/builder",
+			SessionName:  "builder-blocked-slug",
+		},
+		order: 0,
+	}, cityPath, "city", &config.City{
+		Agents: []config.Agent{
+			{Name: "builder", Dir: "gascity", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
+		},
+	}, nil, store, &clock.Fake{Time: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}, nil, nil)
+	if err == nil {
+		t.Fatalf("prepareStartCandidateForCity: want error for uncreatable workdir %q, got prepared=%+v", targetWorkDir, prepared)
+	}
+	if !strings.Contains(err.Error(), targetWorkDir) {
+		t.Fatalf("error = %q, want it to reference workdir %q", err.Error(), targetWorkDir)
+	}
+	if prepared != nil {
+		t.Fatalf("prepared = %+v, want nil on error", prepared)
+	}
+}
+
+// TestPrepareStartCandidateForCity_PoolManagedSkipsWorkDirCreation guards the
+// ga-zogqc1.1 fix's exemption for pool-managed candidates: pool wisps
+// intentionally start before their per-work-bead worktree exists
+// (computePoolTriggerBindingPatch), relying on the provider-level
+// effectiveWorkDir/GC_DIR fallback as their safety net. A pool-managed
+// candidate's unresolved workdir must NOT be eagerly created here, or that
+// already-fixed case would regress.
+func TestPrepareStartCandidateForCity_PoolManagedSkipsWorkDirCreation(t *testing.T) {
+	cityPath := t.TempDir()
+	relWorkDir := filepath.Join(".gc", "worktrees", "gascity", "builder", "pool-slug")
+	targetWorkDir := filepath.Join(cityPath, relWorkDir)
+
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "builder",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/builder"},
+		Metadata: map[string]string{
+			"template":     "builder",
+			"session_name": "builder-pool-slug",
+			"pool_managed": "true",
+			"work_dir":     relWorkDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareStartCandidateForCity(startCandidate{
+		info: sessiontest.SeedBead(t, session),
+		tp: TemplateParams{
+			TemplateName: "gascity/builder",
+			SessionName:  "builder-pool-slug",
+		},
+		order: 0,
+	}, cityPath, "city", &config.City{
+		Agents: []config.Agent{
+			{Name: "builder", Dir: "gascity", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
+		},
+	}, nil, store, &clock.Fake{Time: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareStartCandidateForCity: %v", err)
+	}
+	if prepared.cfg.WorkDir != targetWorkDir {
+		t.Fatalf("prepared.cfg.WorkDir = %q, want %q (path resolution unchanged)", prepared.cfg.WorkDir, targetWorkDir)
+	}
+	if _, statErr := os.Stat(targetWorkDir); !os.IsNotExist(statErr) {
+		t.Fatalf("pool-managed candidate must not have its workdir eagerly created; stat %q = %v", targetWorkDir, statErr)
+	}
+}
+
 func TestPrepareStartCandidateReloadsOverridesBeforeWake(t *testing.T) {
 	store := beads.NewMemStore()
 	session, err := store.Create(beads.Bead{

--- a/release-gates/ga-hilw2y-step-dispatch-workdir-gate.md
+++ b/release-gates/ga-hilw2y-step-dispatch-workdir-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: ga-hilw2y Step-Dispatch Workdir
+
+Date: 2026-07-24
+Bead: ga-hilw2y
+Type: single-bead deploy
+Branch: deploy/ga-hilw2y-gate
+Base: origin/main @ 80e5166473033b9f2807dad048ddcb70dfc3b86e
+Deploy source: 196a8cc223859986101bc0a8634a33064723f847
+Reviewed source: 82c7c5bf536fe40f910fcdeb9a130ac2f22dbecd
+
+## Summary
+
+This change creates the resolved per-step workdir before a step-dispatch
+session starts, or returns a contextual error if the directory cannot be
+created. Pool-managed sessions remain exempt because their workdir materializes
+through the pool trigger binding path.
+
+The deploy source is a rebased form of the reviewed commit. Stable patch-id
+evidence:
+
+| Commit | Stable patch ID |
+| --- | --- |
+| 82c7c5bf536fe40f910fcdeb9a130ac2f22dbecd | f9142e9596d3c77d557764e3bf74242fb8da1db6 |
+| 196a8cc223859986101bc0a8634a33064723f847 | f9142e9596d3c77d557764e3bf74242fb8da1db6 |
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git merge-base --is-ancestor origin/main HEAD` returned 0. `git status --short --branch` showed `deploy/ga-hilw2y-gate...origin/main [ahead 1]`. |
+| 1 | Review PASS present | PASS | Review bead `ga-rcj2zt` is closed and notes contain `VERDICT: PASS` for reviewed commit `82c7c5bf5`. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `cmd/gc/session_lifecycle_parallel.go` and `cmd/gc/session_lifecycle_parallel_test.go`. Focused tests cover directory creation, mkdir failure, and pool-managed exemption. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestPrepareStartCandidateForCity_(CreatesMissingStepDispatchWorkDir|FailsLoudlyWhenStepDispatchWorkDirCannotBeCreated|PoolManagedSkipsWorkDirCreation)$' -count=1 -v` passed. `go vet ./...` passed. `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | Review notes have PASS verdict and no unresolved HIGH findings; reviewer explicitly did not flag the pre-existing path-traversal behavior as a finding. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed only branch/ahead state and no worktree changes. |
+| 7 | Single feature theme | PASS | One subsystem: step-dispatch session workdir preparation in `cmd/gc`, with colocated unit tests. No independent feature themes. |
+
+## Commands
+
+```bash
+git show --format=email --ignore-space-change 82c7c5bf5 | git patch-id --stable
+git show --format=email --ignore-space-change 196a8cc223859986101bc0a8634a33064723f847 | git patch-id --stable
+git diff --check origin/main...HEAD
+go test ./cmd/gc -run 'TestPrepareStartCandidateForCity_(CreatesMissingStepDispatchWorkDir|FailsLoudlyWhenStepDispatchWorkDirCannotBeCreated|PoolManagedSkipsWorkDirCreation)$' -count=1 -v
+go vet ./...
+make test-fast-parallel
+git merge-base --is-ancestor origin/main HEAD
+```


### PR DESCRIPTION
## What this changes

Step-dispatch session starts now create their resolved per-step workdir before spawning the provider. If that directory cannot be created, startup returns a contextual error instead of falling through to a provider-level cwd fallback that can inherit the wrong city or shell context.

Pool-managed sessions remain unchanged. Their workdir is intentionally materialized through the pool trigger binding path, so this guard only applies to named/direct non-pool-managed step dispatch.

## Review notes

- The behavior change is in `cmd/gc/session_lifecycle_parallel.go` around `buildPreparedStartWithWorkDirResolver`.
- The new failure mode is explicit: `creating step-dispatch workdir <path>: <cause>`.
- The pool-managed exemption is deliberate and covered by a regression test.

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] `go test ./cmd/gc -run 'TestPrepareStartCandidateForCity_(CreatesMissingStepDispatchWorkDir|FailsLoudlyWhenStepDispatchWorkDirCannotBeCreated|PoolManagedSkipsWorkDirCreation)$' -count=1 -v`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-hilw2y-step-dispatch-workdir-gate.md`](release-gates/ga-hilw2y-step-dispatch-workdir-gate.md)
