### PR TITLE
fix(suspend): align the awake-set gate with the desired-state rig resolver

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -342,7 +342,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		return 1
 	}
 
-	if isAgentEffectivelySuspendedWith(cfg, &a, st) {
+	if isAgentEffectivelySuspendedWith(cfg, cityPath, &a, st) {
 		fmt.Fprintf(stderr, "gc hook: agent %q is suspended\n", agentName) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -224,30 +224,37 @@ func effectiveCitySuspended(cfg *config.City, st suspensionstate.State) bool {
 // [isAgentEffectivelySuspendedWith] to avoid the per-call disk read.
 func isAgentEffectivelySuspended(cfg *config.City, a *config.Agent) bool {
 	cityPath, _ := resolveCity()
-	return isAgentEffectivelySuspendedWith(cfg, a, loadSuspensionStateBestEffort(cityPath))
+	return isAgentEffectivelySuspendedWith(cfg, cityPath, a, loadSuspensionStateBestEffort(cityPath))
 }
 
 // isAgentEffectivelySuspendedWith is like isAgentEffectivelySuspended
 // but takes a pre-loaded runtime state so callers in hot paths don't
 // re-read the file.
-func isAgentEffectivelySuspendedWith(cfg *config.City, a *config.Agent, st suspensionstate.State) bool {
+//
+// The agent's rig is resolved path-aware via configuredRigName — the same
+// resolver the desired-state build uses (agentInSuspendedRig). Matching the
+// rig by name only (a.Dir == rig.Name) missed rig-bound agents whose Dir is a
+// filesystem path rather than the bare rig name — notably third-party-pack
+// agents bound through a dir override. For those, the desired-state build
+// (path-aware) dropped the session while this gate (name-only) reported the
+// agent awake, so a suspended rig never quiesced them: it drained and re-woke
+// each tick. Keeping the two gates on the same resolver closes that gap.
+func isAgentEffectivelySuspendedWith(cfg *config.City, cityPath string, a *config.Agent, st suspensionstate.State) bool {
 	if effectiveCitySuspended(cfg, st) {
 		return true
 	}
 	if a.Suspended {
 		return true
 	}
-	if a.Dir == "" {
+	rigName := configuredRigName(cityPath, a, cfg.Rigs)
+	if rigName == "" {
 		return false
 	}
 	for i := range cfg.Rigs {
-		if cfg.Rigs[i].Name != a.Dir {
+		if cfg.Rigs[i].Name != rigName {
 			continue
 		}
-		if suspensionstate.EffectiveRigSuspended(st, cfg.Rigs[i].Name, cfg.Rigs[i].EffectiveSuspendedOnStart()) {
-			return true
-		}
-		break
+		return suspensionstate.EffectiveRigSuspended(st, cfg.Rigs[i].Name, cfg.Rigs[i].EffectiveSuspendedOnStart())
 	}
 	return false
 }

--- a/cmd/gc/cmd_suspend_test.go
+++ b/cmd/gc/cmd_suspend_test.go
@@ -272,7 +272,7 @@ func TestAgentEffectivelySuspendedDirect(t *testing.T) {
 		Workspace: config.Workspace{Name: "test"},
 		Agents:    []config.Agent{{Name: "worker", Suspended: true}},
 	}
-	if !isAgentEffectivelySuspendedWith(cfg, &cfg.Agents[0], suspensionstate.State{}) {
+	if !isAgentEffectivelySuspendedWith(cfg, "", &cfg.Agents[0], suspensionstate.State{}) {
 		t.Error("agent with Suspended=true should be effectively suspended")
 	}
 }
@@ -283,8 +283,31 @@ func TestAgentEffectivelySuspendedViaRig(t *testing.T) {
 		Agents:    []config.Agent{{Name: "polecat", Dir: "myrig"}},
 		Rigs:      []config.Rig{{Name: "myrig", Path: "/tmp/myrig", SuspendedOnStart: true}},
 	}
-	if !isAgentEffectivelySuspendedWith(cfg, &cfg.Agents[0], suspensionstate.State{}) {
+	if !isAgentEffectivelySuspendedWith(cfg, "", &cfg.Agents[0], suspensionstate.State{}) {
 		t.Error("agent in rig with suspended_on_start=true should be effectively suspended")
+	}
+}
+
+// TestAgentEffectivelySuspendedViaRigDirPath verifies that an agent whose Dir
+// is a filesystem path pointing at the rig root — rather than the literal rig
+// name — is still recognized as rig-suspended. Third-party-pack agents bound
+// into a rig through a dir override carry a path-form Dir, so name-only rig
+// matching missed them: a suspended rig kept waking them even though the
+// desired-state build (which resolves the rig path-aware, via agentInSuspendedRig)
+// had already dropped them, producing the start/drain wake loop. The awake-set
+// gate must resolve the rig the same path-aware way the desired-state build does.
+func TestAgentEffectivelySuspendedViaRigDirPath(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Agents: []config.Agent{{
+			Name:        "cashtuner",
+			BindingName: "qa-wonks",
+			Dir:         "/tmp/myrig", // the rig PATH, not the rig NAME
+		}},
+		Rigs: []config.Rig{{Name: "myrig", Path: "/tmp/myrig", SuspendedOnStart: true}},
+	}
+	if !isAgentEffectivelySuspendedWith(cfg, "", &cfg.Agents[0], suspensionstate.State{}) {
+		t.Error("agent whose Dir is the suspended rig's path should be effectively suspended")
 	}
 }
 
@@ -293,7 +316,7 @@ func TestAgentEffectivelySuspendedViaCity(t *testing.T) {
 		Workspace: config.Workspace{Name: "test", SuspendedOnStart: true},
 		Agents:    []config.Agent{{Name: "worker"}},
 	}
-	if !isAgentEffectivelySuspendedWith(cfg, &cfg.Agents[0], suspensionstate.State{}) {
+	if !isAgentEffectivelySuspendedWith(cfg, "", &cfg.Agents[0], suspensionstate.State{}) {
 		t.Error("agent in city with suspended_on_start=true should be effectively suspended")
 	}
 }
@@ -303,7 +326,7 @@ func TestAgentEffectivelySuspendedNot(t *testing.T) {
 		Workspace: config.Workspace{Name: "test"},
 		Agents:    []config.Agent{{Name: "worker"}},
 	}
-	if isAgentEffectivelySuspendedWith(cfg, &cfg.Agents[0], suspensionstate.State{}) {
+	if isAgentEffectivelySuspendedWith(cfg, "", &cfg.Agents[0], suspensionstate.State{}) {
 		t.Error("non-suspended agent should not be effectively suspended")
 	}
 }
@@ -324,7 +347,7 @@ func TestSuspendInheritance(t *testing.T) {
 	}
 	for i := range cfg.Agents {
 		a := &cfg.Agents[i]
-		if !isAgentEffectivelySuspendedWith(cfg, a, suspensionstate.State{}) {
+		if !isAgentEffectivelySuspendedWith(cfg, "", a, suspensionstate.State{}) {
 			t.Errorf("agent %q should be suspended when city has suspended_on_start=true", a.QualifiedName())
 		}
 	}

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -50,7 +50,7 @@ func buildAwakeInputFromReconciler(
 		a := &cfg.Agents[i]
 		agent := AwakeAgent{
 			QualifiedName:     a.QualifiedName(),
-			Suspended:         isAgentEffectivelySuspendedWith(cfg, a, suspState),
+			Suspended:         isAgentEffectivelySuspendedWith(cfg, cityPath, a, suspState),
 			SleepAfterIdle:    parseSleepDuration(a.SleepAfterIdle),
 			MinActiveSessions: a.EffectiveMinActiveSessions(),
 		}

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -2068,7 +2068,7 @@ func TestNamedAlways_SuspensionPropagation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &tt.cfg.Agents[0]
-			if !isAgentEffectivelySuspendedWith(&tt.cfg, a, suspensionstate.State{}) {
+			if !isAgentEffectivelySuspendedWith(&tt.cfg, "", a, suspensionstate.State{}) {
 				t.Fatalf("expected agent to be effectively suspended")
 			}
 			qn := a.QualifiedName()

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -308,7 +308,7 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 			continue
 		}
 		seen[qn] = true
-		if isAgentEffectivelySuspendedWith(cfg, a, suspState) {
+		if isAgentEffectivelySuspendedWith(cfg, cityDir, a, suspState) {
 			continue
 		}
 		probeEnv, err := controllerQueryRuntimeEnv(cityDir, cfg, a)


### PR DESCRIPTION
## Summary

`gc rig suspend <rig>` does not quiesce a rig-bound agent whose `Dir` is a filesystem
path rather than the bare rig name. The agent's session start/drain-flaps every 1–2
minutes, indefinitely.

The cause is that two gates decide "is this agent in a suspended rig?", and on `main`
they resolve the agent's rig with **two different resolvers**.

## Two gates, two resolvers

**Path-aware** — the desired-state build, `cmd/gc/build_desired_state.go:4549`:

```go
func agentInSuspendedRig(cityPath string, cfgAgent *config.Agent, rigs []config.Rig, suspendedRigPaths map[string]bool) bool {
	rigName := configuredRigName(cityPath, cfgAgent, rigs)
	...
}
```

**Name-only** — the awake-set gate, `cmd/gc/cmd_suspend.go:233`:

```go
func isAgentEffectivelySuspendedWith(cfg *config.City, a *config.Agent, st suspensionstate.State) bool {
	...
	if a.Dir == "" {
		return false
	}
	for i := range cfg.Rigs {
		if cfg.Rigs[i].Name != a.Dir {   // :244 — bare name comparison
			continue
		}
```

An agent bound through a dir override carries a path-form `Dir`, so the name-only
comparison never matches. The desired-state build (path-aware) drops the session, while
the awake set (name-only) keeps `poolDesired=1` and immediately re-wakes it. The two
gates disagree forever, and the session flaps.

## The fix

Make the awake-set gate use `configuredRigName` — the resolver the desired-state build
already uses. This is **making two existing gates agree, not new behavior**, which is
why the diff is small: one added parameter, one changed comparison, four call sites
updated to thread `cityPath`.

## Why this matters beyond the flap

`gc rig suspend` is currently unreliable for **any** agent whose `Dir` is a path rather
than a rig name — which is every third-party-pack agent bound via dir override.

## Relationship to open #4001 — complementary, and it is why this is worth landing

Open PR #4001 ("don't preserve named session beads for suspended rigs") adds new
suspended-rig behavior in `cmd/gc/session_beads.go`, gated on:

```go
if isAgentEffectivelySuspendedWith(cfg, spec.Agent, suspState) {
	return false
}
```

That is **this same name-only resolver**. So #4001's new suppression inherits the same
blind spot: it silently misses every agent whose `Dir` is a path form. The two PRs do
not overlap (no shared files — #4001 touches `session_beads.go` and
`session_reconciler.go`; this touches `cmd_suspend.go`, `cmd_hook.go`,
`compute_awake_bridge.go`, `session_reconcile.go`). They compose: this PR fixes the
shared resolver #4001 is built on, so #4001's suppression becomes correct for that class
of agent too.

Landing order does not matter — the signature change is mechanical either way.

## Testing

Against `upstream/main` @ bccc52f61, exactly one commit on the branch:

- `go build ./cmd/gc/` — clean
- `go vet ./cmd/gc/` — clean
- `go test ./cmd/gc/ -run 'TestAgentEffectivelySuspended|TestSuspendInheritance|TestNamedAlways_SuspensionPropagation|TestCitySuspended|TestSuspendResume'`
  — 12/12 pass (4.3s), including a new `TestAgentEffectivelySuspendedViaRigDirPath`
  covering the path-form `Dir` case
- Full `make test-fast-parallel` ran as the push gate on this branch: **all fast jobs passed**

These assertions are in-memory and timing-independent.
