### PR TITLE
fix(config): PackDirsForRig("") falls back to AllPackDirs for city-scope agents

### DIFF
--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -1481,6 +1481,34 @@ func TestRenderPromptResolvesMultiRigPackFragmentsForCityScopeAgent(t *testing.T
 	}
 }
 
+// TestRenderPromptCityScopeFragmentCollisionLastRigWins pins the *direction* of
+// a same-named fragment collision across rigs. PackDirsForRig("") returns rig
+// dirs sorted by rig name and renderPrompt parses them in order, so a later
+// {{ define }} replaces an earlier one: the alphabetically last rig wins. The
+// PackDirsForRig doc comment documents this; without this test a change to
+// pack-dir ordering or loadSharedTemplates override semantics would flip the
+// winner silently.
+func TestRenderPromptCityScopeFragmentCollisionLastRigWins(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/a/template-fragments/x.template.md"] = []byte(
+		`{{ define "x" }}FROM-ALPHA{{ end }}`)
+	f.Files["/z/template-fragments/x.template.md"] = []byte(
+		`{{ define "x" }}FROM-ZULU{{ end }}`)
+	f.Files["/city/agents/x/prompt.template.md"] = []byte(`{{ template "x" . }}`)
+
+	cfg := &config.City{
+		RigPackDirs: map[string][]string{
+			"alpha": {"/a"},
+			"zulu":  {"/z"},
+		},
+	}
+	got := renderPrompt(f, "/city", "", "agents/x/prompt.template.md",
+		PromptContext{}, "", io.Discard, cfg.PackDirsForRig(""), nil, nil)
+	if got != "FROM-ZULU" {
+		t.Errorf("renderPrompt(colliding fragment across rigs) = %q, want %q (last rig alphabetically wins)", got, "FROM-ZULU")
+	}
+}
+
 // TestRenderPromptCityRootFragmentsAbsentNoEffect is the regression-safety
 // check: when the city root has no template-fragments/ or prompts/shared/,
 // rendered output is byte-identical to pre-fix behavior (i.e. the new

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -1453,6 +1453,34 @@ func TestRenderPromptResolvesMultiRigPackFragments(t *testing.T) {
 	}
 }
 
+// TestRenderPromptResolvesMultiRigPackFragmentsForCityScopeAgent pins the
+// PackDirsForRig("") fix at the actual call-site level: a rendered prompt for
+// a rig-less (scope="city") agent must see every rig's fragments, not just
+// the city-level ones, mirroring how ga-bmjqvb's symptom was reported.
+func TestRenderPromptResolvesMultiRigPackFragmentsForCityScopeAgent(t *testing.T) {
+	f := fsys.NewFake()
+	alphaDir := "/city/.gc/cache/repos/aaa/packs/alpha"
+	bravoDir := "/city/.gc/cache/repos/bbb/packs/bravo"
+	f.Files[alphaDir+"/template-fragments/a.template.md"] = []byte(
+		`{{ define "a" }}A{{ end }}`)
+	f.Files[bravoDir+"/template-fragments/b.template.md"] = []byte(
+		`{{ define "b" }}B{{ end }}`)
+	f.Files["/city/agents/x/prompt.template.md"] = []byte(
+		`{{ template "a" . }}-{{ template "b" . }}`)
+
+	cfg := &config.City{
+		RigPackDirs: map[string][]string{
+			"alpha": {alphaDir},
+			"bravo": {bravoDir},
+		},
+	}
+	got := renderPrompt(f, "/city", "", "agents/x/prompt.template.md",
+		PromptContext{}, "", io.Discard, cfg.PackDirsForRig(""), nil, nil)
+	if got != "A-B" {
+		t.Errorf("renderPrompt(city-scope agent, PackDirsForRig(\"\")) = %q, want %q", got, "A-B")
+	}
+}
+
 // TestRenderPromptCityRootFragmentsAbsentNoEffect is the regression-safety
 // check: when the city root has no template-fragments/ or prompts/shared/,
 // rendered output is byte-identical to pre-fix behavior (i.e. the new

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2968,8 +2968,12 @@ func (c *City) AllPackDirs() []string {
 // determinism. A fragment name defined identically in more than one rig's pack
 // resolves fine (that's the common case: a shared vocabulary like
 // handoff-routing, meant to render identically everywhere). A name defined with
-// DIFFERENT content in two rigs' packs silently picks whichever rig sorts first
-// alphabetically — a pack-authoring collision this function does not detect.
+// DIFFERENT content in two rigs' packs silently picks whichever rig sorts LAST
+// alphabetically: renderPrompt parses pack dirs in order and a later
+// {{ define }} replaces an earlier one. For the same reason, a rig-imported
+// fragment can shadow a same-named city-level imported-pack fragment (city
+// dirs are parsed first) — city-ROOT fragments still win, they load last.
+// This is a pack-authoring collision this function does not detect.
 // See ga-bmjqvb.
 func (c *City) PackDirsForRig(rigName string) []string {
 	if rigName == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2938,9 +2938,11 @@ func (c *City) FormulasDir() string {
 
 // AllPackDirs returns the union of city-level and all rig-level pack directories
 // (city dirs first, then sorted-by-rig-name dirs), deduplicated. Use this for
-// global scans that intentionally need the full pack-fragment universe. Prompt
-// rendering for a specific rig should use PackDirsForRig so one rig's fragments
-// cannot override another rig's same-named fragments.
+// global scans that intentionally need the full pack-fragment universe, and as
+// the fallback PackDirsForRig("") uses for rig-less (scope="city") agents, which
+// have no single rig to scope to. Prompt rendering for a specific rig should use
+// PackDirsForRig so one rig's fragments cannot override another rig's
+// same-named fragments.
 func (c *City) AllPackDirs() []string {
 	var dirs []string
 	dirs = appendUnique(dirs, c.PackDirs...)
@@ -2959,12 +2961,23 @@ func (c *City) AllPackDirs() []string {
 // directories imported by rigName, deduplicated with city-level dirs kept first.
 // Use this when rendering prompts for one agent so rig-imported template
 // fragments are available without exposing fragments imported by other rigs.
+//
+// rigName == "" means a rig-less (scope="city") agent — e.g. deep-investigator,
+// supervisor, pack-author — which has no single rig to scope to. Those agents
+// fall back to AllPackDirs(): the union across every rig, sorted by rig name for
+// determinism. A fragment name defined identically in more than one rig's pack
+// resolves fine (that's the common case: a shared vocabulary like
+// handoff-routing, meant to render identically everywhere). A name defined with
+// DIFFERENT content in two rigs' packs silently picks whichever rig sorts first
+// alphabetically — a pack-authoring collision this function does not detect.
+// See ga-bmjqvb.
 func (c *City) PackDirsForRig(rigName string) []string {
+	if rigName == "" {
+		return c.AllPackDirs()
+	}
 	var dirs []string
 	dirs = appendUnique(dirs, c.PackDirs...)
-	if rigName != "" {
-		dirs = appendUnique(dirs, c.RigPackDirs[rigName]...)
-	}
+	dirs = appendUnique(dirs, c.RigPackDirs[rigName]...)
 	return dirs
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8200,6 +8200,31 @@ func TestPackDirsForRig(t *testing.T) {
 	}
 }
 
+// TestPackDirsForRigEmptyRigNameFallsBackToAllPackDirs guards the scope="city"
+// agent fix: an empty rigName must resolve every rig's pack dirs via
+// AllPackDirs, not just the city-level ones, so city-scope agents (e.g.
+// deep-investigator, supervisor, pack-author) can see rig-imported fragments.
+func TestPackDirsForRigEmptyRigNameFallsBackToAllPackDirs(t *testing.T) {
+	c := &City{
+		PackDirs: []string{"/city/packs/a"},
+		RigPackDirs: map[string][]string{
+			"zulu":  {"/rig/zulu/packs/z"},
+			"alpha": {"/rig/alpha/packs/x"},
+		},
+	}
+
+	got := c.PackDirsForRig("")
+	want := c.AllPackDirs()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PackDirsForRig(\"\") = %v, want AllPackDirs() = %v", got, want)
+	}
+
+	justCityDirs := []string{"/city/packs/a"}
+	if reflect.DeepEqual(got, justCityDirs) {
+		t.Fatalf("PackDirsForRig(\"\") = %v, regressed to city-only dirs (dropped RigPackDirs)", got)
+	}
+}
+
 func TestDefaultInstallAgentHooksForProvider(t *testing.T) {
 	cases := []struct {
 		provider string


### PR DESCRIPTION
## Summary
- `PackDirsForRig("")` previously returned only city-level `PackDirs`, silently dropping every `RigPackDirs` entry for rig-less (`scope="city"`) agents (deep-investigator, supervisor, pack-author).
- Empty `rigName` now delegates to the existing `AllPackDirs()` (union across all rigs, sorted by rig name for determinism) — the same fallback already used for global scans.
- Doc comments on both functions updated to explain the fallback and the accepted alphabetical-collision risk (a fragment with different content in two rigs' packs silently prefers whichever rig sorts first).
- `cmd/gc/cmd_prime.go:343` and `cmd/gc/template_resolve.go:347` call `PackDirsForRig` and inherit the fix automatically — no changes needed there.

This is the architect-decided fix (Option 2) for ga-bmjqvb, split into ga-bmjqvb.1 (this PR) and ga-bmjqvb.2 (follow-up pack-author cleanup, blocked on this landing).

## Test plan
- [x] `go test ./internal/config/... -run 'TestPackDirsForRig|TestAllPackDirs' -v` — new `TestPackDirsForRigEmptyRigNameFallsBackToAllPackDirs` passes alongside existing cases
- [x] `go test ./cmd/gc/... -run 'TestRenderPromptResolvesMultiRigPackFragments' -v` — new `TestRenderPromptResolvesMultiRigPackFragmentsForCityScopeAgent` passes, pinning the fix at the actual `renderPrompt` call-site
- [x] `go vet ./...` clean
- [x] `make test-fast-parallel` — all 10 fast jobs pass

Fixes ga-bmjqvb.1