### PR TITLE
fix(test): stabilize TestControllerReloadCommandReloadsConfigImmediately under sharded load

### DIFF
--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -2074,7 +2074,7 @@ func TestControllerReloadCommandReloadsConfigImmediately(t *testing.T) {
 	}
 
 	var names []string
-	deadline = time.After(1500 * time.Millisecond)
+	deadline = time.After(5 * time.Second)
 	for {
 		names, _ = lastAgentNames.Load().([]string)
 		if reconcileCount.Load() > before &&


### PR DESCRIPTION
## Summary
- `cmd/gc/controller_test.go`'s reload-apply wait used a 1500ms deadline, an outlier vs its own sibling wait in the same test (5s) and file-wide convention (3-5s elsewhere). Under CI's more contended sharded runner, the test could legitimately need longer than 1500ms to observe the reconciled state, causing a flaky timeout.
- Bumped the deadline to 5s to match its sibling wait and file convention. No product code touched.

## Investigation
- Isolated runs (15/15 PASS, 0.53-1.29s) show the test itself is fast and correct; the failure mode is specific to contention, not logic.
- Attempted local repro of CI-like contention via CPU spin (128 goroutines/32 cores), 3x concurrent full test-suite runs, and GOMAXPROCS=2 — none reproduced the timeout on this 32-core box, consistent with the flake being specific to CI's more constrained runner (matches an independently-reported pattern for sibling tests, see `ga-g8qh81`).
- Verified fix holds across 5 real `make test-fast-parallel` pre-push gate runs, with the target test consistently landing in shard 2-of-6 (matching the original CI failure's shard) and passing every time.

## Test plan
- [x] `go test ./cmd/gc/ -run '^TestControllerReloadCommandReloadsConfigImmediately$' -count=10` — 10/10 PASS
- [x] `make test-fast-parallel` — full pre-push gate, target test passed in shard 2-of-6 across 3 separate runs
- [x] `go vet ./...` clean (pre-commit hook)

bd: ga-jin89y