### PR TITLE
mail: mark-read+close injected auto-handoffs instead of hard-deleting

### DIFF
--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3606,6 +3606,27 @@ func TestMailCheckInjectDoesNotCloseBeads(t *testing.T) {
 	}
 }
 
+// assertAutoHandoffRetainedAddressable pins the dip-6ov51a contract at the inject
+// integration boundary: an injected auto-handoff is MARK-READ + CLOSED and stamped
+// with the retention marker (retain-addressable), NOT hard-deleted, so an
+// unconsumed handoff stays recoverable until the read-gated TTL sweep reclaims it.
+func assertAutoHandoffRetainedAddressable(t *testing.T, store beads.Store, id string) {
+	t.Helper()
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("auto handoff %s must be retained addressable after injection, not hard-deleted; store.Get = %v", id, err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("auto handoff %s status = %q, want closed", id, b.Status)
+	}
+	if got := b.Metadata[mail.ReadMetadataKey]; got != "true" {
+		t.Errorf("auto handoff %s metadata[%q] = %q, want %q (marked read)", id, mail.ReadMetadataKey, got, "true")
+	}
+	if got := b.Metadata["close_reason"]; got != beadmail.RetentionSweepCloseReason {
+		t.Errorf("auto handoff %s close_reason = %q, want %q (retain-addressable)", id, got, beadmail.RetentionSweepCloseReason)
+	}
+}
+
 func TestMailCheckInjectArchivesAutoHandoffMessages(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)
@@ -3632,9 +3653,7 @@ func TestMailCheckInjectArchivesAutoHandoffMessages(t *testing.T) {
 	if !strings.Contains(stdout.String(), auto.ID) {
 		t.Fatalf("injected output missing auto handoff id %s:\n%s", auto.ID, stdout.String())
 	}
-	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("auto handoff mail should be archived after injection, got err=%v", err)
-	}
+	assertAutoHandoffRetainedAddressable(t, store, auto.ID)
 	b, err := store.Get(ordinary.ID)
 	if err != nil {
 		t.Fatalf("ordinary mail should remain: %v", err)
@@ -3645,9 +3664,10 @@ func TestMailCheckInjectArchivesAutoHandoffMessages(t *testing.T) {
 }
 
 // TestMailCheckInjectArchivesEphemeralAutoHandoffMessages verifies that
-// ephemeral (wisp-tier) auto-handoff mail is archived after injection.
+// ephemeral (wisp-tier) auto-handoff mail is retired after injection.
 // gc handoff --auto creates Ephemeral:true beads; BdStore.Get must fall back
-// to the wisp tier so ArchiveInjectedAutoHandoffs can delete them.
+// to the wisp tier so ArchiveInjectedAutoHandoffs can retire them
+// (mark-read + close, retain-addressable — dip-6ov51a).
 func TestMailCheckInjectArchivesEphemeralAutoHandoffMessages(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)
@@ -3671,9 +3691,7 @@ func TestMailCheckInjectArchivesEphemeralAutoHandoffMessages(t *testing.T) {
 	if !strings.Contains(stdout.String(), auto.ID) {
 		t.Fatalf("injected output missing auto handoff id %s:\n%s", auto.ID, stdout.String())
 	}
-	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("ephemeral auto handoff mail should be archived after injection, got err=%v", err)
-	}
+	assertAutoHandoffRetainedAddressable(t, store, auto.ID)
 }
 
 // TestMailCheckInjectFloatsPriorityAutoHandoffIntoWindow is the deliberate
@@ -3719,10 +3737,8 @@ func TestMailCheckInjectFloatsPriorityAutoHandoffIntoWindow(t *testing.T) {
 	if !strings.Contains(stdout.String(), auto.ID) {
 		t.Fatalf("priority:1 auto handoff id %s should float into the injection window:\n%s", auto.ID, stdout.String())
 	}
-	// ...and is archived (deleted) after injection.
-	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("priority:1 auto handoff should be archived after injection, got err=%v", err)
-	}
+	// ...and is retired (mark-read+closed, retain-addressable) after injection.
+	assertAutoHandoffRetainedAddressable(t, store, auto.ID)
 	// The lowest-ranked ordinary message is the one clamped out — still open.
 	clampedOut := ordinaryIDs[len(ordinaryIDs)-1]
 	b, err := store.Get(clampedOut)
@@ -4637,9 +4653,7 @@ name = "mayor"
 	if strings.Contains(stdout.String(), "msg-1") {
 		t.Fatalf("inject path used API inbox instead of local provider:\n%s", stdout.String())
 	}
-	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("auto handoff mail should be archived after local injection, got err=%v", err)
-	}
+	assertAutoHandoffRetainedAddressable(t, store, auto.ID)
 }
 
 func TestRenderMailCheckFromAPIInjectCodexUsesUserPromptSubmit(t *testing.T) {

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -877,9 +877,7 @@ provider = "exec:/not-used-by-auto-handoff"
 			if strings.Contains(context, ordinary.ID) || strings.Contains(context, ordinary.Body) {
 				t.Fatalf("additionalContext = %q, want no ordinary mail %q from the exec: provider at SessionStart", context, ordinary.ID)
 			}
-			if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
-				t.Fatalf("auto-handoff should be archived after SessionStart injection, got err=%v", err)
-			}
+			assertAutoHandoffRetainedAddressable(t, store, auto.ID)
 			if _, err := store.Get(ordinary.ID); err != nil {
 				t.Fatalf("ordinary mail should remain for UserPromptSubmit: %v", err)
 			}
@@ -1086,9 +1084,7 @@ prompt_template = "prompts/worker.md"
 	if !strings.Contains(hookStdout.String(), auto.ID) {
 		t.Fatalf("hook output = %q, want auto-handoff %q", hookStdout.String(), auto.ID)
 	}
-	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
-		t.Fatalf("auto-handoff should be archived after the real SessionStart injection, got err=%v", err)
-	}
+	assertAutoHandoffRetainedAddressable(t, store, auto.ID)
 }
 
 func TestDoPrimeWithHookFormat_GatesDefaultFallbackWithoutManagedSession(t *testing.T) {

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -438,8 +438,19 @@ func (p *Provider) ArchiveMatching(filter ArchiveFilter) ([]mail.Message, []mail
 	return candidates, results, nil
 }
 
-// ArchiveInjectedAutoHandoffs archives auto-handoff messages after they have
-// been injected into a provider hook. Ordinary user mail is left untouched.
+// ArchiveInjectedAutoHandoffs retires auto-handoff messages after they have been
+// injected into a provider hook. Ordinary user mail is left untouched.
+//
+// It MARKS-READ + CLOSES each handoff (retain-addressable) rather than hard
+// store.Delete. The former Delete permanently lost an injected-but-unconsumed
+// handoff (dip-6ov51a): "injected" only means gc-prime's stdout write returned
+// nil — it says nothing about whether the recycled agent consumed the GO the
+// handoff carries before a crash/race/re-cycle. Marking read stops re-injection
+// (CheckAutoHandoffs fetches only unread); closing with RetentionSweepCloseReason
+// keeps the bead addressable (isRemovedMessageBead treats it as system-aged, not
+// user-removed) so an unconsumed handoff stays recoverable, and the already-correct
+// read-gated TTL sweep (PurgeReadMessageWisps) reclaims it later — one unified
+// retention path, no special-case delete, no permanent data loss.
 func (p *Provider) ArchiveInjectedAutoHandoffs(ids []string) error {
 	var errs []error
 	for _, id := range ids {
@@ -460,7 +471,23 @@ func (p *Provider) ArchiveInjectedAutoHandoffs(ids []string) error {
 			!hasLabel(b.Labels, mail.ArchiveAfterInjectLabel) {
 			continue
 		}
-		if err := p.store.Delete(id); err != nil && !errors.Is(err, beads.ErrNotFound) {
+		// Mark read (label + metadata) so a later SessionStart does not re-inject
+		// it and the read-gated TTL sweep can later reclaim it.
+		if err := p.store.Update(id, beads.UpdateOpts{
+			Labels:   []string{"read"},
+			Metadata: map[string]string{mail.ReadMetadataKey: "true"},
+		}); err != nil && !errors.Is(err, beads.ErrNotFound) {
+			errs = append(errs, fmt.Errorf("marking %s read: %w", id, err))
+			continue
+		}
+		// Stamp the retention marker then close, mirroring SweepReadMessagesBefore
+		// so isRemovedMessageBead keeps the closed handoff addressable (recoverable)
+		// until PurgeReadMessageWisps reclaims it — never a hard delete here.
+		if err := p.store.SetMetadata(id, "close_reason", RetentionSweepCloseReason); err != nil && !errors.Is(err, beads.ErrNotFound) {
+			errs = append(errs, fmt.Errorf("stamping %s close_reason: %w", id, err))
+			continue
+		}
+		if err := p.store.Close(id); err != nil && !errors.Is(err, beads.ErrNotFound) {
 			errs = append(errs, fmt.Errorf("archiving %s: %w", id, err))
 		}
 	}

--- a/internal/mail/beadmail/handoff_archive_test.go
+++ b/internal/mail/beadmail/handoff_archive_test.go
@@ -1,0 +1,151 @@
+package beadmail
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail"
+)
+
+// sendInjectableAutoHandoff creates an unread auto-handoff message bead carrying
+// both the AutoHandoffLabel and ArchiveAfterInjectLabel — the exact shape
+// sessionStartAutoHandoffInjection fetches and hands to ArchiveInjectedAutoHandoffs.
+func sendInjectableAutoHandoff(t *testing.T, p *Provider, subject string) mail.Message {
+	t.Helper()
+	msg, err := p.SendHandoff(mail.HandoffIntent{
+		From:     "worker",
+		To:       "worker",
+		Subject:  subject,
+		Body:     "continue durable work — carries a GO",
+		ThreadID: "thread-" + subject,
+		ExtraLabels: []string{
+			mail.AutoHandoffLabel,
+			mail.ArchiveAfterInjectLabel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SendHandoff(%s): %v", subject, err)
+	}
+	return msg
+}
+
+// TestArchiveInjectedAutoHandoffMarksReadRetainsAddressable is the golden TDD
+// pin for dip-6ov51a: ArchiveInjectedAutoHandoffs must MARK-READ + CLOSE
+// (retain-addressable), NOT hard-delete. An injected-but-unconsumed auto-handoff
+// (the write returned nil, but nothing proves the recycled agent consumed the
+// GO it carries) must survive as a recoverable, addressable bead — never
+// permanently lost. Covers spec acceptance 1 (marked read + closed but still
+// addressable), 2 (a second SessionStart does not re-inject it), and 5 (no new
+// hard-Delete of any message bead in the inject path).
+func TestArchiveInjectedAutoHandoffMarksReadRetainsAddressable(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	auto := sendInjectableAutoHandoff(t, p, "context-cycle")
+
+	if err := p.ArchiveInjectedAutoHandoffs([]string{auto.ID}); err != nil {
+		t.Fatalf("ArchiveInjectedAutoHandoffs: %v", err)
+	}
+
+	// Acceptance 5: NOT hard-deleted — the bead still exists at the store level.
+	raw, err := store.Get(auto.ID)
+	if err != nil {
+		t.Fatalf("store.Get after archive = %v; injected handoff was hard-deleted (the dip-6ov51a data loss)", err)
+	}
+
+	// Acceptance 1: marked read + closed, stamped with the retention marker that
+	// keeps it addressable (mirrors the read-gated TTL sweep).
+	if raw.Status != "closed" {
+		t.Errorf("raw.Status = %q, want closed", raw.Status)
+	}
+	if !hasLabel(raw.Labels, "read") {
+		t.Errorf("raw.Labels = %#v, missing %q (must be marked read)", raw.Labels, "read")
+	}
+	if got := raw.Metadata[mail.ReadMetadataKey]; got != "true" {
+		t.Errorf("raw.Metadata[%q] = %q, want %q", mail.ReadMetadataKey, got, "true")
+	}
+	if got := raw.Metadata["close_reason"]; got != RetentionSweepCloseReason {
+		t.Errorf("raw close_reason = %q, want %q (retain-addressable marker)", got, RetentionSweepCloseReason)
+	}
+
+	// Acceptance 1: still addressable through the Provider surface (recoverable
+	// via gc mail show / bd show), exactly like retention-swept read mail — not
+	// treated as user-removed.
+	if _, err := p.Get(auto.ID); err != nil {
+		t.Errorf("p.Get(injected auto-handoff) = %v, want addressable", err)
+	}
+	if _, err := p.Read(auto.ID); err != nil {
+		t.Errorf("p.Read(injected auto-handoff) = %v, want addressable", err)
+	}
+
+	// Acceptance 2: a second SessionStart must not re-inject it. CheckAutoHandoffs
+	// fetches only UNREAD open handoffs; the read+closed bead is excluded.
+	again, err := p.CheckAutoHandoffs([]string{"worker"})
+	if err != nil {
+		t.Fatalf("CheckAutoHandoffs after archive: %v", err)
+	}
+	for _, m := range again {
+		if m.ID == auto.ID {
+			t.Errorf("CheckAutoHandoffs re-surfaced archived handoff %q — would re-inject", auto.ID)
+		}
+	}
+}
+
+// TestArchiveInjectedAutoHandoffReclaimedByReadGatedTTLSweep proves the unified
+// retention path: after inject-archive marks the handoff read, the already-correct
+// read-gated TTL sweep (PurgeReadMessageWisps) reclaims it once it ages past the
+// retention window — one retention path, no special-case delete. It also pins the
+// unread-not-swept regression guard (spec acceptance 3 and 4): an auto-handoff
+// that was never injected stays unread and MUST survive the same sweep, so an
+// unconsumed-and-unarchived handoff is never reclaimed out from under a recycle.
+func TestArchiveInjectedAutoHandoffReclaimedByReadGatedTTLSweep(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	injected := sendInjectableAutoHandoff(t, p, "injected-cycle")
+	neverInjected := sendInjectableAutoHandoff(t, p, "never-injected-cycle")
+
+	if err := p.ArchiveInjectedAutoHandoffs([]string{injected.ID}); err != nil {
+		t.Fatalf("ArchiveInjectedAutoHandoffs: %v", err)
+	}
+
+	// Acceptance 3: immediately after inject the handoff is still recoverable —
+	// it survives the inject, it is not gone.
+	if _, err := p.Get(injected.ID); err != nil {
+		t.Fatalf("p.Get(injected) right after archive = %v, want recoverable", err)
+	}
+
+	// The read-gated wisp sweep reclaims read mail aged past the cutoff. Both
+	// handoffs are wisp-tier (SendHandoff sets Ephemeral); only the read
+	// (injected) one is a candidate.
+	cutoff := time.Now().Add(time.Hour)
+	purged, err := PurgeReadMessageWisps(beads.MailStore{Store: store}, cutoff)
+	if err != nil {
+		t.Fatalf("PurgeReadMessageWisps: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (only the read injected handoff)", purged)
+	}
+
+	// The injected+read handoff is reclaimed by the TTL sweep (its recoverable
+	// window has elapsed) — the one unified retention path.
+	if _, err := store.Get(injected.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("store.Get(injected) after purge = %v, want ErrNotFound (reclaimed)", err)
+	}
+
+	// Acceptance 4 (read-gate regression): the never-injected handoff stayed
+	// UNREAD and must NOT be swept — an unconsumed, unarchived handoff is never
+	// reclaimed by the read-gated sweep.
+	survivor, err := store.Get(neverInjected.ID)
+	if err != nil {
+		t.Fatalf("store.Get(neverInjected) after purge = %v; unread handoff must not be swept", err)
+	}
+	if survivor.Status != "open" {
+		t.Errorf("neverInjected.Status = %q, want open (unread handoff untouched)", survivor.Status)
+	}
+	if hasLabel(survivor.Labels, "read") {
+		t.Errorf("neverInjected must not be marked read; labels = %#v", survivor.Labels)
+	}
+}


### PR DESCRIPTION
## mail: mark-read + close injected auto-handoffs instead of hard-deleting them

`ArchiveInjectedAutoHandoffs` hard-`Delete`d unread auto-handoff mail (a context-cycle continuation carrying a GO/signal) the instant `gc prime`'s stdout write returned nil — with no read/ack gate. "Injected" only means the CLI's `Fprint` returned; it says nothing about whether the recycled agent actually consumed the handoff before a crash/race/re-cycle. So a handoff lost in that window was permanently deleted.

**Change:** replace the hard-`Delete` with **mark-read + close (retain-addressable)**. Mark-read stops re-injection (the inject query fetches only unread); closing with `RetentionSweepCloseReason` keeps the bead addressable (`isRemovedMessageBead` treats that reason as not-removed), so an unconsumed handoff is recoverable; the already-correct read-gated TTL sweep reclaims it later. One unified retention path, no special-case delete, no permanent data-loss. (The TTL sweep itself was already correctly read-gated and is unchanged.)

**Size:** ~20 production lines (one function) + tests. **Verification:** the mark-read `Update` is byte-identical to canonical `MarkRead`; additive label semantics verified across MemStore/NativeDolt/BdStore; every branch of the 3-step (mark-read → stamp → close) partial-failure ordering is idempotent and self-heals via the read-gated sweep. New tests assert the handoff survives inject + is addressable + is later TTL-reclaimed (non-vacuous: a revert to hard-delete fails them). `go build/vet/test` green. Two independent adversarial reviews: both green.

Note (transparency): one cosmetic stale "archiving …" stderr string remains (non-functional).
