### PR TITLE
fix(scripts): make check-routed-test-rows.sh portable to bash 3.2

### DIFF
--- a/scripts/check-routed-test-rows.sh
+++ b/scripts/check-routed-test-rows.sh
@@ -76,9 +76,15 @@ if (( ${#manifest_files[@]} == 0 )); then
     exit 1
 fi
 
-declare -A in_manifest=()
+manifest_set=$'\n'
+in_manifest() {
+    case "$manifest_set" in
+        *$'\n'"$1"$'\n'*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
 for rel in "${manifest_files[@]}"; do
-    in_manifest["$rel"]=1
+    manifest_set+="$rel"$'\n'
     f="$repo_root/$rel"
     if [[ ! -f "$f" ]]; then
         echo "MANIFEST FILE MISSING: $rel (listed in the manifest but not on disk)"
@@ -96,7 +102,7 @@ done
 shopt -s nullglob
 for test_file in "$cmd_dir"/cmd_*_test.go; do
     rel="cmd/gc/$(basename "$test_file")"
-    [[ -n "${in_manifest[$rel]:-}" ]] && continue
+    in_manifest "$rel" && continue
     present=$(count_rows "$test_file")
     if (( present == 0 )); then
         continue


### PR DESCRIPTION
### What breaks

`scripts/check-routed-test-rows.sh` uses a bash-4 associative array
(`declare -A in_manifest=()`) to track which files are covered by the
test-routing manifest. macOS ships `/bin/bash` 3.2.57 (the last GPLv2
release Apple will ship), which does not support `declare -A` at all —
the script dies immediately with `declare: -A: invalid option` before
it can check anything. Anyone running the repo's own routing check on
a stock macOS shell (no Homebrew bash on `PATH`) cannot run it.

### Reproduction

```
$ bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ bash scripts/check-routed-test-rows.sh
scripts/check-routed-test-rows.sh: line 79: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

### The fix

Replace the associative array with a newline-delimited string set and
an `in_manifest()` helper that does a `case`/glob lookup — pure
POSIX-ish bash that bash 3.2 supports. Behavior is unchanged for
callers: the only observable difference is that the script now runs
to completion (and reports real routing violations, if any) instead of
crashing on startup. The pre-existing docs-citation line
(`docs/plans/ga-h6w-read-path-api-routing.md`) is untouched.

### Verification

On top of current `origin/main` (`3db4ed265`):

```
$ bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ bash scripts/check-routed-test-rows.sh; echo "exit=$?"
exit=0
```

Before the fix, the same command dies with `declare: -A: invalid
option` on this bash. After the fix it runs to completion.
