### PR TITLE
fix(session): align bead actor with canonical alias

### DIFF
--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -4195,11 +4195,10 @@ func TestBdRuntimeEnvDoesNotDefaultBeadsActorWhenUnset(t *testing.T) {
 	}
 }
 
-// TestBdRuntimeEnvPreservesInheritedBeadsActor verifies that session
-// contexts (template_resolve.go sets BEADS_ACTOR=<sessname>) and exec
-// orders (orderExecEnv sets BEADS_ACTOR=order:<name>) are not clobbered by
-// the neutral bd runtime env. The key is omitted so the inherited value
-// passes through mergeEnv unchanged.
+// TestBdRuntimeEnvPreservesInheritedBeadsActor verifies that the authoritative
+// session runtime context and exec orders can set BEADS_ACTOR without the
+// neutral bd runtime env clobbering it. The neutral map omits the key so the
+// inherited value passes through mergeEnv unchanged.
 func TestBdRuntimeEnvPreservesInheritedBeadsActor(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/cmd_agent_script.go
+++ b/cmd/gc/cmd_agent_script.go
@@ -816,7 +816,7 @@ func agentScriptHookExitIsNoWork(output, stderr string) bool {
 }
 
 func agentScriptClaimActor() string {
-	for _, key := range []string{"GC_SESSION_NAME", "GC_AGENT", "GC_ALIAS", "BEADS_ACTOR"} {
+	for _, key := range []string{"GC_ALIAS", "BEADS_ACTOR", "GC_AGENT", "GC_SESSION_NAME"} {
 		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 			return value
 		}
@@ -838,7 +838,7 @@ func agentScriptRig() string {
 }
 
 func agentScriptAlias() string {
-	for _, key := range []string{"GC_ALIAS", "GC_SESSION_NAME", "GC_AGENT"} {
+	for _, key := range []string{"GC_ALIAS", "BEADS_ACTOR", "GC_AGENT", "GC_SESSION_NAME"} {
 		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 			return value
 		}

--- a/cmd/gc/cmd_agent_script_test.go
+++ b/cmd/gc/cmd_agent_script_test.go
@@ -14,8 +14,9 @@ import (
 	"time"
 )
 
-func TestAgentScriptBDClaimUsesSessionActor(t *testing.T) {
-	t.Setenv("GC_SESSION_NAME", "demo/worker-1")
+func TestAgentScriptBDClaimUsesCanonicalActor(t *testing.T) {
+	t.Setenv("GC_ALIAS", "demo/worker")
+	t.Setenv("GC_SESSION_NAME", "demo--worker")
 
 	var calls [][]string
 	exec := agentScriptExecutor{
@@ -37,9 +38,42 @@ func TestAgentScriptBDClaimUsesSessionActor(t *testing.T) {
 	if exitCode != nil {
 		t.Fatalf("exitCode = %v, want nil", *exitCode)
 	}
-	want := []string{"bd", "update", "ga-123", "--claim", "--actor", "demo/worker-1"}
+	want := []string{"bd", "update", "ga-123", "--claim", "--actor", "demo/worker"}
 	if len(calls) != 1 || !slices.Equal(calls[0], want) {
 		t.Fatalf("calls = %#v, want %#v", calls, [][]string{want})
+	}
+}
+
+func TestAgentScriptClaimActorFallsBackToSessionName(t *testing.T) {
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_SESSION_NAME", "demo--worker")
+	t.Setenv("BEADS_ACTOR", "")
+
+	if got := agentScriptClaimActor(); got != "demo--worker" {
+		t.Fatalf("agentScriptClaimActor() = %q, want session name fallback", got)
+	}
+}
+
+func TestAgentScriptClaimActorPrefersProjectedActor(t *testing.T) {
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("BEADS_ACTOR", "repair-id")
+	t.Setenv("GC_AGENT", "stale")
+	t.Setenv("GC_SESSION_NAME", "s-repair-id")
+
+	if got := agentScriptClaimActor(); got != "repair-id" {
+		t.Fatalf("agentScriptClaimActor() = %q, want projected actor", got)
+	}
+}
+
+func TestAgentScriptAliasPrefersDurableOwner(t *testing.T) {
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("BEADS_ACTOR", "repair-id")
+	t.Setenv("GC_AGENT", "stale")
+	t.Setenv("GC_SESSION_NAME", "s-repair-id")
+
+	if got := agentScriptAlias(); got != "repair-id" {
+		t.Fatalf("agentScriptAlias() = %q, want durable owner", got)
 	}
 }
 

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -366,13 +366,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 	agentForQuery := resolvedAgentName
 	sessionForQuery := ""
 	if sessionTemplateContext {
-		agentForQuery = os.Getenv("GC_ALIAS")
-		if agentForQuery == "" {
-			agentForQuery = os.Getenv("GC_SESSION_NAME")
-		}
-		if agentForQuery == "" {
-			agentForQuery = os.Getenv("GC_AGENT")
-		}
+		agentForQuery = hookSessionAgentForQuery()
 		sessionForQuery = os.Getenv("GC_SESSION_NAME")
 	} else {
 		sessionForQuery = cliSessionName(cityPath, cityName, resolvedAgentName, cfg.Workspace.SessionTemplate)
@@ -445,7 +439,9 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		sessionID := strings.TrimSpace(overrides["GC_SESSION_ID"])
 		sessionName := strings.TrimSpace(sessionForQuery)
 		alias := strings.TrimSpace(overrides["GC_ALIAS"])
-		assignee := firstNonEmptyHookValue(sessionName, sessionID, alias, agentForQuery, resolvedAgentName)
+		// Write the alias/agent form that read paths query through GC_AGENT.
+		// Session forms remain fallbacks for unaliased workers.
+		assignee := firstNonEmptyHookValue(alias, agentForQuery, resolvedAgentName, sessionName, sessionID)
 		claimOpts := hookClaimOptions{
 			Assignee: assignee,
 			// IdentityCandidates governs ADOPTION of already-owned in_progress/open
@@ -686,6 +682,15 @@ func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, store
 
 func hookClaimPrimaryRouteTarget(a *config.Agent) string {
 	return agentutil.RoutedToIdentity(a)
+}
+
+func hookSessionAgentForQuery() string {
+	return firstNonEmptyHookValue(
+		os.Getenv("GC_ALIAS"),
+		os.Getenv("BEADS_ACTOR"),
+		os.Getenv("GC_AGENT"),
+		os.Getenv("GC_SESSION_NAME"),
+	)
 }
 
 func firstNonEmptyHookValue(values ...string) string {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -1548,7 +1548,7 @@ work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
 	}
 }
 
-func TestHookCommandClaimUsesSessionActorAndPreassignsContinuation(t *testing.T) {
+func TestHookCommandClaimUsesCanonicalActorAndPreassignsContinuation(t *testing.T) {
 	clearGCEnv(t)
 	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
@@ -1602,7 +1602,7 @@ esac
 	t.Setenv("GC_TEMPLATE", "worker")
 	t.Setenv("GC_ALIAS", "worker-1")
 	t.Setenv("GC_SESSION_ID", "session-id-1")
-	t.Setenv("GC_SESSION_NAME", "worker-1")
+	t.Setenv("GC_SESSION_NAME", "test-city--worker-1")
 	t.Setenv("GC_SESSION_ORIGIN", "ephemeral")
 
 	var stdout, stderr bytes.Buffer
@@ -1630,16 +1630,43 @@ esac
 	}
 	logText := string(logData)
 	if !strings.Contains(logText, "actor=worker-1 args=update hw-claim --claim --json") {
-		t.Fatalf("bd claim did not use session BEADS_ACTOR=worker-1; log:\n%s", logText)
+		t.Fatalf("bd claim did not use canonical BEADS_ACTOR=worker-1; log:\n%s", logText)
 	}
 	if !strings.Contains(logText, "actor=worker-1 args=show --json hw-claim") {
-		t.Fatalf("bd canonical read did not use session BEADS_ACTOR=worker-1; log:\n%s", logText)
+		t.Fatalf("bd canonical read did not use BEADS_ACTOR=worker-1; log:\n%s", logText)
 	}
 	if !strings.Contains(logText, "args=update --json hw-next --assignee worker-1") {
 		t.Fatalf("continuation sibling was not preassigned through bd; log:\n%s", logText)
 	}
 	if strings.Contains(logText, "args=update hw-other --assignee") {
 		t.Fatalf("continuation preassignment crossed route target; log:\n%s", logText)
+	}
+}
+
+func TestHookSessionAgentForQueryPrefersOwnershipIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		alias       string
+		actor       string
+		agent       string
+		sessionName string
+		want        string
+	}{
+		{name: "alias", alias: "rig/worker", actor: "session-id", agent: "stale", sessionName: "rig--worker", want: "rig/worker"},
+		{name: "durable actor fallback", actor: "session-id", agent: "stale", sessionName: "s-session-id", want: "session-id"},
+		{name: "compatibility fallback", agent: "session-id", sessionName: "s-session-id", want: "session-id"},
+		{name: "runtime fallback", sessionName: "rig--worker", want: "rig--worker"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearGCEnv(t)
+			t.Setenv("GC_ALIAS", tc.alias)
+			t.Setenv("BEADS_ACTOR", tc.actor)
+			t.Setenv("GC_AGENT", tc.agent)
+			t.Setenv("GC_SESSION_NAME", tc.sessionName)
+			if got := hookSessionAgentForQuery(); got != tc.want {
+				t.Fatalf("hookSessionAgentForQuery() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1781,8 +1781,15 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				bySessionName[createdSessionName] = newBead
 				indexBySessionName[createdSessionName] = len(openBeads) - 1
 				if liveAlias := strings.TrimSpace(meta["alias"]); liveAlias != "" && state == "active" {
-					if err := session.SyncRuntimeAlias(sp, createdSessionName, liveAlias); err != nil {
-						fmt.Fprintf(stderr, "session beads: syncing runtime alias %q for %s: %v\n", liveAlias, agentName, err) //nolint:errcheck
+					runtimeInfo, infoErr := sessFront.Get(newBead.ID)
+					if infoErr != nil {
+						fmt.Fprintf(stderr, "session beads: reading runtime identity for %s: %v\n", agentName, infoErr) //nolint:errcheck
+					} else {
+						runtimeInfo.SessionName = createdSessionName
+						runtimeInfo.Alias = liveAlias
+						if err := session.SyncRuntimeAlias(sp, runtimeInfo); err != nil {
+							fmt.Fprintf(stderr, "session beads: syncing runtime alias %q for %s: %v\n", liveAlias, agentName, err) //nolint:errcheck
+						}
 					}
 				}
 			}
@@ -1975,8 +1982,15 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 						openBeads[idx] = b
 					}
 					if aliasValue, ok := batch["alias"]; ok && state == "active" {
-						if err := session.SyncRuntimeAlias(sp, sn, aliasValue); err != nil {
-							fmt.Fprintf(stderr, "session beads: syncing runtime alias %q for %s: %v\n", aliasValue, agentName, err) //nolint:errcheck
+						runtimeInfo, infoErr := sessFront.Get(b.ID)
+						if infoErr != nil {
+							fmt.Fprintf(stderr, "session beads: reading runtime identity for %s: %v\n", agentName, infoErr) //nolint:errcheck
+						} else {
+							runtimeInfo.SessionName = sn
+							runtimeInfo.Alias = aliasValue
+							if err := session.SyncRuntimeAlias(sp, runtimeInfo); err != nil {
+								fmt.Fprintf(stderr, "session beads: syncing runtime alias %q for %s: %v\n", aliasValue, agentName, err) //nolint:errcheck
+							}
 						}
 					}
 				}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2697,6 +2697,13 @@ func TestSyncSessionBeads_ClearsManagedAliasWhenRemoved(t *testing.T) {
 	} else if got != "" {
 		t.Fatalf("GC_ALIAS = %q, want empty", got)
 	}
+	for _, key := range []string{"GC_AGENT", "BEADS_ACTOR"} {
+		if got, err := sp.GetMeta("s-gc-123", key); err != nil {
+			t.Fatalf("GetMeta(%s): %v", key, err)
+		} else if got != "s-gc-123" {
+			t.Fatalf("%s = %q, want session-name fallback", key, got)
+		}
+	}
 }
 
 func TestSyncSessionBeads_Idempotent(t *testing.T) {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1146,13 +1146,10 @@ func buildPreparedStartWithWorkDirResolver(
 		// recoverRunningPendingCreate / direct-call paths where it was empty.
 		candidate.info = candidate.info.ApplyPatch(sessionpkg.MetadataPatch{"instance_token": instanceToken})
 	}
-	beadAlias := strings.TrimSpace(candidate.info.Alias)
+	runtimeInfo := candidate.info
+	runtimeInfo.SessionName = candidate.name()
 	runtimeEnv := sessionpkg.RuntimeEnvWithSessionContext(
-		candidate.info.ID,
-		candidate.name(),
-		beadAlias,
-		strings.TrimSpace(candidate.info.Template),
-		strings.TrimSpace(candidate.info.SessionOrigin),
+		runtimeInfo,
 		generation,
 		continuationEpoch,
 		instanceToken,

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -7050,13 +7050,11 @@ func TestPrepareStartCandidate_PreservesRuntimeConfigAndProviderEnv(t *testing.T
 		t.Fatalf("continuation_epoch metadata = %q: %v", stored.Metadata["continuation_epoch"], err)
 	}
 
+	expectedInfo := sessiontest.SeedBead(t, stored)
+	expectedInfo.SessionName = tp.SessionName
 	expected := templateParamsToConfig(tp)
 	expected.Env = mergeEnv(expected.Env, sessionpkg.RuntimeEnvWithSessionContext(
-		stored.ID,
-		tp.SessionName,
-		tp.Alias,
-		stored.Metadata["template"],
-		stored.Metadata["session_origin"],
+		expectedInfo,
 		generation,
 		continuationEpoch,
 		stored.Metadata["instance_token"],

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -281,7 +281,6 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		"GC_SESSION_ORIGIN":   "ephemeral",
 		"GC_AGENT":            sessName,
 		"GC_ALIAS":            qualifiedName,
-		"BEADS_ACTOR":         sessName,
 		"GC_DIR":              workDir,
 		"GC_BEADS_SCOPE_ROOT": p.cityPath,
 		// Explicit empty values matter here. tmux session creation uses `env -u`

--- a/engdocs/design/session-model-unification.md
+++ b/engdocs/design/session-model-unification.md
@@ -655,6 +655,7 @@ matches the unified model:
 - `GC_TEMPLATE` = qualified backing agent-config identity
 - `GC_SESSION_ORIGIN` = `named`, `ephemeral`, or `manual`
 - `GC_AGENT` = temporary compatibility alias for the public handle only
+- `BEADS_ACTOR` = exact ownership string the running session presents to `bd`
 
 New prompt and hook logic should key config semantics off `GC_TEMPLATE`
 and lifecycle semantics off `GC_SESSION_ORIGIN`, not off `GC_AGENT`.
@@ -664,8 +665,8 @@ and lifecycle semantics off `GC_SESSION_ORIGIN`, not off `GC_AGENT`.
 | Origin | `configured_named_identity` | `alias` | `session_name` | `GC_ALIAS` | `GC_AGENT` |
 |---|---|---|---|---|---|
 | `named` | present; immutable fully qualified named identity | always equals `configured_named_identity` while config-managed | deterministic runtime handle derived from the named identity and workspace naming policy | same as `alias` | same as `alias` |
-| `ephemeral` | absent | optional, mutable if non-conflicting | opaque runtime handle | alias if present | alias if present, otherwise `session_name` |
-| `manual` | absent | optional, mutable if non-conflicting | opaque runtime handle | alias if present | alias if present, otherwise `session_name` |
+| `ephemeral` | absent | optional, mutable if non-conflicting | opaque runtime handle | alias if present | alias if present; otherwise raw `session_name`, or bead ID when name metadata is absent |
+| `manual` | absent | optional, mutable if non-conflicting | opaque runtime handle | alias if present | alias if present; otherwise raw `session_name`, or bead ID when name metadata is absent |
 
 Configured named sessions do not carry a second mutable runtime alias
 separate from their configured identity.
@@ -685,11 +686,36 @@ Phase 1 `GC_AGENT` contract is exact:
 
 - `named`: identical to `GC_ALIAS`, which is the configured named
   identity
-- `ephemeral` and `manual`: `GC_ALIAS` if present, otherwise
-  `GC_SESSION_NAME`
+- `ephemeral` and `manual`: `GC_ALIAS` if present, otherwise raw persisted
+  `session_name`, falling back to the session bead ID when name metadata is absent
 
 No Phase 1 path may interpret `GC_AGENT` as backing config identity,
 factory target, or durable ownership token.
+
+### Transitional ownership projection
+
+The canonical persistence target remains `assignee=<session-bead-id>` as
+specified in [Ownership and Routing](#ownership-and-routing). Until that
+migration reaches every ownership writer and prompt, GC-owned compatibility
+paths must keep the stored assignee and the runtime actor byte-identical. They
+select the current ownership string in this order:
+
+1. current `alias`
+2. `configured_named_identity` for a recovered named session whose alias is
+   temporarily absent
+3. raw persisted `session_name`
+4. session bead ID when no name metadata exists
+
+`BEADS_ACTOR`, API assignment normalization, hook claims, and scripted claims
+must all use that selector. `GC_AGENT` mirrors the selected value only for
+compatibility; new ownership logic reads `BEADS_ACTOR` or the typed session
+projection rather than treating `GC_AGENT` as a durable field.
+
+Runtime metadata updates do not rewrite the environment of an already-running
+agent process. Deploying a change to this projection therefore requires those
+sessions to restart before direct `bd` commands inherit the new actor. Metadata
+synchronization keeps provider state coherent for subsequent launches; it is
+not a live-process migration.
 
 ## Materialization Rules
 

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -1754,8 +1754,8 @@ func TestPhase2BeadAssignNormalizesCurrentSessionAlias(t *testing.T) {
 		t.Fatalf("assign alias status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.Metadata["session_name"] {
-		t.Fatalf("assignee = %q, want alias normalized to session_name %q", got.Assignee, sessionBead.Metadata["session_name"])
+	if got.Assignee != sessionBead.Metadata["alias"] {
+		t.Fatalf("assignee = %q, want canonical alias %q", got.Assignee, sessionBead.Metadata["alias"])
 	}
 
 	listReq := httptest.NewRequest("GET", cityURL(state, "/beads?assignee=worker"), nil)
@@ -1865,8 +1865,8 @@ func TestPhase2BeadAssignNormalizesCurrentSessionName(t *testing.T) {
 		t.Fatalf("assign session_name status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.Metadata["session_name"] {
-		t.Fatalf("assignee = %q, want session_name preserved as %q", got.Assignee, sessionBead.Metadata["session_name"])
+	if got.Assignee != sessionBead.Metadata["alias"] {
+		t.Fatalf("assignee = %q, want session_name normalized to canonical alias %q", got.Assignee, sessionBead.Metadata["alias"])
 	}
 }
 
@@ -2000,8 +2000,8 @@ func TestPhase2BeadAssignAcceptsRepairableSessionBeadID(t *testing.T) {
 		t.Fatalf("assign repairable session status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.Metadata["session_name"] {
-		t.Fatalf("assignee = %q, want repairable session_name %q", got.Assignee, sessionBead.Metadata["session_name"])
+	if got.Assignee != sessionBead.Metadata["alias"] {
+		t.Fatalf("assignee = %q, want repairable session alias %q", got.Assignee, sessionBead.Metadata["alias"])
 	}
 	gotSession, _ := state.cityBeadStore.Get(sessionBead.ID)
 	if gotSession.Type != session.BeadType {
@@ -2027,8 +2027,8 @@ func TestPhase2BeadUpdateNormalizesRawAssigneeAlias(t *testing.T) {
 		t.Fatalf("update alias status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	got, _ := store.Get(work.ID)
-	if got.Assignee != sessionBead.Metadata["session_name"] {
-		t.Fatalf("assignee = %q, want alias normalized to session_name %q", got.Assignee, sessionBead.Metadata["session_name"])
+	if got.Assignee != sessionBead.Metadata["alias"] {
+		t.Fatalf("assignee = %q, want canonical alias %q", got.Assignee, sessionBead.Metadata["alias"])
 	}
 }
 
@@ -2053,8 +2053,8 @@ func TestPhase2BeadCreateNormalizesRawAssigneeAlias(t *testing.T) {
 	if len(items) != 1 {
 		t.Fatalf("created %d beads, want 1", len(items))
 	}
-	if items[0].Assignee != sessionBead.Metadata["session_name"] {
-		t.Fatalf("created assignee = %q, want alias normalized to session_name %q", items[0].Assignee, sessionBead.Metadata["session_name"])
+	if items[0].Assignee != sessionBead.Metadata["alias"] {
+		t.Fatalf("created assignee = %q, want canonical alias %q", items[0].Assignee, sessionBead.Metadata["alias"])
 	}
 }
 

--- a/internal/session/assignee_identities.go
+++ b/internal/session/assignee_identities.go
@@ -46,17 +46,15 @@ func AssigneeIdentities(i Info) []string {
 	return identities
 }
 
-// AssigneeIdentifier returns the durable agent-facing identity form of a
-// session — its session_name, else alias, else configured named identity —
-// falling back to the bead ID when no name metadata is present so a resolved
-// assignment is never silently cleared. This is the form the agent claims and
-// verifies work with (BEADS_ACTOR / GC_SESSION_NAME), so stamping it keeps
-// assign/update consistent with the claim path (which already stores the raw
-// session-name) and with the form-agnostic matching in AssigneeIdentities.
-// Stamping the bare bead ID here instead made template-routed continuation work
-// unclaimable by name-matching agents.
+// AssigneeIdentifier returns the durable agent-facing ownership identity of a
+// session: its current public alias, configured named identity, or runtime
+// session name, falling back to the bead ID when no name metadata is present.
+// This is the same alias-first identity RuntimeEnvWithSessionContext exposes
+// through GC_ALIAS and BEADS_ACTOR; GC_AGENT mirrors it only for compatibility.
+// Keeping API assignment normalization on this rule prevents one session from
+// owning work under a different exact string than it presents to bd.
 func AssigneeIdentifier(i Info) string {
-	for _, v := range []string{i.SessionNameMetadata, i.Alias, i.ConfiguredNamedIdentity} {
+	for _, v := range []string{i.Alias, i.ConfiguredNamedIdentity, i.SessionNameMetadata} {
 		if v = strings.TrimSpace(v); v != "" {
 			return v
 		}

--- a/internal/session/assignee_identities_test.go
+++ b/internal/session/assignee_identities_test.go
@@ -130,19 +130,19 @@ func TestAssigneeIdentifier(t *testing.T) {
 		want string
 	}{
 		{
-			name: "session_name wins",
+			name: "alias wins",
 			info: Info{ID: "s1", SessionNameMetadata: "sn", Alias: "al", ConfiguredNamedIdentity: "ni"},
-			want: "sn",
-		},
-		{
-			name: "alias when no session_name",
-			info: Info{ID: "s1", Alias: "al", ConfiguredNamedIdentity: "ni"},
 			want: "al",
 		},
 		{
-			name: "configured named identity when no session_name or alias",
-			info: Info{ID: "s1", ConfiguredNamedIdentity: "ni"},
+			name: "configured named identity when no alias",
+			info: Info{ID: "s1", SessionNameMetadata: "sn", ConfiguredNamedIdentity: "ni"},
 			want: "ni",
+		},
+		{
+			name: "session_name when no public identity",
+			info: Info{ID: "s1", SessionNameMetadata: "sn"},
+			want: "sn",
 		},
 		{
 			name: "bead id fallback when no name metadata",
@@ -156,8 +156,8 @@ func TestAssigneeIdentifier(t *testing.T) {
 		},
 		{
 			name: "values trimmed",
-			info: Info{ID: "s1", SessionNameMetadata: "  sn  "},
-			want: "sn",
+			info: Info{ID: "s1", Alias: "  al  ", SessionNameMetadata: "  sn  "},
+			want: "al",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -373,11 +373,7 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 		b.Metadata["instance_token"] = instanceToken
 	}
 	cfg.Env = mergeEnv(cfg.Env, RuntimeEnvWithSessionContext(
-		id,
-		sessName,
-		strings.TrimSpace(b.Metadata["alias"]),
-		strings.TrimSpace(b.Metadata["template"]),
-		strings.TrimSpace(b.Metadata["session_origin"]),
+		infoFromPersistedBead(b),
 		generation,
 		continuationEpoch,
 		instanceToken,
@@ -492,11 +488,7 @@ func (m *Manager) ensureRunningRuntimeOnly(ctx context.Context, id string, b bea
 		b.Metadata["instance_token"] = instanceToken
 	}
 	cfg.Env = mergeEnv(cfg.Env, RuntimeEnvWithSessionContext(
-		id,
-		sessName,
-		strings.TrimSpace(b.Metadata["alias"]),
-		strings.TrimSpace(b.Metadata["template"]),
-		strings.TrimSpace(b.Metadata["session_origin"]),
+		infoFromPersistedBead(b),
 		generation,
 		continuationEpoch,
 		instanceToken,

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -3,7 +3,10 @@ package session
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/runtime"
 )
@@ -56,32 +59,81 @@ func RuntimeEnvWithAlias(sessionID, sessionName, alias string, generation, conti
 	return env
 }
 
-// RuntimeEnvWithSessionContext extends RuntimeEnvWithAlias with the
-// session-model context shared by controller, CLI, and API starts.
-func RuntimeEnvWithSessionContext(sessionID, sessionName, alias, template, origin string, generation, continuationEpoch int, instanceToken string) map[string]string {
-	env := RuntimeEnvWithAlias(sessionID, sessionName, alias, generation, continuationEpoch, instanceToken)
-	if template != "" {
+// RuntimeEnvWithSessionContext projects one session Info into the runtime
+// identity environment shared by controller, CLI, and API starts. Keeping the
+// runtime handle and raw persisted identity on Info lets AssigneeIdentifier
+// choose the exact same ownership string as API assignment normalization,
+// including the bead-ID fallback for a repairable session with no stored name.
+func RuntimeEnvWithSessionContext(info Info, generation, continuationEpoch int, instanceToken string) map[string]string {
+	publicAlias := runtimePublicAlias(info)
+	env := RuntimeEnvWithAlias(info.ID, info.SessionName, publicAlias, generation, continuationEpoch, instanceToken)
+	if template := strings.TrimSpace(info.Template); template != "" {
 		env["GC_TEMPLATE"] = template
 	}
-	if origin != "" {
+	if origin := strings.TrimSpace(info.SessionOrigin); origin != "" {
 		env["GC_SESSION_ORIGIN"] = origin
 	}
-	if alias != "" {
-		env["GC_AGENT"] = alias
-	} else if sessionName != "" {
-		env["GC_AGENT"] = sessionName
+	if identity := AssigneeIdentifier(info); identity != "" {
+		env["GC_AGENT"] = identity
+		env["BEADS_ACTOR"] = identity
 	}
 	return env
 }
 
-// SyncRuntimeAlias updates the live runtime session metadata to reflect the
-// current public alias. Clearing the alias removes GC_ALIAS from the runtime.
-func SyncRuntimeAlias(sp runtime.Provider, sessionName, alias string) error {
+func runtimePublicAlias(info Info) string {
+	if alias := strings.TrimSpace(info.Alias); alias != "" {
+		return alias
+	}
+	return strings.TrimSpace(info.ConfiguredNamedIdentity)
+}
+
+// SyncRuntimeAlias updates live runtime metadata from the session's current
+// public alias and durable ownership identity. Clearing an alias therefore
+// falls back to the same raw session name or bead ID that API assignment uses.
+func SyncRuntimeAlias(sp runtime.Provider, info Info) error {
+	sessionName := strings.TrimSpace(info.SessionName)
 	if sp == nil || sessionName == "" {
 		return nil
 	}
-	if alias == "" {
-		return sp.RemoveMeta(sessionName, "GC_ALIAS")
+	type metaUpdate struct {
+		key    string
+		value  string
+		remove bool
 	}
-	return sp.SetMeta(sessionName, "GC_ALIAS", alias)
+	publicAlias := runtimePublicAlias(info)
+	identity := AssigneeIdentifier(info)
+	updates := []metaUpdate{
+		{key: "GC_ALIAS", value: publicAlias, remove: publicAlias == ""},
+		{key: "GC_AGENT", value: identity, remove: identity == ""},
+		{key: "BEADS_ACTOR", value: identity, remove: identity == ""},
+	}
+	previous := make(map[string]string, len(updates))
+	for _, update := range updates {
+		value, err := sp.GetMeta(sessionName, update.key)
+		if err != nil {
+			return fmt.Errorf("reading %s before runtime identity update: %w", update.key, err)
+		}
+		previous[update.key] = value
+	}
+	apply := func(update metaUpdate) error {
+		if update.remove {
+			return sp.RemoveMeta(sessionName, update.key)
+		}
+		return sp.SetMeta(sessionName, update.key, update.value)
+	}
+	applied := make([]metaUpdate, 0, len(updates))
+	for _, update := range updates {
+		if err := apply(update); err != nil {
+			errs := []error{fmt.Errorf("updating runtime identity %s: %w", update.key, err)}
+			for i := len(applied) - 1; i >= 0; i-- {
+				rollback := metaUpdate{key: applied[i].key, value: previous[applied[i].key], remove: previous[applied[i].key] == ""}
+				if rollbackErr := apply(rollback); rollbackErr != nil {
+					errs = append(errs, fmt.Errorf("rolling back runtime identity %s: %w", rollback.key, rollbackErr))
+				}
+			}
+			return errors.Join(errs...)
+		}
+		applied = append(applied, update)
+	}
+	return nil
 }

--- a/internal/session/lifecycle_actor_test.go
+++ b/internal/session/lifecycle_actor_test.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+type failingMetaProvider struct {
+	runtime.Provider
+	failKey string
+}
+
+func (p failingMetaProvider) SetMeta(name, key, value string) error {
+	if key == p.failKey {
+		return errors.New("set denied")
+	}
+	return p.Provider.SetMeta(name, key, value)
+}
+
+func TestRuntimeEnvWithSessionContextAlignsAgentAndBeadsActor(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		alias                string
+		configuredIdentity   string
+		sessionName          string
+		persistedSessionName string
+		want                 string
+	}{
+		{name: "canonical alias", alias: "rig/worker", sessionName: "rig--worker", persistedSessionName: "rig--worker", want: "rig/worker"},
+		{name: "configured named identity fallback", configuredIdentity: "rig/worker", sessionName: "rig--worker", persistedSessionName: "rig--worker", want: "rig/worker"},
+		{name: "session name fallback", sessionName: "rig--worker", persistedSessionName: "rig--worker", want: "rig--worker"},
+		{name: "bead id fallback", sessionName: "s-session-id", want: "session-id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			info := Info{
+				ID:                      "session-id",
+				SessionName:             tc.sessionName,
+				SessionNameMetadata:     tc.persistedSessionName,
+				Alias:                   tc.alias,
+				ConfiguredNamedIdentity: tc.configuredIdentity,
+				Template:                "rig/template",
+				SessionOrigin:           "ephemeral",
+			}
+			env := RuntimeEnvWithSessionContext(
+				info,
+				DefaultGeneration,
+				DefaultContinuationEpoch,
+				"instance-token",
+			)
+
+			if got := env["GC_SESSION_NAME"]; got != tc.sessionName {
+				t.Fatalf("GC_SESSION_NAME = %q, want %q", got, tc.sessionName)
+			}
+			for _, key := range []string{"GC_AGENT", "BEADS_ACTOR"} {
+				if got := env[key]; got != tc.want {
+					t.Fatalf("%s = %q, want %q", key, got, tc.want)
+				}
+			}
+			if got := AssigneeIdentifier(info); got != env["BEADS_ACTOR"] {
+				t.Fatalf("AssigneeIdentifier = %q, BEADS_ACTOR = %q", got, env["BEADS_ACTOR"])
+			}
+		})
+	}
+}
+
+func TestSyncRuntimeAliasAlignsOwnershipMetadata(t *testing.T) {
+	sp := runtime.NewFake()
+	assertMeta := func(sessionName, key, want string) {
+		t.Helper()
+		got, err := sp.GetMeta(sessionName, key)
+		if err != nil {
+			t.Fatalf("GetMeta(%s): %v", key, err)
+		}
+		if got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	info := Info{ID: "session-id", SessionName: "rig--worker", SessionNameMetadata: "rig--worker", Alias: "rig/worker"}
+	if err := SyncRuntimeAlias(sp, info); err != nil {
+		t.Fatalf("SyncRuntimeAlias(set): %v", err)
+	}
+	for _, key := range []string{"GC_ALIAS", "GC_AGENT", "BEADS_ACTOR"} {
+		assertMeta(info.SessionName, key, "rig/worker")
+	}
+
+	info.Alias = ""
+	if err := SyncRuntimeAlias(sp, info); err != nil {
+		t.Fatalf("SyncRuntimeAlias(clear): %v", err)
+	}
+	assertMeta(info.SessionName, "GC_ALIAS", "")
+	for _, key := range []string{"GC_AGENT", "BEADS_ACTOR"} {
+		assertMeta(info.SessionName, key, "rig--worker")
+	}
+
+	repairInfo := Info{ID: "repair-id", SessionName: "s-repair-id"}
+	if err := SyncRuntimeAlias(sp, repairInfo); err != nil {
+		t.Fatalf("SyncRuntimeAlias(repair): %v", err)
+	}
+	assertMeta(repairInfo.SessionName, "GC_ALIAS", "")
+	for _, key := range []string{"GC_AGENT", "BEADS_ACTOR"} {
+		assertMeta(repairInfo.SessionName, key, "repair-id")
+	}
+}
+
+func TestSyncRuntimeAliasRollsBackOnPartialFailure(t *testing.T) {
+	base := runtime.NewFake()
+	for _, key := range []string{"GC_ALIAS", "GC_AGENT", "BEADS_ACTOR"} {
+		if err := base.SetMeta("rig--worker", key, "old-alias"); err != nil {
+			t.Fatalf("seed %s: %v", key, err)
+		}
+	}
+	sp := failingMetaProvider{Provider: base, failKey: "BEADS_ACTOR"}
+	info := Info{ID: "session-id", SessionName: "rig--worker", SessionNameMetadata: "rig--worker", Alias: "new-alias"}
+
+	if err := SyncRuntimeAlias(sp, info); err == nil {
+		t.Fatal("SyncRuntimeAlias() error = nil, want BEADS_ACTOR failure")
+	}
+	for _, key := range []string{"GC_ALIAS", "GC_AGENT", "BEADS_ACTOR"} {
+		got, err := base.GetMeta("rig--worker", key)
+		if err != nil {
+			t.Fatalf("GetMeta(%s): %v", key, err)
+		}
+		if got != "old-alias" {
+			t.Fatalf("%s after rollback = %q, want old-alias", key, got)
+		}
+	}
+}

--- a/internal/session/lifecycle_holder_token_test.go
+++ b/internal/session/lifecycle_holder_token_test.go
@@ -24,7 +24,7 @@ func TestRuntimeEnvVariantsPropagateHolderToken(t *testing.T) {
 	if alias["BEADS_HOLDER_TOKEN"] != "tok-a" {
 		t.Errorf("WithAlias BEADS_HOLDER_TOKEN = %q, want tok-a", alias["BEADS_HOLDER_TOKEN"])
 	}
-	ctx := RuntimeEnvWithSessionContext("sid", "sname", "al", "tmpl", "cli", DefaultGeneration, DefaultContinuationEpoch, "tok-c")
+	ctx := RuntimeEnvWithSessionContext(Info{ID: "sid", SessionName: "sname", SessionNameMetadata: "sname", Alias: "al", ConfiguredNamedIdentity: "named", Template: "tmpl", SessionOrigin: "cli"}, DefaultGeneration, DefaultContinuationEpoch, "tok-c")
 	if ctx["BEADS_HOLDER_TOKEN"] != "tok-c" {
 		t.Errorf("WithSessionContext BEADS_HOLDER_TOKEN = %q, want tok-c", ctx["BEADS_HOLDER_TOKEN"])
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -972,16 +972,9 @@ func (m *Manager) createStarted(ctx context.Context, spec CreateOptions) (Info, 
 		cfg := hints
 		cfg.Command = startCommand
 		cfg.WorkDir = workDir
-		runtimeAlias := alias
-		if runtimeAlias == "" {
-			runtimeAlias = strings.TrimSpace(extraMeta["agent_name"])
-		}
+		runtimeInfo := m.infoFromBead(b)
 		cfg.Env = mergeEnv(mergeEnv(cfg.Env, env), RuntimeEnvWithSessionContext(
-			b.ID,
-			sessName,
-			runtimeAlias,
-			template,
-			meta["session_origin"],
+			runtimeInfo,
 			DefaultGeneration,
 			DefaultContinuationEpoch,
 			meta["instance_token"],
@@ -1576,15 +1569,19 @@ func (m *Manager) UpdatePresentation(id string, title *string, alias *string) er
 					}
 				}
 				update.Metadata = UpdatedAliasMetadata(b.Metadata, nextAlias)
+				runtimeInfo := m.infoFromBead(b)
+				runtimeInfo.SessionName = sessName
+				nextRuntimeInfo := runtimeInfo
+				nextRuntimeInfo.Alias = nextAlias
 				runtimeRunning := sessName != "" && m.sp != nil && m.sp.IsRunning(sessName)
 				if runtimeRunning {
-					if err := SyncRuntimeAlias(m.sp, sessName, nextAlias); err != nil {
+					if err := SyncRuntimeAlias(m.sp, nextRuntimeInfo); err != nil {
 						return fmt.Errorf("updating runtime alias: %w", err)
 					}
 				}
 				if err := m.store.Update(id, update); err != nil {
 					if runtimeRunning {
-						if rollbackErr := SyncRuntimeAlias(m.sp, sessName, currentAlias); rollbackErr != nil {
+						if rollbackErr := SyncRuntimeAlias(m.sp, runtimeInfo); rollbackErr != nil {
 							log.Printf("session %s: restoring runtime alias %q on %s failed: %v", id, currentAlias, sessName, rollbackErr)
 						}
 					}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1728,7 +1728,7 @@ func TestCreateInjectsUnifiedSessionRuntimeEnv(t *testing.T) {
 	mgr := NewManagerWithOptions(store, sp)
 
 	info, err := mgr.CreateSession(
-		context.Background(), CreateOptions{Alias: "mayor", ExplicitName: "test-city--mayor", Template: "reviewer", Title: "Mayor", Command: "claude", WorkDir: "/tmp", Provider: "claude", Transport: "", Env: map[string]string{"GC_AGENT": "stale"}, Resume: ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{
+		context.Background(), CreateOptions{Alias: "", ExplicitName: "test-city--mayor", Template: "reviewer", Title: "Mayor", Command: "claude", WorkDir: "/tmp", Provider: "claude", Transport: "", Env: map[string]string{"GC_AGENT": "stale"}, Resume: ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{
 			"configured_named_session":  "true",
 			"configured_named_identity": "mayor",
 			"session_origin":            "named",
@@ -1755,6 +1755,7 @@ func TestCreateInjectsUnifiedSessionRuntimeEnv(t *testing.T) {
 		"GC_TEMPLATE":       "reviewer",
 		"GC_SESSION_ORIGIN": "named",
 		"GC_AGENT":          "mayor",
+		"BEADS_ACTOR":       "mayor",
 	} {
 		if got := env[key]; got != want {
 			t.Fatalf("Env[%s] = %q, want %q (env=%v)", key, got, want, env)
@@ -1849,10 +1850,11 @@ func TestCreateAliaslessMultiSessionUsesConcreteRuntimeIdentity(t *testing.T) {
 	for key, want := range map[string]string{
 		"GC_SESSION_ID":     info.ID,
 		"GC_SESSION_NAME":   "ant-adhoc-123",
-		"GC_ALIAS":          "demo/ant-adhoc-123",
+		"GC_ALIAS":          "",
 		"GC_TEMPLATE":       "demo/ant",
 		"GC_SESSION_ORIGIN": "manual",
-		"GC_AGENT":          "demo/ant-adhoc-123",
+		"GC_AGENT":          "ant-adhoc-123",
+		"BEADS_ACTOR":       "ant-adhoc-123",
 	} {
 		if got := env[key]; got != want {
 			t.Fatalf("Env[%s] = %q, want %q (env=%v)", key, got, want, env)
@@ -2573,12 +2575,14 @@ func TestUpdatePresentationSyncsRuntimeAlias(t *testing.T) {
 		t.Fatalf("UpdatePresentation(alias): %v", err)
 	}
 
-	got, err := sp.GetMeta(info.SessionName, "GC_ALIAS")
-	if err != nil {
-		t.Fatalf("GetMeta(GC_ALIAS): %v", err)
-	}
-	if got != nextAlias {
-		t.Fatalf("GC_ALIAS = %q, want %q", got, nextAlias)
+	for _, key := range []string{"GC_ALIAS", "GC_AGENT", "BEADS_ACTOR"} {
+		got, err := sp.GetMeta(info.SessionName, key)
+		if err != nil {
+			t.Fatalf("GetMeta(%s): %v", key, err)
+		}
+		if got != nextAlias {
+			t.Fatalf("%s = %q, want %q", key, got, nextAlias)
+		}
 	}
 
 	bead, err := store.Get(info.ID)


### PR DESCRIPTION
## Problem

Gas City currently has two distinct session identifiers:

- the **public ownership identity** used by work discovery and claims (`alias`, with compatibility fallbacks)
- the provider **runtime handle** (`session_name`)

GC-owned paths selected between them independently. Hook claims, API assignment normalization, scripted claims, and `BEADS_ACTOR` could therefore write/present different exact strings for the same session. `bd` correctly rejects a close when the actor does not exactly match the assignee.

Changing only `BEADS_ACTOR` would invert the mismatch for upstream hook/API paths. The fix must move every GC-owned ownership writer and runtime actor together.

## Decision

The session object model now owns one compatibility selector in `internal/session.AssigneeIdentifier`:

1. current `alias`
2. `configured_named_identity` when recovering a named session whose alias is temporarily absent
3. raw persisted `session_name`
4. session bead ID when name metadata is absent

`RuntimeEnvWithSessionContext` and `SyncRuntimeAlias` accept typed `session.Info` and use that same selector. This preserves the distinction between `Info.SessionName` (the actual provider handle) and `Info.SessionNameMetadata` (the durable ownership fallback).

The CLI and API remain projections over that rule:

- API assign/update/create normalization calls `session.AssigneeIdentifier`
- hook and agent-script claims prefer `GC_ALIAS`, then projected `BEADS_ACTOR`, then compatibility `GC_AGENT`, then the runtime handle
- `template_resolve` no longer independently authors `BEADS_ACTOR`
- alias set/clear/rollback and reconciler alias sync pass post-update typed `session.Info`
- runtime metadata synchronization snapshots and rolls back partial provider failures

## Project-principle alignment

- **Object model at the center:** the selector and runtime projection live in `internal/session`; `cmd/gc` and `internal/api` consume them (`engdocs/architecture/invariants.md`).
- **Claim identity convention:** ownership reads and writes use the current concrete session identity, not the shared template queue key (`engdocs/architecture/prompt-templates.md`, “Claim Identity Convention”).
- **Public identity vs runtime handle:** aliases remain public identities; `session_name` remains the provider handle (`engdocs/design/named-configured-sessions.md`).
- **No new primitive or cognition:** this is deterministic transport normalization. `bd` still owns the atomic claim CAS (`engdocs/contributors/primitive-test.md`).
- **Migration-aware:** the final session-model target remains `assignee=<session-bead-id>`. `engdocs/design/session-model-unification.md` now documents this alias-first compatibility projection until that migration reaches every writer and prompt.
- **No role policy:** no configured role name or judgment entered Go code.

## Compatibility and rollout

- Aliasless sessions retain raw `session_name` ownership; repairable nameless sessions use bead ID while retaining their derived provider handle in `GC_SESSION_NAME`.
- Historical stranded rows are not rewritten here; compatibility readers still accept all supported session identity forms.
- Existing agent processes retain their inherited environment. They must restart before direct `bd` commands inherit the new actor. `Provider.SetMeta` keeps provider metadata coherent for subsequent launches but is not a live-process environment migration.
- No HTTP/SSE schema or dashboard contract changes.

## Verification

- Focused RED/GREEN suite covers alias, configured-name recovery, aliasless session-name fallback, nameless bead-ID fallback, API assign/update/create, hook/script claims, alias set/clear/rollback, reconciler sync, and provider metadata rollback.
- `go test ./internal/session ./internal/api -count=1`: PASS
- focused `go test ./internal/session ./internal/api ./cmd/gc ... -count=1`: PASS
- `make lint`: PASS (0 issues)
- `make vet`: PASS
- `make check-docs`: PASS
- `.githooks/pre-commit`: PASS

The initial CI failure (`TestBuildDesiredState_DependencyFloorIgnoresConfigBlindLegacySlotRecovery`) exposed an over-broad intermediate desired-state fix. That approach was removed; ownership now converges at the typed session/runtime boundary. The exact failing contract passes locally. A full macOS shard remains affected by the pre-existing `/var` versus `/private/var` canonicalization failures, while upstream Linux CI provides the authoritative full-shard result.