### PR TITLE
Exclude session scaffolds from doc coverage census

### DIFF
--- a/release-gates/ga-ubq2x1-docsync-session-scaffold-gate.md
+++ b/release-gates/ga-ubq2x1-docsync-session-scaffold-gate.md
@@ -1,0 +1,41 @@
+# Release Gate: docsync session-scaffold coverage
+
+- Deploy bead: `ga-ubq2x1`
+- Source bead: `ga-z7evh4.2`
+- Reviewed commit: `7ae5019665b0308efc094d0075bd761899ed69bf`
+- Deploy branch: `deploy/ga-ubq2x1-gate`
+- Evaluated: 2026-07-24
+- Gate source: deployer prompt release-gate table. `docs/PROJECT_MANIFEST.md` was not present in this checkout.
+
+## Summary
+
+PASS. This is a single-file test/docsync coverage fix that excludes Gas City session scaffold directories from the documentation tree coverage census.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git fetch origin main`; `git merge-tree --write-tree origin/main 7ae5019665b0308efc094d0075bd761899ed69bf` returned tree `d42820b74c32c3f735635c3c77db6dbbb5b6d609`; `git diff --check origin/main...7ae5019665b0308efc094d0075bd761899ed69bf` produced no output. |
+| 1 | Review PASS present | PASS | Deploy bead `ga-ubq2x1` records reviewer PASS for source bead `ga-z7evh4.2`; source notes contain `REVIEWER VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | Commit set is a single commit, `7ae501966`, touching only `test/docsync/docsync_test.go` (+15/-0). Source notes and direct diff confirm no stranded routed-demand or throttle changes are included. |
+| 3 | Tests pass | PASS | `go test ./test/docsync/... -run TestDocDirCoverage -count=1 -v` passed; `go test ./test/docsync/... -count=1` passed; `go vet ./test/docsync/...` passed; `go build ./...` passed; `go vet ./...` passed; `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | `bd list --status open --limit 0 | rg -i -- 'ga-ubq2x1|ga-z7evh4\\.2|HIGH|request-changes|security'` returned only sling helper bead `ga-rs1d7i`; no open HIGH/request-changes finding was found. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` returned only `## deploy/ga-ubq2x1-gate`. The gate file is committed as the final branch tip before push. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: the docsync documentation coverage test helper. It is independent of the previously split routed-demand work. |
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main 7ae5019665b0308efc094d0075bd761899ed69bf
+git diff --check origin/main...7ae5019665b0308efc094d0075bd761899ed69bf
+git log --oneline --reverse bac288647e0bbbbe2e68bdbe588709eb2827f5ee..7ae5019665b0308efc094d0075bd761899ed69bf
+git diff --stat bac288647e0bbbbe2e68bdbe588709eb2827f5ee..7ae5019665b0308efc094d0075bd761899ed69bf
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./test/docsync/... -run TestDocDirCoverage -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./test/docsync/... -count=1
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go vet ./test/docsync/...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go build ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go vet ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+bd list --status open --limit 0 | rg -i -- 'ga-ubq2x1|ga-z7evh4\.2|HIGH|request-changes|security'
+```

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -51,6 +51,18 @@ func isNestedWorktreeRoot(path string) bool {
 	return err == nil && !info.IsDir()
 }
 
+// isSessionScaffoldRoot reports whether path is a per-session scaffold
+// directory created by the outer gc orchestration (e.g. a bead-specific
+// agent session directory holding .claude/.codex/.gc state) rather than a
+// source or doc tree. These are untracked, gitignored-in-spirit working
+// directories that can be checked out as siblings of the repo's own
+// top-level directories; a .gc marker directory identifies them the same
+// way a .git file identifies a linked worktree above.
+func isSessionScaffoldRoot(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".gc"))
+	return err == nil && info.IsDir()
+}
+
 // knownBrokenLinks lists links to docs that do not exist yet. These are
 // excluded from TestLocalMarkdownLinks failures but still logged. Remove
 // entries as the missing docs are created.
@@ -815,6 +827,9 @@ func TestDocDirCoverage(t *testing.T) {
 		}
 		dirPath := filepath.Join(root, name)
 		if isNestedWorktreeRoot(dirPath) {
+			continue
+		}
+		if isSessionScaffoldRoot(dirPath) {
 			continue
 		}
 		// Check if this directory contains any markdown.


### PR DESCRIPTION
## What this changes

The docsync coverage test now treats Gas City session scaffold directories as infrastructure scaffolding instead of documentation content. This keeps `TestDocDirCoverage` from failing when a sibling session scaffold contains a `.gc` marker but no docs pages.

The change is test-support only. It does not change generated docs, documentation navigation, or runtime behavior.

## Review notes

- The entire change is in `test/docsync/docsync_test.go`.
- No `docs/` pages are changed.
- This PR intentionally excludes the stranded routed-demand throttle work that was split into a separate deploy.

## Test plan

- [x] `go test ./test/docsync/... -run TestDocDirCoverage -count=1 -v`
- [x] `go test ./test/docsync/... -count=1`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-ubq2x1-docsync-session-scaffold-gate.md`](release-gates/ga-ubq2x1-docsync-session-scaffold-gate.md)