### PR TITLE
fix(cmd/gc): lint no longer flags the max=1 named-session singleton flavor as a pool conflict (#4184)

### DIFF
--- a/cmd/gc/cmd_lint.go
+++ b/cmd/gc/cmd_lint.go
@@ -224,11 +224,30 @@ func agentHasPoolControls(agentCfg config.Agent) bool {
 	if agentPoolExplicitlyDisabled(agentCfg) {
 		return false
 	}
+	if agentIsNamedSessionSingleton(agentCfg) {
+		return false
+	}
 	return agentCfg.MinActiveSessions != nil ||
 		agentCfg.MaxActiveSessions != nil ||
 		strings.TrimSpace(agentCfg.ScaleCheck) != "" ||
 		strings.TrimSpace(agentCfg.Namepool) != "" ||
 		len(agentCfg.NamepoolNames) > 0
+}
+
+// agentIsNamedSessionSingleton reports whether agentCfg is the named-session
+// flavor of max_active_sessions=1 documented by
+// (*config.Agent).SupportsInstanceExpansion: max=1 with no
+// min_active_sessions, no scale_check, and no namepool is a singleton with a
+// stable canonical identity, not a pool — a [[named_session]] targeting it is
+// the supported configuration, not a conflict. Pool flavors of max=1 (an
+// explicit MinActiveSessions or a ScaleCheck) keep pool semantics and stay
+// flagged.
+func agentIsNamedSessionSingleton(agentCfg config.Agent) bool {
+	return agentCfg.MaxActiveSessions != nil && *agentCfg.MaxActiveSessions == 1 &&
+		agentCfg.MinActiveSessions == nil &&
+		strings.TrimSpace(agentCfg.ScaleCheck) == "" &&
+		strings.TrimSpace(agentCfg.Namepool) == "" &&
+		len(agentCfg.NamepoolNames) == 0
 }
 
 // agentPoolExplicitlyDisabled reports whether agentCfg uses the documented

--- a/cmd/gc/cmd_lint_test.go
+++ b/cmd/gc/cmd_lint_test.go
@@ -224,6 +224,75 @@ mode = "on_demand"
 	}
 }
 
+// TestLintAllowsNamedSessionSingletonAgent is a regression guard for the
+// max_active_sessions=1 named-session flavor documented by
+// (*config.Agent).SupportsInstanceExpansion: max=1 with no min/scale_check/
+// namepool is a singleton with a stable canonical identity, not a pool.
+// A [[named_session]] targeting that shape is the supported way to declare a
+// persistent seat and must lint clean.
+func TestLintAllowsNamedSessionSingletonAgent(t *testing.T) {
+	packDir := t.TempDir()
+	writeLintFile(t, filepath.Join(packDir, "pack.toml"), `[pack]
+name = "singleton-named"
+version = "0.1.0"
+schema = 2
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.template.md"
+max_active_sessions = 1
+
+[[named_session]]
+template = "worker"
+scope = "rig"
+mode = "on_demand"
+`)
+	writeLintFile(t, filepath.Join(packDir, "prompts", "worker.template.md"), "hello {{.AgentName}}\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"lint", packDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc lint failed on a named-session singleton agent, want pass\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "pool-controlled agent") {
+		t.Fatalf("stderr wrongly flagged the max=1 named-session flavor as pool-controlled:\n%s", stderr.String())
+	}
+}
+
+// TestLintStillRejectsSingletonPoolWithMin pins the boundary of the max=1
+// exemption: an explicit min_active_sessions keeps pool semantics
+// (SupportsInstanceExpansion's pool flavor), so a named_session targeting
+// min=1/max=1 remains a conflict.
+func TestLintStillRejectsSingletonPoolWithMin(t *testing.T) {
+	packDir := t.TempDir()
+	writeLintFile(t, filepath.Join(packDir, "pack.toml"), `[pack]
+name = "singleton-pool-named"
+version = "0.1.0"
+schema = 2
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.template.md"
+min_active_sessions = 1
+max_active_sessions = 1
+
+[[named_session]]
+template = "worker"
+scope = "rig"
+mode = "on_demand"
+`)
+	writeLintFile(t, filepath.Join(packDir, "prompts", "worker.template.md"), "hello {{.AgentName}}\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"lint", packDir}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("gc lint succeeded, want pool conflict for min=1/max=1\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `named_session "worker" targets pool-controlled agent "worker"`) {
+		t.Fatalf("stderr missing named-session pool conflict:\n%s", stderr.String())
+	}
+}
+
 func TestLintPromptDiscoverySkipsIgnoredDirs(t *testing.T) {
 	packDir := t.TempDir()
 	writeLintPack(t, packDir, "skip-dirs", "worker", "prompts/worker.template.md")


### PR DESCRIPTION
## Problem

`gc lint`'s named-session pool-conflict rule flags the **documented named-session singleton shape** — `max_active_sessions = 1` with no `min_active_sessions`, no `scale_check`, no namepool — whenever a `[[named_session]]` targets it:

```
pack.toml: named_session "X" targets pool-controlled agent "X"; remove pool settings from named-session templates or remove [[named_session]] for pool agents
```

This is the sibling of the `min=0+max=0` case #4216 fixed: `agentHasPoolControls` still treats **any** non-nil `MaxActiveSessions` as pool evidence.

But `internal/config`'s `SupportsInstanceExpansion` already documents and encodes the discrimination the linter is missing — `max_active_sessions=1` has two flavors:

- **Pool agents** (`MinActiveSessions` or `ScaleCheck` set) keep pool semantics;
- **Named-session agents** (max=1 with a `[[named_session]]` entry, no Min/ScaleCheck) collapse to the canonical bare identity, because "a phantom '-1' suffix breaks tools that resolve by qualified name."

So the flagged shape is a supported, intended configuration. The rule's own regression test (`TestLintRejectsNamedSessionBackedByPoolControlledAgent`) builds `min=0/max=3` — a genuine multi-session pool; max=1 was never the target.

Concretely, before this change `gc lint` is **red on the canonical gastown pack itself** — 5 findings (mayor, deacon, boot, witness, refinery), all this false positive.

## Fix

A second exemption in `agentHasPoolControls`, following the #4216 helper pattern: `agentIsNamedSessionSingleton` mirrors `SupportsInstanceExpansion`'s named-session flavor (max=1, Min nil, no ScaleCheck, no namepool). Pool flavors of max=1 stay flagged.

## Tests

- `TestLintAllowsNamedSessionSingletonAgent` — bare `max_active_sessions = 1` + `[[named_session]]` lints clean.
- `TestLintStillRejectsSingletonPoolWithMin` — pins the boundary: `min=1/max=1` (explicit Min ⇒ pool flavor) remains a conflict.
- Existing `TestLintRejectsNamedSessionBackedByPoolControlledAgent` (min=0/max=3) and `TestLintAllowsNamedSessionOnExplicitlyDisabledPoolAgent` (#4216) unchanged and passing.

Live verification against real packs: two downstream packs with named-session singletons went from exit 1 to clean, and the canonical gastown pack's 5 findings went to 0, with no change to packs that were already clean.

Refs #4184 (problem 2's sibling; that issue also covers the misleading prescription text, which this PR does not touch) and #4216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2CiS9uoTPRuDWYDU2hfZE