### PR TITLE
test(cmd/gc): migrate batch 4 off ambient city discovery (ga-klo4gz.5)

### DIFF
--- a/cmd/gc/cmd_graph_test.go
+++ b/cmd/gc/cmd_graph_test.go
@@ -467,6 +467,7 @@ func TestOpenRigAwareStoreUsesProviderAwareRigStore(t *testing.T) {
 	writeGraphFileStoreFixture(t, rigDir, beads.Bead{ID: "fe-1", Title: "rig bead", Status: "open", Type: "task"})
 
 	setCwd(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 	var stderr bytes.Buffer
 	store, code := openRigAwareStore([]string{"fe-1"}, &stderr)
 	if code != 0 {
@@ -497,6 +498,7 @@ func TestOpenRigAwareStoreLegacyFileCityUsesSharedCityStore(t *testing.T) {
 	writeGraphFileStoreFixture(t, cityDir, beads.Bead{ID: "fe-1", Title: "legacy shared bead", Status: "open", Type: "task"})
 
 	setCwd(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 	var stderr bytes.Buffer
 	store, code := openRigAwareStore([]string{"fe-1"}, &stderr)
 	if code != 0 {

--- a/cmd/gc/metrics_lifecycle_test.go
+++ b/cmd/gc/metrics_lifecycle_test.go
@@ -878,6 +878,7 @@ func TestProductMetricsLifecycleRealPackDispatchMatrix(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWorkingDirectory) })
+	t.Setenv("GC_CITY_PATH", city)
 	tests := []struct {
 		name       string
 		args       []string
@@ -939,6 +940,7 @@ func TestProductMetricsLifecycleConfigChangeFallbackReportsBeforeInvoke(t *testi
 				t.Fatal(err)
 			}
 			t.Cleanup(func() { _ = os.Chdir(oldWorkingDirectory) })
+			t.Setenv("GC_CITY_PATH", workingDirectory)
 			spy := &productMetricsInvocationSpy{recordResult: productmetrics.RecordDropped}
 			withProductMetricsInvocationSpy(t, spy)
 			stdout := &productMetricsOrderingWriter{spy: spy, name: "stdout"}

--- a/cmd/gc/root_argv_test.go
+++ b/cmd/gc/root_argv_test.go
@@ -179,6 +179,7 @@ func TestRootConstructionUsesInjectedArgsInsteadOfAmbientOSArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWorkingDirectory) })
+	t.Setenv("GC_CITY_PATH", cityPath)
 
 	oldArgs := os.Args
 	t.Cleanup(func() { os.Args = oldArgs })
@@ -248,6 +249,7 @@ func TestNewRootCmdCompatibilityWrapperNeverConsultsAmbientArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWorkingDirectory) })
+	t.Setenv("GC_CITY_PATH", cityPath)
 
 	oldArgs := os.Args
 	os.Args = []string{oldArgs[0], "git-credential", "get"}


### PR DESCRIPTION
## Summary

Part of the `ga-klo4gz` ambient-city-discovery test migration (mayor sequencing ruling in mail `gm-wisp-0zj3zar`). Batch 4/N: adds `t.Setenv("GC_CITY_PATH", dir)` immediately after the existing cwd setup in 6 sites across 3 files, so `resolveCity()` resolves via the explicit-env step instead of the ambient upward-walk step (step 10) that `ga-klo4gz`'s guard will refuse in test binaries.

- `root_argv_test.go`: `TestRootConstructionUsesInjectedArgsInsteadOfAmbientOSArgs`, `TestNewRootCmdCompatibilityWrapperNeverConsultsAmbientArgs`
- `cmd_graph_test.go`: `TestOpenRigAwareStoreUsesProviderAwareRigStore`, `TestOpenRigAwareStoreLegacyFileCityUsesSharedCityStore`
- `metrics_lifecycle_test.go`: `TestProductMetricsLifecycleRealPackDispatchMatrix`, `TestProductMetricsLifecycleConfigChangeFallbackReportsBeforeInvoke`

All 6 sites use incidental city-setup infra (`setupPackExitCity`/`setCwd`/plain `os.Chdir` + `t.TempDir`), not the discovery mechanism under test — confirmed guard-blind by reading each site.

Guard itself is **not included** — reserved for its own PR per the mayor's sequencing ruling.

**Provenance note:** this diff (commit `e002dd201d961a914a1521f6aefad877566d21ab`) was built and pushed to this branch on 2026-07-26 as part of `ga-klo4gz.5`, which closed with "TDD build complete" but never had a PR opened — it fell out of the review queue. Discovered and opened now while re-measuring blast radius for batch 6 (`ga-klo4gz.7`); the diff itself is unchanged from what `ga-klo4gz.5`'s notes recorded as both-ways-green. `git merge-tree` against current `origin/main` shows a clean merge (no conflicts) despite main having advanced since the branch was cut.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/gc/...` clean
- [x] Both-ways-green (verified 2026-07-26 per `ga-klo4gz.5` notes): full `cmd/gc` suite passes with the canary guard (`isTestBinary()` gate on `resolveContextFromDir` step 10) applied locally and uncommitted
- [x] Full `cmd/gc` suite passes clean on plain `origin/main` + this diff alone
- [x] `git merge-tree --write-tree origin/main e002dd201d961a914a1521f6aefad877566d21ab` clean (re-verified 2026-07-27, no conflicts against current main)