### PR TITLE
fix(build): stop buildvcs stamping an enclosing repo's commit into gc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,22 @@ BINARY     := gc
 BUILD_DIR  := bin
 INSTALL_DIR := $(BIN_DIR)
 
-# Version metadata injected via ldflags.
+# Version metadata injected via ldflags. These run git in the build directory,
+# so they resolve a worktree's `.git` gitdir pointer and describe the checkout
+# actually being compiled. The Go toolchain's own buildvcs stamping does not:
+# it identifies a repository by a `.git` *directory*, so from inside a worktree
+# it keeps walking up and stamps whichever repository encloses it. That makes
+# the toolchain stamp actively wrong for a worktree nested in another checkout
+# — a polecat worktree under the city directory picks up the city's commit and
+# the city's dirtiness (ga-u7fb) — so `build` below passes -buildvcs=false and
+# these variables are the single source of truth.
 VERSION    := $(shell tag=$$(git describe --tags --exact-match 2>/dev/null || true); if [ -n "$$tag" ]; then printf '%s' "$$tag" | sed 's/^v//'; else echo "dev"; fi)
 COMMIT     := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DIRTY      := $(shell test -n "$$(git status --porcelain 2>/dev/null)" && echo "-dirty" || true)
 BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 LDFLAGS := -X main.version=$(VERSION) \
-           -X main.commit=$(COMMIT) \
+           -X main.commit=$(COMMIT)$(DIRTY) \
            -X main.date=$(BUILD_TIME)
 
 unique_words = $(if $1,$(firstword $1) $(call unique_words,$(filter-out $(firstword $1),$1)))
@@ -99,7 +108,7 @@ endif
 
 ## build: compile gc binary with version metadata
 build:
-	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/gc
+	go build -buildvcs=false -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/gc
 ifeq ($(shell uname),Darwin)
 	@scripts/sign-darwin-local.sh $(BUILD_DIR)/$(BINARY)
 endif

--- a/cmd/gc/cmd_version.go
+++ b/cmd/gc/cmd_version.go
@@ -23,6 +23,17 @@ var (
 	}
 )
 
+const (
+	// dirtySuffix marks a commit built from a modified working tree. It is
+	// part of the build identity consumers compare: the supervisor reports it
+	// as /health build_id and binary-drift detection matches on it verbatim.
+	dirtySuffix = "-dirty"
+	// minAbbrevCommitLen is the shortest abbreviation trusted to identify a
+	// commit, matching git's own default abbreviation floor. Anything shorter
+	// collides too easily to prove two stamps describe the same revision.
+	minAbbrevCommitLen = 7
+)
+
 func init() {
 	info, ok := debug.ReadBuildInfo()
 	version, commit, date = resolveBuildMetadata(version, commit, date, ok, info)
@@ -43,9 +54,11 @@ func resolveBuildMetadata(
 		currentVersion = normalizeVersion(info.Main.Version)
 	}
 	var dirty bool
+	var revision string
 	for _, s := range info.Settings {
 		switch s.Key {
 		case "vcs.revision":
+			revision = s.Value
 			if currentCommit == "unknown" && s.Value != "" {
 				currentCommit = s.Value
 			}
@@ -57,10 +70,53 @@ func resolveBuildMetadata(
 			dirty = s.Value == "true"
 		}
 	}
-	if dirty && currentCommit != "unknown" {
-		currentCommit += "-dirty"
+	if dirty && currentCommit != "unknown" &&
+		!strings.HasSuffix(currentCommit, dirtySuffix) &&
+		vcsDescribesCommit(revision, currentCommit) {
+		currentCommit += dirtySuffix
 	}
 	return currentVersion, currentCommit, currentDate
+}
+
+// vcsDescribesCommit reports whether the Go toolchain's embedded vcs.revision
+// describes the same commit this binary was linked against, and so whether its
+// companion vcs.modified flag says anything about *our* working tree.
+//
+// The toolchain locates a repository by looking for a `.git` directory. Inside
+// a git worktree `.git` is a gitdir file, which it does not recognize, so it
+// walks up the filesystem and stamps whichever repository encloses the
+// worktree. Where worktrees are nested inside another checkout — a polecat
+// worktree under the city directory, for instance — the embedded revision and
+// dirtiness belong to that unrelated repository, and a pristine tree gets
+// reported as `<our-commit>-dirty` (ga-u7fb). Comparing the two stamps catches
+// exactly that case: an ldflags-injected commit that the embedded revision
+// does not describe means the VCS metadata came from somewhere else.
+//
+// The stamps legitimately differ in length — the build injects an abbreviated
+// hash while the toolchain records the full one — so either being a prefix of
+// the other counts as a match.
+func vcsDescribesCommit(revision, injectedCommit string) bool {
+	if revision == "" {
+		// No revision recorded to contradict the flag. Nothing to check
+		// against, so the toolchain keeps the benefit of the doubt.
+		return true
+	}
+	shorter := strings.ToLower(strings.TrimSuffix(injectedCommit, dirtySuffix))
+	longer := strings.ToLower(revision)
+	if shorter == longer {
+		// Identical stamps, including the case where the commit was adopted
+		// from this very revision. No independent claims to reconcile.
+		return true
+	}
+	if len(shorter) > len(longer) {
+		shorter, longer = longer, shorter
+	}
+	// Two independent stamps: the shorter must be a long enough abbreviation
+	// to actually identify the commit before a prefix match proves anything.
+	if len(shorter) < minAbbrevCommitLen {
+		return false
+	}
+	return strings.HasPrefix(longer, shorter)
 }
 
 func normalizeVersion(v string) string {

--- a/cmd/gc/cmd_version_test.go
+++ b/cmd/gc/cmd_version_test.go
@@ -61,3 +61,95 @@ func TestResolveBuildMetadataUsesVCSSettings(t *testing.T) {
 		t.Fatalf("date = %q, want %q", date, "2026-03-17T00:00:00Z")
 	}
 }
+
+// TestResolveBuildMetadataDirtinessFollowsCommitIdentity pins the rule that
+// keeps a foreign repository's working-tree state out of our build stamp: the
+// toolchain's vcs.modified flag is trusted only when its companion
+// vcs.revision describes the same commit the binary was linked against.
+//
+// The concrete failure this guards (ga-u7fb): Go's buildvcs looks for a `.git`
+// *directory*, so inside a git worktree — where `.git` is a gitdir *file* — it
+// keeps walking up and stamps whichever repository encloses the worktree. A
+// polecat worktree sits inside the city directory, itself a git repo, so a
+// pristine checkout at dc8327db3 was stamped with the city's 251dc9e0f9 and
+// the city's dirtiness, and `gc version --long` reported `dc8327db3-dirty`.
+// That lie propagates to the supervisor's /health build_id and to binary-drift
+// detection, so it must not survive.
+func TestResolveBuildMetadataDirtinessFollowsCommitIdentity(t *testing.T) {
+	const (
+		worktreeShort = "dc8327db3"
+		worktreeFull  = "dc8327db335c0c99ad0be57dca851f51eae2f01b"
+		cityFull      = "251dc9e0f9caf16320cda9e02460c9c867057d12"
+	)
+	tests := []struct {
+		name        string
+		stamped     string
+		vcsRevision string
+		vcsModified string
+		want        string
+	}{
+		{
+			name:        "foreign revision cannot dirty our stamp",
+			stamped:     worktreeShort,
+			vcsRevision: cityFull,
+			vcsModified: "true",
+			want:        worktreeShort,
+		},
+		{
+			name:        "abbreviated stamp matches full revision",
+			stamped:     worktreeShort,
+			vcsRevision: worktreeFull,
+			vcsModified: "true",
+			want:        worktreeShort + "-dirty",
+		},
+		{
+			name:        "full stamp matches full revision",
+			stamped:     worktreeFull,
+			vcsRevision: worktreeFull,
+			vcsModified: "true",
+			want:        worktreeFull + "-dirty",
+		},
+		{
+			name:        "matching revision on a clean tree stays clean",
+			stamped:     worktreeShort,
+			vcsRevision: worktreeFull,
+			vcsModified: "false",
+			want:        worktreeShort,
+		},
+		{
+			name:        "already-stamped dirtiness is not doubled",
+			stamped:     worktreeShort + "-dirty",
+			vcsRevision: worktreeFull,
+			vcsModified: "true",
+			want:        worktreeShort + "-dirty",
+		},
+		{
+			name:        "unstamped build still adopts the toolchain revision",
+			stamped:     "unknown",
+			vcsRevision: worktreeFull,
+			vcsModified: "true",
+			want:        worktreeFull + "-dirty",
+		},
+		{
+			name:        "abbreviation too short to identify a commit is not trusted",
+			stamped:     "dc83",
+			vcsRevision: worktreeFull,
+			vcsModified: "true",
+			want:        "dc83",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: tt.vcsRevision},
+					{Key: "vcs.modified", Value: tt.vcsModified},
+				},
+			}
+			_, commit, _ := resolveBuildMetadata("dev", tt.stamped, "unknown", true, info)
+			if commit != tt.want {
+				t.Fatalf("commit = %q, want %q", commit, tt.want)
+			}
+		})
+	}
+}

--- a/internal/productmetrics/release.go
+++ b/internal/productmetrics/release.go
@@ -136,6 +136,15 @@ func classifyBuild(tag string, dirty bool) (BuildKind, string) {
 // tree. Only an explicit vcs.modified=true stamp counts as dirty; absent VCS
 // metadata (e.g. -buildvcs=false) is treated as clean so release artifacts
 // classify correctly. A dirty tree can never classify as release or canary.
+//
+// The stamp is trusted here without cross-checking the repository it describes,
+// which is safe only because dirtiness cannot change the classification unless
+// compiledReleaseTag is set, and that is injected solely by the GoReleaser
+// workflows. Those build from an ordinary CI checkout, and
+// scripts/verify-release-binary-metadata.sh asserts vcs.modified=false on the
+// resulting binary. Local builds — where the toolchain can stamp an enclosing
+// repository's dirtiness instead of ours (ga-u7fb) — carry no release tag and
+// classify as development either way.
 func buildIsDirty() bool {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {

--- a/scripts/build_provenance_test.go
+++ b/scripts/build_provenance_test.go
@@ -1,0 +1,89 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// buildRecipe extracts the command lines of the Makefile's `build` target.
+func buildRecipe(t *testing.T, makefile string) string {
+	t.Helper()
+	recipe := regexp.MustCompile(`(?m)^build:\n((?:\t[^\n]+\n?)+)`).FindStringSubmatch(makefile)
+	if len(recipe) != 2 {
+		t.Fatal("Makefile has no build target with a command recipe")
+	}
+	return recipe[1]
+}
+
+func readMakefile(t *testing.T) string {
+	t.Helper()
+	makefile, err := os.ReadFile(filepath.Join(repoRoot(t), "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	return string(makefile)
+}
+
+// TestBuildTargetDisablesToolchainVCSStamping asserts that `make build` keeps
+// the Go toolchain out of the provenance business.
+//
+// Go's buildvcs identifies a repository by looking for a `.git` *directory*.
+// Inside a git worktree `.git` is a gitdir *file*, so the toolchain does not
+// recognize the worktree as a repository root and keeps walking up the
+// filesystem. Polecat worktrees live under the city directory, which is itself
+// a git repo, so buildvcs finds the *city's* `.git` and stamps the city's
+// commit and the city's dirtiness into gc — a pristine gascity checkout gets
+// labeled with an unrelated repository's revision and a false `-dirty`
+// (ga-u7fb).
+//
+// The Makefile's own VERSION/COMMIT/DIRTY variables run git in the build
+// directory, which resolves the gitdir pointer correctly and is therefore
+// right regardless of how the worktree is nested. Passing -buildvcs=false
+// makes those variables the single source of truth instead of leaving two
+// competing stamps in the binary, one of which can describe another project.
+func TestBuildTargetDisablesToolchainVCSStamping(t *testing.T) {
+	recipe := buildRecipe(t, readMakefile(t))
+	if !strings.Contains(recipe, "go build") {
+		t.Fatalf("build recipe does not invoke go build:\n%s", recipe)
+	}
+	if !strings.Contains(recipe, "-buildvcs=false") {
+		t.Fatalf("build recipe must pass -buildvcs=false so the Go toolchain cannot stamp an "+
+			"enclosing repository's commit into gc when built from a git worktree (ga-u7fb):\n%s", recipe)
+	}
+}
+
+// TestBuildStampsWorkingTreeDirtiness asserts that disabling buildvcs did not
+// silently drop dirty detection along with the bogus stamp. `gc version
+// --long`, the supervisor's /health build_id, and binary-drift detection all
+// read the same injected commit string, so the `-dirty` marker has to come
+// from somewhere — and with buildvcs off, that somewhere is git run in the
+// build directory.
+func TestBuildStampsWorkingTreeDirtiness(t *testing.T) {
+	makefile := readMakefile(t)
+
+	dirty := regexp.MustCompile(`(?m)^DIRTY\s*:?=\s*(.+)$`).FindStringSubmatch(makefile)
+	if len(dirty) != 2 {
+		t.Fatal("Makefile defines no DIRTY variable; buildvcs is off, so nothing would mark a dirty build")
+	}
+	if !strings.Contains(dirty[1], "git status --porcelain") {
+		t.Fatalf("DIRTY must be derived from `git status --porcelain` in the build directory, got: %s", dirty[1])
+	}
+	if !strings.Contains(dirty[1], "-dirty") {
+		t.Fatalf("DIRTY must expand to the -dirty suffix consumers already parse, got: %s", dirty[1])
+	}
+
+	ldflags := regexp.MustCompile(`(?ms)^LDFLAGS\s*:?=\s*(.*?)\n\n`).FindStringSubmatch(makefile)
+	if len(ldflags) != 2 {
+		t.Fatal("Makefile has no LDFLAGS assignment")
+	}
+	commitFlag := regexp.MustCompile(`-X main\.commit=(\S+)`).FindStringSubmatch(ldflags[1])
+	if len(commitFlag) != 2 {
+		t.Fatalf("LDFLAGS does not inject main.commit:\n%s", ldflags[1])
+	}
+	if !strings.Contains(commitFlag[1], "$(DIRTY)") {
+		t.Fatalf("main.commit must carry $(DIRTY) so a modified tree is visible in `gc version --long`, got: %s", commitFlag[1])
+	}
+}


### PR DESCRIPTION
fix(build): stop buildvcs stamping an enclosing repo's commit into gc (ga-u7fb)

A gc binary built with `make build` from a polecat worktree embedded a
different repository's revision and dirtiness. On a pristine gascity
checkout at dc8327db3, `go version -m bin/gc` reported
vcs.revision=251dc9e0f9 with vcs.modified=true — that is the HEAD of the
city repo at /home/b/gc/thunderburg, not a gascity commit at all — and
`gc version --long` printed `dc8327db3-dirty` on a clean tree.

The Go toolchain identifies a repository by looking for a `.git`
*directory*. In a git worktree `.git` is a gitdir *file*, which it does
not recognize, so it keeps walking up the filesystem. Polecat worktrees
live under the city directory, which is itself a git repo, so buildvcs
finds the city's `.git` and stamps that. The trigger is specifically "git
worktree nested inside another repo's working tree" — a worktree outside
any repo simply yields no stamp, which is why builds in /var/tmp escaped
it.

This is worse than a missing stamp. The injected commit string is the
build identity: cmd/gc reports it as `gc version --long`, the supervisor
publishes it as /health build_id, and DetectBinaryDrift compares it to
decide whether the running supervisor is stale. A false `-dirty` on one
side of that comparison is indistinguishable from real drift.

Two changes, defense in depth:

- Makefile: pass -buildvcs=false to the build target so the toolchain
  cannot contribute a second, possibly foreign, stamp. The existing
  VERSION/COMMIT variables already run git in the build directory, which
  resolves the gitdir pointer correctly and is right regardless of
  nesting; a new DIRTY variable derived from `git status --porcelain`
  preserves dirty detection that would otherwise have been lost with the
  bogus stamp.
- cmd/gc: trust vcs.modified only when its companion vcs.revision
  describes the commit the binary was linked against. Prefix matching
  handles the legitimate short-vs-full hash difference, and byte-equal
  stamps short-circuit so a commit adopted from vcs.revision still reads
  its own dirtiness. This protects hand-rolled `go build -ldflags`
  invocations too, not just `make build`.

GoReleaser is deliberately untouched: it builds from an ordinary CI
checkout where buildvcs is correct, and
scripts/verify-release-binary-metadata.sh asserts vcs.revision and
vcs.modified=false on release binaries. productmetrics.buildIsDirty keeps
reading the raw stamp — dirtiness cannot change its classification unless
compiledReleaseTag is injected, which only GoReleaser does — and gains a
comment recording why it needs no equivalent guard.

Validation: new table test in cmd/gc pins the dirty/identity matrix
(foreign revision, abbreviated match, double-suffix, too-short
abbreviation); new scripts/build_provenance_test.go fails the build if the
Makefile loses -buildvcs=false or the git-derived DIRTY stamp. Verified
end to end by rebuilding in the nested worktree: the binary now carries no
vcs stanza and reports the correct commit. `go vet ./...` clean.

Pre-existing, unrelated: internal/productmetrics'
TestOpenProductionAndPreparationAreLazyAndNonCreating fails under the
fleet's ambient GC_DISABLE_USAGE_METRICS=1 and is filed as ga-bmo6.

