### PR TITLE
fix(events): batch completion reconciliation facts

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -540,6 +540,7 @@ func (cs *controllerState) reconcileExecutionCompletions() {
 	}
 
 	seen := make(map[uintptr]struct{}, len(stores))
+	graphStores := make([]beads.GraphStore, 0, len(stores))
 	for _, store := range stores {
 		store = uncachedBeadStore(store)
 		if store == nil {
@@ -551,8 +552,9 @@ func (cs *controllerState) reconcileExecutionCompletions() {
 			}
 			seen[key] = struct{}{}
 		}
-		executionevent.ReconcileCompleted(ep, beads.GraphStore{Store: store}, "execution-reconcile")
+		graphStores = append(graphStores, beads.GraphStore{Store: store})
 	}
+	executionevent.ReconcileCompletedStores(ep, graphStores, "execution-reconcile")
 }
 
 // uncachedBeadStore peels the controller's policy/cache read layers so a

--- a/internal/executionevent/lifecycle_test.go
+++ b/internal/executionevent/lifecycle_test.go
@@ -2,6 +2,7 @@ package executionevent
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -103,6 +104,110 @@ func TestReconcileCompletedRepairsMissingFactAndRetainsConflictingHistory(t *tes
 	}
 	if len(completed) != 2 || completed[1].SessionID != "gcs-session" || completed[1].RunID != root.ID || completed[1].StepID != "build" {
 		t.Fatalf("completed facts = %#v, want stale history plus authoritative correction", completed)
+	}
+}
+
+func TestReconcileCompletedStoresPreloadsExactFactsOnceAndFailsClosed(t *testing.T) {
+	firstGraph := beads.NewMemStore()
+	firstRoot := mustCreateProjectionRoot(t, firstGraph, "")
+	nilTopologyStep := mustCreateProjectionStep(t, firstGraph, "gcg-nil-topology", firstRoot.ID, "build", "")
+	closed := "closed"
+	if err := firstGraph.Update(nilTopologyStep.ID, beads.UpdateOpts{Status: &closed, Metadata: map[string]string{beadmeta.SessionIDMetadataKey: "gcs-session"}}); err != nil {
+		t.Fatal(err)
+	}
+	nilTopologyStep, err := firstGraph.Get(nilTopologyStep.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nilTopologyFact, ok := LifecycleEvent(events.ExecutionStepCompleted, firstRoot, nilTopologyStep, "prior-reconcile")
+	if !ok || nilTopologyFact.DependsOnStepIDs != nil {
+		t.Fatalf("nil topology fact = %#v, ok=%v", nilTopologyFact, ok)
+	}
+
+	secondGraph := beads.NewMemStore()
+	secondRoot := mustCreateProjectionRoot(t, secondGraph, "")
+	emptyTopologyStep := mustCreateProjectionStep(t, secondGraph, "gcg-empty-topology", secondRoot.ID, "test", "[]")
+	if err := secondGraph.Update(emptyTopologyStep.ID, beads.UpdateOpts{Status: &closed, Metadata: map[string]string{beadmeta.SessionIDMetadataKey: "gcs-session"}}); err != nil {
+		t.Fatal(err)
+	}
+	emptyTopologyStep, err = secondGraph.Get(emptyTopologyStep.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyTopologyFact, ok := LifecycleEvent(events.ExecutionStepCompleted, secondRoot, emptyTopologyStep, "prior-reconcile")
+	if !ok || !reflect.DeepEqual(emptyTopologyFact.DependsOnStepIDs, lifecycleStrings([]string{})) {
+		t.Fatalf("empty topology fact = %#v, ok=%v", emptyTopologyFact, ok)
+	}
+
+	backing := events.NewFake()
+	backing.Record(nilTopologyFact) // Exact fact: must suppress this candidate.
+	emptyTopologyFact.DependsOnStepIDs = nil
+	backing.Record(emptyTopologyFact) // Same tuple except unknown, not known-empty, topology.
+	provider := &countingEventProvider{Provider: backing}
+	stores := []beads.GraphStore{{Store: firstGraph}, {Store: secondGraph}}
+	if got := ReconcileCompletedStores(provider, stores, "execution-reconcile"); got != 1 {
+		t.Fatalf("ReconcileCompletedStores = %d, want one topology correction", got)
+	}
+	if provider.listCalls != 1 {
+		t.Fatalf("completed fact List calls = %d, want one across both stores", provider.listCalls)
+	}
+	if got := ReconcileCompletedStores(provider, stores, "execution-reconcile"); got != 0 {
+		t.Fatalf("second ReconcileCompletedStores = %d, want exact-fact no-op", got)
+	}
+	if provider.listCalls != 2 {
+		t.Fatalf("completed fact List calls after second pass = %d, want one per pass", provider.listCalls)
+	}
+
+	before, err := backing.List(events.Filter{Type: events.ExecutionStepCompleted})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failing := &countingEventProvider{Provider: backing, listErr: errors.New("journal unavailable")}
+	if got := ReconcileCompletedStores(failing, stores, "execution-reconcile"); got != 0 {
+		t.Fatalf("ReconcileCompletedStores with List error = %d, want fail-closed zero", got)
+	}
+	if failing.listCalls != 1 {
+		t.Fatalf("failed completed fact List calls = %d, want one", failing.listCalls)
+	}
+	after, err := backing.List(events.Filter{Type: events.ExecutionStepCompleted})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("List error recorded events: before=%#v after=%#v", before, after)
+	}
+}
+
+type countingEventProvider struct {
+	events.Provider
+	listCalls int
+	listErr   error
+}
+
+func (p *countingEventProvider) List(filter events.Filter) ([]events.Event, error) {
+	p.listCalls++
+	if p.listErr != nil {
+		return nil, p.listErr
+	}
+	return p.Provider.List(filter)
+}
+
+func TestCompletedFactKeyDistinguishesUnknownFromKnownEmptyTopology(t *testing.T) {
+	base := events.Event{Subject: "gcg-attempt", RunID: "gcg-run", SessionID: "gcs-session", StepID: "build"}
+	var nilSlice []string
+	emptySlice := []string{}
+	unknown := completedFactKeyFor(base)
+	presentNil := completedFactKeyFor(events.Event{
+		Subject: base.Subject, RunID: base.RunID, SessionID: base.SessionID, StepID: base.StepID, DependsOnStepIDs: &nilSlice,
+	})
+	presentEmpty := completedFactKeyFor(events.Event{
+		Subject: base.Subject, RunID: base.RunID, SessionID: base.SessionID, StepID: base.StepID, DependsOnStepIDs: &emptySlice,
+	})
+	if presentNil != presentEmpty {
+		t.Fatalf("present nil topology key = %#v, present empty topology key = %#v; want equality", presentNil, presentEmpty)
+	}
+	if unknown == presentEmpty {
+		t.Fatalf("unknown topology key = %#v, known empty topology key = %#v; want distinction", unknown, presentEmpty)
 	}
 }
 

--- a/internal/executionevent/projector.go
+++ b/internal/executionevent/projector.go
@@ -304,75 +304,109 @@ func EmitCompletedFromClosedNotification(recorder events.Recorder, graphStore be
 // repeated, while a conflicting historical fact remains visible alongside the
 // newly projected correction.
 func ReconcileCompleted(recorder events.Provider, graphStore beads.GraphStore, actor string) int {
-	if recorder == nil || graphStore.Store == nil {
+	return ReconcileCompletedStores(recorder, []beads.GraphStore{graphStore}, actor)
+}
+
+// ReconcileCompletedStores repairs completion facts across graph stores with
+// one journal read. The completed-fact index is updated after each append so
+// the pass remains idempotent even when more than one source is scanned.
+func ReconcileCompletedStores(recorder events.Provider, graphStores []beads.GraphStore, actor string) int {
+	if recorder == nil {
 		return 0
 	}
-	roots, err := graphStore.ListByMetadata(
-		map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
-		0,
-		beads.IncludeClosed,
-		beads.WithBothTiers,
-	)
+	hasStore := false
+	for _, graphStore := range graphStores {
+		if graphStore.Store != nil {
+			hasStore = true
+			break
+		}
+	}
+	if !hasStore {
+		return 0
+	}
+
+	existing, err := recorder.List(events.Filter{Type: events.ExecutionStepCompleted})
 	if err != nil {
+		// If the journal cannot be read, avoid generating duplicate recovery
+		// facts. A later reconciliation pass can safely retry.
 		return 0
 	}
-	sort.Slice(roots, func(i, j int) bool { return roots[i].ID < roots[j].ID })
+	completed := make(map[completedFactKey]struct{}, len(existing))
+	for _, event := range existing {
+		if event.Type == events.ExecutionStepCompleted {
+			completed[completedFactKeyFor(event)] = struct{}{}
+		}
+	}
+
 	emitted := 0
-	for _, root := range roots {
-		if root.Metadata[beadmeta.FormulaContractMetadataKey] != beadmeta.FormulaContractGraphV2 {
+	for _, graphStore := range graphStores {
+		if graphStore.Store == nil {
 			continue
 		}
-		definitions, err := currentSteps(graphStore, root.ID)
+		roots, err := graphStore.ListByMetadata(
+			map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+			0,
+			beads.IncludeClosed,
+			beads.WithBothTiers,
+		)
 		if err != nil {
 			continue
 		}
-		for _, definition := range definitions {
-			step, err := graphStore.Get(definition.BeadID)
-			if err != nil || !strings.EqualFold(strings.TrimSpace(step.Status), "closed") {
+		sort.Slice(roots, func(i, j int) bool { return roots[i].ID < roots[j].ID })
+		for _, root := range roots {
+			if root.Metadata[beadmeta.FormulaContractMetadataKey] != beadmeta.FormulaContractGraphV2 {
 				continue
 			}
-			event, ok := LifecycleEvent(events.ExecutionStepCompleted, root, step, actor)
-			if !ok || completedFactExists(recorder, event) {
+			definitions, err := currentSteps(graphStore, root.ID)
+			if err != nil {
 				continue
 			}
-			recorder.Record(event)
-			emitted++
+			for _, definition := range definitions {
+				step, err := graphStore.Get(definition.BeadID)
+				if err != nil || !strings.EqualFold(strings.TrimSpace(step.Status), "closed") {
+					continue
+				}
+				event, ok := LifecycleEvent(events.ExecutionStepCompleted, root, step, actor)
+				if !ok {
+					continue
+				}
+				key := completedFactKeyFor(event)
+				if _, exists := completed[key]; exists {
+					continue
+				}
+				recorder.Record(event)
+				completed[key] = struct{}{}
+				emitted++
+			}
 		}
 	}
 	return emitted
 }
 
-func completedFactExists(provider events.Provider, want events.Event) bool {
-	existing, err := provider.List(events.Filter{
-		Type: events.ExecutionStepCompleted, Subject: want.Subject,
-	})
-	if err != nil {
-		// If the journal cannot be read, avoid generating duplicate recovery
-		// facts. A later reconciliation pass can safely retry.
-		return true
-	}
-	for _, event := range existing {
-		if event.RunID == want.RunID &&
-			event.SessionID == want.SessionID &&
-			event.StepID == want.StepID &&
-			sameTopology(event.DependsOnStepIDs, want.DependsOnStepIDs) {
-			return true
-		}
-	}
-	return false
+type completedFactKey struct {
+	subject           string
+	runID             string
+	sessionID         string
+	stepID            string
+	topologyKnown     bool
+	topologyCanonical string
 }
 
-func sameTopology(left, right *[]string) bool {
-	if left == nil || right == nil {
-		return left == nil && right == nil
+func completedFactKeyFor(event events.Event) completedFactKey {
+	key := completedFactKey{
+		subject:   event.Subject,
+		runID:     event.RunID,
+		sessionID: event.SessionID,
+		stepID:    event.StepID,
 	}
-	if len(*left) != len(*right) {
-		return false
-	}
-	for i := range *left {
-		if (*left)[i] != (*right)[i] {
-			return false
+	if event.DependsOnStepIDs != nil {
+		key.topologyKnown = true
+		if len(*event.DependsOnStepIDs) == 0 {
+			key.topologyCanonical = "[]"
+			return key
 		}
+		topology, _ := json.Marshal(*event.DependsOnStepIDs)
+		key.topologyCanonical = string(topology)
 	}
-	return true
+	return key
 }


### PR DESCRIPTION
## Summary

- preload existing completion facts once across the federated graph-store scan
- index exact run/session/step/topology tuples and update the index after each append
- preserve UNKNOWN versus known-empty topology semantics and fail closed on journal read errors

## Live defect

After #5040, startup scanned the 146 MB event journal once per missing completion. Live repair advanced at roughly one fact every 40 seconds and kept Maintainer City unready. This changes reconciliation from repeated journal scans to one read plus one graph pass.

## Validation

- RED/GREEN counting-provider regression across two stores
- exact nil versus known-empty topology correction and present nil-slice normalization
- preload-error no-write behavior and repeated-pass idempotency
- focused startup, rig-store, and patrol regressions
- `go test -count=1 ./internal/executionevent`