### PR TITLE
test(cmd/gc): migrate batch 5 off ambient city discovery (ga-klo4gz.6)

### DIFF
--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -3655,6 +3655,7 @@ func TestOpenCityOrderStoreUsesProviderAwareStore(t *testing.T) {
 	}
 
 	setCwd(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 	var stderr bytes.Buffer
 	resolved, code := openCityOrderStore(&stderr, "gc order history")
 	if code != 0 {

--- a/cmd/gc/cmd_pack_commands_test.go
+++ b/cmd/gc/cmd_pack_commands_test.go
@@ -227,6 +227,7 @@ func TestNewRootCmdExposesRootPackCommands(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	root := newRootCmd(&bytes.Buffer{}, &bytes.Buffer{})
 	backstage := findSubcommand(root, "backstage")

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -3153,7 +3153,7 @@ func runSessionListProviderFailureHelper(t *testing.T, scenario, markerPath, std
 	buildSessionProviderByName = func(*config.City, string, config.SessionConfig, string, string) (runtime.Provider, error) {
 		return nil, errors.New("injected provider failure")
 	}
-	args := []string{"session", "list"}
+	args := []string{"--city", ".", "session", "list"}
 	if scenario == "json" {
 		args = append(args, "--json")
 	} else if scenario != "text" {

--- a/cmd/gc/provider_store_resolution_test.go
+++ b/cmd/gc/provider_store_resolution_test.go
@@ -73,6 +73,7 @@ prefix = "FE"
 		t.Fatal(err)
 	}
 	chdirProviderAwareTest(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	store, code := openRigAwareStore([]string{"FE-42"}, &bytes.Buffer{})
 	if code != 0 {
@@ -156,6 +157,7 @@ trigger = "manual"
 		t.Fatal(err)
 	}
 	chdirProviderAwareTest(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdOrderHistory("digest", "", &stdout, &stderr)
@@ -398,6 +400,7 @@ trigger = "manual"
 		t.Fatal(err)
 	}
 	chdirProviderAwareTest(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdOrderRun("poll", "", false, nil, &stdout, &stderr)
@@ -444,6 +447,7 @@ pool = "dog"
 		t.Fatal(err)
 	}
 	chdirProviderAwareTest(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdOrderRun("digest", "", false, nil, &stdout, &stderr)


### PR DESCRIPTION
## Summary

Part of the `ga-klo4gz` ambient-city-discovery test migration (mayor sequencing ruling in mail `gm-wisp-0zj3zar`). Batch 5/N: adds `t.Setenv("GC_CITY_PATH", dir)` immediately after the existing cwd setup in 7 sites across 4 files, so `resolveCity()` resolves via the explicit-env step instead of the ambient upward-walk step (step 10) that `ga-klo4gz`'s guard will refuse in test binaries.

- `cmd_order_test.go`: `TestOpenCityOrderStoreUsesProviderAwareStore`
- `cmd_pack_commands_test.go`: `TestNewRootCmdExposesRootPackCommands`
- `provider_store_resolution_test.go`: `TestOpenRigAwareStoreUsesScopeLocalFileStore`, `TestCmdOrderHistoryUsesProviderAwareCityStore`, `TestCmdOrderRunExecSkipsStoreOpenForScopedFileProvider`, `TestCmdOrderRunFormulaUsesProviderAwareCityStore`
- `cmd_session_test.go`: `TestSessionListProviderConstructionFailureReturnsThroughRun` needed a different fix — it drives a subprocess that re-invokes the `gc.test` binary, and that subprocess's own `TestMain` unconditionally wipes `GC_CITY`/`GC_CITY_PATH`/`GC_CITY_ROOT` via `clearProcessLiveEnvForTests()` before the test body runs, regardless of how the parent set `cmd.Env`. CLI flags survive that clearing where env vars can't, so the fix prepends `--city .` to the subprocess's argv instead. This is a newly-observed failure category (env-clearing defeats the standard env fix for subprocess-driving tests) beyond the guard-blind/guard-false-fail/true-ambient-conflict taxonomy from earlier batches.

`cmd_bd_test.go`'s `TestGcBdUsesEnclosingRigWhenNoFlag` is **deliberately left unmigrated**: its purpose is to verify ambient rig-from-cwd discovery itself (it explicitly blanks `GC_CITY_PATH`), so it needs a semantic rewrite rather than a mechanical env fix. Left for the guard's own landing PR, per the existing `TestResolveCityFlag`/`TestRigAnywhere_ResolveContext` precedent from earlier batches.

Guard itself is **not included** — reserved for its own PR per the mayor's sequencing ruling. Remaining after this batch: `cmd_commands_test.go` (~8 sites) and `cmd_sling_test.go` (~10 sites).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/gc/...` clean
- [x] Both-ways-green: full `cmd/gc` suite passes with the canary guard (`isTestBinary()` gate on `resolveContextFromDir` step 10) applied locally and uncommitted
- [x] Full `cmd/gc` suite passes clean on plain `origin/main` + this diff alone (294.208s, 0 failures)
- [x] Pre-push fast suite (`scripts/test-local-parallel fast`) passed