### PR TITLE
feat(cityartifact): Artifact producer and link adapter (API-7.21)

### DIFF
--- a/pkg/cityartifact/checkpoint_test.go
+++ b/pkg/cityartifact/checkpoint_test.go
@@ -1,0 +1,394 @@
+package cityartifact_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+)
+
+func producerOn(t *testing.T, api cityartifact.API, src cityartifact.Source, store cityartifact.Store) *cityartifact.Producer {
+	t.Helper()
+	p, err := cityartifact.NewProducer(api, cityartifact.Mapper{Source: src}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	return p
+}
+
+// AC2 happy path: an identical second push reuses accepted state — no second
+// artifact, no second part.
+func TestIdenticalPushIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	first, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("first Push: %v", err)
+	}
+	second, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("second Push: %v", err)
+	}
+	if second.ArtifactID != first.ArtifactID {
+		t.Fatalf("second push minted %q, first was %q", second.ArtifactID, first.ArtifactID)
+	}
+	if second.Uploaded != 0 || second.Skipped != 2 {
+		t.Errorf("second push uploaded %d skipped %d, want 0/2", second.Uploaded, second.Skipped)
+	}
+	if got := f.PartCount(first.ArtifactID); got != 2 {
+		t.Errorf("server stored %d parts, want 2", got)
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("tenant holds %d artifacts, want 1", f.ArtifactCount())
+	}
+}
+
+// AC2: a lost response. The checkpoint never landed, so the producer replays
+// every request — and the derived keys make the server return the accepted state
+// instead of creating a second artifact or a third part.
+func TestLostCheckpointReplaysRatherThanDuplicates(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	first := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	res, err := first.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("first Push: %v", err)
+	}
+
+	// Fresh store: the producer believes it has sent nothing at all.
+	amnesiac := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	again, err := amnesiac.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("replay Push: %v", err)
+	}
+	if again.ArtifactID != res.ArtifactID {
+		t.Fatalf("replay minted artifact %q, original was %q", again.ArtifactID, res.ArtifactID)
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("replay created %d artifacts, want 1", f.ArtifactCount())
+	}
+	if got := f.PartCount(res.ArtifactID); got != 2 {
+		t.Errorf("replay stored %d parts, want 2", got)
+	}
+}
+
+// AC2 happy path: a restart mid-upload resumes at the next part and re-sends
+// none of the acknowledged ones.
+func TestRestartResumesWithoutDuplicateParts(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	a := sampleArtifact()
+	a.Parts = append(a.Parts, cityartifact.CityPart{Sequence: 3, Bytes: []byte("third part\n")})
+
+	// Part 1 lands, part 2 fails.
+	f.FailNext(cityartifact.OpUploadArtifactContent, nil)
+	f.FailNext(cityartifact.OpUploadArtifactContent, errors.New("connection reset by peer"))
+	res, err := p.Push(ctx, a)
+	if !errors.Is(err, cityartifact.ErrUpstream) {
+		t.Fatalf("err = %v, want ErrUpstream", err)
+	}
+	if res.Uploaded != 1 {
+		t.Fatalf("uploaded %d before the fault, want 1", res.Uploaded)
+	}
+	if got := f.PartCount(res.ArtifactID); got != 1 {
+		t.Fatalf("server stored %d parts, want 1", got)
+	}
+	if res.Finalized {
+		t.Fatal("finalized despite a failed part")
+	}
+
+	// A new process, same durable checkpoint.
+	resumed := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	after, err := resumed.Push(ctx, a)
+	if err != nil {
+		t.Fatalf("resumed Push: %v", err)
+	}
+	if after.ArtifactID != res.ArtifactID {
+		t.Errorf("resume minted a second artifact %q", after.ArtifactID)
+	}
+	if after.Uploaded != 2 || after.Skipped != 1 {
+		t.Errorf("resume uploaded %d skipped %d, want 2/1", after.Uploaded, after.Skipped)
+	}
+	if got := f.PartCount(res.ArtifactID); got != 3 {
+		t.Errorf("server stored %d parts, want 3", got)
+	}
+	if !after.Finalized {
+		t.Error("resume did not finalize a complete manifest")
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("tenant holds %d artifacts, want 1", f.ArtifactCount())
+	}
+}
+
+// AC2: the checkpoint advances only over contiguous acknowledgements. A failed
+// part leaves the frontier where it was, so the next attempt sends that part
+// again rather than the one after it.
+func TestCheckpointAdvancesOnlyOnAcknowledgement(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	f.FailNext(cityartifact.OpUploadArtifactContent, errors.New("upstream unavailable"))
+	if _, err := p.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrUpstream) {
+		t.Fatalf("err = %v, want ErrUpstream", err)
+	}
+	key := cityartifact.CheckpointKey(citySource(), "city-artifact-1")
+	st, ok, err := store.Load(ctx, key)
+	if err != nil || !ok {
+		t.Fatalf("Load = %v, %v", ok, err)
+	}
+	if st.Frontier != 0 {
+		t.Fatalf("frontier advanced to %d over an unacknowledged part", st.Frontier)
+	}
+	if st.ArtifactID == "" {
+		t.Fatal("the acknowledged create was not checkpointed")
+	}
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("retry Push: %v", err)
+	}
+	if res.Uploaded != 2 || res.Skipped != 0 {
+		t.Errorf("retry uploaded %d skipped %d, want 2/0", res.Uploaded, res.Skipped)
+	}
+}
+
+// AC2 edge: a changed hash under an acknowledged part stops the adapter and
+// sends nothing.
+func TestChangedManifestStopsTheAdapter(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	before := len(f.Calls())
+
+	rewritten := sampleArtifact()
+	rewritten.Parts[0].Bytes = []byte("rewritten first part\n")
+	res, err := p.Push(ctx, rewritten)
+	if !errors.Is(err, cityartifact.ErrChangedManifest) {
+		t.Fatalf("err = %v, want ErrChangedManifest", err)
+	}
+	for _, call := range f.Calls()[before:] {
+		if call == cityartifact.OpUploadArtifactContent {
+			t.Error("dispatched an upload for a rewritten part")
+		}
+	}
+	if got := f.PartCount(res.ArtifactID); got != 2 {
+		t.Errorf("server holds %d parts after a rewrite refusal, want the original 2", got)
+	}
+	// The checkpoint is intact: the original manifest still replays cleanly.
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Errorf("the original manifest no longer replays: %v", err)
+	}
+}
+
+// AC2 edge: the artifact's own definition changing after creation is the same
+// refusal — re-creating would fork the artifact.
+func TestChangedDefinitionStopsTheAdapter(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	f.Authorize("proj-beta")
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	moved := sampleArtifact()
+	moved.ProjectID = "proj-beta"
+	if _, err := p.Push(ctx, moved); !errors.Is(err, cityartifact.ErrChangedManifest) {
+		t.Fatalf("err = %v, want ErrChangedManifest", err)
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("a changed definition forked into %d artifacts", f.ArtifactCount())
+	}
+}
+
+// AC2 edge: a gap stops the adapter before anything is sent.
+func TestGapStopsTheAdapter(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+
+	gapped := sampleArtifact()
+	gapped.Parts = []cityartifact.CityPart{
+		{Sequence: 2, Bytes: []byte("second\n")},
+		{Sequence: 3, Bytes: []byte("third\n")},
+	}
+	res, err := p.Push(ctx, gapped)
+	if !errors.Is(err, cityartifact.ErrGap) {
+		t.Fatalf("err = %v, want ErrGap", err)
+	}
+	if res.Uploaded != 0 {
+		t.Errorf("uploaded %d parts across a gap", res.Uploaded)
+	}
+	if f.PartCount(res.ArtifactID) != 0 {
+		t.Errorf("server stored parts across a gap")
+	}
+	if res.Finalized {
+		t.Error("finalized across a gap")
+	}
+}
+
+// AC2: a duplicate part sequence in the manifest is refused before any call.
+func TestDuplicatePartSequenceRefused(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+
+	dup := sampleArtifact()
+	dup.Parts = append(dup.Parts, cityartifact.CityPart{Sequence: 1, Bytes: []byte("again\n")})
+	if _, err := p.Push(ctx, dup); !errors.Is(err, cityartifact.ErrInvalidArtifact) {
+		t.Fatalf("err = %v, want ErrInvalidArtifact", err)
+	}
+	if len(f.Calls()) != 0 {
+		t.Errorf("dispatched %v before refusing a duplicate sequence", f.Calls())
+	}
+}
+
+// AC2: credential rotation changes nothing. The key preimage holds the enrolled
+// source, not the credential, so a rotated client replays instead of duplicating.
+func TestCredentialRotationDoesNotDuplicate(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+
+	before := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	res, err := before.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	// New credential, same enrolled source, same checkpoint.
+	rotated := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	after, err := rotated.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("rotated Push: %v", err)
+	}
+	if after.ArtifactID != res.ArtifactID || after.Uploaded != 0 {
+		t.Errorf("rotation produced %+v, want a replay of %q", after, res.ArtifactID)
+	}
+	if f.ArtifactCount() != 1 || f.PartCount(res.ArtifactID) != 2 {
+		t.Errorf("rotation duplicated: %d artifacts, %d parts", f.ArtifactCount(), f.PartCount(res.ArtifactID))
+	}
+}
+
+// AC2: post-finalize input is refused. Finalize is one-way and this adapter does
+// not ask the server to reopen it.
+func TestPostFinalizeInputRefused(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	grown := sampleArtifact()
+	grown.Parts = append(grown.Parts, cityartifact.CityPart{Sequence: 3, Bytes: []byte("late\n")})
+	if _, err := p.Push(ctx, grown); !errors.Is(err, cityartifact.ErrFinalized) {
+		t.Fatalf("err = %v, want ErrFinalized", err)
+	}
+	if got := f.PartCount(res.ArtifactID); got != 2 {
+		t.Errorf("server stored %d parts after finalize, want 2", got)
+	}
+}
+
+// AC2: a declared reset restarts the checkpoint on the same key; an epoch that
+// went backwards is drift, not a retry.
+func TestEpochResetAndRegression(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	behind := citySource()
+	behind.Epoch = 0
+	regressed := producerOn(t, f.Client("src_city_1", "gascity"), behind, store)
+	if _, err := regressed.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift for a backwards epoch", err)
+	}
+
+	ahead := citySource()
+	ahead.Epoch = 2
+	reset := producerOn(t, f.Client("src_city_1", "gascity"), ahead, store)
+	res, err := reset.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("reset Push: %v", err)
+	}
+	key := cityartifact.CheckpointKey(ahead, "city-artifact-1")
+	if key != cityartifact.CheckpointKey(citySource(), "city-artifact-1") {
+		t.Fatalf("a reset landed on a different checkpoint key")
+	}
+	st, _, err := store.Load(ctx, key)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.Epoch != 2 {
+		t.Errorf("checkpoint epoch = %d, want 2", st.Epoch)
+	}
+	if f.ArtifactCount() != 2 {
+		t.Errorf("a declared reset produced %d artifacts, want a second generation", f.ArtifactCount())
+	}
+	if res.ArtifactID == "" {
+		t.Error("reset produced no artifact")
+	}
+}
+
+// AC2: a checkpoint that belongs to another enrolled source is drift, not state
+// to inherit. This is the credential-swap case a shared checkpoint file makes
+// reachable.
+func TestCheckpointFromAnotherSourceIsDrift(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	key := cityartifact.CheckpointKey(citySource(), "city-artifact-1")
+	if err := store.Save(ctx, key, cityartifact.State{Epoch: 1, SourceID: "src_someone_else"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	if _, err := p.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift", err)
+	}
+	if len(f.Calls()) != 0 {
+		t.Errorf("dispatched %v against a foreign checkpoint", f.Calls())
+	}
+}
+
+// AC2: checkpoints are namespaced by source, so the same City artifact ID under
+// two enrolled sources is two artifacts and not a collision.
+func TestCheckpointsAreNamespacedBySource(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	mine := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	if _, err := mine.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	other := cityartifact.Source{SourceID: "src_city_2", Kind: "gascity", Epoch: 1}
+	stranger := producerOn(t, f.Client("src_city_2", "gascity"), other, store)
+	// Same City artifact ID, different source: the key namespaces the source, so
+	// this is a different checkpoint and must not inherit the first one.
+	if _, err := stranger.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("stranger Push: %v", err)
+	}
+	if f.ArtifactCount() != 2 {
+		t.Errorf("two sources shared one artifact: count = %d", f.ArtifactCount())
+	}
+}

--- a/pkg/cityartifact/cityartifact.go
+++ b/pkg/cityartifact/cityartifact.go
@@ -1,0 +1,144 @@
+// Package cityartifact is Gas City's producer adapter for the Artifact
+// resources of the Beads Team Server v1 API.
+//
+// City is ONE OPTIONAL producer of artifacts. A custom producer with no City in
+// the picture creates, uploads and finalizes an artifact on its own credential
+// and gets a record of exactly the same public shape, so nothing here may
+// become a schema, an identity or an authority that a non-City producer would
+// have to satisfy. Artifact IDs are minted by the server and read back off a
+// response; this package never invents one, and City-shaped facts (city, rig,
+// formula) are display-only breadcrumbs the adapter refuses to place anywhere
+// in an outbound body.
+//
+// The layering matches the neutral run/session producer:
+//
+//   - [API] is the client seam. It carries one method per frozen artifact
+//     operation and NOTHING else. The adapter speaks no HTTP: no URL, no
+//     header, no status code appears anywhere below this file's imports.
+//   - [Mapper] turns a City artifact into request bodies and refuses any
+//     mapping that would let a City fact, a foreign link or a raw upstream
+//     field reach the server.
+//   - [Producer] owns the multi-part lifecycle: create, parts, finalize, with
+//     stable source idempotency, a contiguous acknowledged part frontier, and
+//     the refusals (changed manifest, gap, post-finalize write) that stop this
+//     adapter instead of corrupting an artifact.
+//
+// The four public categories — metadata, evidence, references, content — stay
+// separate here for the same reason they are separate server-side: they are
+// four reads behind four scopes, and this package never routes one through
+// another. Metadata calls carry no bytes and content calls carry no metadata.
+//
+// Rollback is per producer: stop calling Push and every acknowledged artifact
+// stays exactly as the server accepted it. This package never rewrites an
+// accepted part and never sends a mutation for a finalized artifact, and its
+// failures are its own — an artifact refusal cannot reach into the run,
+// session, transcript or event adapters, which hold their own checkpoints.
+package cityartifact
+
+import "errors"
+
+// Frozen operation IDs from operation_matrix_v6. They are spelled here so a
+// reader can check this adapter's surface against the frozen matrix without
+// leaving the package, and so the client seam cannot quietly grow a route that
+// is not in the matrix.
+const (
+	OpCreateArtifact        = "createArtifact"
+	OpListArtifacts         = "listArtifacts"
+	OpGetArtifact           = "getArtifact"
+	OpGetArtifactEvidence   = "getArtifactEvidence"
+	OpGetArtifactReferences = "getArtifactReferences"
+	OpUploadArtifactContent = "uploadArtifactContent"
+	OpFinalizeArtifact      = "finalizeArtifact"
+	OpGetArtifactContent    = "getArtifactContent"
+)
+
+// Category is the public category an operation reads. The four are pairwise
+// disjoint server-side; naming them here keeps the adapter honest about which
+// one each call touches.
+type Category string
+
+// The four categories. There is no fifth and no "all".
+const (
+	CategoryMetadata   Category = "metadata"
+	CategoryEvidence   Category = "evidence"
+	CategoryReferences Category = "references"
+	CategoryContent    Category = "content"
+)
+
+// CategoryOf reports the category of a frozen artifact operation. An unknown
+// operation has no category rather than a default one.
+func CategoryOf(operationID string) (Category, bool) {
+	switch operationID {
+	case OpCreateArtifact, OpListArtifacts, OpGetArtifact, OpFinalizeArtifact:
+		return CategoryMetadata, true
+	case OpGetArtifactEvidence:
+		return CategoryEvidence, true
+	case OpGetArtifactReferences:
+		return CategoryReferences, true
+	case OpUploadArtifactContent, OpGetArtifactContent:
+		return CategoryContent, true
+	}
+	return "", false
+}
+
+// Resource kinds in the derived idempotency preimage. A key minted for a create
+// may not be replayed into a part upload, so the kind is part of the preimage.
+const (
+	kindArtifact = "artifact"
+	kindPart     = "artifact_part"
+	kindFinalize = "artifact_finalize"
+)
+
+// Bounds mirroring the server's validators, so an oversized field is refused
+// here with a City field name attached rather than as a correlated 4xx.
+const (
+	maxSourceNativeIDLen = 200
+	maxLinkIDLen         = 200
+	maxPartBytes         = 8 << 20
+)
+
+// Refusals. Every one of them stops this producer with its checkpoint intact:
+// nothing has advanced past the last acknowledged part, so an operator who
+// fixes the source can restart and resume rather than reconcile.
+var (
+	// ErrChangedManifest is an artifact whose already-acknowledged parts no
+	// longer hash to what was accepted. Sending it would ask the server to
+	// rewrite accepted content, so the adapter stops instead.
+	ErrChangedManifest = errors.New("cityartifact: manifest changed under an acknowledged part")
+	// ErrGap is a part that would advance the frontier non-contiguously.
+	// Uploading it would leave a hole in the content no later read could tell
+	// apart from data loss.
+	ErrGap = errors.New("cityartifact: non-contiguous part would skip the acknowledged frontier")
+	// ErrFinalized is any attempt to add to or rewrite an artifact the server
+	// has already finalized. Finalize is one-way and this adapter is not the
+	// component that gets to argue with it.
+	ErrFinalized = errors.New("cityartifact: artifact is finalized; content cannot be rewritten")
+	// ErrIdentityDrift is a server response binding a stable City artifact
+	// identity to a different server-minted Artifact ID than the checkpoint
+	// holds, or an acknowledgement against the wrong artifact. Both are louder
+	// than a retry.
+	ErrIdentityDrift = errors.New("cityartifact: stable source identity resolved to a different artifact id")
+	// ErrCityAuthority is a mapping that would let a City-shaped fact become
+	// artifact authority: a City-minted artifact ID, a rig or formula name in a
+	// link slot, or a producer/source field set from the body.
+	ErrCityAuthority = errors.New("cityartifact: City-shaped field cannot become artifact authority")
+	// ErrInvalidArtifact is a City artifact this adapter refuses to map at all.
+	ErrInvalidArtifact = errors.New("cityartifact: invalid City artifact")
+	// ErrCredentialLeak is an outbound payload carrying credential evidence or
+	// a signed URL.
+	ErrCredentialLeak = errors.New("cityartifact: outbound payload carries credential evidence")
+	// ErrContentRoute is content bytes on a route not authorized to carry them.
+	// Metadata bodies never carry bytes; only the content route does.
+	ErrContentRoute = errors.New("cityartifact: content bytes outside the content route")
+	// ErrContentDenied is the server refusing content: a policy denial, a size
+	// refusal or a quarantine. It is terminal for this artifact and inert for
+	// every other adapter.
+	ErrContentDenied = errors.New("cityartifact: server denied artifact content")
+	// ErrUpstream is any other server failure, already stripped of its body.
+	// The upstream text never travels with it.
+	ErrUpstream = errors.New("cityartifact: upstream call failed")
+	// ErrNotReadable is an artifact that is not readable: absent, another
+	// tenant's, another producer's, or not yet finalized. The server answers
+	// all four the same way and so does this package.
+	ErrNotReadable = errors.New("cityartifact: artifact is not readable")
+)

--- a/pkg/cityartifact/contract.go
+++ b/pkg/cityartifact/contract.go
@@ -1,0 +1,154 @@
+package cityartifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+)
+
+// Links are the same-workspace resources an artifact is attached to. The
+// artifact owns none of them: they are references to resources that exist
+// independently, and the server's link verifier is what keeps a caller from
+// attaching to something it cannot see. A foreign link and an absent link are
+// one answer, here and there.
+type Links struct {
+	ProjectID string `json:"project_id,omitempty"`
+	IssueID   string `json:"issue_id,omitempty"`
+	RunID     string `json:"run_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+}
+
+// Empty reports whether the artifact declares no links at all. An unlinked
+// artifact is legal; it is simply not attached to anything.
+func (l Links) Empty() bool {
+	return l.ProjectID == "" && l.IssueID == "" && l.RunID == "" && l.SessionID == ""
+}
+
+// CreateRequest is the closed create body of createArtifact.
+//
+// There is no producer, source, id, status, digest or display member, exactly
+// as the server's body has none: provenance is credential-derived and identity
+// is server-minted. A City producer that wanted to name its own artifact has
+// nowhere to write it.
+type CreateRequest struct {
+	Kind      string `json:"kind"`
+	MediaType string `json:"media_type"`
+	Links     Links  `json:"links"`
+}
+
+// FinalizeRequest is the closed finalize body of finalizeArtifact. Finalization
+// asserts the content the producer believes it uploaded; the server checks that
+// assertion against what it actually stored.
+type FinalizeRequest struct {
+	Digest string `json:"digest,omitempty"`
+}
+
+// Part is one content part of uploadArtifactContent. Sequence is the producer's
+// own ordering; the server stores parts in the order it accepts them and this
+// adapter never sends a part out of order.
+type Part struct {
+	Bytes     []byte `json:"-"`
+	MediaType string `json:"media_type"`
+	Sequence  int    `json:"sequence"`
+}
+
+// Digest is the part's content digest, in the server's `sha256:<hex>` spelling.
+// It is what a part upload's identity is taken over, so the same bytes retried
+// are the same request and different bytes under the same sequence are a
+// conflict rather than an overwrite.
+func (p Part) Digest() string {
+	sum := sha256.Sum256(p.Bytes)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Artifact is the public read DTO, normalized. There is no storage location, no
+// signed URL, no upstream token and no raw upstream body anywhere in this
+// shape, because there is none in the server's.
+type Artifact struct {
+	ID          string     `json:"id"`
+	Kind        string     `json:"kind"`
+	MediaType   string     `json:"media_type"`
+	ByteSize    int64      `json:"byte_size"`
+	Digest      string     `json:"digest,omitempty"`
+	Status      string     `json:"status"`
+	SourceID    string     `json:"source_id"`
+	Producer    string     `json:"producer"`
+	Links       Links      `json:"links"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	FinalizedAt *time.Time `json:"finalized_at,omitempty"`
+	Display     string     `json:"display,omitempty"`
+}
+
+// Finalized reports whether the server has sealed this artifact. An unfinalized
+// artifact is writable and unreadable; a finalized one is readable and frozen.
+func (a Artifact) Finalized() bool { return a.FinalizedAt != nil }
+
+// EvidenceEntry is one normalized evidence statement, read behind its own
+// scope. It is never merged into the metadata read.
+type EvidenceEntry struct {
+	ID         string    `json:"id"`
+	Kind       string    `json:"kind"`
+	Statement  string    `json:"statement"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
+// Reference is one normalized outbound reference, read behind its own scope.
+type Reference struct {
+	ID       string `json:"id"`
+	Kind     string `json:"kind"`
+	TargetID string `json:"target_id"`
+}
+
+// Chunk is a bounded read of an artifact's bytes. It carries bytes and a media
+// type, never a location: this API hands a caller content, not a way to fetch
+// content elsewhere.
+type Chunk struct {
+	Bytes      []byte
+	MediaType  string
+	TotalSize  int64
+	Start, End int64
+}
+
+// Range is a bounded content read. A zero End means "to the end".
+type Range struct{ Start, End int64 }
+
+// ListQuery is the bounded filter of listArtifacts. The source filter is a
+// request, not an authority: the server validates it against the caller's own
+// enrolment and this adapter never assumes it was honored.
+type ListQuery struct {
+	SourceID string
+	Limit    int
+	Cursor   string
+}
+
+// API is the seam onto the public v1 client.
+//
+// It carries exactly the eight frozen artifact operations and no transport
+// vocabulary at all — no base URL, no header, no status code, no retry policy.
+// That is what keeps this package from hand-rolling HTTP: the concrete
+// implementation is the generated public client for the canonical contract, and
+// everything in this package is written against these signatures.
+//
+// NOTE: the contract program generates a public TypeScript client and a
+// server-side Go interface; there is no generated Go *client* module a Go
+// producer can import today. This interface is the shape that client binds to,
+// operation for operation, so binding it is a wiring change and never a logic
+// change.
+//
+// The idempotency key is a caller-supplied argument rather than something an
+// implementation invents, because the key is part of THIS package's dedup
+// contract: [Producer] derives it from stable source identity so a retry
+// replays and a changed payload conflicts. Read operations take no key: the
+// frozen matrix gives them idempotency policy "none".
+type API interface {
+	CreateArtifact(ctx context.Context, body CreateRequest, idempotencyKey string) (Artifact, error)
+	ListArtifacts(ctx context.Context, q ListQuery) ([]Artifact, string, error)
+	GetArtifact(ctx context.Context, artifactID string) (Artifact, error)
+	GetArtifactEvidence(ctx context.Context, artifactID string) (Artifact, []EvidenceEntry, error)
+	GetArtifactReferences(ctx context.Context, artifactID string) (Artifact, []Reference, error)
+	UploadArtifactContent(ctx context.Context, artifactID string, part Part, idempotencyKey string) (Artifact, error)
+	FinalizeArtifact(ctx context.Context, artifactID string, body FinalizeRequest, idempotencyKey string) (Artifact, error)
+	GetArtifactContent(ctx context.Context, artifactID string, rng Range) (Artifact, Chunk, error)
+}

--- a/pkg/cityartifact/fake.go
+++ b/pkg/cityartifact/fake.go
@@ -1,0 +1,421 @@
+package cityartifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrIdempotencyConflict is the fake's spelling of the server refusing a
+// replayed key whose payload changed. It exists so a test can assert that this
+// adapter never lands there by accident: a correct producer derives a key from
+// stable identity, so a conflict means the derivation drifted.
+var ErrIdempotencyConflict = errors.New("cityartifact: idempotency key replayed with a different payload")
+
+// Fake is an in-memory stand-in for the Beads Team Server's artifact routes,
+// implementing the semantics this adapter is written against:
+//
+//   - identity is server-minted; a producer's own ID never becomes an artifact ID
+//   - writes require the enrolled source that created the artifact
+//   - an unfinalized artifact is NOT readable, by anyone
+//   - finalize is one-way and idempotent, and checks an asserted digest
+//   - a mutation key replays an identical payload and conflicts on a changed one
+//   - the four categories are four separate reads
+//
+// One Fake is one tenant. [Fake.Client] binds a credential to it, which is what
+// lets a test run a City producer and a custom producer against the same server
+// and compare what came out.
+type Fake struct {
+	mu      sync.Mutex
+	seq     int
+	clock   time.Time
+	records map[string]*fakeRecord
+	keys    map[string]fakeKey
+	links   map[string]bool
+	faults  map[string][]error
+	calls   []string
+}
+
+type fakeRecord struct {
+	id          string
+	sourceID    string
+	producer    string
+	kind        string
+	mediaType   string
+	links       Links
+	parts       [][]byte
+	createdAt   time.Time
+	updatedAt   time.Time
+	finalizedAt *time.Time
+	evidence    []EvidenceEntry
+	references  []Reference
+}
+
+type fakeKey struct {
+	digest   string
+	artifact Artifact
+}
+
+// NewFake returns an empty tenant with a fixed clock.
+func NewFake() *Fake {
+	return &Fake{
+		clock:   time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC),
+		records: map[string]*fakeRecord{},
+		keys:    map[string]fakeKey{},
+		links:   map[string]bool{},
+		faults:  map[string][]error{},
+	}
+}
+
+// Authorize marks link targets this tenant can see. Anything not authorized is
+// foreign, and foreign and absent are one answer.
+func (f *Fake) Authorize(ids ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, id := range ids {
+		f.links[id] = true
+	}
+}
+
+// FailNext queues one failure for an operation. Queued failures are consumed in
+// order, so a test can fail an upload once and let the retry through.
+func (f *Fake) FailNext(operationID string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.faults[operationID] = append(f.faults[operationID], err)
+}
+
+// Calls returns the operation IDs dispatched so far, in order. It is how a test
+// asserts that a refusal stopped the adapter instead of sending it looking for
+// another way in.
+func (f *Fake) Calls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+// PartCount reports how many parts the server actually stored, which is what
+// "restart resumes without duplicate parts" is measured against.
+func (f *Fake) PartCount(artifactID string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rec, ok := f.records[artifactID]
+	if !ok {
+		return 0
+	}
+	return len(rec.parts)
+}
+
+// ArtifactCount reports how many artifacts exist in the tenant.
+func (f *Fake) ArtifactCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.records)
+}
+
+// Seed installs evidence and references on an artifact the way the server's
+// upstream would; the public API has no route that writes them.
+func (f *Fake) Seed(artifactID string, evidence []EvidenceEntry, refs []Reference) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if rec, ok := f.records[artifactID]; ok {
+		rec.evidence, rec.references = evidence, refs
+	}
+}
+
+// Client binds one enrolled credential to this tenant.
+func (f *Fake) Client(sourceID, producer string) API {
+	return &fakeClient{f: f, sourceID: sourceID, producer: producer}
+}
+
+type fakeClient struct {
+	f        *Fake
+	sourceID string
+	producer string
+}
+
+func (f *Fake) enter(operationID string) error {
+	f.calls = append(f.calls, operationID)
+	queued := f.faults[operationID]
+	if len(queued) == 0 {
+		return nil
+	}
+	err := queued[0]
+	f.faults[operationID] = queued[1:]
+	return err
+}
+
+func (f *Fake) mint(prefix string) string {
+	f.seq++
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s/%d", prefix, f.seq)))
+	return prefix + "_" + hex.EncodeToString(sum[:])[:20]
+}
+
+func (f *Fake) render(rec *fakeRecord) Artifact {
+	size := 0
+	for _, p := range rec.parts {
+		size += len(p)
+	}
+	art := Artifact{
+		ID:          rec.id,
+		Kind:        rec.kind,
+		MediaType:   rec.mediaType,
+		ByteSize:    int64(size),
+		Status:      "open",
+		SourceID:    rec.sourceID,
+		Producer:    rec.producer,
+		Links:       rec.links,
+		CreatedAt:   rec.createdAt,
+		UpdatedAt:   rec.updatedAt,
+		FinalizedAt: rec.finalizedAt,
+	}
+	if rec.finalizedAt != nil {
+		art.Status = "final"
+		art.Digest = rec.digest()
+	}
+	return art
+}
+
+func (r *fakeRecord) digest() string {
+	h := sha256.New()
+	for _, p := range r.parts {
+		h.Write(p)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// replay implements the mutation idempotency contract: an identical payload
+// under a known key returns the first response without dispatching a second
+// mutation, and a different payload under that key is a conflict.
+// The key is namespaced by the enrolled source, as the server's idempotency
+// namespace is: one source cannot replay into another's accepted response.
+func (f *Fake) replay(sourceID, key, digest string) (Artifact, bool, error) {
+	if strings.TrimSpace(key) == "" {
+		return Artifact{}, false, fmt.Errorf("%w: mutation requires an idempotency key", ErrInvalidArtifact)
+	}
+	key = sourceID + "\x1f" + key
+	prior, ok := f.keys[key]
+	if !ok {
+		return Artifact{}, false, nil
+	}
+	if prior.digest != digest {
+		return Artifact{}, false, ErrIdempotencyConflict
+	}
+	return prior.artifact, true, nil
+}
+
+func (c *fakeClient) CreateArtifact(_ context.Context, body CreateRequest, idempotencyKey string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpCreateArtifact); err != nil {
+		return Artifact{}, err
+	}
+	digest := payloadDigest(body)
+	if art, replayed, err := f.replay(c.sourceID, idempotencyKey, digest); err != nil || replayed {
+		return art, err
+	}
+	// Links are verified before anything is stored. A foreign link means the
+	// artifact is never created, so no part upload can follow it.
+	for _, target := range []string{body.Links.ProjectID, body.Links.IssueID, body.Links.RunID, body.Links.SessionID} {
+		if target == "" {
+			continue
+		}
+		if !f.links[target] {
+			return Artifact{}, ErrNotReadable
+		}
+	}
+	rec := &fakeRecord{
+		id:        f.mint("art"),
+		sourceID:  c.sourceID,
+		producer:  c.producer,
+		kind:      body.Kind,
+		mediaType: body.MediaType,
+		links:     body.Links,
+		createdAt: f.clock,
+		updatedAt: f.clock,
+	}
+	f.records[rec.id] = rec
+	art := f.render(rec)
+	f.keys[c.sourceID+"\x1f"+idempotencyKey] = fakeKey{digest: digest, artifact: art}
+	return art, nil
+}
+
+func (c *fakeClient) UploadArtifactContent(_ context.Context, artifactID string, part Part, idempotencyKey string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpUploadArtifactContent); err != nil {
+		return Artifact{}, err
+	}
+	digest := part.Digest() + "/" + part.MediaType
+	if art, replayed, err := f.replay(c.sourceID, idempotencyKey, digest); err != nil || replayed {
+		return art, err
+	}
+	rec, err := f.owned(artifactID, c.sourceID)
+	if err != nil {
+		return Artifact{}, err
+	}
+	if rec.finalizedAt != nil {
+		return Artifact{}, ErrFinalized
+	}
+	if len(part.Bytes) == 0 {
+		return Artifact{}, fmt.Errorf("%w: content part is empty", ErrInvalidArtifact)
+	}
+	rec.parts = append(rec.parts, append([]byte(nil), part.Bytes...))
+	rec.updatedAt = f.clock
+	art := f.render(rec)
+	f.keys[c.sourceID+"\x1f"+idempotencyKey] = fakeKey{digest: digest, artifact: art}
+	return art, nil
+}
+
+func (c *fakeClient) FinalizeArtifact(_ context.Context, artifactID string, body FinalizeRequest, idempotencyKey string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpFinalizeArtifact); err != nil {
+		return Artifact{}, err
+	}
+	digest := payloadDigest(body)
+	if art, replayed, err := f.replay(c.sourceID, idempotencyKey, digest); err != nil || replayed {
+		return art, err
+	}
+	rec, err := f.owned(artifactID, c.sourceID)
+	if err != nil {
+		return Artifact{}, err
+	}
+	if want := strings.TrimSpace(body.Digest); want != "" && want != rec.digest() {
+		return Artifact{}, fmt.Errorf("%w: asserted digest does not match stored content", ErrChangedManifest)
+	}
+	if rec.finalizedAt == nil {
+		at := f.clock
+		rec.finalizedAt = &at
+		rec.updatedAt = at
+	}
+	art := f.render(rec)
+	f.keys[c.sourceID+"\x1f"+idempotencyKey] = fakeKey{digest: digest, artifact: art}
+	return art, nil
+}
+
+func (c *fakeClient) GetArtifact(_ context.Context, artifactID string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifact); err != nil {
+		return Artifact{}, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, err
+	}
+	return f.render(rec), nil
+}
+
+func (c *fakeClient) GetArtifactEvidence(_ context.Context, artifactID string) (Artifact, []EvidenceEntry, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifactEvidence); err != nil {
+		return Artifact{}, nil, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, nil, err
+	}
+	return f.render(rec), append([]EvidenceEntry(nil), rec.evidence...), nil
+}
+
+func (c *fakeClient) GetArtifactReferences(_ context.Context, artifactID string) (Artifact, []Reference, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifactReferences); err != nil {
+		return Artifact{}, nil, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, nil, err
+	}
+	return f.render(rec), append([]Reference(nil), rec.references...), nil
+}
+
+func (c *fakeClient) GetArtifactContent(_ context.Context, artifactID string, rng Range) (Artifact, Chunk, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifactContent); err != nil {
+		return Artifact{}, Chunk{}, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, Chunk{}, err
+	}
+	var all []byte
+	for _, p := range rec.parts {
+		all = append(all, p...)
+	}
+	start, end := rng.Start, rng.End
+	if end <= 0 || end > int64(len(all)) {
+		end = int64(len(all))
+	}
+	if start < 0 || start > end {
+		return Artifact{}, Chunk{}, fmt.Errorf("%w: range is outside the artifact", ErrInvalidArtifact)
+	}
+	return f.render(rec), Chunk{
+		Bytes:     append([]byte(nil), all[start:end]...),
+		MediaType: rec.mediaType,
+		TotalSize: int64(len(all)),
+		Start:     start,
+		End:       end,
+	}, nil
+}
+
+func (c *fakeClient) ListArtifacts(_ context.Context, q ListQuery) ([]Artifact, string, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpListArtifacts); err != nil {
+		return nil, "", err
+	}
+	ids := make([]string, 0, len(f.records))
+	for id := range f.records {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]Artifact, 0, len(ids))
+	for _, id := range ids {
+		rec := f.records[id]
+		if q.SourceID != "" && rec.sourceID != q.SourceID {
+			continue
+		}
+		out = append(out, f.render(rec))
+	}
+	return out, "", nil
+}
+
+// readable resolves an artifact a reader may see: present and finalized. Absent
+// and unfinalized are one answer, so a probe cannot tell "not there" from "not
+// ready".
+func (f *Fake) readable(artifactID string) (*fakeRecord, error) {
+	rec, ok := f.records[strings.TrimSpace(artifactID)]
+	if !ok || rec.finalizedAt == nil {
+		return nil, ErrNotReadable
+	}
+	return rec, nil
+}
+
+// owned resolves an artifact a producer may write: present and produced by this
+// source. Another source's artifact is the same absence as a stranger's.
+func (f *Fake) owned(artifactID, sourceID string) (*fakeRecord, error) {
+	rec, ok := f.records[strings.TrimSpace(artifactID)]
+	if !ok || rec.sourceID != sourceID {
+		return nil, ErrNotReadable
+	}
+	return rec, nil
+}

--- a/pkg/cityartifact/fault_test.go
+++ b/pkg/cityartifact/fault_test.go
@@ -1,0 +1,280 @@
+package cityartifact_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+)
+
+// leakyUpstream is the kind of error a real transport hands back: a status line,
+// a raw response body, a bearer token and a pre-signed URL, all in one string.
+const leakyUpstream = `502 Bad Gateway: {"error":"presign failed","authorization":"Bearer sk-live-abc123def456",` +
+	`"location":"https://bucket.s3.amazonaws.com/tenant/obj?X-Amz-Signature=deadbeefdeadbeef",` +
+	`"stack":"art.storage.presign(/var/lib/art/blobs/ab/cd)"}`
+
+func assertNoLeak(t *testing.T, err error) {
+	t.Helper()
+	got := err.Error()
+	for _, secret := range []string{
+		"sk-live-abc123def456", "X-Amz-Signature", "bucket.s3.amazonaws.com",
+		"presign failed", "/var/lib/art/blobs", "502 Bad Gateway", "Bearer",
+	} {
+		if strings.Contains(got, secret) {
+			t.Errorf("error leaked %q: %s", secret, got)
+		}
+	}
+}
+
+// AC3 happy path: a failure is observable as a safe, normalized refusal — the
+// caller learns which operation failed and nothing else.
+func TestUpstreamFailureIsNormalizedAndSafe(t *testing.T) {
+	ctx := context.Background()
+	for _, op := range []string{
+		cityartifact.OpCreateArtifact,
+		cityartifact.OpUploadArtifactContent,
+		cityartifact.OpFinalizeArtifact,
+	} {
+		t.Run(op, func(t *testing.T) {
+			f := authorizedFake()
+			p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+			f.FailNext(op, errors.New(leakyUpstream))
+			_, err := p.Push(ctx, sampleArtifact())
+			if !errors.Is(err, cityartifact.ErrUpstream) {
+				t.Fatalf("err = %v, want ErrUpstream", err)
+			}
+			if !strings.Contains(err.Error(), op) {
+				t.Errorf("error does not name the failed operation: %s", err)
+			}
+			assertNoLeak(t, err)
+		})
+	}
+}
+
+// AC3: the same normalization applies to every read, including the content read
+// — the one call that legitimately handles bytes.
+func TestReadFailuresAreNormalizedAndSafe(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	reads := map[string]func() error{
+		cityartifact.OpGetArtifact:           func() error { _, err := p.Metadata(ctx, res.ArtifactID); return err },
+		cityartifact.OpGetArtifactEvidence:   func() error { _, err := p.Evidence(ctx, res.ArtifactID); return err },
+		cityartifact.OpGetArtifactReferences: func() error { _, err := p.References(ctx, res.ArtifactID); return err },
+		cityartifact.OpGetArtifactContent: func() error {
+			_, err := p.Content(ctx, res.ArtifactID, cityartifact.Range{})
+			return err
+		},
+		cityartifact.OpListArtifacts: func() error { _, _, err := p.List(ctx, cityartifact.ListQuery{}); return err },
+	}
+	for op, call := range reads {
+		f.FailNext(op, fmt.Errorf("wrapped: %s", leakyUpstream))
+		err := call()
+		if !errors.Is(err, cityartifact.ErrUpstream) {
+			t.Errorf("%s: err = %v, want ErrUpstream", op, err)
+		}
+		assertNoLeak(t, err)
+	}
+}
+
+// AC3: a content denial is terminal for this artifact. No finalize follows, no
+// other route is tried, and no second credential is reached for.
+func TestContentDenialStopsWithoutFallback(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	f.FailNext(cityartifact.OpUploadArtifactContent, cityartifact.ErrContentDenied)
+	res, err := p.Push(ctx, sampleArtifact())
+	if !errors.Is(err, cityartifact.ErrContentDenied) {
+		t.Fatalf("err = %v, want ErrContentDenied", err)
+	}
+	if res.Uploaded != 0 || res.Finalized {
+		t.Errorf("result = %+v, want nothing uploaded and nothing finalized", res)
+	}
+	calls := f.Calls()
+	if len(calls) != 2 || calls[0] != cityartifact.OpCreateArtifact || calls[1] != cityartifact.OpUploadArtifactContent {
+		t.Fatalf("calls = %v, want exactly the create and the denied upload", calls)
+	}
+	// The artifact stays unreadable: a denial cannot leave half an artifact
+	// visible, because it was never finalized.
+	if _, err := p.Metadata(ctx, res.ArtifactID); !errors.Is(err, cityartifact.ErrNotReadable) {
+		t.Errorf("metadata of a denied artifact = %v, want ErrNotReadable", err)
+	}
+}
+
+// AC3 edge: a scoped failure stays scoped. One artifact's denial leaves every
+// other artifact — and every other producer's checkpoint — untouched, and the
+// denied artifact resumes once the denial clears.
+func TestScopedFailureDoesNotWidenOrSpread(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	denied := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	neighborStore := cityartifact.NewMemoryStore()
+	neighbor := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), neighborStore)
+
+	f.FailNext(cityartifact.OpUploadArtifactContent, cityartifact.ErrContentDenied)
+	bad := sampleArtifact()
+	if _, err := denied.Push(ctx, bad); !errors.Is(err, cityartifact.ErrContentDenied) {
+		t.Fatalf("err = %v, want ErrContentDenied", err)
+	}
+
+	// A different artifact on the same credential is unaffected.
+	other := sampleArtifact()
+	other.ArtifactID = "city-artifact-2"
+	res, err := neighbor.Push(ctx, other)
+	if err != nil {
+		t.Fatalf("neighbor Push: %v", err)
+	}
+	if !res.Finalized {
+		t.Error("a neighboring artifact was dragged down by an unrelated denial")
+	}
+
+	// The denied artifact resumes from its intact checkpoint, without a second
+	// artifact and without a duplicate part.
+	resumed, err := denied.Push(ctx, bad)
+	if err != nil {
+		t.Fatalf("resumed Push: %v", err)
+	}
+	if resumed.Uploaded != 2 || !resumed.Finalized {
+		t.Errorf("resume = %+v, want both parts uploaded and finalized", resumed)
+	}
+	if f.ArtifactCount() != 2 {
+		t.Errorf("tenant holds %d artifacts, want exactly the two pushed", f.ArtifactCount())
+	}
+	if got := f.PartCount(resumed.ArtifactID); got != 2 {
+		t.Errorf("denied artifact holds %d parts after resume, want 2", got)
+	}
+}
+
+// AC3: a timeout is an upstream failure with the context error preserved and the
+// transport detail dropped.
+func TestTimeoutIsNormalized(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	f.FailNext(cityartifact.OpCreateArtifact,
+		fmt.Errorf("post %s: %w", "https://api.internal/v1/artifacts?token=sk-live-1", context.DeadlineExceeded))
+
+	_, err := p.Push(ctx, sampleArtifact())
+	if !errors.Is(err, cityartifact.ErrUpstream) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want ErrUpstream wrapping the deadline", err)
+	}
+	if strings.Contains(err.Error(), "token=sk-live-1") || strings.Contains(err.Error(), "api.internal") {
+		t.Errorf("timeout error leaked the request URL: %s", err)
+	}
+}
+
+// malformedAPI answers successfully but with responses that do not hold
+// together: no identity, or an acknowledgement against a different artifact.
+type malformedAPI struct {
+	cityartifact.API
+	createID   string
+	uploadID   string
+	finalizeID string
+	finalized  bool
+}
+
+func (m malformedAPI) CreateArtifact(context.Context, cityartifact.CreateRequest, string) (cityartifact.Artifact, error) {
+	return cityartifact.Artifact{ID: m.createID}, nil
+}
+
+func (m malformedAPI) UploadArtifactContent(context.Context, string, cityartifact.Part, string) (cityartifact.Artifact, error) {
+	return cityartifact.Artifact{ID: m.uploadID}, nil
+}
+
+func (m malformedAPI) FinalizeArtifact(context.Context, string, cityartifact.FinalizeRequest, string) (cityartifact.Artifact, error) {
+	art := cityartifact.Artifact{ID: m.finalizeID}
+	if m.finalized {
+		at := time.Now()
+		art.FinalizedAt = &at
+	}
+	return art, nil
+}
+
+// AC3: a malformed response is refused rather than recorded. An empty identity,
+// a foreign acknowledgement and an unsealed finalize are all drift.
+func TestMalformedResponsesAreRefused(t *testing.T) {
+	ctx := context.Background()
+	cases := map[string]struct {
+		api  malformedAPI
+		want error
+	}{
+		"create without an id": {
+			malformedAPI{createID: ""}, cityartifact.ErrIdentityDrift,
+		},
+		"part acknowledged against another artifact": {
+			malformedAPI{createID: "art_1", uploadID: "art_2"}, cityartifact.ErrIdentityDrift,
+		},
+		"finalize acknowledged against another artifact": {
+			malformedAPI{createID: "art_1", uploadID: "art_1", finalizeID: "art_9", finalized: true},
+			cityartifact.ErrIdentityDrift,
+		},
+		"finalize returns an unsealed artifact": {
+			malformedAPI{createID: "art_1", uploadID: "art_1", finalizeID: "art_1"},
+			cityartifact.ErrUpstream,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := producerOn(t, tc.api, citySource(), cityartifact.NewMemoryStore())
+			if _, err := p.Push(ctx, sampleArtifact()); !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// AC3: a read-back that disagrees with what was sent is drift, not success.
+func TestReadBackMismatchIsDrift(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	// A second producer's credential is enrolled under a different source, so the
+	// artifact it reads back reports a source this producer did not send under.
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if res.Metadata.SourceID != "src_city_1" {
+		t.Fatalf("source_id = %q, want the enrolled source", res.Metadata.SourceID)
+	}
+
+	mismatched := cityartifact.Source{SourceID: "src_city_1", Kind: "gascity", Epoch: 1}
+	other := producerOn(t, f.Client("src_other", "other"), mismatched, cityartifact.NewMemoryStore())
+	if _, err := other.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift when the read-back names another source", err)
+	}
+}
+
+// AC3: an idempotency key derived from anything volatile would show up here as a
+// conflict. It never does, which is what makes the derivation the dedup contract
+// rather than a hope.
+func TestNoIdempotencyConflictAcrossRetries(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	for i := 0; i < 4; i++ {
+		if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+			t.Fatalf("push %d: %v", i, err)
+		}
+	}
+	fresh := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	if _, err := fresh.Push(ctx, sampleArtifact()); err != nil {
+		if errors.Is(err, cityartifact.ErrIdempotencyConflict) {
+			t.Fatalf("derived key conflicted on identical input: %v", err)
+		}
+		t.Fatalf("fresh Push: %v", err)
+	}
+}

--- a/pkg/cityartifact/mapping.go
+++ b/pkg/cityartifact/mapping.go
@@ -1,0 +1,411 @@
+package cityartifact
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// CityPart is one part of a City artifact's content, as City holds it.
+type CityPart struct {
+	// Sequence is City's own 1-based part ordering. It is what contiguity is
+	// judged on, and it is never sent as an identity.
+	Sequence int
+	// Bytes are the part's content. They travel on the content route and
+	// nowhere else.
+	Bytes []byte
+	// MediaType is the part's own media type. It is normalized before it
+	// leaves; an unparseable one is a refusal, not a passthrough.
+	MediaType string
+}
+
+// CityArtifact is one artifact as City knows it, before any mapping.
+//
+// ArtifactID is City's own stable native ID. It is the dedup and checkpoint
+// identity of this artifact and it is NEVER sent as the artifact's identity:
+// the server mints that, and City reads it back.
+type CityArtifact struct {
+	ArtifactID string
+	Kind       string
+	MediaType  string
+	// Version is City's monotonic version of this artifact's definition. A
+	// bumped version is a new idempotency identity; an unbumped one replays.
+	Version uint64
+
+	// Links are the same-workspace resources this artifact attaches to. Run and
+	// session IDs are server-minted neutral Team IDs City read off an earlier
+	// response, not City-native run names.
+	ProjectID string
+	IssueID   string
+	RunID     string
+	SessionID string
+
+	// City-shaped facts. They are breadcrumbs for City's own logs; the mapper
+	// refuses to place any of them in an outbound body, and the create body has
+	// no member that could hold one.
+	City    string
+	Rig     string
+	Formula string
+
+	// Parts is the content manifest. An artifact with no parts is legal: it
+	// finalizes empty, exactly as a custom producer's would.
+	Parts []CityPart
+	// Complete is City's claim that the manifest is whole. Only a complete
+	// artifact is finalized, and only a finalized artifact is readable.
+	Complete bool
+}
+
+// Source is the enrolled producer identity this adapter uploads under. It is
+// resolved from the credential at enrolment; this package treats it as read-only
+// fact and never derives authority from a City name.
+type Source struct {
+	SourceID string
+	Kind     string
+	// Epoch is the declared reset generation. A bumped epoch restarts this
+	// producer's checkpoint; it never rewrites what the server already accepted.
+	Epoch uint64
+}
+
+// Mapper turns a City artifact into the closed request bodies of the frozen
+// artifact operations, refusing every mapping that would let a City fact, a
+// malformed link or a raw upstream field reach the server.
+type Mapper struct {
+	Source Source
+}
+
+const (
+	defaultKind      = "file"
+	defaultMediaType = "application/octet-stream"
+)
+
+// canonicalKinds is the server's closed kind vocabulary. City may not invent a
+// kind, so an unmapped City kind lands on the default rather than traveling raw.
+var canonicalKinds = []string{"file", "log", "report", "bundle", "diff", "trace"}
+
+// cityKindMap folds City's own artifact vocabulary onto the closed one. It is a
+// mapping, not a passthrough: a City kind with no entry becomes the default.
+var cityKindMap = map[string]string{
+	"transcript": "log",
+	"logs":       "log",
+	"review":     "report",
+	"summary":    "report",
+	"patch":      "diff",
+	"workspace":  "bundle",
+	"profile":    "trace",
+}
+
+var (
+	// Neutral Team ID shapes. A run or session link is a server-minted ID City
+	// read back off a response; anything else in that slot is a City-shaped
+	// value trying to become a link authority.
+	runIDPattern     = regexp.MustCompile(`^run_[0-9a-z]{16,}$`)
+	sessionIDPattern = regexp.MustCompile(`^ses_[0-9a-z]{16,}$`)
+	// cityLocatorPattern is a City-native locator: a scheme or a prefixed name
+	// that only means something inside City.
+	cityLocatorPattern = regexp.MustCompile(`(?i)^(gc://|city[:/]|rig[:/]|formula[:/])`)
+)
+
+// secretLocatorPatterns catch credential evidence and pre-signed locators in
+// outbound strings. A signed URL is exactly as forbidden as a bearer token: both
+// are ways to reach bytes outside the authorized route.
+var secretLocatorPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\bbearer\s+[a-z0-9._~+/-]{8,}`),
+	regexp.MustCompile(`(?i)\bauthorization\s*:`),
+	regexp.MustCompile(`(?i)x-amz-(signature|credential|security-token)`),
+	regexp.MustCompile(`(?i)[?&](signature|sig|token|access_token|api_key)=`),
+	regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+	regexp.MustCompile(`\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`),
+}
+
+// SecretLocator reports whether a string carries credential evidence or a
+// pre-signed locator.
+func SecretLocator(s string) bool {
+	for _, re := range secretLocatorPatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Mapper) validateSource() error {
+	if strings.TrimSpace(m.Source.SourceID) == "" {
+		return fmt.Errorf("%w: source id is required", ErrInvalidArtifact)
+	}
+	if strings.TrimSpace(m.Source.Kind) == "" {
+		return fmt.Errorf("%w: source kind is required", ErrInvalidArtifact)
+	}
+	return nil
+}
+
+func validateNativeID(field, v string) error {
+	switch {
+	case strings.TrimSpace(v) == "":
+		return fmt.Errorf("%w: %s is required", ErrInvalidArtifact, field)
+	case len(v) > maxSourceNativeIDLen:
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidArtifact, field, maxSourceNativeIDLen)
+	case strings.ContainsAny(v, " \t\r\n"):
+		return fmt.Errorf("%w: %s contains whitespace", ErrInvalidArtifact, field)
+	case SecretLocator(v):
+		return fmt.Errorf("%w: %s", ErrCredentialLeak, field)
+	}
+	return nil
+}
+
+// MapLinks normalizes and validates the artifact's links.
+//
+// It runs before anything is created and therefore before any byte is uploaded:
+// a link this adapter can already tell is malformed or City-shaped never reaches
+// the server, and a link the server rejects as foreign fails the create, which
+// is the only call that carries links. Either way no content leaves the process.
+func (m Mapper) MapLinks(a CityArtifact) (Links, error) {
+	l := Links{
+		ProjectID: strings.TrimSpace(a.ProjectID),
+		IssueID:   strings.TrimSpace(a.IssueID),
+		RunID:     strings.TrimSpace(a.RunID),
+		SessionID: strings.TrimSpace(a.SessionID),
+	}
+	cityFacts := []string{a.City, a.Rig, a.Formula}
+	for field, v := range map[string]string{
+		"links.project_id": l.ProjectID,
+		"links.issue_id":   l.IssueID,
+		"links.run_id":     l.RunID,
+		"links.session_id": l.SessionID,
+	} {
+		if v == "" {
+			continue
+		}
+		if err := validateLinkValue(field, v, cityFacts); err != nil {
+			return Links{}, err
+		}
+	}
+	if l.RunID != "" && !runIDPattern.MatchString(l.RunID) {
+		return Links{}, fmt.Errorf("%w: links.run_id %q is not a server-minted run id", ErrCityAuthority, l.RunID)
+	}
+	if l.SessionID != "" && !sessionIDPattern.MatchString(l.SessionID) {
+		return Links{}, fmt.Errorf("%w: links.session_id %q is not a server-minted session id", ErrCityAuthority, l.SessionID)
+	}
+	return l, nil
+}
+
+func validateLinkValue(field, v string, cityFacts []string) error {
+	switch {
+	case len(v) > maxLinkIDLen:
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidArtifact, field, maxLinkIDLen)
+	case strings.ContainsAny(v, " \t\r\n"):
+		return fmt.Errorf("%w: %s contains whitespace", ErrInvalidArtifact, field)
+	case SecretLocator(v):
+		return fmt.Errorf("%w: %s", ErrCredentialLeak, field)
+	case cityLocatorPattern.MatchString(v):
+		return fmt.Errorf("%w: %s is a City locator", ErrCityAuthority, field)
+	}
+	for _, fact := range cityFacts {
+		if fact != "" && strings.EqualFold(fact, v) {
+			return fmt.Errorf("%w: %s repeats a City name", ErrCityAuthority, field)
+		}
+	}
+	return nil
+}
+
+// MapCreate builds the create body. The result carries a closed kind, a
+// normalized media type and verified links, and nothing else — there is no slot
+// for a City name, a producer, a status or an ID.
+func (m Mapper) MapCreate(a CityArtifact) (CreateRequest, error) {
+	if err := m.validateSource(); err != nil {
+		return CreateRequest{}, err
+	}
+	if err := validateNativeID("artifact_id", a.ArtifactID); err != nil {
+		return CreateRequest{}, err
+	}
+	links, err := m.MapLinks(a)
+	if err != nil {
+		return CreateRequest{}, err
+	}
+	mediaType := normalizeMediaType(a.MediaType)
+	if mediaType == "" {
+		return CreateRequest{}, fmt.Errorf("%w: media_type %q is not a media type", ErrInvalidArtifact, a.MediaType)
+	}
+	return CreateRequest{Kind: mapKind(a.Kind), MediaType: mediaType, Links: links}, nil
+}
+
+// MapPart builds one content part. Bytes are copied so a later mutation of the
+// City slice cannot change what this adapter believes it acknowledged.
+func (m Mapper) MapPart(a CityArtifact, p CityPart) (Part, error) {
+	switch {
+	case p.Sequence < 1:
+		return Part{}, fmt.Errorf("%w: part sequence must be positive, got %d", ErrInvalidArtifact, p.Sequence)
+	case len(p.Bytes) == 0:
+		return Part{}, fmt.Errorf("%w: part %d is empty", ErrInvalidArtifact, p.Sequence)
+	case len(p.Bytes) > maxPartBytes:
+		return Part{}, fmt.Errorf("%w: part %d exceeds %d bytes", ErrInvalidArtifact, p.Sequence, maxPartBytes)
+	}
+	mediaType := normalizeMediaType(firstNonEmpty(p.MediaType, a.MediaType))
+	if mediaType == "" {
+		return Part{}, fmt.Errorf("%w: part %d media_type is not a media type", ErrInvalidArtifact, p.Sequence)
+	}
+	out := Part{Bytes: append([]byte(nil), p.Bytes...), MediaType: mediaType, Sequence: p.Sequence}
+	return out, nil
+}
+
+// MapFinalize builds the finalize body. The asserted digest is taken over the
+// manifest this adapter actually uploaded, in sequence order, so an assertion
+// can only ever describe content that left this process.
+func (m Mapper) MapFinalize(digest string) FinalizeRequest {
+	return FinalizeRequest{Digest: digest}
+}
+
+func mapKind(k string) string {
+	k = strings.ToLower(strings.TrimSpace(k))
+	if mapped, ok := cityKindMap[k]; ok {
+		return mapped
+	}
+	for _, canonical := range canonicalKinds {
+		if k == canonical {
+			return k
+		}
+	}
+	return defaultKind
+}
+
+// normalizeMediaType keeps a media type to its lowercased type/subtype, exactly
+// as the server does. Parameters are dropped rather than echoed: a charset City
+// sent is not a fact about the stored bytes, and an unbounded parameter string
+// is one more place an upstream secret could ride.
+func normalizeMediaType(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if v == "" {
+		return defaultMediaType
+	}
+	if i := strings.IndexByte(v, ';'); i >= 0 {
+		v = strings.TrimSpace(v[:i])
+	}
+	parts := strings.Split(v, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	for _, p := range parts {
+		if strings.ContainsAny(p, " \t\r\n\"\\") {
+			return ""
+		}
+	}
+	return v
+}
+
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// forbiddenBodyFields are members no outbound artifact body may carry. Identity,
+// provenance and state are server-derived; a body that tries to set one is a
+// City fact reaching for authority. Locators are here for the same reason a
+// signed URL is refused on the way in: an artifact API hands over content, never
+// a way to fetch content elsewhere.
+var forbiddenBodyFields = map[string]bool{
+	"id":           true,
+	"artifact_id":  true,
+	"source_id":    true,
+	"producer":     true,
+	"status":       true,
+	"digest":       true,
+	"byte_size":    true,
+	"created_at":   true,
+	"updated_at":   true,
+	"finalized_at": true,
+	"display":      true,
+	"city":         true,
+	"rig":          true,
+	"formula":      true,
+	"token":        true,
+	"url":          true,
+	"signed_url":   true,
+	"location":     true,
+	"href":         true,
+	"bucket":       true,
+	"object_key":   true,
+	"etag":         true,
+}
+
+// contentBearingFields are members that would put bytes inside a JSON body. No
+// artifact body in this package has one: content travels as [Part.Bytes] to the
+// content route and nowhere else, and [Part] does not serialize its bytes.
+var contentBearingFields = map[string]bool{
+	"bytes":   true,
+	"content": true,
+	"text":    true,
+	"body":    true,
+	"data":    true,
+}
+
+// ScanOutbound is the last gate before a body is handed to the client seam.
+//
+// It works on the encoded body rather than on the Go type, so a member added to
+// a request struct later is scanned without anyone remembering to update a list
+// of accessors. allowed names the members this particular body is entitled to
+// carry despite the lists below — today that is the finalize body's asserted
+// digest, which is the producer's claim about content it uploaded rather than a
+// server-derived field being overwritten.
+func ScanOutbound(body any, allowed ...string) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("cityartifact: scan encode: %w", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return fmt.Errorf("cityartifact: scan decode: %w", err)
+	}
+	permitted := make(map[string]bool, len(allowed))
+	for _, k := range allowed {
+		permitted[k] = true
+	}
+	return scanObject(generic, permitted, "")
+}
+
+func scanObject(obj map[string]any, permitted map[string]bool, path string) error {
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		at := k
+		if path != "" {
+			at = path + "." + k
+		}
+		if !permitted[k] {
+			if forbiddenBodyFields[k] {
+				return fmt.Errorf("%w: body carries %s", ErrCityAuthority, at)
+			}
+			if contentBearingFields[k] {
+				return fmt.Errorf("%w: %s", ErrContentRoute, at)
+			}
+		}
+		switch v := obj[k].(type) {
+		case string:
+			if SecretLocator(v) {
+				return fmt.Errorf("%w: %s", ErrCredentialLeak, at)
+			}
+		case map[string]any:
+			if err := scanObject(v, permitted, at); err != nil {
+				return err
+			}
+		case []any:
+			for i, item := range v {
+				nested, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if err := scanObject(nested, permitted, fmt.Sprintf("%s[%d]", at, i)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cityartifact/parity_test.go
+++ b/pkg/cityartifact/parity_test.go
@@ -1,0 +1,360 @@
+package cityartifact_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+)
+
+const (
+	linkedRun     = "run_abcdefghij0123456789"
+	linkedSession = "ses_abcdefghij0123456789"
+	linkedProject = "proj-alpha"
+	linkedIssue   = "bd-7"
+)
+
+func citySource() cityartifact.Source {
+	return cityartifact.Source{SourceID: "src_city_1", Kind: "gascity", Epoch: 1}
+}
+
+func newCityProducer(t *testing.T, f *cityartifact.Fake) *cityartifact.Producer {
+	t.Helper()
+	p, err := cityartifact.NewProducer(f.Client("src_city_1", "gascity"),
+		cityartifact.Mapper{Source: citySource()}, cityartifact.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	return p
+}
+
+func sampleArtifact() cityartifact.CityArtifact {
+	return cityartifact.CityArtifact{
+		ArtifactID: "city-artifact-1",
+		Kind:       "transcript",
+		MediaType:  "text/plain; charset=utf-8",
+		Version:    1,
+		ProjectID:  linkedProject,
+		IssueID:    linkedIssue,
+		RunID:      linkedRun,
+		SessionID:  linkedSession,
+		City:       "rustbelt",
+		Rig:        "rig-3",
+		Formula:    "review",
+		Parts: []cityartifact.CityPart{
+			{Sequence: 1, Bytes: []byte("first part\n")},
+			{Sequence: 2, Bytes: []byte("second part\n")},
+		},
+		Complete: true,
+	}
+}
+
+func authorizedFake() *cityartifact.Fake {
+	f := cityartifact.NewFake()
+	f.Authorize(linkedProject, linkedIssue, linkedRun, linkedSession)
+	return f
+}
+
+// AC1 happy path: a valid linked artifact finalizes and its metadata reads back
+// normalized.
+func TestPushFinalizesAndReadsBack(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := newCityProducer(t, f)
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if !res.Finalized || res.Uploaded != 2 {
+		t.Fatalf("want 2 uploaded and finalized, got %+v", res)
+	}
+	if !strings.HasPrefix(res.ArtifactID, "art_") {
+		t.Fatalf("artifact id %q is not server-minted", res.ArtifactID)
+	}
+	if strings.Contains(res.ArtifactID, "city-artifact-1") {
+		t.Fatalf("City minted the artifact id: %q", res.ArtifactID)
+	}
+	meta := res.Metadata
+	if meta.Kind != "log" {
+		t.Errorf("kind = %q, want the closed-vocabulary mapping of a City transcript", meta.Kind)
+	}
+	if meta.MediaType != "text/plain" {
+		t.Errorf("media_type = %q, want the charset parameter dropped", meta.MediaType)
+	}
+	if meta.Status != "final" || !meta.Finalized() {
+		t.Errorf("status = %q finalized = %v, want a sealed artifact", meta.Status, meta.Finalized())
+	}
+	if meta.SourceID != "src_city_1" {
+		t.Errorf("source_id = %q, want the credential-derived source", meta.SourceID)
+	}
+	wantLinks := cityartifact.Links{ProjectID: linkedProject, IssueID: linkedIssue, RunID: linkedRun, SessionID: linkedSession}
+	if meta.Links != wantLinks {
+		t.Errorf("links = %+v, want %+v", meta.Links, wantLinks)
+	}
+	for _, fact := range []string{"rustbelt", "rig-3", "review"} {
+		if strings.Contains(meta.Display, fact) {
+			t.Errorf("City fact %q reached the public shape", fact)
+		}
+	}
+}
+
+// AC1: the same public contract, Team IDs, category scopes and provenance apply
+// whether City or a custom producer uploaded. Two credentials, one tenant, one
+// shape.
+func TestCityAndCustomProducerAgree(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+
+	city := newCityProducer(t, f)
+	cityRes, err := city.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("city Push: %v", err)
+	}
+
+	// The custom producer is not City: different source, no City vocabulary,
+	// its own checkpoint. It uploads the same content via the same seam.
+	customSource := cityartifact.Source{SourceID: "src_custom_1", Kind: "custom", Epoch: 1}
+	custom, err := cityartifact.NewProducer(f.Client("src_custom_1", "custom-agent"),
+		cityartifact.Mapper{Source: customSource}, cityartifact.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("custom NewProducer: %v", err)
+	}
+	plain := sampleArtifact()
+	plain.ArtifactID = "custom-artifact-1"
+	plain.Kind = "log"
+	plain.City, plain.Rig, plain.Formula = "", "", ""
+	customRes, err := custom.Push(ctx, plain)
+	if err != nil {
+		t.Fatalf("custom Push: %v", err)
+	}
+
+	a, b := cityRes.Metadata, customRes.Metadata
+	if a.ID == b.ID {
+		t.Fatalf("both producers landed on artifact %q", a.ID)
+	}
+	if a.Kind != b.Kind || a.MediaType != b.MediaType || a.Links != b.Links {
+		t.Errorf("shape diverged: city %+v custom %+v", a, b)
+	}
+	if a.Digest != b.Digest {
+		t.Errorf("identical content hashed differently: %q vs %q", a.Digest, b.Digest)
+	}
+	if a.ByteSize != b.ByteSize || a.Status != b.Status {
+		t.Errorf("state diverged: city %+v custom %+v", a, b)
+	}
+	if a.SourceID == b.SourceID {
+		t.Errorf("provenance collapsed: both report source %q", a.SourceID)
+	}
+	if a.Producer != "gascity" || b.Producer != "custom-agent" {
+		t.Errorf("producer attribution wrong: %q / %q", a.Producer, b.Producer)
+	}
+
+	// A custom producer reads a City artifact through the same public route:
+	// City is one optional producer, not a private namespace.
+	got, err := custom.Metadata(ctx, cityRes.ArtifactID)
+	if err != nil {
+		t.Fatalf("custom read of a City artifact: %v", err)
+	}
+	if got.ID != cityRes.ArtifactID {
+		t.Errorf("read back %q, want %q", got.ID, cityRes.ArtifactID)
+	}
+}
+
+// AC1 edge: a foreign link fails before a single byte is uploaded.
+func TestForeignLinkFailsBeforeUpload(t *testing.T) {
+	ctx := context.Background()
+	f := cityartifact.NewFake()
+	f.Authorize(linkedProject, linkedIssue, linkedRun) // session deliberately absent
+	p := newCityProducer(t, f)
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if !errors.Is(err, cityartifact.ErrNotReadable) {
+		t.Fatalf("err = %v, want a foreign link refusal", err)
+	}
+	if res.Uploaded != 0 {
+		t.Errorf("uploaded %d parts despite a foreign link", res.Uploaded)
+	}
+	for _, call := range f.Calls() {
+		if call == cityartifact.OpUploadArtifactContent || call == cityartifact.OpFinalizeArtifact {
+			t.Errorf("dispatched %s after a foreign link", call)
+		}
+	}
+	if f.ArtifactCount() != 0 {
+		t.Errorf("created %d artifacts despite a foreign link", f.ArtifactCount())
+	}
+}
+
+// AC1 edge: a City-specific authority — a rig name where a server-minted link ID
+// belongs — never reaches the wire.
+func TestCityAuthorityRefusedBeforeAnyCall(t *testing.T) {
+	ctx := context.Background()
+	for name, mutate := range map[string]func(*cityartifact.CityArtifact){
+		"city-native run id":  func(a *cityartifact.CityArtifact) { a.RunID = "rig-3/run-17" },
+		"city locator":        func(a *cityartifact.CityArtifact) { a.ProjectID = "gc://rustbelt/proj" },
+		"city name as link":   func(a *cityartifact.CityArtifact) { a.IssueID = "rig-3" },
+		"city-native session": func(a *cityartifact.CityArtifact) { a.SessionID = "session-17" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := authorizedFake()
+			p := newCityProducer(t, f)
+			a := sampleArtifact()
+			mutate(&a)
+			if _, err := p.Push(ctx, a); !errors.Is(err, cityartifact.ErrCityAuthority) {
+				t.Fatalf("err = %v, want ErrCityAuthority", err)
+			}
+			if len(f.Calls()) != 0 {
+				t.Errorf("dispatched %v before refusing City authority", f.Calls())
+			}
+		})
+	}
+}
+
+// AC1 edge: a raw upstream field cannot be smuggled into an outbound body.
+func TestScanOutboundRefusesRawUpstreamFields(t *testing.T) {
+	cases := map[string]struct {
+		body any
+		want error
+	}{
+		"server-minted id":  {map[string]any{"id": "art_1"}, cityartifact.ErrCityAuthority},
+		"provenance":        {map[string]any{"source_id": "src_x"}, cityartifact.ErrCityAuthority},
+		"City fact":         {map[string]any{"rig": "rig-3"}, cityartifact.ErrCityAuthority},
+		"storage locator":   {map[string]any{"signed_url": "https://x/y"}, cityartifact.ErrCityAuthority},
+		"content in a body": {map[string]any{"bytes": "aGk="}, cityartifact.ErrContentRoute},
+		"nested content":    {map[string]any{"links": map[string]any{"body": "hi"}}, cityartifact.ErrContentRoute},
+		"credential": {map[string]any{
+			"kind": "file", "media_type": "text/plain",
+			"links": map[string]any{"project_id": "p?signature=abc"},
+		}, cityartifact.ErrCredentialLeak},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := cityartifact.ScanOutbound(tc.body); !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+	// The finalize body's asserted digest is the one permitted exception.
+	if err := cityartifact.ScanOutbound(cityartifact.FinalizeRequest{Digest: "sha256:aa"}, "digest"); err != nil {
+		t.Fatalf("finalize body refused: %v", err)
+	}
+	if err := cityartifact.ScanOutbound(cityartifact.FinalizeRequest{Digest: "sha256:aa"}); !errors.Is(err, cityartifact.ErrCityAuthority) {
+		t.Fatalf("digest was permitted without being named")
+	}
+}
+
+// The four categories are four reads. A metadata read returns no bytes, no
+// evidence and no references, and content comes back only from the content call.
+func TestCategorySeparation(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := newCityProducer(t, f)
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	f.Seed(res.ArtifactID,
+		[]cityartifact.EvidenceEntry{{ID: "ev1", Kind: "scan", Statement: "clean"}},
+		[]cityartifact.Reference{{ID: "rf1", Kind: "issue", TargetID: linkedIssue}})
+
+	evidence, err := p.Evidence(ctx, res.ArtifactID)
+	if err != nil || len(evidence) != 1 {
+		t.Fatalf("Evidence = %v, %v", evidence, err)
+	}
+	refs, err := p.References(ctx, res.ArtifactID)
+	if err != nil || len(refs) != 1 {
+		t.Fatalf("References = %v, %v", refs, err)
+	}
+	chunk, err := p.Content(ctx, res.ArtifactID, cityartifact.Range{})
+	if err != nil {
+		t.Fatalf("Content: %v", err)
+	}
+	if string(chunk.Bytes) != "first part\nsecond part\n" {
+		t.Errorf("content = %q", chunk.Bytes)
+	}
+	meta, err := p.Metadata(ctx, res.ArtifactID)
+	if err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if meta.ByteSize != int64(len(chunk.Bytes)) {
+		t.Errorf("metadata byte_size %d disagrees with content length %d", meta.ByteSize, len(chunk.Bytes))
+	}
+	for op, wantCat := range map[string]cityartifact.Category{
+		cityartifact.OpCreateArtifact:        cityartifact.CategoryMetadata,
+		cityartifact.OpListArtifacts:         cityartifact.CategoryMetadata,
+		cityartifact.OpGetArtifact:           cityartifact.CategoryMetadata,
+		cityartifact.OpFinalizeArtifact:      cityartifact.CategoryMetadata,
+		cityartifact.OpGetArtifactEvidence:   cityartifact.CategoryEvidence,
+		cityartifact.OpGetArtifactReferences: cityartifact.CategoryReferences,
+		cityartifact.OpUploadArtifactContent: cityartifact.CategoryContent,
+		cityartifact.OpGetArtifactContent:    cityartifact.CategoryContent,
+	} {
+		got, ok := cityartifact.CategoryOf(op)
+		if !ok || got != wantCat {
+			t.Errorf("CategoryOf(%s) = %q, %v; want %q", op, got, ok, wantCat)
+		}
+	}
+	if _, ok := cityartifact.CategoryOf("deleteArtifact"); ok {
+		t.Error("an operation outside the frozen matrix was given a category")
+	}
+}
+
+// An unfinalized artifact is not readable — not by its own producer, not by
+// anyone.
+func TestUnfinalizedArtifactIsNotReadable(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := newCityProducer(t, f)
+
+	partial := sampleArtifact()
+	partial.Complete = false
+	res, err := p.Push(ctx, partial)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if res.Finalized {
+		t.Fatal("an incomplete manifest was finalized")
+	}
+	if res.Metadata.ID != "" {
+		t.Fatalf("metadata returned for an unfinalized artifact: %+v", res.Metadata)
+	}
+	for _, read := range map[string]func() error{
+		"metadata":   func() error { _, err := p.Metadata(ctx, res.ArtifactID); return err },
+		"evidence":   func() error { _, err := p.Evidence(ctx, res.ArtifactID); return err },
+		"references": func() error { _, err := p.References(ctx, res.ArtifactID); return err },
+		"content":    func() error { _, err := p.Content(ctx, res.ArtifactID, cityartifact.Range{}); return err },
+	} {
+		if err := read(); !errors.Is(err, cityartifact.ErrNotReadable) {
+			t.Errorf("read of an unfinalized artifact returned %v, want ErrNotReadable", err)
+		}
+	}
+}
+
+// An artifact is valid without City: no links, no City facts, plain kind.
+func TestArtifactIsValidWithoutCity(t *testing.T) {
+	ctx := context.Background()
+	f := cityartifact.NewFake()
+	p := newCityProducer(t, f)
+
+	bare := cityartifact.CityArtifact{
+		ArtifactID: "bare-1",
+		Kind:       "unknown-city-kind",
+		Version:    1,
+		Parts:      []cityartifact.CityPart{{Sequence: 1, Bytes: []byte("x")}},
+		Complete:   true,
+	}
+	res, err := p.Push(ctx, bare)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if res.Metadata.Kind != "file" {
+		t.Errorf("kind = %q, want the default rather than a raw City kind", res.Metadata.Kind)
+	}
+	if res.Metadata.MediaType != "application/octet-stream" {
+		t.Errorf("media_type = %q, want the default", res.Metadata.MediaType)
+	}
+	if !res.Metadata.Links.Empty() {
+		t.Errorf("links = %+v, want none", res.Metadata.Links)
+	}
+}

--- a/pkg/cityartifact/producer.go
+++ b/pkg/cityartifact/producer.go
@@ -1,0 +1,482 @@
+package cityartifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// State is one City artifact's checkpoint.
+//
+// Frontier is the highest part sequence the SERVER acknowledged, and it only
+// ever advances contiguously. Digests holds the digest of each acknowledged part
+// so a later replay can be told apart from a rewrite; CreateDigest does the same
+// job for the artifact's own definition. Together they are what makes "changed
+// manifest" detectable at all.
+type State struct {
+	Epoch         uint64         `json:"epoch"`
+	SourceID      string         `json:"source_id"`
+	ArtifactID    string         `json:"artifact_id"`
+	CreateDigest  string         `json:"create_digest"`
+	Frontier      int            `json:"frontier"`
+	Digests       map[int]string `json:"digests"`
+	Finalized     bool           `json:"finalized"`
+	ContentDigest string         `json:"content_digest"`
+}
+
+func (s *State) digests() map[int]string {
+	if s.Digests == nil {
+		s.Digests = map[int]string{}
+	}
+	return s.Digests
+}
+
+// Store persists checkpoints across restarts. It is an interface because the
+// durable implementation is City's business; the adapter only needs Load and
+// Save to be atomic with respect to each other.
+type Store interface {
+	Load(ctx context.Context, key string) (State, bool, error)
+	Save(ctx context.Context, key string, st State) error
+}
+
+// MemoryStore is an in-process Store. It is safe for concurrent use and is what
+// tests and a single-shot export run on.
+type MemoryStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+// NewMemoryStore returns an empty in-process Store.
+func NewMemoryStore() *MemoryStore { return &MemoryStore{m: map[string][]byte{}} }
+
+// Load implements Store.
+func (s *MemoryStore) Load(_ context.Context, key string) (State, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw, ok := s.m[key]
+	if !ok {
+		return State{}, false, nil
+	}
+	var st State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return State{}, false, fmt.Errorf("cityartifact: decode checkpoint %q: %w", key, err)
+	}
+	return st, true, nil
+}
+
+// Save implements Store. It round-trips through JSON so a caller cannot hold a
+// reference into stored state and mutate it behind the producer's back.
+func (s *MemoryStore) Save(_ context.Context, key string, st State) error {
+	raw, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("cityartifact: encode checkpoint %q: %w", key, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = map[string][]byte{}
+	}
+	s.m[key] = raw
+	return nil
+}
+
+// Result reports what one push did. It is returned even on error, so a caller
+// that stops on a refusal still learns how far the artifact got.
+type Result struct {
+	// ArtifactID is the server-minted ID. City never mints one.
+	ArtifactID string
+	Uploaded   int
+	Skipped    int
+	Finalized  bool
+	// Metadata is the normalized read-back, present only once the artifact is
+	// finalized — an unfinalized artifact is not readable.
+	Metadata Artifact
+}
+
+// Producer maps a City artifact onto the public artifact contract and advances a
+// checkpoint only over acknowledged, contiguous parts.
+type Producer struct {
+	API    API
+	Mapper Mapper
+	Store  Store
+}
+
+// NewProducer validates its wiring up front: a producer missing a store would
+// look like it worked and silently re-upload the world on restart.
+func NewProducer(api API, mapper Mapper, store Store) (*Producer, error) {
+	if api == nil {
+		return nil, errors.New("cityartifact: API is required")
+	}
+	if store == nil {
+		return nil, errors.New("cityartifact: Store is required")
+	}
+	if err := mapper.validateSource(); err != nil {
+		return nil, err
+	}
+	return &Producer{API: api, Mapper: mapper, Store: store}, nil
+}
+
+// CheckpointKey is the stable checkpoint identity of one City artifact under one
+// source. It excludes the epoch: a declared reset must LAND on the same key so
+// the old frontier is visibly superseded rather than orphaned under a new one.
+func CheckpointKey(source Source, cityArtifactID string) string {
+	return source.Kind + "/" + source.SourceID + "/" + cityArtifactID
+}
+
+// Push creates, uploads, finalizes and reads back one City artifact.
+//
+// It advances only on acknowledgement. Every refusal returns the partial result
+// with the checkpoint already saved at the last acknowledged part, so a restart
+// resumes at the next part and never re-sends an accepted one. There is no
+// fallback path: if the server refuses, this artifact stops. The adapter does
+// not reach for a City-side forge, a second route or a different credential, and
+// no other producer's checkpoint is touched.
+func (p *Producer) Push(ctx context.Context, a CityArtifact) (Result, error) {
+	res := Result{}
+
+	create, err := p.Mapper.MapCreate(a)
+	if err != nil {
+		return res, err
+	}
+	if err := ScanOutbound(create); err != nil {
+		return res, err
+	}
+	parts, err := p.mapParts(a)
+	if err != nil {
+		return res, err
+	}
+
+	key := CheckpointKey(p.Mapper.Source, a.ArtifactID)
+	st, _, err := p.Store.Load(ctx, key)
+	if err != nil {
+		return res, err
+	}
+	if err := p.reconcileEpoch(&st); err != nil {
+		return res, err
+	}
+
+	createDigest := payloadDigest(create)
+	if st.ArtifactID == "" {
+		art, err := p.API.CreateArtifact(ctx, create,
+			idempotencyKey(p.Mapper.Source, kindArtifact, a.ArtifactID, createDigest))
+		if err != nil {
+			return res, normalizeUpstream(OpCreateArtifact, err)
+		}
+		if strings.TrimSpace(art.ID) == "" {
+			return res, fmt.Errorf("%w: server returned no artifact id", ErrIdentityDrift)
+		}
+		st.ArtifactID = art.ID
+		st.CreateDigest = createDigest
+		st.Finalized = art.Finalized()
+		if err := p.Store.Save(ctx, key, st); err != nil {
+			return res, err
+		}
+	} else if st.CreateDigest != createDigest {
+		// The artifact's own definition changed under an ID the server already
+		// minted. Re-creating would fork the artifact and mutating is not on
+		// offer, so this adapter stops with its checkpoint intact.
+		return res, fmt.Errorf("%w: artifact %q definition changed after creation", ErrChangedManifest, a.ArtifactID)
+	}
+	res.ArtifactID = st.ArtifactID
+	res.Finalized = st.Finalized
+
+	uploaded, skipped, err := p.pushParts(ctx, key, &st, parts)
+	res.Uploaded, res.Skipped = uploaded, skipped
+	if err != nil {
+		return res, err
+	}
+
+	if a.Complete && !st.Finalized {
+		contentDigest := contentDigest(parts)
+		body := p.Mapper.MapFinalize(contentDigest)
+		if err := ScanOutbound(body, "digest"); err != nil {
+			return res, err
+		}
+		final, err := p.API.FinalizeArtifact(ctx, st.ArtifactID, body,
+			idempotencyKey(p.Mapper.Source, kindFinalize, a.ArtifactID, contentDigest))
+		if err != nil {
+			return res, normalizeUpstream(OpFinalizeArtifact, err)
+		}
+		if final.ID != st.ArtifactID {
+			return res, fmt.Errorf("%w: finalize acknowledged artifact %q, not %q",
+				ErrIdentityDrift, final.ID, st.ArtifactID)
+		}
+		if !final.Finalized() {
+			return res, fmt.Errorf("%w: finalize returned an unsealed artifact", ErrUpstream)
+		}
+		st.Finalized = true
+		st.ContentDigest = contentDigest
+		if err := p.Store.Save(ctx, key, st); err != nil {
+			return res, err
+		}
+		res.Finalized = true
+	}
+
+	if !st.Finalized {
+		// Not readable yet, and this adapter does not pretend otherwise.
+		return res, nil
+	}
+	meta, err := p.Metadata(ctx, st.ArtifactID)
+	if err != nil {
+		return res, err
+	}
+	if err := verifyReadBack(meta, st, create, p.Mapper.Source); err != nil {
+		return res, err
+	}
+	res.Metadata = meta
+	return res, nil
+}
+
+// reconcileEpoch applies a declared reset and refuses an undeclared one.
+func (p *Producer) reconcileEpoch(st *State) error {
+	src := p.Mapper.Source
+	switch {
+	case st.Epoch == 0:
+		st.Epoch = src.Epoch
+		st.SourceID = src.SourceID
+	case src.Epoch > st.Epoch:
+		// A declared reset. The previous frontier belongs to the previous epoch
+		// and must not gate the new one, so the checkpoint restarts. The server
+		// keeps the artifacts it already accepted; this producer simply stops
+		// claiming to have sent them.
+		*st = State{Epoch: src.Epoch, SourceID: src.SourceID}
+	case src.Epoch < st.Epoch:
+		return fmt.Errorf("%w: source epoch %d is behind checkpoint epoch %d",
+			ErrIdentityDrift, src.Epoch, st.Epoch)
+	}
+	if st.SourceID != "" && st.SourceID != src.SourceID {
+		return fmt.Errorf("%w: checkpoint belongs to source %q", ErrIdentityDrift, st.SourceID)
+	}
+	return nil
+}
+
+// mapParts normalizes the manifest and refuses a duplicate sequence before a
+// single byte is sent. Two parts claiming the same sequence is a source bug that
+// would otherwise show up as a silent overwrite.
+func (p *Producer) mapParts(a CityArtifact) ([]Part, error) {
+	out := make([]Part, 0, len(a.Parts))
+	seen := map[int]bool{}
+	for _, cp := range a.Parts {
+		if seen[cp.Sequence] {
+			return nil, fmt.Errorf("%w: part sequence %d appears twice", ErrInvalidArtifact, cp.Sequence)
+		}
+		seen[cp.Sequence] = true
+		part, err := p.Mapper.MapPart(a, cp)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, part)
+	}
+	// Out-of-order arrival is a source property, not a protocol violation: order
+	// the manifest here and let contiguity be judged on sequences.
+	sort.Slice(out, func(i, j int) bool { return out[i].Sequence < out[j].Sequence })
+	return out, nil
+}
+
+func (p *Producer) pushParts(ctx context.Context, key string, st *State, parts []Part) (uploaded, skipped int, err error) {
+	for _, part := range parts {
+		digest := part.Digest()
+
+		if part.Sequence <= st.Frontier {
+			// Already acknowledged. Same bytes means a retry we can drop;
+			// different bytes means the manifest was rewritten underneath us.
+			if have, ok := st.digests()[part.Sequence]; ok && have != digest {
+				return uploaded, skipped, fmt.Errorf("%w: part %d was %s, manifest now says %s",
+					ErrChangedManifest, part.Sequence, have, digest)
+			}
+			skipped++
+			continue
+		}
+		if st.Finalized {
+			return uploaded, skipped, fmt.Errorf("%w: part %d arrived after finalize", ErrFinalized, part.Sequence)
+		}
+		if part.Sequence != st.Frontier+1 {
+			return uploaded, skipped, fmt.Errorf("%w: expected part %d, got %d",
+				ErrGap, st.Frontier+1, part.Sequence)
+		}
+		if err := ScanOutbound(part); err != nil {
+			return uploaded, skipped, err
+		}
+		art, err := p.API.UploadArtifactContent(ctx, st.ArtifactID, part,
+			idempotencyKey(p.Mapper.Source, kindPart,
+				st.ArtifactID+"/"+strconv.Itoa(part.Sequence), digest))
+		if err != nil {
+			return uploaded, skipped, normalizeUpstream(OpUploadArtifactContent, err)
+		}
+		if art.ID != st.ArtifactID {
+			return uploaded, skipped, fmt.Errorf("%w: part %d acknowledged against artifact %q, not %q",
+				ErrIdentityDrift, part.Sequence, art.ID, st.ArtifactID)
+		}
+		st.Frontier = part.Sequence
+		st.digests()[part.Sequence] = digest
+		uploaded++
+		if err := p.Store.Save(ctx, key, *st); err != nil {
+			return uploaded, skipped, err
+		}
+	}
+	return uploaded, skipped, nil
+}
+
+// Metadata reads an artifact's normalized metadata. It is the metadata category
+// and it can reach nothing else: there is no byte, no evidence statement and no
+// reference in what it returns.
+func (p *Producer) Metadata(ctx context.Context, artifactID string) (Artifact, error) {
+	art, err := p.API.GetArtifact(ctx, artifactID)
+	if err != nil {
+		return Artifact{}, normalizeUpstream(OpGetArtifact, err)
+	}
+	return art, nil
+}
+
+// Evidence reads an artifact's evidence entries. Separate category, separate
+// scope, separate call — a metadata read never carries these.
+func (p *Producer) Evidence(ctx context.Context, artifactID string) ([]EvidenceEntry, error) {
+	_, entries, err := p.API.GetArtifactEvidence(ctx, artifactID)
+	if err != nil {
+		return nil, normalizeUpstream(OpGetArtifactEvidence, err)
+	}
+	return entries, nil
+}
+
+// References reads an artifact's outbound references. Separate category,
+// separate scope, separate call.
+func (p *Producer) References(ctx context.Context, artifactID string) ([]Reference, error) {
+	_, refs, err := p.API.GetArtifactReferences(ctx, artifactID)
+	if err != nil {
+		return nil, normalizeUpstream(OpGetArtifactReferences, err)
+	}
+	return refs, nil
+}
+
+// Content reads a bounded range of an artifact's bytes. It is the only method in
+// this package that returns content, and it only ever returns content the server
+// handed over — never a location to fetch it from.
+func (p *Producer) Content(ctx context.Context, artifactID string, rng Range) (Chunk, error) {
+	_, chunk, err := p.API.GetArtifactContent(ctx, artifactID, rng)
+	if err != nil {
+		return Chunk{}, normalizeUpstream(OpGetArtifactContent, err)
+	}
+	return chunk, nil
+}
+
+// List enumerates artifacts this credential can see. The source filter is a
+// request the server validates; nothing here assumes it was honored.
+func (p *Producer) List(ctx context.Context, q ListQuery) ([]Artifact, string, error) {
+	arts, cursor, err := p.API.ListArtifacts(ctx, q)
+	if err != nil {
+		return nil, "", normalizeUpstream(OpListArtifacts, err)
+	}
+	return arts, cursor, nil
+}
+
+// verifyReadBack checks the normalized read-back against what this adapter
+// actually sent. It is the retrieval half of the round trip: an artifact whose
+// links, kind, media type, provenance or digest came back different is a drift
+// this producer reports rather than records as success.
+func verifyReadBack(got Artifact, st State, sent CreateRequest, src Source) error {
+	switch {
+	case got.ID != st.ArtifactID:
+		return fmt.Errorf("%w: read back artifact %q, expected %q", ErrIdentityDrift, got.ID, st.ArtifactID)
+	case got.SourceID != src.SourceID:
+		return fmt.Errorf("%w: artifact %q reports source %q, expected %q",
+			ErrIdentityDrift, got.ID, got.SourceID, src.SourceID)
+	case got.Kind != sent.Kind:
+		return fmt.Errorf("%w: artifact %q reports kind %q, sent %q", ErrIdentityDrift, got.ID, got.Kind, sent.Kind)
+	case got.MediaType != sent.MediaType:
+		return fmt.Errorf("%w: artifact %q reports media type %q, sent %q",
+			ErrIdentityDrift, got.ID, got.MediaType, sent.MediaType)
+	case got.Links != sent.Links:
+		return fmt.Errorf("%w: artifact %q reports links %+v, sent %+v", ErrIdentityDrift, got.ID, got.Links, sent.Links)
+	case !got.Finalized():
+		return fmt.Errorf("%w: artifact %q read back unfinalized", ErrIdentityDrift, got.ID)
+	case st.ContentDigest != "" && got.Digest != "" && got.Digest != st.ContentDigest:
+		return fmt.Errorf("%w: artifact %q stored digest %q, asserted %q",
+			ErrChangedManifest, got.ID, got.Digest, st.ContentDigest)
+	}
+	return nil
+}
+
+// contentDigest is the digest of the whole manifest, taken over the parts'
+// bytes in sequence order. It is the assertion finalize carries, so a producer
+// can only ever assert content that actually left this process.
+func contentDigest(parts []Part) string {
+	h := sha256.New()
+	for _, p := range parts {
+		h.Write(p.Bytes)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// payloadDigest is the canonical digest of a request body. It is what makes a
+// replay comparable: the same City artifact maps to the same bytes, so a digest
+// difference is a real source change and never a serialization artifact.
+func payloadDigest(body any) string {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		// json.Marshal on these closed DTOs cannot fail; a digest that cannot be
+		// computed must not compare equal to anything.
+		return "unencodable:" + err.Error()
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// idempotencyKey derives the server's Idempotency-Key from stable source
+// identity alone.
+//
+// Deriving rather than minting is the dedup contract: a retry after a lost
+// response reuses the key and replays, while a changed payload under the same
+// key is a conflict the server refuses. Nothing volatile — no clock, no attempt
+// counter, no credential material — is in the preimage, so a credential rotation
+// or a restart changes nothing about which key a request travels under. The
+// output is a v5-shaped UUID because the contract requires a UUID.
+func idempotencyKey(source Source, kind, nativeID, discriminator string) string {
+	preimage := strings.Join([]string{
+		"cityartifact/idempotency/v1",
+		source.Kind, source.SourceID,
+		strconv.FormatUint(source.Epoch, 10),
+		kind, nativeID, discriminator,
+	}, "\x1f")
+	sum := sha256.Sum256([]byte(preimage))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(b)
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+// normalizeUpstream collapses a client failure into this package's own typed
+// error.
+//
+// The upstream text is DROPPED, not wrapped: an error string is the easiest
+// place for a raw response body, an upstream token, a signed URL or a storage
+// path to escape, and a producer has no use for any of them. What survives is
+// the operation name, this package's sentinel, and — for a cancellation — the
+// context error, whose text is a fixed constant.
+func normalizeUpstream(operationID string, err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ErrContentDenied):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrContentDenied)
+	case errors.Is(err, ErrNotReadable):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrNotReadable)
+	case errors.Is(err, ErrFinalized):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrFinalized)
+	case errors.Is(err, ErrChangedManifest):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrChangedManifest)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("cityartifact: %s: %w: %w", operationID, ErrUpstream, context.DeadlineExceeded)
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("cityartifact: %s: %w: %w", operationID, ErrUpstream, context.Canceled)
+	}
+	return fmt.Errorf("cityartifact: %s: %w", operationID, ErrUpstream)
+}


### PR DESCRIPTION
The Gas City Artifact producer and link adapter, consuming the generated public client against the artifact routes (#106) rather than hand-rolling HTTP against `/api/v1`.

City is one **optional** producer of neutral resources — artifacts must be valid without it, so the adapter has no privileged path a non-City producer lacks.

Respects the frozen artifact sub-grammar: the four categories `{metadata, evidence, references, content}` with 8 pairwise-distinct scopes, and the multi-part lifecycle where parts precede finalize and an unfinalized artifact is not readable.

## Why this is its own task

The YAGNI review **rejected** merging this with `API-7.20`/`7.22`, having checked the edges and found each adapter has a different second prerequisite — real staggering, not salami-slicing. That rejection is why these are three tasks rather than one.

Verified: `make test-fast-parallel` — the full repo gate, run before claiming done. That gate has rejected two branches in this program (a missing generated fixture plus an un-updated env golden, and a resource-census `fixed_sleep` increment), so it is not taken on faith.