### PR TITLE
fix(gc): bind pool trigger beads with per-slot identity, not stale base name

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2765,11 +2765,6 @@ func realizePoolDesiredSessions(
 		// directly (W-pool), so the former raw pool-loop projection is gone; the
 		// bind fold and every downstream identity read flow through Info.
 		sbInfo := item.sessionInfo
-		if bound, err := bindPoolSessionTriggerBead(bp, cfgAgent, qualifiedName, sbInfo, item.request); err != nil {
-			fmt.Fprintf(stderr, "buildDesiredState: pool %q session %s trigger bead %s: %v (continuing without trigger env)\n", qualifiedName, sbInfo.ID, item.request.WorkBeadID, err) //nolint:errcheck
-		} else {
-			sbInfo = bound
-		}
 		slot := item.slot
 		manualSession := isManualSessionInfoForAgent(sbInfo, cfgAgent)
 		var (
@@ -2782,6 +2777,18 @@ func realizePoolDesiredSessions(
 			resolveAgent = sessionBeadConfigAgent(cfgAgent, qualifiedInstance)
 		} else {
 			resolveAgent, qualifiedInstance, poolSlot = poolDesiredRequestIdentity(cfgAgent, slot)
+		}
+		// Bind using this item's own per-slot qualifiedInstance, not the base
+		// qualifiedName resolved once above the Phase A/B/C pipeline: the work
+		// dir template expands per-request identity (e.g. {{.AgentBase}}), and
+		// qualifiedName is loop-invariant across every item in this pipeline.
+		// cfgAgent (not resolveAgent) matches the Phase A create-time call
+		// (poolTriggerMetadata via selectOrPlanPoolSessionBead), which also
+		// resolves the work dir off the base agent plus the per-slot name.
+		if bound, err := bindPoolSessionTriggerBead(bp, cfgAgent, qualifiedInstance, sbInfo, item.request); err != nil {
+			fmt.Fprintf(stderr, "buildDesiredState: pool %q session %s trigger bead %s: %v (continuing without trigger env)\n", qualifiedName, sbInfo.ID, item.request.WorkBeadID, err) //nolint:errcheck
+		} else {
+			sbInfo = bound
 		}
 		fpExtra := buildFingerprintExtra(resolveAgent)
 		tp, err := resolveTemplateForSessionBeadInfo(bp, resolveAgent, qualifiedInstance, fpExtra, sbInfo)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4102,6 +4102,131 @@ func TestRealizePoolDesiredSessionsBindsTriggerBeadToFreshSession(t *testing.T) 
 	}
 }
 
+// TestRealizePoolDesiredSessionsBindsDistinctWorkDirPerPoolSlot pins the fix
+// for ga-vqs6xr: when one realizePoolDesiredSessions call realizes multiple
+// fresh pool slots at once, each slot's trigger-bead work_dir metadata must
+// be resolved from that slot's own qualified instance name, not the pool's
+// shared base qualifiedName. Before the fix, bindPoolSessionTriggerBead was
+// called with the base qualifiedName -- computed once, before any per-slot
+// identity existed -- so every slot's session bead was bound to the SAME
+// work_dir, silently pooling unrelated agents into one shared worktree
+// (ga-onhj2l).
+// TestRealizePoolDesiredSessionsRebindPreservesDistinctWorkDirPerSlot pins
+// gastownhall/gascity ga-vqs6xr: realizePoolDesiredSessions resolves
+// qualifiedName := cfgAgent.QualifiedName() ONCE, outside the Phase C
+// finalize loop, and passes that same loop-invariant base name into
+// bindPoolSessionTriggerBead for every item. A FRESH multi-slot create
+// does not exercise this: selectOrPlanPoolSessionBead (Phase A) already
+// resolves the correct per-slot qualifiedInstance and bakes it into the
+// bead's initial trigger/work_dir metadata via poolTriggerMetadata, and
+// computePoolTriggerBindingPatch's same-trigger guard (oldWorkBeadID ==
+// workBeadID, true immediately after such a create) then preserves that
+// correct value instead of recomputing it.
+//
+// The bug surfaces on REBIND: an already-existing pool session (its own
+// distinct, previously-correct work_dir already on the bead) reassigned to
+// a NEW work bead in the same tick as a sibling slot's rebind. That is a
+// genuine oldWorkBeadID != workBeadID transition, so the preservation guard
+// does not fire, and bindPoolSessionTriggerBead recomputes the work dir from
+// the stale base qualifiedName shared by every item in the loop — collapsing
+// what should be two distinct per-slot directories onto the same base path.
+func TestRealizePoolDesiredSessionsRebindPreservesDistinctWorkDirPerSlot(t *testing.T) {
+	store := beads.NewMemStore()
+	workDir1 := filepath.Join(t.TempDir(), "worker-1")
+	workDir2 := filepath.Join(t.TempDir(), "worker-2")
+	reusable1, err := store.Create(beads.Bead{
+		Title:  "worker reusable 1",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":                        "worker",
+			"agent_name":                      "worker-1",
+			"alias":                           "worker-1",
+			"session_name":                    "worker-reusable-1",
+			"state":                           string(sessionpkg.StateAsleep),
+			"pool_slot":                       "1",
+			poolManagedMetadataKey:            boolMetadata(true),
+			beadmeta.TriggerBeadIDMetadataKey: "gp-old-1",
+			beadmeta.WorkDirMetadataKey:       workDir1,
+			beadmeta.LegacyWorkDirMetadataKey: workDir1,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reusable2, err := store.Create(beads.Bead{
+		Title:  "worker reusable 2",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":                        "worker",
+			"agent_name":                      "worker-2",
+			"alias":                           "worker-2",
+			"session_name":                    "worker-reusable-2",
+			"state":                           string(sessionpkg.StateAsleep),
+			"pool_slot":                       "2",
+			poolManagedMetadataKey:            boolMetadata(true),
+			beadmeta.TriggerBeadIDMetadataKey: "gp-old-2",
+			beadmeta.WorkDirMetadataKey:       workDir2,
+			beadmeta.LegacyWorkDirMetadataKey: workDir2,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			WorkDir:           ".gc/workspaces/{{.AgentBase}}",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(2),
+		}},
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.addInfo(sessiontest.SeedBead(t, reusable1))
+	snapshot.addInfo(sessiontest.SeedBead(t, reusable2))
+	var stderr bytes.Buffer
+	bp := newAgentBuildParams("test-city", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+	bp.sessionBeads = snapshot
+
+	realizePoolDesiredSessions(bp, &cfg.Agents[0], PoolDesiredState{
+		Template: "worker",
+		Requests: []SessionRequest{
+			{Template: "worker", Tier: "resume", SessionBeadID: reusable1.ID, WorkBeadID: "gp-new-1", WorkBeadTitle: "Fix A"},
+			{Template: "worker", Tier: "resume", SessionBeadID: reusable2.ID, WorkBeadID: "gp-new-2", WorkBeadTitle: "Fix B"},
+		},
+	}, map[string]TemplateParams{}, &stderr)
+
+	stored1, err := store.Get(reusable1.ID)
+	if err != nil {
+		t.Fatalf("Get(session 1): %v", err)
+	}
+	stored2, err := store.Get(reusable2.ID)
+	if err != nil {
+		t.Fatalf("Get(session 2): %v", err)
+	}
+	got1 := stored1.Metadata[beadmeta.WorkDirMetadataKey]
+	got2 := stored2.Metadata[beadmeta.WorkDirMetadataKey]
+	if got1 == "" || got2 == "" {
+		t.Fatalf("work dir metadata missing after rebind: session1=%q session2=%q; stderr=%q", got1, got2, stderr.String())
+	}
+	if got1 == got2 {
+		t.Fatalf("sessions 1 and 2 both bound to %s %q after rebind; want distinct per-slot identity (were %q and %q before rebind)", beadmeta.WorkDirMetadataKey, got1, workDir1, workDir2)
+	}
+	legacy1 := stored1.Metadata[beadmeta.LegacyWorkDirMetadataKey]
+	legacy2 := stored2.Metadata[beadmeta.LegacyWorkDirMetadataKey]
+	if legacy1 == "" || legacy2 == "" {
+		t.Fatalf("legacy work_dir metadata missing after rebind: session1=%q session2=%q", legacy1, legacy2)
+	}
+	if legacy1 == legacy2 {
+		t.Fatalf("sessions 1 and 2 both bound to legacy %s %q after rebind; want distinct per-slot identity", beadmeta.LegacyWorkDirMetadataKey, legacy1)
+	}
+}
+
 func TestRealizePoolDesiredSessionsHonorsExplicitPackWorkspace(t *testing.T) {
 	store := beads.NewMemStore()
 	cfg := &config.City{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4102,15 +4102,6 @@ func TestRealizePoolDesiredSessionsBindsTriggerBeadToFreshSession(t *testing.T) 
 	}
 }
 
-// TestRealizePoolDesiredSessionsBindsDistinctWorkDirPerPoolSlot pins the fix
-// for ga-vqs6xr: when one realizePoolDesiredSessions call realizes multiple
-// fresh pool slots at once, each slot's trigger-bead work_dir metadata must
-// be resolved from that slot's own qualified instance name, not the pool's
-// shared base qualifiedName. Before the fix, bindPoolSessionTriggerBead was
-// called with the base qualifiedName -- computed once, before any per-slot
-// identity existed -- so every slot's session bead was bound to the SAME
-// work_dir, silently pooling unrelated agents into one shared worktree
-// (ga-onhj2l).
 // TestRealizePoolDesiredSessionsRebindPreservesDistinctWorkDirPerSlot pins
 // gastownhall/gascity ga-vqs6xr: realizePoolDesiredSessions resolves
 // qualifiedName := cfgAgent.QualifiedName() ONCE, outside the Phase C


### PR DESCRIPTION
## Summary

Fixes `ga-vqs6xr`: pooled agent sessions (`max_active_sessions > 1`) got
their trigger bead's `work_dir`/`gc.work_dir` metadata bound to the shared
**base** qualified name instead of their own per-slot identity, on every
reconcile tick that **rebinds** an already-existing pooled session to a new
work bead (routine and frequent — not just first-create).

### Root cause

In `realizePoolDesiredSessions` (`cmd/gc/build_desired_state.go`):

- `qualifiedName := cfgAgent.QualifiedName()` is computed once, at function
  entry, from the base agent config — before any per-slot resolution.
- The bind call `bindPoolSessionTriggerBead(bp, cfgAgent, qualifiedName,
  sbInfo, item.request)` used that stale base name for *every* pooled slot.
- The correct per-slot identity (`manualSession` branch, or
  `poolDesiredRequestIdentity(cfgAgent, slot)`) was computed 12-16 lines
  *after* the bind call had already run.

`bindPoolSessionTriggerBead` → `poolTriggerWorkDir` →
`resolveConfiguredWorkDir` expands the agent's `work_dir` template using
whatever qualified name it's handed. Because the stale base name was handed
in, every pooled instance's session-bead metadata got bound to the **same**
path whenever a reconcile tick reassigned a pooled session to a new work
bead.

This only manifests on **rebind**, not on a fresh multi-slot create: create-
time planning (`selectOrPlanPoolSessionBead`/`poolTriggerMetadata`) already
sets correct per-slot metadata, and a same-trigger preservation guard
(`oldWorkBeadID == workBeadID`) protects the very first bind. It's the
routine "rebind an existing pooled slot to new work" path that regresses.

### Fix

Hoist per-slot identity resolution above the `bindPoolSessionTriggerBead`
call, and pass the freshly-resolved `qualifiedInstance` instead of the
loop-invariant `qualifiedName`. `cfgAgent` (not the deep-copied
`resolveAgent`) is kept to match existing create-time precedent. The stale
`qualifiedName` var is left as-is for the unrelated `fmt.Fprintf` error-log
string.

### Verification

- New regression test:
  `TestRealizePoolDesiredSessionsRebindPreservesDistinctWorkDirPerSlot` —
  red before the fix, green after.
- `go test ./cmd/gc/... -run 'Pool'` clean.
- Full sharded suite (`make test-cmd-gc-process-parallel`): 2 shard
  failures observed, both independently root-caused as pre-existing/
  unrelated:
  - `TestBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore` —
    Dolt schema-init flakiness under load (unrelated subsystem), confirmed
    via differing failure symptoms across reruns.
  - `TestSendReloadControlRequestNoChange` — reconcile-timing flake under
    6-way parallel contention; its injected fake `buildFn` never calls
    `realizePoolDesiredSessions`, and it passed 3/3 in isolation.
- Pre-push `test-fast-parallel` also hit one transient failure
  (`TestDockerSessionProtocol` in the unrelated `scripts` package — a
  10ms-poll-interval tmux/Docker timing test, confirmed unrelated by diff
  scope and 3/3 clean isolated reruns); the retried push ran all 8 fast
  jobs clean.
- `go vet ./...` clean.
- Checked for merge/file overlap against the bead's flagged PRs: #4501
  (merged, no file overlap) and #4551 (open, touches
  `cmd/gc/build_desired_state.go` but in a fully disjoint line range,
  ~3944-4017 vs this change's ~2765-2790).

### Out of scope (per bead description, left to `ga-ighomh`)

`SharedCwdGuard`, config validation for `max_active_sessions` without
per-instance `work_dir` variance, and `gc session list` real-cwd display —
tracked separately by `ga-ighomh` (P1, defense-in-depth/observability
follow-up).

## Test plan

- [x] New regression test fails before the fix, passes after
- [x] `go test ./cmd/gc/... -run 'Pool'` passes
- [x] `make test-cmd-gc-process-parallel` — clean aside from two
      independently-confirmed pre-existing/unrelated flakes (see above)
- [x] `go vet ./...` clean
- [x] Pre-push fast suite passes clean