### PR TITLE
test(cmd/gc): migrate gatedStartProvider.waitForStarts to hangBudget

### DIFF
--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -233,6 +233,30 @@ func (p *gatedStartProvider) ensureNoFurtherStart(t *testing.T, wait time.Durati
 	}
 }
 
+// TestGatedStartProviderWaitForStartsSurvivesDelayPastOldFixedDeadline proves
+// waitForStarts watches for hangBudget, not a fixed deadline: a start signal
+// arriving after the old 3s literal (but well inside hangBudget) must still
+// be observed rather than reported as a timeout.
+func TestGatedStartProviderWaitForStartsSurvivesDelayPastOldFixedDeadline(t *testing.T) {
+	t.Parallel()
+
+	const oldFixedDeadline = 3 * time.Second
+	if hangBudget <= oldFixedDeadline {
+		t.Fatalf("hangBudget = %s, want > %s (the fixed deadline this helper replaced)", hangBudget, oldFixedDeadline)
+	}
+
+	p := newGatedStartProvider()
+	go func() {
+		<-time.After(oldFixedDeadline + time.Second)
+		p.startSignals <- "late-start"
+	}()
+
+	got := p.waitForStarts(t, 1)
+	if len(got) != 1 || got[0] != "late-start" {
+		t.Fatalf("waitForStarts = %v, want [late-start]", got)
+	}
+}
+
 type shutdownWaitProvider struct {
 	*gatedStartProvider
 	listCalled chan struct{}

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -212,7 +212,7 @@ func (p *gatedStartProvider) release(name string) {
 func (p *gatedStartProvider) waitForStarts(t *testing.T, n int) []string {
 	t.Helper()
 	var names []string
-	timeout := time.After(3 * time.Second)
+	timeout := time.After(hangBudget)
 	for len(names) < n {
 		select {
 		case name := <-p.startSignals:


### PR DESCRIPTION
## Summary
- Swaps the raw `time.After(3*time.Second)` literal in `gatedStartProvider.waitForStarts` (`cmd/gc/session_lifecycle_parallel_test.go`) for the shared `hangBudget` constant, matching the sibling helpers `gatedStopProvider.waitForStops`/`waitForInterrupts` already migrated by #4638.
- Test-only change, no production code touched.

## Why this PR exists now
ga-hp32mm was reviewed PASS (verdict recorded 2026-07-25) but the bead was closed on "branch pushed" without a PR ever being opened, leaving the work stranded and untracked. The mayor flagged this explicitly on 2026-07-26 (06:35 PT, on ga-hp32mm's own notes): *"CLOSED BUT NOT LANDED... NEEDED: open a PR from builder/ga-hp32mm (do not cherry-pick to main)."* This PR is that explicitly-requested action, surfaced during the ga-mlyy1g stale-molecule triage sweep. Not auto-merging — landing follows the normal review/merge process.

## Evidence
- RED: `a6b6017a8` — `TestGatedStartProviderWaitForStartsSurvivesDelayPastOldFixedDeadline`, confirmed failing against the raw 3s literal.
- GREEN: `212cd3010` — swap to `hangBudget`; new test + `TestCmdStopForceEscalatesInProgressControllerStop` + `TestCmdStopWaitsForStandaloneControllerExit` pass `-race -count=5` (5/5); full `make test-fast-parallel` all 8 shards clean.
- Reviewer verdict (gascity/reviewer, independently re-verified in a throwaway worktree): PASS. `go vet`/`gofmt` clean, targeted race tests 10/10 pass, full `test-fast-parallel` rerun clean.
- Confirmed today: `212cd3010` is still not an ancestor of `origin/main` — the strand is real and current, not stale.

## Test plan
- [x] `go test ./cmd/gc/... -run 'TestCmdStopForceEscalatesInProgressControllerStop|TestCmdStopWaitsForStandaloneControllerExit'` -race -count=5 (reviewer-verified, 10/10 pass)
- [x] `make test-fast-parallel` full run, all 8 shards (builder + reviewer both verified clean)
- [x] `go vet ./...`, `gofmt` clean

Refs: ga-hp32mm, ga-np3ni9 (molecule root), ga-mlyy1g (triage sweep that surfaced this)