### PR TITLE
test(cmd/gc): make the contextual-errors provider test hermetic too

### DIFF
--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -1484,7 +1484,20 @@ func TestErrorReturningSessionProviderFactoriesPreserveSuccessBehavior(t *testin
 }
 
 func TestErrorReturningSessionProviderFactoriesReturnContextualErrors(t *testing.T) {
-	t.Setenv("GC_CITY", "")
+	// Same ambient-discovery exposure as the sibling above: the "default" case
+	// calls newSessionProvider with no explicit city, so findCity walks up from
+	// the working directory and a checkout nested under a real city root
+	// resolves that live city — attempting a real connection to its production
+	// store from a unit test. This test passes today only because the injected
+	// stub returns an error before the auto.Provider wrap that breaks the
+	// sibling's identity assertion, so it is one behavior change away from
+	// failing the same way. Pin the ceiling here too rather than rely on that.
+	clearGCEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Setenv("GC_CEILING_DIRECTORIES", wd)
 	t.Setenv("GC_SESSION", "broken")
 
 	wantErr := errors.New("injected provider failure")


### PR DESCRIPTION
Closes ga-smudr8. Sibling of #4634 (ga-o2bak3), same root cause, same one-line
shape. Deliberately held back from that PR to keep it minimal; this is the
follow-through.

## The problem

`TestErrorReturningSessionProviderFactoriesReturnContextualErrors/default` calls
`newSessionProvider` with no explicit city. `findCity` therefore walks **up from
the working directory** — and when the checkout is nested under a real city root
(every agent worktree in this fleet is), it resolves the *live* city and attempts
a real connection to its production store. From a unit test.

Measured on `origin/main` before the fix, run from this package's directory:

```
--- PASS: TestErrorReturningSessionProviderFactoriesReturnContextualErrors (1.13s)
    --- PASS: .../status               (0.00s)
    --- PASS: .../status_with_snapshot (0.00s)
    --- PASS: .../default              (1.13s)   <-- 
    --- PASS: .../city                 (0.00s)
WARN native_store_unavailable gate=native_open reason="schema version mismatch:
  database is at v58, binary knows up to v53" scope=/home/jaword/projects/gc-management
```

Two independent tells: `/default` costs 1.13s while its three siblings cost
0.00s, and the run emits a `native_store_unavailable` warning that **names the
real city root**. It is not a hypothetical — the connection is attempted and
happens to be refused by a schema-version mismatch.

## Why it is green today, and why that is not good enough

The injected stub returns an error, so `newSessionProviderFromContext` returns
before reaching the `auto.Provider` wrap at `cmd/gc/providers.go:278` — the exact
line whose identity assertion broke this test's sibling in #4634. So it passes
today for a reason unrelated to hermeticity, and it is one behavior change away
from failing identically.

This is worth saying plainly because a previous investigation recorded this test
as *disproven/unaffected* on the strength of it passing. That observation was
correct; the conclusion did not follow. **"Not failing" is not "hermetic."** The
defect here is the ambient dependency, not a red test.

## The fix

`clearGCEnv(t)` plus pinning `GC_CEILING_DIRECTORIES` to the package directory
via `os.Getwd`, replacing the single `t.Setenv("GC_CITY", "")` that was never
sufficient — clearing `GC_CITY` only removes the *explicit* city, leaving the
upward walk intact.

After, same binary and same cwd as the measurement above:

```
--- PASS: .../default (0.00s)
```

and **no warning emitted at all** — no city resolution is attempted, rather than
attempted-and-tolerated. That distinction is the whole point of the change.

## Ratchet impact: none

Verified against `internal/testpolicy/resourcecensus/census.go` rather than
assumed. The counted-selector list covers `Setenv`, `Unsetenv`, `Clearenv` and
`Chdir`; `Getwd` is absent. `clearGCEnv(t)` is a plain identifier call whose own
`Setenv`s are counted against that helper, not this test. One lexical `Setenv`
is swapped for another. Net counted delta is zero, and there is no `t.Chdir`.

## Verification

- `go vet ./...` clean
- full `make test-fast-parallel` pre-push gate green — all fast jobs passed, no
  `--no-verify`

Scope is one file, +14/-1, test-only.
