### PR TITLE
fix(usage): sweep model usage from live sessions, not only at retirement

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -108,6 +108,12 @@ type CityRuntime struct {
 	asyncStops         asyncStartTracker
 	demandSnapshot     *runtimeDemandSnapshot
 
+	// liveSweepTranscriptPaths memoizes the stable transcript path for each
+	// session awake epoch and provider session key. The worker factory is rebuilt
+	// per tick, so this process-lifetime cache avoids repeating bounded discovery
+	// without carrying a path across a replacement conversation.
+	liveSweepTranscriptPaths sync.Map // liveSweepTranscriptCacheKey -> transcript path
+
 	fsPressureConsecutiveSkips int
 	fsPressureEpisodeLogged    bool
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -108,11 +108,12 @@ type CityRuntime struct {
 	asyncStops         asyncStartTracker
 	demandSnapshot     *runtimeDemandSnapshot
 
-	// liveSweepTranscriptPaths memoizes the stable transcript path for each
-	// session awake epoch and provider session key. The worker factory is rebuilt
-	// per tick, so this process-lifetime cache avoids repeating bounded discovery
-	// without carrying a path across a replacement conversation.
-	liveSweepTranscriptPaths sync.Map // liveSweepTranscriptCacheKey -> transcript path
+	// liveSweepMemos carries the live model-usage sweep's per-session memo: the
+	// resolved transcript path, whether discovery definitively found nothing, and
+	// the sweep-interval floor. The worker factory is rebuilt per tick, so this
+	// process-lifetime cache is what keeps a per-tick live lane from repeating
+	// bounded discovery and transcript reads for every awake session.
+	liveSweepMemos sync.Map // session bead id -> liveSweepMemo
 
 	fsPressureConsecutiveSkips int
 	fsPressureEpisodeLogged    bool
@@ -2188,7 +2189,9 @@ func (cr *CityRuntime) stopConfigWatcher() {
 // readiness quickly, so it skips the undesired-pool-session sweep (a heavy
 // candidate × store × status × identifier bd-read fan-out that, serialized on
 // the readiness path, can exceed the startup watchdog on a heavy-session city —
-// gastownhall/gascity#3288). The first steady-state tick performs the sweep.
+// gastownhall/gascity#3288) and the usage lane's live transcript sweep (bounded
+// per-session file discovery and reads across every awake session at once). The
+// first steady-state tick performs both.
 func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStateResult, sessionBeads *sessionBeadSnapshot, trace *sessionReconcilerTraceCycle, bootReconcile bool) {
 	desiredState := result.State
 	store := cr.cityBeadStore()
@@ -2214,8 +2217,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
 	}
 	// Emit any due compute usage facts by reusing the open-session snapshot this
-	// tick already loaded, rather than issuing a second redundant store scan.
-	cr.emitDueComputeFacts(ctx, sessionBeads.OpenInfos())
+	// tick already loaded, rather than issuing a second redundant store scan. The
+	// boot pass covers the whole fleet at once on the readiness path, so it takes
+	// only the marker-gated terminal lane and leaves the fleet-proportional live
+	// lane to the first steady-state tick.
+	cr.emitDueComputeFacts(ctx, sessionBeads.OpenInfos(), bootReconcile)
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs

--- a/cmd/gc/usage_compute.go
+++ b/cmd/gc/usage_compute.go
@@ -45,6 +45,17 @@ func isComputeTerminalState(state string) bool {
 	return false
 }
 
+// isLiveModelSweepState reports whether a session is currently awake and may
+// still append model invocations to its transcript. It is deliberately
+// disjoint from isComputeTerminalState.
+func isLiveModelSweepState(state string) bool {
+	switch session.State(strings.TrimSpace(state)) {
+	case session.StateActive, session.StateAwake:
+		return true
+	}
+	return false
+}
+
 // emitComputeFactForBead records one compute Fact for a session bead's
 // completed awake interval, exactly once per awake_started_at epoch. Returns
 // true when a fact was recorded. It is a no-op when the sink is discard/nil,
@@ -166,15 +177,25 @@ func computeFactGetCandidate(info session.Info) bool {
 	return strings.TrimSpace(info.UsageComputeEmittedAt) != start
 }
 
-// emitDueComputeFacts emits a compute Fact for any of the given open sessions whose
-// awake interval has ended (terminal state) and has not yet been recorded. It reuses the
-// reconcile tick's already-loaded Info snapshot for the cheap candidate filter
-// (computeFactGetCandidate), then fetches the raw bead ONLY for the few sessions that
-// pass it: the usage lane genuinely needs the whole bead (ResolveRunID walks the
-// run-chain keys, and slept_at is not projected onto session.Info), so this is the usage
-// lane's OWN edge read rather than a snapshot raw-half read. A steady fleet of parked
-// sessions whose intervals are already accounted issues zero Gets. Best-effort: it never
-// blocks or fails the reconcile tick.
+// liveModelSweepCandidate reports whether an open snapshot row is worth
+// loading for an incremental transcript sweep. Unlike terminal compute
+// accounting, a live session remains a candidate every tick; the persisted
+// invocation cursor makes repeated sweeps idempotent.
+func liveModelSweepCandidate(info session.Info) bool {
+	return isLiveModelSweepState(info.MetadataState) &&
+		strings.TrimSpace(info.AwakeStartedAt) != ""
+}
+
+// emitDueComputeFacts accounts for terminal compute intervals and incrementally
+// sweeps model usage from awake sessions. It reuses the reconcile tick's already-loaded
+// Info snapshot for the cheap candidate filters (computeFactGetCandidate,
+// liveModelSweepCandidate), then fetches the raw bead ONLY for the few sessions that
+// pass one: the usage lane genuinely needs the whole bead (ResolveRunID walks the
+// run-chain keys, and neither slept_at nor the transcript cursor is projected onto
+// session.Info), so this is the usage lane's OWN edge read rather than a snapshot
+// raw-half read. A steady fleet of parked sessions whose intervals are already
+// accounted issues zero Gets. Best-effort: it never blocks or fails the reconcile
+// tick.
 func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []session.Info) {
 	if cr.cs == nil {
 		return
@@ -227,21 +248,21 @@ func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []sessi
 		return sweepFactory
 	}
 	now := time.Now().UTC()
-	for _, info := range sessions {
-		if !computeFactGetCandidate(info) {
-			continue
+	processSessionBead := func(b beads.Bead) {
+		if b.Metadata == nil {
+			return
 		}
-		b, err := store.Get(info.ID)
-		if err != nil {
-			logf("usage: loading session %s for compute fact failed: %v", info.ID, err)
-			continue
+		state := b.Metadata["state"]
+		if isLiveModelSweepState(state) {
+			cr.sweepLiveSessionModelUsage(ctx, b, now, logf, modelSweepFactory)
+			return
 		}
 		// Re-check the terminal state from the FRESH bead: a session that re-awoke in
 		// the window since the snapshot was taken must not mint a tiny-wall fact for its
 		// just-STARTED interval and suppress the real end-of-interval emission. Best-
 		// effort accounting, the same NDI class as the sync-tail re-list delta.
-		if b.Metadata == nil || !isComputeTerminalState(b.Metadata["state"]) {
-			continue
+		if !isComputeTerminalState(state) {
+			return
 		}
 		awakeStart := strings.TrimSpace(b.Metadata["awake_started_at"])
 		// Model-usage lane FIRST, symmetric to and beside the compute fact: recover the
@@ -276,5 +297,76 @@ func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []sessi
 		// recorded (idempotent), so wall-time accounting is never delayed by a pending
 		// sweep.
 		emitComputeFactForBead(ctx, sink, store, b, runtimeKind, cr.cityName, now, logf, sweepSettled)
+	}
+	for _, info := range sessions {
+		if !computeFactGetCandidate(info) && !liveModelSweepCandidate(info) {
+			continue
+		}
+		b, err := store.Get(info.ID)
+		if err != nil {
+			logf("usage: loading session %s for usage facts failed: %v", info.ID, err)
+			continue
+		}
+		processSessionBead(b)
+	}
+}
+
+type liveSweepTranscriptCacheKey struct {
+	sessionID  string
+	awakeStart string
+	sessionKey string
+}
+
+// sweepLiveSessionModelUsage incrementally records model usage for an awake
+// session without closing its compute interval or stamping the terminal sweep
+// marker. Transcript discovery is memoized for the current awake epoch and
+// provider session key; a new epoch or replacement conversation therefore
+// resolves its own rollout instead of reusing a stale path.
+func (cr *CityRuntime) sweepLiveSessionModelUsage(
+	ctx context.Context,
+	b beads.Bead,
+	now time.Time,
+	logf func(string, ...any),
+	modelSweepFactory func() *worker.Factory,
+) {
+	if b.Metadata == nil || !isLiveModelSweepState(b.Metadata["state"]) ||
+		strings.TrimSpace(b.Metadata["awake_started_at"]) == "" {
+		return
+	}
+	factory := modelSweepFactory()
+	if factory == nil {
+		return
+	}
+	cacheKey := liveSweepTranscriptCacheKey{
+		sessionID:  b.ID,
+		awakeStart: strings.TrimSpace(b.Metadata["awake_started_at"]),
+		sessionKey: strings.TrimSpace(b.Metadata["session_key"]),
+	}
+	path, cached := cr.cachedLiveTranscriptPath(cacheKey)
+	if !cached {
+		path = factory.DiscoverSweepTranscript(b.ID, b.Metadata, now)
+		if path != "" {
+			cr.rememberLiveTranscriptPath(cacheKey, path)
+		}
+	}
+	if path == "" {
+		return
+	}
+	if _, _, err := factory.SweepSessionModelUsageAtPath(ctx, b.ID, b.Metadata, path, now); err != nil {
+		logf("usage: live model-usage sweep for session %s failed; will retry: %v", b.ID, err)
+	}
+}
+
+func (cr *CityRuntime) cachedLiveTranscriptPath(key liveSweepTranscriptCacheKey) (string, bool) {
+	if value, ok := cr.liveSweepTranscriptPaths.Load(key); ok {
+		path, _ := value.(string)
+		return path, true
+	}
+	return "", false
+}
+
+func (cr *CityRuntime) rememberLiveTranscriptPath(key liveSweepTranscriptCacheKey, path string) {
+	if strings.TrimSpace(path) != "" {
+		cr.liveSweepTranscriptPaths.Store(key, path)
 	}
 }

--- a/cmd/gc/usage_compute.go
+++ b/cmd/gc/usage_compute.go
@@ -28,6 +28,20 @@ const usageComputeEmittedAtKey = "usage_compute_emitted_at"
 // session-interval accounting markers, not domain metadata).
 const usageModelSweptAtKey = "usage_model_swept_at"
 
+// liveModelSweepMinInterval floors how often the reconcile tick re-sweeps one
+// awake session's transcript for model usage. The terminal lane is gated by a
+// persisted per-interval marker, so it touches each session once; a live session
+// has no such endpoint and is a candidate on EVERY tick, which makes the live
+// lane's cost fleet-proportional AND repeated at the tick cadence — a bounded
+// rollout discovery scan plus a transcript tail read per awake session, on the
+// SYNCHRONOUS reconcile tick. Without a floor, a poke-driven sub-second cadence
+// turns that into per-tick file I/O across the whole live fleet. Thirty seconds
+// is far below the interval-scale staleness this lane exists to fix (usage
+// previously appeared only at retirement, hours later) and far above the tick
+// cadence that produces the storm; nothing is lost by waiting, because the
+// cursor-guarded sweep bills the whole batch pending at the moment it next runs.
+const liveModelSweepMinInterval = 30 * time.Second
+
 // isComputeTerminalState reports whether a session state marks the end of an
 // awake interval, at which a compute fact should be emitted. It covers every
 // non-running lifecycle endpoint the controller's open-bead scan can observe:
@@ -196,7 +210,15 @@ func liveModelSweepCandidate(info session.Info) bool {
 // raw-half read. A steady fleet of parked sessions whose intervals are already
 // accounted issues zero Gets. Best-effort: it never blocks or fails the reconcile
 // tick.
-func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []session.Info) {
+//
+// bootReconcile disables the live lane. The terminal lane's cost is unchanged by
+// boot — it is gated by a persisted per-interval marker, so it fires once per
+// interval whenever the pass runs — but the live lane's transcript discovery and
+// reads are proportional to the awake fleet, and the boot pass covers the whole
+// fleet at once on the synchronous readiness path. Deferring the live lane to the
+// first steady-state tick costs one tick of billing latency and keeps startup off
+// the critical path (the same trade beadReconcileTick makes for the pool sweep).
+func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []session.Info, bootReconcile bool) {
 	if cr.cs == nil {
 		return
 	}
@@ -248,13 +270,19 @@ func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []sessi
 		return sweepFactory
 	}
 	now := time.Now().UTC()
+	liveLane := !bootReconcile
 	processSessionBead := func(b beads.Bead) {
 		if b.Metadata == nil {
 			return
 		}
 		state := b.Metadata["state"]
 		if isLiveModelSweepState(state) {
-			cr.sweepLiveSessionModelUsage(ctx, b, now, logf, modelSweepFactory)
+			// Routed off the FRESH bead, so a session that woke since the snapshot
+			// lands here too — and on the boot pass it is skipped just like a
+			// snapshot-live one.
+			if liveLane {
+				cr.sweepLiveSessionModelUsage(ctx, b, now, logf, modelSweepFactory)
+			}
 			return
 		}
 		// Re-check the terminal state from the FRESH bead: a session that re-awoke in
@@ -299,7 +327,14 @@ func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []sessi
 		emitComputeFactForBead(ctx, sink, store, b, runtimeKind, cr.cityName, now, logf, sweepSettled)
 	}
 	for _, info := range sessions {
-		if !computeFactGetCandidate(info) && !liveModelSweepCandidate(info) {
+		// A canceled tick (controller shutdown, reconcile deadline) stops here
+		// rather than working through the rest of the fleet: every remaining
+		// session is picked up idempotently by the next tick.
+		if ctx.Err() != nil {
+			return
+		}
+		liveCandidate := liveLane && liveModelSweepCandidate(info)
+		if !computeFactGetCandidate(info) && !liveCandidate {
 			continue
 		}
 		b, err := store.Get(info.ID)
@@ -311,17 +346,35 @@ func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []sessi
 	}
 }
 
-type liveSweepTranscriptCacheKey struct {
-	sessionID  string
+// liveSweepMemo is one awake session's live model-usage sweep state, held for
+// the process lifetime because the worker factory is rebuilt every tick.
+//
+// awakeStart and sessionKey stamp the epoch and conversation the memo describes:
+// a re-wake or a replacement conversation invalidates it, so it resolves its own
+// rollout rather than sweeping a stale path. Keying the map by session id (with
+// the epoch inside the value) means a long-lived session replaces its memo on
+// each wake instead of accumulating one entry per epoch forever.
+type liveSweepMemo struct {
 	awakeStart string
 	sessionKey string
+	// path is the resolved transcript, empty until discovery succeeds.
+	path string
+	// settledMiss records a DEFINITIVE discovery miss — there is nothing to find
+	// for this epoch, so discovery is never re-attempted for it.
+	settledMiss bool
+	// nextSweepAt floors the sweep cadence (liveModelSweepMinInterval). It also
+	// backs off an unsettled discovery miss, so a session whose transcript cannot
+	// be resolved yet re-attempts discovery on that same floor instead of on
+	// every tick forever.
+	nextSweepAt time.Time
 }
 
 // sweepLiveSessionModelUsage incrementally records model usage for an awake
 // session without closing its compute interval or stamping the terminal sweep
-// marker. Transcript discovery is memoized for the current awake epoch and
-// provider session key; a new epoch or replacement conversation therefore
-// resolves its own rollout instead of reusing a stale path.
+// marker. Transcript discovery and the transcript read are both memoized and
+// throttled per session (see liveSweepMemo and liveModelSweepMinInterval), so a
+// live fleet costs at most one bounded discovery plus one tail read per session
+// per liveModelSweepMinInterval no matter how fast the reconcile tick spins.
 func (cr *CityRuntime) sweepLiveSessionModelUsage(
 	ctx context.Context,
 	b beads.Bead,
@@ -329,44 +382,58 @@ func (cr *CityRuntime) sweepLiveSessionModelUsage(
 	logf func(string, ...any),
 	modelSweepFactory func() *worker.Factory,
 ) {
-	if b.Metadata == nil || !isLiveModelSweepState(b.Metadata["state"]) ||
-		strings.TrimSpace(b.Metadata["awake_started_at"]) == "" {
+	if b.Metadata == nil || !isLiveModelSweepState(b.Metadata["state"]) {
+		return
+	}
+	awakeStart := strings.TrimSpace(b.Metadata["awake_started_at"])
+	if awakeStart == "" {
+		return
+	}
+	memo := cr.liveSweepMemoFor(b.ID, awakeStart, strings.TrimSpace(b.Metadata["session_key"]))
+	if memo.settledMiss || now.Before(memo.nextSweepAt) {
 		return
 	}
 	factory := modelSweepFactory()
 	if factory == nil {
 		return
 	}
-	cacheKey := liveSweepTranscriptCacheKey{
-		sessionID:  b.ID,
-		awakeStart: strings.TrimSpace(b.Metadata["awake_started_at"]),
-		sessionKey: strings.TrimSpace(b.Metadata["session_key"]),
+	if memo.path == "" {
+		// A settled miss is definitive for this epoch (unregistered provider family,
+		// or a keyless codex session whose CLEAN workdir+window scan found nothing —
+		// ambiguity, an out-of-window filename, or a TZ shift, none of which a retry
+		// resolves). Record it so the scan is never repeated; the session's usage is
+		// still recovered by the terminal sweep when its interval ends, and a re-wake
+		// starts a fresh epoch that discovers again.
+		path, settled := factory.DiscoverSweepTranscript(b.ID, b.Metadata, now)
+		memo.path = path
+		memo.settledMiss = path == "" && settled
 	}
-	path, cached := cr.cachedLiveTranscriptPath(cacheKey)
-	if !cached {
-		path = factory.DiscoverSweepTranscript(b.ID, b.Metadata, now)
-		if path != "" {
-			cr.rememberLiveTranscriptPath(cacheKey, path)
-		}
-	}
-	if path == "" {
+	// Persist the memo BEFORE the miss return: an unsettled miss must still take
+	// the interval floor, or discovery repeats on every tick for a session whose
+	// transcript never resolves.
+	memo.nextSweepAt = now.Add(liveModelSweepMinInterval)
+	cr.storeLiveSweepMemo(b.ID, memo)
+	if memo.path == "" {
 		return
 	}
-	if _, _, err := factory.SweepSessionModelUsageAtPath(ctx, b.ID, b.Metadata, path, now); err != nil {
+	if _, _, err := factory.SweepSessionModelUsageAtPath(ctx, b.ID, b.Metadata, memo.path, now); err != nil {
 		logf("usage: live model-usage sweep for session %s failed; will retry: %v", b.ID, err)
 	}
 }
 
-func (cr *CityRuntime) cachedLiveTranscriptPath(key liveSweepTranscriptCacheKey) (string, bool) {
-	if value, ok := cr.liveSweepTranscriptPaths.Load(key); ok {
-		path, _ := value.(string)
-		return path, true
+// liveSweepMemoFor returns the session's memo for the given awake epoch and
+// provider session key, or a fresh one stamped with that identity when none is
+// held or the held one describes a superseded epoch or conversation.
+func (cr *CityRuntime) liveSweepMemoFor(sessionID, awakeStart, sessionKey string) liveSweepMemo {
+	if value, ok := cr.liveSweepMemos.Load(sessionID); ok {
+		if memo, isMemo := value.(liveSweepMemo); isMemo &&
+			memo.awakeStart == awakeStart && memo.sessionKey == sessionKey {
+			return memo
+		}
 	}
-	return "", false
+	return liveSweepMemo{awakeStart: awakeStart, sessionKey: sessionKey}
 }
 
-func (cr *CityRuntime) rememberLiveTranscriptPath(key liveSweepTranscriptCacheKey, path string) {
-	if strings.TrimSpace(path) != "" {
-		cr.liveSweepTranscriptPaths.Store(key, path)
-	}
+func (cr *CityRuntime) storeLiveSweepMemo(sessionID string, memo liveSweepMemo) {
+	cr.liveSweepMemos.Store(sessionID, memo)
 }

--- a/cmd/gc/usage_compute_test.go
+++ b/cmd/gc/usage_compute_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,6 +49,32 @@ func TestComputeFactGetCandidate(t *testing.T) {
 		if got := computeFactGetCandidate(tc.info); got != tc.want {
 			t.Errorf("%s: computeFactGetCandidate = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+func TestLiveModelSweepCandidate(t *testing.T) {
+	const awakeStart = "2026-01-02T00:30:00Z"
+	for _, tc := range []struct {
+		name  string
+		state string
+		awake string
+		want  bool
+	}{
+		{name: "active", state: "active", awake: awakeStart, want: true},
+		{name: "awake alias", state: "awake", awake: awakeStart, want: true},
+		{name: "missing interval anchor", state: "active", want: false},
+		{name: "terminal", state: "asleep", awake: awakeStart, want: false},
+		{name: "transitional", state: "draining", awake: awakeStart, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			info := session.Info{MetadataState: tc.state, AwakeStartedAt: tc.awake}
+			if got := liveModelSweepCandidate(info); got != tc.want {
+				t.Fatalf("liveModelSweepCandidate() = %v, want %v", got, tc.want)
+			}
+			if isLiveModelSweepState(tc.state) && isComputeTerminalState(tc.state) {
+				t.Fatalf("state %q is both live and compute-terminal", tc.state)
+			}
+		})
 	}
 }
 
@@ -275,20 +303,23 @@ func TestEmitComputeFactForBeadHungSinkReturnsPromptly(t *testing.T) {
 	}
 }
 
+const codexSweepSessionKey = "019e3e8e-3591-7532-a1ef-8b9e882bea2f"
+
 // writeCodexRolloutForSweep fabricates a codex rollout transcript
 // (rollout-<localtime>-<sessionID>.jsonl) under root/YYYY/MM/DD reachable by the
 // window-free keyed discovery: a session_meta line whose cwd is workDir, a
 // turn_context supplying the model, and one event_msg token_count per element of
-// tokenCounts ({total, lastInput, lastOutput}). Returns the rollout path.
-func writeCodexRolloutForSweep(t *testing.T, root, workDir, sessionID string, tokenCounts [][3]int) {
+// tokenCounts ({total, lastInput, lastOutput}). The keyed sweep scenarios share
+// codexSweepSessionKey; callers vary only the transcript contents and location.
+func writeCodexRolloutForSweep(t *testing.T, root, workDir string, tokenCounts [][3]int) {
 	t.Helper()
 	dayDir := filepath.Join(root, "2026", "06", "15")
 	if err := os.MkdirAll(dayDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(dayDir, "rollout-2026-06-15T10-00-00-"+sessionID+".jsonl")
+	path := filepath.Join(dayDir, "rollout-2026-06-15T10-00-00-"+codexSweepSessionKey+".jsonl")
 	lines := []string{
-		fmt.Sprintf(`{"timestamp":"2026-06-15T10:00:00.000Z","type":"session_meta","payload":{"id":%q,"cwd":%q}}`, sessionID, workDir),
+		fmt.Sprintf(`{"timestamp":"2026-06-15T10:00:00.000Z","type":"session_meta","payload":{"id":%q,"cwd":%q}}`, codexSweepSessionKey, workDir),
 		`{"timestamp":"2026-06-15T10:00:01.000Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}`,
 	}
 	for i, tc := range tokenCounts {
@@ -315,6 +346,171 @@ func kindCount(facts []usage.Fact, kind usage.Kind) int {
 	return n
 }
 
+// rawSinkKindCount counts the facts of one kind APPENDED to the sink file,
+// without usage.ReadFacts's IdempotencyKey dedup. Idempotency assertions must
+// use this: ReadFacts collapses a replayed fact at read time, so it would
+// silently pass even if a tick re-recorded work the cursor should have skipped.
+func rawSinkKindCount(t *testing.T, path string, kind usage.Kind) int {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("reading usage sink %s: %v", path, err)
+	}
+	n := 0
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var f usage.Fact
+		if err := json.Unmarshal([]byte(line), &f); err != nil {
+			t.Fatalf("malformed usage fact %q: %v", line, err)
+		}
+		if f.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// TestEmitDueComputeFactsSweepsLiveSessionModelUsage is the undercount
+// regression for "model calls today": model facts used to be minted only by the
+// terminal end-of-interval sweep, so a session that stayed awake for hours
+// contributed nothing to the day's totals until it finally closed. The reconcile
+// tick must sweep an AWAKE session's transcript incrementally — billing each
+// invocation as it lands, without minting a compute fact or closing the still-open
+// interval — and the persisted invocation cursor must make a tick with no new
+// transcript activity a no-op.
+func TestEmitDueComputeFactsSweepsLiveSessionModelUsage(t *testing.T) {
+	cityPath := t.TempDir()
+	workDir := t.TempDir()
+	codexRoot := t.TempDir()
+	sinkPath := filepath.Join(cityPath, ".gc", "usage.jsonl")
+	sessionKey := codexSweepSessionKey
+	writeCodexRolloutForSweep(t, codexRoot, workDir, [][3]int{
+		{150, 100, 50},  // total=150, last input=100, output=50
+		{450, 200, 100}, // total=450, last input=200, output=100
+	})
+
+	store := beads.NewMemStore()
+	start := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	// No slept_at and a non-terminal state: this session is still running.
+	b, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Title:  "live codex session",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":            "active",
+			"session_name":     "codex-live-1",
+			"awake_started_at": start.Format(time.RFC3339),
+			"session_key":      sessionKey,
+			"work_dir":         workDir,
+			"provider":         "codex",
+			"builtin_ancestor": "codex",
+			"molecule_id":      "run-L",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Daemon: config.DaemonConfig{ObservePaths: []string{codexRoot}}}
+	cs := &controllerState{cityBeadStore: store, usageSink: usage.NewLocalSink(sinkPath), cityName: "demo", cityPath: cityPath}
+	cr := &CityRuntime{cs: cs, cfg: cfg, sp: runtime.NewFake(), cityName: "demo", cityPath: cityPath, stderr: io.Discard}
+	info := session.Info{ID: b.ID, MetadataState: "active", AwakeStartedAt: start.Format(time.RFC3339)}
+
+	// Tick 1: nothing terminal has happened, yet both invocations already on the
+	// transcript must bill now instead of waiting for retirement.
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	facts1, warnings, err := usage.ReadFacts(sinkPath)
+	if err != nil {
+		t.Fatalf("ReadFacts (tick 1): %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected sink warnings: %v", warnings)
+	}
+	if got := kindCount(facts1, usage.KindModel); got != 2 {
+		t.Fatalf("tick 1 model facts = %d, want 2 (a live session's invocations must bill before it closes); facts: %+v", got, facts1)
+	}
+	if got := kindCount(facts1, usage.KindCompute); got != 0 {
+		t.Fatalf("tick 1 compute facts = %d, want 0: the awake interval has not ended", got)
+	}
+	for _, f := range facts1 {
+		if f.RunID != "run-L" {
+			t.Fatalf("fact RunID = %q, want run-L: %+v", f.RunID, f)
+		}
+		if f.Provider != "codex" {
+			t.Fatalf("model fact Provider = %q, want codex", f.Provider)
+		}
+	}
+
+	// The interval stays OPEN: stamping either accounting marker on a live sweep
+	// would suppress the real end-of-interval compute fact and terminal sweep.
+	afterTick1, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := afterTick1.Metadata[session.MetadataKeyInvocationUsageCursor]; got != "total:450" {
+		t.Fatalf("invocation_usage_cursor = %q, want total:450 (advanced past the swept batch)", got)
+	}
+	if got := afterTick1.Metadata[usageComputeEmittedAtKey]; got != "" {
+		t.Fatalf("live sweep closed the awake interval (usage_compute_emitted_at = %q), want unset", got)
+	}
+	if got := afterTick1.Metadata[usageModelSweptAtKey]; got != "" {
+		t.Fatalf("live sweep stamped the terminal sweep marker (%q), want unset while the interval accumulates", got)
+	}
+
+	// Discovery is memoized for this awake epoch so a per-tick sweep does not
+	// repeat the bounded rollout scan.
+	cacheKey := liveSweepTranscriptCacheKey{
+		sessionID:  b.ID,
+		awakeStart: start.Format(time.RFC3339),
+		sessionKey: sessionKey,
+	}
+	if path, cached := cr.cachedLiveTranscriptPath(cacheKey); !cached || path == "" {
+		t.Fatalf("tick 1 did not memoize the resolved transcript path: path=%q cached=%v", path, cached)
+	}
+
+	// Tick 2: no transcript activity. A live session stays a candidate on every
+	// tick, so only the persisted cursor prevents a double-count.
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	if got := rawSinkKindCount(t, sinkPath, usage.KindModel); got != 2 {
+		t.Fatalf("tick 2 appended model facts to a total of %d, want 2: the cursor must make a no-activity tick a no-op", got)
+	}
+
+	// Tick 3: one new invocation lands. Only that delta bills, and the session is
+	// still awake, so still no compute fact.
+	writeCodexRolloutForSweep(t, codexRoot, workDir, [][3]int{
+		{150, 100, 50},
+		{450, 200, 100},
+		{750, 300, 150},
+	})
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	facts3, _, err := usage.ReadFacts(sinkPath)
+	if err != nil {
+		t.Fatalf("ReadFacts (tick 3): %v", err)
+	}
+	if got := kindCount(facts3, usage.KindModel); got != 3 {
+		t.Fatalf("tick 3 model facts = %d, want 3 (one appended invocation): %+v", got, facts3)
+	}
+	if got := rawSinkKindCount(t, sinkPath, usage.KindModel); got != 3 {
+		t.Fatalf("tick 3 appended model facts to a total of %d, want 3 (only the delta)", got)
+	}
+	if got := kindCount(facts3, usage.KindCompute); got != 0 {
+		t.Fatalf("tick 3 compute facts = %d, want 0 while the session is awake", got)
+	}
+	afterTick3, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := afterTick3.Metadata[session.MetadataKeyInvocationUsageCursor]; got != "total:750" {
+		t.Fatalf("invocation_usage_cursor = %q, want total:750", got)
+	}
+}
+
 // TestEmitDueComputeFactsAlsoSweepsModelUsage is the CORE regression for the
 // token-starvation bug: the controller reconcile tick emits per-interval compute
 // facts but never any model facts for pool-routed, hook-self-driven codex agents,
@@ -330,8 +526,8 @@ func TestEmitDueComputeFactsAlsoSweepsModelUsage(t *testing.T) {
 
 	// Codex names rollouts by the session_key uuid suffix; the keyed no-window
 	// discovery matches on exactly that.
-	sessionKey := "019e3e8e-3591-7532-a1ef-8b9e882bea2f"
-	writeCodexRolloutForSweep(t, codexRoot, workDir, sessionKey, [][3]int{
+	sessionKey := codexSweepSessionKey
+	writeCodexRolloutForSweep(t, codexRoot, workDir, [][3]int{
 		{150, 100, 50},  // total=150, last input=100, output=50
 		{450, 200, 100}, // total=450, last input=200, output=100
 	})
@@ -446,7 +642,7 @@ func TestEmitDueComputeFactsRetriesUnsettledModelSweep(t *testing.T) {
 	workDir := t.TempDir()
 	codexRoot := t.TempDir()
 	sinkPath := filepath.Join(cityPath, ".gc", "usage.jsonl")
-	sessionKey := "019e3e8e-3591-7532-a1ef-8b9e882bea2f"
+	sessionKey := codexSweepSessionKey
 
 	store := beads.NewMemStore()
 	start := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
@@ -503,7 +699,7 @@ func TestEmitDueComputeFactsRetriesUnsettledModelSweep(t *testing.T) {
 	}
 
 	// The transcript is flushed to disk between ticks.
-	writeCodexRolloutForSweep(t, codexRoot, workDir, sessionKey, [][3]int{
+	writeCodexRolloutForSweep(t, codexRoot, workDir, [][3]int{
 		{150, 100, 50},
 		{450, 200, 100},
 	})

--- a/cmd/gc/usage_compute_test.go
+++ b/cmd/gc/usage_compute_test.go
@@ -346,11 +346,11 @@ func kindCount(facts []usage.Fact, kind usage.Kind) int {
 	return n
 }
 
-// rawSinkKindCount counts the facts of one kind APPENDED to the sink file,
+// rawSinkModelFactCount counts the model facts APPENDED to the sink file,
 // without usage.ReadFacts's IdempotencyKey dedup. Idempotency assertions must
 // use this: ReadFacts collapses a replayed fact at read time, so it would
 // silently pass even if a tick re-recorded work the cursor should have skipped.
-func rawSinkKindCount(t *testing.T, path string, kind usage.Kind) int {
+func rawSinkModelFactCount(t *testing.T, path string) int {
 	t.Helper()
 	body, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -368,11 +368,122 @@ func rawSinkKindCount(t *testing.T, path string, kind usage.Kind) int {
 		if err := json.Unmarshal([]byte(line), &f); err != nil {
 			t.Fatalf("malformed usage fact %q: %v", line, err)
 		}
-		if f.Kind == kind {
+		if f.Kind == usage.KindModel {
 			n++
 		}
 	}
 	return n
+}
+
+// liveSweepStart anchors a live fixture just behind the wall clock. A live
+// session has no slept_at, so its transcript-discovery window runs from
+// awake_started_at all the way to now: a hardcoded fixture date drifts out of
+// discovery's bounded day lookback as real time advances, and the fixture stops
+// being discoverable — the test would start failing for everyone on a fixed
+// future day. Deriving the anchor from time.Now keeps the window an hour wide
+// forever.
+func liveSweepStart() time.Time {
+	return time.Now().UTC().Add(-time.Hour)
+}
+
+// liveCodexSessionMeta is an AWAKE codex session's metadata: a non-terminal state
+// and NO slept_at, so it is a live-lane candidate whose discovery window runs to
+// the wall clock. An empty sessionKey is omitted entirely, selecting the keyless
+// (work_dir, wake-window) discovery path.
+func liveCodexSessionMeta(start time.Time, workDir, sessionKey string) map[string]string {
+	meta := map[string]string{
+		"state":            "active",
+		"session_name":     "codex-live-1",
+		"awake_started_at": start.Format(time.RFC3339),
+		"work_dir":         workDir,
+		"provider":         "codex",
+		"builtin_ancestor": "codex",
+		"molecule_id":      "run-L",
+	}
+	if sessionKey != "" {
+		meta["session_key"] = sessionKey
+	}
+	return meta
+}
+
+// liveSweepHarness is the shared wiring for the live model-usage sweep cases: a
+// session bead in a memory store, a real usage sink, and codexRoot as the only
+// transcript search path. The cases differ only in session metadata and in what
+// is on disk, so everything else is built once here.
+type liveSweepHarness struct {
+	cr       *CityRuntime
+	store    *beads.MemStore
+	meta     map[string]string
+	beadID   string
+	sinkPath string
+	info     session.Info
+}
+
+func newLiveSweepHarness(t *testing.T, codexRoot string, meta map[string]string) liveSweepHarness {
+	t.Helper()
+	cityPath := t.TempDir()
+	sinkPath := filepath.Join(cityPath, ".gc", "usage.jsonl")
+	store := beads.NewMemStore()
+	cfg := &config.City{Daemon: config.DaemonConfig{ObservePaths: []string{codexRoot}}}
+	cs := &controllerState{cityBeadStore: store, usageSink: usage.NewLocalSink(sinkPath), cityName: "demo", cityPath: cityPath}
+	h := liveSweepHarness{
+		cr:       &CityRuntime{cs: cs, cfg: cfg, sp: runtime.NewFake(), cityName: "demo", cityPath: cityPath, stderr: io.Discard},
+		store:    store,
+		meta:     meta,
+		sinkPath: sinkPath,
+	}
+	h.info = h.addSession(t, meta)
+	h.beadID = h.info.ID
+	return h
+}
+
+// addSession creates another session bead in the harness store and returns the
+// snapshot row the reconcile tick would hand emitDueComputeFacts for it.
+func (h liveSweepHarness) addSession(t *testing.T, meta map[string]string) session.Info {
+	t.Helper()
+	b, err := h.store.Create(beads.Bead{
+		Type:     session.BeadType,
+		Status:   "open",
+		Title:    meta["session_name"],
+		Labels:   []string{session.LabelSession},
+		Metadata: meta,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session.Info{ID: b.ID, MetadataState: meta["state"], AwakeStartedAt: meta["awake_started_at"]}
+}
+
+// tick runs one STEADY-STATE reconcile-tick usage pass over the harness session.
+// The boot pass is driven directly by the one case that covers it, which needs a
+// two-session snapshot anyway.
+func (h liveSweepHarness) tick() {
+	h.cr.emitDueComputeFacts(context.Background(), []session.Info{h.info}, false)
+}
+
+// memo returns the live-sweep memo the tick holds for this session's current
+// awake epoch and conversation.
+func (h liveSweepHarness) memo() liveSweepMemo {
+	return h.cr.liveSweepMemoFor(h.beadID, h.meta["awake_started_at"], h.meta["session_key"])
+}
+
+// expireSweepThrottle clears the session's liveModelSweepMinInterval floor,
+// standing in for that interval elapsing between ticks. It preserves the rest of
+// the memo (resolved path, settled-miss sentinel) so a case advances only the
+// clock.
+func (h liveSweepHarness) expireSweepThrottle() {
+	memo := h.memo()
+	memo.nextSweepAt = time.Time{}
+	h.cr.storeLiveSweepMemo(h.beadID, memo)
+}
+
+func (h liveSweepHarness) cursor(t *testing.T) string {
+	t.Helper()
+	b, err := h.store.Get(h.beadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b.Metadata[session.MetadataKeyInvocationUsageCursor]
 }
 
 // TestEmitDueComputeFactsSweepsLiveSessionModelUsage is the undercount
@@ -384,48 +495,19 @@ func rawSinkKindCount(t *testing.T, path string, kind usage.Kind) int {
 // interval — and the persisted invocation cursor must make a tick with no new
 // transcript activity a no-op.
 func TestEmitDueComputeFactsSweepsLiveSessionModelUsage(t *testing.T) {
-	cityPath := t.TempDir()
 	workDir := t.TempDir()
 	codexRoot := t.TempDir()
-	sinkPath := filepath.Join(cityPath, ".gc", "usage.jsonl")
-	sessionKey := codexSweepSessionKey
-	writeCodexRolloutForSweep(t, codexRoot, workDir, [][3]int{
+	start := liveSweepStart()
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, codexSweepSessionKey, [][3]int{
 		{150, 100, 50},  // total=150, last input=100, output=50
 		{450, 200, 100}, // total=450, last input=200, output=100
 	})
-
-	store := beads.NewMemStore()
-	start := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
-	// No slept_at and a non-terminal state: this session is still running.
-	b, err := store.Create(beads.Bead{
-		Type:   session.BeadType,
-		Status: "open",
-		Title:  "live codex session",
-		Labels: []string{session.LabelSession},
-		Metadata: map[string]string{
-			"state":            "active",
-			"session_name":     "codex-live-1",
-			"awake_started_at": start.Format(time.RFC3339),
-			"session_key":      sessionKey,
-			"work_dir":         workDir,
-			"provider":         "codex",
-			"builtin_ancestor": "codex",
-			"molecule_id":      "run-L",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &config.City{Daemon: config.DaemonConfig{ObservePaths: []string{codexRoot}}}
-	cs := &controllerState{cityBeadStore: store, usageSink: usage.NewLocalSink(sinkPath), cityName: "demo", cityPath: cityPath}
-	cr := &CityRuntime{cs: cs, cfg: cfg, sp: runtime.NewFake(), cityName: "demo", cityPath: cityPath, stderr: io.Discard}
-	info := session.Info{ID: b.ID, MetadataState: "active", AwakeStartedAt: start.Format(time.RFC3339)}
+	h := newLiveSweepHarness(t, codexRoot, liveCodexSessionMeta(start, workDir, codexSweepSessionKey))
 
 	// Tick 1: nothing terminal has happened, yet both invocations already on the
 	// transcript must bill now instead of waiting for retirement.
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
-	facts1, warnings, err := usage.ReadFacts(sinkPath)
+	h.tick()
+	facts1, warnings, err := usage.ReadFacts(h.sinkPath)
 	if err != nil {
 		t.Fatalf("ReadFacts (tick 1): %v", err)
 	}
@@ -449,7 +531,7 @@ func TestEmitDueComputeFactsSweepsLiveSessionModelUsage(t *testing.T) {
 
 	// The interval stays OPEN: stamping either accounting marker on a live sweep
 	// would suppress the real end-of-interval compute fact and terminal sweep.
-	afterTick1, err := store.Get(b.ID)
+	afterTick1, err := h.store.Get(h.beadID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,49 +547,239 @@ func TestEmitDueComputeFactsSweepsLiveSessionModelUsage(t *testing.T) {
 
 	// Discovery is memoized for this awake epoch so a per-tick sweep does not
 	// repeat the bounded rollout scan.
-	cacheKey := liveSweepTranscriptCacheKey{
-		sessionID:  b.ID,
-		awakeStart: start.Format(time.RFC3339),
-		sessionKey: sessionKey,
-	}
-	if path, cached := cr.cachedLiveTranscriptPath(cacheKey); !cached || path == "" {
-		t.Fatalf("tick 1 did not memoize the resolved transcript path: path=%q cached=%v", path, cached)
+	if memo := h.memo(); memo.path == "" {
+		t.Fatalf("tick 1 did not memoize the resolved transcript path: memo=%+v", memo)
 	}
 
-	// Tick 2: no transcript activity. A live session stays a candidate on every
+	// Tick 2: no transcript activity. The sweep-interval floor is cleared first so
+	// this asserts the CURSOR, not the throttle (TestEmitDueComputeFactsThrottles-
+	// LiveModelSweep owns the floor): a live session stays a candidate on every
 	// tick, so only the persisted cursor prevents a double-count.
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
-	if got := rawSinkKindCount(t, sinkPath, usage.KindModel); got != 2 {
+	h.expireSweepThrottle()
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 2 {
 		t.Fatalf("tick 2 appended model facts to a total of %d, want 2: the cursor must make a no-activity tick a no-op", got)
 	}
 
 	// Tick 3: one new invocation lands. Only that delta bills, and the session is
 	// still awake, so still no compute fact.
-	writeCodexRolloutForSweep(t, codexRoot, workDir, [][3]int{
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, codexSweepSessionKey, [][3]int{
 		{150, 100, 50},
 		{450, 200, 100},
 		{750, 300, 150},
 	})
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
-	facts3, _, err := usage.ReadFacts(sinkPath)
+	h.expireSweepThrottle()
+	h.tick()
+	facts3, _, err := usage.ReadFacts(h.sinkPath)
 	if err != nil {
 		t.Fatalf("ReadFacts (tick 3): %v", err)
 	}
 	if got := kindCount(facts3, usage.KindModel); got != 3 {
 		t.Fatalf("tick 3 model facts = %d, want 3 (one appended invocation): %+v", got, facts3)
 	}
-	if got := rawSinkKindCount(t, sinkPath, usage.KindModel); got != 3 {
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 3 {
 		t.Fatalf("tick 3 appended model facts to a total of %d, want 3 (only the delta)", got)
 	}
 	if got := kindCount(facts3, usage.KindCompute); got != 0 {
 		t.Fatalf("tick 3 compute facts = %d, want 0 while the session is awake", got)
 	}
-	afterTick3, err := store.Get(b.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := afterTick3.Metadata[session.MetadataKeyInvocationUsageCursor]; got != "total:750" {
+	if got := h.cursor(t); got != "total:750" {
 		t.Fatalf("invocation_usage_cursor = %q, want total:750", got)
+	}
+}
+
+// TestEmitDueComputeFactsThrottlesLiveModelSweep pins the live lane's cost
+// bound. Unlike the terminal lane — gated by a persisted per-interval marker, so
+// it touches a session once — a live session is a candidate on EVERY tick, so
+// without a floor the reconcile tick would run bounded transcript discovery and a
+// transcript read for every awake session at whatever cadence the tick spins
+// (pokes drive it sub-second). A session must be swept at most once per
+// liveModelSweepMinInterval no matter how often the tick fires.
+func TestEmitDueComputeFactsThrottlesLiveModelSweep(t *testing.T) {
+	workDir := t.TempDir()
+	codexRoot := t.TempDir()
+	start := liveSweepStart()
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, codexSweepSessionKey, [][3]int{
+		{150, 100, 50},
+		{450, 200, 100},
+	})
+	h := newLiveSweepHarness(t, codexRoot, liveCodexSessionMeta(start, workDir, codexSweepSessionKey))
+
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 2 {
+		t.Fatalf("tick 1 model facts = %d, want 2", got)
+	}
+	if memo := h.memo(); !memo.nextSweepAt.After(time.Now().UTC()) {
+		t.Fatalf("tick 1 left the sweep-interval floor unarmed: nextSweepAt=%v", memo.nextSweepAt)
+	}
+
+	// A third invocation lands and the tick fires again immediately. The session is
+	// inside its floor, so it must not be re-swept — no discovery, no transcript
+	// read, no fact — even though there is genuinely new usage waiting.
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, codexSweepSessionKey, [][3]int{
+		{150, 100, 50},
+		{450, 200, 100},
+		{750, 300, 150},
+	})
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 2 {
+		t.Fatalf("tick 2 model facts = %d, want 2: a tick inside liveModelSweepMinInterval must not re-sweep the session", got)
+	}
+	if got := h.cursor(t); got != "total:450" {
+		t.Fatalf("invocation_usage_cursor = %q, want total:450 (unmoved by the throttled tick)", got)
+	}
+
+	// Once the floor elapses the same session is swept again and the delta bills:
+	// the throttle delays a sweep, it never drops one.
+	h.expireSweepThrottle()
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 3 {
+		t.Fatalf("tick 3 model facts = %d, want 3 (the delta bills once the floor elapses)", got)
+	}
+}
+
+// TestEmitDueComputeFactsSkipsLiveModelSweepOnBootPass pins the boot carve-out.
+// The boot reconcile covers the WHOLE fleet at once on the synchronous readiness
+// path, which is exactly where fleet-proportional per-session file discovery and
+// reads must not land. The live lane therefore waits for the first steady-state
+// tick — while the terminal lane, whose per-interval marker makes it self-limiting,
+// keeps running on boot as before.
+func TestEmitDueComputeFactsSkipsLiveModelSweepOnBootPass(t *testing.T) {
+	workDir := t.TempDir()
+	codexRoot := t.TempDir()
+	start := liveSweepStart()
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, codexSweepSessionKey, [][3]int{
+		{150, 100, 50},
+		{450, 200, 100},
+	})
+	h := newLiveSweepHarness(t, codexRoot, liveCodexSessionMeta(start, workDir, codexSweepSessionKey))
+
+	// A retired session in the same snapshot: its interval ended, so the terminal
+	// lane owes it a compute fact on the boot pass. Its own workdir has no rollout,
+	// so it contributes no model facts either way.
+	slept := start.Add(90 * time.Second)
+	terminal := h.addSession(t, map[string]string{
+		"state":            "asleep",
+		"session_name":     "codex-retired-1",
+		"awake_started_at": start.Format(time.RFC3339),
+		"slept_at":         slept.Format(time.RFC3339),
+		"session_key":      "019e7777-cccc-7000-8000-00000000000b",
+		"work_dir":         t.TempDir(),
+		"provider":         "codex",
+		"builtin_ancestor": "codex",
+		"molecule_id":      "run-T",
+	})
+	snapshot := []session.Info{h.info, terminal}
+
+	h.cr.emitDueComputeFacts(context.Background(), snapshot, true)
+	bootFacts, _, err := usage.ReadFacts(h.sinkPath)
+	if err != nil {
+		t.Fatalf("ReadFacts (boot pass): %v", err)
+	}
+	if got := kindCount(bootFacts, usage.KindModel); got != 0 {
+		t.Fatalf("boot pass model facts = %d, want 0: the live lane must not run on the fleet-wide boot reconcile; facts: %+v", got, bootFacts)
+	}
+	if got := kindCount(bootFacts, usage.KindCompute); got != 1 {
+		t.Fatalf("boot pass compute facts = %d, want 1: the terminal lane's cost profile is unchanged and must keep running on boot", got)
+	}
+	if got := h.cursor(t); got != "" {
+		t.Fatalf("boot pass advanced the live session's invocation cursor to %q, want unset (it must not be swept at all)", got)
+	}
+	if memo := h.memo(); memo.path != "" || !memo.nextSweepAt.IsZero() {
+		t.Fatalf("boot pass touched the live session's sweep memo: %+v", memo)
+	}
+
+	// The very next steady-state tick picks the live session up: boot DEFERS the
+	// lane, it does not disable it.
+	h.cr.emitDueComputeFacts(context.Background(), snapshot, false)
+	steadyFacts, _, err := usage.ReadFacts(h.sinkPath)
+	if err != nil {
+		t.Fatalf("ReadFacts (steady tick): %v", err)
+	}
+	if got := kindCount(steadyFacts, usage.KindModel); got != 2 {
+		t.Fatalf("steady tick model facts = %d, want 2 (the deferred live sweep runs on the first non-boot tick): %+v", got, steadyFacts)
+	}
+}
+
+// TestEmitDueComputeFactsBacksOffUnresolvedLiveSweepDiscovery pins the miss
+// memoization. A live session is a candidate on every tick, so an awake session
+// whose transcript cannot be discovered yet would otherwise re-run the bounded
+// rollout scan forever, once per tick, for its entire life. A TRANSIENT miss must
+// be memoized as a backoff: re-attempted on the sweep floor rather than on every
+// tick, and never dropped.
+func TestEmitDueComputeFactsBacksOffUnresolvedLiveSweepDiscovery(t *testing.T) {
+	workDir := t.TempDir()
+	codexRoot := t.TempDir()
+	start := liveSweepStart()
+	h := newLiveSweepHarness(t, codexRoot, liveCodexSessionMeta(start, workDir, codexSweepSessionKey))
+
+	// Tick 1: the keyed rollout is not on disk yet. That miss is transient — the
+	// file may simply not be flushed — so it must not settle.
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 0 {
+		t.Fatalf("tick 1 model facts = %d, want 0 (no transcript on disk yet)", got)
+	}
+	memo := h.memo()
+	if memo.settledMiss {
+		t.Fatal("a keyed rollout that is merely not flushed yet must not be memoized as a settled miss")
+	}
+	if memo.nextSweepAt.IsZero() {
+		t.Fatal("an unresolved discovery must still arm the sweep floor, or discovery re-runs on every tick forever")
+	}
+
+	// The transcript lands immediately after. Tick 2 is inside the backoff, so
+	// discovery is NOT re-attempted.
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, codexSweepSessionKey, [][3]int{
+		{150, 100, 50},
+		{450, 200, 100},
+	})
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 0 {
+		t.Fatalf("tick 2 model facts = %d, want 0: a memoized miss must not re-run discovery inside its backoff", got)
+	}
+
+	// Once the floor elapses discovery is retried and the pending usage is
+	// recovered.
+	h.expireSweepThrottle()
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 2 {
+		t.Fatalf("tick 3 model facts = %d, want 2 (discovery retried once the backoff elapsed)", got)
+	}
+}
+
+// TestEmitDueComputeFactsStopsRetryingSettledLiveSweepMiss pins the other half of
+// the miss memoization: a DEFINITIVE miss is not retried at all. A keyless codex
+// session whose bounded (work_dir, wake-window) scan comes up empty on a CLEAN
+// scan has nothing to find — the outcome is ambiguity, an out-of-window filename,
+// or a TZ shift, none of which a retry resolves — so the live lane records the
+// verdict once and stops scanning for that awake epoch.
+func TestEmitDueComputeFactsStopsRetryingSettledLiveSweepMiss(t *testing.T) {
+	workDir := t.TempDir()
+	codexRoot := t.TempDir()
+	start := liveSweepStart()
+	// No session_key: discovery takes the keyless workdir+window fallback.
+	h := newLiveSweepHarness(t, codexRoot, liveCodexSessionMeta(start, workDir, ""))
+
+	h.tick()
+	memo := h.memo()
+	if !memo.settledMiss {
+		t.Fatalf("a clean keyless scan that found nothing is definitive and must settle: memo=%+v", memo)
+	}
+
+	// Even with the floor cleared AND a matching rollout now on disk, the settled
+	// miss is never re-attempted. Nothing is lost: the interval's usage is still
+	// recovered by the terminal sweep when the session finally closes, and a re-wake
+	// starts a fresh epoch that discovers again.
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, "019e7777-cccc-7000-8000-00000000000c", [][3]int{
+		{150, 100, 50},
+	})
+	h.expireSweepThrottle()
+	h.tick()
+	if got := rawSinkModelFactCount(t, h.sinkPath); got != 0 {
+		t.Fatalf("model facts = %d, want 0: a settled discovery miss must never re-run discovery", got)
+	}
+	if got := h.cursor(t); got != "" {
+		t.Fatalf("invocation_usage_cursor = %q, want unset (nothing was swept)", got)
 	}
 }
 
@@ -566,7 +838,7 @@ func TestEmitDueComputeFactsAlsoSweepsModelUsage(t *testing.T) {
 	cr := &CityRuntime{cs: cs, cfg: cfg, sp: runtime.NewFake(), cityName: "demo", cityPath: cityPath, stderr: io.Discard}
 
 	info := session.Info{ID: b.ID, MetadataState: "asleep", AwakeStartedAt: start.Format(time.RFC3339)}
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info}, false)
 
 	facts, warnings, err := usage.ReadFacts(sinkPath)
 	if err != nil {
@@ -619,7 +891,7 @@ func TestEmitDueComputeFactsAlsoSweepsModelUsage(t *testing.T) {
 	// A second tick must add no new facts: the cursor blocks the model re-record
 	// and the emit marker blocks the compute re-emit; ReadFacts also dedups any
 	// replay by IdempotencyKey.
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info}, false)
 	facts2, _, err := usage.ReadFacts(sinkPath)
 	if err != nil {
 		t.Fatalf("ReadFacts (second tick): %v", err)
@@ -676,7 +948,7 @@ func TestEmitDueComputeFactsRetriesUnsettledModelSweep(t *testing.T) {
 	// Tick 1: the rollout is not on disk yet → the sweep misses (transient). The
 	// compute fact still records, but neither the compute marker nor the sweep
 	// marker is stamped, so the interval stays open for retry.
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info}, false)
 	facts1, _, err := usage.ReadFacts(sinkPath)
 	if err != nil {
 		t.Fatalf("ReadFacts (tick 1): %v", err)
@@ -706,7 +978,7 @@ func TestEmitDueComputeFactsRetriesUnsettledModelSweep(t *testing.T) {
 
 	// Tick 2: the interval is still a candidate → the sweep retries, discovers the
 	// rollout, and recovers the model facts. No duplicate compute fact.
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info}, false)
 	facts2, _, err := usage.ReadFacts(sinkPath)
 	if err != nil {
 		t.Fatalf("ReadFacts (tick 2): %v", err)
@@ -731,7 +1003,7 @@ func TestEmitDueComputeFactsRetriesUnsettledModelSweep(t *testing.T) {
 
 	// Tick 3: both markers set → no re-Get work, no new facts.
 	info.UsageComputeEmittedAt = awake // reflects the committed interval on the snapshot
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info}, false)
 	facts3, _, err := usage.ReadFacts(sinkPath)
 	if err != nil {
 		t.Fatalf("ReadFacts (tick 3): %v", err)
@@ -741,14 +1013,17 @@ func TestEmitDueComputeFactsRetriesUnsettledModelSweep(t *testing.T) {
 	}
 }
 
-// writeKeylessCodexRolloutForSweep fabricates a codex rollout at the local-date
-// path the codex CLI would use for `at` (session_meta cwd=workDir, a turn_context
+// writeCodexRolloutForSweepAt fabricates a codex rollout at the local-date path
+// the codex CLI would use for `at` (session_meta cwd=workDir, a turn_context
 // model, one token_count per {total, lastInput, lastOutput}). Unlike
-// writeCodexRolloutForSweep — which hardcodes 2026-06-15 and is reachable by the
-// TZ-tolerant keyed lookup — it derives the day dir and filename timestamp from
-// `at` in time.Local, so the keyless workdir+window fallback (which parses rollout
-// filenames in time.Local) resolves it on any host timezone.
-func writeKeylessCodexRolloutForSweep(t *testing.T, root string, at time.Time, workDir, sessionID string, tokenCounts [][3]int) {
+// writeCodexRolloutForSweep — which hardcodes 2026-06-15, fine only for a fixture
+// whose slept_at also pins the discovery window to that date — it derives BOTH the
+// day dir and the filename timestamp from `at` in time.Local, matching how codex
+// names rollouts and how discovery parses them. Any test whose discovery window
+// runs to the wall clock (a live session has no slept_at) must use this: a
+// hardcoded day falls out of the bounded lookback as real time advances, so the
+// fixture would silently stop being discoverable.
+func writeCodexRolloutForSweepAt(t *testing.T, root string, at time.Time, workDir, sessionID string, tokenCounts [][3]int) {
 	t.Helper()
 	local := at.In(time.Local)
 	dayDir := filepath.Join(root, local.Format("2006"), local.Format("01"), local.Format("02"))
@@ -794,7 +1069,7 @@ func TestEmitDueComputeFactsSweepsKeylessCodexViaWorkdir(t *testing.T) {
 	slept := start.Add(90 * time.Second)
 	// A keyless codex rollout in this wisp's unique worktree — no session_key keys
 	// it; only the cwd + interval window resolve it.
-	writeKeylessCodexRolloutForSweep(t, codexRoot, start, workDir, "019e7777-cccc-7000-8000-000000000009", [][3]int{
+	writeCodexRolloutForSweepAt(t, codexRoot, start, workDir, "019e7777-cccc-7000-8000-000000000009", [][3]int{
 		{150, 100, 50},
 		{450, 200, 100},
 	})
@@ -827,7 +1102,7 @@ func TestEmitDueComputeFactsSweepsKeylessCodexViaWorkdir(t *testing.T) {
 	cr := &CityRuntime{cs: cs, cfg: cfg, sp: runtime.NewFake(), cityName: "demo", cityPath: cityPath, stderr: io.Discard}
 	info := session.Info{ID: b.ID, MetadataState: "asleep", AwakeStartedAt: start.Format(time.RFC3339)}
 
-	cr.emitDueComputeFacts(context.Background(), []session.Info{info})
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info}, false)
 
 	facts, warnings, err := usage.ReadFacts(sinkPath)
 	if err != nil {

--- a/internal/worker/invocation_telemetry.go
+++ b/internal/worker/invocation_telemetry.go
@@ -517,6 +517,60 @@ func (f *Factory) SweepSessionModelUsage(ctx context.Context, id string, meta ma
 			slog.String("session_id", id), slog.String("provider", family))
 		return 0, false, nil
 	}
+	return f.sweepResolvedTranscript(ctx, family, id, meta, path, now)
+}
+
+// DiscoverSweepTranscript resolves the transcript path for a model-usage
+// sweep without reading it. It preserves the same bounded keyed and keyless
+// discovery rules as SweepSessionModelUsage so callers can safely memoize a
+// stable rollout path across repeated incremental sweeps. A keyless Codex scan
+// clouded by an I/O fault returns no path and is retried later rather than
+// trusting a potentially ambiguous result.
+func (f *Factory) DiscoverSweepTranscript(id string, meta map[string]string, now time.Time) string {
+	id = strings.TrimSpace(id)
+	if f == nil || id == "" || meta == nil {
+		return ""
+	}
+	family := invocationUsageFamily(sessionpkg.ProviderFamilyFromMetadata(meta, ""))
+	if _, ok := invocationUsageSpecs[family]; !ok {
+		return ""
+	}
+	path, scanClean := f.discoverSweepTranscript(family, id, meta, now)
+	if family == "codex" && strings.TrimSpace(meta["session_key"]) == "" && !scanClean {
+		return ""
+	}
+	return path
+}
+
+// SweepSessionModelUsageAtPath performs the same cursor-guarded extraction,
+// fact emission, metrics, and cursor persistence as SweepSessionModelUsage,
+// using an already-resolved transcript path instead of repeating discovery.
+// An empty path is a transient miss so callers can retry on a later tick.
+func (f *Factory) SweepSessionModelUsageAtPath(ctx context.Context, id string, meta map[string]string, path string, now time.Time) (emitted int, settled bool, err error) {
+	id = strings.TrimSpace(id)
+	if f == nil || id == "" || meta == nil {
+		return 0, true, nil
+	}
+	sink := f.usageSink
+	if sink == nil || sink == usage.Discard {
+		return 0, true, nil
+	}
+	family := invocationUsageFamily(sessionpkg.ProviderFamilyFromMetadata(meta, ""))
+	if _, ok := invocationUsageSpecs[family]; !ok {
+		slog.Debug("model-usage sweep (at path): unregistered provider family; skipping",
+			slog.String("session_id", id), slog.String("provider", strings.TrimSpace(meta["provider"])))
+		return 0, true, nil
+	}
+	if strings.TrimSpace(path) == "" {
+		return 0, false, nil
+	}
+	return f.sweepResolvedTranscript(ctx, family, id, meta, path, now)
+}
+
+// sweepResolvedTranscript owns the post-discovery model-usage sweep shared by
+// the discovery-driven and already-resolved entry points.
+func (f *Factory) sweepResolvedTranscript(ctx context.Context, family, id string, meta map[string]string, path string, now time.Time) (emitted int, settled bool, err error) {
+	sink := f.usageSink
 	usages, extractErr := f.Adapter().InvocationUsage(family, path)
 	if extractErr != nil {
 		// Transient: a torn mid-write tail can fail the parse; retry on a later tick.

--- a/internal/worker/invocation_telemetry.go
+++ b/internal/worker/invocation_telemetry.go
@@ -523,23 +523,34 @@ func (f *Factory) SweepSessionModelUsage(ctx context.Context, id string, meta ma
 // DiscoverSweepTranscript resolves the transcript path for a model-usage
 // sweep without reading it. It preserves the same bounded keyed and keyless
 // discovery rules as SweepSessionModelUsage so callers can safely memoize a
-// stable rollout path across repeated incremental sweeps. A keyless Codex scan
-// clouded by an I/O fault returns no path and is retried later rather than
-// trusting a potentially ambiguous result.
-func (f *Factory) DiscoverSweepTranscript(id string, meta map[string]string, now time.Time) string {
+// stable rollout path across repeated incremental sweeps.
+//
+// settled classifies a miss with the same meaning SweepSessionModelUsage gives
+// it, so a caller that memoizes discovery can distinguish the two kinds: true
+// means there is definitively nothing to find (an unregistered provider family,
+// or a keyless codex session whose bounded workdir+window fallback came up empty
+// on a CLEAN scan) and re-running discovery is pure waste; false means the miss
+// is transient (a keyed rollout not flushed yet, or a keyless scan clouded by an
+// I/O fault, which leaves both an empty result and a lone hit non-definitive) and
+// a later attempt may resolve it. A found path is always settled.
+func (f *Factory) DiscoverSweepTranscript(id string, meta map[string]string, now time.Time) (path string, settled bool) {
 	id = strings.TrimSpace(id)
 	if f == nil || id == "" || meta == nil {
-		return ""
+		return "", true
 	}
 	family := invocationUsageFamily(sessionpkg.ProviderFamilyFromMetadata(meta, ""))
 	if _, ok := invocationUsageSpecs[family]; !ok {
-		return ""
+		return "", true
 	}
 	path, scanClean := f.discoverSweepTranscript(family, id, meta, now)
-	if family == "codex" && strings.TrimSpace(meta["session_key"]) == "" && !scanClean {
-		return ""
+	keylessCodex := family == "codex" && strings.TrimSpace(meta["session_key"]) == ""
+	if keylessCodex && !scanClean {
+		return "", false
 	}
-	return path
+	if path == "" {
+		return "", keylessCodex
+	}
+	return path, true
 }
 
 // SweepSessionModelUsageAtPath performs the same cursor-guarded extraction,


### PR DESCRIPTION
## Problem

Model-usage facts are minted **only when a session retires**. The single
model-fact emitter on the controller tick lives in
`emitDueComputeFacts` (`cmd/gc/usage_compute.go`) and is gated on
`isComputeTerminalState` — `asleep` / `drained` / `archived` / `suspended` /
`quarantined`. A session that is still awake is never even `Get`, because
`computeFactGetCandidate` is the only pre-Get filter and it requires a
terminal state.

The user-visible effect: **"model calls today" undercounts every session
that is still running.** A long-lived agent burns tokens for hours and
contributes nothing to the day's totals until it finally closes, and an
agent awake across a day boundary bills its entire interval to the wrong
day when it does. On a fleet where pool-routed agents self-drive for long
stretches, the live portion of spend is invisible.

## Fix

The reconcile tick now sweeps awake sessions incrementally, beside the
existing terminal lane:

- `isLiveModelSweepState` / `liveModelSweepCandidate` select awake rows
  from the reconcile snapshot. They are deliberately **disjoint** from
  `isComputeTerminalState` (asserted in the tests), so every session is
  handled by exactly one lane.
- `emitDueComputeFacts` routes each loaded bead through one
  `processSessionBead` step: awake beads take the live model-usage sweep,
  terminal beads take the **unchanged** compute-fact + terminal-sweep path.
  The snapshot loop's only behavioral change is that a live candidate now
  also earns a `Get`.
- `sweepLiveSessionModelUsage` records the interval's model facts **without
  closing the interval**: neither `usage_compute_emitted_at` nor
  `usage_model_swept_at` is stamped, so the real end-of-interval compute
  fact and terminal sweep still happen later exactly as before. Repeat
  ticks are made idempotent by the **already-persisted invocation cursor**,
  not by a marker — which is the correct mechanism here, since a live
  session is legitimately a candidate on every single tick.

Because a live session is re-examined every tick, transcript discovery
would otherwise repeat its bounded rollout scan indefinitely. Two additive
`internal/worker` entry points split discovery from extraction:

- `Factory.DiscoverSweepTranscript` — resolves the path under the same
  bounded keyed/keyless rules as `SweepSessionModelUsage`, without reading.
  A keyless Codex scan clouded by an I/O fault returns no path so the tick
  retries rather than trusting an ambiguous result.
- `Factory.SweepSessionModelUsageAtPath` — the same cursor-guarded
  extraction, fact emission, OTel metrics, and cursor persistence, against
  an already-resolved path.

Both delegate to a new shared `sweepResolvedTranscript`, which is
`SweepSessionModelUsage`'s own post-discovery body lifted out verbatim — so
the cursor, metrics, and settle semantics cannot drift between entry
points. `CityRuntime.liveSweepTranscriptPaths` then memoizes the resolved
path per `(session id, awake epoch, provider session key)`. A new awake
epoch or a replacement conversation resolves its own rollout instead of
reusing a stale path.

## What was deliberately left out

This change was split out of a larger internal commit that also carried a
storage refactor. **The routed-enumeration block is intentionally not
here**, along with its `internal/classdb/sessions` import and the
`processed map[string]bool` that existed only to de-duplicate against it.

That block re-listed the whole sessions-class store each tick
(`session.ListAllSessionBeads` with `IncludeClosed: true`, `TierBoth`,
`AllowScan: true`) to reach rows the open snapshot cannot supply. It only
does anything on a city that has routed `[beads.classes.sessions]` to its
own store — where retired sessions are *closed* and therefore vanish from
the open reconcile snapshot. On `main`'s single-store topology it is dead
weight: an unconditional full-store scan added to a synchronous reconcile
tick, guarded by a routing check that is always false. It also solves a
different problem (recently-*closed* rows going unaccounted) than the one
this PR fixes (*live* rows going unaccounted).

Everything carried here is single-store safe and reaches live sessions
through the snapshot the tick already has, adding no new store enumeration.

## Tests

- **`TestEmitDueComputeFactsSweepsLiveSessionModelUsage`** (new) — the
  regression, on plain single-store `main` using the established
  `writeCodexRolloutForSweep` / `usage.NewLocalSink` harness. An awake
  codex session present in the open snapshot:
  - **tick 1** bills both transcript invocations (2 model facts, **0**
    compute facts), advances the cursor to `total:450`, and leaves **both**
    interval markers unset so the terminal lane is not pre-empted;
  - **tick 2**, with no transcript activity, appends nothing;
  - **tick 3**, after one invocation is appended, bills only that delta.

  The idempotency assertions deliberately count **raw sink lines** via a
  new `rawSinkKindCount` helper rather than `usage.ReadFacts`, because
  `ReadFacts` collapses replays by `IdempotencyKey` at read time and would
  pass even if a tick re-recorded work the cursor should have skipped.

- **`TestLiveModelSweepCandidate`** (new) — pins the live/terminal split,
  including the assertion that no state is ever both.

- `writeCodexRolloutForSweep` now takes its session key from a shared
  `codexSweepSessionKey` const instead of a parameter. Every keyed sweep
  scenario passes the same value, and adding a third call site makes
  `unparam` (correctly) flag the parameter as constant.

**Red-then-green evidence.** With the production change reverted to
`main`'s terminal-only gate (`computeFactGetCandidate` alone, live beads
not routed to the sweep) and the new test applied:

```
--- FAIL: TestEmitDueComputeFactsSweepsLiveSessionModelUsage (0.00s)
    usage_compute_test.go:436: tick 1 model facts = 0, want 2 (a live session's invocations must bill before it closes); facts: []
FAIL
FAIL	github.com/gastownhall/gascity/cmd/gc	2.049s
```

With the fix restored, it passes.

**Verification** (`CGO_ENABLED=0`, linux/amd64):

- `go build ./...` — clean
- `go vet ./cmd/gc/ ./internal/worker/` — clean
- `gofmt -l` on the four touched files — clean
- `go test ./internal/worker/` — ok (84.6s)
- `golangci-lint run ./cmd/gc/ ./internal/worker/` — 0 issues
- `go test ./internal/worker/` — ok
- `go test ./cmd/gc/ -run 'Usage|ComputeFacts|ModelSweep' -count=1` — ok,
  12 tests including both new ones

An untargeted full-package `go test ./cmd/gc/` does not pass in this dev
environment: it times out at 600s inside the order-dispatch / managed-Dolt
path (`cmd/gc/order_store.go`, `cmd/gc/order_dispatch.go`), which is
unrelated to the usage lane and untouched here. The CI `cmd/gc process`
shards are the authoritative check for that package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
