### PR TITLE
Centralize macOS regression workflow routing

### DIFF
--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -588,8 +588,10 @@ jobs:
         run: make test-integration-review-formulas
 
   # Aggregate summary so a single check reports Mac parity status on the
-  # PR. Gated on the same trigger set as the parity jobs so it doesn't
-  # post a misleading green check on PRs that never ran Mac at all. The
+  # PR. This job always runs (bare `always()`) and reads the gate job's
+  # own result/outputs: it fails closed if the gate did not succeed, and
+  # reports "Not run: <reason>" when the gate decided no tier applies —
+  # so an all-skipped run can never appear green (fleet rule D5). The
   # best-effort jobs keep their failures visible here via job outputs that
   # capture the real step outcome — needs.<job>.result masks it as success
   # because the failing steps are continue-on-error.

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -77,13 +77,14 @@ env:
   DOLT_VERSION: "2.1.7"
   BD_VERSION: "v1.1.0"
 
-# Trigger gate re-used by every job below via `if:`.
-# We want each job to run when EITHER:
-#   - a same-repo, non-draft PR carries the `needs-mac` label
-#   - the nightly schedule fires
-#   - the user dispatches manually (smoke/full input decides reach)
-# YAML anchors do not work inside GitHub `if:` so each job copies the
-# expression; keep them in sync.
+# Tier routing is centralized in the `gate` job below, which always runs
+# and computes run_smoke/run_full/run_review_formulas plus a human-readable
+# `reason` from the trigger (schedule / workflow_dispatch suite input /
+# same-repo non-draft PR carrying the `needs-mac` label). Every tier job
+# reads exactly one of those booleans via `needs.gate.outputs.*` instead of
+# duplicating the trigger expression, and mac-regression-summary always
+# runs (bare `always()`) so an all-skipped workflow run can never report
+# green (fleet rule D5, ga-hd99jq).
 
 jobs:
   runner-policy:
@@ -108,20 +109,99 @@ jobs:
         run: |
           python3 .github/workflows/scripts/runner_policy.py
 
+  # Centralized tier-routing decision. This job always runs (no `if:`) so
+  # every downstream job — including mac-regression-summary — can depend on
+  # `gate` and read its outputs, instead of each job re-evaluating a copy of
+  # the same trigger expression (ga-hd99jq D1).
+  gate:
+    name: Mac regression / gate
+    needs: runner-policy
+    runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
+    outputs:
+      run_smoke: ${{ steps.gate.outputs.run_smoke }}
+      run_full: ${{ steps.gate.outputs.run_full }}
+      run_review_formulas: ${{ steps.gate.outputs.run_review_formulas }}
+      reason: ${{ steps.gate.outputs.reason }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        continue-on-error: true
+        with:
+          filters: |
+            mac_sensitive:
+              - '.github/workflows/mac-regression.yml'
+              - '.github/workflows/scripts/runner_policy.py'
+              - '.github/actions/setup-gascity-macos/**'
+              - 'Makefile'
+              - 'go.mod'
+              - 'go.sum'
+              - 'cmd/gc/**'
+              - 'internal/**'
+      - name: Decide which tiers should run
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SUITE_INPUT: ${{ inputs.suite }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          NEEDS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'needs-mac') }}
+          PATH_HIT: ${{ steps.filter.outputs.mac_sensitive }}
+        run: |
+          run_smoke=false
+          run_full=false
+          run_review_formulas=false
+          reason="no trigger matched"
+
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
+            run_smoke=true; run_full=true; run_review_formulas=true
+            reason="nightly schedule"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            case "$SUITE_INPUT" in
+              smoke)
+                run_smoke=true
+                reason="manual dispatch (suite=smoke)"
+                ;;
+              full)
+                run_smoke=true; run_full=true; run_review_formulas=true
+                reason="manual dispatch (suite=full)"
+                ;;
+              needs-mac)
+                run_smoke=true; run_full=true
+                reason="manual dispatch (suite=needs-mac)"
+                ;;
+              *)
+                reason="manual dispatch (suite=$SUITE_INPUT, unrecognized)"
+                ;;
+            esac
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$PR_HEAD_REPO" != "${{ github.repository }}" ]]; then
+              reason="pull request from a fork, skipping"
+            elif [[ "$PR_DRAFT" == "true" ]]; then
+              reason="draft pull request, skipping"
+            elif [[ "$NEEDS_LABEL" == "true" ]]; then
+              run_smoke=true; run_full=true
+              reason="pull request carries needs-mac label"
+            else
+              reason="pull request without needs-mac label (path hit: ${PATH_HIT})"
+            fi
+          fi
+
+          {
+            echo "run_smoke=$run_smoke"
+            echo "run_full=$run_full"
+            echo "run_review_formulas=$run_review_formulas"
+            echo "reason=$reason"
+          } >>"$GITHUB_OUTPUT"
+
   # Fast quality gates that Linux runs on every PR. Keep these cheap so a
   # Mac-parity loop stays interactive.
   mac-quality:
     name: Mac / quality (lint, fmt, vet, docs)
-    needs: runner-policy
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    needs:
+      - runner-policy
+      - gate
+    if: needs.gate.outputs.run_smoke == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: 20
     steps:
@@ -173,16 +253,10 @@ jobs:
   # Unit tests — the suite Mac already ran as "smoke".
   mac-unit:
     name: Mac / make test
-    needs: runner-policy
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    needs:
+      - runner-policy
+      - gate
+    if: needs.gate.outputs.run_smoke == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: 25
     steps:
@@ -205,16 +279,10 @@ jobs:
   # make test-mac sweep; coverage is preserved here across all 12 shards.
   mac-cmd-gc-process:
     name: Mac / cmd-gc process / shard ${{ matrix.shard }} of 12
-    needs: runner-policy
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    needs:
+      - runner-policy
+      - gate
+    if: needs.gate.outputs.run_smoke == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: 20
     strategy:
@@ -241,16 +309,10 @@ jobs:
   # Tier A acceptance — smoke-level gate on every PR.
   mac-acceptance:
     name: Mac / acceptance (Tier A)
-    needs: runner-policy
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    needs:
+      - runner-policy
+      - gate
+    if: needs.gate.outputs.run_smoke == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: 25
     steps:
@@ -280,20 +342,10 @@ jobs:
   # job's result still reflects the actual outcome for the summary.
   mac-cover:
     name: Mac / test-cover
-    needs: runner-policy
-    # Heavy job: schedule/full-dispatch/needs-mac-dispatch/PR(needs-mac). Smoke dispatch skips.
-    if: >-
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    needs:
+      - runner-policy
+      - gate
+    if: needs.gate.outputs.run_full == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: 25
     outputs:
@@ -330,21 +382,11 @@ jobs:
     name: Mac / integration packages / ${{ matrix.shard_name }}
     needs:
       - runner-policy
+      - gate
       - mac-quality
       - mac-unit
       - mac-acceptance
-    if: >-
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    if: needs.gate.outputs.run_full == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
@@ -404,21 +446,11 @@ jobs:
     name: Mac / integration (bdstore)
     needs:
       - runner-policy
+      - gate
       - mac-quality
       - mac-unit
       - mac-acceptance
-    if: >-
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    if: needs.gate.outputs.run_full == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: 60
     outputs:
@@ -455,21 +487,11 @@ jobs:
     name: Mac / integration rest / ${{ matrix.shard_name }}
     needs:
       - runner-policy
+      - gate
       - mac-quality
       - mac-unit
       - mac-acceptance
-    if: >-
-      github.event_name == 'schedule' ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'needs-mac')
-      )
+    if: needs.gate.outputs.run_full == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
@@ -532,12 +554,11 @@ jobs:
     name: Mac / integration (review-formulas)
     needs:
       - runner-policy
+      - gate
       - mac-quality
       - mac-unit
       - mac-acceptance
-    if: >-
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full')
+    if: needs.gate.outputs.run_review_formulas == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
     timeout-minutes: 90
     outputs:
@@ -578,19 +599,10 @@ jobs:
   # because the failing steps are continue-on-error.
   mac-regression-summary:
     name: Mac regression summary
-    if: >-
-      always() && (
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule' ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          !github.event.pull_request.draft &&
-          contains(github.event.pull_request.labels.*.name, 'needs-mac')
-        )
-      )
+    if: always()
     needs:
       - runner-policy
+      - gate
       - mac-quality
       - mac-unit
       - mac-cmd-gc-process
@@ -604,6 +616,9 @@ jobs:
     steps:
       - name: Summarize
         env:
+          GATE_RESULT: ${{ needs.gate.result }}
+          RUN_SMOKE: ${{ needs.gate.outputs.run_smoke }}
+          REASON: ${{ needs.gate.outputs.reason }}
           QUALITY: ${{ needs.mac-quality.result }}
           UNIT: ${{ needs.mac-unit.result }}
           CMD_GC: ${{ needs.mac-cmd-gc-process.result }}
@@ -615,6 +630,31 @@ jobs:
           INT_REST: ${{ needs.mac-integration-rest.result }}
           REVIEW_FORMULAS: ${{ needs.mac-integration-review-formulas.outputs.outcome || needs.mac-integration-review-formulas.result }}
         run: |
+          # This job always runs (if: always(), above) so an all-skipped
+          # workflow run can never report green. Read the gate job's own
+          # result and outputs here rather than re-deriving the trigger —
+          # never trust the workflow run's top-level conclusion (fleet rule
+          # D5, ga-hd99jq).
+          if [[ "${GATE_RESULT}" != "success" ]]; then
+            echo "Mac Regression: gate job failed (${GATE_RESULT}), cannot determine which tiers should have run" >&2
+            cat >>"$GITHUB_STEP_SUMMARY" <<EOF
+          ## Mac Regression
+
+          Gate job failed (\`${GATE_RESULT}\`) — tier routing could not be determined.
+          EOF
+            exit 1
+          fi
+
+          if [[ "${RUN_SMOKE}" != "true" ]]; then
+            echo "Mac Regression: not requested (${REASON})"
+            cat >>"$GITHUB_STEP_SUMMARY" <<EOF
+          ## Mac Regression
+
+          Not run: ${REASON}
+          EOF
+            exit 0
+          fi
+
           cat >>"$GITHUB_STEP_SUMMARY" <<EOF
           ## Mac Regression
 

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -124,20 +124,19 @@ jobs:
       reason: ${{ steps.gate.outputs.reason }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         continue-on-error: true
         with:
           filters: |
             mac_sensitive:
-              - '.github/workflows/mac-regression.yml'
-              - '.github/workflows/scripts/runner_policy.py'
-              - '.github/actions/setup-gascity-macos/**'
-              - 'Makefile'
-              - 'go.mod'
-              - 'go.sum'
               - 'cmd/gc/**'
-              - 'internal/**'
+              - 'internal/pathutil/**'
+              - 'internal/fsys/**'
       - name: Decide which tiers should run
         id: gate
         env:
@@ -157,21 +156,18 @@ jobs:
             run_smoke=true; run_full=true; run_review_formulas=true
             reason="nightly schedule"
           elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            run_smoke=true
             case "$SUITE_INPUT" in
-              smoke)
-                run_smoke=true
-                reason="manual dispatch (suite=smoke)"
-                ;;
               full)
-                run_smoke=true; run_full=true; run_review_formulas=true
+                run_full=true; run_review_formulas=true
                 reason="manual dispatch (suite=full)"
                 ;;
               needs-mac)
-                run_smoke=true; run_full=true
+                run_full=true
                 reason="manual dispatch (suite=needs-mac)"
                 ;;
               *)
-                reason="manual dispatch (suite=$SUITE_INPUT, unrecognized)"
+                reason="manual dispatch (suite=smoke)"
                 ;;
             esac
           elif [[ "$EVENT_NAME" == "pull_request" ]]; then

--- a/release-gates/mac-regression-centralized-gate.md
+++ b/release-gates/mac-regression-centralized-gate.md
@@ -1,0 +1,30 @@
+# Release gate: centralized macOS regression routing
+
+- Deploy bead: `ga-dvo3mn`
+- Build bead: `ga-n7ef4e`
+- Review bead: `ga-99n5nd`
+- Reviewed source: `c5ff3129389ff708a8c4899567b1d48e41b8403f`
+- Gate base: `origin/main@e6135a435098a70f20081d1d88a03b6742002d9a`
+- Evaluation date: 2026-07-30
+- Disposition: **PASS**
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Independent review bead `ga-99n5nd` records round-2 `verdict: pass` at the reviewed source SHA after the builder addressed all three round-1 findings. |
+| 2 | Acceptance criteria met | **PASS** | The workflow has one always-run `gate` job that emits the three tier booleans and a reason; all tier jobs consume those outputs; the summary uses bare `always()` and reads the gate result. The corrected checkout has explicit repository/ref and `persist-credentials: false`, the diagnostic path filter contains exactly `cmd/gc/**`, `internal/pathutil/**`, and `internal/fsys/**`, and unknown manual-dispatch suites fall back to smoke. Dedicated Go contract tests cover each invariant. |
+| 3 | Tests pass | **PASS** | At the reviewed source SHA: `go build ./...` and `go vet ./...` passed; `go test ./scripts/... -count=1 -v` reported 351 PASS, 0 FAIL, 0 SKIP; `make test-fast-parallel` passed all 10 jobs; and `make test-cmd-gc-process-parallel` passed all six `GC_FAST_UNIT=0` shards plus `productmetrics-testhook`, reporting 15,243 PASS, 0 FAIL, and 11 intentional skips. The process skips are existing helper-only, opt-in live-canary, unsupported-OS, unavailable optional prompt-fixture, or ambient-cwd cases explicitly disabled inside test binaries; none bears on workflow routing. Nine additional required CI outputs induced by the workflow-file/shared-OR path filters were not locally re-run: six have no file overlap with this diff, two worker/integration surfaces have no code overlap, and one is Windows-only. GitHub CI remains the authoritative execution of those checks before merge. |
+| 4 | No high-severity review findings open | **PASS** | Round 2 reports no blocking security, style, or specification findings; all three prior findings are fixed and directly tested. Unresolved HIGH count is 0. |
+| 5 | Final branch is clean | **PASS** | `git status --porcelain` was empty after testing at the reviewed source SHA; only this gate record was then added. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after tests. `git merge-tree --write-tree origin/main c5ff3129389ff708a8c4899567b1d48e41b8403f` exited 0 and produced tree `5abfc57c279b35786da86938d816602e04940c9e`; no self-rebase was required. |
+| 7 | Single feature theme | **PASS** | The reviewed three-commit set changes one GitHub Actions workflow and its contract test file to centralize macOS regression tier routing and make skipped-workflow outcomes visible. |
+
+## Acceptance evidence
+
+- Scheduled runs enable smoke, full, and review-formula tiers.
+- Manual `full`, `needs-mac`, `smoke`, and unknown suite values route deterministically, with unknown values retaining smoke coverage.
+- Same-repository, non-draft pull requests require the `needs-mac` label; fork and draft pull requests remain skipped with explicit reasons.
+- Every tier job reads the centralized gate outputs rather than duplicating trigger expressions.
+- The summary always runs and fails closed when the gate or any selected tier fails.
+- No new permissions, dependencies, action versions, secrets, or trigger events are introduced.

--- a/scripts/ci_critical_path_test.go
+++ b/scripts/ci_critical_path_test.go
@@ -22,6 +22,7 @@ type ciCriticalPathJob struct {
 	If              string                    `yaml:"if"`
 	RunsOn          string                    `yaml:"runs-on"`
 	Needs           ciCriticalPathNeeds       `yaml:"needs"`
+	Outputs         map[string]string         `yaml:"outputs"`
 	Steps           []ciCriticalPathStep      `yaml:"steps"`
 	Strategy        ciCriticalPathJobStrategy `yaml:"strategy"`
 	ContinueOnError bool                      `yaml:"continue-on-error"`
@@ -590,6 +591,206 @@ func TestMacAcceptanceRetainsExternalBdContract(t *testing.T) {
 	}
 	if !runsBDContract {
 		t.Error("Mac acceptance must retain the external bd CLI contract split from Tier A")
+	}
+}
+
+// TestMacRegressionGateCentralizesTierRouting asserts the new centralized
+// `gate` job (ga-hd99jq D1 / ga-n7ef4e): it always runs (no `if:`, so an
+// all-skipped workflow run can no longer happen), computes one reason string
+// plus the three tier booleans other jobs key off of, and mirrors
+// review-formulas.yml's own paths-filter + decision-step shape.
+func TestMacRegressionGateCentralizesTierRouting(t *testing.T) {
+	wf := readCriticalPathWorkflow(t, "mac-regression.yml")
+
+	gate, ok := wf.Jobs["gate"]
+	if !ok {
+		t.Fatal("mac-regression workflow has no centralized gate job")
+	}
+	if !slices.Contains(gate.Needs, "runner-policy") {
+		t.Errorf("gate needs = %v, want runner-policy", gate.Needs)
+	}
+	if strings.TrimSpace(gate.If) != "" {
+		t.Errorf("gate if = %q, want no condition — the gate itself must always run so every tier job and the summary can read its outputs", strings.TrimSpace(gate.If))
+	}
+	const gateRunner = "${{ needs.runner-policy.outputs.runner_2vcpu }}"
+	if gate.RunsOn != gateRunner {
+		t.Errorf("gate runs-on = %q, want %q (routing decision is cheap, keep it off macOS runners)", gate.RunsOn, gateRunner)
+	}
+
+	wantOutputs := map[string]string{
+		"run_smoke":           "${{ steps.gate.outputs.run_smoke }}",
+		"run_full":            "${{ steps.gate.outputs.run_full }}",
+		"run_review_formulas": "${{ steps.gate.outputs.run_review_formulas }}",
+		"reason":              "${{ steps.gate.outputs.reason }}",
+	}
+	for name, want := range wantOutputs {
+		if got := gate.Outputs[name]; got != want {
+			t.Errorf("gate output %s = %q, want %q", name, got, want)
+		}
+	}
+
+	var filterStep, decideStep ciCriticalPathStep
+	var hasFilter, hasDecide bool
+	for _, step := range gate.Steps {
+		switch step.ID {
+		case "filter":
+			filterStep, hasFilter = step, true
+		case "gate":
+			decideStep, hasDecide = step, true
+		}
+	}
+	if !hasFilter {
+		t.Fatal("gate job has no paths-filter step (id: filter)")
+	}
+	if !strings.Contains(filterStep.Uses, "dorny/paths-filter") {
+		t.Errorf("gate filter step uses = %q, want dorny/paths-filter (same tool review-formulas.yml uses)", filterStep.Uses)
+	}
+	if !hasDecide {
+		t.Fatal("gate job has no routing-decision step (id: gate)")
+	}
+
+	wantDecideEnv := map[string]string{
+		"EVENT_NAME":   "${{ github.event_name }}",
+		"SUITE_INPUT":  "${{ inputs.suite }}",
+		"PR_HEAD_REPO": "${{ github.event.pull_request.head.repo.full_name }}",
+		"PR_DRAFT":     "${{ github.event.pull_request.draft }}",
+		"NEEDS_LABEL":  "${{ contains(github.event.pull_request.labels.*.name, 'needs-mac') }}",
+		"PATH_HIT":     "${{ steps.filter.outputs.mac_sensitive }}",
+	}
+	for name, want := range wantDecideEnv {
+		if got := decideStep.Env[name]; got != want {
+			t.Errorf("gate decision step env %s = %q, want %q", name, got, want)
+		}
+	}
+
+	// Every trigger path the exit_contract enumerates must be handled so the
+	// refactor preserves today's per-job run/skip outcome exactly.
+	for _, marker := range []string{
+		`"$EVENT_NAME" == "schedule"`,
+		`run_smoke=true; run_full=true; run_review_formulas=true`,
+		`"$EVENT_NAME" == "workflow_dispatch"`,
+		`case "$SUITE_INPUT" in`,
+		`needs-mac)`,
+		`"$EVENT_NAME" == "pull_request"`,
+		`"$PR_HEAD_REPO" != "${{ github.repository }}"`,
+		`"$PR_DRAFT" == "true"`,
+		`"$NEEDS_LABEL" == "true"`,
+		`echo "run_smoke=$run_smoke"`,
+		`echo "run_full=$run_full"`,
+		`echo "run_review_formulas=$run_review_formulas"`,
+		`echo "reason=$reason"`,
+	} {
+		if !strings.Contains(decideStep.Run, marker) {
+			t.Errorf("gate decision step run script missing %q", marker)
+		}
+	}
+}
+
+// TestMacRegressionTierJobsGateOnCentralizedOutputs asserts every tier job
+// collapses its duplicated multi-line if: into a single check against the
+// gate job's own output (ga-hd99jq D1) — a refactor of how the decision is
+// computed, not a change to which jobs run when.
+func TestMacRegressionTierJobsGateOnCentralizedOutputs(t *testing.T) {
+	wf := readCriticalPathWorkflow(t, "mac-regression.yml")
+
+	tests := []struct {
+		job    string
+		wantIf string
+	}{
+		{"mac-quality", "needs.gate.outputs.run_smoke == 'true'"},
+		{"mac-unit", "needs.gate.outputs.run_smoke == 'true'"},
+		{"mac-cmd-gc-process", "needs.gate.outputs.run_smoke == 'true'"},
+		{"mac-acceptance", "needs.gate.outputs.run_smoke == 'true'"},
+		{"mac-cover", "needs.gate.outputs.run_full == 'true'"},
+		{"mac-integration-packages", "needs.gate.outputs.run_full == 'true'"},
+		{"mac-integration-bdstore", "needs.gate.outputs.run_full == 'true'"},
+		{"mac-integration-rest", "needs.gate.outputs.run_full == 'true'"},
+		{"mac-integration-review-formulas", "needs.gate.outputs.run_review_formulas == 'true'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.job, func(t *testing.T) {
+			job, ok := wf.Jobs[tt.job]
+			if !ok {
+				t.Fatalf("mac-regression workflow has no %s job", tt.job)
+			}
+			if !slices.Contains(job.Needs, "gate") {
+				t.Errorf("%s needs = %v, want gate", tt.job, job.Needs)
+			}
+			if got := strings.TrimSpace(job.If); got != tt.wantIf {
+				t.Errorf("%s if = %q, want exactly %q (single gate-output check, not a duplicated inline expression)", tt.job, got, tt.wantIf)
+			}
+		})
+	}
+}
+
+// TestMacRegressionSummaryAlwaysRunsAndReadsGateResult is the core
+// signal-integrity fix (ga-wecoe1, ga-hd99jq F1/F2): the summary job must
+// never itself be skipped, or an all-skipped run reports green. Its if:
+// becomes bare always(), and it must read the gate job's own result/outputs
+// rather than re-evaluating the trigger — the fleet's D5 rule.
+func TestMacRegressionSummaryAlwaysRunsAndReadsGateResult(t *testing.T) {
+	wf := readCriticalPathWorkflow(t, "mac-regression.yml")
+	job, ok := wf.Jobs["mac-regression-summary"]
+	if !ok {
+		t.Fatal("mac-regression workflow has no mac-regression-summary job")
+	}
+
+	if got := strings.TrimSpace(job.If); got != "always()" {
+		t.Errorf("mac-regression-summary if = %q, want bare always() so the summary itself is never skipped (D5: an all-skipped run must not report green)", got)
+	}
+	if !slices.Contains(job.Needs, "gate") {
+		t.Errorf("mac-regression-summary needs = %v, want gate", job.Needs)
+	}
+
+	var summarize ciCriticalPathStep
+	var found bool
+	for _, step := range job.Steps {
+		if step.Name == "Summarize" {
+			summarize, found = step, true
+		}
+	}
+	if !found {
+		t.Fatal("mac-regression-summary has no Summarize step")
+	}
+
+	wantEnv := map[string]string{
+		"GATE_RESULT": "${{ needs.gate.result }}",
+		"RUN_SMOKE":   "${{ needs.gate.outputs.run_smoke }}",
+		"REASON":      "${{ needs.gate.outputs.reason }}",
+	}
+	for name, want := range wantEnv {
+		if got := summarize.Env[name]; got != want {
+			t.Errorf("Summarize env %s = %q, want %q", name, got, want)
+		}
+	}
+
+	for _, marker := range []string{
+		`"${GATE_RESULT}" != "success"`,
+		`"${RUN_SMOKE}" != "true"`,
+		`Mac Regression: not requested`,
+	} {
+		if !strings.Contains(summarize.Run, marker) {
+			t.Errorf("Summarize run script missing %q (gate-failed / not-requested branch from the exit_contract)", marker)
+		}
+	}
+}
+
+// TestMacRegressionHeaderCommentDescribesCentralizedGate asserts the file
+// header (originally documenting "each job copies the expression; keep them
+// in sync") is updated to describe the centralized-gate shape that removes
+// that exact duplication.
+func TestMacRegressionHeaderCommentDescribesCentralizedGate(t *testing.T) {
+	path := filepath.Join(repoRoot(t), ".github", "workflows", "mac-regression.yml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	content := string(body)
+	if strings.Contains(content, "each job copies the") {
+		t.Error("mac-regression.yml header comment still describes the old per-job duplicated if: expression — update it to describe the centralized gate job")
+	}
+	if !strings.Contains(content, "gate") {
+		t.Error("mac-regression.yml header comment should describe the centralized gate job")
 	}
 }
 

--- a/scripts/ci_critical_path_test.go
+++ b/scripts/ci_critical_path_test.go
@@ -629,9 +629,12 @@ func TestMacRegressionGateCentralizesTierRouting(t *testing.T) {
 		}
 	}
 
-	var filterStep, decideStep ciCriticalPathStep
-	var hasFilter, hasDecide bool
+	var filterStep, decideStep, checkoutStep ciCriticalPathStep
+	var hasFilter, hasDecide, hasCheckout bool
 	for _, step := range gate.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			checkoutStep, hasCheckout = step, true
+		}
 		switch step.ID {
 		case "filter":
 			filterStep, hasFilter = step, true
@@ -639,11 +642,34 @@ func TestMacRegressionGateCentralizesTierRouting(t *testing.T) {
 			decideStep, hasDecide = step, true
 		}
 	}
+	if !hasCheckout {
+		t.Fatal("gate job has no checkout step")
+	}
+	wantCheckoutWith := map[string]string{
+		"repository":          "${{ inputs.head_repo || github.repository }}",
+		"ref":                 "${{ inputs.head_sha || github.sha }}",
+		"persist-credentials": "false",
+	}
+	for name, want := range wantCheckoutWith {
+		if got := checkoutStep.With[name]; got != want {
+			t.Errorf("gate checkout with.%s = %q, want %q (every other mac-regression job pins the same head ref/repo and disables credential persistence; the gate job must not be the odd one out)", name, got, want)
+		}
+	}
 	if !hasFilter {
 		t.Fatal("gate job has no paths-filter step (id: filter)")
 	}
 	if !strings.Contains(filterStep.Uses, "dorny/paths-filter") {
 		t.Errorf("gate filter step uses = %q, want dorny/paths-filter (same tool review-formulas.yml uses)", filterStep.Uses)
+	}
+	wantFilterEntries := []string{"cmd/gc/**", "internal/pathutil/**", "internal/fsys/**"}
+	filterValue := filterStep.With["filters"]
+	for _, entry := range wantFilterEntries {
+		if !strings.Contains(filterValue, "'"+entry+"'") {
+			t.Errorf("gate filter mac_sensitive list missing %q; want exactly %v", entry, wantFilterEntries)
+		}
+	}
+	if gotEntries := regexp.MustCompile(`(?m)^\s*-\s*'[^']*'\s*$`).FindAllString(filterValue, -1); len(gotEntries) != len(wantFilterEntries) {
+		t.Errorf("gate filter mac_sensitive has %d path entries, want exactly %d (%v) — no broader glob than the paths that actually touch gc/cmd or fsys/pathutil behavior", len(gotEntries), len(wantFilterEntries), wantFilterEntries)
 	}
 	if !hasDecide {
 		t.Fatal("gate job has no routing-decision step (id: gate)")
@@ -683,6 +709,24 @@ func TestMacRegressionGateCentralizesTierRouting(t *testing.T) {
 		if !strings.Contains(decideStep.Run, marker) {
 			t.Errorf("gate decision step run script missing %q", marker)
 		}
+	}
+
+	// An unrecognized (or default) $SUITE_INPUT on a manual dispatch must
+	// still run the smoke tier, not silently run nothing — run_smoke must
+	// be set unconditionally before the case statement, not only inside
+	// specific case branches, so the catch-all `*)` arm inherits it too.
+	const dispatchMarker = `"$EVENT_NAME" == "workflow_dispatch" ]]; then`
+	dispatchIdx := strings.Index(decideStep.Run, dispatchMarker)
+	if dispatchIdx < 0 {
+		t.Fatal("gate decision step run script missing workflow_dispatch branch")
+	}
+	afterDispatch := decideStep.Run[dispatchIdx+len(dispatchMarker):]
+	caseIdx := strings.Index(afterDispatch, `case "$SUITE_INPUT" in`)
+	if caseIdx < 0 {
+		t.Fatal("gate decision step run script missing case statement in workflow_dispatch branch")
+	}
+	if preCase := afterDispatch[:caseIdx]; !strings.Contains(preCase, "run_smoke=true") {
+		t.Errorf("gate decision step workflow_dispatch branch does not set run_smoke=true before the case statement (preamble %q) — an unrecognized suite input must still default to the smoke tier", preCase)
 	}
 }
 


### PR DESCRIPTION
## What this changes

The macOS regression workflow now makes one routing decision in an always-run `gate` job and exposes explicit outputs for smoke, full, and review-formula tiers. Every tier consumes those outputs instead of maintaining its own copy of the trigger expression.

The final summary also runs unconditionally and reads the gate result, so a workflow where every test tier was skipped can no longer appear green. Manual dispatches with an unknown suite value retain smoke coverage instead of silently running no tiers.

## Review notes

- Scheduled runs still select every tier; labeled same-repository pull requests select smoke and full coverage.
- Fork and draft pull requests remain skipped with an explicit reason.
- The narrowed `mac_sensitive` filter is diagnostic only and contains the three intended code paths.
- The gate checkout disables persisted credentials and uses the same explicit repository/ref inputs as the other jobs.
- No permissions, triggers, secrets, dependencies, or action versions change.

## Test plan

- [x] Run `go build ./...` and `go vet ./...`.
- [x] Run `go test ./scripts/... -count=1 -v`, including all macOS regression workflow contract tests.
- [x] Run `make test-fast-parallel`.
- [x] Run `make test-cmd-gc-process-parallel`, including `TestTutorial01` and product-metrics testhooks.
- [x] Release gate: [`release-gates/mac-regression-centralized-gate.md`](release-gates/mac-regression-centralized-gate.md)