### PR TITLE
test(cityparity): cross-adapter parity certification — and two real bugs it found (API-7.23)

### DIFF
--- a/pkg/cityartifact/checkpoint_test.go
+++ b/pkg/cityartifact/checkpoint_test.go
@@ -1,0 +1,394 @@
+package cityartifact_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+)
+
+func producerOn(t *testing.T, api cityartifact.API, src cityartifact.Source, store cityartifact.Store) *cityartifact.Producer {
+	t.Helper()
+	p, err := cityartifact.NewProducer(api, cityartifact.Mapper{Source: src}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	return p
+}
+
+// AC2 happy path: an identical second push reuses accepted state — no second
+// artifact, no second part.
+func TestIdenticalPushIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	first, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("first Push: %v", err)
+	}
+	second, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("second Push: %v", err)
+	}
+	if second.ArtifactID != first.ArtifactID {
+		t.Fatalf("second push minted %q, first was %q", second.ArtifactID, first.ArtifactID)
+	}
+	if second.Uploaded != 0 || second.Skipped != 2 {
+		t.Errorf("second push uploaded %d skipped %d, want 0/2", second.Uploaded, second.Skipped)
+	}
+	if got := f.PartCount(first.ArtifactID); got != 2 {
+		t.Errorf("server stored %d parts, want 2", got)
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("tenant holds %d artifacts, want 1", f.ArtifactCount())
+	}
+}
+
+// AC2: a lost response. The checkpoint never landed, so the producer replays
+// every request — and the derived keys make the server return the accepted state
+// instead of creating a second artifact or a third part.
+func TestLostCheckpointReplaysRatherThanDuplicates(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	first := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	res, err := first.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("first Push: %v", err)
+	}
+
+	// Fresh store: the producer believes it has sent nothing at all.
+	amnesiac := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	again, err := amnesiac.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("replay Push: %v", err)
+	}
+	if again.ArtifactID != res.ArtifactID {
+		t.Fatalf("replay minted artifact %q, original was %q", again.ArtifactID, res.ArtifactID)
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("replay created %d artifacts, want 1", f.ArtifactCount())
+	}
+	if got := f.PartCount(res.ArtifactID); got != 2 {
+		t.Errorf("replay stored %d parts, want 2", got)
+	}
+}
+
+// AC2 happy path: a restart mid-upload resumes at the next part and re-sends
+// none of the acknowledged ones.
+func TestRestartResumesWithoutDuplicateParts(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	a := sampleArtifact()
+	a.Parts = append(a.Parts, cityartifact.CityPart{Sequence: 3, Bytes: []byte("third part\n")})
+
+	// Part 1 lands, part 2 fails.
+	f.FailNext(cityartifact.OpUploadArtifactContent, nil)
+	f.FailNext(cityartifact.OpUploadArtifactContent, errors.New("connection reset by peer"))
+	res, err := p.Push(ctx, a)
+	if !errors.Is(err, cityartifact.ErrUpstream) {
+		t.Fatalf("err = %v, want ErrUpstream", err)
+	}
+	if res.Uploaded != 1 {
+		t.Fatalf("uploaded %d before the fault, want 1", res.Uploaded)
+	}
+	if got := f.PartCount(res.ArtifactID); got != 1 {
+		t.Fatalf("server stored %d parts, want 1", got)
+	}
+	if res.Finalized {
+		t.Fatal("finalized despite a failed part")
+	}
+
+	// A new process, same durable checkpoint.
+	resumed := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	after, err := resumed.Push(ctx, a)
+	if err != nil {
+		t.Fatalf("resumed Push: %v", err)
+	}
+	if after.ArtifactID != res.ArtifactID {
+		t.Errorf("resume minted a second artifact %q", after.ArtifactID)
+	}
+	if after.Uploaded != 2 || after.Skipped != 1 {
+		t.Errorf("resume uploaded %d skipped %d, want 2/1", after.Uploaded, after.Skipped)
+	}
+	if got := f.PartCount(res.ArtifactID); got != 3 {
+		t.Errorf("server stored %d parts, want 3", got)
+	}
+	if !after.Finalized {
+		t.Error("resume did not finalize a complete manifest")
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("tenant holds %d artifacts, want 1", f.ArtifactCount())
+	}
+}
+
+// AC2: the checkpoint advances only over contiguous acknowledgements. A failed
+// part leaves the frontier where it was, so the next attempt sends that part
+// again rather than the one after it.
+func TestCheckpointAdvancesOnlyOnAcknowledgement(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	f.FailNext(cityartifact.OpUploadArtifactContent, errors.New("upstream unavailable"))
+	if _, err := p.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrUpstream) {
+		t.Fatalf("err = %v, want ErrUpstream", err)
+	}
+	key := cityartifact.CheckpointKey(citySource(), "city-artifact-1")
+	st, ok, err := store.Load(ctx, key)
+	if err != nil || !ok {
+		t.Fatalf("Load = %v, %v", ok, err)
+	}
+	if st.Frontier != 0 {
+		t.Fatalf("frontier advanced to %d over an unacknowledged part", st.Frontier)
+	}
+	if st.ArtifactID == "" {
+		t.Fatal("the acknowledged create was not checkpointed")
+	}
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("retry Push: %v", err)
+	}
+	if res.Uploaded != 2 || res.Skipped != 0 {
+		t.Errorf("retry uploaded %d skipped %d, want 2/0", res.Uploaded, res.Skipped)
+	}
+}
+
+// AC2 edge: a changed hash under an acknowledged part stops the adapter and
+// sends nothing.
+func TestChangedManifestStopsTheAdapter(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	before := len(f.Calls())
+
+	rewritten := sampleArtifact()
+	rewritten.Parts[0].Bytes = []byte("rewritten first part\n")
+	res, err := p.Push(ctx, rewritten)
+	if !errors.Is(err, cityartifact.ErrChangedManifest) {
+		t.Fatalf("err = %v, want ErrChangedManifest", err)
+	}
+	for _, call := range f.Calls()[before:] {
+		if call == cityartifact.OpUploadArtifactContent {
+			t.Error("dispatched an upload for a rewritten part")
+		}
+	}
+	if got := f.PartCount(res.ArtifactID); got != 2 {
+		t.Errorf("server holds %d parts after a rewrite refusal, want the original 2", got)
+	}
+	// The checkpoint is intact: the original manifest still replays cleanly.
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Errorf("the original manifest no longer replays: %v", err)
+	}
+}
+
+// AC2 edge: the artifact's own definition changing after creation is the same
+// refusal — re-creating would fork the artifact.
+func TestChangedDefinitionStopsTheAdapter(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	f.Authorize("proj-beta")
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	moved := sampleArtifact()
+	moved.ProjectID = "proj-beta"
+	if _, err := p.Push(ctx, moved); !errors.Is(err, cityartifact.ErrChangedManifest) {
+		t.Fatalf("err = %v, want ErrChangedManifest", err)
+	}
+	if f.ArtifactCount() != 1 {
+		t.Errorf("a changed definition forked into %d artifacts", f.ArtifactCount())
+	}
+}
+
+// AC2 edge: a gap stops the adapter before anything is sent.
+func TestGapStopsTheAdapter(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+
+	gapped := sampleArtifact()
+	gapped.Parts = []cityartifact.CityPart{
+		{Sequence: 2, Bytes: []byte("second\n")},
+		{Sequence: 3, Bytes: []byte("third\n")},
+	}
+	res, err := p.Push(ctx, gapped)
+	if !errors.Is(err, cityartifact.ErrGap) {
+		t.Fatalf("err = %v, want ErrGap", err)
+	}
+	if res.Uploaded != 0 {
+		t.Errorf("uploaded %d parts across a gap", res.Uploaded)
+	}
+	if f.PartCount(res.ArtifactID) != 0 {
+		t.Errorf("server stored parts across a gap")
+	}
+	if res.Finalized {
+		t.Error("finalized across a gap")
+	}
+}
+
+// AC2: a duplicate part sequence in the manifest is refused before any call.
+func TestDuplicatePartSequenceRefused(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+
+	dup := sampleArtifact()
+	dup.Parts = append(dup.Parts, cityartifact.CityPart{Sequence: 1, Bytes: []byte("again\n")})
+	if _, err := p.Push(ctx, dup); !errors.Is(err, cityartifact.ErrInvalidArtifact) {
+		t.Fatalf("err = %v, want ErrInvalidArtifact", err)
+	}
+	if len(f.Calls()) != 0 {
+		t.Errorf("dispatched %v before refusing a duplicate sequence", f.Calls())
+	}
+}
+
+// AC2: credential rotation changes nothing. The key preimage holds the enrolled
+// source, not the credential, so a rotated client replays instead of duplicating.
+func TestCredentialRotationDoesNotDuplicate(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+
+	before := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	res, err := before.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	// New credential, same enrolled source, same checkpoint.
+	rotated := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	after, err := rotated.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("rotated Push: %v", err)
+	}
+	if after.ArtifactID != res.ArtifactID || after.Uploaded != 0 {
+		t.Errorf("rotation produced %+v, want a replay of %q", after, res.ArtifactID)
+	}
+	if f.ArtifactCount() != 1 || f.PartCount(res.ArtifactID) != 2 {
+		t.Errorf("rotation duplicated: %d artifacts, %d parts", f.ArtifactCount(), f.PartCount(res.ArtifactID))
+	}
+}
+
+// AC2: post-finalize input is refused. Finalize is one-way and this adapter does
+// not ask the server to reopen it.
+func TestPostFinalizeInputRefused(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	grown := sampleArtifact()
+	grown.Parts = append(grown.Parts, cityartifact.CityPart{Sequence: 3, Bytes: []byte("late\n")})
+	if _, err := p.Push(ctx, grown); !errors.Is(err, cityartifact.ErrFinalized) {
+		t.Fatalf("err = %v, want ErrFinalized", err)
+	}
+	if got := f.PartCount(res.ArtifactID); got != 2 {
+		t.Errorf("server stored %d parts after finalize, want 2", got)
+	}
+}
+
+// AC2: a declared reset restarts the checkpoint on the same key; an epoch that
+// went backwards is drift, not a retry.
+func TestEpochResetAndRegression(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	behind := citySource()
+	behind.Epoch = 0
+	regressed := producerOn(t, f.Client("src_city_1", "gascity"), behind, store)
+	if _, err := regressed.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift for a backwards epoch", err)
+	}
+
+	ahead := citySource()
+	ahead.Epoch = 2
+	reset := producerOn(t, f.Client("src_city_1", "gascity"), ahead, store)
+	res, err := reset.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("reset Push: %v", err)
+	}
+	key := cityartifact.CheckpointKey(ahead, "city-artifact-1")
+	if key != cityartifact.CheckpointKey(citySource(), "city-artifact-1") {
+		t.Fatalf("a reset landed on a different checkpoint key")
+	}
+	st, _, err := store.Load(ctx, key)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.Epoch != 2 {
+		t.Errorf("checkpoint epoch = %d, want 2", st.Epoch)
+	}
+	if f.ArtifactCount() != 2 {
+		t.Errorf("a declared reset produced %d artifacts, want a second generation", f.ArtifactCount())
+	}
+	if res.ArtifactID == "" {
+		t.Error("reset produced no artifact")
+	}
+}
+
+// AC2: a checkpoint that belongs to another enrolled source is drift, not state
+// to inherit. This is the credential-swap case a shared checkpoint file makes
+// reachable.
+func TestCheckpointFromAnotherSourceIsDrift(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	key := cityartifact.CheckpointKey(citySource(), "city-artifact-1")
+	if err := store.Save(ctx, key, cityartifact.State{Epoch: 1, SourceID: "src_someone_else"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	if _, err := p.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift", err)
+	}
+	if len(f.Calls()) != 0 {
+		t.Errorf("dispatched %v against a foreign checkpoint", f.Calls())
+	}
+}
+
+// AC2: checkpoints are namespaced by source, so the same City artifact ID under
+// two enrolled sources is two artifacts and not a collision.
+func TestCheckpointsAreNamespacedBySource(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	mine := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+	if _, err := mine.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	other := cityartifact.Source{SourceID: "src_city_2", Kind: "gascity", Epoch: 1}
+	stranger := producerOn(t, f.Client("src_city_2", "gascity"), other, store)
+	// Same City artifact ID, different source: the key namespaces the source, so
+	// this is a different checkpoint and must not inherit the first one.
+	if _, err := stranger.Push(ctx, sampleArtifact()); err != nil {
+		t.Fatalf("stranger Push: %v", err)
+	}
+	if f.ArtifactCount() != 2 {
+		t.Errorf("two sources shared one artifact: count = %d", f.ArtifactCount())
+	}
+}

--- a/pkg/cityartifact/cityartifact.go
+++ b/pkg/cityartifact/cityartifact.go
@@ -1,0 +1,144 @@
+// Package cityartifact is Gas City's producer adapter for the Artifact
+// resources of the Beads Team Server v1 API.
+//
+// City is ONE OPTIONAL producer of artifacts. A custom producer with no City in
+// the picture creates, uploads and finalizes an artifact on its own credential
+// and gets a record of exactly the same public shape, so nothing here may
+// become a schema, an identity or an authority that a non-City producer would
+// have to satisfy. Artifact IDs are minted by the server and read back off a
+// response; this package never invents one, and City-shaped facts (city, rig,
+// formula) are display-only breadcrumbs the adapter refuses to place anywhere
+// in an outbound body.
+//
+// The layering matches the neutral run/session producer:
+//
+//   - [API] is the client seam. It carries one method per frozen artifact
+//     operation and NOTHING else. The adapter speaks no HTTP: no URL, no
+//     header, no status code appears anywhere below this file's imports.
+//   - [Mapper] turns a City artifact into request bodies and refuses any
+//     mapping that would let a City fact, a foreign link or a raw upstream
+//     field reach the server.
+//   - [Producer] owns the multi-part lifecycle: create, parts, finalize, with
+//     stable source idempotency, a contiguous acknowledged part frontier, and
+//     the refusals (changed manifest, gap, post-finalize write) that stop this
+//     adapter instead of corrupting an artifact.
+//
+// The four public categories — metadata, evidence, references, content — stay
+// separate here for the same reason they are separate server-side: they are
+// four reads behind four scopes, and this package never routes one through
+// another. Metadata calls carry no bytes and content calls carry no metadata.
+//
+// Rollback is per producer: stop calling Push and every acknowledged artifact
+// stays exactly as the server accepted it. This package never rewrites an
+// accepted part and never sends a mutation for a finalized artifact, and its
+// failures are its own — an artifact refusal cannot reach into the run,
+// session, transcript or event adapters, which hold their own checkpoints.
+package cityartifact
+
+import "errors"
+
+// Frozen operation IDs from operation_matrix_v6. They are spelled here so a
+// reader can check this adapter's surface against the frozen matrix without
+// leaving the package, and so the client seam cannot quietly grow a route that
+// is not in the matrix.
+const (
+	OpCreateArtifact        = "createArtifact"
+	OpListArtifacts         = "listArtifacts"
+	OpGetArtifact           = "getArtifact"
+	OpGetArtifactEvidence   = "getArtifactEvidence"
+	OpGetArtifactReferences = "getArtifactReferences"
+	OpUploadArtifactContent = "uploadArtifactContent"
+	OpFinalizeArtifact      = "finalizeArtifact"
+	OpGetArtifactContent    = "getArtifactContent"
+)
+
+// Category is the public category an operation reads. The four are pairwise
+// disjoint server-side; naming them here keeps the adapter honest about which
+// one each call touches.
+type Category string
+
+// The four categories. There is no fifth and no "all".
+const (
+	CategoryMetadata   Category = "metadata"
+	CategoryEvidence   Category = "evidence"
+	CategoryReferences Category = "references"
+	CategoryContent    Category = "content"
+)
+
+// CategoryOf reports the category of a frozen artifact operation. An unknown
+// operation has no category rather than a default one.
+func CategoryOf(operationID string) (Category, bool) {
+	switch operationID {
+	case OpCreateArtifact, OpListArtifacts, OpGetArtifact, OpFinalizeArtifact:
+		return CategoryMetadata, true
+	case OpGetArtifactEvidence:
+		return CategoryEvidence, true
+	case OpGetArtifactReferences:
+		return CategoryReferences, true
+	case OpUploadArtifactContent, OpGetArtifactContent:
+		return CategoryContent, true
+	}
+	return "", false
+}
+
+// Resource kinds in the derived idempotency preimage. A key minted for a create
+// may not be replayed into a part upload, so the kind is part of the preimage.
+const (
+	kindArtifact = "artifact"
+	kindPart     = "artifact_part"
+	kindFinalize = "artifact_finalize"
+)
+
+// Bounds mirroring the server's validators, so an oversized field is refused
+// here with a City field name attached rather than as a correlated 4xx.
+const (
+	maxSourceNativeIDLen = 200
+	maxLinkIDLen         = 200
+	maxPartBytes         = 8 << 20
+)
+
+// Refusals. Every one of them stops this producer with its checkpoint intact:
+// nothing has advanced past the last acknowledged part, so an operator who
+// fixes the source can restart and resume rather than reconcile.
+var (
+	// ErrChangedManifest is an artifact whose already-acknowledged parts no
+	// longer hash to what was accepted. Sending it would ask the server to
+	// rewrite accepted content, so the adapter stops instead.
+	ErrChangedManifest = errors.New("cityartifact: manifest changed under an acknowledged part")
+	// ErrGap is a part that would advance the frontier non-contiguously.
+	// Uploading it would leave a hole in the content no later read could tell
+	// apart from data loss.
+	ErrGap = errors.New("cityartifact: non-contiguous part would skip the acknowledged frontier")
+	// ErrFinalized is any attempt to add to or rewrite an artifact the server
+	// has already finalized. Finalize is one-way and this adapter is not the
+	// component that gets to argue with it.
+	ErrFinalized = errors.New("cityartifact: artifact is finalized; content cannot be rewritten")
+	// ErrIdentityDrift is a server response binding a stable City artifact
+	// identity to a different server-minted Artifact ID than the checkpoint
+	// holds, or an acknowledgement against the wrong artifact. Both are louder
+	// than a retry.
+	ErrIdentityDrift = errors.New("cityartifact: stable source identity resolved to a different artifact id")
+	// ErrCityAuthority is a mapping that would let a City-shaped fact become
+	// artifact authority: a City-minted artifact ID, a rig or formula name in a
+	// link slot, or a producer/source field set from the body.
+	ErrCityAuthority = errors.New("cityartifact: City-shaped field cannot become artifact authority")
+	// ErrInvalidArtifact is a City artifact this adapter refuses to map at all.
+	ErrInvalidArtifact = errors.New("cityartifact: invalid City artifact")
+	// ErrCredentialLeak is an outbound payload carrying credential evidence or
+	// a signed URL.
+	ErrCredentialLeak = errors.New("cityartifact: outbound payload carries credential evidence")
+	// ErrContentRoute is content bytes on a route not authorized to carry them.
+	// Metadata bodies never carry bytes; only the content route does.
+	ErrContentRoute = errors.New("cityartifact: content bytes outside the content route")
+	// ErrContentDenied is the server refusing content: a policy denial, a size
+	// refusal or a quarantine. It is terminal for this artifact and inert for
+	// every other adapter.
+	ErrContentDenied = errors.New("cityartifact: server denied artifact content")
+	// ErrUpstream is any other server failure, already stripped of its body.
+	// The upstream text never travels with it.
+	ErrUpstream = errors.New("cityartifact: upstream call failed")
+	// ErrNotReadable is an artifact that is not readable: absent, another
+	// tenant's, another producer's, or not yet finalized. The server answers
+	// all four the same way and so does this package.
+	ErrNotReadable = errors.New("cityartifact: artifact is not readable")
+)

--- a/pkg/cityartifact/contract.go
+++ b/pkg/cityartifact/contract.go
@@ -1,0 +1,154 @@
+package cityartifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+)
+
+// Links are the same-workspace resources an artifact is attached to. The
+// artifact owns none of them: they are references to resources that exist
+// independently, and the server's link verifier is what keeps a caller from
+// attaching to something it cannot see. A foreign link and an absent link are
+// one answer, here and there.
+type Links struct {
+	ProjectID string `json:"project_id,omitempty"`
+	IssueID   string `json:"issue_id,omitempty"`
+	RunID     string `json:"run_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+}
+
+// Empty reports whether the artifact declares no links at all. An unlinked
+// artifact is legal; it is simply not attached to anything.
+func (l Links) Empty() bool {
+	return l.ProjectID == "" && l.IssueID == "" && l.RunID == "" && l.SessionID == ""
+}
+
+// CreateRequest is the closed create body of createArtifact.
+//
+// There is no producer, source, id, status, digest or display member, exactly
+// as the server's body has none: provenance is credential-derived and identity
+// is server-minted. A City producer that wanted to name its own artifact has
+// nowhere to write it.
+type CreateRequest struct {
+	Kind      string `json:"kind"`
+	MediaType string `json:"media_type"`
+	Links     Links  `json:"links"`
+}
+
+// FinalizeRequest is the closed finalize body of finalizeArtifact. Finalization
+// asserts the content the producer believes it uploaded; the server checks that
+// assertion against what it actually stored.
+type FinalizeRequest struct {
+	Digest string `json:"digest,omitempty"`
+}
+
+// Part is one content part of uploadArtifactContent. Sequence is the producer's
+// own ordering; the server stores parts in the order it accepts them and this
+// adapter never sends a part out of order.
+type Part struct {
+	Bytes     []byte `json:"-"`
+	MediaType string `json:"media_type"`
+	Sequence  int    `json:"sequence"`
+}
+
+// Digest is the part's content digest, in the server's `sha256:<hex>` spelling.
+// It is what a part upload's identity is taken over, so the same bytes retried
+// are the same request and different bytes under the same sequence are a
+// conflict rather than an overwrite.
+func (p Part) Digest() string {
+	sum := sha256.Sum256(p.Bytes)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Artifact is the public read DTO, normalized. There is no storage location, no
+// signed URL, no upstream token and no raw upstream body anywhere in this
+// shape, because there is none in the server's.
+type Artifact struct {
+	ID          string     `json:"id"`
+	Kind        string     `json:"kind"`
+	MediaType   string     `json:"media_type"`
+	ByteSize    int64      `json:"byte_size"`
+	Digest      string     `json:"digest,omitempty"`
+	Status      string     `json:"status"`
+	SourceID    string     `json:"source_id"`
+	Producer    string     `json:"producer"`
+	Links       Links      `json:"links"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	FinalizedAt *time.Time `json:"finalized_at,omitempty"`
+	Display     string     `json:"display,omitempty"`
+}
+
+// Finalized reports whether the server has sealed this artifact. An unfinalized
+// artifact is writable and unreadable; a finalized one is readable and frozen.
+func (a Artifact) Finalized() bool { return a.FinalizedAt != nil }
+
+// EvidenceEntry is one normalized evidence statement, read behind its own
+// scope. It is never merged into the metadata read.
+type EvidenceEntry struct {
+	ID         string    `json:"id"`
+	Kind       string    `json:"kind"`
+	Statement  string    `json:"statement"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
+// Reference is one normalized outbound reference, read behind its own scope.
+type Reference struct {
+	ID       string `json:"id"`
+	Kind     string `json:"kind"`
+	TargetID string `json:"target_id"`
+}
+
+// Chunk is a bounded read of an artifact's bytes. It carries bytes and a media
+// type, never a location: this API hands a caller content, not a way to fetch
+// content elsewhere.
+type Chunk struct {
+	Bytes      []byte
+	MediaType  string
+	TotalSize  int64
+	Start, End int64
+}
+
+// Range is a bounded content read. A zero End means "to the end".
+type Range struct{ Start, End int64 }
+
+// ListQuery is the bounded filter of listArtifacts. The source filter is a
+// request, not an authority: the server validates it against the caller's own
+// enrolment and this adapter never assumes it was honored.
+type ListQuery struct {
+	SourceID string
+	Limit    int
+	Cursor   string
+}
+
+// API is the seam onto the public v1 client.
+//
+// It carries exactly the eight frozen artifact operations and no transport
+// vocabulary at all — no base URL, no header, no status code, no retry policy.
+// That is what keeps this package from hand-rolling HTTP: the concrete
+// implementation is the generated public client for the canonical contract, and
+// everything in this package is written against these signatures.
+//
+// NOTE: the contract program generates a public TypeScript client and a
+// server-side Go interface; there is no generated Go *client* module a Go
+// producer can import today. This interface is the shape that client binds to,
+// operation for operation, so binding it is a wiring change and never a logic
+// change.
+//
+// The idempotency key is a caller-supplied argument rather than something an
+// implementation invents, because the key is part of THIS package's dedup
+// contract: [Producer] derives it from stable source identity so a retry
+// replays and a changed payload conflicts. Read operations take no key: the
+// frozen matrix gives them idempotency policy "none".
+type API interface {
+	CreateArtifact(ctx context.Context, body CreateRequest, idempotencyKey string) (Artifact, error)
+	ListArtifacts(ctx context.Context, q ListQuery) ([]Artifact, string, error)
+	GetArtifact(ctx context.Context, artifactID string) (Artifact, error)
+	GetArtifactEvidence(ctx context.Context, artifactID string) (Artifact, []EvidenceEntry, error)
+	GetArtifactReferences(ctx context.Context, artifactID string) (Artifact, []Reference, error)
+	UploadArtifactContent(ctx context.Context, artifactID string, part Part, idempotencyKey string) (Artifact, error)
+	FinalizeArtifact(ctx context.Context, artifactID string, body FinalizeRequest, idempotencyKey string) (Artifact, error)
+	GetArtifactContent(ctx context.Context, artifactID string, rng Range) (Artifact, Chunk, error)
+}

--- a/pkg/cityartifact/fake.go
+++ b/pkg/cityartifact/fake.go
@@ -1,0 +1,421 @@
+package cityartifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrIdempotencyConflict is the fake's spelling of the server refusing a
+// replayed key whose payload changed. It exists so a test can assert that this
+// adapter never lands there by accident: a correct producer derives a key from
+// stable identity, so a conflict means the derivation drifted.
+var ErrIdempotencyConflict = errors.New("cityartifact: idempotency key replayed with a different payload")
+
+// Fake is an in-memory stand-in for the Beads Team Server's artifact routes,
+// implementing the semantics this adapter is written against:
+//
+//   - identity is server-minted; a producer's own ID never becomes an artifact ID
+//   - writes require the enrolled source that created the artifact
+//   - an unfinalized artifact is NOT readable, by anyone
+//   - finalize is one-way and idempotent, and checks an asserted digest
+//   - a mutation key replays an identical payload and conflicts on a changed one
+//   - the four categories are four separate reads
+//
+// One Fake is one tenant. [Fake.Client] binds a credential to it, which is what
+// lets a test run a City producer and a custom producer against the same server
+// and compare what came out.
+type Fake struct {
+	mu      sync.Mutex
+	seq     int
+	clock   time.Time
+	records map[string]*fakeRecord
+	keys    map[string]fakeKey
+	links   map[string]bool
+	faults  map[string][]error
+	calls   []string
+}
+
+type fakeRecord struct {
+	id          string
+	sourceID    string
+	producer    string
+	kind        string
+	mediaType   string
+	links       Links
+	parts       [][]byte
+	createdAt   time.Time
+	updatedAt   time.Time
+	finalizedAt *time.Time
+	evidence    []EvidenceEntry
+	references  []Reference
+}
+
+type fakeKey struct {
+	digest   string
+	artifact Artifact
+}
+
+// NewFake returns an empty tenant with a fixed clock.
+func NewFake() *Fake {
+	return &Fake{
+		clock:   time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC),
+		records: map[string]*fakeRecord{},
+		keys:    map[string]fakeKey{},
+		links:   map[string]bool{},
+		faults:  map[string][]error{},
+	}
+}
+
+// Authorize marks link targets this tenant can see. Anything not authorized is
+// foreign, and foreign and absent are one answer.
+func (f *Fake) Authorize(ids ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, id := range ids {
+		f.links[id] = true
+	}
+}
+
+// FailNext queues one failure for an operation. Queued failures are consumed in
+// order, so a test can fail an upload once and let the retry through.
+func (f *Fake) FailNext(operationID string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.faults[operationID] = append(f.faults[operationID], err)
+}
+
+// Calls returns the operation IDs dispatched so far, in order. It is how a test
+// asserts that a refusal stopped the adapter instead of sending it looking for
+// another way in.
+func (f *Fake) Calls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+// PartCount reports how many parts the server actually stored, which is what
+// "restart resumes without duplicate parts" is measured against.
+func (f *Fake) PartCount(artifactID string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rec, ok := f.records[artifactID]
+	if !ok {
+		return 0
+	}
+	return len(rec.parts)
+}
+
+// ArtifactCount reports how many artifacts exist in the tenant.
+func (f *Fake) ArtifactCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.records)
+}
+
+// Seed installs evidence and references on an artifact the way the server's
+// upstream would; the public API has no route that writes them.
+func (f *Fake) Seed(artifactID string, evidence []EvidenceEntry, refs []Reference) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if rec, ok := f.records[artifactID]; ok {
+		rec.evidence, rec.references = evidence, refs
+	}
+}
+
+// Client binds one enrolled credential to this tenant.
+func (f *Fake) Client(sourceID, producer string) API {
+	return &fakeClient{f: f, sourceID: sourceID, producer: producer}
+}
+
+type fakeClient struct {
+	f        *Fake
+	sourceID string
+	producer string
+}
+
+func (f *Fake) enter(operationID string) error {
+	f.calls = append(f.calls, operationID)
+	queued := f.faults[operationID]
+	if len(queued) == 0 {
+		return nil
+	}
+	err := queued[0]
+	f.faults[operationID] = queued[1:]
+	return err
+}
+
+func (f *Fake) mint(prefix string) string {
+	f.seq++
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s/%d", prefix, f.seq)))
+	return prefix + "_" + hex.EncodeToString(sum[:])[:20]
+}
+
+func (f *Fake) render(rec *fakeRecord) Artifact {
+	size := 0
+	for _, p := range rec.parts {
+		size += len(p)
+	}
+	art := Artifact{
+		ID:          rec.id,
+		Kind:        rec.kind,
+		MediaType:   rec.mediaType,
+		ByteSize:    int64(size),
+		Status:      "open",
+		SourceID:    rec.sourceID,
+		Producer:    rec.producer,
+		Links:       rec.links,
+		CreatedAt:   rec.createdAt,
+		UpdatedAt:   rec.updatedAt,
+		FinalizedAt: rec.finalizedAt,
+	}
+	if rec.finalizedAt != nil {
+		art.Status = "final"
+		art.Digest = rec.digest()
+	}
+	return art
+}
+
+func (r *fakeRecord) digest() string {
+	h := sha256.New()
+	for _, p := range r.parts {
+		h.Write(p)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// replay implements the mutation idempotency contract: an identical payload
+// under a known key returns the first response without dispatching a second
+// mutation, and a different payload under that key is a conflict.
+// The key is namespaced by the enrolled source, as the server's idempotency
+// namespace is: one source cannot replay into another's accepted response.
+func (f *Fake) replay(sourceID, key, digest string) (Artifact, bool, error) {
+	if strings.TrimSpace(key) == "" {
+		return Artifact{}, false, fmt.Errorf("%w: mutation requires an idempotency key", ErrInvalidArtifact)
+	}
+	key = sourceID + "\x1f" + key
+	prior, ok := f.keys[key]
+	if !ok {
+		return Artifact{}, false, nil
+	}
+	if prior.digest != digest {
+		return Artifact{}, false, ErrIdempotencyConflict
+	}
+	return prior.artifact, true, nil
+}
+
+func (c *fakeClient) CreateArtifact(_ context.Context, body CreateRequest, idempotencyKey string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpCreateArtifact); err != nil {
+		return Artifact{}, err
+	}
+	digest := payloadDigest(body)
+	if art, replayed, err := f.replay(c.sourceID, idempotencyKey, digest); err != nil || replayed {
+		return art, err
+	}
+	// Links are verified before anything is stored. A foreign link means the
+	// artifact is never created, so no part upload can follow it.
+	for _, target := range []string{body.Links.ProjectID, body.Links.IssueID, body.Links.RunID, body.Links.SessionID} {
+		if target == "" {
+			continue
+		}
+		if !f.links[target] {
+			return Artifact{}, ErrNotReadable
+		}
+	}
+	rec := &fakeRecord{
+		id:        f.mint("art"),
+		sourceID:  c.sourceID,
+		producer:  c.producer,
+		kind:      body.Kind,
+		mediaType: body.MediaType,
+		links:     body.Links,
+		createdAt: f.clock,
+		updatedAt: f.clock,
+	}
+	f.records[rec.id] = rec
+	art := f.render(rec)
+	f.keys[c.sourceID+"\x1f"+idempotencyKey] = fakeKey{digest: digest, artifact: art}
+	return art, nil
+}
+
+func (c *fakeClient) UploadArtifactContent(_ context.Context, artifactID string, part Part, idempotencyKey string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpUploadArtifactContent); err != nil {
+		return Artifact{}, err
+	}
+	digest := part.Digest() + "/" + part.MediaType
+	if art, replayed, err := f.replay(c.sourceID, idempotencyKey, digest); err != nil || replayed {
+		return art, err
+	}
+	rec, err := f.owned(artifactID, c.sourceID)
+	if err != nil {
+		return Artifact{}, err
+	}
+	if rec.finalizedAt != nil {
+		return Artifact{}, ErrFinalized
+	}
+	if len(part.Bytes) == 0 {
+		return Artifact{}, fmt.Errorf("%w: content part is empty", ErrInvalidArtifact)
+	}
+	rec.parts = append(rec.parts, append([]byte(nil), part.Bytes...))
+	rec.updatedAt = f.clock
+	art := f.render(rec)
+	f.keys[c.sourceID+"\x1f"+idempotencyKey] = fakeKey{digest: digest, artifact: art}
+	return art, nil
+}
+
+func (c *fakeClient) FinalizeArtifact(_ context.Context, artifactID string, body FinalizeRequest, idempotencyKey string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpFinalizeArtifact); err != nil {
+		return Artifact{}, err
+	}
+	digest := payloadDigest(body)
+	if art, replayed, err := f.replay(c.sourceID, idempotencyKey, digest); err != nil || replayed {
+		return art, err
+	}
+	rec, err := f.owned(artifactID, c.sourceID)
+	if err != nil {
+		return Artifact{}, err
+	}
+	if want := strings.TrimSpace(body.Digest); want != "" && want != rec.digest() {
+		return Artifact{}, fmt.Errorf("%w: asserted digest does not match stored content", ErrChangedManifest)
+	}
+	if rec.finalizedAt == nil {
+		at := f.clock
+		rec.finalizedAt = &at
+		rec.updatedAt = at
+	}
+	art := f.render(rec)
+	f.keys[c.sourceID+"\x1f"+idempotencyKey] = fakeKey{digest: digest, artifact: art}
+	return art, nil
+}
+
+func (c *fakeClient) GetArtifact(_ context.Context, artifactID string) (Artifact, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifact); err != nil {
+		return Artifact{}, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, err
+	}
+	return f.render(rec), nil
+}
+
+func (c *fakeClient) GetArtifactEvidence(_ context.Context, artifactID string) (Artifact, []EvidenceEntry, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifactEvidence); err != nil {
+		return Artifact{}, nil, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, nil, err
+	}
+	return f.render(rec), append([]EvidenceEntry(nil), rec.evidence...), nil
+}
+
+func (c *fakeClient) GetArtifactReferences(_ context.Context, artifactID string) (Artifact, []Reference, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifactReferences); err != nil {
+		return Artifact{}, nil, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, nil, err
+	}
+	return f.render(rec), append([]Reference(nil), rec.references...), nil
+}
+
+func (c *fakeClient) GetArtifactContent(_ context.Context, artifactID string, rng Range) (Artifact, Chunk, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpGetArtifactContent); err != nil {
+		return Artifact{}, Chunk{}, err
+	}
+	rec, err := f.readable(artifactID)
+	if err != nil {
+		return Artifact{}, Chunk{}, err
+	}
+	var all []byte
+	for _, p := range rec.parts {
+		all = append(all, p...)
+	}
+	start, end := rng.Start, rng.End
+	if end <= 0 || end > int64(len(all)) {
+		end = int64(len(all))
+	}
+	if start < 0 || start > end {
+		return Artifact{}, Chunk{}, fmt.Errorf("%w: range is outside the artifact", ErrInvalidArtifact)
+	}
+	return f.render(rec), Chunk{
+		Bytes:     append([]byte(nil), all[start:end]...),
+		MediaType: rec.mediaType,
+		TotalSize: int64(len(all)),
+		Start:     start,
+		End:       end,
+	}, nil
+}
+
+func (c *fakeClient) ListArtifacts(_ context.Context, q ListQuery) ([]Artifact, string, error) {
+	f := c.f
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.enter(OpListArtifacts); err != nil {
+		return nil, "", err
+	}
+	ids := make([]string, 0, len(f.records))
+	for id := range f.records {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]Artifact, 0, len(ids))
+	for _, id := range ids {
+		rec := f.records[id]
+		if q.SourceID != "" && rec.sourceID != q.SourceID {
+			continue
+		}
+		out = append(out, f.render(rec))
+	}
+	return out, "", nil
+}
+
+// readable resolves an artifact a reader may see: present and finalized. Absent
+// and unfinalized are one answer, so a probe cannot tell "not there" from "not
+// ready".
+func (f *Fake) readable(artifactID string) (*fakeRecord, error) {
+	rec, ok := f.records[strings.TrimSpace(artifactID)]
+	if !ok || rec.finalizedAt == nil {
+		return nil, ErrNotReadable
+	}
+	return rec, nil
+}
+
+// owned resolves an artifact a producer may write: present and produced by this
+// source. Another source's artifact is the same absence as a stranger's.
+func (f *Fake) owned(artifactID, sourceID string) (*fakeRecord, error) {
+	rec, ok := f.records[strings.TrimSpace(artifactID)]
+	if !ok || rec.sourceID != sourceID {
+		return nil, ErrNotReadable
+	}
+	return rec, nil
+}

--- a/pkg/cityartifact/fault_test.go
+++ b/pkg/cityartifact/fault_test.go
@@ -1,0 +1,280 @@
+package cityartifact_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+)
+
+// leakyUpstream is the kind of error a real transport hands back: a status line,
+// a raw response body, a bearer token and a pre-signed URL, all in one string.
+const leakyUpstream = `502 Bad Gateway: {"error":"presign failed","authorization":"Bearer sk-live-abc123def456",` +
+	`"location":"https://bucket.s3.amazonaws.com/tenant/obj?X-Amz-Signature=deadbeefdeadbeef",` +
+	`"stack":"art.storage.presign(/var/lib/art/blobs/ab/cd)"}`
+
+func assertNoLeak(t *testing.T, err error) {
+	t.Helper()
+	got := err.Error()
+	for _, secret := range []string{
+		"sk-live-abc123def456", "X-Amz-Signature", "bucket.s3.amazonaws.com",
+		"presign failed", "/var/lib/art/blobs", "502 Bad Gateway", "Bearer",
+	} {
+		if strings.Contains(got, secret) {
+			t.Errorf("error leaked %q: %s", secret, got)
+		}
+	}
+}
+
+// AC3 happy path: a failure is observable as a safe, normalized refusal — the
+// caller learns which operation failed and nothing else.
+func TestUpstreamFailureIsNormalizedAndSafe(t *testing.T) {
+	ctx := context.Background()
+	for _, op := range []string{
+		cityartifact.OpCreateArtifact,
+		cityartifact.OpUploadArtifactContent,
+		cityartifact.OpFinalizeArtifact,
+	} {
+		t.Run(op, func(t *testing.T) {
+			f := authorizedFake()
+			p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+			f.FailNext(op, errors.New(leakyUpstream))
+			_, err := p.Push(ctx, sampleArtifact())
+			if !errors.Is(err, cityartifact.ErrUpstream) {
+				t.Fatalf("err = %v, want ErrUpstream", err)
+			}
+			if !strings.Contains(err.Error(), op) {
+				t.Errorf("error does not name the failed operation: %s", err)
+			}
+			assertNoLeak(t, err)
+		})
+	}
+}
+
+// AC3: the same normalization applies to every read, including the content read
+// — the one call that legitimately handles bytes.
+func TestReadFailuresAreNormalizedAndSafe(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	reads := map[string]func() error{
+		cityartifact.OpGetArtifact:           func() error { _, err := p.Metadata(ctx, res.ArtifactID); return err },
+		cityartifact.OpGetArtifactEvidence:   func() error { _, err := p.Evidence(ctx, res.ArtifactID); return err },
+		cityartifact.OpGetArtifactReferences: func() error { _, err := p.References(ctx, res.ArtifactID); return err },
+		cityartifact.OpGetArtifactContent: func() error {
+			_, err := p.Content(ctx, res.ArtifactID, cityartifact.Range{})
+			return err
+		},
+		cityartifact.OpListArtifacts: func() error { _, _, err := p.List(ctx, cityartifact.ListQuery{}); return err },
+	}
+	for op, call := range reads {
+		f.FailNext(op, fmt.Errorf("wrapped: %s", leakyUpstream))
+		err := call()
+		if !errors.Is(err, cityartifact.ErrUpstream) {
+			t.Errorf("%s: err = %v, want ErrUpstream", op, err)
+		}
+		assertNoLeak(t, err)
+	}
+}
+
+// AC3: a content denial is terminal for this artifact. No finalize follows, no
+// other route is tried, and no second credential is reached for.
+func TestContentDenialStopsWithoutFallback(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	f.FailNext(cityartifact.OpUploadArtifactContent, cityartifact.ErrContentDenied)
+	res, err := p.Push(ctx, sampleArtifact())
+	if !errors.Is(err, cityartifact.ErrContentDenied) {
+		t.Fatalf("err = %v, want ErrContentDenied", err)
+	}
+	if res.Uploaded != 0 || res.Finalized {
+		t.Errorf("result = %+v, want nothing uploaded and nothing finalized", res)
+	}
+	calls := f.Calls()
+	if len(calls) != 2 || calls[0] != cityartifact.OpCreateArtifact || calls[1] != cityartifact.OpUploadArtifactContent {
+		t.Fatalf("calls = %v, want exactly the create and the denied upload", calls)
+	}
+	// The artifact stays unreadable: a denial cannot leave half an artifact
+	// visible, because it was never finalized.
+	if _, err := p.Metadata(ctx, res.ArtifactID); !errors.Is(err, cityartifact.ErrNotReadable) {
+		t.Errorf("metadata of a denied artifact = %v, want ErrNotReadable", err)
+	}
+}
+
+// AC3 edge: a scoped failure stays scoped. One artifact's denial leaves every
+// other artifact — and every other producer's checkpoint — untouched, and the
+// denied artifact resumes once the denial clears.
+func TestScopedFailureDoesNotWidenOrSpread(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	denied := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	neighborStore := cityartifact.NewMemoryStore()
+	neighbor := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), neighborStore)
+
+	f.FailNext(cityartifact.OpUploadArtifactContent, cityartifact.ErrContentDenied)
+	bad := sampleArtifact()
+	if _, err := denied.Push(ctx, bad); !errors.Is(err, cityartifact.ErrContentDenied) {
+		t.Fatalf("err = %v, want ErrContentDenied", err)
+	}
+
+	// A different artifact on the same credential is unaffected.
+	other := sampleArtifact()
+	other.ArtifactID = "city-artifact-2"
+	res, err := neighbor.Push(ctx, other)
+	if err != nil {
+		t.Fatalf("neighbor Push: %v", err)
+	}
+	if !res.Finalized {
+		t.Error("a neighboring artifact was dragged down by an unrelated denial")
+	}
+
+	// The denied artifact resumes from its intact checkpoint, without a second
+	// artifact and without a duplicate part.
+	resumed, err := denied.Push(ctx, bad)
+	if err != nil {
+		t.Fatalf("resumed Push: %v", err)
+	}
+	if resumed.Uploaded != 2 || !resumed.Finalized {
+		t.Errorf("resume = %+v, want both parts uploaded and finalized", resumed)
+	}
+	if f.ArtifactCount() != 2 {
+		t.Errorf("tenant holds %d artifacts, want exactly the two pushed", f.ArtifactCount())
+	}
+	if got := f.PartCount(resumed.ArtifactID); got != 2 {
+		t.Errorf("denied artifact holds %d parts after resume, want 2", got)
+	}
+}
+
+// AC3: a timeout is an upstream failure with the context error preserved and the
+// transport detail dropped.
+func TestTimeoutIsNormalized(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	f.FailNext(cityartifact.OpCreateArtifact,
+		fmt.Errorf("post %s: %w", "https://api.internal/v1/artifacts?token=sk-live-1", context.DeadlineExceeded))
+
+	_, err := p.Push(ctx, sampleArtifact())
+	if !errors.Is(err, cityartifact.ErrUpstream) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want ErrUpstream wrapping the deadline", err)
+	}
+	if strings.Contains(err.Error(), "token=sk-live-1") || strings.Contains(err.Error(), "api.internal") {
+		t.Errorf("timeout error leaked the request URL: %s", err)
+	}
+}
+
+// malformedAPI answers successfully but with responses that do not hold
+// together: no identity, or an acknowledgement against a different artifact.
+type malformedAPI struct {
+	cityartifact.API
+	createID   string
+	uploadID   string
+	finalizeID string
+	finalized  bool
+}
+
+func (m malformedAPI) CreateArtifact(context.Context, cityartifact.CreateRequest, string) (cityartifact.Artifact, error) {
+	return cityartifact.Artifact{ID: m.createID}, nil
+}
+
+func (m malformedAPI) UploadArtifactContent(context.Context, string, cityartifact.Part, string) (cityartifact.Artifact, error) {
+	return cityartifact.Artifact{ID: m.uploadID}, nil
+}
+
+func (m malformedAPI) FinalizeArtifact(context.Context, string, cityartifact.FinalizeRequest, string) (cityartifact.Artifact, error) {
+	art := cityartifact.Artifact{ID: m.finalizeID}
+	if m.finalized {
+		at := time.Now()
+		art.FinalizedAt = &at
+	}
+	return art, nil
+}
+
+// AC3: a malformed response is refused rather than recorded. An empty identity,
+// a foreign acknowledgement and an unsealed finalize are all drift.
+func TestMalformedResponsesAreRefused(t *testing.T) {
+	ctx := context.Background()
+	cases := map[string]struct {
+		api  malformedAPI
+		want error
+	}{
+		"create without an id": {
+			malformedAPI{createID: ""}, cityartifact.ErrIdentityDrift,
+		},
+		"part acknowledged against another artifact": {
+			malformedAPI{createID: "art_1", uploadID: "art_2"}, cityartifact.ErrIdentityDrift,
+		},
+		"finalize acknowledged against another artifact": {
+			malformedAPI{createID: "art_1", uploadID: "art_1", finalizeID: "art_9", finalized: true},
+			cityartifact.ErrIdentityDrift,
+		},
+		"finalize returns an unsealed artifact": {
+			malformedAPI{createID: "art_1", uploadID: "art_1", finalizeID: "art_1"},
+			cityartifact.ErrUpstream,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := producerOn(t, tc.api, citySource(), cityartifact.NewMemoryStore())
+			if _, err := p.Push(ctx, sampleArtifact()); !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// AC3: a read-back that disagrees with what was sent is drift, not success.
+func TestReadBackMismatchIsDrift(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	// A second producer's credential is enrolled under a different source, so the
+	// artifact it reads back reports a source this producer did not send under.
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if res.Metadata.SourceID != "src_city_1" {
+		t.Fatalf("source_id = %q, want the enrolled source", res.Metadata.SourceID)
+	}
+
+	mismatched := cityartifact.Source{SourceID: "src_city_1", Kind: "gascity", Epoch: 1}
+	other := producerOn(t, f.Client("src_other", "other"), mismatched, cityartifact.NewMemoryStore())
+	if _, err := other.Push(ctx, sampleArtifact()); !errors.Is(err, cityartifact.ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift when the read-back names another source", err)
+	}
+}
+
+// AC3: an idempotency key derived from anything volatile would show up here as a
+// conflict. It never does, which is what makes the derivation the dedup contract
+// rather than a hope.
+func TestNoIdempotencyConflictAcrossRetries(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	store := cityartifact.NewMemoryStore()
+	p := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), store)
+
+	for i := 0; i < 4; i++ {
+		if _, err := p.Push(ctx, sampleArtifact()); err != nil {
+			t.Fatalf("push %d: %v", i, err)
+		}
+	}
+	fresh := producerOn(t, f.Client("src_city_1", "gascity"), citySource(), cityartifact.NewMemoryStore())
+	if _, err := fresh.Push(ctx, sampleArtifact()); err != nil {
+		if errors.Is(err, cityartifact.ErrIdempotencyConflict) {
+			t.Fatalf("derived key conflicted on identical input: %v", err)
+		}
+		t.Fatalf("fresh Push: %v", err)
+	}
+}

--- a/pkg/cityartifact/mapping.go
+++ b/pkg/cityartifact/mapping.go
@@ -1,0 +1,411 @@
+package cityartifact
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// CityPart is one part of a City artifact's content, as City holds it.
+type CityPart struct {
+	// Sequence is City's own 1-based part ordering. It is what contiguity is
+	// judged on, and it is never sent as an identity.
+	Sequence int
+	// Bytes are the part's content. They travel on the content route and
+	// nowhere else.
+	Bytes []byte
+	// MediaType is the part's own media type. It is normalized before it
+	// leaves; an unparseable one is a refusal, not a passthrough.
+	MediaType string
+}
+
+// CityArtifact is one artifact as City knows it, before any mapping.
+//
+// ArtifactID is City's own stable native ID. It is the dedup and checkpoint
+// identity of this artifact and it is NEVER sent as the artifact's identity:
+// the server mints that, and City reads it back.
+type CityArtifact struct {
+	ArtifactID string
+	Kind       string
+	MediaType  string
+	// Version is City's monotonic version of this artifact's definition. A
+	// bumped version is a new idempotency identity; an unbumped one replays.
+	Version uint64
+
+	// Links are the same-workspace resources this artifact attaches to. Run and
+	// session IDs are server-minted neutral Team IDs City read off an earlier
+	// response, not City-native run names.
+	ProjectID string
+	IssueID   string
+	RunID     string
+	SessionID string
+
+	// City-shaped facts. They are breadcrumbs for City's own logs; the mapper
+	// refuses to place any of them in an outbound body, and the create body has
+	// no member that could hold one.
+	City    string
+	Rig     string
+	Formula string
+
+	// Parts is the content manifest. An artifact with no parts is legal: it
+	// finalizes empty, exactly as a custom producer's would.
+	Parts []CityPart
+	// Complete is City's claim that the manifest is whole. Only a complete
+	// artifact is finalized, and only a finalized artifact is readable.
+	Complete bool
+}
+
+// Source is the enrolled producer identity this adapter uploads under. It is
+// resolved from the credential at enrolment; this package treats it as read-only
+// fact and never derives authority from a City name.
+type Source struct {
+	SourceID string
+	Kind     string
+	// Epoch is the declared reset generation. A bumped epoch restarts this
+	// producer's checkpoint; it never rewrites what the server already accepted.
+	Epoch uint64
+}
+
+// Mapper turns a City artifact into the closed request bodies of the frozen
+// artifact operations, refusing every mapping that would let a City fact, a
+// malformed link or a raw upstream field reach the server.
+type Mapper struct {
+	Source Source
+}
+
+const (
+	defaultKind      = "file"
+	defaultMediaType = "application/octet-stream"
+)
+
+// canonicalKinds is the server's closed kind vocabulary. City may not invent a
+// kind, so an unmapped City kind lands on the default rather than traveling raw.
+var canonicalKinds = []string{"file", "log", "report", "bundle", "diff", "trace"}
+
+// cityKindMap folds City's own artifact vocabulary onto the closed one. It is a
+// mapping, not a passthrough: a City kind with no entry becomes the default.
+var cityKindMap = map[string]string{
+	"transcript": "log",
+	"logs":       "log",
+	"review":     "report",
+	"summary":    "report",
+	"patch":      "diff",
+	"workspace":  "bundle",
+	"profile":    "trace",
+}
+
+var (
+	// Neutral Team ID shapes. A run or session link is a server-minted ID City
+	// read back off a response; anything else in that slot is a City-shaped
+	// value trying to become a link authority.
+	runIDPattern     = regexp.MustCompile(`^run_[0-9a-z]{16,}$`)
+	sessionIDPattern = regexp.MustCompile(`^ses_[0-9a-z]{16,}$`)
+	// cityLocatorPattern is a City-native locator: a scheme or a prefixed name
+	// that only means something inside City.
+	cityLocatorPattern = regexp.MustCompile(`(?i)^(gc://|city[:/]|rig[:/]|formula[:/])`)
+)
+
+// secretLocatorPatterns catch credential evidence and pre-signed locators in
+// outbound strings. A signed URL is exactly as forbidden as a bearer token: both
+// are ways to reach bytes outside the authorized route.
+var secretLocatorPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\bbearer\s+[a-z0-9._~+/-]{8,}`),
+	regexp.MustCompile(`(?i)\bauthorization\s*:`),
+	regexp.MustCompile(`(?i)x-amz-(signature|credential|security-token)`),
+	regexp.MustCompile(`(?i)[?&](signature|sig|token|access_token|api_key)=`),
+	regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+	regexp.MustCompile(`\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`),
+}
+
+// SecretLocator reports whether a string carries credential evidence or a
+// pre-signed locator.
+func SecretLocator(s string) bool {
+	for _, re := range secretLocatorPatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Mapper) validateSource() error {
+	if strings.TrimSpace(m.Source.SourceID) == "" {
+		return fmt.Errorf("%w: source id is required", ErrInvalidArtifact)
+	}
+	if strings.TrimSpace(m.Source.Kind) == "" {
+		return fmt.Errorf("%w: source kind is required", ErrInvalidArtifact)
+	}
+	return nil
+}
+
+func validateNativeID(field, v string) error {
+	switch {
+	case strings.TrimSpace(v) == "":
+		return fmt.Errorf("%w: %s is required", ErrInvalidArtifact, field)
+	case len(v) > maxSourceNativeIDLen:
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidArtifact, field, maxSourceNativeIDLen)
+	case strings.ContainsAny(v, " \t\r\n"):
+		return fmt.Errorf("%w: %s contains whitespace", ErrInvalidArtifact, field)
+	case SecretLocator(v):
+		return fmt.Errorf("%w: %s", ErrCredentialLeak, field)
+	}
+	return nil
+}
+
+// MapLinks normalizes and validates the artifact's links.
+//
+// It runs before anything is created and therefore before any byte is uploaded:
+// a link this adapter can already tell is malformed or City-shaped never reaches
+// the server, and a link the server rejects as foreign fails the create, which
+// is the only call that carries links. Either way no content leaves the process.
+func (m Mapper) MapLinks(a CityArtifact) (Links, error) {
+	l := Links{
+		ProjectID: strings.TrimSpace(a.ProjectID),
+		IssueID:   strings.TrimSpace(a.IssueID),
+		RunID:     strings.TrimSpace(a.RunID),
+		SessionID: strings.TrimSpace(a.SessionID),
+	}
+	cityFacts := []string{a.City, a.Rig, a.Formula}
+	for field, v := range map[string]string{
+		"links.project_id": l.ProjectID,
+		"links.issue_id":   l.IssueID,
+		"links.run_id":     l.RunID,
+		"links.session_id": l.SessionID,
+	} {
+		if v == "" {
+			continue
+		}
+		if err := validateLinkValue(field, v, cityFacts); err != nil {
+			return Links{}, err
+		}
+	}
+	if l.RunID != "" && !runIDPattern.MatchString(l.RunID) {
+		return Links{}, fmt.Errorf("%w: links.run_id %q is not a server-minted run id", ErrCityAuthority, l.RunID)
+	}
+	if l.SessionID != "" && !sessionIDPattern.MatchString(l.SessionID) {
+		return Links{}, fmt.Errorf("%w: links.session_id %q is not a server-minted session id", ErrCityAuthority, l.SessionID)
+	}
+	return l, nil
+}
+
+func validateLinkValue(field, v string, cityFacts []string) error {
+	switch {
+	case len(v) > maxLinkIDLen:
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidArtifact, field, maxLinkIDLen)
+	case strings.ContainsAny(v, " \t\r\n"):
+		return fmt.Errorf("%w: %s contains whitespace", ErrInvalidArtifact, field)
+	case SecretLocator(v):
+		return fmt.Errorf("%w: %s", ErrCredentialLeak, field)
+	case cityLocatorPattern.MatchString(v):
+		return fmt.Errorf("%w: %s is a City locator", ErrCityAuthority, field)
+	}
+	for _, fact := range cityFacts {
+		if fact != "" && strings.EqualFold(fact, v) {
+			return fmt.Errorf("%w: %s repeats a City name", ErrCityAuthority, field)
+		}
+	}
+	return nil
+}
+
+// MapCreate builds the create body. The result carries a closed kind, a
+// normalized media type and verified links, and nothing else — there is no slot
+// for a City name, a producer, a status or an ID.
+func (m Mapper) MapCreate(a CityArtifact) (CreateRequest, error) {
+	if err := m.validateSource(); err != nil {
+		return CreateRequest{}, err
+	}
+	if err := validateNativeID("artifact_id", a.ArtifactID); err != nil {
+		return CreateRequest{}, err
+	}
+	links, err := m.MapLinks(a)
+	if err != nil {
+		return CreateRequest{}, err
+	}
+	mediaType := normalizeMediaType(a.MediaType)
+	if mediaType == "" {
+		return CreateRequest{}, fmt.Errorf("%w: media_type %q is not a media type", ErrInvalidArtifact, a.MediaType)
+	}
+	return CreateRequest{Kind: mapKind(a.Kind), MediaType: mediaType, Links: links}, nil
+}
+
+// MapPart builds one content part. Bytes are copied so a later mutation of the
+// City slice cannot change what this adapter believes it acknowledged.
+func (m Mapper) MapPart(a CityArtifact, p CityPart) (Part, error) {
+	switch {
+	case p.Sequence < 1:
+		return Part{}, fmt.Errorf("%w: part sequence must be positive, got %d", ErrInvalidArtifact, p.Sequence)
+	case len(p.Bytes) == 0:
+		return Part{}, fmt.Errorf("%w: part %d is empty", ErrInvalidArtifact, p.Sequence)
+	case len(p.Bytes) > maxPartBytes:
+		return Part{}, fmt.Errorf("%w: part %d exceeds %d bytes", ErrInvalidArtifact, p.Sequence, maxPartBytes)
+	}
+	mediaType := normalizeMediaType(firstNonEmpty(p.MediaType, a.MediaType))
+	if mediaType == "" {
+		return Part{}, fmt.Errorf("%w: part %d media_type is not a media type", ErrInvalidArtifact, p.Sequence)
+	}
+	out := Part{Bytes: append([]byte(nil), p.Bytes...), MediaType: mediaType, Sequence: p.Sequence}
+	return out, nil
+}
+
+// MapFinalize builds the finalize body. The asserted digest is taken over the
+// manifest this adapter actually uploaded, in sequence order, so an assertion
+// can only ever describe content that left this process.
+func (m Mapper) MapFinalize(digest string) FinalizeRequest {
+	return FinalizeRequest{Digest: digest}
+}
+
+func mapKind(k string) string {
+	k = strings.ToLower(strings.TrimSpace(k))
+	if mapped, ok := cityKindMap[k]; ok {
+		return mapped
+	}
+	for _, canonical := range canonicalKinds {
+		if k == canonical {
+			return k
+		}
+	}
+	return defaultKind
+}
+
+// normalizeMediaType keeps a media type to its lowercased type/subtype, exactly
+// as the server does. Parameters are dropped rather than echoed: a charset City
+// sent is not a fact about the stored bytes, and an unbounded parameter string
+// is one more place an upstream secret could ride.
+func normalizeMediaType(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if v == "" {
+		return defaultMediaType
+	}
+	if i := strings.IndexByte(v, ';'); i >= 0 {
+		v = strings.TrimSpace(v[:i])
+	}
+	parts := strings.Split(v, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	for _, p := range parts {
+		if strings.ContainsAny(p, " \t\r\n\"\\") {
+			return ""
+		}
+	}
+	return v
+}
+
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// forbiddenBodyFields are members no outbound artifact body may carry. Identity,
+// provenance and state are server-derived; a body that tries to set one is a
+// City fact reaching for authority. Locators are here for the same reason a
+// signed URL is refused on the way in: an artifact API hands over content, never
+// a way to fetch content elsewhere.
+var forbiddenBodyFields = map[string]bool{
+	"id":           true,
+	"artifact_id":  true,
+	"source_id":    true,
+	"producer":     true,
+	"status":       true,
+	"digest":       true,
+	"byte_size":    true,
+	"created_at":   true,
+	"updated_at":   true,
+	"finalized_at": true,
+	"display":      true,
+	"city":         true,
+	"rig":          true,
+	"formula":      true,
+	"token":        true,
+	"url":          true,
+	"signed_url":   true,
+	"location":     true,
+	"href":         true,
+	"bucket":       true,
+	"object_key":   true,
+	"etag":         true,
+}
+
+// contentBearingFields are members that would put bytes inside a JSON body. No
+// artifact body in this package has one: content travels as [Part.Bytes] to the
+// content route and nowhere else, and [Part] does not serialize its bytes.
+var contentBearingFields = map[string]bool{
+	"bytes":   true,
+	"content": true,
+	"text":    true,
+	"body":    true,
+	"data":    true,
+}
+
+// ScanOutbound is the last gate before a body is handed to the client seam.
+//
+// It works on the encoded body rather than on the Go type, so a member added to
+// a request struct later is scanned without anyone remembering to update a list
+// of accessors. allowed names the members this particular body is entitled to
+// carry despite the lists below — today that is the finalize body's asserted
+// digest, which is the producer's claim about content it uploaded rather than a
+// server-derived field being overwritten.
+func ScanOutbound(body any, allowed ...string) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("cityartifact: scan encode: %w", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return fmt.Errorf("cityartifact: scan decode: %w", err)
+	}
+	permitted := make(map[string]bool, len(allowed))
+	for _, k := range allowed {
+		permitted[k] = true
+	}
+	return scanObject(generic, permitted, "")
+}
+
+func scanObject(obj map[string]any, permitted map[string]bool, path string) error {
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		at := k
+		if path != "" {
+			at = path + "." + k
+		}
+		if !permitted[k] {
+			if forbiddenBodyFields[k] {
+				return fmt.Errorf("%w: body carries %s", ErrCityAuthority, at)
+			}
+			if contentBearingFields[k] {
+				return fmt.Errorf("%w: %s", ErrContentRoute, at)
+			}
+		}
+		switch v := obj[k].(type) {
+		case string:
+			if SecretLocator(v) {
+				return fmt.Errorf("%w: %s", ErrCredentialLeak, at)
+			}
+		case map[string]any:
+			if err := scanObject(v, permitted, at); err != nil {
+				return err
+			}
+		case []any:
+			for i, item := range v {
+				nested, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if err := scanObject(nested, permitted, fmt.Sprintf("%s[%d]", at, i)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cityartifact/parity_test.go
+++ b/pkg/cityartifact/parity_test.go
@@ -1,0 +1,360 @@
+package cityartifact_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+)
+
+const (
+	linkedRun     = "run_abcdefghij0123456789"
+	linkedSession = "ses_abcdefghij0123456789"
+	linkedProject = "proj-alpha"
+	linkedIssue   = "bd-7"
+)
+
+func citySource() cityartifact.Source {
+	return cityartifact.Source{SourceID: "src_city_1", Kind: "gascity", Epoch: 1}
+}
+
+func newCityProducer(t *testing.T, f *cityartifact.Fake) *cityartifact.Producer {
+	t.Helper()
+	p, err := cityartifact.NewProducer(f.Client("src_city_1", "gascity"),
+		cityartifact.Mapper{Source: citySource()}, cityartifact.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	return p
+}
+
+func sampleArtifact() cityartifact.CityArtifact {
+	return cityartifact.CityArtifact{
+		ArtifactID: "city-artifact-1",
+		Kind:       "transcript",
+		MediaType:  "text/plain; charset=utf-8",
+		Version:    1,
+		ProjectID:  linkedProject,
+		IssueID:    linkedIssue,
+		RunID:      linkedRun,
+		SessionID:  linkedSession,
+		City:       "rustbelt",
+		Rig:        "rig-3",
+		Formula:    "review",
+		Parts: []cityartifact.CityPart{
+			{Sequence: 1, Bytes: []byte("first part\n")},
+			{Sequence: 2, Bytes: []byte("second part\n")},
+		},
+		Complete: true,
+	}
+}
+
+func authorizedFake() *cityartifact.Fake {
+	f := cityartifact.NewFake()
+	f.Authorize(linkedProject, linkedIssue, linkedRun, linkedSession)
+	return f
+}
+
+// AC1 happy path: a valid linked artifact finalizes and its metadata reads back
+// normalized.
+func TestPushFinalizesAndReadsBack(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := newCityProducer(t, f)
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if !res.Finalized || res.Uploaded != 2 {
+		t.Fatalf("want 2 uploaded and finalized, got %+v", res)
+	}
+	if !strings.HasPrefix(res.ArtifactID, "art_") {
+		t.Fatalf("artifact id %q is not server-minted", res.ArtifactID)
+	}
+	if strings.Contains(res.ArtifactID, "city-artifact-1") {
+		t.Fatalf("City minted the artifact id: %q", res.ArtifactID)
+	}
+	meta := res.Metadata
+	if meta.Kind != "log" {
+		t.Errorf("kind = %q, want the closed-vocabulary mapping of a City transcript", meta.Kind)
+	}
+	if meta.MediaType != "text/plain" {
+		t.Errorf("media_type = %q, want the charset parameter dropped", meta.MediaType)
+	}
+	if meta.Status != "final" || !meta.Finalized() {
+		t.Errorf("status = %q finalized = %v, want a sealed artifact", meta.Status, meta.Finalized())
+	}
+	if meta.SourceID != "src_city_1" {
+		t.Errorf("source_id = %q, want the credential-derived source", meta.SourceID)
+	}
+	wantLinks := cityartifact.Links{ProjectID: linkedProject, IssueID: linkedIssue, RunID: linkedRun, SessionID: linkedSession}
+	if meta.Links != wantLinks {
+		t.Errorf("links = %+v, want %+v", meta.Links, wantLinks)
+	}
+	for _, fact := range []string{"rustbelt", "rig-3", "review"} {
+		if strings.Contains(meta.Display, fact) {
+			t.Errorf("City fact %q reached the public shape", fact)
+		}
+	}
+}
+
+// AC1: the same public contract, Team IDs, category scopes and provenance apply
+// whether City or a custom producer uploaded. Two credentials, one tenant, one
+// shape.
+func TestCityAndCustomProducerAgree(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+
+	city := newCityProducer(t, f)
+	cityRes, err := city.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("city Push: %v", err)
+	}
+
+	// The custom producer is not City: different source, no City vocabulary,
+	// its own checkpoint. It uploads the same content via the same seam.
+	customSource := cityartifact.Source{SourceID: "src_custom_1", Kind: "custom", Epoch: 1}
+	custom, err := cityartifact.NewProducer(f.Client("src_custom_1", "custom-agent"),
+		cityartifact.Mapper{Source: customSource}, cityartifact.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("custom NewProducer: %v", err)
+	}
+	plain := sampleArtifact()
+	plain.ArtifactID = "custom-artifact-1"
+	plain.Kind = "log"
+	plain.City, plain.Rig, plain.Formula = "", "", ""
+	customRes, err := custom.Push(ctx, plain)
+	if err != nil {
+		t.Fatalf("custom Push: %v", err)
+	}
+
+	a, b := cityRes.Metadata, customRes.Metadata
+	if a.ID == b.ID {
+		t.Fatalf("both producers landed on artifact %q", a.ID)
+	}
+	if a.Kind != b.Kind || a.MediaType != b.MediaType || a.Links != b.Links {
+		t.Errorf("shape diverged: city %+v custom %+v", a, b)
+	}
+	if a.Digest != b.Digest {
+		t.Errorf("identical content hashed differently: %q vs %q", a.Digest, b.Digest)
+	}
+	if a.ByteSize != b.ByteSize || a.Status != b.Status {
+		t.Errorf("state diverged: city %+v custom %+v", a, b)
+	}
+	if a.SourceID == b.SourceID {
+		t.Errorf("provenance collapsed: both report source %q", a.SourceID)
+	}
+	if a.Producer != "gascity" || b.Producer != "custom-agent" {
+		t.Errorf("producer attribution wrong: %q / %q", a.Producer, b.Producer)
+	}
+
+	// A custom producer reads a City artifact through the same public route:
+	// City is one optional producer, not a private namespace.
+	got, err := custom.Metadata(ctx, cityRes.ArtifactID)
+	if err != nil {
+		t.Fatalf("custom read of a City artifact: %v", err)
+	}
+	if got.ID != cityRes.ArtifactID {
+		t.Errorf("read back %q, want %q", got.ID, cityRes.ArtifactID)
+	}
+}
+
+// AC1 edge: a foreign link fails before a single byte is uploaded.
+func TestForeignLinkFailsBeforeUpload(t *testing.T) {
+	ctx := context.Background()
+	f := cityartifact.NewFake()
+	f.Authorize(linkedProject, linkedIssue, linkedRun) // session deliberately absent
+	p := newCityProducer(t, f)
+
+	res, err := p.Push(ctx, sampleArtifact())
+	if !errors.Is(err, cityartifact.ErrNotReadable) {
+		t.Fatalf("err = %v, want a foreign link refusal", err)
+	}
+	if res.Uploaded != 0 {
+		t.Errorf("uploaded %d parts despite a foreign link", res.Uploaded)
+	}
+	for _, call := range f.Calls() {
+		if call == cityartifact.OpUploadArtifactContent || call == cityartifact.OpFinalizeArtifact {
+			t.Errorf("dispatched %s after a foreign link", call)
+		}
+	}
+	if f.ArtifactCount() != 0 {
+		t.Errorf("created %d artifacts despite a foreign link", f.ArtifactCount())
+	}
+}
+
+// AC1 edge: a City-specific authority — a rig name where a server-minted link ID
+// belongs — never reaches the wire.
+func TestCityAuthorityRefusedBeforeAnyCall(t *testing.T) {
+	ctx := context.Background()
+	for name, mutate := range map[string]func(*cityartifact.CityArtifact){
+		"city-native run id":  func(a *cityartifact.CityArtifact) { a.RunID = "rig-3/run-17" },
+		"city locator":        func(a *cityartifact.CityArtifact) { a.ProjectID = "gc://rustbelt/proj" },
+		"city name as link":   func(a *cityartifact.CityArtifact) { a.IssueID = "rig-3" },
+		"city-native session": func(a *cityartifact.CityArtifact) { a.SessionID = "session-17" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := authorizedFake()
+			p := newCityProducer(t, f)
+			a := sampleArtifact()
+			mutate(&a)
+			if _, err := p.Push(ctx, a); !errors.Is(err, cityartifact.ErrCityAuthority) {
+				t.Fatalf("err = %v, want ErrCityAuthority", err)
+			}
+			if len(f.Calls()) != 0 {
+				t.Errorf("dispatched %v before refusing City authority", f.Calls())
+			}
+		})
+	}
+}
+
+// AC1 edge: a raw upstream field cannot be smuggled into an outbound body.
+func TestScanOutboundRefusesRawUpstreamFields(t *testing.T) {
+	cases := map[string]struct {
+		body any
+		want error
+	}{
+		"server-minted id":  {map[string]any{"id": "art_1"}, cityartifact.ErrCityAuthority},
+		"provenance":        {map[string]any{"source_id": "src_x"}, cityartifact.ErrCityAuthority},
+		"City fact":         {map[string]any{"rig": "rig-3"}, cityartifact.ErrCityAuthority},
+		"storage locator":   {map[string]any{"signed_url": "https://x/y"}, cityartifact.ErrCityAuthority},
+		"content in a body": {map[string]any{"bytes": "aGk="}, cityartifact.ErrContentRoute},
+		"nested content":    {map[string]any{"links": map[string]any{"body": "hi"}}, cityartifact.ErrContentRoute},
+		"credential": {map[string]any{
+			"kind": "file", "media_type": "text/plain",
+			"links": map[string]any{"project_id": "p?signature=abc"},
+		}, cityartifact.ErrCredentialLeak},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := cityartifact.ScanOutbound(tc.body); !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+	// The finalize body's asserted digest is the one permitted exception.
+	if err := cityartifact.ScanOutbound(cityartifact.FinalizeRequest{Digest: "sha256:aa"}, "digest"); err != nil {
+		t.Fatalf("finalize body refused: %v", err)
+	}
+	if err := cityartifact.ScanOutbound(cityartifact.FinalizeRequest{Digest: "sha256:aa"}); !errors.Is(err, cityartifact.ErrCityAuthority) {
+		t.Fatalf("digest was permitted without being named")
+	}
+}
+
+// The four categories are four reads. A metadata read returns no bytes, no
+// evidence and no references, and content comes back only from the content call.
+func TestCategorySeparation(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := newCityProducer(t, f)
+	res, err := p.Push(ctx, sampleArtifact())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	f.Seed(res.ArtifactID,
+		[]cityartifact.EvidenceEntry{{ID: "ev1", Kind: "scan", Statement: "clean"}},
+		[]cityartifact.Reference{{ID: "rf1", Kind: "issue", TargetID: linkedIssue}})
+
+	evidence, err := p.Evidence(ctx, res.ArtifactID)
+	if err != nil || len(evidence) != 1 {
+		t.Fatalf("Evidence = %v, %v", evidence, err)
+	}
+	refs, err := p.References(ctx, res.ArtifactID)
+	if err != nil || len(refs) != 1 {
+		t.Fatalf("References = %v, %v", refs, err)
+	}
+	chunk, err := p.Content(ctx, res.ArtifactID, cityartifact.Range{})
+	if err != nil {
+		t.Fatalf("Content: %v", err)
+	}
+	if string(chunk.Bytes) != "first part\nsecond part\n" {
+		t.Errorf("content = %q", chunk.Bytes)
+	}
+	meta, err := p.Metadata(ctx, res.ArtifactID)
+	if err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if meta.ByteSize != int64(len(chunk.Bytes)) {
+		t.Errorf("metadata byte_size %d disagrees with content length %d", meta.ByteSize, len(chunk.Bytes))
+	}
+	for op, wantCat := range map[string]cityartifact.Category{
+		cityartifact.OpCreateArtifact:        cityartifact.CategoryMetadata,
+		cityartifact.OpListArtifacts:         cityartifact.CategoryMetadata,
+		cityartifact.OpGetArtifact:           cityartifact.CategoryMetadata,
+		cityartifact.OpFinalizeArtifact:      cityartifact.CategoryMetadata,
+		cityartifact.OpGetArtifactEvidence:   cityartifact.CategoryEvidence,
+		cityartifact.OpGetArtifactReferences: cityartifact.CategoryReferences,
+		cityartifact.OpUploadArtifactContent: cityartifact.CategoryContent,
+		cityartifact.OpGetArtifactContent:    cityartifact.CategoryContent,
+	} {
+		got, ok := cityartifact.CategoryOf(op)
+		if !ok || got != wantCat {
+			t.Errorf("CategoryOf(%s) = %q, %v; want %q", op, got, ok, wantCat)
+		}
+	}
+	if _, ok := cityartifact.CategoryOf("deleteArtifact"); ok {
+		t.Error("an operation outside the frozen matrix was given a category")
+	}
+}
+
+// An unfinalized artifact is not readable — not by its own producer, not by
+// anyone.
+func TestUnfinalizedArtifactIsNotReadable(t *testing.T) {
+	ctx := context.Background()
+	f := authorizedFake()
+	p := newCityProducer(t, f)
+
+	partial := sampleArtifact()
+	partial.Complete = false
+	res, err := p.Push(ctx, partial)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if res.Finalized {
+		t.Fatal("an incomplete manifest was finalized")
+	}
+	if res.Metadata.ID != "" {
+		t.Fatalf("metadata returned for an unfinalized artifact: %+v", res.Metadata)
+	}
+	for _, read := range map[string]func() error{
+		"metadata":   func() error { _, err := p.Metadata(ctx, res.ArtifactID); return err },
+		"evidence":   func() error { _, err := p.Evidence(ctx, res.ArtifactID); return err },
+		"references": func() error { _, err := p.References(ctx, res.ArtifactID); return err },
+		"content":    func() error { _, err := p.Content(ctx, res.ArtifactID, cityartifact.Range{}); return err },
+	} {
+		if err := read(); !errors.Is(err, cityartifact.ErrNotReadable) {
+			t.Errorf("read of an unfinalized artifact returned %v, want ErrNotReadable", err)
+		}
+	}
+}
+
+// An artifact is valid without City: no links, no City facts, plain kind.
+func TestArtifactIsValidWithoutCity(t *testing.T) {
+	ctx := context.Background()
+	f := cityartifact.NewFake()
+	p := newCityProducer(t, f)
+
+	bare := cityartifact.CityArtifact{
+		ArtifactID: "bare-1",
+		Kind:       "unknown-city-kind",
+		Version:    1,
+		Parts:      []cityartifact.CityPart{{Sequence: 1, Bytes: []byte("x")}},
+		Complete:   true,
+	}
+	res, err := p.Push(ctx, bare)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if res.Metadata.Kind != "file" {
+		t.Errorf("kind = %q, want the default rather than a raw City kind", res.Metadata.Kind)
+	}
+	if res.Metadata.MediaType != "application/octet-stream" {
+		t.Errorf("media_type = %q, want the default", res.Metadata.MediaType)
+	}
+	if !res.Metadata.Links.Empty() {
+		t.Errorf("links = %+v, want none", res.Metadata.Links)
+	}
+}

--- a/pkg/cityartifact/producer.go
+++ b/pkg/cityartifact/producer.go
@@ -1,0 +1,482 @@
+package cityartifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// State is one City artifact's checkpoint.
+//
+// Frontier is the highest part sequence the SERVER acknowledged, and it only
+// ever advances contiguously. Digests holds the digest of each acknowledged part
+// so a later replay can be told apart from a rewrite; CreateDigest does the same
+// job for the artifact's own definition. Together they are what makes "changed
+// manifest" detectable at all.
+type State struct {
+	Epoch         uint64         `json:"epoch"`
+	SourceID      string         `json:"source_id"`
+	ArtifactID    string         `json:"artifact_id"`
+	CreateDigest  string         `json:"create_digest"`
+	Frontier      int            `json:"frontier"`
+	Digests       map[int]string `json:"digests"`
+	Finalized     bool           `json:"finalized"`
+	ContentDigest string         `json:"content_digest"`
+}
+
+func (s *State) digests() map[int]string {
+	if s.Digests == nil {
+		s.Digests = map[int]string{}
+	}
+	return s.Digests
+}
+
+// Store persists checkpoints across restarts. It is an interface because the
+// durable implementation is City's business; the adapter only needs Load and
+// Save to be atomic with respect to each other.
+type Store interface {
+	Load(ctx context.Context, key string) (State, bool, error)
+	Save(ctx context.Context, key string, st State) error
+}
+
+// MemoryStore is an in-process Store. It is safe for concurrent use and is what
+// tests and a single-shot export run on.
+type MemoryStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+// NewMemoryStore returns an empty in-process Store.
+func NewMemoryStore() *MemoryStore { return &MemoryStore{m: map[string][]byte{}} }
+
+// Load implements Store.
+func (s *MemoryStore) Load(_ context.Context, key string) (State, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw, ok := s.m[key]
+	if !ok {
+		return State{}, false, nil
+	}
+	var st State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return State{}, false, fmt.Errorf("cityartifact: decode checkpoint %q: %w", key, err)
+	}
+	return st, true, nil
+}
+
+// Save implements Store. It round-trips through JSON so a caller cannot hold a
+// reference into stored state and mutate it behind the producer's back.
+func (s *MemoryStore) Save(_ context.Context, key string, st State) error {
+	raw, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("cityartifact: encode checkpoint %q: %w", key, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = map[string][]byte{}
+	}
+	s.m[key] = raw
+	return nil
+}
+
+// Result reports what one push did. It is returned even on error, so a caller
+// that stops on a refusal still learns how far the artifact got.
+type Result struct {
+	// ArtifactID is the server-minted ID. City never mints one.
+	ArtifactID string
+	Uploaded   int
+	Skipped    int
+	Finalized  bool
+	// Metadata is the normalized read-back, present only once the artifact is
+	// finalized — an unfinalized artifact is not readable.
+	Metadata Artifact
+}
+
+// Producer maps a City artifact onto the public artifact contract and advances a
+// checkpoint only over acknowledged, contiguous parts.
+type Producer struct {
+	API    API
+	Mapper Mapper
+	Store  Store
+}
+
+// NewProducer validates its wiring up front: a producer missing a store would
+// look like it worked and silently re-upload the world on restart.
+func NewProducer(api API, mapper Mapper, store Store) (*Producer, error) {
+	if api == nil {
+		return nil, errors.New("cityartifact: API is required")
+	}
+	if store == nil {
+		return nil, errors.New("cityartifact: Store is required")
+	}
+	if err := mapper.validateSource(); err != nil {
+		return nil, err
+	}
+	return &Producer{API: api, Mapper: mapper, Store: store}, nil
+}
+
+// CheckpointKey is the stable checkpoint identity of one City artifact under one
+// source. It excludes the epoch: a declared reset must LAND on the same key so
+// the old frontier is visibly superseded rather than orphaned under a new one.
+func CheckpointKey(source Source, cityArtifactID string) string {
+	return source.Kind + "/" + source.SourceID + "/" + cityArtifactID
+}
+
+// Push creates, uploads, finalizes and reads back one City artifact.
+//
+// It advances only on acknowledgement. Every refusal returns the partial result
+// with the checkpoint already saved at the last acknowledged part, so a restart
+// resumes at the next part and never re-sends an accepted one. There is no
+// fallback path: if the server refuses, this artifact stops. The adapter does
+// not reach for a City-side forge, a second route or a different credential, and
+// no other producer's checkpoint is touched.
+func (p *Producer) Push(ctx context.Context, a CityArtifact) (Result, error) {
+	res := Result{}
+
+	create, err := p.Mapper.MapCreate(a)
+	if err != nil {
+		return res, err
+	}
+	if err := ScanOutbound(create); err != nil {
+		return res, err
+	}
+	parts, err := p.mapParts(a)
+	if err != nil {
+		return res, err
+	}
+
+	key := CheckpointKey(p.Mapper.Source, a.ArtifactID)
+	st, _, err := p.Store.Load(ctx, key)
+	if err != nil {
+		return res, err
+	}
+	if err := p.reconcileEpoch(&st); err != nil {
+		return res, err
+	}
+
+	createDigest := payloadDigest(create)
+	if st.ArtifactID == "" {
+		art, err := p.API.CreateArtifact(ctx, create,
+			idempotencyKey(p.Mapper.Source, kindArtifact, a.ArtifactID, createDigest))
+		if err != nil {
+			return res, normalizeUpstream(OpCreateArtifact, err)
+		}
+		if strings.TrimSpace(art.ID) == "" {
+			return res, fmt.Errorf("%w: server returned no artifact id", ErrIdentityDrift)
+		}
+		st.ArtifactID = art.ID
+		st.CreateDigest = createDigest
+		st.Finalized = art.Finalized()
+		if err := p.Store.Save(ctx, key, st); err != nil {
+			return res, err
+		}
+	} else if st.CreateDigest != createDigest {
+		// The artifact's own definition changed under an ID the server already
+		// minted. Re-creating would fork the artifact and mutating is not on
+		// offer, so this adapter stops with its checkpoint intact.
+		return res, fmt.Errorf("%w: artifact %q definition changed after creation", ErrChangedManifest, a.ArtifactID)
+	}
+	res.ArtifactID = st.ArtifactID
+	res.Finalized = st.Finalized
+
+	uploaded, skipped, err := p.pushParts(ctx, key, &st, parts)
+	res.Uploaded, res.Skipped = uploaded, skipped
+	if err != nil {
+		return res, err
+	}
+
+	if a.Complete && !st.Finalized {
+		contentDigest := contentDigest(parts)
+		body := p.Mapper.MapFinalize(contentDigest)
+		if err := ScanOutbound(body, "digest"); err != nil {
+			return res, err
+		}
+		final, err := p.API.FinalizeArtifact(ctx, st.ArtifactID, body,
+			idempotencyKey(p.Mapper.Source, kindFinalize, a.ArtifactID, contentDigest))
+		if err != nil {
+			return res, normalizeUpstream(OpFinalizeArtifact, err)
+		}
+		if final.ID != st.ArtifactID {
+			return res, fmt.Errorf("%w: finalize acknowledged artifact %q, not %q",
+				ErrIdentityDrift, final.ID, st.ArtifactID)
+		}
+		if !final.Finalized() {
+			return res, fmt.Errorf("%w: finalize returned an unsealed artifact", ErrUpstream)
+		}
+		st.Finalized = true
+		st.ContentDigest = contentDigest
+		if err := p.Store.Save(ctx, key, st); err != nil {
+			return res, err
+		}
+		res.Finalized = true
+	}
+
+	if !st.Finalized {
+		// Not readable yet, and this adapter does not pretend otherwise.
+		return res, nil
+	}
+	meta, err := p.Metadata(ctx, st.ArtifactID)
+	if err != nil {
+		return res, err
+	}
+	if err := verifyReadBack(meta, st, create, p.Mapper.Source); err != nil {
+		return res, err
+	}
+	res.Metadata = meta
+	return res, nil
+}
+
+// reconcileEpoch applies a declared reset and refuses an undeclared one.
+func (p *Producer) reconcileEpoch(st *State) error {
+	src := p.Mapper.Source
+	switch {
+	case st.Epoch == 0:
+		st.Epoch = src.Epoch
+		st.SourceID = src.SourceID
+	case src.Epoch > st.Epoch:
+		// A declared reset. The previous frontier belongs to the previous epoch
+		// and must not gate the new one, so the checkpoint restarts. The server
+		// keeps the artifacts it already accepted; this producer simply stops
+		// claiming to have sent them.
+		*st = State{Epoch: src.Epoch, SourceID: src.SourceID}
+	case src.Epoch < st.Epoch:
+		return fmt.Errorf("%w: source epoch %d is behind checkpoint epoch %d",
+			ErrIdentityDrift, src.Epoch, st.Epoch)
+	}
+	if st.SourceID != "" && st.SourceID != src.SourceID {
+		return fmt.Errorf("%w: checkpoint belongs to source %q", ErrIdentityDrift, st.SourceID)
+	}
+	return nil
+}
+
+// mapParts normalizes the manifest and refuses a duplicate sequence before a
+// single byte is sent. Two parts claiming the same sequence is a source bug that
+// would otherwise show up as a silent overwrite.
+func (p *Producer) mapParts(a CityArtifact) ([]Part, error) {
+	out := make([]Part, 0, len(a.Parts))
+	seen := map[int]bool{}
+	for _, cp := range a.Parts {
+		if seen[cp.Sequence] {
+			return nil, fmt.Errorf("%w: part sequence %d appears twice", ErrInvalidArtifact, cp.Sequence)
+		}
+		seen[cp.Sequence] = true
+		part, err := p.Mapper.MapPart(a, cp)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, part)
+	}
+	// Out-of-order arrival is a source property, not a protocol violation: order
+	// the manifest here and let contiguity be judged on sequences.
+	sort.Slice(out, func(i, j int) bool { return out[i].Sequence < out[j].Sequence })
+	return out, nil
+}
+
+func (p *Producer) pushParts(ctx context.Context, key string, st *State, parts []Part) (uploaded, skipped int, err error) {
+	for _, part := range parts {
+		digest := part.Digest()
+
+		if part.Sequence <= st.Frontier {
+			// Already acknowledged. Same bytes means a retry we can drop;
+			// different bytes means the manifest was rewritten underneath us.
+			if have, ok := st.digests()[part.Sequence]; ok && have != digest {
+				return uploaded, skipped, fmt.Errorf("%w: part %d was %s, manifest now says %s",
+					ErrChangedManifest, part.Sequence, have, digest)
+			}
+			skipped++
+			continue
+		}
+		if st.Finalized {
+			return uploaded, skipped, fmt.Errorf("%w: part %d arrived after finalize", ErrFinalized, part.Sequence)
+		}
+		if part.Sequence != st.Frontier+1 {
+			return uploaded, skipped, fmt.Errorf("%w: expected part %d, got %d",
+				ErrGap, st.Frontier+1, part.Sequence)
+		}
+		if err := ScanOutbound(part); err != nil {
+			return uploaded, skipped, err
+		}
+		art, err := p.API.UploadArtifactContent(ctx, st.ArtifactID, part,
+			idempotencyKey(p.Mapper.Source, kindPart,
+				st.ArtifactID+"/"+strconv.Itoa(part.Sequence), digest))
+		if err != nil {
+			return uploaded, skipped, normalizeUpstream(OpUploadArtifactContent, err)
+		}
+		if art.ID != st.ArtifactID {
+			return uploaded, skipped, fmt.Errorf("%w: part %d acknowledged against artifact %q, not %q",
+				ErrIdentityDrift, part.Sequence, art.ID, st.ArtifactID)
+		}
+		st.Frontier = part.Sequence
+		st.digests()[part.Sequence] = digest
+		uploaded++
+		if err := p.Store.Save(ctx, key, *st); err != nil {
+			return uploaded, skipped, err
+		}
+	}
+	return uploaded, skipped, nil
+}
+
+// Metadata reads an artifact's normalized metadata. It is the metadata category
+// and it can reach nothing else: there is no byte, no evidence statement and no
+// reference in what it returns.
+func (p *Producer) Metadata(ctx context.Context, artifactID string) (Artifact, error) {
+	art, err := p.API.GetArtifact(ctx, artifactID)
+	if err != nil {
+		return Artifact{}, normalizeUpstream(OpGetArtifact, err)
+	}
+	return art, nil
+}
+
+// Evidence reads an artifact's evidence entries. Separate category, separate
+// scope, separate call — a metadata read never carries these.
+func (p *Producer) Evidence(ctx context.Context, artifactID string) ([]EvidenceEntry, error) {
+	_, entries, err := p.API.GetArtifactEvidence(ctx, artifactID)
+	if err != nil {
+		return nil, normalizeUpstream(OpGetArtifactEvidence, err)
+	}
+	return entries, nil
+}
+
+// References reads an artifact's outbound references. Separate category,
+// separate scope, separate call.
+func (p *Producer) References(ctx context.Context, artifactID string) ([]Reference, error) {
+	_, refs, err := p.API.GetArtifactReferences(ctx, artifactID)
+	if err != nil {
+		return nil, normalizeUpstream(OpGetArtifactReferences, err)
+	}
+	return refs, nil
+}
+
+// Content reads a bounded range of an artifact's bytes. It is the only method in
+// this package that returns content, and it only ever returns content the server
+// handed over — never a location to fetch it from.
+func (p *Producer) Content(ctx context.Context, artifactID string, rng Range) (Chunk, error) {
+	_, chunk, err := p.API.GetArtifactContent(ctx, artifactID, rng)
+	if err != nil {
+		return Chunk{}, normalizeUpstream(OpGetArtifactContent, err)
+	}
+	return chunk, nil
+}
+
+// List enumerates artifacts this credential can see. The source filter is a
+// request the server validates; nothing here assumes it was honored.
+func (p *Producer) List(ctx context.Context, q ListQuery) ([]Artifact, string, error) {
+	arts, cursor, err := p.API.ListArtifacts(ctx, q)
+	if err != nil {
+		return nil, "", normalizeUpstream(OpListArtifacts, err)
+	}
+	return arts, cursor, nil
+}
+
+// verifyReadBack checks the normalized read-back against what this adapter
+// actually sent. It is the retrieval half of the round trip: an artifact whose
+// links, kind, media type, provenance or digest came back different is a drift
+// this producer reports rather than records as success.
+func verifyReadBack(got Artifact, st State, sent CreateRequest, src Source) error {
+	switch {
+	case got.ID != st.ArtifactID:
+		return fmt.Errorf("%w: read back artifact %q, expected %q", ErrIdentityDrift, got.ID, st.ArtifactID)
+	case got.SourceID != src.SourceID:
+		return fmt.Errorf("%w: artifact %q reports source %q, expected %q",
+			ErrIdentityDrift, got.ID, got.SourceID, src.SourceID)
+	case got.Kind != sent.Kind:
+		return fmt.Errorf("%w: artifact %q reports kind %q, sent %q", ErrIdentityDrift, got.ID, got.Kind, sent.Kind)
+	case got.MediaType != sent.MediaType:
+		return fmt.Errorf("%w: artifact %q reports media type %q, sent %q",
+			ErrIdentityDrift, got.ID, got.MediaType, sent.MediaType)
+	case got.Links != sent.Links:
+		return fmt.Errorf("%w: artifact %q reports links %+v, sent %+v", ErrIdentityDrift, got.ID, got.Links, sent.Links)
+	case !got.Finalized():
+		return fmt.Errorf("%w: artifact %q read back unfinalized", ErrIdentityDrift, got.ID)
+	case st.ContentDigest != "" && got.Digest != "" && got.Digest != st.ContentDigest:
+		return fmt.Errorf("%w: artifact %q stored digest %q, asserted %q",
+			ErrChangedManifest, got.ID, got.Digest, st.ContentDigest)
+	}
+	return nil
+}
+
+// contentDigest is the digest of the whole manifest, taken over the parts'
+// bytes in sequence order. It is the assertion finalize carries, so a producer
+// can only ever assert content that actually left this process.
+func contentDigest(parts []Part) string {
+	h := sha256.New()
+	for _, p := range parts {
+		h.Write(p.Bytes)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// payloadDigest is the canonical digest of a request body. It is what makes a
+// replay comparable: the same City artifact maps to the same bytes, so a digest
+// difference is a real source change and never a serialization artifact.
+func payloadDigest(body any) string {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		// json.Marshal on these closed DTOs cannot fail; a digest that cannot be
+		// computed must not compare equal to anything.
+		return "unencodable:" + err.Error()
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// idempotencyKey derives the server's Idempotency-Key from stable source
+// identity alone.
+//
+// Deriving rather than minting is the dedup contract: a retry after a lost
+// response reuses the key and replays, while a changed payload under the same
+// key is a conflict the server refuses. Nothing volatile — no clock, no attempt
+// counter, no credential material — is in the preimage, so a credential rotation
+// or a restart changes nothing about which key a request travels under. The
+// output is a v5-shaped UUID because the contract requires a UUID.
+func idempotencyKey(source Source, kind, nativeID, discriminator string) string {
+	preimage := strings.Join([]string{
+		"cityartifact/idempotency/v1",
+		source.Kind, source.SourceID,
+		strconv.FormatUint(source.Epoch, 10),
+		kind, nativeID, discriminator,
+	}, "\x1f")
+	sum := sha256.Sum256([]byte(preimage))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(b)
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+// normalizeUpstream collapses a client failure into this package's own typed
+// error.
+//
+// The upstream text is DROPPED, not wrapped: an error string is the easiest
+// place for a raw response body, an upstream token, a signed URL or a storage
+// path to escape, and a producer has no use for any of them. What survives is
+// the operation name, this package's sentinel, and — for a cancellation — the
+// context error, whose text is a fixed constant.
+func normalizeUpstream(operationID string, err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ErrContentDenied):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrContentDenied)
+	case errors.Is(err, ErrNotReadable):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrNotReadable)
+	case errors.Is(err, ErrFinalized):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrFinalized)
+	case errors.Is(err, ErrChangedManifest):
+		return fmt.Errorf("cityartifact: %s: %w", operationID, ErrChangedManifest)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("cityartifact: %s: %w: %w", operationID, ErrUpstream, context.DeadlineExceeded)
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("cityartifact: %s: %w: %w", operationID, ErrUpstream, context.Canceled)
+	}
+	return fmt.Errorf("cityartifact: %s: %w", operationID, ErrUpstream)
+}

--- a/pkg/cityinference/cityinference.go
+++ b/pkg/cityinference/cityinference.go
@@ -1,0 +1,118 @@
+// Package cityinference is Gas City's producer adapter for the neutral
+// inference resource of the Beads Team Server v1 API.
+//
+// City is ONE OPTIONAL producer of inference records. A custom orchestrator
+// with no City in the picture uploads the same records on its own credential,
+// so nothing here may become a schema, an identity or an authority that a
+// non-City producer would have to satisfy.
+//
+// Three facts shape every line below, and all three come from the frozen
+// inference identity design (API-6.1):
+//
+//   - Identity is the triplet (tenant, session_id, upstream_req_id) and the
+//     record ID is a one-way digest over it. This adapter derives the same ID
+//     the server does, and offers it as a checksum, never as a choice.
+//   - Only an exact-tuple match folds. Timestamp, model, vendor, token count,
+//     cost and textual similarity are not comparators here; [Mapper.Fold]
+//     refuses to evaluate them at all rather than returning "no".
+//   - Step attribution is UNAVAILABLE by construction. There is no admitted
+//     wire field for it and there is no field on [CityInvocation] that could
+//     carry one, so the adapter cannot synthesize a step even by accident.
+//     "Unavailable" is a claim this adapter makes out loud; it is not silence.
+//
+// What the adapter does NOT do is as load-bearing as what it does. It never
+// produces a run, session, transcript record or artifact — those are
+// [github.com/gastownhall/gascity/pkg/cityneutral]'s job, and this package only
+// links to the server-minted Team IDs that producer read back. It never sends
+// prompt text, completion text, transcript content or a raw provider payload:
+// [Preflight] rejects the whole request before a byte leaves the process. It
+// never emits an inference event or SSE stream, and it never touches Team
+// Server storage directly.
+//
+// Rollback is per producer. Set [Producer.Disabled] and this adapter stops
+// issuing requests while every acknowledged record stays exactly as the server
+// accepted it, other City producers keep running, and a custom (non-City)
+// inference producer against the same API is unaffected.
+package cityinference
+
+import "errors"
+
+// Frozen operation IDs from operation_matrix_v6. They are spelled here so a
+// reader can check this adapter's surface against the frozen matrix without
+// leaving the package, and so the client seam cannot quietly grow a route that
+// is not in the matrix.
+const (
+	OpCreateInference = "createInference"
+	OpListInferences  = "listInferences"
+	OpGetInference    = "getInference"
+)
+
+// KindInference is the resource kind in the server's idempotency namespace. A
+// key minted for an inference may not be replayed into a run, a session or a
+// transcript record, so the kind is part of the key preimage.
+const KindInference = "inference"
+
+// Bounds mirroring the server's validators, so an oversized field is refused
+// here with a source field name attached rather than as a correlated 4xx.
+const maxNativeIDLen = 200
+
+// Refusals. Every one of them stops this producer with its checkpoint intact:
+// nothing has advanced past the last acknowledged record, so an operator who
+// fixes the source can restart and resume rather than reconcile.
+var (
+	// ErrChangedReplay is an invocation whose stable source identity was
+	// already acknowledged but whose payload no longer matches. Sending it
+	// would ask the server to rewrite accepted input, so the adapter stops.
+	ErrChangedReplay = errors.New("cityinference: source identity replayed with changed payload")
+
+	// ErrHeuristicFold is an offered correlation that rests on anything but an
+	// exact identity tuple. It is a refusal rather than a false answer: a
+	// producer that asked "do these two match on timestamp?" has already made
+	// the category error, and answering the question at all would let the next
+	// caller treat a near-miss as evidence.
+	ErrHeuristicFold = errors.New("cityinference: fold may rest only on an exact identity tuple")
+
+	// ErrSyntheticLinkage is an offered ordinal or step reference. This domain
+	// asserts no order and has no step concept; the honest expression is
+	// coverage class unavailable, never a fabricated link.
+	ErrSyntheticLinkage = errors.New("cityinference: synthesized ordering or step linkage is inadmissible")
+
+	// ErrAttemptRow is an upstream request ID in the err_ class. Those rows are
+	// failed attempts that never produced a metered invocation; admitting one
+	// would let an attempt stand as a call in every sum built over this domain.
+	ErrAttemptRow = errors.New("cityinference: attempt row is not an invocation")
+
+	// ErrContentLeak is outbound bytes carrying prompt, completion, transcript
+	// text or a raw provider payload. Content lives behind transcript and
+	// artifact content authorization and never rides an inference record.
+	ErrContentLeak = errors.New("cityinference: outbound payload carries model content")
+
+	// ErrCredentialLeak is outbound bytes carrying credential evidence. Key
+	// identifiers are attribution tags at most, and never leave this process.
+	ErrCredentialLeak = errors.New("cityinference: outbound payload carries credential evidence")
+
+	// ErrNotFound is any canonical link this tenant cannot resolve. Foreign,
+	// absent, wrong-kind and container-mismatched links all land here with the
+	// same text on purpose: a caller that could tell them apart would have an
+	// existence oracle over another tenant's records.
+	ErrNotFound = errors.New("cityinference: linked record not found")
+
+	// ErrIdentityDrift is a response binding a derived inference identity to a
+	// different neutral Team ID than the checkpoint holds. That is either a
+	// wrong-tenant credential or an undeclared reset; both are louder than a
+	// retry.
+	ErrIdentityDrift = errors.New("cityinference: derived identity resolved to a different neutral id")
+
+	// ErrCoverageRaised is an accepted record whose coverage claims more than
+	// this adapter offered. Coverage is server-derived and immutable, but a
+	// producer that let a raised claim through would be lending its own name to
+	// a completeness assertion it cannot support.
+	ErrCoverageRaised = errors.New("cityinference: accepted coverage claims more than was offered")
+
+	// ErrInvalidInvocation is a City invocation this adapter refuses to map.
+	ErrInvalidInvocation = errors.New("cityinference: invalid City invocation")
+
+	// ErrDisabled is the rollback state: the producer is off and issues no
+	// requests. Acknowledged records and every other producer are unaffected.
+	ErrDisabled = errors.New("cityinference: producer disabled")
+)

--- a/pkg/cityinference/contract.go
+++ b/pkg/cityinference/contract.go
@@ -1,0 +1,273 @@
+package cityinference
+
+import (
+	"context"
+	"time"
+)
+
+// Outcome is the closed normalized outcome vocabulary of an invocation. City
+// may not invent one: the canonical contract has no raw passthrough, so an
+// unmappable City state lands on OutcomeUnknown rather than being echoed
+// through.
+type Outcome string
+
+// The closed outcome vocabulary.
+const (
+	OutcomeOK        Outcome = "ok"
+	OutcomeError     Outcome = "error"
+	OutcomeCancelled Outcome = "cancelled" //nolint:misspell // frozen wire value of the neutral contract
+	OutcomeUnknown   Outcome = "unknown"
+)
+
+// Coverage is a source's claim about how complete one field group is. The
+// vocabulary is the server's closed set, spelled in full because it is a wire
+// vocabulary. This adapter never sends a coverage value — coverage is
+// server-derived and immutable after admission — but it predicts one so a test
+// and an operator can check what was claimed on City's behalf.
+type Coverage string
+
+// The closed coverage vocabulary.
+const (
+	CoverageKnown         Coverage = "known"
+	CoverageUnavailable   Coverage = "unavailable"
+	CoveragePartial       Coverage = "partial"
+	CoverageMetered       Coverage = "metered"
+	CoverageEstimated     Coverage = "estimated"
+	CoverageLegacyUnknown Coverage = "legacy_unknown"
+)
+
+// The closed coverage field-group key set. Every one of these keys appears on
+// every admitted inference: a missing key is a schema violation, not an
+// implicit "unavailable", because silence is what coverage exists to abolish.
+const (
+	FieldGroupTokens     = "usage.tokens"
+	FieldGroupCost       = "usage.cost"
+	FieldGroupSavings    = "usage.savings"
+	FieldGroupStep       = "attribution.step"
+	FieldGroupTranscript = "attribution.transcript_record"
+	FieldGroupOutcome    = "outcome"
+)
+
+// CoverageFieldGroups returns the closed key set in a stable order.
+func CoverageFieldGroups() []string {
+	return []string{
+		FieldGroupTokens, FieldGroupCost, FieldGroupSavings,
+		FieldGroupStep, FieldGroupTranscript, FieldGroupOutcome,
+	}
+}
+
+// IdentityScope says whether a derived identity rests on a provider-assigned
+// request ID or on a locally generated one.
+type IdentityScope string
+
+const (
+	// ScopeInvocation means the upstream request ID is provider-assigned, so
+	// the triplet names the invocation itself and an exact-tuple match is a
+	// genuine duplicate.
+	ScopeInvocation IdentityScope = "invocation"
+	// ScopeObservation means the upstream request ID was generated locally.
+	// Two such IDs for the same real call never converge, so the record
+	// identifies our observation of an invocation and not the invocation.
+	// Fold-ineligible by construction.
+	ScopeObservation IdentityScope = "observation"
+)
+
+// NativeIdentity is the composite that is the only durable native identity of a
+// model invocation. All three components are REQUIRED members; SessionID MAY be
+// the empty string, which is a legal legacy value and not a null.
+type NativeIdentity struct {
+	// Kind pins the derivation. It names the triplet SHAPE, not the producer:
+	// the server admits exactly one shape, so a City-flavored kind would be a
+	// schema the contract rejects, not a courtesy.
+	Kind          string `json:"kind"`
+	Tenant        string `json:"tenant"`
+	SessionID     string `json:"session_id"`
+	UpstreamReqID string `json:"upstream_req_id"`
+}
+
+// NativeIdentityKind is the one admitted triplet shape.
+const NativeIdentityKind = "manifold.triplet.v1"
+
+// UsageObservation is one contribution's usage figures with their provenance.
+//
+// Token counts are what the party that did the work counted. Cost and savings
+// are what a price table computed afterwards. They are separate members because
+// they are separate field groups with separate classes, and "estimated is
+// weaker than metered" is only a sound statement about the same quantity.
+type UsageObservation struct {
+	InputTokens       *uint64 `json:"input_tokens,omitempty"`
+	OutputTokens      *uint64 `json:"output_tokens,omitempty"`
+	CachedInputTokens *uint64 `json:"cached_input_tokens,omitempty"`
+
+	// CostMicros is derived money: metered tokens times an approximate price
+	// table. It is an estimate OF billing, never a billed figure, and it never
+	// reaches a read path.
+	CostMicros *uint64 `json:"cost_micros,omitempty"`
+	// SavedInputTokens and SavedCostMicros are an explicit upper bound that is
+	// never billed. Their own field group keeps them from being summed into
+	// cost.
+	SavedInputTokens *uint64 `json:"saved_input_tokens,omitempty"`
+	SavedCostMicros  *uint64 `json:"saved_cost_micros,omitempty"`
+}
+
+func (u *UsageObservation) metered() bool {
+	return u != nil && (u.InputTokens != nil || u.OutputTokens != nil || u.CachedInputTokens != nil)
+}
+
+// CreateInferenceRequest is the request body of createInference.
+//
+// Ordinal and SourceStepRef are present as explicitly refused members rather
+// than absent from the struct, mirroring the server. That is deliberate on both
+// sides: a caller that hand-builds a request and sets one gets the specific
+// reason code from [Preflight] with zero bytes on the wire, instead of learning
+// from a correlated 422 that it maybe mistyped a field.
+type CreateInferenceRequest struct {
+	NativeIdentity NativeIdentity `json:"native_identity"`
+
+	// ExternalInferenceID is optional and, when present, must equal the
+	// server's own derivation. It is a checksum this adapter offers, never a
+	// choice it makes.
+	ExternalInferenceID string `json:"external_inference_id,omitempty"`
+
+	Provider string  `json:"provider"`
+	Model    string  `json:"model"`
+	Outcome  Outcome `json:"outcome"`
+
+	StartedAt time.Time  `json:"started_at"`
+	EndedAt   *time.Time `json:"ended_at,omitempty"`
+
+	Epoch uint64 `json:"epoch,omitempty"`
+
+	// SessionTeamID and RunTeamID are the canonical containers, always
+	// server-minted Team IDs read back from a prior upsert. A City-native
+	// session or run ID here is a not-found, not a shortcut.
+	SessionTeamID string `json:"session_id,omitempty"`
+	RunTeamID     string `json:"run_id,omitempty"`
+
+	// TranscriptRecordID is the OPTIONAL canonical transcript-record Team ID.
+	// A provider message locator offered here is a not-found in exactly the
+	// same shape as a foreign record.
+	TranscriptRecordID string `json:"transcript_record_id,omitempty"`
+
+	// ObservationID discriminates two honest observations of the SAME
+	// invocation. It is part of the contribution's identity and never of the
+	// inference's, which is what lets a metered and an estimated observation
+	// stand as two contributions on one inference without either being read as
+	// a payload divergence of the other.
+	ObservationID string `json:"observation_id,omitempty"`
+
+	Usage *UsageObservation `json:"usage,omitempty"`
+
+	// Ordinal is refused: this domain asserts no order, so offering one is
+	// synthesis.
+	Ordinal *uint64 `json:"ordinal,omitempty"`
+	// SourceStepRef is refused: no step concept exists at the source, so the
+	// honest expression is coverage class unavailable, not a synthesized link.
+	SourceStepRef string `json:"source_step_ref,omitempty"`
+}
+
+// TokenUsage is a folded metered count. Nil rather than zero when nothing was
+// metered: a 0 means "counted zero", never "we have no number".
+type TokenUsage struct {
+	InputTokens       uint64 `json:"input_tokens"`
+	OutputTokens      uint64 `json:"output_tokens"`
+	CachedInputTokens uint64 `json:"cached_input_tokens"`
+}
+
+// Contribution is one observation's provenance as a read returns it. It carries
+// no monetary figure, because neither read scope in the frozen matrix is a
+// billing-sensitive scope.
+type Contribution struct {
+	ID            string            `json:"id"`
+	ObservationID string            `json:"observation_id"`
+	SourceID      string            `json:"source_id"`
+	SourceKind    string            `json:"source_kind"`
+	UploadedBy    string            `json:"uploaded_by"`
+	UploaderType  string            `json:"uploader_type"`
+	ObservedAt    time.Time         `json:"observed_at"`
+	IngestedAt    time.Time         `json:"ingested_at"`
+	Coverage      map[string]string `json:"coverage"`
+	TokenUsage    *TokenUsage       `json:"token_usage"`
+}
+
+// Inference is the closed neutral inference as a read returns it. ID is the
+// server-minted Team ID and ExternalInferenceID is the derived handle over the
+// native triplet; both are present so a caller can tell them apart, and this
+// adapter treats both as read-only fact.
+type Inference struct {
+	ID                  string `json:"id"`
+	ExternalInferenceID string `json:"external_inference_id"`
+	SourceID            string `json:"source_id"`
+	SourceKind          string `json:"source_kind"`
+
+	SessionID          string `json:"session_id"`
+	RunID              string `json:"run_id"`
+	TranscriptRecordID string `json:"transcript_record_id"`
+
+	Provider string  `json:"provider"`
+	Model    string  `json:"model"`
+	Outcome  Outcome `json:"outcome"`
+
+	StartedAt  time.Time  `json:"started_at"`
+	EndedAt    *time.Time `json:"ended_at"`
+	IngestedAt time.Time  `json:"ingested_at"`
+	Epoch      uint64     `json:"epoch"`
+
+	// IdentityScope and FoldEligible are on the wire because a consumer that
+	// sums this domain has to know which rows may be deduplicated and which may
+	// not. A locally generated row that silently looked foldable is how a
+	// double count becomes invisible.
+	IdentityScope IdentityScope `json:"identity_scope"`
+	FoldEligible  bool          `json:"fold_eligible"`
+
+	TokenUsage    *TokenUsage       `json:"token_usage"`
+	Coverage      map[string]string `json:"coverage"`
+	Contributions []Contribution    `json:"contributions"`
+
+	// Completeness is always unavailable over a best-effort producer. It is a
+	// member rather than an omission because "we do not know whether we
+	// received every record" is a claim this API must make out loud.
+	Completeness string `json:"completeness"`
+
+	ETag string `json:"etag"`
+}
+
+// ListFilter is the ratified filter surface of listInferences: exactly the
+// frozen operation's two parameters. There is no model, vendor or cost
+// dimension, because a filter surface is the easiest place for a forbidden
+// similarity comparator to grow back.
+type ListFilter struct {
+	SourceID     string
+	StartedAfter time.Time
+	Cursor       string
+	Limit        int
+}
+
+// Page is one page of listInferences.
+type Page struct {
+	Items      []Inference `json:"items"`
+	NextCursor string      `json:"next_cursor"`
+}
+
+// API is the seam onto the public v1 client.
+//
+// It carries exactly the three frozen inference operations and no transport
+// vocabulary at all — no base URL, no header, no status code. That is what
+// keeps this package from hand-rolling HTTP: the concrete implementation is the
+// generated public client for the canonical contract, and everything below is
+// written against these signatures.
+//
+// NOTE: the contract program generates a public TypeScript client and a
+// server-side Go interface; there is no generated Go *client* module a Go
+// producer can import today. This interface is the shape that client binds to,
+// method-for-method, so binding it is a wiring change and never a logic change.
+//
+// The idempotency key is a caller-supplied argument rather than something an
+// implementation invents, because the key is part of THIS package's dedup
+// contract: [Producer] derives it from stable source identity so that a retry
+// replays and a changed payload conflicts.
+type API interface {
+	CreateInference(ctx context.Context, body CreateInferenceRequest, idempotencyKey string) (Inference, error)
+	ListInferences(ctx context.Context, filter ListFilter) (Page, error)
+	GetInference(ctx context.Context, inferenceTeamID string) (Inference, error)
+}

--- a/pkg/cityinference/coverage_test.go
+++ b/pkg/cityinference/coverage_test.go
@@ -1,0 +1,172 @@
+package cityinference
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// AC1 fixture: a City invocation with transcript-level attribution and no
+// proven step. The record links the authorized canonical chain and says "step
+// unavailable" out loud, with no synthetic identity and no inline content.
+func TestCoverageFixtureTranscriptLevelAttribution(t *testing.T) {
+	m := testMapper()
+	inv := CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Provider: "anthropic", Model: "m-1", Status: "succeeded",
+		Started:            mustTime(t, "2026-07-30T10:00:00Z"),
+		RunTeamID:          "run_1",
+		SessionTeamID:      "ses_1",
+		TranscriptRecordID: "trc_1",
+		Usage:              &UsageObservation{InputTokens: ptr(120), OutputTokens: ptr(30), CostMicros: ptr(4500)},
+	}
+	want := map[string]Coverage{
+		FieldGroupTokens:     CoverageMetered,
+		FieldGroupCost:       CoverageEstimated,
+		FieldGroupSavings:    CoverageUnavailable,
+		FieldGroupStep:       CoverageUnavailable,
+		FieldGroupTranscript: CoverageKnown,
+		FieldGroupOutcome:    CoverageKnown,
+	}
+	got := m.ExpectedCoverage(inv)
+	if len(got) != len(CoverageFieldGroups()) {
+		t.Fatalf("coverage must carry every field group, got %d", len(got))
+	}
+	for group, class := range want {
+		if got[group] != class {
+			t.Fatalf("%s: want %s, got %s", group, class, got[group])
+		}
+	}
+
+	req, err := m.MapInvocation(inv)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if req.SourceStepRef != "" || req.Ordinal != nil {
+		t.Fatal("mapping produced a step or an ordinal")
+	}
+	if req.RunTeamID != "run_1" || req.SessionTeamID != "ses_1" || req.TranscriptRecordID != "trc_1" {
+		t.Fatalf("canonical links were rewritten: %+v", req)
+	}
+}
+
+// Step coverage is unavailable for every shape of input this adapter can hold.
+// There is no City field, provider locator or timestamp that turns it into
+// anything else, which is the structural half of "never synthesize a step".
+func TestStepCoverageIsUnavailableForEveryInput(t *testing.T) {
+	m := testMapper()
+	for _, inv := range []CityInvocation{
+		{SessionNativeID: "sess-1", UpstreamReqID: "req-1"},
+		{SessionNativeID: "", UpstreamReqID: "req-1"},
+		{SessionNativeID: "sess-1", UpstreamReqID: "gen_1", TranscriptRecordID: "trc_1"},
+		{
+			SessionNativeID: "sess-1", UpstreamReqID: "req-1", RunTeamID: "run_1", SessionTeamID: "ses_1",
+			Usage: &UsageObservation{InputTokens: ptr(1), CostMicros: ptr(1), SavedInputTokens: ptr(1)},
+		},
+	} {
+		if got := m.ExpectedCoverage(inv)[FieldGroupStep]; got != CoverageUnavailable {
+			t.Fatalf("step coverage %s for %+v", got, inv)
+		}
+	}
+}
+
+// A legacy-shaped row's absent groups are legacy_unknown, never unavailable:
+// collapsing the two would let an unexplained blank pass as a structural
+// absence. Step stays unavailable, because that absence really is structural.
+func TestLegacyRowClassifiesAbsenceAsLegacyUnknown(t *testing.T) {
+	m := testMapper()
+	got := m.ExpectedCoverage(CityInvocation{UpstreamReqID: "req-1"})
+	for _, group := range []string{FieldGroupTokens, FieldGroupCost, FieldGroupSavings} {
+		if got[group] != CoverageLegacyUnknown {
+			t.Fatalf("%s: want legacy_unknown, got %s", group, got[group])
+		}
+	}
+	if got[FieldGroupStep] != CoverageUnavailable {
+		t.Fatalf("step: want unavailable, got %s", got[FieldGroupStep])
+	}
+}
+
+// Provider-asserted is not verified and derived cost is not billed: token
+// counts classify metered, cost and savings classify estimated, and savings sit
+// in their own group so nothing sums them into cost.
+func TestMeteredAndEstimatedStaySeparateGroups(t *testing.T) {
+	m := testMapper()
+	got := m.ExpectedCoverage(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Usage: &UsageObservation{InputTokens: ptr(10), CostMicros: ptr(99), SavedInputTokens: ptr(5), SavedCostMicros: ptr(7)},
+	})
+	if got[FieldGroupTokens] != CoverageMetered {
+		t.Fatalf("tokens: want metered, got %s", got[FieldGroupTokens])
+	}
+	if got[FieldGroupCost] != CoverageEstimated || got[FieldGroupSavings] != CoverageEstimated {
+		t.Fatalf("derived money must be estimated: %+v", got)
+	}
+
+	// Savings alone never make tokens metered — an upper bound is not a count.
+	savingsOnly := m.ExpectedCoverage(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Usage: &UsageObservation{SavedInputTokens: ptr(5)},
+	})
+	if savingsOnly[FieldGroupTokens] != CoverageUnavailable {
+		t.Fatalf("savings raised the token class to %s", savingsOnly[FieldGroupTokens])
+	}
+}
+
+// A server response that claims a step, a transcript link we never offered, or
+// a completeness better than unavailable is refused. The producer is lending
+// its name to these claims, so it checks them rather than trusting them.
+func TestProducerRefusesRaisedCoverage(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		mutil func(*Inference)
+	}{
+		{"step claimed known", func(in *Inference) { in.Coverage[FieldGroupStep] = string(CoverageKnown) }},
+		{"transcript claimed known", func(in *Inference) { in.Coverage[FieldGroupTranscript] = string(CoverageKnown) }},
+		{"field group omitted", func(in *Inference) { delete(in.Coverage, FieldGroupOutcome) }},
+		{"completeness claimed known", func(in *Inference) { in.Completeness = string(CoverageKnown) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Producer{Mapper: testMapper()}
+			req := CreateInferenceRequest{
+				NativeIdentity:      NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "s", UpstreamReqID: "req-1"},
+				ExternalInferenceID: mustDerive(t, NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "s", UpstreamReqID: "req-1"}),
+			}
+			got := Inference{
+				ID: "inf_1", ExternalInferenceID: req.ExternalInferenceID,
+				Completeness: string(CoverageUnavailable),
+				Coverage: map[string]string{
+					FieldGroupTokens: string(CoverageMetered), FieldGroupCost: string(CoverageEstimated),
+					FieldGroupSavings: string(CoverageUnavailable), FieldGroupStep: string(CoverageUnavailable),
+					FieldGroupTranscript: string(CoverageUnavailable), FieldGroupOutcome: string(CoverageKnown),
+				},
+				FoldEligible: true,
+			}
+			tc.mutil(&got)
+			if err := p.verify(req, got); !errors.Is(err, ErrCoverageRaised) {
+				t.Fatalf("want ErrCoverageRaised, got %v", err)
+			}
+		})
+	}
+}
+
+// Completeness over a best-effort producer is always unavailable, and the
+// accepted record says so.
+func TestAcceptedRecordReportsCompletenessUnavailable(t *testing.T) {
+	api, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	page, err := api.ListInferences(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("want 1 inference, got %d", len(page.Items))
+	}
+	if page.Items[0].Completeness != string(CoverageUnavailable) {
+		t.Fatalf("completeness %q", page.Items[0].Completeness)
+	}
+	if page.Items[0].Coverage[FieldGroupStep] != string(CoverageUnavailable) {
+		t.Fatalf("step coverage %q", page.Items[0].Coverage[FieldGroupStep])
+	}
+}

--- a/pkg/cityinference/fake.go
+++ b/pkg/cityinference/fake.go
@@ -1,0 +1,328 @@
+package cityinference
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+// FakeWorkspace is one tenant's canonical records inside a [FakeAPI].
+type FakeWorkspace struct {
+	Runs     map[string]bool
+	Sessions map[string]string // session Team ID -> run Team ID
+	Records  map[string]string // transcript record Team ID -> session Team ID
+}
+
+// NewFakeWorkspace returns an empty workspace.
+func NewFakeWorkspace() *FakeWorkspace {
+	return &FakeWorkspace{Runs: map[string]bool{}, Sessions: map[string]string{}, Records: map[string]string{}}
+}
+
+// AddChain registers a run, a session under it and an optional transcript
+// record under the session, all as server-minted Team IDs.
+func (w *FakeWorkspace) AddChain(runID, sessionID, recordID string) {
+	w.Runs[runID] = true
+	w.Sessions[sessionID] = runID
+	if recordID != "" {
+		w.Records[recordID] = sessionID
+	}
+}
+
+// RecordedRequest is one outbound call as a transport spy saw it. Body holds
+// the exact bytes, which is what lets a scanner assert on what left rather than
+// on what a struct says should have left.
+type RecordedRequest struct {
+	OperationID    string
+	IdempotencyKey string
+	Body           []byte
+}
+
+// FakeAPI is an in-process stand-in for the public v1 client with two tenants
+// and a request spy.
+//
+// Its refusals are the ones that matter for a producer: a link the caller's
+// tenant does not own is a not-found with the same text a never-created link
+// gets, so a caller cannot use this API as an existence oracle over the other
+// tenant.
+type FakeAPI struct {
+	mu sync.Mutex
+
+	// Tenant is whose credential the calls arrive on.
+	Tenant string
+	// Credential is the bearer identity. It is deliberately never read: a
+	// rotation must change nothing about identity, idempotency or admission.
+	Credential string
+
+	Workspaces map[string]*FakeWorkspace
+
+	// Requests is the spy. Every attempt is recorded, including ones that fail,
+	// so a test can assert that a refusal issued no write.
+	Requests []RecordedRequest
+
+	// FailNext, when set, fails the next create before any admission and is
+	// then cleared. It models a transport fault mid-batch.
+	FailNext error
+
+	replay     map[string]Inference
+	inferences map[string]*Inference
+	seq        int
+}
+
+// NewFakeAPI returns a fake bound to one tenant.
+func NewFakeAPI(tenant string, workspaces map[string]*FakeWorkspace) *FakeAPI {
+	return &FakeAPI{
+		Tenant:     tenant,
+		Workspaces: workspaces,
+		replay:     map[string]Inference{},
+		inferences: map[string]*Inference{},
+	}
+}
+
+// ErrConflict is the fake's payload-divergence refusal: an exact-tuple match
+// whose invariant core disagrees with the admitted record.
+var ErrConflict = errors.New("cityinference: offered record diverges from the admitted record")
+
+// CreateInference implements [API].
+func (f *FakeAPI) CreateInference(_ context.Context, body CreateInferenceRequest, idempotencyKey string) (Inference, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return Inference{}, err
+	}
+	f.Requests = append(f.Requests, RecordedRequest{
+		OperationID: OpCreateInference, IdempotencyKey: idempotencyKey, Body: raw,
+	})
+
+	if f.FailNext != nil {
+		err := f.FailNext
+		f.FailNext = nil
+		return Inference{}, err
+	}
+	if prior, ok := f.replay[idempotencyKey]; ok {
+		return prior, nil
+	}
+
+	ws := f.Workspaces[f.Tenant]
+	if ws == nil {
+		return Inference{}, ErrNotFound
+	}
+	// Foreign, absent, wrong-kind and mismatched links are one answer. The
+	// checks are ordered so no branch can leak which of the four it was.
+	if body.RunTeamID != "" && !ws.Runs[body.RunTeamID] {
+		return Inference{}, ErrNotFound
+	}
+	if body.SessionTeamID != "" {
+		run, ok := ws.Sessions[body.SessionTeamID]
+		if !ok || (body.RunTeamID != "" && run != body.RunTeamID) {
+			return Inference{}, ErrNotFound
+		}
+	}
+	if body.TranscriptRecordID != "" {
+		session, ok := ws.Records[body.TranscriptRecordID]
+		if !ok || (body.SessionTeamID != "" && session != body.SessionTeamID) {
+			return Inference{}, ErrNotFound
+		}
+	}
+
+	derived, err := DeriveExternalInferenceID(body.NativeIdentity)
+	if err != nil {
+		return Inference{}, err
+	}
+	if body.ExternalInferenceID != "" && body.ExternalInferenceID != derived {
+		return Inference{}, fmt.Errorf("cityinference: offered external_inference_id is not the derivation")
+	}
+	if body.Ordinal != nil || body.SourceStepRef != "" {
+		return Inference{}, ErrSyntheticLinkage
+	}
+	scope, err := ClassifyReqID(body.NativeIdentity.UpstreamReqID)
+	if err != nil {
+		return Inference{}, err
+	}
+
+	mapper := Mapper{Source: Source{Tenant: body.NativeIdentity.Tenant}}
+	inv := CityInvocation{
+		SessionNativeID:    body.NativeIdentity.SessionID,
+		TranscriptRecordID: body.TranscriptRecordID,
+		Usage:              body.Usage,
+	}
+	coverage := map[string]string{}
+	for group, class := range mapper.ExpectedCoverage(inv) {
+		coverage[group] = string(class)
+	}
+
+	observation := body.ObservationID
+	if observation == "" {
+		observation = "primary"
+	}
+	contribution := Contribution{
+		ID:            derived + ":" + observation,
+		ObservationID: observation,
+		SourceKind:    "city",
+		UploadedBy:    f.Tenant,
+		UploaderType:  "workspace_token",
+		ObservedAt:    body.StartedAt,
+		IngestedAt:    body.StartedAt,
+		Coverage:      coverage,
+	}
+	if body.Usage.metered() {
+		contribution.TokenUsage = &TokenUsage{
+			InputTokens:       deref(body.Usage.InputTokens),
+			OutputTokens:      deref(body.Usage.OutputTokens),
+			CachedInputTokens: deref(body.Usage.CachedInputTokens),
+		}
+	}
+
+	if existing, ok := f.inferences[derived]; ok {
+		if existing.Provider != body.Provider || existing.Model != body.Model ||
+			existing.Outcome != body.Outcome || existing.RunID != body.RunTeamID ||
+			existing.SessionID != body.SessionTeamID || existing.TranscriptRecordID != body.TranscriptRecordID {
+			return Inference{}, ErrConflict
+		}
+		for _, c := range existing.Contributions {
+			if c.ObservationID == observation {
+				// Same observation of the same call: a duplicate, not an
+				// addition. The response is the admitted record unchanged.
+				out := *existing
+				f.replay[idempotencyKey] = out
+				return out, nil
+			}
+		}
+		existing.Contributions = append(existing.Contributions, contribution)
+		existing.Coverage = foldCoverage(existing.Contributions)
+		existing.TokenUsage = foldTokens(existing.Contributions, existing.FoldEligible)
+		out := *existing
+		f.replay[idempotencyKey] = out
+		return out, nil
+	}
+
+	f.seq++
+	rec := &Inference{
+		ID:                  "inf_" + strconv.Itoa(f.seq),
+		ExternalInferenceID: derived,
+		SourceID:            "src_" + f.Tenant,
+		SourceKind:          "city",
+		SessionID:           body.SessionTeamID,
+		RunID:               body.RunTeamID,
+		TranscriptRecordID:  body.TranscriptRecordID,
+		Provider:            body.Provider,
+		Model:               body.Model,
+		Outcome:             body.Outcome,
+		StartedAt:           body.StartedAt,
+		EndedAt:             body.EndedAt,
+		IngestedAt:          body.StartedAt,
+		Epoch:               body.Epoch,
+		IdentityScope:       scope,
+		FoldEligible:        scope == ScopeInvocation,
+		Contributions:       []Contribution{contribution},
+		Completeness:        string(CoverageUnavailable),
+		ETag:                "W/\"" + derived + "\"",
+	}
+	rec.Coverage = foldCoverage(rec.Contributions)
+	rec.TokenUsage = foldTokens(rec.Contributions, rec.FoldEligible)
+	f.inferences[derived] = rec
+	out := *rec
+	f.replay[idempotencyKey] = out
+	return out, nil
+}
+
+// ListInferences implements [API].
+func (f *FakeAPI) ListInferences(_ context.Context, filter ListFilter) (Page, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Requests = append(f.Requests, RecordedRequest{OperationID: OpListInferences})
+	var out []Inference
+	for _, rec := range f.inferences {
+		if filter.SourceID != "" && rec.SourceID != filter.SourceID {
+			continue
+		}
+		if !filter.StartedAfter.IsZero() && !rec.StartedAt.After(filter.StartedAfter) {
+			continue
+		}
+		out = append(out, *rec)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].StartedAt.Equal(out[j].StartedAt) {
+			return out[i].StartedAt.After(out[j].StartedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return Page{Items: out}, nil
+}
+
+// GetInference implements [API].
+func (f *FakeAPI) GetInference(_ context.Context, inferenceTeamID string) (Inference, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Requests = append(f.Requests, RecordedRequest{OperationID: OpGetInference})
+	for _, rec := range f.inferences {
+		if rec.ID == inferenceTeamID {
+			return *rec, nil
+		}
+	}
+	return Inference{}, ErrNotFound
+}
+
+// Writes counts the create attempts the spy saw.
+func (f *FakeAPI) Writes() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, r := range f.Requests {
+		if r.OperationID == OpCreateInference {
+			n++
+		}
+	}
+	return n
+}
+
+// foldCoverage takes the WEAKEST class present per field group, never the
+// strongest: an unproven contribution can never raise a folded claim.
+func foldCoverage(contributions []Contribution) map[string]string {
+	out := map[string]string{}
+	for _, group := range CoverageFieldGroups() {
+		weakest := CoverageKnown
+		for _, c := range contributions {
+			class := Coverage(c.Coverage[group])
+			if coverageRank[class] < coverageRank[weakest] {
+				weakest = class
+			}
+		}
+		out[group] = string(weakest)
+	}
+	return out
+}
+
+// foldTokens sums metered counts across fold-eligible contributions only. A
+// fold-ineligible record keeps its single observation and is never summed.
+func foldTokens(contributions []Contribution, foldEligible bool) *TokenUsage {
+	var out *TokenUsage
+	for _, c := range contributions {
+		if c.TokenUsage == nil {
+			continue
+		}
+		if out == nil {
+			out = &TokenUsage{}
+		}
+		if !foldEligible {
+			cp := *c.TokenUsage
+			return &cp
+		}
+		out.InputTokens += c.TokenUsage.InputTokens
+		out.OutputTokens += c.TokenUsage.OutputTokens
+		out.CachedInputTokens += c.TokenUsage.CachedInputTokens
+	}
+	return out
+}
+
+func deref(v *uint64) uint64 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}

--- a/pkg/cityinference/identity_test.go
+++ b/pkg/cityinference/identity_test.go
@@ -1,0 +1,175 @@
+package cityinference
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func ptr(v uint64) *uint64 { return &v }
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return ts
+}
+
+func testSource() Source {
+	return Source{SourceID: "src_city", Kind: "city", Tenant: "org_alpha", Epoch: 7}
+}
+
+func testMapper() Mapper { return Mapper{Source: testSource()} }
+
+func mustDerive(t *testing.T, id NativeIdentity) string {
+	t.Helper()
+	got, err := DeriveExternalInferenceID(id)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	return got
+}
+
+// The identity tuple is exactly (tenant, session_id, upstream_req_id). Nothing
+// else may move the derived ID, and each component moving it alone is what
+// proves the triplet is the whole identity.
+func TestIdentityIsTheTripletAndNothingElse(t *testing.T) {
+	base := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-1"}
+	baseID := mustDerive(t, base)
+
+	for _, tc := range []struct {
+		name string
+		id   NativeIdentity
+	}{
+		{"tenant", NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_beta", SessionID: "sess-1", UpstreamReqID: "req-1"}},
+		{"session", NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-2", UpstreamReqID: "req-1"}},
+		{"req", NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-2"}},
+	} {
+		if got := mustDerive(t, tc.id); got == baseID {
+			t.Fatalf("changing %s left the identity unchanged: %s", tc.name, got)
+		}
+	}
+
+	// A model, a provider and a timestamp are outside the tuple, so two
+	// invocations that differ only in those share one identity.
+	m := testMapper()
+	a := CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic", Model: "m-1", Started: mustTime(t, "2026-07-30T10:00:00Z")}
+	b := a
+	b.Provider, b.Model, b.Started = "openai", "m-2", mustTime(t, "2026-07-30T11:00:00Z")
+	if m.Identity(a) != m.Identity(b) {
+		t.Fatal("model/provider/timestamp leaked into the identity tuple")
+	}
+}
+
+// Length-prefixed framing keeps the preimage injective when a component is
+// empty (the legacy row) or carries a delimiter byte. A naive join does not,
+// and a collision here would silently merge two tenants' invocations.
+func TestDerivationIsInjectiveAcrossEmptyAndDelimiterComponents(t *testing.T) {
+	cases := []NativeIdentity{
+		{Kind: NativeIdentityKind, Tenant: "a", SessionID: "", UpstreamReqID: "bc"},
+		{Kind: NativeIdentityKind, Tenant: "a", SessionID: "b", UpstreamReqID: "c"},
+		{Kind: NativeIdentityKind, Tenant: "ab", SessionID: "", UpstreamReqID: "c"},
+		{Kind: NativeIdentityKind, Tenant: "a:b", SessionID: "c", UpstreamReqID: "d"},
+		{Kind: NativeIdentityKind, Tenant: "a", SessionID: "b:c", UpstreamReqID: "d"},
+	}
+	seen := map[string]NativeIdentity{}
+	for _, id := range cases {
+		got := mustDerive(t, id)
+		if prior, dup := seen[got]; dup {
+			t.Fatalf("collision: %+v and %+v both derive %s", prior, id, got)
+		}
+		seen[got] = id
+	}
+}
+
+// The provider request ID must never become a public identifier, so the derived
+// ID may not contain it in any recoverable form.
+func TestDerivedIDDoesNotCarryTheProviderRequestID(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req_abc123secretish"}
+	got := mustDerive(t, id)
+	if !strings.HasPrefix(got, "mfi1_") {
+		t.Fatalf("unexpected identity shape %q", got)
+	}
+	for _, part := range []string{id.Tenant, id.SessionID, id.UpstreamReqID} {
+		if strings.Contains(got, part) {
+			t.Fatalf("derived id %q leaks component %q", got, part)
+		}
+	}
+}
+
+// The empty session ID is a legal legacy value, not a null. Refusing it would
+// force a producer to invent one, which is the exact synthesis this domain
+// forbids.
+func TestLegacyEmptySessionMapsWithoutSynthesis(t *testing.T) {
+	m := testMapper()
+	req, err := m.MapInvocation(CityInvocation{
+		UpstreamReqID: "req-legacy", Provider: "anthropic", Model: "m-1",
+		Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("legacy invocation refused: %v", err)
+	}
+	if req.NativeIdentity.SessionID != "" {
+		t.Fatalf("legacy session id was synthesized as %q", req.NativeIdentity.SessionID)
+	}
+}
+
+func TestRequestIDPrefixClassification(t *testing.T) {
+	for _, tc := range []struct {
+		reqID string
+		scope IdentityScope
+		err   error
+	}{
+		{"req-provider-1", ScopeInvocation, nil},
+		{"gen_9f2a", ScopeObservation, nil},
+		{"err_timeout", "", ErrAttemptRow},
+		{"", "", ErrInvalidInvocation},
+	} {
+		scope, err := ClassifyReqID(tc.reqID)
+		if tc.err != nil {
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("%q: want %v, got %v", tc.reqID, tc.err, err)
+			}
+			continue
+		}
+		if err != nil || scope != tc.scope {
+			t.Fatalf("%q: want %s, got %s (%v)", tc.reqID, tc.scope, scope, err)
+		}
+	}
+}
+
+// The tenant is enrollment data. A City-side field may not redirect a record
+// into another tenant's identity space, so the mapper reads it from the source
+// and there is no invocation field that could override it.
+func TestTenantComesFromEnrollmentNotFromTheInvocation(t *testing.T) {
+	m := testMapper()
+	req, err := m.MapInvocation(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+		Model: "m-1", Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if req.NativeIdentity.Tenant != testSource().Tenant {
+		t.Fatalf("tenant %q is not the enrolled tenant", req.NativeIdentity.Tenant)
+	}
+}
+
+// The offered external ID is a checksum, never a choice.
+func TestPreflightRejectsAChosenExternalID(t *testing.T) {
+	m := testMapper()
+	req, err := m.MapInvocation(CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+		Model: "m-1", Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	req.ExternalInferenceID = "mfi1_notthederivation"
+	if err := Preflight(req); !errors.Is(err, ErrInvalidInvocation) {
+		t.Fatalf("want ErrInvalidInvocation, got %v", err)
+	}
+}

--- a/pkg/cityinference/isolation_test.go
+++ b/pkg/cityinference/isolation_test.go
@@ -1,0 +1,193 @@
+package cityinference
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// AC3 core: a foreign link and an absent link are the same answer. If they were
+// not, this adapter would be an existence oracle over the other tenant's
+// records, and the two-tenant spy is how that is proven rather than asserted.
+func TestForeignAndAbsentLinksAreIndistinguishable(t *testing.T) {
+	foreign := happyInvocation(t)
+	foreign.TranscriptRecordID = "trc_beta" // real, but owned by the other tenant
+	foreign.UpstreamReqID = "req-foreign"
+
+	absent := happyInvocation(t)
+	absent.TranscriptRecordID = "trc_never_created"
+	absent.UpstreamReqID = "req-absent"
+
+	mismatched := happyInvocation(t)
+	mismatched.SessionTeamID = "ses_2" // same tenant, wrong container for trc_1
+	mismatched.RunTeamID = "run_2"
+	mismatched.UpstreamReqID = "req-mismatch"
+
+	incompatible := happyInvocation(t)
+	incompatible.TranscriptRecordID = "run_1" // a real ID of the wrong kind
+	incompatible.UpstreamReqID = "req-wrongkind"
+
+	var messages []string
+	for _, inv := range []CityInvocation{foreign, absent, mismatched, incompatible} {
+		api, p := newHarness(t)
+		_, err := p.Push(context.Background(), []CityInvocation{inv})
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("%s: want ErrNotFound, got %v", inv.UpstreamReqID, err)
+		}
+		messages = append(messages, err.Error())
+		page, listErr := api.ListInferences(context.Background(), ListFilter{})
+		if listErr != nil {
+			t.Fatalf("list: %v", listErr)
+		}
+		if len(page.Items) != 0 {
+			t.Fatalf("%s: an invalid link still wrote a record", inv.UpstreamReqID)
+		}
+	}
+	for _, msg := range messages[1:] {
+		if msg != messages[0] {
+			t.Fatalf("refusals are distinguishable: %q vs %q", messages[0], msg)
+		}
+	}
+}
+
+// The valid same-workspace link is the control: the identical shape succeeds
+// when the records really are this tenant's.
+func TestSameWorkspaceLinkSucceeds(t *testing.T) {
+	_, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("valid link refused: %v", err)
+	}
+}
+
+// Content and step linkage cannot enter through the City side at all: there is
+// no field on the invocation that could carry either. This is the structural
+// half of "forbidden content is never sent" — the scanner is the other half,
+// and a drift guard here fails the day someone adds the field.
+func TestCityInvocationCannotCarryContentOrStep(t *testing.T) {
+	forbidden := map[string]bool{
+		"Prompt": true, "Completion": true, "Text": true, "Content": true,
+		"Messages": true, "Transcript": true, "RawResponse": true, "Payload": true,
+		"Step": true, "StepID": true, "SourceStepRef": true, "Ordinal": true,
+	}
+	typ := reflect.TypeOf(CityInvocation{})
+	for i := 0; i < typ.NumField(); i++ {
+		if forbidden[typ.Field(i).Name] {
+			t.Fatalf("CityInvocation grew a forbidden field %q", typ.Field(i).Name)
+		}
+	}
+}
+
+// A refused invocation performs no inference write at all: the refusal happens
+// at this adapter's edge, so the spy sees zero calls rather than a 4xx. What
+// this adapter does send is then scanned byte-for-byte.
+func TestRefusedInvocationIssuesNoWriteAndSentBytesAreClean(t *testing.T) {
+	api, p := newHarness(t)
+	bad := happyInvocation(t)
+	bad.UpstreamReqID = "err_upstream_timeout" // an attempt row, refused before send
+	if _, err := p.Push(context.Background(), []CityInvocation{bad}); !errors.Is(err, ErrAttemptRow) {
+		t.Fatalf("want ErrAttemptRow, got %v", err)
+	}
+	if api.Writes() != 0 {
+		t.Fatalf("refused invocation issued %d writes", api.Writes())
+	}
+
+	// Every byte this adapter did send is scanner-clean: no content, no
+	// credential, no unadmitted field.
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if api.Writes() == 0 {
+		t.Fatal("nothing was recorded to scan")
+	}
+	for i, req := range api.Requests {
+		if req.OperationID != OpCreateInference {
+			continue
+		}
+		if err := ScanForbidden(req.Body); err != nil {
+			t.Fatalf("request %d carried forbidden bytes: %v", i, err)
+		}
+	}
+}
+
+// Only the three frozen operations appear on the wire.
+func TestOnlyFrozenOperationsAreCalled(t *testing.T) {
+	api, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	frozen := map[string]bool{OpCreateInference: true, OpListInferences: true, OpGetInference: true}
+	for _, req := range api.Requests {
+		if !frozen[req.OperationID] {
+			t.Fatalf("unfrozen operation %q", req.OperationID)
+		}
+	}
+}
+
+// Rollback: disabling City inference stops this producer and nothing else.
+// Acknowledged records persist, reads keep working, and a custom (non-City)
+// inference producer on the same API is unaffected.
+func TestDisablingCityInferenceLeavesOtherProducersOperational(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	city, err := NewProducer(api, testMapper(), NewMemoryStore())
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	res, err := city.Push(context.Background(), []CityInvocation{happyInvocation(t)})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	accepted := res.Uploaded[0].InferenceTeamID
+
+	city.Disabled = true
+	writesBefore := api.Writes()
+	next := happyInvocation(t)
+	next.UpstreamReqID = "req-after-rollback"
+	if _, err := city.Push(context.Background(), []CityInvocation{next}); !errors.Is(err, ErrDisabled) {
+		t.Fatalf("want ErrDisabled, got %v", err)
+	}
+	if api.Writes() != writesBefore {
+		t.Fatal("a disabled producer issued a write")
+	}
+	if _, err := api.GetInference(context.Background(), accepted); err != nil {
+		t.Fatalf("acknowledged record did not persist through rollback: %v", err)
+	}
+
+	// A custom orchestrator with no City in the picture uploads the same shape
+	// on its own source identity and is untouched by City's rollback.
+	custom := Mapper{Source: Source{SourceID: "src_custom", Kind: "custom_orchestrator", Tenant: tenantAlpha, Epoch: 3}}
+	other, err := NewProducer(api, custom, NewMemoryStore())
+	if err != nil {
+		t.Fatalf("new custom producer: %v", err)
+	}
+	inv := happyInvocation(t)
+	inv.UpstreamReqID = "req-custom-1"
+	if _, err := other.Push(context.Background(), []CityInvocation{inv}); err != nil {
+		t.Fatalf("custom producer refused after City rollback: %v", err)
+	}
+}
+
+// A second City source for the same deployment is a distinct source identity,
+// so its idempotency keys never collide with the first one's. Silent key reuse
+// across sources is how a structural double count becomes invisible.
+func TestIdempotencyKeyIsScopedToTheSource(t *testing.T) {
+	a := testSource()
+	b := testSource()
+	b.SourceID = "src_city_2"
+	if IdempotencyKey(a, "mfi1_x/primary") == IdempotencyKey(b, "mfi1_x/primary") {
+		t.Fatal("two sources share an idempotency key")
+	}
+	c := testSource()
+	c.Epoch = 8
+	if IdempotencyKey(a, "mfi1_x/primary") == IdempotencyKey(c, "mfi1_x/primary") {
+		t.Fatal("an epoch reset reused the pre-reset key")
+	}
+	if IdempotencyKey(a, "mfi1_x/primary") == IdempotencyKey(a, "mfi1_x/secondary") {
+		t.Fatal("two observations share an idempotency key")
+	}
+	// Stability across a fresh Source value: the preimage holds only enrollment
+	// data, so a redeploy that rebuilds the struct resumes the same key.
+	if IdempotencyKey(testSource(), "mfi1_x/primary") != IdempotencyKey(a, "mfi1_x/primary") {
+		t.Fatal("key derivation is not stable across an equivalent source")
+	}
+}

--- a/pkg/cityinference/mapping.go
+++ b/pkg/cityinference/mapping.go
@@ -1,0 +1,471 @@
+package cityinference
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Source is the enrolled producer identity this adapter uploads under.
+type Source struct {
+	SourceID string
+	// Kind is the source class, e.g. "city". It is in the idempotency preimage
+	// so two producers holding the same native IDs cannot collide.
+	Kind string
+	// Tenant is the enrolled tenant handle in the provider's namespace. It is
+	// the first component of the identity triplet, and it is enrollment data:
+	// an invocation may not carry a different one.
+	Tenant string
+	// Epoch is the frozen ingest epoch. It advances only on a declared reset,
+	// never on a restart and never on a credential rotation, and the adapter
+	// refuses to guess one.
+	Epoch uint64
+}
+
+// CityInvocation is one City model invocation as this adapter reads it.
+//
+// There is no step field, and that absence is the design. The frozen contract
+// admits no step reference for this domain, so a field here would exist only to
+// be dropped silently or fabricated — and the honest expression of a step City
+// cannot prove is coverage class unavailable, which [ExpectedCoverage] reports
+// unconditionally. There is likewise no prompt, completion or message-text
+// field: content lives behind transcript and artifact content authorization.
+type CityInvocation struct {
+	// SessionNativeID is the provider-namespace session identifier. The empty
+	// string is a legal legacy value, not a null, and it is never replaced with
+	// a synthesized one.
+	SessionNativeID string
+	// UpstreamReqID is the provider-assigned request identifier, or a locally
+	// generated gen_ value. An err_ value is an attempt row and is refused.
+	UpstreamReqID string
+
+	Provider string
+	Model    string
+	// Status is City-native and is normalized into the closed outcome
+	// vocabulary; an unmappable status becomes OutcomeUnknown rather than
+	// traveling as itself.
+	Status  string
+	Started time.Time
+	Ended   *time.Time
+
+	// RunTeamID, SessionTeamID and TranscriptRecordID are server-minted Team
+	// IDs this City read back from its own neutral upserts. They are links to
+	// already-authorized canonical records; this adapter produces none of them.
+	RunTeamID          string
+	SessionTeamID      string
+	TranscriptRecordID string
+
+	// ObservationID names WHICH observation of the invocation this is. Two
+	// honest observations of one call (a metered one and an estimated one)
+	// carry different values and stand as two contributions on one inference.
+	ObservationID string
+
+	Usage *UsageObservation
+}
+
+// Mapper turns a City invocation into a neutral request body and refuses any
+// mapping that would let a City fact reach a neutral authority field.
+type Mapper struct {
+	Source Source
+}
+
+// inferenceIDDomain is the preimage domain of the derived external inference ID.
+const inferenceIDDomain = "gascity/inference-id/manifold.triplet.v1"
+
+// inferenceIDAlphabet is lowercase base32 with no padding, matching the server.
+var inferenceIDAlphabet = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+
+// DeriveExternalInferenceID mints the external inference ID from a native
+// triplet. It is byte-for-byte the server's derivation, which is the point:
+// two independent derivers converge with no coordination, and that is what
+// makes an exact-tuple duplicate detectable at all.
+//
+// Two properties are load-bearing and neither is stylistic. The framing is
+// length-prefixed, so the preimage stays injective when a component is empty (a
+// legacy row carries session_id = "") or contains a delimiter byte — a naive
+// join does not. The digest is one-way, because the provider request ID must
+// never become a public identifier and a record identity is by definition
+// visible on a read path.
+func DeriveExternalInferenceID(id NativeIdentity) (string, error) {
+	if id.Kind != NativeIdentityKind {
+		return "", fmt.Errorf("%w: unknown native identity kind %q", ErrInvalidInvocation, id.Kind)
+	}
+	h := sha256.New()
+	h.Write([]byte(inferenceIDDomain))
+	for _, s := range []string{id.Tenant, id.SessionID, id.UpstreamReqID} {
+		h.Write([]byte(strconv.Itoa(len(s))))
+		h.Write([]byte{0x3a})
+		h.Write([]byte(s))
+	}
+	return "mfi1_" + inferenceIDAlphabet.EncodeToString(h.Sum(nil)[:20]), nil
+}
+
+// Prefix classes of an upstream request ID.
+const (
+	reqIDPrefixError     = "err_"
+	reqIDPrefixGenerated = "gen_"
+)
+
+// ClassifyReqID decides identity scope from the request-id prefix, and refuses
+// the one prefix that is not an inference at all.
+//
+// err_ rows are attempt rows: a request that never produced a metered
+// invocation. Admitting one would let a failed attempt stand as a call in every
+// sum built over this domain, so it is a categorical reject rather than a
+// zero-usage record.
+func ClassifyReqID(reqID string) (IdentityScope, error) {
+	switch {
+	case reqID == "":
+		return "", fmt.Errorf("%w: upstream_req_id is required", ErrInvalidInvocation)
+	case strings.HasPrefix(reqID, reqIDPrefixError):
+		return "", fmt.Errorf("%w: %s rows never produced a metered invocation", ErrAttemptRow, reqIDPrefixError)
+	case strings.HasPrefix(reqID, reqIDPrefixGenerated):
+		return ScopeObservation, nil
+	}
+	return ScopeInvocation, nil
+}
+
+// Identity returns the native triplet of one invocation under this mapper's
+// enrolled tenant. The tenant comes from enrollment and never from the
+// invocation, so a City-side field cannot redirect a record into another
+// tenant's identity space.
+func (m Mapper) Identity(inv CityInvocation) NativeIdentity {
+	return NativeIdentity{
+		Kind:          NativeIdentityKind,
+		Tenant:        m.Source.Tenant,
+		SessionID:     inv.SessionNativeID,
+		UpstreamReqID: inv.UpstreamReqID,
+	}
+}
+
+// normalizeOutcome maps a City-native status onto the closed vocabulary.
+func normalizeOutcome(status string) Outcome {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "ok", "success", "succeeded", "complete", "completed":
+		return OutcomeOK
+	case "error", "failed", "failure":
+		return OutcomeError
+	case "cancelled", "canceled", "aborted": //nolint:misspell // both City spellings are real inputs
+		return OutcomeCancelled
+	default:
+		return OutcomeUnknown
+	}
+}
+
+// legacy reports the legacy shape: a row with no provider-namespace session.
+// Its absent field groups classify legacy_unknown rather than unavailable,
+// because collapsing the two would let an unexplained blank pass as a
+// structural absence.
+func (m Mapper) legacy(inv CityInvocation) bool { return inv.SessionNativeID == "" }
+
+// ExpectedCoverage is the coverage map this adapter's offer supports.
+//
+// It is NOT authority: coverage is server-derived at admission and immutable
+// after. It exists so a fixture can pin what City claims on its own behalf, and
+// so [Producer] can refuse an accepted record whose coverage came back stronger
+// than what was offered.
+//
+// Nothing here is a guess. Token counts are metered because the party that did
+// the work counted them and we recorded them verbatim — which is not a claim
+// that they are correct. Cost is estimated because a price table produced it,
+// not a counter. Step attribution is unavailable unconditionally: there is no
+// admitted field, so there is nothing to be known about. Transcript attribution
+// is known only when a canonical record ID is linked, because that link is
+// server-verified.
+func (m Mapper) ExpectedCoverage(inv CityInvocation) map[string]Coverage {
+	absent := CoverageUnavailable
+	if m.legacy(inv) {
+		absent = CoverageLegacyUnknown
+	}
+	cov := map[string]Coverage{
+		FieldGroupTokens:     absent,
+		FieldGroupCost:       absent,
+		FieldGroupSavings:    absent,
+		FieldGroupStep:       CoverageUnavailable,
+		FieldGroupTranscript: CoverageUnavailable,
+		FieldGroupOutcome:    CoverageKnown,
+	}
+	if u := inv.Usage; u != nil {
+		if u.metered() {
+			cov[FieldGroupTokens] = CoverageMetered
+		}
+		if u.CostMicros != nil {
+			cov[FieldGroupCost] = CoverageEstimated
+		}
+		if u.SavedInputTokens != nil || u.SavedCostMicros != nil {
+			cov[FieldGroupSavings] = CoverageEstimated
+		}
+	}
+	if inv.TranscriptRecordID != "" {
+		cov[FieldGroupTranscript] = CoverageKnown
+	}
+	return cov
+}
+
+// coverageRank orders the classes weakest to strongest. A fold takes the
+// WEAKEST class present, never the strongest: an unproven contribution can
+// never raise a folded claim.
+var coverageRank = map[Coverage]int{
+	CoverageLegacyUnknown: 0,
+	CoverageUnavailable:   1,
+	CoverageEstimated:     2,
+	CoveragePartial:       3,
+	CoverageMetered:       4,
+	CoverageKnown:         5,
+}
+
+// MapInvocation turns one City invocation into a neutral create request.
+//
+// The container Team IDs travel exactly as City read them back. A City-native
+// run or session ID placed in one of those fields is not translated here into
+// something plausible: it goes as given and resolves to a not-found, which is
+// the same answer a foreign record gets.
+func (m Mapper) MapInvocation(inv CityInvocation) (CreateInferenceRequest, error) {
+	if m.Source.Tenant == "" {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: enrolled tenant is required", ErrInvalidInvocation)
+	}
+	if m.Source.Epoch == 0 {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: source epoch is required and is never guessed", ErrInvalidInvocation)
+	}
+	if _, err := ClassifyReqID(inv.UpstreamReqID); err != nil {
+		return CreateInferenceRequest{}, err
+	}
+	if inv.Provider == "" || inv.Model == "" {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: provider and model are required", ErrInvalidInvocation)
+	}
+	if inv.Started.IsZero() {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: started_at is required", ErrInvalidInvocation)
+	}
+	if inv.Ended != nil && inv.Ended.Before(inv.Started) {
+		return CreateInferenceRequest{}, fmt.Errorf("%w: ended_at precedes started_at", ErrInvalidInvocation)
+	}
+
+	id := m.Identity(inv)
+	external, err := DeriveExternalInferenceID(id)
+	if err != nil {
+		return CreateInferenceRequest{}, err
+	}
+
+	observation := inv.ObservationID
+	if observation == "" {
+		observation = "primary"
+	}
+
+	req := CreateInferenceRequest{
+		NativeIdentity:      id,
+		ExternalInferenceID: external,
+		Provider:            inv.Provider,
+		Model:               inv.Model,
+		Outcome:             normalizeOutcome(inv.Status),
+		StartedAt:           inv.Started.UTC(),
+		Epoch:               m.Source.Epoch,
+		SessionTeamID:       inv.SessionTeamID,
+		RunTeamID:           inv.RunTeamID,
+		TranscriptRecordID:  inv.TranscriptRecordID,
+		ObservationID:       observation,
+		Usage:               inv.Usage,
+	}
+	if inv.Ended != nil {
+		ended := inv.Ended.UTC()
+		req.EndedAt = &ended
+	}
+	if err := Preflight(req); err != nil {
+		return CreateInferenceRequest{}, err
+	}
+	return req, nil
+}
+
+// FoldBasis names what a correlation claim rests on.
+type FoldBasis string
+
+// The one admissible basis, and the inadmissible ones spelled out so a test can
+// enumerate them. They exist as named values precisely so that offering one is
+// a refusal with a reason rather than a silent "no match".
+const (
+	FoldExactTuple  FoldBasis = "exact_tuple"
+	FoldTimestamp   FoldBasis = "timestamp_proximity"
+	FoldModel       FoldBasis = "model_equality"
+	FoldVendor      FoldBasis = "vendor_equality"
+	FoldTokenCount  FoldBasis = "token_count_equality"
+	FoldCost        FoldBasis = "cost_equality"
+	FoldTextual     FoldBasis = "textual_similarity"
+	FoldProviderLoc FoldBasis = "provider_locator"
+	FoldCityField   FoldBasis = "city_field"
+)
+
+// ForbiddenFoldBases returns every basis this adapter refuses, in a stable
+// order, so a decision-table test can assert the closed set rather than a
+// sample of it.
+func ForbiddenFoldBases() []FoldBasis {
+	return []FoldBasis{
+		FoldTimestamp, FoldModel, FoldVendor, FoldTokenCount,
+		FoldCost, FoldTextual, FoldProviderLoc, FoldCityField,
+	}
+}
+
+// CorrelationClaim is an offered assertion that two invocations are the same
+// call.
+type CorrelationClaim struct {
+	Basis FoldBasis
+	A, B  CityInvocation
+}
+
+// Fold decides whether two contributions may be folded into one authoritative
+// sum.
+//
+// Only an exact identity tuple folds, and only when the tuple names an
+// invocation rather than an observation of one: two locally generated request
+// IDs for the same real call never converge, so folding on them would hide a
+// double count. Any other basis is refused outright — the refusal is the
+// answer, because a producer that gets "false" back from a timestamp comparison
+// will try a wider window next.
+func (m Mapper) Fold(claim CorrelationClaim) (bool, error) {
+	if claim.Basis != FoldExactTuple {
+		return false, fmt.Errorf("%w: basis %q is not a comparator in this domain", ErrHeuristicFold, claim.Basis)
+	}
+	scopeA, err := ClassifyReqID(claim.A.UpstreamReqID)
+	if err != nil {
+		return false, err
+	}
+	scopeB, err := ClassifyReqID(claim.B.UpstreamReqID)
+	if err != nil {
+		return false, err
+	}
+	if m.Identity(claim.A) != m.Identity(claim.B) {
+		return false, nil
+	}
+	if scopeA != ScopeInvocation || scopeB != ScopeInvocation {
+		return false, nil
+	}
+	return true, nil
+}
+
+// The closed admitted key set of the create request, per nesting level. A
+// closed allowlist rather than a blocklist of content-shaped names: a blocklist
+// has to guess what content will be called next, and this side of the wire is
+// where prompt text would first appear if the struct ever drifted.
+var admittedKeys = map[string]map[string]bool{
+	"": {
+		"native_identity": true, "external_inference_id": true, "provider": true,
+		"model": true, "outcome": true, "started_at": true, "ended_at": true,
+		"epoch": true, "session_id": true, "run_id": true, "transcript_record_id": true,
+		"observation_id": true, "usage": true, "ordinal": true, "source_step_ref": true,
+	},
+	"native_identity": {
+		"kind": true, "tenant": true, "session_id": true, "upstream_req_id": true,
+	},
+	"usage": {
+		"input_tokens": true, "output_tokens": true, "cached_input_tokens": true,
+		"cost_micros": true, "saved_input_tokens": true, "saved_cost_micros": true,
+	},
+}
+
+// credentialEvidence matches the shapes a credential takes when it leaks into a
+// payload by accident.
+var credentialEvidence = regexp.MustCompile(`(?i)(bearer\s+[a-z0-9._~+/-]{8,}|sk-[a-z0-9]{8,}|authorization|api[_-]?key|secret|password|private[_-]?key)`)
+
+// ScanForbidden reads outbound request bytes and refuses anything the contract
+// does not admit.
+//
+// It works on bytes rather than on the struct so a test can point it at what a
+// transport spy actually recorded. Two classes of refusal: a key outside the
+// closed admitted set (which is how model content would arrive), and a value
+// carrying credential evidence.
+func ScanForbidden(raw []byte) error {
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return fmt.Errorf("%w: outbound payload is not a JSON object", ErrContentLeak)
+	}
+	for _, level := range []string{"", "native_identity", "usage"} {
+		obj := body
+		if level != "" {
+			raw, ok := body[level]
+			if !ok {
+				continue
+			}
+			obj = nil
+			if err := json.Unmarshal(raw, &obj); err != nil {
+				return fmt.Errorf("%w: %s is not a JSON object", ErrContentLeak, level)
+			}
+		}
+		for key := range obj {
+			if !admittedKeys[level][key] {
+				where := key
+				if level != "" {
+					where = level + "." + key
+				}
+				return fmt.Errorf("%w: field %q is not admitted by the inference contract", ErrContentLeak, where)
+			}
+		}
+	}
+	if credentialEvidence.Match(raw) {
+		return fmt.Errorf("%w: payload matches a credential shape", ErrCredentialLeak)
+	}
+	return nil
+}
+
+// Preflight refuses a request before a byte leaves the process.
+//
+// It runs on every request [Producer] sends, including one a caller built by
+// hand, so the never-synthesize rules are enforced at this adapter's edge and
+// not only by a 422 the caller has to correlate back.
+func Preflight(req CreateInferenceRequest) error {
+	if req.Ordinal != nil {
+		return fmt.Errorf("%w: this domain asserts no order, so `ordinal` may not be offered", ErrSyntheticLinkage)
+	}
+	if req.SourceStepRef != "" {
+		return fmt.Errorf("%w: step attribution is unavailable by construction, so `source_step_ref` may not be offered", ErrSyntheticLinkage)
+	}
+	if req.NativeIdentity.Kind != NativeIdentityKind {
+		return fmt.Errorf("%w: unknown native identity kind %q", ErrInvalidInvocation, req.NativeIdentity.Kind)
+	}
+	if err := boundedNativeID("native_identity.tenant", req.NativeIdentity.Tenant, false); err != nil {
+		return err
+	}
+	// session_id is checked only when non-empty: "" is the legal legacy value,
+	// and rejecting it would force a producer to invent one.
+	if err := boundedNativeID("native_identity.session_id", req.NativeIdentity.SessionID, true); err != nil {
+		return err
+	}
+	if err := boundedNativeID("native_identity.upstream_req_id", req.NativeIdentity.UpstreamReqID, false); err != nil {
+		return err
+	}
+	if _, err := ClassifyReqID(req.NativeIdentity.UpstreamReqID); err != nil {
+		return err
+	}
+	if req.ExternalInferenceID != "" {
+		derived, err := DeriveExternalInferenceID(req.NativeIdentity)
+		if err != nil {
+			return err
+		}
+		if derived != req.ExternalInferenceID {
+			return fmt.Errorf("%w: offered external_inference_id is not the derivation of the triplet", ErrInvalidInvocation)
+		}
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("%w: encode request: %w", ErrInvalidInvocation, err)
+	}
+	return ScanForbidden(raw)
+}
+
+func boundedNativeID(field, value string, allowEmpty bool) error {
+	if value == "" {
+		if allowEmpty {
+			return nil
+		}
+		return fmt.Errorf("%w: %s is required", ErrInvalidInvocation, field)
+	}
+	if len(value) > maxNativeIDLen {
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidInvocation, field, maxNativeIDLen)
+	}
+	if strings.ContainsAny(value, "\x00\n\r") {
+		return fmt.Errorf("%w: %s contains a control character", ErrInvalidInvocation, field)
+	}
+	return nil
+}

--- a/pkg/cityinference/mapping_test.go
+++ b/pkg/cityinference/mapping_test.go
@@ -1,0 +1,262 @@
+package cityinference
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// The mapping decision table. Every row is a shape the design names, and every
+// outcome is the one it names for it.
+func TestMappingDecisionTable(t *testing.T) {
+	m := testMapper()
+	base := CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+		Model: "m-1", Status: "succeeded", Started: mustTime(t, "2026-07-30T10:00:00Z"),
+	}
+	with := func(mutate func(*CityInvocation)) CityInvocation {
+		inv := base
+		mutate(&inv)
+		return inv
+	}
+
+	for _, tc := range []struct {
+		name string
+		inv  CityInvocation
+		want error
+	}{
+		{"provider-assigned request id admits", base, nil},
+		{"locally generated request id admits", with(func(i *CityInvocation) { i.UpstreamReqID = "gen_7" }), nil},
+		{"legacy empty session admits", with(func(i *CityInvocation) { i.SessionNativeID = "" }), nil},
+		{"attempt row is refused", with(func(i *CityInvocation) { i.UpstreamReqID = "err_upstream_timeout" }), ErrAttemptRow},
+		{"missing request id is refused", with(func(i *CityInvocation) { i.UpstreamReqID = "" }), ErrInvalidInvocation},
+		{"missing model is refused", with(func(i *CityInvocation) { i.Model = "" }), ErrInvalidInvocation},
+		{"missing start is refused", with(func(i *CityInvocation) { i.Started = time.Time{} }), ErrInvalidInvocation},
+		{"end before start is refused", with(func(i *CityInvocation) {
+			end := mustTime(t, "2026-07-30T09:00:00Z")
+			i.Ended = &end
+		}), ErrInvalidInvocation},
+		{"oversized request id is refused", with(func(i *CityInvocation) {
+			i.UpstreamReqID = string(make([]byte, maxNativeIDLen+1))
+		}), ErrInvalidInvocation},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := m.MapInvocation(tc.inv)
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("want admission, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// An unmappable City status becomes unknown rather than traveling as itself:
+// the canonical contract has no raw passthrough.
+func TestOutcomeVocabularyIsClosed(t *testing.T) {
+	m := testMapper()
+	for status, want := range map[string]Outcome{
+		"succeeded": OutcomeOK, "failed": OutcomeError, "canceled": OutcomeCancelled,
+		"reticulating splines": OutcomeUnknown, "": OutcomeUnknown,
+	} {
+		req, err := m.MapInvocation(CityInvocation{
+			SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic",
+			Model: "m-1", Status: status, Started: mustTime(t, "2026-07-30T10:00:00Z"),
+		})
+		if err != nil {
+			t.Fatalf("%q: %v", status, err)
+		}
+		if req.Outcome != want {
+			t.Fatalf("%q: want %s, got %s", status, want, req.Outcome)
+		}
+	}
+}
+
+// Only an exact identity tuple folds, and only when that tuple names an
+// invocation. Every other basis is refused outright rather than answered.
+func TestFoldOnlyOnExactTuple(t *testing.T) {
+	m := testMapper()
+	a := CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Provider: "anthropic", Model: "m-1"}
+	b := a
+
+	folds, err := m.Fold(CorrelationClaim{Basis: FoldExactTuple, A: a, B: b})
+	if err != nil || !folds {
+		t.Fatalf("exact tuple must fold: %v %v", folds, err)
+	}
+
+	for _, basis := range ForbiddenFoldBases() {
+		folds, err := m.Fold(CorrelationClaim{Basis: basis, A: a, B: b})
+		if !errors.Is(err, ErrHeuristicFold) {
+			t.Fatalf("%s: want ErrHeuristicFold, got %v", basis, err)
+		}
+		if folds {
+			t.Fatalf("%s: refused claim still folded", basis)
+		}
+	}
+}
+
+// Similarity is not identity. Two calls that agree on model, provider, tenant
+// and timestamp but differ in request id stay separate — as do two locally
+// generated ids, which never converge on the same real call.
+func TestSimilarRecordsStaySeparate(t *testing.T) {
+	m := testMapper()
+	ts := mustTime(t, "2026-07-30T10:00:00Z")
+	for _, tc := range []struct {
+		name string
+		a, b CityInvocation
+	}{
+		{
+			"near-identical timestamps, different request ids",
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Model: "m-1", Started: ts},
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-2", Model: "m-1", Started: ts.Add(1)},
+		},
+		{
+			"two locally generated observations of one call",
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "gen_a", Model: "m-1", Started: ts},
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "gen_b", Model: "m-1", Started: ts},
+		},
+		{
+			"legacy row and EIA row sharing a provider request id",
+			CityInvocation{SessionNativeID: "", UpstreamReqID: "req-1", Model: "m-1", Started: ts},
+			CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "req-1", Model: "m-1", Started: ts},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			folds, err := m.Fold(CorrelationClaim{Basis: FoldExactTuple, A: tc.a, B: tc.b})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if folds {
+				t.Fatal("records folded on a non-identity similarity")
+			}
+			if m.Identity(tc.a) == m.Identity(tc.b) {
+				t.Fatal("distinct calls collapsed onto one identity")
+			}
+		})
+	}
+
+	// Even an exact tuple does not fold when the id was generated locally: two
+	// such observations never converge, so folding them would hide a double
+	// count instead of removing one.
+	gen := CityInvocation{SessionNativeID: "sess-1", UpstreamReqID: "gen_a", Model: "m-1", Started: ts}
+	folds, err := m.Fold(CorrelationClaim{Basis: FoldExactTuple, A: gen, B: gen})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if folds {
+		t.Fatal("a locally generated identity was treated as fold-eligible")
+	}
+}
+
+// Ordinal and step reference are refused at this adapter's edge, before a byte
+// leaves, and with the specific reason rather than a generic parse error.
+func TestPreflightRefusesSynthesizedLinkage(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-1"}
+	base := CreateInferenceRequest{
+		NativeIdentity: id, ExternalInferenceID: mustDerive(t, id),
+		Provider: "anthropic", Model: "m-1", Outcome: OutcomeOK,
+		StartedAt: mustTime(t, "2026-07-30T10:00:00Z"),
+	}
+	if err := Preflight(base); err != nil {
+		t.Fatalf("clean request refused: %v", err)
+	}
+
+	withOrdinal := base
+	withOrdinal.Ordinal = ptr(3)
+	if err := Preflight(withOrdinal); !errors.Is(err, ErrSyntheticLinkage) {
+		t.Fatalf("ordinal: want ErrSyntheticLinkage, got %v", err)
+	}
+
+	withStep := base
+	withStep.SourceStepRef = "step_9"
+	if err := Preflight(withStep); !errors.Is(err, ErrSyntheticLinkage) {
+		t.Fatalf("step: want ErrSyntheticLinkage, got %v", err)
+	}
+}
+
+// The scanner works on outbound bytes, so it catches a field the contract does
+// not admit no matter how it got there.
+func TestScannerRefusesUnadmittedFieldsAndCredentials(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "org_alpha", SessionID: "sess-1", UpstreamReqID: "req-1"}
+	clean, err := json.Marshal(CreateInferenceRequest{
+		NativeIdentity: id, ExternalInferenceID: mustDerive(t, id),
+		Provider: "anthropic", Model: "m-1", Outcome: OutcomeOK,
+		StartedAt: mustTime(t, "2026-07-30T10:00:00Z"),
+		Usage:     &UsageObservation{InputTokens: ptr(1)},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ScanForbidden(clean); err != nil {
+		t.Fatalf("clean payload refused: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want error
+	}{
+		{"prompt text", `{"provider":"p","model":"m","prompt":"who are you"}`, ErrContentLeak},
+		{"completion text", `{"provider":"p","model":"m","completion":"I am"}`, ErrContentLeak},
+		{"transcript text", `{"provider":"p","model":"m","messages":[{"role":"user"}]}`, ErrContentLeak},
+		{"raw provider payload", `{"provider":"p","model":"m","raw_response":{"id":"x"}}`, ErrContentLeak},
+		{"nested content", `{"usage":{"input_tokens":1,"prompt":"hi"}}`, ErrContentLeak},
+		{"bearer credential", `{"provider":"Bearer sk-abcdefgh12345678","model":"m"}`, ErrCredentialLeak},
+		{"key identifier", `{"provider":"p","model":"m","native_identity":{"kind":"manifold.triplet.v1","tenant":"t","session_id":"s","upstream_req_id":"api_key=zz"}}`, ErrCredentialLeak},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ScanForbidden([]byte(tc.body)); !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// The admitted key set is closed and matches the request struct exactly. If a
+// field is ever added to the struct without being admitted here, this fails —
+// which is the point: struct drift is how content first arrives.
+func TestAdmittedKeySetMatchesTheRequestStruct(t *testing.T) {
+	id := NativeIdentity{Kind: NativeIdentityKind, Tenant: "t", SessionID: "s", UpstreamReqID: "req-1"}
+	raw, err := json.Marshal(CreateInferenceRequest{
+		NativeIdentity: id, ExternalInferenceID: "x", Provider: "p", Model: "m",
+		Outcome: OutcomeOK, StartedAt: mustTime(t, "2026-07-30T10:00:00Z"),
+		EndedAt: func() *time.Time { ts := mustTime(t, "2026-07-30T10:01:00Z"); return &ts }(),
+		Epoch:   1, SessionTeamID: "ses_1", RunTeamID: "run_1", TranscriptRecordID: "trc_1",
+		ObservationID: "primary", Usage: &UsageObservation{
+			InputTokens: ptr(1), OutputTokens: ptr(1), CachedInputTokens: ptr(1),
+			CostMicros: ptr(1), SavedInputTokens: ptr(1), SavedCostMicros: ptr(1),
+		},
+		Ordinal: ptr(1), SourceStepRef: "step_1",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for key := range body {
+		if !admittedKeys[""][key] {
+			t.Fatalf("request struct emits unadmitted key %q", key)
+		}
+	}
+	for level, sub := range map[string]json.RawMessage{"native_identity": body["native_identity"], "usage": body["usage"]} {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(sub, &obj); err != nil {
+			t.Fatalf("%s: %v", level, err)
+		}
+		for key := range obj {
+			if !admittedKeys[level][key] {
+				t.Fatalf("%s emits unadmitted key %q", level, key)
+			}
+		}
+		if len(obj) != len(admittedKeys[level]) {
+			t.Fatalf("%s: allowlist has %d keys, struct emits %d", level, len(admittedKeys[level]), len(obj))
+		}
+	}
+}

--- a/pkg/cityinference/producer.go
+++ b/pkg/cityinference/producer.go
@@ -1,0 +1,286 @@
+package cityinference
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Acked is one acknowledged contribution as the checkpoint holds it.
+//
+// Digest is the payload digest of what the server accepted. It is what makes a
+// changed replay detectable at all: without it, a re-offer with a different
+// model or outcome is indistinguishable from a retry.
+type Acked struct {
+	InferenceTeamID string `json:"inference_team_id"`
+	Digest          string `json:"digest"`
+}
+
+// State is one City source's inference checkpoint. It is keyed by stable source
+// identity — derived inference ID plus observation ID — and never by anything
+// that changes across a restart or a credential rotation.
+type State struct {
+	Epoch    uint64           `json:"epoch"`
+	SourceID string           `json:"source_id"`
+	Accepted map[string]Acked `json:"accepted"`
+}
+
+// Store persists checkpoints across restarts. It is an interface because the
+// durable implementation is City's business; the adapter only needs load and
+// save to be atomic with respect to each other.
+type Store interface {
+	Load(ctx context.Context, key string) (State, bool, error)
+	Save(ctx context.Context, key string, st State) error
+}
+
+// MemoryStore is an in-process Store. It is safe for concurrent use and is what
+// tests and a single-shot export run on.
+type MemoryStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+// NewMemoryStore returns an empty in-process Store.
+func NewMemoryStore() *MemoryStore { return &MemoryStore{m: map[string][]byte{}} }
+
+// Load implements Store.
+func (s *MemoryStore) Load(_ context.Context, key string) (State, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw, ok := s.m[key]
+	if !ok {
+		return State{}, false, nil
+	}
+	var st State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return State{}, false, fmt.Errorf("cityinference: decode checkpoint %q: %w", key, err)
+	}
+	return st, true, nil
+}
+
+// Save implements Store. It round-trips through JSON so a caller cannot hold a
+// reference into stored state and mutate it behind the producer's back.
+func (s *MemoryStore) Save(_ context.Context, key string, st State) error {
+	raw, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("cityinference: encode checkpoint %q: %w", key, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = map[string][]byte{}
+	}
+	s.m[key] = raw
+	return nil
+}
+
+// Uploaded reports one accepted upload.
+type Uploaded struct {
+	ExternalInferenceID string
+	ObservationID       string
+	InferenceTeamID     string
+}
+
+// Result reports what one push did. It is returned even on error, so a caller
+// that stops on a refusal still learns how far it got.
+type Result struct {
+	Uploaded []Uploaded
+	Accepted int
+	Skipped  int
+}
+
+// Producer maps City invocations onto neutral inference records and advances a
+// checkpoint only over records the server acknowledged.
+type Producer struct {
+	API    API
+	Mapper Mapper
+	Store  Store
+
+	// Disabled is the rollback switch. A disabled producer issues no request
+	// and touches no checkpoint; acknowledged records stay exactly as the
+	// server accepted them and every other producer keeps running.
+	Disabled bool
+}
+
+// NewProducer validates its wiring up front: a producer missing a store would
+// look like it worked and silently re-upload the world on restart.
+func NewProducer(api API, mapper Mapper, store Store) (*Producer, error) {
+	if api == nil {
+		return nil, errors.New("cityinference: API is required")
+	}
+	if store == nil {
+		return nil, errors.New("cityinference: Store is required")
+	}
+	if mapper.Source.SourceID == "" || mapper.Source.Kind == "" {
+		return nil, errors.New("cityinference: source identity is required")
+	}
+	if mapper.Source.Tenant == "" {
+		return nil, errors.New("cityinference: enrolled tenant is required")
+	}
+	if mapper.Source.Epoch == 0 {
+		return nil, errors.New("cityinference: source epoch is required and is never guessed")
+	}
+	return &Producer{API: api, Mapper: mapper, Store: store}, nil
+}
+
+// CheckpointKey is the durable key of this source's inference checkpoint. It
+// carries no credential and no host, so a rotation or a redeploy resumes the
+// same checkpoint rather than starting a second one.
+func CheckpointKey(source Source) string {
+	return source.Kind + "/" + source.SourceID + "/inference"
+}
+
+// Push uploads a batch of City invocations, skipping what the checkpoint
+// already holds and stopping on the first refusal.
+//
+// Order within the batch carries no meaning — this domain asserts none — so a
+// caller may re-offer a batch in any order and get the same outcome.
+func (p *Producer) Push(ctx context.Context, invocations []CityInvocation) (Result, error) {
+	var res Result
+	if p.Disabled {
+		return res, ErrDisabled
+	}
+	key := CheckpointKey(p.Mapper.Source)
+	st, ok, err := p.Store.Load(ctx, key)
+	if err != nil {
+		return res, err
+	}
+	if !ok {
+		st = State{Epoch: p.Mapper.Source.Epoch, SourceID: p.Mapper.Source.SourceID}
+	}
+	if st.Accepted == nil {
+		st.Accepted = map[string]Acked{}
+	}
+	if st.Epoch != p.Mapper.Source.Epoch {
+		// An epoch change is a declared reset, and a reset re-keys identity. It
+		// is not something a restart may infer, so the producer stops.
+		return res, fmt.Errorf("%w: checkpoint epoch %d, source epoch %d", ErrIdentityDrift, st.Epoch, p.Mapper.Source.Epoch)
+	}
+
+	for _, inv := range invocations {
+		req, err := p.Mapper.MapInvocation(inv)
+		if err != nil {
+			return res, err
+		}
+		recordKey := req.ExternalInferenceID + "/" + req.ObservationID
+		digest, err := payloadDigest(req)
+		if err != nil {
+			return res, err
+		}
+		if prior, seen := st.Accepted[recordKey]; seen {
+			if prior.Digest != digest {
+				return res, fmt.Errorf("%w: %s", ErrChangedReplay, recordKey)
+			}
+			res.Skipped++
+			continue
+		}
+
+		got, err := p.API.CreateInference(ctx, req, IdempotencyKey(p.Mapper.Source, recordKey))
+		if err != nil {
+			return res, err
+		}
+		if err := p.verify(req, got); err != nil {
+			return res, err
+		}
+		st.Accepted[recordKey] = Acked{InferenceTeamID: got.ID, Digest: digest}
+		// The checkpoint advances only here, after acceptance. A crash between
+		// the call and this save replays the same idempotency key and the
+		// server answers with the original response.
+		if err := p.Store.Save(ctx, key, st); err != nil {
+			return res, err
+		}
+		res.Uploaded = append(res.Uploaded, Uploaded{
+			ExternalInferenceID: req.ExternalInferenceID,
+			ObservationID:       req.ObservationID,
+			InferenceTeamID:     got.ID,
+		})
+		res.Accepted++
+	}
+	return res, nil
+}
+
+// verify checks what came back against what was offered.
+func (p *Producer) verify(req CreateInferenceRequest, got Inference) error {
+	if got.ID == "" {
+		return fmt.Errorf("%w: response carries no neutral id", ErrIdentityDrift)
+	}
+	if got.ExternalInferenceID != req.ExternalInferenceID {
+		return fmt.Errorf("%w: offered %s, accepted %s", ErrIdentityDrift,
+			req.ExternalInferenceID, got.ExternalInferenceID)
+	}
+	// Every field group is present on every inference. A missing key would be
+	// an implicit "unavailable", and an implicit claim is the thing coverage
+	// exists to abolish.
+	for _, group := range CoverageFieldGroups() {
+		if _, ok := got.Coverage[group]; !ok {
+			return fmt.Errorf("%w: coverage omits field group %q", ErrCoverageRaised, group)
+		}
+	}
+	// Step attribution is unavailable by construction. Anything else means a
+	// step was materialized from data this adapter never had.
+	if Coverage(got.Coverage[FieldGroupStep]) != CoverageUnavailable {
+		return fmt.Errorf("%w: step coverage came back %q", ErrCoverageRaised, got.Coverage[FieldGroupStep])
+	}
+	// Transcript attribution may be known only where a canonical record was
+	// linked. The link is part of the invariant core, so a raised class here is
+	// a fabricated link, not another contribution's.
+	if req.TranscriptRecordID == "" && Coverage(got.Coverage[FieldGroupTranscript]) == CoverageKnown {
+		return fmt.Errorf("%w: transcript coverage claims known with no linked record", ErrCoverageRaised)
+	}
+	if req.TranscriptRecordID != "" && got.TranscriptRecordID != req.TranscriptRecordID {
+		return fmt.Errorf("%w: accepted record links a different transcript record", ErrIdentityDrift)
+	}
+	if got.Completeness != "" && Coverage(got.Completeness) != CoverageUnavailable {
+		return fmt.Errorf("%w: completeness came back %q over a best-effort producer",
+			ErrCoverageRaised, got.Completeness)
+	}
+	scope, err := ClassifyReqID(req.NativeIdentity.UpstreamReqID)
+	if err != nil {
+		return err
+	}
+	if scope == ScopeObservation && got.FoldEligible {
+		return fmt.Errorf("%w: a locally generated request id came back fold-eligible", ErrCoverageRaised)
+	}
+	return nil
+}
+
+// idempotencyDomain separates this producer's keys from every other preimage.
+const idempotencyDomain = "cityinference/idempotency/v1"
+
+// IdempotencyKey derives the server's Idempotency-Key from stable source
+// identity.
+//
+// The preimage holds the enrolled source, the ingest epoch, the resource kind
+// and the record's stable identity, and nothing else. No credential, no key
+// identifier, no wall clock and no attempt counter: a credential rotation would
+// otherwise open a fresh idempotency namespace and turn a retry into a second
+// admitted record.
+func IdempotencyKey(source Source, recordKey string) string {
+	preimage := strings.Join([]string{
+		idempotencyDomain,
+		source.Kind, source.SourceID,
+		strconv.FormatUint(source.Epoch, 10),
+		KindInference, recordKey,
+	}, "\x1f")
+	sum := sha256.Sum256([]byte(preimage))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(b)
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+func payloadDigest(req CreateInferenceRequest) (string, error) {
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: encode request: %w", ErrInvalidInvocation, err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/cityinference/producer_test.go
+++ b/pkg/cityinference/producer_test.go
@@ -1,0 +1,257 @@
+package cityinference
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+const (
+	tenantAlpha = "org_alpha"
+	tenantBeta  = "org_beta"
+)
+
+func newWorkspaces() map[string]*FakeWorkspace {
+	alpha := NewFakeWorkspace()
+	alpha.AddChain("run_1", "ses_1", "trc_1")
+	alpha.AddChain("run_2", "ses_2", "")
+	beta := NewFakeWorkspace()
+	beta.AddChain("run_beta", "ses_beta", "trc_beta")
+	return map[string]*FakeWorkspace{tenantAlpha: alpha, tenantBeta: beta}
+}
+
+func newHarness(t *testing.T) (*FakeAPI, *Producer) {
+	t.Helper()
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	p, err := NewProducer(api, testMapper(), NewMemoryStore())
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	return api, p
+}
+
+func happyInvocation(t *testing.T) CityInvocation {
+	t.Helper()
+	return CityInvocation{
+		SessionNativeID: "sess-1", UpstreamReqID: "req-1",
+		Provider: "anthropic", Model: "m-1", Status: "succeeded",
+		Started:            mustTime(t, "2026-07-30T10:00:00Z"),
+		RunTeamID:          "run_1",
+		SessionTeamID:      "ses_1",
+		TranscriptRecordID: "trc_1",
+		Usage:              &UsageObservation{InputTokens: ptr(120), OutputTokens: ptr(30), CostMicros: ptr(4500)},
+	}
+}
+
+// AC1 happy path: transcript-level attribution succeeds with honest coverage,
+// linking canonical records the workspace already owns.
+func TestPushLinksCanonicalRecords(t *testing.T) {
+	api, p := newHarness(t)
+	res, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if res.Accepted != 1 || len(res.Uploaded) != 1 {
+		t.Fatalf("unexpected result %+v", res)
+	}
+	got, err := api.GetInference(context.Background(), res.Uploaded[0].InferenceTeamID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.RunID != "run_1" || got.SessionID != "ses_1" || got.TranscriptRecordID != "trc_1" {
+		t.Fatalf("links were not preserved: %+v", got)
+	}
+	if got.IdentityScope != ScopeInvocation || !got.FoldEligible {
+		t.Fatalf("provider-assigned id must be fold-eligible: %+v", got)
+	}
+}
+
+// AC2 happy path: a proven invocation uploads once. A retry of the same batch
+// issues no second write, and a restart from the persisted checkpoint issues
+// none either.
+func TestProvenInvocationUploadsOnce(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	batch := []CityInvocation{happyInvocation(t)}
+
+	if _, err := p.Push(context.Background(), batch); err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	res, err := p.Push(context.Background(), batch)
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if res.Accepted != 0 || res.Skipped != 1 {
+		t.Fatalf("retry re-uploaded: %+v", res)
+	}
+
+	// Restart: a fresh producer over the same store must not re-upload.
+	restarted, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	if _, err := restarted.Push(context.Background(), batch); err != nil {
+		t.Fatalf("restarted push: %v", err)
+	}
+	if api.Writes() != 1 {
+		t.Fatalf("want exactly one write, got %d", api.Writes())
+	}
+}
+
+// A credential rotation opens no new idempotency namespace. The key preimage
+// holds no credential, so a rotation mid-stream still replays.
+func TestCredentialRotationDoesNotChangeIdentityOrKey(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	api.Credential = "tok_before"
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	batch := []CityInvocation{happyInvocation(t)}
+	if _, err := p.Push(context.Background(), batch); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	before := api.Requests[0].IdempotencyKey
+
+	api.Credential = "tok_after"
+	rotated, err := NewProducer(api, testMapper(), NewMemoryStore())
+	if err != nil {
+		t.Fatalf("rotated producer: %v", err)
+	}
+	if _, err := rotated.Push(context.Background(), batch); err != nil {
+		t.Fatalf("post-rotation push: %v", err)
+	}
+	if api.Requests[1].IdempotencyKey != before {
+		t.Fatalf("rotation changed the idempotency key: %s -> %s", before, api.Requests[1].IdempotencyKey)
+	}
+	if api.Writes() != 2 {
+		t.Fatalf("want two attempts, got %d", api.Writes())
+	}
+	page, err := api.ListInferences(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("rotation admitted a second record: %d", len(page.Items))
+	}
+}
+
+// A changed payload under an already-acknowledged source identity stops the
+// producer. Sending it would ask the server to rewrite accepted input.
+func TestChangedReplayStopsTheProducer(t *testing.T) {
+	api, p := newHarness(t)
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	changed := happyInvocation(t)
+	changed.Model = "m-2"
+	_, err := p.Push(context.Background(), []CityInvocation{changed})
+	if !errors.Is(err, ErrChangedReplay) {
+		t.Fatalf("want ErrChangedReplay, got %v", err)
+	}
+	if api.Writes() != 1 {
+		t.Fatalf("changed replay issued a write: %d", api.Writes())
+	}
+}
+
+// A fault mid-batch leaves the checkpoint exactly at the last acknowledged
+// record. The restart re-offers only what was never acknowledged.
+func TestFaultMidBatchResumesWithoutReupload(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	second := happyInvocation(t)
+	second.UpstreamReqID = "req-2"
+	second.TranscriptRecordID = ""
+	batch := []CityInvocation{happyInvocation(t), second}
+
+	api.FailNext = errors.New("transport reset")
+	if _, err := p.Push(context.Background(), batch); err == nil {
+		t.Fatal("want transport failure")
+	}
+	if api.Writes() != 1 {
+		t.Fatalf("want one attempted write before the fault, got %d", api.Writes())
+	}
+
+	restarted, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	res, err := restarted.Push(context.Background(), batch)
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if res.Accepted != 2 {
+		t.Fatalf("resume accepted %d, want 2", res.Accepted)
+	}
+	page, err := api.ListInferences(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("want 2 records, got %d", len(page.Items))
+	}
+}
+
+// Two honest observations of the same call — one metered, one estimated — stand
+// as two contributions on one inference. Neither is a payload divergence of the
+// other, and the folded coverage never rises above the weaker one.
+func TestTwoObservationsFoldOntoOneInference(t *testing.T) {
+	api, p := newHarness(t)
+	metered := happyInvocation(t)
+	metered.ObservationID = "metered"
+	estimated := happyInvocation(t)
+	estimated.ObservationID = "estimated"
+	estimated.Usage = &UsageObservation{CostMicros: ptr(4400), SavedCostMicros: ptr(10)}
+
+	res, err := p.Push(context.Background(), []CityInvocation{metered, estimated})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if res.Accepted != 2 {
+		t.Fatalf("want 2 accepted, got %d", res.Accepted)
+	}
+	if res.Uploaded[0].InferenceTeamID != res.Uploaded[1].InferenceTeamID {
+		t.Fatal("exact-tuple observations did not fold onto one inference")
+	}
+	got, err := api.GetInference(context.Background(), res.Uploaded[0].InferenceTeamID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Contributions) != 2 {
+		t.Fatalf("want 2 contributions, got %d", len(got.Contributions))
+	}
+	if Coverage(got.Coverage[FieldGroupTokens]) == CoverageKnown {
+		t.Fatal("folded token coverage was raised to known")
+	}
+}
+
+// An undeclared epoch change is a reset the producer never infers.
+func TestEpochDriftStopsTheProducer(t *testing.T) {
+	api := NewFakeAPI(tenantAlpha, newWorkspaces())
+	store := NewMemoryStore()
+	p, err := NewProducer(api, testMapper(), store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	if _, err := p.Push(context.Background(), []CityInvocation{happyInvocation(t)}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	source := testSource()
+	source.Epoch = 8
+	drifted, err := NewProducer(api, Mapper{Source: source}, store)
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	if _, err := drifted.Push(context.Background(), []CityInvocation{happyInvocation(t)}); !errors.Is(err, ErrIdentityDrift) {
+		t.Fatalf("want ErrIdentityDrift, got %v", err)
+	}
+}

--- a/pkg/cityneutral/checkpoint_test.go
+++ b/pkg/cityneutral/checkpoint_test.go
@@ -1,0 +1,280 @@
+package cityneutral
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func recordsUpTo(n uint64) []CityRecord {
+	out := make([]CityRecord, 0, n)
+	for i := uint64(1); i <= n; i++ {
+		out = append(out, CityRecord{
+			MessageID: "m" + string(rune('0'+i)), Ordinal: i, Role: "user",
+			At: t0.Add(time.Duration(i) * time.Minute), Text: "turn",
+		})
+	}
+	return out
+}
+
+func chainWith(records []CityRecord, complete bool) CityChain {
+	return CityChain{
+		Run: CityRun{RunID: "city-run-7", Status: "running", Started: t0, Version: 1},
+		Sessions: []CitySession{{
+			SessionID: "city-sess-1", Status: "running", Started: t0, Version: 1,
+			Complete: complete, Records: records,
+		}},
+	}
+}
+
+func pushOK(t *testing.T, p *Producer, chain CityChain) Result {
+	t.Helper()
+	res, err := p.Push(context.Background(), chain)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	return res
+}
+
+// AC2 happy path: a restart resumes at the next accepted record and re-sends
+// nothing that was already acknowledged.
+func TestRestartResumesAtNextAcceptedRecord(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	store := NewMemoryStore()
+	mapper := Mapper{Source: citySource(), AllowRawContent: true}
+
+	first, err := NewProducer(f, mapper, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res := pushOK(t, first, chainWith(recordsUpTo(2), false))
+	if res.Accepted != 2 {
+		t.Fatalf("first push accepted %d, want 2", res.Accepted)
+	}
+
+	// A brand new Producer over the same store is the restart: same chain,
+	// grown by two records.
+	second, err := NewProducer(f, mapper, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res = pushOK(t, second, chainWith(recordsUpTo(4), false))
+	if res.Accepted != 2 || res.Skipped != 2 {
+		t.Fatalf("restart push accepted %d skipped %d, want 2/2", res.Accepted, res.Skipped)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	if len(recs) != 4 {
+		t.Fatalf("server holds %d records, want 4 (no duplicates)", len(recs))
+	}
+}
+
+// AC2 fault/checkpoint matrix. Every row starts from the same two-record
+// checkpoint so the difference between rows is only the fault under test.
+func TestCheckpointFaultMatrix(t *testing.T) {
+	base := recordsUpTo(2)
+
+	cases := []struct {
+		name     string
+		finalize bool
+		next     CityChain
+		wantErr  error
+		accepted int
+		skipped  int
+	}{
+		{
+			name:     "duplicate batch deduplicates on stable source identity",
+			next:     chainWith(recordsUpTo(2), false),
+			accepted: 0, skipped: 2,
+		},
+		{
+			name:     "out-of-order batch is ordered before contiguity is judged",
+			next:     chainWith([]CityRecord{base[1], base[0], recordsUpTo(4)[3], recordsUpTo(4)[2]}, false),
+			accepted: 2, skipped: 2,
+		},
+		{
+			name:     "partial batch advances only as far as it is contiguous",
+			next:     chainWith(recordsUpTo(3), false),
+			accepted: 1, skipped: 2,
+		},
+		{
+			name: "gap stops the adapter",
+			next: chainWith(append(append([]CityRecord{}, base...), CityRecord{
+				MessageID: "m5", Ordinal: 5, Role: "user", At: t0.Add(5 * time.Minute), Text: "late",
+			}), false),
+			wantErr: ErrGap,
+		},
+		{
+			name: "changed replay stops the adapter",
+			next: chainWith([]CityRecord{base[0], {
+				MessageID: "m2", Ordinal: 2, Role: "user", At: t0.Add(2 * time.Minute), Text: "rewritten",
+			}}, false),
+			wantErr: ErrChangedReplay,
+		},
+		{
+			name: "reassigned message id at an accepted ordinal stops the adapter",
+			next: chainWith([]CityRecord{base[0], {
+				MessageID: "m9", Ordinal: 2, Role: "user", At: t0.Add(2 * time.Minute), Text: "turn",
+			}}, false),
+			wantErr: ErrChangedReplay,
+		},
+		{
+			name:     "post-finalize append stops the adapter",
+			finalize: true,
+			next:     chainWith(recordsUpTo(3), true),
+			wantErr:  ErrFinalized,
+		},
+		{
+			name:     "re-observing a finalized session is a no-op",
+			finalize: true,
+			next:     chainWith(recordsUpTo(2), true),
+			accepted: 0, skipped: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFake("svc-city@tenant", "gc-city-01", "city")
+			p := newCityProducer(t, f, nil)
+			pushOK(t, p, chainWith(base, tc.finalize))
+
+			res, err := p.Push(context.Background(), tc.next)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				// A refusal must not have advanced anything: the server still
+				// holds exactly the acknowledged prefix.
+				recs, lerr := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+				if lerr != nil {
+					t.Fatalf("ListTranscriptRecords: %v", lerr)
+				}
+				if len(recs) != len(base) {
+					t.Fatalf("refusal left %d records, want %d", len(recs), len(base))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Push: %v", err)
+			}
+			if res.Accepted != tc.accepted || res.Skipped != tc.skipped {
+				t.Fatalf("accepted %d skipped %d, want %d/%d",
+					res.Accepted, res.Skipped, tc.accepted, tc.skipped)
+			}
+		})
+	}
+}
+
+// AC2: a credential rotation mid-flight is recoverable by retry alone. It
+// changes the credential and nothing else — not the source identity, not the
+// epoch, not the checkpoint — so the retry replays under the same derived key
+// and the server stores no duplicate.
+func TestCredentialRotationDoesNotAdvanceOrDuplicate(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	p := newCityProducer(t, f, nil)
+	pushOK(t, p, chainWith(recordsUpTo(2), false))
+
+	rotating := errors.New("401 credential rotated")
+	f.Fail = rotating
+	if _, err := p.Push(context.Background(), chainWith(recordsUpTo(3), false)); !errors.Is(err, rotating) {
+		t.Fatalf("err = %v, want the injected rotation error", err)
+	}
+
+	// The rotation landed on the run upsert, so nothing advanced. Retrying the
+	// identical chain must accept exactly the one new record.
+	res, err := p.Push(context.Background(), chainWith(recordsUpTo(3), false))
+	if err != nil {
+		t.Fatalf("retry after rotation: %v", err)
+	}
+	if res.Accepted != 1 || res.Skipped != 2 {
+		t.Fatalf("retry accepted %d skipped %d, want 1/2", res.Accepted, res.Skipped)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("server holds %d records, want 3", len(recs))
+	}
+}
+
+// AC2: a declared reset advances the epoch, which restarts the frontier under
+// the same checkpoint key. A backwards epoch is not a reset — it is drift.
+func TestResetAdvancesEpochAndBackwardsEpochIsDrift(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	store := NewMemoryStore()
+	p, err := NewProducer(f, Mapper{Source: citySource(), AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	pushOK(t, p, chainWith(recordsUpTo(2), false))
+
+	reset := citySource()
+	reset.Epoch = 2
+	after, err := NewProducer(f, Mapper{Source: reset, AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res := pushOK(t, after, chainWith(recordsUpTo(2), false))
+	if res.Accepted != 2 {
+		t.Fatalf("after reset accepted %d, want 2 (frontier restarted)", res.Accepted)
+	}
+
+	behind, err := NewProducer(f, Mapper{Source: citySource(), AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	if _, err := behind.Push(context.Background(), chainWith(recordsUpTo(2), false)); !errors.Is(err, ErrIdentityDrift) {
+		t.Fatalf("backwards epoch: err = %v, want ErrIdentityDrift", err)
+	}
+}
+
+// AC2: the derived idempotency key depends on stable source identity and
+// nothing else, and it is namespaced per resource kind so a run key cannot be
+// replayed into a session.
+func TestIdempotencyKeyIsStableAndNamespaced(t *testing.T) {
+	src := citySource()
+	run1 := idempotencyKey(src, KindRun, "city-run-7", 3)
+	run2 := idempotencyKey(src, KindRun, "city-run-7", 3)
+	if run1 != run2 {
+		t.Fatalf("key is not stable: %q != %q", run1, run2)
+	}
+	if len(run1) != 36 || run1[14] != '5' {
+		t.Fatalf("key %q is not a v5-shaped UUID", run1)
+	}
+	if sess := idempotencyKey(src, KindSession, "city-run-7", 3); sess == run1 {
+		t.Fatalf("run and session keys collide: %q", sess)
+	}
+	if bumped := idempotencyKey(src, KindRun, "city-run-7", 4); bumped == run1 {
+		t.Fatalf("source_version does not change the key")
+	}
+	other := src
+	other.Epoch = 2
+	if e := idempotencyKey(other, KindRun, "city-run-7", 3); e == run1 {
+		t.Fatalf("epoch does not change the key")
+	}
+}
+
+// A checkpoint minted for one source may not be picked up by another.
+func TestCheckpointIsBoundToItsSource(t *testing.T) {
+	f := NewFake("svc-city@tenant", "gc-city-01", "city")
+	store := NewMemoryStore()
+	p, err := NewProducer(f, Mapper{Source: citySource(), AllowRawContent: true}, store)
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	res := pushOK(t, p, chainWith(recordsUpTo(2), false))
+
+	// Same checkpoint bytes, different source identity: refuse rather than
+	// inherit another producer's frontier.
+	stolen := State{Epoch: 1, SourceID: "someone-else", RunTeamID: res.RunTeamID}
+	if err := store.Save(context.Background(), CheckpointKey(citySource(), "city-run-7"), stolen); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := p.Push(context.Background(), chainWith(recordsUpTo(2), false)); !errors.Is(err, ErrIdentityDrift) {
+		t.Fatalf("err = %v, want ErrIdentityDrift", err)
+	}
+}

--- a/pkg/cityneutral/cityneutral.go
+++ b/pkg/cityneutral/cityneutral.go
@@ -1,0 +1,96 @@
+// Package cityneutral is Gas City's producer adapter for the platform-neutral
+// run, session and transcript-record resources of the Beads Team Server v1 API.
+//
+// City is ONE OPTIONAL producer of those resources. A custom orchestrator with
+// no City in the picture uploads the same chain on its own credential and gets
+// records of the same shape, so nothing here may become a schema, an identity
+// or an authority that a non-City producer would have to satisfy. Every neutral
+// Team ID is minted by the server and read back off a response; this package
+// never invents one, and City-shaped facts (city, rig, formula) are display
+// only, gated, and never load-bearing.
+//
+// The layering is deliberate:
+//
+//   - [API] is the client seam. It carries one method per frozen operation this
+//     adapter uses and NOTHING else. The adapter speaks no HTTP: no URL, no
+//     header, no status code appears below this file's imports.
+//   - [Mapper] turns a City chain into neutral request bodies and refuses any
+//     mapping that would let a City fact reach a neutral authority field.
+//   - [Producer] owns checkpointing: stable source identity for dedup, a
+//     contiguous acknowledged frontier, and the refusals (changed replay, gap,
+//     post-finalize mutation) that stop this adapter instead of corrupting a
+//     neutral record.
+//
+// Rollback is per producer: stop calling Push and the acknowledged records stay
+// exactly as the server accepted them, because this package never rewrites an
+// accepted record and never sends a mutation for a finalized session.
+package cityneutral
+
+import "errors"
+
+// Frozen operation IDs from operation_matrix_v6. They are spelled here so a
+// reader can check the adapter's surface against the frozen matrix without
+// leaving the package, and so the client seam cannot quietly grow a route that
+// is not in the matrix.
+const (
+	OpUpsertRun              = "upsertRun"
+	OpGetRun                 = "getRun"
+	OpUpsertRunSession       = "upsertRunSession"
+	OpGetSession             = "getSession"
+	OpFinalizeSession        = "finalizeSession"
+	OpCreateTranscriptRecord = "createTranscriptRecord"
+	OpListTranscriptRecords  = "listTranscriptRecords"
+	OpGetSessionTranscript   = "getSessionTranscript"
+)
+
+// Resource kinds in the server's idempotency namespace. A key minted for a run
+// may not be replayed into a session, so the kind is part of the key preimage.
+const (
+	KindRun              = "run"
+	KindSession          = "session"
+	KindTranscriptRecord = "transcript_record"
+	// kindSessionFinalize namespaces the finalize key. Finalize has no resource
+	// kind of its own server-side, but a finalize key derived from the same
+	// preimage as the session upsert would collide with it.
+	kindSessionFinalize = "session_finalize"
+)
+
+// Bounds mirroring the server's validators, so an oversized field is refused
+// here with a source field name attached rather than as a correlated 4xx.
+const (
+	maxSourceNativeIDLen  = 200
+	maxDisplayTitleLength = 400
+)
+
+// Refusals. Every one of them stops this producer with its checkpoint intact:
+// nothing has been advanced past the last acknowledged record, so an operator
+// who fixes the source can restart and resume rather than reconcile.
+var (
+	// ErrChangedReplay is a record whose stable source identity was already
+	// acknowledged but whose payload no longer matches. Sending it would ask
+	// the server to rewrite accepted input, so the adapter stops instead.
+	ErrChangedReplay = errors.New("cityneutral: source identity replayed with changed payload")
+	// ErrGap is a record that would advance the frontier non-contiguously.
+	// Uploading it would leave a hole no later read could distinguish from
+	// data loss.
+	ErrGap = errors.New("cityneutral: non-contiguous record would skip the acknowledged frontier")
+	// ErrFinalized is any attempt to add to or mutate a session the server has
+	// already finalized. Finalize is one-way (FIN-1) and this adapter is not
+	// the component that gets to argue with it.
+	ErrFinalized = errors.New("cityneutral: session is finalized; input cannot be rewritten")
+	// ErrIdentityDrift is a server response binding a stable source identity to
+	// a different neutral Team ID than the checkpoint holds. That is either a
+	// wrong-tenant credential or a reset that was never declared; both are
+	// louder than a retry.
+	ErrIdentityDrift = errors.New("cityneutral: stable source identity resolved to a different neutral id")
+	// ErrNeutralAuthority is a mapping that would let a City fact become
+	// neutral authority.
+	ErrNeutralAuthority = errors.New("cityneutral: City-shaped field cannot become neutral authority")
+	// ErrInvalidChain is a City chain this adapter refuses to map at all.
+	ErrInvalidChain = errors.New("cityneutral: invalid City chain")
+	// ErrCredentialLeak is outbound bytes carrying credential evidence.
+	ErrCredentialLeak = errors.New("cityneutral: outbound payload carries credential evidence")
+	// ErrContentRoute is raw transcript content on a route not authorized to
+	// carry it.
+	ErrContentRoute = errors.New("cityneutral: raw content outside its authorized route")
+)

--- a/pkg/cityneutral/contract.go
+++ b/pkg/cityneutral/contract.go
@@ -1,0 +1,191 @@
+package cityneutral
+
+import (
+	"context"
+	"time"
+)
+
+// Status is the closed lifecycle-independent execution status of a neutral run
+// or session. City may not invent one: the canonical contract has no raw
+// passthrough, so an unmappable City state lands on StatusUnknown rather than
+// being echoed through.
+type Status string
+
+// The closed status vocabulary.
+const (
+	StatusPending   Status = "pending"
+	StatusRunning   Status = "running"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusCancelled Status = "cancelled" //nolint:misspell // frozen wire value of the neutral contract
+	StatusUnknown   Status = "unknown"
+)
+
+// Lifecycle is the input-completeness half, orthogonal to Status: a run can be
+// succeeded while its input is still partial because records are still
+// arriving. Only final is terminal, and the transition is one-way.
+type Lifecycle string
+
+// The closed lifecycle vocabulary.
+const (
+	LifecyclePartial Lifecycle = "partial"
+	LifecycleFinal   Lifecycle = "final"
+)
+
+// Role is the closed speaking role of a transcript record.
+type Role string
+
+// The closed role vocabulary.
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleSystem    Role = "system"
+	RoleTool      Role = "tool"
+	RoleUnknown   Role = "unknown"
+)
+
+// Coverage is the source's own claim about how complete this record's input is.
+// The vocabulary is the server's closed set, spelled in full because it is a
+// wire vocabulary; this producer emits only known, partial and unavailable.
+type Coverage string
+
+// The closed coverage vocabulary.
+const (
+	CoverageKnown         Coverage = "known"
+	CoverageUnavailable   Coverage = "unavailable"
+	CoveragePartial       Coverage = "partial"
+	CoverageMetered       Coverage = "metered"
+	CoverageEstimated     Coverage = "estimated"
+	CoverageLegacyUnknown Coverage = "legacy_unknown"
+)
+
+// ContributorRef is the represented author of a record: attribution only, never
+// an authorization input. It is distinct from the uploader (the credential the
+// request arrived on, which the server derives and this package never sends)
+// and from the source (the enrolled producer identity).
+type ContributorRef struct {
+	Kind string `json:"kind"`
+	Ref  string `json:"ref"`
+}
+
+// Upsert is the request body of upsertRun and upsertRunSession. One input type
+// serves both, exactly as the server's contract does: what differs is the
+// container, which comes from the path and the credential and never from the
+// body.
+type Upsert struct {
+	SourceEntityID string          `json:"source_entity_id"`
+	SourceVersion  uint64          `json:"source_version"`
+	Epoch          uint64          `json:"epoch"`
+	Status         Status          `json:"status"`
+	Lifecycle      Lifecycle       `json:"lifecycle"`
+	StartedAt      time.Time       `json:"started_at"`
+	EndedAt        *time.Time      `json:"ended_at,omitempty"`
+	ProjectID      string          `json:"project_id,omitempty"`
+	IssueID        string          `json:"issue_id,omitempty"`
+	Title          string          `json:"title,omitempty"`
+	Coverage       Coverage        `json:"coverage,omitempty"`
+	Contributor    *ContributorRef `json:"contributor,omitempty"`
+}
+
+// TranscriptRecordIngest is the request body of createTranscriptRecord.
+type TranscriptRecordIngest struct {
+	SourceMessageID string          `json:"source_message_id"`
+	SourceVersion   uint64          `json:"source_version"`
+	Epoch           uint64          `json:"epoch"`
+	Ordinal         *uint64         `json:"ordinal,omitempty"`
+	Role            Role            `json:"role"`
+	Author          *ContributorRef `json:"author,omitempty"`
+	OccurredAt      time.Time       `json:"occurred_at"`
+	Text            string          `json:"text,omitempty"`
+	ContentRef      string          `json:"content_ref,omitempty"`
+	Coverage        Coverage        `json:"coverage,omitempty"`
+}
+
+// Run is the closed neutral run as a read returns it. ID is the server-minted
+// Team ID; SourceRunID is the bounded source-native ID. Both are present so a
+// caller can tell them apart, and this producer treats ID as read-only fact.
+type Run struct {
+	ID          string    `json:"id"`
+	SourceRunID string    `json:"source_run_id"`
+	SourceID    string    `json:"source_id"`
+	SourceKind  string    `json:"source_kind"`
+	Status      Status    `json:"status"`
+	Lifecycle   Lifecycle `json:"lifecycle"`
+	Epoch       uint64    `json:"epoch"`
+	Version     uint64    `json:"version"`
+	Finalized   bool      `json:"finalized"`
+	ETag        string    `json:"etag"`
+}
+
+// Session is the closed neutral session as a read returns it. RunID is the
+// same-workspace link to its run, resolved by the server at attach time.
+type Session struct {
+	ID              string    `json:"id"`
+	RunID           string    `json:"run_id"`
+	SourceSessionID string    `json:"source_session_id"`
+	SourceID        string    `json:"source_id"`
+	SourceKind      string    `json:"source_kind"`
+	Status          Status    `json:"status"`
+	Lifecycle       Lifecycle `json:"lifecycle"`
+	Epoch           uint64    `json:"epoch"`
+	Version         uint64    `json:"version"`
+	Finalized       bool      `json:"finalized"`
+	ETag            string    `json:"etag"`
+}
+
+// TranscriptRecord is the closed neutral transcript record as a read returns
+// it.
+type TranscriptRecord struct {
+	ID              string          `json:"id"`
+	SessionID       string          `json:"session_id"`
+	SourceMessageID string          `json:"source_message_id"`
+	SourceID        string          `json:"source_id"`
+	SourceKind      string          `json:"source_kind"`
+	Role            Role            `json:"role"`
+	Author          *ContributorRef `json:"author"`
+	OccurredAt      time.Time       `json:"occurred_at"`
+	Ordinal         *uint64         `json:"ordinal"`
+	Epoch           uint64          `json:"epoch"`
+	Version         uint64          `json:"version"`
+	ContentStatus   string          `json:"content_status"`
+	ETag            string          `json:"etag"`
+}
+
+// TranscriptItem is one entry of the ordered session transcript aggregate.
+type TranscriptItem struct {
+	RecordID        string          `json:"record_id"`
+	SourceMessageID string          `json:"source_message_id"`
+	Role            Role            `json:"role"`
+	Author          *ContributorRef `json:"author"`
+	Ordinal         *uint64         `json:"ordinal"`
+	ContentStatus   string          `json:"content_status"`
+	Text            string          `json:"text"`
+}
+
+// API is the seam onto the public v1 client.
+//
+// It carries exactly the eight frozen operations this adapter needs and no
+// transport vocabulary at all — no base URL, no header, no status code. That is
+// what keeps this package from hand-rolling HTTP: the concrete implementation
+// is the generated public client for the canonical contract, and everything
+// below is written against these signatures.
+//
+// NOTE: the contract program generates a public TypeScript client and a
+// server-side Go interface; there is no generated Go *client* module a Go
+// producer can import today. This interface is the shape that client binds to,
+// method-for-method, so binding it is a wiring change and never a logic change.
+//
+// The idempotency key is a caller-supplied argument rather than something an
+// implementation invents, because the key is part of THIS package's
+// dedup contract: [Producer] derives it from stable source identity so that a
+// retry replays and a changed payload conflicts.
+type API interface {
+	UpsertRun(ctx context.Context, body Upsert, idempotencyKey string) (Run, error)
+	GetRun(ctx context.Context, runTeamID string) (Run, error)
+	UpsertRunSession(ctx context.Context, runTeamID string, body Upsert, idempotencyKey string) (Session, error)
+	GetSession(ctx context.Context, sessionTeamID string) (Session, error)
+	FinalizeSession(ctx context.Context, sessionTeamID string, idempotencyKey string) (Session, error)
+	CreateTranscriptRecord(ctx context.Context, sessionTeamID string, body TranscriptRecordIngest, idempotencyKey string) (TranscriptRecord, error)
+	ListTranscriptRecords(ctx context.Context, sessionTeamID string) ([]TranscriptRecord, error)
+	GetSessionTranscript(ctx context.Context, sessionTeamID string) ([]TranscriptItem, error)
+}

--- a/pkg/cityneutral/fake.go
+++ b/pkg/cityneutral/fake.go
@@ -1,0 +1,301 @@
+package cityneutral
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Fake is an in-memory stand-in for the neutral v1 API.
+//
+// It is not a mock of this package's expectations: it models the parts of the
+// server contract a producer can actually get wrong — server-minted Team IDs,
+// idempotent replay keyed on Idempotency-Key, conflict on a changed payload
+// under a used key, one-way finalize, and ownership derived from the credential
+// rather than from the body. A producer that satisfies this Fake is a producer
+// whose failures against the real server are transport failures.
+//
+// It lives outside _test.go on purpose: a custom orchestrator replaying the
+// same conformance chain needs it too, and the parity claim is only meaningful
+// if both producers run against the SAME server model.
+type Fake struct {
+	mu sync.Mutex
+
+	// Uploader is who the credential says is calling. The server derives it;
+	// no request body may set it, and this Fake never reads it from one.
+	Uploader string
+	// SourceID and SourceKind are the enrolled producer identity bound to the
+	// credential. Also server-derived, also never read from a body.
+	SourceID   string
+	SourceKind string
+
+	// Fail, when set, is returned by the next call and then cleared. It models
+	// a transient fault — a credential mid-rotation, a 5xx — so a test can prove
+	// the producer neither advances nor duplicates across it.
+	Fail error
+
+	seq      uint64
+	runs     map[string]*Run
+	runIdx   map[string]string
+	sessions map[string]*Session
+	sessIdx  map[string]string
+	records  map[string][]TranscriptRecord
+	text     map[string]string
+	keys     map[string]fakeKey
+	// Calls records every accepted operation in order, for parity comparison.
+	Calls []string
+}
+
+type fakeKey struct {
+	digest string
+	id     string
+}
+
+// Fake failure modes, mapped from the server's problem types.
+var (
+	// ErrConflict is an Idempotency-Key reused with a different payload.
+	ErrConflict = errors.New("cityneutral: idempotency key reused with a different payload")
+	// ErrSessionFinalized is a write to a finalized session.
+	ErrSessionFinalized = errors.New("cityneutral: session is finalized")
+	// ErrNotFound is a read or write against an unknown neutral ID.
+	ErrNotFound = errors.New("cityneutral: not found")
+	// ErrMissingKey is a mutation with no Idempotency-Key.
+	ErrMissingKey = errors.New("cityneutral: Idempotency-Key is required")
+)
+
+// NewFake returns a Fake bound to one credential's uploader and source.
+func NewFake(uploader, sourceID, sourceKind string) *Fake {
+	return &Fake{
+		Uploader: uploader, SourceID: sourceID, SourceKind: sourceKind,
+		runs: map[string]*Run{}, runIdx: map[string]string{},
+		sessions: map[string]*Session{}, sessIdx: map[string]string{},
+		records: map[string][]TranscriptRecord{}, text: map[string]string{},
+		keys: map[string]fakeKey{},
+	}
+}
+
+func (f *Fake) mint(prefix string) string {
+	f.seq++
+	return fmt.Sprintf("%s_%016x", prefix, f.seq)
+}
+
+// take consumes a pending injected failure.
+func (f *Fake) take() error {
+	if f.Fail == nil {
+		return nil
+	}
+	err := f.Fail
+	f.Fail = nil
+	return err
+}
+
+// replay resolves an idempotency key: it returns the prior id when the key and
+// payload match, and refuses when the key was used for different bytes.
+func (f *Fake) replay(key, digest string) (string, bool, error) {
+	if key == "" {
+		return "", false, ErrMissingKey
+	}
+	prior, ok := f.keys[key]
+	if !ok {
+		return "", false, nil
+	}
+	if prior.digest != digest {
+		return "", false, fmt.Errorf("%w: key %s", ErrConflict, key)
+	}
+	return prior.id, true, nil
+}
+
+// UpsertRun implements API.
+func (f *Fake) UpsertRun(_ context.Context, body Upsert, key string) (Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return Run{}, err
+	}
+	digest := payloadDigest(body)
+	if id, hit, err := f.replay(key, digest); err != nil {
+		return Run{}, err
+	} else if hit {
+		f.Calls = append(f.Calls, OpUpsertRun+" replay")
+		return *f.runs[id], nil
+	}
+	idxKey := f.SourceID + "/" + body.SourceEntityID
+	id, ok := f.runIdx[idxKey]
+	if !ok {
+		id = f.mint("run")
+		f.runIdx[idxKey] = id
+		f.runs[id] = &Run{
+			ID: id, SourceRunID: body.SourceEntityID,
+			SourceID: f.SourceID, SourceKind: f.SourceKind,
+		}
+	}
+	run := f.runs[id]
+	run.Status, run.Lifecycle, run.Epoch = body.Status, body.Lifecycle, body.Epoch
+	run.Version = body.SourceVersion
+	run.ETag = payloadDigest(*run)
+	f.keys[key] = fakeKey{digest: digest, id: id}
+	f.Calls = append(f.Calls, OpUpsertRun)
+	return *run, nil
+}
+
+// GetRun implements API.
+func (f *Fake) GetRun(_ context.Context, runTeamID string) (Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	run, ok := f.runs[runTeamID]
+	if !ok {
+		return Run{}, fmt.Errorf("%w: run %s", ErrNotFound, runTeamID)
+	}
+	f.Calls = append(f.Calls, OpGetRun)
+	return *run, nil
+}
+
+// UpsertRunSession implements API.
+func (f *Fake) UpsertRunSession(_ context.Context, runTeamID string, body Upsert, key string) (Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return Session{}, err
+	}
+	if _, ok := f.runs[runTeamID]; !ok {
+		return Session{}, fmt.Errorf("%w: run %s", ErrNotFound, runTeamID)
+	}
+	digest := payloadDigest(body)
+	if id, hit, err := f.replay(key, digest); err != nil {
+		return Session{}, err
+	} else if hit {
+		f.Calls = append(f.Calls, OpUpsertRunSession+" replay")
+		return *f.sessions[id], nil
+	}
+	idxKey := f.SourceID + "/" + runTeamID + "/" + body.SourceEntityID
+	id, ok := f.sessIdx[idxKey]
+	if !ok {
+		id = f.mint("ses")
+		f.sessIdx[idxKey] = id
+		f.sessions[id] = &Session{
+			ID: id, RunID: runTeamID, SourceSessionID: body.SourceEntityID,
+			SourceID: f.SourceID, SourceKind: f.SourceKind,
+		}
+	}
+	sess := f.sessions[id]
+	if sess.Finalized {
+		return Session{}, fmt.Errorf("%w: %s", ErrSessionFinalized, id)
+	}
+	sess.Status, sess.Lifecycle, sess.Epoch = body.Status, body.Lifecycle, body.Epoch
+	sess.Version = body.SourceVersion
+	sess.ETag = payloadDigest(*sess)
+	f.keys[key] = fakeKey{digest: digest, id: id}
+	f.Calls = append(f.Calls, OpUpsertRunSession)
+	return *sess, nil
+}
+
+// GetSession implements API.
+func (f *Fake) GetSession(_ context.Context, sessionTeamID string) (Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sess, ok := f.sessions[sessionTeamID]
+	if !ok {
+		return Session{}, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	f.Calls = append(f.Calls, OpGetSession)
+	return *sess, nil
+}
+
+// FinalizeSession implements API. Finalize is one-way and idempotent.
+func (f *Fake) FinalizeSession(_ context.Context, sessionTeamID, key string) (Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return Session{}, err
+	}
+	sess, ok := f.sessions[sessionTeamID]
+	if !ok {
+		return Session{}, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	if key == "" {
+		return Session{}, ErrMissingKey
+	}
+	sess.Finalized = true
+	sess.Lifecycle = LifecycleFinal
+	sess.ETag = payloadDigest(*sess)
+	f.Calls = append(f.Calls, OpFinalizeSession)
+	return *sess, nil
+}
+
+// CreateTranscriptRecord implements API.
+func (f *Fake) CreateTranscriptRecord(_ context.Context, sessionTeamID string, body TranscriptRecordIngest, key string) (TranscriptRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return TranscriptRecord{}, err
+	}
+	sess, ok := f.sessions[sessionTeamID]
+	if !ok {
+		return TranscriptRecord{}, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	digest := payloadDigest(body)
+	if id, hit, err := f.replay(key, digest); err != nil {
+		return TranscriptRecord{}, err
+	} else if hit {
+		for _, r := range f.records[sessionTeamID] {
+			if r.ID == id {
+				f.Calls = append(f.Calls, OpCreateTranscriptRecord+" replay")
+				return r, nil
+			}
+		}
+	}
+	if sess.Finalized {
+		return TranscriptRecord{}, fmt.Errorf("%w: %s", ErrSessionFinalized, sessionTeamID)
+	}
+	id := f.mint("rec")
+	status := "missing"
+	if body.Text != "" {
+		status = "available"
+		f.text[id] = body.Text
+	} else if body.ContentRef != "" {
+		status = "missing"
+	}
+	rec := TranscriptRecord{
+		ID: id, SessionID: sessionTeamID, SourceMessageID: body.SourceMessageID,
+		SourceID: f.SourceID, SourceKind: f.SourceKind,
+		Role: body.Role, Author: body.Author, OccurredAt: body.OccurredAt,
+		Ordinal: body.Ordinal, Epoch: body.Epoch, Version: body.SourceVersion,
+		ContentStatus: status,
+	}
+	rec.ETag = payloadDigest(rec)
+	f.records[sessionTeamID] = append(f.records[sessionTeamID], rec)
+	f.keys[key] = fakeKey{digest: digest, id: id}
+	f.Calls = append(f.Calls, OpCreateTranscriptRecord)
+	return rec, nil
+}
+
+// ListTranscriptRecords implements API.
+func (f *Fake) ListTranscriptRecords(_ context.Context, sessionTeamID string) ([]TranscriptRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.sessions[sessionTeamID]; !ok {
+		return nil, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	f.Calls = append(f.Calls, OpListTranscriptRecords)
+	return append([]TranscriptRecord(nil), f.records[sessionTeamID]...), nil
+}
+
+// GetSessionTranscript implements API.
+func (f *Fake) GetSessionTranscript(_ context.Context, sessionTeamID string) ([]TranscriptItem, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.sessions[sessionTeamID]; !ok {
+		return nil, fmt.Errorf("%w: session %s", ErrNotFound, sessionTeamID)
+	}
+	items := make([]TranscriptItem, 0, len(f.records[sessionTeamID]))
+	for _, r := range f.records[sessionTeamID] {
+		items = append(items, TranscriptItem{
+			RecordID: r.ID, SourceMessageID: r.SourceMessageID, Role: r.Role,
+			Author: r.Author, Ordinal: r.Ordinal, ContentStatus: r.ContentStatus,
+			Text: f.text[r.ID],
+		})
+	}
+	f.Calls = append(f.Calls, OpGetSessionTranscript)
+	return items, nil
+}

--- a/pkg/cityneutral/mapping.go
+++ b/pkg/cityneutral/mapping.go
@@ -1,0 +1,463 @@
+package cityneutral
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CityRun is the City-native run as this adapter reads it. Every field here is
+// source-native: none of it is authority on the neutral side, and the neutral
+// Team ID is absent by construction — there is no field on this struct that
+// could carry one.
+type CityRun struct {
+	// RunID is City's own stable run identifier. It becomes source_entity_id,
+	// which is a source-native ID, NOT a neutral one.
+	RunID   string
+	Status  string
+	Started time.Time
+	Ended   *time.Time
+	// ProjectID and IssueID are source-native scope refs.
+	ProjectID string
+	IssueID   string
+	// Version is City's monotonic revision of this run. It drives
+	// source_version, so a re-read that changed nothing sends nothing new.
+	Version uint64
+	// Rig, Formula and City are City-shaped facts. They are display-only and
+	// gated: with DisplayPolicy off they never leave the process, and they can
+	// never reach an identity, a scope or a status field. Enforced by
+	// [Mapper.MapRun] and asserted by the neutral-authority tests.
+	Rig     string
+	Formula string
+	City    string
+}
+
+// CitySession is one City session under a run.
+type CitySession struct {
+	SessionID string
+	Status    string
+	Started   time.Time
+	Ended     *time.Time
+	Version   uint64
+	// Complete says City considers this session's input closed. It is what
+	// makes the adapter finalize, and it is one-way: a later chain that flips
+	// it back does not un-finalize anything.
+	Complete bool
+	Records  []CityRecord
+}
+
+// CityRecord is one City transcript message.
+type CityRecord struct {
+	// MessageID is City's stable per-message identity. Together with the
+	// session it is the dedup key: the same MessageID with the same payload is
+	// a replay, and with a different payload it is a refusal.
+	MessageID string
+	// Ordinal is City's position within the session, 1-based. Contiguity is
+	// checked on it, so a source that cannot produce one cannot use this
+	// adapter's ordering guarantees.
+	Ordinal uint64
+	Role    string
+	// Author is the represented author: who spoke. Never the uploader, never
+	// the source, never an authorization input.
+	Author *ContributorRef
+	At     time.Time
+	// Text is raw transcript content. It is only ever serialized onto the
+	// transcript-record route; [ScanOutbound] refuses it anywhere else.
+	Text string
+	// ContentRef is a reference to content held elsewhere, for records whose
+	// body this producer is not authorized to ship.
+	ContentRef string
+	Version    uint64
+}
+
+// CityChain is one run and its sessions, the unit [Producer.Push] operates on.
+type CityChain struct {
+	Run      CityRun
+	Sessions []CitySession
+}
+
+// Source identifies this producer to the mapper. SourceID is the enrolled
+// producer identity the server already knows; it is echoed back on reads as
+// provenance and is NOT a credential.
+type Source struct {
+	SourceID string
+	// Kind is the source class, e.g. "city". Used in the idempotency preimage
+	// so two producers with the same native IDs cannot collide.
+	Kind string
+	// Epoch is the frozen source epoch. It advances only on a declared reset,
+	// never on a restart, and the adapter refuses to guess one.
+	Epoch uint64
+}
+
+// Mapper turns a City chain into neutral request bodies.
+//
+// It holds no transport and no state: give it the same chain twice and it
+// produces byte-identical bodies, which is what makes the stable-identity
+// digest meaningful.
+type Mapper struct {
+	Source Source
+	// AllowDisplayContent gates free-form display egress (titles built from
+	// City rig/formula names). Default off: an ungated producer would leak
+	// tenant-shaped strings into a neutral record on nothing but a code path.
+	AllowDisplayContent bool
+	// AllowRawContent gates shipping message text at all. Off means every
+	// record goes as a reference, which is the mode a City with no signed
+	// content policy runs in.
+	AllowRawContent bool
+}
+
+// statusMap is the City→neutral status projection. It is closed on the neutral
+// side: an unrecognized City status becomes StatusUnknown rather than being
+// passed through, because the neutral vocabulary is not City's to extend.
+var statusMap = map[string]Status{
+	"pending":   StatusPending,
+	"queued":    StatusPending,
+	"running":   StatusRunning,
+	"active":    StatusRunning,
+	"succeeded": StatusSucceeded,
+	"done":      StatusSucceeded,
+	"failed":    StatusFailed,
+	"error":     StatusFailed,
+	"cancelled": StatusCancelled, //nolint:misspell // frozen wire value of the neutral contract
+	"canceled":  StatusCancelled,
+}
+
+// roleMap is the City→neutral role projection, closed the same way.
+var roleMap = map[string]Role{
+	"user":      RoleUser,
+	"human":     RoleUser,
+	"assistant": RoleAssistant,
+	"agent":     RoleAssistant,
+	"system":    RoleSystem,
+	"tool":      RoleTool,
+}
+
+var contributorKinds = map[string]bool{
+	"human": true, "agent": true, "worker": true, "model": true, "system": true,
+}
+
+// secretLocatorPatterns mirror the server's refusal list. Screening at the
+// producer is not redundant: it turns a leak into a local error with a source
+// field name attached, instead of a 4xx an operator has to correlate.
+var secretLocatorPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)^arn:aws:secretsmanager:`),
+	regexp.MustCompile(`(?i)^arn:aws:kms:`),
+	regexp.MustCompile(`(?i)^(vault|secret)://`),
+	regexp.MustCompile(`(?i)^projects/[^/]+/secrets/`),
+	regexp.MustCompile(`(?i)\b(AKIA|ASIA)[0-9A-Z]{16}\b`),
+	regexp.MustCompile(`(?i)\b(sk|rk)-[A-Za-z0-9]{20,}`),
+	regexp.MustCompile(`(?i)^(gh[pousr]|xox[baprs])_[A-Za-z0-9]{10,}`),
+	regexp.MustCompile(`(?i)-----BEGIN [A-Z ]*PRIVATE KEY-----`),
+	regexp.MustCompile(`(?i)[?&](access_token|api_key|apikey|secret|password|signature)=`),
+	regexp.MustCompile(`(?i)^(bearer|basic) [A-Za-z0-9+/._-]{16,}`),
+}
+
+// SecretLocator reports whether s carries credential evidence.
+func SecretLocator(s string) bool {
+	for _, re := range secretLocatorPatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateNativeID(field, v string) error {
+	switch {
+	case strings.TrimSpace(v) == "":
+		return fmt.Errorf("%w: %s is required", ErrInvalidChain, field)
+	case len(v) > maxSourceNativeIDLen:
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidChain, field, maxSourceNativeIDLen)
+	case strings.ContainsAny(v, "\x00\n\r"):
+		return fmt.Errorf("%w: %s carries a control character", ErrInvalidChain, field)
+	case SecretLocator(v):
+		return fmt.Errorf("%w: %s", ErrCredentialLeak, field)
+	}
+	return nil
+}
+
+func (m Mapper) validateSource() error {
+	if err := validateNativeID("source.source_id", m.Source.SourceID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(m.Source.Kind) == "" {
+		return fmt.Errorf("%w: source.kind is required", ErrInvalidChain)
+	}
+	if m.Source.Epoch == 0 {
+		return fmt.Errorf("%w: source.epoch is required and starts at 1", ErrInvalidChain)
+	}
+	return nil
+}
+
+// display builds the gated display title. City facts reach a neutral record
+// only through here, only as a title, and only with the gate open.
+func (m Mapper) display(parts ...string) string {
+	if !m.AllowDisplayContent {
+		return ""
+	}
+	kept := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || SecretLocator(p) {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	title := strings.Join(kept, " / ")
+	if len(title) > maxDisplayTitleLength {
+		title = title[:maxDisplayTitleLength]
+	}
+	return title
+}
+
+// MapRun projects a City run onto the neutral upsert body.
+//
+// The neutral-authority rule lives here: rig, formula and city name are
+// arguments to [Mapper.display] and to nothing else. source_entity_id is the
+// City run ID and project/issue are City's own scope refs; none of them is a
+// neutral ID, and the neutral ID is not an input to this function at all.
+func (m Mapper) MapRun(run CityRun) (Upsert, error) {
+	if err := m.validateSource(); err != nil {
+		return Upsert{}, err
+	}
+	if err := validateNativeID("run.run_id", run.RunID); err != nil {
+		return Upsert{}, err
+	}
+	if run.Version == 0 {
+		return Upsert{}, fmt.Errorf("%w: run.version is required and starts at 1", ErrInvalidChain)
+	}
+	if run.Started.IsZero() {
+		return Upsert{}, fmt.Errorf("%w: run.started is required", ErrInvalidChain)
+	}
+	for field, v := range map[string]string{"run.project_id": run.ProjectID, "run.issue_id": run.IssueID} {
+		if v == "" {
+			continue
+		}
+		if err := validateNativeID(field, v); err != nil {
+			return Upsert{}, err
+		}
+	}
+	// A City fact that has managed to look like a neutral Team ID is still not
+	// one, and the cheapest place to say so is before it is serialized.
+	for field, v := range map[string]string{"run.rig": run.Rig, "run.formula": run.Formula, "run.city": run.City} {
+		if looksNeutralID(v) {
+			return Upsert{}, fmt.Errorf("%w: %s", ErrNeutralAuthority, field)
+		}
+	}
+	up := Upsert{
+		SourceEntityID: run.RunID,
+		SourceVersion:  run.Version,
+		Epoch:          m.Source.Epoch,
+		Status:         mapStatus(run.Status),
+		Lifecycle:      LifecyclePartial,
+		StartedAt:      run.Started.UTC(),
+		ProjectID:      run.ProjectID,
+		IssueID:        run.IssueID,
+		Title:          m.display(run.Rig, run.Formula),
+		Coverage:       CoverageKnown,
+	}
+	if run.Ended != nil {
+		e := run.Ended.UTC()
+		if e.Before(up.StartedAt) {
+			return Upsert{}, fmt.Errorf("%w: run.ended precedes run.started", ErrInvalidChain)
+		}
+		up.EndedAt = &e
+	}
+	return up, nil
+}
+
+// MapSession projects a City session onto the neutral upsert body. The run it
+// belongs to is not in the body: it comes from the path, so a session can never
+// claim a run the credential does not reach.
+func (m Mapper) MapSession(sess CitySession) (Upsert, error) {
+	if err := m.validateSource(); err != nil {
+		return Upsert{}, err
+	}
+	if err := validateNativeID("session.session_id", sess.SessionID); err != nil {
+		return Upsert{}, err
+	}
+	if sess.Version == 0 {
+		return Upsert{}, fmt.Errorf("%w: session.version is required and starts at 1", ErrInvalidChain)
+	}
+	if sess.Started.IsZero() {
+		return Upsert{}, fmt.Errorf("%w: session.started is required", ErrInvalidChain)
+	}
+	up := Upsert{
+		SourceEntityID: sess.SessionID,
+		SourceVersion:  sess.Version,
+		Epoch:          m.Source.Epoch,
+		Status:         mapStatus(sess.Status),
+		Lifecycle:      LifecyclePartial,
+		StartedAt:      sess.Started.UTC(),
+		Coverage:       CoverageKnown,
+	}
+	if sess.Ended != nil {
+		e := sess.Ended.UTC()
+		if e.Before(up.StartedAt) {
+			return Upsert{}, fmt.Errorf("%w: session.ended precedes session.started", ErrInvalidChain)
+		}
+		up.EndedAt = &e
+	}
+	return up, nil
+}
+
+// MapRecord projects a City message onto the transcript ingest body.
+//
+// Author is the represented author and travels as attribution. The uploader is
+// the credential the request rides on and appears nowhere in this body; the
+// source is [Source.SourceID] and is likewise server-side provenance, not a
+// body field. Keeping all three apart is the whole point of this function.
+func (m Mapper) MapRecord(rec CityRecord) (TranscriptRecordIngest, error) {
+	if err := m.validateSource(); err != nil {
+		return TranscriptRecordIngest{}, err
+	}
+	if err := validateNativeID("record.message_id", rec.MessageID); err != nil {
+		return TranscriptRecordIngest{}, err
+	}
+	if rec.Ordinal == 0 {
+		return TranscriptRecordIngest{}, fmt.Errorf("%w: record.ordinal is required and starts at 1", ErrInvalidChain)
+	}
+	if rec.At.IsZero() {
+		return TranscriptRecordIngest{}, fmt.Errorf("%w: record.at is required", ErrInvalidChain)
+	}
+	version := rec.Version
+	if version == 0 {
+		version = 1
+	}
+	ord := rec.Ordinal
+	in := TranscriptRecordIngest{
+		SourceMessageID: rec.MessageID,
+		SourceVersion:   version,
+		Epoch:           m.Source.Epoch,
+		Ordinal:         &ord,
+		Role:            mapRole(rec.Role),
+		OccurredAt:      rec.At.UTC(),
+		Coverage:        CoverageKnown,
+	}
+	if rec.Author != nil {
+		if !contributorKinds[rec.Author.Kind] {
+			return TranscriptRecordIngest{}, fmt.Errorf("%w: unknown author kind %q", ErrInvalidChain, rec.Author.Kind)
+		}
+		if err := validateNativeID("record.author.ref", rec.Author.Ref); err != nil {
+			return TranscriptRecordIngest{}, err
+		}
+		author := *rec.Author
+		in.Author = &author
+	}
+	switch {
+	case m.AllowRawContent && rec.Text != "":
+		if SecretLocator(rec.Text) {
+			return TranscriptRecordIngest{}, fmt.Errorf("%w: record.text", ErrCredentialLeak)
+		}
+		in.Text = rec.Text
+	case rec.ContentRef != "":
+		if err := validateNativeID("record.content_ref", rec.ContentRef); err != nil {
+			return TranscriptRecordIngest{}, err
+		}
+		in.ContentRef = rec.ContentRef
+		in.Coverage = CoveragePartial
+	case rec.Text != "":
+		// Content exists but this producer is not authorized to ship it. The
+		// record still goes, because a transcript with a known-withheld turn is
+		// truer than a transcript with a missing one, and `unavailable` is the
+		// server's word for exactly that.
+		in.Coverage = CoverageUnavailable
+	}
+	return in, nil
+}
+
+func mapStatus(s string) Status {
+	if v, ok := statusMap[strings.ToLower(strings.TrimSpace(s))]; ok {
+		return v
+	}
+	return StatusUnknown
+}
+
+func mapRole(r string) Role {
+	if v, ok := roleMap[strings.ToLower(strings.TrimSpace(r))]; ok {
+		return v
+	}
+	return RoleUnknown
+}
+
+// neutralIDPattern is the server's Team ID shape. City strings that match it
+// are refused where they would be mistaken for one.
+var neutralIDPattern = regexp.MustCompile(`^(run|ses|rec)_[0-9a-z]{16,}$`)
+
+func looksNeutralID(v string) bool { return neutralIDPattern.MatchString(strings.TrimSpace(v)) }
+
+// forbiddenBodyFields are members no request body of this adapter may carry.
+// They are the fields that would let a producer assert something only the
+// server may decide: ownership, the uploader, the tenant, or the neutral ID.
+var forbiddenBodyFields = map[string]bool{
+	"id": true, "run_id": true, "session_id": true, "record_id": true,
+	"uploaded_by": true, "uploader": true, "uploader_id": true,
+	"tenant": true, "tenant_id": true, "workspace": true, "workspace_id": true,
+	"source_id": true, "key_id": true, "actor": true, "actor_id": true,
+	"principal": true, "token": true, "authorization": true, "credential": true,
+}
+
+// ScanOutbound is the provenance-and-content scanner: it walks the serialized
+// form of a body about to be sent and refuses it if the bytes carry credential
+// evidence, an ownership assertion, or raw content on a route not authorized to
+// carry it.
+//
+// allowContent is true only for the transcript-record route. Scanning the
+// serialized form rather than the struct is deliberate: it is the bytes that
+// leave, and a future field added to a DTO is covered without anyone
+// remembering to update this function.
+func ScanOutbound(body any, allowContent bool) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("cityneutral: scan encode: %w", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return fmt.Errorf("cityneutral: scan decode: %w", err)
+	}
+	return scanObject(generic, allowContent, "")
+}
+
+func scanObject(obj map[string]any, allowContent bool, path string) error {
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		at := k
+		if path != "" {
+			at = path + "." + k
+		}
+		if forbiddenBodyFields[k] {
+			return fmt.Errorf("%w: body carries %s", ErrNeutralAuthority, at)
+		}
+		if (k == "text" || k == "content" || k == "body") && !allowContent {
+			return fmt.Errorf("%w: %s", ErrContentRoute, at)
+		}
+		switch v := obj[k].(type) {
+		case string:
+			if SecretLocator(v) {
+				return fmt.Errorf("%w: %s", ErrCredentialLeak, at)
+			}
+		case map[string]any:
+			if err := scanObject(v, allowContent, at); err != nil {
+				return err
+			}
+		case []any:
+			for i, item := range v {
+				nested, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if err := scanObject(nested, allowContent, fmt.Sprintf("%s[%d]", at, i)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cityneutral/parity_test.go
+++ b/pkg/cityneutral/parity_test.go
@@ -1,0 +1,294 @@
+package cityneutral
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+var t0 = time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+func citySource() Source {
+	return Source{SourceID: "gc-city-01", Kind: "city", Epoch: 1}
+}
+
+func sampleChain() CityChain {
+	end := t0.Add(9 * time.Minute)
+	return CityChain{
+		Run: CityRun{
+			RunID: "city-run-7", Status: "succeeded", Started: t0, Ended: &end,
+			ProjectID: "proj-a", IssueID: "bd-1", Version: 3,
+			Rig: "rig-alpha", Formula: "formula-bravo", City: "sf",
+		},
+		Sessions: []CitySession{{
+			SessionID: "city-sess-1", Status: "succeeded", Started: t0, Ended: &end,
+			Version: 2, Complete: true,
+			Records: []CityRecord{
+				{
+					MessageID: "m1", Ordinal: 1, Role: "user", At: t0.Add(time.Minute),
+					Author: &ContributorRef{Kind: "human", Ref: "u-42"}, Text: "kick it off",
+				},
+				{
+					MessageID: "m2", Ordinal: 2, Role: "agent", At: t0.Add(2 * time.Minute),
+					Author: &ContributorRef{Kind: "agent", Ref: "worker-9"}, Text: "on it",
+				},
+				{MessageID: "m3", Ordinal: 3, Role: "tool", At: t0.Add(3 * time.Minute), ContentRef: "blob-3"},
+			},
+		}},
+	}
+}
+
+func newCityProducer(t *testing.T, f *Fake, mut func(*Mapper)) *Producer {
+	t.Helper()
+	m := Mapper{Source: citySource(), AllowRawContent: true}
+	if mut != nil {
+		mut(&m)
+	}
+	p, err := NewProducer(f, m, NewMemoryStore())
+	if err != nil {
+		t.Fatalf("NewProducer: %v", err)
+	}
+	return p
+}
+
+// customUpload is a producer with no City in the picture: it builds the neutral
+// bodies from its own domain and mints its own keys. It exists so the parity
+// assertion compares City against a real second implementation rather than
+// against the City adapter wearing a different hat.
+func customUpload(t *testing.T, api API) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	end := t0.Add(9 * time.Minute)
+	run, err := api.UpsertRun(ctx, Upsert{
+		SourceEntityID: "orch-run-7", SourceVersion: 3, Epoch: 1,
+		Status: StatusSucceeded, Lifecycle: LifecyclePartial,
+		StartedAt: t0, EndedAt: &end, ProjectID: "proj-a", IssueID: "bd-1",
+		Coverage: CoverageKnown,
+	}, "11111111-1111-5111-8111-111111111111")
+	if err != nil {
+		t.Fatalf("custom UpsertRun: %v", err)
+	}
+	sess, err := api.UpsertRunSession(ctx, run.ID, Upsert{
+		SourceEntityID: "orch-sess-1", SourceVersion: 2, Epoch: 1,
+		Status: StatusSucceeded, Lifecycle: LifecyclePartial,
+		StartedAt: t0, EndedAt: &end, Coverage: CoverageKnown,
+	}, "22222222-2222-5222-8222-222222222222")
+	if err != nil {
+		t.Fatalf("custom UpsertRunSession: %v", err)
+	}
+	ords := []uint64{1, 2, 3}
+	bodies := []TranscriptRecordIngest{
+		{
+			SourceMessageID: "a1", SourceVersion: 1, Epoch: 1, Ordinal: &ords[0], Role: RoleUser,
+			Author: &ContributorRef{Kind: "human", Ref: "u-42"}, OccurredAt: t0.Add(time.Minute),
+			Text: "kick it off", Coverage: CoverageKnown,
+		},
+		{
+			SourceMessageID: "a2", SourceVersion: 1, Epoch: 1, Ordinal: &ords[1], Role: RoleAssistant,
+			Author: &ContributorRef{Kind: "agent", Ref: "worker-9"}, OccurredAt: t0.Add(2 * time.Minute),
+			Text: "on it", Coverage: CoverageKnown,
+		},
+		{
+			SourceMessageID: "a3", SourceVersion: 1, Epoch: 1, Ordinal: &ords[2], Role: RoleTool,
+			OccurredAt: t0.Add(3 * time.Minute), ContentRef: "blob-3", Coverage: CoveragePartial,
+		},
+	}
+	for i, b := range bodies {
+		key := []string{
+			"33333333-3333-5333-8333-333333333331",
+			"33333333-3333-5333-8333-333333333332",
+			"33333333-3333-5333-8333-333333333333",
+		}[i]
+		if _, err := api.CreateTranscriptRecord(ctx, sess.ID, b, key); err != nil {
+			t.Fatalf("custom CreateTranscriptRecord %d: %v", i, err)
+		}
+	}
+	if _, err := api.FinalizeSession(ctx, sess.ID, "44444444-4444-5444-8444-444444444444"); err != nil {
+		t.Fatalf("custom FinalizeSession: %v", err)
+	}
+	return run.ID, sess.ID
+}
+
+type shape struct {
+	runStatus     Status
+	runLifecycle  Lifecycle
+	runFinalized  bool
+	sessStatus    Status
+	sessLifecycle Lifecycle
+	sessFinalized bool
+	sessLinksRun  bool
+	roles         []Role
+	authors       []string
+	ordinals      []uint64
+	contentStatus []string
+	transcript    []string
+}
+
+func readShape(t *testing.T, api API, runID, sessID string) shape {
+	t.Helper()
+	ctx := context.Background()
+	run, err := api.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	sess, err := api.GetSession(ctx, sessID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	recs, err := api.ListTranscriptRecords(ctx, sessID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	items, err := api.GetSessionTranscript(ctx, sessID)
+	if err != nil {
+		t.Fatalf("GetSessionTranscript: %v", err)
+	}
+	s := shape{
+		runStatus: run.Status, runLifecycle: run.Lifecycle, runFinalized: run.Finalized,
+		sessStatus: sess.Status, sessLifecycle: sess.Lifecycle, sessFinalized: sess.Finalized,
+		sessLinksRun: sess.RunID == run.ID,
+	}
+	for _, r := range recs {
+		s.roles = append(s.roles, r.Role)
+		author := ""
+		if r.Author != nil {
+			author = r.Author.Kind + ":" + r.Author.Ref
+		}
+		s.authors = append(s.authors, author)
+		s.ordinals = append(s.ordinals, *r.Ordinal)
+		s.contentStatus = append(s.contentStatus, r.ContentStatus)
+	}
+	for _, it := range items {
+		s.transcript = append(s.transcript, string(it.Role)+"|"+it.Text)
+	}
+	return s
+}
+
+func eq(t *testing.T, label string, got, want shape) {
+	t.Helper()
+	if got.runStatus != want.runStatus || got.runLifecycle != want.runLifecycle || got.runFinalized != want.runFinalized {
+		t.Errorf("%s: run shape differs: got %+v want %+v", label, got, want)
+	}
+	if got.sessStatus != want.sessStatus || got.sessLifecycle != want.sessLifecycle ||
+		got.sessFinalized != want.sessFinalized || got.sessLinksRun != want.sessLinksRun {
+		t.Errorf("%s: session shape differs: got %+v want %+v", label, got, want)
+	}
+	for _, pair := range []struct {
+		name      string
+		got, want []string
+	}{
+		{name: "authors", got: got.authors, want: want.authors},
+		{name: "content_status", got: got.contentStatus, want: want.contentStatus},
+		{name: "transcript", got: got.transcript, want: want.transcript},
+	} {
+		if len(pair.got) != len(pair.want) {
+			t.Errorf("%s: %s length %d != %d", label, pair.name, len(pair.got), len(pair.want))
+			continue
+		}
+		for i := range pair.got {
+			if pair.got[i] != pair.want[i] {
+				t.Errorf("%s: %s[%d] = %q, want %q", label, pair.name, i, pair.got[i], pair.want[i])
+			}
+		}
+	}
+	if len(got.roles) != len(want.roles) {
+		t.Fatalf("%s: role count %d != %d", label, len(got.roles), len(want.roles))
+	}
+	for i := range got.roles {
+		if got.roles[i] != want.roles[i] {
+			t.Errorf("%s: role[%d] = %q, want %q", label, i, got.roles[i], want.roles[i])
+		}
+		if got.ordinals[i] != want.ordinals[i] {
+			t.Errorf("%s: ordinal[%d] = %d, want %d", label, i, got.ordinals[i], want.ordinals[i])
+		}
+	}
+}
+
+// AC1 happy path: a complete City chain links and retrieves through the public
+// operations, and the records it produces are indistinguishable in shape from a
+// custom producer's — no field is City-required.
+func TestCityVersusCustomProducerParity(t *testing.T) {
+	ctx := context.Background()
+
+	cityFake := NewFake("svc-city@tenant", "gc-city-01", "city")
+	p := newCityProducer(t, cityFake, nil)
+	res, err := p.Push(ctx, sampleChain())
+	if err != nil {
+		t.Fatalf("city Push: %v", err)
+	}
+	if res.Accepted != 3 || len(res.Sessions) != 1 || !res.Sessions[0].Finalized {
+		t.Fatalf("city Push result = %+v, want 3 accepted and a finalized session", res)
+	}
+	cityShape := readShape(t, cityFake, res.RunTeamID, res.Sessions[0].TeamID)
+
+	customFake := NewFake("svc-orch@tenant", "orchestrator-9", "custom")
+	customRun, customSess := customUpload(t, customFake)
+	customShape := readShape(t, customFake, customRun, customSess)
+
+	eq(t, "city-vs-custom", cityShape, customShape)
+
+	// The neutral IDs are server-minted on both sides and carry no source
+	// spelling: a reader cannot tell which producer wrote the record.
+	if res.RunTeamID == "city-run-7" || res.Sessions[0].TeamID == "city-sess-1" {
+		t.Fatalf("neutral IDs echoed City native IDs: %q / %q", res.RunTeamID, res.Sessions[0].TeamID)
+	}
+	if customRun[:4] != res.RunTeamID[:4] {
+		t.Fatalf("neutral run id prefixes differ by producer: %q vs %q", customRun, res.RunTeamID)
+	}
+}
+
+// AC1 edge: City, rig and formula fields cannot become neutral authority.
+func TestCityFactsCannotBecomeNeutralAuthority(t *testing.T) {
+	chain := sampleChain()
+
+	// Gate closed (the default): no City-shaped display string leaves at all.
+	closed, err := (Mapper{Source: citySource()}).MapRun(chain.Run)
+	if err != nil {
+		t.Fatalf("MapRun: %v", err)
+	}
+	if closed.Title != "" {
+		t.Fatalf("display gate closed but title = %q", closed.Title)
+	}
+
+	// Gate open: the City facts reach exactly one non-authoritative field.
+	open, err := (Mapper{Source: citySource(), AllowDisplayContent: true}).MapRun(chain.Run)
+	if err != nil {
+		t.Fatalf("MapRun: %v", err)
+	}
+	if open.Title != "rig-alpha / formula-bravo" {
+		t.Fatalf("title = %q", open.Title)
+	}
+	if open.SourceEntityID != "city-run-7" || open.ProjectID != "proj-a" || open.IssueID != "bd-1" {
+		t.Fatalf("City facts displaced a source-native field: %+v", open)
+	}
+
+	// A City fact spelled like a neutral Team ID is refused rather than
+	// carried: the adapter never lets City name a neutral identity.
+	drift := chain.Run
+	drift.Rig = "run_00000000000000ff"
+	if _, err := (Mapper{Source: citySource(), AllowDisplayContent: true}).MapRun(drift); !errors.Is(err, ErrNeutralAuthority) {
+		t.Fatalf("neutral-shaped rig: err = %v, want ErrNeutralAuthority", err)
+	}
+
+	// The session body carries no run reference: the link comes from the path
+	// and the credential, so a City session cannot claim a foreign run.
+	sessBody, err := (Mapper{Source: citySource()}).MapSession(chain.Sessions[0])
+	if err != nil {
+		t.Fatalf("MapSession: %v", err)
+	}
+	if err := ScanOutbound(sessBody, false); err != nil {
+		t.Fatalf("ScanOutbound(session): %v", err)
+	}
+}
+
+// A neutral record must be valid with no City in the picture: the custom
+// producer's chain reads back complete on every operation this adapter uses.
+func TestNeutralRecordsValidWithoutCity(t *testing.T) {
+	f := NewFake("svc-orch@tenant", "orchestrator-9", "custom")
+	runID, sessID := customUpload(t, f)
+	s := readShape(t, f, runID, sessID)
+	if !s.sessFinalized || !s.sessLinksRun || len(s.roles) != 3 || len(s.transcript) != 3 {
+		t.Fatalf("custom-only chain incomplete: %+v", s)
+	}
+}

--- a/pkg/cityneutral/producer.go
+++ b/pkg/cityneutral/producer.go
@@ -1,0 +1,403 @@
+package cityneutral
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// SessionState is the acknowledged frontier of one session.
+//
+// Frontier is the highest ordinal the SERVER acknowledged, and it only ever
+// advances contiguously. Digests holds the payload digest of each acknowledged
+// record so a later replay can be told apart from a rewrite — the checkpoint is
+// what makes "changed replay" detectable at all.
+type SessionState struct {
+	TeamID    string            `json:"team_id"`
+	Version   uint64            `json:"version"`
+	Finalized bool              `json:"finalized"`
+	Frontier  uint64            `json:"frontier"`
+	Digests   map[uint64]string `json:"digests"`
+	MessageID map[uint64]string `json:"message_id"`
+}
+
+// State is one City run's checkpoint.
+type State struct {
+	Epoch      uint64                   `json:"epoch"`
+	SourceID   string                   `json:"source_id"`
+	RunTeamID  string                   `json:"run_team_id"`
+	RunVersion uint64                   `json:"run_version"`
+	Sessions   map[string]*SessionState `json:"sessions"`
+}
+
+func (s *State) session(sourceSessionID string) *SessionState {
+	if s.Sessions == nil {
+		s.Sessions = map[string]*SessionState{}
+	}
+	st, ok := s.Sessions[sourceSessionID]
+	if !ok {
+		st = &SessionState{Digests: map[uint64]string{}, MessageID: map[uint64]string{}}
+		s.Sessions[sourceSessionID] = st
+	}
+	if st.Digests == nil {
+		st.Digests = map[uint64]string{}
+	}
+	if st.MessageID == nil {
+		st.MessageID = map[uint64]string{}
+	}
+	return st
+}
+
+// Store persists checkpoints across restarts. It is an interface because the
+// durable implementation is City's business; the adapter only needs load and
+// save to be atomic with respect to each other.
+type Store interface {
+	Load(ctx context.Context, key string) (State, bool, error)
+	Save(ctx context.Context, key string, st State) error
+}
+
+// MemoryStore is an in-process Store. It is safe for concurrent use and is what
+// tests and a single-shot export run on.
+type MemoryStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+// NewMemoryStore returns an empty in-process Store.
+func NewMemoryStore() *MemoryStore { return &MemoryStore{m: map[string][]byte{}} }
+
+// Load implements Store.
+func (s *MemoryStore) Load(_ context.Context, key string) (State, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw, ok := s.m[key]
+	if !ok {
+		return State{}, false, nil
+	}
+	var st State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return State{}, false, fmt.Errorf("cityneutral: decode checkpoint %q: %w", key, err)
+	}
+	return st, true, nil
+}
+
+// Save implements Store. It round-trips through JSON so a caller cannot hold a
+// reference into stored state and mutate it behind the producer's back.
+func (s *MemoryStore) Save(_ context.Context, key string, st State) error {
+	raw, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("cityneutral: encode checkpoint %q: %w", key, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = map[string][]byte{}
+	}
+	s.m[key] = raw
+	return nil
+}
+
+// SessionResult reports what one session's push did.
+type SessionResult struct {
+	SourceSessionID string
+	TeamID          string
+	Accepted        int
+	Skipped         int
+	Finalized       bool
+}
+
+// Result reports what one push did. It is returned even on error, so a caller
+// that stops on a refusal still learns how far the chain got.
+type Result struct {
+	RunTeamID string
+	Sessions  []SessionResult
+	Accepted  int
+	Skipped   int
+}
+
+// Producer maps a City chain onto neutral resources and advances a checkpoint
+// only over acknowledged, contiguous records.
+type Producer struct {
+	API    API
+	Mapper Mapper
+	Store  Store
+}
+
+// NewProducer validates its wiring up front: a producer missing a store would
+// look like it worked and silently re-upload the world on restart.
+func NewProducer(api API, mapper Mapper, store Store) (*Producer, error) {
+	if api == nil {
+		return nil, errors.New("cityneutral: API is required")
+	}
+	if store == nil {
+		return nil, errors.New("cityneutral: Store is required")
+	}
+	if err := mapper.validateSource(); err != nil {
+		return nil, err
+	}
+	return &Producer{API: api, Mapper: mapper, Store: store}, nil
+}
+
+// CheckpointKey is the stable checkpoint identity of one City run under one
+// source. It excludes the epoch: a reset must LAND on the same key so the old
+// frontier is visibly superseded rather than orphaned under a new one.
+func CheckpointKey(source Source, cityRunID string) string {
+	return source.Kind + "/" + source.SourceID + "/" + cityRunID
+}
+
+// Push maps, uploads, checkpoints and finalizes one chain.
+//
+// It advances only on acknowledgement. Every refusal returns the partial result
+// with the checkpoint already saved at the last acknowledged record, so a
+// restart resumes at the next accepted record and never re-sends an accepted
+// one.
+func (p *Producer) Push(ctx context.Context, chain CityChain) (Result, error) {
+	key := CheckpointKey(p.Mapper.Source, chain.Run.RunID)
+	st, _, err := p.Store.Load(ctx, key)
+	if err != nil {
+		return Result{}, err
+	}
+	switch {
+	case st.Epoch == 0:
+		st.Epoch = p.Mapper.Source.Epoch
+		st.SourceID = p.Mapper.Source.SourceID
+	case p.Mapper.Source.Epoch > st.Epoch:
+		// A declared reset. The previous frontier belongs to the previous
+		// epoch and must not gate the new one, so the checkpoint restarts —
+		// the server keeps the old records; this producer simply stops
+		// claiming to have sent them.
+		st = State{Epoch: p.Mapper.Source.Epoch, SourceID: p.Mapper.Source.SourceID}
+	case p.Mapper.Source.Epoch < st.Epoch:
+		return Result{}, fmt.Errorf("%w: source epoch %d is behind checkpoint epoch %d",
+			ErrIdentityDrift, p.Mapper.Source.Epoch, st.Epoch)
+	}
+	if st.SourceID != "" && st.SourceID != p.Mapper.Source.SourceID {
+		return Result{}, fmt.Errorf("%w: checkpoint belongs to source %q", ErrIdentityDrift, st.SourceID)
+	}
+
+	res := Result{}
+	runBody, err := p.Mapper.MapRun(chain.Run)
+	if err != nil {
+		return res, err
+	}
+	if err := ScanOutbound(runBody, false); err != nil {
+		return res, err
+	}
+	run, err := p.API.UpsertRun(ctx, runBody, idempotencyKey(p.Mapper.Source, KindRun, chain.Run.RunID, runBody.SourceVersion))
+	if err != nil {
+		return res, fmt.Errorf("cityneutral: %s: %w", OpUpsertRun, err)
+	}
+	if run.ID == "" {
+		return res, fmt.Errorf("%w: server returned no neutral run id", ErrIdentityDrift)
+	}
+	if st.RunTeamID != "" && st.RunTeamID != run.ID {
+		return res, fmt.Errorf("%w: run %q was %q, server now says %q",
+			ErrIdentityDrift, chain.Run.RunID, st.RunTeamID, run.ID)
+	}
+	st.RunTeamID = run.ID
+	st.RunVersion = runBody.SourceVersion
+	res.RunTeamID = run.ID
+	if err := p.Store.Save(ctx, key, st); err != nil {
+		return res, err
+	}
+
+	for _, sess := range chain.Sessions {
+		sr, err := p.pushSession(ctx, key, &st, run.ID, sess)
+		res.Sessions = append(res.Sessions, sr)
+		res.Accepted += sr.Accepted
+		res.Skipped += sr.Skipped
+		if err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+func (p *Producer) pushSession(ctx context.Context, key string, st *State, runTeamID string, sess CitySession) (SessionResult, error) {
+	sr := SessionResult{SourceSessionID: sess.SessionID}
+	sstate := st.session(sess.SessionID)
+	sr.TeamID = sstate.TeamID
+	sr.Finalized = sstate.Finalized
+
+	body, err := p.Mapper.MapSession(sess)
+	if err != nil {
+		return sr, err
+	}
+	if err := ScanOutbound(body, false); err != nil {
+		return sr, err
+	}
+
+	// Post-finalize mutation is refused before anything is sent. A finalized
+	// session may be re-observed (same version, no new records) — that is a
+	// harmless idempotent read of City's own state — but any changed input
+	// stops this adapter rather than asking the server to rewrite final input.
+	if sstate.Finalized {
+		if body.SourceVersion > sstate.Version {
+			return sr, fmt.Errorf("%w: session %q version %d after finalize at %d",
+				ErrFinalized, sess.SessionID, body.SourceVersion, sstate.Version)
+		}
+		if err := p.assertNoNewInput(sess, sstate); err != nil {
+			return sr, err
+		}
+		sr.Skipped += len(sess.Records)
+		return sr, nil
+	}
+
+	session, err := p.API.UpsertRunSession(ctx, runTeamID, body,
+		idempotencyKey(p.Mapper.Source, KindSession, sess.SessionID, body.SourceVersion))
+	if err != nil {
+		return sr, fmt.Errorf("cityneutral: %s: %w", OpUpsertRunSession, err)
+	}
+	if session.ID == "" {
+		return sr, fmt.Errorf("%w: server returned no neutral session id", ErrIdentityDrift)
+	}
+	if sstate.TeamID != "" && sstate.TeamID != session.ID {
+		return sr, fmt.Errorf("%w: session %q was %q, server now says %q",
+			ErrIdentityDrift, sess.SessionID, sstate.TeamID, session.ID)
+	}
+	if session.RunID != runTeamID {
+		return sr, fmt.Errorf("%w: session %q links run %q, not %q",
+			ErrIdentityDrift, sess.SessionID, session.RunID, runTeamID)
+	}
+	sstate.TeamID = session.ID
+	sstate.Version = body.SourceVersion
+	sstate.Finalized = session.Finalized
+	sr.TeamID = session.ID
+	sr.Finalized = session.Finalized
+	if err := p.Store.Save(ctx, key, *st); err != nil {
+		return sr, err
+	}
+
+	// Out-of-order arrival is a source property, not a protocol violation:
+	// order the batch here and let contiguity be judged on ordinals.
+	records := append([]CityRecord(nil), sess.Records...)
+	sort.Slice(records, func(i, j int) bool { return records[i].Ordinal < records[j].Ordinal })
+
+	for _, rec := range records {
+		in, err := p.Mapper.MapRecord(rec)
+		if err != nil {
+			return sr, err
+		}
+		digest := payloadDigest(in)
+
+		if rec.Ordinal <= sstate.Frontier {
+			// Already acknowledged. Same bytes means a retry we can drop;
+			// different bytes means the source rewrote accepted input.
+			if have, ok := sstate.Digests[rec.Ordinal]; ok && have != digest {
+				return sr, fmt.Errorf("%w: session %q ordinal %d (message %q)",
+					ErrChangedReplay, sess.SessionID, rec.Ordinal, rec.MessageID)
+			}
+			if have, ok := sstate.MessageID[rec.Ordinal]; ok && have != rec.MessageID {
+				return sr, fmt.Errorf("%w: session %q ordinal %d was message %q, now %q",
+					ErrChangedReplay, sess.SessionID, rec.Ordinal, have, rec.MessageID)
+			}
+			sr.Skipped++
+			continue
+		}
+		if rec.Ordinal != sstate.Frontier+1 {
+			return sr, fmt.Errorf("%w: session %q expected ordinal %d, got %d",
+				ErrGap, sess.SessionID, sstate.Frontier+1, rec.Ordinal)
+		}
+		if err := ScanOutbound(in, true); err != nil {
+			return sr, err
+		}
+		out, err := p.API.CreateTranscriptRecord(ctx, sstate.TeamID, in,
+			idempotencyKey(p.Mapper.Source, KindTranscriptRecord, sess.SessionID+"/"+rec.MessageID, in.SourceVersion))
+		if err != nil {
+			return sr, fmt.Errorf("cityneutral: %s: %w", OpCreateTranscriptRecord, err)
+		}
+		if out.ID == "" || out.SessionID != sstate.TeamID {
+			return sr, fmt.Errorf("%w: record %q acknowledged against session %q",
+				ErrIdentityDrift, rec.MessageID, out.SessionID)
+		}
+		sstate.Frontier = rec.Ordinal
+		sstate.Digests[rec.Ordinal] = digest
+		sstate.MessageID[rec.Ordinal] = rec.MessageID
+		sr.Accepted++
+		if err := p.Store.Save(ctx, key, *st); err != nil {
+			return sr, err
+		}
+	}
+
+	if sess.Complete && !sstate.Finalized {
+		final, err := p.API.FinalizeSession(ctx, sstate.TeamID,
+			idempotencyKey(p.Mapper.Source, kindSessionFinalize, sess.SessionID, sstate.Frontier))
+		if err != nil {
+			return sr, fmt.Errorf("cityneutral: %s: %w", OpFinalizeSession, err)
+		}
+		sstate.Finalized = final.Finalized
+		sr.Finalized = final.Finalized
+		if err := p.Store.Save(ctx, key, *st); err != nil {
+			return sr, err
+		}
+	}
+	return sr, nil
+}
+
+// assertNoNewInput refuses a finalized session that has grown or changed.
+func (p *Producer) assertNoNewInput(sess CitySession, sstate *SessionState) error {
+	for _, rec := range sess.Records {
+		if rec.Ordinal > sstate.Frontier {
+			return fmt.Errorf("%w: session %q record ordinal %d arrived after finalize",
+				ErrFinalized, sess.SessionID, rec.Ordinal)
+		}
+		if have, ok := sstate.MessageID[rec.Ordinal]; ok && have != rec.MessageID {
+			return fmt.Errorf("%w: session %q ordinal %d changed after finalize",
+				ErrFinalized, sess.SessionID, rec.Ordinal)
+		}
+		in, err := p.Mapper.MapRecord(rec)
+		if err != nil {
+			return err
+		}
+		if have, ok := sstate.Digests[rec.Ordinal]; ok && have != payloadDigest(in) {
+			return fmt.Errorf("%w: session %q ordinal %d payload changed after finalize",
+				ErrFinalized, sess.SessionID, rec.Ordinal)
+		}
+	}
+	return nil
+}
+
+// payloadDigest is the canonical digest of a request body. It is what makes a
+// replay comparable: the same City record maps to the same bytes, so a digest
+// difference is a real source change and never a serialization artifact.
+func payloadDigest(body any) string {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		// json.Marshal on these closed DTOs cannot fail; a digest that cannot
+		// be computed must not compare equal to anything.
+		return "unencodable:" + err.Error()
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// idempotencyKey derives the server's Idempotency-Key from stable source
+// identity alone.
+//
+// Deriving rather than minting is the dedup contract: a retry after a lost
+// response reuses the key and replays, while a changed payload under the same
+// key is a conflict the server refuses. Nothing volatile — no clock, no
+// attempt counter, no credential — is in the preimage, so a credential rotation
+// or a restart changes nothing about which key a record travels under. The
+// output is a v5-shaped UUID because the contract requires a UUID.
+func idempotencyKey(source Source, kind, nativeID string, version uint64) string {
+	preimage := strings.Join([]string{
+		"cityneutral/idempotency/v1",
+		source.Kind, source.SourceID,
+		fmt.Sprintf("%d", source.Epoch),
+		kind, nativeID,
+		fmt.Sprintf("%d", version),
+	}, "\x1f")
+	sum := sha256.Sum256([]byte(preimage))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(b)
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}

--- a/pkg/cityneutral/provenance_test.go
+++ b/pkg/cityneutral/provenance_test.go
@@ -1,0 +1,236 @@
+package cityneutral
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// AC3 happy path: uploader, source, represented author and tenant ownership
+// stay four distinct things on an accepted record.
+func TestUploaderSourceAndAuthorStayDistinct(t *testing.T) {
+	f := NewFake("svc-city@acme", "gc-city-01", "city")
+	p := newCityProducer(t, f, nil)
+	res, err := p.Push(context.Background(), sampleChain())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("got %d records, want 3", len(recs))
+	}
+	first := recs[0]
+	if first.SourceID != "gc-city-01" || first.SourceKind != "city" {
+		t.Fatalf("source not credential-derived: %+v", first)
+	}
+	if first.Author == nil || first.Author.Ref != "u-42" || first.Author.Kind != "human" {
+		t.Fatalf("represented author not preserved: %+v", first.Author)
+	}
+	if first.Author.Ref == f.Uploader || first.SourceID == f.Uploader {
+		t.Fatalf("uploader collapsed into author or source: uploader=%q", f.Uploader)
+	}
+	// The record with no City author keeps a nil author rather than being
+	// silently attributed to the uploader or the source.
+	if recs[2].Author != nil {
+		t.Fatalf("unauthored record acquired an author: %+v", recs[2].Author)
+	}
+}
+
+// AC3 edge: an actor or key ID cannot become the uploader, the source, or an
+// authorization input. The adapter's own claim about who spoke is attribution
+// and is carried in a body field the server treats as non-authoritative; the
+// source on the stored record comes from the credential regardless.
+func TestActorCannotBecomeUploaderOrSource(t *testing.T) {
+	f := NewFake("svc-city@acme", "gc-city-01", "city")
+	p := newCityProducer(t, f, nil)
+
+	chain := sampleChain()
+	// A City author impersonating the uploader and the enrolled source.
+	chain.Sessions[0].Records[0].Author = &ContributorRef{Kind: "human", Ref: "svc-city@acme"}
+	chain.Sessions[0].Records[1].Author = &ContributorRef{Kind: "agent", Ref: "gc-city-01"}
+
+	res, err := p.Push(context.Background(), chain)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	recs, err := f.ListTranscriptRecords(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	for i, r := range recs[:2] {
+		if r.SourceID != "gc-city-01" || r.SourceKind != "city" {
+			t.Fatalf("record %d source came from the body: %+v", i, r)
+		}
+	}
+	// Attribution that happens to spell the uploader is still only attribution:
+	// it changed no ownership field on the stored record.
+	if recs[0].SessionID != res.Sessions[0].TeamID {
+		t.Fatalf("record ownership drifted: %+v", recs[0])
+	}
+}
+
+// AC3: the outbound scanner refuses credential evidence, ownership assertions
+// and raw content outside the transcript-record route.
+func TestScanOutboundRefusals(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         map[string]any
+		allowContent bool
+		want         error
+	}{
+		{
+			name: "bearer token in a field",
+			body: map[string]any{"source_entity_id": "bearer AAAAAAAAAAAAAAAAAAAA"},
+			want: ErrCredentialLeak,
+		},
+		{
+			name: "aws secret arn nested under an author",
+			body: map[string]any{"author": map[string]any{"ref": "arn:aws:secretsmanager:us-east-1:1:secret:x"}},
+			want: ErrCredentialLeak,
+		},
+		{
+			name: "uploader asserted by the producer",
+			body: map[string]any{"uploaded_by": "svc-city@acme"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "signing key id smuggled into a body",
+			body: map[string]any{"key_id": "city-2026-07"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "tenant asserted by the producer",
+			body: map[string]any{"tenant_id": "acme"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "neutral id asserted by the producer",
+			body: map[string]any{"id": "run_00000000000000ff"},
+			want: ErrNeutralAuthority,
+		},
+		{
+			name: "raw content on a non-transcript route",
+			body: map[string]any{"text": "secret plan"},
+			want: ErrContentRoute,
+		},
+		{
+			name:         "raw content on the transcript route is allowed",
+			body:         map[string]any{"text": "secret plan"},
+			allowContent: true,
+			want:         nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ScanOutbound(tc.body, tc.allowContent)
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("err = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// AC3: nothing this adapter serializes carries a credential, a key id, or an
+// ownership assertion — checked on the bytes, not on the struct.
+func TestSerializedBodiesCarryNoCredentialOrOwnership(t *testing.T) {
+	m := Mapper{Source: citySource(), AllowDisplayContent: true, AllowRawContent: true}
+	chain := sampleChain()
+
+	runBody, err := m.MapRun(chain.Run)
+	if err != nil {
+		t.Fatalf("MapRun: %v", err)
+	}
+	sessBody, err := m.MapSession(chain.Sessions[0])
+	if err != nil {
+		t.Fatalf("MapSession: %v", err)
+	}
+	recBody, err := m.MapRecord(chain.Sessions[0].Records[0])
+	if err != nil {
+		t.Fatalf("MapRecord: %v", err)
+	}
+
+	forbidden := []string{
+		"uploaded_by", "uploader", "tenant", "workspace", "key_id",
+		"actor", "principal", "authorization", "credential", `"source_id"`, `"id"`,
+	}
+	for _, body := range []any{runBody, sessBody, recBody} {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		for _, f := range forbidden {
+			if strings.Contains(string(raw), f) {
+				t.Fatalf("body %s carries %q", raw, f)
+			}
+		}
+	}
+
+	// The run and session bodies carry no raw content at all; only the
+	// transcript body may, and only with the content gate open.
+	if err := ScanOutbound(runBody, false); err != nil {
+		t.Fatalf("ScanOutbound(run): %v", err)
+	}
+	if err := ScanOutbound(sessBody, false); err != nil {
+		t.Fatalf("ScanOutbound(session): %v", err)
+	}
+	if err := ScanOutbound(recBody, true); err != nil {
+		t.Fatalf("ScanOutbound(record): %v", err)
+	}
+	if err := ScanOutbound(recBody, false); !errors.Is(err, ErrContentRoute) {
+		t.Fatalf("record body on a non-content route: err = %v, want ErrContentRoute", err)
+	}
+}
+
+// AC3: with the content gate closed the text never leaves, and the record still
+// goes — a transcript with a known-withheld turn beats one with a hole in it.
+func TestContentGateWithholdsTextWithoutDroppingTheRecord(t *testing.T) {
+	f := NewFake("svc-city@acme", "gc-city-01", "city")
+	p := newCityProducer(t, f, func(m *Mapper) { m.AllowRawContent = false })
+	res, err := p.Push(context.Background(), sampleChain())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	items, err := f.GetSessionTranscript(context.Background(), res.Sessions[0].TeamID)
+	if err != nil {
+		t.Fatalf("GetSessionTranscript: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("got %d transcript items, want 3", len(items))
+	}
+	for i, it := range items {
+		if it.Text != "" {
+			t.Fatalf("item %d leaked text %q with the content gate closed", i, it.Text)
+		}
+		if it.ContentStatus != "missing" {
+			t.Fatalf("item %d content status = %q, want missing", i, it.ContentStatus)
+		}
+	}
+}
+
+// A City field carrying credential evidence is refused at the producer with the
+// source field named, instead of becoming a 4xx an operator has to correlate.
+func TestCredentialEvidenceInCityFieldsIsRefused(t *testing.T) {
+	m := Mapper{Source: citySource(), AllowRawContent: true}
+	chain := sampleChain()
+	chain.Run.RunID = "vault://prod/runs/7"
+	if _, err := m.MapRun(chain.Run); !errors.Is(err, ErrCredentialLeak) {
+		t.Fatalf("err = %v, want ErrCredentialLeak", err)
+	}
+
+	rec := sampleChain().Sessions[0].Records[0]
+	rec.Text = "paste this: sk-AAAAAAAAAAAAAAAAAAAAAAAA"
+	if _, err := m.MapRecord(rec); !errors.Is(err, ErrCredentialLeak) {
+		t.Fatalf("text: err = %v, want ErrCredentialLeak", err)
+	}
+}

--- a/pkg/cityparity/doc.go
+++ b/pkg/cityparity/doc.go
@@ -1,0 +1,26 @@
+// Package cityparity is the cross-adapter certification for Gas City's three
+// neutral producer adapters: cityneutral (run, session, transcript),
+// cityartifact (artifact and links) and cityinference (model invocations).
+//
+// It owns no product code and adds no behavior. It exists because the three
+// adapters are three independent implementations of one contract, and three
+// implementations can diverge. Two properties are worth proving across them and
+// cannot be proven inside any one of them:
+//
+//   - Parity. A custom producer with no City anywhere in the path uploads the
+//     same work and gets resources of the same public shape: the same kinds of
+//     Team ID, the same links, the same provenance meanings, the same coverage
+//     claims, the same content boundaries and the same retrieval behavior. If
+//     City parity needed a City-shaped field, City would have stopped being
+//     optional.
+//
+//   - Fault-domain independence. One adapter faulting, lagging, rolling back,
+//     resetting its source epoch or rotating its credential affects that
+//     adapter's checkpoint and nothing else. Acknowledged records survive, and
+//     the other two adapters keep running.
+//
+// Where the three adapters do NOT agree, the tests here say so by name rather
+// than by silence. A divergence recorded as a passing characterization test is
+// a certification finding: it is what blocks the parity report, and the test
+// name is the citation.
+package cityparity

--- a/pkg/cityparity/golden_test.go
+++ b/pkg/cityparity/golden_test.go
@@ -1,0 +1,510 @@
+package cityparity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+	"github.com/gastownhall/gascity/pkg/cityinference"
+	"github.com/gastownhall/gascity/pkg/cityneutral"
+)
+
+var (
+	t0   = time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	tEnd = t0.Add(9 * time.Minute)
+)
+
+const (
+	tenant           = "org_alpha"
+	linkedProject    = "proj-a"
+	linkedIssue      = "bd-1"
+	mediaType        = "text/plain; charset=utf-8"
+	neutralMediaType = "text/plain"
+)
+
+var partBytes = [][]byte{[]byte("first part\n"), []byte("second part\n")}
+
+// producerStyle is one way of producing the same work. City is one of them and
+// deliberately not the privileged one: the custom style speaks the same API
+// with its own enrolled identity, its own native IDs and no City code in the
+// path at all.
+type producerStyle struct {
+	name       string
+	sourceID   string
+	sourceKind string
+	uploader   string
+	// native IDs this style uses on its own side of the boundary.
+	runID, sessionID string
+	msgIDs           []string
+	invSession       string
+	invReq           string
+}
+
+var (
+	cityStyle = producerStyle{
+		name: "city", sourceID: "src_city_1", sourceKind: "city", uploader: "svc-city",
+		runID: "city-run-7", sessionID: "city-sess-1",
+		msgIDs: []string{"m1", "m2", "m3"}, invSession: "sess-1", invReq: "req-1",
+	}
+	customStyle = producerStyle{
+		name: "custom", sourceID: "src_custom_1", sourceKind: "orchestrator", uploader: "svc-orch",
+		runID: "orch-run-7", sessionID: "orch-sess-1",
+		msgIDs: []string{"e1", "e2", "e3"}, invSession: "sess-1", invReq: "req-1",
+	}
+)
+
+// replacer rewrites everything that is legitimately style-specific — the
+// enrolled source identity and the source-native IDs — into placeholders, so
+// what remains in a rendered line is only what the contract says both styles
+// must agree on.
+func (s producerStyle) replacer() *strings.Replacer {
+	// Most specific first: a source kind of "city" is a prefix of the native
+	// run ID "city-run-7", and replacing the kind first would hide the very
+	// difference this placeholder exists to normalize.
+	pairs := []string{
+		s.runID, "<native-run>",
+		s.sessionID, "<native-session>",
+	}
+	for i, m := range s.msgIDs {
+		pairs = append(pairs, m, fmt.Sprintf("<native-msg-%d>", i+1))
+	}
+	pairs = append(pairs,
+		s.sourceID, "<source-id>",
+		s.sourceKind, "<source-kind>",
+		s.uploader, "<uploader>",
+	)
+	return strings.NewReplacer(pairs...)
+}
+
+// symbols renders server-minted Team IDs as first-seen ordinals. Parity is
+// about a Team ID being opaque, server-minted and consistently linked — never
+// about two producers being handed the same string.
+type symbols struct {
+	seen map[string]string
+	n    int
+}
+
+func newSymbols() *symbols { return &symbols{seen: map[string]string{}} }
+
+func (s *symbols) of(id string) string {
+	if id == "" {
+		return "-"
+	}
+	if sym, ok := s.seen[id]; ok {
+		return sym
+	}
+	s.n++
+	s.seen[id] = fmt.Sprintf("#%d", s.n)
+	return s.seen[id]
+}
+
+// chain is the City-native input for the neutral leg.
+func (s producerStyle) chain() cityneutral.CityChain {
+	return cityneutral.CityChain{
+		Run: cityneutral.CityRun{
+			RunID: s.runID, Status: "succeeded", Started: t0, Ended: &tEnd,
+			ProjectID: linkedProject, IssueID: linkedIssue, Version: 3,
+			Rig: "rig-alpha", Formula: "formula-bravo", City: "rustbelt",
+		},
+		Sessions: []cityneutral.CitySession{{
+			SessionID: s.sessionID, Status: "succeeded", Started: t0, Ended: &tEnd,
+			Version: 2, Complete: true,
+			Records: []cityneutral.CityRecord{
+				{MessageID: s.msgIDs[0], Ordinal: 1, Role: "user", At: t0.Add(time.Minute), Text: "kick it off"},
+				{MessageID: s.msgIDs[1], Ordinal: 2, Role: "agent", At: t0.Add(2 * time.Minute), Text: "on it"},
+				{MessageID: s.msgIDs[2], Ordinal: 3, Role: "tool", At: t0.Add(3 * time.Minute), ContentRef: "blob-3"},
+			},
+		}},
+	}
+}
+
+func u64(v uint64) *uint64 { return &v }
+
+// cityNeutralLeg runs the City adapter. customNeutralLeg does the same work
+// with no City code in the path: it builds the neutral bodies itself and mints
+// its own idempotency keys, which is what makes the comparison a comparison of
+// two implementations rather than of one implementation wearing two hats.
+func cityNeutralLeg(t *testing.T, f *cityneutral.Fake, s producerStyle) (string, string) {
+	t.Helper()
+	p, err := cityneutral.NewProducer(f, cityneutral.Mapper{
+		Source:          cityneutral.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1},
+		AllowRawContent: true,
+	}, cityneutral.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("neutral NewProducer: %v", err)
+	}
+	res, err := p.Push(context.Background(), s.chain())
+	if err != nil {
+		t.Fatalf("neutral Push: %v", err)
+	}
+	if len(res.Sessions) != 1 {
+		t.Fatalf("neutral Push produced %d sessions", len(res.Sessions))
+	}
+	return res.RunTeamID, res.Sessions[0].TeamID
+}
+
+func customNeutralLeg(t *testing.T, api cityneutral.API, s producerStyle) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	run, err := api.UpsertRun(ctx, cityneutral.Upsert{
+		SourceEntityID: s.runID, SourceVersion: 3, Epoch: 1,
+		Status: cityneutral.StatusSucceeded, Lifecycle: cityneutral.LifecyclePartial,
+		StartedAt: t0, EndedAt: &tEnd, ProjectID: linkedProject, IssueID: linkedIssue,
+		Coverage: cityneutral.CoverageKnown,
+	}, "11111111-1111-5111-8111-111111111111")
+	if err != nil {
+		t.Fatalf("custom UpsertRun: %v", err)
+	}
+	sess, err := api.UpsertRunSession(ctx, run.ID, cityneutral.Upsert{
+		SourceEntityID: s.sessionID, SourceVersion: 2, Epoch: 1,
+		Status: cityneutral.StatusSucceeded, Lifecycle: cityneutral.LifecyclePartial,
+		StartedAt: t0, EndedAt: &tEnd, Coverage: cityneutral.CoverageKnown,
+	}, "22222222-2222-5222-8222-222222222222")
+	if err != nil {
+		t.Fatalf("custom UpsertRunSession: %v", err)
+	}
+	records := []cityneutral.TranscriptRecordIngest{
+		{
+			SourceMessageID: s.msgIDs[0], SourceVersion: 1, Epoch: 1, Ordinal: u64(1),
+			Role: cityneutral.RoleUser, OccurredAt: t0.Add(time.Minute), Text: "kick it off",
+		},
+		{
+			SourceMessageID: s.msgIDs[1], SourceVersion: 1, Epoch: 1, Ordinal: u64(2),
+			Role: cityneutral.RoleAssistant, OccurredAt: t0.Add(2 * time.Minute), Text: "on it",
+		},
+		{
+			SourceMessageID: s.msgIDs[2], SourceVersion: 1, Epoch: 1, Ordinal: u64(3),
+			Role: cityneutral.RoleTool, OccurredAt: t0.Add(3 * time.Minute), ContentRef: "blob-3",
+		},
+	}
+	for i, rec := range records {
+		if _, err := api.CreateTranscriptRecord(ctx, sess.ID, rec,
+			fmt.Sprintf("3333333%d-3333-5333-8333-333333333333", i)); err != nil {
+			t.Fatalf("custom CreateTranscriptRecord %d: %v", i, err)
+		}
+	}
+	if _, err := api.FinalizeSession(ctx, sess.ID, "44444444-4444-5444-8444-444444444444"); err != nil {
+		t.Fatalf("custom FinalizeSession: %v", err)
+	}
+	return run.ID, sess.ID
+}
+
+func renderNeutral(t *testing.T, api cityneutral.API, sym *symbols, runID, sessID string) []string {
+	t.Helper()
+	ctx := context.Background()
+	run, err := api.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	sess, err := api.GetSession(ctx, sessID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	items, err := api.GetSessionTranscript(ctx, sessID)
+	if err != nil {
+		t.Fatalf("GetSessionTranscript: %v", err)
+	}
+	out := []string{
+		fmt.Sprintf("run id=%s source=%s/%s native=%s status=%s lifecycle=%s epoch=%d final=%t etag_present=%t",
+			sym.of(run.ID), run.SourceKind, run.SourceID, run.SourceRunID, run.Status, run.Lifecycle,
+			run.Epoch, run.Finalized, run.ETag != ""),
+		fmt.Sprintf("session id=%s run=%s source=%s/%s native=%s status=%s lifecycle=%s epoch=%d final=%t",
+			sym.of(sess.ID), sym.of(sess.RunID), sess.SourceKind, sess.SourceID, sess.SourceSessionID,
+			sess.Status, sess.Lifecycle, sess.Epoch, sess.Finalized),
+	}
+	for _, it := range items {
+		ordinal := "-"
+		if it.Ordinal != nil {
+			ordinal = fmt.Sprintf("%d", *it.Ordinal)
+		}
+		out = append(out, fmt.Sprintf("transcript id=%s native=%s role=%s ordinal=%s content=%s text_present=%t",
+			sym.of(it.RecordID), it.SourceMessageID, it.Role, ordinal, it.ContentStatus, it.Text != ""))
+	}
+	return out
+}
+
+func (s producerStyle) artifact(runID, sessID string) cityartifact.CityArtifact {
+	return cityartifact.CityArtifact{
+		ArtifactID: s.runID + "-artifact", Kind: "transcript", MediaType: mediaType, Version: 1,
+		ProjectID: linkedProject, IssueID: linkedIssue, RunID: runID, SessionID: sessID,
+		City: "rustbelt", Rig: "rig-3", Formula: "review",
+		Parts: []cityartifact.CityPart{
+			{Sequence: 1, Bytes: partBytes[0]},
+			{Sequence: 2, Bytes: partBytes[1]},
+		},
+		Complete: true,
+	}
+}
+
+func cityArtifactLeg(t *testing.T, f *cityartifact.Fake, s producerStyle, runID, sessID string) string {
+	t.Helper()
+	p, err := cityartifact.NewProducer(f.Client(s.sourceID, s.sourceKind),
+		cityartifact.Mapper{Source: cityartifact.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1}},
+		cityartifact.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("artifact NewProducer: %v", err)
+	}
+	res, err := p.Push(context.Background(), s.artifact(runID, sessID))
+	if err != nil {
+		t.Fatalf("artifact Push: %v", err)
+	}
+	return res.ArtifactID
+}
+
+func customArtifactLeg(t *testing.T, api cityartifact.API, runID, sessID string) string {
+	t.Helper()
+	ctx := context.Background()
+	// The custom producer speaks the neutral vocabulary directly; the City
+	// adapter reaches the same values by mapping its own ("transcript" is
+	// City's word for an artifact of neutral kind "log"). Parity is asserted at
+	// the neutral layer, which is the only layer both producers share.
+	art, err := api.CreateArtifact(ctx, cityartifact.CreateRequest{
+		Kind: "log", MediaType: neutralMediaType,
+		Links: cityartifact.Links{ProjectID: linkedProject, IssueID: linkedIssue, RunID: runID, SessionID: sessID},
+	}, "55555555-5555-5555-8555-555555555555")
+	if err != nil {
+		t.Fatalf("custom CreateArtifact: %v", err)
+	}
+	for i, b := range partBytes {
+		part := cityartifact.Part{Bytes: b, MediaType: neutralMediaType, Sequence: i + 1}
+		if _, err := api.UploadArtifactContent(ctx, art.ID, part,
+			fmt.Sprintf("6666666%d-6666-5666-8666-666666666666", i)); err != nil {
+			t.Fatalf("custom UploadArtifactContent %d: %v", i, err)
+		}
+	}
+	if _, err := api.FinalizeArtifact(ctx, art.ID, cityartifact.FinalizeRequest{},
+		"77777777-7777-5777-8777-777777777777"); err != nil {
+		t.Fatalf("custom FinalizeArtifact: %v", err)
+	}
+	return art.ID
+}
+
+func renderArtifact(t *testing.T, api cityartifact.API, sym *symbols, artifactID string) []string {
+	t.Helper()
+	ctx := context.Background()
+	meta, err := api.GetArtifact(ctx, artifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact: %v", err)
+	}
+	listed, _, err := api.ListArtifacts(ctx, cityartifact.ListQuery{})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	return []string{
+		fmt.Sprintf("artifact id=%s kind=%s media=%s status=%s bytes=%d digest_present=%t source=%s producer=%s",
+			sym.of(meta.ID), meta.Kind, meta.MediaType, meta.Status, meta.ByteSize, meta.Digest != "",
+			meta.SourceID, meta.Producer),
+		fmt.Sprintf("artifact-links project=%s issue=%s run=%s session=%s",
+			meta.Links.ProjectID, meta.Links.IssueID, sym.of(meta.Links.RunID), sym.of(meta.Links.SessionID)),
+		fmt.Sprintf("artifact-list count=%d", len(listed)),
+	}
+}
+
+func (s producerStyle) invocation(runID, sessID, recID string) cityinference.CityInvocation {
+	return cityinference.CityInvocation{
+		SessionNativeID: s.invSession, UpstreamReqID: s.invReq,
+		Provider: "anthropic", Model: "m-1", Status: "succeeded",
+		Started: t0, Ended: &tEnd,
+		RunTeamID: runID, SessionTeamID: sessID, TranscriptRecordID: recID,
+		Usage: &cityinference.UsageObservation{
+			InputTokens: u64(120), OutputTokens: u64(30), CostMicros: u64(4500),
+		},
+	}
+}
+
+func newInferenceAPI(runID, sessID, recID string) *cityinference.FakeAPI {
+	ws := cityinference.NewFakeWorkspace()
+	ws.AddChain(runID, sessID, recID)
+	return cityinference.NewFakeAPI(tenant, map[string]*cityinference.FakeWorkspace{tenant: ws})
+}
+
+func inferenceSource(s producerStyle) cityinference.Source {
+	return cityinference.Source{SourceID: s.sourceID, Kind: s.sourceKind, Tenant: tenant, Epoch: 1}
+}
+
+func cityInferenceLeg(t *testing.T, api cityinference.API, s producerStyle, runID, sessID, recID string) string {
+	t.Helper()
+	p, err := cityinference.NewProducer(api, cityinference.Mapper{Source: inferenceSource(s)},
+		cityinference.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("inference NewProducer: %v", err)
+	}
+	res, err := p.Push(context.Background(), []cityinference.CityInvocation{s.invocation(runID, sessID, recID)})
+	if err != nil {
+		t.Fatalf("inference Push: %v", err)
+	}
+	if len(res.Uploaded) != 1 {
+		t.Fatalf("inference Push uploaded %d records", len(res.Uploaded))
+	}
+	return res.Uploaded[0].InferenceTeamID
+}
+
+// customInferenceLeg hand-builds the request: no Mapper, no Producer, no City
+// type in the path except the frozen wire structs the server itself defines.
+func customInferenceLeg(t *testing.T, api cityinference.API, s producerStyle, runID, sessID, recID string) string {
+	t.Helper()
+	id := cityinference.NativeIdentity{
+		Kind: cityinference.NativeIdentityKind, Tenant: tenant,
+		SessionID: s.invSession, UpstreamReqID: s.invReq,
+	}
+	ext, err := cityinference.DeriveExternalInferenceID(id)
+	if err != nil {
+		t.Fatalf("custom DeriveExternalInferenceID: %v", err)
+	}
+	req := cityinference.CreateInferenceRequest{
+		NativeIdentity: id, ExternalInferenceID: ext,
+		Provider: "anthropic", Model: "m-1", Outcome: cityinference.OutcomeOK,
+		StartedAt: t0, EndedAt: &tEnd, Epoch: 1,
+		SessionTeamID: sessID, RunTeamID: runID, TranscriptRecordID: recID,
+		Usage: &cityinference.UsageObservation{
+			InputTokens: u64(120), OutputTokens: u64(30), CostMicros: u64(4500),
+		},
+	}
+	if err := cityinference.Preflight(req); err != nil {
+		t.Fatalf("custom Preflight refused a legal request: %v", err)
+	}
+	got, err := api.CreateInference(context.Background(), req, "custom-inference-key-1")
+	if err != nil {
+		t.Fatalf("custom CreateInference: %v", err)
+	}
+	return got.ID
+}
+
+func renderInference(t *testing.T, api cityinference.API, sym *symbols, inferenceID string) []string {
+	t.Helper()
+	ctx := context.Background()
+	inf, err := api.GetInference(ctx, inferenceID)
+	if err != nil {
+		t.Fatalf("GetInference: %v", err)
+	}
+	page, err := api.ListInferences(ctx, cityinference.ListFilter{})
+	if err != nil {
+		t.Fatalf("ListInferences: %v", err)
+	}
+	coverage := make([]string, 0, len(cityinference.CoverageFieldGroups()))
+	for _, g := range cityinference.CoverageFieldGroups() {
+		coverage = append(coverage, g+"="+inf.Coverage[g])
+	}
+	tokens := "-"
+	if inf.TokenUsage != nil {
+		tokens = "present"
+	}
+	// external is rendered RAW on purpose: the derived handle is a function of
+	// the native triplet alone, so both styles must produce the same string.
+	// If producing through City changed it, City would be an identity authority.
+	return []string{
+		fmt.Sprintf("inference id=%s external=%s run=%s session=%s record=%s outcome=%s scope=%s fold=%t",
+			sym.of(inf.ID), inf.ExternalInferenceID, sym.of(inf.RunID), sym.of(inf.SessionID),
+			sym.of(inf.TranscriptRecordID), inf.Outcome, inf.IdentityScope, inf.FoldEligible),
+		fmt.Sprintf("inference-usage tokens=%s completeness=%s epoch=%d contributions=%d",
+			tokens, inf.Completeness, inf.Epoch, len(inf.Contributions)),
+		"inference-coverage " + strings.Join(coverage, " "),
+		fmt.Sprintf("inference-list count=%d", len(page.Items)),
+	}
+}
+
+// graph produces the whole normalized cross-adapter chain for one style. The
+// three adapters are wired to each other through server-minted Team IDs only,
+// which is the same wiring a real deployment has and the reason a City fact
+// cannot become load bearing between them.
+func graph(t *testing.T, s producerStyle, city bool) []string {
+	t.Helper()
+	sym := newSymbols()
+
+	nf := cityneutral.NewFake(s.uploader, s.sourceID, s.sourceKind)
+	var runID, sessID string
+	if city {
+		runID, sessID = cityNeutralLeg(t, nf, s)
+	} else {
+		runID, sessID = customNeutralLeg(t, nf, s)
+	}
+	lines := renderNeutral(t, nf, sym, runID, sessID)
+
+	records, err := nf.ListTranscriptRecords(context.Background(), sessID)
+	if err != nil {
+		t.Fatalf("ListTranscriptRecords: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("no transcript records to link an inference to")
+	}
+	recID := records[0].ID
+
+	af := cityartifact.NewFake()
+	af.Authorize(linkedProject, linkedIssue, runID, sessID)
+	aapi := af.Client(s.sourceID, s.sourceKind)
+	var artifactID string
+	if city {
+		artifactID = cityArtifactLeg(t, af, s, runID, sessID)
+	} else {
+		artifactID = customArtifactLeg(t, aapi, runID, sessID)
+	}
+	lines = append(lines, renderArtifact(t, aapi, sym, artifactID)...)
+
+	iapi := newInferenceAPI(runID, sessID, recID)
+	var inferenceID string
+	if city {
+		inferenceID = cityInferenceLeg(t, iapi, s, runID, sessID, recID)
+	} else {
+		inferenceID = customInferenceLeg(t, iapi, s, runID, sessID, recID)
+	}
+	lines = append(lines, renderInference(t, iapi, sym, inferenceID)...)
+
+	rep := s.replacer()
+	for i, l := range lines {
+		lines[i] = rep.Replace(l)
+	}
+	return lines
+}
+
+// AC1 happy path: the two producer styles yield equivalent normalized
+// resources across all three adapters at once.
+func TestCrossProducerGoldenGraph(t *testing.T) {
+	cityLines := graph(t, cityStyle, true)
+	customLines := graph(t, customStyle, false)
+
+	if len(cityLines) != len(customLines) {
+		t.Fatalf("graph shape differs: city has %d lines, custom has %d\ncity:\n%s\ncustom:\n%s",
+			len(cityLines), len(customLines), strings.Join(cityLines, "\n"), strings.Join(customLines, "\n"))
+	}
+	for i := range cityLines {
+		if cityLines[i] != customLines[i] {
+			t.Errorf("line %d diverges:\n city:   %s\n custom: %s", i, cityLines[i], customLines[i])
+		}
+	}
+}
+
+// AC1: no City-shaped fact survives into any normalized resource. The City
+// chain carries a city, a rig and a formula on every leg; if any of them
+// reached a neutral record, a custom producer would have to satisfy a City
+// schema to reach parity.
+func TestCityFactsNeverReachNeutralResources(t *testing.T) {
+	lines := strings.Join(graph(t, cityStyle, true), "\n")
+	for _, fact := range []string{"rustbelt", "rig-alpha", "formula-bravo", "rig-3", "review"} {
+		if strings.Contains(lines, fact) {
+			t.Errorf("City-only fact %q reached a neutral resource:\n%s", fact, lines)
+		}
+	}
+}
+
+// AC1 edge: every adapter has an outbound guard, and all three refuse rather
+// than truncate. A single adapter that let free-form egress through would make
+// the parity claim style-dependent.
+func TestAllThreeAdaptersGuardOutboundEgress(t *testing.T) {
+	if err := cityneutral.ScanOutbound(cityneutral.TranscriptRecordIngest{
+		SourceMessageID: "m1", Role: cityneutral.RoleUser, OccurredAt: t0, Text: "secret transcript text",
+	}, false); err == nil {
+		t.Error("cityneutral.ScanOutbound admitted free-form content with content egress off")
+	}
+	if err := cityartifact.ScanOutbound(cityartifact.CreateRequest{
+		Kind: "transcript", MediaType: mediaType,
+		Links: cityartifact.Links{RunID: "https://bucket.s3.amazonaws.com/o?X-Amz-Signature=dead"},
+	}); err == nil {
+		t.Error("cityartifact.ScanOutbound admitted a pre-signed locator")
+	}
+	if err := cityinference.ScanForbidden([]byte(`{"prompt":"do the thing","completion":"done"}`)); err == nil {
+		t.Error("cityinference.ScanForbidden admitted prompt and completion text")
+	}
+}

--- a/pkg/cityparity/independence_test.go
+++ b/pkg/cityparity/independence_test.go
@@ -1,0 +1,606 @@
+package cityparity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/pkg/cityartifact"
+	"github.com/gastownhall/gascity/pkg/cityinference"
+	"github.com/gastownhall/gascity/pkg/cityneutral"
+)
+
+// trio is the three adapters wired to each other the way a deployment wires
+// them: through server-minted Team IDs and nothing else. Each holds its own
+// API, its own checkpoint store and its own source epoch.
+type trio struct {
+	nf *cityneutral.Fake
+	np *cityneutral.Producer
+
+	af *cityartifact.Fake
+	ap *cityartifact.Producer
+
+	iapi *cityinference.FakeAPI
+	ip   *cityinference.Producer
+
+	runID, sessID, recID string
+	baseArtifactID       string
+}
+
+func newTrio(t *testing.T) *trio {
+	t.Helper()
+	ctx := context.Background()
+	s := cityStyle
+	tr := &trio{}
+
+	tr.nf = cityneutral.NewFake(s.uploader, s.sourceID, s.sourceKind)
+	np, err := cityneutral.NewProducer(tr.nf, cityneutral.Mapper{
+		Source:          cityneutral.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1},
+		AllowRawContent: true,
+	}, cityneutral.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("neutral NewProducer: %v", err)
+	}
+	tr.np = np
+	res, err := np.Push(ctx, s.chain())
+	if err != nil {
+		t.Fatalf("neutral base Push: %v", err)
+	}
+	tr.runID, tr.sessID = res.RunTeamID, res.Sessions[0].TeamID
+	records, err := tr.nf.ListTranscriptRecords(ctx, tr.sessID)
+	if err != nil || len(records) == 0 {
+		t.Fatalf("base transcript: %v (%d records)", err, len(records))
+	}
+	tr.recID = records[0].ID
+
+	tr.af = cityartifact.NewFake()
+	tr.af.Authorize(linkedProject, linkedIssue, tr.runID, tr.sessID)
+	ap, err := cityartifact.NewProducer(tr.af.Client(s.sourceID, s.sourceKind),
+		cityartifact.Mapper{Source: cityartifact.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1}},
+		cityartifact.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("artifact NewProducer: %v", err)
+	}
+	tr.ap = ap
+	ares, err := ap.Push(ctx, s.artifact(tr.runID, tr.sessID))
+	if err != nil {
+		t.Fatalf("artifact base Push: %v", err)
+	}
+	tr.baseArtifactID = ares.ArtifactID
+
+	tr.iapi = newInferenceAPI(tr.runID, tr.sessID, tr.recID)
+	ip, err := cityinference.NewProducer(tr.iapi,
+		cityinference.Mapper{Source: inferenceSource(s)}, cityinference.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("inference NewProducer: %v", err)
+	}
+	tr.ip = ip
+	if _, err := ip.Push(ctx, []cityinference.CityInvocation{s.invocation(tr.runID, tr.sessID, tr.recID)}); err != nil {
+		t.Fatalf("inference base Push: %v", err)
+	}
+	return tr
+}
+
+// nextRound is one fresh unit of work per adapter. Fresh work matters: a replay
+// of already-acknowledged work is skipped without a call, so it would sail past
+// an injected transport fault and prove nothing.
+func (tr *trio) nextRound(tag string) (cityneutral.CityChain, cityartifact.CityArtifact, cityinference.CityInvocation) {
+	s := cityStyle
+	chain := s.chain()
+	chain.Run.RunID = "city-run-" + tag
+	chain.Sessions[0].SessionID = "city-sess-" + tag
+
+	art := s.artifact(tr.runID, tr.sessID)
+	art.ArtifactID = "city-artifact-" + tag
+
+	inv := s.invocation(tr.runID, tr.sessID, tr.recID)
+	inv.UpstreamReqID = "req-" + tag
+	return chain, art, inv
+}
+
+// pushRound offers each adapter its own fresh work and reports each outcome
+// separately. No adapter's failure is allowed to short-circuit another's push,
+// because that is exactly the coupling under test.
+func (tr *trio) pushRound(tag string) (nErr, aErr, iErr error) {
+	ctx := context.Background()
+	chain, art, inv := tr.nextRound(tag)
+	_, nErr = tr.np.Push(ctx, chain)
+	_, aErr = tr.ap.Push(ctx, art)
+	_, iErr = tr.ip.Push(ctx, []cityinference.CityInvocation{inv})
+	return nErr, aErr, iErr
+}
+
+// assertBaseSurvives checks that everything acknowledged before the fault is
+// still exactly as the server accepted it.
+func (tr *trio) assertBaseSurvives(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := tr.nf.GetRun(ctx, tr.runID); err != nil {
+		t.Errorf("acknowledged run no longer readable: %v", err)
+	}
+	sess, err := tr.nf.GetSession(ctx, tr.sessID)
+	if err != nil {
+		t.Errorf("acknowledged session no longer readable: %v", err)
+	} else if !sess.Finalized {
+		t.Error("acknowledged session lost its finalized state")
+	}
+	records, err := tr.nf.ListTranscriptRecords(ctx, tr.sessID)
+	if err != nil || len(records) != 3 {
+		t.Errorf("acknowledged transcript changed: %v (%d records)", err, len(records))
+	}
+	art, err := tr.af.Client(cityStyle.sourceID, cityStyle.sourceKind).GetArtifact(ctx, tr.baseArtifactID)
+	if err != nil {
+		t.Errorf("acknowledged artifact no longer readable: %v", err)
+	} else if art.Status != "final" {
+		t.Errorf("acknowledged artifact left status %q", art.Status)
+	}
+	page, err := tr.iapi.ListInferences(ctx, cityinference.ListFilter{})
+	if err != nil || len(page.Items) == 0 {
+		t.Errorf("acknowledged inference no longer listed: %v (%d items)", err, len(page.Items))
+	}
+}
+
+// AC2 happy path: the fault-domain matrix. One adapter faults; the other two
+// land their own fresh work in the same round, and every acknowledged record
+// survives. The faulted adapter then recovers on retry without the others
+// having been touched.
+func TestFaultDomainMatrix(t *testing.T) {
+	boom := errors.New("upstream said no")
+	cases := []struct {
+		name    string
+		inject  func(tr *trio)
+		wantErr func(nErr, aErr, iErr error) (others []error, faulted error)
+	}{
+		{
+			name:   "neutral",
+			inject: func(tr *trio) { tr.nf.Fail = boom },
+			wantErr: func(n, a, i error) ([]error, error) {
+				return []error{a, i}, n
+			},
+		},
+		{
+			name:   "artifact",
+			inject: func(tr *trio) { tr.af.FailNext(cityartifact.OpCreateArtifact, boom) },
+			wantErr: func(n, a, i error) ([]error, error) {
+				return []error{n, i}, a
+			},
+		},
+		{
+			name:   "inference",
+			inject: func(tr *trio) { tr.iapi.FailNext = boom },
+			wantErr: func(n, a, i error) ([]error, error) {
+				return []error{n, a}, i
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := newTrio(t)
+			tc.inject(tr)
+
+			others, faulted := tc.wantErr(tr.pushRound("r2"))
+			if faulted == nil {
+				t.Fatal("injected fault did not surface as a refusal")
+			}
+			for i, err := range others {
+				if err != nil {
+					t.Errorf("a neighboring adapter was dragged down by the %s fault (%d): %v", tc.name, i, err)
+				}
+			}
+			tr.assertBaseSurvives(t)
+
+			// The fault was one-shot, so the same offer must now land: a
+			// refusal leaves no half-advanced checkpoint behind.
+			retryOthers, retryFaulted := tc.wantErr(tr.pushRound("r2"))
+			if retryFaulted != nil {
+				t.Errorf("%s adapter did not recover after the fault cleared: %v", tc.name, retryFaulted)
+			}
+			for i, err := range retryOthers {
+				if err != nil {
+					t.Errorf("replaying a neighboring adapter's round was not idempotent (%d): %v", i, err)
+				}
+			}
+			tr.assertBaseSurvives(t)
+		})
+	}
+}
+
+// AC2: lag is not a fault. One adapter simply not pushing must leave the others
+// free to advance, which is the weakest form of independence and the one a
+// shared checkpoint would break first.
+func TestOneAdapterLaggingDoesNotBlockTheOthers(t *testing.T) {
+	ctx := context.Background()
+	tr := newTrio(t)
+	chain, art, inv := tr.nextRound("lag")
+	_ = chain // the neutral adapter is the lagging one: it never offers this chain.
+
+	if _, err := tr.ap.Push(ctx, art); err != nil {
+		t.Errorf("artifact adapter blocked behind a lagging neutral adapter: %v", err)
+	}
+	if _, err := tr.ip.Push(ctx, []cityinference.CityInvocation{inv}); err != nil {
+		t.Errorf("inference adapter blocked behind a lagging neutral adapter: %v", err)
+	}
+	if _, err := tr.nf.GetRun(ctx, tr.runID); err != nil {
+		t.Errorf("lagging adapter's acknowledged run was disturbed: %v", err)
+	}
+}
+
+// AC2: a credential rotation is not an identity change. Every adapter must
+// resume on the same checkpoint and write nothing twice, because no adapter's
+// checkpoint key may contain anything that a rotation changes.
+func TestCredentialRotationChangesNothing(t *testing.T) {
+	ctx := context.Background()
+	s := cityStyle
+	tr := newTrio(t)
+
+	nStore := cityneutral.NewMemoryStore()
+	np, err := cityneutral.NewProducer(tr.nf, cityneutral.Mapper{
+		Source:          cityneutral.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1},
+		AllowRawContent: true,
+	}, nStore)
+	if err != nil {
+		t.Fatalf("neutral NewProducer: %v", err)
+	}
+	// A rotation looks like a restart with an empty local checkpoint: the
+	// producer re-offers, and the server's idempotency is what makes the
+	// re-offer free of duplicates.
+	res, err := np.Push(ctx, s.chain())
+	if err != nil {
+		t.Fatalf("neutral push after rotation: %v", err)
+	}
+	if res.RunTeamID != tr.runID || res.Sessions[0].TeamID != tr.sessID {
+		t.Errorf("rotation re-minted neutral identity: run %q->%q session %q->%q",
+			tr.runID, res.RunTeamID, tr.sessID, res.Sessions[0].TeamID)
+	}
+	records, err := tr.nf.ListTranscriptRecords(ctx, tr.sessID)
+	if err != nil || len(records) != 3 {
+		t.Errorf("rotation duplicated transcript records: %v (%d)", err, len(records))
+	}
+
+	rotated := tr.af.Client(s.sourceID, s.sourceKind)
+	ap, err := cityartifact.NewProducer(rotated,
+		cityartifact.Mapper{Source: cityartifact.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1}},
+		cityartifact.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("artifact NewProducer: %v", err)
+	}
+	ares, err := ap.Push(ctx, s.artifact(tr.runID, tr.sessID))
+	if err != nil {
+		t.Fatalf("artifact push after rotation: %v", err)
+	}
+	if ares.ArtifactID != tr.baseArtifactID {
+		t.Errorf("rotation re-minted artifact identity: %q -> %q", tr.baseArtifactID, ares.ArtifactID)
+	}
+	if got := tr.af.ArtifactCount(); got != 1 {
+		t.Errorf("rotation created a second artifact: count=%d", got)
+	}
+	if got := tr.af.PartCount(tr.baseArtifactID); got != 2 {
+		t.Errorf("rotation duplicated parts: count=%d", got)
+	}
+
+	tr.iapi.Credential = "rotated-bearer"
+	writesBefore := tr.iapi.Writes()
+	ip, err := cityinference.NewProducer(tr.iapi,
+		cityinference.Mapper{Source: inferenceSource(s)}, cityinference.NewMemoryStore())
+	if err != nil {
+		t.Fatalf("inference NewProducer: %v", err)
+	}
+	if _, err := ip.Push(ctx, []cityinference.CityInvocation{s.invocation(tr.runID, tr.sessID, tr.recID)}); err != nil {
+		t.Fatalf("inference push after rotation: %v", err)
+	}
+	page, err := tr.iapi.ListInferences(ctx, cityinference.ListFilter{})
+	if err != nil {
+		t.Fatalf("list after rotation: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Errorf("rotation duplicated the inference record: %d items (writes %d -> %d)",
+			len(page.Items), writesBefore, tr.iapi.Writes())
+	}
+}
+
+// AC2 / FINDING: the three adapters do NOT agree on what a declared reset does.
+//
+// A declared reset — the source epoch advancing — is the loud signal the event
+// contract lacks, and all three adapters put the epoch in their idempotency
+// preimage, so all three agree that a reset re-keys identity. They disagree on
+// what to do next: cityneutral and cityartifact restart the checkpoint and keep
+// producing, while cityinference refuses the push. The inference refusal never
+// writes a new epoch to its checkpoint either, so it is not a pause: the
+// adapter stays refused until an operator deletes the checkpoint out of band.
+//
+// This test asserts what the three adapters do today. It passes, and that is
+// the point: the divergence is real, it is a certification finding against
+// API-7.23-AC2, and this name is its citation.
+func TestDeclaredResetIsNotHandledUniformly(t *testing.T) {
+	ctx := context.Background()
+	s := cityStyle
+
+	nStore := cityneutral.NewMemoryStore()
+	aStore := cityartifact.NewMemoryStore()
+	iStore := cityinference.NewMemoryStore()
+
+	nf := cityneutral.NewFake(s.uploader, s.sourceID, s.sourceKind)
+	np1, err := cityneutral.NewProducer(nf, cityneutral.Mapper{
+		Source:          cityneutral.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1},
+		AllowRawContent: true,
+	}, nStore)
+	if err != nil {
+		t.Fatalf("neutral NewProducer: %v", err)
+	}
+	// The chain and the artifact stay open across the reset. A reset that
+	// replays terminal work is refused for a different reason (the record is
+	// finalized), and that refusal would mask the epoch semantics under test.
+	open := s.chain()
+	open.Sessions[0].Complete = false
+	openArtifact := s.artifact("", "")
+	openArtifact.Complete = false
+
+	res, err := np1.Push(ctx, open)
+	if err != nil {
+		t.Fatalf("neutral epoch-1 push: %v", err)
+	}
+	runID, sessID := res.RunTeamID, res.Sessions[0].TeamID
+
+	af := cityartifact.NewFake()
+	af.Authorize(linkedProject, linkedIssue, runID, sessID)
+	ap1, err := cityartifact.NewProducer(af.Client(s.sourceID, s.sourceKind),
+		cityartifact.Mapper{Source: cityartifact.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1}}, aStore)
+	if err != nil {
+		t.Fatalf("artifact NewProducer: %v", err)
+	}
+	openArtifact.RunID, openArtifact.SessionID = runID, sessID
+	if _, err := ap1.Push(ctx, openArtifact); err != nil {
+		t.Fatalf("artifact epoch-1 push: %v", err)
+	}
+
+	records, err := nf.ListTranscriptRecords(ctx, sessID)
+	if err != nil || len(records) == 0 {
+		t.Fatalf("transcript: %v (%d)", err, len(records))
+	}
+	recID := records[0].ID
+	iapi := newInferenceAPI(runID, sessID, recID)
+	ip1, err := cityinference.NewProducer(iapi, cityinference.Mapper{Source: inferenceSource(s)}, iStore)
+	if err != nil {
+		t.Fatalf("inference NewProducer: %v", err)
+	}
+	if _, err := ip1.Push(ctx, []cityinference.CityInvocation{s.invocation(runID, sessID, recID)}); err != nil {
+		t.Fatalf("inference epoch-1 push: %v", err)
+	}
+
+	// The reset: epoch 2, same enrolled source, same durable checkpoints.
+	np2, err := cityneutral.NewProducer(nf, cityneutral.Mapper{
+		Source:          cityneutral.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 2},
+		AllowRawContent: true,
+	}, nStore)
+	if err != nil {
+		t.Fatalf("neutral NewProducer epoch 2: %v", err)
+	}
+	if _, err := np2.Push(ctx, open); err != nil {
+		t.Errorf("cityneutral no longer absorbs a declared reset: %v", err)
+	}
+
+	ap2, err := cityartifact.NewProducer(af.Client(s.sourceID, s.sourceKind),
+		cityartifact.Mapper{Source: cityartifact.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 2}}, aStore)
+	if err != nil {
+		t.Fatalf("artifact NewProducer epoch 2: %v", err)
+	}
+	if _, err := ap2.Push(ctx, openArtifact); err != nil {
+		t.Errorf("cityartifact no longer absorbs a declared reset: %v", err)
+	}
+
+	iSource := inferenceSource(s)
+	iSource.Epoch = 2
+	ip2, err := cityinference.NewProducer(iapi, cityinference.Mapper{Source: iSource}, iStore)
+	if err != nil {
+		t.Fatalf("inference NewProducer epoch 2: %v", err)
+	}
+	_, err = ip2.Push(ctx, []cityinference.CityInvocation{s.invocation(runID, sessID, recID)})
+	if !errors.Is(err, cityinference.ErrIdentityDrift) {
+		t.Fatalf("cityinference reset behavior changed: want ErrIdentityDrift, got %v", err)
+	}
+
+	// And the refusal is durable: the checkpoint still holds epoch 1, so every
+	// later push under the declared epoch is refused the same way. Two adapters
+	// resume by themselves and one needs an operator.
+	if _, err := ip2.Push(ctx, []cityinference.CityInvocation{s.invocation(runID, sessID, recID)}); !errors.Is(err, cityinference.ErrIdentityDrift) {
+		t.Fatalf("second push after reset: want a durable ErrIdentityDrift, got %v", err)
+	}
+	st, ok, err := iStore.Load(ctx, cityinference.CheckpointKey(iSource))
+	if err != nil || !ok {
+		t.Fatalf("inference checkpoint after reset: %v (found=%t)", err, ok)
+	}
+	if st.Epoch != 1 {
+		t.Fatalf("inference checkpoint epoch = %d, want the refused push to have left it at 1", st.Epoch)
+	}
+}
+
+// AC2 / FINDING: only cityinference has a programmatic rollback switch. The
+// other two roll back by the caller ceasing to call Push, which is a rollback
+// of the scheduler and not of the adapter. Rolling back one adapter is
+// supported in all three cases; doing it the same way is not.
+func TestRollbackSwitchIsNotUniform(t *testing.T) {
+	ctx := context.Background()
+	tr := newTrio(t)
+	tr.ip.Disabled = true
+
+	_, art, inv := tr.nextRound("rb")
+	if _, err := tr.ip.Push(ctx, []cityinference.CityInvocation{inv}); !errors.Is(err, cityinference.ErrDisabled) {
+		t.Fatalf("disabled inference producer: want ErrDisabled, got %v", err)
+	}
+	if _, err := tr.ap.Push(ctx, art); err != nil {
+		t.Errorf("artifact adapter stopped when the inference adapter rolled back: %v", err)
+	}
+	tr.assertBaseSurvives(t)
+
+	writes := tr.iapi.Writes()
+	if _, err := tr.ip.Push(ctx, []cityinference.CityInvocation{inv}); !errors.Is(err, cityinference.ErrDisabled) {
+		t.Fatalf("rollback is not sticky: %v", err)
+	}
+	if got := tr.iapi.Writes(); got != writes {
+		t.Errorf("a rolled-back adapter still issued writes: %d -> %d", writes, got)
+	}
+}
+
+// sharedKV is one durable key-value store shared by two adapters, which is what
+// an operator gets by handing both the same backing table.
+type sharedKV struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newSharedKV() *sharedKV { return &sharedKV{m: map[string][]byte{}} }
+
+func (kv *sharedKV) get(key string) ([]byte, bool) {
+	kv.mu.Lock()
+	defer kv.mu.Unlock()
+	b, ok := kv.m[key]
+	return b, ok
+}
+
+func (kv *sharedKV) put(key string, b []byte) {
+	kv.mu.Lock()
+	defer kv.mu.Unlock()
+	kv.m[key] = b
+}
+
+type neutralKV struct{ kv *sharedKV }
+
+func (s neutralKV) Load(_ context.Context, key string) (cityneutral.State, bool, error) {
+	var st cityneutral.State
+	b, ok := s.kv.get(key)
+	if !ok {
+		return st, false, nil
+	}
+	if err := json.Unmarshal(b, &st); err != nil {
+		return st, false, err
+	}
+	return st, true, nil
+}
+
+func (s neutralKV) Save(_ context.Context, key string, st cityneutral.State) error {
+	b, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	s.kv.put(key, b)
+	return nil
+}
+
+type artifactKV struct{ kv *sharedKV }
+
+func (s artifactKV) Load(_ context.Context, key string) (cityartifact.State, bool, error) {
+	var st cityartifact.State
+	b, ok := s.kv.get(key)
+	if !ok {
+		return st, false, nil
+	}
+	if err := json.Unmarshal(b, &st); err != nil {
+		return st, false, err
+	}
+	return st, true, nil
+}
+
+func (s artifactKV) Save(_ context.Context, key string, st cityartifact.State) error {
+	b, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	s.kv.put(key, b)
+	return nil
+}
+
+// AC2 edge / FINDING: cityneutral and cityartifact mint the SAME checkpoint key
+// for a City run and a City artifact that share a native ID, and their two
+// State documents deserialize into each other without an error. cityinference
+// is the only one of the three whose key names its domain ("/inference").
+//
+// Under separate stores this is invisible. Under one shared store — the same
+// table, the obvious operational choice, and the only thing "shared checkpoint
+// corruption" could mean — one adapter silently erases the other's frontier.
+// That is a cross-adapter fault domain, and this test is its proof.
+func TestNeutralAndArtifactCheckpointKeysCollide(t *testing.T) {
+	ctx := context.Background()
+	s := cityStyle
+	const nativeID = "shared-native-id"
+
+	nKey := cityneutral.CheckpointKey(
+		cityneutral.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1}, nativeID)
+	aKey := cityartifact.CheckpointKey(
+		cityartifact.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1}, nativeID)
+	iKey := cityinference.CheckpointKey(inferenceSource(s))
+
+	if nKey != aKey {
+		t.Fatalf("checkpoint keys no longer collide (%q vs %q): the finding is fixed, "+
+			"update this certification to assert disjointness instead", nKey, aKey)
+	}
+	if iKey == nKey {
+		t.Fatalf("inference key now collides too: %q", iKey)
+	}
+
+	kv := newSharedKV()
+	af := cityartifact.NewFake()
+	af.Authorize(linkedProject, linkedIssue)
+	ap, err := cityartifact.NewProducer(af.Client(s.sourceID, s.sourceKind),
+		cityartifact.Mapper{Source: cityartifact.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1}},
+		artifactKV{kv})
+	if err != nil {
+		t.Fatalf("artifact NewProducer: %v", err)
+	}
+	art := s.artifact("", "")
+	art.ArtifactID = nativeID
+	art.ProjectID, art.IssueID = linkedProject, linkedIssue
+	ares, err := ap.Push(ctx, art)
+	if err != nil {
+		t.Fatalf("artifact push onto the shared store: %v", err)
+	}
+	if ares.ArtifactID == "" {
+		t.Fatal("artifact push produced no ID")
+	}
+
+	before, _, err := (artifactKV{kv}).Load(ctx, aKey)
+	if err != nil {
+		t.Fatalf("load artifact checkpoint: %v", err)
+	}
+	if before.ArtifactID == "" || !before.Finalized {
+		t.Fatalf("artifact checkpoint is not the complete frontier this test needs: %+v", before)
+	}
+
+	// The other adapter's State decodes out of the artifact's bytes with no
+	// error at all. Nothing in either document says which domain wrote it.
+	crossed, ok, err := (neutralKV{kv}).Load(ctx, nKey)
+	if err != nil || !ok {
+		t.Fatalf("an artifact checkpoint should have decoded as a neutral one: %v (found=%t)", err, ok)
+	}
+	if crossed.Epoch != before.Epoch || crossed.SourceID != before.SourceID {
+		t.Fatalf("cross-decode lost the fields that make it look legitimate: %+v", crossed)
+	}
+	if crossed.RunTeamID != "" {
+		t.Fatalf("cross-decoded neutral state carried a run ID: %+v", crossed)
+	}
+
+	nf := cityneutral.NewFake(s.uploader, s.sourceID, s.sourceKind)
+	np, err := cityneutral.NewProducer(nf, cityneutral.Mapper{
+		Source:          cityneutral.Source{SourceID: s.sourceID, Kind: s.sourceKind, Epoch: 1},
+		AllowRawContent: true,
+	}, neutralKV{kv})
+	if err != nil {
+		t.Fatalf("neutral NewProducer: %v", err)
+	}
+	chain := s.chain()
+	chain.Run.RunID = nativeID
+	if _, err := np.Push(ctx, chain); err != nil {
+		t.Fatalf("neutral push under the colliding key: %v", err)
+	}
+
+	after, _, err := (artifactKV{kv}).Load(ctx, aKey)
+	if err != nil {
+		t.Fatalf("reload artifact checkpoint: %v", err)
+	}
+	if after.ArtifactID != "" || after.Finalized || after.Frontier != 0 {
+		t.Fatalf("expected the artifact frontier to be erased by the neighbor, got %+v", after)
+	}
+	t.Logf("FINDING API-7.23-AC2: %s erased the artifact frontier %q (parts %d) under shared key %q",
+		"cityneutral", before.ArtifactID, before.Frontier, aKey)
+}

--- a/pkg/cityparity/manifest.json
+++ b/pkg/cityparity/manifest.json
@@ -1,0 +1,65 @@
+{
+  "schema": "api-7.23.city-producer-parity.v1",
+  "generated_client": "out-of-repo: the three adapters speak hand-written API seams (pkg/city*/contract.go); the generated v1 client is the Team Server's artifact and its digest is not resolvable from gascity, so this manifest asserts no digest for it",
+  "landings": [
+    {
+      "task": "API-7.20",
+      "pr": 4874,
+      "commit": "b44d3935a4b59d4289ceb52a76444095428cb0a6"
+    },
+    {
+      "task": "API-7.21",
+      "pr": 4883,
+      "commit": "bd0675f9842ee379cfcf776c67c2ad602ab36d53"
+    },
+    {
+      "task": "API-7.22",
+      "pr": 4884,
+      "commit": "22c6ce96ed800e1026437e3f8b884c34102d90a3"
+    }
+  ],
+  "packages": {
+    "cityartifact": "sha256:654125bfd885df9445c06a4541f45d6bf201e22dfc48b15de527c479f023c2d1",
+    "cityinference": "sha256:7997a8de3251470f343287a7d90f4a6dafcfe2c563ae9a160d54b43e8ab86caf",
+    "cityneutral": "sha256:74e975907243c8ad1d6b7d18898a0d1539cf296ec9ae5270e949a63ba6776b87",
+    "cityparity": "sha256:716fd3a8716be3a342e0506774f4b96630a9dc9212a08d3c1a71044b3cb08dd6"
+  },
+  "files": {
+    "cityartifact/checkpoint_test.go": "sha256:7a8c2f9406cfca49da64ef619e714fa2b662634d930bcb617cf5f93caf5c663e",
+    "cityartifact/cityartifact.go": "sha256:99731d1ff478ec0cd03b82f54d55c7a3a154654a4bc7e5944b67923e48c37106",
+    "cityartifact/contract.go": "sha256:667d51a756af4fa8433a5c0f8ce18fe296d0f7cb81bc4c119c1177e204c048bf",
+    "cityartifact/fake.go": "sha256:03d00896707d49451ee0ed35cd904d6dd9cb29183a5326b954feadcfb3e30d6c",
+    "cityartifact/fault_test.go": "sha256:2746cdc0820ca4814b54f4d74e02911527603071f3185b7a4ce6f8c4451a2e1f",
+    "cityartifact/mapping.go": "sha256:e4489ef85301d9fee3ad249cb02b1d86c450a7178d12eb0fff7ceb2ce58bd801",
+    "cityartifact/parity_test.go": "sha256:58181e67d6941587635d3b7881adab7a84381c2536ea281654c5c48c701bb3a3",
+    "cityartifact/producer.go": "sha256:d20eca2f10aa5b62db0eef1c34959eb4f13051f16cf1120c0b3071df5597d13b",
+    "cityinference/cityinference.go": "sha256:807fe21aa1e313947dd9122adac34956144acb27c3c82f816e135d0cf80bcc6d",
+    "cityinference/contract.go": "sha256:64fc01e9d53ee9c1c95b713deaf01a4401d3990a62fe1caa58dd08bfb1a013df",
+    "cityinference/coverage_test.go": "sha256:76d77f2c5473487736f9ce5d7b70a97fcc86ab90c006bffb8294c0d2965fec82",
+    "cityinference/fake.go": "sha256:732fcbfc7645c54372887f80202392173678375acd94418cbd93c004f988bf7c",
+    "cityinference/identity_test.go": "sha256:4680b083f0eec3d27dba551df0b12d4a68998800e6756a53b723abacb624fac4",
+    "cityinference/isolation_test.go": "sha256:e8e3ab799f2349731f3bd1f034589c56f55cbf6918d6c5657333b180d7a44ec5",
+    "cityinference/mapping.go": "sha256:ab8c7f74337e7f5104b0d15977652a36757b141ca3da7c3010ab5904c5469434",
+    "cityinference/mapping_test.go": "sha256:f8409b545eb5bb3ddd69af5dbcadd563da28cfc291c2bfe8297ff113f6fd64cc",
+    "cityinference/producer.go": "sha256:2496b747249e6b12804ac8f1319c5c512da9135731947f70ab4c57aa4852642f",
+    "cityinference/producer_test.go": "sha256:bff04544dc80585bd0bfbb50512bcccf12bd0259260f1e971665b229099b148f",
+    "cityneutral/checkpoint_test.go": "sha256:5b0eaafdd91dfea6772a1d20adb9aae43fc9af72d294adbb03645615f7f08986",
+    "cityneutral/cityneutral.go": "sha256:24d415e757b6b33549fa654d484f388571c0dc6a1a81095d454e28df4535d0c0",
+    "cityneutral/contract.go": "sha256:d945b8135eb6c1289d000836b6f993cb725bdc0daca3f6eadc9f7378a04b0892",
+    "cityneutral/fake.go": "sha256:e56703c10f44cc2571ec94c958abe691bb072a52f0438c55c8f2091e43976ace",
+    "cityneutral/mapping.go": "sha256:8b76cad82956fae5d584d3cb0620d05dd47e0a0cb3c67ef74f40f8b69ef1448b",
+    "cityneutral/parity_test.go": "sha256:a3d8df6c649eef4f226c96cb349aa507e7bf31312f47e7c304715a91c0c4d4db",
+    "cityneutral/producer.go": "sha256:c9025ddc393c22fe21b4336e7246a580758ad71ba6c8109a65f42a399d52c29b",
+    "cityneutral/provenance_test.go": "sha256:65b68ae2e9558326235b943b38e8eddd819bf1a1e9bd9b75f042e732cbaaaffe",
+    "cityparity/doc.go": "sha256:d679f649ed66776bfb4cdc5d9d9b9c5048ae6a9d891ae8548fc8c0cc0d4c3914",
+    "cityparity/golden_test.go": "sha256:4bb5b867bef60848c87b4c5b5b45447d39256de93499995579cc1e4a6560dd93",
+    "cityparity/independence_test.go": "sha256:5d75b77f0a4e5fa7b27307103c93e6bdfe5b59e72c6b4f9a87ce459d65e82e71",
+    "cityparity/manifest_test.go": "sha256:0ec087c949de8d8dd34541dd0a4fe431c0d500de29cf8d6f0642516e210b20ec"
+  },
+  "findings": [
+    "AC2/checkpoint-namespace: cityneutral.CheckpointKey and cityartifact.CheckpointKey are byte-identical for a run and an artifact sharing a native ID, and their State documents cross-decode without error. Under one shared checkpoint store the neutral adapter erases the artifact adapter's frontier. Proof: TestNeutralAndArtifactCheckpointKeysCollide. cityinference is the only adapter whose key names its domain.",
+    "AC2/reset: a declared reset (source epoch advance) is absorbed by cityneutral and cityartifact, which restart the checkpoint and keep producing, but refused by cityinference with ErrIdentityDrift. The inference refusal never writes the new epoch, so the adapter stays refused until an operator clears the checkpoint. Proof: TestDeclaredResetIsNotHandledUniformly.",
+    "AC2/rollback: only cityinference has a programmatic kill switch (Producer.Disabled + ErrDisabled); the other two roll back only by the caller ceasing to call Push. Proof: TestRollbackSwitchIsNotUniform.",
+    "AC3/generated-client: not resolvable from this repository; see generated_client above."
+  ]
+}

--- a/pkg/cityparity/manifest_test.go
+++ b/pkg/cityparity/manifest_test.go
@@ -1,0 +1,192 @@
+package cityparity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// manifestPath is the one immutable parity manifest. There is exactly one, and
+// it is data rather than code so a reviewer can diff what was certified.
+const manifestPath = "manifest.json"
+
+// certifiedPackages are the sources whose digests the parity claim rests on:
+// the three adapters it compares and the certification itself. A change to any
+// of them is a change to the claim.
+var certifiedPackages = []string{
+	"cityartifact",
+	"cityinference",
+	"cityneutral",
+	"cityparity",
+}
+
+// Landing records the commit each adapter landed on, as reported by the branch
+// that was merged to produce this certification. It is evidence, not a
+// verifier: nothing in a test can prove a commit is still the tip.
+type Landing struct {
+	Task   string `json:"task"`
+	PR     int    `json:"pr"`
+	Commit string `json:"commit"`
+}
+
+type Manifest struct {
+	Schema string `json:"schema"`
+	// GeneratedClient records where the generated client digest lives. It is
+	// NOT in this repository: the adapters speak hand-written seams
+	// (API interfaces) and the generated client is the Team Server's artifact,
+	// so this certification cannot resolve its digest and says so instead of
+	// implying it checked one.
+	GeneratedClient string            `json:"generated_client"`
+	Landings        []Landing         `json:"landings"`
+	Packages        map[string]string `json:"packages"`
+	Files           map[string]string `json:"files"`
+	Findings        []string          `json:"findings"`
+}
+
+func digestFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // fixed, test-local package paths
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// digests walks the certified packages and returns one entry per Go file plus a
+// per-package roll-up. A new file changes the package digest, which is what
+// makes "any later change invalidates parity" true for additions and not only
+// for edits.
+func digests(t *testing.T) (files map[string]string, packages map[string]string) {
+	t.Helper()
+	files = map[string]string{}
+	packages = map[string]string{}
+	for _, pkg := range certifiedPackages {
+		dir := filepath.Join("..", pkg)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read dir %s: %v", dir, err)
+		}
+		var names []string
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+				continue
+			}
+			names = append(names, e.Name())
+		}
+		if len(names) == 0 {
+			t.Fatalf("certified package %s has no Go files", pkg)
+		}
+		sort.Strings(names)
+		roll := sha256.New()
+		for _, name := range names {
+			rel := pkg + "/" + name
+			d := digestFile(t, filepath.Join(dir, name))
+			files[rel] = d
+			roll.Write([]byte(rel + "\x00" + d + "\n"))
+		}
+		packages[pkg] = "sha256:" + hex.EncodeToString(roll.Sum(nil))
+	}
+	return files, packages
+}
+
+func loadManifest(t *testing.T) Manifest {
+	t.Helper()
+	b, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", manifestPath, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("parse %s: %v", manifestPath, err)
+	}
+	return m
+}
+
+// AC3 happy path: one current immutable manifest resolves, and every digest it
+// consumed still matches. AC3 edge: it does not, and publication is blocked.
+//
+// Set GC_PARITY_UPDATE=1 to re-cut the manifest. That is a deliberate act of
+// re-certification, not a baseline bump: the parity report published against
+// the old manifest no longer describes the code.
+func TestParityManifestDigestsMatch(t *testing.T) {
+	files, packages := digests(t)
+
+	if os.Getenv("GC_PARITY_UPDATE") == "1" {
+		m := loadManifest(t)
+		m.Files, m.Packages = files, packages
+		b, err := json.MarshalIndent(m, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal manifest: %v", err)
+		}
+		if err := os.WriteFile(manifestPath, append(b, '\n'), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		t.Log("manifest re-cut; re-run without GC_PARITY_UPDATE to verify")
+		return
+	}
+
+	m := loadManifest(t)
+	for name, want := range m.Files {
+		got, ok := files[name]
+		if !ok {
+			t.Errorf("certified file %s is gone: the manifest is stale and parity is invalid", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("certified file %s changed since the manifest was cut:\n want %s\n got  %s", name, want, got)
+		}
+	}
+	for name := range files {
+		if _, ok := m.Files[name]; !ok {
+			t.Errorf("file %s is not in the manifest: it landed after certification, so parity is unproven for it", name)
+		}
+	}
+	for pkg, want := range m.Packages {
+		if got := packages[pkg]; got != want {
+			t.Errorf("package %s digest changed: want %s got %s", pkg, want, got)
+		}
+	}
+	if len(m.Packages) != len(certifiedPackages) {
+		t.Errorf("manifest covers %d packages, certification covers %d", len(m.Packages), len(certifiedPackages))
+	}
+}
+
+var commitRE = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// AC3: the manifest names the three adapter commits it was cut over. This is
+// the landing evidence; it is recorded, not verified, and the test says which.
+func TestParityManifestNamesThreeLandings(t *testing.T) {
+	m := loadManifest(t)
+	if m.Schema == "" {
+		t.Error("manifest has no schema version")
+	}
+	if len(m.Landings) != 3 {
+		t.Fatalf("manifest records %d landings, want the three adapter commits", len(m.Landings))
+	}
+	seen := map[string]bool{}
+	for _, l := range m.Landings {
+		if !commitRE.MatchString(l.Commit) {
+			t.Errorf("landing %s has no full commit id: %q", l.Task, l.Commit)
+		}
+		if l.PR == 0 || l.Task == "" {
+			t.Errorf("landing %+v is missing its task or PR", l)
+		}
+		if seen[l.Commit] {
+			t.Errorf("landing %s repeats commit %s", l.Task, l.Commit)
+		}
+		seen[l.Commit] = true
+	}
+	if m.GeneratedClient == "" {
+		t.Error("manifest is silent about the generated client; silence is what this program forbids")
+	}
+	if len(m.Findings) == 0 {
+		t.Error("manifest records no findings section; an empty list must be explicit")
+	}
+}


### PR DESCRIPTION
Cross-adapter parity certification for the three City neutral producers (#4874 run/session/transcript, #4883 artifact, #4884 inference). New package `pkg/cityparity`, **no product code changed**.

## This task nearly did not exist

A YAGNI lens proposed merging the three City adapters into one. The review **rejected** it after checking the edge set and finding each has a different second prerequisite. Had they merged, this certification would have been meaningless — you cannot prove fault-domain independence between three things that are one thing.

It found two real bugs. Both would have been invisible to a merged implementation, and both were invisible to the adapters own in-package tests, because none of those tests imports another adapter.

## Finding 1 — checkpoint key collision (data loss)

```go
// cityneutral    source.Kind + "/" + source.SourceID + "/" + cityRunID
// cityartifact   source.Kind + "/" + source.SourceID + "/" + cityArtifactID
```

Byte-identical construction; neither names its domain. A run and an artifact sharing a native ID share a checkpoint, and their state documents **cross-decode without error**. `TestNeutralAndArtifactCheckpointKeysCollide` drives it over one shared KV store: a neutral push **erases an artifact frontier that had 2 parts and was finalized**.

`cityinference` is the only one that gets this right — its key names its domain.

## Finding 2 — the reset contract was never agreed

`cityneutral` and `cityartifact` treat an epoch advance as a declared reset and keep producing. `cityinference` refuses **any** epoch mismatch and never writes the new epoch, so it stays refused on every later push until an operator clears the checkpoint by hand.

This is exactly the hazard the `API-1.8` manifest raised: City events carry a monotonic seq with no epoch or reset marker, so each adapter invented its own answer.

## What passed

Equivalence is proven positively: the same chain produced twice — once through all three City adapters, once by a hand-built custom producer with **no City code in the path** — yields graphs equal line for line across Team IDs, links, provenance, coverage, content boundaries and retrieval. City facts (city, rig, formula) appear nowhere in the neutral resources.

Fault-domain independence holds: a transport fault injected into each adapter in turn leaves the other two landing fresh work in the same round, every acknowledged record intact.

## Honest status

**AC2 and AC3 are marked unmet.** The findings above are why, and they are the deliverable — a certification reporting all-green while two adapters silently corrupt each others state would be worse than none.

The fixes are on `feat/api-7-23-adapter-divergence-fix`: domain-scoped keys with a read-old-write-new migration, and an explicit `ResetDeclaration` that distinguishes a declared reset from identity drift — because the adapters previously *could not tell them apart*, which turned out to be the actual root cause.

Verified: `make test-fast-parallel` — full repo gate, exit 0.