### PR TITLE
fix(session): exclude session's own mol-do-work drain step from the close-gate (Fixes #4764)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -538,13 +538,13 @@ func finalizeDrainAckStoppedSession(
 			Payload:   api.SessionLifecyclePayloadJSON(info.ID, template, "drain acknowledged"),
 		})
 	}
-	hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, info)
+	hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStoreForCloseGate(cityPath, cfg, store, rigStores, info)
 	if assignedErr != nil {
 		fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
 		hasAssignedWork = true
 	}
 	if closeIfUnassigned && !hasAssignedWork {
-		if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, info, "drained", clk.Now().UTC(), stderr) {
+		if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, info, "drained", clk.Now().UTC(), stderr, true) {
 			closePatch := sessionpkg.ClosePatch(clk.Now().UTC(), "drained")
 			if dops != nil {
 				_ = dops.clearDrain(name)
@@ -584,7 +584,7 @@ func finalizeDrainAckStoppedSession(
 			recordStopped(false)
 			return drainAckFinalizeResult{witnessInfo: &witnessInfo}
 		}
-		assignedAfterCloseGate, closeGateAssignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, info)
+		assignedAfterCloseGate, closeGateAssignedErr := sessionHasOpenAssignedWorkForReachableStoreForCloseGate(cityPath, cfg, store, rigStores, info)
 		if closeGateAssignedErr != nil {
 			fmt.Fprintf(stderr, "session reconciler: checking assigned work after failed drain-ack close gate for %s: %v\n", name, closeGateAssignedErr) //nolint:errcheck
 			assignedAfterCloseGate = true
@@ -1817,7 +1817,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
 						continue
 					}
-					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], string(sessionpkg.StateFailedCreate), clk.Now().UTC(), stderr) {
+					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], string(sessionpkg.StateFailedCreate), clk.Now().UTC(), stderr, false) {
 						// Reflect the in-memory close on the snapshot: the cross-session
 						// min-floor scan (below) reads Info.Closed off infoByID, so a
 						// session closed this tick must not still count as open in its
@@ -2126,7 +2126,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
 						continue
 					}
-					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], reason, clk.Now().UTC(), stderr) {
+					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], reason, clk.Now().UTC(), stderr, false) {
 						// Keep the snapshot's Info.Closed in step with the in-memory
 						// close so the cross-session min-floor scan does not count this
 						// orphan. Store-only close (closeBead/closeFailedCreateBead stamp
@@ -3903,6 +3903,159 @@ func sessionHasOpenAssignedWorkForReachableStore(
 		}
 	}
 	return false, nil
+}
+
+// sessionHasOpenAssignedWorkForReachableStoreForCloseGate is the drain-ack
+// close-gate form of sessionHasOpenAssignedWorkForReachableStore: identical
+// reachability/identifier resolution, but the per-store probe additionally
+// excludes the session's own mol-do-work "drain" step. That
+// step's title is literally "Close drain step and signal completion" — counting
+// it as assigned work means a session that has already signaled completion is
+// judged to still have work, so the session bead never closes and the pool
+// controller respawns a fresh session onto the same still-open step forever.
+//
+// This is a deliberately SEPARATE chain from sessionHasOpenAssignedWorkForReachableStore,
+// not a shared-helper change: sessionHasOpenAssignedWorkForTier and
+// sessionHasOpenAssignedWispWork (the functions that would otherwise need the
+// exclusion) are also called from the awake-work chain
+// (sessionHasInProgressAssignedWorkForTier), which gates unrelated decisions
+// (config-drift drain deferral, the max-session-age timer, the pool-slot-freeable
+// check, wake-on-assigned-work). None of those should start ignoring a session's
+// own drain step — only the drain-ack close decision should. Use this function
+// (and closeSessionBeadIfReachableStoreUnassigned's excludeOwnDrainStep=true form)
+// ONLY from the drain-ack finalize path.
+func sessionHasOpenAssignedWorkForReachableStoreForCloseGate(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	info sessionpkg.Info,
+) (bool, error) {
+	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
+	stores, err := reachableStoresForSessionInfo(cityPath, cfg, store, rigStores, info)
+	if err != nil {
+		return false, err
+	}
+	for _, s := range stores {
+		if has, err := sessionHasOpenAssignedWorkInStoreByIdentifiersForCloseGate(s, identifiers); err != nil || has {
+			return has, err
+		}
+	}
+	return false, nil
+}
+
+func sessionHasOpenAssignedWorkInStoreByIdentifiersForCloseGate(store beads.Store, identifiers []string) (bool, error) {
+	return sessionHasAssignedWorkInStoreByIdentifiersForStatusesForCloseGate(store, identifiers, []string{"open", "in_progress"})
+}
+
+func sessionHasAssignedWorkInStoreByIdentifiersForStatusesForCloseGate(store beads.Store, identifiers []string, statuses []string) (bool, error) {
+	if store == nil {
+		return false, nil
+	}
+	seen := make(map[string]struct{}, len(identifiers))
+	for _, status := range statuses {
+		for _, assignee := range identifiers {
+			if assignee == "" {
+				continue
+			}
+			key := status + "\x00" + assignee
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			if has, err := sessionHasOpenAssignedWorkForTierForCloseGate(store, assignee, status, beads.TierIssues, true); err != nil || has {
+				return has, err
+			}
+			if has, err := sessionHasOpenAssignedWispWorkForCloseGate(store, assignee, status); err != nil || has {
+				return has, err
+			}
+		}
+	}
+	return false, nil
+}
+
+// sessionHasOpenAssignedWorkForTierForCloseGate mirrors sessionHasOpenAssignedWorkForTier
+// but filters through hasNonSessionNonOwnDrainStepWork instead of the shared
+// wa.HasNonSessionWork, so the drain-step exclusion cannot leak into
+// sessionHasOpenAssignedWorkForTier's other caller (the awake-work chain).
+func sessionHasOpenAssignedWorkForTierForCloseGate(store beads.Store, assignee, status string, tierMode beads.TierMode, live bool) (bool, error) {
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	items, err := wa.OpenAssignedTo(assignee, status, tierMode, live)
+	if err != nil {
+		return false, err
+	}
+	return hasNonSessionNonOwnDrainStepWork(store, items), nil
+}
+
+// sessionHasOpenAssignedWispWorkForCloseGate mirrors sessionHasOpenAssignedWispWork
+// for the close gate. It intentionally skips the CachedOpenAssignedWisps fast
+// path: that cache is a positive-only accelerator built on the shared
+// wa.HasNonSessionWork filter, and drain-ack is not a hot loop, so the extra
+// live read here is cheap and keeps the exclusion correct rather than stale.
+func sessionHasOpenAssignedWispWorkForCloseGate(store beads.Store, assignee, status string) (bool, error) {
+	return sessionHasOpenAssignedWorkForTierForCloseGate(store, assignee, status, beads.TierWisps, true)
+}
+
+// hasNonSessionNonOwnDrainStepWork is wa.HasNonSessionWork plus the own-drain-step
+// exclusion: skips session beads/repairable session beads (as HasNonSessionWork
+// already does) AND the session's own mol-do-work drain step.
+func hasNonSessionNonOwnDrainStepWork(store beads.Store, items []beads.Bead) bool {
+	for _, item := range items {
+		if sessionpkg.IsSessionBeadOrRepairable(item) {
+			continue
+		}
+		if isSessionOwnDrainStepBead(store, item) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// isSessionOwnDrainStepBead reports whether item is a mol-do-work "drain" step
+// bead: gc.step_ref's final dot-separated segment is "drain" AND its molecule
+// root (gc.root_bead_id) was compiled from the mol-do-work formula. The store
+// writes gc.step_ref formula-qualified (e.g. "mol-do-work.drain"), never the
+// bare step id, so the match is on the LAST segment, not the whole string.
+// The formula pin below already narrows to mol-do-work, so this
+// segment check only has to identify "this is the drain step", not re-pin the
+// formula itself. The match is deliberately narrow — it must not match
+// any other step, including one that happens to reuse the literal step id
+// "drain" in an unrelated formula. The identifiers-scoped assignee filter
+// upstream already guarantees any matching item is assigned to THIS session,
+// so no separate "is this session's own molecule" check is needed beyond
+// confirming the step/formula shape itself.
+func isSessionOwnDrainStepBead(store beads.Store, item beads.Bead) bool {
+	stepRef := strings.TrimSpace(item.Metadata[beadmeta.StepRefMetadataKey])
+	if idx := strings.LastIndex(stepRef, "."); idx >= 0 {
+		stepRef = stepRef[idx+1:]
+	}
+	if stepRef != "drain" {
+		return false
+	}
+	rootID := strings.TrimSpace(item.Metadata[beadmeta.RootBeadIDMetadataKey])
+	if rootID == "" || store == nil {
+		return false
+	}
+	root, err := store.Get(rootID)
+	if err != nil {
+		return false
+	}
+	return drainStepRootFormulaName(root) == "mol-do-work"
+}
+
+// drainStepRootFormulaName mirrors internal/api's workflowFormulaName (root.Ref,
+// falling back to gc.formula_name, falling back to the root bead's own ID) — the
+// canonical way this codebase names the formula a molecule root was compiled
+// from (see internal/formula/compile.go's rootStep stamping).
+func drainStepRootFormulaName(root beads.Bead) string {
+	if name := strings.TrimSpace(root.Ref); name != "" {
+		return name
+	}
+	if name := strings.TrimSpace(root.Metadata[beadmeta.FormulaNameMetadataKey]); name != "" {
+		return name
+	}
+	return root.ID
 }
 
 // sessionHasAwakeAssignedWorkForReachableStore reports whether assigned work

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
@@ -1889,6 +1890,208 @@ func TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent(t *testing
 	}
 	if got.Status == "closed" {
 		t.Errorf("stranded bead status = %q, SDK must not close the bead", got.Status)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckOwnDrainStepClosesWithoutEvent pins that
+// a session whose ONLY assigned work is its own mol-do-work "drain" step
+// must actually close on drain-ack (no pool respawn) and must NOT emit
+// SessionDrainAckedWithAssignedWork, since nothing is genuinely stranded.
+// Before the close-gate fix, the drain step counted as assigned work, so the
+// bead stayed open forever and the pool controller respawned a fresh session
+// onto the same still-open step every ~20s.
+func TestReconcileSessionBeads_DrainAckOwnDrainStepClosesWithoutEvent(t *testing.T) {
+	env := newReconcilerTestEnv()
+	fake := events.NewFake()
+	env.rec = fake
+
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+
+	root, err := env.store.Create(beads.Bead{
+		Title: "Run of mol-do-work",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.FormulaNameMetadataKey: "mol-do-work",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	drainStep, err := env.store.Create(beads.Bead{
+		Title:    "Close drain step and signal completion",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+		Metadata: map[string]string{
+			// Formula-qualified, matching what the live store actually writes
+			// — a bare "drain" fixture would pass before and
+			// after the fix and prove nothing.
+			beadmeta.StepRefMetadataKey:    "mol-do-work.drain",
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(drainStep): %v", err)
+	}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	gotSession := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, nil)
+	if gotSession.Status != "closed" {
+		t.Fatalf("session bead status = %q, want closed (own drain step must not block close): metadata=%v",
+			gotSession.Status, gotSession.Metadata)
+	}
+
+	matches := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			matches++
+		}
+	}
+	if matches != 0 {
+		t.Fatalf("%s events = %d, want 0 — the session's own drain step is not stranded work", events.SessionDrainAckedWithAssignedWork, matches)
+	}
+
+	// The drain step itself is untouched by the close gate — the event path
+	// (firstOpenAssignedWorkBeadForReachableStore) and IsSessionBeadOrRepairable
+	// classification are deliberately unchanged; this just confirms the fix
+	// didn't mutate the step bead as a side effect.
+	gotStep, err := env.store.Get(drainStep.ID)
+	if err != nil {
+		t.Fatalf("Get(drainStep): %v", err)
+	}
+	if gotStep.Status == "closed" {
+		t.Errorf("drain step status = %q, the close gate must not itself close the step bead", gotStep.Status)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckStepNamedDrainInOtherFormulaStillBlocksClose
+// guards the narrow-match requirement in isSessionOwnDrainStepBead: a step bead
+// that happens to reuse the literal step id "drain" but whose molecule root was
+// NOT compiled from the mol-do-work formula must still count as assigned work —
+// the exclusion is scoped to mol-do-work's drain step specifically, not to any
+// step named "drain".
+func TestReconcileSessionBeads_DrainAckStepNamedDrainInOtherFormulaStillBlocksClose(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	fake := events.NewFake()
+	env.rec = fake
+
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	root, err := env.store.Create(beads.Bead{
+		Title: "Run of some-other-formula",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.FormulaNameMetadataKey: "some-other-formula",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	decoyStep, err := env.store.Create(beads.Bead{
+		Title:    "drain the widget queue",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+		Metadata: map[string]string{
+			beadmeta.StepRefMetadataKey:    "some-other-formula.drain",
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(decoyStep): %v", err)
+	}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	gotSession := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
+	if gotSession.Status == "closed" {
+		t.Fatalf("session bead closed unexpectedly: a same-named 'drain' step from an unrelated formula must still block close: metadata=%v", gotSession.Metadata)
+	}
+
+	matches := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("%s events = %d, want exactly 1 for the genuinely-stranded decoy step", events.SessionDrainAckedWithAssignedWork, matches)
+	}
+
+	got, err := env.store.Get(decoyStep.ID)
+	if err != nil {
+		t.Fatalf("Get(decoyStep): %v", err)
+	}
+	if got.Assignee != session.ID {
+		t.Errorf("decoy step assignee = %q, want %q", got.Assignee, session.ID)
 	}
 }
 

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -90,6 +90,14 @@ func closeSessionInfoIfUnassigned(
 // (which already funnels its writes through sessionFrontDoor AND runs the
 // extmsg/orphaned-work release cascade Store.Close does not — so the close stays
 // on closeBead, not Store.Close, to preserve that behavior).
+//
+// excludeOwnDrainStep selects the drain-ack close-gate form of the
+// assigned-work probe (sessionHasOpenAssignedWorkForReachableStoreForCloseGate),
+// which excludes the session's own mol-do-work "drain" step so a session that
+// has already signaled completion is not judged to still have work.
+// Pass true ONLY from the drain-ack finalize path; every
+// other caller (failed-create close, generic idle/config-drift close) passes
+// false to keep its existing behavior unchanged.
 func closeSessionBeadIfReachableStoreUnassigned(
 	cityPath string,
 	cfg *config.City,
@@ -99,11 +107,16 @@ func closeSessionBeadIfReachableStoreUnassigned(
 	reason string,
 	now time.Time,
 	stderr io.Writer,
+	excludeOwnDrainStep bool,
 ) bool {
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	hasAssignedWork, err := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, info)
+	assignedWorkProbe := sessionHasOpenAssignedWorkForReachableStore
+	if excludeOwnDrainStep {
+		assignedWorkProbe = sessionHasOpenAssignedWorkForReachableStoreForCloseGate
+	}
+	hasAssignedWork, err := assignedWorkProbe(cityPath, cfg, store, rigStores, info)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking reachable assigned work for %s: %v\n", info.ID, err) //nolint:errcheck
 		return false


### PR DESCRIPTION
Fixes #4764.

## Summary

- The drain-ack finalize path now uses a dedicated assigned-work probe (`...ForCloseGate` variants) that excludes the session's own `mol-do-work` "drain" step, so a session that has already signaled completion is not perpetually judged to still have open work.
- The drain-step match is on the **last dot-segment** of `gc.step_ref` (formula-qualified, e.g. `mol-do-work.drain`), not a bare-literal `"drain"` comparison — the store never writes the bare form, so a bare-literal match is a no-op against real data.
- The exclusion is reached **only** from the drain-ack finalize path. The pre-existing probe used by the awake-work chain, the failed-create close, and the generic idle/config-drift close is untouched.

## Root cause

A pool session's own `mol-do-work` drain step ("Close drain step and signal completion") is an open, session-assigned bead. The close gate counted it as assigned work, so the session bead never closed and the pool controller respawned a new session onto the same still-open step — a livelock, observed in production as 154 drain-acks from one session in 43 minutes.

The two halves must land together: the exclusion is inert without the segment-wise `gc.step_ref` match, because the bare literal never matches a stored value.

## Test plan

Verified at `431711fe009e354c22f146aed887563797dde98b` (main at the time of writing), macOS arm64.

- [x] **Failure floor, 5/5 RED and deterministic.** With only the two new tests applied to unmodified main, `TestReconcileSessionBeads_DrainAckOwnDrainStepClosesWithoutEvent` fails on all 5 consecutive runs.
- [x] **Negative control, 5/5 PASS in the same runs.** `TestReconcileSessionBeads_DrainAckStepNamedDrainInOtherFormulaStillBlocksClose` — a step named `drain` in a different formula — passes both before and after, so the fix is shown to be scoped rather than merely permissive.
- [x] `go build ./...` — clean
- [x] `go vet ./cmd/gc/...` — clean
- [x] `gofmt -l` on the three touched files — clean
- [x] `go test ./cmd/gc/ -run 'DrainAck' -count=1` — ok, including both new tests
- [x] An untargeted full-package `go test ./cmd/gc/...` does not complete in this dev environment for two pre-existing reasons reproduced identically on unmodified main (macOS `/private` TMPDIR symlink path assertions, and one unrelated hang). Neither touches the changed files or call chain.