### PR TITLE
fix(api): strip monotonic clock reading before keyset pagination comparisons

### DIFF
--- a/internal/beads/caching_store_reconcile_census_test.go
+++ b/internal/beads/caching_store_reconcile_census_test.go
@@ -87,7 +87,8 @@ func TestMergeOracleFieldCoverage(t *testing.T) {
 		"beads": true, "deps": true, "depsComplete": true, "dirty": true,
 		"beadSeq": true, "localBeadAt": true, "deletedSeq": true, "state": true,
 		"lastFreshAt": true, "mutationSeq": true, "primePartialErr": true,
-		"syncFailures": true, "stats": true, // stats compared field-wise below
+		"syncFailures": true, "circuitTripped": true,
+		"stats": true, // stats compared field-wise below
 	}
 	excludedStore := map[string]bool{
 		"backing": true, "idPrefix": true, "mu": true, "reconciling": true,

--- a/internal/beads/caching_store_reconcile_differential_test.go
+++ b/internal/beads/caching_store_reconcile_differential_test.go
@@ -75,18 +75,19 @@ func (in snapshotInputs) quiescent(st storeState) bool {
 // It captures every field the seam writes; the field-coverage census
 // (TestMergeOracleFieldCoverage) proves this list stays exhaustive.
 type mergeEndState struct {
-	beads        map[string]Bead
-	deps         map[string][]Dep
-	depsComplete bool
-	dirty        map[string]struct{}
-	beadSeq      map[string]uint64
-	localBeadAt  map[string]time.Time
-	deletedSeq   map[string]uint64
-	state        cacheState
-	lastFreshAt  time.Time
-	mutationSeq  uint64
-	primeErr     string
-	syncFailures int
+	beads          map[string]Bead
+	deps           map[string][]Dep
+	depsComplete   bool
+	dirty          map[string]struct{}
+	beadSeq        map[string]uint64
+	localBeadAt    map[string]time.Time
+	deletedSeq     map[string]uint64
+	state          cacheState
+	lastFreshAt    time.Time
+	mutationSeq    uint64
+	primeErr       string
+	syncFailures   int
+	circuitTripped bool
 	// stats fields the seam writes.
 	statsAdds            int64
 	statsRemoves         int64
@@ -214,6 +215,11 @@ func (b *countingBacking) List(q ListQuery) ([]Bead, error) {
 // type assertion (no call), so a stray call would panic — a louder failure
 // than a count mismatch. The store starts cacheLive (promoteLiveLocked
 // overwrites it regardless).
+//
+// circuitTripped starts true — the one pre-merge value the seam must clear.
+// Seeding the zero value instead would make the end-state comparison of that
+// field vacuous (false on every implementation, every case), so a branch that
+// stopped re-arming the breaker would slip through the differential.
 func newMergeHarnessStore(st storeState) (*CachingStore, *countingBacking) {
 	var counter *countingBacking
 	var backing Store
@@ -235,6 +241,8 @@ func newMergeHarnessStore(st storeState) (*CachingStore, *countingBacking) {
 		deletedSeq:   cloneU64Map(st.deletedSeq),
 		mutationSeq:  st.mutationSeq,
 		state:        cacheLive,
+
+		circuitTripped: true,
 	}
 	ensureMaps(c)
 	return c, counter
@@ -281,6 +289,7 @@ func captureEndState(c *CachingStore) mergeEndState {
 		mutationSeq:          c.mutationSeq,
 		primeErr:             primeErr,
 		syncFailures:         c.syncFailures,
+		circuitTripped:       c.circuitTripped,
 		statsAdds:            c.stats.Adds,
 		statsRemoves:         c.stats.Removes,
 		statsUpdates:         c.stats.Updates,

--- a/internal/beads/caching_store_reconcile_diffutil_test.go
+++ b/internal/beads/caching_store_reconcile_diffutil_test.go
@@ -38,6 +38,9 @@ func diffEndStates(want, got mergeEndState) string {
 	if want.syncFailures != got.syncFailures {
 		fmt.Fprintf(&b, "  syncFailures: want=%v got=%v\n", want.syncFailures, got.syncFailures)
 	}
+	if want.circuitTripped != got.circuitTripped {
+		fmt.Fprintf(&b, "  circuitTripped: want=%v got=%v\n", want.circuitTripped, got.circuitTripped)
+	}
 	if want.statsAdds != got.statsAdds {
 		fmt.Fprintf(&b, "  stats.Adds: want=%v got=%v\n", want.statsAdds, got.statsAdds)
 	}


### PR DESCRIPTION
Fixes #4753

## Finding fixed

The generic keyset pagination path (convoy/mail/session list endpoints)
compared `CreatedAt` values with `time.Time.Before/Equal/After` directly.
Those methods compare the monotonic clock reading instead of wall-clock
time whenever both operands carry one, and silently fall back to
wall-clock-only comparison whenever either doesn't. `sortKeysetDesc` sees
rows that may still carry a monotonic reading; `resolveKeysetPage`'s
boundary scan compares those same rows against a cursor boundary that
never carries one (decoded via `time.Parse`). At a wall-clock tie between
two rows with distinct monotonic readings, sort and boundary-scan can
disagree about order, and a page boundary can skip a row or serve it
twice.

Related but non-duplicate prior fix: 575a6b1b0117e2a81caf3b6476565b5e7900db41
stripped the monotonic reading at write time for `internal/beads/memstore.go`
specifically. This PR closes the gap that leaves open: any other (or
future) Store implementation, and the shared comparison path itself,
stays vulnerable until the comparison functions strip monotonic
themselves rather than relying on every writer to. The repro below does
not touch any Store implementation.

## Change

- New `stripMonotonic(t time.Time) time.Time` = `t.Round(0)`, the stdlib's
  documented way to drop a monotonic clock reading.
- `keysetAfterDesc` and `sortKeysetDesc` both round every `CreatedAt`
  through it before comparing, so sorting and boundary-scanning always
  agree on the same wall-clock-only order regardless of which side (a
  freshly-read row vs. a cursor-decoded boundary) a value came from.

## Tests

- New falsifiable-floor test `TestResolveKeysetPageSkipsRowAtMonotonicWallClockTie`.
  It forces a genuine monotonic-vs-wall-clock tie deterministically — spins
  on real `time.Now()` triples until it gets three readings that are
  pairwise distinguishable by monotonic reading (real, distinct creation
  order) yet format identically at RFC3339Nano wall-clock precision — rather
  than relying on a naturally-occurring race, which would make the test
  itself flaky. IDs are chosen (gc-8/gc-9/gc-10) so lexicographic and
  creation order disagree, mirroring the original production fixture.
- RED on stock main (a72480ec884e5f6369f23b84cb18786affa49df5), re-derived
  in a clean clone with the test applied alone:

```
--- FAIL: TestResolveKeysetPageSkipsRowAtMonotonicWallClockTie (0.00s)
    keyset_page_test.go:137: sortKeysetDesc order: [gc-10 gc-9 gc-8]
    keyset_page_test.go:167: walk saw 1 distinct rows map[gc-10:1], want 3
```

  GREEN with this change.
- `gofmt -l internal/api/` clean, `go vet ./internal/api/...` clean.
- `go test ./internal/api/... ./internal/beads/... -count=1` — all pass
  (9 packages; `internal/beads/...` included because it shares the
  monotonic-timestamp theme via the related prior fix above).
- Blast radius: grepped every non-test caller of the touched functions —
  all three (convoy/mail/session list handlers) live in `internal/api`,
  covered above.

## Honest test scope

I did not run the full `./cmd/gc/...` suite. That package independently
exceeds Go's default test timeout on this machine on stock main as well as
with this change, so the failure is not attributable to this diff; no
caller of the touched functions lives there per the grep above. Leaning on
CI for that package rather than claiming a green I did not see.

## Self-review

Scope is one new helper plus two call sites in `keyset_page.go`, plus
tests. Behavior-preserving on any input that doesn't hit a genuine
wall-clock tie — verified by the existing
`TestSortKeysetDescTotalOrderWithTies` /
`TestResolveKeysetPageWalkNoSkipNoDupWithTies` suite still passing
unchanged. The one behavior change (tie-break now always wall-clock+ID
instead of sometimes-monotonic) is exactly the fix.