### PR TITLE
Add generator for checked TESTING.md resource ledger

### DIFF
--- a/internal/testpolicy/resourcecensus/census.go
+++ b/internal/testpolicy/resourcecensus/census.go
@@ -2052,14 +2052,34 @@ const (
 
 // CheckedMarkdownBlock returns the single generated inventory block.
 func CheckedMarkdownBlock(document string) (string, error) {
-	if strings.Count(document, markdownBegin) != 1 || strings.Count(document, markdownEnd) != 1 {
-		return "", errors.New("TESTING.md must contain exactly one checked test resource ledger marker pair")
+	start, end, err := markdownBlockSpan(document)
+	if err != nil {
+		return "", err
 	}
-	start := strings.Index(document, markdownBegin)
-	end := strings.Index(document, markdownEnd)
+	return document[start:end], nil
+}
+
+// ReplaceMarkdownBlock returns document with its single checked test resource
+// ledger block replaced by replacement. Content outside the marker pair is
+// preserved byte-for-byte. Pass RenderMarkdown's output as replacement to
+// regenerate the block from a Ledger.
+func ReplaceMarkdownBlock(document, replacement string) (string, error) {
+	start, end, err := markdownBlockSpan(document)
+	if err != nil {
+		return "", err
+	}
+	return document[:start] + replacement + document[end:], nil
+}
+
+func markdownBlockSpan(document string) (start, end int, err error) {
+	if strings.Count(document, markdownBegin) != 1 || strings.Count(document, markdownEnd) != 1 {
+		return 0, 0, errors.New("TESTING.md must contain exactly one checked test resource ledger marker pair")
+	}
+	start = strings.Index(document, markdownBegin)
+	end = strings.Index(document, markdownEnd)
 	if end < start {
-		return "", errors.New("TESTING.md resource ledger end marker precedes begin marker")
+		return 0, 0, errors.New("TESTING.md resource ledger end marker precedes begin marker")
 	}
 	end += len(markdownEnd)
-	return document[start:end], nil
+	return start, end, nil
 }

--- a/internal/testpolicy/resourcecensus/census_test.go
+++ b/internal/testpolicy/resourcecensus/census_test.go
@@ -1,12 +1,12 @@
 package resourcecensus
 
 import (
+	"flag"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"go/types"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -15,6 +15,12 @@ import (
 	"testing/fstest"
 	"time"
 )
+
+// updateLedgerDoc regenerates the TESTING.md checked resource ledger block
+// from test/test-resources.toml when set. Run:
+//
+//	go test ./internal/testpolicy/resourcecensus -run TestRepositoryLedgerMatchesCensusAndDocumentation -update
+var updateLedgerDoc = flag.Bool("update", false, "regenerate the TESTING.md checked resource ledger block from test/test-resources.toml")
 
 func TestScanUsesImportIdentityAndParsedBuildConstraints(t *testing.T) {
 	t.Parallel()
@@ -2278,6 +2284,75 @@ func TestCheckedMarkdownBlockRequiresOneOrderedMarkerPair(t *testing.T) {
 	}
 }
 
+func TestReplaceMarkdownBlockRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	document := "# Title\n\nintro text\n\n" + markdownBegin + "\nstale content\n" + markdownEnd + "\n\ntrailing text\n"
+	replacement := markdownBegin + "\nfresh content\n" + markdownEnd
+
+	updated, err := ReplaceMarkdownBlock(document, replacement)
+	if err != nil {
+		t.Fatalf("ReplaceMarkdownBlock: %v", err)
+	}
+	want := "# Title\n\nintro text\n\n" + replacement + "\n\ntrailing text\n"
+	if updated != want {
+		t.Fatalf("ReplaceMarkdownBlock mismatch\n--- got ---\n%s\n--- want ---\n%s", updated, want)
+	}
+
+	block, err := CheckedMarkdownBlock(updated)
+	if err != nil {
+		t.Fatalf("CheckedMarkdownBlock(updated): %v", err)
+	}
+	if block != replacement {
+		t.Fatalf("round-trip mismatch\n--- got ---\n%s\n--- want ---\n%s", block, replacement)
+	}
+}
+
+func TestGeneratedLedgerBlockRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	ledger := Ledger{
+		Version: 2,
+		AuditBaseline: []Baseline{
+			validAudit(ScopeAll, ResourceFixedSleep, 4, 2),
+		},
+		Debt: []Baseline{
+			validDebt(ScopeUntagged, ResourceSubprocess, 3, 2),
+		},
+	}
+	generated := RenderMarkdown(ledger)
+	document := "# TESTING\n\nsome preamble\n\n" + markdownBegin + "\nold, stale table\n" + markdownEnd + "\n\nmore docs below\n"
+
+	updated, err := ReplaceMarkdownBlock(document, generated)
+	if err != nil {
+		t.Fatalf("ReplaceMarkdownBlock: %v", err)
+	}
+	block, err := CheckedMarkdownBlock(updated)
+	if err != nil {
+		t.Fatalf("CheckedMarkdownBlock(updated): %v", err)
+	}
+	if block != generated {
+		t.Fatalf("generated ledger block did not round-trip\n--- got ---\n%s\n--- want ---\n%s", block, generated)
+	}
+	if !strings.HasPrefix(updated, "# TESTING\n\nsome preamble\n\n") || !strings.HasSuffix(updated, "\n\nmore docs below\n") {
+		t.Fatalf("ReplaceMarkdownBlock altered content outside the marker pair:\n%s", updated)
+	}
+}
+
+func TestReplaceMarkdownBlockRequiresOneOrderedMarkerPair(t *testing.T) {
+	t.Parallel()
+
+	for _, document := range []string{
+		"no markers",
+		markdownEnd + "\n" + markdownBegin,
+		markdownBegin + "\n" + markdownEnd + "\n" + markdownBegin,
+	} {
+		if _, err := ReplaceMarkdownBlock(document, markdownBegin+markdownEnd); err == nil {
+			t.Fatalf("ReplaceMarkdownBlock(%q) unexpectedly succeeded", document)
+		}
+	}
+}
+
 func TestRepositoryLedgerMatchesCensusAndDocumentation(t *testing.T) {
 	root := repositoryRoot(t)
 	ledger, err := LoadLedger(filepath.Join(root, "test", "test-resources.toml"))
@@ -2292,16 +2367,32 @@ func TestRepositoryLedgerMatchesCensusAndDocumentation(t *testing.T) {
 		t.Fatalf("resource ledger drift:\n%v", err)
 	}
 
-	doc, err := fs.ReadFile(os.DirFS(root), "TESTING.md")
+	testingMDPath := filepath.Join(root, "TESTING.md")
+	doc, err := os.ReadFile(testingMDPath)
 	if err != nil {
 		t.Fatalf("read TESTING.md: %v", err)
 	}
+	want := RenderMarkdown(ledger)
+
+	if *updateLedgerDoc {
+		updated, err := ReplaceMarkdownBlock(string(doc), want)
+		if err != nil {
+			t.Fatalf("replace TESTING.md ledger block: %v", err)
+		}
+		if updated != string(doc) {
+			if err := os.WriteFile(testingMDPath, []byte(updated), 0o644); err != nil {
+				t.Fatalf("write TESTING.md: %v", err)
+			}
+			doc = []byte(updated)
+		}
+	}
+
 	got, err := CheckedMarkdownBlock(string(doc))
 	if err != nil {
-		t.Fatalf("checked TESTING.md block: %v\n--- wanted block ---\n%s", err, RenderMarkdown(ledger))
+		t.Fatalf("checked TESTING.md block: %v\n--- wanted block ---\n%s", err, want)
 	}
-	if want := RenderMarkdown(ledger); got != want {
-		t.Fatalf("TESTING.md resource ledger block is stale\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	if got != want {
+		t.Fatalf("TESTING.md resource ledger block is stale; run `go test ./internal/testpolicy/resourcecensus -run TestRepositoryLedgerMatchesCensusAndDocumentation -update` to regenerate it, then review the diff\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
 

--- a/release-gates/ga-yg3x8u-resourcecensus-ledger-generator-gate.md
+++ b/release-gates/ga-yg3x8u-resourcecensus-ledger-generator-gate.md
@@ -1,0 +1,60 @@
+# Release Gate: resource-census TESTING.md ledger generator
+
+Bead: ga-yg3x8u  
+Source review bead: ga-ffmf9m  
+Build bead: ga-cwfzvz  
+Reviewed commit: 57ff991178fd2a0a788591cb5e86651ee476af28  
+Gate date: 2026-07-28
+
+## Summary
+
+PASS. The resource-census package now exposes a checked-markdown block
+replacement helper and gives
+`TestRepositoryLedgerMatchesCensusAndDocumentation` an `-update` mode. The
+failure message names the exact regeneration command, and regeneration
+replaces only the marked ledger block while preserving the rest of
+`TESTING.md` byte-for-byte.
+
+`docs/PROJECT_MANIFEST.md` is not present on the reviewed commit or current
+`origin/main`; this gate uses the deployer role release criteria and the
+canonical repository guidance in `TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-ffmf9m is closed with close reason `pass`; its notes record `verdict: pass`, no style or security findings, and independent acceptance verification at reviewed commit 57ff991178fd2a0a788591cb5e86651ee476af28. |
+| 2 | Acceptance criteria met | PASS | All four ga-cwfzvz acceptance criteria were checked against the reviewed code and reproduced locally. The focused acceptance suite passed 5 tests with 0 failures and 0 skips. A deliberate one-line corruption of the checked `TESTING.md` block failed with the exact documented `-update` command; running that command passed and restored the original Git blob exactly. `TestGeneratedLedgerBlockRoundTrips` proves generated content round-trips while surrounding content remains unchanged. |
+| 3 | Tests pass | PASS | Documented CI-equivalent command `make test-fast-parallel`: 10 PASS, 0 FAIL, 0 SKIP jobs. Focused acceptance command: 5 PASS, 0 FAIL, 0 SKIP tests. `go vet ./...` passed. No skip justification is required because both recorded runs had zero skips. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes report no style findings, no security findings, no blockers, and no uncovered criteria. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | The reviewed commit was checked out detached with an empty `git status --short`; the deliberate acceptance-test corruption was repaired by the generator back to the exact original blob before the full suite. The gate artifact is the only deployer-added file and will be committed on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first as required. `git merge-tree --write-tree origin/main 57ff991178fd2a0a788591cb5e86651ee476af28` exited 0 against `origin/main@1c8573165a5e8d52146ca7cdbf4b9d9b4429b731` and produced tree `d0c51d4410a1ac020236d2912cba0d803179fbca`; no self-rebase was needed. |
+| 7 | Single feature theme | PASS | The commit changes only `internal/testpolicy/resourcecensus/census.go` and its adjacent test file. Both changes implement and prove one behavior: deterministic regeneration of the checked TESTING.md resource ledger. |
+
+## Acceptance Evidence
+
+1. A single command is documented by the test flag comment and surfaced in
+   the stale-ledger diagnostic:
+   `go test ./internal/testpolicy/resourcecensus -run TestRepositoryLedgerMatchesCensusAndDocumentation -update`.
+2. After changing the checked ledger's subprocess count from 541 to 999, the
+   non-update test failed and printed that exact command.
+3. Running the command alone made the test pass and restored `TESTING.md` from
+   modified content to its original blob
+   `c5aad29fedf6c1880c42c14457638acb010c6fbe`, with no hand edit.
+4. `TestGeneratedLedgerBlockRoundTrips` passed and verifies both generated
+   block equality and preservation of surrounding documentation.
+
+## Test Evidence
+
+| Command | Counts | Result |
+|---------|--------|--------|
+| `go test -count=1 -v ./internal/testpolicy/resourcecensus/... -run 'TestReplaceMarkdownBlockRoundTrips\|TestGeneratedLedgerBlockRoundTrips\|TestReplaceMarkdownBlockRequiresOneOrderedMarkerPair\|TestRepositoryLedgerMatchesCensusAndDocumentation\|TestCheckedMarkdownBlock'` | 5 PASS, 0 FAIL, 0 SKIP tests | PASS |
+| Deliberate stale-ledger run: `go test -count=1 ./internal/testpolicy/resourcecensus -run TestRepositoryLedgerMatchesCensusAndDocumentation` | 0 PASS, 1 expected FAIL, 0 SKIP tests | Expected RED; diagnostic named the regeneration command |
+| Repair run: `go test ./internal/testpolicy/resourcecensus -run TestRepositoryLedgerMatchesCensusAndDocumentation -update` | 1 PASS, 0 FAIL, 0 SKIP tests | PASS; original and regenerated Git blob IDs matched |
+| `make test-fast-parallel` | 10 PASS, 0 FAIL, 0 SKIP jobs | PASS |
+| `go vet ./...` | Not a test-counting command | PASS |
+
+## Final Gate Result
+
+PASS. The reviewed commit is suitable for an isolated deploy branch, pull
+request, and merge-authority handoff.


### PR DESCRIPTION
## What this changes

`TestRepositoryLedgerMatchesCensusAndDocumentation` now supports an opt-in `-update` mode that regenerates the checked resource-ledger block in `TESTING.md` from `test/test-resources.toml`. When the ledger is stale, the failure tells maintainers the exact command to run instead of requiring a manual table transcription.

The resource-census package now shares marker validation through a single span helper and provides `ReplaceMarkdownBlock`, which replaces only the checked marker range and preserves all surrounding documentation byte-for-byte.

## Review notes

- Regeneration is opt-in; ordinary test runs never write to `TESTING.md`.
- The update path targets the repository's fixed `TESTING.md` location and writes only when generated content differs.
- Marker validation still requires exactly one ordered begin/end pair and preserves the existing error behavior.
- There are no config changes, migrations, new dependencies, or runtime production paths involved.

## Test plan

- [x] Five focused resource-census acceptance tests: 5 PASS, 0 FAIL, 0 SKIP.
- [x] Corrupt the checked ledger block, confirm the stale test names the regeneration command, run `-update`, and verify the file returns to its identical Git blob.
- [x] `make test-fast-parallel`: 10 PASS, 0 FAIL, 0 SKIP jobs.
- [x] `go vet ./...`.
- [x] Release gate: [`release-gates/ga-yg3x8u-resourcecensus-ledger-generator-gate.md`](release-gates/ga-yg3x8u-resourcecensus-ledger-generator-gate.md)
