### PR TITLE
fix(runtime/k8s): pod-local gc init is scaffold-only (--no-start --skip-provider-readiness)

### DIFF
--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -831,7 +831,7 @@ func initCityInPod(ctx context.Context, ops k8sOps, podName, ctrlCity string) er
 	// start a local Dolt server. Pod sessions consume the projected GC_DOLT_*
 	// connection target through env; they do not rewrite canonical .beads files.
 	_, err := ops.execInPod(ctx, podName, "agent",
-		[]string{"env", "GC_DOLT=skip", "gc", "init", "--from", "/tmp/city-src", "/workspace"}, nil)
+		[]string{"env", "GC_DOLT=skip", "gc", "init", "--from", "/tmp/city-src", "/workspace", "--no-start", "--skip-provider-readiness"}, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -2198,4 +2198,21 @@ func TestInitCityInPodSkipsDolt(t *testing.T) {
 	if !hasSkip {
 		t.Errorf("gc init should run with GC_DOLT=skip; got cmd=%v", gcInitCmd)
 	}
+
+	// Pod-local init only scaffolds a session filesystem; it must not register
+	// or start a city, and must not run provider login/readiness probes (a
+	// gateway-backed provider cannot satisfy a first-party-login probe, and the
+	// controller owns readiness). Assert both flags are present.
+	for _, flag := range []string{"--no-start", "--skip-provider-readiness"} {
+		found := false
+		for _, arg := range gcInitCmd {
+			if arg == flag {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("gc init should run with %s; got cmd=%v", flag, gcInitCmd)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

The in-pod `gc init` that scaffolds a worker pod's filesystem runs the full
workstation init path, including the provider-readiness preflight. For a
deployment whose model access goes through a gateway or proxy rather than
first-party OAuth, that preflight cannot pass, so every worker pod dies at
startup with "startup is blocked by provider readiness".

`initCityInPod` (`internal/runtime/k8s/provider.go`) execs
`gc init --from /tmp/city-src /workspace` with no flags. `finalizeInit` then runs
the provider-readiness probe, where `probeClaude` requires
`APIProvider == "firstParty"` and rejects API-key or gateway auth. It also
registers and starts a city, which a pod-local scaffold has no business doing.

Neither step belongs here. `initCityInPod` exists only to lay down a session
filesystem. The controller owns readiness, and pod sessions consume the projected
`GC_DOLT_*` connection target through env rather than standing up their own city.
The controller's own init already passes both flags, so this makes the in-pod
init consistent with it rather than inventing a new policy.

Found running the Kubernetes provider end-to-end (#4704).

## Testing

- [ ] `make check` was not run locally. `gofmt` and `go vet` are clean and
      targeted `go test` is green for every touched package, but the full
      `golangci-lint` pass exhausts the dev box this was prepared on. We are
      relying on CI for it.

`TestInitCityInPodSkipsDolt` is extended to assert both flags reach the in-pod
argv, alongside the existing `GC_DOLT=skip` assertion.

## Checklist

- [x] Linked an issue: #4704
- [x] Added or updated tests for behavior changes
- [ ] No docs update needed. This is internal provider behavior
- [x] No breaking changes. `--no-start` and `--skip-provider-readiness` only
      suppress work the pod-local scaffold should never have been doing, and no
      user-facing flag or config changes
