### PR TITLE
fix(beads): sanitize digit-leading rig prefixes before use as Dolt database name

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -469,7 +469,18 @@ func defaultScopeDoltDatabase(cityPath, dir, prefix string) string {
 	if samePath(cityPath, dir) {
 		return "hq"
 	}
-	return prefix
+	return sanitizeDoltDatabaseName(prefix)
+}
+
+// sanitizeDoltDatabaseName rewrites a rig prefix into a name Dolt will
+// accept as a database identifier. Dolt rejects names that start with a
+// digit (e.g. a prefix derived from an all-numeric rig directory name like
+// t.TempDir()'s "001"), so such names get a non-digit prefix.
+func sanitizeDoltDatabaseName(name string) string {
+	if name != "" && name[0] >= '0' && name[0] <= '9' {
+		return "r" + name
+	}
+	return name
 }
 
 func isReservedManagedDoltDatabase(name string) bool {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -11796,3 +11796,63 @@ func publishRejectingManagedDoltRuntimeForTest(t *testing.T, cityPath string) fu
 		<-done
 	}
 }
+
+// TestDefaultScopeDoltDatabase covers ga-p658sc: a rig whose derived prefix
+// is digit-leading (e.g. "001", the basename t.TempDir() hands to `gc rig
+// add` in acceptance tests) must not be used verbatim as a Dolt database
+// name, since Dolt rejects identifiers that start with a digit. The HQ
+// scope and ordinary letter-led prefixes must be unaffected.
+func TestDefaultScopeDoltDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "001")
+
+	tests := []struct {
+		name   string
+		dir    string
+		prefix string
+		want   string
+	}{
+		{
+			name:   "hq scope always returns hq regardless of prefix",
+			dir:    cityPath,
+			prefix: "001",
+			want:   "hq",
+		},
+		{
+			name:   "ordinary letter-led prefix is unchanged",
+			dir:    rigPath,
+			prefix: "ga",
+			want:   "ga",
+		},
+		{
+			name:   "digit-leading prefix is sanitized to a non-digit-leading name",
+			dir:    rigPath,
+			prefix: "001",
+			want:   "r001",
+		},
+		{
+			name:   "longer all-numeric prefix is sanitized",
+			dir:    rigPath,
+			prefix: "12345",
+			want:   "r12345",
+		},
+		{
+			name:   "digit elsewhere in the prefix is unaffected",
+			dir:    rigPath,
+			prefix: "g1",
+			want:   "g1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := defaultScopeDoltDatabase(cityPath, tt.dir, tt.prefix)
+			if got != tt.want {
+				t.Errorf("defaultScopeDoltDatabase(%q, %q, %q) = %q, want %q", cityPath, tt.dir, tt.prefix, got, tt.want)
+			}
+			if got != "hq" && got != "" && got[0] >= '0' && got[0] <= '9' {
+				t.Errorf("defaultScopeDoltDatabase(%q, %q, %q) = %q starts with a digit; Dolt rejects digit-leading database names", cityPath, tt.dir, tt.prefix, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `Nightly` workflow's `Integration / SQLite coordination store` job failed deterministically (18/18 tests, all 3 sampled runs) with `Error: invalid database name "001": invalid database name: 001`.
- Root cause: the Dolt database name for a rig scope was derived from a rig prefix that can be a bare digit string (e.g. a rig named `001`), which Dolt rejects as a database name since it must not start with a digit.
- Fix: `sanitizeDoltDatabaseName` now prefixes digit-leading rig-prefix names with `"r"` before use as a Dolt database name, called from `defaultScopeDoltDatabase` for non-HQ scopes.

## Test plan
- [x] RED: added `TestDefaultScopeDoltDatabase` reproducing the invalid-name failure (68ed7cde8)
- [x] GREEN: sanitization fix makes the new test pass (adbf5fed2)
- [x] `make test-fast-parallel` passes locally (all 10 shards, including 6-way `unit-cmd-gc` split)
- [x] Acceptance-level repro (`TestRegression_GastownWithRigs`) re-verified passing against the fix

refs ga-p658sc

Note: this task's molecule/step-bead tracking scaffolding was lost mid-session to a confirmed Dolt-server-strain incident (see notes on ga-p658sc for details) — ga-p658sc is the durable reference for this work, there is no surviving step-bead chain.