### PR TITLE
test(cmd/gc): derive hangBudget from testutil.GoroutineRaceTimeout

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1340,6 +1340,36 @@ operation completes in < 1s on an idle machine but fails under CI CPU
 saturation. The only exception is a timer that is itself the subject under
 test (e.g., testing that a function honours a 100ms deadline).
 
+### Floors, ceilings, and inputs
+
+`GoroutineRaceTimeout` and `ExecRaceTimeout` are **floors** — the minimum a
+deadline may be. They are not a target to set every wait to.
+
+Some packages additionally define a **hang budget**: the point at which the
+package gives up and declares a wait wedged. `cmd/gc` has one (`hangBudget` in
+`cmd/gc/hangbudget_test.go`), derived from `GoroutineRaceTimeout` rather than
+declared independently, so there is one source of truth. Which to reach for:
+
+- **Does any assertion depend on how long the wait took?** Keep an explicit
+  deadline and comment which bound it asserts. This is the "subject under test"
+  exception above.
+- **Is the wait purely a hang detector** — the real assertions come after it
+  returns? Use the package's hang budget (`awaitClose`/`awaitCond` in `cmd/gc`).
+  Sizing it is not a correctness knob: these helpers return the instant their
+  condition is met, so raising the budget does not slow a passing run and
+  lowering it does not make the suite stricter. It only changes how long a
+  genuinely wedged test takes to report.
+- **Otherwise**, use `GoroutineRaceTimeout` / `ExecRaceTimeout` directly.
+
+Two things are never migrated to a hang budget:
+
+- **A value the test feeds the system** — a timeout passed *into* the code under
+  test defines the scenario being exercised, not how patiently the test watches.
+  Widening one makes the test prove less.
+- **The window of a negative assertion** ("nothing arrived within X"). There the
+  window *is* the assertion; budget-governing it makes the test slower and
+  weaker.
+
 ## Decision guide
 
 | Question you're testing | Tier |

--- a/cmd/gc/hangbudget_helpers_test.go
+++ b/cmd/gc/hangbudget_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // The hang-budget helpers exist to remove a class of load-sensitive flake in
@@ -87,10 +89,22 @@ func TestAwaitCondEvaluatesTheConditionBeforeSleeping(t *testing.T) {
 // change that would re-introduce the flake: someone shrinking it to "make the
 // suite faster". Shrinking it cannot make a passing suite faster — the waits
 // return on their condition — it can only convert load spikes back into red
-// builds. The floor is set well above the largest fixed deadline this migration
-// replaced (15s, cmd_stop_test.go's controller-availability poll).
+// builds.
+//
+// Two independent floors are asserted. The first is TESTING.md's "Test deadline
+// rule", which this package must not fall below. The second is this migration's
+// own evidence: the largest fixed deadline it replaced was 15s
+// (cmd_stop_test.go's controller-availability poll), and guarded regions were
+// measured at 18.0-19.8s under single-core starvation, so anything at or below
+// 2x the replaced deadline is known-insufficient rather than merely aggressive.
 func TestHangBudgetStaysAHangDetector(t *testing.T) {
 	t.Parallel()
+
+	if hangBudget < testutil.GoroutineRaceTimeout {
+		t.Fatalf("hangBudget = %s, want >= testutil.GoroutineRaceTimeout (%s); "+
+			"TESTING.md's test deadline rule is a floor this package may not go below",
+			hangBudget, testutil.GoroutineRaceTimeout)
+	}
 
 	const largestReplacedDeadline = 15 * time.Second
 	if hangBudget < 2*largestReplacedDeadline {

--- a/cmd/gc/hangbudget_test.go
+++ b/cmd/gc/hangbudget_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // hangBudget is the single wall-clock ceiling shared by every test-side wait in
@@ -23,12 +25,24 @@ import (
 // its own short deadline — hangBudget is the wrong tool there and would add a
 // full minute of dead wait.
 //
-// Sized as a genuine hang budget rather than fitted to any observed run: the
-// slowest guarded region measured under fleet load was ~3.9s (ga-h51wa1), and
-// Go's package -timeout remains the real backstop. This exists only so a wedged
-// wait fails at the line that wedged, with a useful message, instead of taking
-// the whole package down with an unattributed timeout.
-const hangBudget = 60 * time.Second
+// RELATIONSHIP TO testutil.GoroutineRaceTimeout — these are not competing
+// constants, which is why hangBudget is derived from it rather than declared
+// alongside it. TESTING.md's "Test deadline rule" makes GoroutineRaceTimeout
+// the MINIMUM safe deadline for a timer racing a goroutine ("must be >= 10s").
+// hangBudget is the point at which this package declares a wedge, which is a
+// ceiling, not a floor. Use GoroutineRaceTimeout directly when a test needs a
+// deadline that satisfies the rule; use awaitClose/awaitCond when the wait is
+// purely a hang detector and no assertion depends on how long it took.
+//
+// Why the floor alone is not enough here: measured under single-core CPU
+// starvation, the guarded regions in this package took 18.0-19.8s to complete
+// (ga-h51wa1). A 10s deadline would have failed all eight of those runs even
+// though nothing was wedged. The multiplier gives roughly 3x headroom over the
+// worst run actually observed; Go's package -timeout remains the real backstop.
+// This constant exists only so a wedged wait fails at the line that wedged,
+// with a useful message, instead of taking the whole package down with an
+// unattributed timeout.
+const hangBudget = 6 * testutil.GoroutineRaceTimeout
 
 // hangPollInterval is how often awaitCond re-evaluates its condition. It is a
 // responsiveness knob only; it has no bearing on whether a test passes.


### PR DESCRIPTION
Follow-up to #4638 (ga-hpos14). #4638 landed `const hangBudget = 60 * time.Second`
package-local in `cmd/gc`, next to a pre-existing `testutil.GoroutineRaceTimeout`
(10s) that TESTING.md already mandates. Main carries both today.

## The collision, as it exists on main (c34b7894f)

`TESTING.md:1332` "Test deadline rule" requires `testutil.GoroutineRaceTimeout` /
`ExecRaceTimeout` for any timer racing a goroutine, exec, or socket start
(">= 10s"). `cmd/gc` already adopts them in **20 sites across 9 files**. Two of
those files also use `hangBudget`, in the same file and the same syntactic
position (`case <-time.After(X)`):

| file | `GoroutineRaceTimeout` | `hangBudget` |
| --- | --- | --- |
| `cmd/gc/controller_test.go` | 2 | 7 |
| `cmd/gc/session_lifecycle_parallel_test.go` | 3 | 2 |

Two constants a reader would reasonably assume mean the same thing — the
fragmentation #4638 existed to end, re-created at N=2. N=2 with no documented
rule for which to reach for is the state that grows back.

> **Correction to the bead's evidence.** ga-hpos14's description names
> `city_runtime_test.go` as a both-constants file. That is wrong — it uses
> `GoroutineRaceTimeout` x2 and `hangBudget` **x0**. `session_lifecycle_parallel_test.go`
> is the actual second file, which the bead does not mention. The overlap set is
> the two files above. Bead updated.

## What this does

```go
const hangBudget = 6 * testutil.GoroutineRaceTimeout
```

Same 60s. Derived, not declared alongside — one source of truth, and the
relationship is explicit instead of implicit in a 60-vs-10 mismatch.

Plus a `Floors, ceilings, and inputs` subsection in TESTING.md under the
existing rule, and an expanded doc comment on the constant itself, so the
convention is reachable without reading this PR.

`TestHangBudgetStaysAHangDetector` now asserts **both** floors — TESTING.md's
10s rule and this migration's own `2 * largestReplacedDeadline` evidence — so
shrinking the budget below either is a build failure, not a judgement call.

## Why this and not "promote it to `testutil.HangBudget`"

The mayor's mail offered two options: (A) promote `hangBudget` into
`internal/testutil` and re-point the 10s sites at it, or (B) keep it
package-local and document the boundary explicitly. **This is B**, and the
reason is that the floor/ceiling distinction is real and load-bearing rather
than a naming accident:

- `GoroutineRaceTimeout` is a **floor** — the minimum any racing deadline may
  be, applying fleet-wide.
- `hangBudget` is a **ceiling** — the point at which *this package* declares a
  wait wedged.

60s satisfies ">= 10s"; it does not contradict it. They are different kinds of
number, so collapsing them into one shared constant would be the actual error.

The budget is also a per-package property: 60s is sized from measurement in
`cmd/gc` specifically — under single-core CPU starvation its guarded regions
took **18.0-19.8s**, so a 10s deadline would have failed all eight runs with
nothing wedged. Promoting that number to `internal/testutil` would assert it
for the 22 non-`cmd/gc` files that have no such measurement behind them. Option
A is the right move once a second package needs a budget and can show its own
number; doing it now would be inventing a shared constant from one data point.

What B owed and this pays: the rule is now written down in TESTING.md and in
the constant's doc comment, so the next person picks correctly without finding
this thread.

## Coordination

`ga-hp32mm` (builder) also touches `cmd_stop_test.go`. **No conflict**: this
branch touches only `TESTING.md`, `cmd/gc/hangbudget_test.go`, and
`cmd/gc/hangbudget_helpers_test.go`, and the numeric value of `hangBudget` is
unchanged at 60s — so the `gated{Start,Stop}Provider` helpers that bead migrates
onto `hangBudget` get the same duration either way, whichever lands first.

## Verification

- `go vet ./cmd/gc/ ./internal/testutil/` clean
- `TestHangBudget* / TestAwaitClose* / TestAwaitCond*` pass
- pre-push `test-fast-parallel` sweep green (all 6 `cmd/gc` shards + core)

Refs: ga-hpos14, ga-h51wa1, ga-o2bak3, ga-hp32mm
