### PR TITLE
Fix formula-attach execution routing metadata

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1797,6 +1797,13 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			} else {
 				w("  This assigns the bead to \"" + a.QualifiedName() + "\".")
 			}
+			// A formula attach routes more than the work bead: the cooked
+			// wisp/workflow root is routed to the same agent. Without this
+			// line the preview shows only the plain-routing effect, so a
+			// reader cannot anticipate the second routed bead.
+			if opts.OnFormula != "" || (!opts.NoFormula && a.EffectiveDefaultSlingFormula() != "") {
+				w("  A wisp/workflow root is also cooked and routed to the agent.")
+			}
 		}
 		w("")
 	}

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/graphroute"
+	"github.com/gastownhall/gascity/internal/graphv2"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
@@ -1797,11 +1798,15 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			} else {
 				w("  This assigns the bead to \"" + a.QualifiedName() + "\".")
 			}
-			// A formula attach routes more than the work bead: the cooked
-			// wisp/workflow root is routed to the same agent. Without this
-			// line the preview shows only the plain-routing effect, so a
-			// reader cannot anticipate the second routed bead.
-			if opts.OnFormula != "" || (!opts.NoFormula && a.EffectiveDefaultSlingFormula() != "") {
+			// A graph.v2 formula attach routes more than the work bead: the
+			// cooked workflow root is also routed to the same agent. Without
+			// this line the preview shows only the plain-routing effect, so a
+			// reader cannot anticipate the second routed bead. Legacy (non-
+			// graph.v2) attach deliberately leaves the wisp root unrouted --
+			// see the design-intent comment on the finalize() call in
+			// slingFormula (internal/sling/sling_core.go, citing #2848 and
+			// TestOnFormulaAttachesAndRoutes) -- so this must not fire there.
+			if dryRunFormulaAttachIsGraphV2(opts, deps, a) {
 				w("  A wisp/workflow root is also cooked and routed to the agent.")
 			}
 		}
@@ -1815,6 +1820,28 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 
 	w("No side effects executed (--dry-run).")
 	return 0
+}
+
+// dryRunFormulaAttachIsGraphV2 reports whether the formula this sling would
+// attach (an explicit --on, or the target's default_sling_formula) is a
+// graph.v2 formula. Resolution failures (unknown formula, parse error) report
+// false rather than surfacing an error here -- a dry-run preview must not
+// fail on a formula-name typo the live attach path will report clearly on
+// its own, and understating the preview is the safe direction: it never
+// claims a second routed bead that legacy attach will not create.
+func dryRunFormulaAttachIsGraphV2(opts slingOpts, deps slingDeps, a config.Agent) bool {
+	formulaName := opts.OnFormula
+	if formulaName == "" {
+		if opts.NoFormula {
+			return false
+		}
+		formulaName = a.EffectiveDefaultSlingFormula()
+	}
+	if formulaName == "" {
+		return false
+	}
+	isGraph, _, err := graphv2.IsGraphV2Formula(formulaName, sling.SlingFormulaSearchPaths(deps, a))
+	return err == nil && isGraph
 }
 
 // dryRunBatch prints a step-by-step preview of what gc sling would do for a

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
-	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/graphroute"
 	"github.com/gastownhall/gascity/internal/pgauth"
@@ -6420,7 +6419,6 @@ title = "Do work"
 }
 
 func TestDryRunOnFormulaGraphV2(t *testing.T) {
-	formulatest.EnableV2ForTest(t)
 	formulaDir := t.TempDir()
 	writeGraphV2FormulaForDryRunTest(t, formulaDir, "graph-work")
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -6384,6 +6384,9 @@ func TestDryRunOnFormula(t *testing.T) {
 	if !strings.Contains(out, "bd update 'BL-42' --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing route command: %s", out)
 	}
+	if !strings.Contains(out, "A wisp/workflow root is also cooked and routed to the agent.") {
+		t.Errorf("stdout missing wisp-root disclosure: %s", out)
+	}
 	if len(runner.calls) != 0 {
 		t.Errorf("got %d runner calls, want 0: %v", len(runner.calls), runner.calls)
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/graphroute"
 	"github.com/gastownhall/gascity/internal/pgauth"
@@ -6384,8 +6385,73 @@ func TestDryRunOnFormula(t *testing.T) {
 	if !strings.Contains(out, "bd update 'BL-42' --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing route command: %s", out)
 	}
+	// code-review (sharedTestFormulaDir) is version=1, not graph.v2: legacy
+	// attach deliberately leaves the wisp root unrouted (see the
+	// design-intent comment on the finalize() call in slingFormula,
+	// internal/sling/sling_core.go, citing #2848 and
+	// TestOnFormulaAttachesAndRoutes), so the preview must not claim a
+	// second routed bead here. See TestDryRunOnFormulaGraphV2 for the
+	// graph.v2 case where the line is expected.
+	if strings.Contains(out, "A wisp/workflow root is also cooked and routed to the agent.") {
+		t.Errorf("stdout has wisp-root disclosure for a legacy (non-graph.v2) formula attach: %s", out)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("got %d runner calls, want 0: %v", len(runner.calls), runner.calls)
+	}
+}
+
+// writeGraphV2FormulaForDryRunTest writes a minimal graph.v2-contract
+// formula file, mirroring internal/sling's writeNamedGraphV2ConvoyFormula
+// (unexported there, so duplicated here rather than reused across packages).
+func writeGraphV2FormulaForDryRunTest(t *testing.T, dir, name string) {
+	t.Helper()
+	content := fmt.Sprintf(`
+formula = %q
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`, name)
+	if err := os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDryRunOnFormulaGraphV2(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	formulaDir := t.TempDir()
+	writeGraphV2FormulaForDryRunTest(t, formulaDir, "graph-work")
+
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Daemon:        config.DaemonConfig{FormulaV2: boolPtr(true)},
+		FormulaLayers: config.FormulaLayers{City: []string{formulaDir}},
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	q := newFakeChildQuerier()
+	q.beadsByID["BL-42"] = beads.Bead{ID: "BL-42", Type: "task", Status: "open"}
+	q.childrenOf["BL-42"] = []beads.Bead{} // no molecule children
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
+	opts := testOpts(a, "BL-42")
+	opts.OnFormula = "graph-work"
+	opts.DryRun = true
+	code := doSling(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dry-run returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Attach formula:") {
+		t.Errorf("stdout missing attach section: %s", out)
+	}
 	if !strings.Contains(out, "A wisp/workflow root is also cooked and routed to the agent.") {
-		t.Errorf("stdout missing wisp-root disclosure: %s", out)
+		t.Errorf("stdout missing wisp-root disclosure for a graph.v2 formula attach: %s", out)
 	}
 	if len(runner.calls) != 0 {
 		t.Errorf("got %d runner calls, want 0: %v", len(runner.calls), runner.calls)

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -295,7 +295,10 @@ type attachmentDecision struct {
 // fail-closed idempotent state rather than clear it and risk minting a
 // duplicate attachment.
 func onFormulaNeedsAttachment(opts SlingOpts, querier BeadQuerier, deps SlingDeps) (attachmentDecision, error) {
-	if opts.OnFormula == "" {
+	// Both formula-backed routes reach the same attach path, so the
+	// routed-raw override has to apply to a target's default_sling_formula
+	// as well as an explicit --on.
+	if !usesFormulaBackedRoute(opts) {
 		return attachmentDecision{}, nil
 	}
 	hasMolecule, err := HasMoleculeChildren(querier, opts.BeadOrFormula, deps.Store)
@@ -519,7 +522,13 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 				if rollbackErr := rollbackGraphV2ReplacementLaunch(deps.Store, mResult.RootID, replacedSnapshot); rollbackErr != nil {
 					return wfResult, errors.Join(wfErr, rollbackErr)
 				}
+				return wfResult, wfErr
 			}
+			// The convoy-first branch deliberately passes an empty
+			// sourceBeadID (the source is tracked through the input convoy,
+			// not gc.source_bead_id), so doStartGraphWorkflow's own restamp
+			// never covers it. Stamp the work bead here instead.
+			restampWorkBeadRouting(deps, beadID, a, &wfResult)
 			return wfResult, wfErr
 		})
 		if lockedErr != nil {
@@ -722,6 +731,29 @@ func validateBuiltInRouteStoreReachable(deps SlingDeps, beadID string, a config.
 	}
 }
 
+// restampWorkBeadRouting stamps gc.routed_to on the work bead a graph workflow
+// was attached to. gc.routed_to on the WORK bead is what the claim path reads;
+// the cooked workflow root carries the graph-routing metadata instead, so an
+// attach that routes only the root leaves the work bead looking unrouted to
+// anything reading gc.routed_to directly. Failures are reported as metadata
+// errors rather than failing the launch: by this point the workflow is already
+// running, and unwinding it over a routing restamp would be worse than a
+// surfaced warning.
+func restampWorkBeadRouting(deps SlingDeps, beadID string, a config.Agent, result *SlingResult) {
+	beadID = strings.TrimSpace(beadID)
+	if beadID == "" || deps.Store == nil || result == nil {
+		return
+	}
+	target := strings.TrimSpace(agentutil.RoutedToIdentity(&a))
+	if target == "" {
+		return
+	}
+	if err := deps.Store.SetMetadata(beadID, beadmeta.RoutedToMetadataKey, target); err != nil {
+		result.MetadataErrors = append(result.MetadataErrors,
+			fmt.Sprintf("setting %s on %s: %v", beadmeta.RoutedToMetadataKey, beadID, err))
+	}
+}
+
 // doStartGraphWorkflow performs post-instantiation graph workflow setup.
 func doStartGraphWorkflow(rootID, sourceBeadID string, a config.Agent, method string, deps SlingDeps) (SlingResult, error) {
 	var result SlingResult
@@ -752,6 +784,7 @@ func doStartGraphWorkflow(rootID, sourceBeadID string, a config.Agent, method st
 		if err := deps.Store.SetMetadata(sourceBeadID, "workflow_id", rootID); err != nil {
 			return result, fmt.Errorf("setting workflow_id on %s: %w", sourceBeadID, err)
 		}
+		restampWorkBeadRouting(deps, sourceBeadID, a, &result)
 	}
 	telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), method, nil)
 	if deps.Notify != nil {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -195,10 +195,17 @@ func resolveIdempotentShortCircuit(opts SlingOpts, a config.Agent, deps SlingDep
 			// onto in-progress work), but say so explicitly: without this
 			// warning the CLI prints only the generic "already routed" message,
 			// giving no signal that the requested --on formula was never
-			// attached or that --force would override the skip.
+			// attached or that --force would override the skip. opts.OnFormula
+			// is empty when this was reached via the target's
+			// default_sling_formula rather than an explicit --on, so fall back
+			// to naming that instead of rendering an empty flag value.
+			skippedFormula := opts.OnFormula
+			if skippedFormula == "" {
+				skippedFormula = a.EffectiveDefaultSlingFormula()
+			}
 			result.BeadWarnings = append(result.BeadWarnings, fmt.Sprintf(
 				"bead %s is claimed by %s with no molecule attached; --on %s was skipped to avoid re-attaching onto in-progress work — rerun with --force to attach it anyway",
-				opts.BeadOrFormula, decision.Assignee, opts.OnFormula))
+				opts.BeadOrFormula, decision.Assignee, skippedFormula))
 		}
 	}
 	if !check.Idempotent {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -731,12 +731,19 @@ func validateBuiltInRouteStoreReachable(deps SlingDeps, beadID string, a config.
 	}
 }
 
-// restampWorkBeadRouting stamps gc.routed_to on the work bead a graph workflow
-// was attached to. gc.routed_to on the WORK bead is what the claim path reads;
-// the cooked workflow root carries the graph-routing metadata instead, so an
-// attach that routes only the root leaves the work bead looking unrouted to
-// anything reading gc.routed_to directly. Failures are reported as metadata
-// errors rather than failing the launch: by this point the workflow is already
+// restampWorkBeadRouting stamps gc.execution_routed_to on the work bead a
+// graph workflow was attached to. A graph.v2 work bead must not get the
+// claim-semantics gc.routed_to key once its workflow has started, because the
+// pool's tier-3 claim query and the drain engine's own dispatch are two
+// uncoordinated authorities -- neither checks the bead's Assignee/the other's
+// lock field, so stamping gc.routed_to there is a structural double-dispatch
+// hazard, not merely an observability fix. The existing ExecutionRoutedToKey
+// (gc.execution_routed_to) is already read by the graphroute resolver, convoy
+// dispatch, dashboard orders feed, and dispatch engine. Apply
+// NormalizePoolRouteTarget to the computed target so slot-suffixed pool
+// instances collapse to their base template name (the same pass every other
+// gc.routed_to writer applies). Failures are reported as metadata errors
+// rather than failing the launch: by this point the workflow is already
 // running, and unwinding it over a routing restamp would be worse than a
 // surfaced warning.
 func restampWorkBeadRouting(deps SlingDeps, beadID string, a config.Agent, result *SlingResult) {
@@ -744,13 +751,13 @@ func restampWorkBeadRouting(deps SlingDeps, beadID string, a config.Agent, resul
 	if beadID == "" || deps.Store == nil || result == nil {
 		return
 	}
-	target := strings.TrimSpace(agentutil.RoutedToIdentity(&a))
+	target := agentutil.NormalizePoolRouteTarget(deps.Cfg, strings.TrimSpace(agentutil.RoutedToIdentity(&a)))
 	if target == "" {
 		return
 	}
-	if err := deps.Store.SetMetadata(beadID, beadmeta.RoutedToMetadataKey, target); err != nil {
+	if err := deps.Store.SetMetadata(beadID, beadmeta.ExecutionRoutedToMetadataKey, target); err != nil {
 		result.MetadataErrors = append(result.MetadataErrors,
-			fmt.Sprintf("setting %s on %s: %v", beadmeta.RoutedToMetadataKey, beadID, err))
+			fmt.Sprintf("setting %s on %s: %v", beadmeta.ExecutionRoutedToMetadataKey, beadID, err))
 	}
 }
 

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	beadsexec "github.com/gastownhall/gascity/internal/beads/exec"
@@ -1415,6 +1416,93 @@ func TestDoSlingIdempotent(t *testing.T) {
 	}
 }
 
+// TestOnFormulaNeedsAttachmentAppliesToDefaultSlingFormula guards the
+// broadened usesFormulaBackedRoute check in onFormulaNeedsAttachment: a
+// target's configured default_sling_formula must reach the same
+// routed-raw-needs-attach decision as an explicit --on formula. Before this
+// guard covered both routes, a bead slung with no --on flag onto a target
+// with default_sling_formula set would be treated as a settled idempotent
+// no-op forever, even though it was only ever routed raw and never fanned
+// into a molecule.
+func TestOnFormulaNeedsAttachmentAppliesToDefaultSlingFormula(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:    "work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	a := config.Agent{Name: "mayor", DefaultSlingFormula: stringPtr("code-review")}
+	opts := SlingOpts{Target: a, BeadOrFormula: bead.ID}
+	deps := SlingDeps{Store: store}
+
+	decision, err := onFormulaNeedsAttachment(opts, store, deps)
+	if err != nil {
+		t.Fatalf("onFormulaNeedsAttachment error: %v", err)
+	}
+	if !decision.NeedsAttach {
+		t.Fatalf("decision = %+v, want NeedsAttach=true via target's default_sling_formula (no explicit --on)", decision)
+	}
+}
+
+// TestDoSlingSkippedForClaimWarningNamesDefaultFormula guards the
+// SkippedForClaim warning text reached via a target's default_sling_formula
+// (no explicit --on). The message interpolates opts.OnFormula, which is
+// empty on this path — before this is fixed it renders "--on  was skipped"
+// (double space, no formula named) instead of naming the default formula
+// that was actually skipped.
+func TestDoSlingSkippedForClaimWarningNamesDefaultFormula(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1), DefaultSlingFormula: stringPtr("code-review")}
+
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "convoy", Type: "convoy", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create(convoy): %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "test",
+		ParentID: convoy.ID,
+		Assignee: "mayor",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+
+	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = store
+	result, err := DoSling(testOpts(a, bead.ID), deps, store)
+	if err != nil {
+		t.Fatalf("DoSling error: %v", err)
+	}
+	if !result.Idempotent {
+		t.Fatalf("expected Idempotent=true (claimed by target, no molecule attached: skip, not fail), got %+v", result)
+	}
+	if len(runner.calls) != 0 {
+		t.Error("runner should not have been called")
+	}
+
+	var named bool
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "--on  was skipped") {
+			t.Fatalf("BeadWarnings contains %q: still renders the empty explicit --on flag instead of the target's default_sling_formula name", w)
+		}
+		if strings.Contains(w, "code-review") {
+			named = true
+		}
+	}
+	if !named {
+		t.Fatalf("BeadWarnings = %v, want a warning naming the skipped default formula %q", result.BeadWarnings, "code-review")
+	}
+}
+
 func TestCheckBatchBurnOutputsWarn(t *testing.T) {
 	store := beads.NewMemStoreFrom(0, []beads.Bead{
 		{ID: "BL-2", Type: "task", Status: "open"},
@@ -2512,11 +2600,63 @@ func TestSlingAttachGraphFormulaCreatesConvoyFirstRoot(t *testing.T) {
 	if len(members) != 1 || members[0].ID != source.ID {
 		t.Fatalf("members = %+v, want source %s", members, source.ID)
 	}
-	// The work bead's gc.routed_to is the single source of truth the pool
-	// claim path reads. A convoy-first graph.v2 attach must restamp it on
-	// the source bead, not only route the cooked workflow root.
-	if got := sourceAfter.Metadata[beadmeta.RoutedToMetadataKey]; got != "mayor" {
-		t.Fatalf("source gc.routed_to = %q, want mayor", got)
+	// restampWorkBeadRouting stamps ExecutionRoutedTo (gc.execution_routed_to),
+	// not the claim-semantics gc.routed_to. Verify the correct key is set
+	// and the claim key is NOT set.
+	if got := sourceAfter.Metadata[beadmeta.ExecutionRoutedToMetadataKey]; got != "mayor" {
+		t.Fatalf("source gc.execution_routed_to = %q, want mayor", got)
+	}
+	if got := sourceAfter.Metadata[beadmeta.RoutedToMetadataKey]; got != "" {
+		t.Fatalf("source gc.routed_to = %q, want empty (must not be set on graph.v2 work bead)", got)
+	}
+}
+
+// TestRestampWorkBeadRoutingCollapsesPoolInstanceResolvedViaResolveAgent
+// guards the actual production resolution path for a pool-instance target.
+// An agent obtained via agentutil.ResolveAgent -- as the real CLI/API
+// dispatch paths do -- never has PoolName set on the returned copy:
+// agentutil.DeepCopyAgent copies the base template's own (empty) PoolName
+// rather than pointing the synthesized instance back at its template. A
+// hand-constructed config.Agent{PoolName: "..."} literal masks this and
+// would pass even without the NormalizePoolRouteTarget collapse in
+// restampWorkBeadRouting, because RoutedToIdentity would already resolve
+// correctly from the (test-only) pre-set PoolName.
+func TestRestampWorkBeadRoutingCollapsesPoolInstanceResolvedViaResolveAgent(t *testing.T) {
+	cfg := &config.City{
+		Rigs:   []config.Rig{{Name: "myrig"}},
+		Agents: []config.Agent{{Name: "polecat", Dir: "myrig", MaxActiveSessions: intPtr(4)}},
+	}
+	target := "myrig/polecat-2"
+	a, ok := agentutil.ResolveAgent(cfg, target, agentutil.ResolveOpts{AllowPoolMembers: true})
+	if !ok {
+		t.Fatalf("ResolveAgent(%q) failed to resolve", target)
+	}
+	if a.PoolName != "" {
+		t.Fatalf("fixture premise broken: resolved pool instance already has PoolName=%q; if DeepCopyAgent now sets it, this test no longer exercises the collapse path it targets", a.PoolName)
+	}
+
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	deps := SlingDeps{Store: store, Cfg: cfg}
+	result := &SlingResult{}
+	restampWorkBeadRouting(deps, bead.ID, a, result)
+
+	if len(result.MetadataErrors) != 0 {
+		t.Fatalf("MetadataErrors = %v, want none", result.MetadataErrors)
+	}
+	after, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := after.Metadata[beadmeta.ExecutionRoutedToMetadataKey]; got != "myrig/polecat" {
+		t.Fatalf("gc.execution_routed_to = %q, want myrig/polecat (collapsed from slot-suffixed %s resolved via agentutil.ResolveAgent)", got, target)
+	}
+	if got := after.Metadata[beadmeta.RoutedToMetadataKey]; got != "" {
+		t.Fatalf("gc.routed_to = %q, want empty", got)
 	}
 }
 

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2512,6 +2512,12 @@ func TestSlingAttachGraphFormulaCreatesConvoyFirstRoot(t *testing.T) {
 	if len(members) != 1 || members[0].ID != source.ID {
 		t.Fatalf("members = %+v, want source %s", members, source.ID)
 	}
+	// The work bead's gc.routed_to is the single source of truth the pool
+	// claim path reads. A convoy-first graph.v2 attach must restamp it on
+	// the source bead, not only route the cooked workflow root.
+	if got := sourceAfter.Metadata[beadmeta.RoutedToMetadataKey]; got != "mayor" {
+		t.Fatalf("source gc.routed_to = %q, want mayor", got)
+	}
 }
 
 func TestSlingAttachGraphFormulaEmitsCurrentExecutionFacts(t *testing.T) {

--- a/release-gates/ga-mwrstg-sling-formula-attach-routing-fix-gate.md
+++ b/release-gates/ga-mwrstg-sling-formula-attach-routing-fix-gate.md
@@ -1,0 +1,42 @@
+# Release gate: sling formula-attach routing fix
+
+- **Deploy bead:** `ga-mwrstg`
+- **Build bead:** `ga-f43t9b`
+- **Review bead:** `ga-gr10vs`
+- **Reviewed source:** `13362a5c4b42a30ee8cdcd3f5e8632e1911f0126`
+- **Base checked:** `origin/main` at `ad4d0ab4a9e14f57faed3eaa20a658ef743e1c09`
+- **Isolated gate branch:** `deploy/ga-mwrstg-gate`
+**Verdict:** **PASS**
+
+`docs/PROJECT_MANIFEST.md` is absent from both the reviewed source and current
+`origin/main`, so there are no additional repository-local release criteria to
+apply beyond the seven deployer criteria below.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-gr10vs` records `REVIEWER VERDICT: PASS` for the feature at `23f6f1af7`, with all six acceptance items checked directly. The post-review gate repair at `13362a5c4` only removes the newly introduced legacy `formulatest` coupling; the deploy bead records that SHA as the repaired authoritative source. |
+| 2 | Acceptance criteria met | PASS | Direct inspection confirms formula attachment writes `beadmeta.ExecutionRoutedToMetadataKey` after resolving and normalizing pool routes, preserves the default-formula idempotent warning, limits workflow-root dry-run disclosure to formulas v2, and leaves `gc.routed_to` unset on the source bead. Focused tests: `go test -json -count=1 ./internal/sling` = 232 PASS, 0 FAIL, 0 SKIP; `GC_FAST_UNIT=0 go test -json -count=1 ./cmd/gc -run 'TestDryRun\|Sling'` = 226 PASS, 0 FAIL, 0 SKIP. |
+| 3 | Tests pass | PASS | Documented CI-equivalent coverage used `make test-local-full-parallel` with the pinned `bd` v1.1.0 release (`8e4e59d39`). Gate accounting after environment-corrected reruns: 38 jobs PASS, 0 feature FAIL, 2 justified SKIP. The two skipped tmux jobs use exact-key `list-keys` syntax that returns empty under host tmux 3.7b; the exact three-test comparison produces the same two failures on this head and current `origin/main`, while the hidden-client test passes. This is safe for a change limited to `cmd/gc/cmd_sling*` and `internal/sling/*`. Five corrected REST shards then passed with the real platform home and an isolated home only for the pinned `bd` process (90 top-level tests, 0 FAIL). The regression guard `GC_FAST_UNIT=0 go test -json -count=1 ./internal/testenv -run '^TestLegacyFormulaV2MechanismFrozen$'` = 1 PASS, 0 FAIL, 0 SKIP. |
+| 4 | No high-severity review findings open | PASS | The review records zero unresolved HIGH findings, and no new high-severity finding was identified during gate inspection. |
+| 5 | Final branch is clean | PASS | The isolated branch was clean at the reviewed source before this checklist was added. The checklist is the only gate-owned file and will be committed before push; the post-commit cleanliness check is required below. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first and refreshed after `origin/main` advanced. `git merge-base origin/main 13362a5c4` is `a585e07a9`; `git merge-tree --write-tree origin/main 13362a5c4` returned 0 against `ad4d0ab4a` and produced tree `3c52e0a15dc6dadb2d4df3cd47b1702ca8def514`. No bounded self-rebase was needed. The already-merged pre-flight found no base-repository commit or PR for the reviewed source. |
+| 7 | Single feature theme | PASS | All four commits and all four changed files form one `sling` feature: formula-attachment route restamping, its idempotent messaging and formulas-v2 dry-run disclosure, plus direct regression coverage. |
+
+## Additional static evidence
+
+- `go vet ./...` — PASS.
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=a585e07a93782c24a629359cf635f9e95beded5d make lint-affected` — PASS, 0 issues.
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=a585e07a93782c24a629359cf635f9e95beded5d make fmt-check-changed` — PASS.
+- `git diff --check a585e07a93782c24a629359cf635f9e95beded5d..HEAD` — PASS.
+- `git config core.hooksPath` — `.githooks`.
+
+## Reviewed history
+
+```text
+8038caf7a fix(sling): restamp gc.routed_to on formula-attach and disclose it in --dry-run
+d1e958485 test(sling): red — regression coverage for #4763 fix plan (refs ga-f43t9b)
+23f6f1af7 fix(sling): fix default-formula skip message and scope dry-run wisp-root disclosure to graph.v2 (refs ga-f43t9b)
+13362a5c4 test(sling): drop legacy formulatest coupling from graph.v2 dry-run test (refs ga-mwrstg)
+```


### PR DESCRIPTION
## What this changes

When `gc sling` attaches a default formulas-v2 workflow to an existing work bead, the bead now records `gc.execution_routed_to` after the destination agent is resolved. Pool-slot destinations are normalized to their base pool name, so controller demand and later execution consistently refer to the same route.

The idempotent attachment warning now names the default formula that was already attached. Dry runs only promise workflow-root routing for formulas v2, matching the behavior that will actually occur.

## Review notes

- The new execution-routing metadata is written only after workflow startup succeeds; rollback paths do not leave a false route behind.
- This changes no configuration, API shape, or migration surface.
- Legacy formula attachment keeps its existing behavior; workflow-root disclosure is formulas-v2 only.

## Test plan

- [x] Run the documented local CI-equivalent unit, process, and integration shards; see the release gate for the tmux 3.7 baseline variance.
- [x] Exercise `internal/sling` routing/restamping tests and `cmd/gc` sling/dry-run tests with zero failures or skips.
- [x] Verify the legacy formulas-v2 coupling freeze and affected-file static checks.
- [x] Release gate: [`release-gates/ga-mwrstg-sling-formula-attach-routing-fix-gate.md`](release-gates/ga-mwrstg-sling-formula-attach-routing-fix-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4762 — addresses the missing routing restamp on formula attach — including the convoy-first graph.v2 branch that passes an empty sourceBeadID and so skipped it — by stamping gc.execution_routed_to (pool slots normalized to their base pool), and adds the --dry-run disclosure that a workflow root is also cooked and routed, scoped to formulas v2; it deliberately leaves gc.routed_to unset on graph.v2 work beads to avoid a double-dispatch hazard, so the claim-path field named in that issue stays as-is and anything reading it directly is unchanged

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->