### PR TITLE
fix(controller): keep partial dispatcher demand reads retention-only

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -63,10 +63,13 @@ type DesiredStateResult struct {
 	BaseState        map[string]TemplateParams
 	ScaleCheckCounts map[string]int // nil when store is nil or scale_check not run
 	// ScaleCheckPartialTemplates records all templates whose bead-backed demand
-	// probe failed. PoolScaleCheckPartialTemplates drives generic pool retention;
+	// probe failed. PoolScaleCheckPartialTemplates blocks fresh pool creates;
+	// PoolPartialRetentionTemplates preserves existing pool capacity and may also
+	// contain retention-only failures where another store proved positive demand.
 	// NamedScaleCheckPartialTemplates only protects configured named sessions.
 	ScaleCheckPartialTemplates      map[string]bool
 	PoolScaleCheckPartialTemplates  map[string]bool
+	PoolPartialRetentionTemplates   map[string]bool
 	NamedScaleCheckPartialTemplates map[string]bool
 	PoolDesiredCounts               map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
 	WorkSet                         map[string]bool
@@ -682,6 +685,7 @@ func buildDesiredStateWithSessionBeads(
 	var scaleCheckCounts map[string]int
 	var scaleCheckDemandByTemplate map[string]scaleCheckDemand
 	var poolScaleCheckPartialTemplates map[string]bool
+	var poolPartialRetentionTemplates map[string]bool
 	var namedScaleCheckPartialTemplates map[string]bool
 	var scaleCheckPartialTemplates map[string]bool
 	var namedDefaultDemand map[string]bool
@@ -792,6 +796,7 @@ func buildDesiredStateWithSessionBeads(
 				scaleCheckDemandByTemplate[template] = mergeScaleCheckDemand(scaleCheckDemandByTemplate[template], defaultDemand[template], count)
 			}
 		}
+		poolPartialRetentionTemplates = mergeScaleCheckPartialTemplates(poolPartialRetentionTemplates, poolScaleCheckPartialTemplates)
 		if len(controlDispatcherOpenDemand) > 0 {
 			if scaleCheckCounts == nil {
 				scaleCheckCounts = make(map[string]int)
@@ -805,10 +810,11 @@ func buildDesiredStateWithSessionBeads(
 		if unassignedRoutedPartial {
 			// The unassigned-routed live read failed, so controlDispatcherOpenDemand
 			// above is a partial (possibly empty) view — not proof of zero demand.
-			// Mark every deterministic control-dispatcher template partial so
-			// retainScaleCheckPartialPoolDesired preserves the running dispatcher
-			// this tick instead of draining it on a transient outage (gc-ft31x).
-			poolScaleCheckPartialTemplates = markControlDispatcherTemplatesPartial(cfg, poolScaleCheckPartialTemplates)
+			// Mark every deterministic control-dispatcher template for retention so
+			// a running dispatcher survives this tick. This is intentionally not a
+			// create-suppression marker: another healthy store may have proved real
+			// control demand that justifies starting a cold dispatcher (gc-ft31x.2).
+			poolPartialRetentionTemplates = markControlDispatcherTemplatesPartial(cfg, poolPartialRetentionTemplates)
 		}
 		readyUnassignedRoutedWorkBeads, readyUnassignedRoutedWorkStoreRefs = selectReadyUnassignedRoutedWork(
 			unassignedRoutedBeads,
@@ -828,7 +834,7 @@ func buildDesiredStateWithSessionBeads(
 			}
 			namedScaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(namedScaleCheckPartialTemplates, partialTemplates)
 		}
-		scaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(scaleCheckPartialTemplates, poolScaleCheckPartialTemplates)
+		scaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(scaleCheckPartialTemplates, poolPartialRetentionTemplates)
 		scaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(scaleCheckPartialTemplates, namedScaleCheckPartialTemplates)
 		if len(scaleCheckPartialTemplates) > 0 {
 			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed for %s, retaining affected sessions\n", strings.Join(sortedBoolMapKeys(scaleCheckPartialTemplates), ",")) //nolint:errcheck
@@ -1014,7 +1020,7 @@ func buildDesiredStateWithSessionBeads(
 	// Phase 2: discover session beads created outside config iteration
 	// (e.g., by "gc session new"). Include them in desired state if they
 	// have a valid template and are not held/closed.
-	applySessionBeadDesiredOverlay(bp, cfg, desired, suspendedRigPaths, poolScaleCheckPartialTemplates, namedScaleCheckPartialTemplates, stderr)
+	applySessionBeadDesiredOverlay(bp, cfg, desired, suspendedRigPaths, poolPartialRetentionTemplates, namedScaleCheckPartialTemplates, stderr)
 
 	var continuationClaimCandidates []ContinuationClaimCandidate
 	continuationClaimQueryPartial := storePartial
@@ -1034,6 +1040,7 @@ func buildDesiredStateWithSessionBeads(
 		ScaleCheckCounts:                   scaleCheckCounts,
 		ScaleCheckPartialTemplates:         scaleCheckPartialTemplates,
 		PoolScaleCheckPartialTemplates:     poolScaleCheckPartialTemplates,
+		PoolPartialRetentionTemplates:      poolPartialRetentionTemplates,
 		NamedScaleCheckPartialTemplates:    namedScaleCheckPartialTemplates,
 		AssignedWorkBeads:                  assignedWorkBeads,
 		AssignedWorkStores:                 assignedWorkStores,
@@ -1187,7 +1194,7 @@ func refreshDesiredStateWithSessionBeads(
 
 	bp := newAgentBuildParams(cityName, cityPath, cfg, sp, result.BeaconTime, store, stderr)
 	bp.sessionBeads = sessionBeads
-	applySessionBeadDesiredOverlay(bp, cfg, refreshed.State, buildSuspendedRigPathsForCity(cfg, cityPath), result.PoolScaleCheckPartialTemplates, result.NamedScaleCheckPartialTemplates, stderr)
+	applySessionBeadDesiredOverlay(bp, cfg, refreshed.State, buildSuspendedRigPathsForCity(cfg, cityPath), effectivePoolPartialRetentionTemplates(result), result.NamedScaleCheckPartialTemplates, stderr)
 	return refreshed
 }
 
@@ -1870,6 +1877,13 @@ func mergeScaleCheckPartialTemplates(dst, src map[string]bool) map[string]bool {
 		}
 	}
 	return dst
+}
+
+func effectivePoolPartialRetentionTemplates(result DesiredStateResult) map[string]bool {
+	return mergeScaleCheckPartialTemplates(
+		mergeScaleCheckPartialTemplates(nil, result.PoolScaleCheckPartialTemplates),
+		result.PoolPartialRetentionTemplates,
+	)
 }
 
 func sortedBoolMapKeys(values map[string]bool) []string {

--- a/cmd/gc/build_desired_state_blocked_demand_test.go
+++ b/cmd/gc/build_desired_state_blocked_demand_test.go
@@ -97,6 +97,21 @@ func TestCollectOpenUnassignedRoutedWorkReportsPartialOnLiveOutage(t *testing.T)
 func TestBuildDesiredStateRetainsControlDispatcherOnRoutedDemandOutage(t *testing.T) {
 	cityPath := t.TempDir()
 	store := liveOpenListErrorStore{Store: beads.NewMemStore(), err: errors.New("live open list outage")}
+	dispatcherSession := beads.Bead{
+		ID:     "session-control-dispatcher",
+		Title:  "control dispatcher",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "template:control-dispatcher"},
+		Metadata: map[string]string{
+			"session_name":         "control-dispatcher-1",
+			"template":             config.ControlDispatcherAgentName,
+			"agent_name":           config.ControlDispatcherAgentName,
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+		},
+	}
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{{
@@ -108,14 +123,79 @@ func TestBuildDesiredStateRetainsControlDispatcherOnRoutedDemandOutage(t *testin
 	}
 	dispatcher := config.ControlDispatcherAgentName
 
-	got := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	snapshot := newSessionBeadSnapshot([]beads.Bead{dispatcherSession})
+	got := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, nil, snapshot, nil, io.Discard,
+	)
 
-	if !got.PoolScaleCheckPartialTemplates[dispatcher] {
-		t.Fatalf("PoolScaleCheckPartialTemplates = %v, want control-dispatcher template %q marked partial on a routed-demand outage (gc-ft31x)", got.PoolScaleCheckPartialTemplates, dispatcher)
+	if got.PoolScaleCheckPartialTemplates[dispatcher] {
+		t.Fatalf("PoolScaleCheckPartialTemplates = %v, want routed-demand outage to remain retention-only", got.PoolScaleCheckPartialTemplates)
+	}
+	if !got.PoolPartialRetentionTemplates[dispatcher] {
+		t.Fatalf("PoolPartialRetentionTemplates = %v, want control-dispatcher template %q retained on a routed-demand outage (gc-ft31x)", got.PoolPartialRetentionTemplates, dispatcher)
 	}
 	if !got.ScaleCheckPartialTemplates[dispatcher] {
 		t.Fatalf("ScaleCheckPartialTemplates = %v, want control-dispatcher template %q marked partial on a routed-demand outage (gc-ft31x)", got.ScaleCheckPartialTemplates, dispatcher)
 	}
+	if _, ok := got.State["control-dispatcher-1"]; !ok {
+		t.Fatalf("desired state = %v, want existing dispatcher retained during routed-demand outage", mapKeys(got.State))
+	}
+	retained := retainScaleCheckPartialPoolDesired(cfg, nil, snapshot, got.PoolPartialRetentionTemplates)
+	if retained[dispatcher] != 1 {
+		t.Fatalf("retained dispatcher count = %d, want 1", retained[dispatcher])
+	}
+}
+
+// TestBuildDesiredStateStartsColdControlDispatcherFromHealthyStoreDuringOtherStoreOutage
+// covers gc-ft31x.2: a failed live routed-demand read is retention-only. It
+// must preserve an existing dispatcher, but it must not veto a cold dispatcher
+// create justified by real control work visible in another store.
+func TestBuildDesiredStateStartsColdControlDispatcherFromHealthyStoreDuringOtherStoreOutage(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := liveOpenListErrorStore{Store: beads.NewMemStore(), err: errors.New("city live open list outage")}
+	rigStore := beads.NewMemStore()
+	if _, err := rigStore.Create(beads.Bead{
+		Title:  "Finalize workflow",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:     beadmeta.KindWorkflowFinalize,
+			beadmeta.RoutedToMetadataKey: "core.control-dispatcher",
+		},
+	}); err != nil {
+		t.Fatalf("create rig control work: %v", err)
+	}
+
+	maxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "fixture", Path: t.TempDir()}},
+		Agents: []config.Agent{{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: &maxActive,
+		}},
+	}
+
+	got := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), cityStore,
+		map[string]beads.Store{"fixture": rigStore}, newSessionBeadSnapshot(nil), nil, io.Discard,
+	)
+
+	if got.ScaleCheckCounts["core.control-dispatcher"] != 1 {
+		t.Fatalf("ScaleCheckCounts = %v, want healthy-store control demand for core.control-dispatcher", got.ScaleCheckCounts)
+	}
+	if got.PoolScaleCheckPartialTemplates["core.control-dispatcher"] {
+		t.Fatalf("PoolScaleCheckPartialTemplates = %v, want unrelated live-list outage not to suppress cold create", got.PoolScaleCheckPartialTemplates)
+	}
+	for _, desired := range got.State {
+		if desired.TemplateName == "core.control-dispatcher" {
+			return
+		}
+	}
+	t.Fatalf("desired state = %v, want cold core.control-dispatcher planned despite unrelated store outage", mapKeys(got.State))
 }
 
 // blockedDemandStore models the production controller-demand List reads for a

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2255,7 +2255,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
 				cr.cfg, poolWorkBeads, sessionBeads.OpenInfos(), result.ScaleCheckCounts, trace)),
 			sessionBeads,
-			result.PoolScaleCheckPartialTemplates,
+			effectivePoolPartialRetentionTemplates(result),
 		)
 		recordPhase(TraceSitePoolDemandCompute, "bead_reconcile.compute_pool_desired", phaseStart, map[string]any{
 			"pool_work_bead_count": len(poolWorkBeads),
@@ -3066,7 +3066,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		PoolDesiredCounts(ComputePoolDesiredStates(
 			filteredCfg, poolWorkBeads, openInfos, wfcResult.ScaleCheckCounts)),
 		filteredSnap,
-		wfcResult.PoolScaleCheckPartialTemplates,
+		effectivePoolPartialRetentionTemplates(wfcResult),
 	)
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
@@ -3282,7 +3282,7 @@ func (cr *CityRuntime) loadDemandSnapshot(
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
 				cr.cfg, poolWorkBeads, openSessionInfos, result.ScaleCheckCounts, trace)),
 			sessionBeads,
-			result.PoolScaleCheckPartialTemplates,
+			effectivePoolPartialRetentionTemplates(result),
 		)
 		if result.PoolDesiredCounts == nil {
 			result.PoolDesiredCounts = make(map[string]int)

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1025,7 +1025,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		PoolDesiredCounts(ComputePoolDesiredStates(
 			cfg, poolWorkBeads, openInfos, dsResult.ScaleCheckCounts)),
 		sessionBeads,
-		dsResult.PoolScaleCheckPartialTemplates,
+		effectivePoolPartialRetentionTemplates(dsResult),
 	)
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)


### PR DESCRIPTION
## Problem

When a demand read over multiple stores completes only partially, the scale-check pass marks every control-dispatcher template as partial. That marking does two jobs at once: it retains existing dispatcher sessions (correct, fail-safe) and it suppresses new dispatcher creates (incorrect when a healthy store is exposing real control demand). The result is a cold system that cannot spawn its first control dispatcher while any store read is degraded, even though another store has live demand. Follow-up to the demand-read work in #4395.

## Fix

Split the two behaviors. Partial-read markings are now retention-only: they keep existing dispatchers alive but never veto a create. Create suppression applies only from an ordinary scale-check verdict computed over the stores that did read successfully.

## Tests

New two-store regression: one store exposes control demand, the other simulates an outage mid-read. The test fails before the production change (cold dispatcher create vetoed) and passes after (create planned, existing dispatchers still retained). Focused suite run with the race detector, plus vet and build, all green at this head.
