### PR TITLE
fix: fence cache after ambiguous metadata writes

### DIFF
--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -424,6 +424,13 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 		return nil
 	}
 	if err := c.backing.SetMetadataBatch(id, kvs); err != nil {
+		// The backing may have rejected, partially committed, or fully committed
+		// the batch before returning an error. Fence the cached pre-write row
+		// until an ordinary read installs backing truth.
+		c.mu.Lock()
+		c.noteMutationLocked(id)
+		c.markDirtyLocked(id)
+		c.mu.Unlock()
 		return err
 	}
 

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -65,6 +65,25 @@ type releaseRefreshFailOnceStore struct {
 	failNextGet bool
 }
 
+type ambiguousMetadataBatchStore struct {
+	Store
+	err        error
+	commitKeys []string
+}
+
+func (s *ambiguousMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	committed := make(map[string]string, len(s.commitKeys))
+	for _, key := range s.commitKeys {
+		committed[key] = kvs[key]
+	}
+	if len(committed) > 0 {
+		if err := s.Store.SetMetadataBatch(id, committed); err != nil {
+			return err
+		}
+	}
+	return s.err
+}
+
 func (s *releaseRefreshFailOnceStore) Get(id string) (Bead, error) {
 	if s.failNextGet {
 		s.failNextGet = false
@@ -265,6 +284,80 @@ func TestCachingStoreSetMetadataBatchNotifiesBeadUpdated(t *testing.T) {
 	}
 	if updated.Metadata["review"] != "fixed" {
 		t.Fatalf("notification metadata = %#v, want review=fixed", updated.Metadata)
+	}
+}
+
+func TestCachingStoreSetMetadataBatchErrorFencesStaleRow(t *testing.T) {
+	patch := map[string]string{"state": "asleep", "reason": "healed"}
+	for _, tc := range []struct {
+		name       string
+		commitKeys []string
+		wantState  string
+		wantReason string
+	}{
+		{name: "rejected", wantState: "active", wantReason: "old"},
+		{name: "partially committed", commitKeys: []string{"state"}, wantState: "asleep", wantReason: "old"},
+		{name: "fully committed", commitKeys: []string{"state", "reason"}, wantState: "asleep", wantReason: "healed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := NewMemStore()
+			bead, err := mem.Create(Bead{
+				Title:    "worker",
+				Type:     "session",
+				Metadata: map[string]string{"state": "active", "reason": "old"},
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			writeErr := errors.New("ambiguous metadata batch")
+			backing := &ambiguousMetadataBatchStore{
+				Store:      mem,
+				err:        writeErr,
+				commitKeys: tc.commitKeys,
+			}
+			notifications := 0
+			cache := NewCachingStoreForTest(backing, func(string, string, json.RawMessage) {
+				notifications++
+			})
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+			cache.mu.RLock()
+			startSeq := cache.mutationSeq
+			cache.mu.RUnlock()
+
+			if err := cache.SetMetadataBatch(bead.ID, patch); !errors.Is(err, writeErr) {
+				t.Fatalf("SetMetadataBatch error = %v, want %v", err, writeErr)
+			}
+
+			cache.mu.RLock()
+			fence := cache.beadSeq[bead.ID]
+			_, dirty := cache.dirty[bead.ID]
+			_, local := cache.localBeadAt[bead.ID]
+			cache.mu.RUnlock()
+			if fence <= startSeq || !dirty || local {
+				t.Fatalf("ambiguity fence = seq:%d start:%d dirty:%v local:%v", fence, startSeq, dirty, local)
+			}
+			if notifications != 0 {
+				t.Fatalf("notifications = %d, want 0 for an unconfirmed write", notifications)
+			}
+			query := ListQuery{Type: "session"}
+			if _, ok := cache.CachedList(query); ok {
+				t.Fatal("CachedList served a row whose backing write outcome is unknown")
+			}
+
+			rows, err := cache.List(query)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(rows) != 1 || rows[0].Metadata["state"] != tc.wantState || rows[0].Metadata["reason"] != tc.wantReason {
+				t.Fatalf("List metadata = %#v, want state=%q reason=%q", rows, tc.wantState, tc.wantReason)
+			}
+			if rows, ok := cache.CachedList(query); !ok || len(rows) != 1 ||
+				rows[0].Metadata["state"] != tc.wantState || rows[0].Metadata["reason"] != tc.wantReason {
+				t.Fatalf("CachedList after reread = %#v, ok=%v", rows, ok)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

If `CachingStore.SetMetadataBatch` returns an error, treat the backing outcome as unknown. The cache now advances the row mutation fence and marks the pre-write row dirty, without applying the proposed patch or emitting a success notification. The next ordinary read installs backing truth.

This is an independent reconciler-safety extraction; it does not depend on PR #4652 and adds no new abstraction.

Tracking: ga-f7v2ft.64.1

## TDD evidence

RED before the production change:

```text
ambiguity fence = seq:0 start:0 dirty:false local:false
```

The failure reproduced for rejected, partially committed, and fully committed backing outcomes.

GREEN after the seven-line production change:

- All `TestCachingStoreSetMetadataBatch*` tests pass.
- Focused race test passes.
- Full `internal/beads` package passes.
- All six fast `cmd/gc` shards pass.
- `go vet ./...` and changed-package lint pass.

`make test-fast-parallel` retains one unrelated environment failure in `internal/doctor/TestCustomTypesCheck_TableDrift`: the installed bd binary has `CGO_ENABLED=0` and cannot initialize embedded Dolt. The exact failure was already reproduced on pristine base for PR #4652; no doctor, bd, or Dolt code is changed here.

## Scope guard

Two files and exactly 100 added lines. The monolith version used 305 lines and a dedicated 295-line harness; this extraction uses the existing cache invariants and one table-driven test instead.