### PR TITLE
fix(hook): decode work_query beads per-element so one malformed bead can't halt the claim scan

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -162,10 +162,13 @@ func tryHookClaim(workQuery, dir string, opts *hookClaimOptions, ops *hookClaimO
 	if !workQueryHasReadyWork(normalized) {
 		return hookClaimResult{}
 	}
-	candidates, err := decodeHookClaimBeads(normalized)
+	candidates, skipped, err := decodeHookClaimBeads(normalized)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: requires JSON work_query output to identify claim candidates: %v\n", err) //nolint:errcheck
 		return hookClaimResult{terminal: true, code: 1}
+	}
+	for _, skip := range skipped {
+		fmt.Fprintf(stderr, "gc hook --claim: skipping undecodable bead %s: %v\n", skip.ID, skip.Err) //nolint:errcheck
 	}
 	if len(candidates) == 0 {
 		return hookClaimResult{}
@@ -1289,24 +1292,78 @@ func hookClaimEnvMap(env []string, dir string, actor string) map[string]string {
 	return out
 }
 
-func decodeHookClaimBeads(output string) ([]beads.Bead, error) {
+// hookClaimSkip records a work_query element that parsed as JSON but could not
+// be unmarshaled into a claim candidate — e.g. a bead a buggy filer wrote with
+// a value whose type does not match beads.Bead (a numeric "status", say). The
+// scan reports these so the caller can log and skip them instead of failing
+// wholesale: one malformed bead must not halt dispatch city-wide.
+type hookClaimSkip struct {
+	ID  string
+	Err error
+}
+
+// decodeHookClaimBeads parses work_query output into claim candidates. It is
+// resilient to individual malformed beads: the array is split into raw elements
+// first, then each is typed-decoded independently, so a single undecodable bead
+// is collected into skipped rather than failing the whole scan. A top-level
+// value that is not a JSON array still returns an error, preserving the
+// "requires JSON work_query output" contract for non-JSON command output.
+//
+// Non-string *metadata* values are already tolerated one layer down:
+// beads.Bead.Metadata is a StringMap that coerces them to their JSON text form,
+// so a nested-object or boolean metadata value decodes fine and is never
+// skipped. The per-element split guards the batch against type errors OUTSIDE
+// metadata (e.g. a numeric "status"), which that coercion does not repair and
+// which would otherwise fail the whole-slice unmarshal and drop every bead.
+func decodeHookClaimBeads(output string) ([]beads.Bead, []hookClaimSkip, error) {
 	output = strings.TrimSpace(output)
 	if output == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if !json.Valid([]byte(output)) {
 		extracted, ok := firstHookJSONValue(output)
 		if !ok {
-			return nil, errors.New("output is not JSON")
+			return nil, nil, errors.New("output is not JSON")
 		}
 		output = extracted
 	}
 	output = normalizeWorkQueryOutput(output)
-	var candidates []beads.Bead
-	if err := json.Unmarshal([]byte(output), &candidates); err != nil {
-		return nil, err
+	// Split into raw elements before typed decoding so one malformed bead
+	// cannot fail the whole batch. json.RawMessage accepts any valid JSON
+	// value, so the array split never trips on a bead that a direct
+	// []beads.Bead unmarshal would reject.
+	var raws []json.RawMessage
+	if err := json.Unmarshal([]byte(output), &raws); err != nil {
+		return nil, nil, err
 	}
-	return candidates, nil
+	candidates := make([]beads.Bead, 0, len(raws))
+	var skipped []hookClaimSkip
+	for _, raw := range raws {
+		var bead beads.Bead
+		if err := json.Unmarshal(raw, &bead); err != nil {
+			skipped = append(skipped, hookClaimSkip{ID: hookClaimBeadIDForLog(raw), Err: err})
+			continue
+		}
+		candidates = append(candidates, bead)
+	}
+	return candidates, skipped, nil
+}
+
+// hookClaimBeadIDForLog best-effort extracts a bead id from a raw work_query
+// element for skip diagnostics. A malformed bead is typically malformed only in
+// one field; its id remains a decodable string, so logging it keeps the skip
+// actionable (the offending bead can be traced to fix the upstream filer).
+// Returns "<unknown>" when even the id cannot be read.
+func hookClaimBeadIDForLog(raw json.RawMessage) string {
+	var probe struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &probe); err == nil {
+		if id := strings.TrimSpace(probe.ID); id != "" {
+			return id
+		}
+	}
+	return "<unknown>"
 }
 
 func firstHookJSONValue(output string) (string, bool) {

--- a/cmd/gc/cmd_hook_claim_metadata_test.go
+++ b/cmd/gc/cmd_hook_claim_metadata_test.go
@@ -16,7 +16,7 @@ import "testing"
 func TestDecodeHookClaimBeadsToleratesNonStringMetadata(t *testing.T) {
 	output := `[{"id":"gcw-1","metadata":{"refinery_reviewed":true,"count":42,"note":"ok"}}]`
 
-	got, err := decodeHookClaimBeads(output)
+	got, _, err := decodeHookClaimBeads(output)
 	if err != nil {
 		t.Fatalf("decodeHookClaimBeads returned error on non-string metadata: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestDecodeHookClaimBeadsToleratesNonStringMetadata(t *testing.T) {
 func TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch(t *testing.T) {
 	output := `[{"id":"a","metadata":{"note":"fine"}},{"id":"b","metadata":{"gc.parked":true}},{"id":"c"}]`
 
-	got, err := decodeHookClaimBeads(output)
+	got, _, err := decodeHookClaimBeads(output)
 	if err != nil {
 		t.Fatalf("decodeHookClaimBeads returned error: %v", err)
 	}

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -884,6 +884,103 @@ func TestDoHookClaimRejectsNonJSONWorkQueryOutput(t *testing.T) {
 	}
 }
 
+func TestDoHookClaimToleratesMalformedMetadataBead(t *testing.T) {
+	var claimedID string
+	runner := func(string, string) (string, error) {
+		// First element is undecodable — "status" is a number where beads.Bead
+		// declares a string — so it is skipped; second is plain, claimable pool
+		// work and must still be claimed.
+		//
+		// Deliberately NOT a nested-object metadata value: beads.Bead.Metadata
+		// is a StringMap that coerces those to strings during decode, so such a
+		// bead decodes fine and is claimed normally rather than skipped (the
+		// stronger outcome). The skip path this test guards is for type errors
+		// outside metadata, which that coercion does not repair.
+		return `[
+			{"id":"poison-1","status":5,"metadata":{"gc.routed_to":"worker"}},
+			{"id":"good-1","status":"open","metadata":{"gc.routed_to":"worker"}}
+		]`, nil
+	}
+	ops := hookClaimOps{
+		Runner: runner,
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimedID = beadID
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
+		},
+	}
+	opts := hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("bd ready --json", "/tmp/work", opts, ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHookClaim(malformed+good) = %d, want 0 (poison skipped, good claimed); stderr=%s", code, stderr.String())
+	}
+	if claimedID != "good-1" {
+		t.Fatalf("claimed ID = %q, want good-1 (the well-formed bead)", claimedID)
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.Action != "work" || result.Reason != "claimed" || result.BeadID != "good-1" {
+		t.Fatalf("unexpected claim result: %+v", result)
+	}
+	// The skip must be observable (logged) and name the offending bead — a
+	// silently-dropped bead would mask the upstream filer bug.
+	if !strings.Contains(stderr.String(), "poison-1") {
+		t.Fatalf("stderr = %q, want it to log the skipped malformed bead id poison-1", stderr.String())
+	}
+}
+
+func TestDecodeHookClaimBeadsSkipsUndecodableBead(t *testing.T) {
+	// Middle element is undecodable: "status" is a number where beads.Bead
+	// declares a string. The well-formed beads on either side must still
+	// decode, so one bad bead cannot halt dispatch city-wide.
+	//
+	// Deliberately NOT a non-string *metadata* value: beads.Bead.Metadata is a
+	// StringMap that coerces those to strings during decode, so such a bead
+	// decodes successfully and is never skipped — pinned by
+	// TestDecodeHookClaimBeadsToleratesNonStringMetadata and
+	// TestDecodeHookClaimBeadsOneBadBeadDoesNotPoisonBatch. The per-element
+	// split this test covers is what protects the batch from type errors
+	// OUTSIDE metadata, which that coercion does not repair.
+	output := `[
+		{"id":"ok-1","status":"open","metadata":{"gc.routed_to":"worker"}},
+		{"id":"bad-1","status":5},
+		{"id":"ok-2","status":"open"}
+	]`
+	candidates, skipped, err := decodeHookClaimBeads(output)
+	if err != nil {
+		t.Fatalf("decodeHookClaimBeads returned error %v, want nil (one malformed bead must be skipped, not fatal)", err)
+	}
+	gotIDs := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		gotIDs = append(gotIDs, c.ID)
+	}
+	if got, want := strings.Join(gotIDs, ","), "ok-1,ok-2"; got != want {
+		t.Fatalf("decoded candidate ids = %q, want %q", got, want)
+	}
+	if len(skipped) != 1 || skipped[0].ID != "bad-1" {
+		t.Fatalf("skipped = %+v, want exactly one skip naming bad-1", skipped)
+	}
+	if skipped[0].Err == nil {
+		t.Fatal("skipped[0].Err = nil, want the underlying decode error for diagnostics")
+	}
+}
+
+func TestDecodeHookClaimBeadsNonJSONStillErrors(t *testing.T) {
+	// Plain command text (not JSON at all) must remain a hard error — the
+	// per-element tolerance only relaxes decoding within a valid JSON array.
+	if _, _, err := decodeHookClaimBeads("hw-1  open  Fix the bug"); err == nil {
+		t.Fatal("decodeHookClaimBeads(text) = nil error, want a non-JSON error")
+	}
+}
+
 func TestDoHookClaimCommandErrorKeepsProtocolStdoutEmpty(t *testing.T) {
 	runner := func(string, string) (string, error) {
 		return "[]\n", fmt.Errorf("timed out after 15s with partial stdout")


### PR DESCRIPTION
fix(hook): decode work_query beads per-element so one malformed bead can't halt the claim scan

gc hook --claim decodes the whole work_query result in a single
json.Unmarshal into []beads.Bead. A single bead whose JSON does not fit
the struct — e.g. a buggy filer that wrote a numeric "status" where
beads.Bead declares a string — fails that whole unmarshal, so one
malformed bead drops every candidate and can halt the claim/dispatch scan
city-wide for every pool agent.

decodeHookClaimBeads now splits the array into raw elements and decodes
each independently: an undecodable bead is collected as a hookClaimSkip
(best-effort id + error), logged and skipped by the caller, while the
well-formed beads are still returned and claimed. A top-level value that
is not a JSON array still errors, preserving the "requires JSON
work_query output" contract for non-JSON command output.

Non-string *metadata* values are already tolerated one layer down —
beads.Bead.Metadata is a StringMap that coerces them to their JSON text
form — so this closes the remaining gap for type errors OUTSIDE metadata,
which that coercion does not repair. The existing claim-stage skip in
claimFirstEligibleHookCandidate runs one step after decode and cannot
help: the whole-slice unmarshal fails before any candidate is reached.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SPX6Fxz7A9aeQ2PPdqbqKT

