### PR TITLE
feat(doctor): gate bulk deletes on fresh backups

### DIFF
--- a/internal/doctor/checks_bd_backup_freshness.go
+++ b/internal/doctor/checks_bd_backup_freshness.go
@@ -163,12 +163,9 @@ func (c *BdBackupFreshnessCheck) freshnessScanTargets() []bdBackupFreshnessTarge
 // configured" is DoltBackupCheck's concern, and failing closed there would
 // block bulk deletion on every unbacked city.
 func BulkDeleteSafe(cityPath string, cfg *config.City, maxAge time.Duration, now time.Time) (bool, string) {
-	scopeRoots := managedDoltScopeRootsForConfig(cityPath, cfg, nil)
-	for _, scopeRoot := range scopeRoots {
-		scopeRoot = filepath.Clean(scopeRoot)
-		label := bdBackupScopeLabel(cityPath, scopeRoot)
-		beadsDir := filepath.Join(scopeRoot, ".beads")
-		if finding, ok := scanBackupFreshness(label, beadsDir, now, maxAge); ok {
+	check := NewBdBackupFreshnessCheckForConfig(cityPath, cfg, nil)
+	for _, target := range check.freshnessScanTargets() {
+		if finding, ok := scanBackupFreshness(target.Label, target.BeadsDir, now, maxAge); ok {
 			return false, finding
 		}
 	}

--- a/internal/doctor/checks_bd_backup_freshness.go
+++ b/internal/doctor/checks_bd_backup_freshness.go
@@ -143,6 +143,38 @@ func (c *BdBackupFreshnessCheck) freshnessScanTargets() []bdBackupFreshnessTarge
 	return targets
 }
 
+// BulkDeleteSafe reports whether it is safe to perform a bulk bead deletion
+// given the current backup freshness across all managed scopes. It returns
+// safe=false and a human-readable reason as soon as one managed scope's ACTIVE
+// backup pipeline is not demonstrably current.
+//
+// Which pipeline is "active" per scope, and therefore which state file decides
+// freshness, is scanBackupFreshness's judgement — this gate deliberately does
+// not re-derive it, so the gate and BdBackupFreshnessCheck can never disagree
+// about whether a scope is protected. Concretely that means a scope with a
+// registered Dolt destination is judged on its Dolt sync state (including the
+// registered-but-never-synced case, which is unsafe), and only a scope that
+// never migrated is judged on the legacy embedded-store state.
+//
+// The gate is fail-closed on doubt: an unreadable, unparseable, or
+// timestamp-less state file blocks the deletion rather than being ignored,
+// because it leaves the recovery point unknown. The one deliberate exception is
+// a scope with NO backup state at all, which is treated as safe — "no backup
+// configured" is DoltBackupCheck's concern, and failing closed there would
+// block bulk deletion on every unbacked city.
+func BulkDeleteSafe(cityPath string, cfg *config.City, maxAge time.Duration, now time.Time) (bool, string) {
+	scopeRoots := managedDoltScopeRootsForConfig(cityPath, cfg, nil)
+	for _, scopeRoot := range scopeRoots {
+		scopeRoot = filepath.Clean(scopeRoot)
+		label := bdBackupScopeLabel(cityPath, scopeRoot)
+		beadsDir := filepath.Join(scopeRoot, ".beads")
+		if finding, ok := scanBackupFreshness(label, beadsDir, now, maxAge); ok {
+			return false, finding
+		}
+	}
+	return true, ""
+}
+
 // scanBackupFreshness reports whether a scope's ACTIVE backup pipeline has
 // stopped syncing.
 //

--- a/internal/doctor/checks_bd_backup_freshness.go
+++ b/internal/doctor/checks_bd_backup_freshness.go
@@ -162,8 +162,18 @@ func (c *BdBackupFreshnessCheck) freshnessScanTargets() []bdBackupFreshnessTarge
 // a scope with NO backup state at all, which is treated as safe — "no backup
 // configured" is DoltBackupCheck's concern, and failing closed there would
 // block bulk deletion on every unbacked city.
+//
+// maxAge is used as given and is not clamped, so a non-positive value reads
+// every scope as stale and blocks every deletion.
 func BulkDeleteSafe(cityPath string, cfg *config.City, maxAge time.Duration, now time.Time) (bool, string) {
 	check := NewBdBackupFreshnessCheckForConfig(cityPath, cfg, nil)
+	if cfg == nil {
+		// No config in hand: discover scopes from disk, the same fallback the
+		// check uses when city.toml fails to load. Silently narrowing to the
+		// city root here would leave every rig unscanned and fail this gate
+		// OPEN — the one direction a delete gate must never fail.
+		check = NewBdBackupFreshnessCheckForScopeRoots(cityPath, managedDoltScopeRoots(cityPath), maxAge, nil)
+	}
 	for _, target := range check.freshnessScanTargets() {
 		if finding, ok := scanBackupFreshness(target.Label, target.BeadsDir, now, maxAge); ok {
 			return false, finding

--- a/internal/doctor/checks_bd_backup_freshness_test.go
+++ b/internal/doctor/checks_bd_backup_freshness_test.go
@@ -6,7 +6,65 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
+
+func TestBulkDeleteSafe(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	maxAge := 24 * time.Hour
+
+	t.Run("all scopes fresh → safe", func(t *testing.T) {
+		scope1 := t.TempDir()
+		scope2 := t.TempDir()
+		writeBackupStateForFreshness(t, scope1, now.Add(-1*time.Hour).Format(time.RFC3339))
+		writeBackupStateForFreshness(t, scope2, now.Add(-2*time.Hour).Format(time.RFC3339))
+		cfg := &config.City{Rigs: []config.Rig{
+			{Path: scope1},
+			{Path: scope2},
+		}}
+		safe, reason := BulkDeleteSafe(scope1, cfg, maxAge, now)
+		if !safe {
+			t.Fatalf("all fresh: want safe=true, got safe=false, reason=%q", reason)
+		}
+		if reason != "" {
+			t.Fatalf("all fresh: want empty reason, got %q", reason)
+		}
+	})
+
+	t.Run("one stale scope → unsafe, reason contains scope label", func(t *testing.T) {
+		fresh := t.TempDir()
+		stale := t.TempDir()
+		writeBackupStateForFreshness(t, fresh, now.Add(-1*time.Hour).Format(time.RFC3339))
+		writeBackupStateForFreshness(t, stale, now.Add(-48*time.Hour).Format(time.RFC3339))
+		// Use stale path as cityPath so it appears as a labeled scope
+		cfg := &config.City{Rigs: []config.Rig{
+			{Path: fresh},
+			{Path: stale},
+		}}
+		safe, reason := BulkDeleteSafe(fresh, cfg, maxAge, now)
+		if safe {
+			t.Fatalf("stale scope: want safe=false, got safe=true")
+		}
+		if reason == "" {
+			t.Fatalf("stale scope: want non-empty reason")
+		}
+	})
+
+	t.Run("no backup_state.json in any scope → safe (unconfigured is not this check's job)", func(t *testing.T) {
+		scope1 := t.TempDir()
+		scope2 := t.TempDir()
+		cfg := &config.City{Rigs: []config.Rig{
+			{Path: scope1},
+			{Path: scope2},
+		}}
+		safe, reason := BulkDeleteSafe(scope1, cfg, maxAge, now)
+		if !safe {
+			t.Fatalf("no backup config: want safe=true, got safe=false, reason=%q", reason)
+		}
+		_ = reason
+	})
+}
 
 func writeBackupStateForFreshness(t *testing.T, scopeRoot, timestamp string) {
 	t.Helper()

--- a/internal/doctor/checks_bd_backup_freshness_test.go
+++ b/internal/doctor/checks_bd_backup_freshness_test.go
@@ -37,7 +37,6 @@ func TestBulkDeleteSafe(t *testing.T) {
 		stale := t.TempDir()
 		writeBackupStateForFreshness(t, fresh, now.Add(-1*time.Hour).Format(time.RFC3339))
 		writeBackupStateForFreshness(t, stale, now.Add(-48*time.Hour).Format(time.RFC3339))
-		// Use stale path as cityPath so it appears as a labeled scope
 		cfg := &config.City{Rigs: []config.Rig{
 			{Path: fresh},
 			{Path: stale},
@@ -46,8 +45,8 @@ func TestBulkDeleteSafe(t *testing.T) {
 		if safe {
 			t.Fatalf("stale scope: want safe=false, got safe=true")
 		}
-		if reason == "" {
-			t.Fatalf("stale scope: want non-empty reason")
+		if !strings.Contains(reason, stale) {
+			t.Fatalf("stale scope: reason should name the stale scope %q, got %q", stale, reason)
 		}
 	})
 
@@ -62,7 +61,45 @@ func TestBulkDeleteSafe(t *testing.T) {
 		if !safe {
 			t.Fatalf("no backup config: want safe=true, got safe=false, reason=%q", reason)
 		}
-		_ = reason
+		if reason != "" {
+			t.Fatalf("no backup config: want empty reason, got %q", reason)
+		}
+	})
+
+	t.Run("migrated scope with a never-synced dolt backup → unsafe", func(t *testing.T) {
+		scope := t.TempDir()
+		writeDoltBackupRegistration(t, scope) // no dolt-backup-state.json
+		cfg := &config.City{Rigs: []config.Rig{{Path: scope}}}
+		safe, reason := BulkDeleteSafe(scope, cfg, maxAge, now)
+		if safe {
+			t.Fatalf("never-synced dolt backup: want safe=false, got safe=true")
+		}
+		if !strings.Contains(reason, "never synced") {
+			t.Fatalf("reason should say the backup never synced, got %q", reason)
+		}
+	})
+
+	// With no config in hand the gate must discover scopes from disk. Narrowing
+	// to the city root would leave the rig unscanned and return safe=true —
+	// failing this gate OPEN on a destructive operation.
+	t.Run("nil config still scans rigs discovered on disk", func(t *testing.T) {
+		city := t.TempDir()
+		rig := filepath.Join(city, "rigs", "alpha")
+		if err := os.MkdirAll(filepath.Join(rig, ".beads"), 0o755); err != nil {
+			t.Fatalf("mkdir rig .beads: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(rig, ".beads", "metadata.json"), []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("write metadata.json: %v", err)
+		}
+		writeBackupStateForFreshness(t, rig, now.Add(-48*time.Hour).Format(time.RFC3339))
+
+		safe, reason := BulkDeleteSafe(city, nil, maxAge, now)
+		if safe {
+			t.Fatalf("nil config with a stale rig: want safe=false, got safe=true")
+		}
+		if !strings.Contains(reason, "ago") {
+			t.Fatalf("reason should describe the stale age, got %q", reason)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

This is the `doctor`-scoped replacement for #3845. It preserves Karel Bourgois's original commit and authorship while separating the backup-freshness API from the mixed-scope branch.

- adds `BulkDeleteSafe` over the existing backup-freshness machinery
- covers fresh, stale, and unconfigured managed scopes
- reuses the check's canonical managed-scope target selection

Original commit assigned here: `0398fca9136120d9e5d4613a42ecc90720968338`.

## Test plan

- `go test ./internal/doctor`
- pre-commit `lint-changed`, generated-doc freshness, and `go vet ./...`

Split from and supersedes the `doctor` portion of #3845. Please credit @bourgois for the original implementation.
