### PR TITLE
Normalize canonical path ingest for formulas, workflows, and skills

### DIFF
--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // Formula file extensions. Canonical TOML is preferred, infixed TOML remains
@@ -206,10 +207,7 @@ func (p *Parser) parseResolvedAt(data []byte, absPath, label string) (*Formula, 
 }
 
 func descriptionFileBaseDir(path string) string {
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return filepath.Dir(resolved)
-	}
-	return filepath.Dir(path)
+	return filepath.Dir(pathutil.NormalizePathForCompare(path))
 }
 
 // Parse parses a formula from JSON bytes.

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -3607,3 +3607,32 @@ title = "Do work"
 		t.Errorf("error missing '1..{n}' (single-brace form, guards against double-brace regression): %v", err)
 	}
 }
+
+// TestDescriptionFileBaseDirResolvesSymlinkedParentWithMissingLeaf pins the
+// ga-iawy13.6 canonical-path-at-ingest fix: descriptionFileBaseDir must
+// resolve through a symlinked parent directory even when the path itself
+// (e.g. a ParseTOMLAt source path whose bytes were never written to disk)
+// does not exist. Today it only attempts to resolve the full path and
+// falls back to the unresolved parent on failure, with no walk-up at all.
+func TestDescriptionFileBaseDirResolvesSymlinkedParentWithMissingLeaf(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	aliasDir := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	missing := filepath.Join(aliasDir, "not-yet-created.toml")
+	got := descriptionFileBaseDir(missing)
+
+	want, err := filepath.EvalSymlinks(aliasDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(aliasDir): %v", err)
+	}
+	if got != want {
+		t.Errorf("descriptionFileBaseDir(%q) = %q, want %q (resolved through symlinked parent)", missing, got, want)
+	}
+}

--- a/internal/formula/source.go
+++ b/internal/formula/source.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/git"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // Source abstracts how formula files are located and read. The default
@@ -150,15 +151,7 @@ func (g *GitRefSource) repoTopAndRelPath(path string) (string, string, bool) {
 }
 
 func canonicalExistingPath(path string) string {
-	path = filepath.Clean(path)
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return filepath.Clean(resolved)
-	}
-	dir := filepath.Dir(path)
-	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
-		return filepath.Join(filepath.Clean(resolved), filepath.Base(path))
-	}
-	return path
+	return pathutil.NormalizePathForCompare(path)
 }
 
 // Stat reports whether a regular blob exists at the configured ref

--- a/internal/formula/source_test.go
+++ b/internal/formula/source_test.go
@@ -585,3 +585,34 @@ func derefString(s *string) string {
 	}
 	return *s
 }
+
+// TestCanonicalExistingPathResolvesSymlinkedGrandparentWithTwoMissingLevels
+// pins the ga-iawy13.6 canonical-path-at-ingest fix: canonicalExistingPath
+// must walk up past more than one missing path component to find a
+// resolvable symlinked ancestor, matching pathutil.NormalizePathForCompare.
+// Today it only tries the immediate parent, so a path missing at both the
+// leaf and the immediate-parent level resolves through the unresolved
+// symlink instead of its real target.
+func TestCanonicalExistingPathResolvesSymlinkedGrandparentWithTwoMissingLevels(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	aliasDir := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	missing := filepath.Join(aliasDir, "missing-parent", "missing-leaf")
+	got := canonicalExistingPath(missing)
+
+	resolvedAlias, err := filepath.EvalSymlinks(aliasDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(aliasDir): %v", err)
+	}
+	want := filepath.Join(resolvedAlias, "missing-parent", "missing-leaf")
+	if got != want {
+		t.Errorf("canonicalExistingPath(%q) = %q, want %q (resolved through symlinked grandparent, 2 missing levels)", missing, got, want)
+	}
+}

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // vendorSinks maps an agent provider to the relative directory under the
@@ -934,52 +935,19 @@ func targetUnderOwnedRoot(target string, ownedRoots []string) bool {
 	return false
 }
 
-// canonicalizePath returns a path with all leading symlinks resolved
-// (via filepath.EvalSymlinks). When the path itself does not exist
-// (e.g., a dangling symlink target or a not-yet-created sink entry),
-// the function walks up to find the deepest ancestor that does exist,
-// canonicalizes that, and re-appends the missing tail. This handles
-// platforms where common roots are symlinks (macOS /tmp →
-// /private/tmp; certain Linux distros where /var symlinks elsewhere)
-// without breaking comparisons against materializer-written targets
-// that may have been recorded with the unresolved prefix.
+// canonicalizePath returns path with all symlinks resolved, walking up to
+// the deepest existing ancestor when path itself does not exist (e.g., a
+// dangling symlink target or a not-yet-created sink entry) and re-appending
+// the missing tail. Delegates to pathutil.NormalizePathForCompare, which
+// also collapses platform path aliases (macOS /tmp → /private/tmp; certain
+// Linux distros where /var symlinks elsewhere) so comparisons against
+// materializer-written targets don't break on an unresolved prefix.
 //
-// Returns an error only when filepath.Abs fails on a relative input.
-// All EvalSymlinks errors are absorbed by the walk-up fallback.
-func canonicalizePath(path string) (string, error) {
-	if path == "" {
-		return "", nil
-	}
-	abs := path
-	if !filepath.IsAbs(abs) {
-		a, err := filepath.Abs(abs)
-		if err != nil {
-			return "", err
-		}
-		abs = a
-	}
-	abs = filepath.Clean(abs)
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved, nil
-	}
-	// Walk up until an ancestor exists; canonicalize it, then re-append
-	// the missing suffix. Falls back to the cleaned absolute path when
-	// nothing along the way exists (e.g., entirely-fictional path
-	// supplied by a test).
-	var suffix []string
-	cur := abs
-	for {
-		parent := filepath.Dir(cur)
-		suffix = append([]string{filepath.Base(cur)}, suffix...)
-		if parent == cur {
-			return abs, nil
-		}
-		if resolved, err := filepath.EvalSymlinks(parent); err == nil {
-			parts := append([]string{resolved}, suffix...)
-			return filepath.Join(parts...), nil
-		}
-		cur = parent
-	}
+// Always returns a nil error; the signature is kept for call-site
+// compatibility (all callers already treat resolution failure as
+// non-fatal).
+func canonicalizePath(path string) (string, error) { //nolint:unparam // error slot preserves the call-site contract for all 7 callers
+	return pathutil.NormalizePathForCompare(path), nil
 }
 
 // atomicSymlink creates or replaces a symlink at path pointing to

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/closeorder"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // ConflictError is returned when a graph workflow launch is blocked by one
@@ -350,11 +351,7 @@ func canonicalScopeRef(scopeRef string) string {
 	if scopeRef == "" {
 		return ""
 	}
-	scopeRef = filepath.Clean(scopeRef)
-	if resolved, err := filepath.EvalSymlinks(scopeRef); err == nil && strings.TrimSpace(resolved) != "" {
-		return resolved
-	}
-	return scopeRef
+	return pathutil.NormalizePathForCompare(scopeRef)
 }
 
 // ListWorkflowBeads returns the root and all descendant beads tagged with
@@ -776,12 +773,5 @@ func canonicalCityPath(cityPath string) (string, error) {
 	if cleaned == "" || cleaned == "." {
 		return "", fmt.Errorf("source workflow lock requires city path")
 	}
-	abs, err := filepath.Abs(cleaned)
-	if err != nil {
-		return "", fmt.Errorf("canonicalize city path: %w", err)
-	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil && strings.TrimSpace(resolved) != "" {
-		return resolved, nil
-	}
-	return abs, nil
+	return pathutil.NormalizePathForCompare(cleaned), nil
 }

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -351,7 +351,25 @@ func canonicalScopeRef(scopeRef string) string {
 	if scopeRef == "" {
 		return ""
 	}
+	if isStoreScopeSentinel(scopeRef) {
+		return scopeRef
+	}
 	return pathutil.NormalizePathForCompare(scopeRef)
+}
+
+// isStoreScopeSentinel reports whether ref is a logical store reference such
+// as "rig:alpha" or "city:main" rather than a filesystem path.
+// LockScopeForStoreRef falls through to the literal ref when a rig name cannot
+// be resolved to a path; absolutizing that sentinel would make the derived
+// lock key and lock filename depend on the caller's working directory and
+// silently weaken mutual exclusion. A single-character scheme (a Windows drive
+// letter) is a path, not a sentinel.
+func isStoreScopeSentinel(ref string) bool {
+	i := strings.IndexByte(ref, ':')
+	if i < 2 {
+		return false
+	}
+	return !strings.ContainsAny(ref[:i], `/\`)
 }
 
 // ListWorkflowBeads returns the root and all descendant beads tagged with

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -954,3 +954,77 @@ func TestSnapshotRestoreWorkflowBeadsRestoresMutableState(t *testing.T) {
 		t.Fatalf("child unrelated metadata = %q, want keep", got)
 	}
 }
+
+// TestCanonicalScopeRefResolvesSymlinkedParentWithMissingLeaf pins the
+// ga-iawy13.6 canonical-path-at-ingest fix: canonicalScopeRef must resolve
+// through a symlinked parent directory even when the leaf itself does not
+// exist yet. Today it attempts EvalSymlinks only on the full path and
+// falls back to the unresolved input on failure, with no walk-up.
+func TestCanonicalScopeRefResolvesSymlinkedParentWithMissingLeaf(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	aliasDir := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	missing := filepath.Join(aliasDir, "missing-leaf")
+	got := canonicalScopeRef(missing)
+
+	resolvedAlias, err := filepath.EvalSymlinks(aliasDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(aliasDir): %v", err)
+	}
+	want := filepath.Join(resolvedAlias, "missing-leaf")
+	if got != want {
+		t.Errorf("canonicalScopeRef(%q) = %q, want %q (resolved through symlinked parent)", missing, got, want)
+	}
+}
+
+// TestCanonicalScopeRefReturnsAbsolutePathForUnresolvableRelativeInput pins
+// that canonicalScopeRef always yields an absolute path for reliable
+// cross-process lock-key comparison, even when EvalSymlinks cannot resolve
+// anything at all. Today a relative input that cannot be resolved is
+// returned unchanged (still relative).
+func TestCanonicalScopeRefReturnsAbsolutePathForUnresolvableRelativeInput(t *testing.T) {
+	const relative = "does-not-exist-anywhere/leaf"
+	got := canonicalScopeRef(relative)
+	if !filepath.IsAbs(got) {
+		t.Errorf("canonicalScopeRef(%q) = %q, want an absolute path", relative, got)
+	}
+}
+
+// TestCanonicalCityPathResolvesSymlinkedParentWithMissingLeaf pins the
+// ga-iawy13.6 canonical-path-at-ingest fix: canonicalCityPath must resolve
+// through a symlinked parent directory even when the leaf itself does not
+// exist yet. Today it attempts EvalSymlinks only on the absolute path and
+// falls back to the unresolved abs path on failure, with no walk-up.
+func TestCanonicalCityPathResolvesSymlinkedParentWithMissingLeaf(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	aliasDir := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	missing := filepath.Join(aliasDir, "missing-leaf")
+	got, err := canonicalCityPath(missing)
+	if err != nil {
+		t.Fatalf("canonicalCityPath(%q): %v", missing, err)
+	}
+
+	resolvedAlias, evalErr := filepath.EvalSymlinks(aliasDir)
+	if evalErr != nil {
+		t.Fatalf("EvalSymlinks(aliasDir): %v", evalErr)
+	}
+	want := filepath.Join(resolvedAlias, "missing-leaf")
+	if got != want {
+		t.Errorf("canonicalCityPath(%q) = %q, want %q (resolved through symlinked parent)", missing, got, want)
+	}
+}

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -1028,3 +1028,18 @@ func TestCanonicalCityPathResolvesSymlinkedParentWithMissingLeaf(t *testing.T) {
 		t.Errorf("canonicalCityPath(%q) = %q, want %q (resolved through symlinked parent)", missing, got, want)
 	}
 }
+
+// TestCanonicalScopeRefKeepsStoreSentinelStableAcrossWorkingDirs pins that a
+// logical store sentinel is not absolutized. LockScopeForStoreRef returns the
+// literal "rig:<name>" when the rig cannot be resolved to a path; if that were
+// made cwd-relative, two gc processes started from different directories would
+// derive different lock keys and lock files for the same logical scope.
+func TestCanonicalScopeRefKeepsStoreSentinelStableAcrossWorkingDirs(t *testing.T) {
+	for _, ref := range []string{"rig:alpha", "city:main"} {
+		a := func() string { t.Chdir(t.TempDir()); return canonicalScopeRef(ref) }()
+		b := func() string { t.Chdir(t.TempDir()); return canonicalScopeRef(ref) }()
+		if a != ref || b != ref {
+			t.Errorf("canonicalScopeRef(%q) = %q / %q, want %q verbatim from both dirs", ref, a, b, ref)
+		}
+	}
+}

--- a/release-gates/ga-sdcjgv-canonical-path-ingest-gate.md
+++ b/release-gates/ga-sdcjgv-canonical-path-ingest-gate.md
@@ -1,0 +1,97 @@
+# Release Gate: Canonical path ingest for formulas, workflows, and skills
+
+- Deploy bead: `ga-sdcjgv`
+- Build bead: `ga-iawy13.6`
+- Review bead: `ga-q8rpff`
+- Reviewed commit: `775129cb25b1b96e077eeb85c442e912d58c0dce`
+- Final rebased code commit: `81c5073cc6a8c19c30e70af83928b5fa5fa052b8`
+- Isolated branch: `deploy/ga-sdcjgv-gate`
+- Base: `origin/main` at `c4880aef5f2c6be534358f09354c1d249e32161c`
+- Overall result: **PASS**
+
+The repository does not contain `docs/PROJECT_MANIFEST.md` at this revision.
+This checklist therefore applies the canonical seven deployer release criteria
+plus the repository requirements in `AGENTS.md`, `TESTING.md`, and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Criterion 6 evaluated first
+
+**PASS.** The final code commit is cleanly based on `origin/main`.
+
+- `git merge-base --is-ancestor origin/main 81c5073c` returned `0`.
+- `git merge-tree --write-tree origin/main 81c5073c` returned tree
+  `d62e74e354413ca917c27bc93dd11483a9b1d43e` with exit `0`.
+- `origin/main` resolved to
+  `c4880aef5f2c6be534358f09354c1d249e32161c`.
+- The code-only remote deploy ref resolved to
+  `81c5073cc6a8c19c30e70af83928b5fa5fa052b8` before evaluation.
+
+No additional self-rebase was required during this gate cycle.
+
+## Acceptance evidence
+
+All five scoped production sites are comparison or identity preparation and
+delegate to `pathutil.NormalizePathForCompare` on the final code commit:
+
+| Site | Classification | Disposition |
+| --- | --- | --- |
+| `internal/formula/parser.go:descriptionFileBaseDir` | Description-file anchor preparation | Normalize once before deriving the directory. |
+| `internal/formula/source.go:canonicalExistingPath` | Cache-key and `filepath.Rel` preparation | Delegate to the shared normalizer, including multi-level missing tails. |
+| `internal/sourceworkflow/sourceworkflow.go:canonicalScopeRef` | Workflow lock identity | Preserve the empty sentinel; otherwise normalize to a canonical absolute path. |
+| `internal/sourceworkflow/sourceworkflow.go:canonicalCityPath` | Workflow lock identity plus empty-path validation | Preserve validation and normalize the accepted path once. |
+| `internal/materialize/skills.go:canonicalizePath` | Ownership-root and containment comparison | Preserve the call-site contract and delegate to the shared normalizer. |
+
+`rg 'filepath\.EvalSymlinks|EvalSymlinks'` over the four scoped production
+files returned no matches. The final two-commit diff is confined to seven
+files in the formula, source-workflow, and skill-materialization canonical-path
+theme. Regression tests cover symlinked parents, missing leaves, multi-level
+missing tails, and absolute lock identities; existing materializer containment
+coverage remains in place.
+
+## Test evidence integrity
+
+The changed `internal/**` Go paths activate the required process-backed
+`cmd/gc` and PR integration lanes in `.github/workflows/ci.yml`. The final
+evidence ran those documented sharded lanes with the CI-pinned `bd v1.1.0`
+and Dolt `2.1.7`, a short on-disk `/var/tmp` fixture root, and tmux `3.4` for
+the tmux matrix.
+
+- `make test-fast-parallel`: **10 PASS, 0 FAIL, 0 SKIP** at job level.
+- Process-backed `cmd/gc`: **6 PASS, 0 FAIL, 0 SKIP** local shards, plus
+  product-metrics testhook **1 PASS, 0 FAIL, 0 SKIP**.
+- PR integration coverage: core packages **4 PASS**, integration-tagged
+  `cmd/gc` **6 PASS**, runtime tmux **6 PASS**, bdstore **1 PASS**, REST smoke
+  **2 PASS**; total **19 PASS, 0 FAIL, 0 SKIP** at shard/job level.
+- Additional formula-review integration jobs completed **5 PASS, 0 FAIL,
+  0 SKIP**.
+- `go test -count=1 -json ./internal/formula ./internal/sourceworkflow
+  ./internal/materialize`: **796 PASS, 0 FAIL, 1 SKIP**. The skip is
+  `TestCompileBugReportFlowV2`, whose unrelated external fixture
+  `/home/ubuntu/tooling/formulas/mol-bug-report-flow-v2.toml` is absent.
+- `go vet ./...`: exit `0`.
+- `go build ./...`: exit `0`.
+
+Two setup diagnostics are deliberately excluded from the counts above: an
+initial descriptive temp path exceeded the Unix socket length limit, and a
+clean HOME override was rejected by the platform-supervisor contract. Both
+runs were interrupted after diagnosis. Every affected required shard was then
+rerun in a valid job-specific environment and passed; no PASS is inferred from
+either interrupted diagnostic.
+
+## Release criteria
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | **PASS** | `ga-q8rpff` is closed with reason `pass`; its notes record `verdict: pass`, no uncovered criteria, and no blocker/major/security findings. |
+| 2 | Acceptance criteria met | **PASS** | The per-site classification matrix covers every scoped production site. All comparison sites use the shared canonicalizer, no scoped bare call remains, validation and call-site contracts are preserved, and the required symlink/missing-tail regressions are covered. |
+| 3 | Tests pass | **PASS** | All path-required CI-equivalent lanes passed with the counts and environment evidence above. The one targeted skip is external-fixture-only and does not exercise this change. |
+| 4 | No high-severity review findings open | **PASS** | Review notes report no blocker, major, HIGH, or CRITICAL findings. Unresolved high-severity finding count: **0**. |
+| 5 | Final branch is clean | **PASS** | The detached evaluation worktree remained pinned to `81c5073c` before and after testing with zero status entries. The isolated deploy branch was reset mechanically to that SHA and was clean before this checklist was added. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first; see the dedicated section above. |
+| 7 | Single feature theme | **PASS** | The two feature commits implement one coherent canonical-path-at-ingest change across formula, workflow-lock, and skill-materialization comparison boundaries. No independent feature is bundled. |
+
+## Gate disposition
+
+The gate passes. Commit this checklist on the isolated deploy branch, push that
+branch only after the shared-branch safety guard passes, open the PR, and route
+the verified merge-request to the merge authority. The deployer does not merge.


### PR DESCRIPTION
## What this changes

Formula description files, Git-backed formula sources, source-workflow lock identities, and skill materialization roots now use the same canonical path normalization at their ingest boundaries. Symlinked parents and not-yet-created path tails therefore resolve consistently before cache keys, lock keys, and containment comparisons are made.

This removes duplicated `filepath.EvalSymlinks` fallback logic at five sites while preserving existing validation and call-site contracts.

## Review notes

- The change is internal-only: no new configuration, endpoint, wire shape, or migration.
- `canonicalCityPath` still rejects empty paths, and `canonicalizePath` retains its existing `(string, error)` call-site contract.
- The main behavior to inspect is missing-leaf handling under symlinked parent directories.

## Test plan

- [x] Exercise formula, workflow-lock, and skill-materialization symlink/missing-tail regressions.
- [x] Run required process-backed `cmd/gc` and PR integration shards with CI-pinned bd/Dolt and tmux.
- [x] Run `go vet ./...` and `go build ./...`.
- [x] Release gate: [`release-gates/ga-sdcjgv-canonical-path-ingest-gate.md`](release-gates/ga-sdcjgv-canonical-path-ingest-gate.md)
