### PR TITLE
test(cmd/gc): let the dolt leak guard see servers rooted in the checkout

### DIFF
--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -632,3 +632,74 @@ func TestDoltLeakGuardedTestingMRunWithSweepsOrphanDirsAtStartup(t *testing.T) {
 		t.Fatalf("call order = %v, want [sweepStale sweepOrphanDirs runTests ...]", order)
 	}
 }
+
+// A dolt sql-server rooted in the source checkout rather than under the run's
+// temp root is the leak shape the guard used to miss entirely: cmd/gc's own
+// package dir is structurally outside tempRoot, so PathWithin(tempRoot, cfg)
+// was false and the process was skipped in silence. .gitignore hides the
+// matching cmd/gc/.gc and cmd/gc/.beads dirs, so nothing surfaced it.
+func TestSnapshotDoltProcessesForConfigRootsCatchesSourceTreeLeak(t *testing.T) {
+	tempRoot := filepath.Join("/tmp", "gct12345-678")
+	sourceRoot := filepath.Join("/home", "dev", "gascity", "cmd", "gc")
+
+	underTemp := DoltProcInfo{
+		PID:  1001,
+		Argv: []string{"dolt", "sql-server", "--config", filepath.Join(tempRoot, "TestX", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")},
+	}
+	underSource := DoltProcInfo{
+		PID:  1002,
+		Argv: []string{"dolt", "sql-server", "--config", filepath.Join(sourceRoot, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")},
+	}
+	// A real city server on the same machine must stay out of the snapshot: the
+	// reaping paths kill everything the snapshot returns, so widening the guard
+	// must not put a developer's own city at risk.
+	realCity := DoltProcInfo{
+		PID:  1003,
+		Argv: []string{"dolt", "sql-server", "--config", filepath.Join("/home", "dev", "city", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")},
+	}
+
+	enumerate := func() ([]DoltProcInfo, error) {
+		return []DoltProcInfo{underTemp, underSource, realCity}, nil
+	}
+
+	got, err := snapshotDoltProcessesForConfigRoots(enumerate, []string{tempRoot, sourceRoot})
+	if err != nil {
+		t.Fatalf("snapshotDoltProcessesForConfigRoots: %v", err)
+	}
+	if _, ok := got[1002]; !ok {
+		t.Errorf("source-tree leak PID 1002 missing from snapshot: %#v", got)
+	}
+	if _, ok := got[1001]; !ok {
+		t.Errorf("temp-root leak PID 1001 missing from snapshot: %#v", got)
+	}
+	if _, ok := got[1003]; ok {
+		t.Errorf("real city server PID 1003 must not be snapshotted (the reaper kills these): %#v", got)
+	}
+
+	// The pre-fix behaviour, pinned so a regression to a single root is caught.
+	tempOnly, err := snapshotDoltProcessesForConfigRoots(enumerate, []string{tempRoot})
+	if err != nil {
+		t.Fatalf("snapshotDoltProcessesForConfigRoots(tempRoot only): %v", err)
+	}
+	if _, ok := tempOnly[1002]; ok {
+		t.Errorf("tempRoot-only snapshot should not see the source-tree leak: %#v", tempOnly)
+	}
+}
+
+// An unresolved root must narrow the snapshot, never widen it to match every
+// dolt server on the host — the reaping paths would then kill real cities.
+func TestSnapshotDoltProcessesForConfigRootsIgnoresEmptyRoots(t *testing.T) {
+	proc := DoltProcInfo{
+		PID:  2001,
+		Argv: []string{"dolt", "sql-server", "--config", filepath.Join("/home", "dev", "city", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")},
+	}
+	got, err := snapshotDoltProcessesForConfigRoots(func() ([]DoltProcInfo, error) {
+		return []DoltProcInfo{proc}, nil
+	}, []string{"", ""})
+	if err != nil {
+		t.Fatalf("snapshotDoltProcessesForConfigRoots: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty roots matched %d process(es), want 0: %#v", len(got), got)
+	}
+}

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -676,7 +676,7 @@ func TestSnapshotDoltProcessesForConfigRootsCatchesSourceTreeLeak(t *testing.T) 
 		t.Errorf("real city server PID 1003 must not be snapshotted (the reaper kills these): %#v", got)
 	}
 
-	// The pre-fix behaviour, pinned so a regression to a single root is caught.
+	// The pre-fix behavior, pinned so a regression to a single root is caught.
 	tempOnly, err := snapshotDoltProcessesForConfigRoots(enumerate, []string{tempRoot})
 	if err != nil {
 		t.Fatalf("snapshotDoltProcessesForConfigRoots(tempRoot only): %v", err)

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -123,7 +123,7 @@ type doltLeakGuardedTestingM struct {
 func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...string) *doltLeakGuardedTestingM {
 	// A failure here must not be fatal: os.Getwd only fails in exotic cases
 	// (an unlinked cwd), and losing the second root degrades the guard to its
-	// previous tempRoot-only behaviour rather than breaking every test run.
+	// previous tempRoot-only behavior rather than breaking every test run.
 	sourceRoot, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: resolving source root: %v\n", err) //nolint:errcheck

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -101,17 +101,59 @@ func requireNoLeakedDoltAfterForPaths(t *testing.T, paths ...string) {
 }
 
 type doltLeakGuardedTestingM struct {
-	m            *testing.M
-	tempRoot     string
+	m        *testing.M
+	tempRoot string
+	// sourceRoot is the package directory the test binary runs in. A managed
+	// dolt provider handed a city root of "" or "." resolves it to this
+	// directory, so the server and its data_dir land in the source checkout
+	// at cmd/gc/.gc and cmd/gc/.beads instead of under tempRoot. Those
+	// escaped the guard entirely while it watched tempRoot alone, and
+	// .gitignore hides the on-disk half, so they accumulated unnoticed.
+	//
+	// Watching this root is safe for the reaping paths as well as detection:
+	// no real city lives inside the checkout, so a dolt sql-server rooted
+	// here is a test leak by construction. That is why the fix names a
+	// second root rather than watching every dolt process on the machine —
+	// an unscoped guard would reap the developer's own city servers, which
+	// legitimately start and stop during a long test run.
+	sourceRoot   string
 	cleanupPaths []string
 }
 
 func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...string) *doltLeakGuardedTestingM {
+	// A failure here must not be fatal: os.Getwd only fails in exotic cases
+	// (an unlinked cwd), and losing the second root degrades the guard to its
+	// previous tempRoot-only behaviour rather than breaking every test run.
+	sourceRoot, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: resolving source root: %v\n", err) //nolint:errcheck
+		sourceRoot = ""
+	}
 	return &doltLeakGuardedTestingM{
 		m:            m,
 		tempRoot:     tempRoot,
+		sourceRoot:   sourceRoot,
 		cleanupPaths: cleanupPaths,
 	}
+}
+
+// leakRoots are the config-path roots the guard treats as test-owned. A dolt
+// sql-server whose --config lies under any of them is this run's to detect and
+// reap.
+func (g *doltLeakGuardedTestingM) leakRoots() []string {
+	return []string{g.tempRoot, g.sourceRoot}
+}
+
+// nonEmptyLeakRoots is leakRoots minus unresolved entries, for diagnostics that
+// name the roots a leak was found under.
+func (g *doltLeakGuardedTestingM) nonEmptyLeakRoots() []string {
+	roots := make([]string, 0, 2)
+	for _, root := range g.leakRoots() {
+		if root != "" {
+			roots = append(roots, root)
+		}
+	}
+	return roots
 }
 
 func (g *doltLeakGuardedTestingM) Run() int {
@@ -131,7 +173,7 @@ func (g *doltLeakGuardedTestingM) runWith(
 	stopSignalHandler := g.installSignalHandler()
 	defer stopSignalHandler()
 
-	initial, initialErr := snapshotDoltProcessesForConfigRoot(enumerate, g.tempRoot)
+	initial, initialErr := snapshotDoltProcessesForConfigRoots(enumerate, g.leakRoots())
 	if initialErr != nil {
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: initial scan failed: %v\n", initialErr) //nolint:errcheck
 	}
@@ -140,12 +182,12 @@ func (g *doltLeakGuardedTestingM) runWith(
 
 	guardFailed := initialErr != nil
 	if initialErr == nil {
-		final, finalErr := snapshotDoltProcessesForConfigRoot(enumerate, g.tempRoot)
+		final, finalErr := snapshotDoltProcessesForConfigRoots(enumerate, g.leakRoots())
 		if finalErr != nil {
 			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: final scan failed: %v\n", finalErr) //nolint:errcheck
 			guardFailed = true
 		} else if leaked := diffDoltProcessSnapshots(initial, final); len(leaked) > 0 {
-			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: leaked %d dolt sql-server process(es) under %s\n", len(leaked), g.tempRoot) //nolint:errcheck
+			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: leaked %d dolt sql-server process(es) under %s\n", len(leaked), strings.Join(g.nonEmptyLeakRoots(), ", ")) //nolint:errcheck
 			writeDoltLeakReport(os.Stderr, leaked)
 			reapLeaks(leaked)
 			guardFailed = true
@@ -194,7 +236,7 @@ func (g *doltLeakGuardedTestingM) cleanupTemporaryPaths() {
 }
 
 func (g *doltLeakGuardedTestingM) reapDoltProcessesUnderRoot(label string) bool {
-	procs, err := snapshotDoltProcessesForConfigRoot(discoverDoltProcesses, g.tempRoot)
+	procs, err := snapshotDoltProcessesForConfigRoots(discoverDoltProcesses, g.leakRoots())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s scan failed: %v\n", label, err) //nolint:errcheck
 		return true
@@ -209,7 +251,7 @@ func (g *doltLeakGuardedTestingM) reapDoltProcessesUnderRoot(label string) bool 
 	sort.Slice(leaked, func(i, j int) bool {
 		return leaked[i].PID < leaked[j].PID
 	})
-	fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s sweep reaping %d dolt sql-server process(es) under %s\n", label, len(leaked), g.tempRoot) //nolint:errcheck
+	fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s sweep reaping %d dolt sql-server process(es) under %s\n", label, len(leaked), strings.Join(g.nonEmptyLeakRoots(), ", ")) //nolint:errcheck
 	writeDoltLeakReport(os.Stderr, leaked)
 	reapDoltLeakProcesses(leaked)
 	return true
@@ -310,7 +352,11 @@ func cmdGCTestConfigOwnerPID(configPath string, tempParent string) (int, bool) {
 	return 0, false
 }
 
-func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error), root string) (map[int]DoltProcInfo, error) {
+// snapshotDoltProcessesForConfigRoots returns the dolt sql-servers whose
+// --config path lies under any of roots. Empty roots are ignored, so a caller
+// that could not resolve one still gets the others rather than matching
+// everything.
+func snapshotDoltProcessesForConfigRoots(enumerate func() ([]DoltProcInfo, error), roots []string) (map[int]DoltProcInfo, error) {
 	procs, err := enumerate()
 	if err != nil {
 		return nil, err
@@ -318,12 +364,19 @@ func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error)
 	out := make(map[int]DoltProcInfo, len(procs))
 	for _, p := range procs {
 		configPath := extractConfigPath(p.Argv)
-		if root == "" || !pathutil.PathWithin(root, configPath) {
-			continue
+		for _, root := range roots {
+			if root == "" || !pathutil.PathWithin(root, configPath) {
+				continue
+			}
+			out[p.PID] = p
+			break
 		}
-		out[p.PID] = p
 	}
 	return out, nil
+}
+
+func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error), root string) (map[int]DoltProcInfo, error) {
+	return snapshotDoltProcessesForConfigRoots(enumerate, []string{root})
 }
 
 func diffDoltProcessSnapshots(initial, final map[int]DoltProcInfo) []DoltProcInfo {


### PR DESCRIPTION
Refs #4673.

The dolt leak guard wired into `cmd/gc`'s `TestMain` snapshots dolt sql-servers before and after the run, diffs them, reaps the difference and fails the run. It filtered candidates to a single root:

```go
if root == "" || !pathutil.PathWithin(root, configPath) { continue }
```

`root` is the run's temp root. A test that starts the managed dolt provider with the city root resolved to the **package directory** instead of a `t.TempDir()` puts both the process and its `data_dir` inside the source checkout:

```
--config  cmd/gc/.gc/runtime/packs/dolt/dolt-config.yaml
data_dir  cmd/gc/.beads/dolt
```

That path is structurally outside the temp root, so `PathWithin` is false and the guard skipped it **in silence**. A dolt server leaked into `/tmp` fails the build; one leaked into the repo did not. `.gitignore` covers `.gc/` and `**/.beads/*`, so `git status` stayed clean while these accumulated — 5 of 6 local worktrees had collected the state, and one server had been running 17.7h holding a listening port and ~28 MB.

## Why a second root, and not an unscoped guard

The issue suggests snapshotting all dolt servers and treating any new one not owned by a registered city as a leak. Implemented literally that is unsafe, and the reason is worth being explicit about: **the same snapshot function feeds `reapDoltProcessesUnderRoot`**, which kills every process it returns and runs both as the startup sweep and from the signal handler. A guard watching every dolt server on the machine would reap the developer's own city servers, which legitimately start and stop during a long test run. The "not owned by a registered city" clause is doing load-bearing work the guard has no way to evaluate — it has no registry of cities.

Naming the checkout as a second root is precise instead. No real city lives inside a source checkout, so a dolt server rooted there is a test leak by construction, which makes it safe for the reaping paths and not merely for detection.

The test binary's cwd **is** the package directory, so `os.Getwd()` in the guard constructor yields exactly that root. Capturing it once at construction also makes it immune to any later `os.Chdir` by a test.

Empty roots continue to match nothing, preserving the old `root == ""` behaviour. That property is load-bearing given the reaping paths: a root that failed to resolve must narrow the guard, never widen it to every server on the host. `os.Getwd()` failure is therefore non-fatal and degrades to the previous temp-root-only behaviour.

## Tests

- `TestSnapshotDoltProcessesForConfigRootsCatchesSourceTreeLeak` — the source-tree leak is caught, the temp-root leak still is, and a real city server outside both roots is **not** snapshotted (the reaper-safety property). It also pins the pre-fix single-root behaviour, so a regression back to one root is caught.
- `TestSnapshotDoltProcessesForConfigRootsIgnoresEmptyRoots` — empty roots match nothing.

`go test ./cmd/gc -run 'TestSnapshotDoltProcessesForConfigRoot|TestDoltLeakGuarded|TestDiffDoltProcessSnapshots'` → 6 PASS / 0 FAIL, including the 4 pre-existing guard tests. `go vet ./cmd/gc` clean, `gofmt` clean.

## Scope: this makes the leak visible, it does not stop it

This is the broad half of #4673 only. The narrow half — stopping whichever test resolves the city root to the package directory — is **not** fixed here, and #4673's "no `cmd/gc/.gc` or `cmd/gc/.beads` dir is created" criterion is therefore not yet met.

That is deliberate: the culprit test was never identified, and the issue notes a bisect is expensive on this package. With the guard widened it no longer needs one — the run now fails and `writeDoltLeakReport` prints the leaked pid and full argv, so the suite names the culprit itself on the next full run.

A lead for whoever takes the narrow fix. A full `cmd/gc` run on `main` created `cmd/gc/.gc/events.jsonl` and `cmd/gc/.gc/scripts/gc-beads-bd.sh` in the checkout, but no dolt config and no server — the precursor, not the full leak. The file that appears is the **beads provider script**, and `clearInheritedBeadsEnv` in this same package already documents that chain: inherited `GC_BEADS=bd` triggers `gc-beads-bd.sh` and leaks an orphan dolt sql-server "because test cleanup paths do not call `shutdownBeadsProvider`". That predicts the leak is intermittent and env-dependent, which would explain why a single culprit test was never pinned.

## Unrelated pre-existing failure you will hit

`go test ./cmd/gc` cannot exit 0 on `main` today, independent of this change: zero `--- FAIL` lines, every test passes, and the exit comes from the guard correctly catching a *different* leak.

```
pid=4010752 argv="dolt sql-server --config <tempRoot>/TestInitFromWithoutHostedPreservesTemplate.../002/city/.gc/runtime/packs/dolt/dolt-config.yaml"
```

That one lands under the temp root, so the existing guard already sees it — the mirror image of this issue. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aSHpYfaSAz43US5yjWuLz
