### PR TITLE
Fix lifecycle worktree provisioning for existing worktrees

### DIFF
--- a/examples/lifecycle/packs/lifecycle/assets/scripts/worktree-setup.sh
+++ b/examples/lifecycle/packs/lifecycle/assets/scripts/worktree-setup.sh
@@ -38,8 +38,60 @@ else
     SYNC="${4:-}"
 fi
 
+append_exclude() {
+    PATTERN="$1"
+    grep -qxF "$PATTERN" "$EXCLUDE" 2>/dev/null || printf '%s\n' "$PATTERN" >> "$EXCLUDE"
+}
+
+# Idempotent: bead redirect, submodule init, and local excludes. Safe to
+# call on every invocation (fresh-create AND pre-existing-worktree), so a
+# worktree that already existed before this provisioning was added — or
+# whose redirect/excludes were later clobbered — converges on re-run
+# instead of staying stuck with whatever it had at creation time.
+ensure_worktree_provisioning() {
+    # Bead redirect for filesystem beads.
+    mkdir -p "$WT/.beads"
+    echo "$RIG_ROOT/.beads" > "$WT/.beads/redirect"
+
+    # Submodule init (best-effort).
+    git -C "$WT" submodule init 2>/dev/null || true
+
+    # Keep runtime ignores local to git metadata instead of mutating the tracked
+    # repository .gitignore.
+    EXCLUDE=$(git -C "$WT" rev-parse --git-path info/exclude)
+    case "$EXCLUDE" in
+        /*) ;;
+        *) EXCLUDE="$WT/$EXCLUDE" ;;
+    esac
+    mkdir -p "$(dirname "$EXCLUDE")"
+    touch "$EXCLUDE"
+
+    MARKER="# Gas City worktree infrastructure (local excludes)"
+    if ! grep -qF "$MARKER" "$EXCLUDE" 2>/dev/null; then
+        if [ -s "$EXCLUDE" ] && [ "$(tail -c 1 "$EXCLUDE" 2>/dev/null || true)" != "" ]; then
+            printf '\n' >> "$EXCLUDE"
+        fi
+        printf '%s\n' "$MARKER" >> "$EXCLUDE"
+    fi
+
+    append_exclude ".beads/redirect"
+    append_exclude ".beads/hooks/"
+    append_exclude ".beads/formulas/"
+    append_exclude ".logs/"
+    append_exclude "worktrees/"
+    append_exclude "__pycache__/"
+    append_exclude ".claude/"
+    append_exclude ".codex/"
+    append_exclude ".gemini/"
+    append_exclude ".opencode/"
+    append_exclude ".github/hooks/"
+    append_exclude ".github/copilot-instructions.md"
+    append_exclude "state.json"
+}
+
 # Idempotent: skip if worktree already exists.
 if [ -d "$WT/.git" ] || [ -f "$WT/.git" ]; then
+    ensure_worktree_provisioning
     [ "$SYNC" = "--sync" ] && { git -C "$WT" fetch origin 2>/dev/null; git -C "$WT" pull --rebase 2>/dev/null || true; }
     exit 0
 fi
@@ -111,49 +163,7 @@ if [ -n "$STAGE" ]; then
 fi
 trap - EXIT HUP INT TERM
 
-# Bead redirect for filesystem beads.
-mkdir -p "$WT/.beads"
-echo "$RIG_ROOT/.beads" > "$WT/.beads/redirect"
-
-# Submodule init (best-effort).
-git -C "$WT" submodule init 2>/dev/null || true
-
-# Keep runtime ignores local to git metadata instead of mutating the tracked
-# repository .gitignore.
-EXCLUDE=$(git -C "$WT" rev-parse --git-path info/exclude)
-case "$EXCLUDE" in
-    /*) ;;
-    *) EXCLUDE="$WT/$EXCLUDE" ;;
-esac
-mkdir -p "$(dirname "$EXCLUDE")"
-touch "$EXCLUDE"
-
-MARKER="# Gas City worktree infrastructure (local excludes)"
-if ! grep -qF "$MARKER" "$EXCLUDE" 2>/dev/null; then
-    if [ -s "$EXCLUDE" ] && [ "$(tail -c 1 "$EXCLUDE" 2>/dev/null || true)" != "" ]; then
-        printf '\n' >> "$EXCLUDE"
-    fi
-    printf '%s\n' "$MARKER" >> "$EXCLUDE"
-fi
-
-append_exclude() {
-    PATTERN="$1"
-    grep -qxF "$PATTERN" "$EXCLUDE" 2>/dev/null || printf '%s\n' "$PATTERN" >> "$EXCLUDE"
-}
-
-append_exclude ".beads/redirect"
-append_exclude ".beads/hooks/"
-append_exclude ".beads/formulas/"
-append_exclude ".logs/"
-append_exclude "worktrees/"
-append_exclude "__pycache__/"
-append_exclude ".claude/"
-append_exclude ".codex/"
-append_exclude ".gemini/"
-append_exclude ".opencode/"
-append_exclude ".github/hooks/"
-append_exclude ".github/copilot-instructions.md"
-append_exclude "state.json"
+ensure_worktree_provisioning
 
 # Optional sync.
 [ "$SYNC" = "--sync" ] && { git -C "$WT" fetch origin 2>/dev/null; git -C "$WT" pull --rebase 2>/dev/null || true; }

--- a/release-gates/ga-bgh2wi-lifecycle-worktree-provisioning-gate.md
+++ b/release-gates/ga-bgh2wi-lifecycle-worktree-provisioning-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: lifecycle worktree provisioning convergence
+
+Deploy bead: `ga-bgh2wi`
+Source bead: `ga-g8lt3x`
+Reviewed commit: `da9099c3c73609a9ecc45c796177cbf163ac8ff4`
+Reviewed commits: `31dc58d72`, `da9099c3c73609a9ecc45c796177cbf163ac8ff4`
+Planned deploy branch: `deploy/ga-bgh2wi-gate`
+Base: `origin/main` at `c31a67ea0fdbc13bff05b7a821cfead0d165dbc8`
+Gate evaluated: `2026-07-28`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the deployer role's release criteria, the source bead's done-when criteria,
+and the repository test policy in `TESTING.md`.
+
+## Result
+
+PASS.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first after `git fetch origin main`. `git merge-tree --write-tree origin/main da9099c3c73609a9ecc45c796177cbf163ac8ff4` exited 0 and produced merged tree `61de7fb992c0c890122e49eef7c5d0b7697408d9`. No self-rebase was needed. |
+| 1 | Review PASS present | PASS | `ga-bgh2wi` records `verdict: pass` for reviewed tip `da9099c3c73609a9ecc45c796177cbf163ac8ff4`; the reviewer independently checked the diff, reproduction, build, vet, style, security, and regression coverage. |
+| 2 | Acceptance criteria met | PASS | `ensure_worktree_provisioning` owns the bead redirect, submodule initialization, and local excludes; it is called from both the pre-existing-worktree early exit and fresh-create path, after the existence check. Tier A passed `TestLifecycleWorktreeSetupRedirectAppliesToPreExistingWorktree` and the fresh-create control `TestLifecycleWorktreeSetupBeadRedirect`. The related worktree tests also passed. |
+| 3 | Tests pass | PASS | `go build ./...` and `go vet ./...` passed. Documented `make test` passed with `34,129 PASS / 0 FAIL / 169 SKIP` tests (`163 PASS / 0 FAIL / 18 SKIP` packages). Documented per-PR Tier A `make test-acceptance` passed all 6 packages; structured replay recorded `344 PASS / 0 FAIL / 8 SKIP` tests. The fast-unit skips are the repository's documented process/integration/build-tag exclusions. Tier A's eight skips are seven explicit pending self-host UX tests and one opt-in live pack-registry smoke requiring `GC_TEST_GASCITY_PACKS_REGISTRY`; none touches the lifecycle worktree script or its tests. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report no style or security findings and no uncovered acceptance criteria; no HIGH finding remains open. |
+| 5 | Final branch is clean | PASS | The detached reviewed commit was clean before this checklist was added, and `git diff --check origin/main...da9099c3c73609a9ecc45c796177cbf163ac8ff4` passed. The deploy branch will contain only the reviewed two-commit series plus this gate checklist. |
+| 7 | Single feature theme | PASS | The series changes one lifecycle example script plus its acceptance tests. Both commits are the red/green pair for making worktree provisioning converge on pre-existing worktrees. |
+
+## Diff Scope
+
+```text
+examples/lifecycle/packs/lifecycle/assets/scripts/worktree-setup.sh | 96 ++++++++++--------
+test/acceptance/worktree_lifecycle_test.go                          | 110 +++++++++++++++++++++
+test/acceptance/worktree_test.go                                    | 15 ++-
+3 files changed, 175 insertions(+), 46 deletions(-)
+```
+
+## Focused Acceptance Evidence
+
+```text
+PASS TestLifecycleWorktreeSetupBeadRedirect
+PASS TestLifecycleWorktreeSetupRedirectAppliesToPreExistingWorktree
+PASS TestWorktreeBranchNamespacing
+PASS TestWorktreeIdempotent
+PASS TestWorktreeBeadRedirect
+```

--- a/test/acceptance/worktree_lifecycle_test.go
+++ b/test/acceptance/worktree_lifecycle_test.go
@@ -12,7 +12,6 @@ package acceptance_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -37,9 +36,7 @@ func lifecycleWorktreeSetupScript(t *testing.T) string {
 // (investigations/ga-58xwg1/repro_gascity_clean.sh) evaluates it.
 func runLifecycleScript(t *testing.T, script, repoDir, wt, agent string) {
 	t.Helper()
-	cmd := exec.Command("sh", script, repoDir, wt, agent, "--sync")
-	cmd.Env = os.Environ()
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runScriptCommand(script, repoDir, wt, agent); err != nil {
 		t.Logf("worktree-setup.sh exited non-zero (tracked separately, not asserted here): %v\n%s", err, out)
 	}
 }

--- a/test/acceptance/worktree_lifecycle_test.go
+++ b/test/acceptance/worktree_lifecycle_test.go
@@ -1,0 +1,113 @@
+//go:build acceptance_a
+
+// Lifecycle-example worktree acceptance tests.
+//
+// worktree-setup.sh in the "lifecycle" example pack
+// (examples/lifecycle/packs/lifecycle/assets/scripts/worktree-setup.sh) is
+// an independently maintained script, not the same file as the gastown
+// pack's embedded copy exercised by worktree_test.go -- the two happen to
+// share a name and structure but have separate histories. Kept in its own
+// file so the two script sources are never conflated.
+package acceptance_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+// lifecycleWorktreeSetupScript returns the path to the lifecycle example
+// pack's worktree-setup.sh as checked into this repo.
+func lifecycleWorktreeSetupScript(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(helpers.FindModuleRoot(), "examples", "lifecycle", "packs", "lifecycle", "assets", "scripts", "worktree-setup.sh")
+}
+
+// runLifecycleScript runs the lifecycle worktree-setup.sh script. Unlike
+// runScript (used for the gastown pack's copy), this does not fail the
+// test on a non-zero exit: this script currently exits 128 on every
+// invocation from an unrelated, separately-tracked issue (ga-g8lt3x's
+// "Out of scope" note) that is not this bead's deliverable. The exit is
+// logged for visibility; the actual pass/fail signal is the .beads/redirect
+// assertion each test makes afterward, exactly as the shell-level repro
+// (investigations/ga-58xwg1/repro_gascity_clean.sh) evaluates it.
+func runLifecycleScript(t *testing.T, script, repoDir, wt, agent string) {
+	t.Helper()
+	cmd := exec.Command("sh", script, repoDir, wt, agent, "--sync")
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Logf("worktree-setup.sh exited non-zero (tracked separately, not asserted here): %v\n%s", err, out)
+	}
+}
+
+// TestLifecycleWorktreeSetupBeadRedirect verifies that the lifecycle
+// example's worktree-setup.sh creates a .beads/redirect file pointing to
+// the rig's .beads directory on a fresh worktree. Control case -- must
+// keep passing across the ga-g8lt3x fix.
+func TestLifecycleWorktreeSetupBeadRedirect(t *testing.T) {
+	repoDir := t.TempDir()
+	git(t, repoDir, "init")
+	git(t, repoDir, "commit", "--allow-empty", "-m", "initial")
+
+	script := lifecycleWorktreeSetupScript(t)
+
+	wt := filepath.Join(t.TempDir(), "worktree")
+	runLifecycleScript(t, script, repoDir, wt, "polecat")
+
+	redirect := filepath.Join(wt, ".beads", "redirect")
+	data, err := os.ReadFile(redirect)
+	if err != nil {
+		t.Fatalf(".beads/redirect not created: %v", err)
+	}
+
+	want := repoDir + "/.beads"
+	if got := strings.TrimSpace(string(data)); got != want {
+		t.Fatalf(".beads/redirect = %q, want %q", got, want)
+	}
+}
+
+// TestLifecycleWorktreeSetupRedirectAppliesToPreExistingWorktree is a
+// regression test for ga-g8lt3x: a worktree created by any means other
+// than this script (a plain "git worktree add", an older script version,
+// or a redirect later clobbered) used to hit the early-exit branch and
+// skip the bead-redirect / local-excludes provisioning forever -- no
+// convergence, even across repeated pre_start invocations on the same
+// worktree.
+func TestLifecycleWorktreeSetupRedirectAppliesToPreExistingWorktree(t *testing.T) {
+	repoDir := t.TempDir()
+	git(t, repoDir, "init")
+	git(t, repoDir, "commit", "--allow-empty", "-m", "initial")
+
+	script := lifecycleWorktreeSetupScript(t)
+
+	wt := filepath.Join(t.TempDir(), "worktree")
+	// Simulate a worktree created by some other path -- the setup
+	// script has never touched it yet.
+	git(t, repoDir, "worktree", "add", "-b", "gc-agent-b", wt)
+
+	if _, err := os.Stat(filepath.Join(wt, ".beads", "redirect")); err == nil {
+		t.Fatal("redirect already present before setup script ran -- test setup is wrong")
+	}
+
+	// pre_start runs the script on every session start; a converging
+	// fix must not need a special first-time case, so run it 3x on the
+	// same already-existing worktree.
+	for i := 0; i < 3; i++ {
+		runLifecycleScript(t, script, repoDir, wt, "agent-b")
+	}
+
+	redirect := filepath.Join(wt, ".beads", "redirect")
+	data, err := os.ReadFile(redirect)
+	if err != nil {
+		t.Fatalf(".beads/redirect not created for pre-existing worktree after 3 runs: %v", err)
+	}
+
+	want := repoDir + "/.beads"
+	if got := strings.TrimSpace(string(data)); got != want {
+		t.Fatalf(".beads/redirect = %q, want %q", got, want)
+	}
+}

--- a/test/acceptance/worktree_test.go
+++ b/test/acceptance/worktree_test.go
@@ -132,12 +132,21 @@ func git(t *testing.T, dir string, args ...string) string {
 
 func runScript(t *testing.T, script, repoDir, wt, agent string) {
 	t.Helper()
-	cmd := exec.Command("sh", script, repoDir, wt, agent, "--sync")
-	cmd.Env = os.Environ()
-	out, err := cmd.CombinedOutput()
+	out, err := runScriptCommand(script, repoDir, wt, agent)
 	if err != nil {
 		t.Fatalf("worktree-setup.sh failed: %v\n%s", err, out)
 	}
+}
+
+// runScriptCommand runs a worktree-setup.sh script and returns its
+// combined output without asserting on the result. Shared by runScript
+// (strict) and runLifecycleScript in worktree_lifecycle_test.go
+// (tolerant of a known non-zero exit), so the package has a single
+// os/exec call site for this pattern instead of one per caller.
+func runScriptCommand(script, repoDir, wt, agent string) ([]byte, error) {
+	cmd := exec.Command("sh", script, repoDir, wt, agent, "--sync")
+	cmd.Env = os.Environ()
+	return cmd.CombinedOutput()
 }
 
 func currentBranch(t *testing.T, dir string) string {


### PR DESCRIPTION
## What this changes

The lifecycle example pack now reapplies its worktree provisioning whenever `worktree-setup.sh` encounters an existing worktree. Worktrees created manually, by an older script, or with later-clobbered metadata now converge on the expected `.beads/redirect`, submodule initialization, and local Git excludes during the next agent startup.

Previously, the existing-worktree fast path returned before any of that provisioning ran, leaving agents attached to the wrong beads store or missing the local runtime excludes.

## Review notes

- The existing creation-time provisioning is factored into one idempotent helper and called from both the existing-worktree and fresh-create paths.
- The helper remains below the worktree existence check, so it does not create or touch the target before `git worktree add` on the fresh path.
- This does not change the separately tracked non-zero exit behavior of the lifecycle example's fresh-create path.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — fast-unit baseline
- [x] `make test-acceptance` — Tier A command-level PR gate, including fresh and pre-existing lifecycle worktrees
- [x] Repository pre-push fast suite — all nine lanes passed
- [x] Release gate: [`release-gates/ga-bgh2wi-lifecycle-worktree-provisioning-gate.md`](release-gates/ga-bgh2wi-lifecycle-worktree-provisioning-gate.md)