### PR TITLE
fix(usage): emit compute facts while sessions are draining

### DIFF
--- a/cmd/gc/usage_compute.go
+++ b/cmd/gc/usage_compute.go
@@ -45,15 +45,16 @@ const liveModelSweepMinInterval = 30 * time.Second
 // isComputeTerminalState reports whether a session state marks the end of an
 // awake interval, at which a compute fact should be emitted. It covers every
 // non-running lifecycle endpoint the controller's open-bead scan can observe:
-// idle-sleep (asleep), controller drain (drained), retirement (archived),
-// operator suspend (suspended), and crash-loop quarantine (quarantined). A
-// session closed directly from active without first passing through one of
-// these open states is the known v0 scan limitation (see
-// engdocs/design/usage-facts-v0.md).
+// idle-sleep (asleep), controller drain (draining — the open-set state while
+// drain-ack-stop is pending; drained is usually only stamped at close),
+// retirement (archived), operator suspend (suspended), and crash-loop
+// quarantine (quarantined). A session closed directly from active without
+// first passing through one of these open states is the known v0 scan
+// limitation (see engdocs/design/usage-facts-v0.md).
 func isComputeTerminalState(state string) bool {
 	switch session.State(strings.TrimSpace(state)) {
-	case session.StateAsleep, session.StateDrained, session.StateArchived,
-		session.StateSuspended, session.StateQuarantined:
+	case session.StateAsleep, session.StateDraining, session.StateDrained,
+		session.StateArchived, session.StateSuspended, session.StateQuarantined:
 		return true
 	}
 	return false

--- a/cmd/gc/usage_compute_test.go
+++ b/cmd/gc/usage_compute_test.go
@@ -1139,14 +1139,17 @@ func TestEmitDueComputeFactsSweepsKeylessCodexViaWorkdir(t *testing.T) {
 
 func TestIsComputeTerminalState(t *testing.T) {
 	// Every non-running endpoint the open-bead scan can observe.
-	for _, s := range []string{"asleep", "drained", "archived", "suspended", "quarantined"} {
+	// Include draining: pool drain-ack-stop-pending keeps the bead open in
+	// state=draining until close stamps drained (which has already left the
+	// open set the scan reads).
+	for _, s := range []string{"asleep", "draining", "drained", "archived", "suspended", "quarantined"} {
 		if !isComputeTerminalState(s) {
 			t.Errorf("%q should be terminal", s)
 		}
 	}
-	// Running states, transient states, and closed (which leaves the open set the
-	// scan reads) are not emitted by the scan.
-	for _, s := range []string{"active", "awake", "creating", "draining", "closed", ""} {
+	// Running states and closed (which leaves the open set the scan reads) are
+	// not emitted by the scan.
+	for _, s := range []string{"active", "awake", "creating", "closed", ""} {
 		if isComputeTerminalState(s) {
 			t.Errorf("%q should not be terminal", s)
 		}


### PR DESCRIPTION
## Summary

Treat `state=draining` as compute-terminal for end-of-interval usage emission.

Pool `drain-ack-stop-pending` keeps beads **open** in `draining`; `drained` is typically stamped only at close, after the bead has left `OpenInfos()`. Without this, pool retirements under-count wall/token usage to zero when idle sleep is off.

## Context

Observed on a live city: closed pool sessions had `awake_started_at` but no `usage_compute_emitted_at`. Idle sleep is often off for interactive_resume pools, so drain/close is the only terminal transition.

Verified locally: after `gc runtime drain` + `drain-ack`, a compute fact was written for the draining interval.

Related: [#4994](https://github.com/gastownhall/gascity/pull/4994) (live sweep; `draining` is still not live), [#5025](https://github.com/gastownhall/gascity/pull/5025) (closed-race recovery if the bead leaves the open set before a tick sees `draining`).

## Test plan

- [x] `go test ./cmd/gc -run 'TestIsComputeTerminalState|TestLiveModelSweepCandidate|TestComputeFactGetCandidate'`
- [x] Live: drain-ack a pool session → compute fact in `.gc/usage.jsonl`