### PR TITLE
fix(cmd/gc): widen CI jitter tolerance in reload-drain timeout test

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -4946,7 +4946,13 @@ func TestCityRuntimeReloadDrainBoundedByTimeout(t *testing.T) {
 	start := time.Now()
 	cr.reloadConfig(context.Background(), &lastProviderName, cityPath)
 	elapsed := time.Since(start)
-	if elapsed < reloadOrderDrainTimeout || elapsed > reloadOrderDrainTimeout+500*time.Millisecond {
+	// elapsed is the subject under test (it proves reloadConfig actually
+	// bounds its wait on od.release rather than hanging on it forever), so
+	// this stays an explicit deadline rather than a hangBudget wait. The
+	// upper bound carries a generous tail to absorb CI scheduler jitter on
+	// top of the real reloadOrderDrainTimeout floor; the lower bound has no
+	// slop since contention only ever slows this down, never speeds it up.
+	if elapsed < reloadOrderDrainTimeout || elapsed > reloadOrderDrainTimeout+3*time.Second {
 		t.Fatalf("reload elapsed = %s, want bounded near %s", elapsed, reloadOrderDrainTimeout)
 	}
 	close(od.release)


### PR DESCRIPTION
## Summary
- `TestCityRuntimeReloadDrainBoundedByTimeout` asserts `reloadConfig`'s elapsed time is bounded near the production `reloadOrderDrainTimeout` (1s) constant.
- The upper-bound slop was a bare 500ms, too tight for CI scheduler contention — observed failures overshot by 159ms and 439ms on separate prior occasions.
- Since elapsed time is the subject under test here (the assertion literally depends on duration), this is TESTING.md's documented exception and is not eligible for migration to the `hangBudget`/`awaitCond` pattern (unlike PR #4638's sibling fixes).
- Widened only the upper-bound jitter tolerance (500ms → 3s slop, so 1s → 4s total window). `reloadOrderDrainTimeout` itself and the lower-bound check are untouched.

## Test plan
- [x] `go build ./cmd/gc/...` clean
- [x] `go vet ./cmd/gc/...` clean
- [x] Targeted test: 20/20 passes under idle load
- [x] Targeted test: 15/15 passes under artificial 28-way CPU contention (approximating CI shard-parallel load)
- [x] Full `go test ./cmd/gc/...` passes (417s, no regressions)
- [x] Real pre-push gate (`make test-fast-parallel`, not `--no-verify`) passed on retry after first attempt hit an unrelated, already-tracked host-contention flake (ga-alwb9s, `TestCmdStopWallClockTimeoutBoundsDirectStop`)

Closes ga-ajmj0y.