### PR TITLE
fix(dolt): dedup compact quarantine mail so a stable quarantine pages once

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1315,8 +1315,12 @@ write_compact_marker() {
     return 1
   fi
   if [ "$dir" = "$quarantine_dir" ]; then
-    send_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at" || true
-    record_quarantine_notify_state "$db" "$reason" 1
+    emit_compact_quarantine_event "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at"
+    if mail_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at"; then
+      record_quarantine_notify_state "$db" "$reason" 1
+    else
+      record_quarantine_notify_state "$db" "$reason" 0
+    fi
   fi
   return 0
 }
@@ -1338,7 +1342,10 @@ mail_compact_quarantine_alert() {
   _ca_reason="$4"
   _ca_created_at="${5:-<unknown>}"
   _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
-  gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg" || true
+  if gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg"; then
+    return 0
+  fi
+  return 1
 }
 
 send_compact_quarantine_alert() {
@@ -1377,7 +1384,7 @@ record_quarantine_notify_state() {
   _qn_emitted="$3"
 
   _qn_marker=$(compact_marker_path "$quarantine_dir" "$db")
-  [ -f "$_qn_marker" ] || return 0
+  [ -f "$_qn_marker" ] && [ -r "$_qn_marker" ] || return 0
 
   _qn_seen_count=$(compact_marker_value "$quarantine_dir" "$db" seen_count || true)
   case "$_qn_seen_count" in ''|*[!0-9]*) _qn_seen_count=0 ;; esac
@@ -1400,13 +1407,20 @@ record_quarantine_notify_state() {
     return 0
   }
   umask "$_qn_old_umask"
+  if ! awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason)=/' "$_qn_marker" > "$_qn_tmp" 2>/dev/null; then
+    rm -f "$_qn_tmp"
+    return 0
+  fi
   if ! {
-    awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason)=/' "$_qn_marker"
     printf 'seen_count=%s\n' "$_qn_seen_count"
     printf 'notify_count=%s\n' "$_qn_notify_count"
     printf 'last_notified_ts=%s\n' "$_qn_last_ts"
     printf 'last_notified_reason=%s\n' "$_qn_last_reason"
-  } > "$_qn_tmp" 2>/dev/null; then
+  } >> "$_qn_tmp" 2>/dev/null; then
+    rm -f "$_qn_tmp"
+    return 0
+  fi
+  if ! grep -q '^db=' "$_qn_tmp" 2>/dev/null; then
     rm -f "$_qn_tmp"
     return 0
   fi
@@ -1430,8 +1444,9 @@ report_existing_quarantine() {
 
   quarantine_alert_emitted=0
   if quarantine_should_notify "$db" "${quarantine_reason:-<unknown>}"; then
-    mail_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"
-    quarantine_alert_emitted=1
+    if mail_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"; then
+      quarantine_alert_emitted=1
+    fi
   fi
   record_quarantine_notify_state "$db" "${quarantine_reason:-<unknown>}" "$quarantine_alert_emitted"
 }

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1316,11 +1316,12 @@ write_compact_marker() {
   fi
   if [ "$dir" = "$quarantine_dir" ]; then
     send_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at" || true
+    record_quarantine_notify_state "$db" "$reason" 1
   fi
   return 0
 }
 
-send_compact_quarantine_alert() {
+emit_compact_quarantine_event() {
   _ca_db="$1"
   _ca_type="$2"
   _ca_path="$3"
@@ -1328,7 +1329,111 @@ send_compact_quarantine_alert() {
   _ca_created_at="${5:-<unknown>}"
   _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
   gc event emit dolt.compact.quarantine --actor controller --message "$_ca_msg" || true
+}
+
+mail_compact_quarantine_alert() {
+  _ca_db="$1"
+  _ca_type="$2"
+  _ca_path="$3"
+  _ca_reason="$4"
+  _ca_created_at="${5:-<unknown>}"
+  _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
   gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg" || true
+}
+
+send_compact_quarantine_alert() {
+  emit_compact_quarantine_event "$@"
+  mail_compact_quarantine_alert "$@"
+}
+
+# quarantine_should_notify DB REASON
+#   Fail-open dedup check: EMIT (return 0) unless the quarantine marker's
+#   last_notified_reason already matches REASON, meaning a mail already went
+#   out for this exact quarantine state. A missing marker, missing field, or
+#   unreadable marker always emits — this must never wrongly suppress a real
+#   alert. Mirrors the notify-once-per-distinct-state marker shape in
+#   gc-management's packs/maintainer-pr-review/scripts/hold-notice-lib.sh.
+quarantine_should_notify() {
+  db="$1"
+  reason="$2"
+  _qn_marker=$(compact_marker_path "$quarantine_dir" "$db")
+  [ -f "$_qn_marker" ] && [ -r "$_qn_marker" ] || return 0
+  _qn_prev_reason=$(compact_marker_value "$quarantine_dir" "$db" last_notified_reason || true)
+  [ -n "$_qn_prev_reason" ] || return 0
+  [ "$_qn_prev_reason" = "$reason" ] && return 1
+  return 0
+}
+
+# record_quarantine_notify_state DB REASON EMITTED
+#   Patches only the notify-bookkeeping fields (seen_count, notify_count,
+#   last_notified_ts, last_notified_reason) onto DB's existing quarantine
+#   marker, preserving every other field byte-for-byte. EMITTED=1 bumps
+#   notify_count and stamps last_notified_ts/last_notified_reason; EMITTED=0
+#   only bumps seen_count. A missing marker or write failure is a silent
+#   no-op — bookkeeping must never block or fail compaction.
+record_quarantine_notify_state() {
+  db="$1"
+  reason="$2"
+  _qn_emitted="$3"
+
+  _qn_marker=$(compact_marker_path "$quarantine_dir" "$db")
+  [ -f "$_qn_marker" ] || return 0
+
+  _qn_seen_count=$(compact_marker_value "$quarantine_dir" "$db" seen_count || true)
+  case "$_qn_seen_count" in ''|*[!0-9]*) _qn_seen_count=0 ;; esac
+  _qn_seen_count=$((_qn_seen_count + 1))
+
+  _qn_notify_count=$(compact_marker_value "$quarantine_dir" "$db" notify_count || true)
+  case "$_qn_notify_count" in ''|*[!0-9]*) _qn_notify_count=0 ;; esac
+  _qn_last_ts=$(compact_marker_value "$quarantine_dir" "$db" last_notified_ts || true)
+  _qn_last_reason=$(compact_marker_value "$quarantine_dir" "$db" last_notified_reason || true)
+  if [ "$_qn_emitted" = "1" ]; then
+    _qn_notify_count=$((_qn_notify_count + 1))
+    _qn_last_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    _qn_last_reason="$reason"
+  fi
+
+  _qn_old_umask=$(umask)
+  umask 077
+  _qn_tmp=$(mktemp "$quarantine_dir/$db.tmp.XXXXXX") || {
+    umask "$_qn_old_umask"
+    return 0
+  }
+  umask "$_qn_old_umask"
+  if ! {
+    awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason)=/' "$_qn_marker"
+    printf 'seen_count=%s\n' "$_qn_seen_count"
+    printf 'notify_count=%s\n' "$_qn_notify_count"
+    printf 'last_notified_ts=%s\n' "$_qn_last_ts"
+    printf 'last_notified_reason=%s\n' "$_qn_last_reason"
+  } > "$_qn_tmp" 2>/dev/null; then
+    rm -f "$_qn_tmp"
+    return 0
+  fi
+  mv -f "$_qn_tmp" "$_qn_marker" || rm -f "$_qn_tmp"
+  return 0
+}
+
+# report_existing_quarantine DB
+#   Diagnostic + alert path for a compact/bare-gc invocation that hit an
+#   already-quarantined database. The event still fires every cycle; the
+#   mail is gated by quarantine_should_notify so a stable quarantine reason
+#   pages once instead of on every subsequent run.
+report_existing_quarantine() {
+  db="$1"
+  quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
+  quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
+  quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
+  print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
+
+  emit_compact_quarantine_event "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"
+
+  quarantine_alert_emitted=0
+  if quarantine_should_notify "$db" "${quarantine_reason:-<unknown>}"; then
+    mail_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"
+    quarantine_alert_emitted=1
+  fi
+  record_quarantine_notify_state "$db" "${quarantine_reason:-<unknown>}" "$quarantine_alert_emitted"
 }
 
 ensure_compact_marker_writable() {
@@ -1881,11 +1986,7 @@ flatten_database() {
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
-    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
-    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
-    send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
+    report_existing_quarantine "$db"
     return 1
   fi
 
@@ -2590,11 +2691,7 @@ bare_gc_database() {
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
-    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
-    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
-    send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
+    report_existing_quarantine "$db"
     return 1
   fi
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -109,6 +109,7 @@ type compactScriptFixture struct {
 	binDir        string
 	doltLog       string
 	gcLog         string
+	mailFailFile  string
 	stateFile     string
 	hashStateFile string
 	port          int
@@ -144,7 +145,7 @@ func newCompactScriptFixture(t *testing.T) compactScriptFixture {
 	writeManagedRuntimeStateForScriptWithPID(t, cityPath, port, os.Getpid())
 
 	binDir := t.TempDir()
-	gcLog := writeCompactFakeGC(t, binDir)
+	gcLog, mailFailFile := writeCompactFakeGC(t, binDir)
 	doltLog := writeCompactFakeDolt(t, binDir)
 	stateFile := filepath.Join(binDir, "head-state")
 	if err := os.WriteFile(stateFile, []byte("headcommit\n"), 0o644); err != nil {
@@ -161,6 +162,7 @@ func newCompactScriptFixture(t *testing.T) compactScriptFixture {
 		binDir:        binDir,
 		doltLog:       doltLog,
 		gcLog:         gcLog,
+		mailFailFile:  mailFailFile,
 		stateFile:     stateFile,
 		hashStateFile: hashStateFile,
 		port:          port,
@@ -225,6 +227,13 @@ func (f compactScriptFixture) runWithArgs(t *testing.T, mode string, args []stri
 
 func replaceCompactMarkerCreatedAt(t *testing.T, markerPath, createdAt string) {
 	t.Helper()
+	replaceCompactMarkerField(t, markerPath, "created_at", createdAt)
+}
+
+// replaceCompactMarkerField rewrites the first KEY=VALUE line of a compact
+// marker in place, leaving every other line byte-for-byte intact.
+func replaceCompactMarkerField(t *testing.T, markerPath, key, value string) {
+	t.Helper()
 	data, err := os.ReadFile(markerPath)
 	if err != nil {
 		t.Fatalf("read compact marker: %v", err)
@@ -232,14 +241,14 @@ func replaceCompactMarkerCreatedAt(t *testing.T, markerPath, createdAt string) {
 	lines := strings.Split(string(data), "\n")
 	replaced := false
 	for i, line := range lines {
-		if strings.HasPrefix(line, "created_at=") {
-			lines[i] = "created_at=" + createdAt
+		if strings.HasPrefix(line, key+"=") {
+			lines[i] = key + "=" + value
 			replaced = true
 			break
 		}
 	}
 	if !replaced {
-		t.Fatalf("compact marker missing created_at:\n%s", data)
+		t.Fatalf("compact marker missing %s:\n%s", key, data)
 	}
 	if err := os.WriteFile(markerPath, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
 		t.Fatalf("rewrite compact marker: %v", err)
@@ -318,18 +327,28 @@ func runCompactScriptCommand(t *testing.T, mode string) (string, string, error) 
 	return out, fixture.doltLog, err
 }
 
-func writeCompactFakeGC(t *testing.T, binDir string) string {
+// writeCompactFakeGC installs the fake `gc` used by the compact-script
+// fixtures. It logs every invocation and, when the returned mail-failure
+// sentinel file exists, fails `gc mail send` so tests can exercise the
+// script's mail-delivery failure path. The sentinel does not exist by
+// default, so mail succeeds unless a test opts in.
+func writeCompactFakeGC(t *testing.T, binDir string) (logPath, mailFailPath string) {
 	t.Helper()
-	logPath := filepath.Join(binDir, "gc.log")
+	logPath = filepath.Join(binDir, "gc.log")
+	mailFailPath = filepath.Join(binDir, "gc-mail-fail")
 	writeExecutable(t, filepath.Join(binDir, "gc"), fmt.Sprintf(`#!/bin/sh
 printf 'gc %%s\n' "$*" >> %s
 if [ "${1:-}" = "rig" ] && [ "${2:-}" = "list" ]; then
   printf '{"rigs":[]}\n'
   exit 0
 fi
+if [ "${1:-}" = "mail" ] && [ "${2:-}" = "send" ] && [ -f %s ]; then
+  printf 'fake gc: mail send failed\n' >&2
+  exit 1
+fi
 exit 0
-`, shellQuote(logPath)))
-	return logPath
+`, shellQuote(logPath), shellQuote(mailFailPath)))
+	return logPath, mailFailPath
 }
 
 func readCompactGCLog(t *testing.T, fixture compactScriptFixture) string {
@@ -3360,6 +3379,113 @@ func TestCompactScriptExistingQuarantineMarkerAlertsOnceAcrossRepeatedCycles(t *
 	eventLines := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")
 	if len(eventLines) != 3 {
 		t.Fatalf("each compact cycle should still emit a dolt.compact.quarantine event even when the mail is suppressed, got %d\nlog:\n%s", len(eventLines), log)
+	}
+}
+
+func TestCompactScriptQuarantineMailFailureIsRetriedNextCycle(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	if err := os.WriteFile(fixture.mailFailFile, nil, 0o644); err != nil {
+		t.Fatalf("arm mail-failure sentinel: %v", err)
+	}
+
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+
+	// The mail that would have paged the operator failed to send. Dedup
+	// bookkeeping must not record it as delivered, or the quarantine goes
+	// unreported forever.
+	if err := os.Remove(fixture.mailFailFile); err != nil {
+		t.Fatalf("disarm mail-failure sentinel: %v", err)
+	}
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("second compact succeeded despite quarantine:\n%s", secondOut)
+	}
+	log := readCompactGCLog(t, fixture)
+	if mailLines := compactGCLogLinesWithPrefix(log, "gc mail send "); len(mailLines) != 2 {
+		t.Fatalf("a failed quarantine mail must be retried on the next cycle, want 2 attempts, got %d\nlog:\n%s", len(mailLines), log)
+	}
+
+	// Once a send finally succeeds, dedup takes over again.
+	thirdOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("third compact succeeded despite quarantine:\n%s", thirdOut)
+	}
+	log = readCompactGCLog(t, fixture)
+	if mailLines := compactGCLogLinesWithPrefix(log, "gc mail send "); len(mailLines) != 2 {
+		t.Fatalf("a successful retry should re-establish dedup, want 2 attempts, got %d\nlog:\n%s", len(mailLines), log)
+	}
+}
+
+func TestCompactScriptQuarantineReasonChangeReMails(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("second compact succeeded despite quarantine:\n%s", secondOut)
+	}
+	log := readCompactGCLog(t, fixture)
+	if mailLines := compactGCLogLinesWithPrefix(log, "gc mail send "); len(mailLines) != 1 {
+		t.Fatalf("dedup should be established after two cycles, want 1 mail, got %d\nlog:\n%s", len(mailLines), log)
+	}
+
+	// Dedup is keyed on the quarantine reason, not on the marker's mere
+	// existence: a quarantine that changes cause is a new operator-visible
+	// state and must page again.
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	const newReason = "manual repair pending"
+	replaceCompactMarkerField(t, marker, "reason", newReason)
+
+	thirdOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("third compact succeeded despite quarantine:\n%s", thirdOut)
+	}
+	log = readCompactGCLog(t, fixture)
+	mailLines := compactGCLogLinesWithPrefix(log, "gc mail send ")
+	if len(mailLines) != 2 {
+		t.Fatalf("a changed quarantine reason must send a fresh mail, want 2, got %d\nlog:\n%s", len(mailLines), log)
+	}
+	if !strings.Contains(mailLines[1], "reason="+newReason) {
+		t.Fatalf("re-sent mail should carry the new reason\nline:\n%s\nlog:\n%s", mailLines[1], log)
+	}
+}
+
+func TestCompactScriptUnreadableQuarantineMarkerIsNotClobbered(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file mode")
+	}
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+
+	// The marker is the operator's only record of why the database was
+	// quarantined. Notify bookkeeping must not rewrite a marker it cannot
+	// read — doing so would erase exactly the evidence the recovery
+	// instructions tell the operator to preserve.
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if err := os.Chmod(marker, 0o000); err != nil {
+		t.Fatalf("chmod quarantine marker unreadable: %v", err)
+	}
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("second compact succeeded despite quarantine:\n%s", secondOut)
+	}
+	if err := os.Chmod(marker, 0o600); err != nil {
+		t.Fatalf("restore quarantine marker mode: %v", err)
+	}
+
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten row count decreased" {
+		t.Fatalf("unreadable quarantine marker lost its reason: %q", reason)
+	}
+	if createdAt := compactMarkerValue(t, marker, "created_at"); createdAt == "" {
+		t.Fatal("unreadable quarantine marker lost its created_at")
 	}
 }
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -3330,6 +3330,39 @@ func TestCompactScriptQuarantineBlocksSecondCycleAfterRowCountDecrease(t *testin
 	}
 }
 
+func TestCompactScriptExistingQuarantineMarkerAlertsOnceAcrossRepeatedCycles(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("second compact succeeded despite quarantine:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "integrity quarantine marker exists") {
+		t.Fatalf("second compact missing quarantine explanation:\n%s", secondOut)
+	}
+	thirdOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("third compact succeeded despite quarantine:\n%s", thirdOut)
+	}
+
+	// Two consecutive compact runs over an unchanged quarantine condition
+	// must send exactly one operator mail — a stable, correct quarantine
+	// should not page forever. The event stays unconditional (one per
+	// cycle) so downstream automation can still observe every check.
+	log := readCompactGCLog(t, fixture)
+	mailLines := compactGCLogLinesWithPrefix(log, "gc mail send ")
+	if len(mailLines) != 1 {
+		t.Fatalf("three compact runs over an unchanged quarantine condition should send exactly one operator mail, got %d\nlog:\n%s", len(mailLines), log)
+	}
+	eventLines := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")
+	if len(eventLines) != 3 {
+		t.Fatalf("each compact cycle should still emit a dolt.compact.quarantine event even when the mail is suppressed, got %d\nlog:\n%s", len(eventLines), log)
+	}
+}
+
 func TestCompactScriptFreshQuarantineMarkerAlertsDefaultMayor(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")


### PR DESCRIPTION
## Summary

- The re-alert loop wasn't in `write_compact_marker`'s quarantine-install
  path — that path is already one-shot by construction (gated once per
  `flatten_database()` call). The actual repeat-offender was two
  byte-identical "already quarantined, refuse" guard blocks in
  `flatten_database()` and `bare_gc_database()`, which sent an
  unconditional mail on **every** compact/bare-gc invocation with zero
  dedup — matching the "re-alerting for 23 days" symptom in ga-5trg1x.
- Collapsed both duplicated guards into one shared
  `report_existing_quarantine` helper (fixing the bug in one place
  instead of two, and removing pre-existing duplication).
- Split `send_compact_quarantine_alert` into `emit_compact_quarantine_event`
  (unconditional — still fires every cycle so downstream automation can
  observe every check) and `mail_compact_quarantine_alert` (gated by a
  new fail-open `quarantine_should_notify` check keyed on
  `last_notified_reason`).
- Added `record_quarantine_notify_state`, which additively patches
  `seen_count` / `notify_count` / `last_notified_ts` /
  `last_notified_reason` onto the existing quarantine marker without
  touching any other field (including `created_at`) — mirroring the
  notify-once-per-distinct-state marker shape in
  `hold-notice-lib.sh`.
- The fresh-install path in `write_compact_marker` now also calls
  `record_quarantine_notify_state` (alert stays unconditional there,
  since it's already one-shot) so the very next run doesn't fail-open
  and double-mail.
- Out of scope, deliberately: the bead's optional "alert on
  compact-pending-gc too" stretch goal, and the separate
  `ensure_remote_push_retry_fresh` mechanism (different marker family —
  `pending_push`/`pending_gc`, not `quarantine`).

## Test plan

- [x] New test `TestCompactScriptExistingQuarantineMarkerAlertsOnceAcrossRepeatedCycles`:
      three consecutive compact runs over an unchanged quarantine
      condition send exactly one mail, while the event still fires all
      three times.
- [x] Verified retroactively against the original bug via
      `git stash` on just the source file: the new test fails (3 mails
      across 3 runs) against pre-fix code, passes against the fix.
- [x] Full quarantine-filtered suite (20 tests) passes, including all
      previously-existing alert/recipient/refusal tests.
- [x] Full `go test ./examples/bd/dolt/...` passes.
- [x] `go vet ./...` clean.
- [x] `shellcheck -s sh` on `run.sh` — no new warnings.

Fixes ga-5trg1x.