### PR TITLE
fix(dolt): deduplicate unchanged quarantine alert mail

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1316,11 +1316,12 @@ write_compact_marker() {
   fi
   if [ "$dir" = "$quarantine_dir" ]; then
     send_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at" || true
+    record_quarantine_notify_state "$db" "$reason" 1
   fi
   return 0
 }
 
-send_compact_quarantine_alert() {
+emit_compact_quarantine_event() {
   _ca_db="$1"
   _ca_type="$2"
   _ca_path="$3"
@@ -1328,7 +1329,111 @@ send_compact_quarantine_alert() {
   _ca_created_at="${5:-<unknown>}"
   _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
   gc event emit dolt.compact.quarantine --actor controller --message "$_ca_msg" || true
+}
+
+mail_compact_quarantine_alert() {
+  _ca_db="$1"
+  _ca_type="$2"
+  _ca_path="$3"
+  _ca_reason="$4"
+  _ca_created_at="${5:-<unknown>}"
+  _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
   gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg" || true
+}
+
+send_compact_quarantine_alert() {
+  emit_compact_quarantine_event "$@"
+  mail_compact_quarantine_alert "$@"
+}
+
+# quarantine_should_notify DB REASON
+#   Fail-open dedup check: EMIT (return 0) unless the quarantine marker's
+#   last_notified_reason already matches REASON, meaning a mail already went
+#   out for this exact quarantine state. A missing marker, missing field, or
+#   unreadable marker always emits — this must never wrongly suppress a real
+#   alert. Mirrors the notify-once-per-distinct-state marker shape in
+#   gc-management's packs/maintainer-pr-review/scripts/hold-notice-lib.sh.
+quarantine_should_notify() {
+  db="$1"
+  reason="$2"
+  _qn_marker=$(compact_marker_path "$quarantine_dir" "$db")
+  [ -f "$_qn_marker" ] && [ -r "$_qn_marker" ] || return 0
+  _qn_prev_reason=$(compact_marker_value "$quarantine_dir" "$db" last_notified_reason || true)
+  [ -n "$_qn_prev_reason" ] || return 0
+  [ "$_qn_prev_reason" = "$reason" ] && return 1
+  return 0
+}
+
+# record_quarantine_notify_state DB REASON EMITTED
+#   Patches only the notify-bookkeeping fields (seen_count, notify_count,
+#   last_notified_ts, last_notified_reason) onto DB's existing quarantine
+#   marker, preserving every other field byte-for-byte. EMITTED=1 bumps
+#   notify_count and stamps last_notified_ts/last_notified_reason; EMITTED=0
+#   only bumps seen_count. A missing marker or write failure is a silent
+#   no-op — bookkeeping must never block or fail compaction.
+record_quarantine_notify_state() {
+  db="$1"
+  reason="$2"
+  _qn_emitted="$3"
+
+  _qn_marker=$(compact_marker_path "$quarantine_dir" "$db")
+  [ -f "$_qn_marker" ] || return 0
+
+  _qn_seen_count=$(compact_marker_value "$quarantine_dir" "$db" seen_count || true)
+  case "$_qn_seen_count" in ''|*[!0-9]*) _qn_seen_count=0 ;; esac
+  _qn_seen_count=$((_qn_seen_count + 1))
+
+  _qn_notify_count=$(compact_marker_value "$quarantine_dir" "$db" notify_count || true)
+  case "$_qn_notify_count" in ''|*[!0-9]*) _qn_notify_count=0 ;; esac
+  _qn_last_ts=$(compact_marker_value "$quarantine_dir" "$db" last_notified_ts || true)
+  _qn_last_reason=$(compact_marker_value "$quarantine_dir" "$db" last_notified_reason || true)
+  if [ "$_qn_emitted" = "1" ]; then
+    _qn_notify_count=$((_qn_notify_count + 1))
+    _qn_last_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    _qn_last_reason="$reason"
+  fi
+
+  _qn_old_umask=$(umask)
+  umask 077
+  _qn_tmp=$(mktemp "$quarantine_dir/$db.tmp.XXXXXX") || {
+    umask "$_qn_old_umask"
+    return 0
+  }
+  umask "$_qn_old_umask"
+  if ! {
+    awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason)=/' "$_qn_marker"
+    printf 'seen_count=%s\n' "$_qn_seen_count"
+    printf 'notify_count=%s\n' "$_qn_notify_count"
+    printf 'last_notified_ts=%s\n' "$_qn_last_ts"
+    printf 'last_notified_reason=%s\n' "$_qn_last_reason"
+  } > "$_qn_tmp" 2>/dev/null; then
+    rm -f "$_qn_tmp"
+    return 0
+  fi
+  mv -f "$_qn_tmp" "$_qn_marker" || rm -f "$_qn_tmp"
+  return 0
+}
+
+# report_existing_quarantine DB
+#   Diagnostic + alert path for a compact/bare-gc invocation that hit an
+#   already-quarantined database. The event still fires every cycle; the
+#   mail is gated by quarantine_should_notify so a stable quarantine reason
+#   pages once instead of on every subsequent run.
+report_existing_quarantine() {
+  db="$1"
+  quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
+  quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
+  quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
+  print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
+
+  emit_compact_quarantine_event "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"
+
+  quarantine_alert_emitted=0
+  if quarantine_should_notify "$db" "${quarantine_reason:-<unknown>}"; then
+    mail_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"
+    quarantine_alert_emitted=1
+  fi
+  record_quarantine_notify_state "$db" "${quarantine_reason:-<unknown>}" "$quarantine_alert_emitted"
 }
 
 ensure_compact_marker_writable() {
@@ -1881,11 +1986,7 @@ flatten_database() {
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
-    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
-    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
-    send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
+    report_existing_quarantine "$db"
     return 1
   fi
 
@@ -2590,11 +2691,7 @@ bare_gc_database() {
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
-    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
-    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
-    send_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" || true
+    report_existing_quarantine "$db"
     return 1
   fi
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -3330,6 +3330,39 @@ func TestCompactScriptQuarantineBlocksSecondCycleAfterRowCountDecrease(t *testin
 	}
 }
 
+func TestCompactScriptExistingQuarantineMarkerAlertsOnceAcrossRepeatedCycles(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("second compact succeeded despite quarantine:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "integrity quarantine marker exists") {
+		t.Fatalf("second compact missing quarantine explanation:\n%s", secondOut)
+	}
+	thirdOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("third compact succeeded despite quarantine:\n%s", thirdOut)
+	}
+
+	// Two consecutive compact runs over an unchanged quarantine condition
+	// must send exactly one operator mail — a stable, correct quarantine
+	// should not page forever. The event stays unconditional (one per
+	// cycle) so downstream automation can still observe every check.
+	log := readCompactGCLog(t, fixture)
+	mailLines := compactGCLogLinesWithPrefix(log, "gc mail send ")
+	if len(mailLines) != 1 {
+		t.Fatalf("three compact runs over an unchanged quarantine condition should send exactly one operator mail, got %d\nlog:\n%s", len(mailLines), log)
+	}
+	eventLines := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")
+	if len(eventLines) != 3 {
+		t.Fatalf("each compact cycle should still emit a dolt.compact.quarantine event even when the mail is suppressed, got %d\nlog:\n%s", len(eventLines), log)
+	}
+}
+
 func TestCompactScriptFreshQuarantineMarkerAlertsDefaultMayor(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")

--- a/release-gates/ga-zm49qq-dolt-compact-quarantine-alert-dedup-gate.md
+++ b/release-gates/ga-zm49qq-dolt-compact-quarantine-alert-dedup-gate.md
@@ -1,0 +1,56 @@
+# Release Gate: Dolt compact quarantine alert deduplication
+
+Date: 2026-07-28  
+Deployer: `gascity/deployer`  
+Deploy bead: `ga-zm49qq`  
+Reviewed commit: `6108f7b6a8b045c8ea970f408d5f034c968cdd31`  
+Base checked: `origin/main` at `311effd094d3a5085c364d4cab017f65442d43b8`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This evaluation
+uses the deployer release criteria and the repository's canonical
+`TESTING.md` policy.
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-dfuwzf` is closed with `REVIEW VERDICT: PASS` for the exact reviewed commit. |
+| 2 | Acceptance criteria met | PASS | Existing quarantine markers now emit their event every cycle but mail only when their state has not already been notified. Notify bookkeeping is atomically updated in the marker, and failures remain fail-open toward notifying. The new three-cycle regression test observes exactly one mail and three quarantine events. |
+| 3 | Tests pass | PASS | `go test -count=1 ./examples/bd/dolt/...`, `go build ./...`, `go vet ./...`, and `make test-fast-parallel` all passed. The sharded fast run completed 9/9 jobs successfully. `gofmt` is clean. Shellcheck reports the same five warning codes at the reviewed commit and merge-base, so this change adds zero warnings. |
+| 4 | No high-severity review findings open | PASS | The review records no blockers and no HIGH or CRITICAL findings. Its sole observation is explicitly non-blocking defense-in-depth. |
+| 5 | Final branch is clean | PASS | `git status --porcelain` was empty on `deploy/ga-zm49qq-gate` before this checklist was written. This checklist is the deployer's only additional change and will be committed separately. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main HEAD` succeeded against current main, producing tree `5b2a8c9fcd9c591c9132391ff7e77c78b39fd66b`. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The reviewed commit changes only the Dolt compact quarantine alert path and its direct execution-script regression test. |
+
+## Acceptance Evidence
+
+- A fresh quarantine still emits its event and mail immediately.
+- Repeated compact cycles over an unchanged quarantine emit an event every
+  time but send one operator mail total.
+- Existing and old-format markers fail open: missing or unreadable notification
+  bookkeeping cannot suppress a real alert.
+- `record_quarantine_notify_state` updates only `seen_count`, `notify_count`,
+  `last_notified_ts`, and `last_notified_reason` through the existing
+  restrictive-umask and atomic-rename pattern.
+- The reviewed range contains one commit and changes exactly:
+  `examples/bd/dolt/commands/compact/run.sh` and
+  `examples/bd/dolt/dog_exec_scripts_test.go`.
+
+## Commands Run
+
+```text
+git fetch origin main
+git merge-tree --write-tree origin/main HEAD
+git diff --check <merge-base>..HEAD
+gofmt -l examples/bd/dolt/dog_exec_scripts_test.go
+shellcheck -f json examples/bd/dolt/commands/compact/run.sh
+git show <merge-base>:examples/bd/dolt/commands/compact/run.sh | shellcheck -s sh -f json -
+go test -count=1 ./examples/bd/dolt/...
+go build ./...
+go vet ./...
+make test-fast-parallel
+```
+
+## Decision
+
+PASS. The isolated deploy branch is ready for merge-authority review.


### PR DESCRIPTION
## What this changes

Dolt compact quarantine handling now sends operator mail once for an unchanged quarantine state instead of paging on every compact cycle. The `dolt.compact.quarantine` event remains emitted every cycle so downstream automation retains full visibility.

Quarantine markers record observation and notification counts plus the last notification time and reason. Missing or unreadable bookkeeping fails open toward sending an alert.

## Review notes

- This changes only the example Dolt compact script and its execution-script tests.
- Fresh quarantines still mail immediately.
- Existing old-format markers notify once and are upgraded by the atomic marker rewrite.
- Event emission is deliberately not deduplicated.

## Test plan

- [x] `go test -count=1 ./examples/bd/dolt/...`
- [x] `go build ./...` and `go vet ./...`
- [x] `make test-fast-parallel` — all 9 shards pass
- [x] Release gate: [`release-gates/ga-zm49qq-dolt-compact-quarantine-alert-dedup-gate.md`](release-gates/ga-zm49qq-dolt-compact-quarantine-alert-dedup-gate.md)
