### PR TITLE
test(bench): measure the readiness pass a city with locked imports pays

### DIFF
--- a/cmd/gc/builtin_readiness_cost_bench_test.go
+++ b/cmd/gc/builtin_readiness_cost_bench_test.go
@@ -4,7 +4,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // newReadinessCostCity writes a minimal bd-provider city.
@@ -25,6 +28,11 @@ func newReadinessCostCity(b *testing.B) string {
 // Read this against BenchmarkCityConfigParseOnly. The readiness pass, not the
 // parse, is what a config load costs — which is why skipping a redundant load
 // is worth anything, and why the pass itself must still run once per process.
+//
+// This shape deliberately measures the cheapest one: no packs.lock and a warm
+// memo. Use BenchmarkBuiltinReadinessPassLocked to measure the pass a city with
+// locked bundled imports pays; that benchmark's comment explains what this one
+// cannot see.
 func BenchmarkBuiltinReadinessPass(b *testing.B) {
 	b.Setenv("GC_HOME", b.TempDir())
 	cityPath := newReadinessCostCity(b)
@@ -38,6 +46,81 @@ func BenchmarkBuiltinReadinessPass(b *testing.B) {
 			b.Fatalf("EnsureBuiltinRuntimeAssets: %v", err)
 		}
 	}
+}
+
+// BenchmarkBuiltinReadinessPassLocked measures the readiness pass a city with
+// locked bundled imports pays: a city whose packs.lock pins a bundled source at
+// its canonical commit, with the per-city ready memo cleared before each
+// iteration.
+//
+// THE LOCKFILE IS WHAT THIS BENCHMARK IS FOR. BenchmarkBuiltinReadinessPass
+// builds a city with no packs.lock, so lockedBundledCanonicalImports finds
+// nothing and the locked-imports half of the pass — one of the two places
+// EnsureBuiltinRuntimeAssets validates a synthetic pack cache — never runs at
+// all. A locked bundled source resolves to its own cache directory, and
+// MaterializeSyntheticRepo writes every bundled pack layout into every such
+// directory, so validating it is a second full walk of the whole bundled pack
+// set rather than an incremental check. Measured on this fixture, adding the
+// lockfile is +50.1% allocations; that is essentially the whole gap between
+// the two benchmarks.
+//
+// Clearing the per-city memo is the secondary, and much smaller, half.
+// builtinRuntimeReadyCache is a package-level sync.Map, so from the second
+// iteration onward the warm benchmark takes the ready fast path, while a
+// one-shot `gc` process starts that map empty and always takes the
+// non-memoized revalidation path. Measured in isolation that axis is +0.26%
+// allocations. It is kept because it makes the shape honest, not because it
+// is where the cost is — do not attribute the difference to it.
+//
+// The consequence is that the warm benchmark is insensitive to changes in most
+// of the pass it is named after: work that only the locked-imports half
+// performs measures as zero against it.
+//
+// FIDELITY: this reproduces the SHAPE of the cost, not the exact pass a real
+// city runs. The fixture locks gastown, which this fixture city does not
+// import, so the locked arm walks the bundled pack set three times. A real
+// bd-provider `gc init` city locks core and bd, which normalize to the same
+// clone URL, and pays four. The benchmark therefore understates a real city
+// and is conservative in the direction that matters.
+func BenchmarkBuiltinReadinessPassLocked(b *testing.B) {
+	b.Setenv("GC_HOME", b.TempDir())
+	cityPath := newReadinessCostCity(b)
+	// The canonical pin for gastown is its own public-pack version, not
+	// BundledPackImportVersion. A bundled source locked at any other commit is
+	// an ordinary remote import that the preflight skips entirely, which would
+	// leave this measuring a city with no locked bundled imports after all.
+	writePreflightImportLock(b, cityPath, strings.TrimPrefix(config.PublicGastownPackVersion, "sha:"))
+	// Fail loudly rather than quietly measuring the warm shape twice if that
+	// ever stops holding.
+	locked, err := lockedBundledCanonicalImports(cityPath)
+	if err != nil {
+		b.Fatalf("lockedBundledCanonicalImports: %v", err)
+	}
+	if len(locked) == 0 {
+		b.Fatal("fixture pinned no canonical bundled imports; the locked-imports half of the pass would not run")
+	}
+	if _, err := loadCityConfig(cityPath, io.Discard); err != nil {
+		b.Fatalf("warming: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		resetBuiltinRuntimeReadyCacheFor(cityPath)
+		b.StartTimer()
+		if err := EnsureBuiltinRuntimeAssets(cityPath, io.Discard); err != nil {
+			b.Fatalf("EnsureBuiltinRuntimeAssets: %v", err)
+		}
+	}
+}
+
+// resetBuiltinRuntimeReadyCacheFor clears one city's builtin readiness memo so
+// the next EnsureBuiltinRuntimeAssets call for that city runs the pass a fresh
+// process would. It deletes only that city's entry: the memo is a package-level
+// sync.Map shared by every test in this binary, and ranging over it would evict
+// entries this benchmark does not own.
+func resetBuiltinRuntimeReadyCacheFor(cityPath string) {
+	builtinRuntimeReadyCache.Delete(normalizePathForCompare(cityPath))
 }
 
 // BenchmarkCityConfigParseOnly measures the config parse plus pack expansion

--- a/cmd/gc/legacy_pack_preflight_test.go
+++ b/cmd/gc/legacy_pack_preflight_test.go
@@ -122,9 +122,11 @@ fetched = "2026-01-01T00:00:00Z"
 
 // writePreflightImportLock pins the public gastown source at commit in a
 // fresh packs.lock (every preflight scenario uses that bundled source).
-func writePreflightImportLock(t *testing.T, cityPath, commit string) {
+// It takes a testing.TB so the readiness benchmarks can build the same
+// locked-city shape the preflight tests assert on.
+func writePreflightImportLock(tb testing.TB, cityPath, commit string) {
 	source := config.PublicGastownPackSource
-	t.Helper()
+	tb.Helper()
 	lockToml := fmt.Sprintf(`schema = 1
 
 [packs.%q]
@@ -133,7 +135,7 @@ commit = %q
 fetched = "2026-01-01T00:00:00Z"
 `, source, commit)
 	if err := os.WriteFile(filepath.Join(cityPath, packman.LockfileName), []byte(lockToml), 0o644); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## The juicy parts

**There is no end-user win in this PR — it is test-only, and that is the point.** `BenchmarkBuiltinReadinessPass` builds its fixture city without a `packs.lock`, so the locked-imports half of `EnsureBuiltinRuntimeAssets` — one of the two places it validates a synthetic pack cache — never executes under it. The benchmark measures roughly half of the pass it is named after, and it scored a change measured at ~51 ms of CPU per real invocation as *exactly zero*, with allocation counts identical to the digit.

`BenchmarkBuiltinReadinessPassLocked` makes the missing walk visible: 42,135 vs 63,334 allocs/op, a ratio of 1.5031 that is stable across rebases. That is what makes the readiness-pass numbers in the sibling PRs checkable at all, and what would catch a future duplicate walk in the half nothing currently watches. Note that nothing in CI runs `-bench` today, so this is a tool for a human, not an automated guard.

## What this is

A second benchmark for the builtin readiness pass, covering the case the
existing one structurally cannot see: a city that has a `packs.lock`.

Test-only. No production code changes.

## Why I was looking at this

I have been profiling `gc`'s own startup cost while working on
[#4441](https://github.com/gastownhall/gascity/issues/4441). This benchmark gap
is not part of that proposal — it is something I ran into underneath it, and it
looks like a general-benefit fix worth sending on its own regardless of what
happens to #4441. Reviewing it as an independent change is the right call; it
does not depend on anything else I have open.

The specific way I found it: a change I could measure at roughly 51 ms of CPU
per real invocation came out as **exactly zero** against
`BenchmarkBuiltinReadinessPass`, with allocation counts identical to the digit.
That is a strange enough result to chase.

## The gap

`BenchmarkBuiltinReadinessPass` builds its fixture city with no `packs.lock`.

With no lockfile, `lockedBundledCanonicalImports` finds nothing, so the
locked-imports half of `EnsureBuiltinRuntimeAssets` — one of the two places it
validates a synthetic pack cache — never runs at all. The benchmark measures
roughly half of the pass it is named after.

A locked bundled source resolves to its own cache directory, and
`MaterializeSyntheticRepo` writes every bundled pack layout into every such
directory. Validating it is therefore a **second full walk of the whole bundled
pack set**, not an incremental check.

## The measurement

`BenchmarkBuiltinReadinessPassLocked` pins a bundled source at its canonical
commit and clears that city's ready memo per iteration:

| benchmark | allocs/op |
| --- | ---: |
| `BenchmarkBuiltinReadinessPass` | 42,135 |
| `BenchmarkBuiltinReadinessPassLocked` | 63,334 |

Ratio **1.5031**. (Representative run at `-benchtime 10x`. Counts move by a
handful of allocations between runs; the ratio does not — I saw 1.5031 and
1.5033 across rebases onto different upstream bases.)

That ratio is the argument. One full walk of the bundled pack set is ~21,068
allocations, so the warm shape is doing two walks and the locked shape three.
A benchmark that cannot see the third walk will approve its removal — or its
accidental duplication — as exactly zero.

I have quoted allocations rather than wall-clock deliberately. Allocation counts
here are deterministic to the digit. The `ns/op` figures move with machine load,
and this change is not about a time saving in the first place.

## Attribution — I checked which half actually costs

Two things separate the two shapes, and I decomposed them 2x2 rather than
assuming:

| axis | effect |
| --- | ---: |
| adding the lockfile | **+50.1% allocs** |
| clearing the per-city memo | +0.26% allocs |

So it is essentially all lockfile. The memo clearing is kept because it makes
the shape honest — a one-shot `gc` process starts `builtinRuntimeReadyCache`
empty and always takes the non-memoized revalidation path — but it is a
correctness detail, not where the cost is. The benchmark is named `Locked` for
that reason rather than `Cold`, which would point at the wrong half.

## Fidelity, stated plainly

This reproduces the **shape** of the cost, not the exact pass a real city runs.

The fixture locks `gastown`, which the fixture city does not import, so the
locked arm walks the bundled pack set three times. A real bd-provider `gc init`
city locks `core` and `bd`, which normalize to the same clone URL, and pays
four. The benchmark understates a real city — conservative in the direction
that matters for a guard.

## Two traps pinned in the fixture

Both cost me time, so they are asserted rather than commented:

- **gastown's canonical pin is `PublicGastownPackVersion`, not
  `BundledPackImportVersion`.** Locked at the latter it is an ordinary remote
  import that the preflight skips entirely, which leaves the benchmark
  measuring a city with no locked bundled imports after all. My first draft did
  exactly that and reported no change. There is now a `b.Fatal` on an empty
  `lockedBundledCanonicalImports`.
- **The readiness memo is a package-level `sync.Map` shared by every test in
  the binary.** The reset deletes only this city's key rather than ranging over
  the map and evicting entries it does not own.

## Notes for the reviewer

- `writePreflightImportLock` changes from `*testing.T` to `testing.TB` so the
  benchmark builds the same locked-city shape the preflight tests already
  assert on. That is the only change to an existing file.
- The benchmark is hermetic — no network.
- If you re-run these, note that `go test -bench -count 6` does **not**
  interleave arms; it runs all six of A then all six of B, so a host that
  changes load mid-run fabricates a difference. Interleave with an outer shell
  loop of `-count 1`. The allocation figures above are stable either way.
- Nothing in CI currently runs `-bench`, so the fixture's `b.Fatal` guard only
  fires for a human running it directly. Happy to wire it into a workflow if
  you would like that, but I did not want to add CI time unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

