### PR TITLE
Honor explicit --city for formula scope resolution

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -95,6 +95,7 @@ Use --var to substitute variables and preview the resolved output.
 
 When --rig is set (or cwd is inside a rig), rig-scoped formula_vars from
 city.toml are shown as "(rig default=...)" alongside each applicable var.
+An explicit --city pins city scope, which has no rig-scoped formula_vars.
 
 Examples:
   gc formula show mol-feature

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -1099,11 +1099,11 @@ type formulaScope struct {
 }
 
 // resolveFormulaScope determines the rig (if any) under which a formula
-// invocation should run. Priority: --rig flag > GC_RIG env > enclosing rig
-// from cwd > city. The GC_RIG tier mirrors resolveBdScopeTarget (cmd_bd.go):
-// the controller sets GC_RIG reliably, while cwd detection fails for
-// pool/polecat worktrees under .gc/worktrees/, which are not inside the
-// registered rig.Path.
+// invocation should run. Priority: --rig flag > explicit --city flag >
+// GC_RIG env > enclosing rig from cwd > city. The GC_RIG tier mirrors
+// resolveBdScopeTarget (cmd_bd.go): the controller sets GC_RIG reliably,
+// while cwd detection fails for pool/polecat worktrees under
+// .gc/worktrees/, which are not inside the registered rig.Path.
 func resolveFormulaScope(cfg *config.City, cityPath string, stderr io.Writer) (formulaScope, error) {
 	if name := strings.TrimSpace(rigFlag); name != "" {
 		rig, ok := rigByName(cfg, name)
@@ -1114,6 +1114,16 @@ func resolveFormulaScope(cfg *config.City, cityPath string, stderr io.Writer) (f
 			return formulaScope{}, fmt.Errorf("rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it", rig.Name, rig.Name)
 		}
 		return rigFormulaScope(cfg, cityPath, rig), nil
+	}
+
+	// An explicit --city pins city scope, symmetric with explicit --rig: a
+	// deliberate city scope must never be silently downgraded to a rig store
+	// by GC_RIG env or cwd auto-detection below. GC_RIG is ambient on every
+	// controller-spawned agent, so without this pin `gc --city X formula
+	// cook` lands on a rig store. (gastownhall/gascity#3410 did the same for
+	// `gc bd`.)
+	if strings.TrimSpace(cityFlag) != "" {
+		return formulaScope{storeRoot: cityPath, searchPaths: cfg.FormulaLayers.City}, nil
 	}
 
 	gcRigDiscarded := ""
@@ -1163,10 +1173,10 @@ func rigFormulaScope(cfg *config.City, cityPath string, rig config.Rig) formulaS
 }
 
 // rigFormulaVarsForScope returns rig-scoped formula var defaults for the
-// active scope (honoring --rig, GC_RIG env, and cwd — same priority as
-// resolveFormulaScope). Returns an empty map when no rig context is active
-// so callers can treat the result as read-only annotations without nil
-// checks. No stderr warning here for a discarded GC_RIG: this is always
+// active scope (honoring --rig, explicit --city, GC_RIG env, and cwd — same
+// priority as resolveFormulaScope). Returns an empty map when no rig context
+// is active so callers can treat the result as read-only annotations without
+// nil checks. No stderr warning here for a discarded GC_RIG: this is always
 // called alongside resolveFormulaScope (see newFormulaShowCmd), which
 // already warns once for the same condition.
 func rigFormulaVarsForScope(cfg *config.City, cityPath string) map[string]string {
@@ -1177,6 +1187,11 @@ func rigFormulaVarsForScope(cfg *config.City, cityPath string) map[string]string
 		if rig, ok := rigByName(cfg, name); ok {
 			return cloneStringMap(rig.FormulaVars)
 		}
+		return map[string]string{}
+	}
+	// Symmetric with resolveFormulaScope: an explicit --city pins city scope,
+	// which has no rig-scoped formula vars.
+	if strings.TrimSpace(cityFlag) != "" {
 		return map[string]string{}
 	}
 	if gcRig := strings.TrimSpace(os.Getenv("GC_RIG")); gcRig != "" {

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -396,6 +396,212 @@ func TestResolveFormulaScope_UnknownGCRIGEnvFallsThroughAndWarns(t *testing.T) {
 	}
 }
 
+// TestResolveFormulaScope_ExplicitCityPinsCityScope verifies that an explicit
+// --city flag pins city scope ahead of GC_RIG env: a deliberate city scope
+// must never be silently downgraded to a rig store by the ambient GC_RIG env
+// var every controller-spawned agent carries. Mirrors the identical guard in
+// cmd_bd.go's resolveBdScopeTarget (gastownhall/gascity#3410).
+func TestResolveFormulaScope_ExplicitCityPinsCityScope(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{
+				Name: "my-project",
+				Path: rigPath,
+				FormulaVars: map[string]string{
+					"test_command": "make test-fast",
+				},
+			},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"my-project": {"/city/formulas", "/rigs/my-project/formulas"},
+			},
+		},
+	}
+
+	// cwd outside both cityPath and rigPath, simulating a pool/polecat
+	// worktree under .gc/worktrees/ — isolates the assertion to the
+	// GC_RIG-vs-city precedence rather than cwd auto-detection.
+	t.Chdir(t.TempDir())
+	prevRig := rigFlag
+	t.Cleanup(func() { rigFlag = prevRig })
+	rigFlag = ""
+	prevCity := cityFlag
+	t.Cleanup(func() { cityFlag = prevCity })
+	cityFlag = cityPath
+	t.Setenv("GC_RIG", "my-project")
+
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != cityPath {
+		t.Errorf("storeRoot = %q, want %q (--city must pin city scope over GC_RIG)", scope.storeRoot, cityPath)
+	}
+	if scope.rig != "" {
+		t.Errorf("rig = %q, want empty (city scope)", scope.rig)
+	}
+	want := []string{"/city/formulas"}
+	if !reflect.DeepEqual(scope.searchPaths, want) {
+		t.Errorf("searchPaths = %v, want %v", scope.searchPaths, want)
+	}
+
+	vars := rigFormulaVarsForScope(cfg, cityPath)
+	if len(vars) != 0 {
+		t.Errorf("rigFormulaVarsForScope = %v, want empty (city scope pinned by --city)", vars)
+	}
+}
+
+// TestResolveFormulaScope_ExplicitCityOverridesCwdResolvedRig verifies that
+// --city also pins city scope ahead of cwd-based rig auto-detection, not just
+// GC_RIG env. This is a deliberate behavior change (pre-existing cwd
+// detection would otherwise win) — matching the identical override in
+// cmd_bd.go's resolveBdScopeTarget, and must be called out in the commit
+// message per that precedent.
+func TestResolveFormulaScope_ExplicitCityOverridesCwdResolvedRig(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "my-project", Path: rigPath}},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"my-project": {"/city/formulas", "/rigs/my-project/formulas"},
+			},
+		},
+	}
+
+	t.Chdir(rigPath) // cwd resolves to the my-project rig
+	prevRig := rigFlag
+	t.Cleanup(func() { rigFlag = prevRig })
+	rigFlag = ""
+	prevCity := cityFlag
+	t.Cleanup(func() { cityFlag = prevCity })
+	cityFlag = cityPath
+
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != cityPath {
+		t.Errorf("storeRoot = %q, want %q (--city must pin city scope over cwd-resolved rig)", scope.storeRoot, cityPath)
+	}
+	if scope.rig != "" {
+		t.Errorf("rig = %q, want empty (city scope)", scope.rig)
+	}
+}
+
+// TestResolveFormulaScope_GCRIGEnvOverridesCwdResolvedRig closes a precedence
+// coverage gap: GC_RIG env must win over a DIFFERENT rig that cwd would
+// otherwise resolve to, not just over city-when-cwd-resolves-nothing (already
+// covered by TestResolveFormulaScope_GCRIGEnvRoutesWhenCwdOutsideRig). Pins
+// the documented "GC_RIG env > enclosing rig from cwd" ordering.
+func TestResolveFormulaScope_GCRIGEnvOverridesCwdResolvedRig(t *testing.T) {
+	cityPath := t.TempDir()
+	rigAPath := filepath.Join(cityPath, "rig-a")
+	rigBPath := filepath.Join(cityPath, "rig-b")
+	for _, p := range []string{rigAPath, rigBPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "rig-a", Path: rigAPath},
+			{Name: "rig-b", Path: rigBPath},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"rig-a": {"/city/formulas", "/rigs/rig-a/formulas"},
+				"rig-b": {"/city/formulas", "/rigs/rig-b/formulas"},
+			},
+		},
+	}
+
+	t.Chdir(rigAPath) // cwd resolves to rig-a
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = ""
+	t.Setenv("GC_RIG", "rig-b")
+
+	scope, err := resolveFormulaScope(cfg, cityPath, io.Discard)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != rigBPath {
+		t.Errorf("storeRoot = %q, want %q (GC_RIG must win over cwd-resolved rig-a)", scope.storeRoot, rigBPath)
+	}
+	if scope.rig != "rig-b" {
+		t.Errorf("rig = %q, want %q", scope.rig, "rig-b")
+	}
+}
+
+// TestResolveFormulaScope_UnboundGCRIGFallsThroughToCwdRigAndWarnsRigName
+// closes a second precedence coverage gap: when GC_RIG names a declared-but-
+// unbound rig and cwd resolves to a DIFFERENT bound rig, scope must fall
+// through to that cwd-resolved rig, and the discard warning must name the
+// actual "<rig>" rig rather than "city" — exercising the scopeDesc arm that
+// TestResolveFormulaScope_UnknownGCRIGEnvFallsThroughAndWarns (cwd outside
+// any rig) does not reach.
+func TestResolveFormulaScope_UnboundGCRIGFallsThroughToCwdRigAndWarnsRigName(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "my-project", Path: rigPath},
+			{Name: "unbound", Path: ""},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"my-project": {"/city/formulas", "/rigs/my-project/formulas"},
+			},
+		},
+	}
+
+	t.Chdir(rigPath) // cwd resolves to my-project
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = ""
+	t.Setenv("GC_RIG", "unbound")
+
+	var stderr bytes.Buffer
+	scope, err := resolveFormulaScope(cfg, cityPath, &stderr)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != rigPath {
+		t.Errorf("storeRoot = %q, want %q (fallthrough to cwd-resolved rig)", scope.storeRoot, rigPath)
+	}
+	if scope.rig != "my-project" {
+		t.Errorf("rig = %q, want %q", scope.rig, "my-project")
+	}
+	warn := stderr.String()
+	if !strings.Contains(warn, `"my-project" rig`) {
+		t.Errorf("expected warning naming %q, got %q", `"my-project" rig`, warn)
+	}
+	if strings.Contains(warn, "the city scope") {
+		t.Errorf("warning incorrectly names city scope instead of the cwd-resolved rig: %q", warn)
+	}
+}
+
 func TestFormulaShowJSONFromRecipe(t *testing.T) {
 	defaultValue := "main"
 	priority := 1

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1653,6 +1653,7 @@ Use --var to substitute variables and preview the resolved output.
 
 When --rig is set (or cwd is inside a rig), rig-scoped formula_vars from
 city.toml are shown as "(rig default=...)" alongside each applicable var.
+An explicit --city pins city scope, which has no rig-scoped formula_vars.
 
 Examples:
   gc formula show mol-feature

--- a/release-gates/explicit-city-scope-pin-gate.md
+++ b/release-gates/explicit-city-scope-pin-gate.md
@@ -1,4 +1,4 @@
-# Release gate: explicit `--city` formula scope pin
+# Release gate: explicit formula city-scope pin
 
 - Deploy bead: `ga-vcj2vo`
 - Build bead: `ga-61cxkw`

--- a/release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md
+++ b/release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md
@@ -2,8 +2,8 @@
 
 - Deploy bead: `ga-djfr2g`
 - Build bead: `ga-fstubn`
-- Reviewed source: `6c5712c0f58d8c7e4605dc2b145cbb96ef9e772f`
-- Gate base: `origin/main@682a0726f5ad20cedd39e3b97e0f9d6f7fa7b919`
+- Reviewed source: `e25f6e9df1a7b50059c11a0448a12c24aae00b4a`
+- Gate base: `origin/main@e6135a435098a70f20081d1d88a03b6742002d9a`
 - Evaluation date: 2026-07-30
 - Disposition: **PASS**
 
@@ -11,12 +11,12 @@
 
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
-| 1 | Review PASS present | **PASS** | `ga-djfr2g` records `verdict: pass` after an independent review at the reviewed source SHA. |
+| 1 | Review PASS present | **PASS** | Independent review bead `ga-4qlsxg` records `verdict: pass` at the reviewed source SHA. |
 | 2 | Acceptance criteria met | **PASS** | Focused tests pass for valid `GC_RIG` routing outside a registered rig path, explicit `--rig` precedence, invalid/unbound `GC_RIG` warning plus cwd/city fallback, unchanged behavior when `GC_RIG` is unset, and rig-scoped formula variables. The implementation is shared by formula show, catalog, cook, and version-check call sites. |
-| 3 | Tests pass | **PASS** | `go build ./...` passed; `go vet ./...` passed; `go test -count=1 ./cmd/gc/... -run 'TestResolveFormulaScope\|TestRigFormulaVarsForScope' -v` passed, 14/14 (including the new `--city` city-pin and precedence-gap tests); `make test-fast-parallel` passed all 10 jobs. All commands ran at the reviewed source SHA. |
+| 3 | Tests pass | **PASS** | At the reviewed source SHA: `go build ./...` and `go vet ./...` passed; the focused formula-scope command passed 14 PASS, 0 FAIL, 0 SKIP; `make test-fast-parallel` passed 10/10 jobs; and the required `make test-cmd-gc-process-parallel` coverage passed all six `GC_FAST_UNIT=0` shards plus `productmetrics-testhook`, with 15,247 PASS, 0 FAIL, and 11 intentional skips. `TestTutorial01` ran and passed. The skips are existing helper-only, opt-in live-canary, unsupported-OS, unavailable optional prompt-fixture, or ambient-cwd cases explicitly disabled inside test binaries; none bears on formula scope precedence. |
 | 4 | No high-severity review findings open | **PASS** | Reviewer notes report no style, security, or specification findings and no blocking findings; unresolved HIGH count is 0. |
 | 5 | Final branch is clean | **PASS** | `git status --porcelain` was empty at the reviewed source SHA before this gate record was created. |
-| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main 6c5712c0f58d8c7e4605dc2b145cbb96ef9e772f` exited 0 against the gate base and produced tree `b6eb17bd687e0a2391e3e2726fb58bd70897d0a3`; no self-rebase was required. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main e25f6e9df1a7b50059c11a0448a12c24aae00b4a` exited 0 against the gate base and produced tree `06495988b3b266e76e96f99fdac35647b81abc94`; no self-rebase was required. |
 | 7 | Single feature theme | **PASS** | The three-commit diff (RED `62d4260e0`, GREEN `6c5712c0f`, and this gate-doc refresh) is confined to `cmd/gc/cmd_formula.go`, `cmd/gc/cmd_formula_test.go`, and this gate doc, implementing, testing, and recording one formula scope-resolution behavior — including the restored `--city` scope pin. |
 
 ## Acceptance evidence

--- a/release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md
+++ b/release-gates/ga-djfr2g-formula-gc-rig-scope-gate.md
@@ -2,9 +2,9 @@
 
 - Deploy bead: `ga-djfr2g`
 - Build bead: `ga-fstubn`
-- Reviewed source: `8dcf51a1821596ec2aa79a016b2457adb62b4c9e`
+- Reviewed source: `6c5712c0f58d8c7e4605dc2b145cbb96ef9e772f`
 - Gate base: `origin/main@682a0726f5ad20cedd39e3b97e0f9d6f7fa7b919`
-- Evaluation date: 2026-07-28
+- Evaluation date: 2026-07-30
 - Disposition: **PASS**
 
 ## Gate checklist
@@ -13,11 +13,11 @@
 |---|---|---|---|
 | 1 | Review PASS present | **PASS** | `ga-djfr2g` records `verdict: pass` after an independent review at the reviewed source SHA. |
 | 2 | Acceptance criteria met | **PASS** | Focused tests pass for valid `GC_RIG` routing outside a registered rig path, explicit `--rig` precedence, invalid/unbound `GC_RIG` warning plus cwd/city fallback, unchanged behavior when `GC_RIG` is unset, and rig-scoped formula variables. The implementation is shared by formula show, catalog, cook, and version-check call sites. |
-| 3 | Tests pass | **PASS** | `go build ./...` passed; `go test -count=1 ./cmd/gc/... -run 'TestResolveFormulaScope\|TestRigFormulaVarsForScope' -v` passed; `make test-fast-parallel` passed all 9 jobs; `go vet ./...` passed. All commands ran at the reviewed source SHA. |
+| 3 | Tests pass | **PASS** | `go build ./...` passed; `go vet ./...` passed; `go test -count=1 ./cmd/gc/... -run 'TestResolveFormulaScope\|TestRigFormulaVarsForScope' -v` passed, 14/14 (including the new `--city` city-pin and precedence-gap tests); `make test-fast-parallel` passed all 10 jobs. All commands ran at the reviewed source SHA. |
 | 4 | No high-severity review findings open | **PASS** | Reviewer notes report no style, security, or specification findings and no blocking findings; unresolved HIGH count is 0. |
 | 5 | Final branch is clean | **PASS** | `git status --porcelain` was empty at the reviewed source SHA before this gate record was created. |
-| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main 8dcf51a1821596ec2aa79a016b2457adb62b4c9e` exited 0 against the gate base and produced tree `cccf7c4176560777c13c6cfcd733fafb10885d8c`; no self-rebase was required. |
-| 7 | Single feature theme | **PASS** | The two-commit diff is confined to `cmd/gc/cmd_formula.go` and `cmd/gc/cmd_formula_test.go`, implementing and testing one formula scope-resolution behavior. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main 6c5712c0f58d8c7e4605dc2b145cbb96ef9e772f` exited 0 against the gate base and produced tree `b6eb17bd687e0a2391e3e2726fb58bd70897d0a3`; no self-rebase was required. |
+| 7 | Single feature theme | **PASS** | The three-commit diff (RED `62d4260e0`, GREEN `6c5712c0f`, and this gate-doc refresh) is confined to `cmd/gc/cmd_formula.go`, `cmd/gc/cmd_formula_test.go`, and this gate doc, implementing, testing, and recording one formula scope-resolution behavior — including the restored `--city` scope pin. |
 
 ## Acceptance evidence
 
@@ -25,4 +25,5 @@
 - A valid bound rig selects its store root, formula layers, and formula variables even when the agent worktree is outside the rig path.
 - An unknown or unbound `GC_RIG` does not make formula commands unusable: resolution falls through and emits a warning naming the discarded value and selected scope.
 - Existing cwd and city fallback behavior remains in place when `GC_RIG` is unset.
+- An explicit `--city` pins city scope ahead of `GC_RIG` and cwd discovery.
 - No configuration schema, API wire shape, migration, or new dependency is introduced.

--- a/release-gates/ga-vcj2vo-explicit-city-scope-pin-gate.md
+++ b/release-gates/ga-vcj2vo-explicit-city-scope-pin-gate.md
@@ -1,0 +1,29 @@
+# Release gate: explicit `--city` formula scope pin
+
+- Deploy bead: `ga-vcj2vo`
+- Build bead: `ga-61cxkw`
+- Review bead: `ga-4qlsxg`
+- Reviewed source: `e25f6e9df1a7b50059c11a0448a12c24aae00b4a`
+- Gate base: `origin/main@e6135a435098a70f20081d1d88a03b6742002d9a`
+- Evaluation date: 2026-07-30
+- Disposition: **PASS**
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Independent review bead `ga-4qlsxg` records `verdict: pass` for reviewed source `e25f6e9df1a7b50059c11a0448a12c24aae00b4a`. |
+| 2 | Acceptance criteria met | **PASS** | `resolveFormulaScope` and `rigFormulaVarsForScope` both honor explicit `--city` after explicit `--rig` and before ambient `GC_RIG` or cwd discovery. Focused tests cover city-over-`GC_RIG`, city-over-cwd, `GC_RIG`-over-cwd, and unbound-`GC_RIG` fallthrough with the selected-rig warning. |
+| 3 | Tests pass | **PASS** | At the reviewed source SHA, `go build ./...` and `go vet ./...` passed. `go test ./cmd/gc/ -run 'TestResolveFormulaScope\|TestRigFormulaVarsForScope' -count=1 -v` reported 14 PASS, 0 FAIL, 0 SKIP. `make test-fast-parallel` passed all 10 jobs. The required `make test-cmd-gc-process-parallel` coverage passed all six `GC_FAST_UNIT=0` shards plus `productmetrics-testhook`, reporting 15,247 PASS, 0 FAIL, and 11 intentional skips; `TestTutorial01` ran and passed. The skips are existing helper-only, opt-in live-canary, unsupported-OS, unavailable optional prompt-fixture, or ambient-cwd cases explicitly disabled inside test binaries; none bears on formula scope precedence. |
+| 4 | No high-severity review findings open | **PASS** | The independent review reports no security, style, specification, blocker, or major findings; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | **PASS** | `git status --porcelain` was empty after testing at the reviewed source SHA; only these gate-record edits were then added. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main e25f6e9df1a7b50059c11a0448a12c24aae00b4a` exited 0 against the gate base and produced tree `06495988b3b266e76e96f99fdac35647b81abc94`; no self-rebase was required. |
+| 7 | Single feature theme | **PASS** | The reviewed three-commit set changes `cmd/gc` formula scope resolution, its tests, and the corresponding gate evidence only. It restores one precedence rule: explicit `--city` pins city scope ahead of ambient rig discovery. |
+
+## Acceptance evidence
+
+- Explicit `--rig` remains the highest-priority scope selector.
+- Explicit `--city` now pins formula operations to city storage and city formula layers ahead of `GC_RIG` and cwd-based rig discovery.
+- City scope supplies no rig-scoped formula variables.
+- Existing `GC_RIG` precedence and unbound-rig fallthrough behavior remain covered.
+- No configuration schema, API wire shape, migration, dependency, or unrelated subsystem changes.


### PR DESCRIPTION
## What this changes

`gc --city <path> formula ...` now stays explicitly city-scoped even when the process has an ambient `GC_RIG` or runs inside a registered rig. Before this fix, formula commands could silently select a rig store despite the operator supplying `--city`.

Formula scope resolution and rig-scoped formula-variable lookup now apply the same precedence: explicit `--rig`, explicit `--city`, `GC_RIG`, cwd discovery, then city fallback. This follows the existing `gc bd` behavior and keeps the two formula resolution paths symmetric.

This is a follow-up to #4760: the earlier scope work landed without its maintainer-side `--city` guard. Jim Wordelman's original commits remain unchanged; this PR adds the guard as separate maintainer-authored commits.

## Review notes

- Explicit `--rig` remains the highest-priority selector.
- Explicit `--city` deliberately overrides cwd-based rig discovery as well as `GC_RIG`.
- There are no config, API, dependency, or migration changes.
- The focused tests cover both new city-pin cases and the surrounding `GC_RIG`/cwd precedence behavior.

## Test plan

- [x] Run `go build ./...` and `go vet ./...`.
- [x] Run the focused formula-scope tests with verbose result counts.
- [x] Run `make test-fast-parallel`.
- [x] Run `make test-cmd-gc-process-parallel`, including `TestTutorial01` with `GC_FAST_UNIT=0` and the product-metrics testhook profile.
- [x] Release gate: [`release-gates/explicit-city-scope-pin-gate.md`](release-gates/explicit-city-scope-pin-gate.md)