### PR TITLE
fix(formula): preserve resolved description_file stub paths through expansion

### DIFF
--- a/internal/formula/controlflow.go
+++ b/internal/formula/controlflow.go
@@ -226,9 +226,17 @@ func expandLoopIteration(step *Step, iteration int, iterVars map[string]string) 
 		// Create unique ID for this iteration
 		iterID := fmt.Sprintf("%s.iter%d.%s", step.ID, iteration, bodyStep.ID)
 
-		// Substitute loop variables in title and description
+		// Substitute loop variables in title and description while preserving
+		// only the already-resolved path embedded in an oversized
+		// description_file stub (gastownhall/gascity#4860).
 		title := substituteLoopVars(bodyStep.Title, iterVars)
-		description := substituteLoopVars(bodyStep.Description, iterVars)
+		description := substituteDescriptionPreservingPath(
+			bodyStep.Description,
+			bodyStep.DescriptionFileResolvedPath,
+			func(value string) string {
+				return substituteLoopVars(value, iterVars)
+			},
+		)
 
 		clone := cloneStep(bodyStep)
 		clone.ID = iterID

--- a/internal/formula/controlflow_test.go
+++ b/internal/formula/controlflow_test.go
@@ -64,6 +64,45 @@ func TestApplyLoops_FixedCount(t *testing.T) {
 	}
 }
 
+// TestExpandLoopIterationPreservesOversizedDescriptionFileStubPath guards the
+// same failure class as gastownhall/gascity#4860 in the loop-body expansion
+// path: a body step's Description generated from an oversized
+// description_file (DescriptionFileResolvedPath set) embeds an
+// already-resolved absolute path. Blind loop-var substitution over the full
+// Description text must not touch that path even when the loop variable name
+// collides with placeholder text still present in the resolved path (e.g. an
+// asset shipped under a literal "{i}.md" filename) — mirroring expandStep's
+// identical guard for expansion templates.
+func TestExpandLoopIterationPreservesOversizedDescriptionFileStubPath(t *testing.T) {
+	step := &Step{
+		ID: "process",
+		Loop: &LoopSpec{
+			Body: []*Step{
+				{
+					ID:                          "task",
+					Title:                       "Process item {i}",
+					Description:                 "iteration {i}: stub referencing /assets/{i}.md",
+					DescriptionFileResolvedPath: "/assets/{i}.md",
+				},
+			},
+		},
+	}
+
+	result, err := expandLoopIteration(step, 1, map[string]string{"i": "42"})
+	if err != nil {
+		t.Fatalf("expandLoopIteration: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(result))
+	}
+	if result[0].Description != "iteration 42: stub referencing /assets/{i}.md" {
+		t.Errorf("Description = %q, want non-path text substituted and only the resolved path preserved (gastownhall/gascity#4860)", result[0].Description)
+	}
+	if result[0].Title != "Process item 42" {
+		t.Errorf("Title = %q, want loop var substituted normally", result[0].Title)
+	}
+}
+
 func TestApplyLoopsPreservesRalphTimeout(t *testing.T) {
 	steps := []*Step{
 		{

--- a/internal/formula/expand.go
+++ b/internal/formula/expand.go
@@ -287,6 +287,8 @@ func substituteResolvedStubVars(value string, vars map[string]string) string {
 // composition so a later expansion can protect it again.
 func substituteExpandedDescription(tmpl, target *Step, vars map[string]string) (string, string) {
 	const targetPathToken = "\x00gc-target-description-file-resolved-path\x00"
+	carriesResolvedTargetDescription := target.DescriptionFileResolvedPath != "" &&
+		strings.Contains(tmpl.Description, "{target.description}")
 
 	targetForSubstitution := *target
 	if target.DescriptionFileResolvedPath != "" {
@@ -302,7 +304,7 @@ func substituteExpandedDescription(tmpl, target *Step, vars map[string]string) (
 		tmpl.DescriptionFileResolvedPath,
 		func(value string) string {
 			value = substituteTargetPlaceholders(value, &targetForSubstitution)
-			if tmpl.DescriptionFileResolvedPath != "" {
+			if tmpl.DescriptionFileResolvedPath != "" || carriesResolvedTargetDescription {
 				return substituteResolvedStubVars(value, vars)
 			}
 			return substituteVars(value, vars)
@@ -311,8 +313,7 @@ func substituteExpandedDescription(tmpl, target *Step, vars map[string]string) (
 	description = strings.ReplaceAll(description, targetPathToken, target.DescriptionFileResolvedPath)
 
 	resolvedPath := tmpl.DescriptionFileResolvedPath
-	if resolvedPath == "" && target.DescriptionFileResolvedPath != "" &&
-		strings.Contains(tmpl.Description, "{target.description}") {
+	if resolvedPath == "" && carriesResolvedTargetDescription {
 		resolvedPath = target.DescriptionFileResolvedPath
 	}
 	return description, resolvedPath

--- a/internal/formula/expand.go
+++ b/internal/formula/expand.go
@@ -247,6 +247,77 @@ func countStepIDs(steps []*Step, counts map[string]int) {
 	}
 }
 
+// substituteDescriptionPreservingPath applies substitute to every description
+// segment except the already-resolved oversized description_file path.
+func substituteDescriptionPreservingPath(description, resolvedPath string, substitute func(string) string) string {
+	if resolvedPath == "" {
+		return substitute(description)
+	}
+
+	const token = "\x00gc-description-file-resolved-path\x00"
+	protected := strings.ReplaceAll(description, resolvedPath, token)
+	return strings.ReplaceAll(substitute(protected), token, resolvedPath)
+}
+
+// substituteResolvedStubVars resolves both {{name}} values in the generated
+// Formula Variables block and ordinary {name} expansion placeholders without
+// recursively substituting inside the resolved values themselves.
+func substituteResolvedStubVars(value string, vars map[string]string) string {
+	var replacements []string
+	protected := varPattern.ReplaceAllStringFunc(value, func(match string) string {
+		name := match[2 : len(match)-2]
+		replacement := match
+		if resolved, ok := vars[name]; ok {
+			replacement = resolved
+		}
+		token := fmt.Sprintf("\x00gc-description-formula-var-%d\x00", len(replacements))
+		replacements = append(replacements, replacement)
+		return token
+	})
+	protected = substituteVars(protected, vars)
+	for i, replacement := range replacements {
+		token := fmt.Sprintf("\x00gc-description-formula-var-%d\x00", i)
+		protected = strings.ReplaceAll(protected, token, replacement)
+	}
+	return protected
+}
+
+// substituteExpandedDescription expands all non-path portions of a template
+// description and carries the protected path through target-description
+// composition so a later expansion can protect it again.
+func substituteExpandedDescription(tmpl, target *Step, vars map[string]string) (string, string) {
+	const targetPathToken = "\x00gc-target-description-file-resolved-path\x00"
+
+	targetForSubstitution := *target
+	if target.DescriptionFileResolvedPath != "" {
+		targetForSubstitution.Description = strings.ReplaceAll(
+			target.Description,
+			target.DescriptionFileResolvedPath,
+			targetPathToken,
+		)
+	}
+
+	description := substituteDescriptionPreservingPath(
+		tmpl.Description,
+		tmpl.DescriptionFileResolvedPath,
+		func(value string) string {
+			value = substituteTargetPlaceholders(value, &targetForSubstitution)
+			if tmpl.DescriptionFileResolvedPath != "" {
+				return substituteResolvedStubVars(value, vars)
+			}
+			return substituteVars(value, vars)
+		},
+	)
+	description = strings.ReplaceAll(description, targetPathToken, target.DescriptionFileResolvedPath)
+
+	resolvedPath := tmpl.DescriptionFileResolvedPath
+	if resolvedPath == "" && target.DescriptionFileResolvedPath != "" &&
+		strings.Contains(tmpl.Description, "{target.description}") {
+		resolvedPath = target.DescriptionFileResolvedPath
+	}
+	return description, resolvedPath
+}
+
 // expandStep expands a target step using the given template.
 // Returns the expanded steps with placeholders substituted.
 // The depth parameter tracks recursion depth for children; if it exceeds
@@ -264,7 +335,7 @@ func expandStep(target *Step, template []*Step, depth int, vars map[string]strin
 		expanded := cloneStep(tmpl)
 		expanded.ID = substituteVars(substituteTargetPlaceholders(tmpl.ID, target), vars)
 		expanded.Title = substituteVars(substituteTargetPlaceholders(tmpl.Title, target), vars)
-		expanded.Description = substituteVars(substituteTargetPlaceholders(tmpl.Description, target), vars)
+		expanded.Description, expanded.DescriptionFileResolvedPath = substituteExpandedDescription(tmpl, target, vars)
 		expanded.Notes = substituteVars(substituteTargetPlaceholders(tmpl.Notes, target), vars)
 		expanded.Assignee = substituteVars(tmpl.Assignee, vars)
 		// Keep condition expressions intact for the normal condition-filtering

--- a/internal/formula/expand_test.go
+++ b/internal/formula/expand_test.go
@@ -413,6 +413,146 @@ func TestApplyExpansions(t *testing.T) {
 	})
 }
 
+// TestApplyExpansionsPreservesOversizedDescriptionFileStubPath pins
+// gastownhall/gascity#4860: an expansion template step whose description_file
+// is too large to inline (> descriptionFileInlineMaxBytes) gets its
+// Description replaced with an external-prompt stub that embeds the resolved
+// on-disk path. That resolved path is computed once, at parse time, against
+// the LITERAL description_file value — including any "{target}" placeholder
+// text the on-disk asset name itself still contains. Expansion then
+// substitutes "{target}" throughout the template's Description text for
+// every other legitimate use of the placeholder, which — before the fix —
+// also corrupted the already-resolved path embedded in the stub, redirecting
+// the agent at a file that was never shipped (ENOENT).
+func TestApplyExpansionsPreservesOversizedDescriptionFileStubPath(t *testing.T) {
+	tmp := t.TempDir()
+	formulasDir := filepath.Join(tmp, "pack", "formulas")
+	assetsDir := filepath.Join(tmp, "pack", "assets")
+	for _, dir := range []string{formulasDir, assetsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	// The shipped asset is literally named "{target}.md" (braces included) —
+	// exactly the gastownhall/gascity#4860 reproduction. Content must exceed
+	// descriptionFileInlineMaxBytes so resolveDescriptionFiles emits the
+	// external-prompt stub instead of inlining the content.
+	largeContent := strings.Repeat("large prompt body\n", descriptionFileInlineMaxBytes/16+128)
+	if len(largeContent) <= descriptionFileInlineMaxBytes {
+		t.Fatalf("test asset length = %d, want > %d", len(largeContent), descriptionFileInlineMaxBytes)
+	}
+	assetPath := filepath.Join(assetsDir, "{target}.md")
+	if err := os.WriteFile(assetPath, []byte(largeContent), 0o644); err != nil {
+		t.Fatalf("write asset: %v", err)
+	}
+
+	expansionFormula := `{
+		"formula": "review-pass",
+		"type": "expansion",
+		"version": 1,
+		"vars": {
+			"audience": {"default": "operators"}
+		},
+		"template": [
+			{"id": "{target}.review", "title": "Review {target.title}", "description_file": "../assets/{target}.md"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(formulasDir, "review-pass.formula.json"), []byte(expansionFormula), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	parser := NewParser(formulasDir)
+	steps := []*Step{{ID: "contract", Title: "Contract"}}
+	compose := &ComposeRules{
+		Expand: []*ExpandRule{
+			{
+				Target: "contract",
+				With:   "review-pass",
+				Vars:   map[string]string{"audience": "security reviewers"},
+			},
+		},
+	}
+
+	result, err := ApplyExpansions(steps, compose, parser)
+	if err != nil {
+		t.Fatalf("ApplyExpansions failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 expanded step, got %d", len(result))
+	}
+	if result[0].ID != "contract.review" {
+		t.Fatalf("result[0].ID = %q, want contract.review", result[0].ID)
+	}
+
+	wantDescription := descriptionFileReferenceDescription(
+		"../assets/contract.md",
+		assetPath,
+		len(largeContent),
+		map[string]*VarDef{"audience": {}},
+	)
+	wantDescription = strings.ReplaceAll(wantDescription, "{{audience}}", "security reviewers")
+	if result[0].Description != wantDescription {
+		t.Fatalf("Description mismatch:\n--- got ---\n%s\n--- want ---\n%s", result[0].Description, wantDescription)
+	}
+	if result[0].DescriptionFileResolvedPath != assetPath {
+		t.Fatalf("DescriptionFileResolvedPath = %q, want %q", result[0].DescriptionFileResolvedPath, assetPath)
+	}
+}
+
+func TestExpandStepPreservesProtectedStubThroughTargetDescription(t *testing.T) {
+	resolvedPath := "/tmp/pack/assets/{audience}.md"
+	target := &Step{
+		ID:                          "contract",
+		Title:                       "Contract",
+		Description:                 descriptionFileReferenceDescription("../assets/{audience}.md", resolvedPath, 5000, nil),
+		DescriptionFileResolvedPath: resolvedPath,
+	}
+
+	first, err := expandStep(target, []*Step{{
+		ID:          "{target}.wrapped",
+		Title:       "Wrap {target.title}",
+		Description: "Wrapper:\n\n{target.description}",
+	}}, 0, map[string]string{"audience": "security"})
+	if err != nil {
+		t.Fatalf("first expandStep: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("first expansion produced %d steps, want 1", len(first))
+	}
+	wantWrapped := "Wrapper:\n\n" + descriptionFileReferenceDescription(
+		"../assets/security.md",
+		resolvedPath,
+		5000,
+		nil,
+	)
+	if first[0].Description != wantWrapped {
+		t.Fatalf("first Description mismatch:\n--- got ---\n%s\n--- want ---\n%s", first[0].Description, wantWrapped)
+	}
+	if first[0].DescriptionFileResolvedPath != resolvedPath {
+		t.Fatalf("first DescriptionFileResolvedPath = %q, want %q", first[0].DescriptionFileResolvedPath, resolvedPath)
+	}
+
+	second, err := expandStep(first[0], []*Step{{
+		ID:          "{target}.outer",
+		Title:       "Outer {target.title}",
+		Description: "Outer:\n\n{target.description}",
+	}}, 0, map[string]string{"audience": "platform"})
+	if err != nil {
+		t.Fatalf("second expandStep: %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("second expansion produced %d steps, want 1", len(second))
+	}
+	wantNested := "Outer:\n\n" + wantWrapped
+	if second[0].Description != wantNested {
+		t.Fatalf("nested Description mismatch:\n--- got ---\n%s\n--- want ---\n%s", second[0].Description, wantNested)
+	}
+	if second[0].DescriptionFileResolvedPath != resolvedPath {
+		t.Fatalf("nested DescriptionFileResolvedPath = %q, want %q", second[0].DescriptionFileResolvedPath, resolvedPath)
+	}
+}
+
 func TestBuildStepMap(t *testing.T) {
 	steps := []*Step{
 		{

--- a/internal/formula/expand_test.go
+++ b/internal/formula/expand_test.go
@@ -553,6 +553,38 @@ func TestExpandStepPreservesProtectedStubThroughTargetDescription(t *testing.T) 
 	}
 }
 
+func TestExpandStepPreservesFormulaVarsThroughTargetDescription(t *testing.T) {
+	resolvedPath := "/tmp/pack/assets/{audience}.md"
+	varDefs := map[string]*VarDef{"audience": {}}
+	target := &Step{
+		ID:                          "contract",
+		Description:                 descriptionFileReferenceDescription("../assets/{audience}.md", resolvedPath, 5000, varDefs),
+		DescriptionFileResolvedPath: resolvedPath,
+	}
+
+	result, err := expandStep(target, []*Step{{
+		ID:          "{target}.wrapped",
+		Description: "Wrapper:\n\n{target.description}",
+	}}, 0, map[string]string{"audience": "security reviewers"})
+	if err != nil {
+		t.Fatalf("expandStep: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expandStep produced %d steps, want 1", len(result))
+	}
+
+	want := "Wrapper:\n\n" + descriptionFileReferenceDescription(
+		"../assets/security reviewers.md",
+		resolvedPath,
+		5000,
+		varDefs,
+	)
+	want = strings.ReplaceAll(want, "{{audience}}", "security reviewers")
+	if result[0].Description != want {
+		t.Fatalf("Description mismatch:\n--- got ---\n%s\n--- want ---\n%s", result[0].Description, want)
+	}
+}
+
 func TestBuildStepMap(t *testing.T) {
 	steps := []*Step{
 		{

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -817,8 +817,14 @@ func (p *Parser) resolveDescriptionFiles(steps []*Step, baseDir string, strict b
 			} else {
 				if len(data) > descriptionFileInlineMaxBytes {
 					step.Description = descriptionFileReferenceDescription(step.DescriptionFile, path, len(data), vars)
+					// Record the resolved path out-of-band so a later
+					// substitution pass over Description (expansion
+					// templates, loop bodies) can recognize this stub and
+					// leave its embedded path untouched (gastownhall/gascity#4860).
+					step.DescriptionFileResolvedPath = path
 				} else {
 					step.Description = string(data)
+					step.DescriptionFileResolvedPath = ""
 				}
 				step.DescriptionFile = "" // consumed; don't serialize
 			}

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -335,6 +335,18 @@ type Step struct {
 	// SourceLocation is the path within the source formula.
 	// Format: "steps[0]", "steps[2].children[1]", "advice[0].after", "loop.body[0]"
 	SourceLocation string `json:"-"` // Internal only, not serialized to JSON
+
+	// DescriptionFileResolvedPath is the absolute on-disk path
+	// resolveDescriptionFiles resolved for an oversized description_file
+	// (see descriptionFileInlineMaxBytes). Set when Description contains the
+	// generated external-prompt stub (descriptionFileReferenceDescription)
+	// referencing that path, including after {target.description} composition.
+	// Kept out-of-band so later template/{{var}} substitution can preserve only
+	// the resolved-path segment while still expanding the rest of the stub.
+	// Otherwise a placeholder that also appears literally in the resolved path
+	// (e.g. an asset shipped under a literal "{target}.md" filename) gets
+	// corrupted by the same substitution pass (gastownhall/gascity#4860).
+	DescriptionFileResolvedPath string `json:"-"` // Internal only, not serialized to JSON
 }
 
 // DrainSpec defines a graph.v2 drain control step.


### PR DESCRIPTION
Closes #4860

## Problem

When an expansion template's `description_file` exceeds the inline threshold,
the parser replaces it with an external-prompt stub containing the already
resolved absolute file path. Later expansion substitutes `{target}` and
formula variables across the stub text. If placeholder text also appears
literally in the resolved filename, that pass corrupts the path and points the
agent at a file that was never shipped.

The first fix preserved the whole stub verbatim. That protected the path, but
also closed the Formula Variables window: declared expansion-local values in
the generated stub stayed unresolved.

Nested composition exposed a second form of the same boundary bug. A protected
stub inserted through `{target.description}` into a template without its own
`description_file` took the ordinary single-brace substitution path. That path
matched the inner `{name}` in `{{name}}` and corrupted the resolved Formula
Variables value into `{value}`.

## Fix

This deliberately preserves rather than re-resolves the path. Check-path
re-resolution is correct when expansion selects a genuinely different file,
such as `contract.sh`. The #4860 reproduction instead ships a file whose name
literally contains braces, such as `{target}.md`; looking up `contract.md`
after expansion cannot find that file. The parse-time resolved path is already
authoritative.

`Step.DescriptionFileResolvedPath` records that path out of band. Expansion
now masks only the recorded path segment, substitutes target and formula
values through the rest of the generated stub, and restores the exact path.
The Formula Variables block therefore carries its resolved expansion-local
values without reopening path corruption. Loop-body expansion uses the same
partial-protection helper, so non-path loop text still expands.

When a protected stub is inserted through `{target.description}`, the expanded
step inherits the recorded path and uses the same double-brace-aware
substitution path. A later expansion can protect that path again, and a nested
Formula Variables entry remains a resolved value rather than becoming a
single-braced placeholder.

## Tests

- `TestApplyExpansionsPreservesOversizedDescriptionFileStubPath` builds the
  real oversized literal-brace asset and pins the complete emitted stub,
  including the literal resolved path and resolved Formula Variables value.
- `TestExpandStepPreservesProtectedStubThroughTargetDescription` composes the
  stub through `{target.description}` twice and pins both the description and
  propagated path marker.
- `TestExpandStepPreservesFormulaVarsThroughTargetDescription` pins the nested
  non-empty Formula Variables case that previously emitted `{value}`.
- `TestExpandLoopIterationPreservesOversizedDescriptionFileStubPath` pins
  substitution outside the path while preserving the exact path segment.
- On the exact head: the focused regression passed 10 times, the complete
  `internal/formula` package passed, and full formatting, lint, `go vet ./...`,
  and `go build ./...` passed on Linux.
- The sharded fast suite had no new failure signature. Its only non-green
  results were the existing Herdr CLI contract mismatch and post-pass Dolt
  leak guard, both reproduced on the frozen base outside this diff.
