### PR TITLE
fix(config): caveat pack compatibility risk in workspace-identity deprecation warning (#3887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dry-run default, where they are the only backend cost) so the scan never
   does unbounded reads per tick. Fixes #3780.
 
+- **The legacy workspace-identity deprecation warning now caveats that
+  following it can silently break packs pinned to an older revision.**
+  `city.toml`'s `workspace.name`/`workspace.prefix` deprecation hint told
+  operators to move those fields to `.gc/site.toml`, but any installed pack
+  still pinned to a revision that reads `workspace.name` directly (rather
+  than the newer site-binding-aware resolution) would silently lose its
+  identity/routing once the field was removed — reported after one
+  deployment lost inbound Discord messages for ~2 days with zero alarms
+  before anyone checked delivery receipts. The warning now says so
+  explicitly, so operators check pack compatibility before acting on it.
+  (#3887)
+
 - **The dolt pack's `run_bounded` python3 fallback now sends SIGTERM before
   SIGKILL, matching its documented contract.** The fallback (used when
   neither `timeout` nor `gtimeout` is on `PATH`, the default on stock macOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   identity/routing once the field was removed — reported after one
   deployment lost inbound Discord messages for ~2 days with zero alarms
   before anyone checked delivery receipts. The warning now says so
-  explicitly, so operators check pack compatibility before acting on it.
-  (#3887)
+  explicitly, naming `gc doctor --fix` (which performs the removal) so
+  operators check pack compatibility before running it. (#3887)
 
 - **The dolt pack's `run_bounded` python3 fallback now sends SIGTERM before
   SIGKILL, matching its documented contract.** The fallback (used when

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -83,7 +83,7 @@ func legacyWorkspaceIdentitySurfaceWarnings(cfg *City, source string) []string {
 	if len(workspaceFields) > 0 {
 		warnings = append(warnings, fmt.Sprintf(
 			"%s: %s (%s); move them to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; fragments must be updated by hand). "+
-				"Some installed packs pinned to an older revision may still read these fields directly instead of .gc/site.toml -- confirm pack "+
+				"Some installed packs pinned to an older revision may still read these fields directly instead of .gc/site.toml — confirm pack "+
 				"compatibility before running `gc doctor --fix` or removing these fields by hand, or routing/identity that depends on "+
 				"workspace identity may silently stop working",
 			source,

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -84,7 +84,8 @@ func legacyWorkspaceIdentitySurfaceWarnings(cfg *City, source string) []string {
 		warnings = append(warnings, fmt.Sprintf(
 			"%s: %s (%s); move them to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; fragments must be updated by hand). "+
 				"Some installed packs pinned to an older revision may still read these fields directly instead of .gc/site.toml -- confirm pack "+
-				"compatibility before removing them, or routing/identity that depends on workspace identity may silently stop working",
+				"compatibility before running `gc doctor --fix` or removing these fields by hand, or routing/identity that depends on "+
+				"workspace identity may silently stop working",
 			source,
 			legacyWorkspaceIdentityWarningFragment,
 			strings.Join(workspaceFields, ", "),

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -82,7 +82,9 @@ func legacyWorkspaceIdentitySurfaceWarnings(cfg *City, source string) []string {
 	}
 	if len(workspaceFields) > 0 {
 		warnings = append(warnings, fmt.Sprintf(
-			"%s: %s (%s); move them to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; fragments must be updated by hand)",
+			"%s: %s (%s); move them to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; fragments must be updated by hand). "+
+				"Some installed packs pinned to an older revision may still read these fields directly instead of .gc/site.toml -- confirm pack "+
+				"compatibility before removing them, or routing/identity that depends on workspace identity may silently stop working",
 			source,
 			legacyWorkspaceIdentityWarningFragment,
 			strings.Join(workspaceFields, ", "),

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -512,6 +512,9 @@ func TestLegacyWorkspaceIdentityWarningCaveatsPackCompatibility(t *testing.T) {
 	if !strings.Contains(warnings[0], "pinned to an older revision may still read") {
 		t.Fatalf("warning = %q, want a pack-compatibility caveat", warnings[0])
 	}
+	if !strings.Contains(warnings[0], "confirm pack compatibility before running `gc doctor --fix`") {
+		t.Fatalf("warning = %q, want the caveat to name `gc doctor --fix`, which itself removes the fields", warnings[0])
+	}
 }
 
 func TestLoadWithIncludes_RejectsLegacyRigPathInSchema2City(t *testing.T) {

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -497,6 +497,23 @@ path = "/legacy/frontend"
 	}
 }
 
+func TestLegacyWorkspaceIdentityWarningCaveatsPackCompatibility(t *testing.T) {
+	// #3887: an operator who strips workspace.name/workspace.prefix from
+	// city.toml on this hint alone can silently break any installed pack still
+	// pinned to a revision that reads those fields directly instead of
+	// .gc/site.toml (observed: inbound Discord messages eaten for ~2 days with
+	// zero alarms). The warning must caveat that risk so operators check pack
+	// compatibility before acting on it.
+	cfg := &City{Workspace: Workspace{Name: "legacy-city"}}
+	warnings := legacyWorkspaceIdentitySurfaceWarnings(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one workspace identity warning", warnings)
+	}
+	if !strings.Contains(warnings[0], "pinned to an older revision may still read") {
+		t.Fatalf("warning = %q, want a pack-compatibility caveat", warnings[0])
+	}
+}
+
 func TestLoadWithIncludes_RejectsLegacyRigPathInSchema2City(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`


### PR DESCRIPTION
## Summary
Addresses the first of #3887's two asks: the workspace-identity deprecation hint told operators to remove `workspace.name` (and related fields) from `city.toml` with no signal that a pack pinned to an older revision might still read those fields directly instead of `.gc/site.toml` — following the hint alone could silently break routing/identity for a consumer like Discord.

## Fix
`internal/config/site_binding.go`'s `legacyWorkspaceIdentitySurfaceWarnings` now appends a caveat sentence to the existing deprecation message, kept pack-agnostic (no hardcoded pack names/versions):

> "... Some installed packs pinned to an older revision may still read these fields directly instead of `.gc/site.toml` -- confirm pack compatibility before removing them, or routing/identity that depends on workspace identity may silently stop working"

## Scope note
#3887's second ask — a sequence-aware `doctor --fix` that detects installed packs' pinned revisions and skips/warns per-pack — would require this core config package to hardcode knowledge of specific downstream packs' version histories, which is a layering violation per this repo's own core/pack boundary rules (`AGENTS.md`: "Do not bury... pack-specific assumptions in generic SDK paths"). That needs either a maintainer-designed pack-declared-compat mechanism or an explicit decision to accept the layering cost — not attempted here.

## Test plan
- [x] New test `TestLegacyWorkspaceIdentityWarningCaveatsPackCompatibility` — confirmed red before the fix, green after.
- [x] Full existing warning-assertion set green (`TestLegacySiteBindingSurfaceErrorAggregatesViolations`, `TestLoadWithIncludes_WarnsOnLegacyWorkspaceIdentityInSchema2City`, `TestLoadWithIncludes_WarnsOnLegacyWorkspaceIdentityInSchema2Fragments`, `TestLoadWithIncludes_AppliesWorkspaceIdentitySiteBinding`) — all match on `strings.Contains`, none broke on the appended text.
- [x] Full `internal/config` suite green, `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
