### PR TITLE
Fix event rotation conformance timeout accounting

### DIFF
--- a/internal/events/eventstest/conformance.go
+++ b/internal/events/eventstest/conformance.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // rotatableProvider is the small interface a Provider must satisfy
@@ -733,7 +734,15 @@ func RunRotationTests(t *testing.T, newProvider func(t *testing.T) (events.Provi
 
 		// Phase 2: start a watcher BEFORE rotation. Drain any backlog
 		// so the watcher's offset is at end-of-active before we rotate.
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		//
+		// The watcher's own context is cancel-only, not deadline-bound:
+		// ForceRotate's fsync+rename and the gzip+reap behind res.Done below
+		// are this subtest's heaviest I/O, and sit between here and the
+		// post-rotate reads. A shared deadline charges that setup I/O
+		// against the read's budget instead of the read itself — nextWithin
+		// gives each blocking read its own fresh deadline so a slow disk
+		// slows the test instead of failing it.
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		w, err := p.Watch(ctx, 0)
 		if err != nil {
@@ -741,9 +750,24 @@ func RunRotationTests(t *testing.T, newProvider func(t *testing.T) (events.Provi
 		}
 		defer w.Close() //nolint:errcheck // test cleanup
 
+		nextWithin := func(d time.Duration) (events.Event, error) {
+			type result struct {
+				e   events.Event
+				err error
+			}
+			ch := make(chan result, 1)
+			go func() { e, err := w.Next(); ch <- result{e, err} }()
+			select {
+			case r := <-ch:
+				return r.e, r.err
+			case <-time.After(d):
+				return events.Event{}, context.DeadlineExceeded
+			}
+		}
+
 		seen := make([]events.Event, 0, 5)
 		for i := 0; i < 5; i++ {
-			e, err := w.Next()
+			e, err := nextWithin(testutil.GoroutineRaceTimeout)
 			if err != nil {
 				t.Fatalf("Next pre %d: %v", i, err)
 			}
@@ -776,7 +800,7 @@ func RunRotationTests(t *testing.T, newProvider func(t *testing.T) (events.Provi
 		// (c) The watcher should yield the anchor + the post-rotate
 		// events without gap.
 		for i := 0; i < 4; i++ { // 1 anchor + 3 post-rotate
-			e, err := w.Next()
+			e, err := nextWithin(testutil.GoroutineRaceTimeout)
 			if err != nil {
 				t.Fatalf("Next post %d: %v", i, err)
 			}

--- a/release-gates/ga-u7f149-rotation-conformance-timeout-gate.md
+++ b/release-gates/ga-u7f149-rotation-conformance-timeout-gate.md
@@ -1,0 +1,51 @@
+# Release Gate: rotation conformance per-read timeout
+
+Status: PASS
+
+Deploy bead: `ga-u7f149`
+Source bead: `ga-mllb6t`
+Review bead: `ga-7y3hku`
+Reviewed commit: `e26a24c1868d057d615cb5533fbed3dc97e10e9a`
+Planned deploy branch: `deploy/ga-u7f149-gate`
+Base evaluated: `origin/main` at `7a5bdeeee5c240663964916cea4c8f72dd91c1f4`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the deployer role's release criteria and the repository testing policy in
+`TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. The reviewed branch's remote tip exactly matched the recorded SHA. `git merge-tree --write-tree origin/main e26a24c1868d057d615cb5533fbed3dc97e10e9a` exited 0 and produced tree `b552224ff6f5d068933d28bc0e395da972430397`. |
+| 1 | Review PASS present | PASS | Review bead `ga-7y3hku` is closed with verdict PASS for `builder/ga-c1r8af` at the reviewed commit. Its style, security, and specification checks all report no blocking findings. |
+| 2 | Acceptance criteria met | PASS | `RunRotationTests` now uses `context.WithCancel` for watcher lifetime and routes every blocking read through `nextWithin(testutil.GoroutineRaceTimeout)`. No `context.WithTimeout`, direct loop-level `w.Next`, or `10*time.Second` literal remains in the function. The file is gofmt-clean, the focused conformance test passed 20 repetitions, the independent exec consumer passed, and a freshly built stress binary completed 600/600 rotation-invariant runs without failure. |
+| 3 | Tests pass | PASS | `go test ./internal/events/... -run TestFileRecorderConformance -count=20`; `go test ./internal/events/exec/... -count=1`; 24 workers × 25 runs of `TestFileRecorderConformance/RotationPreservesInvariants` from a freshly built binary (600 runs, 0 failures); `make test-fast-parallel` (all 9 jobs passed); and `go vet ./...` all passed. |
+| 4 | No high-severity review findings open | PASS | Review notes report no style or security findings and no blocking issue; unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | Before creating this checklist, `git status --porcelain=v1` returned no entries at the exact reviewed commit. The checklist is committed separately as the deploy-branch tip. |
+| 7 | Single feature theme | PASS | The reviewed commit changes only `internal/events/eventstest/conformance.go`, within one test-harness subsystem, to replace a shared rotation deadline with per-read deadlines. |
+
+## Acceptance Evidence
+
+- The watcher remains explicitly bounded by the existing deferred `cancel` and
+  `Close` calls, while rotation I/O no longer consumes the read deadline.
+- Both the pre-rotation drain and post-rotation read loop call the same local
+  `nextWithin` helper with the repository's centralized goroutine-race timeout.
+- The helper uses a buffered result channel, matching the existing per-read
+  timeout idiom in this conformance package without introducing a new
+  production abstraction.
+- Production event recording and watcher code are unchanged.
+
+## Commands
+
+```text
+git ls-remote origin refs/heads/builder/ga-c1r8af
+git merge-tree --write-tree origin/main e26a24c1868d057d615cb5533fbed3dc97e10e9a
+gofmt -l internal/events/eventstest/conformance.go
+git diff --check e26a24c1868d057d615cb5533fbed3dc97e10e9a^
+go test ./internal/events/... -run TestFileRecorderConformance -count=20
+go test ./internal/events/exec/... -count=1
+go test -c ./internal/events
+make test-fast-parallel
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

Makes the file-recorder rotation conformance test reliable on slow or contended disks. The test previously used one 10-second context for watcher setup, rotation fsync/rename work, archive compression and reaping, and the later reads. Enough setup I/O could therefore expire the context before the watcher tried to read events that were already durable.

The watcher now has a cancel-only lifetime, while each blocking read gets its own fresh repository-standard timeout. Production event recording and watcher behavior are unchanged.

## Review notes

- Scope is limited to `internal/events/eventstest/conformance.go`.
- Both pre-rotation and post-rotation reads use the same local buffered helper.
- There are no configuration, API, schema, dependency, or migration changes.

## Test plan

- [x] `go test ./internal/events/... -run TestFileRecorderConformance -count=20`
- [x] `go test ./internal/events/exec/... -count=1`
- [x] Fresh test binary: 600 rotation-invariant stress runs, zero failures
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-u7f149-rotation-conformance-timeout-gate.md`](release-gates/ga-u7f149-rotation-conformance-timeout-gate.md)