### PR TITLE
fix(storehealth): bound LastMaintenance's event-log scan (#4418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Last GC:` status line. Previously this cost two full scans of
   `events.jsonl` on every `gc status` call, dominating latency on large event
   logs and surfacing as a spurious "runtime status probe timed out" warning.
+
+  Operator note: `Last GC:` may now be absent on a busy city even though
+  maintenance has run. The tail scan looks back a bounded 8 MiB, and it reads
+  only the active `events.jsonl` — never the rotated `.gz` archives — so a
+  maintenance event that has aged out of the window, or out of the active file
+  entirely, is reported as absent rather than stale. The field is display-only
+  and nothing gates on it. `gc maintenance status` is the fallback, with one
+  caveat: it reads the supervisor's in-memory run history, so it requires a
+  running supervisor and resets when the supervisor restarts. It is a live
+  view, not an equivalent durable source; for durable history, query the event
+  log for `store.maintenance.*` directly. (gascity#4418)
+
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is invisible to it regardless of name, while vendor/testdata (tracked or
   not) stay excluded as before. (gascity#4479)
 
+- **`gc status` no longer pays a full event-log scan for a cosmetic field.**
+  `storehealth.LastMaintenance` now prefers the `TailProvider` backward-scan
+  fast path over an unbounded forward `List` when the provider supports it,
+  and a new `Filter.MaxScanBytes` bounds that backward scan so a rare or
+  never-emitted event type (the common case: a city that has never run store
+  maintenance) can no longer force a full-file walk just to populate the
+  `Last GC:` status line. Previously this cost two full scans of
+  `events.jsonl` on every `gc status` call, dominating latency on large event
+  logs and surfacing as a spurious "runtime status probe timed out" warning.
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -803,6 +803,62 @@ func TestReadFilteredTailMaxScanBytesBoundsBackwardWalk(t *testing.T) {
 	}
 }
 
+// TestReadFilteredTailMaxScanBytesNonAlignedLimit pins the per-chunk clamp:
+// a MaxScanBytes that is not a multiple of the 64KB chunk size must stop the
+// backward walk at exactly that byte, not at the next chunk boundary. The
+// file is sized so the only match sits in the dead zone between the two —
+// past the 100KB window, but inside the 128KB an unclamped walk would read
+// as two whole chunks — so a bound checked only between chunks returns the
+// match and fails this test.
+func TestReadFilteredTailMaxScanBytesNonAlignedLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	base := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	appendEvent := func(e Event) {
+		t.Helper()
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(raw)
+		buf.WriteString("\n")
+	}
+
+	const window = 100 * 1024 // deliberately not a multiple of the 64KB chunk
+
+	// The only matching event is the first line in the file, so its distance
+	// from EOF is simply the file size.
+	appendEvent(Event{Seq: 1, Type: "target.type", Actor: "api", Ts: base})
+	padding := string(bytes.Repeat([]byte("x"), 4*1024))
+	for i := 0; buf.Len() < 108*1024; i++ {
+		appendEvent(Event{Seq: uint64(i + 2), Type: "other.type", Actor: "api", Ts: base.Add(time.Duration(i) * time.Second), Message: padding})
+	}
+	if size := int64(buf.Len()); size <= window || size >= 128*1024 {
+		t.Fatalf("file is %d bytes, want in (%d, %d) so the match lands between the window and the next chunk boundary", size, window, 128*1024)
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bounded, err := ReadFilteredTail(path, Filter{Type: "target.type", MaxScanBytes: window}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bounded) != 0 {
+		t.Fatalf("bounded scan got %d events, want 0 (match sits outside the %d-byte window; the chunk read must be clamped to it)", len(bounded), window)
+	}
+
+	unbounded, err := ReadFilteredTail(path, Filter{Type: "target.type"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unbounded) != 1 || unbounded[0].Seq != 1 {
+		t.Fatalf("unbounded scan got %+v, want the seq-1 match (proves the bound, not the filter, caused the empty result)", unbounded)
+	}
+}
+
 func TestReadFilteredTailLimitModesAndMissingFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -751,6 +751,58 @@ func TestReadFilteredTailScansBackwardsAcrossChunks(t *testing.T) {
 	}
 }
 
+// TestReadFilteredTailMaxScanBytesBoundsBackwardWalk is the regression for
+// #4418: a Filter.Type that never matches near EOF (the common case for a
+// rare/optional event type) otherwise forces readFilteredTailFromFile to
+// walk the entire file backward, at the same cost as an unfiltered forward
+// scan. MaxScanBytes caps that walk; "not found within the window" must be
+// the result rather than an unbounded scan.
+func TestReadFilteredTailMaxScanBytesBoundsBackwardWalk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	base := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	appendEvent := func(e Event) {
+		t.Helper()
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(raw)
+		buf.WriteString("\n")
+	}
+
+	// The only matching event sits near the start of the file.
+	appendEvent(Event{Seq: 1, Type: "target.type", Actor: "api", Ts: base})
+	// Pad well past a 64KB scan window with non-matching events before EOF —
+	// this is what a rare/optional Type filter looks like against a long,
+	// otherwise-unrelated event stream.
+	padding := string(bytes.Repeat([]byte("x"), 4*1024))
+	for i := 0; i < 40; i++ { // ~160KB of padding, several chunks past 64KB
+		appendEvent(Event{Seq: uint64(i + 2), Type: "other.type", Actor: "api", Ts: base.Add(time.Duration(i) * time.Second), Message: padding})
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bounded, err := ReadFilteredTail(path, Filter{Type: "target.type", MaxScanBytes: 64 * 1024}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bounded) != 0 {
+		t.Fatalf("bounded scan got %d events, want 0 (match sits outside the 64KB window)", len(bounded))
+	}
+
+	unbounded, err := ReadFilteredTail(path, Filter{Type: "target.type"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unbounded) != 1 || unbounded[0].Seq != 1 {
+		t.Fatalf("unbounded scan got %+v, want the seq-1 match (proves the bound, not the filter, caused the empty result)", unbounded)
+	}
+}
+
 func TestReadFilteredTailLimitModesAndMissingFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -32,6 +32,16 @@ type Filter struct {
 	// stable resume point regardless of concurrent appends.
 	BeforeSeq uint64
 	Limit     int // cap results at this count (0 or negative = unlimited)
+	// MaxScanBytes bounds how far a tail scan (ReadFilteredTail /
+	// TailProvider.ListTail) walks backward from EOF before giving up,
+	// even if Limit hasn't been reached (0 or negative = unbounded). It
+	// exists for callers where "no match within the recent window" is an
+	// acceptable, already-representable result — a rare or optional Type
+	// filter can otherwise force a full-file backward walk with the same
+	// cost as an unfiltered forward scan (#4418). It has no effect on
+	// ReadFiltered's forward scan or on List/ListTail implementations
+	// that are not byte-scanning a file (e.g. Fake, Multiplexer).
+	MaxScanBytes int64
 }
 
 // matchesFilter reports whether e satisfies all non-zero predicates in f.
@@ -384,7 +394,7 @@ func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) 
 	var reversed []Event
 	var pending []byte
 	end := size
-	for end > 0 && len(reversed) < limit {
+	for end > 0 && len(reversed) < limit && (filter.MaxScanBytes <= 0 || size-end < filter.MaxScanBytes) {
 		n := chunkSize
 		if end < n {
 			n = end

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -399,6 +399,17 @@ func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) 
 		if end < n {
 			n = end
 		}
+		// Clamp the read to what remains of the byte budget so a
+		// MaxScanBytes that is not a chunkSize multiple stops the walk
+		// mid-chunk rather than overscanning by up to one full chunk.
+		// The loop condition guarantees remaining > 0 on entry, and the
+		// chunk is read at start = end - n, so a smaller n simply moves
+		// the walk's stopping point without misaligning pending.
+		if filter.MaxScanBytes > 0 {
+			if remaining := filter.MaxScanBytes - (size - end); remaining < n {
+				n = remaining
+			}
+		}
 		start := end - n
 		chunk := make([]byte, n)
 		if _, err := f.ReadAt(chunk, start); err != nil && err != io.EOF {

--- a/internal/storehealth/storehealth.go
+++ b/internal/storehealth/storehealth.go
@@ -126,6 +126,14 @@ func WalkSize(path string) int64 {
 // measured ~800 bytes/event average, while capping the worst case (a log
 // that has never emitted a matching event) to a small fraction of a full
 // scan.
+//
+// The window is not the only way this can miss, and not the dominant one.
+// FileRecorder.ListTail reads the ACTIVE events.jsonl only; it never opens
+// the sibling .gz archives that the old List path walked via ReadFiltered.
+// With rotation on by default at 256 MiB (defaultRotationMaxSize in
+// internal/events/recorder.go), a maintenance event that has aged into an
+// archive is invisible to this caller no matter how large the window is.
+// That is accepted, not an oversight — see LastMaintenance.
 const lastMaintenanceScanWindowBytes = 8 * 1024 * 1024
 
 // LastMaintenance returns the timestamp and status ("success" or
@@ -137,6 +145,20 @@ const lastMaintenanceScanWindowBytes = 8 * 1024 * 1024
 // backward-tail scan instead of the unbounded forward List — see
 // lastMaintenanceScanWindowBytes. Providers without a tail fast path (e.g.
 // an exec-script provider) fall back to the original unbounded List call.
+//
+// This caller takes a short ListTail result at face value. It deliberately
+// does NOT take the under-fill fall-through that fetchEventPageAscending
+// (internal/api/huma_handlers_events.go) uses, where a tail result shorter
+// than the requested limit cannot distinguish "log exhausted" from "active
+// file exhausted, older matches in the archives" and so falls back to the
+// archive-aware full scan. Falling back here would restore exactly the full
+// scan this path exists to remove — and it would fire on the common case
+// (a city that has never run store maintenance), which is the worst case.
+// The cost is that a maintenance timestamp older than the window, or aged
+// into a rotated .gz archive, is reported as absent. Every consumer of the
+// resulting LastGCAt renders it conditionally for display and none gates a
+// decision on it, so absent is a safe answer. Operators who need a durable
+// answer have `gc maintenance status`.
 func LastMaintenance(ep events.Provider) (time.Time, string) {
 	if ep == nil {
 		return time.Time{}, ""

--- a/internal/storehealth/storehealth.go
+++ b/internal/storehealth/storehealth.go
@@ -115,14 +115,33 @@ func WalkSize(path string) int64 {
 	return total
 }
 
+// lastMaintenanceScanWindowBytes bounds the TailProvider fast path in
+// LastMaintenance: a rare/optional event type (store maintenance may never
+// have run) forces a full-file backward walk otherwise, at the same cost as
+// an unfiltered forward scan (#4418). "Not found within the window" is a
+// valid, already-representable result — Health.LastGCAt is omitempty and
+// the status line simply omits "Last GC:" — so this trades a theoretical
+// miss on a maintenance event older than the window for bounded latency on
+// every call. 8 MiB comfortably covers many thousands of events at the
+// measured ~800 bytes/event average, while capping the worst case (a log
+// that has never emitted a matching event) to a small fraction of a full
+// scan.
+const lastMaintenanceScanWindowBytes = 8 * 1024 * 1024
+
 // LastMaintenance returns the timestamp and status ("success" or
 // "failed") of the most-recent store-maintenance event in provider.
 // Zero time and empty status when no events, provider is nil, or the
 // provider returns an error.
+//
+// When provider implements [events.TailProvider], this uses the bounded
+// backward-tail scan instead of the unbounded forward List — see
+// lastMaintenanceScanWindowBytes. Providers without a tail fast path (e.g.
+// an exec-script provider) fall back to the original unbounded List call.
 func LastMaintenance(ep events.Provider) (time.Time, string) {
 	if ep == nil {
 		return time.Time{}, ""
 	}
+	tp, hasTail := ep.(events.TailProvider)
 	var (
 		latestTs     time.Time
 		latestStatus string
@@ -134,7 +153,15 @@ func LastMaintenance(ep events.Provider) (time.Time, string) {
 		{events.StoreMaintenanceDone, "success"},
 		{events.StoreMaintenanceFailed, "failed"},
 	} {
-		evts, err := ep.List(events.Filter{Type: spec.typ})
+		var (
+			evts []events.Event
+			err  error
+		)
+		if hasTail {
+			evts, err = tp.ListTail(events.Filter{Type: spec.typ, MaxScanBytes: lastMaintenanceScanWindowBytes}, 1)
+		} else {
+			evts, err = ep.List(events.Filter{Type: spec.typ})
+		}
 		if err != nil {
 			continue
 		}

--- a/internal/storehealth/storehealth_test.go
+++ b/internal/storehealth/storehealth_test.go
@@ -1,7 +1,11 @@
 package storehealth
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -324,5 +328,86 @@ func TestLastMaintenanceFallsBackWithoutTailProvider(t *testing.T) {
 	gotTs, gotStatus := LastMaintenance(pwt)
 	if !gotTs.Equal(ts) || gotStatus != "failed" {
 		t.Fatalf("LastMaintenance = (%v,%q), want (%v,failed)", gotTs, gotStatus, ts)
+	}
+}
+
+// writeArchivedEvents writes evts as a gzipped canonical events archive
+// beside path, using the rotation naming convention
+// (events.jsonl.archive-<ts>-seq-<first>-<last>.gz) that the archive-aware
+// read path discovers by directory listing.
+func writeArchivedEvents(t *testing.T, path string, evts []events.Event) {
+	t.Helper()
+	if len(evts) == 0 {
+		t.Fatal("writeArchivedEvents: no events")
+	}
+	var raw bytes.Buffer
+	for _, e := range evts {
+		line, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw.Write(line)
+		raw.WriteString("\n")
+	}
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	if _, err := zw.Write(raw.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	name := fmt.Sprintf("events.jsonl.archive-%s-seq-%d-%d.gz",
+		evts[0].Ts.UTC().Format("20060102T150405Z"), evts[0].Seq, evts[len(evts)-1].Seq)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(path), name), gz.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLastMaintenanceDoesNotReadRotatedArchives pins accepted, documented
+// behavior rather than a bug: FileRecorder.ListTail scans the active
+// events.jsonl only, so a maintenance event that has aged into a rotated
+// .gz archive is reported as absent. The old unbounded List path did read
+// archives; taking the archive-aware fall-through here (as
+// fetchEventPageAscending does) would restore the full scan #4418 removed,
+// and LastGCAt is display-only in every consumer. If this test starts
+// failing because LastMaintenance grew a fall-through, that is a
+// deliberate re-trade — update the comment on
+// lastMaintenanceScanWindowBytes with it, do not just delete the test.
+func TestLastMaintenanceDoesNotReadRotatedArchives(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	ts := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	payload, err := json.Marshal(events.StoreMaintenanceDonePayload{DurationSeconds: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The only maintenance event lives in the archive; the active file
+	// holds unrelated traffic, as it would after a rotation.
+	writeArchivedEvents(t, path, []events.Event{
+		{Seq: 1, Type: events.StoreMaintenanceDone, Ts: ts, Payload: payload},
+	})
+
+	rec, err := events.NewFileRecorder(path, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+	rec.Record(events.Event{Type: "unrelated.event", Ts: ts.Add(time.Hour)})
+
+	// Control: the archive-aware List path DOES see it, so an empty result
+	// below is archive-blindness and not a broken fixture.
+	viaList, err := rec.List(events.Filter{Type: events.StoreMaintenanceDone})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(viaList) != 1 {
+		t.Fatalf("List got %d events, want 1 (fixture must be readable via the archive-aware path)", len(viaList))
+	}
+
+	gotTs, gotStatus := LastMaintenance(rec)
+	if !gotTs.IsZero() || gotStatus != "" {
+		t.Fatalf("LastMaintenance = (%v,%q), want (zero,\"\") — the tail fast path reads the active file only", gotTs, gotStatus)
 	}
 }

--- a/internal/storehealth/storehealth_test.go
+++ b/internal/storehealth/storehealth_test.go
@@ -258,3 +258,71 @@ func TestLastMaintenanceNoEvents(t *testing.T) {
 		t.Fatalf("LastMaintenance(empty) = (%v,%q), want (zero,\"\")", ts, status)
 	}
 }
+
+// recordingProvider wraps a Fake and counts List vs ListTail calls, so tests
+// can assert which path LastMaintenance actually took rather than only
+// inferring it from the result.
+type recordingProvider struct {
+	*events.Fake
+	listCalls     int
+	listTailCalls int
+}
+
+func (r *recordingProvider) List(filter events.Filter) ([]events.Event, error) {
+	r.listCalls++
+	return r.Fake.List(filter)
+}
+
+func (r *recordingProvider) ListTail(filter events.Filter, limit int) ([]events.Event, error) {
+	r.listTailCalls++
+	return r.Fake.ListTail(filter, limit)
+}
+
+// providerWithoutTail implements events.Provider but deliberately omits
+// ListTail, so LastMaintenance must fall back to the unbounded List path
+// rather than a type assertion panicking or silently returning nothing.
+type providerWithoutTail struct {
+	*events.Fake
+}
+
+func (p *providerWithoutTail) List(filter events.Filter) ([]events.Event, error) {
+	return p.Fake.List(filter)
+}
+
+// TestLastMaintenanceUsesTailProviderFastPath is the regression for #4418:
+// when the provider implements events.TailProvider, LastMaintenance must
+// call ListTail (the bounded backward scan) instead of the unbounded List,
+// which on a large event log with a rare Type filter costs a full-file scan
+// for what is ultimately a cosmetic status field.
+func TestLastMaintenanceUsesTailProviderFastPath(t *testing.T) {
+	rp := &recordingProvider{Fake: events.NewFake()}
+	payload, _ := json.Marshal(events.StoreMaintenanceDonePayload{DurationSeconds: 3})
+	ts := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	rp.Record(events.Event{Type: events.StoreMaintenanceDone, Ts: ts, Payload: payload})
+
+	gotTs, gotStatus := LastMaintenance(rp)
+	if !gotTs.Equal(ts) || gotStatus != "success" {
+		t.Fatalf("LastMaintenance = (%v,%q), want (%v,success)", gotTs, gotStatus, ts)
+	}
+	if rp.listTailCalls == 0 {
+		t.Fatalf("listTailCalls = 0, want > 0 (LastMaintenance should prefer the TailProvider fast path)")
+	}
+	if rp.listCalls != 0 {
+		t.Fatalf("listCalls = %d, want 0 (fast path should not also fall back to List)", rp.listCalls)
+	}
+}
+
+// TestLastMaintenanceFallsBackWithoutTailProvider guards the fallback: a
+// provider that does not implement events.TailProvider (e.g. an exec-script
+// provider) must still get a correct answer via the existing List path.
+func TestLastMaintenanceFallsBackWithoutTailProvider(t *testing.T) {
+	pwt := &providerWithoutTail{Fake: events.NewFake()}
+	payload, _ := json.Marshal(events.StoreMaintenanceFailedPayload{Stage: "gc"})
+	ts := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	pwt.Record(events.Event{Type: events.StoreMaintenanceFailed, Ts: ts, Payload: payload})
+
+	gotTs, gotStatus := LastMaintenance(pwt)
+	if !gotTs.Equal(ts) || gotStatus != "failed" {
+		t.Fatalf("LastMaintenance = (%v,%q), want (%v,failed)", gotTs, gotStatus, ts)
+	}
+}


### PR DESCRIPTION
## Summary

`gc status` scanned the entire `events.jsonl` twice on every call to populate the cosmetic `Last GC:` field, since `storehealth.LastMaintenance` called the unbounded `ep.List(Filter{Type: ...})` instead of the `TailProvider` fast path other callers already use (`internal/api/huma_handlers_events.go`'s `fetchEventPageAscending`, the fix for #1987). On a large city (263 MB / 327k events, never emitted a maintenance event) this cost ~3.3s of the ~4.8s user CPU in `gc status`, and produced a spurious "runtime status probe timed out; using partial status" warning on every run.

Fixes #4418.

## Root cause and fix

Switching to `ListTail` alone doesn't fully fix it: `readFilteredTailFromFile`'s loop condition (`for end > 0 && len(reversed) < limit`) means that when the filtered `Type` never matches near EOF — the common case, since store maintenance may never have run — the backward walk degrades to a full-file scan anyway, identical in cost to the forward scan it replaces.

This adds `Filter.MaxScanBytes` (same shape as the existing `Limit`/`AfterSeq`/`BeforeSeq` fields; zero value = unbounded, no effect on any other caller) to cap that backward walk. `LastMaintenance` now type-asserts `TailProvider` and passes a bounded `MaxScanBytes`; "not found within the window" is already a valid, correctly-rendered result since `Health.LastGCAt` is `omitempty`. Providers without `TailProvider` (e.g. an exec-script provider) keep the original unbounded `List` path, unchanged.

## Testing

- `go build ./...` — clean
- `go test ./internal/events/... ./internal/storehealth/...` — full suite green, including two new regression tests:
  - `TestReadFilteredTailMaxScanBytesBoundsBackwardWalk` — proves the bound actually stops the backward walk before reaching a match placed outside the window (and that an unbounded call still finds it, ruling out a false negative from the filter itself)
  - `TestLastMaintenanceUsesTailProviderFastPath` / `TestLastMaintenanceFallsBackWithoutTailProvider` — proves `LastMaintenance` takes the `ListTail` path when available (via a call-counting wrapper) and still returns the correct answer via the fallback when it isn't
- `go test ./cmd/gc/... ./internal/api/...` (the two other `LastMaintenance` call sites) — existing store-health tests pass unchanged, no signature change so no caller edits needed
- `go vet ./internal/events/... ./internal/storehealth/...` — clean
- `gofmt -l` — clean on all touched files
- Diff scoped to exactly 5 files: `internal/events/reader.go`, `internal/events/events_test.go`, `internal/storehealth/storehealth.go`, `internal/storehealth/storehealth_test.go`, `CHANGELOG.md`

Note on CI: the local `test-fast-parallel` pre-push gate flagged unrelated failures on this run (`TestStopManagedCity*`, `TestProbeDetachedWork_TmuxExitStatus`, `TestRunStartDriftCheck_...`, `TestDoctorCheckVersionFloor`, `TestCompactScript*`) — none touch `internal/events`/`internal/storehealth`, a different set failed on each of two full retries, and one confirmed passing cleanly in isolation, consistent with load-induced flakiness on a busy local machine rather than a regression from this change.
