### PR TITLE
test(docsync): skip ephemeral agent work directories

### DIFF
--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -819,7 +819,7 @@ func TestDocDirCoverage(t *testing.T) {
 			continue
 		}
 		name := e.Name()
-		if strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules" {
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "ga-") || name == "vendor" || name == "node_modules" {
 			continue
 		}
 		if known[name] {


### PR DESCRIPTION
## Summary

Replacement docsync part of #3835. Preserves original commit eebe4825d by @quad341 and isolates it from the reconciler behavior change.

- skip ephemeral ga-* agent work directories in TestDocDirCoverage
- no production-code changes

## Verification

- go test ./test/docsync -run ^TestDocDirCoverage$ — pass
- go vet ./... — pass

## Review

This split part requires its own normal adopt/review record before merge. Do not merge solely on the review record attached to #3835.