### PR TITLE
fix(api): stop suspended rigs making /status permanently partial

### DIFF
--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -146,9 +146,18 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 	var rawRunning int
 	agentDetails := make([]StatusAgentDetail, 0, len(cfg.Agents))
 	suspendedRigs := make(map[string]bool, len(cfg.Rigs))
+	// cacheColdRigs mirrors the controller's per-rig cache refresh gate
+	// (rigStoreBackgroundRefresh): a rig suspended by EFFECTIVE state gets no
+	// async full prime and no reconciler, so its cache never reaches live and
+	// the cache-only Ready projection can never answer. It is deliberately not
+	// the same set as suspendedRigs, which grows below to include rigs merely
+	// inferred suspended because every one of their agents is — those keep a
+	// refreshing cache and must still be asked for ready work.
+	cacheColdRigs := make(map[string]bool, len(cfg.Rigs))
 	for _, r := range cfg.Rigs {
 		if suspensionstate.EffectiveRigSuspended(citySt, r.Name, r.EffectiveSuspendedOnStart()) {
 			suspendedRigs[r.Name] = true
+			cacheColdRigs[r.Name] = true
 		}
 	}
 	perRigAgentTotals := make(map[string]int, len(cfg.Rigs))
@@ -247,7 +256,7 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 	var wc workCounts
 	if !lite {
 		var workErrs []string
-		wc, workErrs = s.statusWorkCounts(ctx)
+		wc, workErrs = s.statusWorkCounts(ctx, cacheColdRigs)
 		partialErrors = append(partialErrors, workErrs...)
 	}
 
@@ -577,7 +586,14 @@ type statusWorkResult struct {
 // beads.Counter answer persisted counts without hydrating rows — the caching
 // layer counts matches in memory when its cache is clean (#1896). Stores are
 // queried concurrently; results aggregate in deterministic city/rig order.
-func (s *Server) statusWorkCounts(ctx context.Context) (workCounts, []string) {
+//
+// Rigs in cacheColdRigs are asked for persisted counts but not for ready work.
+// Their store runs no background cache refresh, so the cache-only Ready
+// projection is guaranteed to decline with ErrCacheUnavailable — reporting that
+// as a partial error made every city with a suspended rig permanently partial,
+// which greys out unrelated status tiles in the dashboard. Skipping the read
+// changes no count: the failing read already contributed zero ready work.
+func (s *Server) statusWorkCounts(ctx context.Context, cacheColdRigs map[string]bool) (workCounts, []string) {
 	stores := s.state.BeadStores()
 	// sortedRigNames deduplicates rigs sharing one store instance, so each
 	// store's persisted statuses are counted exactly once.
@@ -602,7 +618,7 @@ func (s *Server) statusWorkCounts(ctx context.Context) (workCounts, []string) {
 			label:         "rig " + rigName,
 			store:         stores[rigName],
 			includeStored: true,
-			includeReady:  rigName != cityName,
+			includeReady:  rigName != cityName && !cacheColdRigs[rigName],
 		})
 	}
 

--- a/internal/api/handler_status_suspended_ready_test.go
+++ b/internal/api/handler_status_suspended_ready_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// coldCacheStore models a rig store whose cache runs no background refresh:
+// persisted counts answer normally, but the cache-only Ready projection always
+// declines with ErrCacheUnavailable, exactly as CachingStore.ReadyContext does
+// for a store that never reached cacheLive.
+type coldCacheStore struct {
+	beads.Store
+	readyCalls atomic.Int32
+}
+
+func (c *coldCacheStore) ReadyContext(context.Context, ...beads.ReadyQuery) ([]beads.Bead, error) {
+	c.readyCalls.Add(1)
+	return nil, fmt.Errorf("reading complete ready projection from cache: %w", beads.ErrCacheUnavailable)
+}
+
+func newColdCacheRigState(t *testing.T) (*fakeState, *coldCacheStore) {
+	t.Helper()
+	backing := beads.NewMemStore()
+	if _, err := backing.Create(beads.Bead{Type: "task", Title: "rig work", Status: "open"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cold := &coldCacheStore{Store: backing}
+	state := newFakeState(t)
+	state.stores = map[string]beads.Store{"myrig": cold}
+	state.cityBeadStore = nil
+	return state, cold
+}
+
+// TestStatusWorkCountsSkipsReadyForCacheColdRigs is the regression for the
+// permanently-partial status bug: a suspended rig gets no background cache
+// refresh (rigStoreBackgroundRefresh), so its cache-only Ready read can never
+// succeed. Asking anyway made /status report partial: true forever, which the
+// dashboard renders by grey-dotting every systems tile — dolt store, mail and
+// agents alike — even though all of them are healthy.
+func TestStatusWorkCountsSkipsReadyForCacheColdRigs(t *testing.T) {
+	state, cold := newColdCacheRigState(t)
+	s := &Server{state: state}
+
+	wc, errs := s.statusWorkCounts(context.Background(), map[string]bool{"myrig": true})
+
+	if len(errs) != 0 {
+		t.Fatalf("partial errors = %v, want none for a cache-cold rig", errs)
+	}
+	if got := cold.readyCalls.Load(); got != 0 {
+		t.Errorf("ready reads = %d, want 0 — the read is known to fail, so it must be skipped", got)
+	}
+	if wc.Open != 1 {
+		t.Errorf("Open = %d, want 1 — persisted counts must still be collected", wc.Open)
+	}
+	if wc.Ready != 0 {
+		t.Errorf("Ready = %d, want 0 — a cache-cold rig contributes no ready work", wc.Ready)
+	}
+}
+
+// TestStatusWorkCountsStillReportsReadyFailureForRefreshingRigs pins the other
+// half: when a rig is NOT cache-cold, a declining Ready read is a genuine
+// problem and must still surface as a partial error. The fix must not silence
+// cache failures on rigs whose cache is supposed to be live.
+func TestStatusWorkCountsStillReportsReadyFailureForRefreshingRigs(t *testing.T) {
+	state, cold := newColdCacheRigState(t)
+	s := &Server{state: state}
+
+	_, errs := s.statusWorkCounts(context.Background(), nil)
+
+	if len(errs) != 1 {
+		t.Fatalf("partial errors = %v, want exactly 1", errs)
+	}
+	if !strings.Contains(errs[0], "rig myrig work ready:") {
+		t.Errorf("partial error = %q, want it to name the rig's ready read", errs[0])
+	}
+	if got := cold.readyCalls.Load(); got != 1 {
+		t.Errorf("ready reads = %d, want 1 — a refreshing rig must still be asked", got)
+	}
+}


### PR DESCRIPTION
## Problem

A city with **any** effectively-suspended rig reports `partial: true` on every `/v0/city/{city}/status` call, permanently.

The chain:

1. `rigStoreBackgroundRefresh` (`cmd/gc/api_state.go`) deliberately skips the async full prime and the reconciler for suspended rigs — reconciling idle rigs every cycle is pure cost (the #1978 follow-up). Their `CachingStore` therefore never leaves `cachePartial`.
2. `statusWorkCounts` (`internal/api/handler_status.go`) asks **every** rig for ready work regardless: `includeReady: rigName != cityName`.
3. That read is strictly cache-only — `CachingStore.ReadyContext` → `cachedReadyCompleteOnly`, which requires `cacheLive` and has no live fallback — so for those rigs it always returns `ErrCacheUnavailable`.
4. `statusStoreWorkCountsFor` records it as a partial error, and the body is marked partial.

So the API reports a degraded read for a condition the controller intentionally created.

## User-visible impact

The dashboard collapses the whole thing into one flag:

```js
const f = stale ? "stale" : status.partial ? "partial" : null
```

…and applies it to the dolt-store, mail **and** agents tiles alike. All three go grey with `partial · last reported <the real value>` while being perfectly healthy. Only the live-feed tile escapes, because it reads SSE state instead.

## Reproduction

Observed on a real 4-rig city with 3 rigs suspended:

```json
"partial": true,
"partial_errors": [
  "rig sbf work ready: reading complete ready projection from cache: bead cache unavailable",
  "rig scloud_manual work ready: ... bead cache unavailable",
  "rig socratecloud_erp_full work ready: ... bead cache unavailable"
]
```

The three names are exactly the suspended rigs; the one live rig is absent. A sibling city on the same binary with zero suspended rigs has no `partial` field at all. Resuming the three rigs cleared it immediately, confirming suspension as the sole trigger.

## Fix

Skip the ready read for rigs whose store has no background refresh.

**No count changes** — the skipped read was already failing and contributing zero ready work. This only removes the false partial signal.

The predicate is a **separate set** from `suspendedRigs`, deliberately. `suspendedRigs` is later widened to include rigs merely *inferred* suspended because all of their agents are; those keep a refreshing cache, so reusing that set would silently drop real ready work from the count. `cacheColdRigs` mirrors `rigStoreBackgroundRefresh` exactly (`EffectiveRigSuspended` only).

## Tests

Two, covering both directions:

- `TestStatusWorkCountsSkipsReadyForCacheColdRigs` — a cache-cold rig produces no partial error, its ready read is never attempted, and its persisted counts still land.
- `TestStatusWorkCountsStillReportsReadyFailureForRefreshingRigs` — a rig that is *not* cache-cold still surfaces a declining ready read as a partial error, so this isn't "silence cache failures."

Verified not false-green: with the guard reverted, the first test fails on the exact production error string.

`go test ./internal/api/` passes in full (103s); `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
