### PR TITLE
fix(events): honor Since in the archive skip-fast path (176s -> 1.0s)

### DIFF
--- a/internal/events/rotation_archive.go
+++ b/internal/events/rotation_archive.go
@@ -134,6 +134,17 @@ func archiveOverlapsFilter(info archiveInfo, filter Filter) bool {
 	if filter.BeforeSeq > 0 && info.FirstSeq >= filter.BeforeSeq {
 		return false
 	}
+	// Every event in an archive was appended to the live log before that
+	// log was rotated, so event.Time <= info.Timestamp. An archive rotated
+	// strictly before the caller's Since therefore cannot hold a match and
+	// need not be gunzipped. A zero Timestamp carries no such guarantee
+	// (legacy basenames predate the stamped convention), so it is read.
+	// Until is deliberately not handled here: the filename records only the
+	// rotation instant, not the archive's first event, so there is no sound
+	// upper-bound skip.
+	if !filter.Since.IsZero() && !info.Timestamp.IsZero() && info.Timestamp.Before(filter.Since) {
+		return false
+	}
 	return true
 }
 

--- a/internal/events/rotation_archive.go
+++ b/internal/events/rotation_archive.go
@@ -135,14 +135,21 @@ func archiveOverlapsFilter(info archiveInfo, filter Filter) bool {
 		return false
 	}
 	// Every event in an archive was appended to the live log before that
-	// log was rotated, so event.Time <= info.Timestamp. An archive rotated
-	// strictly before the caller's Since therefore cannot hold a match and
-	// need not be gunzipped. A zero Timestamp carries no such guarantee
-	// (legacy basenames predate the stamped convention), so it is read.
+	// log was rotated at true instant T, so event.Time <= T. But
+	// info.Timestamp is T truncated to whole seconds (archiveTimestampLayout
+	// has no sub-second component), so info.Timestamp <= T < info.Timestamp+1s
+	// — the true rotation instant, and therefore every event.Time, can land
+	// anywhere up to (but not including) the NEXT whole second. A Since
+	// inside that truncation window cannot be ruled out and must still be
+	// read; only a Since at or beyond info.Timestamp+1s is guaranteed to
+	// postdate every possible event.Time (#4628). A zero Timestamp carries
+	// no such guarantee (legacy basenames predate the stamped convention),
+	// so it is read. This also assumes event.Ts is never clamped forward of
+	// the true rotation instant by the recorder (see ga-da13nh follow-up).
 	// Until is deliberately not handled here: the filename records only the
 	// rotation instant, not the archive's first event, so there is no sound
 	// upper-bound skip.
-	if !filter.Since.IsZero() && !info.Timestamp.IsZero() && info.Timestamp.Before(filter.Since) {
+	if !filter.Since.IsZero() && !info.Timestamp.IsZero() && info.Timestamp.Add(time.Second).Before(filter.Since) {
 		return false
 	}
 	return true

--- a/internal/events/rotation_archive_test.go
+++ b/internal/events/rotation_archive_test.go
@@ -141,8 +141,13 @@ func TestArchiveOverlapsFilter(t *testing.T) {
 // TestArchiveOverlapsFilterSkipsArchivesOlderThanSince pins the skip-fast
 // contract for time-bounded reads: an archive whose rotation timestamp
 // predates filter.Since cannot contain a matching event, so the reader must
-// not gunzip it. Every event in an archive was appended to the live log
-// before that log was rotated, so event.Time <= info.Timestamp always holds.
+// not gunzip it. The archive filename records only info.Timestamp, the
+// rotation instant TRUNCATED to whole seconds — the true rotation instant T
+// can land anywhere in [info.Timestamp, info.Timestamp+1s). Every event in
+// the archive was appended before T, so event.Time <= T, which only gives
+// event.Time < info.Timestamp+1s (see #4628). A Since strictly inside that
+// truncation second must therefore still be read; only a Since at or beyond
+// info.Timestamp+1s can be safely skipped.
 func TestArchiveOverlapsFilterSkipsArchivesOlderThanSince(t *testing.T) {
 	// Rotated 2026-05-07; the live fleet queries with ?since=5m.
 	info := archiveInfo{
@@ -162,9 +167,19 @@ func TestArchiveOverlapsFilterSkipsArchivesOlderThanSince(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "Since one second after archive rotation is skippable",
+			name: "Since one second after archive rotation must still be read (true rotation instant is unknown within the truncation second)",
 			f:    Filter{Since: time.Date(2026, 5, 7, 0, 0, 1, 0, time.UTC)},
+			want: true,
+		},
+		{
+			name: "Since one second and one nanosecond after archive rotation is skippable",
+			f:    Filter{Since: time.Date(2026, 5, 7, 0, 0, 1, 1, time.UTC)},
 			want: false,
+		},
+		{
+			name: "Since strictly inside the rotation's truncation second must still be read",
+			f:    Filter{Since: time.Date(2026, 5, 7, 0, 0, 0, 500000000, time.UTC)},
+			want: true,
 		},
 		{
 			name: "Since before archive rotation must still be read",

--- a/internal/events/rotation_archive_test.go
+++ b/internal/events/rotation_archive_test.go
@@ -137,3 +137,57 @@ func TestArchiveOverlapsFilter(t *testing.T) {
 		})
 	}
 }
+
+// TestArchiveOverlapsFilterSkipsArchivesOlderThanSince pins the skip-fast
+// contract for time-bounded reads: an archive whose rotation timestamp
+// predates filter.Since cannot contain a matching event, so the reader must
+// not gunzip it. Every event in an archive was appended to the live log
+// before that log was rotated, so event.Time <= info.Timestamp always holds.
+func TestArchiveOverlapsFilterSkipsArchivesOlderThanSince(t *testing.T) {
+	// Rotated 2026-05-07; the live fleet queries with ?since=5m.
+	info := archiveInfo{
+		Basename:  "events.jsonl.archive-20260507T000000Z-seq-100-200.gz",
+		Timestamp: time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC),
+		FirstSeq:  100,
+		LastSeq:   200,
+	}
+	tests := []struct {
+		name string
+		f    Filter
+		want bool
+	}{
+		{
+			name: "Since well after archive rotation is skippable",
+			f:    Filter{Since: time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC)},
+			want: false,
+		},
+		{
+			name: "Since one second after archive rotation is skippable",
+			f:    Filter{Since: time.Date(2026, 5, 7, 0, 0, 1, 0, time.UTC)},
+			want: false,
+		},
+		{
+			name: "Since before archive rotation must still be read",
+			f:    Filter{Since: time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)},
+			want: true,
+		},
+		{
+			name: "Since exactly at rotation must still be read (inclusive bound)",
+			f:    Filter{Since: time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)},
+			want: true,
+		},
+		{
+			name: "zero Since is unbounded and must still be read",
+			f:    Filter{},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := archiveOverlapsFilter(info, tc.f); got != tc.want {
+				t.Errorf("archiveOverlapsFilter(Since=%v) = %v, want %v",
+					tc.f.Since, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/events/rotation_reader_test.go
+++ b/internal/events/rotation_reader_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -397,6 +398,53 @@ func TestReadAllSurvivesMultipleRotations(t *testing.T) {
 	// Last event is the tail.
 	if got[len(got)-1].Subject != "tail" {
 		t.Errorf("last event subject = %q, want %q", got[len(got)-1].Subject, "tail")
+	}
+}
+
+// TestReadFilteredIncludesEventWithinArchiveSubSecondWindow pins the exact
+// silent-drop scenario from #4628: the archive filename records only the
+// whole-second-truncated rotation instant, so the true rotation (and any
+// event legitimately appended just before it) can land anywhere within that
+// truncation second. A Since inside that same second must still surface the
+// event rather than have the archive skip-fast past it ungunzipped. The
+// archive is built directly with a fixed rotation timestamp (not via a real
+// ForceRotate) so the test is deterministic and independent of wall-clock
+// timing.
+func TestReadFilteredIncludesEventWithinArchiveSubSecondWindow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+
+	// Filename truncates to the whole second; the true rotation instant (and
+	// the event inside the archive) can be anywhere in
+	// [rotationSecond, rotationSecond+1s) — here, 900ms in, mirroring the
+	// bug report's own worked example.
+	rotationSecond := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	eventTs := rotationSecond.Add(500 * time.Millisecond)
+
+	line, err := json.Marshal(Event{Seq: 1, Type: BeadCreated, Ts: eventTs, Actor: "human", Subject: "sub-second"})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	src := filepath.Join(dir, "archive-source.jsonl")
+	if err := os.WriteFile(src, append(line, '\n'), 0o644); err != nil {
+		t.Fatalf("write archive source: %v", err)
+	}
+	archive := filepath.Join(dir, formatArchiveBasename(rotationSecond, 1, 1))
+	var stderr bytes.Buffer
+	if err := gzipAndArchive(src, archive, &stderr); err != nil {
+		t.Fatalf("gzipAndArchive: %v", err)
+	}
+
+	// Since falls after the filename's floored instant but before the
+	// event's actual sub-second timestamp — exactly the window the old
+	// skip-fast check misjudged.
+	since := rotationSecond.Add(250 * time.Millisecond)
+	got, err := ReadFiltered(path, Filter{Since: since})
+	if err != nil {
+		t.Fatalf("ReadFiltered: %v", err)
+	}
+	if len(got) != 1 || got[0].Seq != 1 {
+		t.Fatalf("ReadFiltered(Since=%v) = %v, want the sub-second event (seq 1)", since, got)
 	}
 }
 


### PR DESCRIPTION
## Root cause

`archiveOverlapsFilter` (`internal/events/rotation_archive.go:130`) consulted only
`AfterSeq`/`BeforeSeq`. It ignored `Since`/`Until` entirely — even though
`archiveInfo.Timestamp` (line 16) already carries the rotation instant parsed
from the filename.

That matters because the city event list exposes **no `after_seq` param**
(`EventListInput`, `internal/api/huma_types_events.go:15`) — `since` is the only
lower bound a client can send. So for a selective filter:

1. `fetchEventPageAscending` (`internal/api/huma_handlers_events.go:163`) tries the
   cheap `ListTail` first;
2. a selective filter returns fewer than `limit+1` rows, so it falls through to
   `listWithInFlight` — the full scan;
3. `archiveOverlapsFilter` excludes nothing, so
4. `streamArchive` (`internal/events/reader.go:326`, which discards its `Filter`)
   gunzips and JSON-parses **the entire archive history** to match nothing.

On this fleet that is **53 archives / 2.1 GB per request**.

## Evidence from the running supervisor

`perf record` against the live process (no restart, no pprof needed):

| symbol | share of process CPU |
| --- | --- |
| `streamArchive` (cumulative) | **68.55%** |
| `encoding/json.Unmarshal` beneath it | 48.48% |
| `compress/flate` (gunzip) | ~15% |

Access log — these are abandoned long-polls, **31 of 39** event requests in the
sampled window:

```
GET /v0/city/gc-management/events 499 3m22.306013s
GET /v0/city/gc-management/events 499 3m21.733299s
GET /v0/city/gc-management/events 499 3m28.211963s
```

Direct reproduction against the live server:

```
?type=zzz.nonexistent.event.type&limit=50   ->  176.36s
```

## The fix

Every event in an archive was appended to the live log before that log was
rotated at true instant T, so `event.Time <= T`. But `info.Timestamp` (parsed
from the filename) is `T` truncated to whole seconds, so only
`info.Timestamp <= T < info.Timestamp+1s` is known — the true rotation instant,
and therefore every event in the archive, can land anywhere up to (but not
including) the next whole second. An archive is safe to skip only once `Since`
reaches that `+1s` slack; a `Since` inside the truncation second must still be
read. Skipping under that bound is sound, not a heuristic.

Measured against the real 2.1 GB archive set: **53 of 53 archives skipped** for
`since=5m`, and the same selective query goes **176s -> 1.0s** — the `+1s` slack
costs nothing at that distance.

## Deliberate bounds

- **Zero `Timestamp` is still read.** Legacy basenames predate the stamped
  convention and carry no such guarantee.
- **`Until` is deliberately not handled.** The filename records the rotation
  instant, not the archive's *first* event, so there is no sound upper-bound
  skip without extra metadata.
- **Assumes events do not carry future timestamps.** An event stamped after its
  own rotation instant could be skipped by a `Since` between the two. This is the
  same assumption the existing seq-based skip already makes. No current writer
  does this (traced every non-test `Ts:` producer in the tree); tracked as a
  platform-contract follow-up rather than enforced here.

## Not fixed here

A selective filter with **no** `since` still replays all history — there is no
lower bound to skip on. That is a contract question (bounded scan? default
window? expose `after_seq`?), filed separately as a `needs-architecture` bead
rather than decided from this seat.

## Test

`TestArchiveOverlapsFilterSkipsArchivesOlderThanSince` pins both sides of the
`+1s` truncation boundary (`Since == Timestamp+1s` must still read;
`Since == Timestamp+1s+1ns` may skip), plus the pre-existing guard cases
(`Since` before rotation, `Since` exactly at rotation, zero `Since`).
`TestReadFilteredIncludesEventWithinArchiveSubSecondWindow` pins the same
scenario end-to-end against a real gzip'd archive: an event at `rotation+500ms`,
queried with `Since=rotation+250ms`, must still come back.

Gates: `go vet` clean; `internal/events` and `internal/api` both green.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4167 — implements the Since-vs-archive-basename-timestamp prune in archiveOverlapsFilter that the filed issue proposes as its first fix bullet, so time-bounded reads no longer gunzip every retained archive; it does not make ReadFilteredTail archive-aware (the truncation-at-rotation-boundary half), does not add the per-request archive/byte budget, does not handle Until, and a selective filter sent with no lower time bound still replays all history

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
