### PR TITLE
fix(session): ReleaseWorkBead re-verifies live status — stale cached enumeration must not reopen a freshly closed bead

### DIFF
--- a/cmd/gc/work_assignment.go
+++ b/cmd/gc/work_assignment.go
@@ -167,6 +167,25 @@ func (w workAssignment) ReleaseWorkBead(item beads.Bead, runTargetFallback strin
 	if store == nil {
 		return nil
 	}
+	// The callers' enumerations can answer from the CachingStore's stale view
+	// (the closed-session release path deliberately runs the unflagged, cached
+	// query). A work bead whose worker closed it inside the staleness window
+	// arrives here still reading in_progress, and the release below would reset
+	// an honestly COMPLETED close back to open — detaching it for re-claim and
+	// producing the claim → work → close → reopen → re-claim loop (fast-lifecycle
+	// bodies lose this race every cycle; lanes claim but never advance). Re-read
+	// the bead through the live handle before mutating: a bead that is already
+	// closed needs no release, and the in_progress→open decision must key off
+	// current status, not the enumeration snapshot's. A failed live read falls
+	// back to the snapshot rather than skipping: releasing a vanished bead is
+	// harmless (Update errors are the caller's per-item log line), while skipping
+	// a genuinely stuck one would strand it assigned to a dead session.
+	if current, err := beads.HandlesFor(store).Live.Get(item.ID); err == nil {
+		if current.Status == "closed" {
+			return nil
+		}
+		item = current
+	}
 	empty := ""
 	update := beads.UpdateOpts{
 		Assignee: &empty,

--- a/cmd/gc/work_assignment_release_clobber_test.go
+++ b/cmd/gc/work_assignment_release_clobber_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// liveGetWorkStore wraps the recording write store with a controllable Get so
+// tests can model the live backing view diverging from the (possibly stale)
+// enumeration snapshot the caller passed to ReleaseWorkBead.
+type liveGetWorkStore struct {
+	*recordingWriteWorkStore
+	live map[string]beads.Bead
+}
+
+func (s *liveGetWorkStore) Get(id string) (beads.Bead, error) {
+	if b, ok := s.live[id]; ok {
+		return b, nil
+	}
+	return beads.Bead{}, beads.ErrNotFound
+}
+
+// TestWorkAssignmentReleaseWorkBead_SkipsFreshlyClosedBead is the regression
+// test for the claim/reopen stall loop: the caller's enumeration answered from
+// the CachingStore's stale view and handed release a bead that read
+// in_progress, while the live store already had it CLOSED (the worker closed
+// it honestly moments before its session was torn down). Release must emit NO
+// write at all — resetting it to open would destroy the completed close and
+// re-queue finished work forever.
+func TestWorkAssignmentReleaseWorkBead_SkipsFreshlyClosedBead(t *testing.T) {
+	rec := newRecordingWriteWorkStore()
+	store := &liveGetWorkStore{recordingWriteWorkStore: rec, live: map[string]beads.Bead{
+		"w-done": {ID: "w-done", Status: "closed", Assignee: "keeper-s1"},
+	}}
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+
+	stale := beads.Bead{ID: "w-done", Status: "in_progress", Assignee: "keeper-s1"}
+	if err := wa.ReleaseWorkBead(stale, ""); err != nil {
+		t.Fatalf("ReleaseWorkBead: %v", err)
+	}
+	if len(rec.updates) != 0 {
+		t.Fatalf("expected NO Update on a live-closed bead, got %#v", rec.updates)
+	}
+	if len(rec.metaSets) != 0 {
+		t.Fatalf("expected NO SetMetadata on a live-closed bead, got %#v", rec.metaSets)
+	}
+}
+
+// TestWorkAssignmentReleaseWorkBead_LiveStatusGovernsReset asserts the
+// in_progress→open decision keys off the live view, not the stale snapshot:
+// a bead the live store reads as open (worker already released it back) gets
+// the assignee/affinity clear but NO redundant status write, even when the
+// snapshot still said in_progress.
+func TestWorkAssignmentReleaseWorkBead_LiveStatusGovernsReset(t *testing.T) {
+	rec := newRecordingWriteWorkStore()
+	store := &liveGetWorkStore{recordingWriteWorkStore: rec, live: map[string]beads.Bead{
+		"w-live-open": {ID: "w-live-open", Status: "open", Assignee: "keeper-s1"},
+	}}
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+
+	stale := beads.Bead{ID: "w-live-open", Status: "in_progress", Assignee: "keeper-s1"}
+	if err := wa.ReleaseWorkBead(stale, ""); err != nil {
+		t.Fatalf("ReleaseWorkBead: %v", err)
+	}
+	if len(rec.updates) != 1 {
+		t.Fatalf("expected 1 Update, got %d: %#v", len(rec.updates), rec.updates)
+	}
+	got := rec.updates[0]
+	if got.opts.Status != nil {
+		t.Fatalf("Status should be nil when the live view is already open, got %q", *got.opts.Status)
+	}
+	if derefStr(got.opts.Assignee) != "" {
+		t.Fatalf("Assignee = %q, want empty-string clear", derefStr(got.opts.Assignee))
+	}
+}
+
+// TestWorkAssignmentReleaseWorkBead_LiveReadFailureFallsBack asserts a failed
+// live read releases from the snapshot unchanged (the pre-fix behavior):
+// skipping on error would strand a genuinely stuck bead assigned to a dead
+// session, which is the exact condition release exists to repair.
+func TestWorkAssignmentReleaseWorkBead_LiveReadFailureFallsBack(t *testing.T) {
+	rec := newRecordingWriteWorkStore()
+	store := &liveGetWorkStore{recordingWriteWorkStore: rec, live: map[string]beads.Bead{}}
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+
+	stale := beads.Bead{ID: "w-stuck", Status: "in_progress", Assignee: "keeper-s1"}
+	if err := wa.ReleaseWorkBead(stale, ""); err != nil {
+		t.Fatalf("ReleaseWorkBead: %v", err)
+	}
+	if len(rec.updates) != 1 {
+		t.Fatalf("expected 1 Update, got %d: %#v", len(rec.updates), rec.updates)
+	}
+	got := rec.updates[0]
+	if got.opts.Status == nil || *got.opts.Status != "open" {
+		t.Fatalf("Status = %v, want open (snapshot fallback)", got.opts.Status)
+	}
+}


### PR DESCRIPTION
## The defect

`releaseWorkFromClosedSessionBead` enumerates a closing session's work through the deliberately-unflagged `List{Assignee,Status}` query, which a `CachingStore` answers from its cached view. A worker that honestly closes its work bead moments before its session is torn down loses a race: the release enumeration still reads the bead as `in_progress`, and `ReleaseWorkBead` "resets" it to `open` + clears the assignee — silently destroying a completed close.

Fast-lifecycle runtimes (a single-shot local-model harness with a ~30-60s claim-to-exit cycle) lose this race essentially every time; long-lived sessions only intermittently — which made the resulting stall look mysterious: lanes claim, work completes, and the city never advances because finished work keeps re-entering the routed queue. Observed live (Dolt history): `bd: update <id>` → `closed`, then `gc: update bead <id>` → `open`/unassigned 10-12s later, on every cycle.

## The fix

Guard at the release primitive so all callers (closed-session release, retired-session unclaim, orphan fallback) are covered: re-read the bead through `HandlesFor(store).Live` before mutating —

- live status `closed` → skip the release entirely (a closed bead needs no detach);
- otherwise use the live bead for the `in_progress`→`open` decision and the run_target-fallback check, not the enumeration snapshot;
- a failed live read falls back to the snapshot (pre-fix behavior): releasing a vanished bead is harmless, while skipping a genuinely stuck one would strand it assigned to a dead session.

## Tests

Three regression tests in `cmd/gc/work_assignment_release_clobber_test.go`:
- live-closed bead → **no write emitted at all**;
- live-open bead with a stale in_progress snapshot → assignee/affinity clear only, no redundant status write;
- live-read failure → snapshot fallback preserved.

Existing recording-fake byte-identity tests pass unchanged (the fake's Get errors for never-created beads, exercising the fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)