### PR TITLE
Normalize canonical path comparisons in sessionlog readers

### DIFF
--- a/internal/sessionlog/kimi_reader.go
+++ b/internal/sessionlog/kimi_reader.go
@@ -175,11 +175,11 @@ func findKimiSessionFilesIn(root, workHash string) []kimiContextCandidate {
 }
 
 func findKimiSessionFilesInVisited(root, workHash string, visited map[string]bool) []kimiContextCandidate {
-	root = canonicalKimiSessionRoot(root)
-	if root == "" || visited[root] {
+	canonical := canonicalKimiSessionRoot(root)
+	if canonical == "" || visited[canonical] {
 		return nil
 	}
-	visited[root] = true
+	visited[canonical] = true
 
 	workRoot := filepath.Join(root, workHash)
 	files := kimiContextFiles(workRoot)
@@ -206,11 +206,11 @@ func findKimiSessionFileByIDIn(root, workHash, sessionID string) string {
 }
 
 func findKimiSessionFileByIDInVisited(root, workHash, sessionID string, visited map[string]bool) string {
-	root = canonicalKimiSessionRoot(root)
-	if root == "" || visited[root] {
+	canonical := canonicalKimiSessionRoot(root)
+	if canonical == "" || visited[canonical] {
 		return ""
 	}
-	visited[root] = true
+	visited[canonical] = true
 
 	path := kimiTranscriptPath(filepath.Join(root, workHash), sessionID)
 	info, err := os.Stat(path)

--- a/internal/sessionlog/kimi_reader_test.go
+++ b/internal/sessionlog/kimi_reader_test.go
@@ -313,6 +313,32 @@ func TestFindKimiSessionFileFollowsSymlinkedRoots(t *testing.T) {
 	}
 }
 
+// Companion to TestFindKimiSessionFileFollowsSymlinkedRoots: a dangling
+// symlinked account root is a deliberate existence check (bare EvalSymlinks
+// site), not comparison prep, so it must be skipped without error and must
+// not block discovery through a later, valid sibling root.
+func TestFindKimiSessionFileSkipsBrokenSymlinkedRoot(t *testing.T) {
+	isolateKimiSearchRoots(t)
+	base := t.TempDir()
+	accountRoot := t.TempDir()
+	workDir := "/tmp/gascity/phase1/kimi-broken"
+	workHash := kimiWorkDirHash(workDir)
+	want := writeKimiContext(t, filepath.Join(accountRoot, workHash, "session-key", "context.jsonl"), []string{
+		`{"role":"user","content":"via valid root"}`,
+	})
+
+	if err := os.Symlink(filepath.Join(base, "does-not-exist"), filepath.Join(base, "account-a-broken")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	if err := os.Symlink(accountRoot, filepath.Join(base, "account-b-valid")); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindKimiSessionFile([]string{base}, workDir); !samePath(got, want) {
+		t.Fatalf("FindKimiSessionFile() = %q, want %q (broken sibling root must be skipped, not fatal)", got, want)
+	}
+}
+
 // isolateKimiSearchRoots pins every ambient variable DefaultKimiSearchPaths
 // reads, so a discovery test sees only the roots it creates. Pinning HOME alone
 // is insufficient: KIMI_CODE_HOME contributes a root independently of HOME, and


### PR DESCRIPTION
## What this changes

Sessionlog discovery now treats real paths, symlink aliases, and relative aliases as the same physical identity when deduplicating Codex rollout candidates and Kimi session roots. This prevents duplicate records and false ambiguity when the same transcript tree is reachable through more than one path spelling.

Traversal behavior stays intentionally conservative: broken symlink roots are skipped, while returned Kimi transcript paths retain the caller-provided lexical root. Canonical paths are comparison keys only, so callers do not unexpectedly receive absolute paths.

## Review notes

- Four comparison-only ingest sites use `pathutil.NormalizePathForCompare` for stable dedup keys.
- Six `filepath.EvalSymlinks` sites remain as functional resolvability checks, each with an adjacent exception comment.
- No API, configuration, wire-shape, or migration changes are included.

## Test plan

- [x] `make test-fast-parallel` — 10/10 jobs
- [x] `make test-cmd-gc-process-parallel` — 7/7 jobs
- [x] PR integration matrix — 14/14 shards
- [x] Worker Phase 1 and Phase 2 conformance — Claude, Codex, and Gemini profiles
- [x] `go test -count=1 -json ./internal/sessionlog/...` — 293 PASS, 0 FAIL, 7 Darwin-only SKIP
- [x] Release gate: [`release-gates/ga-w7a2xm-sessionlog-canonical-path-readers-gate.md`](release-gates/ga-w7a2xm-sessionlog-canonical-path-readers-gate.md)