### PR TITLE
Fail gc sling when routed work is invisible to the target query

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -212,6 +212,25 @@ func SetSlingTargetIndexForTest(fn func(n int) int) (restore func()) {
 	return func() { slingTargetIndex = prev }
 }
 
+// slingWorkQueryProbeOverride lets tests replace the WorkQueryProbe that
+// populateSlingDepsCallbacks would otherwise install on cmdSling's
+// internally-constructed slingDeps. cmdSling takes no deps parameter, so
+// callers that build a slingDeps themselves (doSling + testDeps) can already
+// set deps.WorkQueryProbe directly -- this seam exists for cmdSling-level
+// tests, which have no other way to opt out of the real, shell-executing
+// cliWorkQueryProbe. Default nil: production and any test that doesn't set
+// it get the real probe. See SetSlingWorkQueryProbeForTest.
+var slingWorkQueryProbeOverride func(a config.Agent) (string, error)
+
+// SetSlingWorkQueryProbeForTest overrides the WorkQueryProbe cmdSling installs
+// on its internally-constructed slingDeps and returns a restore func. Test
+// only -- mirrors SetSlingTargetIndexForTest.
+func SetSlingWorkQueryProbeForTest(fn func(a config.Agent) (string, error)) (restore func()) {
+	prev := slingWorkQueryProbeOverride
+	slingWorkQueryProbeOverride = fn
+	return func() { slingWorkQueryProbeOverride = prev }
+}
+
 // inferSling1ArgTarget resolves the routing target for a 1-arg `gc sling <bead>`
 // from the bead's rig default_sling_target(s), probing the existing source bead
 // for its prefix. It is the store-touching pre-core orchestration extracted from
@@ -687,6 +706,52 @@ func populateSlingDepsCallbacks(deps *slingDeps) {
 	deps.Notify = &cliNotifier{}
 	deps.DirectSessionResolver = cliDirectSessionResolver
 	deps.Router = cliBeadRouter{deps: deps}
+	// WorkQueryProbe alone gets a nil-guard: its nil state has an established
+	// "skip the postcondition check" meaning (see SlingDeps.WorkQueryProbe),
+	// and test infra relies on being able to install its own probe instead of
+	// this real, shell-executing one -- typically one that returns
+	// sling.ErrSkipWorkQueryProbe, since a fake modeling real work_query
+	// visibility off the test's Store can't track callers that reassign
+	// deps.Store after the deps are built. Callers that build a slingDeps
+	// themselves (doSling + cmd_sling_test.go's testDeps) set
+	// deps.WorkQueryProbe directly, so this nil-guard is already a no-op for
+	// them; cmdSling builds its own deps with no caller-visible seam, so it
+	// additionally consults slingWorkQueryProbeOverride (see
+	// SetSlingWorkQueryProbeForTest) before falling back to the real probe.
+	// The other callback fields above have no such caller-visible nil
+	// semantic and are safe to always overwrite.
+	if deps.WorkQueryProbe == nil {
+		if slingWorkQueryProbeOverride != nil {
+			deps.WorkQueryProbe = slingWorkQueryProbeOverride
+		} else {
+			deps.WorkQueryProbe = cliWorkQueryProbe(deps.CityPath, deps.CityName, deps.Cfg)
+		}
+	}
+}
+
+// cliWorkQueryProbe implements sling.SlingDeps.WorkQueryProbe by running the
+// target agent's own work_query, reusing the exact env/dir/timeout resolution
+// gc hook already uses (hookQueryEnv + shellWorkQueryWithEnv) so the
+// postcondition check sees precisely what a real hook poll would see.
+func cliWorkQueryProbe(cityPath, cityName string, cfg *config.City) func(a config.Agent) (string, error) {
+	return func(a config.Agent) (string, error) {
+		workQuery := a.EffectiveWorkQueryForBeads(cfg.Beads)
+		workQuery = expandAgentCommandTemplate(cityPath, cityName, &a, cfg.Rigs, "work_query", workQuery, os.Stderr)
+		workDir := agentCommandDir(cityPath, &a, cfg.Rigs)
+		overrides, err := hookQueryEnv(cityPath, cfg, &a)
+		if err != nil {
+			return "", err
+		}
+		resolvedAgentName := a.QualifiedName()
+		overrides["GC_AGENT"] = resolvedAgentName
+		overrides["GC_ALIAS"] = resolvedAgentName
+		overrides["GC_SESSION_NAME"] = cliSessionName(cityPath, cityName, resolvedAgentName, cfg.Workspace.SessionTemplate)
+		overrides["GC_SESSION_ID"] = ""
+		overrides["GC_SESSION_ORIGIN"] = ""
+		overrides["GC_TEMPLATE"] = ""
+		queryEnv := mergeRuntimeEnv(os.Environ(), overrides)
+		return shellWorkQueryWithEnv(workQuery, workDir, queryEnv)
+	}
 }
 
 func cliDirectSessionResolver(store beads.Store, cityName, cityPath string, cfg *config.City, target, rigContext string) (string, bool, error) {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -291,7 +291,21 @@ func testDeps(cfg *config.City, sp runtime.Provider, runner SlingRunner) (slingD
 		Runner:   runner,
 		Store:    newSlingTestStore(),
 		StoreRef: "city:test-city",
+		// These tests don't model a real work_query (and many swap Store
+		// out after this call returns, which a Store-backed fake can't
+		// track -- see ga-wvtgnv). Opt out of the postcondition check
+		// explicitly rather than faking visibility.
+		WorkQueryProbe: skipWorkQueryProbe,
 	}, &stdout, &stderr
+}
+
+// skipWorkQueryProbe is the default WorkQueryProbe (see SlingDeps.WorkQueryProbe)
+// for cmd/gc's sling tests: it opts every call out of the routed-bead
+// visibility postcondition via sling.ErrSkipWorkQueryProbe, since these
+// fixtures don't model a real work_query. Tests that specifically exercise
+// the postcondition set deps.WorkQueryProbe themselves.
+func skipWorkQueryProbe(config.Agent) (string, error) {
+	return "", sling.ErrSkipWorkQueryProbe
 }
 
 //nolint:unused // retained for future sling path-resolution scenarios
@@ -2594,6 +2608,10 @@ func TestCmdSlingHyphenatedRigPrefixMultiDashExistingBeadDoesNotOrphan(t *testin
 func TestCmdSlingOneArgHyphenatedPrefixMultiDashExistingBeadUsesDefaultTarget(t *testing.T) {
 	beadID := "agent-diagnostics-spawn-storm"
 	cityDir, rigDir, _ := setupCmdSlingHyphenatedRigPrefixBeadFixture(t, beadID, "agent-diagnostics")
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
@@ -2765,6 +2783,10 @@ func assertStoreHasNoBeadTitle(t *testing.T, cityDir, storeDir, beadTitle string
 
 func TestCmdSlingConfiguredPrefixAllAlphaExistingBeadUsesSelectedPrefixStore(t *testing.T) {
 	cityDir, frontendDir := setupCmdSlingConfiguredPrefixAllAlphaFrontendFixture(t, false, true)
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
@@ -2805,6 +2827,10 @@ func TestCmdSlingConfiguredPrefixAllAlphaExistingBeadUsesSelectedPrefixStore(t *
 
 func TestCmdSlingOneArgConfiguredPrefixAllAlphaExistingBeadUsesDefaultTarget(t *testing.T) {
 	cityDir, frontendDir := setupCmdSlingConfiguredPrefixAllAlphaFrontendFixture(t, true, true)
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
@@ -3018,6 +3044,10 @@ func TestCmdSlingMultiDashBeadIDRoutesExistingBead(t *testing.T) {
 	// gc sling target fo-spawn-storm must route the existing bead and must
 	// not create a new inline bead, when "fo-spawn-storm" exists in the store.
 	cityDir, rigDir := setupCmdSlingMultiDashBeadFixture(t, true)
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
@@ -3061,6 +3091,10 @@ func TestCmdSlingMultiDashBeadIDRoutesExistingBead(t *testing.T) {
 
 func TestCmdSlingOneArgMultiDashExistingBeadUsesDefaultTarget(t *testing.T) {
 	cityDir, rigDir := setupCmdSlingMultiDashBeadFixture(t, true)
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
@@ -3233,6 +3267,10 @@ dir = "live_docs"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	t.Chdir(cityDir)
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
@@ -8900,6 +8938,10 @@ func TestCmdSlingMultiDefaultTargetsPicksFromList(t *testing.T) {
 	cityDir, rigDir := setupCmdSlingMultiDefaultTargetsFixture(t,
 		[]string{"foundations/worker-a", "foundations/worker-b"},
 	)
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
@@ -8935,6 +8977,10 @@ func TestCmdSlingMultiDefaultTargetsSingleEntry(t *testing.T) {
 	cityDir, rigDir := setupCmdSlingMultiDefaultTargetsFixture(t,
 		[]string{"foundations/worker-a"},
 	)
+	// This fixture's file store isn't visible to a real bd subprocess (see
+	// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+	restore := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(

--- a/cmd/gc/sling_seam_test.go
+++ b/cmd/gc/sling_seam_test.go
@@ -127,6 +127,10 @@ func TestCmdSlingMultiDefaultTargets_DeterministicPick(t *testing.T) {
 				[]string{"foundations/worker-a", "foundations/worker-b"})
 			restore := SetSlingTargetIndexForTest(func(int) int { return tc.idx })
 			defer restore()
+			// This fixture's file store isn't visible to a real bd subprocess (see
+			// ga-wvtgnv); opt out of the postcondition check like doSling's testDeps does.
+			restoreProbe := SetSlingWorkQueryProbeForTest(skipWorkQueryProbe)
+			defer restoreProbe()
 
 			var stdout, stderr bytes.Buffer
 			code := cmdSling(

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -148,9 +148,19 @@ type SlingDeps struct {
 	// raw output, mirroring the probe `gc hook` issues for that agent. Used
 	// by finalize's post-routing postcondition check to confirm a routed
 	// bead is actually visible to whatever will pick it up next. nil = skip
-	// the postcondition check.
+	// the postcondition check entirely. A non-nil probe that wants to opt
+	// out of a specific call (e.g. a caller whose fixture doesn't model a
+	// real work_query) can return ErrSkipWorkQueryProbe instead of wiring a
+	// probe that fakes visibility.
 	WorkQueryProbe func(a config.Agent) (output string, err error)
 }
+
+// ErrSkipWorkQueryProbe is a sentinel a WorkQueryProbe implementation can
+// return to explicitly opt out of the routed-bead visibility postcondition
+// for one call, distinct from a nil WorkQueryProbe (which opts out for the
+// whole sling operation). Intended for callers that wire a probe for other
+// reasons but have no real work_query to check against.
+var ErrSkipWorkQueryProbe = errors.New("sling: work query probe skipped")
 
 // graphStore returns the store that owns the graph (workflow/v2) beads this
 // sling materializes. It is the create-side seam for the workflow molecule:

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -144,6 +144,12 @@ type SlingDeps struct {
 	// DirectSessionResolver optionally materializes direct graph assignee
 	// targets to concrete session bead IDs.
 	DirectSessionResolver func(store beads.Store, cityName, cityPath string, cfg *config.City, target, rigContext string) (string, bool, error)
+	// WorkQueryProbe runs the target agent's own work_query and returns its
+	// raw output, mirroring the probe `gc hook` issues for that agent. Used
+	// by finalize's post-routing postcondition check to confirm a routed
+	// bead is actually visible to whatever will pick it up next. nil = skip
+	// the postcondition check.
+	WorkQueryProbe func(a config.Agent) (output string, err error)
 }
 
 // graphStore returns the store that owns the graph (workflow/v2) beads this

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -2,6 +2,7 @@ package sling
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -662,7 +663,68 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 		result.NudgeAgent = &a
 	}
 
+	// Postcondition (ga-wvtgnv): verify the routed bead is actually visible
+	// to the target's own work_query, so a pack.toml work_query override
+	// that filters on labels/metadata sling never set can't silently strand
+	// the bead. Skip when no probe is wired (nil = skip, e.g. most tests and
+	// callers), on dry-run (nothing was actually routed to verify), or under
+	// Force (which already tolerates routing a bead the local store/query
+	// may not resolve -- see the auto-convoy Force tolerance above).
+	if deps.WorkQueryProbe != nil && !opts.DryRun && !opts.Force {
+		target := agentutil.RoutedToIdentity(&a)
+		output, err := deps.WorkQueryProbe(a)
+		switch {
+		case errors.Is(err, ErrSkipWorkQueryProbe):
+			// Probe explicitly opted out of checking this call; treat as satisfied.
+		case err != nil:
+			return result, fmt.Errorf("sling: checking %s visible to %s's work_query: %w", beadID, target, err)
+		case !workQueryContainsBead(output, beadID):
+			return result, fmt.Errorf("sling: %s routed to %s but not visible to its work_query "+
+				"after routing — check labels/metadata/holds against the query "+
+				"%s actually runs", beadID, target, target)
+		}
+	}
+
 	return result, nil
+}
+
+// workQueryContainsBead reports whether beadID appears in a work_query's
+// output. It mirrors workQueryHasReadyWork's JSON-array/object/no-work-line
+// parsing (cmd/gc/cmd_hook.go) but matches a specific bead ID within the
+// parsed structure rather than treating any non-empty output as a hit, so a
+// bead ID that happens to be a substring of another bead's ID or fields
+// cannot produce a false match.
+func workQueryContainsBead(output, beadID string) bool {
+	output = strings.TrimSpace(output)
+	if output == "" || strings.Contains(output, "No ready work found") {
+		return false
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		return false
+	}
+	switch v := decoded.(type) {
+	case []any:
+		for _, item := range v {
+			if workQueryEntryIsBead(item, beadID) {
+				return true
+			}
+		}
+		return false
+	case map[string]any:
+		return workQueryEntryIsBead(v, beadID)
+	default:
+		return false
+	}
+}
+
+func workQueryEntryIsBead(item any, beadID string) bool {
+	m, ok := item.(map[string]any)
+	if !ok {
+		return false
+	}
+	id, ok := m["id"].(string)
+	return ok && id == beadID
 }
 
 func validateBuiltInRouteStoreReachable(deps SlingDeps, beadID string, a config.Agent) error {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -1076,6 +1076,56 @@ func TestDoSlingBeadToFixedAgent(t *testing.T) {
 	}
 }
 
+// TestDoSlingFailsWhenBeadNotVisibleToTargetWorkQuery covers the stranded-bead
+// bug (gastownhall/gascity issue behind ga-wvtgnv): routing succeeds but the
+// target's own work_query — e.g. a pack.toml override that filters on a label
+// this bead lacks — never surfaces the bead, so no worker ever picks it up.
+// DoSling must fail loudly instead of returning success.
+func TestDoSlingFailsWhenBeadNotVisibleToTargetWorkQuery(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
+	deps.WorkQueryProbe = func(_ config.Agent) (string, error) {
+		// Simulates a work_query whose label filter excludes this bead.
+		return "[]", nil
+	}
+	_, err := DoSling(testOpts(a, "BL-42"), deps, nil)
+	if err == nil {
+		t.Fatal("DoSling error = nil, want error: bead routed but not visible to target's work_query")
+	}
+	if !strings.Contains(err.Error(), "BL-42") || !strings.Contains(err.Error(), "mayor") || !strings.Contains(err.Error(), "work_query") {
+		t.Errorf("DoSling error = %q, want it to name the bead, the target, and work_query", err.Error())
+	}
+}
+
+// TestDoSlingSucceedsWhenBeadVisibleToTargetWorkQuery guards against a false
+// positive from the new postcondition check: when the target's work_query
+// output does include the routed bead, DoSling must succeed exactly as it
+// did before the postcondition check existed.
+func TestDoSlingSucceedsWhenBeadVisibleToTargetWorkQuery(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
+	deps.WorkQueryProbe = func(_ config.Agent) (string, error) {
+		return `[{"id":"BL-42","status":"open"}]`, nil
+	}
+	result, err := DoSling(testOpts(a, "BL-42"), deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling error: %v", err)
+	}
+	if result.BeadID != "BL-42" {
+		t.Errorf("BeadID = %q, want BL-42", result.BeadID)
+	}
+}
+
 func TestDoSlingSuspendedAgentWarns(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/release-gates/ga-x8jw29-sling-work-query-visibility-gate.md
+++ b/release-gates/ga-x8jw29-sling-work-query-visibility-gate.md
@@ -1,0 +1,56 @@
+# Release Gate: `gc sling` work-query visibility postcondition
+
+- Deploy bead: `ga-x8jw29`
+- Source bead: `ga-wvtgnv`
+- Reviewed commit: `84d5244c700ff764813d8ff241d8c55ae2914fed`
+- Compared with: `origin/main@8a6809e8fa6dc71faaa04e6a5ee4822dce130275`
+- Result: **PASS**
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses the
+seven release criteria from the active deployer instructions, the source bead's
+acceptance criteria, and `TESTING.md`.
+
+## Release criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | The source bead records `REVIEW (gascity/reviewer): PASS` for the exact reviewed commit. The reviewer independently ran build, vet, focused `internal/sling` tests, and the complete `cmd/gc` sling test surface. |
+| 2 | Acceptance criteria met | PASS | `SlingDeps.WorkQueryProbe` is injected at the CLI boundary; `cliWorkQueryProbe` reuses `hookQueryEnv` and `shellWorkQueryWithEnv`; `finalize` returns an actionable error when the routed bead's exact JSON `id` is absent; dry-run and force-mode semantics are preserved; formulas v2 keep their separate launch-visibility mechanism. The failure and success cases are covered by `TestDoSlingFailsWhenBeadNotVisibleToTargetWorkQuery` and `TestDoSlingSucceedsWhenBeadVisibleToTargetWorkQuery`. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed all eight jobs. Uncached focused runs also passed: `go test -count=1 ./internal/sling/...` and `go test -count=1 ./cmd/gc/... -run 'Sling'`. `go build ./...` and `go vet ./...` exited 0. |
+| 4 | No high-severity review findings open | PASS | The reviewer recorded no blocking issues and only one non-blocking comment-precision nit. Unresolved high-severity findings: 0. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v1` was empty before creating this gate artifact; the isolated deploy branch was rechecked clean after committing it. |
+| 6 | Branch diverges cleanly from main | PASS | After `git fetch origin main`, `git merge-tree --write-tree origin/main 84d5244c700ff764813d8ff241d8c55ae2914fed` exited 0 and produced tree `f391259380c1b2189bd7dc64a85891a530110ab4`. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The two-commit set touches only `cmd/gc` and `internal/sling` routing/probe code and their tests. Every change supports the single post-routing visibility guarantee. |
+
+## Acceptance evidence
+
+- A routed bead absent from the target's work-query output produces a non-nil
+  error naming the bead, target, and `work_query`; the CLI's existing error
+  path converts it to a non-zero exit.
+- The membership check decodes JSON arrays or objects and compares the exact
+  `id` field, avoiding substring false positives.
+- The passing case returns success when the routed bead is visible.
+- `DoSling` returns before routing on dry-run. `--force` skips the
+  postcondition because it explicitly permits dispatch when the local
+  bead/query cannot resolve the bead.
+- Standalone and attached v1 formulas verify the claimable root or source bead
+  through the shared finalizer. Formulas v2 continue through their existing
+  workflow-launch visibility check.
+- `internal/sling` does not import `cmd/gc`; the shell execution, environment,
+  working-directory, and timeout behavior remains owned by the CLI boundary.
+- `gofmt -l` returned no changed files and `git diff --check` passed.
+
+## Commands
+
+```text
+git fetch origin main
+git merge-tree --write-tree origin/main 84d5244c700ff764813d8ff241d8c55ae2914fed
+git diff --check origin/main...84d5244c700ff764813d8ff241d8c55ae2914fed
+gofmt -l cmd/gc/cmd_sling.go cmd/gc/cmd_sling_test.go cmd/gc/sling_seam_test.go internal/sling/sling.go internal/sling/sling_core.go internal/sling/sling_test.go
+go test -count=1 ./internal/sling/...
+go test -count=1 ./cmd/gc/... -run 'Sling'
+make test-fast-parallel
+go build ./...
+go vet ./...
+git status --porcelain=v1
+```


### PR DESCRIPTION
## What this changes

`gc sling` now verifies that routed work is visible to the target agent's effective `work_query` before reporting success. If routing metadata is written but the query still excludes the bead—for example because the query filters on a missing label, dependency state, or hold—the command exits non-zero with an error naming the bead and target instead of silently stranding the work.

The check runs through the same command, environment, working-directory, and timeout machinery that `gc hook` uses. It therefore tests the target's real pickup surface rather than duplicating or trying to interpret pack-specific query rules.

## Review notes

- The new `SlingDeps.WorkQueryProbe` keeps shell execution at the CLI boundary; `internal/sling` only consumes the narrow callback.
- Query output is decoded as JSON and matched by the exact bead `id`, including array and single-object shapes.
- A failed postcondition occurs after the routing operation; the non-zero result is an explicit warning that the routed state exists but is not claimable through the target query.
- Dry-run remains side-effect-free, `--force` retains its missing-bead tolerance, and formulas v2 retain their existing workflow-launch visibility check.
- No configuration, API, schema, or migration changes are required.

## Test plan

- [x] `make test-fast-parallel` — all eight shards pass
- [x] `go test -count=1 ./internal/sling/...`
- [x] `go test -count=1 ./cmd/gc/... -run 'Sling'`
- [x] `go build ./...` and `go vet ./...`
- [x] Release gate: [`release-gates/ga-x8jw29-sling-work-query-visibility-gate.md`](release-gates/ga-x8jw29-sling-work-query-visibility-gate.md)
