### PR TITLE
perf(builtinpacks): scope each synthetic pack cache to its own repository

### DIFF
--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -252,7 +252,11 @@ func ensureRequiredBuiltinSourcesCached(cityPath string, verifier *syntheticCach
 		if err != nil {
 			return fmt.Errorf("resolving cache path for bundled %s pack: %w", name, err)
 		}
-		if verifier.Valid(cachePath, commit) {
+		repository, known := builtinpacks.RepositoryForSource(source)
+		if !known {
+			return fmt.Errorf("resolving bundled repository for %s pack source %q", name, source)
+		}
+		if verifier.Valid(cachePath, repository, commit) {
 			continue
 		}
 		if _, err := packman.EnsureRepoInCache(cityPath, source, commit); err != nil {
@@ -269,7 +273,8 @@ func requiredBuiltinSourcesUsable(cityPath string, verifier *syntheticCacheVerif
 		if err != nil {
 			return false
 		}
-		if !verifier.Valid(cachePath, commit) {
+		repository, known := builtinpacks.RepositoryForSource(source)
+		if !known || !verifier.Valid(cachePath, repository, commit) {
 			return false
 		}
 	}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -681,7 +681,7 @@ func TestEnsureBuiltinRuntimeAssetsHydratesCacheAndShim(t *testing.T) {
 		if err != nil {
 			t.Fatalf("RepoCachePath(%s): %v", name, err)
 		}
-		if err := builtinpacks.ValidateSyntheticRepo(cachePath, commit); err != nil {
+		if err := builtinpacks.ValidateSyntheticRepo(cachePath, builtinpacks.Repository, commit); err != nil {
 			t.Errorf("%s cache invalid after hydration: %v", name, err)
 		}
 	}
@@ -739,7 +739,7 @@ func TestEnsureBuiltinRuntimeAssetsSkipsShimForNonBdCity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoCachePath(core): %v", err)
 	}
-	if err := builtinpacks.ValidateSyntheticRepo(coreCache, commit); err != nil {
+	if err := builtinpacks.ValidateSyntheticRepo(coreCache, builtinpacks.Repository, commit); err != nil {
 		t.Errorf("core cache invalid after hydration: %v", err)
 	}
 }
@@ -1049,7 +1049,7 @@ func TestEnsureBuiltinRuntimeAssetsRehydratesEvictedOptionalLockedBundledCache(t
 	if err != nil {
 		t.Fatalf("RepoCachePath(gastown): %v", err)
 	}
-	if err := builtinpacks.ValidateSyntheticRepo(cachePath, commit); err != nil {
+	if err := builtinpacks.ValidateSyntheticRepo(cachePath, builtinpacks.PublicRepository, commit); err != nil {
 		t.Fatalf("gastown cache invalid after ready: %v", err)
 	}
 
@@ -1065,7 +1065,7 @@ func TestEnsureBuiltinRuntimeAssetsRehydratesEvictedOptionalLockedBundledCache(t
 		t.Fatalf("EnsureBuiltinRuntimeAssets after optional cache eviction: %v", err)
 	}
 
-	if err := builtinpacks.ValidateSyntheticRepo(cachePath, commit); err != nil {
+	if err := builtinpacks.ValidateSyntheticRepo(cachePath, builtinpacks.PublicRepository, commit); err != nil {
 		t.Fatalf("optional locked bundled cache not rehydrated after ready fast path: %v", err)
 	}
 }
@@ -1158,7 +1158,7 @@ func TestLoadCityConfigFSHydratesBuiltinRuntimeAssets(t *testing.T) {
 		if err != nil {
 			t.Fatalf("RepoCachePath(%s): %v", name, err)
 		}
-		if err := builtinpacks.ValidateSyntheticRepo(cachePath, commit); err != nil {
+		if err := builtinpacks.ValidateSyntheticRepo(cachePath, builtinpacks.Repository, commit); err != nil {
 			t.Errorf("%s cache invalid after loadCityConfigFS: %v", name, err)
 		}
 	}

--- a/cmd/gc/legacy_pack_preflight.go
+++ b/cmd/gc/legacy_pack_preflight.go
@@ -86,7 +86,11 @@ func ensureBundledLockedRemoteImportsCached(cityPath string, verifier *synthetic
 		if err != nil {
 			return fmt.Errorf("resolving cache path for bundled import %q from packs.lock: %w", imp.source, err)
 		}
-		if verifier.Valid(cachePath, imp.commit) {
+		repository, known := builtinpacks.RepositoryForSource(imp.source)
+		if !known {
+			return fmt.Errorf("resolving bundled repository for locked import %q", imp.source)
+		}
+		if verifier.Valid(cachePath, repository, imp.commit) {
 			continue
 		}
 		if _, err := packman.EnsureRepoInCache(cityPath, imp.source, imp.commit); err != nil {
@@ -116,7 +120,8 @@ func lockedBundledImportsUsable(cityPath string, verifier *syntheticCacheVerifie
 		if err != nil {
 			return false
 		}
-		if !verifier.Valid(cachePath, imp.commit) {
+		repository, known := builtinpacks.RepositoryForSource(imp.source)
+		if !known || !verifier.Valid(cachePath, repository, imp.commit) {
 			return false
 		}
 	}

--- a/cmd/gc/synthetic_cache_verifier.go
+++ b/cmd/gc/synthetic_cache_verifier.go
@@ -7,11 +7,12 @@ import "github.com/gastownhall/gascity/internal/builtinpacks"
 //
 // Every bundled source of a repository resolves to a single synthetic cache
 // directory — the cache key strips the subpath — and ValidateSyntheticRepo
-// checks every pack layout in that directory regardless of which source asked.
-// requiredBuiltinSourcesUsable and lockedBundledImportsUsable therefore ask the
-// identical question about the identical directory, and that question is not
-// cheap: it os.ReadFile's every cached pack file and compares it against the
-// copy embedded in the running binary.
+// checks that repository's pack layouts in that directory regardless of which
+// of its sources asked. requiredBuiltinSourcesUsable and
+// lockedBundledImportsUsable therefore ask the identical question about the
+// identical directory, and that question is not cheap: it os.ReadFile's every
+// cached pack file and compares it against the copy embedded in the running
+// binary.
 //
 // Only POSITIVE verdicts are memoized, and that is what makes the repair paths
 // safe: no verdict about a broken cache is ever recorded, so there is nothing
@@ -33,14 +34,21 @@ func newSyntheticCacheVerifier() *syntheticCacheVerifier {
 	return &syntheticCacheVerifier{valid: make(map[string]struct{})}
 }
 
-// Valid reports whether the synthetic pack cache at cachePath validates for
-// commit, reusing a positive verdict already reached in this pass.
-func (v *syntheticCacheVerifier) Valid(cachePath, commit string) bool {
-	key := cachePath + "\x00" + commit
+// Valid reports whether the synthetic pack cache at cachePath validates as
+// repository's cache at commit, reusing a positive verdict already reached in
+// this pass.
+//
+// The repository is part of the memo key even though a cache directory can
+// only ever belong to one repository: a verdict is recorded for the exact
+// question that was asked, so a caller that derived a different repository for
+// the same directory gets its own answer from the validator rather than one
+// reached for a question it did not ask.
+func (v *syntheticCacheVerifier) Valid(cachePath, repository, commit string) bool {
+	key := cachePath + "\x00" + repository + "\x00" + commit
 	if _, ok := v.valid[key]; ok {
 		return true
 	}
-	if builtinpacks.ValidateSyntheticRepo(cachePath, commit) != nil {
+	if builtinpacks.ValidateSyntheticRepo(cachePath, repository, commit) != nil {
 		return false
 	}
 	v.valid[key] = struct{}{}

--- a/cmd/gc/synthetic_cache_verifier_test.go
+++ b/cmd/gc/synthetic_cache_verifier_test.go
@@ -74,16 +74,16 @@ func TestSyntheticCacheVerifierDoesNotMemoizeNegativeVerdicts(t *testing.T) {
 
 	pass := newSyntheticCacheVerifier()
 	corruptCachedPackFileForTest(t, cacheDir)
-	if pass.Valid(cacheDir, commit) {
+	if pass.Valid(cacheDir, builtinpacks.Repository, commit) {
 		t.Fatal("corrupted cache reported valid")
 	}
 
 	// Stand in for the repair every caller performs after a negative verdict.
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("re-materializing the cache: %v", err)
 	}
 
-	if !pass.Valid(cacheDir, commit) {
+	if !pass.Valid(cacheDir, builtinpacks.Repository, commit) {
 		t.Error("the verifier memoized a negative verdict; a repaired cache still reads as broken")
 	}
 }
@@ -144,7 +144,11 @@ func materializeSyntheticCacheForTest(t *testing.T, source, commit string) strin
 	if err != nil {
 		t.Fatalf("RepoCachePath(%q): %v", source, err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	repository, known := builtinpacks.RepositoryForSource(source)
+	if !known {
+		t.Fatalf("RepositoryForSource(%q): not a bundled source", source)
+	}
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 	return cacheDir

--- a/examples/gastown/embedded_pack_test.go
+++ b/examples/gastown/embedded_pack_test.go
@@ -90,7 +90,11 @@ func primeBundledGastownCache(t *testing.T) {
 		if err != nil {
 			t.Fatalf("RepoCachePath(%s): %v", pin.source, err)
 		}
-		if err := builtinpacks.MaterializeSyntheticRepo(cachePath, commit); err != nil {
+		repository, known := builtinpacks.RepositoryForSource(pin.source)
+		if !known {
+			t.Fatalf("RepositoryForSource(%s): not a bundled source", pin.source)
+		}
+		if err := builtinpacks.MaterializeSyntheticRepo(cachePath, repository, commit); err != nil {
 			t.Fatalf("MaterializeSyntheticRepo(%s): %v", pin.source, err)
 		}
 	}

--- a/examples/swarm/swarm_test.go
+++ b/examples/swarm/swarm_test.go
@@ -41,7 +41,7 @@ func primeBundledPackCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoCachePath: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 }

--- a/examples/t3bridge-gastown/t3bridge_gastown_test.go
+++ b/examples/t3bridge-gastown/t3bridge_gastown_test.go
@@ -35,7 +35,7 @@ func primeBundledPackCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoCachePath: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 }

--- a/internal/builtinpacks/registry.go
+++ b/internal/builtinpacks/registry.go
@@ -208,6 +208,32 @@ func syntheticPackLayouts() []syntheticPackLayout {
 	return layouts
 }
 
+// KnownRepository reports whether repository is one of the two repositories
+// whose layouts this binary can materialize.
+func KnownRepository(repository string) bool {
+	return repository == Repository || repository == PublicRepository
+}
+
+// layoutsForRepository returns only the layouts addressable from repository's
+// cache directory.
+//
+// A cache directory is keyed on the normalized clone URL with the subpath
+// stripped (config.RepoCacheKey), and every import resolves to
+// <cache>/<subpath> — never the cache root. So a gascity.git cache directory
+// can only ever serve gascity.git subpaths, and the public-repository layouts
+// materialized alongside them were unreachable: dead weight that was written to
+// disk and then byte-compared on every readiness pass.
+func layoutsForRepository(repository string) []syntheticPackLayout {
+	all := syntheticPackLayouts()
+	scoped := make([]syntheticPackLayout, 0, len(all))
+	for _, layout := range all {
+		if layout.Repository == repository {
+			scoped = append(scoped, layout)
+		}
+	}
+	return scoped
+}
+
 func legacySubpathsForPack(name string) []string {
 	switch name {
 	case "dolt":
@@ -241,9 +267,12 @@ func IsSource(source string) bool {
 // imports between bundled pack subpaths resolve like a real checkout. Callers
 // must hold any repo-cache write lock for dst and pass only a disposable cache
 // directory; existing contents are removed unconditionally before writing.
-func MaterializeSyntheticRepo(dst, commit string) error {
+func MaterializeSyntheticRepo(dst, repository, commit string) error {
 	if strings.TrimSpace(commit) == "" {
 		return fmt.Errorf("commit is required")
+	}
+	if !KnownRepository(repository) {
+		return fmt.Errorf("unknown bundled pack repository %q", repository)
 	}
 	if err := validateSyntheticDestination(dst); err != nil {
 		return err
@@ -251,7 +280,7 @@ func MaterializeSyntheticRepo(dst, commit string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return fmt.Errorf("removing stale bundled pack cache %q: %w", dst, err)
 	}
-	for _, layout := range syntheticPackLayouts() {
+	for _, layout := range layoutsForRepository(repository) {
 		target := filepath.Join(dst, filepath.FromSlash(layout.Subpath))
 		if err := materializeFS(layout.Pack.FS, target); err != nil {
 			return fmt.Errorf("materializing bundled pack %q at %s: %w", layout.Pack.Name, layout.Subpath, err)
@@ -262,8 +291,8 @@ func MaterializeSyntheticRepo(dst, commit string) error {
 		return err
 	}
 	marker := syntheticMarker{
-		Schema:      1,
-		Repository:  Repository,
+		Schema:      syntheticMarkerSchema,
+		Repository:  repository,
 		Commit:      commit,
 		ContentHash: hash,
 	}
@@ -282,7 +311,7 @@ func MaterializeSyntheticRepo(dst, commit string) error {
 // walking the materialized file set. It is the resolution-path variant: callers
 // on the hot pack-resolution path use it to gate cache hits cheaply. Full
 // file-set and file-content integrity is verified only by ValidateSyntheticRepo.
-func ValidateSyntheticRepoFast(dir, commit string) error {
+func ValidateSyntheticRepoFast(dir, repository, commit string) error {
 	info, err := os.Lstat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -307,11 +336,22 @@ func ValidateSyntheticRepoFast(dir, commit string) error {
 	if _, err := toml.Decode(string(data), &marker); err != nil {
 		return fmt.Errorf("parsing bundled pack cache marker: %w", err)
 	}
-	if marker.Schema != 1 {
+	if !KnownRepository(repository) {
+		// This variant never consults the layout set at all, so an unknown
+		// repository would be accepted on the marker fields alone. Rejecting it
+		// keeps the fast path a strict prefilter: it must never admit a cache
+		// that ValidateSyntheticRepo would reject.
+		return fmt.Errorf("unknown bundled pack repository %q", repository)
+	}
+	if marker.Schema != syntheticMarkerSchema {
 		return fmt.Errorf("unsupported bundled pack cache marker schema %d", marker.Schema)
 	}
-	if marker.Repository != Repository {
-		return fmt.Errorf("bundled pack cache repository %q does not match %q", marker.Repository, Repository)
+	// The caller supplies the repository it resolved this cache directory for,
+	// exactly as it supplies the commit. Trusting the marker's own value instead
+	// would leave a cache materialized for the wrong repository validating
+	// cleanly and then failing later at import resolution.
+	if marker.Repository != repository {
+		return fmt.Errorf("bundled pack cache repository %q does not match %q", marker.Repository, repository)
 	}
 	if !gitutil.SameCommit(marker.Commit, commit) {
 		return fmt.Errorf("bundled pack cache commit %q does not match %q", marker.Commit, commit)
@@ -329,7 +369,7 @@ func ValidateSyntheticRepoFast(dir, commit string) error {
 // ValidateSyntheticRepo verifies that dir is a synthetic bundled-pack cache
 // created for the current binary content and the source's canonical pin
 // commit (the only commit production callers materialize).
-func ValidateSyntheticRepo(dir, commit string) error {
+func ValidateSyntheticRepo(dir, repository, commit string) error {
 	info, err := os.Lstat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -355,11 +395,23 @@ func ValidateSyntheticRepo(dir, commit string) error {
 	if _, err := toml.Decode(string(data), &marker); err != nil {
 		return fmt.Errorf("parsing bundled pack cache marker: %w", err)
 	}
-	if marker.Schema != 1 {
+	if !KnownRepository(repository) {
+		// Without this an unknown repository collapses the layout set to empty,
+		// so the allowed-path set is just the marker and the per-pack compare
+		// loop never runs — a directory holding nothing but a well-formed marker
+		// would validate. MaterializeSyntheticRepo has always rejected this on
+		// the write side; the read side must match.
+		return fmt.Errorf("unknown bundled pack repository %q", repository)
+	}
+	if marker.Schema != syntheticMarkerSchema {
 		return fmt.Errorf("unsupported bundled pack cache marker schema %d", marker.Schema)
 	}
-	if marker.Repository != Repository {
-		return fmt.Errorf("bundled pack cache repository %q does not match %q", marker.Repository, Repository)
+	// The caller supplies the repository it resolved this cache directory for,
+	// exactly as it supplies the commit. Trusting the marker's own value instead
+	// would leave a cache materialized for the wrong repository validating
+	// cleanly and then failing later at import resolution.
+	if marker.Repository != repository {
+		return fmt.Errorf("bundled pack cache repository %q does not match %q", marker.Repository, repository)
 	}
 	if !gitutil.SameCommit(marker.Commit, commit) {
 		return fmt.Errorf("bundled pack cache commit %q does not match %q", marker.Commit, commit)
@@ -371,10 +423,10 @@ func ValidateSyntheticRepo(dir, commit string) error {
 	if marker.ContentHash != wantHash {
 		return fmt.Errorf("bundled pack cache content hash %q does not match current binary %q", marker.ContentHash, wantHash)
 	}
-	if err := validateSyntheticRepoFileSet(dir); err != nil {
+	if err := validateSyntheticRepoFileSet(dir, repository); err != nil {
 		return err
 	}
-	for _, layout := range syntheticPackLayouts() {
+	for _, layout := range layoutsForRepository(repository) {
 		if err := validatePackFiles(layout.Pack, filepath.Join(dir, filepath.FromSlash(layout.Subpath))); err != nil {
 			return err
 		}
@@ -432,6 +484,14 @@ var syntheticContentHashOnce = sync.OnceValues(SyntheticContentHash)
 // "bundled pack cache content hash does not match current binary" wedge that
 // recurs whenever a deploy leaves two binary versions running side by side.
 //
+// The marker SCHEMA is folded in for the same reason. A schema change alters
+// the on-disk layout a binary expects without altering the embedded content that
+// produced it, so two generations would otherwise share one directory and each
+// reject the other's marker — re-materializing the whole tree on every
+// invocation, in both directions, for as long as the rollout lasted. Binding the
+// key to the schema costs one materialization per generation instead, which is
+// what this mechanism already does for a content change.
+//
 // It returns "" only when the embedded pack set cannot be hashed, which is a
 // build-integrity failure that MaterializeSyntheticRepo and ValidateSyntheticRepo
 // surface with full context on the next cache operation. Callers fold the
@@ -444,8 +504,14 @@ func SyntheticCacheKeyComponent() string {
 	if err != nil {
 		return ""
 	}
-	return hash
+	return fmt.Sprintf("%s+schema%d", hash, syntheticMarkerSchema)
 }
+
+// syntheticMarkerSchema is the marker format version. Schema 1 markers recorded
+// a hardcoded repository and a cache holding every repository's layouts; they
+// are rejected so the cache re-materializes scoped to its own repository. That
+// is the ordinary self-heal path, not a migration.
+const syntheticMarkerSchema = 2
 
 type syntheticMarker struct {
 	Schema      int    `toml:"schema"`
@@ -480,10 +546,11 @@ func materializeFS(src fs.FS, dst string) error {
 // every expected file present, with the expected mode and content.
 //
 // It does not walk dst looking for unexpected files. validateSyntheticRepoFileSet
-// already walks the whole cache once against the union of every layout's
-// manifest, and that union check strictly subsumes a per-pack one: a file
-// unexpected for its own pack is absent from the union too. Keeping both meant
-// about nine traversals of the same tree per call.
+// already walks the whole cache once against the union of that repository's
+// layout manifests, and that union check strictly subsumes a per-pack one:
+// ValidateSyntheticRepo calls validatePackFiles for exactly the layouts the
+// union is built from, so a file unexpected for its own pack is absent from the
+// union too. Keeping both meant about nine traversals of the same tree per call.
 func validatePackFiles(pack Pack, dst string) error {
 	manifest, err := manifestForPack(pack)
 	if err != nil {
@@ -509,8 +576,8 @@ func validatePackFiles(pack Pack, dst string) error {
 	return nil
 }
 
-func validateSyntheticRepoFileSet(dir string) error {
-	allowedFiles, allowedDirs, err := syntheticRepoAllowedPaths()
+func validateSyntheticRepoFileSet(dir, repository string) error {
+	allowedFiles, allowedDirs, err := syntheticRepoAllowedPaths(repository)
 	if err != nil {
 		return err
 	}
@@ -553,17 +620,40 @@ func validateSyntheticRepoFileSet(dir string) error {
 }
 
 // syntheticRepoAllowedPaths returns the file and directory sets a materialized
-// synthetic repo may contain.
+// synthetic repo for repository may contain.
 //
-// The result derives entirely from content embedded in the running binary, so it
-// is memoized for the process lifetime the same way syntheticContentHashOnce
-// memoizes the content hash. Rebuilding it per call re-walked every bundled
-// pack's embed.FS on every config load. Callers must treat the returned maps as
-// read-only.
-func syntheticRepoAllowedPaths() (map[string]struct{}, map[string]struct{}, error) {
-	cached := syntheticRepoAllowedPathsOnce()
-	return cached.files, cached.dirs, cached.err
+// The set is scoped to one repository. A cache directory is keyed on the
+// normalized clone URL with the subpath stripped, and imports resolve to
+// <cache>/<subpath> rather than the cache root, so a cache for one repository
+// can only ever serve that repository's subpaths. Admitting another
+// repository's layouts here would widen the allowed set to paths this cache can
+// never legitimately contain.
+//
+// A repository's set derives entirely from content embedded in the running
+// binary, so it is memoized for the process lifetime the same way manifestCache
+// memoizes the per-pack manifests it is built from. Rebuilding it per call
+// re-walked every bundled pack's embed.FS on every config load. Callers must
+// treat the returned maps as read-only.
+func syntheticRepoAllowedPaths(repository string) (map[string]struct{}, map[string]struct{}, error) {
+	if !KnownRepository(repository) {
+		// Not memoized, so the memo's key set stays bounded by the repositories
+		// this binary embeds layouts for. An unknown repository yields the
+		// marker-only set, which is why ValidateSyntheticRepo rejects it before
+		// reaching here rather than relying on this set to be non-empty.
+		return computeSyntheticRepoAllowedPaths(repository)
+	}
+	if cached, ok := syntheticRepoAllowedPathsCache.Load(repository); ok {
+		sets := cached.(syntheticRepoPathSets)
+		return sets.files, sets.dirs, sets.err
+	}
+	files, dirs, err := computeSyntheticRepoAllowedPaths(repository)
+	syntheticRepoAllowedPathsCache.Store(repository, syntheticRepoPathSets{files: files, dirs: dirs, err: err})
+	return files, dirs, err
 }
+
+// syntheticRepoAllowedPathsCache memoizes the allowed-path sets by repository.
+// Entries are read-only once stored.
+var syntheticRepoAllowedPathsCache sync.Map
 
 type syntheticRepoPathSets struct {
 	files map[string]struct{}
@@ -571,15 +661,10 @@ type syntheticRepoPathSets struct {
 	err   error
 }
 
-var syntheticRepoAllowedPathsOnce = sync.OnceValue(func() syntheticRepoPathSets {
-	files, dirs, err := computeSyntheticRepoAllowedPaths()
-	return syntheticRepoPathSets{files: files, dirs: dirs, err: err}
-})
-
-func computeSyntheticRepoAllowedPaths() (map[string]struct{}, map[string]struct{}, error) {
+func computeSyntheticRepoAllowedPaths(repository string) (map[string]struct{}, map[string]struct{}, error) {
 	files := map[string]struct{}{syntheticMarkerFile: {}}
 	dirs := make(map[string]struct{})
-	for _, layout := range syntheticPackLayouts() {
+	for _, layout := range layoutsForRepository(repository) {
 		subpath := filepath.ToSlash(layout.Subpath)
 		manifest, err := manifestForPack(layout.Pack)
 		if err != nil {
@@ -646,6 +731,26 @@ func manifestForFS(src fs.FS) (map[string]fileEntry, error) {
 		return nil, fmt.Errorf("bundled pack manifest is missing pack.toml")
 	}
 	return manifest, nil
+}
+
+// RepositoryForSource reports the bundled-pack repository that source's clone
+// URL normalizes to, and whether it is one this binary can materialize.
+//
+// It answers only "which cache directory does this belong to". The subpath is
+// deliberately ignored, so ok is true for any subpath under a known repository,
+// including one that addresses no bundled pack. Whether source actually names a
+// bundled pack layout is a separate question, answered by IsSource /
+// SourceLayout; callers that need both gate on both.
+//
+// Callers pair it with a cache directory: the directory is keyed on the same
+// normalized clone URL, so the repository is what scopes which layouts that
+// directory may hold.
+func RepositoryForSource(source string) (string, bool) {
+	repository, _ := splitSource(source)
+	if !KnownRepository(repository) {
+		return "", false
+	}
+	return repository, true
 }
 
 func splitSource(source string) (repository, subpath string) {

--- a/internal/builtinpacks/registry_scoped_test.go
+++ b/internal/builtinpacks/registry_scoped_test.go
@@ -1,0 +1,286 @@
+package builtinpacks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A synthetic cache directory is keyed on the normalized clone URL with the
+// subpath stripped, and every import resolves to <cache>/<subpath> — never the
+// cache root. So a gascity.git cache directory can only ever serve gascity.git
+// subpaths. It used to be materialized with EVERY repository's layouts anyway,
+// and ValidateSyntheticRepo then byte-compared all of them on every readiness
+// pass.
+//
+// These tests pin that each cache holds and validates only its own
+// repository's layouts, and — the part that matters — that the layouts which
+// stopped being materialized are REJECTED if present rather than ignored.
+
+// TestMaterializeSyntheticRepoWritesOnlyItsRepositorysLayouts pins the scoping
+// in both directions, so a filter that silently matched everything (or nothing)
+// fails.
+func TestMaterializeSyntheticRepoWritesOnlyItsRepositorysLayouts(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		repository string
+	}{
+		{"gascity.git", Repository},
+		{"public packs", PublicRepository},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := MaterializeSyntheticRepo(dir, tc.repository, "deadbeef"); err != nil {
+				t.Fatalf("MaterializeSyntheticRepo: %v", err)
+			}
+			for _, layout := range syntheticPackLayouts() {
+				path := filepath.Join(dir, filepath.FromSlash(layout.Subpath))
+				_, err := os.Stat(path)
+				present := err == nil
+				want := layout.Repository == tc.repository
+				if present != want {
+					t.Errorf("subpath %s of %s present=%v, want %v", layout.Subpath, layout.Repository, present, want)
+				}
+			}
+		})
+	}
+}
+
+// TestMaterializeSyntheticRepoScopingActuallyDropsLayouts guards against the
+// filter being a no-op because both repositories happen to hold every layout.
+// If this fails, every other test in this file is vacuous.
+func TestMaterializeSyntheticRepoScopingActuallyDropsLayouts(t *testing.T) {
+	all := len(syntheticPackLayouts())
+	own := len(layoutsForRepository(Repository))
+	public := len(layoutsForRepository(PublicRepository))
+	if own == 0 || public == 0 {
+		t.Fatalf("a repository has no layouts (own=%d public=%d); scoping cannot be exercised", own, public)
+	}
+	if own+public != all {
+		t.Fatalf("layouts do not partition by repository: own=%d + public=%d != all=%d", own, public, all)
+	}
+	if own == all || public == all {
+		t.Fatalf("scoping drops nothing: own=%d public=%d all=%d", own, public, all)
+	}
+}
+
+// TestValidateSyntheticRepoRejectsCrossRepositoryStray is the load-bearing one:
+// it distinguishes "correctly scoped" from "silently stopped checking".
+//
+// A public-repository layout dropped into a gascity.git cache is no longer part
+// of that cache's expected file set — so it must be reported as an unexpected
+// file, not ignored. Without this assertion, an implementation that narrowed
+// the allowed set AND narrowed the walk would look identical to a correct one.
+func TestValidateSyntheticRepoRejectsCrossRepositoryStray(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeSyntheticRepo(dir, Repository, "deadbeef"); err != nil {
+		t.Fatalf("MaterializeSyntheticRepo: %v", err)
+	}
+	if err := ValidateSyntheticRepo(dir, Repository, "deadbeef"); err != nil {
+		t.Fatalf("freshly materialized cache is invalid: %v", err)
+	}
+
+	// A subpath that belongs to the OTHER repository.
+	var foreign string
+	for _, layout := range syntheticPackLayouts() {
+		if layout.Repository == PublicRepository {
+			foreign = layout.Subpath
+			break
+		}
+	}
+	if foreign == "" {
+		t.Skip("no public-repository layout registered")
+	}
+	stray := filepath.Join(dir, filepath.FromSlash(foreign), "pack.toml")
+	if err := os.MkdirAll(filepath.Dir(stray), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(stray, []byte("[pack]\nname = \"foreign\"\n"), 0o644); err != nil {
+		t.Fatalf("write stray: %v", err)
+	}
+
+	err := ValidateSyntheticRepo(dir, Repository, "deadbeef")
+	if err == nil {
+		t.Fatal("a cross-repository layout was accepted; the file-set check no longer covers it")
+	}
+	if !strings.Contains(err.Error(), "unexpected") {
+		t.Errorf("error = %v, want an unexpected-file/directory rejection", err)
+	}
+}
+
+// TestValidateSyntheticRepoRejectsRepositoryMismatch pins that the caller's
+// repository is cross-checked against the marker, exactly as the commit already
+// is. Trusting the marker's own value would let a cache materialized for the
+// wrong repository validate cleanly and then fail later at import resolution.
+func TestValidateSyntheticRepoRejectsRepositoryMismatch(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeSyntheticRepo(dir, Repository, "deadbeef"); err != nil {
+		t.Fatalf("MaterializeSyntheticRepo: %v", err)
+	}
+	if err := ValidateSyntheticRepo(dir, PublicRepository, "deadbeef"); err == nil {
+		t.Fatal("ValidateSyntheticRepo accepted a mismatched repository")
+	}
+	if err := ValidateSyntheticRepoFast(dir, PublicRepository, "deadbeef"); err == nil {
+		t.Fatal("ValidateSyntheticRepoFast accepted a mismatched repository")
+	}
+}
+
+// TestValidateSyntheticRepoRejectsSupersededMarkerSchema pins that a cache
+// written by an older binary — one whose marker recorded a hardcoded repository
+// and whose tree held every repository's layouts — is rejected so it
+// re-materializes scoped. That is the ordinary self-heal path, not a migration.
+func TestValidateSyntheticRepoRejectsSupersededMarkerSchema(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeSyntheticRepo(dir, Repository, "deadbeef"); err != nil {
+		t.Fatalf("MaterializeSyntheticRepo: %v", err)
+	}
+	markerPath := filepath.Join(dir, syntheticMarkerFile)
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("reading marker: %v", err)
+	}
+	downgraded := strings.Replace(string(data), "schema = 2", "schema = 1", 1)
+	if downgraded == string(data) {
+		t.Fatalf("marker does not declare schema = 2:\n%s", data)
+	}
+	if err := os.WriteFile(markerPath, []byte(downgraded), 0o644); err != nil {
+		t.Fatalf("writing marker: %v", err)
+	}
+
+	if err := ValidateSyntheticRepo(dir, Repository, "deadbeef"); err == nil {
+		t.Error("ValidateSyntheticRepo accepted a schema-1 marker")
+	}
+	if err := ValidateSyntheticRepoFast(dir, Repository, "deadbeef"); err == nil {
+		t.Error("ValidateSyntheticRepoFast accepted a schema-1 marker")
+	}
+}
+
+// TestMaterializeSyntheticRepoRejectsUnknownRepository pins that the repository
+// is validated rather than used to silently produce an empty cache — a filter
+// that matched nothing would otherwise write a marker and no packs, and that
+// cache would then validate.
+func TestMaterializeSyntheticRepoRejectsUnknownRepository(t *testing.T) {
+	dir := t.TempDir()
+	err := MaterializeSyntheticRepo(dir, "https://github.com/example/other.git", "deadbeef")
+	if err == nil {
+		t.Fatal("MaterializeSyntheticRepo accepted an unknown repository")
+	}
+	if !strings.Contains(err.Error(), "unknown bundled pack repository") {
+		t.Errorf("error = %v, want an unknown-repository rejection", err)
+	}
+}
+
+// TestRepositoryForSourceMapsBothRepositories pins the helper every caller uses
+// to derive the repository from the source it already holds, including the fact
+// that it keys on the clone URL alone: a subpath that names no bundled pack
+// still maps to its repository, because it still maps to that repository's cache
+// directory.
+func TestRepositoryForSourceMapsBothRepositories(t *testing.T) {
+	for _, layout := range syntheticPackLayouts() {
+		source := layout.Repository + "//" + layout.Subpath
+		got, ok := RepositoryForSource(source)
+		if !ok {
+			t.Errorf("RepositoryForSource(%q) not recognized", source)
+			continue
+		}
+		if got != layout.Repository {
+			t.Errorf("RepositoryForSource(%q) = %q, want %q", source, got, layout.Repository)
+		}
+	}
+	if _, ok := RepositoryForSource("https://github.com/example/other.git//pack"); ok {
+		t.Error("RepositoryForSource accepted a non-bundled source")
+	}
+	// A subpath under a known repository that addresses no bundled pack still
+	// resolves: it still lands in that repository's cache directory. Callers
+	// that need "is this a bundled pack" gate on IsSource as well.
+	nonPack := Repository + "//docs"
+	if got, ok := RepositoryForSource(nonPack); !ok || got != Repository {
+		t.Errorf("RepositoryForSource(%q) = %q, %v; want %q, true", nonPack, got, ok, Repository)
+	}
+	if IsSource(nonPack) {
+		t.Errorf("IsSource(%q) = true; the two helpers are expected to disagree here", nonPack)
+	}
+}
+
+// TestSyntheticCacheKeyComponentBindsToMarkerSchema pins the property that
+// keeps a rollout from thrashing.
+//
+// The cache is machine-global and shared by every gc on the box. A marker
+// schema change alters the on-disk layout a binary expects WITHOUT altering the
+// embedded content that produced it, so two generations would resolve to one
+// directory and each reject the other's marker — re-materializing the entire
+// tree on every invocation, in both directions, for the length of the rollout.
+// The cost is not just the wasted rewrite: each re-materialization takes the
+// EXCLUSIVE repo-cache lock, which covers the whole machine-global cache root,
+// so every other gc on the box waits behind it.
+//
+// The component already binds to embedded content for the same reason (see its
+// doc comment, which names the side-by-side-deploy wedge). This asserts the
+// schema is in there too, so the two generations simply use different
+// directories.
+func TestSyntheticCacheKeyComponentBindsToMarkerSchema(t *testing.T) {
+	component := SyntheticCacheKeyComponent()
+	if component == "" {
+		t.Fatal("SyntheticCacheKeyComponent is empty; embedded packs cannot be hashed")
+	}
+	want := fmt.Sprintf("schema%d", syntheticMarkerSchema)
+	if !strings.Contains(component, want) {
+		t.Errorf("cache key component %q does not encode %q; a schema bump would make two binary generations share one cache directory and re-materialize it on every invocation", component, want)
+	}
+	hash, err := SyntheticContentHash()
+	if err != nil {
+		t.Fatalf("SyntheticContentHash: %v", err)
+	}
+	if !strings.Contains(component, hash) {
+		t.Errorf("cache key component %q no longer encodes the content hash %q", component, hash)
+	}
+}
+
+// TestValidateSyntheticRepoRejectsUnknownRepository pins the read-side guard.
+//
+// An unknown repository collapses the layout set to empty, so the allowed-path
+// set becomes just the marker and the per-pack byte-compare loop never runs — a
+// directory holding nothing but a well-formed marker validates clean. That is
+// the same hazard MaterializeSyntheticRepo has always rejected on the write
+// side; leaving the read side unguarded made a tamper-detection function
+// asymmetric.
+//
+// No production caller can reach it today: all of them derive the repository
+// from RepositoryForSource, which only ever returns the two known values. This
+// is defense in depth, one future call site away from being live — which is
+// exactly the kind of gap that is cheap now and expensive later.
+func TestValidateSyntheticRepoRejectsUnknownRepository(t *testing.T) {
+	const unknown = "https://github.com/example/other.git"
+
+	// A directory holding only a well-formed marker for an unknown repository:
+	// correct content hash, matching commit, current schema.
+	dir := t.TempDir()
+	hash, err := SyntheticContentHash()
+	if err != nil {
+		t.Fatalf("SyntheticContentHash: %v", err)
+	}
+	marker := fmt.Sprintf("schema = %d\nrepository = %q\ncommit = %q\ncontent_hash = %q\n",
+		syntheticMarkerSchema, unknown, "deadbeef", hash)
+	if err := os.WriteFile(filepath.Join(dir, syntheticMarkerFile), []byte(marker), 0o644); err != nil {
+		t.Fatalf("writing marker: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		validate func() error
+	}{
+		{"ValidateSyntheticRepo", func() error { return ValidateSyntheticRepo(dir, unknown, "deadbeef") }},
+		{"ValidateSyntheticRepoFast", func() error { return ValidateSyntheticRepoFast(dir, unknown, "deadbeef") }},
+	} {
+		err := tc.validate()
+		if err == nil {
+			t.Errorf("%s accepted a pack-less cache for an unknown repository", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "unknown bundled pack repository") {
+			t.Errorf("%s error = %v, want an unknown-repository rejection", tc.name, err)
+		}
+	}
+}

--- a/internal/builtinpacks/registry_test.go
+++ b/internal/builtinpacks/registry_test.go
@@ -150,7 +150,7 @@ func TestMaterializeSyntheticRepoRoundTripReplacesDestination(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "cache")
 	writeFile(t, filepath.Join(dst, "stale.txt"), "stale")
 
-	if err := MaterializeSyntheticRepo(dst, testCommit); err != nil {
+	if err := MaterializeSyntheticRepo(dst, Repository, testCommit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dst, "stale.txt")); !os.IsNotExist(err) {
@@ -159,13 +159,13 @@ func TestMaterializeSyntheticRepoRoundTripReplacesDestination(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dst, syntheticMarkerFile)); err != nil {
 		t.Fatalf("marker stat: %v", err)
 	}
-	if err := ValidateSyntheticRepo(dst, testCommit); err != nil {
+	if err := ValidateSyntheticRepo(dst, Repository, testCommit); err != nil {
 		t.Fatalf("ValidateSyntheticRepo: %v", err)
 	}
 }
 
 func TestMaterializeSyntheticRepoRejectsEmptyCommit(t *testing.T) {
-	err := MaterializeSyntheticRepo(filepath.Join(t.TempDir(), "cache"), " \t\n")
+	err := MaterializeSyntheticRepo(filepath.Join(t.TempDir(), "cache"), Repository, " \t\n")
 	if err == nil {
 		t.Fatal("MaterializeSyntheticRepo accepted empty commit")
 	}
@@ -177,7 +177,7 @@ func TestMaterializeSyntheticRepoRejectsEmptyCommit(t *testing.T) {
 func TestMaterializeSyntheticRepoRejectsUnsafeDestination(t *testing.T) {
 	for _, dst := range []string{"", string(filepath.Separator)} {
 		t.Run(dst, func(t *testing.T) {
-			err := MaterializeSyntheticRepo(dst, testCommit)
+			err := MaterializeSyntheticRepo(dst, Repository, testCommit)
 			if err == nil {
 				t.Fatalf("MaterializeSyntheticRepo(%q) succeeded, want unsafe-path error", dst)
 			}
@@ -250,7 +250,7 @@ func TestMaterializeSyntheticRepoProductionCallersStayAllowlisted(t *testing.T) 
 
 func TestValidateSyntheticRepoAcceptsEquivalentCommit(t *testing.T) {
 	dst := materializeTestRepo(t)
-	if err := ValidateSyntheticRepo(dst, "ABCDEF1"); err != nil {
+	if err := ValidateSyntheticRepo(dst, Repository, "ABCDEF1"); err != nil {
 		t.Fatalf("ValidateSyntheticRepo with abbreviated uppercase commit: %v", err)
 	}
 }
@@ -276,7 +276,7 @@ name = "tampered"
 schema = 1
 `)
 
-	err := ValidateSyntheticRepo(dst, testCommit)
+	err := ValidateSyntheticRepo(dst, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepo accepted tampered content")
 	}
@@ -292,7 +292,7 @@ func TestValidateSyntheticRepoRejectsTamperedMode(t *testing.T) {
 		t.Fatalf("Chmod(%q): %v", target, err)
 	}
 
-	err := ValidateSyntheticRepo(dst, testCommit)
+	err := ValidateSyntheticRepo(dst, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepo accepted tampered file mode")
 	}
@@ -314,7 +314,7 @@ func TestValidateSyntheticRepoRejectsSymlinkAncestor(t *testing.T) {
 		t.Fatalf("Symlink(internal): %v", err)
 	}
 
-	err := ValidateSyntheticRepo(dst, testCommit)
+	err := ValidateSyntheticRepo(dst, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepo accepted symlink ancestor")
 	}
@@ -330,7 +330,7 @@ func TestValidateSyntheticRepoRejectsSymlinkRoot(t *testing.T) {
 		t.Fatalf("Symlink(cache-link): %v", err)
 	}
 
-	err := ValidateSyntheticRepo(link, testCommit)
+	err := ValidateSyntheticRepo(link, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepo accepted symlink root")
 	}
@@ -343,7 +343,7 @@ func TestValidateSyntheticRepoRejectsNonDirectoryRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "cache")
 	writeFile(t, root, "not a directory")
 
-	err := ValidateSyntheticRepo(root, testCommit)
+	err := ValidateSyntheticRepo(root, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepo accepted non-directory root")
 	}
@@ -356,7 +356,7 @@ func TestValidateSyntheticRepoRejectsUnexpectedFiles(t *testing.T) {
 	dst := materializeTestRepo(t)
 	writeFile(t, filepath.Join(dst, "internal/bootstrap/packs/core/agents/injected/prompt.md"), "malicious")
 
-	err := ValidateSyntheticRepo(dst, testCommit)
+	err := ValidateSyntheticRepo(dst, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepo accepted unexpected file")
 	}
@@ -369,7 +369,7 @@ func TestValidateSyntheticRepoRejectsUnexpectedRootSibling(t *testing.T) {
 	dst := materializeTestRepo(t)
 	writeFile(t, filepath.Join(dst, "scratch.txt"), "malicious")
 
-	err := ValidateSyntheticRepo(dst, testCommit)
+	err := ValidateSyntheticRepo(dst, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepo accepted unexpected root sibling")
 	}
@@ -381,7 +381,7 @@ func TestValidateSyntheticRepoRejectsUnexpectedRootSibling(t *testing.T) {
 func materializeTestRepo(t *testing.T) string {
 	t.Helper()
 	dst := filepath.Join(t.TempDir(), "cache")
-	if err := MaterializeSyntheticRepo(dst, testCommit); err != nil {
+	if err := MaterializeSyntheticRepo(dst, Repository, testCommit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 	return dst
@@ -430,14 +430,14 @@ func testRepoRoot(t *testing.T) string {
 
 func TestValidateSyntheticRepoFastAcceptsValidRepo(t *testing.T) {
 	dst := materializeTestRepo(t)
-	if err := ValidateSyntheticRepoFast(dst, testCommit); err != nil {
+	if err := ValidateSyntheticRepoFast(dst, Repository, testCommit); err != nil {
 		t.Fatalf("ValidateSyntheticRepoFast: %v", err)
 	}
 }
 
 func TestValidateSyntheticRepoFastAcceptsEquivalentCommit(t *testing.T) {
 	dst := materializeTestRepo(t)
-	if err := ValidateSyntheticRepoFast(dst, "ABCDEF1"); err != nil {
+	if err := ValidateSyntheticRepoFast(dst, Repository, "ABCDEF1"); err != nil {
 		t.Fatalf("ValidateSyntheticRepoFast with abbreviated uppercase commit: %v", err)
 	}
 }
@@ -448,7 +448,7 @@ func TestValidateSyntheticRepoFastRejectsSymlinkRoot(t *testing.T) {
 	if err := os.Symlink(dst, link); err != nil {
 		t.Fatalf("Symlink(cache-link): %v", err)
 	}
-	err := ValidateSyntheticRepoFast(link, testCommit)
+	err := ValidateSyntheticRepoFast(link, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepoFast accepted symlink root")
 	}
@@ -460,7 +460,7 @@ func TestValidateSyntheticRepoFastRejectsSymlinkRoot(t *testing.T) {
 func TestValidateSyntheticRepoFastRejectsNonDirectoryRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "cache")
 	writeFile(t, root, "not a directory")
-	err := ValidateSyntheticRepoFast(root, testCommit)
+	err := ValidateSyntheticRepoFast(root, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepoFast accepted non-directory root")
 	}
@@ -474,7 +474,7 @@ func TestValidateSyntheticRepoFastRejectsMissingMarker(t *testing.T) {
 	if err := os.Remove(filepath.Join(dst, syntheticMarkerFile)); err != nil {
 		t.Fatalf("Remove(marker): %v", err)
 	}
-	err := ValidateSyntheticRepoFast(dst, testCommit)
+	err := ValidateSyntheticRepoFast(dst, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepoFast accepted missing marker")
 	}
@@ -485,7 +485,7 @@ func TestValidateSyntheticRepoFastRejectsMissingMarker(t *testing.T) {
 
 func TestValidateSyntheticRepoFastRejectsWrongCommit(t *testing.T) {
 	dst := materializeTestRepo(t)
-	err := ValidateSyntheticRepoFast(dst, "0000000000000000000000000000000000000000")
+	err := ValidateSyntheticRepoFast(dst, Repository, "0000000000000000000000000000000000000000")
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepoFast accepted wrong commit")
 	}
@@ -505,7 +505,7 @@ func TestValidateSyntheticRepoFastRejectsWrongContentHash(t *testing.T) {
 	if err := os.WriteFile(markerPath, []byte(tampered), 0o644); err != nil {
 		t.Fatalf("WriteFile(marker): %v", err)
 	}
-	err = ValidateSyntheticRepoFast(dst, testCommit)
+	err = ValidateSyntheticRepoFast(dst, Repository, testCommit)
 	if err == nil {
 		t.Fatal("ValidateSyntheticRepoFast accepted wrong content hash")
 	}
@@ -514,6 +514,15 @@ func TestValidateSyntheticRepoFastRejectsWrongContentHash(t *testing.T) {
 	}
 }
 
+// TestSyntheticCacheKeyComponentMatchesContentHash pins that the cache key stays
+// bound to the embedded pack content, which is what stops two binaries with
+// different packs sharing one cache directory.
+//
+// The component is no longer the bare content hash: the marker schema is folded
+// in alongside it, because a schema change alters the on-disk layout a binary
+// expects WITHOUT altering the content that produced it. See
+// TestSyntheticCacheKeyComponentBindsToMarkerSchema. The content hash must still
+// be present and the value must still be stable.
 func TestSyntheticCacheKeyComponentMatchesContentHash(t *testing.T) {
 	want, err := SyntheticContentHash()
 	if err != nil {
@@ -523,8 +532,8 @@ func TestSyntheticCacheKeyComponentMatchesContentHash(t *testing.T) {
 	if got == "" {
 		t.Fatal("SyntheticCacheKeyComponent returned empty for a valid binary")
 	}
-	if got != want {
-		t.Fatalf("SyntheticCacheKeyComponent = %q, want content hash %q", got, want)
+	if !strings.Contains(got, want) {
+		t.Fatalf("SyntheticCacheKeyComponent = %q, want it to contain the content hash %q", got, want)
 	}
 	if !strings.HasPrefix(got, "sha256:") {
 		t.Fatalf("SyntheticCacheKeyComponent = %q, want sha256 prefix", got)
@@ -535,12 +544,21 @@ func TestSyntheticCacheKeyComponentMatchesContentHash(t *testing.T) {
 }
 
 // TestValidateSyntheticRepoRejectsStrayFilesAnywhere pins the coverage that
-// justifies validatePackFiles no longer walking its own directory. The whole-tree
-// walk in validateSyntheticRepoFileSet checks every path against the union of all
-// layout manifests, which strictly subsumes a per-pack check: a file that is
-// unexpected for its own pack is absent from the union too. Nested layouts
-// (examples/bd contains examples/bd/dolt) are covered explicitly, because that is
-// the case where a per-pack and a union check could conceivably disagree.
+// justifies validatePackFiles no longer walking its own directory, and that
+// scoping the allowed set to the cache's own repository does not weaken it.
+//
+// validateSyntheticRepoFileSet walks the whole tree once and checks every path
+// against the union of the manifests of that repository's layouts. That union
+// check strictly subsumes a per-pack one: ValidateSyntheticRepo calls
+// validatePackFiles for exactly the layouts the union is built from, so a file
+// unexpected for its own pack is absent from the union too. Scoping only removes
+// paths from that union, so nothing a stray could previously land on has become
+// allowed.
+//
+// Nested layouts (examples/bd contains examples/bd/dolt) are covered explicitly:
+// flattening several manifests into one allowed set is where a per-pack and a
+// union check could conceivably disagree, and both the nested directory and its
+// parent are exercised.
 func TestValidateSyntheticRepoRejectsStrayFilesAnywhere(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -561,7 +579,7 @@ func TestValidateSyntheticRepoRejectsStrayFilesAnywhere(t *testing.T) {
 			if err := os.WriteFile(stray, []byte("stray"), 0o644); err != nil {
 				t.Fatalf("WriteFile: %v", err)
 			}
-			if err := ValidateSyntheticRepo(dst, testCommit); err == nil {
+			if err := ValidateSyntheticRepo(dst, Repository, testCommit); err == nil {
 				t.Fatalf("ValidateSyntheticRepo accepted a stray file at %s", tc.rel)
 			}
 		})
@@ -569,22 +587,57 @@ func TestValidateSyntheticRepoRejectsStrayFilesAnywhere(t *testing.T) {
 }
 
 // TestSyntheticRepoAllowedPathsIsStable pins that memoizing the allowed-path sets
-// does not change what they contain across calls.
+// does not change what they contain across calls, and — now that the memo is
+// keyed by repository — that each repository gets its own set rather than
+// whichever one was computed first.
 func TestSyntheticRepoAllowedPathsIsStable(t *testing.T) {
-	files1, dirs1, err := syntheticRepoAllowedPaths()
-	if err != nil {
-		t.Fatalf("syntheticRepoAllowedPaths: %v", err)
+	for _, tc := range []struct {
+		name       string
+		repository string
+	}{
+		{"gascity.git", Repository},
+		{"public packs", PublicRepository},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repository := tc.repository
+			files1, dirs1, err := syntheticRepoAllowedPaths(repository)
+			if err != nil {
+				t.Fatalf("syntheticRepoAllowedPaths: %v", err)
+			}
+			files2, dirs2, err := syntheticRepoAllowedPaths(repository)
+			if err != nil {
+				t.Fatalf("syntheticRepoAllowedPaths (second call): %v", err)
+			}
+			if len(files1) != len(files2) || len(dirs1) != len(dirs2) {
+				t.Fatalf("allowed paths changed between calls: files %d/%d dirs %d/%d",
+					len(files1), len(files2), len(dirs1), len(dirs2))
+			}
+			if len(files1) == 0 {
+				t.Fatal("allowed file set is empty")
+			}
+			freshFiles, freshDirs, err := computeSyntheticRepoAllowedPaths(repository)
+			if err != nil {
+				t.Fatalf("computeSyntheticRepoAllowedPaths: %v", err)
+			}
+			assertPathSetsEqual(t, "files", files1, freshFiles)
+			assertPathSetsEqual(t, "dirs", dirs1, freshDirs)
+		})
 	}
-	files2, dirs2, err := syntheticRepoAllowedPaths()
-	if err != nil {
-		t.Fatalf("syntheticRepoAllowedPaths (second call): %v", err)
+}
+
+// assertPathSetsEqual reports every difference between a memoized path set and a
+// freshly computed one, so a mis-keyed memo names the paths it got wrong.
+func assertPathSetsEqual(t *testing.T, kind string, cached, fresh map[string]struct{}) {
+	t.Helper()
+	for rel := range fresh {
+		if _, ok := cached[rel]; !ok {
+			t.Errorf("memoized %s set missing %s", kind, rel)
+		}
 	}
-	if len(files1) != len(files2) || len(dirs1) != len(dirs2) {
-		t.Fatalf("allowed paths changed between calls: files %d/%d dirs %d/%d",
-			len(files1), len(files2), len(dirs1), len(dirs2))
-	}
-	if len(files1) == 0 {
-		t.Fatal("allowed file set is empty")
+	for rel := range cached {
+		if _, ok := fresh[rel]; !ok {
+			t.Errorf("memoized %s set has extra %s", kind, rel)
+		}
 	}
 }
 

--- a/internal/config/bundled_import_test.go
+++ b/internal/config/bundled_import_test.go
@@ -17,7 +17,7 @@ func TestResolveLockedRemoteImportAcceptsBundledSyntheticCache(t *testing.T) {
 	commit := canonicalBundledCommit(source)
 	writeBundledImportLock(t, cityDir, source, commit)
 	cacheDir := bundledRepoCacheDir(home, source, commit)
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 
@@ -44,7 +44,7 @@ func TestResolveLockedRemoteImportFastPathToleratesBundledSyntheticContentDrift(
 	commit := canonicalBundledCommit(source)
 	writeBundledImportLock(t, cityDir, source, commit)
 	cacheDir := bundledRepoCacheDir(home, source, commit)
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 	writeTestFile(t, cacheDir, "internal/bootstrap/packs/core/pack.toml", `
@@ -73,7 +73,7 @@ func TestResolveLockedRemoteImportFastPathToleratesBundledSyntheticExtraFile(t *
 	commit := canonicalBundledCommit(source)
 	writeBundledImportLock(t, cityDir, source, commit)
 	cacheDir := bundledRepoCacheDir(home, source, commit)
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 	writeTestFile(t, cacheDir, "internal/bootstrap/packs/core/agents/injected/prompt.md", "extra file")
@@ -93,7 +93,7 @@ func TestResolveInstalledRemoteImportAcceptsBundledSyntheticCache(t *testing.T) 
 	commit := canonicalBundledCommit(source)
 	writeBundledImportLock(t, cityDir, source, commit)
 	cacheDir := bundledRepoCacheDir(home, source, commit)
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 
@@ -112,7 +112,7 @@ func TestResolveImportPackRefAcceptsPublicGastownSyntheticCache(t *testing.T) {
 	commit := strings.TrimPrefix(PublicGastownPackVersion, "sha:")
 	writeBundledImportLock(t, cityDir, source, commit)
 	cacheDir := bundledRepoCacheDir(home, source, commit)
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.PublicRepository, commit); err != nil {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 
@@ -139,7 +139,7 @@ func TestLoadWithIncludes_RigBundledImportSelfHealsOfflineWithoutLock(t *testing
 	source := PublicGastownPackSource
 	commit := strings.TrimPrefix(PublicGastownPackVersion, "sha:")
 	cacheDir := bundledRepoCacheDir(home, source, commit)
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.PublicRepository, commit); err != nil {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 
@@ -488,7 +488,7 @@ func TestResolveInstalledRemoteImportBundledFallbackWithoutLock(t *testing.T) {
 	if got != want {
 		t.Fatalf("cacheDir = %q, want %q", got, want)
 	}
-	if err := builtinpacks.ValidateSyntheticRepo(got, commit); err != nil {
+	if err := builtinpacks.ValidateSyntheticRepo(got, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("fallback did not hydrate a valid synthetic cache: %v", err)
 	}
 }
@@ -532,7 +532,7 @@ func TestResolveInstalledRemoteImportLockedBundledSelfHealsWhenCacheAbsent(t *te
 	if got != cacheDir {
 		t.Fatalf("cacheDir = %q, want %q", got, cacheDir)
 	}
-	if err := builtinpacks.ValidateSyntheticRepo(got, commit); err != nil {
+	if err := builtinpacks.ValidateSyntheticRepo(got, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("self-heal did not produce a valid synthetic cache: %v", err)
 	}
 }

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -298,14 +298,18 @@ func resolveBundledSourceWithoutLock(source, declaredVersion string) (string, bo
 		return "", true, fmt.Errorf("resolving global repo cache root: %w", err)
 	}
 	cacheDir := filepath.Join(cacheRoot, RepoCacheKey(source, commit))
-	if builtinpacks.ValidateSyntheticRepoFast(cacheDir, commit) == nil {
+	repository, ok := builtinpacks.RepositoryForSource(source)
+	if !ok {
+		return "", true, fmt.Errorf("resolving bundled repository for %q", source)
+	}
+	if builtinpacks.ValidateSyntheticRepoFast(cacheDir, repository, commit) == nil {
 		return cacheDir, true, nil
 	}
 	if _, err := WithRepoCacheWriteLock(cacheRoot, func() (string, error) {
-		if builtinpacks.ValidateSyntheticRepo(cacheDir, commit) == nil {
+		if builtinpacks.ValidateSyntheticRepo(cacheDir, repository, commit) == nil {
 			return cacheDir, nil
 		}
-		return cacheDir, builtinpacks.MaterializeSyntheticRepo(cacheDir, commit)
+		return cacheDir, builtinpacks.MaterializeSyntheticRepo(cacheDir, repository, commit)
 	}); err != nil {
 		return "", true, fmt.Errorf("hydrating synthetic repo cache: %w", err)
 	}
@@ -439,16 +443,20 @@ func rematerializeAbsentBundledCache(source, cacheRoot, cacheDir, commit string)
 		// Present (possibly drifted/tampered) or unstattable: do not auto-heal.
 		return false
 	}
+	repository, ok := builtinpacks.RepositoryForSource(source)
+	if !ok {
+		return false
+	}
 	if _, err := WithRepoCacheWriteLock(cacheRoot, func() (string, error) {
 		// Re-check under the lock: another writer may have materialized it.
-		if builtinpacks.ValidateSyntheticRepo(cacheDir, commit) == nil {
+		if builtinpacks.ValidateSyntheticRepo(cacheDir, repository, commit) == nil {
 			return cacheDir, nil
 		}
-		return cacheDir, builtinpacks.MaterializeSyntheticRepo(cacheDir, commit)
+		return cacheDir, builtinpacks.MaterializeSyntheticRepo(cacheDir, repository, commit)
 	}); err != nil {
 		return false
 	}
-	return builtinpacks.ValidateSyntheticRepo(cacheDir, commit) == nil
+	return builtinpacks.ValidateSyntheticRepo(cacheDir, repository, commit) == nil
 }
 
 // ResetRemoteCacheValidationCache clears memoized remote-cache validations
@@ -463,8 +471,8 @@ func ResetRemoteCacheValidationCache() {
 func validateInstalledRemoteCache(source, cacheDir, commit string) error {
 	gitPath := filepath.Join(cacheDir, ".git")
 	gitInfo, gitStatErr := os.Stat(gitPath)
-	if IsBundledSourceAtCanonicalPin(source, commit) {
-		err := builtinpacks.ValidateSyntheticRepoFast(cacheDir, commit)
+	if repository, ok := builtinpacks.RepositoryForSource(source); ok && IsBundledSourceAtCanonicalPin(source, commit) {
+		err := builtinpacks.ValidateSyntheticRepoFast(cacheDir, repository, commit)
 		if err == nil {
 			return nil
 		}

--- a/internal/config/pack_include_test.go
+++ b/internal/config/pack_include_test.go
@@ -452,7 +452,7 @@ func TestResolveBundledSourceWithoutLockHitsFastPathOnPreMaterializedCache(t *te
 	if err := os.MkdirAll(filepath.Dir(cacheDir), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 
@@ -487,7 +487,7 @@ func TestValidateInstalledRemoteCacheAcceptsBundledCanonicalPinFast(t *testing.T
 	if err := os.MkdirAll(filepath.Dir(cacheDir), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 

--- a/internal/packman/bundled_test.go
+++ b/internal/packman/bundled_test.go
@@ -48,7 +48,7 @@ func TestEnsureRepoInCacheMaterializesBundledSourceWithoutGit(t *testing.T) {
 	if _, err := os.Stat(packToml); err != nil {
 		t.Fatalf("synthetic cache missing gastown pack.toml: %v", err)
 	}
-	if err := builtinpacks.ValidateSyntheticRepo(got, commit); err != nil {
+	if err := builtinpacks.ValidateSyntheticRepo(got, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("ValidateSyntheticRepo: %v", err)
 	}
 }
@@ -123,7 +123,7 @@ func TestReadCachedPackImportsAcceptsBundledSyntheticCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoCachePath: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 
@@ -170,7 +170,7 @@ func TestMaterializeBundledRepoInCacheLockedRejectsNonCanonicalPath(t *testing.T
 	nonCanonical := filepath.Join(t.TempDir(), "cache")
 
 	prevMaterialize := materializeSyntheticRepo
-	materializeSyntheticRepo = func(string, string) error {
+	materializeSyntheticRepo = func(string, string, string) error {
 		t.Fatal("materializeSyntheticRepo was called for non-canonical path")
 		return nil
 	}
@@ -213,7 +213,7 @@ func TestEnsureBundledCacheMaterializeFailureIncludesRecoveryCause(t *testing.T)
 	t.Cleanup(func() { runGit = prevGit })
 
 	prevMaterialize := materializeSyntheticRepo
-	materializeSyntheticRepo = func(dst, gotCommit string) error {
+	materializeSyntheticRepo = func(dst, _, gotCommit string) error {
 		if dst != cachePath {
 			t.Fatalf("materialize dst = %q, want %q", dst, cachePath)
 		}
@@ -278,7 +278,7 @@ func TestEnsureRepoInCacheClonesBundledSourceAtNonCanonicalPin(t *testing.T) {
 	t.Cleanup(func() { runNetworkGit = prevNetGit })
 
 	prevMaterialize := materializeSyntheticRepo
-	materializeSyntheticRepo = func(string, string) error {
+	materializeSyntheticRepo = func(string, string, string) error {
 		t.Fatal("materializeSyntheticRepo was called for a non-canonical pin")
 		return nil
 	}
@@ -307,7 +307,7 @@ func TestEnsureRepoInCacheClonesBundledSourceAtNonCanonicalPin(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(got, ".gc-bundled-pack-cache.toml")); !os.IsNotExist(err) {
 		t.Fatalf("synthetic marker stat err = %v, want not exist", err)
 	}
-	if err := builtinpacks.ValidateSyntheticRepo(got, commit); err == nil {
+	if err := builtinpacks.ValidateSyntheticRepo(got, builtinpacks.Repository, commit); err == nil {
 		t.Fatal("clone result validates as a synthetic cache; embedded content must not be materialized")
 	}
 	data, err := os.ReadFile(filepath.Join(got, "examples", "gastown", "packs", "gastown", "pack.toml"))

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -70,7 +70,11 @@ func EnsureRepoInCache(cityRoot, source, commit string) (string, error) {
 }
 
 func ensureBundledRepoInCacheLocked(source, commit, cachePath string) (string, error) {
-	validationErr := builtinpacks.ValidateSyntheticRepo(cachePath, commit)
+	repository, ok := builtinpacks.RepositoryForSource(source)
+	if !ok {
+		return "", fmt.Errorf("resolving bundled repository for %q", source)
+	}
+	validationErr := builtinpacks.ValidateSyntheticRepo(cachePath, repository, commit)
 	if validationErr == nil {
 		if err := validateCachedPackRoot(source, cachePath); err != nil {
 			return "", err
@@ -156,7 +160,11 @@ func materializeBundledRepoInCacheLocked(source, commit, cachePath string) error
 	if cachePath != expected {
 		return fmt.Errorf("refusing to materialize bundled repo cache at non-canonical path %q, expected %q", cachePath, expected)
 	}
-	return materializeSyntheticRepo(cachePath, commit)
+	repository, ok := builtinpacks.RepositoryForSource(source)
+	if !ok {
+		return fmt.Errorf("resolving bundled repository for %q", source)
+	}
+	return materializeSyntheticRepo(cachePath, repository, commit)
 }
 
 func withRepoCacheReadLock(fn func() error) error {

--- a/internal/packman/check.go
+++ b/internal/packman/check.go
@@ -279,8 +279,8 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 		return "", false
 	}
 
-	if config.IsBundledSourceAtCanonicalPin(source, commit) {
-		if err := builtinpacks.ValidateSyntheticRepo(cachePath, commit); err != nil {
+	if repository, known := builtinpacks.RepositoryForSource(source); known && config.IsBundledSourceAtCanonicalPin(source, commit) {
+		if err := builtinpacks.ValidateSyntheticRepo(cachePath, repository, commit); err != nil {
 			gitInfo, gitErr := os.Stat(filepath.Join(cachePath, ".git"))
 			if gitErr == nil && !gitutil.MissingCheckoutMarker(gitInfo, gitErr) {
 				if !s.validateCachedGitCheckout(name, source, commit, cachePath) {

--- a/internal/packman/check_test.go
+++ b/internal/packman/check_test.go
@@ -289,7 +289,7 @@ func TestCheckInstalledAcceptsBundledSyntheticCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoCachePath: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 
@@ -361,7 +361,7 @@ func TestCheckInstalledReportsInvalidSyntheticCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoCachePath: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cachePath, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(cachePath, "examples", "gastown", "packs", "gastown", "pack.toml"), []byte("tampered"), 0o644); err != nil {

--- a/internal/packman/install.go
+++ b/internal/packman/install.go
@@ -58,8 +58,8 @@ func ReadCachedPackImports(source, commit string) (map[string]config.Import, err
 	}
 	var imports map[string]config.Import
 	if err := config.WithRepoCacheReadLock(root, func() error {
-		if config.IsBundledSourceAtCanonicalPin(source, commit) {
-			if err := builtinpacks.ValidateSyntheticRepo(cachePath, commit); err != nil {
+		if repository, known := builtinpacks.RepositoryForSource(source); known && config.IsBundledSourceAtCanonicalPin(source, commit) {
+			if err := builtinpacks.ValidateSyntheticRepo(cachePath, repository, commit); err != nil {
 				gitInfo, gitErr := os.Stat(filepath.Join(cachePath, ".git"))
 				if gitutil.MissingCheckoutMarker(gitInfo, gitErr) {
 					return fmt.Errorf("synthetic cache is invalid: %w", err)
@@ -144,7 +144,8 @@ func EnsureBundledPacksCurrent(cityRoot string) error {
 		if err != nil {
 			return err
 		}
-		if builtinpacks.ValidateSyntheticRepoFast(cachePath, pack.Commit) == nil {
+		repository, known := builtinpacks.RepositoryForSource(source)
+		if known && builtinpacks.ValidateSyntheticRepoFast(cachePath, repository, pack.Commit) == nil {
 			continue
 		}
 		if _, err := EnsureRepoInCache(cityRoot, source, pack.Commit); err != nil {

--- a/internal/packman/install_test.go
+++ b/internal/packman/install_test.go
@@ -913,12 +913,15 @@ func TestEnsureBundledPacksCurrentRepairsStaleSyntheticCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoCachePath: %v", err)
 	}
-	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 	staleMarker := `.gc-bundled-pack-cache.toml`
 	stalePath := filepath.Join(cacheDir, staleMarker)
-	staleData := `schema = 1
+	// schema must match the current marker schema: the point of this fixture is
+	// the CONTENT-HASH skew branch, and a stale schema would trip the earlier
+	// schema check instead, leaving the skew case unexercised.
+	staleData := `schema = 2
 repository = "https://github.com/gastownhall/gascity.git"
 commit = "` + commit + `"
 content_hash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
@@ -927,7 +930,7 @@ content_hash = "sha256:000000000000000000000000000000000000000000000000000000000
 		t.Fatalf("WriteFile(stale marker): %v", err)
 	}
 	// Confirm the cache is stale before the repair.
-	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err == nil {
+	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err == nil {
 		t.Fatal("expected stale cache to fail validation before repair")
 	}
 
@@ -936,7 +939,7 @@ content_hash = "sha256:000000000000000000000000000000000000000000000000000000000
 	}
 
 	// After repair the cache must pass validation.
-	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err != nil {
+	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err != nil {
 		t.Fatalf("ValidateSyntheticRepo after repair: %v", err)
 	}
 
@@ -947,7 +950,7 @@ content_hash = "sha256:000000000000000000000000000000000000000000000000000000000
 	if err := os.WriteFile(sentinel, []byte("keep"), 0o644); err != nil {
 		t.Fatalf("WriteFile(sentinel): %v", err)
 	}
-	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err == nil {
+	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, builtinpacks.Repository, commit); err == nil {
 		t.Fatal("expected full validation to reject the unrelated sentinel")
 	}
 


### PR DESCRIPTION
## The juicy parts

Every `gc` command runs the builtin readiness pass, and today that pass byte-compares cached pack files belonging to a repository the cache can never serve. Scoping the cache removes that work: the `gascity.git` cache drops from 491 files to 228, and the remainder moves to its own `gascity-packs.git` cache — `228 + 264 − 1 = 491`, so nothing is trimmed heuristically.

On one darwin/arm64 machine, warm `gc version` against the same populated `GC_HOME` went 216/207/219 ms on `main` to 158/168/163 ms here — roughly 25% off warm startup. That is three runs per arm on one box: a shape, not a benchmark. Detection gets *stricter* rather than looser, because a narrower allowed set rejects files it used to tolerate.

Two things to weigh against that. Folding the marker schema into the cache key is what stops two binary generations re-materializing over each other under the exclusive repo-cache lock. And the price is exactly one orphaned cache directory per machine (~3.7 MB), reclaimed by `gc import prune --apply` — disclosed below rather than left to be discovered.

## What this is

A synthetic pack cache directory now holds — and is validated against — only the
layouts of the repository it belongs to.

## Why I was looking at this

I have been profiling `gc`'s own startup cost alongside
[#4441](https://github.com/gastownhall/gascity/issues/4441). This is not part of
that proposal and does not depend on it; it is a general-benefit change I ran
into underneath it and it should be reviewed on its own merits.

## The observation

A cache directory is keyed on the normalized clone URL **with the subpath
stripped**, and imports resolve to `<cache>/<subpath>` rather than the cache
root. So a cache built for `gascity.git` can only ever serve `gascity.git`
subpaths.

It was nevertheless materialized with *every* repository's layouts, and every one
of those was byte-compared against the embedded copy on each readiness pass —
`os.ReadFile` per cached file.

## The measurement

Numbers below are from one machine (darwin/arm64), built `gc` binaries, this
branch vs `main`, one run per data point except where noted. Not a rigorous
benchmark — enough to show the shape, not enough to quote to three digits.

**Files materialized** (`gc doctor` against a fresh `GC_HOME`, one cache dir):

| cache | files |
| --- | ---: |
| `gascity.git` — before | 491 |
| `gascity.git` — after | **228** |
| `gascity-packs.git` — after | 264 |

The arithmetic is the useful part: `228 + 264 − 1 = 491`. The `− 1` is the
marker: the old single cache had one, the two scoped caches have one each, so
the split adds exactly one file back. The rest of the difference is exactly the
other repository's layouts and nothing else — not a heuristic trim.

(A `gc doctor` probe on a fresh `GC_HOME` reports 493 / 230 rather than
491 / 228; the extra two are the probe's own city scaffolding, not cache
contents.)

**Warm startup** (`gc version`, same populated `GC_HOME`). Re-measured after
#4880 merged, against `main` **including** #4880, because #4880 already removed
several traversals per call and I did not want to claim any of its win as this
PR's. Interleaved — arms alternate every round, 10 invocations per data point:

| round | `main` (incl. #4880) | this branch |
| ---: | ---: | ---: |
| 1 | 178.0 ms | **117.4 ms** |
| 2 | 153.6 ms | **111.5 ms** |
| 3 | 150.3 ms | **118.3 ms** |
| 4 | 157.6 ms | **112.4 ms** |
| 5 | 147.9 ms | **107.2 ms** |
| 6 | 144.6 ms | **111.9 ms** |

Medians ≈ 152 ms → 112 ms, so roughly 25% off warm startup, and every round
favours the branch. That is the readiness pass no longer byte-comparing the other
repository's 263 files. One machine (darwin/arm64) — the effect is large and
consistent enough to report, but it is one box, not a fleet.

**Files rewritten during those warm runs: 0 on both arms.** That is the answer
to "does the schema bump make this thrash" — it does not. The bump costs exactly
one re-materialization, once, and steady state is unchanged.

## Detection gets stronger, not weaker

Worth saying plainly, because a smaller allowed set reads like a looser check.

Scoping only ever **narrows** the set of paths a cache may contain, and a
narrower set produces *more* rejections. A layout belonging to the other
repository used to be tolerated inside this cache; it is now an unexpected file
and fails validation.

## The marker schema is folded into the cache key

This is the part I would most want a reviewer to check, because leaving it out
is actively harmful rather than merely incomplete.

Without it, an old and a new binary resolve to the **same** machine-global
directory, each rejects the other's marker, and each re-materializes the whole
tree on every invocation — in both directions, for as long as two generations are
in use. And each of those re-materializations takes the **exclusive** repo-cache
lock, which covers the whole cache root, so every other `gc` on the box waits
behind a rewrite it did not need. That is the failure mode; I did not try to put
a clean number on it, because the interesting cost is contention rather than
single-command latency.

`SyntheticCacheKeyComponent` already existed for exactly this failure — the
citywide wedge that recurs whenever a deploy leaves two binary versions running
side by side — but it was bound only to embedded *content*. A schema change
alters the expected *layout* without altering content, so content alone cannot
separate them. The schema is now part of the key, and the two binaries simply use
different directories.

Schema 1 markers are rejected rather than migrated. That is the ordinary
self-heal path, not a migration step.

### The cost: one orphaned directory per machine

Stating this rather than letting a reviewer find it, because "invalidates every
cache on every machine" is the headline risk of this PR.

Because the schema is folded into the cache key, a schema-2 binary resolves a
**new** directory name and never touches the schema-1 one. Nothing deletes it.
Every machine that upgrades gains one orphaned cache directory (~3.7 MB here).

Reclamation is manual: `gc import prune --apply`. The old directory's name is not
in any `packs.lock` under the new key, so it classifies as unreferenced, and it is
removed once it is older than `--keep-days` (default 7).

This is acceptable and precedented — any change to the embedded pack content does
exactly the same thing today, since the content hash is already in the key — but
it is a real disclosure and it should be in the PR, not discovered.

## Two correctness details

- **The caller supplies the repository and it is cross-checked against the
  marker**, mirroring how `commit` is already handled. Trusting the marker alone
  would let a cache built for the wrong repository validate clean and then fail
  at import resolution.
- **Both validators reject an unknown repository.** Without that the layout set
  collapses to empty, and a directory holding nothing but a well-formed marker
  validates clean.

Both of these came out of adversarial review of an earlier draft, which
reproduced the empty-layout-set hole.

## Notes for the reviewer

- Test-side changes are mostly the `ValidateSyntheticRepo` /
  `MaterializeSyntheticRepo` signature gaining `repository`.
- `TestValidateSyntheticRepoRejectsStrayFilesAnywhere` covers stray files at
  every depth under the **scoped** allowed set, including nested layouts
  (`examples/bd` contains `examples/bd/dolt`) — the case where flattening several
  manifests into one allowed set could conceivably admit a path no single
  manifest claims.
- **`validatePackFiles` no longer walks its own subtree** — #4880 removed that
  walk, because the whole-tree walk in `validateSyntheticRepoFileSet` already
  subsumed it. That whole-tree walk is what this PR scopes, and scoping only
  narrows the union it checks against, so the subsumption still holds:
  `ValidateSyntheticRepo` calls `validatePackFiles` for exactly the layouts the
  union is built from. (An earlier revision of this description said the opposite;
  it was written before #4880 landed.)
- The new `RepositoryForSource` call sites add about five `if !ok { return err }`
  branches that are unreachable today: every one of them is already gated
  upstream by `IsSource` / `IsBundledSourceAtCanonicalPin`, so the source is
  known to be bundled before the helper is asked. They are defense in depth
  against a future caller, not a fix for a reachable case — flagging it so nobody
  goes hunting for the bug they are guarding.
- This is deliberately standalone against `main` rather than stacked on my other
  open PRs, so it can be reviewed and landed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


