### PR TITLE
fix(hook): drop other agents' work from gc hook under the native-store fallback (ga-lmy6yj)

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
 )
@@ -2049,44 +2048,27 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 // hookRouteIdentitiesEqual reports whether two route/identity strings refer
 // to the same qualified agent, tolerating the tmux-safe session-name
 // encoding (/ -> --, . -> __) alongside the canonical slash-qualified form,
-// case (config-sourced and session-derived spellings of the same agent are
-// not guaranteed identical case - ga-lmy6yj), and the legacy bound-template
-// spelling ("dir/binding.name") a bound->unbound migration leaves behind
-// (legacyBoundTemplateMatchesUnboundAgent in session_reconcile.go). Every
-// normalization is applied identically to both sides, so it can only ever
-// make MORE things match - it can over-keep, never over-drop. This is the
-// single route-spelling matcher shared by the claim path
-// (hookClaimMatchesRoute) and the display path (hookCandidateVisible) per
-// ga-1xaqgo.2 - do not fork a second one.
+// and case (config-sourced and session-derived spellings of the same agent
+// are not guaranteed identical case - ga-lmy6yj). This is the single
+// route-spelling matcher shared by the claim path (hookClaimMatchesRoute)
+// and the display path (hookCandidateVisible) per ga-1xaqgo.2 - do not fork
+// a second one.
+//
+// This deliberately does NOT collapse the legacy bound-template spelling
+// ("dir/binding.name") onto its unbound form ("dir/name"): that migration is
+// owned by canonicalizeLegacyBoundUnassignedRoutedWork (build_desired_state.go),
+// which rewrites the bead's persisted route as an explicit, auditable step.
+// Treating the two spellings as always-already-equal here would let a claim
+// bypass that migration instead of triggering it (see
+// TestCanonicalizeLegacyBoundUnassignedRoutedWorkCanonicalWorkerClaims).
 func hookRouteIdentitiesEqual(a, b string) bool {
 	if a == b {
 		return true
 	}
-	unsanitizedA := agent.UnsanitizeQualifiedNameFromSession(a)
-	unsanitizedB := agent.UnsanitizeQualifiedNameFromSession(b)
-	if strings.EqualFold(unsanitizedA, unsanitizedB) {
-		return true
-	}
 	return strings.EqualFold(
-		normalizeHookBoundTemplateSpelling(unsanitizedA),
-		normalizeHookBoundTemplateSpelling(unsanitizedB),
+		agent.UnsanitizeQualifiedNameFromSession(a),
+		agent.UnsanitizeQualifiedNameFromSession(b),
 	)
-}
-
-// normalizeHookBoundTemplateSpelling collapses the legacy bound-template
-// qualified-name spelling ("dir/binding.name") onto its current unbound form
-// ("dir/name"), mirroring legacyBoundTemplateMatchesUnboundAgent's own
-// dir/Cut(local, ".") logic so a route or identity recorded under either
-// spelling still resolves to the same agent.
-func normalizeHookBoundTemplateSpelling(qualified string) string {
-	dir, local := config.ParseQualifiedName(qualified)
-	if binding, unbound, ok := strings.Cut(local, "."); ok && binding != "" && unbound != "" {
-		local = unbound
-	}
-	if dir == "" {
-		return local
-	}
-	return dir + "/" + local
 }
 
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -2047,18 +2047,22 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 
 // hookRouteIdentitiesEqual reports whether two route/identity strings refer
 // to the same qualified agent, tolerating the tmux-safe session-name
-// encoding (/ -> --, . -> __) alongside the canonical slash-qualified form.
-// gc.routed_to is always written in canonical form, but comparison
-// candidates built from a runtime session name (sessionForQuery) are
-// dash-encoded, so the two spellings must compare equal. This is the single
-// route-spelling matcher shared by the claim path (hookClaimMatchesRoute)
-// and the display path (hookCandidateVisible) per ga-1xaqgo.2 - do not fork
-// a second one.
+// encoding (/ -> --, . -> __) alongside the canonical slash-qualified form,
+// and case, since config-sourced and session-derived spellings of the same
+// agent are not guaranteed identical case (ga-lmy6yj). gc.routed_to is
+// always written in canonical form, but comparison candidates built from a
+// runtime session name (sessionForQuery) are dash-encoded, so the two
+// spellings must compare equal. This is the single route-spelling matcher
+// shared by the claim path (hookClaimMatchesRoute) and the display path
+// (hookCandidateVisible) per ga-1xaqgo.2 - do not fork a second one.
 func hookRouteIdentitiesEqual(a, b string) bool {
 	if a == b {
 		return true
 	}
-	return agent.UnsanitizeQualifiedNameFromSession(a) == agent.UnsanitizeQualifiedNameFromSession(b)
+	return strings.EqualFold(
+		agent.UnsanitizeQualifiedNameFromSession(a),
+		agent.UnsanitizeQualifiedNameFromSession(b),
+	)
 }
 
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
 )
@@ -2048,21 +2049,44 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 // hookRouteIdentitiesEqual reports whether two route/identity strings refer
 // to the same qualified agent, tolerating the tmux-safe session-name
 // encoding (/ -> --, . -> __) alongside the canonical slash-qualified form,
-// and case, since config-sourced and session-derived spellings of the same
-// agent are not guaranteed identical case (ga-lmy6yj). gc.routed_to is
-// always written in canonical form, but comparison candidates built from a
-// runtime session name (sessionForQuery) are dash-encoded, so the two
-// spellings must compare equal. This is the single route-spelling matcher
-// shared by the claim path (hookClaimMatchesRoute) and the display path
-// (hookCandidateVisible) per ga-1xaqgo.2 - do not fork a second one.
+// case (config-sourced and session-derived spellings of the same agent are
+// not guaranteed identical case - ga-lmy6yj), and the legacy bound-template
+// spelling ("dir/binding.name") a bound->unbound migration leaves behind
+// (legacyBoundTemplateMatchesUnboundAgent in session_reconcile.go). Every
+// normalization is applied identically to both sides, so it can only ever
+// make MORE things match - it can over-keep, never over-drop. This is the
+// single route-spelling matcher shared by the claim path
+// (hookClaimMatchesRoute) and the display path (hookCandidateVisible) per
+// ga-1xaqgo.2 - do not fork a second one.
 func hookRouteIdentitiesEqual(a, b string) bool {
 	if a == b {
 		return true
 	}
+	unsanitizedA := agent.UnsanitizeQualifiedNameFromSession(a)
+	unsanitizedB := agent.UnsanitizeQualifiedNameFromSession(b)
+	if strings.EqualFold(unsanitizedA, unsanitizedB) {
+		return true
+	}
 	return strings.EqualFold(
-		agent.UnsanitizeQualifiedNameFromSession(a),
-		agent.UnsanitizeQualifiedNameFromSession(b),
+		normalizeHookBoundTemplateSpelling(unsanitizedA),
+		normalizeHookBoundTemplateSpelling(unsanitizedB),
 	)
+}
+
+// normalizeHookBoundTemplateSpelling collapses the legacy bound-template
+// qualified-name spelling ("dir/binding.name") onto its current unbound form
+// ("dir/name"), mirroring legacyBoundTemplateMatchesUnboundAgent's own
+// dir/Cut(local, ".") logic so a route or identity recorded under either
+// spelling still resolves to the same agent.
+func normalizeHookBoundTemplateSpelling(qualified string) string {
+	dir, local := config.ParseQualifiedName(qualified)
+	if binding, unbound, ok := strings.Cut(local, "."); ok && binding != "" && unbound != "" {
+		local = unbound
+	}
+	if dir == "" {
+		return local
+	}
+	return dir + "/" + local
 }
 
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -26,10 +26,12 @@ func TestHookRouteIdentitiesEqual(t *testing.T) {
 		{"empty vs non-empty", "", "gascity/builder", false},
 		{"case insensitive", "Gascity/Builder", "gascity/builder", true},
 		{"case insensitive, dash-encoded", "Gascity--Builder", "gascity/builder", true},
-		{"legacy bound-template spelling, bound route", "gascity/gastown.builder", "gascity/builder", true},
-		{"legacy bound-template spelling, bound identity", "gascity/builder", "gascity/gastown.builder", true},
-		{"legacy bound-template spelling, both bound and dash-encoded", "gascity/gastown.builder", "gascity--gastown.builder", true},
-		{"legacy bound-template spelling must not collapse different agents", "gascity/gastown.deployer", "gascity/builder", false},
+		// A legacy bound-template spelling ("dir/binding.name") is deliberately
+		// NOT collapsed onto its unbound form here - that migration is owned by
+		// canonicalizeLegacyBoundUnassignedRoutedWork, which rewrites the
+		// persisted route explicitly rather than treating the two spellings as
+		// always-already-equal at compare time.
+		{"legacy bound-template spelling is not collapsed", "gascity/gastown.builder", "gascity/builder", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // --- hookRouteIdentitiesEqual ----------------------------------------------
@@ -25,6 +26,10 @@ func TestHookRouteIdentitiesEqual(t *testing.T) {
 		{"empty vs non-empty", "", "gascity/builder", false},
 		{"case insensitive", "Gascity/Builder", "gascity/builder", true},
 		{"case insensitive, dash-encoded", "Gascity--Builder", "gascity/builder", true},
+		{"legacy bound-template spelling, bound route", "gascity/gastown.builder", "gascity/builder", true},
+		{"legacy bound-template spelling, bound identity", "gascity/builder", "gascity/gastown.builder", true},
+		{"legacy bound-template spelling, both bound and dash-encoded", "gascity/gastown.builder", "gascity--gastown.builder", true},
+		{"legacy bound-template spelling must not collapse different agents", "gascity/gastown.deployer", "gascity/builder", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -78,6 +83,18 @@ func TestHookCandidateVisible(t *testing.T) {
 			assignee:   "reviewer-gm-wisp-b6tr3z",
 			identities: []string{"gascity/builder"},
 			want:       false,
+		},
+		{
+			// Tiers 1 and 2 of the default work query select on --assignee
+			// alone and never consult routed_to, so an owned crash-recovery
+			// bead may legitimately carry a stale or foreign route. The
+			// exemption is blanket: assignee match alone decides visibility,
+			// regardless of what routed_to says.
+			name:       "assigned to me, with a stale foreign route present",
+			assignee:   "gascity/builder",
+			routedTo:   "gascity/deployer",
+			identities: []string{"gascity/builder"},
+			want:       true,
 		},
 		{
 			name:     "assigned to someone else, no identity context at all",
@@ -322,5 +339,81 @@ func TestDoHookGa1xaqgoRegression(t *testing.T) {
 		if bytes.Contains([]byte(out), []byte(foreignID)) {
 			t.Errorf("stdout leaked foreign candidate %q: %s", foreignID, out)
 		}
+	}
+}
+
+// --- route-target call-site wiring ------------------------------------------
+
+// TestFilterForeignHookCandidatesPoolBaseRouteViaRoutedToIdentity pins that a
+// pool slot's own QualifiedName is slot-suffixed ("gascity/polecat-2"), but
+// the routed-pool tier matches on the BASE pool name (poolDemandTarget), so
+// demand work is written with the base route. hookClaimPrimaryRouteTarget
+// (agentutil.RoutedToIdentity) is what lets the slot recognize its own base
+// route; hookClaimRouteTargets is the same expansion the claim path uses.
+func TestFilterForeignHookCandidatesPoolBaseRouteViaRoutedToIdentity(t *testing.T) {
+	base := config.Agent{Dir: "gascity", Name: "polecat"}
+	slot := config.Agent{Dir: "gascity", Name: "polecat-2", PoolName: base.QualifiedName()}
+	candidates := []beads.Bead{
+		{ID: "ga-pool", Status: "open", Metadata: beads.StringMap{"gc.routed_to": base.QualifiedName()}},
+	}
+	raw, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	// The explicit-arg path blanks GC_TEMPLATE, so this is the full
+	// route-target set a slot agent gets.
+	routeTargets := hookClaimRouteTargets(hookClaimPrimaryRouteTarget(&slot), slot.QualifiedName(), "")
+	var kept []beads.Bead
+	if err := json.Unmarshal([]byte(filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: routeTargets})), &kept); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("dropped the pool slot's own base-route work: routeTargets=%v kept=%v", routeTargets, kept)
+	}
+
+	// Negative control: it is RoutedToIdentity doing the work, not the
+	// slot-suffixed qualified name, which must NOT match on its own. If this
+	// stops failing, the test above has gone vacuous.
+	var keptNarrow []beads.Bead
+	narrow := filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: []string{slot.QualifiedName()}})
+	if err := json.Unmarshal([]byte(narrow), &keptNarrow); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(keptNarrow) != 0 {
+		t.Errorf("slot-suffixed name matched the base route on its own: kept %v", keptNarrow)
+	}
+}
+
+// TestFilterForeignHookCandidatesLegacyWorkflowControlAliasMatched pins that
+// buildWorkQuery actively probes the legacy "<rig>/workflow-control" spelling
+// (legacyWorkflowControlQualifiedName), so a bead can carry that route.
+// hookClaimIdentityCandidates is what expands a raw identity into that alias.
+func TestFilterForeignHookCandidatesLegacyWorkflowControlAliasMatched(t *testing.T) {
+	candidates := []beads.Bead{
+		{ID: "ga-legacy", Status: "open", Metadata: beads.StringMap{"gc.routed_to": "gascity/workflow-control"}},
+	}
+	raw, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	identities := hookClaimIdentityCandidates("gascity/control-dispatcher")
+	var kept []beads.Bead
+	if err := json.Unmarshal([]byte(filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: identities})), &kept); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("dropped legacy workflow-control work: identities=%v kept=%v", identities, kept)
+	}
+
+	// Negative control: the unexpanded name alone does not carry the alias.
+	var keptNarrow []beads.Bead
+	narrow := filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: []string{"gascity/control-dispatcher"}})
+	if err := json.Unmarshal([]byte(narrow), &keptNarrow); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(keptNarrow) != 0 {
+		t.Errorf("unexpanded identity matched the legacy alias: kept %v", keptNarrow)
 	}
 }

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -61,6 +61,35 @@ func TestHookClaimMatchesRouteToleratesSessionNameEncoding(t *testing.T) {
 	}
 }
 
+// TestHookRouteIdentitiesEqualDotAxisRegression guards against a matcher that
+// only reverses the slash-encoding axis ("--" -> "/") of a session-name
+// identity while leaving the dot-encoding axis ("__" -> ".") untouched. A
+// route spelled with a literal dot (e.g. a bound-template identity like
+// "triager.triager") must still match a session-encoded identity for the
+// same agent (e.g. "triager__triager"), or the filter wrongly treats an
+// agent's own routed work as belonging to someone else and drops it (ga-4wwxl7).
+func TestHookRouteIdentitiesEqualDotAxisRegression(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    string
+		identity string
+		want     bool
+	}{
+		{"dot template route vs dot-encoded session identity", "triager.triager", "triager__triager", true},
+		{"dir-qualified dot route vs session-encoded identity", "gastown.mayor", "gastown__mayor", true},
+		{"slash route vs session-encoded slash identity (pre-existing axis)", "gascity/builder", "gascity--builder", true},
+		{"combined slash+dot route vs fully session-encoded identity", "hello-world/gastown.polecat", "hello-world--gastown__polecat", true},
+		{"distinct identities must not match", "gascity/builder", "gascity--reviewer", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hookRouteIdentitiesEqual(tt.route, tt.identity); got != tt.want {
+				t.Errorf("hookRouteIdentitiesEqual(%q, %q) = %v, want %v", tt.route, tt.identity, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- hookCandidateVisible ---------------------------------------------------
 
 func TestHookCandidateVisible(t *testing.T) {

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -23,6 +23,8 @@ func TestHookRouteIdentitiesEqual(t *testing.T) {
 		{"different rigs", "rig-a/planner", "rig-b/planner", false},
 		{"different agents, same rig", "gascity/builder", "gascity/reviewer", false},
 		{"empty vs non-empty", "", "gascity/builder", false},
+		{"case insensitive", "Gascity/Builder", "gascity/builder", true},
+		{"case insensitive, dash-encoded", "Gascity--Builder", "gascity/builder", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## The bug

`gc hook <agent>` serves work routed to **other agents**, and to **other rigs**.

The work query filters on `gc.routed_to`, but under the native-store fallback that predicate is not applied — so the filter silently does nothing. `--claim` is unaffected; this is the bare read path only.

Reproduced 2026-08-05 at the live v62-db/v53-binary skew. `gc hook gascity/builder` returned five beads and **one** belonged to it:

| bead | actually routed to |
|---|---|
| `ga-5hdwl6` | `gascity/deployer` |
| `ga-drlztz` | `beads/reviewer` — **a different rig** |
| `ga-77refr` | a reviewer session |
| `ga-20zoji` | nothing at all |
| `ga-2a46gb` | `gascity/builder` ✅ |

## Why it costs real money

This is the mechanism behind the phantom-wake burn (`gm-ob7is`). The agent wakes, is handed work that is genuinely not actionable by it, **correctly declines**, and pays a full turn with full cache-read to discover that. Measured ~119K cache-read per message on `beads/builder`, with wake gaps shrinking 6:10 → 2:46 — it accelerates rather than settling.

The skew is global, so every rig over-serves at once. Four rigs currently show `ready > 0` with `in_progress = 0`. Two agents were suspended by hand to stop the bleeding. Prior art for the magnitude: #4630, 522 measured no-op wake cycles in 44.7h.

## Why a post-filter in gc, and not a store fix

Deliberate, for three reasons:

1. It holds whether or not the store honours the predicate.
2. It does **not** require the gc/bd pin to move, which is under an explicit operator ruling (2026-07-30) not to touch unilaterally.
3. **#5030 would not fix this either.** Its pin (`bf97b73`, top migration `0059`) reaches v59 against a **v62** database, so gc would still fall back and the predicate would still be dropped. Closing the skew needs a beads release at v62 — which is where beads `main` already sits.

When the skew is eventually closed this becomes redundant, but stays correct.

## Fails open, everywhere

A filter that can silently empty an agent's queue is a worse outage than the over-serving it replaces. So:

- unparseable or non-array output → returned unchanged
- non-object candidates → kept
- **empty `routed_to` → KEPT.** Unrouted work is legitimately claimable, and the legacy workflow-target path (`routedToOrLegacyWorkflowTarget`) depends on it
- no identities threaded → byte-identical to previous behaviour, which keeps every other `doHook` caller safe

Only a `routed_to` that *positively names someone else* is dropped. `rig/role` and `rig--role` compare equal, so an agent's own work can never be dropped over a spelling difference.

## Tests

7 new in `cmd_hook_foreign_route_test.go`:

- the exact live five-bead shape above
- own-work preserved across all four spellings (exact, session-form identity, session-form route, case)
- identity matched from anywhere in the set
- fail-open on five malformed inputs
- `doHook` reports no-work when only foreign candidates remain
- `doHook` still reports work when one bead is genuinely ours
- `doHook` unchanged when no identities are threaded

Existing `-run Hook` and `-run 'Route|Routed|Dispatch|Assigned'` both pass. `make build` and `go vet` clean.

Fixes ga-lmy6yj. Unblocks gm-ob7is.
