### PR TITLE
fix(session): show config reason for drained always-mode named sessions

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -154,7 +154,9 @@ func sessionWithinDesiredConfigInfo(info sessionpkg.Info, cfg *config.City, pool
 	if agent == nil {
 		return nil, false
 	}
-	if isDrainedSessionInfo(info) {
+	// ComputeAwakeSet deliberately reuses drained always-mode named beads.
+	// Keep the display classifier aligned with that decision.
+	if isDrainedSessionInfo(info) && (!isNamedSessionInfo(info) || namedSessionModeInfo(info) != "always") {
 		return agent, false
 	}
 	if info.DependencyOnlyMetadata == "true" {
@@ -175,7 +177,7 @@ func sessionWithinDesiredConfig(session beads.Bead, cfg *config.City, poolDesire
 	if agent == nil {
 		return nil, false
 	}
-	if isDrainedSessionBead(session) {
+	if isDrainedSessionBead(session) && (!isNamedSessionBead(session) || namedSessionMode(session) != "always") {
 		return agent, false
 	}
 	if session.Metadata["dependency_only"] == "true" {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -437,7 +437,7 @@ func TestPendingCreateStartedAtNowSubstitutesCurrentTimeForZeroInput(t *testing.
 	}
 }
 
-func TestWakeReasons_DrainedSleepPoolSessionDoesNotGetWakeConfig(t *testing.T) {
+func TestWakeReasons_DrainedConfigEligibility(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}
 
@@ -447,19 +447,53 @@ func TestWakeReasons_DrainedSleepPoolSessionDoesNotGetWakeConfig(t *testing.T) {
 		},
 	}
 
-	session := makeBead("b1", map[string]string{
-		"template":     "worker",
-		"session_name": "test-worker-1",
-		"pool_slot":    "1",
-		"state":        "asleep",
-		"sleep_reason": "drained",
-	})
+	tests := []struct {
+		name       string
+		metadata   map[string]string
+		wantConfig bool
+	}{
+		{
+			name: "always named session",
+			metadata: map[string]string{
+				"template":                  "worker",
+				"session_name":              "always-worker",
+				"configured_named_session":  "true",
+				"configured_named_identity": "always-worker",
+				"configured_named_mode":     "always",
+			},
+			wantConfig: true,
+		},
+		{
+			name: "on demand named session",
+			metadata: map[string]string{
+				"template":                  "worker",
+				"session_name":              "demand-worker",
+				"configured_named_session":  "true",
+				"configured_named_identity": "demand-worker",
+				"configured_named_mode":     "on_demand",
+			},
+		},
+		{
+			name: "pool slot",
+			metadata: map[string]string{
+				"template":     "worker",
+				"session_name": "test-worker-1",
+				"pool_slot":    "1",
+			},
+		},
+	}
 
-	reasons := wakeReasonsForBead(session, cfg, nil, map[string]int{"worker": 3}, nil, nil, clk)
-	for _, reason := range reasons {
-		if reason == WakeConfig {
-			t.Fatalf("drained sleep session should not get WakeConfig, got %v", reasons)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.metadata["state"] = "asleep"
+			tt.metadata["sleep_reason"] = "drained"
+			session := makeBead("b1", tt.metadata)
+
+			reasons := wakeReasonsForBead(session, cfg, nil, map[string]int{"worker": 3}, nil, nil, clk)
+			if got := containsWakeReason(reasons, WakeConfig); got != tt.wantConfig {
+				t.Fatalf("WakeConfig present = %v, want %v; reasons = %v", got, tt.wantConfig, reasons)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Supersedes #4826 (closed: its head desynced after a low-level ref update; identical content rebased onto current main).

## Problem
`sessionWithinDesiredConfigInfo` (`cmd/gc/session_reconcile.go`) short-circuits `configEligible=false` for any drained session bead — but `ComputeAwakeSet`'s always-mode named branch has no Drained guard and will respawn that bead on the next tick. `gc session list` therefore hides the `config` reason at the exact moment the reconciler is about to respawn the seat (operator-confusing during #4824-class loops).

## Fix
Display-only: the drained short-circuit exempts always-mode named sessions, mirroring the decision path. `on_demand` and pool sessions unchanged; both Info- and Bead-based variants fixed symmetrically.

## Tests
Drained always named → config reason present; drained on_demand → unchanged; drained pool slot → unchanged. Focused `go test ./cmd/gc` green.

Related: #4824

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZbWgbQuggwArbwXEd76kN