### PR TITLE
Fix API rig creation for symlinked city roots

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gastownhall/gascity/internal/orderdiscovery"
 	"github.com/gastownhall/gascity/internal/orderdispatch"
 	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/rig"
 	"github.com/gastownhall/gascity/internal/rollout"
 	"github.com/gastownhall/gascity/internal/rollout/gate"
@@ -1716,8 +1717,12 @@ func (cs *controllerState) DeleteAgent(name string) error {
 // than a 500.
 func assertRigPathWithinCity(cityPath, resolved string) error {
 	// Lexical check first: rejects "../" escapes and absolute paths that resolve
-	// to a sibling/parent of the city.
-	if err := relWithinCity(cityPath, resolved); err != nil {
+	// to a sibling/parent of the city. Normalize both sides so a symlinked city
+	// ancestor (cityPath raw, resolved already resolveStoreScopeRoot-resolved)
+	// doesn't register as a false-positive escape.
+	normalizedCity := pathutil.NormalizePathForCompare(cityPath)
+	normalizedTarget := pathutil.NormalizePathForCompare(resolved)
+	if err := relWithinCity(normalizedCity, normalizedTarget); err != nil {
 		return err
 	}
 	// Symlink-aware check: a "../"-free lexical path can still escape through a

--- a/cmd/gc/api_state_rig_path_symlink_test.go
+++ b/cmd/gc/api_state_rig_path_symlink_test.go
@@ -1,9 +1,7 @@
 package main
 
-// Reproducer for the symlinked-city CreateRig rejection (adjacent defect found
-// while investigating ga-xbilek). Drop this into cmd/gc/ and run:
-//
-//	go test ./cmd/gc/ -run TestAssertRigPathWithinCity -v
+// Regression coverage for the symlinked-city CreateRig rejection (adjacent
+// defect found while investigating ga-xbilek).
 //
 // It needs no macOS and no GOTMPDIR emulation — it creates its own symlink.
 
@@ -13,19 +11,19 @@ import (
 	"testing"
 )
 
-// TestAssertRigPathWithinCityRejectsResolvedTargetUnderRawCity shows that
-// controllerState.CreateRig rejects a rig living INSIDE the city with
-// "rig path %s escapes the city root" whenever the city is reached through a
+// TestAssertRigPathWithinCityAcceptsResolvedTargetUnderSymlinkedCity pins that a
+// rig living INSIDE the city validates even when the city is reached through a
 // symlinked ancestor (e.g. ~/gc -> /data/gc, the exact case
 // resolveStoreScopeRoot's own comment says it supports).
 //
-// CreateRig (api_state.go:1788) sets r.Path = resolveStoreScopeRoot(...), which
-// normalizes through pathutil and therefore RESOLVES the symlink. It then calls
-// assertRigPathWithinCity(cs.cityPath, r.Path) (api_state.go:1796) where
-// cs.cityPath is still the UNRESOLVED form. The lexical first pass
-// (relWithinCity, api_state.go:1740) compares those two mismatched forms and
-// reports an escape.
-func TestAssertRigPathWithinCityRejectsResolvedTargetUnderRawCity(t *testing.T) {
+// controllerState.CreateRig sets r.Path = resolveStoreScopeRoot(...), which
+// normalizes through pathutil and therefore RESOLVES the symlink, then calls
+// assertRigPathWithinCity(cs.cityPath, r.Path) with cs.cityPath still in its
+// UNRESOLVED form. assertRigPathWithinCity normalizes both operands before the
+// lexical relWithinCity pass, so those two forms no longer disagree and an
+// in-city rig is not reported as an escape. The independent symlink-aware pass
+// that follows is unchanged, so a genuine escape must still fail both checks.
+func TestAssertRigPathWithinCityAcceptsResolvedTargetUnderSymlinkedCity(t *testing.T) {
 	root := t.TempDir()
 	realDir := filepath.Join(root, "real")
 	if err := os.MkdirAll(realDir, 0o755); err != nil {

--- a/cmd/gc/api_state_rig_path_symlink_test.go
+++ b/cmd/gc/api_state_rig_path_symlink_test.go
@@ -1,0 +1,83 @@
+package main
+
+// Reproducer for the symlinked-city CreateRig rejection (adjacent defect found
+// while investigating ga-xbilek). Drop this into cmd/gc/ and run:
+//
+//	go test ./cmd/gc/ -run TestAssertRigPathWithinCity -v
+//
+// It needs no macOS and no GOTMPDIR emulation — it creates its own symlink.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAssertRigPathWithinCityRejectsResolvedTargetUnderRawCity shows that
+// controllerState.CreateRig rejects a rig living INSIDE the city with
+// "rig path %s escapes the city root" whenever the city is reached through a
+// symlinked ancestor (e.g. ~/gc -> /data/gc, the exact case
+// resolveStoreScopeRoot's own comment says it supports).
+//
+// CreateRig (api_state.go:1788) sets r.Path = resolveStoreScopeRoot(...), which
+// normalizes through pathutil and therefore RESOLVES the symlink. It then calls
+// assertRigPathWithinCity(cs.cityPath, r.Path) (api_state.go:1796) where
+// cs.cityPath is still the UNRESOLVED form. The lexical first pass
+// (relWithinCity, api_state.go:1740) compares those two mismatched forms and
+// reports an escape.
+func TestAssertRigPathWithinCityRejectsResolvedTargetUnderRawCity(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	cityPath := filepath.Join(link, "city")
+	rigPath := filepath.Join(cityPath, "repo")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved := resolveStoreScopeRoot(cityPath, rigPath)
+	if resolved == rigPath {
+		t.Fatalf("precondition: resolveStoreScopeRoot did not resolve the symlink (got %q)", resolved)
+	}
+
+	if err := assertRigPathWithinCity(cityPath, resolved); err != nil {
+		t.Fatalf("assertRigPathWithinCity(%q, %q) = %v, want nil: the rig is inside the city, "+
+			"only the two arguments disagree about symlink resolution", cityPath, resolved, err)
+	}
+}
+
+// TestAssertRigPathWithinCityAcceptsWhenBothSidesResolved disproves the
+// alternative hypothesis that the symlink-AWARE second pass is at fault: with
+// both arguments in the same form the identical layout validates cleanly.
+func TestAssertRigPathWithinCityAcceptsWhenBothSidesResolved(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	cityPath := filepath.Join(link, "city")
+	rigPath := filepath.Join(cityPath, "repo")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolvedCity, err := filepath.EvalSymlinks(cityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assertRigPathWithinCity(resolvedCity, resolveStoreScopeRoot(cityPath, rigPath)); err != nil {
+		t.Fatalf("assertRigPathWithinCity(%q, ...) = %v, want nil", resolvedCity, err)
+	}
+}

--- a/release-gates/ga-bp4zyv-symlink-safe-city-root-containment-gate.md
+++ b/release-gates/ga-bp4zyv-symlink-safe-city-root-containment-gate.md
@@ -1,0 +1,48 @@
+# Release gate: symlink-safe city-root containment
+
+- Deploy bead: `ga-bp4zyv`
+- Source review: `ga-bnd1fs`
+- Reviewed commit: `026f11a4131964d24c33c6cb5c65d5f785441bf1`
+- Reviewed base: `4a636f6ad88002556c6c0891b7b9e07f9502c81c`
+- Main evaluated: `origin/main@9a88d149cd5c3fb1054f75f8d540fd2aefa465e1`
+- Deploy branch: `deploy/ga-bp4zyv-gate`
+- Evaluated: `2026-07-30T04:36:26Z`
+- Overall verdict: **PASS**
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository at the evaluated
+commit, so this checklist applies the deployer role's release-gate criteria.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 6 | Branch diverges cleanly from main | **PASS** | Checked first and rechecked after tests. `git merge-tree --write-tree origin/main 026f11a4131964d24c33c6cb5c65d5f785441bf1` exited 0 against `origin/main@9a88d149cd5c3fb1054f75f8d540fd2aefa465e1` and produced tree `1999b4e91bb28274c16f8a7fd8082aa38a6f6220`. No self-rebase or source-branch mutation was needed. |
+| 1 | Review PASS present | **PASS** | The deploy bead records a reviewed-and-passed verdict for exact commit `026f11a4131964d24c33c6cb5c65d5f785441bf1`. The source review reports no style, security, or correctness findings. |
+| 2 | Acceptance criteria met | **PASS** | The focused containment suite passed 12 tests, 0 failed, 0 skipped. It covers both valid symlinked-city forms, six `controllerState.CreateRig` behaviors, and four git-provision rejection paths, including relative escapes, absolute client paths, and symlinked-parent escapes. The implementation normalizes both lexical operands while leaving the independent symlink-aware containment pass unchanged. |
+| 3 | Tests pass | **PASS** | On the exact reviewed SHA: `go build ./...`, `go vet ./...`, and `gofmt -l` passed; `make test-fast-parallel` passed 10/10 jobs (0 fail, 0 skip); the documented non-short `cmd/gc` coverage inside `make test-local-full-parallel` passed all six process shards plus the product-metrics testhook (7/7 jobs, 0 fail, 0 skip); `make test-acceptance` passed the Tier A package (0 fail; five tag-empty packages reported no tests to run); and `make test-worker-core-phase2-all` passed 3/3 package invocations (0 fail, 0 skip). The broad 40-job local sweep also exposed host-only failures outside the changed files: the host `bd` binary differed from the verified CI archive despite sharing its version string, tmux 3.7b returned no builtin key bindings, and Dolt 2.2.1 rejected dirty migration fixtures that CI runs under Dolt 2.1.7. The CI-archive rerun cleared the `bdflags` and formula-retry failures; serial reruns cleared the readiness, live-contract, and cleanup races (4 top-level PASS, 0 FAIL, 5 fixture-required subtest SKIPs). The two remaining host-tool failures are in unchanged tmux/recovery code, and the exact merge-base CI run `30496938823` passed every corresponding required lane. |
+| 4 | No high-severity review findings open | **PASS** | The reviewer reports no security findings and no blocking findings. Unresolved HIGH/CRITICAL findings: 0. |
+| 5 | Final branch is clean | **PASS** | Detached reviewed commit `026f11a41` had an empty `git status --porcelain=v1` before this checklist was added; `git diff --check` against the reviewed base passed. The configured hook path is `.githooks`; this checklist is the only deployer-authored release commit. |
+| 7 | Single feature theme | **PASS** | The two-commit TDD diff changes only `cmd/gc/api_state.go` and its focused test (+90/-2). Both commits address one behavior: API rig creation when the city root is reached through a symlink. |
+
+## Review notes
+
+- `assertRigPathWithinCity` reuses `pathutil.NormalizePathForCompare` on the
+  city root and target before the lexical containment check.
+- The second, symlink-aware `EvalSymlinks`/`realPathForContainment` pass is
+  unchanged, so escaping paths still have to pass both containment checks.
+- Local `gc rig add` behavior, API wire shapes, configuration, and storage
+  migrations are unchanged.
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main 026f11a4131964d24c33c6cb5c65d5f785441bf1
+git diff --check 4a636f6ad88002556c6c0891b7b9e07f9502c81c..026f11a4131964d24c33c6cb5c65d5f785441bf1
+gofmt -l cmd/gc/api_state.go cmd/gc/api_state_rig_path_symlink_test.go
+go test -count=1 -v ./cmd/gc -run '^(TestAssertRigPathWithinCityRejectsResolvedTargetUnderRawCity|TestAssertRigPathWithinCityAcceptsWhenBothSidesResolved|TestProvisionRigFromGitRejectsPreexistingPath|TestProvisionRigFromGitRejectsEscapingRelativePath|TestProvisionRigFromGitRejectsAbsoluteClientPath|TestProvisionRigFromGitRejectsSymlinkedParent|TestControllerStateCreateRigPokesReconciler|TestControllerStateCreateRigRejectsDuplicateName|TestControllerStateCreateRigDetectsDefaultBranch|TestControllerStateCreateRigRejectsOutOfCityPath|TestControllerStateCreateRigDetectsDefaultBranchForRelativePath|TestControllerStateCreateRigInitializesStoreBeforePublishing)$'
+go build ./...
+go vet ./...
+make test-local-full-parallel
+PATH="<verified-ci-bd-v1.1.0>:$PATH" make test-fast-parallel
+PATH="<verified-ci-bd-v1.1.0>:$PATH" make test-acceptance
+PATH="<verified-ci-bd-v1.1.0>:$PATH" make test-worker-core-phase2-all
+```


### PR DESCRIPTION
## What this changes

API rig creation now accepts a rig that is genuinely inside a city when the city directory is reached through a filesystem symlink. Previously, the lexical containment check compared the unresolved city path with an already-resolved target path and incorrectly reported that the rig escaped the city root.

The fix normalizes both operands before the lexical check and preserves the existing symlink-aware real-path check as an independent safety boundary.

## Review notes

- The change is confined to the API rig-path containment helper and its focused regression tests.
- Relative escapes, absolute client paths, and targets beneath symlinked parents outside the city remain rejected.
- Local `gc rig add` behavior is unchanged.
- There are no API schema, configuration, dependency, or migration changes.

## Test plan

- [x] Focused containment and rig-creation suite: 12 pass, 0 fail, 0 skip.
- [x] `go build ./...`, `go vet ./...`, and the 10-job fast unit baseline.
- [x] All six non-short `cmd/gc` process shards plus the product-metrics testhook.
- [x] Tier A acceptance and worker phase-2 contracts.
- [x] Release gate: [`release-gates/ga-bp4zyv-symlink-safe-city-root-containment-gate.md`](release-gates/ga-bp4zyv-symlink-safe-city-root-containment-gate.md)
