### PR TITLE
fix(api): sort run steps into topological order (#4699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now uses `Popen` + `terminate()` + a 2s grace `wait()` + `kill()`,
   streaming output instead of buffering it. (gascity#4823)
 
+- **`GET /runs/{id}/steps` returns steps in topological (pipeline) order, not
+  arbitrary fold order.** No level of the read chain — the handler, the
+  member-bead projection, or the run projection fold — applied any sort, so
+  the Runs dashboard's Formula Graph rendered a run's steps in whatever order
+  the projection happened to yield, unreadable as a pipeline. Steps are now
+  topologically sorted on each member's real dependency edges (`Dependencies`
+  and `Needs`), with a deterministic bead-ID tiebreak for independent steps
+  and steps carrying no dependency data. (gascity#4699)
+
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/internal/api/huma_handlers_runs.go
+++ b/internal/api/huma_handlers_runs.go
@@ -275,7 +275,7 @@ func (s *Server) humaHandleRunSteps(ctx context.Context, input *RunStepsInput) (
 	}
 	runStatus := runproj.CanonicalRunStatusForLane(lane, rootPtr, countStartedMembers(fold.beads, lane.ID))
 
-	members := runMemberBeads(fold.beads, input.RunID)
+	members := topoSortRunSteps(runMemberBeads(fold.beads, input.RunID))
 	out := &RunStepsOutput{}
 	out.Body.RunID = input.RunID
 	out.Body.Steps = make([]RunStep, 0, len(members))

--- a/internal/api/huma_handlers_runs_test.go
+++ b/internal/api/huma_handlers_runs_test.go
@@ -916,6 +916,65 @@ func TestRunStepsClampsFailedRunToCanceled(t *testing.T) {
 	}
 }
 
+// runChildBeadWithNeeds is runChildBead plus a Needs list, scoped to root
+// "sps-1p12" and status "open" (the only fixture that needs step-order data
+// today — ordering is independent of step status). Kept separate from
+// runChildBead (used by many status-focused tests) so adding Needs support
+// here can't perturb their fixtures.
+func runChildBeadWithNeeds(id string, needs ...string) beads.Bead {
+	b := runChildBead(id, "sps-1p12", "open", nil)
+	b.Needs = needs
+	return b
+}
+
+// TestRunStepsEndpointReturnsTopologicalOrder is the end-to-end regression
+// guard for gascity#4699: GET /runs/{id}/steps returned steps in arbitrary
+// fold order, not the pipeline's actual dependency order. This reproduces
+// the issue's own 9-step repro (declared prep -> author-en -> translate-ro
+// -> feature-pr -> review -> gate-merge-feature -> archive-materialize ->
+// merge-archive -> land) with bead-creation (and therefore fold) order
+// scrambled relative to declaration order, matching what the issue observed
+// on a real graph.v2 run.
+func TestRunStepsEndpointReturnsTopologicalOrder(t *testing.T) {
+	root := runRootBead("sps-1p12", "sps-baseline", "open")
+	s := newRunServer(t,
+		beadCreatedEvent(1, root),
+		beadCreatedEvent(2, runChildBeadWithNeeds("sps-1p12.merge-archive", "sps-1p12.archive-materialize")),
+		beadCreatedEvent(3, runChildBeadWithNeeds("sps-1p12.author-en", "sps-1p12.prep")),
+		beadCreatedEvent(4, runChildBeadWithNeeds("sps-1p12.translate-ro", "sps-1p12.author-en")),
+		beadCreatedEvent(5, runChildBeadWithNeeds("sps-1p12.gate-merge-feature", "sps-1p12.review")),
+		beadCreatedEvent(6, runChildBeadWithNeeds("sps-1p12.archive-materialize", "sps-1p12.gate-merge-feature")),
+		beadCreatedEvent(7, runChildBeadWithNeeds("sps-1p12.feature-pr", "sps-1p12.translate-ro")),
+		beadCreatedEvent(8, runChildBeadWithNeeds("sps-1p12.land", "sps-1p12.merge-archive")),
+		beadCreatedEvent(9, runChildBeadWithNeeds("sps-1p12.review", "sps-1p12.feature-pr")),
+		beadCreatedEvent(10, runChildBeadWithNeeds("sps-1p12.prep")),
+	)
+	out, err := s.humaHandleRunSteps(context.Background(), &RunStepsInput{
+		CityScope: CityScope{CityName: "test-city"},
+		RunID:     "sps-1p12",
+	})
+	if err != nil {
+		t.Fatalf("humaHandleRunSteps error: %v", err)
+	}
+	got := make([]string, len(out.Body.Steps))
+	for i, st := range out.Body.Steps {
+		got[i] = st.ID
+	}
+	want := []string{
+		"sps-1p12.prep", "sps-1p12.author-en", "sps-1p12.translate-ro", "sps-1p12.feature-pr",
+		"sps-1p12.review", "sps-1p12.gate-merge-feature", "sps-1p12.archive-materialize",
+		"sps-1p12.merge-archive", "sps-1p12.land",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("steps = %v, want %v (length mismatch)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("steps = %v, want %v (diverges at index %d)", got, want, i)
+		}
+	}
+}
+
 // TestRunGetBeyondHistoricalCap guards the false-404 defect: with more completed
 // runs than the projection's historical lane cap, every run must still resolve by
 // id (the single-run path bypasses the list cap via BuildRunLane).

--- a/internal/api/run_steps_order.go
+++ b/internal/api/run_steps_order.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"sort"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// runStepDependencyEdges returns each member's step-ordering prerequisite
+// edges (prerequisite ID -> dependent ID), drawn from the real bead
+// Dependencies and Needs fields the run projection fold preserves. Edges to
+// a bead outside the member set are dropped: a Needs entry carrying a
+// non-blocking type prefix (e.g. "tracks:x", see internal/molecule
+// stepToBead) never resolves to a real member ID, so it silently
+// contributes no edge instead of needing separate type filtering — the same
+// property runproj.snapshotDeps relies on for its own dependency-edge fold.
+func runStepDependencyEdges(members []beads.Bead) map[string][]string {
+	memberIDs := make(map[string]bool, len(members))
+	for i := range members {
+		memberIDs[members[i].ID] = true
+	}
+	edges := make(map[string][]string, len(members))
+	seen := make(map[string]bool)
+	add := func(from, to string) {
+		if from == "" || to == "" || from == to {
+			return
+		}
+		if !memberIDs[from] || !memberIDs[to] {
+			return
+		}
+		key := from + "\x00" + to
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		edges[from] = append(edges[from], to)
+	}
+	for i := range members {
+		b := members[i]
+		for _, d := range b.Dependencies {
+			add(d.DependsOnID, d.IssueID)
+		}
+		for _, need := range b.Needs {
+			add(need, b.ID)
+		}
+	}
+	return edges
+}
+
+// topoSortRunSteps orders members into a topological order of their
+// step-ordering dependency edges (runStepDependencyEdges), so the Runs API
+// returns a run's steps in an order readable as a pipeline instead of
+// whatever order the projection fold happened to yield (gascity#4699). Ties
+// — independent steps, or steps with no dependency data at all — break on
+// bead ID, giving a fully deterministic order across repeated calls. A
+// cycle (which a valid formula-produced graph should never contain) cannot
+// stall the sort: any bead the frontier never reaches is appended,
+// ID-sorted, once the frontier empties, so the result always holds exactly
+// len(members) beads.
+func topoSortRunSteps(members []beads.Bead) []beads.Bead {
+	if len(members) < 2 {
+		return members
+	}
+	byID := make(map[string]beads.Bead, len(members))
+	inDegree := make(map[string]int, len(members))
+	for i := range members {
+		byID[members[i].ID] = members[i]
+		inDegree[members[i].ID] = 0
+	}
+	edges := runStepDependencyEdges(members)
+	for _, tos := range edges {
+		for _, to := range tos {
+			inDegree[to]++
+		}
+	}
+
+	var frontier []string
+	for id, deg := range inDegree {
+		if deg == 0 {
+			frontier = append(frontier, id)
+		}
+	}
+	sort.Strings(frontier)
+
+	ordered := make([]beads.Bead, 0, len(members))
+	visited := make(map[string]bool, len(members))
+	for len(frontier) > 0 {
+		id := frontier[0]
+		frontier = frontier[1:]
+		visited[id] = true
+		ordered = append(ordered, byID[id])
+
+		var newlyReady []string
+		for _, to := range edges[id] {
+			inDegree[to]--
+			if inDegree[to] == 0 {
+				newlyReady = append(newlyReady, to)
+			}
+		}
+		if len(newlyReady) > 0 {
+			frontier = append(frontier, newlyReady...)
+			sort.Strings(frontier)
+		}
+	}
+
+	if len(ordered) < len(members) {
+		var leftover []string
+		for i := range members {
+			if !visited[members[i].ID] {
+				leftover = append(leftover, members[i].ID)
+			}
+		}
+		sort.Strings(leftover)
+		for _, id := range leftover {
+			ordered = append(ordered, byID[id])
+		}
+	}
+	return ordered
+}

--- a/internal/api/run_steps_order_test.go
+++ b/internal/api/run_steps_order_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func stepBead(id string, needs ...string) beads.Bead {
+	return beads.Bead{ID: id, Title: "Step " + id, Status: "open", Type: "task", Needs: needs}
+}
+
+func orderedIDs(t *testing.T, members []beads.Bead) []string {
+	t.Helper()
+	ids := make([]string, len(members))
+	for i, m := range members {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
+func assertOrder(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("order = %v, want %v (length mismatch)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v (diverges at index %d)", got, want, i)
+		}
+	}
+}
+
+// TestTopoSortRunStepsLinearChain reproduces gascity#4699's own repro: a
+// 9-step chain declared in one order, whose fold-order arrival is scrambled
+// (mirroring the arbitrary order the issue observed), must come back out in
+// declaration order once topologically sorted on the Needs edges alone.
+func TestTopoSortRunStepsLinearChain(t *testing.T) {
+	// Declared order: prep -> author-en -> translate-ro -> feature-pr ->
+	// review -> gate-merge-feature -> archive-materialize -> merge-archive -> land.
+	prep := stepBead("prep")
+	authorEn := stepBead("author-en", "prep")
+	translateRo := stepBead("translate-ro", "author-en")
+	featurePr := stepBead("feature-pr", "translate-ro")
+	review := stepBead("review", "feature-pr")
+	gateMergeFeature := stepBead("gate-merge-feature", "review")
+	archiveMaterialize := stepBead("archive-materialize", "gate-merge-feature")
+	mergeArchive := stepBead("merge-archive", "archive-materialize")
+	land := stepBead("land", "merge-archive")
+
+	// Scrambled arrival order, matching the issue's own observed output.
+	scrambled := []beads.Bead{
+		mergeArchive, authorEn, translateRo, gateMergeFeature, archiveMaterialize,
+		featurePr, land, review, prep,
+	}
+
+	got := orderedIDs(t, topoSortRunSteps(scrambled))
+	want := []string{
+		"prep", "author-en", "translate-ro", "feature-pr", "review",
+		"gate-merge-feature", "archive-materialize", "merge-archive", "land",
+	}
+	assertOrder(t, got, want)
+}
+
+// TestTopoSortRunStepsFanOutFanInTieBreaksOnID confirms two independent
+// branches (b, c both depending only on a) land in a deterministic order —
+// bead ID — rather than an arbitrary one, and that the fan-in step (d) still
+// waits for both.
+func TestTopoSortRunStepsFanOutFanIn(t *testing.T) {
+	a := stepBead("a")
+	c := stepBead("c", "a")
+	b := stepBead("b", "a")
+	d := stepBead("d", "b", "c")
+
+	got := orderedIDs(t, topoSortRunSteps([]beads.Bead{d, c, b, a}))
+	assertOrder(t, got, []string{"a", "b", "c", "d"})
+}
+
+// TestTopoSortRunStepsNoDependencyDataFallsBackToIDOrder covers steps with
+// no Needs/Dependencies at all (e.g. a v1/wisp member never carrying
+// step-order metadata) — the sort must still return every member, ID-sorted,
+// rather than leaving fold-arrival order in place.
+func TestTopoSortRunStepsNoDependencyDataFallsBackToIDOrder(t *testing.T) {
+	got := orderedIDs(t, topoSortRunSteps([]beads.Bead{
+		stepBead("z"), stepBead("a"), stepBead("m"),
+	}))
+	assertOrder(t, got, []string{"a", "m", "z"})
+}
+
+// TestTopoSortRunStepsIgnoresEdgesOutsideMemberSet proves a Needs entry
+// pointing outside the member set (a non-blocking type-prefixed entry like
+// "tracks:x", or a bead this run doesn't actually hold) is silently dropped
+// rather than crashing or corrupting the order of the beads that ARE members.
+func TestTopoSortRunStepsIgnoresEdgesOutsideMemberSet(t *testing.T) {
+	got := orderedIDs(t, topoSortRunSteps([]beads.Bead{
+		stepBead("second", "first", "tracks:some-other-run.step9", "ghost-id"),
+		stepBead("first"),
+	}))
+	assertOrder(t, got, []string{"first", "second"})
+}
+
+// TestTopoSortRunStepsHandlesCycleWithoutHanging is a defensive regression
+// guard: a formula-produced graph should never contain a cycle, but a
+// malformed one must not hang the endpoint. Cycle members are appended,
+// ID-sorted, once the frontier empties.
+func TestTopoSortRunStepsHandlesCycleWithoutHanging(t *testing.T) {
+	x := stepBead("x", "y")
+	y := stepBead("y", "x")
+	entry := stepBead("entry")
+
+	done := make(chan []string, 1)
+	go func() {
+		done <- orderedIDs(t, topoSortRunSteps([]beads.Bead{y, x, entry}))
+	}()
+	select {
+	case got := <-done:
+		if len(got) != 3 {
+			t.Fatalf("order = %v, want 3 beads", got)
+		}
+		if got[0] != "entry" {
+			t.Fatalf("order = %v, want entry first (only non-cycle member)", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("topoSortRunSteps did not return on a cyclic graph")
+	}
+}


### PR DESCRIPTION
## What this fixes

`GET /runs/{id}/steps` returned a run's steps in whatever order the event-log projection fold happened to yield — not declaration order, not topological order, not creation order. A `graph.v2` run creates its whole step set in one transaction, so every step shares the same `created_at` to the second, leaving fold order undefined. The dashboard's Formula Graph was faithfully rendering an unreadable pipeline as a result.

## Fix

Adds `topoSortRunSteps` (`internal/api/run_steps_order.go`) — a Kahn's-algorithm topological sort over each member bead's real dependency edges (`Dependencies` and `Needs`, both already present on the fold's beads, no extra store round-trip), with a deterministic bead-ID tiebreak for independent steps and for any step carrying no dependency data at all. A defensive cycle-handling path guarantees termination even on a malformed graph (appends unreached beads ID-sorted rather than hanging).

Edge-building mirrors the existing `runproj.snapshotDeps` logic already used for the run detail graph — same semantics (prerequisite → dependent, edges outside the member set silently dropped), just relocated to the `api` package where the steps handler lives.

Wired into `humaHandleRunSteps` with a one-line change: `runMemberBeads(...)` → `topoSortRunSteps(runMemberBeads(...))`.

## Testing

TDD'd throughout — five unit tests directly on `topoSortRunSteps` (linear chain reproducing the issue's own 9-step repro, fan-out/fan-in tie-break, no-dependency-data fallback, edges-outside-member-set silently dropped, cycle doesn't hang) plus one true end-to-end regression test through `humaHandleRunSteps` itself, confirmed red against the unwired handler (reproduced the exact bug shape — `merge-archive` first, `prep` last) before wiring the fix in and confirming green.

Full `go test ./internal/api/...` passes (fresh, `-count=1`), `go vet` clean. No OpenAPI/wire-shape change — response ordering only, confirmed no diff under `docs/reference/schema/` or `internal/api/openapi.json`.

**Note on the pre-push gate:** `make test-fast-parallel` failed on unrelated `cmd/gc` lifecycle-timing tests (`TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds`, `TestEnsureBeadsProvider_execDoesNotReclassifyProviderAfterStart`, plus `TestDoctorCheckVersionFloor`/`TestBackupScriptSkipsConcurrentRunBeforeBackupSync`), none touching this diff. Confirmed flaky via isolated reruns (both pass clean alone). Consistent with heavy concurrent machine load, not this change.

Closes #4699.