### PR TITLE
fix(gc): resolve binding-qualified city-scoped pool instances (#4843)

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -301,8 +301,13 @@ func resolveAgentIdentity(cfg *config.City, input, currentRigDir string) (config
 	if a, ok := findAgentByQualified(cfg, input); ok {
 		return a, true
 	}
-	// Step 2b: qualified pool instance — "rig/polecat-2" matches pool "rig/polecat".
-	if strings.Contains(input, "/") {
+	// Step 2b: qualified pool instance — "rig/polecat-2" (slash-qualified) or
+	// "binding.polecat-2" (dot-qualified, binding-qualified city-scoped pool)
+	// matches the corresponding pool template. Mirrors the shared resolver
+	// helper (internal/agentutil/resolve.go), which gates on
+	// ContainsAny(input, "/.") so dot-qualified instances resolve too
+	// (#4843).
+	if strings.ContainsAny(input, "/.") {
 		if a, ok := resolvePoolInstance(cfg, input); ok {
 			return a, true
 		}

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -364,6 +364,31 @@ func TestResolveAgentIdentityRejectsCanonicalSingletonPoolSuffix(t *testing.T) {
 	}
 }
 
+// TestResolveAgentIdentityResolvesBindingQualifiedPoolInstance is a
+// regression for #4843: a binding-qualified, city-scoped pool instance like
+// "testpack.worker-1" must resolve to its "testpack.worker" pool. The
+// CLI-local resolveAgentIdentity gated its Step 2b pool-instance check on
+// strings.Contains(input, "/"), so the dot-qualified form was never routed
+// to resolvePoolInstance — even though the shared resolver helper
+// (internal/agentutil/resolve.go) already handles it via ContainsAny(input, "/.").
+func TestResolveAgentIdentityResolvesBindingQualifiedPoolInstance(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", BindingName: "testpack", Dir: "", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
+		},
+	}
+	a, ok := resolveAgentIdentity(cfg, "testpack.worker-1", "")
+	if !ok {
+		t.Fatalf("resolveAgentIdentity(testpack.worker-1) = (_, false), want the worker pool instance")
+	}
+	if a.Name != "worker-1" {
+		t.Fatalf("resolveAgentIdentity(testpack.worker-1) resolved Name = %q, want %q", a.Name, "worker-1")
+	}
+	if _, ok := resolveAgentIdentity(cfg, "testpack.worker-3", ""); ok {
+		t.Fatal("resolveAgentIdentity(testpack.worker-3) = true, want false: exceeds max_active_sessions=2")
+	}
+}
+
 func TestResolveAgentIdentityUsesRigContextForScopeUnqualifiedControlDispatcher(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1321,6 +1321,63 @@ func TestDoSlingNudgePoolUsesCityStoreForSessionBeads(t *testing.T) {
 	}
 }
 
+// TestDoSlingNudgePoolMemberBindingQualifiedCityScope is a regression for
+// #4843: doSlingNudge must deliver a nudge to a running, city-scoped,
+// binding-qualified pool instance (testpack.worker-1). Before the
+// resolveAgentIdentity Step 2b guard fix, doSlingNudge's identity lookup on the
+// dot-qualified ref (cmd_sling.go:1521) failed, so it logged
+// `agent "testpack.worker-1" not found in config` and returned handled
+// without delivering the nudge or poking the controller, leaving routed pool
+// work unclaimed.
+func TestDoSlingNudgePoolMemberBindingQualifiedCityScope(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	sessionName := "testpack__worker-session-test"
+	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	sp.Calls = nil
+	a := config.Agent{
+		Name:              "worker",
+		BindingName:       "testpack",
+		Dir:               "",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2),
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{a},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+	if _, err := deps.Store.Create(beads.Bead{
+		Title:  "testpack.worker-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "testpack.worker",
+			"session_name": sessionName,
+			"pool_slot":    "1",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := startNudgePoller
+	startNudgePoller = func(_, _, _ string) error { return nil }
+	t.Cleanup(func() { startNudgePoller = prev })
+
+	doSlingNudge(&a, deps.CityName, deps.CityPath, cfg, sp, deps.Store, stdout, stderr)
+	if strings.Contains(stderr.String(), "not found in config") {
+		t.Fatalf("doSlingNudge logged 'not found in config' for a binding-qualified pool instance (#4843); stderr=%q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "No running sessions") || strings.Contains(stderr.String(), "poke failed") {
+		t.Fatalf("sling nudge missed live binding-qualified pool session; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "testpack.worker-1") {
+		t.Fatalf("stdout = %q, want nudge delivered to binding-qualified pool instance testpack.worker-1", stdout.String())
+	}
+}
+
 func TestDoSlingNudgePoolNoMembers(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()


### PR DESCRIPTION
resolveAgentIdentity's Step 2b pool-instance check was gated on strings.Contains(input, "/"), so a binding-qualified, city-scoped instance like "testpack.worker-1" (dot form, no slash) was never routed to resolvePoolInstance -- even though resolvePoolInstance's prefix (QualifiedName()+"-" = "testpack.worker-") matches it, and the shared resolver helper internal/agentutil/resolve.go already gates on ContainsAny(input, "/."). This was CLI-local resolver drift.

Effect: gc sling <city>/<pool>-1 --nudge on such a pool logged 'agent "testpack.worker-1" not found in config' and returned handled, so a running pool member was never nudged -- the symptom reported in #4843.

Fix: widen the Step 2b guard to strings.ContainsAny(input, "/."), aligning the CLI-local resolver to the shared helper (fix candidate A from the issue; candidate B, full resolver consolidation, is an explicit follow-up per the reporter, not this change). resolvePoolInstance is self-guarding (QualifiedName prefix + SupportsInstanceExpansion + max checks), so non-instance dot names (core.control-dispatcher, gastown.mayor) still fall through unchanged.

Tests:
- cmd_agent_test.go: resolveAgentIdentity resolves "testpack.worker-1" and still rejects an out-of-bound instance ("testpack.worker-3").
- cmd_sling_test.go: doSlingNudge delivers the nudge to a running city-scoped, binding-qualified pool member instead of taking the "not found in config" false-handled path.

Fixes #4843

## Summary

- Explain the change and why it is needed.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
  > **Note:** `docs/` is authored for [docs.gascityhall.com](https://docs.gascityhall.com) (Mintlify), not for direct GitHub viewing. Use extensionless page links (e.g. `/tutorials/01-beads`, not `/tutorials/01-beads.md`). If something looks broken on GitHub but works on the live site, that's intentional.
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [ ] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
