### PR TITLE
feat(api): publish the bead delete endpoint's soft-delete contract in the spec

### DIFF
--- a/docs/reference/schema/openapi.json
+++ b/docs/reference/schema/openapi.json
@@ -24524,6 +24524,7 @@
     },
     "/v0/city/{cityName}/bead/{id}": {
       "delete": {
+        "description": "Closes the bead. This is a soft delete: the bead remains readable and retains its history, with status \"closed\". The API exposes no hard delete, so a caller that needs the record actually removed must not rely on this endpoint.",
         "operationId": "delete-v0-city-by-city-name-bead-by-id",
         "parameters": [
           {

--- a/docs/reference/schema/openapi.txt
+++ b/docs/reference/schema/openapi.txt
@@ -24524,6 +24524,7 @@
     },
     "/v0/city/{cityName}/bead/{id}": {
       "delete": {
+        "description": "Closes the bead. This is a soft delete: the bead remains readable and retains its history, with status \"closed\". The API exposes no hard delete, so a caller that needs the record actually removed must not rely on this endpoint.",
         "operationId": "delete-v0-city-by-city-name-bead-by-id",
         "parameters": [
           {

--- a/internal/api/city_scope.go
+++ b/internal/api/city_scope.go
@@ -137,6 +137,21 @@ func errorStatuses(codes ...int) func(o *huma.Operation) {
 	}
 }
 
+// describes sets an operation's description, so a contract a caller cannot
+// infer from the method and path is published in the spec rather than left in
+// the handler's Go doc. Generated clients and the OpenAPI document are all most
+// consumers ever see; a semantic the handler comment alone records is, in
+// practice, undocumented.
+func describes(text string) func(o *huma.Operation) {
+	return func(o *huma.Operation) {
+		if o.Description == "" {
+			o.Description = text
+			return
+		}
+		o.Description += "\n\n" + text
+	}
+}
+
 // listOrder documents a list endpoint's total order and cursor contract in
 // its operation description. Every keyset list declares its order here so
 // consumers never have to reverse-engineer it from behavior (the pre-S4

--- a/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/sdk.gen.ts
+++ b/internal/api/dashboardspa/web/shared/src/generated/gc-supervisor-client/sdk.gen.ts
@@ -157,6 +157,8 @@ export const createAgent = <ThrowOnError extends boolean = false>(options: Optio
 
 /**
  * Delete v0 city by city name bead by ID
+ *
+ * Closes the bead. This is a soft delete: the bead remains readable and retains its history, with status "closed". The API exposes no hard delete, so a caller that needs the record actually removed must not rely on this endpoint.
  */
 export const deleteV0CityByCityNameBeadById = <ThrowOnError extends boolean = false>(options: Options<DeleteV0CityByCityNameBeadByIdData, ThrowOnError>) => (options.client ?? client).delete<DeleteV0CityByCityNameBeadByIdResponses, DeleteV0CityByCityNameBeadByIdErrors, ThrowOnError>({ url: '/v0/city/{cityName}/bead/{id}', ...options });
 

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -24524,6 +24524,7 @@
     },
     "/v0/city/{cityName}/bead/{id}": {
       "delete": {
+        "description": "Closes the bead. This is a soft delete: the bead remains readable and retains its history, with status \"closed\". The API exposes no hard delete, so a caller that needs the record actually removed must not rely on this endpoint.",
         "operationId": "delete-v0-city-by-city-name-bead-by-id",
         "parameters": [
           {

--- a/internal/api/supervisor_city_routes.go
+++ b/internal/api/supervisor_city_routes.go
@@ -214,7 +214,8 @@ func (sm *SupervisorMux) registerCityRoutes() {
 	cityPost(sm, "/bead/{id}/update", (*Server).humaHandleBeadUpdate, errorStatuses(http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict))
 	cityPatch(sm, "/bead/{id}", (*Server).humaHandleBeadUpdate, errorStatuses(http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict))
 	cityPost(sm, "/bead/{id}/assign", (*Server).humaHandleBeadAssign, errorStatuses(http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict))
-	cityDelete(sm, "/bead/{id}", (*Server).humaHandleBeadDelete, errorStatuses(http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict))
+	cityDelete(sm, "/bead/{id}", (*Server).humaHandleBeadDelete, errorStatuses(http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict),
+		describes("Closes the bead. This is a soft delete: the bead remains readable and retains its history, with status \"closed\". The API exposes no hard delete, so a caller that needs the record actually removed must not rely on this endpoint."))
 
 	// Mail. Part of the P12 error-contract slice (see Beads above): each op
 	// enumerates the error statuses it can return (Huma adds auto 422/500);


### PR DESCRIPTION
## The juicy parts

`DELETE /v0/city/{cityName}/bead/{id}` is a soft delete — it closes the bead — and that was recorded only in an unexported handler's Go doc comment. The OpenAPI document and every generated client described the operation as `Delete v0 city by city name bead by ID`, with no description at all. So a consumer wiring a cleanup path onto this endpoint could watch it return `200` and leave every bead in place: closed, still readable, still returned by any query that includes closed beads. Nothing in the published contract contradicted the expectation the HTTP verb sets.

The audience is API consumers and tooling authors, not end users. This is spec/document only, with **no behaviour change** — the sole runtime effect is a string in the generated spec. Measured before the change, 14 of 166 operations carried a description and this was not one of them; the reusable `describes(...)` option added here appends rather than overwrites, so it composes with the existing `listOrder` contract.

## TL;DR

`DELETE /v0/city/{cityName}/bead/{id}` is a **soft delete** — it closes the bead. That was documented only in the handler's Go doc comment, so the OpenAPI document and every generated client described it as `Delete v0 city by city name bead by ID` with **no description at all**. This publishes the contract. Spec/document only; no behavior change.

## Why it matters

A caller who needs a bead actually removed can wire a cleanup path onto this endpoint, watch it return `200`, and leave every bead in place — closed, still readable, still returned by any query that includes closed beads. Nothing in the published contract contradicts the expectation the HTTP verb sets.

The semantics were never in doubt in the source:

```go
// humaHandleBeadDelete is the Huma-typed handler for DELETE /v0/bead/{id}.
// It is implemented as a soft-delete (store.Close) — see the `"closed"`
// status field for honest wire-contract semantics. Hard-delete is not
// exposed through the API.
```

But the handler is unexported, and the generated client and OpenAPI document are all most consumers ever see. A semantic recorded only in a handler comment is, in practice, undocumented.

Measured before this change: **14 of 166** operations carry a description, and the bead delete was not one of them.

## Behavior

```gherkin
Given a consumer reading the OpenAPI document or a generated client
When it looks up DELETE /v0/city/{cityName}/bead/{id}
Then the operation states that the bead is closed, remains readable, keeps its
     history, and that the API exposes no hard delete
```

```gherkin
Given any caller of DELETE /v0/city/{cityName}/bead/{id}
When the request is served
Then the response, status codes and stored state are exactly as before
```

```gherkin
Given an operation registered without describes(...)
When the spec is generated
Then its description is unchanged
```

## Why it's safe

- The only runtime effect is the string in the generated spec. Handler, routing, status codes and store behavior are untouched.
- `describes` appends rather than overwrites, matching `listOrder`, so composing both on one operation keeps each contract.
- Regenerated with `go run ./cmd/genspec` + `go generate ./internal/api/genclient`. The Go client did not drift — descriptions do not reach it — so the diff in generated artifacts is one line each in `internal/api/openapi.json`, `docs/reference/schema/openapi.json`, and `docs/reference/schema/openapi.txt`.
- `go vet ./internal/api/` clean; full `./internal/api/` suite green (68s), including the spec-in-sync gate.

## Related work

- #4201 — introduced `listOrder`, which documents list ordering on the operation for the same reason ("so consumers never have to reverse-engineer it from behavior"). `describes` is the general form of that idiom; `listOrder` is unchanged.
- #2536 — `gc beads close / delete` has no first-class CLI path, and turns on the same close-versus-delete distinction this endpoint blurs.

## Scope

| File | Change |
|---|---|
| `internal/api/city_scope.go` | add `describes(text)` operation option (+14) |
| `internal/api/supervisor_city_routes.go` | describe the bead delete op (+2/-1) |
| `internal/api/openapi.json`, `docs/reference/schema/openapi.{json,txt}` | regenerated (+1 each) |

