### PR TITLE
fix(hooks): inject auto handoff context at session start

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -95,7 +95,11 @@ to empty output from valid conditional logic, or on suspended states
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		if jsonOut {
 			var buf strings.Builder
-			if doPrimeWithHookFormat(args, &buf, stderr, hookMode, hookFormat, strictMode) != 0 {
+			// Preview only: a strings.Builder write never fails, so a
+			// consuming run here would archive durable handoff mail before
+			// the real stdout write — and even on success would eat the
+			// continuation the next SessionStart hook must deliver.
+			if doPrimeWithHookFormatOpts(args, &buf, stderr, hookMode, hookFormat, strictMode, false) != 0 {
 				return errExit
 			}
 			agentName, _ := primeInvocationAgentName(args)
@@ -175,6 +179,15 @@ func primeInvocationAgentName(args []string) (string, bool) {
 }
 
 func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode bool, hookFormat string, strictMode bool) int {
+	return doPrimeWithHookFormatOpts(args, stdout, stderr, hookMode, hookFormat, strictMode, true)
+}
+
+// doPrimeWithHookFormatOpts is the full entry point. consumeHandoff=false makes
+// the invocation non-destructive: durable auto-handoff mail is still rendered
+// into the output, but is not archived. Preview callers (--json) pass false so
+// that a diagnostic run cannot eat the continuation the real SessionStart hook
+// is supposed to deliver.
+func doPrimeWithHookFormatOpts(args []string, stdout, stderr io.Writer, hookMode bool, hookFormat string, strictMode, consumeHandoff bool) int {
 	agentName, sessionTemplateContext := primeInvocationAgentName(args)
 	var hookContext primeHookContext
 	suppressHookPrompt := false
@@ -206,7 +219,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			writePrimePromptWithFormat(stdout, "", "", "", hookMode, hookFormat, false, "", nil)
 			return 0
 		}
-		injection := primeHookContextSuffix("", hookMode, hookContext, stderr)
+		injection := primeHookContextSuffix("", hookMode, hookContext, stderr, consumeHandoff)
 		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 		return 0
 	}
@@ -223,7 +236,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			fmt.Fprintf(stderr, "gc prime: loading city config: %v\n", err) //nolint:errcheck
 			return 1
 		}
-		injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+		injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr, consumeHandoff)
 		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 		return 0
 	}
@@ -331,7 +344,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
 				packDirs, fragments, nil)
 			if prompt != "" {
-				injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+				injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr, consumeHandoff)
 				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 				return 0
 			}
@@ -355,7 +368,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			}
 			if promptFile != "" {
 				if content, fErr := os.ReadFile(promptFile); fErr == nil {
-					injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+					injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr, consumeHandoff)
 					writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, string(content), hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 					return 0
 				}
@@ -367,7 +380,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	// when the agent has no prompt_template and doesn't match a builtin
 	// worker prompt — a supported config shape, so the default prompt is
 	// the correct output even under --strict.
-	injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+	injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr, consumeHandoff)
 	writePrimePromptWithFormat(stdout, cityName, agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 	return 0
 }

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -203,18 +203,15 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			return 1
 		}
 		if hookMode && primeHookSessionStart(hookContext) {
-			writePrimePromptWithFormat(stdout, "", "", "", hookMode, hookFormat, false, "")
+			writePrimePromptWithFormat(stdout, "", "", "", hookMode, hookFormat, false, "", nil)
 			return 0
 		}
-		var stepReminder string
-		if hookMode {
-			stepReminder = wispStepInjectionContent("")
-		}
-		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, stepReminder)
+		injection := primeHookContextSuffix("", hookMode, hookContext, stderr)
+		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 		return 0
 	}
 	if hookMode && primeHookSessionStart(hookContext) && !primeHookHasLiveManagedSession(cityPath) {
-		writePrimePromptWithFormat(stdout, "", "", "", hookMode, hookFormat, false, "")
+		writePrimePromptWithFormat(stdout, "", "", "", hookMode, hookFormat, false, "", nil)
 		return 0
 	}
 	if !strictMode && primeHookSessionStart(hookContext) {
@@ -226,11 +223,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			fmt.Fprintf(stderr, "gc prime: loading city config: %v\n", err) //nolint:errcheck
 			return 1
 		}
-		var stepReminder string
-		if hookMode {
-			stepReminder = wispStepInjectionContent(cityPath)
-		}
-		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, stepReminder)
+		injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 		return 0
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
@@ -337,11 +331,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
 				packDirs, fragments, nil)
 			if prompt != "" {
-				var stepReminder string
-				if hookMode {
-					stepReminder = wispStepInjectionContent(cityPath)
-				}
-				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat, suppressHookPrompt, stepReminder)
+				injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 				return 0
 			}
 			// File is present but rendered empty. Treat as a legitimate
@@ -364,11 +355,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			}
 			if promptFile != "" {
 				if content, fErr := os.ReadFile(promptFile); fErr == nil {
-					var stepReminder string
-					if hookMode {
-						stepReminder = wispStepInjectionContent(cityPath)
-					}
-					writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, string(content), hookMode, hookFormat, suppressHookPrompt, stepReminder)
+					injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+					writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, string(content), hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 					return 0
 				}
 			}
@@ -379,11 +367,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	// when the agent has no prompt_template and doesn't match a builtin
 	// worker prompt — a supported config shape, so the default prompt is
 	// the correct output even under --strict.
-	var stepReminder string
-	if hookMode {
-		stepReminder = wispStepInjectionContent(cityPath)
-	}
-	writePrimePromptWithFormat(stdout, cityName, agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, stepReminder)
+	injection := primeHookContextSuffix(cityPath, hookMode, hookContext, stderr)
+	writePrimePromptWithFormat(stdout, cityName, agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt, injection.text, injection.afterDelivery)
 	return 0
 }
 
@@ -551,7 +536,7 @@ func primeHookHasLiveManagedSession(cityPath string) bool {
 	}
 }
 
-func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt string, hookMode bool, hookFormat string, suppressPrompt bool, hookContextSuffix string) {
+func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt string, hookMode bool, hookFormat string, suppressPrompt bool, hookContextSuffix string, afterDelivery func()) {
 	if hookMode && suppressPrompt {
 		// Managed sessions receive the rendered startup prompt through the
 		// launch payload or nudge path. SessionStart hooks add context only.
@@ -565,10 +550,14 @@ func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt st
 		prompt += hookContextSuffix
 	}
 	if hookMode && hookFormat != "" {
-		_ = writeProviderHookContextForEvent(stdout, hookFormat, "SessionStart", prompt)
+		if err := writeProviderHookContextForEvent(stdout, hookFormat, "SessionStart", prompt); err == nil && afterDelivery != nil {
+			afterDelivery()
+		}
 		return
 	}
-	fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout
+	if _, err := fmt.Fprint(stdout, prompt); err == nil && afterDelivery != nil { //nolint:errcheck // best-effort stdout
+		afterDelivery()
+	}
 }
 
 func readPrimeHookContext() primeHookContext {

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -754,6 +754,98 @@ provider = "exec:/not-used-by-auto-handoff"
 	}
 }
 
+// TestDoPrimeWithHook_JSONModeDoesNotArchiveAutoHandoff pins the preview
+// contract of `gc prime --hook --json`: it renders exactly what the hook would
+// emit, including durable auto-handoff mail, but must not consume it. The
+// --json path buffers into a strings.Builder whose writes never fail, so a
+// consuming run would archive the handoff before the real stdout write — and
+// even on success would eat the continuation the next SessionStart must deliver.
+func TestDoPrimeWithHook_JSONModeDoesNotArchiveAutoHandoff(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	promptDir := filepath.Join(cityDir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "worker.md"), []byte("launch-only startup prompt\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "gastown"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.md"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_AGENT", "worker")
+	t.Setenv("GC_ALIAS", "worker")
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_SESSION_NAME", "gastown--worker")
+	sessionID := createPrimeHookSession(t, cityDir, "gastown--worker", "worker")
+	auto, ok := createHandoffMail(store, store, events.Discard, sessionID, sessionID,
+		[]string{"context cycle", "continue the durable task"}, "context cycle",
+		[]string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel}, &bytes.Buffer{})
+	if !ok {
+		t.Fatal("createHandoffMail(auto) failed")
+	}
+	t.Setenv("GC_SESSION_ID", sessionID)
+	t.Setenv(managedSessionHookEnv, "1")
+	t.Setenv("GC_HOOK_SOURCE", "startup")
+	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+	t.Setenv(startupPromptDeliveredEnv, "1")
+	withPrimeHookStdin(t)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newPrimeCmd(&stdout, &stderr)
+	cmd.SetOut(&stderr)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--json", "--hook", "--hook-format", "codex"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc prime --json --hook = %v; stderr=%q", err, stderr.String())
+	}
+
+	var got primeJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("--json output is not JSON: %v; stdout=%q", err, stdout.String())
+	}
+	// The preview must be faithful: the handoff the hook would emit is present.
+	for _, want := range []string{auto.ID, auto.Subject, auto.Body} {
+		if !strings.Contains(got.Content, want) {
+			t.Fatalf("content = %q, want auto-handoff substring %q", got.Content, want)
+		}
+	}
+	// ...but previewing must not consume it.
+	if _, err := store.Get(auto.ID); err != nil {
+		t.Fatalf("--json preview must leave auto-handoff durable, got err=%v", err)
+	}
+
+	// The real hook invocation still consumes it, so the preview did not
+	// merely mark the mail read in a way that suppresses later delivery.
+	var hookStdout bytes.Buffer
+	if code := doPrimeWithHookFormat(nil, &hookStdout, &stderr, true, "codex", false); code != 0 {
+		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(hookStdout.String(), auto.ID) {
+		t.Fatalf("hook output = %q, want auto-handoff %q", hookStdout.String(), auto.ID)
+	}
+	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("auto-handoff should be archived after the real SessionStart injection, got err=%v", err)
+	}
+}
+
 func TestDoPrimeWithHookFormat_GatesDefaultFallbackWithoutManagedSession(t *testing.T) {
 	t.Setenv("GC_CITY", filepath.Join(t.TempDir(), "missing-city"))
 	t.Setenv("GC_ALIAS", "")

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,8 +12,19 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/mail/beadmail"
 )
+
+type primeHookFailWriter struct {
+	err error
+}
+
+func (w primeHookFailWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
 
 func TestBuildPrimeContextFallsBackToConfiguredRigRoot(t *testing.T) {
 	t.Setenv("GC_RIG", "demo")
@@ -607,9 +619,8 @@ func mustCreateInProgressStore(t *testing.T, store beads.Store, b beads.Bead) be
 // managed-SessionStart regression: when the startup prompt is suppressed
 // (GC_STARTUP_PROMPT_DELIVERED=1 + managed hook + SessionStart), the rendered
 // startup prompt must be absent from the single hook payload, but the agent's
-// active formula step <system-reminder> must still be injected. The step
-// reminder is hook-only context, not the startup prompt, so it survives
-// suppression — this is the SessionStart leg of the hook-inject feature.
+// active formula step and durable auto-handoff <system-reminders> must still be
+// injected. Both are hook-only context, so they survive suppression.
 func TestDoPrimeWithHook_DeliveredStartupPromptKeepsStepReminder(t *testing.T) {
 	for _, hookFormat := range []string{"codex", hookOutputFormatGemini} {
 		t.Run(hookFormat, func(t *testing.T) {
@@ -633,6 +644,9 @@ name = "gastown"
 [[agent]]
 name = "worker"
 prompt_template = "prompts/worker.md"
+
+[mail]
+provider = "exec:/not-used-by-auto-handoff"
 `), 0o644); err != nil {
 				t.Fatalf("WriteFile(city.toml): %v", err)
 			}
@@ -662,6 +676,16 @@ prompt_template = "prompts/worker.md"
 			t.Setenv("GC_TEMPLATE", "worker")
 			t.Setenv("GC_SESSION_NAME", "gastown--worker")
 			sessionID := createPrimeHookSession(t, cityDir, "gastown--worker", "worker")
+			auto, ok := createHandoffMail(store, store, events.Discard, sessionID, sessionID,
+				[]string{"context cycle", "continue the durable task"}, "context cycle",
+				[]string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel}, &bytes.Buffer{})
+			if !ok {
+				t.Fatal("createHandoffMail(auto) failed")
+			}
+			ordinary, err := beadmail.New(store).Send("human", sessionID, "ordinary", "leave this for UserPromptSubmit")
+			if err != nil {
+				t.Fatalf("Send ordinary mail: %v", err)
+			}
 			t.Setenv("GC_SESSION_ID", sessionID)
 			t.Setenv(managedSessionHookEnv, "1")
 			t.Setenv("GC_HOOK_SOURCE", "startup")
@@ -696,6 +720,35 @@ prompt_template = "prompts/worker.md"
 			}
 			if !strings.Contains(context, "[gastown] worker") {
 				t.Fatalf("additionalContext = %q, want hook beacon", context)
+			}
+			for _, want := range []string{auto.ID, auto.Subject, auto.Body} {
+				if !strings.Contains(context, want) {
+					t.Fatalf("additionalContext = %q, want auto-handoff substring %q", context, want)
+				}
+			}
+			if strings.Contains(context, ordinary.ID) || strings.Contains(context, ordinary.Body) {
+				t.Fatalf("additionalContext = %q, must not inject ordinary mail %q at SessionStart", context, ordinary.ID)
+			}
+			if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
+				t.Fatalf("auto-handoff should be archived after SessionStart injection, got err=%v", err)
+			}
+			if _, err := store.Get(ordinary.ID); err != nil {
+				t.Fatalf("ordinary mail should remain for UserPromptSubmit: %v", err)
+			}
+
+			// A provider-hook write failure must leave the next auto-handoff
+			// durable for retry; delivery acknowledgement is the archive point.
+			undelivered, ok := createHandoffMail(store, store, events.Discard, sessionID, sessionID,
+				[]string{"context cycle retry", "retry the durable task"}, "context cycle",
+				[]string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel}, &bytes.Buffer{})
+			if !ok {
+				t.Fatal("createHandoffMail(undelivered) failed")
+			}
+			if code := doPrimeWithHookFormat(nil, primeHookFailWriter{err: errors.New("hook output unavailable")}, &stderr, true, hookFormat, false); code != 0 {
+				t.Fatalf("doPrimeWithHookFormat(failed writer) = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			if _, err := store.Get(undelivered.ID); err != nil {
+				t.Fatalf("auto-handoff must remain durable when SessionStart output fails: %v", err)
 			}
 		})
 	}

--- a/cmd/gc/prime_auto_handoff_inject.go
+++ b/cmd/gc/prime_auto_handoff_inject.go
@@ -17,7 +17,11 @@ type primeHookContextInjection struct {
 // primeHookContextSuffix builds the single provider-hook context owned by gc
 // prime. A managed SessionStart receives durable auto-handoff mail here because
 // a recycled successor can otherwise idle before any UserPromptSubmit hook.
-func primeHookContextSuffix(cityPath string, hookMode bool, hookContext primeHookContext, stderr io.Writer) primeHookContextInjection {
+//
+// consumeHandoff gates only the destructive archive: preview callers (--json)
+// still render the exact text the hook would emit, but must not consume the
+// durable mail out from under the real SessionStart invocation.
+func primeHookContextSuffix(cityPath string, hookMode bool, hookContext primeHookContext, stderr io.Writer, consumeHandoff bool) primeHookContextInjection {
 	if !hookMode {
 		return primeHookContextInjection{}
 	}
@@ -25,7 +29,9 @@ func primeHookContextSuffix(cityPath string, hookMode bool, hookContext primeHoo
 	if primeHookSessionStart(hookContext) {
 		autoHandoff := sessionStartAutoHandoffInjection(stderr)
 		injection.text += autoHandoff.text
-		injection.afterDelivery = autoHandoff.afterDelivery
+		if consumeHandoff {
+			injection.afterDelivery = autoHandoff.afterDelivery
+		}
 	}
 	return injection
 }

--- a/cmd/gc/prime_auto_handoff_inject.go
+++ b/cmd/gc/prime_auto_handoff_inject.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/mail/beadmail"
+)
+
+type primeHookContextInjection struct {
+	text          string
+	afterDelivery func()
+}
+
+// primeHookContextSuffix builds the single provider-hook context owned by gc
+// prime. A managed SessionStart receives durable auto-handoff mail here because
+// a recycled successor can otherwise idle before any UserPromptSubmit hook.
+func primeHookContextSuffix(cityPath string, hookMode bool, hookContext primeHookContext, stderr io.Writer) primeHookContextInjection {
+	if !hookMode {
+		return primeHookContextInjection{}
+	}
+	injection := primeHookContextInjection{text: wispStepInjectionContent(cityPath)}
+	if primeHookSessionStart(hookContext) {
+		autoHandoff := sessionStartAutoHandoffInjection(stderr)
+		injection.text += autoHandoff.text
+		injection.afterDelivery = autoHandoff.afterDelivery
+	}
+	return injection
+}
+
+// sessionStartAutoHandoffInjection returns only durable auto-handoff mail for
+// the current managed session. It intentionally constructs beadmail directly:
+// gc handoff persists this continuation class through beadmail regardless of
+// any separately configured ordinary-mail provider.
+func sessionStartAutoHandoffInjection(stderr io.Writer) primeHookContextInjection {
+	store, cityPath, code := openCityStoreWithPath(io.Discard, "gc prime")
+	if store == nil || code != 0 {
+		return primeHookContextInjection{}
+	}
+	cfg, _ := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
+	msgStore := resolveMailMessagesStore(store, cfg, cityPath, nil)
+	sessStore := cliSessionStore(store, cfg, cityPath)
+	mp := beadmail.NewWithStores(msgStore, sessStore)
+	sessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID"))
+	target, err := resolveMailTargetsWithConfig(cityPath, cfg, sessStore, sessionID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc prime: resolving auto-handoff mailbox: %v\n", err) //nolint:errcheck // best-effort hook diagnostics
+		return primeHookContextInjection{}
+	}
+	messages, err := mp.CheckAutoHandoffs(target.recipients)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc prime: checking auto-handoff mail: %v\n", err) //nolint:errcheck // best-effort hook diagnostics
+		return primeHookContextInjection{}
+	}
+	if len(messages) == 0 {
+		return primeHookContextInjection{}
+	}
+	injectedMessages := sortMailByPriority(messages)
+	if len(injectedMessages) > mailInjectMaxMessages {
+		injectedMessages = injectedMessages[:mailInjectMaxMessages]
+	}
+	return primeHookContextInjection{
+		text: formatInjectOutput(messages),
+		afterDelivery: func() {
+			archiveInjectedAutoHandoffMessages(mp, injectedMessages, stderr)
+		},
+	}
+}

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -536,6 +537,35 @@ func (p *Provider) All(recipient string) ([]mail.Message, error) {
 // Check returns unread messages for the recipient without marking them read.
 func (p *Provider) Check(recipient string) ([]mail.Message, error) {
 	return p.filterMessages(recipient, false)
+}
+
+// CheckAutoHandoffs returns unread continuation mail carrying both labels that
+// opt it into automatic SessionStart delivery. It deliberately excludes normal
+// mail so a recycle does not duplicate the UserPromptSubmit inbox injection.
+func (p *Provider) CheckAutoHandoffs(recipients []string) ([]mail.Message, error) {
+	routes := p.recipientRoutesForAll(recipients)
+	candidates, err := p.messageCandidatesForRoutes(routes)
+	if err != nil {
+		return nil, fmt.Errorf("beadmail: listing auto-handoff messages: %w", err)
+	}
+	var messages []mail.Message
+	for _, b := range candidates {
+		if b.Status != "open" ||
+			(len(routes) > 0 && !matchesRecipientRoute(routes, b.Assignee)) ||
+			hasLabel(b.Labels, "read") ||
+			!hasLabel(b.Labels, mail.AutoHandoffLabel) ||
+			!hasLabel(b.Labels, mail.ArchiveAfterInjectLabel) {
+			continue
+		}
+		messages = append(messages, beadToMessage(b))
+	}
+	sort.Slice(messages, func(i, j int) bool {
+		if messages[i].CreatedAt.Equal(messages[j].CreatedAt) {
+			return messages[i].ID < messages[j].ID
+		}
+		return messages[i].CreatedAt.Before(messages[j].CreatedAt)
+	})
+	return messages, nil
 }
 
 // Reply creates a reply to an existing message. Inherits ThreadID from the

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -2303,6 +2303,56 @@ func TestCheck(t *testing.T) {
 	}
 }
 
+func TestCheckAutoHandoffsReturnsOnlyUnreadDeliveryMarkedMail(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+	if _, err := p.Send("human", "worker", "ordinary", "leave this for normal mail injection"); err != nil {
+		t.Fatalf("Send ordinary: %v", err)
+	}
+	missingArchiveMarker, err := p.SendHandoff(mail.HandoffIntent{
+		From:        "worker",
+		To:          "worker",
+		Subject:     "not deliverable",
+		ThreadID:    "thread-missing-marker",
+		ExtraLabels: []string{mail.AutoHandoffLabel},
+	})
+	if err != nil {
+		t.Fatalf("SendHandoff missing archive marker: %v", err)
+	}
+	auto, err := p.SendHandoff(mail.HandoffIntent{
+		From:        "worker",
+		To:          "worker",
+		Subject:     "context cycle",
+		Body:        "continue durable work",
+		ThreadID:    "thread-auto",
+		ExtraLabels: []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+	})
+	if err != nil {
+		t.Fatalf("SendHandoff auto: %v", err)
+	}
+	readAuto, err := p.SendHandoff(mail.HandoffIntent{
+		From:        "worker",
+		To:          "worker",
+		Subject:     "already delivered",
+		ThreadID:    "thread-read-auto",
+		ExtraLabels: []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+	})
+	if err != nil {
+		t.Fatalf("SendHandoff read auto: %v", err)
+	}
+	if err := p.MarkRead(readAuto.ID); err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	messages, err := p.CheckAutoHandoffs([]string{"worker"})
+	if err != nil {
+		t.Fatalf("CheckAutoHandoffs: %v", err)
+	}
+	if len(messages) != 1 || messages[0].ID != auto.ID {
+		t.Fatalf("CheckAutoHandoffs = %#v, want only %q (not %q)", messages, auto.ID, missingArchiveMarker.ID)
+	}
+}
+
 // --- Provider session-list cache (ga-q6ct) ---
 
 // countingSessionListStore counts broad gc:session List calls and forwards


### PR DESCRIPTION
## Summary

Fresh provider sessions can otherwise reach an empty prompt after a context-cycle handoff: the handoff is durable, but ordinary mailbox injection waits for a later `UserPromptSubmit` hook that may never occur. Deliver explicitly marked auto-handoff mail in the managed `SessionStart` context instead.

The change uses the existing handoff labels and the existing sanitized, priority-aware mail formatter. It archives only the messages that were actually delivered, and only after provider-hook output succeeds.

## Behavior

- Given a managed `SessionStart` and unread mail carrying both auto-handoff delivery labels, when `gc prime --hook` writes startup context successfully, then the successor receives the handoff before its first user prompt and the delivered handoff is archived.
- Given ordinary, already-read, or partially marked mail, it is not injected at `SessionStart`; the normal `UserPromptSubmit` inbox path is unchanged.
- Given provider-hook output fails, the handoff remains durable and unread for retry.

## Why this is safe

This does not change handoff, reset, or wake decisions. It only supplies durable continuation context at the `SessionStart` hook boundary. Continuation mail is deliberately read through beadmail because `gc handoff --auto` persists that class of mail there regardless of an independently configured ordinary-mail provider.

## Related work

- #1552 introduced `gc handoff --auto` for PreCompact handoffs.
- #2920 archives injected auto-handoff mail after successful delivery.
- #3762 is a related fresh-start handoff issue on the manual attach path; it is not fixed by this PR.

## Scope

- `cmd/gc`: SessionStart hook context and regression coverage.
- `internal/mail/beadmail`: explicit selector for delivery-marked auto-handoff messages.

## Testing

- [x] `go test ./cmd/gc -run '^TestDoPrimeWithHook_DeliveredStartupPromptKeepsStepReminder$' -count=1`
- [x] `go test ./internal/mail/beadmail -run '^TestCheckAutoHandoffsReturnsOnlyUnreadDeliveryMarkedMail$' -count=1`
- [x] `go build ./cmd/gc/`
- [x] `go vet ./...`
- [ ] `make check` (CI)
- [ ] `make test-integration` (CI runtime coverage)

## Checklist

- [x] Related upstream work is linked above; no separate issue is needed for this narrow regression fix.
- [x] Tests cover the delivery, exclusion, archive, and output-failure boundaries.
- [x] No docs change is needed: there is no public CLI or configuration surface change.
- [x] No breaking change or migration is required.
