### PR TITLE
fix(searchpath): find Nix-installed provider CLIs (#3962)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bound or explicitly configured endpoints keep bd's own output unchanged
   (gastownhall/gascity#1374).
 
+- **`gc init` provider readiness now finds Nix-installed CLIs.** Provider
+  readiness probes (`gc init --default-provider gemini` and friends) search a
+  deterministic, user-aware set of install directories rather than the
+  ambient `$PATH`, so a CLI installed via Nix (`~/.nix-profile/bin` for
+  classic `nix-env`, `~/.local/state/nix/profiles/profile/bin` for the newer
+  `nix profile install`) was reported as "not installed" even when it was on
+  the shell's `PATH`. Both locations are now included, matching the existing
+  npm/pnpm/yarn/cargo/nvm handling in `internal/searchpath`. Fixes #3962.
+
 - **ACP activity is now available across process boundaries.** ACP
   `session/update` timestamps are published through an atomic, coalesced
   sidecar, allowing a process other than the session owner to report

--- a/internal/searchpath/searchpath.go
+++ b/internal/searchpath/searchpath.go
@@ -101,6 +101,15 @@ func userManagedDirs(homeDir string) []string {
 		filepath.Join(homeDir, ".npm-global", "bin"),
 		filepath.Join(homeDir, ".yarn", "bin"),
 		filepath.Join(homeDir, ".config", "yarn", "global", "node_modules", ".bin"),
+		// Nix single-user profile bins. `.nix-profile` is the classic
+		// nix-env symlink; `.local/state/nix/profiles/profile` is where
+		// the newer `nix profile install` (flake-based) command links by
+		// default. gc init's provider-readiness probes use this search
+		// path (NOT the ambient PATH), so a CLI installed via Nix was
+		// previously reported as "not installed" even though it was on
+		// the shell's PATH (gastownhall/gascity#3962).
+		filepath.Join(homeDir, ".nix-profile", "bin"),
+		filepath.Join(homeDir, ".local", "state", "nix", "profiles", "profile", "bin"),
 	)
 	dirs = append(dirs, globExistingDirs(
 		filepath.Join(homeDir, ".nvm", "versions", "node", "*", "bin"),

--- a/internal/searchpath/searchpath_test.go
+++ b/internal/searchpath/searchpath_test.go
@@ -121,6 +121,39 @@ func TestDedupePreservesOrder(t *testing.T) {
 	}
 }
 
+func TestExpandIncludesNixProfileBin(t *testing.T) {
+	home := t.TempDir()
+	nixProfileBin := filepath.Join(home, ".nix-profile", "bin")
+	if err := os.MkdirAll(nixProfileBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dirs := Expand(home, "darwin", "/usr/bin")
+	if !slices.Contains(dirs, nixProfileBin) {
+		t.Fatalf("expected %q in dirs: %v", nixProfileBin, dirs)
+	}
+}
+
+func TestExpandIncludesNixProfileInstallBin(t *testing.T) {
+	home := t.TempDir()
+	nixProfileInstallBin := filepath.Join(home, ".local", "state", "nix", "profiles", "profile", "bin")
+	if err := os.MkdirAll(nixProfileInstallBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dirs := Expand(home, "linux", "/usr/bin")
+	if !slices.Contains(dirs, nixProfileInstallBin) {
+		t.Fatalf("expected %q in dirs: %v", nixProfileInstallBin, dirs)
+	}
+}
+
+func TestExpandOmitsAbsentNixProfileBin(t *testing.T) {
+	home := t.TempDir()
+	dirs := Expand(home, "darwin", "/usr/bin")
+	nixProfileBin := filepath.Join(home, ".nix-profile", "bin")
+	if slices.Contains(dirs, nixProfileBin) {
+		t.Fatalf("did not expect absent %q in dirs: %v", nixProfileBin, dirs)
+	}
+}
+
 func TestExpandNVMVersionsReverseSorted(t *testing.T) {
 	home := t.TempDir()
 	// Create two nvm version dirs.


### PR DESCRIPTION
## Summary
Fixes #3962: `gc init`'s provider-readiness probes (`api.ProbeProviders`) use a deterministic, user-aware install-path search (`internal/searchpath`) rather than the ambient `$PATH`, deliberately, so API calls don't depend on shell-specific edits. That search list already special-cases npm/pnpm/yarn/cargo/nvm/etc. (with a comment citing the identical prior fix for pnpm, #3001), but had no Nix entries — so `gc init --default-provider gemini` reported "is not installed" for a Nix-installed `gemini` binary even though it was on the shell's `PATH`.

## Fix
Added the two current Nix profile bin locations to the existing search list in `internal/searchpath/searchpath.go`'s `userManagedDirs`: `~/.nix-profile/bin` (classic `nix-env`, matches the issue's exact repro) and `~/.local/state/nix/profiles/profile/bin` (newer `nix profile install` default). Same existence-gated pattern as every other entry in that list — zero risk to hosts without Nix.

## Test plan
- [x] 3 new tests: `TestExpandIncludesNixProfileBin`, `TestExpandIncludesNixProfileInstallBin`, `TestExpandOmitsAbsentNixProfileBin` — confirmed red against unfixed code, green after the fix.
- [x] Full `internal/searchpath` suite green, `go build ./...` and `go vet ./internal/searchpath/... ./internal/api/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)