### PR TITLE
fix(cmd/gc): use lockedBuffer for stdout/stderr in controller tests

### DIFF
--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -38,7 +38,7 @@ func TestControllerLoopCancel(t *testing.T) {
 		return DesiredStateResult{}
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	controllerLoop(ctx, time.Hour, cfg, "test", "", nil, buildFn, sp, nil, nil, nil, nil, nil, events.Discard, nil, nil, nil, nil, &stdout, &stderr)
 
@@ -68,7 +68,7 @@ func TestControllerLoopTick(t *testing.T) {
 		return DesiredStateResult{}
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	controllerLoop(ctx, time.Millisecond, cfg, "test", "", nil, buildFn, sp, nil, nil, nil, nil, nil, events.Discard, nil, nil, nil, nil, &stdout, &stderr)
 
@@ -110,7 +110,7 @@ func TestGracefulStopAllFallsBackWhenPartialListOmitsExplicitTarget(t *testing.T
 	}
 	_ = sp.Start(context.Background(), "alpha", runtime.Config{})
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 	gracefulStopAll([]string{"alpha"}, sp, 20*time.Millisecond, events.Discard, nil, beads.SessionStore{}, &stdout, &stderr)
 	if sp.IsRunning("alpha") {
 		t.Fatal("gracefulStopAll should stop explicit targets even when partial listing omits them")
@@ -171,7 +171,7 @@ func TestControllerShutdown(t *testing.T) {
 	// Dolt-backed .beads/ database).
 	tomlPath := writeCityTOML(t, dir, "test", "mayor")
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	// Run controller in a goroutine; it will block until canceled.
 	// Use a close-able channel so cleanup can detect whether the
@@ -481,7 +481,7 @@ func TestControllerReloadsConfig(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	loopDone := make(chan struct{})
 	go func() {
@@ -575,7 +575,7 @@ func TestControllerReloadsConfigImmediatelyOnWatchEvent(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	loopDone := make(chan struct{})
 	go func() {
@@ -1201,7 +1201,7 @@ func TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	done := make(chan struct{})
 	go func() {
@@ -1858,7 +1858,7 @@ func TestControllerReloadInvalidConfig(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	done := make(chan struct{})
 	go func() {
@@ -1935,7 +1935,7 @@ func TestControllerReloadCityNameChange(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	go controllerLoop(ctx, 20*time.Millisecond, cfg, "test", tomlPath, nil,
 		buildFn, sp, nil, nil, nil, nil, nil, events.Discard, nil, nil, nil, nil, &stdout, &stderr)
@@ -2032,7 +2032,7 @@ func TestControllerReloadCommandReloadsConfigImmediately(t *testing.T) {
 		return DesiredStateResult{State: ds}
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 	done := make(chan struct{})
 	go func() {
 		runController(dir, tomlPath, cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &stdout, &stderr)
@@ -2132,7 +2132,7 @@ func TestControllerPokeTriggersImmediate(t *testing.T) {
 	// operations rather than falling back to cwd.
 	tomlPath := writeCityTOML(t, dir, "test")
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 
 	done := make(chan struct{})
 	go func() {


### PR DESCRIPTION
## Summary
- `controllerLoop` runs on a background goroutine and writes startup/reload diagnostics (e.g. `city_runtime.go`'s `fmt.Fprintln(cr.stdout, "City started.")`) to the stdout/stderr `io.Writer` while several tests' main goroutines concurrently poll `buffer.String()` to detect readiness.
- A plain `bytes.Buffer` is not safe for that concurrent access — caught by `go test -race`.
- Replaces all 11 occurrences of `var stdout, stderr bytes.Buffer` in `cmd/gc/controller_test.go` with the existing mutex-guarded `lockedBuffer` type (already used elsewhere in the package, e.g. `cmd_supervisor_test.go`), which is a drop-in `io.Writer` with a synchronized `String()`.

Fixes ga-9cndyo.

## Test plan
- [x] `go test -count=3 -race ./cmd/gc -run '^TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout$'` — RED before the fix (`WARNING: DATA RACE`), GREEN after (`ok`, 3 runs).
- [x] `go test -race ./cmd/gc -run '^(TestControllerLoopCancel|TestControllerLoopTick|TestGracefulStopAllFallsBackWhenPartialListOmitsExplicitTarget|TestControllerShutdown|TestControllerReloadsConfig|TestControllerReloadsConfigImmediatelyOnWatchEvent|TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout|TestControllerReloadInvalidConfig|TestControllerReloadCityNameChange|TestControllerReloadCommandReloadsConfigImmediately|TestControllerPokeTriggersImmediate)$'` — all 11 affected tests pass under `-race` (2 skip on `GC_FAST_UNIT`, unrelated).
- [x] `go vet ./cmd/gc/...` clean.
- [x] `make test-fast-parallel` — all shards pass except the known, pre-existing, unrelated `TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior/default` ambient-city-cwd flake (root-cause fix tracked separately at ga-klo4gz, in progress under builder-1). Confirmed via isolated rerun that this fails identically and is untouched by this diff — pushed with `--no-verify` per the sanctioned bypass procedure, mayor notified (gm-wisp-0ogjblu).