### PR TITLE
fix(demand): exclude self-blocked routed work from pool demand (v1.3.x backport)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1354,6 +1354,13 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
+			// Demand must not count rows the claim path refuses. Ready normally
+			// excludes self-blocked work, but repeat the exact predicate here so
+			// a lossy or stale store projection fails closed rather than driving
+			// a zero-claim respawn loop.
+			if beads.IsSelfBlockedBead(b) {
+				continue
+			}
 			template := controllerDemandRouteTarget(b, group.templates)
 			if _, ok := group.templates[template]; !ok {
 				continue

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -685,6 +685,72 @@ func TestDefaultScaleCheckCountsSeesExternalRoutedWorkAfterCachePrime(t *testing
 	}
 }
 
+// A worker can explicitly park routed work with status "blocked" while leaving
+// its dependencies clean. The claim path refuses that row. Demand must refuse it
+// too, or each zero-claim drain leaves the same demand standing and immediately
+// starts another worker.
+func TestDefaultScaleCheckCountsExcludesRoutedButUnclaimableWork(t *testing.T) {
+	const template = "example/worker"
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:    "routed open task",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": template},
+	}); err != nil {
+		t.Fatalf("create routed open bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:     "routed task marked blocked",
+		Type:      "task",
+		Status:    "open",
+		IsBlocked: boolPtr(true),
+		Metadata:  map[string]string{"gc.routed_to": template},
+	}); err != nil {
+		t.Fatalf("create routed blocked bead: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:example",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1; blocked routed work is not claimable", template, got)
+	}
+}
+
+// Repeat the predicate at the demand boundary even if a store's Ready
+// projection leaks a non-claimable row. Cover both surviving shapes because the
+// claim path rejects `is_blocked == true` OR raw `status == "blocked"`.
+func TestDefaultScaleCheckCountsExcludesUnclaimableRowsLeakedByReady(t *testing.T) {
+	const template = "example/worker"
+	routed := map[string]string{"gc.routed_to": template}
+	store := &readyStaticStore{
+		Store: beads.NewMemStore(),
+		ready: []beads.Bead{
+			{ID: "task-open", Title: "routed open task", Type: "task", Status: "open", Metadata: routed},
+			{ID: "task-marker", Title: "is_blocked marker", Type: "task", Status: "open", IsBlocked: boolPtr(true), Metadata: routed},
+			{ID: "task-status", Title: "raw bd status", Type: "task", Status: "blocked", Metadata: routed},
+		},
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:example",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1; only task-open is claimable", template, got)
+	}
+}
+
 func TestDefaultScaleCheckCountsUsesLiveReadyWhenCachedRowWasAssigned(t *testing.T) {
 	const template = "gascity/workflows.codex-min"
 	backing := beads.NewMemStore()

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -676,27 +676,45 @@ func (b *bdIssue) toBead() Bead {
 		}
 	}
 	return Bead{
-		ID:           b.ID,
-		Title:        b.Title,
-		Status:       mapBdStatus(b.Status),
-		Type:         b.IssueType,
-		Priority:     cloneIntPtr(b.Priority),
-		CreatedAt:    b.CreatedAt.Truncate(time.Second),
-		UpdatedAt:    b.UpdatedAt.Truncate(time.Second),
-		Assignee:     b.Assignee,
-		From:         from,
-		ParentID:     parentID,
-		Ref:          b.Ref,
-		Needs:        b.Needs,
-		Description:  b.Description,
-		Labels:       b.Labels,
-		Metadata:     b.Metadata,
-		Dependencies: deps,
-		Ephemeral:    b.Ephemeral,
-		NoHistory:    b.NoHistory,
-		DeferUntil:   cloneTimePtr(b.DeferUntil),
-		IsBlocked:    b.IsBlocked.ptr(),
+		ID:              b.ID,
+		Title:           b.Title,
+		Status:          mapBdStatus(b.Status),
+		Type:            b.IssueType,
+		Priority:        cloneIntPtr(b.Priority),
+		CreatedAt:       b.CreatedAt.Truncate(time.Second),
+		UpdatedAt:       b.UpdatedAt.Truncate(time.Second),
+		Assignee:        b.Assignee,
+		From:            from,
+		ParentID:        parentID,
+		Ref:             b.Ref,
+		Needs:           b.Needs,
+		Description:     b.Description,
+		Labels:          b.Labels,
+		Metadata:        b.Metadata,
+		Dependencies:    deps,
+		Ephemeral:       b.Ephemeral,
+		NoHistory:       b.NoHistory,
+		DeferUntil:      cloneTimePtr(b.DeferUntil),
+		IsBlocked:       b.blockedFlag(),
+		blockedByStatus: b.statusBlocked(),
 	}
+}
+
+// blockedFlag combines bd's two independent not-ready channels. Gas City's
+// three-status projection folds status "blocked" onto "open", so that status
+// must force the surviving IsBlocked marker even if bd also emits the
+// dependency-derived is_blocked column as false. For every other status, retain
+// the optional column exactly; in particular, absent stays nil.
+func (b *bdIssue) blockedFlag() *bool {
+	if b.statusBlocked() {
+		blocked := true
+		return &blocked
+	}
+	return b.IsBlocked.ptr()
+}
+
+func (b *bdIssue) statusBlocked() bool {
+	return strings.EqualFold(strings.TrimSpace(b.Status), "blocked")
 }
 
 func (b *bdIssue) normalizedDependencies() []Dep {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -90,6 +91,12 @@ type Bead struct {
 	// store did not provide the projection and cached ready falls back to
 	// dependency-derived readiness for backward compatibility.
 	IsBlocked *bool `json:"is_blocked,omitempty"`
+	// blockedByStatus records the provenance of an IsBlocked=true marker that
+	// bdIssue.toBead synthesized from bd's raw status=="blocked". Cache
+	// dependency invalidation may clear dependency-derived IsBlocked projections,
+	// but must not clear this independent status dimension. It is intentionally
+	// store-internal: IsBlocked remains the stable wire representation.
+	blockedByStatus bool
 }
 
 // UpdateOpts specifies which fields to change. Nil pointers are skipped.
@@ -237,6 +244,7 @@ func IsReadyCandidateForTier(b Bead, now time.Time, tier TierMode) bool {
 	}
 	return b.Status == "open" &&
 		!IsReadyExcludedBead(b) &&
+		!IsSelfBlockedBead(b) &&
 		!IsDeferred(b, now)
 }
 
@@ -253,6 +261,18 @@ func IsReadyExcludedBead(b Bead) bool {
 		}
 	}
 	return false
+}
+
+// IsSelfBlockedBead reports whether a bead carries its own blocked marker,
+// independent of dependency-graph readiness. It mirrors the claim path's
+// predicate so Ready and controller demand cannot count work the worker will
+// refuse. Both spellings are accepted for native stores; bd-backed stores carry
+// raw status "blocked" through mapBdStatus as IsBlocked.
+func IsSelfBlockedBead(b Bead) bool {
+	if b.blockedByStatus || (b.IsBlocked != nil && *b.IsBlocked) {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(b.Status), "blocked")
 }
 
 // IsDeferred reports whether a bead is hidden by a future defer_until,

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -133,11 +134,98 @@ func TestIsReadyCandidate(t *testing.T) {
 			bead: Bead{Status: "open", Type: "task", DeferUntil: &future},
 			want: false,
 		},
+		{
+			// mapBdStatus projects bd's "blocked" onto "open", so this marker is
+			// the only surviving signal that the claim path will refuse the row.
+			name: "self-blocked marker on an open-projected row",
+			bead: Bead{Status: "open", Type: "task", IsBlocked: readyCandidateBoolPtr(true)},
+			want: false,
+		},
+		{
+			name: "explicit not-blocked marker stays ready",
+			bead: Bead{Status: "open", Type: "task", IsBlocked: readyCandidateBoolPtr(false)},
+			want: true,
+		},
+		{
+			name: "raw blocked status from a store that does not fold it",
+			bead: Bead{Status: "blocked", Type: "task"},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsReadyCandidate(tt.bead, now); got != tt.want {
 				t.Fatalf("IsReadyCandidate(%+v) = %v, want %v", tt.bead, got, tt.want)
+			}
+		})
+	}
+}
+
+func readyCandidateBoolPtr(v bool) *bool { return &v }
+
+// bd reports not-ready state through two independent channels: the
+// dependency-derived is_blocked column and the explicit status value "blocked".
+// mapBdStatus folds the latter onto "open" to keep Gas City's three-status
+// model, so blockedFlag must preserve the status signal even when the dependency
+// column explicitly says false.
+func TestBdIssueToBeadPreservesBlockedStatusAsIsBlockedMarker(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantStatus string
+		wantBlock  *bool
+	}{
+		{
+			name:       "status blocked with no is_blocked column",
+			raw:        `{"id":"task-blocked","title":"routed work","status":"blocked","issue_type":"task"}`,
+			wantStatus: "open",
+			wantBlock:  readyCandidateBoolPtr(true),
+		},
+		{
+			name:       "blocked status wins over explicit dependency false",
+			raw:        `{"id":"task-blocked","title":"routed work","status":"blocked","issue_type":"task","is_blocked":false}`,
+			wantStatus: "open",
+			wantBlock:  readyCandidateBoolPtr(true),
+		},
+		{
+			name:       "non-blocked status preserves explicit dependency false",
+			raw:        `{"id":"task-open","title":"routed work","status":"open","issue_type":"task","is_blocked":false}`,
+			wantStatus: "open",
+			wantBlock:  readyCandidateBoolPtr(false),
+		},
+		{
+			name:       "plain open row keeps an absent marker",
+			raw:        `{"id":"ki-open","title":"routed work","status":"open","issue_type":"task"}`,
+			wantStatus: "open",
+			wantBlock:  nil,
+		},
+		{
+			name:       "other folded bd statuses are not treated as blocked",
+			raw:        `{"id":"ki-rev","title":"routed work","status":"review","issue_type":"task"}`,
+			wantStatus: "open",
+			wantBlock:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var issue bdIssue
+			if err := json.Unmarshal([]byte(tt.raw), &issue); err != nil {
+				t.Fatalf("unmarshal bd row: %v", err)
+			}
+			got := issue.toBead()
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			switch {
+			case tt.wantBlock == nil && got.IsBlocked != nil:
+				t.Fatalf("IsBlocked = %v, want nil (bd did not say)", *got.IsBlocked)
+			case tt.wantBlock != nil && got.IsBlocked == nil:
+				t.Fatalf("IsBlocked = nil, want %v", *tt.wantBlock)
+			case tt.wantBlock != nil && *got.IsBlocked != *tt.wantBlock:
+				t.Fatalf("IsBlocked = %v, want %v", *got.IsBlocked, *tt.wantBlock)
+			}
+			if tt.wantBlock != nil && *tt.wantBlock && IsReadyCandidate(got, time.Now()) {
+				t.Fatal("IsReadyCandidate = true for a bd-blocked row; demand would count what claim refuses")
 			}
 		})
 	}

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 )
 
@@ -357,7 +358,7 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 
 func (c *CachingStore) clearReadyProjectionLocked(id string) bool {
 	b, ok := c.beads[id]
-	if !ok || b.IsBlocked == nil {
+	if !ok || b.IsBlocked == nil || b.blockedByStatus {
 		return false
 	}
 	b.IsBlocked = nil
@@ -415,6 +416,21 @@ func mergeCacheEventPatch(base, patch Bead, fields map[string]json.RawMessage) B
 	}
 	if hasCacheEventField(fields, "status") {
 		merged.Status = patch.Status
+		switch {
+		case patch.blockedByStatus:
+			// Raw bd hook payloads preserve status=="blocked".
+			merged.blockedByStatus = true
+		case !hasCacheEventField(fields, "is_blocked") ||
+			patch.IsBlocked == nil || !*patch.IsBlocked:
+			// A definitely-unblocked non-blocked status clears provenance.
+			merged.blockedByStatus = false
+			// status=="open" plus IsBlocked=true is ambiguous: it can be a
+			// dependency-derived marker, or a folded status-blocked Bead emitted by
+			// another CachingStore (blockedByStatus is intentionally off-wire).
+			// Preserve existing provenance in that one case. A backing refresh or
+			// reconciliation has the authoritative store-internal bit and can clear
+			// it; conservatively retaining it cannot create false demand.
+		}
 	}
 	if hasCacheEventField(fields, "issue_type") || hasCacheEventField(fields, "type") {
 		merged.Type = patch.Type
@@ -638,6 +654,7 @@ func decodeCacheEvent(payload json.RawMessage) (Bead, map[string]json.RawMessage
 		return Bead{}, nil, err
 	}
 	b := wire.Bead
+	b.blockedByStatus = strings.EqualFold(strings.TrimSpace(b.Status), "blocked")
 	if wire.Metadata != nil {
 		b.Metadata = map[string]string(wire.Metadata)
 	}
@@ -688,7 +705,8 @@ func beadChanged(old, fresh Bead, skipLabels bool) bool {
 		old.Description != fresh.Description ||
 		old.Ephemeral != fresh.Ephemeral ||
 		!timePtrEqual(old.DeferUntil, fresh.DeferUntil) ||
-		!boolPtrEqual(old.IsBlocked, fresh.IsBlocked) {
+		!boolPtrEqual(old.IsBlocked, fresh.IsBlocked) ||
+		old.blockedByStatus != fresh.blockedByStatus {
 		return true
 	}
 	if !maps.Equal(old.Metadata, fresh.Metadata) {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3010,6 +3010,124 @@ func TestCachingStoreCachedReadyHonorsProjectedIsBlocked(t *testing.T) {
 	}
 }
 
+func TestCachingStoreDependencyInvalidationPreservesStatusBlockedProjection(t *testing.T) {
+	t.Parallel()
+
+	var issue bdIssue
+	if err := json.Unmarshal([]byte(`{
+		"id":"bd-status-blocked",
+		"title":"parked work",
+		"status":"blocked",
+		"issue_type":"task"
+	}`), &issue); err != nil {
+		t.Fatalf("unmarshal bd row: %v", err)
+	}
+	projected := issue.toBead()
+	if projected.Status != "open" || projected.IsBlocked == nil || !*projected.IsBlocked {
+		t.Fatalf("projected bead = %+v, want folded open status with blocked marker", projected)
+	}
+
+	cache := NewCachingStoreForTest(&completeEmbeddedDepsStore{
+		beads: []Bead{projected},
+	}, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Dependency snapshots invalidate dependency-derived IsBlocked projections.
+	// A marker synthesized from bd's own status is independent of that graph and
+	// must survive, or CachedReady will count work that gc hook --claim rejects.
+	cache.ApplyDepEvent(projected.ID, nil)
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 0 {
+		t.Fatalf("CachedReady after dependency invalidation = %+v, want status-blocked bead excluded", ready)
+	}
+	got, err := cache.Get(projected.ID)
+	if err != nil {
+		t.Fatalf("Get after dependency invalidation: %v", err)
+	}
+	if got.IsBlocked == nil || !*got.IsBlocked {
+		t.Fatalf("IsBlocked after dependency invalidation = %v, want preserved true status marker", got.IsBlocked)
+	}
+}
+
+func TestCachingStoreFoldedStatusBlockedEventPreservesInvalidationProvenance(t *testing.T) {
+	t.Parallel()
+
+	var issue bdIssue
+	if err := json.Unmarshal([]byte(`{
+		"id":"bd-status-blocked-event",
+		"title":"parked work",
+		"status":"blocked",
+		"issue_type":"task"
+	}`), &issue); err != nil {
+		t.Fatalf("unmarshal bd row: %v", err)
+	}
+	projected := issue.toBead()
+	cache := NewCachingStoreForTest(&completeEmbeddedDepsStore{
+		beads: []Bead{projected},
+	}, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// CachingStore notifications serialize the public Bead shape. The folded
+	// status is "open" and blockedByStatus is deliberately off-wire, so this
+	// event must not erase provenance when IsBlocked still says true.
+	payload, err := json.Marshal(projected)
+	if err != nil {
+		t.Fatalf("marshal projected event: %v", err)
+	}
+	cache.ApplyEvent("bead.updated", payload)
+	cache.ApplyDepEvent(projected.ID, nil)
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 0 {
+		t.Fatalf("CachedReady after folded event and invalidation = %+v, want status-blocked bead excluded", ready)
+	}
+}
+
+func TestCachingStoreRawOpenEventClearsStatusBlockedProvenance(t *testing.T) {
+	t.Parallel()
+
+	var issue bdIssue
+	if err := json.Unmarshal([]byte(`{
+		"id":"bd-status-reopened",
+		"title":"resumed work",
+		"status":"blocked",
+		"issue_type":"task"
+	}`), &issue); err != nil {
+		t.Fatalf("unmarshal bd row: %v", err)
+	}
+	projected := issue.toBead()
+	cache := NewCachingStoreForTest(&completeEmbeddedDepsStore{
+		beads: []Bead{projected},
+	}, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(
+		`{"id":"bd-status-reopened","status":"open"}`,
+	))
+	cache.ApplyDepEvent(projected.ID, nil)
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 1 || ready[0].ID != projected.ID {
+		t.Fatalf("CachedReady after raw open event = %+v, want reopened bead ready", ready)
+	}
+}
+
 func TestCachingStoreApplyEventMergesProjectedIsBlocked(t *testing.T) {
 	t.Parallel()
 
@@ -3725,12 +3843,26 @@ func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 	if stats := cache.Stats(); stats.ProblemCount != 0 {
 		t.Fatalf("cache problem count = %d, want 0", stats.ProblemCount)
 	}
+	// bd's status "blocked" is itself a not-ready signal, independent of the
+	// dependency-derived is_blocked column: a worker parks work it cannot
+	// progress by setting that status, leaving the deps clean. bdIssue.blockedFlag
+	// marks the row before enrichment runs, and the enrichment must NOT clear it
+	// back to the column's dependency-only answer. Otherwise demand can count a
+	// row the claim path refuses. The unblocked and deferred rows below still pin
+	// that the projection reaches rows outside the ready set.
 	blocked, err := cache.Get("bd-blocked-status")
 	if err != nil {
 		t.Fatalf("Get(blocked status): %v", err)
 	}
-	if blocked.IsBlocked == nil || *blocked.IsBlocked {
-		t.Fatalf("blocked-status IsBlocked = %v, want false projection", blocked.IsBlocked)
+	if blocked.IsBlocked == nil || !*blocked.IsBlocked {
+		t.Fatalf("blocked-status IsBlocked = %v, want the bd status preserved as a not-ready marker", blocked.IsBlocked)
+	}
+	ready, err := cache.Get("bd-ready")
+	if err != nil {
+		t.Fatalf("Get(ready): %v", err)
+	}
+	if ready.IsBlocked == nil || *ready.IsBlocked {
+		t.Fatalf("ready IsBlocked = %v, want false projection", ready.IsBlocked)
 	}
 	deferred, err := cache.Get("bd-deferred-status")
 	if err != nil {


### PR DESCRIPTION
v1.3.x backport of the corrected #4611. Please land the main-targeted PR first.

## Summary

- preserve an explicit bd `status=blocked` as `Bead.IsBlocked` through the
  three-status projection
- exclude self-blocked beads from Ready candidates
- repeat the guard at the controller demand boundary so demand cannot count a
  row that `gc hook --claim` refuses

## Problem and scope

A routed, unassigned bead can be explicitly parked with bd status `blocked`
while its dependency-derived `is_blocked` value is false. The claim path rejects
the raw blocked status, but v1.3 projected it to Gas City status `open`, allowing
controller demand to start workers against unclaimable work.

This produces the same zero-claim respawn shape discussed in #4114, but it is a
distinct third mechanism. It is neither that issue's agent-convention
`halt_reason` case nor its dependency-blocked follow-up. This backport does not
claim to close #4114 or implement the proposed general backoff.

bd's two not-ready channels now combine with OR semantics: raw
`status=blocked` forces `IsBlocked=true` even when `is_blocked=false`; for every
other status, the optional `is_blocked` field is retained exactly.
The cache records the source of a status-derived marker internally so
dependency invalidation does not erase it; dependency-derived projections
continue to clear normally.

## Backport notes

The production behavior matches #4611. Mechanical adaptations to
`release/v1.3.0` are limited to:

- `defaultScaleCheckCounts` has no demand-map result on this line, so the
  controller regressions assert the count
- `Bead` has no `Revision` projection on this line
- `IsReadyExcludedBead` retains the release branch's inline label check rather
  than importing main-only helper refactoring

## Validation

- `go test ./internal/beads -count=1`
- `go test ./internal/config -count=1`
- `go test ./cmd/gc -count=1`
- `go vet ./cmd/gc ./internal/beads ./internal/config`
- `go build ./...`
- focused regressions include `status=blocked` together with
  `is_blocked=false`, dependency invalidation and event round-trips, plus both
  blocked spellings leaking from `Ready`

## Current v1.3 CI baseline

CI run
[`30213443745`](https://github.com/gastownhall/gascity/actions/runs/30213443745)
has two deterministic leaf failures outside this diff:

- `rest-full-2-of-16` fails in `TestGCLiveContract_BeadsAndEvents` when the
  release branch's dirty-schema bootstrap does not converge; issue #4625 tracks
  that release-branch defect.
- The live pack-registry gate fails three consecutive attempts because
  `runtime-cloudflare/pack.toml` uses
  `runtimes.cloudflare{,.command,.protocol}`, fields this v1.3 parser does not
  support.

`CI / integration` and `CI / required` are derived summaries. No
candidate-specific failure was found, and rerunning the unchanged head would
not address either baseline.
