### PR TITLE
fix(lint): keep module checksums read-only

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 version: "2"
 
+run:
+  modules-download-mode: readonly
+
 severity:
   default: error
 

--- a/Makefile
+++ b/Makefile
@@ -300,10 +300,15 @@ lint-changed: $(GOLANGCI_LINT)
 		echo "lint-changed: no changed Go files"; \
 		exit 0; \
 	fi; \
-	pkgs="$$(printf '%s\n' "$$files" | sed '/^$$/d' | sort -u | while IFS= read -r file; do dirname "$$file"; done | sort -u | while IFS= read -r dir; do \
+	dirs="$$(printf '%s\n' "$$files" | sed '/^$$/d' | sort -u | while IFS= read -r file; do dirname "$$file"; done | sort -u)"; \
+	pkgs="$$(for dir in $$dirs; do \
 		if [ "$$dir" = "." ]; then pkg="."; else pkg="./$$dir"; fi; \
-		if go list "$$pkg" >/dev/null 2>&1; then printf '%s\n' "$$pkg"; fi; \
-	done | sort -u)"; \
+		if ! go list "$$pkg" >/dev/null; then \
+			echo "lint-changed: unable to load $$pkg" >&2; \
+			exit 1; \
+		fi; \
+		printf '%s\n' "$$pkg"; \
+	done)" || exit $$?; \
 	if [ -z "$$pkgs" ]; then \
 		echo "lint-changed: no lintable Go packages"; \
 		exit 0; \

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ LINT_BASE ?= origin/main
 LINT_CHANGED_REF ?= HEAD
 LINT_CHANGED_SCOPE ?= worktree
 LINT_FLAGS ?=
+LINT_READONLY_GOFLAGS = $$(go env GOFLAGS | sed -E 's/(^|[[:space:]])-mod=[^[:space:]]+//g') -mod=readonly
 CI_STATIC_SELECT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))scripts/ci-static-select
 CI_STATIC_GO ?= go
 
@@ -267,15 +268,16 @@ lint: lint-full
 
 ## lint-full: run golangci-lint across all packages
 lint-full: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run $(LINT_FLAGS) ./...
+	GOFLAGS="$(LINT_READONLY_GOFLAGS)" $(GOLANGCI_LINT) run $(LINT_FLAGS) ./...
 
 ## lint-new: run golangci-lint for issues introduced since LINT_BASE
 lint-new: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run $(LINT_FLAGS) --new-from-merge-base=$(LINT_BASE) --whole-files ./...
+	GOFLAGS="$(LINT_READONLY_GOFLAGS)" $(GOLANGCI_LINT) run $(LINT_FLAGS) --new-from-merge-base=$(LINT_BASE) --whole-files ./...
 
 ## lint-changed: run golangci-lint only for packages touched by changed Go files
 lint-changed: $(GOLANGCI_LINT)
-	@case "$(LINT_CHANGED_SCOPE)" in \
+	@export GOFLAGS="$(LINT_READONLY_GOFLAGS)"; \
+	case "$(LINT_CHANGED_SCOPE)" in \
 		staged) \
 			files="$$(git diff --cached --name-only --diff-filter=ACMRT -- '*.go')"; \
 			;; \
@@ -311,7 +313,7 @@ lint-changed: $(GOLANGCI_LINT)
 
 ## lint-affected: lint packages affected by changed Go build inputs or embedded files
 lint-affected: $(GOLANGCI_LINT)
-	@"$(CI_STATIC_SELECT)" lint-affected "$(GOLANGCI_LINT)" "$(CI_STATIC_GO)" $(LINT_FLAGS)
+	@GOFLAGS="$(LINT_READONLY_GOFLAGS)" "$(CI_STATIC_SELECT)" lint-affected "$(GOLANGCI_LINT)" "$(CI_STATIC_GO)" $(LINT_FLAGS)
 
 ## fmt-check: fail if formatting would change files
 fmt-check: $(GOLANGCI_LINT)

--- a/scripts/lint_readonly_contract_test.go
+++ b/scripts/lint_readonly_contract_test.go
@@ -1,0 +1,74 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLintUsesReadonlyModuleDownloads(t *testing.T) {
+	configPath := filepath.Join(repoRoot(t), ".golangci.yml")
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", configPath, err)
+	}
+
+	var config struct {
+		Run struct {
+			ModulesDownloadMode string `yaml:"modules-download-mode"`
+		} `yaml:"run"`
+	}
+	if err := yaml.Unmarshal(body, &config); err != nil {
+		t.Fatalf("parse %s: %v", configPath, err)
+	}
+	if config.Run.ModulesDownloadMode != "readonly" {
+		t.Fatalf("run.modules-download-mode = %q, want readonly", config.Run.ModulesDownloadMode)
+	}
+
+	makefile, err := os.ReadFile(filepath.Join(repoRoot(t), "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	const readonlyGOFlags = "LINT_READONLY_GOFLAGS = $$(go env GOFLAGS | sed -E 's/(^|[[:space:]])-mod=[^[:space:]]+//g') -mod=readonly"
+	if !strings.Contains(string(makefile), readonlyGOFlags) {
+		t.Fatalf("Makefile must derive LINT_READONLY_GOFLAGS from effective GOFLAGS")
+	}
+	for target, wantGOFLAGS := range map[string]string{
+		"lint-full":     `GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
+		"lint-new":      `GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
+		"lint-changed":  `export GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
+		"lint-affected": `GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
+	} {
+		t.Run(target, func(t *testing.T) {
+			body := makeTargetBody(t, string(makefile), target)
+			for _, override := range []string{"--config", "--no-config"} {
+				if strings.Contains(body, override) {
+					t.Fatalf("%s overrides shared lint configuration with %q", target, override)
+				}
+			}
+			if strings.Contains(body, "--modules-download-mode") {
+				t.Fatalf("%s must not rely on a lint CLI module-mode override", target)
+			}
+			if !strings.Contains(body, wantGOFLAGS) {
+				t.Fatalf("%s must scope LINT_READONLY_GOFLAGS to its subprocess tree", target)
+			}
+		})
+	}
+}
+
+func makeTargetBody(t *testing.T, makefile, target string) string {
+	t.Helper()
+	prefix := target + ":"
+	start := strings.Index(makefile, prefix)
+	if start < 0 {
+		t.Fatalf("Makefile has no %s target", target)
+	}
+	body := makefile[start:]
+	if next := strings.Index(body, "\n## "); next >= 0 {
+		body = body[:next]
+	}
+	return body
+}

--- a/scripts/lint_readonly_contract_test.go
+++ b/scripts/lint_readonly_contract_test.go
@@ -59,6 +59,78 @@ func TestLintUsesReadonlyModuleDownloads(t *testing.T) {
 	}
 }
 
+func TestLintChangedFailsClosedWhenReadonlyMetadataIsStale(t *testing.T) {
+	fixture := newPRStaticScopeFixture(t, map[string]string{
+		"alpha/alpha.go": "package alpha\n\nfunc Value() int { return 1 }\n",
+	})
+	writeTestFile(t, filepath.Join(fixture.repoRoot, "go.sum"), "example.com/dependency v1.0.0 h1:before\n")
+	writeTestFile(t, filepath.Join(fixture.repoRoot, "alpha", "alpha.go"), "package alpha\n\nfunc Value() int { return 2 }\n")
+
+	goTool := filepath.Join(t.TempDir(), "go")
+	writeExecutable(t, goTool, `#!/bin/sh
+set -eu
+case "${1-}" in
+  env)
+    if [ "${2-}" = "GOFLAGS" ]; then
+      printf '%s\n' "${GOFLAGS-}"
+    fi
+    exit 0
+    ;;
+  list)
+    case "${GOFLAGS-}" in
+      *-mod=readonly*)
+        echo "go: updates to go.sum needed; disabled by -mod=readonly" >&2
+        exit 1
+        ;;
+    esac
+    echo "unexpected writable module resolution" >> go.sum
+    exit 0
+    ;;
+esac
+echo "unexpected go invocation: $*" >&2
+exit 1
+`)
+
+	before, err := os.ReadFile(filepath.Join(fixture.repoRoot, "go.sum"))
+	if err != nil {
+		t.Fatalf("read go.sum before lint: %v", err)
+	}
+	fixture.resetCalls(t)
+	cmd := makeCommand(
+		"--no-print-directory",
+		"-f", fixture.productionMakefile,
+		"GOLANGCI_LINT="+fixture.fakeLint,
+		"LINT_CHANGED_SCOPE=tracked",
+		"LINT_CHANGED_REF=HEAD",
+		"LINT_FLAGS=",
+		"lint-changed",
+	)
+	cmd.Dir = fixture.repoRoot
+	env := fixture.commandEnv()
+	for index, entry := range env {
+		if strings.HasPrefix(entry, "GOFLAGS=") {
+			env[index] = "GOFLAGS=-mod=mod"
+		}
+	}
+	env = append(env, "PATH="+filepath.Dir(goTool)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("lint-changed succeeded with stale readonly metadata:\n%s", output)
+	}
+	if !strings.Contains(string(output), "updates to go.sum needed") {
+		t.Fatalf("lint-changed error did not preserve the module failure:\n%s", output)
+	}
+	after, err := os.ReadFile(filepath.Join(fixture.repoRoot, "go.sum"))
+	if err != nil {
+		t.Fatalf("read go.sum after lint: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("lint-changed modified go.sum under ambient -mod=mod:\nbefore: %q\nafter:  %q", before, after)
+	}
+	fixture.requireNoCalls(t)
+}
+
 func makeTargetBody(t *testing.T, makefile, target string) string {
 	t.Helper()
 	prefix := target + ":"


### PR DESCRIPTION
## Summary
- run every lint entry point with readonly module resolution while retaining the other effective Go flags
- make changed-package discovery fail closed when readonly module metadata is unresolved
- add regression coverage for ambient `-mod=mod`, unchanged `go.sum`, and surfaced metadata failures

## Verification
- `GOENV=off go test ./scripts -run '^(TestLintUsesReadonlyModuleDownloads|TestLintChangedFailsClosedWhenReadonlyMetadataIsStale|TestChangedStaticTargetsScopeLintAndFormattingToTheDiff)$' -count=1`\n- `GOENV=off go test ./scripts -count=1`\n- `GOENV=off go vet ./scripts`\n- repository pre-push `make test-fast-parallel`\n- stale golangci-lint v2.10.1 fixture with ambient `GOFLAGS=-mod=mod`: `go.sum` SHA unchanged\n\n## Review\nSol review approved commit `2361fad804`; no Blockers or Majors.