### PR TITLE
Write stale worktree markers from the prune path

### DIFF
--- a/cmd/gc/session_worktree_prune.go
+++ b/cmd/gc/session_worktree_prune.go
@@ -20,6 +20,7 @@ import (
 // without standing up real git worktrees.
 type gitProbe interface {
 	IsRepo() bool
+	CurrentBranch() (string, error)
 	HasUncommittedWork() bool
 	HasUnpushedCommitsResult() (bool, error)
 	HasStashesResult() (bool, error)
@@ -29,6 +30,21 @@ type gitProbe interface {
 // newGitProbe returns a gitProbe scoped to the given directory. Indirected
 // through a package-level var so tests can stub the git invocations.
 var newGitProbe = func(workDir string) gitProbe { return git.New(workDir) }
+
+// writeWorktreeStaleMarker records why workerDir was left in place instead of
+// pruned, so cleanupClosedBeadAgentHomeWorktrees (agent_home_worktree_cleanup.go)
+// can later detect when it's safe to reclaim. Best-effort: write failures are
+// logged but never alter the caller's control flow.
+func writeWorktreeStaleMarker(gp gitProbe, workerDir, reason string, stderr io.Writer) {
+	branch, err := gp.CurrentBranch()
+	if err != nil {
+		branch = ""
+	}
+	content := fmt.Sprintf("branch=%s\nreason=%s\n", branch, reason)
+	if err := os.WriteFile(filepath.Join(workerDir, worktreeStaleFileName), []byte(content), 0o644); err != nil {
+		fmt.Fprintf(stderr, "session reconciler: writing %s marker for %s: %v\n", worktreeStaleFileName, workerDir, err) //nolint:errcheck
+	}
+}
 
 // pruneAgentHomeWorktreeIfSafe removes the worktree at the closed session's
 // worker_dir, after applying the same safety gates as doctor's
@@ -80,6 +96,7 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	}
 	if gp.HasUncommittedWork() {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has uncommitted changes\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "uncommitted-work", stderr)
 		return false
 	}
 	hasUnpushed, err := gp.HasUnpushedCommitsResult()
@@ -89,6 +106,7 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	}
 	if hasUnpushed {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has unpushed commits\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "unpushed-commits", stderr)
 		return false
 	}
 	hasStashes, err := gp.HasStashesResult()
@@ -98,6 +116,7 @@ func pruneAgentHomeWorktreeIfSafe(session beads.Bead, cityPath string, cfg *conf
 	}
 	if hasStashes {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has stashed work\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "stashed-work", stderr)
 		return false
 	}
 
@@ -152,6 +171,7 @@ func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg
 	}
 	if gp.HasUncommittedWork() {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has uncommitted changes\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "uncommitted-work", stderr)
 		return
 	}
 	hasUnpushed, err := gp.HasUnpushedCommitsResult()
@@ -161,6 +181,7 @@ func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg
 	}
 	if hasUnpushed {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has unpushed commits\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "unpushed-commits", stderr)
 		return
 	}
 	hasStashes, err := gp.HasStashesResult()
@@ -170,6 +191,7 @@ func pruneAgentHomeWorktreeIfSafeInfo(info sessionpkg.Info, cityPath string, cfg
 	}
 	if hasStashes {
 		fmt.Fprintf(stderr, "session reconciler: not pruning worker_dir %s: has stashed work\n", workerDir) //nolint:errcheck
+		writeWorktreeStaleMarker(gp, workerDir, "stashed-work", stderr)
 		return
 	}
 

--- a/cmd/gc/session_worktree_prune_info_test.go
+++ b/cmd/gc/session_worktree_prune_info_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// sessionInfo returns a session.Info mirroring fx.sessionBead(), for
+// exercising the session.Info form of the worker_dir auto-prune path
+// (pruneAgentHomeWorktreeIfSafeInfo) against the same fixture.
+func (fx *pruneTestFixture) sessionInfo() sessionpkg.Info {
+	return sessionpkg.Info{
+		ID:                  "session-1",
+		WorkerDir:           fx.workerDir,
+		Template:            "demo/polecat",
+		SessionNameMetadata: "demo/polecat-3",
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_DisabledByConfig(t *testing.T) {
+	fx := newPruneFixture(t)
+	off := false
+	fx.cfg.Daemon.AutoPruneWorkerDir = &off
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called while config disabled prune")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_NoWorkerDir(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	info.WorkerDir = ""
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called with no worker_dir")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_LegacyWorkDirKey(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	info.WorkerDir = ""
+	info.WorkDir = fx.workerDir
+
+	probe := &fakeGitProbe{isRepo: true}
+	fx.setProbe(fx.workerDir, probe)
+	rigProbe := &fakeGitProbe{isRepo: true}
+	fx.setProbe(fx.rigRoot, rigProbe)
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if !rigProbe.removeInvoked || rigProbe.removedPath != fx.workerDir || !rigProbe.removedForce {
+		t.Fatalf("expected WorktreeRemove(%q, true) on rig root; got invoked=%v path=%q force=%v",
+			fx.workerDir, rigProbe.removeInvoked, rigProbe.removedPath, rigProbe.removedForce)
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_OutsideWorktreesTree(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	outside := filepath.Join(fx.cityPath, "elsewhere", "polecat-3")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, ".git"), []byte("gitdir: /fake\n"), 0o644); err != nil {
+		t.Fatalf("write .git: %v", err)
+	}
+	info.WorkerDir = outside
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called for path outside .gc/worktrees")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RejectsWorktreesRoot(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	wtRoot := filepath.Join(fx.cityPath, ".gc", "worktrees")
+	if err := os.WriteFile(filepath.Join(wtRoot, ".git"), []byte("gitdir: /fake\n"), 0o644); err != nil {
+		t.Fatalf("write .git on wtRoot: %v", err)
+	}
+	info.WorkerDir = wtRoot
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called for .gc/worktrees root itself")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RelativeWorkerDir(t *testing.T) {
+	fx := newPruneFixture(t)
+	info := fx.sessionInfo()
+	info.WorkerDir = "relative/path"
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(info, fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called for relative worker_dir")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_MissingDotGit(t *testing.T) {
+	fx := newPruneFixture(t)
+	if err := os.Remove(filepath.Join(fx.workerDir, ".git")); err != nil {
+		t.Fatalf("remove .git: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if rigProbe := fx.probesByWD[fx.rigRoot]; rigProbe != nil && rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove called with missing .git pointer")
+	}
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_NotARepo(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: false})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HasUncommitted(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUncommitted: true, currentBranch: "builder/ga-abc123"})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "uncommitted changes") {
+		t.Errorf("expected uncommitted-reason log; got %q", stderr.String())
+	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-abc123", "uncommitted-work")
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HasUnpushed(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUnpushed: true, currentBranch: "builder/ga-def456"})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "unpushed commits") {
+		t.Errorf("expected unpushed-reason log; got %q", stderr.String())
+	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-def456", "unpushed-commits")
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_UnpushedProbeError(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, unpushedErr: errors.New("boom")})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "unpushed probe failed") {
+		t.Errorf("expected unpushed-error log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HasStashes(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasStashes: true, currentBranch: "builder/ga-ghi789"})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "stashed work") {
+		t.Errorf("expected stashes-reason log; got %q", stderr.String())
+	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-ghi789", "stashed-work")
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_StashProbeError(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, stashesErr: errors.New("boom")})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "stash probe failed") {
+		t.Errorf("expected stash-error log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RigPathUnresolved(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.cfg.Rigs = nil
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "rig path unresolved") {
+		t.Errorf("expected rig-unresolved log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_RemoveFails(t *testing.T) {
+	fx := newPruneFixture(t)
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true})
+	fx.setProbe(fx.rigRoot, &fakeGitProbe{
+		isRepo:         true,
+		worktreeRemove: func(_ string, _ bool) error { return errors.New("locked") },
+	})
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if !strings.Contains(stderr.String(), "pruning worker_dir") || !strings.Contains(stderr.String(), "locked") {
+		t.Errorf("expected removal-error log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_HappyPath(t *testing.T) {
+	fx := newPruneFixture(t)
+	wdProbe := &fakeGitProbe{isRepo: true}
+	rigProbe := &fakeGitProbe{isRepo: true}
+	fx.setProbe(fx.workerDir, wdProbe)
+	fx.setProbe(fx.rigRoot, rigProbe)
+
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, fx.cfg, &stderr)
+	if wdProbe.removeInvoked {
+		t.Error("WorktreeRemove invoked on worker_dir; should be invoked on rig root only")
+	}
+	if !rigProbe.removeInvoked {
+		t.Fatal("WorktreeRemove not invoked on rig root")
+	}
+	if rigProbe.removedPath != fx.workerDir {
+		t.Errorf("WorktreeRemove path = %q, want %q", rigProbe.removedPath, fx.workerDir)
+	}
+	if !rigProbe.removedForce {
+		t.Error("WorktreeRemove force flag = false, want true")
+	}
+	if !strings.Contains(stderr.String(), "pruned worker_dir") {
+		t.Errorf("expected success log; got %q", stderr.String())
+	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
+}
+
+func TestPruneAgentHomeWorktreeIfSafeInfo_NilConfig(t *testing.T) {
+	fx := newPruneFixture(t)
+	var stderr bytes.Buffer
+	pruneAgentHomeWorktreeIfSafeInfo(fx.sessionInfo(), fx.cityPath, nil, &stderr)
+}
+
+func TestLookupRigRootForSessionInfo(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "demo", Path: "/x/demo"},
+			{Name: "other", Path: "/x/other"},
+		},
+	}
+	cases := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{"qualified match", "demo/polecat", "/x/demo"},
+		{"other rig", "other/refinery", "/x/other"},
+		{"unqualified", "polecat", ""},
+		{"unknown rig", "missing/polecat", ""},
+		{"empty", "", ""},
+		{"leading slash", "/polecat", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info := sessionpkg.Info{Template: c.template}
+			got := lookupRigRootForSessionInfo(info, cfg)
+			if got != c.want {
+				t.Errorf("lookupRigRootForSessionInfo(%q) = %q, want %q", c.template, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_worktree_prune_test.go
+++ b/cmd/gc/session_worktree_prune_test.go
@@ -17,19 +17,24 @@ import (
 // records the (path, force) of every WorktreeRemove invocation so tests
 // can assert which directory the removal targeted.
 type fakeGitProbe struct {
-	isRepo         bool
-	hasUncommitted bool
-	hasUnpushed    bool
-	unpushedErr    error
-	hasStashes     bool
-	stashesErr     error
-	worktreeRemove func(path string, force bool) error
-	removedPath    string
-	removedForce   bool
-	removeInvoked  bool
+	isRepo           bool
+	currentBranch    string
+	currentBranchErr error
+	hasUncommitted   bool
+	hasUnpushed      bool
+	unpushedErr      error
+	hasStashes       bool
+	stashesErr       error
+	worktreeRemove   func(path string, force bool) error
+	removedPath      string
+	removedForce     bool
+	removeInvoked    bool
 }
 
-func (f *fakeGitProbe) IsRepo() bool             { return f.isRepo }
+func (f *fakeGitProbe) IsRepo() bool { return f.isRepo }
+func (f *fakeGitProbe) CurrentBranch() (string, error) {
+	return f.currentBranch, f.currentBranchErr
+}
 func (f *fakeGitProbe) HasUncommittedWork() bool { return f.hasUncommitted }
 func (f *fakeGitProbe) HasUnpushedCommitsResult() (bool, error) {
 	return f.hasUnpushed, f.unpushedErr
@@ -43,6 +48,35 @@ func (f *fakeGitProbe) WorktreeRemove(path string, force bool) error {
 		return f.worktreeRemove(path, force)
 	}
 	return nil
+}
+
+// assertWorktreeStaleMarker fails the test unless workerDir contains a
+// .worktree-stale marker recording the given branch and reason. Shared by
+// both the raw and session.Info test forms.
+func assertWorktreeStaleMarker(t *testing.T, workerDir, wantBranch, wantReason string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(workerDir, worktreeStaleFileName))
+	if err != nil {
+		t.Fatalf("reading %s marker: %v", worktreeStaleFileName, err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "branch="+wantBranch) {
+		t.Errorf("marker content = %q, want to contain %q", content, "branch="+wantBranch)
+	}
+	if !strings.Contains(content, "reason="+wantReason) {
+		t.Errorf("marker content = %q, want to contain %q", content, "reason="+wantReason)
+	}
+}
+
+// assertNoWorktreeStaleMarker fails the test if workerDir contains a
+// .worktree-stale marker.
+func assertNoWorktreeStaleMarker(t *testing.T, workerDir string) {
+	t.Helper()
+	if _, err := os.ReadFile(filepath.Join(workerDir, worktreeStaleFileName)); err == nil {
+		t.Errorf("%s marker unexpectedly present in %s", worktreeStaleFileName, workerDir)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("checking %s marker: %v", worktreeStaleFileName, err)
+	}
 }
 
 // pruneTestFixture wires a temp city directory, a writable worker_dir
@@ -166,6 +200,7 @@ func TestPruneAgentHomeWorktreeIfSafe_LegacyWorkDirKey(t *testing.T) {
 		t.Fatalf("expected WorktreeRemove(%q, true) on rig root; got invoked=%v path=%q force=%v",
 			fx.workerDir, rigProbe.removeInvoked, rigProbe.removedPath, rigProbe.removedForce)
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_OutsideWorktreesTree(t *testing.T) {
@@ -232,11 +267,12 @@ func TestPruneAgentHomeWorktreeIfSafe_NotARepo(t *testing.T) {
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
 		t.Fatal("prune returned true when IsRepo=false")
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HasUncommitted(t *testing.T) {
 	fx := newPruneFixture(t)
-	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUncommitted: true})
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUncommitted: true, currentBranch: "builder/ga-abc123"})
 
 	var stderr bytes.Buffer
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
@@ -245,11 +281,12 @@ func TestPruneAgentHomeWorktreeIfSafe_HasUncommitted(t *testing.T) {
 	if !strings.Contains(stderr.String(), "uncommitted changes") {
 		t.Errorf("expected uncommitted-reason log; got %q", stderr.String())
 	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-abc123", "uncommitted-work")
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HasUnpushed(t *testing.T) {
 	fx := newPruneFixture(t)
-	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUnpushed: true})
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasUnpushed: true, currentBranch: "builder/ga-def456"})
 
 	var stderr bytes.Buffer
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
@@ -258,6 +295,7 @@ func TestPruneAgentHomeWorktreeIfSafe_HasUnpushed(t *testing.T) {
 	if !strings.Contains(stderr.String(), "unpushed commits") {
 		t.Errorf("expected unpushed-reason log; got %q", stderr.String())
 	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-def456", "unpushed-commits")
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_UnpushedProbeError(t *testing.T) {
@@ -271,11 +309,12 @@ func TestPruneAgentHomeWorktreeIfSafe_UnpushedProbeError(t *testing.T) {
 	if !strings.Contains(stderr.String(), "unpushed probe failed") {
 		t.Errorf("expected unpushed-error log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HasStashes(t *testing.T) {
 	fx := newPruneFixture(t)
-	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasStashes: true})
+	fx.setProbe(fx.workerDir, &fakeGitProbe{isRepo: true, hasStashes: true, currentBranch: "builder/ga-ghi789"})
 
 	var stderr bytes.Buffer
 	if pruneAgentHomeWorktreeIfSafe(fx.sessionBead(), fx.cityPath, fx.cfg, &stderr) {
@@ -284,6 +323,7 @@ func TestPruneAgentHomeWorktreeIfSafe_HasStashes(t *testing.T) {
 	if !strings.Contains(stderr.String(), "stashed work") {
 		t.Errorf("expected stashes-reason log; got %q", stderr.String())
 	}
+	assertWorktreeStaleMarker(t, fx.workerDir, "builder/ga-ghi789", "stashed-work")
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_StashProbeError(t *testing.T) {
@@ -297,6 +337,7 @@ func TestPruneAgentHomeWorktreeIfSafe_StashProbeError(t *testing.T) {
 	if !strings.Contains(stderr.String(), "stash probe failed") {
 		t.Errorf("expected stash-error log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_RigPathUnresolved(t *testing.T) {
@@ -311,6 +352,7 @@ func TestPruneAgentHomeWorktreeIfSafe_RigPathUnresolved(t *testing.T) {
 	if !strings.Contains(stderr.String(), "rig path unresolved") {
 		t.Errorf("expected rig-unresolved log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_RigPathEmpty(t *testing.T) {
@@ -325,6 +367,7 @@ func TestPruneAgentHomeWorktreeIfSafe_RigPathEmpty(t *testing.T) {
 	if !strings.Contains(stderr.String(), "rig path unresolved") {
 		t.Errorf("expected rig-unresolved log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_RemoveFails(t *testing.T) {
@@ -342,6 +385,7 @@ func TestPruneAgentHomeWorktreeIfSafe_RemoveFails(t *testing.T) {
 	if !strings.Contains(stderr.String(), "pruning worker_dir") || !strings.Contains(stderr.String(), "locked") {
 		t.Errorf("expected removal-error log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_HappyPath(t *testing.T) {
@@ -370,6 +414,7 @@ func TestPruneAgentHomeWorktreeIfSafe_HappyPath(t *testing.T) {
 	if !strings.Contains(stderr.String(), "pruned worker_dir") {
 		t.Errorf("expected success log; got %q", stderr.String())
 	}
+	assertNoWorktreeStaleMarker(t, fx.workerDir)
 }
 
 func TestPruneAgentHomeWorktreeIfSafe_NilConfig(t *testing.T) {

--- a/release-gates/ga-8mode6-worktree-stale-producer-gate.md
+++ b/release-gates/ga-8mode6-worktree-stale-producer-gate.md
@@ -1,0 +1,44 @@
+# Release Gate: `.worktree-stale` producer
+
+- Deploy bead: `ga-8mode6`
+- Source bead: `ga-vzt5pq.3`
+- Reviewed commit: `4ca644542590dcede58955dfb2c18bb8d19b4e09`
+- Deploy branch: `deploy/ga-8mode6-gate`
+- Evaluated: 2026-07-24
+- Gate source: deployer prompt release-gate table. `docs/PROJECT_MANIFEST.md` was not present in this checkout.
+
+## Summary
+
+PASS. This change wires the existing agent-home worktree cleanup marker into the prune path: when an agent-home worktree is confirmed dirty, Gas City writes `.worktree-stale` with the current branch and reason so the existing cleanup consumer can revisit it later.
+
+The candidate is unchanged from the reviewed SHA. A prior gate attempt failed under fast-suite contention on a `city_runtime_test.go` timeout; builder re-ran the exact failing test/shard three times clean, and this gate's bounded rerun also produced a clean fast-suite pass.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git fetch origin main`; `git merge-tree --write-tree origin/main 4ca644542590dcede58955dfb2c18bb8d19b4e09` returned tree `48ac259dd904133abcb8aa2c606f7917f2e1099d`; `git diff --check origin/main...4ca644542590dcede58955dfb2c18bb8d19b4e09` produced no output. |
+| 1 | Review PASS present | PASS | Deploy bead `ga-8mode6` records reviewer PASS for source bead `ga-vzt5pq.3`; source notes contain `REVIEW VERDICT: PASS`. Builder retry notes routed the unchanged reviewed commit back to deploy after reproducing the prior gate failure as a timing-sensitive flake. |
+| 2 | Acceptance criteria met | PASS | Commit set is the expected red/green pair: `890b6bd6d` and `4ca644542`. Diff is limited to `cmd/gc/session_worktree_prune.go`, `cmd/gc/session_worktree_prune_test.go`, and `cmd/gc/session_worktree_prune_info_test.go`. Focused tests verify marker writes for uncommitted, unpushed, and stashed work, plus marker absence on no-op/error paths. |
+| 3 | Tests pass | PASS | Focused `go test ./cmd/gc -run 'TestPruneAgentHomeWorktreeIfSafe|WorktreeStale|CurrentBranch|TestCleanupClosedBeadAgentHomeWorktrees_DetachesToMainNotCurrentBranch' -count=1 -v` passed. `go build ./...` passed. `go vet ./...` passed. Initial `make test-fast-parallel` failed on unrelated `TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity`; isolated single-test retry passed, exact shard 4/6 retry passed, and bounded full-suite rerun of `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | `bd list --status open --limit 0 | rg -i -- 'ga-8mode6|ga-vzt5pq\\.3|HIGH|request-changes|security'` returned only sling helper beads `ga-htgtnv` and `ga-n2ch96`; no open HIGH/request-changes finding was found. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` returned only `## deploy/ga-8mode6-gate`. The gate file is committed as the final branch tip before push. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: the session worktree prune marker producer and its tests. It does not alter the cleanup consumer or unrelated runtime behavior. |
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main 4ca644542590dcede58955dfb2c18bb8d19b4e09
+git diff --check origin/main...4ca644542590dcede58955dfb2c18bb8d19b4e09
+git log --oneline --reverse 97e1cb5272a41f21efd7e137a143c35cf34cc713..4ca644542590dcede58955dfb2c18bb8d19b4e09
+git diff --stat 97e1cb5272a41f21efd7e137a143c35cf34cc713..4ca644542590dcede58955dfb2c18bb8d19b4e09
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./cmd/gc -run 'TestPruneAgentHomeWorktreeIfSafe|WorktreeStale|CurrentBranch|TestCleanupClosedBeadAgentHomeWorktrees_DetachesToMainNotCurrentBranch' -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go build ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go vet ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./cmd/gc -run '^TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity$' -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GC_FAST_UNIT=1 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 4 6
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+bd list --status open --limit 0 | rg -i -- 'ga-8mode6|ga-vzt5pq\.3|HIGH|request-changes|security'
+```


### PR DESCRIPTION
## What this changes

When Gas City declines to prune an agent-home worktree because it is confirmed dirty, it now writes the existing `.worktree-stale` marker with the current branch and reason. That gives the existing cleanup path a concrete signal to revisit the worktree later instead of leaving the marker consumer unreachable.

The marker write is best-effort and advisory: failures are logged without changing prune control flow, and the cleanup consumer still revalidates the worktree before detaching anything.

## Review notes

- The producer is in `cmd/gc/session_worktree_prune.go`.
- Raw and info-form coverage lives in `cmd/gc/session_worktree_prune_test.go` and `cmd/gc/session_worktree_prune_info_test.go`.
- The existing consumer in `cmd/gc/agent_home_worktree_cleanup.go` is intentionally unchanged.
- The gate records an unrelated fast-suite timeout that passed on bounded retry; the final full suite and push hook both passed.

## Test plan

- [x] `go test ./cmd/gc -run 'TestPruneAgentHomeWorktreeIfSafe|WorktreeStale|CurrentBranch|TestCleanupClosedBeadAgentHomeWorktrees_DetachesToMainNotCurrentBranch' -count=1 -v`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-8mode6-worktree-stale-producer-gate.md`](release-gates/ga-8mode6-worktree-stale-producer-gate.md)