### PR TITLE
fix(beads): classify CachingStore.circuitTripped in the merge oracle

### DIFF
--- a/internal/beads/caching_store_reconcile_census_test.go
+++ b/internal/beads/caching_store_reconcile_census_test.go
@@ -87,7 +87,8 @@ func TestMergeOracleFieldCoverage(t *testing.T) {
 		"beads": true, "deps": true, "depsComplete": true, "dirty": true,
 		"beadSeq": true, "localBeadAt": true, "deletedSeq": true, "state": true,
 		"lastFreshAt": true, "mutationSeq": true, "primePartialErr": true,
-		"syncFailures": true, "stats": true, // stats compared field-wise below
+		"syncFailures": true, "circuitTripped": true,
+		"stats": true, // stats compared field-wise below
 	}
 	excludedStore := map[string]bool{
 		"backing": true, "idPrefix": true, "mu": true, "reconciling": true,

--- a/internal/beads/caching_store_reconcile_differential_test.go
+++ b/internal/beads/caching_store_reconcile_differential_test.go
@@ -75,18 +75,19 @@ func (in snapshotInputs) quiescent(st storeState) bool {
 // It captures every field the seam writes; the field-coverage census
 // (TestMergeOracleFieldCoverage) proves this list stays exhaustive.
 type mergeEndState struct {
-	beads        map[string]Bead
-	deps         map[string][]Dep
-	depsComplete bool
-	dirty        map[string]struct{}
-	beadSeq      map[string]uint64
-	localBeadAt  map[string]time.Time
-	deletedSeq   map[string]uint64
-	state        cacheState
-	lastFreshAt  time.Time
-	mutationSeq  uint64
-	primeErr     string
-	syncFailures int
+	beads          map[string]Bead
+	deps           map[string][]Dep
+	depsComplete   bool
+	dirty          map[string]struct{}
+	beadSeq        map[string]uint64
+	localBeadAt    map[string]time.Time
+	deletedSeq     map[string]uint64
+	state          cacheState
+	lastFreshAt    time.Time
+	mutationSeq    uint64
+	primeErr       string
+	syncFailures   int
+	circuitTripped bool
 	// stats fields the seam writes.
 	statsAdds            int64
 	statsRemoves         int64
@@ -281,6 +282,7 @@ func captureEndState(c *CachingStore) mergeEndState {
 		mutationSeq:          c.mutationSeq,
 		primeErr:             primeErr,
 		syncFailures:         c.syncFailures,
+		circuitTripped:       c.circuitTripped,
 		statsAdds:            c.stats.Adds,
 		statsRemoves:         c.stats.Removes,
 		statsUpdates:         c.stats.Updates,


### PR DESCRIPTION
## Problem
Since #3379 merged (`8ea0080bf`), `TestMergeOracleFieldCoverage` fails on stock main:

```
caching_store_reconcile_census_test.go:101: CachingStore.circuitTripped is neither compared
nor justified-excluded by the merge oracle — classify it (a seam-written field must be compared)
```

Reproduced at `588f5741b` with no other changes (`go test ./internal/beads -run TestMergeOracleFieldCoverage`). Every PR rebased onto current main inherits this red in `Integration / packages-core-2-of-4`.

## Fix
Classify `circuitTripped` as **compared**: it is reset by `promoteLiveLocked()` during the merge seam, so the oracle must capture and compare it — the census's own rule for seam-written fields. Census and differential oracle updated together.

## Tests
`TestMergeOracleFieldCoverage` green at head; `go vet ./internal/beads` and the pre-commit hook pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZbWgbQuggwArbwXEd76kN