### PR TITLE
feat(beads): add cross-ledger --assignee to gc beads list

### DIFF
--- a/cmd/gc/bead_format.go
+++ b/cmd/gc/bead_format.go
@@ -34,15 +34,24 @@ func parseBeadFormat(args []string) (string, []string) {
 	return format, rest
 }
 
-// beadFilters holds optional --label and --status flags parsed from args.
+// beadFilters holds optional --label, --status, and --assignee flags parsed
+// from args.
 type beadFilters struct {
 	label  string
 	status string
-	all    bool
+	// assignee restricts the listing to beads whose assignee matches exactly.
+	// It is the cross-ledger counterpart to `bd list --assignee`: bare bd reads
+	// one ledger, so a bead living on a RIG ledger but assigned to a
+	// city-scoped agent (e.g. gastown.mayor) is invisible to it. `gc beads
+	// list` already sweeps every rig store plus the city store, so pairing that
+	// sweep with an assignee filter answers "what work is assigned to me
+	// anywhere in town" in one command (ga-rp4k).
+	assignee string
+	all      bool
 }
 
-// parseBeadFilters extracts --label, --status, and --all from args, returning
-// the filters and the remaining args with those flags removed. Like
+// parseBeadFilters extracts --label, --status, --assignee, and --all from args,
+// returning the filters and the remaining args with those flags removed. Like
 // parseBeadFormat it backs the testscript fake-bd harness; the gc `beads list`
 // command parses these flags through cobra.
 func parseBeadFilters(args []string) (beadFilters, []string) {
@@ -60,6 +69,11 @@ func parseBeadFilters(args []string) (beadFilters, []string) {
 		case args[i] == "--status" && i+1 < len(args):
 			f.status = args[i+1]
 			i++
+		case strings.HasPrefix(args[i], "--assignee="):
+			f.assignee = strings.TrimPrefix(args[i], "--assignee=")
+		case args[i] == "--assignee" && i+1 < len(args):
+			f.assignee = args[i+1]
+			i++
 		case args[i] == "--all":
 			f.all = true
 		default:
@@ -71,13 +85,21 @@ func parseBeadFilters(args []string) (beadFilters, []string) {
 
 // filterBeads returns beads matching the given filters. Empty filter fields
 // match everything.
+//
+// The empty-filter fast path must name every filter field: omitting one makes
+// that filter silently match everything when it is the ONLY filter supplied
+// (`gc beads list --assignee=X` with no --status/--label), which reads as "this
+// agent owns every bead in town" rather than a filtered listing.
 func filterBeads(bs []beads.Bead, f beadFilters) []beads.Bead {
-	if f.label == "" && f.status == "" {
+	if f.label == "" && f.status == "" && f.assignee == "" {
 		return bs
 	}
 	var out []beads.Bead
 	for _, b := range bs {
 		if f.status != "" && b.Status != f.status {
+			continue
+		}
+		if f.assignee != "" && b.Assignee != f.assignee {
 			continue
 		}
 		if f.label != "" {

--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -41,8 +41,8 @@ fallback to direct bd reads.`,
 
 func newBeadsListCmd(stdout, stderr io.Writer) *cobra.Command {
 	var (
-		label, status, format string
-		all                   bool
+		label, status, assignee, format string
+		all                             bool
 	)
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -51,16 +51,26 @@ func newBeadsListCmd(stdout, stderr io.Writer) *cobra.Command {
 the controller is alive and falling back to a direct multi-store read
 otherwise.
 
-Supports --label, --status, --all, and --format. --format=json emits
-JSON (API-path JSON includes _cache_age_s; fallback-path JSON omits
-it). The bare --json flag is reserved by the CLI's JSON-contract layer
-and is not wired for this command; use --format=json.`,
+Supports --label, --status, --assignee, --all, and --format.
+--format=json emits JSON (API-path JSON includes _cache_age_s;
+fallback-path JSON omits it). The bare --json flag is reserved by the
+CLI's JSON-contract layer and is not wired for this command; use
+--format=json.
+
+--assignee is the cross-ledger form of "bd list --assignee". Bare bd
+reads a single ledger, so a bead that lives on a RIG ledger but is
+assigned to a city-scoped agent is invisible to it; this command sweeps
+every rig store plus the city store, so it answers "what is assigned to
+this agent anywhere in town" in one call. Use it when an agent's own
+startup work check comes back empty but work is genuinely assigned to
+it.`,
 		Example: `  gc beads list
   gc beads list --label ready-to-build
-  gc beads list --status open --format=json`,
+  gc beads list --status open --format=json
+  gc beads list --assignee gastown.mayor --status in_progress`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdBeadsList(format, beadFilters{label: label, status: status, all: all}, stdout, stderr) != 0 {
+			if cmdBeadsList(format, beadFilters{label: label, status: status, assignee: assignee, all: all}, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -68,6 +78,7 @@ and is not wired for this command; use --format=json.`,
 	}
 	cmd.Flags().StringVar(&label, "label", "", "filter to beads carrying this label")
 	cmd.Flags().StringVar(&status, "status", "", "filter to beads in this status")
+	cmd.Flags().StringVar(&assignee, "assignee", "", "filter to beads assigned to this identity (across every rig and the city)")
 	cmd.Flags().BoolVar(&all, "all", false, "include closed beads (default: open only)")
 	cmd.Flags().StringVar(&format, "format", "text", "output format: text or json")
 	return cmd
@@ -133,6 +144,13 @@ var beadsListAPIClient = func(cityPath string) (*api.Client, string) {
 // routeBeadsList dispatches `beads list` to the supervisor API when a
 // controller is up; otherwise falls back to the local multi-store iterator.
 // Emits exactly one route=... log line per exit path (gated on GC_DEBUG).
+//
+// --assignee is deliberately NOT sent as a query parameter: the endpoint has no
+// assignee filter, and renderBeadsListFromAPI re-applies every filter through
+// filterBeads anyway. The API lane therefore over-fetches and narrows on the
+// client, which is exact because ListBeads follows next_cursor to completion
+// rather than truncating to page 1. Adding a server-side assignee filter is a
+// pure efficiency change and must keep filterBeads as the authority.
 func routeBeadsList(cityPath string, c *api.Client, nilReason, format string, filters beadFilters, stdout, stderr io.Writer) int {
 	var cr api.CachedRead[[]beads.Bead]
 	return routeRead(c, "beads list", nilReason, stderr,
@@ -282,10 +300,18 @@ func doBeadsShowFallback(cityPath, beadID, format string, stdout, stderr io.Writ
 // for sorting. --all maps to IncludeClosed (matching `bd list --all`); the
 // CLI always opts into AllowScan because an unfiltered list is a valid
 // default UX.
+//
+// Assignee is pushed down into the per-store query rather than filtered after
+// the merge: every backend honors ListQuery.Assignee (the bd store forwards it
+// as `--assignee`, the native and caching stores match it in memory), so the
+// stores return only the caller's rows instead of every bead in town. Because
+// the store set spans each rig plus the city, this is the cross-ledger assignee
+// read that bare `bd list --assignee` cannot do (ga-rp4k).
 func collectBeadsAcrossStores(stores []convoyStoreView, filters beadFilters) ([]beads.Bead, error) {
 	q := beads.ListQuery{
 		Label:         filters.label,
 		Status:        filters.status,
+		Assignee:      filters.assignee,
 		IncludeClosed: filters.all,
 		AllowScan:     true,
 	}

--- a/cmd/gc/cmd_beads_assignee_test.go
+++ b/cmd/gc/cmd_beads_assignee_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// The regression under test (ga-rp4k): a bead that lives on a RIG ledger but is
+// assigned to a city-scoped agent (gastown.mayor) is invisible to bare
+// `bd list --assignee`, because bare bd reads one ledger. `gc beads list`
+// already sweeps every rig store plus the city store, so pairing that sweep
+// with --assignee is the cross-ledger read. Three P1/P2 delays on 2026-07-26
+// traced to the mayor reporting an empty hook while holding assigned
+// rig-ledger work.
+
+// newAssigneeTestStore returns an in-memory store seeded with the given beads.
+// Assignee and Status are preserved as supplied so the filters under test see
+// realistic rows.
+func newAssigneeTestStore(t *testing.T, seed []beads.Bead) beads.Store {
+	t.Helper()
+	store := beads.NewMemStore()
+	for _, b := range seed {
+		created, err := store.Create(b)
+		if err != nil {
+			t.Fatalf("seeding bead %q: %v", b.Title, err)
+		}
+		// Create fills ID/Status/CreatedAt; force the status the case wants.
+		if b.Status != "" && created.Status != b.Status {
+			if err := store.Update(created.ID, beads.UpdateOpts{Status: &b.Status}); err != nil {
+				t.Fatalf("setting status on %q: %v", created.ID, err)
+			}
+		}
+	}
+	return store
+}
+
+// TestCollectBeadsAcrossStores_AssigneeSpansRigLedgers is the core regression
+// pin: an assignee filter must reach beads held in a NON-city store. The city
+// store here stands in for the town ledger and the second store for a rig
+// ledger; only the rig store holds the mayor's bead, which is exactly the shape
+// that made ga-6s9 / ga-0562 invisible.
+func TestCollectBeadsAcrossStores_AssigneeSpansRigLedgers(t *testing.T) {
+	cityStore := newAssigneeTestStore(t, []beads.Bead{
+		{Title: "town bead for someone else", Assignee: "gastown.witness", Status: "open"},
+	})
+	rigStore := newAssigneeTestStore(t, []beads.Bead{
+		{Title: "rig bead for the mayor", Assignee: "gastown.mayor", Status: "open"},
+		{Title: "rig bead for a polecat", Assignee: "gascity/gastown.polecat", Status: "open"},
+	})
+	stores := []convoyStoreView{
+		{path: "city", store: cityStore},
+		{path: "rig", store: rigStore},
+	}
+
+	got, err := collectBeadsAcrossStores(stores, beadFilters{assignee: "gastown.mayor"})
+	if err != nil {
+		t.Fatalf("collectBeadsAcrossStores: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("assignee sweep returned %d beads, want 1; got=%+v", len(got), got)
+	}
+	if got[0].Title != "rig bead for the mayor" {
+		t.Errorf("assignee sweep returned %q, want the rig-ledger bead", got[0].Title)
+	}
+	if got[0].Assignee != "gastown.mayor" {
+		t.Errorf("returned bead assignee = %q, want %q", got[0].Assignee, "gastown.mayor")
+	}
+}
+
+// TestCollectBeadsAcrossStores_AssigneeCombinesWithStatus verifies the assignee
+// filter composes with --status instead of overriding it. The mayor's startup
+// check is an in_progress query, so an assignee sweep that ignored status would
+// hand back already-open backlog as if it were resumable work.
+func TestCollectBeadsAcrossStores_AssigneeCombinesWithStatus(t *testing.T) {
+	rigStore := newAssigneeTestStore(t, []beads.Bead{
+		{Title: "mayor in progress", Assignee: "gastown.mayor", Status: "in_progress"},
+		{Title: "mayor still open", Assignee: "gastown.mayor", Status: "open"},
+		{Title: "other in progress", Assignee: "gastown.witness", Status: "in_progress"},
+	})
+	stores := []convoyStoreView{{path: "rig", store: rigStore}}
+
+	got, err := collectBeadsAcrossStores(stores, beadFilters{
+		assignee: "gastown.mayor",
+		status:   "in_progress",
+	})
+	if err != nil {
+		t.Fatalf("collectBeadsAcrossStores: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("assignee+status returned %d beads, want 1; got=%+v", len(got), got)
+	}
+	if got[0].Title != "mayor in progress" {
+		t.Errorf("assignee+status returned %q, want %q", got[0].Title, "mayor in progress")
+	}
+}
+
+// TestFilterBeads_Assignee covers the client-side filter the API lane relies on.
+// The first subtest is the important one: assignee as the ONLY filter must not
+// hit filterBeads' empty-filter fast path, which would return every bead in
+// town and read as "this agent owns everything".
+func TestFilterBeads_Assignee(t *testing.T) {
+	all := []beads.Bead{
+		{ID: "ga-1", Assignee: "gastown.mayor", Status: "open"},
+		{ID: "ga-2", Assignee: "gastown.witness", Status: "open"},
+		{ID: "ga-3", Assignee: "gastown.mayor", Status: "in_progress"},
+		{ID: "ga-4", Assignee: "", Status: "open"},
+	}
+
+	tests := []struct {
+		name    string
+		filters beadFilters
+		wantIDs []string
+	}{
+		{
+			name:    "assignee only is not short-circuited",
+			filters: beadFilters{assignee: "gastown.mayor"},
+			wantIDs: []string{"ga-1", "ga-3"},
+		},
+		{
+			name:    "assignee with status",
+			filters: beadFilters{assignee: "gastown.mayor", status: "in_progress"},
+			wantIDs: []string{"ga-3"},
+		},
+		{
+			name:    "assignee matches exactly, not by prefix",
+			filters: beadFilters{assignee: "gastown.may"},
+			wantIDs: nil,
+		},
+		{
+			name:    "unassigned beads are excluded",
+			filters: beadFilters{assignee: "gastown.witness"},
+			wantIDs: []string{"ga-2"},
+		},
+		{
+			name:    "no filters still returns everything",
+			filters: beadFilters{},
+			wantIDs: []string{"ga-1", "ga-2", "ga-3", "ga-4"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterBeads(all, tc.filters)
+			if len(got) != len(tc.wantIDs) {
+				t.Fatalf("filterBeads returned %d beads, want %d; got=%+v", len(got), len(tc.wantIDs), got)
+			}
+			for i, want := range tc.wantIDs {
+				if got[i].ID != want {
+					t.Errorf("bead[%d] = %q, want %q", i, got[i].ID, want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseBeadFilters_Assignee pins both flag spellings and, critically, that
+// --assignee is consumed rather than left in the positional remainder where the
+// fake-bd harness would treat it as a bead ID.
+func TestParseBeadFilters_Assignee(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantAssignee string
+		wantRest     []string
+	}{
+		{
+			name:         "equals form",
+			args:         []string{"--assignee=gastown.mayor"},
+			wantAssignee: "gastown.mayor",
+			wantRest:     nil,
+		},
+		{
+			name:         "space-separated form",
+			args:         []string{"--assignee", "gastown.mayor"},
+			wantAssignee: "gastown.mayor",
+			wantRest:     nil,
+		},
+		{
+			name:         "alongside other filters, positional preserved",
+			args:         []string{"--status", "in_progress", "--assignee", "gastown.mayor", "ga-xyz"},
+			wantAssignee: "gastown.mayor",
+			wantRest:     []string{"ga-xyz"},
+		},
+		{
+			name:         "empty assignee value stays empty",
+			args:         []string{"--assignee="},
+			wantAssignee: "",
+			wantRest:     nil,
+		},
+		{
+			name:         "trailing flag with no value is not consumed as a filter",
+			args:         []string{"--assignee"},
+			wantAssignee: "",
+			wantRest:     []string{"--assignee"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, rest := parseBeadFilters(tc.args)
+			if got.assignee != tc.wantAssignee {
+				t.Errorf("assignee = %q, want %q", got.assignee, tc.wantAssignee)
+			}
+			if len(rest) != len(tc.wantRest) {
+				t.Fatalf("rest = %v, want %v", rest, tc.wantRest)
+			}
+			for i, want := range tc.wantRest {
+				if rest[i] != want {
+					t.Errorf("rest[%d] = %q, want %q", i, rest[i], want)
+				}
+			}
+		})
+	}
+}
+
+// The API-lane assignee filter is the same filterBeads path covered above
+// (assignee-only must not short-circuit to "match everything"). An end-to-end
+// routeBeadsList + httptest case would grow the untagged http_test_server census
+// baseline; that ratchet update is deliberately out of scope for this
+// filing-prep PR (ga-fpdi.20 drops the fork census commit).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -393,10 +393,19 @@ List beads across all rigs, routed through the supervisor API when
 the controller is alive and falling back to a direct multi-store read
 otherwise.
 
-Supports --label, --status, --all, and --format. --format=json emits
-JSON (API-path JSON includes _cache_age_s; fallback-path JSON omits
-it). The bare --json flag is reserved by the CLI's JSON-contract layer
-and is not wired for this command; use --format=json.
+Supports --label, --status, --assignee, --all, and --format.
+--format=json emits JSON (API-path JSON includes _cache_age_s;
+fallback-path JSON omits it). The bare --json flag is reserved by the
+CLI's JSON-contract layer and is not wired for this command; use
+--format=json.
+
+--assignee is the cross-ledger form of "bd list --assignee". Bare bd
+reads a single ledger, so a bead that lives on a RIG ledger but is
+assigned to a city-scoped agent is invisible to it; this command sweeps
+every rig store plus the city store, so it answers "what is assigned to
+this agent anywhere in town" in one call. Use it when an agent's own
+startup work check comes back empty but work is genuinely assigned to
+it.
 
 ```
 gc beads list [flags]
@@ -408,11 +417,13 @@ gc beads list [flags]
 gc beads list
 gc beads list --label ready-to-build
 gc beads list --status open --format=json
+gc beads list --assignee gastown.mayor --status in_progress
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--all` | bool |  | include closed beads (default: open only) |
+| `--assignee` | string |  | filter to beads assigned to this identity (across every rig and the city) |
 | `--format` | string | `text` | output format: text or json |
 | `--label` | string |  | filter to beads carrying this label |
 | `--status` | string |  | filter to beads in this status |


### PR DESCRIPTION
feat(beads): add cross-ledger --assignee to gc beads list (ga-rp4k)

The mayor repeatedly reported an empty hook while genuinely holding
assigned work, twice delaying P1/P2 work on 2026-07-26 (ga-6s9, ga-0562,
ga-b5h). Root cause: an agent's startup work check runs the shell string
rendered from Agent.EffectiveAssignedInProgressQuery, which is a bare
`bd list --status in_progress --assignee=$id`. Bare bd reads ONE ledger,
so a bead that lives on a rig ledger but is assigned to a city-scoped
agent such as gastown.mayor is invisible to it. Mail from another agent
was the only path by which such work became visible.

This adds the primitive the bead asked for: a cross-ledger assignee read.
`gc beads list` already opens every rig store plus the city store, so it
was one filter short of answering "what work is assigned to me anywhere
in town". Verified against the live town, where it returns five
mayor-assigned beads spanning three ledgers (gascity ga-*, gc-packs gp-*,
town th-*); bare bd in any single scope sees at most two of them. ga-6s9
and gp-an5 were both live-invisible at the time of the fix.

Assignee is pushed down into beads.ListQuery rather than filtered after
the merge, because every backend honors it (the bd store forwards it as
`--assignee`; native/caching stores match in memory), so stores return
only the caller's rows. The API lane keeps narrowing client-side through
filterBeads: that endpoint has no assignee parameter, and ListBeads
follows next_cursor to completion, so the client-side result is exact.

Deliberately NOT changed: the generated work_query strings in
internal/config/workquery.go. Those are byte-identity pinned by a parity
oracle and golden files, and gc hook executes them once PER FEDERATED
STORE — claimStoreWithFallback commits the claim to the store a row came
from, so a query string that itself crossed ledgers would corrupt claim
attribution. Cross-store discovery belongs in the Go store-sweep layer,
which is where this change puts it.

Note gc hook ALREADY federates across rig stores for city-scoped agents
(agentIsCrossStoreEligible -> appendRigHookStores), so the remaining gap
is the prompt text that bypasses it. The mayor's startup fragment lives
in gascity-packs (template-fragments/propulsion.template.md), a repo that
is not a registered rig, so that half cannot land through this refinery
handoff and is reported on the bead instead.

Tests: cmd/gc/cmd_beads_assignee_test.go pins the cross-store sweep, the
assignee+status composition, both flag spellings, and the empty-filter
fast path (assignee as the only filter must not degrade to "match
everything"). Each test was confirmed to fail with the fix reverted.

