### PR TITLE
Make command tests select their city explicitly (batch 2)

### DIFF
--- a/cmd/gc/cmd_event_emit_test.go
+++ b/cmd/gc/cmd_event_emit_test.go
@@ -185,6 +185,7 @@ func TestEventPayloadForEmitFallsBackToStoreBead(t *testing.T) {
 	}
 
 	t.Chdir(dir)
+	t.Setenv("GC_CITY_PATH", dir)
 	var stderr bytes.Buffer
 	payload := eventPayloadForEmit(`{"bead":}`, created.ID, &stderr)
 	if stderr.Len() != 0 {

--- a/cmd/gc/cmd_formula_tutorial_regression_test.go
+++ b/cmd/gc/cmd_formula_tutorial_regression_test.go
@@ -59,6 +59,7 @@ needs = ["cook"]
 `)
 
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout bytes.Buffer
 	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
@@ -91,6 +92,7 @@ condition = "{{env}} == staging"
 `)
 
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout bytes.Buffer
 	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
@@ -124,6 +126,7 @@ title = "[{{epic}}] Implement: {{feature}}"
 `)
 
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout bytes.Buffer
 	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
@@ -161,6 +164,7 @@ title = "[{{epic}}] Implement: {{feature}}"
 `)
 
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout bytes.Buffer
 	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
@@ -203,6 +207,7 @@ title = "[{{epic}}] Implement: {{feature}}"
 `)
 
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout bytes.Buffer
 	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
@@ -239,6 +244,7 @@ title = "[{{epic}}] Deploy {{env}}"
 `)
 
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	stderr := &bytes.Buffer{}
 	cmd := newFormulaShowCmd(&bytes.Buffer{}, stderr)

--- a/cmd/gc/cmd_formula_version_check_test.go
+++ b/cmd/gc/cmd_formula_version_check_test.go
@@ -112,6 +112,7 @@ func TestFormulaVersionCheck_MatchExitsZero(t *testing.T) {
 	cityDir, diskHash := writeVersionCheckCity(t)
 	beadID := createVersionCheckBead(t, cityDir, "deploy", diskHash)
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
@@ -135,6 +136,7 @@ func TestFormulaVersionCheck_DivergeReturnsErrExit(t *testing.T) {
 	cityDir, _ := writeVersionCheckCity(t)
 	beadID := createVersionCheckBead(t, cityDir, "deploy", "deadbeefdeadbeefdeadbeefdeadbeef")
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
@@ -160,6 +162,7 @@ func TestFormulaVersionCheck_DivergeShowsFormulaPath(t *testing.T) {
 	cityDir, _ := writeVersionCheckCity(t)
 	beadID := createVersionCheckBead(t, cityDir, "deploy", "deadbeefdeadbeefdeadbeefdeadbeef")
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
@@ -180,6 +183,7 @@ func TestFormulaVersionCheck_JSONOutput(t *testing.T) {
 	cityDir, diskHash := writeVersionCheckCity(t)
 	beadID := createVersionCheckBead(t, cityDir, "deploy", diskHash)
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
@@ -218,6 +222,7 @@ func TestFormulaVersionCheck_MissingFormulaHashErrors(t *testing.T) {
 	// hash="" → don't set gc.formula_hash metadata.
 	beadID := createVersionCheckBead(t, cityDir, "deploy", "")
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
@@ -254,6 +259,7 @@ func TestFormulaVersionCheck_MissingRefErrors(t *testing.T) {
 		t.Fatalf("SetMetadata: %v", err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
@@ -273,6 +279,7 @@ func TestFormulaVersionCheck_MissingRefErrors(t *testing.T) {
 func TestFormulaVersionCheck_BeadNotFoundErrors(t *testing.T) {
 	cityDir, _ := writeVersionCheckCity(t)
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
@@ -294,6 +301,7 @@ func TestFormulaVersionCheck_FormulaNotOnDiskErrors(t *testing.T) {
 	cityDir, _ := writeVersionCheckCity(t)
 	beadID := createVersionCheckBead(t, cityDir, "ghost-formula", "abc123")
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)

--- a/cmd/gc/order_enabled_filter_test.go
+++ b/cmd/gc/order_enabled_filter_test.go
@@ -94,6 +94,7 @@ func TestCmdOrderShowIncludesOverrideDisabledOrder(t *testing.T) {
 	clearCityRigFlags(t)
 	cityDir, _ := newPersistedOrderEnabledFilterCity(t)
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdOrderShow("drop", "", &stdout, &stderr)
@@ -125,6 +126,7 @@ func TestCmdOrderHistoryIncludesOverrideDisabledOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdOrderHistory("drop", "", &stdout, &stderr)

--- a/release-gates/ga-e66rtz-ambient-city-discovery-batch-2-gate.md
+++ b/release-gates/ga-e66rtz-ambient-city-discovery-batch-2-gate.md
@@ -1,0 +1,46 @@
+# Release Gate: Explicit city paths for command tests, batch 2
+
+- Deploy bead: `ga-e66rtz`
+- Source review bead: `ga-do76zk`
+- Reviewed commit: `0230167ae9cdec48254c84ece95ad8063cd76a91`
+- Gated commit after bounded self-rebase: `7868a0148515db3e59e635dd0e2ec5e909876386`
+- Base: `origin/main@9efcfb5411be1056e2a824bacebc65421a98f982`
+- Deploy branch: `deploy/ga-e66rtz-gate`
+- Gate date: 2026-07-25
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this
+  checkout, so this checklist uses the active deployer criteria and `TESTING.md`.
+
+## Gate Results
+
+Criterion 6 was evaluated first as required.
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead `ga-do76zk` is closed with `REVIEW VERDICT: PASS`. Its independent review covered the complete 17-line diff, build, vet, focused tests, security, coverage, and CI-integrity concerns. |
+| 2 | Acceptance criteria met | PASS | The patch adds `t.Setenv("GC_CITY_PATH", dir)` immediately after the existing `t.Chdir(dir)` at 17 sites in the four specified `cmd/gc` test files. The focused smoke passed all 17 affected tests. No production code changed. |
+| 3 | Tests pass | PASS | On gated commit `7868a0148`, `go build ./...` and `go vet ./...` passed; the 17 affected tests passed; and `make test-fast-parallel` passed all nine jobs (`unit-core`, six `unit-cmd-gc` shards, `fsys-darwin-compile`, and `push-gate-lock-selftest`). |
+| 4 | No high-severity review findings open | PASS | The source review records no security, coverage, CI-integrity, or other unresolved HIGH finding. Deployer inspection found no additional high-severity concern in this test-only change. |
+| 5 | Final branch is clean | PASS | Before this checklist was added, `git status --porcelain=v1` produced no output and `git diff --check origin/main...HEAD` passed. This checklist is committed as the isolated deploy branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | The reviewed commit did not contain current main, so the canonical bounded helper replayed it from `0230167ae9` to `7868a01485` on `origin/main@9efcfb5411`. `git range-diff` reported the patch as identical, the lease-protected push to the isolated deploy branch succeeded, and `git ls-remote` verified the remote at `7868a0148515db3e59e635dd0e2ec5e909876386`. |
+| 7 | Single feature theme | PASS | The commit changes four `cmd/gc` test files only, with one repeated purpose: make city selection explicit instead of relying on ambient upward discovery. |
+
+## Acceptance Checks
+
+- PASS: The event-emit fallback test pins its temporary city explicitly.
+- PASS: Six formula-show tutorial tests pin their temporary city explicitly.
+- PASS: Eight formula version-check tests pin their temporary city explicitly.
+- PASS: Two order show/history tests pin their temporary city explicitly.
+- PASS: The change remains test-only: 17 insertions in four files.
+- PASS: Parent bead `ga-klo4gz` remains sequenced after the full migration; this
+  batch does not clear the ambient-discovery guard to land.
+
+## Commands
+
+```text
+git range-diff 2c4c43b270d72365a0080530b0c3e3503f898e7d..0230167ae9cdec48254c84ece95ad8063cd76a91 9efcfb5411be1056e2a824bacebc65421a98f982..7868a0148515db3e59e635dd0e2ec5e909876386
+git diff --check origin/main...HEAD
+go build ./...
+go vet ./...
+go test -count=1 ./cmd/gc -run '^(TestEventPayloadForEmitFallsBackToStoreBead|TestFormulaShowTutorialStepCountMatchesRenderedSteps|TestFormulaShowTutorialConditionUsesDefaultVars|TestFormulaShowDoesNotRejectRequiredVars|TestFormulaShowHighlightsRequiredVars|TestFormulaShowWithPartialVarsStillShowsRequiredVars|TestFormulaShowValidatesProvidedVarsWithoutRequiringMissingVars|TestFormulaVersionCheck_MatchExitsZero|TestFormulaVersionCheck_DivergeReturnsErrExit|TestFormulaVersionCheck_DivergeShowsFormulaPath|TestFormulaVersionCheck_JSONOutput|TestFormulaVersionCheck_MissingFormulaHashErrors|TestFormulaVersionCheck_MissingRefErrors|TestFormulaVersionCheck_BeadNotFoundErrors|TestFormulaVersionCheck_FormulaNotOnDiskErrors|TestCmdOrderShowIncludesOverrideDisabledOrder|TestCmdOrderHistoryIncludesOverrideDisabledOrder)$' -v
+make test-fast-parallel
+```


### PR DESCRIPTION
## What this changes

Seventeen command tests now set `GC_CITY_PATH` to the temporary city they already enter. Order show/history, event emission, formula preview, and formula version-check tests therefore select their fixture city explicitly instead of depending on an ambient upward search for `city.toml`.

This is a test-hermeticity change only; production command behavior is unchanged.

## Review notes

- The diff is 17 identical one-line additions across four `cmd/gc` test files.
- The explicit city path is set immediately after each existing `t.Chdir` call.
- This is batch 2 of the migration. The test-binary ambient-discovery guard is intentionally not included and must wait until every affected test file has migrated.
- There are no config, API, wire-format, or migration changes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] All 17 directly affected tests
- [x] `make test-fast-parallel` (all nine jobs)
- [x] Release gate: [`release-gates/ga-e66rtz-ambient-city-discovery-batch-2-gate.md`](release-gates/ga-e66rtz-ambient-city-discovery-batch-2-gate.md)
