### PR TITLE
Add optional workflow worktree release hint

### DIFF
--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -196,6 +196,7 @@ const (
 	WorkBranchMetadataKey          = "gc.work_branch"
 	WorkCommitMetadataKey          = "gc.work_commit"
 	WorkDirMetadataKey             = "gc.work_dir"
+	WorkDirReleasedAtMetadataKey   = "gc.work_dir_released_at"
 	WorkOutcomeMetadataKey         = "gc.work_outcome"
 	WorkVerificationMetadataKey    = "gc.work_verification"
 	WorkflowIDMetadataKey          = "gc.workflow_id"
@@ -222,6 +223,12 @@ const (
 //
 // The set of valid WorkOutcomeMetadataKey values and the "shipped requires a
 // commit on the branch" rule live with the close gate in cmd/gc.
+
+// WorkDirReleasedAtMetadataKey ("gc.work_dir_released_at") is a best-effort
+// RFC3339 timestamp stamped onto a workflow root by workflow-finalize when the
+// workflow's outcome is Pass and the root carries WorkDirMetadataKey. It is a
+// voluntary end-of-use hint for the borrow-veto reaper scan, never
+// authoritative on its own — a write failure here must not abort finalize.
 
 // FormulaVarPrefix is the dynamic key prefix under which formula-supplied
 // variables are written as gc.var.<name>. The suffix is open-world (a
@@ -433,6 +440,7 @@ var KnownMetadataKeys = []string{
 	WorkBranchMetadataKey,
 	WorkCommitMetadataKey,
 	WorkDirMetadataKey,
+	WorkDirReleasedAtMetadataKey,
 	WorkOutcomeMetadataKey,
 	WorkVerificationMetadataKey,
 	WorkflowIDMetadataKey,

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -841,6 +841,9 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 		}
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow head: %w", rootID, err))
 	}
+	if outcome == beadmeta.OutcomePass {
+		stampWorkDirReleasedAt(store, rootID, opts)
+	}
 	if _, err := sourceworkflow.CloseSpecSidecarsForRoot(store, rootID, sourceworkflow.WorkflowSpecSidecarClosedReason); err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing workflow spec sidecars: %w", rootID, err))
 	}
@@ -1509,6 +1512,26 @@ func findScopeBody(all []beads.Bead, rootID, scopeRef string) (beads.Bead, bool)
 
 func setOutcomeAndClose(store beads.Store, beadID, outcome string) error {
 	return updateMetadataAndClose(store, beadID, map[string]string{beadmeta.OutcomeMetadataKey: outcome})
+}
+
+// stampWorkDirReleasedAt best-effort-marks a workflow root's work directory as
+// voluntarily released once its workflow finalizes with a Pass outcome. This
+// is a non-authoritative optimization hint only — the borrow-veto reaper scan
+// remains the authoritative check before any worktree is reclaimed — so a
+// read or write failure here is traced and swallowed rather than propagated;
+// it must never abort finalize.
+func stampWorkDirReleasedAt(store beads.Store, rootID string, opts ProcessOptions) {
+	root, err := store.Get(rootID)
+	if err != nil {
+		opts.tracef("workflow-finalize root=%s work-dir-released-at-get-err=%v", rootID, err)
+		return
+	}
+	if strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) == "" {
+		return
+	}
+	if err := store.SetMetadata(rootID, beadmeta.WorkDirReleasedAtMetadataKey, time.Now().Format(time.RFC3339)); err != nil {
+		opts.tracef("workflow-finalize root=%s work-dir-released-at-set-err=%v", rootID, err)
+	}
 }
 
 // ReconcileClosedScopeMember re-reads a just-closed bead and delegates to

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -9846,6 +9847,212 @@ func TestProcessWorkflowFinalize_PurgeOnMissingDir(t *testing.T) {
 	}
 	if !result.Processed {
 		t.Fatalf("result = %+v, want processed", result)
+	}
+}
+
+// TestProcessWorkflowFinalizeStampsWorkDirReleasedAtOnPass verifies FR-6
+// (ga-vzt5pq.2): on a Pass outcome, processWorkflowFinalize best-effort
+// stamps gc.work_dir_released_at (RFC3339) onto the workflow root bead that
+// carries gc.work_dir, signaling voluntary end-of-use for the (separately
+// owned) borrow-veto reaper scan to later consult as an optimization.
+func TestProcessWorkflowFinalizeStampsWorkDirReleasedAtOnPass(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.work_dir":         "/home/jaword/projects/gascity/worktrees/demo",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	stamp := rootAfter.Metadata["gc.work_dir_released_at"]
+	if stamp == "" {
+		t.Fatalf("gc.work_dir_released_at not stamped on root bead; metadata = %+v", rootAfter.Metadata)
+	}
+	released, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		t.Fatalf("gc.work_dir_released_at = %q is not a valid RFC3339 timestamp: %v", stamp, err)
+	}
+	if age := time.Since(released); age < -2*time.Second || age > time.Minute {
+		t.Fatalf("gc.work_dir_released_at = %v is not a fresh timestamp (age = %v)", released, age)
+	}
+}
+
+// TestProcessWorkflowFinalizeDoesNotStampWorkDirReleasedAtOnFailure verifies
+// the FR-6 release hint is Pass-only: a workflow that finalizes with
+// outcome=fail must not stamp gc.work_dir_released_at, since a failed
+// workflow's worktree is not being voluntarily released -- a human or a
+// retry may still need it.
+func TestProcessWorkflowFinalizeDoesNotStampWorkDirReleasedAtOnFailure(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.work_dir":         "/home/jaword/projects/gascity/worktrees/demo",
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "cleanup",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "fail",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("result = %+v, want processed workflow-fail", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if stamp, ok := rootAfter.Metadata["gc.work_dir_released_at"]; ok {
+		t.Fatalf("gc.work_dir_released_at = %q, want unset on a failed workflow", stamp)
+	}
+}
+
+// TestProcessWorkflowFinalizeSkipsWorkDirReleasedAtWhenNoWorkDir verifies
+// the FR-6 release hint is a no-op when the root bead carries no gc.work_dir:
+// there is nothing to release, so finalize must not invent a stamp (and must
+// not error).
+func TestProcessWorkflowFinalizeSkipsWorkDirReleasedAtWhenNoWorkDir(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if stamp, ok := rootAfter.Metadata["gc.work_dir_released_at"]; ok {
+		t.Fatalf("gc.work_dir_released_at = %q, want unset when root has no gc.work_dir", stamp)
+	}
+}
+
+// failWorkDirReleaseStore injects a metadata-write failure whenever the
+// FR-6 release-hint key is written, whether via a single SetMetadata call or
+// batched through SetMetadataBatch. It lets tests prove the stamp is
+// genuinely best-effort per its exit contract: never authoritative, so its
+// own failure must not propagate.
+type failWorkDirReleaseStore struct {
+	beads.Store
+}
+
+func (s *failWorkDirReleaseStore) SetMetadata(id, key, value string) error {
+	if key == "gc.work_dir_released_at" {
+		return errors.New("injected work_dir_released_at metadata failure")
+	}
+	return s.Store.SetMetadata(id, key, value)
+}
+
+func (s *failWorkDirReleaseStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if _, ok := kvs["gc.work_dir_released_at"]; ok {
+		return errors.New("injected work_dir_released_at metadata batch failure")
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+// TestProcessWorkflowFinalizeWorkDirReleaseStampFailureDoesNotAbortFinalize
+// verifies the FR-6 stamp is best-effort per its exit contract: a failure
+// writing gc.work_dir_released_at must not fail or abort the finalize step
+// itself -- the hint is an optimization, never authoritative (the borrow-veto
+// scan in the sibling FR-1/FR-2 bead remains the sole authoritative gate).
+func TestProcessWorkflowFinalizeWorkDirReleaseStampFailureDoesNotAbortFinalize(t *testing.T) {
+	t.Parallel()
+
+	store := &failWorkDirReleaseStore{Store: beads.NewMemStore()}
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.work_dir":         "/home/jaword/projects/gascity/worktrees/demo",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v, want finalize to succeed despite injected release-hint failure", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("result = %+v, want processed workflow-pass", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if rootAfter.Status != "closed" {
+		t.Fatalf("workflow status = %q, want closed despite injected release-hint failure", rootAfter.Status)
 	}
 }
 

--- a/release-gates/ga-plwera-worktree-release-hint-gate.md
+++ b/release-gates/ga-plwera-worktree-release-hint-gate.md
@@ -1,0 +1,47 @@
+# Release Gate: optional worktree release hint
+
+Deploy bead: ga-plwera
+Source bead: ga-vzt5pq.2
+Reviewed source: fe0d831ce9df79bc811fd117cd0815b04b72e2c0
+Source branch: builder/ga-vzt5pq.2 (provenance only)
+
+## Summary
+
+This single-bead release adds an optional `gc.work_dir_released_at` metadata hint
+when `workflow-finalize` completes with a Pass outcome and the workflow root
+carries `gc.work_dir`. The hint is best-effort and non-authoritative; the
+borrow-veto reaper scan remains the safety gate before any worktree is reclaimed.
+
+`docs/PROJECT_MANIFEST.md` is not present in this gascity worktree or rig root;
+the gate uses the deployer prompt's seven release criteria.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git fetch origin main` succeeded. `git merge-tree --write-tree origin/main fe0d831ce9df79bc811fd117cd0815b04b72e2c0` exited 0 and produced tree `fad20f8caf5afb079212f8d4e04e05bfa08ae2b9`, so the reviewed source merges with current `origin/main` without conflicts. No self-rebase was attempted. |
+| 1 | Review PASS present | PASS | Deploy bead `ga-plwera` says reviewer `gascity/reviewer` reviewed and PASSED. Source bead `ga-vzt5pq.2` notes contain `REVIEWER VERDICT: PASS`. Review step `ga-laiw55` is closed with "Review complete" and records build/vet/test evidence. |
+| 2 | Acceptance criteria met | PASS | The reviewed diff from merge base `d5fbb58c983251bfe9df8c53be1b86ab6bef6408` to `fe0d831c` touches exactly `internal/beadmeta/keys.go`, `internal/dispatch/runtime.go`, and `internal/dispatch/runtime_test.go`. It adds `beadmeta.WorkDirReleasedAtMetadataKey`, registers it in `KnownMetadataKeys`, stamps it only after `workflow-finalize` resolves `OutcomePass`, no-ops when root `gc.work_dir` is empty, and swallows/traces read/write errors. |
+| 3 | Tests pass | PASS | `go build ./...` passed. `go vet ./...` passed. `go test -count=1 ./internal/dispatch/... ./internal/beadmeta/...` passed. Smoke `go test -count=1 -v ./internal/dispatch -run '^TestProcessWorkflowFinalize(StampsWorkDirReleasedAtOnPass|DoesNotStampWorkDirReleasedAtOnFailure|SkipsWorkDirReleasedAtWhenNoWorkDir|WorkDirReleaseStampFailureDoesNotAbortFinalize)$'` passed all four new tests. `gofmt -l internal/beadmeta/keys.go internal/dispatch/runtime.go internal/dispatch/runtime_test.go` produced no output. `git diff --check d5fbb58c983251bfe9df8c53be1b86ab6bef6408..fe0d831ce9df79bc811fd117cd0815b04b72e2c0` produced no output. Broad `make test-fast-parallel` was run and failed only in `cmd/gc` tests outside the diff: deterministic main-baseline `TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior/default` (tracked as `ga-y4se3w`, reproduced alone) and contention flake `TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity` (tracked as `ga-oe89yz` / `ga-1ah24y`, passed alone). No changed-package or feature-smoke test failed. |
+| 4 | No high-severity review findings open | PASS | Source bead notes record "OWASP SECURITY WALK - no findings" and no minor blocking observations. `bd search ga-vzt5pq.2` returned only the deploy bead. No linked HIGH finding bead is open for this change. |
+| 5 | Final branch is clean | PASS | Reviewed source was clean at `fe0d831c` before writing this gate. After committing the gate file, `git status --porcelain=v1` produced no output and `core.hooksPath` was `.githooks`. |
+| 7 | Single feature theme | PASS | The commit set is two commits under one subsystem theme: workflow-finalize emits a non-authoritative worktree release hint and tests its Pass-only/best-effort semantics. It does not include independent user-facing behavior or unrelated packages. |
+
+## Test Runs
+
+| Command | Result |
+|---|---|
+| `go build ./...` | PASS |
+| `go vet ./...` | PASS |
+| `go test -count=1 ./internal/dispatch/... ./internal/beadmeta/...` | PASS |
+| `go test -count=1 -v ./internal/dispatch -run '^TestProcessWorkflowFinalize(StampsWorkDirReleasedAtOnPass|DoesNotStampWorkDirReleasedAtOnFailure|SkipsWorkDirReleasedAtWhenNoWorkDir|WorkDirReleaseStampFailureDoesNotAbortFinalize)$'` | PASS |
+| `gofmt -l internal/beadmeta/keys.go internal/dispatch/runtime.go internal/dispatch/runtime_test.go` | PASS, no output |
+| `git diff --check d5fbb58c983251bfe9df8c53be1b86ab6bef6408..fe0d831ce9df79bc811fd117cd0815b04b72e2c0` | PASS, no output |
+| `make test-fast-parallel` | Baseline exception: failed only in known unrelated `cmd/gc` tests tracked as `ga-y4se3w`, `ga-oe89yz`, and `ga-1ah24y`; changed-package tests and feature smoke passed. |
+
+## Reviewed Commits
+
+| Commit | Purpose |
+|---|---|
+| bcf686889a7f34140a27783ecad9187bb6824338 | RED tests for the workflow-finalize worktree release hint. |
+| fe0d831ce9df79bc811fd117cd0815b04b72e2c0 | GREEN implementation for `gc.work_dir_released_at`. |


### PR DESCRIPTION
## What this changes

Workflow finalization now records a best-effort `gc.work_dir_released_at` timestamp on a workflow root when the workflow finishes with a Pass outcome and the root already carries `gc.work_dir`. Operators and later cleanup code can use this as a voluntary end-of-use hint without treating a closed workflow as proof that its worktree is safe to reclaim.

The change is intentionally conservative: the new metadata is only a hint, failures to write it are traced and swallowed, and the borrow-veto reaper scan remains the authority before any worktree is reclaimed.

## Review notes

- Adds `beadmeta.WorkDirReleasedAtMetadataKey` for `gc.work_dir_released_at` and registers it in the known metadata key list.
- Stamps the hint from `workflow-finalize` only on Pass outcomes.
- Leaves failed workflows and roots without `gc.work_dir` untouched.
- Does not change reaper behavior, bead schema, control kinds, or dispatch contracts.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./internal/dispatch/... ./internal/beadmeta/...`
- [x] `go test -count=1 -v ./internal/dispatch -run '^TestProcessWorkflowFinalize(StampsWorkDirReleasedAtOnPass|DoesNotStampWorkDirReleasedAtOnFailure|SkipsWorkDirReleasedAtWhenNoWorkDir|WorkDirReleaseStampFailureDoesNotAbortFinalize)$'`
- [x] `gofmt -l internal/beadmeta/keys.go internal/dispatch/runtime.go internal/dispatch/runtime_test.go`
- [x] `git diff --check d5fbb58c983251bfe9df8c53be1b86ab6bef6408..fe0d831ce9df79bc811fd117cd0815b04b72e2c0`
- [x] Release gate: [`release-gates/ga-plwera-worktree-release-hint-gate.md`](release-gates/ga-plwera-worktree-release-hint-gate.md)

Local `make test-fast-parallel` was attempted during the gate and again through the normal pre-push hook. It is blocked in this live worktree by existing `cmd/gc` baseline failures outside this diff; the gate file records the exact failing tests and tracking beads.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4492 — adds an optional, non-authoritative gc.work_dir_released_at end-of-use hint stamped by workflow-finalize on Pass outcomes, a small supporting step toward the explicit end-of-use signaling that issue describes; it does not relocate do-work's worktree creation, add the borrow veto, or fix the enumerated reaper defects, which remain open

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->