### PR TITLE
fix(compact): defer same-count table value-hash drift on a proven writer race

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -35,16 +35,17 @@
 #      otherwise looks identical to the ambiguous gain+drift corruption signal.
 #      Quarantining that false positive blocks all future GC of the db and
 #      starves DOLT_GC until host memory is exhausted. So, mirroring the remote-
-#      push path's HEAD-stability defer, gain+drift and row-count-decrease
-#      cases are downgraded from a blocking quarantine to a skip-and-retry-
-#      next-run ONLY when a concurrent writer is proven. A writer is proven
-#      (and distinguished from the flatten's OWN commit) when either HEAD
-#      captured immediately before the mutating reset differs from the stable
-#      pre-flight HEAD (a writer landed in the preflight->reset window, before
-#      the flatten committed), or HEAD captured after verify moved past the
-#      flatten's own commit (a writer landed during/after verify). All other
-#      failures — and gain+drift or row-decrease with a stable HEAD — still
-#      quarantine. Probe failure leaves the race unproven and quarantines.
+#      push path's HEAD-stability defer, gain+drift, row-count-decrease, and
+#      same-count value-hash-drift cases are downgraded from a blocking
+#      quarantine to a skip-and-retry-next-run ONLY when a concurrent writer is
+#      proven. A writer is proven (and distinguished from the flatten's OWN
+#      commit) when either HEAD captured immediately before the mutating reset
+#      differs from the stable pre-flight HEAD (a writer landed in the
+#      preflight->reset window, before the flatten committed), or HEAD captured
+#      after verify moved past the flatten's own commit (a writer landed
+#      during/after verify). All other failures — and any of those signatures
+#      with a stable HEAD — still quarantine. Probe failure leaves the race
+#      unproven and quarantines.
 #   4b. Committed-root drift gate. When per-table verification passed but the
 #      whole-database hash still drifted, DOLT_DIFF_STAT names the tables that
 #      differ across the flatten. Drift is benign only when every named table
@@ -2734,10 +2735,12 @@ flatten_database() {
   if [ "$verify_counts_rc" -ne 0 ]; then
     integrity_reason="${verify_counts_failure_reason:-post-flatten integrity check failed}"
     integrity_guidance="${verify_counts_failure_guidance:-post-flatten integrity check failed; investigate before re-running}"
-    # Downgrade quarantine -> defer ONLY for the ambiguous gain+drift case when
-    # a concurrent writer is proven. Every other integrity failure (row-count
-    # decrease, same-count hash drift, table-list drift, probe failure) and the
-    # gain+drift case with a stable HEAD still quarantine below unchanged.
+    # The blocks below each downgrade a quarantine to a skip-and-retry defer for
+    # one benign concurrent-writer signature — gain+drift, row-count decrease, or
+    # same-count value-hash drift — but only when a concurrent writer is
+    # HEAD-proven (or, for gain+drift, proven additive-only via DOLT_DIFF). A
+    # signature mixed with any other failure category, table-list drift, a probe
+    # failure, or a stable HEAD still quarantines below unchanged.
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_gain:-0}" = "1" ] && \
        [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] && \
@@ -2805,9 +2808,37 @@ flatten_database() {
       rm -f "$preflight_tmp"
       return 0
     fi
+    # Downgrade quarantine -> defer for concurrent-writer UPDATE. A concurrent
+    # UPDATE during the flatten window changes a committed table's value hash
+    # while leaving its row count unchanged — the net-zero-row-count churn that
+    # dominates the busiest db's workload (ephemeral wisp pour/burn and bead/mail
+    # row updates). The whole-database value-hash drift downgrade below already
+    # defers a same-content change when a concurrent writer is HEAD-proven, so the
+    # per-table check must not be stricter than the database-level check for the
+    # same phenomenon. Safe to defer when a writer is proven and no other anomaly
+    # (row gain+drift, row decrease, table-list change, or probe failure)
+    # prevents safe deferral.
+    if [ "$writer_race_detected" = "1" ] && \
+       [ "${verify_counts_saw_same_count_hash_drift:-0}" = "1" ] && \
+       [ "${verify_counts_saw_gain_hash_drift:-0}" != "1" ] && \
+       [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
+       [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
+       [ "${verify_counts_saw_probe_failure:-0}" != "1" ]; then
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — same-count table value hash drift is concurrent-writer UPDATE data, not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+      if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+        "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+        "$compacted_from_head" "$local_branch" "$remote_branch"; then
+        rm -f "$preflight_tmp"
+        return 1
+      fi
+      rm -f "$preflight_tmp"
+      return 0
+    fi
     if [ "$writer_race_detected" = "1" ] && \
        { [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] || \
-         [ "${verify_counts_saw_row_decrease:-0}" = "1" ]; }; then
+         [ "${verify_counts_saw_row_decrease:-0}" = "1" ] || \
+         [ "${verify_counts_saw_same_count_hash_drift:-0}" = "1" ]; }; then
       printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s), but additional integrity failure category prevents defer; quarantine unchanged\n' \
         "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
     fi

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -754,7 +754,7 @@ case "$query" in
     # probe, which reports writercommit so HEAD has moved past the flatten's own
     # commit. verify_counts still sees compactcommit (gain+drift) because it does
     # not probe HEAD and the "$(current_head)" gates read the real state.
-    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "same_count_hash_drift_with_writer_race" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       calls_file="$state_file.postverify-head-calls"
       calls=0
       if [ -f "$calls_file" ]; then
@@ -852,7 +852,7 @@ case "$query" in
       print_cell ""
       exit 0
     fi
-    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "row_count_decreases_with_hash_change" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "row_count_decreases_with_hash_change" ] || [ "$mode" = "same_count_hash_drift_with_writer_race" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-beads-after-writer
       exit 0
     fi
@@ -5656,6 +5656,42 @@ func TestCompactScriptDefersWhenWriterDeletesRows(t *testing.T) {
 	}
 	if strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("concurrent-DELETE defer must skip GC this run:\n%s", string(data))
+	}
+}
+
+// A concurrent UPDATE during the flatten window changes a committed table's
+// value hash while leaving its row count unchanged — the net-zero-row-count
+// churn that dominates the busiest db's workload (ephemeral wisp pour/burn and
+// bead/mail row updates). With a HEAD-proven concurrent writer this is benign
+// writer data, not corruption, and must defer-and-retry rather than quarantine.
+// The stable-HEAD control for the same signature is
+// TestCompactScriptQuarantinesSameRowCountWriterBeforeFullGC.
+func TestCompactScriptDefersWhenWriterCommitsCausingSameCountHashDrift(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "same_count_hash_drift_with_writer_race", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("concurrent-UPDATE same-count defer must exit 0 (skip, not failure): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "same-count table value hash drift is concurrent-writer UPDATE data, not corruption") {
+		t.Fatalf("output missing concurrent-UPDATE same-count defer message:\n%s", out)
+	}
+	if !strings.Contains(out, "deferring, will retry next run") {
+		t.Fatalf("output missing defer confirmation:\n%s", out)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
+		t.Fatalf("concurrent-UPDATE same-count defer must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if reason := compactMarkerValue(t, pendingGC, "reason"); reason != "writer race during flatten deferred full GC" {
+		t.Fatalf("concurrent-UPDATE same-count defer should record pending-GC retry marker, got reason %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("concurrent-UPDATE same-count defer must skip GC this run:\n%s", string(data))
 	}
 }
 


### PR DESCRIPTION
fix(compact): defer same-count table value-hash drift on a proven writer race (ga-zb1)

The post-flatten per-table integrity check reads DOLT_HASHOF_TABLE live, so a
concurrent net-zero-row-count writer (the bead/mail UPDATE workload that
dominates the busiest db) committing inside the flatten->verify window shifts a
committed table's value hash without changing its row count. verify_counts flags
this as saw_same_count_hash_drift, but every writer-race defer path in the
verify-failure gate required same_count_hash_drift != 1, so the case ALWAYS
quarantined even when a concurrent writer was HEAD-proven. On a high-churn db
(hq) this fired ~hourly, and each quarantine marker blocks all future GC of the db.

The database-level value-hash drift check (reached only after per-table verify
passes) already defers a same-content change when a writer is HEAD-proven; the
per-table check was simply stricter than the database-level check for the same
phenomenon. Add a per-table defer path for same-count value-hash drift, gated on
a HEAD-proven writer and the absence of any other anomaly (gain+drift,
row-decrease, table-list change, probe failure), mirroring the existing
row-decrease defer path. Stable-HEAD same-count drift (no proven writer) still
quarantines; same-count drift mixed with another failure category still quarantines.

Adds TestCompactScriptDefersWhenWriterCommitsCausingSameCountHashDrift. Existing
controls stay green: TestCompactScriptQuarantinesSameRowCountWriterBeforeFullGC
(stable HEAD) and TestCompactScriptQuarantinesMixedSignalsDespiteWriterRace
(mixed signals).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

