### PR TITLE
fix(events): reconcile graph step completions on patrol

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -451,11 +451,8 @@ func (cs *controllerState) startBeadEventWatcher(ctx context.Context) {
 	// A controller can crash after the durable bead.closed journal append but
 	// before its best-effort lifecycle append. The normal watcher intentionally
 	// begins at the boot-time journal head, so reconcile closed graph.v2 steps
-	// before tailing to repair that otherwise permanent gap. ReconcileCompleted
-	// reads exact facts from the same journal to make restart passes idempotent.
-	graphStore := cs.GraphBeadStore()
-	graphStore.Store = uncachedBeadStore(graphStore.Store)
-	executionevent.ReconcileCompleted(ep, graphStore, "execution-reconcile")
+	// before tailing to repair that otherwise permanent gap.
+	cs.reconcileExecutionCompletions()
 	seq := cs.beadEventStartSeq
 	// A captured seq of 0 with OK=true means the log was genuinely empty at
 	// construction — Watch(0) then replays exactly the prime-window events and
@@ -505,6 +502,20 @@ func (cs *controllerState) startBeadEventWatcher(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// reconcileExecutionCompletions repairs graph.v2 completion facts from the
+// authoritative graph store. It is safe to call at startup and on patrol ticks:
+// ReconcileCompleted uses the event journal's exact fact as its idempotency
+// record, so repeated passes do not duplicate lifecycle events.
+func (cs *controllerState) reconcileExecutionCompletions() {
+	ep := cs.EventProvider()
+	if ep == nil {
+		return
+	}
+	graphStore := cs.GraphBeadStore()
+	graphStore.Store = uncachedBeadStore(graphStore.Store)
+	executionevent.ReconcileCompleted(ep, graphStore, "execution-reconcile")
 }
 
 // uncachedBeadStore peels the controller's policy/cache read layers so a

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log"
 	"os"
@@ -1288,6 +1289,14 @@ func (cr *CityRuntime) tick(
 		phaseStart = time.Now()
 		cr.beadReconcileTick(ctx, result, sessionBeads, trace, false)
 		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile_tick", phaseStart, traceDesiredStateFields(result))
+	}
+	// Graph stores intentionally do not emit bead.closed. Reconcile their
+	// closed graph.v2 steps only at the authoritative patrol cadence, not on
+	// event-driven ticks, so lifecycle recovery remains bounded and idempotent.
+	if trigger == "patrol" && cr.cs != nil {
+		phaseStart = time.Now()
+		cr.cs.reconcileExecutionCompletions()
+		recordPhase(TraceSiteControllerTickPhase, "reconcile_execution_completions", phaseStart, nil)
 	}
 
 	// Wisp GC: purge expired closed molecules. The molecule/wisp/workflow purge

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1564,6 +1564,92 @@ func TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot(t *testing.T) {
 	}
 }
 
+func TestCityRuntimePatrolReconcilesGraphStepClosedAfterWatcherStartup(t *testing.T) {
+	backing := beads.NewMemStore()
+	root, err := backing.Create(beads.Bead{ID: "gcg-run", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+		beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	step, err := backing.Create(beads.Bead{ID: "gcg-build-attempt", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+		beadmeta.StepIDMetadataKey:     "build",
+		beadmeta.SessionIDMetadataKey:  "gcs-session",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ep := events.NewFake()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cs := &controllerState{
+		cfg:           &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		cityBeadStore: backing,
+		eventProv:     ep,
+	}
+	cs.startBeadEventWatcher(ctx)
+
+	if err := backing.Close(step.ID); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := ep.List(events.Filter{Type: events.ExecutionStepCompleted, Subject: step.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(completed) != 0 {
+		t.Fatalf("completed events before patrol = %#v, want none without bead.closed", completed)
+	}
+
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg:      cs.cfg,
+		sp:       runtime.NewFake(),
+		cs:       cs,
+		buildFnWithSessionBeads: func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+	var dirty atomic.Bool
+	var lastProviderName string
+	var prevPoolRunning map[string]bool
+	cr.tick(ctx, &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "poke")
+	completed, err = ep.List(events.Filter{Type: events.ExecutionStepCompleted, Subject: step.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(completed) != 0 {
+		t.Fatalf("completed events after poke = %#v, want no global reconciliation outside patrol", completed)
+	}
+
+	cr.tick(ctx, &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "patrol")
+
+	completed, err = ep.List(events.Filter{Type: events.ExecutionStepCompleted, Subject: step.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("completed events after patrol = %#v, want one", completed)
+	}
+	if got := completed[0]; got.RunID != root.ID || got.SessionID != "gcs-session" || got.StepID != "build" {
+		t.Fatalf("completed event = %#v", got)
+	}
+
+	cr.tick(ctx, &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "patrol")
+	completed, err = ep.List(events.Filter{Type: events.ExecutionStepCompleted, Subject: step.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("completed events after second patrol = %#v, want exact-fact no-op", completed)
+	}
+}
+
 func TestCityRuntimeTickReturnsBeforeDemandWhenCanceled(t *testing.T) {
 	store := beads.NewMemStore()
 	od := &recordingOrderDispatcher{}


### PR DESCRIPTION
## Summary

- factor execution-completion reconciliation into one controller helper
- run it on patrol ticks after bead reconciliation, preserving scan-free poke ticks
- emit missing graph.v2 completion facts idempotently when graph-store closes do not produce `bead.closed`

## Validation

- focused patrol reconciliation regression
- startup reconciliation regression
- `go test ./internal/executionevent`
- `go vet ./internal/executionevent ./cmd/gc`
- mandatory pre-commit and pre-push suites