### PR TITLE
worker: require explicit permission policy for managed launches

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -952,6 +952,9 @@ func buildPreparedStartWithWorkDirResolver(
 	// schema flags.
 	sessionOverrides := parseSessionTemplateOverridesForLaunch(candidate.info)
 	applySchemaOptionOverridesForLaunch(&agentCfg, &tp, candidate.info.ID, sessionOverrides)
+	if err := config.ValidateManagedLaunchPermissionPolicy(tp.ResolvedProvider, agentCfg.Command); err != nil {
+		return nil, candidate.info, fmt.Errorf("session %q: %w", candidate.name(), err)
+	}
 
 	coreHash := runtime.CoreFingerprint(agentCfg)
 	coreBreakdown := runtime.CoreFingerprintBreakdown(agentCfg)
@@ -978,6 +981,9 @@ func buildPreparedStartWithWorkDirResolver(
 			launchOverrides[k] = v
 		}
 		applySchemaOptionOverridesForLaunch(&agentCfg, &tp, candidate.info.ID, launchOverrides)
+		if err := config.ValidateManagedLaunchPermissionPolicy(tp.ResolvedProvider, agentCfg.Command); err != nil {
+			return nil, candidate.info, fmt.Errorf("session %q: %w", candidate.name(), err)
+		}
 	}
 
 	preOverrideWorkDir := agentCfg.WorkDir

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -197,6 +197,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
 		command = command + " " + shellquote.Join(defaultArgs)
 	}
+	if err := config.ValidateManagedLaunchPermissionPolicy(resolved, command); err != nil {
+		return TemplateParams{}, fmt.Errorf("agent %q: %w", qualifiedName, err)
+	}
 	sa, err := ensureClaudeSettingsArgs(p.fs, p.cityPath, providerFamily, p.stderr)
 	if err != nil {
 		return TemplateParams{}, fmt.Errorf("agent %q: %w", qualifiedName, err)

--- a/cmd/gc/template_resolve_permission_policy_test.go
+++ b/cmd/gc/template_resolve_permission_policy_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestResolveTemplateRefusesModelOnlySchemaThatDropsPermissionPolicy(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	base := "builtin:claude"
+	providers := map[string]config.ProviderSpec{
+		"claude-managed": {
+			Base: &base,
+			OptionDefaults: map[string]string{
+				"model": "opus",
+			},
+			OptionsSchema: []config.ProviderOption{{
+				Key: "model",
+				Choices: []config.OptionChoice{{
+					Value:    "opus",
+					FlagArgs: []string{"--model", "claude-opus-5"},
+				}},
+			}},
+		},
+	}
+	city := &config.City{
+		Workspace: config.Workspace{Provider: "claude-managed"},
+		Providers: providers,
+	}
+	params := &agentBuildParams{
+		city:       city,
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &city.Workspace,
+		providers:  providers,
+		lookPath:   func(string) (string, error) { return "/usr/bin/claude", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+	agent := &config.Agent{Name: "worker", Provider: "claude-managed", Scope: "city"}
+
+	_, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err == nil {
+		t.Fatal("resolveTemplate() error = nil, want missing permission-policy refusal")
+	}
+	if !strings.Contains(err.Error(), "permission policy") {
+		t.Fatalf("resolveTemplate() error = %q, want permission-policy diagnostic", err)
+	}
+}

--- a/internal/config/launch_command.go
+++ b/internal/config/launch_command.go
@@ -44,8 +44,78 @@ func BuildProviderLaunchCommand(cityPath string, resolved *ResolvedProvider, opt
 		}
 		command = ReplaceSchemaFlags(command, resolved.OptionsSchema, mergedArgs)
 	}
+	if err := ValidateManagedLaunchPermissionPolicy(resolved, command); err != nil {
+		return ProviderLaunchCommand{}, err
+	}
 
 	return appendProviderSettings(cityPath, providerSettingsFamily(resolved), command), nil
+}
+
+// ValidateManagedLaunchPermissionPolicy refuses prompt-capable providers whose
+// final managed command has no declared permission-policy flag. A provider
+// that can stop for an approval prompt must never fall back to its interactive
+// default inside an unattended session: that turns a configuration merge miss
+// into an immediate launch error instead of an invisible, unbounded wait.
+//
+// The accepted argv shapes come from the provider contract itself
+// (PermissionModes and the permission_mode option choices), keeping this guard
+// provider-neutral and compatible with inherited/custom provider names.
+func ValidateManagedLaunchPermissionPolicy(resolved *ResolvedProvider, command string) error {
+	if resolved == nil || !resolved.EmitsPermissionWarning {
+		return nil
+	}
+
+	var policies [][]string
+	for _, declared := range resolved.PermissionModes {
+		if argv := shellquote.Split(strings.TrimSpace(declared)); len(argv) > 0 {
+			policies = append(policies, argv)
+		}
+	}
+	for _, option := range resolved.OptionsSchema {
+		if option.Key != "permission_mode" {
+			continue
+		}
+		for _, choice := range option.Choices {
+			if len(choice.FlagArgs) > 0 {
+				policies = append(policies, choice.FlagArgs)
+			}
+			policies = append(policies, choice.FlagAliases...)
+		}
+	}
+
+	commandArgv := shellquote.Split(command)
+	for _, policy := range policies {
+		if containsArgvSequence(commandArgv, policy) {
+			return nil
+		}
+	}
+	name := strings.TrimSpace(resolved.Name)
+	if name == "" {
+		name = strings.TrimSpace(resolved.BuiltinAncestor)
+	}
+	if name == "" {
+		name = "provider"
+	}
+	return fmt.Errorf("managed provider %q launch has no explicit permission policy; preserve permission_mode when merging options_schema", name)
+}
+
+func containsArgvSequence(argv, sequence []string) bool {
+	if len(sequence) == 0 || len(sequence) > len(argv) {
+		return false
+	}
+	for start := 0; start <= len(argv)-len(sequence); start++ {
+		matched := true
+		for offset := range sequence {
+			if argv[start+offset] != sequence[offset] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
 }
 
 // BuildProviderResumeCommand applies schema-managed option overrides to a

--- a/internal/config/launch_command_test.go
+++ b/internal/config/launch_command_test.go
@@ -60,6 +60,25 @@ func TestBuildProviderLaunchCommandAppliesOptionOverrides(t *testing.T) {
 	}
 }
 
+func TestBuildProviderLaunchCommandRefusesPromptCapableProviderWithoutPermissionPolicy(t *testing.T) {
+	rp := &ResolvedProvider{
+		Name:                   "claude-custom",
+		Command:                "claude",
+		EmitsPermissionWarning: true,
+		PermissionModes:        map[string]string{"attended": "--permission-mode auto"},
+		OptionsSchema:          []ProviderOption{{Key: "model", Choices: []OptionChoice{{Value: "opus", FlagArgs: []string{"--model", "claude-opus-5"}}}}},
+		EffectiveDefaults:      map[string]string{"model": "opus"},
+	}
+
+	_, err := BuildProviderLaunchCommand("", rp, nil, "")
+	if err == nil {
+		t.Fatal("BuildProviderLaunchCommand() error = nil, want missing permission-policy refusal")
+	}
+	if !strings.Contains(err.Error(), "permission policy") {
+		t.Fatalf("BuildProviderLaunchCommand() error = %q, want permission-policy diagnostic", err)
+	}
+}
+
 func TestBuildProviderLaunchCommandIgnoresInitialMessageOverride(t *testing.T) {
 	spec := BuiltinProviders()["claude"]
 	rp := specToResolved("claude", &spec)

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -70,6 +70,36 @@ func TestBuiltinProvidersClaude(t *testing.T) {
 	}
 }
 
+func TestBuiltinProvidersClaudePermissionModesMatchCurrentCLI(t *testing.T) {
+	p := BuiltinProviders()["claude"]
+	if got, want := p.PermissionModes["auto-edit"], "--permission-mode auto"; got != want {
+		t.Fatalf("PermissionModes[auto-edit] = %q, want %q", got, want)
+	}
+	if got, want := p.PermissionModes["full-auto"], "--permission-mode dontAsk"; got != want {
+		t.Fatalf("PermissionModes[full-auto] = %q, want %q", got, want)
+	}
+
+	var permission ProviderOption
+	for _, option := range p.OptionsSchema {
+		if option.Key == "permission_mode" {
+			permission = option
+			break
+		}
+	}
+	if permission.Key == "" {
+		t.Fatal("claude provider missing permission_mode option")
+	}
+	want := map[string][]string{
+		"auto-edit": {"--permission-mode", "auto"},
+		"full-auto": {"--permission-mode", "dontAsk"},
+	}
+	for _, choice := range permission.Choices {
+		if wantArgs, ok := want[choice.Value]; ok && !reflect.DeepEqual(choice.FlagArgs, wantArgs) {
+			t.Fatalf("permission choice %q FlagArgs = %v, want %v", choice.Value, choice.FlagArgs, wantArgs)
+		}
+	}
+}
+
 func TestBuiltinProvidersClaudeModelChoices(t *testing.T) {
 	p := BuiltinProviders()["claude"]
 	var model OptionChoice

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -128,8 +128,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		PermissionModes: map[string]string{
 			"unrestricted": "--dangerously-skip-permissions",
 			"plan":         "--permission-mode plan",
-			"auto-edit":    "--permission-mode auto-edit",
-			"full-auto":    "--permission-mode full-auto",
+			"auto-edit":    "--permission-mode auto",
+			"full-auto":    "--permission-mode dontAsk",
 		},
 		OptionsSchema: []BuiltinProviderOption{
 			{
@@ -138,8 +138,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:    "select",
 				Default: "auto-edit",
 				Choices: []BuiltinOptionChoice{
-					{Value: "auto-edit", Label: "Edit automatically", FlagArgs: []string{"--permission-mode", "auto-edit"}},
-					{Value: "full-auto", Label: "Full auto", FlagArgs: []string{"--permission-mode", "full-auto"}},
+					{Value: "auto-edit", Label: "Attend approvals", FlagArgs: []string{"--permission-mode", "auto"}},
+					{Value: "full-auto", Label: "Fail instead of asking", FlagArgs: []string{"--permission-mode", "dontAsk"}},
 					{Value: "plan", Label: "Plan mode", FlagArgs: []string{"--permission-mode", "plan"}},
 					{Value: "unrestricted", Label: "Bypass permissions", FlagArgs: []string{"--dangerously-skip-permissions"}},
 				},


### PR DESCRIPTION
## Summary

- reject prompt-capable managed provider launches whose final command has no explicit permission policy
- validate the command after provider defaults, schema options, and session-specific overrides are applied
- map Claude's abstract attended and unattended modes to the current CLI values (`auto` and `dontAsk`)

## Why

A child provider schema or late session override can preserve model selection while accidentally dropping the permission-mode option. The resulting managed worker falls back to the provider's interactive default and can wait indefinitely for an approval that no operator can see.

The validation is provider-neutral: accepted argument sequences come from the resolved provider's declared `PermissionModes` and `permission_mode` option choices. Providers that do not emit permission warnings are unchanged.

## Validation

- red-first regressions cover provider launch construction, template resolution, and final session override paths
- `go test ./internal/config ./internal/worker/builtin ./cmd/gc`
- repository pre-push fast gate passed all ten jobs on the submitted head
