### PR TITLE
fix: share push-gate slots across linked worktrees

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -897,8 +897,10 @@ from real regressions.
 `scripts/test-local-parallel` — the one place all four heavy targets
 (`fast`, `cmd-gc-process`, `integration`, `full`) funnel through — acquires
 one of `PUSH_GATE_MAX_CONCURRENT` (default 2) numbered `flock(1)` slots
-under `<city_root>/.gc/gate-slots` (or `<repo>/.git/gate-slots` outside a
-city) before running any jobs, and holds it for the invocation's entire
+under `<city_root>/.gc/gate-slots` (or, outside a city, the repository's
+common git dir — `<repo>/.git/gate-slots` in a normal clone, and the one
+shared common dir for all of a repo's linked worktrees) before running any
+jobs, and holds it for the invocation's entire
 lifetime. The mechanism (`scripts/push-gate-lock-lib.sh`) is adapted from
 `packs/maintainer-pr-review/scripts/run-lock-lib.sh`'s
 `mpr_acquire_global_slot` in the gc-management meta-repo, with one

--- a/scripts/push-gate-lock-lib.sh
+++ b/scripts/push-gate-lock-lib.sh
@@ -89,7 +89,10 @@
 #       sessions rely on via env vars). Returns 1 if nothing is found.
 #   push_gate_slots_dir
 #       Print the slot directory to use: <city_root>/.gc/gate-slots when
-#       push_gate_city_root resolves, else <repo_root>/.git/gate-slots
+#       push_gate_city_root resolves, else <git_common_dir>/gate-slots —
+#       still <repo_root>/.git/gate-slots in a normal clone, but sibling
+#       linked worktrees resolve to the one shared common dir instead of a
+#       per-worktree `.git` file that cannot hold a directory
 #       (NFR4 fallback, never /tmp — see AGENTS.md Build Cache Conventions).
 #       Does not create the directory (push_gate_acquire_slot does).
 #   push_gate_acquire_slot <slot_dir> <fd_out_var> [holder_label]
@@ -180,8 +183,13 @@ push_gate_slots_dir() {
         printf '%s/.gc/gate-slots\n' "$_pgs_city_root"
         return 0
     fi
+    # --git-common-dir (Git 2.5+) may print a path relative to $PWD, so
+    # absolutize it here rather than with --path-format=absolute (Git 2.31+):
+    # git rev-parse echoes an unrecognized option and still exits 0, which
+    # would smuggle garbage past this `if` on older git.
     local _pgs_git_common
-    if _pgs_git_common="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+    if _pgs_git_common="$(git rev-parse --git-common-dir 2>/dev/null)" && [[ -n "$_pgs_git_common" ]]; then
+        _pgs_git_common="$(cd "$_pgs_git_common" 2>/dev/null && pwd)" || return 1
         printf '%s/gate-slots\n' "$_pgs_git_common"
         return 0
     fi

--- a/scripts/push-gate-lock-lib.sh
+++ b/scripts/push-gate-lock-lib.sh
@@ -172,7 +172,7 @@ push_gate_city_root() {
     return 1
 }
 
-# Print the slot directory to use (city-rooted, or repo-relative fallback).
+# Print the slot directory to use (city-rooted, or common-Git-dir fallback).
 # Does not create it.
 push_gate_slots_dir() {
     local _pgs_city_root
@@ -180,9 +180,9 @@ push_gate_slots_dir() {
         printf '%s/.gc/gate-slots\n' "$_pgs_city_root"
         return 0
     fi
-    local _pgs_repo_root
-    if _pgs_repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-        printf '%s/.git/gate-slots\n' "$_pgs_repo_root"
+    local _pgs_git_common
+    if _pgs_git_common="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+        printf '%s/gate-slots\n' "$_pgs_git_common"
         return 0
     fi
     return 1

--- a/scripts/test-push-gate-lock.sh
+++ b/scripts/test-push-gate-lock.sh
@@ -248,7 +248,9 @@ git -C "$LINKED_REPO" worktree add -q --detach "$LINKED_B"
 
 SLOTS_LINKED_A="$(cd "$LINKED_A" && GC_CITY_PATH="" GC_CITY="" GC_CITY_ROOT="" HOME="$WORK/unrelated-home" push_gate_slots_dir)"
 SLOTS_LINKED_B="$(cd "$LINKED_B" && GC_CITY_PATH="" GC_CITY="" GC_CITY_ROOT="" HOME="$WORK/unrelated-home" push_gate_slots_dir)"
-assert_eq "slots_dir.linked_worktree_uses_common_git_dir" "$SLOTS_LINKED_A" "$LINKED_REPO/.git/gate-slots"
+LINKED_COMMON="$(cd "$LINKED_REPO/.git" && pwd -P)"
+SLOTS_LINKED_A_N="$(cd "$(dirname "$SLOTS_LINKED_A")" && pwd -P)/gate-slots"
+assert_eq "slots_dir.linked_worktree_uses_common_git_dir" "$SLOTS_LINKED_A_N" "$LINKED_COMMON/gate-slots"
 assert_eq "slots_dir.linked_worktrees_share_slots" "$SLOTS_LINKED_B" "$SLOTS_LINKED_A"
 
 FD_LINKED=""

--- a/scripts/test-push-gate-lock.sh
+++ b/scripts/test-push-gate-lock.sh
@@ -233,6 +233,32 @@ mkdir -p "$NOCITY"
 SLOTS_FALLBACK="$(cd "$NOCITY" && GC_CITY_PATH="" GC_CITY="" GC_CITY_ROOT="" HOME="$WORK/unrelated-home" push_gate_slots_dir)"
 assert_eq "slots_dir.falls_back_to_repo_relative" "$SLOTS_FALLBACK" "$NOCITY/.git/gate-slots"
 
+LINKED_REPO="$WORK/linked-repo"
+LINKED_A="$WORK/linked-a"
+LINKED_B="$WORK/linked-b"
+mkdir -p "$LINKED_REPO"
+git -C "$LINKED_REPO" init -q
+git -C "$LINKED_REPO" config user.name "Push Gate Test"
+git -C "$LINKED_REPO" config user.email "push-gate-test@example.invalid"
+: >"$LINKED_REPO/tracked"
+git -C "$LINKED_REPO" add tracked
+git -C "$LINKED_REPO" commit -qm "seed linked worktree fixture"
+git -C "$LINKED_REPO" worktree add -q --detach "$LINKED_A"
+git -C "$LINKED_REPO" worktree add -q --detach "$LINKED_B"
+
+SLOTS_LINKED_A="$(cd "$LINKED_A" && GC_CITY_PATH="" GC_CITY="" GC_CITY_ROOT="" HOME="$WORK/unrelated-home" push_gate_slots_dir)"
+SLOTS_LINKED_B="$(cd "$LINKED_B" && GC_CITY_PATH="" GC_CITY="" GC_CITY_ROOT="" HOME="$WORK/unrelated-home" push_gate_slots_dir)"
+assert_eq "slots_dir.linked_worktree_uses_common_git_dir" "$SLOTS_LINKED_A" "$LINKED_REPO/.git/gate-slots"
+assert_eq "slots_dir.linked_worktrees_share_slots" "$SLOTS_LINKED_B" "$SLOTS_LINKED_A"
+
+FD_LINKED=""
+if push_gate_acquire_slot "$SLOTS_LINKED_A" FD_LINKED "linked-holder"; then
+    record_pass "slots_dir.linked_worktree_can_acquire"
+    push_gate_release_slot "$FD_LINKED"
+else
+    record_fail "slots_dir.linked_worktree_can_acquire" "resolved slot directory is not usable: $SLOTS_LINKED_A"
+fi
+
 # ---------------- static wiring assertions against test-local-parallel ----------------
 assert_true "wiring.sources_lib"   grep -q 'push-gate-lock-lib.sh' "$LOCAL_PARALLEL"
 assert_true "wiring.calls_acquire" grep -q 'push_gate_acquire_slot' "$LOCAL_PARALLEL"


### PR DESCRIPTION
## Summary

- Resolve the non-city push-gate fallback through the repository common Git directory.
- Make sibling linked worktrees share one valid slot directory instead of trying to create a directory beneath their .git gitfile.
- Preserve city-root precedence and normal-clone behavior.

Tracks bead ga-3rd1m.

## Testing

- [ ] `make check` (not run; the documented sharded fast gate and vet were run directly)
- [ ] `make check-docs` (not applicable; no docs changed)
- [ ] `make test-integration` (not applicable; no runtime, controller, or workflow behavior changed)
- [x] `bash scripts/test-push-gate-lock.sh` (48/48)
- [x] `shellcheck scripts/push-gate-lock-lib.sh scripts/test-push-gate-lock.sh`
- [x] `go test ./scripts -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`

## Checklist

- [x] Linked bead ga-3rd1m
- [x] Added a real two-linked-worktree regression and acquisition proof
- [x] No user-facing documentation change required
- [x] No breaking change or migration required