### PR TITLE
fix(core): make mol-do-work drain step provider-agnostic (GC_BEAD_ID → GC_TRIGGER_BEAD_ID fallback)

### DIFF
--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -142,8 +142,9 @@ Work is done. Close this drain step, then signal the controller to reclaim this
 session:
 
 ```bash
-if [ -n "${GC_BEAD_ID:-}" ]; then
-  gc bd update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Drain acknowledged."
+DRAIN_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-}}"
+if [ -n "$DRAIN_BEAD_ID" ]; then
+  gc bd update "$DRAIN_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Drain acknowledged."
 fi
 gc runtime drain-ack
 ```


### PR DESCRIPTION
## What

The `mol-do-work` drain step self-closes its bead only when `$GC_BEAD_ID` is set. The **claude provider never exports `GC_BEAD_ID`** — it exports `GC_TRIGGER_BEAD_ID` (and `GC_TRIGGER_WORK_BEAD_ID`). So under the claude provider the drain guard is always false.

**Impact:** the drain bead stays `open`, the downstream `workflow-finalize` step (which `needs` it) never fires, and the whole molecule wedges `in_progress` forever — unless an operator notices the unset var and substitutes the id by hand.

## Fix

Fall back to `GC_TRIGGER_BEAD_ID` when `GC_BEAD_ID` is unset:

```bash
DRAIN_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-}}"
```

Smallest, provider-agnostic change; no provider-contract change required.

## Why it's safe

`GC_TRIGGER_BEAD_ID` is set per session from the session's own `TriggerBeadID` (`cmd/gc/build_desired_state.go:3073-3078`). Each molecule step is its own session bead, so for the drain step `GC_TRIGGER_BEAD_ID` names the **drain bead itself** — the exact bead the guard intends to close. Verified empirically: during drain step `ga-kw0y`, `env | grep ^GC_` showed `GC_TRIGGER_BEAD_ID=ga-kw0y` with `GC_BEAD_ID` unset.

## Scope

- Only `mol-do-work.toml` carries this drain prose; siblings `mol-polecat-*` do not (grep confirmed) — one-file fix.
- The `do-work` step (line ~122) has a structurally similar `$GC_BEAD_ID` guard but a different purpose (wrapper-bead close, with a `!= WORK_BEAD_ID` sibling condition) and no repro attached. Left unchanged here to keep the PR scoped to the confirmed break.

## Acceptance

- A `mol-do-work` run under the claude provider ends with its drain bead **closed** without manual id substitution.
- The molecule root reaches `closed` (`workflow-finalize` fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)