### PR TITLE
fix(scripts): push-gate misreports an impossible slot-dir as a wait-bound timeout in linked worktrees

### DIFF
--- a/scripts/push-gate-lock-lib.sh
+++ b/scripts/push-gate-lock-lib.sh
@@ -68,10 +68,15 @@
 #   - Malformed tunables fall back to their documented defaults with a
 #     diagnostic naming the offending variable; they never reach arithmetic
 #     or `sleep` unvalidated.
-#   - A timed-out acquire returns 1 (shell-false). This library never calls
-#     `exit` itself — mapping a timeout to process exit code 75 is the
-#     caller's job (scripts/test-local-parallel), keeping this file a pure,
-#     testable function library.
+#   - A timed-out acquire returns 1 (shell-false), and ONLY a timed-out
+#     acquire returns 1 — every degrade case (missing flock(1), a slot dir
+#     that cannot be created) prints its own diagnostic and returns 0 with
+#     an empty fd instead, so callers can trust that a 1 always means a
+#     real wait-bound expiry, never an environment defect misreported as
+#     fleet contention. This library never calls `exit` itself — mapping a
+#     timeout to process exit code 75 is the caller's job
+#     (scripts/test-local-parallel), keeping this file a pure, testable
+#     function library.
 #
 # FUNCTIONS
 #   push_gate_city_root
@@ -100,12 +105,15 @@
 #       PUSH_GATE_MAX_WAIT_SECONDS (default 600), PUSH_GATE_POLL_SECONDS
 #       (default 15); each is validated and falls back to its default on a
 #       malformed value. holder_label defaults to
-#       ${GC_SESSION_NAME:-${GC_AGENT:-${GC_TEMPLATE:-unknown}}}. Sweeps
-#       slots 0..N-1 non-blocking; acquires the first free one immediately
-#       (fd assigned to the caller's <fd_out_var>, return 0). If all slots
-#       are busy: prints an immediate unbuffered diagnostic naming current
-#       holders (FR5), then re-sweeps every POLL_SECONDS until a slot frees
-#       or MAX_WAIT_SECONDS elapses. Returns 0 (acquired) or 1 (timed out —
+#       ${GC_SESSION_NAME:-${GC_AGENT:-${GC_TEMPLATE:-unknown}}}. If the slot
+#       dir cannot be created (e.g. an unwritable parent), degrades the same
+#       way as a missing flock(1): diagnostic to stderr, empty fd, return 0
+#       — never conflated with a timeout. Otherwise sweeps slots 0..N-1
+#       non-blocking; acquires the first free one immediately (fd assigned
+#       to the caller's <fd_out_var>, return 0). If all slots are busy:
+#       prints an immediate unbuffered diagnostic naming current holders
+#       (FR5), then re-sweeps every POLL_SECONDS until a slot frees or
+#       MAX_WAIT_SECONDS elapses. Returns 0 (acquired) or 1 (timed out —
 #       caller should `exit 75`).
 #   push_gate_describe_slots <slot_dir> <max_concurrent>
 #       Print one "slot-<i>: <holder line>" line per currently-occupied
@@ -276,7 +284,16 @@ push_gate_acquire_slot() {
     local _pgl_host
     _pgl_host="$(hostname 2>/dev/null || echo unknown)"
 
-    mkdir -p "$_pgl_slot_dir" 2>/dev/null || return 1
+    # An unwritable slot dir (e.g. a parent path component that is a file,
+    # as .git is in a linked worktree prior to push_gate_slots_dir's
+    # common-dir fix) is a degrade case, not a wait-bound timeout — same
+    # `return 1` used to mean both, which sent operators chasing fleet
+    # contention that did not exist. Degrade best-effort instead.
+    if ! mkdir -p "$_pgl_slot_dir" 2>/dev/null; then
+        echo "push-gate: cannot create slot dir $_pgl_slot_dir — running without a cross-invocation cap" >&2
+        eval "$_pgl_fd_var="
+        return 0
+    fi
 
     local _pgl_i _pgl_slot _pgl_fd _pgl_announced=0 _pgl_start=0
 

--- a/scripts/test-push-gate-lock.sh
+++ b/scripts/test-push-gate-lock.sh
@@ -168,6 +168,29 @@ NOFLOCK_OUT="$(LIB="$LIB" DIR="$WORK/noflock-slots" PATH="$WORK/empty-bin" \
 assert_contains "no_flock.warns_and_names_flock" "$NOFLOCK_OUT" "flock(1) not found"
 assert_contains "no_flock.returns_zero_empty_fd" "$NOFLOCK_OUT" "rc=0 fd=[]"
 
+# ---------------- mkdir failure: degrade best-effort, never misreport as timeout ----------------
+# The original bug (ga-5enlx8): a linked worktree's .git is a FILE, so the
+# slots-dir fallback resolved under it and mkdir -p could never succeed. The
+# old code mapped that mkdir failure to the same `return 1` as a real
+# wait-bound timeout, so operators chased fleet contention that did not
+# exist. A blocked FILE (not a permission bit, so this holds even as root)
+# stands in for that unwritable-parent case.
+BLOCKED_PARENT="$WORK/blocked-parent"
+: >"$BLOCKED_PARENT"
+MKDIRFAIL_OUT="$(LIB="$LIB" DIR="$BLOCKED_PARENT/gate-slots" \
+    PUSH_GATE_MAX_CONCURRENT=1 PUSH_GATE_MAX_WAIT_SECONDS=5 PUSH_GATE_POLL_SECONDS=1 \
+    bash -c '. "$LIB"; z=preset; push_gate_acquire_slot "$DIR" z holder-G; echo "rc=$? fd=[$z]"' 2>&1)"
+assert_contains "mkdir_fail.warns_cannot_create_slot_dir" "$MKDIRFAIL_OUT" "cannot create slot dir"
+assert_contains "mkdir_fail.returns_zero_empty_fd"        "$MKDIRFAIL_OUT" "rc=0 fd=[]"
+# The misreporting was the actual harm, so assert the absence of the timeout
+# message directly rather than relying on rc=0 to imply it.
+case "$MKDIRFAIL_OUT" in
+    *"timed out"*)
+        record_fail "mkdir_fail.never_reports_timeout" "found 'timed out' in output: $MKDIRFAIL_OUT" ;;
+    *)
+        record_pass "mkdir_fail.never_reports_timeout" ;;
+esac
+
 # ---------------- malformed tunables fall back to their documented defaults ----------------
 # Each bad value must be rejected by name and replaced, never fed to
 # arithmetic (`-1`, `abc`) or turned into a busy loop / zero-slot sweep (`0`).


### PR DESCRIPTION
## Problem

`push_gate_slots_dir()` in `scripts/push-gate-lock-lib.sh` falls back to
`<repo_root>/.git/gate-slots` when it cannot resolve a city root. In a **linked
worktree** `.git` is a *file*, not a directory, so
`push_gate_acquire_slot()`'s `mkdir -p ... || return 1` can never succeed.

The contract reads `return 1` as "timed out", so the caller prints the
wait-bound message — "giving up after the wait bound" — for a condition that
is not contention at all and will never clear.

A push from a worktree that does not resolve a city root therefore fails
**100% of the time while reporting transient contention**, which invites
exactly the wrong remedy (retry, or bypass the gate).

## Evidence this is a misreport, not a timeout

- `mkdir` fails with `Not a directory`
- the wait loop's own announce line ("all N slot(s) busy, waiting up to 600s")
  never appears in the failing log
- elapsed was ~5s against a 600s wait bound
- slot 1 was verifiably free at the time

## Fix

Degrade instead of misreporting: when the slot directory cannot be created,
say so and fall through, rather than returning the code that means "timed
out". A gate that cannot run must not claim it ran and lost a race.

## Tests

`scripts/test-push-gate-lock.sh` gains coverage for the linked-worktree case
(`.git` as a file), committed RED first (`03366c24e`) and then GREEN
(`5b36d1eb0`).
