### PR TITLE
fix(session): reset-pending awake arm must respect Drained (Fixes #4751)

### DIFF
--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -216,6 +216,91 @@ func TestBuildAwakeInputFromReconcilerCarriesResetPendingMetadata(t *testing.T) 
 	}
 }
 
+func TestBuildAwakeInputFromReconcilerCarriesDrainedResetPendingCombination(t *testing.T) {
+	now := time.Now().UTC()
+	metadata := func(withMarker bool) map[string]string {
+		m := map[string]string{
+			"state":                      "drained",
+			"session_name":               "s-drained-reset",
+			"template":                   "build-agent",
+			"continuation_reset_pending": "true",
+		}
+		if withMarker {
+			m[session.ResetCommittedAtKey] = now.Format(time.RFC3339)
+		}
+		return m
+	}
+
+	// A stalled reset (marker committed, start never happened) followed by a
+	// drain-ack leaves drained + pending + marker. The bridge must surface
+	// that combination, or the Drained guard on the reset-pending awake arm
+	// can never observe the state it exists for.
+	input := buildAwakeInputFromReconciler(
+		&config.City{},
+		"", // cityPath: empty exercises zero suspension state
+		[]session.Info{sessiontest.SeedBead(t, beads.Bead{
+			ID:       "mc-session-1",
+			Status:   "open",
+			Type:     "session",
+			Metadata: metadata(true),
+		})},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		now,
+	)
+	if len(input.SessionBeads) != 1 {
+		t.Fatalf("SessionBeads length = %d, want 1", len(input.SessionBeads))
+	}
+	got := input.SessionBeads[0]
+	if !got.Drained {
+		t.Fatalf("Drained = false, want true")
+	}
+	if !got.ContinuationResetPending {
+		t.Fatalf("ContinuationResetPending = false, want true")
+	}
+
+	// A drain-ack alone stamps continuation_reset_pending without
+	// reset_committed_at; the bridge deliberately does not surface that
+	// shape as reset-pending.
+	input = buildAwakeInputFromReconciler(
+		&config.City{},
+		"", // cityPath: empty exercises zero suspension state
+		[]session.Info{sessiontest.SeedBead(t, beads.Bead{
+			ID:       "mc-session-2",
+			Status:   "open",
+			Type:     "session",
+			Metadata: metadata(false),
+		})},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		now,
+	)
+	if len(input.SessionBeads) != 1 {
+		t.Fatalf("SessionBeads length = %d, want 1", len(input.SessionBeads))
+	}
+	got = input.SessionBeads[0]
+	if !got.Drained {
+		t.Fatalf("Drained = false, want true")
+	}
+	if got.ContinuationResetPending {
+		t.Fatalf("ContinuationResetPending = true for drain-ack-only metadata, want false")
+	}
+}
+
 func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T) {
 	now := time.Now().UTC()
 	sp := runtime.NewFake()

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -368,8 +368,19 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 	}
 
+	// continuation_reset_pending means "the next wake must start a fresh
+	// conversation" — it is not itself a reason to wake a Drained session.
+	// AcknowledgeDrainPatch(freshWake=true) stamps state=drained +
+	// continuation_reset_pending=true together when a wake_mode=fresh session
+	// drain-acks (e.g. it only has blocked assigned work). Without this guard
+	// that pending flag alone re-desires the session every tick, undoing the
+	// drain-ack and driving a perpetual wake/drain oscillation (each cycle a
+	// full fresh model boot). Mirrors the Drained guard on the pin arm below.
+	// A legitimate reset-pending session is asleep-but-not-drained (restart
+	// request, config-drift reset) or already carries pending-create/
+	// explicit-wake — both remain unaffected by this guard.
 	for _, bead := range input.SessionBeads {
-		if !bead.ContinuationResetPending || bead.RestartRequested || bead.WaitHold {
+		if !bead.ContinuationResetPending || bead.RestartRequested || bead.WaitHold || bead.Drained {
 			continue
 		}
 		switch desired[bead.SessionName] {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -921,6 +921,31 @@ func TestDrained_PinnedStaysAsleepUntilUndrained(t *testing.T) {
 	assertAsleep(t, result, "polecat-mc-1")
 }
 
+// TestDrained_ResetPendingStaysAsleep reproduces the wake/drain oscillation
+// (production P1): a wake_mode=fresh session that drain-acks while it only
+// has blocked assigned work gets state=drained + continuation_reset_pending=
+// true from AcknowledgeDrainPatch (internal/session/lifecycle_transition.go).
+// continuation_reset_pending alone must NOT re-desire a drained session — that
+// reopens it every reconcile tick (~30-60s), forever, each cycle paying for a
+// full fresh model boot. The pin arm already guards Drained; the reset-pending
+// arm did not. An assigned-but-blocked (open, not Ready) work bead is included
+// to prove the assigned-work path isn't what's keeping this asleep — it is
+// legitimately blocked, matching the production precondition.
+func TestDrained_ResetPendingStaysAsleep(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat",
+				State: "drained", Drained: true, ContinuationResetPending: true,
+			},
+		},
+		WorkBeads: []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-1", Status: "open", Ready: false}},
+		Now:       now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
 // ---------------------------------------------------------------------------
 // Hold
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4751

## Finding fixed

`ComputeAwakeSet`'s `continuation_reset_pending` arm had no `Drained` guard,
unlike the pin arm a few lines below it. A `wake_mode=fresh` session that
drain-acks while it holds only blocked assigned work gets `state=drained` and
`continuation_reset_pending=true` together from `AcknowledgeDrainPatch` — and
the pending flag alone re-desired the drained session on the very next
reconcile tick, undoing the drain-ack. The session boots fresh, its hook
serves nothing, it drain-acks, and the cycle repeats at the reconciler's tick
interval without self-terminating.

Observed in production: an always-awake named session cycled roughly 60 times
in one night at a ~30-60s period, each cycle paying for a full fresh model
boot.

## Change

One line of behavior plus its test: add `|| bead.Drained` to the reset-pending
arm's skip condition, mirroring the pin arm's existing `pinBlockedByState`
exclusion. This NARROWS what wakes a session; nothing widens.

`continuation_reset_pending` means "the next wake must start a fresh
conversation", not "wake this session now". A drained session stays reachable
through every normal drain-clearing path — attach, pending interaction,
explicit wake, pending-create, or genuine assigned work — and honors the
pending reset when it wakes through one of those.

Legitimate reset-pending flows are unaffected: `RestartRequestPatch` and
`ContinuationResetWakePatch` target asleep-but-not-drained sessions, and
`ConfigDriftResetPatch`'s StartPending/Creating case is already caught first
by the pending-create desired-set pass, so this guard never has to
distinguish them.

## Tests

- `TestDrained_ResetPendingStaysAsleep` (new): drained + `ContinuationResetPending=true`
  + an assigned-but-blocked (open, `Ready=false`) work bead must stay asleep.
  RED on unmodified main at `a72480ec884e5f6369f23b84cb18786affa49df5`:

  ```
  compute_awake_set_test.go:946: session "polecat-mc-1" should be asleep but is awake (reason: reset-pending)
  --- FAIL: TestDrained_ResetPendingStaysAsleep (0.00s)
  ```

  GREEN with the change.
- `TestNamedOnDemand_ResetPendingWakesWithoutDemand` (pre-existing, unmodified)
  passes both before and after — it is the anti-inversion control: a
  NOT-drained session with reset-pending is still re-desired, so a fix that
  merely suppressed the arm would fail it.
- `go test ./cmd/gc/ -run 'Awake|Drained|Sleep' -count=1` passes (5.7s).
  `gofmt -l cmd/gc/` and `go vet ./cmd/gc/` clean.
- Honest test scope: I did not run the full `./cmd/gc/` package to completion —
  it exceeds Go's default timeout on this machine on unmodified main as well,
  in `builtinpacks` filesystem materialization with no call-graph overlap to
  this diff. Leaning on CI for that rather than claiming a green I did not see.

## Dogfooding

This guard has been running in a live multi-session deployment since
2026-07-27, where it stopped the oscillation described above.

## Note on scope

This started as a two-armed fix. The other arm — `NativeDoltStore.Ready()`
resurfacing a dateless-deferred bead as demand — turned out to be already
fixed on main by #4632, which our deployment's base predates. Only this arm is
new, so only this arm is here.