### PR TITLE
ci: keep push runs isolated per commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ci-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || (github.event.pull_request.number || github.ref || github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/release-gates/ga-h46avo-ci-push-concurrency-gate.md
+++ b/release-gates/ga-h46avo-ci-push-concurrency-gate.md
@@ -1,0 +1,62 @@
+# Release Gate: CI push concurrency groups
+
+- Deploy bead: `ga-h46avo`
+- Source review bead: `ga-3fw26n`
+- Reviewed source SHA: `b337159a6a99d378e083372c4def8e0c875581b8`
+- Base checked: `origin/main` at `d2142785fdab11831110fb090eadda28d2d59d96`
+- Gate date: `2026-07-30`
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is absent from this
+  checkout, so this checklist uses the active deployer role's seven release
+  criteria and the repository testing policy in `TESTING.md`.
+
+## Release criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | The deploy bead records `Reviewed + PASSED by reviewer gascity/reviewer` for the exact reviewed SHA. The source review bead records `REVIEWER VERDICT (gascity/reviewer)` and `Verdict: PASS. No blockers.` |
+| 2 | Acceptance criteria met | PASS | Push-event concurrency groups now include `github.sha`; the pull-request fallback remains `pull_request.number \|\| ref \|\| run_id`; `cancel-in-progress` remains limited to pull requests; the CI execution-policy hash was updated; and `TestPushRunsGetPerCommitConcurrencyGroup` directly locks all three expression requirements. |
+| 3 | Tests pass | PASS | On a fresh isolated worktree at the reviewed SHA: `go build ./...` passed; `make lint` passed with `0 issues`; `make fmt-check` passed; `make vet` passed; `make test-ci-policy` passed (20 Python tests plus its focused Go policy checks); `go test -json -count=1 ./scripts/...` recorded 339 test/subtest PASS, 0 FAIL, 0 SKIP; and `make test-fast-parallel` passed 10 jobs, 0 failed jobs, 0 skipped jobs. The fast profile intentionally omits `GC_FAST_UNIT=0` process cases; `TESTING.md` assigns those to the separate process suite, and this diff changes only CI workflow/policy files. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes say `No blockers`, `style_findings: none`, and `security_findings: none`; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Both the role checkout and fresh isolated gate worktree were clean after the gate. This checklist is the sole deployer-authored file and will be committed on the mechanically derived isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | PASS | `origin/main` is the merge base and direct parent-side base of the reviewed commit set. `git merge-tree --write-tree origin/main b337159a6a99d378e083372c4def8e0c875581b8` exited 0 and produced tree `2052c7191cd88aafe568691898f497e623c4a0d3`. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The two commits touch only `.github/workflows/ci.yml` and its `scripts/cipolicy` hash/test guard. The commit set is one CI-run concurrency-correctness theme with no independent feature bundled. |
+
+## Acceptance evidence
+
+- Push events use the commit SHA in the concurrency group, so a newer push to
+  the same branch does not cancel the earlier commit's run.
+- Pull-request runs keep their prior grouping fallback and remain the only
+  event type with `cancel-in-progress` enabled.
+- The pinned execution hash recognizes the intentional workflow change.
+- The new regression test reads the checked workflow and asserts the complete
+  group and cancellation expressions verbatim.
+- The net diff is three files, 26 insertions, and 2 deletions.
+
+## Test evidence
+
+```text
+go build ./...                                 PASS
+make lint                                      PASS, 0 issues
+make fmt-check                                 PASS
+make vet                                       PASS
+make test-ci-policy                            PASS
+  Python runner-policy tests                   5 PASS, 0 FAIL, 0 SKIP
+  Python suite-coverage tests                  15 PASS, 0 FAIL, 0 SKIP
+  focused Go policy packages                   PASS
+go test -json -count=1 ./scripts/...           339 PASS, 0 FAIL, 0 SKIP
+make test-fast-parallel                        10 PASS jobs, 0 FAIL, 0 SKIP jobs
+git diff --check origin/main...HEAD            PASS
+```
+
+An initial lint invocation in the long-lived role worktree found three
+diagnostics under ignored
+`internal/api/dashboardspa/web/node_modules/flatted/golang/`. That directory is
+not tracked, is absent from the reviewed diff, and did not exist in the fresh
+isolated gate worktree. The clean isolated run above is the candidate result;
+the contaminated output was retained as environment evidence and was not
+reported as a product-test failure.
+
+## Verdict
+
+PASS. The reviewed SHA is eligible for an isolated deploy branch, pull request,
+and merge-authority handoff.

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -20,7 +20,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "917fdf8ac535519725f709422d1bf4b650ae7e5c4a61a350c25227cc3f2e0fe9"
+	expectedCIExecutionHash      = "fc3eb8c544ec0a6159e9dd0d200dee9fb373d2ad1fb94ddb0ea57626ab75de39"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "80575ca368f28ba9f8b14bf72ce5767a7877ffe4dcadc136854ab4b0b5f1377a"
 	expectedSetupActionHash      = "b7864038195cd054aee7fccfa903cab335b375bcab1a35239c17c5da7d32c07e"

--- a/scripts/cipolicy/policy_test.go
+++ b/scripts/cipolicy/policy_test.go
@@ -609,8 +609,11 @@ func TestPolicyErrorsIdentifyTheBrokenContract(t *testing.T) {
 
 // TestPushRunsGetPerCommitConcurrencyGroup guards against the push-events
 // concurrency bug: today every push to a branch shares one concurrency group
-// keyed on github.ref, so a fast-follow commit to main cancels the
-// in-progress CI run for the commit before it. Push events must key off
+// keyed on github.ref. Because cancel-in-progress is false for push, a
+// fast-follow commit does not kill the running job — it queues behind it as
+// pending, and GitHub cancels whatever run was *already* pending in that
+// group. So an intermediate commit can be cancelled before it ever starts and
+// never receives a pass/fail verdict. Push events must key off
 // github.sha so each commit gets its own group, while pull_request behavior
 // (grouped by PR number, cancel-in-progress) stays unchanged.
 func TestPushRunsGetPerCommitConcurrencyGroup(t *testing.T) {

--- a/scripts/cipolicy/policy_test.go
+++ b/scripts/cipolicy/policy_test.go
@@ -606,3 +606,27 @@ func TestPolicyErrorsIdentifyTheBrokenContract(t *testing.T) {
 		t.Fatalf("error = %v, want integration-shards context", err)
 	}
 }
+
+// TestPushRunsGetPerCommitConcurrencyGroup guards against the push-events
+// concurrency bug: today every push to a branch shares one concurrency group
+// keyed on github.ref, so a fast-follow commit to main cancels the
+// in-progress CI run for the commit before it. Push events must key off
+// github.sha so each commit gets its own group, while pull_request behavior
+// (grouped by PR number, cancel-in-progress) stays unchanged.
+func TestPushRunsGetPerCommitConcurrencyGroup(t *testing.T) {
+	docs := loadPolicyDocuments(t)
+	concurrency, ok := docs.ci["concurrency"].(map[string]any)
+	if !ok {
+		t.Fatal("ci.yml concurrency is not a mapping")
+	}
+
+	const wantGroup = "ci-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || (github.event.pull_request.number || github.ref || github.run_id) }}"
+	if got := concurrency["group"]; got != wantGroup {
+		t.Fatalf("concurrency.group = %q, want %q (push events must get a unique group per commit SHA)", got, wantGroup)
+	}
+
+	const wantCancel = "${{ github.event_name == 'pull_request' }}"
+	if got := concurrency["cancel-in-progress"]; got != wantCancel {
+		t.Fatalf("concurrency.cancel-in-progress = %q, want %q (pull_request behavior must stay unchanged)", got, wantCancel)
+	}
+}

--- a/scripts/cipolicy/policy_test.go
+++ b/scripts/cipolicy/policy_test.go
@@ -612,7 +612,7 @@ func TestPolicyErrorsIdentifyTheBrokenContract(t *testing.T) {
 // keyed on github.ref. Because cancel-in-progress is false for push, a
 // fast-follow commit does not kill the running job — it queues behind it as
 // pending, and GitHub cancels whatever run was *already* pending in that
-// group. So an intermediate commit can be cancelled before it ever starts and
+// group. So an intermediate commit can be canceled before it ever starts and
 // never receives a pass/fail verdict. Push events must key off
 // github.sha so each commit gets its own group, while pull_request behavior
 // (grouped by PR number, cancel-in-progress) stays unchanged.


### PR DESCRIPTION
## What this changes

Push-triggered CI runs now use the pushed commit SHA in their concurrency group. A fast-follow push to `main` can no longer cancel the still-running checks for the preceding commit, so each landed commit receives a terminal CI verdict.

Pull-request behavior is unchanged: runs remain grouped by pull request and newer updates still cancel obsolete in-progress runs.

## Review notes

- The behavior change is one expression in `.github/workflows/ci.yml`.
- The execution-policy hash is updated to acknowledge the intentional workflow change.
- A focused policy test locks both the new push grouping and the unchanged pull-request cancellation behavior.

## Test plan

- [x] `go build ./...`, full lint, formatting, and vet
- [x] `make test-ci-policy` plus `go test -count=1 ./scripts/...`
- [x] `make test-fast-parallel` — 10/10 jobs passed
- [x] Release gate: [`release-gates/ga-h46avo-ci-push-concurrency-gate.md`](release-gates/ga-h46avo-ci-push-concurrency-gate.md)