### PR TITLE
test(cmd/gc): migrate batch 6 off ambient city discovery (ga-klo4gz.7)

### DIFF
--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -220,6 +220,17 @@ func TestPackCommandExitHelper(t *testing.T) {
 		return
 	}
 
+	// TestMain's clearProcessLiveEnvForTests scrubs GC_CITY_PATH (and the
+	// rest of inheritedCityRoutingEnvVars) before m.Run reaches this test,
+	// so any GC_CITY_PATH the parent set on cmd.Env is already gone by now.
+	// cmd.Dir pins this process's cwd to the intended city, so restore the
+	// override from there rather than threading the path through argv.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Setenv("GC_CITY_PATH", cwd)
+
 	code := func() int {
 		defer func() {
 			if err := os.WriteFile(invocation.afterRun, []byte("reached\n"), 0o600); err != nil {
@@ -1728,6 +1739,7 @@ func TestE1LazyMissingTreeMatchesEagerFlagOwnership(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("GC_CITY_PATH", cityA)
 	tests := []struct {
 		name string
 		args []string
@@ -1814,6 +1826,7 @@ func TestE1EagerLazyControlDifferentialMatrix(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("GC_CITY_PATH", cityA)
 
 	tests := []struct {
 		name       string
@@ -2095,6 +2108,7 @@ func TestE1ScopeLookingArgsAfterLeafPassThrough(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("GC_CITY_PATH", cityA)
 
 	tests := []struct {
 		name string
@@ -2578,6 +2592,7 @@ func TestTryPackCommandFallbackReturnsTypedNonzeroOutcome(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("GC_CITY_PATH", cityPath)
 
 	var stdout, stderr bytes.Buffer
 	got := tryPackCommandFallback([]string{"backstage", "hello"}, &stdout, &stderr)

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1644,6 +1644,7 @@ dir = "frontend"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling([]string{"frontend/worker", "ship feature"}, false, false, true, "", nil, "", true, false, false, "", false, false, false, "", "", &stdout, &stderr)
@@ -1715,6 +1716,7 @@ mode = "on_demand"
 	}
 	writeBuiltinImportsLock(t, cityDir, "core")
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling([]string{"worker", "ship feature"}, false, false, true, "", nil, "", true, false, false, "", false, false, false, "", "", &stdout, &stderr)
@@ -1839,6 +1841,7 @@ dir = "frontend"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 	return cityDir
 }
 
@@ -1959,6 +1962,7 @@ func TestCmdSlingInlineBeadRigScopedBdProvider(t *testing.T) {
 	calls := installCaptureBdRunner(t)
 
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling([]string{"frontend/worker", "ship feature"}, false, false, true, "", nil, "", true, false, false, "", false, false, false, "", "", &stdout, &stderr)
@@ -1989,10 +1993,11 @@ func TestCmdSlingInlineBeadBareTargetFromRigCwdBdProvider(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_BEADS", "bd")
 
-	_, rigDir := setupRigScopedBdCity(t)
+	cityDir, rigDir := setupRigScopedBdCity(t)
 	calls := installCaptureBdRunner(t)
 
 	t.Chdir(rigDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling([]string{"worker", "ship feature"}, false, false, true, "", nil, "", true, false, false, "", false, false, false, "", "", &stdout, &stderr)
@@ -2962,6 +2967,7 @@ sling_query = "true"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(


### PR DESCRIPTION
## Summary

Part of the `ga-klo4gz` ambient-city-discovery test migration. Batch 6/N: adds `t.Setenv("GC_CITY_PATH", dir)` immediately after each test's existing cwd/temp-city setup across 2 files, so `resolveCity()` resolves via the explicit-env step instead of the ambient upward-walk step (step 10) that `ga-klo4gz`'s guard will refuse in test binaries.

- `cmd_sling_test.go` (6 sites): `TestCmdSlingUsesRigScopedFileStoreForBuiltInRouting`, `TestCmdSlingDefaultFormulaDoesNotMaterializePoolSession`, `setupCmdSlingBeadExistsFixture` (shared helper), `TestCmdSlingInlineBeadRigScopedBdProvider`, `TestCmdSlingInlineBeadBareTargetFromRigCwdBdProvider` (also had to stop discarding `setupRigScopedBdCity`'s city-dir return value via `_`, since the test only chdirs into the rig subdir, not the city root), `TestCmdSlingForceMissingBeadPrintsAutoConvoyWarning`.
- `cmd_commands_test.go` (5 sites): `TestE1LazyMissingTreeMatchesEagerFlagOwnership`, `TestE1EagerLazyControlDifferentialMatrix`, `TestE1ScopeLookingArgsAfterLeafPassThrough`, `TestTryPackCommandFallbackReturnsTypedNonzeroOutcome` — straightforward env fix. `TestPackCommandExitHelper` needed a different fix: it's the re-exec entry point for 3 subprocess-driving tests (`exec.Command(os.Args[0], ...)`), and that subprocess's own `TestMain` unconditionally scrubs `GC_CITY_PATH` via `clearProcessLiveEnvForTests()` before the test body runs, regardless of how the parent set `cmd.Env` — so the override has to be restored *inside* `TestPackCommandExitHelper` itself (derived from `os.Getwd()`, since `cmd.Dir` already pins the child's cwd to the intended city) rather than threaded through the parent's env/argv. Same failure category `cmd_bd_test.go` hit in batch 5 (env-clearing defeats the standard env fix for subprocess-driving tests), just requiring the fix at the re-exec entry point instead of via `--city`.

`TestE1PreLeafBooleanHelpNoScopeEager` is **excluded**: true ambient conflict (its whole point is exercising the no-explicit-scope path), so it fails identically with or without this migration and is left for the guard's own landing PR.

Guard itself is **not included** — reserved for its own PR per the mayor's sequencing ruling (mail `gm-wisp-0zj3zar`). Full-suite canary validation surfaced 7 more out-of-scope failures beyond this batch's target files, filed as `ga-klo4gz.8` (batch 7/N): `cmd_graph_test.go`, `metrics_lifecycle_test.go`, `root_argv_test.go`, and a residual `main_test.go` site.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/gc/...` clean
- [x] Both-ways-green: full `cmd/gc` suite passes with the canary guard (`isTestBinary()` gate on `resolveContextFromDir` step 10) applied locally and uncommitted (12 failures, all reconciled against known exclusions + `ga-klo4gz.8`)
- [x] Full `cmd/gc` suite passes clean on plain `origin/main` + this diff alone (293.163s, 0 failures)
- [x] Pre-push fast suite (`scripts/test-local-parallel fast`) passed