### PR TITLE
fix(gc): document and JSON-report gc stop's supervisor unregister behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is invisible to it regardless of name, while vendor/testdata (tracked or
   not) stay excluded as before. (gascity#4479)
 
+- **`gc stop --help` and `gc stop --json` now state what actually happens to
+  a supervisor-managed city's registration.** `gc stop` has always
+  unregistered a supervisor-managed city as part of stopping it, but neither
+  the CLI help nor the `--json` output said so — a user reading "Stop all
+  agent sessions in the city" reasonably expected `gc start` to find the
+  city again later. Help text now documents the unregister behavior and
+  points at `gc register`/`gc unregister` for the split operations; the
+  `--json` envelope gained an `unregistered` field reporting whether this
+  stop also removed the supervisor registration (gastownhall/gascity#4366).
+
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -133,8 +133,9 @@ func cmdStopJSONSequence(args []string, stdout, stderr io.Writer, force bool, js
 
 	stopLoadedCity := func() stopCommandOutcome {
 		return stopCommandOutcome{
-			code:     cmdStopBodyWithoutSuccess(cityPath, cfg, force, stopStdout, stderr),
-			cityPath: cityPath,
+			code:         cmdStopBodyWithoutSuccess(cityPath, cfg, force, stopStdout, stderr),
+			cityPath:     cityPath,
+			unregistered: unregisteredFromSupervisor,
 		}
 	}
 	if wallClockCapApplied {

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -31,6 +31,12 @@ shutdown timeout, then force-kills any remaining sessions. Also stops
 the Dolt server and cleans up orphan sessions. If a controller is
 running, delegates shutdown to it.
 
+If the city is registered with the machine-wide supervisor, stop also
+unregisters it (equivalent to a following "gc unregister") — the city
+will not be found by name or auto-started again until it is re-registered
+with "gc register". Use "gc unregister" directly to remove a registration
+without stopping sessions.
+
 Use --timeout=DURATION to cap the wall-clock time gc stop will spend
 before giving up; the default budgets configured session interrupt and
 stop waves, the configured shutdown grace wait, and a second orphan
@@ -65,8 +71,9 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 }
 
 type stopCommandOutcome struct {
-	code     int
-	cityPath string
+	code         int
+	cityPath     string
+	unregistered bool
 }
 
 func cmdStopJSON(args []string, stdout, stderr io.Writer, wallClockTimeout time.Duration, force bool, jsonOut bool) int {
@@ -82,7 +89,7 @@ func cmdStopJSON(args []string, stdout, stderr io.Writer, wallClockTimeout time.
 		return outcome.code
 	}
 	if jsonOut {
-		return writeCityStopSuccess(stdout, stderr, outcome.cityPath, force)
+		return writeCityStopSuccess(stdout, stderr, outcome.cityPath, force, outcome.unregistered)
 	}
 	fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
 	return 0
@@ -100,23 +107,25 @@ func cmdStopJSONSequence(args []string, stdout, stderr io.Writer, force bool, js
 		stopStdout = io.Discard
 	}
 
+	unregisteredFromSupervisor := false
 	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stopStdout, stderr, "gc stop", force); handled {
 		if code != 0 {
 			return stopCommandOutcome{code: code, cityPath: cityPath}
 		}
+		unregisteredFromSupervisor = true
 		if supervisorAliveHook() != 0 {
 			if !stopCityManagedBeadsProviderAfterSuccessfulStop(cityPath, stderr) {
 				return stopCommandOutcome{code: 1, cityPath: cityPath}
 			}
 			warnInvalidConfigAfterSuccessfulStop(cityPath, stderr)
-			return stopCommandOutcome{cityPath: cityPath}
+			return stopCommandOutcome{cityPath: cityPath, unregistered: unregisteredFromSupervisor}
 		}
 	}
 
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
 		if handled, code := stopManagedRuntimeWithoutConfig(cityPath, err, stopStdout, stderr, force); handled {
-			return stopCommandOutcome{code: code, cityPath: cityPath}
+			return stopCommandOutcome{code: code, cityPath: cityPath, unregistered: unregisteredFromSupervisor}
 		}
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return stopCommandOutcome{code: 1, cityPath: cityPath}
@@ -163,13 +172,14 @@ func runStopWithWallClockCap(wallClockCap time.Duration, stderr io.Writer, stop 
 // against a later test.
 var stopBodyLifecycleHook func(<-chan struct{})
 
-func writeCityStopSuccess(stdout, stderr io.Writer, cityPath string, force bool) int {
+func writeCityStopSuccess(stdout, stderr io.Writer, cityPath string, force, unregistered bool) int {
 	return writeLifecycleActionJSONOrExit(stdout, stderr, "gc stop", lifecycleActionJSON{
-		Command:  "stop",
-		Action:   "stop",
-		Message:  "City stopped.",
-		CityPath: cityPath,
-		Force:    lifecycleBoolPtr(force),
+		Command:      "stop",
+		Action:       "stop",
+		Message:      "City stopped.",
+		CityPath:     cityPath,
+		Force:        lifecycleBoolPtr(force),
+		Unregistered: lifecycleBoolPtr(unregistered),
 	})
 }
 

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -690,6 +690,56 @@ func TestControllerStopTimeoutUsesHostingMode(t *testing.T) {
 	}
 }
 
+// TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity pins the
+// #4366 fix: gc stop --json must report that a supervisor-managed city was
+// unregistered from the registry as part of the stop, not just that
+// sessions stopped. Reuses the invalid-city-toml scaffolding from
+// TestCmdStopSupervisorManagedInvalidCityTomlWaitsForControllerStop, the
+// simplest existing setup that reaches the supervisor-managed success path.
+func TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := filepath.Join(t.TempDir(), "invalid-supervisor-city")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\nname = \"broken\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := registryAt(t, gcHome)
+	if err := reg.Register(cityDir, "invalid-supervisor-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", true },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	waitForSupervisorControllerStopHook = func(string, time.Duration) error { return nil }
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, time.Second, false, true)
+	if code != 0 {
+		t.Fatalf("cmdStopJSON() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	var got lifecycleActionJSON
+	if err := json.Unmarshal([]byte(stdout.String()), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Unregistered == nil || !*got.Unregistered {
+		t.Fatalf("payload.Unregistered = %v, want pointer to true; payload=%+v", got.Unregistered, got)
+	}
+}
+
 func TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails(t *testing.T) {
 	resetFlags(t)
 	cityDir := setupInvalidConfigManagedRuntime(t)
@@ -1314,4 +1364,42 @@ func controllerAcceptsPing(dir string, timeout time.Duration) bool {
 	buf := make([]byte, 64)
 	n, err := conn.Read(buf)
 	return err == nil && strings.TrimSpace(string(buf[:n])) != ""
+}
+
+// TestWriteCityStopSuccessReportsUnregisteredFlag pins the #4366 JSON
+// envelope contract at the unit level: the unregistered bool passed to
+// writeCityStopSuccess must come through verbatim (not omitted, not
+// defaulted), so gc stop --json can distinguish an unmanaged-city stop from
+// one that also removed a supervisor registration.
+func TestWriteCityStopSuccessReportsUnregisteredFlag(t *testing.T) {
+	for _, unregistered := range []bool{true, false} {
+		t.Run(fmt.Sprintf("unregistered=%v", unregistered), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := writeCityStopSuccess(&stdout, &stderr, "/city", false, unregistered)
+			if code != 0 {
+				t.Fatalf("writeCityStopSuccess() = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			var got lifecycleActionJSON
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			if got.Unregistered == nil || *got.Unregistered != unregistered {
+				t.Fatalf("payload.Unregistered = %v, want pointer to %v; payload=%+v", got.Unregistered, unregistered, got)
+			}
+		})
+	}
+}
+
+// TestStopHelpDocumentsSupervisorUnregisterBehavior pins the #4366
+// help/behavior parity fix: gc stop's long help must state that it
+// unregisters a supervisor-managed city, since cmdStopJSON actually does
+// that (via unregisterCityFromSupervisorWithForce) before help readers would
+// otherwise expect from "Stop all agent sessions in the city".
+func TestStopHelpDocumentsSupervisorUnregisterBehavior(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newStopCmd(&stdout, &stderr)
+	long := strings.ToLower(cmd.Long)
+	if !strings.Contains(long, "unregister") {
+		t.Fatalf("gc stop --help does not mention unregistering a supervisor-managed city; Long=%q", cmd.Long)
+	}
 }

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -740,6 +740,73 @@ func TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity(t *testing.T
 	}
 }
 
+// TestCmdStopJSONReportsUnregisteredTrueWhenSupervisorNotRunning closes the
+// remaining #4366 branch: a registered city whose supervisor is not alive
+// falls through to the ordinary loaded-config stop, so the unregister the
+// command just performed must still be reported. The sibling
+// TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity only covers
+// the alive-supervisor early return and never reaches this path, because it
+// stubs the alive hook to a live PID and writes an invalid city.toml. Here
+// the alive hook returns 0 and city.toml is valid, so cmdStopJSONSequence
+// runs stopLoadedCity.
+func TestCmdStopJSONReportsUnregisteredTrueWhenSupervisorNotRunning(t *testing.T) {
+	resetFlags(t)
+	gcHome := shortSocketTempDir(t, "gc-home-")
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := shortSocketTempDir(t, "gc-stop-city-")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "unregistered-on-stop"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Session:   config.SessionConfig{Provider: "subprocess"},
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := registryAt(t, gcHome)
+	if err := reg.Register(cityDir, "unregistered-on-stop"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 0 },
+		func(string) (bool, string, bool) { return false, "", true },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) (runtime.Provider, error) {
+		return runtime.NewFake(), nil
+	}
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, time.Second, false, true)
+	if code != 0 {
+		t.Fatalf("cmdStopJSON() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	var got lifecycleActionJSON
+	if err := json.Unmarshal([]byte(stdout.String()), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Unregistered == nil || !*got.Unregistered {
+		t.Fatalf("payload.Unregistered = %v, want pointer to true; payload=%+v", got.Unregistered, got)
+	}
+}
+
 func TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails(t *testing.T) {
 	resetFlags(t)
 	cityDir := setupInvalidConfigManagedRuntime(t)

--- a/cmd/gc/lifecycle_action_json.go
+++ b/cmd/gc/lifecycle_action_json.go
@@ -22,8 +22,12 @@ type lifecycleActionJSON struct {
 	Force     *bool  `json:"force,omitempty"`
 	Async     *bool  `json:"async,omitempty"`
 	Soft      *bool  `json:"soft,omitempty"`
-	Outcome   string `json:"outcome,omitempty"`
-	Revision  string `json:"revision,omitempty"`
+	// Unregistered reports whether this action also removed the city's
+	// supervisor registration (gc stop unregisters a supervisor-managed
+	// city as part of stopping it; see gastownhall/gascity#4366).
+	Unregistered *bool  `json:"unregistered,omitempty"`
+	Outcome      string `json:"outcome,omitempty"`
+	Revision     string `json:"revision,omitempty"`
 }
 
 func writeLifecycleActionJSON(stdout io.Writer, payload lifecycleActionJSON) error {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4475,6 +4475,12 @@ shutdown timeout, then force-kills any remaining sessions. Also stops
 the Dolt server and cleans up orphan sessions. If a controller is
 running, delegates shutdown to it.
 
+If the city is registered with the machine-wide supervisor, stop also
+unregisters it (equivalent to a following "gc unregister") — the city
+will not be found by name or auto-started again until it is re-registered
+with "gc register". Use "gc unregister" directly to remove a registration
+without stopping sessions.
+
 Use --timeout=DURATION to cap the wall-clock time gc stop will spend
 before giving up; the default budgets configured session interrupt and
 stop waves, the configured shutdown grace wait, and a second orphan


### PR DESCRIPTION
## Summary
- Part of #4366 (Customer Zero report). Only the confirmed-on-current-main half is addressed here: `gc stop` has always unregistered a supervisor-managed city from the registry as part of stopping it, but neither `--help` nor `--json` output said so. (The plain-text path already prints an explicit "Unregistered city '<name>' (<path>)" line, so the original report's "silent" framing didn't hold on current main — the real, confirmed gap was narrower: help text and the JSON envelope.)
- The other half of #4366 (cache false-positive) is out of scope here — the issue's own triage notes point to PR #3314 as the likely upstream fix already, but say the exact historical incident can't be distinguished from a current writer without the original reporter retesting.

## Changes
- `newStopCmd`'s `Long` help now states the unregister behavior and points at `gc register`/`gc unregister` for the split operations.
- `lifecycleActionJSON` gained an `Unregistered *bool` field (same pattern as the existing `Force`/`Wait`/`Async` fields); `writeCityStopSuccess` now threads through whether this stop call also unregistered, so `gc stop --json` can distinguish an unmanaged-city stop from one that also removed the supervisor registration.

## Test plan
- [x] TDD red→green confirmed (compile-red before the field/param existed)
- [x] `go vet ./cmd/gc/...` clean
- [x] Targeted stop/suspend/register/unregister/reload/restart test subset green
- [x] 3 new tests: JSON-true integration test reusing existing supervisor-managed-invalid-toml scaffolding, a unit test on `writeCityStopSuccess` table-driving true/false, a help-text assertion
- [x] `docs/reference/cli.md` regenerated automatically with the new help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)