### PR TITLE
Wake named sessions for routed demand and retry transient push-guard reads

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -888,8 +888,17 @@ func buildDesiredStateWithSessionBeads(
 	// NamedSessionRoutedDemand: routed (unassigned) scale-check demand on the
 	// backing template, independent of direct assignee demand above. See the
 	// field doc on DesiredStateResult.NamedSessionRoutedDemand.
+	// Canonical singleton backing pools only. This signal exists solely to
+	// compensate for alias suppression, and alias suppression applies exactly to
+	// canonical singleton identities (see canonicalSingletonAliasHeldTemplates).
+	// A multi-instance backing pool can serve routed demand with an ordinary
+	// standby, so waking the named holder there would wake it AND mint the
+	// standby — the overprovisioning this signal is meant to prevent.
 	namedRoutedDemand := make(map[string]bool, len(namedSpecs))
 	for identity, spec := range namedSpecs {
+		if !spec.Agent.UsesCanonicalSingletonPoolIdentity() {
+			continue
+		}
 		if scaleCheckCounts[namedSessionBackingTemplate(spec)] > 0 {
 			namedRoutedDemand[identity] = true
 		}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -77,6 +77,17 @@ type DesiredStateResult struct {
 	// direct assignee demand (Assignee == identity). The reconciler merges this
 	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
+	// NamedSessionRoutedDemand records, per named-session identity, whether
+	// there is routed-but-unassigned demand on the identity's backing template
+	// (ScaleCheckCounts[backingTemplate] > 0), computed BEFORE canonical-alias
+	// pool suppression runs. Unlike NamedSessionDemand this is not
+	// assignee-direct and must never be merged into poolDesired or treated as
+	// sleep-suppressing — it exists solely to give ComputeAwakeSet a wake-only
+	// signal for an asleep named holder whose alias correctly suppresses the
+	// redundant pool standby (ga-jl73y2): routed-but-unclaimed demand that
+	// should wake the holder once, without affecting pool sizing or later
+	// idle-sleep decisions.
+	NamedSessionRoutedDemand map[string]bool
 	// ReadyAssigned is the set of AssignedWorkBeads that carry real wake-demand
 	// readiness, keyed by store ref + bead ID: in-progress work, assigned
 	// molecule roots, and store-Ready()/deps-gated open work. Beads admitted
@@ -874,6 +885,15 @@ func buildDesiredStateWithSessionBeads(
 	if len(assignedWorkBeads) > 0 {
 		fmt.Fprintf(stderr, "namedWorkReady: %d assigned beads, %d named specs, ready=%v\n", len(assignedWorkBeads), len(namedSpecs), namedWorkReady) //nolint:errcheck
 	}
+	// NamedSessionRoutedDemand: routed (unassigned) scale-check demand on the
+	// backing template, independent of direct assignee demand above. See the
+	// field doc on DesiredStateResult.NamedSessionRoutedDemand.
+	namedRoutedDemand := make(map[string]bool, len(namedSpecs))
+	for identity, spec := range namedSpecs {
+		if scaleCheckCounts[namedSessionBackingTemplate(spec)] > 0 {
+			namedRoutedDemand[identity] = true
+		}
+	}
 	for identity, spec := range namedSpecs {
 		canonicalInfo, hasCanonical := findCanonicalNamedSessionInfo(bp.sessionBeads, spec)
 		if !hasCanonical {
@@ -938,6 +958,7 @@ func buildDesiredStateWithSessionBeads(
 		ReadyUnassignedRoutedWorkStoreRefs: readyUnassignedRoutedWorkStoreRefs,
 		ReadyAssigned:                      readyAssigned,
 		NamedSessionDemand:                 namedWorkReady,
+		NamedSessionRoutedDemand:           namedRoutedDemand,
 		StoreQueryPartial:                  storePartial,
 		BeaconTime:                         beaconTime,
 	}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -6272,6 +6272,74 @@ func TestBuildDesiredState_NamedBackingPoolNoCap_RoutedDemandDoesNotSpawnPhantom
 	}
 }
 
+// NamedSessionRoutedDemand exists only to compensate for alias suppression, and
+// alias suppression applies exactly to canonical singleton identities. On a
+// multi-instance backing pool nothing suppresses the standby, so emitting the
+// signal there would wake the named holder AND mint a standby for the same
+// routed work — overprovisioning. Routed demand must still reach ordinary pool
+// sizing in that case; only the named wake is withheld.
+func TestBuildDesiredState_RoutedDemandWakesOnlyCanonicalSingletonNamedSessions(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const singletonTemplate = "solo"
+	const multiTemplate = "crew"
+	for _, template := range []string{singletonTemplate, multiTemplate} {
+		if _, err := store.Create(beads.Bead{
+			Title:    template + " routed work",
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{"gc.routed_to": template},
+		}); err != nil {
+			t.Fatalf("create routed demand for %q: %v", template, err)
+		}
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              singletonTemplate,
+				StartCommand:      "true",
+				WorkQuery:         "printf ''",
+				MaxActiveSessions: intPtr(1), // UsesCanonicalSingletonPoolIdentity() == true
+			},
+			{
+				Name:              multiTemplate,
+				StartCommand:      "true",
+				WorkQuery:         "printf ''",
+				MaxActiveSessions: intPtr(2), // multi-instance: standby is legitimate
+			},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: singletonTemplate, Mode: "on_demand"},
+			{Template: multiTemplate, Mode: "on_demand"},
+		},
+	}
+	singletonIdentity := cfg.NamedSessions[0].QualifiedName()
+	multiIdentity := cfg.NamedSessions[1].QualifiedName()
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	// Control: the singleton keeps the wake signal, so this test fails loudly if
+	// the gate is simply switched off rather than made selective.
+	if !dsResult.NamedSessionRoutedDemand[singletonIdentity] {
+		t.Fatalf("canonical singleton %q lost its routed wake signal; routed_demand=%v scale_counts=%v",
+			singletonIdentity, dsResult.NamedSessionRoutedDemand, dsResult.ScaleCheckCounts)
+	}
+	// Regression: the multi-instance pool must NOT also wake its named holder.
+	if dsResult.NamedSessionRoutedDemand[multiIdentity] {
+		t.Fatalf("multi-instance backing pool %q emitted NamedSessionRoutedDemand for %q; "+
+			"its standby already serves routed demand, so waking the named holder overprovisions "+
+			"(routed_demand=%v scale_counts=%v)",
+			multiTemplate, multiIdentity, dsResult.NamedSessionRoutedDemand, dsResult.ScaleCheckCounts)
+	}
+	// ...and routed demand still reaches ordinary pool sizing for that template.
+	if dsResult.ScaleCheckCounts[multiTemplate] <= 0 {
+		t.Fatalf("multi-instance template %q lost routed demand entirely (scale_counts=%v); "+
+			"the gate must withhold only the named wake, not the pool demand",
+			multiTemplate, dsResult.ScaleCheckCounts)
+	}
+}
+
 func TestBuildDesiredState_OnDemandNamedSession_RuntimeAssigneeDoesNotMaterialize(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "fixture")

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2342,6 +2342,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		awakeAssignedWorkBeads, rigStores, readyWaitSet, cr.sessionDrains, cr.providerHealthGate,
 		poolDesired,
 		result.NamedSessionDemand,
+		result.NamedSessionRoutedDemand,
 		result.snapshotQueryPartial(),
 		workSet, cityName,
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
@@ -3057,6 +3058,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		cr.providerHealthGate,
 		poolDesired,
 		wfcResult.NamedSessionDemand,
+		wfcResult.NamedSessionRoutedDemand,
 		false, // storeQueryPartial: config-change path doesn't query work beads
 		nil,   // workSet: not computed for config-change reconcile
 		cr.cityName,

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -979,6 +979,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		sigCtx, cityPath, sessionBeads.OpenForReconcile(), sessionBeads, ds, cfgNames, cfg, sp, sessStore,
 		nil, awakeAssignedWorkBeads, rigStores, nil, dt, nil, poolDesired,
 		dsResult.NamedSessionDemand,
+		dsResult.NamedSessionRoutedDemand,
 		dsResult.snapshotQueryPartial(),
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -247,7 +247,7 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 				reasons = []WakeReason{WakePin}
 			case "wait-ready":
 				reasons = []WakeReason{WakeWait}
-			case "assigned-work", "named-demand", "work-query":
+			case "assigned-work", "named-demand", "routed-demand", "work-query":
 				reasons = []WakeReason{WakeWork}
 			case "min-active":
 				reasons = []WakeReason{WakeConfig}

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -21,6 +21,7 @@ func buildAwakeInputFromReconciler(
 	sessionInfos []session.Info,
 	poolDesired map[string]int,
 	namedSessionDemand map[string]bool,
+	namedRoutedDemand map[string]bool,
 	workSet map[string]bool,
 	readyWaitSet map[string]bool,
 	assignedWorkBeads []beads.Bead,
@@ -30,16 +31,17 @@ func buildAwakeInputFromReconciler(
 	clk time.Time,
 ) AwakeInput {
 	input := AwakeInput{
-		ScaleCheckCounts:   poolDesired,
-		NamedSessionDemand: cloneBoolMap(namedSessionDemand),
-		WorkSet:            workSet,
-		ReadyWaitSet:       readyWaitSet,
-		RunningSessions:    make(map[string]bool),
-		AttachedSessions:   make(map[string]bool),
-		PendingSessions:    make(map[string]bool),
-		ChatIdleTimeout:    cfg.ChatSessions.IdleTimeoutDuration(),
-		ManualGracePeriod:  cfg.ChatSessions.GracePeriodDuration(),
-		Now:                clk,
+		ScaleCheckCounts:         poolDesired,
+		NamedSessionDemand:       cloneBoolMap(namedSessionDemand),
+		NamedSessionRoutedDemand: cloneBoolMap(namedRoutedDemand),
+		WorkSet:                  workSet,
+		ReadyWaitSet:             readyWaitSet,
+		RunningSessions:          make(map[string]bool),
+		AttachedSessions:         make(map[string]bool),
+		PendingSessions:          make(map[string]bool),
+		ChatIdleTimeout:          cfg.ChatSessions.IdleTimeoutDuration(),
+		ManualGracePeriod:        cfg.ChatSessions.GracePeriodDuration(),
+		Now:                      clk,
 	}
 
 	// Agents. Load runtime suspension state once against the in-scope

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -527,6 +527,29 @@ func TestAwakeSetToWakeEvalsPreservesDecisionReason(t *testing.T) {
 	}
 }
 
+func TestAwakeSetToWakeEvalsMapsRoutedDemandToWakeWork(t *testing.T) {
+	evals := awakeSetToWakeEvals(
+		map[string]AwakeDecision{
+			"s-worker": {ShouldWake: true, Reason: "routed-demand"},
+		},
+		[]AwakeSessionBead{{
+			ID:          "mc-session-1",
+			SessionName: "s-worker",
+		}},
+	)
+
+	got := evals["mc-session-1"]
+	if got.Reason != "routed-demand" {
+		t.Fatalf("Reason = %q, want routed-demand", got.Reason)
+	}
+	if !containsWakeReason(got.Reasons, WakeWork) {
+		t.Fatalf("Reasons = %v, want WakeWork (routed demand is work, not config)", got.Reasons)
+	}
+	if containsWakeReason(got.Reasons, WakeConfig) {
+		t.Fatalf("Reasons = %v, must not fall through to WakeConfig", got.Reasons)
+	}
+}
+
 func TestAwakeSetToWakeEvalsMapsMinActiveToWakeConfig(t *testing.T) {
 	evals := awakeSetToWakeEvals(
 		map[string]AwakeDecision{

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -34,6 +34,7 @@ func TestBuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilitySta
 		nil,
 		nil,
 		nil,
+		nil,
 		now,
 	)
 
@@ -67,7 +68,7 @@ func TestBuildAwakeInputFromReconcilerReadsInfoSnapshot(t *testing.T) {
 
 	input := buildAwakeInputFromReconciler(
 		&config.City{}, "", []session.Info{info},
-		nil, nil, nil, nil, nil, nil, nil, nil, now,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, now,
 	)
 
 	if len(input.SessionBeads) != 1 {
@@ -105,6 +106,7 @@ func TestBuildAwakeInputFromReconcilerCanonicalizesLegacyBoundTemplate(t *testin
 				"wake_request": "explicit",
 			},
 		})},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -160,6 +162,7 @@ func TestBuildAwakeInputFromReconcilerKeepsUnresolvableTemplateRaw(t *testing.T)
 		nil,
 		nil,
 		nil,
+		nil,
 		now,
 	)
 
@@ -189,6 +192,7 @@ func TestBuildAwakeInputFromReconcilerCarriesResetPendingMetadata(t *testing.T) 
 				session.ResetCommittedAtKey:  now.Format(time.RFC3339),
 			},
 		})},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -241,6 +245,7 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 		nil,
 		nil,
 		nil,
+		nil,
 		[]wakeTarget{{info: sessiontest.SeedBead(t, sessionBead), alive: true}},
 		sp,
 		now,
@@ -286,6 +291,7 @@ func TestBuildAwakeInputFromReconciler_BlockedAssignedOpenBeadDoesNotKeepSession
 		cfg,
 		"",
 		[]session.Info{sessiontest.SeedBead(t, sessionBead)},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -342,6 +348,7 @@ func TestBuildAwakeInputFromReconciler_ReadyAssignedOpenBeadWakesSession(t *test
 		nil,
 		nil,
 		nil,
+		nil,
 		[]beads.Bead{readyWork},
 		[]bool{true}, // readyAssignedFlags: bead IS ready
 		nil,
@@ -387,6 +394,7 @@ func TestBuildAwakeInputFromReconciler_InProgressAssignedBeadStillWakes(t *testi
 		cfg,
 		"",
 		[]session.Info{sessiontest.SeedBead(t, sessionBead)},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -467,6 +475,7 @@ func TestBuildAwakeInputFromReconciler_CrossStoreSameIDReadinessIsStoreScoped(t 
 		cfg,
 		"",
 		[]session.Info{sessiontest.SeedBead(t, citySession), sessiontest.SeedBead(t, rigSession)},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -570,6 +579,7 @@ func TestBuildAwakeInputFromReconcilerCarriesNamedSessionDemand(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		runtime.NewFake(),
 		now,
 	)
@@ -615,6 +625,7 @@ func TestBuildAwakeInputFromReconciler_RigNamedWorkQueryDemandWakesCanonicalSess
 		cfg,
 		"", // cityPath: empty exercises zero suspension state
 		[]session.Info{sessiontest.SeedBead(t, sessionBead)},
+		nil,
 		nil,
 		nil,
 		map[string]bool{"rig-a/worker": true},
@@ -676,7 +687,7 @@ func TestBuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes(t *testing.T) 
 		cfg,
 		"", // cityPath: empty exercises zero suspension state
 		[]session.Info{sessiontest.SeedBead(t, postChurnBead)},
-		nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
 		runtime.NewFake(),
 		now,
 	)

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -19,21 +19,22 @@ const defaultOnDemandIdleTimeout = 5 * time.Minute
 // should be awake. All external I/O (shell commands, tmux checks, store
 // queries) happens before this function is called.
 type AwakeInput struct {
-	Agents             []AwakeAgent
-	NamedSessions      []AwakeNamedSession
-	SessionBeads       []AwakeSessionBead
-	WorkBeads          []AwakeWorkBead // in_progress assigned work plus ready open assigned work
-	ScaleCheckCounts   map[string]int  // agent template → scale_check count
-	NamedSessionDemand map[string]bool // named-session identity → routed/assigned work demand
-	NamedSessionWorkQ  map[string]bool // named-session identity → bridge-carried work_query demand
-	WorkSet            map[string]bool // agent template → work_query found pending work
-	RunningSessions    map[string]bool // session name → tmux exists
-	AttachedSessions   map[string]bool // session name → user attached
-	PendingSessions    map[string]bool // session name → pending interaction
-	ReadyWaitSet       map[string]bool // session bead ID → durable wait is ready
-	ChatIdleTimeout    time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
-	ManualGracePeriod  time.Duration   // grace period before manual sessions can be idle-slept (0 = disabled)
-	Now                time.Time
+	Agents                   []AwakeAgent
+	NamedSessions            []AwakeNamedSession
+	SessionBeads             []AwakeSessionBead
+	WorkBeads                []AwakeWorkBead // in_progress assigned work plus ready open assigned work
+	ScaleCheckCounts         map[string]int  // agent template → scale_check count
+	NamedSessionDemand       map[string]bool // named-session identity → routed/assigned work demand
+	NamedSessionRoutedDemand map[string]bool // named-session identity → pre-suppression routed demand on backing template (wake-only, see DesiredStateResult.NamedSessionRoutedDemand)
+	NamedSessionWorkQ        map[string]bool // named-session identity → bridge-carried work_query demand
+	WorkSet                  map[string]bool // agent template → work_query found pending work
+	RunningSessions          map[string]bool // session name → tmux exists
+	AttachedSessions         map[string]bool // session name → user attached
+	PendingSessions          map[string]bool // session name → pending interaction
+	ReadyWaitSet             map[string]bool // session bead ID → durable wait is ready
+	ChatIdleTimeout          time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
+	ManualGracePeriod        time.Duration   // grace period before manual sessions can be idle-slept (0 = disabled)
+	Now                      time.Time
 }
 
 // AwakeAgent represents an [[agent]] config entry.
@@ -185,6 +186,8 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			switch {
 			case input.NamedSessionDemand[ns.Identity]:
 				reason = "named-demand"
+			case input.NamedSessionRoutedDemand[ns.Identity]:
+				reason = "routed-demand"
 			case input.NamedSessionWorkQ[ns.Identity]:
 				reason = "work-query"
 			default:

--- a/cmd/gc/compute_awake_set_min_active_test.go
+++ b/cmd/gc/compute_awake_set_min_active_test.go
@@ -157,7 +157,7 @@ func TestBuildAwakeInputPropagatesMinActiveSessions(t *testing.T) {
 	input := buildAwakeInputFromReconciler(
 		&config.City{Agents: []config.Agent{{Name: "pl", MinActiveSessions: &minSess}}},
 		"", // cityPath: empty exercises zero suspension state
-		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		time.Now().UTC(),
 	)
 	var found bool
@@ -199,7 +199,7 @@ func TestMinActive_LegacyBoundTemplateRevivedThroughBridge(t *testing.T) {
 				"template":     "rig/gc.pl",
 			},
 		})},
-		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		time.Now().UTC(),
 	)
 	result := ComputeAwakeSet(input)

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -352,10 +352,19 @@ func canonicalSingletonAliasHeldTemplates(cfg *config.City, sessionInfos []sessi
 			if sb.Closed || isPoolManagedSessionInfo(sb) || isDrainedSessionInfo(sb) || isFailedCreateSessionInfo(sb) {
 				continue
 			}
-			if strings.TrimSpace(sb.MetadataState) == "asleep" {
-				continue
-			}
 			if strings.TrimSpace(sb.Alias) == template {
+				held[template] = struct{}{}
+				break
+			}
+			// A named session's Alias holds its own configured identity, not
+			// the backing template (build_desired_state.go sets tp.Alias =
+			// identity for every named session, e.g. "primary" bound to
+			// template "worker"). When identity != template, the Alias check
+			// above never matches even though this bead is the singleton
+			// slot's sole occupant. Its Template field is always the backing
+			// template's qualified name, so use that as the named-session
+			// match instead of Alias.
+			if isNamedSessionInfo(sb) && strings.TrimSpace(sb.Template) == template {
 				held[template] = struct{}{}
 				break
 			}

--- a/cmd/gc/pool_desired_state_asleep_alias_test.go
+++ b/cmd/gc/pool_desired_state_asleep_alias_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// asleepNamedAliasHolder builds a configured named-session bead that owns the
+// canonical alias for "mayor" and is currently asleep — the exact shape live
+// gascity/reviewer bead gm-gjmwz2 held in every one of its asleep samples
+// (state=asleep AND alias=gascity/reviewer, 4/4 samples between 16:04 and
+// 19:59 on 2026-07-24).
+func asleepNamedAliasHolder() beads.Bead {
+	return beads.Bead{
+		ID:     "sess-asleep",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"session_name":               "mayor",
+			"template":                   "mayor",
+			"alias":                      "mayor",
+			"session_origin":             "named",
+			"state":                      "asleep",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	}
+}
+
+// TestCanonicalSingletonAliasHeldTemplates_AsleepNamedHolderStillHoldsAlias is
+// the missing case in TestCanonicalSingletonAliasHeldTemplates_ExcludesFailedCreateHolder.
+//
+// That test enumerates the four categories that genuinely RELEASE the canonical
+// alias — closed and drained (retire path), pool-managed (never held it), and
+// failed-create (failedCreateIdentityReleased in names.go). Each has an explicit
+// release mechanism. Sleeping has none: an asleep named session keeps its alias
+// and reclaims it on wake.
+//
+// canonicalSingletonAliasHeldTemplates nonetheless skips asleep holders
+// (pool_desired_state.go:355-357), so the pool sees a free alias, mints an
+// ephemeral standby, and that standby immediately parks on
+// pool_alias_conflict and is drained — the wake/spawn/drain churn in ga-vcmg58.
+func TestCanonicalSingletonAliasHeldTemplates_AsleepNamedHolderStillHoldsAlias(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("mayor", "", intPtr(1), 0)}, // canonical singleton
+	}
+
+	held := canonicalSingletonAliasHeldTemplates(cfg, sessionInfosFromBeads([]beads.Bead{asleepNamedAliasHolder()}))
+	if _, ok := held["mayor"]; !ok {
+		t.Fatalf("asleep named holder still owns the canonical alias (sleeping has no release path, "+
+			"unlike closed/drained/pool-managed/failed-create) and must mark mayor held; got %v", held)
+	}
+}
+
+// asleepNamedAliasHolderWithDivergentIdentity mirrors asleepNamedAliasHolder
+// but for a named session whose configured identity differs from its backing
+// template ("primary" bound to template "worker") — the shape
+// TestReconcileSessionBeads_OnDemandNamedSessionWakesFromSingletonPoolDemandWithoutNamedDemand
+// exercises end-to-end. build_desired_state.go sets a named session bead's
+// Alias to its identity, not its backing template, so the plain
+// alias==template comparison in canonicalSingletonAliasHeldTemplates can
+// never match this shape; only the Template-based named-session fallback can.
+func asleepNamedAliasHolderWithDivergentIdentity() beads.Bead {
+	return beads.Bead{
+		ID:     "sess-asleep-divergent",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"session_name":               "primary",
+			"template":                   "worker",
+			"alias":                      "primary",
+			"session_origin":             "named",
+			"state":                      "asleep",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "primary",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	}
+}
+
+// TestCanonicalSingletonAliasHeldTemplates_AsleepNamedHolderIdentityDiffersFromTemplate
+// isolates the Template-based fallback match at the canonicalSingletonAliasHeldTemplates
+// unit level (not just end-to-end through the reconciler): a named session's
+// Alias carries its identity ("primary"), never its backing template
+// ("worker"), so the plain Alias==template comparison can never mark the
+// template held for this shape — only the isNamedSessionInfo/Template match
+// does. Without it, a canonical singleton whose sole named occupant has a
+// distinct identity would look permanently free and take a redundant standby
+// every reconcile tick.
+func TestCanonicalSingletonAliasHeldTemplates_AsleepNamedHolderIdentityDiffersFromTemplate(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("worker", "", intPtr(1), 0)}, // canonical singleton
+	}
+
+	held := canonicalSingletonAliasHeldTemplates(cfg, sessionInfosFromBeads([]beads.Bead{asleepNamedAliasHolderWithDivergentIdentity()}))
+	if _, ok := held["worker"]; !ok {
+		t.Fatalf("named holder with identity %q != template %q must still mark the template held via the "+
+			"Template-based fallback match, not just Alias; got %v", "primary", "worker", held)
+	}
+}
+
+// TestComputePoolDesiredStates_AsleepNamedHolderSuppressesRedundantStandby is
+// the end-to-end consequence: routed demand arriving while the named singleton
+// sleeps must wake that holder, not mint a second session it can never hand the
+// alias to.
+//
+// Live trace (gascity/reviewer, 2026-07-24, trigger bead ga-z3bhzw):
+//
+//	18:10:38  pool mints wisp gm-pgn1w      (named holder gm-gjmwz2 asleep since 16:04:39)
+//	18:11:00  state=active
+//	18:11:20  pool_alias_conflict=gascity/reviewer, count=1   <- born dead
+//	18:11:51  pool_alias_conflict_count=3
+//	18:13:17  state=drained, closed
+//	18:13:38  gm-gjmwz2 wakes and does the work anyway
+//
+// Net effect: one full worktree setup + agent boot burned per routed bead that
+// arrives while the singleton sleeps.
+func TestComputePoolDesiredStates_AsleepNamedHolderSuppressesRedundantStandby(t *testing.T) {
+	cfg := &config.City{
+		Agents:        []config.Agent{poolAgent("mayor", "", intPtr(1), 0)},
+		NamedSessions: []config.NamedSession{{Template: "mayor", Mode: "on_demand"}},
+	}
+
+	// One unit of routed demand, exactly as the default routed-work probe
+	// reports it for an on_demand named-backing template
+	// (build_desired_state.go:469-471).
+	result := ComputePoolDesiredStates(
+		cfg,
+		nil,
+		sessionInfosFromBeads([]beads.Bead{asleepNamedAliasHolder()}),
+		map[string]int{"mayor": 1},
+	)
+
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
+	}
+	if total != 0 {
+		t.Fatalf("pool requests = %d, want 0 — the asleep named holder owns the canonical alias, "+
+			"so a pool standby can never acquire it and is drained after parking on "+
+			"pool_alias_conflict (ga-vcmg58). Routed demand must wake the holder instead.", total)
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1095,7 +1095,12 @@ func wakeDemandOverridesSleepSuppression(
 	if eval.HasAssignedWork {
 		return true
 	}
-	hasDemand := poolDesired[template] > 0
+	// Routed demand wakes the canonical alias holder. Alias suppression
+	// deliberately drops the standby's poolDesired to zero, so the pool count
+	// alone cannot carry the signal here — without this the holder stays
+	// asleep under a configured non-interactive sleep policy and the routed
+	// work never gets picked up.
+	hasDemand := poolDesired[template] > 0 || decision.Reason == "routed-demand"
 	if hasDemand && policy.Class == config.SessionSleepNonInteractive {
 		return true
 	}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1192,7 +1192,7 @@ func reconcileSessionBeadsAtPath(
 	snap := newSessionBeadSnapshotFromReconcileRows(sessionpkg.ReconcileRowsFromBeads(sessions))
 	return reconcileSessionBeadsAtPathWithNamedDemand(
 		ctx, cityPath, snap.OpenForReconcile(), snap, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt, nil,
-		poolDesired, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
+		poolDesired, nil, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
 		startOptions...,
 	)
 }
@@ -1215,6 +1215,7 @@ func reconcileSessionBeadsAtPathWithNamedDemand(
 	gate *providerHealthGate,
 	poolDesired map[string]int,
 	namedSessionDemand map[string]bool,
+	namedRoutedDemand map[string]bool,
 	storeQueryPartial bool,
 	workSet map[string]bool,
 	cityName string,
@@ -1231,7 +1232,7 @@ func reconcileSessionBeadsAtPathWithNamedDemand(
 	// reconcileSessionBeadsAtPath builds them from raw beads for tests).
 	return reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cityPath, rows, snapshot, desiredState, configuredNames, cfg, sp, beads.SessionStore{Store: store}, dops, assignedWorkBeads, rigStores, readyWaitSet, dt, gate,
-		poolDesired, namedSessionDemand, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
+		poolDesired, namedSessionDemand, namedRoutedDemand, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
 		startOptions...,
 	)
 }
@@ -1271,7 +1272,7 @@ func reconcileSessionBeadsTraced(
 	snap := newSessionBeadSnapshotFromReconcileRows(sessionpkg.ReconcileRowsFromBeads(sessions))
 	return reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cityPath, snap.OpenForReconcile(), snap, desiredState, configuredNames, cfg, sp, beads.SessionStore{Store: store}, dops, assignedWorkBeads, rigStores, readyWaitSet, dt, nil,
-		poolDesired, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, trace,
+		poolDesired, nil, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, trace,
 		startOptions...,
 	)
 }
@@ -1294,6 +1295,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	gate *providerHealthGate,
 	poolDesired map[string]int,
 	namedSessionDemand map[string]bool,
+	namedRoutedDemand map[string]bool,
 	storeQueryPartial bool,
 	workSet map[string]bool,
 	cityName string,
@@ -3304,7 +3306,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		sessionInfos[i] = infoByID[orderedIDs[i]]
 	}
 	awakeInput := buildAwakeInputFromReconciler(
-		cfg, cityPath, sessionInfos, poolDesired, namedSessionDemand, workSet, readyWaitSet,
+		cfg, cityPath, sessionInfos, poolDesired, namedSessionDemand, namedRoutedDemand, workSet, readyWaitSet,
 		assignedWorkBeads, reconcileOpts.readyAssignedFlags, wakeTargets, sp, clk.Now(),
 	)
 	awakeDecisions := ComputeAwakeSet(awakeInput)

--- a/cmd/gc/session_reconciler_killsite_fold_test.go
+++ b/cmd/gc/session_reconciler_killsite_fold_test.go
@@ -70,7 +70,7 @@ func maxAgeReconcileSnapshot(e *reconcilerTestEnv, sessions []beads.Bead, tr max
 	snap := newSessionBeadSnapshotFromReconcileRows(sessionpkg.ReconcileRowsFromBeads(sessions))
 	reconcileSessionBeadsTracedWithNamedDemand(
 		context.Background(), "", snap.OpenForReconcile(), snap, e.desiredState, cfgNames, e.cfg, e.sp,
-		beads.SessionStore{Store: e.store}, nil, nil, nil, nil, e.dt, nil, poolDesired, nil, false, nil, "",
+		beads.SessionStore{Store: e.store}, nil, nil, nil, nil, e.dt, nil, poolDesired, nil, nil, false, nil, "",
 		nil, e.clk, e.rec, 0, 0, &e.stdout, &e.stderr, nil,
 		withMaxSessionAgeTracker(tr),
 	)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3131,7 +3131,7 @@ func TestReconcileSessionBeads_StrandedCarrierThreadedThroughTick(t *testing.T) 
 			reconcileSessionBeadsTracedWithNamedDemand(
 				context.Background(), "", snap.OpenForReconcile(), carrier, env.desiredState, map[string]bool{"worker": true},
 				env.cfg, env.sp, beads.SessionStore{Store: failing}, newFakeDrainOps(), nil, nil, nil,
-				env.dt, nil, map[string]int{"worker": 1}, nil, false, nil, "", nil, env.clk, env.rec, 0, 0,
+				env.dt, nil, map[string]int{"worker": 1}, nil, nil, false, nil, "", nil, env.clk, env.rec, 0, 0,
 				&env.stdout, &env.stderr, nil,
 			)
 		}
@@ -3188,7 +3188,7 @@ func TestReconcileSessionBeads_Phase0HealVisibleOnSnapshot(t *testing.T) {
 	reconcileSessionBeadsTracedWithNamedDemand(
 		context.Background(), "", snap.OpenForReconcile(), snap, env.desiredState, map[string]bool{"worker": true},
 		env.cfg, env.sp, beads.SessionStore{Store: env.store}, newFakeDrainOps(), nil, nil, nil,
-		env.dt, nil, poolDesired, nil, false, nil, "", nil, env.clk, env.rec, 0, 0,
+		env.dt, nil, poolDesired, nil, nil, false, nil, "", nil, env.clk, env.rec, 0, 0,
 		&env.stdout, &env.stderr, nil,
 	)
 
@@ -4682,18 +4682,24 @@ func TestReconcileSessionBeads_OnDemandNamedSessionWakesFromPoolDemandWithoutNam
 	}
 	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
 
-	woken, running, namedDemand, starts := reconcileExistingAsleepNamedSessionWithRoutedWork(t, cfg, sessionName, "mayor", "mayor")
+	woken, running, namedDemand, routedDemand, starts, postSessions := reconcileExistingAsleepNamedSessionWithRoutedWork(t, cfg, sessionName, "mayor", "mayor")
 	if namedDemand["mayor"] {
 		t.Fatalf("NamedSessionDemand[mayor] = true for routed_to=mayor, want false because routed_to targets pools")
+	}
+	if !routedDemand["mayor"] {
+		t.Fatalf("NamedSessionRoutedDemand[mayor] = false, want true: routed-but-unassigned demand on the backing template must set the new pre-suppression signal")
 	}
 	if woken != 1 {
 		t.Fatalf("woken = %d, want 1; starts=%v", woken, starts)
 	}
-	if running {
-		t.Fatalf("on-demand named session %q started from routed pool demand; starts=%v", sessionName, starts)
+	if !running {
+		t.Fatalf("on-demand named session %q did not wake from routed pool demand (asleep holder should wake directly instead of a pool standby); starts=%v", sessionName, starts)
 	}
-	if len(starts) == 0 {
-		t.Fatal("pool demand did not start any session")
+	if len(starts) != 1 || starts[0] != sessionName {
+		t.Fatalf("starts = %v, want exactly [%s]: the asleep named holder owns the canonical alias, so no pool standby should ever be spawned for it", starts, sessionName)
+	}
+	if len(postSessions) != 1 {
+		t.Fatalf("session beads after reconcile = %d, want 1: zero standby session beads must be created when the asleep named holder owns the canonical alias", len(postSessions))
 	}
 }
 
@@ -4709,22 +4715,28 @@ func TestReconcileSessionBeads_OnDemandNamedSessionWakesFromSingletonPoolDemandW
 		NamedSessions: []config.NamedSession{{Name: "primary", Template: "worker", Mode: "on_demand"}},
 	}
 
-	woken, running, namedDemand, starts := reconcileExistingAsleepNamedSessionWithRoutedWork(t, cfg, "primary", "primary", "worker")
+	woken, running, namedDemand, routedDemand, starts, postSessions := reconcileExistingAsleepNamedSessionWithRoutedWork(t, cfg, "primary", "primary", "worker")
 	if namedDemand["primary"] {
 		t.Fatalf("NamedSessionDemand[primary] = true for routed_to=worker, want false because routed_to targets pools")
+	}
+	if !routedDemand["primary"] {
+		t.Fatalf("NamedSessionRoutedDemand[primary] = false, want true: routed-but-unassigned demand on the backing template must set the new pre-suppression signal")
 	}
 	if woken != 1 {
 		t.Fatalf("woken = %d, want 1; starts=%v", woken, starts)
 	}
-	if running {
-		t.Fatalf("on-demand named session primary started from routed pool demand; starts=%v", starts)
+	if !running {
+		t.Fatalf("on-demand named session primary did not wake from routed pool demand (asleep holder should wake directly instead of a pool standby); starts=%v", starts)
 	}
-	if len(starts) == 0 {
-		t.Fatal("pool demand did not start any session")
+	if len(starts) != 1 || starts[0] != "primary" {
+		t.Fatalf("starts = %v, want exactly [primary]: the asleep named holder owns the canonical alias, so no pool standby should ever be spawned for it", starts)
+	}
+	if len(postSessions) != 1 {
+		t.Fatalf("session beads after reconcile = %d, want 1: zero standby session beads must be created when the asleep named holder owns the canonical alias", len(postSessions))
 	}
 }
 
-func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config.City, sessionName, identity, routedTo string) (int, bool, map[string]bool, []string) {
+func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config.City, sessionName, identity, routedTo string) (int, bool, map[string]bool, map[string]bool, []string, []beads.Bead) {
 	t.Helper()
 
 	cityPath := t.TempDir()
@@ -4778,7 +4790,7 @@ func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config
 	woken := reconcileSessionBeadsAtPathWithNamedDemand(
 		context.Background(), cityPath, snap.OpenForReconcile(), snap, dsResult.State, cfgNames, cfg, sp,
 		store, nil, dsResult.AssignedWorkBeads, nil, nil, newDrainTracker(), nil, poolDesired,
-		dsResult.NamedSessionDemand, dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+		dsResult.NamedSessionDemand, dsResult.NamedSessionRoutedDemand, dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
 		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	var starts []string
@@ -4787,7 +4799,59 @@ func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config
 			starts = append(starts, call.Name)
 		}
 	}
-	return woken, sp.IsRunning(sessionName), dsResult.NamedSessionDemand, starts
+	postSessions, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads (post-reconcile): %v", err)
+	}
+	return woken, sp.IsRunning(sessionName), dsResult.NamedSessionDemand, dsResult.NamedSessionRoutedDemand, starts, postSessions
+}
+
+// TestReconcileSessionBeads_AsleepNamedSingletonRegressionWakesInsteadOfStandby
+// is the end-to-end regression test for ga-jl73y2 (Option A): it drives the
+// real BuildDesiredState -> ComputePoolDesiredStates -> ComputeAwakeSet ->
+// reconcile pipeline (via reconcileExistingAsleepNamedSessionWithRoutedWork,
+// same as the two inverted tests above) for the exact live-incident shape —
+// canonical singleton "mayor", asleep, identity==template, one unit of
+// routed-but-unassigned demand, zero assignee-direct demand — and additionally
+// asserts on the surviving session bead's metadata directly, not just a bare
+// count: no bead of pool/ephemeral origin exists, and the one bead that does
+// exist is still the same named holder, not a replacement.
+func TestReconcileSessionBeads_AsleepNamedSingletonRegressionWakesInsteadOfStandby(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{Template: "mayor", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
+
+	woken, running, namedDemand, routedDemand, starts, postSessions := reconcileExistingAsleepNamedSessionWithRoutedWork(t, cfg, sessionName, "mayor", "mayor")
+	if namedDemand["mayor"] {
+		t.Fatalf("NamedSessionDemand[mayor] = true, want false: this scenario is routed-unassigned demand only, zero assignee-direct demand")
+	}
+	if !routedDemand["mayor"] {
+		t.Fatalf("NamedSessionRoutedDemand[mayor] = false, want true")
+	}
+	if woken != 1 || !running {
+		t.Fatalf("asleep named singleton must wake from routed-unassigned demand: woken=%d running=%v starts=%v", woken, running, starts)
+	}
+	if len(starts) != 1 || starts[0] != sessionName {
+		t.Fatalf("starts = %v, want exactly [%s]: no standby session may ever be started for a template whose canonical alias is held by an asleep named holder", starts, sessionName)
+	}
+	if len(postSessions) != 1 {
+		t.Fatalf("session beads after reconcile = %d, want 1: zero standby session beads created for the mayor template", len(postSessions))
+	}
+	held := postSessions[0]
+	if origin := held.Metadata["session_origin"]; origin == "ephemeral" {
+		t.Fatalf("surviving session bead has session_origin=%q — a pool-spawned standby was minted despite the asleep named holder owning the canonical alias", origin)
+	}
+	if held.Metadata[namedSessionIdentityMetadata] != "mayor" {
+		t.Fatalf("surviving session bead identity = %q, want %q: the original named holder must still be the one occupying the slot, not a replacement", held.Metadata[namedSessionIdentityMetadata], "mayor")
+	}
 }
 
 func TestReconcileSessionBeads_SyncsGCDirWithWorkDirOverride(t *testing.T) {

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -600,7 +600,7 @@ func TestReconcileTraceResultsObservePostTickValues(t *testing.T) {
 	reconcileSessionBeadsTracedWithNamedDemand(
 		context.Background(), cityDir, snap.OpenForReconcile(), snap, nil, map[string]bool{},
 		cfg, runtime.NewFake(), beads.SessionStore{Store: store}, nil, nil, nil, nil,
-		newDrainTracker(), nil, nil, nil, false, nil, cityName, nil, clock.Real{},
+		newDrainTracker(), nil, nil, nil, nil, false, nil, cityName, nil, clock.Real{},
 		events.Discard, 0, 0, io.Discard, io.Discard, cycle,
 	)
 
@@ -661,6 +661,7 @@ func TestSessionReconcilePhaseTraceUsesDistinctSites(t *testing.T) {
 		nil, // gate (*providerHealthGate) — ADR-0013 A1 M3a
 		nil,
 		nil,
+		nil, // namedRoutedDemand
 		false,
 		nil,
 		"trace-town",

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -405,6 +405,26 @@ func TestReconcilerWakeDemandOverridesSleepSuppressionForAssignedWork(t *testing
 	}
 }
 
+// Routed demand wakes the canonical alias holder, but alias suppression
+// deliberately zeroes the standby's poolDesired. Without an explicit override
+// the holder stays asleep under a configured non-interactive sleep policy
+// (sleep_after_idle) and the routed work is never picked up.
+func TestReconcilerWakeDemandOverridesSleepSuppressionForRoutedDemand(t *testing.T) {
+	policy := resolvedSessionSleepPolicy{Class: config.SessionSleepNonInteractive}
+	decision := AwakeDecision{ShouldWake: true, Reason: "routed-demand"}
+	eval := wakeEvaluation{Reasons: []WakeReason{WakeWork}}
+
+	if !wakeDemandOverridesSleepSuppression(decision, eval, policy, map[string]int{"worker": 0}, "worker", false) {
+		t.Fatal("routed demand should override noninteractive sleep suppression when alias suppression zeroed poolDesired")
+	}
+	if !wakeDemandOverridesSleepSuppression(decision, eval, policy, nil, "worker", false) {
+		t.Fatal("routed demand should override noninteractive sleep suppression with no pool entry at all")
+	}
+	if wakeDemandOverridesSleepSuppression(decision, eval, policy, nil, "worker", true) {
+		t.Fatal("explicit sleep intent should still override routed demand")
+	}
+}
+
 func TestReconcileSessionBeads_MinActiveCityStopWakeBypassesInteractiveSleepSuppression(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/release-gates/ga-tg4m6s-named-session-routed-demand-push-guard-retry-gate.md
+++ b/release-gates/ga-tg4m6s-named-session-routed-demand-push-guard-retry-gate.md
@@ -1,0 +1,45 @@
+# Release Gate: Named-session routed-demand wake and push-guard read retry
+
+- Deploy bead: `ga-tg4m6s`
+- Reviewed source: `8137a6d6e73513336c12d3cb9815b185ff4a1773`
+- Source commits:
+  - `ff2621058af04ff57a109fe52cecc2ff07564da1` — wake asleep on-demand named singletons on routed demand
+  - `8137a6d6e73513336c12d3cb9815b185ff4a1773` — bound and retry push-ownership-guard bead reads
+- Review bead: `ga-lstvw3`
+- Base evaluated: `origin/main@c967f1eebef64fe1ad4d9d287fd778fcd796f640`
+- Overall verdict: **PASS**
+
+## Gate checklist
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | **PASS** | Closed review bead `ga-lstvw3` records `REVIEW VERDICT: PASS` for exact commit `8137a6d6e73513336c12d3cb9815b185ff4a1773`, independently verifies both bundled fixes, and concludes: “Both fixes: PASS. No blocking findings.” |
+| 2 | Acceptance criteria met | **PASS** | The asleep named-session alias holder now suppresses a redundant standby while `NamedSessionRoutedDemand` wakes that holder from raw pre-suppression routed demand. The signal is threaded through desired-state/reconciler/awake-set plumbing and remains absent from `mergeNamedSessionDemand` and `wakeDemandOverridesSleepSuppression`, preserving the wake-only, non-pool-sizing, non-sleep-suppressing contract. The push guard adds environment-overridable `POG_READ_ATTEMPTS` (default 3) to both `bd list` and `bd show` reads, preserves fail-closed behavior, and suggests retry before `--no-verify`. |
+| 3 | Tests pass | **PASS** | Exact-SHA checks passed on the first attempt: six focused routed-demand/alias/reconciler regressions; `scripts/test-push-ownership-guard.sh` (`pass=26 fail=0`), including transient recovery, exhaustion, and real ownership-change blocking; `go test ./scripts/... -count=1 -run TestPushOwnershipGuard`; shell syntax checks; `go build ./...`; `go vet ./...`; and serialized `make test-fast-parallel` with all eight jobs green. |
+| 4 | No high-severity review findings open | **PASS** | `ga-lstvw3` reports no blocking findings after OWASP, test-coverage, design-contract, and retry-integrity review. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | **PASS** | `git status --porcelain=v1` was empty after all exact-SHA validation. `git diff --check origin/main...HEAD` produced no output. The configured hook path is active at `/home/jaword/projects/gascity/.githooks`; the gate commit runs the pre-commit hook. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first after fetching main. `git merge-tree --write-tree origin/main 8137a6d6e73513336c12d3cb9815b185ff4a1773` exited 0 and produced tree `3db85acd35f38148ef728a68dbcf178fd9f31899`; no content conflicts. The candidate is 15 commits behind / 2 ahead of current main, and no self-rebase or source-branch mutation was required. |
+| 7 | Single feature theme | **PASS** | The commit set is exactly the explicitly reviewed reliability bundle: route unassigned demand to the existing named-session holder without a redundant standby, and keep the ownership guard reliable under transient Dolt read contention while delivering that change. There are no additional source-branch commits or unrelated product surfaces. |
+
+## Acceptance evidence
+
+### Named-session routed demand
+
+- `TestCanonicalSingletonAliasHeldTemplates_AsleepNamedHolderStillHoldsAlias`
+- `TestCanonicalSingletonAliasHeldTemplates_AsleepNamedHolderIdentityDiffersFromTemplate`
+- `TestComputePoolDesiredStates_AsleepNamedHolderSuppressesRedundantStandby`
+- `TestReconcileSessionBeads_OnDemandNamedSessionWakesFromPoolDemandWithoutNamedDemand`
+- `TestReconcileSessionBeads_OnDemandNamedSessionWakesFromSingletonPoolDemandWithoutNamedDemand`
+- `TestReconcileSessionBeads_AsleepNamedSingletonRegressionWakesInsteadOfStandby`
+
+All six passed with `-count=1`.
+
+### Push ownership guard
+
+- A transient failed read recovers and permits the push.
+- Persistent read failure exhausts exactly three attempts and still blocks.
+- Recovery followed by a real ownership change still blocks.
+- Both guarded read sites use the bounded retry helper.
+- Retry guidance precedes the last-resort `--no-verify` text.
+
+The shell suite passed `26/26`, and its Go wrapper passed.

--- a/release-gates/ga-tg4m6s-named-session-routed-demand-push-guard-retry-gate.md
+++ b/release-gates/ga-tg4m6s-named-session-routed-demand-push-guard-retry-gate.md
@@ -9,12 +9,28 @@
 - Base evaluated: `origin/main@c967f1eebef64fe1ad4d9d287fd778fcd796f640`
 - Overall verdict: **PASS**
 
+### Maintainer fixups after the reviewed SHA
+
+The gate below was evaluated at `8137a6d6e`. Maintainer review of the PR
+surfaced integration gaps that were fixed on the branch afterward, so the
+checklist evidence no longer describes the branch head verbatim — the
+corrections are called out inline in criteria 2 and 3:
+
+- `37a364c9d` — classify routed demand as work (`awakeSetToWakeEvals`) and keep
+  its wake through non-interactive sleep suppression.
+- This commit — gate `NamedSessionRoutedDemand` to canonical singleton backing
+  pools, plus this gate refresh.
+
+These are maintainer-side integration fixes to the same feature, not new
+surfaces. They are **not** covered by the `ga-lstvw3` review verdict, which
+closed against `8137a6d6e`.
+
 ## Gate checklist
 
 | # | Criterion | Verdict | Evidence |
 |---|-----------|---------|----------|
 | 1 | Review PASS present | **PASS** | Closed review bead `ga-lstvw3` records `REVIEW VERDICT: PASS` for exact commit `8137a6d6e73513336c12d3cb9815b185ff4a1773`, independently verifies both bundled fixes, and concludes: “Both fixes: PASS. No blocking findings.” |
-| 2 | Acceptance criteria met | **PASS** | The asleep named-session alias holder now suppresses a redundant standby while `NamedSessionRoutedDemand` wakes that holder from raw pre-suppression routed demand. The signal is threaded through desired-state/reconciler/awake-set plumbing and remains absent from `mergeNamedSessionDemand` and `wakeDemandOverridesSleepSuppression`, preserving the wake-only, non-pool-sizing, non-sleep-suppressing contract. The push guard adds environment-overridable `POG_READ_ATTEMPTS` (default 3) to both `bd list` and `bd show` reads, preserves fail-closed behavior, and suggests retry before `--no-verify`. |
+| 2 | Acceptance criteria met | **PASS** | The asleep named-session alias holder now suppresses a redundant standby while `NamedSessionRoutedDemand` wakes that holder from raw pre-suppression routed demand. The signal is threaded through desired-state/reconciler/awake-set plumbing and remains absent from `mergeNamedSessionDemand`, preserving the wake-only, non-pool-sizing contract. **Corrected after `37a364c9d`:** the original wording also claimed the signal stays absent from `wakeDemandOverridesSleepSuppression`. It is now deliberately present there. Alias suppression zeroes the standby's `poolDesired`, so the pool count cannot carry the signal at that site and the holder would stay asleep under a configured non-interactive sleep policy — the exact wake this feature exists to perform. Explicit sleep intent still wins, so the non-sleep-suppressing intent is preserved for operator-requested sleep. **Scoped after this commit:** the signal is emitted only for canonical singleton backing pools, since a multi-instance pool serves routed demand with an ordinary standby and would otherwise both wake the holder and mint one. The push guard adds environment-overridable `POG_READ_ATTEMPTS` (default 3) to both `bd list` and `bd show` reads, preserves fail-closed behavior, and suggests retry before `--no-verify`. |
 | 3 | Tests pass | **PASS** | Exact-SHA checks passed on the first attempt: six focused routed-demand/alias/reconciler regressions; `scripts/test-push-ownership-guard.sh` (`pass=26 fail=0`), including transient recovery, exhaustion, and real ownership-change blocking; `go test ./scripts/... -count=1 -run TestPushOwnershipGuard`; shell syntax checks; `go build ./...`; `go vet ./...`; and serialized `make test-fast-parallel` with all eight jobs green. |
 | 4 | No high-severity review findings open | **PASS** | `ga-lstvw3` reports no blocking findings after OWASP, test-coverage, design-contract, and retry-integrity review. Unresolved HIGH findings: 0. |
 | 5 | Final branch is clean | **PASS** | `git status --porcelain=v1` was empty after all exact-SHA validation. `git diff --check origin/main...HEAD` produced no output. The configured hook path is active at `/home/jaword/projects/gascity/.githooks`; the gate commit runs the pre-commit hook. |
@@ -33,6 +49,20 @@
 - `TestReconcileSessionBeads_AsleepNamedSingletonRegressionWakesInsteadOfStandby`
 
 All six passed with `-count=1`.
+
+#### Added by the maintainer fixups
+
+- `TestAwakeSetToWakeEvalsMapsRoutedDemandToWakeWork` — `"routed-demand"` maps to
+  `WakeWork`, not the `WakeConfig` default fallthrough.
+- `TestReconcilerWakeDemandOverridesSleepSuppressionForRoutedDemand` — the holder
+  wakes under a non-interactive sleep policy when alias suppression has zeroed
+  `poolDesired`, and explicit sleep intent still overrides.
+- `TestBuildDesiredState_RoutedDemandWakesOnlyCanonicalSingletonNamedSessions` —
+  a multi-instance backing pool does not emit the wake signal, while routed
+  demand still reaches ordinary pool sizing; the singleton control still does.
+
+Each was confirmed to **fail** with its production change reverted and the test
+left in place, so all three pin real behavior rather than passing vacuously.
 
 ### Push ownership guard
 

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -45,8 +45,20 @@
 # attempt_bounded_self_rebase directly against synthetic repos with no real
 # bead behind them (e.g. scripts/test-rebase-resolve.sh) and must stay
 # hermetic — it is not meant to be set on a real push path.
+#
+# bd/Dolt reads below are wrapped by _pog_read_with_retry: a transient
+# failure (lock contention, a slow response) is retried up to
+# POG_READ_ATTEMPTS times, each attempt bounded by POG_TIMEOUT_SECONDS, with
+# a short sleep between attempts. Only once every attempt fails does the
+# guard block — this does not weaken fail-closed semantics (a persistently
+# unreachable bd still blocks) and does not mask a genuine ownership change
+# (a real answer, allow or block, is accepted on its first attempt; only a
+# failed/empty read is retried). Override POG_READ_ATTEMPTS for test
+# harnesses that want to exercise a specific attempt count without eating
+# the real sleep/timeout cost of the production default.
 
 POG_TIMEOUT_SECONDS="${POG_TIMEOUT_SECONDS:-5}"
+POG_READ_ATTEMPTS="${POG_READ_ATTEMPTS:-3}"
 
 # _pog_timeout <seconds> <cmd...>: run <cmd...> bounded by <seconds>,
 # mirroring the timeout/gtimeout fallback shim in
@@ -63,6 +75,32 @@ _pog_timeout() {
     else
         "$@"
     fi
+}
+
+# _pog_read_with_retry <cmd...>: run <cmd...> (each attempt bounded by
+# _pog_timeout/POG_TIMEOUT_SECONDS), retrying up to POG_READ_ATTEMPTS times
+# with a short sleep between attempts (1s, then 2s) whenever an attempt
+# exits non-zero or prints nothing — the shape of a transient bd/Dolt read
+# (lock contention, a slow response), not a genuine answer. Prints the
+# first successful attempt's stdout and returns 0; if every attempt fails,
+# prints nothing and returns 1 so the caller still fails closed. Never
+# inspects the content of a successful read — a real answer (allow- or
+# block-worthy) is accepted on its first attempt exactly the same way, so
+# retrying cannot mask a genuine ownership change.
+_pog_read_with_retry() {
+    local attempt=1
+    local out
+    while (( attempt <= POG_READ_ATTEMPTS )); do
+        if out="$(_pog_timeout "$POG_TIMEOUT_SECONDS" "$@" 2>/dev/null)" && [[ -n "$out" ]]; then
+            printf '%s' "$out"
+            return 0
+        fi
+        if (( attempt < POG_READ_ATTEMPTS )); then
+            sleep "$attempt"
+        fi
+        attempt=$((attempt + 1))
+    done
+    return 1
 }
 
 # _pog_resolve_bead_id: prints the bead id this push should be checked
@@ -118,7 +156,7 @@ _pog_resolve_bead_id() {
     local assignee_id=""
     if [[ -n "${GC_AGENT:-}" ]] && command -v bd >/dev/null 2>&1; then
         local list_json
-        list_json="$(_pog_timeout "$POG_TIMEOUT_SECONDS" bd list --assignee="$GC_AGENT" --status=in_progress --json 2>/dev/null || true)"
+        list_json="$(_pog_read_with_retry bd list --assignee="$GC_AGENT" --status=in_progress --json || true)"
         if [[ -n "$list_json" ]]; then
             assignee_id="$(jq -r '.[0].id // empty' <<<"$list_json" 2>/dev/null || true)"
         fi
@@ -154,12 +192,12 @@ assert_bead_still_claimed() {
     fi
 
     local json
-    if ! json="$(_pog_timeout "$POG_TIMEOUT_SECONDS" bd show "$id" --json 2>/dev/null)" || [[ -z "$json" ]]; then
-        echo "push-ownership-guard: BLOCKED — bd show $id timed out or bd/Dolt is unreachable; cannot confirm $id is still claimed. Bypass with: git push --no-verify" >&2
+    if ! json="$(_pog_read_with_retry bd show "$id" --json)" || [[ -z "$json" ]]; then
+        echo "push-ownership-guard: BLOCKED — bd show $id unreachable after $POG_READ_ATTEMPTS attempts; re-run the push first — if it keeps failing, bd/Dolt needs attention. Last resort: git push --no-verify" >&2
         return 1
     fi
     if ! jq -e '.' <<<"$json" >/dev/null 2>&1; then
-        echo "push-ownership-guard: BLOCKED — bd show $id --json returned unparseable output; cannot confirm $id is still claimed. Bypass with: git push --no-verify" >&2
+        echo "push-ownership-guard: BLOCKED — bd show $id --json returned unparseable output; re-run the push first — if it keeps failing, bd/Dolt needs attention. Last resort: git push --no-verify" >&2
         return 1
     fi
 

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -82,16 +82,29 @@ remote_sha() {
 # Fake `bd`: behavior driven by state files, so each test writes exactly the
 # response it needs without a combinatorial helper signature.
 #
-#   <dir>/fake-bd-state/show-json   -- `bd show <any-id> --json` echoes this
-#                                       verbatim (exit 0).
-#   <dir>/fake-bd-state/show-exit   -- if present, `bd show` exits with this
-#                                       code instead (no output) — simulates
-#                                       bd/Dolt unreachable.
-#   <dir>/fake-bd-state/show-sleep  -- if present, `bd show` sleeps this many
-#                                       seconds first — simulates a hung
-#                                       read for timeout tests.
-#   <dir>/fake-bd-state/list-json   -- response to `bd list ... --json`
-#                                       (defaults to "[]").
+#   <dir>/fake-bd-state/show-json      -- `bd show <any-id> --json` echoes
+#                                          this verbatim (exit 0).
+#   <dir>/fake-bd-state/show-exit      -- if present, `bd show` exits with
+#                                          this code instead (no output) —
+#                                          simulates bd/Dolt unreachable.
+#   <dir>/fake-bd-state/show-sleep     -- if present, `bd show` sleeps this
+#                                          many seconds first — simulates a
+#                                          hung read for timeout tests.
+#   <dir>/fake-bd-state/show-fail-count -- if present, the first N `bd show`
+#                                          calls exit 1 (no output) and only
+#                                          call N+1 onward falls through to
+#                                          show-exit/show-json — simulates a
+#                                          transient failure that clears up
+#                                          after N attempts, for retry tests.
+#                                          Each call increments
+#                                          show-call-count (1-based) so a
+#                                          test can assert exactly how many
+#                                          attempts were made.
+#   <dir>/fake-bd-state/list-json      -- response to `bd list ... --json`
+#                                          (defaults to "[]").
+#   <dir>/fake-bd-state/list-fail-count -- same as show-fail-count, for
+#                                          `bd list` (counter:
+#                                          list-call-count).
 # ---------------------------------------------------------------------------
 
 write_fake_bd() {
@@ -106,6 +119,16 @@ case "$1" in
     if [ -f "$state/show-sleep" ]; then
       sleep "$(cat "$state/show-sleep")"
     fi
+    if [ -f "$state/show-fail-count" ]; then
+      n="$(cat "$state/show-fail-count")"
+      c=0
+      [ -f "$state/show-call-count" ] && c="$(cat "$state/show-call-count")"
+      c=$((c + 1))
+      echo "$c" > "$state/show-call-count"
+      if [ "$c" -le "$n" ]; then
+        exit 1
+      fi
+    fi
     if [ -f "$state/show-exit" ]; then
       exit "$(cat "$state/show-exit")"
     fi
@@ -116,6 +139,16 @@ case "$1" in
     exit 1
     ;;
   list)
+    if [ -f "$state/list-fail-count" ]; then
+      n="$(cat "$state/list-fail-count")"
+      c=0
+      [ -f "$state/list-call-count" ] && c="$(cat "$state/list-call-count")"
+      c=$((c + 1))
+      echo "$c" > "$state/list-call-count"
+      if [ "$c" -le "$n" ]; then
+        exit 1
+      fi
+    fi
     if [ -f "$state/list-json" ]; then
       cat "$state/list-json"
       exit 0
@@ -147,14 +180,21 @@ write_show_json() {
 # unchanged; supply them to exercise the session identity-set match.
 # Combined stdout+stderr is the caller's to capture; the subshell's exit
 # code is assert_bead_still_claimed's.
+#
+# POG_READ_ATTEMPTS defaults to 1 here (not the production default of 3) so
+# every pre-existing caller that doesn't care about retry behavior keeps its
+# original single-shot timing untouched. Tests that exercise retries set
+# POG_READ_ATTEMPTS as a prefix on the call, e.g.
+# `POG_READ_ATTEMPTS=3 run_guard ...`.
 run_guard() {
     local repo="$1" fbd="$2" agent="$3" template="$4" pog_timeout="${5:-5}"
     local session_id="${6:-}" session_name="${7:-}"
+    local read_attempts="${POG_READ_ATTEMPTS:-1}"
     (
         cd "$repo" || exit 1
         PATH="$fbd:$PATH" GC_AGENT="$agent" GC_TEMPLATE="$template" \
             GC_SESSION_ID="$session_id" GC_SESSION_NAME="$session_name" \
-            POG_TIMEOUT_SECONDS="$pog_timeout" LIB="$LIB" \
+            POG_TIMEOUT_SECONDS="$pog_timeout" POG_READ_ATTEMPTS="$read_attempts" LIB="$LIB" \
             bash -c '. "$LIB"; assert_bead_still_claimed'
     )
 }
@@ -324,6 +364,94 @@ test_block_on_bd_timeout() {
 }
 
 # ---------------------------------------------------------------------------
+# Bounded retry (ga-e8hal3): a single transient bd/Dolt read failure must
+# not fail the push closed — only exhausting every attempt does. Retrying
+# must never mask a genuine, successfully-read ownership change.
+# ---------------------------------------------------------------------------
+
+test_retry_recovers_from_transient_failure() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    write_show_json "$fbd" "ga-abc123.1" "in_progress" "agent-x" "tmpl-x" "[]"
+    echo 1 > "$fbd/fake-bd-state/show-fail-count"  # first bd show call fails, second succeeds
+    out="$(POG_READ_ATTEMPTS=3 run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]]; then
+        record_pass "retry/recovers-from-transient-failure (rc=0, one flaky read then success allows the push)"
+    else
+        record_fail "retry/recovers-from-transient-failure" "expected rc=0 after one flaky read then success, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_retry_exhausted_still_blocks() {
+    local repo fbd out rc calls
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    echo 99 > "$fbd/fake-bd-state/show-fail-count"  # never succeeds within any attempt budget
+    out="$(POG_READ_ATTEMPTS=3 run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    calls="$(cat "$fbd/fake-bd-state/show-call-count" 2>/dev/null || echo 0)"
+    if [[ $rc -ne 0 ]] && [[ "$calls" -eq 3 ]] && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "retry/exhausted-still-blocks (rc=$rc, retried exactly 3x then blocked, mentions --no-verify)"
+    else
+        record_fail "retry/exhausted-still-blocks" "expected rc!=0 after exactly 3 attempts mentioning --no-verify, got rc=$rc calls=$calls, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_retry_recovers_then_still_blocks_on_real_ownership_change() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    write_show_json "$fbd" "ga-abc123.1" "closed" "agent-x" "tmpl-x" "[]"
+    echo 1 > "$fbd/fake-bd-state/show-fail-count"
+    out="$(POG_READ_ATTEMPTS=3 run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]] && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "retry/recovers-then-still-blocks-on-real-ownership-change (rc=$rc, retries don't mask a genuine close)"
+    else
+        record_fail "retry/recovers-then-still-blocks-on-real-ownership-change" "expected non-zero rc mentioning status+--no-verify after one flaky read then a real close, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_retry_unreachable_message_mentions_retry_before_no_verify() {
+    local repo fbd out rc before_noverify
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    mkdir -p "$fbd/fake-bd-state"
+    echo 1 > "$fbd/fake-bd-state/show-exit"
+    out="$(POG_READ_ATTEMPTS=2 run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    before_noverify="${out%%--no-verify*}"
+    if [[ $rc -ne 0 ]] && grep -qi "re-run" <<<"$before_noverify" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "retry/unreachable-message-names-retry-before-no-verify (rc=$rc)"
+    else
+        record_fail "retry/unreachable-message-names-retry-before-no-verify" "expected retry-first wording before --no-verify, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_retry_parse_failure_message_mentions_retry_before_no_verify() {
+    local repo fbd out rc before_noverify
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    mkdir -p "$fbd/fake-bd-state"
+    printf 'not valid json' > "$fbd/fake-bd-state/show-json"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    before_noverify="${out%%--no-verify*}"
+    if [[ $rc -ne 0 ]] && grep -qi "re-run" <<<"$before_noverify" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "retry/parse-failure-message-names-retry-before-no-verify (rc=$rc)"
+    else
+        record_fail "retry/parse-failure-message-names-retry-before-no-verify" "expected retry-first wording before --no-verify, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# ---------------------------------------------------------------------------
 # Bead-id resolution.
 # ---------------------------------------------------------------------------
 
@@ -380,6 +508,23 @@ test_bead_id_fallback_used_when_branch_no_match() {
         record_pass "resolve/assignee-fallback-used-when-branch-no-match (rc=0)"
     else
         record_fail "resolve/assignee-fallback-used-when-branch-no-match" "expected rc=0, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_retry_recovers_bead_id_fallback_from_transient_failure() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "chore/unrelated-cleanup")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    echo 1 > "$fbd/fake-bd-state/list-fail-count"  # first bd list call fails, second succeeds
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-fallbk.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(POG_READ_ATTEMPTS=3 run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]]; then
+        record_pass "retry/recovers-bead-id-fallback-from-transient-failure (rc=0, list retry then resolved+allowed)"
+    else
+        record_fail "retry/recovers-bead-id-fallback-from-transient-failure" "expected rc=0, got rc=$rc, output: $out"
     fi
     rm -rf "$repo" "$fbd"
 }
@@ -566,9 +711,15 @@ run_all() {
     test_block_on_hold_external
     test_block_on_bd_unreachable
     test_block_on_bd_timeout
+    test_retry_recovers_from_transient_failure
+    test_retry_exhausted_still_blocks
+    test_retry_recovers_then_still_blocks_on_real_ownership_change
+    test_retry_unreachable_message_mentions_retry_before_no_verify
+    test_retry_parse_failure_message_mentions_retry_before_no_verify
     test_bead_id_branch_wins_and_warns_on_disagreement
     test_bead_id_branch_resolves_multi_level_subbead_id
     test_bead_id_fallback_used_when_branch_no_match
+    test_retry_recovers_bead_id_fallback_from_transient_failure
     test_allow_when_no_bead_id_resolvable
     test_fallback_cannot_detect_staleness_after_status_leaves_in_progress
     test_hook_blocks_push_on_stale_claim


### PR DESCRIPTION
## What this changes

When routed but unassigned work targets an asleep on-demand named session, the controller now wakes the existing canonical alias holder instead of spawning a pool standby that cannot acquire the same alias. The wake decision uses raw pre-suppression routed demand, so alias suppression can prevent the redundant standby without erasing the signal needed to wake the holder.

The push ownership guard now retries transient `bd list` and `bd show` read failures before blocking a push. Reads remain bounded and fail closed after three attempts by default; a parseable ownership change still blocks immediately, and the diagnostic recommends retrying before naming `--no-verify` as a last resort.

## Review notes

- `NamedSessionRoutedDemand` is wake-only. It does not feed pool sizing, merge into assignee demand, or override sleep suppression.
- `POG_READ_ATTEMPTS` is environment-overridable and defaults to 3; the existing per-attempt timeout is unchanged.
- Retry wraps only the two ownership reads and does not weaken `POG_DISABLE`, ownership parsing, or the force-with-lease path.
- There are no configuration migrations or public API changes.

## Test plan

- [x] Run the six focused alias-holder, pool-suppression, awake-set, and end-to-end reconciler regressions.
- [x] Run `scripts/test-push-ownership-guard.sh` and verify transient recovery, retry exhaustion, and genuine ownership-change blocking (`26/26`).
- [x] Run `go build ./...`, `go vet ./...`, and the serialized eight-shard `make test-fast-parallel` baseline.
- [x] Release gate: [`release-gates/ga-tg4m6s-named-session-routed-demand-push-guard-retry-gate.md`](release-gates/ga-tg4m6s-named-session-routed-demand-push-guard-retry-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3914 — touches the same singleton-pool / same-template named-session alias self-collision: canonicalSingletonAliasHeldTemplates now treats an asleep named holder — and one whose identity differs from its backing template — as still owning the canonical alias, so no redundant pool standby is minted to park on pool_alias_conflict. It does not touch the identity-normalization deferral path, so the per-pass deferral log line and conflict-metadata write described in that issue remain.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->