### PR TITLE
Normalize configured city and rig paths at ingest

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1307,7 +1307,7 @@ func bdRuntimeEnvForRigWithErrorRecovery(cityPath string, cfg *config.City, rigP
 
 func bdRuntimeEnvForRigWithErrorRecoveryContext(ctx context.Context, cityPath string, cfg *config.City, rigPath string, allowRecovery bool) (map[string]string, error) {
 	env, cityErr := bdRuntimeEnvWithErrorRecoveryContext(ctx, cityPath, allowRecovery)
-	rigPath = filepath.Clean(rigPath)
+	rigPath = normalizePathForCompare(rigPath)
 	// Pin the rig store explicitly. The gc-beads-bd provider derives its Dolt
 	// data root from GC_CITY_PATH unless BEADS_DIR is set, so cwd-based
 	// discovery is not sufficient for rig-scoped operations.

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -351,6 +351,41 @@ func TestBdRuntimeEnvNoRecoveryMatchesRecoveryForExternalTarget(t *testing.T) {
 	}
 }
 
+// TestBdRuntimeEnvForRigResolvesSymlinkAlias pins ga-iawy13.8: GC_RIG_ROOT
+// and BEADS_DIR must canonicalize a symlink-alias rig path the same way
+// findCity canonicalizes city paths, not just filepath.Clean it. BEADS_DIR
+// and GC_RIG_ROOT are set unconditionally before any dolt/backend branching,
+// so the error return is deliberately ignored here -- only the two env
+// values are under test.
+func TestBdRuntimeEnvForRigResolvesSymlinkAlias(t *testing.T) {
+	root := t.TempDir()
+	realRoot := filepath.Join(root, "real")
+	rigPath := filepath.Join(realRoot, "repo")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := filepath.Join(root, "alias")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlink setup unavailable: %v", err)
+	}
+	aliasRigPath := filepath.Join(aliasRoot, "repo")
+
+	cityPath := t.TempDir()
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: rigPath}}}
+	env, err := bdRuntimeEnvForRigWithError(cityPath, cfg, aliasRigPath)
+	if err != nil {
+		t.Logf("bdRuntimeEnvForRigWithError() error = %v (ignored; BEADS_DIR/GC_RIG_ROOT are set before backend resolution)", err)
+	}
+
+	wantBeadsDir := filepath.Join(rigPath, ".beads")
+	if env["BEADS_DIR"] != wantBeadsDir {
+		t.Errorf("BEADS_DIR = %q, want canonical %q (must resolve the symlink alias, not just Clean it)", env["BEADS_DIR"], wantBeadsDir)
+	}
+	if env["GC_RIG_ROOT"] != rigPath {
+		t.Errorf("GC_RIG_ROOT = %q, want canonical %q (must resolve the symlink alias, not just Clean it)", env["GC_RIG_ROOT"], rigPath)
+	}
+}
+
 // TestBdRuntimeEnvForRigNoRecoveryMatchesRecoveryForExternalTarget is
 // TestBdRuntimeEnvNoRecoveryMatchesRecoveryForExternalTarget for the
 // rig-scoped resolver.

--- a/cmd/gc/city_arg_resolve_test.go
+++ b/cmd/gc/city_arg_resolve_test.go
@@ -337,6 +337,80 @@ func TestResolveCityFlagValueByName(t *testing.T) {
 	}
 }
 
+// makeCitySymlinkAliasFixture creates a real city directory plus a sibling
+// symlink alias to its parent, mirroring makeRigSymlinkAliasFixture in
+// main_test.go. Returns the canonical city path and an alias path that
+// reaches the same city through a symlinked ancestor.
+func makeCitySymlinkAliasFixture(t *testing.T) (cityPath, aliasCityPath string) {
+	t.Helper()
+
+	root := t.TempDir()
+	realRoot := filepath.Join(root, "real")
+	cityPath = filepath.Join(realRoot, "my-city")
+	mkTestCity(t, cityPath)
+	aliasRoot := filepath.Join(root, "alias")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlink setup unavailable: %v", err)
+	}
+	return cityPath, filepath.Join(aliasRoot, "my-city")
+}
+
+// TestResolveCityFlagValueResolvesSymlinkAlias pins ga-iawy13.8: --city must
+// canonicalize a symlink-alias path to the same value findCity would produce
+// from cwd discovery, not just filepath.Abs it. Deliberately compares with
+// raw == (not samePath, which normalizes both sides and would pass even
+// against the un-normalized result).
+func TestResolveCityFlagValueResolvesSymlinkAlias(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cityPath, aliasCityPath := makeCitySymlinkAliasFixture(t)
+
+	got, err := resolveCityFlagValue(aliasCityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != cityPath {
+		t.Fatalf("resolveCityFlagValue(%q) = %q, want canonical %q (must resolve the symlink alias, not just Abs it)", aliasCityPath, got, cityPath)
+	}
+}
+
+// TestResolveExplicitCityPathEnvResolvesSymlinkAlias pins ga-iawy13.8 for the
+// GC_CITY_PATH env ingest point (path-only, so it exercises validateCityPath
+// directly without registry name resolution).
+func TestResolveExplicitCityPathEnvResolvesSymlinkAlias(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cityPath, aliasCityPath := makeCitySymlinkAliasFixture(t)
+
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", aliasCityPath)
+	t.Setenv("GC_CITY_ROOT", "")
+
+	got, ok := resolveExplicitCityPathEnv()
+	if !ok {
+		t.Fatal("resolveExplicitCityPathEnv() ok = false, want true")
+	}
+	if got != cityPath {
+		t.Fatalf("resolveExplicitCityPathEnv() via GC_CITY_PATH = %q, want canonical %q (must resolve the symlink alias, not just Abs it)", got, cityPath)
+	}
+}
+
+// TestResolveCommandContextPathArgResolvesSymlinkAlias pins ga-iawy13.8 for
+// the bare positional city/rig path argument (resolveContextFromPath's
+// direct HasCityConfig branch), which currently returns the raw Abs'd alias
+// path instead of canonicalizing like its sibling branches (findCity,
+// resolveRigPathToContext) already do.
+func TestResolveCommandContextPathArgResolvesSymlinkAlias(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cityPath, aliasCityPath := makeCitySymlinkAliasFixture(t)
+
+	ctx, err := resolveCommandContext([]string{aliasCityPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.CityPath != cityPath {
+		t.Fatalf("resolveCommandContext([%q]).CityPath = %q, want canonical %q (must resolve the symlink alias, not just Abs it)", aliasCityPath, ctx.CityPath, cityPath)
+	}
+}
+
 func TestResolveExplicitCityPathEnvByName(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	t.Chdir(t.TempDir())

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -735,10 +735,7 @@ func resolveCity() (string, error) {
 }
 
 func resolveContextFromPath(path string) (resolvedContext, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return resolvedContext{}, err
-	}
+	abs := normalizePathForCompare(path)
 	// Validate the explicit target directly before scanning the registry for
 	// rig bindings. An unrelated registered city with a broken/stale config
 	// must not abort resolution of a perfectly healthy explicit target
@@ -778,10 +775,7 @@ func resolveContextFromPath(path string) (resolvedContext, error) {
 
 // validateCityPath resolves and validates a path as a city directory.
 func validateCityPath(p string) (string, error) {
-	abs, err := filepath.Abs(p)
-	if err != nil {
-		return "", err
-	}
+	abs := normalizePathForCompare(p)
 	if citylayout.HasCityConfig(abs) || citylayout.HasRuntimeRoot(abs) {
 		return abs, nil
 	}

--- a/release-gates/ga-jx0gqf-normalize-configured-paths-gate.md
+++ b/release-gates/ga-jx0gqf-normalize-configured-paths-gate.md
@@ -1,0 +1,66 @@
+# Release gate: normalize configured city and rig paths at ingest
+
+- Deploy bead: `ga-jx0gqf`
+- Build bead: `ga-iawy13.8`
+- Source review: `ga-lb56pa`
+- Reviewed commit: `5dc166233f37aff9817be18c7a38a33b70e1ebd5`
+- Reviewed base: `2ff1536d9b014ea9728f46bbe7ece6f3378d76ad`
+- Main evaluated: `origin/main@1f948e67b0ac088492af67c0748f521aad5768b0`
+- Deploy branch: `deploy/ga-jx0gqf-gate`
+- Evaluated: `2026-08-03T18:16:05Z`
+- Overall verdict: **PASS**
+
+`docs/PROJECT_MANIFEST.md` is not present at the evaluated commit, so this
+checklist applies the deployer role's release-gate criteria together with
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 6 | Branch diverges cleanly from main | **PASS** | Checked first and rechecked after tests. `git merge-tree --write-tree origin/main 5dc166233f37aff9817be18c7a38a33b70e1ebd5` exited 0 against `origin/main@1f948e67b0ac088492af67c0748f521aad5768b0` and produced tree `6e80d2f2ce92899e47d232c6b12815253142242a`. The reviewed SHA remained the deploy source; no remote source branch was changed. |
+| 1 | Review PASS present | **PASS** | Review bead `ga-lb56pa` is closed with reason `pass` for exact commit `5dc166233f37aff9817be18c7a38a33b70e1ebd5`. The review records `verdict: pass`, no style findings, and no blocking security or correctness findings. |
+| 2 | Acceptance criteria met | **PASS** | Nine focused tests passed, 0 failed, 0 skipped. The four TDD regressions prove symlink-ancestor convergence for `--city`, `GC_CITY_PATH`, positional city/rig paths, and the `GC_RIG_ROOT`/`BEADS_DIR` projection. Existing passing contracts cover relative/local city input and source precedence, missing leaves through `pathutil.NormalizePathForCompare`, and contextual unknown-city errors. The three production changes replace inconsistent `Abs`/`Clean` ingest with the shared normalizer; no schema, flag, environment-variable, or API contract changes. The build/review notes inventory `city.toml`, `--city`, `--rig`, `GC_CITY*`, and `GC_RIG_ROOT`, and verify already-canonical or out-of-increment seams rather than adding duplicate downstream normalization. |
+| 3 | Tests pass | **PASS** | On the exact reviewed SHA, `go build ./...`, `go vet ./...`, `gofmt -l` on all four changed files, and `git diff --check` passed. `make test-fast-parallel` passed 10/10 jobs (0 fail, 0 skip). The documented non-short CLI lane ran with `GC_FAST_UNIT=0` and the checksum-pinned CI `bd` archive: 15,362 PASS, 0 FAIL, 11 SKIP; the skips are helper-only, platform/opt-in, optional-pack, or ambient-CWD fallback cases, and none exercises the migrated explicit-ingest branches. The product-metrics testhook passed 12, failed 0, skipped 0. Worker phase 2 passed 26/26 requirements for each of Claude, Codex, and Gemini (78 PASS, 0 FAIL, 0 unsupported). Focused acceptance coverage passed 9/9. The PR integration smoke/core/cmd-gc/bdstore jobs and an isolated review-formula retry passed. The broad local RC stress sweep additionally exposed unchanged host-only limitations: tmux 3.7b does not return builtin key bindings without a server, and five `rest-full` shards timed out waiting for supervisors during the 29-way run. Those are outside the four-file diff; the exact merge-base CI run [30826419301](https://github.com/gastownhall/gascity/actions/runs/30826419301) and current-main CI run [30833610783](https://github.com/gastownhall/gascity/actions/runs/30833610783) passed the corresponding lanes. |
+| 4 | No high-severity review findings open | **PASS** | The reviewer reports no blocker or major style, correctness, or security findings. The only informational note is the shared normalizer's pre-existing best-effort fallback if `filepath.Abs` cannot resolve a relative path. Unresolved HIGH/CRITICAL findings: 0. |
+| 5 | Final branch is clean | **PASS** | The detached reviewed commit had an empty `git status --short` before this checklist was added. `git diff --check 2ff1536d9b014ea9728f46bbe7ece6f3378d76ad..5dc166233f37aff9817be18c7a38a33b70e1ebd5` passed, and `core.hooksPath` is `.githooks`. This checklist is the only deployer-authored release commit. |
+| 7 | Single feature theme | **PASS** | The two-commit TDD set changes four files in `cmd/gc` (+112/-9), all for one behavior: canonicalizing configured city and rig paths once at their CLI/environment ingest boundaries. No independent feature is bundled. |
+
+## Acceptance evidence
+
+| Surface | Owning boundary | Evidence |
+|---|---|---|
+| `--city`, `GC_CITY`, `GC_CITY_PATH`, `GC_CITY_ROOT` | `validateCityPath` | `TestResolveCityFlagValueResolvesSymlinkAlias`, `TestResolveExplicitCityPathEnvResolvesSymlinkAlias` |
+| Positional city/rig path | `resolveContextFromPath` | `TestResolveCommandContextPathArgResolvesSymlinkAlias` |
+| `GC_RIG_ROOT`, `BEADS_DIR` | `bdRuntimeEnvForRigWithErrorRecoveryContext` | `TestBdRuntimeEnvForRigResolvesSymlinkAlias` |
+| Relative/local input and source precedence | Existing city reference resolver | `TestNormalizePathForCompare`, `TestResolveExplicitCityPathEnvLocalWinsOverRegistration` |
+| Missing leaf under a symlinked ancestor | Shared `pathutil` normalizer | `TestNormalizePathForCompareResolvesSymlinkAncestorForMissingLeaf` |
+| Contextual invalid-city error | Existing city reference resolver | `TestResolveCityRefNameNoMatchLoudError` |
+
+## Review notes
+
+- This is internal path canonicalization only. It adds no configuration fields,
+  flags, environment variables, endpoints, migrations, or dependencies.
+- `--rig` and `city.toml` paths already converge through their existing
+  normalized registry/config boundaries; this increment fixes only the three
+  proven gaps whose raw string values could escape.
+- The diff replaces three local `filepath.Abs`/`filepath.Clean` operations with
+  the existing `normalizePathForCompare` wrapper. It does not add another
+  normalization mechanism.
+
+## Commands
+
+```bash
+git fetch origin main
+git merge-tree --write-tree origin/main 5dc166233f37aff9817be18c7a38a33b70e1ebd5
+git diff --check 2ff1536d9b014ea9728f46bbe7ece6f3378d76ad..5dc166233f37aff9817be18c7a38a33b70e1ebd5
+gofmt -l cmd/gc/bd_env.go cmd/gc/bd_env_test.go cmd/gc/city_arg_resolve_test.go cmd/gc/main.go
+go build ./...
+go vet ./...
+make test-fast-parallel
+GC_FAST_UNIT=0 scripts/go-test-observable gate-cmd-gc-process -- -timeout 25m ./cmd/gc
+make test-productmetrics-testhook
+make test-worker-core-phase2-all PROFILE=claude/tmux-cli
+make test-worker-core-phase2-all PROFILE=codex/tmux-cli
+make test-worker-core-phase2-all PROFILE=gemini/tmux-cli
+go test -count=1 -v ./internal/pathutil ./cmd/gc -run '<focused acceptance regex>'
+make test-integration-shards-parallel
+```


### PR DESCRIPTION
## What this changes

Gas City now canonicalizes explicit city and rig paths as they enter `gc`. Paths supplied through `--city`, `GC_CITY`/`GC_CITY_PATH`/`GC_CITY_ROOT`, positional city or rig arguments, and the rig-scoped `GC_RIG_ROOT`/`BEADS_DIR` environment now resolve symlinked ancestors to the same absolute path used by discovery.

This prevents one physical city or rig from acquiring different string identities depending on whether an operator uses its real path or a symlink alias. Missing leaf paths retain the existing longest-ancestor normalization behavior. CLI flags, environment-variable contracts, configuration schemas, and ordinary non-symlinked paths are unchanged.

## Review notes

- The implementation reuses the existing `normalizePathForCompare` boundary helper; it does not introduce another canonicalization mechanism.
- The production diff is limited to three ingest points in `cmd/gc/main.go` and `cmd/gc/bd_env.go`, with focused regressions alongside them.
- `--rig` and `city.toml` paths already converge through their normalized registry/config paths, so those flows are intentionally unchanged.
- There is no migration, new default, endpoint, dependency, or wire-format change.

## Test plan

- [x] Focused symlink, relative-input, missing-leaf, precedence, and contextual-error contracts: 9 pass, 0 fail, 0 skip
- [x] `make test-fast-parallel`: 10/10 jobs pass
- [x] Non-short `cmd/gc` process lane with the CI-pinned `bd`: 15,362 pass, 0 fail; 11 documented helper/platform/opt-in skips
- [x] Worker phase-2 conformance for Claude, Codex, and Gemini: 78/78 requirements pass
- [x] `go build ./...` and `go vet ./...`
- [x] Release gate: [`release-gates/ga-jx0gqf-normalize-configured-paths-gate.md`](release-gates/ga-jx0gqf-normalize-configured-paths-gate.md)
