### PR TITLE
fix(pool): resolve modern pool session names in orphan-release liveness check

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -614,9 +614,14 @@ func directSessionBeadIDCandidates(assignee string) []string {
 		if assignee[i] != '-' {
 			continue
 		}
-		if suffix := assignee[i+1:]; suffix != "" {
-			candidates = append(candidates, suffix)
+		// A qualified agent name encodes "/" as "--" (agent.SessionNameFor),
+		// so the byte after a "-" can be another "-". Such a suffix is never a
+		// bead ID, and stores that shell out would read it as a flag.
+		suffix := assignee[i+1:]
+		if suffix == "" || suffix[0] == '-' {
+			continue
 		}
+		candidates = append(candidates, suffix)
 	}
 	return candidates
 }

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -590,14 +590,33 @@ func liveSessionBeadExistsByIdentity(store beads.Store, assignee string) bool {
 	return false
 }
 
+// directSessionBeadIDCandidates returns the bead IDs a work-bead assignee could
+// name, so liveSessionBeadExistsByIdentity can resolve the owning session bead
+// with a direct Get instead of depending on the open-session snapshot or the
+// live gc:session label list.
+//
+// A pool assignee is PoolSessionName(template, beadID) —
+// "<sanitized-template-base>-<beadID>" — and bead IDs contain a "-" themselves
+// ("th-vb20q"), so the ID is not simply the final "-"-delimited segment.
+// Enumerating every suffix that begins just after a "-" covers both the modern
+// form and the legacy "-mc-" form without special-casing either.
+//
+// Extra candidates cannot produce a false "session is live" answer: the caller
+// still requires the resolved bead to be a non-closed session bead whose own
+// assignee identities contain this exact assignee.
 func directSessionBeadIDCandidates(assignee string) []string {
 	assignee = strings.TrimSpace(assignee)
 	if assignee == "" {
 		return nil
 	}
 	candidates := []string{assignee}
-	if idx := strings.LastIndex(assignee, "-mc-"); idx >= 0 {
-		candidates = append(candidates, assignee[idx+1:])
+	for i := 0; i < len(assignee); i++ {
+		if assignee[i] != '-' {
+			continue
+		}
+		if suffix := assignee[i+1:]; suffix != "" {
+			candidates = append(candidates, suffix)
+		}
 	}
 	return candidates
 }

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -2600,5 +2601,26 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveModernPoolSessionWhenLiveListMi
 	}
 	if got.Assignee != sessionName {
 		t.Fatalf("assignee = %q, want %q", got.Assignee, sessionName)
+	}
+}
+
+func TestDirectSessionBeadIDCandidates_SkipsFlagLikeCandidates(t *testing.T) {
+	// agent.SessionNameFor encodes "/" as "--" for qualified identities, so a
+	// named-session assignee can carry a "--" pair. The suffix starting at the
+	// second "-" of that pair begins with "-", which is never a bead ID and
+	// which shell-out stores would read as a flag.
+	sessionName := agent.SessionNameFor("", "hello-world/polecat", "") + "-th-abc12"
+	if sessionName != "hello-world--polecat-th-abc12" {
+		t.Fatalf("session name = %q, want hello-world--polecat-th-abc12", sessionName)
+	}
+
+	candidates := directSessionBeadIDCandidates(sessionName)
+	if !slices.Contains(candidates, "th-abc12") {
+		t.Fatalf("candidates = %v, want to contain the session bead ID %q", candidates, "th-abc12")
+	}
+	for _, c := range candidates {
+		if strings.HasPrefix(c, "-") {
+			t.Fatalf("candidate %q starts with %q; stores that shell out would read it as a flag (all: %v)", c, "-", candidates)
+		}
 	}
 }

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"log"
+	"slices"
 	"strings"
 	"testing"
 
@@ -2494,4 +2495,110 @@ func gcSweepSessionBeadsFromBeads(store beads.Store, sessionBeads []beads.Bead) 
 		infos = append(infos, seedSessionInfo(b))
 	}
 	return GCSweepSessionBeads(store, nil, infos)
+}
+
+func TestDirectSessionBeadIDCandidates_DerivesModernPoolSessionBeadID(t *testing.T) {
+	// Regression (ga-us0j): pool session names are
+	// PoolSessionName(template, beadID) == "<sanitized-template-base>-<beadID>",
+	// and bead IDs themselves contain a "-" ("th-vb20q"), so the bead ID is
+	// not the final "-"-delimited segment. The direct-resolution candidates
+	// must still offer it, otherwise liveSessionBeadExistsByIdentity cannot
+	// resolve a live modern-named session and orphan release drops a live
+	// worker's claim.
+	sessionName := PoolSessionName("gascity/koolkats.polekitten", "th-vb20q")
+	if sessionName != "koolkats__polekitten-th-vb20q" {
+		t.Fatalf("PoolSessionName = %q, want koolkats__polekitten-th-vb20q", sessionName)
+	}
+
+	candidates := directSessionBeadIDCandidates(sessionName)
+	if !slices.Contains(candidates, "th-vb20q") {
+		t.Fatalf("candidates = %v, want to contain the session bead ID %q", candidates, "th-vb20q")
+	}
+
+	// The legacy "-mc-" form must keep resolving.
+	legacy := directSessionBeadIDCandidates("worker-mc-live")
+	if !slices.Contains(legacy, "mc-live") {
+		t.Fatalf("legacy candidates = %v, want to contain %q", legacy, "mc-live")
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsLiveModernPoolSessionWhenLiveListMissesIt(t *testing.T) {
+	// Regression (ga-us0j): a live pool worker's claim was reset to
+	// open+unassigned while the worker was mid-run. The work bead kept
+	// gc.routed_to, so it immediately re-matched pending pool demand and a
+	// second worker could be spawned onto the same bead and branch.
+	//
+	// The trigger is a live session that is absent from BOTH the open-session
+	// snapshot and the live gc:session label list. The designed backstop is
+	// liveSessionBeadExistsByIdentity resolving the session bead directly by
+	// ID, but it only understood the legacy "-mc-" naming, so modern pool
+	// session names had no backstop at all.
+	base := beads.NewMemStore()
+	sessionBead, err := base.Create(beads.Bead{
+		Title:  "polekitten",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":             "gascity/koolkats.polekitten",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	// The session name embeds this session bead's own ID, exactly as the
+	// runtime builds it.
+	sessionName := PoolSessionName("gascity/koolkats.polekitten", sessionBead.ID)
+	if err := base.SetMetadata(sessionBead.ID, "session_name", sessionName); err != nil {
+		t.Fatalf("Set session_name: %v", err)
+	}
+
+	work, err := base.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: sessionName,
+		Metadata: map[string]string{"gc.routed_to": "gascity/koolkats.polekitten"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := base.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = base.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	// The live gc:session label list misses the session; Get still resolves it.
+	store := sessionListMissStore{Store: base}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{
+			Name:              "gascity/koolkats.polekitten",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(2),
+		}}},
+		"",
+		nil, // open-session snapshot also misses the live session
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none — the owning pool session is live", released)
+	}
+
+	got, err := base.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress — a live worker's claim was dropped", got.Status)
+	}
+	if got.Assignee != sessionName {
+		t.Fatalf("assignee = %q, want %q", got.Assignee, sessionName)
+	}
 }


### PR DESCRIPTION
fix(pool): resolve modern pool session names in orphan-release liveness check (ga-us0j)

A live pool worker's claim was reset to open+unassigned while the worker
was mid-run, twice in 75 minutes. The work bead kept gc.routed_to, which
is exactly the controller's pending-pool-demand shape, so the bead
immediately re-matched pool demand and a second worker could be spawned
onto the same bead and the same polecat/<bead-id> branch.

The writer is releaseOrphanedPoolAssignments: it swaps status->open and
assignee->"" and clears only beadmeta.SessionAffinityMetadataKeys
(gc.session_affinity, gc.continuation_group), leaving gc.routed_to,
gc.session_name and gc.work_dir intact. That partial-write signature
matches both observed incidents exactly.

For that release to fire, every liveness gate must miss the owning
session. The last of them, liveSessionBeadExistsByIdentity, is the
snapshot- and list-independent backstop: it resolves the session bead
with a direct Get. But directSessionBeadIDCandidates only understood the
legacy "-mc-" naming. A modern pool assignee is
PoolSessionName(template, beadID) == "<sanitized-template-base>-<beadID>"
("koolkats__polekitten-th-vb20q"), and bead IDs contain a "-" themselves,
so the bead ID is not the final "-"-delimited segment and no candidate
ever resolved. Modern-named pool sessions therefore had no backstop, and
any snapshot or gc:session label-list miss dropped a live worker's claim.

Enumerate every suffix beginning just after a "-" instead of
special-casing "-mc-", which the general form subsumes. Extra candidates
cannot yield a false "live" answer: the caller still requires the
resolved bead to be a non-closed session bead whose own assignee
identities contain the exact assignee.

This restores the intended backstop. It does not explain why the
open-session snapshot and the live gc:session list both missed a live,
open, correctly-labelled session bead; that remains open as ga-ohnx.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

fix(pool): drop flag-like session-bead ID candidates (ga-us0j)

agent.SessionNameFor encodes "/" as "--" for qualified identities, so a
named-session assignee can carry a "--" pair. Enumerating suffixes after
every "-" therefore emits one that itself starts with "-", which is never
a bead ID and which stores that shell out to bd would read as a flag
rather than an ID.

Skip those candidates.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

