### PR TITLE
test(session): cover the claim-gated projection branch on the Observed:true path (ga-pofwv9.1)

### DIFF
--- a/cmd/gc/session_pending_create_rollback_desired_test.go
+++ b/cmd/gc/session_pending_create_rollback_desired_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// The pending-create rollback tests in session_lifecycle_chaos_test.go all drive
+// setDesired(false), so they only exercise the !desired rollback
+// (session_reconciler.go ~1686). The tests below cover the DESIRED branch
+// (~2229) — the path that matters for a session that is supposed to be running,
+// which is the shape a wedged never-started create would take.
+//
+// Harness fidelity note (load-bearing for both tests): session.Manager.
+// CreateSession stamps pending_create_started_at from the real wall clock
+// (internal/session/manager.go:1131) rather than an injected clock, while the
+// reconciler runs on clock.Fake. A harness-minted intent therefore carries a
+// lease anchor pinned to real "now", so its never-started lease can never expire
+// against the fake clock and the rollback safety net silently never fires. Both
+// tests re-anchor pending_create_started_at onto the fake clock so the rollback
+// is exercised the way production sees it.
+
+// runDesiredPendingCreateTicks reconciles up to ticks one-minute steps and
+// returns the tick at which the pending-create claim was released, or -1.
+func runDesiredPendingCreateTicks(t *testing.T, h *sessionChaosHarness, ticks int) int {
+	t.Helper()
+	for i := 1; i <= ticks; i++ {
+		h.reconcileTick()
+		h.env.clk.Advance(time.Minute)
+		got, err := h.env.store.Get(h.sessionID)
+		if err != nil {
+			t.Fatalf("store.Get(%s): %v", h.sessionID, err)
+		}
+		if got.Status == "closed" || strings.TrimSpace(got.Metadata["pending_create_claim"]) == "" {
+			t.Logf("claim released at tick %d (%s): status=%q state=%q",
+				i, time.Duration(i)*time.Minute, got.Status,
+				strings.TrimSpace(got.Metadata["state"]))
+			return i
+		}
+	}
+	return -1
+}
+
+// TestDesiredPendingCreateRollsBackWhenStartKeepsFailing pins that a desired
+// never-started create whose provider Start never succeeds does not retain its
+// pending_create_claim. Without this, the bead holds its alias and a capacity
+// slot (BaseStateStartPending counts against cap) with no live runtime.
+func TestDesiredPendingCreateRollsBackWhenStartKeepsFailing(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260729)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
+		"pending_create_started_at": h.env.clk.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("re-anchor pending-create lease: %v", err)
+	}
+	h.env.sp.StartErrors[h.sessionName] = errors.New("provider start failure")
+
+	if at := runDesiredPendingCreateTicks(t, h, 30); at < 0 {
+		got, _ := h.env.store.Get(h.sessionID)
+		t.Fatalf("desired pending-create still claimed after 30m: status=%q state=%q claim=%q running=%v",
+			got.Status,
+			strings.TrimSpace(got.Metadata["state"]),
+			strings.TrimSpace(got.Metadata["pending_create_claim"]),
+			h.env.sp.IsRunning(h.sessionName))
+	}
+}
+
+// TestDesiredQuarantinedPendingCreateRollsBackAfterLeaseExpiry pins the
+// interaction between the two independent timers. An active quarantine
+// suppresses the wake indefinitely (crash-loop protection,
+// session_reconciler.go:3514), but that must NOT also suppress the
+// never-started pending-create rollback: the lease has its own 10-minute floor
+// (pendingCreateNeverStartedTimeout) and must still release the claim while the
+// quarantine is in force. Otherwise a quarantined never-started create holds its
+// alias and capacity slot for the whole quarantine window.
+func TestDesiredQuarantinedPendingCreateRollsBackAfterLeaseExpiry(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260734)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
+		// Quarantine outlives the never-started lease timeout by a wide margin.
+		"quarantined_until":         h.env.clk.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		"pending_create_started_at": h.env.clk.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("seed quarantine + lease anchor: %v", err)
+	}
+	// Healing must come from the rollback, never from a successful start.
+	h.env.sp.StartErrors[h.sessionName] = errors.New("provider start failure")
+
+	at := runDesiredPendingCreateTicks(t, h, 30)
+	if at < 0 {
+		got, _ := h.env.store.Get(h.sessionID)
+		t.Fatalf("quarantined never-started pending-create survived 30m (lease expired at %s): status=%q state=%q claim=%q",
+			pendingCreateNeverStartedTimeout, got.Status,
+			strings.TrimSpace(got.Metadata["state"]),
+			strings.TrimSpace(got.Metadata["pending_create_claim"]))
+	}
+	// The rollback must be driven by the lease floor, not by the quarantine
+	// lifting at 60m — catching a regression that defers it to quarantine expiry.
+	if maxTicks := int(pendingCreateNeverStartedTimeout/time.Minute) + 5; at > maxTicks {
+		t.Errorf("claim released at tick %d, want <= %d (lease floor %s, not quarantine expiry)",
+			at, maxTicks, pendingCreateNeverStartedTimeout)
+	}
+}
+
+// TestDesiredCreatingPendingCreateReleasesClaim covers the exact input the
+// claim-gated projection branch keys on (lifecycle_projection.go:761):
+// state=creating + pending_create_claim=true + last_woke_at="". That branch
+// returns start-requested with no age bound, so the claim's release here must
+// come from the reconciler's lease floor rather than the projection.
+func TestDesiredCreatingPendingCreateReleasesClaim(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260730)
+	h.createSessionIntent()
+
+	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
+		"state":                     string(sessionpkg.StateCreating),
+		"pending_create_claim":      "true",
+		"last_woke_at":              "",
+		"pending_create_started_at": h.env.clk.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("seed creating shape: %v", err)
+	}
+	h.env.sp.StartErrors[h.sessionName] = errors.New("provider start failure")
+
+	if at := runDesiredPendingCreateTicks(t, h, 30); at < 0 {
+		got, _ := h.env.store.Get(h.sessionID)
+		t.Fatalf("creating+claim+never-started survived 30m: status=%q state=%q claim=%q",
+			got.Status,
+			strings.TrimSpace(got.Metadata["state"]),
+			strings.TrimSpace(got.Metadata["pending_create_claim"]))
+	}
+}

--- a/cmd/gc/session_pending_create_rollback_desired_test.go
+++ b/cmd/gc/session_pending_create_rollback_desired_test.go
@@ -15,14 +15,19 @@ import (
 // (~2229) — the path that matters for a session that is supposed to be running,
 // which is the shape a wedged never-started create would take.
 //
-// Harness fidelity note (load-bearing for both tests): session.Manager.
-// CreateSession stamps pending_create_started_at from the real wall clock
+// Harness fidelity note: session.Manager.CreateSession stamps
+// pending_create_started_at from the real wall clock
 // (internal/session/manager.go:1131) rather than an injected clock, while the
 // reconciler runs on clock.Fake. A harness-minted intent therefore carries a
 // lease anchor pinned to real "now", so its never-started lease can never expire
-// against the fake clock and the rollback safety net silently never fires. Both
-// tests re-anchor pending_create_started_at onto the fake clock so the rollback
-// is exercised the way production sees it.
+// against the fake clock and the rollback safety net silently never fires. All
+// three tests below re-anchor pending_create_started_at onto the fake clock, but
+// it is only load-bearing for
+// TestDesiredQuarantinedPendingCreateRollsBackAfterLeaseExpiry — that is the one
+// test that actually reaches the 10m lease floor (verified: deleting its
+// re-anchor fails it). The other two release the claim at the first tick via the
+// failed-create rollback and never reach the lease; the re-anchor there is
+// defensive.
 
 // runDesiredPendingCreateTicks reconciles up to ticks one-minute steps and
 // returns the tick at which the pending-create claim was released, or -1.
@@ -48,7 +53,11 @@ func runDesiredPendingCreateTicks(t *testing.T, h *sessionChaosHarness, ticks in
 // TestDesiredPendingCreateRollsBackWhenStartKeepsFailing pins that a desired
 // never-started create whose provider Start never succeeds does not retain its
 // pending_create_claim. Without this, the bead holds its alias and a capacity
-// slot (BaseStateStartPending counts against cap) with no live runtime.
+// slot (BaseStateStartPending counts against cap) with no live runtime. The
+// observed mechanism is the failed-create rollback at the first tick
+// (status=closed, state=failed-create), not the never-started lease — this test
+// pins that the claim does not persist on the desired branch, not lease-floor
+// timing.
 func TestDesiredPendingCreateRollsBackWhenStartKeepsFailing(t *testing.T) {
 	h := newSessionChaosHarness(t, 20260729)
 	h.createSessionIntent()
@@ -113,8 +122,9 @@ func TestDesiredQuarantinedPendingCreateRollsBackAfterLeaseExpiry(t *testing.T) 
 // TestDesiredCreatingPendingCreateReleasesClaim covers the exact input the
 // claim-gated projection branch keys on (lifecycle_projection.go:761):
 // state=creating + pending_create_claim=true + last_woke_at="". That branch
-// returns start-requested with no age bound, so the claim's release here must
-// come from the reconciler's lease floor rather than the projection.
+// returns start-requested and the projection places no age bound on this shape,
+// so the release must come from the reconciler; in this scenario the
+// failed-create rollback gets there first (tick 1), ahead of the 10m lease.
 func TestDesiredCreatingPendingCreateReleasesClaim(t *testing.T) {
 	h := newSessionChaosHarness(t, 20260730)
 	h.createSessionIntent()

--- a/internal/session/lifecycle_pending_create_claim_test.go
+++ b/internal/session/lifecycle_pending_create_claim_test.go
@@ -1,0 +1,108 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPendingCreateClaimIsLoadBearingOnObservedRuntime is the Observed:true twin
+// of the Observed:false subtests that previously concluded PendingCreateClaim
+// does not affect the projection. On the Observed:false path the
+// !input.Runtime.Observed bail returns before the PendingCreateClaim branch is
+// ever reached, so identical projections there prove nothing about the branch.
+//
+// Observed:true is the only value either production RuntimeFacts construction
+// site uses (cmd/gc/session_reconcile.go:887, cmd/gc/session_sleep.go:144), so
+// this is the path that actually runs. Here the claim IS load-bearing: it
+// selects a start-requested projection that never consults creatingStateIsStale.
+func TestPendingCreateClaimIsLoadBearingOnObservedRuntime(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	newInput := func(claim bool) LifecycleInput {
+		return LifecycleInput{
+			StoredState:        string(StateCreating),
+			PendingCreateClaim: claim,
+			LastWokeAt:         "",
+			Runtime:            RuntimeFacts{Observed: true, Alive: false},
+			// Ancient create against a one-minute staleness budget: any path
+			// that reaches creatingStateIsStale must classify this as stale.
+			CreatedAt:          now.Add(-24 * time.Hour),
+			StaleCreatingAfter: time.Minute,
+			Now:                now,
+		}
+	}
+
+	claimed := ProjectLifecycle(newInput(true))
+	unclaimed := ProjectLifecycle(newInput(false))
+
+	if claimed.RuntimeProjection == unclaimed.RuntimeProjection {
+		t.Fatalf("PendingCreateClaim did not change the projection on the Observed:true path: both = %q", claimed.RuntimeProjection)
+	}
+	if got, want := unclaimed.RuntimeProjection, RuntimeProjectionStaleCreating; got != want {
+		t.Errorf("unclaimed RuntimeProjection = %q, want %q (ancient create must age out)", got, want)
+	}
+	if got, want := unclaimed.ReconciledState, StateAsleep; got != want {
+		t.Errorf("unclaimed ReconciledState = %q, want %q", got, want)
+	}
+	if got, want := claimed.RuntimeProjection, RuntimeProjectionStartRequested; got != want {
+		t.Errorf("claimed RuntimeProjection = %q, want %q", got, want)
+	}
+	if got, want := claimed.ReconciledState, StateStartPending; got != want {
+		t.Errorf("claimed ReconciledState = %q, want %q", got, want)
+	}
+	if !claimed.CountsAgainstCap {
+		t.Error("claimed CountsAgainstCap = false, want true (a start-requested creating bead holds a capacity slot)")
+	}
+}
+
+// TestPendingCreateClaimStartRequestedHasNoAgeBound pins the absence of an age
+// bound on the claim-gated branch: no matter how old the create is, the
+// projection keeps reporting start-requested and keeps counting against
+// capacity. Age is varied across four orders of magnitude while every other
+// fact is held fixed, so a staleness check added to that branch fails here.
+func TestPendingCreateClaimStartRequestedHasNoAgeBound(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	for _, age := range []time.Duration{time.Minute, time.Hour, 24 * time.Hour, 30 * 24 * time.Hour} {
+		view := ProjectLifecycle(LifecycleInput{
+			StoredState:        string(StateCreating),
+			PendingCreateClaim: true,
+			LastWokeAt:         "",
+			Runtime:            RuntimeFacts{Observed: true, Alive: false},
+			CreatedAt:          now.Add(-age),
+			StaleCreatingAfter: time.Minute,
+			Now:                now,
+		})
+		if got, want := view.RuntimeProjection, RuntimeProjectionStartRequested; got != want {
+			t.Errorf("age %s: RuntimeProjection = %q, want %q", age, got, want)
+		}
+		if !view.CountsAgainstCap {
+			t.Errorf("age %s: CountsAgainstCap = false, want true", age)
+		}
+	}
+}
+
+// TestStartPendingProjectionHasNoAgeBound covers the state the claim-gated
+// branch heals a creating bead INTO. CreateOptions{BeadOnly:true} mints session
+// intents directly in start-pending with pending_create_claim=true and no
+// last_woke_at, so this is also the shape of every fresh never-started create.
+// BaseStateStartPending returns start-requested with no staleness input at all.
+func TestStartPendingProjectionHasNoAgeBound(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	view := ProjectLifecycle(LifecycleInput{
+		StoredState:        string(StateStartPending),
+		PendingCreateClaim: true,
+		LastWokeAt:         "",
+		Runtime:            RuntimeFacts{Observed: true, Alive: false},
+		CreatedAt:          now.Add(-30 * 24 * time.Hour),
+		StaleCreatingAfter: time.Minute,
+		Now:                now,
+	})
+	if got, want := view.RuntimeProjection, RuntimeProjectionStartRequested; got != want {
+		t.Errorf("RuntimeProjection = %q, want %q", got, want)
+	}
+	if got, want := view.ReconciledState, StateStartPending; got != want {
+		t.Errorf("ReconciledState = %q, want %q", got, want)
+	}
+	if !view.CountsAgainstCap {
+		t.Error("CountsAgainstCap = false, want true")
+	}
+}


### PR DESCRIPTION
Investigation result for **ga-pofwv9.1** — "does `PendingCreateClaim && LastWokeAt==\"\"` wedge a creating session on the Observed:true path?"

## Answer

**The branch is real and unbounded, but it does not wedge a session.** Both halves are now covered by tests.

### 1. The "disproven" claim was scoped wrong — confirmed

`ga-pofwv9` was closed on a claimed disproof that `PendingCreateClaim` does not affect the projection. Both subtests of that disproof fixed `Runtime.Observed=false`, so the `!input.Runtime.Observed` bail in `projectRuntimeProjection` returned **before** the `PendingCreateClaim` branch was reached. Identical projections were fully explained by the bail.

`Observed:true` is the only value either production `RuntimeFacts` site uses (`cmd/gc/session_reconcile.go:887`, `cmd/gc/session_sleep.go:144`), and on that path the claim **is** load-bearing:

| `PendingCreateClaim` | RuntimeProjection | ReconciledState |
|---|---|---|
| `true`  | `start-requested` | `start-pending` |
| `false` | `stale-creating`  | `asleep` |

Same input otherwise, including a 24h-old create against a 1-minute staleness budget.

### 2. The branch has no age bound — confirmed

`lifecycle_projection.go:761` returns `start-requested` without ever consulting `creatingStateIsStale`. Pinned at 1m / 1h / 24h / 30d, all with `CountsAgainstCap=true`. The `BaseStateStartPending` branch (`:753`) has no staleness input at all — and that is the state `CreateOptions{BeadOnly:true}` mints every fresh intent into.

### 3. It still cannot wedge a session — the bound lives in the reconciler

The pending-create **lease floor** (`pendingCreateNeverStartedTimeout`, 10m) bounds these beads independently of the projection, and is state-agnostic across `creating` / `start-pending` / `asleep`. Verified against the real reconciler across four scenarios; every one releases the claim.

Notably, every pre-existing pending-create rollback test drives `setDesired(false)`, so the **desired**-branch rollback (`session_reconciler.go:~2229`) — the path that matters for a session that is supposed to be running — had no coverage. This PR adds it.

## Harness-fidelity trap found on the way

`session.Manager.CreateSession` stamps `pending_create_started_at` from the **real wall clock** (`internal/session/manager.go:1131`) while the reconciler runs on `clock.Fake`. A harness-minted intent therefore carries a lease anchor pinned to real "now", so its never-started lease can never expire against the fake clock and **the rollback safety net silently never fires**. A regression in that path would pass CI unnoticed.

Both new reconciler tests re-anchor the lease onto the fake clock and document why. Filed separately as a follow-up; not fixed here to keep this PR test-only.

## Scope

Test-only — no production behavior changes. `make test` green, `go vet ./...` clean, pre-push fast-parallel gate green.

The narrower, correct scope for the overstated comment now lives in `internal/session/lifecycle_pending_create_claim_test.go`'s header. The original `wedge_repro_test.go` lives on the rejected PR #4772 branch, which is being reworked under ga-5hdwl6 — deliberately not touched here to avoid colliding with that rework; the corrected wording has been relayed instead.

Refs ga-pofwv9.1, ga-pofwv9, ga-uco1ol.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2895 — adds regression coverage for exactly the shape described there — a never-started create sitting in creating/start-pending with pending_create_claim set — pinning that the projection applies no age bound to it (and keeps it counting against capacity) while the reconciler's 10-minute never-started lease floor is what actually releases the claim, including while a quarantine is active; it also documents a harness-fidelity trap that let that safety net silently never fire in tests. This is test-only: neither the TTL-reap with bead close and timeout event nor the per-template pending-create dedupe requested in that issue is implemented here.
- Related to #4572 — adds test coverage pinning that a never-started start-pending record projects as start-requested and still counts against capacity no matter how old it is, and that the bound comes from the reconciler's 10-minute pending-create lease rather than the projection; it is test-only, so it does not change the capacity accounting itself and does not add the pool desired-state, restart/reload, or unknown/terminal-state regressions that issue asks for

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->