### PR TITLE
perf(api): cache orders feed by time bucket

### DIFF
--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -569,10 +569,18 @@ func (s *Server) humaHandleOrdersFeed(_ context.Context, input *OrdersFeedInput)
 	}
 
 	limit := normalizeFeedLimit(input.Limit)
-	index := s.latestIndex()
 
+	// The feed body is O(store history) to build: per rig, a full active scan
+	// plus a closed-history workflow-roots scan, and an order-tracking list
+	// that fans out into a latest-run lookup per tracked order. Key its cache
+	// entry on a time bucket, not the event index: on a busy city the index
+	// advances every tick, so the index-keyed entry missed on nearly every
+	// poll and the slow body was rebuilt per request. The endpoint has no
+	// blocking variant, so there is no strict-freshness caller to bypass (same
+	// lever as /status and /formulas/feed).
 	cacheKey := "orders-feed?" + scopeKind + "|" + scopeRef + "|" + strconv.Itoa(input.Limit)
-	if body, ok := cachedResponseAs[ordersFeedBody](s, cacheKey, index); ok {
+	bucket := responseCacheTimeBucket(time.Now())
+	if body, ok := cachedResponseAs[ordersFeedBody](s, cacheKey, bucket); ok {
 		return &struct {
 			Body ordersFeedBody
 		}{Body: body}, nil
@@ -623,7 +631,7 @@ func (s *Server) humaHandleOrdersFeed(_ context.Context, input *OrdersFeedInput)
 	body.PartialErrors = appendUniqueStrings(body.PartialErrors, workflowRuns.PartialErrors...)
 	body.PartialErrors = appendUniqueStrings(body.PartialErrors, orderRuns.PartialErrors...)
 
-	s.storeResponse(cacheKey, index, body)
+	s.storeResponse(cacheKey, bucket, body)
 
 	return &struct {
 		Body ordersFeedBody

--- a/internal/api/response_cache_test.go
+++ b/internal/api/response_cache_test.go
@@ -210,7 +210,22 @@ func TestHandleAgentListCachesUntilIndexChanges(t *testing.T) {
 	}
 }
 
-func TestHandleOrdersFeedCachesUntilIndexChanges(t *testing.T) {
+// TestHandleOrdersFeedCachesAcrossIndexChanges pins the orders feed to a
+// wall-clock TTL bucket rather than the event sequence. The feed body is
+// O(store history) to build — a full active scan plus a closed-history
+// workflow-roots scan per rig, with a latest-run lookup per tracked order — so
+// on a busy city whose sequence advances every poll, an index-keyed cache
+// missed on nearly every request and rebuilt the body each time. Recording an
+// event must NOT bust the feed cache within the TTL window, matching /status
+// and /formulas/feed.
+func TestHandleOrdersFeedCachesAcrossIndexChanges(t *testing.T) {
+	// Pin a wide TTL so every request in this test lands in the same time
+	// bucket; this isolates the "index churn must not bust the cache" property
+	// from wall-clock bucket-boundary timing.
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Hour
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
+
 	state := newFakeState(t)
 	rigStore := &countingStore{Store: beads.NewMemStore()}
 	cityStore := &countingStore{Store: beads.NewMemStore()}
@@ -256,17 +271,21 @@ func TestHandleOrdersFeedCachesUntilIndexChanges(t *testing.T) {
 		t.Fatalf("city ListByLabel calls after cached repeat = %d, want 1", cityStore.listByLabelCalls)
 	}
 
-	state.eventProv.Record(events.Event{Type: events.BeadCreated, Actor: "human"})
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("third feed = %d, want 200", rec.Code)
+	// A moving event sequence — the busy-city scenario — must keep hitting the
+	// time-bucketed cache, not force a rebuild on every poll.
+	for i := 0; i < 5; i++ {
+		state.eventProv.Record(events.Event{Type: events.BeadCreated, Actor: "human"})
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("feed after event %d = %d, want 200", i, rec.Code)
+		}
 	}
-	if rigStore.listCalls != 2 {
-		t.Fatalf("rig List calls after index change = %d, want 2", rigStore.listCalls)
+	if rigStore.listCalls != 1 {
+		t.Fatalf("rig List calls after 5 index changes = %d, want 1 (time-bucketed cache must survive sequence churn)", rigStore.listCalls)
 	}
-	if cityStore.listByLabelCalls != 2 {
-		t.Fatalf("city ListByLabel calls after index change = %d, want 2", cityStore.listByLabelCalls)
+	if cityStore.listByLabelCalls != 1 {
+		t.Fatalf("city ListByLabel calls after 5 index changes = %d, want 1 (time-bucketed cache must survive sequence churn)", cityStore.listByLabelCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- key the expensive orders feed cache by a short wall-clock bucket instead of the event index
- prevent unrelated event churn from forcing a full feed rebuild on every poll
- add a regression test that records repeated events while asserting the cached store-read counts stay flat

Promoted from the focused changes in the older `public/fix/orders-feed-cache-thrash` branch onto current upstream main. The old branch and its benchmark commit remain untouched for provenance.

## Test plan

- `go test ./internal/api -run '^TestHandleOrdersFeedCachesAcrossIndexChanges$' -count=1`
- `git diff --check`