### PR TITLE
perf(preflight): validate the shared synthetic pack cache once per readiness pass

### DIFF
--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -64,16 +64,20 @@ func EnsureBuiltinRuntimeAssets(cityPath string, warningWriter io.Writer) error 
 		pruneRetiredSystemPacks(cityPath, warningWriter)
 		return nil
 	}
-	if state.ready && requiredBuiltinSourcesUsable(cityPath) && lockedBundledImportsUsable(cityPath) {
+	// One verifier for the whole pass: the ready fast path and the repair path
+	// both validate the shared synthetic cache directory, and within a single
+	// pass that is the same question asked repeatedly.
+	verifier := newSyntheticCacheVerifier()
+	if state.ready && requiredBuiltinSourcesUsable(cityPath, verifier) && lockedBundledImportsUsable(cityPath, verifier) {
 		return nil
 	}
 	state.ready = false
 
 	var problems []error
-	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+	if err := ensureBundledLockedRemoteImportsCached(cityPath, verifier); err != nil {
 		problems = append(problems, err)
 	}
-	if err := ensureRequiredBuiltinSourcesCached(cityPath); err != nil {
+	if err := ensureRequiredBuiltinSourcesCached(cityPath, verifier); err != nil {
 		problems = append(problems, err)
 	}
 	if err := ensureGcBeadsBdShim(cityPath); err != nil {
@@ -82,7 +86,9 @@ func EnsureBuiltinRuntimeAssets(cityPath string, warningWriter io.Writer) error 
 	pruneRetiredSystemPacks(cityPath, warningWriter)
 
 	if len(problems) > 0 {
-		if !requiredBuiltinSourcesUsable(cityPath) {
+		// A fresh verifier: the repairs above just rewrote caches, so this
+		// last-resort check must not reuse anything decided before them.
+		if !requiredBuiltinSourcesUsable(cityPath, newSyntheticCacheVerifier()) {
 			state.lastWarning = ""
 			return fmt.Errorf("preparing builtin pack caches: %w", problems[0])
 		}
@@ -236,14 +242,17 @@ func builtinImportsForNames(names []string) (map[string]config.Import, []string)
 // required bundled sources at the canonical pin, independent of packs.lock,
 // so the stable shim target and pre-migration cities always have the
 // current binary's content available.
-func ensureRequiredBuiltinSourcesCached(cityPath string) error {
+// The verifier scopes cache validation to the calling readiness pass; every
+// required source of a repository shares one synthetic cache directory, so
+// without it the same directory is walked once per source.
+func ensureRequiredBuiltinSourcesCached(cityPath string, verifier *syntheticCacheVerifier) error {
 	commit := bundledPackImportCommit()
 	for name, source := range requiredBuiltinSources(cityPath) {
 		cachePath, err := packman.RepoCachePath(source, commit)
 		if err != nil {
 			return fmt.Errorf("resolving cache path for bundled %s pack: %w", name, err)
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, commit) == nil {
+		if verifier.Valid(cachePath, commit) {
 			continue
 		}
 		if _, err := packman.EnsureRepoInCache(cityPath, source, commit); err != nil {
@@ -253,14 +262,14 @@ func ensureRequiredBuiltinSourcesCached(cityPath string) error {
 	return nil
 }
 
-func requiredBuiltinSourcesUsable(cityPath string) bool {
+func requiredBuiltinSourcesUsable(cityPath string, verifier *syntheticCacheVerifier) bool {
 	commit := bundledPackImportCommit()
 	for _, source := range requiredBuiltinSources(cityPath) {
 		cachePath, err := packman.RepoCachePath(source, commit)
 		if err != nil {
 			return false
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, commit) != nil {
+		if !verifier.Valid(cachePath, commit) {
 			return false
 		}
 	}

--- a/cmd/gc/legacy_pack_preflight.go
+++ b/cmd/gc/legacy_pack_preflight.go
@@ -74,8 +74,9 @@ func lockedBundledCanonicalImports(cityPath string) ([]lockedBundledImport, erro
 // install". A cache that already validates is skipped lock-free; only on
 // validation failure does the preflight take the write-locked
 // packman.EnsureRepoInCache repair path, which revalidates under the lock
-// (a concurrent repair between the two checks is therefore benign).
-func ensureBundledLockedRemoteImportsCached(cityPath string) error {
+// (a concurrent repair between the two checks is therefore benign). The
+// verifier scopes that validation to the calling readiness pass.
+func ensureBundledLockedRemoteImportsCached(cityPath string, verifier *syntheticCacheVerifier) error {
 	imports, err := lockedBundledCanonicalImports(cityPath)
 	if err != nil {
 		return err
@@ -85,7 +86,7 @@ func ensureBundledLockedRemoteImportsCached(cityPath string) error {
 		if err != nil {
 			return fmt.Errorf("resolving cache path for bundled import %q from packs.lock: %w", imp.source, err)
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, imp.commit) == nil {
+		if verifier.Valid(cachePath, imp.commit) {
 			continue
 		}
 		if _, err := packman.EnsureRepoInCache(cityPath, imp.source, imp.commit); err != nil {
@@ -104,7 +105,8 @@ func ensureBundledLockedRemoteImportsCached(cityPath string) error {
 // locked-but-missing synthetic cache. A lockfile that cannot be read or that
 // has a malformed entry is reported unusable so the caller falls through to
 // ensureBundledLockedRemoteImportsCached, which surfaces the underlying error.
-func lockedBundledImportsUsable(cityPath string) bool {
+// The verifier scopes that validation to the calling readiness pass.
+func lockedBundledImportsUsable(cityPath string, verifier *syntheticCacheVerifier) bool {
 	imports, err := lockedBundledCanonicalImports(cityPath)
 	if err != nil {
 		return false
@@ -114,7 +116,7 @@ func lockedBundledImportsUsable(cityPath string) bool {
 		if err != nil {
 			return false
 		}
-		if builtinpacks.ValidateSyntheticRepo(cachePath, imp.commit) != nil {
+		if !verifier.Valid(cachePath, imp.commit) {
 			return false
 		}
 	}

--- a/cmd/gc/legacy_pack_preflight_test.go
+++ b/cmd/gc/legacy_pack_preflight_test.go
@@ -21,7 +21,7 @@ func TestEnsureBundledLockedRemoteImportsCachedHydratesBundledLockEntry(t *testi
 	commit := strings.TrimPrefix(config.PublicGastownPackVersion, "sha:")
 	writePreflightImportLock(t, cityPath, commit)
 
-	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+	if err := ensureBundledLockedRemoteImportsCached(cityPath, newSyntheticCacheVerifier()); err != nil {
 		t.Fatalf("ensureBundledLockedRemoteImportsCached returned error: %v", err)
 	}
 
@@ -42,7 +42,7 @@ func TestEnsureBundledLockedRemoteImportsCachedValidatesWarmCacheWithoutWriteLoc
 	commit := strings.TrimPrefix(config.PublicGastownPackVersion, "sha:")
 	writePreflightImportLock(t, cityPath, commit)
 
-	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+	if err := ensureBundledLockedRemoteImportsCached(cityPath, newSyntheticCacheVerifier()); err != nil {
 		t.Fatalf("cold hydration returned error: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestEnsureBundledLockedRemoteImportsCachedValidatesWarmCacheWithoutWriteLoc
 	}()
 
 	warm := make(chan error, 1)
-	go func() { warm <- ensureBundledLockedRemoteImportsCached(cityPath) }()
+	go func() { warm <- ensureBundledLockedRemoteImportsCached(cityPath, newSyntheticCacheVerifier()) }()
 	select {
 	case err := <-warm:
 		if err != nil {
@@ -87,7 +87,7 @@ func TestEnsureBundledLockedRemoteImportsCachedRejectsBundledLockEntryWithoutCom
 	source := config.PublicGastownPackSource
 	writePreflightImportLock(t, cityPath, "")
 
-	err := ensureBundledLockedRemoteImportsCached(cityPath)
+	err := ensureBundledLockedRemoteImportsCached(cityPath, newSyntheticCacheVerifier())
 	if err == nil {
 		t.Fatal("ensureBundledLockedRemoteImportsCached succeeded, want missing commit error")
 	}
@@ -112,7 +112,7 @@ fetched = "2026-01-01T00:00:00Z"
 		t.Fatal(err)
 	}
 
-	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+	if err := ensureBundledLockedRemoteImportsCached(cityPath, newSyntheticCacheVerifier()); err != nil {
 		t.Fatalf("ensureBundledLockedRemoteImportsCached returned error: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(home, ".gc", "cache", "repos")); !os.IsNotExist(err) {
@@ -149,7 +149,7 @@ func TestEnsureBundledLockedRemoteImportsCachedSkipsNonCanonicalBundledPin(t *te
 	cityPath := t.TempDir()
 	writePreflightImportLock(t, cityPath, "0123456789abcdef0123456789abcdef01234567")
 
-	if err := ensureBundledLockedRemoteImportsCached(cityPath); err != nil {
+	if err := ensureBundledLockedRemoteImportsCached(cityPath, newSyntheticCacheVerifier()); err != nil {
 		t.Fatalf("ensureBundledLockedRemoteImportsCached returned error: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(home, ".gc", "cache", "repos")); !os.IsNotExist(err) {

--- a/cmd/gc/synthetic_cache_verifier.go
+++ b/cmd/gc/synthetic_cache_verifier.go
@@ -1,0 +1,48 @@
+package main
+
+import "github.com/gastownhall/gascity/internal/builtinpacks"
+
+// syntheticCacheVerifier deduplicates builtinpacks.ValidateSyntheticRepo
+// within ONE builtin readiness pass.
+//
+// Every bundled source of a repository resolves to a single synthetic cache
+// directory — the cache key strips the subpath — and ValidateSyntheticRepo
+// checks every pack layout in that directory regardless of which source asked.
+// requiredBuiltinSourcesUsable and lockedBundledImportsUsable therefore ask the
+// identical question about the identical directory, and that question is not
+// cheap: it os.ReadFile's every cached pack file and compares it against the
+// copy embedded in the running binary.
+//
+// Only POSITIVE verdicts are memoized, and that is what makes the repair paths
+// safe: no verdict about a broken cache is ever recorded, so there is nothing
+// stale for a caller to observe after it repairs one. A caller that repaired a
+// cache necessarily got its negative verdict from a full validation, and the
+// next question about that directory runs a full validation too.
+//
+// A verifier is scoped to one readiness pass and is not safe for concurrent
+// use. A verdict therefore never outlives the pass that produced it: every
+// pass still runs the full validator at least once, which is what detects and
+// repairs a corrupted cache.
+type syntheticCacheVerifier struct {
+	valid map[string]struct{}
+}
+
+// newSyntheticCacheVerifier returns a verifier scoped to a single readiness
+// pass.
+func newSyntheticCacheVerifier() *syntheticCacheVerifier {
+	return &syntheticCacheVerifier{valid: make(map[string]struct{})}
+}
+
+// Valid reports whether the synthetic pack cache at cachePath validates for
+// commit, reusing a positive verdict already reached in this pass.
+func (v *syntheticCacheVerifier) Valid(cachePath, commit string) bool {
+	key := cachePath + "\x00" + commit
+	if _, ok := v.valid[key]; ok {
+		return true
+	}
+	if builtinpacks.ValidateSyntheticRepo(cachePath, commit) != nil {
+		return false
+	}
+	v.valid[key] = struct{}{}
+	return true
+}

--- a/cmd/gc/synthetic_cache_verifier_test.go
+++ b/cmd/gc/synthetic_cache_verifier_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/builtinpacks"
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+// TestReadinessHelpersValidateTheSharedCacheOncePerPass pins the contract the
+// verifier exists for, and pins its scope in the same test.
+//
+// Every bundled source of a repository resolves to ONE synthetic cache
+// directory, and ValidateSyntheticRepo checks every pack layout in that
+// directory regardless of which source asked. requiredBuiltinSourcesUsable and
+// lockedBundledImportsUsable therefore asked the identical question, and that
+// question re-reads every cached pack file to compare it against the embedded
+// copy.
+//
+// The two assertions are deliberately opposed: with no memo the first fails,
+// with a memo that outlives the pass the second fails. Neither can pass
+// vacuously, and the second is the self-healing contract in miniature.
+func TestReadinessHelpersValidateTheSharedCacheOncePerPass(t *testing.T) {
+	clearGCEnv(t) // isolated GC_HOME so the corruption never touches the shared test cache
+	city := t.TempDir()
+
+	source, ok := builtinpacks.Source("core")
+	if !ok {
+		t.Fatal(`builtinpacks.Source("core") is not registered`)
+	}
+	commit := bundledPackImportCommit()
+	writeBundledSourceImportLock(t, city, source, commit)
+
+	cacheDir := materializeSyntheticCacheForTest(t, source, commit)
+
+	pass := newSyntheticCacheVerifier()
+	if !requiredBuiltinSourcesUsable(city, pass) {
+		t.Fatal("required builtin sources unusable against a freshly materialized cache")
+	}
+	if !lockedBundledImportsUsable(city, newSyntheticCacheVerifier()) {
+		t.Fatal("locked bundled imports unusable against a freshly materialized cache")
+	}
+
+	corruptCachedPackFileForTest(t, cacheDir)
+
+	// The required-sources helper already validated this exact directory in
+	// this pass. The locked-imports helper must not walk it again — if it
+	// does, it sees the corruption and reports unusable.
+	if !lockedBundledImportsUsable(city, pass) {
+		t.Error("the second readiness helper re-validated a directory the first already validated in the same pass; the duplicate walk is back")
+	}
+
+	// A new pass must see the corruption, or nothing would ever self-heal.
+	if lockedBundledImportsUsable(city, newSyntheticCacheVerifier()) {
+		t.Error("a new pass reused a verdict from a previous one; a corrupted cache would never be repaired")
+	}
+}
+
+// TestSyntheticCacheVerifierDoesNotMemoizeNegativeVerdicts pins that a failed
+// verdict is never remembered. A negative means the caller is about to repair
+// the cache, so memoizing it would make the post-repair re-check answer about
+// the pre-repair state.
+func TestSyntheticCacheVerifierDoesNotMemoizeNegativeVerdicts(t *testing.T) {
+	clearGCEnv(t)
+	source, ok := builtinpacks.Source("core")
+	if !ok {
+		t.Fatal(`builtinpacks.Source("core") is not registered`)
+	}
+	commit := bundledPackImportCommit()
+	cacheDir := materializeSyntheticCacheForTest(t, source, commit)
+
+	pass := newSyntheticCacheVerifier()
+	corruptCachedPackFileForTest(t, cacheDir)
+	if pass.Valid(cacheDir, commit) {
+		t.Fatal("corrupted cache reported valid")
+	}
+
+	// Stand in for the repair every caller performs after a negative verdict.
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+		t.Fatalf("re-materializing the cache: %v", err)
+	}
+
+	if !pass.Valid(cacheDir, commit) {
+		t.Error("the verifier memoized a negative verdict; a repaired cache still reads as broken")
+	}
+}
+
+// TestEnsureRequiredBuiltinSourcesCachedRevalidatesAfterItsOwnRepair walks the
+// production repair sequence rather than the verifier in isolation: a helper
+// reaches a negative verdict, repairs the cache, and something later in the
+// same pass asks about the same directory again. It must see the repaired tree.
+//
+// This is the sequence that would break if negative verdicts were ever
+// memoized, and it holds regardless of the order the required-sources loop
+// happens to visit its map in: every entry resolves to the same
+// (cacheDir, commit) memo key, so whichever entry takes the repair branch, the
+// rest re-derive their verdict from the repaired tree.
+func TestEnsureRequiredBuiltinSourcesCachedRevalidatesAfterItsOwnRepair(t *testing.T) {
+	clearGCEnv(t)
+	city := t.TempDir()
+	source, ok := builtinpacks.Source("core")
+	if !ok {
+		t.Fatal(`builtinpacks.Source("core") is not registered`)
+	}
+	commit := bundledPackImportCommit()
+	cacheDir := materializeSyntheticCacheForTest(t, source, commit)
+
+	// The order-independence claim above holds only while every required
+	// source really does resolve to this one directory. Pin that rather than
+	// leave the coverage incidental to the current pack registry.
+	for name, required := range requiredBuiltinSources(city) {
+		path, err := packman.RepoCachePath(required, commit)
+		if err != nil {
+			t.Fatalf("RepoCachePath(%q): %v", required, err)
+		}
+		if path != cacheDir {
+			t.Fatalf("required source %q resolves to %s, not the single cache dir %s; this test no longer covers every map ordering", name, path, cacheDir)
+		}
+	}
+
+	corruptCachedPackFileForTest(t, cacheDir)
+
+	pass := newSyntheticCacheVerifier()
+	if requiredBuiltinSourcesUsable(city, pass) {
+		t.Fatal("corrupted cache reported usable")
+	}
+	if err := ensureRequiredBuiltinSourcesCached(city, pass); err != nil {
+		t.Fatalf("ensureRequiredBuiltinSourcesCached: %v", err)
+	}
+
+	if !requiredBuiltinSourcesUsable(city, pass) {
+		t.Error("the pass carried a verdict from before its own repair; a repaired cache still reads as broken")
+	}
+}
+
+// materializeSyntheticCacheForTest writes the running binary's bundled pack
+// tree to the cache directory source+commit resolves to, and returns it.
+func materializeSyntheticCacheForTest(t *testing.T, source, commit string) string {
+	t.Helper()
+	cacheDir, err := packman.RepoCachePath(source, commit)
+	if err != nil {
+		t.Fatalf("RepoCachePath(%q): %v", source, err)
+	}
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+		t.Fatalf("MaterializeSyntheticRepo: %v", err)
+	}
+	return cacheDir
+}
+
+// corruptCachedPackFileForTest rewrites one cached pack file so the cache no
+// longer matches the content embedded in the running binary. Only the
+// whole-tree walk detects this — the cache marker still reads clean.
+func corruptCachedPackFileForTest(t *testing.T, cacheDir string) {
+	t.Helper()
+	pack, ok := builtinpacks.ByName("core")
+	if !ok {
+		t.Fatal(`builtinpacks.ByName("core") is not registered`)
+	}
+	target := filepath.Join(cacheDir, filepath.FromSlash(pack.Subpath), "pack.toml")
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("cached core pack.toml is missing: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("[pack]\nname = \"tampered\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatalf("corrupting cached pack file: %v", err)
+	}
+}
+
+// writeBundledSourceImportLock pins one bundled source in the city's packs.lock
+// so lockedBundledCanonicalImports reports it. Unlike writePreflightImportLock
+// it takes the source, because these tests need a lock entry that resolves to
+// the SAME cache directory as the required builtin sources.
+func writeBundledSourceImportLock(t *testing.T, cityPath, source, commit string) {
+	t.Helper()
+	lockToml := fmt.Sprintf(`schema = 1
+
+[packs.%q]
+version = "1.0.0"
+commit = %q
+fetched = "2026-01-01T00:00:00Z"
+`, source, commit)
+	if err := os.WriteFile(filepath.Join(cityPath, packman.LockfileName), []byte(lockToml), 0o644); err != nil {
+		t.Fatalf("writing packs.lock: %v", err)
+	}
+}


### PR DESCRIPTION
## The juicy parts

A user waits on the builtin readiness pass on every single `gc` invocation, and that pass currently walks and byte-compares the same synthetic cache directory several times over, because each bundled source asks about it separately. After this, each `(cacheDir, commit)` pair is validated once per pass: **4 full walks down to 1** on a bd-provider city with a `packs.lock`, and **5 down to 2** on a `gc init --config gastown` city.

The evidence is structural rather than timed — the call-count claim is verifiable by reading the diff, with no benchmark. **I have no wall-clock number of my own for this one and I am not borrowing anyone else's.** The saving is also smaller on a pass that actually repairs a cache (~3 walks, not 1), and the self-healing contract is unchanged: only positive verdicts are memoized, and a verdict never outlives the pass that produced it.

## What this is

The builtin readiness pass now validates each synthetic pack cache directory
once, instead of once per bundled source that happens to resolve to it.

For a plain bd-provider city — where `packs.lock` pins `core` and `bd`, both of
which resolve to the same directory — that is **4 full walks of the bundled
pack tree per pass, down to 1**. For a `gc init --config gastown` city, which
additionally locks the public gastown pack in a second repository, it is **5
down to 2**.

No behaviour change. The self-healing contract is untouched: the full validator
still runs at least once every pass.

## Why I was looking at this

I have been profiling `gc`'s own startup cost alongside
[#4441](https://github.com/gastownhall/gascity/issues/4441). This is not part of
that proposal and does not depend on it; it is a general-benefit change I ran
into underneath it, and it should be reviewed on its own merits. It is the same
category as #4723, #4565 and #4768 — make the path `gc` walks on every
invocation cheaper.

## The observation

A repo cache directory is keyed on the normalized clone URL **with the subpath
stripped**. Every bundled source of a repository therefore resolves to *one*
directory, and `ValidateSyntheticRepo` checks every pack layout in that
directory regardless of which source asked.

Two helpers ask that question, and they ask the identical question:

- `requiredBuiltinSourcesUsable` / `ensureRequiredBuiltinSourcesCached`, once
  per required source (`core`, plus `bd` on a bd-provider city, plus `dolt` on
  a direct-exec lifecycle);
- `lockedBundledImportsUsable` / `ensureBundledLockedRemoteImportsCached`, once
  per bundled source pinned at its canonical commit in `packs.lock`.

The question is not cheap. `ValidateSyntheticRepo` `os.ReadFile`s every cached
pack file and compares it byte-for-byte against the copy embedded in the running
binary.

## The evidence

The claim is structural, and it is verifiable by reading the diff with no
timing at all:

> The number of `ValidateSyntheticRepo` calls per readiness pass drops from
> `len(requiredSources) + len(lockedBundledImports)` to the number of
> **distinct** `(cacheDir, commit)` pairs among them.

Worked through for the shapes `gc init` produces, on a warm valid cache:

| city | before | after |
| --- | ---: | ---: |
| bd-provider, no lockfile | 2 | 1 |
| bd-provider with `packs.lock` (`core`, `bd`) | 4 | 1 |
| `gc init --config gastown` (adds `[imports.gastown]`) | 5 | 2 |

The gastown row is the one worth checking, because it is where an absolute
"always 1" would be wrong. `GastownCityWithProviders` seeds
`[imports.gastown]` at `PublicGastownPackSource`
(`internal/config/public_packs.go`), whose clone URL is `gascity-packs.git` at
a different canonical pin — so it is a genuinely second cache directory, and
one walk of it survives.

Two honest qualifications on those numbers:

- **They describe a pass over a valid cache** — the ordinary case, and the one
  that runs on every `gc` invocation. When a cache actually needs repairing the
  saving is smaller: the repair path does not memoize anything after a
  successful `EnsureRepoInCache`, and `EnsureRepoInCache` re-validates under
  the write lock (`internal/packman/cache.go:73`), so a self-healing pass on
  the bd-provider shape still performs roughly 3 walks rather than 1.
- **No wall-clock number here is mine.** A downstream fork measured this class
  of change in the tens of milliseconds of CPU per invocation, but that was a
  different codebase whose baseline was already partly deduplicated, so I am
  not going to present it as a bound on what you would see. I would rather the
  structural argument carry this on its own.

## Behaviour, as BDD

**Given** a city whose required builtin sources and locked bundled imports all
resolve to the same synthetic cache directory, and that cache is valid
**When** a readiness pass runs
**Then** the directory is validated exactly once, and the pass reports ready.

**Given** the same city, and the cache is corrupted after the city was marked
ready
**When** the next readiness pass runs
**Then** the corruption is detected — the verdict from the previous pass is not
reused — and the cache is rehydrated from the embedded packs.

**Given** a readiness pass that has reached a negative verdict for a cache
directory and repaired it
**When** anything later in that same pass asks about the directory again
**Then** it is re-validated against the repaired tree, and reports valid.

## Why it is safe

The whole argument closes on one property:

> **Only positive verdicts are memoized.** No verdict about a broken cache is
> ever recorded, so there is nothing stale for a repair path to observe. A
> caller that repaired a cache necessarily obtained its negative verdict from a
> full validation, and the next question about that directory runs a full
> validation too.

That is why there is no invalidation API. There is nothing to invalidate.

The remaining properties fall out of scope rather than mechanism:

- **A verifier is scoped to one readiness pass.** It is a local in
  `EnsureBuiltinRuntimeAssets`, not package state. A verdict never outlives the
  pass that produced it, so every pass runs the full validator at least once and
  the self-healing contract runs fresh every time.
- **The degraded-path re-check uses a fresh verifier.** After the repair
  attempts, `EnsureBuiltinRuntimeAssets` re-asks `requiredBuiltinSourcesUsable`
  to decide between a hard error and a warning. That call deliberately builds a
  new verifier, so the decision cannot rest on anything decided before the
  repairs ran.
- **Map iteration order does not matter.** `ensureRequiredBuiltinSourcesCached`
  ranges over a map. Every entry in it resolves to the same
  `(cacheDir, commit)` memo key, so whichever entry happens to take the repair
  branch, the rest re-derive their verdict from the repaired tree. This is
  pinned by test, not just reasoned about.
- **It widens an existing lock-free window, and does not open a new one.**
  `Valid` reads without taking the repo-cache lock, exactly as the two helpers
  already did, so reusing a verdict stretches the gap between observing a cache
  and acting on it. `main` already races between its own successive lock-free
  reads; and because the cache directory name folds in the binary's pack
  content hash, any concurrent writer is writing byte-identical content. Worth
  naming rather than leaving for you to notice.
- **`TestEnsureBuiltinRuntimeAssetsRehydratesCorruptedCache` still passes.** That
  is the contract that a corrupted `gc-beads-bd` lifecycle script self-heals on
  the next pass, and it is the test I would have looked at first as a reviewer.
  I ran it explicitly.
- **What I deliberately did not do:** swap the full walk for a cheaper
  marker-only check. The marker cannot see per-file drift, and the whole-tree
  walk is exactly what repairs a corrupted cached script. That cost is the
  contract, not an oversight.

## Scope

| Area | Change |
| --- | --- |
| `cmd/gc/synthetic_cache_verifier.go` | New. `syntheticCacheVerifier` — 48 lines, one map, one method. |
| `cmd/gc/embed_builtin_packs.go` | `EnsureBuiltinRuntimeAssets` builds one verifier per pass and threads it through; `ensureRequiredBuiltinSourcesCached` and `requiredBuiltinSourcesUsable` take it. |
| `cmd/gc/legacy_pack_preflight.go` | `ensureBundledLockedRemoteImportsCached` and `lockedBundledImportsUsable` take it. |
| `cmd/gc/legacy_pack_preflight_test.go` | Call sites updated for the new parameter. Nothing else. |
| `cmd/gc/synthetic_cache_verifier_test.go` | New. Three tests. |
| Everything else | Untouched. No public API, no wire format, no config, no schema. |

## How the tests are built

The signature change means these tests cannot be run red-then-green against
`main` — they would not compile. So **each one was verified to fail against a
deliberately broken implementation** instead, which pins the behaviour more
tightly than red-green would have:

| Mutation | Test that catches it |
| --- | --- |
| memo removed entirely | `TestReadinessHelpersValidateTheSharedCacheOncePerPass` — "the duplicate walk is back" |
| memo made package-global (leaks across passes) | same test — "a new pass reused a verdict" |
| negative verdicts memoized (on the type) | `TestSyntheticCacheVerifierDoesNotMemoizeNegativeVerdicts` |
| negative verdicts memoized (through the real helper, across its own repair) | `TestEnsureRequiredBuiltinSourcesCachedRevalidatesAfterItsOwnRepair` |

The last two pin the same property at two different levels — the type in
isolation, and the production sequence in `ensureRequiredBuiltinSourcesCached`.
I originally described the second as pinning the repair path's re-validation,
which claimed more than it does, so: **what none of these catch** is a
hypothetical mutation that recorded a positive verdict straight from a
successful `EnsureRepoInCache` return instead of re-validating. That would
survive all three. I left it untested rather than contrive an injection point,
on the grounds that `EnsureRepoInCache` itself validates under the write lock
before returning, so such a memo would be weaker but not actually wrong.

`TestReadinessHelpersValidateTheSharedCacheOncePerPass` is the headline. It makes
two *opposed* assertions against a corrupted cache, so neither can pass
vacuously: with the **same** verifier the second helper must report the cache
usable (it must not re-walk what the first already validated in this pass), and
with a **fresh** verifier it must report the cache unusable (a new pass must see
the corruption). It also proves the two helpers really do share a directory — if
they did not, the shared-verifier assertion would fail rather than pass.

`TestEnsureRequiredBuiltinSourcesCachedRevalidatesAfterItsOwnRepair` walks the
production repair sequence through the real helper rather than exercising the
verifier in isolation. It also asserts up front that every required source
resolves to one cache directory, which is what makes its coverage of the map
iteration order complete rather than incidental — if the pack registry ever
changes so that it does not, the test says so instead of quietly narrowing.

## Notes for the reviewer

- `writeBundledSourceImportLock` in the new test file overlaps with the existing
  `writePreflightImportLock`, which hardcodes the gastown source. These tests
  need a lock entry that resolves to the *same* cache directory as the required
  builtin sources, so it takes the source as a parameter. Consolidating the two
  is a reasonable follow-up; I kept them separate here because I have another
  branch that changes `writePreflightImportLock`'s signature, and I did not want
  to couple the two reviews.
- This is deliberately standalone against `main` rather than stacked on my other
  open PRs, so it can be reviewed and landed independently.
- I have a separate change in preparation that scopes each of these caches to
  its own repository. It is not proposed yet, and it touches the same four
  `ValidateSyntheticRepo` call sites, so it will conflict textually with this
  one. The two are semantically independent — `cacheDir` already determines the
  repository, so the memo key needs no change — and rebasing it onto this is
  mechanical. Mentioning it only so the overlap is not a surprise later; nothing
  here depends on it.
- `go build ./...` and `go vet ./...` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

