### PR TITLE
fix(test): five architectural guards are silent no-ops in any git worktree

### DIFF
--- a/internal/beads/boundary_test.go
+++ b/internal/beads/boundary_test.go
@@ -195,6 +195,38 @@ func TestFindBdExecViolationsSkipsNestedGoModules(t *testing.T) {
 	}
 }
 
+// TestFindBdExecViolationsScansWorktreeRoot pins the fix for ga-vpcbsa: every
+// gc agent session runs from a worktree under .gc/worktrees/, where
+// root/.git is a FILE (a `gitdir:` pointer), not a directory.
+// filepath.Walk invokes the callback on root first, so without a
+// `path != root` guard around the .git-file SkipDir check, the walk returns
+// filepath.SkipDir on entry zero and visits zero files — the invariant
+// passes vacuously instead of actually scanning anything.
+func TestFindBdExecViolationsScansWorktreeRoot(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/fixture\n")
+
+	// Simulate a git worktree checkout: root's .git is a FILE, not a dir.
+	mustWriteFile(t, filepath.Join(root, ".git"), "gitdir: /nowhere\n")
+
+	// A real violation, directly in the checkout, outside any allowed dir.
+	mustWriteFile(t, filepath.Join(root, "cmd", "gc", "example.go"),
+		"package main\n\nfunc run() { exec.Command(\"bd\", \"prime\") }\n")
+
+	violations, err := findBdExecViolations(root)
+	if err != nil {
+		t.Fatalf("findBdExecViolations: %v", err)
+	}
+
+	if len(violations) != 1 {
+		t.Fatalf("violations = %v, want exactly 1 (root's .git file must not stop the walk)", violations)
+	}
+	if !strings.Contains(violations[0], filepath.Join("cmd", "gc", "example.go")) {
+		t.Fatalf("violations[0] = %q, want the cmd/gc/example.go violation", violations[0])
+	}
+}
+
 func mustWriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/beads/boundary_test.go
+++ b/internal/beads/boundary_test.go
@@ -52,9 +52,16 @@ func findBdExecViolations(root string) ([]string, error) {
 			if base == ".git" || base == "vendor" || base == ".claude" || base == ".gc" || strings.HasPrefix(base, ".beads-src") {
 				return filepath.SkipDir
 			}
-			// Skip git worktrees embedded in the repo (have a .git file, not dir).
-			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
-				return filepath.SkipDir
+			// Skip git worktrees embedded in the repo (have a .git file, not
+			// dir) — but never apply this to root itself. gc agent sessions run
+			// from inside a worktree, so root legitimately has a .git file
+			// rather than a .git directory; skipping on that condition here
+			// would SkipDir the walk's very first entry and silently visit
+			// zero files.
+			if path != root {
+				if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+					return filepath.SkipDir
+				}
 			}
 			// Skip nested Go modules: any directory other than root that owns
 			// its own go.mod is a separate module's source tree (a module-cache

--- a/internal/beads/contract/identity_test.go
+++ b/internal/beads/contract/identity_test.go
@@ -594,9 +594,16 @@ func TestNoExternalIdentityWriters(t *testing.T) {
 			if _, skip := skipDirs[d.Name()]; skip {
 				return filepath.SkipDir
 			}
-			// Skip git worktrees embedded in the repo (have a .git file, not dir).
-			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
-				return filepath.SkipDir
+			// Skip git worktrees embedded in the repo (have a .git file, not
+			// dir) — but never apply this to root itself. gc agent sessions run
+			// from inside a worktree, so root legitimately has a .git file
+			// rather than a .git directory; skipping on that condition here
+			// would SkipDir the walk's very first entry and silently visit
+			// zero files.
+			if path != root {
+				if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+					return filepath.SkipDir
+				}
 			}
 			return nil
 		}

--- a/internal/builtinpacks/registry_test.go
+++ b/internal/builtinpacks/registry_test.go
@@ -208,9 +208,16 @@ func TestMaterializeSyntheticRepoProductionCallersStayAllowlisted(t *testing.T) 
 			case ".git", ".gc", "node_modules", "worktrees":
 				return filepath.SkipDir
 			}
-			// Skip git worktrees embedded in the repo (have a .git file, not dir).
-			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
-				return filepath.SkipDir
+			// Skip git worktrees embedded in the repo (have a .git file, not
+			// dir) — but never apply this to repoRoot itself. gc agent
+			// sessions run from inside a worktree, so repoRoot legitimately
+			// has a .git file rather than a .git directory; skipping on that
+			// condition here would SkipDir the walk's very first entry and
+			// silently visit zero files.
+			if path != repoRoot {
+				if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+					return filepath.SkipDir
+				}
 			}
 			return nil
 		}

--- a/internal/logutil/walkthrough_urls_test.go
+++ b/internal/logutil/walkthrough_urls_test.go
@@ -45,9 +45,16 @@ func TestWalkthroughURLStringsStayInContractFile(t *testing.T) {
 			case ".git", ".gc", "node_modules":
 				return filepath.SkipDir
 			}
-			// Skip git worktrees embedded in the repo (have a .git file, not dir).
-			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
-				return filepath.SkipDir
+			// Skip git worktrees embedded in the repo (have a .git file, not
+			// dir) — but never apply this to root itself. gc agent sessions run
+			// from inside a worktree, so root legitimately has a .git file
+			// rather than a .git directory; skipping on that condition here
+			// would SkipDir the walk's very first entry and silently visit
+			// zero files.
+			if path != root {
+				if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+					return filepath.SkipDir
+				}
 			}
 			return nil
 		}

--- a/internal/pgauth/no_external_env_test.go
+++ b/internal/pgauth/no_external_env_test.go
@@ -41,9 +41,16 @@ func TestNoDirectPostgresEnvReadsOutsidePgauth(t *testing.T) {
 			if base == ".git" || base == "vendor" || base == ".claude" || base == ".beads" || base == ".gc" || base == "worktrees" || strings.HasPrefix(base, ".beads-src") || strings.HasPrefix(base, "node_modules") {
 				return filepath.SkipDir
 			}
-			// Skip git worktrees embedded in the repo (have a .git file, not dir).
-			if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
-				return filepath.SkipDir
+			// Skip git worktrees embedded in the repo (have a .git file, not
+			// dir) — but never apply this to root itself. gc agent sessions run
+			// from inside a worktree, so root legitimately has a .git file
+			// rather than a .git directory; skipping on that condition here
+			// would SkipDir the walk's very first entry and silently visit
+			// zero files.
+			if path != root {
+				if fi, serr := os.Stat(filepath.Join(path, ".git")); serr == nil && !fi.IsDir() {
+					return filepath.SkipDir
+				}
 			}
 			return nil
 		}


### PR DESCRIPTION
## Problem

Five architectural guard tests walk the repository looking for violations.
Each one skips `.git` with an unguarded `SkipDir` check that also matches the
**walk root itself**.

In a linked worktree `.git` is a *file* at the root, so the guard matches at
the very first entry and returns `filepath.SkipDir` for the root — ending the
walk immediately. The test then finds zero violations and passes.

So in any git worktree these five guards are **silent no-ops**: they report
green without having examined a single file. Every agent working in a linked
worktree — which is how the fleet works — has been running them for nothing.

## Affected guards

| file | guards |
|---|---|
| `internal/beads/boundary_test.go` | bd-exec boundary violations |
| `internal/beads/contract/identity_test.go` | identity contract |
| `internal/builtinpacks/registry_test.go` | builtin pack registry |
| `internal/logutil/walkthrough_urls_test.go` | walkthrough URL policy |
| `internal/pgauth/no_external_env_test.go` | external env access |

## Fix

Guard the skip with a `path != root` condition so the walk root is never
itself skipped. `internal/testenv/lint_test.go`'s `isNestedWorktreeRoot` is
the reference shape.

## Tests

`TestFindBdExecViolationsScansWorktreeRoot` added, committed RED first
(`0e6b9f4ca`) then GREEN (`57795dd08`) — the new test fails on the pre-fix
tree, confirming the guards really were returning early.

Each of the five sites was fixed with the same `path != root` guard rather
than one-off patches, so the class is closed rather than the instance.
