### PR TITLE
fix(gc): stop bd's dolt-unreachable message from suggesting a conflicting bd dolt start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--json` envelope gained an `unregistered` field reporting whether this
   stop also removed the supervisor registration (gastownhall/gascity#4366).
 
+- **`gc bd` no longer lets bd's own error message steer operators into a
+  Dolt-server conflict.** When the managed Dolt server is unreachable, bd
+  (with `dolt.auto-start: false`, which gc always sets) tells the operator
+  to run `bd dolt start` — but that starts a second, unmanaged Dolt server
+  that fights gc's own managed server for the same data directory. `gc bd`
+  now detects that suggestion in bd's stderr and appends a corrective hint
+  pointing at the actual remedy (`gc start` / `gc dolt restart`) alongside
+  bd's original output, without altering bd's own exit code
+  (gastownhall/gascity#1374).
+
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that fights gc's own managed server for the same data directory. `gc bd`
   now detects that suggestion in bd's stderr and appends a corrective hint
   pointing at the actual remedy (`gc start` / `gc dolt restart`) alongside
-  bd's original output, without altering bd's own exit code
+  bd's original output, without altering bd's own exit code. The hint fires
+  only for gc-managed Dolt endpoints, whose lifecycle gc owns; externally
+  bound or explicitly configured endpoints keep bd's own output unchanged
   (gastownhall/gascity#1374).
 
 - **ACP activity is now available across process boundaries.** ACP

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1127,6 +1127,28 @@ func bdOutputSuggestsConflictingDoltStart(s string) bool {
 		strings.Contains(lower, bdDoltStartSuggestionMarkerCommand)
 }
 
+// bdScopeDoltIsGcManaged reports whether the corrective `gc start` /
+// `gc dolt restart` hint applies to this scope. gc owns the Dolt
+// lifecycle only for a managed, local endpoint: an externally-bound
+// store, or an explicit/city-canonical endpoint (which resolves
+// External even on 127.0.0.1), is not gc's to restart, and pointing the
+// operator at gc lifecycle commands there sends them at the wrong
+// remedy. Mirrors the ownership predicate managedBDRecoveryAllowed
+// applies. Fails closed — no hint — when ownership cannot be resolved.
+func bdScopeDoltIsGcManaged(cityPath, scopeRoot string) bool {
+	if scopeRoot == "" {
+		scopeRoot = cityPath
+	}
+	if bound, err := scopeStoreIsExternallyBound(cityPath, scopeRoot); err != nil || bound {
+		return false
+	}
+	target, ok, err := canonicalScopeDoltTarget(cityPath, scopeRoot)
+	if err != nil || !ok {
+		return false
+	}
+	return !target.External && managedLocalDoltHost(target.Host)
+}
+
 func bdCommandRunnerWithManagedRetry(cityPath string, envFn func(dir string) map[string]string) beads.CommandRunner {
 	return bdCommandRunnerWithManagedRetryErr(cityPath, func(dir string) (map[string]string, error) {
 		return envFn(dir), nil

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1101,6 +1101,32 @@ func bdOutputIndicatesSilentFallback(s string) bool {
 		strings.Contains(lower, bdSilentFallbackMarkerEmptyDB)
 }
 
+// bdDoltStartSuggestionMarkerAutoStart and bdDoltStartSuggestionMarkerCommand
+// are the substring pair bd emits when the managed Dolt server is
+// unreachable and dolt.auto-start is disabled: bd suggests running
+// `bd dolt start` to recover. In a gc-managed city (gc always sets
+// dolt.auto-start: false) that suggestion is actively harmful — it starts a
+// second, unmanaged Dolt server that fights gc's own server for the same
+// data directory (gastownhall/gascity#1374). Load-bearing only in
+// bdOutputSuggestsConflictingDoltStart; if bd's banner wording ever
+// changes, this is the only edit site.
+const (
+	bdDoltStartSuggestionMarkerAutoStart = "auto-start is disabled"
+	bdDoltStartSuggestionMarkerCommand   = "bd dolt start"
+)
+
+// bdOutputSuggestsConflictingDoltStart reports whether the given bd output
+// (typically captured stderr) contains the marker pair bd emits when it
+// tells the operator to run `bd dolt start` because managed auto-start is
+// disabled. Requiring both markers (rather than the command substring
+// alone) avoids a false positive on unrelated mentions of "bd dolt start",
+// e.g. in bd's own --help text.
+func bdOutputSuggestsConflictingDoltStart(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, bdDoltStartSuggestionMarkerAutoStart) &&
+		strings.Contains(lower, bdDoltStartSuggestionMarkerCommand)
+}
+
 func bdCommandRunnerWithManagedRetry(cityPath string, envFn func(dir string) map[string]string) beads.CommandRunner {
 	return bdCommandRunnerWithManagedRetryErr(cityPath, func(dir string) (map[string]string, error) {
 		return envFn(dir), nil

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -430,7 +430,8 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 
 	if runErr != nil {
 		if traceExit > 0 {
-			if bdOutputSuggestsConflictingDoltStart(stderrScan.String()) {
+			if bdOutputSuggestsConflictingDoltStart(stderrScan.String()) &&
+				bdScopeDoltIsGcManaged(cityPath, target.ScopeRoot) {
 				fmt.Fprintln(stderr, bdDoltStartConflictUserMessage) //nolint:errcheck // best-effort stderr
 			}
 			return traceExit

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -41,6 +41,14 @@ const bdSilentFallbackExitCode = 4
 
 const bdSilentFallbackUserMessage = "gc bd: managed Dolt unreachable; bd fell back to on-disk auto-import mode. If this command wrote data, that write was NOT persisted. Restart the managed Dolt server (or check connectivity) and retry. (See gastownhall/gascity#2080.)"
 
+// bdDoltStartConflictUserMessage is appended (bd's own output is left
+// intact) when bd's error output suggests running `bd dolt start` to
+// recover from an unreachable managed Dolt server. That command starts a
+// second, unmanaged Dolt server that conflicts with gc's own managed server
+// on the same data directory, so gc bd points at the gc-managed remedy
+// instead. See gastownhall/gascity#1374.
+const bdDoltStartConflictUserMessage = "gc bd: bd suggested \"bd dolt start\" to recover, but that starts a second, unmanaged Dolt server that will conflict with gc's managed server on the same data directory. Run \"gc start\" (or \"gc dolt restart\") to restart the managed Dolt server instead, then retry. (See gastownhall/gascity#1374.)"
+
 // bdStderrScanLimit caps how much of bd's stderr gc retains to scan for the
 // silent-fallback marker. bd emits the marker pair while opening the store —
 // before it runs the subcommand — so the marker, when present, always lands
@@ -422,6 +430,9 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 
 	if runErr != nil {
 		if traceExit > 0 {
+			if bdOutputSuggestsConflictingDoltStart(stderrScan.String()) {
+				fmt.Fprintln(stderr, bdDoltStartConflictUserMessage) //nolint:errcheck // best-effort stderr
+			}
 			return traceExit
 		}
 		fmt.Fprintf(stderr, "gc bd: %v\n", runErr) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1791,6 +1791,54 @@ name = "demo"
 	t.Setenv("GC_DOLT_PORT", port)
 }
 
+// managedDoltTestSetup is silentFallbackTestSetup for a Dolt endpoint gc
+// actually manages. The difference is the scope config: managed_city origin
+// with no explicit dolt.host/dolt.port, so the endpoint resolves from the
+// managed runtime state writeReachableManagedDoltState wrote and reports
+// External=false. silentFallbackTestSetup's city_canonical + explicit
+// host/port shape resolves External=true even on 127.0.0.1, which is a
+// server gc does not own.
+func managedDoltTestSetup(t *testing.T, fakeBdScript string) {
+	t.Helper()
+
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	t.Cleanup(func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	})
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	port := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "issue_prefix: demo\n" +
+		"gc.endpoint_origin: managed_city\n" +
+		"gc.endpoint_status: verified\n" +
+		"dolt.auto-start: false\n"
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_DOLT_PORT", port)
+}
+
 // TestGcBdSurfacesSilentFallbackAsLoudError_UpdatePath pins the #2080 fix:
 // when bd's update path silently falls back to the on-disk store, gc bd must
 // convert that into a non-zero exit with an operator-facing message instead
@@ -1933,9 +1981,11 @@ exit 1
 // append a corrective hint pointing at the gc-managed remedy instead,
 // because following bd's own suggestion starts a second, unmanaged Dolt
 // server that conflicts with gc's on the same data directory. bd's original
-// output and exit code must still pass through unchanged.
+// output and exit code must still pass through unchanged. The scope is a
+// gc-managed endpoint — the only topology where gc's own lifecycle commands
+// are the remedy.
 func TestGcBdSurfacesDoltStartConflictHint(t *testing.T) {
-	silentFallbackTestSetup(t, doltStartConflictFakeBdScript)
+	managedDoltTestSetup(t, doltStartConflictFakeBdScript)
 
 	var stdout, stderr bytes.Buffer
 	got := doBd([]string{"list"}, &stdout, &stderr)
@@ -1947,6 +1997,30 @@ func TestGcBdSurfacesDoltStartConflictHint(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "gc start") {
 		t.Fatalf("stderr missing corrective hint toward the gc-managed remedy; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdNoDoltStartConflictHintOnExternalEndpoint pins the ownership gate:
+// gc bd disables bd's auto-start for every endpoint, so an unreachable
+// external endpoint emits the same "run bd dolt start" banner. gc does not
+// own that server, so `gc start` / `gc dolt restart` cannot recover it and
+// the hint must stay silent — bd's own output and exit code are the whole
+// answer there. silentFallbackTestSetup's city_canonical + explicit
+// host/port config is exactly that topology (External=true even though the
+// host is 127.0.0.1).
+func TestGcBdNoDoltStartConflictHintOnExternalEndpoint(t *testing.T) {
+	silentFallbackTestSetup(t, doltStartConflictFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"list"}, &stdout, &stderr)
+	if got != 1 {
+		t.Fatalf("doBd(list) = %d, want 1 (bd's own exit code preserved); stderr=%q", got, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "bd dolt start") {
+		t.Fatalf("original bd stderr not passed through; stderr=%q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "gc start") {
+		t.Fatalf("corrective hint fired for an endpoint gc does not manage; stderr=%q", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1915,6 +1915,89 @@ exit 3
 	}
 }
 
+// doltStartConflictFakeBdScript emits bd's real "managed Dolt unreachable,
+// start it yourself" banner (gastownhall/gascity#1374) and exits 1, the way
+// bd behaves when dolt.auto-start is disabled (as gc always sets it in a
+// managed city) and the managed server has gone down.
+const doltStartConflictFakeBdScript = `#!/bin/sh
+echo "Dolt server unreachable at 127.0.0.1:0: dial tcp 127.0.0.1:0: connect: can't assign requested address" >&2
+echo "" >&2
+echo "Dolt server auto-start is disabled (dolt.auto-start: false)." >&2
+echo "Start the server manually:" >&2
+echo "  bd dolt start" >&2
+exit 1
+`
+
+// TestGcBdSurfacesDoltStartConflictHint pins the #1374 fix: when bd's own
+// error output suggests running "bd dolt start" to recover, gc bd must
+// append a corrective hint pointing at the gc-managed remedy instead,
+// because following bd's own suggestion starts a second, unmanaged Dolt
+// server that conflicts with gc's on the same data directory. bd's original
+// output and exit code must still pass through unchanged.
+func TestGcBdSurfacesDoltStartConflictHint(t *testing.T) {
+	silentFallbackTestSetup(t, doltStartConflictFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"list"}, &stdout, &stderr)
+	if got != 1 {
+		t.Fatalf("doBd(list) = %d, want 1 (bd's own exit code preserved); stderr=%q", got, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "bd dolt start") {
+		t.Fatalf("original bd stderr not passed through; stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gc start") {
+		t.Fatalf("stderr missing corrective hint toward the gc-managed remedy; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdNoDoltStartConflictHintOnUnrelatedError guards against a false
+// positive: a plain bd usage error that happens to share no wording with
+// the "bd dolt start" banner must not trigger the corrective hint.
+func TestGcBdNoDoltStartConflictHintOnUnrelatedError(t *testing.T) {
+	const bdRejectsScript = `#!/bin/sh
+echo "bd: simulated usage error" >&2
+exit 3
+`
+	silentFallbackTestSetup(t, bdRejectsScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"list"}, &stdout, &stderr)
+	if got != 3 {
+		t.Fatalf("doBd(list) = %d, want 3 (bd's own exit code preserved); stderr=%q", got, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "gc start") {
+		t.Fatalf("corrective hint fired on an unrelated bd error; stderr=%q", stderr.String())
+	}
+}
+
+// TestBdOutputSuggestsConflictingDoltStart covers the marker-detection
+// helper directly with table-driven cases so the source-of-truth for what
+// counts as "bd suggested a conflicting bd dolt start" is unit-pinned.
+func TestBdOutputSuggestsConflictingDoltStart(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"single marker only auto-start-disabled", "Dolt server auto-start is disabled (dolt.auto-start: false).", false},
+		{"single marker only bd dolt start", "  bd dolt start", false},
+		{"both markers, real bd banner", "Dolt server unreachable at 127.0.0.1:0: dial tcp 127.0.0.1:0: connect: can't assign requested address\n\nDolt server auto-start is disabled (dolt.auto-start: false).\nStart the server manually:\n  bd dolt start\n", true},
+		{"both markers same line", "auto-start is disabled, run bd dolt start", true},
+		{"case insensitive", "DOLT SERVER AUTO-START IS DISABLED. RUN: BD DOLT START", true},
+		{"unrelated transport error", "dial tcp 127.0.0.1:3306: connect: connection refused", false},
+		{"unrelated usage error", "bd: simulated usage error", false},
+		{"bd dolt start mentioned without disabled marker", "see 'bd dolt start --help' for standalone usage", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bdOutputSuggestsConflictingDoltStart(tt.input); got != tt.want {
+				t.Errorf("bdOutputSuggestsConflictingDoltStart(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestBdOutputIndicatesSilentFallback covers the marker-detection helper
 // directly with table-driven cases so the source-of-truth for what counts
 // as "silent fallback" is unit-pinned.


### PR DESCRIPTION
## Summary
- Fixes #1374: when gc's managed Dolt server is unreachable, bd (always run by gc with `dolt.auto-start: false`) tells the operator to run `bd dolt start` to recover — but that starts a second, unmanaged Dolt server that fights gc's own managed server for the same data directory, making the outage worse.
- `gc bd` already scans bd's stderr for one known marker pattern (the silent-fallback banner, from the #2079/#2080 fix). This adds a second marker pair for bd's auto-start-disabled suggestion; on a non-zero bd exit, `gc bd` now appends a corrective hint pointing at the actual remedy (`gc start` / `gc dolt restart`) alongside bd's original output, without touching bd's own exit code.

## Test plan
- [x] TDD red→green confirmed
- [x] `go vet ./cmd/gc/...` clean
- [x] Targeted `go test ./cmd/gc/... -run "Bd|Dolt"` green
- [x] New table-driven detector test + two integration tests via fake-bd-script harness (hint fires on the real bd banner, hint does NOT fire on an unrelated bd error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)