### PR TITLE
fix(sling): resolve namepool pool members for --nudge

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1507,7 +1507,7 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 	st := cfg.Workspace.SessionTemplate
 
 	if a.Suspended {
-		fmt.Fprintf(stderr, "cannot nudge: agent %q is suspended\n", a.QualifiedName()) //nolint:errcheck // best-effort
+		fmt.Fprintf(stderr, "warning: cannot nudge %q: agent is suspended — bead routed but not nudged\n", a.QualifiedName()) //nolint:errcheck // best-effort
 		return
 	}
 
@@ -1526,11 +1526,7 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 				if err != nil || !running {
 					continue
 				}
-				member, ok := resolveAgentIdentity(cfg, ref.qualifiedInstance, currentRigContext(cfg))
-				if !ok {
-					fmt.Fprintf(stderr, "gc sling: agent %q not found in config\n", ref.qualifiedInstance) //nolint:errcheck // best-effort
-					return true
-				}
+				member := resolvePoolNudgeMember(cfg, a, ref.qualifiedInstance)
 				target := buildSlingNudgeTarget(member, cityName, cityPath, cfg, sessStore, ref.sessionName)
 				deliverSlingNudge(target, sp, rawStore, cityPath, stdout, stderr)
 				return true
@@ -1563,6 +1559,25 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 	sn := lookupSessionNameOrLegacy(sessStore, cityName, a.QualifiedName(), st)
 	target := buildSlingNudgeTarget(*a, cityName, cityPath, cfg, sessStore, sn)
 	deliverSlingNudge(target, sp, store, cityPath, stdout, stderr)
+}
+
+// resolvePoolNudgeMember resolves the config identity to nudge for a live pool
+// member. Live members are addressed by their instance identity, which is not
+// itself a config entry: numeric slots expand to "pool-N", and namepool slots
+// expand to the namepool name (e.g. "rig/binding.furiosa"). resolveAgentIdentity
+// synthesizes the numeric shape but has no namepool knowledge, so a config
+// lookup alone strands every namepool pool member.
+//
+// The pool agent the bead was routed to is always in config, so its instance
+// projection is the correct fallback: pool members inherit the pool's provider
+// and workspace settings, and only the identity differs.
+func resolvePoolNudgeMember(cfg *config.City, pool *config.Agent, qualifiedInstance string) config.Agent {
+	if member, ok := resolveAgentIdentity(cfg, qualifiedInstance, currentRigContext(cfg)); ok {
+		return member
+	}
+	// sessionBeadConfigAgent returns the pool agent itself when the identity is
+	// not an expanded instance, so a non-nil pool always yields a usable agent.
+	return *sessionBeadConfigAgent(pool, qualifiedInstance)
 }
 
 // pokeController sends a "poke" command to the controller socket to
@@ -1657,7 +1672,7 @@ func deliverSlingNudge(target nudgeTarget, sp runtime.Provider, store beads.Stor
 
 	if err := enqueueQueuedNudgeWithStore(target.cityPath, beads.NudgesStore{Store: store}, newQueuedNudgeWithOptions(target.agent.QualifiedName(), msg, "sling", now, queuedNudgeOptionsFromTarget(target))); err != nil {
 		telemetry.RecordNudge(context.Background(), target.agent.QualifiedName(), err)
-		fmt.Fprintf(stderr, "gc sling: nudge failed: %v\n", err) //nolint:errcheck // best-effort
+		fmt.Fprintf(stderr, "warning: bead routed but nudge failed: %v\n", err) //nolint:errcheck // best-effort
 		return
 	}
 	if running {

--- a/cmd/gc/sling_nudge_pool_instance_test.go
+++ b/cmd/gc/sling_nudge_pool_instance_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// namepoolAgentForNudgeTest builds the pool shape that reproduces ga-mzq6: a
+// pool whose members are named from a namepool file, so live instances are
+// addressed as "dir/binding.<namepool-name>" rather than "pool-N". Those
+// instance identities are not config entries.
+func namepoolAgentForNudgeTest() config.Agent {
+	return config.Agent{
+		Name:              "polecat",
+		Dir:               "gascity",
+		BindingName:       "gastown",
+		NamepoolNames:     []string{"furiosa", "rictus"},
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(2),
+	}
+}
+
+// TestDoSlingNudgeNamepoolInstanceReachesRunningSession covers ga-mzq6
+// acceptance criterion 1: when a namepool-named pool member is already
+// running, the nudge resolves the live instance and is delivered instead of
+// failing the config lookup on the instance name.
+func TestDoSlingNudgeNamepoolInstanceReachesRunningSession(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	const sessionName = "gastown__polecat-th-dpcg1"
+	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("Start(%q): %v", sessionName, err)
+	}
+	sp.Calls = nil
+
+	a := namepoolAgentForNudgeTest()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{a},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+	if _, err := deps.Store.Create(beads.Bead{
+		Title:  "gascity/gastown.furiosa",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "gascity/gastown.polecat",
+			"session_name": sessionName,
+			"pool_slot":    "1",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := startNudgePoller
+	startNudgePoller = func(_, _, _ string) error { return nil }
+	t.Cleanup(func() { startNudgePoller = prev })
+
+	doSlingNudge(&a, deps.CityName, deps.CityPath, cfg, sp, deps.Store, stdout, stderr)
+
+	if strings.Contains(stderr.String(), "not found in config") {
+		t.Fatalf("stderr = %q, want no config lookup failure for the live pool instance", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "No running sessions") || strings.Contains(stderr.String(), "No running sessions") {
+		t.Fatalf("stdout=%q stderr=%q, want the live instance nudged, not the zero-instance wake path", stdout.String(), stderr.String())
+	}
+	var observedLiveSession bool
+	for _, call := range sp.Calls {
+		if call.Method == "IsRunning" && call.Name == sessionName {
+			observedLiveSession = true
+			break
+		}
+	}
+	if !observedLiveSession {
+		t.Fatalf("runtime calls = %#v, want IsRunning for namepool instance session %q", sp.Calls, sessionName)
+	}
+	if !strings.Contains(stdout.String(), "gascity/gastown.furiosa") {
+		t.Fatalf("stdout = %q, want nudge output naming the namepool pool instance", stdout.String())
+	}
+}
+
+// TestDoSlingNudgeNamepoolNoRunningInstancePokesController covers ga-mzq6
+// acceptance criterion 2: with no live pool member, the zero-instance path
+// still pokes the controller for a wake.
+func TestDoSlingNudgeNamepoolNoRunningInstancePokesController(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	a := namepoolAgentForNudgeTest()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{a},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir() // isolated path so poke cannot hit a real socket
+
+	doSlingNudge(&a, deps.CityName, deps.CityPath, cfg, sp, deps.Store, stdout, stderr)
+
+	// Both poke outcomes (socket present or absent) print "No running sessions
+	// for <pool>"; asserting on the shared prefix keeps this independent of
+	// whether a controller socket exists on the test host.
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, `No running sessions for "gascity/gastown.polecat"`) {
+		t.Fatalf("stdout=%q stderr=%q, want the zero-instance controller wake path", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "not found in config") {
+		t.Fatalf("stderr = %q, want no config lookup failure on the zero-instance path", stderr.String())
+	}
+}
+
+// TestSlingNudgeFailureReadsAsWarning covers ga-mzq6 acceptance criterion 3:
+// a nudge-delivery failure must not be phrased like a sling failure, because
+// the bead was already routed by the time the nudge runs.
+func TestSlingNudgeFailureReadsAsWarning(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	a := config.Agent{Name: "mayor", Suspended: true, MaxActiveSessions: intPtr(1)}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{a},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+
+	doSlingNudge(&a, deps.CityName, deps.CityPath, cfg, sp, deps.Store, stdout, stderr)
+
+	got := stderr.String()
+	if !strings.HasPrefix(got, "warning: ") {
+		t.Fatalf("stderr = %q, want a 'warning: ' prefix so the routed sling is not misread as failed", got)
+	}
+	if !strings.Contains(got, "bead routed") {
+		t.Fatalf("stderr = %q, want the message to state the bead was still routed", got)
+	}
+}


### PR DESCRIPTION
fix(sling): resolve namepool pool members for --nudge (ga-mzq6)

gc sling <pool-agent> <bead> --nudge routed the bead and then failed the
nudge with 'agent "gascity/gastown.furiosa" not found in config' whenever a
pool member was already running. Reproduced 7/7 across two independent
sessions; the zero-instance path (poke controller for wake) was never
affected, which is what pinned the trigger to instance resolution.

doSlingNudge resolved the live member by feeding ref.qualifiedInstance to
resolveAgentIdentity. Pool instance identities are not config entries, and
resolveAgentIdentity only synthesizes the numeric "pool-N" shape via
resolvePoolInstance/matchPoolInstance. Namepool pools name their slots from
NamepoolNames instead (poolInstanceName), so every namepool member resolves
to a name the config lookup cannot know about. The miss branch printed and
returned true, i.e. reported the ref as handled, so the live session got no
nudge and the zero-instance controller poke was skipped too.

resolvePoolNudgeMember keeps the config lookup first, so any genuinely
configured identity still wins, and falls back to the pool agent's own
instance projection via the existing sessionBeadConfigAgent helper. The pool
agent is by definition in config (it is what the bead was routed to) and
members inherit its provider and workspace settings, so only the identity
differs. Nudge-level failures also lost the 'gc sling:' prefix that real
sling errors use and now read as 'warning: ...', because the bead is already
routed by the time the nudge runs and the old phrasing invited operators to
re-sling an already-routed bead.

Validation: new cmd/gc/sling_nudge_pool_instance_test.go covers both states
from acceptance criterion 4 - a namepool member already running (reproduced
the exact reported error before the fix) and no running member (zero-instance
poke path unchanged) - plus the warning-phrasing assertion. Full
Sling|Nudge|Pool test surface in cmd/gc passes; pre-commit lint and
go vet ./... clean.

