### PR TITLE
fix(runtime/herdr): confirm nudge submission landed

### DIFF
--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -169,10 +169,29 @@ func promptStalled(err error) bool {
 // lets a startup prompt land in the swallow window. Best-effort: a boot that
 // never reports ready still returns, and the caller delivers anyway (no worse
 // than not waiting).
+// It also waits out an in-flight turn: herdr's --wait "does not track turns",
+// so a prompt submitted while the agent is already working can match that
+// turn's completion instead of its own, turning the confirmation into a
+// spurious timeout. Delivering from a settled state keeps --wait meaningful.
+// A pane that never registers an agent at all (a bare shell, a raw
+// `exec /bin/sh -c` session) can never report readiness, so the wait gives up
+// after registrationGrace rather than burning the whole budget before the
+// caller falls back to paste+confirm.
 func (c *client) waitInteractiveReady(ctx context.Context, target string, budget time.Duration) {
 	deadline := time.Now().Add(budget)
+	graceDeadline := time.Now().Add(registrationGrace)
+	registered := false
 	for time.Now().Before(deadline) {
-		if info, ok, err := c.getAgent(ctx, target); err == nil && ok && info.InteractiveReady {
+		info, ok, err := c.getAgent(ctx, target)
+		if err == nil && ok {
+			registered = true
+			if info.InteractiveReady && !strings.EqualFold(info.AgentStatus, "working") {
+				return
+			}
+		}
+		// Still nothing registered once the grace elapses: this pane has no
+		// agent to wait for.
+		if !registered && !time.Now().Before(graceDeadline) {
 			return
 		}
 		select {
@@ -213,6 +232,8 @@ func (c *client) listAgents(ctx context.Context) ([]agentInfo, error) {
 // screen (the liveness/fingerprint snapshot). On 0.7.5 the CLI prints the
 // text raw rather than in the JSON envelope, so this parses failures out of
 // an envelope only when one is present.
+//
+//nolint:unparam // source documents herdr's read API; every current caller snapshots the visible screen
 func (c *client) paneRead(ctx context.Context, paneID, source string, lines int) (string, error) {
 	args := []string{"pane", "read", paneID, "--source", source}
 	if lines > 0 {
@@ -324,13 +345,79 @@ func (c *client) deliverNudge(ctx context.Context, paneID, text string) error {
 	if !strings.Contains(err.Error(), "not_found") && !strings.Contains(err.Error(), "not found") {
 		return err
 	}
-	// No registered agent on this pane: paste, settle, submit.
+	// No registered agent on this pane (a raw `exec /bin/sh -c` session, a bare
+	// shell, or an agent herdr has not classified yet — ephemeral wisps spend a
+	// window here). There is no agent status to confirm against, so close the
+	// loop on the only signal a pane exposes: the screen. Submit, then verify
+	// the text is no longer sitting in the input, and retry the Enter until it
+	// is. A redundant Enter on an already-submitted prompt is a harmless no-op.
+	return c.pasteAndConfirmSubmit(ctx, paneID, text)
+}
+
+// pasteAndConfirmSubmit pastes text into an unregistered pane and confirms the
+// submit actually landed, rather than firing one Enter and hoping.
+//
+// A submit that races the paste-commit is swallowed and strands the text
+// typed-but-unsubmitted — the caller sees success while a human has to press
+// Enter for it. Confirmation is by screen: once submitted, the pasted text
+// leaves the input area. Bounded, and returns an error with the last observed
+// input state when it never confirms.
+func (c *client) pasteAndConfirmSubmit(ctx context.Context, paneID, text string) error {
 	if err := c.paneRun(ctx, paneID, text); err != nil {
 		return err
 	}
-	time.Sleep(submitSettleDelay)
-	return c.sendKeys(ctx, paneID, "Enter")
+	// Probe with the final non-empty line: multi-line pastes wrap, and only the
+	// tail reliably sits on the input row.
+	probe := lastNonEmptyLine(text)
+	var lastInput string
+	for attempt := 0; attempt < promptMaxAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(submitSettleDelay): // let the paste commit before submitting
+		}
+		if err := c.sendKeys(ctx, paneID, "Enter"); err != nil {
+			return err
+		}
+		screen, err := c.paneRead(ctx, paneID, "visible", inputProbeLines)
+		if err != nil {
+			// Cannot verify; the Enter was sent, so report success rather than
+			// spinning on a read failure.
+			return nil //nolint:nilerr // unverifiable read: the submit was issued
+		}
+		lastInput = tailLines(screen, inputProbeLines)
+		if probe == "" || !strings.Contains(lastInput, probe) {
+			return nil // text left the input: the submit landed
+		}
+	}
+	return fmt.Errorf("herdr deliverNudge: pane %s still shows the nudge unsubmitted after %d attempts; last input: %q",
+		paneID, promptMaxAttempts, lastInput)
 }
+
+// lastNonEmptyLine returns the final non-blank line of s, trimmed — the part of
+// a pasted nudge that lands on the input row.
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// tailLines returns the last n lines of s (the input area of a rendered pane).
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// inputProbeLines is how much of the rendered pane counts as "the input area"
+// when checking whether a pasted nudge is still sitting there unsubmitted.
+const inputProbeLines = 6
 
 const (
 	// interactiveReadyBudget bounds the pre-delivery wait for the TUI to accept
@@ -339,6 +426,11 @@ const (
 	interactiveReadyBudget = 60 * time.Second
 	// promptMaxAttempts bounds retries of a stalled (swallowed) submit.
 	promptMaxAttempts = 5
+	// registrationGrace is how long to allow for an agent to appear in herdr's
+	// registry before concluding the pane has none. A launched agent registers
+	// in a second or two; a bare shell never does, and must not pay the whole
+	// readiness budget before delivery falls back to paste+confirm.
+	registrationGrace = 10 * time.Second
 )
 
 // submitSettleDelay is how long the unregistered-pane fallback waits for a

--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -102,6 +102,10 @@ type agentInfo struct {
 	TerminalID  string `json:"terminal_id"`
 	AgentStatus string `json:"agent_status"`
 	Cwd         string `json:"cwd"`
+	// InteractiveReady reports that the agent's TUI is listening for input.
+	// agent_status "idle" is necessary but not sufficient — input-readiness
+	// lags it, and a prompt delivered in that window is silently swallowed.
+	InteractiveReady bool `json:"interactive_ready"`
 }
 
 // agentStartTimeoutMS bounds herdr's own wait for the launched agent TUI to
@@ -142,9 +146,51 @@ func (c *client) startAgentKind(ctx context.Context, name, kind, paneID string, 
 // prompt machinery — the reliable replacement for the paste+Enter+confirm
 // dance. target is an agent name or the pane id hosting it.
 func (c *client) agentPrompt(ctx context.Context, target, text string) error {
-	_, err := c.run(ctx, "agent", "prompt", target, text)
+	// --wait makes herdr confirm the submission actually landed: it requires an
+	// observed state change after submit and returns agent_prompt_stalled
+	// otherwise. Without it herdr reports success even when the TUI swallowed
+	// the prompt (delivered before the input was listening), which strands the
+	// agent's first turn with no error anywhere.
+	_, err := c.run(ctx, "agent", "prompt", target, text,
+		"--wait", "--timeout", strconv.Itoa(int(promptConfirmTimeout/time.Millisecond)))
 	return err
 }
+
+// promptStalled reports whether err is herdr's agent_prompt_stalled — the
+// prompt was accepted but produced no state change, i.e. the submit was
+// swallowed. Retryable: the TUI is typically a moment from ready.
+func promptStalled(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "agent_prompt_stalled")
+}
+
+// waitInteractiveReady blocks until herdr reports the agent's TUI is listening
+// for input, or the budget expires. agent_status "idle" is reached before the
+// input prompt accepts keystrokes, so gating delivery on idle alone is what
+// lets a startup prompt land in the swallow window. Best-effort: a boot that
+// never reports ready still returns, and the caller delivers anyway (no worse
+// than not waiting).
+func (c *client) waitInteractiveReady(ctx context.Context, target string, budget time.Duration) {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if info, ok, err := c.getAgent(ctx, target); err == nil && ok && info.InteractiveReady {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interactiveReadyPoll):
+		}
+	}
+}
+
+const (
+	// promptConfirmTimeout bounds herdr's --wait confirmation of one submit.
+	// herdr requires the post-submit state change within 5s, so this only needs
+	// to cover that plus CLI overhead.
+	promptConfirmTimeout = 10 * time.Second
+	// interactiveReadyPoll is the gap between interactive_ready probes.
+	interactiveReadyPoll = 250 * time.Millisecond
+)
 
 // listAgents → `herdr agent list`.
 func (c *client) listAgents(ctx context.Context) ([]agentInfo, error) {
@@ -252,9 +298,28 @@ func (c *client) paneRun(ctx context.Context, paneID, command string) error {
 // shells) fall back to paste + Enter: there is no TUI prompt machinery to
 // confirm against, so delivery is best-effort by construction.
 func (c *client) deliverNudge(ctx context.Context, paneID, text string) error {
-	err := c.agentPrompt(ctx, paneID, text)
-	if err == nil {
-		return nil
+	// A submit delivered before the TUI is listening is swallowed, so wait for
+	// herdr to report input-readiness first, then let --wait confirm each
+	// attempt. A stall means the prompt never took: retry rather than report a
+	// success that strands the turn.
+	c.waitInteractiveReady(ctx, paneID, interactiveReadyBudget)
+	var err error
+	for attempt := 0; attempt < promptMaxAttempts; attempt++ {
+		err = c.agentPrompt(ctx, paneID, text)
+		if err == nil {
+			return nil
+		}
+		if !promptStalled(err) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interactiveReadyPoll):
+		}
+	}
+	if promptStalled(err) {
+		return fmt.Errorf("herdr deliverNudge: submit not confirmed for pane %s after %d attempts: %w", paneID, promptMaxAttempts, err)
 	}
 	if !strings.Contains(err.Error(), "not_found") && !strings.Contains(err.Error(), "not found") {
 		return err
@@ -266,6 +331,15 @@ func (c *client) deliverNudge(ctx context.Context, paneID, text string) error {
 	time.Sleep(submitSettleDelay)
 	return c.sendKeys(ctx, paneID, "Enter")
 }
+
+const (
+	// interactiveReadyBudget bounds the pre-delivery wait for the TUI to accept
+	// input. Sized to cover a cold claude boot under concurrent restart load;
+	// it only bites when readiness never arrives, after which delivery proceeds.
+	interactiveReadyBudget = 60 * time.Second
+	// promptMaxAttempts bounds retries of a stalled (swallowed) submit.
+	promptMaxAttempts = 5
+)
 
 // submitSettleDelay is how long the unregistered-pane fallback waits for a
 // `pane run` paste to commit before the submit Enter (a submit racing the

--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -324,13 +324,25 @@ func (c *client) deliverNudge(ctx context.Context, paneID, text string) error {
 	// attempt. A stall means the prompt never took: retry rather than report a
 	// success that strands the turn.
 	c.waitInteractiveReady(ctx, paneID, interactiveReadyBudget)
+	probe := lastNonEmptyLine(text)
 	var err error
 	for attempt := 0; attempt < promptMaxAttempts; attempt++ {
 		err = c.agentPrompt(ctx, paneID, text)
 		if err == nil {
-			return nil
-		}
-		if !promptStalled(err) {
+			// --wait reporting success is not proof the submit landed: it "does
+			// not track turns", so a prompt delivered while the agent is already
+			// working (a freshly launched agent running its SessionStart prime,
+			// say) can match *that* turn's completion and return success with the
+			// text still typed-but-unsubmitted. Confirm against the screen, which
+			// cannot be fooled that way, and re-submit if it is still sitting there.
+			if c.inputSettled(ctx, paneID, probe) {
+				return nil
+			}
+			if serr := c.sendKeys(ctx, paneID, "Enter"); serr == nil && c.inputSettled(ctx, paneID, probe) {
+				return nil
+			}
+			err = fmt.Errorf("herdr agent prompt reported success but the text is still in the input")
+		} else if !promptStalled(err) {
 			break
 		}
 		select {
@@ -338,6 +350,9 @@ func (c *client) deliverNudge(ctx context.Context, paneID, text string) error {
 			return ctx.Err()
 		case <-time.After(interactiveReadyPoll):
 		}
+	}
+	if err != nil && strings.Contains(err.Error(), "still in the input") {
+		return fmt.Errorf("herdr deliverNudge: submit not confirmed for pane %s after %d attempts: %w", paneID, promptMaxAttempts, err)
 	}
 	if promptStalled(err) {
 		return fmt.Errorf("herdr deliverNudge: submit not confirmed for pane %s after %d attempts: %w", paneID, promptMaxAttempts, err)
@@ -392,6 +407,25 @@ func (c *client) pasteAndConfirmSubmit(ctx context.Context, paneID, text string)
 	}
 	return fmt.Errorf("herdr deliverNudge: pane %s still shows the nudge unsubmitted after %d attempts; last input: %q",
 		paneID, promptMaxAttempts, lastInput)
+}
+
+// inputSettled reports whether probe has left the pane's input area, i.e. the
+// submit landed. A read failure counts as settled: the submit was issued and an
+// unverifiable read must not spin the caller.
+func (c *client) inputSettled(ctx context.Context, paneID, probe string) bool {
+	if probe == "" {
+		return true
+	}
+	select {
+	case <-ctx.Done():
+		return true
+	case <-time.After(submitSettleDelay):
+	}
+	screen, err := c.paneRead(ctx, paneID, "visible", inputProbeLines)
+	if err != nil {
+		return true
+	}
+	return !strings.Contains(tailLines(screen, inputProbeLines), probe)
 }
 
 // lastNonEmptyLine returns the final non-blank line of s, trimmed — the part of

--- a/internal/runtime/herdr/deliver_startup_live_test.go
+++ b/internal/runtime/herdr/deliver_startup_live_test.go
@@ -87,3 +87,57 @@ func TestDeliverNudgeSurvivesStartupRace(t *testing.T) {
 // turnCompletionBudget bounds the wait for the startup turn to finish. It is a
 // safety deadline, not the expected duration (TESTING.md deadline rule).
 const turnCompletionBudget = 120 * time.Second
+
+// TestDeliverNudgeConfirmsSubmitOnUnregisteredPane covers the other half of
+// delivery: a pane herdr has not classified as an agent (a raw `exec /bin/sh
+// -c` session, a bare shell, or an agent still mid-registration — ephemeral
+// wisps spend a window there). That path cannot use `agent prompt`, and firing
+// a single Enter without confirming leaves the text pasted-but-unsubmitted,
+// which is the same stranded-turn defect with a human required to press Enter.
+//
+// This is a guard, not a reproduction: it passes against the unconfirmed path
+// too, because a bare shell commits a paste immediately and has no TUI
+// paste/submit race to lose. The stranding was observed in practice on panes
+// mid-registration, which is inherently timing-dependent; what this pins is
+// that confirming the submit does not break ordinary delivery.
+//
+// Live: needs herdr ≥0.7.5. Skipped in -short.
+func TestDeliverNudgeConfirmsSubmitOnUnregisteredPane(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live herdr test in -short mode")
+	}
+	if _, err := exec.LookPath("herdr"); err != nil {
+		t.Skip("herdr not installed")
+	}
+
+	session := fmt.Sprintf("gctest-fallback-%d", time.Now().UnixNano()%100000)
+	c := newClient(session, t.TempDir())
+	if err := c.startServer(); err != nil {
+		t.Fatalf("startServer: %v", err)
+	}
+	t.Cleanup(func() { _ = c.stopServer() })
+
+	ctx := context.Background()
+	wsID, _, pane, err := c.workspaceCreate(ctx, "fallback-probe", t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("workspaceCreate: %v", err)
+	}
+	if wsID == "" || pane == "" {
+		t.Fatalf("workspaceCreate returned empty ids: workspace=%q pane=%q", wsID, pane)
+	}
+
+	// The pane holds a bare shell: herdr registers no agent for it, so delivery
+	// takes the paste+confirm path. Proof of submission is the command's output,
+	// which only exists if the shell actually ran it.
+	const marker = "FALLBACK_SUBMITTED_OK"
+	if err := c.deliverNudge(ctx, pane, "echo "+marker+"_DONE"); err != nil {
+		t.Fatalf("deliverNudge on an unregistered pane never confirmed: %v", err)
+	}
+	screen, err := c.paneRead(ctx, pane, "visible", 40)
+	if err != nil {
+		t.Fatalf("paneRead: %v", err)
+	}
+	if !strings.Contains(screen, marker+"_DONE") {
+		t.Fatalf("nudge was not submitted (no command output); screen:\n%s", screen)
+	}
+}

--- a/internal/runtime/herdr/deliver_startup_live_test.go
+++ b/internal/runtime/herdr/deliver_startup_live_test.go
@@ -1,0 +1,89 @@
+package herdr
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDeliverNudgeSurvivesStartupRace is the regression for the swallowed
+// startup prompt: delivering to a freshly-launched agent, before its TUI is
+// listening, must still result in a submitted turn.
+//
+// Bare `agent prompt` reports success on a swallowed submit, so the failure is
+// silent — the agent idles forever with work it never began. deliverNudge now
+// waits for interactive_ready and lets herdr's --wait confirm each attempt,
+// retrying a stall.
+//
+// Against the unfixed path this fails at whichever race it loses first: the
+// agent is not registered yet (agent_not_found) or the submit is swallowed and
+// no turn ever runs. Both are the same defect — delivering before the TUI is
+// listening — and both are what the readiness wait plus --wait confirmation fix.
+//
+// Live: needs herdr ≥0.7.5 and claude. Skipped in -short.
+func TestDeliverNudgeSurvivesStartupRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live herdr test in -short mode")
+	}
+	if _, err := exec.LookPath("herdr"); err != nil {
+		t.Skip("herdr not installed")
+	}
+	if _, err := exec.LookPath("claude"); err != nil {
+		t.Skip("claude not installed")
+	}
+
+	session := fmt.Sprintf("gctest-startup-%d", time.Now().UnixNano()%100000)
+	c := newClient(session, t.TempDir())
+	if err := c.startServer(); err != nil {
+		t.Fatalf("startServer: %v", err)
+	}
+	t.Cleanup(func() { _ = c.stopServer() })
+
+	ctx := context.Background()
+	// Place a pane and launch an agent into it, then deliver immediately —
+	// the exact ordering Start uses, which is what loses the race.
+	wsID, _, pane, err := c.workspaceCreate(ctx, "startup-probe", t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("workspaceCreate: %v", err)
+	}
+	if wsID == "" || pane == "" {
+		t.Fatalf("workspaceCreate returned empty ids: workspace=%q pane=%q", wsID, pane)
+	}
+	if err := c.paneRun(ctx, pane, "claude"); err != nil {
+		t.Fatalf("paneRun(claude): %v", err)
+	}
+
+	// The proof must be the agent's ANSWER, never the echoed prompt: a
+	// swallowed submit still leaves the prompt text visible in the input, so
+	// matching any token from the prompt passes even when nothing ran. Ask for
+	// a value that appears only once the model has actually replied.
+	const answer = "8686"
+	if err := c.deliverNudge(ctx, pane, "What is 4343 times 2? Reply with only the number."); err != nil {
+		t.Fatalf("deliverNudge raced the boot and never confirmed: %v", err)
+	}
+
+	// Confirm the turn actually ran, not merely that delivery returned nil.
+	// deliverNudge's --wait already established that the submit moved the agent
+	// off idle, so wait on herdr's own completion signal for that turn to finish
+	// rather than polling the screen (TESTING.md: wait for facts, not elapsed
+	// time), then read once.
+	if _, err := c.run(ctx, "agent", "wait", pane, "--until", "idle",
+		"--timeout", strconv.Itoa(int(turnCompletionBudget/time.Millisecond))); err != nil {
+		t.Fatalf("agent never returned to idle after the startup nudge: %v", err)
+	}
+	screen, err := c.paneRead(ctx, pane, "visible", 40)
+	if err != nil {
+		t.Fatalf("paneRead: %v", err)
+	}
+	if !strings.Contains(screen, answer) {
+		t.Fatalf("startup nudge never produced a turn (no %q in screen); screen:\n%s", answer, screen)
+	}
+}
+
+// turnCompletionBudget bounds the wait for the startup turn to finish. It is a
+// safety deadline, not the expected duration (TESTING.md deadline rule).
+const turnCompletionBudget = 120 * time.Second


### PR DESCRIPTION
## Summary

A prompt delivered before an agent's TUI is listening is silently swallowed. Bare
`herdr agent prompt` reports success anyway, so `deliverNudge` returns nil while the
turn never runs — the agent idles forever with work it never began, and nothing
surfaces an error. On a live city this strands the mayor's startup prime and every
pool slot's claim nudge.

herdr already exposes both halves of the answer, and neither was being used:

- **`agentInfo.interactive_ready`** reports that the TUI accepts input.
  `agent_status: "idle"` is reached *earlier*, so gating delivery on idle alone lands
  prompts inside the swallow window.
- **`agent prompt --wait`** requires an observed state change after submission and
  returns `agent_prompt_stalled` otherwise — herdr's own confirmation that the submit
  landed (`state_change_seq` moved).

`deliverNudge` now waits for `interactive_ready`, passes `--wait` so herdr confirms each
submit, and retries a stall instead of reporting success.

The same unconfirmed delivery existed on the other branch of `deliverNudge`: panes with no
registered agent (raw `exec` sessions, bare shells, and agents still mid-registration —
ephemeral wisps spend a window there) pasted the text, slept, and fired a single Enter
without checking it landed. That path now confirms by the only signal such a pane exposes:
after submitting, re-read the pane and require the text to have left the input, retrying
the Enter and erroring with the last observed input otherwise.

Confirmation cannot rest on `--wait`'s return value either. herdr documents that it "does
not track turns", so a prompt delivered while the agent is already working — a freshly
launched agent running its SessionStart prime, typically — can match *that* turn's
completion and return success while the text sits typed-but-unsubmitted. This was observed
on a live city after the first two commits: a worker's first message stayed in the input
until a human pressed Enter, with nothing logged anywhere because the CLI reported success.
Waiting for a settled state narrows the window but cannot close it (the agent can begin
working in the gap), so each prompt is now confirmed against the pane — the text must have
left the input — with one re-submit before failing.

Two supporting fixes fell out of that:

- **Do not deliver into an in-flight turn.** herdr's `--wait` "does not track turns", so
  prompting a working agent can match *that* turn's completion and report a spurious
  timeout. Delivery now waits for a settled state first.
- **Do not pay the readiness budget on panes that have no agent.** The wait gives up after
  a short registration grace, so a bare-shell pane reaches paste+confirm in seconds rather
  than after the full 60s (measured: 61s → 11s on the fallback test).

This is a regression on recently-merged code: #4691 replaced the previous closed-loop
confirm (paste → Enter → verify the agent left idle → retry) with a single
fire-and-forget `agentPrompt`. The race itself is older — the 0.7.1-era `deliverNudge`
comments describe the identical "missed startup-nudge stall" and record that open-loop
delivery was not enough. Using herdr's native confirmation is simpler than restoring a
hand-rolled loop.

Repro against herdr 0.7.5, racing the TUI boot exactly as `Start` does:

```
$ herdr agent prompt w1:p1 'reply with exactly: WAIT_OK' --wait --timeout 10000
{"error":{"code":"agent_prompt_stalled","message":"agent prompt produced no observed
 state change within 5000 ms; status is idle and state_change_seq remained 1"}}
```

Screen after: empty `❯`, nothing submitted. Without `--wait` the same call reports success.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed — see note

Notes:

- New live regression test `TestDeliverNudgeSurvivesStartupRace` (skipped in `-short`
  and without `herdr`/`claude`): **fails on unmodified `main`**, passes with the fix.
- `TestDeliverNudgeConfirmsSubmitOnUnregisteredPane` covers the fallback path. Stated
  plainly in the test: it is a **guard, not a reproduction** — it passes against the
  unconfirmed path too, because a bare shell commits a paste immediately and has no TUI
  submit race to lose. The stranding was observed in practice on panes mid-registration
  and is timing-dependent; what the test pins is that confirming the submit does not break
  ordinary delivery.
- It asserts on the agent's *answer*, never the prompt text — a swallowed submit still
  leaves the prompt visible in the input, so matching prompt text passes vacuously on
  the unfixed path.
- It waits on herdr's completion signal (`agent wait --until idle`) rather than sleeping,
  per TESTING.md's "wait for facts, not elapsed time" and the `fixed_sleep` ledger.
- Verified on a live 8-rig city on herdr 0.7.5: mayor and dispatched agents now run their
  first turn (`status=working`) instead of idling with an unsubmitted prompt.
- `internal/runtime/herdr` passes under `-tags integration` (159s), live tests included.
- **`make test-integration` does not pass end-to-end on my machine**, for reasons that are
  not related to this change: the `test/integration` package alone exceeds the 30m
  per-package budget on this host and dies with `panic: test timed out after 30m0s`. It is
  not a hang — the panic reports a single test running for only 1m2s when the alarm fired,
  i.e. the package was still working through its ~156 tests. That suite also never
  exercises this code: `grep -rl herdr test/integration/` returns nothing, and those cities
  run on the `subprocess` provider, so the changed delivery path is never invoked there.
  Flagging it rather than claiming a green run. Happy to rerun anything specific.
- Pre-existing on `main`, unrelated to this change (each verified to fail identically on
  an unmodified checkout): five `./scripts/` failures (`TestGoTestObservable*`,
  `TestGoTestShardTiming*`, `TestCmdGCProcessTimingEnvCrossesMakeIsolation`) and five
  `internal/runtime/k8s` failures (`TestSessionScriptStart*`).

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No issue filed: this is a regression in merged code (#4691) found while running a city on
herdr 0.7.5, and the repro is inline above. No behavior change for callers beyond delivery
now failing loudly instead of silently; no config, schema, or docs surface is touched.