### PR TITLE
fix(dispatch): consume typed coordinator closes without retrying

### DIFF
--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -149,6 +149,7 @@ const (
 	ReasoningMetadataKey                 = "gc.reasoning"
 	RequiredArtifactMetadataKey          = "gc.required_artifact"
 	RequiredArtifactsMetadataKey         = "gc.required_artifacts"
+	ReviewGateMetadataKey                = "gc.review_gate"
 	RetryCountMetadataKey                = "gc.retry_count"
 	RetryFromMetadataKey                 = "gc.retry_from"
 	RetrySessionRecycledMetadataKey      = "gc.retry_session_recycled"
@@ -392,6 +393,7 @@ var KnownMetadataKeys = []string{
 	ReasoningMetadataKey,
 	RequiredArtifactMetadataKey,
 	RequiredArtifactsMetadataKey,
+	ReviewGateMetadataKey,
 	RetryCountMetadataKey,
 	RetryFromMetadataKey,
 	RetrySessionRecycledMetadataKey,

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -61,8 +61,14 @@ const (
 	ControllerErrorClassMetadataKey      = "gc.controller_error_class"
 	ControllerErrorMetadataKey           = "gc.controller_error"
 	ControllerRetryableMetadataKey       = "gc.controller_retryable"
-	CurrentRunIDMetadataKey              = "gc.current_run_id"
-	CwdMetadataKey                       = "gc.cwd"
+	// CoordinatorOutcomeProducerDispositionMetadataKey holds the JSON typed-close
+	// envelope written by the gc-outcome-close helper (contract_version, disposition,
+	// work_id, recorded_by, reason, [producer]). It is the authoritative typed
+	// step-close record; the controller folds it so a helper-closed attempt whose
+	// gc.outcome is empty is not misread as a missing outcome (gc-e2xqk).
+	CoordinatorOutcomeProducerDispositionMetadataKey = "gc.coordinator_outcome.producer_disposition"
+	CurrentRunIDMetadataKey                          = "gc.current_run_id"
+	CwdMetadataKey                                   = "gc.cwd"
 	// AttachFencePendingMetadataKey marks a fenced attach's sub-DAG root
 	// between speculative (deferred, non-runnable) creation and the CAS-last
 	// epoch fence committing. Cleared on activation; a root still carrying it
@@ -308,6 +314,7 @@ var KnownMetadataKeys = []string{
 	ControllerErrorClassMetadataKey,
 	ControllerErrorMetadataKey,
 	ControllerRetryableMetadataKey,
+	CoordinatorOutcomeProducerDispositionMetadataKey,
 	CurrentRunIDMetadataKey,
 	CwdMetadataKey,
 	AttachFencePendingMetadataKey,

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -61,11 +61,8 @@ const (
 	ControllerErrorClassMetadataKey      = "gc.controller_error_class"
 	ControllerErrorMetadataKey           = "gc.controller_error"
 	ControllerRetryableMetadataKey       = "gc.controller_retryable"
-	// CoordinatorOutcomeProducerDispositionMetadataKey holds the JSON typed-close
-	// envelope written by the gc-outcome-close helper (contract_version, disposition,
-	// work_id, recorded_by, reason, [producer]). It is the authoritative typed
-	// step-close record; the controller folds it so a helper-closed attempt whose
-	// gc.outcome is empty is not misread as a missing outcome (gc-e2xqk).
+	// CoordinatorOutcomeProducerDispositionMetadataKey holds the typed-close JSON
+	// envelope written by gc-outcome-close.
 	CoordinatorOutcomeProducerDispositionMetadataKey = "gc.coordinator_outcome.producer_disposition"
 	CurrentRunIDMetadataKey                          = "gc.current_run_id"
 	CwdMetadataKey                                   = "gc.cwd"

--- a/internal/beadmeta/values.go
+++ b/internal/beadmeta/values.go
@@ -59,9 +59,11 @@ const (
 
 // Values of the CoordinatorOutcomeProducerDispositionMetadataKey typed-close
 // envelope written by the gc-outcome-close helper. CoordinatorOutcomeContractVersion
-// pins the JSON shape. A clean close is deliverable or non-deliverable; gc-outcome-close
-// never records a failure (failures take the gc.outcome=fail path), so the controller
-// folds either disposition as a pass.
+// pins the JSON shape. A deliverable close is an explicit success and names some
+// producer (the actor kind is caller-supplied configuration, not enumerated here); a
+// non-deliverable close is a deliberate "intentionally not a deliverable" terminal
+// (e.g. obsolete work) and names no producer. Failures are NOT recorded here (they
+// take the gc.outcome=fail path).
 const (
 	CoordinatorOutcomeContractVersion    = 1
 	CoordinatorDispositionDeliverable    = "deliverable"

--- a/internal/beadmeta/values.go
+++ b/internal/beadmeta/values.go
@@ -57,6 +57,17 @@ const (
 	OutcomeMissingRoot = "missing_root"
 )
 
+// Values of the CoordinatorOutcomeProducerDispositionMetadataKey typed-close
+// envelope written by the gc-outcome-close helper. CoordinatorOutcomeContractVersion
+// pins the JSON shape. A clean close is deliverable or non-deliverable; gc-outcome-close
+// never records a failure (failures take the gc.outcome=fail path), so the controller
+// folds either disposition as a pass.
+const (
+	CoordinatorOutcomeContractVersion    = 1
+	CoordinatorDispositionDeliverable    = "deliverable"
+	CoordinatorDispositionNonDeliverable = "non-deliverable"
+)
+
 // Values of WorkOutcomeMetadataKey ("gc.work_outcome"), the typed work-record
 // close disposition (ADR-0009). Deliberately disjoint from the control-plane
 // OutcomeMetadataKey vocabulary above so the two never collide on one key. Only

--- a/internal/beadmeta/values.go
+++ b/internal/beadmeta/values.go
@@ -63,6 +63,8 @@ const (
 	CoordinatorOutcomeContractVersion    = 1
 	CoordinatorDispositionDeliverable    = "deliverable"
 	CoordinatorDispositionNonDeliverable = "non-deliverable"
+	CoordinatorPassingVerdictReview      = "review_verdict"
+	CoordinatorPassingVerdictEvidence    = "evidence.reviewer_verdict"
 )
 
 // Values of WorkOutcomeMetadataKey ("gc.work_outcome"), the typed work-record

--- a/internal/beadmeta/values.go
+++ b/internal/beadmeta/values.go
@@ -58,12 +58,7 @@ const (
 )
 
 // Values of the CoordinatorOutcomeProducerDispositionMetadataKey typed-close
-// envelope written by the gc-outcome-close helper. CoordinatorOutcomeContractVersion
-// pins the JSON shape. A deliverable close is an explicit success and names some
-// producer (the actor kind is caller-supplied configuration, not enumerated here); a
-// non-deliverable close is a deliberate "intentionally not a deliverable" terminal
-// (e.g. obsolete work) and names no producer. Failures are NOT recorded here (they
-// take the gc.outcome=fail path).
+// envelope. Producer values remain open-world configuration.
 const (
 	CoordinatorOutcomeContractVersion    = 1
 	CoordinatorDispositionDeliverable    = "deliverable"

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -713,6 +713,68 @@ func TestProcessRetryControlRetriesInvalidWorkerResultContract(t *testing.T) {
 	}
 }
 
+// TestProcessRetryControlFoldsTypedCoordinatorOutcomeWithoutRetry reproduces the
+// gc-e2xqk controller missing_outcome race end to end. Attempt 1 is closed through
+// the gc-outcome-close typed contract: its disposition lives under
+// gc.coordinator_outcome.producer_disposition (with gc.outcome.producer), and
+// gc.outcome is never set. Before the fix the controller read only gc.outcome, saw
+// it empty, recorded transient/missing_outcome, and minted a spurious attempt 2
+// (the gpk-u06l4 -> gpk-2d2p0 symptom). The controller must instead fold the typed
+// close as a pass and close the control exactly once with no retry.
+func TestProcessRetryControlFoldsTypedCoordinatorOutcomeWithoutRetry(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review",
+		Metadata: map[string]string{
+			"gc.kind":             "retry",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.review",
+			"gc.step_id":          "review",
+			"gc.max_attempts":     "3",
+			"gc.on_exhausted":     "hard_fail",
+			"gc.source_step_spec": `{"id":"review","title":"Review","type":"task","retry":{"max_attempts":3}}`,
+			"gc.control_epoch":    "1",
+		},
+	})
+	attempt1 := mustCreate(t, store, beads.Bead{
+		Title: "review attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.review.attempt.1",
+			"gc.attempt":          "1",
+			"gc.outcome.producer": "formula-step",
+		},
+	})
+	// gc-outcome-close records work_id = the closed bead's own ID.
+	disposition := fmt.Sprintf(`{"contract_version":1,"disposition":"deliverable","work_id":%q,"recorded_by":"formula-step","reason":"done","producer":"formula-step"}`, attempt1.ID)
+	if err := store.SetMetadata(attempt1.ID, "gc.coordinator_outcome.producer_disposition", disposition); err != nil {
+		t.Fatalf("set producer_disposition: %v", err)
+	}
+	mustClose(t, store, attempt1.ID)
+	mustDep(t, store, control.ID, attempt1.ID, "blocks")
+
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	// A retry path yields Action "retry" with the control left open (see
+	// TestProcessRetryControlRetriesInvalidWorkerResultContract); folding the typed
+	// outcome yields Action "pass" with the control closed exactly once.
+	if !result.Processed || result.Action != "pass" {
+		t.Fatalf("result = %+v, want processed pass (no spurious retry)", result)
+	}
+	after := mustGet(t, store, control.ID)
+	if after.Status != "closed" || after.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("control = status %q outcome %q, want closed/pass", after.Status, after.Metadata["gc.outcome"])
+	}
+}
+
 func TestProcessRetryControlClosesEnclosingScopeOnFailure(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -713,14 +713,8 @@ func TestProcessRetryControlRetriesInvalidWorkerResultContract(t *testing.T) {
 	}
 }
 
-// TestProcessRetryControlFoldsTypedCoordinatorOutcomeWithoutRetry reproduces the
-// gc-e2xqk controller missing_outcome race end to end. Attempt 1 is closed through
-// the gc-outcome-close typed contract: its disposition lives under
-// gc.coordinator_outcome.producer_disposition (with gc.outcome.producer), and
-// gc.outcome is never set. Before the fix the controller read only gc.outcome, saw
-// it empty, recorded transient/missing_outcome, and minted a spurious attempt 2
-// (the gpk-u06l4 -> gpk-2d2p0 symptom). The controller must instead fold the typed
-// close as a pass and close the control exactly once with no retry.
+// TestProcessRetryControlFoldsTypedCoordinatorOutcomeWithoutRetry reproduces
+// gc-e2xqk end to end: a typed deliverable close must not mint attempt 2.
 func TestProcessRetryControlFoldsTypedCoordinatorOutcomeWithoutRetry(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
@@ -763,9 +757,6 @@ func TestProcessRetryControlFoldsTypedCoordinatorOutcomeWithoutRetry(t *testing.
 	if err != nil {
 		t.Fatalf("processRetryControl: %v", err)
 	}
-	// A retry path yields Action "retry" with the control left open (see
-	// TestProcessRetryControlRetriesInvalidWorkerResultContract); folding the typed
-	// outcome yields Action "pass" with the control closed exactly once.
 	if !result.Processed || result.Action != "pass" {
 		t.Fatalf("result = %+v, want processed pass (no spurious retry)", result)
 	}

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -302,6 +303,12 @@ func typedDeliverableCloseFor(subject beads.Bead) bool {
 		Producer        *string `json:"producer"`
 	}
 	if err := decoder.Decode(&envelope); err != nil {
+		return false
+	}
+	// Reject trailing data after the envelope: DisallowUnknownFields only guards the
+	// first object, so a valid envelope followed by more JSON or garbage must fail
+	// closed rather than forge a pass.
+	if err := decoder.Decode(new(json.RawMessage)); err != io.EOF {
 		return false
 	}
 	switch envelope.Disposition {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -268,8 +268,51 @@ type retryEvalResult struct {
 	Reason  string
 }
 
+// typedCoordinatorOutcomeIsCleanClose reports whether the subject carries a valid
+// gc-outcome-close typed close for itself. That helper records the step outcome
+// under CoordinatorOutcomeProducerDispositionMetadataKey (a JSON envelope), NOT
+// gc.outcome, so an attempt it closed has an empty gc.outcome. The controller must
+// fold that typed close instead of misreading the empty gc.outcome as a missing
+// outcome and minting a spurious retry (gc-e2xqk). It is a clean close, exactly
+// once, when the envelope is contract_version 1, names this subject as its work_id
+// (so a propagated/foreign record is ignored), and carries a known disposition.
+// gc-outcome-close only records clean closes (deliverable / non-deliverable);
+// failures take the gc.outcome=fail path, so either disposition folds as a pass.
+func typedCoordinatorOutcomeIsCleanClose(subject beads.Bead) bool {
+	raw := strings.TrimSpace(subject.Metadata[beadmeta.CoordinatorOutcomeProducerDispositionMetadataKey])
+	if raw == "" {
+		return false
+	}
+	var envelope struct {
+		ContractVersion int    `json:"contract_version"`
+		Disposition     string `json:"disposition"`
+		WorkID          string `json:"work_id"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return false
+	}
+	if envelope.ContractVersion != beadmeta.CoordinatorOutcomeContractVersion || envelope.WorkID != subject.ID {
+		return false
+	}
+	switch envelope.Disposition {
+	case beadmeta.CoordinatorDispositionDeliverable, beadmeta.CoordinatorDispositionNonDeliverable:
+		return true
+	default:
+		return false
+	}
+}
+
 func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	outcome := strings.TrimSpace(subject.Metadata[beadmeta.OutcomeMetadataKey])
+	if outcome == "" && typedCoordinatorOutcomeIsCleanClose(subject) {
+		// The attempt closed through the gc-outcome-close typed contract, which
+		// records its disposition under CoordinatorOutcomeProducerDispositionMetadataKey
+		// and leaves gc.outcome empty. Fold that clean typed close as a pass so it is
+		// consumed exactly once rather than misread as a missing outcome (gc-e2xqk).
+		// Normalizing to OutcomePass keeps the pass-path postconditions (failure
+		// metadata, required output/artifacts) applying uniformly below.
+		outcome = beadmeta.OutcomePass
+	}
 	switch outcome {
 	case beadmeta.OutcomePass:
 		if strings.TrimSpace(subject.Metadata[beadmeta.FailureClassMetadataKey]) != "" || strings.TrimSpace(subject.Metadata[beadmeta.FailureReasonMetadataKey]) != "" {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -268,49 +268,80 @@ type retryEvalResult struct {
 	Reason  string
 }
 
-// typedCoordinatorOutcomeIsCleanClose reports whether the subject carries a valid
-// gc-outcome-close typed close for itself. That helper records the step outcome
-// under CoordinatorOutcomeProducerDispositionMetadataKey (a JSON envelope), NOT
-// gc.outcome, so an attempt it closed has an empty gc.outcome. The controller must
-// fold that typed close instead of misreading the empty gc.outcome as a missing
-// outcome and minting a spurious retry (gc-e2xqk). It is a clean close, exactly
-// once, when the envelope is contract_version 1, names this subject as its work_id
-// (so a propagated/foreign record is ignored), and carries a known disposition.
-// gc-outcome-close only records clean closes (deliverable / non-deliverable);
-// failures take the gc.outcome=fail path, so either disposition folds as a pass.
-func typedCoordinatorOutcomeIsCleanClose(subject beads.Bead) bool {
+// typedDeliverableCloseFor reports whether the subject carries a valid, complete
+// gc-outcome-close *deliverable* typed close for itself. gc-outcome-close records the
+// terminal state under CoordinatorOutcomeProducerDispositionMetadataKey (a JSON
+// envelope) instead of gc.outcome, so a helper-closed attempt has an empty gc.outcome
+// and the controller must fold the typed close rather than misread it as a missing
+// outcome and mint a spurious retry (gc-e2xqk).
+//
+// Only a deliverable close is an explicit success: it names the producer that shipped
+// the step's deliverable, so it is equivalent to gc.outcome=pass and folds exactly
+// once. A non-deliverable close ("intentionally not a deliverable") is NOT synthesized
+// to pass — the retry contract requires an explicit gc.outcome and treats its absence
+// as invalid (engdocs/design/formula-v2-transient-retries.md) — so it falls through to
+// the missing_outcome path. The envelope is accepted only when it is complete and
+// self-referential: contract_version 1, work_id == subject.ID (so a propagated or
+// foreign record is ignored), non-empty recorded_by and reason, a present non-empty
+// producer (the actor kind is caller-supplied configuration, validated structurally,
+// never matched against a hardcoded set of role names), and no unknown fields, so a
+// truncated or schema-skewed record cannot forge a pass.
+func typedDeliverableCloseFor(subject beads.Bead) bool {
 	raw := strings.TrimSpace(subject.Metadata[beadmeta.CoordinatorOutcomeProducerDispositionMetadataKey])
 	if raw == "" {
 		return false
 	}
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
 	var envelope struct {
-		ContractVersion int    `json:"contract_version"`
-		Disposition     string `json:"disposition"`
-		WorkID          string `json:"work_id"`
+		ContractVersion int     `json:"contract_version"`
+		Disposition     string  `json:"disposition"`
+		WorkID          string  `json:"work_id"`
+		RecordedBy      string  `json:"recorded_by"`
+		Reason          string  `json:"reason"`
+		Producer        *string `json:"producer"`
 	}
-	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
-		return false
-	}
-	if envelope.ContractVersion != beadmeta.CoordinatorOutcomeContractVersion || envelope.WorkID != subject.ID {
+	if err := decoder.Decode(&envelope); err != nil {
 		return false
 	}
 	switch envelope.Disposition {
-	case beadmeta.CoordinatorDispositionDeliverable, beadmeta.CoordinatorDispositionNonDeliverable:
-		return true
+	case beadmeta.CoordinatorDispositionDeliverable:
+		// Validated below.
+	case beadmeta.CoordinatorDispositionNonDeliverable:
+		// A deliberate non-deliverable is terminal but not a success; leave it to the
+		// missing_outcome path rather than synthesizing a pass.
+		return false
 	default:
 		return false
 	}
+	if envelope.ContractVersion != beadmeta.CoordinatorOutcomeContractVersion {
+		return false
+	}
+	if envelope.WorkID != subject.ID {
+		return false
+	}
+	if strings.TrimSpace(envelope.RecordedBy) == "" || strings.TrimSpace(envelope.Reason) == "" {
+		return false
+	}
+	// A deliverable names some producer, but the actor kind is caller-supplied
+	// configuration: require a present, non-empty value structurally rather than
+	// matching a hardcoded set of role names (ZFC / zero hardcoded roles).
+	if envelope.Producer == nil || strings.TrimSpace(*envelope.Producer) == "" {
+		return false
+	}
+	return true
 }
 
 func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	outcome := strings.TrimSpace(subject.Metadata[beadmeta.OutcomeMetadataKey])
-	if outcome == "" && typedCoordinatorOutcomeIsCleanClose(subject) {
+	if outcome == "" && typedDeliverableCloseFor(subject) {
 		// The attempt closed through the gc-outcome-close typed contract, which
-		// records its disposition under CoordinatorOutcomeProducerDispositionMetadataKey
-		// and leaves gc.outcome empty. Fold that clean typed close as a pass so it is
-		// consumed exactly once rather than misread as a missing outcome (gc-e2xqk).
-		// Normalizing to OutcomePass keeps the pass-path postconditions (failure
-		// metadata, required output/artifacts) applying uniformly below.
+		// records a deliverable disposition under
+		// CoordinatorOutcomeProducerDispositionMetadataKey and leaves gc.outcome empty.
+		// Fold that validated deliverable close as a pass so it is consumed exactly
+		// once rather than misread as a missing outcome (gc-e2xqk). Normalizing to
+		// OutcomePass keeps the pass-path postconditions (failure metadata, required
+		// output/artifacts) applying uniformly below.
 		outcome = beadmeta.OutcomePass
 	}
 	switch outcome {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -269,24 +269,8 @@ type retryEvalResult struct {
 	Reason  string
 }
 
-// typedDeliverableCloseFor reports whether the subject carries a valid, complete
-// gc-outcome-close *deliverable* typed close for itself. gc-outcome-close records the
-// terminal state under CoordinatorOutcomeProducerDispositionMetadataKey (a JSON
-// envelope) instead of gc.outcome, so a helper-closed attempt has an empty gc.outcome
-// and the controller must fold the typed close rather than misread it as a missing
-// outcome and mint a spurious retry (gc-e2xqk).
-//
-// Only a deliverable close is an explicit success: it names the producer that shipped
-// the step's deliverable, so it is equivalent to gc.outcome=pass and folds exactly
-// once. A non-deliverable close ("intentionally not a deliverable") is NOT synthesized
-// to pass — the retry contract requires an explicit gc.outcome and treats its absence
-// as invalid (engdocs/design/formula-v2-transient-retries.md) — so it falls through to
-// the missing_outcome path. The envelope is accepted only when it is complete and
-// self-referential: contract_version 1, work_id == subject.ID (so a propagated or
-// foreign record is ignored), non-empty recorded_by and reason, a present non-empty
-// producer (the actor kind is caller-supplied configuration, validated structurally,
-// never matched against a hardcoded set of role names), and no unknown fields, so a
-// truncated or schema-skewed record cannot forge a pass.
+// typedDeliverableCloseFor reports whether subject carries a complete, strict
+// gc-outcome-close deliverable envelope for itself. Producer names are open-world.
 func typedDeliverableCloseFor(subject beads.Bead) bool {
 	raw := strings.TrimSpace(subject.Metadata[beadmeta.CoordinatorOutcomeProducerDispositionMetadataKey])
 	if raw == "" {
@@ -311,14 +295,7 @@ func typedDeliverableCloseFor(subject beads.Bead) bool {
 	if err := decoder.Decode(new(json.RawMessage)); err != io.EOF {
 		return false
 	}
-	switch envelope.Disposition {
-	case beadmeta.CoordinatorDispositionDeliverable:
-		// Validated below.
-	case beadmeta.CoordinatorDispositionNonDeliverable:
-		// A deliberate non-deliverable is terminal but not a success; leave it to the
-		// missing_outcome path rather than synthesizing a pass.
-		return false
-	default:
+	if envelope.Disposition != beadmeta.CoordinatorDispositionDeliverable {
 		return false
 	}
 	if envelope.ContractVersion != beadmeta.CoordinatorOutcomeContractVersion {
@@ -330,9 +307,6 @@ func typedDeliverableCloseFor(subject beads.Bead) bool {
 	if strings.TrimSpace(envelope.RecordedBy) == "" || strings.TrimSpace(envelope.Reason) == "" {
 		return false
 	}
-	// A deliverable names some producer, but the actor kind is caller-supplied
-	// configuration: require a present, non-empty value structurally rather than
-	// matching a hardcoded set of role names (ZFC / zero hardcoded roles).
 	if envelope.Producer == nil || strings.TrimSpace(*envelope.Producer) == "" {
 		return false
 	}
@@ -342,13 +316,6 @@ func typedDeliverableCloseFor(subject beads.Bead) bool {
 func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	outcome := strings.TrimSpace(subject.Metadata[beadmeta.OutcomeMetadataKey])
 	if outcome == "" && typedDeliverableCloseFor(subject) {
-		// The attempt closed through the gc-outcome-close typed contract, which
-		// records a deliverable disposition under
-		// CoordinatorOutcomeProducerDispositionMetadataKey and leaves gc.outcome empty.
-		// Fold that validated deliverable close as a pass so it is consumed exactly
-		// once rather than misread as a missing outcome (gc-e2xqk). Normalizing to
-		// OutcomePass keeps the pass-path postconditions (failure metadata, required
-		// output/artifacts) applying uniformly below.
 		outcome = beadmeta.OutcomePass
 	}
 	switch outcome {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -285,6 +285,7 @@ func typedDeliverableCloseFor(subject beads.Bead) bool {
 		RecordedBy      string  `json:"recorded_by"`
 		Reason          string  `json:"reason"`
 		Producer        *string `json:"producer"`
+		PassingVerdict  string  `json:"passing_verdict"`
 	}
 	if err := decoder.Decode(&envelope); err != nil {
 		return false
@@ -309,6 +310,17 @@ func typedDeliverableCloseFor(subject beads.Bead) bool {
 	}
 	if envelope.Producer == nil || strings.TrimSpace(*envelope.Producer) == "" {
 		return false
+	}
+	if envelope.PassingVerdict != "" {
+		switch envelope.PassingVerdict {
+		case beadmeta.CoordinatorPassingVerdictReview, beadmeta.CoordinatorPassingVerdictEvidence:
+		default:
+			return false
+		}
+		if subject.Metadata[beadmeta.ReviewGateMetadataKey] != "consumed" ||
+			subject.Metadata[envelope.PassingVerdict] != beadmeta.OutcomePass {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -2,7 +2,6 @@ package dispatch
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -222,20 +221,23 @@ func TestClassifyRetryAttemptCanceledIsTerminalNonRetry(t *testing.T) {
 // TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome pins the graph.v2
 // controller missing_outcome race (gc-e2xqk). An attempt closed through the
 // gc-outcome-close typed contract records its disposition under
-// gc.coordinator_outcome.producer_disposition (plus gc.outcome.producer), leaving
-// gc.outcome empty. Before the fix that empty gc.outcome fell to the
-// missing_outcome transient branch and the controller minted a spurious retry
-// even though a valid typed outcome existed. A valid contract_version=1 clean
-// close — deliverable or non-deliverable, since gc-outcome-close never records a
-// failure — must fold as pass exactly once; a malformed, wrong-version,
-// foreign-work_id, or unknown-disposition record must stay missing_outcome.
+// gc.coordinator_outcome.producer_disposition, leaving gc.outcome empty, and the
+// controller misread that as a missing outcome and minted a spurious retry.
+//
+// Only a fully validated *deliverable* close (an explicit producer-named success)
+// folds to pass, exactly once. A non-deliverable close ("intentionally not a
+// deliverable") is NOT synthesized to pass: the retry contract requires an explicit
+// gc.outcome and treats its absence as invalid, so it stays missing_outcome. The
+// deliverable envelope is accepted only when it is complete and self-referential —
+// contract_version 1, work_id == subject.ID, non-empty recorded_by and reason, a
+// known deliverable producer, and no unknown fields — so a truncated or schema-skewed
+// record cannot forge a pass.
 func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 	t.Parallel()
 
 	const attemptID = "gc-attempt1"
-	typedClose := func(disposition, workID string) string {
-		return fmt.Sprintf(`{"contract_version":1,"disposition":%q,"work_id":%q,"recorded_by":"formula-step","reason":"done","producer":"formula-step"}`, disposition, workID)
-	}
+	// A complete, valid deliverable typed close for attemptID.
+	const validDeliverable = `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step"}`
 
 	tests := []struct {
 		name     string
@@ -243,17 +245,10 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 		want     retryEvalResult
 	}{
 		{
-			name: "deliverable typed close folds as pass",
+			name: "valid deliverable close folds as pass",
 			metadata: map[string]string{
-				"gc.coordinator_outcome.producer_disposition": typedClose("deliverable", attemptID),
+				"gc.coordinator_outcome.producer_disposition": validDeliverable,
 				"gc.outcome.producer":                         "formula-step",
-			},
-			want: retryEvalResult{Outcome: "pass"},
-		},
-		{
-			name: "non-deliverable typed close folds as pass",
-			metadata: map[string]string{
-				"gc.coordinator_outcome.producer_disposition": typedClose("non-deliverable", attemptID),
 			},
 			want: retryEvalResult{Outcome: "pass"},
 		},
@@ -261,12 +256,67 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 			name: "explicit gc.outcome takes precedence over typed close",
 			metadata: map[string]string{
 				"gc.outcome": "pass",
-				"gc.coordinator_outcome.producer_disposition": typedClose("deliverable", attemptID),
+				"gc.coordinator_outcome.producer_disposition": validDeliverable,
 			},
 			want: retryEvalResult{Outcome: "pass"},
 		},
 		{
-			name: "malformed typed close stays missing_outcome",
+			// A deliberate non-deliverable (obsolete/no-op) close carries no producer
+			// and no gc.outcome. The retry contract requires an explicit gc.outcome, so
+			// this must NOT synthesize pass (gc-e2xqk P1); it stays missing_outcome.
+			name: "non-deliverable close stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"non-deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"obsolete"}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			// An arbitrary, novel producer string is accepted structurally: the actor
+			// kind is caller-supplied configuration, never matched against a hardcoded
+			// allowlist of role names (ZFC / zero hardcoded roles).
+			name: "deliverable with arbitrary producer folds as pass",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"novel-writer-42"}`,
+			},
+			want: retryEvalResult{Outcome: "pass"},
+		},
+		{
+			name: "deliverable absent producer stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped"}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "deliverable empty producer stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":""}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "deliverable empty recorded_by stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"","reason":"shipped","producer":"formula-step"}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "deliverable empty reason stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"","producer":"formula-step"}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "unknown envelope field stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step","surprise":"x"}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "malformed json stays missing_outcome",
 			metadata: map[string]string{
 				"gc.coordinator_outcome.producer_disposition": "{not json",
 			},
@@ -275,21 +325,21 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 		{
 			name: "wrong contract_version stays missing_outcome",
 			metadata: map[string]string{
-				"gc.coordinator_outcome.producer_disposition": `{"contract_version":2,"disposition":"deliverable","work_id":"gc-attempt1"}`,
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":2,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step"}`,
 			},
 			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
 		},
 		{
 			name: "foreign work_id stays missing_outcome",
 			metadata: map[string]string{
-				"gc.coordinator_outcome.producer_disposition": typedClose("deliverable", "gc-someone-else"),
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-someone-else","recorded_by":"tester","reason":"shipped","producer":"formula-step"}`,
 			},
 			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
 		},
 		{
 			name: "unknown disposition stays missing_outcome",
 			metadata: map[string]string{
-				"gc.coordinator_outcome.producer_disposition": typedClose("mystery", attemptID),
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"mystery","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped"}`,
 			},
 			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
 		},

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -316,6 +316,16 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
 		},
 		{
+			// A valid envelope followed by trailing JSON/garbage must fail closed:
+			// json.Decoder consumes only the first value and DisallowUnknownFields
+			// guards only that first object.
+			name: "deliverable with trailing data stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step"} {"junk":1}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
 			name: "malformed json stays missing_outcome",
 			metadata: map[string]string{
 				"gc.coordinator_outcome.producer_disposition": "{not json",

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -218,25 +218,12 @@ func TestClassifyRetryAttemptCanceledIsTerminalNonRetry(t *testing.T) {
 	}
 }
 
-// TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome pins the graph.v2
-// controller missing_outcome race (gc-e2xqk). An attempt closed through the
-// gc-outcome-close typed contract records its disposition under
-// gc.coordinator_outcome.producer_disposition, leaving gc.outcome empty, and the
-// controller misread that as a missing outcome and minted a spurious retry.
-//
-// Only a fully validated *deliverable* close (an explicit producer-named success)
-// folds to pass, exactly once. A non-deliverable close ("intentionally not a
-// deliverable") is NOT synthesized to pass: the retry contract requires an explicit
-// gc.outcome and treats its absence as invalid, so it stays missing_outcome. The
-// deliverable envelope is accepted only when it is complete and self-referential —
-// contract_version 1, work_id == subject.ID, non-empty recorded_by and reason, a
-// known deliverable producer, and no unknown fields — so a truncated or schema-skewed
-// record cannot forge a pass.
+// TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome pins strict validation
+// of the typed close that reproduces gc-e2xqk.
 func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 	t.Parallel()
 
 	const attemptID = "gc-attempt1"
-	// A complete, valid deliverable typed close for attemptID.
 	const validDeliverable = `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step"}`
 
 	tests := []struct {
@@ -261,9 +248,6 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 			want: retryEvalResult{Outcome: "pass"},
 		},
 		{
-			// A deliberate non-deliverable (obsolete/no-op) close carries no producer
-			// and no gc.outcome. The retry contract requires an explicit gc.outcome, so
-			// this must NOT synthesize pass (gc-e2xqk P1); it stays missing_outcome.
 			name: "non-deliverable close stays missing_outcome",
 			metadata: map[string]string{
 				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"non-deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"obsolete"}`,
@@ -271,9 +255,6 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
 		},
 		{
-			// An arbitrary, novel producer string is accepted structurally: the actor
-			// kind is caller-supplied configuration, never matched against a hardcoded
-			// allowlist of role names (ZFC / zero hardcoded roles).
 			name: "deliverable with arbitrary producer folds as pass",
 			metadata: map[string]string{
 				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"novel-writer-42"}`,
@@ -316,9 +297,6 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
 		},
 		{
-			// A valid envelope followed by trailing JSON/garbage must fail closed:
-			// json.Decoder consumes only the first value and DisallowUnknownFields
-			// guards only that first object.
 			name: "deliverable with trailing data stays missing_outcome",
 			metadata: map[string]string{
 				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step"} {"junk":1}`,
@@ -361,7 +339,6 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := classifyRetryAttempt(beads.Bead{ID: attemptID, Metadata: tt.metadata})

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -2,6 +2,7 @@ package dispatch
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -215,6 +216,99 @@ func TestClassifyRetryAttemptCanceledIsTerminalNonRetry(t *testing.T) {
 	want := retryEvalResult{Outcome: "canceled"}
 	if got != want {
 		t.Fatalf("classifyRetryAttempt(canceled) = %+v, want %+v", got, want)
+	}
+}
+
+// TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome pins the graph.v2
+// controller missing_outcome race (gc-e2xqk). An attempt closed through the
+// gc-outcome-close typed contract records its disposition under
+// gc.coordinator_outcome.producer_disposition (plus gc.outcome.producer), leaving
+// gc.outcome empty. Before the fix that empty gc.outcome fell to the
+// missing_outcome transient branch and the controller minted a spurious retry
+// even though a valid typed outcome existed. A valid contract_version=1 clean
+// close — deliverable or non-deliverable, since gc-outcome-close never records a
+// failure — must fold as pass exactly once; a malformed, wrong-version,
+// foreign-work_id, or unknown-disposition record must stay missing_outcome.
+func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
+	t.Parallel()
+
+	const attemptID = "gc-attempt1"
+	typedClose := func(disposition, workID string) string {
+		return fmt.Sprintf(`{"contract_version":1,"disposition":%q,"work_id":%q,"recorded_by":"formula-step","reason":"done","producer":"formula-step"}`, disposition, workID)
+	}
+
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     retryEvalResult
+	}{
+		{
+			name: "deliverable typed close folds as pass",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": typedClose("deliverable", attemptID),
+				"gc.outcome.producer":                         "formula-step",
+			},
+			want: retryEvalResult{Outcome: "pass"},
+		},
+		{
+			name: "non-deliverable typed close folds as pass",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": typedClose("non-deliverable", attemptID),
+			},
+			want: retryEvalResult{Outcome: "pass"},
+		},
+		{
+			name: "explicit gc.outcome takes precedence over typed close",
+			metadata: map[string]string{
+				"gc.outcome": "pass",
+				"gc.coordinator_outcome.producer_disposition": typedClose("deliverable", attemptID),
+			},
+			want: retryEvalResult{Outcome: "pass"},
+		},
+		{
+			name: "malformed typed close stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": "{not json",
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "wrong contract_version stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":2,"disposition":"deliverable","work_id":"gc-attempt1"}`,
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "foreign work_id stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": typedClose("deliverable", "gc-someone-else"),
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "unknown disposition stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": typedClose("mystery", attemptID),
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name:     "no typed outcome stays missing_outcome",
+			metadata: map[string]string{},
+			want:     retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyRetryAttempt(beads.Bead{ID: attemptID, Metadata: tt.metadata})
+			if got != tt.want {
+				t.Fatalf("classifyRetryAttempt() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -240,6 +240,42 @@ func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {
 			want: retryEvalResult{Outcome: "pass"},
 		},
 		{
+			name: "valid deliverable close with passing verdict folds as pass",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step","passing_verdict":"evidence.reviewer_verdict"}`,
+				"gc.review_gate":            "consumed",
+				"evidence.reviewer_verdict": "pass",
+			},
+			want: retryEvalResult{Outcome: "pass"},
+		},
+		{
+			name: "passing verdict requires consumed review gate",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step","passing_verdict":"evidence.reviewer_verdict"}`,
+				"gc.review_gate":            "pass",
+				"evidence.reviewer_verdict": "pass",
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "passing verdict requires published pass",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step","passing_verdict":"review_verdict"}`,
+				"gc.review_gate": "consumed",
+				"review_verdict": "reject",
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
+			name: "unsupported passing verdict stays missing_outcome",
+			metadata: map[string]string{
+				"gc.coordinator_outcome.producer_disposition": `{"contract_version":1,"disposition":"deliverable","work_id":"gc-attempt1","recorded_by":"tester","reason":"shipped","producer":"formula-step","passing_verdict":"surprise"}`,
+				"gc.review_gate": "consumed",
+				"surprise":       "pass",
+			},
+			want: retryEvalResult{Outcome: "transient", Reason: "missing_outcome"},
+		},
+		{
 			name: "explicit gc.outcome takes precedence over typed close",
 			metadata: map[string]string{
 				"gc.outcome": "pass",


### PR DESCRIPTION
## Summary

- fold complete typed deliverable-close envelopes into retry PASS instead of minting duplicate attempts
- reject malformed, trailing, stale, cross-work, and incomplete envelopes fail-closed
- validate optional passing-verdict closes against the consumed review gate and published PASS
- add focused regression coverage for plain and reviewed close paths

## Recovery evidence

- recovered from land-failed bead `gc-e2xqk`; original branch was left untouched
- independent Claude cross-provider review: PASS on exact SHA `84464bd6197a2aefbf80f6b78177f0314a5998f3`
- erosion verdict: paid-down in `696cece45`

## Verification

- mandatory pre-push sharded fast gate: PASS (twice)
- `go test -race -count=1 ./internal/dispatch`: PASS
- `go test -cover ./internal/dispatch`: PASS (78.7% package)
- `go build ./cmd/gc/`: PASS
- `go vet ./...`: PASS
- pre-commit hook (`lint-changed`, generated-doc consistency, vet): PASS

Two unrelated full-suite environment/timing failures were captured without retrying them into green: `gc-8ytgh` and `gc-h8mek`. Neither failing package is touched by this PR.