### PR TITLE
test(cmd/gc): make prime, nudge, and formula tests use explicit city paths

### DIFF
--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -772,6 +772,7 @@ title = "Do work for {{convoy_id}}"
 		t.Fatalf("write formula: %v", err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 	store, err := openStoreAtForCity(cityDir, cityDir)
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -876,7 +877,7 @@ title = "Do work"
 	// review, quad341): the "cmd/gc+untagged" scope only counts *_test.go call
 	// sites beneath cmd/gc, so routing through internal/formulatest keeps the
 	// env/cwd baselines flat with no policy change.
-	formulatest.SetupHermeticCookEnv(t, cityDir)
+	formulatest.SetupHermeticCookEnv(t, cityDir, cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaCookCmd(&stdout, &stderr)
@@ -949,8 +950,10 @@ title = "Do work"
 	// Select the rig scope via cwd (enclosing-rig resolution in
 	// resolveFormulaScope), which reads the rig from city.toml's [[rigs]] — no
 	// site-registry registration needed, unlike the --rig flag path. The helper
-	// chdirs into the rig dir; resolveCity walks up to the city.toml.
-	formulatest.SetupHermeticCookEnv(t, rigDir)
+	// chdirs into the rig dir while pointing GC_CITY_PATH at cityDir directly,
+	// so the enclosing-rig cwd lookup still sees the rig dir while city
+	// resolution itself no longer depends on an ambient upward walk.
+	formulatest.SetupHermeticCookEnv(t, rigDir, cityDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd := newFormulaCookCmd(&stdout, &stderr)
@@ -1019,6 +1022,7 @@ title = "Do work for {{convoy_id}}"
 		}
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 	store, err := openStoreAtForCity(cityDir, cityDir)
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -1086,6 +1090,7 @@ title = "Do work for {{convoy_id}}"
 		t.Fatalf("write formula: %v", err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 	store, err := openStoreAtForCity(cityDir, cityDir)
 	if err != nil {
 		t.Fatalf("open store: %v", err)

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4179,6 +4179,7 @@ start_command = "echo"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	store, err := openCityStoreAt(cityDir)
 	if err != nil {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -6106,6 +6106,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrime([]string{"mayor"}, &stdout, &stderr)
@@ -6147,6 +6148,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_AGENT", "mayor")
 
 	var stdout, stderr bytes.Buffer
@@ -6186,6 +6188,7 @@ name = "test-city"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrime([]string{"ada"}, &stdout, &stderr)
@@ -6220,6 +6223,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrime([]string{"nonexistent"}, &stdout, &stderr)
@@ -6256,6 +6260,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithMode([]string{"nonexistent"}, &stdout, &stderr, false, true)
@@ -6302,6 +6307,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
@@ -6363,6 +6369,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithMode(nil, &stdout, &stderr, false, true)
@@ -6409,6 +6416,7 @@ max_active_sessions = 1
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
@@ -6450,6 +6458,7 @@ prompt_template = "prompts/does-not-exist.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
@@ -6494,6 +6503,7 @@ prompt_template = %q
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
@@ -6548,6 +6558,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	// Clear GC_RIG so .RigName evaluates to empty and the conditional
 	// short-circuits. Without this, an ambient GC_RIG would produce output.
@@ -6590,6 +6601,7 @@ name = "mayor"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	t.Setenv("GC_SESSION_ID", "test-session-123")
 	t.Setenv("GC_PROVIDER_SESSION_ID", "provider-session-123")
@@ -6657,6 +6669,7 @@ prompt_template = "prompts/does-not-exist.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	t.Setenv("GC_SESSION_ID", sessionBead.ID)
 	t.Setenv("GC_PROVIDER_SESSION_ID", "provider-session-missing-template")
@@ -6713,6 +6726,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	t.Setenv("GC_SESSION_ID", "test-session-456")
 
@@ -6773,6 +6787,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
@@ -6815,6 +6830,7 @@ suspended = true
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	t.Setenv("GC_SESSION_ID", "test-session-suspended")
 
@@ -6890,6 +6906,7 @@ max = 3
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrime([]string{"polecat"}, &stdout, &stderr)
@@ -6933,6 +6950,7 @@ max = -1
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrime([]string{"polecat"}, &stdout, &stderr)
@@ -6988,6 +7006,7 @@ max = -1
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrime([]string{"worker"}, &stdout, &stderr)
@@ -7045,6 +7064,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_AGENT", "mayor")
 
 	reader, writer, err := os.Pipe()
@@ -7144,6 +7164,7 @@ prompt_template = "prompts/probe.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_AGENT", "probe")
 	t.Setenv("GC_SESSION_ID", sessionBead.ID)
 	t.Setenv("GEMINI_SESSION_ID", "gemini-provider-session")
@@ -7223,6 +7244,7 @@ prompt_template = "prompts/probe.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_AGENT", "probe")
 	t.Setenv("GC_SESSION_ID", sessionBead.ID)
 	t.Setenv("GC_PROVIDER_SESSION_ID", "omp-provider-session")
@@ -7396,6 +7418,7 @@ prompt_template = "prompts/probe.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_AGENT", "probe")
 	t.Setenv("GC_SESSION_ID", sessionBead.ID)
 	t.Setenv("GC_SESSION_NAME", "probe")
@@ -7454,6 +7477,7 @@ prompt_template = "prompts/probe.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_ALIAS", "probe-live")
 	t.Setenv("GC_TEMPLATE", "probe")
 
@@ -7519,6 +7543,7 @@ prompt_template = "prompts/probe.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_ALIAS", "probe-live")
 	t.Setenv("GC_SESSION_ID", sessionBead.ID)
 	t.Setenv("GC_TEMPLATE", "")
@@ -7568,6 +7593,7 @@ prompt_template = "prompts/mayor.md"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY_PATH", dir)
 	t.Setenv("GC_AGENT", "bl-9jl") // bead ID, not an agent name
 	t.Setenv("GC_ALIAS", "mayor")
 

--- a/internal/formulatest/env.go
+++ b/internal/formulatest/env.go
@@ -4,8 +4,16 @@ import "testing"
 
 // SetupHermeticCookEnv prepares the process environment and working directory a
 // standalone `gc formula cook` test needs: isolated GC_HOME / XDG_RUNTIME_DIR
-// temp dirs, the fake-session + file-beads + skip-dolt providers, and cwd at
-// cityDir (call it after the city.toml and formulas are written there).
+// temp dirs, the fake-session + file-beads + skip-dolt providers, GC_CITY_PATH
+// pointed at cityRootDir (an explicit override so city resolution does not
+// depend on ambient upward city.toml discovery), and cwd at chdirDir (call it
+// after the city.toml and formulas are written).
+//
+// chdirDir and cityRootDir are the same directory for ordinary city-scoped
+// cook runs. They diverge when a test chdirs into a rig subdirectory to
+// exercise resolveFormulaScope's cwd-based enclosing-rig lookup: cwd must
+// stay at the rig dir for that lookup to see the right rig, while the city
+// itself still needs an explicit, non-ambient path to resolve.
 //
 // It deliberately lives outside cmd/gc so the t.Setenv/t.Chdir call sites are
 // not counted by the cmd/gc resource-census ratchet
@@ -14,12 +22,13 @@ import "testing"
 // through this shared helper keeps those env/cwd baselines flat. Consolidating
 // this boilerplate into one auditable helper is also the migration the ratchet
 // is guarding.
-func SetupHermeticCookEnv(tb testing.TB, cityDir string) {
+func SetupHermeticCookEnv(tb testing.TB, chdirDir, cityRootDir string) {
 	tb.Helper()
 	tb.Setenv("GC_HOME", tb.TempDir())
 	tb.Setenv("XDG_RUNTIME_DIR", tb.TempDir())
 	tb.Setenv("GC_SESSION", "fake")
 	tb.Setenv("GC_BEADS", "file")
 	tb.Setenv("GC_DOLT", "skip")
-	tb.Chdir(cityDir)
+	tb.Chdir(chdirDir)
+	tb.Setenv("GC_CITY_PATH", cityRootDir)
 }

--- a/release-gates/ga-ql2s5k-ambient-city-discovery-batch-3-gate.md
+++ b/release-gates/ga-ql2s5k-ambient-city-discovery-batch-3-gate.md
@@ -1,0 +1,53 @@
+# Release Gate: Explicit city paths for command tests, batch 3
+
+- Deploy bead: `ga-ql2s5k`
+- Source review bead: `ga-xy2gbc`
+- Reviewed commit: `48a40cd9ab4fa5d25b2eca14dd8826238faa4718`
+- Gated commit after bounded self-rebase: `eabb4f7c771b464f5b09864f71671d5b2e69bc12`
+- Base: `origin/main@1bc642727251a84a33d0316a0d3d26e3e9c11ffe`
+- Deploy branch: `deploy/ga-ql2s5k-gate`
+- Gate date: 2026-07-25
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this
+  checkout, so this checklist uses the active deployer criteria and `TESTING.md`.
+
+## Gate Results
+
+Criterion 6 was evaluated first as required.
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead `ga-xy2gbc` is closed with `REVIEW VERDICT: PASS`. The independent review covered the complete diff, build, vet, focused tests, security, coverage, CI integrity, and the parent-bead sequencing constraint. |
+| 2 | Acceptance criteria met | PASS | The patch explicitly pins `GC_CITY_PATH` at 26 `main_test.go` sites, one `cmd_nudge_test.go` site, and five `cmd_formula_test.go` sites. `SetupHermeticCookEnv` now separates its working directory from the exact city root, and both repo-wide callers pass the correct pair. All 36 directly affected, indirectly affected, and guard-blind control tests passed. No production code changed. |
+| 3 | Tests pass | PASS | On gated commit `eabb4f7c7`, `go build ./...` and `go vet ./...` passed; all 36 focused tests passed; and `make test-fast-parallel` passed all nine jobs (`unit-core`, six `unit-cmd-gc` shards, `fsys-darwin-compile`, and `push-gate-lock-selftest`). |
+| 4 | No high-severity review findings open | PASS | The source review records only two non-blocking bookkeeping nits: the original base attribution and a verification-count typo. It records no unresolved HIGH, security, coverage, or CI-integrity finding. Deployer inspection found no additional high-severity concern in this test-only change. |
+| 5 | Final branch is clean | PASS | Before this checklist was added, `git status --porcelain` produced no output, `git diff --check origin/main..HEAD` passed, and `gofmt -l` produced no output for all four changed files. This checklist is committed as the isolated deploy branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | The reviewed commit did not contain current main, so the canonical bounded helper replayed it from `48a40cd9ab` to `eabb4f7c77` on `origin/main@1bc6427272`. `git range-diff` reported the patch as identical, the lease-protected push to the isolated deploy branch succeeded, `git ls-remote` verified the remote at `eabb4f7c771b464f5b09864f71671d5b2e69bc12`, and a final fetch confirmed current main is its ancestor. |
+| 7 | Single feature theme | PASS | The commit changes three `cmd/gc` test files and their shared test helper for one purpose: make city selection explicit instead of relying on ambient upward discovery. |
+
+## Acceptance Checks
+
+- PASS: Twenty-six prime/session-hook test sites in `cmd/gc/main_test.go` pin
+  their temporary city explicitly.
+- PASS: `TestCmdSessionNudgeQueueResolvesSessionName` pins its temporary city
+  explicitly.
+- PASS: Three direct formula-cook sites pin their city explicitly.
+- PASS: Both formula-cook helper call sites preserve cwd-based rig selection
+  while passing the exact city root through `GC_CITY_PATH`.
+- PASS: `SetupHermeticCookEnv` has exactly two repo-wide callers, and both use
+  the new `chdirDir, cityRootDir` contract.
+- PASS: The change remains test-only: 48 insertions and 7 deletions across
+  three test files and `internal/formulatest/env.go`.
+- PASS: Parent bead `ga-klo4gz` remains sequenced after the full migration;
+  this batch does not clear the ambient-discovery guard to land.
+
+## Commands
+
+```text
+git range-diff 2c4c43b270d72365a0080530b0c3e3503f898e7d..48a40cd9ab4fa5d25b2eca14dd8826238faa4718 1bc642727251a84a33d0316a0d3d26e3e9c11ffe..eabb4f7c771b464f5b09864f71671d5b2e69bc12
+git diff --check origin/main..HEAD
+gofmt -l cmd/gc/main_test.go cmd/gc/cmd_nudge_test.go cmd/gc/cmd_formula_test.go internal/formulatest/env.go
+go build ./...
+go vet ./...
+go test -count=1 -run '^(TestCmdSessionNudgeQueueResolvesSessionName|TestDoPrimeBareName|TestDoPrimeCodexHookPersistsProviderSessionKeyFromHookStdin|TestDoPrimeFallsBackToGCAliasWhenGCAgentUnresolvable|TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork|TestDoPrimeGeminiHookPersistsProviderSessionKey|TestDoPrimeHookDoesNotCreateRuntimeSessionSidecar|TestDoPrimeHookFallsBackToGCTemplateForManualSessionAlias|TestDoPrimeHookFallsBackToSessionTemplateForManualSessionAlias|TestDoPrimeHookIgnoresProviderSessionKeyFromHookStdinForNonCodex|TestDoPrimeHookPersistsGenericProviderSessionKey|TestDoPrimeHookWarnsWhenRequiredProviderSessionKeyMissing|TestDoPrimeNoArgs|TestDoPrimePoolAgentFallback|TestDoPrimeStrictAbsoluteTemplatePath|TestDoPrimeStrictAgentWithEmptyPromptTemplate|TestDoPrimeStrictHookModeDoesNotCreateRuntimeSidecarOnSuccess|TestDoPrimeStrictHookModeMissingTemplateDoesNotUpdateProviderMetadataOnFailure|TestDoPrimeStrictHookModeOnSuspendedAgentDoesNotCreateRuntimeSidecar|TestDoPrimeStrictHookModeUnknownAgentDoesNotCreateRuntimeSidecar|TestDoPrimeStrictKnownAgent|TestDoPrimeStrictMissingTemplateFile|TestDoPrimeStrictNoAgentName|TestDoPrimeStrictNoCity|TestDoPrimeStrictTemplateRendersLegitimatelyEmpty|TestDoPrimeStrictUnknownAgent|TestDoPrimeStrictUnreadableTemplateFile|TestDoPrimeUsesGCAgentEnv|TestDoPrimeWithDiscoveredCityAgent|TestDoPrimeWithKnownAgent|TestDoPrimeWithUnknownAgent|TestFormulaCookAttachGraphV2AllowsDifferentLiveBareBeadRoots|TestFormulaCookAttachGraphV2CreatesFreshRootForBareBeadTarget|TestFormulaCookAttachGraphV2RejectsLiveLegacySourceWorkflow|TestFormulaCookStandaloneGraphV2StampsRunRootStoreScope|TestFormulaCookStandaloneGraphV2StampsRunRootStoreScopeForRig)$' -v ./cmd/gc
+make test-fast-parallel
+```


### PR DESCRIPTION
## What this changes

Makes the `gc prime` session-hook tests, session-nudge tests, and formula-cook tests select their temporary city explicitly through `GC_CITY_PATH` instead of relying on an upward search from the process working directory. This keeps the tests hermetic and prevents an unrelated ambient city from changing their behavior.

The shared formula test helper now accepts the working directory and exact city root separately. That preserves cwd-based rig selection while still making city resolution explicit.

## Review notes

- This is test-only; no production command behavior changes.
- `internal/formulatest.SetupHermeticCookEnv` changes from one path argument to separate `chdirDir` and `cityRootDir` arguments; its only two callers are updated here.
- This intentionally does not add the test-binary ambient-discovery guard. Remaining migration batches must land before that guard is enabled.

## Test plan

- [x] Run all 36 directly affected, indirectly affected, and guard-blind control tests in `./cmd/gc`.
- [x] Run `make test-fast-parallel`; all nine jobs pass.
- [x] Run `go build ./...` and `go vet ./...`.
- [x] Release gate: [`release-gates/ga-ql2s5k-ambient-city-discovery-batch-3-gate.md`](release-gates/ga-ql2s5k-ambient-city-discovery-batch-3-gate.md)