### PR TITLE
feat(bd): refuse a `gc bd update` whose --set-metadata pairs bd would drop

### DIFF
--- a/cmd/gc/bd_mistyped_metadata.go
+++ b/cmd/gc/bd_mistyped_metadata.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/gastownhall/gascity/internal/bdflags"
+)
+
+// mistypedMetadataPairRefusal reports whether a `gc bd` invocation carries
+// `--set-metadata` pairs bd would silently drop, and the message to print.
+//
+// gc bd writes exec raw bd, so nothing upstream of this sees them. It depends
+// only on internal/bdflags — the upstream-owned source of truth for bd's flag
+// names — so this guard carries no fork-local dependency.
+func mistypedMetadataPairRefusal(bdArgs []string) (string, bool) {
+	verb, verbArgs := bdflags.SplitGlobalFlags(bdArgs)
+	return bdflags.DroppedMetadataRefusal("gc bd", verb, verbArgs)
+}

--- a/cmd/gc/bd_mistyped_metadata_test.go
+++ b/cmd/gc/bd_mistyped_metadata_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestGCBdRefusesMistypedMetadataPairs pins that `gc bd update` refuses a bare
+// key=value in bd's positional issue-id slot.
+//
+// `--set-metadata` is a repeatable stringArray taking ONE pair per flag, so in
+// `--set-metadata a=1 b=2 c=3` only `a=1` is the flag's value. bd reads `b=2` and
+// `c=3` as issue ids, fails to resolve them, prints the failures to stderr — and
+// still prints its success line and EXITS 0. Measured on bd 1.1.0 and unchanged
+// in 1.1.2: six pairs in, one pair written, exit 0, so no caller can tell.
+//
+// gc bd writes exec raw bd rather than the routed fastpath, so the classifier's
+// guard does not cover this path; it needs its own. The refusal must come before
+// any store work, so nothing is written and the exit code is honest.
+func TestGCBdRefusesMistypedMetadataPairs(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"trailing pairs", []string{"update", "bd-1", "--set-metadata", "a=1", "b=2", "c=3"}},
+		{"one trailing pair", []string{"update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+		{"inline flag form", []string{"update", "bd-1", "--set-metadata=a=1", "b=2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := doBd(tc.args, &stdout, &stderr)
+			if code == 0 {
+				t.Fatalf("doBd(%v) = 0, want non-zero; stderr=%q", tc.args, stderr.String())
+			}
+			msg := stderr.String()
+			if !strings.Contains(msg, "--set-metadata") {
+				t.Errorf("stderr %q does not name --set-metadata", msg)
+			}
+			// The message must name the offending token, so the caller can see
+			// which pair bd would have dropped.
+			if !strings.Contains(msg, "b=2") {
+				t.Errorf("stderr %q does not name the dropped pair b=2", msg)
+			}
+		})
+	}
+}
+
+// TestGCBdRefusesMistypedMetadataPairsBehindGlobalFlags pins the exit-code
+// contract through the path that used to disarm the guard.
+//
+// The guard is keyed off the bd subcommand, and bd's global value-flags sit
+// BEFORE the subcommand. Locating the verb as the first non-dash token read
+// `bob` out of `bd --actor bob update <id> …`, so the verb was not "update", the
+// refusal did not fire, and raw bd performed exactly the silent 1-of-N write
+// plus exit 0 the guard exists to prevent.
+//
+// The exit code is the whole contract: this defect survives precisely because
+// everything downstream trusts an exit code that lies. So this asserts the code,
+// not just the message — and the guard runs before resolveBdCity, so a refusal
+// here is also proof that no store was opened and nothing was written.
+func TestGCBdRefusesMistypedMetadataPairsBehindGlobalFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"--actor", []string{"--actor", "bob", "update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+		{"-C dir", []string{"-C", "/some/dir", "update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+		{"--db path", []string{"--db", "/x/y.db", "update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+		{"--directory", []string{"--directory", "/d", "update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+		{"--dolt-auto-commit", []string{"--dolt-auto-commit", "off", "update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+		{"stacked globals", []string{"--actor", "bob", "--json", "-C", "/d", "update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+		{"inline global", []string{"--actor=bob", "update", "bd-1", "--set-metadata", "a=1", "b=2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := doBd(tc.args, &stdout, &stderr)
+			if code == 0 {
+				t.Fatalf("doBd(%v) = 0, want non-zero; stderr=%q", tc.args, stderr.String())
+			}
+			msg := stderr.String()
+			if !strings.Contains(msg, "would be dropped") {
+				t.Fatalf("doBd(%v) exited %d but not via the mistyped-pair guard; stderr=%q", tc.args, code, msg)
+			}
+			if !strings.Contains(msg, "b=2") {
+				t.Errorf("stderr %q does not name the dropped pair b=2", msg)
+			}
+		})
+	}
+}
+
+// TestGCBdAllowsCorrectMetadataForms pins that the guard does not fire on the
+// shapes that actually work: one --set-metadata per pair, a plain id, and
+// several ids sharing one pair (bd applies the update to every id). These must
+// get past the guard and continue into normal resolution — the guard is not
+// allowed to become a reason a working invocation stops working.
+func TestGCBdAllowsCorrectMetadataForms(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"repeated flag", []string{"update", "bd-1", "--set-metadata", "a=1", "--set-metadata", "b=2"}},
+		{"single pair", []string{"update", "bd-1", "--set-metadata", "a=1"}},
+		{"multi-id one pair", []string{"update", "bd-1", "bd-2", "--set-metadata", "a=1"}},
+		{"flag value before id", []string{"update", "--set-metadata", "a=1", "bd-1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			_ = doBd(tc.args, &stdout, &stderr)
+			// The call fails later for want of a city/store in this environment;
+			// what matters is that it was NOT stopped by the mistyped-pair guard.
+			if strings.Contains(stderr.String(), "would be dropped") {
+				t.Fatalf("guard fired on a valid form %v: %s", tc.args, stderr.String())
+			}
+		})
+	}
+}

--- a/cmd/gc/bd_mistyped_metadata_test.go
+++ b/cmd/gc/bd_mistyped_metadata_test.go
@@ -97,6 +97,15 @@ func TestGCBdRefusesMistypedMetadataPairsBehindGlobalFlags(t *testing.T) {
 // get past the guard and continue into normal resolution — the guard is not
 // allowed to become a reason a working invocation stops working.
 func TestGCBdAllowsCorrectMetadataForms(t *testing.T) {
+	// These forms deliberately run PAST the guard, so pin an explicit non-city
+	// temp dir rather than leaning on ambient state: doBd then fails
+	// deterministically at resolveBdCity, before any store is opened or bd is
+	// exec'd. TestMain's env scrub and the test-binary refusal of ambient
+	// upward discovery cover this today; pinning it here keeps the isolation
+	// local to the test instead of a property of that scrub list, and matches
+	// the idiom every sibling test in cmd_bd_test.go uses.
+	t.Setenv("GC_CITY_PATH", t.TempDir())
+
 	cases := []struct {
 		name string
 		args []string

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -206,6 +206,13 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Refuse a dropped --set-metadata pair before any store work, so nothing is
+	// written and the exit code is honest. bd applies the subset and exits 0.
+	if msg, mistyped := mistypedMetadataPairRefusal(bdArgs); mistyped {
+		fmt.Fprint(stderr, msg) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
 	cityPath, err := resolveBdCity(cityName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/internal/bdflags/bdargs.go
+++ b/internal/bdflags/bdargs.go
@@ -1,0 +1,112 @@
+package bdflags
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SplitGlobalFlags splits a bd argv into its subcommand and the arguments that
+// follow it, skipping the values of global value-flags.
+//
+// Taking the first non-dash token as the subcommand reads a global flag's VALUE
+// instead: `bd --actor bob update <id> ...` yields "bob". Anything keyed off the
+// subcommand — a mutation guard, a routing decision — is then bypassed by a
+// token the caller never meant as a verb.
+func SplitGlobalFlags(args []string) (string, []string) {
+	globals := GlobalValueFlags()
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "-") {
+			return a, args[i+1:]
+		}
+		// An inline --flag=value consumes nothing further.
+		if strings.IndexByte(a, '=') < 0 && globals[a] && i+1 < len(args) {
+			i++
+		}
+	}
+	return "", nil
+}
+
+// Positionals returns the positional arguments of a bd subcommand's argv,
+// skipping every token consumed as a flag's value.
+//
+// It needs the FULL value-flag set for the subcommand, not a subset: with a
+// partial set the value of any omitted flag is read as a positional. That is how
+// `update <id> --add-label role=worker` came to look like a stray key=value
+// token rather than a flag value.
+func Positionals(sub string, args []string) []string {
+	needsValue := ValueFlags(sub)
+	var positionals []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "-") {
+			positionals = append(positionals, a)
+			continue
+		}
+		hasInlineValue := strings.IndexByte(a, '=') >= 0
+		name := a
+		if hasInlineValue {
+			name = a[:strings.IndexByte(a, '=')]
+		}
+		if !hasInlineValue && needsValue[name] && i+1 < len(args) {
+			i++
+		}
+	}
+	return positionals
+}
+
+// DroppedMetadataPairs returns the bare key=value tokens sitting in `bd update`'s
+// positional issue-id slot — the --set-metadata pairs bd is about to discard.
+//
+// --set-metadata is a repeatable flag taking ONE pair per occurrence, so in
+// `--set-metadata a=1 b=2 c=3` only a=1 is the flag's value; b=2 and c=3 become
+// positional issue ids. bd fails to resolve them, reports the failures on
+// stderr, prints its success line for the id that did resolve, and EXITS 0 —
+// so a caller cannot distinguish a full write from a 1-of-N write, and no
+// exit-code check in any script can see it.
+//
+// No bead id contains '=', so such a positional never resolved under bd either:
+// reporting one cannot condemn an invocation that previously worked.
+func DroppedMetadataPairs(args []string) []string {
+	var dropped []string
+	for _, p := range Positionals("update", args) {
+		if strings.IndexByte(p, '=') >= 0 {
+			dropped = append(dropped, p)
+		}
+	}
+	return dropped
+}
+
+// DroppedMetadataRefusal builds the refusal message for a `bd update` whose
+// metadata pairs would be silently dropped, or reports false for any other verb
+// and every well-formed invocation. prefix names the entry point (e.g. "gc bd").
+//
+// The message names each dropped pair and the form that works, because the
+// caller's own output gives it nothing: bd prints success and exits 0 however
+// many pairs it discarded.
+func DroppedMetadataRefusal(prefix, verb string, args []string) (string, bool) {
+	if verb != "update" {
+		return "", false
+	}
+	dropped := DroppedMetadataPairs(args)
+	if len(dropped) == 0 {
+		return "", false
+	}
+	corrected := make([]string, 0, len(dropped))
+	for _, pair := range dropped {
+		corrected = append(corrected, "--set-metadata "+pair)
+	}
+	subject, object := "it", "an issue id"
+	if len(dropped) > 1 {
+		subject, object = "them", "issue ids"
+	}
+	return fmt.Sprintf(
+		"%s: refusing update: %s would be dropped. --set-metadata takes ONE key=value per flag, so bd reads %s as %s, fails to resolve %s, and still exits 0 after writing only the first pair. Repeat the flag instead: %s\n",
+		prefix,
+		strings.Join(dropped, ", "),
+		strings.Join(dropped, ", "),
+		object,
+		subject,
+		strings.Join(corrected, " "),
+	), true
+}

--- a/internal/bdflags/bdargs_test.go
+++ b/internal/bdflags/bdargs_test.go
@@ -1,0 +1,162 @@
+package bdflags
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSplitGlobalFlagsSkipsGlobalFlagValues pins that a global flag's VALUE is
+// never mistaken for the subcommand. Taking the first non-dash token reads
+// "bob" out of `bd --actor bob update <id> ...`, so anything keyed off the
+// subcommand is bypassed by a token the caller never meant as a verb.
+func TestSplitGlobalFlagsSkipsGlobalFlagValues(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantVerb string
+		wantRest []string
+	}{
+		{"plain", []string{"update", "bd-1"}, "update", []string{"bd-1"}},
+		{"--actor", []string{"--actor", "bob", "update", "bd-1"}, "update", []string{"bd-1"}},
+		{"-C dir", []string{"-C", "/some/dir", "update", "bd-1"}, "update", []string{"bd-1"}},
+		{"--db", []string{"--db", "/x/y.db", "update", "bd-1"}, "update", []string{"bd-1"}},
+		{"--directory", []string{"--directory", "/d", "close", "bd-1"}, "close", []string{"bd-1"}},
+		{"inline form consumes nothing", []string{"--actor=bob", "update", "bd-1"}, "update", []string{"bd-1"}},
+		{"bool global", []string{"--json", "update", "bd-1"}, "update", []string{"bd-1"}},
+		{"stacked", []string{"--actor", "bob", "--json", "-C", "/d", "update", "bd-1"}, "update", []string{"bd-1"}},
+		{"no verb", []string{"--actor", "bob"}, "", nil},
+		{"empty", nil, "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verb, rest := SplitGlobalFlags(tc.args)
+			if verb != tc.wantVerb {
+				t.Errorf("verb = %q, want %q", verb, tc.wantVerb)
+			}
+			if !reflect.DeepEqual(rest, tc.wantRest) {
+				t.Errorf("rest = %v, want %v", rest, tc.wantRest)
+			}
+		})
+	}
+}
+
+// TestGlobalValueFlagsIsComplete pins the global value-flag set against bd's
+// own persistent-flag list. A flag missing from this table silently reopens the
+// bypass below: SplitGlobalFlags would read that flag's value as the verb, and
+// every guard keyed off the verb stops firing — with no test failing.
+//
+// Sourced from `bd --help` (bd 1.1.0). bd declares exactly four persistent
+// flags that consume the next argument; -C and --directory are the two spellings
+// of one of them. Every other persistent flag (--global, --ignore-schema-skew,
+// --json, --profile, -q/--quiet, --readonly, --sandbox, -v/--verbose, -h/--help,
+// -V/--version) is boolean and consumes nothing.
+func TestGlobalValueFlagsIsComplete(t *testing.T) {
+	want := map[string]bool{
+		"--actor": true, "--db": true, "-C": true, "--directory": true,
+		"--dolt-auto-commit": true,
+	}
+	if got := GlobalValueFlags(); !reflect.DeepEqual(got, want) {
+		t.Errorf("GlobalValueFlags() = %v, want %v; re-check `bd --help` persistent flags", got, want)
+	}
+}
+
+// TestRefusalFiresBehindAGlobalFlag composes the two halves of the guard the way
+// the caller does — locate the verb, then judge its args — and pins that a
+// global value-flag before the verb does not disarm it.
+//
+// Testing SplitGlobalFlags and DroppedMetadataRefusal only in isolation leaves
+// the composition untested, and the composition is where the bypass lived:
+// `bd --actor bob update <id> --set-metadata a=1 b=2` yielded verb "bob", the
+// refusal is scoped to "update", so it never fired and bd performed the silent
+// 1-of-N write the guard exists to prevent.
+func TestRefusalFiresBehindAGlobalFlag(t *testing.T) {
+	prefixes := [][]string{
+		{"--actor", "bob"},
+		{"-C", "/some/dir"},
+		{"--db", "/x/y.db"},
+		{"--directory", "/d"},
+		{"--dolt-auto-commit", "off"},
+		{"--actor", "bob", "--json", "-C", "/d"},
+	}
+	for _, prefix := range prefixes {
+		args := append(append([]string{}, prefix...), "update", "bd-1", "--set-metadata", "a=1", "b=2")
+		verb, rest := SplitGlobalFlags(args)
+		msg, ok := DroppedMetadataRefusal("gc bd", verb, rest)
+		if !ok {
+			t.Errorf("prefix %v: refusal did not fire (verb=%q); the silent 1-of-N write survives", prefix, verb)
+			continue
+		}
+		if !contains(msg, "b=2") {
+			t.Errorf("prefix %v: message %q does not name the dropped pair", prefix, msg)
+		}
+	}
+}
+
+// TestPositionalsKnowsEveryValueTakingFlag is the drift guard: positional
+// detection must consume the value of EVERY value-taking flag for the
+// subcommand. With a partial set, the value of any omitted flag is read as a
+// positional — which is how `update <id> --add-label role=worker` came to look
+// like a stray key=value token.
+func TestPositionalsKnowsEveryValueTakingFlag(t *testing.T) {
+	for flag := range ValueFlags("update") {
+		got := Positionals("update", []string{"bd-1", flag, "role=worker"})
+		if len(got) != 1 || got[0] != "bd-1" {
+			t.Errorf("Positionals(update, bd-1 %s role=worker) = %v; the flag's value was read as an id", flag, got)
+		}
+	}
+}
+
+// TestDroppedMetadataPairs pins detection in both directions.
+func TestDroppedMetadataPairs(t *testing.T) {
+	dropped := [][]string{
+		{"bd-1", "--set-metadata", "a=1", "b=2"},
+		{"bd-1", "--set-metadata", "a=1", "b=2", "c=3"},
+		{"bd-1", "--set-metadata=a=1", "b=2"},
+	}
+	for _, args := range dropped {
+		if len(DroppedMetadataPairs(args)) == 0 {
+			t.Errorf("DroppedMetadataPairs(%v) = none; want the dropped pair caught", args)
+		}
+	}
+	valid := [][]string{
+		{"bd-1", "--set-metadata", "a=1"},
+		{"bd-1", "--set-metadata", "a=1", "--set-metadata", "b=2"},
+		{"bd-1", "--add-label", "role=worker"},
+		{"bd-1", "--set-labels", "a=b"},
+		{"bd-1", "--external-ref", "https://example.test/i/ABC-1?tab=activity"},
+		{"bd-1", "--metadata", `{"url":"https://x?a=b"}`},
+		{"bd-1", "bd-2", "--set-metadata", "a=1"},
+	}
+	for _, args := range valid {
+		if got := DroppedMetadataPairs(args); len(got) != 0 {
+			t.Errorf("DroppedMetadataPairs(%v) = %v; this is a valid invocation", args, got)
+		}
+	}
+}
+
+// TestDroppedMetadataRefusalOnlyUpdate pins that the refusal is scoped to update.
+func TestDroppedMetadataRefusalOnlyUpdate(t *testing.T) {
+	if _, ok := DroppedMetadataRefusal("gc bd", "create", []string{"t", "--set-metadata", "a=1", "b=2"}); ok {
+		t.Error("refusal fired for create; --set-metadata is an update flag")
+	}
+	msg, ok := DroppedMetadataRefusal("gc bd", "update", []string{"bd-1", "--set-metadata", "a=1", "b=2"})
+	if !ok {
+		t.Fatal("refusal did not fire for update")
+	}
+	for _, want := range []string{"b=2", "--set-metadata", "exits 0"} {
+		if !contains(msg, want) {
+			t.Errorf("message %q missing %q", msg, want)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	}()
+}

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -169,6 +169,13 @@ var boolFlagsBySub = map[string]map[string]bool{
 	"dep remove": {},
 }
 
+// GlobalValueFlags returns the flags accepted by every bd subcommand that
+// consume the next argument as their value. A caller locating the subcommand in
+// an argv must skip these values, or it reads one of them as the verb.
+func GlobalValueFlags() map[string]bool {
+	return mergeFlagSets(globalValueFlags)
+}
+
 // Subcommands returns the bd subcommand keys this package has flag
 // manifests for (e.g. "close", "mol pour"), in no particular order.
 func Subcommands() []string {


### PR DESCRIPTION
## The juicy parts

This is silent data loss with a success exit code. `bd update <id> --set-metadata a=1 b=2 c=3` stores **one** pair, prints its success line, and **exits 0** — `b=2` and `c=3` land in bd's variadic issue-id slot, fail to resolve on stderr, and are discarded. A caller cannot distinguish a full write from a 1-of-N write, so ordinary `|| exit 1` error handling is blind to it.

This refuses the shape before any store work: nothing is written, the exit code is honest, and the message names each dropped pair and the repeated-flag form that works. It cannot condemn an invocation that previously worked, because **no bead id contains `=`** — a `=`-bearing positional was already failing under bd, just quietly. The only change is a silent partial write becoming a loud refusal, issued before the write.

Scope is `gc bd`, which execs bd, so nothing between the caller and this behaviour sees it. The guard is keyed off the bd subcommand and is **not** disarmed by a global flag before the verb — `gc bd --actor bob update <id> --set-metadata a=1 b=2` is refused with a non-zero exit and writes nothing, verified against a real store. A raw `bd` invocation is still exposed; the exit-code contract itself is filed upstream as steveyegge/beads#5247.

## TL;DR

`bd update <id> --set-metadata a=1 b=2 c=3` writes **one** pair, reports success, and **exits 0**. `gc bd` execs bd, so nothing between the caller and that behaviour sees it. This refuses the shape before any store work — nothing written, honest exit code.

## The behaviour

`--set-metadata` is repeatable and takes ONE `key=value` per occurrence; `bd update` is variadic over issue ids. So only `a=1` is the flag's value — `b=2` and `c=3` become positional issue ids.

```console
$ bd update bd-abc --set-metadata probe_a=1 probe_b=2 probe_c=3
✓ Updated issue: bd-abc — scratch probe
Error resolving probe_b=2: no issue found matching "probe_b=2"
Error resolving probe_c=3: no issue found matching "probe_c=3"
$ echo $?
0
$ bd show bd-abc --json | jq -c '.[0].metadata'
{"probe_a": 1}
```

Three pairs in, one stored, exit 0. A caller cannot distinguish a full write from a 1-of-N write, so no `|| exit` guard can catch it. Reproduced on bd 1.1.0, unchanged in 1.1.2 (`cmd/bd/update.go` is identical between them). Reported upstream as steveyegge/beads#5247. The asymmetry that hides it: repeated `--unset-metadata` flags all apply — only the set path loses pairs.

## Why it can't break a working invocation

**No issue id contains `=`.** A `=`-bearing positional therefore never resolved under bd either — it was already failing, silently. The guard converts a silent partial write into a loud refusal, issued *before* the write rather than after.

## Behaviour

```gherkin
Given `gc bd update <id> --set-metadata a=1 b=2`
When doBd runs
Then it exits non-zero, names the dropped pair and the repeated-flag form,
     and performs no store work
```

```gherkin
Given `gc bd update <id> --set-metadata a=1 --set-metadata b=2`
When doBd runs
Then it proceeds unchanged
```

```gherkin
Given `gc bd update <id> --add-label role=worker`
When doBd runs
Then it proceeds unchanged — the value belongs to --add-label, not the id slot
```

## The part that needs care

Positional detection needs the **complete** value-flag table. With a subset, the value of any omitted flag is read as a positional id — and `gc bd update <id> --add-label <key>=<value>` is shipped verbatim in `internal/bootstrap/packs/core/skills/gc-work/SKILL.md:50`, so a partial table breaks a documented command. `internal/bdflags` already declares itself the single source of truth for bd's per-subcommand flag names, so the argv parsing lives there rather than beside it.

`SplitGlobalFlags` also skips global value-flag values: locating the subcommand by first non-flag token reads `bob` out of `bd --actor bob update …`, which would bypass any guard keyed off the subcommand — including this one.

Tests cover both directions — a drift guard proves **every** value-taking `update` flag is a non-false-positive, the real dropped-pair shapes are caught, and the refusal is scoped to `update`.

## What this does not cover

Same failure mode — bd reports success for a partial write and exits 0 — outside this guard's reach:

- **A raw `bd` invocation.** `gc bd` is the only entry point guarded here. Filed upstream as steveyegge/beads#5247.
- **A partial multi-id update.** `bd update <good-id> <bad-id> --set-metadata k=v` writes one bead, fails to resolve the other on stderr, and exits 0. The token carries no `=`, so this guard cannot distinguish it from a legitimate id. Measured on bd 1.1.0.
- **`bdMutationWriteIDs` (pre-existing, `cmd/gc/cmd_bd.go`).** The exact-ID guard added for gcy-g4o takes `sub := args[0]`, so *any* leading global flag — value or boolean — skips it, and `gc bd --json update <id> …` reaches bd unverified. That is a different guard against a different failure (substring resolution mutating the wrong bead), it predates this PR, and this PR does not change it. `SplitGlobalFlags` is the obvious fix, but it widens that guard's activation surface, so it belongs in its own change rather than being smuggled in here.

## Scope

| File | Change |
|---|---|
| `internal/bdflags/bdargs.go` | new — argv parsing (+120) |
| `internal/bdflags/bdflags.go` | `GlobalValueFlags()` accessor (+7) |
| `cmd/gc/bd_mistyped_metadata.go` | new — the guard (+16) |
| `cmd/gc/cmd_bd.go` | hook in `doBd` (+6) |
| tests | `bdargs_test.go`, `bd_mistyped_metadata_test.go` |

## Related

- steveyegge/beads#5247 — the exit-code contract, upstream in bd. This guard is the downstream mitigation; it protects `gc bd` only, not a bd invocation an agent improvises.
- #4901 — publishing the bead DELETE endpoint's soft-delete contract in the spec (same theme: a CLI/API surface that reports success for something other than what the caller asked).


