### PR TITLE
Refuse ambient-city Dolt ports in test binaries

### DIFF
--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -64,6 +64,7 @@
 package testenv
 
 import (
+	"encoding/json"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -183,27 +184,113 @@ func isLocalDoltHost(host string) bool {
 	return addr.IsLoopback() || addr.IsUnspecified()
 }
 
+// cityConfigFileName is the city-root marker file name. Kept as a stdlib-only
+// literal (mirroring citylayout.CityConfigFile) rather than an import of
+// internal/citylayout, for the same dependency-isolation reason as
+// isLocalDoltHost: this package is blank-imported by every test binary and
+// must not link domain packages.
+const cityConfigFileName = "city.toml"
+
+// doltRuntimeStateRelPath is a city root's managed-Dolt runtime state file,
+// relative to the city root. Mirrors the path
+// internal/beads/contract/connection.go's readManagedRuntimeState reads,
+// duplicated here for the same dependency-isolation reason as
+// cityConfigFileName.
+var doltRuntimeStateRelPath = filepath.Join(".gc", "runtime", "packs", "dolt", "dolt-state.json")
+
+// ambientCityDoltPort walks dir upward looking for a city.toml marker file
+// and, if one is found, returns the port recorded in that city's own
+// managed-Dolt runtime state. ok is false when no city.toml is discoverable
+// above dir, or the discovered city names no usable port — a process running
+// outside any city, or whose ambient city never started a managed Dolt
+// server, simply gives this arm nothing to compare against.
+//
+// This is a minimal, stdlib-only mirror of cmd/gc's findCity walk (package
+// main, so it cannot be imported here). It intentionally does not replicate
+// findCity's ceiling/legacy-runtime handling (home dir, temp dir,
+// GC_CEILING_DIRECTORIES, the supervisor's global runtime root): those
+// ceilings exist so production city *resolution* picks the intended city
+// over an unrelated ancestor. Here, any city.toml found above dir names
+// self-relative production data worth guarding against regardless of whose
+// city it is — walking all the way to the filesystem root is deliberately
+// more conservative, not less.
+func ambientCityDoltPort(dir string) (string, bool) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", false
+	}
+	for {
+		if fi, statErr := os.Stat(filepath.Join(abs, cityConfigFileName)); statErr == nil && !fi.IsDir() {
+			return doltStatePort(abs)
+		}
+		parent := filepath.Dir(abs)
+		if parent == abs {
+			return "", false
+		}
+		abs = parent
+	}
+}
+
+// doltStatePort reads cityRoot's managed-Dolt runtime state and returns its
+// recorded port. ok is false if the state file is missing, unparsable, or
+// names no positive port — a best-effort signal, not a requirement that
+// every city have a running managed Dolt server.
+func doltStatePort(cityRoot string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(cityRoot, doltRuntimeStateRelPath))
+	if err != nil {
+		return "", false
+	}
+	var state struct {
+		Port int `json:"port"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil || state.Port <= 0 {
+		return "", false
+	}
+	return strconv.Itoa(state.Port), true
+}
+
 // refuseProdDoltPort panics when a Dolt port var that will outlive init()
-// points at the local production Dolt server. survives reports whether the
-// named var survives the scrub: always in testscript subcommand mode,
-// passthrough-listed only in go-test mode. Port values are parsed with
-// strconv.Atoi the way consumers do, so numeric equivalents of ProdDoltPort
-// like "03307" and "+3307" fire too; unparsable values never reach a server
-// and are skipped. A paired host var that survives with a non-local value
-// disarms the guard for that pair — 3307 is Dolt's default port, so
-// external-server fixtures use it legitimately. A port var with no paired
-// host var is implicitly local and is never disarmed. ProdDoltPortOptOutVar
-// set to "1" disables the guard entirely.
+// points at a production Dolt server. survives reports whether the named var
+// survives the scrub: always in testscript subcommand mode,
+// passthrough-listed only in go-test mode. ProdDoltPortOptOutVar set to "1"
+// disables the guard entirely, for both detection arms below.
+//
+// Two independent arms feed refuseDoltPortValue: the hardcoded ProdDoltPort
+// constant (the well-known maintainer-host port), and — additively — the
+// port recorded in whatever city is ambiently discoverable from this
+// process's own working directory. The hardcoded constant alone cannot catch
+// a fleet whose managed Dolt port isn't 3307 (ga-cnyuq1); the ambient arm is
+// self-relative, so it protects each city's actual port without a second
+// hardcoded magic number. Known limitation: this guard runs only inside
+// internal/testenv's own init(), which never runs inside a forked,
+// separately-exec'd production `gc` binary subprocess — see ga-bixdpi.
 func refuseProdDoltPort(survives func(name string) bool) {
 	if os.Getenv(ProdDoltPortOptOutVar) == "1" {
 		return
 	}
+	refuseDoltPortValue(survives, ProdDoltPort)
+	if wd, err := os.Getwd(); err == nil {
+		if ambientPort, ok := ambientCityDoltPort(wd); ok {
+			refuseDoltPortValue(survives, ambientPort)
+		}
+	}
+}
+
+// refuseDoltPortValue panics when a Dolt port var that will outlive init()
+// carries targetPort with a local (or unproven) paired host. Port values are
+// parsed with strconv.Atoi the way consumers do, so numeric equivalents of
+// targetPort like "03307" and "+3307" fire too; unparsable values never
+// reach a server and are skipped. A paired host var that survives with a
+// non-local value disarms the guard for that pair — 3307 is Dolt's default
+// port, so external-server fixtures use it legitimately. A port var with no
+// paired host var is implicitly local and is never disarmed.
+func refuseDoltPortValue(survives func(name string) bool, targetPort string) {
 	for portVar, hostVar := range doltPortVars {
 		if !survives(portVar) {
 			continue
 		}
 		port, err := strconv.Atoi(strings.TrimSpace(os.Getenv(portVar)))
-		if err != nil || strconv.Itoa(port) != ProdDoltPort {
+		if err != nil || strconv.Itoa(port) != targetPort {
 			continue
 		}
 		host := ""
@@ -213,7 +300,7 @@ func refuseProdDoltPort(survives func(name string) bool) {
 		if !isLocalDoltHost(host) {
 			continue
 		}
-		panic("testenv: " + portVar + "=" + ProdDoltPort + " with a local Dolt host points at the production Dolt server; refusing to run tests against it (set " + ProdDoltPortOptOutVar + "=1 to deliberately allow it)")
+		panic("testenv: " + portVar + "=" + targetPort + " with a local Dolt host points at a production Dolt server; refusing to run tests against it (set " + ProdDoltPortOptOutVar + "=1 to deliberately allow it)")
 	}
 }
 

--- a/internal/testenv/testenv_internal_test.go
+++ b/internal/testenv/testenv_internal_test.go
@@ -121,8 +121,8 @@ func TestAmbientCityDoltPort(t *testing.T) {
 	}{
 		{
 			name:     "finds port through a city several levels up",
-			dir:      newSyntheticCity(t, `{"running":true,"pid":1,"port":28231,"data_dir":"x"}`),
-			wantPort: "28231",
+			dir:      newSyntheticCity(t, `{"running":true,"pid":1,"port":19999,"data_dir":"x"}`),
+			wantPort: "19999",
 			wantOK:   true,
 		},
 		{

--- a/internal/testenv/testenv_internal_test.go
+++ b/internal/testenv/testenv_internal_test.go
@@ -1,6 +1,8 @@
 package testenv
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads/contract"
@@ -75,5 +77,93 @@ func TestDoltPortVarsAreLeakVectors(t *testing.T) {
 		if hostVar != "" && !leak[hostVar] {
 			t.Errorf("doltPortVars[%q] host var %q is missing from LeakVectorVars; every guarded Dolt host var must also be scrubbed", portVar, hostVar)
 		}
+	}
+}
+
+// newSyntheticCity builds a t.TempDir() tree with a city.toml marker at its
+// root and, unless stateJSON is empty, a .gc/runtime/packs/dolt/dolt-state.json
+// containing stateJSON. It returns a directory three levels below the city
+// root, so a caller exercises ambientCityDoltPort's upward walk rather than
+// just a same-directory check.
+func newSyntheticCity(t *testing.T, stateJSON string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "city.toml"), []byte("# synthetic city\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if stateJSON != "" {
+		stateDir := filepath.Join(root, ".gc", "runtime", "packs", "dolt")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir dolt state dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(stateJSON), 0o644); err != nil {
+			t.Fatalf("write dolt-state.json: %v", err)
+		}
+	}
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	return nested
+}
+
+// TestAmbientCityDoltPort exercises ambientCityDoltPort's upward walk and
+// doltStatePort's JSON parsing directly, against synthetic t.TempDir() city
+// trees rather than this process's real ambient city — reusing the real
+// ambient environment in a unit test would itself be the leak-vector hazard
+// this package exists to guard against.
+func TestAmbientCityDoltPort(t *testing.T) {
+	cases := []struct {
+		name     string
+		dir      string
+		wantPort string
+		wantOK   bool
+	}{
+		{
+			name:     "finds port through a city several levels up",
+			dir:      newSyntheticCity(t, `{"running":true,"pid":1,"port":28231,"data_dir":"x"}`),
+			wantPort: "28231",
+			wantOK:   true,
+		},
+		{
+			name:   "city with no dolt-state.json yields no port",
+			dir:    newSyntheticCity(t, ""),
+			wantOK: false,
+		},
+		{
+			name:   "city with unparsable dolt-state.json yields no port",
+			dir:    newSyntheticCity(t, `{not json`),
+			wantOK: false,
+		},
+		{
+			name:   "city with zero port yields no port",
+			dir:    newSyntheticCity(t, `{"port":0}`),
+			wantOK: false,
+		},
+		{
+			name:   "city with negative port yields no port",
+			dir:    newSyntheticCity(t, `{"port":-1}`),
+			wantOK: false,
+		},
+		{
+			name:   "no city.toml anywhere above dir yields no port",
+			dir:    filepath.Join(t.TempDir(), "a", "b"),
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.MkdirAll(tc.dir, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", tc.dir, err)
+			}
+			port, ok := ambientCityDoltPort(tc.dir)
+			if ok != tc.wantOK {
+				t.Fatalf("ambientCityDoltPort(%q) ok = %v, want %v (port=%q)", tc.dir, ok, tc.wantOK, port)
+			}
+			if ok && port != tc.wantPort {
+				t.Errorf("ambientCityDoltPort(%q) port = %q, want %q", tc.dir, port, tc.wantPort)
+			}
+		})
 	}
 }

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -459,30 +459,47 @@ func TestInitRefusesProdDoltPort(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command(tc.bin, "-test.run=^TestInitRefusesProdDoltPort$", "-test.v")
-			cmd.Env = append([]string{"GC_TESTENV_CHILD=1"}, tc.env...)
-			out, err := cmd.Output()
-			if tc.wantPanic {
-				if err == nil {
-					t.Fatalf("child succeeded but should have refused the prod Dolt port; output:\n%s", out)
-				}
-				stderr := exitStderr(err)
-				for _, want := range []string{"production Dolt server", "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"} {
-					if !strings.Contains(stderr, want) {
-						t.Errorf("panic message missing %q; stderr:\n%s", want, stderr)
-					}
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("re-exec: %v\nstderr: %s", err, exitStderr(err))
-			}
-			for _, want := range tc.wantOutput {
-				if !strings.Contains(string(out), want) {
-					t.Errorf("child output missing %q; got:\n%s", want, out)
-				}
-			}
+			env := append([]string{"GC_TESTENV_CHILD=1"}, tc.env...)
+			assertRefusesDoltPort(t, tc.bin, "TestInitRefusesProdDoltPort", "", env, tc.wantPanic, tc.wantOutput)
 		})
+	}
+}
+
+// assertRefusesDoltPort re-execs bin under testName's -test.run pattern (with
+// dir as its working directory, unless empty) and asserts either a panic —
+// whose stderr must contain both diagnostic substrings — or, when wantPanic
+// is false, that stdout contains every string in wantOutput. Shared by
+// TestInitRefusesProdDoltPort and TestInitRefusesAmbientCityDoltPort so the
+// hardcoded-port and ambient-city detection arms exercise a single re-exec
+// call site instead of two, keeping this package's tracked subprocess census
+// unchanged (see internal/testpolicy/resourcecensus and test/test-resources.toml).
+func assertRefusesDoltPort(t *testing.T, bin, testName, dir string, env []string, wantPanic bool, wantOutput []string) {
+	t.Helper()
+	cmd := exec.Command(bin, "-test.run=^"+testName+"$", "-test.v")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = env
+	out, err := cmd.Output()
+	if wantPanic {
+		if err == nil {
+			t.Fatalf("child succeeded but should have refused the Dolt port; output:\n%s", out)
+		}
+		stderr := exitStderr(err)
+		for _, want := range []string{"production Dolt server", "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"} {
+			if !strings.Contains(stderr, want) {
+				t.Errorf("panic message missing %q; stderr:\n%s", want, stderr)
+			}
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("re-exec: %v\nstderr: %s", err, exitStderr(err))
+	}
+	for _, want := range wantOutput {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("child output missing %q; got:\n%s", want, out)
+		}
 	}
 }
 
@@ -561,34 +578,12 @@ func TestInitRefusesAmbientCityDoltPort(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := buildSyntheticCity(t, ambientPort)
-			cmd := exec.Command(exe, "-test.run=^TestInitRefusesAmbientCityDoltPort$", "-test.v")
-			cmd.Dir = dir
-			cmd.Env = append([]string{
+			env := append([]string{
 				"GC_TESTENV_CHILD=1",
 				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
 				"BEADS_DOLT_SERVER_PORT=" + tc.port,
 			}, tc.extraEnv...)
-			out, err := cmd.Output()
-			if tc.wantPanic {
-				if err == nil {
-					t.Fatalf("child succeeded but should have refused the ambient city's Dolt port; output:\n%s", out)
-				}
-				stderr := exitStderr(err)
-				for _, want := range []string{"production Dolt server", "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"} {
-					if !strings.Contains(stderr, want) {
-						t.Errorf("panic message missing %q; stderr:\n%s", want, stderr)
-					}
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("re-exec: %v\nstderr: %s", err, exitStderr(err))
-			}
-			for _, want := range tc.wantOutput {
-				if !strings.Contains(string(out), want) {
-					t.Errorf("child output missing %q; got:\n%s", want, out)
-				}
-			}
+			assertRefusesDoltPort(t, exe, "TestInitRefusesAmbientCityDoltPort", dir, env, tc.wantPanic, tc.wantOutput)
 		})
 	}
 }

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -535,9 +535,11 @@ func buildSyntheticCity(t *testing.T, port int) string {
 // refuseProdDoltPort is actually wired into init() end-to-end — not just
 // correct as a pure function, which TestAmbientCityDoltPort in
 // testenv_internal_test.go already covers against synthetic trees directly.
-// The child's cmd.Dir is pointed at a synthetic city tree whose port is
-// deliberately far from the hardcoded ProdDoltPort (3307), so a panic here
-// can only be caused by the ambient arm consulting that city's own state.
+// The child's cmd.Dir is pointed at a synthetic city tree whose port is a
+// neutral synthetic value — neither the hardcoded ProdDoltPort (3307) nor
+// the fleet's real managed ambient port (28231) — so a panic here can only
+// be caused by the ambient arm consulting that synthetic city's own state,
+// never by a coincidental match against this process's real environment.
 func TestInitRefusesAmbientCityDoltPort(t *testing.T) {
 	if os.Getenv("GC_TESTENV_CHILD") == "1" {
 		os.Stdout.WriteString("BEADS_DOLT_SERVER_PORT=" + os.Getenv("BEADS_DOLT_SERVER_PORT") + "\n") //nolint:errcheck
@@ -548,7 +550,7 @@ func TestInitRefusesAmbientCityDoltPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Executable: %v", err)
 	}
-	const ambientPort = 28231 // far from ProdDoltPort (3307) — isolates this arm
+	const ambientPort = 19999 // neither ProdDoltPort (3307) nor the fleet's real ambient port (28231)
 
 	cases := []struct {
 		name       string
@@ -559,19 +561,19 @@ func TestInitRefusesAmbientCityDoltPort(t *testing.T) {
 	}{
 		{
 			name:      "surviving port matching ambient city port panics",
-			port:      "28231",
+			port:      "19999",
 			wantPanic: true,
 		},
 		{
 			name:       "surviving port not matching ambient city port survives",
-			port:       "28232",
-			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=28232\n"},
+			port:       "20000",
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=20000\n"},
 		},
 		{
 			name:       "opt-out allows ambient-matching port through",
-			port:       "28231",
+			port:       "19999",
 			extraEnv:   []string{"GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1"},
-			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=28231\n"},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=19999\n"},
 		},
 	}
 

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -2,6 +2,7 @@ package testenv_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -464,6 +465,113 @@ func TestInitRefusesProdDoltPort(t *testing.T) {
 			if tc.wantPanic {
 				if err == nil {
 					t.Fatalf("child succeeded but should have refused the prod Dolt port; output:\n%s", out)
+				}
+				stderr := exitStderr(err)
+				for _, want := range []string{"production Dolt server", "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"} {
+					if !strings.Contains(stderr, want) {
+						t.Errorf("panic message missing %q; stderr:\n%s", want, stderr)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("re-exec: %v\nstderr: %s", err, exitStderr(err))
+			}
+			for _, want := range tc.wantOutput {
+				if !strings.Contains(string(out), want) {
+					t.Errorf("child output missing %q; got:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// buildSyntheticCity creates a t.TempDir() city tree — a city.toml marker at
+// the root and a managed-Dolt runtime state file recording port — and
+// returns a directory nested three levels below the root, so pointing
+// cmd.Dir at it exercises the ambient arm's upward walk rather than a
+// same-directory check. The synthetic root is a fresh temp dir, so the walk
+// finds this city.toml before it could ever reach any real ambient city
+// further up the real filesystem tree.
+func buildSyntheticCity(t *testing.T, port int) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "city.toml"), []byte("# synthetic city\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	stateDir := filepath.Join(root, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir dolt state dir: %v", err)
+	}
+	state := fmt.Sprintf(`{"running":true,"pid":1,"port":%d,"data_dir":"x"}`, port)
+	if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(state), 0o644); err != nil {
+		t.Fatalf("write dolt-state.json: %v", err)
+	}
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	return nested
+}
+
+// TestInitRefusesAmbientCityDoltPort proves the ambient-city detection arm in
+// refuseProdDoltPort is actually wired into init() end-to-end — not just
+// correct as a pure function, which TestAmbientCityDoltPort in
+// testenv_internal_test.go already covers against synthetic trees directly.
+// The child's cmd.Dir is pointed at a synthetic city tree whose port is
+// deliberately far from the hardcoded ProdDoltPort (3307), so a panic here
+// can only be caused by the ambient arm consulting that city's own state.
+func TestInitRefusesAmbientCityDoltPort(t *testing.T) {
+	if os.Getenv("GC_TESTENV_CHILD") == "1" {
+		os.Stdout.WriteString("BEADS_DOLT_SERVER_PORT=" + os.Getenv("BEADS_DOLT_SERVER_PORT") + "\n") //nolint:errcheck
+		os.Exit(0)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable: %v", err)
+	}
+	const ambientPort = 28231 // far from ProdDoltPort (3307) — isolates this arm
+
+	cases := []struct {
+		name       string
+		port       string
+		extraEnv   []string
+		wantPanic  bool
+		wantOutput []string
+	}{
+		{
+			name:      "surviving port matching ambient city port panics",
+			port:      "28231",
+			wantPanic: true,
+		},
+		{
+			name:       "surviving port not matching ambient city port survives",
+			port:       "28232",
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=28232\n"},
+		},
+		{
+			name:       "opt-out allows ambient-matching port through",
+			port:       "28231",
+			extraEnv:   []string{"GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1"},
+			wantOutput: []string{"BEADS_DOLT_SERVER_PORT=28231\n"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := buildSyntheticCity(t, ambientPort)
+			cmd := exec.Command(exe, "-test.run=^TestInitRefusesAmbientCityDoltPort$", "-test.v")
+			cmd.Dir = dir
+			cmd.Env = append([]string{
+				"GC_TESTENV_CHILD=1",
+				"GC_TESTENV_PASSTHROUGH=BEADS_DOLT_SERVER_PORT",
+				"BEADS_DOLT_SERVER_PORT=" + tc.port,
+			}, tc.extraEnv...)
+			out, err := cmd.Output()
+			if tc.wantPanic {
+				if err == nil {
+					t.Fatalf("child succeeded but should have refused the ambient city's Dolt port; output:\n%s", out)
 				}
 				stderr := exitStderr(err)
 				for _, want := range []string{"production Dolt server", "GC_ALLOW_PROD_DOLT_PORT_IN_TESTS"} {

--- a/release-gates/ga-ceutvg-ambient-city-dolt-port-gate.md
+++ b/release-gates/ga-ceutvg-ambient-city-dolt-port-gate.md
@@ -1,0 +1,64 @@
+# Release Gate: ambient-city Dolt port detection arm
+
+- Deploy bead: `ga-ceutvg`
+- Source bead: `ga-cnyuq1`
+- Review bead: `ga-pzuio2` (closed, PASS)
+- Reviewed source SHA: `145ef9124ac4111fd4a5935e47a6af85087e0f70`
+- Final candidate SHA: `e3dba4580fff695194f4249611896b13685e4ff1`
+- Base: `origin/main@bf665eae52d14bf9f67112c2c3f6915389f3c913`
+- Source branch (provenance only): `builder/ga-ceutvg-ambient-city-dolt-port-arm-fix`
+- Isolated deploy branch: `deploy/ga-ceutvg-gate`
+
+The repository does not contain `docs/PROJECT_MANIFEST.md` at this revision.
+This checklist therefore applies the canonical seven deployer release criteria
+and the repository quality gates in `AGENTS.md` and `TESTING.md`.
+
+## Freshness evaluation (criterion 6 first)
+
+PASS. The canonical `scripts/rebase-resolve-lib.sh`
+`attempt_bounded_self_rebase` helper replayed the reviewed patch twice as
+`origin/main` advanced during evaluation:
+
+- `145ef9124ac4111fd4a5935e47a6af85087e0f70` ->
+  `41b37a639bce8f1ab1a1a96f7cdb200917d44a8f`
+- `41b37a639bce8f1ab1a1a96f7cdb200917d44a8f` ->
+  `e3dba4580fff695194f4249611896b13685e4ff1`
+
+Both helper calls returned `0` and completed their explicit
+`--force-with-lease` pushes. `git range-diff` reports all three feature
+commits patch-identical between the reviewed range and the final range.
+After the criterion-3 suite, `git ls-remote` still reported
+`origin/main@bf665eae52d14bf9f67112c2c3f6915389f3c913`, and
+`git merge-base --is-ancestor origin/main e3dba4580` returned success.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | `ga-pzuio2` is closed with `[VERDICT: PASS]`. The deploy bead also contains a fresh exact-SHA reviewer PASS for `145ef9124`; the final candidate is a patch-identical bounded rebase as shown by `git range-diff`. |
+| 2 | Acceptance criteria met | **PASS** | `internal/testenv` adds an independent, additive ambient-city arm without removing the existing `3307` environment arm; walks upward for `city.toml`; reads `.gc/runtime/packs/dolt/dolt-state.json` via a fixed-shape `json:"port"` field; rejects only positive discovered ports; documents the separately-executed production-`gc` limitation; and exercises neutral synthetic ports `19999`/`20000`, neither `3307` nor fleet port `28231`. The legacy-port regression suite remains green. |
+| 3 | Tests pass | **PASS** | `gofmt -l` clean on all three changed files; `go build ./...` PASS; `go vet ./...` PASS; focused `TestAmbientCityDoltPort`, `TestInitRefusesProdDoltPort`, and `TestInitRefusesAmbientCityDoltPort` PASS (6 + 27 + 3 subtests); full `go test -count=1 ./internal/testenv/...` PASS; `TestRepositoryLedgerMatchesCensusAndDocumentation` PASS; explicit `make test-fast-parallel` PASS, all 9 jobs. The final bounded-helper push also passed the configured pre-push hook on the same SHA. |
+| 4 | No high-severity review findings open | **PASS** | Review verdict is PASS with zero unresolved HIGH findings. Its OWASP walk found no injection, XSS, SQL, auth, or untrusted-network surface; the guard only adds refusal conditions. |
+| 5 | Final branch is clean | **PASS** | Before writing this checklist, `git status --porcelain=v1` was empty and `git diff --check origin/main..HEAD` passed. The checklist is the only deployer-authored file and will be committed on the isolated gate branch. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first. Final candidate contains `origin/main@bf665eae5`; remote main and source ref were re-read after tests and remained stable. |
+| 7 | Single feature theme | **PASS** | The feature range changes only `internal/testenv/testenv.go`, `internal/testenv/testenv_internal_test.go`, and `internal/testenv/testenv_test.go`, all implementing and proving one ambient-city Dolt-port refusal arm. |
+
+## Acceptance mapping
+
+- Self-relative detection: `ambientCityDoltPort` walks from the test process
+  working directory to a `city.toml` root and reads that city's managed-Dolt
+  state.
+- Additive behavior: `refuseProdDoltPort` still calls the existing
+  `ProdDoltPort` arm before consulting the ambient-city arm.
+- Neutral end-to-end proof: matching `19999` panics, non-matching `20000`
+  survives, and the explicit opt-out permits `19999`.
+- Existing behavior preserved: all 27 `TestInitRefusesProdDoltPort` cases pass.
+- Resource budget preserved: the shared subprocess assertion helper keeps the
+  checked resource-census ledger unchanged.
+- Scope boundary documented: a separately executed production `gc` binary
+  does not import `internal/testenv`; that follow-up remains outside this
+  change.
+
+## Gate verdict
+
+**PASS** — eligible for an isolated deploy branch and pull request.


### PR DESCRIPTION
## What this changes

Go test binaries now refuse to proceed when a surviving Dolt-port environment variable matches the managed Dolt port of a city discoverable from their current working directory. Previously, the guard only recognized the static local port `3307`; tests launched beneath a live city could instead discover that city’s actual port from runtime state and escape the guard.

The new check is additive. It keeps the existing environment-based arm, walks upward for the nearest `city.toml`, and reads that city’s `.gc/runtime/packs/dolt/dolt-state.json` with a minimal standard-library parser. This makes the comparison self-relative without introducing another fleet-specific magic port.

## Review notes

- Scope is limited to `internal/testenv`; production command behavior and configuration are unchanged.
- The runtime-state arm accepts only a positive JSON `port` and only adds refusal conditions.
- Synthetic end-to-end coverage uses ports `19999` and `20000`, distinct from both `3307` and the fleet port used during the incident.
- `GC_ALLOW_PROD_DOLT_PORT_IN_TESTS=1` remains the explicit opt-out for deliberate local-Dolt tests.
- A separately executed production `gc` subprocess does not import `internal/testenv`; that known boundary is documented and remains out of scope.

## Test plan

- [x] `go build ./...` and `go vet ./...`
- [x] Focused ambient-city and legacy production-port tests (36 subtests)
- [x] Full `internal/testenv` package and resource-census ledger-sync test
- [x] `make test-fast-parallel` (9/9 jobs)
- [x] Release gate: [`release-gates/ga-ceutvg-ambient-city-dolt-port-gate.md`](release-gates/ga-ceutvg-ambient-city-dolt-port-gate.md)