### PR TITLE
feat(cityproducer): run, session and transcript producer adapter (API-7.20)

### DIFF
--- a/pkg/cityneutral/checkpoint_test.go
+++ b/pkg/cityneutral/checkpoint_test.go
@@ -1,0 +1,280 @@
+package cityneutral
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func recordsUpTo(n uint64) []CityRecord {
+	out := make([]CityRecord, 0, n)
+	for i := uint64(1); i <= n; i++ {
+		out = append(out, CityRecord{
+			MessageID: "m" + string(rune('0'+i)), Ordinal: i, Role: "user",
+			At: t0.Add(time.Duration(i) * time.Minute), Text: "turn",
+		})
+	}
+	return out
+}
+
+func chainWith(records []CityRecord, complete bool) CityChain {
+	return CityChain{
+		Run: CityRun{RunID: "city-run-7", Status: "running", Started: t0, Version: 1},
+		Sessions: []CitySession{{
+			SessionID: "city-sess-1", Status: "running", Started: t0, Version: 1,
+			Complete: complete, Records: records,
+		}},
+	}
+}
+
+func pushOK(t *testing.T, p *Producer, chain CityChain) Result {
+	t.Helper()
+	res, err := p.Push(context.Background(), chain)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	return res
+}
+
+// AC2 happy path: a restart resumes at the next accepted record and re-sends
+// nothing that was already acknowledged.
+func TestRestartResumesAtNextAcceptedRecord(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	store := NewMemoryStore()
+	mapper := Mapper{Source: citySource(), AllowRawContent: true}
+
+	first, err := NewProducer(f, mapper, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res := pushOK(t, first, chainWith(recordsUpTo(2), false))
+	if res.Accepted != 2 {
+		t.Fatalf("first push accepted %d, want 2", res.Accepted)
+	}
+
+	// A brand new Producer over the same store is the restart: same chain,
+	// grown by two records.
+	second, err := NewProducer(f, mapper, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res = pushOK(t, second, chainWith(recordsUpTo(4), false))
+	if res.Accepted != 2 || res.Skipped != 2 {
+		t.Fatalf("restart push accepted %d skipped %d, want 2/2", res.Accepted, res.Skipped)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	if len(recs) != 4 {
+		t.Fatalf("server holds %d records, want 4 (no duplicates)", len(recs))
+	}
+}
+
+// AC2 fault/checkpoint matrix. Every row starts from the same two-record
+// checkpoint so the difference between rows is only the fault under test.
+func TestCheckpointFaultMatrix(t *testing.T) {
+	base := recordsUpTo(2)
+
+	cases := []struct {
+		name     string
+		finalize bool
+		next     CityChain
+		wantErr  error
+		accepted int
+		skipped  int
+	}{
+		{
+			name:     "duplicate batch deduplicates on stable source identity",
+			next:     chainWith(recordsUpTo(2), false),
+			accepted: 0, skipped: 2,
+		},
+		{
+			name:     "out-of-order batch is ordered before contiguity is judged",
+			next:     chainWith([]CityRecord{base[1], base[0], recordsUpTo(4)[3], recordsUpTo(4)[2]}, false),
+			accepted: 2, skipped: 2,
+		},
+		{
+			name:     "partial batch advances only as far as it is contiguous",
+			next:     chainWith(recordsUpTo(3), false),
+			accepted: 1, skipped: 2,
+		},
+		{
+			name: "gap stops the adapter",
+			next: chainWith(append(append([]CityRecord{}, base...), CityRecord{
+				MessageID: "m5", Ordinal: 5, Role: "user", At: t0.Add(5 * time.Minute), Text: "late",
+			}), false),
+			wantErr: ErrGap,
+		},
+		{
+			name: "changed replay stops the adapter",
+			next: chainWith([]CityRecord{base[0], {
+				MessageID: "m2", Ordinal: 2, Role: "user", At: t0.Add(2 * time.Minute), Text: "rewritten",
+			}}, false),
+			wantErr: ErrChangedReplay,
+		},
+		{
+			name: "reassigned message id at an accepted ordinal stops the adapter",
+			next: chainWith([]CityRecord{base[0], {
+				MessageID: "m9", Ordinal: 2, Role: "user", At: t0.Add(2 * time.Minute), Text: "turn",
+			}}, false),
+			wantErr: ErrChangedReplay,
+		},
+		{
+			name:     "post-finalize append stops the adapter",
+			finalize: true,
+			next:     chainWith(recordsUpTo(3), true),
+			wantErr:  ErrFinalized,
+		},
+		{
+			name:     "re-observing a finalized session is a no-op",
+			finalize: true,
+			next:     chainWith(recordsUpTo(2), true),
+			accepted: 0, skipped: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFake("svc-city@tenant", "gc-city-01", "city")
+			p := newCityProducer(t, f, nil)
+			pushOK(t, p, chainWith(base, tc.finalize))
+
+			res, err := p.Push(context.Background(), tc.next)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				// A refusal must not have advanced anything: the server still
+				// holds exactly the acknowledged prefix.
+				recs, lerr := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+				if lerr != nil {
+					t.Fatalf("ListTranscriptRecords: %v", lerr)
+				}
+				if len(recs) != len(base) {
+					t.Fatalf("refusal left %d records, want %d", len(recs), len(base))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Push: %v", err)
+			}
+			if res.Accepted != tc.accepted || res.Skipped != tc.skipped {
+				t.Fatalf("accepted %d skipped %d, want %d/%d",
+					res.Accepted, res.Skipped, tc.accepted, tc.skipped)
+			}
+		})
+	}
+}
+
+// AC2: a credential rotation mid-flight is recoverable by retry alone. It
+// changes the credential and nothing else — not the source identity, not the
+// epoch, not the checkpoint — so the retry replays under the same derived key
+// and the server stores no duplicate.
+func TestCredentialRotationDoesNotAdvanceOrDuplicate(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	p := newCityProducer(t, f, nil)
+	pushOK(t, p, chainWith(recordsUpTo(2), false))
+
+	rotating := errors.New("401 credential rotated")
+	f.Fail = rotating
+	if _, err := p.Push(context.Background(), chainWith(recordsUpTo(3), false)); !errors.Is(err, rotating) {
+		t.Fatalf("err = %v, want the injected rotation error", err)
+	}
+
+	// The rotation landed on the run upsert, so nothing advanced. Retrying the
+	// identical chain must accept exactly the one new record.
+	res, err := p.Push(context.Background(), chainWith(recordsUpTo(3), false))
+	if err != nil {
+		t.Fatalf("retry after rotation: %v", err)
+	}
+	if res.Accepted != 1 || res.Skipped != 2 {
+		t.Fatalf("retry accepted %d skipped %d, want 1/2", res.Accepted, res.Skipped)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("server holds %d records, want 3", len(recs))
+	}
+}
+
+// AC2: a declared reset advances the epoch, which restarts the frontier under
+// the same checkpoint key. A backwards epoch is not a reset — it is drift.
+func TestResetAdvancesEpochAndBackwardsEpochIsDrift(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	store := NewMemoryStore()
+	p, err := NewProducer(f, Mapper{Source: citySource(), AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	pushOK(t, p, chainWith(recordsUpTo(2), false))
+
+	reset := citySource()
+	reset.Epoch = 2
+	after, err := NewProducer(f, Mapper{Source: reset, AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res := pushOK(t, after, chainWith(recordsUpTo(2), false))
+	if res.Accepted != 2 {
+		t.Fatalf("after reset accepted %d, want 2 (frontier restarted)", res.Accepted)
+	}
+
+	behind, err := NewProducer(f, Mapper{Source: citySource(), AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	if _, err := behind.Push(context.Background(), chainWith(recordsUpTo(2), false)); !errors.Is(err, ErrIdentityDrift) {
+		t.Fatalf("backwards epoch: err = %v, want ErrIdentityDrift", err)
+	}
+}
+
+// AC2: the derived idempotency key depends on stable source identity and
+// nothing else, and it is namespaced per resource kind so a run key cannot be
+// replayed into a session.
+func TestIdempotencyKeyIsStableAndNamespaced(t *testing.T) {
+	src := citySource()
+	run1 := idempotencyKey(src, KindRun, "city-run-7", 3)
+	run2 := idempotencyKey(src, KindRun, "city-run-7", 3)
+	if run1 != run2 {
+		t.Fatalf("key is not stable: %q != %q", run1, run2)
+	}
+	if len(run1) != 36 || run1[14] != '5' {
+		t.Fatalf("key %q is not a v5-shaped UUID", run1)
+	}
+	if sess := idempotencyKey(src, KindSession, "city-run-7", 3); sess == run1 {
+		t.Fatalf("run and session keys collide: %q", sess)
+	}
+	if bumped := idempotencyKey(src, KindRun, "city-run-7", 4); bumped == run1 {
+		t.Fatalf("source_version does not change the key")
+	}
+	other := src
+	other.Epoch = 2
+	if e := idempotencyKey(other, KindRun, "city-run-7", 3); e == run1 {
+		t.Fatalf("epoch does not change the key")
+	}
+}
+
+// A checkpoint minted for one source may not be picked up by another.
+func TestCheckpointIsBoundToItsSource(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	store := NewMemoryStore()
+	p, err := NewProducer(f, Mapper{Source: citySource(), AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res := pushOK(t, p, chainWith(recordsUpTo(2), false))
+
+	// Same checkpoint bytes, different source identity: refuse rather than
+	// inherit another producer's frontier.
+	stolen := State{Epoch: 1, SourceID: "someone-else", RunTeamID: res.RunTeamID}
+	if err := store.Save(context.Background(), CheckpointKey(citySource(), "city-run-7"), stolen); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := p.Push(context.Background(), chainWith(recordsUpTo(2), false)); !errors.Is(err, ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift", err)
+	}
+}

--- a/pkg/cityneutral/cityneutral.go
+++ b/pkg/cityneutral/cityneutral.go
@@ -1,0 +1,96 @@
+// Package cityneutral is Gas City's producer adapter for the platform-neutral
+// run, session and transcript-record resources of the Beads Team Server v1 API.
+//
+// City is ONE OPTIONAL producer of those resources. A custom orchestrator with
+// no City in the picture uploads the same chain on its own credential and gets
+// records of the same shape, so nothing here may become a schema, an identity
+// or an authority that a non-City producer would have to satisfy. Every neutral
+// Team ID is minted by the server and read back off a response; this package
+// never invents one, and City-shaped facts (city, rig, formula) are display
+// only, gated, and never load-bearing.
+//
+// The layering is deliberate:
+//
+//   - [API] is the client seam. It carries one method per frozen operation this
+//     adapter uses and NOTHING else. The adapter speaks no HTTP: no URL, no
+//     header, no status code appears below this file's imports.
+//   - [Mapper] turns a City chain into neutral request bodies and refuses any
+//     mapping that would let a City fact reach a neutral authority field.
+//   - [Producer] owns checkpointing: stable source identity for dedup, a
+//     contiguous acknowledged frontier, and the refusals (changed replay, gap,
+//     post-finalize mutation) that stop this adapter instead of corrupting a
+//     neutral record.
+//
+// Rollback is per producer: stop calling Push and the acknowledged records stay
+// exactly as the server accepted them, because this package never rewrites an
+// accepted record and never sends a mutation for a finalized session.
+package cityneutral
+
+import "errors"
+
+// Frozen operation IDs from operation_matrix_v6. They are spelled here so a
+// reader can check the adapter's surface against the frozen matrix without
+// leaving the package, and so the client seam cannot quietly grow a route that
+// is not in the matrix.
+const (
+	OpUpsertRun              = "upsertRun"
+	OpGetRun                 = "getRun"
+	OpUpsertRunSession       = "upsertRunSession"
+	OpGetSession             = "getSession"
+	OpFinalizeSession        = "finalizeSession"
+	OpCreateTranscriptRecord = "createTranscriptRecord"
+	OpListTranscriptRecords  = "listTranscriptRecords"
+	OpGetSessionTranscript   = "getSessionTranscript"
+)
+
+// Resource kinds in the server's idempotency namespace. A key minted for a run
+// may not be replayed into a session, so the kind is part of the key preimage.
+const (
+	KindRun              = "run"
+	KindSession          = "session"
+	KindTranscriptRecord = "transcript_record"
+	// kindSessionFinalize namespaces the finalize key. Finalize has no resource
+	// kind of its own server-side, but a finalize key derived from the same
+	// preimage as the session upsert would collide with it.
+	kindSessionFinalize = "session_finalize"
+)
+
+// Bounds mirroring the server's validators, so an oversized field is refused
+// here with a source field name attached rather than as a correlated 4xx.
+const (
+	maxSourceNativeIDLen  = 200
+	maxDisplayTitleLength = 400
+)
+
+// Refusals. Every one of them stops this producer with its checkpoint intact:
+// nothing has been advanced past the last acknowledged record, so an operator
+// who fixes the source can restart and resume rather than reconcile.
+var (
+	// ErrChangedReplay is a record whose stable source identity was already
+	// acknowledged but whose payload no longer matches. Sending it would ask
+	// the server to rewrite accepted input, so the adapter stops instead.
+	ErrChangedReplay = errors.New("cityneutral: source identity replayed with changed payload")
+	// ErrGap is a record that would advance the frontier non-contiguously.
+	// Uploading it would leave a hole no later read could distinguish from
+	// data loss.
+	ErrGap = errors.New("cityneutral: non-contiguous record would skip the acknowledged frontier")
+	// ErrFinalized is any attempt to add to or mutate a session the server has
+	// already finalized. Finalize is one-way (FIN-1) and this adapter is not
+	// the component that gets to argue with it.
+	ErrFinalized = errors.New("cityneutral: session is finalized; input cannot be rewritten")
+	// ErrIdentityDrift is a server response binding a stable source identity to
+	// a different neutral Team ID than the checkpoint holds. That is either a
+	// wrong-tenant credential or a reset that was never declared; both are
+	// louder than a retry.
+	ErrIdentityDrift = errors.New("cityneutral: stable source identity resolved to a different neutral id")
+	// ErrNeutralAuthority is a mapping that would let a City fact become
+	// neutral authority.
+	ErrNeutralAuthority = errors.New("cityneutral: City-shaped field cannot become neutral authority")
+	// ErrInvalidChain is a City chain this adapter refuses to map at all.
+	ErrInvalidChain = errors.New("cityneutral: invalid City chain")
+	// ErrCredentialLeak is outbound bytes carrying credential evidence.
+	ErrCredentialLeak = errors.New("cityneutral: outbound payload carries credential evidence")
+	// ErrContentRoute is raw transcript content on a route not authorized to
+	// carry it.
+	ErrContentRoute = errors.New("cityneutral: raw content outside its authorized route")
+)

--- a/pkg/cityneutral/contract.go
+++ b/pkg/cityneutral/contract.go
@@ -1,0 +1,191 @@
+package cityneutral
+
+import (
+	"context"
+	"time"
+)
+
+// Status is the closed lifecycle-independent execution status of a neutral run
+// or session. City may not invent one: the canonical contract has no raw
+// passthrough, so an unmappable City state lands on StatusUnknown rather than
+// being echoed through.
+type Status string
+
+// The closed status vocabulary.
+const (
+	StatusPending   Status = "pending"
+	StatusRunning   Status = "running"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusCancelled Status = "cancelled" //nolint:misspell // frozen wire value of the neutral contract
+	StatusUnknown   Status = "unknown"
+)
+
+// Lifecycle is the input-completeness half, orthogonal to Status: a run can be
+// succeeded while its input is still partial because records are still
+// arriving. Only final is terminal, and the transition is one-way.
+type Lifecycle string
+
+// The closed lifecycle vocabulary.
+const (
+	LifecyclePartial Lifecycle = "partial"
+	LifecycleFinal   Lifecycle = "final"
+)
+
+// Role is the closed speaking role of a transcript record.
+type Role string
+
+// The closed role vocabulary.
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleSystem    Role = "system"
+	RoleTool      Role = "tool"
+	RoleUnknown   Role = "unknown"
+)
+
+// Coverage is the source's own claim about how complete this record's input is.
+// The vocabulary is the server's closed set, spelled in full because it is a
+// wire vocabulary; this producer emits only known, partial and unavailable.
+type Coverage string
+
+// The closed coverage vocabulary.
+const (
+	CoverageKnown         Coverage = "known"
+	CoverageUnavailable   Coverage = "unavailable"
+	CoveragePartial       Coverage = "partial"
+	CoverageMetered       Coverage = "metered"
+	CoverageEstimated     Coverage = "estimated"
+	CoverageLegacyUnknown Coverage = "legacy_unknown"
+)
+
+// ContributorRef is the represented author of a record: attribution only, never
+// an authorization input. It is distinct from the uploader (the credential the
+// request arrived on, which the server derives and this package never sends)
+// and from the source (the enrolled producer identity).
+type ContributorRef struct {
+	Kind string `json:"kind"`
+	Ref  string `json:"ref"`
+}
+
+// Upsert is the request body of upsertRun and upsertRunSession. One input type
+// serves both, exactly as the server's contract does: what differs is the
+// container, which comes from the path and the credential and never from the
+// body.
+type Upsert struct {
+	SourceEntityID string          `json:"source_entity_id"`
+	SourceVersion  uint64          `json:"source_version"`
+	Epoch          uint64          `json:"epoch"`
+	Status         Status          `json:"status"`
+	Lifecycle      Lifecycle       `json:"lifecycle"`
+	StartedAt      time.Time       `json:"started_at"`
+	EndedAt        *time.Time      `json:"ended_at,omitempty"`
+	ProjectID      string          `json:"project_id,omitempty"`
+	IssueID        string          `json:"issue_id,omitempty"`
+	Title          string          `json:"title,omitempty"`
+	Coverage       Coverage        `json:"coverage,omitempty"`
+	Contributor    *ContributorRef `json:"contributor,omitempty"`
+}
+
+// TranscriptRecordIngest is the request body of createTranscriptRecord.
+type TranscriptRecordIngest struct {
+	SourceMessageID string          `json:"source_message_id"`
+	SourceVersion   uint64          `json:"source_version"`
+	Epoch           uint64          `json:"epoch"`
+	Ordinal         *uint64         `json:"ordinal,omitempty"`
+	Role            Role            `json:"role"`
+	Author          *ContributorRef `json:"author,omitempty"`
+	OccurredAt      time.Time       `json:"occurred_at"`
+	Text            string          `json:"text,omitempty"`
+	ContentRef      string          `json:"content_ref,omitempty"`
+	Coverage        Coverage        `json:"coverage,omitempty"`
+}
+
+// Run is the closed neutral run as a read returns it. ID is the server-minted
+// Team ID; SourceRunID is the bounded source-native ID. Both are present so a
+// caller can tell them apart, and this producer treats ID as read-only fact.
+type Run struct {
+	ID          string    `json:"id"`
+	SourceRunID string    `json:"source_run_id"`
+	SourceID    string    `json:"source_id"`
+	SourceKind  string    `json:"source_kind"`
+	Status      Status    `json:"status"`
+	Lifecycle   Lifecycle `json:"lifecycle"`
+	Epoch       uint64    `json:"epoch"`
+	Version     uint64    `json:"version"`
+	Finalized   bool      `json:"finalized"`
+	ETag        string    `json:"etag"`
+}
+
+// Session is the closed neutral session as a read returns it. RunID is the
+// same-workspace link to its run, resolved by the server at attach time.
+type Session struct {
+	ID              string    `json:"id"`
+	RunID           string    `json:"run_id"`
+	SourceSessionID string    `json:"source_session_id"`
+	SourceID        string    `json:"source_id"`
+	SourceKind      string    `json:"source_kind"`
+	Status          Status    `json:"status"`
+	Lifecycle       Lifecycle `json:"lifecycle"`
+	Epoch           uint64    `json:"epoch"`
+	Version         uint64    `json:"version"`
+	Finalized       bool      `json:"finalized"`
+	ETag            string    `json:"etag"`
+}
+
+// TranscriptRecord is the closed neutral transcript record as a read returns
+// it.
+type TranscriptRecord struct {
+	ID              string          `json:"id"`
+	SessionID       string          `json:"session_id"`
+	SourceMessageID string          `json:"source_message_id"`
+	SourceID        string          `json:"source_id"`
+	SourceKind      string          `json:"source_kind"`
+	Role            Role            `json:"role"`
+	Author          *ContributorRef `json:"author"`
+	OccurredAt      time.Time       `json:"occurred_at"`
+	Ordinal         *uint64         `json:"ordinal"`
+	Epoch           uint64          `json:"epoch"`
+	Version         uint64          `json:"version"`
+	ContentStatus   string          `json:"content_status"`
+	ETag            string          `json:"etag"`
+}
+
+// TranscriptItem is one entry of the ordered session transcript aggregate.
+type TranscriptItem struct {
+	RecordID        string          `json:"record_id"`
+	SourceMessageID string          `json:"source_message_id"`
+	Role            Role            `json:"role"`
+	Author          *ContributorRef `json:"author"`
+	Ordinal         *uint64         `json:"ordinal"`
+	ContentStatus   string          `json:"content_status"`
+	Text            string          `json:"text"`
+}
+
+// API is the seam onto the public v1 client.
+//
+// It carries exactly the eight frozen operations this adapter needs and no
+// transport vocabulary at all — no base URL, no header, no status code. That is
+// what keeps this package from hand-rolling HTTP: the concrete implementation
+// is the generated public client for the canonical contract, and everything
+// below is written against these signatures.
+//
+// NOTE: the contract program generates a public TypeScript client and a
+// server-side Go interface; there is no generated Go *client* module a Go
+// producer can import today. This interface is the shape that client binds to,
+// method-for-method, so binding it is a wiring change and never a logic change.
+//
+// The idempotency key is a caller-supplied argument rather than something an
+// implementation invents, because the key is part of THIS package's
+// dedup contract: [Producer] derives it from stable source identity so that a
+// retry replays and a changed payload conflicts.
+type API interface {
+	UpsertRun(ctx context.Context, body Upsert, idempotencyKey string) (Run, error)
+	GetRun(ctx context.Context, runTeamID string) (Run, error)
+	UpsertRunSession(ctx context.Context, runTeamID string, body Upsert, idempotencyKey string) (Session, error)
+	GetSession(ctx context.Context, sessionTeamID string) (Session, error)
+	FinalizeSession(ctx context.Context, sessionTeamID string, idempotencyKey string) (Session, error)
+	CreateTranscriptRecord(ctx context.Context, sessionTeamID string, body TranscriptRecordIngest, idempotencyKey string) (TranscriptRecord, error)
+	ListTranscriptRecords(ctx context.Context, sessionTeamID string) ([]TranscriptRecord, error)
+	GetSessionTranscript(ctx context.Context, sessionTeamID string) ([]TranscriptItem, error)
+}

--- a/pkg/cityneutral/fake.go
+++ b/pkg/cityneutral/fake.go
@@ -1,0 +1,301 @@
+package cityneutral
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Fake is an in-memory stand-in for the neutral v1 API.
+//
+// It is not a mock of this package's expectations: it models the parts of the
+// server contract a producer can actually get wrong — server-minted Team IDs,
+// idempotent replay keyed on Idempotency-Key, conflict on a changed payload
+// under a used key, one-way finalize, and ownership derived from the credential
+// rather than from the body. A producer that satisfies this Fake is a producer
+// whose failures against the real server are transport failures.
+//
+// It lives outside _test.go on purpose: a custom orchestrator replaying the
+// same conformance chain needs it too, and the parity claim is only meaningful
+// if both producers run against the SAME server model.
+type Fake struct {
+	mu sync.Mutex
+
+	// Uploader is who the credential says is calling. The server derives it;
+	// no request body may set it, and this Fake never reads it from one.
+	Uploader string
+	// SourceID and SourceKind are the enrolled producer identity bound to the
+	// credential. Also server-derived, also never read from a body.
+	SourceID   string
+	SourceKind string
+
+	// Fail, when set, is returned by the next call and then cleared. It models
+	// a transient fault — a credential mid-rotation, a 5xx — so a test can prove
+	// the producer neither advances nor duplicates across it.
+	Fail error
+
+	seq      uint64
+	runs     map[string]*Run
+	runIdx   map[string]string
+	sessions map[string]*Session
+	sessIdx  map[string]string
+	records  map[string][]TranscriptRecord
+	text     map[string]string
+	keys     map[string]fakeKey
+	// Calls records every accepted operation in order, for parity comparison.
+	Calls []string
+}
+
+type fakeKey struct {
+	digest string
+	id     string
+}
+
+// Fake failure modes, mapped from the server's problem types.
+var (
+	// ErrConflict is an Idempotency-Key reused with a different payload.
+	ErrConflict = errors.New("cityneutral: idempotency key reused with a different payload")
+	// ErrSessionFinalized is a write to a finalized session.
+	ErrSessionFinalized = errors.New("cityneutral: session is finalized")
+	// ErrNotFound is a read or write against an unknown neutral ID.
+	ErrNotFound = errors.New("cityneutral: not found")
+	// ErrMissingKey is a mutation with no Idempotency-Key.
+	ErrMissingKey = errors.New("cityneutral: Idempotency-Key is required")
+)
+
+// NewFake returns a Fake bound to one credential's uploader and source.
+func NewFake(uploader, sourceID, sourceKind string) *Fake {
+	return &Fake{
+		Uploader: uploader, SourceID: sourceID, SourceKind: sourceKind,
+		runs: map[string]*Run{}, runIdx: map[string]string{},
+		sessions: map[string]*Session{}, sessIdx: map[string]string{},
+		records: map[string][]TranscriptRecord{}, text: map[string]string{},
+		keys: map[string]fakeKey{},
+	}
+}
+
+func (f *Fake) mint(prefix string) string {
+	f.seq++
+	return fmt.Sprintf("%s_%016x", prefix, f.seq)
+}
+
+// take consumes a pending injected failure.
+func (f *Fake) take() error {
+	if f.Fail == nil {
+		return nil
+	}
+	err := f.Fail
+	f.Fail = nil
+	return err
+}
+
+// replay resolves an idempotency key: it returns the prior id when the key and
+// payload match, and refuses when the key was used for different bytes.
+func (f *Fake) replay(key, digest string) (string, bool, error) {
+	if key == "" {
+		return "", false, ErrMissingKey
+	}
+	prior, ok := f.keys[key]
+	if !ok {
+		return "", false, nil
+	}
+	if prior.digest != digest {
+		return "", false, fmt.Errorf("%w: key %s", ErrConflict, key)
+	}
+	return prior.id, true, nil
+}
+
+// UpsertRun implements API.
+func (f *Fake) UpsertRun(_ context.Context, body Upsert, key string) (Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return Run{}, err
+	}
+	digest := payloadDigest(body)
+	if id, hit, err := f.replay(key, digest); err != nil {
+		return Run{}, err
+	} else if hit {
+		f.Calls = append(f.Calls, OpUpsertRun+" replay")
+		return *f.runs[id], nil
+	}
+	idxKey := f.SourceID + "/" + body.SourceEntityID
+	id, ok := f.runIdx[idxKey]
+	if !ok {
+		id = f.mint("run")
+		f.runIdx[idxKey] = id
+		f.runs[id] = &Run{
+			ID: id, SourceRunID: body.SourceEntityID,
+			SourceID: f.SourceID, SourceKind: f.SourceKind,
+		}
+	}
+	run := f.runs[id]
+	run.Status, run.Lifecycle, run.Epoch = body.Status, body.Lifecycle, body.Epoch
+	run.Version = body.SourceVersion
+	run.ETag = payloadDigest(*run)
+	f.keys[key] = fakeKey{digest: digest, id: id}
+	f.Calls = append(f.Calls, OpUpsertRun)
+	return *run, nil
+}
+
+// GetRun implements API.
+func (f *Fake) GetRun(_ context.Context, runTeamID string) (Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	run, ok := f.runs[runTeamID]
+	if !ok {
+		return Run{}, fmt.Errorf("%w: run %s", ErrNotFound, runTeamID)
+	}
+	f.Calls = append(f.Calls, OpGetRun)
+	return *run, nil
+}
+
+// UpsertRunSession implements API.
+func (f *Fake) UpsertRunSession(_ context.Context, runTeamID string, body Upsert, key string) (Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return Session{}, err
+	}
+	if _, ok := f.runs[runTeamID]; !ok {
+		return Session{}, fmt.Errorf("%w: run %s", ErrNotFound, runTeamID)
+	}
+	digest := payloadDigest(body)
+	if id, hit, err := f.replay(key, digest); err != nil {
+		return Session{}, err
+	} else if hit {
+		f.Calls = append(f.Calls, OpUpsertRunSession+" replay")
+		return *f.sessions[id], nil
+	}
+	idxKey := f.SourceID + "/" + runTeamID + "/" + body.SourceEntityID
+	id, ok := f.sessIdx[idxKey]
+	if !ok {
+		id = f.mint("ses")
+		f.sessIdx[idxKey] = id
+		f.sessions[id] = &Session{
+			ID: id, RunID: runTeamID, SourceSessionID: body.SourceEntityID,
+			SourceID: f.SourceID, SourceKind: f.SourceKind,
+		}
+	}
+	sess := f.sessions[id]
+	if sess.Finalized {
+		return Session{}, fmt.Errorf("%w: %s", ErrSessionFinalized, id)
+	}
+	sess.Status, sess.Lifecycle, sess.Epoch = body.Status, body.Lifecycle, body.Epoch
+	sess.Version = body.SourceVersion
+	sess.ETag = payloadDigest(*sess)
+	f.keys[key] = fakeKey{digest: digest, id: id}
+	f.Calls = append(f.Calls, OpUpsertRunSession)
+	return *sess, nil
+}
+
+// GetSession implements API.
+func (f *Fake) GetSession(_ context.Context, sessionTeamID string) (Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sess, ok := f.sessions[sessionTeamID]
+	if !ok {
+		return Session{}, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	f.Calls = append(f.Calls, OpGetSession)
+	return *sess, nil
+}
+
+// FinalizeSession implements API. Finalize is one-way and idempotent.
+func (f *Fake) FinalizeSession(_ context.Context, sessionTeamID, key string) (Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return Session{}, err
+	}
+	sess, ok := f.sessions[sessionTeamID]
+	if !ok {
+		return Session{}, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	if key == "" {
+		return Session{}, ErrMissingKey
+	}
+	sess.Finalized = true
+	sess.Lifecycle = LifecycleFinal
+	sess.ETag = payloadDigest(*sess)
+	f.Calls = append(f.Calls, OpFinalizeSession)
+	return *sess, nil
+}
+
+// CreateTranscriptRecord implements API.
+func (f *Fake) CreateTranscriptRecord(_ context.Context, sessionTeamID string, body TranscriptRecordIngest, key string) (TranscriptRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return TranscriptRecord{}, err
+	}
+	sess, ok := f.sessions[sessionTeamID]
+	if !ok {
+		return TranscriptRecord{}, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	digest := payloadDigest(body)
+	if id, hit, err := f.replay(key, digest); err != nil {
+		return TranscriptRecord{}, err
+	} else if hit {
+		for _, r := range f.records[sessionTeamID] {
+			if r.ID == id {
+				f.Calls = append(f.Calls, OpCreateTranscriptRecord+" replay")
+				return r, nil
+			}
+		}
+	}
+	if sess.Finalized {
+		return TranscriptRecord{}, fmt.Errorf("%w: %s", ErrSessionFinalized, sessionTeamID)
+	}
+	id := f.mint("rec")
+	status := "missing"
+	if body.Text != "" {
+		status = "available"
+		f.text[id] = body.Text
+	} else if body.ContentRef != "" {
+		status = "missing"
+	}
+	rec := TranscriptRecord{
+		ID: id, SessionID: sessionTeamID, SourceMessageID: body.SourceMessageID,
+		SourceID: f.SourceID, SourceKind: f.SourceKind,
+		Role: body.Role, Author: body.Author, OccurredAt: body.OccurredAt,
+		Ordinal: body.Ordinal, Epoch: body.Epoch, Version: body.SourceVersion,
+		ContentStatus: status,
+	}
+	rec.ETag = payloadDigest(rec)
+	f.records[sessionTeamID] = append(f.records[sessionTeamID], rec)
+	f.keys[key] = fakeKey{digest: digest, id: id}
+	f.Calls = append(f.Calls, OpCreateTranscriptRecord)
+	return rec, nil
+}
+
+// ListTranscriptRecords implements API.
+func (f *Fake) ListTranscriptRecords(_ context.Context, sessionTeamID string) ([]TranscriptRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.sessions[sessionTeamID]; !ok {
+		return nil, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	f.Calls = append(f.Calls, OpListTranscriptRecords)
+	return append([]TranscriptRecord(nil), f.records[sessionTeamID]...), nil
+}
+
+// GetSessionTranscript implements API.
+func (f *Fake) GetSessionTranscript(_ context.Context, sessionTeamID string) ([]TranscriptItem, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.sessions[sessionTeamID]; !ok {
+		return nil, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	items := make([]TranscriptItem, 0, len(f.records[sessionTeamID]))
+	for _, r := range f.records[sessionTeamID] {
+		items = append(items, TranscriptItem{
+			RecordID: r.ID, SourceMessageID: r.SourceMessageID, Role: r.Role,
+			Author: r.Author, Ordinal: r.Ordinal, ContentStatus: r.ContentStatus,
+			Text: f.text[r.ID],
+		})
+	}
+	f.Calls = append(f.Calls, OpGetSessionTranscript)
+	return items, nil
+}

--- a/pkg/cityneutral/mapping.go
+++ b/pkg/cityneutral/mapping.go
@@ -1,0 +1,463 @@
+package cityneutral
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CityRun is the City-native run as this adapter reads it. Every field here is
+// source-native: none of it is authority on the neutral side, and the neutral
+// Team ID is absent by construction — there is no field on this struct that
+// could carry one.
+type CityRun struct {
+	// RunID is City's own stable run identifier. It becomes source_entity_id,
+	// which is a source-native ID, NOT a neutral one.
+	RunID   string
+	Status  string
+	Started time.Time
+	Ended   *time.Time
+	// ProjectID and IssueID are source-native scope refs.
+	ProjectID string
+	IssueID   string
+	// Version is City's monotonic revision of this run. It drives
+	// source_version, so a re-read that changed nothing sends nothing new.
+	Version uint64
+	// Rig, Formula and City are City-shaped facts. They are display-only and
+	// gated: with DisplayPolicy off they never leave the process, and they can
+	// never reach an identity, a scope or a status field. Enforced by
+	// [Mapper.MapRun] and asserted by the neutral-authority tests.
+	Rig     string
+	Formula string
+	City    string
+}
+
+// CitySession is one City session under a run.
+type CitySession struct {
+	SessionID string
+	Status    string
+	Started   time.Time
+	Ended     *time.Time
+	Version   uint64
+	// Complete says City considers this session's input closed. It is what
+	// makes the adapter finalize, and it is one-way: a later chain that flips
+	// it back does not un-finalize anything.
+	Complete bool
+	Records  []CityRecord
+}
+
+// CityRecord is one City transcript message.
+type CityRecord struct {
+	// MessageID is City's stable per-message identity. Together with the
+	// session it is the dedup key: the same MessageID with the same payload is
+	// a replay, and with a different payload it is a refusal.
+	MessageID string
+	// Ordinal is City's position within the session, 1-based. Contiguity is
+	// checked on it, so a source that cannot produce one cannot use this
+	// adapter's ordering guarantees.
+	Ordinal uint64
+	Role    string
+	// Author is the represented author: who spoke. Never the uploader, never
+	// the source, never an authorization input.
+	Author *ContributorRef
+	At     time.Time
+	// Text is raw transcript content. It is only ever serialized onto the
+	// transcript-record route; [ScanOutbound] refuses it anywhere else.
+	Text string
+	// ContentRef is a reference to content held elsewhere, for records whose
+	// body this producer is not authorized to ship.
+	ContentRef string
+	Version    uint64
+}
+
+// CityChain is one run and its sessions, the unit [Producer.Push] operates on.
+type CityChain struct {
+	Run      CityRun
+	Sessions []CitySession
+}
+
+// Source identifies this producer to the mapper. SourceID is the enrolled
+// producer identity the server already knows; it is echoed back on reads as
+// provenance and is NOT a credential.
+type Source struct {
+	SourceID string
+	// Kind is the source class, e.g. "city". Used in the idempotency preimage
+	// so two producers with the same native IDs cannot collide.
+	Kind string
+	// Epoch is the frozen source epoch. It advances only on a declared reset,
+	// never on a restart, and the adapter refuses to guess one.
+	Epoch uint64
+}
+
+// Mapper turns a City chain into neutral request bodies.
+//
+// It holds no transport and no state: give it the same chain twice and it
+// produces byte-identical bodies, which is what makes the stable-identity
+// digest meaningful.
+type Mapper struct {
+	Source Source
+	// AllowDisplayContent gates free-form display egress (titles built from
+	// City rig/formula names). Default off: an ungated producer would leak
+	// tenant-shaped strings into a neutral record on nothing but a code path.
+	AllowDisplayContent bool
+	// AllowRawContent gates shipping message text at all. Off means every
+	// record goes as a reference, which is the mode a City with no signed
+	// content policy runs in.
+	AllowRawContent bool
+}
+
+// statusMap is the City→neutral status projection. It is closed on the neutral
+// side: an unrecognized City status becomes StatusUnknown rather than being
+// passed through, because the neutral vocabulary is not City's to extend.
+var statusMap = map[string]Status{
+	"pending":   StatusPending,
+	"queued":    StatusPending,
+	"running":   StatusRunning,
+	"active":    StatusRunning,
+	"succeeded": StatusSucceeded,
+	"done":      StatusSucceeded,
+	"failed":    StatusFailed,
+	"error":     StatusFailed,
+	"cancelled": StatusCancelled, //nolint:misspell // frozen wire value of the neutral contract
+	"canceled":  StatusCancelled,
+}
+
+// roleMap is the City→neutral role projection, closed the same way.
+var roleMap = map[string]Role{
+	"user":      RoleUser,
+	"human":     RoleUser,
+	"assistant": RoleAssistant,
+	"agent":     RoleAssistant,
+	"system":    RoleSystem,
+	"tool":      RoleTool,
+}
+
+var contributorKinds = map[string]bool{
+	"human": true, "agent": true, "worker": true, "model": true, "system": true,
+}
+
+// secretLocatorPatterns mirror the server's refusal list. Screening at the
+// producer is not redundant: it turns a leak into a local error with a source
+// field name attached, instead of a 4xx an operator has to correlate.
+var secretLocatorPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)^arn:aws:secretsmanager:`),
+	regexp.MustCompile(`(?i)^arn:aws:kms:`),
+	regexp.MustCompile(`(?i)^(vault|secret)://`),
+	regexp.MustCompile(`(?i)^projects/[^/]+/secrets/`),
+	regexp.MustCompile(`(?i)\b(AKIA|ASIA)[0-9A-Z]{16}\b`),
+	regexp.MustCompile(`(?i)\b(sk|rk)-[A-Za-z0-9]{20,}`),
+	regexp.MustCompile(`(?i)^(gh[pousr]|xox[baprs])_[A-Za-z0-9]{10,}`),
+	regexp.MustCompile(`(?i)-----BEGIN [A-Z ]*PRIVATE KEY-----`),
+	regexp.MustCompile(`(?i)[?&](access_token|api_key|apikey|secret|password|signature)=`),
+	regexp.MustCompile(`(?i)^(bearer|basic) [A-Za-z0-9+/._-]{16,}`),
+}
+
+// SecretLocator reports whether s carries credential evidence.
+func SecretLocator(s string) bool {
+	for _, re := range secretLocatorPatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateNativeID(field, v string) error {
+	switch {
+	case strings.TrimSpace(v) == "":
+		return fmt.Errorf("%w: %s is required", ErrInvalidChain, field)
+	case len(v) > maxSourceNativeIDLen:
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidChain, field, maxSourceNativeIDLen)
+	case strings.ContainsAny(v, "\x00\n\r"):
+		return fmt.Errorf("%w: %s carries a control character", ErrInvalidChain, field)
+	case SecretLocator(v):
+		return fmt.Errorf("%w: %s", ErrCredentialLeak, field)
+	}
+	return nil
+}
+
+func (m Mapper) validateSource() error {
+	if err := validateNativeID("source.source_id", m.Source.SourceID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(m.Source.Kind) == "" {
+		return fmt.Errorf("%w: source.kind is required", ErrInvalidChain)
+	}
+	if m.Source.Epoch == 0 {
+		return fmt.Errorf("%w: source.epoch is required and starts at 1", ErrInvalidChain)
+	}
+	return nil
+}
+
+// display builds the gated display title. City facts reach a neutral record
+// only through here, only as a title, and only with the gate open.
+func (m Mapper) display(parts ...string) string {
+	if !m.AllowDisplayContent {
+		return ""
+	}
+	kept := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || SecretLocator(p) {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	title := strings.Join(kept, " / ")
+	if len(title) > maxDisplayTitleLength {
+		title = title[:maxDisplayTitleLength]
+	}
+	return title
+}
+
+// MapRun projects a City run onto the neutral upsert body.
+//
+// The neutral-authority rule lives here: rig, formula and city name are
+// arguments to [Mapper.display] and to nothing else. source_entity_id is the
+// City run ID and project/issue are City's own scope refs; none of them is a
+// neutral ID, and the neutral ID is not an input to this function at all.
+func (m Mapper) MapRun(run CityRun) (Upsert, error) {
+	if err := m.validateSource(); err != nil {
+		return Upsert{}, err
+	}
+	if err := validateNativeID("run.run_id", run.RunID); err != nil {
+		return Upsert{}, err
+	}
+	if run.Version == 0 {
+		return Upsert{}, fmt.Errorf("%w: run.version is required and starts at 1", ErrInvalidChain)
+	}
+	if run.Started.IsZero() {
+		return Upsert{}, fmt.Errorf("%w: run.started is required", ErrInvalidChain)
+	}
+	for field, v := range map[string]string{"run.project_id": run.ProjectID, "run.issue_id": run.IssueID} {
+		if v == "" {
+			continue
+		}
+		if err := validateNativeID(field, v); err != nil {
+			return Upsert{}, err
+		}
+	}
+	// A City fact that has managed to look like a neutral Team ID is still not
+	// one, and the cheapest place to say so is before it is serialized.
+	for field, v := range map[string]string{"run.rig": run.Rig, "run.formula": run.Formula, "run.city": run.City} {
+		if looksNeutralID(v) {
+			return Upsert{}, fmt.Errorf("%w: %s", ErrNeutralAuthority, field)
+		}
+	}
+	up := Upsert{
+		SourceEntityID: run.RunID,
+		SourceVersion:  run.Version,
+		Epoch:          m.Source.Epoch,
+		Status:         mapStatus(run.Status),
+		Lifecycle:      LifecyclePartial,
+		StartedAt:      run.Started.UTC(),
+		ProjectID:      run.ProjectID,
+		IssueID:        run.IssueID,
+		Title:          m.display(run.Rig, run.Formula),
+		Coverage:       CoverageKnown,
+	}
+	if run.Ended != nil {
+		e := run.Ended.UTC()
+		if e.Before(up.StartedAt) {
+			return Upsert{}, fmt.Errorf("%w: run.ended precedes run.started", ErrInvalidChain)
+		}
+		up.EndedAt = &e
+	}
+	return up, nil
+}
+
+// MapSession projects a City session onto the neutral upsert body. The run it
+// belongs to is not in the body: it comes from the path, so a session can never
+// claim a run the credential does not reach.
+func (m Mapper) MapSession(sess CitySession) (Upsert, error) {
+	if err := m.validateSource(); err != nil {
+		return Upsert{}, err
+	}
+	if err := validateNativeID("session.session_id", sess.SessionID); err != nil {
+		return Upsert{}, err
+	}
+	if sess.Version == 0 {
+		return Upsert{}, fmt.Errorf("%w: session.version is required and starts at 1", ErrInvalidChain)
+	}
+	if sess.Started.IsZero() {
+		return Upsert{}, fmt.Errorf("%w: session.started is required", ErrInvalidChain)
+	}
+	up := Upsert{
+		SourceEntityID: sess.SessionID,
+		SourceVersion:  sess.Version,
+		Epoch:          m.Source.Epoch,
+		Status:         mapStatus(sess.Status),
+		Lifecycle:      LifecyclePartial,
+		StartedAt:      sess.Started.UTC(),
+		Coverage:       CoverageKnown,
+	}
+	if sess.Ended != nil {
+		e := sess.Ended.UTC()
+		if e.Before(up.StartedAt) {
+			return Upsert{}, fmt.Errorf("%w: session.ended precedes session.started", ErrInvalidChain)
+		}
+		up.EndedAt = &e
+	}
+	return up, nil
+}
+
+// MapRecord projects a City message onto the transcript ingest body.
+//
+// Author is the represented author and travels as attribution. The uploader is
+// the credential the request rides on and appears nowhere in this body; the
+// source is [Source.SourceID] and is likewise server-side provenance, not a
+// body field. Keeping all three apart is the whole point of this function.
+func (m Mapper) MapRecord(rec CityRecord) (TranscriptRecordIngest, error) {
+	if err := m.validateSource(); err != nil {
+		return TranscriptRecordIngest{}, err
+	}
+	if err := validateNativeID("record.message_id", rec.MessageID); err != nil {
+		return TranscriptRecordIngest{}, err
+	}
+	if rec.Ordinal == 0 {
+		return TranscriptRecordIngest{}, fmt.Errorf("%w: record.ordinal is required and starts at 1", ErrInvalidChain)
+	}
+	if rec.At.IsZero() {
+		return TranscriptRecordIngest{}, fmt.Errorf("%w: record.at is required", ErrInvalidChain)
+	}
+	version := rec.Version
+	if version == 0 {
+		version = 1
+	}
+	ord := rec.Ordinal
+	in := TranscriptRecordIngest{
+		SourceMessageID: rec.MessageID,
+		SourceVersion:   version,
+		Epoch:           m.Source.Epoch,
+		Ordinal:         &ord,
+		Role:            mapRole(rec.Role),
+		OccurredAt:      rec.At.UTC(),
+		Coverage:        CoverageKnown,
+	}
+	if rec.Author != nil {
+		if !contributorKinds[rec.Author.Kind] {
+			return TranscriptRecordIngest{}, fmt.Errorf("%w: unknown author kind %q", ErrInvalidChain, rec.Author.Kind)
+		}
+		if err := validateNativeID("record.author.ref", rec.Author.Ref); err != nil {
+			return TranscriptRecordIngest{}, err
+		}
+		author := *rec.Author
+		in.Author = &author
+	}
+	switch {
+	case m.AllowRawContent && rec.Text != "":
+		if SecretLocator(rec.Text) {
+			return TranscriptRecordIngest{}, fmt.Errorf("%w: record.text", ErrCredentialLeak)
+		}
+		in.Text = rec.Text
+	case rec.ContentRef != "":
+		if err := validateNativeID("record.content_ref", rec.ContentRef); err != nil {
+			return TranscriptRecordIngest{}, err
+		}
+		in.ContentRef = rec.ContentRef
+		in.Coverage = CoveragePartial
+	case rec.Text != "":
+		// Content exists but this producer is not authorized to ship it. The
+		// record still goes, because a transcript with a known-withheld turn is
+		// truer than a transcript with a missing one, and `unavailable` is the
+		// server's word for exactly that.
+		in.Coverage = CoverageUnavailable
+	}
+	return in, nil
+}
+
+func mapStatus(s string) Status {
+	if v, ok := statusMap[strings.ToLower(strings.TrimSpace(s))]; ok {
+		return v
+	}
+	return StatusUnknown
+}
+
+func mapRole(r string) Role {
+	if v, ok := roleMap[strings.ToLower(strings.TrimSpace(r))]; ok {
+		return v
+	}
+	return RoleUnknown
+}
+
+// neutralIDPattern is the server's Team ID shape. City strings that match it
+// are refused where they would be mistaken for one.
+var neutralIDPattern = regexp.MustCompile(`^(run|ses|rec)_[0-9a-z]{16,}$`)
+
+func looksNeutralID(v string) bool { return neutralIDPattern.MatchString(strings.TrimSpace(v)) }
+
+// forbiddenBodyFields are members no request body of this adapter may carry.
+// They are the fields that would let a producer assert something only the
+// server may decide: ownership, the uploader, the tenant, or the neutral ID.
+var forbiddenBodyFields = map[string]bool{
+	"id": true, "run_id": true, "session_id": true, "record_id": true,
+	"uploaded_by": true, "uploader": true, "uploader_id": true,
+	"tenant": true, "tenant_id": true, "workspace": true, "workspace_id": true,
+	"source_id": true, "key_id": true, "actor": true, "actor_id": true,
+	"principal": true, "token": true, "authorization": true, "credential": true,
+}
+
+// ScanOutbound is the provenance-and-content scanner: it walks the serialized
+// form of a body about to be sent and refuses it if the bytes carry credential
+// evidence, an ownership assertion, or raw content on a route not authorized to
+// carry it.
+//
+// allowContent is true only for the transcript-record route. Scanning the
+// serialized form rather than the struct is deliberate: it is the bytes that
+// leave, and a future field added to a DTO is covered without anyone
+// remembering to update this function.
+func ScanOutbound(body any, allowContent bool) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("cityneutral: scan encode: %w", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return fmt.Errorf("cityneutral: scan decode: %w", err)
+	}
+	return scanObject(generic, allowContent, "")
+}
+
+func scanObject(obj map[string]any, allowContent bool, path string) error {
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		at := k
+		if path != "" {
+			at = path + "." + k
+		}
+		if forbiddenBodyFields[k] {
+			return fmt.Errorf("%w: body carries %s", ErrNeutralAuthority, at)
+		}
+		if (k == "text" || k == "content" || k == "body") && !allowContent {
+			return fmt.Errorf("%w: %s", ErrContentRoute, at)
+		}
+		switch v := obj[k].(type) {
+		case string:
+			if SecretLocator(v) {
+				return fmt.Errorf("%w: %s", ErrCredentialLeak, at)
+			}
+		case map[string]any:
+			if err := scanObject(v, allowContent, at); err != nil {
+				return err
+			}
+		case []any:
+			for i, item := range v {
+				nested, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if err := scanObject(nested, allowContent, fmt.Sprintf("%s[%d]", at, i)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cityneutral/parity_test.go
+++ b/pkg/cityneutral/parity_test.go
@@ -1,0 +1,294 @@
+package cityneutral
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+var t0 = time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+func citySource() Source {
+	return Source{SourceID: "gc-city-01", Kind: "city", Epoch: 1}
+}
+
+func sampleChain() CityChain {
+	end := t0.Add(9 * time.Minute)
+	return CityChain{
+		Run: CityRun{
+			RunID: "city-run-7", Status: "succeeded", Started: t0, Ended: &end,
+			ProjectID: "proj-a", IssueID: "bd-1", Version: 3,
+			Rig: "rig-alpha", Formula: "formula-bravo", City: "sf",
+		},
+		Sessions: []CitySession{{
+			SessionID: "city-sess-1", Status: "succeeded", Started: t0, Ended: &end,
+			Version: 2, Complete: true,
+			Records: []CityRecord{
+				{
+					MessageID: "m1", Ordinal: 1, Role: "user", At: t0.Add(time.Minute),
+					Author: &ContributorRef{Kind: "human", Ref: "u-42"}, Text: "kick it off",
+				},
+				{
+					MessageID: "m2", Ordinal: 2, Role: "agent", At: t0.Add(2 * time.Minute),
+					Author: &ContributorRef{Kind: "agent", Ref: "worker-9"}, Text: "on it",
+				},
+				{MessageID: "m3", Ordinal: 3, Role: "tool", At: t0.Add(3 * time.Minute), ContentRef: "blob-3"},
+			},
+		}},
+	}
+}
+
+func newCityProducer(t *testing.T, f *Fake, mut func(*Mapper)) *Producer {
+	t.Helper()
+	m := Mapper{Source: citySource(), AllowRawContent: true}
+	if mut != nil {
+		mut(&m)
+	}
+	p, err := NewProducer(f, m, NewMemoryStore())
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	return p
+}
+
+// customUpload is a producer with no City in the picture: it builds the neutral
+// bodies from its own domain and mints its own keys. It exists so the parity
+// assertion compares City against a real second implementation rather than
+// against the City adapter wearing a different hat.
+func customUpload(t *testing.T, api API) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	end := t0.Add(9 * time.Minute)
+	run, err := api.UpsertRun(ctx, Upsert{
+		SourceEntityID: "orch-run-7", SourceVersion: 3, Epoch: 1,
+		Status: StatusSucceeded, Lifecycle: LifecyclePartial,
+		StartedAt: t0, EndedAt: &end, ProjectID: "proj-a", IssueID: "bd-1",
+		Coverage: CoverageKnown,
+	}, "11111111-1111-5111-8111-111111111111")
+	if err != nil {
+		t.Fatalf("custom UpsertRun: %v", err)
+	}
+	sess, err := api.UpsertRunSession(ctx, run.ID, Upsert{
+		SourceEntityID: "orch-sess-1", SourceVersion: 2, Epoch: 1,
+		Status: StatusSucceeded, Lifecycle: LifecyclePartial,
+		StartedAt: t0, EndedAt: &end, Coverage: CoverageKnown,
+	}, "22222222-2222-5222-8222-222222222222")
+	if err != nil {
+		t.Fatalf("custom UpsertRunSession: %v", err)
+	}
+	ords := []uint64{1, 2, 3}
+	bodies := []TranscriptRecordIngest{
+		{
+			SourceMessageID: "a1", SourceVersion: 1, Epoch: 1, Ordinal: &ords[0], Role: RoleUser,
+			Author: &ContributorRef{Kind: "human", Ref: "u-42"}, OccurredAt: t0.Add(time.Minute),
+			Text: "kick it off", Coverage: CoverageKnown,
+		},
+		{
+			SourceMessageID: "a2", SourceVersion: 1, Epoch: 1, Ordinal: &ords[1], Role: RoleAssistant,
+			Author: &ContributorRef{Kind: "agent", Ref: "worker-9"}, OccurredAt: t0.Add(2 * time.Minute),
+			Text: "on it", Coverage: CoverageKnown,
+		},
+		{
+			SourceMessageID: "a3", SourceVersion: 1, Epoch: 1, Ordinal: &ords[2], Role: RoleTool,
+			OccurredAt: t0.Add(3 * time.Minute), ContentRef: "blob-3", Coverage: CoveragePartial,
+		},
+	}
+	for i, b := range bodies {
+		key := []string{
+			"33333333-3333-5333-8333-333333333331",
+			"33333333-3333-5333-8333-333333333332",
+			"33333333-3333-5333-8333-333333333333",
+		}[i]
+		if _, err := api.CreateTranscriptRecord(ctx, sess.ID, b, key); err != nil {
+			t.Fatalf("custom CreateTranscriptRecord %d: %v", i, err)
+		}
+	}
+	if _, err := api.FinalizeSession(ctx, sess.ID, "44444444-4444-5444-8444-444444444444"); err != nil {
+		t.Fatalf("custom FinalizeSession: %v", err)
+	}
+	return run.ID, sess.ID
+}
+
+type shape struct {
+	runStatus     Status
+	runLifecycle  Lifecycle
+	runFinalized  bool
+	sessStatus    Status
+	sessLifecycle Lifecycle
+	sessFinalized bool
+	sessLinksRun  bool
+	roles         []Role
+	authors       []string
+	ordinals      []uint64
+	contentStatus []string
+	transcript    []string
+}
+
+func readShape(t *testing.T, api API, runID, sessID string) shape {
+	t.Helper()
+	ctx := context.Background()
+	run, err := api.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	sess, err := api.GetSession(ctx, sessID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	recs, err := api.ListTranscriptRecords(ctx, sessID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	items, err := api.GetSessionTranscript(ctx, sessID)
+	if err != nil {
+		t.Fatalf("GetSessionTranscript: %v", err)
+	}
+	s := shape{
+		runStatus: run.Status, runLifecycle: run.Lifecycle, runFinalized: run.Finalized,
+		sessStatus: sess.Status, sessLifecycle: sess.Lifecycle, sessFinalized: sess.Finalized,
+		sessLinksRun: sess.RunID == run.ID,
+	}
+	for _, r := range recs {
+		s.roles = append(s.roles, r.Role)
+		author := ""
+		if r.Author != nil {
+			author = r.Author.Kind + ":" + r.Author.Ref
+		}
+		s.authors = append(s.authors, author)
+		s.ordinals = append(s.ordinals, *r.Ordinal)
+		s.contentStatus = append(s.contentStatus, r.ContentStatus)
+	}
+	for _, it := range items {
+		s.transcript = append(s.transcript, string(it.Role)+"|"+it.Text)
+	}
+	return s
+}
+
+func eq(t *testing.T, label string, got, want shape) {
+	t.Helper()
+	if got.runStatus != want.runStatus || got.runLifecycle != want.runLifecycle || got.runFinalized != want.runFinalized {
+		t.Errorf("%s: run shape differs: got %+v want %+v", label, got, want)
+	}
+	if got.sessStatus != want.sessStatus || got.sessLifecycle != want.sessLifecycle ||
+		got.sessFinalized != want.sessFinalized || got.sessLinksRun != want.sessLinksRun {
+		t.Errorf("%s: session shape differs: got %+v want %+v", label, got, want)
+	}
+	for _, pair := range []struct {
+		name      string
+		got, want []string
+	}{
+		{name: "authors", got: got.authors, want: want.authors},
+		{name: "content_status", got: got.contentStatus, want: want.contentStatus},
+		{name: "transcript", got: got.transcript, want: want.transcript},
+	} {
+		if len(pair.got) != len(pair.want) {
+			t.Errorf("%s: %s length %d != %d", label, pair.name, len(pair.got), len(pair.want))
+			continue
+		}
+		for i := range pair.got {
+			if pair.got[i] != pair.want[i] {
+				t.Errorf("%s: %s[%d] = %q, want %q", label, pair.name, i, pair.got[i], pair.want[i])
+			}
+		}
+	}
+	if len(got.roles) != len(want.roles) {
+		t.Fatalf("%s: role count %d != %d", label, len(got.roles), len(want.roles))
+	}
+	for i := range got.roles {
+		if got.roles[i] != want.roles[i] {
+			t.Errorf("%s: role[%d] = %q, want %q", label, i, got.roles[i], want.roles[i])
+		}
+		if got.ordinals[i] != want.ordinals[i] {
+			t.Errorf("%s: ordinal[%d] = %d, want %d", label, i, got.ordinals[i], want.ordinals[i])
+		}
+	}
+}
+
+// AC1 happy path: a complete City chain links and retrieves through the public
+// operations, and the records it produces are indistinguishable in shape from a
+// custom producer's — no field is City-required.
+func TestCityVersusCustomProducerParity(t *testing.T) {
+	ctx := context.Background()
+
+	cityFake := NewFake("svc-city@tenant", "gc-city-01", "city")
+	p := newCityProducer(t, cityFake, nil)
+	res, err := p.Push(ctx, sampleChain())
+	if err != nil {
+		t.Fatalf("city Push: %v", err)
+	}
+	if res.Accepted != 3 || len(res.Sessions) != 1 || !res.Sessions[0].Finalized {
+		t.Fatalf("city Push result = %+v, want 3 accepted and a finalized session", res)
+	}
+	cityShape := readShape(t, cityFake, res.RunTeamID, res.Sessions[0].TeamID)
+
+	customFake := NewFake("svc-orch@tenant", "orchestrator-9", "custom")
+	customRun, customSess := customUpload(t, customFake)
+	customShape := readShape(t, customFake, customRun, customSess)
+
+	eq(t, "city-vs-custom", cityShape, customShape)
+
+	// The neutral IDs are server-minted on both sides and carry no source
+	// spelling: a reader cannot tell which producer wrote the record.
+	if res.RunTeamID == "city-run-7" || res.Sessions[0].TeamID == "city-sess-1" {
+		t.Fatalf("neutral IDs echoed City native IDs: %q / %q", res.RunTeamID, res.Sessions[0].TeamID)
+	}
+	if customRun[:4] != res.RunTeamID[:4] {
+		t.Fatalf("neutral run id prefixes differ by producer: %q vs %q", customRun, res.RunTeamID)
+	}
+}
+
+// AC1 edge: City, rig and formula fields cannot become neutral authority.
+func TestCityFactsCannotBecomeNeutralAuthority(t *testing.T) {
+	chain := sampleChain()
+
+	// Gate closed (the default): no City-shaped display string leaves at all.
+	closed, err := (Mapper{Source: citySource()}).MapRun(chain.Run)
+	if err != nil {
+		t.Fatalf("MapRun: %v", err)
+	}
+	if closed.Title != "" {
+		t.Fatalf("display gate closed but title = %q", closed.Title)
+	}
+
+	// Gate open: the City facts reach exactly one non-authoritative field.
+	open, err := (Mapper{Source: citySource(), AllowDisplayContent: true}).MapRun(chain.Run)
+	if err != nil {
+		t.Fatalf("MapRun: %v", err)
+	}
+	if open.Title != "rig-alpha / formula-bravo" {
+		t.Fatalf("title = %q", open.Title)
+	}
+	if open.SourceEntityID != "city-run-7" || open.ProjectID != "proj-a" || open.IssueID != "bd-1" {
+		t.Fatalf("City facts displaced a source-native field: %+v", open)
+	}
+
+	// A City fact spelled like a neutral Team ID is refused rather than
+	// carried: the adapter never lets City name a neutral identity.
+	drift := chain.Run
+	drift.Rig = "run_00000000000000ff"
+	if _, err := (Mapper{Source: citySource(), AllowDisplayContent: true}).MapRun(drift); !errors.Is(err, ErrNeutralAuthority) {
+		t.Fatalf("neutral-shaped rig: err = %v, want ErrNeutralAuthority", err)
+	}
+
+	// The session body carries no run reference: the link comes from the path
+	// and the credential, so a City session cannot claim a foreign run.
+	sessBody, err := (Mapper{Source: citySource()}).MapSession(chain.Sessions[0])
+	if err != nil {
+		t.Fatalf("MapSession: %v", err)
+	}
+	if err := ScanOutbound(sessBody, false); err != nil {
+		t.Fatalf("ScanOutbound(session): %v", err)
+	}
+}
+
+// A neutral record must be valid with no City in the picture: the custom
+// producer's chain reads back complete on every operation this adapter uses.
+func TestNeutralRecordsValidWithoutCity(t *testing.T) {
+	f := NewFake("svc-orch@tenant", "orchestrator-9", "custom")
+	runID, sessID := customUpload(t, f)
+	s := readShape(t, f, runID, sessID)
+	if !s.sessFinalized || !s.sessLinksRun || len(s.roles) != 3 || len(s.transcript) != 3 {
+		t.Fatalf("custom-only chain incomplete: %+v", s)
+	}
+}

--- a/pkg/cityneutral/producer.go
+++ b/pkg/cityneutral/producer.go
@@ -1,0 +1,403 @@
+package cityneutral
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// SessionState is the acknowledged frontier of one session.
+//
+// Frontier is the highest ordinal the SERVER acknowledged, and it only ever
+// advances contiguously. Digests holds the payload digest of each acknowledged
+// record so a later replay can be told apart from a rewrite — the checkpoint is
+// what makes "changed replay" detectable at all.
+type SessionState struct {
+	TeamID    string            `json:"team_id"`
+	Version   uint64            `json:"version"`
+	Finalized bool              `json:"finalized"`
+	Frontier  uint64            `json:"frontier"`
+	Digests   map[uint64]string `json:"digests"`
+	MessageID map[uint64]string `json:"message_id"`
+}
+
+// State is one City run's checkpoint.
+type State struct {
+	Epoch      uint64                   `json:"epoch"`
+	SourceID   string                   `json:"source_id"`
+	RunTeamID  string                   `json:"run_team_id"`
+	RunVersion uint64                   `json:"run_version"`
+	Sessions   map[string]*SessionState `json:"sessions"`
+}
+
+func (s *State) session(sourceSessionID string) *SessionState {
+	if s.Sessions == nil {
+		s.Sessions = map[string]*SessionState{}
+	}
+	st, ok := s.Sessions[sourceSessionID]
+	if !ok {
+		st = &SessionState{Digests: map[uint64]string{}, MessageID: map[uint64]string{}}
+		s.Sessions[sourceSessionID] = st
+	}
+	if st.Digests == nil {
+		st.Digests = map[uint64]string{}
+	}
+	if st.MessageID == nil {
+		st.MessageID = map[uint64]string{}
+	}
+	return st
+}
+
+// Store persists checkpoints across restarts. It is an interface because the
+// durable implementation is City's business; the adapter only needs load and
+// save to be atomic with respect to each other.
+type Store interface {
+	Load(ctx context.Context, key string) (State, bool, error)
+	Save(ctx context.Context, key string, st State) error
+}
+
+// MemoryStore is an in-process Store. It is safe for concurrent use and is what
+// tests and a single-shot export run on.
+type MemoryStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+// NewMemoryStore returns an empty in-process Store.
+func NewMemoryStore() *MemoryStore { return &MemoryStore{m: map[string][]byte{}} }
+
+// Load implements Store.
+func (s *MemoryStore) Load(_ context.Context, key string) (State, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw, ok := s.m[key]
+	if !ok {
+		return State{}, false, nil
+	}
+	var st State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return State{}, false, fmt.Errorf("cityneutral: decode checkpoint %q: %w", key, err)
+	}
+	return st, true, nil
+}
+
+// Save implements Store. It round-trips through JSON so a caller cannot hold a
+// reference into stored state and mutate it behind the producer's back.
+func (s *MemoryStore) Save(_ context.Context, key string, st State) error {
+	raw, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("cityneutral: encode checkpoint %q: %w", key, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = map[string][]byte{}
+	}
+	s.m[key] = raw
+	return nil
+}
+
+// SessionResult reports what one session's push did.
+type SessionResult struct {
+	SourceSessionID string
+	TeamID          string
+	Accepted        int
+	Skipped         int
+	Finalized       bool
+}
+
+// Result reports what one push did. It is returned even on error, so a caller
+// that stops on a refusal still learns how far the chain got.
+type Result struct {
+	RunTeamID string
+	Sessions  []SessionResult
+	Accepted  int
+	Skipped   int
+}
+
+// Producer maps a City chain onto neutral resources and advances a checkpoint
+// only over acknowledged, contiguous records.
+type Producer struct {
+	API    API
+	Mapper Mapper
+	Store  Store
+}
+
+// NewProducer validates its wiring up front: a producer missing a store would
+// look like it worked and silently re-upload the world on restart.
+func NewProducer(api API, mapper Mapper, store Store) (*Producer, error) {
+	if api == nil {
+		return nil, errors.New("cityneutral: API is required")
+	}
+	if store == nil {
+		return nil, errors.New("cityneutral: Store is required")
+	}
+	if err := mapper.validateSource(); err != nil {
+		return nil, err
+	}
+	return &Producer{API: api, Mapper: mapper, Store: store}, nil
+}
+
+// CheckpointKey is the stable checkpoint identity of one City run under one
+// source. It excludes the epoch: a reset must LAND on the same key so the old
+// frontier is visibly superseded rather than orphaned under a new one.
+func CheckpointKey(source Source, cityRunID string) string {
+	return source.Kind + "/" + source.SourceID + "/" + cityRunID
+}
+
+// Push maps, uploads, checkpoints and finalizes one chain.
+//
+// It advances only on acknowledgement. Every refusal returns the partial result
+// with the checkpoint already saved at the last acknowledged record, so a
+// restart resumes at the next accepted record and never re-sends an accepted
+// one.
+func (p *Producer) Push(ctx context.Context, chain CityChain) (Result, error) {
+	key := CheckpointKey(p.Mapper.Source, chain.Run.RunID)
+	st, _, err := p.Store.Load(ctx, key)
+	if err != nil {
+		return Result{}, err
+	}
+	switch {
+	case st.Epoch == 0:
+		st.Epoch = p.Mapper.Source.Epoch
+		st.SourceID = p.Mapper.Source.SourceID
+	case p.Mapper.Source.Epoch > st.Epoch:
+		// A declared reset. The previous frontier belongs to the previous
+		// epoch and must not gate the new one, so the checkpoint restarts —
+		// the server keeps the old records; this producer simply stops
+		// claiming to have sent them.
+		st = State{Epoch: p.Mapper.Source.Epoch, SourceID: p.Mapper.Source.SourceID}
+	case p.Mapper.Source.Epoch < st.Epoch:
+		return Result{}, fmt.Errorf("%w: source epoch %d is behind checkpoint epoch %d",
+			ErrIdentityDrift, p.Mapper.Source.Epoch, st.Epoch)
+	}
+	if st.SourceID != "" && st.SourceID != p.Mapper.Source.SourceID {
+		return Result{}, fmt.Errorf("%w: checkpoint belongs to source %q", ErrIdentityDrift, st.SourceID)
+	}
+
+	res := Result{}
+	runBody, err := p.Mapper.MapRun(chain.Run)
+	if err != nil {
+		return res, err
+	}
+	if err := ScanOutbound(runBody, false); err != nil {
+		return res, err
+	}
+	run, err := p.API.UpsertRun(ctx, runBody, idempotencyKey(p.Mapper.Source, KindRun, chain.Run.RunID, runBody.SourceVersion))
+	if err != nil {
+		return res, fmt.Errorf("cityneutral: %s: %w", OpUpsertRun, err)
+	}
+	if run.ID == "" {
+		return res, fmt.Errorf("%w: server returned no neutral run id", ErrIdentityDrift)
+	}
+	if st.RunTeamID != "" && st.RunTeamID != run.ID {
+		return res, fmt.Errorf("%w: run %q was %q, server now says %q",
+			ErrIdentityDrift, chain.Run.RunID, st.RunTeamID, run.ID)
+	}
+	st.RunTeamID = run.ID
+	st.RunVersion = runBody.SourceVersion
+	res.RunTeamID = run.ID
+	if err := p.Store.Save(ctx, key, st); err != nil {
+		return res, err
+	}
+
+	for _, sess := range chain.Sessions {
+		sr, err := p.pushSession(ctx, key, &st, run.ID, sess)
+		res.Sessions = append(res.Sessions, sr)
+		res.Accepted += sr.Accepted
+		res.Skipped += sr.Skipped
+		if err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+func (p *Producer) pushSession(ctx context.Context, key string, st *State, runTeamID string, sess CitySession) (SessionResult, error) {
+	sr := SessionResult{SourceSessionID: sess.SessionID}
+	sstate := st.session(sess.SessionID)
+	sr.TeamID = sstate.TeamID
+	sr.Finalized = sstate.Finalized
+
+	body, err := p.Mapper.MapSession(sess)
+	if err != nil {
+		return sr, err
+	}
+	if err := ScanOutbound(body, false); err != nil {
+		return sr, err
+	}
+
+	// Post-finalize mutation is refused before anything is sent. A finalized
+	// session may be re-observed (same version, no new records) — that is a
+	// harmless idempotent read of City's own state — but any changed input
+	// stops this adapter rather than asking the server to rewrite final input.
+	if sstate.Finalized {
+		if body.SourceVersion > sstate.Version {
+			return sr, fmt.Errorf("%w: session %q version %d after finalize at %d",
+				ErrFinalized, sess.SessionID, body.SourceVersion, sstate.Version)
+		}
+		if err := p.assertNoNewInput(sess, sstate); err != nil {
+			return sr, err
+		}
+		sr.Skipped += len(sess.Records)
+		return sr, nil
+	}
+
+	session, err := p.API.UpsertRunSession(ctx, runTeamID, body,
+		idempotencyKey(p.Mapper.Source, KindSession, sess.SessionID, body.SourceVersion))
+	if err != nil {
+		return sr, fmt.Errorf("cityneutral: %s: %w", OpUpsertRunSession, err)
+	}
+	if session.ID == "" {
+		return sr, fmt.Errorf("%w: server returned no neutral session id", ErrIdentityDrift)
+	}
+	if sstate.TeamID != "" && sstate.TeamID != session.ID {
+		return sr, fmt.Errorf("%w: session %q was %q, server now says %q",
+			ErrIdentityDrift, sess.SessionID, sstate.TeamID, session.ID)
+	}
+	if session.RunID != runTeamID {
+		return sr, fmt.Errorf("%w: session %q links run %q, not %q",
+			ErrIdentityDrift, sess.SessionID, session.RunID, runTeamID)
+	}
+	sstate.TeamID = session.ID
+	sstate.Version = body.SourceVersion
+	sstate.Finalized = session.Finalized
+	sr.TeamID = session.ID
+	sr.Finalized = session.Finalized
+	if err := p.Store.Save(ctx, key, *st); err != nil {
+		return sr, err
+	}
+
+	// Out-of-order arrival is a source property, not a protocol violation:
+	// order the batch here and let contiguity be judged on ordinals.
+	records := append([]CityRecord(nil), sess.Records...)
+	sort.Slice(records, func(i, j int) bool { return records[i].Ordinal < records[j].Ordinal })
+
+	for _, rec := range records {
+		in, err := p.Mapper.MapRecord(rec)
+		if err != nil {
+			return sr, err
+		}
+		digest := payloadDigest(in)
+
+		if rec.Ordinal <= sstate.Frontier {
+			// Already acknowledged. Same bytes means a retry we can drop;
+			// different bytes means the source rewrote accepted input.
+			if have, ok := sstate.Digests[rec.Ordinal]; ok && have != digest {
+				return sr, fmt.Errorf("%w: session %q ordinal %d (message %q)",
+					ErrChangedReplay, sess.SessionID, rec.Ordinal, rec.MessageID)
+			}
+			if have, ok := sstate.MessageID[rec.Ordinal]; ok && have != rec.MessageID {
+				return sr, fmt.Errorf("%w: session %q ordinal %d was message %q, now %q",
+					ErrChangedReplay, sess.SessionID, rec.Ordinal, have, rec.MessageID)
+			}
+			sr.Skipped++
+			continue
+		}
+		if rec.Ordinal != sstate.Frontier+1 {
+			return sr, fmt.Errorf("%w: session %q expected ordinal %d, got %d",
+				ErrGap, sess.SessionID, sstate.Frontier+1, rec.Ordinal)
+		}
+		if err := ScanOutbound(in, true); err != nil {
+			return sr, err
+		}
+		out, err := p.API.CreateTranscriptRecord(ctx, sstate.TeamID, in,
+			idempotencyKey(p.Mapper.Source, KindTranscriptRecord, sess.SessionID+"/"+rec.MessageID, in.SourceVersion))
+		if err != nil {
+			return sr, fmt.Errorf("cityneutral: %s: %w", OpCreateTranscriptRecord, err)
+		}
+		if out.ID == "" || out.SessionID != sstate.TeamID {
+			return sr, fmt.Errorf("%w: record %q acknowledged against session %q",
+				ErrIdentityDrift, rec.MessageID, out.SessionID)
+		}
+		sstate.Frontier = rec.Ordinal
+		sstate.Digests[rec.Ordinal] = digest
+		sstate.MessageID[rec.Ordinal] = rec.MessageID
+		sr.Accepted++
+		if err := p.Store.Save(ctx, key, *st); err != nil {
+			return sr, err
+		}
+	}
+
+	if sess.Complete && !sstate.Finalized {
+		final, err := p.API.FinalizeSession(ctx, sstate.TeamID,
+			idempotencyKey(p.Mapper.Source, kindSessionFinalize, sess.SessionID, sstate.Frontier))
+		if err != nil {
+			return sr, fmt.Errorf("cityneutral: %s: %w", OpFinalizeSession, err)
+		}
+		sstate.Finalized = final.Finalized
+		sr.Finalized = final.Finalized
+		if err := p.Store.Save(ctx, key, *st); err != nil {
+			return sr, err
+		}
+	}
+	return sr, nil
+}
+
+// assertNoNewInput refuses a finalized session that has grown or changed.
+func (p *Producer) assertNoNewInput(sess CitySession, sstate *SessionState) error {
+	for _, rec := range sess.Records {
+		if rec.Ordinal > sstate.Frontier {
+			return fmt.Errorf("%w: session %q record ordinal %d arrived after finalize",
+				ErrFinalized, sess.SessionID, rec.Ordinal)
+		}
+		if have, ok := sstate.MessageID[rec.Ordinal]; ok && have != rec.MessageID {
+			return fmt.Errorf("%w: session %q ordinal %d changed after finalize",
+				ErrFinalized, sess.SessionID, rec.Ordinal)
+		}
+		in, err := p.Mapper.MapRecord(rec)
+		if err != nil {
+			return err
+		}
+		if have, ok := sstate.Digests[rec.Ordinal]; ok && have != payloadDigest(in) {
+			return fmt.Errorf("%w: session %q ordinal %d payload changed after finalize",
+				ErrFinalized, sess.SessionID, rec.Ordinal)
+		}
+	}
+	return nil
+}
+
+// payloadDigest is the canonical digest of a request body. It is what makes a
+// replay comparable: the same City record maps to the same bytes, so a digest
+// difference is a real source change and never a serialization artifact.
+func payloadDigest(body any) string {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		// json.Marshal on these closed DTOs cannot fail; a digest that cannot
+		// be computed must not compare equal to anything.
+		return "unencodable:" + err.Error()
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// idempotencyKey derives the server's Idempotency-Key from stable source
+// identity alone.
+//
+// Deriving rather than minting is the dedup contract: a retry after a lost
+// response reuses the key and replays, while a changed payload under the same
+// key is a conflict the server refuses. Nothing volatile — no clock, no
+// attempt counter, no credential — is in the preimage, so a credential rotation
+// or a restart changes nothing about which key a record travels under. The
+// output is a v5-shaped UUID because the contract requires a UUID.
+func idempotencyKey(source Source, kind, nativeID string, version uint64) string {
+	preimage := strings.Join([]string{
+		"cityneutral/idempotency/v1",
+		source.Kind, source.SourceID,
+		fmt.Sprintf("%d", source.Epoch),
+		kind, nativeID,
+		fmt.Sprintf("%d", version),
+	}, "\x1f")
+	sum := sha256.Sum256([]byte(preimage))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(b)
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}

--- a/pkg/cityneutral/provenance_test.go
+++ b/pkg/cityneutral/provenance_test.go
@@ -1,0 +1,236 @@
+package cityneutral
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// AC3 happy path: uploader, source, represented author and tenant ownership
+// stay four distinct things on an accepted record.
+func TestUploaderSourceAndAuthorStayDistinct(t *testing.T) {
+	f := NewFake("svc-city@acme", "gc-city-01", "city")
+	p := newCityProducer(t, f, nil)
+	res, err := p.Push(context.Background(), sampleChain())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("got %d records, want 3", len(recs))
+	}
+	first := recs[0]
+	if first.SourceID != "gc-city-01" || first.SourceKind != "city" {
+		t.Fatalf("source not credential-derived: %+v", first)
+	}
+	if first.Author == nil || first.Author.Ref != "u-42" || first.Author.Kind != "human" {
+		t.Fatalf("represented author not preserved: %+v", first.Author)
+	}
+	if first.Author.Ref == f.Uploader || first.SourceID == f.Uploader {
+		t.Fatalf("uploader collapsed into author or source: uploader=%q", f.Uploader)
+	}
+	// The record with no City author keeps a nil author rather than being
+	// silently attributed to the uploader or the source.
+	if recs[2].Author != nil {
+		t.Fatalf("unauthored record acquired an author: %+v", recs[2].Author)
+	}
+}
+
+// AC3 edge: an actor or key ID cannot become the uploader, the source, or an
+// authorization input. The adapter's own claim about who spoke is attribution
+// and is carried in a body field the server treats as non-authoritative; the
+// source on the stored record comes from the credential regardless.
+func TestActorCannotBecomeUploaderOrSource(t *testing.T) {
+	f := NewFake("svc-city@acme", "gc-city-01", "city")
+	p := newCityProducer(t, f, nil)
+
+	chain := sampleChain()
+	// A City author impersonating the uploader and the enrolled source.
+	chain.Sessions[0].Records[0].Author = &ContributorRef{Kind: "human", Ref: "svc-city@acme"}
+	chain.Sessions[0].Records[1].Author = &ContributorRef{Kind: "agent", Ref: "gc-city-01"}
+
+	res, err := p.Push(context.Background(), chain)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	for i, r := range recs[:2] {
+		if r.SourceID != "gc-city-01" || r.SourceKind != "city" {
+			t.Fatalf("record %d source came from the body: %+v", i, r)
+		}
+	}
+	// Attribution that happens to spell the uploader is still only attribution:
+	// it changed no ownership field on the stored record.
+	if recs[0].SessionID != res.Sessions[0].TeamID {
+		t.Fatalf("record ownership drifted: %+v", recs[0])
+	}
+}
+
+// AC3: the outbound scanner refuses credential evidence, ownership assertions
+// and raw content outside the transcript-record route.
+func TestScanOutboundRefusals(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         map[string]any
+		allowContent bool
+		want         error
+	}{
+		{
+			name: "bearer token in a field",
+			body: map[string]any{"source_entity_id": "bearer AAAAAAAAAAAAAAAAAAAA"},
+			want: ErrCredentialLeak,
+		},
+		{
+			name: "aws secret arn nested under an author",
+			body: map[string]any{"author": map[string]any{"ref": "arn:aws:secretsmanager:us-east-1:1:secret:x"}},
+			want: ErrCredentialLeak,
+		},
+		{
+			name: "uploader asserted by the producer",
+			body: map[string]any{"uploaded_by": "svc-city@acme"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "signing key id smuggled into a body",
+			body: map[string]any{"key_id": "city-2026-07"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "tenant asserted by the producer",
+			body: map[string]any{"tenant_id": "acme"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "neutral id asserted by the producer",
+			body: map[string]any{"id": "run_00000000000000ff"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "raw content on a non-transcript route",
+			body: map[string]any{"text": "secret plan"},
+			want: ErrContentRoute,
+		},
+		{
+			name:         "raw content on the transcript route is allowed",
+			body:         map[string]any{"text": "secret plan"},
+			allowContent: true,
+			want:         nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ScanOutbound(tc.body, tc.allowContent)
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("err = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// AC3: nothing this adapter serializes carries a credential, a key id, or an
+// ownership assertion — checked on the bytes, not on the struct.
+func TestSerializedBodiesCarryNoCredentialOrOwnership(t *testing.T) {
+	m := Mapper{Source: citySource(), AllowDisplayContent: true, AllowRawContent: true}
+	chain := sampleChain()
+
+	runBody, err := m.MapRun(chain.Run)
+	if err != nil {
+		t.Fatalf("MapRun: %v", err)
+	}
+	sessBody, err := m.MapSession(chain.Sessions[0])
+	if err != nil {
+		t.Fatalf("MapSession: %v", err)
+	}
+	recBody, err := m.MapRecord(chain.Sessions[0].Records[0])
+	if err != nil {
+		t.Fatalf("MapRecord: %v", err)
+	}
+
+	forbidden := []string{
+		"uploaded_by", "uploader", "tenant", "workspace", "key_id",
+		"actor", "principal", "authorization", "credential", `"source_id"`, `"id"`,
+	}
+	for _, body := range []any{runBody, sessBody, recBody} {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		for _, f := range forbidden {
+			if strings.Contains(string(raw), f) {
+				t.Fatalf("body %s carries %q", raw, f)
+			}
+		}
+	}
+
+	// The run and session bodies carry no raw content at all; only the
+	// transcript body may, and only with the content gate open.
+	if err := ScanOutbound(runBody, false); err != nil {
+		t.Fatalf("ScanOutbound(run): %v", err)
+	}
+	if err := ScanOutbound(sessBody, false); err != nil {
+		t.Fatalf("ScanOutbound(session): %v", err)
+	}
+	if err := ScanOutbound(recBody, true); err != nil {
+		t.Fatalf("ScanOutbound(record): %v", err)
+	}
+	if err := ScanOutbound(recBody, false); !errors.Is(err, ErrContentRoute) {
+		t.Fatalf("record body on a non-content route: err = %v, want ErrContentRoute", err)
+	}
+}
+
+// AC3: with the content gate closed the text never leaves, and the record still
+// goes — a transcript with a known-withheld turn beats one with a hole in it.
+func TestContentGateWithholdsTextWithoutDroppingTheRecord(t *testing.T) {
+	f := NewFake("svc-city@acme", "gc-city-01", "city")
+	p := newCityProducer(t, f, func(m *Mapper) { m.AllowRawContent = false })
+	res, err := p.Push(context.Background(), sampleChain())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	items, err := f.GetSessionTranscript(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("GetSessionTranscript: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("got %d transcript items, want 3", len(items))
+	}
+	for i, it := range items {
+		if it.Text != "" {
+			t.Fatalf("item %d leaked text %q with the content gate closed", i, it.Text)
+		}
+		if it.ContentStatus != "missing" {
+			t.Fatalf("item %d content status = %q, want missing", i, it.ContentStatus)
+		}
+	}
+}
+
+// A City field carrying credential evidence is refused at the producer with the
+// source field named, instead of becoming a 4xx an operator has to correlate.
+func TestCredentialEvidenceInCityFieldsIsRefused(t *testing.T) {
+	m := Mapper{Source: citySource(), AllowRawContent: true}
+	chain := sampleChain()
+	chain.Run.RunID = "vault://prod/runs/7"
+	if _, err := m.MapRun(chain.Run); !errors.Is(err, ErrCredentialLeak) {
+		t.Fatalf("err = %v, want ErrCredentialLeak", err)
+	}
+
+	rec := sampleChain().Sessions[0].Records[0]
+	rec.Text = "paste this: sk-AAAAAAAAAAAAAAAAAAAAAAAA"
+	if _, err := m.MapRecord(rec); !errors.Is(err, ErrCredentialLeak) {
+		t.Fatalf("text: err = %v, want ErrCredentialLeak", err)
+	}
+}


### PR DESCRIPTION
The Gas City producer adapter for platform-neutral run, session and transcript records.

## Why this is greenfield

`API-1.8` proved Gas City produces **no** neutral run/session/transcript records over HTTP today — the only record-shaped egress is a redacted event-export batch. So this is a new producer, not a migration.

The framing that matters: City is one **optional** producer of neutral resources. Those records must be valid without it, which is why this consumes the generated public client rather than hand-rolling HTTP against `/api/v1` — the adapter has no privileged path a non-City producer lacks.

## Why this stayed its own task

The YAGNI review **rejected** merging this with `API-7.21`/`7.22`. It checked the edges and found each adapter has a *different* second prerequisite, so the split buys real staggering rather than being salami-slicing. That rejection is why this is one task and not a third of one.

Verified: `make test-fast-parallel` — **EXIT=0**, the full repo gate. That gate has rejected two branches in this program (a missing generated fixture plus an un-updated env golden, and a resource-census `fixed_sleep` increment), so it was run before claiming done rather than after a failed push.