### PR TITLE
fix(workflow): preserve existing gc.routed_to on reopen-source

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1370,16 +1370,33 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if err := target.storeView.store.SetMetadata(currentSource.ID, "workflow_id", ""); err != nil {
 			return err
 		}
-		// Pre-route to gc.run_target so the bead is never left unrouted
-		// between the reopen and the caller's follow-up re-sling (vp-nq8 /
-		// FR-C0.1). A blank gc.routed_to is invisible to route-reclaim (which
-		// only heals set-but-dead/stuck routes) and causes unrouted-feeder to
-		// mis-route to the rig planner instead of the correct next step, so an
-		// unset route orphans the bead if the re-sling fails to land.
+		// Pre-route so the bead is never left unrouted between the reopen and
+		// the caller's follow-up re-sling (vp-nq8 / FR-C0.1). A blank
+		// gc.routed_to is invisible to route-reclaim (which only heals
+		// set-but-dead/stuck routes) and causes unrouted-feeder to mis-route to
+		// the rig planner instead of the correct next step, so an unset route
+		// orphans the bead if the re-sling fails to land.
 		//
-		// When gc.run_target is empty (legacy beads created before the field
-		// was stamped), we fall back to blank for backward compatibility.
+		// gc.run_target wins when present. Otherwise keep the route the bead
+		// already carries instead of blanking it (ga-20zd). Re-pooling a bead
+		// takes two separate commands — the caller writes the route with
+		// `gc bd update`, and calls reopen-source — and blanking made that pair
+		// order-dependent: a reopen landing after the route write silently
+		// erased it. The bead then looked correctly re-pooled (rejection
+		// metadata set, branch intact) while being invisible to pool-demand
+		// dispatch, which filters on gc.routed_to. Nothing healed it either:
+		// restoreCarriedWorkRoutes can only recover a route from
+		// gc.run_target, which plain work beads never carry, so the bead sat
+		// until a human re-slung it by hand.
+		//
+		// Preserving costs the caller nothing. A re-sling to a different target
+		// overwrites the route, and one to the same target still re-runs
+		// finalize via resolveConvoyRecovery, which sees the just-deleted
+		// workflow rather than short-circuiting as idempotent.
 		nextRoute := strings.TrimSpace(currentSource.Metadata[beadmeta.RunTargetMetadataKey])
+		if nextRoute == "" {
+			nextRoute = strings.TrimSpace(currentSource.Metadata[beadmeta.RoutedToMetadataKey])
+		}
 		if err := target.storeView.store.SetMetadata(currentSource.ID, beadmeta.RoutedToMetadataKey, nextRoute); err != nil {
 			return err
 		}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1295,12 +1295,20 @@ func TestCmdWorkflowDeleteSourceClosesGraphV2OnlyRoot(t *testing.T) {
 	}
 }
 
-func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
-	// Backward-compat: when gc.run_target is not set on the source bead
-	// (legacy beads stamped before the field existed), reopen-source clears
-	// gc.routed_to so the caller's explicit re-sling can write the correct
-	// route.  A blank gc.routed_to is not ideal (route-reclaim skips it) but
-	// is no worse than the pre-FR-C0.1 behavior for this legacy class.
+func TestCmdWorkflowReopenSourcePreservesRouteWithoutRunTarget(t *testing.T) {
+	// ga-20zd: when gc.run_target is absent, reopen-source must fall back to
+	// the route the bead already carries instead of blanking it. Blanking made
+	// the reopen destructive and order-dependent: the refinery's rejection path
+	// writes the pool route with `gc bd update` and calls reopen-source as a
+	// separate command, so a reopen that landed after the metadata write
+	// silently erased the route. The bead then looked correctly re-pooled
+	// (rejection_reason set, branch intact) but was invisible to pool-demand
+	// dispatch, which filters on gc.routed_to.
+	//
+	// Preserving is safe for the caller's follow-up re-sling: a re-sling to a
+	// different target overwrites the route, and a re-sling to the same target
+	// hits resolveConvoyRecovery, which detects the just-deleted workflow and
+	// re-runs finalize rather than short-circuiting as idempotent.
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1325,7 +1333,7 @@ func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
 	if err := store.SetMetadata(source.ID, "workflow_id", "wf-gone"); err != nil {
 		t.Fatalf("SetMetadata(workflow_id): %v", err)
 	}
-	if err := store.SetMetadata(source.ID, "gc.routed_to", "mayor"); err != nil {
+	if err := store.SetMetadata(source.ID, "gc.routed_to", "myrig/voxist.executor"); err != nil {
 		t.Fatalf("SetMetadata(gc.routed_to): %v", err)
 	}
 	if err := store.SetMetadata(source.ID, "gc.session_affinity", "require"); err != nil {
@@ -1354,14 +1362,66 @@ func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
 	if got := strings.TrimSpace(updated.Metadata["workflow_id"]); got != "" {
 		t.Fatalf("workflow_id = %q, want cleared", got)
 	}
-	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != "" {
-		t.Fatalf("gc.routed_to = %q, want cleared (no gc.run_target → legacy blank)", got)
+	const wantRoute = "myrig/voxist.executor"
+	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != wantRoute {
+		t.Fatalf("gc.routed_to = %q, want %q preserved (no gc.run_target → keep existing route)", got, wantRoute)
 	}
 	if got := strings.TrimSpace(updated.Metadata["gc.session_affinity"]); got != "" {
 		t.Fatalf("gc.session_affinity = %q, want cleared with unassigned reopen", got)
 	}
 	if got := strings.TrimSpace(updated.Metadata["gc.continuation_group"]); got != "" {
 		t.Fatalf("gc.continuation_group = %q, want cleared with unassigned reopen", got)
+	}
+	if updated.Status != "open" {
+		t.Fatalf("status = %q, want open", updated.Status)
+	}
+	if updated.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", updated.Assignee)
+	}
+}
+
+func TestCmdWorkflowReopenSourceLeavesRouteBlankWhenNoRouteAvailable(t *testing.T) {
+	// ga-20zd: preserving an existing route must not invent one. A bead
+	// carrying neither gc.run_target nor gc.routed_to still reopens blank —
+	// the pre-existing behavior for that class is unchanged.
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", "wf-gone"); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updated, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != "" {
+		t.Fatalf("gc.routed_to = %q, want blank (no run_target, no prior route)", got)
 	}
 	if updated.Status != "open" {
 		t.Fatalf("status = %q, want open", updated.Status)


### PR DESCRIPTION
## Summary

`cmdWorkflowReopenSource` blanks a bead's `gc.routed_to` whenever `gc.run_target` is
empty. The comment directly above that line already documents why a blank route is
harmful — and then the code falls back to blank anyway, for backward compatibility.

This changes the fallback: when `gc.run_target` is empty, keep the route the bead
already carries. Three lines of logic.

## The code on main

`cmd/gc/cmd_convoy_dispatch.go` (main @ bccc52f61):

```go
// A blank gc.routed_to is invisible to route-reclaim (which only heals
// set-but-dead/stuck routes) and causes unrouted-feeder to mis-route to the rig
// planner instead of the correct next step, so an unset route orphans the bead if
// the re-sling fails to land.
//
// When gc.run_target is empty (legacy beads created before the field was stamped),
// we fall back to blank for backward compatibility.
nextRoute := strings.TrimSpace(currentSource.Metadata[beadmeta.RunTargetMetadataKey])
```

The comment states the harm precisely. The backward-compatibility fallback is what
delivers it.

## Why blanking is the harmful branch

Re-pooling a bead takes two separate commands: the caller writes the route with
`gc bd update`, then calls reopen-source. Blanking makes that pair order-dependent —
a reopen landing after the route write silently erases it.

The bead then *looks* correctly re-pooled: rejection metadata set, branch intact,
status open. But it is invisible to pool-demand dispatch, which filters on
`gc.routed_to`. And nothing heals it — `restoreCarriedWorkRoutes` can only recover a
route from `gc.run_target`, which plain work beads never carry. The bead sits until a
human re-slings it by hand.

## Backward compatibility is preserved

A legacy bead carrying neither `gc.run_target` nor `gc.routed_to` still ends blank —
the stated goal of the original fallback is untouched. The change only affects beads
that actually had a route to lose. Falling back to the existing route is strictly
safer than falling back to blank.

Preserving also costs the caller nothing: a re-sling to a different target overwrites
the route, and one to the same target still re-runs finalize via
`resolveConvoyRecovery`, which sees the just-deleted workflow rather than
short-circuiting as idempotent.

## Field evidence

Plain standalone work beads never carry `gc.run_target` — 0 of 40 sampled on our
city — so for that entire class the reopen *always* blanked the route. We had a P1
sit stranded for 35+ minutes, invisible to pool-demand dispatch, until a human
re-slung it manually.

## Relationship to existing PRs — checked, not assumed

- **Not a duplicate of merged #4165** ("re-read live bead before re-stamping
  `gc.routed_to`"). That fix is on the dispatch path; this is `reopen-source`, a
  different call site with a different failure mode.
- **Complementary to open #4498** ("treat leaked `routed_to="null"` literal as
  unrouted"). #4498 touches `cmd/gc/cmd_hook_claim.go` and hardens how a bad route is
  *read* at claim time. This touches `cmd/gc/cmd_convoy_dispatch.go` and prevents a
  good route from being *erased* at reopen. No file overlap; different points on the
  same `gc.routed_to` lifecycle.

## Testing

Against `upstream/main` @ bccc52f61, exactly one commit on the branch:

- `go build ./cmd/gc/` — clean
- `go vet ./cmd/gc/` — clean
- `go test ./cmd/gc/ -run TestCmdWorkflowReopenSource` — 5/5 pass (4.5s), including new
  coverage for the preserve path and for the legacy blank-fallback case
- `go test ./internal/testpolicy/resourcecensus/` — passes; no ratchet needed

Test runtimes are sub-second and load-insensitive.
