### PR TITLE
test(cmd/gc): migrate two more wall-clock deadlines to hangBudget

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -477,7 +477,13 @@ func TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving(t *test
 		t.Fatalf("stale runtime update did not hide alpha/helper; agents = %+v", got.Agents)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// hangBudget, not a short fixed deadline: nothing in this test asserts how
+	// long WaitForAgentVisibility takes, only that it eventually returns nil
+	// once the fresh runtime update lands below. The 100ms window right after
+	// this IS a negative assertion ("must not resolve before the fresh update
+	// lands") and must not be migrated -- see cmd/gc/hangbudget_test.go's
+	// carve-out doc comment.
+	ctx, cancel := context.WithTimeout(context.Background(), hangBudget)
 	defer cancel()
 	waitErr := make(chan error, 1)
 	go func() {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -4903,8 +4903,19 @@ func TestCityRuntimeReloadDrainShortCircuitsOnTickContextCancel(t *testing.T) {
 	lastProviderName := "fake"
 	start := time.Now()
 	cr.reloadConfig(ctx, &lastProviderName, cityPath)
-	if elapsed := time.Since(start); elapsed >= reloadOrderDrainTimeout {
-		t.Fatalf("reload drain took %s after tick context cancellation, want less than %s", elapsed, reloadOrderDrainTimeout)
+	// errs[0] below is the precise proof that the cancellation short-circuit
+	// fired: blockingOrderDispatcher.drain records ctx.Err() synchronously at
+	// entry, before its select, so it reads context.Canceled regardless of
+	// which select arm later wins. elapsed is not a latency SLO here -- that
+	// claim belongs to reloadOrderDrainTimeout's own test,
+	// TestCityRuntimeReloadDrainBoundedByTimeout. It spans the whole
+	// reloadConfig call (config read, order rescan, drain), not just the
+	// drain select, so a tight bound fails on unrelated I/O contention
+	// without proving anything errs[0] doesn't already prove on its own; it
+	// stays only as a hang detector against the short-circuit regressing into
+	// blocking indefinitely.
+	if elapsed := time.Since(start); elapsed > hangBudget {
+		t.Fatalf("reload drain took %s after tick context cancellation, want it to return well inside the hang budget", elapsed)
 	}
 	errs := od.drainContextErrors()
 	if len(errs) == 0 || !errors.Is(errs[0], context.Canceled) {


### PR DESCRIPTION
## Summary

Fixes 2 of the 5 tests in ga-f5clwo (wall-clock-bound tests producing false reds under load) by correcting their assertion SHAPE, per the bead's explicit "not a request to bump timeouts" constraint.

- **`TestCityRuntimeReloadDrainShortCircuitsOnTickContextCancel`**: the elapsed check duplicated as a latency SLO what the very next line already proves structurally (`errs[0]==context.Canceled`, captured synchronously at entry by the test fake regardless of scheduling). Loosened to `hangBudget` — it now only guards against the short-circuit regressing into an indefinite block.
- **`TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving`**: the outer `context.WithTimeout` is pure hang-detector shape (test never measures elapsed time). Migrated to `hangBudget`. Left the sibling 100ms negative-assertion window in the same function untouched — it's the substance of that assertion, not a wait to be budgeted.

Both changes follow the established shape/rationale from #4745 and #4734 (input vs. observation vs. negative-assertion framework).

The remaining test in ga-f5clwo's original 5 (`TestResolveDoltConnectionTargetManagedCity_EnvOverride`) doesn't fit this bead's shape — zero wall-clock assertions in the test itself, the flake is a hardcoded 250ms `net.DialTimeout` in production code with no injection seam. Split out to ga-qro1xt.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean (full repo)
- [x] `make test-fast-parallel` — all 10 jobs pass (twice: once locally, once via push-gate hook)
- [x] Target tests pass at `-count=1` under normal conditions
- [x] Target tests + sibling `TestCityRuntimeReloadDrainBoundedByTimeout` run 18/18 clean under synthetic single-core CPU starvation (test process + 12 burn loops taskset-pinned to one core), 2.5-3.9s each, well inside `hangBudget` (60s)

Refs: ga-f5clwo, ga-h51wa1, ga-o2bak3