### PR TITLE
fix(events): reconcile rig graph completions

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -513,9 +514,45 @@ func (cs *controllerState) reconcileExecutionCompletions() {
 	if ep == nil {
 		return
 	}
-	graphStore := cs.GraphBeadStore()
-	graphStore.Store = uncachedBeadStore(graphStore.Store)
-	executionevent.ReconcileCompleted(ep, graphStore, "execution-reconcile")
+
+	// Graph coordination may be relocated from the city work store, while
+	// graph.v2 executions normally live in the individual rig work stores.
+	// Scan both surfaces in stable order, collapsing wrappers first so aliases
+	// are not scanned more than once.
+	cs.mu.RLock()
+	stores := []beads.Store{
+		resolveGraphStore(cs.cityBeadStore, cs.cfg, cs.cityPath, cs.eventProv),
+		cs.cityBeadStore,
+	}
+	rigStores := make(map[string]beads.Store, len(cs.beadStores))
+	for name, store := range cs.beadStores {
+		rigStores[name] = store
+	}
+	cs.mu.RUnlock()
+
+	rigNames := make([]string, 0, len(rigStores))
+	for name := range rigStores {
+		rigNames = append(rigNames, name)
+	}
+	sort.Strings(rigNames)
+	for _, name := range rigNames {
+		stores = append(stores, rigStores[name])
+	}
+
+	seen := make(map[uintptr]struct{}, len(stores))
+	for _, store := range stores {
+		store = uncachedBeadStore(store)
+		if store == nil {
+			continue
+		}
+		if key, ok := storePointerKey(store); ok {
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		executionevent.ReconcileCompleted(ep, beads.GraphStore{Store: store}, "execution-reconcile")
+	}
 }
 
 // uncachedBeadStore peels the controller's policy/cache read layers so a

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2145,6 +2145,55 @@ func TestControllerStateBeadEventWatcherReconcilesCompletedCloseAfterRestart(t *
 	}
 }
 
+func TestControllerStateReconcileExecutionCompletionsScansConfiguredRigStores(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	root, err := rigStore.Create(beads.Bead{ID: "gcg-run", Metadata: map[string]string{
+		"gc.kind": "workflow", "gc.formula_contract": "graph.v2",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	step, err := rigStore.Create(beads.Bead{ID: "gcg-build-attempt", Metadata: map[string]string{
+		"gc.root_bead_id": root.ID, "gc.step_id": "build", "gc.session_id": "gcs-session",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rigStore.Close(step.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	ep := events.NewFake()
+	cs := &controllerState{
+		cfg:           &config.City{Rigs: []config.Rig{{Name: "gascity"}}},
+		cityBeadStore: cityStore,
+		beadStores:    map[string]beads.Store{"gascity": rigStore},
+		eventProv:     ep,
+	}
+	cs.reconcileExecutionCompletions()
+
+	completed, err := ep.List(events.Filter{Type: events.ExecutionStepCompleted, Subject: step.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("completed events after rig reconciliation = %#v, want one", completed)
+	}
+	if got := completed[0]; got.RunID != root.ID || got.SessionID != "gcs-session" || got.StepID != "build" {
+		t.Fatalf("reconciled completed event = %#v", got)
+	}
+
+	cs.reconcileExecutionCompletions()
+	completed, err = ep.List(events.Filter{Type: events.ExecutionStepCompleted, Subject: step.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("completed events after repeated rig reconciliation = %#v, want exact-fact no-op", completed)
+	}
+}
+
 func TestWrapWithCachingStoreCachesNonBdStore(t *testing.T) {
 	backing := beads.NewMemStore()
 	created, err := backing.Create(beads.Bead{Title: "non-bd backing"})


### PR DESCRIPTION
## Summary

- scan the graph-class, city, and configured rig stores for closed graph.v2 steps
- unwrap and de-duplicate backing stores before reconciliation
- preserve exact-fact idempotency across repeated patrols

## Live defect

The authentic graph.v2 run and step were stored in the `gascity` rig store, while completion repair scanned only the city graph store. This left `execution.step_completed` at zero after deployment.

## Validation

- RED: rig-local closed step produced no completion with an empty city store
- GREEN: rig-local recovery, startup recovery, and patrol idempotency regressions
- `go test -count=1 ./internal/executionevent`
- commit hooks: changed lint, generated docs, and `go vet ./...`