### PR TITLE
perf(config): let a loader that discards provenance decline the revision snapshot

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -33,6 +33,19 @@ func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, 
 	return loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), warningWriter...)
 }
 
+// skipRevisionSnapshot is the load option shared by the loaders in this file.
+//
+// The load-time revision snapshot content-hashes every pack directory so that a
+// later config.Revision() call can compare against the tree as it was loaded.
+// Neither loader here returns the Provenance — both use it to emit warnings and
+// then drop it — so nothing they load can ever observe the snapshot, and
+// building it is pure cost on a one-shot command. Loaders that do hand the
+// Provenance back keep the default.
+//
+// Revision reads from disk for anything the snapshot does not hold, so declining
+// it changes no revision value; see config.LoadOptions.SkipRevisionSnapshot.
+var skipRevisionSnapshot = config.LoadOptions{SkipRevisionSnapshot: true}
+
 // loadCityConfigFS is the testable variant of loadCityConfig that accepts a
 // filesystem implementation. Used by functions that take an fsys.FS parameter
 // for unit testing.
@@ -40,7 +53,7 @@ func loadCityConfigFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (
 	if err := ensureBuiltinPacksForConfigLoad(fs, tomlPath, resolveLoadCityConfigWarningWriter(warningWriter...)); err != nil {
 		return nil, err
 	}
-	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath)
+	cfg, prov, err := config.LoadWithIncludesOptions(fs, tomlPath, skipRevisionSnapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +72,7 @@ func loadCityConfigFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (
 // briefly reflect stale builtin-pack content after an upgrade until a normal
 // gc command refreshes the generated packs.
 func loadCityConfigWithoutBuiltinPackRefreshFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (*config.City, error) {
-	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath)
+	cfg, prov, err := config.LoadWithIncludesOptions(fs, tomlPath, skipRevisionSnapshot)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gc/load_city_config_snapshot_test.go
+++ b/cmd/gc/load_city_config_snapshot_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCityConfigLoadersDeclineTheRevisionSnapshot pins a file-level invariant:
+// every city-config loader in cmd_agent.go discards the Provenance, so every one
+// of them must decline the load-time revision snapshot.
+//
+// The snapshot content-hashes every pack directory so a later config.Revision()
+// can compare against the tree as it was loaded. These loaders return only
+// *config.City — they use the Provenance to emit warnings and then drop it — so
+// nothing they load can observe the snapshot, and building it is pure cost on a
+// one-shot command.
+//
+// This is a source-level guard rather than a behavioral one because the cost is
+// invisible by construction: a loader that reverts to the default returns
+// exactly the same config and passes every functional test, it just re-reads
+// every pack file. Nothing fails; it only gets slower, which is precisely the
+// regression a test suite does not otherwise catch.
+//
+// It follows the file-scanning idiom of TestGCNonTestFilesStayOnWorkerBoundary
+// and TestGCNonTestFilesStayOnRigProvisionBoundary: read the guarded file from a
+// runtime.Caller-derived directory rather than the process working directory,
+// and match with substring needles.
+//
+// Scope is deliberately narrow. Only cmd_agent.go's loaders are known to discard
+// the Provenance; roughly a dozen other call sites elsewhere in the tree do the
+// same thing and are out of scope for this change and this guard.
+//
+// If a loader here is ever changed to RETURN the Provenance it should keep the
+// default instead, and this test should be updated to exempt it by name rather
+// than deleted.
+func TestCityConfigLoadersDeclineTheRevisionSnapshot(t *testing.T) {
+	const guarded = "cmd_agent.go"
+	const capturingCall = "config.LoadWithIncludes("
+	const decliningCall = "config.LoadWithIncludesOptions("
+	const option = "skipRevisionSnapshot"
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(currentFile), guarded))
+	if err != nil {
+		t.Fatalf("reading %s: %v", guarded, err)
+	}
+	text := string(src)
+
+	// capturingCall ends in '(' so it does not also match decliningCall, whose
+	// next character is 'O'.
+	if strings.Contains(text, capturingCall) {
+		t.Errorf("%s calls %s — that form always captures the revision snapshot; use %s..., %s)",
+			guarded, capturingCall, decliningCall, option)
+	}
+
+	// Scan line by line rather than with a bracket-matching regex: a pattern
+	// like `\([^)]*\)` truncates at the first ')', so a future call containing a
+	// nested call expression would fail spuriously with a misleading message.
+	found := 0
+	for i, line := range strings.Split(text, "\n") {
+		if !strings.Contains(line, decliningCall) {
+			continue
+		}
+		found++
+		if !strings.Contains(line, option) {
+			t.Errorf("%s:%d does not decline the revision snapshot: %s",
+				guarded, i+1, strings.TrimSpace(line))
+		}
+	}
+	if found == 0 {
+		t.Fatalf("no %s call in %s; this guard is no longer watching anything", decliningCall, guarded)
+	}
+}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -98,9 +98,26 @@ type LoadOptions struct {
 	// AllowMissingProviderReferences leaves provider-reference catalog errors
 	// non-fatal for repair tools that need to inspect broken configs.
 	AllowMissingProviderReferences bool
-	deferRigPatches                bool
-	deferredRigPatches             *[]deferredRigPatches
-	allowLegacyOrderLayouts        bool
+	// SkipRevisionSnapshot declines the load-time revision snapshot, which
+	// content-hashes every pack directory so that a later Revision() call can
+	// compare against the config as it was loaded.
+	//
+	// Only long-running processes ever compute a Revision; a one-shot command
+	// loads config, uses it and exits. Set this on those callers to skip work
+	// nothing will read.
+	//
+	// Declining the snapshot cannot change a revision VALUE: every read of it
+	// already falls back to reading from disk (writeRevisionDirHash,
+	// revisionSnapshotFile, revisionConventionDirs), so it is a prefetch, not
+	// an input. What it does give up is load-time faithfulness — a revision
+	// computed without it reflects the tree at Revision() time rather than at
+	// load time. That only matters to a caller holding a Provenance across a
+	// window in which the config may change, which is exactly the long-running
+	// case that should leave this false.
+	SkipRevisionSnapshot    bool
+	deferRigPatches         bool
+	deferredRigPatches      *[]deferredRigPatches
+	allowLegacyOrderLayouts bool
 }
 
 // LoadWithIncludes loads a city.toml and merges all included fragments.
@@ -773,8 +790,12 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 
 	// Capture revision inputs after all config and pack discovery so callers
 	// can compare the loaded snapshot to future reloads without re-reading
-	// mutable files from disk.
-	prov.captureRevisionSnapshot(fs, root, cityRoot)
+	// mutable files from disk. Callers that never compute a Revision opt out
+	// via SkipRevisionSnapshot; Revision falls back to reading from disk, so
+	// the value is the same either way.
+	if !opts.SkipRevisionSnapshot {
+		prov.captureRevisionSnapshot(fs, root, cityRoot)
+	}
 
 	return root, prov, nil
 }

--- a/internal/config/revision_test.go
+++ b/internal/config/revision_test.go
@@ -647,3 +647,120 @@ func TestWatchDirs_Deduplicates(t *testing.T) {
 		t.Errorf("got %d dirs, want 1 (deduplicated): %v", len(dirs), dirs)
 	}
 }
+
+// The revision snapshot is captured at load time so a later Revision() call can
+// compare against the config as it was loaded rather than as it is now. Building
+// it content-hashes every pack directory, which is pure cost for a caller that
+// never computes a Revision — and cmd/gc's city-config loaders do not even
+// return the Provenance. LoadOptions.SkipRevisionSnapshot lets those callers
+// decline it.
+//
+// Every read of the snapshot already falls back to reading from disk
+// (writeRevisionDirHash -> PackContentHashRecursive, revisionSnapshotFile ->
+// fs.ReadFile, revisionConventionDirs -> existingConventionDiscoveryDirsFS), so
+// declining it must not change a revision VALUE for anybody. The tests below pin
+// that, and pin that the option stays opt-in.
+
+// writeRevisionSnapshotOptCity builds a city whose revision covers more than
+// city.toml: a city pack directory and a convention-discovered agents tree, so
+// both the directory-hash and the convention-directory fallbacks are exercised.
+func writeRevisionSnapshotOptCity(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, dir, "city.toml", `[workspace]
+name = "revision-snapshot-opt"
+includes = ["packs/shared"]
+`)
+	writeFile(t, dir, "packs/shared/pack.toml", `[pack]
+name = "shared"
+schema = 1
+`)
+	writeFile(t, dir, "packs/shared/prompts/worker.md", "worker prompt body\n")
+	writeFile(t, dir, "agents/worker/prompt.template.md", "first prompt\n")
+	return dir
+}
+
+func TestSkipRevisionSnapshot_PreservesRevisionValue(t *testing.T) {
+	dir := writeRevisionSnapshotOptCity(t)
+	cityPath := filepath.Join(dir, "city.toml")
+
+	capturedCfg, capturedProv, err := LoadWithIncludesOptions(fsys.OSFS{}, cityPath, LoadOptions{})
+	if err != nil {
+		t.Fatalf("loading with snapshot: %v", err)
+	}
+	skippedCfg, skippedProv, err := LoadWithIncludesOptions(fsys.OSFS{}, cityPath, LoadOptions{SkipRevisionSnapshot: true})
+	if err != nil {
+		t.Fatalf("loading without snapshot: %v", err)
+	}
+
+	// Without these the test would compare two identical states and pass
+	// vacuously.
+	if capturedProv.revisionSnapshot == nil {
+		t.Fatal("default load captured no snapshot; the two arms are not different states")
+	}
+	if skippedProv.revisionSnapshot != nil {
+		t.Fatal("SkipRevisionSnapshot captured a snapshot anyway")
+	}
+
+	captured := Revision(fsys.OSFS{}, capturedProv, capturedCfg, dir)
+	skipped := Revision(fsys.OSFS{}, skippedProv, skippedCfg, dir)
+	if captured == "" {
+		t.Fatal("revision is empty; the fixture is not exercising Revision")
+	}
+	if captured != skipped {
+		t.Fatalf("revision differs without the snapshot:\n  with    %s\n  without %s", captured, skipped)
+	}
+}
+
+// TestSkipRevisionSnapshot_StillDetectsPackContentChange pins that declining the
+// prefetch does not blind revision comparison: editing a file inside a pack must
+// still change the revision, which is the property the reconciler depends on
+// (regression guard gastownhall/gascity#779). The default arm is a control — it
+// proves the edited file participates in the revision at all, so a passing
+// skipped arm means something.
+func TestSkipRevisionSnapshot_StillDetectsPackContentChange(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts LoadOptions
+	}{
+		{name: "default", opts: LoadOptions{}},
+		{name: "skip snapshot", opts: LoadOptions{SkipRevisionSnapshot: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := writeRevisionSnapshotOptCity(t)
+			cityPath := filepath.Join(dir, "city.toml")
+
+			cfg, prov, err := LoadWithIncludesOptions(fsys.OSFS{}, cityPath, tc.opts)
+			if err != nil {
+				t.Fatalf("loading: %v", err)
+			}
+			before := Revision(fsys.OSFS{}, prov, cfg, dir)
+
+			writeFile(t, dir, "packs/shared/prompts/worker.md", "edited prompt body\n")
+
+			reloadedCfg, reloadedProv, err := LoadWithIncludesOptions(fsys.OSFS{}, cityPath, tc.opts)
+			if err != nil {
+				t.Fatalf("reloading: %v", err)
+			}
+			after := Revision(fsys.OSFS{}, reloadedProv, reloadedCfg, dir)
+
+			if before == after {
+				t.Fatal("pack content edit did not change the revision; reconciler change detection would be blind")
+			}
+		})
+	}
+}
+
+// TestLoadWithIncludes_CapturesRevisionSnapshotByDefault pins that the option is
+// opt-in, so every existing caller keeps today's load-time-faithful behavior.
+func TestLoadWithIncludes_CapturesRevisionSnapshotByDefault(t *testing.T) {
+	dir := writeRevisionSnapshotOptCity(t)
+
+	_, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if prov.revisionSnapshot == nil {
+		t.Fatal("LoadWithIncludes captured no revision snapshot; the default changed")
+	}
+}


### PR DESCRIPTION
## The juicy parts

**There is no user-visible behaviour change here, and the measured win on upstream's fixture city is small**: `-36 allocs/op (-1.2%)` and `-1.1% B/op` on the existing `BenchmarkCityConfigParseOnly`, deterministic to the digit across three runs per arm. I am **not** quoting a wall-clock figure — on that fixture it sits inside run-to-run noise, and I removed a significance test rather than report one reached by optional stopping.

The case for the change is structural, not numeric. The three city-config loaders in `cmd_agent.go` return only `*config.City` and drop the `Provenance`, so nothing they load can ever observe the load-time revision snapshot they pay to build. Every reader of that snapshot already falls back to reading from disk, so declining it cannot change a revision value — that argument is the part I would most like checked.

The skipped work is one `PackContentHashRecursive` per pack directory, so it scales with the pack set, but that measurement comes from a city I cannot ship as a fixture and is not the headline. The option is opt-in; every other caller is byte-for-byte unchanged.

## What this is

`config.LoadOptions` gains `SkipRevisionSnapshot`, and the three city-config
loaders in `cmd/gc/cmd_agent.go` opt in.

The option is **opt-in**, so every other caller keeps today's behaviour byte for
byte.

## Why I was looking at this

I have been profiling `gc`'s own startup cost alongside
[#4441](https://github.com/gastownhall/gascity/issues/4441). This is not part of
that proposal and does not depend on it — it is a general-benefit change I ran
into underneath it, and it should be reviewed entirely on its own merits.

## The observation

`config.LoadWithIncludes` always captures a load-time revision snapshot, which
content-hashes every pack directory with `PackContentHashRecursive` so a later
`config.Revision()` can compare against the tree as it was loaded.

The three loaders in `cmd_agent.go` return only `*config.City`. They use the
`Provenance` to emit warnings and then drop it. Nothing they load can observe
the snapshot, so on those paths building it is unobservable work.

## Why declining it cannot change a revision value

This is the part I would most like checked, so here is the whole argument.

Every reader of the snapshot already falls back to reading from disk:

| reader | fallback |
| --- | --- |
| `writeRevisionDirHash` | `PackContentHashRecursive` |
| `revisionSnapshotFile` | `fs.ReadFile` |
| `revisionConventionDirs` | `existingConventionDiscoveryDirsFS` |

The snapshot is a **prefetch, not an input**. Declining it cannot produce a
different revision value.

What it does give up is *load-time faithfulness*: a `Revision()` computed later
reflects the tree as it is then, rather than as it was at load. That distinction
only matters to a caller holding a `Provenance` across a window in which config
may change — the long-running case, which loads through
`loadCityConfigWithBuiltinPacks` and keeps the default.

`captureRevisionSnapshot` also calls `recordMissingSourceContents`. I checked
every reader of `sourceContents`; none observes it on these paths.

## Measurement, and what I am deliberately not claiming

| | allocs/op | B/op |
| --- | ---: | ---: |
| `BenchmarkCityConfigParseOnly` before | 3,108 | 381,177 |
| after | 3,072 | 376,912 |
| | **-36 (-1.2%)** | **-1.1%** |

Those counts are deterministic — identical to the digit across three runs of
each arm.

**I am not quoting a wall-clock figure.** On upstream's small fixture city the
saving sits inside run-to-run noise. I originally had a significance test here
and removed it: the sample size had been extended *because* the first one was
not significant, which is optional stopping, and the resulting p-value would not
have meant what it appeared to mean. Rather than patch that up I have dropped
the timing claim and left the deterministic figure and the structural argument,
which are what actually support the change.

The saving scales with the pack set — the skipped work is one
`PackContentHashRecursive` per pack directory — so on a large city with many
packs it is worth materially more than it is on the upstream fixture. That
measurement comes from a city I cannot ship as a fixture, so I am not making it
the headline. **The case for this change is that the work is unobservable, not
that it is large.**

## The guard

`TestCityConfigLoadersDeclineTheRevisionSnapshot` is a source-level test rather
than a behavioural one, because the cost is invisible by construction: a loader
that reverts returns exactly the same config and passes every functional test.
It just re-reads every pack file. Nothing fails; it only gets slower — precisely
the regression a test suite does not otherwise catch.

It follows the file-scanning idiom of
`TestGCNonTestFilesStayOnRigProvisionBoundary` (`runtime.Caller(0)` +
`filepath.Dir` + substring needles) rather than inventing a new one.

I mutation-tested it, since a guard that cannot fail is worse than no guard:

- reverting a loader to `config.LoadWithIncludes(` → fails, naming the file
- keeping `...Options(` but dropping the option → fails, naming file and line

## Scope

Roughly a dozen other non-test call sites discard the `Provenance` the same way
— `init_provider_readiness.go`, `cmd_extmsg.go`, `doctor_v2_checks.go`,
`cmd_convoy.go`, `cmd_init.go`, `cmd_wait.go`, `internal/dispatch/control.go`
and others.

They are deliberately **out of scope** here and the guard does not speak for
them. I would rather land the narrow version and let you tell me whether the
broader sweep is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

