### PR TITLE
test: keep Dolt identity state outside TempDir cleanup

### DIFF
--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1239,13 +1239,16 @@ func TestBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore(t *testing.
 	if err != nil {
 		t.Fatalf("writeManagedBdWaitTestCityScaffold: %v", err)
 	}
-	requireNoLeakedDoltAfterForPaths(t, cityPath)
 	const projectID = "gc-rig-worktree-consistency-test"
 	setupQueries := append(seedDatabaseProjectIDQueries(projectID),
 		"CALL DOLT_ADD('.')",
 		"CALL DOLT_COMMIT('-m', 'test: seed rig worktree identity', '--author', 'gascity-test <test@gascity.local>')")
-	_, port, _, cleanupDolt := startPasswordedDoltServer(t, filepath.Join(t.TempDir(), "fe"), setupQueries...)
+	feRepoDir := filepath.Join(t.TempDir(), "fe")
+	_, port, _, cleanupDolt := startPasswordedDoltServer(t, feRepoDir, setupQueries...)
 	defer cleanupDolt()
+	// Cover the fe server's own repo root (the actual live-process dir, not
+	// just cityPath) and the relocated dolt identity HOME (ga-7dgcg6).
+	requireNoLeakedDoltAfterForPaths(t, cityPath, feRepoDir, os.Getenv("HOME"))
 
 	for _, scope := range []struct {
 		name     string

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -343,13 +343,27 @@ func writeTestDoltIdentity(homeDir string) error {
 	return os.WriteFile(filepath.Join(doltDir, "config_global.json"), data, 0o644)
 }
 
+// doltIdentityHomeDir returns a fresh directory for dolt/git identity files,
+// created outside every t.TempDir() tree rather than nested inside one.
+// t.TempDir()'s cleanup is a single-pass, non-retrying RemoveAll on its
+// shared parent (see ga-7dgcg6); a dolt/bd child process still writing
+// under DOLT_ROOT_PATH when that RemoveAll fires turns an otherwise-passing
+// test into an ENOTEMPTY failure. Cleanup here is best-effort so a lingering
+// writer fails only this directory's own removal, not the whole test tree.
+func doltIdentityHomeDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(os.TempDir(), "gc-dolt-identity-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(dolt identity home): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func configureTestDoltIdentityEnv(t *testing.T) {
 	t.Helper()
 
-	homeDir := filepath.Join(t.TempDir(), "home")
-	if err := os.MkdirAll(homeDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(test home): %v", err)
-	}
+	homeDir := doltIdentityHomeDir(t)
 	if err := writeTestGitIdentity(homeDir); err != nil {
 		t.Fatalf("write test git identity: %v", err)
 	}

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // gcEnvVars lists the GC_* identity and session-routing variables that
@@ -358,4 +359,24 @@ func configureTestDoltIdentityEnv(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(homeDir, ".gitconfig"))
 	t.Setenv("DOLT_ROOT_PATH", homeDir)
+}
+
+// TestConfigureTestDoltIdentityEnvHomeIsOutsideTestTempDir guards against
+// ga-7dgcg6: a live dolt/bd child process rooted under DOLT_ROOT_PATH can
+// still be writing when this test's t.TempDir() runs its single-pass
+// RemoveAll, turning an otherwise-passing test into an ENOTEMPTY failure.
+// DOLT_ROOT_PATH must live outside every t.TempDir() this test allocates.
+func TestConfigureTestDoltIdentityEnvHomeIsOutsideTestTempDir(t *testing.T) {
+	marker := t.TempDir()
+	tempRoot := filepath.Dir(marker)
+
+	configureTestDoltIdentityEnv(t)
+
+	doltRoot := os.Getenv("DOLT_ROOT_PATH")
+	if doltRoot == "" {
+		t.Fatal("DOLT_ROOT_PATH not set by configureTestDoltIdentityEnv")
+	}
+	if pathutil.PathWithin(tempRoot, doltRoot) {
+		t.Fatalf("DOLT_ROOT_PATH %q must not live under this test's t.TempDir() root %q — a live child process still writing there when t.TempDir()'s single-pass RemoveAll runs fails an otherwise-passing test (ga-7dgcg6)", doltRoot, tempRoot)
+	}
 }

--- a/release-gates/ga-pfdabs-dolt-identity-tempdir-cleanup-gate.md
+++ b/release-gates/ga-pfdabs-dolt-identity-tempdir-cleanup-gate.md
@@ -1,0 +1,32 @@
+# Release gate: isolate Dolt test identity from `t.TempDir` cleanup
+
+- Deploy bead: `ga-pfdabs`
+- Build bead: `ga-7dgcg6`
+- Review bead: `ga-0gqma7`
+- Reviewed commit: `25148bc121317fb357d84f43fbd53eabdca64f6e`
+- Gate base: `origin/main` at `29b36facde4ffe557b6fb5b99c7375468600b606`
+- Evaluated: 2026-07-31
+- Result: **PASS**
+
+Criterion 6 was evaluated first, as required. The remaining criteria were then
+evaluated in numeric order. `docs/PROJECT_MANIFEST.md` is absent from both the
+reviewed commit and current `origin/main`; this checklist therefore applies the
+deployer gate criteria and
+`engdocs/contributors/release-gate-criteria-conventions.md` directly.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-0gqma7` is closed with reason `pass`; its notes record `verdict: pass` and pin deploy commit `25148bc121317fb357d84f43fbd53eabdca64f6e`. |
+| 2 | Acceptance criteria met | **PASS** | The reviewed diff adds `doltIdentityHomeDir`, places Dolt/Git identity files outside every `t.TempDir` tree, redirects `configureTestDoltIdentityEnv` to it, and widens the leak guard to `cityPath`, `feRepoDir`, and the identity home. The regression test fails on RED commit `296cc5920` and passes on the reviewed commit. `GC_FAST_UNIT=0 go test ./cmd/gc/ -run '^TestBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore$' -count=3` passed all 3 repetitions. `gofmt -l` returned no files. The reviewer also verified the remaining shared-helper call sites and `go vet ./...`. |
+| 3 | Tests pass | **PASS** | Required target `make test-cmd-gc-process-parallel` was run in detached worktrees at merge-base `4a636f6ad88002556c6c0891b7b9e07f9502c81c` and reviewed commit `25148bc121317fb357d84f43fbd53eabdca64f6e`. Both sides produced **4 PASS jobs, 3 FAIL jobs, 0 SKIP jobs** and the identical failing set: `TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork`, `TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork`, and `TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession`. Shards 4-6 and `productmetrics-testhook` passed on both sides. The pre-push `make test-fast-parallel` run likewise produced **9 PASS jobs, 1 FAIL job, 0 SKIP jobs**; its sole failure, `TestCustomTypesCheck_TableDrift`, was reproduced at both the merge-base and reviewed SHA with the identical missing-`tst` error. These failures are the known ambient-HOME Dolt leak (`ga-zxpfic`): real `bd` is redirected to fleet server `127.0.0.1:3308`, where temporary databases are absent. Both differentials therefore show **0 change-introduced regressions**; the environment fix is tracked by `ga-8pkpor`. The shard wrappers do not emit exact per-test PASS/SKIP counts for red shards, so no unsupported aggregate is claimed. Process-suite logs: `/var/tmp/gc-local-tests.h62qwY` (merge-base) and `/var/tmp/gc-local-tests.lCATVj` (reviewed); pre-push log: `/var/tmp/gc-local-tests.ZRvOxj`; focused doctor logs: `/var/tmp/gc-ga-pfdabs-diff.e7RVAA/{base,reviewed}.doctor.log`. |
+| 4 | No high-severity review findings open | **PASS** | Review notes record no style, security, or specification findings and no unresolved HIGH findings. |
+| 5 | Final branch is clean | **PASS** | The isolated gate worktree was clean at gate commit parent `25148bc121317fb357d84f43fbd53eabdca64f6e` before this checklist was amended; the checklist is the only gate-commit delta. |
+| 6 | Branch diverges cleanly from main | **PASS** | After fetching `origin/main`, `git merge-tree --write-tree origin/main 25148bc121317fb357d84f43fbd53eabdca64f6e` exited 0 and produced tree `96f5fcbae551d89a868720d2f18e93de9ef47078`; no self-rebase was required. |
+| 7 | Single feature theme | **PASS** | The two-commit change touches only `cmd/gc/testenv_test.go` and `cmd/gc/cmd_bd_test.go`, both within the Dolt-backed `cmd/gc` test-environment cleanup theme. |
+
+## Gate decision
+
+The reviewed change introduces no process-suite regression relative to its
+merge-base, satisfies its focused RED/GREEN acceptance evidence, and remains
+conflict-free with current `origin/main`. It is eligible for an isolated deploy
+branch and pull request.


### PR DESCRIPTION
## What this changes

Process-backed `cmd/gc` tests now allocate the temporary HOME used for Dolt and Git identity outside the city or repository `t.TempDir` tree. Cleanup guards watch both locations, so delayed helper-process or Dolt file activity cannot leave the test tree non-empty and turn an otherwise successful test into an `ENOTEMPTY` cleanup failure.

This is test-harness-only behavior. Production runtime behavior, configuration, APIs, and persistent data formats are unchanged.

## Review notes

- Check the lifetime and cleanup ordering across `doltIdentityHomeDir`, `configureTestDoltIdentityEnv`, and `requireNoLeakedDoltAfterForPaths`.
- The identity HOME is created with `os.MkdirTemp`, uses restrictive default permissions, and is registered for cleanup independently of the test city tree.
- There are no migration or rollout steps.

## Test plan

- [x] Verify the regression test fails with identity HOME under `t.TempDir` and passes with the out-of-tree HOME.
- [x] Run `GC_FAST_UNIT=0 go test ./cmd/gc/ -run '^TestBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore$' -count=3`.
- [x] Run the full `cmd/gc` process suite and compare environmental failures with the merge base; confirm zero new regressions.
- [x] Release gate: [`release-gates/ga-pfdabs-dolt-identity-tempdir-cleanup-gate.md`](release-gates/ga-pfdabs-dolt-identity-tempdir-cleanup-gate.md)