### PR TITLE
fix(reaper): normalize both sides of the worktree containment check

### DIFF
--- a/cmd/gc/bead_worktree_reaper.go
+++ b/cmd/gc/bead_worktree_reaper.go
@@ -444,6 +444,15 @@ func extractBeadIDFromWorktreeName(cfg *config.City, name string) string {
 // isStrictlyUnderDir reports whether path is strictly contained within dir
 // (i.e., it is not dir itself and has dir as a prefix component).
 func isStrictlyUnderDir(dir, path string) bool {
+	// Normalize both sides. git worktree list reports canonical paths, while
+	// dir is derived from the configured city path, which may still contain a
+	// symlinked ancestor (on macOS every $TMPDIR path does, via /var ->
+	// private/var). Comparing the two raw forms makes filepath.Rel return a
+	// "../.." escape for a worktree that is plainly inside the city, so this
+	// defense-in-depth check silently drops every reap candidate. The
+	// PathWithin gate directly above already compares normalized.
+	dir = pathutil.NormalizePathForCompare(dir)
+	path = pathutil.NormalizePathForCompare(path)
 	rel, err := filepath.Rel(dir, path)
 	if err != nil {
 		return false

--- a/cmd/gc/bead_worktree_reaper_symlink_test.go
+++ b/cmd/gc/bead_worktree_reaper_symlink_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIsStrictlyUnderDirNormalizesSymlinkedAncestor pins the containment check
+// that made every scheduled Mac Regression run red (ga-xbilek).
+//
+// reapClosedBeadWorktrees compares two paths that reach it in different forms:
+// worktreePath comes from `git worktree list`, which reports canonical paths,
+// while wtRoot is built from the configured city path, which may still contain
+// a symlinked ancestor. On macOS that is unconditional — every $TMPDIR and /tmp
+// path sits under /var -> private/var — so isStrictlyUnderDir saw a "../.."
+// escape for a worktree plainly inside the city and skipped every candidate.
+// Both the reap list and the protect list came back empty, which is exactly how
+// all 16 TestReapClosedBeadWorktrees_* tests and both
+// TestCityRuntimeTick_*Reap* tests failed on macOS.
+//
+// The symlink below plays the role /var -> private/var plays on macOS, so this
+// test fails without the normalization on every platform, not just darwin.
+func TestIsStrictlyUnderDirNormalizesSymlinkedAncestor(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	// dir as the reaper builds it: through the symlinked ancestor.
+	dir := filepath.Join(link, "city", ".gc", "worktrees")
+	// path as `git worktree list` reports it: fully resolved.
+	resolvedWorktree := filepath.Join(realDir, "city", ".gc", "worktrees", "mrig", "builder", "ga-abc123")
+	if err := os.MkdirAll(resolvedWorktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isStrictlyUnderDir(dir, resolvedWorktree) {
+		t.Errorf("isStrictlyUnderDir(%q, %q) = false, want true: the worktree is inside the city, "+
+			"the two arguments only disagree about symlink resolution", dir, resolvedWorktree)
+	}
+}
+
+// TestIsStrictlyUnderDirStillRejectsEscapes proves the normalization did not
+// weaken the guard: a genuinely outside path, and the directory itself, must
+// still be rejected. Without this, "fix the false negative" could silently
+// become "accept everything", which on this code path authorizes a recursive
+// delete.
+func TestIsStrictlyUnderDirStillRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "city", ".gc", "worktrees")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(root, "elsewhere", "ga-abc123")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if isStrictlyUnderDir(dir, outside) {
+		t.Errorf("isStrictlyUnderDir(%q, %q) = true, want false: path is outside the worktree root", dir, outside)
+	}
+	if isStrictlyUnderDir(dir, dir) {
+		t.Errorf("isStrictlyUnderDir(%q, %q) = true, want false: dir is not strictly under itself", dir, dir)
+	}
+
+	// A symlink that points OUT of the root must be rejected on its resolved
+	// target, not accepted on its lexical position inside the root.
+	escaping := filepath.Join(dir, "escape")
+	if err := os.Symlink(outside, escaping); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	if isStrictlyUnderDir(dir, escaping) {
+		t.Errorf("isStrictlyUnderDir(%q, %q) = true, want false: symlink resolves outside the worktree root",
+			dir, escaping)
+	}
+}


### PR DESCRIPTION
Fixes the defect that has made every scheduled `Mac Regression` run red since
2026-07-20. Investigation: **ga-xbilek**.

## Root cause — one line, one file

`cmd/gc/bead_worktree_reaper.go` `reapClosedBeadWorktrees` compares two paths
that reach it in **different forms**:

- `worktreePath` comes from `git worktree list`, which reports **canonical** paths.
- `wtRoot` is built at line 114 from the configured city path, which may still
  contain a **symlinked ancestor**.

Line 146 gates on `pathutil.PathWithin(...)`, which normalizes — that passes.
Line 151 then gates on `isStrictlyUnderDir(wtRoot, worktreePath)`, which compared
the two **raw** forms with `filepath.Rel`. `Rel` reports a `"../.."` escape for a
worktree that is plainly inside the city, so this defense-in-depth check hit
`continue` for **every** candidate: both `report.Reaped` and `report.Protected`
came back empty.

On macOS that is unconditional — every `$TMPDIR` path sits under `/var ->
private/var` — which is why the whole reaper family failed on every scheduled
run. The gate directly above already compared normalized; this one was missed.

## Fix

Normalize both arguments via `pathutil.NormalizePathForCompare` before the
`filepath.Rel` compare. 9 lines in the production file (mostly comment).

## Evidence

Reproduces on **any** platform with a symlinked temp root standing in for
macOS's `/var -> private/var`, so no mac is needed. Note `GOTMPDIR`, not
`TMPDIR` — the repo's go shim pins `GOTMPDIR` and `t.TempDir()` follows it, so a
`TMPDIR`-only attempt is silently ignored and *falsely* disproves the theory:

```bash
mkdir -p /var/tmp/gcxb/real && ln -s /var/tmp/gcxb/real /var/tmp/gcxb/link
GC_FAST_UNIT=0 GOTMPDIR=/var/tmp/gcxb/link go test ./cmd/gc/ -count=1 \
  -run 'TestReapClosedBeadWorktrees|TestCityRuntimeTick.*Reap|TestIsStrictlyUnderDir'
```

| | without the fix | with the fix |
| --- | --- | --- |
| result | **20 FAIL** | **26 PASS**, 0 fail, 0 skip |

The 20 failures under the negative control are exactly the families CI reports:
16 `TestReapClosedBeadWorktrees_*`, `TestCityRuntimeTick_ReapsClosedBeadWorktreeWhenEnabled`,
`TestCityRuntimeTick_DryRunReapDeletesNothing`, plus the 2 new tests below.

**Disproved alternative:** that symlinks as such, or the symlink-aware second
pass, were at fault. With both arguments in the *same* form the identical
symlinked layout validates cleanly, which localizes the defect to argument
asymmetry rather than to symlink handling.

## Also closes a hole in the other direction

Without normalization the guard also **accepted** a symlink sitting lexically
inside the worktree root but resolving **outside** it — on a code path that
authorizes recursive deletion. Normalizing resolves the target, so the escape is
now rejected. `TestIsStrictlyUnderDirStillRejectsEscapes` covers that direction
and pins that "fix the false negative" did not become "accept everything".

## Why this PR carries `needs-mac`

PR-triggered `Mac Regression` jobs are gated on the `needs-mac` label
(`.github/workflows/mac-regression.yml:116-123`); without it every job skips and
the workflow reports **success without running anything**. The label is on this
PR so macOS actually exercises the change.

## Relationship to the sibling beads

- **ga-646c0q** (P1, in flight) — the same asymmetry at
  `cmd/gc/api_state.go`, where API `CreateRig` rejects an in-city rig as
  "escapes the city root". Different site, separate fix; not touched here.
- **ga-4bqjjn / ga-iawy13** — the architecture ruling for the whole class is
  *canonical-at-ingest*: normalize once at the domain boundary, and past it let
  comparison sites use plain `filepath.Rel`. This PR deliberately normalizes **at
  the check**, which is the narrow point fix that unblocks CI now, and I want to
  flag the tension rather than hide it. My recommendation for `ga-iawy13`: keep
  the resolution here even after ingest normalization lands, because this
  particular check gates a recursive delete, and ingest-canonicalisation of the
  *city path* does not defend against a symlink created *inside* the worktree
  root later. If the sweep decides otherwise, this is a 2-line revert.

## Scope

2 files, +91 (−0): 9 lines in `bead_worktree_reaper.go`, 82 in a new
`bead_worktree_reaper_symlink_test.go`. No API or behavior change beyond the
containment check itself.
