### PR TITLE
formula: warn when an extends var-override silently drops a parent's required

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -518,6 +518,16 @@ func printGraphV2Deprecations(stderr io.Writer, deprecations []string) {
 	}
 }
 
+// printRecipeWarnings surfaces non-fatal cook-time advisories raised while
+// resolving a formula (e.g. an extends override dropping a parent's required
+// flag, dip-5hkepo). They never gate cook; they make an otherwise-silent drop
+// observable to the operator.
+func printRecipeWarnings(stderr io.Writer, warnings []string) {
+	for _, w := range warnings {
+		fmt.Fprintf(stderr, "warning: %s\n", w) //nolint:errcheck
+	}
+}
+
 func formulaCommandError(stderr io.Writer, command string, jsonOutput bool, err error) error {
 	if err == nil || jsonOutput {
 		return err
@@ -672,6 +682,7 @@ conflicting live workflow from the same source is an error.`,
 						if err != nil {
 							return fmt.Errorf("compile: %w", err)
 						}
+						printRecipeWarnings(stderr, recipe.Warnings)
 						if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Title: title, Vars: cookVars}); err != nil {
 							return fmt.Errorf("validate runtime vars: %w", err)
 						}
@@ -769,6 +780,7 @@ conflicting live workflow from the same source is an error.`,
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook: compile", jsonOutput, err)
 				}
+				printRecipeWarnings(stderr, recipe.Warnings)
 				graphRootKey := ""
 				if inv.InputConvoy != "" {
 					graphRootKey = stampFormulaCookGraphV2Root(recipe, args[0], inv.InputConvoy, cookVars)
@@ -832,6 +844,7 @@ conflicting live workflow from the same source is an error.`,
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook: compile", jsonOutput, err)
 				}
+				printRecipeWarnings(stderr, recipe.Warnings)
 				if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Title: title, Vars: cookVars}); err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -213,7 +213,14 @@ func compileFormula(name string, searchPaths []string, vars map[string]string, v
 	}
 
 	// Stage 13: Flatten to Recipe
-	return toRecipeWithGraph(resolved, graphWorkflow)
+	recipe, err := toRecipeWithGraph(resolved, graphWorkflow)
+	if err != nil {
+		return nil, err
+	}
+	// Surface non-fatal resolve advisories (e.g. an extends override dropping a
+	// parent's required flag, dip-5hkepo) so cook can print them.
+	recipe.Warnings = parser.Warnings()
+	return recipe, nil
 }
 
 func loadResolvedAspectFormula(parser *Parser, name string, collectRequirements formulaRequirementCollector) (*Formula, error) {

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -53,6 +53,37 @@ type Parser struct {
 
 	// resolvingChain tracks the order of formulas being resolved (for error messages).
 	resolvingChain []string
+
+	// warnings accumulates non-fatal cook-time advisories surfaced during
+	// Resolve — e.g. an extends override that drops a parent's required=true
+	// (dip-5hkepo: the whole-VarDef replacement footgun). They never gate
+	// resolution; cook/compile surface them so the drop is observable rather
+	// than silent. Deduplicated on append.
+	warnings []string
+}
+
+// Warnings returns the non-fatal advisories accumulated across Resolve calls
+// on this parser (see the warnings field). Callers (cook/compile) surface these
+// after a successful resolve; an empty slice means none were raised.
+func (p *Parser) Warnings() []string { return p.warnings }
+
+// addWarning appends msg to the parser's warnings, skipping exact duplicates so
+// a diamond extends graph that re-resolves a shared parent warns only once.
+func (p *Parser) addWarning(msg string) {
+	if slices.Contains(p.warnings, msg) {
+		return
+	}
+	p.warnings = append(p.warnings, msg)
+}
+
+// varDefDefaultForWarning renders a child var's default for a required-drop
+// warning: `""` for an explicit empty default, a quoted value for a set
+// default, or <none> when the child declared no default at all.
+func varDefDefaultForWarning(v *VarDef) string {
+	if v == nil || v.Default == nil {
+		return "<none>"
+	}
+	return fmt.Sprintf("%q", *v.Default)
 }
 
 // NewParser creates a new formula parser.
@@ -347,8 +378,23 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 		merged.Compose = mergeComposeRules(merged.Compose, parent.Compose)
 	}
 
-	// Apply child overrides
+	// Apply child overrides. A child VarDef replaces the parent's whole
+	// object, so an override that omits required=true silently drops a
+	// parent's requiredness — the extends guard-neutralization footgun
+	// (dip-5hkepo): a child re-declaring a var with default="" erases a
+	// parent's required=true, and nothing downstream flags the now-optional
+	// empty. We keep the child-wins behavior (a child with a default is
+	// legitimately making the var optional, and required+default are mutually
+	// exclusive), but emit a cook-time warning so the drop is observable
+	// rather than silent.
 	for name, varDef := range formula.Vars {
+		if parentVar, ok := merged.Vars[name]; ok && parentVar != nil && varDef != nil &&
+			parentVar.Required && !varDef.Required {
+			p.addWarning(fmt.Sprintf(
+				"formula %q: var %q override drops the parent's required=true (child default=%s); "+
+					"the var is no longer required — confirm this is intended (dip-5hkepo)",
+				formula.Formula, name, varDefDefaultForWarning(varDef)))
+		}
 		merged.Vars[name] = varDef
 	}
 

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1261,6 +1261,113 @@ func TestParseFile_AndResolve(t *testing.T) {
 	}
 }
 
+// TestResolve_ExtendsOverrideDropsRequiredWarns covers dip-5hkepo change D:
+// the whole-VarDef extends override lets a child re-declaring a var with
+// default="" silently erase a parent's required=true. The merge keeps
+// child-wins semantics (a child with a default is legitimately optional —
+// required and default are mutually exclusive, and preserving required would
+// break the build-from-plan flow whose plan_path is produced mid-flight), but
+// the drop must no longer be SILENT: Resolve surfaces a cook-time warning.
+func TestResolve_ExtendsOverrideDropsRequiredWarns(t *testing.T) {
+	writePair := func(t *testing.T, childVars string) (*Parser, *Formula) {
+		t.Helper()
+		dir := t.TempDir()
+		formulaDir := filepath.Join(dir, ".beads", "formulas")
+		if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		parent := `{
+  "formula": "from-decompose-base",
+  "version": 1,
+  "type": "workflow",
+  "vars": {
+    "plan_path": {"description": "Approved plan path", "required": true}
+  },
+  "steps": [{"id": "decompose", "title": "Decompose"}]
+}`
+		if err := os.WriteFile(filepath.Join(formulaDir, "from-decompose-base.formula.json"), []byte(parent), 0o644); err != nil {
+			t.Fatalf("write parent: %v", err)
+		}
+		child := fmt.Sprintf(`{
+  "formula": "from-plan-base",
+  "version": 1,
+  "type": "workflow",
+  "extends": ["from-decompose-base"],
+  "vars": %s,
+  "steps": [{"id": "plan", "title": "Plan"}]
+}`, childVars)
+		childPath := filepath.Join(formulaDir, "from-plan-base.formula.json")
+		if err := os.WriteFile(childPath, []byte(child), 0o644); err != nil {
+			t.Fatalf("write child: %v", err)
+		}
+		p := NewParser(formulaDir)
+		f, err := p.ParseFile(childPath)
+		if err != nil {
+			t.Fatalf("ParseFile: %v", err)
+		}
+		return p, f
+	}
+
+	t.Run("default_empty_drop_warns_and_child_wins", func(t *testing.T) {
+		// Child re-declares plan_path with default="" and no required — the
+		// exact dip-5hkepo footgun.
+		p, f := writePair(t, `{"plan_path": {"description": "Plan path to produce", "default": ""}}`)
+		resolved, err := p.Resolve(f)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		// Behavior unchanged: child wins, var is optional with an empty default.
+		got := resolved.Vars["plan_path"]
+		if got == nil {
+			t.Fatal("plan_path var missing after resolve")
+		}
+		if got.Required {
+			t.Error("plan_path.Required = true, want false (child override wins — preserving it would break build-from-plan)")
+		}
+		if got.Default == nil || *got.Default != "" {
+			t.Errorf("plan_path.Default = %v, want non-nil empty string", got.Default)
+		}
+		// The drop is no longer silent: a cook-time warning names the var.
+		if !hasWarningMentioning(p.Warnings(), "plan_path") {
+			t.Errorf("Warnings() = %v, want one mentioning plan_path required-drop", p.Warnings())
+		}
+	})
+
+	t.Run("child_keeps_required_no_warning", func(t *testing.T) {
+		p, f := writePair(t, `{"plan_path": {"description": "Plan path", "required": true}}`)
+		if _, err := p.Resolve(f); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if len(p.Warnings()) != 0 {
+			t.Errorf("Warnings() = %v, want none when the child keeps required=true", p.Warnings())
+		}
+	})
+
+	t.Run("no_override_no_warning", func(t *testing.T) {
+		// Child overrides an unrelated var; plan_path inherited untouched.
+		p, f := writePair(t, `{"env": {"default": "dev"}}`)
+		resolved, err := p.Resolve(f)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if got := resolved.Vars["plan_path"]; got == nil || !got.Required {
+			t.Errorf("inherited plan_path.Required = %v, want required=true preserved", got)
+		}
+		if len(p.Warnings()) != 0 {
+			t.Errorf("Warnings() = %v, want none when plan_path is not overridden", p.Warnings())
+		}
+	})
+}
+
+func hasWarningMentioning(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestResolve_InheritsGraphContractFromParent(t *testing.T) {
 	dir := t.TempDir()
 	formulaDir := filepath.Join(dir, ".beads", "formulas")

--- a/internal/formula/recipe.go
+++ b/internal/formula/recipe.go
@@ -52,6 +52,12 @@ type Recipe struct {
 
 	// FormulaSource is the file path from which the formula was loaded.
 	FormulaSource string
+
+	// Warnings holds non-fatal cook-time advisories raised while resolving the
+	// formula (e.g. an extends override that drops a parent's required flag,
+	// dip-5hkepo). Callers surface these to the operator; they never gate
+	// compilation.
+	Warnings []string
 }
 
 // RecipeStep represents a single step in a compiled recipe.


### PR DESCRIPTION
## formula: warn when an `extends` var-override silently drops a parent's `required`

When a child formula overrides a variable that a parent declared `required = true`, the `extends` merge (`merged.Vars[name] = varDef`) replaces the whole `VarDef` object — silently discarding the parent's `required` flag. There is no signal that the contract was weakened, so a downstream consumer that assumed the variable was required can mint with an empty value (the misconfiguration class behind the empty-artifact-path bug fixed in the companion gascity-packs PR).

**Change:** on that override, `parser.go` now appends a deduplicated cook-time warning (surfaced via `Recipe.Warnings` → `printRecipeWarnings` to stderr) naming the variable and both formulas. **Child-wins behavior is unchanged** — the override still applies exactly as before; this is observability only, so no existing formula changes behavior or breaks.

Deliberately warn-not-preserve: preserving `required=true` through the override would fail legitimate launches where the value is produced mid-flow rather than supplied at launch (runtime var validation runs on raw opts before defaults apply). A warning surfaces the risk without breaking that valid pattern.

### Change size
Production Go: ~74 lines (`parser.go` warning logic + `recipe.go`/`compile.go`/`cmd_formula.go` plumbing). Tests: 107 lines (`parser_test.go`: drop-warns / child-wins / keeps-required-no-warn / no-override-no-warn). No generated, no docs.

### Verification
`go vet ./...` clean; `go build ./...` clean; `go test ./internal/formula/...` PASS including the new `TestResolve_ExtendsOverrideDropsRequiredWarns` (3 subtests). Behavior-preserving; two independent adversarial reviews confirmed side-effect-free.

Companion PR (gascity-packs) carries the decompose-stage hardening that this warning helps surface.
