### PR TITLE
fix(nudge): run queue TTL/max-attempts maintenance sweep unconditionally each dispatch tick

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -2453,6 +2453,31 @@ func recordNudgeDispatchSkips(cityPath string, counts map[string]int64) error {
 	})
 }
 
+// runNudgeQueueMaintenanceSweep runs the queue's recover/TTL-expiry/dead-
+// letter-retention passes over the whole queue, independent of whether any
+// pending item currently matches an open session. Every other maintenance
+// call site (claimDueQueuedNudgesMatching, listQueuedNudges,
+// listQueuedNudgesForTarget, ...) only runs these passes as a side effect of
+// an operation scoped to a specific agent/target, so an item whose target
+// never matches never gets swept by any of them. The supervisor dispatch
+// tick is the one path that iterates the whole queue every cycle regardless
+// of match outcome, so it owns running this sweep unconditionally.
+func runNudgeQueueMaintenanceSweep(cityPath string, now time.Time) error {
+	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	defer maint.close() //nolint:errcheck // best-effort
+	return withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
+		front := maint.frontForState(state)
+		deadline := noMaintenanceDeadline()
+		if err := recoverExpiredInFlightNudges(state, front, now, deadline); err != nil {
+			return err
+		}
+		if err := pruneExpiredQueuedNudges(state, front, now, deadline); err != nil {
+			return err
+		}
+		return pruneDeadQueuedNudges(state, front, now, deadline)
+	})
+}
+
 func pruneExpiredQueuedNudges(state *nudgeQueueState, front *nudgequeue.Store, now, deadline time.Time) error {
 	return pruneExpiredQueuedNudgesWithClock(state, front, now, deadline, clock.Real{})
 }

--- a/cmd/gc/nudge_dispatcher.go
+++ b/cmd/gc/nudge_dispatcher.go
@@ -124,6 +124,17 @@ func dispatchAllQueuedNudges(cityPath string, cfg *config.City, store, sessStore
 	if !nudgeDispatcherIsSupervisor(cfg) {
 		return 0, nil
 	}
+	now := time.Now()
+	// Run the queue's TTL/max-attempts maintenance sweep unconditionally,
+	// independent of whether any item below matches an open session. The
+	// per-session loop's only path to recover/prune is a successful claim in
+	// claimDueQueuedNudgesForTarget, which a structurally orphaned item
+	// (target agent has no open session, and never will again) can never
+	// reach — leaving it in Pending past its ExpiresAt forever. See
+	// ra-oudpha finding-3.
+	if err := runNudgeQueueMaintenanceSweep(cityPath, now); err != nil {
+		return 0, fmt.Errorf("nudge queue maintenance sweep: %w", err)
+	}
 	state, err := nudgequeue.LoadState(cityPath)
 	if err != nil {
 		return 0, fmt.Errorf("loading nudge queue: %w", err)
@@ -131,7 +142,6 @@ func dispatchAllQueuedNudges(cityPath string, cfg *config.City, store, sessStore
 	if len(state.Pending) == 0 && len(state.InFlight) == 0 {
 		return 0, nil
 	}
-	now := time.Now()
 	pendingAgents := make(map[string]bool, len(state.Pending))
 	for _, item := range state.Pending {
 		if item.Agent == "" {

--- a/cmd/gc/nudge_dispatcher_test.go
+++ b/cmd/gc/nudge_dispatcher_test.go
@@ -141,6 +141,53 @@ func TestDispatchAllQueuedNudgesEmptyQueue(t *testing.T) {
 	}
 }
 
+// TestDispatchAllQueuedNudgesSweepsExpiredOrphanEvenWithoutMatch guards
+// against ra-oudpha finding-3's orphan population: a queued item whose
+// target agent has no open session can never reach step 2's "matched"
+// check in the per-session loop, so it can never reach the sweep that
+// claimDueQueuedNudgesForTarget runs as a side effect of a successful
+// claim. Before the fix, such an item sat in Pending forever, past its
+// TTL, invisible to every maintenance pass. The dispatch tick must sweep
+// the whole queue unconditionally so TTL expiry (#4421 semantics) still
+// applies to items no open session will ever match.
+func TestDispatchAllQueuedNudgesSweepsExpiredOrphanEvenWithoutMatch(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
+	dir := t.TempDir()
+	// Created 25h ago, so ExpiresAt (created+24h TTL) is already 1h in the
+	// past. "ghost-agent" has no open session in the snapshot below and
+	// never will, so it can never satisfy the per-session loop's match step.
+	item := newQueuedNudge("ghost-agent", "msg", time.Now().Add(-25*time.Hour))
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	delivered, err := dispatchAllQueuedNudges(dir, supervisorCfg(), nil, nil, nil, newSessionBeadSnapshot(nil), nil)
+	if err != nil {
+		t.Fatalf("dispatchAllQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Fatalf("delivered = %d, want 0", delivered)
+	}
+
+	// Read the raw persisted state (not via listQueuedNudges, which would
+	// run its own maintenance sweep as a side effect and mask the bug).
+	state, err := nudgequeue.LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(state.Pending) != 0 {
+		t.Fatalf("pending = %d, want 0 (expired orphan should have been swept by the dispatch tick)", len(state.Pending))
+	}
+	if len(state.Dead) != 1 {
+		t.Fatalf("dead = %d, want 1", len(state.Dead))
+	}
+	if state.Dead[0].LastError != "expired" {
+		t.Fatalf("dead[0].LastError = %q, want %q", state.Dead[0].LastError, "expired")
+	}
+}
+
 func TestDispatchAllQueuedNudgesSkipsNotYetDue(t *testing.T) {
 	clearGCEnv(t)
 	disableManagedDoltRecoveryForTest(t)


### PR DESCRIPTION
## Summary

Runs the nudge queue's TTL/max-attempts maintenance sweep unconditionally on
every supervisor-side dispatch tick, instead of only as a side effect of a
claim/list call scoped to one matched agent.

## Problem

`dispatchAllQueuedNudges` (`cmd/gc/nudge_dispatcher.go`) iterates every
currently-open session and, for each one, checks whether any pending queue
item's agent key matches it. Only on a match does it ever reach
`claimDueQueuedNudgesForTarget`, which is the *only* code path (shared with
`listQueuedNudges` / `listQueuedNudgesForTarget`) that runs the queue's
recover/TTL-expiry/dead-letter-retention maintenance pass
(`recoverExpiredInFlightNudges` + `pruneExpiredQueuedNudges` +
`pruneDeadQueuedNudges`).

A queued item whose target agent has **no currently-open session** can never
satisfy that match — the `OpenInfo` that would trigger it is gone, often
permanently (pool/session-generation churn). Such an item then never reaches
any maintenance-pass call site and sits in `Pending` forever, past its
`ExpiresAt`, invisible to every existing instrument.

Live evidence (ra-oudpha finding-3, mechanic J, 2026-08-05): 61 pending
queue entries with `last_attempt_at`/`claimed_at` still zero after 9+ hours
of continuously-firing dispatch ticks. ~53 of them targeted agents with no
open session at all — permanently unmatchable, and (per the sampled
`created_at` values) already past their 24h TTL.

## Fix

`dispatchAllQueuedNudges` now runs a new `runNudgeQueueMaintenanceSweep`
helper unconditionally, once per tick, right after confirming supervisor
mode — independent of whether the tick's per-session loop matches anything.
The helper is the same recover/prune sequence already used by
`claimDueQueuedNudgesMatching` / `listQueuedNudges` /
`listQueuedNudgesForTarget`, factored out so the dispatch tick can invoke it
directly under its own `withNudgeQueueState` transaction.

This is upstream-worthy per #4421's existing TTL/max-attempts semantics — it
closes a general queue-hygiene gap (any maintenance-call-site-shaped queue
has this bug if it gains a "some scan never touches every item" path), not
something fork-specific.

## Testing

New test `TestDispatchAllQueuedNudgesSweepsExpiredOrphanEvenWithoutMatch`
(`cmd/gc/nudge_dispatcher_test.go`): enqueues an item for `ghost-agent`
(created 25h ago, so its 24h TTL has already elapsed) with an empty session
snapshot (no open session will ever match it), runs one
`dispatchAllQueuedNudges` tick, then reads the *raw* persisted state via
`nudgequeue.LoadState` (not `listQueuedNudges`, which would run its own
maintenance sweep as a side effect and mask the bug) to assert the item
moved from `Pending` to `Dead` with `LastError == "expired"`.

- Fail-before proven: reverted to pre-fix `dispatchAllQueuedNudges`, the new
  test fails with `pending = 1, want 0`.
- Pass-after: `go test ./cmd/gc/... -run TestDispatchAllQueuedNudgesSweepsExpiredOrphanEvenWithoutMatch -v` — PASS.
- `go test ./cmd/gc/... -run 'TestDispatchAllQueuedNudges|TestClaimDueQueuedNudges|TestListQueuedNudges|TestNudge'` — all PASS (no regressions in the surrounding nudge suite).
- `go build ./...` and `go vet ./...` — clean.
- Full `go test ./cmd/gc/...`: only 2 failures, `TestResolveImportRootFallsBackToStandalonePackDir` and `TestResolveImportRootPrefersNearestPackUnderCity` — confirmed pre-existing macOS `/var` vs `/private/var` tmpdir-symlink flakes by reproducing them identically on an unmodified clone of the same commit; unrelated to this change.

## Scope

Touches only `cmd/gc/nudge_dispatcher.go` (call the sweep) and
`cmd/gc/cmd_nudge.go` (new `runNudgeQueueMaintenanceSweep` helper, built from
existing pieces). No behavior change for matched targets; no change to
prune/expiry semantics, only to when they run.
