### PR TITLE
fix(runtime): add missing hash/fnv import to city_runtime.go (main is red)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log"
 	"os"


### PR DESCRIPTION
## Problem

`main` does not compile. #3667 added `sessionBeadSnapshotFingerprint`, which calls `fnv.New64a()`, without adding `hash/fnv` to `cmd/gc/city_runtime.go`'s import block:

```
$ git checkout 3f4173e3c   # current main, no other commits
$ go build ./cmd/gc/
# github.com/gastownhall/gascity/cmd/gc
cmd/gc/city_runtime.go:3424:7: undefined: fnv
```

Because CI builds each PR **merged with** `main`, this fails every job that compiles `cmd/gc` on every open pull request: all twelve `cmd/gc process` shards, the integration suites, `Preflight / static checks`, and `Preflight / generated artifacts` — the last surfacing it as `genschema: generating CLI docs: exit status 1`, which reads like a codegen problem rather than a missing import. I found it while working out why 28 checks went red on #4073 with a diff that touches none of those files.

## Fix

The import. One line, in sorted position; nothing else in #3667 needed changing.

## Verification

```
$ go build ./...                  # clean
$ go vet ./cmd/gc/                # clean
$ gofumpt -l cmd/gc/city_runtime.go   # clean
```

#3667's own tests pass with it in place:

```
--- PASS: TestSessionBeadSnapshotFingerprintReflectsRawMetadata
--- PASS: TestCityRuntimeDemandSnapshotRefreshesForNewRoutedReadyWork
--- PASS: TestCityRuntimeDemandSnapshotReusesStablePatrolDemand
--- PASS: TestCityRuntimeDemandSnapshotRetainsOnlyPoolScaleCheckPartials
--- PASS: TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot
```

Those could not have run as merged, since the package they live in does not build — which is presumably how this got through.

Sending it as its own PR rather than folding it into #4073, so it can land immediately and unblock everyone else's CI too.