### PR TITLE
fix(beads/exec): expose Store.IDPrefix() from GC_BEADS_PREFIX

### DIFF
--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -42,6 +42,19 @@ func (s *Store) SetEnv(env map[string]string) {
 	s.env = env
 }
 
+// IDPrefix returns the bead ID prefix for this exec-backed scope, taken from
+// the projected GC_BEADS_PREFIX env. NewCachingStore uses this to key the
+// per-scope cache (owner metadata); without it an exec-backed rig store caches
+// as "(no-prefix)" and the reconciler's rig-scoped scale-check cannot associate
+// routed rig beads with the rig pool, so a direct `gc sling <rig>/<agent>` never
+// scales a worker.
+func (s *Store) IDPrefix() string {
+	if s == nil {
+		return ""
+	}
+	return strings.TrimSpace(s.env["GC_BEADS_PREFIX"])
+}
+
 // NewStore returns a Store that delegates to the given script.
 // The script path may be absolute, relative, or a bare name resolved via
 // exec.LookPath.

--- a/internal/beads/exec/idprefix_test.go
+++ b/internal/beads/exec/idprefix_test.go
@@ -1,0 +1,54 @@
+package exec //nolint:revive // internal package, always imported with alias
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestStoreIDPrefixFromEnv verifies the exec store exposes its scope prefix from
+// the projected GC_BEADS_PREFIX, including whitespace trimming and empty/nil env.
+func TestStoreIDPrefixFromEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "set", env: map[string]string{"GC_BEADS_PREFIX": "tr"}, want: "tr"},
+		{name: "trims whitespace", env: map[string]string{"GC_BEADS_PREFIX": "  tr\n"}, want: "tr"},
+		{name: "empty value", env: map[string]string{"GC_BEADS_PREFIX": ""}, want: ""},
+		{name: "absent key", env: map[string]string{"GC_CITY": "x"}, want: ""},
+		{name: "nil env", env: nil, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewStore("beads-provider")
+			s.SetEnv(tc.env)
+			if got := s.IDPrefix(); got != tc.want {
+				t.Fatalf("IDPrefix() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStoreIDPrefixNilReceiver guards the nil-receiver path.
+func TestStoreIDPrefixNilReceiver(t *testing.T) {
+	var s *Store
+	if got := s.IDPrefix(); got != "" {
+		t.Fatalf("nil Store IDPrefix() = %q, want empty", got)
+	}
+}
+
+// TestCachingStoreDerivesPrefixFromExecStore is the regression this fix exists
+// for: NewCachingStore must pick up an exec-backed store's scope prefix via the
+// optional IDPrefix() capability, so a rig-scoped cache is keyed by prefix
+// rather than "(no-prefix)".
+func TestCachingStoreDerivesPrefixFromExecStore(t *testing.T) {
+	s := NewStore("beads-provider")
+	s.SetEnv(map[string]string{"GC_BEADS_PREFIX": "tr"})
+
+	cache := beads.NewCachingStore(s, nil)
+	if got := cache.IDPrefix(); got != "tr" {
+		t.Fatalf("NewCachingStore(execStore).IDPrefix() = %q, want %q", got, "tr")
+	}
+}


### PR DESCRIPTION
## Summary

An exec-backed bead store does not report its own ID prefix, so any cache
wrapping one is keyed as `(no-prefix)` and rig-scoped bead ownership breaks.

`beads.NewCachingStore` derives its prefix from a `*BdStore`, or from any backing
that implements the optional `IDPrefix() string` capability
(`internal/beads/caching_store.go:245`). `internal/beads/exec.Store` implemented
neither. An `exec:`-backed rig store, such as `exec:gc-beads-k8s` for a rig
scope, therefore caches with an empty prefix. The reconciler logs
`beads cache: reconciled rig=(no-prefix)`, the rig-scoped scale check cannot
associate a routed rig bead with the rig pool, and a direct
`gc sling <rig>/<agent>` never scales a worker.

The prefix is already available. `docs/reference/exec-beads-provider.md`
documents `GC_BEADS_PREFIX` as "the bead-ID prefix for this scope", and the
provider already projects it into the script's environment. The store just never
exposed it. This returns the trimmed value through the capability
`NewCachingStore` is already looking for, so there is no new mechanism and no new
config.

Found while running the Kubernetes provider end-to-end (#4704), but it is not
k8s-specific. It affects every `exec:` store in a prefixed scope.

### Possible follow-up, not in this PR

`NewCachingStore` records a "missing issue prefix" problem only when the backing
is a `*BdStore` (`caching_store.go:254`). Any other backing with an empty prefix
degrades silently, which is why this needed a live cluster to notice. Widening
that diagnostic to all backings seems worthwhile, but it is a separate
behavioral change.

## Testing

- [ ] `make check` was not run locally. `gofmt` and `go vet` are clean and
      targeted `go test` is green for every touched package, but the full
      `golangci-lint` pass exhausts the dev box this was prepared on. We are
      relying on CI for it.

New unit tests cover the env-to-prefix mapping (set, whitespace-trimmed, empty,
absent, nil env, nil receiver) plus the regression itself:
`NewCachingStore(execStore).IDPrefix()` must return the scope prefix rather than
`""`.

## Checklist

- [x] Linked an issue: #4704
- [x] Added or updated tests for behavior changes
- [ ] No docs update needed. This makes the code match the documented
      `GC_BEADS_PREFIX` contract
- [x] No breaking changes. Stores that never had a prefix keep behaving as
      before. Only exec stores in a prefixed scope change, and only from "no
      prefix" to the correct one
