### PR TITLE
docs(engdocs): record the beads issue-lifecycle handoff and next-session prompt

### DIFF
--- a/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
+++ b/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
@@ -8,12 +8,14 @@ Pick up the beads issue-lifecycle follow-up queue. Read the handoff first, in fu
 
     /data/projects/gascity/engdocs/contributors/beads-issue-lifecycle-handoff.md
 
-Short version: six PRs have merged upstream — `b92442d1a` #5191 (the `issueops.Lifecycle` facade reached
+Short version: eight PRs have merged upstream — `b92442d1a` #5191 (the `issueops.Lifecycle` facade reached
 via `store.IssueLifecycle()`, three backends, conformance suite, CLI adoption), `ff6eeedbf` #5206 (a
 generic done-crossing status update now enforces close policy, with `bd update --force` overriding it),
 the two Wave 1 P1s (`532dadf98` #5211, `29af03b8c` #5212), and two of Wave 2 (`252e42c70` #5217 —
 the uow assignee fence plus the conformance case the contract never had; `ed8526721` #5218 — the
-`BEADS_DIR` config leak). A queue of follow-up beads remains. Your job is to work that queue.
+`BEADS_DIR` config leak), plus `8f421b64f` #5236 (`ga-ktn9pe.4.8` — idempotent re-close by ordering, not
+by clearing the pin) and `dd3ad8f98` #5255 (`ga-kjkv1` — a done-crossing generic update now closes like
+`bd close`). A queue of follow-up beads remains. Your job is to work that queue.
 
 Work in `/data/projects/beads-public-issueops-simple`, branching fresh off `origin/main` for each item.
 
@@ -35,14 +37,18 @@ the test fails, restore it verbatim, confirm `git diff` is empty. Copy the file 
 
 **Wave 1 (P1) is done** — #5211 and #5212 are merged. Do not re-open them.
 
-**Wave 2 remaining:** `ga-dpfii` and `ga-tsjxb` — details in the handoff. `ga-z0qmv` and `ga-e6h6i`
-have shipped. `ga-kjkv1` is investigated but **blocked on an owner ruling**, and its premise turned out
-to be wrong: it is an integrity violation against `types.Validate`, not a close-policy bypass. Read the
-bead's notes before touching it; do not re-derive.
+**Wave 2 remaining:** `ga-dpfii` and `ga-tsjxb` — details in the handoff. `ga-z0qmv`, `ga-e6h6i` and
+`ga-kjkv1` have shipped.
 
-**Also queued, from the Wave 1 review council:** `ga-ktn9pe.4.8`, `.9`, `.10`, `.11`, `.12`. The first
-three need an owner ruling before you implement — bring the options, do not pick. `.11` and `.12` are
-straightforward and can go whenever.
+**Check the premise before you start.** Two Wave 2 beads in a row described their own defect wrongly:
+`ga-e6h6i` blamed a cache when the value was re-read from disk every `Initialize`, and `ga-kjkv1` was
+filed as a close-policy bypass when it was an integrity defect. Both fixes only worked because someone
+re-derived the mechanism instead of trusting the bead text.
+
+**Also queued, from the review councils:** `.9`, `.10`, `.11`, `.12`, `.13`, `.14`, `.15`. `.8` has
+shipped. `.9`, `.10` and `.14` need an owner ruling before you implement — bring the options, do not
+pick. `.14` is the one to raise first: it is the pin-vs-deletion-protection question, and `issue.Pinned`
+gates six destructive call sites, so getting it wrong deletes beads.
 
 **Wave 3:** `ga-c69el` plus two items that still need beads (unify partial-failure exit codes; unify the
 `--json` contract) and four review findings owed beads. **Both unification items are breaking wire changes —
@@ -94,13 +100,13 @@ Commit trailers, exactly, after one blank line:
 Count with `grep -cE '^[[:space:]]*--- PASS'`; `domain/db` nests four levels and a shallower pattern
 undercounts badly.
 
-    cmd/bd -run TestParity                                     40
+    cmd/bd -run TestParity                                     43
     internal/storage/domain/db -run TestDomainDB               800
-    internal/storage/dolt -run TestIssueOperations             74
+    internal/storage/dolt -run TestIssueOperations             75
     internal/storage/embeddeddolt -run TestEmbeddedIssueOperations  56   (needs BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1)
-    internal/storage/uow                                       136
-    internal/storage/issueops                                  350
-    internal/validation                                        218
+    internal/storage/uow                                       145
+    internal/storage/issueops                                  372
+    internal/validation                                        220
     internal/config                                            297
 
 `go test ./cmd/bd/` has ~25 pre-existing top-level failures (init/config/doctor/completion) identical on

--- a/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
+++ b/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
@@ -1,0 +1,114 @@
+# Next-session prompt
+
+Paste everything below the line into a fresh session. It is self-contained.
+
+---
+
+Pick up the beads issue-lifecycle follow-up queue. Read the handoff first, in full, before touching anything:
+
+    /data/projects/gascity/engdocs/contributors/beads-issue-lifecycle-handoff.md
+
+Short version: two PRs have merged upstream (`b92442d1a` #5191 — the `issueops.Lifecycle` facade reached via
+`store.IssueLifecycle()`, three backends, conformance suite, CLI adoption; `ff6eeedbf` #5206 — a generic
+done-crossing status update now enforces close policy, with `bd update --force` overriding it). A queue of
+follow-up beads remains. Your job is to work that queue.
+
+Work in `/data/projects/beads-public-issueops-simple`, branching fresh off `origin/main` for each item.
+
+## Process, per item — this is the owner's instruction, follow it
+
+Fable for design/architecture → Opus for implementation → a **fable review council before commit** → open a
+PR following `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` → wait for green CI → merge.
+
+One PR per bead. Never Sonnet; prefer fable for councils, fall back to Opus on 429. If a council returns an
+empty findings array, check `agents_error` before believing it — an all-429 run is indistinguishable from a
+clean pass.
+
+## Order
+
+**Wave 1 (P1), start here:**
+- `ga-2kkue` — `bd create -t <infra-type>` lands in `issues` on the proxied path.
+  `cmd/bd/create_proxied_server.go:142` routes on `Ephemeral || NoHistory` and never consults infra types;
+  `domain.CreateContext` already carries an `InfraTypes` field, so this is ~2 lines plus tests.
+- `ga-z3vht` — `bd close` ignores `issue.Pinned`. `internal/validation/issue.go:53-63` checks
+  `Status == StatusPinned` instead of the boolean. **The owner has ruled: refuse if the boolean is set OR
+  the status is `pinned`** — strictly additive. That ruling came from an audit showing Gas Town pins by
+  *status* at 21 sites, so a boolean-only check would strip its protection.
+
+**Wave 2 (P2):** `ga-z0qmv`, `ga-kjkv1`, `ga-dpfii`, `ga-tsjxb`, `ga-e6h6i` — details in the handoff.
+
+**Wave 3:** `ga-c69el` plus two items that still need beads (unify partial-failure exit codes; unify the
+`--json` contract) and four review findings owed beads. **Both unification items are breaking wire changes —
+bring the owner exact before/after shapes and let them choose. Do not pick a direction yourself.**
+
+## Read the handoff's "Failure patterns" section before writing code
+
+Condensed, because each of these cost a revert or a red CI run:
+
+1. **A policy check added at a shared layer reaches callers that cannot satisfy it.** This happened twice in
+   this campaign, both times riding into a commit whose subject said "validate…". Before adding any check to
+   a shared helper, write the caller table: every caller, does it enforce, can it override. Make the
+   transport fail loudly when a caller forgets to plumb the override.
+2. **Establish baselines from `origin/main`, never from inside your branch.** A test was labelled
+   "pre-existing" and that label propagated through four agents before someone diffed against a real
+   `origin/main` worktree and found the branch had broken it.
+3. **This repo prints `ok` while running zero tests in several ways.** `-run TestSuite` matches nothing in
+   `domain/db` (it is `TestDomainDB`); embedded tests SKIP silently without `BEADS_TEST_EMBEDDED_DOLT=1`.
+   Always `-v`, always count `RUN/PASS/SKIP/FAIL`.
+4. **Ambient environment leaks into verdicts.** `getOwner()` reads `GIT_AUTHOR_EMAIL`, which changes
+   `bd create --json` output. Pin ambient inputs in test harnesses.
+5. **After a squash-merge every SHA from the merged branch is dangling upstream.** Never cite branch-local
+   hashes in shipped source or docs.
+
+## Environment — non-obvious and load-bearing
+
+```bash
+export GOTOOLCHAIN=go1.26.5
+export GOPROXY="file://$(go env GOMODCACHE)/cache/download"
+export GOSUMDB=off
+export GOFLAGS=-mod=readonly
+export GIT_AUTHOR_NAME="Julian Knutsen" GIT_AUTHOR_EMAIL="julianknutsen@users.noreply.github.com"
+export GIT_COMMITTER_NAME="Julian Knutsen" GIT_COMMITTER_EMAIL="julianknutsen@users.noreply.github.com"
+```
+
+`GOTOOLCHAIN` must be exported in the committing shell or the pre-commit hook's golangci-lint dies.
+`GOPROXY` must be the file:// cache — the hook does a network lookup every run and `GOPROXY=off` fails it.
+Never `git stash` (shared stack across worktrees). Do not change `core.hooksPath` (shared config); run the
+gate by hand instead. `gh pr edit` is broken — use `gh api ... -X PATCH --input -`. Never `go clean -cache`.
+Never run `./internal/storage/dolt` or `./internal/storage/embeddeddolt` unfiltered.
+
+Commit trailers, exactly, after one blank line:
+
+    Agent-Signature: claude-opus-5
+    Co-authored-by: CI Bot <ci@beads.test>
+
+## Baselines that must not regress
+
+Count with `grep -cE '^[[:space:]]*--- PASS'`; `domain/db` nests four levels and a shallower pattern
+undercounts badly.
+
+    cmd/bd -run TestParity                                     40
+    internal/storage/domain/db -run TestDomainDB               800
+    internal/storage/dolt -run TestIssueOperations             73
+    internal/storage/embeddeddolt -run TestEmbeddedIssueOperations  56   (needs BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1)
+    internal/storage/uow                                       135
+    internal/storage/issueops                                  338
+
+`go test ./cmd/bd/` has ~25 pre-existing top-level failures (init/config/doctor/completion) identical on
+`origin/main` — compare the failing set **by name**, not by count. `make ci-pr-lint` fails on `origin/main`
+itself (two gosec findings in a file none of this touches).
+
+`cmd/bd/write_verbs_parity_test.go` is the CLI-equivalence evidence. **Do not edit its assertions** except
+for an owner-approved behavior change, in the commit that causes it, with a comment naming the ruling.
+
+## Owner rulings already made
+
+Listed in the handoff. Do not relitigate them — most cost several rounds to settle. The one most likely to
+tempt you: `issueops` exports **no constructor**; the accessor `store.IssueLifecycle()` *is* the API, and a
+new capability gets a new role and a new accessor rather than a method on `Lifecycle`.
+
+## Also open
+
+`gastownhall/gascity#4885` is a **deliberate draft** — it routes Gas City's `NativeDoltStore` onto the
+facade and cannot compile until beads publishes a release containing the accessor. Do not add a `replace`
+directive to make it green. It unblocks when a release ships.

--- a/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
+++ b/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
@@ -8,10 +8,11 @@ Pick up the beads issue-lifecycle follow-up queue. Read the handoff first, in fu
 
     /data/projects/gascity/engdocs/contributors/beads-issue-lifecycle-handoff.md
 
-Short version: two PRs have merged upstream (`b92442d1a` #5191 — the `issueops.Lifecycle` facade reached via
-`store.IssueLifecycle()`, three backends, conformance suite, CLI adoption; `ff6eeedbf` #5206 — a generic
-done-crossing status update now enforces close policy, with `bd update --force` overriding it). A queue of
-follow-up beads remains. Your job is to work that queue.
+Short version: four PRs have merged upstream — `b92442d1a` #5191 (the `issueops.Lifecycle` facade reached
+via `store.IssueLifecycle()`, three backends, conformance suite, CLI adoption), `ff6eeedbf` #5206 (a
+generic done-crossing status update now enforces close policy, with `bd update --force` overriding it),
+and the two Wave 1 P1s, `532dadf98` #5211 and `29af03b8c` #5212. A queue of follow-up beads remains. Your
+job is to work that queue.
 
 Work in `/data/projects/beads-public-issueops-simple`, branching fresh off `origin/main` for each item.
 
@@ -24,18 +25,23 @@ One PR per bead. Never Sonnet; prefer fable for councils, fall back to Opus on 4
 empty findings array, check `agents_error` before believing it — an all-429 run is indistinguishable from a
 clean pass.
 
+Give the council three *distinct* lenses — blast-radius, test-adequacy, correctness — not three identical
+reviewers. And mutation-check every new test before you open the PR: revert the production hunk, confirm
+the test fails, restore it verbatim, confirm `git diff` is empty. Copy the file aside and back; never
+`git stash`.
+
 ## Order
 
-**Wave 1 (P1), start here:**
-- `ga-2kkue` — `bd create -t <infra-type>` lands in `issues` on the proxied path.
-  `cmd/bd/create_proxied_server.go:142` routes on `Ephemeral || NoHistory` and never consults infra types;
-  `domain.CreateContext` already carries an `InfraTypes` field, so this is ~2 lines plus tests.
-- `ga-z3vht` — `bd close` ignores `issue.Pinned`. `internal/validation/issue.go:53-63` checks
-  `Status == StatusPinned` instead of the boolean. **The owner has ruled: refuse if the boolean is set OR
-  the status is `pinned`** — strictly additive. That ruling came from an audit showing Gas Town pins by
-  *status* at 21 sites, so a boolean-only check would strip its protection.
+**Wave 1 (P1) is done** — #5211 and #5212 are merged. Do not re-open them.
 
-**Wave 2 (P2):** `ga-z0qmv`, `ga-kjkv1`, `ga-dpfii`, `ga-tsjxb`, `ga-e6h6i` — details in the handoff.
+**Start with Wave 2 (P2):** `ga-z0qmv`, `ga-kjkv1`, `ga-dpfii`, `ga-tsjxb`, `ga-e6h6i` — details in the
+handoff. `ga-z0qmv` is the one to take first: the uow `Lifecycle` backend silently lost the
+foreign-assignee transfer fence, and the conformance suite has no assignee-transfer case, which is
+exactly why nothing caught it. Fix it *with* a cross-backend conformance case.
+
+**Also queued, from the Wave 1 review council:** `ga-ktn9pe.4.8`, `.9`, `.10`, `.11`, `.12`. The first
+three need an owner ruling before you implement — bring the options, do not pick. `.11` and `.12` are
+straightforward and can go whenever.
 
 **Wave 3:** `ga-c69el` plus two items that still need beads (unify partial-failure exit codes; unify the
 `--json` contract) and four review findings owed beads. **Both unification items are breaking wire changes —
@@ -93,6 +99,7 @@ undercounts badly.
     internal/storage/embeddeddolt -run TestEmbeddedIssueOperations  56   (needs BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1)
     internal/storage/uow                                       135
     internal/storage/issueops                                  338
+    internal/validation                                        218
 
 `go test ./cmd/bd/` has ~25 pre-existing top-level failures (init/config/doctor/completion) identical on
 `origin/main` — compare the failing set **by name**, not by count. `make ci-pr-lint` fails on `origin/main`

--- a/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
+++ b/engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md
@@ -8,11 +8,12 @@ Pick up the beads issue-lifecycle follow-up queue. Read the handoff first, in fu
 
     /data/projects/gascity/engdocs/contributors/beads-issue-lifecycle-handoff.md
 
-Short version: four PRs have merged upstream — `b92442d1a` #5191 (the `issueops.Lifecycle` facade reached
+Short version: six PRs have merged upstream — `b92442d1a` #5191 (the `issueops.Lifecycle` facade reached
 via `store.IssueLifecycle()`, three backends, conformance suite, CLI adoption), `ff6eeedbf` #5206 (a
 generic done-crossing status update now enforces close policy, with `bd update --force` overriding it),
-and the two Wave 1 P1s, `532dadf98` #5211 and `29af03b8c` #5212. A queue of follow-up beads remains. Your
-job is to work that queue.
+the two Wave 1 P1s (`532dadf98` #5211, `29af03b8c` #5212), and two of Wave 2 (`252e42c70` #5217 —
+the uow assignee fence plus the conformance case the contract never had; `ed8526721` #5218 — the
+`BEADS_DIR` config leak). A queue of follow-up beads remains. Your job is to work that queue.
 
 Work in `/data/projects/beads-public-issueops-simple`, branching fresh off `origin/main` for each item.
 
@@ -34,10 +35,10 @@ the test fails, restore it verbatim, confirm `git diff` is empty. Copy the file 
 
 **Wave 1 (P1) is done** — #5211 and #5212 are merged. Do not re-open them.
 
-**Start with Wave 2 (P2):** `ga-z0qmv`, `ga-kjkv1`, `ga-dpfii`, `ga-tsjxb`, `ga-e6h6i` — details in the
-handoff. `ga-z0qmv` is the one to take first: the uow `Lifecycle` backend silently lost the
-foreign-assignee transfer fence, and the conformance suite has no assignee-transfer case, which is
-exactly why nothing caught it. Fix it *with* a cross-backend conformance case.
+**Wave 2 remaining:** `ga-dpfii` and `ga-tsjxb` — details in the handoff. `ga-z0qmv` and `ga-e6h6i`
+have shipped. `ga-kjkv1` is investigated but **blocked on an owner ruling**, and its premise turned out
+to be wrong: it is an integrity violation against `types.Validate`, not a close-policy bypass. Read the
+bead's notes before touching it; do not re-derive.
 
 **Also queued, from the Wave 1 review council:** `ga-ktn9pe.4.8`, `.9`, `.10`, `.11`, `.12`. The first
 three need an owner ruling before you implement — bring the options, do not pick. `.11` and `.12` are
@@ -95,11 +96,12 @@ undercounts badly.
 
     cmd/bd -run TestParity                                     40
     internal/storage/domain/db -run TestDomainDB               800
-    internal/storage/dolt -run TestIssueOperations             73
+    internal/storage/dolt -run TestIssueOperations             74
     internal/storage/embeddeddolt -run TestEmbeddedIssueOperations  56   (needs BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1)
-    internal/storage/uow                                       135
-    internal/storage/issueops                                  338
+    internal/storage/uow                                       136
+    internal/storage/issueops                                  350
     internal/validation                                        218
+    internal/config                                            297
 
 `go test ./cmd/bd/` has ~25 pre-existing top-level failures (init/config/doctor/completion) identical on
 `origin/main` — compare the failing set **by name**, not by count. `make ci-pr-lint` fails on `origin/main`

--- a/engdocs/contributors/beads-issue-lifecycle-handoff.md
+++ b/engdocs/contributors/beads-issue-lifecycle-handoff.md
@@ -68,10 +68,18 @@ the whole discipline. `storage.Storage` reached 71 methods because it lacked thi
 9. **A generic done-crossing update enforces close policy**, and **`bd update --force` overrides both**
    the assignee fence and close policy. Shipped in #5206.
 10. **`bd close` pinned check**: refuse if `issue.Pinned` **OR** `status == pinned`. Strictly additive.
-    This was decided by audit: Gas Town pins by *status* at 21 sites (`b.List(ListOptions{Status:
-    StatusPinned})` in `hook_check.go`, `prime_output.go`, `molecule_step.go`, `up.go`), so a
-    boolean-only check would strip its protection. Gas City reads the boolean
-    (`compute_awake_set.go:443,467`).
+    Decided by audit: Gas Town pins by *status* — an independent 2026-08-02 recount found ~22
+    functional non-test sites (`b.List(ListOptions{Status: StatusPinned})` in `hook_check.go`,
+    `prime_output.go`, `molecule_step.go`, `up.go` and others), so a boolean-only check would strip
+    its protection. That leg is verified and the ruling stands on it.
+    **Correction:** the other stated premise — "Gas City reads the boolean
+    (`compute_awake_set.go:443,467`)" — is **false**, and it appears in #5212's commit message and PR
+    body as well as here. That field is declared `Pinned bool // pin_awake durable wake reason`
+    (`cmd/gc/compute_awake_set.go:69`) and populated from `session.WakeCausePinned`
+    (`compute_awake_bridge.go:130`). Gas City has **zero** consumers of the beads boolean; its beads
+    client has no `Pinned` field and `git log --all -S 'issue.Pinned' -- cmd/gc/` is empty. The
+    boolean half of the check is harmless and strictly additive, but do not reason further from the
+    Gas City claim.
 11. **Commit identity**: author `Julian Knutsen <julianknutsen@users.noreply.github.com>`; trailers
     `Agent-Signature: <model>` and `Co-authored-by: CI Bot <ci@beads.test>`. A council suggested the repo's
     `<agent> on behalf of <human>` form instead — the owner's choice stands.

--- a/engdocs/contributors/beads-issue-lifecycle-handoff.md
+++ b/engdocs/contributors/beads-issue-lifecycle-handoff.md
@@ -16,6 +16,8 @@ policy is implemented once instead of three times. Two PRs have merged; a queue 
 | --- | --- | --- |
 | `b92442d1a` | #5191 | The facade: `issueops.Lifecycle` (Create/Update/Close/Reopen), reached via `store.IssueLifecycle()`. Three backends, a cross-backend conformance suite, CLI adoption, and ~10 bug fixes. |
 | `ff6eeedbf` | #5206 | A generic status update crossing into a done category now enforces close policy; `bd update --force` gains a dual meaning. |
+| `532dadf98` | #5211 | `ga-2kkue`: the proxied single-create path consults `cctx.InfraTypes`, so `bd create -t <infra-type>` lands in `wisps` like every other create surface. |
+| `29af03b8c` | #5212 | `ga-z3vht`: `NotPinned` refuses on `issue.Pinned` **or** `status == pinned` (ruling 10). Strictly additive. |
 
 ### Open
 
@@ -80,16 +82,28 @@ Never Sonnet. Prefer fable for red-teams/councils; fall back to Opus on 429, nev
 `agents_error` / `<failures>` before trusting an empty findings array** — an all-429 council returns
 `{"findings":[]}` which is indistinguishable from a clean pass.
 
+Give the council **three distinct lenses** rather than three identical reviewers: blast-radius (build the
+caller table yourself, do not trust the author's), test-adequacy (assume the tests are lying), and
+correctness (produce a concrete wrong outcome or downgrade the severity). On Wave 1 those three found
+overlapping-but-different things; redundant reviewers would have found one of them.
+
+**Mutation-check every new test before opening the PR.** Revert the production hunk, confirm the new test
+fails, restore it verbatim, and confirm `git diff` is empty. A test that passes both ways is worse than no
+test, because it reads as coverage. Never do this with `git stash` — the stack is shared across worktrees;
+copy the file aside and copy it back.
+
 ## Remaining work
 
-### Wave 1 (P1)
+### Wave 1 (P1) — done
 
-- **`ga-2kkue`** — `bd create -t <infra-type>` lands in `issues` on the proxied path.
-  `cmd/bd/create_proxied_server.go:142` routes on `Ephemeral || NoHistory` and never consults infra types,
-  while the embedded path (`create_atomic.go:44`) checks `IsInfraTypeCtx`. `domain.CreateContext` now
-  carries an `InfraTypes` field, making this ~2 lines.
-- **`ga-z3vht`** — `bd close` ignores `issue.Pinned`. `internal/validation/issue.go:53-63` checks
-  `Status == StatusPinned` rather than the boolean. Implement ruling 10 (boolean OR status).
+Both shipped; see the merged table above. Two scoping lessons worth carrying forward:
+
+- `ga-2kkue` was filed as "~2 lines" and the production change really was three, but only after
+  establishing that the markdown-batch and graph-plan proxied paths are *also* infra-type-blind. Those
+  were left alone deliberately: their embedded counterparts route on flags too, so the two sides are at
+  parity with each other, and a mixed-type batch cannot be expressed by one boolean at all.
+- `ga-z3vht` stayed at the validation layer on purpose. `bd batch` close bypasses all close validation
+  and has no force lever, so a shared-layer guard would have reproduced failure pattern 1 below.
 
 ### Wave 2 (P2)
 
@@ -110,6 +124,34 @@ Never Sonnet. Prefer fable for red-teams/councils; fall back to Opus on 429, nev
   `string`). `TestIssueUpdateAcceptsLegacyIssueTypeRepresentations` pins that typed values round-trip, so
   widening changes accept/reject behavior and needs cross-backend verification.
 - **`ga-e6h6i`** — `cmd/bd` leaks `issue-prefix` into viper across tests, surviving `initConfigForTest`.
+
+### Filed by the Wave 1 fable review council
+
+All five came out of reviewing #5211/#5212 and were filed rather than folded in. **The first three need
+an owner ruling before anyone implements them.**
+
+- **`ga-ktn9pe.4.8`** (P2, owner ruling) — `bd close --force` leaves `pinned=true` residue, so the new
+  boolean trigger now refuses the *idempotent re-close* that used to exit 0. `closeIssueInTx` sets only
+  status/closed_at/updated_at/close_reason/closed_by_session/row_lock; there is no pinned-clear anywhere
+  in the dolt close lane, and `bd batch` produces the same residue. This matters beyond tidiness: per
+  `close.go:189-200` the idempotent re-close is the *only* mechanism that re-drives a stranded molecule
+  auto-close. Fix is either clearing pinned on close (mirroring `update.go:329-343`) or exempting
+  `status == closed` from the boolean trigger — the latter narrows ruling 10, so it is not an
+  implementer's call.
+- **`ga-ktn9pe.4.9`** (P2, owner ruling) — `issueops/close.go` has **no pinned check of either kind**, so
+  linked-library consumers reaching `store.IssueLifecycle().Close()` are unprotected, and `bd batch`
+  bypasses all close validation with no force lever. Needs a ruling on whether `CloseRequest.Force` grows
+  yet another meaning (it already gained a dual one in #5206) and whether batch gets a force lever.
+- **`ga-ktn9pe.4.10`** (P3, owner ruling) — `bd update --status closed` bypasses the pinned refusal
+  entirely and then auto-clears the pin at `update.go:338`. Possibly sanctioned, since update *is* the
+  pin/unpin verb. #5206 added blocker/open-children policy to that path but omitted pinned.
+- **`ga-ktn9pe.4.11`** (P3) — `bd create --dry-run` previews `ephemeral:false` for an infra type on
+  *both* the proxied and embedded paths, because both build the preview from flags alone. Before #5211
+  the proxied preview and proxied behavior agreed by both being wrong. Fix both paths together.
+- **`ga-ktn9pe.4.12`** (P3) — `forClose`/`forUpdate`/`forDelete`/`forReopen`
+  (`internal/validation/issue.go:204-240`) are production-dead; `validateIssueClosable` hand-rolls the
+  same chains. #5212 had to update `forClose`'s test purely to keep dead code consistent. Wire it or
+  delete it.
 
 ### Wave 3 — CLI consistency (all four approved by the owner)
 
@@ -207,7 +249,7 @@ export GOFLAGS=-mod=readonly
 
 ## Verification baselines
 
-As of `ff6eeedbf`. Count with `grep -cE '^[[:space:]]*--- PASS'` — `domain/db` nests four levels deep and a
+As of `29af03b8c`. Count with `grep -cE '^[[:space:]]*--- PASS'` — `domain/db` nests four levels deep and a
 shallower pattern undercounts by an order of magnitude.
 
 ```bash
@@ -218,6 +260,7 @@ BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 \
   go test -v -count=1 -run TestEmbeddedIssueOperations ./internal/storage/embeddeddolt/   # 56
 go test -v -count=1 ./internal/storage/uow/                                      # 135
 go test -v -count=1 ./internal/storage/issueops/                                 # 338
+go test -v -count=1 ./internal/validation/                                       # 218
 BASE_SHA=origin/main bash scripts/check-migration-hygiene.sh                     # clean
 ```
 

--- a/engdocs/contributors/beads-issue-lifecycle-handoff.md
+++ b/engdocs/contributors/beads-issue-lifecycle-handoff.md
@@ -6,7 +6,7 @@ Last updated 2026-08-01. Supersedes `beads-guarded-ops-handoff.md` for everythin
 
 A campaign to give beads one guarded issue-lifecycle surface, used by the `bd` CLI, linked-library
 consumers (Gas City's `NativeDoltStore`), and eventually the HTTP/proxied path — so that close/reopen/update
-policy is implemented once instead of three times. Six PRs have merged; a queue of follow-ups remains.
+policy is implemented once instead of three times. Eight PRs have merged; a queue of follow-ups remains.
 
 ## Where it stands
 
@@ -20,6 +20,8 @@ policy is implemented once instead of three times. Six PRs have merged; a queue 
 | `29af03b8c` | #5212 | `ga-z3vht`: `NotPinned` refuses on `issue.Pinned` **or** `status == pinned` (ruling 10). Strictly additive. |
 | `252e42c70` | #5217 | `ga-z0qmv`: the assignee-transfer fence enforced in `uow.issueOperations.Update`, predicate shared via `AuthorizeAssigneeTransferWithPools`, plus the cross-backend conformance case the contract never had. |
 | `ed8526721` | #5218 | `ga-e6h6i`: `BEADS_DIR` honors `BEADS_TEST_IGNORE_REPO_CONFIG`, closing the config leak that let a dispatched command re-import the repo's `issue-prefix`. |
+| `8f421b64f` | #5236 | `ga-ktn9pe.4.8`: idempotent re-close restored by ordering the already-closed no-op ahead of validation — **not** by clearing the pin. |
+| `dd3ad8f98` | #5255 | `ga-kjkv1`: a done-crossing generic update applies close's field effects in both funnels; an explicit `closed_at` is judged against the row's status. |
 
 ### Open
 
@@ -109,19 +111,6 @@ Both shipped; see the merged table above. Two scoping lessons worth carrying for
 
 ### Wave 2 (P2)
 
-- **`ga-kjkv1`** — **blocked on an owner ruling**, and the bead's framing turned out to be wrong.
-  Investigated but deliberately not implemented. A metadata-only write moves no status, so the row never
-  crosses into done and #5206's gate has nothing to catch — the issue stays open. This is not a policy
-  bypass; it is an **integrity** violation. `types.Validate` (`internal/types/types.go:345-351`) declares
-  "`closed_at` set iff `status == closed`" a hard invariant and enforces it on create and import, but the
-  update funnels do not — `ValidateScalarUpdates` checks only `issue_type`/`assignee`/`owner`. So a generic
-  update can mint rows the type's own validator calls invalid. Pre-existing is *confirmed*, not assumed:
-  both allowlists (`issueops/update.go:23` and `domain/db/issue.go:43`) have carried the three keys since
-  `46be5594d` (#3665), long before `ff6eeedbf`. The only in-repo map builder that sets `closed_at` is
-  `internal/linear/mapping.go:860`, which is dead code with test-only callers. Options and per-option
-  broken-caller tables are recorded on the bead; the advisory lean is to drop `closed_at` and
-  `close_reason` from **both** funnels while keeping `closed_by_session`. **Whichever option is chosen,
-  both funnels must change in the same commit or they drift.**
 - **`ga-dpfii`** — federated cross-prefix dependency targets classify differently across write plumbings.
   `ExecuteCreate` treats cross-prefix as external and skips the existence check; the uow path only treats a
   literal `external:` prefix as external. Share one classifier, mirroring how `ClassifyPublicCreateError`
@@ -130,7 +119,7 @@ Both shipped; see the merged table above. Two scoping lessons worth carrying for
   `string`). `TestIssueUpdateAcceptsLegacyIssueTypeRepresentations` pins that typed values round-trip, so
   widening changes accept/reject behavior and needs cross-backend verification.
 
-`ga-z0qmv` and `ga-e6h6i` shipped — see the merged table. Two things they taught:
+`ga-z0qmv`, `ga-e6h6i` and `ga-kjkv1` shipped — see the merged table. Three things they taught:
 
 - The `ga-z0qmv` fence was **not** put back where it was removed from. It went into
   `uow.issueOperations.Update` at the facade layer, and the predicate was extracted into
@@ -142,6 +131,10 @@ Both shipped; see the merged table above. Two scoping lessons worth carrying for
   `Initialize` builds a fresh one. The repo config was **re-read from disk on every `Initialize`** because
   in-process dispatch leaks `BEADS_DIR` via a raw `os.Setenv` with no restore, and `BEADS_DIR` was the one
   source that never consulted the ignore set. A fix aimed at cache invalidation would not have worked.
+- `ga-kjkv1` was filed as a close-policy bypass and was not one. A metadata-only write moves no status, so
+  the row never crosses into done and #5206's gate has nothing to catch. It was an **integrity** defect
+  against the `closed_at`-iff-`status == closed` biconditional `types.Validate` enforces on create and
+  import but not on the update funnels. Two beads in a row had their premise wrong; check the premise.
 
 ### Filed by the fable review councils
 
@@ -172,6 +165,16 @@ Filed rather than folded in. **`.8`, `.9` and `.10` need an owner ruling before 
 - **`ga-ktn9pe.4.13`** (P3) — the new assignee-transfer conformance case seeds only the `issues` table, so
   wisp foreign-assignee transfers are covered by no cross-backend test. A wisp-specific fast path added on
   one backend would reopen the exact divergence class #5217 just closed, on the other table.
+- **`ga-ktn9pe.4.14`** (P2, owner ruling) — **two** divergences, not one. `bd close` keeps the pin while the
+  `issueops` funnel auto-clears it on any status change away from `pinned` (`update.go:329-343`); and the
+  `domain/db` funnel has **no pin auto-clear at all**, so the same `bd update --status closed` behaves
+  oppositely on the two write plumbings. This is not cosmetic: `issue.Pinned` is the deletion-protection
+  flag at six destructive call sites — `bd gc` (`gc.go:97`, `gc_proxied_server.go:72`), `bd purge`
+  (`purge.go:279`, `purge_proxied_server.go:90`) and `bd cleanup` (`cleanup.go:107`). Note that a shared
+  helper did **not** prevent this: both funnels already call `ManageClosedAt`, yet the pin block exists in
+  one. Whichever direction is ruled, both funnels move in the same commit with a conformance case.
+- **`ga-ktn9pe.4.15`** (P3) — the generic-update reopen branch is literal-keyed and, unlike the reopen verb,
+  skips `defer_until` clearing and the reopen comment event. Deferred out of `ga-kjkv1` by ruling.
 
 ### Wave 3 — CLI consistency (all four approved by the owner)
 
@@ -269,18 +272,18 @@ export GOFLAGS=-mod=readonly
 
 ## Verification baselines
 
-As of `ed8526721`. Count with `grep -cE '^[[:space:]]*--- PASS'` — `domain/db` nests four levels deep and a
+As of `dd3ad8f98`. Count with `grep -cE '^[[:space:]]*--- PASS'` — `domain/db` nests four levels deep and a
 shallower pattern undercounts by an order of magnitude.
 
 ```bash
-go test -v -count=1 -run TestParity ./cmd/bd/                                    # 40
+go test -v -count=1 -run TestParity ./cmd/bd/                                    # 43
 go test -v -count=1 -run TestDomainDB ./internal/storage/domain/db/              # 800
 go test -v -count=1 -run TestIssueOperations ./internal/storage/dolt/            # 73
 BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 \
   go test -v -count=1 -run TestEmbeddedIssueOperations ./internal/storage/embeddeddolt/   # 56
-go test -v -count=1 ./internal/storage/uow/                                      # 136
-go test -v -count=1 ./internal/storage/issueops/                                 # 350
-go test -v -count=1 ./internal/validation/                                       # 218
+go test -v -count=1 ./internal/storage/uow/                                      # 145
+go test -v -count=1 ./internal/storage/issueops/                                 # 372
+go test -v -count=1 ./internal/validation/                                       # 220
 go test -v -count=1 ./internal/config/                                           # 297
 BASE_SHA=origin/main bash scripts/check-migration-hygiene.sh                     # clean
 ```

--- a/engdocs/contributors/beads-issue-lifecycle-handoff.md
+++ b/engdocs/contributors/beads-issue-lifecycle-handoff.md
@@ -1,0 +1,237 @@
+# Beads issue-lifecycle work — handoff
+
+Last updated 2026-08-01. Supersedes `beads-guarded-ops-handoff.md` for everything under epic `ga-ktn9pe.4`.
+
+## What this is
+
+A campaign to give beads one guarded issue-lifecycle surface, used by the `bd` CLI, linked-library
+consumers (Gas City's `NativeDoltStore`), and eventually the HTTP/proxied path — so that close/reopen/update
+policy is implemented once instead of three times. Two PRs have merged; a queue of follow-ups remains.
+
+## Where it stands
+
+### Merged upstream (gastownhall/beads)
+
+| SHA | PR | What |
+| --- | --- | --- |
+| `b92442d1a` | #5191 | The facade: `issueops.Lifecycle` (Create/Update/Close/Reopen), reached via `store.IssueLifecycle()`. Three backends, a cross-backend conformance suite, CLI adoption, and ~10 bug fixes. |
+| `ff6eeedbf` | #5206 | A generic status update crossing into a done category now enforces close policy; `bd update --force` gains a dual meaning. |
+
+### Open
+
+- **gastownhall/gascity#4885** — draft, deliberately. Routes `NativeDoltStore` writes through
+  `store.IssueLifecycle()`. It **cannot compile** until beads publishes a release containing the accessor;
+  that is expected and documented in the PR body. Do not add a `replace` directive to make it green.
+  Correctness was proven out-of-tree by building against the upstream branch in a scratch dir.
+
+### The public API, as merged
+
+```go
+// package issueops — a LEAF package: only non-stdlib deps are internal/types and itself.
+// Declares the contract only. No constructor.
+type Lifecycle interface { Create; Update; Close; Reopen }
+
+// internal/storage
+type Storage interface { /* ~71 legacy methods */; IssueLifecycle() (issueops.Lifecycle, error) }
+
+// every consumer
+store, err := beads.OpenBestAvailable(ctx, beadsDir)   // config -> substrate
+ops,   err := store.IssueLifecycle()                   // substrate -> lifecycle verbs
+```
+
+**The naming rule, which matters more than the name:** a new capability gets a **new role and a new
+accessor**, never a method appended to `Lifecycle`. `bd note`, `tag`, `label`, `assign`, `priority`,
+`defer`, `done`, `set`, `claim` are all `Update` with a parameter — `IssuePatch` already carries
+`Notes`, `Labels`, `Metadata`. Rejecting `AddLabel()` / `SetPriority()` / `AppendNote()`-shaped additions is
+the whole discipline. `storage.Storage` reached 71 methods because it lacked this rule.
+
+## Owner rulings — settled, do not relitigate
+
+1. **Constructor** — the accessor *is* the API. No `issueops.New`, no `Source` handle, no `From*`
+   constructors. `store.IssueLifecycle()`.
+2. **`Claim` stays** in `UpdateRequest` (`bd update --claim` exists today).
+3. **`persistence.go`'s issue↔wisp move stays** inside generic Update (main's `DoltStore.UpdateIssue`
+   already does it; removing it regresses frozen semantics).
+4. **`ForceIDPrefix` stays.** Note: an earlier claim that it had no consumer was **wrong** —
+   `bd create --force` uses it at `cmd/bd/create.go:584`.
+5. **`bd create --id <occupied>` refuses** instead of silently upserting. Shipped in #5191.
+6. **A compound update is one atomic operation** — one hook (including bare `--claim`, which previously
+   fired none), delta-only label events, one version commit, with the ID-bearing Dolt commit message kept.
+7. **`bd update --parent` replaces all parent edges atomically** (previously removed only the first).
+8. **`bd reopen` on a non-closed issue reports nothing-to-do** rather than printing "Reopened".
+9. **A generic done-crossing update enforces close policy**, and **`bd update --force` overrides both**
+   the assignee fence and close policy. Shipped in #5206.
+10. **`bd close` pinned check**: refuse if `issue.Pinned` **OR** `status == pinned`. Strictly additive.
+    This was decided by audit: Gas Town pins by *status* at 21 sites (`b.List(ListOptions{Status:
+    StatusPinned})` in `hook_check.go`, `prime_output.go`, `molecule_step.go`, `up.go`), so a
+    boolean-only check would strip its protection. Gas City reads the boolean
+    (`compute_awake_set.go:443,467`).
+11. **Commit identity**: author `Julian Knutsen <julianknutsen@users.noreply.github.com>`; trailers
+    `Agent-Signature: <model>` and `Co-authored-by: CI Bot <ci@beads.test>`. A council suggested the repo's
+    `<agent> on behalf of <human>` form instead — the owner's choice stands.
+12. **PR batching**: one PR per bead, opened in waves, P1s first.
+
+## Process for each remaining item
+
+Fable for design/architecture → Opus for implementation → a fable review council before commit → PR
+following `CONTRIBUTING.md` + `.github/PULL_REQUEST_TEMPLATE.md` → wait for green CI → merge.
+
+Never Sonnet. Prefer fable for red-teams/councils; fall back to Opus on 429, never Sonnet. **Check
+`agents_error` / `<failures>` before trusting an empty findings array** — an all-429 council returns
+`{"findings":[]}` which is indistinguishable from a clean pass.
+
+## Remaining work
+
+### Wave 1 (P1)
+
+- **`ga-2kkue`** — `bd create -t <infra-type>` lands in `issues` on the proxied path.
+  `cmd/bd/create_proxied_server.go:142` routes on `Ephemeral || NoHistory` and never consults infra types,
+  while the embedded path (`create_atomic.go:44`) checks `IsInfraTypeCtx`. `domain.CreateContext` now
+  carries an `InfraTypes` field, making this ~2 lines.
+- **`ga-z3vht`** — `bd close` ignores `issue.Pinned`. `internal/validation/issue.go:53-63` checks
+  `Status == StatusPinned` rather than the boolean. Implement ruling 10 (boolean OR status).
+
+### Wave 2 (P2)
+
+- **`ga-z0qmv`** — the uow `Lifecycle` backend no longer enforces the foreign-assignee transfer fence.
+  It delegated to `domain.ApplyUpdate`, whose fence was removed as a rider. dolt/embeddeddolt enforce via
+  `issueops.AuthorizeAssigneeTransfer` (`aggregate.go:142`, reached from `execution.go:133`). Fix by
+  relocating the check into `uow.issueOperations.Update` at the facade layer, **with a cross-backend
+  conformance case** — the suite has no assignee-transfer case today, which is why nothing caught it.
+- **`ga-kjkv1`** — `closed_at` / `close_reason` / `closed_by_session` are writable as standalone
+  generic-update fields, so close metadata can be stamped without a `status` key. #5206's gate keys off the
+  status change, so this is now the visible seam in an otherwise closed hole. Confirm pre-existing against
+  `origin/main` before fixing.
+- **`ga-dpfii`** — federated cross-prefix dependency targets classify differently across write plumbings.
+  `ExecuteCreate` treats cross-prefix as external and skips the existence check; the uow path only treats a
+  literal `external:` prefix as external. Share one classifier, mirroring how `ClassifyPublicCreateError`
+  became the single funnel.
+- **`ga-tsjxb`** — domain `issue_type` validation skips typed `types.IssueType` values (type-asserts only
+  `string`). `TestIssueUpdateAcceptsLegacyIssueTypeRepresentations` pins that typed values round-trip, so
+  widening changes accept/reject behavior and needs cross-backend verification.
+- **`ga-e6h6i`** — `cmd/bd` leaks `issue-prefix` into viper across tests, surviving `initConfigForTest`.
+
+### Wave 3 — CLI consistency (all four approved by the owner)
+
+- **`ga-c69el`** covers two: `bd reopen` never records last-touched (unlike create/update/close — and
+  `close.go:29-31`'s own doc claims it does), and prints a bare ID where the others use `formatFeedbackID`.
+- **Unify partial-failure exit codes** — `bd close` exits 0, `bd update` exits 1 for the same shape.
+  **Needs a bead.** Breaking either way it is unified.
+- **Unify the `--json` contract** — create emits a sorted-key object with `schema_version`;
+  update/close/reopen emit struct-order arrays without it. **Needs a bead.** Breaking for anything parsing it.
+
+> **Owner input required before implementing the last two.** Bring exact before/after wire shapes and let
+> the owner choose; do not pick a direction unilaterally.
+
+### Wave 3 — review findings still owed beads
+
+- Version-commit messages for create/close/reopen lost the issue ID (breaks `bd dolt log | grep <id>`);
+  update retains its ID via `updateCommitMessage`.
+- A claim-verify replay can double-apply `--append-notes` in a compound facade update
+  (`internal/storage/dolt/issue_operations.go:51,65-78`, `claim_verify.go:161-190`).
+- No batch-mode HEAD-advance test for `bd close` / `bd reopen` (create and update are covered).
+- `issueops` contract docs reference internal symbols rather than the four verbs;
+  `CreateDependency.Metadata` is a bare string that must secretly be valid JSON; `CloseRequest.Session`
+  is undocumented.
+- **`ga-tbr0w`** (filed) — `cmd/bd/ado.go:914-918` writes the non-allowlisted key `source_system` and
+  swallows the error.
+
+### Blocked
+
+- **`ga-ktn9pe.4.2`** (Gas City `NativeDoltStore`) and **`ga-jvr4ef`** (HTTP handler thinning) need a
+  proxy-resolvable beads release. Local `replace` directives are barred.
+- The **proxied-server rewire onto the facade** — it changes Dolt commit granularity (today
+  `bd close a b c` is one commit; the facade commits per issue) and the parity suite explicitly could not
+  pin the proxied output/exit contract. Needs proxied contract-pin tests committed and green **first**.
+- **`ga-ktn9pe.4.7`** gates the OSS publish on `ga-ktn9pe.3` (hosted multibackend rebase). Consider
+  splitting: publishing the OSS pseudo-version is what unblocks the two consumers, and neither needs the
+  hosted rebase.
+
+## Failure patterns this campaign actually hit
+
+Read this section before writing code. Every item cost a revert or a red CI run.
+
+1. **A policy check added at a shared layer reaches callers that cannot satisfy it.** Happened twice.
+   A closed-boundary guard in `UpdateIssueInTx` broke the proxied server and `bd batch`, which had no way to
+   translate its refusal. An assignee fence in `domain.ApplyUpdate` read a spec field the proxied caller
+   never populated, so `--force` was silently ignored. **Both rode in under commit messages that said
+   "validate…".** Before adding any check to a shared helper, write the caller table: every caller, does it
+   enforce, can it override. #5206 does this and its transport is deliberately fail-loud — a caller that
+   forgets to plumb the override is refused by name rather than silently losing it.
+2. **"Unchanged from baseline" is only as good as the baseline.** `TestReopenCommand` was labelled
+   pre-existing and that label propagated to four agents; it had actually been broken by commit 1 of the
+   branch. It surfaced only when someone diffed the failing set against a real `origin/main` worktree.
+   **Always establish a baseline from `origin/main`, not from inside the branch.**
+3. **This repo has several ways to print `ok` while running zero tests.** `-run TestSuite` matches nothing
+   in `domain/db` (the entry point is `TestDomainDB`). Embedded tests all SKIP without
+   `BEADS_TEST_EMBEDDED_DOLT=1`. Always use `-v` and count `RUN/PASS/SKIP/FAIL`.
+4. **Ambient environment leaks into test verdicts.** `getOwner()` reads `GIT_AUTHOR_EMAIL`, so
+   `bd create --json` gains an `owner` key when it is set — which every agent had exported for commit
+   authorship, and CI sets too. A parity test asserting an exact key set passed locally and failed in
+   agents. Pin ambient inputs in the harness.
+5. **After a squash-merge, every SHA from the merged branch is dangling upstream.** Do not cite branch-local
+   commit hashes in shipped source or docs.
+
+## Environment and tooling gotchas
+
+```bash
+export GOTOOLCHAIN=go1.26.5
+export GOPROXY="file://$(go env GOMODCACHE)/cache/download"
+export GOSUMDB=off
+export GOFLAGS=-mod=readonly
+```
+
+- **`GOTOOLCHAIN` must be exported in the committing shell** or the pre-commit hook's golangci-lint
+  self-builds under go1.25 and dies.
+- **`GOPROXY` must be the file:// module cache.** The hook runs `go run golangci-lint@v2.10.1`, which does a
+  network deprecation lookup on *every* invocation and dies on a TLS blip. `GOPROXY=off` does **not** work —
+  it fails the lookup instead.
+- **Never `git stash`.** The stash stack is shared across all worktrees of a repo; another session can pop
+  your entry. Use a WIP commit or a tarball.
+- **`core.hooksPath` lives in the shared git config** (`/data/projects/beads/.git/config`) and has been seen
+  pointing at a sibling checkout. Do not "fix" it — it affects other worktrees. Run the gate by hand:
+  `gofmt -l internal cmd . | grep -v vendor` and
+  `CGO_ENABLED=0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --new-from-rev=HEAD`.
+- **`gh pr edit` fails** with a Projects-classic deprecation error. Use
+  `gh api repos/OWNER/REPO/pulls/N -X PATCH --input -` with a JSON body.
+- **Push targets**: `gascity/beads` is a genuine fork of `gastownhall/beads` — PRs go fork → upstream.
+  For Gas City, the `julianknutsen` remote **301-redirects to `gastownhall/gascity`**; it is not a fork, so
+  pushing there writes to upstream directly.
+- **Gas City has a pre-push gate** that runs `make test-fast-parallel` behind a slot mechanism. On a branch
+  that cannot compile (e.g. #4885) it can only be bypassed with `--no-verify`, which requires owner consent.
+- **Never `go clean -cache`**; never set `GOCACHE`/`TMPDIR`. Never run `./internal/storage/dolt` or
+  `./internal/storage/embeddeddolt` unfiltered — 816 and 114 test functions.
+- **`go test ./cmd/bd/` has ~25 pre-existing top-level failures** (init/config/doctor/completion), identical
+  on `origin/main`. Compare the failing set **by name**, not by count.
+- **`make ci-pr-lint` fails on `origin/main` itself** — two gosec findings in `cmd/bd/main.go`. Pre-existing.
+
+## Verification baselines
+
+As of `ff6eeedbf`. Count with `grep -cE '^[[:space:]]*--- PASS'` — `domain/db` nests four levels deep and a
+shallower pattern undercounts by an order of magnitude.
+
+```bash
+go test -v -count=1 -run TestParity ./cmd/bd/                                    # 40
+go test -v -count=1 -run TestDomainDB ./internal/storage/domain/db/              # 800
+go test -v -count=1 -run TestIssueOperations ./internal/storage/dolt/            # 73
+BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 \
+  go test -v -count=1 -run TestEmbeddedIssueOperations ./internal/storage/embeddeddolt/   # 56
+go test -v -count=1 ./internal/storage/uow/                                      # 135
+go test -v -count=1 ./internal/storage/issueops/                                 # 338
+BASE_SHA=origin/main bash scripts/check-migration-hygiene.sh                     # clean
+```
+
+`cmd/bd/write_verbs_parity_test.go` (40 tests) is the CLI-equivalence evidence. **Its assertions may not be
+edited** except for an owner-approved behavior change, in the commit that causes it, with a comment naming
+the ruling. It is proven non-vacuous and is order- and environment-independent.
+
+## Key paths
+
+- Beads working tree: `/data/projects/beads-public-issueops-simple` (a worktree of `/data/projects/beads`)
+- Gas City consumer: `/data/projects/gascity-native-dolt-issueops-simple`
+- Contract: `issueops/issueops.go` · engine: `internal/storage/issueops/` · backends:
+  `internal/storage/{dolt,embeddeddolt,uow}/issue_operations*.go` · conformance:
+  `internal/storage/conformance/issue_operations_contract.go`
+- Design docs from this campaign: `/var/tmp/w46-final-design.md`, `/var/tmp/w46-yagni.md`,
+  `/var/tmp/w46-cli-swap-plan.md`, `/var/tmp/w46-closepolicy-workorder.md`
+- Recovery backups: `/var/tmp/w46-recovery-backup-20260730T195534`

--- a/engdocs/contributors/beads-issue-lifecycle-handoff.md
+++ b/engdocs/contributors/beads-issue-lifecycle-handoff.md
@@ -6,7 +6,7 @@ Last updated 2026-08-01. Supersedes `beads-guarded-ops-handoff.md` for everythin
 
 A campaign to give beads one guarded issue-lifecycle surface, used by the `bd` CLI, linked-library
 consumers (Gas City's `NativeDoltStore`), and eventually the HTTP/proxied path — so that close/reopen/update
-policy is implemented once instead of three times. Two PRs have merged; a queue of follow-ups remains.
+policy is implemented once instead of three times. Six PRs have merged; a queue of follow-ups remains.
 
 ## Where it stands
 
@@ -18,6 +18,8 @@ policy is implemented once instead of three times. Two PRs have merged; a queue 
 | `ff6eeedbf` | #5206 | A generic status update crossing into a done category now enforces close policy; `bd update --force` gains a dual meaning. |
 | `532dadf98` | #5211 | `ga-2kkue`: the proxied single-create path consults `cctx.InfraTypes`, so `bd create -t <infra-type>` lands in `wisps` like every other create surface. |
 | `29af03b8c` | #5212 | `ga-z3vht`: `NotPinned` refuses on `issue.Pinned` **or** `status == pinned` (ruling 10). Strictly additive. |
+| `252e42c70` | #5217 | `ga-z0qmv`: the assignee-transfer fence enforced in `uow.issueOperations.Update`, predicate shared via `AuthorizeAssigneeTransferWithPools`, plus the cross-backend conformance case the contract never had. |
+| `ed8526721` | #5218 | `ga-e6h6i`: `BEADS_DIR` honors `BEADS_TEST_IGNORE_REPO_CONFIG`, closing the config leak that let a dispatched command re-import the repo's `issue-prefix`. |
 
 ### Open
 
@@ -107,15 +109,19 @@ Both shipped; see the merged table above. Two scoping lessons worth carrying for
 
 ### Wave 2 (P2)
 
-- **`ga-z0qmv`** — the uow `Lifecycle` backend no longer enforces the foreign-assignee transfer fence.
-  It delegated to `domain.ApplyUpdate`, whose fence was removed as a rider. dolt/embeddeddolt enforce via
-  `issueops.AuthorizeAssigneeTransfer` (`aggregate.go:142`, reached from `execution.go:133`). Fix by
-  relocating the check into `uow.issueOperations.Update` at the facade layer, **with a cross-backend
-  conformance case** — the suite has no assignee-transfer case today, which is why nothing caught it.
-- **`ga-kjkv1`** — `closed_at` / `close_reason` / `closed_by_session` are writable as standalone
-  generic-update fields, so close metadata can be stamped without a `status` key. #5206's gate keys off the
-  status change, so this is now the visible seam in an otherwise closed hole. Confirm pre-existing against
-  `origin/main` before fixing.
+- **`ga-kjkv1`** — **blocked on an owner ruling**, and the bead's framing turned out to be wrong.
+  Investigated but deliberately not implemented. A metadata-only write moves no status, so the row never
+  crosses into done and #5206's gate has nothing to catch — the issue stays open. This is not a policy
+  bypass; it is an **integrity** violation. `types.Validate` (`internal/types/types.go:345-351`) declares
+  "`closed_at` set iff `status == closed`" a hard invariant and enforces it on create and import, but the
+  update funnels do not — `ValidateScalarUpdates` checks only `issue_type`/`assignee`/`owner`. So a generic
+  update can mint rows the type's own validator calls invalid. Pre-existing is *confirmed*, not assumed:
+  both allowlists (`issueops/update.go:23` and `domain/db/issue.go:43`) have carried the three keys since
+  `46be5594d` (#3665), long before `ff6eeedbf`. The only in-repo map builder that sets `closed_at` is
+  `internal/linear/mapping.go:860`, which is dead code with test-only callers. Options and per-option
+  broken-caller tables are recorded on the bead; the advisory lean is to drop `closed_at` and
+  `close_reason` from **both** funnels while keeping `closed_by_session`. **Whichever option is chosen,
+  both funnels must change in the same commit or they drift.**
 - **`ga-dpfii`** — federated cross-prefix dependency targets classify differently across write plumbings.
   `ExecuteCreate` treats cross-prefix as external and skips the existence check; the uow path only treats a
   literal `external:` prefix as external. Share one classifier, mirroring how `ClassifyPublicCreateError`
@@ -123,12 +129,23 @@ Both shipped; see the merged table above. Two scoping lessons worth carrying for
 - **`ga-tsjxb`** — domain `issue_type` validation skips typed `types.IssueType` values (type-asserts only
   `string`). `TestIssueUpdateAcceptsLegacyIssueTypeRepresentations` pins that typed values round-trip, so
   widening changes accept/reject behavior and needs cross-backend verification.
-- **`ga-e6h6i`** — `cmd/bd` leaks `issue-prefix` into viper across tests, surviving `initConfigForTest`.
 
-### Filed by the Wave 1 fable review council
+`ga-z0qmv` and `ga-e6h6i` shipped — see the merged table. Two things they taught:
 
-All five came out of reviewing #5211/#5212 and were filed rather than folded in. **The first three need
-an owner ruling before anyone implements them.**
+- The `ga-z0qmv` fence was **not** put back where it was removed from. It went into
+  `uow.issueOperations.Update` at the facade layer, and the predicate was extracted into
+  `issueops.AuthorizeAssigneeTransferWithPools` — pure, pools-injected — so the DBTX path and the uow path
+  evaluate one function instead of two copies that can drift. Putting it back in `domain.ApplyUpdate`
+  would have repeated the original incident verbatim.
+- `ga-e6h6i`'s bead described the mechanism backwards, and it is worth knowing which way round it is:
+  nothing was cached and nothing survived a reset. `ResetForTesting` nils the package viper and
+  `Initialize` builds a fresh one. The repo config was **re-read from disk on every `Initialize`** because
+  in-process dispatch leaks `BEADS_DIR` via a raw `os.Setenv` with no restore, and `BEADS_DIR` was the one
+  source that never consulted the ignore set. A fix aimed at cache invalidation would not have worked.
+
+### Filed by the fable review councils
+
+Filed rather than folded in. **`.8`, `.9` and `.10` need an owner ruling before anyone implements them.**
 
 - **`ga-ktn9pe.4.8`** (P2, owner ruling) — `bd close --force` leaves `pinned=true` residue, so the new
   boolean trigger now refuses the *idempotent re-close* that used to exit 0. `closeIssueInTx` sets only
@@ -152,6 +169,9 @@ an owner ruling before anyone implements them.**
   (`internal/validation/issue.go:204-240`) are production-dead; `validateIssueClosable` hand-rolls the
   same chains. #5212 had to update `forClose`'s test purely to keep dead code consistent. Wire it or
   delete it.
+- **`ga-ktn9pe.4.13`** (P3) — the new assignee-transfer conformance case seeds only the `issues` table, so
+  wisp foreign-assignee transfers are covered by no cross-backend test. A wisp-specific fast path added on
+  one backend would reopen the exact divergence class #5217 just closed, on the other table.
 
 ### Wave 3 — CLI consistency (all four approved by the owner)
 
@@ -249,7 +269,7 @@ export GOFLAGS=-mod=readonly
 
 ## Verification baselines
 
-As of `29af03b8c`. Count with `grep -cE '^[[:space:]]*--- PASS'` — `domain/db` nests four levels deep and a
+As of `ed8526721`. Count with `grep -cE '^[[:space:]]*--- PASS'` — `domain/db` nests four levels deep and a
 shallower pattern undercounts by an order of magnitude.
 
 ```bash
@@ -258,9 +278,10 @@ go test -v -count=1 -run TestDomainDB ./internal/storage/domain/db/             
 go test -v -count=1 -run TestIssueOperations ./internal/storage/dolt/            # 73
 BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 \
   go test -v -count=1 -run TestEmbeddedIssueOperations ./internal/storage/embeddeddolt/   # 56
-go test -v -count=1 ./internal/storage/uow/                                      # 135
-go test -v -count=1 ./internal/storage/issueops/                                 # 338
+go test -v -count=1 ./internal/storage/uow/                                      # 136
+go test -v -count=1 ./internal/storage/issueops/                                 # 350
 go test -v -count=1 ./internal/validation/                                       # 218
+go test -v -count=1 ./internal/config/                                           # 297
 BASE_SHA=origin/main bash scripts/check-migration-hygiene.sh                     # clean
 ```
 

--- a/engdocs/contributors/beads-pinned-boolean-removal-plan.md
+++ b/engdocs/contributors/beads-pinned-boolean-removal-plan.md
@@ -1,0 +1,354 @@
+# Retiring the beads `pinned` boolean — phased plan
+
+Written 2026-08-02. The ruling this implements is recorded on `ga-ktn9pe.4.14`; this file is the
+work order.
+
+## The decision in one paragraph
+
+The `pinned` boolean column on beads issues and wisps is removed. `status='pinned'` becomes the
+sole pin mechanism. Surfaces that spell the word — `bd list --pinned`, the `pinned:` query
+predicate, the `pinned_issues` stat — survive as sugar over the status; the boolean beneath them
+does not. The load-bearing fact: all three destructive commands pre-filter their candidate sets
+to `Status=closed` before consulting the pin (`gc.go:84-90`, `purge.go:114-118`, `cleanup.go`),
+so a status-pinned bead is never a deletion candidate in the first place. The boolean's only
+unique capability is protecting a bead that is closed **and** pinned — a state the status cannot
+express, that is conceptually incoherent, and of which a fleet census found exactly zero
+instances.
+
+## Why this is safe to do now
+
+Two rows carry `pinned=1` fleet-wide: `mc-5pt81` and `mc-yl5fo` in maintainer-city, both
+`bd:memory` beads, both carrying `status='pinned'` **and** the boolean, both set at create time.
+They need no data migration — the status protects them identically. The only writer is an
+unmerged prototype whose every boolean read is strictly conjunctive with the status, and whose
+own violation message calls it "the pinned compatibility marker".
+
+**This is the last cheap moment.** Once memory beads land and rows accumulate, removal needs a
+data migration and a conversation with whoever owns them.
+
+
+## Point of no return
+
+Phase 9 (the guarded DROP COLUMN migration pair). Every phase before it is a clean git revert
+because the column and DB rows are untouched. Once the migration runs on any shared database,
+reversal is fix-forward only: a new migration re-ADDing the column with DEFAULT 0, with the
+(redundant) pinned=1 values of mc-5pt81/mc-yl5fo unrecoverable and historical values unreadable
+via dolt_history_issues. Phase 9 therefore ships alone, re-numbered at land time, and only after
+Phases 7 and 8 are deployed fleet-wide including every bd-enterprise deployment sharing a hosted
+DB.
+
+## Phases
+
+### Phase 0 — Gates (NOT yet done — both block Phase 1)
+
+**Changes.** GATE A — hosted census. The local fleet census could not reach the hosted gateway. Run a READ-
+ONLY aggregation against every issues/wisps table the hosted gateway serves, using the normal
+hosted-read path (EIA credential via BEADS_DOLT_CREDENTIAL_COMMAND, per the beads-1045
+convention — never a direct dolt server touch): `SELECT status, COUNT(*) FROM issues WHERE
+pinned = 1 GROUP BY status;` and the same for `wisps`, per database. PASS iff every returned row
+has status='pinned' (in particular: zero rows with status='closed' and zero with any open
+status). Any closed+pinned or open+pinned row is exactly the state only the boolean protects —
+it invalidates the 'migration is free' premise and goes back to the owner before Phase 1. GATE B
+— shared-agent-memory owner ack. Get written confirmation from the owner of beads
+feature/shared-agent-memory-prototype / the mc-hpshy field trial that status='pinned' alone
+carries the memory-bead contract, and record it on ga-ktn9pe.4.14. The code answer is already
+yes (every boolean read is conjunctive with status — projection.go:150-154,
+memory_activate.go:378-379, issueops/generation_cas.go:81,525), but the branch's own comments
+call it a designed 'compatibility marker', so the supersession must be explicit, not inferred.
+
+**Proven by.** Gate A: the SQL result set pasted onto the bead (statuses all 'pinned'). Gate B: owner ack
+recorded on the bead.
+
+**Depends on.** Nothing.
+
+**Reversal.** N/A — read-only.
+
+### Phase 1 — beads: close the last origination path (graph plans)
+
+**Changes.** cmd/bd/graph_apply.go: delete GraphApplyNode.Pinned (~:64) and the `issue.Pinned = node.Pinned`
+assignment (~:870); knownGraphNodeFields self-updates (built by reflection from json tags,
+:152). Add graphFieldHints entry: `"pinned": "use \"status\": \"pinned\" — the pinned status is
+the single pin mechanism"`. Update cmd/bd/help_supplements/create_graph_plan.md (drop the pinned
+example, :32). Adjudicated behavior (verified this session, origin/main db966433eb): plans
+carrying "pinned" hit warnUnknownGraphFields (:264-286, invoked :342-343) — stderr warning
+naming the field + hint, field dropped, exit 0. Warn-with-hint, not reject; the auditor claim of
+hard rejection was wrong. ~3 files + tests.
+
+**Proven by.** graph_apply tests: new assertion that a plan with "pinned": true warns with the corrective hint
+and creates the bead un-pinned; a plan with "status": "pinned" still pins
+(validateGraphApplyNodeFields:657 accepts it). scripts/check-cli-docs-drift.sh.
+
+**Depends on.** Phase 0.
+
+**Reversal.** git revert — field and column still exist everywhere else.
+
+### Phase 2 — beads: close guard goes status-only
+
+**Changes.** internal/validation/issue.go: drop `issue.Pinned ||` from NotPinned (:66) and rewrite the doc
+comment (:51-58) to state status-only semantics. cmd/bd/close.go: keep the ga-ktn9pe.4.8 skip-
+validation branch (closed-re-close idempotence) but rewrite its boolean-pinned rationale comment
+(:126-140). Rewrite internal/validation/issue_test.go and cmd/bd/show_unit_helpers_test.go
+boolean legs. 4 files.
+
+**Proven by.** internal/validation/issue_test.go; cmd/bd/show_unit_helpers_test.go; oracle-a
+enumerated.json:405-420 (update --status pinned then close) stays green as the regression
+sentinel — invisible change for all real rows since the guard was already status-aware.
+
+**Depends on.** Phase 0. Independent of Phase 1.
+
+**Reversal.** git revert.
+
+### Phase 3 — beads: query-language predicate becomes status sugar
+
+**Changes.** internal/query/parser.go:338 + evaluator.go (:191-192, :477-478, :722-723): alias `pinned:true`
+→ status='pinned' and `pinned:false` → status != 'pinned' (ExcludeStatus machinery exists,
+evaluator.go:220,595); in-memory predicate re-keys `i.Pinned` → `i.Status == StatusPinned`.
+Update docs/cli-reference/query.md:46 to describe it as a status alias. RULED: alias, not
+removal — outright removal is the one hard script break (documented predicate → parse error). ~4
+files.
+
+**Proven by.** internal/query/query_test.go with new alias cases, including: status-pinned row now MATCHES
+pinned:true (the divergence is the point of the ruling; zero live rows diverge today per
+census). Docs-drift check.
+
+**Depends on.** Phase 0. Independent of 1-2.
+
+**Reversal.** git revert.
+
+### Phase 4 — beads: bd list --pinned/--no-pinned re-key to status
+
+**Changes.** internal/workapi/list.go (:308-314): --pinned → Status=pinned, --no-pinned → ExcludeStatus
+(already the default at :205-206); the `bd list --status hooked` boolean-suppression special
+case (:311) dissolves. cmd/bd/list.go / list_input.go flag wiring; regenerate
+internal/workapi/testdata/list_filter_golden.json; docs/cli-reference/list.md. RULED: keep both
+flags as status sugar — help text ('Show only pinned issues') stays literally true, and the re-
+key FIXES a latent bug: a status-only pin is invisible to `bd list --pinned` today. Do NOT yet
+delete IssueFilter.Pinned (compile-coupled into Phase 7); just stop populating it. ~5 files.
+
+**Proven by.** list_embedded_test.go, list_helpers_test.go, regenerated golden (currently pins Pinned:false
+into nearly every case — forgetting it fails every list test); new test: status-pinned bead
+appears under --pinned.
+
+**Depends on.** Phase 0. Independent of 1-3.
+
+**Reversal.** git revert.
+
+### Phase 5 — beads: stats + display re-key
+
+**Changes.** internal/storage/issueops/statistics.go (:11,22,30): SUM(pinned=1) → COUNT(status='pinned');
+RULED: KEEP the `pinned_issues` JSON key (types.go:1690, no omitempty — always present; MCP
+models.py:286 tolerant either way but keep it). cmd/bd/list_format.go:23-25,
+show_format.go:287-288, format/format.go (:63,72,94,104): delete the boolean 📌/'Pinned: yes'
+indicators — format.go:163 already renders 📌 for the STATUS, so re-keying would duplicate. ~5
+files.
+
+**Proven by.** cmd/bd/status_test.go, count_filter_test.go; conformance audit_search-counts-stats.go:261-294
+rewritten to status-keyed counting (its comment explicitly isolates the column — that
+distinction is what's being abolished). Output identical for the two dual-marked mc rows.
+
+**Depends on.** Phase 0.
+
+**Reversal.** git revert.
+
+### Phase 6 — beads: delete redundant boolean checks on destructive + ready/wisp/doctor paths (two PRs)
+
+**Changes.** PR 6a — destructive commands: cmd/bd/closed_delete_candidates.go (:10,30-31) drop the
+issue.Pinned skip; candidates are pre-filtered to Status=closed (gc.go:84-90, purge.go:114-118)
+so the check can never fire post-removal. RULED: KEEP the `pinned_skipped` JSON key and 'Pinned
+(skipped)' wiring emitting a definitional 0 (purge.go, purge_proxied_server.go, cleanup.go) —
+zero wire breakage. ~5 files. PR 6b — non-destructive protections:
+internal/storage/sqlbuild/ready.go:109 drop `(pinned = 0 OR pinned IS NULL)`;
+issueops/ready_work.go (:301-310 populate, :433 check); cmd/bd/wisp.go isProtectedWisp (:700-718
+— StatusPinned already protected via CategoryFrozen, :661,677; the :709 comment claiming the
+flag is 'independent of the status' is overruled by this ruling);
+cmd/bd/doctor/maintenance.go:94-98 raw SQL + doctor/fix/maintenance.go:63-85; scripts/bench-
+ready-indexes/main.go (:185,197). Rewrite conformance audit_dependencies_readiness.go:395-404
+(testAuditReadyTypeAndPinnedExclusions creates Open+Pinned:true — the exact boolean-only
+capability being removed) to Status=StatusPinned. ~5 files + conformance.
+
+**Proven by.** 6a: closed_delete_candidates_test.go rewrite; purge/cleanup --json goldens show
+pinned_skipped:0. 6b: rewritten conformance readiness audit green against every conforming
+store; ready_embedded_test.go; doctor/maintenance_cgo_test.go; wisp tests.
+
+**Depends on.** Phase 0. The raw-SQL deletions here MUST land before Phase 9 or those queries hard-fail post-
+drop.
+
+**Reversal.** git revert per PR.
+
+### Phase 7 — beads: remove the wire field and storage plumbing (the one necessarily-large atomic PR)
+
+**Changes.** Everything compile-coupled through types.Issue.Pinned, in ONE commit because splitting is a
+build failure: types.go:137 delete Issue.Pinned; :1762-1763 delete IssueFilter.Pinned;
+ComputeContentHash :198 — RULED: replace `w.flag(i.Pinned, "pinned")` with a literal
+`w.h.Write([]byte{0}) // retired pinned-flag slot; keeps hashes stable` (flag always wrote the
+separator, :260-265; naive deletion churns EVERY issue's hash and breaks the cross-clone
+determinism contract at :174-176 — verified this session); sqlbuild.go:42 IssueSelectColumns +
+ALL positional scans (issueops/scan.go, issueops/history.go, dolt/history.go —
+domain/db/issue.go:35-37 aliases the column list, so both plumbings move together); INSERT lists
+(issueops/helpers.go:115,139; domain/db/issue.go:687,730 — issueUpsertColumns already excludes
+pinned, import-UPDATE leg untouched); WHERE builders (sqlbuild/filter.go:203-207,
+dolt/transaction.go:540-545); update allowlists BOTH plumbings (issueops/update.go:25,
+domain/db/issue.go:44) + auto-clear block (update.go:443-457) + matchesBool (:700-701);
+public_create.go:125; openapi.v0.yaml 4 sites (:969,1071,1152,1277) + `make api-gen`; the ~28
+test files (grep `Pinned: true|pinned = 1|--pinned`). Old JSONL with "pinned":true still imports
+(unknown-field drop); optionally add a one-line import notice for the dropped key — the only
+zero-feedback surface. cmd/bd/info.go changelog entries (:1155, :1201): leave — changelog
+history is immutable, and the :1155 '--pinned works' line describes a flag that no longer exists
+on main (verified: bd update registers no --pinned).
+
+**Proven by.** Full suite. Specifically: write_verbs_parity_test.go / parity_direct_test.go / serve-reads
+parity (both plumbings must move together or parity fails); the conformance suite; the OpenAPI
+spec-sync check + httpapi/pinning.go compile assertions; dolt/schema_parity_test.go stays green
+(column still exists in DB AND migrations — nothing compares code to schema); content-hash tests
+unchanged (placeholder preserves the byte stream).
+
+**Depends on.** Phases 1-6 (they exist to shrink this PR to the compile-coupled core). MUST precede Phase 9 by
+at least one full release.
+
+**Reversal.** git revert — safe as long as no drop migration has shipped, which is exactly why Phase 9 is
+separate.
+
+### Phase 8 — bd-enterprise: sync the fork before any migration ships
+
+**Changes.** Merge upstream beads through Phase 7 into /data/projects/bd-enterprise. Low-conflict: the fork's
+pinned surface is a strict SUBSET of beads main (its NotPinned at
+internal/validation/issue.go:57 is already status-only; it lacks main's update.go matcher,
+close.go boolean handling, and wisp boolean protection). Its enterprise-specific 'pinned' hits
+are homonyms (DPoP jkt pinning, Dolt connection pinning, version pinning) — untouched.
+Coordinate Phase 9's migration version numbers with the fork's sequence NOW to avoid a
+duplicate-version collision on rebase. Deploy the synced binaries to every enterprise deployment
+that shares a hosted Dolt DB with a beads-main binary — answering the open question of who owns
+that sequencing is part of this phase's exit criteria.
+
+**Proven by.** Fork CI green post-merge; `git grep -n 'issue\.Pinned\|\.Pinned\b' -- 'cmd/bd'
+'internal/storage' 'internal/types' 'internal/validation'` returns only homonyms; all shared-DB
+deployments confirmed on the synced binary.
+
+**Depends on.** Phase 7. HARD-BLOCKS Phase 9.
+
+**Reversal.** Revert the merge on the fork (standard).
+
+### Phase 9 — beads: drop the column — POINT OF NO RETURN
+
+**Changes.** One PR, two migration files, nothing else: (a) main-plane guarded fix-forward migration (next
+free number at land time; auditors cited next-after-0062 against 2af843a601 — RE-NUMBER at land
+time, main has moved): INFORMATION_SCHEMA-guarded `ALTER TABLE issues DROP COLUMN pinned` +
+guarded wisps drop, exactly the 0060_add_storage_class idempotence pattern (DROP precedent:
+ignored/0005); (b) the MANDATORY ignored-series twin (next after 0021) dropping wisps.pinned —
+wisps is dolt_ignored (0019), fresh clones materialize it from the ignored series alone and
+never run a main-plane wisps ALTER (hygiene check D; bd-hs7fa precedent). Guard both so double
+application is a no-op. Also update migration_repairs.go:140 (repair DDL still lists the column)
+in the same PR. Ship ONLY after the entire fleet — including every bd-enterprise deployment
+sharing a hosted DB — runs Phase-7+ binaries. The two mc rows (mc-5pt81, mc-yl5fo) need NO data
+migration: status='pinned' protects them identically; their pinned=1 is silently discarded, and
+that discard is correct.
+
+**Proven by.** scripts/check-migration-hygiene.sh (checks A-D); dolt/schema_parity_test.go post-migration;
+fresh-clone wisps materialization; run-twice idempotence of both guards.
+
+**Depends on.** Phases 7 AND 8, each fully deployed fleet-wide. This is the point of no return.
+
+**Reversal.** Fix-forward ONLY (migration hygiene forbids editing shipped migrations): a NEW guarded migration
+re-ADDing the column with DEFAULT 0. The two rows' pinned=1 values are NOT restored — acceptable
+and ruled, since the value was redundant with their status. Historical pinned values at old dolt
+commits become unreadable via dolt_history_issues regardless (history tables mirror current
+schema).
+
+### Phase 10 — downstream: Gas Town at its next SDK bump; Gas City nothing
+
+**Changes.** Gas Town: delete internal/mail/store.go:251 (`Pinned: si.Pinned`) in the SAME commit as its next
+beads SDK bump past Phase 7 — the value is already dead (ToMessage(), types.go:387-439, never
+copies it) and it is the single compile-time dependency; Gas Town pins beads v1.0.0 so there is
+no urgency. The inert `gt mail send --pinned` flag is a SEPARATE Gas Town-owner decision (see
+doNotBundle). Gas City: zero changes in any phase — no boolean consumers, native store has no
+such column (native_dolt_store.go:805,962,1985,2162 never touch it); bump its two lockstepped
+bd-version knobs (go.mod + deps.env) on normal cadence. Prototype branches: if the shared-agent-
+memory field trial is ever revived, it rebases onto post-removal main and drops
+candidate.go:158,164 `Pinned: true`, projection.go:150-155 `!issue.Pinned`,
+memory_activate.go:378-379 CAS precondition, generation_cas plumbing, memory_list.go:221 — all
+loud compile errors, all capability-neutral.
+
+**Proven by.** Gas Town builds at bump time (the field access is a compile error otherwise). Gas City: nothing
+to prove.
+
+**Depends on.** Phase 7 (for the SDK bump). No ordering constraint on the rest of the campaign.
+
+**Reversal.** Trivial per-repo reverts.
+
+## What this makes moot — and what survives
+
+- ga-ktn9pe.4.9 (facade close has no pinned check): boolean half CLOSED-AS-MOOT — there is no
+boolean to check. Status half SURVIVES and gains weight: under the single mechanism,
+transitioning status away from 'pinned' via close is the ONLY way a pinned bead can lose
+gc/purge/cleanup immunity, so a close path that skips the status-only validation.NotPinned guard
+is a live protection hole, not a stale nit. Re-scope the bead to 'facade close must enforce
+NotPinned (status)'; do not close it.
+- ga-ktn9pe.4.17 (fourth close path): same disposition — boolean half CLOSED-AS-MOOT, status half
+survives re-scoped to the status-only NotPinned guard on that path. Do not close.
+- Ruling 10 / ga-z3vht, boolean half: CLOSED-AS-MOOT in full — every provision of that ruling that
+concerned the `pinned` column/field is void. The status-based half of ruling 10 stands unchanged
+and is unaffected by this removal.
+
+## Do not bundle
+
+- NEVER bundle the code removal (Phase 7) with the schema drop (Phase 9). Migrations run at new-
+binary startup against shared dolt databases that older binaries may still serve; a pre-removal
+binary against a post-drop DB hard-fails EVERY issue scan and insert (positional SELECT/INSERT
+lists name `pinned` — Error 1054). Two releases, minimum.
+- MUST bundle (the inverse rule): the main-plane drop migration and its ignored-series wisps twin
+ship in the same PR (hygiene check D; bd-hs7fa precedent). And within Phase 7, the types.Issue
+field, the openapi.v0.yaml edits (4 sites), `make api-gen`, and the SELECT/scan/INSERT edits
+across BOTH plumbings are one atomic commit — spec-sync tests and compile coupling make any
+split a build failure.
+- Do NOT bundle the Gas Town `gt mail send --pinned` flag removal into this campaign. It is
+already a no-op on the beads path (Message.Pinned never serialized — router.go:1126-1162,
+buildLabels :235-255) but it is user-visible Gas Town CLI surface; it needs its own Gas Town-
+owner ruling. Only the one-line `store.go:251` delete is forced, and only at SDK-bump time.
+- Do NOT bundle any status-string sweep. The surviving mechanism IS `status='pinned'`:
+internal/linear/mapping.go:450-451, ui/styles.go, statuses.go:24, every `status <> 'pinned'` SQL
+in issueops/blocked*.go, dolt/queries.go:127, domain/db/*, workapi/list.go:206, and migrations
+0017-0047 view SQL are all LEAVE ALONE. An over-eager grep-sweep here removes the mechanism the
+ruling keeps.
+- Do NOT bundle a 'cleanup' of the content-hash placeholder byte into any later refactor. Deleting
+it churns every issue's content hash and breaks the cross-clone determinism contract
+(types.go:174-176). It is ruled, permanent, and cheap.
+- Do NOT let a homonym sweep touch: Gas City session pin_awake (cmd/gc/compute_awake_set.go:70,
+cmd_session_pin.go:137), bd-enterprise DPoP jkt pinning (gwauth/store/store.go:22) and Dolt
+connection pinning (uow/doltserver_tx.go), or formula/binary version pinning. A false 'Gas City
+reads the boolean' claim from exactly this collision already reached a merged commit message
+once.
+
+## Residual risks
+
+- Hosted census (Phase 0 Gate A) may surface a closed+pinned or open+pinned row the local census
+could not see. That is the one finding that reopens the ruling — it is exactly why the gate
+blocks Phase 1.
+- Archived JSONL exports are files outside any census. A hypothetical old export containing a
+boolean-only closed+pinned row would restore months later with no error, no warning
+(import.go:264 plain Unmarshal), and no protection. Probability near zero (no such row ever
+observed; the only known writer set both markers); the optional import notice in Phase 7 closes
+it cheaply.
+- Automation feeding graph plans with "pinned": true keeps exiting 0 while no longer pinning —
+mitigated by the stderr warning + the new graphFieldHints entry naming the replacement, but
+pipelines that discard stderr see nothing. Only known plan author is the unmerged prototype,
+which also sets status.
+- Content-hash placeholder byte: a future 'dead code' cleanup that deletes it churns every issue's
+content hash. No comparer exists in-repo today (import stale-guard keys on updated_at), but the
+determinism contract at types.go:174-176 means a future consumer of that promise would break
+silently. The placeholder is ruled permanent.
+- Mixed-fleet window: any pre-Phase-7 binary (notably un-synced bd-enterprise deployments —
+domain/db/issue.go:612,655 in the fork lists the column in INSERTs) against a post-Phase-9 DB
+hard-fails all issue reads and writes. Phase 8's exit criteria (who owns shared-DB sequencing)
+is the open operational question and must be answered before Phase 9, not after.
+- Stale-checkout traps for the implementer: /data/projects/beads sits on local/deploy-current-
+integrated, which LACKS GraphApplyNode.Pinned and carries list-filter logic in a different file
+than origin/main; /data/projects/gascity root is a detached hybrid. Work from origin/main via
+worktree; one auditor made exactly this error before re-verifying. Also: origin/main moved from
+the audited 2af843a601 to db966433eb during scoping — verified zero pinned-surface drift, but
+line numbers are per-SHA and Phase 9's migration number must be picked at land time.
+- beads main may grow new boolean consumers between now and Phase 7 (close.go and update.go grew
+them recently). Each addition widens Phase 7 and the fork merge. Land Phases 1-6 promptly to
+freeze the surface.
+- The 'pinned' homonym field (session pin_awake, DPoP pinning, connection pinning, version
+pinning) has already produced one false claim in a merged commit message. Every future reference
+to consumers must cite file:line.


### PR DESCRIPTION
## Summary

Adds two contributor docs covering the beads issue-lifecycle campaign (epic `ga-ktn9pe.4`) — a campaign to give beads one guarded issue-lifecycle surface used by the `bd` CLI, linked-library consumers (Gas City's `NativeDoltStore`), and eventually the HTTP/proxied path, so close/reopen/update policy is implemented once instead of three times.

Two PRs have landed upstream in `gastownhall/beads`:

- [`b92442d1a`](https://github.com/gastownhall/beads/commit/b92442d1a) (gastownhall/beads#5191) — the `issueops.Lifecycle` facade reached via `store.IssueLifecycle()`: three backends, a cross-backend conformance suite, CLI adoption, and ~10 bug fixes.
- [`ff6eeedbf`](https://github.com/gastownhall/beads/commit/ff6eeedbf) (gastownhall/beads#5206) — a generic status update crossing into a done category now enforces close policy; `bd update --force` gains a dual meaning.

`engdocs/contributors/beads-issue-lifecycle-handoff.md` is the reference: merged/open/blocked state, the twelve settled owner rulings **with the reasoning behind them**, the remaining queue in wave order, the failure patterns this campaign actually hit, environment gotchas, verification baselines, and key paths.

`engdocs/contributors/beads-issue-lifecycle-NEXT-SESSION-PROMPT.md` is a paste-ready, self-contained prompt that points at the handoff.

Both are engineering docs, so they live under `engdocs/` rather than the published `docs/` tree. Docs-only — no code, no behavior change.

## Why the rulings carry their reasoning, not just their outcome

Several rulings reversed on evidence and would be tempting to "simplify" back. The clearest case is the pinned-check ruling: `bd close` must refuse if `issue.Pinned` **OR** `status == pinned`, because an audit found Gas Town pins by *status* at 21 sites, so a boolean-only check would have stripped its existing protection. A reader who saw only the outcome would be tempted to narrow it.

The same applies to the "Failure patterns this campaign actually hit" section. Each of those five entries cost a revert or a red CI run, and none is inferable from the code — most notably that a policy check added at a shared layer reaches callers that cannot satisfy it (this happened twice, both times riding into a commit whose subject said "validate…").

## Two items still need owner input

Recorded in the handoff and repeated in the prompt: unifying the partial-failure exit codes (`bd close` exits 0, `bd update` exits 1 for the same shape) and unifying the `--json` contract (create emits a sorted-key object with `schema_version`; update/close/reopen emit struct-order arrays without it) are both **breaking wire changes**. The prompt explicitly instructs the next session to bring exact before/after shapes to the owner rather than pick a direction.

## Note for the reviewer

The handoff's first line says it supersedes `beads-guarded-ops-handoff.md`. That predecessor doc has never been committed to this repo — it exists only untracked in a local checkout — so the reference does not resolve for anyone reading this on GitHub. It is referenced in backticks rather than as a link, so no docs check catches it. Say the word and I'll add the predecessor to this PR or reword the line; I left it alone rather than expanding scope unasked.

## Testing

- [x] `make check-docs` (`go test ./test/docsync`) — ok
- [x] `make test-fast-parallel` — "All fast jobs passed" (ran as the pre-push gate)
- [ ] `make check` — not run; docs-only change, no Go sources touched
- [ ] `make test-integration` — not run; no runtime, controller, or workflow behavior changed

Additional verification specific to this change:

- Confirmed both cited beads SHAs are squash-merge commits reachable from `gastownhall/beads` `origin/main`, not dangling branch-local hashes — that is the handoff's own failure pattern #5, so the docs had to not violate it.
- Neither file contains markdown links or strings on the `TestNoKnownStaleDocReferences` banned list, so the engdocs link and stale-reference checks have nothing to catch.

## Checklist

- [x] Linked an issue — epic `ga-ktn9pe.4`; the docs are recorded on it
- [ ] Added or updated tests — n/a, docs-only
- [x] Updated docs for user-facing changes — this PR *is* the docs change
- [x] Called out breaking changes or migration notes — none here; the two breaking items are flagged above as needing owner input before anyone implements them
