### PR TITLE
test(build-desired-state): pin always-mode custom-scale-check guard (#4749 mpr fix-plan)

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -7487,6 +7487,49 @@ func TestBuildDesiredState_OnDemandNamedSession_ColdCustomScaleCheckWakesOnRoute
 	}
 }
 
+func TestBuildDesiredState_AlwaysNamedSession_ColdCustomScaleCheckDoesNotAddPoolDemand(t *testing.T) {
+	// Pins the namedSessionMode != "always" guard added in PR #4749: an
+	// always-mode named session with a custom scale_check must not receive
+	// the cold-wake probe that on-demand named sessions get. None of the
+	// existing "always" tests reach this guard because none of them
+	// configure a custom scale_check.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title: "queued dog job",
+		Metadata: map[string]string{
+			"gc.routed_to": "dog",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 0",
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "always",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if dsResult.ScaleCheckCounts["dog"] != 0 {
+		t.Fatalf("ScaleCheckCounts[dog] = %d, want 0 (always-mode guard should suppress the cold-wake probe)", dsResult.ScaleCheckCounts["dog"])
+	}
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" && tp.ConfiguredNamedIdentity == "" {
+			t.Fatalf("cold-wake probe materialized an unconfigured dog-N phantom beside the always-on named session: %+v", tp)
+		}
+	}
+}
+
 func TestBuildDesiredState_OnDemandNamedSession_NoExplicitScaleCheckUsesWorkQuery(t *testing.T) {
 	// work_query is session-local introspection in Phase 1 and must not drive
 	// controller-side named materialization.


### PR DESCRIPTION
## Summary
- Adds `TestBuildDesiredState_AlwaysNamedSession_ColdCustomScaleCheckDoesNotAddPoolDemand`, pinning the `namedSessionMode != "always"` guard that PR #4749 added.
- Test-only, per the mpr fix-plan for #4749 (`fix-plan.md`, run `20260728T083029Z`): "No production-code change. Leave `cmd/gc/build_desired_state.go` exactly as submitted." The production code on `main` is exactly what the mpr ensemble (qwen + claude opus-5 + codex) already reviewed and accepted — nothing is broken, the regression test pinning the guard was just missing.
- Closes ga-qfwldm.

## Test plan
- [x] `go test ./cmd/gc/ -run 'TestBuildDesiredState_OnDemandNamedSession|TestBuildDesiredState_AlwaysNamedSession' -count=1` — PASS (21 tests)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l cmd/gc/build_desired_state_test.go` clean
- [x] Mutation check (required by fix-plan): temporarily removed the `if namedSessionMode != "always"` guard around the `defaultScaleTargets` append — confirmed the new test fails (`ScaleCheckCounts[dog] = 1, want 0`) — then restored verbatim (`git diff` on the production file shows zero delta).
- [x] `make test-fast-parallel` — all fast jobs passed