### PR TITLE
fix(orders): persist renudge-stale-human-gates ledger per send, not once at exit (#4770)

### DIFF
--- a/internal/bootstrap/packs/core/assets/scripts/renudge-stale-human-gates.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/renudge-stale-human-gates.sh
@@ -135,6 +135,15 @@ fi
 STATE="$(cat "$STATE_FILE" 2>/dev/null || true)"
 echo "$STATE" | jq -e 'type == "object"' >/dev/null 2>&1 || STATE='{}'
 
+# Atomic write of $STATE to disk: temp file in the same dir, then rename.
+# Called after EVERY successful send (not just once at exit) so a process
+# death mid-sweep loses at most the gate in flight, never the whole ledger.
+write_state() {
+    __write_state_tmp="$(mktemp "$PACK_STATE_DIR/.renudge-stale-human-gates-state.XXXXXX")"
+    printf '%s\n' "$STATE" > "$__write_state_tmp"
+    mv -f "$__write_state_tmp" "$STATE_FILE"
+}
+
 RENUDGED=0
 FAILED=0
 while IFS= read -r scope; do
@@ -216,6 +225,7 @@ Resolve with: gc bd gate resolve $gate_id"
         # undeliverable one surfaces and retries next sweep.
         if gc mail send "$ADDRESSEE" -s "$SUBJECT" -m "$BODY" --notify >/dev/null 2>&1; then
             STATE="$(echo "$STATE" | jq --arg k "$gate_id" --arg now "$NOW_ISO" '.[$k] = $now')"
+            write_state
             RENUDGED=$((RENUDGED + 1))
         else
             echo "renudge-stale-human-gates: FAILED to re-notify addressee '$ADDRESSEE' of stale human gate $gate_id (will retry next sweep)" >&2
@@ -231,10 +241,7 @@ RETENTION_S="$(duration_to_seconds "$RETENTION")"
 STATE="$(echo "$STATE" | jq --argjson keep "$RETENTION_S" \
     'with_entries(select((now - (.value | fromdateiso8601)) <= $keep))')" || true
 
-# Atomic write: temp file in the same dir, then rename.
-TMP="$(mktemp "$PACK_STATE_DIR/.renudge-stale-human-gates-state.XXXXXX")"
-printf '%s\n' "$STATE" > "$TMP"
-mv -f "$TMP" "$STATE_FILE"
+write_state
 
 if [ "$RENUDGED" -gt 0 ]; then
     echo "renudge-stale-human-gates: re-notified $RENUDGED stale human gate addressee(s)"


### PR DESCRIPTION
## Summary

Fixes #4770. `renudge-stale-human-gates.sh` wrote its per-gate dedup ledger to disk exactly once, at
the end of the sweep, after every gate had been processed — so the mail was durable before the
record that it was sent. A process death anywhere between the first successful `gc mail send` and
that final write loses every already-sent gate's ledger entry, and the next 5-minute cooldown run
re-nudges all of them.

This is the abnormal-death analogue of the loud-fail argument #4543 made and #4553 (which introduced
this script) adopted for the documented-non-zero-exit case; this PR extends the same "state durable
before the process can end" reasoning to death the script never gets a chance to handle at all.

## Fix

Extracted the existing atomic mktemp+mv write into a `write_state()` helper and call it immediately
after each successful `gc mail send`, in addition to the existing end-of-sweep call (now routed
through the same helper) before the retention prune. Additive, 3 hunks, 11 lines added / 4 removed —
the 4 removed lines are the old single end-of-sweep write, replaced by a call to the new helper.
Dedup semantics, closed-gate re-verification, and the one-reminder-per-gate-per-hour cadence are
untouched.

**Cost, stated deliberately rather than left to be discovered:** this turns one mktemp+rename per
*sweep* into one per *successful send*. On a city with N stale human gates that is N atomic writes
per sweep instead of 1 — in our own deployment, roughly 25 per 5-minute sweep rather than 1. We
think that is the right trade: the ledger is a small JSON object bounded by
`GC_STALE_GATE_STATE_RETENTION` (default 24h), the write is a few hundred bytes to the pack state
dir, and it only occurs on sweeps that actually send mail — while the failure it prevents is a
re-notification storm at 12x the intended cadence aimed at a human. Worth flagging because this
script runs under a controller exec-timeout, so its own runtime budget is not free. If you would
rather bound it (e.g. write at most once per K sends, or only when the ledger has grown), say so and
I will adjust — but a partial ledger is what makes the fix work, so batching re-opens a smaller
version of the same window.

## Testing

RED, on unmodified current main (`679e6e46`), isolated harness — fake `gc` first on `PATH`; no live
order run, gate, bead or mailbox touched. Each iteration is a pair: run 1 killed ~0.35s after its
first successful send, run 2 the next cooldown sweep seconds later. With `RENUDGE_INTERVAL=1h`, no
gate sent in run 1 may be sent again in run 2.

```
iter 1: rc1=137  state-after-kill=ABSENT  run1-sent=[g1]     run2-sent=[g1 g2 g3 g4 g5]  RED (re-sent: g1)
iter 2: rc1=137  state-after-kill=ABSENT  run1-sent=[g1 g2]  run2-sent=[g1 g2 g3 g4 g5]  RED (re-sent: g1 g2)
iter 3: rc1=137  state-after-kill=ABSENT  run1-sent=[g1]     run2-sent=[g1 g2 g3 g4 g5]  RED (re-sent: g1)
iter 4: rc1=137  state-after-kill=ABSENT  run1-sent=[g1 g2]  run2-sent=[g1 g2 g3 g4 g5]  RED (re-sent: g1 g2)
iter 5: rc1=137  state-after-kill=ABSENT  run1-sent=[g1 g2]  run2-sent=[g1 g2 g3 g4 g5]  RED (re-sent: g1 g2)
TOTAL: 0 clean / 5 re-send, over 5 iterations
```

GREEN, this branch, identical setup and kill timing:

```
iter 1: rc1=137  state-after-kill={"g1":...}          run1-sent=[g1]     run2-sent=[g2 g3 g4 g5]  GREEN
iter 2: rc1=137  state-after-kill={"g1":...,"g2":...} run1-sent=[g1 g2]  run2-sent=[g3 g4 g5]     GREEN
iter 3: rc1=137  state-after-kill={"g1":...,"g2":...} run1-sent=[g1 g2]  run2-sent=[g3 g4 g5]     GREEN
iter 4: rc1=137  state-after-kill={"g1":...,"g2":...} run1-sent=[g1 g2]  run2-sent=[g3 g4 g5]     GREEN
iter 5: rc1=137  state-after-kill={"g1":...,"g2":...} run1-sent=[g1 g2]  run2-sent=[g3 g4 g5]     GREEN
TOTAL: 5 clean / 0 re-send, over 5 iterations
```

5/5 both directions, deterministic. The `run2-sent` column is the load-bearing half: the gates that
were genuinely never sent are still sent on the next sweep, so the fix is scoped rather than merely
permissive — it suppresses re-sends, not sends.

- [x] `bash -n` on the fixed script — clean
- [x] RED/GREEN floor re-derived at this PR's own base (`679e6e46`), 5 runs each direction
- [ ] `go test ./internal/bootstrap/packs/...` — could not run locally: `go-icu-regex` fails to cgo-compile
      on this machine (`unicode/regex.h` not found). A/B-verified identical on unmodified stock, so it is
      environmental and not this change; no Go code is touched. Deferred to CI.

## Checklist

- [x] Linked an issue (#4770, opened alongside this PR)
- [x] Added test evidence for the behavior change (RED/GREEN transcripts above). A Go behavioral test
      mirroring `TestRenudgeStaleHumanGatesScriptContract` in `pack_orders_test.go` would be a reasonable
      follow-up but is not required to land this fix — the existing contract test does not exercise
      abnormal death, and the shell harness above covers that case without teaching the Go harness to
      SIGKILL a subprocess.
- [x] No breaking changes — purely additive within the same script; no CLI surface, no other file touched.
