### PR TITLE
fix(gitcred): accept the Kubernetes Secret-mount permission shape

### DIFF
--- a/docs/guides/understanding-packs.md
+++ b/docs/guides/understanding-packs.md
@@ -332,8 +332,11 @@ $ gc import credential add github.com/gascity --ssh-key-file ~/.ssh/packbot_ed25
 The `match` argument is a bare host or `host/path-prefix` (longest-prefix wins,
 so same-host different-org credentials coexist). Exactly one pointer flag is
 required. By default the rule is written to `<city>/.gc/credentials.toml`
-(0600); `--global` writes `$GC_HOME/credentials.toml` instead. List and remove
-registered rules with:
+(0600); `--global` writes `$GC_HOME/credentials.toml` instead. gc refuses to
+load a `credentials.toml` that is world-accessible or group-writable: the modes
+it accepts are 0600/0400, plus the root-owned own-group 0440 that a Kubernetes
+Secret volume mounted with `fsGroup` produces. List and remove registered rules
+with:
 
 ```text
 $ gc import credential list

--- a/internal/doctor/checks_pack_credentials.go
+++ b/internal/doctor/checks_pack_credentials.go
@@ -38,7 +38,7 @@ func (c *PackCredentialsCheck) Run(ctx *CheckContext) *CheckResult {
 	if err != nil {
 		r.Status = StatusError
 		r.Message = fmt.Sprintf("pack credentials could not be loaded: %v", err)
-		r.FixHint = "fix the credentials.toml permissions (must be 0600) and pointer cardinality, then re-run gc doctor"
+		r.FixHint = "fix the credentials.toml permissions (must be 0600/0400, or root-owned own-group 0440 for a Kubernetes Secret mount) and pointer cardinality, then re-run gc doctor"
 		return r
 	}
 

--- a/internal/gitcred/rules.go
+++ b/internal/gitcred/rules.go
@@ -3,6 +3,7 @@ package gitcred
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -34,7 +35,8 @@ const credentialsFileName = "credentials.toml"
 // fallback.
 const commandLayerOrigin = "$" + EnvCredentialCommand
 
-// ErrInsecurePermissions reports a credentials file readable by group or other.
+// ErrInsecurePermissions reports a credentials file whose mode exposes it
+// beyond its owner. secureMode is the exact predicate.
 var ErrInsecurePermissions = errors.New("credentials file is group/world accessible")
 
 // Rule is one [[credential]] entry. Exactly one pointer field (Helper,
@@ -86,8 +88,10 @@ type credentialsFile struct {
 //  3. $GC_HOME/credentials.toml — gchome.Default().
 //  4. $GC_GIT_CREDENTIAL_COMMAND — recorded as a rule-less fallback layer.
 //
-// Every file present must be 0600/0400 (no group/other bits; the check is
-// skipped on Windows) or Load returns ErrInsecurePermissions wrapping the path.
+// Every file present must be owner-only — 0600/0400, or the root-owned
+// own-group 0440 a Kubernetes Secret volume mount produces (see secureMode);
+// the check is skipped on Windows. Otherwise Load returns
+// ErrInsecurePermissions wrapping the path.
 // Missing files are not errors. A literal "token"/"password" key, or a rule
 // with zero or more than one pointer field, is a hard parse error.
 func Load(cityRoot string) (*Rules, error) {
@@ -187,7 +191,7 @@ func loadFileLayer(path string) (*layer, error) {
 		}
 		return nil, fmt.Errorf("reading credentials file %q: %w", path, err)
 	}
-	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+	if runtime.GOOS != "windows" && !fileModeSecure(info) {
 		return nil, fmt.Errorf("%w: %s", ErrInsecurePermissions, path)
 	}
 	data, err := os.ReadFile(path)
@@ -211,6 +215,49 @@ func loadFileLayer(path string) (*layer, error) {
 		lyr.rules = append(lyr.rules, LoadedRule{Rule: rule, Origin: abs})
 	}
 	return lyr, nil
+}
+
+// unknownID stands in for an owner we could not read. It is (uid_t)-1, which no
+// file is ever owned by, so an unreadable owner fails the group-read exemption
+// in secureMode closed.
+const unknownID = ^uint32(0)
+
+// fileModeSecure reports whether a credentials file's mode is safe to load.
+// Ownership comes from the platform statOwner; when the FileInfo carries none,
+// the file is treated as foreign-owned.
+func fileModeSecure(info fs.FileInfo) bool {
+	uid, gid, ok := statOwner(info)
+	if !ok {
+		uid, gid = unknownID, unknownID
+	}
+	return secureMode(info.Mode().Perm(), uid, gid, uint32(os.Getegid()))
+}
+
+// secureMode is the permission gate for a credentials file. Owner bits are
+// unrestricted; every world bit and every group write/exec bit is rejected.
+//
+// Group READ is accepted only for the exact shape kubelet produces for a Secret
+// volume mounted with fsGroup: owned by root — Secret volume files always are,
+// there is no fsUser — group-owned by our own effective gid, group bits exactly
+// r--. That exemption is what lets the reader consume the Secret mount directly.
+// The alternative is copying the Secret into an emptyDir at init, which freezes
+// the credentials for the pod's whole lifetime: kubelet can atomically rotate a
+// Secret volume, but it cannot rotate a copy.
+//
+// The exemption grants an attacker nothing: reading the file already requires
+// membership in our own primary group, and the rules file holds no secrets —
+// only match patterns, usernames, and token_file paths. The tokens themselves
+// live in the files those paths name (resolve.go). A user-owned 0640 file is
+// still rejected, because your own files are never root-owned: off-cluster
+// behavior is identical to the strict 0o077 check this replaced.
+func secureMode(perm fs.FileMode, uid, gid, egid uint32) bool {
+	if perm&0o007 != 0 || perm&0o030 != 0 {
+		return false
+	}
+	if perm&0o040 != 0 {
+		return uid == 0 && gid == egid
+	}
+	return true
 }
 
 // ruleFromRaw converts a decoded [[credential]] table into a validated Rule. It

--- a/internal/gitcred/rules_test.go
+++ b/internal/gitcred/rules_test.go
@@ -2,6 +2,7 @@ package gitcred
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -116,6 +117,92 @@ func TestLoadInsecurePermissions(t *testing.T) {
 	_, err := Load(city)
 	if !errors.Is(err, ErrInsecurePermissions) {
 		t.Fatalf("want ErrInsecurePermissions, got %v", err)
+	}
+}
+
+func TestSecureMode(t *testing.T) {
+	const egid = 1001
+	const me = 1001
+	tests := []struct {
+		name string
+		perm fs.FileMode
+		uid  uint32
+		gid  uint32
+		want bool
+	}{
+		{"owner read only", 0o400, me, egid, true},
+		{"owner read write", 0o600, me, egid, true},
+		{"kubernetes secret mount", 0o440, 0, egid, true},
+		{"world readable", 0o644, 0, egid, false},
+		{"world readable owner only otherwise", 0o404, me, egid, false},
+		{"group writable", 0o660, 0, egid, false},
+		{"group executable", 0o450, 0, egid, false},
+		{"group readable foreign gid", 0o440, 0, egid + 1, false},
+		{"group readable not root owned", 0o440, me, egid, false},
+		{"group readable owner unknown", 0o440, unknownID, unknownID, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := secureMode(tc.perm, tc.uid, tc.gid, egid); got != tc.want {
+				t.Fatalf("secureMode(%v, uid=%d, gid=%d, egid=%d) = %v, want %v",
+					tc.perm, tc.uid, tc.gid, egid, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsUserOwnedGroupRead(t *testing.T) {
+	// The group-read exemption is for root-owned Secret mounts only. A 0640
+	// file the user created themselves is still insecure, which is what keeps
+	// laptop and CI behavior identical to the pre-exemption check.
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are POSIX-only")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a file we create is root-owned and would be exempt")
+	}
+	city := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv(EnvCredentialCommand, "")
+	writeCredFile(t, filepath.Join(city, ".gc", "credentials.toml"), "[[credential]]\nmatch=\"a.com\"\nhelper=\"x\"\n", 0o640)
+
+	_, err := Load(city)
+	if !errors.Is(err, ErrInsecurePermissions) {
+		t.Fatalf("want ErrInsecurePermissions, got %v", err)
+	}
+}
+
+func TestLoadAcceptsRootOwnedGroupReadable(t *testing.T) {
+	// The accept path end to end, on a real file. Only a root test process can
+	// produce the root:ourgid 0440 shape kubelet mounts, so this is skipped
+	// everywhere else; TestSecureMode covers the predicate unprivileged.
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are POSIX-only")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("needs root to chown the fixture to the Secret-mount shape")
+	}
+	city := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv(EnvCredentialsFile, "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv(EnvCredentialCommand, "")
+	path := filepath.Join(city, ".gc", "credentials.toml")
+	writeCredFile(t, path, "[[credential]]\nmatch=\"a.com\"\ntoken_file=\"/run/x\"\n", 0o440)
+	if err := os.Chown(path, 0, os.Getegid()); err != nil {
+		t.Fatalf("chown: %v", err)
+	}
+
+	rules, err := Load(city)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if all := rules.All(); len(all) != 1 || all[0].Match != "a.com" {
+		t.Fatalf("want the root-owned rule loaded, got %+v", all)
 	}
 }
 

--- a/internal/gitcred/rules_unix.go
+++ b/internal/gitcred/rules_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package gitcred
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+// statOwner returns the file's owning uid and gid. ok is false when the
+// FileInfo exposes no Unix ownership metadata; callers must treat that as
+// "owner unknown", never as a match.
+func statOwner(info fs.FileInfo) (uid, gid uint32, ok bool) {
+	stat, isUnix := info.Sys().(*syscall.Stat_t)
+	if !isUnix {
+		return 0, 0, false
+	}
+	return stat.Uid, stat.Gid, true
+}

--- a/internal/gitcred/rules_unix_test.go
+++ b/internal/gitcred/rules_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package gitcred
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStatOwnerReportsRealOwnership pins the plumbing between os.Stat and
+// secureMode. Every other permission test is a rejection, and a broken
+// statOwner would fail closed and still pass them; only the accept path
+// depends on these values being the real uid/gid, and that path needs root to
+// reproduce (see TestLoadAcceptsRootOwnedGroupReadable).
+func TestStatOwnerReportsRealOwnership(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cred")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	uid, gid, ok := statOwner(info)
+	if !ok {
+		t.Fatalf("statOwner reported no Unix ownership for %s", path)
+	}
+	if uid != uint32(os.Geteuid()) {
+		t.Fatalf("uid = %d, want %d", uid, os.Geteuid())
+	}
+	if gid != uint32(os.Getegid()) {
+		t.Fatalf("gid = %d, want %d", gid, os.Getegid())
+	}
+}

--- a/internal/gitcred/rules_windows.go
+++ b/internal/gitcred/rules_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package gitcred
+
+import "io/fs"
+
+// statOwner has no Unix ownership to report on Windows. loadFileLayer skips the
+// permission gate there entirely; returning ok=false keeps any other caller
+// fail-closed.
+func statOwner(fs.FileInfo) (uid, gid uint32, ok bool) {
+	return 0, 0, false
+}


### PR DESCRIPTION
**Prerequisite for making rotated git credentials reach a running Gas City controller.** The crucible-side change is blocked on this landing first.

## The problem

Credential rules files had to be owner-only — `0600`/`0400`. That's the right instinct on a laptop, but it makes a Kubernetes Secret impossible to mount directly:

- Secret volume files are **always owned by root**. There is no `fsUser` in any released Kubernetes; `SetVolumeOwnership` does `Lchown(path, -1, fsGroup)` — uid explicitly untouched.
- kubelet then ORs group-read into read-only volume modes, so `defaultMode: 0400` and `0440` **both** yield `root:<fsGroup>` mode `0440`.

So the only way to satisfy the old gate was to copy the files elsewhere at pod start — and a copy can't rotate. The running controller keeps the credentials it booted with, forever. Observed live: Secret at revision 2 with real tokens, pod 7h old, in-pod file still the tokenless 65-byte header, `git ls-remote` failing with *"could not read Username"*.

## The change

Group **read** is accepted for exactly the shape kubelet produces: owned by root, group-owned by our own effective gid, group bits exactly `r--`, no world bits. Everything else is unchanged.

**What stays rejected, deliberately:**

- All world bits.
- **Group write and group execute.** This is the half that protects something real: a rules file names a `helper` that gc runs through `sh -c`, and its `match` patterns decide which host receives the token. Anyone who can write it gets code execution *and* credential rerouting. Relaxing only world bits (`&0o007`) would have given that away — explicitly rejected.

**Why the root-ownership requirement matters.** Your own files are never root-owned, so a `0640` file on a developer machine still fails exactly as before. That's not incidental: on macOS every user shares the `staff` group (gid 20), so a plain "group matches my gid" rule would have quietly started accepting group-readable credential files there. Requiring `uid == 0` encodes "this came from kubelet" as a filesystem fact rather than environment sniffing.

Unreadable ownership is treated as foreign, so the exemption fails closed. Check still skipped on Windows.

## What this does NOT license

Confidentiality was never the property this gate protected. The rules file holds **no secrets by construction** — entries carry pointers (`helper` / `token_file` / `token_env` / `ssh_key_file`), never literals, and literal secret keys are rejected on load with a test asserting the error doesn't leak the value.

The real credentials are the token files, and they're read in `resolve.go` with a plain `os.ReadFile` and **no permission check at all**. Extending this predicate there is the obvious next step and is deliberately left to a follow-up to keep this reviewable — noting it must use the *new* predicate, since Secret-mounted token files are also `root:<gid>` `g+r`.

## Tests

`secureMode` is tested as a **pure function** with injected `uid`/`gid`/`egid`, so the negative cases express a genuinely foreign gid rather than passing trivially because the test process owns the files it creates. Cases: owner-only `0400`/`0600`, the kubelet shape, world-readable, group-writable, group-executable, **foreign gid**, non-root owner, and unknown ownership failing closed. Ownership plumbing (`statOwner`) is tested separately against real files.

## Verification

```
gofmt -l                      clean
go build ./...                exit 0
go vet ./internal/gitcred ./internal/doctor   exit 0
go test ./internal/gitcred/...  ok
go test ./internal/doctor/...   ok 32.6s
GOOS=windows go build          exit 0
GOOS=darwin  go build          exit 0
```

Cross-platform builds matter here: `syscall.Stat_t` is unix-only, hence the `rules_unix.go` / `rules_windows.go` split.

Determined by a four-lens security council (threat model / Kubernetes mechanics / invariant blast radius / adversary) with a deciding chair, then adversarially verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
