### PR TITLE
fix(version): preserve SemVer build metadata in normalizeVersion

### DIFF
--- a/cmd/gc/cmd_version.go
+++ b/cmd/gc/cmd_version.go
@@ -17,9 +17,9 @@ var (
 	commit                   = "unknown"
 	date                     = "unknown"
 	goPseudoVersionSuffixRes = []*regexp.Regexp{
-		regexp.MustCompile(`^(.*)\.0\.\d{14}-[0-9a-f]{12,}$`),
-		regexp.MustCompile(`^(.*)-0\.\d{14}-[0-9a-f]{12,}$`),
-		regexp.MustCompile(`^(.*)-\d{14}-[0-9a-f]{12,}$`),
+		regexp.MustCompile(`^(.*)\.0\.\d{14}-[0-9a-f]{12,}(?:\+\S*)?$`),
+		regexp.MustCompile(`^(.*)-0\.\d{14}-[0-9a-f]{12,}(?:\+\S*)?$`),
+		regexp.MustCompile(`^(.*)-\d{14}-[0-9a-f]{12,}(?:\+\S*)?$`),
 	}
 )
 
@@ -69,9 +69,9 @@ func normalizeVersion(v string) string {
 	if v == "" || v == "(devel)" {
 		return "dev"
 	}
-	if i := strings.IndexByte(v, '+'); i >= 0 {
-		v = v[:i]
-	}
+	// Strip +incompatible only (Go v2+ module compat sentinel for repos without a /vN import path).
+	// Preserve all other build metadata (e.g. +ra.1 marks a locally-patched release).
+	v = strings.TrimSuffix(v, "+incompatible")
 	for _, re := range goPseudoVersionSuffixRes {
 		if m := re.FindStringSubmatch(v); len(m) == 2 {
 			v = m[1]

--- a/cmd/gc/cmd_version_test.go
+++ b/cmd/gc/cmd_version_test.go
@@ -16,6 +16,13 @@ func TestNormalizeVersion(t *testing.T) {
 		{in: "v0.0.0-20260317225312-41a12e4914cb", want: "dev"},
 		{in: "(devel)", want: "dev"},
 		{in: "", want: "dev"},
+		// SemVer build metadata must be preserved.
+		{in: "1.3.5+ra.1", want: "1.3.5+ra.1"},
+		{in: "1.3.5", want: "1.3.5"},
+		// Pseudo-version with a newer timestamp still collapses.
+		{in: "v0.0.0-20260719191849-4c2927134266", want: "dev"},
+		// +incompatible is the one Go-specific suffix we strip.
+		{in: "1.2.3+incompatible", want: "1.2.3"},
 	}
 	for _, tt := range tests {
 		if got := normalizeVersion(tt.in); got != tt.want {


### PR DESCRIPTION
Fixes #4756

## Finding fixed

`normalizeVersion` in `cmd/gc/cmd_version.go` truncated at the first `+`,
discarding all SemVer build metadata from `gc version` output. This PR
strips only the Go-specific `+incompatible` suffix and preserves
everything else, extending the pseudo-version-collapse regexes to
tolerate a trailing build-metadata suffix so `+dirty` handling is
unaffected.

## Why this doesn't conflict with SemVer §10

Precedence must ignore build metadata — but the value this function
produces is display-only, so no precedence decision is involved. It flows
from `resolveBuildMetadata` into the package-level `version` var, which is
read only by `gc version`'s stdout/JSON output and by a status accessor
(`cmd/gc/api_state.go`).

I checked every non-test call site of `compareSemver` and
`deps.CompareVersions` on current main
(a72480ec884e5f6369f23b84cb18786affa49df5): `cmd/gc/cmd_pack_registry.go:770`,
`internal/doctor/checks.go:435`, `internal/packman/resolve.go` (several), and
`internal/beads/bdstore_ready_projection.go:93`. None of them receives this
value — the two that use a variable spelled `version` take an
independently-sourced one (`c.getVersion()` for an external binary, and the
parsed output of `bd version` respectively). `internal/deps/version.go` has
its own separate, unexported `normalizeVersion` used solely for comparison,
which already strips build metadata for precedence purposes per spec; this
PR does not touch it.

## Tests

Extended `TestNormalizeVersion` with the falsifiable pre-fix case, a newer
pseudo-version timestamp, and an explicit `+incompatible` pin. RED on
unmodified main with the test cases applied alone:

```
--- FAIL: TestNormalizeVersion (0.00s)
    cmd_version_test.go:29: normalizeVersion("1.3.5+ra.1") = "1.3.5", want "1.3.5+ra.1"
```

GREEN with the change. `gofmt -l cmd/gc/` clean, `go vet ./cmd/gc/...` clean.

## Honest test scope

I ran `go test ./cmd/gc/ -run 'TestNormalizeVersion|TestVersion'`, not the
full `./cmd/gc/...` suite — that package independently exceeds Go's default
test timeout on this machine on stock main as well as with this change, so
a failure there would not be attributable to this diff. Leaning on CI for
the full package rather than claiming a green I did not see.

## Dogfooding

This change has run continuously on a patched build in a live deployment
since 2026-07-19; it is what makes that build distinguishable from stock in
`gc version`, which is the reason it was written.