### PR TITLE
fix(doctor): order-firing-current timeout is advisory, not blocking (#4895)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   always locks to `sha:<HEAD commit>`, matching the documented behavior;
   registry/remote sources are unaffected. Fixes #3659.
 
+- **`gc doctor`'s `order-firing-current` check no longer hard-fails
+  `gc doctor` (exit code, `BlockingFailed`) when its own order-history
+  lookup times out.** The check races a Dolt-backed order-history query
+  against a 15s budget; on timeout it returned `StatusError` with no
+  `Severity` set, silently defaulting to `SeverityBlocking` (the zero
+  value of `CheckSeverity`) — turning a slow-but-healthy city's doctor run
+  red even when scheduled orders were firing normally, since a timed-out
+  lookup proves nothing about actual order staleness. The timeout branch
+  now explicitly sets `Severity: SeverityAdvisory` and `TimedOut: true`,
+  matching how `Doctor.boundedRun`'s own per-check timeout is already
+  reported, so callers (including `--json` output) can distinguish
+  "confirmed stale" from "the query didn't finish in time." (#4895)
+
 - **The dolt pack's `run_bounded` python3 fallback now sends SIGTERM before
   SIGKILL, matching its documented contract.** The fallback (used when
   neither `timeout` nor `gtimeout` is on `PATH`, the default on stock macOS)

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -118,11 +118,20 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 	case result := <-results:
 		return result
 	case <-time.After(timeout):
+		// A timed-out lookup is inconclusive, not proof of a stale/never-fired
+		// order (#4895): the query being slow says nothing about whether orders
+		// are actually firing. SeverityBlocking is CheckSeverity's zero value, so
+		// leaving Severity unset here would silently gate `gc doctor` (and its
+		// exit code) red on a busy-but-healthy city. Mark it advisory and
+		// TimedOut, matching how Doctor.boundedRun reports its own per-check
+		// timeout, so callers can tell "confirmed stale" from "couldn't tell".
 		return &CheckResult{
-			Name:    c.Name(),
-			Status:  StatusError,
-			Message: fmt.Sprintf("order history lookup timed out after %s", timeout),
-			FixHint: orderFiringTimeoutHint,
+			Name:     c.Name(),
+			Status:   StatusError,
+			Severity: SeverityAdvisory,
+			TimedOut: true,
+			Message:  fmt.Sprintf("order history lookup timed out after %s", timeout),
+			FixHint:  orderFiringTimeoutHint,
 		}
 	}
 }

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -664,4 +664,15 @@ func TestOrderFiringCurrent_TimesOutStalledOrderHistory(t *testing.T) {
 	if !strings.Contains(result.Message, "order history lookup timed out after 20ms") {
 		t.Fatalf("message = %q, want timeout diagnostic", result.Message)
 	}
+	// A slow-but-inconclusive lookup must not gate gc doctor red the same way a
+	// confirmed stale/never-fired order does (#4895): the query timing out proves
+	// nothing about whether orders are actually firing, so it must not report as
+	// SeverityBlocking (the CheckSeverity zero value, which this branch silently
+	// fell into before it explicitly set Severity).
+	if result.Severity != SeverityAdvisory {
+		t.Fatalf("severity = %v, want SeverityAdvisory (a timed-out lookup is inconclusive, not proof of a stale order)", result.Severity)
+	}
+	if !result.TimedOut {
+		t.Fatalf("TimedOut = false, want true so callers (JSON output, doctor summary) can distinguish this from a confirmed failure")
+	}
 }


### PR DESCRIPTION
## Summary
Fixes #4895: `gc doctor`'s `order-firing-current` check races its Dolt-backed order-history lookup against a hardcoded 15s budget. On timeout it returned `StatusError` with no `Severity` set, silently defaulting to `SeverityBlocking` (the zero value of `CheckSeverity`) — gating `gc doctor`'s exit code red on a merely-slow-but-inconclusive lookup, even when scheduled orders are firing normally. A timed-out lookup proves nothing about actual order staleness.

## Fix
`OrderFiringCurrentCheck.Run`'s timeout branch now explicitly sets `Severity: SeverityAdvisory` and `TimedOut: true`, matching the pattern `Doctor.boundedRun`'s own per-check timeout already uses. This is the smallest of the issue's three proposed fixes ("timeout should be non-blocking"); the hardcoded-vs-`--check-timeout` mismatch and the lookup-cost optimization it also raises are separate, real asks left for follow-up work.

## Test plan
- [x] Extended `TestOrderFiringCurrent_TimesOutStalledOrderHistory` with assertions on `Severity`/`TimedOut` — confirmed red (`severity = 0`, i.e. `SeverityBlocking`) before the fix, green after.
- [x] Full `internal/doctor` suite green, `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
