### PR TITLE
fix: forward push-gate controls from make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ LOCAL_TEST_JOBS ?= $(shell ./scripts/test-local-job-count)
 
 ## test-fast-parallel: run the default fast suite with cmd/gc sharded locally
 test-fast-parallel:
-	$(TEST_ENV) LOCAL_TEST_JOBS=$(LOCAL_TEST_JOBS) CMD_GC_PROCESS_TOTAL=$(CMD_GC_PROCESS_TOTAL) ./scripts/test-local-parallel fast
+	$(TEST_ENV) GC_PUSH_GATE_NO_CAP="$${GC_PUSH_GATE_NO_CAP-}" PUSH_GATE_MAX_CONCURRENT="$${PUSH_GATE_MAX_CONCURRENT-}" PUSH_GATE_MAX_WAIT_SECONDS="$${PUSH_GATE_MAX_WAIT_SECONDS-}" PUSH_GATE_POLL_SECONDS="$${PUSH_GATE_POLL_SECONDS-}" LOCAL_TEST_JOBS=$(LOCAL_TEST_JOBS) CMD_GC_PROCESS_TOTAL=$(CMD_GC_PROCESS_TOTAL) ./scripts/test-local-parallel fast
 
 ## test-fsys-darwin-compile: cross-compile internal/fsys for macOS so
 ## unix.Stat_t field-type regressions fail in the default fast test path.

--- a/scripts/precommit_contract_test.go
+++ b/scripts/precommit_contract_test.go
@@ -65,7 +65,12 @@ func TestTestFastParallelUsesSanitizedEnvironmentAndMachineAwareConcurrency(t *t
 			strings.HasPrefix(entry, "GC_TEST_LOCAL_MEMORY_KIB=") ||
 			strings.HasPrefix(entry, "GC_TEST_LOCAL_MEMINFO=") ||
 			strings.HasPrefix(entry, "GC_TEST_LOCAL_PROC_CGROUP=") ||
-			strings.HasPrefix(entry, "GC_TEST_LOCAL_CGROUP_ROOT=") {
+			strings.HasPrefix(entry, "GC_TEST_LOCAL_CGROUP_ROOT=") ||
+			strings.HasPrefix(entry, "GC_PUSH_GATE_NO_CAP=") ||
+			strings.HasPrefix(entry, "PUSH_GATE_MAX_CONCURRENT=") ||
+			strings.HasPrefix(entry, "PUSH_GATE_MAX_WAIT_SECONDS=") ||
+			strings.HasPrefix(entry, "PUSH_GATE_POLL_SECONDS=") ||
+			strings.HasPrefix(entry, "PUSH_GATE_UNRELATED_SENTINEL=") {
 			continue
 		}
 		baseEnv = append(baseEnv, entry)
@@ -98,7 +103,14 @@ func TestTestFastParallelUsesSanitizedEnvironmentAndMachineAwareConcurrency(t *t
 			args = append(args, "test-fast-parallel")
 			cmd := exec.Command("make", args...)
 			cmd.Dir = repoRoot
-			cmd.Env = append(append([]string(nil), baseEnv...), "GC_TEST_LOCAL_CPUS="+tt.cpus)
+			cmd.Env = append(append([]string(nil), baseEnv...),
+				"GC_TEST_LOCAL_CPUS="+tt.cpus,
+				"GC_PUSH_GATE_NO_CAP=1",
+				"PUSH_GATE_MAX_CONCURRENT=7",
+				"PUSH_GATE_MAX_WAIT_SECONDS=13",
+				"PUSH_GATE_POLL_SECONDS=2",
+				"PUSH_GATE_UNRELATED_SENTINEL=must-not-leak",
+			)
 			if tt.memoryKiB != "" {
 				cmd.Env = append(cmd.Env, "GC_TEST_LOCAL_MEMORY_KIB="+tt.memoryKiB)
 			}
@@ -119,6 +131,20 @@ func TestTestFastParallelUsesSanitizedEnvironmentAndMachineAwareConcurrency(t *t
 			wantJobAssignment := " LOCAL_TEST_JOBS=" + tt.wantJobs + " CMD_GC_PROCESS_TOTAL="
 			if !strings.Contains(command, wantJobAssignment) {
 				t.Fatalf("test-fast-parallel job count should be %s:\n%s", tt.wantJobs, command)
+			}
+			for _, key := range []string{
+				"GC_PUSH_GATE_NO_CAP",
+				"PUSH_GATE_MAX_CONCURRENT",
+				"PUSH_GATE_MAX_WAIT_SECONDS",
+				"PUSH_GATE_POLL_SECONDS",
+			} {
+				wantForwarding := key + `="${` + key + `-}"`
+				if !strings.Contains(command, wantForwarding) {
+					t.Fatalf("test-fast-parallel should forward %s through TEST_ENV:\n%s", key, command)
+				}
+			}
+			if strings.Contains(command, "PUSH_GATE_UNRELATED_SENTINEL") {
+				t.Fatalf("test-fast-parallel must keep unrelated ambient variables out of TEST_ENV:\n%s", command)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Forward the documented push-gate bypass and tuning variables from `make test-fast-parallel` across its scrubbed `env -i` boundary.
- Keep the environment scrub intact; an unrelated ambient sentinel remains excluded.
- Extend the existing Make contract without adding another subprocess-census entry.

Tracks bead ga-4bbeq.

## Testing

- [ ] `make check` (not run; the relevant sharded inventory and vet were run directly)
- [ ] `make check-docs` (not applicable; no docs changed)
- [ ] `make test-integration` (not applicable; no runtime, controller, or workflow behavior changed)
- [x] RED proof: focused contract failed on missing `GC_PUSH_GATE_NO_CAP` forwarding before the Makefile change
- [x] `go test ./scripts -run TestTestFastParallelUsesSanitizedEnvironmentAndMachineAwareConcurrency -count=1`
- [x] `go test ./scripts -count=1`
- [x] Live linked-worktree proof: `GC_PUSH_GATE_NO_CAP=1 make test-fast-parallel` launched all nine shards instead of failing at `.git/gate-slots`
- [x] Full non-cmd/gc core inventory with a pinned CGO-capable `bd`
- [x] All six fast `cmd/gc` shards, push-gate self-test, and Darwin compile
- [x] `go vet ./...`

Host note: the wrapper run itself had one unrelated failure because another process replaced the global `bd` with a CGO-disabled build during the run. The exact failing doctor test and the complete core inventory passed with a pinned CGO-capable `bd`.

## Checklist

- [x] Linked bead ga-4bbeq
- [x] Added a regression for all four controls plus unrelated-variable exclusion
- [x] No user-facing documentation change required
- [x] No breaking change or migration required