### PR TITLE
fix(builtin/claude): map auto-edit to acceptEdits for current Claude Code (#4602)

### DIFF
--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -125,11 +125,13 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		ForkFlag:               "--fork-session",
 		PrintArgs:              []string{"-p"},
 		TitleModel:             "haiku",
+		// Config-facing names map to current CLI values: Claude Code rejects the
+		// legacy "auto-edit"/"full-auto" it used to accept (GH#4602).
 		PermissionModes: map[string]string{
 			"unrestricted": "--dangerously-skip-permissions",
 			"plan":         "--permission-mode plan",
-			"auto-edit":    "--permission-mode auto-edit",
-			"full-auto":    "--permission-mode full-auto",
+			"auto-edit":    "--permission-mode acceptEdits",
+			"full-auto":    "--permission-mode dontAsk",
 		},
 		OptionsSchema: []BuiltinProviderOption{
 			{
@@ -138,8 +140,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:    "select",
 				Default: "auto-edit",
 				Choices: []BuiltinOptionChoice{
-					{Value: "auto-edit", Label: "Edit automatically", FlagArgs: []string{"--permission-mode", "auto-edit"}},
-					{Value: "full-auto", Label: "Full auto", FlagArgs: []string{"--permission-mode", "full-auto"}},
+					{Value: "auto-edit", Label: "Edit automatically", FlagArgs: []string{"--permission-mode", "acceptEdits"}},
+					{Value: "full-auto", Label: "Full auto", FlagArgs: []string{"--permission-mode", "dontAsk"}},
 					{Value: "plan", Label: "Plan mode", FlagArgs: []string{"--permission-mode", "plan"}},
 					{Value: "unrestricted", Label: "Bypass permissions", FlagArgs: []string{"--dangerously-skip-permissions"}},
 				},

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -175,3 +175,49 @@ func TestBuiltinCodexModelChoicesIncludeGPT56Variants(t *testing.T) {
 		}
 	}
 }
+
+// GH#4602: Claude Code >= 2.1.170 rejects --permission-mode auto-edit / full-auto.
+// Config-facing values stay "auto-edit"/"full-auto"; CLI args must be modern modes.
+func TestClaudePermissionModeMapsToAcceptedCLIValues(t *testing.T) {
+	providers := BuiltinProviders()
+	claude, ok := providers["claude"]
+	if !ok {
+		t.Fatal("BuiltinProviders() missing claude")
+	}
+
+	if got := claude.PermissionModes["auto-edit"]; got != "--permission-mode acceptEdits" {
+		t.Errorf("PermissionModes[auto-edit] = %q, want --permission-mode acceptEdits", got)
+	}
+	if got := claude.PermissionModes["full-auto"]; got != "--permission-mode dontAsk" {
+		t.Errorf("PermissionModes[full-auto] = %q, want --permission-mode dontAsk", got)
+	}
+
+	var permOpt BuiltinProviderOption
+	for _, option := range claude.OptionsSchema {
+		if option.Key == "permission_mode" {
+			permOpt = option
+			break
+		}
+	}
+	if permOpt.Key == "" {
+		t.Fatal("claude provider missing permission_mode option")
+	}
+	byValue := make(map[string]BuiltinOptionChoice, len(permOpt.Choices))
+	for _, c := range permOpt.Choices {
+		byValue[c.Value] = c
+	}
+	autoEdit, ok := byValue["auto-edit"]
+	if !ok {
+		t.Fatal("claude permission_mode choices missing auto-edit")
+	}
+	if len(autoEdit.FlagArgs) != 2 || autoEdit.FlagArgs[0] != "--permission-mode" || autoEdit.FlagArgs[1] != "acceptEdits" {
+		t.Errorf("auto-edit FlagArgs = %v, want [--permission-mode acceptEdits]", autoEdit.FlagArgs)
+	}
+	fullAuto, ok := byValue["full-auto"]
+	if !ok {
+		t.Fatal("claude permission_mode choices missing full-auto")
+	}
+	if len(fullAuto.FlagArgs) != 2 || fullAuto.FlagArgs[0] != "--permission-mode" || fullAuto.FlagArgs[1] != "dontAsk" {
+		t.Errorf("full-auto FlagArgs = %v, want [--permission-mode dontAsk]", fullAuto.FlagArgs)
+	}
+}


### PR DESCRIPTION
## Summary

Claude Code >= 2.1.170 rejects `--permission-mode auto-edit` (and `full-auto`). `builtin:claude` still emitted those legacy values, so every gc session with the default claude permission mode died at launch.

Map config-facing values to current CLI modes (same mapping the grok profile already uses):

- `auto-edit` → `--permission-mode acceptEdits`
- `full-auto` → `--permission-mode dontAsk`

Config keys/defaults stay `auto-edit` so existing TOML keeps working.

Closes #4602

## Test plan

- [x] `go test ./internal/worker/builtin/ -run TestClaudePermissionModeMapsToAcceptedCLIValues -count=1` — pass
- [x] `go test ./internal/worker/builtin/... -count=1` and `go vet` on a probe branch merged with current `main` — pass (0.135s)
