### PR TITLE
fix(paths): route discovery + store-scope through the single path normalizer

### DIFF
--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 type cityDiscoveryOptions struct {
@@ -35,7 +36,12 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 			// cityPath-derived store scopes fail the native-store identity
 			// gate ("database project_id could not be confirmed") and every
 			// command degrades to the bd-subprocess fallback.
-			if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			// Normalize through pathutil rather than bare EvalSymlinks: the
+			// latter leaves the darwin /private alias in place, so a city
+			// discovered from an already-canonical /var path would be
+			// reported as /private/var and fail identity comparisons against
+			// the very path it was found from.
+			if resolved := pathutil.NormalizePathForCompare(dir); resolved != "" {
 				return resolved, nil
 			}
 			return dir, nil
@@ -149,31 +155,19 @@ func normalizeDiscoveryPath(path string) string {
 	if path == "" {
 		return ""
 	}
-	abs, err := filepath.Abs(path)
-	if err == nil {
-		path = abs
-	}
 	// Resolve symlinks so ceiling comparisons match regardless of how the
 	// path was obtained: on macOS, t.Chdir/os.Getwd can yield /tmp/... while
 	// the same directory resolves to /private/tmp/..., and comparing the two
 	// raw forms silently defeats the ceiling. Both the walked directory and
 	// the configured ceilings flow through here, so resolution stays
-	// symmetric. For paths that do not (fully) exist, resolve the longest
-	// existing ancestor and re-append the remainder, so a configured-but-
-	// not-yet-created ceiling still normalizes consistently instead of
-	// silently dropping out of the comparison.
-	path = filepath.Clean(path)
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return filepath.Clean(resolved)
-	}
-	dir, rest := path, ""
-	for dir != string(filepath.Separator) && dir != "." {
-		parent := filepath.Dir(dir)
-		rest = filepath.Join(filepath.Base(dir), rest)
-		dir = parent
-		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
-			return filepath.Clean(filepath.Join(resolved, rest))
-		}
-	}
-	return path
+	// symmetric. For paths that do not (fully) exist, the normalizer resolves
+	// the longest existing ancestor and re-appends the remainder, so a
+	// configured-but-not-yet-created ceiling still normalizes consistently
+	// instead of silently dropping out of the comparison.
+	//
+	// pathutil is the single normalizer: it additionally collapses the darwin
+	// /private alias, which bare EvalSymlinks does not. Resolving without that
+	// collapse turns an already-canonical /var input into /private/var output,
+	// so two paths naming one directory compare unequal.
+	return pathutil.NormalizePathForCompare(path)
 }

--- a/cmd/gc/city_discovery_symlink_test.go
+++ b/cmd/gc/city_discovery_symlink_test.go
@@ -26,11 +26,11 @@ func TestNormalizeDiscoveryPathResolvesExistingSymlink(t *testing.T) {
 		t.Skipf("symlinks unsupported on this platform: %v", err)
 	}
 
-	resolved, err := filepath.EvalSymlinks(realDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Clean(resolved)
+	// Expectation derived with the production normalizer rather than bare
+	// EvalSymlinks, which on darwin returns the /private alias of a path
+	// already canonical as /var. Comparison stays exact: if resolution stopped
+	// happening, got would still be the .../link path and fail.
+	want := canonicalTestPath(realDir)
 
 	if got := normalizeDiscoveryPath(link); got != want {
 		t.Errorf("normalizeDiscoveryPath(%q) = %q, want resolved real path %q", link, got, want)
@@ -59,11 +59,8 @@ func TestNormalizeDiscoveryPathFallsBackToLongestExistingAncestor(t *testing.T) 
 	// comparison because EvalSymlinks failed on the leaf.
 	missing := filepath.Join(link, "not", "yet", "created")
 
-	resolved, err := filepath.EvalSymlinks(realDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(filepath.Clean(resolved), "not", "yet", "created")
+	// See the sibling test: normalizer-derived expectation, exact comparison.
+	want := filepath.Join(canonicalTestPath(realDir), "not", "yet", "created")
 
 	if got := normalizeDiscoveryPath(missing); got != want {
 		t.Errorf("normalizeDiscoveryPath(%q) = %q, want %q", missing, got, want)
@@ -90,11 +87,16 @@ func TestFindCityResolvesSymlinkedCityDir(t *testing.T) {
 		t.Skipf("symlinks unsupported on this platform: %v", err)
 	}
 
-	resolved, err := filepath.EvalSymlinks(realCity)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Clean(resolved)
+	// Derive the expectation with the same normalizer production uses, not bare
+	// EvalSymlinks: on darwin EvalSymlinks alone yields the /private alias of a
+	// path already canonical as /var, so a correct resolution would still be
+	// reported as a mismatch.
+	//
+	// Deliberately compared with exact equality rather than assertSameTestPath.
+	// Canonicalizing both sides would also resolve the link itself, so the
+	// assertion would hold even if findCity returned the unresolved link path —
+	// which is the exact regression this test exists to catch.
+	want := canonicalTestPath(realCity)
 
 	got, err := findCity(link)
 	if err != nil {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/rollout/gate"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
@@ -1480,13 +1481,17 @@ func resolveStoreScopeRoot(cityPath, storePath string) string {
 	if !filepath.IsAbs(scopeRoot) {
 		scopeRoot = filepath.Join(cityPath, scopeRoot)
 	}
-	scopeRoot = filepath.Clean(scopeRoot)
 	// Resolve symlinks so a city reached through a linked path (e.g. ~/gc ->
 	// /real/city) yields the same scope root as the real path. Without this the
 	// native-store identity gate sees an unregistered scope and rejects it
 	// ("database project_id could not be confirmed"), silently degrading to the
 	// bd-subprocess fallback.
-	if resolved, err := filepath.EvalSymlinks(scopeRoot); err == nil {
+	//
+	// Normalize through pathutil, not bare EvalSymlinks: pathutil also collapses
+	// the darwin /private alias. Resolving without that collapse maps an
+	// already-canonical /var city path to a /private/var scope root, so the
+	// scope no longer matches the city it was derived from.
+	if resolved := pathutil.NormalizePathForCompare(scopeRoot); resolved != "" {
 		scopeRoot = resolved
 	}
 	return scopeRoot


### PR DESCRIPTION
Fixes a cross-platform path-identity bug that makes **30 `cmd/gc` tests fail on darwin** (48 -> 18 in the package, 0 regressions), and removes a duplicated normalizer.

## Root cause

`findCity`, `normalizeDiscoveryPath` and `resolveStoreScopeRoot` each resolve symlinks with bare `filepath.EvalSymlinks`.

`internal/pathutil.NormalizePathForCompare` already resolves symlinks **and then** collapses the darwin `/private` alias (`canonicalizePlatformPathAlias`). `EvalSymlinks` alone does only the first half — so a path already canonical as `/var` comes back as `/private/var`, and two names for one directory compare unequal:

```
findCity(".../001") = "/private/var/.../001", want "/var/.../001"
```

The user-visible consequence is not cosmetic: a city discovered from `/var/…` is reported at `/private/var/…` and then fails the **native-store identity gate it was derived from** ("database project_id could not be confirmed"), silently degrading to the bd-subprocess fallback. Store scope roots stop matching their own city the same way.

## Also: one normalizer, not two

`normalizeDiscoveryPath` was a hand-rolled copy of the normalizer — the same resolve-longest-existing-ancestor-and-re-append logic as pathutil's `normalizeMissingPath`, minus the alias collapse. It now delegates, so the tree holds one normalizer instead of two that disagree.

The existing comments already described the intended behaviour correctly; only the implementation was incomplete. Symlink resolution is fully preserved — that intent is deliberate (linked city dirs) and still covered.

## Why CI is green today

On Linux `/tmp` and `/var` are real directories, so `EvalSymlinks` and the normalizer agree. The bug is invisible to Linux CI and reproduces on any darwin checkout.

## About the three test changes

Three tests derived expectations with bare `EvalSymlinks` and so encoded the same bug. They now derive from the normalizer.

Deliberately **not** switched to `assertSameTestPath`: canonicalizing both sides would also resolve the link under test, so the assertion would still pass if resolution stopped happening entirely — silently gutting the exact regression those tests exist to catch. Comparisons stay exact; only the expectation derivation changed.

Verified by disabling resolution in the production path and confirming all three still fail.

## Scope

The remaining 18 darwin failures are a different family (`TestReapClosedBeadWorktrees_*`, failing `Protected = []`, zero `/private` references). Unrelated to path normalization and deliberately not bundled here.

Verified on this branch (based on `main`): `go build` clean, `go vet` clean, affected tests green, failure sets diffed before/after with 0 new failures.