### PR TITLE
fix(dolt): skip the compaction remote phase for .no-sync databases

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -137,6 +137,25 @@ succeed. Do **not** set the global opt-out in the shared `mol-dog-compactor`
 order for the same reason; set the per-database env on the affected city
 instead.
 
+## Compacting a database that must never reach a remote
+
+Some databases are deliberately local — a privacy boundary, or a store whose
+remote was configured by accident. Mark those `.no-sync` and compaction skips
+its remote phase entirely: no fetch, no push, and no deferred push recorded.
+The database still flattens and GCs, so it keeps the disk benefit:
+
+```bash
+# Exclude one database from all remote sync, compaction included.
+touch <cityPath>/.beads/dolt/<database>/.no-sync
+```
+
+`gc dolt sync` and `gc dolt pull` honor the same marker, so one file covers
+every remote path.
+
+Choose `.no-sync` over `--skip-fetch` when a database must never reach a
+remote. `--skip-fetch` defers the push and waits for the remote to become
+usable later; `.no-sync` states that it never will.
+
 ## Expected Outcome
 
 DoltHub's archive format typically delivers ~30% compression on top of

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -47,6 +47,9 @@
 # Remote push failures are recorded in compact-pending-push markers and do not
 # fail local compaction. Later runs retry those markers before threshold skips,
 # and unverified remote heads must become ancestry-verifiable before push.
+# A database marked .no-sync (same marker the sync and pull commands honor) has
+# no remote phase at all: it is never fetched or pushed, never gets a
+# pending-push marker, and an existing one is cleared so it cannot block flatten.
 # Surgical mode (preserve recent N commits via interactive rebase) is
 # intentionally not implemented; flatten is sufficient for bloat recovery
 # and avoids the rebase-vs-concurrent-write hazards.
@@ -1236,6 +1239,16 @@ oldgen_has_files() {
   [ -n "$(find "$oldgen_dir" -mindepth 1 -print -quit 2>/dev/null)" ]
 }
 
+# no_sync_database reports whether the operator excluded this database from all
+# remote sync with a .no-sync marker — the same contract the sync and pull
+# commands honor (commands/sync/run.sh, commands/pull/run.sh). Such a database
+# has no push step, so compaction treats it exactly like a database with no
+# remotes: flatten and GC locally, never fetch or push, never defer a push.
+no_sync_database() {
+  db="$1"
+  [ -f "$DOLT_DATA_DIR/$db/.no-sync" ]
+}
+
 compact_marker_path() {
   dir="$1"
   db="$2"
@@ -1882,6 +1895,11 @@ flatten_database() {
       return 0
     fi
     pending_remote=$(compact_marker_value "$pending_gc_dir" "$db" remote || true)
+    if [ -n "$pending_remote" ] && no_sync_database "$db"; then
+      # Marker predates the .no-sync marker: retry the GC, drop the push.
+      printf 'compact: db=%s pending_gc remote=%s dropped — remote sync disabled (.no-sync)\n' "$db" "$pending_remote"
+      pending_remote=""
+    fi
     pending_expected_remote_head=$(compact_marker_value "$pending_gc_dir" "$db" expected_remote_head || true)
     pending_expected_remote_head_verified=$(compact_marker_value "$pending_gc_dir" "$db" expected_remote_head_verified || true)
     pending_compacted_from_head=$(compact_marker_value "$pending_gc_dir" "$db" compacted_from_head || true)
@@ -1945,6 +1963,18 @@ flatten_database() {
       return "$push_rc"
     fi
     return 1
+  fi
+
+  if has_compact_marker "$pending_push_dir" "$db" && no_sync_database "$db"; then
+    # The marker records a push this database must never make. Keeping it would
+    # block flatten forever: the retry branch below returns before the flatten
+    # path, and past the max-age window it hard-fails as stale on every run.
+    if [ -n "$dry_run" ]; then
+      printf 'compact: db=%s pending_push=present but remote sync disabled (.no-sync) — dry-run (would clear deferred push)\n' "$db"
+      return 0
+    fi
+    printf 'compact: db=%s pending_push=present but remote sync disabled (.no-sync) — clearing deferred push\n' "$db"
+    clear_compact_marker "$pending_push_dir" "$db"
   fi
 
   if has_compact_marker "$pending_push_dir" "$db"; then
@@ -2072,7 +2102,9 @@ flatten_database() {
   remote_branch="main"
   expected_remote_head=""
   expected_remote_head_verified=0
-  if probed_remote=$(select_remote "$db"); then
+  if no_sync_database "$db"; then
+    printf 'compact: db=%s remote sync disabled (.no-sync) — compacting locally only\n' "$db"
+  elif probed_remote=$(select_remote "$db"); then
     remote="$probed_remote"
   else
     printf 'compact: db=%s remote selection failed — fail\n' "$db" >&2

--- a/examples/bd/dolt/compact_no_sync_test.go
+++ b/examples/bd/dolt/compact_no_sync_test.go
@@ -1,0 +1,164 @@
+package dolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeNoSyncMarker marks a database as excluded from remote sync, matching the
+// contract the sync and pull commands already honor
+// (commands/sync/run.sh, commands/pull/run.sh: "$data_dir/<db>/.no-sync").
+func writeNoSyncMarker(t *testing.T, dataDir, db string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dataDir, db, ".no-sync"), nil, 0o644); err != nil {
+		t.Fatalf("write .no-sync marker: %v", err)
+	}
+}
+
+// TestCompactScriptSkipsRemotePhaseForNoSyncDatabase asserts that a database
+// marked .no-sync gets local compaction only: no fetch, no push, and no
+// pending-push marker. A .no-sync database has no push step to defer, so
+// quarantining it on a failed push is a self-inflicted block.
+func TestCompactScriptSkipsRemotePhaseForNoSyncDatabase(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	writeNoSyncMarker(t, fixture.dataDir, "beads")
+
+	out, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact should succeed locally for a .no-sync database: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+
+	for _, want := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_GC"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf(".no-sync must not block local compaction; missing %s:\n%s", want, log)
+		}
+	}
+	if strings.Contains(log, "DOLT_FETCH") {
+		t.Fatalf(".no-sync database must not be fetched:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_PUSH") {
+		t.Fatalf(".no-sync database must not be pushed:\n%s", log)
+	}
+
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		markerData, _ := os.ReadFile(marker)
+		t.Fatalf(".no-sync database must not get a pending-push marker (stat err=%v):\n%s", err, markerData)
+	}
+}
+
+// TestCompactScriptClearsPendingPushMarkerWhenDatabaseBecomesNoSync asserts that
+// an already-quarantined database recovers once it is marked .no-sync. Without
+// this, the marker written before the .no-sync marker existed blocks flatten
+// forever: the pending-push branch returns before the flatten path is reached,
+// and past the max-age window the retry is refused as stale.
+func TestCompactScriptClearsPendingPushMarkerWhenDatabaseBecomesNoSync(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	firstOut, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should defer the push: %v\n%s", err, firstOut)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("fetch failure should write pending-push marker: %v", err)
+	}
+
+	// Operator marks the database no-sync: the deferred push is now meaningless.
+	writeNoSyncMarker(t, fixture.dataDir, "beads")
+	// Age the marker past the retry window, matching the production markers that
+	// have been blocking compaction for weeks.
+	replaceCompactMarkerCreatedAt(t, marker, "2026-01-01T00:00:00Z")
+
+	secondOut, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact must not stay blocked on a stale push marker for a .no-sync database: %v\n%s", err, secondOut)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf(".no-sync database must have its pending-push marker cleared (stat err=%v)\n%s", err, secondOut)
+	}
+	if strings.Contains(secondOut, "manual review required") {
+		t.Fatalf(".no-sync database must not demand manual review for a push it will never make:\n%s", secondOut)
+	}
+}
+
+// TestCompactScriptDryRunPreservesPendingPushMarkerForNoSyncDatabase pins that
+// the .no-sync recovery obeys --dry-run: it reports the clear it would make and
+// leaves the marker on disk.
+func TestCompactScriptDryRunPreservesPendingPushMarkerForNoSyncDatabase(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	firstOut, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should defer the push: %v\n%s", err, firstOut)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("fetch failure should write pending-push marker: %v", err)
+	}
+	writeNoSyncMarker(t, fixture.dataDir, "beads")
+
+	out, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500", "GC_DOLT_COMPACT_DRY_RUN=1")
+	if err != nil {
+		t.Fatalf("dry run should succeed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "dry-run (would clear deferred push)") {
+		t.Fatalf("dry run should report the clear it would make:\n%s", out)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("dry run must not delete the pending-push marker: %v", err)
+	}
+}
+
+// TestCompactScriptPendingPushMarkerBlocksFlattenEvenWhenFresh is a disproof
+// artifact, not a bug report: it pins the fact that a pending-push marker blocks
+// the flatten path by PRESENCE, not by staleness. It documents why "age the
+// stale marker out" is not by itself a fix — a fresh marker still yields a
+// push-retry-only run with no flatten.
+func TestCompactScriptPendingPushMarkerBlocksFlattenEvenWhenFresh(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	firstOut, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should defer the push: %v\n%s", err, firstOut)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("fetch failure should write pending-push marker: %v", err)
+	}
+	if err := os.Truncate(fixture.doltLog, 0); err != nil {
+		t.Fatalf("truncate dolt log: %v", err)
+	}
+
+	// Marker is well inside the retry window — staleness cannot be the blocker.
+	replaceCompactMarkerCreatedAt(t, marker, nowStampForCompactMarker(t))
+
+	secondOut, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("fresh-marker retry should not hard-fail: %v\n%s", err, secondOut)
+	}
+	if strings.Contains(secondOut, "marker is stale") {
+		t.Fatalf("marker should be fresh for this disproof:\n%s", secondOut)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(data), "DOLT_RESET") {
+		t.Fatalf("HYPOTHESIS DISPROVED DIFFERENTLY: a fresh pending-push marker DID allow flatten:\n%s", data)
+	}
+}
+
+func nowStampForCompactMarker(t *testing.T) string {
+	t.Helper()
+	return time.Now().UTC().Format("2006-01-02T15:04:05Z")
+}


### PR DESCRIPTION
Fixes the `.no-sync` half of ga-sl4ka3.

## The bug

`gc dolt compact` had no `.no-sync` awareness, so a database the operator had
deliberately excluded from remote sync still got fetched and pushed. When that
push failed — correctly, because the database is not supposed to reach a remote —
compaction quarantined itself on the failure and never compacted that database
again.

On this city that has been live since 2026-07-01. The marker records its own
contradiction:

```
db=gascity
reason=flatten and full GC succeeded but remote fetch before push failed
created_at=2026-07-01T13:40:41Z
```

Local compaction succeeded. The quarantine is gating on a step that should never
have run: `.beads/dolt/gascity/.no-sync` has existed since 2026-05-27.

## Why it never recovers

Two mechanisms compound, both in `examples/bd/dolt/commands/compact/run.sh`:

1. `flatten_database` returns from its pending-push branch after retrying only
   the push — the flatten path below is never reached. The marker blocks
   compaction by **presence**, not by age.
2. Past `GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS` (48h), the retry hard-fails
   as stale and fires a quarantine alert — which is also the recurring mayor
   mail this generates.

So the deadlock is permanent, and it is self-sustaining: the push can never
succeed, so the marker can never clear.

## The fix

Treat a `.no-sync` database exactly like a database with no remotes — a path
that is already exercised in production every run (`hq` has no remotes):

- Skip remote selection, so no fetch, no push, and no pending-push marker.
- Clear a pre-existing pending-push marker for a `.no-sync` database. Without
  this the fix would stop *new* markers but leave the stuck ones blocking
  compaction forever.
- Drop the recorded remote from a pending-GC marker written before `.no-sync`
  was set, so its GC retry does not resurrect the push.

`--dry-run` reports the clear it would make and leaves the marker on disk.

## Tests

New `examples/bd/dolt/compact_no_sync_test.go` (separate file — both other open
PRs touching this pack edit `dog_exec_scripts_test.go`):

- `TestCompactScriptSkipsRemotePhaseForNoSyncDatabase` — local compaction runs,
  no `DOLT_FETCH`/`DOLT_PUSH`, no marker. Failed before the fix with two
  `CALL DOLT_FETCH('origin')` calls in the log.
- `TestCompactScriptClearsPendingPushMarkerWhenDatabaseBecomesNoSync` — an
  already-stuck database recovers. Failed before the fix with the exact
  production error: `pending_push marker is stale age=... — manual review
  required before remote push retry`.
- `TestCompactScriptDryRunPreservesPendingPushMarkerForNoSyncDatabase` —
  dry-run does not mutate.
- `TestCompactScriptPendingPushMarkerBlocksFlattenEvenWhenFresh` — a disproof
  artifact, not a fix assertion. It pins that a **fresh** marker still blocks
  flatten, which is why "age the stale marker out" would not have been a fix.

Full `./examples/bd/dolt/` suite passes; no behavior change for databases
without a `.no-sync` marker.

## Verification this does NOT claim

The bead asks for verification by observing a real compaction that completes for
`gascity` and a measurable drop in `.beads/dolt/gascity` (currently 6.0G of a
20G store). That needs this deployed and a real compaction run against the live
store — it is not something these hermetic tests establish, and I did not run a
compaction against live data or touch the production markers.

## Not fixed here

`mcdclient` and `my_db` are stuck for a different reason: real remotes that have
genuinely diverged. Their markers are not covered by `.no-sync`, and unblocking
them means deciding what a compaction force-push may do to a diverged remote.
The documented `--skip-fetch` workaround walks into the same deadlock. Filed as
ga-9ebj9m for an architecture call, with the evidence.
