### PR TITLE
fix(gc): wake cold named on-demand pools on routed demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -516,7 +516,31 @@ func buildDesiredStateWithSessionBeads(
 			}
 			if store != nil && isCold && !storeScopedControlDispatcher {
 				for _, source := range activeStores {
-					defaultNamedScaleTargets = append(defaultNamedScaleTargets, defaultScaleCheckTarget{template: template, store: source.store, storeKey: source.ref})
+					target := defaultScaleCheckTarget{template: template, store: source.store, storeKey: source.ref}
+					// Mirror the generic-pool cold-wake probe below (vp-s37 /
+					// #3078): a custom scale_check that is cold and asleep
+					// cannot see routed demand, so probe every active store
+					// and feed defaultScaleTargets too, not just
+					// defaultNamedScaleTargets (which only preserves
+					// partial-query retention for defaultNamedSessionDemand
+					// and never itself produces demand — see its doc
+					// comment). Gate on mode != "always": an always-on named
+					// session is already unconditionally desired by the
+					// named pass, so adding pool demand for the same
+					// template would spawn a redundant {name}-N phantom
+					// alongside it, mirroring the identical guard on the
+					// !hasCustomScaleCheck branch above.
+					if namedSessionMode != "always" {
+						defaultScaleTargets = append(defaultScaleTargets, target)
+					}
+					defaultNamedScaleTargets = append(defaultNamedScaleTargets, target)
+				}
+				if namedSessionMode != "always" {
+					// Clamp to 1 in the merge below (coldWakeTemplates), same
+					// as the generic-pool branch: this probe only wakes the
+					// pool from zero and must never override the custom
+					// check's own authoritative warm count.
+					coldWakeTemplates[template] = true
 				}
 			}
 			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -7430,6 +7430,63 @@ func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckZeroDoesNotMaterialize
 	}
 }
 
+func TestBuildDesiredState_OnDemandNamedSession_ColdCustomScaleCheckWakesOnRoutedDemand(t *testing.T) {
+	// FR-S0.1 cold-wake bootstrap (ga-d5au8t): a named-session-backing pool
+	// with a custom scale_check that is cold (zero running sessions, min=0)
+	// must still wake from generic gc.routed_to demand it cannot see while
+	// asleep, exactly like the already-correct generic (non-named) cold
+	// custom-scale_check pool branch (build_desired_state.go:588-593). Before
+	// the fix, the cold-wake probe targets for this named+custom-scale_check
+	// +cold combination were appended only to
+	// defaultNamedScaleTargets, which feeds defaultNamedSessionDemand -- a
+	// function that by design never populates real demand from routed_to
+	// (named sessions wake only via direct Assignee=<identity> matches). So
+	// the routed bead below was stranded forever: scale_check reports 0, and
+	// nothing else ever woke the pool to re-evaluate it.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title: "queued dog job",
+		Metadata: map[string]string{
+			"gc.routed_to": "dog",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 0",
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if dsResult.ScaleCheckCounts["dog"] != 1 {
+		t.Fatalf("ScaleCheckCounts[dog] = %d, want 1 (cold-wake probe should surface routed demand the custom scale_check can't see while asleep)", dsResult.ScaleCheckCounts["dog"])
+	}
+	dogCount := 0
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			dogCount++
+			if tp.ConfiguredNamedIdentity != "" {
+				t.Fatalf("cold-wake probe materialized configured named identity: %+v", tp)
+			}
+		}
+	}
+	if dogCount != 1 {
+		t.Fatalf("dog ephemeral desired count = %d, want 1 (cold-wake probe should spawn exactly one ephemeral session, clamped, not zero and not name-N phantoms)", dogCount)
+	}
+}
+
 func TestBuildDesiredState_OnDemandNamedSession_NoExplicitScaleCheckUsesWorkQuery(t *testing.T) {
 	// work_query is session-local introspection in Phase 1 and must not drive
 	// controller-side named materialization.

--- a/release-gates/ga-huwqp6-named-on-demand-cold-custom-scale-check-wake-gate.md
+++ b/release-gates/ga-huwqp6-named-on-demand-cold-custom-scale-check-wake-gate.md
@@ -1,0 +1,38 @@
+# Release Gate: Named on-demand cold custom-scale-check wake
+
+- Deploy bead: `ga-huwqp6`
+- Source review: `ga-k3jb5n.1.1`
+- Reviewed commit: `b14fc3390fdea034dcd5e4fa6638fde9bb4e8afe`
+- Candidate base: `af42a94245a547a0c47ec26054afa5fd1347b567`
+- Main evaluated: `origin/main@a72480ec884e5f6369f23b84cb18786affa49df5`
+- Deploy branch: `deploy/ga-huwqp6-gate`
+- Evaluated: `2026-07-28T04:46:33Z`
+- Overall verdict: **PASS**
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository at the evaluated
+commit, so this checklist applies the deployer role's release-gate criteria.
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | **PASS** | Checked first after fetching `origin/main`. `git merge-tree --write-tree origin/main b14fc3390fdea034dcd5e4fa6638fde9bb4e8afe` exited 0 and produced tree `47cf1c92546e38bd376d179996de5c4fd014fd43`. No self-rebase or source-branch mutation was needed. |
+| 1 | Review PASS present | **PASS** | Review bead `ga-k3jb5n.1.1` is closed with `REVIEW VERDICT: PASS` and `FINAL VERDICT: PASS` for exact commit `b14fc3390fdea034dcd5e4fa6638fde9bb4e8afe`. |
+| 2 | Acceptance criteria met | **PASS** | The cold-wake probe for an `on_demand` named-session-backing pool with a custom `scale_check` now feeds `defaultScaleTargets` and records the template in `coldWakeTemplates`, allowing generic `gc.routed_to` demand to reach the existing named-session wake signal. The new regression test proves the routed-demand count and guards against phantom named-identity materialization. The `namedSessionMode == "always"` suppression boundary remains green. The retired deploy's unrelated parent `7eb9f2d7e3d07b2ec7ab175b6897531c3b56c6c5` is absent from the reviewed commit's ancestry. |
+| 3 | Tests pass | **PASS** | First-attempt checks on the exact reviewed SHA passed: `gofmt -l` on both changed files was empty; the focused regression plus two `always`-mode boundary tests passed; `go build ./...` passed; `go vet ./...` passed; and `make test-fast-parallel` passed all nine jobs (`fsys-darwin-compile`, `push-gate-lock-selftest`, `unit-core`, and all six `unit-cmd-gc` shards). |
+| 4 | No high-severity review findings open | **PASS** | The exact-SHA review reports no security findings, no coverage gaps, and no blockers. Unresolved HIGH/CRITICAL findings: 0. |
+| 5 | Final branch is clean | **PASS** | Before adding this checklist, detached `b14fc3390` had an empty `git status --porcelain=v1`; `git diff --check` against its merge base passed. The configured hook path is `.githooks`; this checklist is the only deployer-authored release commit. |
+| 7 | Single feature theme | **PASS** | The reviewed commit is one commit touching two files in one subsystem: `cmd/gc/build_desired_state.go` and its unit test (+82/-1). It fixes only cold routed-demand visibility for named on-demand pools with a custom `scale_check`. |
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main b14fc3390fdea034dcd5e4fa6638fde9bb4e8afe
+git merge-base origin/main b14fc3390fdea034dcd5e4fa6638fde9bb4e8afe
+git merge-base --is-ancestor 7eb9f2d7e3d07b2ec7ab175b6897531c3b56c6c5 b14fc3390fdea034dcd5e4fa6638fde9bb4e8afe
+git diff --check af42a94245a547a0c47ec26054afa5fd1347b567..b14fc3390fdea034dcd5e4fa6638fde9bb4e8afe
+gofmt -l cmd/gc/build_desired_state.go cmd/gc/build_desired_state_test.go
+go test ./cmd/gc/... -run 'TestBuildDesiredState_OnDemandNamedSession_ColdCustomScaleCheckWakesOnRoutedDemand|TestBuildDesiredState_IncludesImportedAlwaysNamedSessions|TestBuildDesiredState_AlwaysNamedSession_MaterializesWithoutWorkBeads' -count=1 -v
+go build ./...
+go vet ./...
+make test-fast-parallel
+```


### PR DESCRIPTION
## What this changes

A cold `on_demand` named-session-backing pool with a custom `scale_check` now wakes when generic routed work arrives. Previously, this combination only probed named-session demand while cold, so the custom scale path could report no work and leave the pool asleep even though a bead was routed to it.

The fix reuses the existing generic cold-wake target and clamping path. It preserves `always`-mode behavior and does not materialize a phantom named identity during the probe.

## Review notes

- The production change is confined to the cold custom-`scale_check` branch in `cmd/gc/build_desired_state.go`.
- There are no config-shape, default-value, endpoint, or migration changes.
- The regression test covers both routed-demand visibility and the no-phantom-identity boundary.

## Test plan

- [x] Focused cold-wake regression and `always`-mode boundary tests
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test-fast-parallel` — all nine jobs passed
- [x] Release gate: [`release-gates/ga-huwqp6-named-on-demand-cold-custom-scale-check-wake-gate.md`](release-gates/ga-huwqp6-named-on-demand-cold-custom-scale-check-wake-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3872 — covers one narrow configuration of the scale-from-zero demand blindness described in that issue (incident 5 of five): a cold on_demand named-session-backing pool with a custom scale_check now feeds the generic cold-wake probe so gc.routed_to demand can reach it; it does not touch the other four incidents (adoption alias stamping, serve-loop store pinning, drift-relaunch priming loss, ghost session beads), and pools with no custom scale_check are outside this change

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->