### PR TITLE
fix(provider): skip startup-dialog polling for OpenCode

### DIFF
--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -109,6 +109,7 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 			wantPromptFlag:        "--prompt",
 			wantReadyDelayMs:      8000,
 			wantProcessNames:      []string{"opencode", "node", "bun"},
+			wantAcceptDialogs:     phase2BoolPtr(false),
 			wantModelOverride:     "opencode/deepseek-v4-flash-free",
 			wantModelOverrideArgs: []string{"--model", "opencode/deepseek-v4-flash-free"},
 		},

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -313,6 +313,9 @@ func TestBuiltinProvidersOpenCode(t *testing.T) {
 	if p.ReadyDelayMs != 8000 {
 		t.Errorf("ReadyDelayMs = %d, want 8000", p.ReadyDelayMs)
 	}
+	if p.AcceptStartupDialogs == nil || *p.AcceptStartupDialogs {
+		t.Errorf("AcceptStartupDialogs = %v, want false (OpenCode permissions are non-interactive)", p.AcceptStartupDialogs)
+	}
 }
 
 func TestBuiltinProvidersKiro(t *testing.T) {

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -1804,6 +1804,27 @@ func TestResolveProviderBuiltinOpenCodeCustomCommandKeepsACPArgsOnCustomBinary(t
 	}
 }
 
+func TestResolveProviderOpenCodeStartupDialogPolicyInheritedByWrapper(t *testing.T) {
+	base := "builtin:opencode"
+	agent := &Agent{Name: "worker", Provider: "wrapped-opencode"}
+	cityProviders := map[string]ProviderSpec{
+		"wrapped-opencode": {
+			Base: &base,
+		},
+	}
+
+	rp, err := ResolveProvider(agent, nil, cityProviders, lookPathOnly("opencode"))
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	if rp.BuiltinAncestor != "opencode" {
+		t.Fatalf("BuiltinAncestor = %q, want opencode", rp.BuiltinAncestor)
+	}
+	if rp.AcceptStartupDialogs == nil || *rp.AcceptStartupDialogs {
+		t.Fatalf("AcceptStartupDialogs = %v, want false inherited from builtin opencode", rp.AcceptStartupDialogs)
+	}
+}
+
 // --- Tri-state capability bool tests ---
 //
 // These verify the three-way *bool semantics for SupportsHooks,

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -511,20 +511,26 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		ResumeStyle:        "subcommand",
 	},
 	"opencode": {
-		DisplayName:      "OpenCode",
-		Command:          "opencode",
-		Args:             []string{},
-		PromptMode:       "flag",
-		PromptFlag:       "--prompt",
-		ReadyDelayMs:     8000,
-		ProcessNames:     []string{"opencode", "node", "bun"},
-		Env:              map[string]string{"OPENCODE_PERMISSION": `{"*":"allow"}`},
-		SupportsACP:      true,
-		SupportsHooks:    true,
-		InstructionsFile: "AGENTS.md",
-		ResumeFlag:       "--session",
-		ResumeStyle:      "flag",
-		ACPArgs:          []string{"acp"},
+		DisplayName:  "OpenCode",
+		Command:      "opencode",
+		Args:         []string{},
+		PromptMode:   "flag",
+		PromptFlag:   "--prompt",
+		ReadyDelayMs: 8000,
+		ProcessNames: []string{"opencode", "node", "bun"},
+		// OpenCode handles permissions through OPENCODE_PERMISSION and does not
+		// show the Claude/Codex startup dialogs. Without this override, its
+		// process-name hint enables two acceptance passes. Each pass polls
+		// multiple unsupported dialog classes with independent timeouts, so the
+		// first can exhaust the managed startup lease while OpenCode is working.
+		AcceptStartupDialogs: boolPtr(false),
+		Env:                  map[string]string{"OPENCODE_PERMISSION": `{"*":"allow"}`},
+		SupportsACP:          true,
+		SupportsHooks:        true,
+		InstructionsFile:     "AGENTS.md",
+		ResumeFlag:           "--session",
+		ResumeStyle:          "flag",
+		ACPArgs:              []string{"acp"},
 		OptionsSchema: []BuiltinProviderOption{
 			{
 				Key:   "model",


### PR DESCRIPTION
## Summary

- disable Claude/Codex startup-dialog polling for the builtin OpenCode provider
- preserve OpenCode's process detection and eight-second readiness delay
- pin the policy through builtin, wrapper-inheritance, and phase-2 runtime tests

## Problem

`shouldAcceptStartupDialogs` defaults to true when a provider declares process
names. Builtin OpenCode declares `opencode`, `node`, and `bun`, so managed tmux
starts run the shared startup-dialog scanner both before and after readiness.

That scanner recognizes dialogs and ready states from Claude, Codex, Gemini,
and pi, not OpenCode's active full-screen UI. Its timeout is applied per dialog
class. A live OpenCode process executing its `--prompt` work can therefore
consume the outer 60-second session-start lease inside the first scan. The
caller then reports `context deadline exceeded` and cleans up a session that
was already working.

OpenCode is already configured non-interactively with
`OPENCODE_PERMISSION={"*":"allow"}` and does not use any dialog handled by this
scanner. Setting `AcceptStartupDialogs` to false follows the existing
Kimi/Kiro provider pattern and leaves the actual command/process/readiness
checks intact.

## Validation

- `go test ./internal/config ./internal/worker/builtin ./internal/runtime/tmux -count=1`
- `go test ./cmd/gc -run '^TestPhase2StartupMaterialization$/opencode/tmux-cli' -count=1`
- `go test ./cmd/gc -count=1 -parallel=4`
- `go vet ./...`
- `go build ./...`

Live OpenCode 1.18.5 validation reduced managed tmux startup from exhausting
the 60-second lease while actively working to returning successfully in about
14 seconds. The worker then completed claim, work, handoff, and clean drain.
