### PR TITLE
fix(reconciler): keep stops on the city tmux socket

### DIFF
--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -74,6 +74,36 @@ func newFakeDrainOps() *fakeDrainOps {
 	}
 }
 
+func TestProviderDrainOpsClearRestartRequestedUsesCityTmuxSocket(t *testing.T) {
+	const socket = "bright-lights"
+	argsFile := filepath.Join(t.TempDir(), "args")
+	installFakeTmux(t, `printf '%s\n' "$@" > "$FAKE_TMUX_ARGS"`)
+	t.Setenv("FAKE_TMUX_ARGS", argsFile)
+
+	sp, err := newSessionProviderForCityByName(
+		nil,
+		"tmux",
+		config.SessionConfig{Socket: socket},
+		"city",
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("newSessionProviderForCityByName: %v", err)
+	}
+	if err := newDrainOps(sp).clearRestartRequested("worker"); err != nil {
+		t.Fatalf("clearRestartRequested: %v", err)
+	}
+
+	got, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read fake tmux args: %v", err)
+	}
+	want := "-u\n-L\n" + socket + "\nset-environment\n-t\nworker\n-u\nGC_RESTART_REQUESTED\n"
+	if string(got) != want {
+		t.Fatalf("tmux args = %q, want %q", got, want)
+	}
+}
+
 func TestE2b2ProviderConstructionFailuresReturnThroughRun(t *testing.T) {
 	if cityPath, sessionID, markerPath, ok := e2b2ProviderFailureHelperArgs(os.Args); ok {
 		runE2b2ProviderFailureHelper(t, cityPath, sessionID, markerPath)

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -884,7 +884,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		}
 	}
 
-	sp, err := newSessionProvider()
+	sp, err := newSessionProviderForCity(cfg, cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/bootstrap"
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -2061,5 +2062,76 @@ func TestPassthroughEnvWithholdsControllerTokenFromChildProcess(t *testing.T) {
 	}
 	if strings.Contains(string(out), token) {
 		t.Errorf("child process received the controller token: %s", out)
+	}
+}
+
+// TestStartStandaloneBuildsSessionProviderFromResolvedCityConfig pins the
+// wiring at cmd_start.go's provider-construction site: the provider must be
+// built from the config and path gc start already resolved, not from a second,
+// independent city rediscovery.
+//
+// The regression it guards is silent. The rediscovery path
+// (newSessionProvider → loadSessionProviderContext) swallows both
+// resolveCity() and loadCityConfig() errors and returns a cfg-less context, so
+// tmuxConfigFromSession falls back through sc.Socket → cityName → "" and lands
+// on the default tmux socket. Every socket-scoped operation then targets the
+// wrong server while start still reports success.
+//
+// cwd is pointed at an empty directory so rediscovery cannot accidentally
+// resolve this city: with the fix the captured socket is the configured label,
+// and without it the capture is empty.
+func TestStartStandaloneBuildsSessionProviderFromResolvedCityConfig(t *testing.T) {
+	const (
+		socketLabel = "bright-lights"
+		cityName    = "socket-wiring-city"
+	)
+
+	cityPath := t.TempDir()
+	clearInheritedBeadsEnv(t)
+	requireNoLeakedDoltAfterForPaths(t, cityPath)
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(filepath.Join(cityPath, citylayout.RuntimeRoot), 0o755); err != nil {
+		t.Fatalf("scaffold runtime root: %v", err)
+	}
+	cityTOML := "[workspace]\nname = \"" + cityName + "\"\n\n" +
+		"[beads]\nprovider = \"file\"\n\n" +
+		"[session]\nsocket = \"" + socketLabel + "\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityTOML), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	var (
+		calls       int
+		gotSocket   string
+		gotCityName string
+		gotCityPath string
+	)
+	oldBuild := buildSessionProviderByName
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+	buildSessionProviderByName = func(_ *config.City, _ string, sc config.SessionConfig, resolvedName, resolvedPath string) (runtime.Provider, error) {
+		calls++
+		gotSocket, gotCityName, gotCityPath = sc.Socket, resolvedName, resolvedPath
+		return runtime.NewFake(), nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doStartStandalone([]string{cityPath}, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("doStartStandalone exit = %d, want 0\nstdout:\n%s\nstderr:\n%s",
+			code, stdout.String(), stderr.String())
+	}
+
+	if calls == 0 {
+		t.Fatal("buildSessionProviderByName never called; the seam no longer covers gc start's provider construction")
+	}
+	if gotSocket != socketLabel {
+		t.Errorf("session socket = %q, want %q; gc start built its provider from a rediscovered city instead of the resolved config",
+			gotSocket, socketLabel)
+	}
+	if gotCityName != cityName {
+		t.Errorf("city name = %q, want %q", gotCityName, cityName)
+	}
+	if gotCityPath != cityPath {
+		t.Errorf("city path = %q, want %q", gotCityPath, cityPath)
 	}
 }

--- a/cmd/gc/provider_factory_census_test.go
+++ b/cmd/gc/provider_factory_census_test.go
@@ -79,7 +79,7 @@ var canonicalProviderCalls = map[string]int{
 	"cmd_session.go:doSessionPeekFallback:newSessionProvider:bind-error":                                                                       1,
 	"cmd_session_reset.go:cmdSessionReset:newSessionProvider:bind-error":                                                                       1,
 	"cmd_sling.go:cmdSlingWithJSON:newSessionProvider:bind-error":                                                                              1,
-	"cmd_start.go:doStartStandalone:newSessionProvider:bind-error":                                                                             1,
+	"cmd_start.go:doStartStandalone:newSessionProviderForCity:bind-error":                                                                      1,
 	"cmd_status.go:cmdRigStatus:newStatusSessionProviderForCityWithSnapshot:bind-error":                                                        1,
 	"cmd_stop.go:cmdStopBodyWithoutSuccess:sessionProviderForStopCity:bind-error":                                                              1,
 	"cmd_supervisor.go:reconcileCities:newSessionProviderFromContext:bind-error":                                                               1,


### PR DESCRIPTION
## Problem
Sessions are created on the city's labeled tmux socket (`-L <label>`), but the standalone controller's stop/drain-ops provider is constructed without the city config, so stop-path tmux calls hit the DEFAULT socket. Field signature: supervisor logs `tmux -u: no such session: <name>` then `Stopped restart-requested session` — while the pane is alive the whole time on the labeled socket. Consequences observed live: resets accepted-but-never-committed for any continuously-running session, phantom "active" counts, and start-nudges failing with `no tmux server running`.

## Fix
Wiring only: the standalone controller provider construction now carries the city config/path, preserving the configured socket label — matching the start path. Supervisor startup and hot reload were verified to already use city-aware construction.

## Tests
Argv-level regression: restart-marker clearing must issue `tmux -u -L <label>` when a socket label is configured. Focused `go test ./cmd/gc` + full `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZbWgbQuggwArbwXEd76kN