### PR TITLE
fix(import): local-in-git pack imports lock to HEAD, not latest tag (#3659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`gc import add` of a local in-git pack now locks to HEAD, not the repo's
+  latest tag.** Per `gc import add --help`, a local path inside a git
+  worktree is documented to be "locked to the current commit," but the
+  default version resolution (absent an explicit `--version`) preferred the
+  repo's latest semver tag whenever one existed. A pack added to the
+  worktree after the last tag was cut resolved to a checkout whose tree
+  predates the pack, failing with a misleading "missing pack.toml" error
+  even though the pack exists at HEAD. A local-worktree-promoted source now
+  always locks to `sha:<HEAD commit>`, matching the documented behavior;
+  registry/remote sources are unaffected. Fixes #3659.
+
 - **The dolt pack's `run_bounded` python3 fallback now sends SIGTERM before
   SIGKILL, matching its documented contract.** The fallback (used when
   neither `timeout` nor `gtimeout` is on `PATH`, the default on stock macOS)

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -2358,7 +2358,15 @@ scope = "city"
 	}
 }
 
-func TestDoImportAddLocalGitRepoWithTagsWritesDefaultConstraint(t *testing.T) {
+// TestDoImportAddLocalGitRepoWithTagsStillLocksToHEAD confirms a local-in-git
+// import locks to the worktree's HEAD commit even when the repo also has a
+// semver tag that happens to point at the same commit -- a local worktree
+// source locks to HEAD unconditionally, per gc import add --help ("local
+// paths inside git worktrees at HEAD: ... locked to the current commit") and
+// the gastownhall/gascity#3659 fix; the tag's presence is incidental, not a
+// signal to prefer semver-constraint resolution over the worktree the user
+// actually pointed at.
+func TestDoImportAddLocalGitRepoWithTagsStillLocksToHEAD(t *testing.T) {
 	clearGCEnv(t)
 	dir := t.TempDir()
 	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
@@ -2395,8 +2403,82 @@ scope = "city"
 	if imp.Source != wantSource {
 		t.Fatalf("Source = %q, want %q", imp.Source, wantSource)
 	}
-	if got, want := imp.Version, "^1.2"; got != want {
+	headCommit := gitOutputImport(t, packDir, "rev-parse", "HEAD")
+	if got, want := imp.Version, "sha:"+headCommit; got != want {
 		t.Fatalf("Version = %q, want %q", got, want)
+	}
+}
+
+// TestDoImportAddLocalGitRepoWithStaleTagLocksToHEADNotTag is the regression
+// for gastownhall/gascity#3659: a local-in-git import locked to the repo's
+// latest semver tag instead of HEAD, so a pack added to the worktree after
+// the last tag was cut resolved to a checkout that lacks pack.toml at all
+// (the tagged tree predates the pack), failing with a misleading "missing
+// pack.toml" error even though the pack exists at HEAD. Per gc import add
+// --help, a local path inside a git worktree at HEAD must lock to the
+// current commit, not to whatever the repo's git tags happen to say.
+func TestDoImportAddLocalGitRepoWithStaleTagLocksToHEADNotTag(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+
+	workDir := t.TempDir()
+	packDir := filepath.Join(workDir, "stale-tag-pack")
+	mustGitImport(t, "", "init", packDir)
+	writePlaceholder := filepath.Join(packDir, "README.md")
+	if err := os.WriteFile(writePlaceholder, []byte("placeholder\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGitImport(t, packDir, "add", "-A")
+	mustGitImport(t, packDir, "commit", "-m", "initial, no pack yet")
+	mustGitImport(t, packDir, "tag", "-a", "v0.1.0", "-m", "release v0.1.0")
+
+	// pack.toml lands AFTER the only tag, so v0.1.0's tree does not contain it.
+	packToml := filepath.Join(packDir, "pack.toml")
+	if err := os.WriteFile(packToml, []byte(`[pack]
+name = "stale-tag-pack"
+schema = 1
+
+[[agent]]
+name = "sentinel"
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGitImport(t, packDir, "add", "-A")
+	mustGitImport(t, packDir, "commit", "-m", "add pack.toml")
+	headCommit := gitOutputImport(t, packDir, "rev-parse", "HEAD")
+
+	relSource, err := filepath.Rel(dir, packDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportAdd(fsys.OSFS{}, dir, relSource, "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+
+	cfgFile, err := config.Load(fsys.OSFS{}, filepath.Join(dir, "pack.toml"))
+	if err != nil {
+		t.Fatalf("Load(pack.toml): %v", err)
+	}
+	resolvedPackDir, err := filepath.EvalSymlinks(packDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSource := "file://" + filepath.ToSlash(resolvedPackDir)
+	imp := cfgFile.Imports["stale-tag-pack"]
+	if got, want := imp.Version, "sha:"+headCommit; got != want {
+		t.Fatalf("Version = %q, want %q (must lock to HEAD, not the stale tag v0.1.0)", got, want)
+	}
+	lock, err := packman.ReadLockfile(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := lock.Packs[wantSource].Commit; got != headCommit {
+		t.Fatalf("Commit = %q, want %q", got, headCommit)
 	}
 }
 

--- a/internal/importsvc/importsvc.go
+++ b/internal/importsvc/importsvc.go
@@ -165,9 +165,13 @@ func (d Deps) fenceSource(source string) error {
 // resolveImportVersion validates and resolves the version constraint for an add.
 // Git-backed sources reject a ref embedded in the URL and, when no constraint is
 // given, default to the resolved semver/HEAD; non-git path sources reject a
-// constraint outright. The returned error already carries the transport-mapped
-// sentinel (ErrInvalidSource or ErrVersionResolveFailed).
-func (d Deps) resolveImportVersion(cityRoot, source, versionConstraint string, gitBacked bool) (string, error) {
+// constraint outright. localHead marks a source promoted from a local git
+// worktree: absent an explicit constraint, it locks to the worktree's current
+// HEAD commit rather than the repo's latest semver tag, which may predate the
+// pack existing in the tree at all (gastownhall/gascity#3659). The returned
+// error already carries the transport-mapped sentinel (ErrInvalidSource or
+// ErrVersionResolveFailed).
+func (d Deps) resolveImportVersion(cityRoot, source, versionConstraint string, gitBacked, localHead bool) (string, error) {
 	if !gitBacked {
 		if versionConstraint != "" {
 			return "", fmt.Errorf("%w: --version is only valid for git-backed imports", ErrInvalidSource)
@@ -179,6 +183,13 @@ func (d Deps) resolveImportVersion(cityRoot, source, versionConstraint string, g
 	}
 	if versionConstraint != "" {
 		return versionConstraint, nil
+	}
+	if localHead {
+		commit, err := d.resolveHeadCommit()(cityRoot, source)
+		if err != nil {
+			return "", fmt.Errorf("%w: %w", ErrVersionResolveFailed, err)
+		}
+		return "sha:" + commit, nil
 	}
 	version, err := d.defaultImportVersionForSource(cityRoot, source)
 	if err != nil {
@@ -204,7 +215,7 @@ func AddImportWith(fs fsys.FS, cityPath, source, nameOverride, versionConstraint
 		return nil, fmt.Errorf("%w: %w", ErrScopeLoad, err)
 	}
 
-	source, gitBacked, err := normalizeImportAddSource(fs, cityPath, source)
+	source, gitBacked, localHead, err := normalizeImportAddSource(fs, cityPath, source)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidSource, err)
 	}
@@ -240,7 +251,7 @@ func AddImportWith(fs fsys.FS, cityPath, source, nameOverride, versionConstraint
 		}
 	}
 
-	version, err := deps.resolveImportVersion(cityPath, source, versionConstraint, gitBacked)
+	version, err := deps.resolveImportVersion(cityPath, source, versionConstraint, gitBacked, localHead)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/importsvc/source.go
+++ b/internal/importsvc/source.go
@@ -45,31 +45,36 @@ func hasRepositoryRefInSource(source string) bool {
 // normalizeImportAddSource canonicalizes the user-supplied source. Remote git
 // sources pass through unchanged; local paths are validated as pack targets and
 // promoted to file:// repo sources when they sit at the HEAD of a git worktree.
-// The boolean reports whether the resolved source is git-backed.
-func normalizeImportAddSource(fs fsys.FS, cityPath, source string) (string, bool, error) {
+// The first boolean reports whether the resolved source is git-backed; the
+// second reports whether it was promoted from a local git worktree, which
+// means the default version (absent an explicit constraint) must lock to
+// HEAD rather than the repo's latest semver tag -- the worktree is what the
+// user pointed at, and a tag cut before the pack existed in the tree would
+// resolve to a checkout missing it entirely (gastownhall/gascity#3659).
+func normalizeImportAddSource(fs fsys.FS, cityPath, source string) (string, bool, bool, error) {
 	if isRemoteImportSource(source) {
 		if err := rejectSourceUserinfo(source); err != nil {
-			return "", false, err
+			return "", false, false, err
 		}
-		return source, true, nil
+		return source, true, false, nil
 	}
 
 	targetDir, err := resolveImportAddPath(cityPath, source)
 	if err != nil {
-		return "", false, err
+		return "", false, false, err
 	}
 	if err := validateImportPackTarget(fs, targetDir); err != nil {
-		return "", false, err
+		return "", false, false, err
 	}
 
 	canonical, ok, err := canonicalizeLocalGitImportSource(targetDir)
 	if err != nil {
-		return "", false, err
+		return "", false, false, err
 	}
 	if ok {
-		return canonical, true, nil
+		return canonical, true, true, nil
 	}
-	return source, false, nil
+	return source, false, false, nil
 }
 
 // rejectSourceUserinfo refuses a URL-scheme source that embeds credentials in


### PR DESCRIPTION
## Summary
Fixes #3659: `gc import add <local-in-git-pack>` (no `--version`) is documented to lock to HEAD for local paths inside git worktrees, but the default resolution actually preferred the repo's latest semver tag whenever one existed, only falling back to HEAD when the repo had zero tags. A pack added to the worktree after the last tag was cut resolves to a checkout whose tree predates the pack, so `validateCachedPackRoot` fails with a misleading "missing pack.toml" error (and deletes the cache dir on the way out).

Checked for an existing PR first: #3731 fixes the sibling issue #3710 (a *remote* import with an explicit `--version` constraint resolved against git tags instead of the registry's release table) — a different call path (`internal/packman/resolve.go`'s constrained `VersionResolver` seam) from this bug, which is in the *unconstrained default* path (`internal/importsvc/importsvc.go`'s `defaultImportVersionForSource`). Confirmed genuinely uncovered by #3731.

## Fix
`normalizeImportAddSource` now also reports whether a source was promoted from a local git worktree (`internal/importsvc/source.go`); when it was and no `--version` constraint is given, `resolveImportVersion` locks straight to `sha:<HEAD commit>` instead of going through tag-based default resolution. Registry/remote sources are untouched — same code path, same gating, no change to their behavior.

## Test plan
- [x] New regression test `TestDoImportAddLocalGitRepoWithStaleTagLocksToHEADNotTag` builds a real git repo (tag cut before `pack.toml` exists, so the tag's tree lacks it) — confirmed red against unfixed code (reproduces the exact "missing pack.toml" error from the issue), green after the fix.
- [x] Updated a pre-existing test (`TestDoImportAddLocalGitRepoWithTagsWritesDefaultConstraint`, renamed to `...StillLocksToHEAD`) that had been asserting the buggy tag-preferring behavior as expected — it only passed before because its tag and HEAD happened to be the same commit, masking the drift case.
- [x] Full `internal/importsvc` and `cmd/gc` import suites green, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)