### PR TITLE
feat: export native formula step topology

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -240,16 +240,17 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 	if ep != nil {
 		recorder = ep
 	}
-	onChange := func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage) {
+	onChange := func(eventType, beadID, runID, sessionID, stepID string, dependsOnStepIDs *[]string, payload json.RawMessage) {
 		if recorder != nil {
 			recorder.Record(events.Event{
-				Type:      eventType,
-				Actor:     "cache-reconcile",
-				Subject:   beadID,
-				RunID:     runID,
-				SessionID: sessionID,
-				StepID:    stepID,
-				Payload:   payload,
+				Type:             eventType,
+				Actor:            "cache-reconcile",
+				Subject:          beadID,
+				RunID:            runID,
+				SessionID:        sessionID,
+				StepID:           stepID,
+				DependsOnStepIDs: dependsOnStepIDs,
+				Payload:          payload,
 			})
 		}
 	}

--- a/cmd/gc/event_export.go
+++ b/cmd/gc/event_export.go
@@ -82,10 +82,9 @@ func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers
 		TokenProvider: tokenProvider,
 		Salt:          salt,
 		ExportRef:     ec.ExportRefEnabled(),
-		// Events now carry typed run_id/session_id stamped at the record site, so
-		// emit the opaque correlation ids. They are safeRef-gated and remain
-		// within the v1 wire schema (the envelope already defines both as optional
-		// omitempty fields), so this does not bump SchemaVersion.
+		// Events carry typed run/session correlation and native step topology
+		// stamped at the record site. The projection validates that closed set
+		// before it leaves the city.
 		EmitCorrelation: true,
 		BatchMax:        ec.BatchMaxEvents,
 		BatchInterval:   ec.BatchIntervalDuration(),

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -125,6 +125,7 @@ const (
 	MaxAttemptsMetadataKey               = "gc.max_attempts"
 	MissingRootBeadIDMetadataKey         = "gc.missing_root_bead_id"
 	ModelMetadataKey                     = "gc.model"
+	NativeStepDependenciesMetadataKey    = "gc.native_step_dependencies.v1"
 	NextAttemptMetadataKey               = "gc.next_attempt"
 	OnExhaustedMetadataKey               = "gc.on_exhausted"
 	OnFailMetadataKey                    = "gc.on_fail"
@@ -366,6 +367,7 @@ var KnownMetadataKeys = []string{
 	MaxAttemptsMetadataKey,
 	MissingRootBeadIDMetadataKey,
 	ModelMetadataKey,
+	NativeStepDependenciesMetadataKey,
 	NextAttemptMetadataKey,
 	OnExhaustedMetadataKey,
 	OnFailMetadataKey,

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -46,7 +46,7 @@ type CachingStore struct {
 	syncFailures   int
 	circuitTripped bool
 	stats          CacheStats
-	onChange       func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)
+	onChange       func(eventType, beadID, runID, sessionID, stepID string, dependsOnStepIDs *[]string, payload json.RawMessage)
 	problemf       func(string)
 	problemLog     map[string]cacheProblemLogState
 
@@ -233,7 +233,7 @@ func computeAutoStagger(agentID string) time.Duration {
 // changed bead's metadata at the record site (see notifyChange); the wiring
 // stamps them onto the recorded event so the redacted export can forward them
 // as typed primitives without ever decoding the payload.
-func NewCachingStore(backing Store, onChange func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)) *CachingStore {
+func NewCachingStore(backing Store, onChange func(eventType, beadID, runID, sessionID, stepID string, dependsOnStepIDs *[]string, payload json.RawMessage)) *CachingStore {
 	prefix := ""
 	bdBacking := false
 	nilBdBacking := false
@@ -261,7 +261,7 @@ func NewCachingStore(backing Store, onChange func(eventType, beadID, runID, sess
 
 // NewCachingStoreForTest wraps any Store for testing without production prefix
 // validation. It keeps the legacy 3-param onChange (tests do not exercise the
-// run/session ids); adaptLegacyOnChange bridges it to the production 5-param form.
+// typed correlation fields); adaptLegacyOnChange bridges it to production form.
 func NewCachingStoreForTest(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return newCachingStore(backing, "", adaptLegacyOnChange(onChange))
 }
@@ -275,11 +275,11 @@ func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange f
 // adaptLegacyOnChange bridges the legacy 3-param onChange used by the test
 // constructors to the production 5-param form, dropping the run/session ids the
 // tests do not exercise. Nil-safe.
-func adaptLegacyOnChange(fn func(eventType, beadID string, payload json.RawMessage)) func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage) {
+func adaptLegacyOnChange(fn func(eventType, beadID string, payload json.RawMessage)) func(eventType, beadID, runID, sessionID, stepID string, dependsOnStepIDs *[]string, payload json.RawMessage) {
 	if fn == nil {
 		return nil
 	}
-	return func(eventType, beadID string, _, _, _ string, payload json.RawMessage) {
+	return func(eventType, beadID string, _, _, _ string, _ *[]string, payload json.RawMessage) {
 		fn(eventType, beadID, payload)
 	}
 }
@@ -291,7 +291,7 @@ func (c *CachingStore) SetPrimeRetryDelayForTest(fn func(attempt int) time.Durat
 	c.primeRetryDelay = fn
 }
 
-func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage)) *CachingStore {
+func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID, runID, sessionID, stepID string, dependsOnStepIDs *[]string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:     backing,
 		idPrefix:    normalizeIDPrefix(idPrefix),

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 )
@@ -662,14 +664,47 @@ func (c *CachingStore) notifyChange(eventType string, b Bead) {
 	// free-form metadata map. The run-chain (workflow_id || molecule_id ||
 	// gc.root_bead_id || bead.ID) always resolves to a non-empty id since b.ID is
 	// non-empty; session id is a direct, optional metadata read. Both are
-	// safeRef-gated again at the export boundary.
+	// Run/session are safeRef-gated at the export boundary; native step topology
+	// retains its own established 256-byte domain there.
 	runID := beadmeta.ResolveRunID(b.Metadata, b.ID, "")
 	sessionID := b.Metadata[beadmeta.SessionIDMetadataKey]
-	// step_id is the acting work bead the lifecycle event is about: a work/dispatch
-	// bead carries its own gc.step_id, so a bead.created/closed on one stamps that
-	// step. Non-work beads (sessions, mail, …) carry none → empty, omitted at export.
+	// step_id is the semantic native execution step carried explicitly by the
+	// lifecycle bead. Non-work beads (sessions, mail, …) carry none → omitted.
 	stepID := b.Metadata[beadmeta.StepIDMetadataKey]
-	c.onChange(eventType, b.ID, runID, sessionID, stepID, payload)
+	c.onChange(eventType, b.ID, runID, sessionID, stepID, nativeStepDependencies(b.Metadata, stepID), payload)
+}
+
+// nativeStepDependencies returns the explicit, canonical native topology fact.
+// It never derives edges from physical bead dependencies or other mutable state:
+// absent/malformed metadata is UNKNOWN (nil), while a canonical [] is a known root.
+func nativeStepDependencies(metadata map[string]string, stepID string) *[]string {
+	if !validTopologyStepID(stepID) {
+		return nil
+	}
+	raw, ok := metadata[beadmeta.NativeStepDependenciesMetadataKey]
+	if !ok {
+		return nil
+	}
+	var dependencies []string
+	if err := json.Unmarshal([]byte(raw), &dependencies); err != nil || dependencies == nil {
+		return nil
+	}
+	previous := ""
+	for _, dependency := range dependencies {
+		if !validTopologyStepID(dependency) || dependency == stepID || (previous != "" && dependency <= previous) {
+			return nil
+		}
+		previous = dependency
+	}
+	canonical, err := json.Marshal(dependencies)
+	if err != nil || raw != string(canonical) {
+		return nil
+	}
+	return &dependencies
+}
+
+func validTopologyStepID(id string) bool {
+	return len(id) <= 256 && utf8.ValidString(id) && strings.TrimSpace(id) != ""
 }
 
 type cacheNotification struct {

--- a/internal/beads/caching_store_runid_test.go
+++ b/internal/beads/caching_store_runid_test.go
@@ -12,7 +12,7 @@ import (
 // without ever decoding the payload.
 func TestNotifyChangeResolvesRunSession(t *testing.T) {
 	var gotType, gotID, gotRun, gotSession, gotStep string
-	cs := NewCachingStore(NewMemStore(), func(eventType, beadID, runID, sessionID, stepID string, _ json.RawMessage) {
+	cs := NewCachingStore(NewMemStore(), func(eventType, beadID, runID, sessionID, stepID string, _ *[]string, _ json.RawMessage) {
 		gotType, gotID, gotRun, gotSession, gotStep = eventType, beadID, runID, sessionID, stepID
 	})
 
@@ -38,7 +38,7 @@ func TestNotifyChangeResolvesRunSession(t *testing.T) {
 
 	// workflow_id wins the run-chain precedence over gc.root_bead_id.
 	var run2 string
-	cs2 := NewCachingStore(NewMemStore(), func(_, _, runID, _, _ string, _ json.RawMessage) { run2 = runID })
+	cs2 := NewCachingStore(NewMemStore(), func(_, _, runID, _, _ string, _ *[]string, _ json.RawMessage) { run2 = runID })
 	cs2.notifyChange("bead.created", Bead{ID: "mc-2", Metadata: map[string]string{
 		"workflow_id":     "wf-graph-root",
 		"gc.root_bead_id": "wf-root-x",
@@ -50,7 +50,7 @@ func TestNotifyChangeResolvesRunSession(t *testing.T) {
 	// No run-chain metadata: run falls back to the bead's own id; session + step empty
 	// (a non-work bead carries no gc.step_id).
 	var run3, sess3, step3 string
-	cs3 := NewCachingStore(NewMemStore(), func(_, _, runID, sessionID, stepID string, _ json.RawMessage) {
+	cs3 := NewCachingStore(NewMemStore(), func(_, _, runID, sessionID, stepID string, _ *[]string, _ json.RawMessage) {
 		run3, sess3, step3 = runID, sessionID, stepID
 	})
 	cs3.notifyChange("bead.created", Bead{ID: "mc-3"})

--- a/internal/beads/event_payload_contract_test.go
+++ b/internal/beads/event_payload_contract_test.go
@@ -33,7 +33,7 @@ func TestNotifyChangePayloadDecodesViaSharedDecoder(t *testing.T) {
 	}
 
 	var got json.RawMessage
-	cs := NewCachingStore(NewMemStore(), func(_, _, _, _, _ string, payload json.RawMessage) {
+	cs := NewCachingStore(NewMemStore(), func(_, _, _, _, _ string, _ *[]string, payload json.RawMessage) {
 		got = payload
 	})
 	cs.notifyChange("bead.created", seed)

--- a/internal/beads/native_step_topology_test.go
+++ b/internal/beads/native_step_topology_test.go
@@ -1,0 +1,32 @@
+package beads
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+)
+
+func TestNativeStepDependenciesReadsOnlyCanonicalMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		metadata map[string]string
+		stepID   string
+		want     *[]string
+	}{
+		{name: "missing is unknown", stepID: "step-b"},
+		{name: "known root", stepID: "step-root", metadata: map[string]string{beadmeta.NativeStepDependenciesMetadataKey: "[]"}, want: ptr([]string{})},
+		{name: "canonical dependency list", stepID: "step-b", metadata: map[string]string{beadmeta.NativeStepDependenciesMetadataKey: `["step-a","step-c"]`}, want: ptr([]string{"step-a", "step-c"})},
+		{name: "noncanonical ordering is unknown", stepID: "step-c", metadata: map[string]string{beadmeta.NativeStepDependenciesMetadataKey: `["step-b","step-a"]`}},
+		{name: "self edge is unknown", stepID: "step-a", metadata: map[string]string{beadmeta.NativeStepDependenciesMetadataKey: `["step-a"]`}},
+		{name: "malformed is unknown", stepID: "step-b", metadata: map[string]string{beadmeta.NativeStepDependenciesMetadataKey: `not-json`}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nativeStepDependencies(tc.metadata, tc.stepID); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("nativeStepDependencies() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func ptr(values []string) *[]string { return &values }

--- a/internal/beads/runview_roundtrip_test.go
+++ b/internal/beads/runview_roundtrip_test.go
@@ -90,17 +90,18 @@ func recordThroughNotifyChange(t *testing.T, seeds ...beadSeed) []events.Event {
 	t.Helper()
 	var out []events.Event
 	seq := uint64(0)
-	cs := beads.NewCachingStore(beads.NewMemStore(), func(eventType, beadID, runID, sessionID, stepID string, payload json.RawMessage) {
+	cs := beads.NewCachingStore(beads.NewMemStore(), func(eventType, beadID, runID, sessionID, stepID string, dependsOnStepIDs *[]string, payload json.RawMessage) {
 		seq++
 		out = append(out, events.Event{
-			Seq:       seq,
-			Type:      eventType,
-			Actor:     "cache-reconcile",
-			Subject:   beadID,
-			RunID:     runID,
-			SessionID: sessionID,
-			StepID:    stepID,
-			Payload:   payload,
+			Seq:              seq,
+			Type:             eventType,
+			Actor:            "cache-reconcile",
+			Subject:          beadID,
+			RunID:            runID,
+			SessionID:        sessionID,
+			StepID:           stepID,
+			DependsOnStepIDs: dependsOnStepIDs,
+			Payload:          payload,
 		})
 	})
 	for _, s := range seeds {

--- a/internal/eventfeed/muxsource.go
+++ b/internal/eventfeed/muxsource.go
@@ -49,22 +49,31 @@ func NewMuxSource(providers func() map[string]events.Provider, cursors func() ma
 
 // toExport projects a tagged event down to the exporter's closed primitive set.
 // It forwards only envelope-safe fields (seq/type/time/actor/subject) plus the
-// two opaque correlation ids (run_id/session_id) the record site stamped onto
-// the typed Event fields; it never reads Payload or Message, so a payload-decode
-// can never reintroduce free-form content. The ids are safeRef-gated again in
-// ProjectEvent before egress.
+// opaque run/session correlation ids and native execution-step topology stamped
+// onto typed Event fields; it never reads Payload or Message, so a payload-decode
+// can never reintroduce free-form content. ProjectEvent validates each field at
+// egress.
 func toExport(te events.TaggedEvent) eventexport.TaggedEvent {
 	return eventexport.TaggedEvent{
-		City:      te.City,
-		Seq:       te.Seq,
-		Type:      te.Type,
-		Ts:        te.Ts,
-		Actor:     te.Actor,
-		Subject:   te.Subject,
-		RunID:     te.RunID,
-		SessionID: te.SessionID,
-		StepID:    te.StepID,
+		City:             te.City,
+		Seq:              te.Seq,
+		Type:             te.Type,
+		Ts:               te.Ts,
+		Actor:            te.Actor,
+		Subject:          te.Subject,
+		RunID:            te.RunID,
+		SessionID:        te.SessionID,
+		StepID:           te.StepID,
+		DependsOnStepIDs: cloneStepDependencies(te.DependsOnStepIDs),
 	}
+}
+
+func cloneStepDependencies(dependencies *[]string) *[]string {
+	if dependencies == nil {
+		return nil
+	}
+	clone := append([]string(nil), (*dependencies)...)
+	return &clone
 }
 
 // Next yields the next tagged event, transparently rebuilding the multiplexer on

--- a/internal/eventfeed/muxsource_test.go
+++ b/internal/eventfeed/muxsource_test.go
@@ -314,20 +314,24 @@ func TestAdapter_NoLeakFromPayload(t *testing.T) {
 // TestToExport_ForwardsTypedRunSession proves the adapter forwards the typed
 // Event.RunID/SessionID (stamped at the record site) through to the projected
 // envelope when EmitCorrelation is on.
-func TestToExport_ForwardsTypedRunSession(t *testing.T) {
+func TestToExport_ForwardsTypedRunSessionAndNativeTopology(t *testing.T) {
+	deps := []string{"step-a"}
 	te := events.TaggedEvent{
 		Event: events.Event{
 			Seq: 1, Type: "bead.closed", Ts: time.Date(2026, 6, 21, 10, 3, 27, 0, time.UTC),
-			Actor: "cache-reconcile", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a",
+			Actor: "cache-reconcile", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a", StepID: "step-b", DependsOnStepIDs: &deps,
 		},
 		City: "c",
 	}
 	ex := toExport(te)
-	if ex.RunID != "wf-root-abc" || ex.SessionID != "sess-9f2a" {
-		t.Fatalf("toExport must forward typed run/session, got run=%q session=%q", ex.RunID, ex.SessionID)
+	if ex.RunID != "wf-root-abc" || ex.SessionID != "sess-9f2a" || ex.StepID != "step-b" || ex.DependsOnStepIDs == nil || (*ex.DependsOnStepIDs)[0] != "step-a" {
+		t.Fatalf("toExport must forward typed correlation/topology, got %+v", ex)
+	}
+	if ex.DependsOnStepIDs == &deps {
+		t.Fatal("toExport retained caller-owned topology slice")
 	}
 	env, ok := eventexport.ProjectEvent(ex, eventexport.Options{Salt: []byte("sixteen-byte-salt-xx"), ExportRef: true, EmitCorrelation: true})
-	if !ok || env.RunID != "wf-root-abc" || env.SessionID != "sess-9f2a" {
-		t.Fatalf("projected envelope must carry forwarded run/session, got %+v", env)
+	if !ok || env.RunID != "wf-root-abc" || env.SessionID != "sess-9f2a" || env.DependsOnStepIDs == nil || (*env.DependsOnStepIDs)[0] != "step-a" {
+		t.Fatalf("projected envelope must carry forwarded correlation/topology, got %+v", env)
 	}
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -309,6 +309,9 @@ type Event struct {
 	RunID     string          `json:"run_id,omitempty"`
 	SessionID string          `json:"session_id,omitempty"`
 	StepID    string          `json:"step_id,omitempty"`
+	// DependsOnStepIDs is nil for unknown native topology; a present empty
+	// slice represents a known root.
+	DependsOnStepIDs *[]string `json:"depends_on_step_ids,omitempty"`
 }
 
 // Recorder records events. Safe for concurrent use. Best-effort.

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -134,6 +134,7 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 	if len(recipe.Steps) == 0 {
 		return nil, false, "", fmt.Errorf("recipe %q has no steps", recipe.Name)
 	}
+	recipe = recipeWithNativeStepDependencies(recipe)
 
 	vars := applyVarDefaults(opts.Vars, recipe.Vars)
 	priorityOverride := clonePriority(opts.PriorityOverride)
@@ -393,6 +394,7 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 	if len(recipe.Steps) == 0 {
 		return &beads.GraphApplyPlan{}, nil
 	}
+	recipe = fragmentRecipeWithNativeStepDependencies(recipe)
 
 	existingLogicalBeadIDs, err := existingLogicalBeadIDIndex(store, opts.RootID)
 	if err != nil {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -759,6 +759,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	if len(recipe.Steps) == 0 {
 		return nil, fmt.Errorf("recipe %q has no steps", recipe.Name)
 	}
+	recipe = recipeWithNativeStepDependencies(recipe)
 	if !opts.DeferAssignees && IsGraphApplyEnabled() {
 		if applier, ok := beads.GraphApplyFor(store); ok {
 			result, err := instantiateViaGraphApply(ctx, applier, recipe, opts)
@@ -1060,6 +1061,7 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 	if len(recipe.Steps) == 0 {
 		return &FragmentResult{IDMapping: map[string]string{}}, nil
 	}
+	recipe = fragmentRecipeWithNativeStepDependencies(recipe)
 	priorityOverride := clonePriority(opts.PriorityOverride)
 	if priorityOverride == nil {
 		root, err := store.Get(opts.RootID)

--- a/internal/molecule/native_step_topology.go
+++ b/internal/molecule/native_step_topology.go
@@ -1,0 +1,126 @@
+package molecule
+
+import (
+	"encoding/json"
+	"maps"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+// recipeWithNativeStepDependencies derives the private, canonical native-step
+// topology fact from the compiled recipe graph. It intentionally has no access
+// to physical bead IDs or Needs: those are materialization details, not native
+// execution topology.
+//
+// A missing or invalid fact stays absent (UNKNOWN). A valid step with no native
+// prerequisites gets an explicit empty array (known root). The returned recipe
+// is a copy, so repeated materialization never mutates its caller's recipe.
+func recipeWithNativeStepDependencies(recipe *formula.Recipe) *formula.Recipe {
+	if recipe == nil {
+		return nil
+	}
+
+	clone := *recipe
+	clone.Steps = recipeStepsWithNativeStepDependencies(recipe.Steps, recipe.Deps)
+	return &clone
+}
+
+func fragmentRecipeWithNativeStepDependencies(recipe *formula.FragmentRecipe) *formula.FragmentRecipe {
+	if recipe == nil {
+		return nil
+	}
+	clone := *recipe
+	clone.Steps = recipeStepsWithNativeStepDependencies(recipe.Steps, recipe.Deps)
+	return &clone
+}
+
+func recipeStepsWithNativeStepDependencies(steps []formula.RecipeStep, recipeDeps []formula.RecipeDep) []formula.RecipeStep {
+	clone := make([]formula.RecipeStep, len(steps))
+	copy(clone, steps)
+	for i := range clone {
+		clone[i].Metadata = maps.Clone(steps[i].Metadata)
+		delete(clone[i].Metadata, beadmeta.NativeStepDependenciesMetadataKey)
+		if _, intentional := clone[i].Metadata[beadmeta.StepIDMetadataKey]; !intentional && validNativeStepID(clone[i].ID) {
+			if clone[i].Metadata == nil {
+				clone[i].Metadata = make(map[string]string, 1)
+			}
+			clone[i].Metadata[beadmeta.StepIDMetadataKey] = clone[i].ID
+		}
+	}
+
+	stepCount := make(map[string]int, len(clone))
+	for _, step := range clone {
+		stepCount[step.ID]++
+	}
+
+	nativeByStepID := make(map[string]string, len(clone))
+	invalidNativeIDs := make(map[string]bool)
+	for _, step := range clone {
+		nativeID := step.Metadata[beadmeta.StepIDMetadataKey]
+		if !validNativeStepID(nativeID) {
+			continue
+		}
+		if stepCount[step.ID] != 1 {
+			invalidNativeIDs[nativeID] = true
+			continue
+		}
+		nativeByStepID[step.ID] = nativeID
+	}
+
+	dependenciesByNativeID := make(map[string]map[string]struct{}, len(nativeByStepID))
+	for _, nativeID := range nativeByStepID {
+		if dependenciesByNativeID[nativeID] == nil {
+			dependenciesByNativeID[nativeID] = make(map[string]struct{})
+		}
+	}
+	for _, dep := range recipeDeps {
+		if dep.Type == "parent-child" {
+			continue
+		}
+		nativeID, ok := nativeByStepID[dep.StepID]
+		if !ok {
+			continue
+		}
+		dependencyNativeID, ok := nativeByStepID[dep.DependsOnID]
+		if !ok || dep.StepID == dep.DependsOnID {
+			invalidNativeIDs[nativeID] = true
+			continue
+		}
+		if dependencyNativeID != nativeID {
+			dependenciesByNativeID[nativeID][dependencyNativeID] = struct{}{}
+		}
+	}
+
+	for i, step := range clone {
+		nativeID, ok := nativeByStepID[step.ID]
+		if !ok || invalidNativeIDs[nativeID] {
+			continue
+		}
+		dependencies := make([]string, 0, len(dependenciesByNativeID[nativeID]))
+		for dependency := range dependenciesByNativeID[nativeID] {
+			dependencies = append(dependencies, dependency)
+		}
+		sort.Strings(dependencies)
+		encoded, err := json.Marshal(dependencies)
+		if err != nil {
+			continue
+		}
+		if clone[i].Metadata == nil {
+			clone[i].Metadata = make(map[string]string, 1)
+		}
+		clone[i].Metadata[beadmeta.NativeStepDependenciesMetadataKey] = string(encoded)
+	}
+
+	return clone
+}
+
+// validNativeStepID preserves the existing execution_step_id storage domain:
+// an exact, nonblank UTF-8 value up to 256 bytes. It deliberately does not
+// invent a new public identifier regex.
+func validNativeStepID(id string) bool {
+	return len(id) <= 256 && utf8.ValidString(id) && strings.TrimSpace(id) != ""
+}

--- a/internal/molecule/native_step_topology_test.go
+++ b/internal/molecule/native_step_topology_test.go
@@ -1,0 +1,205 @@
+package molecule
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+func TestRecipeNativeStepDependenciesStampCanonicalRecipeTopology(t *testing.T) {
+	recipe := &formula.Recipe{
+		Steps: []formula.RecipeStep{
+			{ID: "workflow", Metadata: map[string]string{beadmeta.StepIDMetadataKey: "native-root"}},
+			{ID: "prepare", Metadata: map[string]string{beadmeta.StepIDMetadataKey: "native-prepare"}},
+			{ID: "build", Metadata: map[string]string{beadmeta.StepIDMetadataKey: "native-build"}},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "prepare", DependsOnID: "workflow", Type: "parent-child"},
+			{StepID: "build", DependsOnID: "prepare", Type: "blocks"},
+		},
+	}
+
+	stamped := recipeWithNativeStepDependencies(recipe)
+	if got, want := stamped.Steps[0].Metadata["gc.native_step_dependencies.v1"], "[]"; got != want {
+		t.Fatalf("root topology = %q, want %q", got, want)
+	}
+	if got, want := stamped.Steps[1].Metadata["gc.native_step_dependencies.v1"], "[]"; got != want {
+		t.Fatalf("parent-only topology = %q, want %q", got, want)
+	}
+	if got, want := stamped.Steps[2].Metadata["gc.native_step_dependencies.v1"], `["native-prepare"]`; got != want {
+		t.Fatalf("build topology = %q, want %q", got, want)
+	}
+	if !reflect.DeepEqual(recipe.Steps[2].Metadata, map[string]string{beadmeta.StepIDMetadataKey: "native-build"}) {
+		t.Fatalf("input recipe mutated: %#v", recipe.Steps[2].Metadata)
+	}
+}
+
+func TestRecipeNativeStepDependenciesOmitUnsafeTopology(t *testing.T) {
+	recipe := &formula.Recipe{
+		Steps: []formula.RecipeStep{
+			{ID: "source", Metadata: map[string]string{beadmeta.StepIDMetadataKey: "native-source"}},
+			{ID: "target", Metadata: map[string]string{beadmeta.StepIDMetadataKey: " "}},
+			{ID: "self", Metadata: map[string]string{beadmeta.StepIDMetadataKey: "native-self"}},
+			{ID: "empty", Metadata: map[string]string{beadmeta.StepIDMetadataKey: ""}},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "source", DependsOnID: "target", Type: "blocks"},
+			{StepID: "self", DependsOnID: "self", Type: "blocks"},
+		},
+	}
+
+	stamped := recipeWithNativeStepDependencies(recipe)
+	for _, index := range []int{0, 1, 2, 3} {
+		if got := stamped.Steps[index].Metadata["gc.native_step_dependencies.v1"]; got != "" {
+			t.Fatalf("step %q topology = %q, want omitted", stamped.Steps[index].ID, got)
+		}
+	}
+}
+
+func TestCompiledGraphRecipeStampsNativeStepTopology(t *testing.T) {
+	formulaDir := t.TempDir()
+	const formulaName = "native-step-topology"
+	formulaBytes := []byte(`formula = "native-step-topology"
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "first"
+title = "First"
+
+[[steps]]
+id = "second"
+title = "Second"
+needs = ["first"]
+`)
+	if err := os.WriteFile(filepath.Join(formulaDir, formulaName+".toml"), formulaBytes, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	recipe, err := formula.Compile(context.Background(), formulaName, []string{formulaDir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	nodes := make(map[string]beads.GraphApplyNode, len(plan.Nodes))
+	for _, node := range plan.Nodes {
+		nodes[node.Key] = node
+	}
+	nativeByRecipeID := make(map[string]string, len(recipe.Steps))
+	for _, step := range recipe.Steps {
+		want := step.Metadata[beadmeta.StepIDMetadataKey]
+		if want == "" {
+			want = step.ID
+		}
+		nativeByRecipeID[step.ID] = want
+		if got := nodes[step.ID].Metadata[beadmeta.StepIDMetadataKey]; got != want {
+			t.Fatalf("node %q gc.step_id = %q, want %q", step.ID, got, want)
+		}
+	}
+	for _, step := range recipe.Steps {
+		dependencies := make([]string, 0)
+		for _, dep := range recipe.Deps {
+			if dep.StepID == step.ID && dep.Type != "parent-child" {
+				dependencies = append(dependencies, nativeByRecipeID[dep.DependsOnID])
+			}
+		}
+		sort.Strings(dependencies)
+		want, err := json.Marshal(dependencies)
+		if err != nil {
+			t.Fatalf("marshal expected topology: %v", err)
+		}
+		if got := nodes[step.ID].Metadata[beadmeta.NativeStepDependenciesMetadataKey]; got != string(want) {
+			t.Fatalf("node %q topology = %q, want %q", step.ID, got, want)
+		}
+	}
+}
+
+func TestCompiledReviewQuorumCollapsesRetryMachineryIntoNativeSteps(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	searchDir := filepath.Join(cwd, "..", "bootstrap", "packs", "core", "formulas")
+	recipe, err := formula.Compile(context.Background(), "mol-review-quorum", []string{searchDir}, map[string]string{
+		"subject":           "PR-123",
+		"lane_one_id":       "primary",
+		"lane_one_provider": "provider-a",
+		"lane_one_model":    "model-a",
+		"lane_one_target":   "target-a",
+		"lane_two_id":       "secondary",
+		"lane_two_provider": "provider-b",
+		"lane_two_model":    "model-b",
+		"lane_two_target":   "target-b",
+		"synthesis_target":  "review-synthesis",
+	})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	nodes := make(map[string]beads.GraphApplyNode, len(plan.Nodes))
+	for _, node := range plan.Nodes {
+		nodes[node.Key] = node
+	}
+
+	for _, key := range []string{
+		"mol-review-quorum.review-lane-one",
+		"mol-review-quorum.review-lane-one.attempt.1",
+		"mol-review-quorum.review-lane-two",
+		"mol-review-quorum.review-lane-two.attempt.1",
+	} {
+		if got, want := nodes[key].Metadata[beadmeta.NativeStepDependenciesMetadataKey], "[]"; got != want {
+			t.Fatalf("node %q topology = %q, want %q", key, got, want)
+		}
+	}
+	if got, want := nodes["mol-review-quorum.synthesize-review-quorum"].Metadata[beadmeta.NativeStepDependenciesMetadataKey], `["review-lane-one","review-lane-two"]`; got != want {
+		t.Fatalf("synthesis topology = %q, want %q", got, want)
+	}
+}
+
+func TestNativeStepDependenciesMaterializeThroughGraphAndSequentialPaths(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "native-topology",
+		Steps: []formula.RecipeStep{
+			{ID: "native-topology", IsRoot: true, Metadata: map[string]string{beadmeta.StepIDMetadataKey: "root"}},
+			{ID: "native-topology.first", Metadata: map[string]string{beadmeta.StepIDMetadataKey: "first"}},
+			{ID: "native-topology.second", Metadata: map[string]string{beadmeta.StepIDMetadataKey: "second"}},
+		},
+		Deps: []formula.RecipeDep{{StepID: "native-topology.second", DependsOnID: "native-topology.first", Type: "blocks"}},
+	}
+
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	if got, want := plan.Nodes[2].Metadata[beadmeta.NativeStepDependenciesMetadataKey], `["first"]`; got != want {
+		t.Fatalf("graph node topology = %q, want %q", got, want)
+	}
+
+	store := beads.NewMemStore()
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	second, err := store.Get(result.IDMapping["native-topology.second"])
+	if err != nil {
+		t.Fatalf("Get second: %v", err)
+	}
+	if got, want := second.Metadata[beadmeta.NativeStepDependenciesMetadataKey], `["first"]`; got != want {
+		t.Fatalf("sequential bead topology = %q, want %q", got, want)
+	}
+}

--- a/pkg/eventexport/exporter.go
+++ b/pkg/eventexport/exporter.go
@@ -27,10 +27,13 @@ type TaggedEvent struct {
 	Subject   string
 	RunID     string
 	SessionID string
-	StepID    string   // opaque acting-work-bead (run step) id; safeRef-gated at projection (EmitCorrelation)
-	Title     string   // FREE-FORM bead title; emitted only under the content opt-in (Options.emitContent)
-	Formula   string   // FREE-FORM run formula name; emitted only under the content opt-in (Options.emitContent)
-	_         struct{} // force keyed literals; blocks positional field transposition
+	StepID    string // native execution-step identity (nonblank UTF-8, <=256 bytes; EmitCorrelation)
+	// DependsOnStepIDs is nil when native topology is unknown; an explicit empty
+	// slice represents a known root.
+	DependsOnStepIDs *[]string
+	Title            string   // FREE-FORM bead title; emitted only under the content opt-in (Options.emitContent)
+	Formula          string   // FREE-FORM run formula name; emitted only under the content opt-in (Options.emitContent)
+	_                struct{} // force keyed literals; blocks positional field transposition
 }
 
 // Source yields tagged events in per-city seq order. The real Source wraps the
@@ -49,7 +52,7 @@ type Config struct {
 	TokenProvider     func() (string, error)
 	Salt              []byte
 	ExportRef         bool
-	EmitCorrelation   bool // emit opaque run_id/session_id/step_id (default false)
+	EmitCorrelation   bool // emit run/session correlation plus native step topology (default false)
 	Profile           Profile
 	BatchMax          int           // max events per POST (default 1000)
 	BatchInterval     time.Duration // max time between POSTs (default 5s)
@@ -179,8 +182,8 @@ func (e *Exporter) ingest(te TaggedEvent) {
 		return // already processed (resume overlap)
 	}
 	e.high[te.City] = te.Seq
-	// Correlation ids (run_id/session_id/step_id) are emitted only when
-	// EmitCorrelation is set (default false), so the projection stays envelope-only
+	// Run/session correlation plus native execution-step topology are emitted only
+	// when EmitCorrelation is set (default false), so the projection stays envelope-only
 	// unless opted in. The Exporter intentionally exposes no content (title/formula)
 	// opt-in: the producer path — a reachable Config knob plus the typed source
 	// fields — is staged behind ga-mt1e99, and the projection's content gate

--- a/pkg/eventexport/exporter_test.go
+++ b/pkg/eventexport/exporter_test.go
@@ -242,9 +242,7 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 // TestExporter_EmitCorrelation proves the end-to-end exported batch carries
-// run_id/session_id only when Config.EmitCorrelation is true (the version-neutral
-// opt-in; SchemaVersion is unchanged since the envelope already defines the fields
-// and they stay omitted by default).
+// run/session/step correlation only when Config.EmitCorrelation is true.
 func TestExporter_EmitCorrelation(t *testing.T) {
 	run := func(emit bool) Batch {
 		cp := &capture{}
@@ -281,10 +279,10 @@ func TestExporter_EmitCorrelation(t *testing.T) {
 	if on.Events[0].RunID != "wf-root-abc" || on.Events[0].SessionID != "sess-9f2a" || on.Events[0].StepID != "mc-step-7" {
 		t.Fatalf("EmitCorrelation=true must carry run/session/step, got %+v", on.Events[0])
 	}
-	// Headline invariant: a v1-pinned receiver accepts the populated batch with no
-	// schema mismatch — emitting run/session is v1-compatible (no flag day).
+	// A receiver pinned to this build's schema accepts populated optional
+	// correlation fields without a schema mismatch.
 	if err := ValidateBatch(on); err != nil {
-		t.Fatalf("v1 receiver must accept a populated batch: %v", err)
+		t.Fatalf("receiver must accept a populated batch: %v", err)
 	}
 
 	off := run(false)

--- a/pkg/eventexport/golden_test.go
+++ b/pkg/eventexport/golden_test.go
@@ -39,6 +39,21 @@ func TestGoldenWireBytes(t *testing.T) {
 			want: `{"seq":2,"type":"bead.created","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","ref":"mc-2","run_id":"wf-root-abc","session_id":"sess-9f2a","step_id":"mc-step-7"}`,
 		},
 		{
+			name: "native topology omitted remains unknown",
+			env:  Envelope{Seq: 4, Type: "bead.closed", TS: "2026-06-21T10:03:27Z", ActorHash: "0123456789abcdef", StepID: "step-b"},
+			want: `{"seq":4,"type":"bead.closed","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","step_id":"step-b"}`,
+		},
+		{
+			name: "native topology explicit root remains empty array",
+			env:  Envelope{Seq: 5, Type: "bead.closed", TS: "2026-06-21T10:03:27Z", ActorHash: "0123456789abcdef", StepID: "step-root", DependsOnStepIDs: slicePtr([]string{})},
+			want: `{"seq":5,"type":"bead.closed","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","step_id":"step-root","depends_on_step_ids":[]}`,
+		},
+		{
+			name: "native topology populated remains ordered array",
+			env:  Envelope{Seq: 6, Type: "bead.closed", TS: "2026-06-21T10:03:27Z", ActorHash: "0123456789abcdef", StepID: "step-b", DependsOnStepIDs: slicePtr([]string{"step-a"})},
+			want: `{"seq":6,"type":"bead.closed","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","step_id":"step-b","depends_on_step_ids":["step-a"]}`,
+		},
+		{
 			// The content opt-in path: free-form title/formula serialize verbatim
 			// after step_id. Pinning this anchors the off-by-default exemption — the
 			// empty-field cases above prove the DEFAULT wire is byte-identical to the
@@ -60,8 +75,10 @@ func TestGoldenWireBytes(t *testing.T) {
 	}
 }
 
+func slicePtr(values []string) *[]string { return &values }
+
 // TestBatchGoldenBytes pins the batch envelope shape: an opaque city_hash (never
-// a cleartext city name) and schema_version 2.
+// a cleartext city name) and schema_version 3.
 func TestBatchGoldenBytes(t *testing.T) {
 	b := Batch{CityHash: "7f3a9c1e5b2d4068", SchemaVersion: SchemaVersion, Events: []Envelope{
 		{Seq: 1, Type: "convoy.closed", TS: "2026-06-21T10:03:27Z", ActorHash: "0123456789abcdef", Ref: "gcg-4216"},
@@ -70,7 +87,7 @@ func TestBatchGoldenBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `{"city_hash":"7f3a9c1e5b2d4068","schema_version":2,"events":[{"seq":1,"type":"convoy.closed","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","ref":"gcg-4216"}]}`
+	want := `{"city_hash":"7f3a9c1e5b2d4068","schema_version":3,"events":[{"seq":1,"type":"convoy.closed","ts":"2026-06-21T10:03:27Z","actor_hash":"0123456789abcdef","ref":"gcg-4216"}]}`
 	if string(out) != want {
 		t.Fatalf("batch golden:\n got %s\nwant %s", out, want)
 	}

--- a/pkg/eventexport/project.go
+++ b/pkg/eventexport/project.go
@@ -5,7 +5,8 @@
 // titles/descriptions, mail bodies, external-message identities, filesystem
 // paths). This package never sees that content: a caller hands it only a
 // TaggedEvent — the closed set of primitive fields that may ever leave the box
-// (sequence, type, time, actor, subject, and two opaque correlation ids) — and
+// (sequence, type, time, actor, subject, opaque run/session correlation ids,
+// and native execution-step topology) — and
 // the projection reduces it to a fixed envelope: type, time, a salted actor
 // hash, an id-regex-gated reference, and the opaque run/session ids. An unknown
 // or non-allowlisted event type is dropped, and the envelope is a closed struct
@@ -44,7 +45,9 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // SchemaVersion is stamped on every batch so the receiver can evolve the
@@ -73,8 +76,9 @@ import (
 //
 // v2 replaced the cleartext city_id with a salted, non-reversible city_hash so
 // an operator-chosen city name (which can itself embed a customer/org
-// identifier) no longer leaves the box.
-const SchemaVersion = 2
+// identifier) no longer leaves the box. v3 adds native execution-step
+// dependencies to the envelope.
+const SchemaVersion = 3
 
 // Profile selects the redaction profile. There is exactly one today; it is part
 // of the public API so Validate can stay profile-aware as profiles are added
@@ -89,9 +93,10 @@ const (
 )
 
 const (
-	maxRefLen     = 64  // run_id/session_id/ref over this are DROPPED, not truncated.
-	minSaltLen    = 16  // below this the salted actor hash is brute-forceable; fail closed.
-	maxContentLen = 256 // free-form title/formula over this are DROPPED, not truncated.
+	maxRefLen             = 64  // run_id/session_id/ref over this are DROPPED, not truncated.
+	maxExecutionStepIDLen = 256 // native execution step ids retain their established storage domain.
+	minSaltLen            = 16  // below this the salted actor hash is brute-forceable; fail closed.
+	maxContentLen         = 256 // free-form title/formula over this are DROPPED, not truncated.
 )
 
 // allowedTypes is the default-deny allowlist of exportable event types, keyed by
@@ -166,7 +171,10 @@ type Envelope struct {
 	Ref       string `json:"ref,omitempty"`        // id-regex-gated reference (opaque id/slug only)
 	RunID     string `json:"run_id,omitempty"`     // opaque run-root correlation id (safeRef-gated)
 	SessionID string `json:"session_id,omitempty"` // opaque session correlation id (safeRef-gated)
-	StepID    string `json:"step_id,omitempty"`    // opaque acting-work-bead (run step) id; safeRef-gated, EmitCorrelation
+	StepID    string `json:"step_id,omitempty"`    // native execution-step identity (nonblank UTF-8, <=256 bytes), EmitCorrelation
+	// DependsOnStepIDs is nil when native topology is unknown. A present empty
+	// slice is a known native root; a non-empty slice is strictly sorted and unique.
+	DependsOnStepIDs *[]string `json:"depends_on_step_ids,omitempty"`
 	// Title/Formula are the DELIBERATE exception to envelope-only: free-form content
 	// (a bead's human title; a run's formula name), gated by the package-internal
 	// content opt-in (Options.emitContent), length-capped (dropped, not truncated),
@@ -194,7 +202,7 @@ type Batch struct {
 // the envelope-only default, and keeping it package-private is what makes the
 // SchemaVersion no-bump exemption sound. An out-of-package importer constructs
 // Options with keyed literals and so CANNOT enable content, which means no caller
-// of the exported ProjectEvent can emit Title/Formula on a SchemaVersion==2
+// of the exported ProjectEvent can emit Title/Formula on a SchemaVersion==3
 // batch. The field exists only for in-package projection tests and the future
 // producer path (ga-mt1e99), which owns exposing a reachable opt-in and the
 // SchemaVersion decision that reachable content egress then requires.
@@ -202,7 +210,7 @@ type Options struct {
 	Salt            []byte  // actor-hash salt; must be >= 16 bytes (ProjectEvent fails closed otherwise)
 	ExportRef       bool    // include the id-gated ref (opaque ids/slugs only)
 	Profile         Profile // redaction profile (default ProfileRedactedEnvelope)
-	EmitCorrelation bool    // emit opaque run_id/session_id/step_id; default false (the production export sets it true)
+	EmitCorrelation bool    // emit run/session correlation and native step topology; default false (the production export sets it true)
 	emitContent     bool    // emit free-form Title/Formula; default false. REVERSES the envelope-only default. UNEXPORTED so no out-of-package caller can enable content egress; the reachable producer opt-in is staged (ga-mt1e99).
 }
 
@@ -259,6 +267,9 @@ func ProjectEvent(te TaggedEvent, opt Options) (Envelope, bool) {
 	if len(opt.Salt) < minSaltLen {
 		return Envelope{}, false
 	}
+	if te.DependsOnStepIDs != nil && !opt.EmitCorrelation {
+		return Envelope{}, false
+	}
 	env := Envelope{Seq: te.Seq, Type: te.Type, TS: te.Ts.UTC().Format(time.RFC3339Nano)}
 	if mailReduced[te.Type] {
 		return env, true // {type, ts} only
@@ -276,8 +287,15 @@ func ProjectEvent(te TaggedEvent, opt Options) (Envelope, bool) {
 		if s := safeRef(te.SessionID); s != "" {
 			env.SessionID = s
 		}
-		if st := safeRef(te.StepID); st != "" {
+		if st := validExecutionStepID(te.StepID); st != "" {
 			env.StepID = st
+			deps, ok := normalizeStepDependencies(st, te.DependsOnStepIDs)
+			if !ok {
+				return Envelope{}, false
+			}
+			env.DependsOnStepIDs = deps
+		} else if te.DependsOnStepIDs != nil {
+			return Envelope{}, false
 		}
 	}
 	// Content fields are the deliberate exception to the envelope-only default:
@@ -294,6 +312,9 @@ func ProjectEvent(te TaggedEvent, opt Options) (Envelope, bool) {
 	}
 	return env, true
 }
+
+// ErrInvalidStepTopology reports malformed native execution-step dependencies.
+var ErrInvalidStepTopology = errors.New("eventexport: invalid step topology")
 
 // ValidateEnvelope re-asserts the wire-authoritative redaction invariants on a
 // projected envelope, with NO producer configuration. It is the trust-boundary
@@ -312,7 +333,7 @@ func ValidateEnvelope(env Envelope) error {
 		return fmt.Errorf("eventexport: invalid ts %q", env.TS)
 	}
 	if mailReduced[env.Type] {
-		if env.ActorHash != "" || env.Ref != "" || env.RunID != "" || env.SessionID != "" || env.StepID != "" || env.Title != "" || env.Formula != "" {
+		if env.ActorHash != "" || env.Ref != "" || env.RunID != "" || env.SessionID != "" || env.StepID != "" || env.DependsOnStepIDs != nil || env.Title != "" || env.Formula != "" {
 			return fmt.Errorf("eventexport: %q must carry only {seq,type,ts}", env.Type)
 		}
 		return nil
@@ -334,8 +355,11 @@ func ValidateEnvelope(env Envelope) error {
 	if env.SessionID != "" && !IsOpaqueRef(env.SessionID) {
 		return fmt.Errorf("eventexport: session_id %q is not an opaque id", env.SessionID)
 	}
-	if env.StepID != "" && !IsOpaqueRef(env.StepID) {
-		return fmt.Errorf("eventexport: step_id %q is not an opaque id", env.StepID)
+	if env.StepID != "" && validExecutionStepID(env.StepID) == "" {
+		return fmt.Errorf("eventexport: step_id exceeds the execution-step domain")
+	}
+	if err := validateStepDependencies(env.StepID, env.DependsOnStepIDs); err != nil {
+		return err
 	}
 	// Title/Formula are free-form content (the content opt-in exception): the wire
 	// invariant is a length bound, NOT opaqueness — charset is unrestricted.
@@ -382,7 +406,7 @@ var ErrSchemaMismatch = errors.New("eventexport: batch schema_version mismatch")
 
 // ValidateBatch checks a received batch end to end: its schema_version must equal
 // SchemaVersion (else it returns an error wrapping ErrSchemaMismatch), its
-// city_hash must be the opaque 16-hex partition-key shape that schema v2 promises
+// city_hash must retain the opaque 16-hex partition-key shape introduced in v2
 // (rejecting empty, cleartext, or otherwise malformed values at the receiver trust
 // boundary, the same shape gate ValidateEnvelope applies to actor_hash), then every
 // envelope must pass ValidateEnvelope. Validation is fail-fast: it returns the
@@ -400,6 +424,51 @@ func ValidateBatch(b Batch) error {
 		}
 	}
 	return nil
+}
+
+func normalizeStepDependencies(stepID string, dependencies *[]string) (*[]string, bool) {
+	if dependencies == nil {
+		return nil, true
+	}
+	normalized := append([]string(nil), (*dependencies)...)
+	sort.Strings(normalized)
+	if err := validateStepDependencies(stepID, &normalized); err != nil {
+		return nil, false
+	}
+	return &normalized, true
+}
+
+func validateStepDependencies(stepID string, dependencies *[]string) error {
+	if dependencies == nil {
+		return nil
+	}
+	if stepID == "" {
+		return fmt.Errorf("%w: depends_on_step_ids requires step_id", ErrInvalidStepTopology)
+	}
+	previous := ""
+	for _, dependency := range *dependencies {
+		if validExecutionStepID(dependency) == "" {
+			return fmt.Errorf("%w: dependency exceeds the execution-step domain", ErrInvalidStepTopology)
+		}
+		if dependency == stepID {
+			return fmt.Errorf("%w: step cannot depend on itself", ErrInvalidStepTopology)
+		}
+		if previous != "" && dependency <= previous {
+			return fmt.Errorf("%w: dependencies must be strictly sorted and unique", ErrInvalidStepTopology)
+		}
+		previous = dependency
+	}
+	return nil
+}
+
+// validExecutionStepID preserves the existing execution_step_id domain. It is
+// intentionally separate from safeRef: native step ids are opaque application
+// values, not the lowercase 64-byte correlation slugs used by run/session/ref.
+func validExecutionStepID(id string) string {
+	if len(id) > maxExecutionStepIDLen || !utf8.ValidString(id) || strings.TrimSpace(id) == "" {
+		return ""
+	}
+	return id
 }
 
 // IsOpaqueRef reports whether s is a non-empty opaque lowercase id/slug (the

--- a/pkg/eventexport/project_test.go
+++ b/pkg/eventexport/project_test.go
@@ -2,6 +2,8 @@ package eventexport
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -124,9 +126,8 @@ func TestProjectEvent_RunSessionGating(t *testing.T) {
 	}
 }
 
-// step_id (the acting work bead) is gated exactly like run/session: EmitCorrelation
-// fail-closed, safeRef-opaque-only, never on mail-reduced types, empty when the
-// subject bead carries no gc.step_id.
+// step_id is native execution identity: it uses its established nonblank,
+// 256-byte domain rather than the 64-byte lowercase correlation-slug gate.
 func TestProjectEvent_StepIDGating(t *testing.T) {
 	te := func(step string) TaggedEvent {
 		return TaggedEvent{Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "gc", Subject: "mc-1", RunID: "wf-root-abc", SessionID: "sess-9f2a", StepID: step}
@@ -136,12 +137,12 @@ func TestProjectEvent_StepIDGating(t *testing.T) {
 		t.Fatalf("EmitCorrelation=false must drop step_id, got %q", g.StepID)
 	}
 	on := Options{Salt: testSalt, ExportRef: true, EmitCorrelation: true}
-	if g, ok := ProjectEvent(te("mc-step-7"), on); !ok || g.StepID != "mc-step-7" {
-		t.Fatalf("opaque step_id must round-trip when emitted, got %q ok=%v", g.StepID, ok)
+	if g, ok := ProjectEvent(te("Step A / provider:value"), on); !ok || g.StepID != "Step A / provider:value" {
+		t.Fatalf("native step_id must retain its established domain, got %q ok=%v", g.StepID, ok)
 	}
-	for _, bad := range []string{"gascity/codex", "user@host", "Up Per", "a b"} {
+	for _, bad := range []string{"", "   ", strings.Repeat("x", 257)} {
 		if g, _ := ProjectEvent(te(bad), on); g.StepID != "" {
-			t.Fatalf("non-opaque step_id %q must drop to empty, got %q", bad, g.StepID)
+			t.Fatalf("invalid execution step_id %q must drop to empty, got %q", bad, g.StepID)
 		}
 	}
 	mail := te("mc-step-7")
@@ -152,6 +153,59 @@ func TestProjectEvent_StepIDGating(t *testing.T) {
 	// A non-work bead carries no gc.step_id → empty, omitted cleanly (no error).
 	if g, ok := ProjectEvent(te(""), on); !ok || g.StepID != "" {
 		t.Fatalf("empty step_id must be omitted cleanly, got %q ok=%v", g.StepID, ok)
+	}
+}
+
+func TestProjectEventNormalizesNativeStepDependencies(t *testing.T) {
+	deps := []string{"step-c", "step-a"}
+	env, ok := ProjectEvent(TaggedEvent{
+		Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "gc", Subject: "mc-1",
+		StepID: "step-b", DependsOnStepIDs: &deps,
+	}, Options{Salt: testSalt, EmitCorrelation: true})
+	if !ok || env.DependsOnStepIDs == nil {
+		t.Fatalf("ProjectEvent() = %+v, %v; want emitted topology", env, ok)
+	}
+	if got, want := *env.DependsOnStepIDs, []string{"step-a", "step-c"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("depends_on_step_ids = %v, want %v", got, want)
+	}
+	if env.DependsOnStepIDs == &deps {
+		t.Fatal("ProjectEvent retained caller-owned dependency slice")
+	}
+
+	root := []string{}
+	env, ok = ProjectEvent(TaggedEvent{
+		Seq: 2, Type: "bead.closed", Ts: fixedTS, Actor: "gc", Subject: "mc-2",
+		StepID: "step-root", DependsOnStepIDs: &root,
+	}, Options{Salt: testSalt, EmitCorrelation: true})
+	if !ok || env.DependsOnStepIDs == nil || len(*env.DependsOnStepIDs) != 0 {
+		t.Fatalf("explicit root = %+v, %v; want present empty dependency list", env, ok)
+	}
+}
+
+func TestProjectEventRejectsInvalidPresentNativeTopology(t *testing.T) {
+	deps := []string{"step-a", "step-a"}
+	if _, ok := ProjectEvent(TaggedEvent{
+		Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "gc", Subject: "mc-1",
+		StepID: "step-b", DependsOnStepIDs: &deps,
+	}, Options{Salt: testSalt, EmitCorrelation: true}); ok {
+		t.Fatal("ProjectEvent emitted invalid present topology")
+	}
+}
+
+func TestProjectEventAcceptsMoreThanSixtyFourNativeDependencies(t *testing.T) {
+	deps := make([]string, 65)
+	for i := range deps {
+		deps[i] = fmt.Sprintf("dependency-%03d", i)
+	}
+	env, ok := ProjectEvent(TaggedEvent{
+		Seq: 1, Type: "bead.closed", Ts: fixedTS, Actor: "gc", Subject: "mc-1",
+		StepID: "target", DependsOnStepIDs: &deps,
+	}, Options{Salt: testSalt, EmitCorrelation: true})
+	if !ok || env.DependsOnStepIDs == nil || len(*env.DependsOnStepIDs) != len(deps) {
+		t.Fatalf("ProjectEvent() = %+v, %v; want all %d dependencies", env, ok, len(deps))
+	}
+	if err := ValidateEnvelope(env); err != nil {
+		t.Fatalf("ValidateEnvelope() = %v, want accepted unbounded topology", err)
 	}
 }
 

--- a/pkg/eventexport/validate_test.go
+++ b/pkg/eventexport/validate_test.go
@@ -48,7 +48,7 @@ func TestValidateEnvelope_Rejects(t *testing.T) {
 		"non-opaque ref":      {Seq: 1, Type: "bead.closed", TS: rfc(t), Ref: "a/b"},
 		"non-opaque run_id":   {Seq: 1, Type: "bead.closed", TS: rfc(t), RunID: "a/b"},
 		"non-opaque session":  {Seq: 1, Type: "bead.closed", TS: rfc(t), SessionID: "A@b"},
-		"non-opaque step_id":  {Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "a/b"},
+		"over-cap step_id":    {Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: strings.Repeat("x", maxExecutionStepIDLen+1)},
 		"mail with extras":    {Seq: 1, Type: "mail.sent", TS: rfc(t), ActorHash: "0123456789abcdef"},
 		"mail with step_id":   {Seq: 1, Type: "mail.sent", TS: rfc(t), StepID: "mc-step-1"},
 		// Receiver-side content trust boundary: the length cap and the
@@ -117,8 +117,8 @@ func TestValidateBatch(t *testing.T) {
 		t.Fatalf("schema skew must wrap ErrSchemaMismatch, got %v", err)
 	}
 
-	// Receiver trust boundary: city_hash must be the opaque 16-hex partition-key
-	// shape schema v2 promises. An empty, too-short, cleartext-shaped, uppercase,
+	// Receiver trust boundary: city_hash retains the opaque 16-hex partition-key
+	// shape introduced in schema v2. An empty, too-short, cleartext-shaped, uppercase,
 	// or over-length value is rejected before any row is processed — the receiver
 	// cannot assume the producer redacted the operator-chosen city name.
 	for name, ch := range map[string]string{
@@ -151,6 +151,30 @@ func TestValidateBatch(t *testing.T) {
 	}
 }
 
+func TestValidateEnvelopeNativeStepDependencies(t *testing.T) {
+	root := []string{}
+	for _, tc := range []struct {
+		name string
+		env  Envelope
+		want error
+	}{
+		{name: "omitted is unknown", env: Envelope{Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "step-a"}},
+		{name: "explicit empty is known root", env: Envelope{Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "step-a", DependsOnStepIDs: &root}},
+		{name: "sorted unique dependencies", env: Envelope{Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "step-b", DependsOnStepIDs: &[]string{"step-a", "step-c"}}},
+		{name: "dependencies require step", env: Envelope{Seq: 1, Type: "bead.closed", TS: rfc(t), DependsOnStepIDs: &[]string{"step-a"}}, want: ErrInvalidStepTopology},
+		{name: "duplicate dependency", env: Envelope{Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "step-b", DependsOnStepIDs: &[]string{"step-a", "step-a"}}, want: ErrInvalidStepTopology},
+		{name: "out of order dependency", env: Envelope{Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "step-c", DependsOnStepIDs: &[]string{"step-b", "step-a"}}, want: ErrInvalidStepTopology},
+		{name: "self dependency", env: Envelope{Seq: 1, Type: "bead.closed", TS: rfc(t), StepID: "step-a", DependsOnStepIDs: &[]string{"step-a"}}, want: ErrInvalidStepTopology},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEnvelope(tc.env)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("ValidateEnvelope() error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
 }
@@ -180,20 +204,21 @@ func TestProfileZeroValue(t *testing.T) {
 // author to gate it in ProjectEvent + ValidateEnvelope (and bump SchemaVersion if
 // the wire changes) rather than letting it ship ungated.
 func TestEnvelopeFieldCount(t *testing.T) {
-	// 11 = the original 7 + StepID (a version-NEUTRAL opaque correlation field,
-	// gated in ProjectEvent + ValidateEnvelope exactly like run_id/session_id) +
+	// 12 = the original 7 + StepID (a version-NEUTRAL native execution identity,
+	// gated in ProjectEvent + ValidateEnvelope) +
 	// Title + Formula (free-form content under the content opt-in — the deliberate
 	// exception to envelope-only, gated separately and length-capped, never
 	// opaque-gated) + the trailing blank `_ struct{}` keyed-literal guard, which is
-	// NOT a wire field (json ignores it; it only forces keyed Envelope literals).
-	if n := reflect.TypeOf(Envelope{}).NumField(); n != 11 {
+	// NOT a wire field (json ignores it; it only forces keyed Envelope literals),
+	// plus the optional DependsOnStepIDs topology field.
+	if n := reflect.TypeOf(Envelope{}).NumField(); n != 12 {
 		t.Fatalf("Envelope has %d fields; a field changed — gate it in ProjectEvent and ValidateEnvelope, then update this guard (and bump SchemaVersion if the wire changes)", n)
 	}
 }
 
 // TestOptionsContentOptInUnexported locks the content opt-in as package-private.
 // If emitContent were exported, any importer of pkg/eventexport could call
-// ProjectEvent with content enabled and emit Title/Formula on a SchemaVersion==2
+// ProjectEvent with content enabled and emit Title/Formula on a SchemaVersion==3
 // batch — exactly the reachable wire change the off-by-default exemption forbids.
 // When a producer makes content reachable (ga-mt1e99) it owns the SchemaVersion
 // decision; exporting this gate without that coordination must fail here rather
@@ -204,7 +229,7 @@ func TestOptionsContentOptInUnexported(t *testing.T) {
 		t.Fatal("Options.emitContent missing: the content opt-in gate must exist as an unexported field")
 	}
 	if f.PkgPath == "" {
-		t.Fatal("Options.emitContent must stay UNEXPORTED: an exported content opt-in lets importers emit title/formula on schema v2 without a SchemaVersion bump (see ga-mt1e99)")
+		t.Fatal("Options.emitContent must stay UNEXPORTED: an exported content opt-in lets importers emit title/formula on schema v3 without a SchemaVersion bump (see ga-mt1e99)")
 	}
 }
 
@@ -241,7 +266,7 @@ func TestProjectEvent_ContentGating(t *testing.T) {
 		t.Fatalf("formula must round-trip verbatim, got %q want %q", on.Formula, src.Formula)
 	}
 	if on.StepID != src.StepID {
-		t.Fatalf("step_id must round-trip (opaque), got %q want %q", on.StepID, src.StepID)
+		t.Fatalf("step_id must round-trip, got %q want %q", on.StepID, src.StepID)
 	}
 	if err := ValidateEnvelope(on); err != nil {
 		t.Fatalf("populated content envelope must validate: %v", err)


### PR DESCRIPTION
## Summary

- stamp compiled formula steps with stable native execution-step identities
- export optional native prerequisite step IDs through the typed v3 event envelope
- preserve topology through cache reconciliation and event projection
- collapse retry/control machinery onto the semantic native step while keeping bead references as work linkage only

## Contract

- omitted depends_on_step_ids means topology is unknown
- an empty array is an authoritative root
- a non-empty array contains unique, non-empty prerequisite native step IDs in lexical order
- topology requires execution_step_id and rejects self-references

## Validation

The earlier broad fast gate exercised the tree and isolated one policy failure: TestLegacyFormulaV2MechanismFrozen. The test was corrected by removing both legacy global toggles; no no-op rollout hook was added. The exact policy test and topology regressions then passed.

Focused rerun at this head:

- go test -count=1 ./internal/molecule ./internal/beads ./internal/eventfeed ./pkg/eventexport
- go test -count=1 ./cmd/gc -run Test\(WrapWithCachingStore\|StartEventExport\)
- go vet ./internal/molecule ./internal/beads ./internal/eventfeed ./pkg/eventexport ./cmd/gc

Additional green evidence at this head:

- go test ./internal/testenv -run TestLegacyFormulaV2MechanismFrozen -count=1
- go test ./internal/molecule -run Test\(CompiledGraphRecipeStampsNativeStepTopology\|CompiledReviewQuorumCollapsesRetryMachineryIntoNativeSteps\|NativeStepDependenciesMaterializeThroughGraphAndSequentialPaths\) -count=1
- affected-package race tests
- pre-commit lint, generated-contract checks, and go vet ./...

Tracking: ga-15w7g.26.3