### PR TITLE
fix(scripts): rename push-ownership-guard local 'status' to avoid zsh collision

### DIFF
--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -163,14 +163,18 @@ assert_bead_still_claimed() {
         return 1
     fi
 
-    local status assignee routed_to labels
-    status="$(jq -r '.[0].status // empty' <<<"$json")"
+    # NOTE: never name this local 'status' — it is a zsh special parameter
+    # (linked to $?, alongside $pipestatus) and this function is sourced
+    # into the deployer's ambient zsh shell (ga-xi7wi6); binding a local
+    # named 'status' there is a read-only-variable error, not a shadow.
+    local bead_status assignee routed_to labels
+    bead_status="$(jq -r '.[0].status // empty' <<<"$json")"
     assignee="$(jq -r '.[0].assignee // empty' <<<"$json")"
     routed_to="$(jq -r '.[0].metadata."gc.routed_to" // empty' <<<"$json")"
     labels="$(jq -r '.[0].labels[]? // empty' <<<"$json")"
 
-    if [[ "$status" != "in_progress" && "$status" != "open" ]]; then
-        echo "push-ownership-guard: BLOCKED — $id status is '$status', not in_progress/open; the claim behind this push is stale. Bypass with: git push --no-verify" >&2
+    if [[ "$bead_status" != "in_progress" && "$bead_status" != "open" ]]; then
+        echo "push-ownership-guard: BLOCKED — $id status is '$bead_status', not in_progress/open; the claim behind this push is stale. Bypass with: git push --no-verify" >&2
         return 1
     fi
 

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -159,6 +159,24 @@ run_guard() {
     )
 }
 
+# run_guard_zsh: identical to run_guard, but sources and calls the guard
+# under a real zsh subprocess instead of bash. push-ownership-guard.sh is
+# SOURCED into the deployer's ambient interactive shell (zsh, in this fork —
+# see rebase-resolve-lib.sh's attempt_bounded_self_rebase, Layer B), not
+# executed via its own bash shebang, so zsh's parsing/builtin rules apply to
+# assert_bead_still_claimed's body at call time (ga-xi7wi6).
+run_guard_zsh() {
+    local repo="$1" fbd="$2" agent="$3" template="$4" pog_timeout="${5:-5}"
+    local session_id="${6:-}" session_name="${7:-}"
+    (
+        cd "$repo" || exit 1
+        PATH="$fbd:$PATH" GC_AGENT="$agent" GC_TEMPLATE="$template" \
+            GC_SESSION_ID="$session_id" GC_SESSION_NAME="$session_name" \
+            POG_TIMEOUT_SECONDS="$pog_timeout" LIB="$LIB" \
+            zsh -c '. "$LIB"; assert_bead_still_claimed'
+    )
+}
+
 # ---------------------------------------------------------------------------
 # assert_bead_still_claimed — direct tests.
 # ---------------------------------------------------------------------------
@@ -174,6 +192,32 @@ test_allow_clean_claim() {
         record_pass "allow/clean-claim"
     else
         record_fail "allow/clean-claim" "expected rc=0, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# test_allow_clean_claim_under_zsh mirrors test_allow_clean_claim exactly,
+# but runs assert_bead_still_claimed under a real zsh subprocess (ga-xi7wi6):
+# a local variable named 'status' collides with zsh's read-only special
+# parameter of the same name, so the guard must never bind that name.
+# Skips (does not fail) when zsh isn't installed, matching the fallback
+# style of _pog_timeout degrading gracefully on a missing dev tool rather
+# than failing the whole suite closed.
+test_allow_clean_claim_under_zsh() {
+    if ! command -v zsh >/dev/null 2>&1; then
+        echo "  skip allow/clean-claim-under-zsh — zsh not installed"
+        return
+    fi
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    write_show_json "$fbd" "ga-abc123.1" "in_progress" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard_zsh "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]]; then
+        record_pass "allow/clean-claim-under-zsh"
+    else
+        record_fail "allow/clean-claim-under-zsh" "expected rc=0, got rc=$rc, output: $out"
     fi
     rm -rf "$repo" "$fbd"
 }
@@ -557,6 +601,7 @@ test_rebase_lib_calls_guard_before_force_with_lease() {
 
 run_all() {
     test_allow_clean_claim
+    test_allow_clean_claim_under_zsh
     test_block_on_closed
     test_block_on_reassigned
     test_allow_when_assignee_is_session_id


### PR DESCRIPTION
## Summary
- `assert_bead_still_claimed()` in `scripts/push-ownership-guard.sh` bound a
  local named `status`, which is a read-only zsh special parameter (linked
  to `$?`, alongside `$pipestatus`). Since this function is sourced into the
  deployer's ambient zsh shell (via `rebase-resolve-lib.sh`), the assignment
  aborted the function with `read-only variable: status` instead of
  returning a clean nonzero status — silently defeating the guard's
  fail-closed contract under zsh.
- Renamed the local to `bead_status`; no behavior change under bash.
- Added zsh-mode regression coverage to `test-push-ownership-guard.sh`
  (`run_guard_zsh` helper + `test_allow_clean_claim_under_zsh`), skipping
  gracefully when zsh isn't on PATH.
- Checked the other 3 sites the bead flagged as "same pattern, not yet
  confirmed broken" (`test-push-ownership-guard.sh:136`, `:468`,
  `smoke-macos.sh:95`) — all have their own bash shebangs and are never
  sourced anywhere in the repo, so they're not exposed to ambient-zsh
  invocation. Left untouched per the bead's explicit scope boundary.

Fixes ga-xi7wi6. Discovered as a second, independent zsh incompatibility
while unblocking ga-ql4bmm's deploy gate (ga-g1mlel hit this after
ga-ab7pgm's BASH_SOURCE fix cleared the first one).

## Test plan
- [x] TDD: new zsh test written first, confirmed RED against the unfixed
      script (`read-only variable: status`, pass=20 fail=1), then GREEN
      after the fix (pass=21 fail=0)
- [x] `shellcheck` clean on both changed files
- [x] `go build ./... && go vet ./...`
- [x] `go test ./scripts/... -run TestPushOwnershipGuard -v`
- [x] `go test ./internal/testpolicy/resourcecensus/...` (no baseline bump
      needed — the new `zsh -c` call is nested inside a script already
      wrapped by one pre-existing Go-level `exec.Command`)
- [x] `make test-fast-parallel` — 9/9 jobs green