### PR TITLE
feat(cityinference): inference producer adapter (API-7.22)

### DIFF
--- a/pkg/cityinference/cityinference.go
+++ b/pkg/cityinference/cityinference.go
@@ -1,0 +1,118 @@
+// Package cityinference is Gas City's producer adapter for the neutral
+// inference resource of the Beads Team Server v1 API.
+//
+// City is ONE OPTIONAL producer of inference records. A custom orchestrator
+// with no City in the picture uploads the same records on its own credential,
+// so nothing here may become a schema, an identity or an authority that a
+// non-City producer would have to satisfy.
+//
+// Three facts shape every line below, and all three come from the frozen
+// inference identity design (API-6.1):
+//
+//   - Identity is the triplet (tenant, session_id, upstream_req_id) and the
+//     record ID is a one-way digest over it. This adapter derives the same ID
+//     the server does, and offers it as a checksum, never as a choice.
+//   - Only an exact-tuple match folds. Timestamp, model, vendor, token count,
+//     cost and textual similarity are not comparators here; [Mapper.Fold]
+//     refuses to evaluate them at all rather than returning "no".
+//   - Step attribution is UNAVAILABLE by construction. There is no admitted
+//     wire field for it and there is no field on [CityInvocation] that could
+//     carry one, so the adapter cannot synthesize a step even by accident.
+//     "Unavailable" is a claim this adapter makes out loud; it is not silence.
+//
+// What the adapter does NOT do is as load-bearing as what it does. It never
+// produces a run, session, transcript record or artifact — those are
+// [github.com/gastownhall/gascity/pkg/cityneutral]'s job, and this package only
+// links to the server-minted Team IDs that producer read back. It never sends
+// prompt text, completion text, transcript content or a raw provider payload:
+// [Preflight] rejects the whole request before a byte leaves the process. It
+// never emits an inference event or SSE stream, and it never touches Team
+// Server storage directly.
+//
+// Rollback is per producer. Set [Producer.Disabled] and this adapter stops
+// issuing requests while every acknowledged record stays exactly as the server
+// accepted it, other City producers keep running, and a custom (non-City)
+// inference producer against the same API is unaffected.
+package cityinference
+
+import "errors"
+
+// Frozen operation IDs from operation_matrix_v6. They are spelled here so a
+// reader can check this adapter's surface against the frozen matrix without
+// leaving the package, and so the client seam cannot quietly grow a route that
+// is not in the matrix.
+const (
+	OpCreateInference = "createInference"
+	OpListInferences  = "listInferences"
+	OpGetInference    = "getInference"
+)
+
+// KindInference is the resource kind in the server's idempotency namespace. A
+// key minted for an inference may not be replayed into a run, a session or a
+// transcript record, so the kind is part of the key preimage.
+const KindInference = "inference"
+
+// Bounds mirroring the server's validators, so an oversized field is refused
+// here with a source field name attached rather than as a correlated 4xx.
+const maxNativeIDLen = 200
+
+// Refusals. Every one of them stops this producer with its checkpoint intact:
+// nothing has advanced past the last acknowledged record, so an operator who
+// fixes the source can restart and resume rather than reconcile.
+var (
+	// ErrChangedReplay is an invocation whose stable source identity was
+	// already acknowledged but whose payload no longer matches. Sending it
+	// would ask the server to rewrite accepted input, so the adapter stops.
+	ErrChangedReplay = errors.New("cityinference: source identity replayed with changed payload")
+
+	// ErrHeuristicFold is an offered correlation that rests on anything but an
+	// exact identity tuple. It is a refusal rather than a false answer: a
+	// producer that asked "do these two match on timestamp?" has already made
+	// the category error, and answering the question at all would let the next
+	// caller treat a near-miss as evidence.
+	ErrHeuristicFold = errors.New("cityinference: fold may rest only on an exact identity tuple")
+
+	// ErrSyntheticLinkage is an offered ordinal or step reference. This domain
+	// asserts no order and has no step concept; the honest expression is
+	// coverage class unavailable, never a fabricated link.
+	ErrSyntheticLinkage = errors.New("cityinference: synthesized ordering or step linkage is inadmissible")
+
+	// ErrAttemptRow is an upstream request ID in the err_ class. Those rows are
+	// failed attempts that never produced a metered invocation; admitting one
+	// would let an attempt stand as a call in every sum built over this domain.
+	ErrAttemptRow = errors.New("cityinference: attempt row is not an invocation")
+
+	// ErrContentLeak is outbound bytes carrying prompt, completion, transcript
+	// text or a raw provider payload. Content lives behind transcript and
+	// artifact content authorization and never rides an inference record.
+	ErrContentLeak = errors.New("cityinference: outbound payload carries model content")
+
+	// ErrCredentialLeak is outbound bytes carrying credential evidence. Key
+	// identifiers are attribution tags at most, and never leave this process.
+	ErrCredentialLeak = errors.New("cityinference: outbound payload carries credential evidence")
+
+	// ErrNotFound is any canonical link this tenant cannot resolve. Foreign,
+	// absent, wrong-kind and container-mismatched links all land here with the
+	// same text on purpose: a caller that could tell them apart would have an
+	// existence oracle over another tenant's records.
+	ErrNotFound = errors.New("cityinference: linked record not found")
+
+	// ErrIdentityDrift is a response binding a derived inference identity to a
+	// different neutral Team ID than the checkpoint holds. That is either a
+	// wrong-tenant credential or an undeclared reset; both are louder than a
+	// retry.
+	ErrIdentityDrift = errors.New("cityinference: derived identity resolved to a different neutral id")
+
+	// ErrCoverageRaised is an accepted record whose coverage claims more than
+	// this adapter offered. Coverage is server-derived and immutable, but a
+	// producer that let a raised claim through would be lending its own name to
+	// a completeness assertion it cannot support.
+	ErrCoverageRaised = errors.New("cityinference: accepted coverage claims more than was offered")
+
+	// ErrInvalidInvocation is a City invocation this adapter refuses to map.
+	ErrInvalidInvocation = errors.New("cityinference: invalid City invocation")
+
+	// ErrDisabled is the rollback state: the producer is off and issues no
+	// requests. Acknowledged records and every other producer are unaffected.
+	ErrDisabled = errors.New("cityinference: producer disabled")
+)

--- a/pkg/cityinference/contract.go
+++ b/pkg/cityinference/contract.go
@@ -1,0 +1,273 @@
+package cityinference
+
+import (
+	"context"
+	"time"
+)
+
+// Outcome is the closed normalized outcome vocabulary of an invocation. City
+// may not invent one: the canonical contract has no raw passthrough, so an
+// unmappable City state lands on OutcomeUnknown rather than being echoed
+// through.
+type Outcome string
+
+// The closed outcome vocabulary.
+const (
+	OutcomeOK        Outcome = "ok"
+	OutcomeError     Outcome = "error"
+	OutcomeCancelled Outcome = "cancelled" //nolint:misspell // frozen wire value of the neutral contract
+	OutcomeUnknown   Outcome = "unknown"
+)
+
+// Coverage is a source's claim about how complete one field group is. The
+// vocabulary is the server's closed set, spelled in full because it is a wire
+// vocabulary. This adapter never sends a coverage value — coverage is
+// server-derived and immutable after admission — but it predicts one so a test
+// and an operator can check what was claimed on City's behalf.
+type Coverage string
+
+// The closed coverage vocabulary.
+const (
+	CoverageKnown         Coverage = "known"
+	CoverageUnavailable   Coverage = "unavailable"
+	CoveragePartial       Coverage = "partial"
+	CoverageMetered       Coverage = "metered"
+	CoverageEstimated     Coverage = "estimated"
+	CoverageLegacyUnknown Coverage = "legacy_unknown"
+)
+
+// The closed coverage field-group key set. Every one of these keys appears on
+// every admitted inference: a missing key is a schema violation, not an
+// implicit "unavailable", because silence is what coverage exists to abolish.
+const (
+	FieldGroupTokens     = "usage.tokens"
+	FieldGroupCost       = "usage.cost"
+	FieldGroupSavings    = "usage.savings"
+	FieldGroupStep       = "attribution.step"
+	FieldGroupTranscript = "attribution.transcript_record"
+	FieldGroupOutcome    = "outcome"
+)
+
+// CoverageFieldGroups returns the closed key set in a stable order.
+func CoverageFieldGroups() []string {
+	return []string{
+		FieldGroupTokens, FieldGroupCost, FieldGroupSavings,
+		FieldGroupStep, FieldGroupTranscript, FieldGroupOutcome,
+	}
+}
+
+// IdentityScope says whether a derived identity rests on a provider-assigned
+// request ID or on a locally generated one.
+type IdentityScope string
+
+const (
+	// ScopeInvocation means the upstream request ID is provider-assigned, so
+	// the triplet names the invocation itself and an exact-tuple match is a
+	// genuine duplicate.
+	ScopeInvocation IdentityScope = "invocation"
+	// ScopeObservation means the upstream request ID was generated locally.
+	// Two such IDs for the same real call never converge, so the record
+	// identifies our observation of an invocation and not the invocation.
+	// Fold-ineligible by construction.
+	ScopeObservation IdentityScope = "observation"
+)
+
+// NativeIdentity is the composite that is the only durable native identity of a
+// model invocation. All three components are REQUIRED members; SessionID MAY be
+// the empty string, which is a legal legacy value and not a null.
+type NativeIdentity struct {
+	// Kind pins the derivation. It names the triplet SHAPE, not the producer:
+	// the server admits exactly one shape, so a City-flavored kind would be a
+	// schema the contract rejects, not a courtesy.
+	Kind          string `json:"kind"`
+	Tenant        string `json:"tenant"`
+	SessionID     string `json:"session_id"`
+	UpstreamReqID string `json:"upstream_req_id"`
+}
+
+// NativeIdentityKind is the one admitted triplet shape.
+const NativeIdentityKind = "manifold.triplet.v1"
+
+// UsageObservation is one contribution's usage figures with their provenance.
+//
+// Token counts are what the party that did the work counted. Cost and savings
+// are what a price table computed afterwards. They are separate members because
+// they are separate field groups with separate classes, and "estimated is
+// weaker than metered" is only a sound statement about the same quantity.
+type UsageObservation struct {
+	InputTokens       *uint64 `json:"input_tokens,omitempty"`
+	OutputTokens      *uint64 `json:"output_tokens,omitempty"`
+	CachedInputTokens *uint64 `json:"cached_input_tokens,omitempty"`
+
+	// CostMicros is derived money: metered tokens times an approximate price
+	// table. It is an estimate OF billing, never a billed figure, and it never
+	// reaches a read path.
+	CostMicros *uint64 `json:"cost_micros,omitempty"`
+	// SavedInputTokens and SavedCostMicros are an explicit upper bound that is
+	// never billed. Their own field group keeps them from being summed into
+	// cost.
+	SavedInputTokens *uint64 `json:"saved_input_tokens,omitempty"`
+	SavedCostMicros  *uint64 `json:"saved_cost_micros,omitempty"`
+}
+
+func (u *UsageObservation) metered() bool {
+	return u != nil && (u.InputTokens != nil || u.OutputTokens != nil || u.CachedInputTokens != nil)
+}
+
+// CreateInferenceRequest is the request body of createInference.
+//
+// Ordinal and SourceStepRef are present as explicitly refused members rather
+// than absent from the struct, mirroring the server. That is deliberate on both
+// sides: a caller that hand-builds a request and sets one gets the specific
+// reason code from [Preflight] with zero bytes on the wire, instead of learning
+// from a correlated 422 that it maybe mistyped a field.
+type CreateInferenceRequest struct {
+	NativeIdentity NativeIdentity `json:"native_identity"`
+
+	// ExternalInferenceID is optional and, when present, must equal the
+	// server's own derivation. It is a checksum this adapter offers, never a
+	// choice it makes.
+	ExternalInferenceID string `json:"external_inference_id,omitempty"`
+
+	Provider string  `json:"provider"`
+	Model    string  `json:"model"`
+	Outcome  Outcome `json:"outcome"`
+
+	StartedAt time.Time  `json:"started_at"`
+	EndedAt   *time.Time `json:"ended_at,omitempty"`
+
+	Epoch uint64 `json:"epoch,omitempty"`
+
+	// SessionTeamID and RunTeamID are the canonical containers, always
+	// server-minted Team IDs read back from a prior upsert. A City-native
+	// session or run ID here is a not-found, not a shortcut.
+	SessionTeamID string `json:"session_id,omitempty"`
+	RunTeamID     string `json:"run_id,omitempty"`
+
+	// TranscriptRecordID is the OPTIONAL canonical transcript-record Team ID.
+	// A provider message locator offered here is a not-found in exactly the
+	// same shape as a foreign record.
+	TranscriptRecordID string `json:"transcript_record_id,omitempty"`
+
+	// ObservationID discriminates two honest observations of the SAME
+	// invocation. It is part of the contribution's identity and never of the
+	// inference's, which is what lets a metered and an estimated observation
+	// stand as two contributions on one inference without either being read as
+	// a payload divergence of the other.
+	ObservationID string `json:"observation_id,omitempty"`
+
+	Usage *UsageObservation `json:"usage,omitempty"`
+
+	// Ordinal is refused: this domain asserts no order, so offering one is
+	// synthesis.
+	Ordinal *uint64 `json:"ordinal,omitempty"`
+	// SourceStepRef is refused: no step concept exists at the source, so the
+	// honest expression is coverage class unavailable, not a synthesized link.
+	SourceStepRef string `json:"source_step_ref,omitempty"`
+}
+
+// TokenUsage is a folded metered count. Nil rather than zero when nothing was
+// metered: a 0 means "counted zero", never "we have no number".
+type TokenUsage struct {
+	InputTokens       uint64 `json:"input_tokens"`
+	OutputTokens      uint64 `json:"output_tokens"`
+	CachedInputTokens uint64 `json:"cached_input_tokens"`
+}
+
+// Contribution is one observation's provenance as a read returns it. It carries
+// no monetary figure, because neither read scope in the frozen matrix is a
+// billing-sensitive scope.
+type Contribution struct {
+	ID            string            `json:"id"`
+	ObservationID string            `json:"observation_id"`
+	SourceID      string            `json:"source_id"`
+	SourceKind    string            `json:"source_kind"`
+	UploadedBy    string            `json:"uploaded_by"`
+	UploaderType  string            `json:"uploader_type"`
+	ObservedAt    time.Time         `json:"observed_at"`
+	IngestedAt    time.Time         `json:"ingested_at"`
+	Coverage      map[string]string `json:"coverage"`
+	TokenUsage    *TokenUsage       `json:"token_usage"`
+}
+
+// Inference is the closed neutral inference as a read returns it. ID is the
+// server-minted Team ID and ExternalInferenceID is the derived handle over the
+// native triplet; both are present so a caller can tell them apart, and this
+// adapter treats both as read-only fact.
+type Inference struct {
+	ID                  string `json:"id"`
+	ExternalInferenceID string `json:"external_inference_id"`
+	SourceID            string `json:"source_id"`
+	SourceKind          string `json:"source_kind"`
+
+	SessionID          string `json:"session_id"`
+	RunID              string `json:"run_id"`
+	TranscriptRecordID string `json:"transcript_record_id"`
+
+	Provider string  `json:"provider"`
+	Model    string  `json:"model"`
+	Outcome  Outcome `json:"outcome"`
+
+	StartedAt  time.Time  `json:"started_at"`
+	EndedAt    *time.Time `json:"ended_at"`
+	IngestedAt time.Time  `json:"ingested_at"`
+	Epoch      uint64     `json:"epoch"`
+
+	// IdentityScope and FoldEligible are on the wire because a consumer that
+	// sums this domain has to know which rows may be deduplicated and which may
+	// not. A locally generated row that silently looked foldable is how a
+	// double count becomes invisible.
+	IdentityScope IdentityScope `json:"identity_scope"`
+	FoldEligible  bool          `json:"fold_eligible"`
+
+	TokenUsage    *TokenUsage       `json:"token_usage"`
+	Coverage      map[string]string `json:"coverage"`
+	Contributions []Contribution    `json:"contributions"`
+
+	// Completeness is always unavailable over a best-effort producer. It is a
+	// member rather than an omission because "we do not know whether we
+	// received every record" is a claim this API must make out loud.
+	Completeness string `json:"completeness"`
+
+	ETag string `json:"etag"`
+}
+
+// ListFilter is the ratified filter surface of listInferences: exactly the
+// frozen operation's two parameters. There is no model, vendor or cost
+// dimension, because a filter surface is the easiest place for a forbidden
+// similarity comparator to grow back.
+type ListFilter struct {
+	SourceID     string
+	StartedAfter time.Time
+	Cursor       string
+	Limit        int
+}
+
+// Page is one page of listInferences.
+type Page struct {
+	Items      []Inference `json:"items"`
+	NextCursor string      `json:"next_cursor"`
+}
+
+// API is the seam onto the public v1 client.
+//
+// It carries exactly the three frozen inference operations and no transport
+// vocabulary at all — no base URL, no header, no status code. That is what
+// keeps this package from hand-rolling HTTP: the concrete implementation is the
+// generated public client for the canonical contract, and everything below is
+// written against these signatures.
+//
+// NOTE: the contract program generates a public TypeScript client and a
+// server-side Go interface; there is no generated Go *client* module a Go
+// producer can import today. This interface is the shape that client binds to,
+// method-for-method, so binding it is a wiring change and never a logic change.
+//
+// The idempotency key is a caller-supplied argument rather than something an
+// implementation invents, because the key is part of THIS package's dedup
+// contract: [Producer] derives it from stable source identity so that a retry
+// replays and a changed payload conflicts.
+type API interface {
+	CreateInference(ctx context.Context, body CreateInferenceRequest, idempotencyKey string) (Inference, error)
+	ListInferences(ctx context.Context, filter ListFilter) (Page, error)
+	GetInference(ctx context.Context, inferenceTeamID string) (Inference, error)
+}

--- a/pkg/cityinference/coverage_test.go
+++ b/pkg/cityinference/coverage_test.go
@@ -1,0 +1,172 @@
+package cityinference
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// AC1 fixture: a City invocation with transcript-level attribution and no
+// proven step. The record links the authorized canonical chain and says "step
+// unavailable" out loud, with no synthetic identity and no inline content.
+func TestCoverageFixtureTranscriptLevelAttribution(t *testing.T) {
+	m := testMapper()
+	inv := CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Provider: "anthropic", Model: "m-1", Status: "succeeded",
+		Started:            mustTime(t, "2026-07-30T10:00:00Z"),
+		RunTeamID:          "run_1",
+		SessionTeamID:      "ses_1",
+		TranscriptRecordID: "trc_1",
+		Usage:              &UsageObservation{InputTokens: ptr(120), OutputTokens: ptr(30), CostMicros: ptr(4500)},
+	}
+	want := map[string]Coverage{
+		FieldGroupTokens:     CoverageMetered,
+		FieldGroupCost:       CoverageEstimated,
+		FieldGroupSavings:    CoverageUnavailable,
+		FieldGroupStep:       CoverageUnavailable,
+		FieldGroupTranscript: CoverageKnown,
+		FieldGroupOutcome:    CoverageKnown,
+	}
+	got := m.ExpectedCoverage(inv)
+	if len(got) != len(CoverageFieldGroups()) {
+		t.Fatalf("coverage must carry every field group, got %d", len(got))
+	}
+	for group, class := range want {
+		if got[group] != class {
+			t.Fatalf("%s: want %s, got %s", group, class, got[group])
+		}
+	}
+
+	req, err := m.MapInvocation(inv)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if req.SourceStepRef != "" || req.Ordinal != nil {
+		t.Fatal("mapping produced a step or an ordinal")
+	}
+	if req.RunTeamID != "run_1" || req.SessionTeamID != "ses_1" || req.TranscriptRecordID != "trc_1" {
+		t.Fatalf("canonical links were rewritten: %+v", req)
+	}
+}
+
+// Step coverage is unavailable for every shape of input this adapter can hold.
+// There is no City field, provider locator or timestamp that turns it into
+// anything else, which is the structural half of "never synthesize a step".
+func TestStepCoverageIsUnavailableForEveryInput(t *testing.T) {
+	m := testMapper()
+	for _, inv := range []CityInvocation{
+		{SessionNativeID: "sess-1", UpstreamReqID: "req-1"},
+		{SessionNativeID: "", UpstreamReqID: "req-1"},
+		{SessionNativeID: "sess-1", UpstreamReqID: "gen_1", TranscriptRecordID: "trc_1"},
+		{
+			SessionNativeID: "sess-1", UpstreamReqID: "req-1", RunTeamID: "run_1", SessionTeamID: "ses_1",
+			Usage: &UsageObservation{InputTokens: ptr(1), CostMicros: ptr(1), SavedInputTokens: ptr(1)},
+		},
+	} {
+		if got := m.ExpectedCoverage(inv)[FieldGroupStep]; got != CoverageUnavailable {
+			t.Fatalf("step coverage %s for %+v", got, inv)
+		}
+	}
+}
+
+// A legacy-shaped row's absent groups are legacy_unknown, never unavailable:
+// collapsing the two would let an unexplained blank pass as a structural
+// absence. Step stays unavailable, because that absence really is structural.
+func TestLegacyRowClassifiesAbsenceAsLegacyUnknown(t *testing.T) {
+	m := testMapper()
+	got := m.ExpectedCoverage(CityInvocation{UpstreamReqID: "req-1"})
+	for _, group := range []string{FieldGroupTokens, FieldGroupCost, FieldGroupSavings} {
+		if got[group] != CoverageLegacyUnknown {
+			t.Fatalf("%s: want legacy_unknown, got %s", group, got[group])
+		}
+	}
+	if got[FieldGroupStep] != CoverageUnavailable {
+		t.Fatalf("step: want unavailable, got %s", got[FieldGroupStep])
+	}
+}
+
+// Provider-asserted is not verified and derived cost is not billed: token
+// counts classify metered, cost and savings classify estimated, and savings sit
+// in their own group so nothing sums them into cost.
+func TestMeteredAndEstimatedStaySeparateGroups(t *testing.T) {
+	m := testMapper()
+	got := m.ExpectedCoverage(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Usage: &UsageObservation{InputTokens: ptr(10), CostMicros: ptr(99), SavedInputTokens: ptr(5), SavedCostMicros: ptr(7)},
+	})
+	if got[FieldGroupTokens] != CoverageMetered {
+		t.Fatalf("tokens: want metered, got %s", got[FieldGroupTokens])
+	}
+	if got[FieldGroupCost] != CoverageEstimated || got[FieldGroupSavings] != CoverageEstimated {
+		t.Fatalf("derived money must be estimated: %+v", got)
+	}
+
+	// Savings alone never make tokens metered — an upper bound is not a count.
+	savingsOnly := m.ExpectedCoverage(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Usage: &UsageObservation{SavedInputTokens: ptr(5)},
+	})
+	if savingsOnly[FieldGroupTokens] != CoverageUnavailable {
+		t.Fatalf("savings raised the token class to %s", savingsOnly[FieldGroupTokens])
+	}
+}
+
+// A server response that claims a step, a transcript link we never offered, or
+// a completeness better than unavailable is refused. The producer is lending
+// its name to these claims, so it checks them rather than trusting them.
+func TestProducerRefusesRaisedCoverage(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		mutil func(*Inference)
+	}{
+		{"step claimed known", func(in *Inference) { in.Coverage[FieldGroupStep] = string(CoverageKnown) }},
+		{"transcript claimed known", func(in *Inference) { in.Coverage[FieldGroupTranscript] = string(CoverageKnown) }},
+		{"field group omitted", func(in *Inference) { delete(in.Coverage, FieldGroupOutcome) }},
+		{"completeness claimed known", func(in *Inference) { in.Completeness = string(CoverageKnown) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Producer{Mapper: testMapper()}
+			req := CreateInferenceRequest{
+				NativeIdentity:      NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "s", UpstreamReqID: "req-1"},
+				ExternalInferenceID: mustDerive(t, NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "s", UpstreamReqID: "req-1"}),
+			}
+			got := Inference{
+				ID: "inf_1", ExternalInferenceID: req.ExternalInferenceID,
+				Completeness: string(CoverageUnavailable),
+				Coverage: map[string]string{
+					FieldGroupTokens: string(CoverageMetered), FieldGroupCost: string(CoverageEstimated),
+					FieldGroupSavings: string(CoverageUnavailable), FieldGroupStep: string(CoverageUnavailable),
+					FieldGroupTranscript: string(CoverageUnavailable), FieldGroupOutcome: string(CoverageKnown),
+				},
+				FoldEligible: true,
+			}
+			tc.mutil(&got)
+			if err := p.verify(req, got); !errors.Is(err, ErrCoverageRaised) {
+				t.Fatalf("want ErrCoverageRaised, got %v", err)
+			}
+		})
+	}
+}
+
+// Completeness over a best-effort producer is always unavailable, and the
+// accepted record says so.
+func TestAcceptedRecordReportsCompletenessUnavailable(t *testing.T) {
+	api, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	page, err := api.ListInferences(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("want 1 inference, got %d", len(page.Items))
+	}
+	if page.Items[0].Completeness != string(CoverageUnavailable) {
+		t.Fatalf("completeness %q", page.Items[0].Completeness)
+	}
+	if page.Items[0].Coverage[FieldGroupStep] != string(CoverageUnavailable) {
+		t.Fatalf("step coverage %q", page.Items[0].Coverage[FieldGroupStep])
+	}
+}

--- a/pkg/cityinference/fake.go
+++ b/pkg/cityinference/fake.go
@@ -1,0 +1,328 @@
+package cityinference
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+// FakeWorkspace is one tenant's canonical records inside a [FakeAPI].
+type FakeWorkspace struct {
+	Runs     map[string]bool
+	Sessions map[string]string // session Team ID -> run Team ID
+	Records  map[string]string // transcript record Team ID -> session Team ID
+}
+
+// NewFakeWorkspace returns an empty workspace.
+func NewFakeWorkspace() *FakeWorkspace {
+	return &FakeWorkspace{Runs: map[string]bool{}, Sessions: map[string]string{}, Records: map[string]string{}}
+}
+
+// AddChain registers a run, a session under it and an optional transcript
+// record under the session, all as server-minted Team IDs.
+func (w *FakeWorkspace) AddChain(runID, sessionID, recordID string) {
+	w.Runs[runID] = true
+	w.Sessions[sessionID] = runID
+	if recordID != "" {
+		w.Records[recordID] = sessionID
+	}
+}
+
+// RecordedRequest is one outbound call as a transport spy saw it. Body holds
+// the exact bytes, which is what lets a scanner assert on what left rather than
+// on what a struct says should have left.
+type RecordedRequest struct {
+	OperationID    string
+	IdempotencyKey string
+	Body           []byte
+}
+
+// FakeAPI is an in-process stand-in for the public v1 client with two tenants
+// and a request spy.
+//
+// Its refusals are the ones that matter for a producer: a link the caller's
+// tenant does not own is a not-found with the same text a never-created link
+// gets, so a caller cannot use this API as an existence oracle over the other
+// tenant.
+type FakeAPI struct {
+	mu sync.Mutex
+
+	// Tenant is whose credential the calls arrive on.
+	Tenant string
+	// Credential is the bearer identity. It is deliberately never read: a
+	// rotation must change nothing about identity, idempotency or admission.
+	Credential string
+
+	Workspaces map[string]*FakeWorkspace
+
+	// Requests is the spy. Every attempt is recorded, including ones that fail,
+	// so a test can assert that a refusal issued no write.
+	Requests []RecordedRequest
+
+	// FailNext, when set, fails the next create before any admission and is
+	// then cleared. It models a transport fault mid-batch.
+	FailNext error
+
+	replay     map[string]Inference
+	inferences map[string]*Inference
+	seq        int
+}
+
+// NewFakeAPI returns a fake bound to one tenant.
+func NewFakeAPI(tenant string, workspaces map[string]*FakeWorkspace) *FakeAPI {
+	return &FakeAPI{
+		Tenant:     tenant,
+		Workspaces: workspaces,
+		replay:     map[string]Inference{},
+		inferences: map[string]*Inference{},
+	}
+}
+
+// ErrConflict is the fake's payload-divergence refusal: an exact-tuple match
+// whose invariant core disagrees with the admitted record.
+var ErrConflict = errors.New("cityinference: offered record diverges from the admitted record")
+
+// CreateInference implements [API].
+func (f *FakeAPI) CreateInference(_ context.Context, body CreateInferenceRequest, idempotencyKey string) (Inference, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return Inference{}, err
+	}
+	f.Requests = append(f.Requests, RecordedRequest{
+		OperationID: OpCreateInference, IdempotencyKey: idempotencyKey, Body: raw,
+	})
+
+	if f.FailNext != nil {
+		err := f.FailNext
+		f.FailNext = nil
+		return Inference{}, err
+	}
+	if prior, ok := f.replay[idempotencyKey]; ok {
+		return prior, nil
+	}
+
+	ws := f.Workspaces[f.Tenant]
+	if ws == nil {
+		return Inference{}, ErrNotFound
+	}
+	// Foreign, absent, wrong-kind and mismatched links are one answer. The
+	// checks are ordered so no branch can leak which of the four it was.
+	if body.RunTeamID != "" && !ws.Runs[body.RunTeamID] {
+		return Inference{}, ErrNotFound
+	}
+	if body.SessionTeamID != "" {
+		run, ok := ws.Sessions[body.SessionTeamID]
+		if !ok || (body.RunTeamID != "" && run != body.RunTeamID) {
+			return Inference{}, ErrNotFound
+		}
+	}
+	if body.TranscriptRecordID != "" {
+		session, ok := ws.Records[body.TranscriptRecordID]
+		if !ok || (body.SessionTeamID != "" && session != body.SessionTeamID) {
+			return Inference{}, ErrNotFound
+		}
+	}
+
+	derived, err := DeriveExternalInferenceID(body.NativeIdentity)
+	if err != nil {
+		return Inference{}, err
+	}
+	if body.ExternalInferenceID != "" && body.ExternalInferenceID != derived {
+		return Inference{}, fmt.Errorf("cityinference: offered external_inference_id is not the derivation")
+	}
+	if body.Ordinal != nil || body.SourceStepRef != "" {
+		return Inference{}, ErrSyntheticLinkage
+	}
+	scope, err := ClassifyReqID(body.NativeIdentity.UpstreamReqID)
+	if err != nil {
+		return Inference{}, err
+	}
+
+	mapper := Mapper{Source: Source{Tenant: body.NativeIdentity.Tenant}}
+	inv := CityInvocation{
+		SessionNativeID:    body.NativeIdentity.SessionID,
+		TranscriptRecordID: body.TranscriptRecordID,
+		Usage:              body.Usage,
+	}
+	coverage := map[string]string{}
+	for group, class := range mapper.ExpectedCoverage(inv) {
+		coverage[group] = string(class)
+	}
+
+	observation := body.ObservationID
+	if observation == "" {
+		observation = "primary"
+	}
+	contribution := Contribution{
+		ID:            derived + ":" + observation,
+		ObservationID: observation,
+		SourceKind:    "city",
+		UploadedBy:    f.Tenant,
+		UploaderType:  "workspace_token",
+		ObservedAt:    body.StartedAt,
+		IngestedAt:    body.StartedAt,
+		Coverage:      coverage,
+	}
+	if body.Usage.metered() {
+		contribution.TokenUsage = &TokenUsage{
+			InputTokens:       deref(body.Usage.InputTokens),
+			OutputTokens:      deref(body.Usage.OutputTokens),
+			CachedInputTokens: deref(body.Usage.CachedInputTokens),
+		}
+	}
+
+	if existing, ok := f.inferences[derived]; ok {
+		if existing.Provider != body.Provider || existing.Model != body.Model ||
+			existing.Outcome != body.Outcome || existing.RunID != body.RunTeamID ||
+			existing.SessionID != body.SessionTeamID || existing.TranscriptRecordID != body.TranscriptRecordID {
+			return Inference{}, ErrConflict
+		}
+		for _, c := range existing.Contributions {
+			if c.ObservationID == observation {
+				// Same observation of the same call: a duplicate, not an
+				// addition. The response is the admitted record unchanged.
+				out := *existing
+				f.replay[idempotencyKey] = out
+				return out, nil
+			}
+		}
+		existing.Contributions = append(existing.Contributions, contribution)
+		existing.Coverage = foldCoverage(existing.Contributions)
+		existing.TokenUsage = foldTokens(existing.Contributions, existing.FoldEligible)
+		out := *existing
+		f.replay[idempotencyKey] = out
+		return out, nil
+	}
+
+	f.seq++
+	rec := &Inference{
+		ID:                  "inf_" + strconv.Itoa(f.seq),
+		ExternalInferenceID: derived,
+		SourceID:            "src_" + f.Tenant,
+		SourceKind:          "city",
+		SessionID:           body.SessionTeamID,
+		RunID:               body.RunTeamID,
+		TranscriptRecordID:  body.TranscriptRecordID,
+		Provider:            body.Provider,
+		Model:               body.Model,
+		Outcome:             body.Outcome,
+		StartedAt:           body.StartedAt,
+		EndedAt:             body.EndedAt,
+		IngestedAt:          body.StartedAt,
+		Epoch:               body.Epoch,
+		IdentityScope:       scope,
+		FoldEligible:        scope == ScopeInvocation,
+		Contributions:       []Contribution{contribution},
+		Completeness:        string(CoverageUnavailable),
+		ETag:                "W/\"" + derived + "\"",
+	}
+	rec.Coverage = foldCoverage(rec.Contributions)
+	rec.TokenUsage = foldTokens(rec.Contributions, rec.FoldEligible)
+	f.inferences[derived] = rec
+	out := *rec
+	f.replay[idempotencyKey] = out
+	return out, nil
+}
+
+// ListInferences implements [API].
+func (f *FakeAPI) ListInferences(_ context.Context, filter ListFilter) (Page, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Requests = append(f.Requests, RecordedRequest{OperationID: OpListInferences})
+	var out []Inference
+	for _, rec := range f.inferences {
+		if filter.SourceID != "" && rec.SourceID != filter.SourceID {
+			continue
+		}
+		if !filter.StartedAfter.IsZero() && !rec.StartedAt.After(filter.StartedAfter) {
+			continue
+		}
+		out = append(out, *rec)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].StartedAt.Equal(out[j].StartedAt) {
+			return out[i].StartedAt.After(out[j].StartedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return Page{Items: out}, nil
+}
+
+// GetInference implements [API].
+func (f *FakeAPI) GetInference(_ context.Context, inferenceTeamID string) (Inference, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Requests = append(f.Requests, RecordedRequest{OperationID: OpGetInference})
+	for _, rec := range f.inferences {
+		if rec.ID == inferenceTeamID {
+			return *rec, nil
+		}
+	}
+	return Inference{}, ErrNotFound
+}
+
+// Writes counts the create attempts the spy saw.
+func (f *FakeAPI) Writes() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, r := range f.Requests {
+		if r.OperationID == OpCreateInference {
+			n++
+		}
+	}
+	return n
+}
+
+// foldCoverage takes the WEAKEST class present per field group, never the
+// strongest: an unproven contribution can never raise a folded claim.
+func foldCoverage(contributions []Contribution) map[string]string {
+	out := map[string]string{}
+	for _, group := range CoverageFieldGroups() {
+		weakest := CoverageKnown
+		for _, c := range contributions {
+			class := Coverage(c.Coverage[group])
+			if coverageRank[class] < coverageRank[weakest] {
+				weakest = class
+			}
+		}
+		out[group] = string(weakest)
+	}
+	return out
+}
+
+// foldTokens sums metered counts across fold-eligible contributions only. A
+// fold-ineligible record keeps its single observation and is never summed.
+func foldTokens(contributions []Contribution, foldEligible bool) *TokenUsage {
+	var out *TokenUsage
+	for _, c := range contributions {
+		if c.TokenUsage == nil {
+			continue
+		}
+		if out == nil {
+			out = &TokenUsage{}
+		}
+		if !foldEligible {
+			cp := *c.TokenUsage
+			return &cp
+		}
+		out.InputTokens += c.TokenUsage.InputTokens
+		out.OutputTokens += c.TokenUsage.OutputTokens
+		out.CachedInputTokens += c.TokenUsage.CachedInputTokens
+	}
+	return out
+}
+
+func deref(v *uint64) uint64 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}

--- a/pkg/cityinference/identity_test.go
+++ b/pkg/cityinference/identity_test.go
@@ -1,0 +1,175 @@
+package cityinference
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func ptr(v uint64) *uint64 { return &v }
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return ts
+}
+
+func testSource() Source {
+	return Source{SourceID: "src_city", Kind: "city", Tenant: "org_alpha", Epoch: 7}
+}
+
+func testMapper() Mapper { return Mapper{Source: testSource()} }
+
+func mustDerive(t *testing.T, id NativeIdentity) string {
+	t.Helper()
+	got, err := DeriveExternalInferenceID(id)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	return got
+}
+
+// The identity tuple is exactly (tenant, session_id, upstream_req_id). Nothing
+// else may move the derived ID, and each component moving it alone is what
+// proves the triplet is the whole identity.
+func TestIdentityIsTheTripletAndNothingElse(t *testing.T) {
+	base := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-1"}
+	baseID := mustDerive(t, base)
+
+	for _, tc := range []struct {
+		name string
+		id   NativeIdentity
+	}{
+		{"tenant", NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_beta", SessionID: "sess-1", UpstreamReqID: "req-1"}},
+		{"session", NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-2", UpstreamReqID: "req-1"}},
+		{"req", NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-2"}},
+	} {
+		if got := mustDerive(t, tc.id); got == baseID {
+			t.Fatalf("changing %s left the identity unchanged: %s", tc.name, got)
+		}
+	}
+
+	// A model, a provider and a timestamp are outside the tuple, so two
+	// invocations that differ only in those share one identity.
+	m := testMapper()
+	a := CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic", Model: "m-1", Started: mustTime(t, "2026-07-30T10:00:00Z")}
+	b := a
+	b.Provider, b.Model, b.Started = "openai", "m-2", mustTime(t, "2026-07-30T11:00:00Z")
+	if m.Identity(a) != m.Identity(b) {
+		t.Fatal("model/provider/timestamp leaked into the identity tuple")
+	}
+}
+
+// Length-prefixed framing keeps the preimage injective when a component is
+// empty (the legacy row) or carries a delimiter byte. A naive join does not,
+// and a collision here would silently merge two tenants' invocations.
+func TestDerivationIsInjectiveAcrossEmptyAndDelimiterComponents(t *testing.T) {
+	cases := []NativeIdentity{
+		{Kind: NativeIdentityKind, Tenant: "a", SessionID: "", UpstreamReqID: "bc"},
+		{Kind: NativeIdentityKind, Tenant: "a", SessionID: "b", UpstreamReqID: "c"},
+		{Kind: NativeIdentityKind, Tenant: "ab", SessionID: "", UpstreamReqID: "c"},
+		{Kind: NativeIdentityKind, Tenant: "a:b", SessionID: "c", UpstreamReqID: "d"},
+		{Kind: NativeIdentityKind, Tenant: "a", SessionID: "b:c", UpstreamReqID: "d"},
+	}
+	seen := map[string]NativeIdentity{}
+	for _, id := range cases {
+		got := mustDerive(t, id)
+		if prior, dup := seen[got]; dup {
+			t.Fatalf("collision: %+v and %+v both derive %s", prior, id, got)
+		}
+		seen[got] = id
+	}
+}
+
+// The provider request ID must never become a public identifier, so the derived
+// ID may not contain it in any recoverable form.
+func TestDerivedIDDoesNotCarryTheProviderRequestID(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req_abc123secretish"}
+	got := mustDerive(t, id)
+	if !strings.HasPrefix(got, "mfi1_") {
+		t.Fatalf("unexpected identity shape %q", got)
+	}
+	for _, part := range []string{id.Tenant, id.SessionID, id.UpstreamReqID} {
+		if strings.Contains(got, part) {
+			t.Fatalf("derived id %q leaks component %q", got, part)
+		}
+	}
+}
+
+// The empty session ID is a legal legacy value, not a null. Refusing it would
+// force a producer to invent one, which is the exact synthesis this domain
+// forbids.
+func TestLegacyEmptySessionMapsWithoutSynthesis(t *testing.T) {
+	m := testMapper()
+	req, err := m.MapInvocation(CityInvocation{
+		UpstreamReqID: "req-legacy", Provider: "anthropic", Model: "m-1",
+		Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("legacy invocation refused: %v", err)
+	}
+	if req.NativeIdentity.SessionID != "" {
+		t.Fatalf("legacy session id was synthesized as %q", req.NativeIdentity.SessionID)
+	}
+}
+
+func TestRequestIDPrefixClassification(t *testing.T) {
+	for _, tc := range []struct {
+		reqID string
+		scope IdentityScope
+		err   error
+	}{
+		{"req-provider-1", ScopeInvocation, nil},
+		{"gen_9f2a", ScopeObservation, nil},
+		{"err_timeout", "", ErrAttemptRow},
+		{"", "", ErrInvalidInvocation},
+	} {
+		scope, err := ClassifyReqID(tc.reqID)
+		if tc.err != nil {
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("%q: want %v, got %v", tc.reqID, tc.err, err)
+			}
+			continue
+		}
+		if err != nil || scope != tc.scope {
+			t.Fatalf("%q: want %s, got %s (%v)", tc.reqID, tc.scope, scope, err)
+		}
+	}
+}
+
+// The tenant is enrollment data. A City-side field may not redirect a record
+// into another tenant's identity space, so the mapper reads it from the source
+// and there is no invocation field that could override it.
+func TestTenantComesFromEnrollmentNotFromTheInvocation(t *testing.T) {
+	m := testMapper()
+	req, err := m.MapInvocation(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+		Model: "m-1", Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if req.NativeIdentity.Tenant != testSource().Tenant {
+		t.Fatalf("tenant %q is not the enrolled tenant", req.NativeIdentity.Tenant)
+	}
+}
+
+// The offered external ID is a checksum, never a choice.
+func TestPreflightRejectsAChosenExternalID(t *testing.T) {
+	m := testMapper()
+	req, err := m.MapInvocation(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+		Model: "m-1", Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	req.ExternalInferenceID = "mfi1_notthederivation"
+	if err := Preflight(req); !errors.Is(err, ErrInvalidInvocation) {
+		t.Fatalf("want ErrInvalidInvocation, got %v", err)
+	}
+}

--- a/pkg/cityinference/isolation_test.go
+++ b/pkg/cityinference/isolation_test.go
@@ -1,0 +1,193 @@
+package cityinference
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// AC3 core: a foreign link and an absent link are the same answer. If they were
+// not, this adapter would be an existence oracle over the other tenant's
+// records, and the two-tenant spy is how that is proven rather than asserted.
+func TestForeignAndAbsentLinksAreIndistinguishable(t *testing.T) {
+	foreign := happyInvocation(t)
+	foreign.TranscriptRecordID = "trc_beta" // real, but owned by the other tenant
+	foreign.UpstreamReqID = "req-foreign"
+
+	absent := happyInvocation(t)
+	absent.TranscriptRecordID = "trc_never_created"
+	absent.UpstreamReqID = "req-absent"
+
+	mismatched := happyInvocation(t)
+	mismatched.SessionTeamID = "ses_2" // same tenant, wrong container for trc_1
+	mismatched.RunTeamID = "run_2"
+	mismatched.UpstreamReqID = "req-mismatch"
+
+	incompatible := happyInvocation(t)
+	incompatible.TranscriptRecordID = "run_1" // a real ID of the wrong kind
+	incompatible.UpstreamReqID = "req-wrongkind"
+
+	var messages []string
+	for _, inv := range []CityInvocation{foreign, absent, mismatched, incompatible} {
+		api, p := newHarness(t)
+		_, err := p.Push(context.Background(), []CityInvocation{inv})
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("%s: want ErrNotFound, got %v", inv.UpstreamReqID, err)
+		}
+		messages = append(messages, err.Error())
+		page, listErr := api.ListInferences(context.Background(), ListFilter{})
+		if listErr != nil {
+			t.Fatalf("list: %v", listErr)
+		}
+		if len(page.Items) != 0 {
+			t.Fatalf("%s: an invalid link still wrote a record", inv.UpstreamReqID)
+		}
+	}
+	for _, msg := range messages[1:] {
+		if msg != messages[0] {
+			t.Fatalf("refusals are distinguishable: %q vs %q", messages[0], msg)
+		}
+	}
+}
+
+// The valid same-workspace link is the control: the identical shape succeeds
+// when the records really are this tenant's.
+func TestSameWorkspaceLinkSucceeds(t *testing.T) {
+	_, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("valid link refused: %v", err)
+	}
+}
+
+// Content and step linkage cannot enter through the City side at all: there is
+// no field on the invocation that could carry either. This is the structural
+// half of "forbidden content is never sent" — the scanner is the other half,
+// and a drift guard here fails the day someone adds the field.
+func TestCityInvocationCannotCarryContentOrStep(t *testing.T) {
+	forbidden := map[string]bool{
+		"Prompt": true, "Completion": true, "Text": true, "Content": true,
+		"Messages": true, "Transcript": true, "RawResponse": true, "Payload": true,
+		"Step": true, "StepID": true, "SourceStepRef": true, "Ordinal": true,
+	}
+	typ := reflect.TypeOf(CityInvocation{})
+	for i := 0; i < typ.NumField(); i++ {
+		if forbidden[typ.Field(i).Name] {
+			t.Fatalf("CityInvocation grew a forbidden field %q", typ.Field(i).Name)
+		}
+	}
+}
+
+// A refused invocation performs no inference write at all: the refusal happens
+// at this adapter's edge, so the spy sees zero calls rather than a 4xx. What
+// this adapter does send is then scanned byte-for-byte.
+func TestRefusedInvocationIssuesNoWriteAndSentBytesAreClean(t *testing.T) {
+	api, p := newHarness(t)
+	bad := happyInvocation(t)
+	bad.UpstreamReqID = "err_upstream_timeout" // an attempt row, refused before send
+	if _, err := p.Push(context.Background(), []CityInvocation{bad}); !errors.Is(err, ErrAttemptRow) {
+		t.Fatalf("want ErrAttemptRow, got %v", err)
+	}
+	if api.Writes() != 0 {
+		t.Fatalf("refused invocation issued %d writes", api.Writes())
+	}
+
+	// Every byte this adapter did send is scanner-clean: no content, no
+	// credential, no unadmitted field.
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if api.Writes() == 0 {
+		t.Fatal("nothing was recorded to scan")
+	}
+	for i, req := range api.Requests {
+		if req.OperationID != OpCreateInference {
+			continue
+		}
+		if err := ScanForbidden(req.Body); err != nil {
+			t.Fatalf("request %d carried forbidden bytes: %v", i, err)
+		}
+	}
+}
+
+// Only the three frozen operations appear on the wire.
+func TestOnlyFrozenOperationsAreCalled(t *testing.T) {
+	api, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	frozen := map[string]bool{OpCreateInference: true, OpListInferences: true, OpGetInference: true}
+	for _, req := range api.Requests {
+		if !frozen[req.OperationID] {
+			t.Fatalf("unfrozen operation %q", req.OperationID)
+		}
+	}
+}
+
+// Rollback: disabling City inference stops this producer and nothing else.
+// Acknowledged records persist, reads keep working, and a custom (non-City)
+// inference producer on the same API is unaffected.
+func TestDisablingCityInferenceLeavesOtherProducersOperational(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	city, err := NewProducer(api, testMapper(), NewMemoryStore())
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	res, err := city.Push(context.Background(), []CityInvocation{happyInvocation(t)})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	accepted := res.Uploaded[0].InferenceTeamID
+
+	city.Disabled = true
+	writesBefore := api.Writes()
+	next := happyInvocation(t)
+	next.UpstreamReqID = "req-after-rollback"
+	if _, err := city.Push(context.Background(), []CityInvocation{next}); !errors.Is(err, ErrDisabled) {
+		t.Fatalf("want ErrDisabled, got %v", err)
+	}
+	if api.Writes() != writesBefore {
+		t.Fatal("a disabled producer issued a write")
+	}
+	if _, err := api.GetInference(context.Background(), accepted); err != nil {
+		t.Fatalf("acknowledged record did not persist through rollback: %v", err)
+	}
+
+	// A custom orchestrator with no City in the picture uploads the same shape
+	// on its own source identity and is untouched by City's rollback.
+	custom := Mapper{Source: Source{SourceID: "src_custom", Kind: "custom_orchestrator", Tenant: tenantAlpha, Epoch: 3}}
+	other, err := NewProducer(api, custom, NewMemoryStore())
+	if err != nil {
+		t.Fatalf("new custom producer: %v", err)
+	}
+	inv := happyInvocation(t)
+	inv.UpstreamReqID = "req-custom-1"
+	if _, err := other.Push(context.Background(), []CityInvocation{inv}); err != nil {
+		t.Fatalf("custom producer refused after City rollback: %v", err)
+	}
+}
+
+// A second City source for the same deployment is a distinct source identity,
+// so its idempotency keys never collide with the first one's. Silent key reuse
+// across sources is how a structural double count becomes invisible.
+func TestIdempotencyKeyIsScopedToTheSource(t *testing.T) {
+	a := testSource()
+	b := testSource()
+	b.SourceID = "src_city_2"
+	if IdempotencyKey(a, "mfi1_x/primary") == IdempotencyKey(b, "mfi1_x/primary") {
+		t.Fatal("two sources share an idempotency key")
+	}
+	c := testSource()
+	c.Epoch = 8
+	if IdempotencyKey(a, "mfi1_x/primary") == IdempotencyKey(c, "mfi1_x/primary") {
+		t.Fatal("an epoch reset reused the pre-reset key")
+	}
+	if IdempotencyKey(a, "mfi1_x/primary") == IdempotencyKey(a, "mfi1_x/secondary") {
+		t.Fatal("two observations share an idempotency key")
+	}
+	// Stability across a fresh Source value: the preimage holds only enrollment
+	// data, so a redeploy that rebuilds the struct resumes the same key.
+	if IdempotencyKey(testSource(), "mfi1_x/primary") != IdempotencyKey(a, "mfi1_x/primary") {
+		t.Fatal("key derivation is not stable across an equivalent source")
+	}
+}

--- a/pkg/cityinference/mapping.go
+++ b/pkg/cityinference/mapping.go
@@ -1,0 +1,471 @@
+package cityinference
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Source is the enrolled producer identity this adapter uploads under.
+type Source struct {
+	SourceID string
+	// Kind is the source class, e.g. "city". It is in the idempotency preimage
+	// so two producers holding the same native IDs cannot collide.
+	Kind string
+	// Tenant is the enrolled tenant handle in the provider's namespace. It is
+	// the first component of the identity triplet, and it is enrollment data:
+	// an invocation may not carry a different one.
+	Tenant string
+	// Epoch is the frozen ingest epoch. It advances only on a declared reset,
+	// never on a restart and never on a credential rotation, and the adapter
+	// refuses to guess one.
+	Epoch uint64
+}
+
+// CityInvocation is one City model invocation as this adapter reads it.
+//
+// There is no step field, and that absence is the design. The frozen contract
+// admits no step reference for this domain, so a field here would exist only to
+// be dropped silently or fabricated — and the honest expression of a step City
+// cannot prove is coverage class unavailable, which [ExpectedCoverage] reports
+// unconditionally. There is likewise no prompt, completion or message-text
+// field: content lives behind transcript and artifact content authorization.
+type CityInvocation struct {
+	// SessionNativeID is the provider-namespace session identifier. The empty
+	// string is a legal legacy value, not a null, and it is never replaced with
+	// a synthesized one.
+	SessionNativeID string
+	// UpstreamReqID is the provider-assigned request identifier, or a locally
+	// generated gen_ value. An err_ value is an attempt row and is refused.
+	UpstreamReqID string
+
+	Provider string
+	Model    string
+	// Status is City-native and is normalized into the closed outcome
+	// vocabulary; an unmappable status becomes OutcomeUnknown rather than
+	// traveling as itself.
+	Status  string
+	Started time.Time
+	Ended   *time.Time
+
+	// RunTeamID, SessionTeamID and TranscriptRecordID are server-minted Team
+	// IDs this City read back from its own neutral upserts. They are links to
+	// already-authorized canonical records; this adapter produces none of them.
+	RunTeamID          string
+	SessionTeamID      string
+	TranscriptRecordID string
+
+	// ObservationID names WHICH observation of the invocation this is. Two
+	// honest observations of one call (a metered one and an estimated one)
+	// carry different values and stand as two contributions on one inference.
+	ObservationID string
+
+	Usage *UsageObservation
+}
+
+// Mapper turns a City invocation into a neutral request body and refuses any
+// mapping that would let a City fact reach a neutral authority field.
+type Mapper struct {
+	Source Source
+}
+
+// inferenceIDDomain is the preimage domain of the derived external inference ID.
+const inferenceIDDomain = "gascity/inference-id/manifold.triplet.v1"
+
+// inferenceIDAlphabet is lowercase base32 with no padding, matching the server.
+var inferenceIDAlphabet = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+
+// DeriveExternalInferenceID mints the external inference ID from a native
+// triplet. It is byte-for-byte the server's derivation, which is the point:
+// two independent derivers converge with no coordination, and that is what
+// makes an exact-tuple duplicate detectable at all.
+//
+// Two properties are load-bearing and neither is stylistic. The framing is
+// length-prefixed, so the preimage stays injective when a component is empty (a
+// legacy row carries session_id = "") or contains a delimiter byte — a naive
+// join does not. The digest is one-way, because the provider request ID must
+// never become a public identifier and a record identity is by definition
+// visible on a read path.
+func DeriveExternalInferenceID(id NativeIdentity) (string, error) {
+	if id.Kind != NativeIdentityKind {
+		return "", fmt.Errorf("%w: unknown native identity kind %q", ErrInvalidInvocation, id.Kind)
+	}
+	h := sha256.New()
+	h.Write([]byte(inferenceIDDomain))
+	for _, s := range []string{id.Tenant, id.SessionID, id.UpstreamReqID} {
+		h.Write([]byte(strconv.Itoa(len(s))))
+		h.Write([]byte{0x3a})
+		h.Write([]byte(s))
+	}
+	return "mfi1_" + inferenceIDAlphabet.EncodeToString(h.Sum(nil)[:20]), nil
+}
+
+// Prefix classes of an upstream request ID.
+const (
+	reqIDPrefixError     = "err_"
+	reqIDPrefixGenerated = "gen_"
+)
+
+// ClassifyReqID decides identity scope from the request-id prefix, and refuses
+// the one prefix that is not an inference at all.
+//
+// err_ rows are attempt rows: a request that never produced a metered
+// invocation. Admitting one would let a failed attempt stand as a call in every
+// sum built over this domain, so it is a categorical reject rather than a
+// zero-usage record.
+func ClassifyReqID(reqID string) (IdentityScope, error) {
+	switch {
+	case reqID == "":
+		return "", fmt.Errorf("%w: upstream_req_id is required", ErrInvalidInvocation)
+	case strings.HasPrefix(reqID, reqIDPrefixError):
+		return "", fmt.Errorf("%w: %s rows never produced a metered invocation", ErrAttemptRow, reqIDPrefixError)
+	case strings.HasPrefix(reqID, reqIDPrefixGenerated):
+		return ScopeObservation, nil
+	}
+	return ScopeInvocation, nil
+}
+
+// Identity returns the native triplet of one invocation under this mapper's
+// enrolled tenant. The tenant comes from enrollment and never from the
+// invocation, so a City-side field cannot redirect a record into another
+// tenant's identity space.
+func (m Mapper) Identity(inv CityInvocation) NativeIdentity {
+	return NativeIdentity{
+		Kind:          NativeIdentityKind,
+		Tenant:        m.Source.Tenant,
+		SessionID:     inv.SessionNativeID,
+		UpstreamReqID: inv.UpstreamReqID,
+	}
+}
+
+// normalizeOutcome maps a City-native status onto the closed vocabulary.
+func normalizeOutcome(status string) Outcome {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "ok", "success", "succeeded", "complete", "completed":
+		return OutcomeOK
+	case "error", "failed", "failure":
+		return OutcomeError
+	case "cancelled", "canceled", "aborted": //nolint:misspell // both City spellings are real inputs
+		return OutcomeCancelled
+	default:
+		return OutcomeUnknown
+	}
+}
+
+// legacy reports the legacy shape: a row with no provider-namespace session.
+// Its absent field groups classify legacy_unknown rather than unavailable,
+// because collapsing the two would let an unexplained blank pass as a
+// structural absence.
+func (m Mapper) legacy(inv CityInvocation) bool { return inv.SessionNativeID == "" }
+
+// ExpectedCoverage is the coverage map this adapter's offer supports.
+//
+// It is NOT authority: coverage is server-derived at admission and immutable
+// after. It exists so a fixture can pin what City claims on its own behalf, and
+// so [Producer] can refuse an accepted record whose coverage came back stronger
+// than what was offered.
+//
+// Nothing here is a guess. Token counts are metered because the party that did
+// the work counted them and we recorded them verbatim — which is not a claim
+// that they are correct. Cost is estimated because a price table produced it,
+// not a counter. Step attribution is unavailable unconditionally: there is no
+// admitted field, so there is nothing to be known about. Transcript attribution
+// is known only when a canonical record ID is linked, because that link is
+// server-verified.
+func (m Mapper) ExpectedCoverage(inv CityInvocation) map[string]Coverage {
+	absent := CoverageUnavailable
+	if m.legacy(inv) {
+		absent = CoverageLegacyUnknown
+	}
+	cov := map[string]Coverage{
+		FieldGroupTokens:     absent,
+		FieldGroupCost:       absent,
+		FieldGroupSavings:    absent,
+		FieldGroupStep:       CoverageUnavailable,
+		FieldGroupTranscript: CoverageUnavailable,
+		FieldGroupOutcome:    CoverageKnown,
+	}
+	if u := inv.Usage; u != nil {
+		if u.metered() {
+			cov[FieldGroupTokens] = CoverageMetered
+		}
+		if u.CostMicros != nil {
+			cov[FieldGroupCost] = CoverageEstimated
+		}
+		if u.SavedInputTokens != nil || u.SavedCostMicros != nil {
+			cov[FieldGroupSavings] = CoverageEstimated
+		}
+	}
+	if inv.TranscriptRecordID != "" {
+		cov[FieldGroupTranscript] = CoverageKnown
+	}
+	return cov
+}
+
+// coverageRank orders the classes weakest to strongest. A fold takes the
+// WEAKEST class present, never the strongest: an unproven contribution can
+// never raise a folded claim.
+var coverageRank = map[Coverage]int{
+	CoverageLegacyUnknown: 0,
+	CoverageUnavailable:   1,
+	CoverageEstimated:     2,
+	CoveragePartial:       3,
+	CoverageMetered:       4,
+	CoverageKnown:         5,
+}
+
+// MapInvocation turns one City invocation into a neutral create request.
+//
+// The container Team IDs travel exactly as City read them back. A City-native
+// run or session ID placed in one of those fields is not translated here into
+// something plausible: it goes as given and resolves to a not-found, which is
+// the same answer a foreign record gets.
+func (m Mapper) MapInvocation(inv CityInvocation) (CreateInferenceRequest, error) {
+	if m.Source.Tenant == "" {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: enrolled tenant is required", ErrInvalidInvocation)
+	}
+	if m.Source.Epoch == 0 {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: source epoch is required and is never guessed", ErrInvalidInvocation)
+	}
+	if _, err := ClassifyReqID(inv.UpstreamReqID); err != nil {
+		return CreateInferenceRequest{}, err
+	}
+	if inv.Provider == "" || inv.Model == "" {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: provider and model are required", ErrInvalidInvocation)
+	}
+	if inv.Started.IsZero() {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: started_at is required", ErrInvalidInvocation)
+	}
+	if inv.Ended != nil && inv.Ended.Before(inv.Started) {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: ended_at precedes started_at", ErrInvalidInvocation)
+	}
+
+	id := m.Identity(inv)
+	external, err := DeriveExternalInferenceID(id)
+	if err != nil {
+		return CreateInferenceRequest{}, err
+	}
+
+	observation := inv.ObservationID
+	if observation == "" {
+		observation = "primary"
+	}
+
+	req := CreateInferenceRequest{
+		NativeIdentity:      id,
+		ExternalInferenceID: external,
+		Provider:            inv.Provider,
+		Model:               inv.Model,
+		Outcome:             normalizeOutcome(inv.Status),
+		StartedAt:           inv.Started.UTC(),
+		Epoch:               m.Source.Epoch,
+		SessionTeamID:       inv.SessionTeamID,
+		RunTeamID:           inv.RunTeamID,
+		TranscriptRecordID:  inv.TranscriptRecordID,
+		ObservationID:       observation,
+		Usage:               inv.Usage,
+	}
+	if inv.Ended != nil {
+		ended := inv.Ended.UTC()
+		req.EndedAt = &ended
+	}
+	if err := Preflight(req); err != nil {
+		return CreateInferenceRequest{}, err
+	}
+	return req, nil
+}
+
+// FoldBasis names what a correlation claim rests on.
+type FoldBasis string
+
+// The one admissible basis, and the inadmissible ones spelled out so a test can
+// enumerate them. They exist as named values precisely so that offering one is
+// a refusal with a reason rather than a silent "no match".
+const (
+	FoldExactTuple  FoldBasis = "exact_tuple"
+	FoldTimestamp   FoldBasis = "timestamp_proximity"
+	FoldModel       FoldBasis = "model_equality"
+	FoldVendor      FoldBasis = "vendor_equality"
+	FoldTokenCount  FoldBasis = "token_count_equality"
+	FoldCost        FoldBasis = "cost_equality"
+	FoldTextual     FoldBasis = "textual_similarity"
+	FoldProviderLoc FoldBasis = "provider_locator"
+	FoldCityField   FoldBasis = "city_field"
+)
+
+// ForbiddenFoldBases returns every basis this adapter refuses, in a stable
+// order, so a decision-table test can assert the closed set rather than a
+// sample of it.
+func ForbiddenFoldBases() []FoldBasis {
+	return []FoldBasis{
+		FoldTimestamp, FoldModel, FoldVendor, FoldTokenCount,
+		FoldCost, FoldTextual, FoldProviderLoc, FoldCityField,
+	}
+}
+
+// CorrelationClaim is an offered assertion that two invocations are the same
+// call.
+type CorrelationClaim struct {
+	Basis FoldBasis
+	A, B  CityInvocation
+}
+
+// Fold decides whether two contributions may be folded into one authoritative
+// sum.
+//
+// Only an exact identity tuple folds, and only when the tuple names an
+// invocation rather than an observation of one: two locally generated request
+// IDs for the same real call never converge, so folding on them would hide a
+// double count. Any other basis is refused outright — the refusal is the
+// answer, because a producer that gets "false" back from a timestamp comparison
+// will try a wider window next.
+func (m Mapper) Fold(claim CorrelationClaim) (bool, error) {
+	if claim.Basis != FoldExactTuple {
+		return false, fmt.Errorf("%w: basis %q is not a comparator in this domain", ErrHeuristicFold, claim.Basis)
+	}
+	scopeA, err := ClassifyReqID(claim.A.UpstreamReqID)
+	if err != nil {
+		return false, err
+	}
+	scopeB, err := ClassifyReqID(claim.B.UpstreamReqID)
+	if err != nil {
+		return false, err
+	}
+	if m.Identity(claim.A) != m.Identity(claim.B) {
+		return false, nil
+	}
+	if scopeA != ScopeInvocation || scopeB != ScopeInvocation {
+		return false, nil
+	}
+	return true, nil
+}
+
+// The closed admitted key set of the create request, per nesting level. A
+// closed allowlist rather than a blocklist of content-shaped names: a blocklist
+// has to guess what content will be called next, and this side of the wire is
+// where prompt text would first appear if the struct ever drifted.
+var admittedKeys = map[string]map[string]bool{
+	"": {
+		"native_identity": true, "external_inference_id": true, "provider": true,
+		"model": true, "outcome": true, "started_at": true, "ended_at": true,
+		"epoch": true, "session_id": true, "run_id": true, "transcript_record_id": true,
+		"observation_id": true, "usage": true, "ordinal": true, "source_step_ref": true,
+	},
+	"native_identity": {
+		"kind": true, "tenant": true, "session_id": true, "upstream_req_id": true,
+	},
+	"usage": {
+		"input_tokens": true, "output_tokens": true, "cached_input_tokens": true,
+		"cost_micros": true, "saved_input_tokens": true, "saved_cost_micros": true,
+	},
+}
+
+// credentialEvidence matches the shapes a credential takes when it leaks into a
+// payload by accident.
+var credentialEvidence = regexp.MustCompile(`(?i)(bearer\s+[a-z0-9._~+/-]{8,}|sk-[a-z0-9]{8,}|authorization|api[_-]?key|secret|password|private[_-]?key)`)
+
+// ScanForbidden reads outbound request bytes and refuses anything the contract
+// does not admit.
+//
+// It works on bytes rather than on the struct so a test can point it at what a
+// transport spy actually recorded. Two classes of refusal: a key outside the
+// closed admitted set (which is how model content would arrive), and a value
+// carrying credential evidence.
+func ScanForbidden(raw []byte) error {
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return fmt.Errorf("%w: outbound payload is not a JSON object", ErrContentLeak)
+	}
+	for _, level := range []string{"", "native_identity", "usage"} {
+		obj := body
+		if level != "" {
+			raw, ok := body[level]
+			if !ok {
+				continue
+			}
+			obj = nil
+			if err := json.Unmarshal(raw, &obj); err != nil {
+				return fmt.Errorf("%w: %s is not a JSON object", ErrContentLeak, level)
+			}
+		}
+		for key := range obj {
+			if !admittedKeys[level][key] {
+				where := key
+				if level != "" {
+					where = level + "." + key
+				}
+				return fmt.Errorf("%w: field %q is not admitted by the inference contract", ErrContentLeak, where)
+			}
+		}
+	}
+	if credentialEvidence.Match(raw) {
+		return fmt.Errorf("%w: payload matches a credential shape", ErrCredentialLeak)
+	}
+	return nil
+}
+
+// Preflight refuses a request before a byte leaves the process.
+//
+// It runs on every request [Producer] sends, including one a caller built by
+// hand, so the never-synthesize rules are enforced at this adapter's edge and
+// not only by a 422 the caller has to correlate back.
+func Preflight(req CreateInferenceRequest) error {
+	if req.Ordinal != nil {
+		return fmt.Errorf("%w: this domain asserts no order, so `ordinal` may not be offered", ErrSyntheticLinkage)
+	}
+	if req.SourceStepRef != "" {
+		return fmt.Errorf("%w: step attribution is unavailable by construction, so `source_step_ref` may not be offered", ErrSyntheticLinkage)
+	}
+	if req.NativeIdentity.Kind != NativeIdentityKind {
+		return fmt.Errorf("%w: unknown native identity kind %q", ErrInvalidInvocation, req.NativeIdentity.Kind)
+	}
+	if err := boundedNativeID("native_identity.tenant", req.NativeIdentity.Tenant, false); err != nil {
+		return err
+	}
+	// session_id is checked only when non-empty: "" is the legal legacy value,
+	// and rejecting it would force a producer to invent one.
+	if err := boundedNativeID("native_identity.session_id", req.NativeIdentity.SessionID, true); err != nil {
+		return err
+	}
+	if err := boundedNativeID("native_identity.upstream_req_id", req.NativeIdentity.UpstreamReqID, false); err != nil {
+		return err
+	}
+	if _, err := ClassifyReqID(req.NativeIdentity.UpstreamReqID); err != nil {
+		return err
+	}
+	if req.ExternalInferenceID != "" {
+		derived, err := DeriveExternalInferenceID(req.NativeIdentity)
+		if err != nil {
+			return err
+		}
+		if derived != req.ExternalInferenceID {
+			return fmt.Errorf("%w: offered external_inference_id is not the derivation of the triplet", ErrInvalidInvocation)
+		}
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("%w: encode request: %w", ErrInvalidInvocation, err)
+	}
+	return ScanForbidden(raw)
+}
+
+func boundedNativeID(field, value string, allowEmpty bool) error {
+	if value == "" {
+		if allowEmpty {
+			return nil
+		}
+		return fmt.Errorf("%w: %s is required", ErrInvalidInvocation, field)
+	}
+	if len(value) > maxNativeIDLen {
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidInvocation, field, maxNativeIDLen)
+	}
+	if strings.ContainsAny(value, "\x00\n\r") {
+		return fmt.Errorf("%w: %s contains a control character", ErrInvalidInvocation, field)
+	}
+	return nil
+}

--- a/pkg/cityinference/mapping_test.go
+++ b/pkg/cityinference/mapping_test.go
@@ -1,0 +1,262 @@
+package cityinference
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// The mapping decision table. Every row is a shape the design names, and every
+// outcome is the one it names for it.
+func TestMappingDecisionTable(t *testing.T) {
+	m := testMapper()
+	base := CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+		Model: "m-1", Status: "succeeded", Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	}
+	with := func(mutate func(*CityInvocation)) CityInvocation {
+		inv := base
+		mutate(&inv)
+		return inv
+	}
+
+	for _, tc := range []struct {
+		name string
+		inv  CityInvocation
+		want error
+	}{
+		{"provider-assigned request id admits", base, nil},
+		{"locally generated request id admits", with(func(i *CityInvocation) { i.UpstreamReqID = "gen_7" }), nil},
+		{"legacy empty session admits", with(func(i *CityInvocation) { i.SessionNativeID = "" }), nil},
+		{"attempt row is refused", with(func(i *CityInvocation) { i.UpstreamReqID = "err_upstream_timeout" }), ErrAttemptRow},
+		{"missing request id is refused", with(func(i *CityInvocation) { i.UpstreamReqID = "" }), ErrInvalidInvocation},
+		{"missing model is refused", with(func(i *CityInvocation) { i.Model = "" }), ErrInvalidInvocation},
+		{"missing start is refused", with(func(i *CityInvocation) { i.Started = time.Time{} }), ErrInvalidInvocation},
+		{"end before start is refused", with(func(i *CityInvocation) {
+			end := mustTime(t, "2026-07-30T09:00:00Z")
+			i.Ended = &end
+		}), ErrInvalidInvocation},
+		{"oversized request id is refused", with(func(i *CityInvocation) {
+			i.UpstreamReqID = string(make([]byte, maxNativeIDLen+1))
+		}), ErrInvalidInvocation},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := m.MapInvocation(tc.inv)
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("want admission, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// An unmappable City status becomes unknown rather than traveling as itself:
+// the canonical contract has no raw passthrough.
+func TestOutcomeVocabularyIsClosed(t *testing.T) {
+	m := testMapper()
+	for status, want := range map[string]Outcome{
+		"succeeded": OutcomeOK, "failed": OutcomeError, "canceled": OutcomeCancelled,
+		"reticulating splines": OutcomeUnknown, "": OutcomeUnknown,
+	} {
+		req, err := m.MapInvocation(CityInvocation{
+			SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+			Model: "m-1", Status: status, Started: mustTime(t, "2026-07-30T10:00:00Z"),
+		})
+		if err != nil {
+			t.Fatalf("%q: %v", status, err)
+		}
+		if req.Outcome != want {
+			t.Fatalf("%q: want %s, got %s", status, want, req.Outcome)
+		}
+	}
+}
+
+// Only an exact identity tuple folds, and only when that tuple names an
+// invocation. Every other basis is refused outright rather than answered.
+func TestFoldOnlyOnExactTuple(t *testing.T) {
+	m := testMapper()
+	a := CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic", Model: "m-1"}
+	b := a
+
+	folds, err := m.Fold(CorrelationClaim{Basis: FoldExactTuple, A: a, B: b})
+	if err != nil || !folds {
+		t.Fatalf("exact tuple must fold: %v %v", folds, err)
+	}
+
+	for _, basis := range ForbiddenFoldBases() {
+		folds, err := m.Fold(CorrelationClaim{Basis: basis, A: a, B: b})
+		if !errors.Is(err, ErrHeuristicFold) {
+			t.Fatalf("%s: want ErrHeuristicFold, got %v", basis, err)
+		}
+		if folds {
+			t.Fatalf("%s: refused claim still folded", basis)
+		}
+	}
+}
+
+// Similarity is not identity. Two calls that agree on model, provider, tenant
+// and timestamp but differ in request id stay separate — as do two locally
+// generated ids, which never converge on the same real call.
+func TestSimilarRecordsStaySeparate(t *testing.T) {
+	m := testMapper()
+	ts := mustTime(t, "2026-07-30T10:00:00Z")
+	for _, tc := range []struct {
+		name string
+		a, b CityInvocation
+	}{
+		{
+			"near-identical timestamps, different request ids",
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Model: "m-1", Started: ts},
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-2", Model: "m-1", Started: ts.Add(1)},
+		},
+		{
+			"two locally generated observations of one call",
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "gen_a", Model: "m-1", Started: ts},
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "gen_b", Model: "m-1", Started: ts},
+		},
+		{
+			"legacy row and EIA row sharing a provider request id",
+			CityInvocation{SessionNativeID: "", UpstreamReqID: "req-1", Model: "m-1", Started: ts},
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Model: "m-1", Started: ts},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			folds, err := m.Fold(CorrelationClaim{Basis: FoldExactTuple, A: tc.a, B: tc.b})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if folds {
+				t.Fatal("records folded on a non-identity similarity")
+			}
+			if m.Identity(tc.a) == m.Identity(tc.b) {
+				t.Fatal("distinct calls collapsed onto one identity")
+			}
+		})
+	}
+
+	// Even an exact tuple does not fold when the id was generated locally: two
+	// such observations never converge, so folding them would hide a double
+	// count instead of removing one.
+	gen := CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "gen_a", Model: "m-1", Started: ts}
+	folds, err := m.Fold(CorrelationClaim{Basis: FoldExactTuple, A: gen, B: gen})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if folds {
+		t.Fatal("a locally generated identity was treated as fold-eligible")
+	}
+}
+
+// Ordinal and step reference are refused at this adapter's edge, before a byte
+// leaves, and with the specific reason rather than a generic parse error.
+func TestPreflightRefusesSynthesizedLinkage(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-1"}
+	base := CreateInferenceRequest{
+		NativeIdentity: id, ExternalInferenceID: mustDerive(t, id),
+		Provider: "anthropic", Model: "m-1", Outcome: OutcomeOK,
+		StartedAt: mustTime(t, "2026-07-30T10:00:00Z"),
+	}
+	if err := Preflight(base); err != nil {
+		t.Fatalf("clean request refused: %v", err)
+	}
+
+	withOrdinal := base
+	withOrdinal.Ordinal = ptr(3)
+	if err := Preflight(withOrdinal); !errors.Is(err, ErrSyntheticLinkage) {
+		t.Fatalf("ordinal: want ErrSyntheticLinkage, got %v", err)
+	}
+
+	withStep := base
+	withStep.SourceStepRef = "step_9"
+	if err := Preflight(withStep); !errors.Is(err, ErrSyntheticLinkage) {
+		t.Fatalf("step: want ErrSyntheticLinkage, got %v", err)
+	}
+}
+
+// The scanner works on outbound bytes, so it catches a field the contract does
+// not admit no matter how it got there.
+func TestScannerRefusesUnadmittedFieldsAndCredentials(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-1"}
+	clean, err := json.Marshal(CreateInferenceRequest{
+		NativeIdentity: id, ExternalInferenceID: mustDerive(t, id),
+		Provider: "anthropic", Model: "m-1", Outcome: OutcomeOK,
+		StartedAt: mustTime(t, "2026-07-30T10:00:00Z"),
+		Usage:     &UsageObservation{InputTokens: ptr(1)},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ScanForbidden(clean); err != nil {
+		t.Fatalf("clean payload refused: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want error
+	}{
+		{"prompt text", `{"provider":"p","model":"m","prompt":"who are you"}`, ErrContentLeak},
+		{"completion text", `{"provider":"p","model":"m","completion":"I am"}`, ErrContentLeak},
+		{"transcript text", `{"provider":"p","model":"m","messages":[{"role":"user"}]}`, ErrContentLeak},
+		{"raw provider payload", `{"provider":"p","model":"m","raw_response":{"id":"x"}}`, ErrContentLeak},
+		{"nested content", `{"usage":{"input_tokens":1,"prompt":"hi"}}`, ErrContentLeak},
+		{"bearer credential", `{"provider":"Bearer sk-abcdefgh12345678","model":"m"}`, ErrCredentialLeak},
+		{"key identifier", `{"provider":"p","model":"m","native_identity":{"kind":"manifold.triplet.v1","tenant":"t","session_id":"s","upstream_req_id":"api_key=zz"}}`, ErrCredentialLeak},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ScanForbidden([]byte(tc.body)); !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// The admitted key set is closed and matches the request struct exactly. If a
+// field is ever added to the struct without being admitted here, this fails —
+// which is the point: struct drift is how content first arrives.
+func TestAdmittedKeySetMatchesTheRequestStruct(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "t", SessionID: "s", UpstreamReqID: "req-1"}
+	raw, err := json.Marshal(CreateInferenceRequest{
+		NativeIdentity: id, ExternalInferenceID: "x", Provider: "p", Model: "m",
+		Outcome: OutcomeOK, StartedAt: mustTime(t, "2026-07-30T10:00:00Z"),
+		EndedAt: func() *time.Time { ts := mustTime(t, "2026-07-30T10:01:00Z"); return &ts }(),
+		Epoch:   1, SessionTeamID: "ses_1", RunTeamID: "run_1", TranscriptRecordID: "trc_1",
+		ObservationID: "primary", Usage: &UsageObservation{
+			InputTokens: ptr(1), OutputTokens: ptr(1), CachedInputTokens: ptr(1),
+			CostMicros: ptr(1), SavedInputTokens: ptr(1), SavedCostMicros: ptr(1),
+		},
+		Ordinal: ptr(1), SourceStepRef: "step_1",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for key := range body {
+		if !admittedKeys[""][key] {
+			t.Fatalf("request struct emits unadmitted key %q", key)
+		}
+	}
+	for level, sub := range map[string]json.RawMessage{"native_identity": body["native_identity"], "usage": body["usage"]} {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(sub, &obj); err != nil {
+			t.Fatalf("%s: %v", level, err)
+		}
+		for key := range obj {
+			if !admittedKeys[level][key] {
+				t.Fatalf("%s emits unadmitted key %q", level, key)
+			}
+		}
+		if len(obj) != len(admittedKeys[level]) {
+			t.Fatalf("%s: allowlist has %d keys, struct emits %d", level, len(admittedKeys[level]), len(obj))
+		}
+	}
+}

--- a/pkg/cityinference/producer.go
+++ b/pkg/cityinference/producer.go
@@ -1,0 +1,286 @@
+package cityinference
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Acked is one acknowledged contribution as the checkpoint holds it.
+//
+// Digest is the payload digest of what the server accepted. It is what makes a
+// changed replay detectable at all: without it, a re-offer with a different
+// model or outcome is indistinguishable from a retry.
+type Acked struct {
+	InferenceTeamID string `json:"inference_team_id"`
+	Digest          string `json:"digest"`
+}
+
+// State is one City source's inference checkpoint. It is keyed by stable source
+// identity — derived inference ID plus observation ID — and never by anything
+// that changes across a restart or a credential rotation.
+type State struct {
+	Epoch    uint64           `json:"epoch"`
+	SourceID string           `json:"source_id"`
+	Accepted map[string]Acked `json:"accepted"`
+}
+
+// Store persists checkpoints across restarts. It is an interface because the
+// durable implementation is City's business; the adapter only needs load and
+// save to be atomic with respect to each other.
+type Store interface {
+	Load(ctx context.Context, key string) (State, bool, error)
+	Save(ctx context.Context, key string, st State) error
+}
+
+// MemoryStore is an in-process Store. It is safe for concurrent use and is what
+// tests and a single-shot export run on.
+type MemoryStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+// NewMemoryStore returns an empty in-process Store.
+func NewMemoryStore() *MemoryStore { return &MemoryStore{m: map[string][]byte{}} }
+
+// Load implements Store.
+func (s *MemoryStore) Load(_ context.Context, key string) (State, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw, ok := s.m[key]
+	if !ok {
+		return State{}, false, nil
+	}
+	var st State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return State{}, false, fmt.Errorf("cityinference: decode checkpoint %q: %w", key, err)
+	}
+	return st, true, nil
+}
+
+// Save implements Store. It round-trips through JSON so a caller cannot hold a
+// reference into stored state and mutate it behind the producer's back.
+func (s *MemoryStore) Save(_ context.Context, key string, st State) error {
+	raw, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("cityinference: encode checkpoint %q: %w", key, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = map[string][]byte{}
+	}
+	s.m[key] = raw
+	return nil
+}
+
+// Uploaded reports one accepted upload.
+type Uploaded struct {
+	ExternalInferenceID string
+	ObservationID       string
+	InferenceTeamID     string
+}
+
+// Result reports what one push did. It is returned even on error, so a caller
+// that stops on a refusal still learns how far it got.
+type Result struct {
+	Uploaded []Uploaded
+	Accepted int
+	Skipped  int
+}
+
+// Producer maps City invocations onto neutral inference records and advances a
+// checkpoint only over records the server acknowledged.
+type Producer struct {
+	API    API
+	Mapper Mapper
+	Store  Store
+
+	// Disabled is the rollback switch. A disabled producer issues no request
+	// and touches no checkpoint; acknowledged records stay exactly as the
+	// server accepted them and every other producer keeps running.
+	Disabled bool
+}
+
+// NewProducer validates its wiring up front: a producer missing a store would
+// look like it worked and silently re-upload the world on restart.
+func NewProducer(api API, mapper Mapper, store Store) (*Producer, error) {
+	if api == nil {
+		return nil, errors.New("cityinference: API is required")
+	}
+	if store == nil {
+		return nil, errors.New("cityinference: Store is required")
+	}
+	if mapper.Source.SourceID == "" || mapper.Source.Kind == "" {
+		return nil, errors.New("cityinference: source identity is required")
+	}
+	if mapper.Source.Tenant == "" {
+		return nil, errors.New("cityinference: enrolled tenant is required")
+	}
+	if mapper.Source.Epoch == 0 {
+		return nil, errors.New("cityinference: source epoch is required and is never guessed")
+	}
+	return &Producer{API: api, Mapper: mapper, Store: store}, nil
+}
+
+// CheckpointKey is the durable key of this source's inference checkpoint. It
+// carries no credential and no host, so a rotation or a redeploy resumes the
+// same checkpoint rather than starting a second one.
+func CheckpointKey(source Source) string {
+	return source.Kind + "/" + source.SourceID + "/inference"
+}
+
+// Push uploads a batch of City invocations, skipping what the checkpoint
+// already holds and stopping on the first refusal.
+//
+// Order within the batch carries no meaning — this domain asserts none — so a
+// caller may re-offer a batch in any order and get the same outcome.
+func (p *Producer) Push(ctx context.Context, invocations []CityInvocation) (Result, error) {
+	var res Result
+	if p.Disabled {
+		return res, ErrDisabled
+	}
+	key := CheckpointKey(p.Mapper.Source)
+	st, ok, err := p.Store.Load(ctx, key)
+	if err != nil {
+		return res, err
+	}
+	if !ok {
+		st = State{Epoch: p.Mapper.Source.Epoch, SourceID: p.Mapper.Source.SourceID}
+	}
+	if st.Accepted == nil {
+		st.Accepted = map[string]Acked{}
+	}
+	if st.Epoch != p.Mapper.Source.Epoch {
+		// An epoch change is a declared reset, and a reset re-keys identity. It
+		// is not something a restart may infer, so the producer stops.
+		return res, fmt.Errorf("%w: checkpoint epoch %d, source epoch %d", ErrIdentityDrift, st.Epoch, p.Mapper.Source.Epoch)
+	}
+
+	for _, inv := range invocations {
+		req, err := p.Mapper.MapInvocation(inv)
+		if err != nil {
+			return res, err
+		}
+		recordKey := req.ExternalInferenceID + "/" + req.ObservationID
+		digest, err := payloadDigest(req)
+		if err != nil {
+			return res, err
+		}
+		if prior, seen := st.Accepted[recordKey]; seen {
+			if prior.Digest != digest {
+				return res, fmt.Errorf("%w: %s", ErrChangedReplay, recordKey)
+			}
+			res.Skipped++
+			continue
+		}
+
+		got, err := p.API.CreateInference(ctx, req, IdempotencyKey(p.Mapper.Source, recordKey))
+		if err != nil {
+			return res, err
+		}
+		if err := p.verify(req, got); err != nil {
+			return res, err
+		}
+		st.Accepted[recordKey] = Acked{InferenceTeamID: got.ID, Digest: digest}
+		// The checkpoint advances only here, after acceptance. A crash between
+		// the call and this save replays the same idempotency key and the
+		// server answers with the original response.
+		if err := p.Store.Save(ctx, key, st); err != nil {
+			return res, err
+		}
+		res.Uploaded = append(res.Uploaded, Uploaded{
+			ExternalInferenceID: req.ExternalInferenceID,
+			ObservationID:       req.ObservationID,
+			InferenceTeamID:     got.ID,
+		})
+		res.Accepted++
+	}
+	return res, nil
+}
+
+// verify checks what came back against what was offered.
+func (p *Producer) verify(req CreateInferenceRequest, got Inference) error {
+	if got.ID == "" {
+		return fmt.Errorf("%w: response carries no neutral id", ErrIdentityDrift)
+	}
+	if got.ExternalInferenceID != req.ExternalInferenceID {
+		return fmt.Errorf("%w: offered %s, accepted %s", ErrIdentityDrift,
+			req.ExternalInferenceID, got.ExternalInferenceID)
+	}
+	// Every field group is present on every inference. A missing key would be
+	// an implicit "unavailable", and an implicit claim is the thing coverage
+	// exists to abolish.
+	for _, group := range CoverageFieldGroups() {
+		if _, ok := got.Coverage[group]; !ok {
+			return fmt.Errorf("%w: coverage omits field group %q", ErrCoverageRaised, group)
+		}
+	}
+	// Step attribution is unavailable by construction. Anything else means a
+	// step was materialized from data this adapter never had.
+	if Coverage(got.Coverage[FieldGroupStep]) != CoverageUnavailable {
+		return fmt.Errorf("%w: step coverage came back %q", ErrCoverageRaised, got.Coverage[FieldGroupStep])
+	}
+	// Transcript attribution may be known only where a canonical record was
+	// linked. The link is part of the invariant core, so a raised class here is
+	// a fabricated link, not another contribution's.
+	if req.TranscriptRecordID == "" && Coverage(got.Coverage[FieldGroupTranscript]) == CoverageKnown {
+		return fmt.Errorf("%w: transcript coverage claims known with no linked record", ErrCoverageRaised)
+	}
+	if req.TranscriptRecordID != "" && got.TranscriptRecordID != req.TranscriptRecordID {
+		return fmt.Errorf("%w: accepted record links a different transcript record", ErrIdentityDrift)
+	}
+	if got.Completeness != "" && Coverage(got.Completeness) != CoverageUnavailable {
+		return fmt.Errorf("%w: completeness came back %q over a best-effort producer",
+			ErrCoverageRaised, got.Completeness)
+	}
+	scope, err := ClassifyReqID(req.NativeIdentity.UpstreamReqID)
+	if err != nil {
+		return err
+	}
+	if scope == ScopeObservation && got.FoldEligible {
+		return fmt.Errorf("%w: a locally generated request id came back fold-eligible", ErrCoverageRaised)
+	}
+	return nil
+}
+
+// idempotencyDomain separates this producer's keys from every other preimage.
+const idempotencyDomain = "cityinference/idempotency/v1"
+
+// IdempotencyKey derives the server's Idempotency-Key from stable source
+// identity.
+//
+// The preimage holds the enrolled source, the ingest epoch, the resource kind
+// and the record's stable identity, and nothing else. No credential, no key
+// identifier, no wall clock and no attempt counter: a credential rotation would
+// otherwise open a fresh idempotency namespace and turn a retry into a second
+// admitted record.
+func IdempotencyKey(source Source, recordKey string) string {
+	preimage := strings.Join([]string{
+		idempotencyDomain,
+		source.Kind, source.SourceID,
+		strconv.FormatUint(source.Epoch, 10),
+		KindInference, recordKey,
+	}, "\x1f")
+	sum := sha256.Sum256([]byte(preimage))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(b)
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+func payloadDigest(req CreateInferenceRequest) (string, error) {
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: encode request: %w", ErrInvalidInvocation, err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/cityinference/producer_test.go
+++ b/pkg/cityinference/producer_test.go
@@ -1,0 +1,257 @@
+package cityinference
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+const (
+	tenantAlpha = "org_alpha"
+	tenantBeta  = "org_beta"
+)
+
+func newWorkspaces() map[string]*FakeWorkspace {
+	alpha := NewFakeWorkspace()
+	alpha.AddChain("run_1", "ses_1", "trc_1")
+	alpha.AddChain("run_2", "ses_2", "")
+	beta := NewFakeWorkspace()
+	beta.AddChain("run_beta", "ses_beta", "trc_beta")
+	return map[string]*FakeWorkspace{tenantAlpha: alpha, tenantBeta: beta}
+}
+
+func newHarness(t *testing.T) (*FakeAPI, *Producer) {
+	t.Helper()
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	p, err := NewProducer(api, testMapper(), NewMemoryStore())
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	return api, p
+}
+
+func happyInvocation(t *testing.T) CityInvocation {
+	t.Helper()
+	return CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Provider: "anthropic", Model: "m-1", Status: "succeeded",
+		Started:            mustTime(t, "2026-07-30T10:00:00Z"),
+		RunTeamID:          "run_1",
+		SessionTeamID:      "ses_1",
+		TranscriptRecordID: "trc_1",
+		Usage:              &UsageObservation{InputTokens: ptr(120), OutputTokens: ptr(30), CostMicros: ptr(4500)},
+	}
+}
+
+// AC1 happy path: transcript-level attribution succeeds with honest coverage,
+// linking canonical records the workspace already owns.
+func TestPushLinksCanonicalRecords(t *testing.T) {
+	api, p := newHarness(t)
+	res, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if res.Accepted != 1 || len(res.Uploaded) != 1 {
+		t.Fatalf("unexpected result %+v", res)
+	}
+	got, err := api.GetInference(context.Background(), res.Uploaded[0].InferenceTeamID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.RunID != "run_1" || got.SessionID != "ses_1" || got.TranscriptRecordID != "trc_1" {
+		t.Fatalf("links were not preserved: %+v", got)
+	}
+	if got.IdentityScope != ScopeInvocation || !got.FoldEligible {
+		t.Fatalf("provider-assigned id must be fold-eligible: %+v", got)
+	}
+}
+
+// AC2 happy path: a proven invocation uploads once. A retry of the same batch
+// issues no second write, and a restart from the persisted checkpoint issues
+// none either.
+func TestProvenInvocationUploadsOnce(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	batch := []CityInvocation{happyInvocation(t)}
+
+	if _, err := p.Push(context.Background(), batch); err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	res, err := p.Push(context.Background(), batch)
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if res.Accepted != 0 || res.Skipped != 1 {
+		t.Fatalf("retry re-uploaded: %+v", res)
+	}
+
+	// Restart: a fresh producer over the same store must not re-upload.
+	restarted, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	if _, err := restarted.Push(context.Background(), batch); err != nil {
+		t.Fatalf("restarted push: %v", err)
+	}
+	if api.Writes() != 1 {
+		t.Fatalf("want exactly one write, got %d", api.Writes())
+	}
+}
+
+// A credential rotation opens no new idempotency namespace. The key preimage
+// holds no credential, so a rotation mid-stream still replays.
+func TestCredentialRotationDoesNotChangeIdentityOrKey(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	api.Credential = "tok_before"
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	batch := []CityInvocation{happyInvocation(t)}
+	if _, err := p.Push(context.Background(), batch); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	before := api.Requests[0].IdempotencyKey
+
+	api.Credential = "tok_after"
+	rotated, err := NewProducer(api, testMapper(), NewMemoryStore())
+	if err != nil {
+		t.Fatalf("rotated producer: %v", err)
+	}
+	if _, err := rotated.Push(context.Background(), batch); err != nil {
+		t.Fatalf("post-rotation push: %v", err)
+	}
+	if api.Requests[1].IdempotencyKey != before {
+		t.Fatalf("rotation changed the idempotency key: %s -> %s", before, api.Requests[1].IdempotencyKey)
+	}
+	if api.Writes() != 2 {
+		t.Fatalf("want two attempts, got %d", api.Writes())
+	}
+	page, err := api.ListInferences(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("rotation admitted a second record: %d", len(page.Items))
+	}
+}
+
+// A changed payload under an already-acknowledged source identity stops the
+// producer. Sending it would ask the server to rewrite accepted input.
+func TestChangedReplayStopsTheProducer(t *testing.T) {
+	api, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	changed := happyInvocation(t)
+	changed.Model = "m-2"
+	_, err := p.Push(context.Background(), []CityInvocation{changed})
+	if !errors.Is(err, ErrChangedReplay) {
+		t.Fatalf("want ErrChangedReplay, got %v", err)
+	}
+	if api.Writes() != 1 {
+		t.Fatalf("changed replay issued a write: %d", api.Writes())
+	}
+}
+
+// A fault mid-batch leaves the checkpoint exactly at the last acknowledged
+// record. The restart re-offers only what was never acknowledged.
+func TestFaultMidBatchResumesWithoutReupload(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	second := happyInvocation(t)
+	second.UpstreamReqID = "req-2"
+	second.TranscriptRecordID = ""
+	batch := []CityInvocation{happyInvocation(t), second}
+
+	api.FailNext = errors.New("transport reset")
+	if _, err := p.Push(context.Background(), batch); err == nil {
+		t.Fatal("want transport failure")
+	}
+	if api.Writes() != 1 {
+		t.Fatalf("want one attempted write before the fault, got %d", api.Writes())
+	}
+
+	restarted, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	res, err := restarted.Push(context.Background(), batch)
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if res.Accepted != 2 {
+		t.Fatalf("resume accepted %d, want 2", res.Accepted)
+	}
+	page, err := api.ListInferences(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("want 2 records, got %d", len(page.Items))
+	}
+}
+
+// Two honest observations of the same call — one metered, one estimated — stand
+// as two contributions on one inference. Neither is a payload divergence of the
+// other, and the folded coverage never rises above the weaker one.
+func TestTwoObservationsFoldOntoOneInference(t *testing.T) {
+	api, p := newHarness(t)
+	metered := happyInvocation(t)
+	metered.ObservationID = "metered"
+	estimated := happyInvocation(t)
+	estimated.ObservationID = "estimated"
+	estimated.Usage = &UsageObservation{CostMicros: ptr(4400), SavedCostMicros: ptr(10)}
+
+	res, err := p.Push(context.Background(), []CityInvocation{metered, estimated})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if res.Accepted != 2 {
+		t.Fatalf("want 2 accepted, got %d", res.Accepted)
+	}
+	if res.Uploaded[0].InferenceTeamID != res.Uploaded[1].InferenceTeamID {
+		t.Fatal("exact-tuple observations did not fold onto one inference")
+	}
+	got, err := api.GetInference(context.Background(), res.Uploaded[0].InferenceTeamID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Contributions) != 2 {
+		t.Fatalf("want 2 contributions, got %d", len(got.Contributions))
+	}
+	if Coverage(got.Coverage[FieldGroupTokens]) == CoverageKnown {
+		t.Fatal("folded token coverage was raised to known")
+	}
+}
+
+// An undeclared epoch change is a reset the producer never infers.
+func TestEpochDriftStopsTheProducer(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	source := testSource()
+	source.Epoch = 8
+	drifted, err := NewProducer(api, Mapper{Source: source}, store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	if _, err := drifted.Push(context.Background(), []CityInvocation{happyInvocation(t)}); !errors.Is(err, ErrIdentityDrift) {
+		t.Fatalf("want ErrIdentityDrift, got %v", err)
+	}
+}


### PR DESCRIPTION
The Gas City inference producer, consuming the generated public client against the inference routes (#107).

Bound by the `API-6.1` identity and coverage design, whose constraints are the point of the task rather than incidental to it:

- Identity is the composite `(tenant, session_id, upstream_req_id)` — only **exact-tuple** pairs fold.
- `run_id`, `step` and transcript linkage are **unavailable by construction** and are emitted as unavailable, never synthesized. Inventing them would manufacture provenance that does not exist.
- Coverage claims stay honest: provider-asserted token counts are not presented as independently verified, and derived cost is not presented as billed.

## Why this is separate from API-7.20/7.21

The YAGNI review — which cut 17 tasks for salami-slicing — explicitly **rejected** merging the three City producer adapters, having verified in the edge set that each has a different second prerequisite. The split buys real staggering.

Verified: `make test-fast-parallel`, the full repo gate, run before claiming done rather than after a failed push.