### PR TITLE
fix(demand): exclude self-blocked routed work from pool demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1481,6 +1481,19 @@ func defaultScaleCheckCountsAndDemand(cfg *config.City, targets []defaultScaleCh
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
+			// Non-claimable statuses are excluded here for the same reason
+			// readyExcludeTypes excludes convoy/epic containers: the claim path
+			// will not hand these rows out, so counting them manufactures demand
+			// no worker can consume. beads.IsSelfBlockedBead is the exact
+			// predicate cmd_hook's isSelfBlockedHookCandidate applies to the
+			// worker's work_query result, which is what makes the two sides
+			// agree rather than approximately agree. Ready() already drops these
+			// at every healthy store; the guard is restated on the demand path
+			// so a store whose projection folds "blocked" onto "open" fails
+			// closed to no demand instead of open to an unbounded respawn loop.
+			if beads.IsSelfBlockedBead(b) {
+				continue
+			}
 			template := controllerDemandRouteTarget(cfg, b, group.templates)
 			if _, ok := group.templates[template]; !ok {
 				continue

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -852,6 +852,91 @@ func TestDefaultScaleCheckCountsSeesExternalRoutedWorkAfterCachePrime(t *testing
 	}
 }
 
+// A worker that sets its claimed bead to bd status "blocked" without releasing
+// the route leaves a row that is routed but NOT claimable: the claim path's
+// filterUnreadyHookCandidates/isSelfBlockedHookCandidate strips it, so
+// `gc hook --claim` returns nothing and the worker drain-acks. If route
+// discovery still counts that row, the controller sees undiminished demand and
+// starts another worker immediately.
+//
+// bd's "blocked" reaches Gas City as an is_blocked marker on an "open"-projected
+// row (mapBdStatus folds bd's status vocabulary onto three statuses;
+// bdIssue.blockedFlag preserves the marker), which is the shape asserted here.
+// A routed, unassigned, genuinely open row must still count, or the fix would
+// trade a spawn loop for a starved pool.
+func TestDefaultScaleCheckCountsExcludesRoutedButUnclaimableWork(t *testing.T) {
+	const template = "example/worker"
+	store := beads.NewMemStore()
+	claimable, err := store.Create(beads.Bead{
+		Title:    "routed open task",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: template},
+	})
+	if err != nil {
+		t.Fatalf("create routed open bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "routed task a worker marked blocked",
+		Type:   "task",
+		Status: "open",
+		// The projected shape of a bd row whose status is "blocked".
+		IsBlocked: boolPtr(true),
+		Metadata:  map[string]string{beadmeta.RoutedToMetadataKey: template},
+	}); err != nil {
+		t.Fatalf("create routed blocked bead: %v", err)
+	}
+
+	counts, demand, _, errs := defaultScaleCheckCountsAndDemand(nil, []defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:example",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand[%q] = %d, want 1 — a routed blocked bead is not claimable and must not create demand", template, got)
+	}
+	if got := demand[template].WorkBeadIDs; !reflect.DeepEqual(got, []string{claimable.ID}) {
+		t.Fatalf("WorkBeadIDs = %v, want only the claimable routed bead [%s]", got, claimable.ID)
+	}
+}
+
+// Demand must fail closed even when the store's Ready leaks a non-claimable row:
+// the live loop ran against a cached projection that had already folded bd's
+// "blocked" onto "open", so the demand path cannot delegate the whole check to
+// the store the way it delegates the convoy/epic type exclusion to
+// readyExcludeTypes. Both spellings of the marker are covered because the claim
+// path accepts both (is_blocked OR status=="blocked").
+func TestDefaultScaleCheckCountsExcludesUnclaimableRowsLeakedByReady(t *testing.T) {
+	const template = "example/worker"
+	routed := map[string]string{beadmeta.RoutedToMetadataKey: template}
+	store := &readyStaticStore{
+		Store: beads.NewMemStore(),
+		ready: []beads.Bead{
+			{ID: "ki-open", Title: "routed open task", Type: "task", Status: "open", Metadata: routed},
+			{ID: "task-marker", Title: "is_blocked marker", Type: "task", Status: "open", IsBlocked: boolPtr(true), Metadata: routed},
+			{ID: "task-status", Title: "raw bd status", Type: "task", Status: "blocked", Metadata: routed},
+		},
+	}
+
+	counts, demand, _, errs := defaultScaleCheckCountsAndDemand(nil, []defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:example",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCountsAndDemand[%q] = %d, want 1 — only ki-open is claimable", template, got)
+	}
+	if got := demand[template].WorkBeadIDs; !reflect.DeepEqual(got, []string{"ki-open"}) {
+		t.Fatalf("WorkBeadIDs = %v, want [ki-open]", got)
+	}
+}
+
 func TestDefaultScaleCheckDemandCarriesTriggerBeadID(t *testing.T) {
 	const template = "gascity/workflows.codex-min"
 	store := beads.NewMemStore()

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -789,28 +789,59 @@ func (b *bdIssue) toBead() Bead {
 		}
 	}
 	return Bead{
-		ID:           b.ID,
-		Title:        b.Title,
-		Status:       mapBdStatus(b.Status),
-		Type:         b.IssueType,
-		Priority:     cloneIntPtr(b.Priority),
-		CreatedAt:    b.CreatedAt.Truncate(time.Second),
-		UpdatedAt:    b.UpdatedAt.Truncate(time.Second),
-		Assignee:     b.Assignee,
-		From:         from,
-		ParentID:     parentID,
-		Ref:          b.Ref,
-		Needs:        b.Needs,
-		Description:  b.Description,
-		Labels:       b.Labels,
-		Metadata:     b.Metadata,
-		Dependencies: deps,
-		Ephemeral:    b.Ephemeral,
-		NoHistory:    b.NoHistory,
-		DeferUntil:   cloneTimePtr(b.DeferUntil),
-		IsBlocked:    b.IsBlocked.ptr(),
-		Revision:     b.Revision,
+		ID:              b.ID,
+		Title:           b.Title,
+		Status:          mapBdStatus(b.Status),
+		Type:            b.IssueType,
+		Priority:        cloneIntPtr(b.Priority),
+		CreatedAt:       b.CreatedAt.Truncate(time.Second),
+		UpdatedAt:       b.UpdatedAt.Truncate(time.Second),
+		Assignee:        b.Assignee,
+		From:            from,
+		ParentID:        parentID,
+		Ref:             b.Ref,
+		Needs:           b.Needs,
+		Description:     b.Description,
+		Labels:          b.Labels,
+		Metadata:        b.Metadata,
+		Dependencies:    deps,
+		Ephemeral:       b.Ephemeral,
+		NoHistory:       b.NoHistory,
+		DeferUntil:      cloneTimePtr(b.DeferUntil),
+		IsBlocked:       b.blockedFlag(),
+		blockedByStatus: b.statusBlocked(),
+		Revision:        b.Revision,
 	}
+}
+
+// blockedFlag resolves the Bead.IsBlocked marker from bd's row. bd carries the
+// self-blocked signal on TWO channels and a given bd build may populate either:
+// the denormalized is_blocked column, and the status value "blocked" itself.
+// mapBdStatus deliberately folds bd's richer status vocabulary (blocked,
+// review, testing) onto Gas City's three-status model, so a row whose ONLY
+// self-blocked signal was status=="blocked" used to arrive here indistinguishable
+// from healthy open work — the projection erased the one field the claim path
+// keys on. Preserving it as is_blocked keeps the three-status model intact while
+// making the marker survive the projection, so demand-side readers can apply the
+// same non-claimable predicate the claim path applies (cmd/gc
+// isSelfBlockedHookCandidate, which tests is_blocked OR status=="blocked").
+//
+// The two channels are independent and combine with OR semantics, matching the
+// claim path: status "blocked" always wins, even when the dependency-derived
+// is_blocked column explicitly says false. For every other status, preserve the
+// optional is_blocked value exactly. In particular, an absent marker stays nil
+// ("bd did not say") rather than becoming a synthesized false, which would flip
+// cachedBeadReady from "consult dependencies" to "definitely ready".
+func (b *bdIssue) blockedFlag() *bool {
+	if b.statusBlocked() {
+		blocked := true
+		return &blocked
+	}
+	return b.IsBlocked.ptr()
+}
+
+func (b *bdIssue) statusBlocked() bool {
+	return strings.EqualFold(strings.TrimSpace(b.Status), "blocked")
 }
 
 func (b *bdIssue) normalizedDependencies() []Dep {
@@ -874,6 +905,10 @@ func isBdClaimConflictMessage(msg string) bool {
 // mapBdStatus maps bd's statuses to Gas City's 3. bd uses: open,
 // in_progress, blocked, review, testing, closed. Gas City uses:
 // open, in_progress, closed.
+//
+// The fold is lossy by design, so anything that must survive it has to be
+// carried on a dedicated field: bd's "blocked" is preserved as the is_blocked
+// marker by bdIssue.blockedFlag, because "open" here does NOT mean claimable.
 func mapBdStatus(s string) string {
 	switch s {
 	case "closed":

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -100,10 +101,28 @@ type Bead struct {
 	// nil or past means ready). Create paths preserve it; UpdateOpts does not
 	// mutate it.
 	DeferUntil *time.Time `json:"defer_until,omitempty"`
-	// IsBlocked carries bd's denormalized ready-work projection. Nil means the
-	// store did not provide the projection and cached ready falls back to
-	// dependency-derived readiness for backward compatibility.
+	// IsBlocked carries bd's denormalized ready-work projection: "bd says this
+	// bead is not ready", which cachedBeadReady consumes as a short-circuit over
+	// dependency-derived readiness. Nil means the store did not provide the
+	// projection and cached ready falls back to dependencies for backward
+	// compatibility.
+	//
+	// It carries BOTH of bd's not-ready dimensions, because bd populates them on
+	// different channels and Gas City must honor either: the dependency-derived
+	// is_blocked column, and the bd status value "blocked" (a worker parking work
+	// it cannot progress). mapBdStatus folds bd's status vocabulary onto Gas
+	// City's three statuses, so the second dimension would otherwise be erased at
+	// the projection boundary — see bdIssue.blockedFlag. This is the only
+	// not-claimable signal that survives every hop from bd's JSON through the
+	// cache and the HTTP/SSE wire to the controller's demand readers, which is
+	// what lets demand and `gc hook --claim` agree on one set.
 	IsBlocked *bool `json:"is_blocked,omitempty"`
+	// blockedByStatus records the provenance of an IsBlocked=true marker that
+	// bdIssue.toBead synthesized from bd's raw status=="blocked". Cache
+	// dependency invalidation may clear dependency-derived IsBlocked projections,
+	// but must not clear this independent status dimension. It is intentionally
+	// store-internal: IsBlocked remains the stable wire representation.
+	blockedByStatus bool
 	// Revision is the store-internal optimistic-concurrency token for
 	// ConditionalWriter. It is deliberately json:"-" so it stays off every HTTP
 	// and SSE wire path (beads.Bead is both the Huma response type and the SSE
@@ -473,6 +492,7 @@ func IsReadyCandidateForTier(b Bead, now time.Time, tier TierMode) bool {
 	}
 	return b.Status == "open" &&
 		!IsReadyExcludedBead(b) &&
+		!IsSelfBlockedBead(b) &&
 		!IsDeferred(b, now)
 }
 
@@ -480,6 +500,31 @@ func IsReadyCandidateForTier(b Bead, now time.Time, tier TierMode) bool {
 // actionable Ready work.
 func IsReadyExcludedBead(b Bead) bool {
 	return IsReadyExcludedType(b.Type) || HasReadyExcludedLabel(b)
+}
+
+// IsSelfBlockedBead reports whether a bead carries its own blocked marker,
+// independent of the dependency graph checked by the per-store blocker
+// predicates. It is the STATUS dimension of Ready exclusion, exactly parallel
+// to IsReadyExcludedBead's TYPE dimension (the convoy/epic infrastructure
+// guard): a self-blocked bead is real work that simply is not claimable now.
+//
+// This mirrors cmd/gc isSelfBlockedHookCandidate — the claim path's filter — so
+// demand and claim agree on one set instead of approximating each other. Demand
+// that counts what claim refuses to hand out IS a spawn loop: the controller
+// starts a worker, the worker's `gc hook --claim` finds nothing, it drain-acks,
+// and the unchanged demand immediately starts another one.
+//
+// bd's richer status vocabulary is folded onto Gas City's three statuses by
+// mapBdStatus, so a bd-side "blocked" arrives here as the is_blocked marker
+// preserved by bdIssue.blockedFlag rather than as a distinct Status. Both
+// spellings are accepted so native and bd-backed stores answer identically.
+// An absent marker means NOT blocked: bd's denormalized projection is not
+// always populated, and over-filtering here would strand ready work.
+func IsSelfBlockedBead(b Bead) bool {
+	if b.blockedByStatus || (b.IsBlocked != nil && *b.IsBlocked) {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(b.Status), "blocked")
 }
 
 // HasReadyExcludedLabel reports whether a bead carries a label that marks it

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -136,11 +136,98 @@ func TestIsReadyCandidate(t *testing.T) {
 			bead: Bead{Status: "open", Type: "task", DeferUntil: &future},
 			want: false,
 		},
+		{
+			// mapBdStatus projects bd's "blocked" onto "open", so this marker is
+			// the only surviving signal that the claim path will refuse the row.
+			name: "self-blocked marker on an open-projected row",
+			bead: Bead{Status: "open", Type: "task", IsBlocked: readyCandidateBoolPtr(true)},
+			want: false,
+		},
+		{
+			name: "explicit not-blocked marker stays ready",
+			bead: Bead{Status: "open", Type: "task", IsBlocked: readyCandidateBoolPtr(false)},
+			want: true,
+		},
+		{
+			name: "raw blocked status from a store that does not fold it",
+			bead: Bead{Status: "blocked", Type: "task"},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsReadyCandidate(tt.bead, now); got != tt.want {
 				t.Fatalf("IsReadyCandidate(%+v) = %v, want %v", tt.bead, got, tt.want)
+			}
+		})
+	}
+}
+
+func readyCandidateBoolPtr(v bool) *bool { return &v }
+
+// bd reports not-ready state through two independent channels: the
+// dependency-derived is_blocked column and the explicit status value "blocked".
+// mapBdStatus folds the latter onto "open" to keep Gas City's three-status
+// model, so blockedFlag must preserve the status signal even when the dependency
+// column explicitly says false.
+func TestBdIssueToBeadPreservesBlockedStatusAsIsBlockedMarker(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantStatus string
+		wantBlock  *bool
+	}{
+		{
+			name:       "status blocked with no is_blocked column",
+			raw:        `{"id":"task-blocked","title":"routed work","status":"blocked","issue_type":"task"}`,
+			wantStatus: "open",
+			wantBlock:  readyCandidateBoolPtr(true),
+		},
+		{
+			name:       "blocked status wins over explicit dependency false",
+			raw:        `{"id":"task-blocked","title":"routed work","status":"blocked","issue_type":"task","is_blocked":false}`,
+			wantStatus: "open",
+			wantBlock:  readyCandidateBoolPtr(true),
+		},
+		{
+			name:       "non-blocked status preserves explicit dependency false",
+			raw:        `{"id":"task-open","title":"routed work","status":"open","issue_type":"task","is_blocked":false}`,
+			wantStatus: "open",
+			wantBlock:  readyCandidateBoolPtr(false),
+		},
+		{
+			name:       "plain open row keeps an absent marker",
+			raw:        `{"id":"ki-open","title":"routed work","status":"open","issue_type":"task"}`,
+			wantStatus: "open",
+			wantBlock:  nil,
+		},
+		{
+			name:       "other folded bd statuses are not treated as blocked",
+			raw:        `{"id":"ki-rev","title":"routed work","status":"review","issue_type":"task"}`,
+			wantStatus: "open",
+			wantBlock:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var issue bdIssue
+			if err := json.Unmarshal([]byte(tt.raw), &issue); err != nil {
+				t.Fatalf("unmarshal bd row: %v", err)
+			}
+			got := issue.toBead()
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			switch {
+			case tt.wantBlock == nil && got.IsBlocked != nil:
+				t.Fatalf("IsBlocked = %v, want nil (bd did not say)", *got.IsBlocked)
+			case tt.wantBlock != nil && got.IsBlocked == nil:
+				t.Fatalf("IsBlocked = nil, want %v", *tt.wantBlock)
+			case tt.wantBlock != nil && *got.IsBlocked != *tt.wantBlock:
+				t.Fatalf("IsBlocked = %v, want %v", *got.IsBlocked, *tt.wantBlock)
+			}
+			if tt.wantBlock != nil && *tt.wantBlock && IsReadyCandidate(got, time.Now()) {
+				t.Fatal("IsReadyCandidate = true for a bd-blocked row; demand would count what claim refuses")
 			}
 		})
 	}

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -362,7 +362,7 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 
 func (c *CachingStore) clearReadyProjectionLocked(id string) bool {
 	b, ok := c.beads[id]
-	if !ok || b.IsBlocked == nil {
+	if !ok || b.IsBlocked == nil || b.blockedByStatus {
 		return false
 	}
 	b.IsBlocked = nil
@@ -420,6 +420,21 @@ func mergeCacheEventPatch(base, patch Bead, fields map[string]json.RawMessage) B
 	}
 	if hasCacheEventField(fields, "status") {
 		merged.Status = patch.Status
+		switch {
+		case patch.blockedByStatus:
+			// Raw bd hook payloads preserve status=="blocked".
+			merged.blockedByStatus = true
+		case !hasCacheEventField(fields, "is_blocked") ||
+			patch.IsBlocked == nil || !*patch.IsBlocked:
+			// A definitely-unblocked non-blocked status clears provenance.
+			merged.blockedByStatus = false
+			// status=="open" plus IsBlocked=true is ambiguous: it can be a
+			// dependency-derived marker, or a folded status-blocked Bead emitted by
+			// another CachingStore (blockedByStatus is intentionally off-wire).
+			// Preserve existing provenance in that one case. A backing refresh or
+			// reconciliation has the authoritative store-internal bit and can clear
+			// it; conservatively retaining it cannot create false demand.
+		}
 	}
 	if hasCacheEventField(fields, "issue_type") || hasCacheEventField(fields, "type") {
 		merged.Type = patch.Type
@@ -697,7 +712,8 @@ func beadChanged(old, fresh Bead, skipLabels bool) bool {
 		old.Description != fresh.Description ||
 		old.Ephemeral != fresh.Ephemeral ||
 		!timePtrEqual(old.DeferUntil, fresh.DeferUntil) ||
-		!boolPtrEqual(old.IsBlocked, fresh.IsBlocked) {
+		!boolPtrEqual(old.IsBlocked, fresh.IsBlocked) ||
+		old.blockedByStatus != fresh.blockedByStatus {
 		return true
 	}
 	if !maps.Equal(old.Metadata, fresh.Metadata) {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3051,6 +3051,124 @@ func TestCachingStoreCachedReadyHonorsProjectedIsBlocked(t *testing.T) {
 	}
 }
 
+func TestCachingStoreDependencyInvalidationPreservesStatusBlockedProjection(t *testing.T) {
+	t.Parallel()
+
+	var issue bdIssue
+	if err := json.Unmarshal([]byte(`{
+		"id":"bd-status-blocked",
+		"title":"parked work",
+		"status":"blocked",
+		"issue_type":"task"
+	}`), &issue); err != nil {
+		t.Fatalf("unmarshal bd row: %v", err)
+	}
+	projected := issue.toBead()
+	if projected.Status != "open" || projected.IsBlocked == nil || !*projected.IsBlocked {
+		t.Fatalf("projected bead = %+v, want folded open status with blocked marker", projected)
+	}
+
+	cache := NewCachingStoreForTest(&completeEmbeddedDepsStore{
+		beads: []Bead{projected},
+	}, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Dependency snapshots invalidate dependency-derived IsBlocked projections.
+	// A marker synthesized from bd's own status is independent of that graph and
+	// must survive, or CachedReady will count work that gc hook --claim rejects.
+	cache.ApplyDepEvent(projected.ID, nil)
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 0 {
+		t.Fatalf("CachedReady after dependency invalidation = %+v, want status-blocked bead excluded", ready)
+	}
+	got, err := cache.Get(projected.ID)
+	if err != nil {
+		t.Fatalf("Get after dependency invalidation: %v", err)
+	}
+	if got.IsBlocked == nil || !*got.IsBlocked {
+		t.Fatalf("IsBlocked after dependency invalidation = %v, want preserved true status marker", got.IsBlocked)
+	}
+}
+
+func TestCachingStoreFoldedStatusBlockedEventPreservesInvalidationProvenance(t *testing.T) {
+	t.Parallel()
+
+	var issue bdIssue
+	if err := json.Unmarshal([]byte(`{
+		"id":"bd-status-blocked-event",
+		"title":"parked work",
+		"status":"blocked",
+		"issue_type":"task"
+	}`), &issue); err != nil {
+		t.Fatalf("unmarshal bd row: %v", err)
+	}
+	projected := issue.toBead()
+	cache := NewCachingStoreForTest(&completeEmbeddedDepsStore{
+		beads: []Bead{projected},
+	}, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// CachingStore notifications serialize the public Bead shape. The folded
+	// status is "open" and blockedByStatus is deliberately off-wire, so this
+	// event must not erase provenance when IsBlocked still says true.
+	payload, err := json.Marshal(projected)
+	if err != nil {
+		t.Fatalf("marshal projected event: %v", err)
+	}
+	cache.ApplyEvent("bead.updated", payload)
+	cache.ApplyDepEvent(projected.ID, nil)
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 0 {
+		t.Fatalf("CachedReady after folded event and invalidation = %+v, want status-blocked bead excluded", ready)
+	}
+}
+
+func TestCachingStoreRawOpenEventClearsStatusBlockedProvenance(t *testing.T) {
+	t.Parallel()
+
+	var issue bdIssue
+	if err := json.Unmarshal([]byte(`{
+		"id":"bd-status-reopened",
+		"title":"resumed work",
+		"status":"blocked",
+		"issue_type":"task"
+	}`), &issue); err != nil {
+		t.Fatalf("unmarshal bd row: %v", err)
+	}
+	projected := issue.toBead()
+	cache := NewCachingStoreForTest(&completeEmbeddedDepsStore{
+		beads: []Bead{projected},
+	}, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(
+		`{"id":"bd-status-reopened","status":"open"}`,
+	))
+	cache.ApplyDepEvent(projected.ID, nil)
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 1 || ready[0].ID != projected.ID {
+		t.Fatalf("CachedReady after raw open event = %+v, want reopened bead ready", ready)
+	}
+}
+
 func TestCachingStoreApplyEventMergesProjectedIsBlocked(t *testing.T) {
 	t.Parallel()
 
@@ -3838,12 +3956,26 @@ func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 	if stats := cache.Stats(); stats.ProblemCount != 0 {
 		t.Fatalf("cache problem count = %d, want 0", stats.ProblemCount)
 	}
+	// bd's status "blocked" is itself a not-ready signal, independent of the
+	// dependency-derived is_blocked column: a worker parks work it cannot
+	// progress by setting that status, leaving the deps clean. bdIssue.blockedFlag
+	// marks the row before enrichment runs, and the enrichment must NOT clear it
+	// back to the column's dependency-only answer. Otherwise demand can count a
+	// row the claim path refuses. The unblocked and deferred rows below still pin
+	// that the projection reaches rows outside the ready set.
 	blocked, err := cache.Get("bd-blocked-status")
 	if err != nil {
 		t.Fatalf("Get(blocked status): %v", err)
 	}
-	if blocked.IsBlocked == nil || *blocked.IsBlocked {
-		t.Fatalf("blocked-status IsBlocked = %v, want false projection", blocked.IsBlocked)
+	if blocked.IsBlocked == nil || !*blocked.IsBlocked {
+		t.Fatalf("blocked-status IsBlocked = %v, want the bd status preserved as a not-ready marker", blocked.IsBlocked)
+	}
+	ready, err := cache.Get("bd-ready")
+	if err != nil {
+		t.Fatalf("Get(ready): %v", err)
+	}
+	if ready.IsBlocked == nil || *ready.IsBlocked {
+		t.Fatalf("ready IsBlocked = %v, want false projection", ready.IsBlocked)
 	}
 	deferred, err := cache.Get("bd-deferred-status")
 	if err != nil {

--- a/internal/beads/event_payload.go
+++ b/internal/beads/event_payload.go
@@ -1,6 +1,9 @@
 package beads
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // DecodeBeadEventPayload extracts a Bead from a bead.* event payload. It is the
 // single shared decoder for the bead-event wire shape; the API layer, the
@@ -46,6 +49,7 @@ func decodeRawBead(data json.RawMessage) (Bead, bool) {
 	if err := json.Unmarshal(data, &b); err != nil || b.ID == "" {
 		return Bead{}, false
 	}
+	b.blockedByStatus = strings.EqualFold(strings.TrimSpace(b.Status), "blocked")
 	if b.Type == "" {
 		var compat struct {
 			Type string `json:"type"`


### PR DESCRIPTION
## Summary

- preserve an explicit bd `status=blocked` as `Bead.IsBlocked` when projecting
  bd's richer status vocabulary onto Gas City's three statuses
- exclude self-blocked beads from Ready candidates
- repeat the same guard at the controller demand boundary so a stale or lossy
  store projection cannot create demand that `gc hook --claim` refuses

## Problem

A routed, unassigned bead may be explicitly parked with bd status `blocked`
while having no open dependency. The claim path rejects that row, but
`mapBdStatus` projects bd's `blocked` status onto Gas City status `open`.
Previously, controller demand could therefore count the row and start a worker;
the worker claimed nothing, drain-acked, and left the same demand standing for
another start.

This is related to #4114 because it produces the same zero-claim respawn shape,
but it is a distinct third mechanism. It is not #4114's agent-convention
`halt_reason` mechanism, and it is not the dependency-blocked mechanism described
in that issue's follow-up comment. This PR does not claim to close #4114 or add
the controller-side zero-claim backoff proposed there.

## Fix

bd exposes two independent not-ready channels:

1. the dependency-derived `is_blocked` field; and
2. the explicit status value `blocked`.

They now combine with the same OR semantics used by the claim path. Raw
`status=blocked` always produces `IsBlocked=true`, even if bd also emits
`is_blocked=false` because the dependency graph is clean. For every other
status, the optional `is_blocked` value is preserved exactly, including `nil`.

`beads.IsSelfBlockedBead` is used by Ready filtering and repeated in the
controller's native demand loop. The second check is intentional defense in
depth: demand must not fail open if a Store implementation leaks a raw blocked
row from `Ready`.

`CachingStore` also retains store-internal provenance for an `IsBlocked=true`
marker synthesized from raw `status=blocked`. Dependency mutations still clear
dependency-derived ready projections, but no longer erase the independent
status marker and temporarily expose the parked row as ready. The provenance
stays out of the public HTTP/OpenAPI shape; `IsBlocked` remains its wire
representation.

## Scope

This corrects explicit self-blocked status handling only. It does not infer
agent-level conventions such as `halt_reason`, and it does not replace the
general zero-claim backoff/alerting proposed in #4114.

## Validation

- `go test ./internal/beads -count=1`
- `go test ./internal/config -count=1`
- `go test ./cmd/gc -count=1`
- `go vet ./cmd/gc ./internal/beads ./internal/config`
- `go build ./...`
- focused regressions cover:
  - `status=blocked` with no `is_blocked` field
  - the conflicting two-channel case: `status=blocked` plus
    `is_blocked=false`
  - preservation of explicit and absent `is_blocked` values for other statuses
  - dependency invalidation preserving a status-derived marker while still
    clearing dependency-derived projections
  - folded cache events preserving that provenance, and a raw reopen clearing it
  - both blocked spellings leaking from a Store's `Ready` result
