### PR TITLE
fix(api): join agent slots to their live sessions (#4703)

### DIFF
--- a/internal/api/agent_session_join.go
+++ b/internal/api/agent_session_join.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// liveAgentSession is the slice of a live session's identity the agent
+// handlers need in order to report a pool slot as running: the runtime name to
+// probe and the persisted state to fall back on when the runtime probe itself
+// is unavailable.
+type liveAgentSession struct {
+	sessionName string
+	state       session.State
+	id          string
+}
+
+// agentSessionIdentities returns the qualified agent identities a live session
+// may be occupying, most authoritative first.
+//
+// The precedence mirrors statusSessionQualifiedName: AgentName is the identity
+// the runtime recorded for the session, and it is only meaningful when it says
+// something the template does not already say. Alias is added because that is
+// where the pool spawner records the *slot* a bounded-pool session occupies
+// (e.g. "rig/pack.archivist-1"), which is exactly the key the agent roster is
+// enumerated under. The sanitized-session-name reversal is the last resort and
+// matches what discoverUnlimitedPool does for unlimited pools.
+func agentSessionIdentities(cityName, sessTmpl string, info session.Info) []string {
+	template := strings.TrimSpace(info.Template)
+
+	var keys []string
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		// A key equal to the template is not a slot identity — the template is
+		// the *pool*, and attributing a session to it would let one worker
+		// masquerade as the whole pool.
+		if candidate == "" || candidate == template {
+			return
+		}
+		for _, existing := range keys {
+			if existing == candidate {
+				return
+			}
+		}
+		keys = append(keys, candidate)
+	}
+
+	add(info.AgentName)
+	add(info.Alias)
+
+	runtimeName := strings.TrimSpace(info.SessionName)
+	if runtimeName == "" {
+		runtimeName = strings.TrimSpace(info.SessionNameMetadata)
+	}
+	if runtimeName != "" {
+		qnSanitized := runtimeName
+		if templatePrefix := agent.SessionNameFor(cityName, "", sessTmpl); templatePrefix != "" &&
+			strings.HasPrefix(qnSanitized, templatePrefix) {
+			qnSanitized = qnSanitized[len(templatePrefix):]
+		}
+		add(agent.UnsanitizeQualifiedNameFromSession(qnSanitized))
+	}
+
+	return keys
+}
+
+// agentLiveSessionIndex indexes non-terminal sessions by the qualified agent
+// identity each one occupies.
+//
+// This exists because the agent roster and the session runtime disagree on how
+// a bounded-pool member is named. The roster enumerates deterministic slots
+// ("<pool>-1".."<pool>-N", see expandAgent) and probes the tmux name derived
+// from the slot; the runtime names an ephemeral pool session after its session
+// id and without the rig prefix ("pack__archivist-de-o44"). The two never
+// match, so before this index every bounded-pool slot reported stopped while
+// its worker was executing — only singletons whose deterministic name happens
+// to equal their runtime name (mayor) ever reported running. See #4703.
+//
+// Returns nil when there is no session store or the read fails; callers treat a
+// nil index as "no fallback available" and keep the deterministic answer, so a
+// degraded store can never turn a running agent into a *wrong* claim.
+func (s *Server) agentLiveSessionIndex(cityName, sessTmpl string) map[string]liveAgentSession {
+	store := s.state.SessionsBeadStore()
+	if store.Store == nil {
+		return nil
+	}
+	infos, _, err := sessionReadModelInfos(session.NewStore(store))
+	if err != nil {
+		return nil
+	}
+
+	index := make(map[string]liveAgentSession, len(infos))
+	for _, info := range infos {
+		if info.Closed {
+			continue
+		}
+		state := statusSessionStateInfo(info)
+		if state == session.StateArchived {
+			continue
+		}
+
+		runtimeName := strings.TrimSpace(info.SessionName)
+		if runtimeName == "" {
+			runtimeName = strings.TrimSpace(info.SessionNameMetadata)
+		}
+		if runtimeName == "" {
+			continue
+		}
+
+		live := liveAgentSession{
+			sessionName: runtimeName,
+			state:       state,
+			id:          strings.TrimSpace(info.ID),
+		}
+		for _, key := range agentSessionIdentities(cityName, sessTmpl, info) {
+			// The read model is sorted created-desc, so the first session to
+			// claim a slot is the newest one holding it. Later (older) sessions
+			// for the same slot must not overwrite it.
+			if _, taken := index[key]; taken {
+				continue
+			}
+			index[key] = live
+		}
+	}
+	return index
+}
+
+// resolveAgentRuntime returns the runtime session name to use for an agent slot
+// and whether that slot is running.
+//
+// The deterministic name is probed first, so the common singleton path costs
+// exactly what it did before and needs no session-store read. Only on a miss is
+// the lazily-built index consulted, via lookup, which memoizes for the caller.
+func resolveAgentRuntime(
+	sp interface{ IsRunning(string) bool },
+	deterministicName string,
+	qualifiedName string,
+	lookup func() map[string]liveAgentSession,
+) (string, bool) {
+	if sp != nil && sp.IsRunning(deterministicName) {
+		return deterministicName, true
+	}
+	if lookup == nil {
+		return deterministicName, false
+	}
+	live, ok := lookup()[qualifiedName]
+	if !ok {
+		return deterministicName, false
+	}
+	// Prefer the runtime probe against the *correct* name; fall back to the
+	// persisted state so the roster still reflects a live worker when the tmux
+	// probe is unavailable (which is precisely when the roster matters most).
+	if sp != nil && sp.IsRunning(live.sessionName) {
+		return live.sessionName, true
+	}
+	return live.sessionName, live.state == session.StateActive
+}
+
+// memoizedAgentSessionIndex wraps agentLiveSessionIndex so a single request
+// pays for at most one session-store read no matter how many slots miss.
+func (s *Server) memoizedAgentSessionIndex(cityName, sessTmpl string) func() map[string]liveAgentSession {
+	var (
+		built bool
+		index map[string]liveAgentSession
+	)
+	return func() map[string]liveAgentSession {
+		if !built {
+			index = s.agentLiveSessionIndex(cityName, sessTmpl)
+			built = true
+		}
+		return index
+	}
+}

--- a/internal/api/agent_session_join_test.go
+++ b/internal/api/agent_session_join_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func TestAgentSessionIdentitiesPrefersAgentNameThenAlias(t *testing.T) {
+	keys := agentSessionIdentities("devcity", "", session.Info{
+		Template:    "myrig/pack.archivist",
+		AgentName:   "myrig/pack.archivist-2",
+		Alias:       "myrig/pack.archivist-1",
+		SessionName: "pack__archivist-de-o44",
+	})
+
+	if len(keys) == 0 || keys[0] != "myrig/pack.archivist-2" {
+		t.Fatalf("keys = %v, want AgentName first", keys)
+	}
+	if len(keys) < 2 || keys[1] != "myrig/pack.archivist-1" {
+		t.Fatalf("keys = %v, want Alias second", keys)
+	}
+}
+
+// The template names the pool, not a slot. Attributing a session to it would
+// let a single worker masquerade as the whole pool in the roster.
+func TestAgentSessionIdentitiesSkipsTemplate(t *testing.T) {
+	keys := agentSessionIdentities("devcity", "", session.Info{
+		Template:    "myrig/pack.archivist",
+		AgentName:   "myrig/pack.archivist",
+		Alias:       "myrig/pack.archivist",
+		SessionName: "myrig--pack__archivist",
+	})
+
+	for _, key := range keys {
+		if key == "myrig/pack.archivist" {
+			t.Fatalf("keys = %v, must not contain the bare template", keys)
+		}
+	}
+}
+
+func TestAgentSessionIdentitiesFallsBackToSessionName(t *testing.T) {
+	keys := agentSessionIdentities("devcity", "", session.Info{
+		Template:    "myrig/pack.archivist",
+		SessionName: "myrig--pack__archivist-1",
+	})
+
+	if len(keys) != 1 || keys[0] != "myrig/pack.archivist-1" {
+		t.Fatalf("keys = %v, want the unsanitized session name", keys)
+	}
+}
+
+type stubRunningProvider struct {
+	running map[string]bool
+}
+
+func (s stubRunningProvider) IsRunning(name string) bool { return s.running[name] }
+
+func TestResolveAgentRuntimeDeterministicHitSkipsIndex(t *testing.T) {
+	sp := stubRunningProvider{running: map[string]bool{"mayor": true}}
+	lookupCalls := 0
+	lookup := func() map[string]liveAgentSession {
+		lookupCalls++
+		return nil
+	}
+
+	name, running := resolveAgentRuntime(sp, "mayor", "mayor", lookup)
+
+	if !running || name != "mayor" {
+		t.Fatalf("got (%q, %v), want (\"mayor\", true)", name, running)
+	}
+	if lookupCalls != 0 {
+		t.Errorf("lookup called %d times on the deterministic hit path, want 0", lookupCalls)
+	}
+}
+
+func TestResolveAgentRuntimeAdoptsLiveSessionName(t *testing.T) {
+	sp := stubRunningProvider{running: map[string]bool{"pack__archivist-de-o44": true}}
+	lookup := func() map[string]liveAgentSession {
+		return map[string]liveAgentSession{
+			"myrig/pack.archivist-1": {sessionName: "pack__archivist-de-o44", state: session.StateActive},
+		}
+	}
+
+	name, running := resolveAgentRuntime(
+		sp, "myrig--pack__archivist-1", "myrig/pack.archivist-1", lookup)
+
+	if !running {
+		t.Error("running = false, want true — the slot's session is alive under a different name")
+	}
+	if name != "pack__archivist-de-o44" {
+		t.Errorf("sessionName = %q, want the live runtime name", name)
+	}
+}
+
+// When the runtime probe cannot see the session (a socket mismatch, a partial
+// runtime), the persisted state is the better answer for the roster.
+func TestResolveAgentRuntimeFallsBackToPersistedState(t *testing.T) {
+	sp := stubRunningProvider{running: map[string]bool{}}
+	lookup := func() map[string]liveAgentSession {
+		return map[string]liveAgentSession{
+			"myrig/pack.archivist-1": {sessionName: "pack__archivist-de-o44", state: session.StateActive},
+		}
+	}
+
+	_, running := resolveAgentRuntime(
+		sp, "myrig--pack__archivist-1", "myrig/pack.archivist-1", lookup)
+
+	if !running {
+		t.Error("running = false, want true from the persisted active state")
+	}
+}
+
+func TestResolveAgentRuntimeAsleepSessionIsNotRunning(t *testing.T) {
+	sp := stubRunningProvider{running: map[string]bool{}}
+	lookup := func() map[string]liveAgentSession {
+		return map[string]liveAgentSession{
+			"myrig/pack.archivist-1": {sessionName: "pack__archivist-de-o44", state: session.StateAsleep},
+		}
+	}
+
+	name, running := resolveAgentRuntime(
+		sp, "myrig--pack__archivist-1", "myrig/pack.archivist-1", lookup)
+
+	if running {
+		t.Error("running = true for an asleep session, want false")
+	}
+	if name != "pack__archivist-de-o44" {
+		t.Errorf("sessionName = %q, want the live runtime name even when not running", name)
+	}
+}
+
+func TestResolveAgentRuntimeNoMatchKeepsDeterministicName(t *testing.T) {
+	sp := stubRunningProvider{running: map[string]bool{}}
+	lookup := func() map[string]liveAgentSession { return nil }
+
+	name, running := resolveAgentRuntime(
+		sp, "myrig--pack__archivist-1", "myrig/pack.archivist-1", lookup)
+
+	if running {
+		t.Error("running = true with no matching session, want false")
+	}
+	if name != "myrig--pack__archivist-1" {
+		t.Errorf("sessionName = %q, want the deterministic name preserved", name)
+	}
+}
+
+// End-to-end regression for #4703: a bounded pool whose live session is named
+// after its session id (not its slot ordinal) must still report running.
+func TestAgentListReportsBoundedPoolSlotRunningFromAliasedSession(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg.Agents = []config.Agent{
+		{
+			Name:              "archivist",
+			Dir:               "myrig",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(2),
+		},
+	}
+
+	mgr := session.NewManagerWithOptions(state.cityBeadStore, state.sp)
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{
+		Template:  "myrig/archivist",
+		Alias:     "myrig/archivist-1",
+		Title:     "myrig/archivist-1",
+		Command:   "echo test",
+		WorkDir:   "/tmp",
+		Provider:  "test",
+		Hints:     runtime.Config{},
+		ExtraMeta: map[string]string{"session_origin": "ephemeral"},
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Guard the premise: the slot's deterministic name must NOT be what the
+	// runtime actually started, else this test would pass without the fix.
+	deterministic := agentSessionName(state.CityName(), "myrig/archivist-1", "")
+	if info.SessionName == deterministic {
+		t.Fatalf("runtime session name %q equals the deterministic slot name; "+
+			"the bug this test covers cannot occur", info.SessionName)
+	}
+	if !state.sp.IsRunning(info.SessionName) {
+		t.Fatalf("session %q not running in the fake provider", info.SessionName)
+	}
+
+	srv := New(state)
+	h := newTestCityHandlerWith(t, state, srv)
+	req := httptest.NewRequest("GET", cityURL(state, "/agents"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Items []agentResponse `json:"items"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var slot *agentResponse
+	for i := range resp.Items {
+		if resp.Items[i].Name == "myrig/archivist-1" {
+			slot = &resp.Items[i]
+			break
+		}
+	}
+	if slot == nil {
+		t.Fatalf("slot myrig/archivist-1 absent from roster: %+v", resp.Items)
+	}
+	if !slot.Running {
+		t.Errorf("slot Running = false, want true (live session %q)", info.SessionName)
+	}
+	if slot.State == "stopped" {
+		t.Errorf("slot State = %q, want a live state", slot.State)
+	}
+	if slot.Session == nil || slot.Session.Name != info.SessionName {
+		t.Errorf("slot Session = %+v, want the live runtime name %q", slot.Session, info.SessionName)
+	}
+}

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -49,6 +49,10 @@ func (s *Server) humaHandleAgentList(ctx context.Context, input *AgentListInput)
 		}
 	}
 
+	// Built at most once, and only if a deterministic session-name probe misses
+	// (see #4703 — bounded-pool slots never match their ephemeral session name).
+	liveSessions := s.memoizedAgentSessionIndex(cityName, sessTmpl)
+
 	var agents []agentResponse
 	for _, a := range cfg.Agents {
 		// Provenance is a property of the declared agent, shared by every
@@ -63,8 +67,12 @@ func (s *Server) humaHandleAgentList(ctx context.Context, input *AgentListInput)
 				continue
 			}
 
-			sessionName := agentSessionName(cityName, ea.qualifiedName, sessTmpl)
-			running := sp.IsRunning(sessionName)
+			sessionName, running := resolveAgentRuntime(
+				sp,
+				agentSessionName(cityName, ea.qualifiedName, sessTmpl),
+				ea.qualifiedName,
+				liveSessions,
+			)
 
 			if input.Running == "true" && !running {
 				continue
@@ -184,8 +192,13 @@ func (s *Server) agentByName(name string) (*IndexOutput[agentResponse], error) {
 		return nil, apierr.AgentNotFound.Msg("agent " + name + " not found")
 	}
 
-	sessionName := agentSessionName(cityName, name, cfg.Workspace.SessionTemplate)
-	running := sp.IsRunning(sessionName)
+	sessTmpl := cfg.Workspace.SessionTemplate
+	sessionName, running := resolveAgentRuntime(
+		sp,
+		agentSessionName(cityName, name, sessTmpl),
+		name,
+		s.memoizedAgentSessionIndex(cityName, sessTmpl),
+	)
 
 	suspended := agentCfg.Suspended
 	if v, err := sp.GetMeta(sessionName, "suspended"); err == nil && v == "true" {


### PR DESCRIPTION
Fixes #4703.

## The bug

`GET /v0/city/{city}/agents` reports every **bounded-pool** worker as `state=stopped, running=false`, even while that worker is executing. In a city whose only singleton is `mayor`, the Agents view shows exactly one running agent — the mayor — permanently.

The same server process disagrees with itself:

```
GET /v0/city/devcity/sessions
  de-o44  state=active  running=true  agent_kind=pool
          template=scloud_specs/dev-specs.archivist
          alias=scloud_specs/dev-specs.archivist-1
          session_name=dev-specs__archivist-de-o44

GET /v0/city/devcity/agents
  scloud_specs/dev-specs.archivist-1   state=stopped  running=false   <-- same worker
  mayor                                state=idle     running=true
```

## Cause

`humaHandleAgentList` derived liveness by reconstructing a deterministic tmux name from the agent **slot** and probing it:

```go
sessionName := agentSessionName(cityName, ea.qualifiedName, sessTmpl)
running := sp.IsRunning(sessionName)
```

For a bounded pool, `expandAgent` statically enumerates slots `<pool>-1 … <pool>-N`, so the probed name is `SessionNameFor(<slot>)`. The runtime names an ephemeral pool session after its **session id**, and without the rig prefix. Verified by calling `agent.SessionNameFor` directly:

| agent slot | name probed | live tmux session |
|---|---|---|
| `scloud_specs/dev-specs.archivist-1` | `scloud_specs--dev-specs__archivist-1` | `dev-specs__archivist-de-o44` |
| `scloud_specs/dev-specs.spec-writer-1` | `scloud_specs--dev-specs__spec-writer-1` | `dev-specs__spec-writer-de-g41` |
| `scloud_specs/core.control-dispatcher` | `scloud_specs--core__control-dispatcher` | `core__control-dispatcher-de-5pj` |
| `mayor` | `mayor` | `mayor` — **only match** |

Two independent divergences: no rig prefix, and a session-id suffix instead of the slot ordinal. `mayor` is a singleton whose deterministic name coincides with its runtime name, which is the entire reason it is the one agent that ever reports running.

Everything gated on `running` was skipped too — `Session`, `LastActivity`, `Attached`, peek, `enrichSessionMeta` — `computeAgentState` landed on `stopped`, and `?running=true` returned an empty list while the pool was busy.

`discoverUnlimitedPool` and `appendUnlimitedPoolSessionBeads` already do the right thing in spirit, but both return early unless the pool is *unlimited*, so a pool with `max_active_sessions = 2` never reaches them.

## The fix

The session record already knows the answer, so no new data is needed: `Info.Alias` is the slot the session occupies, and `Info.AgentName` is the identity `statusSessionQualifiedName` already treats as authoritative. This indexes live sessions by qualified identity and consults that index when the deterministic probe misses, adopting the session's real name for the downstream runtime calls.

Deliberate properties:

- **The deterministic probe stays first**, so the singleton path costs exactly what it did before and reads no session store. The index is built at most once per request, and only after a miss (`memoizedAgentSessionIndex`).
- **A key equal to the template is rejected.** The template names the pool; attributing a session to it would let one worker masquerade as the whole pool.
- **Newest wins.** The read model is created-desc, so the first session to claim a slot holds it and older ones cannot overwrite.
- **A degraded store cannot invent liveness.** On a failed read the index is nil and the deterministic answer stands.
- **When the runtime probe cannot see the correctly-named session, persisted state decides** — precisely the partial-runtime case where the roster matters most.

## Tests

`agent_session_join_test.go` covers identity precedence, template rejection, the session-name fallback, and each `resolveAgentRuntime` branch (deterministic hit skips the index entirely; adopting a live name; persisted-state fallback; asleep is not running; no match preserves the deterministic name).

The end-to-end test asserts its own premise — it fails if the runtime name ever equals the deterministic slot name, so it cannot silently stop covering the bug. Confirmed failing before the fix:

```
slot Running = false, want true (live session "s-gc-1")
slot State = "stopped", want a live state
slot Session = <nil>, want the live runtime name "s-gc-1"
```

and passing after. `gofmt` clean, `go vet ./internal/api/` clean, full `go test ./internal/api/` green.

Reproduced on a live city (two `graph.v2` pool-workflow runs in flight, `max_active_sessions = 2`); the bug and this fix were both first validated there before rebasing onto `main`.
