### PR TITLE
perf(builtinpacks): memoize embedded pack data and drop a redundant cache walk

### DIFF
--- a/internal/builtinpacks/registry.go
+++ b/internal/builtinpacks/registry.go
@@ -399,7 +399,7 @@ func SyntheticContentHash() (string, error) {
 	var entries []string
 	for _, layout := range syntheticPackLayouts() {
 		pack := layout.Pack
-		manifest, err := manifestForFS(pack.FS)
+		manifest, err := manifestForPack(pack)
 		if err != nil {
 			return "", fmt.Errorf("hashing bundled pack %q: %w", pack.Name, err)
 		}
@@ -476,8 +476,16 @@ func materializeFS(src fs.FS, dst string) error {
 	return nil
 }
 
+// validatePackFiles verifies a materialized pack against the embedded manifest:
+// every expected file present, with the expected mode and content.
+//
+// It does not walk dst looking for unexpected files. validateSyntheticRepoFileSet
+// already walks the whole cache once against the union of every layout's
+// manifest, and that union check strictly subsumes a per-pack one: a file
+// unexpected for its own pack is absent from the union too. Keeping both meant
+// about nine traversals of the same tree per call.
 func validatePackFiles(pack Pack, dst string) error {
-	manifest, err := manifestForFS(pack.FS)
+	manifest, err := manifestForPack(pack)
 	if err != nil {
 		return fmt.Errorf("reading bundled pack %q manifest: %w", pack.Name, err)
 	}
@@ -497,25 +505,6 @@ func validatePackFiles(pack Pack, dst string) error {
 		if !bytes.Equal(got, want.data) {
 			return fmt.Errorf("bundled pack cache %q file %s content differs from current binary", pack.Name, rel)
 		}
-	}
-	if err := filepath.WalkDir(dst, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(dst, path)
-		if err != nil {
-			return err
-		}
-		rel = filepath.ToSlash(rel)
-		if _, ok := manifest[rel]; !ok {
-			return fmt.Errorf("bundled pack cache %q contains unexpected file %s", pack.Name, rel)
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("validating bundled pack cache %q file set: %w", pack.Name, err)
 	}
 	return nil
 }
@@ -563,12 +552,36 @@ func validateSyntheticRepoFileSet(dir string) error {
 	return nil
 }
 
+// syntheticRepoAllowedPaths returns the file and directory sets a materialized
+// synthetic repo may contain.
+//
+// The result derives entirely from content embedded in the running binary, so it
+// is memoized for the process lifetime the same way syntheticContentHashOnce
+// memoizes the content hash. Rebuilding it per call re-walked every bundled
+// pack's embed.FS on every config load. Callers must treat the returned maps as
+// read-only.
 func syntheticRepoAllowedPaths() (map[string]struct{}, map[string]struct{}, error) {
+	cached := syntheticRepoAllowedPathsOnce()
+	return cached.files, cached.dirs, cached.err
+}
+
+type syntheticRepoPathSets struct {
+	files map[string]struct{}
+	dirs  map[string]struct{}
+	err   error
+}
+
+var syntheticRepoAllowedPathsOnce = sync.OnceValue(func() syntheticRepoPathSets {
+	files, dirs, err := computeSyntheticRepoAllowedPaths()
+	return syntheticRepoPathSets{files: files, dirs: dirs, err: err}
+})
+
+func computeSyntheticRepoAllowedPaths() (map[string]struct{}, map[string]struct{}, error) {
 	files := map[string]struct{}{syntheticMarkerFile: {}}
 	dirs := make(map[string]struct{})
 	for _, layout := range syntheticPackLayouts() {
 		subpath := filepath.ToSlash(layout.Subpath)
-		manifest, err := manifestForFS(layout.Pack.FS)
+		manifest, err := manifestForPack(layout.Pack)
 		if err != nil {
 			return nil, nil, fmt.Errorf("reading bundled pack %q manifest: %w", layout.Pack.Name, err)
 		}
@@ -581,6 +594,28 @@ func syntheticRepoAllowedPaths() (map[string]struct{}, map[string]struct{}, erro
 		}
 	}
 	return files, dirs, nil
+}
+
+// manifestCache memoizes per-pack manifests by pack name. A pack's manifest is a
+// pure function of content embedded in the running binary, so it cannot change
+// within a process. Rebuilding it re-read every bundled file on every call.
+// Entries are read-only once stored.
+var manifestCache sync.Map
+
+type syntheticManifestResult struct {
+	manifest map[string]fileEntry
+	err      error
+}
+
+// manifestForPack returns the memoized manifest for a bundled pack.
+func manifestForPack(pack Pack) (map[string]fileEntry, error) {
+	if cached, ok := manifestCache.Load(pack.Name); ok {
+		entry := cached.(syntheticManifestResult)
+		return entry.manifest, entry.err
+	}
+	manifest, err := manifestForFS(pack.FS)
+	manifestCache.Store(pack.Name, syntheticManifestResult{manifest: manifest, err: err})
+	return manifest, err
 }
 
 func manifestForFS(src fs.FS) (map[string]fileEntry, error) {

--- a/internal/builtinpacks/registry_test.go
+++ b/internal/builtinpacks/registry_test.go
@@ -533,3 +533,84 @@ func TestSyntheticCacheKeyComponentMatchesContentHash(t *testing.T) {
 		t.Fatalf("SyntheticCacheKeyComponent not stable across calls: %q != %q", got, second)
 	}
 }
+
+// TestValidateSyntheticRepoRejectsStrayFilesAnywhere pins the coverage that
+// justifies validatePackFiles no longer walking its own directory. The whole-tree
+// walk in validateSyntheticRepoFileSet checks every path against the union of all
+// layout manifests, which strictly subsumes a per-pack check: a file that is
+// unexpected for its own pack is absent from the union too. Nested layouts
+// (examples/bd contains examples/bd/dolt) are covered explicitly, because that is
+// the case where a per-pack and a union check could conceivably disagree.
+func TestValidateSyntheticRepoRejectsStrayFilesAnywhere(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rel  string
+	}{
+		{"pack root", "internal/bootstrap/packs/core/STRAY.txt"},
+		{"deep inside a pack", "internal/bootstrap/packs/core/assets/STRAY.txt"},
+		{"inside a nested pack", "examples/bd/dolt/STRAY.txt"},
+		{"in the parent of a nested pack", "examples/bd/STRAY.txt"},
+		{"cache root", "STRAY.txt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := materializeTestRepo(t)
+			stray := filepath.Join(dst, filepath.FromSlash(tc.rel))
+			if err := os.MkdirAll(filepath.Dir(stray), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(stray, []byte("stray"), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if err := ValidateSyntheticRepo(dst, testCommit); err == nil {
+				t.Fatalf("ValidateSyntheticRepo accepted a stray file at %s", tc.rel)
+			}
+		})
+	}
+}
+
+// TestSyntheticRepoAllowedPathsIsStable pins that memoizing the allowed-path sets
+// does not change what they contain across calls.
+func TestSyntheticRepoAllowedPathsIsStable(t *testing.T) {
+	files1, dirs1, err := syntheticRepoAllowedPaths()
+	if err != nil {
+		t.Fatalf("syntheticRepoAllowedPaths: %v", err)
+	}
+	files2, dirs2, err := syntheticRepoAllowedPaths()
+	if err != nil {
+		t.Fatalf("syntheticRepoAllowedPaths (second call): %v", err)
+	}
+	if len(files1) != len(files2) || len(dirs1) != len(dirs2) {
+		t.Fatalf("allowed paths changed between calls: files %d/%d dirs %d/%d",
+			len(files1), len(files2), len(dirs1), len(dirs2))
+	}
+	if len(files1) == 0 {
+		t.Fatal("allowed file set is empty")
+	}
+}
+
+// TestManifestForPackMatchesUncached pins that the memoized per-pack manifest is
+// identical to a freshly built one.
+func TestManifestForPackMatchesUncached(t *testing.T) {
+	for _, pack := range All() {
+		cached, err := manifestForPack(pack)
+		if err != nil {
+			t.Fatalf("manifestForPack(%s): %v", pack.Name, err)
+		}
+		fresh, err := manifestForFS(pack.FS)
+		if err != nil {
+			t.Fatalf("manifestForFS(%s): %v", pack.Name, err)
+		}
+		if len(cached) != len(fresh) {
+			t.Fatalf("pack %s: memoized manifest has %d entries, fresh has %d", pack.Name, len(cached), len(fresh))
+		}
+		for rel, want := range fresh {
+			got, ok := cached[rel]
+			if !ok {
+				t.Fatalf("pack %s: memoized manifest missing %s", pack.Name, rel)
+			}
+			if got.perm != want.perm || !bytes.Equal(got.data, want.data) {
+				t.Fatalf("pack %s: memoized manifest differs for %s", pack.Name, rel)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## The juicy parts

Every command that loads config pays the bundled-pack cache validation, and it was rebuilding two pure functions of embedded binary content on every call and walking the same tree about nine times. On `BenchmarkBuiltinReadinessPass` — a Go benchmark of that path, alternated across two compiled test binaries, 6 rounds x 20 iterations — this is 76.51 → 51.12 ms/op and 42,136 → 16,910 allocs/op. That is the benchmark's measurement of the readiness path, not an end-to-end `gc` wall clock, and per #4916 that fixture city has no `packs.lock`, so it covers only one of the pass's two halves.

**File content is still compared byte-for-byte.** The removed per-pack walk is strictly subsumed by the union walk that already ran, pinned by `TestValidateSyntheticRepoRejectsStrayFilesAnywhere` across five stray-file placements including both nesting cases. Worth knowing before weighing that: an earlier revision of this PR replaced content comparison with an mtime check for a bigger win, CI caught that it was unsound on Linux, and it was removed. What is left carries no stat-based assumption. This removes *different* redundant work from the same invocation than #4565, #4723 or #4768 — it does not replace any of them.

The bundled pack cache validation that runs before every config load rebuilt two
pure functions of embedded content on every call, and walked the same tree about
nine times.

## Changes

1. **Memoize the allowed-path sets and the per-pack manifests.** Both derive
   entirely from content embedded in the running binary, so they cannot change
   within a process. This follows the `syntheticContentHashOnce` precedent already
   in this file. `materializeFS` keeps the uncached `manifestForFS` because it is
   the write path.
2. **Drop `validatePackFiles`' own directory walk.** `validateSyntheticRepoFileSet`
   already walks the whole cache once against the union of every layout's
   manifest, and that union check strictly subsumes a per-pack one: a file
   unexpected for its own pack is absent from the union too.

**File content is still compared byte-for-byte.** Every integrity property the
validation had before is unchanged — this is purely about not redoing work.

## Measured

`BenchmarkBuiltinReadinessPass` (added by #4723) measures exactly this path. Two
compiled test binaries alternated, 6 rounds x 20 iterations:

| | before | after | change |
|---|---|---|---|
| time | 76.51 ms/op | 51.12 ms/op | **-33.2%** |
| memory | 22,490,590 B/op | 8,504,894 B/op | **-62.2%** |
| allocations | 42,136 | 16,910 | **-59.9%** |

Every command that loads config pays this, not only `gc bd`.

## Tests

- `TestValidateSyntheticRepoRejectsStrayFilesAnywhere` — pins the subsumption
  across five stray-file placements, including both nesting cases
  (`examples/bd` contains `examples/bd/dolt`), which is where a per-pack and a
  union check could conceivably disagree.
- `TestSyntheticRepoAllowedPathsIsStable` and `TestManifestForPackMatchesUncached`
  — pin that memoization changes no content.
- Both `EnsureBuiltinRuntimeAssets` rehydration contract tests pass unmodified.

## Related work

Continues the invocation-cost line rather than replacing any of it — each removes
*different* redundant work from the same invocation:

- #4565 (merged) — skip pack discovery for `gc bd`
- #4723 (merged) — stop reloading the city config inside a store open
- #4768 (open) — reuse the write-guard's store read in the bd close gate
- **this PR** — stop rebuilding embedded pack data and re-walking the cache

## History

An earlier revision of this PR also replaced the per-file content comparison with
an mtime-based check, for a larger win. **CI caught that it was unsound** and it
has been removed: a same-size in-place rewrite landing inside the same filesystem
timestamp tick as the cache marker is not detectable from stat alone, and
`TestValidateSyntheticRepoRejectsSameSizeTamper` failed on Linux CI while passing
on APFS. What remains carries no such assumption.
