### PR TITLE
fix(rig): fail loudly when --include resolves to no pack

### DIFF
--- a/cmd/gc/cmd_rig_include_canonical_test.go
+++ b/cmd/gc/cmd_rig_include_canonical_test.go
@@ -87,6 +87,73 @@ func TestRigAddIncludeCanonicalizesBuiltinPackSource(t *testing.T) {
 	}
 }
 
+// TestRigAddIncludeFailsLoudlyForUnresolvableName is the gascity#4620
+// regression guard, and the counterpart to the canonicalization test above:
+// a --include token that names NO pack gc can resolve — not bundled, not a
+// [packs] key, no pack.toml on disk — must fail the add outright.
+//
+// Before the fix, canonicalization rewrote bundled names like "gastown" to a
+// canonical URL and let every other name degrade to the literal "./<name>",
+// which the pack loader resolves against the city root. `gc rig add`
+// reported SUCCESS while writing it, and every pack-expanding command then
+// failed for the WHOLE CITY — `gc bd`, `gc rig list` — with an error that
+// looks like a Dolt/connectivity problem, far from the command that caused
+// it. Failing at add time is the only outcome that costs the operator
+// nothing to diagnose.
+func TestRigAddIncludeFailsLoudlyForUnresolvableName(t *testing.T) {
+	cityPath := t.TempDir()
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
+
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	before, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "docbook")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// No GC_DOLT/GC_BEADS setup: the add must abort at include validation,
+	// which runs before the beads-store init. Needing neither is itself part
+	// of the contract — nothing is provisioned before the tokens are checked.
+	var stdout, stderr bytes.Buffer
+	// The exact reported invocation: one bundled name that resolves, two that
+	// do not. The resolvable one must not mask the others.
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"gastown", "koolkats", "oversight-rig"}, "", "", "", false, false, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("gc rig add reported success with unresolvable --include names; stdout:\n%s", stdout.String())
+	}
+
+	// Both bad tokens must be named — one round trip per bad name is the
+	// diagnosis cost this bug is about.
+	for _, want := range []string{"koolkats", "oversight-rig"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr does not name unresolvable --include %q:\n%s", want, stderr.String())
+		}
+	}
+
+	// city.toml must be byte-identical: the rig-add contract is that config
+	// is written last, so a validation failure leaves the city untouched
+	// rather than half-registered with a source that bricks pack expansion.
+	after, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("city.toml was mutated by a failed rig add:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if strings.Contains(string(after), "./koolkats") {
+		t.Errorf("city.toml persisted the unresolvable literal source ./koolkats:\n%s", after)
+	}
+}
+
+// The acceptance side of this guard — a --include naming a real local pack
+// dir must still succeed — is covered end-to-end by TestDoRigAdd_WithPack and
+// exhaustively across every resolvable token form by
+// TestResolveIncludeSourcesAcceptsResolvableForms in internal/rig.
+
 // TestRigAddDefaultRigImportsPersistPinnedBundledVersion guards the sibling
 // path of the explicit --include pin hardening: `gc rig add` WITHOUT
 // --include composes the rig's imports from root-pack defaults (plus legacy

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -35,6 +35,24 @@ func (f mkdirAllErrorFS) MkdirAll(path string, perm os.FileMode) error {
 	return f.FS.MkdirAll(path, perm)
 }
 
+// writeLocalCityPacks materializes a local pack (a directory holding
+// pack.toml) at each city-relative path, so an --include naming it resolves.
+// `gc rig add` rejects include tokens that resolve to no pack, so a test that
+// exercises import composition has to supply packs that actually exist.
+func writeLocalCityPacks(t *testing.T, cityPath string, relPaths ...string) {
+	t.Helper()
+	for _, rel := range relPaths {
+		dir := filepath.Join(cityPath, filepath.FromSlash(rel))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		packToml := fmt.Sprintf("[pack]\nname = %q\nschema = 2\n", filepath.Base(dir))
+		if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(packToml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func writeSchema2RigCity(t *testing.T, cityPath, workspaceName, cityToml, siteToml string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
@@ -718,6 +736,7 @@ func TestDoRigAdd_ReAddWarnsDifferingFlags(t *testing.T) {
 		"[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\n",
 		fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"my-frontend\"\npath = %q\n", rigPath),
 	)
+	writeLocalCityPacks(t, cityPath, "packs/new")
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -892,6 +911,7 @@ func TestDoRigAdd_ExplicitIncludeSkipsUnusedDefaultRigImportErrors(t *testing.T)
 	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte("not = [valid\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeLocalCityPacks(t, cityPath, "packs/custom")
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -1423,6 +1443,7 @@ ref = "v1.2.3"
 func TestDoRigAdd_WithMultiplePacks(t *testing.T) {
 	cityPath := t.TempDir()
 	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
+	writeLocalCityPacks(t, cityPath, "packs/planner", "packs/architect")
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -1861,6 +1882,8 @@ func TestDoRigAdd_ExplicitIncludeOverridesDefault(t *testing.T) {
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
+
+	writeLocalCityPacks(t, cityPath, "packs/custom")
 
 	var stdout, stderr bytes.Buffer
 	// Explicit --include should override default_rig_includes while still

--- a/internal/rig/imports.go
+++ b/internal/rig/imports.go
@@ -1,6 +1,7 @@
 package rig
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -10,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/packregistry"
+	"github.com/gastownhall/gascity/internal/remotesource"
 )
 
 func formatBoundImports(imports []config.BoundImport) string {
@@ -126,6 +128,128 @@ func registryPackIncludeSource(fs fsys.FS, cityPath, tok string, pathDeclared bo
 		return "", false
 	}
 	return resolveRegistryPack(tok)
+}
+
+// resolveIncludeSources canonicalizes the --include tokens for a rig add and
+// fails when any token names something gc cannot resolve to a pack.
+//
+// It is the single entry point for Step 4 of Provision: canonicalization and
+// validation must run as a pair, because canonicalization is what turns a
+// pack name (builtin or registry) into a resolvable remote source, and
+// validation is what catches every token it did not rewrite. Splitting them
+// at the call site would let a future caller take the rewrite without the
+// guard.
+//
+// Validation runs AFTER canonicalizePackIncludes so precedence 4 (registry
+// catalog) has already rewritten matched names to remote sources. Checking
+// before the registry step would reject valid registry packs that only become
+// remote after that rewrite.
+func resolveIncludeSources(fs fsys.FS, cityPath string, includes []string, packs map[string]config.PackSource, resolveRegistryPack func(string) (string, bool)) ([]string, error) {
+	canonical := canonicalizePackIncludes(fs, cityPath, includes, packs, resolveRegistryPack)
+	if err := validateIncludeSources(fs, cityPath, canonical, packs); err != nil {
+		return nil, err
+	}
+	return canonical, nil
+}
+
+// validateIncludeSources rejects canonicalized --include tokens that do not
+// resolve to a pack, so `gc rig add` fails at add time instead of writing an
+// unresolvable rig import (gascity#4620).
+//
+// An unrecognized token degrades to the literal local source "./<token>"
+// (config.legacyImportSourceFor), which the pack loader resolves against the
+// CITY ROOT. When no such directory exists, pack expansion fails for every
+// rig in the city rather than only the rig being added, and the failure
+// surfaces far from the command that caused it — `gc rig add` has already
+// reported success by then. Every token is checked through one classifier so
+// resolution is consistent across names: the pre-fix behavior rewrote a
+// bundled name like "gastown" to a canonical URL while a sibling name
+// silently became "./<name>".
+//
+// Callers must pass already-canonicalized tokens (including any registry
+// rewrites). A bare registry pack name is accepted only after
+// canonicalizePackIncludes has turned it into a remote source.
+func validateIncludeSources(fs fsys.FS, cityPath string, includes []string, packs map[string]config.PackSource) error {
+	var unresolved []string
+	for _, inc := range includes {
+		if token := strings.TrimSpace(inc); !includeSourceResolves(fs, cityPath, token, packs) {
+			unresolved = append(unresolved, token)
+		}
+	}
+	if len(unresolved) == 0 {
+		return nil
+	}
+	bundled := strings.Join(bundledPackNames(), ", ")
+	lines := make([]string, 0, len(unresolved))
+	for _, token := range unresolved {
+		lines = append(lines, fmt.Sprintf("--include %q does not resolve to a pack.\n"+
+			"  Checked: bundled packs (%s), registry catalog (after name rewrite), [packs] keys in city.toml, and %s.\n"+
+			"  Pass a directory containing pack.toml, a remote source (https://…, github.com/owner/repo, git@…), a registry pack name, or register the pack under [packs] in city.toml first.",
+			token, bundled, filepath.Join(localIncludeDir(cityPath, token), "pack.toml")))
+	}
+	return errors.New(strings.Join(lines, "\n"))
+}
+
+// includeSourceResolves reports whether a canonicalized --include token names
+// a pack gc can resolve. The checks mirror how the pack loader resolves a rig
+// import source: registered [packs] keys win, remote sources (including
+// sources produced by builtin/registry canonicalization) are resolved later
+// by the pack installer, and everything else must be a local directory
+// holding pack.toml.
+func includeSourceResolves(fs fsys.FS, cityPath, token string, packs map[string]config.PackSource) bool {
+	if token == "" {
+		return false
+	}
+	if _, ok := packs[token]; ok {
+		return true
+	}
+	if _, ok := packs[includeBindingHint(token)]; ok {
+		return true
+	}
+	if remotesource.IsRemote(token) {
+		return true
+	}
+	_, err := fs.Stat(filepath.Join(localIncludeDir(cityPath, token), "pack.toml"))
+	return err == nil
+}
+
+// localIncludeDir resolves a local --include token to the directory the pack
+// loader would read it from. Rig imports are declared in city.toml, so
+// relative sources resolve against the city root (config.resolveConfigPath
+// with declDir == cityRoot) — not against the working directory the operator
+// happened to run `gc rig add` from.
+func localIncludeDir(cityPath, token string) string {
+	slash := filepath.ToSlash(token)
+	if rest, ok := strings.CutPrefix(slash, "//"); ok {
+		return filepath.Join(cityPath, filepath.FromSlash(rest))
+	}
+	if filepath.IsAbs(token) {
+		return token
+	}
+	return filepath.Join(cityPath, filepath.FromSlash(slash))
+}
+
+// includeBindingHint reduces an --include token to the single-segment pack
+// name it would bind as, matching canonicalizePackIncludes so the [packs]
+// lookup and the error message agree on what the operator named.
+func includeBindingHint(token string) string {
+	name := strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(token)), "./")
+	if rest, ok := strings.CutPrefix(name, "packs/"); ok {
+		name = rest
+	}
+	return name
+}
+
+// bundledPackNames lists the packs gc can resolve from a bare name, for the
+// unresolvable-include error. Reading the registry keeps the message correct
+// as packs are added rather than restating a list that drifts.
+func bundledPackNames() []string {
+	all := builtinpacks.All()
+	names := make([]string, 0, len(all))
+	for _, pack := range all {
+		names = append(names, pack.Name)
+	}
+	return names
 }
 
 func boundImportsFromImportMap(imports map[string]config.Import) []config.BoundImport {

--- a/internal/rig/imports_test.go
+++ b/internal/rig/imports_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/builtinpacks"
@@ -159,5 +160,168 @@ func TestCanonicalizePackIncludesWithoutResolver(t *testing.T) {
 	got := canonicalizePackIncludes(fsys.OSFS{}, cityPath, []string{"wespd/cacc-twin-team"}, nil, nil)
 	if want := []string{"wespd/cacc-twin-team"}; !slices.Equal(got, want) {
 		t.Errorf("canonicalizePackIncludes = %q, want %q", got, want)
+	}
+}
+
+// writePackDir materializes a minimal pack directory (a dir holding
+// pack.toml) at dir, which is what the pack loader requires of any local
+// import source.
+func writePackDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"local\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResolveIncludeSourcesRejectsUnresolvableName is the gascity#4620
+// regression guard: a --include token that names nothing gc can resolve —
+// not a bundled pack, not a registry pack, not a [packs] key, no pack.toml
+// on disk — must fail at rig-add time instead of degrading to the literal
+// "./<name>" source.
+//
+// The literal form resolves against the CITY ROOT, where the directory does
+// not exist, so persisting it breaks pack expansion for every rig in the
+// city, not just the rig being added. Reporting success while writing it is
+// the worst outcome: the operator gets no signal at the point of the
+// mistake, and the resulting failure presents as a Dolt/connectivity problem.
+func TestResolveIncludeSourcesRejectsUnresolvableName(t *testing.T) {
+	cityPath := t.TempDir()
+
+	_, err := resolveIncludeSources(fsys.OSFS{}, cityPath, []string{"koolkats"}, nil, nil)
+	if err == nil {
+		t.Fatal("resolveIncludeSources accepted an unresolvable --include name; it must fail loudly at add time")
+	}
+	msg := err.Error()
+	// The message must name the offending token and the path that was
+	// checked, so the operator can act without re-deriving the resolution
+	// rules.
+	if !strings.Contains(msg, "koolkats") {
+		t.Errorf("error does not name the offending token: %q", msg)
+	}
+	if !strings.Contains(msg, filepath.Join(cityPath, "koolkats")) {
+		t.Errorf("error does not report the local path that was checked: %q", msg)
+	}
+}
+
+// TestResolveIncludeSourcesReportsEveryUnresolvableToken guards the
+// diagnosis cost: an operator who passed several bad --include names must
+// see all of them in one failure, not fix-and-retry once per token.
+func TestResolveIncludeSourcesReportsEveryUnresolvableToken(t *testing.T) {
+	cityPath := t.TempDir()
+
+	_, err := resolveIncludeSources(fsys.OSFS{}, cityPath, []string{"koolkats", "oversight-rig"}, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for two unresolvable --include names")
+	}
+	for _, want := range []string{"koolkats", "oversight-rig"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error omits unresolvable token %q: %q", want, err.Error())
+		}
+	}
+}
+
+// TestResolveIncludeSourcesAcceptsResolvableForms pins the other half of the
+// contract: every token gc CAN resolve keeps working, and each resolves
+// through the same classifier so the outcome is consistent across names.
+// The observed defect surface in gascity#4620 was the split where "gastown"
+// canonicalized to a URL while sibling names silently degraded — these cases
+// are the ones that must not start failing.
+func TestResolveIncludeSourcesAcceptsResolvableForms(t *testing.T) {
+	cityPath := t.TempDir()
+	writePackDir(t, filepath.Join(cityPath, "localpack"))
+	writePackDir(t, filepath.Join(cityPath, "packs", "nested"))
+	absPack := filepath.Join(t.TempDir(), "abspack")
+	writePackDir(t, absPack)
+
+	bundled, ok := builtinpacks.CanonicalImportSource("gastown")
+	if !ok {
+		t.Fatal("bundled gastown pack not registered")
+	}
+	packs := map[string]config.PackSource{
+		"registered": {Source: "https://github.com/example/registered"},
+	}
+	registrySource := "https://github.com/example/wespd-cacc-twin-team.git"
+	resolveRegistry := func(name string) (string, bool) {
+		if name == "wespd/cacc-twin-team" {
+			return registrySource, true
+		}
+		return "", false
+	}
+
+	cases := []struct {
+		name    string
+		include string
+		want    string
+	}{
+		{"bundled builtin name", "gastown", bundled},
+		{"bundled builtin under packs/", "packs/gastown", bundled},
+		{"registered [packs] key", "registered", "registered"},
+		{"local pack dir", "localpack", "localpack"},
+		{"local pack dir with ./ prefix", "./localpack", "./localpack"},
+		{"nested local pack dir", "packs/nested", "packs/nested"},
+		{"absolute local pack dir", absPack, absPack},
+		{"https remote source", "https://github.com/example/pack", "https://github.com/example/pack"},
+		{"github shorthand remote source", "github.com/example/pack", "github.com/example/pack"},
+		{"scp-style remote source", "git@github.com:example/pack.git", "git@github.com:example/pack.git"},
+		{"remote source with subpath and ref", "https://github.com/example/pack//sub#v1", "https://github.com/example/pack//sub#v1"},
+		// Registry rewrite is precedence 4: validation must run AFTER it, or
+		// a valid catalog name would be rejected as an unresolvable bare token.
+		{"registry pack name", "wespd/cacc-twin-team", registrySource},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveIncludeSources(fsys.OSFS{}, cityPath, []string{tc.include}, packs, resolveRegistry)
+			if err != nil {
+				t.Fatalf("resolveIncludeSources(%q) errored: %v", tc.include, err)
+			}
+			if len(got) != 1 || got[0] != tc.want {
+				t.Fatalf("resolveIncludeSources(%q) = %v, want [%q]", tc.include, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveIncludeSourcesPrefersLocalAndConfiguredOverBuiltin preserves the
+// gascity#3137 precedence rules through the added validation: a token that
+// names a registered [packs] key or a real local pack dir keeps that
+// meaning and is never shadowed by a same-named bundled pack.
+func TestResolveIncludeSourcesPrefersLocalAndConfiguredOverBuiltin(t *testing.T) {
+	cityPath := t.TempDir()
+	writePackDir(t, filepath.Join(cityPath, "gastown"))
+
+	got, err := resolveIncludeSources(fsys.OSFS{}, cityPath, []string{"gastown"}, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveIncludeSources: %v", err)
+	}
+	if len(got) != 1 || got[0] != "gastown" {
+		t.Fatalf("local pack dir was shadowed by the builtin: got %v, want [\"gastown\"]", got)
+	}
+
+	packs := map[string]config.PackSource{"gastown": {Source: "https://github.com/example/gastown"}}
+	got, err = resolveIncludeSources(fsys.OSFS{}, t.TempDir(), []string{"gastown"}, packs, nil)
+	if err != nil {
+		t.Fatalf("resolveIncludeSources: %v", err)
+	}
+	if len(got) != 1 || got[0] != "gastown" {
+		t.Fatalf("configured [packs] key was shadowed by the builtin: got %v, want [\"gastown\"]", got)
+	}
+}
+
+// TestResolveIncludeSourcesRejectsUnmatchedRegistryName ensures a scoped
+// name that the registry catalog does not know is still rejected — the
+// post-registry validation is what catches "looks like a name, rewrote
+// nothing" tokens that would otherwise become "./owner/pack".
+func TestResolveIncludeSourcesRejectsUnmatchedRegistryName(t *testing.T) {
+	cityPath := t.TempDir()
+	resolve := func(string) (string, bool) { return "", false }
+	_, err := resolveIncludeSources(fsys.OSFS{}, cityPath, []string{"wespd/missing-pack"}, nil, resolve)
+	if err == nil {
+		t.Fatal("expected error for registry miss that left the token unrewritten")
+	}
+	if !strings.Contains(err.Error(), "wespd/missing-pack") {
+		t.Errorf("error does not name the token: %q", err.Error())
 	}
 }

--- a/internal/rig/provision.go
+++ b/internal/rig/provision.go
@@ -71,8 +71,15 @@ func Provision(deps Deps, req ProvisionRequest) (config.Rig, ProvisionResult, er
 	hasGit, defaultBranchOverride, resolvedDefaultBranch := resolveGitDefaultBranch(deps, req, rigPath)
 
 	// Step 4: canonicalize --include tokens that name a pack (builtin or
-	// registry) rather than a path.
-	includes = canonicalizePackIncludes(fs, cityPath, includes, cfg.Packs, deps.ResolveRegistryPack)
+	// registry) rather than a path, and reject any token that resolves to no
+	// pack at all. Validation runs after the registry rewrite so a valid
+	// registry pack name is not rejected before it becomes a remote source.
+	// This runs before every mutation so an unresolvable include leaves the
+	// city untouched instead of bricking pack expansion citywide.
+	includes, err = resolveIncludeSources(fs, cityPath, includes, cfg.Packs, deps.ResolveRegistryPack)
+	if err != nil {
+		return config.Rig{}, result, err
+	}
 
 	// Steps 5-9: resolve imports, detect re-add, derive the prefix, build the next
 	// config, and validate it before any filesystem mutation.


### PR DESCRIPTION
fix(rig): fail loudly when --include resolves to no pack

Port gascity#4620 onto upstream's renamed canonicalizePackIncludes:
after builtin and registry rewrites, reject any --include token that
still does not name a resolvable pack so `gc rig add` cannot persist
"./unknown" and brick citywide pack expansion.

Validation runs after the registry step (precedence 4) so a valid
catalog pack name is not rejected before it becomes a remote source.

Work bead: ga-fpdi.5 (filing-prep for upstream PR; no gh pr create).

