### PR TITLE
Normalize canonical path comparison inputs in convergence and dispatch

### DIFF
--- a/internal/convergence/artifact.go
+++ b/internal/convergence/artifact.go
@@ -32,6 +32,12 @@ func ValidateArtifactDir(dir string) error {
 	}
 	// Canonicalize with EvalSymlinks so comparisons are consistent
 	// when the artifact root itself contains symlinked components.
+	// canonical-path-exception: existence/resolvability only, not comparison
+	// preparation. absDir is already absolute (filepath.Abs above), so this
+	// call cannot diverge into a relative/absolute mismatch; its error path
+	// is the deliberate "artifact directory must exist" check for this
+	// function, which pathutil.NormalizePathForCompare's never-errors
+	// contract would silently swallow.
 	absDir, err = filepath.EvalSymlinks(absDir)
 	if err != nil {
 		return fmt.Errorf("resolving artifact directory: %w", err)
@@ -46,6 +52,13 @@ func ValidateArtifactDir(dir string) error {
 
 		// Check for symlinks using EvalSymlinks for full resolution
 		// (handles multi-hop chains), consistent with ResolveConditionPath.
+		// canonical-path-exception: existence/resolvability only, not
+		// comparison preparation. path comes from WalkDir(absDir, ...) and
+		// is already absolute, so this cannot diverge into a
+		// relative/absolute mismatch; a broken or unresolvable symlink
+		// target must fail directory validation here, which
+		// pathutil.NormalizePathForCompare's never-errors contract would
+		// silently paper over.
 		if typ&os.ModeSymlink != 0 {
 			resolved, err := filepath.EvalSymlinks(path)
 			if err != nil {

--- a/internal/convergence/artifact_test.go
+++ b/internal/convergence/artifact_test.go
@@ -145,3 +145,17 @@ func TestValidateArtifactDir_FIFO(t *testing.T) {
 		t.Errorf("error should mention unsafe file type, got: %v", err)
 	}
 }
+
+// Regression-pins ValidateArtifactDir's existence-check behavior (refs
+// ga-iawy13.4): a missing artifact directory must still produce an error.
+// This root EvalSymlinks site is deliberate existence checking, not
+// comparison preparation, and must keep failing the same way after the
+// canonical-path-at-ingest migration.
+func TestValidateArtifactDir_MissingDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+
+	err := ValidateArtifactDir(dir)
+	if err == nil {
+		t.Fatal("expected error for missing artifact directory, got nil")
+	}
+}

--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -208,6 +208,14 @@ func ResolveConditionPath(envelope, base, conditionPath string) (string, error) 
 	// symlink — which broke filepath.Rel in the containment checks below —
 	// and ensures the post-resolution containment check compares like with
 	// like.
+	//
+	// NormalizePathForCompare does more than absolutize-and-resolve: on
+	// darwin it also collapses the /private/tmp and /private/var host
+	// aliases back to /tmp and /var, which is the REVERSE direction from
+	// bare filepath.EvalSymlinks. Any value compared against canonEnvelope
+	// or canonBase must therefore go through pathutil too — a bare
+	// EvalSymlinks result is in a different convention and will mismatch on
+	// darwin even when the paths name the same location.
 	canonEnvelope := pathutil.NormalizePathForCompare(envelope)
 	canonBase := pathutil.NormalizePathForCompare(base)
 
@@ -245,8 +253,16 @@ func ResolveConditionPath(envelope, base, conditionPath string) (string, error) 
 	// Re-validate the symlink-resolved path against the same envelope-OR-base
 	// rule to close the symlink-escape gap (gastownhall/gascity#2354 review).
 	// Absolute paths still skip — same rationale as the pre-resolution check.
+	//
+	// Use pathutil.PathWithin rather than the lexical containedIn: resolved
+	// comes from bare filepath.EvalSymlinks, so on darwin it carries the
+	// /private prefix that canonEnvelope/canonBase have had collapsed away.
+	// PathWithin normalizes both operands, so the alias collapse applies
+	// symmetrically. (The pre-resolution check above keeps containedIn:
+	// absPath is derived from canonBase, so both sides already share a
+	// convention there.)
 	if !filepath.IsAbs(conditionPath) {
-		if !containedIn(resolved, canonEnvelope) && !containedIn(resolved, canonBase) {
+		if !pathutil.PathWithin(canonEnvelope, resolved) && !pathutil.PathWithin(canonBase, resolved) {
 			return "", fmt.Errorf("resolving gate condition path: symlink target outside containment: %s", conditionPath)
 		}
 	}

--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -199,18 +199,17 @@ func ResolveConditionPath(envelope, base, conditionPath string) (string, error) 
 		base = envelope
 	}
 
-	// Canonicalize envelope and base first so that symlinked workspace
-	// roots (e.g., /tmp → /private/tmp on macOS) don't cause false
-	// rejections and so the post-resolution containment check below
-	// compares like with like.
-	canonEnvelope, err := filepath.EvalSymlinks(envelope)
-	if err != nil {
-		canonEnvelope = filepath.Clean(envelope) // best-effort if envelope doesn't exist yet
-	}
-	canonBase, err := filepath.EvalSymlinks(base)
-	if err != nil {
-		canonBase = filepath.Clean(base) // best-effort if base doesn't exist yet
-	}
+	// Canonicalize envelope and base first via pathutil.NormalizePathForCompare,
+	// which absolutizes before resolving symlinks (falling back to a
+	// best-effort ancestor walk when the path doesn't exist yet). This keeps
+	// symlinked workspace roots (e.g., /tmp → /private/tmp on macOS) from
+	// causing false rejections, keeps a relative envelope/base (e.g. ".")
+	// from staying relative while a resolved target becomes absolute via a
+	// symlink — which broke filepath.Rel in the containment checks below —
+	// and ensures the post-resolution containment check compares like with
+	// like.
+	canonEnvelope := pathutil.NormalizePathForCompare(envelope)
+	canonBase := pathutil.NormalizePathForCompare(base)
 
 	var absPath string
 	if filepath.IsAbs(conditionPath) {
@@ -231,6 +230,11 @@ func ResolveConditionPath(envelope, base, conditionPath string) (string, error) 
 
 	// Resolve symlinks to the real path. Scripts may be symlinked from
 	// a shared tooling directory (e.g., ~/tooling/scripts/).
+	// canonical-path-exception: existence/resolvability only, not comparison
+	// preparation. This call's error path is the behavior — a dangling or
+	// unresolvable conditionPath must fail gate resolution here, so it
+	// cannot be replaced with pathutil.NormalizePathForCompare, which never
+	// errors.
 	resolved, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
 		return "", fmt.Errorf("resolving gate condition path: %w", err)

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -558,6 +558,46 @@ func TestResolveConditionPath(t *testing.T) {
 		}
 		testutil.AssertSamePath(t, got, script)
 	})
+
+	// Pins the darwin half of the same comparison contract: on macOS the
+	// system temp root lives under /var (or /tmp), which EvalSymlinks
+	// expands to /private/var (or /private/tmp) while
+	// pathutil.NormalizePathForCompare collapses it back the other way.
+	// canonEnvelope/canonBase therefore carry the collapsed spelling while
+	// the post-resolution `resolved` (bare EvalSymlinks) carries the
+	// /private spelling — a lexical containment check compares the two
+	// conventions and falsely rejects a plainly contained script. The
+	// containment check must normalize both sides.
+	//
+	// This needs the real os.TempDir() root, not an arbitrary directory:
+	// the /private alias only exists on the platform temp trees. No symlink
+	// is created by the test — the platform's own /var symlink is the
+	// trigger.
+	t.Run("darwin private temp alias must not falsely reject a contained relative condition path", func(t *testing.T) {
+		if runtime.GOOS != "darwin" {
+			t.Skip("darwin-only: the /private/{tmp,var} alias collapse is a no-op on other platforms")
+		}
+		root, err := os.MkdirTemp(os.TempDir(), "gc-cond-alias-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(root) })
+
+		scripts := filepath.Join(root, "scripts")
+		if err := os.MkdirAll(scripts, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := filepath.Join(scripts, "check.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := ResolveConditionPath(root, "", "scripts/check.sh")
+		if err != nil {
+			t.Fatalf("unexpected error: %v — post-resolution containment must normalize both operands, not compare a /private-prefixed resolved path against an alias-collapsed envelope", err)
+		}
+		testutil.AssertSamePath(t, got, script)
+	})
 }
 
 func TestRunConditionPass(t *testing.T) {

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -520,6 +520,44 @@ func TestResolveConditionPath(t *testing.T) {
 			t.Errorf("expected path traversal error, got: %v", err)
 		}
 	})
+
+	// Pins the canonical-path-at-ingest bug this migration fixes
+	// (ga-iawy13.4): a relative envelope (e.g. "." from an
+	// as-yet-unresolved city path) combined with a conditionPath that
+	// crosses a symlink component makes the current bare
+	// EvalSymlinks-without-Abs canonicalization produce an ABSOLUTE
+	// resolved target while canonEnvelope/canonBase stay RELATIVE.
+	// filepath.Rel(relative, absolute) errors, and containedIn treats any
+	// Rel error as "not contained" — so a completely legitimate, safely
+	// contained path is falsely rejected as escaping containment. Once
+	// canonEnvelope/canonBase are normalized via
+	// pathutil.NormalizePathForCompare (which absolutizes first), this
+	// must succeed.
+	t.Run("relative envelope combined with a symlinked conditionPath segment must not be falsely rejected", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink semantics differ on Windows")
+		}
+		dir := t.TempDir()
+		realDir := filepath.Join(dir, "real")
+		if err := os.MkdirAll(realDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := filepath.Join(realDir, "check.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realDir, filepath.Join(dir, "alias")); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+
+		t.Chdir(dir)
+
+		got, err := ResolveConditionPath(".", "", "alias/check.sh")
+		if err != nil {
+			t.Fatalf("unexpected error: %v — envelope/base must be canonicalized to absolute before containment comparison, not left relative", err)
+		}
+		testutil.AssertSamePath(t, got, script)
+	})
 }
 
 func TestRunConditionPass(t *testing.T) {

--- a/internal/convergence/evaluate.go
+++ b/internal/convergence/evaluate.go
@@ -47,6 +47,13 @@ func ResolveEvaluateStep(cityPath string, formula Formula) (EvaluateStep, error)
 	// workspace roots (e.g., /tmp -> /private/tmp on macOS) from causing
 	// false rejections, and keeps a relative cityPath (e.g. ".") from
 	// producing a relative PromptPath below.
+	//
+	// NormalizePathForCompare does more than absolutize-and-resolve: on
+	// darwin it also collapses the /private/tmp and /private/var host
+	// aliases back to /tmp and /var, which is the REVERSE direction from
+	// bare filepath.EvalSymlinks. resolved is built on canonCity and so
+	// inherits that convention; any value compared against it must pass
+	// through pathutil too.
 	canonCity := pathutil.NormalizePathForCompare(cityPath)
 
 	resolved := filepath.Clean(filepath.Join(canonCity, promptPath))
@@ -66,8 +73,16 @@ func ResolveEvaluateStep(cityPath string, formula Formula) (EvaluateStep, error)
 	// failing, so pathutil.NormalizePathForCompare's fallback-and-never-error
 	// contract would change this function's behavior, not just its
 	// canonicalization.
+	//
+	// Only realResolved is normalized before the comparison. It is already
+	// fully symlink-resolved, so NormalizePathForCompare on it amounts to
+	// the darwin alias collapse alone — which puts it in the same convention
+	// as resolved (built on the collapsed canonCity). Do NOT switch this to
+	// pathutil.SamePath: that would normalize resolved too, re-resolving it
+	// through its own symlink, so a genuinely symlinked prompt would compare
+	// equal and this rejection would stop firing.
 	realResolved, err := filepath.EvalSymlinks(resolved)
-	if err == nil && realResolved != resolved {
+	if err == nil && pathutil.NormalizePathForCompare(realResolved) != resolved {
 		return EvaluateStep{}, fmt.Errorf("evaluate prompt path contains symlinks: %s resolves to %s", resolved, realResolved)
 	}
 

--- a/internal/convergence/evaluate.go
+++ b/internal/convergence/evaluate.go
@@ -41,12 +41,13 @@ func ResolveEvaluateStep(cityPath string, formula Formula) (EvaluateStep, error)
 		promptPath = formula.EvaluatePrompt
 	}
 
-	// Canonicalize cityPath first so that symlinked workspace roots
-	// (e.g., /tmp -> /private/tmp on macOS) don't cause false rejections.
-	canonCity, err := filepath.EvalSymlinks(cityPath)
-	if err != nil {
-		canonCity = filepath.Clean(cityPath) // best-effort if city doesn't exist yet
-	}
+	// Canonicalize cityPath first via pathutil.NormalizePathForCompare, which
+	// absolutizes before resolving symlinks (falling back to a best-effort
+	// ancestor walk when the path doesn't exist yet). This keeps symlinked
+	// workspace roots (e.g., /tmp -> /private/tmp on macOS) from causing
+	// false rejections, and keeps a relative cityPath (e.g. ".") from
+	// producing a relative PromptPath below.
+	canonCity := pathutil.NormalizePathForCompare(cityPath)
 
 	resolved := filepath.Clean(filepath.Join(canonCity, promptPath))
 
@@ -57,6 +58,14 @@ func ResolveEvaluateStep(cityPath string, formula Formula) (EvaluateStep, error)
 	}
 
 	// Reject symlinks in the resolved path (matching ResolveConditionPath).
+	// canonical-path-exception: existence/resolvability only, not comparison
+	// preparation. This deliberately checks whether the resolved path IS a
+	// symlink — a blanket "reject any symlink component" policy that is
+	// stricter than, and different in kind from, plain containment — and
+	// silently tolerates an unresolvable path (err != nil) rather than
+	// failing, so pathutil.NormalizePathForCompare's fallback-and-never-error
+	// contract would change this function's behavior, not just its
+	// canonicalization.
 	realResolved, err := filepath.EvalSymlinks(resolved)
 	if err == nil && realResolved != resolved {
 		return EvaluateStep{}, fmt.Errorf("evaluate prompt path contains symlinks: %s resolves to %s", resolved, realResolved)

--- a/internal/convergence/evaluate_test.go
+++ b/internal/convergence/evaluate_test.go
@@ -1,9 +1,13 @@
 package convergence
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 func TestResolveEvaluateStep_DefaultPath(t *testing.T) {
@@ -137,4 +141,75 @@ func TestResolveEvaluateStep_RelativeCityPathReturnsAbsolutePromptPath(t *testin
 	if step.PromptPath != want {
 		t.Errorf("PromptPath = %q, want %q", step.PromptPath, want)
 	}
+}
+
+// Pins the symlink-presence rejection itself, which the comparison above sits
+// on top of. Normalizing realResolved must not weaken it: normalizing BOTH
+// operands (e.g. via pathutil.SamePath) would re-resolve the prompt path
+// through its own symlink, both sides would compare equal, and this rejection
+// would silently stop firing. Portable — this runs on every platform, unlike
+// the darwin-guarded alias tests.
+func TestResolveEvaluateStep_SymlinkedPromptStillRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	city := t.TempDir()
+	outside := t.TempDir()
+
+	target := filepath.Join(outside, "real-evaluate.md")
+	if err := os.WriteFile(target, []byte("bd meta set convergence.agent_verdict\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(city, DefaultEvaluatePromptPath)
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+
+	_, err := ResolveEvaluateStep(city, Formula{Name: "test"})
+	if err == nil {
+		t.Fatal("expected a symlinked evaluate prompt to be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "contains symlinks") {
+		t.Errorf("expected a symlink rejection, got: %v", err)
+	}
+}
+
+// Pins the darwin half of the same comparison contract. canonCity comes from
+// pathutil.NormalizePathForCompare, which on macOS collapses the platform
+// temp root's /private/var (or /private/tmp) spelling back to /var (or /tmp);
+// the symlink-presence check's realResolved comes from bare EvalSymlinks and
+// carries the /private spelling. Comparing the two raw conventions rejects a
+// prompt file that is not a symlink at all, so realResolved must be
+// normalized before the comparison.
+//
+// This needs the real os.TempDir() root (the /private alias only exists on the
+// platform temp trees) AND the prompt file actually present on disk — the
+// check is guarded by `err == nil`, so a missing file makes EvalSymlinks fail
+// and the comparison is skipped entirely.
+func TestResolveEvaluateStep_DarwinPrivateTempAliasWithExistingPrompt(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: the /private/{tmp,var} alias collapse is a no-op on other platforms")
+	}
+	city, err := os.MkdirTemp(os.TempDir(), "gc-eval-alias-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(city) })
+
+	prompt := filepath.Join(city, DefaultEvaluatePromptPath)
+	if err := os.MkdirAll(filepath.Dir(prompt), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(prompt, []byte("bd meta set convergence.agent_verdict\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	step, err := ResolveEvaluateStep(city, Formula{Name: "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v — the symlink-presence check must normalize realResolved before comparing it against a path built on the alias-collapsed canonCity", err)
+	}
+	testutil.AssertSamePath(t, step.PromptPath, prompt)
 }

--- a/internal/convergence/evaluate_test.go
+++ b/internal/convergence/evaluate_test.go
@@ -112,3 +112,29 @@ func TestValidateEvaluatePrompt_EmptyContent(t *testing.T) {
 		t.Errorf("error should mention missing 'convergence.agent_verdict', got: %v", err)
 	}
 }
+
+// Pins the canonical-path-at-ingest bug this migration fixes (ga-iawy13.4):
+// a relative cityPath (e.g. "." from an as-yet-unresolved city path) makes
+// the current bare EvalSymlinks-without-Abs canonicalization leave
+// canonCity relative, so the function silently succeeds but returns a
+// relative PromptPath instead of an absolute one. Once canonCity is
+// normalized via pathutil.NormalizePathForCompare (which absolutizes
+// first), PromptPath must be absolute.
+func TestResolveEvaluateStep_RelativeCityPathReturnsAbsolutePromptPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	f := Formula{Name: "test"}
+	step, err := ResolveEvaluateStep(".", f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !filepath.IsAbs(step.PromptPath) {
+		t.Fatalf("PromptPath = %q, want an absolute path — cityPath must be canonicalized to absolute before joining, not left relative", step.PromptPath)
+	}
+	want := filepath.Join(dir, DefaultEvaluatePromptPath)
+	if step.PromptPath != want {
+		t.Errorf("PromptPath = %q, want %q", step.PromptPath, want)
+	}
+}

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -427,11 +427,27 @@ func requiredArtifactPathInWorktree(worktree, path string) (bool, error) {
 	return pathutil.PathWithin(absWorktree, absPath), nil
 }
 
+// requiredArtifactTargetInWorktree reports whether path's symlink-resolved
+// target is contained within worktree's symlink-resolved root, tolerating a
+// missing path (treated as contained; the caller's earlier os.Stat is what
+// classifies missing artifacts as failures).
 func requiredArtifactTargetInWorktree(worktree, path string) (bool, error) {
+	// canonical-path-exception: existence/resolvability only, not comparison
+	// preparation. worktree is always an absolute git-worktree path stamped
+	// by the controller (never a bare "." or other unresolved relative
+	// value); a worktree that no longer resolves must fail this check,
+	// which pathutil.NormalizePathForCompare's never-errors contract would
+	// silently paper over.
 	resolvedWorktree, err := filepath.EvalSymlinks(filepath.Clean(worktree))
 	if err != nil {
 		return false, fmt.Errorf("resolving required artifact worktree symlinks %q: %w", worktree, err)
 	}
+	// canonical-path-exception: existence/resolvability only, not comparison
+	// preparation. A missing artifact target is deliberately treated as
+	// contained (true) here — validateRequiredArtifacts' earlier os.Stat
+	// call is what classifies missing/unreadable artifacts as failures;
+	// this function only needs to gate symlink escapes for targets that
+	// exist.
 	resolvedPath, err := filepath.EvalSymlinks(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -671,6 +672,83 @@ func TestRequiredArtifactTemplatesTreatsSingularAsOnePath(t *testing.T) {
 			t.Fatalf("requiredArtifactTemplates()[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
 		}
 	}
+}
+
+// TestRequiredArtifactTargetInWorktree regression-pins the
+// existence/resolvability checks in requiredArtifactTargetInWorktree's two
+// bare EvalSymlinks calls (refs ga-iawy13.4): a missing target is treated
+// as contained (the caller's earlier os.Stat already classifies
+// missing/unreadable paths, so this function only needs to gate symlink
+// escapes for targets that exist), a symlinked worktree root resolves
+// correctly for a contained target, and a target that escapes via symlink
+// is rejected. These sites are deliberate existence/resolvability
+// checking, not comparison preparation, and must keep behaving identically
+// after the canonical-path-at-ingest migration.
+func TestRequiredArtifactTargetInWorktree(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing target treated as contained", func(t *testing.T) {
+		t.Parallel()
+		worktree := t.TempDir()
+		missing := filepath.Join(worktree, "does-not-exist.md")
+
+		got, err := requiredArtifactTargetInWorktree(worktree, missing)
+		if err != nil {
+			t.Fatalf("requiredArtifactTargetInWorktree: %v", err)
+		}
+		if !got {
+			t.Fatal("expected missing target to be treated as contained (true)")
+		}
+	})
+
+	t.Run("symlinked worktree root with contained target resolves", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink semantics differ on Windows")
+		}
+		t.Parallel()
+		realDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(realDir, "review.md"), []byte("ok"), 0o644); err != nil {
+			t.Fatalf("write artifact: %v", err)
+		}
+		aliasParent := t.TempDir()
+		alias := filepath.Join(aliasParent, "worktree-alias")
+		if err := os.Symlink(realDir, alias); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+
+		got, err := requiredArtifactTargetInWorktree(alias, filepath.Join(alias, "review.md"))
+		if err != nil {
+			t.Fatalf("requiredArtifactTargetInWorktree: %v", err)
+		}
+		if !got {
+			t.Fatal("expected symlinked worktree root with contained target to resolve as contained")
+		}
+	})
+
+	t.Run("target escaping via symlink is rejected", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink semantics differ on Windows")
+		}
+		t.Parallel()
+		worktree := t.TempDir()
+		outside := t.TempDir()
+		outsideFile := filepath.Join(outside, "secret.md")
+		if err := os.WriteFile(outsideFile, []byte("secret"), 0o644); err != nil {
+			t.Fatalf("write outside file: %v", err)
+		}
+		link := filepath.Join(worktree, "review.md")
+		if err := os.Symlink(outsideFile, link); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+
+		got, err := requiredArtifactTargetInWorktree(worktree, link)
+		if err != nil {
+			t.Fatalf("requiredArtifactTargetInWorktree: %v", err)
+		}
+		if got {
+			t.Fatal("expected target escaping worktree via symlink to be rejected (false)")
+		}
+	})
 }
 
 type fakeFileInfo struct {

--- a/release-gates/ga-94bs0w-canonical-path-convergence-dispatch-gate.md
+++ b/release-gates/ga-94bs0w-canonical-path-convergence-dispatch-gate.md
@@ -1,0 +1,48 @@
+# Release gate: canonical path classification in convergence and dispatch
+
+- Deploy bead: `ga-94bs0w`
+- Build bead: `ga-iawy13.4`
+- Review bead: `ga-72lu2m`
+- Reviewed source: `e8b75defefb74c6844a19a722cebdbd54dbe470a`
+- Deploy branch: `deploy/ga-94bs0w-gate`
+- Gate base: `origin/main@0223c3af63cf5cab296f9abed25bcced5eb91794`
+- Evaluation date: 2026-08-03
+- Disposition: **PASS**
+
+`docs/PROJECT_MANIFEST.md` is not present at the reviewed commit, so this
+checklist applies the deployer role's release criteria and the repository's
+documented test-evidence policy.
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first and rechecked after testing. `git merge-tree --write-tree origin/main e8b75defefb74c6844a19a722cebdbd54dbe470a` exited 0 against `origin/main@0223c3af63cf5cab296f9abed25bcced5eb91794` and produced tree `fe1ab02e397d97fade37998bea4085db92d1702d`. The source is two commits ahead and one behind current main with no content conflict; no self-rebase or source-branch mutation was needed. |
+| 1 | Review PASS present | **PASS** | Review bead `ga-72lu2m` is closed with reason `pass`, records `verdict: pass`, and names the exact reviewed source SHA. The reviewer independently verified the classification, tests, formatting, and path-containment security behavior. |
+| 2 | Acceptance criteria met | **PASS** | All nine scoped `filepath.EvalSymlinks` sites are classified in the matrix below. The three comparison-preparation inputs use `pathutil.NormalizePathForCompare` at subsystem entry; the six existence/resolvability checks remain bare with adjacent `canonical-path-exception` justification. New tests cover relative and symlinked spellings, missing paths, contained targets, and symlink escapes. The focused package suite and vet pass, and no scoped production call remains unexplained. |
+| 3 | Tests pass | **PASS** | At the exact reviewed SHA, documented `make test-fast-parallel` completed **10 PASS jobs, 0 FAIL jobs, 0 SKIP jobs**. `go build ./...` and `go vet ./...` exited 0. A fresh JSON run of `go test -count=1 ./internal/convergence/... ./internal/dispatch/...` recorded **738 PASS, 0 FAIL, 0 SKIP**. `git diff --check origin/main...HEAD` also passed. |
+| 4 | No high-severity review findings open | **PASS** | Reviewer notes report no specification, style, security, compatibility, or uncovered-criteria blockers. Unresolved HIGH/CRITICAL findings: 0. |
+| 5 | Final branch is clean | **PASS** | Before adding this checklist, `git status --porcelain=v1 --untracked-files=all` produced no output. The configured hook path is `.githooks`; this checklist is the sole deployer-authored release change and will be committed before push. |
+| 7 | Single feature theme | **PASS** | The two-commit TDD set changes one canonical-path-at-ingest behavior across the coupled convergence and dispatch path-validation surfaces. All eight changed files are implementation or adjacent tests for that theme; no independent feature is bundled. |
+
+## Per-site classification
+
+| Site | Behavior class | Disposition |
+|---|---|---|
+| `internal/convergence/artifact.go` — artifact root | Existence/resolvability | Keep `EvalSymlinks`; a missing or unresolvable artifact directory must fail. |
+| `internal/convergence/artifact.go` — walked symlink target | Existence/resolvability | Keep `EvalSymlinks`; a dangling or unresolvable target must fail validation. |
+| `internal/convergence/condition.go` — envelope | Comparison preparation | Normalize once with `pathutil.NormalizePathForCompare`. |
+| `internal/convergence/condition.go` — base | Comparison preparation | Normalize once with `pathutil.NormalizePathForCompare`. |
+| `internal/convergence/condition.go` — condition script | Existence/resolvability | Keep `EvalSymlinks`; the script must resolve to an executable file. |
+| `internal/convergence/evaluate.go` — city path | Comparison preparation | Normalize once with `pathutil.NormalizePathForCompare`. |
+| `internal/convergence/evaluate.go` — prompt path | Existence/resolvability | Keep `EvalSymlinks`; preserve the explicit symlink-presence check and deferred missing-file behavior. |
+| `internal/dispatch/retry.go` — worktree root | Existence/resolvability | Keep `EvalSymlinks`; fail closed if the worktree root does not resolve. |
+| `internal/dispatch/retry.go` — required artifact target | Existence/resolvability | Keep `EvalSymlinks`; preserve missing-target tolerance while rejecting a resolved target outside the worktree. |
+
+## Acceptance evidence
+
+- `TestResolveConditionPath/relative_envelope_combined_with_a_symlinked_conditionPath_segment_must_not_be_falsely_rejected` proves relative and symlinked spellings converge on the same containment decision.
+- `TestResolveEvaluateStep_RelativeCityPathReturnsAbsolutePromptPath` proves a relative city path produces a canonical absolute prompt path.
+- `TestValidateArtifactDir_MissingDir` preserves the artifact-root existence failure.
+- `TestRequiredArtifactTargetInWorktree` covers a missing target, a symlinked worktree root with a contained target, and a symlink escape outside the worktree.
+- No API, configuration, persistence, generated-schema, or dependency change is included.


### PR DESCRIPTION
## What this changes

Convergence gate and dispatch artifact paths now make identity and containment decisions from canonical inputs. Relative, real, and symlinked spellings of the same envelope, base, or city directory therefore produce the same result instead of triggering false path-escape rejection or returning a relative prompt path.

The change deliberately keeps direct `filepath.EvalSymlinks` calls where resolution failure is part of the behavior, such as missing artifact directories, dangling condition scripts, and retry artifact targets. Those sites are documented beside the call so future migrations preserve their error semantics.

## Review notes

- Review the convergence condition-path and evaluate-prompt boundaries together with dispatch retry artifact containment; these are the three comparison inputs and six existence/resolvability checks covered by the classification.
- Missing-path and symlink-escape behavior remains fail-closed where required; missing retry artifacts retain their existing classification path.
- No API, configuration, persistence, dependency, or migration change is included.

## Test plan

- [x] `make test-fast-parallel` — 10 jobs passed, 0 failed, 0 skipped
- [x] `go build ./...` and `go vet ./...`
- [x] `go test -count=1 ./internal/convergence/... ./internal/dispatch/...` — 738 passed, 0 failed, 0 skipped
- [x] Release gate: [`release-gates/ga-94bs0w-canonical-path-convergence-dispatch-gate.md`](release-gates/ga-94bs0w-canonical-path-convergence-dispatch-gate.md)
