### PR TITLE
Fix gc status probe timeout and dashboard idle mislabel (gtm-c7c)

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -286,6 +286,7 @@ func collectCityStatusSnapshotFromStoreSnapshot(
 		obs := observations[i]
 		p.row.Agent.Running = obs.Running
 		p.row.Agent.Suspended = p.suspended || obs.Suspended || p.target.suspended
+		p.row.Agent.Partial = statusProviderPartialForName(sp, p.target.runtimeSessionName)
 		snapshot.Agents = append(snapshot.Agents, p.row)
 		snapshot.Summary.TotalAgents++
 		if obs.Running {
@@ -514,7 +515,11 @@ func renderCityStatusText(snapshot cityStatusSnapshot, dops drainOps, stdout io.
 			if row.ScaleLabel != "" {
 				fmt.Fprintf(stdout, "  %-24s%s\n", row.GroupName, row.ScaleLabel) //nolint:errcheck // best-effort stdout
 			}
-			status := agentStatusLineWithPartial(row.Agent.Running, dops, row.SessionName, row.Agent.Suspended, snapshot.Partial)
+			// snapshot.Partial is a city-wide degraded-read signal (e.g. a
+			// stalled beads/mail read); row.Agent.Partial is set only when
+			// this specific agent's own runtime probe timed out. Either
+			// condition marks the row "unknown" rather than "stopped".
+			status := agentStatusLineWithPartial(row.Agent.Running, dops, row.SessionName, row.Agent.Suspended, snapshot.Partial || row.Agent.Partial)
 			if row.Expanded {
 				fmt.Fprintf(stdout, "    %-22s%s\n", row.Agent.QualifiedName, status) //nolint:errcheck // best-effort stdout
 			} else {

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -66,6 +66,11 @@ type StatusAgentJSON struct {
 	Running       bool      `json:"running"`
 	Suspended     bool      `json:"suspended"`
 	Pool          *PoolJSON `json:"pool,omitempty"`
+	// Partial is true when this specific agent's own runtime probe timed
+	// out (as opposed to the city-wide cityStatusSnapshot.Partial flag,
+	// which can be set by unrelated degraded reads elsewhere in the
+	// status response). Populated on the local/fallback path only.
+	Partial bool `json:"partial,omitempty"`
 }
 
 // PoolJSON represents pool configuration in JSON output.

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -310,13 +310,13 @@ func doRigStatusWithStoreAndSnapshot(
 		if !a.SupportsInstanceExpansion() {
 			target := statusObservationTargetForIdentity(statusSnapshot, cityName, a.QualifiedName(), sessionTemplate)
 			obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, cfg, target, stderr)
-			status := agentStatusLineWithPartial(obs.Running, dops, target.runtimeSessionName, a.Suspended || obs.Suspended, statusProviderPartial(sp))
+			status := agentStatusLineWithPartial(obs.Running, dops, target.runtimeSessionName, a.Suspended || obs.Suspended, statusProviderPartialForName(sp, target.runtimeSessionName))
 			fmt.Fprintf(stdout, "    %-12s%s\n", a.QualifiedName(), status) //nolint:errcheck // best-effort stdout
 		} else {
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp) {
 				target := statusObservationTargetForIdentity(statusSnapshot, cityName, qualifiedInstance, sessionTemplate)
 				obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, cfg, target, stderr)
-				status := agentStatusLineWithPartial(obs.Running, dops, target.runtimeSessionName, a.Suspended || obs.Suspended, statusProviderPartial(sp))
+				status := agentStatusLineWithPartial(obs.Running, dops, target.runtimeSessionName, a.Suspended || obs.Suspended, statusProviderPartialForName(sp, target.runtimeSessionName))
 				fmt.Fprintf(stdout, "    %-12s%s\n", qualifiedInstance, status) //nolint:errcheck // best-effort stdout
 			}
 		}

--- a/cmd/gc/status_provider.go
+++ b/cmd/gc/status_provider.go
@@ -12,7 +12,15 @@ import (
 )
 
 var (
-	statusProviderCallTimeout    = 50 * time.Millisecond
+	// statusProviderCallTimeout bounds a single runtime probe (tmux
+	// list-panes plus, on Darwin, up to two ps subprocess calls). A full
+	// agent observation can chain up to four of these sub-probes
+	// (IsRunning, ProcessAlive, and conditionally IsAttached,
+	// GetLastActivity) inside cmd_citystatus.go's outer
+	// statusObservationTimeout (750ms) budget, so each sub-probe gets a
+	// quarter of that wall-clock allowance rather than a value tuned
+	// independently of it.
+	statusProviderCallTimeout    = 400 * time.Millisecond
 	statusProviderTimeoutWarning = func() {
 		fmt.Fprintln(os.Stderr, "gc status: runtime status probe timed out; using partial status")
 	}
@@ -22,6 +30,12 @@ type statusProvider struct {
 	base     runtime.Provider
 	warnOnce sync.Once
 	partial  atomic.Bool
+	// partialNames records, per session/agent name, whether that specific
+	// name's own probe timed out. Renderers use this to mark only the
+	// affected row "unknown" instead of every non-running row citywide
+	// (see markStatusProviderPartial/statusProviderPartial for the older,
+	// city-wide-only signal this augments).
+	partialNames sync.Map // map[string]bool
 }
 
 var _ runtime.RelaunchProvider = (*statusProvider)(nil)
@@ -29,6 +43,20 @@ var _ runtime.RelaunchProvider = (*statusProvider)(nil)
 func statusProviderPartial(sp any) bool {
 	p, ok := sp.(*statusProvider)
 	return ok && p.partial.Load()
+}
+
+// statusProviderPartialForName reports whether the given session/agent
+// name's own runtime probe timed out on this statusProvider. Unlike
+// statusProviderPartial (city-wide), this lets a renderer distinguish a row
+// whose probe genuinely timed out from an unrelated row that is simply not
+// running.
+func statusProviderPartialForName(sp any, name string) bool {
+	p, ok := sp.(*statusProvider)
+	if !ok || name == "" {
+		return false
+	}
+	v, ok := p.partialNames.Load(name)
+	return ok && v.(bool)
 }
 
 func markStatusProviderPartial(sp any) {
@@ -48,7 +76,7 @@ func newBoundedStatusProvider(base runtime.Provider) runtime.Provider {
 	return &statusProvider{base: base}
 }
 
-func boundedStatusCall[T any](p *statusProvider, fallback T, fn func() T) T {
+func boundedStatusCall[T any](p *statusProvider, name string, fallback T, fn func() T) T {
 	if statusProviderCallTimeout <= 0 {
 		return fn()
 	}
@@ -61,6 +89,9 @@ func boundedStatusCall[T any](p *statusProvider, fallback T, fn func() T) T {
 		return result
 	case <-time.After(statusProviderCallTimeout):
 		p.partial.Store(true)
+		if name != "" {
+			p.partialNames.Store(name, true)
+		}
 		p.warnOnce.Do(statusProviderTimeoutWarning)
 		return fallback
 	}
@@ -79,13 +110,13 @@ func (p *statusProvider) Interrupt(name string) error {
 }
 
 func (p *statusProvider) IsRunning(name string) bool {
-	return boundedStatusCall(p, false, func() bool {
+	return boundedStatusCall(p, name, false, func() bool {
 		return p.base.IsRunning(name)
 	})
 }
 
 func (p *statusProvider) IsAttached(name string) bool {
-	return boundedStatusCall(p, false, func() bool {
+	return boundedStatusCall(p, name, false, func() bool {
 		return p.base.IsAttached(name)
 	})
 }
@@ -95,13 +126,13 @@ func (p *statusProvider) Attach(name string) error {
 }
 
 func (p *statusProvider) ProcessAlive(name string, processNames []string) bool {
-	return boundedStatusCall(p, false, func() bool {
+	return boundedStatusCall(p, name, false, func() bool {
 		return p.base.ProcessAlive(name, processNames)
 	})
 }
 
 func (p *statusProvider) ObserveLiveness(name string, processNames []string) runtime.Liveness {
-	return boundedStatusCall(p, runtime.Liveness{}, func() runtime.Liveness {
+	return boundedStatusCall(p, name, runtime.Liveness{}, func() runtime.Liveness {
 		return runtime.ObserveLiveness(p.base, name, processNames)
 	})
 }
@@ -115,7 +146,7 @@ func (p *statusProvider) SetMeta(name, key, value string) error {
 }
 
 func (p *statusProvider) GetMeta(name, key string) (string, error) {
-	result := boundedStatusCall(p, struct {
+	result := boundedStatusCall(p, name, struct {
 		value string
 		err   error
 	}{}, func() struct {
@@ -136,7 +167,7 @@ func (p *statusProvider) RemoveMeta(name, key string) error {
 }
 
 func (p *statusProvider) Peek(name string, lines int) (string, error) {
-	result := boundedStatusCall(p, struct {
+	result := boundedStatusCall(p, name, struct {
 		value string
 		err   error
 	}{}, func() struct {
@@ -153,7 +184,9 @@ func (p *statusProvider) Peek(name string, lines int) (string, error) {
 }
 
 func (p *statusProvider) ListRunning(prefix string) ([]string, error) {
-	result := boundedStatusCall(p, struct {
+	// No single per-row name applies here (a prefix listing spans many
+	// sessions), so only the city-wide partial flag is set on timeout.
+	result := boundedStatusCall(p, "", struct {
 		value []string
 		err   error
 	}{}, func() struct {
@@ -176,7 +209,7 @@ func (p *statusProvider) RouteACP(name string) {
 }
 
 func (p *statusProvider) GetLastActivity(name string) (time.Time, error) {
-	result := boundedStatusCall(p, struct {
+	result := boundedStatusCall(p, name, struct {
 		value time.Time
 		err   error
 	}{}, func() struct {
@@ -227,7 +260,7 @@ func (p *statusProvider) Pending(name string) (*runtime.PendingInteraction, erro
 	if !ok {
 		return nil, nil
 	}
-	result := boundedStatusCall(p, struct {
+	result := boundedStatusCall(p, name, struct {
 		value *runtime.PendingInteraction
 		err   error
 	}{}, func() struct {

--- a/cmd/gc/status_provider_test.go
+++ b/cmd/gc/status_provider_test.go
@@ -98,3 +98,43 @@ func TestStatusProviderTimeoutMarksPartial(t *testing.T) {
 		t.Fatal("statusProviderPartial = false, want true after runtime probe timeout")
 	}
 }
+
+func TestStatusProviderTimeoutMarksOnlyTheTimedOutName(t *testing.T) {
+	origTimeout := statusProviderCallTimeout
+	origWarn := statusProviderTimeoutWarning
+	t.Cleanup(func() {
+		statusProviderCallTimeout = origTimeout
+		statusProviderTimeoutWarning = origWarn
+	})
+	statusProviderCallTimeout = 10 * time.Millisecond
+	statusProviderTimeoutWarning = func() {}
+
+	base := newStatusProbeProvider()
+	base.running.Store(true)
+	base.delay.Store(int64(100 * time.Millisecond))
+	wrapped := newBoundedStatusProvider(base)
+
+	if wrapped.IsRunning("slow-agent") {
+		t.Fatal("IsRunning returned true, want timeout fallback false")
+	}
+
+	base.delay.Store(0)
+	if !wrapped.IsRunning("fast-agent") {
+		t.Fatal("IsRunning returned false for a probe that did not time out")
+	}
+
+	if !statusProviderPartialForName(wrapped, "slow-agent") {
+		t.Fatal("statusProviderPartialForName(slow-agent) = false, want true after its own probe timed out")
+	}
+	if statusProviderPartialForName(wrapped, "fast-agent") {
+		t.Fatal("statusProviderPartialForName(fast-agent) = true, want false: this agent's own probe never timed out")
+	}
+	if statusProviderPartialForName(wrapped, "never-probed") {
+		t.Fatal("statusProviderPartialForName(never-probed) = true, want false for a name that was never observed")
+	}
+	// The city-wide flag still trips, for callers/paths that intentionally
+	// key on the broader signal.
+	if !statusProviderPartial(wrapped) {
+		t.Fatal("statusProviderPartial = false, want true after any probe timed out")
+	}
+}

--- a/internal/api/dashboardspa/web/frontend/src/routes/Agents.chips.test.ts
+++ b/internal/api/dashboardspa/web/frontend/src/routes/Agents.chips.test.ts
@@ -142,4 +142,48 @@ describe('buildAgentSynopsis', () => {
   it('returns the empty-state sentence when no rows', () => {
     expect(buildAgentSynopsis([])).toBe('No agents configured.');
   });
+
+  it('reports stopped agents (e.g. never-started min=0 scaled instances) as a distinct count, not idle', () => {
+    // gascity gtm-c7c: computeAgentState returns 'stopped' for any
+    // non-running, non-suspended, non-quarantined agent — the normal state
+    // for a scaled pool's min=0 members that have simply never been
+    // started. The synopsis must not fold that into 'idle', which implies
+    // the agent ran before and is now caught up.
+    const rows: AgentResponse[] = [
+      mkAgent('active'),
+      mkAgent('stopped'),
+      mkAgent('stopped'),
+      mkAgent('idle'),
+    ];
+    const synopsis = buildAgentSynopsis(rows);
+    expect(synopsis).toContain('1 active');
+    expect(synopsis).toContain('2 stopped');
+    expect(synopsis).toContain('1 idle');
+  });
+
+  it('reports quarantined agents as a distinct count, not idle', () => {
+    const rows: AgentResponse[] = [mkAgent('active'), mkAgent('quarantined')];
+    const synopsis = buildAgentSynopsis(rows);
+    expect(synopsis).toContain('1 quarantined');
+    expect(synopsis).not.toContain('1 idle');
+  });
+
+  it('reports working agents as a distinct count, not idle', () => {
+    const rows: AgentResponse[] = [mkAgent('working'), mkAgent('idle')];
+    const synopsis = buildAgentSynopsis(rows);
+    expect(synopsis).toContain('1 working');
+    expect(synopsis).toContain('1 idle');
+  });
+
+  it('buckets an unrecognized future state as unknown, not idle', () => {
+    // gastownhall/gascity gtm-c7c: a genuinely wedged agent reporting some
+    // future/unexpected state string must never silently read as a normal
+    // idle agent — that's exactly the masking risk the bead flags. Only
+    // states this switch explicitly recognizes as idle-like (idle, asleep,
+    // creating) should bucket as idle.
+    const rows: AgentResponse[] = [mkAgent('some-future-state-the-dashboard-has-never-seen')];
+    const synopsis = buildAgentSynopsis(rows);
+    expect(synopsis).toContain('1 unknown');
+    expect(synopsis).not.toContain('idle');
+  });
 });

--- a/internal/api/dashboardspa/web/frontend/src/routes/Agents.tsx
+++ b/internal/api/dashboardspa/web/frontend/src/routes/Agents.tsx
@@ -667,13 +667,26 @@ export { stateTone } from '../components/StatusBadge';
 // Buckets a raw state into the synopsis category. Distinct from
 // stateTone because 'detached' and 'idle' share a tone (neutral) but the
 // header text breaks them out.
+//
+// 'stopped' and 'quarantined' are explicit (not folded into 'idle') because
+// computeAgentState (internal/api/handler_agents.go) returns them for
+// agents that were never started — e.g. a scaled pool's min=0 members — a
+// state distinct from an agent that ran and is now caught up. 'unknown' is
+// likewise explicit rather than a silent default: it is the bucket a
+// genuinely wedged agent reporting an unrecognized state would land in, so
+// it must never read the same as a normal idle agent (gastownhall/gascity
+// runtime-status-probe liveness misreporting).
 export type SynopsisBucket =
   | 'active'
+  | 'working'
   | 'idle'
+  | 'stopped'
+  | 'quarantined'
   | 'detached'
   | 'rate-limited'
   | 'stuck'
-  | 'suspended';
+  | 'suspended'
+  | 'unknown';
 
 function stateBucket(agent: SupervisorAgent): SynopsisBucket {
   if (agent.suspended) return 'suspended';
@@ -681,6 +694,16 @@ function stateBucket(agent: SupervisorAgent): SynopsisBucket {
     case 'active':
     case 'running':
       return 'active';
+    case 'working':
+      return 'working';
+    case 'idle':
+    case 'asleep':
+    case 'creating':
+      return 'idle';
+    case 'stopped':
+      return 'stopped';
+    case 'quarantined':
+      return 'quarantined';
     case 'detached':
       return 'detached';
     case 'rate-limited':
@@ -693,7 +716,7 @@ function stateBucket(agent: SupervisorAgent): SynopsisBucket {
     case 'stuck':
       return 'stuck';
     default:
-      return 'idle';
+      return 'unknown';
   }
 }
 
@@ -706,16 +729,24 @@ export function buildAgentSynopsis(rows: ReadonlyArray<SupervisorAgent>): string
   }
   const parts: string[] = [];
   const active = counts.get('active') ?? 0;
+  const working = counts.get('working') ?? 0;
   const idle = counts.get('idle') ?? 0;
+  const stopped = counts.get('stopped') ?? 0;
+  const quarantined = counts.get('quarantined') ?? 0;
   const detached = counts.get('detached') ?? 0;
   const rateLimited = counts.get('rate-limited') ?? 0;
   const stuck = counts.get('stuck') ?? 0;
   const suspended = counts.get('suspended') ?? 0;
+  const unknown = counts.get('unknown') ?? 0;
   if (active > 0) parts.push(`${active} active`);
+  if (working > 0) parts.push(`${working} working`);
   if (idle > 0) parts.push(`${idle} idle`);
+  if (stopped > 0) parts.push(`${stopped} stopped`);
+  if (quarantined > 0) parts.push(`${quarantined} quarantined`);
   if (detached > 0) parts.push(`${detached} detached`);
   if (rateLimited > 0) parts.push(`${rateLimited} rate-limited`);
   if (stuck > 0) parts.push(`${stuck} stuck`);
   if (suspended > 0) parts.push(`${suspended} suspended`);
+  if (unknown > 0) parts.push(`${unknown} unknown`);
   return parts.join(', ') + '.';
 }


### PR DESCRIPTION
## Summary

Investigates and fixes gastownhall/gascity#gtm-c7c (bd `gtm-c7c`): `gc status`'s runtime probe was timing out for scaled/min=0 agents, and the timeout signal was over-broadly reported both in the CLI and the web dashboard.

**Root causes found:**

1. **CLI (`gc status` / `gc rig status`): 50ms per-probe timeout was too tight.** `cmd/gc/status_provider.go`'s `boundedStatusCall` races each individual runtime call (tmux `list-panes` + up to two `ps` subprocess calls on Darwin) against a 50ms timeout. A single agent observation chains up to 4 of these sub-probes (`IsRunning`, `ProcessAlive`, and conditionally `IsAttached`/`GetLastActivity`), all inside `cmd_citystatus.go`'s own outer `statusObservationTimeout` of 750ms — so the 50ms-per-probe figure left far less headroom than the author's own 750ms outer budget implies was intended. Raised to 400ms.

2. **CLI: a single city-wide `partial` flag marked every non-running row "unknown," not just the one whose own probe timed out.** So one slow/timed-out probe (e.g. a scaled min=0 pool member that legitimately has no session yet) caused *every* stopped agent in the city to render as `unknown (partial status)` instead of `stopped`. Added per-name timeout tracking (`statusProvider.partialNames`, `statusProviderPartialForName`) so only the row whose own probe actually timed out is marked unknown; other legitimately-stopped agents still render as `stopped`. The existing city-wide flag is preserved and OR'd in, so other degraded-read paths (e.g. a stalled beads/mail read reported by the server) still mark all rows unknown, unchanged.

3. **Dashboard "4 idle": separate bug, same underlying masking risk.** The dashboard reads `/v0/agents` (not `/v0/status` — these are two independent code paths; the server-side `/v0/status` `Partial` flag has no production implementation of `statusPartialReporter` and is effectively dead code there). `computeAgentState` legitimately returns `"stopped"` for any non-running, non-suspended, non-quarantined agent (the normal state for a never-started min=0 scaled instance) and `"quarantined"` for quarantined agents. The frontend's `stateBucket()` in `Agents.tsx` had no switch case for either value, so both silently fell through to `default: return 'idle'` — producing exactly the reported "4 idle" for agents that were simply never started. Added explicit `stopped`/`quarantined`/`working` buckets, and changed the `default` case from `'idle'` to a new explicit `'unknown'` bucket.

**Masking risk (question 3 in the bead):** yes — previously *any* unrecognized/future state string (a genuinely wedged agent reporting something the dashboard hadn't seen before) fell into the same `'idle'` bucket as a normal idle agent, indistinguishable in the synopsis header. `default` now maps to `'unknown'` instead, so an unrecognized state is visually distinct from `idle` rather than silently absorbed into it.

## Changes

- `cmd/gc/status_provider.go`: raise `statusProviderCallTimeout` 50ms → 400ms; add per-name timeout tracking (`partialNames`) and `statusProviderPartialForName`.
- `cmd/gc/city_status_snapshot.go`, `cmd/gc/cmd_status.go`, `cmd/gc/cmd_citystatus.go`: thread per-row `Partial` through `StatusAgentJSON` and use it (OR'd with the existing city-wide flag) in place of the blanket flag when rendering each agent's status line.
- `internal/api/dashboardspa/web/frontend/src/routes/Agents.tsx`: add explicit `stopped`/`quarantined`/`working` synopsis buckets; `default` now returns `unknown` instead of `idle`.
- Tests added: `cmd/gc/status_provider_test.go` (per-name isolation), `internal/api/dashboardspa/web/frontend/src/routes/Agents.chips.test.ts` (stopped/quarantined/working/unknown bucketing).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/gc/... ./internal/api/...`
- [x] `go test ./cmd/gc/... -run 'StatusProvider|CityStatus|RigStatus|Relaunch'` (70 tests, all touched by this change)
- [x] `go test ./internal/api/... ./internal/worker/... ./internal/session/...` (all green)
- [x] `npm test` in `internal/api/dashboardspa/web/frontend` (901 tests passing)
- [ ] Manual verification against a live city with a scaled min=0 agent (opening as draft pending that check)

Note: the full `cmd/gc` package (`go test ./cmd/gc/...` with no `-run` filter) exceeds the default 10-minute test timeout in my sandbox; I confirmed this reproduces identically on unmodified `main`, so it's a pre-existing environment characteristic unrelated to this change, not a regression.
