### PR TITLE
fix(sling): warn when --on skips attach on a claimed, unmoleculed bead

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -174,7 +174,7 @@ func resolveIdempotentShortCircuit(opts SlingOpts, a config.Agent, deps SlingDep
 		NoConvoy: opts.NoConvoy,
 	})
 	if check.Idempotent {
-		needsAttach, probeErr := onFormulaNeedsAttachment(opts, querier, deps)
+		decision, probeErr := onFormulaNeedsAttachment(opts, querier, deps)
 		switch {
 		case probeErr != nil:
 			// The attachment probe failed, so we cannot prove the routed bead
@@ -184,11 +184,21 @@ func resolveIdempotentShortCircuit(opts SlingOpts, a config.Agent, deps SlingDep
 			result.BeadWarnings = append(result.BeadWarnings, fmt.Sprintf(
 				"could not verify molecule attachment for %s; treating --on as an idempotent no-op: %v",
 				opts.BeadOrFormula, probeErr))
-		case needsAttach:
+		case decision.NeedsAttach:
 			// The bead is routed to the target but carries no molecule — an
 			// earlier plain sling routed it raw. Do not treat --on as an
 			// idempotent no-op; fall through so the formula attaches.
 			check.Idempotent = false
+		case decision.SkippedForClaim:
+			// Another worker already claimed this bead and no molecule is
+			// attached. Idempotency is preserved deliberately (do not re-attach
+			// onto in-progress work), but say so explicitly: without this
+			// warning the CLI prints only the generic "already routed" message,
+			// giving no signal that the requested --on formula was never
+			// attached or that --force would override the skip.
+			result.BeadWarnings = append(result.BeadWarnings, fmt.Sprintf(
+				"bead %s is claimed by %s with no molecule attached; --on %s was skipped to avoid re-attaching onto in-progress work — rerun with --force to attach it anyway",
+				opts.BeadOrFormula, decision.Assignee, opts.OnFormula))
 		}
 	}
 	if !check.Idempotent {
@@ -253,6 +263,22 @@ func shouldCheckBeadState(opts SlingOpts) bool {
 	return !opts.IsFormula && !opts.Force && (!opts.DryRun || !opts.InlineText)
 }
 
+// attachmentDecision is the result of onFormulaNeedsAttachment: whether an
+// --on formula attach should proceed on an otherwise-idempotent routed bead,
+// and, when it should not, why -- so the caller can distinguish "nothing to
+// do" (a molecule is already attached) from "skipped because another worker
+// owns this bead" (SkippedForClaim), which needs its own warning rather than
+// silently folding into the generic idempotent no-op.
+type attachmentDecision struct {
+	NeedsAttach bool
+	// SkippedForClaim is true when the bead has no molecule but is already
+	// claimed (Assignee set), so the attach was intentionally skipped rather
+	// than performed. Only meaningful when NeedsAttach is false.
+	SkippedForClaim bool
+	// Assignee is the claiming identity when SkippedForClaim is true.
+	Assignee string
+}
+
 // onFormulaNeedsAttachment reports whether this is an --on sling whose target
 // bead the caller has already determined reads Idempotent (gc.routed_to ==
 // target, or pool-labeled) but that has no attached molecule yet. The
@@ -264,29 +290,35 @@ func shouldCheckBeadState(opts SlingOpts) bool {
 // molecule; a stale one is burned).
 //
 // The returned error is non-nil only when the molecule-attachment probe could
-// not complete. In that case the result is (false, err): the caller cannot
-// prove the bead is unmoleculed, so it must preserve the fail-closed idempotent
-// state rather than clear it and risk minting a duplicate attachment.
-func onFormulaNeedsAttachment(opts SlingOpts, querier BeadQuerier, deps SlingDeps) (bool, error) {
+// not complete. In that case the result is (attachmentDecision{}, err): the
+// caller cannot prove the bead is unmoleculed, so it must preserve the
+// fail-closed idempotent state rather than clear it and risk minting a
+// duplicate attachment.
+func onFormulaNeedsAttachment(opts SlingOpts, querier BeadQuerier, deps SlingDeps) (attachmentDecision, error) {
 	if opts.OnFormula == "" {
-		return false, nil
+		return attachmentDecision{}, nil
 	}
 	hasMolecule, err := HasMoleculeChildren(querier, opts.BeadOrFormula, deps.Store)
 	if err != nil {
-		return false, err
+		return attachmentDecision{}, err
 	}
 	if hasMolecule {
-		return false, nil
+		return attachmentDecision{}, nil
 	}
 	// No molecule attached. Only override idempotency for an UNCLAIMED bead — the
 	// routed-raw footgun (gc.routed_to set, no assignee, no molecule). If a worker
 	// has already claimed it (assignee set), leave it idempotent rather than
-	// re-attaching a formula onto work in progress.
+	// re-attaching a formula onto work in progress -- but report the claim so the
+	// caller can warn that the attach was skipped, distinctly from "already done".
 	bead, ok := BeadFromGetters(opts.BeadOrFormula, querier, deps.Store)
 	if !ok {
-		return false, nil
+		return attachmentDecision{}, nil
 	}
-	return strings.TrimSpace(bead.Assignee) == "", nil
+	assignee := strings.TrimSpace(bead.Assignee)
+	if assignee == "" {
+		return attachmentDecision{NeedsAttach: true}, nil
+	}
+	return attachmentDecision{SkippedForClaim: true, Assignee: assignee}, nil
 }
 
 func shouldValidateBuiltInRouteStoreReachable(opts SlingOpts, deps SlingDeps) bool {

--- a/internal/sling/sling_on_idempotency_test.go
+++ b/internal/sling/sling_on_idempotency_test.go
@@ -2,6 +2,7 @@ package sling
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -41,16 +42,18 @@ func TestOnFormulaNeedsAttachment(t *testing.T) {
 	deps := SlingDeps{Store: store}
 
 	// A non---on sling never overrides idempotency.
-	if need, err := onFormulaNeedsAttachment(SlingOpts{BeadOrFormula: routedRaw.ID}, store, deps); need || err != nil {
-		t.Errorf("plain sling: onFormulaNeedsAttachment = (%v, %v), want (false, nil)", need, err)
+	if dec, err := onFormulaNeedsAttachment(SlingOpts{BeadOrFormula: routedRaw.ID}, store, deps); dec.NeedsAttach || err != nil {
+		t.Errorf("plain sling: onFormulaNeedsAttachment = (%+v, %v), want NeedsAttach=false, nil", dec, err)
 	}
 	// --on on a routed-raw (unclaimed, no-molecule) bead must attach (the footgun).
-	if need, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: routedRaw.ID}, store, deps); !need || err != nil {
-		t.Errorf("routed-raw --on: onFormulaNeedsAttachment = (%v, %v), want (true, nil) (no molecule => must attach)", need, err)
+	if dec, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: routedRaw.ID}, store, deps); !dec.NeedsAttach || err != nil {
+		t.Errorf("routed-raw --on: onFormulaNeedsAttachment = (%+v, %v), want NeedsAttach=true, nil (no molecule => must attach)", dec, err)
 	}
 
 	// A CLAIMED bead (assignee set) with no molecule stays idempotent — do not
-	// re-attach onto a worker's in-progress bead.
+	// re-attach onto a worker's in-progress bead. The decision still reports the
+	// claim so the caller can warn instead of silently no-op'ing the requested
+	// formula attach.
 	claimed, err := store.Create(beads.Bead{
 		Type:     "task",
 		Status:   "open",
@@ -60,8 +63,12 @@ func TestOnFormulaNeedsAttachment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create claimed: %v", err)
 	}
-	if need, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: claimed.ID}, store, deps); need || err != nil {
-		t.Errorf("claimed --on: onFormulaNeedsAttachment = (%v, %v), want (false, nil) (worker owns it, stay idempotent)", need, err)
+	dec, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: claimed.ID}, store, deps)
+	if dec.NeedsAttach || err != nil {
+		t.Errorf("claimed --on: onFormulaNeedsAttachment = (%+v, %v), want NeedsAttach=false, nil (worker owns it, stay idempotent)", dec, err)
+	}
+	if !dec.SkippedForClaim || dec.Assignee != "worker" {
+		t.Errorf("claimed --on: onFormulaNeedsAttachment = %+v, want SkippedForClaim=true, Assignee=%q", dec, "worker")
 	}
 }
 
@@ -91,8 +98,8 @@ func TestRoutedRawBeadReadsIdempotentWhichOnFormulaMustOverride(t *testing.T) {
 		t.Fatalf("routed-raw bead: expected Idempotent=true (the footgun), got %+v", res)
 	}
 	// ...and the --on override fires because there is no molecule.
-	if need, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: bead.ID}, store, SlingDeps{Store: store}); !need || err != nil {
-		t.Fatalf("--on override should fire for a routed-raw bead with no molecule: got (%v, %v)", need, err)
+	if dec, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: bead.ID}, store, SlingDeps{Store: store}); !dec.NeedsAttach || err != nil {
+		t.Fatalf("--on override should fire for a routed-raw bead with no molecule: got (%+v, %v)", dec, err)
 	}
 }
 
@@ -107,8 +114,12 @@ func TestOnFormulaNeedsAttachmentMoleculePresentStaysIdempotent(t *testing.T) {
 		{ID: "MOL-1", Type: "molecule", Status: "open", ParentID: "BL-1"},
 	}, nil)
 	deps := SlingDeps{Store: store}
-	if need, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: "BL-1"}, store, deps); need || err != nil {
-		t.Errorf("molecule-present --on: onFormulaNeedsAttachment = (%v, %v), want (false, nil) (has molecule => stay idempotent)", need, err)
+	dec, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: "BL-1"}, store, deps)
+	if dec.NeedsAttach || err != nil {
+		t.Errorf("molecule-present --on: onFormulaNeedsAttachment = (%+v, %v), want NeedsAttach=false, nil (has molecule => stay idempotent)", dec, err)
+	}
+	if dec.SkippedForClaim {
+		t.Errorf("molecule-present --on: onFormulaNeedsAttachment = %+v, want SkippedForClaim=false (molecule already present, not a claim skip)", dec)
 	}
 }
 
@@ -126,11 +137,51 @@ func TestOnFormulaNeedsAttachmentProbeErrorStaysIdempotent(t *testing.T) {
 	store := listErrStore{Store: mem, err: probeErr}
 	deps := SlingDeps{Store: store}
 
-	need, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: "BL-1"}, store, deps)
-	if need {
-		t.Error("probe error: onFormulaNeedsAttachment = true, want false (cannot prove no molecule => fail closed)")
+	dec, err := onFormulaNeedsAttachment(SlingOpts{OnFormula: "code-review", BeadOrFormula: "BL-1"}, store, deps)
+	if dec.NeedsAttach {
+		t.Error("probe error: onFormulaNeedsAttachment NeedsAttach = true, want false (cannot prove no molecule => fail closed)")
 	}
 	if !errors.Is(err, probeErr) {
 		t.Errorf("probe error: onFormulaNeedsAttachment err = %v, want %v surfaced", err, probeErr)
+	}
+}
+
+// When resolveIdempotentShortCircuit stays idempotent specifically because the
+// bead is claimed with no molecule attached, it must say so in a bead warning
+// -- distinct from the generic "already routed" message -- rather than
+// silently returning exit 0 with no indication that the requested --on
+// formula was never attached. This pins ga-juszt2: the prior behavior gave no
+// signal that --force was required to actually attach the formula.
+func TestResolveIdempotentShortCircuitWarnsWhenOnFormulaSkippedForClaim(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{
+			ID:       "BL-1",
+			Type:     "task",
+			Status:   "open",
+			Assignee: "worker",
+			Metadata: map[string]string{"gc.routed_to": "worker"},
+		},
+	}, nil)
+	deps := SlingDeps{Store: store}
+	// NoConvoy: true bypasses the separate convoy-tracking recovery check (a
+	// parentless routed bead would otherwise read as needing finalize to
+	// recreate a missing auto-convoy) so this test isolates the claim-skip
+	// warning path under test rather than that unrelated mechanism.
+	opts := SlingOpts{OnFormula: "mol-tdd-build", BeadOrFormula: "BL-1", Target: config.Agent{Name: "worker"}, NoConvoy: true}
+
+	var result SlingResult
+	shortCircuited := resolveIdempotentShortCircuit(opts, opts.Target, deps, store, &result)
+
+	if !shortCircuited || !result.Idempotent {
+		t.Fatalf("claimed bead, no molecule, --on: expected idempotent short-circuit, got shortCircuited=%v result=%+v", shortCircuited, result)
+	}
+	if len(result.BeadWarnings) != 1 {
+		t.Fatalf("claimed bead, no molecule, --on: want exactly 1 bead warning, got %d: %+v", len(result.BeadWarnings), result.BeadWarnings)
+	}
+	warning := result.BeadWarnings[0]
+	for _, want := range []string{"BL-1", "worker", "mol-tdd-build", "--force"} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("claimed bead, no molecule, --on: warning %q does not mention %q", warning, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `gc sling --on <formula>` on a bead that is already routed+claimed (assignee set) but has no molecule attached correctly stays idempotent (by design, per #4204 — never re-attach onto a worker's in-progress bead), but silently did so: the CLI printed only the generic `"already routed to X — skipping (idempotent)"` message, with no indication the requested formula was never attached or that `--force` would override it.
- `onFormulaNeedsAttachment` now returns a small `attachmentDecision` struct instead of a bare `bool`, distinguishing "nothing to do" (molecule already present) from "skipped because another worker claimed this bead" (`SkippedForClaim`).
- `resolveIdempotentShortCircuit` gains a switch case for `SkippedForClaim` that appends an explicit bead warning naming the bead, the claiming assignee, the skipped formula, and `--force`. `printSlingWarnings` already prints `BeadWarnings` unconditionally, so this surfaces on stderr with no `cmd_sling.go` changes needed.
- The claimed-bead idempotency behavior itself is unchanged by design — only the missing observability around that choice is fixed.

Fixes ga-juszt2. Real-world incident: ga-f9udbh's `--force` re-run (wisp `ga-46ofeu`, branch `builder/ga-46ofeu`) is the exact case this warning now explains up front.

## Test plan
- [x] `TestOnFormulaNeedsAttachment` (claimed-bead case extended to assert `SkippedForClaim`/`Assignee`)
- [x] `TestRoutedRawBeadReadsIdempotentWhichOnFormulaMustOverride` — unclaimed routed-raw override still fires
- [x] `TestOnFormulaNeedsAttachmentMoleculePresentStaysIdempotent` — molecule-present path unaffected, not a claim skip
- [x] `TestOnFormulaNeedsAttachmentProbeErrorStaysIdempotent` — probe-error fail-closed path unaffected
- [x] New: `TestResolveIdempotentShortCircuitWarnsWhenOnFormulaSkippedForClaim` — pins the new warning's content (bead ID, assignee, formula, `--force`)
- [x] `go test ./internal/sling/...` — full package, pass
- [x] `go test ./cmd/gc/...` — full package (incl. `TestDoSlingIdempotentWithOnFormula`, the pre-existing test covering this exact claimed+idempotent+`--on` scenario), pass
- [x] `go vet ./...`, `gofmt -l` — clean
- [x] pre-commit and pre-push hooks (lint, fast local suite) — clean