### PR TITLE
fix(ci): give mac-quality job enough time to finish (ga-sv32ce)

### DIFF
--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -199,7 +199,7 @@ jobs:
       - gate
     if: needs.gate.outputs.run_smoke == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
- `mac-quality`'s 20-minute timeout killed 11 of the last 14 scheduled nightly runs, silently losing all macOS lint/fmt/vet/docs coverage on ~79% of nightlies
- The 3 runs that did finish took 12m40s-19m29s, so real work already sits at the edge of the 20-minute budget
- Bump `timeout-minutes` to 35 to leave headroom for a cold `golangci-lint` cache without masking a genuine hang

## Test plan
- [x] No unit test applies (CI job budget change) — reproducing artifact is the measured duration series across 14 consecutive scheduled runs, documented on ga-sv32ce
- [ ] Confirm `mac-quality` completes within the new budget on the next scheduled/triggered run

Fixes ga-sv32ce