### PR TITLE
fix(session): stamp pending-create intents from manager clock

### DIFF
--- a/cmd/gc/session_lifecycle_chaos_test.go
+++ b/cmd/gc/session_lifecycle_chaos_test.go
@@ -1007,7 +1007,7 @@ func newSessionChaosHarness(t *testing.T, seed int64) *sessionChaosHarness {
 	return &sessionChaosHarness{
 		t:        t,
 		env:      env,
-		manager:  sessionpkg.NewManagerWithOptions(env.store, env.sp),
+		manager:  sessionpkg.NewManagerWithOptions(env.store, env.sp, sessionpkg.WithClock(env.clk)),
 		rng:      rand.New(rand.NewSource(seed)), //nolint:gosec // deterministic test chaos, not security-sensitive.
 		seed:     seed,
 		template: template,

--- a/cmd/gc/session_pending_create_rollback_desired_test.go
+++ b/cmd/gc/session_pending_create_rollback_desired_test.go
@@ -15,19 +15,10 @@ import (
 // (~2229) — the path that matters for a session that is supposed to be running,
 // which is the shape a wedged never-started create would take.
 //
-// Harness fidelity note: session.Manager.CreateSession stamps
-// pending_create_started_at from the real wall clock
-// (internal/session/manager.go:1131) rather than an injected clock, while the
-// reconciler runs on clock.Fake. A harness-minted intent therefore carries a
-// lease anchor pinned to real "now", so its never-started lease can never expire
-// against the fake clock and the rollback safety net silently never fires. All
-// three tests below re-anchor pending_create_started_at onto the fake clock, but
-// it is only load-bearing for
-// TestDesiredQuarantinedPendingCreateRollsBackAfterLeaseExpiry — that is the one
-// test that actually reaches the 10m lease floor (verified: deleting its
-// re-anchor fails it). The other two release the claim at the first tick via the
-// failed-create rollback and never reach the lease; the re-anchor there is
-// defensive.
+// newSessionChaosHarness wires the Manager with the harness's own clock.Fake
+// (session_lifecycle_chaos_test.go), so a harness-minted intent's
+// pending_create_started_at anchors on the same clock the reconciler reads —
+// no manual re-anchoring needed.
 
 // runDesiredPendingCreateTicks reconciles up to ticks one-minute steps and
 // returns the tick at which the pending-create claim was released, or -1.
@@ -63,11 +54,6 @@ func TestDesiredPendingCreateRollsBackWhenStartKeepsFailing(t *testing.T) {
 	h.createSessionIntent()
 	h.assertCreatingIntent()
 
-	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
-		"pending_create_started_at": h.env.clk.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("re-anchor pending-create lease: %v", err)
-	}
 	h.env.sp.StartErrors[h.sessionName] = errors.New("provider start failure")
 
 	if at := runDesiredPendingCreateTicks(t, h, 30); at < 0 {
@@ -95,10 +81,9 @@ func TestDesiredQuarantinedPendingCreateRollsBackAfterLeaseExpiry(t *testing.T) 
 
 	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
 		// Quarantine outlives the never-started lease timeout by a wide margin.
-		"quarantined_until":         h.env.clk.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-		"pending_create_started_at": h.env.clk.Now().UTC().Format(time.RFC3339),
+		"quarantined_until": h.env.clk.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 	}); err != nil {
-		t.Fatalf("seed quarantine + lease anchor: %v", err)
+		t.Fatalf("seed quarantine: %v", err)
 	}
 	// Healing must come from the rollback, never from a successful start.
 	h.env.sp.StartErrors[h.sessionName] = errors.New("provider start failure")
@@ -130,10 +115,9 @@ func TestDesiredCreatingPendingCreateReleasesClaim(t *testing.T) {
 	h.createSessionIntent()
 
 	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
-		"state":                     string(sessionpkg.StateCreating),
-		"pending_create_claim":      "true",
-		"last_woke_at":              "",
-		"pending_create_started_at": h.env.clk.Now().UTC().Format(time.RFC3339),
+		"state":                string(sessionpkg.StateCreating),
+		"pending_create_claim": "true",
+		"last_woke_at":         "",
 	}); err != nil {
 		t.Fatalf("seed creating shape: %v", err)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -793,6 +793,17 @@ func WithStaleKeyDetectionWaiter(waiter StaleKeyDetectionWaiter) ManagerOption {
 	}
 }
 
+// WithClock supplies the time source the Manager stamps lifecycle timestamps
+// from (e.g. pending_create_started_at). A nil clock retains the immutable
+// production wall clock.
+func WithClock(clk clock.Clock) ManagerOption {
+	return func(m *Manager) {
+		if clk != nil {
+			m.clk = clk
+		}
+	}
+}
+
 // NewManagerWithOptions creates a Manager backed by the given bead store and
 // session provider, applying any capability options. It is the canonical
 // constructor; the named NewManager* variants below are one-line presets.
@@ -1128,7 +1139,7 @@ func (m *Manager) createBeadOnly(spec CreateOptions) (Info, error) {
 			meta["session_key"] = sessionKey
 		}
 		meta["pending_create_claim"] = "true"
-		meta["pending_create_started_at"] = pendingCreateStartedAt(time.Now().UTC())
+		meta["pending_create_started_at"] = pendingCreateStartedAt(m.now().UTC())
 		if explicitName != "" {
 			meta["session_name"] = explicitName
 			meta["session_name_explicit"] = "true"

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1185,6 +1185,38 @@ func TestCreateSessionBeadOnly(t *testing.T) {
 	}
 }
 
+// TestCreateSessionBeadOnlyStampsPendingCreateStartedAtFromManagerClock pins
+// that pending_create_started_at is read from the Manager's injected clock,
+// not the real wall clock. The never-started pending-create lease
+// (cmd/gc/session_reconciler.go pendingCreateNeverStartedLeaseExpiredInfo)
+// anchors on this timestamp and compares it against clock.Fake in reconciler
+// tests; if the stamp comes from real time instead, the anchor and the
+// comparison live on different timelines and the lease can never expire in
+// those tests, silently disabling the rollback safety net.
+func TestCreateSessionBeadOnlyStampsPendingCreateStartedAtFromManagerClock(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManagerWithOptions(store, sp)
+	fakeNow := time.Date(2030, 1, 1, 12, 0, 0, 0, time.UTC)
+	mgr.clk = &clock.Fake{Time: fakeNow}
+
+	info, err := mgr.CreateSession(context.Background(), CreateOptions{BeadOnly: true, Template: "helper", Title: "my chat", Command: "claude", WorkDir: "/tmp", Provider: "claude", Transport: "", Resume: ProviderResume{}})
+	if err != nil {
+		t.Fatalf("CreateSessionBeadOnly: %v", err)
+	}
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	got, err := time.Parse(time.RFC3339, b.Metadata["pending_create_started_at"])
+	if err != nil {
+		t.Fatalf("pending_create_started_at = %q, not RFC3339: %v", b.Metadata["pending_create_started_at"], err)
+	}
+	if !got.Equal(fakeNow) {
+		t.Errorf("pending_create_started_at = %v, want %v (manager clock, not real wall clock)", got, fakeNow)
+	}
+}
+
 func TestGetSurfacesAgentNameMetadata(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/release-gates/ga-0yb884-pending-create-manager-clock-gate.md
+++ b/release-gates/ga-0yb884-pending-create-manager-clock-gate.md
@@ -1,0 +1,58 @@
+# Release Gate: pending-create timestamps use the manager clock
+
+- Deploy bead: `ga-0yb884`
+- Review bead: `ga-g8n6ot`
+- Reviewed source commit: `d19b9e51eb51aad0b924766804dbd7cc6677bae9`
+- Base checked: `origin/main` at `b677c58ac3628d70636fa7ad58286cc7d8074df8`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This checklist
+applies the release criteria supplied in the deployer instructions and the
+repository's documented test targets.
+
+## Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-g8n6ot` is closed with reason `pass`; its notes record `REVIEWER VERDICT: PASS` for the exact reviewed source commit. |
+| 2 | Acceptance criteria met | PASS | `createBeadOnly` now stamps `pending_create_started_at` using the manager clock in UTC; the existing nil-safe production fallback remains the real clock. The session chaos harness supplies its fake clock, the rollback tests no longer rewrite timestamp metadata manually, and the lease-expiry test releases at fake-clock tick 12, beyond the 10-minute floor. |
+| 3 | Tests pass | PASS | `LOCAL_TEST_JOBS=2 make test-local-full-parallel` completed 40 runner jobs: **40 PASS, 0 FAIL, 0 SKIP**. The controlled local toolchain used the repository-compatible `bd` 1.1.0, Dolt 2.1.7, and tmux 3.4 while retaining the real city home. Four named clock/rollback tests passed with **4 PASS, 0 FAIL, 0 SKIP**. `go build ./...` and `go vet ./...` both exited 0. |
+| 4 | No high-severity review findings open | PASS | The reviewer reported no blockers and no OWASP concerns; unresolved HIGH finding count is 0. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --porcelain=v1` produced no output and `git diff --check` exited 0. The gate file is the only deployer-added change and will be committed before push. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first and rechecked after the test run. `git merge-tree --write-tree origin/main d19b9e51eb51aad0b924766804dbd7cc6677bae9` exited 0 against the current base and produced tree `d353717df2396a2c379bf6994edfa73e42b93957`; no self-rebase was needed. |
+| 7 | Single feature theme | PASS | The two reviewed commits touch four files in `internal/session` and `cmd/gc` for one behavior: sourcing pending-create timestamps and their rollback tests from the manager clock. |
+
+## Test Evidence
+
+```text
+LOCAL_TEST_JOBS=2 make test-local-full-parallel
+40 PASS, 0 FAIL, 0 SKIP
+
+go test ./internal/session/... -run TestCreateSessionBeadOnlyStampsPendingCreateStartedAtFromManagerClock -json
+1 named test PASS, 0 FAIL, 0 SKIP
+
+go test ./cmd/gc/... -run 'TestDesiredPendingCreateRollsBackWhenStartKeepsFailing|TestDesiredQuarantinedPendingCreateRollsBackAfterLeaseExpiry|TestDesiredCreatingPendingCreateReleasesClaim' -json
+3 named tests PASS, 0 FAIL, 0 SKIP
+
+go build ./...
+PASS
+
+go vet ./...
+PASS
+```
+
+The full runner's zero-skip result needs no skip exception. Earlier diagnostic
+runs exposed host-tool mismatches and local Dolt bootstrap contention; they
+were not counted as release evidence. The final audited run used pinned,
+repository-compatible tools and two-way local concurrency and completed
+without failures or skips.
+
+## Scope Evidence
+
+```text
+cmd/gc/session_lifecycle_chaos_test.go
+cmd/gc/session_pending_create_rollback_desired_test.go
+internal/session/manager.go
+internal/session/manager_test.go
+
+4 files changed, 54 insertions(+), 27 deletions(-)
+```


### PR DESCRIPTION
## What this changes

Session intents created in bead-only mode now stamp `pending_create_started_at` from the Session Manager's configured clock. Production continues to use real time by default, while fake-clock reconciliation tests now exercise the same timestamp timeline end to end, allowing the never-started rollback safety net to expire naturally under test.

## Review notes

- `session.WithClock` is an optional Manager construction option; a nil or omitted clock preserves the existing real-time behavior.
- The change is limited to the pending-create timestamp and its reconciliation tests. Timeout values and production scheduling behavior are unchanged.
- There are no configuration, API, storage-shape, migration, or compatibility changes.
- The rollback tests no longer rewrite timestamp metadata manually; the lease-expiry path now reaches release at fake-clock minute 12, beyond the 10-minute floor.

## Test plan

- [x] `go build ./...` and `go vet ./...`
- [x] Four targeted manager-clock and pending-create rollback tests: 4 PASS, 0 FAIL, 0 SKIP
- [x] `LOCAL_TEST_JOBS=2 make test-local-full-parallel`: 40 PASS, 0 FAIL, 0 SKIP
- [x] Repository pre-push fast suite: 10 PASS, 0 FAIL, 0 SKIP
- [x] Release gate: [`release-gates/ga-0yb884-pending-create-manager-clock-gate.md`](release-gates/ga-0yb884-pending-create-manager-clock-gate.md)