### PR TITLE
fix(events): scope exports by registered city

### DIFF
--- a/cmd/gc/city_registry.go
+++ b/cmd/gc/city_registry.go
@@ -299,11 +299,12 @@ func (r *cityRegistry) TransientCityEventProviders() map[string]events.Provider 
 		if v == nil || v.Started {
 			continue
 		}
-		name := v.Name
-		if registeredName, ok := registeredNamesByPath[pathutil.NormalizePathForCompare(v.Path)]; ok {
-			name = registeredName
-		} else if name == "" {
-			name = filepath.Base(v.Path)
+		name, registered := registeredNamesByPath[pathutil.NormalizePathForCompare(v.Path)]
+		if !registered {
+			name = v.Name
+			if name == "" || snap.byName[name] != v {
+				continue
+			}
 		}
 		paths[name] = v.Path
 	}

--- a/cmd/gc/city_registry.go
+++ b/cmd/gc/city_registry.go
@@ -63,11 +63,16 @@ type cityRegistry struct {
 	initStatus           map[string]cityInitProgress
 	initFailures         map[string]*initFailRecord
 	panicHistory         map[string]*panicRecord
-	pendingRequestIDs    map[string]string    // city path → request_id for async correlation
-	recentlyUnregistered map[string]time.Time // city path → unregister time (grace period for event delivery)
-	supervisorRecorder   events.Recorder      // supervisor-level event recorder for city lifecycle events
+	pendingRequestIDs    map[string]string                   // city path → request_id for async correlation
+	recentlyUnregistered map[string]recentlyUnregisteredCity // city path → stable name and unregister time
+	supervisorRecorder   events.Recorder                     // supervisor-level event recorder for city lifecycle events
 
 	gen uint64 // monotonic generation counter
+}
+
+type recentlyUnregisteredCity struct {
+	name           string
+	unregisteredAt time.Time
 }
 
 // newCityRegistry creates a registry initialized with an empty snapshot.
@@ -78,7 +83,7 @@ func newCityRegistry() *cityRegistry {
 		initFailures:         make(map[string]*initFailRecord),
 		panicHistory:         make(map[string]*panicRecord),
 		pendingRequestIDs:    make(map[string]string),
-		recentlyUnregistered: make(map[string]time.Time),
+		recentlyUnregistered: make(map[string]recentlyUnregisteredCity),
 	}
 	// Initialize with empty snapshot to prevent nil-dereference panic
 	// if an API request arrives before the first reconciliation tick.
@@ -155,7 +160,11 @@ func (r *cityRegistry) SupervisorEventRecorder() events.Recorder {
 func (r *cityRegistry) MarkRecentlyUnregistered(cityPath string) {
 	r.citiesMu.Lock()
 	defer r.citiesMu.Unlock()
-	r.recentlyUnregistered[cityPath] = time.Now()
+	name := filepath.Base(cityPath)
+	if v, ok := r.snap.Load().byPath[cityPath]; ok && v.Name != "" {
+		name = v.Name
+	}
+	r.recentlyUnregistered[cityPath] = recentlyUnregisteredCity{name: name, unregisteredAt: time.Now()}
 }
 
 const recentlyUnregisteredGrace = 2 * time.Minute
@@ -275,6 +284,15 @@ func (r *cityRegistry) Snapshot() *citySnapshot {
 // simply skipped.
 func (r *cityRegistry) TransientCityEventProviders() map[string]events.Provider {
 	snap := r.snap.Load()
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	entries, registryErr := reg.List()
+	registeredNamesByPath := make(map[string]string, len(entries))
+	if registryErr == nil {
+		for _, e := range entries {
+			registeredNamesByPath[pathutil.NormalizePathForCompare(e.Path)] = e.EffectiveName()
+		}
+	}
+
 	// Collect non-Running cities known to the runtime registry.
 	paths := make(map[string]string, len(snap.all))
 	for _, v := range snap.all {
@@ -282,7 +300,9 @@ func (r *cityRegistry) TransientCityEventProviders() map[string]events.Provider 
 			continue
 		}
 		name := v.Name
-		if name == "" {
+		if registeredName, ok := registeredNamesByPath[pathutil.NormalizePathForCompare(v.Path)]; ok {
+			name = registeredName
+		} else if name == "" {
 			name = filepath.Base(v.Path)
 		}
 		paths[name] = v.Path
@@ -297,8 +317,7 @@ func (r *cityRegistry) TransientCityEventProviders() map[string]events.Provider 
 			running[name] = struct{}{}
 		}
 	}
-	reg := supervisor.NewRegistry(supervisor.RegistryPath())
-	if entries, err := reg.List(); err == nil {
+	if registryErr == nil {
 		for _, e := range entries {
 			name := e.EffectiveName()
 			if _, already := running[name]; already {
@@ -315,12 +334,15 @@ func (r *cityRegistry) TransientCityEventProviders() map[string]events.Provider 
 	// observe completion events after the city leaves the registry.
 	r.citiesMu.Lock()
 	now := time.Now()
-	for path, ts := range r.recentlyUnregistered {
-		if now.Sub(ts) > recentlyUnregisteredGrace {
+	for path, city := range r.recentlyUnregistered {
+		if now.Sub(city.unregisteredAt) > recentlyUnregisteredGrace {
 			delete(r.recentlyUnregistered, path)
 			continue
 		}
-		name := filepath.Base(path)
+		name := city.name
+		if name == "" {
+			name = filepath.Base(path)
+		}
 		if _, already := running[name]; already {
 			continue
 		}

--- a/cmd/gc/event_export.go
+++ b/cmd/gc/event_export.go
@@ -110,7 +110,7 @@ func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers
 	// not leave sidecars writing .gcmeta files that imply an event stream exists.
 	transcriptmeta.SetEnabled(true)
 
-	src := eventfeed.NewMuxSource(providers, exp.Cursors, muxRebuildInterval, logf)
+	src := eventfeed.NewMuxSource(exportProvidersForCities(providers, ec.Cities), exp.Cursors, muxRebuildInterval, logf)
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() { defer wg.Done(); _ = exp.Run(ctx, src) }()
@@ -118,6 +118,33 @@ func startEventExport(ctx context.Context, ec supervisor.ExportConfig, providers
 
 	logf("enabled -> %s (envelope-only metadata; no payloads leave the box)", ec.Endpoint)
 	return &wg
+}
+
+// exportProvidersForCities restricts a dynamic provider source to the exact
+// configured city names. A nil city list preserves the existing all-city
+// behavior; every non-nil list is restrictive, including an empty list or one
+// containing only invalid names.
+func exportProvidersForCities(providers func() map[string]events.Provider, cities []string) func() map[string]events.Provider {
+	if cities == nil {
+		return providers
+	}
+
+	allowed := make(map[string]struct{}, len(cities))
+	for _, city := range cities {
+		if supervisor.IsValidCityName(city) {
+			allowed[city] = struct{}{}
+		}
+	}
+	return func() map[string]events.Provider {
+		available := providers()
+		filtered := make(map[string]events.Provider, len(allowed))
+		for city, provider := range available {
+			if _, ok := allowed[city]; ok {
+				filtered[city] = provider
+			}
+		}
+		return filtered
+	}
 }
 
 // persistExportCursors snapshots the exporter cursor to disk periodically and on

--- a/cmd/gc/event_export_test.go
+++ b/cmd/gc/event_export_test.go
@@ -80,6 +80,34 @@ func TestExportProvidersForCitiesFiltersDynamicProviders(t *testing.T) {
 	}
 }
 
+func TestExportProvidersForCitiesExcludesRegisteredAliasAfterInitFailure(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := writeCityEventLog(t, "north")
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := newCityRegistry()
+	providers := exportProvidersForCities(registry.TransientCityEventProviders, []string{"north"})
+	if got := providers(); len(got) != 0 {
+		t.Fatalf("registry-only providers = %#v, want no matching configured city", got)
+	}
+
+	registry.BatchUpdate(func(
+		_ map[string]*managedCity,
+		_ map[string]cityInitProgress,
+		initFailures map[string]*initFailRecord,
+		_ map[string]*panicRecord,
+	) {
+		initFailures[cityPath] = &initFailRecord{lastError: "test failure"}
+	})
+
+	if got := providers(); len(got) != 0 {
+		t.Fatalf("providers after init failure = %#v, want no matching configured city", got)
+	}
+}
+
 // TestResolveExportCredentials_EmptyTokenFileErrors proves a configured but
 // empty (or whitespace-only) token_file fails closed: the provider returns an
 // error so the cursor holds and the empty credential surfaces, instead of

--- a/cmd/gc/event_export_test.go
+++ b/cmd/gc/event_export_test.go
@@ -5,12 +5,80 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/transcriptmeta"
 )
+
+func TestExportProvidersForCities(t *testing.T) {
+	north := events.NewFake()
+	south := events.NewFake()
+	invalid := events.NewFake()
+	providers := map[string]events.Provider{
+		"north":    north,
+		"south":    south,
+		"bad/name": invalid,
+	}
+	source := func() map[string]events.Provider {
+		result := make(map[string]events.Provider, len(providers))
+		for city, provider := range providers {
+			result[city] = provider
+		}
+		return result
+	}
+
+	tests := []struct {
+		name   string
+		cities []string
+		want   []string
+	}{
+		{name: "omitted cities keeps every provider", want: []string{"bad/name", "north", "south"}},
+		{name: "explicit empty exports no providers", cities: []string{}, want: []string{}},
+		{name: "only blank and invalid names export no providers", cities: []string{"", "  ", "bad/name"}, want: []string{}},
+		{name: "selects exact configured names only", cities: []string{"north", " south ", "bad/name"}, want: []string{"north"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := exportProvidersForCities(source, tt.cities)
+			got := filtered()
+			names := make([]string, 0, len(got))
+			for city := range got {
+				names = append(names, city)
+			}
+			slices.Sort(names)
+			if !slices.Equal(names, tt.want) {
+				t.Fatalf("provider names = %v, want %v", names, tt.want)
+			}
+		})
+	}
+}
+
+func TestExportProvidersForCitiesFiltersDynamicProviders(t *testing.T) {
+	north := events.NewFake()
+	south := events.NewFake()
+	providers := map[string]events.Provider{"north": north}
+	source := func() map[string]events.Provider {
+		result := make(map[string]events.Provider, len(providers))
+		for city, provider := range providers {
+			result[city] = provider
+		}
+		return result
+	}
+
+	filtered := exportProvidersForCities(source, []string{"north"})
+	if got := filtered(); len(got) != 1 || got["north"] != north {
+		t.Fatalf("initial providers = %#v, want north only", got)
+	}
+
+	providers["south"] = south
+	if got := filtered(); len(got) != 1 || got["north"] != north {
+		t.Fatalf("providers after dynamic update = %#v, want north only", got)
+	}
+}
 
 // TestResolveExportCredentials_EmptyTokenFileErrors proves a configured but
 // empty (or whitespace-only) token_file fails closed: the provider returns an

--- a/cmd/gc/event_export_test.go
+++ b/cmd/gc/event_export_test.go
@@ -108,6 +108,57 @@ func TestExportProvidersForCitiesExcludesRegisteredAliasAfterInitFailure(t *test
 	}
 }
 
+func TestExportProvidersForCitiesFailsClosedOnInitFailureWhenRegistryMalformed(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := writeCityEventLog(t, "north")
+	registryFile := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := registryFile.Register(cityPath, "secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(supervisor.RegistryPath(), []byte("[[cities]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registryFile.List(); err == nil {
+		t.Fatal("malformed supervisor registry unexpectedly loaded")
+	}
+
+	registry := newCityRegistry()
+	registry.BatchUpdate(func(
+		_ map[string]*managedCity,
+		_ map[string]cityInitProgress,
+		initFailures map[string]*initFailRecord,
+		_ map[string]*panicRecord,
+	) {
+		initFailures[cityPath] = &initFailRecord{lastError: "test failure"}
+	})
+
+	providers := exportProvidersForCities(registry.TransientCityEventProviders, []string{"north"})
+	if got := providers(); len(got) != 0 {
+		t.Fatalf("providers with malformed registry = %#v, want no matching configured city", got)
+	}
+}
+
+func TestExportProvidersForCitiesExcludesUnregisteredInitFailureBasename(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := writeCityEventLog(t, "north")
+	registry := newCityRegistry()
+	registry.BatchUpdate(func(
+		_ map[string]*managedCity,
+		_ map[string]cityInitProgress,
+		initFailures map[string]*initFailRecord,
+		_ map[string]*panicRecord,
+	) {
+		initFailures[cityPath] = &initFailRecord{lastError: "test failure"}
+	})
+
+	providers := exportProvidersForCities(registry.TransientCityEventProviders, []string{"north"})
+	if got := providers(); len(got) != 0 {
+		t.Fatalf("unregistered failure providers = %#v, want no matching configured city", got)
+	}
+}
+
 // TestResolveExportCredentials_EmptyTokenFileErrors proves a configured but
 // empty (or whitespace-only) token_file fails closed: the provider returns an
 // error so the cursor holds and the empty credential surfaces, instead of

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -85,6 +85,10 @@ type EventsSection struct {
 type ExportConfig struct {
 	// Endpoint is the HTTP URL that receives batched, envelope-only events.
 	Endpoint string `toml:"endpoint,omitempty"`
+	// Cities optionally restricts export to exact registered city names. A nil
+	// slice preserves the all-city default; an explicitly empty slice exports no
+	// city events.
+	Cities []string `toml:"cities,omitempty"`
 	// Token, when set, is sent as an Authorization: Bearer header.
 	Token string `toml:"token,omitempty"`
 	// TokenFile, when set, is a path to a file holding the bearer token. It is

--- a/internal/supervisor/config_test.go
+++ b/internal/supervisor/config_test.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -157,6 +158,62 @@ policy_ref = "platform-sso"
 	}
 	if cfg.Publication.TenantAuth.PolicyRef != "platform-sso" {
 		t.Errorf("Publication.TenantAuth.PolicyRef = %q, want platform-sso", cfg.Publication.TenantAuth.PolicyRef)
+	}
+}
+
+func TestLoadConfigEventExportCities(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		wantNil  bool
+		want     []string
+	}{
+		{
+			name: "omitted preserves all-city default",
+			contents: `
+[events.export]
+endpoint = "https://example.invalid/ingest"
+`,
+			wantNil: true,
+		},
+		{
+			name: "explicit empty is retained",
+			contents: `
+[events.export]
+endpoint = "https://example.invalid/ingest"
+cities = []
+`,
+			want: []string{},
+		},
+		{
+			name: "configured names retain exact spelling and order",
+			contents: `
+[events.export]
+endpoint = "https://example.invalid/ingest"
+cities = ["north", " south "]
+`,
+			want: []string{"north", " south "},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "supervisor.toml")
+			if err := os.WriteFile(path, []byte(tt.contents), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := LoadConfig(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (cfg.Events.Export.Cities == nil) != tt.wantNil {
+				t.Fatalf("Cities nil = %t, want %t", cfg.Events.Export.Cities == nil, tt.wantNil)
+			}
+			if got := cfg.Events.Export.Cities; !slices.Equal(got, tt.want) {
+				t.Fatalf("Cities = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an optional exact city allowlist for event export
- preserve each registered city identity across dynamic provider rebuilds
- fail closed when a transient identity cannot be resolved safely

## Behavior

An omitted allowlist keeps the existing all-city behavior. An explicit empty or nonmatching allowlist exports nothing.

## Verification

- TDD coverage for omitted, empty, matching, nonmatching, rebuild, and failure paths
- focused package tests and vet passed
- mandatory pre-push fast test shards passed