### PR TITLE
fix(controller): close terminal workflow residue

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4148,7 +4148,8 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		if sessionName != "" && strings.TrimSpace(wb.Metadata[beadmeta.SessionNameMetadataKey]) != sessionName {
 			patch[beadmeta.SessionNameMetadataKey] = sessionName
 		}
-		if workDir != "" && strings.TrimSpace(wb.Metadata[beadmeta.WorkDirMetadataKey]) != workDir {
+		if workDir != "" && strings.TrimSpace(wb.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
+			(!sbInfo.PoolManaged || workDirStampHasOwnershipEvidence(wb.Metadata, workDir)) {
 			patch[beadmeta.WorkDirMetadataKey] = workDir
 		}
 		if len(patch) > 0 {
@@ -4161,8 +4162,21 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		// workBeads and route-time stamping skips it for pool agents. The
 		// dashboard's root-only snapshot reads the root's own metadata, so a
 		// worked step back-fills its root via gc.root_bead_id. (#2843)
-		stampRunRootFromStep(store, wb, sessionName, workDir, stampedRoots, stderr)
+		stampRunRootFromStep(store, wb, sessionName, workDir, !sbInfo.PoolManaged, stampedRoots, stderr)
 	}
+}
+
+// workDirStampHasOwnershipEvidence reports whether existing bead metadata
+// already identifies workDir as the work artifact directory. Session
+// reconciliation of a pool session observes a slot cwd; it does not create or
+// own a managed worktree, so it must not manufacture gc.work_dir on an
+// arbitrary routed bead. Doing so turns a pool slot label into incomplete
+// worktree ownership evidence and makes demand fail closed. The worktree
+// creator writes the legacy artifact path first; reconciliation may only mirror
+// that value. Non-pool sessions retain the historical observability stamp.
+func workDirStampHasOwnershipEvidence(metadata map[string]string, workDir string) bool {
+	legacy := strings.TrimSpace(metadata[beadmeta.LegacyWorkDirMetadataKey])
+	return legacy != "" && legacy == workDir
 }
 
 // stampRunRootFromStep copies a step's resolved session_name/work_dir onto its
@@ -4170,7 +4184,7 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 // the root and writes only the keys that differ. Best-effort — a root that is
 // in another store, already gone, or already stamped is silently skipped (a
 // cross-store root gets stamped on its own store's reconcile pass).
-func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workDir string, stampedRoots map[string]struct{}, stderr io.Writer) {
+func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workDir string, allowUnownedWorkDir bool, stampedRoots map[string]struct{}, stderr io.Writer) {
 	rootID := strings.TrimSpace(step.Metadata[beadmeta.RootBeadIDMetadataKey])
 	if rootID == "" || rootID == step.ID {
 		return
@@ -4189,7 +4203,8 @@ func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workD
 	if sessionName != "" && strings.TrimSpace(root.Metadata[beadmeta.SessionNameMetadataKey]) != sessionName {
 		patch[beadmeta.SessionNameMetadataKey] = sessionName
 	}
-	if workDir != "" && strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) != workDir {
+	if workDir != "" && strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
+		(allowUnownedWorkDir || workDirStampHasOwnershipEvidence(root.Metadata, workDir)) {
 		patch[beadmeta.WorkDirMetadataKey] = workDir
 	}
 	if len(patch) == 0 {

--- a/cmd/gc/build_desired_state_session_stamp_test.go
+++ b/cmd/gc/build_desired_state_session_stamp_test.go
@@ -63,6 +63,32 @@ func TestStampRunSessionIdentityStampsInProgressAssignedBead(t *testing.T) {
 	}
 }
 
+func TestStampRunSessionIdentityDoesNotManufactureWorktreeEvidence(t *testing.T) {
+	const (
+		sessionName = "polecat-gc-734732"
+		slotDir     = "/home/ds/gascity-worktrees/polecat-slots/polecat-2"
+	)
+	run := beads.Bead{ID: "gc-demand", Type: "task", Status: "in_progress", Assignee: sessionName}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+	store := &countingStore{Store: mem}
+	poolSession := stampTestSession(sessionName, slotDir)
+	poolSession.Metadata["pool_managed"] = "true"
+	sessions := newSessionBeadSnapshot([]beads.Bead{poolSession})
+
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+
+	got, err := mem.Get(run.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", run.ID, err)
+	}
+	if got.Metadata["gc.session_name"] != sessionName {
+		t.Fatalf("gc.session_name = %q, want %q", got.Metadata["gc.session_name"], sessionName)
+	}
+	if value, exists := got.Metadata["gc.work_dir"]; exists {
+		t.Fatalf("gc.work_dir was manufactured as %q from a pool slot; worktree ownership evidence must come from the worktree creator", value)
+	}
+}
+
 func TestStampRunSessionIdentityPropagatesToRunRoot(t *testing.T) {
 	// #2843: a worked in-progress STEP back-fills its workflow ROOT (which the
 	// dashboard's root-only snapshot reads). The root is a control-lane bead,

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/mail/beadmail"
+	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
@@ -165,6 +166,13 @@ func (m *memoryWispGC) runGC(graphStore beads.GraphStore, mailStore beads.MailSt
 			log.Printf("wisp gc: closed %d generated spec sidecars for closed workflow roots", closedSpecs)
 		}
 
+		closedMembers, memberErr := closeGeneratedMembersForClosedRoots(store)
+		if memberErr != nil {
+			deleteErr = errors.Join(deleteErr, fmt.Errorf("closing generated members for terminal workflow roots: %w", memberErr))
+		} else if closedMembers > 0 {
+			log.Printf("wisp gc: closed %d generated members for terminal workflow roots", closedMembers)
+		}
+
 		// Close abandoned OPEN roots BEFORE the closed-root purge below so a
 		// root the sweep closes this tick can be collected by the purge in the
 		// same tick when it has already aged past m.ttl (the purge gates on
@@ -210,6 +218,30 @@ func (m *memoryWispGC) runGC(graphStore beads.GraphStore, mailStore beads.MailSt
 	}
 
 	return purged, deleteErr
+}
+
+// closeGeneratedMembersForClosedRoots repairs terminal workflow roots whose
+// finalizer, supersession, or partial materialization left generated members
+// open. Closed roots are the authority boundary: live roots are never listed
+// and therefore never touched. Each subtree close is ordered and idempotent.
+func closeGeneratedMembersForClosedRoots(store beads.Store) (int, error) {
+	roots, err := closedWispGCEntries(store)
+	if err != nil {
+		return 0, err
+	}
+	closed := 0
+	var closeErr error
+	for _, root := range roots {
+		n, err := molecule.CloseSubtreeWithMetadata(store, root.ID, map[string]string{
+			beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped,
+			"close_reason":              sourceworkflow.WorkflowSkippedCloseReason,
+		})
+		closed += n
+		if err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("closing terminal workflow subtree %s: %w", root.ID, err))
+		}
+	}
+	return closed, closeErr
 }
 
 // wispGCRootSelector pairs a List selector with a short label used for error

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -110,6 +110,57 @@ func TestWispGC_NothingExpired(t *testing.T) {
 	}
 }
 
+func TestWispGCClosesGeneratedMembersOnlyForTerminalRoots(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBeadWithMetadata("completed-root", now.Add(-30*time.Minute), "closed", "task", map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.outcome":          "pass",
+		}),
+		makeGCBeadWithMetadata("completed-step", now.Add(-30*time.Minute), "open", "task", map[string]string{
+			"gc.root_bead_id": "completed-root",
+		}),
+		makeGCBeadWithMetadata("superseded-root", now.Add(-30*time.Minute), "closed", "task", map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.outcome":          "canceled",
+		}),
+		makeGCBeadWithMetadata("partial-step", now.Add(-30*time.Minute), "open", "task", map[string]string{
+			"gc.root_bead_id": "superseded-root",
+		}),
+		makeGCBeadWithMetadata("live-root", now.Add(-30*time.Minute), "in_progress", "task", map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		}),
+		makeGCBeadWithMetadata("live-step", now.Add(-30*time.Minute), "open", "task", map[string]string{
+			"gc.root_bead_id": "live-root",
+		}),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	if _, err := wg.runGC(beads.GraphStore{Store: store}, beads.MailStore{Store: store}, now); err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+
+	for _, id := range []string{"completed-step", "partial-step"} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" || got.Metadata["gc.outcome"] != "skipped" {
+			t.Fatalf("%s = status %q outcome %q, want closed/skipped", id, got.Status, got.Metadata["gc.outcome"])
+		}
+	}
+	live, err := store.Get("live-step")
+	if err != nil {
+		t.Fatalf("Get(live-step): %v", err)
+	}
+	if live.Status != "open" {
+		t.Fatalf("live-step status = %q, want open", live.Status)
+	}
+}
+
 func TestWispGC_ClosesOpenSpecSidecarsForClosedWorkflowRoots(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -841,8 +841,21 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 		}
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow head: %w", rootID, err))
 	}
+	// Generated spec sidecars are topology records rather than executable
+	// members; preserve their established successful cleanup outcome before the
+	// remaining subtree is skipped.
 	if _, err := sourceworkflow.CloseSpecSidecarsForRoot(store, rootID, sourceworkflow.WorkflowSpecSidecarClosedReason); err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing workflow spec sidecars: %w", rootID, err))
+	}
+	// A terminal root makes every still-open generated member non-executable.
+	// Close the remainder as one ordered, idempotent batch before completing
+	// the finalizer. This also repairs partially materialized workflows whose
+	// unused steps were never reached by ordinary dependency progression.
+	if _, err := molecule.CloseSubtreeWithMetadata(store, rootID, map[string]string{
+		beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped,
+		"close_reason":              sourceworkflow.WorkflowSkippedCloseReason,
+	}); err != nil {
+		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing terminal workflow members: %w", rootID, err))
 	}
 	if outcome == beadmeta.OutcomePass {
 		if err := closeSourceBeadChain(store, rootID, opts); err != nil {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -2764,6 +2764,57 @@ func TestProcessWorkflowFinalizeClosesOpenSpecSidecars(t *testing.T) {
 	}
 }
 
+func TestProcessWorkflowFinalizeClosesRemainingGeneratedMembers(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	remaining := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "partially materialized step that can no longer execute",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "unused",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("workflow result = %+v, want processed workflow-pass", result)
+	}
+
+	remainingAfter := mustGetBead(t, store, remaining.ID)
+	if remainingAfter.Status != "closed" {
+		t.Fatalf("remaining generated member status = %q, want closed", remainingAfter.Status)
+	}
+	if got := remainingAfter.Metadata["gc.outcome"]; got != "skipped" {
+		t.Fatalf("remaining generated member gc.outcome = %q, want skipped", got)
+	}
+	finalizerAfter := mustGetBead(t, store, finalizer.ID)
+	if got := finalizerAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("finalizer gc.outcome = %q, want pass", got)
+	}
+}
+
 func TestProcessWorkflowFinalizeTreatsQuarantinedControlAsFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -83,6 +83,16 @@ func ListSubtree(store beads.Store, rootID string) ([]beads.Bead, error) {
 // Parent/child depth (deepest first) is used as the tie-breaker when no
 // blocks edge constrains the order.
 func CloseSubtree(store beads.Store, rootID string) (int, error) {
+	return CloseSubtreeWithMetadata(store, rootID, map[string]string{
+		"close_reason": SubtreeClosedReason,
+	})
+}
+
+// CloseSubtreeWithMetadata closes the root bead and every open descendant,
+// stamping metadata on each newly closed bead. It preserves CloseSubtree's
+// descendant-first, blocker-first ordering and is idempotent for an already
+// closed subtree.
+func CloseSubtreeWithMetadata(store beads.Store, rootID string, metadata map[string]string) (int, error) {
 	matched, err := ListSubtree(store, rootID)
 	if err != nil {
 		return 0, err
@@ -141,7 +151,5 @@ func CloseSubtree(store beads.Store, rootID string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return store.CloseAll(ordered, map[string]string{
-		"close_reason": SubtreeClosedReason,
-	})
+	return store.CloseAll(ordered, metadata)
 }


### PR DESCRIPTION
Closes gc-szyof.\n\n- atomically skips generated workflow members when a root reaches terminal disposition\n- repairs terminal-root residue during wisp GC without touching live roots\n- prevents pool session cwd stamping from manufacturing incomplete worktree evidence\n\nVerification: make test-fast-parallel; go vet ./...; pre-commit and push gates.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2903 — extends the closed-workflow-root cleanup from that tracker's stack — where generated spec sidecars under closed roots were autoclosed — to generated workflow members, which the finalizer and wisp GC now close when a root reaches terminal disposition. It is a follow-on change in the same open-bead-leak class rather than part of the enumerated stacked-PR series, and it does not cover the remaining items listed there.
- Related to #4449 — addresses part of this in stampRunSessionIdentity: for pool-managed sessions the slot's process cwd is no longer stamped into a work bead's gc.work_dir, and stampRunRootFromStep no longer propagates it to the workflow root unless prior metadata already identifies that path as the artifact dir; non-pool sessions still stamp the process dir, and the separate process-cwd key plus clearing of already-poisoned stamps described in that issue are not part of this change

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->