### PR TITLE
fix(reviewquorum): harden finalize behavior

### DIFF
--- a/internal/reviewquorum/finalize.go
+++ b/internal/reviewquorum/finalize.go
@@ -59,6 +59,37 @@ func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 		if len(laneFailures) > 0 {
 			continue
 		}
+		if strings.TrimSpace(lane.Summary) != "" {
+			laneSummaries = append(laneSummaries, fmt.Sprintf("%s: %s", lane.LaneID, strings.TrimSpace(lane.Summary)))
+		}
+		if lane.FailureClass != "" || lane.FailureReason != "" {
+			class, reason := ClassifyFailure(lane.FailureClass, lane.FailureReason)
+			if class != FailureClassNone {
+				if class == FailureClassTransient {
+					transientFailures = append(transientFailures, formatLaneFailure(lane.LaneID, reason))
+				} else {
+					hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
+				}
+				continue
+			}
+		}
+
+		verdict := normalizeToken(lane.Verdict)
+		switch verdict {
+		case VerdictBlocked:
+			class, reason := ClassifyFailure(lane.FailureClass, lane.FailureReason)
+			if class == FailureClassTransient {
+				transientFailures = append(transientFailures, formatLaneFailure(lane.LaneID, reason))
+			} else {
+				hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
+			}
+			continue
+		case VerdictPass, VerdictPassWithFindings, VerdictFail:
+		default:
+			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, "unknown_verdict_value"))
+			continue
+		}
+
 		mergeLaneFindings(findingAccumulators, &findingOrder, lane)
 		summary.Evidence = append(summary.Evidence, cloneEvidence(lane.Evidence)...)
 		summary.Usage = addUsage(summary.Usage, lane.Usage)
@@ -74,33 +105,12 @@ func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
 		}
 
-		if strings.TrimSpace(lane.Summary) != "" {
-			laneSummaries = append(laneSummaries, fmt.Sprintf("%s: %s", lane.LaneID, strings.TrimSpace(lane.Summary)))
-		}
-		if lane.FailureClass != "" || lane.FailureReason != "" {
-			class, reason := ClassifyFailure(lane.FailureClass, lane.FailureReason)
-			if class != FailureClassNone {
-				if class == FailureClassTransient {
-					transientFailures = append(transientFailures, formatLaneFailure(lane.LaneID, reason))
-				} else {
-					hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
-				}
-				continue
-			}
-		}
-		switch normalizeToken(lane.Verdict) {
+		switch verdict {
 		case VerdictPass:
 		case VerdictPassWithFindings:
 			summary.Verdict = VerdictPassWithFindings
 		case VerdictFail:
 			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, "lane_failed"))
-		case VerdictBlocked:
-			class, reason := ClassifyFailure(lane.FailureClass, lane.FailureReason)
-			if class == FailureClassTransient {
-				transientFailures = append(transientFailures, formatLaneFailure(lane.LaneID, reason))
-			} else {
-				hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
-			}
 		default:
 			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, "unknown_verdict_value"))
 		}

--- a/internal/reviewquorum/finalize_test.go
+++ b/internal/reviewquorum/finalize_test.go
@@ -358,6 +358,32 @@ func TestFinalizeSoftFailsTransientLaneWithoutAwaitingFinalize(t *testing.T) {
 	}
 }
 
+func TestFinalizeSoftFailsTransientLaneWithoutReadOnlyProof(t *testing.T) {
+	got := finalize([]LaneOutput{
+		{
+			LaneID:        lanePrimary,
+			Provider:      "local",
+			Model:         "model-a",
+			Verdict:       VerdictBlocked,
+			FailureClass:  FailureClassTransient,
+			FailureReason: "provider_rate_limited",
+		},
+	})
+
+	if got.Verdict != VerdictBlocked {
+		t.Fatalf("Verdict = %q, want %q", got.Verdict, VerdictBlocked)
+	}
+	if got.FailureClass != FailureClassTransient {
+		t.Fatalf("FailureClass = %q, want transient", got.FailureClass)
+	}
+	if got.FailureReason != "lane=primary reason=provider_rate_limited" {
+		t.Fatalf("FailureReason = %q, want lane=primary reason=provider_rate_limited", got.FailureReason)
+	}
+	if strings.Contains(got.FailureReason, "read_only") {
+		t.Fatalf("FailureReason = %q, want no read-only failure for transient blocked lane", got.FailureReason)
+	}
+}
+
 func TestFinalizeFindingsRequestChanges(t *testing.T) {
 	got := finalize([]LaneOutput{
 		{


### PR DESCRIPTION
## Summary

- classify transient/blocked lane failures before merging read-only evidence
- reject unknown verdicts before accepting lane findings, evidence, or usage
- preserve deterministic hard/transient failure behavior

Promoted from the focused change in the older stacked `public/feat/review-finalize-fixes` branch onto current upstream main. The source branch remains untouched for provenance.

## Test plan

- `go test ./internal/reviewquorum -count=1`
- `git diff --check`