### PR TITLE
fix(convergence): preserve GC_HOME for gate subprocesses

### DIFF
--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -24,6 +24,19 @@ const (
 	textFileBusyRetryDelay    = 25 * time.Millisecond
 )
 
+// conditionGCHome resolves the gc state directory for gate subprocesses. Gate
+// HOME is intentionally sandboxed to the city, so it cannot also be used for
+// gc's machine-level cache and registry state.
+func conditionGCHome() string {
+	if value := strings.TrimSpace(os.Getenv("GC_HOME")); value != "" {
+		return value
+	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, ".gc")
+	}
+	return filepath.Join(os.TempDir(), ".gc")
+}
+
 // conditionPATH resolves the tool directories gate scripts actually need.
 // This keeps the env narrow while ensuring gate scripts use the same bd/gc
 // binaries as the running city instead of whatever older copy happens to live
@@ -90,6 +103,7 @@ func (ce ConditionEnv) Environ() []string {
 	env := []string{
 		"PATH=" + conditionPATH(),
 		"HOME=" + home,
+		"GC_HOME=" + conditionGCHome(),
 		"TMPDIR=" + os.TempDir(),
 		"BEADS_DIR=" + filepath.Join(storePath, ".beads"),
 		"GC_BEAD_ID=" + ce.BeadID,

--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/gchome"
 	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
@@ -28,13 +29,7 @@ const (
 // HOME is intentionally sandboxed to the city, so it cannot also be used for
 // gc's machine-level cache and registry state.
 func conditionGCHome() string {
-	if value := strings.TrimSpace(os.Getenv("GC_HOME")); value != "" {
-		return value
-	}
-	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
-		return filepath.Join(home, ".gc")
-	}
-	return filepath.Join(os.TempDir(), ".gc")
+	return gchome.ResolveReadOnly().Path()
 }
 
 // conditionPATH resolves the tool directories gate scripts actually need.

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/gchome"
 	"github.com/gastownhall/gascity/internal/testutil"
 )
 
@@ -79,6 +80,18 @@ func TestConditionEnvEnviron(t *testing.T) {
 	}
 	if _, ok := lookup["TMPDIR"]; !ok {
 		t.Error("missing TMPDIR env var")
+	}
+}
+
+func TestConditionGCHomeFallbackIsNotSharedTempDir(t *testing.T) {
+	t.Setenv("GC_HOME", "")
+
+	got := conditionGCHome()
+	if got == filepath.Join(os.TempDir(), ".gc") {
+		t.Fatalf("conditionGCHome() = %q, must not be the shared world-writable temp home (gastownhall/gascity#3506)", got)
+	}
+	if want := gchome.ResolveReadOnly().Path(); got != want {
+		t.Fatalf("conditionGCHome() = %q, want canonical gchome resolution %q", got, want)
 	}
 }
 

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestConditionEnvEnviron(t *testing.T) {
+	t.Setenv("GC_HOME", "/operator/gc-home")
+
 	env := ConditionEnv{
 		BeadID:               "bead-123",
 		Iteration:            3,
@@ -41,6 +43,7 @@ func TestConditionEnvEnviron(t *testing.T) {
 	// Required vars.
 	checks := map[string]string{
 		"PATH":                      conditionPATH(),
+		"GC_HOME":                   "/operator/gc-home",
 		"BEADS_DIR":                 "/home/test/city/.beads",
 		"GC_BEAD_ID":                "bead-123",
 		"GC_ITERATION":              "3",


### PR DESCRIPTION
## Problem

Gate scripts run with `HOME` deliberately sandboxed to the city directory, so a gate cannot write into the operator's real home. But `gc` resolves its **machine-level** state directory as `HOME/.gc` when `GC_HOME` is unset (`internal/gchome/gchome.go`).

So any `gc` invoked from a gate script resolves its cache and registry to `<city>/.gc` instead of the machine's `~/.gc` — a second, divergent copy of machine state that nothing else in the fleet reads. Silent: the gate succeeds, it just populated the wrong directory.

## Fix

Pass `GC_HOME` through explicitly to gate subprocesses. The sandboxed `HOME` stays sandboxed; machine-level state stays machine-level. Resolution order mirrors `gchome`: explicit `GC_HOME` → `HOME/.gc` → temp fallback.

## Tests

`condition_test.go` asserts `GC_HOME` is present in the gate subprocess environment (fails on this base without the fix: `missing env var GC_HOME`).

`go test ./internal/convergence/` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4859 — adds GC_HOME to the gate/check subprocess environment in ConditionEnv.Environ(), so a nested gc resolves its machine-level cache and registry against the operator's real ~/.gc instead of the empty city-local one, while leaving the sandboxed HOME intact — this is the issue's recommended fix candidate A, implemented by resolving GC_HOME inside the convergence package rather than threading a field from runRalphCheck

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->