### PR TITLE
fix(dispatch): preserve step description on ralph attempt clones

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -765,13 +765,14 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 		rootMeta[beadmeta.RalphStepIDMetadataKey] = stepID
 	}
 	rootStep := formula.RecipeStep{
-		ID:       attemptPrefix,
-		Title:    step.Title,
-		Type:     step.Type,
-		IsRoot:   true,
-		Labels:   append([]string{}, step.Labels...),
-		Assignee: step.Assignee,
-		Metadata: rootMeta,
+		ID:          attemptPrefix,
+		Title:       step.Title,
+		Description: step.Description,
+		Type:        step.Type,
+		IsRoot:      true,
+		Labels:      append([]string{}, step.Labels...),
+		Assignee:    step.Assignee,
+		Metadata:    rootMeta,
 	}
 	if step.Type == "" {
 		rootStep.Type = "task"

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -2436,6 +2436,49 @@ func TestBuildAttemptRecipeSimpleRetry(t *testing.T) {
 	}
 }
 
+// TestBuildAttemptRecipePreservesStepDescription pins gastownhall/gascity#4861:
+// ralph-loop attempt beads created for later iterations lost the task
+// description, making fresh-session execution fail with "missing_task_input"
+// while a warm session could mask the defect through context carryover.
+// buildAttemptRecipe's root attempt step copied title/type/labels/assignee/
+// metadata from the frozen step spec but not step.Description. This drives
+// attempts 1 and 2 (the reported failure was specifically iteration 2+) and
+// asserts both iteration roots retain the authored description — the same
+// symmetry retry cloning already has for subject/child/check beads
+// (internal/dispatch/ralph.go, ~526-535/563-572/596-605).
+func TestBuildAttemptRecipePreservesStepDescription(t *testing.T) {
+	t.Parallel()
+
+	const authoredDescription = "Full task description with detailed requirements the agent needs to do the work without any ambient session context."
+
+	step := &formula.Step{
+		ID:          "converge",
+		Title:       "Converge",
+		Description: authoredDescription,
+		Type:        "task",
+		Ralph:       &formula.RalphSpec{MaxAttempts: 5},
+	}
+
+	control := beads.Bead{
+		ID: "gc-1",
+		Metadata: map[string]string{
+			"gc.step_id":  "converge",
+			"gc.step_ref": "mol-test.converge",
+		},
+	}
+
+	for _, attempt := range []int{1, 2} {
+		recipe := buildAttemptRecipe(step, control, attempt)
+		if len(recipe.Steps) != 1 {
+			t.Fatalf("attempt %d: steps = %d, want 1", attempt, len(recipe.Steps))
+		}
+		rootStep := recipe.Steps[0]
+		if rootStep.Description != authoredDescription {
+			t.Errorf("attempt %d: root step Description = %q, want %q (a fresh session claiming this attempt would fail with missing_task_input)", attempt, rootStep.Description, authoredDescription)
+		}
+	}
+}
+
 func TestBuildAttemptRecipeRalphWithChildren(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #4861

## Problem

In a stage-gated ralph run, iteration 1 of a control had the full authored
step description, but iterations 2+ had `desc_len=0`. A warm pi session
could mask this through prior context carryover, but a fresh session
correctly reported `missing_task_input`: "claimed bead has no description
or requirements payload." This is reachable whenever a gate forces
another ralph iteration.

`spawnNextAttempt` deserializes the frozen step spec and calls
`buildAttemptRecipe` (`internal/dispatch/control.go`). Its root attempt
step copied `title`/`type`/`labels`/`assignee`/`metadata` from that spec
into the `formula.RecipeStep` literal, but never `step.Description`.

## Fix

Add `Description: step.Description` to the root `formula.RecipeStep`
literal in `buildAttemptRecipe`. This is the control-path counterpart to
retry cloning, which already preserves descriptions for subject, child,
and check beads (`internal/dispatch/ralph.go`, ~526-535 / ~563-572 /
~596-605) — `buildAttemptRecipe`'s root step was the missed parallel for
engine-owned iteration cloning specifically.

No distinction between the control path and retry cloning appears
intentional in the surrounding code or comments; every other
step-authored field (title, type, labels, assignee, metadata) is
threaded through the same literal.

## Tests

`TestBuildAttemptRecipePreservesStepDescription`
(`internal/dispatch/control_test.go`), modeled on the existing
`TestBuildAttemptRecipeSimpleRetry`/`TestBuildAttemptRecipeRalphWithChildren`
pattern of calling `buildAttemptRecipe` directly: builds a `formula.Step`
with an authored `Description`, calls `buildAttemptRecipe(step, control,
attempt)` for `attempt` 1 and 2, and asserts the root recipe step's
`Description` matches the authored value both times — pinning the
specific fresh-session failure mode from the issue (iteration 2 losing
the description while iteration 1, materialized through a different
path, kept it).

`gofmt -l`, `go vet ./internal/dispatch/...`, and
`go test ./internal/dispatch/... -count=1` all green (including the full
`TestBuildAttemptRecipe*` suite). `go build ./...` also verified clean.

Written red-first: the new test fails against main with `Description =
""` for both attempts before the fix, and passes after.
