### PR TITLE
fix(session): exclude mail message beads from work-release enumeration

### DIFF
--- a/cmd/gc/session_beads_mail_release_test.go
+++ b/cmd/gc/session_beads_mail_release_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// ra-59207: the session-close WORK-RELEASE sweep (releaseWorkFromClosedSessionBead)
+// and the retired-session/orphan release path (unclaimWorkAssignedToRetiredSessionBead)
+// enumerate every bead assigned to the closing/retiring session with status in
+// (in_progress, open) and hand each one to ReleaseWorkBead, which clears its
+// Assignee. That enumeration has no type filter beyond skipping session beads,
+// so a type=message mail wisp — still unread, addressed to the closing session's
+// own raw ID (the self-handoff case) — is treated as WORK and stripped. A mail
+// bead has no claim/routing semantics: clearing its Assignee does not "release"
+// anything, it deletes the wisp's only route to an inbox, silently.
+//
+// These tests are the falsifiable-check floor demanded by the bead: each MUST
+// fail on unpatched source (mail Assignee comes back "") and pass once
+// excludeMailMessageBeads (work_assignment.go) filters mail beads out of
+// OpenAssignedToBasic/OpenAssignedTo before ReleaseWorkBead ever sees them.
+
+// TestReleaseWorkFromClosedSessionBeadLeavesMailBeadUntouched is the close-path
+// falsifiable case: an unread self-handoff-shaped mail wisp, still open,
+// assigned to the closing session, must survive with its Assignee unchanged.
+func TestReleaseWorkFromClosedSessionBeadLeavesMailBeadUntouched(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	// Self-handoff mail: addressed to the raw session ID (current.display falls
+	// back to GC_SESSION_ID for an unaliased seat), still unread (status open)
+	// when the session closes.
+	mailBead, err := store.Create(beads.Bead{
+		Title:    "HANDOFF: context filling",
+		Type:     "message",
+		Status:   "open",
+		Assignee: sessionBead.ID,
+	})
+	if err != nil {
+		t.Fatalf("create mail bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	releaseWorkFromClosedSessionBead(store, sessionBead, &stderr)
+
+	got, err := store.Get(mailBead.ID)
+	if err != nil {
+		t.Fatalf("get mail bead: %v", err)
+	}
+	if got.Assignee != sessionBead.ID {
+		t.Fatalf("mail bead Assignee = %q, want unchanged %q (release must never touch a mail wisp's only route to an inbox)", got.Assignee, sessionBead.ID)
+	}
+	if got.Status != "open" {
+		t.Fatalf("mail bead Status = %q, want unchanged %q", got.Status, "open")
+	}
+}
+
+// TestReleaseWorkFromClosedSessionBeadStillReleasesRealWork is the companion
+// assertion: a genuine WORK bead assigned to the same closing session must
+// still be released (assignee cleared, in_progress reset to open) — the mail
+// exclusion must not disable the real release behavior.
+func TestReleaseWorkFromClosedSessionBeadStillReleasesRealWork(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	mailBead, err := store.Create(beads.Bead{
+		Title:    "HANDOFF: context filling",
+		Type:     "message",
+		Status:   "open",
+		Assignee: sessionBead.ID,
+	})
+	if err != nil {
+		t.Fatalf("create mail bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "real work",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	releaseWorkFromClosedSessionBead(store, sessionBead, &stderr)
+
+	gotMail, err := store.Get(mailBead.ID)
+	if err != nil {
+		t.Fatalf("get mail bead: %v", err)
+	}
+	if gotMail.Assignee != sessionBead.ID {
+		t.Fatalf("mail bead Assignee = %q, want unchanged %q", gotMail.Assignee, sessionBead.ID)
+	}
+
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Fatalf("work bead Assignee = %q, want cleared", gotWork.Assignee)
+	}
+	if gotWork.Status != "open" {
+		t.Fatalf("work bead Status = %q, want open (in_progress must reset on release)", gotWork.Status)
+	}
+}
+
+// TestUnclaimWorkAssignedToRetiredSessionBeadLeavesMailBeadUntouched covers the
+// same bug class at the retired-session/orphan release site (same unfiltered
+// OpenAssignedTo query + ReleaseWorkBead pair, per the bead's own list of
+// affected sites), so the class is closed rather than one call site.
+func TestUnclaimWorkAssignedToRetiredSessionBeadLeavesMailBeadUntouched(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	mailBead, err := store.Create(beads.Bead{
+		Title:    "HANDOFF: context filling",
+		Type:     "message",
+		Status:   "open",
+		Assignee: sessionBead.ID,
+	})
+	if err != nil {
+		t.Fatalf("create mail bead: %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "real work",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	unclaimWorkAssignedToRetiredSessionBead(store, nil, sessionBead, "fallback/worker", &stderr)
+
+	gotMail, err := store.Get(mailBead.ID)
+	if err != nil {
+		t.Fatalf("get mail bead: %v", err)
+	}
+	if gotMail.Assignee != sessionBead.ID {
+		t.Fatalf("mail bead Assignee = %q, want unchanged %q (orphan-release must never touch a mail wisp)", gotMail.Assignee, sessionBead.ID)
+	}
+
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Fatalf("work bead Assignee = %q, want cleared (mail exclusion must not disable real orphan release)", gotWork.Assignee)
+	}
+}

--- a/cmd/gc/work_assignment.go
+++ b/cmd/gc/work_assignment.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail/beadmail"
 )
 
 // workAssignment is the typed boundary façade the SESSION reconciler uses to
@@ -45,11 +46,13 @@ func (w workAssignment) unwrapped() beads.Store {
 
 // OpenAssignedTo returns the open or in-progress WORK beads in this store
 // assigned to the given identity for the given tier mode, excluding session
-// beads. It is the typed form of the raw
+// beads and mail message beads. It is the typed form of the raw
 // List{Assignee,Status,Live,TierMode} probe the reconciler ran directly.
 // status selects the bead status ("open" / "in_progress"); live mirrors the
 // raw ListQuery.Live flag. Session beads (and repairable session beads) are
-// filtered out, matching the raw probes.
+// filtered out, matching the raw probes; mail message beads are filtered out
+// here too (ra-59207) — a mail wisp has no claim/routing semantics, so every
+// caller that reassigns or releases what this returns must never see one.
 func (w workAssignment) OpenAssignedTo(assignee, status string, tierMode beads.TierMode, live bool) ([]beads.Bead, error) {
 	store := w.unwrapped()
 	if store == nil {
@@ -59,7 +62,7 @@ func (w workAssignment) OpenAssignedTo(assignee, status string, tierMode beads.T
 	if err != nil {
 		return nil, err
 	}
-	return items, nil
+	return excludeMailMessageBeads(items), nil
 }
 
 // CachedOpenAssignedWisps returns cached open-assigned wisp-tier WORK beads when
@@ -113,12 +116,40 @@ func (w workAssignment) HasNonSessionWork(items []beads.Bead) bool {
 // releaseWorkFromClosedSessionBead, kept distinct from OpenAssignedTo because the
 // close-release path deliberately runs the unflagged query — making it byte-
 // identical to OpenAssignedTo's flagged query would change the emitted bead op.
+// Like OpenAssignedTo, mail message beads are excluded (ra-59207): they are not
+// WORK and have no claim/routing semantics for the release path to act on.
 func (w workAssignment) OpenAssignedToBasic(assignee, status string) ([]beads.Bead, error) {
 	store := w.unwrapped()
 	if store == nil {
 		return nil, nil
 	}
-	return store.List(beads.ListQuery{Assignee: assignee, Status: status})
+	items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status})
+	if err != nil {
+		return nil, err
+	}
+	return excludeMailMessageBeads(items), nil
+}
+
+// excludeMailMessageBeads filters mail message beads (beadmail.IsMessageBead)
+// out of a WORK query result. A mail wisp is a delivery route, not a claimable
+// unit of work — it can be neither released nor reassigned — so every WORK
+// enumeration in this file (and every caller downstream, all of which treat
+// their results as releasable/reassignable WORK) must exclude it at the source
+// rather than repeat the check at each call site (ra-59207: the session-close
+// WORK-RELEASE sweep clearing a mail bead's assignee silently destroyed its
+// only route to an inbox).
+func excludeMailMessageBeads(items []beads.Bead) []beads.Bead {
+	if len(items) == 0 {
+		return items
+	}
+	out := items[:0:0]
+	for _, item := range items {
+		if beadmail.IsMessageBead(item) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
 }
 
 // ReleaseWorkBead detaches one WORK bead from its (closed/retired) session: it


### PR DESCRIPTION
## The defect

`releaseWorkFromClosedSessionBead` (cmd/gc/session_beads.go ~:3119) enumerates every bead assigned to a closing session's identities with status in (`in_progress`, `open`):

```go
wa.OpenAssignedToBasic(assignee, status)  ->  store.List(ListQuery{Assignee, Status})
```

The query has **no type filter**, and the only per-item skip is `session.IsSessionBeadOrRepairable`. `type=message` mail wisps assigned to that session are therefore treated as work beads and passed to `workAssignment.ReleaseWorkBead`, which sets `Assignee=""`.

A mail bead has no claim or routing semantics. Clearing its assignee releases nothing — **it deletes the mail's only route to an inbox**, silently, with no error at any point.

A **self-handoff is the archetype**, because it is the one mail addressed to a raw session id rather than a stable alias (`current.display` falls back to `GC_SESSION_ID`), and the addressee session then closes by design. Alias-addressed mail (`'moiraine'`) is never matched by the release query. So the mail that gets destroyed is precisely a handoff still unread when its session closes — exactly when the successor needs it.

## Evidence from a live store

Census of all 2628 `type=message` beads in our city store:

- **200** have an empty top-level `Assignee`.
- **199 of those 200** carry `gc.continuation_group=""` **and** `gc.session_affinity=""` — the exact write signature of `ReleaseWorkBead` (work_assignment.go:134: `UpdateOpts{Assignee:&"", Metadata: clearedSessionAffinityMetadata()}`).
- **0 of the 2428** correctly-addressed message beads carry that pair. Built-in negative control.

Status discriminator matches the release query's own predicate (`status in (in_progress, open)`):

- Cleared (n=200): 186 `status=open`, 187 never read.
- Survivors addressed to a session id whose session is closed (n=153): 144 `status=closed`, 128 read.

That is: mail **read** (→ closed) before its addressee session closed survives; mail still **open** at session close is stripped.

Create-path was ruled out empirically — a controlled `gc handoff --auto` read back at +9s and again at +3min after several reconcile ticks retained `assignee='ra-f0btsg'`. The assignee is written correctly and cleared later.

## The fix

Exclude mail message beads at the shared query layer rather than per call site: `excludeMailMessageBeads` (using the already-exported `beadmail.IsMessageBead`) applied inside `workAssignment.OpenAssignedTo` and `OpenAssignedToBasic`, whose doc comments already promise they return WORK beads.

This covers the whole bug class in one place — `releaseWorkFromClosedSessionBead`, `unclaimWorkAssignedToRetiredSessionBead(+Info)`, `reassignWorkAssignedToRetiredSessionBead(+Info)`, and the reconciler's `firstOpenAssignedWorkBeadInStoreByIdentifiers` / `collectSessionAssignedWork(Info)` — instead of the same conditional at nine sites (session_beads.go :1055/:1106/:1153/:1202, session_reconciler.go :3953/:4152/:4537/:4587/:4731).

`SendHandoff`, `createMessageBead` and `BdStore.Create` are deliberately untouched — passing `intent.To` unresolved is not the bug.

## Tests

Three new tests in `cmd/gc/session_beads_mail_release_test.go`, each falsifiable:

1. `TestReleaseWorkFromClosedSessionBeadLeavesMailBeadUntouched` — self-handoff-shaped open mail bead on a closing session; asserts `Assignee` unchanged.
2. `TestReleaseWorkFromClosedSessionBeadStillReleasesRealWork` — companion: a real `in_progress` work bead on the same session **is** still released (assignee cleared, status reset to open), so the fix does not disable the real behaviour.
3. `TestUnclaimWorkAssignedToRetiredSessionBeadLeavesMailBeadUntouched` — same shape at the retired-session/orphan site, closing the class rather than one call site.

Pre-fix (fix source reverted, tests retained) all three **FAIL** with the exact destructive symptom:

```
session_beads_mail_release_test.go:65: mail bead Assignee = "", want unchanged "gc-1"
```

Post-fix all three **PASS**. `go vet ./cmd/gc/...` exits 0.

Note on the full-package run: `go test ./cmd/gc/...` shows 18 failures, all in `TestReapClosedBeadWorktrees_*` / `TestCityRuntimeTick_Reaps*` — a worktree-reaping subsystem unrelated to these files. Confirmed pre-existing by reverting this change entirely and re-running `TestReapClosedBeadWorktrees_ProtectsViaCrossMoleculeBorrowVeto` alone: fails identically ("Protected = [], want exactly 1 borrow-veto entry") with this diff absent.

## Not included

Retro-repair of already-stripped mail beads is out of scope — their assignees are not recoverable (`bd history` returns null for ephemeral wisps).
