### PR TITLE
Resolve full dotted bead IDs in push guard branches

### DIFF
--- a/release-gates/ga-hzy30q-push-ownership-guard-gate.md
+++ b/release-gates/ga-hzy30q-push-ownership-guard-gate.md
@@ -1,0 +1,40 @@
+# Release Gate: push-ownership guard multi-level bead IDs
+
+- Deploy bead: `ga-hzy30q`
+- Source bead: `ga-nnjcuc.2`
+- Reviewed commit: `7af0671436ba10f2e0f275e3ef627393806651ef`
+- Deploy branch: `deploy/ga-hzy30q-gate`
+- Evaluated: 2026-07-24
+- Gate source: deployer prompt release-gate table. `docs/PROJECT_MANIFEST.md` was not present in this checkout.
+
+## Summary
+
+PASS. This is a single-theme shell guard fix. It changes only the push ownership guard and its shell test harness so branch names containing repeatable dotted bead IDs, such as `ga-o3ko1j.4.3`, resolve the full bead ID instead of truncating to `ga-o3ko1j.4`.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git fetch origin main`; `git merge-tree --write-tree origin/main 7af0671436ba10f2e0f275e3ef627393806651ef` returned tree `5179bfeb0cd424b4a6381c18bfad45b8758ec7d7`; `git diff --check origin/main...7af0671436ba10f2e0f275e3ef627393806651ef` produced no output. |
+| 1 | Review PASS present | PASS | Deploy bead `ga-hzy30q` records reviewer PASS for source bead `ga-nnjcuc.2`; source notes contain `REVIEWER VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | Commit set is the expected red/green pair: `d877d93e5` and `7af067143`. Diff is limited to `scripts/push-ownership-guard.sh` and `scripts/test-push-ownership-guard.sh`; no `cmd/gc` or dead-assignee fallback files are included. Targeted guard suite includes the regression `resolve/branch-resolves-full-multi-level-subbead-id`. |
+| 3 | Tests pass | PASS | `bash scripts/test-push-ownership-guard.sh` passed `20/20`; `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh` passed with ShellCheck 0.11.0; `go build ./...` passed; `go vet ./...` passed; `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | `bd list --status open --limit 0 | rg -i -- 'ga-hzy30q|ga-nnjcuc\\.2|HIGH|request-changes|security'` returned only sling helper bead `ga-pqt5hs`; no open HIGH/request-changes finding was found. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` returned only `## deploy/ga-hzy30q-gate`. The gate file is committed as the final branch tip before push. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: `scripts/push-ownership-guard.sh` plus its test harness. Removing this fix would only affect branch-to-bead ID resolution for push guard checks. |
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main 7af0671436ba10f2e0f275e3ef627393806651ef
+git diff --check origin/main...7af0671436ba10f2e0f275e3ef627393806651ef
+git log --oneline --reverse bac288647e0bbbbe2e68bdbe588709eb2827f5ee..7af0671436ba10f2e0f275e3ef627393806651ef
+git diff --stat bac288647e0bbbbe2e68bdbe588709eb2827f5ee..7af0671436ba10f2e0f275e3ef627393806651ef
+bash scripts/test-push-ownership-guard.sh
+shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go build ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go vet ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+bd list --status open --limit 0 | rg -i -- 'ga-hzy30q|ga-nnjcuc\.2|HIGH|request-changes|security'
+```

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -67,12 +67,17 @@ _pog_timeout() {
 
 # _pog_resolve_bead_id: prints the bead id this push should be checked
 # against; prints nothing if none can be resolved. Resolution order:
-#   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)? —
-#      the bead's own id format, extended with an optional sub-bead suffix
-#      because this repo's real branch convention is
-#      builder/<bead-id>-<slug> and sub-beads (e.g. ga-fip9ps.1) are
-#      routine; the literal 6-char-only pattern would misresolve to the
-#      parent bead on a sub-bead's own branch.
+#   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)* —
+#      the bead's own id format, extended with zero or more repeated
+#      sub-bead suffixes because this repo's real branch convention is
+#      builder/<bead-id>-<slug> and sub-beads are routine at any nesting
+#      depth: a single-level sub-bead (e.g. ga-fip9ps.1) as well as a
+#      grandchild (e.g. ga-o3ko1j.4.3). The suffix group must repeat (`*`),
+#      not just appear once (`?`) — a single optional group truncates a
+#      grandchild id after its first dotted segment, misresolving to the
+#      wrong (and possibly closed) parent/child bead instead of the actual
+#      grandchild bead the branch is for. The literal 6-char-only pattern
+#      would misresolve to the root bead on any sub-bead's own branch.
 #   2. Falls back to this session's single in-progress assignment
 #      (bd list --assignee="$GC_AGENT" --status=in_progress --json) when
 #      the branch name doesn't match.
@@ -107,7 +112,7 @@ _pog_resolve_bead_id() {
 
     local branch_id=""
     if [[ -n "$branch" ]]; then
-        branch_id="$(grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)?' <<<"$branch" | head -1 || true)"
+        branch_id="$(grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)*' <<<"$branch" | head -1 || true)"
     fi
 
     local assignee_id=""

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -344,6 +344,30 @@ test_bead_id_branch_wins_and_warns_on_disagreement() {
     rm -rf "$repo" "$fbd"
 }
 
+# Regression: a branch encoding a multi-level sub-bead id (a grandchild bead,
+# e.g. ga-o3ko1j.4.3) must resolve to the FULL id, not truncate after the
+# first dotted segment. Caught live: builder/ga-o3ko1j.4.3's push resolved to
+# ga-o3ko1j.4 (a different, already-closed parent bead), blocking a healthy
+# in-progress push as "stale". Forces the assignee-fallback to disagree so
+# the resolver's warning names the id it actually picked — the only
+# observable signal for resolution output (see the sibling
+# branch-wins-warns-on-disagreement test above for the same technique).
+test_bead_id_branch_resolves_multi_level_subbead_id() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-o3ko1j.4.3-dead-assignee-fallback")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    printf '[{"id":"ga-other01.9"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-o3ko1j.4.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]] && grep -q "ga-o3ko1j.4.3" <<<"$out"; then
+        record_pass "resolve/branch-resolves-full-multi-level-subbead-id (rc=0, full id ga-o3ko1j.4.3 named, not truncated to ga-o3ko1j.4)"
+    else
+        record_fail "resolve/branch-resolves-full-multi-level-subbead-id" "expected rc=0 with full id ga-o3ko1j.4.3 in the resolver's warning, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
 test_bead_id_fallback_used_when_branch_no_match() {
     local repo fbd out rc
     repo="$(new_repo_with_branch "chore/unrelated-cleanup")"
@@ -543,6 +567,7 @@ run_all() {
     test_block_on_bd_unreachable
     test_block_on_bd_timeout
     test_bead_id_branch_wins_and_warns_on_disagreement
+    test_bead_id_branch_resolves_multi_level_subbead_id
     test_bead_id_fallback_used_when_branch_no_match
     test_allow_when_no_bead_id_resolvable
     test_fallback_cannot_detect_staleness_after_status_leaves_in_progress


### PR DESCRIPTION
## What this changes

The Git pre-push ownership guard now resolves full dotted Gas City bead IDs from branch names, including multi-level IDs such as `ga-o3ko1j.4.3`. This prevents the guard from truncating the branch to an ancestor bead ID and incorrectly blocking a valid push as stale or misassigned.

The change is limited to branch-name parsing in the shell guard and its regression tests. It does not change bead claims, routing rules, or the `gc` command surface.

## Review notes

- The behavior change is in `scripts/push-ownership-guard.sh`.
- The regression coverage is in `scripts/test-push-ownership-guard.sh`.
- This PR intentionally excludes the unrelated dead-assignee pool-wake fallback that was split into a separate deploy.

## Test plan

- [x] `bash scripts/test-push-ownership-guard.sh`
- [x] `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-hzy30q-push-ownership-guard-gate.md`](release-gates/ga-hzy30q-push-ownership-guard-gate.md)