### PR TITLE
fix(worker): retry transcript metadata sidecar

### DIFF
--- a/internal/worker/handle.go
+++ b/internal/worker/handle.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/pricing"
@@ -277,6 +278,13 @@ type SessionHandle struct {
 	// skip both the keyed-path resolve and the write once the sidecar is current.
 	sidecarMu     sync.Mutex
 	sidecarDoneID string
+	// sidecarRetrySchedule is nil in production, where the sidecar retry uses
+	// time.AfterFunc. Tests supply a channel-backed scheduler to drive retries
+	// deterministically.
+	sidecarRetrySchedule  func(time.Duration, func())
+	sidecarRetryID        string
+	sidecarRetryAttempts  int
+	sidecarRetryScheduled bool
 }
 
 var (

--- a/internal/worker/handle_transcriptmeta.go
+++ b/internal/worker/handle_transcriptmeta.go
@@ -3,9 +3,67 @@ package worker
 import (
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/transcriptmeta"
 )
+
+const (
+	transcriptSessionMetaRetryDelay    = time.Second
+	transcriptSessionMetaRetryAttempts = 3
+)
+
+// recordTranscriptSessionMetaAfterTurn writes the sidecar after successful
+// delivery. A Codex rollout can appear just after tmux receives that delivery,
+// so the export-enabled supervisor retries a bounded number of initial misses.
+// One-shot CLI processes leave transcriptmeta disabled and do no retry work.
+func (h *SessionHandle) recordTranscriptSessionMetaAfterTurn() {
+	if !transcriptmeta.Enabled() {
+		return
+	}
+	if h.writeTranscriptSessionMeta() {
+		return
+	}
+	h.scheduleTranscriptSessionMetaRetry()
+}
+
+func (h *SessionHandle) scheduleTranscriptSessionMetaRetry() {
+	id := h.currentSessionID()
+	if id == "" || !transcriptmeta.Enabled() {
+		return
+	}
+
+	h.sidecarMu.Lock()
+	if h.sidecarRetryID != id {
+		h.sidecarRetryID = id
+		h.sidecarRetryAttempts = 0
+		h.sidecarRetryScheduled = false
+	}
+	if h.sidecarRetryScheduled || h.sidecarRetryAttempts >= transcriptSessionMetaRetryAttempts {
+		h.sidecarMu.Unlock()
+		return
+	}
+	h.sidecarRetryScheduled = true
+	h.sidecarRetryAttempts++
+	schedule := h.sidecarRetrySchedule
+	h.sidecarMu.Unlock()
+
+	if schedule == nil {
+		schedule = func(delay time.Duration, retry func()) { time.AfterFunc(delay, retry) }
+	}
+	schedule(transcriptSessionMetaRetryDelay, func() {
+		h.sidecarMu.Lock()
+		if h.sidecarRetryID == id {
+			h.sidecarRetryScheduled = false
+		}
+		h.sidecarMu.Unlock()
+
+		if h.currentSessionID() != id || !transcriptmeta.Enabled() || h.writeTranscriptSessionMeta() {
+			return
+		}
+		h.scheduleTranscriptSessionMetaRetry()
+	})
+}
 
 // writeTranscriptSessionMeta records the worker's gc session id in a sidecar
 // next to its provider transcript, so an out-of-band reader that sees only the
@@ -22,13 +80,13 @@ import (
 // filename suffix). It is skipped for gemini/opencode/mimocode, which have no
 // 1:1 by-id lookup, so only the ambiguous workdir/mtime fallback would be
 // available — and that could mis-attribute one session's transcript to another.
-func (h *SessionHandle) writeTranscriptSessionMeta() {
+func (h *SessionHandle) writeTranscriptSessionMeta() bool {
 	if !transcriptmeta.Enabled() {
-		return
+		return true
 	}
 	id := h.currentSessionID()
 	if id == "" {
-		return
+		return true
 	}
 	// Fast path: once the sidecar is confirmed current for this session id, skip
 	// the keyed-path resolve (a bead read plus transcript discovery, including
@@ -38,7 +96,7 @@ func (h *SessionHandle) writeTranscriptSessionMeta() {
 	done := h.sidecarDoneID == id
 	h.sidecarMu.Unlock()
 	if done {
-		return
+		return true
 	}
 
 	path, err := h.manager.KeyedTranscriptPath(id, h.adapter.SearchPaths)
@@ -48,10 +106,10 @@ func (h *SessionHandle) writeTranscriptSessionMeta() {
 		// mirroring the write-error path below; leave the guard unset so a later
 		// call retries.
 		slog.Debug("transcript session sidecar resolve failed", "session", id, "err", err)
-		return
+		return false
 	}
 	if strings.TrimSpace(path) == "" {
-		return // no keyed path yet (key not persisted, or a workdir-only provider)
+		return false // no keyed path yet (key not persisted, or a workdir-only provider)
 	}
 
 	// id is the session bead id (currentSessionID == session.Info.ID), the same
@@ -62,12 +120,13 @@ func (h *SessionHandle) writeTranscriptSessionMeta() {
 		// A real write failure (e.g. read-only/full fs); best-effort, never
 		// fatal to the turn. Leave the guard unset so a later call retries.
 		slog.Debug("transcript session sidecar write failed", "session", id, "err", err)
-		return
+		return false
 	}
 	if !ok {
-		return // transcript not on disk yet — retry on a later turn
+		return false // transcript not on disk yet — retry on a later turn
 	}
 	h.sidecarMu.Lock()
 	h.sidecarDoneID = id
 	h.sidecarMu.Unlock()
+	return true
 }

--- a/internal/worker/handle_transcriptmeta_test.go
+++ b/internal/worker/handle_transcriptmeta_test.go
@@ -78,6 +78,78 @@ func TestSessionHandleWritesKeyedTranscriptSidecar(t *testing.T) {
 	}
 }
 
+// TestSessionHandleRetriesSidecarAfterTranscriptAppears proves the delivery
+// path retries a keyed sidecar miss once the provider creates its transcript.
+// The scheduler is injected so the test controls retry delivery without wall
+// time or polling.
+func TestSessionHandleRetriesSidecarAfterTranscriptAppears(t *testing.T) {
+	transcriptmeta.SetEnabled(true)
+	t.Cleanup(func() { transcriptmeta.SetEnabled(false) })
+
+	handle, id, transcript := claudeKeyedFixture(t)
+	if err := os.Remove(transcript); err != nil {
+		t.Fatalf("remove initial transcript: %v", err)
+	}
+	retries := make(chan func(), 1)
+	handle.sidecarRetrySchedule = func(_ time.Duration, retry func()) { retries <- retry }
+
+	handle.recordTranscriptSessionMetaAfterTurn()
+	if got := len(retries); got != 1 {
+		t.Fatalf("scheduled retries = %d, want 1 after the initial keyed-path miss", got)
+	}
+	if err := os.WriteFile(transcript, []byte("transcript body\n"), 0o644); err != nil {
+		t.Fatalf("create transcript after delivery: %v", err)
+	}
+
+	(<-retries)()
+	got, err := os.ReadFile(transcript + transcriptmeta.Suffix)
+	if err != nil {
+		t.Fatalf("read retried sidecar: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != id {
+		t.Fatalf("retried sidecar = %q, want session bead id %q", strings.TrimSpace(string(got)), id)
+	}
+}
+
+// TestSessionHandleDoesNotScheduleSidecarRetryWhenDisabled protects the
+// one-shot CLI path: it leaves transcriptmeta disabled and must not create
+// background retry work.
+func TestSessionHandleDoesNotScheduleSidecarRetryWhenDisabled(t *testing.T) {
+	handle, _, transcript := claudeKeyedFixture(t)
+	if err := os.Remove(transcript); err != nil {
+		t.Fatalf("remove initial transcript: %v", err)
+	}
+	retries := make(chan func(), 1)
+	handle.sidecarRetrySchedule = func(_ time.Duration, retry func()) { retries <- retry }
+
+	handle.recordTranscriptSessionMetaAfterTurn()
+	if got := len(retries); got != 0 {
+		t.Fatalf("scheduled retries = %d, want none when transcript metadata is disabled", got)
+	}
+}
+
+// TestSessionHandleBoundsSidecarRetry verifies a permanently absent transcript
+// cannot leave a supervisor handle scheduling retry work indefinitely.
+func TestSessionHandleBoundsSidecarRetry(t *testing.T) {
+	transcriptmeta.SetEnabled(true)
+	t.Cleanup(func() { transcriptmeta.SetEnabled(false) })
+
+	handle, _, transcript := claudeKeyedFixture(t)
+	if err := os.Remove(transcript); err != nil {
+		t.Fatalf("remove initial transcript: %v", err)
+	}
+	retries := make(chan func(), transcriptSessionMetaRetryAttempts)
+	handle.sidecarRetrySchedule = func(_ time.Duration, retry func()) { retries <- retry }
+
+	handle.recordTranscriptSessionMetaAfterTurn()
+	for range transcriptSessionMetaRetryAttempts {
+		(<-retries)()
+	}
+	if got := len(retries); got != 0 {
+		t.Fatalf("scheduled retries = %d after retry limit, want 0", got)
+	}
+}
+
 // TestSessionHandleSidecarIDIsExportableRef locks the cross-rail join contract:
 // the id the worker writes to the sidecar is the SAME value the redacted event
 // exporter emits as session_id only if it survives eventexport's opaque-ref gate

--- a/internal/worker/invocation_telemetry.go
+++ b/internal/worker/invocation_telemetry.go
@@ -102,7 +102,7 @@ func (h *SessionHandle) recordInvocationTelemetry(ctx context.Context) {
 	// whether the sidecar should be written, and the Message/Nudge callers expect
 	// the write on every successful turn. Best-effort and a no-op unless
 	// correlation is armed; it uses its own guard, not invTelemetryMu.
-	defer h.writeTranscriptSessionMeta()
+	defer h.recordTranscriptSessionMetaAfterTurn()
 
 	if operationEventsSuppressed(ctx) {
 		return


### PR DESCRIPTION
Summary
- retry an initially missing keyed transcript metadata sidecar after successful supervisor delivery
- bound retries to three one-second attempts and retain the existing idempotent write
- leave disabled one-shot CLI processes unchanged

Validation
- go test ./internal/worker -count=1
- go vet ./internal/worker
- commit-hook lint: 0 issues