### PR TITLE
fix(formula): human step-gates must not be minted with .assignee

### DIFF
--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -536,6 +536,11 @@ func flattenSteps(steps []*Step, parentID string, idMapping map[string]string, o
 					Timeout: step.Gate.Timeout,
 				},
 			}
+			if step.Gate.Type == "human" && step.Gate.ID != "" {
+				gateStep.Metadata = map[string]string{
+					beadmeta.DeferredAssigneeMetadataKey: step.Gate.ID,
+				}
+			}
 			defP := 2
 			gateStep.Priority = &defP
 			*out = append(*out, gateStep)

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2304,6 +2304,50 @@ depends_on = ["implement"]
 	}
 }
 
+func TestCookHumanStepGateDefersResolverWithoutAssignee(t *testing.T) {
+	dir := t.TempDir()
+	toml := `
+formula = "human-gate"
+version = 1
+
+[[steps]]
+id = "approve"
+title = "Approve release"
+
+[steps.gate]
+type = "human"
+id = "release-resolver"
+`
+	if err := os.WriteFile(filepath.Join(dir, "human-gate.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("writing formula: %v", err)
+	}
+
+	for _, graphApply := range []bool{false, true} {
+		t.Run(fmt.Sprintf("graph_apply=%t", graphApply), func(t *testing.T) {
+			previous := IsGraphApplyEnabled()
+			SetGraphApplyEnabled(graphApply)
+			t.Cleanup(func() { SetGraphApplyEnabled(previous) })
+
+			store := beads.NewMemStore()
+			result, err := Cook(context.Background(), store, "human-gate", []string{dir}, Options{})
+			if err != nil {
+				t.Fatalf("Cook: %v", err)
+			}
+
+			gate, err := store.Get(result.IDMapping["human-gate.gate-approve"])
+			if err != nil {
+				t.Fatalf("Get gate: %v", err)
+			}
+			if gate.Assignee != "" {
+				t.Errorf("gate.Assignee = %q, want empty", gate.Assignee)
+			}
+			if got := gate.Metadata[DeferredAssigneeMetadataKey]; got != "release-resolver" {
+				t.Errorf("gate.Metadata[%q] = %q, want %q", DeferredAssigneeMetadataKey, got, "release-resolver")
+			}
+		})
+	}
+}
+
 func TestCookEndToEndCheckSyntax(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem
A formula `[steps.gate]` (type=human) mints its gate bead with `.assignee=<resolver>`. Gates are not workable, but the serve path reads `.assignee` as claimable work — so every formula-minted gate is perpetual serve/drain fuel for its resolver. Observed live: a report formula minted four identical human gates assigned to one named session, driving 100+ wake/drain cycles per hour on that seat (same family as #4824). The CLI gate-creation path already gets this right; the formula engine did not.

## Fix
The formula mint now writes the resolver to the deferred-assignee metadata key the renudge path already reads, and leaves `.assignee` empty — one field, one reader, consistent with the CLI path.

## Tests
RED-first: formula-minted human step-gate carries no `.assignee` and carries the resolver in the correct metadata key; renudge reader verified. `go test ./internal/formula ./internal/molecule` + `go vet ./...` green. (Sibling audit found a related legacy-v1 case where authored tasks retain an assignee after becoming readiness-excluded step beads — deliberately left unchanged here, noted for a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZbWgbQuggwArbwXEd76kN