### PR TITLE
fix(sling): treat pool-session claims as idempotent instead of double-minting (#4785)

### DIFF
--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -470,8 +470,18 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 	}
 
 	target := agentutil.RoutedToIdentity(&a)
+	isMulti := agentutil.IsMultiSessionAgent(&a)
 	if strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) == target {
-		if b.Assignee == "" || b.Assignee == target {
+		// A pool session claims routed work under its own session identity
+		// ("<target>-<session bead id>"), not under the bare pool target, so
+		// bare equality reads already-claimed pool work as un-slung and mints a
+		// second attempt for it. The original keeps gc.routed_to once wrapped,
+		// so both it and its do-work step satisfy the pool work_query: one unit
+		// of work, two dispatchable rows, two sessions. Treat a claim by any of
+		// this pool's own sessions as idempotent. Anchored to target+"-", so a
+		// claim by a different pool still falls through to the warning below.
+		claimedByOwnPoolSession := isMulti && strings.HasPrefix(b.Assignee, target+"-")
+		if b.Assignee == "" || b.Assignee == target || claimedByOwnPoolSession {
 			return resolveConvoyRecovery(q, b, deps, opts, beadID)
 		}
 		return BeadCheckResult{
@@ -479,7 +489,6 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 		}
 	}
 
-	isMulti := agentutil.IsMultiSessionAgent(&a)
 	if !isMulti {
 		if b.Assignee == target {
 			return resolveConvoyRecovery(q, b, deps, opts, beadID)

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -4695,3 +4695,54 @@ func TestCheckBeadStateRoutedPoolForeignAssigneeStillWarns(t *testing.T) {
 		t.Fatalf("expected a warning naming the conflicting assignee, got none")
 	}
 }
+
+// TestCheckBeadStateRoutedPoolSiblingPrefixIsCurrentlyOverMatched pins a known
+// gap in the target+"-" anchor rather than asserting the invariant the
+// neighboring control claims. TestCheckBeadStateRoutedPoolForeignAssigneeStillWarns
+// pairs "novices-sess1" against target "smiths" — two strings sharing no prefix —
+// so it passes even with the anchor removed entirely and cannot detect an
+// over-match. This case uses the real boundary: a sibling pool whose qualified
+// name begins with this pool's qualified name plus "-".
+//
+// Current behavior is that the sibling's claim reads as this pool's own and the
+// conflict warning is suppressed. That is a lost warning, not a double-mint —
+// the over-match lands on the idempotent branch, which dispatches nothing. This
+// test asserts that behavior so the gap is visible and any future tightening of
+// the ownership predicate has to update it deliberately.
+func TestCheckBeadStateRoutedPoolSiblingPrefixIsCurrentlyOverMatched(t *testing.T) {
+	store := beads.NewMemStore()
+	a := config.Agent{
+		Name:              "smiths",
+		Dir:               "myrig",
+		MinActiveSessions: intPtr(1),
+		MaxActiveSessions: intPtr(4),
+	}
+	target := agentutil.RoutedToIdentity(&a) // "myrig/smiths"
+
+	convoy, err := store.Create(beads.Bead{Title: "auto convoy", Type: "convoy", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create(convoy): %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "pool work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: target + "-ops-1", // sibling pool "myrig/smiths-ops", slot 1
+		Metadata: map[string]string{"gc.routed_to": target},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, bead.ID, "tracks"); err != nil {
+		t.Fatalf("store.DepAdd(tracks): %v", err)
+	}
+
+	result := CheckBeadState(store, bead.ID, a, SlingDeps{Store: store})
+
+	if !result.Idempotent {
+		t.Fatalf("known over-match: expected Idempotent=true for a sibling-pool claim under the current anchor, got %+v", result)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("known over-match: expected the conflict warning to be suppressed, got %v", result.Warnings)
+	}
+}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -4583,3 +4583,115 @@ func TestBuildSlingFormulaVarsBaseBranchPrefersBeadTarget(t *testing.T) {
 		t.Fatalf("base_branch var = %q, want %q (bead metadata.target wins)", got, "release/v2")
 	}
 }
+
+// TestCheckBeadStateRoutedPoolWorkClaimedByPoolSessionIsIdempotent guards the
+// double-mint the pool work_query used to produce. A bead routed to a
+// multi-session pool keeps gc.routed_to after it is wrapped, so the pool query
+//
+//	bd ready --unassigned --metadata-field gc.routed_to=<pool> --exclude-type=epic
+//
+// can surface the ORIGINAL alongside its own wrapper's do-work step: one unit of
+// work, two dispatchable rows, two sessions. Once a pool session has claimed the
+// bead its assignee is a pool session identity ("<pool>-<session bead id>"), not
+// the bare pool target — so the bare-equality check treated an already-claimed
+// bead as un-slung and minted a second attempt. For a multi-session agent, a
+// pool-session assignee must read as idempotent.
+func TestCheckBeadStateRoutedPoolWorkClaimedByPoolSessionIsIdempotent(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "auto convoy", Type: "convoy", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create(convoy): %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "pool work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "smiths-sess1",
+		Metadata: map[string]string{"gc.routed_to": "smiths"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, bead.ID, "tracks"); err != nil {
+		t.Fatalf("store.DepAdd(tracks): %v", err)
+	}
+	a := config.Agent{
+		Name:              "smiths",
+		MinActiveSessions: intPtr(1),
+		MaxActiveSessions: intPtr(4),
+	}
+
+	result := CheckBeadState(store, bead.ID, a, SlingDeps{Store: store})
+
+	if !result.Idempotent {
+		t.Fatalf("expected Idempotent=true when pool work is already claimed by a pool session, got %+v", result)
+	}
+}
+
+// TestCheckBeadStateRoutedSingletonForeignAssigneeStillWarns is the
+// anti-inversion control for the case above: the pool-session-prefix reading is
+// scoped to multi-session agents, so a SINGLETON agent is untouched by it and a
+// prefix-shaped assignee on its routed bead must still warn.
+//
+// max_active_sessions=1 is what makes the agent a singleton here
+// (UsesCanonicalSingletonPoolIdentity), and it is load-bearing for this control:
+// an agent with no session limits at all reports IsMultiSessionAgent()==true,
+// which is the branch the case above covers.
+func TestCheckBeadStateRoutedSingletonForeignAssigneeStillWarns(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:    "routed work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "mayor-sess1",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+	a := config.Agent{
+		Name:              "mayor",
+		MaxActiveSessions: intPtr(1),
+	}
+
+	result := CheckBeadState(store, bead.ID, a, SlingDeps{Store: store})
+
+	if result.Idempotent {
+		t.Fatalf("expected Idempotent=false for a singleton agent with a foreign assignee, got %+v", result)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected a warning naming the conflicting assignee, got none")
+	}
+}
+
+// TestCheckBeadStateRoutedPoolForeignAssigneeStillWarns is the second
+// anti-inversion control: prefix matching must be anchored to this pool's
+// target, not to any pool-shaped assignee. Work claimed by a DIFFERENT pool is
+// still a conflict and must still warn.
+func TestCheckBeadStateRoutedPoolForeignAssigneeStillWarns(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:    "pool work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "novices-sess1",
+		Metadata: map[string]string{"gc.routed_to": "smiths"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+	a := config.Agent{
+		Name:              "smiths",
+		MinActiveSessions: intPtr(1),
+		MaxActiveSessions: intPtr(4),
+	}
+
+	result := CheckBeadState(store, bead.ID, a, SlingDeps{Store: store})
+
+	if result.Idempotent {
+		t.Fatalf("expected Idempotent=false when another pool holds the bead, got %+v", result)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected a warning naming the conflicting assignee, got none")
+	}
+}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -4744,5 +4745,44 @@ func TestCheckBeadStateRoutedPoolSiblingPrefixIsCurrentlyOverMatched(t *testing.
 	}
 	if len(result.Warnings) != 0 {
 		t.Fatalf("known over-match: expected the conflict warning to be suppressed, got %v", result.Warnings)
+	}
+}
+
+// TestCheckBeadStateRoutedRigQualifiedPoolSessionIsNotMatched pins the
+// complement of the anchor's reach. RoutedToIdentity returns the
+// UNSANITIZED qualified name ("myrig/smiths"), but a pool session's
+// runtime identity is sanitized — SanitizeQualifiedNameForSession
+// encodes "/" as "--" — so the real assignee is "myrig--smiths-2" and
+// target+"-" never matches it. The target+"-" anchor therefore only
+// fires for Dir-less pools. This is a lost fix, not a regression: the
+// pre-fix behavior for this shape is unchanged. Asserted so the gap is
+// visible until a session->pool ownership lookup replaces the prefix.
+func TestCheckBeadStateRoutedRigQualifiedPoolSessionIsNotMatched(t *testing.T) {
+	store := beads.NewMemStore()
+	a := config.Agent{
+		Name:              "smiths",
+		Dir:               "myrig",
+		MinActiveSessions: intPtr(1),
+		MaxActiveSessions: intPtr(4),
+	}
+	target := agentutil.RoutedToIdentity(&a) // "myrig/smiths"
+	bead, err := store.Create(beads.Bead{
+		Title:    "pool work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: agent.SanitizeQualifiedNameForSession(target + "-2"), // "myrig--smiths-2"
+		Metadata: map[string]string{"gc.routed_to": target},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+
+	result := CheckBeadState(store, bead.ID, a, SlingDeps{Store: store})
+
+	if result.Idempotent {
+		t.Fatalf("known gap: sanitized rig-qualified pool session is not matched by the target+\"-\" anchor; got %+v", result)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected the conflict warning for an unmatched pool-session claim, got none")
 	}
 }


### PR DESCRIPTION
Fixes #4785.

## Summary

`gc sling` minted a second attempt for pool work that a pool session had already claimed, so one unit of work occupied two dispatchable rows and two sessions raced for it.

A bead routed to a pool keeps `gc.routed_to` after it is wrapped, so the original satisfies the pool work_query alongside its own wrapper's do-work step. `CheckBeadStateWithOptions` decided idempotency with `b.Assignee == "" || b.Assignee == target`, but a pool session claims under its own session identity (`<target>-<session id>`), never the bare pool target — so an already-claimed bead read as un-slung.

## Changes

- `internal/sling/sling_attachment.go`: for a multi-session agent, a claim by one of the pool's own sessions now reads as idempotent. The prefix is anchored to `target+"-"`, so a claim by a different pool or any other identity still falls through to the existing conflict warning. Singleton agents are unaffected — they take the `!IsMultiSessionAgent` branch and never reach this comparison.
- `internal/sling/sling_test.go`: three cases. The pool-session claim, plus two anti-inversion controls — a singleton agent with a prefix-shaped assignee, and a claim held by a *different* pool — which pass both before and after and pin the change to the intended branch.

This serves strictly less, never more: it removes a duplicate dispatch path and adds none.

## Verification

Against `main` at 725eaa8c9:

- new pool-session case fails **5/5** with the tests applied alone, passes **5/5** with the fix
- both anti-inversion controls pass on either side, so the change is pinned to the branch it intends
- `go test ./internal/sling/` green; `gofmt` and `go vet` clean

The `-count=5` runs are not decoration — the fixtures are pure in-memory store state with no clock or scheduling dependence, and the counts are reported so a single lucky sample is not mistaken for a floor.

## Test gap this closes

`internal/sling/sling_test.go` had no coverage of a multi-session pool agent's assignee comparison. The neighbouring cases all use an empty assignee, so the pool-session shape was never exercised — that gap is what let this ship.

## Relationship to #4762 / #4763

Adjacent, not overlapping, and settled by running the reproduction rather than by reading the description: my new test still fails **5/5** against the head of #4763. That PR restamps `gc.routed_to` on the work bead after a formula attach; this one fixes the claim-side check that the restamped routing then exercises. They compose — restamping `gc.routed_to` on more work beads increases the population that can double-mint, which makes this half load-bearing rather than redundant. Neither depends on the other to land first.
