### PR TITLE
Periodic Dolt GC sweep, beads v1.1.2 bump, dog-doctor latency threshold

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -521,8 +521,13 @@ func (cs *controllerState) startMaintenanceLoop(ctx context.Context) {
 		DiskFreeBytes:     doltContainerFreeBytesFunc,
 		DiskMinFreeBytes:  doltDiskMinFreeBytes(),
 		DiskWarnFreeBytes: doltDiskWarnFreeBytes(),
+		OpenDoltOps:       maintenanceDoltOpsFactory(cityPath),
+		StoreSizeBytes:    maintenanceStoreSizeFunc(cityPath),
 	}
-	active := deps.OpenDoltOps != nil && deps.OpenDoltBackup != nil
+	// "active" tracks whether CALL DOLT_GC is wired (the primary maintenance
+	// action). The backup snapshot is a separate, optional stage that no-ops
+	// when OpenDoltBackup is nil, so it does not gate the active banner.
+	active := deps.OpenDoltOps != nil
 	// Always log the loop's startup so operators can confirm initialization
 	// (and its mode) from the supervisor log, not just the observe-only case.
 	fmt.Fprintln(os.Stderr, maintenanceStartupLine(cfg.Maintenance.Dolt.IntervalOrDefault(), active)) //nolint:errcheck // best-effort stderr
@@ -543,7 +548,7 @@ func (cs *controllerState) startMaintenanceLoop(ctx context.Context) {
 func maintenanceStartupLine(interval time.Duration, active bool) string {
 	mode := "active"
 	if !active {
-		mode = "observe-only (snapshot and DOLT_GC not yet wired)"
+		mode = "observe-only (CALL DOLT_GC not wired — non-Dolt backend)"
 	}
 	return fmt.Sprintf("store-maintenance: loop started interval=%s mode=%s", interval, mode)
 }

--- a/cmd/gc/maintenance_dolt_ops.go
+++ b/cmd/gc/maintenance_dolt_ops.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/doltauth"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/storehealth"
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// maintenanceStoreSizeFunc returns a probe that measures the on-disk size
+// of the city's managed Dolt store. It feeds the store-maintenance size
+// gate (skip CALL DOLT_GC below MinStoreMB) and the before/after byte
+// deltas recorded on each run. A missing store reads as 0 bytes.
+func maintenanceStoreSizeFunc(cityPath string) func() int64 {
+	return func() int64 {
+		return storehealth.WalkSize(storehealth.StorePath(cityPath))
+	}
+}
+
+// maintenanceDoltOpsFactory builds the DoltOpsFactory the store-maintenance
+// loop uses to sweep CALL DOLT_GC across the city's managed Dolt databases.
+// It returns nil when the city scope is Postgres-backed — there is no Dolt
+// server to GC — which leaves the loop in observe-only mode.
+//
+// The connection is resolved per cycle (not cached) so endpoint changes are
+// picked up and no idle connection is held across the maintenance interval.
+// A resolution or dial failure surfaces as a stage="gc" MaintenanceError for
+// that cycle; the loop alerts and retries on the next interval rather than
+// failing supervisor startup.
+func maintenanceDoltOpsFactory(cityPath string) supervisor.DoltOpsFactory {
+	if scopeBackendIsPostgres(cityPath, cityPath) {
+		return nil
+	}
+	return supervisor.NewSQLDoltOps(func(_ context.Context) (*sql.DB, error) {
+		dsn, err := resolveMaintenanceDoltDSN(cityPath)
+		if err != nil {
+			return nil, err
+		}
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			return nil, err
+		}
+		// The sweep is sequential (one database at a time); a small pool is
+		// enough and bounds idle connections held against the Dolt server.
+		db.SetMaxOpenConns(2)
+		db.SetConnMaxLifetime(time.Minute)
+		return db, nil
+	})
+}
+
+// resolveMaintenanceDoltDSN resolves the city-scope managed Dolt endpoint
+// and credentials into a go-sql-driver/mysql DSN. Mirrors the resolution in
+// internal/api (resolveDoltConnection + buildDoltDSN), kept local because
+// those helpers are unexported there.
+func resolveMaintenanceDoltDSN(cityPath string) (string, error) {
+	target, err := contract.ResolveDoltConnectionTarget(fsys.OSFS{}, cityPath, cityPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve dolt target: %w", err)
+	}
+	host := strings.TrimSpace(target.Host)
+	if host == "" {
+		return "", fmt.Errorf("missing dolt host for city %s", cityPath)
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(target.Port))
+	if err != nil {
+		return "", fmt.Errorf("parse dolt port %q: %w", target.Port, err)
+	}
+	auth := doltauth.Resolve(doltauth.AuthScopeRoot(cityPath, cityPath, target), strings.TrimSpace(target.User), host, port)
+	return buildMaintenanceDoltDSN(auth.User, auth.Password, host, port, target.Database), nil
+}
+
+// buildMaintenanceDoltDSN formats a mysql DSN for the maintenance sweep.
+// The database is the city default; the sweep selects each target database
+// with USE, so the DSN only needs an initial database the connection can
+// open. AllowNativePasswords mirrors every other managed-Dolt connection in
+// this binary.
+func buildMaintenanceDoltDSN(user, password, host string, port int, database string) string {
+	user = strings.TrimSpace(user)
+	if user == "" {
+		user = "root"
+	}
+	cfg := mysql.Config{
+		User:                 user,
+		Passwd:               password,
+		Net:                  "tcp",
+		Addr:                 fmt.Sprintf("%s:%d", host, port),
+		DBName:               database,
+		AllowNativePasswords: true,
+		// No ReadTimeout: CALL DOLT_GC can run for minutes and is bounded by
+		// the per-database context deadline (DoltMaintenance.GCTimeout), not
+		// the driver's socket read timeout. Timeout is the dial timeout only.
+		Timeout: 10 * time.Second,
+	}
+	return cfg.FormatDSN()
+}

--- a/cmd/gc/maintenance_dolt_ops_test.go
+++ b/cmd/gc/maintenance_dolt_ops_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/gastownhall/gascity/internal/storehealth"
+)
+
+func TestMaintenanceStoreSizeFunc(t *testing.T) {
+	city := t.TempDir()
+
+	// A city with no Dolt store yet reads as 0 bytes (fresh install).
+	if got := maintenanceStoreSizeFunc(city)(); got != 0 {
+		t.Fatalf("store size with no store dir = %d, want 0", got)
+	}
+
+	storeDir := storehealth.StorePath(city)
+	if err := os.MkdirAll(filepath.Join(storeDir, "noms"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("0123456789") // 10 bytes
+	if err := os.WriteFile(filepath.Join(storeDir, "noms", "chunk.bin"), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := maintenanceStoreSizeFunc(city)(); got != int64(len(payload)) {
+		t.Fatalf("store size = %d, want %d", got, len(payload))
+	}
+}
+
+func TestBuildMaintenanceDoltDSN(t *testing.T) {
+	cases := []struct {
+		name     string
+		user     string
+		password string
+		wantUser string
+	}{
+		{name: "explicit user", user: "agent", wantUser: "agent"},
+		{name: "defaults to root", user: "", wantUser: "root"},
+		{name: "escapes password", user: "agent", password: "p@ss:word", wantUser: "agent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dsn := buildMaintenanceDoltDSN(tc.user, tc.password, "db.example.com", 3307, "hq")
+			cfg, err := mysql.ParseDSN(dsn)
+			if err != nil {
+				t.Fatalf("ParseDSN(%q) error = %v", dsn, err)
+			}
+			if cfg.User != tc.wantUser {
+				t.Errorf("User = %q, want %q", cfg.User, tc.wantUser)
+			}
+			if cfg.Passwd != tc.password {
+				t.Errorf("Passwd = %q, want %q", cfg.Passwd, tc.password)
+			}
+			if cfg.Net != "tcp" {
+				t.Errorf("Net = %q, want tcp", cfg.Net)
+			}
+			if cfg.Addr != "db.example.com:3307" {
+				t.Errorf("Addr = %q, want db.example.com:3307", cfg.Addr)
+			}
+			if cfg.DBName != "hq" {
+				t.Errorf("DBName = %q, want hq", cfg.DBName)
+			}
+			if !cfg.AllowNativePasswords {
+				t.Error("AllowNativePasswords disabled; managed Dolt auth needs it enabled")
+			}
+		})
+	}
+}
+
+func TestMaintenanceDoltOpsFactoryNonPostgresReturnsFactory(t *testing.T) {
+	// A plain city directory (no Postgres backend metadata) must yield a
+	// non-nil factory so the loop runs in active GC mode. The Postgres-nil
+	// branch is a defensive guard for non-Dolt backends and is exercised by
+	// the backend-resolution tests rather than reconstructed here.
+	city := t.TempDir()
+	if maintenanceDoltOpsFactory(city) == nil {
+		t.Fatal("maintenanceDoltOpsFactory(non-postgres city) = nil; want non-nil DoltOpsFactory")
+	}
+}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -375,6 +375,7 @@ DoltMaintenance configures the periodic Dolt store maintenance loop.
 | `interval` | string |  | `168h` | Interval is the cadence between maintenance runs as a duration string (e.g., "168h"). Defaults to 168h (weekly). |
 | `alert_to` | string |  |  | AlertTo is the agent identity to mail on failure (e.g., "gascity/mayor"). Empty disables alert mail. |
 | `gc_timeout` | string |  | `10m` | GCTimeout is the ceiling for CALL DOLT_GC() as a duration string. Defaults to 10m. |
+| `min_store_mb` | integer |  | `1024` | MinStoreMB gates CALL DOLT_GC() on the on-disk store size: the GC stage is skipped when the store is smaller than this many mebibytes, because dolt_gc on a small store reclaims little and is not worth the maintenance lease. Nil (unset) defaults to 1024 (≈1 GiB), the size at which observed store bloat begins to degrade query latency. Set to 0 to disable the gate and run GC on every scheduled cycle regardless of size. Negative values are treated as 0 (disabled). |
 
 ## EventsConfig
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1490,6 +1490,11 @@
           "type": "string",
           "description": "GCTimeout is the ceiling for CALL DOLT_GC() as a duration string.\nDefaults to 10m.",
           "default": "10m"
+        },
+        "min_store_mb": {
+          "type": "integer",
+          "description": "MinStoreMB gates CALL DOLT_GC() on the on-disk store size: the GC\nstage is skipped when the store is smaller than this many mebibytes,\nbecause dolt_gc on a small store reclaims little and is not worth the\nmaintenance lease. Nil (unset) defaults to 1024 (≈1 GiB), the size at\nwhich observed store bloat begins to degrade query latency. Set to 0\nto disable the gate and run GC on every scheduled cycle regardless of\nsize. Negative values are treated as 0 (disabled).",
+          "default": 1024
         }
       },
       "additionalProperties": false,

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1490,6 +1490,11 @@
           "type": "string",
           "description": "GCTimeout is the ceiling for CALL DOLT_GC() as a duration string.\nDefaults to 10m.",
           "default": "10m"
+        },
+        "min_store_mb": {
+          "type": "integer",
+          "description": "MinStoreMB gates CALL DOLT_GC() on the on-disk store size: the GC\nstage is skipped when the store is smaller than this many mebibytes,\nbecause dolt_gc on a small store reclaims little and is not worth the\nmaintenance lease. Nil (unset) defaults to 1024 (≈1 GiB), the size at\nwhich observed store bloat begins to degrade query latency. Set to 0\nto disable the gate and run GC on every scheduled cycle regardless of\nsize. Negative values are treated as 0 (disabled).",
+          "default": 1024
         }
       },
       "additionalProperties": false,

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -322,6 +322,26 @@ override targeting a nonexistent order is an error, not a silent no-op — `gc
 order` commands fail; `gc start` logs the error and continues with the unmatched
 override skipped.
 
+### Tuning an exec order's environment
+
+For `exec` orders, `[orders.overrides.env]` injects environment variables into
+the order's child process. This is the supported way to retune a pack script's
+thresholds without editing (and losing on re-embed) its source. For example,
+the built-in `mol-dog-doctor` order emits a `Dolt health advisory [MEDIUM]`
+mail when Dolt probe latency reaches its warn threshold (3s by default). On a
+heavily loaded box where healthy latency grazes higher, raise it to 5s:
+
+```toml
+[[orders.overrides]]
+name = "mol-dog-doctor"
+
+[orders.overrides.env]
+GC_DOCTOR_LATENCY_WARN_MS = "5000"
+```
+
+Env overrides apply only to `exec` orders; controller-owned routing and
+identity keys are rejected before dispatch.
+
 <Accordion title="Disambiguating overrides when an order exists both city-wide and per-rig">
 Many orders expand at scan time into one instance per rig (anything in a rig's
 `orders/` directory or a pack imported into a rig). When the same order appears

--- a/engdocs/contributors/dolt-maintenance.md
+++ b/engdocs/contributors/dolt-maintenance.md
@@ -8,18 +8,20 @@ The loop runs **inside the supervisor process** when opted in via
 
 ## Current wiring status
 
-**Observe-only mode (as of this release).** The SQL connection to Dolt
-(`OpenDoltOps`) and the backup runner (`OpenDoltBackup`) are not yet
-wired in the production controller. When `[maintenance.dolt]
-enabled=true`, the loop runs on schedule, emits events, and records
-history — but steps 2 (snapshot) and 3 (compaction) below are no-ops.
-The supervisor logs `store-maintenance: enabled in observe-only mode
-(snapshot and DOLT_GC not yet wired)` at startup.
+**Compaction is wired (active mode).** The SQL connection to Dolt
+(`OpenDoltOps`) is wired in the production controller, so step 3 below
+runs `CALL DOLT_GC()` against the live store. On a Dolt-backed city the
+supervisor logs `store-maintenance: loop started interval=<I> mode=active`
+at startup; on a non-Dolt (Postgres) backend it logs `mode=observe-only
+(CALL DOLT_GC not wired — non-Dolt backend)` and the GC step no-ops.
 
-Production wiring of the snapshot and GC factories will land in a
-follow-up. Until then, `gc maintenance status` and the events are
-meaningful for scheduling/alert testing, but a `gc.store.maintenance.done`
-event does **not** imply compaction occurred.
+**The pre-gc snapshot is not yet wired.** The backup runner
+(`OpenDoltBackup`) is still nil, so step 2 (snapshot) is a no-op and the
+*Emergency rollback* section below has no snapshot to restore from until
+that lands in a follow-up. This matches the prior interim behavior (a
+launchd `dolt-gc.sh` that GC'd without snapshotting); the supervisor now
+owns the GC on the same risk profile, gated on store size and verified by
+the per-database smoke test.
 
 ## What this runs
 
@@ -30,10 +32,20 @@ For each scheduled cycle the supervisor:
 2. **Snapshot** — `dolt backup sync` to
    `<city>/.beads/dolt-backups/current/`, then atomically rotates
    `current/` to `success/<timestamp>/` (see *Snapshot layout* below).
-3. **Compaction** — `CALL DOLT_GC()` against the managed Dolt server,
-   bounded by `gc_timeout` (default `10m`).
-4. **Smoke test** — `SELECT COUNT(*) FROM issues` (5 s timeout) to
-   confirm the store is readable.
+   *(Not yet wired — see Current wiring status.)*
+3. **Compaction** — a per-database sweep. Each Dolt database is a
+   separate repository with its own chunk store, so the loop runs
+   `SHOW DATABASES`, drops the system schemas, and runs `CALL DOLT_GC()`
+   against every remaining database (`hq` + each rig), each bounded by
+   `gc_timeout` (default `10m`). The whole sweep is skipped when the
+   on-disk store is below `min_store_mb` (default `1024` MiB ≈ 1 GiB),
+   because GC on a small store reclaims little; a skipped cycle still
+   records a `done` event with `before_bytes == after_bytes`.
+4. **Smoke test** — after GC'ing a database, `SELECT COUNT(*) FROM issues`
+   against it (5 s timeout) confirms the store is still queryable. A SQL
+   error fails the cycle (`stage=smoke-test`); a zero count is healthy —
+   an empty rig is a valid post-gc state. Per-database failures are
+   aggregated, and the failing database names appear in the error.
 5. **Prune** — keep the 3 newest successful snapshots and the most
    recent failed snapshot; older entries are removed. Prune errors
    are logged but do not regress a successful run.
@@ -56,9 +68,10 @@ until they explicitly opt in.
    [maintenance.dolt]
    enabled = true
    # All other keys are optional; defaults shown:
-   # interval   = "168h"   # weekly
-   # gc_timeout = "10m"
-   # alert_to   = ""       # no alert until set; see "Alerting" below
+   # interval     = "168h"  # weekly
+   # gc_timeout   = "10m"
+   # min_store_mb = 1024     # skip GC below ~1 GiB; 0 disables the gate
+   # alert_to     = ""       # no alert until set; see "Alerting" below
    ```
 
 2. Restart the controller so the loop picks up the new config:
@@ -255,8 +268,9 @@ events remain visible via `gc events`.
 ## References
 
 - Implementation:
-  - `internal/supervisor/maintenance.go` (loop + lease)
+  - `internal/supervisor/maintenance.go` (loop + lease + per-database GC sweep)
   - `internal/supervisor/maintenance_snapshot.go` (backup + retention)
+  - `cmd/gc/maintenance_dolt_ops.go` (production GC connection + size probe wiring)
   - `cmd/gc/cmd_maintenance.go` (CLI)
   - `cmd/gc/store_health.go` (status block)
 - Dolt: `dolt gc`, `dolt backup`, `dolt clone`

--- a/examples/bd/dolt/assets/scripts/latency.sh
+++ b/examples/bd/dolt/assets/scripts/latency.sh
@@ -5,7 +5,8 @@
 #
 # Replaces whole-second 'date +%s' timing, which quantizes a sub-second probe
 # to 0s or 1s depending on whether it straddles a wall-clock second tick —
-# producing false latency WARNs (and MEDIUM advisory mail) at a 1s threshold.
+# producing false latency WARNs (and MEDIUM advisory mail) at a low (e.g. 1s)
+# warn threshold.
 
 # _now_ms_plausible VALUE — exit 0 when VALUE looks like an epoch-millisecond
 # reading: all digits, 13 or 14 of them (epoch-ms is 13 digits from 2001-09-09
@@ -34,7 +35,7 @@ _now_ms_plausible() {
 #
 # The cascade exists because a GNU-only implementation silently degrades to
 # whole seconds on BSD/macOS, where a sub-second probe that straddles a
-# wall-clock second tick measures 1000ms and false-trips the default 1000ms
+# wall-clock second tick measures 1000ms and false-trips a low (e.g. 1000ms)
 # warn threshold — the same advisory storm the millisecond rewrite was meant
 # to stop, in different units.
 now_ms() {
@@ -61,4 +62,22 @@ now_ms() {
 # '>=' semantics, now in milliseconds.
 latency_should_warn() {
   [ "${1:-0}" -ge "${2:-0}" ]
+}
+
+# latency_warn_threshold_ms — echo the latency-WARN threshold in milliseconds,
+# resolved from the environment. Precedence, first match wins:
+#   1. GC_DOCTOR_LATENCY_WARN_MS — explicit millisecond threshold.
+#   2. GC_DOCTOR_LATENCY_WARN_S  — legacy whole-second knob, scaled x1000.
+#   3. 3000ms (3s) default.
+#
+# The default is 3s, not 1s. A box hosting several rigs grazes 1-2s probe
+# latency routinely while the data plane stays healthy, so a 1s threshold
+# false-tripped the MEDIUM "Dolt health advisory" mail dozens of times a day
+# (gascity ga-w7u). 3s sits above that routine band and one tier below the
+# deacon patrol's 5s "server may be overloaded" line, so the informational
+# advisory still gives an early heads-up without the noise. Operators retune
+# it per city without editing this script via the mol-dog-doctor order's
+# [[orders.overrides]].env (set GC_DOCTOR_LATENCY_WARN_MS).
+latency_warn_threshold_ms() {
+  printf '%s\n' "${GC_DOCTOR_LATENCY_WARN_MS:-$(( ${GC_DOCTOR_LATENCY_WARN_S:-3} * 1000 ))}"
 }

--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -25,10 +25,10 @@ PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." 
 PORT="$GC_DOLT_PORT"
 HOST="${GC_DOLT_HOST:-127.0.0.1}"
 USER="${GC_DOLT_USER:-root}"
-# Latency warn threshold in milliseconds. GC_DOCTOR_LATENCY_WARN_MS takes
-# precedence; otherwise derive from the legacy seconds knob (default 1s ->
-# 1000ms) for backward compatibility.
-LATENCY_WARN_MS="${GC_DOCTOR_LATENCY_WARN_MS:-$(( ${GC_DOCTOR_LATENCY_WARN_S:-1} * 1000 ))}"
+# Latency warn threshold in milliseconds; latency_warn_threshold_ms (sourced
+# from latency.sh) resolves the GC_DOCTOR_LATENCY_WARN_MS / _S env knobs and
+# the 3s default. Retune per city via the order's [[orders.overrides]].env.
+LATENCY_WARN_MS="$(latency_warn_threshold_ms)"
 CONN_WARN_PCT="${GC_DOCTOR_CONN_WARN_PCT:-80}"
 BACKUP_STALE_S="${GC_DOCTOR_BACKUP_STALE_S:-43200}"  # 2x 6h backup interval
 BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -2347,6 +2347,159 @@ func TestWitnessStartupAndNoIdleReconcileWisps(t *testing.T) {
 	}
 }
 
+// gastownRolePrompts returns every gastown role's prompt template, keyed by role
+// name and valued by its packs/gastown-relative path (for renderGastownPromptForPack
+// / gastownRel). It globs agents/*/prompt.template.md so cross-role guards cover
+// newly added roles automatically instead of going stale against a hand-kept list.
+func gastownRolePrompts(t *testing.T) map[string]string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(packRoot(), "packs", "gastown", "agents", "*", "prompt.template.md"))
+	if err != nil {
+		t.Fatalf("glob role prompts: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no gastown role prompt templates found under packs/gastown/agents")
+	}
+	prompts := make(map[string]string, len(matches))
+	for _, m := range matches {
+		role := filepath.Base(filepath.Dir(m))
+		prompts[role] = "packs/gastown/agents/" + role + "/prompt.template.md"
+	}
+	return prompts
+}
+
+// isWispHookCheckCommand reports whether a rendered prompt line is a wisp/molecule
+// hook-check: a `gc bd list`/`gc bd query` filtered to the molecule (or the
+// invalid wisp) type. These are the lookups that must request --json, because
+// bd's text list view hides ephemeral (wisp-table) rows — see the ga-p9g root
+// cause documented on TestAllRoleWispHookChecksUseJSON.
+func isWispHookCheckCommand(line string) bool {
+	if !strings.Contains(line, "gc bd list") && !strings.Contains(line, "gc bd query") {
+		return false
+	}
+	return strings.Contains(line, "--type=molecule") || strings.Contains(line, "--type=wisp")
+}
+
+// TestAllRoleWispHookChecksUseJSON is the cross-role regression guard for the
+// town-wide wisp-leak family (ga-p9g), generalizing the witness-only ga-7c6 fix
+// to every role prompt.
+//
+// Root cause (external bd v1.0.5, cmd/bd/list.go): wisps/molecules live in the
+// separate wisps table (migration 007). SearchIssues normally unions it, but the
+// *text* list path sets filter.SkipWisps=true as a perf optimization while the
+// *JSON* path never does. So `gc bd list … --type=molecule` in text form silently
+// returns "No issues found" while the same query with --json returns the wisp.
+// molecule/wisp are not bd "infra" types ({agent,rig,role,message}), so an
+// explicit --type filter cannot rescue the text path. A role whose patrol-wisp
+// reconciliation reads its hook in text form never sees its own wisp and pours a
+// duplicate on every restart.
+//
+// The in-repo SDK already defends against this — config hook-check queries use
+// --json (Agent.effectiveAssignedInProgressQuery), and internal/beads
+// BdStore.listWispsTier unions `bd query "ephemeral=true …"` precisely because
+// "the installed bd list surface does not expose ephemeral rows." This guard
+// extends that invariant to the gastown role prompts: every role's wisp/molecule
+// hook-check must request --json. It would have failed against the pre-fix witness
+// prompt, which reconciled wisps with text-form `gc bd list --type=molecule`.
+func TestAllRoleWispHookChecksUseJSON(t *testing.T) {
+	examined := 0
+	for role, rel := range gastownRolePrompts(t) {
+		rendered := renderGastownPromptForPack(t, rel,
+			"gastown/"+role, role, "demo", "gastown", "gastown.")
+		for i, line := range strings.Split(rendered, "\n") {
+			if !isWispHookCheckCommand(line) {
+				continue
+			}
+			examined++
+			if !strings.Contains(line, "--json") {
+				t.Errorf("%s prompt line %d runs a molecule/wisp hook-check without --json; "+
+					"bd's text list view hides wisp-table rows, so the lookup silently finds "+
+					"nothing and the role pours a duplicate wisp (ga-p9g):\n  %s",
+					role, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+	// Guard against a vacuous pass: at least the witness/deacon/refinery patrol
+	// reconciliations issue molecule/wisp hook-checks. If the matcher stops
+	// finding any (template refactor, renamed command), fail loudly rather than
+	// silently certifying an invariant that examined nothing.
+	if examined == 0 {
+		t.Fatal("examined no molecule/wisp hook-check commands across any role prompt; " +
+			"isWispHookCheckCommand no longer matches the templates — this guard would pass vacuously")
+	}
+}
+
+// TestAllRoleWispHookChecksUseValidMoleculeType guards the type half of the same
+// invariant: patrol wisps are molecule-rooted (mol-*-patrol), so a hook-check must
+// filter --type=molecule, never --type=wisp. "wisp" is not a valid bd issue type —
+// bd rejects it outright (`invalid issue type "wisp"`) — so the query errors and
+// matches nothing, producing the same duplicate-wisp leak as the text-view bug.
+//
+// knownWispTypeOffenders are roles whose external prompt templates
+// (gastownhall/gascity-packs, the read-only module dependency this repo consumes)
+// still ship the invalid --type=wisp. They are tracked for an upstream fix
+// (deacon/refinery → --type=molecule, mirroring the witness ga-7c6 fix). The
+// allowlist is deliberately self-cleaning: each listed role must STILL use
+// --type=wisp, so once the pack dependency is bumped to a fixed version the
+// offending line disappears, this test fails, and the stale entry must be removed —
+// tightening the guard to enforce valid types for every role.
+func TestAllRoleWispHookChecksUseValidMoleculeType(t *testing.T) {
+	knownWispTypeOffenders := map[string]string{
+		"deacon":   "gascity-packs deacon prompt still uses gc bd list --type=wisp; fix upstream to --type=molecule",
+		"refinery": "gascity-packs refinery prompt still uses gc bd list --type=wisp; fix upstream to --type=molecule",
+	}
+	for role, rel := range gastownRolePrompts(t) {
+		rendered := renderGastownPromptForPack(t, rel,
+			"gastown/"+role, role, "demo", "gastown", "gastown.")
+		usesInvalidWispType := false
+		for _, line := range strings.Split(rendered, "\n") {
+			if strings.Contains(line, "gc bd") && strings.Contains(line, "--type=wisp") {
+				usesInvalidWispType = true
+				if _, known := knownWispTypeOffenders[role]; !known {
+					t.Errorf("%s prompt runs a gc bd command with invalid --type=wisp; "+
+						"\"wisp\" is not a bd issue type (bd: invalid issue type \"wisp\"), so the "+
+						"lookup matches nothing and the role pours a duplicate wisp — use "+
+						"--type=molecule (ga-p9g):\n  %s", role, strings.TrimSpace(line))
+				}
+			}
+		}
+		if reason, known := knownWispTypeOffenders[role]; known && !usesInvalidWispType {
+			t.Errorf("%s is allow-listed as a known --type=wisp offender (%q) but its prompt no "+
+				"longer uses --type=wisp; the upstream gascity-packs fix has landed — remove %q from "+
+				"knownWispTypeOffenders so this guard enforces valid wisp types for every role",
+				role, reason, role)
+		}
+	}
+}
+
+// TestIsWispHookCheckCommandMatchesWispLookups pins the matcher used by the
+// cross-role wisp guards, proving they are not vacuous: the pre-fix witness
+// lookup (text-form `gc bd list … --type=molecule`, the exact ga-p9g symptom) is
+// matched — so TestAllRoleWispHookChecksUseJSON would flag it for lacking --json —
+// while ordinary non-wisp commands and the wisp-pouring command are not matched.
+func TestIsWispHookCheckCommandMatchesWispLookups(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"prefix witness text-form (the bug)", `  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule`, true},
+		{"fixed witness json-form", `  gc bd list --assignee="$GC_AGENT" --status=in_progress --type=molecule --limit=0 --json | jq -r '.[].id'`, true},
+		{"deacon invalid wisp type", `  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id')`, true},
+		{"bd query ephemeral molecule", `gc bd query --json 'type=molecule AND ephemeral=true'`, false}, // no --type= flag form
+		{"plain assigned-work list (not a wisp lookup)", `gc bd list --assignee="$GC_AGENT" --status=in_progress`, false},
+		{"wisp pour, not a lookup", `WISP=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')`, false},
+		{"prose mentioning wisps", "Wisp roots are `issue_type=molecule`; find them with gc bd.", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isWispHookCheckCommand(c.line); got != c.want {
+				t.Errorf("isWispHookCheckCommand(%q) = %v, want %v", c.line, got, c.want)
+			}
+		})
+	}
+}
+
 func TestGastownRigTargetShellExpressionsRenderForRigAndHQ(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	github.com/steveyegge/beads v1.1.0
+	github.com/steveyegge/beads v1.1.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -959,6 +959,8 @@ github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xI
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steveyegge/beads v1.1.0 h1:OopHv7K5CWGRNiBinTsEU8pexzZPCPI02LqZ/cPiV5k=
 github.com/steveyegge/beads v1.1.0/go.mod h1:kGQMfFl+LvvOxQ8dAxUITxuTBeMbjv+eogStn+IiucE=
+github.com/steveyegge/beads v1.1.2 h1:cYfMv/2VjB4b0VMmkKlnsHwun5EvoqjFr2ldZUGLpRU=
+github.com/steveyegge/beads v1.1.2/go.mod h1:kGQMfFl+LvvOxQ8dAxUITxuTBeMbjv+eogStn+IiucE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2422,6 +2422,14 @@ type DoltMaintenance struct {
 	// GCTimeout is the ceiling for CALL DOLT_GC() as a duration string.
 	// Defaults to 10m.
 	GCTimeout string `toml:"gc_timeout,omitempty" jsonschema:"default=10m"`
+	// MinStoreMB gates CALL DOLT_GC() on the on-disk store size: the GC
+	// stage is skipped when the store is smaller than this many mebibytes,
+	// because dolt_gc on a small store reclaims little and is not worth the
+	// maintenance lease. Nil (unset) defaults to 1024 (≈1 GiB), the size at
+	// which observed store bloat begins to degrade query latency. Set to 0
+	// to disable the gate and run GC on every scheduled cycle regardless of
+	// size. Negative values are treated as 0 (disabled).
+	MinStoreMB *int `toml:"min_store_mb,omitempty" jsonschema:"default=1024"`
 }
 
 // IntervalOrDefault returns the parsed Interval, falling back to 168h
@@ -2435,6 +2443,26 @@ func (d DoltMaintenance) IntervalOrDefault() time.Duration {
 // when unset or unparseable.
 func (d DoltMaintenance) GCTimeoutOrDefault() time.Duration {
 	return durationOr(d.GCTimeout, 10*time.Minute)
+}
+
+// defaultMinStoreMB is the store-size floor (in mebibytes) applied when
+// MinStoreMB is unset. 1024 MiB (≈1 GiB) matches the interim launchd
+// dolt-gc threshold and the point at which store bloat begins to slow
+// queries.
+const defaultMinStoreMB = 1024
+
+// MinStoreBytesOrDefault returns the on-disk store-size floor in bytes
+// below which the GC stage is skipped. A nil MinStoreMB defaults to
+// 1024 MiB (≈1 GiB); an explicit 0 or negative value disables the gate
+// (returns 0, meaning "always GC").
+func (d DoltMaintenance) MinStoreBytesOrDefault() int64 {
+	if d.MinStoreMB == nil {
+		return int64(defaultMinStoreMB) << 20
+	}
+	if *d.MinStoreMB <= 0 {
+		return 0
+	}
+	return int64(*d.MinStoreMB) << 20
 }
 
 // DaemonConfig holds controller daemon settings.

--- a/internal/config/maintenance_test.go
+++ b/internal/config/maintenance_test.go
@@ -12,6 +12,7 @@ enabled = true
 interval = "168h"
 alert_to = "gascity/mayor"
 gc_timeout = "10m"
+min_store_mb = 2048
 `
 	cfg, err := Parse([]byte(data))
 	if err != nil {
@@ -28,6 +29,9 @@ gc_timeout = "10m"
 	}
 	if cfg.Maintenance.Dolt.GCTimeout != "10m" {
 		t.Errorf("expected GCTimeout=10m, got %q", cfg.Maintenance.Dolt.GCTimeout)
+	}
+	if cfg.Maintenance.Dolt.MinStoreMB == nil || *cfg.Maintenance.Dolt.MinStoreMB != 2048 {
+		t.Errorf("expected MinStoreMB=2048, got %v", cfg.Maintenance.Dolt.MinStoreMB)
 	}
 }
 
@@ -51,6 +55,9 @@ name = "test"
 	}
 	if cfg.Maintenance.Dolt.GCTimeout != "" {
 		t.Errorf("expected GCTimeout empty, got %q", cfg.Maintenance.Dolt.GCTimeout)
+	}
+	if cfg.Maintenance.Dolt.MinStoreMB != nil {
+		t.Errorf("expected MinStoreMB nil (zero value), got %v", *cfg.Maintenance.Dolt.MinStoreMB)
 	}
 }
 
@@ -108,6 +115,31 @@ func TestDoltMaintenanceGCTimeoutOrDefault(t *testing.T) {
 			d := DoltMaintenance{GCTimeout: tc.timeout}
 			if got := d.GCTimeoutOrDefault(); got != tc.want {
 				t.Errorf("GCTimeoutOrDefault() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
+func TestDoltMaintenanceMinStoreBytesOrDefault(t *testing.T) {
+	const mib = int64(1) << 20
+	cases := []struct {
+		name string
+		mb   *int
+		want int64
+	}{
+		{"nil uses ~1GiB default", nil, 1024 * mib},
+		{"explicit zero disables gate", intPtr(0), 0},
+		{"explicit negative disables gate", intPtr(-5), 0},
+		{"explicit 512 MiB", intPtr(512), 512 * mib},
+		{"explicit 4096 MiB", intPtr(4096), 4096 * mib},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := DoltMaintenance{MinStoreMB: tc.mb}
+			if got := d.MinStoreBytesOrDefault(); got != tc.want {
+				t.Errorf("MinStoreBytesOrDefault() = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/internal/supervisor/maintenance.go
+++ b/internal/supervisor/maintenance.go
@@ -65,16 +65,29 @@ type MaintenanceRun struct {
 	SnapshotPath string
 }
 
-// DoltOps is the minimal SQL surface the maintenance loop needs to run
-// CALL DOLT_GC() and the post-gc smoke test. Production wraps *sql.DB
-// via NewSQLDoltOps; tests supply fakes. Close must release the
-// underlying connection exactly once per cycle.
+// DoltOps is the minimal SQL surface the maintenance loop needs to sweep
+// CALL DOLT_GC() across every managed database and run the post-gc smoke
+// test. Each Dolt database is a separate repository with its own chunk
+// store, so reclaiming the whole store requires one GC per database — see
+// runDoltGC. Production wraps *sql.DB via NewSQLDoltOps; tests supply
+// fakes. Close must release the underlying connection exactly once per
+// cycle.
 type DoltOps interface {
-	// ExecGC runs CALL DOLT_GC() with the supplied context's deadline.
-	ExecGC(ctx context.Context) error
-	// SmokeCount runs SELECT COUNT(*) FROM issues against the current
-	// database and returns the scalar result.
-	SmokeCount(ctx context.Context) (int, error)
+	// ListDatabases returns the database names visible to the connection
+	// (SHOW DATABASES), including system schemas. The caller filters those
+	// out via gcTargetDatabases.
+	ListDatabases(ctx context.Context) ([]string, error)
+	// ExecGCFor runs CALL DOLT_GC() against database db with the supplied
+	// context's deadline. Implementations must pin the USE + CALL to a
+	// single connection so a pool cannot split them across sessions and
+	// GC the wrong database.
+	ExecGCFor(ctx context.Context, db string) error
+	// SmokeCountFor runs SELECT COUNT(*) FROM issues against database db
+	// and returns the scalar result. A SQL error means the store is not
+	// queryable after GC (the smoke-test failure signal); the count itself
+	// is informational — an empty database is a healthy post-gc state for a
+	// freshly-created rig, so a per-database zero is not a failure.
+	SmokeCountFor(ctx context.Context, db string) (int, error)
 	// Close releases the underlying connection.
 	Close() error
 }
@@ -156,6 +169,16 @@ type StoreMaintenanceLoopDeps struct {
 	// threshold (but is still above DiskMinFreeBytes) StoreDiskWarn is
 	// emitted and the GC proceeds.
 	DiskWarnFreeBytes int64
+
+	// StoreSizeBytes returns the current on-disk size of the managed Dolt
+	// store in bytes. It gates CALL DOLT_GC on Cfg.MinStoreMB: when the
+	// store is smaller than the floor the sweep is skipped (dolt_gc on a
+	// small store reclaims little and is not worth the maintenance lease).
+	// It also supplies the before/after byte deltas recorded on each run.
+	// Nil disables the size gate (GC always runs) and leaves
+	// BeforeBytes/AfterBytes zero. Production wires this to
+	// storehealth.WalkSize(storehealth.StorePath(cityPath)).
+	StoreSizeBytes func() int64
 }
 
 // StoreMaintenanceLoop runs periodic Dolt store maintenance inside the
@@ -178,6 +201,7 @@ type StoreMaintenanceLoop struct {
 	diskFreeBytes     func(path string) (int64, error)
 	diskMinFreeBytes  int64
 	diskWarnFreeBytes int64
+	storeSizeBytes    func() int64
 
 	// mu is the in-process maintenance lease. runOnce and TriggerNow hold
 	// it for the duration of a single maintenance cycle; each contends on
@@ -247,6 +271,7 @@ func NewStoreMaintenanceLoop(deps StoreMaintenanceLoopDeps) *StoreMaintenanceLoo
 		diskFreeBytes:     deps.DiskFreeBytes,
 		diskMinFreeBytes:  deps.DiskMinFreeBytes,
 		diskWarnFreeBytes: deps.DiskWarnFreeBytes,
+		storeSizeBytes:    deps.StoreSizeBytes,
 		lastRunAt:         deps.LastRunAt,
 		history:           make([]MaintenanceRun, 0, maintenanceHistorySize),
 	}
@@ -399,25 +424,25 @@ func (m *StoreMaintenanceLoop) executeCycleLocked(ctx context.Context) Maintenan
 
 	snapshotPath, err := m.runSnapshot(ctx)
 	if err != nil {
-		return m.finishCycleLocked(started, snapshotPath, err)
+		return m.finishCycleLocked(started, snapshotPath, gcSweepResult{}, err)
 	}
 	if m.checkDiskPreflight() {
 		// Disk is critically low — skip CALL DOLT_GC to avoid growing the
 		// store further. The StoreDiskCritical event informs operators.
 		// C1 (hold-on-store-unreachable) handles downstream safety.
-		return m.finishCycleLocked(started, snapshotPath, nil)
+		return m.finishCycleLocked(started, snapshotPath, gcSweepResult{}, nil)
 	}
-	if err := m.runDoltGC(ctx); err != nil {
-		return m.finishCycleLocked(started, snapshotPath, err)
-	}
-	return m.finishCycleLocked(started, snapshotPath, nil)
+	sweep, err := m.runDoltGC(ctx)
+	return m.finishCycleLocked(started, snapshotPath, sweep, err)
 }
 
-func (m *StoreMaintenanceLoop) finishCycleLocked(started time.Time, snapshotPath string, err error) MaintenanceRun {
+func (m *StoreMaintenanceLoop) finishCycleLocked(started time.Time, snapshotPath string, sweep gcSweepResult, err error) MaintenanceRun {
 	run := MaintenanceRun{
 		StartedAt:    started,
 		FinishedAt:   m.clock(),
 		SnapshotPath: snapshotPath,
+		BeforeBytes:  sweep.BeforeBytes,
+		AfterBytes:   sweep.AfterBytes,
 	}
 	if err != nil {
 		run.Stage = "maintenance"
@@ -593,46 +618,159 @@ func (m *StoreMaintenanceLoop) appendHistoryLocked(r MaintenanceRun) {
 	}
 }
 
-// runDoltGC runs CALL DOLT_GC() followed by the SELECT COUNT(*) smoke
-// test against the managed Dolt store. Design D4 + D5 from ga-d5y.
-//
-// Returns nil on success. A non-nil return is a *MaintenanceError
-// whose Stage classifies the failing phase:
-//
-//   - "gc": factory error, SQL error from CALL DOLT_GC(), or the
-//     configured GCTimeout elapsed.
-//   - "smoke-test": SQL error on SELECT COUNT(*), the 5 s smoke
-//     deadline elapsed, or the query returned 0 rows (which indicates
-//     either a corrupted schema or a wiped table and is never a
-//     healthy post-gc state for a running city).
-//
-// When openDoltOps is nil, runDoltGC returns nil.
-func (m *StoreMaintenanceLoop) runDoltGC(ctx context.Context) error {
-	if m.openDoltOps == nil {
-		return nil
+// gcSweepResult reports the measured outcome of a runDoltGC sweep so the
+// cycle can populate MaintenanceRun.BeforeBytes/AfterBytes. Skipped is
+// true when the store-size gate declined to run any GC because the store
+// was below the configured floor; in that case BeforeBytes == AfterBytes.
+type gcSweepResult struct {
+	BeforeBytes int64
+	AfterBytes  int64
+	Skipped     bool
+}
+
+// gcSystemDatabases are the Dolt/MySQL system schemas SHOW DATABASES
+// surfaces that must never be GC-swept: they hold no bead chunk data and
+// CALL DOLT_GC against them is meaningless. Mirrors the system-DB sets in
+// cmd/gc (dolt_sql_health.go, dolt_cleanup_drop_planner.go); kept as a
+// local copy because internal/supervisor must not import the cmd/gc top
+// layer. Keys are lowercase; gcTargetDatabases lowercases before lookup.
+var gcSystemDatabases = map[string]struct{}{
+	"information_schema": {},
+	"mysql":              {},
+	"performance_schema": {},
+	"sys":                {},
+	"dolt":               {},
+	"dolt_cluster":       {},
+	"__gc_probe":         {},
+}
+
+// gcTargetDatabases returns the subset of all that should be swept by
+// CALL DOLT_GC: every database minus the well-known system schemas and
+// blank entries. Input order is preserved and original casing is retained
+// so the names round-trip back into USE statements. Pure function; no I/O.
+func gcTargetDatabases(all []string) []string {
+	out := make([]string, 0, len(all))
+	for _, db := range all {
+		name := strings.TrimSpace(db)
+		if name == "" {
+			continue
+		}
+		if _, sys := gcSystemDatabases[strings.ToLower(name)]; sys {
+			continue
+		}
+		out = append(out, name)
 	}
+	return out
+}
+
+// measureStoreBytes returns the current on-disk store size, or 0 when no
+// StoreSizeBytes probe is wired. A negative reading is clamped to 0 so a
+// misbehaving probe cannot poison the size gate or the byte deltas.
+func (m *StoreMaintenanceLoop) measureStoreBytes() int64 {
+	if m.storeSizeBytes == nil {
+		return 0
+	}
+	if n := m.storeSizeBytes(); n > 0 {
+		return n
+	}
+	return 0
+}
+
+// runDoltGC sweeps CALL DOLT_GC() across every managed database and runs
+// the per-database SELECT COUNT(*) smoke test. Design D4 + D5 from ga-d5y,
+// extended to a multi-database sweep for ga-uvq: each Dolt database is a
+// separate repository with its own chunk store, so reclaiming the whole
+// store requires one GC per database.
+//
+// The sweep is gated on store size: when StoreSizeBytes is wired and the
+// store is below Cfg.MinStoreBytesOrDefault(), GC is skipped (dolt_gc on a
+// small store reclaims little and is not worth the maintenance lease) and
+// the returned result has Skipped=true with BeforeBytes == AfterBytes.
+//
+// The returned gcSweepResult carries the before/after byte readings even
+// on failure (BeforeBytes is measured before any GC runs). A non-nil error
+// aggregates every per-database failure via errors.Join; finishCycleLocked
+// classifies the run Stage from the first *MaintenanceError in the chain:
+//
+//   - "gc": factory error, SHOW DATABASES error, a SQL error from CALL
+//     DOLT_GC(), or the configured GCTimeout elapsing for some database.
+//   - "smoke-test": a SQL error on a post-gc SELECT COUNT(*) or the 5 s
+//     smoke deadline elapsing for some database. A per-database zero count
+//     is healthy (an empty rig) and is not a failure.
+//
+// When openDoltOps is nil, runDoltGC returns a zero result and nil error.
+func (m *StoreMaintenanceLoop) runDoltGC(ctx context.Context) (gcSweepResult, error) {
+	var res gcSweepResult
+	if m.openDoltOps == nil {
+		return res, nil
+	}
+
+	res.BeforeBytes = m.measureStoreBytes()
+	if floor := m.cfg.MinStoreBytesOrDefault(); floor > 0 && res.BeforeBytes > 0 && res.BeforeBytes < floor {
+		res.Skipped = true
+		res.AfterBytes = res.BeforeBytes
+		fmt.Fprintf(m.stderr, //nolint:errcheck // best-effort stderr
+			"store-maintenance: store %s below floor %s; skipping CALL DOLT_GC\n",
+			formatMiB(res.BeforeBytes), formatMiB(floor))
+		return res, nil
+	}
+
 	ops, err := m.openDoltOps(ctx)
 	if err != nil {
-		return &MaintenanceError{Stage: "gc", Err: fmt.Errorf("open dolt conn: %w", err)}
+		return res, &MaintenanceError{Stage: "gc", Err: fmt.Errorf("open dolt conn: %w", err)}
 	}
 	defer ops.Close() //nolint:errcheck // best-effort cleanup; underlying pool manages lifecycle
 
+	listCtx, cancelList := context.WithTimeout(ctx, maintenanceSmokeTimeout)
+	defer cancelList()
+	all, err := ops.ListDatabases(listCtx)
+	if err != nil {
+		return res, &MaintenanceError{Stage: "gc", Err: fmt.Errorf("list databases: %w", err)}
+	}
+	targets := gcTargetDatabases(all)
+	if len(targets) == 0 {
+		fmt.Fprintf(m.stderr, "store-maintenance: no user databases to GC (saw %d system schemas)\n", len(all)) //nolint:errcheck
+		res.AfterBytes = res.BeforeBytes
+		return res, nil
+	}
+
+	var errs []error
+	for _, db := range targets {
+		if err := m.gcOneDatabase(ctx, ops, db); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	res.AfterBytes = m.measureStoreBytes()
+	return res, errors.Join(errs...)
+}
+
+// gcOneDatabase runs CALL DOLT_GC() then the post-gc smoke test against a
+// single database, each under its own deadline (GCTimeoutOrDefault for the
+// GC, maintenanceSmokeTimeout for the smoke test). The returned error, when
+// non-nil, is a *MaintenanceError whose Stage names the failing phase and
+// whose cause is annotated with db so an aggregated sweep error identifies
+// which database failed.
+func (m *StoreMaintenanceLoop) gcOneDatabase(ctx context.Context, ops DoltOps, db string) error {
 	gcCtx, cancelGC := context.WithTimeout(ctx, m.cfg.GCTimeoutOrDefault())
 	defer cancelGC()
-	if err := ops.ExecGC(gcCtx); err != nil {
-		return &MaintenanceError{Stage: "gc", Err: err}
+	if err := ops.ExecGCFor(gcCtx, db); err != nil {
+		return &MaintenanceError{Stage: "gc", Err: fmt.Errorf("db %q: %w", db, err)}
 	}
 
 	smokeCtx, cancelSmoke := context.WithTimeout(ctx, maintenanceSmokeTimeout)
 	defer cancelSmoke()
-	count, err := ops.SmokeCount(smokeCtx)
-	if err != nil {
-		return &MaintenanceError{Stage: "smoke-test", Err: err}
-	}
-	if count == 0 {
-		return &MaintenanceError{Stage: "smoke-test", Err: errors.New("SELECT COUNT(*) returned 0 rows")}
+	// A SQL error means the database is not queryable after GC. The count
+	// itself is informational: an empty database is a healthy post-gc state.
+	if _, err := ops.SmokeCountFor(smokeCtx, db); err != nil {
+		return &MaintenanceError{Stage: "smoke-test", Err: fmt.Errorf("db %q: %w", db, err)}
 	}
 	return nil
+}
+
+// formatMiB renders a byte count as a whole-MiB string for operator log
+// lines (e.g. "896 MiB"). Used only for human-readable stderr output.
+func formatMiB(b int64) string {
+	return fmt.Sprintf("%d MiB", b>>20)
 }
 
 // NewSQLDoltOps adapts a *sql.DB opener to the DoltOps interface. The
@@ -651,24 +789,53 @@ func NewSQLDoltOps(open func(ctx context.Context) (*sql.DB, error)) DoltOpsFacto
 	}
 }
 
-// sqlDoltOps implements DoltOps against a *sql.DB pool. ExecGC and
-// SmokeCount each take one connection from the pool and return it;
-// Close closes the pool.
+// sqlDoltOps implements DoltOps against a *sql.DB pool. ExecGCFor pins its
+// USE + CALL DOLT_GC to a single connection so the pool cannot split them
+// across sessions; SmokeCountFor uses a qualified table name and so is
+// pool-safe without pinning. Close closes the pool.
 type sqlDoltOps struct {
 	db *sql.DB
 }
 
-func (s *sqlDoltOps) ExecGC(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, "CALL DOLT_GC()")
+func (s *sqlDoltOps) ListDatabases(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, "SHOW DATABASES")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck // read-only iteration; row error surfaced via rows.Err
+	var dbs []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		dbs = append(dbs, name)
+	}
+	return dbs, rows.Err()
+}
+
+func (s *sqlDoltOps) ExecGCFor(ctx context.Context, db string) error {
+	// USE sets per-session state, so it and CALL DOLT_GC must run on the
+	// same connection — a pooled *sql.DB could otherwise route them to
+	// different sessions and GC the wrong database.
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close() //nolint:errcheck // returns the connection to the pool
+	if _, err := conn.ExecContext(ctx, "USE "+quoteDoltIdent(db)); err != nil {
+		return err
+	}
+	_, err = conn.ExecContext(ctx, "CALL DOLT_GC()")
 	return err
 }
 
-func (s *sqlDoltOps) SmokeCount(ctx context.Context) (int, error) {
+func (s *sqlDoltOps) SmokeCountFor(ctx context.Context, db string) (int, error) {
 	var n int
-	// LIMIT 1 is redundant on a COUNT(*) aggregate but matches the
-	// design-doc literal so the runbook and the code stay in lockstep.
-	row := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM `"+maintenanceSmokeTable+"` LIMIT 1")
-	if err := row.Scan(&n); err != nil {
+	// Qualified table reference (db.issues) keeps this pool-safe — no USE,
+	// so it does not need a pinned connection.
+	q := "SELECT COUNT(*) FROM " + quoteDoltIdent(db) + "." + quoteDoltIdent(maintenanceSmokeTable)
+	if err := s.db.QueryRowContext(ctx, q).Scan(&n); err != nil {
 		return 0, err
 	}
 	return n, nil
@@ -676,6 +843,14 @@ func (s *sqlDoltOps) SmokeCount(ctx context.Context) (int, error) {
 
 func (s *sqlDoltOps) Close() error {
 	return s.db.Close()
+}
+
+// quoteDoltIdent backtick-quotes a SQL identifier and escapes embedded
+// backticks by doubling them (MySQL convention). Dolt derives database
+// names from repository directory names, which may start with a digit or
+// contain characters that require quoting.
+func quoteDoltIdent(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }
 
 // SeedLastRunAt returns the timestamp of the most recent

--- a/internal/supervisor/maintenance_gc_test.go
+++ b/internal/supervisor/maintenance_gc_test.go
@@ -3,6 +3,8 @@ package supervisor
 import (
 	"context"
 	"errors"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,8 +12,13 @@ import (
 )
 
 // fakeDoltOps is a scripted DoltOps for runDoltGC tests. Fields drive
-// ExecGC / SmokeCount behavior; call counters verify ordering.
+// ListDatabases / ExecGCFor / SmokeCountFor behavior; call counters and
+// gcDBs verify the per-database sweep order. Errors apply uniformly to
+// every database.
 type fakeDoltOps struct {
+	databases []string // nil ⇒ default single target "hq"
+	listErr   error
+
 	execGCErr   error
 	execGCDelay time.Duration
 
@@ -19,14 +26,34 @@ type fakeDoltOps struct {
 	smokeErr   error
 	smokeDelay time.Duration
 
+	listCalls  int
 	gcCalls    int
 	smokeCalls int
+	gcDBs      []string // databases passed to ExecGCFor, in order
 	closed     bool
 	calls      *[]string
 }
 
-func (f *fakeDoltOps) ExecGC(ctx context.Context) error {
+func (f *fakeDoltOps) ListDatabases(ctx context.Context) ([]string, error) {
+	f.listCalls++
+	if f.calls != nil {
+		*f.calls = append(*f.calls, "gc.list")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.databases == nil {
+		return []string{"hq"}, nil
+	}
+	return f.databases, nil
+}
+
+func (f *fakeDoltOps) ExecGCFor(ctx context.Context, db string) error {
 	f.gcCalls++
+	f.gcDBs = append(f.gcDBs, db)
 	if f.calls != nil {
 		*f.calls = append(*f.calls, "gc.exec")
 	}
@@ -40,7 +67,7 @@ func (f *fakeDoltOps) ExecGC(ctx context.Context) error {
 	return f.execGCErr
 }
 
-func (f *fakeDoltOps) SmokeCount(ctx context.Context) (int, error) {
+func (f *fakeDoltOps) SmokeCountFor(ctx context.Context, _ string) (int, error) {
 	f.smokeCalls++
 	if f.calls != nil {
 		*f.calls = append(*f.calls, "gc.smoke")
@@ -74,22 +101,80 @@ func newGCTestLoop(t *testing.T, cfg config.DoltMaintenance, ops *fakeDoltOps) *
 	})
 }
 
-func TestRunDoltGC_HappyPathReturnsNilAndClosesConn(t *testing.T) {
+func TestRunDoltGC_HappyPathSweepsAllTargetsAndClosesConn(t *testing.T) {
 	t.Parallel()
-	ops := &fakeDoltOps{smokeCount: 5}
+	ops := &fakeDoltOps{databases: []string{"hq", "gascity"}, smokeCount: 5}
 	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
 
-	if err := loop.runDoltGC(context.Background()); err != nil {
+	res, err := loop.runDoltGC(context.Background())
+	if err != nil {
 		t.Fatalf("runDoltGC = %v; want nil on happy path", err)
 	}
-	if ops.gcCalls != 1 {
-		t.Errorf("ExecGC called %d times; want 1", ops.gcCalls)
+	if res.Skipped {
+		t.Errorf("res.Skipped = true; want false when GC runs")
 	}
-	if ops.smokeCalls != 1 {
-		t.Errorf("SmokeCount called %d times; want 1", ops.smokeCalls)
+	if ops.gcCalls != 2 {
+		t.Errorf("ExecGCFor called %d times; want 2 (one per target DB)", ops.gcCalls)
+	}
+	if ops.smokeCalls != 2 {
+		t.Errorf("SmokeCountFor called %d times; want 2", ops.smokeCalls)
+	}
+	if want := []string{"hq", "gascity"}; !slices.Equal(ops.gcDBs, want) {
+		t.Errorf("gcDBs = %v; want %v", ops.gcDBs, want)
 	}
 	if !ops.closed {
 		t.Errorf("ops.Close not called — connection would leak in production")
+	}
+}
+
+func TestRunDoltGC_FiltersSystemDatabases(t *testing.T) {
+	t.Parallel()
+	ops := &fakeDoltOps{
+		databases:  []string{"information_schema", "mysql", "hq", "performance_schema", "gascity", "dolt", "__gc_probe"},
+		smokeCount: 1,
+	}
+	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
+
+	if _, err := loop.runDoltGC(context.Background()); err != nil {
+		t.Fatalf("runDoltGC = %v; want nil", err)
+	}
+	if want := []string{"hq", "gascity"}; !slices.Equal(ops.gcDBs, want) {
+		t.Errorf("gcDBs = %v; want %v (system schemas must be filtered)", ops.gcDBs, want)
+	}
+}
+
+func TestRunDoltGC_NoTargetDatabasesIsNoop(t *testing.T) {
+	t.Parallel()
+	ops := &fakeDoltOps{databases: []string{"information_schema", "mysql", "dolt"}}
+	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
+
+	res, err := loop.runDoltGC(context.Background())
+	if err != nil {
+		t.Fatalf("runDoltGC = %v; want nil when only system DBs present", err)
+	}
+	if ops.gcCalls != 0 {
+		t.Errorf("ExecGCFor called %d times; want 0 when no user databases", ops.gcCalls)
+	}
+	if res.Skipped {
+		t.Errorf("res.Skipped = true; want false (no-target is not a size-gate skip)")
+	}
+}
+
+func TestRunDoltGC_ListError_ReturnsStageGC(t *testing.T) {
+	t.Parallel()
+	ops := &fakeDoltOps{listErr: errors.New("connection reset")}
+	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
+
+	_, err := loop.runDoltGC(context.Background())
+	var me *MaintenanceError
+	if !errors.As(err, &me) {
+		t.Fatalf("runDoltGC = %v; want *MaintenanceError", err)
+	}
+	if me.Stage != "gc" {
+		t.Errorf("Stage = %q; want %q", me.Stage, "gc")
+	}
+	if ops.gcCalls != 0 {
+		t.Errorf("ExecGCFor ran despite list failure (%d calls); want 0", ops.gcCalls)
 	}
 }
 
@@ -98,7 +183,7 @@ func TestRunDoltGC_SQLErrorAtGC_ReturnsStageGC(t *testing.T) {
 	ops := &fakeDoltOps{execGCErr: errors.New("out of disk")}
 	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
 
-	err := loop.runDoltGC(context.Background())
+	_, err := loop.runDoltGC(context.Background())
 	var me *MaintenanceError
 	if !errors.As(err, &me) {
 		t.Fatalf("runDoltGC = %v; want *MaintenanceError", err)
@@ -107,10 +192,34 @@ func TestRunDoltGC_SQLErrorAtGC_ReturnsStageGC(t *testing.T) {
 		t.Errorf("Stage = %q; want %q", me.Stage, "gc")
 	}
 	if ops.smokeCalls != 0 {
-		t.Errorf("SmokeCount ran after gc failure (%d calls); want 0", ops.smokeCalls)
+		t.Errorf("SmokeCountFor ran after gc failure (%d calls); want 0", ops.smokeCalls)
 	}
 	if !ops.closed {
 		t.Errorf("ops.Close not called on failure path — connection would leak")
+	}
+}
+
+func TestRunDoltGC_AggregatesPerDatabaseFailures(t *testing.T) {
+	t.Parallel()
+	ops := &fakeDoltOps{databases: []string{"hq", "gascity"}, execGCErr: errors.New("boom")}
+	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
+
+	_, err := loop.runDoltGC(context.Background())
+	if err == nil {
+		t.Fatal("runDoltGC = nil; want aggregated error")
+	}
+	var me *MaintenanceError
+	if !errors.As(err, &me) || me.Stage != "gc" {
+		t.Fatalf("errors.As stage = %v; want a *MaintenanceError with Stage=gc", err)
+	}
+	// errors.Join concatenates both failures; both DB names must appear so
+	// operators can see every database that failed, not just the first.
+	msg := err.Error()
+	if !strings.Contains(msg, `"hq"`) || !strings.Contains(msg, `"gascity"`) {
+		t.Errorf("aggregated error %q; want it to name both hq and gascity", msg)
+	}
+	if ops.gcCalls != 2 {
+		t.Errorf("ExecGCFor called %d times; want 2 (sweep continues past a failure)", ops.gcCalls)
 	}
 }
 
@@ -120,7 +229,7 @@ func TestRunDoltGC_GCDeadlineExceeded_ReturnsStageGC(t *testing.T) {
 	ops := &fakeDoltOps{execGCDelay: 100 * time.Millisecond}
 	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "10ms"}, ops)
 
-	err := loop.runDoltGC(context.Background())
+	_, err := loop.runDoltGC(context.Background())
 	var me *MaintenanceError
 	if !errors.As(err, &me) {
 		t.Fatalf("runDoltGC = %v; want *MaintenanceError", err)
@@ -133,21 +242,19 @@ func TestRunDoltGC_GCDeadlineExceeded_ReturnsStageGC(t *testing.T) {
 	}
 }
 
-func TestRunDoltGC_SmokeCountZero_ReturnsStageSmokeTest(t *testing.T) {
+func TestRunDoltGC_SmokeZeroCountIsHealthy(t *testing.T) {
 	t.Parallel()
+	// A per-database zero count is a healthy post-gc state (an empty rig),
+	// not a smoke-test failure — the multi-DB sweep cannot assume every
+	// database is non-empty the way the old single-store check did.
 	ops := &fakeDoltOps{smokeCount: 0}
 	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
 
-	err := loop.runDoltGC(context.Background())
-	var me *MaintenanceError
-	if !errors.As(err, &me) {
-		t.Fatalf("runDoltGC = %v; want *MaintenanceError", err)
-	}
-	if me.Stage != "smoke-test" {
-		t.Errorf("Stage = %q; want %q", me.Stage, "smoke-test")
+	if _, err := loop.runDoltGC(context.Background()); err != nil {
+		t.Fatalf("runDoltGC with zero smoke count = %v; want nil (empty DB is healthy)", err)
 	}
 	if ops.gcCalls != 1 {
-		t.Errorf("ExecGC should still run when smoke fails (got %d calls); want 1", ops.gcCalls)
+		t.Errorf("ExecGCFor called %d times; want 1", ops.gcCalls)
 	}
 }
 
@@ -156,13 +263,16 @@ func TestRunDoltGC_SmokeSQLError_ReturnsStageSmokeTest(t *testing.T) {
 	ops := &fakeDoltOps{smokeErr: errors.New("table not found")}
 	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
 
-	err := loop.runDoltGC(context.Background())
+	_, err := loop.runDoltGC(context.Background())
 	var me *MaintenanceError
 	if !errors.As(err, &me) {
 		t.Fatalf("runDoltGC = %v; want *MaintenanceError", err)
 	}
 	if me.Stage != "smoke-test" {
 		t.Errorf("Stage = %q; want %q", me.Stage, "smoke-test")
+	}
+	if ops.gcCalls != 1 {
+		t.Errorf("ExecGCFor should still run when smoke fails (got %d calls); want 1", ops.gcCalls)
 	}
 }
 
@@ -176,7 +286,7 @@ func TestRunDoltGC_SmokeDeadlineExceeded_ReturnsStageSmokeTest(t *testing.T) {
 	ops := &fakeDoltOps{smokeDelay: 100 * time.Millisecond}
 	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
 
-	err := loop.runDoltGC(context.Background())
+	_, err := loop.runDoltGC(context.Background())
 	var me *MaintenanceError
 	if !errors.As(err, &me) {
 		t.Fatalf("runDoltGC = %v; want *MaintenanceError", err)
@@ -199,7 +309,7 @@ func TestRunDoltGC_OpenError_ReturnsStageGC(t *testing.T) {
 		},
 	})
 
-	err := loop.runDoltGC(context.Background())
+	_, err := loop.runDoltGC(context.Background())
 	var me *MaintenanceError
 	if !errors.As(err, &me) {
 		t.Fatalf("runDoltGC = %v; want *MaintenanceError", err)
@@ -217,7 +327,113 @@ func TestRunDoltGC_NilFactoryReturnsNil(t *testing.T) {
 		Cfg:      config.DoltMaintenance{Enabled: true, GCTimeout: "1s"},
 		CityPath: t.TempDir(),
 	})
-	if err := loop.runDoltGC(context.Background()); err != nil {
+	res, err := loop.runDoltGC(context.Background())
+	if err != nil {
 		t.Fatalf("runDoltGC with nil factory = %v; want nil", err)
+	}
+	if res != (gcSweepResult{}) {
+		t.Errorf("res = %+v; want zero value when factory is nil", res)
+	}
+}
+
+// --- store-size gate ---------------------------------------------------
+
+func minStoreMB(v int) *int { return &v }
+
+func newGateTestLoop(t *testing.T, cfg config.DoltMaintenance, ops *fakeDoltOps, size int64) *StoreMaintenanceLoop {
+	t.Helper()
+	return NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg:            cfg,
+		CityPath:       t.TempDir(),
+		StoreSizeBytes: func() int64 { return size },
+		OpenDoltOps: func(context.Context) (DoltOps, error) {
+			return ops, nil
+		},
+	})
+}
+
+func TestRunDoltGC_SizeGateSkipsSmallStore(t *testing.T) {
+	t.Parallel()
+	const mib = int64(1) << 20
+	ops := &fakeDoltOps{smokeCount: 1}
+	// Default MinStoreMB (nil) ⇒ 1 GiB floor; a 100 MiB store is below it.
+	loop := newGateTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops, 100*mib)
+
+	res, err := loop.runDoltGC(context.Background())
+	if err != nil {
+		t.Fatalf("runDoltGC = %v; want nil when gated", err)
+	}
+	if !res.Skipped {
+		t.Errorf("res.Skipped = false; want true when store below floor")
+	}
+	if res.BeforeBytes != 100*mib || res.AfterBytes != 100*mib {
+		t.Errorf("res before/after = %d/%d; want %d/%d (no GC, no change)", res.BeforeBytes, res.AfterBytes, 100*mib, 100*mib)
+	}
+	if ops.gcCalls != 0 || ops.listCalls != 0 {
+		t.Errorf("gcCalls=%d listCalls=%d; want 0/0 — gate must skip before opening a connection", ops.gcCalls, ops.listCalls)
+	}
+}
+
+func TestRunDoltGC_SizeGateRunsAboveFloor(t *testing.T) {
+	t.Parallel()
+	const mib = int64(1) << 20
+	ops := &fakeDoltOps{smokeCount: 1}
+	loop := newGateTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops, 2048*mib)
+
+	res, err := loop.runDoltGC(context.Background())
+	if err != nil {
+		t.Fatalf("runDoltGC = %v; want nil", err)
+	}
+	if res.Skipped {
+		t.Errorf("res.Skipped = true; want false for a 2 GiB store above the 1 GiB floor")
+	}
+	if ops.gcCalls != 1 {
+		t.Errorf("ExecGCFor called %d times; want 1", ops.gcCalls)
+	}
+	if res.BeforeBytes != 2048*mib || res.AfterBytes != 2048*mib {
+		t.Errorf("res before/after = %d/%d; want both %d", res.BeforeBytes, res.AfterBytes, 2048*mib)
+	}
+}
+
+func TestRunDoltGC_SizeGateDisabledWhenMinStoreZero(t *testing.T) {
+	t.Parallel()
+	const mib = int64(1) << 20
+	ops := &fakeDoltOps{smokeCount: 1}
+	// MinStoreMB=0 disables the gate ⇒ GC runs even on a tiny store.
+	cfg := config.DoltMaintenance{Enabled: true, GCTimeout: "1s", MinStoreMB: minStoreMB(0)}
+	loop := newGateTestLoop(t, cfg, ops, 1*mib)
+
+	res, err := loop.runDoltGC(context.Background())
+	if err != nil {
+		t.Fatalf("runDoltGC = %v; want nil", err)
+	}
+	if res.Skipped {
+		t.Errorf("res.Skipped = true; want false when the size gate is disabled")
+	}
+	if ops.gcCalls != 1 {
+		t.Errorf("ExecGCFor called %d times; want 1 (gate disabled)", ops.gcCalls)
+	}
+}
+
+func TestGCTargetDatabases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", nil, []string{}},
+		{"all system", []string{"information_schema", "mysql", "dolt", "sys", "performance_schema", "dolt_cluster", "__gc_probe"}, []string{}},
+		{"user dbs preserved in order", []string{"hq", "information_schema", "gascity", "mysql"}, []string{"hq", "gascity"}},
+		{"blank entries dropped", []string{"", "  ", "hq"}, []string{"hq"}},
+		{"system match is case-insensitive", []string{"INFORMATION_SCHEMA", "MySQL", "Rig1"}, []string{"Rig1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gcTargetDatabases(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("gcTargetDatabases(%v) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/supervisor/maintenance_trigger_test.go
+++ b/internal/supervisor/maintenance_trigger_test.go
@@ -69,7 +69,7 @@ func TestTriggerNow_RunsSnapshotThenGC(t *testing.T) {
 	if run.SnapshotPath == "" {
 		t.Fatal("run.SnapshotPath is empty; want snapshot path recorded")
 	}
-	wantCalls := []string{"backup.add", "backup.sync", "gc.exec", "gc.smoke"}
+	wantCalls := []string{"backup.add", "backup.sync", "gc.list", "gc.exec", "gc.smoke"}
 	if !slices.Equal(calls, wantCalls) {
 		t.Fatalf("calls = %v; want %v", calls, wantCalls)
 	}
@@ -184,7 +184,11 @@ type gatedDoltOps struct {
 	proceed chan struct{}
 }
 
-func (g *gatedDoltOps) ExecGC(ctx context.Context) error {
+func (g *gatedDoltOps) ListDatabases(context.Context) ([]string, error) {
+	return []string{"hq"}, nil
+}
+
+func (g *gatedDoltOps) ExecGCFor(ctx context.Context, _ string) error {
 	g.once.Do(func() { close(g.opened) })
 	select {
 	case <-g.proceed:
@@ -194,7 +198,7 @@ func (g *gatedDoltOps) ExecGC(ctx context.Context) error {
 	}
 }
 
-func (g *gatedDoltOps) SmokeCount(context.Context) (int, error) {
+func (g *gatedDoltOps) SmokeCountFor(context.Context, string) (int, error) {
 	return 1, nil
 }
 

--- a/test/dolt/latency_test.sh
+++ b/test/dolt/latency_test.sh
@@ -33,7 +33,7 @@ else
   bad "now_ms resolution: got ${d}ms, want 5..800 (whole-second clock yields 0 or 1000)"
 fi
 
-# A fast probe does NOT warn at the default 1000ms threshold.
+# A fast probe does NOT warn at a 1000ms threshold.
 if latency_should_warn 50 1000; then bad "50ms probe warned at 1000ms threshold (false positive)"; else pass "50ms probe -> no warn"; fi
 
 # A genuinely slow probe warns.
@@ -41,6 +41,25 @@ if latency_should_warn 1500 1000; then pass "1500ms probe -> warn"; else bad "15
 
 # Boundary equality warns (>= semantics preserved).
 if latency_should_warn 1000 1000; then pass "1000ms == threshold -> warn"; else bad "boundary 1000ms did not warn"; fi
+
+# --- latency_warn_threshold_ms: default + override precedence --------------
+# The doctor resolves its warn threshold from the environment so operators can
+# retune it per city via [[orders.overrides]].env without editing scripts.
+command -v latency_warn_threshold_ms >/dev/null 2>&1 \
+  || { echo "FAIL: latency_warn_threshold_ms not defined"; exit 1; }
+
+# Default (no env) is 3000ms (3s) — above the 1-2s a loaded shared box grazes
+# routinely, so the MEDIUM advisory stops false-tripping on healthy latency.
+t=$(unset GC_DOCTOR_LATENCY_WARN_MS GC_DOCTOR_LATENCY_WARN_S; latency_warn_threshold_ms)
+if [ "$t" = "3000" ]; then pass "default threshold = 3000ms (3s)"; else bad "default threshold = ${t}ms, want 3000"; fi
+
+# Legacy whole-second knob scales x1000 (backward compatibility).
+t=$(unset GC_DOCTOR_LATENCY_WARN_MS; GC_DOCTOR_LATENCY_WARN_S=5; latency_warn_threshold_ms)
+if [ "$t" = "5000" ]; then pass "GC_DOCTOR_LATENCY_WARN_S=5 -> 5000ms"; else bad "seconds knob -> ${t}ms, want 5000"; fi
+
+# Millisecond knob wins over the legacy seconds knob.
+t=$(GC_DOCTOR_LATENCY_WARN_MS=4500; GC_DOCTOR_LATENCY_WARN_S=9; latency_warn_threshold_ms)
+if [ "$t" = "4500" ]; then pass "GC_DOCTOR_LATENCY_WARN_MS wins over _S"; else bad "WARN_MS precedence -> ${t}ms, want 4500"; fi
 
 # Regression of the original bug — 30 fast probes must NEVER false-warn.
 i=0; warned=0


### PR DESCRIPTION
Four changes that have been running locally on a production city for
several weeks but were never pushed. Splitting on request — they are
grouped here because they were carried on the same unpushed local branch.

### `chore(deps): bump beads to v1.1.2 to match the bd CLI`
`internal/beads/contract/preflight_checker.go:281` requires **exact string
equality** between the `bd` CLI version and the linked beads library
version. Homebrew now ships `bd` 1.1.2 while `go.mod` pinned `v1.1.0`, so
the `version_compat` preflight failed and took the native store offline
(`WARN native_store_unavailable`) on every city. Verified: builds via
`make build`, links `v1.1.2`, and the warning is gone on two cities.

### `feat(dolt): wire periodic per-database DOLT_GC sweep in supervisor maintenance (ga-uvq)`
Adds `cmd/gc/maintenance_dolt_ops.go`. Without it, stores grow unbounded
between manual compactions — a `.beads` here reached 863 MB, and the `hq`
database alone took **4m20s** to open, which blew the reconcile deadline
and made `gc start` fail with `reconcile queue is busy`.

### `feat(dolt): env-tunable dog-doctor latency-warn threshold, default 1s->3s (ga-w7u)`
The 1s default is noisy on a busy shared Dolt.

### `test(gastown): guard all role wisp hook-checks use --json + valid molecule type (ga-p9g)`
Test-only guard.

Rebased cleanly onto current `main` (565 commits of drift, zero
conflicts). `git cherry -v origin/main` confirms none had an upstream
patch equivalent.
