### PR TITLE
Fix quality gate module mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ LINT_BASE ?= origin/main
 LINT_CHANGED_REF ?= HEAD
 LINT_CHANGED_SCOPE ?= worktree
 LINT_FLAGS ?=
-LINT_READONLY_GOFLAGS = $$(go env GOFLAGS | sed -E 's/(^|[[:space:]])-mod=[^[:space:]]+//g') -mod=readonly
+QUALITY_GATE_GOFLAGS = $$(go env GOFLAGS | sed -E 's/(^|[[:space:]])-mod=[^[:space:]]+//g') -mod=readonly
 CI_STATIC_SELECT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))scripts/ci-static-select
 CI_STATIC_GO ?= go
 
@@ -268,15 +268,15 @@ lint: lint-full
 
 ## lint-full: run golangci-lint across all packages
 lint-full: $(GOLANGCI_LINT)
-	GOFLAGS="$(LINT_READONLY_GOFLAGS)" $(GOLANGCI_LINT) run $(LINT_FLAGS) ./...
+	GOFLAGS="$(QUALITY_GATE_GOFLAGS)" $(GOLANGCI_LINT) run $(LINT_FLAGS) ./...
 
 ## lint-new: run golangci-lint for issues introduced since LINT_BASE
 lint-new: $(GOLANGCI_LINT)
-	GOFLAGS="$(LINT_READONLY_GOFLAGS)" $(GOLANGCI_LINT) run $(LINT_FLAGS) --new-from-merge-base=$(LINT_BASE) --whole-files ./...
+	GOFLAGS="$(QUALITY_GATE_GOFLAGS)" $(GOLANGCI_LINT) run $(LINT_FLAGS) --new-from-merge-base=$(LINT_BASE) --whole-files ./...
 
 ## lint-changed: run golangci-lint only for packages touched by changed Go files
 lint-changed: $(GOLANGCI_LINT)
-	@export GOFLAGS="$(LINT_READONLY_GOFLAGS)"; \
+	@export GOFLAGS="$(QUALITY_GATE_GOFLAGS)"; \
 	case "$(LINT_CHANGED_SCOPE)" in \
 		staged) \
 			files="$$(git diff --cached --name-only --diff-filter=ACMRT -- '*.go')"; \
@@ -318,15 +318,15 @@ lint-changed: $(GOLANGCI_LINT)
 
 ## lint-affected: lint packages affected by changed Go build inputs or embedded files
 lint-affected: $(GOLANGCI_LINT)
-	@GOFLAGS="$(LINT_READONLY_GOFLAGS)" "$(CI_STATIC_SELECT)" lint-affected "$(GOLANGCI_LINT)" "$(CI_STATIC_GO)" $(LINT_FLAGS)
+	@GOFLAGS="$(QUALITY_GATE_GOFLAGS)" "$(CI_STATIC_SELECT)" lint-affected "$(GOLANGCI_LINT)" "$(CI_STATIC_GO)" $(LINT_FLAGS)
 
 ## fmt-check: fail if formatting would change files
 fmt-check: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) fmt --diff ./...
+	GOFLAGS="$(QUALITY_GATE_GOFLAGS)" $(GOLANGCI_LINT) fmt --diff ./...
 
 ## fmt-check-changed: fail if formatting would change a regular changed Go file
 fmt-check-changed: $(GOLANGCI_LINT)
-	@"$(CI_STATIC_SELECT)" fmt-check-changed "$(GOLANGCI_LINT)"
+	@GOFLAGS="$(QUALITY_GATE_GOFLAGS)" "$(CI_STATIC_SELECT)" fmt-check-changed "$(GOLANGCI_LINT)"
 
 ## fmt: auto-fix formatting
 fmt: $(GOLANGCI_LINT)
@@ -334,7 +334,7 @@ fmt: $(GOLANGCI_LINT)
 
 ## vet: run go vet
 vet:
-	go vet ./...
+	GOFLAGS="$(QUALITY_GATE_GOFLAGS)" go vet ./...
 
 ## TEST_ENV: env -i wrapper for `go test` invocations. Strips host env so
 ## agent-session vars (GC_CITY, GC_HOME, GC_SESSION_ID, ...) cannot leak into
@@ -413,7 +413,7 @@ test-ci-policy:
 ## cache input hashes over local working files.
 ## Wrapped in $(TEST_ENV) — see comment above for why.
 test: test-fsys-darwin-compile
-	$(TEST_ENV) GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 -timeout 15m ./...
+	$(TEST_ENV) GOFLAGS="$(QUALITY_GATE_GOFLAGS)" GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 -timeout 15m ./...
 
 # MAC_UNIT_PKGS excludes cmd/gc from the Mac unit sweep; cmd/gc runs
 # sharded via the mac-cmd-gc-process CI matrix job instead.
@@ -434,7 +434,7 @@ test-fast-parallel:
 test-fsys-darwin-compile:
 	@tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$tmp"' EXIT; \
-	$(TEST_ENV) GOOS=darwin GOARCH=arm64 go test -c -o "$$tmp/fsys.test" ./internal/fsys
+	$(TEST_ENV) GOFLAGS="$(QUALITY_GATE_GOFLAGS)" GOOS=darwin GOARCH=arm64 go test -c -o "$$tmp/fsys.test" ./internal/fsys
 
 ## test-pack-registry-live: run the opt-in gascity-packs registry canary
 test-pack-registry-live:

--- a/scripts/lint_readonly_contract_test.go
+++ b/scripts/lint_readonly_contract_test.go
@@ -32,15 +32,15 @@ func TestLintUsesReadonlyModuleDownloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read Makefile: %v", err)
 	}
-	const readonlyGOFlags = "LINT_READONLY_GOFLAGS = $$(go env GOFLAGS | sed -E 's/(^|[[:space:]])-mod=[^[:space:]]+//g') -mod=readonly"
+	const readonlyGOFlags = "QUALITY_GATE_GOFLAGS = $$(go env GOFLAGS | sed -E 's/(^|[[:space:]])-mod=[^[:space:]]+//g') -mod=readonly"
 	if !strings.Contains(string(makefile), readonlyGOFlags) {
-		t.Fatalf("Makefile must derive LINT_READONLY_GOFLAGS from effective GOFLAGS")
+		t.Fatalf("Makefile must derive QUALITY_GATE_GOFLAGS from effective GOFLAGS")
 	}
 	for target, wantGOFLAGS := range map[string]string{
-		"lint-full":     `GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
-		"lint-new":      `GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
-		"lint-changed":  `export GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
-		"lint-affected": `GOFLAGS="$(LINT_READONLY_GOFLAGS)"`,
+		"lint-full":     `GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+		"lint-new":      `GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+		"lint-changed":  `export GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+		"lint-affected": `GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
 	} {
 		t.Run(target, func(t *testing.T) {
 			body := makeTargetBody(t, string(makefile), target)
@@ -53,9 +53,86 @@ func TestLintUsesReadonlyModuleDownloads(t *testing.T) {
 				t.Fatalf("%s must not rely on a lint CLI module-mode override", target)
 			}
 			if !strings.Contains(body, wantGOFLAGS) {
-				t.Fatalf("%s must scope LINT_READONLY_GOFLAGS to its subprocess tree", target)
+				t.Fatalf("%s must scope QUALITY_GATE_GOFLAGS to its subprocess tree", target)
 			}
 		})
+	}
+}
+
+func TestQualityGateTargetsUseReadonlyModuleDownloads(t *testing.T) {
+	makefile, err := os.ReadFile(filepath.Join(repoRoot(t), "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	const readonlyGOFlags = "QUALITY_GATE_GOFLAGS = $$(go env GOFLAGS | sed -E 's/(^|[[:space:]])-mod=[^[:space:]]+//g') -mod=readonly"
+	if !strings.Contains(string(makefile), readonlyGOFlags) {
+		t.Fatalf("Makefile must normalize QUALITY_GATE_GOFLAGS from effective GOFLAGS")
+	}
+
+	for target, wantGOFLAGS := range map[string]string{
+		"fmt-check":                `GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+		"fmt-check-changed":        `GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+		"vet":                      `GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+		"test":                     `$(TEST_ENV) GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+		"test-fsys-darwin-compile": `$(TEST_ENV) GOFLAGS="$(QUALITY_GATE_GOFLAGS)"`,
+	} {
+		t.Run(target, func(t *testing.T) {
+			if body := makeTargetBody(t, string(makefile), target); !strings.Contains(body, wantGOFLAGS) {
+				t.Fatalf("%s must scope QUALITY_GATE_GOFLAGS to its subprocess tree", target)
+			}
+		})
+	}
+}
+
+func TestFmtCheckDoesNotModifyGoSumWithAmbientWritableModuleMode(t *testing.T) {
+	fixture := newPRStaticScopeFixture(t, map[string]string{
+		"example.go": "package example\n\nfunc Value() int { return 1 }\n",
+	})
+	goSumPath := filepath.Join(fixture.repoRoot, "go.sum")
+	writeTestFile(t, goSumPath, "example.com/dependency v1.0.0 h1:before\n")
+
+	mutatingLint := filepath.Join(t.TempDir(), "golangci-lint")
+	writeExecutable(t, mutatingLint, `#!/bin/sh
+set -eu
+case "${GOFLAGS-}" in
+  *-tags=quality*) ;;
+  *)
+    echo "formatter lost non-module GOFLAGS" >&2
+    exit 1
+    ;;
+esac
+case "${GOFLAGS-}" in
+  *-mod=readonly*) exit 0 ;;
+esac
+printf '%s\n' 'unexpected writable formatter resolution' >> go.sum
+`)
+
+	cmd := makeCommand(
+		"--no-print-directory",
+		"-f", fixture.productionMakefile,
+		"GOLANGCI_LINT="+mutatingLint,
+		"fmt-check",
+	)
+	cmd.Dir = fixture.repoRoot
+	env := fixture.commandEnv()
+	for index, entry := range env {
+		if strings.HasPrefix(entry, "GOFLAGS=") {
+			env[index] = "GOFLAGS=-tags=quality -mod=mod"
+		}
+	}
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fmt-check failed: %v\n%s", err, output)
+	}
+
+	got, err := os.ReadFile(goSumPath)
+	if err != nil {
+		t.Fatalf("read go.sum after fmt-check: %v", err)
+	}
+	const want = "example.com/dependency v1.0.0 h1:before\n"
+	if string(got) != want {
+		t.Fatalf("fmt-check modified go.sum under ambient -mod=mod:\nwant: %q\n got: %q", want, got)
 	}
 }
 
@@ -134,7 +211,12 @@ exit 1
 func makeTargetBody(t *testing.T, makefile, target string) string {
 	t.Helper()
 	prefix := target + ":"
-	start := strings.Index(makefile, prefix)
+	start := strings.Index(makefile, "\n"+prefix)
+	if start >= 0 {
+		start++
+	} else if strings.HasPrefix(makefile, prefix) {
+		start = 0
+	}
 	if start < 0 {
 		t.Fatalf("Makefile has no %s target", target)
 	}


### PR DESCRIPTION
## Summary

- normalize quality-gate `GOFLAGS` once, preserving non-module flags and forcing `-mod=readonly`
- apply it to lint, formatting checks, vet, and the default test gates
- add a regression proving `fmt-check` cannot change `go.sum` under ambient `-mod=mod`

## Completed verification

- focused scripts contract tests, including the new formatter mutation regression
- `GOFLAGS=-mod=mod make check` completed in the isolated worktree
- the live test JSON stream contains no fail events
- `git diff --exit-code -- go.sum` and the final worktree check are clean

## Incomplete verification

- the automatic pre-push fast fanout ended before its final summary, leaving incomplete cmd/gc shard logs without an assertion failure. It is intentionally not reported as green.

The branch is pushed for CI. Do not merge until normal PR checks complete.