### PR TITLE
fix(storehealth): distinguish unmeasured row counts from a real zero

### DIFF
--- a/cmd/gc/city_status_store_health_test.go
+++ b/cmd/gc/city_status_store_health_test.go
@@ -181,12 +181,12 @@ func TestCityStatusSnapshotWarnsOnHighRatio(t *testing.T) {
 	// via storeHealthFromInputs directly instead.
 	rows := 221
 	const bytes = int64(11_200_000_000)
-	h := storeHealthFromInputs(cityPath, bytes, rows, time.Time{}, "")
+	h := storeHealthFromInputs(cityPath, bytes, rows, true, time.Time{}, "")
 	if !h.Warning {
 		t.Fatalf("Warning = false, want true for %d bytes / %d rows", bytes, rows)
 	}
 	// Sanity: below-threshold case.
-	h = storeHealthFromInputs(cityPath, 50_000_000, rows, time.Time{}, "")
+	h = storeHealthFromInputs(cityPath, 50_000_000, rows, true, time.Time{}, "")
 	if h.Warning {
 		t.Fatalf("Warning = true, want false for 50 MB / %d rows", rows)
 	}

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -96,14 +96,19 @@ type StatusSummaryJSON struct {
 // StoreHealth is the JSON shape of the Dolt bead store health block
 // surfaced by gc status. See ADR 0002 / bead ga-d5y design D9.
 type StoreHealth struct {
-	Path         string  `json:"path"`
-	SizeBytes    int64   `json:"size_bytes"`
-	LiveRows     int     `json:"live_rows"`
-	RatioMB      float64 `json:"ratio_mb_per_row"`
-	Warning      bool    `json:"warning"`
-	ThresholdMB  float64 `json:"threshold_mb_per_row"`
-	LastGCAt     string  `json:"last_gc_at,omitempty"`
-	LastGCStatus string  `json:"last_gc_status,omitempty"`
+	Path      string `json:"path"`
+	SizeBytes int64  `json:"size_bytes"`
+	LiveRows  int    `json:"live_rows"`
+	// LiveRowsUnknown is true when the row count failed or timed out.
+	// LiveRows, RatioMB, and Warning carry no meaning in that case — a
+	// consumer MUST check this field before trusting a "0" LiveRows or a
+	// "false" Warning as a real measurement.
+	LiveRowsUnknown bool    `json:"live_rows_unknown,omitempty"`
+	RatioMB         float64 `json:"ratio_mb_per_row"`
+	Warning         bool    `json:"warning"`
+	ThresholdMB     float64 `json:"threshold_mb_per_row"`
+	LastGCAt        string  `json:"last_gc_at,omitempty"`
+	LastGCStatus    string  `json:"last_gc_status,omitempty"`
 }
 
 var (

--- a/cmd/gc/store_health.go
+++ b/cmd/gc/store_health.go
@@ -13,25 +13,29 @@ import (
 
 // statusStoreHealthTimeout bounds the store-health row count so a live city
 // with a large closed-history table cannot stall `gc status` for minutes. The
-// count drives only the on-disk size ratio and is best-effort, so a timeout
-// returns 0 — mirroring the API server's countBeadStoreRows defense
-// (internal/api/store_health.go, statusStoreReadTimeout), which this CLI local
-// fallback never inherited. It matches the server's 1s bound.
+// count drives only the on-disk size ratio and is best-effort: a timeout
+// means the count is UNMEASURED, not zero. The API server's
+// countBeadStoreRows (internal/api/store_health.go, statusStoreReadTimeout)
+// returns an error on the same failure modes rather than fabricating a
+// count; liveRowCount mirrors that by returning measured=false instead of a
+// bare 0. It matches the server's 1s bound.
 const statusStoreHealthTimeout = time.Second
 
 // storeHealthFromInputs assembles a CLI-facing *StoreHealth from the raw
-// measurements. LastGCAt is serialized as RFC3339 UTC when present;
-// when the maintenance log is empty, LastGCAt and LastGCStatus are
-// omitted (json:"omitempty").
-func storeHealthFromInputs(cityPath string, sizeBytes int64, liveRows int, lastGCAt time.Time, lastGCStatus string) *StoreHealth {
-	h := storehealth.Compute(cityPath, sizeBytes, liveRows, lastGCAt, lastGCStatus)
+// measurements. rowsMeasured distinguishes a real liveRows count from a
+// count that failed or timed out — see storehealth.Compute. LastGCAt is
+// serialized as RFC3339 UTC when present; when the maintenance log is
+// empty, LastGCAt and LastGCStatus are omitted (json:"omitempty").
+func storeHealthFromInputs(cityPath string, sizeBytes int64, liveRows int, rowsMeasured bool, lastGCAt time.Time, lastGCStatus string) *StoreHealth {
+	h := storehealth.Compute(cityPath, sizeBytes, liveRows, rowsMeasured, lastGCAt, lastGCStatus)
 	out := &StoreHealth{
-		Path:        h.Path,
-		SizeBytes:   h.SizeBytes,
-		LiveRows:    h.LiveRows,
-		RatioMB:     h.RatioMB,
-		Warning:     h.Warning,
-		ThresholdMB: h.ThresholdMB,
+		Path:            h.Path,
+		SizeBytes:       h.SizeBytes,
+		LiveRows:        h.LiveRows,
+		LiveRowsUnknown: !h.RowsMeasured,
+		RatioMB:         h.RatioMB,
+		Warning:         h.Warning,
+		ThresholdMB:     h.ThresholdMB,
 	}
 	if !h.LastGCAt.IsZero() {
 		out.LastGCAt = h.LastGCAt.UTC().Format(time.RFC3339)
@@ -42,40 +46,44 @@ func storeHealthFromInputs(cityPath string, sizeBytes int64, liveRows int, lastG
 
 // collectStoreHealth measures the Dolt store at cityPath and the latest
 // maintenance event via ep, returning a populated *StoreHealth.
-// liveRowCount provides the live row count; callers without a store pass
-// nil and LiveRows is reported as zero.
+// liveRowCount provides the live row count and whether it was actually
+// measured; callers without a store pass nil and the count is unmeasured.
 func collectStoreHealth(cityPath string, store beads.Store, ep events.Provider) *StoreHealth {
 	size := storehealth.WalkSize(storehealth.StorePath(cityPath))
-	rows := liveRowCount(store)
+	rows, measured := liveRowCount(store)
 	lastAt, lastStatus := storehealth.LastMaintenance(ep)
-	return storeHealthFromInputs(cityPath, size, rows, lastAt, lastStatus)
+	return storeHealthFromInputs(cityPath, size, rows, measured, lastAt, lastStatus)
 }
 
-// liveRowCount returns the number of beads known to store, or 0 when store is
+// liveRowCount returns the number of beads known to store and whether that
+// count is real. measured is false — and rows is meaningless — when store is
 // nil, the count fails, or it does not finish within statusStoreHealthTimeout.
-// Counts all statuses (including closed) because the ratio is about on-disk row
-// footprint, not actionable work — but that closed-inclusive scan is never
-// cache-answerable and hydrates the whole history from the backend, so it is
-// bounded to keep `gc status` responsive. A Counter-capable store (Dolt /
-// CachingStore) answers from the catalog without hydrating rows; otherwise a
-// bounded full scan is the fallback.
-func liveRowCount(store beads.Store) int {
+// A caller MUST NOT treat rows as a real zero when measured is false: that
+// conflation renders a timed-out count byte-identically to a healthy,
+// genuinely empty store. Counts all statuses (including closed) because the
+// ratio is about
+// on-disk row footprint, not actionable work — but that closed-inclusive scan
+// is never cache-answerable and hydrates the whole history from the backend,
+// so it is bounded to keep `gc status` responsive. A Counter-capable store
+// (Dolt / CachingStore) answers from the catalog without hydrating rows;
+// otherwise a bounded full scan is the fallback.
+func liveRowCount(store beads.Store) (rows int, measured bool) {
 	if store == nil {
-		return 0
+		return 0, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), statusStoreHealthTimeout)
 	defer cancel()
 	query := beads.ListQuery{AllowScan: true, IncludeClosed: true}
 	if counter, ok := store.(beads.Counter); ok {
 		if n, err := counter.Count(ctx, query); err == nil {
-			return n
+			return n, true
 		}
 	}
 	list, err := listBeadsWithTimeout(ctx, store, query)
 	if err != nil {
-		return 0
+		return 0, false
 	}
-	return len(list)
+	return len(list), true
 }
 
 // listBeadsWithTimeout runs store.List on a goroutine and returns its result,
@@ -111,12 +119,21 @@ func renderStoreHealthBlock(w io.Writer, h *StoreHealth) {
 	fmt.Fprintln(w, "Store health:")                                       //nolint:errcheck // best-effort stdout
 	fmt.Fprintf(w, "  Path:        %s\n", h.Path)                          //nolint:errcheck // best-effort stdout
 	fmt.Fprintf(w, "  Size:        %s\n", storeHealthSIBytes(h.SizeBytes)) //nolint:errcheck // best-effort stdout
-	fmt.Fprintf(w, "  Live rows:   %d\n", h.LiveRows)                      //nolint:errcheck // best-effort stdout
-	suffix := ""
-	if h.Warning {
-		suffix = "  \u26a0 maintenance overdue"
+	if h.LiveRowsUnknown {
+		// The ratio line is deliberately omitted rather than printed as
+		// 0.0 MB/row: with no row count there is no ratio, and rendering
+		// one would restate the defect this branch exists to fix. The
+		// cause is not named because the caller does not know it \u2014 a nil
+		// store, a scan error and a timeout are all unmeasured.
+		fmt.Fprintln(w, "  Live rows:   unknown (count unavailable)") //nolint:errcheck // best-effort stdout
+	} else {
+		fmt.Fprintf(w, "  Live rows:   %d\n", h.LiveRows) //nolint:errcheck // best-effort stdout
+		suffix := ""
+		if h.Warning {
+			suffix = "  \u26a0 maintenance overdue"
+		}
+		fmt.Fprintf(w, "  Ratio:       %.1f MB/row  (threshold %.1f MB/row)%s\n", h.RatioMB, h.ThresholdMB, suffix) //nolint:errcheck // best-effort stdout
 	}
-	fmt.Fprintf(w, "  Ratio:       %.1f MB/row  (threshold %.1f MB/row)%s\n", h.RatioMB, h.ThresholdMB, suffix) //nolint:errcheck // best-effort stdout
 	if h.LastGCAt != "" {
 		fmt.Fprintf(w, "  Last GC:     %s (%s)\n", h.LastGCAt, h.LastGCStatus) //nolint:errcheck // best-effort stdout
 	}

--- a/cmd/gc/store_health_test.go
+++ b/cmd/gc/store_health_test.go
@@ -33,7 +33,7 @@ func TestStoreHealthSIBytes(t *testing.T) {
 }
 
 func TestStoreHealthFromInputsOmitsLastGCWhenZero(t *testing.T) {
-	h := storeHealthFromInputs("/c", 1_000_000, 1, time.Time{}, "")
+	h := storeHealthFromInputs("/c", 1_000_000, 1, true, time.Time{}, "")
 	if h.LastGCAt != "" {
 		t.Errorf("LastGCAt = %q, want empty", h.LastGCAt)
 	}
@@ -52,7 +52,7 @@ func TestStoreHealthFromInputsOmitsLastGCWhenZero(t *testing.T) {
 
 func TestStoreHealthFromInputsFormatsLastGCAsRFC3339(t *testing.T) {
 	ts := time.Date(2026, 4, 1, 3, 15, 30, 0, time.UTC)
-	h := storeHealthFromInputs("/c", 0, 0, ts, "success")
+	h := storeHealthFromInputs("/c", 0, 0, true, ts, "success")
 	if h.LastGCAt != "2026-04-01T03:15:30Z" {
 		t.Errorf("LastGCAt = %q, want 2026-04-01T03:15:30Z", h.LastGCAt)
 	}
@@ -70,7 +70,7 @@ func TestRenderStoreHealthBlockNil(t *testing.T) {
 }
 
 func TestRenderStoreHealthBlockWarning(t *testing.T) {
-	h := storeHealthFromInputs("/c", 11_200_000_000, 221, time.Date(2026, 4, 1, 3, 0, 0, 0, time.UTC), "success")
+	h := storeHealthFromInputs("/c", 11_200_000_000, 221, true, time.Date(2026, 4, 1, 3, 0, 0, 0, time.UTC), "success")
 	var buf bytes.Buffer
 	renderStoreHealthBlock(&buf, h)
 
@@ -92,7 +92,7 @@ func TestRenderStoreHealthBlockWarning(t *testing.T) {
 }
 
 func TestRenderStoreHealthBlockNoWarning(t *testing.T) {
-	h := storeHealthFromInputs("/c", 50_000_000, 221, time.Time{}, "")
+	h := storeHealthFromInputs("/c", 50_000_000, 221, true, time.Time{}, "")
 	var buf bytes.Buffer
 	renderStoreHealthBlock(&buf, h)
 
@@ -108,9 +108,47 @@ func TestRenderStoreHealthBlockNoWarning(t *testing.T) {
 	}
 }
 
+// The operator-facing surface of an unmeasured count must not read as a
+// healthy store. A large store with no usable row count previously rendered
+// "Live rows: 0 / Ratio: 0.0 MB/row" with no warning — byte-identical to a
+// genuinely empty, healthy city. It must now say the count is unavailable and
+// must not print a fabricated ratio.
+func TestRenderStoreHealthBlockUnmeasuredRowsSaysUnknownAndOmitsRatio(t *testing.T) {
+	h := storeHealthFromInputs("/c", 11_200_000_000, 0, false, time.Time{}, "")
+	var buf bytes.Buffer
+	renderStoreHealthBlock(&buf, h)
+
+	out := buf.String()
+	if !strings.Contains(out, "Live rows:   unknown") {
+		t.Errorf("output does not report the row count as unknown:\n%s", out)
+	}
+	if strings.Contains(out, "Ratio:") {
+		t.Errorf("output prints a ratio for an unmeasured row count:\n%s", out)
+	}
+	if strings.Contains(out, "⚠") || strings.Contains(out, "maintenance overdue") {
+		t.Errorf("output warns off an unmeasured row count:\n%s", out)
+	}
+}
+
+// An unmeasured count must still render the maintenance tail; the unknown
+// branch reports less, not a truncated block.
+func TestRenderStoreHealthBlockUnmeasuredRowsStillRendersLastGC(t *testing.T) {
+	h := storeHealthFromInputs("/c", 11_200_000_000, 0, false, time.Unix(1700000000, 0), "done")
+	var buf bytes.Buffer
+	renderStoreHealthBlock(&buf, h)
+
+	if out := buf.String(); !strings.Contains(out, "Last GC:") {
+		t.Errorf("output drops Last GC when the row count is unmeasured:\n%s", out)
+	}
+}
+
 func TestLiveRowCountNilStore(t *testing.T) {
-	if got := liveRowCount(nil); got != 0 {
-		t.Fatalf("liveRowCount(nil) = %d, want 0", got)
+	got, measured := liveRowCount(nil)
+	if got != 0 {
+		t.Fatalf("liveRowCount(nil) rows = %d, want 0", got)
+	}
+	if measured {
+		t.Fatalf("liveRowCount(nil) measured = true, want false — there is no store to count")
 	}
 }
 
@@ -121,8 +159,12 @@ func TestLiveRowCountCountsBeads(t *testing.T) {
 			t.Fatalf("Create: %v", err)
 		}
 	}
-	if got := liveRowCount(store); got != 3 {
+	got, measured := liveRowCount(store)
+	if got != 3 {
 		t.Fatalf("liveRowCount = %d, want 3", got)
+	}
+	if !measured {
+		t.Fatalf("measured = false, want true for a successful count")
 	}
 }
 
@@ -140,8 +182,12 @@ func TestLiveRowCountIncludesClosedBeads(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	if got := liveRowCount(store); got != 2 {
+	got, measured := liveRowCount(store)
+	if got != 2 {
 		t.Fatalf("liveRowCount = %d, want 2 including closed bead %s and open bead %s", got, closed.ID, open.ID)
+	}
+	if !measured {
+		t.Fatalf("measured = false, want true for a successful count")
 	}
 }
 

--- a/cmd/gc/store_health_timeout_test.go
+++ b/cmd/gc/store_health_timeout_test.go
@@ -30,7 +30,10 @@ func (f *fakeHealthStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 // `gc status`: liveRowCount ran an unbounded IncludeClosed full-history scan
 // (store.List) with no timeout, so a live city with a large closed-history
 // table hung status for ~2 minutes. When the Counter cannot answer, the scan
-// must be bounded and return 0 (best-effort) rather than stall.
+// must be bounded. rows=0 on a bound is a placeholder, not a measurement — see
+// TestLiveRowCountTimeoutIsUnmeasuredNotZero: a caller
+// that treats it as a real zero renders a timed-out count byte-identically to
+// a healthy, empty store.
 func TestLiveRowCountBoundsSlowScan(t *testing.T) {
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) }) // let the leaked List goroutine exit
@@ -45,14 +48,40 @@ func TestLiveRowCountBoundsSlowScan(t *testing.T) {
 	}
 
 	start := time.Now()
-	got := liveRowCount(store)
+	got, measured := liveRowCount(store)
 	elapsed := time.Since(start)
 
 	if got != 0 {
-		t.Fatalf("liveRowCount = %d, want 0 when the scan times out", got)
+		t.Fatalf("liveRowCount rows = %d, want 0 (placeholder) when the scan times out", got)
+	}
+	if measured {
+		t.Fatalf("liveRowCount measured = true, want false — a bounded scan that hit its deadline is not a real count")
 	}
 	if elapsed > statusStoreHealthTimeout+2*time.Second {
 		t.Fatalf("liveRowCount did not bound the scan: took %s (bound %s)", elapsed, statusStoreHealthTimeout)
+	}
+}
+
+// TestLiveRowCountTimeoutIsUnmeasuredNotZero is the falsifying test for this
+// change. Before the fix, liveRowCount had no way to signal "the count did
+// not complete" other than returning a bare 0, indistinguishable from a real
+// empty store. This asserts the fixed contract directly.
+func TestLiveRowCountTimeoutIsUnmeasuredNotZero(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	store := &fakeHealthStore{
+		countFn: func(context.Context, beads.ListQuery) (int, error) {
+			return 0, errors.New("count unsupported for this query")
+		},
+		listFn: func(beads.ListQuery) ([]beads.Bead, error) {
+			<-release
+			return nil, nil
+		},
+	}
+
+	rows, measured := liveRowCount(store)
+	if measured {
+		t.Fatalf("liveRowCount reported measured=true after a timeout; want false so a timed-out count is never mistaken for a real zero (rows=%d)", rows)
 	}
 }
 
@@ -72,7 +101,11 @@ func TestLiveRowCountUsesCounterFastPath(t *testing.T) {
 		},
 	}
 
-	if got := liveRowCount(store); got != 42 {
+	got, measured := liveRowCount(store)
+	if got != 42 {
 		t.Fatalf("liveRowCount = %d, want 42 from the Counter fast path", got)
+	}
+	if !measured {
+		t.Fatalf("measured = false, want true when the Counter answers")
 	}
 }

--- a/engdocs/contributors/dolt-maintenance.md
+++ b/engdocs/contributors/dolt-maintenance.md
@@ -122,6 +122,25 @@ Store health:
   Last GC:     2026-04-22T10:00:00Z (success)
 ```
 
+When the row count cannot be completed — there is no store, the scan
+errors, or it exceeds its 1 s bound — the block reports the count as
+unavailable instead:
+
+```text
+Store health:
+  Path:        /path/to/city/.beads/dolt
+  Size:        11.2 GB
+  Live rows:   unknown (count unavailable)
+  Last GC:     2026-04-22T10:00:00Z (success)
+```
+
+The `Ratio:` line is omitted entirely rather than printed as a
+misleading `0.0 MB/row`, and `gc status --json` sets
+`live_rows_unknown: true`. **That state means retry / investigate, not
+pass:** `live_rows`, `ratio_mb_per_row` and `warning` carry no meaning
+when the count is unknown, so a `0` row count or an absent warning there
+must never be read as a healthy store.
+
 The `⚠ maintenance overdue` suffix appears when
 `size_bytes > 1.0 MB × live_rows`. The same data is available under
 `store_health` in `gc status --json`.

--- a/internal/api/store_health.go
+++ b/internal/api/store_health.go
@@ -88,7 +88,10 @@ func (s *Server) computeStoreHealth(ctx context.Context) (*StatusStoreHealth, er
 		return nil, err
 	}
 	lastAt, lastStatus := storehealth.LastMaintenance(s.state.EventProvider())
-	h := storehealth.Compute(cityPath, size, rows, lastAt, lastStatus)
+	// countBeadStoreRows returns an error (handled above) rather than a
+	// fabricated count on every failure path, so rows here is always a
+	// real measurement.
+	h := storehealth.Compute(cityPath, size, rows, true, lastAt, lastStatus)
 	return statusStoreHealthFromDomain(h), nil
 }
 

--- a/internal/storehealth/storehealth.go
+++ b/internal/storehealth/storehealth.go
@@ -37,11 +37,18 @@ const MinWarnSizeBytes = 1_000_000_000 // 1 GB
 // Health summarizes disk and maintenance health of the Dolt bead store.
 // A pointer *Health is included in status payloads so "no data" (e.g.
 // supervisor not running) is representable as nil rather than a
-// confusing zero-valued block.
+// confusing zero-valued block. The same idiom applies one level down at
+// RowsMeasured: LiveRows alone cannot distinguish a genuinely empty
+// store from a row count that failed or timed out, so a caller that
+// fabricates LiveRows=0 on measurement failure makes an unmeasured
+// store indistinguishable from a healthy one. RowsMeasured is that
+// distinction; when false, RatioMB and Warning are never computed and
+// LiveRows carries no meaning.
 type Health struct {
 	Path         string
 	SizeBytes    int64
 	LiveRows     int
+	RowsMeasured bool
 	RatioMB      float64
 	Warning      bool
 	ThresholdMB  float64
@@ -63,16 +70,24 @@ func StorePath(cityPath string) string {
 
 // Compute builds a Health from measured inputs. Pure function — all
 // I/O is performed by the caller via WalkSize and LastMaintenance.
-func Compute(cityPath string, sizeBytes int64, retainedRows int, lastGCAt time.Time, lastGCStatus string) Health {
+//
+// rowsMeasured tells Compute whether retainedRows is a real count or a
+// caller's placeholder for "the count did not complete" (nil store,
+// scan error, timeout). Callers MUST NOT pass rowsMeasured=true with a
+// fabricated retainedRows value — doing so is exactly the defect this
+// parameter exists to prevent: a failed measurement rendering
+// byte-identically to a healthy, genuinely-empty store.
+func Compute(cityPath string, sizeBytes int64, retainedRows int, rowsMeasured bool, lastGCAt time.Time, lastGCStatus string) Health {
 	h := Health{
 		Path:         StorePath(cityPath),
 		SizeBytes:    sizeBytes,
 		LiveRows:     retainedRows,
+		RowsMeasured: rowsMeasured,
 		ThresholdMB:  DefaultThresholdMB,
 		LastGCAt:     lastGCAt,
 		LastGCStatus: lastGCStatus,
 	}
-	if retainedRows > 0 {
+	if rowsMeasured && retainedRows > 0 {
 		h.RatioMB = float64(sizeBytes) / (bytesPerMB * float64(retainedRows))
 		h.Warning = sizeBytes > MinWarnSizeBytes && sizeBytes > int64(DefaultThresholdMB*bytesPerMB)*int64(retainedRows)
 	}

--- a/internal/storehealth/storehealth_test.go
+++ b/internal/storehealth/storehealth_test.go
@@ -38,7 +38,7 @@ func TestStorePath_DoltliteMetadata(t *testing.T) {
 func TestComputeWarningHighRatio(t *testing.T) {
 	// 11.2 GB (decimal) / 221 rows = ~50.68 MB/row, warning.
 	const size = 11_200_000_000
-	h := Compute("/c", size, 221, time.Time{}, "")
+	h := Compute("/c", size, 221, true, time.Time{}, "")
 	if !h.Warning {
 		t.Fatalf("Warning = false, want true for size=%d rows=221", size)
 	}
@@ -56,7 +56,7 @@ func TestComputeWarningHighRatio(t *testing.T) {
 func TestComputeNoWarningLowRatio(t *testing.T) {
 	// 50 MB / 221 rows = ~0.23 MB/row, no warning.
 	const size = 50_000_000
-	h := Compute("/c", size, 221, time.Time{}, "")
+	h := Compute("/c", size, 221, true, time.Time{}, "")
 	if h.Warning {
 		t.Fatalf("Warning = true, want false for size=%d rows=221", size)
 	}
@@ -68,16 +68,53 @@ func TestComputeNoWarningLowRatio(t *testing.T) {
 func TestComputeZeroRetainedRowsDoesNotWarnForBookkeepingBytes(t *testing.T) {
 	// The denominator is retained rows (open and closed). A genuinely empty
 	// store can still contain bookkeeping files, which alone are not unhealthy.
-	h := Compute("/c", 1, 0, time.Time{}, "")
+	h := Compute("/c", 1, 0, true, time.Time{}, "")
 	if h.Warning {
 		t.Fatalf("Warning = true, want false for bookkeeping bytes with zero retained rows")
 	}
 }
 
 func TestComputeZeroEverything(t *testing.T) {
-	h := Compute("/c", 0, 0, time.Time{}, "")
+	h := Compute("/c", 0, 0, true, time.Time{}, "")
 	if h.Warning {
 		t.Fatalf("Warning = true, want false for all-zero inputs")
+	}
+}
+
+// TestComputeUnmeasuredRowsNeverWarns: a row count that failed or
+// timed out must never be treated as a real zero. Even with a large
+// sizeBytes that would trip the ratio warning if 0 retained rows were real,
+// rowsMeasured=false must suppress the warning entirely — there is nothing
+// to compute a ratio against.
+func TestComputeUnmeasuredRowsNeverWarns(t *testing.T) {
+	const size = 11_200_000_000 // would warn at 221 real rows (see TestComputeWarningHighRatio)
+	h := Compute("/c", size, 0, false, time.Time{}, "")
+	if h.Warning {
+		t.Fatalf("Warning = true, want false when rows are unmeasured (RowsMeasured=false)")
+	}
+	if h.RatioMB != 0 {
+		t.Fatalf("RatioMB = %v, want 0 when rows are unmeasured", h.RatioMB)
+	}
+	if h.RowsMeasured {
+		t.Fatalf("RowsMeasured = true, want false")
+	}
+}
+
+// TestComputeUnmeasuredIsDistinguishableFromRealZero pins the actual
+// deliverable: two Health values with identical LiveRows=0 but different
+// RowsMeasured must be distinguishable by callers, so a failed measurement
+// can never render byte-identically to a genuinely empty, healthy store.
+func TestComputeUnmeasuredIsDistinguishableFromRealZero(t *testing.T) {
+	measured := Compute("/c", 1, 0, true, time.Time{}, "")
+	unmeasured := Compute("/c", 1, 0, false, time.Time{}, "")
+	if measured.RowsMeasured == unmeasured.RowsMeasured {
+		t.Fatalf("RowsMeasured did not distinguish a real zero-row count from an unmeasured one")
+	}
+	if !measured.RowsMeasured {
+		t.Fatalf("measured.RowsMeasured = false, want true")
+	}
+	if unmeasured.RowsMeasured {
+		t.Fatalf("unmeasured.RowsMeasured = true, want false")
 	}
 }
 
@@ -88,11 +125,11 @@ func TestComputeBoundary(t *testing.T) {
 	// MinWarnSizeBytes, so this exercises the ratio boundary alone,
 	// not the absolute-size floor (see TestComputeSmallStoreFloor).
 	const rows = 2000
-	h := Compute("/c", int64(DefaultThresholdMB*bytesPerMB)*int64(rows), rows, time.Time{}, "")
+	h := Compute("/c", int64(DefaultThresholdMB*bytesPerMB)*int64(rows), rows, true, time.Time{}, "")
 	if h.Warning {
 		t.Fatalf("Warning = true at exact threshold, want false")
 	}
-	h = Compute("/c", int64(DefaultThresholdMB*bytesPerMB)*int64(rows)+1, rows, time.Time{}, "")
+	h = Compute("/c", int64(DefaultThresholdMB*bytesPerMB)*int64(rows)+1, rows, true, time.Time{}, "")
 	if !h.Warning {
 		t.Fatalf("Warning = false one byte over threshold, want true")
 	}
@@ -109,7 +146,7 @@ func TestComputeBoundary(t *testing.T) {
 // the total size is still well under the absolute floor.
 func TestComputeSmallStoreFloorSuppressesFalsePositive(t *testing.T) {
 	const size = 343_000_000
-	h := Compute("/c", size, 7, time.Time{}, "")
+	h := Compute("/c", size, 7, true, time.Time{}, "")
 	if h.Warning {
 		t.Fatalf("Warning = true, want false (343MB/7 rows is below the absolute floor despite a high ratio)")
 	}
@@ -125,7 +162,7 @@ func TestComputeSmallStoreFloorSuppressesFalsePositive(t *testing.T) {
 // are exceeded.
 func TestComputeLargeStoreStillWarnsAboveFloor(t *testing.T) {
 	const size = 11_200_000_000
-	h := Compute("/c", size, 221, time.Time{}, "")
+	h := Compute("/c", size, 221, true, time.Time{}, "")
 	if !h.Warning {
 		t.Fatalf("Warning = false, want true (11.2GB/221 rows is well above both the ratio threshold and the absolute floor)")
 	}
@@ -133,7 +170,7 @@ func TestComputeLargeStoreStillWarnsAboveFloor(t *testing.T) {
 
 func TestComputeCarriesLastGC(t *testing.T) {
 	ts := time.Date(2026, 4, 1, 3, 0, 0, 0, time.UTC)
-	h := Compute("/c", 1, 1, ts, "success")
+	h := Compute("/c", 1, 1, true, ts, "success")
 	if !h.LastGCAt.Equal(ts) {
 		t.Fatalf("LastGCAt = %v, want %v", h.LastGCAt, ts)
 	}


### PR DESCRIPTION
## Summary

- `storehealth.Health` / `Compute` gain a `RowsMeasured` signal, so "the count did not complete" is representable distinctly from "the count completed and found zero rows"
- `cmd/gc`'s `liveRowCount` stops fabricating a `0` on a nil store, a scan error, or a timeout — it now returns `(rows int, measured bool)`
- `gc status` reports `Live rows: unknown (count unavailable)` and omits the ratio line entirely when unmeasured; the CLI JSON gains an additive `live_rows_unknown` field

## The defect

`liveRowCount` returned a bare `0` on three distinct failure modes (nil store, scan error, `statusStoreHealthTimeout` — 1s over a closed-inclusive full-history scan). `Compute` evaluated `RatioMB`/`Warning` only inside `if retainedRows > 0`, with no way to tell a real zero from a failed measurement. A timed-out count rendered byte-identically to a healthy, empty store, so a store can grow without bound and stay green forever whenever the count cannot finish in time.

Full write-up, including the demonstration on unmodified `main`, in #4743.

`#4464` made the happy-path count fast; `#4307` fixed the **API** half of this class (`countBeadStoreRows` errors instead of fabricating). Neither touched `cmd/gc/store_health.go` — the current doc comment on `statusStoreHealthTimeout` says as much. This is the CLI-side completion of #4307.

Deliberately **not** a timeout-widening fix: a bigger bound moves the cliff, it doesn't remove the ambiguity.

## The fix

- `Health` gains `RowsMeasured bool`; `Compute` gains a `rowsMeasured bool` parameter and computes `RatioMB`/`Warning` only when `rowsMeasured && retainedRows > 0`. This mirrors the existing `*Health` pointer idiom, where nil means "no data" specifically so it cannot be misread as a zero-valued block.
- `liveRowCount` returns `(rows int, measured bool)`; every failure path returns `(0, false)`.
- `storeHealthFromInputs` / `collectStoreHealth` thread `rowsMeasured` through and surface it as `StoreHealth.LiveRowsUnknown` (`json:"live_rows_unknown,omitempty"`).
- `renderStoreHealthBlock` prints `Live rows: unknown (count unavailable)` and omits the ratio line rather than a misleading `0.0 MB/row`. The cause is **not** named in the message because the caller does not know it — a nil store, a scan error and a timeout are all simply unmeasured, and asserting "timed out" would repeat the same mistake this PR fixes at a smaller scale.
- `internal/api`'s `Compute` call site passes `rowsMeasured=true` explicitly, with a comment recording why it is always true there.

## What each state now means

- **Measured + `Warning=false`** — the store was counted; the ratio is at or below threshold (or suppressed by the absolute floor). Safe to treat as healthy.
- **Measured + `Warning=true`** — the store was counted; the ratio exceeds both the floor and the threshold. Maintenance is actionable now.
- **Unmeasured** (`RowsMeasured=false` / `live_rows_unknown=true`) — **nothing** may be concluded about store health. `LiveRows`, `RatioMB` and `Warning` are not meaningful. A caller alarming off `StoreHealth` must treat this as "retry / investigate", never as "pass". `RowsMeasured=false` with `Warning=true` is impossible by construction.

## Test evidence

**Behavioural RED on unmodified `af42a94245a547a0c47ec26054afa5fd1347b567`**, using the pre-change signature so it demonstrates the bug rather than the signature change:

```
DEFECT CONFIRMED on stock main: an 11.2 GB store with an UNMEASURED row count
yields Warning=false, RatioMB=0.0 — identical to a genuinely empty healthy
store. The ratio check can never fire.
--- FAIL: TestStockMain_UnmeasuredLargeStoreIsIndistinguishableFromHealthyEmpty
```

The shipped tests also fail to compile against stock `main`, since the capability they assert does not exist there.

**GREEN** with the fix: `./internal/storehealth/...` and `./internal/api/` fully pass; `./cmd/gc/ -run 'StoreHealth|LiveRowCount'` passes 20/20, including five new tests:

- `TestComputeUnmeasuredRowsNeverWarns`
- `TestComputeUnmeasuredIsDistinguishableFromRealZero`
- `TestLiveRowCountTimeoutIsUnmeasuredNotZero`
- `TestRenderStoreHealthBlockUnmeasuredRowsSaysUnknownAndOmitsRatio`
- `TestRenderStoreHealthBlockUnmeasuredRowsStillRendersLastGC`

`go build ./...`, `go vet` and `gofmt` clean.

The full `./cmd/gc/...` package was also run: 45 failures, all pre-existing on this base and unrelated — every one is the macOS `TMPDIR` artifact where `t.TempDir()`/`os.Getwd()` resolve `/var/folders/...` through its `/private/var/folders/...` symlink (rig-root, worktree-reap and quarantine assertions comparing the two literally). None is in the store-health surface. Verified against stock `main` on the same machine, not assumed.

## Blast radius

`storehealth.Compute` has exactly two callers in the whole tree (grep-confirmed), both updated: `cmd/gc/store_health.go` and `internal/api/store_health.go`.

Pinned unchanged: warn-path ratio semantics (`DefaultThresholdMB = 1.0`, `MinWarnSizeBytes = 1_000_000_000`, `bytesPerMB = 1_000_000` SI — cited from source, not restated), with `TestComputeWarningHighRatio` and `TestRenderStoreHealthBlockWarning` still passing verbatim. API error propagation is untouched, exactly as #4307 left it.

`internal/storehealth.Health` is an internal Go struct with no JSON tags and is never itself serialized. The API wire type `StatusStoreHealth` is unchanged, so `/v0/status` and every consumer of it — including the generated dashboard client and zod types — are unaffected and no codegen is needed. Only the CLI-local `cmd/gc.StoreHealth` (`gc status --json`) gains one additive `omitempty` field, false in the common case.

Fixes #4743