### PR TITLE
fix(api): add cheap ?enrich=false roster mode to GET /sessions (#4390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bound or explicitly configured endpoints keep bd's own output unchanged
   (gastownhall/gascity#1374).
 
+- **`GET /sessions` gained a cheap `?enrich=false` roster mode.** Per-session
+  runtime enrichment (running state, active bead, peek) ran unconditionally
+  over every session that matched the filter — not just the requested page
+  — via `Manager.ListFromInfos`'s live overlay, serializing behind the
+  runtime provider's own rate limits at fleet scale (a Kubernetes provider's
+  client-go QPS limiter serializing one pod GET per session was the
+  reported case: ~21 active sessions took 40-49s, ~34 took ~70s). A caller
+  that only needs a roster (id/state/alias, e.g. building a recipient list)
+  can now pass `enrich=false` for a read-model-only response with zero
+  runtime calls; the default (omitted) still enriches, unchanged. Split
+  `Manager.ListFromInfos` into a new `FilterInfos` (filter only) plus the
+  existing `EnrichInfos` overlay so the fast path can skip enrichment
+  without duplicating the filter logic. (gascity#4390)
+
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -47058,6 +47058,17 @@
               "description": "Include last output preview.",
               "type": "boolean"
             }
+          },
+          {
+            "description": "Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.",
+            "explode": false,
+            "in": "query",
+            "name": "enrich",
+            "schema": {
+              "default": true,
+              "description": "Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -47058,6 +47058,17 @@
               "description": "Include last output preview.",
               "type": "boolean"
             }
+          },
+          {
+            "description": "Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.",
+            "explode": false,
+            "in": "query",
+            "name": "enrich",
+            "schema": {
+              "default": true,
+              "description": "Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/internal/api/cache_read_model.go
+++ b/internal/api/cache_read_model.go
@@ -36,19 +36,31 @@ func sessionReadModelListings(sessFront *session.Store) ([]session.ListedSession
 	return nil, nil, err
 }
 
-// filterEnrichReadModel filters a typed read-model feed by state and template and
-// applies the runtime overlay (Manager.ListFromInfos), returning the enriched
-// session list paired with a by-id lookup of each session's persisted-response
-// projection. The pair is pre-joined per ListedSession row, so the session
-// response builder re-attaches the persisted facts by id — no bead index and no
-// bead->response projection. Filter-then-enrich order is preserved inside
-// ListFromInfos (the persisted state filter runs before the runtime downgrade).
-func filterEnrichReadModel(mgr *session.Manager, listings []session.ListedSession, stateFilter, templateFilter string) ([]session.Info, map[string]session.PersistedResponse) {
+// filterEnrichReadModel filters a typed read-model feed by state and template and,
+// when enrich is true, applies the runtime overlay (Manager.ListFromInfos),
+// returning the enriched session list paired with a by-id lookup of each
+// session's persisted-response projection. The pair is pre-joined per
+// ListedSession row, so the session response builder re-attaches the persisted
+// facts by id — no bead index and no bead->response projection. Filter-then-enrich
+// order is preserved inside ListFromInfos (the persisted state filter runs before
+// the runtime downgrade).
+//
+// enrich=false skips the runtime overlay via Manager.FilterInfos instead —
+// filter only, zero IsRunning/IsAttached/GetLastActivity calls. This is the
+// fleet-wide (pre-pagination) half of the gascity#4390 cheap-roster path: at
+// fleet scale, EnrichInfos here — not the per-page enrichment loop in
+// humaHandleSessionList — is what serializes behind the runtime provider's own
+// rate limits, since it runs over every session that matches the filter, not
+// just the requested page.
+func filterEnrichReadModel(mgr *session.Manager, listings []session.ListedSession, stateFilter, templateFilter string, enrich bool) ([]session.Info, map[string]session.PersistedResponse) {
 	infos := make([]session.Info, len(listings))
 	responseByID := make(map[string]session.PersistedResponse, len(listings))
 	for i, listing := range listings {
 		infos[i] = listing.Info
 		responseByID[listing.Info.ID] = listing.Response
+	}
+	if !enrich {
+		return mgr.FilterInfos(infos, stateFilter, templateFilter), responseByID
 	}
 	return mgr.ListFromInfos(infos, stateFilter, templateFilter), responseByID
 }

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/types.gen.ts
@@ -18143,6 +18143,10 @@ export type GetV0CityByCityNameSessionsData = {
          * Include last output preview.
          */
         peek?: boolean;
+        /**
+         * Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.
+         */
+        enrich?: boolean;
     };
     url: '/v0/city/{cityName}/sessions';
 };

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/zod.gen.ts
@@ -9323,7 +9323,8 @@ export const zGetV0CityByCityNameSessionsQuery = z.object({
     limit: z.coerce.bigint().gte(BigInt(0)).lte(BigInt(1000)).optional().default(BigInt(100)),
     state: z.string().optional(),
     template: z.string().optional(),
-    peek: z.boolean().optional()
+    peek: z.boolean().optional(),
+    enrich: z.boolean().optional().default(true)
 });
 
 /**

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -9743,6 +9743,9 @@ type GetV0CityByCityNameSessionsParams struct {
 
 	// Peek Include last output preview.
 	Peek *bool `form:"peek,omitempty" json:"peek,omitempty"`
+
+	// Enrich Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.
+	Enrich *bool `form:"enrich,omitempty" json:"enrich,omitempty"`
 }
 
 // CreateSessionParams defines parameters for CreateSession.
@@ -31374,6 +31377,22 @@ func NewGetV0CityByCityNameSessionsRequest(server string, cityName string, param
 		if params.Peek != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "peek", *params.Peek, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Enrich != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "enrich", *params.Enrich, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -251,7 +251,7 @@ func (s *Server) handleSessionList(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
-	sessions, responseByID := filterEnrichReadModel(mgr, listings, stateFilter, templateFilter)
+	sessions, responseByID := filterEnrichReadModel(mgr, listings, stateFilter, templateFilter, true)
 
 	// Resolve the legacy offset page before runtime/transcript enrichment so
 	// off-page sessions do not perform filesystem discovery on every list poll.

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -872,6 +872,77 @@ func TestHandleSessionListEnrichesOnlyRequestedPage(t *testing.T) {
 	}
 }
 
+// TestHandleSessionListEnrichFalseSkipsAllRuntimeCalls is the regression
+// guard for gascity#4390: per-session runtime enrichment (running state,
+// active bead, peek) is what serializes /sessions behind the runtime's own
+// rate limits at fleet scale (e.g. a Kubernetes provider's client-go QPS
+// limiter serializing pod GETs one request per session). enrich=false must
+// skip it entirely — zero calls into the session runtime provider — and
+// still return the full read-model roster (id/state/etc.), not an empty or
+// truncated page.
+func TestHandleSessionListEnrichFalseSkipsAllRuntimeCalls(t *testing.T) {
+	fs := newSessionFakeState(t)
+	createTestSession(t, fs.cityBeadStore, fs.sp, "S1")
+	createTestSession(t, fs.cityBeadStore, fs.sp, "S2")
+	createTestSession(t, fs.cityBeadStore, fs.sp, "S3")
+	fs.sp.Calls = nil
+
+	h := newTestCityHandler(t, fs)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/sessions?enrich=false&peek=true"), nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Items []sessionResponse `json:"items"`
+		Total int               `json:"total"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 3 || resp.Total != 3 {
+		t.Fatalf("items/total = %d/%d, want 3/3 — the roster itself must still be complete", len(resp.Items), resp.Total)
+	}
+	for _, item := range resp.Items {
+		if item.ID == "" || item.State == "" {
+			t.Fatalf("item %+v missing read-model fields", item)
+		}
+	}
+	if calls := fs.sp.SnapshotCalls(); len(calls) != 0 {
+		t.Fatalf("runtime provider calls = %d, want 0 with enrich=false: %+v", len(calls), calls)
+	}
+}
+
+// TestHandleSessionListEnrichDefaultsTrue confirms the default (no enrich
+// param at all — the pre-gascity#4390 request shape every existing client
+// sends) still performs full enrichment, so adding the opt-out cannot
+// silently change behavior for callers who don't know about it.
+func TestHandleSessionListEnrichDefaultsTrue(t *testing.T) {
+	fs := newSessionFakeState(t)
+	createTestSession(t, fs.cityBeadStore, fs.sp, "S1")
+	fs.sp.Calls = nil
+
+	h := newTestCityHandler(t, fs)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/sessions?peek=true"), nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	peekCalls := 0
+	for _, call := range fs.sp.SnapshotCalls() {
+		if call.Method == "Peek" {
+			peekCalls++
+		}
+	}
+	if peekCalls != 1 {
+		t.Fatalf("Peek calls = %d, want 1 — default (no enrich param) must still enrich", peekCalls)
+	}
+}
+
 func TestHandleSessionGet(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -38,7 +38,7 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	if err != nil {
 		return nil, apierr.Internal.Msg(err.Error())
 	}
-	sessions, responseByID := filterEnrichReadModel(mgr, listings, input.State, input.Template)
+	sessions, responseByID := filterEnrichReadModel(mgr, listings, input.State, input.Template, input.Enrich)
 
 	// Unified page contract (S4): default 100 like every other keyset list.
 	// The offset-cursor era defaulted sessions to the 1000-row server cap;
@@ -78,11 +78,19 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	for j, i := range pageIdx {
 		pageSessions[j] = sessions[i]
 	}
-	keyedTranscriptPaths := session.ResolveKeyedTranscriptPaths(sessionTranscriptLookupCandidates(pageSessions), s.sessionLogPaths(), sessionTranscriptProviderFallback(cfg))
+	// enrich=false skips per-session runtime enrichment entirely (including
+	// the keyed-transcript-path prefetch, which exists solely to feed it),
+	// returning the read-model roster only — see SessionListInput.Enrich.
+	var keyedTranscriptPaths map[string]string
+	if input.Enrich {
+		keyedTranscriptPaths = session.ResolveKeyedTranscriptPaths(sessionTranscriptLookupCandidates(pageSessions), s.sessionLogPaths(), sessionTranscriptProviderFallback(cfg))
+	}
 	page := make([]sessionResponse, len(pageSessions))
 	for j, sess := range pageSessions {
 		page[j] = sessionResponseWithReason(sess, responseByID[sess.ID], cfg, s.state.SessionProvider(), hasDeferredQueue)
-		s.enrichSessionResponseWithKeyedPaths(&page[j], sess, cfg, s.runtimeSessionResponseHandle(sess), wantPeek, false, false, 0, keyedTranscriptPaths)
+		if input.Enrich {
+			s.enrichSessionResponseWithKeyedPaths(&page[j], sess, cfg, s.runtimeSessionResponseHandle(sess), wantPeek, false, false, 0, keyedTranscriptPaths)
+		}
 	}
 	return &ListOutput[sessionResponse]{
 		Index:     s.latestIndex(),

--- a/internal/api/huma_types_sessions.go
+++ b/internal/api/huma_types_sessions.go
@@ -18,6 +18,19 @@ type SessionListInput struct {
 	State    string `query:"state" required:"false" doc:"Filter by session state (e.g. active, closed)."`
 	Template string `query:"template" required:"false" doc:"Filter by session template (agent qualified name)."`
 	Peek     bool   `query:"peek" required:"false" doc:"Include last output preview."`
+	// Enrich defaults to true (unchanged historical behavior: running state,
+	// active bead, and peek/model enrichment per row). enrich=false skips all
+	// per-session runtime enrichment and returns the read-model roster only —
+	// no runtime probe calls at all. At fleet scale, per-row enrichment is
+	// serialized behind the runtime's own rate limits (e.g. a Kubernetes
+	// provider's client-go QPS limiter serializing pod GETs), so a caller that
+	// only needs a roster (id/state/alias, e.g. building a recipient list)
+	// pays minutes instead of milliseconds without this escape hatch
+	// (gascity#4390). Skipping the overlay also skips the runtime
+	// stale-active downgrade, so State is the persisted value: a
+	// state=active&enrich=false roster can include a session whose runtime
+	// is no longer alive.
+	Enrich bool `query:"enrich" required:"false" default:"true" doc:"Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active."`
 }
 
 // CityPendingInput is the Huma input for GET /v0/city/{cityName}/pending.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -47058,6 +47058,17 @@
               "description": "Include last output preview.",
               "type": "boolean"
             }
+          },
+          {
+            "description": "Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.",
+            "explode": false,
+            "in": "query",
+            "name": "enrich",
+            "schema": {
+              "default": true,
+              "description": "Include per-session runtime enrichment (running state, active bead, peek/model info). Defaults to true; set false for a cheap read-model-only roster with zero runtime calls. With enrich=false the runtime stale-active downgrade is skipped too, so state is the persisted value and an active session whose runtime is no longer alive is still reported as active.",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/internal/session/list_from_infos_test.go
+++ b/internal/session/list_from_infos_test.go
@@ -71,3 +71,74 @@ func TestListFromInfosMatchesListFullFromBeads(t *testing.T) {
 		}
 	}
 }
+
+// TestFilterInfosMatchesListFromInfosWithoutEnrich is the split oracle for
+// gascity#4390's cheap-roster path: FilterInfos (the filter-only half) must
+// (a) apply exactly the same persisted-state filter as ListFromInfos, and
+// (b) leave every surviving Info completely unenriched — none of the runtime
+// fields EnrichInfo sets (Transport, Attached, LastActive, the stale-active
+// State downgrade) may appear — so EnrichInfos(FilterInfos(x)) stays provably
+// equal to ListFromInfos(x) across the same state/template filter matrix.
+func TestFilterInfosMatchesListFromInfosWithoutEnrich(t *testing.T) {
+	at := func(minN int) time.Time {
+		return time.Date(2026, 1, 2, 3, 4, minN, 0, time.UTC)
+	}
+	corpus := []beads.Bead{
+		{
+			ID: "canonical", Type: BeadType, Status: "open", Labels: []string{LabelSession},
+			Metadata: map[string]string{"state": "asleep", "template": "polecat", "session_name": "canonical"}, CreatedAt: at(1),
+		},
+		{
+			ID: "type-only", Type: BeadType, Status: "open",
+			Metadata: map[string]string{"state": "active", "template": "polecat", "session_name": "type-only"}, CreatedAt: at(2),
+		},
+		{
+			ID: "label-only", Type: "", Status: "open", Labels: []string{LabelSession},
+			Metadata: map[string]string{"state": "asleep", "template": "sky", "session_name": "label-only"}, CreatedAt: at(3),
+		},
+		{
+			ID: "non-session", Type: "task", Status: "open", Labels: []string{"work"},
+			Metadata: map[string]string{"state": "active"}, CreatedAt: at(4),
+		},
+		{
+			ID: "closed", Type: BeadType, Status: "closed", Labels: []string{LabelSession},
+			Metadata: map[string]string{"state": "asleep", "template": "polecat", "session_name": "closed"}, CreatedAt: at(5),
+		},
+	}
+	infos := make([]Info, 0, len(corpus))
+	for _, b := range corpus {
+		infos = append(infos, infoFromPersistedBead(b))
+	}
+
+	// A live runtime provider that would make EnrichInfo observably change an
+	// active session's fields — "type-only" is deliberately left un-Start'd
+	// (IsRunning=false), which is exactly what triggers EnrichInfo's
+	// stale-active-downgrade (State: active -> asleep). That downgrade is the
+	// most reliable unenriched/enriched tell available here: unlike
+	// Attached/LastActive (which the downgrade itself skips setting once State
+	// is no longer StateActive), the downgrade always fires for an active
+	// session whose runtime the provider doesn't know about.
+	sp := runtime.NewFake()
+	mgr := NewManagerWithOptions(beads.NewMemStore(), sp)
+
+	for _, sf := range []string{"", "asleep", "active", "all", "closed", "active,asleep"} {
+		for _, tf := range []string{"", "polecat", "sky"} {
+			// Two independent calls: FilterInfos is pure over its input slice
+			// (never mutates infos), so calling it twice and checking each
+			// result separately avoids EnrichInfos's in-place mutation of its
+			// argument contaminating the unenriched-row check below.
+			forUnenrichedCheck := mgr.FilterInfos(infos, sf, tf)
+			for _, info := range forUnenrichedCheck {
+				if info.ID == "type-only" && info.State != StateActive {
+					t.Fatalf("FilterInfos(state=%q,template=%q) downgraded type-only's State to %q — FilterInfos must not run the runtime stale-active check", sf, tf, info.State)
+				}
+			}
+
+			enrichedWant := mgr.ListFromInfos(infos, sf, tf)
+			enrichedGot := mgr.EnrichInfos(mgr.FilterInfos(infos, sf, tf))
+			if !reflect.DeepEqual(enrichedGot, enrichedWant) {
+				t.Fatalf("EnrichInfos(FilterInfos(state=%q,template=%q)) diverged from ListFromInfos:\n got = %+v\nwant = %+v", sf, tf, enrichedGot, enrichedWant)
+			}
+		}
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1969,6 +1969,18 @@ func (m *Manager) PersistedStore() *Store {
 // persisted projection, before the runtime stale-active downgrade), and the
 // IsSessionBeadOrRepairableInfo guard mirrors the old defensive filter.
 func (m *Manager) ListFromInfos(infos []Info, stateFilter, templateFilter string) []Info {
+	return m.EnrichInfos(m.FilterInfos(infos, stateFilter, templateFilter))
+}
+
+// FilterInfos is the filter-only half of ListFromInfos: the persisted-state
+// filter (repairable-bead guard + state/template match) with no runtime
+// overlay. Split out so a caller that doesn't want per-session live-runtime
+// calls (IsRunning/IsAttached/GetLastActivity via EnrichInfos) — e.g. a cheap
+// roster read that skips runtime enrichment entirely, gascity#4390 — can
+// filter without paying for it. ListFromInfos is exactly
+// EnrichInfos(FilterInfos(...)); this split changes no existing caller's
+// behavior.
+func (m *Manager) FilterInfos(infos []Info, stateFilter, templateFilter string) []Info {
 	result := make([]Info, 0, len(infos))
 	for _, info := range infos {
 		if !IsSessionBeadOrRepairableInfo(info) {
@@ -1979,7 +1991,7 @@ func (m *Manager) ListFromInfos(infos []Info, stateFilter, templateFilter string
 		}
 		result = append(result, info)
 	}
-	return m.EnrichInfos(result)
+	return result
 }
 
 // PersistSessionKey stores a provider resume key on an existing session when


### PR DESCRIPTION
## What this fixes

`Manager.ListFromInfos` applied its runtime overlay (`IsRunning`/`IsAttached`/`GetLastActivity` via `EnrichInfos`) to every session matching the state/template filter — not just the requested page — before pagination even runs. At fleet scale this serializes behind the runtime provider's own rate limits: a Kubernetes provider's client-go QPS limiter serializing one pod GET per session took 40-49s at ~21 active sessions and ~70s at ~34. A caller that only needs a roster (id/state/alias — e.g. building a mail recipient list) had no way to skip it and would time out entirely.

## Fix

Split `Manager.ListFromInfos` into a new `FilterInfos` (the filter-only half — persisted-state filter, no runtime calls) plus the existing `EnrichInfos` overlay. `ListFromInfos` is now exactly `EnrichInfos(FilterInfos(...))` — a pure, behavior-preserving refactor confirmed by the existing `TestListFromInfosMatchesListFullFromBeads` oracle test passing unchanged.

`SessionListInput` gains `Enrich bool` (`query:"enrich"`, `default:"true"` — existing callers who don't pass the param keep today's behavior unchanged). `enrich=false` routes through `FilterInfos` instead of `ListFromInfos` and skips the per-page enrichment loop entirely (including the keyed-transcript-path prefetch, which exists solely to feed it) — zero runtime provider calls.

Scoped to the modern Huma-typed `GET /v0/city/{cityName}/sessions` endpoint only; the legacy raw-`net/http` sessions-list handler (`handler_sessions.go`) stays on its unconditional `enrich=true` path, unchanged.

## Testing

TDD'd throughout. Two new regression tests through the real HTTP handler (`internal/api/handler_sessions_test.go`):
- `TestHandleSessionListEnrichFalseSkipsAllRuntimeCalls` — 3 sessions, `enrich=false&peek=true`, asserts the roster is still complete (items/total = 3/3, every row has id+state) AND zero calls landed on the fake runtime provider.
- `TestHandleSessionListEnrichDefaultsTrue` — no `enrich` param at all (the shape every existing client sends today) still performs full enrichment (Peek call = 1), proving the default can't silently change behavior for callers who don't know about the new param.

Plus a new split-oracle unit test in `internal/session/` (`TestFilterInfosMatchesListFromInfosWithoutEnrich`) verifying `FilterInfos` applies the identical filter as `ListFromInfos` while leaving every row completely unenriched — verified this test actually catches a real regression by temporarily sabotaging `FilterInfos` to enrich internally and confirming it failed red, then restoring the fix and confirming green.

Regenerated `openapi.json`, docs schema, and the Go/TS API clients for the new query param; `make dashboard-ci` passes clean. Full `go test ./internal/api/... ./internal/session/...` green (`-count=1`, no cache). Also ran a broad `cmd/gc` subset (session/completion-related tests, ~245s) since `FilterInfos`'s sibling `ListFromInfos` has CLI callers there — all green, no regressions.

**Note on the pre-push gate:** `make test-fast-parallel` failed on 4 unrelated `cmd/gc` lifecycle-timeout tests (`TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds`, `TestStopManagedCityDoesNotUseStartupOrDriftTimeouts`, `TestStopManagedCityForcesCleanupAfterTimeout`, `TestNativeDoltOpenEnvForScopeContextCancelsManagedRecovery`), none touching `internal/api` or `internal/session` — both of which were independently confirmed green above. Consistent with heavy concurrent machine load seen across multiple pushes today.

Closes #4390.