### PR TITLE
fix(t3bridge): use provider family for Codex envelope model

### DIFF
--- a/cmd/gc/template_resolve_t3bridge.go
+++ b/cmd/gc/template_resolve_t3bridge.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"strings"
+
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 func applyT3BridgeRuntimeConfig(tp TemplateParams, env map[string]string) {
@@ -121,7 +123,13 @@ func t3BridgeStartupEnvelopeModel(provider string, tp TemplateParams) string {
 	if v := tp.Env["GC_MODEL"]; v != "" {
 		return v
 	}
-	if provider == "codex" {
+	// Resolve custom-provider ancestry and aliases before selecting the Codex
+	// default. Preserve the existing Claude fallback for every other provider.
+	source := resolvedProviderLaunchFamily(tp.ResolvedProvider)
+	if source == "" {
+		source = provider
+	}
+	if sessionpkg.ProviderFamilyFromMetadata(nil, source) == "codex" {
 		return "gpt-5-codex"
 	}
 	return "claude-opus-4-6"

--- a/cmd/gc/template_resolve_test.go
+++ b/cmd/gc/template_resolve_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
 
 func TestIsOperationalScript(t *testing.T) {
 	cases := []struct {
@@ -61,7 +65,15 @@ func TestT3BridgeStartupEnvelopeModel_UsesCurrentProviderDefaults(t *testing.T) 
 		{
 			name: "codex-mini",
 			tp:   TemplateParams{Env: map[string]string{"GC_PROVIDER": "codex-mini"}},
-			want: "claude-opus-4-6",
+			want: "gpt-5-codex",
+		},
+		{
+			name: "custom provider with codex ancestor",
+			tp: TemplateParams{
+				Env:              map[string]string{"GC_PROVIDER": "speedy"},
+				ResolvedProvider: &config.ResolvedProvider{Name: "speedy", BuiltinAncestor: "codex"},
+			},
+			want: "gpt-5-codex",
 		},
 		{
 			name: "claude",


### PR DESCRIPTION
## Summary

T3Bridge selected its default startup-envelope model with an exact `provider == "codex"` check. Codex aliases such as `codex-mini`, and custom providers whose resolved builtin ancestor is Codex, therefore fell through to the Claude fallback and were stamped with `claude-opus-4-6`.

This change resolves the provider family through the existing canonical helpers before selecting the Codex default. Explicit `--model` and `GC_MODEL` values retain precedence, and the existing fallback for every non-Codex provider is unchanged.

## Testing

- Regression proof on current `main`: the new alias and Codex-derived custom-provider cases both fail with `claude-opus-4-6` before the fix.
- `go test ./cmd/gc -run '^(TestT3BridgeStartupEnvelopeModel_PrefersResolvedEnvModel|TestT3BridgeStartupEnvelopeModel_UsesCurrentProviderDefaults)$' -count=10`
- `make check`
- `LOCAL_TEST_JOBS=2 make test-cmd-gc-process-parallel`
- `LOCAL_TEST_JOBS=2 make test-integration-shards-parallel`: all 4 core, all 6 `cmd/gc`, all 3 runtime/tmux, `bdstore`, and several REST shards passed. The remaining shards failed during Beads/Dolt initialization with schema-migration errors or `bd` timeouts before exercising this change. A representative failing formula shard reproduces on untouched upstream `main` at the same Beads/Dolt setup boundary.

## Checklist

- [x] Added focused regression coverage for Codex aliases and Codex-derived custom providers.
- [x] Preserved explicit model precedence and all non-Codex fallback behavior.
- [x] No documentation change is needed; there is no new command or configuration surface.
- [x] No breaking change or migration.
