### PR TITLE
Refuse conflicting gc sling routes without force

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1723,6 +1723,11 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 				w("  Bead " + opts.BeadOrFormula + " is already routed to " + a.QualifiedName() + ".")
 				w("  Without --force, sling would skip routing (exit 0).")
 				w("")
+			} else if check.Conflict != nil {
+				w("Routing conflict:")
+				w("  " + check.Conflict.Error() + ".")
+				w("  Without --force, sling would refuse to route (exit 1).")
+				w("")
 			}
 		}
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -7231,6 +7231,52 @@ func TestDryRunIdempotentBead(t *testing.T) {
 	}
 }
 
+// TestDryRunRoutingConflict pins the dry-run preview for a bead whose
+// gc.routed_to metadata already names a different target: the preview must
+// surface a "Routing conflict:" section describing the refusal instead of
+// silently previewing an overwrite, while still exiting 0 and executing no
+// side effects (dry-run never hard-errors).
+func TestDryRunRoutingConflict(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "deacon", MaxActiveSessions: intPtr(1)}
+	q := &fakeQuerier{
+		bead: beads.Bead{
+			ID:     "BL-42",
+			Title:  "Login page",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": "rig/polecat",
+			},
+		},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
+	opts := testOpts(a, "BL-42")
+	opts.DryRun = true
+	code := doSling(opts, deps, q, stdout, stderr)
+
+	// Dry-run never hard-errors; it renders the conflict as a preview section.
+	if code != 0 {
+		t.Fatalf("returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Routing conflict:") {
+		t.Errorf("stdout missing Routing conflict section: %s", out)
+	}
+	if !strings.Contains(out, "Without --force, sling would refuse to route (exit 1).") {
+		t.Errorf("stdout should describe the refusal: %s", out)
+	}
+	if !strings.Contains(out, "No side effects executed (--dry-run).") {
+		t.Errorf("stdout missing footer: %s", out)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("got %d runner calls, want 0: %v", len(runner.calls), runner.calls)
+	}
+}
+
 // --- Cross-rig guard tests ---
 
 func TestRigPrefixForAgentCityWide(t *testing.T) {

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -1634,6 +1634,10 @@ func PromoteWorkflowLaunchBead(store beads.Store, beadID string) error {
 type BeadCheckResult struct {
 	Idempotent bool
 	Warnings   []string
+	// Conflict is populated in the GREEN step (ga-l3qg8t) when the bead's
+	// gc.routed_to metadata already names a different target. RED-step
+	// stub: always nil.
+	Conflict error
 }
 
 // BeadCheckOptions configures pre-flight bead state checks for a route.

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -1634,9 +1634,9 @@ func PromoteWorkflowLaunchBead(store beads.Store, beadID string) error {
 type BeadCheckResult struct {
 	Idempotent bool
 	Warnings   []string
-	// Conflict is populated in the GREEN step (ga-l3qg8t) when the bead's
-	// gc.routed_to metadata already names a different target. RED-step
-	// stub: always nil.
+	// Conflict is non-nil when the bead's gc.routed_to metadata already
+	// names a target other than the one being checked. Callers with a
+	// custom SlingQuery never see this populated — see routedStateWarnings.
 	Conflict error
 }
 

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -448,7 +448,8 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 	}
 
 	if IsCustomSlingQuery(a) {
-		return BeadCheckResult{Warnings: routedStateWarnings(b, beadID)}
+		warnings, _ := routedStateWarnings(b, beadID)
+		return BeadCheckResult{Warnings: warnings}
 	}
 
 	target := a.QualifiedName()
@@ -466,7 +467,8 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 		if b.Assignee == target {
 			return resolveConvoyRecovery(q, b, deps, opts, beadID)
 		}
-		return BeadCheckResult{Warnings: routedStateWarnings(b, beadID)}
+		warnings, _ := routedStateWarnings(b, beadID)
+		return BeadCheckResult{Warnings: warnings}
 	}
 
 	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) == "" {
@@ -477,14 +479,19 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 			}
 		}
 	}
-	return BeadCheckResult{Warnings: routedStateWarnings(b, beadID)}
+	warnings, _ := routedStateWarnings(b, beadID)
+	return BeadCheckResult{Warnings: warnings}
 }
 
 // routedStateWarnings reports human-readable warnings describing any existing
 // routing state on b (assignee, gc.routed_to metadata, and pool: labels) that
-// would collide with a fresh sling of beadID. It returns nil when b carries no
-// such state.
-func routedStateWarnings(b beads.Bead, beadID string) []string {
+// would collide with a fresh sling of beadID. It returns nil warnings when b
+// carries no such state.
+//
+// The error return will report a routing conflict (an existing gc.routed_to
+// that names a different target) starting in the GREEN step (ga-l3qg8t);
+// this RED-step stub always returns a nil error.
+func routedStateWarnings(b beads.Bead, beadID string) ([]string, error) { //nolint:unparam // error becomes meaningful in the GREEN step (ga-l3qg8t); this RED-step stub always returns nil
 	var warnings []string
 	if b.Assignee != "" {
 		warnings = append(warnings, fmt.Sprintf("warning: bead %s already assigned to %q", beadID, b.Assignee))
@@ -497,5 +504,5 @@ func routedStateWarnings(b beads.Bead, beadID string) []string {
 			warnings = append(warnings, fmt.Sprintf("warning: bead %s already has pool label %q", beadID, l))
 		}
 	}
-	return warnings
+	return warnings, nil
 }

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -467,8 +467,8 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 		if b.Assignee == target {
 			return resolveConvoyRecovery(q, b, deps, opts, beadID)
 		}
-		warnings, _ := routedStateWarnings(b, beadID)
-		return BeadCheckResult{Warnings: warnings}
+		warnings, conflict := routedStateWarnings(b, beadID)
+		return BeadCheckResult{Warnings: warnings, Conflict: conflict}
 	}
 
 	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) == "" {
@@ -479,8 +479,8 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 			}
 		}
 	}
-	warnings, _ := routedStateWarnings(b, beadID)
-	return BeadCheckResult{Warnings: warnings}
+	warnings, conflict := routedStateWarnings(b, beadID)
+	return BeadCheckResult{Warnings: warnings, Conflict: conflict}
 }
 
 // routedStateWarnings reports human-readable warnings describing any existing
@@ -488,21 +488,26 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 // would collide with a fresh sling of beadID. It returns nil warnings when b
 // carries no such state.
 //
-// The error return will report a routing conflict (an existing gc.routed_to
-// that names a different target) starting in the GREEN step (ga-l3qg8t);
-// this RED-step stub always returns a nil error.
-func routedStateWarnings(b beads.Bead, beadID string) ([]string, error) { //nolint:unparam // error becomes meaningful in the GREEN step (ga-l3qg8t); this RED-step stub always returns nil
+// The error return reports a routing conflict: a non-blank gc.routed_to that
+// names a different target than the one about to be routed. Callers that
+// invoke this after already confirming gc.routed_to differs from their own
+// target (the only callers that reach it) can treat a non-nil error as that
+// conflict; callers for agents with a custom SlingQuery deliberately discard
+// it, since those agents don't key routing off gc.routed_to equality.
+func routedStateWarnings(b beads.Bead, beadID string) ([]string, error) {
 	var warnings []string
+	var conflict error
 	if b.Assignee != "" {
 		warnings = append(warnings, fmt.Sprintf("warning: bead %s already assigned to %q", beadID, b.Assignee))
 	}
 	if routedTo := strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]); routedTo != "" {
 		warnings = append(warnings, fmt.Sprintf("warning: bead %s already routed to %q", beadID, routedTo))
+		conflict = fmt.Errorf("gc sling: bead %s already routed to %q; use --force to override", beadID, routedTo)
 	}
 	for _, l := range b.Labels {
 		if strings.HasPrefix(l, "pool:") {
 			warnings = append(warnings, fmt.Sprintf("warning: bead %s already has pool label %q", beadID, l))
 		}
 	}
-	return warnings, nil
+	return warnings, conflict
 }

--- a/internal/sling/sling_attachment_test.go
+++ b/internal/sling/sling_attachment_test.go
@@ -2,10 +2,12 @@ package sling
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestRoutedStateWarnings(t *testing.T) {
@@ -13,6 +15,9 @@ func TestRoutedStateWarnings(t *testing.T) {
 		name string
 		bead beads.Bead
 		want []string
+		// wantConflict, when non-empty, must be a substring of the returned
+		// conflict error. When empty, the conflict must be nil.
+		wantConflict string
 	}{
 		{
 			name: "clean bead has no warnings",
@@ -25,9 +30,10 @@ func TestRoutedStateWarnings(t *testing.T) {
 			want: []string{`warning: bead bd-1 already assigned to "rig/polecat"`},
 		},
 		{
-			name: "routed_to only",
-			bead: beads.Bead{Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "rig/polecat"}},
-			want: []string{`warning: bead bd-1 already routed to "rig/polecat"`},
+			name:         "routed_to only",
+			bead:         beads.Bead{Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "rig/polecat"}},
+			want:         []string{`warning: bead bd-1 already routed to "rig/polecat"`},
+			wantConflict: `bd-1 already routed to "rig/polecat"`,
 		},
 		{
 			name: "blank routed_to metadata is ignored",
@@ -57,15 +63,99 @@ func TestRoutedStateWarnings(t *testing.T) {
 				`warning: bead bd-1 already has pool label "pool:builders"`,
 				`warning: bead bd-1 already has pool label "pool:reviewers"`,
 			},
+			wantConflict: `bd-1 already routed to "rig/deacon"`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := routedStateWarnings(tt.bead, "bd-1")
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("routedStateWarnings() = %#v, want %#v", got, tt.want)
+			gotWarnings, gotConflict := routedStateWarnings(tt.bead, "bd-1")
+			if !reflect.DeepEqual(gotWarnings, tt.want) {
+				t.Fatalf("routedStateWarnings() warnings = %#v, want %#v", gotWarnings, tt.want)
+			}
+			if tt.wantConflict == "" {
+				if gotConflict != nil {
+					t.Fatalf("routedStateWarnings() conflict = %v, want nil", gotConflict)
+				}
+				return
+			}
+			if gotConflict == nil {
+				t.Fatalf("routedStateWarnings() conflict = nil, want error containing %q", tt.wantConflict)
+			}
+			if !strings.Contains(gotConflict.Error(), tt.wantConflict) {
+				t.Fatalf("routedStateWarnings() conflict = %q, want substring %q", gotConflict.Error(), tt.wantConflict)
 			}
 		})
 	}
+}
+
+// TestCheckBeadStateWithOptions_RoutingConflict pins the higher-level
+// behavior CheckBeadStateWithOptions must expose so gc sling can hard-refuse
+// a conflicting gc.routed_to overwrite: a bead already routed to a different
+// target reports Conflict; a bead already routed to the checked target is
+// idempotent, not a conflict; custom sling-query agents never see a
+// conflict (they keep the existing unconditional warn-and-proceed
+// behavior); and an assignee alone (no gc.routed_to metadata) is not a
+// routing conflict.
+func TestCheckBeadStateWithOptions_RoutingConflict(t *testing.T) {
+	single := config.Agent{Name: "deacon", MaxActiveSessions: intPtr(1)}
+
+	t.Run("routed to a different target reports conflict", func(t *testing.T) {
+		b := beads.Bead{
+			ID:       "bd-1",
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "rig/polecat"},
+		}
+		store := beads.NewMemStoreFrom(0, []beads.Bead{b}, nil)
+		result := CheckBeadStateWithOptions(store, "bd-1", single, SlingDeps{}, BeadCheckOptions{})
+		if result.Conflict == nil {
+			t.Fatal("expected a routing conflict, got nil")
+		}
+	})
+
+	t.Run("already routed to the checked target is idempotent, not a conflict", func(t *testing.T) {
+		b := beads.Bead{
+			ID:       "bd-1",
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: single.QualifiedName()},
+		}
+		store := beads.NewMemStoreFrom(0, []beads.Bead{b}, nil)
+		// NoConvoy isolates this check from the pre-existing convoy-recovery
+		// path (resolveConvoyRecovery), which is orthogonal to routing
+		// conflict detection and would otherwise report Idempotent=false
+		// here simply because the fixture has no tracking convoy bead.
+		result := CheckBeadStateWithOptions(store, "bd-1", single, SlingDeps{}, BeadCheckOptions{NoConvoy: true})
+		if result.Conflict != nil {
+			t.Fatalf("expected no conflict for an idempotent route, got %v", result.Conflict)
+		}
+		if !result.Idempotent {
+			t.Fatal("expected Idempotent=true when routed_to already matches the target")
+		}
+	})
+
+	t.Run("custom sling query agents are never reported as conflicting", func(t *testing.T) {
+		custom := config.Agent{
+			Name:       "deacon",
+			SlingQuery: "label:special",
+		}
+		b := beads.Bead{
+			ID:       "bd-1",
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "rig/polecat"},
+		}
+		store := beads.NewMemStoreFrom(0, []beads.Bead{b}, nil)
+		result := CheckBeadStateWithOptions(store, "bd-1", custom, SlingDeps{}, BeadCheckOptions{})
+		if result.Conflict != nil {
+			t.Fatalf("custom sling query agents must not report routing conflicts, got %v", result.Conflict)
+		}
+	})
+
+	t.Run("assignee without routed_to metadata is not a routing conflict", func(t *testing.T) {
+		b := beads.Bead{
+			ID:       "bd-1",
+			Assignee: "rig/polecat",
+		}
+		store := beads.NewMemStoreFrom(0, []beads.Bead{b}, nil)
+		result := CheckBeadStateWithOptions(store, "bd-1", single, SlingDeps{}, BeadCheckOptions{})
+		if result.Conflict != nil {
+			t.Fatalf("expected no conflict when gc.routed_to is unset, got %v", result.Conflict)
+		}
+	})
 }

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -118,7 +118,11 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 
 	// Pre-flight idempotency check.
 	if shouldCheckBeadState(opts) {
-		if resolveIdempotentShortCircuit(opts, a, deps, querier, &result) {
+		idempotent, err := resolveIdempotentShortCircuit(opts, a, deps, querier, &result)
+		if err != nil {
+			return result, err
+		}
+		if idempotent {
 			return result, nil
 		}
 	}
@@ -169,10 +173,17 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 // formula still attaches. If the molecule-attachment probe cannot complete, the
 // fail-closed idempotent state is preserved and the probe failure is surfaced
 // as a bead warning rather than silently flipping into a mutating attach path.
-func resolveIdempotentShortCircuit(opts SlingOpts, a config.Agent, deps SlingDeps, querier BeadQuerier, result *SlingResult) bool {
+// A non-nil error reports a routing conflict (gc.routed_to already names a
+// different target): the caller must hard-refuse rather than proceed, except
+// during a dry-run preview, which never hard-errors and instead surfaces the
+// conflict as a rendered section.
+func resolveIdempotentShortCircuit(opts SlingOpts, a config.Agent, deps SlingDeps, querier BeadQuerier, result *SlingResult) (bool, error) {
 	check := CheckBeadStateWithOptions(querier, opts.BeadOrFormula, a, deps, BeadCheckOptions{
 		NoConvoy: opts.NoConvoy,
 	})
+	if check.Conflict != nil && !opts.DryRun {
+		return false, check.Conflict
+	}
 	if check.Idempotent {
 		needsAttach, probeErr := onFormulaNeedsAttachment(opts, querier, deps)
 		switch {
@@ -193,7 +204,7 @@ func resolveIdempotentShortCircuit(opts SlingOpts, a config.Agent, deps SlingDep
 	}
 	if !check.Idempotent {
 		result.BeadWarnings = append(result.BeadWarnings, check.Warnings...)
-		return false
+		return false, nil
 	}
 	result.Idempotent = true
 	result.DryRun = opts.DryRun
@@ -209,7 +220,7 @@ func resolveIdempotentShortCircuit(opts SlingOpts, a config.Agent, deps SlingDep
 	if opts.Nudge && !opts.DryRun {
 		result.NudgeAgent = &a
 	}
-	return true
+	return true, nil
 }
 
 // rigSuspended reports whether the named rig is marked suspended in config.

--- a/internal/sling/sling_core_test.go
+++ b/internal/sling/sling_core_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -87,4 +88,87 @@ func TestAttachFormulaToBeadEntryShapes(t *testing.T) {
 			t.Errorf("error = %q, want prefix %q", err.Error(), want)
 		}
 	})
+}
+
+// TestDoSlingRefusesConflictingRoute pins the hard-refuse behavior: slinging
+// a bead whose gc.routed_to metadata already names a different target must
+// fail, and must leave the existing route untouched, when --force is not
+// passed.
+func TestDoSlingRefusesConflictingRoute(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "deacon", MaxActiveSessions: intPtr(1)}
+	routed := beads.Bead{
+		ID:     "BL-1",
+		Title:  "BL-1",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: "rig/polecat",
+		},
+	}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{routed}, nil)
+	router := &fakeBeadRouter{}
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Router = router
+	deps.Store = store
+
+	_, err := DoSling(SlingOpts{Target: a, BeadOrFormula: "BL-1"}, deps, store)
+	if err == nil {
+		t.Fatal("expected DoSling to refuse a conflicting gc.routed_to overwrite without --force")
+	}
+
+	// The actual gc.routed_to write is owned by the injected Router (in
+	// production, cmd/gc's cliBeadRouter); the refusal must happen in
+	// DoSling's own pre-flight, before Router.Route is ever called.
+	if len(router.routed) != 0 {
+		t.Fatalf("expected DoSling to refuse before delegating to the router, got %d route call(s)", len(router.routed))
+	}
+
+	got, getErr := store.Get("BL-1")
+	if getErr != nil {
+		t.Fatalf("store.Get: %v", getErr)
+	}
+	if got.Metadata[beadmeta.RoutedToMetadataKey] != "rig/polecat" {
+		t.Errorf("gc.routed_to = %q, want unchanged %q", got.Metadata[beadmeta.RoutedToMetadataKey], "rig/polecat")
+	}
+}
+
+// TestDoSlingForceOverridesConflictingRoute pins the --force escape hatch:
+// with --force, a conflicting gc.routed_to is overwritten and DoSling
+// succeeds.
+func TestDoSlingForceOverridesConflictingRoute(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "deacon", MaxActiveSessions: intPtr(1)}
+	routed := beads.Bead{
+		ID:     "BL-1",
+		Title:  "BL-1",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: "rig/polecat",
+		},
+	}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{routed}, nil)
+	router := &fakeBeadRouter{}
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Router = router
+	deps.Store = store
+
+	_, err := DoSling(SlingOpts{Target: a, BeadOrFormula: "BL-1", Force: true}, deps, store)
+	if err != nil {
+		t.Fatalf("DoSling with --force: %v", err)
+	}
+
+	// The gc.routed_to write itself belongs to the Router implementation (in
+	// production, cmd/gc's cliBeadRouter); what DoSling owns is delegating to
+	// it despite the pre-existing conflicting route.
+	if len(router.routed) != 1 {
+		t.Fatalf("got %d route call(s), want 1", len(router.routed))
+	}
+	if router.routed[0].BeadID != "BL-1" {
+		t.Errorf("routed BeadID = %q, want BL-1", router.routed[0].BeadID)
+	}
+	if router.routed[0].Target != a.QualifiedName() {
+		t.Errorf("routed Target = %q, want %q", router.routed[0].Target, a.QualifiedName())
+	}
 }

--- a/release-gates/ga-lwthk0-sling-route-conflict-gate.md
+++ b/release-gates/ga-lwthk0-sling-route-conflict-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: `gc sling` conflicting route refusal
+
+- Deploy bead: `ga-lwthk0`
+- Source bead: `ga-3afq3j`
+- Reviewed commit: `ba4b3d1b7c90b8d14adecf3c666390bcb9c5d596`
+- Deploy branch: `deploy/ga-lwthk0-gate`
+- Evaluated: 2026-07-25
+- Gate source: deployer prompt release-gate table. `docs/PROJECT_MANIFEST.md` was not present in this checkout.
+
+## Summary
+
+PASS. `gc sling` now hard-refuses to overwrite an existing conflicting `gc.routed_to` value unless `--force` is used, and `--dry-run` renders the same routing conflict instead of previewing a misleading successful route.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git fetch origin main`; `git merge-tree --write-tree origin/main ba4b3d1b7c90b8d14adecf3c666390bcb9c5d596` returned tree `551f1cefefbd287ba1c3f8461827c4f3f08e6419`; `git diff --check origin/main...ba4b3d1b7c90b8d14adecf3c666390bcb9c5d596` produced no output. |
+| 1 | Review PASS present | PASS | Deploy bead `ga-lwthk0` records reviewer PASS for source bead `ga-3afq3j`; source notes contain `Review verdict: PASS`. |
+| 2 | Acceptance criteria met | PASS | Commit set is the expected red/green pair: `93aebd64a` and `ba4b3d1b7`. Diff covers the sling conflict result, attachment check, preflight propagation, CLI dry-run rendering, and regression tests. `--force`, custom SlingQuery, and assignee-only cases remain outside the hard-conflict path as specified. |
+| 3 | Tests pass | PASS | Focused sling regression run passed for `TestRoutedStateWarnings`, `TestCheckBeadStateWithOptions_RoutingConflict`, `TestDoSlingRefusesConflictingRoute`, `TestDoSlingForceOverridesConflictingRoute`, and `TestDryRunRoutingConflict`. `go test ./internal/sling -count=1` passed. `go build ./...` passed. `go vet ./...` passed. Initial `make test-fast-parallel` failed on unrelated `internal/productmetrics` `TestConcurrentGreaterEpochResumeAndDisableHaveOneCASWinner`; isolated retry of that test passed, and bounded full-suite rerun of `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | `bd list --status open --limit 0 | rg -i -- 'ga-lwthk0|ga-3afq3j|HIGH|request-changes|security'` returned only sling helper beads `ga-9xqgt7`, `ga-epfzr0`, and `ga-ykkkyq`; no open HIGH/request-changes finding was found. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` returned only `## deploy/ga-lwthk0-gate`. The gate file is committed as the final branch tip before push. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: `gc sling` route-conflict handling and its tests. The sibling multi-line inline-text fix is intentionally separate. |
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main ba4b3d1b7c90b8d14adecf3c666390bcb9c5d596
+git diff --check origin/main...ba4b3d1b7c90b8d14adecf3c666390bcb9c5d596
+git log --oneline --reverse 80e5166473033b9f2807dad048ddcb70dfc3b86e..ba4b3d1b7c90b8d14adecf3c666390bcb9c5d596
+git diff --stat 80e5166473033b9f2807dad048ddcb70dfc3b86e..ba4b3d1b7c90b8d14adecf3c666390bcb9c5d596
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./internal/sling ./cmd/gc -run 'TestRoutedStateWarnings|TestCheckBeadStateWithOptions_RoutingConflict|TestDoSlingRefusesConflictingRoute|TestDoSlingForceOverridesConflictingRoute|TestDryRunRoutingConflict' -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./internal/sling -count=1
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go build ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go vet ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./internal/productmetrics -run '^TestConcurrentGreaterEpochResumeAndDisableHaveOneCASWinner$' -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+bd list --status open --limit 0 | rg -i -- 'ga-lwthk0|ga-3afq3j|HIGH|request-changes|security'
+```


### PR DESCRIPTION
## What this changes

`gc sling` now refuses to overwrite a bead's existing `gc.routed_to` when that route points at a different target. Operators must use `--force` for that override, which prevents accidental route clobbering while preserving the existing explicit escape hatch.

Dry-run output now shows the same routing conflict instead of previewing a route that the real command would reject.

## Review notes

- Core behavior is in `internal/sling/sling_attachment.go`, `internal/sling/sling_core.go`, and `internal/sling/sling.go`.
- CLI dry-run rendering is in `cmd/gc/cmd_sling.go`.
- Custom SlingQuery agents and assignee-only warnings remain warn-and-proceed.
- The sibling multi-line inline-text validation change is intentionally separate.

## Test plan

- [x] `go test ./internal/sling ./cmd/gc -run 'TestRoutedStateWarnings|TestCheckBeadStateWithOptions_RoutingConflict|TestDoSlingRefusesConflictingRoute|TestDoSlingForceOverridesConflictingRoute|TestDryRunRoutingConflict' -count=1 -v`
- [x] `go test ./internal/sling -count=1`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-lwthk0-sling-route-conflict-gate.md`](release-gates/ga-lwthk0-sling-route-conflict-gate.md)