### PR TITLE
fix(materialize): heal pre-manifest skill sinks orphaned by retired roots

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gastownhall/gascity/internal/doctor"
 	doctorchecks "github.com/gastownhall/gascity/internal/doctor/checks"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/materialize"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/rollout"
@@ -244,6 +245,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewInstructionsFileCheck(cfg, cityPath))
 		register(doctor.NewServiceSecretsPermsCheck(cfg, cityPath))
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
+		register(doctor.NewSkillDanglingSinkCheck(doctorSkillStaticSinks(cityPath, cfg), materialize.LegacyOwnedRootsFor(cityPath), doctorLiveSessionSinks(cityPath, cfg)))
 		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath, doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr))))
 		register(newCodexHooksDriftCheck(cityPath, codexHookWorkDirs(cityPath, cfg)))
 		register(doctor.NewRigPackCoverageCheck(cfg, cityPath))

--- a/cmd/gc/cmd_doctor_skill_sinks.go
+++ b/cmd/gc/cmd_doctor_skill_sinks.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/materialize"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// doctorSkillStaticSinks resolves the config-derived skill sink
+// directories the dangling-sink doctor check scans: every agent's
+// scope-root × provider vendor sink, mirroring the stage-1
+// materializer's targeting (skill_supervisor.go) so the check sees
+// exactly the directories the materializer writes.
+func doctorSkillStaticSinks(cityPath string, cfg *config.City) []string {
+	var sinks []string
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		provider := effectiveAgentProviderFamily(agent, cfg.Workspace.Provider, cfg.Providers)
+		vendor, ok := materialize.VendorSink(provider)
+		if !ok {
+			continue
+		}
+		scopeRoot := resolveAgentScopeRoot(agent, cityPath, cfg.Rigs)
+		if !filepath.IsAbs(scopeRoot) {
+			scopeRoot = filepath.Join(cityPath, scopeRoot)
+		}
+		sinks = append(sinks, filepath.Join(scopeRoot, vendor))
+	}
+	return sinks
+}
+
+// doctorLiveSessionSinks returns a lazy enumerator for the dangling-sink
+// doctor check: each live (non-closed) session's WorkDir × vendor sink.
+// Stage-2 sessions materialize into their per-session worktree, not the
+// scope root, so scope-root-only scanning misses exactly the crew sinks
+// hq-38je found broken. Laziness keeps the session store out of doctor
+// check construction; a store failure yields no live sinks rather than
+// failing the whole check (the static sinks still scan).
+func doctorLiveSessionSinks(cityPath string, cfg *config.City) func() []string {
+	return func() []string {
+		store, err := openSessionProviderStore(cityPath)
+		if err != nil {
+			return nil
+		}
+		infos, err := session.NewStore(beads.SessionStore{Store: cliSessionStore(store, cfg, cityPath)}).ListLabeledSessionInfosUnfiltered()
+		if err != nil {
+			return nil
+		}
+		var sinks []string
+		for _, info := range infos {
+			if info.Closed || info.WorkDir == "" {
+				continue
+			}
+			vendor, ok := materialize.VendorSink(info.Provider)
+			if !ok {
+				continue
+			}
+			sinks = append(sinks, filepath.Join(info.WorkDir, vendor))
+		}
+		return sinks
+	}
+}

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -126,7 +126,7 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 				}
 			}
 
-			if err := materializeSkillsIntoWorkdir(cfg, &agent, workdir, sharedCatalog, stdout, stderr); err != nil {
+			if err := materializeSkillsIntoWorkdir(cfg, &agent, cityPath, workdir, sharedCatalog, stdout, stderr); err != nil {
 				return errExit
 			}
 			return nil
@@ -160,7 +160,7 @@ func decodeSharedCatalogSnapshot(encoded string) (materialize.CityCatalog, error
 	return cat, nil
 }
 
-func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir string, sharedCatalog *materialize.CityCatalog, stdout, stderr io.Writer) error {
+func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, cityPath, workdir string, sharedCatalog *materialize.CityCatalog, stdout, stderr io.Writer) error {
 	if cfg == nil || agent == nil {
 		fmt.Fprintln(stderr, "gc internal materialize-skills: missing city config or agent") //nolint:errcheck // best-effort stderr
 		return errExit
@@ -210,10 +210,11 @@ func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir
 	}
 
 	res, err := materialize.Run(materialize.Request{
-		SinkDir:     filepath.Join(absWorkdir, vendorSink),
-		Desired:     desired,
-		OwnedRoots:  owned,
-		LegacyNames: materialize.LegacyStubNames(),
+		SinkDir:          filepath.Join(absWorkdir, vendorSink),
+		Desired:          desired,
+		OwnedRoots:       owned,
+		LegacyNames:      materialize.LegacyStubNames(),
+		LegacyOwnedRoots: materialize.LegacyOwnedRootsFor(cityPath),
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/skill_install_dir_test.go
+++ b/cmd/gc/skill_install_dir_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestSkillInstallDirsPerProviderAcrossScopes is the issue #3643 regression
+// guard. The requirement: in a fresh install the pack skill must be
+// installed into the directory each provider's CLI actually reads, at the
+// city scope AND at every rig scope — whether the rig lives under the city
+// tree (a subdir rig) or out of tree.
+//
+// It drives the real production path (InjectImplicitAgents → stage-1
+// materialization) rather than hand-authored [[agent]] entries, because the
+// implicit per-provider agents are what a default `gc init` city relies on,
+// and that path is what the bug report exercised.
+//
+// canonicalSink is the project-scoped skills directory each provider's own
+// CLI scans, verified against vendor docs (2026-06):
+//
+//	claude   → .claude/skills   (code.claude.com/docs/en/skills)
+//	codex    → .agents/skills   (developers.openai.com/codex/skills — Codex
+//	                             does NOT read a project-scoped .codex/skills)
+//	gemini   → .gemini/skills   (github.com/google-gemini/gemini-cli)
+//	opencode → .opencode/skills (opencode.ai/docs/skills)
+//	mimocode → .mimocode/skills (mimo.xiaomi.com/mimocode/skills)
+func TestSkillInstallDirsPerProviderAcrossScopes(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+
+	// The pack ships a shared "mayor" skill (as the gascity pack does).
+	writeSkillSource(t, filepath.Join(cityPath, "skills", "mayor"))
+
+	// A rig under the city tree.
+	subdirRig := filepath.Join(cityPath, "rigs", "inside")
+	if err := os.MkdirAll(subdirRig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A rig out of the city tree: a sibling temp dir not under cityPath.
+	outOfTreeRig := filepath.Join(t.TempDir(), "temp-rig")
+	if err := os.MkdirAll(outOfTreeRig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalSink := map[string]string{
+		"claude":   ".claude/skills",
+		"codex":    ".agents/skills",
+		"gemini":   ".gemini/skills",
+		"opencode": ".opencode/skills",
+		"mimocode": ".mimocode/skills",
+	}
+
+	providers := map[string]config.ProviderSpec{}
+	for name := range canonicalSink {
+		providers[name] = config.ProviderSpec{}
+	}
+
+	cfg := &config.City{
+		PackSkillsDir: filepath.Join(cityPath, "skills"),
+		Session:       config.SessionConfig{Provider: "tmux"},
+		Providers:     providers,
+		Rigs: []config.Rig{
+			{Name: "inside", Path: subdirRig},
+			{Name: "temp-rig", Path: outOfTreeRig},
+		},
+	}
+
+	// Fresh-install production path: implicit per-provider agents at city
+	// scope and at each rig scope.
+	config.InjectImplicitAgents(cfg)
+	config.ApplyAgentDefaults(cfg)
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("runStage1SkillMaterialization: %v", err)
+	}
+
+	scopes := []struct {
+		label string
+		root  string
+	}{
+		{"city", cityPath},
+		{"subdir-rig", subdirRig},
+		{"out-of-tree-rig", outOfTreeRig},
+	}
+
+	wantSource := filepath.Join(cityPath, "skills", "mayor")
+	for _, sc := range scopes {
+		for provider, sink := range canonicalSink {
+			link := filepath.Join(sc.root, filepath.FromSlash(sink), "mayor")
+			info, err := os.Lstat(link)
+			if err != nil {
+				t.Errorf("%s / %s: skill not installed where the CLI reads it: %v (want symlink at %s)",
+					sc.label, provider, err, link)
+				continue
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("%s / %s: %s is not a symlink", sc.label, provider, link)
+				continue
+			}
+			// The provider CLI follows the symlink target, so a dangling
+			// or mis-targeted link delivers zero skills even though the
+			// link exists. Assert it resolves to the shared mayor source.
+			tgt, err := os.Readlink(link)
+			if err != nil {
+				t.Errorf("%s / %s: readlink %s: %v", sc.label, provider, link, err)
+				continue
+			}
+			if tgt != wantSource {
+				t.Errorf("%s / %s: symlink target = %q, want %q", sc.label, provider, tgt, wantSource)
+			}
+		}
+	}
+
+	if stderr.Len() > 0 {
+		t.Logf("stderr:\n%s", stderr.String())
+	}
+}

--- a/cmd/gc/skill_install_dir_test.go
+++ b/cmd/gc/skill_install_dir_test.go
@@ -32,7 +32,6 @@ import (
 func TestSkillInstallDirsPerProviderAcrossScopes(t *testing.T) {
 	clearGCEnv(t)
 	cityPath := t.TempDir()
-	t.Setenv("GC_HOME", t.TempDir())
 
 	// The pack ships a shared "mayor" skill (as the gascity pack does).
 	writeSkillSource(t, filepath.Join(cityPath, "skills", "mayor"))

--- a/cmd/gc/skill_supervisor.go
+++ b/cmd/gc/skill_supervisor.go
@@ -107,10 +107,11 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 		}
 
 		res, merr := materialize.Run(materialize.Request{
-			SinkDir:     sinkDir,
-			Desired:     desired,
-			OwnedRoots:  owned,
-			LegacyNames: materialize.LegacyStubNames(),
+			SinkDir:          sinkDir,
+			Desired:          desired,
+			OwnedRoots:       owned,
+			LegacyNames:      materialize.LegacyStubNames(),
+			LegacyOwnedRoots: materialize.LegacyOwnedRootsFor(cityPath),
 		})
 		if merr != nil {
 			fmt.Fprintf(stderr, "gc: stage-1 materialize-skills for agent %q at %s: %v\n", //nolint:errcheck // best-effort stderr

--- a/cmd/gc/skill_supervisor_test.go
+++ b/cmd/gc/skill_supervisor_test.go
@@ -201,8 +201,9 @@ func TestRunStage1SkipsUnsupportedProvider(t *testing.T) {
 
 // TestRunStage1MixedProvidersCreateSiblingSinks verifies the spec's
 // mixed-provider scenario: a claude agent and a codex agent at the
-// same scope root produce sibling .claude/skills/ and .codex/skills/
-// sinks with the same city-pack skill.
+// same scope root produce sibling .claude/skills/ and .agents/skills/
+// sinks (the codex CLI reads .agents/skills, not .codex/skills) with the
+// same city-pack skill.
 func TestRunStage1MixedProvidersCreateSiblingSinks(t *testing.T) {
 	clearGCEnv(t)
 	cityPath := t.TempDir()
@@ -223,7 +224,7 @@ func TestRunStage1MixedProvidersCreateSiblingSinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, vendor := range []string{".claude", ".codex"} {
+	for _, vendor := range []string{".claude", ".agents"} {
 		sink := filepath.Join(cityPath, vendor, "skills", "plan")
 		info, err := os.Lstat(sink)
 		if err != nil {
@@ -553,8 +554,8 @@ func TestRunStage1AgentLocalOnlyInItsOwnSink(t *testing.T) {
 	if _, err := os.Lstat(filepath.Join(cityPath, ".claude", "skills", "mayor-only")); err != nil {
 		t.Errorf("mayor-only missing from claude sink: %v", err)
 	}
-	// deputy's codex sink does NOT get mayor's private skill.
-	if _, err := os.Lstat(filepath.Join(cityPath, ".codex", "skills", "mayor-only")); !os.IsNotExist(err) {
+	// deputy's codex sink (.agents/skills) does NOT get mayor's private skill.
+	if _, err := os.Lstat(filepath.Join(cityPath, ".agents", "skills", "mayor-only")); !os.IsNotExist(err) {
 		t.Errorf("mayor-only leaked into codex sink; err=%v", err)
 	}
 }

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -34,6 +34,7 @@ named-always-min-conflict
 instructions-file
 service-secrets-perms
 skill-collision
+skill-dangling-sink
 order-firing-current
 codex-hooks-drift
 rig-pack-coverage

--- a/docs/guides/capabilities-for-coding-agent-users.md
+++ b/docs/guides/capabilities-for-coding-agent-users.md
@@ -51,14 +51,18 @@ applies.
 - Pick the scope:
   - `skills/<name>/` at **pack level** → shared with **every** agent in the
     city.
-  - `agents/<role>/skills/<name>/` at **role level** → only agents of that role
-    (and its pooled instances). On a name collision, the role-local skill wins.
-- At startup Gas City **symlinks** both scopes into each agent's
-  provider-specific skill sink — `.claude/skills/`, `.codex/skills/`,
-  `.gemini/skills/`, `.opencode/skills/`. List with `gc skill list`.
-- It *places* files into each provider's convention; it doesn't translate them.
-  Providers whose convention isn't confirmed (copilot, cursor, pi, omp) are
-  skipped for now.
+  - `agents/<role>/skills/<name>/` at **role level** → only agents of that
+    role (and all its pooled instances). On a name collision, the role-local
+    skill wins.
+- At startup Gas City **symlinks** the pack level and role level skill directories into
+  each agent's provider-specific skill sink — `.claude/skills/`,
+  `.agents/skills/` (codex), `.gemini/skills/`, `.opencode/skills/`. List with
+  `gc skill list`.
+- It *places* the files into each provider's own convention; it doesn't
+  translate them. Providers whose convention isn't confirmed (copilot, cursor,
+  pi, omp) are skipped for now.
+- No framework *around* skills: no per-agent allow-lists. Within a scope every
+  eligible agent gets every skill; the model decides when one applies.
 - MCP is list-only today (`gc mcp list` shows what's catalogued; you wire the
   servers yourself).
 

--- a/engdocs/proposals/skill-materialization.md
+++ b/engdocs/proposals/skill-materialization.md
@@ -199,7 +199,7 @@ workdir, or a sidecar init step).
 | Provider   | Skill sink           | v0.15.1 status    |
 |------------|----------------------|-------------------|
 | `claude`   | `.claude/skills/`    | materialize       |
-| `codex`    | `.codex/skills/`     | materialize       |
+| `codex`    | `.agents/skills/`    | materialize       |
 | `gemini`   | `.gemini/skills/`    | materialize       |
 | `opencode` | `.opencode/skills/`  | materialize       |
 | `copilot`  | —                    | skip (no sink)    |
@@ -463,7 +463,7 @@ scope root:
   .claude/skills/           # materialized for claude agents
     gc-work/ -> ...
     plan/ -> ...
-  .codex/skills/            # materialized for codex agents
+  .agents/skills/           # materialized for codex agents
     gc-work/ -> ...
     plan/ -> ...
 ```

--- a/internal/doctor/skill_dangling_sink_check.go
+++ b/internal/doctor/skill_dangling_sink_check.go
@@ -1,0 +1,157 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/materialize"
+)
+
+// SkillDanglingSinkCheck surfaces dangling symlinks in agent skill
+// sinks — links whose target no longer exists. The motivating case is
+// the .gc/system/packs retirement (#3344): its config-only migration
+// stranded every pre-manifest sink link, and the materializer's
+// ownership gate then treated those orphans as user-owned forever
+// (hq-38je). gc doctor previously reported only skill collisions, so
+// the fleet-wide breakage was invisible to the standard health check.
+//
+// The check walks a static sink list (agent scope-root × vendor sinks,
+// resolved by the caller from config) plus a lazily-evaluated live
+// session-workdir sink list, and Lstat/Readlinks every entry. Dangling
+// links are classified gc-owned (target under a legacy/cache root —
+// safe for --fix to remove; the next materialize pass recreates any
+// still-desired link) or user-owned (reported only).
+type SkillDanglingSinkCheck struct {
+	staticSinks []string
+	gcRoots     []string
+	liveSinksFn func() []string
+}
+
+// NewSkillDanglingSinkCheck builds a check that scans the given sink
+// directories for dangling symlinks. staticSinks are the config-derived
+// agent sinks; gcOwnedRoots are the retired/managed roots (typically
+// materialize.LegacyOwnedRootsFor(cityPath)) whose dangling links
+// --fix may remove. liveSinksFn, when non-nil, is evaluated inside Run
+// so store-backed live-session enumeration does not slow check
+// construction or fail a doctor run that never reaches this check.
+func NewSkillDanglingSinkCheck(staticSinks []string, gcOwnedRoots []string, liveSinksFn func() []string) *SkillDanglingSinkCheck {
+	return &SkillDanglingSinkCheck{staticSinks: staticSinks, gcRoots: gcOwnedRoots, liveSinksFn: liveSinksFn}
+}
+
+// Name returns the check identifier.
+func (c *SkillDanglingSinkCheck) Name() string { return "skill-dangling-sink" }
+
+// danglingSinkLink records one dangling symlink found in a sink.
+type danglingSinkLink struct {
+	path    string // absolute path of the symlink
+	target  string // raw readlink target
+	gcOwned bool   // target under a legacy/cache root — safe to remove
+}
+
+// scan walks every sink and returns the dangling links, deduplicated
+// and sorted by path. Missing sink directories are skipped silently —
+// an agent that never started has no sink and nothing to report.
+func (c *SkillDanglingSinkCheck) scan() []danglingSinkLink {
+	sinks := append([]string{}, c.staticSinks...)
+	if c.liveSinksFn != nil {
+		sinks = append(sinks, c.liveSinksFn()...)
+	}
+	seen := make(map[string]bool)
+	var out []danglingSinkLink
+	for _, sink := range sinks {
+		if sink == "" || seen[sink] {
+			continue
+		}
+		seen[sink] = true
+		entries, err := os.ReadDir(sink)
+		if err != nil {
+			continue
+		}
+		for _, de := range entries {
+			path := filepath.Join(sink, de.Name())
+			info, err := os.Lstat(path)
+			if err != nil || info.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
+			target, err := os.Readlink(path)
+			if err != nil {
+				continue
+			}
+			// Dangling = following the link fails with not-exist.
+			// Other stat errors (permission, I/O) are inconclusive —
+			// never classify as dangling, so --fix cannot remove a
+			// link whose health we could not establish.
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				continue
+			}
+			out = append(out, danglingSinkLink{
+				path:    path,
+				target:  target,
+				gcOwned: materialize.TargetUnderManagedRoot(target, c.gcRoots),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
+	return out
+}
+
+// Run reports a warning when any sink entry is a dangling symlink.
+func (c *SkillDanglingSinkCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	dangling := c.scan()
+	if len(dangling) == 0 {
+		r.Status = StatusOK
+		r.Message = "no dangling skill-sink symlinks"
+		return r
+	}
+	gcOwned := 0
+	details := make([]string, 0, len(dangling))
+	for _, d := range dangling {
+		class := "user-owned"
+		if d.gcOwned {
+			class = "gc-owned"
+			gcOwned++
+		}
+		details = append(details, fmt.Sprintf("%s -> %s (%s, dangling)", d.path, d.target, class))
+	}
+	r.Status = StatusWarning
+	r.Severity = SeverityAdvisory
+	r.Message = fmt.Sprintf("%d dangling skill-sink symlink(s) (%d gc-owned)", len(dangling), gcOwned)
+	r.Details = details
+	if gcOwned > 0 {
+		r.FixHint = "gc doctor --fix removes gc-owned dangling links; the next materialize pass recreates any still-desired link"
+	} else {
+		r.FixHint = "remove user-owned dangling links manually after confirming the target is truly retired"
+	}
+	return r
+}
+
+// CanFix returns true — gc-owned dangling links are safe to remove.
+func (c *SkillDanglingSinkCheck) CanFix() bool { return true }
+
+// WarmupEligible returns false — the scan is cheap but the live-session
+// sink enumeration opens the session store, which the `gc start`
+// warm-up path should not pay for.
+func (c *SkillDanglingSinkCheck) WarmupEligible() bool { return false }
+
+// Fix removes every gc-owned dangling symlink found by a fresh scan.
+// User-owned links are never touched. A re-scan (rather than cached Run
+// state) keeps the deletion decision current with the filesystem.
+func (c *SkillDanglingSinkCheck) Fix(_ *CheckContext) error {
+	var failed []string
+	for _, d := range c.scan() {
+		if !d.gcOwned {
+			continue
+		}
+		if err := os.Remove(d.path); err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %v", d.path, err))
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("removing dangling gc-owned skill-sink links: %s", strings.Join(failed, "; "))
+	}
+	return nil
+}

--- a/internal/doctor/skill_dangling_sink_check_test.go
+++ b/internal/doctor/skill_dangling_sink_check_test.go
@@ -1,0 +1,141 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mkSinkLink creates a symlink at sink/<name> -> target, creating the
+// sink directory. The target is never created — the link dangles.
+func mkDanglingLink(t *testing.T, sink, name, target string) {
+	t.Helper()
+	if err := os.MkdirAll(sink, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(sink, name)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSkillDanglingSinkCheckClean(t *testing.T) {
+	t.Parallel()
+	sink := t.TempDir()
+	live := filepath.Join(t.TempDir(), "skill")
+	if err := os.MkdirAll(live, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(live, filepath.Join(sink, "gc-work")); err != nil {
+		t.Fatal(err)
+	}
+	c := NewSkillDanglingSinkCheck([]string{sink}, nil, nil)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v, want OK (%s)", r.Status, r.Message)
+	}
+}
+
+func TestSkillDanglingSinkCheckMissingSinkSkipped(t *testing.T) {
+	t.Parallel()
+	c := NewSkillDanglingSinkCheck([]string{filepath.Join(t.TempDir(), "no-such-sink")}, nil, nil)
+	if r := c.Run(&CheckContext{}); r.Status != StatusOK {
+		t.Fatalf("status = %v, want OK (%s)", r.Status, r.Message)
+	}
+}
+
+func TestSkillDanglingSinkCheckFlagsAndClassifies(t *testing.T) {
+	t.Parallel()
+	sink := t.TempDir()
+	legacyRoot := filepath.Join(t.TempDir(), ".gc", "system", "packs")
+	userRoot := filepath.Join(t.TempDir(), "user")
+	mkDanglingLink(t, sink, "core.gc-mail", filepath.Join(legacyRoot, "core", "skills", "gc-mail"))
+	mkDanglingLink(t, sink, "mine", filepath.Join(userRoot, "mine"))
+
+	c := NewSkillDanglingSinkCheck([]string{sink}, []string{legacyRoot}, nil)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning", r.Status)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Errorf("severity = %v, want advisory", r.Severity)
+	}
+	if !strings.Contains(r.Message, "2 dangling") || !strings.Contains(r.Message, "1 gc-owned") {
+		t.Errorf("message = %q", r.Message)
+	}
+	if r.FixHint == "" {
+		t.Error("FixHint empty with gc-owned dangling links present")
+	}
+}
+
+func TestSkillDanglingSinkCheckFixRemovesOnlyGcOwned(t *testing.T) {
+	t.Parallel()
+	sink := t.TempDir()
+	legacyRoot := filepath.Join(t.TempDir(), ".gc", "system", "packs")
+	cacheRoot := filepath.Join(t.TempDir(), ".gc", "cache", "repos")
+	userRoot := filepath.Join(t.TempDir(), "user")
+	gcLegacy := filepath.Join(sink, "core.gc-mail")
+	gcCache := filepath.Join(sink, "core.gc-work")
+	userLink := filepath.Join(sink, "mine")
+	mkDanglingLink(t, sink, "core.gc-mail", filepath.Join(legacyRoot, "core", "skills", "gc-mail"))
+	mkDanglingLink(t, sink, "core.gc-work", filepath.Join(cacheRoot, "be555", "skills", "gc-work"))
+	mkDanglingLink(t, sink, "mine", filepath.Join(userRoot, "mine"))
+
+	c := NewSkillDanglingSinkCheck([]string{sink}, []string{legacyRoot, cacheRoot}, nil)
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{gcLegacy, gcCache} {
+		if _, err := os.Lstat(p); !os.IsNotExist(err) {
+			t.Errorf("gc-owned dangling link survived fix: %s (err=%v)", p, err)
+		}
+	}
+	if _, err := os.Lstat(userLink); err != nil {
+		t.Errorf("user-owned link removed by fix: %v", err)
+	}
+	// Post-fix run reports clean for gc-owned; the user link remains
+	// flagged but is not fixable.
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning || !strings.Contains(r.Message, "1 dangling") || !strings.Contains(r.Message, "0 gc-owned") {
+		t.Errorf("post-fix result = %v %q", r.Status, r.Message)
+	}
+}
+
+func TestSkillDanglingSinkCheckLiveSinksLazy(t *testing.T) {
+	t.Parallel()
+	staticSink := t.TempDir()
+	liveSink := t.TempDir()
+	legacyRoot := filepath.Join(t.TempDir(), ".gc", "system", "packs")
+	mkDanglingLink(t, liveSink, "core.gc-city", filepath.Join(legacyRoot, "core", "skills", "gc-city"))
+
+	calls := 0
+	c := NewSkillDanglingSinkCheck([]string{staticSink}, []string{legacyRoot}, func() []string {
+		calls++
+		return []string{liveSink}
+	})
+	if calls != 0 {
+		t.Fatal("liveSinksFn evaluated during construction")
+	}
+	r := c.Run(&CheckContext{})
+	if calls != 1 {
+		t.Fatalf("liveSinksFn called %d times, want 1", calls)
+	}
+	if r.Status != StatusWarning || !strings.Contains(r.Message, "1 dangling") {
+		t.Fatalf("result = %v %q", r.Status, r.Message)
+	}
+}
+
+func TestSkillDanglingSinkCheckDeduplicatesSinks(t *testing.T) {
+	t.Parallel()
+	sink := t.TempDir()
+	legacyRoot := filepath.Join(t.TempDir(), ".gc", "system", "packs")
+	mkDanglingLink(t, sink, "core.gc-mail", filepath.Join(legacyRoot, "core", "skills", "gc-mail"))
+
+	// Same sink via static list and live list (scope root == session
+	// workdir for stage-1-only agents) must report once.
+	c := NewSkillDanglingSinkCheck([]string{sink}, []string{legacyRoot}, func() []string { return []string{sink} })
+	r := c.Run(&CheckContext{})
+	if !strings.Contains(r.Message, "1 dangling") {
+		t.Fatalf("message = %q, want exactly one report", r.Message)
+	}
+}

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -53,13 +53,25 @@ import (
 // vendorSinks maps an agent provider to the relative directory under the
 // agent's scope-root or session WorkDir where skills are materialized.
 //
-// Only the providers with verified skill-reading behavior are included.
+// Each path is the project-scoped skills directory that the provider's own
+// CLI actually scans (a directory of <name>/SKILL.md), verified against
+// vendor docs (2026-06):
+//
+//	claude   → .claude/skills   (code.claude.com/docs/en/skills)
+//	codex    → .agents/skills   (developers.openai.com/codex/skills — Codex
+//	                             scans .agents/skills from cwd up to the repo
+//	                             root; it does NOT read a project-scoped
+//	                             .codex/skills, only ~/.codex for user state)
+//	gemini   → .gemini/skills   (github.com/google-gemini/gemini-cli docs/cli/skills.md)
+//	opencode → .opencode/skills (opencode.ai/docs/skills)
+//	mimocode → .mimocode/skills (mimo.xiaomi.com/mimocode/skills)
+//
 // The other providers recognized by hooks.go (copilot, cursor, pi, omp)
 // intentionally have no entry — VendorSink returns ok=false so the caller
 // can log a single skip line per session.
 var vendorSinks = map[string]string{
 	"claude":   ".claude/skills",
-	"codex":    ".codex/skills",
+	"codex":    ".agents/skills",
 	"gemini":   ".gemini/skills",
 	"opencode": ".opencode/skills",
 	"mimocode": ".mimocode/skills",

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -46,6 +46,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/bootstrap"
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -339,6 +340,19 @@ type Request struct {
 	// symlinks. Pass nil to skip legacy migration. Use LegacyStubNames()
 	// for the canonical list.
 	LegacyNames []string
+	// LegacyOwnedRoots lists RETIRED gc-managed source roots whose
+	// stranded symlinks the cleanup walk should still recognize as
+	// gc-owned: targets under them are gc's own leftover property, never
+	// user content. The motivating case is the .gc/system/packs
+	// projection retired by #3344 with a config-only migration —
+	// pre-manifest sink links pointing into it classify as "user-owned"
+	// under OwnedRoots+manifest alone and are skipped forever
+	// (hq-38je). Links under these roots are re-pointed when their name
+	// is desired and deleted only once dangling when undesired; a
+	// still-resolving legacy link for an undesired name is left alone.
+	// Use LegacyOwnedRootsFor for the canonical list. Pass nil to keep
+	// the historical behavior.
+	LegacyOwnedRoots []string
 }
 
 // SkippedConflict records a name in the desired set that could not be
@@ -490,6 +504,19 @@ func Run(req Request) (Result, error) {
 	manifest := loadOwnershipManifest(absSink)
 	manifestDirty := false
 
+	legacyOwned := make([]string, 0, len(req.LegacyOwnedRoots))
+	for _, root := range req.LegacyOwnedRoots {
+		if root == "" {
+			continue
+		}
+		canon, err := canonicalizePath(root)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("canonicalize legacy owned root %q: %v", root, err))
+			continue
+		}
+		legacyOwned = append(legacyOwned, canon)
+	}
+
 	// Step 2: legacy stub migration.
 	for _, name := range req.LegacyNames {
 		path := filepath.Join(absSink, name)
@@ -536,15 +563,30 @@ func Run(req Request) (Result, error) {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("canonicalize target %q: %v", target, terr))
 			continue
 		}
+		legacyTarget := false
 		if !targetUnderOwnedRoot(canonTarget, owned) && !manifestRecordsTarget(manifest, name, canonTarget) {
-			// External target — symlink the user placed themselves. Not
-			// under any currently-owned root, and not a target this
+			// Not under any currently-owned root, and not a target this
 			// materializer's own manifest remembers writing for this name
-			// in a previous pass.
-			continue
+			// in a previous pass. Retired gc-managed roots
+			// (LegacyOwnedRoots) still mark the link as gc's own stranded
+			// property — e.g. a pre-#3344 .gc/system/packs projection
+			// target orphaned by the config-only retirement migration.
+			if !targetUnderOwnedRoot(canonTarget, legacyOwned) {
+				// External target — symlink the user placed themselves.
+				continue
+			}
+			legacyTarget = true
 		}
 		desired, want := desiredByName[name]
 		if !want {
+			if legacyTarget {
+				// Stranded legacy-root links are removed only once they
+				// dangle; a still-resolving link for an undesired name may
+				// be serving content the user relies on.
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					continue
+				}
+			}
 			// Owned but not desired — delete (covers dangling and orphaned).
 			if rmErr := os.Remove(path); rmErr != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("removing orphan symlink %q: %v", path, rmErr))
@@ -651,6 +693,52 @@ func Run(req Request) (Result, error) {
 	sort.Strings(result.LegacyMigrated)
 	sort.Strings(result.Warnings)
 	return result, nil
+}
+
+// TargetUnderManagedRoot reports whether target falls under one of the
+// given gc-managed roots, canonicalizing both sides the same way the
+// cleanup walk does so /var ↔ /private/var aliases compare equal. It
+// exists so the doctor dangling-sink check classifies link ownership
+// with exactly the materializer's logic instead of drifting into a
+// second convention. Canonicalization failures classify as false (not
+// owned) — the safe direction for a deletion decision.
+func TargetUnderManagedRoot(target string, roots []string) bool {
+	canonTarget, err := canonicalizePath(target)
+	if err != nil {
+		return false
+	}
+	canonRoots := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		canon, err := canonicalizePath(root)
+		if err != nil {
+			continue
+		}
+		canonRoots = append(canonRoots, canon)
+	}
+	return targetUnderOwnedRoot(canonTarget, canonRoots)
+}
+
+// LegacyOwnedRootsFor returns the canonical retired gc-managed source
+// roots for Request.LegacyOwnedRoots:
+//
+//   - <cityPath>/.gc/system/packs — the per-city projection retired by
+//     #3344, whose config-only migration stranded every pre-manifest
+//     sink symlink that pointed into it (hq-38je).
+//   - <GC_HOME>/cache/repos — the global content-addressed pack
+//     checkout cache; a pruned checkout strands pre-manifest links
+//     that #4130's manifest only covers going forward.
+//
+// The cache root is omitted when GC_HOME is unresolvable (hermetic
+// test binaries) rather than erroring the whole materialization pass.
+func LegacyOwnedRootsFor(cityPath string) []string {
+	roots := []string{filepath.Join(cityPath, citylayout.SystemPacksRoot)}
+	if cacheRoot, err := config.GlobalRepoCacheRoot(); err == nil {
+		roots = append(roots, cacheRoot)
+	}
+	return roots
 }
 
 // LegacyStubNames returns the canonical list of v0.15.0 stub names that

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -99,7 +99,7 @@ func TestVendorSink(t *testing.T) {
 		wantOK   bool
 	}{
 		{"claude", ".claude/skills", true},
-		{"codex", ".codex/skills", true},
+		{"codex", ".agents/skills", true},
 		{"gemini", ".gemini/skills", true},
 		{"opencode", ".opencode/skills", true},
 		{"mimocode", ".mimocode/skills", true},

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -771,6 +771,162 @@ func TestMaterializeAgentSinkDirRequired(t *testing.T) {
 	}
 }
 
+// legacyRootTarget builds a symlink at sink/<name> pointing into a
+// retired root (e.g. the pre-#3344 .gc/system/packs projection) that no
+// longer exists on disk — the orphaned shape hq-38je root-caused.
+func mustDanglingLegacyLink(t *testing.T, sink, name, legacyRoot string) string {
+	t.Helper()
+	target := filepath.Join(legacyRoot, "core", "skills", name)
+	mustSymlink(t, target, filepath.Join(sink, name))
+	return target
+}
+
+func TestRunDeletesDanglingLegacyRootLink(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mkSkill(t, src, "gc-work")
+	sink := t.TempDir()
+	legacyRoot := filepath.Join(t.TempDir(), ".gc", "system", "packs") // never created — retired
+	mustDanglingLegacyLink(t, sink, "qlandia-crew.prep-convoy", legacyRoot)
+
+	_, err := Run(Request{
+		SinkDir:          sink,
+		Desired:          []SkillEntry{{Name: "gc-work", Source: filepath.Join(src, "gc-work"), Origin: "core"}},
+		OwnedRoots:       []string{src},
+		LegacyOwnedRoots: []string{legacyRoot},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(sink, "qlandia-crew.prep-convoy")); !os.IsNotExist(err) {
+		t.Errorf("dangling legacy link survived: lstat err=%v", err)
+	}
+	checkSymlink(t, filepath.Join(sink, "gc-work"), filepath.Join(src, "gc-work"))
+}
+
+func TestRunRepointsDesiredLegacyRootLink(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mkSkill(t, src, "gc-mail")
+	sink := t.TempDir()
+	legacyRoot := filepath.Join(t.TempDir(), ".gc", "system", "packs")
+	mustDanglingLegacyLink(t, sink, "gc-mail", legacyRoot)
+
+	res, err := Run(Request{
+		SinkDir:          sink,
+		Desired:          []SkillEntry{{Name: "gc-mail", Source: filepath.Join(src, "gc-mail"), Origin: "core"}},
+		OwnedRoots:       []string{src},
+		LegacyOwnedRoots: []string{legacyRoot},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res.Materialized, []string{"gc-mail"}) {
+		t.Fatalf("Materialized = %v", res.Materialized)
+	}
+	checkSymlink(t, filepath.Join(sink, "gc-mail"), filepath.Join(src, "gc-mail"))
+	if len(res.Skipped) != 0 {
+		t.Errorf("legacy-target link misreported as user-owned: %+v", res.Skipped)
+	}
+}
+
+func TestRunRepointsLiveDesiredLegacyRootLink(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mkSkill(t, src, "gc-mail")
+	sink := t.TempDir()
+	// Legacy target still exists on disk (e.g. an old cache checkout not
+	// yet pruned): a desired name must still re-point at the current
+	// source — the pre-manifest #4130 case.
+	legacyRoot := t.TempDir()
+	legacyTarget := filepath.Join(legacyRoot, "oldsha", "skills", "gc-mail")
+	if err := os.MkdirAll(legacyTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustSymlink(t, legacyTarget, filepath.Join(sink, "gc-mail"))
+
+	res, err := Run(Request{
+		SinkDir:          sink,
+		Desired:          []SkillEntry{{Name: "gc-mail", Source: filepath.Join(src, "gc-mail"), Origin: "core"}},
+		OwnedRoots:       []string{src},
+		LegacyOwnedRoots: []string{legacyRoot},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res.Materialized, []string{"gc-mail"}) {
+		t.Fatalf("Materialized = %v", res.Materialized)
+	}
+	checkSymlink(t, filepath.Join(sink, "gc-mail"), filepath.Join(src, "gc-mail"))
+}
+
+func TestRunKeepsLiveUndesiredLegacyRootLink(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	sink := t.TempDir()
+	// Live legacy target + name not desired: leave alone. Deleting a
+	// still-resolving link could strand content the user relies on; the
+	// doctor check surfaces it instead.
+	legacyRoot := t.TempDir()
+	legacyTarget := filepath.Join(legacyRoot, "core", "skills", "old-skill")
+	if err := os.MkdirAll(legacyTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustSymlink(t, legacyTarget, filepath.Join(sink, "old-skill"))
+
+	_, err := Run(Request{
+		SinkDir:          sink,
+		Desired:          nil,
+		OwnedRoots:       []string{src},
+		LegacyOwnedRoots: []string{legacyRoot},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSymlink(t, filepath.Join(sink, "old-skill"), legacyTarget)
+}
+
+func TestRunKeepsDanglingLegacyRootLinkWithoutOptIn(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	sink := t.TempDir()
+	legacyRoot := filepath.Join(t.TempDir(), ".gc", "system", "packs")
+	target := mustDanglingLegacyLink(t, sink, "core.gc-mail", legacyRoot)
+
+	// No LegacyOwnedRoots: the historical behavior — orphaned pre-manifest
+	// links classify as user-owned and survive forever.
+	_, err := Run(Request{
+		SinkDir:    sink,
+		OwnedRoots: []string{src},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSymlink(t, filepath.Join(sink, "core.gc-mail"), target)
+}
+
+func TestRunDeletesDanglingCacheRepoLink(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	sink := t.TempDir()
+	// Cache checkout pruned out from under a pre-manifest link.
+	cacheRoot := filepath.Join(t.TempDir(), ".gc", "cache", "repos")
+	target := filepath.Join(cacheRoot, "be555e483c79", "internal", "bootstrap", "packs", "core", "skills", "gc-mail")
+	mustSymlink(t, target, filepath.Join(sink, "core.gc-mail"))
+
+	_, err := Run(Request{
+		SinkDir:          sink,
+		OwnedRoots:       []string{src},
+		LegacyOwnedRoots: []string{cacheRoot},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(sink, "core.gc-mail")); !os.IsNotExist(err) {
+		t.Errorf("dangling cache-target link survived: lstat err=%v", err)
+	}
+}
+
 func TestMaterializeAgentRemovesAllOwnedWhenDesiredEmpty(t *testing.T) {
 	t.Parallel()
 	src := t.TempDir()


### PR DESCRIPTION
## Summary

The #3344 retirement of `.gc/system/packs` shipped a **config-only migration**: no sink-side pass ever re-pointed or removed the pre-manifest symlinks that targeted it. The cleanup walk's ownership gate (`OwnedRoots` + the #4130 manifest) classifies those orphans as user-owned forever — so every sink written before #4130's manifest keeps serving (or skipping on) dead links indefinitely, and `gc doctor` has no check that surfaces them.

**Forward-port note:** #3647 merged into `release/v1.3.0` at 22:24 UTC on June 21, after the final reconciliation-branch commit for #3589 at 21:06 UTC. The release back-merge reached `main` at 00:26 UTC but did not contain #3647, and no later release→main reconciliation was opened. The fix remains present in every v1.3 tag from v1.3.2 through v1.3.5 and was never reverted. This PR therefore forward-ports #3647 as its first commit (authorship preserved) before the `LegacyOwnedRoots` fix; there is no external merge dependency. The second commit is the complete new behavior introduced by this PR.

## Fix

**`Request.LegacyOwnedRoots`** (internal/materialize/skills.go): targets under *retired* gc-managed roots are recognized as gc's own stranded property, never user content. Safety matrix:

| link state | name desired | name not desired |
|---|---|---|
| target under legacy root, dangling | atomic re-point at current source | **delete** |
| target under legacy root, live | atomic re-point at current source | **leave alone** (may be serving content) |

Both `materialize.Run` callers (stage-1 supervisor, `gc internal materialize-skills`) pass `LegacyOwnedRootsFor(cityPath)` = `<city>/.gc/system/packs` + `<GC_HOME>/cache/repos` (a pruned cache checkout strands pre-manifest links the same way the retired projection does).

**`gc doctor` `skill-dangling-sink` check** (sibling of `skill-collision`): walks agent scope-root × vendor sinks plus live session-workdir sinks (lazily enumerated from the session store), Lstat/Readlinks every entry, and reports dangling links classified gc-owned vs user-owned via the newly exported `materialize.TargetUnderManagedRoot`, so doctor and the materializer share exactly one ownership convention. `--fix` removes only gc-owned dangling links — the next materialize pass recreates any still-desired link. Advisory severity; never gates.

## Testing

- 6 new materializer tests (delete dangling / re-point desired dangling / re-point desired live / keep live undesired / no-opt-in preserves historical behavior / cache-root variant) — green.
- 6 new doctor check tests (clean, missing sink, classify, fix-only-gc-owned, lazy live sinks, dedupe) — green.
- Full `internal/materialize` + `internal/doctor` packages green; `cmd/gc` Skill|Materialize|Doctor tests green (incl. updated `doctor_check_names.golden`); `go vet ./...` clean.
- E2E on a synthetic city: `gc doctor` flags 2 dangling (1 gc-owned), `--fix` removes only the gc-owned link, user-owned link untouched.
- One unrelated pre-existing failure on macOS (`TestDoctorStoreFactoryUsesExplicitCityForRigOutsideCityTree`, /var↔/private/var alias) reproduces on clean `main`.