### PR TITLE
test(docsync): skip ga- agent work directories

### DIFF
--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -819,7 +819,7 @@ func TestDocDirCoverage(t *testing.T) {
 			continue
 		}
 		name := e.Name()
-		if strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules" {
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "ga-") || name == "vendor" || name == "node_modules" {
 			continue
 		}
 		if known[name] {


### PR DESCRIPTION
## Summary

- skip ephemeral ga- agent work directories in TestDocDirCoverage

This is the docsync-scoped replacement for #3835. All credit belongs to @quad341; the cherry-picked commit retains original authorship.

## Validation

- go test ./test/docsync
- go vet ./...
- git diff --check origin/main...HEAD

No merge without a dedicated review record.