### PR TITLE
fix(session): let a live singleton pool session reclaim its alias from a drained same-identity predecessor

### DIFF
--- a/cmd/gc/build_desired_state_pool_info.go
+++ b/cmd/gc/build_desired_state_pool_info.go
@@ -402,7 +402,7 @@ func normalizeNonExpandingPoolSessionInfo(
 	}
 	if aliasNeedsUpdate {
 		if err := session.WithCitySessionAliasLock(bp.cityPath, canonical, func() error {
-			if err := session.EnsureAliasAvailableWithConfig(bp.beadStore, bp.city, canonical, info.ID); err != nil {
+			if err := session.EnsureAliasAvailableWithConfigForOwner(bp.beadStore, bp.city, canonical, info.ID, canonical); err != nil {
 				return err
 			}
 			return apply()

--- a/cmd/gc/session_wpool_twins_test.go
+++ b/cmd/gc/session_wpool_twins_test.go
@@ -395,3 +395,73 @@ func TestSnapshotAddInfoConcurrentAndCoherent(t *testing.T) {
 		}
 	}
 }
+
+// TestNormalizeNonExpandingPoolSessionInfoForSelectionDrainedNamedPredecessor pins
+// the production call site of the #2885 self-owner exception. An asleep, drained
+// configured-named predecessor for canonical identity X used to squat X's alias
+// forever: the alias claim failed with ErrSessionAliasExists, selection fell back
+// to recording deferred pool-alias-conflict bookkeeping, and the live pool-managed
+// session never collapsed onto its own canonical identity.
+//
+// Both cfg.NamedSessions arrangements are exercised because the owner-scoped
+// claim changes behavior in the trailing reserved-alias loop too: with X present
+// in cfg.NamedSessions, selfOwner == reserved short-circuits the reservation that
+// would otherwise refuse the alias.
+func TestNormalizeNonExpandingPoolSessionInfoForSelectionDrainedNamedPredecessor(t *testing.T) {
+	cfgAgent := &config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	canonical := cfgAgent.QualifiedName()
+
+	cases := []struct {
+		name string
+		city *config.City
+	}{
+		{
+			name: "canonical absent from cfg.NamedSessions",
+			city: &config.City{},
+		},
+		{
+			name: "canonical reserved by cfg.NamedSessions",
+			city: &config.City{NamedSessions: []config.NamedSession{{Name: "mayor", Template: "mayor"}}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			predecessor := wpoolSessionBead("gm-drained-named", "open", "mayor", nil, map[string]string{
+				"session_name": canonical, "session_origin": "named",
+				"configured_named_session": "true", "configured_named_identity": canonical,
+				"state": "asleep", "sleep_reason": "drained",
+			})
+			liveBead := wpoolSessionBead("gm-live", "open", "mayor-1", nil, map[string]string{
+				"template": "mayor", "agent_name": "mayor-1", "alias": "mayor-1",
+				"session_name": "s-live", "pool_managed": "true", "state": "awake",
+			})
+			store := beads.NewMemStoreFrom(1, []beads.Bead{predecessor, liveBead}, nil)
+			bp := &agentBuildParams{beadStore: store, city: tc.city}
+
+			folded, err := normalizeNonExpandingPoolSessionInfoForSelection(bp, cfgAgent, sessiontest.SeedBead(t, liveBead))
+			if err != nil {
+				t.Fatalf("normalizeNonExpandingPoolSessionInfoForSelection: %v", err)
+			}
+			if folded.Alias != canonical {
+				t.Errorf("alias = %q, want %q (drained named predecessor must not block the collapse)", folded.Alias, canonical)
+			}
+			if folded.PoolAliasConflict != "" || folded.PoolAliasConflictCount != "" || folded.PoolAliasConflictAt != "" {
+				t.Errorf("deferred-conflict bookkeeping recorded: conflict=%q count=%q at=%q",
+					folded.PoolAliasConflict, folded.PoolAliasConflictCount, folded.PoolAliasConflictAt)
+			}
+
+			persisted, err := session.NewStore(beads.SessionStore{Store: store}).Get("gm-live")
+			if err != nil {
+				t.Fatalf("store Get: %v", err)
+			}
+			if persisted.Alias != canonical {
+				t.Errorf("persisted alias = %q, want %q", persisted.Alias, canonical)
+			}
+			if persisted.PoolAliasConflict != "" || persisted.PoolAliasConflictCount != "" || persisted.PoolAliasConflictAt != "" {
+				t.Errorf("persisted deferred-conflict bookkeeping: conflict=%q count=%q at=%q",
+					persisted.PoolAliasConflict, persisted.PoolAliasConflictCount, persisted.PoolAliasConflictAt)
+			}
+		})
+	}
+}

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -615,13 +615,26 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 			// claimant asserts the exact owner identity the holder was
 			// minted for, (2) the holder is asleep rather than genuinely
 			// running, and (3) the holder is recognizably a
-			// configured-named-session bead. This mirrors the self-owner
-			// exception the agent_name branch below already has, and does
-			// not resurrect or steal an alias from an unrelated, live, or
-			// ambiguous session.
+			// configured-named-session bead FOR THAT SAME IDENTITY. This
+			// mirrors the self-owner exception the agent_name branch below
+			// already has, and does not resurrect or steal an alias from an
+			// unrelated, live, or ambiguous session.
+			//
+			// Condition (3) is two-part on purpose.
+			// wasConfiguredNamedSession(b) establishes the holder is a
+			// configured-named-session bead at all, but it is owner-AGNOSTIC
+			// — a bead minted for a DIFFERENT configured identity that merely
+			// persisted this identity's runtime session_name would satisfy it
+			// and hand the alias over on the claimant's assertion alone.
+			// configuredNamedIdentitySignalsMatch is the owner-scoped
+			// recognizer introduced for the identical trap in
+			// name_claim_sweep.go (review #3373); it matches the recorded
+			// identity, alias, agent_name, or template/role signal against
+			// THIS identity.
 			if selfOwner != "" && selfOwner == alias &&
 				strings.TrimSpace(b.Metadata["state"]) == string(StateAsleep) &&
-				wasConfiguredNamedSession(b) {
+				wasConfiguredNamedSession(b) &&
+				configuredNamedIdentitySignalsMatch(b, selfOwner) {
 				continue
 			}
 			return fmt.Errorf("%w: %q conflicts with session name on %s", ErrSessionAliasExists, alias, b.ID)

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -608,6 +608,22 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 			continue
 		}
 		if strings.TrimSpace(b.Metadata["session_name"]) == alias {
+			// A superseded, non-running (asleep) configured-named-session
+			// predecessor for the SAME identity must not block that
+			// identity's own live holder from claiming its canonical alias
+			// (#2885, Fix Candidate A). Scoped narrowly: only when (1) the
+			// claimant asserts the exact owner identity the holder was
+			// minted for, (2) the holder is asleep rather than genuinely
+			// running, and (3) the holder is recognizably a
+			// configured-named-session bead. This mirrors the self-owner
+			// exception the agent_name branch below already has, and does
+			// not resurrect or steal an alias from an unrelated, live, or
+			// ambiguous session.
+			if selfOwner != "" && selfOwner == alias &&
+				strings.TrimSpace(b.Metadata["state"]) == string(StateAsleep) &&
+				wasConfiguredNamedSession(b) {
+				continue
+			}
 			return fmt.Errorf("%w: %q conflicts with session name on %s", ErrSessionAliasExists, alias, b.ID)
 		}
 		if strings.TrimSpace(b.Metadata["alias"]) == alias {

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -1144,3 +1144,59 @@ func TestWithCitySessionLocks_EmptyCityPathSharesIdentifierNamespace(t *testing.
 	}
 	<-acquired
 }
+
+// An open, asleep, drained configured-named-session bead squats the canonical
+// alias forever in front of the LIVE pool-managed session for the same
+// identity. The session_name-match branch of ensureSessionAliasAvailable has
+// no self-owner exception, unlike the agent_name branch below it, so it
+// unconditionally blocks the live session's claim to its own canonical alias.
+// This is the root diagnosed in #2885 ("singleton pool canonical alias
+// squatted forever by asleep (non-closed) predecessor"), Fix Candidate A:
+// skip a superseded, non-running predecessor for the SAME canonical identity
+// when the requester is that identity's live holder.
+func TestEnsureSessionAliasAvailable_DrainedNamedPredecessorBlocksLiveSelfOwnerClaim(t *testing.T) {
+	store := beads.NewMemStore()
+
+	if _, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name":              "perrin",
+			"session_origin":            "named",
+			"configured_named_session":  "true",
+			"configured_named_identity": "perrin",
+			"state":                     "asleep",
+			"sleep_reason":              "drained",
+		},
+	}); err != nil {
+		t.Fatalf("Create(drained named holder): %v", err)
+	}
+
+	live, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "perrin-gc-live1",
+			"agent_name":   "perrin",
+			"template":     "perrin",
+			"pool_managed": "true",
+			"state":        "awake",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(live typed session): %v", err)
+	}
+
+	// The live session, claiming its own canonical alias, is not blocked by
+	// its own drained predecessor.
+	if err := ensureSessionAliasAvailable(store, nil, "perrin", live.ID, "perrin"); err != nil {
+		t.Fatalf("ensureSessionAliasAvailable(live self-owner vs drained predecessor) = %v, want nil", err)
+	}
+
+	// A third party (different selfOwner) must still be refused the alias:
+	// the drained bead still legitimately reserves the identity against
+	// anyone who is not that identity's own live holder.
+	if err := ensureSessionAliasAvailable(store, nil, "perrin", "gc-stranger", "siuan"); !errors.Is(err, ErrSessionAliasExists) {
+		t.Fatalf("ensureSessionAliasAvailable(different owner vs drained predecessor) = %v, want ErrSessionAliasExists", err)
+	}
+}

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -1200,3 +1200,91 @@ func TestEnsureSessionAliasAvailable_DrainedNamedPredecessorBlocksLiveSelfOwnerC
 		t.Fatalf("ensureSessionAliasAvailable(different owner vs drained predecessor) = %v, want ErrSessionAliasExists", err)
 	}
 }
+
+// The #2885 self-owner exception above is a three-part guard, and each part is
+// load-bearing. These negatives pin all three in the refusing direction so a
+// later loosening of the condition fails here rather than silently handing a
+// canonical alias to a claimant that only asserted ownership.
+//
+// The mismatched-identity case is the one wasConfiguredNamedSession alone
+// cannot catch: it is owner-AGNOSTIC, so the owner-scoped
+// configuredNamedIdentitySignalsMatch (the recognizer name_claim_sweep.go
+// adopted for the identical trap in review #3373) is what refuses it.
+func TestEnsureSessionAliasAvailable_SelfOwnerExceptionRefusesUnqualifiedHolders(t *testing.T) {
+	cases := []struct {
+		name   string
+		holder map[string]string
+	}{
+		{
+			// Guard condition 3, owner-scoped half: a configured-named-session
+			// bead minted for a DIFFERENT identity that merely persisted
+			// "perrin" as its runtime session_name. No alias, agent_name, or
+			// template resolves to "perrin", so it is not perrin's predecessor
+			// and must keep blocking perrin's claim.
+			name: "mismatched configured identity",
+			holder: map[string]string{
+				"session_name":              "perrin",
+				"session_origin":            "named",
+				"configured_named_session":  "true",
+				"configured_named_identity": "egwene",
+				"state":                     "asleep",
+				"sleep_reason":              "drained",
+			},
+		},
+		{
+			// Guard condition 2: same identity, but the holder is awake — a
+			// genuinely running session, not a superseded predecessor.
+			name: "same identity but awake",
+			holder: map[string]string{
+				"session_name":              "perrin",
+				"session_origin":            "named",
+				"configured_named_session":  "true",
+				"configured_named_identity": "perrin",
+				"state":                     "awake",
+			},
+		},
+		{
+			// Guard condition 3, recognition half: an asleep holder with no
+			// configured-named signals at all is an ordinary session squatting
+			// the name, not a configured-named predecessor.
+			name: "asleep but not a configured named session",
+			holder: map[string]string{
+				"session_name": "perrin",
+				"state":        "asleep",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+
+			if _, err := store.Create(beads.Bead{
+				Type:     BeadType,
+				Labels:   []string{LabelSession},
+				Metadata: tc.holder,
+			}); err != nil {
+				t.Fatalf("Create(holder): %v", err)
+			}
+
+			live, err := store.Create(beads.Bead{
+				Type:   BeadType,
+				Labels: []string{LabelSession},
+				Metadata: map[string]string{
+					"session_name": "perrin-gc-live1",
+					"agent_name":   "perrin",
+					"template":     "perrin",
+					"pool_managed": "true",
+					"state":        "awake",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create(live typed session): %v", err)
+			}
+
+			if err := ensureSessionAliasAvailable(store, nil, "perrin", live.ID, "perrin"); !errors.Is(err, ErrSessionAliasExists) {
+				t.Fatalf("ensureSessionAliasAvailable(self-owner vs %s) = %v, want ErrSessionAliasExists", tc.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements the Fix Candidate A recommended by the filer of #2885.

## Problem

`ensureSessionAliasAvailable`'s `session_name`-match branch has no self-owner exception, unlike its `agent_name`-match sibling a few lines below it:

```go
if strings.TrimSpace(b.Metadata["session_name"]) == alias {
    return fmt.Errorf("%w: %q conflicts with session name on %s", ErrSessionAliasExists, alias, b.ID)
}
...
if strings.TrimSpace(b.Metadata["agent_name"]) == alias {
    if selfOwner != "" && selfOwner == alias {
        continue
    }
    ...
}
```

An asleep/drained configured-named-session predecessor is neither `closed` nor `failedCreateIdentityReleased`, so neither existing skip applies and it blocks the live session **for the same identity** from claiming its own canonical alias — permanently.

Two symptoms fall out of this:

1. `deferring singleton pool identity normalization` on every reconcile tick — the report in #2885.
2. Named-session resolution mints a *duplicate* session. Because the live session never claims the canonical alias, `LookupConfiguredNamedSession` cannot find it (its candidate queries are exact-metadata lookups on `configured_named_identity` or `session_name`, and the live pool-managed bead carries neither the identity metadata nor the bare name — it carries the typed `agent-gc-XXXX` form). `resolveConfiguredNamedSessionID` falls through to `ensureSessionIDForTemplateWithOptions` and materializes a second session. A nudge addressed to the bare identity then resolves to the drained predecessor and reports success while reaching nothing.

Observed live on a production bead that accumulated `pool_alias_conflict_count=16` against exactly this block — written by `recordDeferredNonExpandingPoolAliasConflictInfo` — on a build newer than #3955, so #3955 (a related but distinct pool-demand fix) did not close this gap.

## Fix

Skip the predecessor only when all three hold:

1. `selfOwner` equals the alias being claimed — the claimant asserts the exact owner identity the holder was minted for;
2. the holder is `asleep`, not genuinely running;
3. the holder is recognizably a configured-named-session bead (`wasConfiguredNamedSession`).

A different owner, or an awake holder, is still refused.

Companion change: the one real call site that normalizes a pool session's alias to its canonical identity (`cmd/gc/build_desired_state_pool_info.go`) was calling `EnsureAliasAvailableWithConfig`, i.e. `selfOwner == ""`, so the new exception could never fire for the live path. It now calls `EnsureAliasAvailableWithConfigForOwner` passing the canonical identity as owner. Without this the fix is correct but inert for the reported scenario.

## Tests

`TestEnsureSessionAliasAvailable_DrainedNamedPredecessorBlocksLiveSelfOwnerClaim` (new). RED on unmodified `af42a94245a547a0c47ec26054afa5fd1347b567`:

```
    names_test.go:1230: ensureSessionAliasAvailable(live self-owner vs drained predecessor) = session alias already exists: "perrin" conflicts with session name on gc-1, want nil
--- FAIL: TestEnsureSessionAliasAvailable_DrainedNamedPredecessorBlocksLiveSelfOwnerClaim (0.00s)
FAIL	github.com/gastownhall/gascity/internal/session	0.891s
```

GREEN with the fix. The test also pins the blast radius: a third party with a different `selfOwner` is still refused with `ErrSessionAliasExists`.

Verified: `go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/session/...` green; `go test ./cmd/gc/ -run 'Alias|PoolIdentity|NamedSession|PendingCreate|SingletonPool'` green, including `TestRecordDeferredNonExpandingPoolAliasConflictInfoFold` (the function whose call site changed) and the `TestResolveSessionIDMaterializingNamed_*` family. `pending_create` rollback paths and `session_reconciler.go` are untouched.

## Scope

Deliberately not addressing #2885's Fix Candidate B (have the reconciler retire the superseded predecessor). That is the better long-term direction but has lifecycle blast radius; the filer recommended A first and this is A.

Fixes #2885