### PR TITLE
Reconcile push ownership fallback with nested bead IDs

### DIFF
--- a/release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md
+++ b/release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md
@@ -67,3 +67,29 @@ supplement because it has not completed builder/reviewer routing.
 | 4 | No high-severity review findings open | PASS | `ga-jkkrbe` is closed with a PASS verdict, reports no inaccuracies or scope creep, and identifies no security finding because executable behavior is unchanged. |
 | 5 | Final branch is clean | PASS | `git status --porcelain=v1` produced no output at the reviewed SHA before this gate supplement was added. |
 | 7 | Single feature theme | PASS | The supplemental commit touches only the push ownership guard's header; the existing PR remains confined to the same guard and its tests. |
+
+## Supplemental evaluation: mutation-proof retry test
+
+- Deploy bead: `ga-2bf7oo`
+- Review bead: `ga-r7c5gl`
+- Reviewed commit: `3391c40f2fb399add86aa18831a1e7287885899d`
+- Parent / prior PR head: `54170bf9c4e801c1f10405a06bbe103340c5f4ac`
+- Combined candidate: `d2b354aafec461dd0d88343971e0986158eb62dc`
+- Base checked: `origin/main` at `8a6809e8fa6dc71faaa04e6a5ee4822dce130275`
+- Evaluated: 2026-07-26
+
+PASS. The reviewed follow-up adds three regression cases that prove a
+reassigned, rerouted, or held branch bead cannot be authorized by a distinct
+valid fallback assignment. It pins the current `rc=2`-only retry invariant
+without changing the guard itself or resolving the separate
+authorization-relatedness design question on `ga-1hc9k3`.
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first after applying the reviewed patch to the live PR head. `git merge-tree --write-tree origin/main d2b354aaf` exited 0 and produced tree `095611af5412988c901a7e4df70a5d8cb2e949d9`; `git diff --check` produced no output. |
+| 1 | Review PASS present | PASS | Closed review bead `ga-r7c5gl` records `REVIEW VERDICT: PASS` for exact source commit `3391c40f2fb399add86aa18831a1e7287885899d`. The reviewer also applied that test file to the PR lineage after GAP 2 (`2ebc78034`) and independently re-ran both the unmutated and mutation-proof checks on the combined tree. The patch cherry-picked without conflict onto the live PR head as `d2b354aaf`. |
+| 2 | Acceptance criteria met | PASS | The delta is exactly 60 additive lines in `scripts/test-push-ownership-guard.sh`: three cases cover reassigned, rerouted, and `hold:mayor` branch beads while a distinct valid fallback exists. The unchanged guard passes all 25 cases. The review independently proved the test's sensitivity by changing the retry condition from `rc -eq 2` to `rc -ne 0`: exactly the three new cases failed and all 22 prior cases passed. |
+| 3 | Tests pass | PASS | On combined candidate `d2b354aaf`: Bash syntax and ShellCheck passed; the ownership-guard suite passed 25/25; `go test ./scripts/...`, `go build ./...`, `go vet ./...`, and `make test-fast-parallel` passed. |
+| 4 | No high-severity review findings open | PASS | `ga-r7c5gl` is closed with a PASS verdict and reports no inaccuracies, scope creep, security finding, or coverage gap. PR #4651 had zero comments and zero reviews when this supplement was evaluated. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v1` produced no output at combined candidate `d2b354aaf` before this gate supplement was added. |
+| 7 | Single feature theme | PASS | The supplemental patch touches only the push ownership guard's existing shell regression suite; PR #4651 remains confined to the same guard subsystem and its tests. |

--- a/release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md
+++ b/release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md
@@ -1,0 +1,43 @@
+# Release Gate: push-ownership guard reconciliation
+
+- Deploy bead: `ga-1hc9k3`
+- Source/review lineage: `ga-z3bhzw` / `ga-0jpfvu`
+- Reviewed commit: `b38534a4b394dd77c47e69f3438e7d2928b9d505`
+- Deploy branch: `deploy/ga-1hc9k3-gate`
+- Base checked: `origin/main` at `25eb009e87b1b2a9b3b5031615996120562cb0b8`
+- Evaluated: 2026-07-25
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the deployer role's release criteria plus the repository gates in `AGENTS.md`
+and `TESTING.md`.
+
+## Summary
+
+PASS. This single-theme change reconciles the push ownership guard's
+assignee-fallback retry with its multi-level bead-ID parsing. The guard remains
+fail-closed and both callers retain the unchanged
+`assert_bead_still_claimed` contract.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git fetch origin main`; `git merge-tree --write-tree origin/main b38534a4b` exited 0 and produced tree `4c9993200d10d03acae637ed31b2124b0fab2e75`; `git diff --check origin/main...b38534a4b` produced no output. No self-rebase was required. |
+| 1 | Review PASS present | PASS | Closed review bead `ga-0jpfvu` records `Verdict: PASS` for exact commit `b38534a4b394dd77c47e69f3438e7d2928b9d505`. |
+| 2 | Acceptance criteria met | PASS | `git diff --exit-code 4cd597c9d b38534a4b -- scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh` exited 0, proving zero semantic drift from the previously reviewed implementation. The diff retains `_pog_branch_bead_id`, `_pog_assignee_bead_id`, and `_pog_check_bead_claimed`; uses the repeatable `ga-[0-9a-z]{6}(\.[0-9]+)*` suffix; retries only when the primary branch bead is terminal; and keeps both callers on `assert_bead_still_claimed`. The dedicated guard and Layer-B suites passed 22/22 and 23/23. |
+| 3 | Tests pass | PASS | On the exact reviewed SHA: Bash syntax and ShellCheck passed; `go test ./scripts/...` passed; the two previously flaky regressions passed together; `go build ./...` passed; `go vet ./...` passed; and the first `make test-fast-parallel` attempt passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | `ga-0jpfvu` is closed with a PASS verdict and states that there are no open questions on the diff. The carried-forward security/spec/coverage review reported no blocker or coverage gap. |
+| 5 | Final branch is clean | PASS | Before adding this checklist, `git status --porcelain=v1` produced no output at the reviewed SHA. This checklist is committed as the only deployer-added change before push. |
+| 7 | Single feature theme | PASS | `git diff --name-status origin/main...b38534a4b` lists only `scripts/push-ownership-guard.sh` and `scripts/test-push-ownership-guard.sh`; both belong to the push ownership guard subsystem. |
+
+## Test Log Summary
+
+- `bash -n scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh scripts/rebase-resolve-lib.sh scripts/test-rebase-resolve.sh`: PASS
+- `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh scripts/rebase-resolve-lib.sh scripts/test-rebase-resolve.sh`: PASS
+- `bash scripts/test-push-ownership-guard.sh`: PASS, 22 passed and 0 failed
+- `bash scripts/test-rebase-resolve.sh`: PASS, 23 passed and 0 failed
+- `go test ./scripts/...`: PASS
+- `go test ./cmd/gc -run '^(TestCmdStopWallClockTimeoutBoundsDirectStop|TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity)$' -count=1`: PASS
+- `go build ./...`: PASS
+- `go vet ./...`: PASS
+- `make test-fast-parallel`: PASS, 8/8 fast jobs passed on the first attempt

--- a/release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md
+++ b/release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md
@@ -41,3 +41,29 @@ fail-closed and both callers retain the unchanged
 - `go build ./...`: PASS
 - `go vet ./...`: PASS
 - `make test-fast-parallel`: PASS, 8/8 fast jobs passed on the first attempt
+
+## Supplemental evaluation: guard header refresh
+
+- Deploy bead: `ga-qvl7oc`
+- Review bead: `ga-jkkrbe`
+- Reviewed commit: `2ebc7803491a0a5c35738d70ab08c3cc63763a2b`
+- Parent / prior PR head: `19141edb18306dffcc009c04aa10683e0bcaa676`
+- Base checked: `origin/main` at `bbb7354377996e553e1e1dd4821ade2afd6ab1a1`
+- Evaluated: 2026-07-25
+
+PASS. The reviewed follow-up refreshes only the header comments in
+`scripts/push-ownership-guard.sh` so they describe the existing
+branch-bead/assignee-bead retry contract. It intentionally documents, without
+resolving, the open authorization-semantics question tracked on `ga-1hc9k3`.
+The sibling mutation-proof test (`ga-3vvi6r`) is not included in this
+supplement because it has not completed builder/reviewer routing.
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. The reviewed commit is a direct child of the prior PR head. `git merge-tree --write-tree origin/main 2ebc78034` exited 0 and produced tree `b7b2cd3f4e75c945761901508fa6d95c338429e0`; `git diff --check` produced no output. |
+| 1 | Review PASS present | PASS | Closed review bead `ga-jkkrbe` records `REVIEW VERDICT: PASS` for exact commit `2ebc7803491a0a5c35738d70ab08c3cc63763a2b`. |
+| 2 | Acceptance criteria met | PASS | An executable-line diff check confirmed every added/removed line is a comment or blank line. The refreshed header accurately documents branch-first resolution, the terminal-status-only (`rc=2`) fallback, the non-retryable `rc=1` states, and the intentionally unresolved lack of a relatedness check. |
+| 3 | Tests pass | PASS | On the exact reviewed SHA: Bash syntax and ShellCheck passed; the ownership-guard suite passed 22/22; `go test ./scripts/...`, `go build ./...`, and `go vet ./...` passed; and the first `make test-fast-parallel` attempt passed all 8 fast jobs. |
+| 4 | No high-severity review findings open | PASS | `ga-jkkrbe` is closed with a PASS verdict, reports no inaccuracies or scope creep, and identifies no security finding because executable behavior is unchanged. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v1` produced no output at the reviewed SHA before this gate supplement was added. |
+| 7 | Single feature theme | PASS | The supplemental commit touches only the push ownership guard's header; the existing PR remains confined to the same guard and its tests. |

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -65,88 +65,71 @@ _pog_timeout() {
     fi
 }
 
-# _pog_resolve_bead_id: prints the bead id this push should be checked
-# against; prints nothing if none can be resolved. Resolution order:
-#   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)* —
-#      the bead's own id format, extended with zero or more repeated
-#      sub-bead suffixes because this repo's real branch convention is
-#      builder/<bead-id>-<slug> and sub-beads are routine at any nesting
-#      depth: a single-level sub-bead (e.g. ga-fip9ps.1) as well as a
-#      grandchild (e.g. ga-o3ko1j.4.3). The suffix group must repeat (`*`),
-#      not just appear once (`?`) — a single optional group truncates a
-#      grandchild id after its first dotted segment, misresolving to the
-#      wrong (and possibly closed) parent/child bead instead of the actual
-#      grandchild bead the branch is for. The literal 6-char-only pattern
-#      would misresolve to the root bead on any sub-bead's own branch.
-#   2. Falls back to this session's single in-progress assignment
-#      (bd list --assignee="$GC_AGENT" --status=in_progress --json) when
-#      the branch name doesn't match.
-# If both resolve and disagree, the branch match wins (it's the more
-# specific signal) and a warning goes to stderr — this is a best-effort
-# cross-check, not a hard failure, since branch-naming habits can
-# legitimately drift from bd's bookkeeping.
-#
-# KNOWN LIMITATION of path 2 (confirmed by manual repro, not yet filed as
-# its own bead): the fallback query itself filters on --status=in_progress,
-# so it cannot find a bead that has already left in_progress (e.g. closed
-# by the exact mayor ruling this guard exists to catch) by the time the
-# fallback runs. In that narrow intersection — branch name doesn't encode
-# the bead id AND the status flip lands before this resolves — no id
-# resolves at all, and assert_bead_still_claimed's "nothing to check"
-# branch below allows the push. This does NOT affect path 1: this repo's
-# real branch convention (builder/<bead-id>-<slug>) always encodes the
-# bead id, so the primary path is unaffected by a bead's status changing
-# out from under it — confirmed via manual repro, see
-# test_fallback_cannot_detect_staleness_after_status_leaves_in_progress in
-# scripts/test-push-ownership-guard.sh. The fallback query shape matches
-# ga-fip9ps.1's own spec verbatim; widening it (e.g. dropping the status
-# filter) trades this gap for ambiguous multi-match resolution against an
-# agent's whole bead history, which is a real design decision for whoever
-# owns that tradeoff, not a mechanical fix — left for a follow-up bead.
-# Prints nothing (not an error) when neither resolves — the caller treats
-# that as "nothing to check," which is what lets Layer A wire this in
-# unconditionally without blocking every push in the repo.
-_pog_resolve_bead_id() {
+# _pog_branch_bead_id: prints the bead id parsed from the current branch
+# name, matched against ga-[0-9a-z]{6}(\.[0-9]+)* — the bead's own id
+# format, extended with zero or more repeated sub-bead suffixes because
+# this repo's real branch convention is builder/<bead-id>-<slug> and
+# sub-beads are routine at any nesting depth: a single-level sub-bead
+# (e.g. ga-fip9ps.1) as well as a grandchild (e.g. ga-o3ko1j.4.3). The
+# suffix group must repeat (`*`), not just appear once (`?`) — a single
+# optional group truncates a grandchild id after its first dotted segment,
+# misresolving to the wrong (and possibly closed) parent/child bead
+# instead of the actual grandchild bead the branch is for. The literal
+# 6-char-only pattern would misresolve to the root bead on any sub-bead's
+# own branch. Prints nothing if the branch doesn't match.
+_pog_branch_bead_id() {
     local branch=""
     branch="$(git symbolic-ref --short HEAD 2>/dev/null || git branch --show-current 2>/dev/null || true)"
-
-    local branch_id=""
     if [[ -n "$branch" ]]; then
-        branch_id="$(grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)*' <<<"$branch" | head -1 || true)"
+        grep -oE 'ga-[0-9a-z]{6}(\.[0-9]+)*' <<<"$branch" | head -1 || true
     fi
+}
 
-    local assignee_id=""
+# _pog_assignee_bead_id: prints this session's single in-progress bd
+# assignment (bd list --assignee="$GC_AGENT" --status=in_progress --json).
+# Prints nothing if none resolves.
+#
+# KNOWN LIMITATION (confirmed by manual repro, not yet filed as its own
+# bead): this query filters on --status=in_progress, so it cannot find a
+# bead that has already left that status (e.g. closed by the exact mayor
+# ruling this guard exists to catch) by the time it runs. When
+# _pog_branch_bead_id also doesn't resolve, that means no id resolves at
+# all and assert_bead_still_claimed's "nothing to check" branch allows the
+# push — see test_fallback_cannot_detect_staleness_after_status_leaves_in_progress
+# in scripts/test-push-ownership-guard.sh. This does NOT affect the branch
+# path: this repo's real branch convention (builder/<bead-id>-<slug>)
+# always encodes the bead id. Widening this query (e.g. dropping the status
+# filter) trades this gap for ambiguous multi-match resolution against an
+# agent's whole bead history — a real design decision, not a mechanical
+# fix — left for a follow-up bead.
+_pog_assignee_bead_id() {
     if [[ -n "${GC_AGENT:-}" ]] && command -v bd >/dev/null 2>&1; then
         local list_json
         list_json="$(_pog_timeout "$POG_TIMEOUT_SECONDS" bd list --assignee="$GC_AGENT" --status=in_progress --json 2>/dev/null || true)"
         if [[ -n "$list_json" ]]; then
-            assignee_id="$(jq -r '.[0].id // empty' <<<"$list_json" 2>/dev/null || true)"
+            jq -r '.[0].id // empty' <<<"$list_json" 2>/dev/null || true
         fi
-    fi
-
-    if [[ -n "$branch_id" && -n "$assignee_id" && "$branch_id" != "$assignee_id" ]]; then
-        echo "push-ownership-guard: WARNING branch name resolves to $branch_id but this session's in-progress assignment is $assignee_id; using $branch_id (branch name wins)" >&2
-    fi
-
-    if [[ -n "$branch_id" ]]; then
-        printf '%s' "$branch_id"
-    else
-        printf '%s' "$assignee_id"
     fi
 }
 
-# assert_bead_still_claimed: the exported guard. Returns 0 to allow the
-# push, non-zero to block it. See file header for the full contract.
-assert_bead_still_claimed() {
-    if [[ "${POG_DISABLE:-0}" == "1" ]]; then
-        return 0
-    fi
-
-    local id
-    id="$(_pog_resolve_bead_id)"
-    if [[ -z "$id" ]]; then
-        return 0  # nothing to check
-    fi
+# _pog_check_bead_claimed <id>: the core ownership/staleness check against
+# one resolved bead id. Prints a BLOCKED explanation to stderr and returns
+# non-zero if the check fails, 0 if it passes.
+#   Return codes:
+#     0 — claim confirmed, still valid.
+#     2 — blocked because the bead's status is terminal (not
+#         in_progress/open). This is the ONLY failure mode
+#         assert_bead_still_claimed treats as retryable against a fallback
+#         id, since a branch-encoded bead closing via a normal handoff
+#         looks identical, from here, to one closed out from under this
+#         push — the caller distinguishes them by whether a separate,
+#         still-valid assignment exists.
+#     1 — blocked for any other reason (bd unreachable, timed out,
+#         unparseable, reassigned, rerouted, held). Not retryable: these
+#         mean this session's specific claim was actively superseded, which
+#         a fallback id must never paper over.
+_pog_check_bead_claimed() {
+    local id="$1"
 
     if ! command -v bd >/dev/null 2>&1; then
         echo "push-ownership-guard: BLOCKED — bd is not on PATH, cannot verify $id is still claimed. Bypass with: git push --no-verify" >&2
@@ -171,7 +154,7 @@ assert_bead_still_claimed() {
 
     if [[ "$status" != "in_progress" && "$status" != "open" ]]; then
         echo "push-ownership-guard: BLOCKED — $id status is '$status', not in_progress/open; the claim behind this push is stale. Bypass with: git push --no-verify" >&2
-        return 1
+        return 2
     fi
 
     # A session-run claim sets bead.assignee from the first non-empty of
@@ -212,4 +195,62 @@ assert_bead_still_claimed() {
     fi
 
     return 0
+}
+
+# assert_bead_still_claimed: the exported guard. Returns 0 to allow the
+# push, non-zero to block it. See file header for the full contract.
+#
+# Resolves branch_id and assignee_id separately (rather than collapsing to
+# one winner up front) because it needs both: branch_id is checked first
+# (it's the more specific signal — see _pog_branch_bead_id), but when
+# branch_id's bead has legitimately closed (e.g. ga-hilw2y — a builder's
+# branch still names the bead that originally spawned it after that bead
+# closed normally into a separate deploy-tracking bead), this retries the
+# full check against assignee_id rather than treating an ordinary handoff
+# as staleness. If both resolve and disagree, a warning goes to stderr
+# either way — a best-effort cross-check, not a hard failure, since
+# branch-naming habits can legitimately drift from bd's bookkeeping.
+assert_bead_still_claimed() {
+    if [[ "${POG_DISABLE:-0}" == "1" ]]; then
+        return 0
+    fi
+
+    local branch_id assignee_id
+    branch_id="$(_pog_branch_bead_id)"
+    assignee_id="$(_pog_assignee_bead_id)"
+
+    if [[ -n "$branch_id" && -n "$assignee_id" && "$branch_id" != "$assignee_id" ]]; then
+        echo "push-ownership-guard: WARNING branch name resolves to $branch_id but this session's in-progress assignment is $assignee_id; using $branch_id (branch name wins)" >&2
+    fi
+
+    local id="$branch_id"
+    [[ -z "$id" ]] && id="$assignee_id"
+    if [[ -z "$id" ]]; then
+        return 0  # nothing to check
+    fi
+
+    _pog_check_bead_claimed "$id"
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        return 0
+    fi
+
+    # Retry against the assignee bead ONLY when the branch-encoded bead
+    # specifically failed on terminal status (rc=2) and a distinct
+    # assignee bead exists — e.g. ga-hilw2y, where the branch still names
+    # the bead that originally spawned it after that bead closed normally
+    # into a separate deploy-tracking bead. Any other block reason
+    # (reassigned/rerouted/held, rc=1) is NOT retried: those mean this
+    # session's specific claim was actively superseded, which must keep
+    # blocking exactly as before even though branch_id's bead is still
+    # in_progress/open.
+    if [[ $rc -eq 2 && "$id" == "$branch_id" && -n "$assignee_id" && "$assignee_id" != "$branch_id" ]]; then
+        echo "push-ownership-guard: $branch_id is closed but this session's own in-progress assignment is $assignee_id; retrying against it before blocking" >&2
+        if _pog_check_bead_claimed "$assignee_id"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    return 1
 }

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -13,14 +13,29 @@
 # closes that gap by re-reading bd's live state at the last possible moment
 # before the push leaves the machine.
 #
-# THE EXPORTED FUNCTION: assert_bead_still_claimed. Re-resolves which bead
-# this push is for (branch name, falling back to this session's in-progress
-# assignment), re-reads its live state from bd, and returns non-zero
-# (blocking the push) unless the bead is still open/in_progress, still
-# assigned to one of this session's identities (any of GC_SESSION_NAME,
-# GC_SESSION_ID, GC_ALIAS, GC_AGENT — mirroring the claim path), still
-# routed to this session's config identity, and not held by the mayor or an
-# external actor.
+# THE EXPORTED FUNCTION: assert_bead_still_claimed. Resolves two candidate
+# bead ids — branch_id (parsed from the branch name, _pog_branch_bead_id)
+# and assignee_id (this session's own in-progress bd assignment,
+# _pog_assignee_bead_id) — and checks branch_id first when present, since
+# it's the more specific signal. Returns non-zero (blocking the push)
+# unless the checked bead is still open/in_progress, still assigned to one
+# of this session's identities (any of GC_SESSION_NAME, GC_SESSION_ID,
+# GC_ALIAS, GC_AGENT — mirroring the claim path), still routed to this
+# session's config identity, and not held by the mayor or an external
+# actor (see _pog_check_bead_claimed for the per-bead check and its
+# return-code contract).
+#
+# RETRY: if branch_id's bead fails ONLY because its status is terminal
+# (rc=2 — e.g. it closed normally into a separate follow-on bead, as with
+# ga-hilw2y) and a distinct assignee_id exists, the same check retries
+# against assignee_id before blocking, so an ordinary handoff isn't
+# mistaken for staleness. Every other block reason (reassigned, rerouted,
+# held, bd unreachable — rc=1) is never retried against a fallback id:
+# those mean this session's specific claim was actively superseded, which
+# a fallback must not paper over. The retry has no relatedness check
+# between branch_id and assignee_id today — any distinct in-progress
+# assignment qualifies. Whether it should require one is an open
+# authorization-semantics question tracked in ga-1hc9k3, not decided here.
 #
 # TWO CALL SITES (defense in depth — see ga-fip9ps.1 bead notes):
 #   Layer A — .githooks/pre-push calls this unconditionally for every

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -398,6 +398,63 @@ test_block_when_branch_bead_closed_and_assignee_bead_also_invalid() {
     rm -rf "$repo" "$fbd"
 }
 
+test_block_reassigned_branch_bead_despite_valid_assignee_fallback() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    # The branch bead was reassigned, while bd list resolves a distinct
+    # fallback that would pass every ownership check if retried.
+    write_show_json "$fbd" "ga-abc123.1" "in_progress" "someone-else" "tmpl-x" "[]"
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-fallbk.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]] && grep -qi "assignee" <<<"$out" && grep -q "ga-fallbk.3" <<<"$out"; then
+        record_pass "fallback/block-reassigned-branch-bead-despite-valid-assignee-fallback (rc=$rc)"
+    else
+        record_fail "fallback/block-reassigned-branch-bead-despite-valid-assignee-fallback" "expected non-zero rc naming the reassignment and fallback id, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_block_rerouted_branch_bead_despite_valid_assignee_fallback() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    # The branch bead was rerouted, while bd list resolves a distinct
+    # fallback that would pass every ownership check if retried.
+    write_show_json "$fbd" "ga-abc123.1" "in_progress" "agent-x" "other-tmpl" "[]"
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-fallbk.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]] && grep -qi "routed_to" <<<"$out" && grep -q "ga-fallbk.3" <<<"$out"; then
+        record_pass "fallback/block-rerouted-branch-bead-despite-valid-assignee-fallback (rc=$rc)"
+    else
+        record_fail "fallback/block-rerouted-branch-bead-despite-valid-assignee-fallback" "expected non-zero rc naming the reroute and fallback id, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_block_held_branch_bead_despite_valid_assignee_fallback() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    # The branch bead is held, while bd list resolves a distinct fallback
+    # that would pass every ownership check if retried.
+    write_show_json "$fbd" "ga-abc123.1" "in_progress" "agent-x" "tmpl-x" '["hold:mayor"]'
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-fallbk.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]] && grep -q "hold:mayor" <<<"$out" && grep -q "ga-fallbk.3" <<<"$out"; then
+        record_pass "fallback/block-held-branch-bead-despite-valid-assignee-fallback (rc=$rc)"
+    else
+        record_fail "fallback/block-held-branch-bead-despite-valid-assignee-fallback" "expected non-zero rc naming the hold and fallback id, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
 # ---------------------------------------------------------------------------
 # Bead-id resolution.
 # ---------------------------------------------------------------------------
@@ -643,6 +700,9 @@ run_all() {
     test_block_on_bd_timeout
     test_allow_fallback_when_branch_bead_closed_but_assignee_bead_valid
     test_block_when_branch_bead_closed_and_assignee_bead_also_invalid
+    test_block_reassigned_branch_bead_despite_valid_assignee_fallback
+    test_block_rerouted_branch_bead_despite_valid_assignee_fallback
+    test_block_held_branch_bead_despite_valid_assignee_fallback
     test_bead_id_branch_wins_and_warns_on_disagreement
     test_bead_id_branch_resolves_multi_level_subbead_id
     test_bead_id_fallback_used_when_branch_no_match

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -2,7 +2,7 @@
 #
 # test-push-ownership-guard.sh — unit tests for the pre-push bead
 # ownership/staleness guard (bead ga-fip9ps.1; guards the race described in
-# ga-fip9ps). Three layers:
+# ga-fip9ps). Four layers:
 #
 #   1. assert_bead_still_claimed (scripts/push-ownership-guard.sh) exercised
 #      directly against real temp git repos with a fake `bd` on PATH: allow
@@ -14,8 +14,13 @@
 #      neither resolves (nothing to check — required for Layer A to be
 #      wired in unconditionally without blocking unrelated pushes). Also
 #      pins a known limitation of that fallback — see the KNOWN LIMITATION
-#      comment on _pog_resolve_bead_id in push-ownership-guard.sh.
-#   3. Hook wiring: a real .githooks/pre-push, installed into a real temp
+#      comment on _pog_assignee_bead_id in push-ownership-guard.sh.
+#   3. Fallback-to-assignee retry (ga-fip9ps.3, ga-hilw2y): when the
+#      branch-encoded bead has closed via a legitimate handoff rather than
+#      being reassigned/rerouted/held out from under this session, retries
+#      the full check against this session's own in-progress assignment
+#      before blocking.
+#   4. Hook wiring: a real .githooks/pre-push, installed into a real temp
 #      repo pushing to a real bare remote, actually rejects a stale-claim
 #      push, actually allows a clean one, and `--no-verify` actually
 #      bypasses the guard end to end.
@@ -82,8 +87,16 @@ remote_sha() {
 # Fake `bd`: behavior driven by state files, so each test writes exactly the
 # response it needs without a combinatorial helper signature.
 #
+#   <dir>/fake-bd-state/show-json-<id> -- `bd show <id> --json` echoes this
+#                                       verbatim (exit 0) when present —
+#                                       checked before the generic file below,
+#                                       so a test can give two different ids
+#                                       two different responses (needed for
+#                                       the branch-bead-closed/assignee-bead-
+#                                       fallback tests).
 #   <dir>/fake-bd-state/show-json   -- `bd show <any-id> --json` echoes this
-#                                       verbatim (exit 0).
+#                                       verbatim (exit 0) when no id-specific
+#                                       file matches.
 #   <dir>/fake-bd-state/show-exit   -- if present, `bd show` exits with this
 #                                       code instead (no output) — simulates
 #                                       bd/Dolt unreachable.
@@ -109,6 +122,10 @@ case "$1" in
     if [ -f "$state/show-exit" ]; then
       exit "$(cat "$state/show-exit")"
     fi
+    if [ -f "$state/show-json-$2" ]; then
+      cat "$state/show-json-$2"
+      exit 0
+    fi
     if [ -f "$state/show-json" ]; then
       cat "$state/show-json"
       exit 0
@@ -132,11 +149,20 @@ FAKE
 }
 
 # write_show_json <fake-bd-dir> <id> <status> <assignee> <routed_to> [labels-json-array]
+#
+# Writes both the generic show-json fallback AND an id-specific
+# show-json-<id> file, so tests that only ever query one id behave exactly
+# as before (last writer of the generic file, which is also the one
+# id-specific file that matters), while tests that query two distinct ids
+# (e.g. a closed branch-bead and a valid assignee-bead) can call this twice
+# with different ids and get independently correct responses.
 write_show_json() {
     local fbd="$1" id="$2" status="$3" assignee="$4" routed_to="$5" labels="${6:-[]}"
     mkdir -p "$fbd/fake-bd-state"
     printf '[{"id":"%s","status":"%s","assignee":"%s","metadata":{"gc.routed_to":"%s"},"labels":%s}]' \
         "$id" "$status" "$assignee" "$routed_to" "$labels" > "$fbd/fake-bd-state/show-json"
+    printf '[{"id":"%s","status":"%s","assignee":"%s","metadata":{"gc.routed_to":"%s"},"labels":%s}]' \
+        "$id" "$status" "$assignee" "$routed_to" "$labels" > "$fbd/fake-bd-state/show-json-$id"
 }
 
 # run_guard <repo> <fake-bd-dir> <gc-agent> <gc-template> [pog-timeout-seconds] [gc-session-id] [gc-session-name]
@@ -324,6 +350,55 @@ test_block_on_bd_timeout() {
 }
 
 # ---------------------------------------------------------------------------
+# Fallback to the assignee bead when the branch-encoded bead closed via a
+# legitimate handoff (ga-hilw2y: a builder's branch still names the bead
+# that originally spawned it — e.g. ga-zogqc1.1 — after that bead closed
+# normally into a separate deploy-tracking bead; the guard must not treat
+# that ordinary handoff as staleness when this session's own in-progress
+# assignment is a different, still-valid bead).
+# ---------------------------------------------------------------------------
+
+test_allow_fallback_when_branch_bead_closed_but_assignee_bead_valid() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    # Branch-encoded bead closed via a normal handoff...
+    write_show_json "$fbd" "ga-abc123.1" "closed" "agent-x" "tmpl-x" "[]"
+    # ...but this session's own in-progress assignment is a distinct,
+    # still-valid bead.
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-fallbk.3" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]] && grep -q "ga-fallbk.3" <<<"$out"; then
+        record_pass "fallback/allow-when-branch-bead-closed-but-assignee-bead-valid (rc=0, names the fallback id)"
+    else
+        record_fail "fallback/allow-when-branch-bead-closed-but-assignee-bead-valid" "expected rc=0 naming ga-fallbk.3, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+test_block_when_branch_bead_closed_and_assignee_bead_also_invalid() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    write_show_json "$fbd" "ga-abc123.1" "closed" "agent-x" "tmpl-x" "[]"
+    printf '[{"id":"ga-fallbk.3"}]' > "$fbd/fake-bd-state/list-json"
+    # The fallback candidate is ALSO invalid (closed) — the fallback must be
+    # fully re-validated, not a blanket allow just because a distinct
+    # assignee id exists.
+    write_show_json "$fbd" "ga-fallbk.3" "closed" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]] && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "fallback/block-when-branch-bead-closed-and-assignee-bead-also-invalid (rc=$rc, still blocks)"
+    else
+        record_fail "fallback/block-when-branch-bead-closed-and-assignee-bead-also-invalid" "expected non-zero rc mentioning --no-verify, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# ---------------------------------------------------------------------------
 # Bead-id resolution.
 # ---------------------------------------------------------------------------
 
@@ -404,7 +479,7 @@ test_allow_when_no_bead_id_resolvable() {
 # --status=in_progress, so it cannot find a bead that has already left that
 # status (e.g. closed by the exact mayor ruling this guard exists to catch)
 # by the time the fallback runs. See the KNOWN LIMITATION comment on
-# _pog_resolve_bead_id in push-ownership-guard.sh — this pins the current,
+# _pog_assignee_bead_id in push-ownership-guard.sh — this pins the current,
 # spec-compliant behavior so a change to the fallback algorithm is a
 # deliberate, visible decision, not a silent regression either direction.
 # Confirmed against a real bd via manual repro (ga-fip9ps.1 bead notes);
@@ -566,6 +641,8 @@ run_all() {
     test_block_on_hold_external
     test_block_on_bd_unreachable
     test_block_on_bd_timeout
+    test_allow_fallback_when_branch_bead_closed_but_assignee_bead_valid
+    test_block_when_branch_bead_closed_and_assignee_bead_also_invalid
     test_bead_id_branch_wins_and_warns_on_disagreement
     test_bead_id_branch_resolves_multi_level_subbead_id
     test_bead_id_fallback_used_when_branch_no_match


### PR DESCRIPTION
## What this changes

The pre-push ownership guard now preserves two complementary behaviors: it recognizes full multi-level dotted bead IDs in branch names, and when that branch-encoded bead is already terminal it retries ownership validation against the session’s current active bead. This unblocks legitimate pushes and bounded self-rebases whose branch names retain closed provenance IDs.

The fallback remains fail-closed. Reassigned, rerouted, held, unreachable, or malformed bead state still blocks the push; the retry is available only for a terminal branch bead and runs the same complete validation against a distinct active assignee bead.

## Review notes

- The production change is confined to `scripts/push-ownership-guard.sh`; its shell harness carries the regression coverage.
- The exported `assert_bead_still_claimed` contract and both callers (`.githooks/pre-push` and Layer B self-rebase) are unchanged.
- There are no configuration, wire-format, migration, or runtime-role changes.

## Test plan

- [x] Ownership-guard shell suite: 22/22
- [x] Layer-B rebase-resolver shell suite: 23/23
- [x] Bash syntax, ShellCheck, `go test ./scripts/...`, `go build ./...`, and `go vet ./...`
- [x] `make test-fast-parallel`: 8/8 jobs, including the push-time run
- [x] Release gate: [`release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md`](release-gates/ga-1hc9k3-push-ownership-guard-reconciliation-gate.md)