### PR TITLE
fix(cmd/gc): isolate provider-factory test from ambient city discovery

### DIFF
--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -1412,7 +1412,18 @@ func TestNewSessionProviderFromContext_PackRuntimeCollisionSurfaces(t *testing.T
 }
 
 func TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior(t *testing.T) {
-	t.Setenv("GC_CITY", "")
+	// The "default" case calls newSessionProvider with no explicit city, so it
+	// falls through to ambient discovery. findCity walks up from the working
+	// directory, and a checkout nested under a real city root (every gc rig
+	// worktree) resolves that live city, wrapping the injected fake in an
+	// auto.Provider. Pin the discovery ceiling to the package directory so the
+	// walk stops before it can reach an ambient city.toml.
+	clearGCEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Setenv("GC_CEILING_DIRECTORIES", wd)
 	t.Setenv("GC_SESSION", "fake")
 
 	base := runtime.NewFake()


### PR DESCRIPTION
## Summary

`TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior/default`
fails deterministically in **any checkout nested under a live city root** —
which is every `gc` rig worktree — and passes everywhere else. One binary
compiled at `origin/main`, only the working directory varied:

| binary | cwd | result |
| --- | --- | --- |
| `origin/main` | worktree `cmd/gc` (city-rooted) | **FAIL** 0.88s — resolves the live city, `factory provider = *auto.Provider` |
| `origin/main` | `/var/tmp` | PASS 0.00s |
| this PR | worktree `cmd/gc` (city-rooted) | PASS 0.00s — **no city resolution at all** |

`default` is the only one of the four subtests that calls `newSessionProvider()`
(`cmd/gc/providers.go:183`) with no explicit config, so it falls through to
ambient city resolution. `findCity()` walks up from the working directory; its
ceiling check bounds how far a walk *climbs*, but does not stop a walk that
starts inside a real city tree and finds `city.toml` on the way up. When that
ambient city's roster has ACP-routed agents, `hasACPProviderTargets` fires at
`cmd/gc/providers.go:278` and the injected `*runtime.Fake` is wrapped in an
`*auto.Provider`, breaking the `sp == base` identity assertion.

This pins `GC_CEILING_DIRECTORIES` to the package directory so the walk stops
before it can reach an ambient `city.toml`, and uses the existing `clearGCEnv`
helper for the rest of the ambient `GC_*`/`BEADS_*`/`DOLT_*` state. That is the
established idiom in this package — `provider_factory_e2c1_test.go` bounds
discovery the same way, and `clearGCEnv` itself sets that variable.

## Why not `t.Chdir(t.TempDir())`

That was the obvious fix and it does work, but it grows the `cwd` resource
census, and that ledger's declared invariant is *"untagged cmd/gc cwd call/file
totals cannot grow; reductions must lower this baseline"*. Landing it therefore
requires raising a migration ratchet's baseline (owner `ga-80po0c.2.3`, expires
2026-10-01) — a policy decision, not a test fix.

This form adds **no** `Chdir` and swaps one lexical `Setenv` (`GC_CITY`) for
another (`GC_CEILING_DIRECTORIES`), so it is **ledger-neutral**:
`TestRepositoryLedgerMatchesCensusAndDocumentation` passes with no ledger edit,
no `TESTING.md` churn, and the ratchet left intact.

## Why this matters beyond one test

This was the **last red test in the local pre-push gate**
(`make test-fast-parallel`). Because a GitHub runner never has a city above the
checkout, CI is structurally always in the passing cell — so the gate has been
**red for every agent and green in CI**, and 14+ `--no-verify` bypasses were
logged across five agents in a single evening as the rational response to a gate
that cannot pass in the environment agents actually work in. Tracked as
`ga-o2bak3`. The companion `HOME`-sensitivity half landed in #4631.

## Relationship to #4630

#4630 carries a different fix for this same bug (`t.Chdir` plus a commit raising
the census baseline) as a passenger on an unrelated idle-kill change that is
architecturally held. That coupling is what kept the gate red — it made a
fleet-wide test failure wait on an unrelated architectural decision. **Nothing
in #4630 or its hold is touched by this PR**; its copy becomes a no-op once this
lands. A third copy of the fix was also sitting reviewed-but-un-PR'd on
`builder/ga-y4se3w-provider-factory-default-fix` (review bead `ga-liodwd`);
that branch would have failed CI on the census ratchet as-is.

## Verification

- `make test-fast-parallel` from a **city-rooted agent worktree**: all 8 jobs
  ok, 0 FAIL lines, exit 0. This is the environment where the gate has been red.
- `TestRepositoryLedgerMatchesCensusAndDocumentation` passes with no ledger
  change.
- Pre-commit lint, schema/doc regeneration and `go vet ./...` clean.
