### PR TITLE
perf(api): skip graph parent walks for graphv2

### DIFF
--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -437,6 +437,15 @@ func collectBeadGraph(store beads.Store, root beads.Bead) ([]beads.Bead, []workf
 		parentEdges = append(parentEdges, edge)
 	}
 
+	for _, child := range graphBeads {
+		if _, ok := beadIndex[child.ParentID]; ok {
+			addParentEdge(child.ParentID, child.ID)
+		}
+	}
+	if isGraphV2MetadataGraph(root, metadataChildren) {
+		return graphBeads, parentEdges, nil
+	}
+
 	// Discover parent-linked descendants and their parent-child edges by walking
 	// the tree one BFS level at a time, fetching each level's children with a
 	// single batched store.List(ParentIDs=...) call. This replaces the former
@@ -478,6 +487,16 @@ func collectBeadGraph(store beads.Store, root beads.Bead) ([]beads.Bead, []workf
 	}
 
 	return graphBeads, parentEdges, nil
+}
+
+func isGraphV2MetadataGraph(root beads.Bead, metadataChildren []beads.Bead) bool {
+	if len(metadataChildren) == 0 {
+		return false
+	}
+	if !sling.IsWorkflowAttachment(root) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(root.Metadata[beadmeta.FormulaContractMetadataKey]), "graph.v2")
 }
 
 func mergeWorkflowDeps(primary, extra []workflowDepResponse) []workflowDepResponse {

--- a/internal/api/handler_beads_graph_test.go
+++ b/internal/api/handler_beads_graph_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -19,6 +20,18 @@ type beadGraphResponse struct {
 		To   string `json:"to"`
 		Kind string `json:"kind"`
 	} `json:"deps"`
+}
+
+type graphCountingListStore struct {
+	beads.Store
+	parentListCalls int
+}
+
+func (s *graphCountingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.ParentID != "" {
+		s.parentListCalls++
+	}
+	return s.Store.List(query)
 }
 
 func createBeadWithMeta(t *testing.T, store beads.Store, title string, meta map[string]string) beads.Bead {
@@ -47,6 +60,72 @@ func getGraph(t *testing.T, h http.Handler, fs *fakeState, rootID string) (*http
 		}
 	}
 	return rec, resp
+}
+
+func TestBeadGraphGraphV2MetadataGraphSkipsParentWalk(t *testing.T) {
+	state := newFakeState(t)
+	base := state.stores["myrig"]
+
+	root := createBeadWithMeta(t, base, "Workflow Root", map[string]string{
+		beadmeta.KindMetadataKey:            "workflow",
+		beadmeta.FormulaContractMetadataKey: "graph.v2",
+	})
+	child, err := base.Create(beads.Bead{
+		Title:    "Step 1",
+		Type:     "task",
+		ParentID: root.ID,
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	grandchild, err := base.Create(beads.Bead{
+		Title:    "Step 1.1",
+		Type:     "task",
+		ParentID: child.ID,
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(grandchild): %v", err)
+	}
+
+	counting := &graphCountingListStore{Store: base}
+	state.stores["myrig"] = counting
+	h := newTestCityHandler(t, state)
+
+	rec, resp := getGraph(t, h, state, root.ID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if counting.parentListCalls != 0 {
+		t.Fatalf("ParentID List calls = %d, want 0 for graph.v2 metadata graph", counting.parentListCalls)
+	}
+	beadIDs := map[string]bool{}
+	for _, b := range resp.Beads {
+		beadIDs[b.ID] = true
+	}
+	for _, id := range []string{root.ID, child.ID, grandchild.ID} {
+		if !beadIDs[id] {
+			t.Fatalf("graph beads missing %s; got %#v", id, resp.Beads)
+		}
+	}
+	edges := map[string]bool{}
+	for _, dep := range resp.Deps {
+		edges[dep.From+"|"+dep.To+"|"+dep.Kind] = true
+	}
+	for _, edge := range []string{
+		root.ID + "|" + child.ID + "|parent-child",
+		child.ID + "|" + grandchild.ID + "|parent-child",
+	} {
+		if !edges[edge] {
+			t.Fatalf("graph deps missing %s; got %#v", edge, resp.Deps)
+		}
+	}
 }
 
 func TestBeadGraphReturnsRootAndChildren(t *testing.T) {


### PR DESCRIPTION
## Summary

- construct parent-child edges directly from the already materialized graph.v2 metadata graph
- skip the breadth-first store parent walk when graph.v2 metadata is authoritative
- retain the existing walk for legacy/non-graph.v2 shapes and add a store-read regression test

Promoted from the focused tip change in the older stacked `public/fix/bead-graph-workflow-fast-path` branch onto current upstream main. The source branch remains untouched for provenance.

## Test plan

- `go test ./internal/api -run '^TestBeadGraphGraphV2MetadataGraphSkipsParentWalk$' -count=1`
- `git diff --check`