### PR TITLE
perf(cli): reuse the write-guard's store read in the bd close gate

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -263,6 +263,14 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	//
 	// Note: gc bd show (read passthrough) does NOT have this guard and still
 	// substring-resolves. That is intentional — reads are non-destructive.
+	//
+	// guardStore/guardBeads capture the store this guard opens and the beads
+	// it reads so the work-record close gate below can reuse them instead of
+	// opening the store and re-fetching the same bead a second time.
+	var (
+		guardStore beads.Store
+		guardBeads map[string]beads.Bead
+	)
 	if writeIDs, writeOK, ambiguous := bdMutationWriteIDs(bdArgs); writeOK {
 		if ambiguous {
 			fmt.Fprintf(stderr, "gc bd: cannot safely verify bead IDs (unrecognized flag in args %v); aborting to prevent substring-resolution mutation of the wrong bead\n", bdArgs) //nolint:errcheck // best-effort stderr
@@ -273,13 +281,18 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 			// Store-unavailable: we cannot verify, but we must not block
 			// legitimate writes. Fall through; bd will error on actual problems.
 			if storeErr == nil {
+				guardStore = store
+				guardBeads = make(map[string]beads.Bead, len(writeIDs))
 				for _, id := range writeIDs {
-					_, getErr := store.Get(id)
+					bead, getErr := store.Get(id)
 					if errors.Is(getErr, beads.ErrIDCollision) {
 						// bd resolved a different bead — block the write to prevent
 						// mutating the wrong bead via substring resolution.
 						fmt.Fprintf(stderr, "gc bd: bead %q resolved to a different bead ID (substring collision); aborting to prevent mutating the wrong bead\n", id) //nolint:errcheck // best-effort stderr
 						return 1
+					}
+					if getErr == nil {
+						guardBeads[id] = bead
 					}
 					// ErrNotFound or any other error: bead may be absent, ephemeral,
 					// or the read seam differs from the write seam — fall through.
@@ -291,8 +304,10 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// Work-record close gate (ADR-0009): a close routed through the SDK seam
 	// must satisfy the typed work-record contract (gc.work_outcome present;
 	// shipped ⇒ gc.work_commit reachable on gc.work_branch). Warn-only by default;
-	// blocks the close only when GC_WORK_RECORD_ENFORCE is set.
-	if runWorkRecordCloseGate(bdArgs, target.ScopeRoot, cityPath, cfg, stderr) {
+	// blocks the close only when GC_WORK_RECORD_ENFORCE is set. Reuses the
+	// store/beads the write-ID guard above already opened and read, and the
+	// config the caller already loaded.
+	if runWorkRecordCloseGate(bdArgs, target.ScopeRoot, cityPath, cfg, guardStore, guardBeads, stderr) {
 		return 1
 	}
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -259,6 +259,14 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	//
 	// Note: gc bd show (read passthrough) does NOT have this guard and still
 	// substring-resolves. That is intentional — reads are non-destructive.
+	//
+	// guardStore/guardBeads capture the store this guard opens and the beads
+	// it reads so the work-record close gate below can reuse them instead of
+	// opening the store and re-fetching the same bead a second time.
+	var (
+		guardStore beads.Store
+		guardBeads map[string]beads.Bead
+	)
 	if writeIDs, writeOK, ambiguous := bdMutationWriteIDs(bdArgs); writeOK {
 		if ambiguous {
 			fmt.Fprintf(stderr, "gc bd: cannot safely verify bead IDs (unrecognized flag in args %v); aborting to prevent substring-resolution mutation of the wrong bead\n", bdArgs) //nolint:errcheck // best-effort stderr
@@ -269,13 +277,18 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 			// Store-unavailable: we cannot verify, but we must not block
 			// legitimate writes. Fall through; bd will error on actual problems.
 			if storeErr == nil {
+				guardStore = store
+				guardBeads = make(map[string]beads.Bead, len(writeIDs))
 				for _, id := range writeIDs {
-					_, getErr := store.Get(id)
+					bead, getErr := store.Get(id)
 					if errors.Is(getErr, beads.ErrIDCollision) {
 						// bd resolved a different bead — block the write to prevent
 						// mutating the wrong bead via substring resolution.
 						fmt.Fprintf(stderr, "gc bd: bead %q resolved to a different bead ID (substring collision); aborting to prevent mutating the wrong bead\n", id) //nolint:errcheck // best-effort stderr
 						return 1
+					}
+					if getErr == nil {
+						guardBeads[id] = bead
 					}
 					// ErrNotFound or any other error: bead may be absent, ephemeral,
 					// or the read seam differs from the write seam — fall through.
@@ -287,8 +300,9 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// Work-record close gate (ADR-0009): a close routed through the SDK seam
 	// must satisfy the typed work-record contract (gc.work_outcome present;
 	// shipped ⇒ gc.work_commit reachable on gc.work_branch). Warn-only by default;
-	// blocks the close only when GC_WORK_RECORD_ENFORCE is set.
-	if runWorkRecordCloseGate(bdArgs, target.ScopeRoot, cityPath, stderr) {
+	// blocks the close only when GC_WORK_RECORD_ENFORCE is set. Reuses the
+	// store/beads the write-ID guard above already opened and read.
+	if runWorkRecordCloseGate(bdArgs, target.ScopeRoot, cityPath, guardStore, guardBeads, stderr) {
 		return 1
 	}
 

--- a/cmd/gc/native_dolt_env_cfg_reuse_test.go
+++ b/cmd/gc/native_dolt_env_cfg_reuse_test.go
@@ -204,3 +204,64 @@ func TestWorkRecordCloseGateReusesTheLoadedCityConfig(t *testing.T) {
 		t.Fatalf("found %d config-carrying store open(s) in runWorkRecordCloseGate, want exactly 1", opens)
 	}
 }
+
+// The write-ID collision guard reads every bead a mutating `gc bd` invocation
+// targets, and the work-record close gate then reads that same set again for
+// the same IDs — so `gc bd close` opened the store twice and paid for the same
+// store.Get twice. runWorkRecordCloseGate accepts the guard's store and beads
+// to skip the second round trip, but accepting them only dedupes if doBd
+// actually hands them over: a refactor that drops the arguments back to nil
+// would restore the double read with the whole suite still green.
+func TestBdCloseGateReusesTheWriteGuardsStoreRead(t *testing.T) {
+	const (
+		callee        = "runWorkRecordCloseGate"
+		wantStoreArg  = "guardStore"
+		wantBeadsArg  = "guardBeads"
+		storeArgIndex = 4
+		beadsArgIndex = 5
+	)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "cmd_bd.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing cmd_bd.go: %v", err)
+	}
+
+	fn := findFuncDecl(file, "doBd")
+	if fn == nil {
+		t.Fatal("doBd not found in cmd_bd.go")
+	}
+
+	var calls int
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok || ident.Name != callee {
+			return true
+		}
+		calls++
+		if len(call.Args) != 7 {
+			t.Fatalf("%s: got %d args, want 7", callee, len(call.Args))
+		}
+		for _, want := range []struct {
+			index int
+			name  string
+		}{
+			{storeArgIndex, wantStoreArg},
+			{beadsArgIndex, wantBeadsArg},
+		} {
+			arg, ok := call.Args[want.index].(*ast.Ident)
+			if !ok || arg.Name != want.name {
+				t.Fatalf("doBd passes %s as %s arg %d; want the write-ID guard's %q, so the gate reuses the read it already paid for",
+					exprText(call.Args[want.index]), callee, want.index, want.name)
+			}
+		}
+		return true
+	})
+	if calls != 1 {
+		t.Fatalf("found %d %s call(s) in doBd, want exactly 1", calls, callee)
+	}
+}

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -183,22 +183,35 @@ func bdUpdateClosesStatus(bdArgs []string) bool {
 // `gc bd update --status=closed`) invocation closes against the work-record
 // contract. Best-effort: it never blocks on its own read failure. Returns
 // whether the close should be blocked (only when enforcement is enabled).
-func runWorkRecordCloseGate(bdArgs []string, scopeRoot, cityPath string, cfg *config.City, stderr io.Writer) bool {
+//
+// preOpened and preFetched let a caller that already opened the store and
+// fetched the target beads (e.g. the write-ID collision guard, which reads
+// the same beads for the same IDs immediately before this gate runs) hand
+// them in instead of paying a second openStoreAtForCity + store.Get round
+// trip. Both are optional (nil is fine): preOpened falls back to opening its
+// own store, and any ID missing from preFetched falls back to store.Get.
+func runWorkRecordCloseGate(bdArgs []string, scopeRoot, cityPath string, cfg *config.City, preOpened beads.Store, preFetched map[string]beads.Bead, stderr io.Writer) bool {
 	if _, ok := workRecordCloseTargets(bdArgs); !ok {
 		return false
 	}
-	store, err := openStoreAtForCityWithConfig(scopeRoot, cityPath, cfg)
-	if err != nil {
-		// Cannot verify — never block a close on our own read failure.
-		return false
+	store := preOpened
+	if store == nil {
+		var err error
+		store, err = openStoreAtForCityWithConfig(scopeRoot, cityPath, cfg)
+		if err != nil {
+			// Cannot verify — never block a close on our own read failure.
+			return false
+		}
 	}
-	return evaluateWorkRecordCloseGate(bdArgs, store, scopeRoot, workRecordEnforceEnabled(), stderr)
+	return evaluateWorkRecordCloseGate(bdArgs, store, preFetched, scopeRoot, workRecordEnforceEnabled(), stderr)
 }
 
 // evaluateWorkRecordCloseGate is the store-driven core of the close gate, split
 // from the IO wrapper so it is unit-testable with an in-memory store. It logs
-// each violation and reports whether the close should be blocked.
-func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, scopeRoot string, enforce bool, stderr io.Writer) (block bool) {
+// each violation and reports whether the close should be blocked. preFetched
+// (optional) supplies beads already read by an earlier guard in this same
+// invocation, avoiding a duplicate store.Get for the same ID.
+func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, preFetched map[string]beads.Bead, scopeRoot string, enforce bool, stderr io.Writer) (block bool) {
 	ids, ok := workRecordCloseTargets(bdArgs)
 	if !ok {
 		return false
@@ -208,8 +221,15 @@ func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, scopeRoot s
 		mode = "enforced"
 	}
 	for _, id := range ids {
-		bead, getErr := store.Get(id)
-		if getErr != nil || !isWorkRecordGatedBead(bead) {
+		bead, cached := preFetched[id]
+		if !cached {
+			var getErr error
+			bead, getErr = store.Get(id)
+			if getErr != nil {
+				continue
+			}
+		}
+		if !isWorkRecordGatedBead(bead) {
 			continue
 		}
 		var projectionErr error

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -182,22 +182,35 @@ func bdUpdateClosesStatus(bdArgs []string) bool {
 // `gc bd update --status=closed`) invocation closes against the work-record
 // contract. Best-effort: it never blocks on its own read failure. Returns
 // whether the close should be blocked (only when enforcement is enabled).
-func runWorkRecordCloseGate(bdArgs []string, scopeRoot, cityPath string, stderr io.Writer) bool {
+//
+// preOpened and preFetched let a caller that already opened the store and
+// fetched the target beads (e.g. the write-ID collision guard, which reads
+// the same beads for the same IDs immediately before this gate runs) hand
+// them in instead of paying a second openStoreAtForCity + store.Get round
+// trip. Both are optional (nil is fine): preOpened falls back to opening its
+// own store, and any ID missing from preFetched falls back to store.Get.
+func runWorkRecordCloseGate(bdArgs []string, scopeRoot, cityPath string, preOpened beads.Store, preFetched map[string]beads.Bead, stderr io.Writer) bool {
 	if _, ok := workRecordCloseTargets(bdArgs); !ok {
 		return false
 	}
-	store, err := openStoreAtForCity(scopeRoot, cityPath)
-	if err != nil {
-		// Cannot verify — never block a close on our own read failure.
-		return false
+	store := preOpened
+	if store == nil {
+		var err error
+		store, err = openStoreAtForCity(scopeRoot, cityPath)
+		if err != nil {
+			// Cannot verify — never block a close on our own read failure.
+			return false
+		}
 	}
-	return evaluateWorkRecordCloseGate(bdArgs, store, scopeRoot, workRecordEnforceEnabled(), stderr)
+	return evaluateWorkRecordCloseGate(bdArgs, store, preFetched, scopeRoot, workRecordEnforceEnabled(), stderr)
 }
 
 // evaluateWorkRecordCloseGate is the store-driven core of the close gate, split
 // from the IO wrapper so it is unit-testable with an in-memory store. It logs
-// each violation and reports whether the close should be blocked.
-func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, scopeRoot string, enforce bool, stderr io.Writer) (block bool) {
+// each violation and reports whether the close should be blocked. preFetched
+// (optional) supplies beads already read by an earlier guard in this same
+// invocation, avoiding a duplicate store.Get for the same ID.
+func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, preFetched map[string]beads.Bead, scopeRoot string, enforce bool, stderr io.Writer) (block bool) {
 	ids, ok := workRecordCloseTargets(bdArgs)
 	if !ok {
 		return false
@@ -207,8 +220,15 @@ func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, scopeRoot s
 		mode = "enforced"
 	}
 	for _, id := range ids {
-		bead, getErr := store.Get(id)
-		if getErr != nil || !isWorkRecordGatedBead(bead) {
+		bead, cached := preFetched[id]
+		if !cached {
+			var getErr error
+			bead, getErr = store.Get(id)
+			if getErr != nil {
+				continue
+			}
+		}
+		if !isWorkRecordGatedBead(bead) {
 			continue
 		}
 		var projectionErr error

--- a/cmd/gc/work_record_gate_test.go
+++ b/cmd/gc/work_record_gate_test.go
@@ -321,7 +321,7 @@ func TestEvaluateWorkRecordCloseGate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var stderr strings.Builder
-			block := evaluateWorkRecordCloseGate(tc.args, newStore(), t.TempDir(), tc.enforce, &stderr)
+			block := evaluateWorkRecordCloseGate(tc.args, newStore(), nil, t.TempDir(), tc.enforce, &stderr)
 			if block != tc.wantBlock {
 				t.Fatalf("block = %v, want %v; stderr=%s", block, tc.wantBlock, stderr.String())
 			}
@@ -368,11 +368,60 @@ func TestEvaluateWorkRecordCloseGateAtomicShippedUpdate(t *testing.T) {
 		"--status=closed",
 	}
 	var stderr strings.Builder
-	if block := evaluateWorkRecordCloseGate(args, store, repoDir, true, &stderr); block {
+	if block := evaluateWorkRecordCloseGate(args, store, nil, repoDir, true, &stderr); block {
 		t.Fatalf("valid atomic shipped close blocked; stderr=%s", stderr.String())
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("valid atomic shipped close warned: %q", got)
+	}
+}
+
+// panicOnGetStore embeds a nil beads.Store and overrides Get to panic. It
+// proves a code path never falls back to the store for a given ID — used to
+// assert the close gate actually consumes preFetched beads instead of
+// re-reading them: gc bd close previously paid for the same store.Get twice,
+// once in the write-ID guard and once in this gate.
+type panicOnGetStore struct{ beads.Store }
+
+func (panicOnGetStore) Get(id string) (beads.Bead, error) {
+	panic("store.Get called for id " + id + ": preFetched bead should have been used")
+}
+
+func TestEvaluateWorkRecordCloseGateUsesPreFetchedBead(t *testing.T) {
+	preFetched := map[string]beads.Bead{
+		"wr-shipped-nocommit": {ID: "wr-shipped-nocommit", Type: "task", Status: "in_progress", Metadata: map[string]string{beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped}},
+	}
+	var stderr strings.Builder
+	block := evaluateWorkRecordCloseGate([]string{"close", "wr-shipped-nocommit"}, panicOnGetStore{}, preFetched, t.TempDir(), true, &stderr)
+	if !block {
+		t.Fatalf("expected block=true for shipped-without-commit, got false; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "work-record gate (enforced)") {
+		t.Fatalf("expected enforced gate output, got %q", stderr.String())
+	}
+}
+
+// TestRunWorkRecordCloseGateReusesPreOpenedStore proves runWorkRecordCloseGate
+// never calls openStoreAtForCity when handed a preOpened store — it's the IO
+// wrapper's half of the dedup (evaluateWorkRecordCloseGate proves the
+// preFetched-bead half above). cityPath is deliberately bogus: opening a
+// real store at it would fail, causing the gate to fail open (block=false, no
+// stderr) — indistinguishable from a no-op success. Asserting a violation
+// fires instead proves preOpened/preFetched were actually used, not silently
+// bypassed by a failed fallback open.
+func TestRunWorkRecordCloseGateReusesPreOpenedStore(t *testing.T) {
+	preFetched := map[string]beads.Bead{
+		"wr-shipped-nocommit": {ID: "wr-shipped-nocommit", Type: "task", Status: "in_progress", Metadata: map[string]string{beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped}},
+	}
+	var stderr strings.Builder
+	const bogusCityPath = "/nonexistent/does-not-exist"
+	t.Setenv(workRecordEnforceEnvVar, "1")
+	block := runWorkRecordCloseGate([]string{"close", "wr-shipped-nocommit"}, t.TempDir(), bogusCityPath, nil, panicOnGetStore{}, preFetched, &stderr)
+	if !block {
+		t.Fatalf("expected block=true for shipped-without-commit, got false (fallback store open may have silently swallowed the preOpened store); stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "work-record gate (enforced)") {
+		t.Fatalf("expected enforced gate output, got %q", stderr.String())
 	}
 }
 

--- a/cmd/gc/work_record_gate_test.go
+++ b/cmd/gc/work_record_gate_test.go
@@ -321,7 +321,7 @@ func TestEvaluateWorkRecordCloseGate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var stderr strings.Builder
-			block := evaluateWorkRecordCloseGate(tc.args, newStore(), t.TempDir(), tc.enforce, &stderr)
+			block := evaluateWorkRecordCloseGate(tc.args, newStore(), nil, t.TempDir(), tc.enforce, &stderr)
 			if block != tc.wantBlock {
 				t.Fatalf("block = %v, want %v; stderr=%s", block, tc.wantBlock, stderr.String())
 			}
@@ -368,11 +368,60 @@ func TestEvaluateWorkRecordCloseGateAtomicShippedUpdate(t *testing.T) {
 		"--status=closed",
 	}
 	var stderr strings.Builder
-	if block := evaluateWorkRecordCloseGate(args, store, repoDir, true, &stderr); block {
+	if block := evaluateWorkRecordCloseGate(args, store, nil, repoDir, true, &stderr); block {
 		t.Fatalf("valid atomic shipped close blocked; stderr=%s", stderr.String())
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("valid atomic shipped close warned: %q", got)
+	}
+}
+
+// panicOnGetStore embeds a nil beads.Store and overrides Get to panic. It
+// proves a code path never falls back to the store for a given ID — used to
+// assert the close gate actually consumes preFetched beads instead of
+// re-reading them: gc bd close previously paid for the same store.Get twice,
+// once in the write-ID guard and once in this gate.
+type panicOnGetStore struct{ beads.Store }
+
+func (panicOnGetStore) Get(id string) (beads.Bead, error) {
+	panic("store.Get called for id " + id + ": preFetched bead should have been used")
+}
+
+func TestEvaluateWorkRecordCloseGateUsesPreFetchedBead(t *testing.T) {
+	preFetched := map[string]beads.Bead{
+		"wr-shipped-nocommit": {ID: "wr-shipped-nocommit", Type: "task", Status: "in_progress", Metadata: map[string]string{beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped}},
+	}
+	var stderr strings.Builder
+	block := evaluateWorkRecordCloseGate([]string{"close", "wr-shipped-nocommit"}, panicOnGetStore{}, preFetched, t.TempDir(), true, &stderr)
+	if !block {
+		t.Fatalf("expected block=true for shipped-without-commit, got false; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "work-record gate (enforced)") {
+		t.Fatalf("expected enforced gate output, got %q", stderr.String())
+	}
+}
+
+// TestRunWorkRecordCloseGateReusesPreOpenedStore proves runWorkRecordCloseGate
+// never calls openStoreAtForCity when handed a preOpened store — it's the IO
+// wrapper's half of the dedup (evaluateWorkRecordCloseGate proves the
+// preFetched-bead half above). cityPath is deliberately bogus: opening a
+// real store at it would fail, causing the gate to fail open (block=false, no
+// stderr) — indistinguishable from a no-op success. Asserting a violation
+// fires instead proves preOpened/preFetched were actually used, not silently
+// bypassed by a failed fallback open.
+func TestRunWorkRecordCloseGateReusesPreOpenedStore(t *testing.T) {
+	preFetched := map[string]beads.Bead{
+		"wr-shipped-nocommit": {ID: "wr-shipped-nocommit", Type: "task", Status: "in_progress", Metadata: map[string]string{beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped}},
+	}
+	var stderr strings.Builder
+	const bogusCityPath = "/nonexistent/does-not-exist"
+	t.Setenv(workRecordEnforceEnvVar, "1")
+	block := runWorkRecordCloseGate([]string{"close", "wr-shipped-nocommit"}, t.TempDir(), bogusCityPath, panicOnGetStore{}, preFetched, &stderr)
+	if !block {
+		t.Fatalf("expected block=true for shipped-without-commit, got false (fallback store open may have silently swallowed the preOpened store); stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "work-record gate (enforced)") {
+		t.Fatalf("expected enforced gate output, got %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
**Part 2 of 2 — `gc bd` invocation cost.** **#4723** removes redundant *config
loads* from the same invocation; this PR removes a duplicate *store open + bead
read* from the close gate. They are separate wins with separate evidence, but
they overlap in code and are best reviewed as a pair — both change the
signature of `runWorkRecordCloseGate`, so whichever merges second needs a
rebase (details under *Related work*). Earlier and already merged in this same
line of work: #4565.

---

## Summary

`gc bd close` spawns five `bd` subprocesses. Two of them are a verbatim repeat
of the two before them:

```
context --json
show --json <id>
context --json      <- duplicate
show --json <id>    <- duplicate
close <id>
```

The exact-ID write guard opens a store and reads every bead the invocation is
about to mutate. The work-record close gate then runs immediately after and
does the same two things again — its own `openStoreAtForCity`, its own
`store.Get` of the same id — because the two were written independently and
neither knows the other ran.

This threads the store and beads the guard already opened into
`runWorkRecordCloseGate`. **`gc bd close` now spawns three `bd` subprocesses
instead of five.** No output changes, no new flag, no new user-facing surface.

## What it costs today

Counted with a `bd` shim on `PATH` that records each invocation and execs the
real `bd`, against this branch and against pristine `main`:

| verb | `main` | this branch |
| --- | ---: | ---: |
| `gc bd close` | 5 subprocesses | **3** |
| `gc bd show` | 1 | 1 |

A count is the honest measurement here: it is what the change actually
controls, and unlike wall clock it cannot be distorted by load on the
measuring box.

For the wall-clock share those two subprocesses represent, profiling `gc bd
close` on a clean, isolated city (n=21, p50 2779.3 ms) attributed the
duplicate pair as follows:

| component | ms | share |
| --- | ---: | ---: |
| close-gate `store.Get` (duplicate) | 550.4 | 19.8% |
| close-gate `openStore` (duplicate) | 373.0 | 13.4% |
| **duplicate pair total** | **923.4** | **33.2%** |

**Read that as an attributed upper bound, not a measured speedup.** It is the
share of wall clock those two operations accounted for in the profile; it is
not an end-to-end A/B of the two binaries. The absolute milliseconds are
inflated — the box was under load ~9.5 — so the proportion is the meaningful
figure and the absolutes are not. An interleaved end-to-end A/B needs a quiet
machine; happy to produce one before merge if you would like it.

## Behavior

Given a `gc bd close` whose write-ID guard successfully opened a store and
read the target bead, when the work-record close gate runs, then it evaluates
the bead the guard already fetched instead of opening a second store and
re-reading it.

Given a `gc bd close` where the guard's store open failed or the guard was
skipped (`preOpened` is nil), when the gate runs, then it opens its own store
exactly as before.

Given an id the gate must check that is absent from `preFetched`, when the
gate evaluates it, then it falls back to `store.Get` for that id.

Given no store is available at all, when the gate runs, then it still fails
open and never blocks a close on its own read failure.

Given a `gc bd update`, when it runs, then its subprocess count is unchanged —
it shares the write-ID guard but does not reach the close gate.

Given `gc bd show`, `list`, `ready` or any read passthrough, then nothing about
them changes.

## Evidence

- **Two tests pin the dedup by construction.** Both hand the gate a store whose
  `Get` panics, so a silent fallback to a second read fails loudly instead of
  passing quietly: `TestEvaluateWorkRecordCloseGateUsesPreFetchedBead` (the
  bead half) and `TestRunWorkRecordCloseGateReusesPreOpenedStore` (the store
  half). The second uses a deliberately bogus `cityPath`, because a fallback
  open there would fail and make the gate fail open — `block=false`, no stderr
  — which is indistinguishable from a no-op success. Asserting that a violation
  *does* fire proves the pre-opened store was really used.
- **Output is byte-identical.** Comparing this build against pristine `main`
  across `show --json`, `show`, `list --json`, `ready --json`,
  `update --priority`, `close` and `update --status=closed`: stdout, stderr and
  exit code match on all seven shapes, with **no** timestamp normalisation.
  Each shape also ran the baseline binary twice as a determinism control, so a
  shape that was never deterministic could not be mistaken for a passing diff.
- **Full `./cmd/gc/` suite, both arms, no skip regex on either.** Baseline is
  pristine `main` at `431711fe0`; the patched arm is that same commit plus this
  fix. **Baseline 56 failures, patched 54, and the set of tests failing on the
  patched arm but not the baseline is empty.**

  Two caveats I would rather state than have you find. First, 54 pre-existing
  failures is not a healthy suite — this local environment fails a large block
  of dolt- and rig-scoped store tests on pristine `main` before any patch is
  applied, so I gated on the *set difference* between arms rather than on a
  green run. Second, two tests failed on the baseline and passed on the patched
  arm: `TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds`
  and `TestStopManagedCityDoesNotUseStartupOrDriftTimeouts`. **I am not claiming
  those as fixes.** Both are timeout-sensitive, the two arms ran back-to-back
  under different machine load, and there is no causal path from deduplicating a
  store read to managed-city stop or drift-check timing. Treat them as load
  noise in the baseline direction.

  The gated commit differs from this branch only in comment text (internal
  tracker IDs removed); the diff between them touches no executable line.
- `go build ./cmd/gc/`, `gofmt` and `go vet` clean.

## Why it's safe

Both new parameters are optional and nil-safe, so every path that does not
have a pre-opened store behaves exactly as it does today — including the
fail-open contract, which is the gate's whole safety property. The gate is
still the only thing deciding whether a close is blocked; this changes only
where it gets the bead from. `evaluateWorkRecordCloseGate` remains unit-testable
with an in-memory store, and the split between it and the IO wrapper is
unchanged.

The one thing to look at in review: the guard and the gate now share a store
handle within a single invocation. They already ran back-to-back against the
same city in the same process, so the bead either read is the same bead; the
change removes the second read, not a second point of truth.

## Scope

| file | change |
| --- | --- |
| `cmd/gc/cmd_bd.go` | capture the guard's store + fetched beads; pass them on |
| `cmd/gc/work_record_gate.go` | accept optional `preOpened` / `preFetched`, with fallbacks |
| `cmd/gc/work_record_gate_test.go` | two tests pinning the dedup |

## Related work

- #4723 removes redundant *config* loads from the same invocation. Different
  redundancy and a different cost centre, and the two compose — but **they
  overlap in code and will conflict textually.** Both change the signature of
  `runWorkRecordCloseGate`: #4723 adds a `cfg *config.City` parameter, this PR
  adds `preOpened beads.Store` and `preFetched map[string]beads.Bead`.
  Whichever merges second needs a rebase. I am happy to do that in whichever
  order you prefer rather than leave you a conflict — just say which.
- #4565 removed pack-command discovery from `gc bd` root construction.
- #1978 (now closed) tracked the broader per-invocation `bd` process and
  connection cost. This removes two of those processes from `close` but does
  not change the model.
- #4441 proposes routing hot `bd` reads to the warm controller. This adopts no
  part of that design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
