### PR TITLE
fix(pidutil): parse proc state after comm

### DIFF
--- a/internal/pidutil/pidutil.go
+++ b/internal/pidutil/pidutil.go
@@ -41,11 +41,37 @@ func Alive(pid int) bool {
 	if err != nil {
 		return !psReportsZombie(pid)
 	}
-	fields := strings.Fields(string(data))
-	if len(fields) >= 3 && fields[2] == "Z" {
+	state, ok := procStatState(string(data))
+	if ok && state == "Z" {
 		return false
 	}
 	return true
+}
+
+// procStatState returns field 3 (state) from a Linux /proc/<pid>/stat row.
+// Field 2 (comm) may contain spaces and parentheses, so the state is the first
+// token after comm's final closing parenthesis, not the third whitespace token.
+func procStatState(stat string) (string, bool) {
+	lparen := strings.IndexByte(stat, '(')
+	rparen := strings.LastIndexByte(stat, ')')
+	if lparen <= 0 || rparen <= lparen ||
+		!isASCIIWhitespace(stat[lparen-1]) ||
+		rparen+1 >= len(stat) || !isASCIIWhitespace(stat[rparen+1]) {
+		return "", false
+	}
+	parsedPID, err := strconv.Atoi(strings.TrimSpace(stat[:lparen]))
+	if err != nil || parsedPID <= 0 {
+		return "", false
+	}
+	fields := strings.Fields(stat[rparen+1:])
+	if len(fields) == 0 || len(fields[0]) != 1 {
+		return "", false
+	}
+	return fields[0], true
+}
+
+func isASCIIWhitespace(b byte) bool {
+	return b == ' ' || b >= '\t' && b <= '\r'
 }
 
 // StartTime returns a PID's start time — field 22 (starttime, in clock ticks

--- a/internal/pidutil/pidutil_test.go
+++ b/internal/pidutil/pidutil_test.go
@@ -33,6 +33,67 @@ func TestAliveTreatsZombieAsDead(t *testing.T) {
 	t.Fatalf("Alive(%d) stayed true for exited child", cmd.Process.Pid)
 }
 
+func TestProcStatState(t *testing.T) {
+	tests := []struct {
+		name string
+		stat string
+		want string
+		ok   bool
+	}{
+		{
+			name: "ordinary sleeping process",
+			stat: "123 (gc) S 1 2 3",
+			want: "S",
+			ok:   true,
+		},
+		{
+			name: "spaced zombie comm",
+			stat: "123 (gc worker) Z 1 2 3",
+			want: "Z",
+			ok:   true,
+		},
+		{
+			name: "embedded parentheses in running comm",
+			stat: "123 (gc (worker) name) R 1 2 3",
+			want: "R",
+			ok:   true,
+		},
+		{
+			name: "missing closing parenthesis",
+			stat: "123 (gc worker Z 1 2 3",
+		},
+		{
+			name: "missing state",
+			stat: "123 (gc worker)",
+		},
+		{
+			name: "invalid pid prefix",
+			stat: "not-a-pid (gc worker) Z 1 2 3",
+		},
+		{
+			name: "invalid multi-character state",
+			stat: "123 (gc worker) ZZ 1 2 3",
+		},
+		{
+			name: "missing separator before comm",
+			stat: "123(gc worker) Z 1 2 3",
+		},
+		{
+			name: "missing separator after comm",
+			stat: "123 (gc worker)Z 1 2 3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := procStatState(tc.stat)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("procStatState(%q) = (%q, %v), want (%q, %v)", tc.stat, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
 func TestPSReportsZombieReturnsWhenPSHangs(t *testing.T) {
 	binDir := t.TempDir()
 	psPath := filepath.Join(binDir, "ps")


### PR DESCRIPTION
## Summary

- parse Linux `/proc/<pid>/stat` state after the final `)` that terminates `comm`, instead of assuming the third whitespace token is state
- keep malformed stat data conservative and preserve the existing signal-zero, read-error, EPERM, and non-Linux fallback behavior
- add deterministic coverage for ordinary, spaced, embedded-parenthesis, zombie, non-zombie, and malformed stat rows

This is the focused parser follow-up requested in the maintainer review of #4953. A legal multi-word `comm` currently shifts `strings.Fields` indexes and can make `pidutil.Alive` report a zombie as alive.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed — not run; no docs changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed — not run; this change is isolated to a pure parser and package tests

Additional focused checks:

- `go test -count=10 ./internal/pidutil -run '^TestProcStatState$'`
- `go test -count=1 ./internal/pidutil`
- `go vet ./internal/pidutil`
- `golangci-lint run ./internal/pidutil/...`
- repository pre-commit hook, including the fast CI-equivalent Go gates
- `git diff --check 3db4ed265db02a411b081e4581b435d80d4a5311..11da09c725b2a34ef9db851f47e174714f7c1f21`

## Checklist

- [x] Linked an issue, or explained why one is not needed — no public issue; this is a separately scoped follow-up from the approved review on #4953
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes — not applicable; no user-facing contract changed
- [x] Called out breaking changes or migration notes — none
