### PR TITLE
feat(gc): surface pack publisher trust in registry commands

### DIFF
--- a/cmd/gc/cmd_pack_registry.go
+++ b/cmd/gc/cmd_pack_registry.go
@@ -228,6 +228,8 @@ type packRegistryShowJSONResult struct {
 	SchemaVersion string                    `json:"schema_version"`
 	Registry      string                    `json:"registry"`
 	Name          string                    `json:"name"`
+	Tier          string                    `json:"tier"`
+	Publisher     string                    `json:"publisher"`
 	Description   string                    `json:"description"`
 	Source        string                    `json:"source"`
 	SourceKind    string                    `json:"source_kind"`
@@ -238,6 +240,8 @@ type packRegistryShowJSONResult struct {
 type packRegistryPackJSON struct {
 	Registry    string `json:"registry"`
 	Name        string `json:"name"`
+	Tier        string `json:"tier"`
+	Publisher   string `json:"publisher"`
 	Description string `json:"description"`
 	Source      string `json:"source"`
 	SourceKind  string `json:"source_kind"`
@@ -519,6 +523,8 @@ func doPackRegistrySearch(query, registry string, refresh bool, limit int, all b
 			jsonResults = append(jsonResults, packRegistryPackJSON{
 				Registry:    result.registry,
 				Name:        result.pack.Name,
+				Tier:        result.pack.Tier,
+				Publisher:   result.pack.Publisher,
 				Description: result.pack.Description,
 				Source:      result.pack.Source,
 				SourceKind:  result.pack.SourceKind,
@@ -548,9 +554,9 @@ func doPackRegistrySearch(query, registry string, refresh bool, limit int, all b
 		fmt.Fprintln(stdout, "No registry packs found.") //nolint:errcheck
 		return 0
 	}
-	fmt.Fprintln(stdout, "Registry  Name                  Latest        Description") //nolint:errcheck
+	fmt.Fprintln(stdout, "Registry  Name                  Latest        Tier       Publisher             Description") //nolint:errcheck
 	for _, result := range results {
-		fmt.Fprintf(stdout, "%-9s %-21s %-13s %s\n", result.registry, result.pack.Name, latestVersion(result.pack), result.pack.Description) //nolint:errcheck
+		fmt.Fprintf(stdout, "%-9s %-21s %-13s %-10s %-21s %s\n", result.registry, result.pack.Name, latestVersion(result.pack), result.pack.Tier, result.pack.Publisher, result.pack.Description) //nolint:errcheck
 	}
 	if truncated {
 		fmt.Fprintf(stderr, "warning: results truncated to %d; use --all to show all\n", limit) //nolint:errcheck
@@ -628,6 +634,8 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 			SchemaVersion: "1",
 			Registry:      match.registry,
 			Name:          match.pack.Name,
+			Tier:          match.pack.Tier,
+			Publisher:     match.pack.Publisher,
 			Description:   match.pack.Description,
 			Source:        match.pack.Source,
 			SourceKind:    match.pack.SourceKind,
@@ -640,6 +648,8 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		return 0
 	}
 	fmt.Fprintf(stdout, "Pack:        %s:%s\n", match.registry, match.pack.Name) //nolint:errcheck
+	fmt.Fprintf(stdout, "Tier:        %s\n", match.pack.Tier)                    //nolint:errcheck
+	fmt.Fprintf(stdout, "Publisher:   %s\n", match.pack.Publisher)               //nolint:errcheck
 	fmt.Fprintf(stdout, "Description: %s\n", match.pack.Description)             //nolint:errcheck
 	fmt.Fprintf(stdout, "Source:      %s\n", match.pack.Source)                  //nolint:errcheck
 	fmt.Fprintf(stdout, "Source kind: %s\n", match.pack.SourceKind)              //nolint:errcheck

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,25 @@ source_kind = "git"
   commit = "89abcdef0123456789abcdef0123456789abcdef"
   hash = "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
   description = "Other release."
+`
+
+const packRegistryAttributionCatalog = `schema = 1
+
+[[pack]]
+name = "maintained"
+tier = "maintained"
+publisher = "Gas City"
+description = "Maintained pack."
+source = "https://packages.example/maintained.git"
+source_kind = "git"
+
+[[pack]]
+name = "malformed"
+tier = "maintained"
+publisher = 42
+description = "Malformed attribution."
+source = "https://packages.example/malformed.git"
+source_kind = "git"
 `
 
 const packRegistryUnsortedCatalog = `schema = 1
@@ -137,6 +157,128 @@ func TestPackRegistryAddListSearchShowRemove(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(home, "registry-cache", "local")); !os.IsNotExist(err) {
 		t.Fatalf("registry cache not pruned by refresh, stat err=%v", err)
+	}
+}
+
+func TestPackRegistrySearchAndShowExposeAttribution(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
+	catalogDir := writeRegistryCatalog(t, packRegistryAttributionCatalog)
+
+	var stdout, stderr bytes.Buffer
+	if code := doPackRegistryAdd("local", catalogDir, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := doPackRegistrySearch("", "", false, 50, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("search code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"Tier",
+		"Publisher",
+		"maintained",
+		"Gas City",
+		"community",
+		packregistry.UnknownPublisher,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("search output missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	for _, tc := range []struct {
+		name      string
+		tier      string
+		publisher string
+	}{
+		{name: "maintained", tier: packregistry.CatalogTierMaintained, publisher: "Gas City"},
+		{name: "malformed", tier: packregistry.CatalogTierCommunity, publisher: packregistry.UnknownPublisher},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout.Reset()
+			stderr.Reset()
+			if code := doPackRegistryShow(tc.name, false, false, &stdout, &stderr); code != 0 {
+				t.Fatalf("show code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Tier:        "+tc.tier) {
+				t.Errorf("show output missing tier %q:\n%s", tc.tier, stdout.String())
+			}
+			if !strings.Contains(stdout.String(), "Publisher:   "+tc.publisher) {
+				t.Errorf("show output missing publisher %q:\n%s", tc.publisher, stdout.String())
+			}
+		})
+	}
+}
+
+func TestPackRegistrySearchAndShowJSONExposeAttribution(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
+	catalogDir := writeRegistryCatalog(t, packRegistryAttributionCatalog)
+
+	var stdout, stderr bytes.Buffer
+	if code := doPackRegistryAdd("local", catalogDir, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := doPackRegistrySearch("", "", false, 50, false, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("search code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	var searchResult packRegistrySearchJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &searchResult); err != nil {
+		t.Fatalf("decode search JSON: %v\n%s", err, stdout.String())
+	}
+	if searchResult.SchemaVersion != "1" {
+		t.Errorf("search schema_version = %q, want 1", searchResult.SchemaVersion)
+	}
+	got := make(map[string][2]string, len(searchResult.Results))
+	for _, pack := range searchResult.Results {
+		got[pack.Name] = [2]string{pack.Tier, pack.Publisher}
+	}
+	want := map[string][2]string{
+		"maintained": {packregistry.CatalogTierMaintained, "Gas City"},
+		"malformed":  {packregistry.CatalogTierCommunity, packregistry.UnknownPublisher},
+	}
+	for name, wantAttribution := range want {
+		if gotAttribution := got[name]; gotAttribution != wantAttribution {
+			t.Errorf("%s search attribution = %q/%q, want %q/%q",
+				name,
+				gotAttribution[0],
+				gotAttribution[1],
+				wantAttribution[0],
+				wantAttribution[1],
+			)
+		}
+	}
+
+	for name, wantAttribution := range want {
+		t.Run(name, func(t *testing.T) {
+			stdout.Reset()
+			stderr.Reset()
+			if code := doPackRegistryShow(name, false, true, &stdout, &stderr); code != 0 {
+				t.Fatalf("show code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			var showResult packRegistryShowJSONResult
+			if err := json.Unmarshal(stdout.Bytes(), &showResult); err != nil {
+				t.Fatalf("decode show JSON: %v\n%s", err, stdout.String())
+			}
+			if showResult.SchemaVersion != "1" {
+				t.Errorf("show schema_version = %q, want 1", showResult.SchemaVersion)
+			}
+			if gotAttribution := [2]string{showResult.Tier, showResult.Publisher}; gotAttribution != wantAttribution {
+				t.Errorf("show attribution = %q/%q, want %q/%q",
+					gotAttribution[0],
+					gotAttribution[1],
+					wantAttribution[0],
+					wantAttribution[1],
+				)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/cmd_pack_release.go
+++ b/cmd/gc/cmd_pack_release.go
@@ -449,6 +449,8 @@ func stampPackRelease(registryPath, packName string, opts packReleaseStampOption
 		}
 		catalog.Packs = append(catalog.Packs, packregistry.CatalogPack{
 			Name:        packName,
+			Tier:        packregistry.CatalogTierCommunity,
+			Publisher:   packregistry.UnknownPublisher,
 			Description: opts.PackDescription,
 			Source:      opts.Source,
 			SourceKind:  "git",

--- a/cmd/gc/cmd_pack_release_test.go
+++ b/cmd/gc/cmd_pack_release_test.go
@@ -72,6 +72,18 @@ func TestPackReleaseStampCreatesAndValidatesRegistryRelease(t *testing.T) {
 	if !strings.Contains(stdout.String(), "stamped demo 0.1.0") {
 		t.Fatalf("stamp stdout = %q", stdout.String())
 	}
+	emitted, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("ReadFile(registry): %v", err)
+	}
+	for _, want := range []string{
+		`tier = "community"`,
+		`publisher = "Unknown publisher"`,
+	} {
+		if !strings.Contains(string(emitted), want) {
+			t.Errorf("stamped registry missing safe attribution %q:\n%s", want, emitted)
+		}
+	}
 
 	stdout.Reset()
 	stderr.Reset()

--- a/cmd/gc/testdata/pack-registry-attribution.txtar
+++ b/cmd/gc/testdata/pack-registry-attribution.txtar
@@ -1,0 +1,56 @@
+# Pack registry attribution is visible through the real CLI entrypoint.
+#
+# Tests:
+# - search text shows effective tier and publisher
+# - show text labels effective tier and publisher
+# - search and show JSON expose the same normalized fields
+# - malformed attribution downgrades one pack without rejecting the catalog
+
+exec gc pack registry add local $WORK/catalog
+stdout 'Added pack registry "local".'
+
+exec gc pack registry search --registry local --all
+stdout 'Tier +Publisher'
+stdout 'maintained.*maintained.*Gas City'
+stdout 'malformed.*community.*Unknown publisher'
+
+exec gc pack registry show local:maintained
+stdout '^Tier:        maintained$'
+stdout '^Publisher:   Gas City$'
+
+exec gc pack registry show local:malformed
+stdout '^Tier:        community$'
+stdout '^Publisher:   Unknown publisher$'
+
+exec gc pack registry search --registry local --all --json
+stdout '"name":"maintained","tier":"maintained","publisher":"Gas City"'
+stdout '"name":"malformed","tier":"community","publisher":"Unknown publisher"'
+
+exec gc pack registry show local:maintained --json
+stdout '"name":"maintained"'
+stdout '"tier":"maintained"'
+stdout '"publisher":"Gas City"'
+
+exec gc pack registry show local:malformed --json
+stdout '"name":"malformed"'
+stdout '"tier":"community"'
+stdout '"publisher":"Unknown publisher"'
+
+-- catalog/registry.toml --
+schema = 1
+
+[[pack]]
+name = "maintained"
+tier = "maintained"
+publisher = "Gas City"
+description = "Maintained pack."
+source = "https://packages.example/maintained.git"
+source_kind = "git"
+
+[[pack]]
+name = "malformed"
+tier = "maintained"
+publisher = 42
+description = "Malformed attribution."
+source = "https://packages.example/malformed.git"
+source_kind = "git"

--- a/internal/packregistry/catalog.go
+++ b/internal/packregistry/catalog.go
@@ -25,6 +25,12 @@ import (
 const (
 	// CatalogSchema is the supported registry catalog schema version.
 	CatalogSchema = 1
+	// CatalogTierMaintained identifies a pack maintained by a known publisher.
+	CatalogTierMaintained = "maintained"
+	// CatalogTierCommunity identifies a community-maintained or unattributed pack.
+	CatalogTierCommunity = "community"
+	// UnknownPublisher is the safe publisher fallback for missing or malformed attribution.
+	UnknownPublisher = "Unknown publisher"
 	// DefaultMaxBytes is the default maximum registry catalog size.
 	DefaultMaxBytes = 16 << 20
 	// DefaultFetchTimeout is the default timeout for remote registry fetches.
@@ -49,6 +55,23 @@ type Catalog struct {
 // CatalogPack describes one pack entry in a registry catalog.
 type CatalogPack struct {
 	Name        string           `toml:"name"`
+	Tier        string           `toml:"tier"`
+	Publisher   string           `toml:"publisher"`
+	Description string           `toml:"description"`
+	Source      string           `toml:"source"`
+	SourceKind  string           `toml:"source_kind"`
+	Releases    []CatalogRelease `toml:"release,omitempty"`
+}
+
+type rawCatalog struct {
+	Schema int              `toml:"schema"`
+	Packs  []rawCatalogPack `toml:"pack,omitempty"`
+}
+
+type rawCatalogPack struct {
+	Name        string           `toml:"name"`
+	Tier        any              `toml:"tier"`
+	Publisher   any              `toml:"publisher"`
 	Description string           `toml:"description"`
 	Source      string           `toml:"source"`
 	SourceKind  string           `toml:"source_kind"`
@@ -135,9 +158,25 @@ func FetchCatalog(ctx context.Context, source Source, opts FetchOptions) ([]byte
 
 // ParseCatalog decodes and version-checks registry catalog data.
 func ParseCatalog(data []byte) (Catalog, error) {
-	var catalog Catalog
-	if _, err := toml.Decode(string(data), &catalog); err != nil {
-		return catalog, fmt.Errorf("parsing registry catalog: %w", err)
+	var raw rawCatalog
+	if _, err := toml.Decode(string(data), &raw); err != nil {
+		return Catalog{}, fmt.Errorf("parsing registry catalog: %w", err)
+	}
+	catalog := Catalog{
+		Schema: raw.Schema,
+		Packs:  make([]CatalogPack, 0, len(raw.Packs)),
+	}
+	for _, rawPack := range raw.Packs {
+		tier, publisher := normalizeCatalogAttribution(rawPack.Tier, rawPack.Publisher)
+		catalog.Packs = append(catalog.Packs, CatalogPack{
+			Name:        rawPack.Name,
+			Tier:        tier,
+			Publisher:   publisher,
+			Description: rawPack.Description,
+			Source:      rawPack.Source,
+			SourceKind:  rawPack.SourceKind,
+			Releases:    rawPack.Releases,
+		})
 	}
 	if catalog.Schema == 0 {
 		catalog.Schema = CatalogSchema
@@ -146,6 +185,18 @@ func ParseCatalog(data []byte) (Catalog, error) {
 		return catalog, fmt.Errorf("unsupported registry catalog schema %d", catalog.Schema)
 	}
 	return catalog, nil
+}
+
+func normalizeCatalogAttribution(rawTier, rawPublisher any) (string, string) {
+	publisher, ok := rawPublisher.(string)
+	publisher = strings.TrimSpace(publisher)
+	if !ok || publisher == "" || publisher == UnknownPublisher {
+		publisher = UnknownPublisher
+	}
+	if tier, ok := rawTier.(string); ok && tier == CatalogTierMaintained && publisher != UnknownPublisher {
+		return CatalogTierMaintained, publisher
+	}
+	return CatalogTierCommunity, publisher
 }
 
 // ValidateCatalog validates registry catalog structure and source policy.

--- a/internal/packregistry/catalog_test.go
+++ b/internal/packregistry/catalog_test.go
@@ -29,6 +29,92 @@ source_kind = "git"
   description = "Stable release."
 `
 
+func TestParseCatalogNormalizesAttributionPermissively(t *testing.T) {
+	const catalogText = `schema = 1
+
+[[pack]]
+name = "maintained"
+tier = "maintained"
+publisher = "  Gas City  "
+description = "Maintained pack."
+source = "https://packages.example/maintained.git"
+source_kind = "git"
+
+[[pack]]
+name = "community"
+tier = "community"
+publisher = "wespd"
+description = "Community pack."
+source = "https://packages.example/community.git"
+source_kind = "git"
+
+[[pack]]
+name = "missing"
+description = "Legacy pack."
+source = "https://packages.example/missing.git"
+source_kind = "git"
+
+[[pack]]
+name = "invalid-tier"
+tier = "official"
+publisher = "Impostor"
+description = "Invalid tier."
+source = "https://packages.example/invalid-tier.git"
+source_kind = "git"
+
+[[pack]]
+name = "unattributed-maintained"
+tier = "maintained"
+publisher = " "
+description = "Maintained without a publisher."
+source = "https://packages.example/unattributed-maintained.git"
+source_kind = "git"
+
+[[pack]]
+name = "malformed"
+tier = true
+publisher = 42
+description = "Malformed attribution types."
+source = "https://packages.example/malformed.git"
+source_kind = "git"
+`
+
+	catalog, err := ParseCatalog([]byte(catalogText))
+	if err != nil {
+		t.Fatalf("ParseCatalog: %v", err)
+	}
+	if err := ValidateCatalog(catalog, true); err != nil {
+		t.Fatalf("ValidateCatalog: %v", err)
+	}
+
+	got := make(map[string][2]string, len(catalog.Packs))
+	for _, pack := range catalog.Packs {
+		got[pack.Name] = [2]string{pack.Tier, pack.Publisher}
+	}
+	want := map[string][2]string{
+		"maintained":              {CatalogTierMaintained, "Gas City"},
+		"community":               {CatalogTierCommunity, "wespd"},
+		"missing":                 {CatalogTierCommunity, UnknownPublisher},
+		"invalid-tier":            {CatalogTierCommunity, "Impostor"},
+		"unattributed-maintained": {CatalogTierCommunity, UnknownPublisher},
+		"malformed":               {CatalogTierCommunity, UnknownPublisher},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("attribution rows = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for name, wantAttribution := range want {
+		if gotAttribution := got[name]; gotAttribution != wantAttribution {
+			t.Errorf("%s attribution = %q/%q, want %q/%q",
+				name,
+				gotAttribution[0],
+				gotAttribution[1],
+				wantAttribution[0],
+				wantAttribution[1],
+			)
+		}
+	}
+}
+
 func TestValidateCatalogNamesReleasesAndHashes(t *testing.T) {
 	catalog, err := ParseCatalog([]byte(validCatalog))
 	if err != nil {

--- a/schemas/pack/registry/search/result.schema.json
+++ b/schemas/pack/registry/search/result.schema.json
@@ -50,7 +50,7 @@
       "items": {
         "type": "object",
         "description": "One matching pack entry from a registry catalog.",
-        "required": ["registry", "name", "description", "source", "source_kind", "latest"],
+        "required": ["registry", "name", "tier", "publisher", "description", "source", "source_kind", "latest"],
         "properties": {
           "registry": {
             "type": "string",
@@ -62,6 +62,15 @@
             "type": "string",
             "pattern": "^[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?$",
             "description": "Pack name as published in the registry catalog."
+          },
+          "tier": {
+            "enum": ["maintained", "community"],
+            "description": "Effective pack trust tier after safe attribution normalization."
+          },
+          "publisher": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Effective publisher name, or Unknown publisher when attribution is unavailable."
           },
           "description": {
             "type": "string",

--- a/schemas/pack/registry/show/result.schema.json
+++ b/schemas/pack/registry/show/result.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "description": "Result payload for gc pack registry show.",
-  "required": ["schema_version", "ok", "registry", "name", "description", "source", "source_kind", "latest", "releases"],
+  "required": ["schema_version", "ok", "registry", "name", "tier", "publisher", "description", "source", "source_kind", "latest", "releases"],
   "properties": {
     "schema_version": {
       "const": "1",
@@ -22,6 +22,15 @@
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?$",
       "description": "Pack name as published in the registry catalog."
+    },
+    "tier": {
+      "enum": ["maintained", "community"],
+      "description": "Effective pack trust tier after safe attribution normalization."
+    },
+    "publisher": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Effective publisher name, or Unknown publisher when attribution is unavailable."
     },
     "description": {
       "type": "string",


### PR DESCRIPTION
## Summary

- Normalize registry attribution into safe effective `tier` and `publisher` values; malformed or missing claims downgrade without rejecting the catalog.
- Expose attribution consistently in `gc pack registry search` and `show`, in text output and schema-v1 JSON.
- Stamp new pack releases with safe `community / Unknown publisher` attribution so generated catalogs are valid by construction.
- Keep attribution presentation-only: it does not authorize installs or alter pack selection.

## Testing

- [x] `make test-fast-parallel` on rebased HEAD via the normal pre-push hook (all 9 jobs passed)
- [x] `go vet ./...`
- [x] formatting and `git diff --check`
- [x] focused release-stamp, catalog normalization, CLI entrypoint, text, JSON, and schema tests
- [x] full local parallel lane: all feature-relevant unit and integration groups passed; REST shards 7 and 8 passed on isolated rerun after repairing a transient shared `bd` install race
- [x] delegated five-axis pre-commit review: APPROVE, no required findings

The full lane also reproduced pre-existing `TestSweep_ReapsRealDoltDataDirAfterSIGKILL` twice. It is unrelated to this diff and is tracked in `ga-em9pd`; the cause is context-canceled `lsof` output being treated as a completed nonzero result.

## Checklist

- [x] No standalone issue is needed; this is the Gas City half of the coordinated Registry publisher-trust feature.
- [x] Added or updated tests for behavior changes.
- [x] Documentation impact reviewed; no existing command-output field reference requires an update.
- [x] No breaking changes or migration steps. Registry schema remains version 1.