### PR TITLE
fix(prime): persist the provider resume key before the SessionStart output gate

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -195,7 +195,9 @@ func doPrimeWithHookFormatOpts(args []string, stdout, stderr io.Writer, hookMode
 		hookContext = readPrimeHookContext()
 		suppressHookPrompt = managedSessionHookPromptAlreadyDelivered(hookContext)
 	}
-	// In non-strict mode, hook side effects fire eagerly (existing behavior).
+	// In non-strict mode, hook side effects fire eagerly for every event. The
+	// SessionStart live-session gate below controls prompt output only; provider
+	// resume-key persistence has its own session and provider guards.
 	// In strict mode, we defer them until after strict checks pass so that a
 	// failing --strict invocation does not update provider resume metadata for
 	// failed agent resolution or template validation.
@@ -205,7 +207,7 @@ func doPrimeWithHookFormatOpts(args []string, stdout, stderr io.Writer, hookMode
 		}
 		persistPrimeHookProviderSessionKey(hookContext.ProviderSessionID, stderr)
 	}
-	if !strictMode && !primeHookSessionStart(hookContext) {
+	if !strictMode {
 		runHookSideEffects()
 	}
 
@@ -226,9 +228,6 @@ func doPrimeWithHookFormatOpts(args []string, stdout, stderr io.Writer, hookMode
 	if hookMode && primeHookSessionStart(hookContext) && !primeHookHasLiveManagedSession(cityPath) {
 		writePrimePromptWithFormat(stdout, "", "", "", hookMode, hookFormat, false, "", nil)
 		return 0
-	}
-	if !strictMode && primeHookSessionStart(hookContext) {
-		runHookSideEffects()
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -7362,6 +7362,40 @@ base = "builtin:gemini"`)
 	}
 }
 
+func TestDoPrimeManagedSessionStartPersistsProviderKeyBeforeOutputGate(t *testing.T) {
+	dir, sessionID := setupPrimeHookProviderSessionKeyTest(t, "codex", `[providers.codex]
+base = "builtin:codex"`)
+	t.Setenv("GC_SESSION_NAME", "")
+	t.Setenv("GC_PROVIDER_SESSION_ID_REQUIRED", "codex")
+	t.Setenv("GC_PROVIDER_SESSION_ID", "0199aaaa-bbbb-7000-8000-c0ffee000042")
+	t.Setenv(managedSessionHookEnv, "1")
+	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+	withPrimeHookStdin(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatCodex, false); code != 0 {
+		t.Fatalf("doPrimeWithHookFormat = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	updatedStore, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := updatedStore.Get(sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["session_key"]); got != "0199aaaa-bbbb-7000-8000-c0ffee000042" {
+		t.Fatalf("session_key = %q, want provider key persisted before SessionStart output gate", got)
+	}
+	if !strings.Contains(stderr.String(), "persisted resume session_key") {
+		t.Fatalf("stderr = %q, want successful provider session-key diagnostic", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Gas City Agent") {
+		t.Fatalf("stdout = %q, want SessionStart prompt output to remain gated", stdout.String())
+	}
+}
+
 func TestDoPrimeHookWarnsWhenRequiredProviderSessionKeyMissing(t *testing.T) {
 	dir, sessionID := setupPrimeHookProviderSessionKeyTest(t, "kimi", `[providers.kimi]
 base = "builtin:kimi"`)


### PR DESCRIPTION
## Problem

On a **live managed session**, prime's SessionStart path returns as soon as it decides not to emit prompt output — the gate at `cmd/gc/cmd_prime.go` returns `0` *before* `runHookSideEffects()` is reached.

`runHookSideEffects()` is where the provider's resume key is captured and persisted. So for precisely the sessions that *have* a runtime to resume, the key is never written. A later resume then restarts the agent from scratch instead of continuing its thread — silently, since nothing errors.

## Fix

Run the side effects **before** the output gate. Capturing durable state should not be conditional on whether this particular invocation prints a prompt.

## Why now

This lands on top of #3954, which added the Claude resume-key capture arm. That fix supplies the key this path was dropping, so the two together are what make managed-session resume actually work end to end.

## Tests

`cmd/gc/main_test.go` gains a regression asserting the provider key is persisted before the SessionStart output gate (fails on this base without the fix: `session_key = "", want provider key persisted before SessionStart output gate`).

Full `cmd/gc` prime/hook suite green; `go vet ./cmd/gc/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)