### PR TITLE
fix(dispatch): retry temporarily blocked workflow finalize

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -463,6 +463,9 @@ func IsTransientControllerError(err error) bool {
 		"database is locked",
 		"database table is locked",
 		"sqlite_busy",
+		// A workflow root may remain blocked briefly while sibling work closes.
+		// Retrying preserves the open finalize bead for the next serve cycle.
+		"cannot close blocked issue",
 		// bd's client-side Dolt breaker fails fast while the server is down.
 		// These errors are recoverable, so a long-running control dispatcher
 		// must keep sweeping rather than exit permanently during the outage.

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -1696,6 +1696,7 @@ func TestIsTransientControllerError(t *testing.T) {
 		{name: "dolt breaker open", err: errors.New("Error: failed to open database: dolt circuit breaker is open: server appears down, failing fast (cooldown 5s)"), want: true},
 		{name: "dolt breaker failing fast", err: errors.New(`querying control work for fixture/core.control-dispatcher: running work query "bd ready": exit status 1: server appears down, failing fast (cooldown 5s)`), want: true},
 		{name: "dolt server unreachable", err: errors.New("begin read tx: dolt server unreachable"), want: true},
+		{name: "workflow root close blocked", err: errors.New("gsp-p68ch6: completing workflow head: updating bead \"gsp-p68ch6\": exit status 1: cannot close blocked issue: gsp-p68ch6 is blocked by [gsp-yl7fpr]"), want: true},
 		{name: "non work query sigterm", err: errors.New("starting provider: exit status 143: Terminated"), want: false},
 		{name: "bad step spec", err: errors.New("deserializing step spec: invalid character 'n'"), want: false},
 	}


### PR DESCRIPTION
## Summary

- treat `cannot close blocked issue` as a transient controller error
- preserve workflow-finalize beads for retry instead of hard-quarantining them
- add regression coverage for the wrapped beads error

Closes #4975

## Verification

- `go test ./internal/dispatch`
- `go vet ./internal/dispatch/...`
- pre-push `make test-fast-parallel` (all fast jobs passed)
- isolated rerun of transient Herdr timeout: `go test ./internal/runtime/herdr -run TestHerdrConformance/Start_DuplicateReturnsError -count=1`