### PR TITLE
feat(doctor): add order-outcome-healthy — surface orders that fire on schedule but always fail

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -247,6 +247,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		register(doctor.NewSkillDanglingSinkCheck(doctorSkillStaticSinks(cityPath, cfg), materialize.LegacyOwnedRootsFor(cityPath), doctorLiveSessionSinks(cityPath, cfg)))
 		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath, doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr))))
+		register(doctor.NewOrderOutcomeHealthyCheck(cfg, cityPath))
 		register(newCodexHooksDriftCheck(cityPath, codexHookWorkDirs(cityPath, cfg)))
 		register(doctor.NewRigPackCoverageCheck(cfg, cityPath))
 		register(newPackRuntimesDoctorCheck(cfg))

--- a/cmd/gc/cmd_doctor_order_outcome_test.go
+++ b/cmd/gc/cmd_doctor_order_outcome_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestBuildDoctorChecksRegistersOrderOutcomeHealthy(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_DOLT", "skip")
+	cfg := &config.City{Workspace: config.Workspace{Name: "demo"}}
+
+	names := doctorCheckNames(buildDoctorChecks(cityDir, cfg, nil, buildDoctorChecksOpts{
+		ControllerRunning:    false,
+		SkipCityDoltCheck:    true,
+		SkipManagedDoltCheck: true,
+	}))
+
+	firing := doctorCheckIndex(names, "order-firing-current")
+	if firing < 0 {
+		t.Fatalf("order-firing-current missing: %v", names)
+	}
+	outcome := doctorCheckIndex(names, "order-outcome-healthy")
+	if outcome != firing+1 {
+		t.Fatalf("order-outcome-healthy index = %d, want immediately after order-firing-current at %d; names=%v", outcome, firing, names)
+	}
+}

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -36,6 +36,7 @@ service-secrets-perms
 skill-collision
 skill-dangling-sink
 order-firing-current
+order-outcome-healthy
 codex-hooks-drift
 rig-pack-coverage
 pack-runtimes

--- a/internal/doctor/checks_order_outcome.go
+++ b/internal/doctor/checks_order_outcome.go
@@ -1,0 +1,298 @@
+package doctor
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+const (
+	orderOutcomeHealthyName = "order-outcome-healthy"
+
+	// orderOutcomeInspectHintFmt mirrors the sibling check's
+	// orderFiringInspectHintFmt so the pair emits consistently-shaped hints.
+	orderOutcomeInspectHintFmt = "Inspect with: gc order check && gc order history %s"
+
+	// orderOutcomeFailureThreshold is the consecutive-failure count that flags an
+	// order. Three, not two: two in a row is a plausible transient for anything
+	// touching the network or a lock. Three, not five: on a 6h order five failures
+	// is 30h before anything surfaces.
+	orderOutcomeFailureThreshold = 3
+
+	// orderOutcomeStartGrace covers gastownhall/gascity#3898 — for ~5 minutes
+	// after a supervisor start, exec orders fail spuriously because dispatch
+	// begins before pack staging completes. 2x margin on the observed window.
+	orderOutcomeStartGrace = 10 * time.Minute
+)
+
+// nearControllerStart reports whether ts falls within grace after any controller
+// start. Every start is checked, not just the newest: two restarts with no
+// successful run between them would otherwise leave the older burst counted and
+// manufacture a false positive.
+func nearControllerStart(ts time.Time, starts []time.Time, grace time.Duration) bool {
+	if grace <= 0 {
+		return false
+	}
+	for _, start := range starts {
+		if start.IsZero() || ts.Before(start) {
+			continue
+		}
+		if ts.Sub(start) <= grace {
+			return true
+		}
+	}
+	return false
+}
+
+// consecutiveOrderFailures counts trailing order.failed events for one order.
+//
+// outcomes must hold order.completed and order.failed events ordered by Seq
+// ascending; the walk runs newest-first and stops at the first success.
+//
+// A success always ends the streak, even if it falls within the post-start grace
+// window. The grace window skips only spurious FAILURES (neither counting them nor
+// allowing them to break the streak); a success is proof the order works.
+//
+// Failures inside the post-start grace window are SKIPPED, not reset. Resetting
+// would let a frequently-restarting city zero a genuinely broken order's streak
+// on every restart, which is the opposite of what this check is for.
+//
+// sawOutcome distinguishes "ran and succeeded" from "never produced an outcome";
+// order-firing-current already owns the never-fired case.
+//
+// skipped counts trailing failures that were inside the post-start grace
+// window and therefore excluded from streak. Callers need this to avoid
+// reporting "last run succeeded" when every trailing run actually failed but
+// was suppressed as a spurious post-restart burst — see classifyOrderOutcome.
+func consecutiveOrderFailures(outcomes []events.Event, subject string, starts []time.Time, grace time.Duration) (streak int, lastMessage string, sawOutcome bool, skipped int) {
+	lastMessageSet := false
+
+	for i := len(outcomes) - 1; i >= 0; i-- {
+		event := outcomes[i]
+		if event.Subject != subject {
+			continue
+		}
+		sawOutcome = true
+		if event.Type != events.OrderFailed {
+			break
+		}
+		if nearControllerStart(event.Ts, starts, grace) {
+			skipped++
+			continue
+		}
+		streak++
+		if !lastMessageSet {
+			lastMessage = event.Message
+			lastMessageSet = true
+		}
+	}
+
+	return streak, lastMessage, sawOutcome, skipped
+}
+
+// classifyOrderOutcome turns one order's failure streak into a doctor result.
+//
+// skipped is the grace-window-skipped-failure count from consecutiveOrderFailures.
+// When streak == 0 but skipped > 0, every trailing run actually failed (just
+// inside the post-start grace window); reporting "last run succeeded" would be
+// a false statement in the diagnostic tool at exactly the moment an operator is
+// most likely reading it — just after a restart.
+func classifyOrderOutcome(order orders.Order, streak int, threshold int, lastMessage string, sawOutcome bool, skipped int) (CheckStatus, string) {
+	name := orderDisplayName(order)
+
+	if !sawOutcome {
+		return StatusOK, fmt.Sprintf("%s: no completed runs yet", name)
+	}
+	if streak == 0 {
+		if skipped > 0 {
+			return StatusOK, fmt.Sprintf("%s: %d recent failure(s) within controller-start grace window", name, skipped)
+		}
+		return StatusOK, fmt.Sprintf("%s: last run succeeded", name)
+	}
+	if streak < threshold {
+		return StatusOK, fmt.Sprintf("%s: %d consecutive failure(s), under threshold %d", name, streak, threshold)
+	}
+
+	detail := fmt.Sprintf("%s: %d consecutive failures", name, streak)
+	if strings.TrimSpace(lastMessage) != "" {
+		detail = fmt.Sprintf("%s, last %q", detail, lastMessage)
+	}
+	return StatusWarning, detail
+}
+
+// OrderOutcomeHealthyCheck reports scheduled orders failing repeatedly.
+//
+// Sibling to OrderFiringCurrentCheck, which answers "did it run?" while this
+// answers "did it succeed?". An order that fires faithfully on schedule and fails
+// every time leaves order-firing-current green, so the failure is invisible: the
+// only trace is order.failed in the event log, which nobody reads unprompted.
+type OrderOutcomeHealthyCheck struct {
+	cfg       *config.City
+	cityPath  string
+	threshold int
+	grace     time.Duration
+}
+
+// NewOrderOutcomeHealthyCheck creates the repeated-order-failure check.
+func NewOrderOutcomeHealthyCheck(cfg *config.City, cityPath string) *OrderOutcomeHealthyCheck {
+	return &OrderOutcomeHealthyCheck{
+		cfg:       cfg,
+		cityPath:  cityPath,
+		threshold: orderOutcomeFailureThreshold,
+		grace:     orderOutcomeStartGrace,
+	}
+}
+
+// Name returns the check identifier shown by gc doctor.
+func (c *OrderOutcomeHealthyCheck) Name() string { return orderOutcomeHealthyName }
+
+// CanFix reports whether the check can repair a failing order. It cannot:
+// remediation depends entirely on why the order fails.
+func (c *OrderOutcomeHealthyCheck) CanFix() bool { return false }
+
+// Fix is a no-op for the reason given on CanFix.
+func (c *OrderOutcomeHealthyCheck) Fix(_ *CheckContext) error { return nil }
+
+// Run counts each scheduled order's trailing consecutive failures.
+//
+// Unlike order-firing-current this needs no goroutine-plus-timeout guard: that
+// check wraps its work because the order-history resolver opens the beads/Dolt
+// store without accepting a context. This one reads only the event log.
+func (c *OrderOutcomeHealthyCheck) Run(ctx *CheckContext) *CheckResult {
+	// This check is advisory on every path: a failing order must not gate gc doctor.
+	// Blocking would fail gc doctor outright and gate every clean-doctor dependency
+	// on transient order breakage, including during maintenance. SeverityAdvisory
+	// is the only source of truth, set here at construction.
+	result := &CheckResult{Name: c.Name(), Severity: SeverityAdvisory}
+	if c.cfg == nil {
+		result.Status = StatusOK
+		result.Message = "no city config loaded"
+		return result
+	}
+
+	cityPath := c.cityPath
+	if cityPath == "" && ctx != nil {
+		cityPath = ctx.CityPath
+	}
+	if cityPath == "" {
+		result.Status = StatusError
+		result.Message = "city path unavailable"
+		return result
+	}
+
+	// Same helper order-firing-current uses, so the two checks can never
+	// disagree about which orders are in scope.
+	allOrders, err := scanOrderFiringCurrentOrders(cityPath, c.cfg)
+	if err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("scan orders: %v", err)
+		return result
+	}
+
+	eventPath := filepath.Join(cityPath, citylayout.RuntimeRoot, "events.jsonl")
+	outcomes, err := readOrderOutcomeEvents(eventPath)
+	if err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("read order outcome events: %v", err)
+		return result
+	}
+	starts, err := controllerStartTimes(eventPath)
+	if err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("read controller start events: %v", err)
+		return result
+	}
+
+	worst := StatusOK
+	monitored := 0
+	failing := 0
+	var firstFailingHint string
+	suspendedRigs := orderFiringCurrentSuspendedRigs(c.cfg)
+
+	for _, order := range allOrders {
+		// Manual and event-triggered orders are out of scope by construction,
+		// matching the sibling check. This is what keeps a manual order that was
+		// abandoned mid-failure from alarming forever, with no recency heuristic
+		// needed: it simply is not in the monitored set.
+		if order.Trigger != "cron" && order.Trigger != "cooldown" {
+			continue
+		}
+		if orderFiringCurrentOrderSuspended(suspendedRigs, order) {
+			continue
+		}
+		monitored++
+
+		streak, lastMessage, sawOutcome, skipped := consecutiveOrderFailures(outcomes, order.ScopedName(), starts, c.grace)
+		status, detail := classifyOrderOutcome(order, streak, c.threshold, lastMessage, sawOutcome, skipped)
+		worst = worseStatus(worst, status)
+		result.Details = append(result.Details, detail)
+		if status != StatusOK {
+			failing++
+			if firstFailingHint == "" {
+				// gc order history takes a bare name positionally and filters
+				// on a.Name; the scoped form matches zero orders on the
+				// local-iterator path used when the supervisor API is
+				// unavailable — exactly when someone is debugging a broken
+				// city. orderHistoryHintTarget yields the --rig form instead.
+				firstFailingHint = orderHistoryHintTarget(order)
+			}
+		}
+	}
+
+	if monitored == 0 {
+		result.Status = StatusOK
+		result.Message = "no cron or cooldown orders"
+		return result
+	}
+
+	result.Status = worst
+	if worst == StatusOK {
+		result.Message = "all scheduled orders succeeding"
+	} else {
+		result.Message = fmt.Sprintf("%d order(s) failing repeatedly", failing)
+		result.FixHint = fmt.Sprintf(orderOutcomeInspectHintFmt, firstFailingHint)
+	}
+	return result
+}
+
+// readOrderOutcomeEvents returns order.completed and order.failed merged in Seq
+// order. events.Filter matches a single Type, hence two reads.
+func readOrderOutcomeEvents(eventPath string) ([]events.Event, error) {
+	completed, err := events.ReadFiltered(eventPath, events.Filter{Type: events.OrderCompleted})
+	if err != nil {
+		return nil, err
+	}
+	failed, err := events.ReadFiltered(eventPath, events.Filter{Type: events.OrderFailed})
+	if err != nil {
+		return nil, err
+	}
+	merged := make([]events.Event, 0, len(completed)+len(failed))
+	merged = append(merged, completed...)
+	merged = append(merged, failed...)
+	// Seq, not Ts: the log is append-only and seq-ordered, and two events in the
+	// same second would otherwise sort arbitrarily.
+	sort.Slice(merged, func(i, j int) bool { return merged[i].Seq < merged[j].Seq })
+	return merged, nil
+}
+
+// controllerStartTimes returns every controller.started timestamp. The sibling
+// check's latestControllerStartedAt returns only the newest, which is not enough
+// here — see nearControllerStart.
+func controllerStartTimes(eventPath string) ([]time.Time, error) {
+	startEvents, err := events.ReadFiltered(eventPath, events.Filter{Type: events.ControllerStarted})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]time.Time, 0, len(startEvents))
+	for _, event := range startEvents {
+		out = append(out, event.Ts)
+	}
+	return out, nil
+}

--- a/internal/doctor/checks_order_outcome_test.go
+++ b/internal/doctor/checks_order_outcome_test.go
@@ -1,0 +1,518 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// outcomeEvent builds one order.completed / order.failed event. seq is what the
+// counter orders by, so tests control sequence explicitly.
+func outcomeEvent(seq uint64, subject, eventType string, ts time.Time, message string) events.Event {
+	return events.Event{Seq: seq, Type: eventType, Ts: ts, Subject: subject, Message: message}
+}
+
+func TestConsecutiveOrderFailuresCountsTrailingFailures(t *testing.T) {
+	base := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	outcomes := []events.Event{
+		outcomeEvent(1, "refresh-family-clones:rig:st", events.OrderCompleted, base, ""),
+		outcomeEvent(2, "refresh-family-clones:rig:st", events.OrderFailed, base.Add(6*time.Hour), "exit status 128"),
+		outcomeEvent(3, "refresh-family-clones:rig:st", events.OrderFailed, base.Add(12*time.Hour), "exit status 128"),
+		outcomeEvent(4, "refresh-family-clones:rig:st", events.OrderFailed, base.Add(18*time.Hour), "exit status 128"),
+	}
+
+	streak, lastMessage, sawOutcome, skipped := consecutiveOrderFailures(outcomes, "refresh-family-clones:rig:st", nil, 10*time.Minute)
+
+	if streak != 3 {
+		t.Fatalf("streak = %d, want 3", streak)
+	}
+	if lastMessage != "exit status 128" {
+		t.Fatalf("lastMessage = %q, want %q", lastMessage, "exit status 128")
+	}
+	if !sawOutcome {
+		t.Fatal("sawOutcome = false, want true")
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0 — no starts provided", skipped)
+	}
+}
+
+func TestConsecutiveOrderFailuresStopsAtSuccess(t *testing.T) {
+	base := time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+	// The dolt-remotes-patrol shape: many lifetime failures, currently healthy.
+	outcomes := []events.Event{
+		outcomeEvent(1, "dolt-remotes-patrol", events.OrderFailed, base, "exit status 1"),
+		outcomeEvent(2, "dolt-remotes-patrol", events.OrderFailed, base.Add(15*time.Minute), "exit status 1"),
+		outcomeEvent(3, "dolt-remotes-patrol", events.OrderFailed, base.Add(30*time.Minute), "exit status 1"),
+		outcomeEvent(4, "dolt-remotes-patrol", events.OrderCompleted, base.Add(45*time.Minute), ""),
+	}
+
+	streak, _, sawOutcome, _ := consecutiveOrderFailures(outcomes, "dolt-remotes-patrol", nil, 10*time.Minute)
+
+	if streak != 0 {
+		t.Fatalf("streak = %d, want 0", streak)
+	}
+	if !sawOutcome {
+		t.Fatal("sawOutcome = false, want true")
+	}
+}
+
+func TestConsecutiveOrderFailuresIgnoresOtherOrders(t *testing.T) {
+	base := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	outcomes := []events.Event{
+		outcomeEvent(1, "beads-health", events.OrderFailed, base, "context canceled"),
+		outcomeEvent(2, "dolt-health", events.OrderFailed, base.Add(time.Minute), "exit status 1"),
+		outcomeEvent(3, "beads-health", events.OrderCompleted, base.Add(2*time.Minute), ""),
+		outcomeEvent(4, "dolt-health", events.OrderFailed, base.Add(3*time.Minute), "exit status 1"),
+	}
+
+	streak, _, _, _ := consecutiveOrderFailures(outcomes, "dolt-health", nil, 10*time.Minute)
+
+	if streak != 2 {
+		t.Fatalf("streak = %d, want 2 (beads-health events must not interleave)", streak)
+	}
+}
+
+func TestConsecutiveOrderFailuresReportsNoOutcomes(t *testing.T) {
+	streak, lastMessage, sawOutcome, skipped := consecutiveOrderFailures(nil, "never-run", nil, 10*time.Minute)
+
+	if streak != 0 || lastMessage != "" {
+		t.Fatalf("streak/lastMessage = %d/%q, want 0/\"\"", streak, lastMessage)
+	}
+	if sawOutcome {
+		t.Fatal("sawOutcome = true, want false for an order with no outcome events")
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0", skipped)
+	}
+}
+
+func TestConsecutiveOrderFailuresSkipsPostStartBurst(t *testing.T) {
+	// gastownhall/gascity#3898: for ~5 min after supervisor start, exec orders
+	// fail spuriously. A 30s-cooldown order logs ~10 consecutive such failures.
+	start := time.Date(2026, 8, 4, 23, 23, 0, 0, time.UTC)
+	outcomes := []events.Event{}
+	for i := 0; i < 10; i++ {
+		outcomes = append(outcomes, outcomeEvent(uint64(i+1), "dolt-health", events.OrderFailed,
+			start.Add(time.Duration(i+1)*30*time.Second), "gc: unknown command \"dolt\""))
+	}
+
+	streak, _, sawOutcome, skipped := consecutiveOrderFailures(outcomes, "dolt-health", []time.Time{start}, 10*time.Minute)
+
+	if streak != 0 {
+		t.Fatalf("streak = %d, want 0 — every failure is inside the grace window", streak)
+	}
+	if !sawOutcome {
+		t.Fatal("sawOutcome = false, want true")
+	}
+	if skipped != 10 {
+		t.Fatalf("skipped = %d, want 10 — every failure was inside the grace window", skipped)
+	}
+}
+
+func TestConsecutiveOrderFailuresSkipsWithoutResetting(t *testing.T) {
+	// A skipped in-window failure must neither count nor break the streak:
+	// resetting would let a frequently-restarting city zero a broken order forever.
+	start := time.Date(2026, 8, 4, 23, 23, 0, 0, time.UTC)
+	outcomes := []events.Event{
+		outcomeEvent(1, "dolt-health", events.OrderCompleted, start.Add(-time.Hour), ""),
+		outcomeEvent(2, "dolt-health", events.OrderFailed, start.Add(-30*time.Minute), "exit status 1"),
+		outcomeEvent(3, "dolt-health", events.OrderFailed, start.Add(2*time.Minute), "context canceled"),
+		outcomeEvent(4, "dolt-health", events.OrderFailed, start.Add(30*time.Minute), "exit status 1"),
+	}
+
+	streak, _, _, skipped := consecutiveOrderFailures(outcomes, "dolt-health", []time.Time{start}, 10*time.Minute)
+
+	if streak != 2 {
+		t.Fatalf("streak = %d, want 2 — the in-window failure is skipped, not counted, and must not reset", streak)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+}
+
+func TestConsecutiveOrderFailuresChecksEveryStart(t *testing.T) {
+	// Two restarts with no successful run between them. Checking only the LATEST
+	// start would count the older burst and manufacture a false positive.
+	first := time.Date(2026, 8, 4, 20, 0, 0, 0, time.UTC)
+	second := time.Date(2026, 8, 4, 23, 0, 0, 0, time.UTC)
+	outcomes := []events.Event{
+		outcomeEvent(1, "gate-sweep", events.OrderFailed, first.Add(time.Minute), "context canceled"),
+		outcomeEvent(2, "gate-sweep", events.OrderFailed, first.Add(2*time.Minute), "context canceled"),
+		outcomeEvent(3, "gate-sweep", events.OrderFailed, second.Add(time.Minute), "context canceled"),
+		outcomeEvent(4, "gate-sweep", events.OrderFailed, second.Add(2*time.Minute), "context canceled"),
+	}
+
+	streak, _, _, skipped := consecutiveOrderFailures(outcomes, "gate-sweep", []time.Time{first, second}, 10*time.Minute)
+
+	if streak != 0 {
+		t.Fatalf("streak = %d, want 0 — all four failures sit inside one grace window or the other", streak)
+	}
+	if skipped != 4 {
+		t.Fatalf("skipped = %d, want 4", skipped)
+	}
+}
+
+func TestConsecutiveOrderFailuresUndercountsAcrossGraceWindow(t *testing.T) {
+	// The dolt-remotes-patrol shape: a genuine 27-failure run with exactly one
+	// failure landing near a controller start. "Skip" means neither count nor
+	// break, so the answer is 26 — NOT 1 (which is what breaking would give) and
+	// not 27. The undercount is accepted: counting in-window failures would
+	// reintroduce the #3898 false positive, and a run long enough to span a
+	// restart is already far past a threshold of 3.
+	base := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	start := base.Add(13 * time.Hour)
+	outcomes := []events.Event{
+		outcomeEvent(0, "dolt-remotes-patrol", events.OrderCompleted, base.Add(-time.Hour), ""),
+	}
+	seq := uint64(1)
+	for i := 0; i < 27; i++ {
+		ts := base.Add(time.Duration(i) * time.Hour)
+		if i == 13 {
+			ts = start.Add(2 * time.Minute) // the one inside the grace window
+		}
+		outcomes = append(outcomes, outcomeEvent(seq, "dolt-remotes-patrol", events.OrderFailed, ts, "exit status 1"))
+		seq++
+	}
+
+	streak, _, _, skipped := consecutiveOrderFailures(outcomes, "dolt-remotes-patrol", []time.Time{start}, 10*time.Minute)
+
+	if streak != 26 {
+		t.Fatalf("streak = %d, want 26 (27 failures, one skipped inside the grace window, run not broken)", streak)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+}
+
+func TestConsecutiveOrderFailuresStopsAtSuccessInsideGraceWindow(t *testing.T) {
+	// A success is proof the order works and ends the streak, even inside the
+	// grace window. Skipping it would let the walk run past onto stale failures
+	// from before the success — the exact false positive this check prevents.
+	start := time.Date(2026, 8, 4, 23, 23, 0, 0, time.UTC)
+	outcomes := []events.Event{
+		outcomeEvent(1, "probe-order", events.OrderFailed, start.Add(-100*time.Hour), "exit status 1"),
+		outcomeEvent(2, "probe-order", events.OrderFailed, start.Add(-99*time.Hour), "exit status 1"),
+		outcomeEvent(3, "probe-order", events.OrderFailed, start.Add(-98*time.Hour), "exit status 1"),
+		outcomeEvent(4, "probe-order", events.OrderCompleted, start.Add(2*time.Minute), ""),
+	}
+
+	streak, _, sawOutcome, skipped := consecutiveOrderFailures(outcomes, "probe-order", []time.Time{start}, 10*time.Minute)
+
+	if streak != 0 {
+		t.Fatalf("streak = %d, want 0 — the success inside the grace window must end the walk", streak)
+	}
+	if !sawOutcome {
+		t.Fatal("sawOutcome = false, want true")
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0 — the success ends the walk before any failure is inspected", skipped)
+	}
+}
+
+func TestConsecutiveOrderFailuresPrefersNewestMessageEvenWhenEmpty(t *testing.T) {
+	base := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	outcomes := []events.Event{
+		outcomeEvent(1, "probe-order", events.OrderFailed, base, "real reason"),
+		outcomeEvent(2, "probe-order", events.OrderFailed, base.Add(time.Hour), ""),
+	}
+
+	streak, lastMessage, _, _ := consecutiveOrderFailures(outcomes, "probe-order", nil, 10*time.Minute)
+
+	if streak != 2 {
+		t.Fatalf("streak = %d, want 2", streak)
+	}
+	if lastMessage != "" {
+		t.Fatalf("lastMessage = %q, want \"\" — the newest failure's message wins even when empty", lastMessage)
+	}
+}
+
+func TestNearControllerStartBoundaries(t *testing.T) {
+	start := time.Date(2026, 8, 4, 23, 0, 0, 0, time.UTC)
+	grace := 10 * time.Minute
+
+	cases := []struct {
+		name string
+		ts   time.Time
+		want bool
+	}{
+		{"before start", start.Add(-time.Second), false},
+		{"at start", start, true},
+		{"inside window", start.Add(5 * time.Minute), true},
+		{"at boundary", start.Add(grace), true},
+		{"past boundary", start.Add(grace + time.Second), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nearControllerStart(tc.ts, []time.Time{start}, grace); got != tc.want {
+				t.Fatalf("nearControllerStart(%v) = %v, want %v", tc.ts, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNearControllerStartWithNoStarts(t *testing.T) {
+	ts := time.Date(2026, 8, 4, 23, 0, 0, 0, time.UTC)
+	if nearControllerStart(ts, nil, 10*time.Minute) {
+		t.Fatal("nearControllerStart = true with no starts, want false")
+	}
+}
+
+func TestClassifyOrderOutcomeFlagsAtThreshold(t *testing.T) {
+	order := orders.Order{Name: "refresh-family-clones", Rig: "st"}
+
+	status, detail := classifyOrderOutcome(order, 3, 3, "exit status 128", true, 0)
+
+	if status != StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning", status)
+	}
+	if !strings.Contains(detail, "3 consecutive failures") {
+		t.Fatalf("detail = %q, want it to state the streak", detail)
+	}
+	if !strings.Contains(detail, "exit status 128") {
+		t.Fatalf("detail = %q, want it to carry the last failure message", detail)
+	}
+}
+
+func TestClassifyOrderOutcomeAllowsUnderThreshold(t *testing.T) {
+	order := orders.Order{Name: "dolt-remotes-patrol"}
+
+	status, detail := classifyOrderOutcome(order, 2, 3, "exit status 1", true, 0)
+
+	if status != StatusOK {
+		t.Fatalf("status = %v, want StatusOK for a streak under threshold", status)
+	}
+	if !strings.Contains(detail, "2 consecutive") {
+		t.Fatalf("detail = %q, want it to report the sub-threshold streak", detail)
+	}
+}
+
+func TestClassifyOrderOutcomeHealthyOrder(t *testing.T) {
+	order := orders.Order{Name: "gate-sweep"}
+
+	status, detail := classifyOrderOutcome(order, 0, 3, "", true, 0)
+
+	if status != StatusOK {
+		t.Fatalf("status = %v, want StatusOK", status)
+	}
+	if !strings.Contains(detail, "last run succeeded") {
+		t.Fatalf("detail = %q, want it to say the last run succeeded", detail)
+	}
+}
+
+func TestClassifyOrderOutcomeNoOutcomesYet(t *testing.T) {
+	order := orders.Order{Name: "brand-new-order"}
+
+	status, detail := classifyOrderOutcome(order, 0, 3, "", false, 0)
+
+	if status != StatusOK {
+		t.Fatalf("status = %v, want StatusOK — order-firing-current owns the never-fired case", status)
+	}
+	if !strings.Contains(detail, "no completed runs yet") {
+		t.Fatalf("detail = %q, want it to distinguish never-ran from succeeded", detail)
+	}
+}
+
+func TestClassifyOrderOutcomeOmitsEmptyMessage(t *testing.T) {
+	order := orders.Order{Name: "some-order"}
+
+	_, detail := classifyOrderOutcome(order, 3, 3, "", true, 0)
+
+	if strings.Contains(detail, `""`) {
+		t.Fatalf("detail = %q, want no empty-quote artifact when the message is blank", detail)
+	}
+}
+
+func TestClassifyOrderOutcomeReportsGraceWindowSkipsInsteadOfSuccess(t *testing.T) {
+	// gastownhall/gascity FIX 4: when every trailing failure sits inside the
+	// controller-start grace window, streak == 0 but the order did NOT
+	// succeed. Claiming "last run succeeded" would be a false statement in
+	// the diagnostic tool at exactly the moment an operator reads it — just
+	// after a restart.
+	order := orders.Order{Name: "dolt-health"}
+
+	status, detail := classifyOrderOutcome(order, 0, 3, "", true, 10)
+
+	if status != StatusOK {
+		t.Fatalf("status = %v, want StatusOK — this suppresses the alarm as intended", status)
+	}
+	if strings.Contains(detail, "last run succeeded") {
+		t.Fatalf("detail = %q, must not claim success when every trailing run actually failed", detail)
+	}
+	if !strings.Contains(detail, "10 recent failure(s) within controller-start grace window") {
+		t.Fatalf("detail = %q, want it to report the grace-window-skipped count instead", detail)
+	}
+}
+
+func TestOrderOutcomeHealthySkipsManualOrders(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "orders"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// One scheduled, one manual. Only the scheduled one may appear in details:
+	// ticket-intake sat at a permanent streak of 20 from 2026-06-17 purely
+	// because it was switched to trigger="manual".
+	if err := os.WriteFile(filepath.Join(cityDir, "orders", "scheduled-order.toml"),
+		[]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"5m\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "orders", "manual-order.toml"),
+		[]byte("[order]\nexec = \"true\"\ntrigger = \"manual\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "demo"}}
+	result := NewOrderOutcomeHealthyCheck(cfg, cityDir).Run(&CheckContext{CityPath: cityDir})
+
+	if result.Severity != SeverityAdvisory {
+		t.Fatalf("severity = %v, want SeverityAdvisory", result.Severity)
+	}
+	joined := strings.Join(result.Details, "\n")
+	if !strings.Contains(joined, "scheduled-order") {
+		t.Fatalf("scheduled order missing from details:\n%s", joined)
+	}
+	if strings.Contains(joined, "manual-order") {
+		t.Fatalf("manual order must be out of scope by construction:\n%s", joined)
+	}
+}
+
+func TestOrderOutcomeHealthyReportsCleanCity(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "orders"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "orders", "scheduled-order.toml"),
+		[]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"5m\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "demo"}}
+	// No events.jsonl at all: a missing log must read as "nothing to report",
+	// not as an error, or a fresh city fails doctor on its first run.
+	result := NewOrderOutcomeHealthyCheck(cfg, cityDir).Run(&CheckContext{CityPath: cityDir})
+
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v (%s), want StatusOK on a city with no event log", result.Status, result.Message)
+	}
+}
+
+// TestOrderOutcomeHealthy_FlagsRigScopedOrderFailureStreak is an end-to-end
+// Run test using a RIG-SCOPED order and a real .gc/events.jsonl. FIX 2:
+// neither pre-existing Run test used a rig-scoped order or wrote outcome
+// events, so nothing exercised the event read, the Seq merge, the
+// order.ScopedName() subject match, the failing-order message, or FixHint.
+// Swapping order.ScopedName() for order.Name on the subject-match line blinds
+// the check to every rig-scoped order — including the one whose 3-day silent
+// failure is the motivating case for this check — while passing every other
+// test in the suite. This test is written to fail under that regression.
+func TestOrderOutcomeHealthy_FlagsRigScopedOrderFailureStreak(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+
+	rigPath := filepath.Join(cityPath, "rigs", "st")
+	rigFormulas := filepath.Join(rigPath, "formulas")
+	rigOrders := filepath.Join(rigPath, "orders")
+	if err := os.MkdirAll(rigOrders, 0o755); err != nil {
+		t.Fatalf("creating rig orders dir: %v", err)
+	}
+	cfg.Rigs = []config.Rig{{Name: "st", Path: rigPath}}
+	cfg.FormulaLayers.Rigs = map[string][]string{"st": {cfg.FormulaLayers.City[0], rigFormulas}}
+	writeOrderFiringTestOrderInDir(t, rigOrders, "refresh-family-clones", "cooldown", "6h")
+
+	// order.ScopedName() for Rig "st" is "refresh-family-clones:rig:st" —
+	// see orders.Order.ScopedName(). The recorded events must use that exact
+	// scoped subject, matching how the real dispatcher records order outcomes.
+	scopedSubject := "refresh-family-clones:rig:st"
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.OrderFailed, Ts: now.Add(-18 * time.Hour), Subject: scopedSubject, Message: "exit status 128"},
+		events.Event{Type: events.OrderFailed, Ts: now.Add(-12 * time.Hour), Subject: scopedSubject, Message: "exit status 128"},
+		events.Event{Type: events.OrderFailed, Ts: now.Add(-6 * time.Hour), Subject: scopedSubject, Message: "exit status 128"},
+	)
+
+	result := NewOrderOutcomeHealthyCheck(cfg, cityPath).Run(&CheckContext{CityPath: cityPath})
+
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning; msg=%s details=%v", result.Status, result.Message, result.Details)
+	}
+	if result.Severity != SeverityAdvisory {
+		t.Fatalf("severity = %v, want SeverityAdvisory", result.Severity)
+	}
+	if result.Message != "1 order(s) failing repeatedly" {
+		t.Fatalf("message = %q, want it to name exactly 1 failing order", result.Message)
+	}
+	joined := strings.Join(result.Details, "\n")
+	if !strings.Contains(joined, "3 consecutive failures") {
+		t.Fatalf("details = %v, want them to carry the streak count", result.Details)
+	}
+	wantHint := "Inspect with: gc order check && gc order history refresh-family-clones --rig st"
+	if result.FixHint != wantHint {
+		t.Fatalf("FixHint = %q, want %q — gc order history takes a bare name positionally", result.FixHint, wantHint)
+	}
+}
+
+// TestOrderFiringCurrentAndOrderOutcomeHealthy_MonitorSameOrderSet pins the
+// keystone property the design relies on: order-firing-current and
+// order-outcome-healthy must monitor exactly the same order set (both share
+// scanOrderFiringCurrentOrders), which is what excludes manual orders without
+// a recency heuristic. Without this test, a future change to one filter chain
+// could silently diverge the pair with every other test still green.
+func TestOrderFiringCurrentAndOrderOutcomeHealthy_MonitorSameOrderSet(t *testing.T) {
+	cityPath, cfg := orderFiringTestCity(t)
+	ordersDir := filepath.Join(cityPath, "orders")
+	writeOrderFiringTestOrderInDir(t, ordersDir, "cooldown-order", "cooldown", "5m")
+	writeOrderFiringTestOrderInDir(t, ordersDir, "cron-order", "cron", "*/5 * * * *")
+	writeOrderFiringTestOrderInDir(t, ordersDir, "manual-order", "manual", "")
+	if err := os.WriteFile(filepath.Join(ordersDir, "disabled-order.toml"),
+		[]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"5m\"\nenabled = false\n"), 0o644); err != nil {
+		t.Fatalf("write disabled-order.toml: %v", err)
+	}
+
+	firingResult := NewOrderFiringCurrentCheck(cfg, cityPath).Run(&CheckContext{CityPath: cityPath})
+	outcomeResult := NewOrderOutcomeHealthyCheck(cfg, cityPath).Run(&CheckContext{CityPath: cityPath})
+
+	firingNames := orderOutcomeTestDetailNames(firingResult.Details)
+	outcomeNames := orderOutcomeTestDetailNames(outcomeResult.Details)
+
+	if len(firingNames) == 0 {
+		t.Fatalf("order-firing-current monitored no orders; details = %v", firingResult.Details)
+	}
+	if got, want := strings.Join(outcomeNames, ","), strings.Join(firingNames, ","); got != want {
+		t.Fatalf("monitored order sets diverge:\n  order-firing-current:   %v\n  order-outcome-healthy:  %v", firingNames, outcomeNames)
+	}
+	for _, excluded := range []string{"manual-order", "disabled-order"} {
+		for _, name := range append(append([]string{}, firingNames...), outcomeNames...) {
+			if name == excluded {
+				t.Fatalf("%s must be out of scope for both checks, got names %v / %v", excluded, firingNames, outcomeNames)
+			}
+		}
+	}
+}
+
+// orderOutcomeTestDetailNames extracts the order display name from each
+// detail line. Both checks' details begin with the order display name
+// followed by ": ".
+func orderOutcomeTestDetailNames(details []string) []string {
+	names := make([]string, 0, len(details))
+	for _, d := range details {
+		name, _, ok := strings.Cut(d, ": ")
+		if !ok {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -81,6 +81,7 @@ func TestCheckWarmupEligibleDefaultsFalse(t *testing.T) {
 		&NestedWorktreePruneCheck{},
 		&OrphanSessionsCheck{},
 		&OrderFiringCurrentCheck{},
+		&OrderOutcomeHealthyCheck{},
 		&PackCacheCheck{},
 		&PreStartScriptsCheck{},
 		&ProviderParityCheck{},

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -130,6 +130,10 @@ func (c *OrderFiringCurrentCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *OrderOutcomeHealthyCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *OrphanSessionsCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
## The gap

`order-firing-current` answers **"did it run?"**. Nothing answers **"did it succeed?"**.

An order that fires faithfully on schedule and fails every single time leaves `order-firing-current` green — the order *does* run, it just fails. The only trace is `order.failed` in `.gc/events.jsonl`, which nobody reads unless already suspicious.

Observed in practice: a 6h cooldown order failed on every run for three days (~12 consecutive failures, exit status 128) while `gc doctor` stayed clean. It was found by accident. Reviewing that city's full event history afterwards turned up **four** separate sustained runs of this shape — consecutive-failure streaks of 45, 27, 20 and 14 — of which only one had ever been noticed.

This PR adds the missing half of the pair.

## What it does

Walks each scheduled order's outcome events newest-first, counts consecutive `order.failed`, warns at three:

```
⚠ order-outcome-healthy — 1 order(s) failing repeatedly
   refresh-family-clones:rig:st: 3 consecutive failures, last "exit status 128"
   hint: Inspect with: gc order check && gc order history refresh-family-clones --rig st
```

## Design decisions worth reviewing

**Threshold 3.** Two consecutive failures is a plausible transient for anything touching the network or a lock. On the city measured, one order had **61 lifetime failures while being entirely healthy** — so a rate rule or a lifetime-count rule would flag it permanently. Only a *consecutive* streak separates a persistently broken order from one that fails and recovers. Five would mean 30h of silence on a 6h order.

**Advisory, not blocking** — unlike its sibling. A failing order is real but rarely an emergency, and blocking severity would gate every clean-doctor dependency on transient order breakage, including during maintenance. Happy to change this if you'd rather it match `order-firing-current`.

**The order set is shared, not reimplemented.** The check calls the same `scanOrderFiringCurrentOrders` and applies the same trigger and suspended-rig filters as its sibling. That guarantees the two can never disagree about scope, and it excludes manual orders *by construction* rather than by a recency heuristic — a manual order abandoned mid-failure simply isn't in the monitored set. A test runs **both** checks over one fixture and asserts the sets are identical, so a future divergence fails loudly instead of silently.

## Relationship to #3898

Failures within 10 minutes of any `controller.started` are skipped, because of that issue: for ~5 minutes after supervisor start, exec orders fail spuriously (`gc: unknown command "dolt"`, missing staged assets) since dispatch begins before pack staging completes. An order on a 30s cadence logs ~10 consecutive spurious failures in that window, which would false-positive any streak rule.

Two subtleties, both tested:

- **Skipped, never reset.** Resetting would let a frequently-restarting city zero a genuinely broken order's streak on every restart.
- **A success always ends the walk, window or not.** Testing the window *before* the event type inverts the check's purpose: a real recovery landing near a restart gets skipped, the walk runs past it onto stale failures predating the recovery, and a *working* order is reported as failing. This was a real bug caught in review — five pre-recovery failures plus a success two minutes after a start produced a streak of 5 instead of 0.

Every controller start is consulted, not just the newest: two restarts with no successful run between them would otherwise leave the older burst counted.

This PR **does not fix #3898** — the grace window hides it from this check, it doesn't address the wasted order runs or the false recovery that issue describes.

## Relationship to #2360

That issue documents `jsonl-export.sh`'s per-script consecutive-failure counter — independently also using a **threshold of 3** — escalating via `gc mail send mayor/`. With no backoff, de-dup, or terminal transition it produced `Consecutive failures: 614 (threshold: 3)`: 614 consecutive HIGH mayor mails for one condition.

A pull-based doctor check reports current state idempotently and structurally cannot do that, which is a substantive argument for this shape rather than a push path. The tradeoff is real and worth stating: something must run `gc doctor` for the signal to be seen. Making doctor results reach a human unprompted is a separate concern that should be solved once for all checks, not for this one.

## Known limitation

For orders dispatched as wisps, `dispatchWisp` records `order.completed` as soon as the wisp bead is created and labelled, so the spawned agent's actual outcome never reaches the event log. For those orders this answers "did dispatch succeed?" rather than "did the work succeed?". Exec orders — the motivating case — are fully covered. Recorded here rather than worked around.

## Testing

- Unit tests on the streak counter and the classifier, each written before its implementation and verified to fail against the wrong behaviour, including the grace-window ordering bug above.
- An end-to-end `Run` test using a **rig-scoped** order and a real `events.jsonl`, verified to fail if `order.ScopedName()` is swapped for `order.Name` — that swap blinds the check to every rig-scoped order and previously passed the entire suite.
- A test asserting both checks monitor an identical order set over one fixture.
- `go vet`, `golangci-lint` (0 issues), `internal/doctor` and the `cmd/gc` doctor tests all pass on this base.

Also verified running against a live city: 21 orders monitored, both checks' order sets identical, zero orders flagged (no retroactive noise on first deploy). Applied retroactively to that city's history it would have caught all four sustained runs.

Refs #3898, #2360