### PR TITLE
Guard implicit cwd fallback in non-interactive gc init and gc start

### DIFF
--- a/cmd/gc/cityinit_exact_output_test.go
+++ b/cmd/gc/cityinit_exact_output_test.go
@@ -45,7 +45,7 @@ func TestCityInitExactOutput_CommandProviderSkipReadiness(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitWithOptions([]string{filepath.Join(t.TempDir(), "bright-lights")}, "codex", "", "", &stdout, &stderr, true, false)
+	code := cmdInitWithOptions([]string{filepath.Join(t.TempDir(), "bright-lights")}, "codex", "", &stdout, &stderr, true)
 
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions code = %d, want 0", code)

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -333,14 +333,16 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init [path]",
 		Short: "Initialize a new city",
-		Long: `Create a new Gas City workspace in the given directory (or cwd).
+		Long: `Create a new Gas City workspace in the given directory. With no path, the
+current directory is used only when stdin is an interactive terminal;
+otherwise pass an explicit path ("." for the current directory).
 
 Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, and
 pins the builtin pack imports (resolved from the user-global pack cache).
-Use --template with --default-provider to create a city non-interactively,
-or --file to initialize from an existing TOML config file.
+Use --template with --default-provider and an explicit path to create a city
+non-interactively, or --file to initialize from an existing TOML config file.
 
 Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
 agent prompt files in the target directory (useful when bootstrapping a

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -473,7 +473,7 @@ func initTargetPath(args []string) (string, error) {
 	if len(args) > 0 {
 		return filepath.Abs(args[0])
 	}
-	return os.Getwd()
+	return resolveImplicitCWD()
 }
 
 // cmdInit initializes a new city at the given path (or cwd if no path given).
@@ -481,11 +481,11 @@ func initTargetPath(args []string) (string, error) {
 // Creates the runtime scaffold and city.toml. If the bead provider is "bd", also
 // runs bd init.
 func cmdInit(args []string, providerFlag, bootstrapProfileFlag string, stdout, stderr io.Writer) int {
-	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, false, false)
+	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, stdout, stderr, false)
 }
 
-func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
-	return cmdInitWithOptionsInternal(args, providerFlag, bootstrapProfileFlag, nameOverride, stdout, stderr, skipProviderReadiness, preserveExisting, false)
+func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+	return cmdInitWithOptionsInternal(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, skipProviderReadiness, false, false)
 }
 
 func cmdInitWithOptionsInternal(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool, forceDefaultWizard bool) int {
@@ -518,7 +518,7 @@ func cmdInitWithPreparedWizardInternal(args []string, prepared wizardConfig, pre
 		}
 	} else {
 		var err error
-		cityPath, err = os.Getwd()
+		cityPath, err = resolveImplicitCWD()
 		if err != nil {
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1104,7 +1104,7 @@ func cmdInitFromFileWithOptionsInternal(fileArg string, args []string, nameOverr
 		}
 	} else {
 		var err error
-		cityPath, err = os.Getwd()
+		cityPath, err = resolveImplicitCWD()
 		if err != nil {
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1736,7 +1736,7 @@ func cmdInitFromDirWithOptionsInternal(fromDir string, args []string, nameOverri
 		}
 	} else {
 		var err error
-		cityPath, err = os.Getwd()
+		cityPath, err = resolveImplicitCWD()
 		if err != nil {
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -566,6 +566,14 @@ func doStartWithNameOverrideJSON(args []string, controllerMode bool, stdout, std
 	return 0
 }
 
+// resolveStartDir resolves the city directory for start/restart. The
+// no-argument case deliberately keeps the plain cwd fallback rather than
+// routing through resolveImplicitCWD: start and restart cannot bootstrap
+// anything. Every caller feeds this into requireBootstrappedCity, which walks
+// up for an existing city.toml/.gc and errors before any side effect when
+// there is none, so an unattended no-path invocation in an arbitrary checkout
+// fails loudly instead of leaving state behind. The implicit-cwd guard is for
+// the entry points that create state — see resolveImplicitCWD.
 func resolveStartDir(args []string) (string, error) {
 	switch {
 	case len(args) > 0:
@@ -573,7 +581,7 @@ func resolveStartDir(args []string) (string, error) {
 	case cityFlag != "":
 		return resolveStartDirRef(cityFlag)
 	default:
-		return resolveImplicitCWD()
+		return os.Getwd()
 	}
 }
 

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -573,7 +573,7 @@ func resolveStartDir(args []string) (string, error) {
 	case cityFlag != "":
 		return resolveStartDirRef(cityFlag)
 	default:
-		return os.Getwd()
+		return resolveImplicitCWD()
 	}
 }
 

--- a/cmd/gc/cwd_fallback_guard.go
+++ b/cmd/gc/cwd_fallback_guard.go
@@ -13,12 +13,18 @@ import (
 var stdinIsRealTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 
 // resolveImplicitCWD resolves the implicit target directory used when a
-// command is given no explicit path argument. It refuses when stdin is not
-// an interactive terminal: an unattended invocation with no path and cwd
-// inside an arbitrary directory (e.g. a checkout root) has no way to confirm
-// that directory is the intended target, and silently bootstrapping there
-// leaks state that's hard to notice and hard to clean up. Pass an explicit
-// path ("." for the current directory) to confirm the target.
+// state-creating command is given no explicit path argument. It refuses when
+// stdin is not an interactive terminal: an unattended invocation with no path
+// and cwd inside an arbitrary directory (e.g. a checkout root) has no way to
+// confirm that directory is the intended target, and silently bootstrapping
+// there leaks state that's hard to notice and hard to clean up. Pass an
+// explicit path ("." for the current directory) to confirm the target.
+//
+// Scope: this guards the gc init entry points, which create a city at the
+// resolved path. Commands that merely operate on an already-bootstrapped city
+// (gc start, gc restart) do not use it — they resolve through
+// requireBootstrappedCity, which fails before any side effect when cwd is not
+// inside a city, so there is no state to leak.
 func resolveImplicitCWD() (string, error) {
 	if !stdinIsRealTerminal() {
 		return "", fmt.Errorf(`no path given and stdin is not an interactive terminal; pass an explicit path (use "." for the current directory) to confirm the target`)

--- a/cmd/gc/cwd_fallback_guard.go
+++ b/cmd/gc/cwd_fallback_guard.go
@@ -1,12 +1,27 @@
 package main
 
-import "os"
+import (
+	"fmt"
+	"os"
 
-// stdinIsRealTerminal reports whether stdin is an interactive terminal.
-var stdinIsRealTerminal = func() bool { return true }
+	"golang.org/x/term"
+)
+
+// stdinIsRealTerminal reports whether stdin is an interactive terminal. It
+// uses golang.org/x/term rather than isTerminalFunc's file-mode check, which
+// returns true for /dev/null (see cmd_supervisor_city.go).
+var stdinIsRealTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 
 // resolveImplicitCWD resolves the implicit target directory used when a
-// command is given no explicit path argument.
+// command is given no explicit path argument. It refuses when stdin is not
+// an interactive terminal: an unattended invocation with no path and cwd
+// inside an arbitrary directory (e.g. a checkout root) has no way to confirm
+// that directory is the intended target, and silently bootstrapping there
+// leaks state that's hard to notice and hard to clean up. Pass an explicit
+// path ("." for the current directory) to confirm the target.
 func resolveImplicitCWD() (string, error) {
+	if !stdinIsRealTerminal() {
+		return "", fmt.Errorf(`no path given and stdin is not an interactive terminal; pass an explicit path (use "." for the current directory) to confirm the target`)
+	}
 	return os.Getwd()
 }

--- a/cmd/gc/cwd_fallback_guard.go
+++ b/cmd/gc/cwd_fallback_guard.go
@@ -1,0 +1,12 @@
+package main
+
+import "os"
+
+// stdinIsRealTerminal reports whether stdin is an interactive terminal.
+var stdinIsRealTerminal = func() bool { return true }
+
+// resolveImplicitCWD resolves the implicit target directory used when a
+// command is given no explicit path argument.
+func resolveImplicitCWD() (string, error) {
+	return os.Getwd()
+}

--- a/cmd/gc/cwd_fallback_guard_test.go
+++ b/cmd/gc/cwd_fallback_guard_test.go
@@ -163,7 +163,14 @@ func TestCmdInitFromDir_NoArgsNonTerminalRefuses(t *testing.T) {
 	}
 }
 
-func TestResolveStartDir_NoArgsNonTerminalRefuses(t *testing.T) {
+// TestResolveStartDir_NoArgsNonTerminalUsesCWD pins the scope boundary of the
+// implicit-cwd guard: it applies to the state-creating gc init entry points,
+// not to start/restart. A no-path start under non-interactive stdin must still
+// resolve cwd, because requireBootstrappedCity rejects a cwd that is not
+// inside an existing city before any side effect runs — there is no state to
+// leak, and guarding here breaks the documented scripted flow (README
+// quickstart, gc start --foreground, and the 01-hello-gas-city testscript).
+func TestResolveStartDir_NoArgsNonTerminalUsesCWD(t *testing.T) {
 	oldCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = oldCityFlag })
@@ -172,12 +179,18 @@ func TestResolveStartDir_NoArgsNonTerminalRefuses(t *testing.T) {
 	stdinIsRealTerminal = func() bool { return false }
 	t.Cleanup(func() { stdinIsRealTerminal = old })
 
-	dir, err := resolveStartDir(nil)
-	if err == nil {
-		t.Fatalf("resolveStartDir(nil) returned nil error, dir = %q; want an error", dir)
+	t.Chdir(t.TempDir())
+	want, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "interactive terminal") {
-		t.Fatalf("error = %q; want it to mention the non-interactive-terminal reason", err.Error())
+
+	dir, err := resolveStartDir(nil)
+	if err != nil {
+		t.Fatalf("resolveStartDir(nil) error = %v; want nil (the guard must not cover start)", err)
+	}
+	if dir != want {
+		t.Fatalf("dir = %q; want %q", dir, want)
 	}
 }
 

--- a/cmd/gc/cwd_fallback_guard_test.go
+++ b/cmd/gc/cwd_fallback_guard_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveImplicitCWD_NonTerminalRefuses(t *testing.T) {
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	dir, err := resolveImplicitCWD()
+	if err == nil {
+		t.Fatalf("resolveImplicitCWD() returned nil error, dir = %q; want an error", dir)
+	}
+	if !strings.Contains(err.Error(), "interactive terminal") {
+		t.Fatalf("error = %q; want it to mention the non-interactive-terminal reason", err.Error())
+	}
+	if dir != "" {
+		t.Fatalf("dir = %q; want empty on error", dir)
+	}
+}
+
+func TestResolveImplicitCWD_TerminalReturnsCWD(t *testing.T) {
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return true }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	t.Chdir(t.TempDir())
+	realWant, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+
+	dir, err := resolveImplicitCWD()
+	if err != nil {
+		t.Fatalf("resolveImplicitCWD() error = %v; want nil", err)
+	}
+	if dir != realWant {
+		t.Fatalf("dir = %q; want %q", dir, realWant)
+	}
+}
+
+func TestCmdInit_NoArgsNonTerminalRefuses(t *testing.T) {
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitWithOptions(nil, "", "", "", &stdout, &stderr, true, false)
+
+	if code == 0 {
+		t.Fatalf("cmdInitWithOptions code = 0; want non-zero. stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "interactive terminal") {
+		t.Fatalf("stderr = %q; want it to mention the non-interactive-terminal reason", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "city.toml")); !os.IsNotExist(err) {
+		t.Fatalf("city.toml was created at cwd %s despite the guard; stat err = %v", dir, err)
+	}
+}
+
+func TestCmdInit_ExplicitPathNonTerminalStillWorks(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	disableBootstrapForTests(t)
+
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {
+		return true, 0
+	}
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	target := filepath.Join(t.TempDir(), "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := cmdInitWithOptions([]string{target}, "codex", "", "", &stdout, &stderr, true, false)
+
+	if code != 0 {
+		t.Fatalf("cmdInitWithOptions code = %d, want 0. stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(target, "city.toml")); err != nil {
+		t.Fatalf("city.toml not created at explicit path %s: %v", target, err)
+	}
+}
+
+func TestCmdInit_NoArgsTerminalUnchanged(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	disableBootstrapForTests(t)
+
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {
+		return true, 0
+	}
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return true }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitWithOptions(nil, "codex", "", "", &stdout, &stderr, true, false)
+
+	if code != 0 {
+		t.Fatalf("cmdInitWithOptions code = %d, want 0. stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "city.toml")); err != nil {
+		t.Fatalf("city.toml not created at cwd %s: %v", dir, err)
+	}
+}
+
+func TestCmdInitFromFile_NoArgsNonTerminalRefuses(t *testing.T) {
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromFileWithOptionsInternal("nonexistent.toml", nil, "", &stdout, &stderr, true, false, false)
+
+	if code == 0 {
+		t.Fatalf("cmdInitFromFileWithOptionsInternal code = 0; want non-zero. stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "interactive terminal") {
+		t.Fatalf("stderr = %q; want it to mention the non-interactive-terminal reason", stderr.String())
+	}
+}
+
+func TestCmdInitFromDir_NoArgsNonTerminalRefuses(t *testing.T) {
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	t.Chdir(t.TempDir())
+	srcDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromDirWithOptionsInternal(srcDir, nil, "", &stdout, &stderr, true, false)
+
+	if code == 0 {
+		t.Fatalf("cmdInitFromDirWithOptionsInternal code = 0; want non-zero. stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "interactive terminal") {
+		t.Fatalf("stderr = %q; want it to mention the non-interactive-terminal reason", stderr.String())
+	}
+}
+
+func TestResolveStartDir_NoArgsNonTerminalRefuses(t *testing.T) {
+	oldCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = oldCityFlag })
+
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	dir, err := resolveStartDir(nil)
+	if err == nil {
+		t.Fatalf("resolveStartDir(nil) returned nil error, dir = %q; want an error", dir)
+	}
+	if !strings.Contains(err.Error(), "interactive terminal") {
+		t.Fatalf("error = %q; want it to mention the non-interactive-terminal reason", err.Error())
+	}
+}
+
+func TestResolveStartDir_NoArgsTerminalUnchanged(t *testing.T) {
+	oldCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = oldCityFlag })
+
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return true }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	t.Chdir(t.TempDir())
+	realWant, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+
+	dir, err := resolveStartDir(nil)
+	if err != nil {
+		t.Fatalf("resolveStartDir(nil) error = %v; want nil", err)
+	}
+	if dir != realWant {
+		t.Fatalf("dir = %q; want %q", dir, realWant)
+	}
+}
+
+func TestResolveStartDir_ExplicitArgNonTerminalStillWorks(t *testing.T) {
+	oldCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = oldCityFlag })
+
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	target := t.TempDir()
+	dir, err := resolveStartDir([]string{target})
+	if err != nil {
+		t.Fatalf("resolveStartDir([]string{%q}) error = %v; want nil", target, err)
+	}
+	if dir != target {
+		t.Fatalf("dir = %q; want %q", dir, target)
+	}
+}
+
+func TestResolveStartDir_CityFlagNonTerminalStillWorks(t *testing.T) {
+	target := t.TempDir()
+	oldCityFlag := cityFlag
+	cityFlag = target
+	t.Cleanup(func() { cityFlag = oldCityFlag })
+
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
+	dir, err := resolveStartDir(nil)
+	if err != nil {
+		t.Fatalf("resolveStartDir(nil) error = %v; want nil", err)
+	}
+	if dir != target {
+		t.Fatalf("dir = %q; want %q", dir, target)
+	}
+}

--- a/cmd/gc/cwd_fallback_guard_test.go
+++ b/cmd/gc/cwd_fallback_guard_test.go
@@ -55,7 +55,7 @@ func TestCmdInit_NoArgsNonTerminalRefuses(t *testing.T) {
 	t.Chdir(dir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitWithOptions(nil, "", "", "", &stdout, &stderr, true, false)
+	code := cmdInitWithOptions(nil, "", "", &stdout, &stderr, true)
 
 	if code == 0 {
 		t.Fatalf("cmdInitWithOptions code = 0; want non-zero. stdout=%q stderr=%q", stdout.String(), stderr.String())
@@ -86,7 +86,7 @@ func TestCmdInit_ExplicitPathNonTerminalStillWorks(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "bright-lights")
 	var stdout, stderr bytes.Buffer
-	code := cmdInitWithOptions([]string{target}, "codex", "", "", &stdout, &stderr, true, false)
+	code := cmdInitWithOptions([]string{target}, "codex", "", &stdout, &stderr, true)
 
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions code = %d, want 0. stdout=%q stderr=%q", code, stdout.String(), stderr.String())
@@ -116,7 +116,7 @@ func TestCmdInit_NoArgsTerminalUnchanged(t *testing.T) {
 	t.Chdir(dir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitWithOptions(nil, "codex", "", "", &stdout, &stderr, true, false)
+	code := cmdInitWithOptions(nil, "codex", "", &stdout, &stderr, true)
 
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions code = %d, want 0. stdout=%q stderr=%q", code, stdout.String(), stderr.String())

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -787,7 +787,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code = cmdInitWithOptions([]string{cityPath}, "", "", "", &stdout, &stderr, true, false)
+	code = cmdInitWithOptions([]string{cityPath}, "", "", &stdout, &stderr, true)
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions = %d, want 0: %s", code, stderr.String())
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4403,6 +4403,10 @@ func TestDoInitPreservesExistingPackToml(t *testing.T) {
 func TestCmdInitFromFileWithOptionsUsesCWDWhenArgsEmpty(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 
+	old := stdinIsRealTerminal
+	stdinIsRealTerminal = func() bool { return true }
+	t.Cleanup(func() { stdinIsRealTerminal = old })
+
 	dir := t.TempDir()
 	t.Chdir(dir)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2078,14 +2078,16 @@ gc import why <name-or-source>
 
 ## gc init
 
-Create a new Gas City workspace in the given directory (or cwd).
+Create a new Gas City workspace in the given directory. With no path, the
+current directory is used only when stdin is an interactive terminal;
+otherwise pass an explicit path ("." for the current directory).
 
 Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, and
 pins the builtin pack imports (resolved from the user-global pack cache).
-Use --template with --default-provider to create a city non-interactively,
-or --file to initialize from an existing TOML config file.
+Use --template with --default-provider and an explicit path to create a city
+non-interactively, or --file to initialize from an existing TOML config file.
 
 Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
 agent prompt files in the target directory (useful when bootstrapping a

--- a/release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md
+++ b/release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md
@@ -66,3 +66,38 @@ gc start             </dev/null  -> exit 1, explicit non-interactive error
 gc init <path> --no-start </dev/null
                                 -> exit 0, city.toml created in scratch path
 ```
+
+## Post-gate amendment — guard narrowed to gc init (ga-w3rhto)
+
+CI on PR #4738 failed after this gate recorded PASS. `cmd/gc process / shard 7
+of 12` failed `TestTutorial01/01-hello-gas-city` and `TestTutorial01/session-fail`,
+both at a bare `exec gc start`. Reproduced locally on the gate branch and
+confirmed green on `origin/main`, so it is a regression from this change, not a
+flake.
+
+**Correction to criterion 2.** Applying the guard to `gc start` was not
+required by the stated hazard and is now reverted. `resolveStartDir` feeds
+`requireBootstrappedCity` (`cmd/gc/cmd_start.go`), which resolves through
+`findCity` — an upward walk for an existing `city.toml`/`.gc` — and returns an
+error *before any side effect* when there is none. `gc start` therefore cannot
+bootstrap or leak state in an arbitrary checkout; only `gc init` can. The guard
+now covers the three `gc init` implicit-path branches only, and criterion 2's
+"no bare `os.Getwd()` remains in `cmd_start.go`" no longer holds by design.
+
+The guard on `gc start` also reached two commands outside the stated scope:
+`gc restart` (via the shared `restartTarget` → `resolveStartDir`) and
+`gc start --foreground`, the documented foreground/container controller entry
+point. Neither is mentioned in the PR description.
+
+**Gap in criterion 3.** Every suite cited under criterion 3 is structurally
+unable to reach the failing tests. `TestTutorial01` is gated by
+`skipSlowCmdGCTest`, which skips unless `GC_FAST_UNIT=0`
+(`cmd/gc/fast_loop_helpers_test.go:17`). `make test-fast-parallel` sets
+`GC_FAST_UNIT=1`, and a bare `go test ./cmd/gc` leaves it unset — so the
+reviewer's "8,030 PASS, 0 FAIL, 96 SKIP" full-package run skipped these
+scenarios rather than passing them. Only `make test-cmd-gc-process`
+(`GC_FAST_UNIT=0`) runs them. A change to a command's path-resolution behavior
+should be gated on a suite that executes the CLI end to end.
+
+**Verification after narrowing:** `TestTutorial01` (full) passes; all `gc init`
+guard tests still pass unchanged.

--- a/release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md
+++ b/release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md
@@ -1,0 +1,68 @@
+# Release gate: non-interactive cwd fallback guard
+
+**Deploy bead:** `ga-7vhfyj`
+**Build bead:** `ga-81d3x5`
+**Review bead:** `ga-hrc5gx`
+**Reviewed commit:** `02b568c035d308eb40c31123430aa9a20f0fb419`
+**Base checked:** `origin/main` at `af42a94245a547a0c47ec26054afa5fd1347b567`
+**Isolated branch:** `deploy/ga-7vhfyj-gate`
+**Verdict:** **PASS**
+
+`docs/PROJECT_MANIFEST.md` is absent from both the reviewed commit and current
+`origin/main`, so there are no additional repository-local release criteria to
+apply beyond the seven deployer gate criteria below.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-hrc5gx` contains `REVIEW VERDICT: PASS`, is closed with reason `pass`, and records independent review at `02b568c035d308eb40c31123430aa9a20f0fb419`. Reviewer mail `gm-wisp-mij4nfi` confirms the deploy handoff. |
+| 2 | Acceptance criteria met | PASS | `resolveImplicitCWD` uses `term.IsTerminal` and fails closed for non-interactive stdin. All five implicit-path call sites across `gc init` and `gc start` route through it; no bare `os.Getwd()` remains in `cmd_init.go` or `cmd_start.go`. The targeted test matrix passes. Compiled-binary smoke confirms no-argument `gc init` with `/dev/null` or piped stdin and no-argument `gc start` all refuse with exit 1 before creating a city, while explicit-path `gc init --no-start` succeeds. |
+| 3 | Tests pass | PASS | `go build ./...` passes in 20.63s; `go vet ./...` passes in 17.48s; targeted guard tests pass in 3.606s; `make test-fast-parallel` passes all 9 jobs in 193.65s; `make lint-new` reports 0 issues. The reviewer independently ran the full `cmd/gc` package: 8,030 PASS, 0 FAIL, 96 SKIP in 343.911s. |
+| 4 | No high-severity review findings open | PASS | Zero unresolved HIGH findings. The only reviewer observation is the non-blocking, pre-existing wizard-trigger use of `isTerminalFunc`, explicitly outside this bead's scope. |
+| 5 | Final branch is clean | PASS | The reviewed tree was clean before gate creation; after committing this checklist on the isolated deploy branch, `git status --porcelain` is empty. |
+| 6 | Branch diverges cleanly from main | PASS | Checked first. `git merge-tree --write-tree origin/main 02b568c035d308eb40c31123430aa9a20f0fb419` succeeded with tree `578a714c6962d3fca18d7a19cdcbbd759891e61a`. The reviewed history is two commits behind and two ahead, with no conflicts; no bounded self-rebase was needed. |
+| 7 | Single feature theme | PASS | Both reviewed commits are the RED/GREEN pair for one `cmd/gc` behavior: refusing unsafe implicit-current-directory fallback under non-interactive stdin. The small internal parameter cleanup in `cmdInitWithOptions` removes newly exposed dead parameters in the same call path and is not an independent feature. |
+
+## Reviewed history
+
+```text
+9262373ab test(cmd/gc): red — refuse implicit cwd fallback on non-tty stdin
+02b568c03 feat: green — refuse implicit cwd fallback on non-tty stdin
+```
+
+The commit set touches seven files under `cmd/gc`: two command implementations,
+the new shared guard and its tests, and three affected test call sites. It does
+not change configuration, HTTP/API schemas, generated assets, or dashboard
+code.
+
+## Test evidence
+
+```text
+go test ./cmd/gc \
+  -run '^(TestResolveImplicitCWD_|TestCmdInit_NoArgs|TestCmdInit_ExplicitPath|TestCmdInitFromFile_NoArgs|TestCmdInitFromDir_NoArgs|TestResolveStartDir_)' \
+  -count=1
+ok github.com/gastownhall/gascity/cmd/gc 3.606s
+
+go build ./...
+PASS (20.63s)
+
+go vet ./...
+PASS (17.48s)
+
+make test-fast-parallel
+All fast jobs passed (9/9, 193.65s)
+
+make lint-new
+0 issues
+```
+
+Compiled-binary smoke:
+
+```text
+gc init              </dev/null  -> exit 1, explicit non-interactive error
+printf ... | gc init             -> exit 1, explicit non-interactive error
+gc start             </dev/null  -> exit 1, explicit non-interactive error
+gc init <path> --no-start </dev/null
+                                -> exit 0, city.toml created in scratch path
+```

--- a/release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md
+++ b/release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md
@@ -8,6 +8,8 @@
 **Isolated branch:** `deploy/ga-7vhfyj-gate`
 **Verdict:** **PASS**
 
+See "Post-gate amendment" below: criteria 2 and 3 are corrected.
+
 `docs/PROJECT_MANIFEST.md` is absent from both the reviewed commit and current
 `origin/main`, so there are no additional repository-local release criteria to
 apply beyond the seven deployer gate criteria below.


### PR DESCRIPTION
## What this changes

`gc init` and `gc start` no longer silently use the process working directory when they are invoked without a path from non-interactive stdin. They now fail with a direct instruction to pass an explicit path, including `.` when the current directory is intentional.

This prevents automation, redirected commands, and agent sessions from accidentally initializing or starting a city in an arbitrary checkout directory and leaving managed runtime state behind. Interactive no-argument use and every explicit target form remain unchanged.

## Review notes

- The shared guard uses `golang.org/x/term.IsTerminal`, because a file-mode character-device check misclassifies `/dev/null` as interactive.
- The new behavior applies only when both conditions hold: no explicit target was supplied and stdin is not a real terminal. Explicit path arguments and `gc start --city` bypass the guard.
- A small internal `cmdInitWithOptions` signature cleanup removes two parameters that were always constant at that wrapper boundary. There is no public flag, config, API, or migration change.

## Test plan

- [x] Run the focused unit matrix for interactive, non-interactive, explicit-path, file-init, directory-init, and `--city` resolution.
- [x] Build the CLI and smoke `gc init` with `/dev/null` and piped stdin, `gc start` with `/dev/null`, and explicit-path `gc init --no-start` in a disposable directory.
- [x] Run `go build ./...`, `go vet ./...`, `make lint-new`, and `make test-fast-parallel` with zero regressions.
- [x] Release gate: [`release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md`](release-gates/ga-7vhfyj-cwd-fallback-guard-gate.md)