### PR TITLE
fix(sling): restamp gc.routed_to on formula-attach and disclose it in --dry-run (Fixes #4762)

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1790,6 +1790,13 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			} else {
 				w("  This assigns the bead to \"" + a.QualifiedName() + "\".")
 			}
+			// A formula attach routes more than the work bead: the cooked
+			// wisp/workflow root is routed to the same agent. Without this
+			// line the preview shows only the plain-routing effect, so a
+			// reader cannot anticipate the second routed bead.
+			if opts.OnFormula != "" || (!opts.NoFormula && a.EffectiveDefaultSlingFormula() != "") {
+				w("  A wisp/workflow root is also cooked and routed to the agent.")
+			}
 		}
 		w("")
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -6378,6 +6378,9 @@ func TestDryRunOnFormula(t *testing.T) {
 	if !strings.Contains(out, "bd update 'BL-42' --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing route command: %s", out)
 	}
+	if !strings.Contains(out, "A wisp/workflow root is also cooked and routed to the agent.") {
+		t.Errorf("stdout missing wisp-root disclosure: %s", out)
+	}
 	if len(runner.calls) != 0 {
 		t.Errorf("got %d runner calls, want 0: %v", len(runner.calls), runner.calls)
 	}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -295,7 +295,10 @@ type attachmentDecision struct {
 // fail-closed idempotent state rather than clear it and risk minting a
 // duplicate attachment.
 func onFormulaNeedsAttachment(opts SlingOpts, querier BeadQuerier, deps SlingDeps) (attachmentDecision, error) {
-	if opts.OnFormula == "" {
+	// Both formula-backed routes reach the same attach path, so the
+	// routed-raw override has to apply to a target's default_sling_formula
+	// as well as an explicit --on.
+	if !usesFormulaBackedRoute(opts) {
 		return attachmentDecision{}, nil
 	}
 	hasMolecule, err := HasMoleculeChildren(querier, opts.BeadOrFormula, deps.Store)
@@ -518,7 +521,13 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 				if rollbackErr := rollbackGraphV2ReplacementLaunch(deps.Store, mResult.RootID, replacedSnapshot); rollbackErr != nil {
 					return wfResult, errors.Join(wfErr, rollbackErr)
 				}
+				return wfResult, wfErr
 			}
+			// The convoy-first branch deliberately passes an empty
+			// sourceBeadID (the source is tracked through the input convoy,
+			// not gc.source_bead_id), so doStartGraphWorkflow's own restamp
+			// never covers it. Stamp the work bead here instead.
+			restampWorkBeadRouting(deps, beadID, a, &wfResult)
 			return wfResult, wfErr
 		})
 	}
@@ -712,6 +721,29 @@ func validateBuiltInRouteStoreReachable(deps SlingDeps, beadID string, a config.
 	}
 }
 
+// restampWorkBeadRouting stamps gc.routed_to on the work bead a graph workflow
+// was attached to. gc.routed_to on the WORK bead is what the claim path reads;
+// the cooked workflow root carries the graph-routing metadata instead, so an
+// attach that routes only the root leaves the work bead looking unrouted to
+// anything reading gc.routed_to directly. Failures are reported as metadata
+// errors rather than failing the launch: by this point the workflow is already
+// running, and unwinding it over a routing restamp would be worse than a
+// surfaced warning.
+func restampWorkBeadRouting(deps SlingDeps, beadID string, a config.Agent, result *SlingResult) {
+	beadID = strings.TrimSpace(beadID)
+	if beadID == "" || deps.Store == nil || result == nil {
+		return
+	}
+	target := strings.TrimSpace(agentutil.RoutedToIdentity(&a))
+	if target == "" {
+		return
+	}
+	if err := deps.Store.SetMetadata(beadID, beadmeta.RoutedToMetadataKey, target); err != nil {
+		result.MetadataErrors = append(result.MetadataErrors,
+			fmt.Sprintf("setting %s on %s: %v", beadmeta.RoutedToMetadataKey, beadID, err))
+	}
+}
+
 // doStartGraphWorkflow performs post-instantiation graph workflow setup.
 func doStartGraphWorkflow(rootID, sourceBeadID string, a config.Agent, method string, deps SlingDeps) (SlingResult, error) {
 	var result SlingResult
@@ -742,6 +774,7 @@ func doStartGraphWorkflow(rootID, sourceBeadID string, a config.Agent, method st
 		if err := deps.Store.SetMetadata(sourceBeadID, "workflow_id", rootID); err != nil {
 			return result, fmt.Errorf("setting workflow_id on %s: %w", sourceBeadID, err)
 		}
+		restampWorkBeadRouting(deps, sourceBeadID, a, &result)
 	}
 	telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), method, nil)
 	if deps.Notify != nil {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2506,6 +2506,12 @@ func TestSlingAttachGraphFormulaCreatesConvoyFirstRoot(t *testing.T) {
 	if len(members) != 1 || members[0].ID != source.ID {
 		t.Fatalf("members = %+v, want source %s", members, source.ID)
 	}
+	// The work bead's gc.routed_to is the single source of truth the pool
+	// claim path reads. A convoy-first graph.v2 attach must restamp it on
+	// the source bead, not only route the cooked workflow root.
+	if got := sourceAfter.Metadata[beadmeta.RoutedToMetadataKey]; got != "mayor" {
+		t.Fatalf("source gc.routed_to = %q, want mayor", got)
+	}
 }
 
 func TestSlingAttachGraphFormulaCreatesFreshRootForBareBeadTarget(t *testing.T) {


### PR DESCRIPTION
Fixes #4762.

## Summary

- `gc sling <agent> <bead> --on=<formula>` (and the `default_sling_formula` path) never restamped `gc.routed_to` on the work bead after attaching a formula — only the cooked wisp/workflow root got routed. `gc.routed_to` on the work bead is what the claim path reads, so the work bead was left looking unrouted.
- The convoy-first graph.v2 attach branch was the one silently missing this: it passes `sourceBeadID=""` into `doStartGraphWorkflow` by design (source tracked via the input convoy, not `gc.source_bead_id`), so the helper's own metadata pass never covered it.
- `--dry-run`'s preview for a formula attach didn't disclose that a separate wisp/workflow root is cooked and routed, so the preview and the real run's routing effects diverged with no warning.

## Changes

- `internal/sling/sling_core.go`: add `restampWorkBeadRouting`; call it from the convoy-first graph.v2 attach branch (on success only, after rollback handling) and from `doStartGraphWorkflow` for any launch with a non-empty `sourceBeadID`. Restamp failures land in `MetadataErrors` rather than failing a workflow that is already running. Also widen `onFormulaNeedsAttachment`'s guard from `opts.OnFormula == ""` to `!usesFormulaBackedRoute(opts)` so the routed-raw idempotency override applies to `default_sling_formula` as well as explicit `--on`.
- `cmd/gc/cmd_sling.go`: `dryRunSingle` now prints "A wisp/workflow root is also cooked and routed to the agent." whenever a formula attach (`--on` or default) is in play.
- Tests: `TestSlingAttachGraphFormulaCreatesConvoyFirstRoot` asserts the source bead's `gc.routed_to` after a convoy-first attach; `TestDryRunOnFormula` asserts the new disclosure line.

## Test plan

Verified at `431711fe009e354c22f146aed887563797dde98b` (main at the time of writing), macOS arm64.

- [x] Failure floor: both new assertions run **5/5 RED** on unmodified main, deterministic — not a one-shot observation.
- [x] `go build ./cmd/gc/... ./internal/sling/...`
- [x] `go vet ./cmd/gc/... ./internal/sling/...` — clean
- [x] `gofmt -l` on the four touched files — clean
- [x] `go test ./internal/sling/... -count=1` — full package, ok
- [x] `go test ./cmd/gc/... -run 'Sling|DryRun|Route|Formula' -count=1` — both target tests pass. Ten unrelated tests in this scope fail on my machine, and the **identical ten fail byte-for-byte on unmodified main** (verified by stashing the diff and re-running the same selector): they are local `/private/var` vs `/var` TMPDIR-symlink fixture artifacts on macOS, not something this diff touches. The full `./cmd/gc/...` run is avoided here because it hits a known pre-existing hang unrelated to this change.