### PR TITLE
fix(gc): correct gc formula cook --attach help text (blocks, not parent-child)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   view, not an equivalent durable source; for durable history, query the event
   log for `store.maintenance.*` directly. (gascity#4418)
 
+- **`gc formula cook --attach`'s help text no longer claims a parent-child
+  relationship it never creates.** `--attach=<bead-id>` has only ever added
+  a `blocks` dependency from the attached bead to the sub-DAG root
+  (`ensureFormulaCookAttachDep` / `molecule.Attach` both call
+  `store.DepAdd(..., "blocks")`, never setting `ParentID`), but the long
+  help described it as creating the sub-DAG "as children of the given
+  bead." Since convoy auto-close watches parent-child children, not
+  `blocks` dependents, a user following the old description would wrongly
+  expect an attached sub-DAG's completion to trigger the attached convoy's
+  auto-close — it never does. Help text now describes the actual `blocks`
+  -only relationship and says so explicitly (gastownhall/gascity#2392).
+
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -617,11 +617,15 @@ func newFormulaCookCmd(stdout, stderr io.Writer) *cobra.Command {
 This is a low-level workflow construction tool. It creates the formula root
 and all compiled step beads without routing any work.
 
-With --attach=<bead-id>, the sub-DAG is created as children of the given
-bead. The bead gains a blocking dependency on the sub-DAG root, so it won't
-close until the sub-DAG completes. This is the core primitive for late-bound
-DAG expansion — any agent, script, or workflow step can call it to expand a
-bead into a sub-workflow at runtime.
+With --attach=<bead-id>, the given bead gains a blocking dependency on the
+sub-DAG root, so it won't close until the sub-DAG completes. This is a
+"blocks" dependency only, not a parent-child relationship — the sub-DAG
+root does not become a child of the attached bead (gc bd list --parent
+will not find it), and convoy auto-close, which watches parent-child
+children rather than blocks dependents, is not triggered by the sub-DAG
+completing. This is the core primitive for late-bound DAG expansion — any
+agent, script, or workflow step can call it to expand a bead into a
+sub-workflow at runtime.
 
 With --attach on a v2 formula — one declaring
 [requires] formula_compiler = ">=2.0.0" — the invocation runs under a

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -622,10 +622,10 @@ sub-DAG root, so it won't close until the sub-DAG completes. This is a
 "blocks" dependency only, not a parent-child relationship — the sub-DAG
 root does not become a child of the attached bead (gc bd list --parent
 will not find it), and convoy auto-close, which watches parent-child
-children rather than blocks dependents, is not triggered by the sub-DAG
-completing. This is the core primitive for late-bound DAG expansion — any
-agent, script, or workflow step can call it to expand a bead into a
-sub-workflow at runtime.
+children and "tracks" members rather than blocks dependents, is not
+triggered by the sub-DAG completing. This is the core primitive for
+late-bound DAG expansion — any agent, script, or workflow step can call it
+to expand a bead into a sub-workflow at runtime.
 
 With --attach on a v2 formula — one declaring
 [requires] formula_compiler = ">=2.0.0" — the invocation runs under a

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -1587,3 +1587,28 @@ title = "Do work for {{convoy_id}}"
 		}
 	}
 }
+
+// TestFormulaCookAttachHelpDoesNotClaimParentChild pins the #2392 fix:
+// --attach only ever creates a "blocks" dependency back to the attached
+// bead (ensureFormulaCookAttachDep / molecule.Attach both call
+// store.DepAdd(attachBeadID, rootID, "blocks"), never setting ParentID) —
+// the sub-DAG root never becomes a child of the attached bead. The help
+// text previously claimed otherwise ("created as children of the given
+// bead"), which is actionably wrong: convoy auto-close watches
+// parent-child children, not blocks dependents, so a user following the
+// old description would wrongly expect an attached sub-DAG's completion
+// to trigger the attached convoy's auto-close.
+func TestFormulaCookAttachHelpDoesNotClaimParentChild(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	long := strings.ToLower(cmd.Long)
+	if strings.Contains(long, "created as children") {
+		t.Fatalf("gc formula cook --help still claims --attach creates a parent-child relationship; Long=%q", cmd.Long)
+	}
+	if !strings.Contains(long, "blocking dependency") && !strings.Contains(long, "blocks") {
+		t.Fatalf("gc formula cook --help no longer describes the actual blocks-only relationship; Long=%q", cmd.Long)
+	}
+	if !strings.Contains(long, "not") || !strings.Contains(long, "parent") {
+		t.Fatalf("gc formula cook --help does not clarify that --attach is not a parent-child relationship; Long=%q", cmd.Long)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1682,11 +1682,15 @@ Compile and instantiate a formula as real beads in the current store.
 This is a low-level workflow construction tool. It creates the formula root
 and all compiled step beads without routing any work.
 
-With --attach=&lt;bead-id&gt;, the sub-DAG is created as children of the given
-bead. The bead gains a blocking dependency on the sub-DAG root, so it won't
-close until the sub-DAG completes. This is the core primitive for late-bound
-DAG expansion — any agent, script, or workflow step can call it to expand a
-bead into a sub-workflow at runtime.
+With --attach=&lt;bead-id&gt;, the given bead gains a blocking dependency on the
+sub-DAG root, so it won't close until the sub-DAG completes. This is a
+"blocks" dependency only, not a parent-child relationship — the sub-DAG
+root does not become a child of the attached bead (gc bd list --parent
+will not find it), and convoy auto-close, which watches parent-child
+children rather than blocks dependents, is not triggered by the sub-DAG
+completing. This is the core primitive for late-bound DAG expansion — any
+agent, script, or workflow step can call it to expand a bead into a
+sub-workflow at runtime.
 
 With --attach on a v2 formula — one declaring
 [requires] formula_compiler = "&gt;=2.0.0" — the invocation runs under a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1687,10 +1687,10 @@ sub-DAG root, so it won't close until the sub-DAG completes. This is a
 "blocks" dependency only, not a parent-child relationship — the sub-DAG
 root does not become a child of the attached bead (gc bd list --parent
 will not find it), and convoy auto-close, which watches parent-child
-children rather than blocks dependents, is not triggered by the sub-DAG
-completing. This is the core primitive for late-bound DAG expansion — any
-agent, script, or workflow step can call it to expand a bead into a
-sub-workflow at runtime.
+children and "tracks" members rather than blocks dependents, is not
+triggered by the sub-DAG completing. This is the core primitive for
+late-bound DAG expansion — any agent, script, or workflow step can call it
+to expand a bead into a sub-workflow at runtime.
 
 With --attach on a v2 formula — one declaring
 [requires] formula_compiler = "&gt;=2.0.0" — the invocation runs under a


### PR DESCRIPTION
## Summary
- Fixes #2392: `gc formula cook --attach`'s help text claims the sub-DAG is "created as children of the given bead" (a parent-child relationship). Confirmed on current main this has never been true — both code paths (`ensureFormulaCookAttachDep` for v2 formulas, `molecule.Attach` for v1) only ever call `store.DepAdd(attachBeadID, rootID, "blocks")`, never setting `ParentID`.
- This isn't cosmetic: convoy auto-close (`doConvoyAutocloseWith`) watches parent-child children, not `blocks` dependents, so a user following the old description reasonably expects an attached sub-DAG's completion to trigger the attached convoy's auto-close — it never does. Real users hit this building fan-out patterns (cook N sub-workflows, attach to a parent convoy, expect auto-close on completion).
- Scope: the issue offered two directions — (1) change the implementation to also set `ParentID`, or (2) fix the docs to match reality. Went with (2) only: changing what `--attach` does to an established primitive risks side effects on other parent-child consumers not audited here, while documenting current behavior accurately is correct regardless of which direction is eventually chosen for the underlying composability gap.

## Changes
- `cmd/gc/cmd_formula.go`: `Long` help text now explicitly says it's a `blocks`-only relationship, not parent-child, and that convoy auto-close won't fire from it.
- `cmd/gc/cmd_formula_test.go`: new `TestFormulaCookAttachHelpDoesNotClaimParentChild`.
- `docs/reference/cli.md`: auto-regenerated with the new help text.

## Test plan
- [x] TDD red→green confirmed
- [x] `go vet ./cmd/gc/...` clean
- [x] Full `TestFormulaCook*`/`TestFormula*` suite green (no regressions)
- [x] docsync regenerated `cli.md` with the new text as expected, no other diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)