### PR TITLE
Align BEADS_ACTOR with the stable agent alias

### DIFF
--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -4086,10 +4086,10 @@ func TestBdRuntimeEnvDoesNotDefaultBeadsActorWhenUnset(t *testing.T) {
 }
 
 // TestBdRuntimeEnvPreservesInheritedBeadsActor verifies that session
-// contexts (template_resolve.go sets BEADS_ACTOR=<sessname>) and exec
-// orders (orderExecEnv sets BEADS_ACTOR=order:<name>) are not clobbered by
-// the neutral bd runtime env. The key is omitted so the inherited value
-// passes through mergeEnv unchanged.
+// contexts (template_resolve.go sets BEADS_ACTOR=<qualifiedName>, matching
+// GC_ALIAS) and exec orders (orderExecEnv sets BEADS_ACTOR=order:<name>) are
+// not clobbered by the neutral bd runtime env. The key is omitted so the
+// inherited value passes through mergeEnv unchanged.
 func TestBdRuntimeEnvPreservesInheritedBeadsActor(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5849,6 +5849,13 @@ func TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession(
 	beadsDir := filepath.Join(cityPath, ".beads")
 	t.Setenv("PATH", strings.Join([]string{filepath.Dir(bdPath), filepath.Dir(jqPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
 	t.Setenv("BEADS_DIR", beadsDir)
+	// Isolate HOME so this test can't pick up an ambient ~/.beads/config.yaml
+	// (e.g. dolt.shared-server: true) and collide with an unrelated dolt
+	// server on the machine's default shared-server port. Both runExternal's
+	// bd subprocesses and buildDesiredState's internal shellScaleCheck/
+	// beads.ExecCommandRunnerWithEnv calls fall back to the live process env
+	// for HOME, so t.Setenv here covers every exec path below.
+	t.Setenv("HOME", t.TempDir())
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
 	}

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -111,6 +111,12 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork(t *testing.T) {
 		t.Skip("jq not installed")
 	}
 	t.Setenv("PATH", filepath.Dir(bdPath)+":"+filepath.Dir(jqPath)+":"+os.Getenv("PATH"))
+	// Isolate HOME so this test can't pick up an ambient ~/.beads/config.yaml
+	// (e.g. dolt.shared-server: true) and collide with an unrelated dolt
+	// server on the machine's default shared-server port. bd and shellScaleCheck
+	// both fall back to the live process env for HOME, so t.Setenv here covers
+	// every subprocess spawned below.
+	t.Setenv("HOME", t.TempDir())
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
@@ -155,6 +161,12 @@ func TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork(t *testi
 		t.Skip("jq not installed")
 	}
 	t.Setenv("PATH", filepath.Dir(bdPath)+":"+filepath.Dir(jqPath)+":"+os.Getenv("PATH"))
+	// Isolate HOME so this test can't pick up an ambient ~/.beads/config.yaml
+	// (e.g. dolt.shared-server: true) and collide with an unrelated dolt
+	// server on the machine's default shared-server port. bd and shellScaleCheck
+	// both fall back to the live process env for HOME, so t.Setenv here covers
+	// every subprocess spawned below.
+	t.Setenv("HOME", t.TempDir())
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -281,7 +281,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		"GC_SESSION_ORIGIN":   "ephemeral",
 		"GC_AGENT":            sessName,
 		"GC_ALIAS":            qualifiedName,
-		"BEADS_ACTOR":         sessName,
+		"BEADS_ACTOR":         qualifiedName,
 		"GC_DIR":              workDir,
 		"GC_BEADS_SCOPE_ROOT": p.cityPath,
 		// Explicit empty values matter here. tmux session creation uses `env -u`

--- a/cmd/gc/template_resolve_env_test.go
+++ b/cmd/gc/template_resolve_env_test.go
@@ -238,3 +238,44 @@ func TestResolveTemplateInjectsPerDispatcherTraceDefault(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveTemplateSetsBeadsActorToQualifiedNameNotSessionName asserts that
+// BEADS_ACTOR matches GC_ALIAS (the qualified name the Work Loop claims beads
+// with via `bd update --claim --assignee=$GC_ALIAS`), not GC_SESSION_NAME (the
+// tmux-safe sanitized form, "/" -> "--"). Before this fix, BEADS_ACTOR was set
+// to the session name, so bd's cross-actor close guard rejected an agent's
+// own legitimately-claimed bead for every dir-qualified agent (refs
+// ga-jav9u9).
+func TestResolveTemplateSetsBeadsActorToQualifiedNameNotSessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	qualifiedName := "app/builder"
+	agent := &config.Agent{Name: "builder", Dir: "app"}
+	tp, err := resolveTemplate(params, agent, qualifiedName, nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_SESSION_NAME"]; got == qualifiedName {
+		t.Fatalf("test setup invalid: GC_SESSION_NAME = %q should differ from qualifiedName %q to exercise the divergence this test targets", got, qualifiedName)
+	}
+	if got := tp.Env["BEADS_ACTOR"]; got != qualifiedName {
+		t.Fatalf("BEADS_ACTOR = %q, want %q (GC_ALIAS's qualified name); got session name %q instead", got, qualifiedName, tp.Env["GC_SESSION_NAME"])
+	}
+	if got := tp.Env["BEADS_ACTOR"]; got != tp.Env["GC_ALIAS"] {
+		t.Fatalf("BEADS_ACTOR = %q, want to match GC_ALIAS = %q", got, tp.Env["GC_ALIAS"])
+	}
+}

--- a/release-gates/beads-actor-qualified-name-gate.md
+++ b/release-gates/beads-actor-qualified-name-gate.md
@@ -1,0 +1,36 @@
+# Release gate: align BEADS_ACTOR with the stable agent alias
+
+- Deploy bead: `ga-d6zqfj`
+- Build bead: `ga-jav9u9`
+- Source review: `ga-mfccbk`
+- Reviewed commit: `941812ce44b193ebfc3ab3903861bcf79467e3e3`
+- Reviewed base: `1f948e67b0ac088492af67c0748f521aad5768b0`
+- Main evaluated: `origin/main@3b4e9ea98a636f3cf2a0db5945f03de69e9fb651`
+- Source branch: `builder/ga-jav9u9` (provenance and bounded-rebase target only)
+- Planned deploy branch: `deploy/ga-d6zqfj-gate`
+- Evaluated: `2026-08-03`
+- Overall verdict: **FAIL**
+
+`docs/PROJECT_MANIFEST.md` is not present at the evaluated commit, so this
+checklist applies the deployer role's release-gate criteria together with
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+Evaluation stopped after criterion 6 as required. No test suite, push of the
+deploy branch, or pull request was attempted.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 6 | Branch diverges cleanly from main | **FAIL** | Evaluated first after `git fetch origin main`. `origin/main@3b4e9ea98a636f3cf2a0db5945f03de69e9fb651` was not an ancestor of reviewed commit `941812ce44b193ebfc3ab3903861bcf79467e3e3` (merge base `1f948e67b0ac088492af67c0748f521aad5768b0`). `git merge-tree --write-tree origin/main 941812ce44b193ebfc3ab3903861bcf79467e3e3` was conflict-free and produced tree `e2f8444bf610d36846c6ccdd1d5f46ed917a64e0`, so the permitted bounded helper was attempted on the internally authored source branch. It rebased locally to `08f5fff1d0499cba7a8963402915932b42ea19f2`, but returned `rc=14`: `push-ownership-guard` resolved the branch to closed build bead `ga-jav9u9` and blocked the required force-with-lease push. Remote `origin/builder/ga-jav9u9` therefore remains at `941812ce44b193ebfc3ab3903861bcf79467e3e3`. Per the guardrail, a locally rebased but unpushed source is not a criterion-6 PASS. |
+| 1 | Review PASS present | **SKIPPED** | Fail-fast after criterion 6. The review bead was not promoted into gate evidence. |
+| 2 | Acceptance criteria met | **SKIPPED** | Fail-fast after criterion 6; acceptance criteria were not re-evaluated. |
+| 3 | Tests pass | **SKIPPED** | Fail-fast after criterion 6. The documented CI-equivalent command for this `cmd/gc/**` change is `make test-cmd-gc-process-parallel`, but it was intentionally not run on an unpushable rebased source. PASS/FAIL/SKIP counts are therefore not claimed. |
+| 4 | No high-severity review findings open | **SKIPPED** | Fail-fast after criterion 6. |
+| 5 | Final branch is clean | **SKIPPED** | Fail-fast after criterion 6. The helper left the temporary source worktree clean before this checklist was written, but cleanliness is not promoted to a gate PASS after criterion 6 failed. |
+| 7 | Single feature theme | **SKIPPED** | Fail-fast after criterion 6. |
+
+## Required remediation
+
+The builder must re-establish a pushable source branch on current `origin/main`
+and return it for review/deploy. The deployer must then rerun the complete gate,
+including `make test-cmd-gc-process-parallel`, before preparing an isolated
+`deploy/ga-d6zqfj-gate` branch or opening a pull request.

--- a/release-gates/beads-actor-qualified-name-gate.md
+++ b/release-gates/beads-actor-qualified-name-gate.md
@@ -4,33 +4,36 @@
 - Build bead: `ga-jav9u9`
 - Source review: `ga-mfccbk`
 - Reviewed commit: `941812ce44b193ebfc3ab3903861bcf79467e3e3`
-- Reviewed base: `1f948e67b0ac088492af67c0748f521aad5768b0`
-- Main evaluated: `origin/main@3b4e9ea98a636f3cf2a0db5945f03de69e9fb651`
-- Source branch: `builder/ga-jav9u9` (provenance and bounded-rebase target only)
+- Gated source tip: `6384e9a82b0950a219041fa0efe121dec40aea8b`
+- Main evaluated: `origin/main@85e3e5022b925c9781fb64e0b1a043133770cf72`
+- Source branch: `builder/ga-jav9u9`
 - Planned deploy branch: `deploy/ga-d6zqfj-gate`
 - Evaluated: `2026-08-03`
 - Overall verdict: **FAIL**
 
-`docs/PROJECT_MANIFEST.md` is not present at the evaluated commit, so this
-checklist applies the deployer role's release-gate criteria together with
+`docs/PROJECT_MANIFEST.md` is not present at the evaluated commit. This
+checklist therefore applies the deployer role's seven release criteria and
 `engdocs/contributors/release-gate-criteria-conventions.md`.
 
-Evaluation stopped after criterion 6 as required. No test suite, push of the
-deploy branch, or pull request was attempted.
+The builder rebased the reviewed RED and GREEN commits onto current main after
+the prior gate attempt. Their stable patch IDs are unchanged (`1069edfc...` and
+`0f232508...` respectively), so the gated source contains the same reviewed
+feature patch plus the prior gate record.
 
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
-| 6 | Branch diverges cleanly from main | **FAIL** | Evaluated first after `git fetch origin main`. `origin/main@3b4e9ea98a636f3cf2a0db5945f03de69e9fb651` was not an ancestor of reviewed commit `941812ce44b193ebfc3ab3903861bcf79467e3e3` (merge base `1f948e67b0ac088492af67c0748f521aad5768b0`). `git merge-tree --write-tree origin/main 941812ce44b193ebfc3ab3903861bcf79467e3e3` was conflict-free and produced tree `e2f8444bf610d36846c6ccdd1d5f46ed917a64e0`, so the permitted bounded helper was attempted on the internally authored source branch. It rebased locally to `08f5fff1d0499cba7a8963402915932b42ea19f2`, but returned `rc=14`: `push-ownership-guard` resolved the branch to closed build bead `ga-jav9u9` and blocked the required force-with-lease push. Remote `origin/builder/ga-jav9u9` therefore remains at `941812ce44b193ebfc3ab3903861bcf79467e3e3`. Per the guardrail, a locally rebased but unpushed source is not a criterion-6 PASS. |
-| 1 | Review PASS present | **SKIPPED** | Fail-fast after criterion 6. The review bead was not promoted into gate evidence. |
-| 2 | Acceptance criteria met | **SKIPPED** | Fail-fast after criterion 6; acceptance criteria were not re-evaluated. |
-| 3 | Tests pass | **SKIPPED** | Fail-fast after criterion 6. The documented CI-equivalent command for this `cmd/gc/**` change is `make test-cmd-gc-process-parallel`, but it was intentionally not run on an unpushable rebased source. PASS/FAIL/SKIP counts are therefore not claimed. |
-| 4 | No high-severity review findings open | **SKIPPED** | Fail-fast after criterion 6. |
-| 5 | Final branch is clean | **SKIPPED** | Fail-fast after criterion 6. The helper left the temporary source worktree clean before this checklist was written, but cleanliness is not promoted to a gate PASS after criterion 6 failed. |
-| 7 | Single feature theme | **SKIPPED** | Fail-fast after criterion 6. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first after `git fetch origin main builder/ga-jav9u9`. `origin/main@85e3e5022b925c9781fb64e0b1a043133770cf72` is an ancestor of the clean source tip `6384e9a82b0950a219041fa0efe121dec40aea8b`, which exactly matched `origin/builder/ga-jav9u9`; merge base was the current main tip and `git diff --check origin/main...HEAD` was clean. No bounded self-rebase was required. |
+| 1 | Review PASS present | **PASS** | Review bead `ga-mfccbk` is closed with `close_reason=pass`, `verdict: pass`, and reviewed commit `941812ce44b193ebfc3ab3903861bcf79467e3e3`. The rebased RED/GREEN commits have stable patch IDs identical to the reviewed commits. |
+| 2 | Acceptance criteria met | **PASS** | `cmd/gc/template_resolve.go` sets `BEADS_ACTOR` to `qualifiedName`, matching `GC_ALIAS`, rather than the per-session `sessName`. `TestResolveTemplateSetsBeadsActorToQualifiedNameNotSessionName` passed independently: 1 PASS, 0 FAIL, 0 SKIP. |
+| 3 | Tests pass | **FAIL** | Required path-matched local CI equivalent `make test-cmd-gc-process-parallel`: 4/7 jobs PASS (`cmd-gc-process` shards 1, 3, 6 plus `productmetrics-testhook`), 3/7 FAIL (shards 2, 4, 5), 0 jobs SKIP; exit 123. Failing tests were `TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession`, `TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork`, and `TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork`. Two failures explicitly report `database "beads" not found on Dolt server at 127.0.0.1:3308`; the third reports its generated `bd ready` command exiting 1. Logs: `/var/tmp/gc-local-tests.r4VqAA/cmd-gc-process-{2,4,5}-of-6.log`. Per test-evidence policy, this red required run cannot be promoted to PASS even though the feature-focused test is green. Remaining path-matched integration and worker-core lanes were not run after the required process suite failed. |
+| 4 | No high-severity review findings open | **PASS** | Review bead `ga-mfccbk` records no style or security findings and no blocker/major/minor security issue; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | **PASS** | The source worktree was clean at `6384e9a82b0950a219041fa0efe121dec40aea8b` before this checklist was written; the gate record is committed below as the only deployer change. |
+| 7 | Single feature theme | **PASS** | The substantive diff is confined to `cmd/gc` agent-environment identity construction, its focused regression test, and one directly related test comment. The prior gate record is release evidence for the same feature, not an independent theme. |
 
 ## Required remediation
 
-The builder must re-establish a pushable source branch on current `origin/main`
-and return it for review/deploy. The deployer must then rerun the complete gate,
-including `make test-cmd-gc-process-parallel`, before preparing an isolated
-`deploy/ga-d6zqfj-gate` branch or opening a pull request.
+The builder must make the documented `cmd/gc` process suite pass on the exact
+source tip, including isolating the three pool tests from the ambient Dolt
+endpoint or otherwise proving and repairing the failing test environment. The
+deployer must rerun the full gate before creating or pushing an isolated deploy
+branch. No deploy branch was pushed and no pull request was opened.

--- a/release-gates/beads-actor-qualified-name-gate.md
+++ b/release-gates/beads-actor-qualified-name-gate.md
@@ -3,13 +3,12 @@
 - Deploy bead: `ga-d6zqfj`
 - Build bead: `ga-jav9u9`
 - Source review: `ga-mfccbk`
-- Reviewed commit: `941812ce44b193ebfc3ab3903861bcf79467e3e3`
-- Remediated remote source tip: `1e1b25ca62e1ff6a259fe829bd20ce1fe73d1b77`
-- Main evaluated: `origin/main@e4c62220f24c7fb6db5c2454dd2c54b7edb20d07`
-- Source branch: `builder/ga-jav9u9`
-- Planned deploy branch: `deploy/ga-d6zqfj-gate`
-- Evaluated: `2026-08-03`
-- Overall verdict: **FAIL**
+- Reviewed feature commit: `941812ce44b193ebfc3ab3903861bcf79467e3e3`
+- Gate source tip: `072f6da09f487274385eedb1e3d8a83b228ed8b8`
+- Main evaluated: `origin/main@4f127d926ea346f8fa97055af87c6afaf5ea13bb`
+- Deploy branch: `deploy/ga-d6zqfj-gate`
+- Evaluated: `2026-08-04`
+- Overall verdict: **PASS**
 
 `docs/PROJECT_MANIFEST.md` is not present at the evaluated commit. This
 checklist therefore applies the deployer role's seven release criteria and
@@ -17,16 +16,17 @@ checklist therefore applies the deployer role's seven release criteria and
 
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
-| 6 | Branch diverges cleanly from main | **FAIL** | Evaluated first after fetching `origin/main` and `origin/builder/ga-jav9u9`. The remote source tip `1e1b25ca62e1ff6a259fe829bd20ce1fe73d1b77` does not contain `origin/main@e4c62220f24c7fb6db5c2454dd2c54b7edb20d07`. The required `attempt_bounded_self_rebase builder/ga-jav9u9 main` rebased locally to `b716a7e9d15e5a290ee532441f665869d37bf0e2` but returned `rc=14`: `push-ownership-guard` resolved closed build bead `ga-jav9u9` from the branch name and blocked the required force-with-lease push. `origin/builder/ga-jav9u9` remained at `1e1b25ca62e1ff6a259fe829bd20ce1fe73d1b77`; the unsuccessful local rebase emitted no authoritative `AFTER_SHA` and cannot satisfy the gate. |
-| 1 | Review PASS present | **SKIPPED** | Fail-fast after criterion 6. |
-| 2 | Acceptance criteria met | **SKIPPED** | Fail-fast after criterion 6. |
-| 3 | Tests pass | **SKIPPED** | Fail-fast after criterion 6; no test command was run on a shippable source SHA. |
-| 4 | No high-severity review findings open | **SKIPPED** | Fail-fast after criterion 6. |
-| 5 | Final branch is clean | **SKIPPED** | Fail-fast after criterion 6. |
-| 7 | Single feature theme | **SKIPPED** | Fail-fast after criterion 6. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first after fetching `origin/main` and `origin/builder/ga-jav9u9`. `origin/main@4f127d926ea346f8fa97055af87c6afaf5ea13bb` is an ancestor of the remediated source tip `072f6da09f487274385eedb1e3d8a83b228ed8b8`; no self-rebase was needed. |
+| 1 | Review PASS present | **PASS** | Review bead `ga-mfccbk` is closed with reason `pass`; its notes record `verdict: pass` for reviewed feature commit `941812ce44b193ebfc3ab3903861bcf79467e3e3`. |
+| 2 | Acceptance criteria met | **PASS** | `cmd/gc/template_resolve.go` now sets `BEADS_ACTOR` to `qualifiedName`, matching `GC_ALIAS`, rather than the session name. `TestResolveTemplateSetsBeadsActorToQualifiedNameNotSessionName` proves the session name differs and asserts both identity values match; focused verification ran 2 PASS, 0 FAIL, 0 SKIP. |
+| 3 | Tests pass | **PASS** | The changed `cmd/gc/**` paths require the `cmd_gc_process` CI lane. `make test-cmd-gc-process-parallel` ran 7 jobs: 7 PASS, 0 FAIL, 0 SKIP (six process shards plus `productmetrics-testhook`). Required fast baseline `make test-fast-parallel` ran 10 jobs: 10 PASS, 0 FAIL, 0 SKIP. `go vet ./...` also passed. |
+| 4 | No high-severity review findings open | **PASS** | Review bead `ga-mfccbk` records no style or security findings and no blocker, major, minor, or HIGH finding; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | **PASS** | The isolated deploy worktree was clean at the evaluated source before this checklist update; after committing the checklist, `git status --short` was rechecked and was empty. |
+| 7 | Single feature theme | **PASS** | The commit set is one `cmd/gc` identity-environment fix: align `BEADS_ACTOR` with the stable qualified alias and cover it with regression tests. The additional test-only HOME isolation changes remediate the prior environmental gate failure and introduce no independent product behavior. |
 
-## Required remediation
+## Test evidence
 
-The builder must publish a source tip containing current `origin/main` and
-route the deploy bead back for a full gate rerun. No isolated deploy branch was
-pushed and no pull request was opened.
+- CI-equivalent: `make test-cmd-gc-process-parallel` — 7 PASS, 0 FAIL, 0 SKIP jobs.
+- Fast baseline: `make test-fast-parallel` — 10 PASS, 0 FAIL, 0 SKIP jobs.
+- Focused acceptance: `go test ./cmd/gc -run '^(TestResolveTemplateSetsBeadsActorToQualifiedNameNotSessionName|TestBdRuntimeEnvPreservesInheritedBeadsActor)$' -count=1 -v` — 2 PASS, 0 FAIL, 0 SKIP tests.
+- Static analysis: `go vet ./...` — PASS.

--- a/release-gates/beads-actor-qualified-name-gate.md
+++ b/release-gates/beads-actor-qualified-name-gate.md
@@ -4,8 +4,8 @@
 - Build bead: `ga-jav9u9`
 - Source review: `ga-mfccbk`
 - Reviewed commit: `941812ce44b193ebfc3ab3903861bcf79467e3e3`
-- Gated source tip: `6384e9a82b0950a219041fa0efe121dec40aea8b`
-- Main evaluated: `origin/main@85e3e5022b925c9781fb64e0b1a043133770cf72`
+- Remediated remote source tip: `1e1b25ca62e1ff6a259fe829bd20ce1fe73d1b77`
+- Main evaluated: `origin/main@e4c62220f24c7fb6db5c2454dd2c54b7edb20d07`
 - Source branch: `builder/ga-jav9u9`
 - Planned deploy branch: `deploy/ga-d6zqfj-gate`
 - Evaluated: `2026-08-03`
@@ -15,25 +15,18 @@
 checklist therefore applies the deployer role's seven release criteria and
 `engdocs/contributors/release-gate-criteria-conventions.md`.
 
-The builder rebased the reviewed RED and GREEN commits onto current main after
-the prior gate attempt. Their stable patch IDs are unchanged (`1069edfc...` and
-`0f232508...` respectively), so the gated source contains the same reviewed
-feature patch plus the prior gate record.
-
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
-| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first after `git fetch origin main builder/ga-jav9u9`. `origin/main@85e3e5022b925c9781fb64e0b1a043133770cf72` is an ancestor of the clean source tip `6384e9a82b0950a219041fa0efe121dec40aea8b`, which exactly matched `origin/builder/ga-jav9u9`; merge base was the current main tip and `git diff --check origin/main...HEAD` was clean. No bounded self-rebase was required. |
-| 1 | Review PASS present | **PASS** | Review bead `ga-mfccbk` is closed with `close_reason=pass`, `verdict: pass`, and reviewed commit `941812ce44b193ebfc3ab3903861bcf79467e3e3`. The rebased RED/GREEN commits have stable patch IDs identical to the reviewed commits. |
-| 2 | Acceptance criteria met | **PASS** | `cmd/gc/template_resolve.go` sets `BEADS_ACTOR` to `qualifiedName`, matching `GC_ALIAS`, rather than the per-session `sessName`. `TestResolveTemplateSetsBeadsActorToQualifiedNameNotSessionName` passed independently: 1 PASS, 0 FAIL, 0 SKIP. |
-| 3 | Tests pass | **FAIL** | Required path-matched local CI equivalent `make test-cmd-gc-process-parallel`: 4/7 jobs PASS (`cmd-gc-process` shards 1, 3, 6 plus `productmetrics-testhook`), 3/7 FAIL (shards 2, 4, 5), 0 jobs SKIP; exit 123. Failing tests were `TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession`, `TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork`, and `TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork`. Two failures explicitly report `database "beads" not found on Dolt server at 127.0.0.1:3308`; the third reports its generated `bd ready` command exiting 1. Logs: `/var/tmp/gc-local-tests.r4VqAA/cmd-gc-process-{2,4,5}-of-6.log`. Per test-evidence policy, this red required run cannot be promoted to PASS even though the feature-focused test is green. Remaining path-matched integration and worker-core lanes were not run after the required process suite failed. |
-| 4 | No high-severity review findings open | **PASS** | Review bead `ga-mfccbk` records no style or security findings and no blocker/major/minor security issue; unresolved HIGH count is 0. |
-| 5 | Final branch is clean | **PASS** | The source worktree was clean at `6384e9a82b0950a219041fa0efe121dec40aea8b` before this checklist was written; the gate record is committed below as the only deployer change. |
-| 7 | Single feature theme | **PASS** | The substantive diff is confined to `cmd/gc` agent-environment identity construction, its focused regression test, and one directly related test comment. The prior gate record is release evidence for the same feature, not an independent theme. |
+| 6 | Branch diverges cleanly from main | **FAIL** | Evaluated first after fetching `origin/main` and `origin/builder/ga-jav9u9`. The remote source tip `1e1b25ca62e1ff6a259fe829bd20ce1fe73d1b77` does not contain `origin/main@e4c62220f24c7fb6db5c2454dd2c54b7edb20d07`. The required `attempt_bounded_self_rebase builder/ga-jav9u9 main` rebased locally to `b716a7e9d15e5a290ee532441f665869d37bf0e2` but returned `rc=14`: `push-ownership-guard` resolved closed build bead `ga-jav9u9` from the branch name and blocked the required force-with-lease push. `origin/builder/ga-jav9u9` remained at `1e1b25ca62e1ff6a259fe829bd20ce1fe73d1b77`; the unsuccessful local rebase emitted no authoritative `AFTER_SHA` and cannot satisfy the gate. |
+| 1 | Review PASS present | **SKIPPED** | Fail-fast after criterion 6. |
+| 2 | Acceptance criteria met | **SKIPPED** | Fail-fast after criterion 6. |
+| 3 | Tests pass | **SKIPPED** | Fail-fast after criterion 6; no test command was run on a shippable source SHA. |
+| 4 | No high-severity review findings open | **SKIPPED** | Fail-fast after criterion 6. |
+| 5 | Final branch is clean | **SKIPPED** | Fail-fast after criterion 6. |
+| 7 | Single feature theme | **SKIPPED** | Fail-fast after criterion 6. |
 
 ## Required remediation
 
-The builder must make the documented `cmd/gc` process suite pass on the exact
-source tip, including isolating the three pool tests from the ambient Dolt
-endpoint or otherwise proving and repairing the failing test environment. The
-deployer must rerun the full gate before creating or pushing an isolated deploy
-branch. No deploy branch was pushed and no pull request was opened.
+The builder must publish a source tip containing current `origin/main` and
+route the deploy bead back for a full gate rerun. No isolated deploy branch was
+pushed and no pull request was opened.


### PR DESCRIPTION
## What this changes

When `gc` launches an agent, `BEADS_ACTOR` now uses the same qualified, stable identity as `GC_ALIAS` and the bead assignee. Agents can close work they legitimately claimed without reaching for `--force`, while beads' cross-actor ownership guard remains meaningful for real mismatches.

The process-backed pool tests also isolate `HOME`, preventing machine-local Beads/Dolt configuration from redirecting their subprocesses to an unrelated shared Dolt server.

## Review notes

- The behavior change is confined to interactive agent-session environment construction in `cmd/gc/template_resolve.go`.
- Controller and order-execution actor identities are unchanged.
- There is no config migration or user action required.
- The additional `HOME` changes are test-only hermeticity fixes discovered by the release gate.

## Test plan

- [x] Run the required process-backed `cmd/gc` suite: `make test-cmd-gc-process-parallel`.
- [x] Run the fast baseline: `make test-fast-parallel`.
- [x] Verify the focused alias/actor regression tests and `go vet ./...`.
- [x] Release gate: [`release-gates/beads-actor-qualified-name-gate.md`](release-gates/beads-actor-qualified-name-gate.md)
