### PR TITLE
fix(resilience): dispatch breaker state-change callbacks outside b.mu

### DIFF
--- a/internal/resilience/breaker.go
+++ b/internal/resilience/breaker.go
@@ -183,6 +183,8 @@ func (b *Breaker) Allow() bool {
 	if !b.settings.Enabled {
 		return true
 	}
+	var pending *pendingNotify
+	defer func() { pending.dispatch() }()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	now := b.now()
@@ -191,7 +193,7 @@ func (b *Breaker) Allow() bool {
 		if now.Before(b.deadline) {
 			return false
 		}
-		b.transitionLocked(StateHalfOpen, 0, now)
+		pending = b.transitionLocked(StateHalfOpen, 0, now)
 		b.lastProbeAt = now
 		return true
 	case StateHalfOpen:
@@ -247,12 +249,14 @@ func (b *Breaker) RecordSuccess() {
 	if !b.settings.Enabled {
 		return
 	}
+	var pending *pendingNotify
+	defer func() { pending.dispatch() }()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.failures = 0
 	b.trips = 0
 	if b.state != StateClosed {
-		b.transitionLocked(StateClosed, 0, b.now())
+		pending = b.transitionLocked(StateClosed, 0, b.now())
 	}
 }
 
@@ -265,6 +269,8 @@ func (b *Breaker) RecordFailure() {
 	if !b.settings.Enabled {
 		return
 	}
+	var pending *pendingNotify
+	defer func() { pending.dispatch() }()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	now := b.now()
@@ -274,12 +280,12 @@ func (b *Breaker) RecordFailure() {
 		return
 	case StateHalfOpen:
 		b.trips++
-		b.openLocked(now)
+		pending = b.openLocked(now)
 	default: // closed
 		b.failures++
 		if b.failures >= b.settings.ConsecutiveFailures {
 			b.trips = 1
-			b.openLocked(now)
+			pending = b.openLocked(now)
 		}
 	}
 }
@@ -294,6 +300,8 @@ func (b *Breaker) Trip() {
 	if !b.settings.Enabled {
 		return
 	}
+	var pending *pendingNotify
+	defer func() { pending.dispatch() }()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	switch b.state {
@@ -304,7 +312,7 @@ func (b *Breaker) Trip() {
 	default: // closed
 		b.trips = 1
 	}
-	b.openLocked(b.now())
+	pending = b.openLocked(b.now())
 }
 
 // State returns the current breaker state without mutating it.
@@ -317,12 +325,13 @@ func (b *Breaker) State() State {
 	return b.state
 }
 
-// openLocked moves to StateOpen with a full-jitter backoff deadline.
+// openLocked moves to StateOpen with a full-jitter backoff deadline and returns
+// the notification for the caller to dispatch after unlocking.
 // Caller must hold b.mu and have set b.trips.
-func (b *Breaker) openLocked(now time.Time) {
+func (b *Breaker) openLocked(now time.Time) *pendingNotify {
 	backoff := b.jitter(b.backoffCapLocked())
 	b.deadline = now.Add(backoff)
-	b.transitionLocked(StateOpen, backoff, now)
+	return b.transitionLocked(StateOpen, backoff, now)
 }
 
 // backoffCapLocked returns min(OpenMax, OpenBase << (trips-1)) with
@@ -341,16 +350,49 @@ func (b *Breaker) backoffCapLocked() time.Duration {
 	return capDur
 }
 
-// transitionLocked changes state and notifies the callback. Caller must
-// hold b.mu.
-func (b *Breaker) transitionLocked(to State, backoff time.Duration, now time.Time) {
-	from := b.state
-	if from == to {
+// pendingNotify is a state-change notification captured under b.mu and
+// dispatched after it is released. It carries the callback it was captured
+// with, so dispatch needs no lock of its own and cannot observe a callback
+// rewired after the transition it describes.
+type pendingNotify struct {
+	fn func(Transition)
+	t  Transition
+}
+
+// dispatch delivers the notification. Safe on a nil receiver, so callers can
+// defer it unconditionally without checking whether a transition occurred.
+//
+// MUST NOT be called while b.mu is held: the callback is user-supplied and is
+// expected to read breaker state (State(), Registry.States()), which takes the
+// same non-reentrant mutex.
+func (p *pendingNotify) dispatch() {
+	if p == nil || p.fn == nil {
 		return
 	}
+	p.fn(p.t)
+}
+
+// transitionLocked changes state and returns the notification to dispatch once
+// the lock is released, or nil if the state did not change. Caller must hold
+// b.mu.
+//
+// The callback is deliberately NOT invoked here. Calling it under b.mu
+// deadlocks any callback that reads breaker state — State() and
+// Registry.States() both take b.mu, and Go mutexes are not reentrant — which is
+// exactly what event and diagnostics wiring wants to do. Returning the
+// notification lets each public entry point dispatch it after unlocking.
+func (b *Breaker) transitionLocked(to State, backoff time.Duration, now time.Time) *pendingNotify {
+	from := b.state
+	if from == to {
+		return nil
+	}
 	b.state = to
-	if b.onChange != nil {
-		b.onChange(Transition{
+	if b.onChange == nil {
+		return nil
+	}
+	return &pendingNotify{
+		fn: b.onChange,
+		t: Transition{
 			Scope:    b.scope,
 			OpClass:  b.opClass,
 			From:     from,
@@ -358,7 +400,7 @@ func (b *Breaker) transitionLocked(to State, backoff time.Duration, now time.Tim
 			Failures: b.failures,
 			Backoff:  backoff,
 			At:       now,
-		})
+		},
 	}
 }
 

--- a/internal/resilience/breaker_reentrancy_test.go
+++ b/internal/resilience/breaker_reentrancy_test.go
@@ -1,0 +1,143 @@
+package resilience
+
+import (
+	"testing"
+	"time"
+)
+
+// runWithinDeadline runs fn and reports whether it finished in time. A
+// regression here is a DEADLOCK, not a wrong value, so every test in this file
+// runs the subject on its own goroutine and fails on timeout instead of hanging
+// the package until the go test binary is killed.
+//
+// The goroutine is deliberately leaked on timeout: it is parked on b.mu and can
+// never be woken, so there is nothing to clean up and the test binary is about
+// to fail anyway.
+func runWithinDeadline(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s deadlocked: the state-change callback is being invoked while b.mu is held, "+
+			"so a callback reading breaker state blocks forever on the same non-reentrant mutex", what)
+	}
+}
+
+// TestBreakerCallbackCanReadStateWithoutDeadlock is the regression for
+// dispatching the transition callback under b.mu.
+//
+// Event and diagnostics wiring wants to read breaker state from the callback,
+// which is the whole point of exposing State() and Registry.States(). Both take
+// b.mu, and Go mutexes are not reentrant, so invoking the callback while the
+// lock is held wedges the calling goroutine permanently on its own lock.
+func TestBreakerCallbackCanReadStateWithoutDeadlock(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// trigger drives a state change through one of the four public entry
+		// points that can transition. Each must dispatch after unlocking.
+		trigger func(*Breaker)
+	}{
+		{"RecordFailure trips closed->open", func(b *Breaker) { b.RecordFailure() }},
+		{"Trip forces closed->open", func(b *Breaker) { b.Trip() }},
+		{"RecordSuccess closes a tripped breaker", func(b *Breaker) { b.Trip(); b.RecordSuccess() }},
+		{"Allow admits the half-open probe", func(b *Breaker) {
+			b.Trip()
+			// Move past the backoff deadline so Allow performs the
+			// open -> half-open transition rather than rejecting.
+			b.mu.Lock()
+			b.deadline = b.now().Add(-time.Second)
+			b.mu.Unlock()
+			b.Allow()
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1})
+			var seen []State
+			reg.SetOnStateChange(func(tr Transition) {
+				// The deadlocking read: this is what a diagnostics or event
+				// emitter does with a transition.
+				seen = append(seen, reg.Breaker(tr.Scope, tr.OpClass).State())
+			})
+			b := reg.Breaker("/city/rig", "bd")
+
+			runWithinDeadline(t, tc.name, func() { tc.trigger(b) })
+
+			if len(seen) == 0 {
+				t.Fatal("callback never fired; the test is not exercising a transition")
+			}
+		})
+	}
+}
+
+// TestBreakerCallbackCanReadRegistryStatesWithoutDeadlock covers the other read
+// the wiring performs: a fleet-wide snapshot. Registry.States() locks the
+// registry and then every breaker, so a callback dispatched under b.mu deadlocks
+// on the breaker that is mid-transition.
+func TestBreakerCallbackCanReadRegistryStatesWithoutDeadlock(t *testing.T) {
+	reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1})
+	// More than one breaker, so States() must walk past the transitioning one.
+	reg.Breaker("/city/other", "bd")
+	b := reg.Breaker("/city/rig", "bd")
+
+	var snapshot map[Key]State
+	reg.SetOnStateChange(func(Transition) { snapshot = reg.States() })
+
+	runWithinDeadline(t, "Registry.States() from the callback", func() { b.Trip() })
+
+	if len(snapshot) == 0 {
+		t.Fatal("callback never fired, or States() returned nothing")
+	}
+}
+
+// TestBreakerCallbackObservesTheCompletedTransition pins the ordering the fix
+// depends on: the callback runs AFTER the new state is committed, so a reader
+// sees the state the transition describes rather than the one it replaced.
+//
+// Dispatching post-unlock would be worthless if it exposed a stale read.
+func TestBreakerCallbackObservesTheCompletedTransition(t *testing.T) {
+	reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1})
+	var reported, observed State
+	reg.SetOnStateChange(func(tr Transition) {
+		reported = tr.To
+		observed = reg.Breaker(tr.Scope, tr.OpClass).State()
+	})
+	b := reg.Breaker("/city/rig", "bd")
+
+	runWithinDeadline(t, "transition ordering", func() { b.Trip() })
+
+	if reported != StateOpen {
+		t.Errorf("Transition.To = %v, want %v", reported, StateOpen)
+	}
+	if observed != reported {
+		t.Errorf("State() during callback = %v, want %v — the callback must see the committed state, not the pre-transition one", observed, reported)
+	}
+}
+
+// TestBreakerCallbackRewiredMidTransitionDoesNotFireLate guards the capture
+// semantics. The notification carries the callback it was captured with, so a
+// callback swapped out after the transition is not invoked for a change it was
+// never installed for.
+func TestBreakerCallbackRewiredMidTransitionDoesNotFireLate(t *testing.T) {
+	reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1})
+	firstCalls, secondCalls := 0, 0
+	reg.SetOnStateChange(func(Transition) {
+		firstCalls++
+		// Rewire from inside the callback — legal now that the lock is free.
+		reg.SetOnStateChange(func(Transition) { secondCalls++ })
+	})
+	b := reg.Breaker("/city/rig", "bd")
+
+	runWithinDeadline(t, "rewire from callback", func() { b.Trip() })
+
+	if firstCalls != 1 {
+		t.Errorf("original callback fired %d times, want 1", firstCalls)
+	}
+	if secondCalls != 0 {
+		t.Errorf("replacement callback fired %d times for a transition that predates it, want 0", secondCalls)
+	}
+}


### PR DESCRIPTION
Delivers the cleanup @quad341 wrote during the #3318 review but couldn't push. #3318 merged without it, so the deadlock is on `main` today.

## The bug

`transitionLocked` invoked `onChange` while `b.mu` was held — its own doc said *"Caller must hold b.mu."* But `State()` and `Registry.States()` take that same mutex, and Go mutexes are not reentrant. So any callback reading breaker state wedges the calling goroutine forever on its own lock.

Reading state is exactly what the callback exists for. From the #3318 review:

> *"moving the state-change callback dispatch out from under `b.mu` so the future event/diagnostics wiring can read `State()`/`Registry.States()` without deadlocking"*

All four public entry points that can transition are affected: `Allow`, `RecordSuccess`, `RecordFailure`, `Trip`.

## The fix

`transitionLocked` now returns the notification instead of invoking it; each entry point dispatches after unlocking. The dispatch `defer` is registered **before** the unlock `defer`, so LIFO ordering runs the unlock first — the existing defer-based style is preserved rather than rewritten to explicit unlocks.

The notification carries the callback it was captured with, so dispatch needs no lock of its own, and a callback rewired after a transition is not invoked for a change it was never installed for.

## Tests

Five regressions. Each runs the subject on its own goroutine with a timeout, so a regression **fails** rather than hanging the package until the test binary is killed:

- callback reading `State()`, across all four entry points
- callback reading `Registry.States()` with a second breaker present, so the snapshot must walk past the transitioning one
- the callback observing the **committed** state, not the pre-transition one — post-unlock dispatch would be worthless if it exposed a stale read
- rewiring the callback from inside a callback, which is only legal once the lock is free

Verified by restoring under-lock dispatch: all four entry points deadlock, each hanging the full timeout. `go test -race` and `go vet ./...` clean.

## Timing

`internal/resilience` has **no consumers outside the package** on `main` yet — the wiring PRs (#3319, #3324) are still open. So this lands before anything can depend on the previous synchronous-under-lock dispatch, which makes it a free change now and a breaking one later.

## Why it arrives as a PR rather than a push

Per your note on #4695: GitHub doesn't grant upstream maintainers write access to organization-owned forks, so the original cleanup couldn't reach the branch and the retries were reading a 403 as a network blip. @quad341 and @sjarmak now have pending **write** invitations to `Voxist/gascity` — once accepted, this class of fix can go straight onto the branch instead of round-tripping.

Happy to hand this back if you'd rather land your original version; I reconstructed it from the review description rather than seeing your diff, so the shape may differ.