### PR TITLE
fix(session): release the slot alias for drained and runtime-missing holders

### DIFF
--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -401,6 +401,28 @@ func failedCreateIdentityReleased(b beads.Bead) bool {
 	return strings.TrimSpace(b.Metadata["state"]) == string(StateFailedCreate)
 }
 
+// deadIdentityReleased reports whether an open session bead's identity no
+// longer reserves its alias because the session is finished-by-intent or its
+// runtime is gone: a drained session (drain_at stamped at drain) has completed
+// its pool turn, and a runtime-missing session (durable sleep_reason written by
+// the reconciler when the process vanished) is a husk awaiting cleanup. Both
+// otherwise squat their slot alias forever, wedging every subsequent pool
+// create for the same slot at start-pending (observed post-migration: pool
+// spawns starved for hours behind drained predecessors' aliases). Mirrors the
+// failed-create release semantics.
+func deadIdentityReleased(b beads.Bead) bool {
+	// state=drained is the TERMINAL drained record. The drain_at stamp alone is
+	// NOT sufficient: a drain request that was canceled (assigned work) leaves
+	// drain_at on a live, working session — releasing its alias then makes the
+	// session unmatchable, so the reconciler re-judges it orphaned every tick
+	// and eventually kills it mid-turn (observed: the apply-fixes step's
+	// workers dying in a drain/cancel loop).
+	if strings.TrimSpace(b.Metadata["state"]) == string(StateDrained) {
+		return true
+	}
+	return strings.TrimSpace(b.Metadata["sleep_reason"]) == LifecycleReasonRuntimeMissing
+}
+
 func continuityIneligibleConfiguredOwner(b beads.Bead, selfOwner string) bool {
 	if failedCreateIdentityReleased(b) {
 		return false
@@ -602,6 +624,9 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 			continue
 		}
 		if failedCreateIdentityReleased(b) {
+			continue
+		}
+		if deadIdentityReleased(b) {
 			continue
 		}
 		if b.Status == "closed" {

--- a/internal/session/names_alias_release_test.go
+++ b/internal/session/names_alias_release_test.go
@@ -1,0 +1,59 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestEnsureSessionAliasAvailableReleasesDeadHolders pins the alias-release
+// semantics for holders whose runtime is gone: a drained pool session
+// (drain_at stamped) or a runtime-missing husk (durable sleep_reason) must
+// not block a fresh create claiming the same slot alias, while a live open
+// holder still does.
+func TestEnsureSessionAliasAvailableReleasesDeadHolders(t *testing.T) {
+	mk := func(t *testing.T, store beads.Store, alias string, extra map[string]string) beads.Bead {
+		t.Helper()
+		md := map[string]string{"alias": alias, "gc.kind": "session"}
+		for k, v := range extra {
+			md[k] = v
+		}
+		b, err := store.Create(beads.Bead{Title: alias, Type: "session", Labels: []string{"gc:session"}, Metadata: md})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+
+	t.Run("drained holder releases the alias", func(t *testing.T) {
+		store := beads.NewMemStore()
+		mk(t, store, "rig/gc.run-operator-1", map[string]string{"state": "drained", "drain_at": "2026-07-29T00:00:00Z"})
+		if err := ensureSessionAliasAvailable(store, nil, "rig/gc.run-operator-1", "gcs-session-new", ""); err != nil {
+			t.Fatalf("drained holder must release the alias, got: %v", err)
+		}
+	})
+
+	t.Run("canceled-drain live holder (drain_at without state=drained) still blocks", func(t *testing.T) {
+		store := beads.NewMemStore()
+		mk(t, store, "rig/gc.implementation-worker-1", map[string]string{"drain_at": "2026-07-29T11:06:16Z"})
+		if err := ensureSessionAliasAvailable(store, nil, "rig/gc.implementation-worker-1", "gcs-session-new", ""); err == nil {
+			t.Fatal("a live session with a canceled drain (drain_at stamp only) must keep its alias — releasing it re-orphans a working session every tick")
+		}
+	})
+
+	t.Run("runtime-missing holder releases the alias", func(t *testing.T) {
+		store := beads.NewMemStore()
+		mk(t, store, "rig/gc.run-operator-2", map[string]string{"sleep_reason": LifecycleReasonRuntimeMissing})
+		if err := ensureSessionAliasAvailable(store, nil, "rig/gc.run-operator-2", "gcs-session-new", ""); err != nil {
+			t.Fatalf("runtime-missing holder must release the alias, got: %v", err)
+		}
+	})
+
+	t.Run("live open holder still blocks", func(t *testing.T) {
+		store := beads.NewMemStore()
+		mk(t, store, "rig/gc.run-operator-3", nil)
+		if err := ensureSessionAliasAvailable(store, nil, "rig/gc.run-operator-3", "gcs-session-new", ""); err == nil {
+			t.Fatal("live open holder must still block the alias")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

A pool session that has **drained** (terminal `state=drained`) or whose **runtime vanished** (durable `sleep_reason=runtime-missing`) keeps reserving its slot alias forever. `ensureSessionAliasAvailable` releases identities only for failed creates, so every later pool create for that slot fails with `session alias already exists` and wedges at `start-pending`.

Net effect: **once a slot's first occupant finishes, that pool can never spawn into it again.** In production this shows up as whole pools going silent — routed-ready steps sit unclaimed for hours while the reconciler logs a steady stream of alias conflicts naming sessions that finished long ago.

## Fix

Release both dead classes in `deadIdentityReleased`, mirroring the existing `failedCreateIdentityReleased` semantics. Live open holders still block.

The release keys on the **terminal `state=drained` record, not the `drain_at` stamp**. That distinction is load-bearing: a drain request canceled for assigned work (`clearDrain` removes only the runtime `GC_DRAIN*` keys, never the bead stamp) leaves `drain_at` on a live, working session. Keying on the stamp would make that session unmatchable, so the reconciler would re-judge it orphaned every tick and release its claimed step mid-turn — a drain→cancel→orphan loop that kills working sessions. The regression test pins that case.

## Tests

`TestEnsureSessionAliasAvailableReleasesDeadHolders`, 4 subtests:

- drained holder releases the alias
- **canceled-drain live holder (`drain_at` without `state=drained`) still blocks**
- runtime-missing holder releases the alias
- live open holder still blocks

Verified red before / green after on this base. `go test ./internal/session/` and `go vet ./internal/session/` clean.

Both constants (`StateDrained`, `LifecycleReasonRuntimeMissing`) already exist on main; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2885 — extends the same alias-release guard chain in `ensureSessionAliasAvailable` that the filed issue points at as the root cause, adding release for terminal `state=drained` holders and `sleep_reason=runtime-missing` husks; it does not cover the asleep `city-stop` predecessor described there, so that singleton-pool canonical-alias squat still stands
- Related to #3689 — makes a session whose runtime has vanished (durable sleep_reason=runtime-missing) stop reserving its slot alias, so a fresh create can reclaim that name after the tmux server dies instead of failing with "session alias already exists"; the same change also releases aliases held by drained sessions
- Related to #4448 — covers a second way an unreaped drained or runtime-missing session bead squats its pool slot — the alias reservation that wedges later creates at start-pending — but it does not reap the bead or change the demand accounting, so the open_count starvation described in that issue is untouched

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->