### PR TITLE
fix: preserve runtime native step topology

### DIFF
--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -134,7 +134,10 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 	if len(recipe.Steps) == 0 {
 		return nil, false, "", fmt.Errorf("recipe %q has no steps", recipe.Name)
 	}
-	recipe = recipeWithNativeStepDependencies(recipe)
+	if !opts.nativeStepTopologyPrepared {
+		recipe = recipeWithNativeStepDependencies(recipe)
+		opts.nativeStepTopologyPrepared = true
+	}
 
 	vars := applyVarDefaults(opts.Vars, recipe.Vars)
 	priorityOverride := clonePriority(opts.PriorityOverride)
@@ -394,7 +397,13 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 	if len(recipe.Steps) == 0 {
 		return &beads.GraphApplyPlan{}, nil
 	}
-	recipe = fragmentRecipeWithNativeStepDependencies(recipe)
+	if !opts.nativeStepTopologyPrepared {
+		recipe = fragmentRecipeWithNativeStepDependencies(recipe)
+		if err := applyExternalNativeStepDependencies(store, recipe.Steps, opts.ExternalDeps); err != nil {
+			return nil, err
+		}
+		opts.nativeStepTopologyPrepared = true
+	}
 
 	existingLogicalBeadIDs, err := existingLogicalBeadIDIndex(store, opts.RootID)
 	if err != nil {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -57,6 +57,8 @@ type Options struct {
 	// DeferAssignees creates assignable beads without an assignee and stores
 	// the intended assignee in metadata for later activation.
 	DeferAssignees bool
+
+	nativeStepTopologyPrepared bool
 }
 
 const (
@@ -102,6 +104,8 @@ type FragmentOptions struct {
 	// PriorityOverride forces every created bead to use the given priority.
 	// When nil, the existing workflow root's priority is inherited.
 	PriorityOverride *int
+
+	nativeStepTopologyPrepared bool
 }
 
 // ExternalDep binds a fragment step to an already-existing bead.
@@ -328,12 +332,15 @@ func Attach(ctx context.Context, store beads.Store, recipe *formula.Recipe, atta
 		recipe.Steps[0].Metadata[beadmeta.AttachFencePendingMetadataKey] = "true"
 	}
 
+	recipe = recipeWithNativeStepDependencies(recipe)
+	preserveAttachedNativeStepTopology(parentBead, recipe)
 	result, err := Instantiate(ctx, store, recipe, Options{
-		Title:            opts.Title,
-		Vars:             opts.Vars,
-		PriorityOverride: clonePriority(parentBead.Priority),
-		PreserveRootType: true,
-		DeferAssignees:   fencedDeferred,
+		Title:                      opts.Title,
+		Vars:                       opts.Vars,
+		PriorityOverride:           clonePriority(parentBead.Priority),
+		PreserveRootType:           true,
+		DeferAssignees:             fencedDeferred,
+		nativeStepTopologyPrepared: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("instantiate: %w", err)
@@ -759,7 +766,10 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	if len(recipe.Steps) == 0 {
 		return nil, fmt.Errorf("recipe %q has no steps", recipe.Name)
 	}
-	recipe = recipeWithNativeStepDependencies(recipe)
+	if !opts.nativeStepTopologyPrepared {
+		recipe = recipeWithNativeStepDependencies(recipe)
+		opts.nativeStepTopologyPrepared = true
+	}
 	if !opts.DeferAssignees && IsGraphApplyEnabled() {
 		if applier, ok := beads.GraphApplyFor(store); ok {
 			result, err := instantiateViaGraphApply(ctx, applier, recipe, opts)
@@ -1062,6 +1072,10 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 		return &FragmentResult{IDMapping: map[string]string{}}, nil
 	}
 	recipe = fragmentRecipeWithNativeStepDependencies(recipe)
+	if err := applyExternalNativeStepDependencies(store, recipe.Steps, opts.ExternalDeps); err != nil {
+		return nil, err
+	}
+	opts.nativeStepTopologyPrepared = true
 	priorityOverride := clonePriority(opts.PriorityOverride)
 	if priorityOverride == nil {
 		root, err := store.Get(opts.RootID)

--- a/internal/molecule/native_step_topology.go
+++ b/internal/molecule/native_step_topology.go
@@ -2,12 +2,14 @@ package molecule
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 	"sort"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/formula"
 )
 
@@ -123,4 +125,133 @@ func recipeStepsWithNativeStepDependencies(steps []formula.RecipeStep, recipeDep
 // invent a new public identifier regex.
 func validNativeStepID(id string) bool {
 	return len(id) <= 256 && utf8.ValidString(id) && strings.TrimSpace(id) != ""
+}
+
+func decodeNativeStepDependencies(raw, stepID string) ([]string, bool) {
+	if raw == "" || !validNativeStepID(stepID) {
+		return nil, false
+	}
+	var dependencies []string
+	if err := json.Unmarshal([]byte(raw), &dependencies); err != nil || dependencies == nil {
+		return nil, false
+	}
+	previous := ""
+	for _, dependency := range dependencies {
+		if !validNativeStepID(dependency) || dependency == stepID || (previous != "" && dependency <= previous) {
+			return nil, false
+		}
+		previous = dependency
+	}
+	encoded, err := json.Marshal(dependencies)
+	if err != nil || string(encoded) != raw {
+		return nil, false
+	}
+	return dependencies, true
+}
+
+func normalizeNativeStepDependencies(stepID string, dependencies []string) ([]string, bool) {
+	unique := make(map[string]struct{}, len(dependencies))
+	for _, dependency := range dependencies {
+		if !validNativeStepID(dependency) {
+			return nil, false
+		}
+		if dependency != stepID {
+			unique[dependency] = struct{}{}
+		}
+	}
+	normalized := make([]string, 0, len(unique))
+	for dependency := range unique {
+		normalized = append(normalized, dependency)
+	}
+	sort.Strings(normalized)
+	return normalized, true
+}
+
+// preserveAttachedNativeStepTopology carries an immutable topology fact from a
+// control bead to a new physical occurrence of the same semantic step.
+func preserveAttachedNativeStepTopology(parent beads.Bead, recipe *formula.Recipe) {
+	if recipe == nil || len(recipe.Steps) == 0 {
+		return
+	}
+	root := &recipe.Steps[0]
+	for i := range recipe.Steps {
+		if recipe.Steps[i].IsRoot {
+			root = &recipe.Steps[i]
+			break
+		}
+	}
+	parentStepID := parent.Metadata[beadmeta.StepIDMetadataKey]
+	rootStepID := root.Metadata[beadmeta.StepIDMetadataKey]
+	if !validNativeStepID(parentStepID) || rootStepID != parentStepID {
+		return
+	}
+	raw := parent.Metadata[beadmeta.NativeStepDependenciesMetadataKey]
+	if _, complete := decodeNativeStepDependencies(raw, parentStepID); !complete {
+		delete(root.Metadata, beadmeta.NativeStepDependenciesMetadataKey)
+		return
+	}
+	root.Metadata[beadmeta.NativeStepDependenciesMetadataKey] = raw
+}
+
+// applyExternalNativeStepDependencies adds native edges for physical
+// ExternalDeps. If any prerequisite lacks a native identity, the target fact is
+// omitted rather than publishing an incomplete dependency set as authoritative.
+func applyExternalNativeStepDependencies(store beads.Store, steps []formula.RecipeStep, externalDeps []ExternalDep) error {
+	type accumulator struct {
+		complete     bool
+		dependencies []string
+	}
+	stepIndexes := make(map[string]int, len(steps))
+	for i := range steps {
+		stepIndexes[steps[i].ID] = i
+	}
+	byStep := make(map[string]*accumulator)
+	for _, dependency := range externalDeps {
+		if dependency.StepID == "" || dependency.DependsOnID == "" || dependency.Type == "parent-child" {
+			continue
+		}
+		if _, exists := stepIndexes[dependency.StepID]; !exists {
+			continue
+		}
+		current := byStep[dependency.StepID]
+		if current == nil {
+			current = &accumulator{complete: true}
+			byStep[dependency.StepID] = current
+		}
+		predecessor, err := store.Get(dependency.DependsOnID)
+		if err != nil {
+			return fmt.Errorf("resolving external dependency %q for step %q native topology: %w", dependency.DependsOnID, dependency.StepID, err)
+		}
+		predecessorStepID := predecessor.Metadata[beadmeta.StepIDMetadataKey]
+		if !validNativeStepID(predecessorStepID) {
+			current.complete = false
+			continue
+		}
+		current.dependencies = append(current.dependencies, predecessorStepID)
+	}
+	for stepID, current := range byStep {
+		step := &steps[stepIndexes[stepID]]
+		if !current.complete {
+			delete(step.Metadata, beadmeta.NativeStepDependenciesMetadataKey)
+			continue
+		}
+		nativeStepID := step.Metadata[beadmeta.StepIDMetadataKey]
+		local, complete := decodeNativeStepDependencies(step.Metadata[beadmeta.NativeStepDependenciesMetadataKey], nativeStepID)
+		if !complete {
+			delete(step.Metadata, beadmeta.NativeStepDependenciesMetadataKey)
+			continue
+		}
+		dependencies, complete := normalizeNativeStepDependencies(nativeStepID, append(local, current.dependencies...))
+		if !complete {
+			delete(step.Metadata, beadmeta.NativeStepDependenciesMetadataKey)
+			continue
+		}
+		encoded, err := json.Marshal(dependencies)
+		if err != nil {
+			delete(step.Metadata, beadmeta.NativeStepDependenciesMetadataKey)
+			continue
+		}
+		step.Metadata[beadmeta.NativeStepDependenciesMetadataKey] = string(encoded)
+	}
+	return nil
 }

--- a/internal/molecule/native_step_topology_test.go
+++ b/internal/molecule/native_step_topology_test.go
@@ -203,3 +203,173 @@ func TestNativeStepDependenciesMaterializeThroughGraphAndSequentialPaths(t *test
 		t.Fatalf("sequential bead topology = %q, want %q", got, want)
 	}
 }
+
+func TestAttachPreservesNativeStepDependenciesAcrossRetryAttempts(t *testing.T) {
+	store := beads.NewMemStore()
+	control, err := store.Create(beads.Bead{
+		Title: "Build retry control",
+		Metadata: map[string]string{
+			beadmeta.StepIDMetadataKey:                 "build",
+			beadmeta.StepRefMetadataKey:                "workflow.build",
+			beadmeta.NativeStepDependenciesMetadataKey: `["prepare"]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	recipe := &formula.Recipe{
+		Name: "workflow.build.attempt.2",
+		Steps: []formula.RecipeStep{{
+			ID:     "workflow.build.attempt.2",
+			Title:  "Build",
+			IsRoot: true,
+			Metadata: map[string]string{
+				beadmeta.StepIDMetadataKey:  "build",
+				beadmeta.StepRefMetadataKey: "workflow.build.attempt.2",
+			},
+		}},
+	}
+
+	result, err := Attach(context.Background(), store, recipe, control.ID, AttachOptions{})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	attempt, err := store.Get(result.RootID)
+	if err != nil {
+		t.Fatalf("get attempt: %v", err)
+	}
+	if got, want := attempt.Metadata[beadmeta.NativeStepDependenciesMetadataKey], `["prepare"]`; got != want {
+		t.Fatalf("retry attempt topology = %q, want immutable %q", got, want)
+	}
+}
+
+func TestAttachKeepsRetryTopologyUnknownWhenParentTopologyIsUnknown(t *testing.T) {
+	store := beads.NewMemStore()
+	control, err := store.Create(beads.Bead{
+		Title: "Build retry control",
+		Metadata: map[string]string{
+			beadmeta.StepIDMetadataKey:  "build",
+			beadmeta.StepRefMetadataKey: "workflow.build",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	recipe := &formula.Recipe{
+		Name: "workflow.build.attempt.2",
+		Steps: []formula.RecipeStep{{
+			ID:     "workflow.build.attempt.2",
+			Title:  "Build",
+			IsRoot: true,
+			Metadata: map[string]string{
+				beadmeta.StepIDMetadataKey:  "build",
+				beadmeta.StepRefMetadataKey: "workflow.build.attempt.2",
+			},
+		}},
+	}
+
+	result, err := Attach(context.Background(), store, recipe, control.ID, AttachOptions{})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	attempt, err := store.Get(result.RootID)
+	if err != nil {
+		t.Fatalf("get attempt: %v", err)
+	}
+	if got, present := attempt.Metadata[beadmeta.NativeStepDependenciesMetadataKey]; present {
+		t.Fatalf("retry attempt topology = %q, want omitted UNKNOWN", got)
+	}
+}
+
+func TestInstantiateFragmentIncludesCompleteExternalNativeStepDependencies(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "Workflow"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	predecessor, err := store.Create(beads.Bead{
+		Title:    "Prepare",
+		Metadata: map[string]string{beadmeta.StepIDMetadataKey: "prepare"},
+	})
+	if err != nil {
+		t.Fatalf("create predecessor: %v", err)
+	}
+	fragment := &formula.FragmentRecipe{
+		Name:    "late-build",
+		Steps:   []formula.RecipeStep{{ID: "build", Title: "Build"}},
+		Entries: []string{"build"},
+		Sinks:   []string{"build"},
+	}
+	opts := FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{{
+			StepID:      "build",
+			DependsOnID: predecessor.ID,
+			Type:        "blocks",
+		}},
+	}
+	plan, err := buildFragmentApplyPlan(store, fragment, opts)
+	if err != nil {
+		t.Fatalf("buildFragmentApplyPlan: %v", err)
+	}
+	if got, want := plan.Nodes[0].Metadata[beadmeta.NativeStepDependenciesMetadataKey], `["prepare"]`; got != want {
+		t.Fatalf("graph fragment topology = %q, want %q", got, want)
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, fragment, opts)
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+	build, err := store.Get(result.IDMapping["build"])
+	if err != nil {
+		t.Fatalf("get build: %v", err)
+	}
+	if got, want := build.Metadata[beadmeta.NativeStepDependenciesMetadataKey], `["prepare"]`; got != want {
+		t.Fatalf("fragment topology = %q, want %q", got, want)
+	}
+}
+
+func TestInstantiateFragmentOmitsTopologyWhenExternalNativeStepIsUnknown(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "Workflow"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	unknownPredecessor, err := store.Create(beads.Bead{Title: "Unidentified prerequisite"})
+	if err != nil {
+		t.Fatalf("create predecessor: %v", err)
+	}
+	fragment := &formula.FragmentRecipe{
+		Name:    "late-build",
+		Steps:   []formula.RecipeStep{{ID: "build", Title: "Build"}},
+		Entries: []string{"build"},
+		Sinks:   []string{"build"},
+	}
+	opts := FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{{
+			StepID:      "build",
+			DependsOnID: unknownPredecessor.ID,
+			Type:        "blocks",
+		}},
+	}
+	plan, err := buildFragmentApplyPlan(store, fragment, opts)
+	if err != nil {
+		t.Fatalf("buildFragmentApplyPlan: %v", err)
+	}
+	if got, present := plan.Nodes[0].Metadata[beadmeta.NativeStepDependenciesMetadataKey]; present {
+		t.Fatalf("graph fragment topology = %q, want omitted UNKNOWN", got)
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, fragment, opts)
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+	build, err := store.Get(result.IDMapping["build"])
+	if err != nil {
+		t.Fatalf("get build: %v", err)
+	}
+	if got, present := build.Metadata[beadmeta.NativeStepDependenciesMetadataKey]; present {
+		t.Fatalf("fragment topology = %q, want omitted UNKNOWN", got)
+	}
+}

--- a/pkg/eventexport/project.go
+++ b/pkg/eventexport/project.go
@@ -430,7 +430,7 @@ func normalizeStepDependencies(stepID string, dependencies *[]string) (*[]string
 	if dependencies == nil {
 		return nil, true
 	}
-	normalized := append([]string(nil), (*dependencies)...)
+	normalized := append([]string{}, (*dependencies)...)
 	sort.Strings(normalized)
 	if err := validateStepDependencies(stepID, &normalized); err != nil {
 		return nil, false

--- a/pkg/eventexport/project_test.go
+++ b/pkg/eventexport/project_test.go
@@ -180,6 +180,13 @@ func TestProjectEventNormalizesNativeStepDependencies(t *testing.T) {
 	if !ok || env.DependsOnStepIDs == nil || len(*env.DependsOnStepIDs) != 0 {
 		t.Fatalf("explicit root = %+v, %v; want present empty dependency list", env, ok)
 	}
+	wire, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(wire), `"depends_on_step_ids":[]`) {
+		t.Fatalf("explicit root wire = %s; want empty dependency array", wire)
+	}
 }
 
 func TestProjectEventRejectsInvalidPresentNativeTopology(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve the canonical prerequisite set when Attach creates another physical occurrence of the same semantic step
- include resolvable fragment ExternalDeps in native topology for both graph-plan and sequential materialization
- omit topology when any required external predecessor lacks a native step identity, preserving UNKNOWN instead of publishing a false root
- leave iteration identity, the wire tri-state/domain, and downstream APIs unchanged

## TDD evidence

The focused regressions first failed because every case emitted an authoritative empty array:

- TestAttachPreservesNativeStepDependenciesAcrossRetryAttempts
- TestAttachKeepsRetryTopologyUnknownWhenParentTopologyIsUnknown
- TestInstantiateFragmentIncludesCompleteExternalNativeStepDependencies
- TestInstantiateFragmentOmitsTopologyWhenExternalNativeStepIsUnknown

After the correction:

- go test ./internal/molecule -count=1
- go test ./internal/dispatch -run Test\(RetryLifecycle\|ProcessFanoutSequentialResumeRestoresExternalDeps\) -count=1
- go vet ./internal/molecule ./internal/dispatch
- pre-commit lint, generated-contract checks, and go vet ./...

No producer activation is part of this change.

Tracking: ga-15w7g.26.3

## Runtime export follow-up

Window 3's deploy-branch smoke exposed one projection defect: an authoritative root reached ProjectEvent as a present empty dependency slice but normalized to a nil slice, so JSON emitted `depends_on_step_ids:null` instead of `[]`.

TDD correction in `162c6eda18`:

- strengthened `TestProjectEventNormalizesNativeStepDependencies` to exercise ProjectEvent through JSON encoding
- changed normalization to preserve a non-nil empty slice
- retained omitted UNKNOWN and populated sorted dependencies unchanged
- RED reproduced `null`; GREEN passed 10 focused runs, the full `pkg/eventexport` and `internal/eventfeed` suites, focused vet, and the pre-commit lint/generated/vet checks

Exporter regression: ga-de4ei.

### Deploy-branch re-test

Window 3 cherry-picked only the exporter delta onto the existing deploy branch as `a0a1fcd23691868c01dba53bb5a6c2a76fa8a0a3`. A clean-clone build reported that exact unmodified VCS revision and Maintainer City returned to RUN.

The projection and real-runtime event smokes both passed:

- UNKNOWN omitted `depends_on_step_ids`
- authoritative roots emitted `depends_on_step_ids:[]`
- populated dependencies emitted sorted arrays
- a two-parent join retained both prerequisite IDs in lexical order
- every envelope passed validation and the exported wire contained zero `null` topology values

The runtime smoke used a throwaway city that was removed and unregistered afterward. Producer v3 remained paused and Maintainer City work was not poured or mutated.
