### PR TITLE
fix(session): exempt routed-demand wake from idle-sleep suppression

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -82,12 +82,21 @@ type DesiredStateResult struct {
 	// there is routed-but-unassigned demand on the identity's backing template
 	// (ScaleCheckCounts[backingTemplate] > 0), computed BEFORE canonical-alias
 	// pool suppression runs. Unlike NamedSessionDemand this is not
-	// assignee-direct and must never be merged into poolDesired or treated as
-	// sleep-suppressing — it exists solely to give ComputeAwakeSet a wake-only
-	// signal for an asleep named holder whose alias correctly suppresses the
-	// redundant pool standby (ga-jl73y2): routed-but-unclaimed demand that
-	// should wake the holder once, without affecting pool sizing or later
-	// idle-sleep decisions.
+	// assignee-direct and must never be merged into poolDesired — it exists
+	// solely to give ComputeAwakeSet a wake-only signal for an asleep named
+	// holder whose alias correctly suppresses the redundant pool standby
+	// (ga-jl73y2): routed-but-unclaimed demand that should wake the holder,
+	// without affecting pool sizing.
+	//
+	// It IS sleep-suppressing while the routed demand remains live. The
+	// resulting "routed-demand" wake reason is exempt from ComputeAwakeSet's
+	// idle-sleep pass and overrides non-interactive sleep suppression in
+	// wakeDemandOverridesSleepSuppression — otherwise a long-lived holder
+	// carrying a non-zero idle reference is re-slept on the same tick and the
+	// wake is silently undone. Suppression ends when demand clears: the holder
+	// then drains via the non-exempt "on-demand:running" reason. Scoped to
+	// canonical singleton backing pools, so only the one session that can
+	// serve the demand is kept awake.
 	NamedSessionRoutedDemand map[string]bool
 	// ReadyAssigned is the set of AssignedWorkBeads that carry real wake-demand
 	// readiness, keyed by store ref + bead ID: in-progress work, assigned

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -458,7 +458,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// grace period are also exempt.
 		//
 		// On_demand named sessions woken by routed/named demand
-		// ("named-demand", "work-query") are also exempt: that demand means
+		// ("named-demand", "routed-demand", "work-query") are also exempt: that demand means
 		// there is pending work for this specific session, so an idle window
 		// must not put it back to sleep. Without this, an asleep on_demand
 		// named session (e.g. a refinery) with routed work that already exists
@@ -471,7 +471,8 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
 			desired[name] != "assigned-work" && desired[name] != "min-active" &&
 			desired[name] != "reset-pending" &&
-			desired[name] != "named-demand" && desired[name] != "work-query" &&
+			desired[name] != "named-demand" && desired[name] != "routed-demand" &&
+			desired[name] != "work-query" &&
 			!inManualGracePeriod(bead, input.ManualGracePeriod, input.Now) {
 			agent, hasAgent := lookupAgent(bead.Template)
 			var idleTimeout time.Duration

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -458,15 +458,16 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// grace period are also exempt.
 		//
 		// On_demand named sessions woken by routed/named demand
-		// ("named-demand", "routed-demand", "work-query") are also exempt: that demand means
-		// there is pending work for this specific session, so an idle window
-		// must not put it back to sleep. Without this, an asleep on_demand
-		// named session (e.g. a refinery) with routed work that already exists
-		// (open_count==desired_count==1) is re-slept every tick and the work
-		// is wedged forever — the reconciler reports reason_code=retained
-		// indefinitely. A fresh cold-create wakes only because it has no
-		// idle reference. The "work done, no demand" drain still fires via the
-		// "on-demand:running" reason, which is NOT exempt. See #3413.
+		// ("named-demand", "routed-demand", "work-query") are also exempt:
+		// that demand means there is pending work for this specific session,
+		// so an idle window must not put it back to sleep. Without this, an
+		// asleep on_demand named session (e.g. a refinery) with routed work
+		// that already exists (open_count==desired_count==1) is re-slept every
+		// tick and the work is wedged forever — the reconciler reports
+		// reason_code=retained indefinitely. A fresh cold-create wakes only
+		// because it has no idle reference. The "work done, no demand" drain
+		// still fires via the "on-demand:running" reason, which is NOT exempt.
+		// See #3413.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
 			desired[name] != "assigned-work" && desired[name] != "min-active" &&

--- a/cmd/gc/compute_awake_set_routed_demand_idle_test.go
+++ b/cmd/gc/compute_awake_set_routed_demand_idle_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPR4644_RoutedDemandWakesAsleepNamedHolder(t *testing.T) {
+	const (
+		template    = "gascity/reviewer"
+		identity    = "gascity/reviewer"
+		sessionName = "gascity--reviewer"
+	)
+
+	build := func(idleSince time.Time) AwakeInput {
+		return AwakeInput{
+			Agents: []AwakeAgent{{
+				QualifiedName:  template,
+				SleepAfterIdle: 10 * time.Minute, // idle_timeout = "10m"
+			}},
+			NamedSessions: []AwakeNamedSession{{
+				Identity:    identity,
+				Template:    template,
+				Mode:        "on_demand",
+				RuntimeName: sessionName,
+			}},
+			SessionBeads: []AwakeSessionBead{{
+				ID:                     "gm-gjmwz2",
+				SessionName:            sessionName,
+				Template:               template,
+				State:                  "asleep",
+				SleepReason:            "idle-timeout",
+				NamedIdentity:          identity,
+				ConfiguredNamedSession: true,
+				IdleSince:              idleSince,
+			}},
+			ScaleCheckCounts:         map[string]int{template: 1},
+			NamedSessionRoutedDemand: map[string]bool{identity: true},
+			Now:                      time.Now().UTC(),
+		}
+	}
+
+	t.Run("A_no_idle_reference", func(t *testing.T) {
+		d := ComputeAwakeSet(build(time.Time{}))[sessionName]
+		if !d.ShouldWake {
+			t.Fatalf("want wake, got ShouldWake=false reason=%q", d.Reason)
+		}
+		if d.Reason != "routed-demand" {
+			t.Fatalf("want reason routed-demand, got %q", d.Reason)
+		}
+	})
+
+	t.Run("B_live_shape_stale_idle_reference", func(t *testing.T) {
+		d := ComputeAwakeSet(build(time.Now().UTC().Add(-56 * 24 * time.Hour)))[sessionName]
+		if !d.ShouldWake {
+			t.Fatalf("routed-demand wake was canceled by idle-sleep (final reason=%q); "+
+				"add \"routed-demand\" to the idle-sleep exemption list", d.Reason)
+		}
+	})
+}


### PR DESCRIPTION
## What

Completes the routed-demand wake fix in this PR's branch: adds
`"routed-demand"` to the idle-sleep exemption list in `ComputeAwakeSet`
(`cmd/gc/compute_awake_set.go`), alongside the existing `"named-demand"`
and `"work-query"` exemptions.

## Why

Without this, a live named-session holder woken by
`NamedSessionRoutedDemand` is immediately re-slept by the idle-sleep check
on the same tick whenever its bead's `IdleSince` predates the idle
timeout (the common case for a long-lived holder). This silently
undoes the routed-demand wake this branch otherwise adds, and — because
the branch also marks the template alias-held while asleep — removes the
working alias-deferred pool-standby fallback without restoring the
holder it was supposed to replace.

## Testing

- New test `TestPR4644_RoutedDemandWakesAsleepNamedHolder` (subtests A/B):
  A passes unmodified; B reproduces the re-sleep on the unpatched branch
  and passes after the fix.
- `go test ./cmd/gc/ -run 'Sleep|Wake|Reconcile|Drain|Awake|NamedOnDemand|NamedSession|PoolDesired|Idle' -count=1` — green.
- `go vet ./...` — clean.

## Note on branching

This targets `deploy/ga-tg4m6s-gate` directly (not `main`) as a stacked
PR, rather than pushing straight onto that branch: the branch predates a
still-undeployed push-ownership-guard fix, so a direct push false-positives
on the guard's stale single-function bead resolution. Opening this as its
own PR avoids bypassing that check and keeps the diff scoped to exactly
this fix.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #1427 — touches the same idle-sleep exemption list in ComputeAwakeSet that the filed issue is about, adding "routed-demand" so routed named-session demand is not immediately re-slept; it does not cover that issue's assigned-work case

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->