### PR TITLE
fix(testenv): scrub ambient metrics opt-outs so bare `go test` is trustworthy

### DIFF
--- a/cmd/gc/productmetrics_direct_child_env_test.go
+++ b/cmd/gc/productmetrics_direct_child_env_test.go
@@ -130,6 +130,16 @@ func captureProductMetricsDirectChildEnv(t *testing.T, invoke func() error) []st
 	t.Helper()
 	snapshot := filepath.Join(t.TempDir(), "child.env")
 	t.Setenv(productMetricsDirectChildEnvSpyPath, snapshot)
+	// The spy child is this test binary re-executed, so internal/testenv's
+	// init() scrub runs before the spy reads its environment — and
+	// UsageMetricsDisableEnv is a leak vector there (an ambient value silently
+	// flips the productmetrics projection). Declare it as passthrough so the
+	// value production code deliberately seeded is what the spy sees; without
+	// this the assertion reads an empty value and mistakes the scrub for
+	// missing seeding. Named by literal: importing internal/testenv outside
+	// the generated testenv_import_test.go is a stray import the package's own
+	// lint rejects.
+	t.Setenv("GC_TESTENV_PASSTHROUGH", execenv.UsageMetricsDisableEnv)
 	t.Setenv(execenv.UsageMetricsDisableEnv, "0")
 	t.Setenv("BD_DISABLE_METRICS", "keep-beads-setting")
 	t.Setenv("OTEL_SERVICE_NAME", "keep-otel-setting")

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -105,6 +105,15 @@ const PassthroughVar = "GC_TESTENV_PASSTHROUGH"
 // expensive paths. Rollout-gate env overrides (internal/rollout registry
 // EnvOverride names) DO belong here: a developer's shell value must not leak in
 // and non-deterministically flip a gate's resolved mode during a test.
+//
+// Process-level opt-out vars belong here for the same reason. DO_NOT_TRACK and
+// GC_DISABLE_USAGE_METRICS gate internal/productmetrics, and agent fleets that
+// export GC_DISABLE_USAGE_METRICS=1 into every session leak it into bare
+// `go test` while `make test` (env -i) does not — so the state projection
+// reported environment-disabled instead of the state under test. Whether a
+// productmetrics test passed depended on which shell ran it, which both
+// invented merge-gate rejections of clean branches and could mask a genuine
+// misclassification regression.
 var LeakVectorVars = []string{
 	"BEADS_DIR",
 	"BEADS_DOLT_PASSWORD",
@@ -114,6 +123,7 @@ var LeakVectorVars = []string{
 	"BEADS_DOLT_SERVER_USER",
 	"BEADS_HOLDER_TOKEN",
 	"DOLT_ROOT_PATH",
+	"DO_NOT_TRACK",
 	"GC_AGENT",
 	"GC_ALIAS",
 	"GC_BEADS",
@@ -127,6 +137,7 @@ var LeakVectorVars = []string{
 	"GC_CITY_RUNTIME_DIR",
 	"GC_CONTROL_DISPATCHER_TRACE_DEFAULT",
 	"GC_DIR",
+	"GC_DISABLE_USAGE_METRICS",
 	"GC_DOLT",
 	"GC_DOLT_HOST",
 	"GC_DOLT_PASSWORD",

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -52,6 +53,26 @@ func TestInitScrubsLeakVectors(t *testing.T) {
 	}
 	if !strings.Contains(got, "GC_FAST_UNIT=should-survive") {
 		t.Errorf("GC_FAST_UNIT was scrubbed but should not be; child output:\n%s", got)
+	}
+}
+
+// TestMetricsOptOutVarsAreLeakVectors pins DO_NOT_TRACK and
+// GC_DISABLE_USAGE_METRICS into LeakVectorVars. TestInitScrubsLeakVectors
+// proves whatever is on the list gets scrubbed, which is tautological about
+// membership — dropping a name from the list would silently satisfy it.
+//
+// Membership is the load-bearing part here. Agent fleets that export
+// GC_DISABLE_USAGE_METRICS=1 into every session leak it into bare `go test`
+// while `make test` (env -i) does not. internal/productmetrics then reported
+// environment-disabled instead of the state under test, and whether a test
+// passed depended on which shell ran it — which invented merge-gate
+// rejections of clean branches and could equally mask a real
+// misclassification regression.
+func TestMetricsOptOutVarsAreLeakVectors(t *testing.T) {
+	for _, name := range []string{"DO_NOT_TRACK", "GC_DISABLE_USAGE_METRICS"} {
+		if !slices.Contains(testenv.LeakVectorVars, name) {
+			t.Errorf("%s missing from LeakVectorVars; an ambient value would reach test code and flip the productmetrics state projection", name)
+		}
 	}
 }
 

--- a/internal/workspacesvc/proxy_process_test.go
+++ b/internal/workspacesvc/proxy_process_test.go
@@ -83,7 +83,13 @@ func requirePython3(t *testing.T) {
 // that proxy_process.go intentionally seeds into the helper env. Other GC_*
 // leak vectors stay scrubbed. GC_SERVICE_* vars are not leak vectors so they
 // flow through untouched without being listed here.
-const helperPassthroughForTests = "GC_CITY,GC_CITY_PATH,GC_CITY_RUNTIME_DIR,GC_CONTROL_DISPATCHER_TRACE_DEFAULT"
+//
+// GC_DISABLE_USAGE_METRICS is on the list for the same reason: proxy_process.go
+// seeds the opt-out into every helper env deliberately, and that seeding is
+// what TestProxyProcessDisablesProductMetrics asserts. It is a leak vector
+// elsewhere — an ambient value silently flips the productmetrics projection —
+// so only this intentional seeding is exempted, by name.
+const helperPassthroughForTests = "GC_CITY,GC_CITY_PATH,GC_CITY_RUNTIME_DIR,GC_CONTROL_DISPATCHER_TRACE_DEFAULT,GC_DISABLE_USAGE_METRICS"
 
 // setHelperPassthrough installs extraHelperEnv so proxy_process.start()
 // appends the passthrough var to the helper subprocess env. Tests run


### PR DESCRIPTION
fix(testenv): scrub ambient metrics opt-outs so bare `go test` is trustworthy

Process-level opt-out vars DO_NOT_TRACK and GC_DISABLE_USAGE_METRICS gate
internal/productmetrics. Agent fleets that export GC_DISABLE_USAGE_METRICS=1
into every session leak it into bare `go test` while `make test` (env -i)
does not, so the state projection reported environment-disabled instead of
the state under test. Whether a productmetrics test passed depended on which
shell ran it — inventing merge-gate rejections of clean branches and masking
genuine misclassification regressions.

Add both names to LeakVectorVars (the mechanism Makefile already points at
for the direct-`go test` path) and pin membership with
TestMetricsOptOutVarsAreLeakVectors. Tests that deliberately seed
GC_DISABLE_USAGE_METRICS into re-executed spy children declare it via
GC_TESTENV_PASSTHROUGH so intentional seeding stays visible while ambient
values stay scrubbed.

Fork census/ratchet baseline bumps are intentionally omitted — upstream
re-measures if needed.

