### PR TITLE
session: keep the min_active_sessions pool floor warm (idle-timeout exempt)

### DIFF
--- a/cmd/gc/session_progress.go
+++ b/cmd/gc/session_progress.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -32,9 +33,17 @@ func openPoolSessionCountForTemplate(infoByID map[string]sessionpkg.Info, cfg *c
 // only StateNone (freshly stamped, not yet transitioned), StateActive and
 // StateAwake (running; Awake is the reconciler healState alias for Active —
 // session_reconcile.go / lifecycle_projection.go RuntimeProjectionAlive),
-// StateCreating, and StateStartPending count. This mirrors countMinActiveCovered's
-// covering-states convention (compute_awake_set.go) rather than diverging into a
-// deny-list.
+// StateCreating, and StateStartPending count.
+//
+// It adopts countMinActiveCovered's allow-list SHAPE (compute_awake_set.go)
+// rather than diverging into a deny-list — but deliberately not its state SET.
+// countMinActiveCovered admits only active/creating (plus an asleep bead an
+// earlier pass already marked desired-awake); this predicate additionally
+// admits Awake, StartPending and StateNone, and never admits asleep. The two
+// answer different questions: this one ranks the CURRENT warm occupancy of one
+// session, so anything on its way to (or already) running counts and a dormant
+// bead never does, while countMinActiveCovered counts coverage of the floor
+// including the asleep sessions this tick's wake pass will revive.
 //
 // Why an allow-list (Doc adversarial re-review, sc-sabwwn): every other state —
 // Asleep, Suspended, Draining, Drained, Archived, FailedCreate, Quarantined,
@@ -69,6 +78,18 @@ func isWarmFloorCandidate(info sessionpkg.Info) bool {
 // tick (sc-5mtyhy). This is the per-session, deterministic complement to the
 // count-based isMinFloorIdleWorker the progress-stall recycler uses.
 //
+// The exempt set is the POOL-MANAGED floor members only. Ranking mirrors
+// isMinActivePoolBead (compute_awake_set.go), the predicate that defines which
+// beads the min_active_sessions guarantee covers: configured-named, manual and
+// dependency-only sessions are excluded because they carry their own keep-awake
+// rules and never participate in the floor. Excluding them matters in both
+// directions — a lower-id non-pool session must not consume a floor rank (which
+// would push the real pool member out of the exempt set and no-op this fix in a
+// mixed-identity template), and a non-pool session must never become
+// idle-exempt itself. Like isMinActivePoolBead the filter is exclusion-based:
+// it does NOT require a positive pool-managed flag, so legacy pool beads
+// predating that projection still rank.
+//
 // Determinism (spec acceptance 4): the exempt set is the minSess lowest-id warm
 // same-template pool sessions, mirroring cityStopPoolBeads' bead-ID ordering, so
 // the same concrete sessions stay warm tick over tick with no flapping over
@@ -95,6 +116,13 @@ func isMinFloorExemptIdleSession(infoByID map[string]sessionpkg.Info, cfg *confi
 	lower := 0
 	for sid, info := range infoByID {
 		if !isWarmFloorCandidate(info) || normalizedSessionTemplateInfo(info, cfg) != template {
+			continue
+		}
+		// Pool-managed identities only, mirroring isMinActivePoolBead. The
+		// filter runs before the self-check below, so an excluded identity
+		// neither consumes a floor rank nor becomes exempt itself.
+		if isNamedSessionInfo(info) || strings.TrimSpace(info.ConfiguredNamedIdentity) != "" ||
+			isManualSessionInfo(info) || info.DependencyOnly {
 			continue
 		}
 		switch {

--- a/cmd/gc/session_progress.go
+++ b/cmd/gc/session_progress.go
@@ -26,6 +26,71 @@ func openPoolSessionCountForTemplate(infoByID map[string]sessionpkg.Info, cfg *c
 	return open
 }
 
+// isWarmFloorCandidate reports whether a session Info currently occupies a warm
+// min_active_sessions floor slot: an open, live pool instance (anything not
+// closed and not asleep/draining/suspended). It deliberately EXCLUDES asleep
+// sessions so a dormant low-id bead — e.g. a max-session-age-slept floor
+// session awaiting min-fill recreation — can never mask a live higher-id
+// session out of the deterministic exempt set and get that warm session
+// idle-killed. Creating and freshly-stamped (empty-state) sessions count: they
+// are legitimate floor occupants on their way to active, matching
+// countMinActiveCovered's "covered" notion.
+func isWarmFloorCandidate(info sessionpkg.Info) bool {
+	if info.Closed {
+		return false
+	}
+	switch info.State {
+	case sessionpkg.StateAsleep, sessionpkg.StateDraining, sessionpkg.StateSuspended, sessionpkg.StateClosed:
+		return false
+	}
+	return true
+}
+
+// isMinFloorExemptIdleSession reports whether sessionID is one of the
+// deterministic min_active_sessions floor members for template — the minSess
+// lowest-bead-id warm pool sessions — which the idle-timeout path keeps WARM
+// (exempt from the idle kill) instead of killing and cold-recreating it every
+// tick (sc-5mtyhy). This is the per-session, deterministic complement to the
+// count-based isMinFloorIdleWorker the progress-stall recycler uses.
+//
+// Determinism (spec acceptance 4): the exempt set is the minSess lowest-id warm
+// same-template pool sessions, mirroring cityStopPoolBeads' bead-ID ordering, so
+// the same concrete sessions stay warm tick over tick with no flapping over
+// which one is exempt. sessionID is exempt exactly when it is itself a warm
+// same-template pool session AND fewer than minSess such sessions sort below its
+// ID. Elastic sessions ABOVE the floor are never exempt and idle-reclaim
+// normally (acceptance 2); max_active_sessions still caps the total because this
+// only defers idle kills for the bottom minSess sessions — it never creates any.
+//
+// Selection reads the coherent infoByID snapshot and cfg in memory; no I/O.
+func isMinFloorExemptIdleSession(infoByID map[string]sessionpkg.Info, cfg *config.City, template, sessionID string) bool {
+	if cfg == nil || sessionID == "" {
+		return false
+	}
+	cfgAgent := findAgentByTemplate(cfg, template)
+	if cfgAgent == nil {
+		return false
+	}
+	minFloor := cfgAgent.EffectiveMinActiveSessions()
+	if minFloor <= 0 {
+		return false
+	}
+	self := false
+	lower := 0
+	for sid, info := range infoByID {
+		if !isWarmFloorCandidate(info) || normalizedSessionTemplateInfo(info, cfg) != template {
+			continue
+		}
+		switch {
+		case sid == sessionID:
+			self = true
+		case sid < sessionID:
+			lower++
+		}
+	}
+	return self && lower < minFloor
+}
+
 // isMinFloorIdleWorker reports whether a session is a legitimate pool floor
 // worker that should be exempt from the progress-stall recycler.
 //

--- a/cmd/gc/session_progress.go
+++ b/cmd/gc/session_progress.go
@@ -27,23 +27,39 @@ func openPoolSessionCountForTemplate(infoByID map[string]sessionpkg.Info, cfg *c
 }
 
 // isWarmFloorCandidate reports whether a session Info currently occupies a warm
-// min_active_sessions floor slot: an open, live pool instance (anything not
-// closed and not asleep/draining/suspended). It deliberately EXCLUDES asleep
-// sessions so a dormant low-id bead — e.g. a max-session-age-slept floor
-// session awaiting min-fill recreation — can never mask a live higher-id
-// session out of the deterministic exempt set and get that warm session
-// idle-killed. Creating and freshly-stamped (empty-state) sessions count: they
-// are legitimate floor occupants on their way to active, matching
-// countMinActiveCovered's "covered" notion.
+// min_active_sessions floor slot: an open session in a genuinely-live runtime
+// state (on its way to, or currently, active). It is an explicit ALLOW-LIST —
+// only StateNone (freshly stamped, not yet transitioned), StateActive and
+// StateAwake (running; Awake is the reconciler healState alias for Active —
+// session_reconcile.go / lifecycle_projection.go RuntimeProjectionAlive),
+// StateCreating, and StateStartPending count. This mirrors countMinActiveCovered's
+// covering-states convention (compute_awake_set.go) rather than diverging into a
+// deny-list.
+//
+// Why an allow-list (Doc adversarial re-review, sc-sabwwn): every other state —
+// Asleep, Suspended, Draining, Drained, Archived, FailedCreate, Quarantined,
+// Closed — is a dormant, terminal, or non-runnable bead that can persist with
+// Closed==false yet is NOT a warm occupant. Counting any such stale low-id bead
+// would inflate the floor rank in isMinFloorExemptIdleSession and mask the ACTUAL
+// live low-id floor session out of the deterministic exempt set, getting that
+// warm session idle-killed and cold-recreated — the exact 0<->1 oscillation this
+// fix (sc-5mtyhy) exists to eliminate. A deny-list silently reopened that gap for
+// every state it forgot (Quarantined/FailedCreate/Drained/Archived did leak); the
+// allow-list fails closed — an unknown or newly-added state is excluded, never a
+// spurious floor occupant. The info.Closed guard stays first: a closed bead has
+// State=="" (StateNone), which the allow-list admits, so occupancy must be
+// rejected on Closed before the state switch.
 func isWarmFloorCandidate(info sessionpkg.Info) bool {
 	if info.Closed {
 		return false
 	}
 	switch info.State {
-	case sessionpkg.StateAsleep, sessionpkg.StateDraining, sessionpkg.StateSuspended, sessionpkg.StateClosed:
+	case sessionpkg.StateNone, sessionpkg.StateActive, sessionpkg.StateAwake,
+		sessionpkg.StateCreating, sessionpkg.StateStartPending:
+		return true
+	default:
 		return false
 	}
-	return true
 }
 
 // isMinFloorExemptIdleSession reports whether sessionID is one of the

--- a/cmd/gc/session_progress_test.go
+++ b/cmd/gc/session_progress_test.go
@@ -110,6 +110,45 @@ func TestIsMinFloorExemptIdleSession(t *testing.T) {
 		}
 	})
 
+	t.Run("a stale low-id session in a non-live state does not mask a live higher-id floor member", func(t *testing.T) {
+		// Doc adversarial re-review (sc-sabwwn): the prior isWarmFloorCandidate
+		// deny-list excluded only Asleep/Draining/Suspended/Closed, so a stale
+		// low-id bead in any of these four non-terminal, non-live states (all
+		// persist with Closed==false) inflated the floor rank and masked the live
+		// floor member out of the exempt set — reproducing the kill->cold-recreate
+		// oscillation the fix eliminates. The allow-list excludes each of them, so
+		// the live s-b stays exempt — the same guarantee the Asleep guard proves.
+		staleStates := []sessionpkg.State{
+			sessionpkg.StateQuarantined,
+			sessionpkg.StateFailedCreate,
+			sessionpkg.StateDrained,
+			sessionpkg.StateArchived,
+		}
+		for _, st := range staleStates {
+			stale := sessionpkg.Info{ID: "s-a", Template: "worker", State: st}
+			infoByID := map[string]sessionpkg.Info{"s-a": stale, "s-b": warm("s-b")}
+			if !isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-b") {
+				t.Errorf("state %q: the live s-b must be exempt; a stale low-id s-a in %q must not mask it", st, st)
+			}
+		}
+	})
+
+	t.Run("an awake low-id session IS a live floor member and stays exempt", func(t *testing.T) {
+		// Guards the allow-list's inclusion of StateAwake (the healState alive
+		// alias): a healed-to-awake floor session is genuinely warm, so at min=1
+		// the lowest-id awake session must be the exempt member — omitting Awake
+		// would idle-kill the most common warm state and reproduce the oscillation
+		// in the opposite (under-exemption) direction.
+		awake := sessionpkg.Info{ID: "s-a", Template: "worker", State: sessionpkg.StateAwake}
+		infoByID := map[string]sessionpkg.Info{"s-a": awake, "s-b": warm("s-b")}
+		if !isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-a") {
+			t.Fatal("the awake low-id s-a is a live floor member and must be exempt")
+		}
+		if isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-b") {
+			t.Fatal("s-b is above the floor (s-a is a live awake occupant) and must NOT be exempt")
+		}
+	})
+
 	t.Run("other-template and closed sessions are excluded from the count", func(t *testing.T) {
 		infoByID := map[string]sessionpkg.Info{
 			"s-a": {ID: "s-a", Template: "scout", State: sessionpkg.StateActive},                // other template
@@ -140,21 +179,37 @@ func TestIsMinFloorExemptIdleSession(t *testing.T) {
 	})
 }
 
-// TestIsWarmFloorCandidate pins which session states occupy a warm floor slot:
-// live sessions (active/creating/fresh) count; closed and asleep/draining/
-// suspended sessions do not.
+// TestIsWarmFloorCandidate pins the explicit ALLOW-LIST of states that occupy a
+// warm floor slot: only genuinely-live sessions count — StateNone (fresh),
+// Active, Awake (the healState alive alias), Creating, StartPending. Every other
+// state, including the four Doc's adversarial re-review flagged as leaking under
+// the prior deny-list (Quarantined, FailedCreate, Drained, Archived) plus
+// Asleep/Draining/Suspended/Closed, is NOT a warm occupant (sc-sabwwn). An
+// allow-list fails closed: a state absent from the table is excluded by default.
 func TestIsWarmFloorCandidate(t *testing.T) {
 	cases := []struct {
 		state sessionpkg.State
 		want  bool
 	}{
+		// Live — count toward the warm floor.
 		{sessionpkg.StateActive, true},
+		{sessionpkg.StateAwake, true}, // healState alias for Active — must count, else healed-alive floor sessions get idle-killed
 		{sessionpkg.StateCreating, true},
-		{"", true}, // freshly stamped, not yet active
+		{sessionpkg.StateStartPending, true},
+		{sessionpkg.StateNone, true}, // freshly stamped, not yet active
+		{"", true},                   // StateNone spelled literally — same admit
+		// Dormant / non-runnable — must NOT count.
 		{sessionpkg.StateAsleep, false},
 		{sessionpkg.StateDraining, false},
 		{sessionpkg.StateSuspended, false},
 		{sessionpkg.StateClosed, false},
+		// The four states the prior deny-list forgot (Doc HOLD, sc-sabwwn): each
+		// persists with Closed==false but is stale/non-live, so counting it would
+		// mask the live floor member and reproduce the kill->recreate oscillation.
+		{sessionpkg.StateQuarantined, false},
+		{sessionpkg.StateFailedCreate, false},
+		{sessionpkg.StateDrained, false},
+		{sessionpkg.StateArchived, false},
 	}
 	for _, tc := range cases {
 		if got := isWarmFloorCandidate(sessionpkg.Info{State: tc.state}); got != tc.want {
@@ -163,6 +218,11 @@ func TestIsWarmFloorCandidate(t *testing.T) {
 	}
 	if isWarmFloorCandidate(sessionpkg.Info{State: sessionpkg.StateActive, Closed: true}) {
 		t.Error("a Closed session is never a warm floor candidate")
+	}
+	// The Closed guard must reject even when State=="" (StateNone) — a closed
+	// bead's state is blanked to "", which the allow-list would otherwise admit.
+	if isWarmFloorCandidate(sessionpkg.Info{State: sessionpkg.StateNone, Closed: true}) {
+		t.Error("a Closed session with a blanked (StateNone) state must still be rejected by the Closed guard")
 	}
 }
 

--- a/cmd/gc/session_progress_test.go
+++ b/cmd/gc/session_progress_test.go
@@ -177,6 +177,46 @@ func TestIsMinFloorExemptIdleSession(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("non-pool identities neither consume a floor rank nor are exempt themselves", func(t *testing.T) {
+		// The min_active_sessions guarantee covers pool-managed beads only
+		// (isMinActivePoolBead, compute_awake_set.go): configured-named,
+		// manual and dependency-only sessions are excluded. A lower-id
+		// non-pool session must not push the real pool member (s-b) out of
+		// the min=1 exempt set — that would silently no-op the keep-warm fix
+		// in a mixed-identity template — and must not become idle-exempt
+		// itself, which would extend the exemption beyond the pool floor.
+		cases := []struct {
+			name string
+			info sessionpkg.Info
+		}{
+			{"configured-named session", sessionpkg.Info{
+				ID: "s-a", Template: "worker", State: sessionpkg.StateActive,
+				ConfiguredNamedSession: true,
+			}},
+			{"configured-named identity", sessionpkg.Info{
+				ID: "s-a", Template: "worker", State: sessionpkg.StateActive,
+				ConfiguredNamedIdentity: "worker#1",
+			}},
+			{"manual session", sessionpkg.Info{
+				ID: "s-a", Template: "worker", State: sessionpkg.StateActive,
+				SessionOrigin: "manual",
+			}},
+			{"dependency-only session", sessionpkg.Info{
+				ID: "s-a", Template: "worker", State: sessionpkg.StateActive,
+				DependencyOnly: true,
+			}},
+		}
+		for _, tc := range cases {
+			infoByID := map[string]sessionpkg.Info{"s-a": tc.info, "s-b": warm("s-b")}
+			if !isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-b") {
+				t.Errorf("%s: the pool member s-b must stay exempt; a lower-id %s must not consume the floor rank", tc.name, tc.name)
+			}
+			if isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-a") {
+				t.Errorf("%s: a non-pool session must never be min-floor exempt itself", tc.name)
+			}
+		}
+	})
 }
 
 // TestIsWarmFloorCandidate pins the explicit ALLOW-LIST of states that occupy a

--- a/cmd/gc/session_progress_test.go
+++ b/cmd/gc/session_progress_test.go
@@ -30,6 +30,142 @@ func TestOpenPoolSessionCountForTemplateExcludesClosed(t *testing.T) {
 	}
 }
 
+// floorCfg builds a one-agent city whose pool has the given min_active_sessions
+// floor, matching the shape findAgentByTemplate/EffectiveMinActiveSessions read.
+func floorCfg(minFloor int) *config.City {
+	agent := config.Agent{Name: "worker"}
+	if minFloor > 0 {
+		agent.MinActiveSessions = intPtr(minFloor)
+	}
+	return &config.City{Agents: []config.Agent{agent}}
+}
+
+// warm builds an open, active same-template session Info for the floor-exempt
+// selection tests, keyed by its bead ID (the deterministic ordering key).
+func warm(id string) sessionpkg.Info {
+	return sessionpkg.Info{ID: id, Template: "worker", State: sessionpkg.StateActive}
+}
+
+// TestIsMinFloorExemptIdleSession pins the deterministic per-session floor
+// selection that keeps min_active_sessions sessions warm across idle timeout
+// (sc-5mtyhy). It is the acceptance-2/4 core: the minSess lowest-bead-id warm
+// sessions are exempt and stay exempt tick over tick; above-floor elastic
+// sessions are never exempt and idle-reclaim normally.
+func TestIsMinFloorExemptIdleSession(t *testing.T) {
+	t.Run("at floor: the single warm session is exempt", func(t *testing.T) {
+		infoByID := map[string]sessionpkg.Info{"s-a": warm("s-a")}
+		if !isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-a") {
+			t.Fatal("min=1, one warm session: it must be the exempt floor member")
+		}
+	})
+
+	t.Run("above floor: only the minSess lowest-id sessions are exempt", func(t *testing.T) {
+		// min=1, three warm sessions: only the lowest-id (s-a) stays warm; the
+		// two above-floor elastic sessions (s-b, s-c) idle-reclaim (acceptance 2).
+		infoByID := map[string]sessionpkg.Info{
+			"s-a": warm("s-a"), "s-b": warm("s-b"), "s-c": warm("s-c"),
+		}
+		cfg := floorCfg(1)
+		if !isMinFloorExemptIdleSession(infoByID, cfg, "worker", "s-a") {
+			t.Error("s-a (lowest id) must be exempt")
+		}
+		if isMinFloorExemptIdleSession(infoByID, cfg, "worker", "s-b") {
+			t.Error("s-b is above the floor and must NOT be exempt")
+		}
+		if isMinFloorExemptIdleSession(infoByID, cfg, "worker", "s-c") {
+			t.Error("s-c is above the floor and must NOT be exempt")
+		}
+	})
+
+	t.Run("min=2 exempts the two lowest-id, not the third", func(t *testing.T) {
+		infoByID := map[string]sessionpkg.Info{
+			"s-a": warm("s-a"), "s-b": warm("s-b"), "s-c": warm("s-c"),
+		}
+		cfg := floorCfg(2)
+		if !isMinFloorExemptIdleSession(infoByID, cfg, "worker", "s-a") ||
+			!isMinFloorExemptIdleSession(infoByID, cfg, "worker", "s-b") {
+			t.Error("the two lowest-id sessions (s-a, s-b) must both be exempt at min=2")
+		}
+		if isMinFloorExemptIdleSession(infoByID, cfg, "worker", "s-c") {
+			t.Error("s-c is the third session, above a floor of 2, and must NOT be exempt")
+		}
+	})
+
+	t.Run("no floor: nothing is exempt", func(t *testing.T) {
+		infoByID := map[string]sessionpkg.Info{"s-a": warm("s-a")}
+		if isMinFloorExemptIdleSession(infoByID, floorCfg(0), "worker", "s-a") {
+			t.Fatal("min=0 (no floor): no session may be exempt")
+		}
+	})
+
+	t.Run("asleep low-id session does not mask a live higher-id one", func(t *testing.T) {
+		// s-a is asleep (e.g. max-age-slept awaiting min-fill); the live floor
+		// member is s-b. Counting s-a would push s-b above the floor and get the
+		// only WARM session idle-killed — the exact regression the state filter
+		// prevents. s-b must be exempt.
+		asleep := sessionpkg.Info{ID: "s-a", Template: "worker", State: sessionpkg.StateAsleep}
+		infoByID := map[string]sessionpkg.Info{"s-a": asleep, "s-b": warm("s-b")}
+		if !isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-b") {
+			t.Fatal("the live session s-b must be exempt; the asleep low-id s-a must not mask it")
+		}
+	})
+
+	t.Run("other-template and closed sessions are excluded from the count", func(t *testing.T) {
+		infoByID := map[string]sessionpkg.Info{
+			"s-a": {ID: "s-a", Template: "scout", State: sessionpkg.StateActive},                // other template
+			"s-b": {ID: "s-b", Template: "worker", State: sessionpkg.StateActive, Closed: true}, // closed
+			"s-c": warm("s-c"),                                                                  // the sole open worker
+		}
+		if !isMinFloorExemptIdleSession(infoByID, floorCfg(1), "worker", "s-c") {
+			t.Fatal("s-c is the only open worker; the scout and the closed worker must not count against it")
+		}
+	})
+
+	t.Run("deterministic and stable across ticks: elastic reclaim leaves the floor set unchanged", func(t *testing.T) {
+		cfg := floorCfg(2)
+		// Tick 1: demand spike — 4 warm sessions. Bottom 2 (s-a, s-b) exempt.
+		tick1 := map[string]sessionpkg.Info{
+			"s-a": warm("s-a"), "s-b": warm("s-b"), "s-c": warm("s-c"), "s-d": warm("s-d"),
+		}
+		// Tick 2: demand gone — the two above-floor elastic sessions reclaimed.
+		tick2 := map[string]sessionpkg.Info{"s-a": warm("s-a"), "s-b": warm("s-b")}
+		for _, id := range []string{"s-a", "s-b"} {
+			if !isMinFloorExemptIdleSession(tick1, cfg, "worker", id) {
+				t.Errorf("tick1: %s must be exempt", id)
+			}
+			if !isMinFloorExemptIdleSession(tick2, cfg, "worker", id) {
+				t.Errorf("tick2: %s must STILL be exempt — the warm floor identity is stable, no oscillation", id)
+			}
+		}
+	})
+}
+
+// TestIsWarmFloorCandidate pins which session states occupy a warm floor slot:
+// live sessions (active/creating/fresh) count; closed and asleep/draining/
+// suspended sessions do not.
+func TestIsWarmFloorCandidate(t *testing.T) {
+	cases := []struct {
+		state sessionpkg.State
+		want  bool
+	}{
+		{sessionpkg.StateActive, true},
+		{sessionpkg.StateCreating, true},
+		{"", true}, // freshly stamped, not yet active
+		{sessionpkg.StateAsleep, false},
+		{sessionpkg.StateDraining, false},
+		{sessionpkg.StateSuspended, false},
+		{sessionpkg.StateClosed, false},
+	}
+	for _, tc := range cases {
+		if got := isWarmFloorCandidate(sessionpkg.Info{State: tc.state}); got != tc.want {
+			t.Errorf("isWarmFloorCandidate(state=%q) = %v, want %v", tc.state, got, tc.want)
+		}
+	}
+	if isWarmFloorCandidate(sessionpkg.Info{State: sessionpkg.StateActive, Closed: true}) {
+		t.Error("a Closed session is never a warm floor candidate")
+	}
+}
+
 func TestSessionProgressStalled(t *testing.T) {
 	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
 	stale := now.Add(-time.Hour)    // well past any sane threshold

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -85,6 +85,8 @@ func timerTraceCodes(dec sessionpkg.TimerDecision) (TraceReasonCode, TraceOutcom
 		reason = TraceReasonAssignedWork
 	case string(TraceReasonAssignedWorkExhausted):
 		reason = TraceReasonAssignedWorkExhausted
+	case string(TraceReasonMinFloorIdleWorker):
+		reason = TraceReasonMinFloorIdleWorker
 	default:
 		reason = TraceReasonCode(dec.TraceReason)
 	}
@@ -103,6 +105,8 @@ func timerTraceCodes(dec sessionpkg.TimerDecision) (TraceReasonCode, TraceOutcom
 		outcome = TraceOutcomeDeferredBusy
 	case string(TraceOutcomeStopDeferExhausted):
 		outcome = TraceOutcomeStopDeferExhausted
+	case string(TraceOutcomeDeferredMinFloor):
+		outcome = TraceOutcomeDeferredMinFloor
 	default:
 		outcome = TraceOutcomeCode(dec.TraceOutcome)
 	}
@@ -3215,13 +3219,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				facts.Blocker = lifecycleTimerBlockerInfo(infoByID[id], clk.Now())
 			}
 			dec := sessionpkg.DecideIdleTimeout(facts)
-			for dec.Action == sessionpkg.TimerActionGatherPending || dec.Action == sessionpkg.TimerActionGatherAssignedWork {
-				if dec.Action == sessionpkg.TimerActionGatherPending {
+			for dec.Action == sessionpkg.TimerActionGatherPending ||
+				dec.Action == sessionpkg.TimerActionGatherAssignedWork ||
+				dec.Action == sessionpkg.TimerActionGatherMinFloor {
+				switch dec.Action {
+				case sessionpkg.TimerActionGatherPending:
 					facts.Pending = sessionpkg.PendingNo
 					if pendingInteractionKeepsAwakeInfo(infoByID[id], sp, name, clk) {
 						facts.Pending = sessionpkg.PendingYes
 					}
-				} else {
+				case sessionpkg.TimerActionGatherAssignedWork:
 					hasWork, assignedErr := sessionHasAwakeAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, infoByID[id])
 					if assignedErr != nil {
 						// Fail closed: treat error as "has work" so a transient
@@ -3233,6 +3240,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					facts.AssignedWork = sessionpkg.AssignedWorkNone
 					if hasWork {
 						facts.AssignedWork = sessionpkg.AssignedWorkHas
+					}
+				case sessionpkg.TimerActionGatherMinFloor:
+					// Keep-warm floor exemption (sc-5mtyhy): an idle floor member
+					// with no assigned work is deferred, not idle-killed, so the
+					// pool holds min_active_sessions warm sessions with no
+					// 0↔1 kill/cold-recreate oscillation. Deterministic selection
+					// of the lowest-bead-id floor members off the coherent
+					// infoByID snapshot; no I/O.
+					facts.MinFloor = sessionpkg.MinFloorNo
+					if isMinFloorExemptIdleSession(infoByID, cfg, tp.TemplateName, id) {
+						facts.MinFloor = sessionpkg.MinFloorYes
 					}
 				}
 				dec = sessionpkg.DecideIdleTimeout(facts)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -9453,6 +9453,64 @@ func TestReconcileSessionBeads_IdleTimeoutReclaimsAboveFloorElastic(t *testing.T
 	}
 }
 
+// TestReconcileSessionBeads_IdleTimeoutMinFloorIgnoresNonPoolSession is the
+// mixed-identity end-to-end proof: the min_active_sessions floor covers
+// pool-managed beads only (isMinActivePoolBead), so a LOWER-bead-id
+// configured-named session sharing the template must not consume the floor
+// rank — the real pool member still stays warm — and must not inherit the
+// keep-warm exemption itself: it idle-reclaims exactly as it did before
+// sc-5mtyhy.
+func TestReconcileSessionBeads_IdleTimeoutMinFloorIgnoresNonPoolSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(1)}}}
+	env.addDesired("named", "worker", true)
+	env.addDesired("w1", "worker", true)
+
+	// The named session is created FIRST so it holds the lower bead ID: that
+	// is the ordering under which an un-narrowed floor rank would swallow the
+	// pool member's exempt slot and silently no-op the keep-warm fix.
+	named := env.createSessionBead("named", "worker")
+	env.setSessionMetadata(&named, map[string]string{
+		"configured_named_session":  "true",
+		"configured_named_identity": "named",
+	})
+	pool := env.createSessionBead("w1", "worker")
+	if !(named.ID < pool.ID) {
+		t.Fatalf("fixture: named bead id %q must sort below the pool bead id %q", named.ID, pool.ID)
+	}
+	env.markSessionActive(&named)
+	env.markSessionActive(&pool)
+	if err := env.sp.SetMeta("named", "GC_SESSION_ID", named.ID); err != nil {
+		t.Fatalf("SetMeta(named): %v", err)
+	}
+	if err := env.sp.SetMeta("w1", "GC_SESSION_ID", pool.ID); err != nil {
+		t.Fatalf("SetMeta(w1): %v", err)
+	}
+
+	it := newFakeIdleTracker()
+	it.idle["named"] = true
+	it.idle["w1"] = true
+
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{named, pool}, env.desiredState, configuredSessionNames(env.cfg, "", env.store),
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if !env.sp.IsRunning("w1") {
+		t.Error("the pool floor member must stay warm; a lower-id named session must not consume its floor rank")
+	}
+	if pb, err := env.store.Get(pool.ID); err == nil && pb.Metadata["sleep_reason"] == "idle-timeout" {
+		t.Errorf("pool floor member sleep_reason = idle-timeout, want kept warm")
+	}
+	if env.sp.IsRunning("named") {
+		t.Error("the configured-named session is not a floor member and must follow its pre-existing idle path")
+	}
+	if nb, err := env.store.Get(named.ID); err == nil && nb.Metadata["sleep_reason"] != "idle-timeout" {
+		t.Errorf("named session sleep_reason = %q, want idle-timeout (unchanged pre-existing path)", nb.Metadata["sleep_reason"])
+	}
+}
+
 func TestReconcileSessionBeads_IdleTimeoutUsesTemplateFallbackForPoolSession(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -9369,6 +9369,90 @@ func TestReconcileSessionBeads_IdleTimeoutStopsAndStaysAsleep(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionBeads_IdleTimeoutKeepsMinFloorWarm is the sc-5mtyhy
+// acceptance-1 end-to-end proof: a pool session within the min_active_sessions
+// floor, idle past its timeout with no assigned work, is NOT idle-killed — it
+// stays alive/warm rather than being killed and cold-recreated next tick.
+func TestReconcileSessionBeads_IdleTimeoutKeepsMinFloorWarm(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(1)}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	it := newFakeIdleTracker()
+	it.idle["worker"] = true
+
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, configuredSessionNames(env.cfg, "", env.store),
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("min-floor session must stay warm across idle timeout, not be killed+cold-recreated")
+	}
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Metadata["sleep_reason"] == "idle-timeout" {
+		t.Errorf("sleep_reason = %q, a kept-warm floor session must not be idle-slept", b.Metadata["sleep_reason"])
+	}
+}
+
+// TestReconcileSessionBeads_IdleTimeoutReclaimsAboveFloorElastic is the
+// acceptance-2 end-to-end proof: with a min_active_sessions=1 floor and two
+// idle sessions, the deterministic lowest-bead-id session stays warm while the
+// above-floor elastic session is idle-reclaimed exactly as before the fix — the
+// floor exemption is bounded to minSess and does not leak the pool warm.
+func TestReconcileSessionBeads_IdleTimeoutReclaimsAboveFloorElastic(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(1)}}}
+	env.addDesired("w1", "worker", true)
+	env.addDesired("w2", "worker", true)
+	s1 := env.createSessionBead("w1", "worker")
+	s2 := env.createSessionBead("w2", "worker")
+	env.markSessionActive(&s1)
+	env.markSessionActive(&s2)
+	if err := env.sp.SetMeta("w1", "GC_SESSION_ID", s1.ID); err != nil {
+		t.Fatalf("SetMeta(w1): %v", err)
+	}
+	if err := env.sp.SetMeta("w2", "GC_SESSION_ID", s2.ID); err != nil {
+		t.Fatalf("SetMeta(w2): %v", err)
+	}
+
+	// The floor member is the lowest-bead-id session; the other is elastic.
+	warmName, warmID, reclaimName := "w1", s1.ID, "w2"
+	if s2.ID < s1.ID {
+		warmName, warmID, reclaimName = "w2", s2.ID, "w1"
+	}
+
+	it := newFakeIdleTracker()
+	it.idle["w1"] = true
+	it.idle["w2"] = true
+
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{s1, s2}, env.desiredState, configuredSessionNames(env.cfg, "", env.store),
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if !env.sp.IsRunning(warmName) {
+		t.Errorf("lowest-id floor member %q must stay warm across idle timeout", warmName)
+	}
+	if env.sp.IsRunning(reclaimName) {
+		t.Errorf("above-floor elastic session %q must idle-reclaim as before the fix", reclaimName)
+	}
+	// The kept-warm session is never idle-slept; the reclaimed one is.
+	if wb, err := env.store.Get(warmID); err == nil && wb.Metadata["sleep_reason"] == "idle-timeout" {
+		t.Errorf("floor member %q sleep_reason = idle-timeout, want kept warm", warmName)
+	}
+}
+
 func TestReconcileSessionBeads_IdleTimeoutUsesTemplateFallbackForPoolSession(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -9475,7 +9475,7 @@ func TestReconcileSessionBeads_IdleTimeoutMinFloorIgnoresNonPoolSession(t *testi
 		"configured_named_identity": "named",
 	})
 	pool := env.createSessionBead("w1", "worker")
-	if !(named.ID < pool.ID) {
+	if named.ID >= pool.ID {
 		t.Fatalf("fixture: named bead id %q must sort below the pool bead id %q", named.ID, pool.ID)
 	}
 	env.markSessionActive(&named)

--- a/cmd/gc/session_reconciler_timer_trace_test.go
+++ b/cmd/gc/session_reconciler_timer_trace_test.go
@@ -23,6 +23,7 @@ func TestTimerTraceCodesTotal(t *testing.T) {
 		TraceReasonPending:               true,
 		TraceReasonAssignedWork:          true,
 		TraceReasonAssignedWorkExhausted: true,
+		TraceReasonMinFloorIdleWorker:    true,
 	}
 	namedOutcomes := map[TraceOutcomeCode]bool{
 		TraceOutcomeStop:               true,
@@ -31,6 +32,7 @@ func TestTimerTraceCodesTotal(t *testing.T) {
 		TraceOutcomeDeferredPending:    true,
 		TraceOutcomeDeferredBusy:       true,
 		TraceOutcomeStopDeferExhausted: true,
+		TraceOutcomeDeferredMinFloor:   true,
 	}
 
 	blockers := []string{"", "user_hold", "quarantine"}
@@ -40,14 +42,19 @@ func TestTimerTraceCodesTotal(t *testing.T) {
 	assigned := []sessionpkg.AssignedWorkFact{
 		sessionpkg.AssignedWorkUnknown, sessionpkg.AssignedWorkNone, sessionpkg.AssignedWorkHas,
 	}
+	minfloors := []sessionpkg.MinFloorFact{
+		sessionpkg.MinFloorUnknown, sessionpkg.MinFloorNo, sessionpkg.MinFloorYes,
+	}
 
 	var decisions []sessionpkg.TimerDecision
 	for _, b := range blockers {
 		for _, p := range pendings {
 			for _, a := range assigned {
-				facts := sessionpkg.TimerFacts{Triggered: true, Blocker: b, Pending: p, AssignedWork: a}
-				decisions = append(decisions, sessionpkg.DecideMaxSessionAge(facts))
-				decisions = append(decisions, sessionpkg.DecideIdleTimeout(facts))
+				for _, m := range minfloors {
+					facts := sessionpkg.TimerFacts{Triggered: true, Blocker: b, Pending: p, AssignedWork: a, MinFloor: m}
+					decisions = append(decisions, sessionpkg.DecideMaxSessionAge(facts))
+					decisions = append(decisions, sessionpkg.DecideIdleTimeout(facts))
+				}
 			}
 		}
 	}

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -249,6 +249,7 @@ const (
 	TraceOutcomeStopPending         TraceOutcomeCode = "stop_pending"
 	TraceOutcomeDeferredConfirm     TraceOutcomeCode = "deferred_confirm"
 	TraceOutcomeExempt              TraceOutcomeCode = "exempt"
+	TraceOutcomeDeferredMinFloor    TraceOutcomeCode = "deferred_min_floor"
 	TraceOutcomeRestartInPlace      TraceOutcomeCode = "restart_in_place"
 	TraceOutcomeDeferredPending     TraceOutcomeCode = "deferred_pending"
 	TraceOutcomeRepairInPlace       TraceOutcomeCode = "repair_in_place"

--- a/internal/session/lifecycle_timers.go
+++ b/internal/session/lifecycle_timers.go
@@ -35,6 +35,22 @@ const (
 	AssignedWorkHas
 )
 
+// MinFloorFact is the tri-state min_active_sessions floor-membership fact. It
+// is Unknown until the caller has resolved whether this session is one of the
+// deterministic pool floor members that must be kept warm (never idle-timeout
+// killed and cold-recreated). Only the idle-timeout ladder consults it: the
+// floor's keep-warm guarantee is an idle-reclaim exemption, not a
+// max-session-age one — an aged floor session is still restarted for
+// defense-in-depth and the pool's min-fill recreates it (sc-5mtyhy).
+type MinFloorFact int
+
+// Min-floor fact states.
+const (
+	MinFloorUnknown MinFloorFact = iota
+	MinFloorNo
+	MinFloorYes
+)
+
 // TimerAction is what the caller must do next for one session and one timer.
 type TimerAction int
 
@@ -47,6 +63,9 @@ const (
 	// TimerActionGatherAssignedWork means supply TimerFacts.AssignedWork and
 	// decide again.
 	TimerActionGatherAssignedWork
+	// TimerActionGatherMinFloor means supply TimerFacts.MinFloor and decide
+	// again. Emitted only by DecideIdleTimeout, after the assigned-work rung.
+	TimerActionGatherMinFloor
 	// TimerActionDefer means leave the session alone this tick and record
 	// the decision trace.
 	TimerActionDefer
@@ -70,6 +89,11 @@ type TimerFacts struct {
 	// AssignedWork is the open-assigned-work fact, gathered on demand.
 	// Both the max-session-age and idle-timeout ladders consult it.
 	AssignedWork AssignedWorkFact
+	// MinFloor is the min_active_sessions floor-membership fact, gathered on
+	// demand. Consulted only by the idle-timeout ladder, after AssignedWork:
+	// an idle floor member holding no work is kept warm (deferred) rather
+	// than idle-killed and cold-recreated next tick (sc-5mtyhy).
+	MinFloor MinFloorFact
 }
 
 // TimerDecision is the outcome of one ladder evaluation.
@@ -125,13 +149,18 @@ func DecideMaxSessionAge(f TimerFacts) TimerDecision {
 }
 
 // DecideIdleTimeout evaluates the idle-timeout ladder: blocker, then pending
-// interaction, then assigned work, then stop. A pending interaction cancels
-// any pending drain and keeps the session out of this tick's wake pass — an
-// asymmetry with max-session-age that is part of the existing reconciler
-// contract. Assigned work defers the stop, mirroring DecideMaxSessionAge:
-// without this rung, ComputeAwakeSet's assigned-work exemption re-wakes the
-// session within seconds of the kill, producing an unbounded idle-kill/wake
-// treadmill (ga-3ox7rk).
+// interaction, then assigned work, then min_active_sessions floor membership,
+// then stop. A pending interaction cancels any pending drain and keeps the
+// session out of this tick's wake pass — an asymmetry with max-session-age that
+// is part of the existing reconciler contract. Assigned work defers the stop,
+// mirroring DecideMaxSessionAge: without this rung, ComputeAwakeSet's
+// assigned-work exemption re-wakes the session within seconds of the kill,
+// producing an unbounded idle-kill/wake treadmill (ga-3ox7rk). A floor member
+// with no assigned work defers too: it is kept WARM rather than idle-killed and
+// cold-recreated by the min-fill next tick (sc-5mtyhy). The floor rung sits
+// AFTER assigned work so a busy floor session still defers as assigned_work
+// (and feeds the same-bead exhausted backstop); only a genuinely idle floor
+// member reaches the keep-warm defer.
 func DecideIdleTimeout(f TimerFacts) TimerDecision {
 	if !f.Triggered {
 		return TimerDecision{Action: TimerActionNone}
@@ -153,6 +182,12 @@ func DecideIdleTimeout(f TimerFacts) TimerDecision {
 		return TimerDecision{Action: TimerActionGatherAssignedWork}
 	case AssignedWorkHas:
 		return deferDecision("assigned_work", "deferred_busy")
+	}
+	switch f.MinFloor {
+	case MinFloorUnknown:
+		return TimerDecision{Action: TimerActionGatherMinFloor}
+	case MinFloorYes:
+		return deferDecision("min_floor_idle_worker", "deferred_min_floor")
 	}
 	return TimerDecision{
 		Action:       TimerActionStop,

--- a/internal/session/lifecycle_timers_test.go
+++ b/internal/session/lifecycle_timers_test.go
@@ -145,8 +145,8 @@ func TestDecideIdleTimeoutLadder(t *testing.T) {
 			outcome: "deferred_busy",
 		},
 		{
-			name:    "free idle session stops",
-			facts:   TimerFacts{Triggered: true, Pending: PendingNo, AssignedWork: AssignedWorkNone},
+			name:    "free non-floor idle session stops",
+			facts:   TimerFacts{Triggered: true, Pending: PendingNo, AssignedWork: AssignedWorkNone, MinFloor: MinFloorNo},
 			action:  TimerActionStop,
 			reason:  "idle_timeout",
 			outcome: "stop",
@@ -200,7 +200,7 @@ func TestDecideMaxSessionAgePendingKeepsWakePass(t *testing.T) {
 }
 
 func TestDecideIdleTimeoutStopSleepReason(t *testing.T) {
-	dec := DecideIdleTimeout(TimerFacts{Triggered: true, Pending: PendingNo, AssignedWork: AssignedWorkNone})
+	dec := DecideIdleTimeout(TimerFacts{Triggered: true, Pending: PendingNo, AssignedWork: AssignedWorkNone, MinFloor: MinFloorNo})
 	if dec.SleepReason != "idle-timeout" {
 		t.Fatalf("sleep reason = %q, want %q", dec.SleepReason, "idle-timeout")
 	}
@@ -246,21 +246,103 @@ func TestDecideAssignedWorkExhausted(t *testing.T) {
 	}
 }
 
-// The gather loop must terminate: once both gatherable facts are known the
+// A min_active_sessions floor member with no assigned work is kept WARM: the
+// idle-timeout ladder gathers the floor fact after assigned work, then defers
+// the kill under its own trace/outcome so the concrete session is never
+// idle-killed and cold-recreated (sc-5mtyhy). MinFloorNo falls through to the
+// ordinary idle stop — an above-floor elastic session still idle-reclaims.
+func TestDecideIdleTimeoutMinFloorRung(t *testing.T) {
+	base := TimerFacts{Triggered: true, Pending: PendingNo, AssignedWork: AssignedWorkNone}
+
+	t.Run("unknown floor membership is gathered after assigned work", func(t *testing.T) {
+		dec := DecideIdleTimeout(base) // MinFloor defaults to MinFloorUnknown
+		if dec.Action != TimerActionGatherMinFloor {
+			t.Fatalf("action = %v, want TimerActionGatherMinFloor", dec.Action)
+		}
+	})
+
+	t.Run("floor member defers the idle kill (kept warm)", func(t *testing.T) {
+		f := base
+		f.MinFloor = MinFloorYes
+		dec := DecideIdleTimeout(f)
+		if dec.Action != TimerActionDefer {
+			t.Fatalf("action = %v, want TimerActionDefer", dec.Action)
+		}
+		if dec.TraceReason != "min_floor_idle_worker" || dec.TraceOutcome != "deferred_min_floor" {
+			t.Fatalf("trace = %q/%q, want min_floor_idle_worker/deferred_min_floor", dec.TraceReason, dec.TraceOutcome)
+		}
+		if dec.CancelDrain || dec.SkipWakePass {
+			t.Fatalf("min-floor deferral must not cancel drain or skip wake pass: %+v", dec)
+		}
+	})
+
+	t.Run("above-floor elastic session still stops", func(t *testing.T) {
+		f := base
+		f.MinFloor = MinFloorNo
+		dec := DecideIdleTimeout(f)
+		if dec.Action != TimerActionStop {
+			t.Fatalf("action = %v, want TimerActionStop", dec.Action)
+		}
+		if dec.TraceReason != "idle_timeout" || dec.SleepReason != string(SleepReasonIdleTimeout) {
+			t.Fatalf("non-floor idle session must stop with idle_timeout: %+v", dec)
+		}
+	})
+}
+
+// Assigned work is consulted BEFORE min-floor membership: a busy floor session
+// defers as assigned_work (feeding the same-bead exhausted backstop), never as
+// min_floor. The floor keep-warm rung only protects idle floor members.
+func TestDecideIdleTimeoutAssignedWorkBeatsMinFloor(t *testing.T) {
+	dec := DecideIdleTimeout(TimerFacts{
+		Triggered:    true,
+		Pending:      PendingNo,
+		AssignedWork: AssignedWorkHas,
+		MinFloor:     MinFloorYes,
+	})
+	if dec.Action != TimerActionDefer {
+		t.Fatalf("action = %v, want defer", dec.Action)
+	}
+	if dec.TraceReason != "assigned_work" || dec.TraceOutcome != "deferred_busy" {
+		t.Fatalf("trace = %q/%q, want assigned_work/deferred_busy (assigned work outranks min-floor)", dec.TraceReason, dec.TraceOutcome)
+	}
+}
+
+// The floor keep-warm exemption is idle-timeout only. Max-session-age never
+// consults MinFloor: an aged floor session is still restarted (defense-in-depth
+// churn), and the pool min-fill recreates it.
+func TestDecideMaxSessionAgeIgnoresMinFloor(t *testing.T) {
+	dec := DecideMaxSessionAge(TimerFacts{
+		Triggered:    true,
+		Pending:      PendingNo,
+		AssignedWork: AssignedWorkNone,
+		MinFloor:     MinFloorYes,
+	})
+	if dec.Action != TimerActionStop {
+		t.Fatalf("action = %v, want stop; max-age must not honor the floor exemption", dec.Action)
+	}
+	if dec.TraceReason != "max_session_age" {
+		t.Fatalf("trace reason = %q, want max_session_age", dec.TraceReason)
+	}
+}
+
+// The gather loop must terminate: once every gatherable fact is known the
 // decider may only defer or stop.
 func TestTimerDecisionsTerminate(t *testing.T) {
 	pendings := []PendingFact{PendingNo, PendingYes}
 	works := []AssignedWorkFact{AssignedWorkNone, AssignedWorkHas}
+	minfloors := []MinFloorFact{MinFloorNo, MinFloorYes}
 	blockers := []string{"", "user_hold", "quarantine"}
 	for _, b := range blockers {
 		for _, p := range pendings {
 			for _, w := range works {
-				facts := TimerFacts{Triggered: true, Blocker: b, Pending: p, AssignedWork: w}
-				for _, dec := range []TimerDecision{DecideMaxSessionAge(facts), DecideIdleTimeout(facts)} {
-					switch dec.Action {
-					case TimerActionDefer, TimerActionStop:
-					default:
-						t.Fatalf("facts %+v produced non-terminal action %v", facts, dec.Action)
+				for _, m := range minfloors {
+					facts := TimerFacts{Triggered: true, Blocker: b, Pending: p, AssignedWork: w, MinFloor: m}
+					for _, dec := range []TimerDecision{DecideMaxSessionAge(facts), DecideIdleTimeout(facts)} {
+						switch dec.Action {
+						case TimerActionDefer, TimerActionStop:
+						default:
+							t.Fatalf("facts %+v produced non-terminal action %v", facts, dec.Action)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## session: keep the min_active_sessions pool floor warm (exempt from idle-timeout)

`min_active_sessions` is spawned as a floor (the min-fill top-off pass), but the idle-timeout decision (`DecideIdleTimeout`) was floor-blind — it killed an idle floor session like any elastic one, and the only floor-aware revive path was scoped to `sleep_reason=city-stop`. So an idle-timeout-slept floor session was never revived, only cold-recreated on the next tick: the floor oscillates 0↔1, satisfied on paper but never held warm. That churn is the per-task warm+nudge tax.

**Change:** make the idle-timeout path floor-aware. A pool session within the `min_active_sessions` floor (the deterministic lowest-bead-id `minSess` same-template warm sessions) is now exempt from idle-timeout kill — kept warm, never killed-then-cold-recreated — via a new `MinFloor` rung in `DecideIdleTimeout` (after the assigned-work rung), mirroring the existing `floorExempt` pattern. Above-floor elastic sessions still idle-reclaim exactly as before; `max_active_sessions` still caps total (the exemption only defers a kill, it never spawns); `DecideMaxSessionAge` is untouched (keep-warm is idle-timeout-only).

**Floor-candidacy is an explicit allow-list** (`{None, Active, Awake, Creating, StartPending}`) — only genuinely-live/starting sessions count toward the floor rank, so a stale dormant/terminal bead (Asleep/Quarantined/FailedCreate/Drained/Archived) can't mask a live floor member out of the exempt set.

**Size:** ~90 production Go + tests. **Verification:** tests assert the floor survives idle-timeout, above-floor elastic still reclaims, no kill→cold-recreate oscillation at steady zero demand, and a stale low-id bead in each of the 4 non-live states does NOT mask a live floor member (non-vacuous — reverting the allow-list fails them). `go build/vet/test ./cmd/gc/ ./internal/session/...` green. Two independent adversarial reviews: both green (the initial deny-list masking gap was caught and closed in review).

Note (transparency): one doc comment slightly overstates the parallel to `countMinActiveCovered` (the two state-sets deliberately differ — cosmetic).
