### PR TITLE
Resolve formula rig scope from GC_RIG in agent worktrees

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -123,7 +123,7 @@ Examples:
 			if err != nil {
 				return formulaCommandError(stderr, "gc formula show", jsonOutput, err)
 			}
-			scope, err := resolveFormulaScope(cfg, cityPath)
+			scope, err := resolveFormulaScope(cfg, cityPath, stderr)
 			if err != nil {
 				return formulaCommandError(stderr, "gc formula show", jsonOutput, err)
 			}
@@ -287,7 +287,7 @@ func newFormulaCatalogCmd(stdout, stderr io.Writer) *cobra.Command {
 			if err != nil {
 				return formulaCommandError(stderr, "gc formula catalog", jsonOutput, err)
 			}
-			scope, err := resolveFormulaScope(cfg, cityPath)
+			scope, err := resolveFormulaScope(cfg, cityPath, stderr)
 			if err != nil {
 				return formulaCommandError(stderr, "gc formula catalog", jsonOutput, err)
 			}
@@ -636,7 +636,7 @@ conflicting live workflow from the same source is an error.`,
 			if err != nil {
 				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
-			scope, err := resolveFormulaScope(cfg, cityPath)
+			scope, err := resolveFormulaScope(cfg, cityPath, stderr)
 			if err != nil {
 				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
@@ -1090,9 +1090,12 @@ type formulaScope struct {
 }
 
 // resolveFormulaScope determines the rig (if any) under which a formula
-// invocation should run. Priority: --rig flag > enclosing rig from cwd >
-// city.
-func resolveFormulaScope(cfg *config.City, cityPath string) (formulaScope, error) {
+// invocation should run. Priority: --rig flag > GC_RIG env > enclosing rig
+// from cwd > city. The GC_RIG tier mirrors resolveBdScopeTarget (cmd_bd.go):
+// the controller sets GC_RIG reliably, while cwd detection fails for
+// pool/polecat worktrees under .gc/worktrees/, which are not inside the
+// registered rig.Path.
+func resolveFormulaScope(cfg *config.City, cityPath string, stderr io.Writer) (formulaScope, error) {
 	if name := strings.TrimSpace(rigFlag); name != "" {
 		rig, ok := rigByName(cfg, name)
 		if !ok {
@@ -1104,6 +1107,25 @@ func resolveFormulaScope(cfg *config.City, cityPath string) (formulaScope, error
 		return rigFormulaScope(cfg, cityPath, rig), nil
 	}
 
+	gcRigDiscarded := ""
+	if gcRig := strings.TrimSpace(os.Getenv("GC_RIG")); gcRig != "" {
+		if rig, ok := rigByName(cfg, gcRig); ok && strings.TrimSpace(rig.Path) != "" {
+			return rigFormulaScope(cfg, cityPath, rig), nil
+		}
+		// GC_RIG names an unknown or unbound rig. Unlike an explicit --rig
+		// (which errors on the identical value), we do not fail: falling
+		// through to cwd/city keeps formula commands working from agents
+		// whose GC_RIG names a rig this city does not bind. The discard must
+		// not be silent though — record it and warn below, naming the scope
+		// actually used.
+		gcRigDiscarded = gcRig
+	}
+
+	scope := formulaScope{
+		storeRoot:   cityPath,
+		searchPaths: cfg.FormulaLayers.City,
+	}
+	scopeDesc := "city"
 	if cwd, err := os.Getwd(); err == nil {
 		// resolveRigForDir already filters unbound rigs (see
 		// rig_scope_resolution.go), so a true return guarantees rig.Path is
@@ -1111,14 +1133,16 @@ func resolveFormulaScope(cfg *config.City, cityPath string) (formulaScope, error
 		if rig, ok, rerr := resolveRigForDir(cfg, cityPath, cwd); rerr != nil {
 			return formulaScope{}, rerr
 		} else if ok {
-			return rigFormulaScope(cfg, cityPath, rig), nil
+			scope = rigFormulaScope(cfg, cityPath, rig)
+			scopeDesc = fmt.Sprintf("%q rig", rig.Name)
 		}
 	}
 
-	return formulaScope{
-		storeRoot:   cityPath,
-		searchPaths: cfg.FormulaLayers.City,
-	}, nil
+	if gcRigDiscarded != "" {
+		fmt.Fprintf(stderr, "gc formula: warning: GC_RIG=%q does not name a bound rig in this city; ignoring it and using the %s scope instead (the same value via --rig would error)\n", gcRigDiscarded, scopeDesc) //nolint:errcheck // best-effort stderr
+	}
+
+	return scope, nil
 }
 
 func rigFormulaScope(cfg *config.City, cityPath string, rig config.Rig) formulaScope {
@@ -1130,9 +1154,12 @@ func rigFormulaScope(cfg *config.City, cityPath string, rig config.Rig) formulaS
 }
 
 // rigFormulaVarsForScope returns rig-scoped formula var defaults for the
-// active scope (honoring --rig and cwd). Returns an empty map when no rig
-// context is active so callers can treat the result as read-only
-// annotations without nil checks.
+// active scope (honoring --rig, GC_RIG env, and cwd — same priority as
+// resolveFormulaScope). Returns an empty map when no rig context is active
+// so callers can treat the result as read-only annotations without nil
+// checks. No stderr warning here for a discarded GC_RIG: this is always
+// called alongside resolveFormulaScope (see newFormulaShowCmd), which
+// already warns once for the same condition.
 func rigFormulaVarsForScope(cfg *config.City, cityPath string) map[string]string {
 	if cfg == nil {
 		return map[string]string{}
@@ -1142,6 +1169,11 @@ func rigFormulaVarsForScope(cfg *config.City, cityPath string) map[string]string
 			return cloneStringMap(rig.FormulaVars)
 		}
 		return map[string]string{}
+	}
+	if gcRig := strings.TrimSpace(os.Getenv("GC_RIG")); gcRig != "" {
+		if rig, ok := rigByName(cfg, gcRig); ok && strings.TrimSpace(rig.Path) != "" {
+			return cloneStringMap(rig.FormulaVars)
+		}
 	}
 	if cwd, err := os.Getwd(); err == nil {
 		if rig, ok, rerr := resolveRigForDir(cfg, cityPath, cwd); rerr == nil && ok {
@@ -1188,7 +1220,7 @@ since it was spawned.`,
 			if err != nil {
 				return err
 			}
-			scope, err := resolveFormulaScope(cfg, cityPath)
+			scope, err := resolveFormulaScope(cfg, cityPath, stderr)
 			if err != nil {
 				return err
 			}

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -52,7 +52,7 @@ func TestResolveFormulaScope_RigFlagWins(t *testing.T) {
 	t.Cleanup(func() { rigFlag = prev })
 	rigFlag = "my-project"
 
-	scope, err := resolveFormulaScope(cfg, cityPath)
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
 	if err != nil {
 		t.Fatalf("resolveFormulaScope: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestResolveFormulaScope_CwdInsideRig(t *testing.T) {
 	t.Cleanup(func() { rigFlag = prev })
 	rigFlag = ""
 
-	scope, err := resolveFormulaScope(cfg, cityPath)
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
 	if err != nil {
 		t.Fatalf("resolveFormulaScope: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestResolveFormulaScope_CityScopeWhenNoRig(t *testing.T) {
 	t.Cleanup(func() { rigFlag = prev })
 	rigFlag = ""
 
-	scope, err := resolveFormulaScope(cfg, cityPath)
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
 	if err != nil {
 		t.Fatalf("resolveFormulaScope: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestResolveFormulaScope_UnknownRigErrors(t *testing.T) {
 	t.Cleanup(func() { rigFlag = prev })
 	rigFlag = "ghost"
 
-	_, err := resolveFormulaScope(cfg, cityPath)
+	_, err := resolveFormulaScope(cfg, cityPath, io.Discard)
 	if err == nil {
 		t.Fatal("expected error for unknown rig, got nil")
 	}
@@ -167,7 +167,7 @@ func TestResolveFormulaScope_UnboundRigErrors(t *testing.T) {
 	t.Cleanup(func() { rigFlag = prev })
 	rigFlag = "unbound"
 
-	_, err := resolveFormulaScope(cfg, cityPath)
+	_, err := resolveFormulaScope(cfg, cityPath, io.Discard)
 	if err == nil {
 		t.Fatal("expected error for unbound rig, got nil")
 	}
@@ -259,7 +259,7 @@ func TestResolveFormulaScope_RigFallsBackToCityLayers(t *testing.T) {
 	t.Cleanup(func() { rigFlag = prev })
 	rigFlag = "bare-rig"
 
-	scope, err := resolveFormulaScope(cfg, cityPath)
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
 	if err != nil {
 		t.Fatalf("resolveFormulaScope: %v", err)
 	}

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -223,6 +224,21 @@ func TestRigFormulaVarsForScope(t *testing.T) {
 			t.Errorf("rigFormulaVarsForScope = %v, want empty (no rig context)", vars)
 		}
 	})
+
+	t.Run("GC_RIG env populates FormulaVars when cwd outside rig", func(t *testing.T) {
+		prev := rigFlag
+		t.Cleanup(func() { rigFlag = prev })
+		rigFlag = ""
+		t.Setenv("GC_RIG", "mo")
+
+		// cwd outside both cityPath and rigPath, simulating a pool/polecat
+		// worktree under .gc/worktrees/ where cwd resolution fails.
+		t.Chdir(t.TempDir())
+		vars := rigFormulaVarsForScope(cfg, cityPath)
+		if got := vars["test_command"]; got != "make test-fast" {
+			t.Errorf("rigFormulaVarsForScope()[test_command] = %q, want %q", got, "make test-fast")
+		}
+	})
 }
 
 // TestResolveFormulaScope_RigFallsBackToCityLayers covers the case where a
@@ -253,6 +269,130 @@ func TestResolveFormulaScope_RigFallsBackToCityLayers(t *testing.T) {
 	want := []string{"/city/formulas"}
 	if !reflect.DeepEqual(scope.searchPaths, want) {
 		t.Errorf("searchPaths = %v, want %v (city fallback)", scope.searchPaths, want)
+	}
+}
+
+// TestResolveFormulaScope_GCRIGEnvRoutesWhenCwdOutsideRig covers the bug
+// where `gc formula cook`/`show` ignored GC_RIG env (set by the controller
+// on every rig agent) and fell back to city scope when cwd resolution
+// failed — which it always does for pool/polecat worktrees living under
+// .gc/worktrees/<pack>/<agent>/, since those are not inside the registered
+// rig.Path. This mirrors resolveBdScopeTarget's GC_RIG tier (cmd_bd.go),
+// which already closed the identical gap for `gc bd`. See gastownhall/gascity
+// ga-fstubn.
+func TestResolveFormulaScope_GCRIGEnvRoutesWhenCwdOutsideRig(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "my-project", Path: rigPath}},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"my-project": {"/city/formulas", "/rigs/my-project/formulas"},
+			},
+		},
+	}
+
+	// cwd is deliberately outside both cityPath and rigPath, simulating a
+	// pool/polecat worktree under .gc/worktrees/ — resolveRigForDir cannot
+	// resolve this to any rig.
+	t.Chdir(t.TempDir())
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = ""
+	t.Setenv("GC_RIG", "my-project")
+
+	var stderr bytes.Buffer
+	scope, err := resolveFormulaScope(cfg, cityPath, &stderr)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != rigPath {
+		t.Errorf("storeRoot = %q, want %q", scope.storeRoot, rigPath)
+	}
+	if scope.rig != "my-project" {
+		t.Errorf("rig = %q, want %q", scope.rig, "my-project")
+	}
+	want := []string{"/city/formulas", "/rigs/my-project/formulas"}
+	if !reflect.DeepEqual(scope.searchPaths, want) {
+		t.Errorf("searchPaths = %v, want %v", scope.searchPaths, want)
+	}
+	// A GC_RIG that names a bound rig is honored silently, matching
+	// resolveBdScopeTarget's behavior.
+	if warn := stderr.String(); warn != "" {
+		t.Errorf("expected no warning for a valid GC_RIG, got %q", warn)
+	}
+}
+
+// TestResolveFormulaScope_RigFlagOverridesGCRIGEnv verifies --rig still wins
+// over GC_RIG env, matching resolveBdScopeTarget's priority order.
+func TestResolveFormulaScope_RigFlagOverridesGCRIGEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	otherPath := filepath.Join(cityPath, "other-rig")
+	for _, p := range []string{rigPath, otherPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "my-project", Path: rigPath},
+			{Name: "other-rig", Path: otherPath},
+		},
+	}
+
+	t.Chdir(t.TempDir())
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = "my-project"
+	t.Setenv("GC_RIG", "other-rig")
+
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != rigPath {
+		t.Errorf("storeRoot = %q, want %q (--rig must win over GC_RIG)", scope.storeRoot, rigPath)
+	}
+}
+
+// TestResolveFormulaScope_UnknownGCRIGEnvFallsThroughAndWarns matches
+// resolveBdScopeTarget's behavior: an unresolvable GC_RIG does not error
+// (unlike an identical --rig value), it falls through to cwd/city — but the
+// discard is not silent, so a stale or typo'd GC_RIG doesn't redirect
+// scope with no diagnostic.
+func TestResolveFormulaScope_UnknownGCRIGEnvFallsThroughAndWarns(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "real", Path: filepath.Join(cityPath, "real")}},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+		},
+	}
+
+	t.Chdir(t.TempDir())
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = ""
+	t.Setenv("GC_RIG", "nonexistent-rig")
+
+	var stderr bytes.Buffer
+	scope, err := resolveFormulaScope(cfg, cityPath, &stderr)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != cityPath {
+		t.Errorf("storeRoot = %q, want %q (city fallback)", scope.storeRoot, cityPath)
+	}
+	warn := stderr.String()
+	if !strings.Contains(warn, "GC_RIG") || !strings.Contains(warn, "nonexistent-rig") {
+		t.Errorf("expected a warning naming the discarded GC_RIG value, got %q", warn)
 	}
 }
 

--- a/release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md
+++ b/release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md
@@ -1,0 +1,28 @@
+# Release gate: formula `GC_RIG` scope resolution
+
+- Deploy bead: `ga-djfr2g`
+- Build bead: `ga-fstubn`
+- Reviewed source: `8dcf51a1821596ec2aa79a016b2457adb62b4c9e`
+- Gate base: `origin/main@682a0726f5ad20cedd39e3b97e0f9d6f7fa7b919`
+- Evaluation date: 2026-07-28
+- Disposition: **PASS**
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | `ga-djfr2g` records `verdict: pass` after an independent review at the reviewed source SHA. |
+| 2 | Acceptance criteria met | **PASS** | Focused tests pass for valid `GC_RIG` routing outside a registered rig path, explicit `--rig` precedence, invalid/unbound `GC_RIG` warning plus cwd/city fallback, unchanged behavior when `GC_RIG` is unset, and rig-scoped formula variables. The implementation is shared by formula show, catalog, cook, and version-check call sites. |
+| 3 | Tests pass | **PASS** | `go build ./...` passed; `go test -count=1 ./cmd/gc/... -run 'TestResolveFormulaScope\|TestRigFormulaVarsForScope' -v` passed; `make test-fast-parallel` passed all 9 jobs; `go vet ./...` passed. All commands ran at the reviewed source SHA. |
+| 4 | No high-severity review findings open | **PASS** | Reviewer notes report no style, security, or specification findings and no blocking findings; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | **PASS** | `git status --porcelain` was empty at the reviewed source SHA before this gate record was created. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main 8dcf51a1821596ec2aa79a016b2457adb62b4c9e` exited 0 against the gate base and produced tree `cccf7c4176560777c13c6cfcd733fafb10885d8c`; no self-rebase was required. |
+| 7 | Single feature theme | **PASS** | The two-commit diff is confined to `cmd/gc/cmd_formula.go` and `cmd/gc/cmd_formula_test.go`, implementing and testing one formula scope-resolution behavior. |
+
+## Acceptance evidence
+
+- `GC_RIG` is consulted after explicit `--rig` and before cwd-based discovery.
+- A valid bound rig selects its store root, formula layers, and formula variables even when the agent worktree is outside the rig path.
+- An unknown or unbound `GC_RIG` does not make formula commands unusable: resolution falls through and emits a warning naming the discarded value and selected scope.
+- Existing cwd and city fallback behavior remains in place when `GC_RIG` is unset.
+- No configuration schema, API wire shape, migration, or new dependency is introduced.


### PR DESCRIPTION
## What this changes

`gc formula cook`, `gc formula show`, `gc formula catalog`, and formula version checks now resolve the active rig from `GC_RIG` when they run in pool or agent worktrees outside the rig's registered filesystem path. Operators no longer need to pass `--rig` explicitly just because the current worktree is hosted under `.gc/worktrees/`.

Scope resolution follows the same ordering already used by `gc bd`: explicit `--rig`, then `GC_RIG`, then cwd discovery, then city scope. If `GC_RIG` is unknown or unbound, the command remains usable by falling through to cwd/city scope and emits a warning that identifies the discarded value and selected scope.

## Review notes

- Check that explicit `--rig` still wins over `GC_RIG`.
- Check the invalid/unbound `GC_RIG` warning and fallback behavior; this path intentionally warns rather than failing.
- Rig formula variables use the same resolved environment tier. There are no config-schema, API-wire, dependency, or migration changes.

## Test plan

- [x] Build all Go packages with `go build ./...`.
- [x] Exercise formula scope and variable resolution with focused tests for valid, invalid, overridden, and unset `GC_RIG`.
- [x] Run all nine jobs in `make test-fast-parallel` and run `go vet ./...`.
- [x] Release gate: [`release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md`](release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md)