### PR TITLE
Reject multi-line inline gc sling text

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -2021,6 +2021,15 @@ func resolveInlineBeadAction(cfg *config.City, beadOrFormula string, dryRun bool
 	if !looksLikeInlineText(cfg, beadOrFormula) {
 		return false, false, nil
 	}
+	// Multi-line inline text is never a legitimate bead title — it's almost
+	// always a caller bug (e.g. a newline-joined list of bead IDs passed as
+	// one sling argument instead of iterated one-per-call). Fail loud rather
+	// than silently fabricating a bead whose title is the whole blob; this
+	// applies to both the real and dry-run paths so a dry-run preview can't
+	// promise a bead that would never be created.
+	if lines := strings.Count(beadOrFormula, "\n") + 1; lines > 1 {
+		return false, false, fmt.Errorf("inline text argument spans %d lines; refusing to create a bead from it — pass a single bead ID, iterate over a list (one ID per gc sling), or use --stdin for multi-line bead text", lines)
+	}
 	// Store probe: covers IDs that pass the shape pre-check but fail the
 	// heuristic (e.g. descriptive multi-dash IDs like "fo-spawn-storm").
 	// A store hit means the bead exists and should be routed, not created.

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2363,6 +2363,73 @@ func TestResolveInlineBeadActionMultiDashStoreErrorSurfaces(t *testing.T) {
 	}
 }
 
+func TestResolveInlineBeadActionMultilineTextErrors(t *testing.T) {
+	// Reproduces ga-thcr5n: a newline-joined list of bead IDs passed as a
+	// single sling argument (e.g. by the always-on deacon script) must not
+	// be silently fabricated into one contentless junk bead. Fail loud.
+	blob := strings.Join([]string{
+		"ga-kn8yy6.1", "ga-zogqc1.2.5", "ga-zogqc1.2.4", "ga-zogqc1.2.3",
+		"ga-a700wu", "ga-rzdqvl", "ga-7sy2ac", "ga-cd1895", "ga-fxudqs",
+		"ga-9feee3", "ga-e3zcqv", "ga-gzmzej", "ga-uslskt",
+	}, "\n")
+
+	create, previewInlineText, err := resolveInlineBeadAction(&config.City{}, blob, false, nil)
+	if err == nil {
+		t.Fatal("resolveInlineBeadAction error = nil, want error for multi-line inline text")
+	}
+	if !strings.Contains(err.Error(), "13") {
+		t.Fatalf("resolveInlineBeadAction error = %q, want line count 13", err)
+	}
+	if create {
+		t.Fatal("create = true, want false for multi-line inline text")
+	}
+	if previewInlineText {
+		t.Fatal("previewInlineText = true, want false for multi-line inline text")
+	}
+}
+
+func TestResolveInlineBeadActionMultilineTextErrorsDuringDryRun(t *testing.T) {
+	// The dry-run path must fail the same way — a dry-run preview of a junk
+	// bead is still a lie about what gc sling would do.
+	blob := "ga-abc12\nga-def34\nga-ghi56"
+
+	create, previewInlineText, err := resolveInlineBeadAction(&config.City{}, blob, true, nil)
+	if err == nil {
+		t.Fatal("resolveInlineBeadAction error = nil, want error for multi-line inline text during dry-run")
+	}
+	if create {
+		t.Fatal("create = true, want false for multi-line inline text during dry-run")
+	}
+	if previewInlineText {
+		t.Fatal("previewInlineText = true, want false — must not preview a junk bead")
+	}
+}
+
+func TestResolveInlineBeadActionSingleLineWithSpacesStillCreates(t *testing.T) {
+	// Regression/over-correction guard: the newline guard must key ONLY on
+	// "\n", not general whitespace. Ordinary space-separated inline text
+	// must still create a bead.
+	create, inlineText := mustResolveInlineBeadAction(t, &config.City{}, "write a README", false, nil)
+	if !create {
+		t.Fatal("create = false, want true for single-line inline text with spaces")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false outside dry-run")
+	}
+}
+
+func TestResolveInlineBeadActionSingleBeadIDNoNewlineDoesNotError(t *testing.T) {
+	// Regression guard: a single bead ID (the common case) must not trip the
+	// newline guard or any other new logic.
+	create, inlineText := mustResolveInlineBeadAction(t, &config.City{}, "ga-abc12", false, nil)
+	if create {
+		t.Fatal("create = true, want false for a single bead ID")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false for a single bead ID")
+	}
+}
+
 // TestCmdSlingConfiguredPrefixAllAlphaCrossRigRouteRefused verifies that
 // `gc sling` refuses a route whose source bead and target agent live in
 // different stores. Cross-store routes silently wedge pools because the

--- a/release-gates/ga-3nskfq-sling-multiline-inline-text-gate.md
+++ b/release-gates/ga-3nskfq-sling-multiline-inline-text-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: `gc sling` multi-line inline text refusal
+
+- Deploy bead: `ga-3nskfq`
+- Source bead: `ga-d1n9bd`
+- Reviewed commit: `e4645baf38f1f90ab6568a41133dfac04f968720`
+- Deploy branch: `deploy/ga-3nskfq-gate`
+- Evaluated: 2026-07-25
+- Gate source: deployer prompt release-gate table. `docs/PROJECT_MANIFEST.md` was not present in this checkout.
+
+## Summary
+
+PASS. `gc sling` now rejects pasted multi-line inline text before creating a bead, both for real runs and dry-runs. Single-line inline text and bead IDs keep their existing behavior.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git fetch origin main`; `git merge-tree --write-tree origin/main e4645baf38f1f90ab6568a41133dfac04f968720` returned tree `9dccb7bed629238c001c1ca7af1f00339c1f7d6c`; `git diff --check origin/main...e4645baf38f1f90ab6568a41133dfac04f968720` produced no output. |
+| 1 | Review PASS present | PASS | Deploy bead `ga-3nskfq` records reviewer PASS for source bead `ga-d1n9bd`; source notes contain `Review verdict: PASS`. |
+| 2 | Acceptance criteria met | PASS | Commit set is the expected red/green pair: `4faae17ea` and `e4645baf3`. Diff is limited to `cmd/gc/cmd_sling.go` and `cmd/gc/cmd_sling_test.go`. Focused tests verify multi-line inline text errors for real and dry-run paths, while single-line text and bead IDs keep existing behavior. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestResolveInlineBeadAction' -count=1 -v` passed 14/14. `go build ./...` passed. `go vet ./...` passed. Initial `make test-fast-parallel` failed on unrelated `TestCityRuntimeRun_ConvergenceStartupErrorDoesNotBlockStarted` and `TestProductMetricsDirectChildEnvSessionSubmitPoller`; isolated retries of both tests passed, and bounded full-suite rerun of `make test-fast-parallel` passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | `bd list --status open --limit 0 | rg -i -- 'ga-3nskfq|ga-d1n9bd|HIGH|request-changes|security'` returned only sling helper bead `ga-qk6m1q`; no open HIGH/request-changes finding was found. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` returned only `## deploy/ga-3nskfq-gate`. The gate file is committed as the final branch tip before push. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem: `gc sling` inline text parsing and its tests. The sibling conflicting-route refusal is intentionally separate. |
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main e4645baf38f1f90ab6568a41133dfac04f968720
+git diff --check origin/main...e4645baf38f1f90ab6568a41133dfac04f968720
+git log --oneline --reverse 80e5166473033b9f2807dad048ddcb70dfc3b86e..e4645baf38f1f90ab6568a41133dfac04f968720
+git diff --stat 80e5166473033b9f2807dad048ddcb70dfc3b86e..e4645baf38f1f90ab6568a41133dfac04f968720
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./cmd/gc -run 'TestResolveInlineBeadAction' -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go build ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go vet ./...
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./cmd/gc -run '^TestCityRuntimeRun_ConvergenceStartupErrorDoesNotBlockStarted$' -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE go test ./internal/session -run '^TestProductMetricsDirectChildEnvSessionSubmitPoller$' -count=1 -v
+TMPDIR=/var/tmp env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE make test-fast-parallel
+bd list --status open --limit 0 | rg -i -- 'ga-3nskfq|ga-d1n9bd|HIGH|request-changes|security'
+```


### PR DESCRIPTION
## What this changes

`gc sling` now rejects multi-line inline text before it creates a bead. This prevents pasted multi-line content from becoming a junk newline-joined bead title; users should pass a bead ID, keep inline text to one line, route items one at a time, or use `--stdin` for multi-line bead content.

Dry-run behavior matches the real command, so previews no longer imply that a multi-line inline paste would be accepted.

## Review notes

- The behavior change is in `cmd/gc/cmd_sling.go`.
- Regression coverage is in `cmd/gc/cmd_sling_test.go` under `TestResolveInlineBeadAction*`.
- The guard intentionally targets newline-delimited inline text; bare carriage returns and Unicode line separators are not changed here.
- Internal references: `ga-thcr5n`, `ga-1nxgu9`.

## Test plan

- [x] `go test ./cmd/gc -run 'TestResolveInlineBeadAction' -count=1 -v`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-3nskfq-sling-multiline-inline-text-gate.md`](release-gates/ga-3nskfq-sling-multiline-inline-text-gate.md)