### PR TITLE
docs(dispatch): state the real base_branch resolution order

### DIFF
--- a/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
@@ -135,14 +135,40 @@ These require the gastown pack. They extend the built-in
 
 **mol-polecat-work** — Feature-branch variant. Creates a worktree and
 feature branch, implements, then pushes and reassigns to the refinery
-for merge review. Production default for multi-agent setups. The polecat's
-`base_branch` comes from `metadata.target` on the work bead if present,
-otherwise from a parent convoy with `metadata.target`, otherwise from
-the rig repo's default branch.
+for merge review. Production default for multi-agent setups.
 
 ```
 gc sling <agent> <bead-id> --on mol-polecat-work
 ```
+
+The polecat cuts its branch from `origin/<base_branch>` and stamps
+`metadata.target` for the refinery, so `base_branch` decides where the
+work lands. `gc sling` resolves it in this order, first match wins:
+
+1. `metadata.target` on the work bead, or on the nearest parent convoy
+   that carries one — the per-bead override.
+2. `default_branch` recorded for the bead's rig in `city.toml`.
+3. `default_branch` recorded for the agent's rig in `city.toml`.
+4. A live probe of the rig repo's `origin/HEAD`.
+
+Tiers 2 and 3 are the knob to reach for when a repo's mainline is not
+what `origin/HEAD` advertises. A repo whose `origin/HEAD` still points at
+a mirror-only `main` while work belongs on an integration branch sets it
+once, per rig:
+
+```toml
+[[rigs]]
+name = "myrig"
+default_branch = "develop"
+```
+
+Without that, resolution falls through to the tier-4 probe and every
+polecat branch is cut from the mirror. `gc rig add` captures
+`default_branch` from the repo at add time, so a rig registered before
+its mainline moved keeps the stale value until you update it — check
+`gc rig list --json` rather than inferring the answer from
+`git symbolic-ref refs/remotes/origin/HEAD`, which only ever reports
+tier 4.
 
 **mol-idea-to-plan** — Planning workflow for a coordinator session. Turns a
 rough idea into a PRD, reviewed design doc, and beads DAG using Gas City's

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -4516,3 +4516,66 @@ func TestSlingFormulaTargetBranch_FallsBackToProbeWhenUnset(t *testing.T) {
 		t.Errorf("SlingFormulaTargetBranch = %q, want %q (fallback to live probe)", got, "trunk")
 	}
 }
+
+// TestBuildSlingFormulaVarsInjectsBaseBranchFromRigDefault covers a repo
+// whose mainline differs from origin/HEAD: the live probe points at a
+// mirror-only "main" while city.toml records default_branch = "develop".
+// The recorded branch must reach the formula as base_branch.
+//
+// The tiers themselves are covered by the SlingFormulaTargetBranch tests
+// above; what this locks is the wiring in buildSlingFormulaVars. If the
+// injection stops firing, base_branch falls through to the formula's own
+// "main" default and every polecat worktree is cut from the wrong branch
+// silently, because a missing var is indistinguishable from an authored
+// default at render time.
+func TestBuildSlingFormulaVarsInjectsBaseBranchFromRigDefault(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC", DefaultBranch: "develop"},
+		},
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		Branches: fixedBranchResolver{branch: "main"},
+	}
+	a := config.Agent{Name: "polecat", Dir: "scamper"}
+
+	vars := BuildSlingFormulaVars("mol-polecat-work", "SC-1", nil, a, deps)
+
+	if got := vars["base_branch"]; got != "develop" {
+		t.Fatalf("base_branch var = %q, want %q (rig default_branch beats the origin/HEAD probe)", got, "develop")
+	}
+}
+
+// TestBuildSlingFormulaVarsBaseBranchPrefersBeadTarget locks tier 1 at the
+// wiring layer: an explicit metadata.target on the work bead overrides the
+// rig's recorded default_branch. This is the per-bead escape hatch callers
+// use to retarget a single piece of work (a release branch, an integration
+// branch) without editing city.toml.
+func TestBuildSlingFormulaVarsBaseBranchPrefersBeadTarget(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC", DefaultBranch: "develop"},
+		},
+	}
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{Metadata: map[string]string{"target": "release/v2"}})
+	if err != nil {
+		t.Fatalf("seeding bead: %v", err)
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    store,
+		Branches: fixedBranchResolver{branch: "main"},
+	}
+	a := config.Agent{Name: "polecat", Dir: "scamper"}
+
+	vars := BuildSlingFormulaVars("mol-polecat-work", bead.ID, nil, a, deps)
+
+	if got := vars["base_branch"]; got != "release/v2" {
+		t.Fatalf("base_branch var = %q, want %q (bead metadata.target wins)", got, "release/v2")
+	}
+}


### PR DESCRIPTION
docs(dispatch): state the real base_branch resolution order (ga-7mh5)

The gc-dispatch skill described a three-tier base_branch order that
omitted the default_branch tiers entirely and ended at "the rig repo's
default branch" — which reads as the origin/HEAD probe. An agent that
cross-checks that sentence with
`git symbolic-ref refs/remotes/origin/HEAD` can conclude the wrong base
and hand-rebase work that was already based correctly.

The resolver itself is not defective: SlingFormulaTargetBranch already
places a rig's recorded default_branch (tiers 2-3) ahead of the
origin/HEAD probe (tier 4). The documentation is what misled readers.

This updates the skill to state all four tiers, names default_branch as
the knob for a repo whose mainline differs from origin/HEAD, shows the
city.toml stanza, and tells the reader to confirm with
`gc rig list --json` instead of inferring from origin/HEAD (tier 4 only).

The accompanying tests close a real gap rather than restating the
resolver tests: buildSlingFormulaVars — the wiring that decides whether
base_branch is injected at all — had no coverage. If that injection stops
firing, the var falls through to the formula's own "main" default and
every polecat branch is cut from the wrong branch silently, because an
absent var is indistinguishable from an authored default at render time.

Source: dc8327db3 (ga-7mh5), adapted for upstream (soften fork/ROE
framing to generic "repo whose mainline differs from origin/HEAD").

