### PR TITLE
fix(supervisor): arm metadata with external forwarder

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1448,6 +1448,11 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "Supervisor API listening on http://%s\n", addr) //nolint:errcheck
 	writeSupervisorDashboardStartup(stdout, dashboardMounted, readOnly, bind, port)
 
+	// External event forwarders consume the typed supervisor stream without
+	// configuring [events.export]. Allow that long-lived supervisor unit to arm
+	// the same transcript correlation sidecars independently.
+	armSupervisorTranscriptMetaFromEnv(stderr)
+
 	// Redacted event export (opt-in via [events.export]). No-op unless an
 	// endpoint is configured.
 	if supCfg.Events.Export.Enabled() {

--- a/cmd/gc/event_export.go
+++ b/cmd/gc/event_export.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +28,28 @@ const muxRebuildInterval = 60 * time.Second
 // salt makes the actor hash brute-forceable, so eventexport.ProjectEvent drops
 // every event. Used only to warn loudly at startup.
 const minActorSaltLen = 16
+
+const supervisorTranscriptMetaEnv = "GC_TRANSCRIPT_META_ENABLED"
+
+// armSupervisorTranscriptMetaFromEnv enables transcript correlation for a
+// supervisor whose events are shipped by an external forwarder. Such a
+// deployment intentionally has no [events.export], so startEventExport cannot
+// arm the gate. The environment is scoped to the long-lived supervisor unit;
+// one-shot gc processes remain disabled by default.
+func armSupervisorTranscriptMetaFromEnv(stderr io.Writer) {
+	raw, configured := os.LookupEnv(supervisorTranscriptMetaEnv)
+	if !configured {
+		return
+	}
+	enabled, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		fmt.Fprintf(stderr, "gc supervisor: ignoring invalid %s=%q: %v\n", supervisorTranscriptMetaEnv, raw, err) //nolint:errcheck
+		return
+	}
+	if enabled {
+		transcriptmeta.SetEnabled(true)
+	}
+}
 
 // startEventExport launches the redacted event exporter when [events.export] is
 // configured. It is opt-in: with no endpoint the supervisor ships nothing.

--- a/cmd/gc/event_export_test.go
+++ b/cmd/gc/event_export_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/events"
@@ -295,5 +297,33 @@ func TestStartEventExport_SuccessfulStartupArmsSidecar(t *testing.T) {
 
 	if !transcriptmeta.Enabled() {
 		t.Fatal("sidecar gate must be armed once the exporter clears its fail-closed startup")
+	}
+}
+
+func TestArmSupervisorTranscriptMetaFromEnv(t *testing.T) {
+	transcriptmeta.SetEnabled(false)
+	t.Cleanup(func() { transcriptmeta.SetEnabled(false) })
+	t.Setenv(supervisorTranscriptMetaEnv, "true")
+
+	armSupervisorTranscriptMetaFromEnv(io.Discard)
+
+	if !transcriptmeta.Enabled() {
+		t.Fatal("external-forwarder supervisor gate must arm transcript metadata")
+	}
+}
+
+func TestArmSupervisorTranscriptMetaFromEnvRejectsInvalidValue(t *testing.T) {
+	transcriptmeta.SetEnabled(false)
+	t.Cleanup(func() { transcriptmeta.SetEnabled(false) })
+	t.Setenv(supervisorTranscriptMetaEnv, "enabled-ish")
+	var stderr bytes.Buffer
+
+	armSupervisorTranscriptMetaFromEnv(&stderr)
+
+	if transcriptmeta.Enabled() {
+		t.Fatal("invalid external-forwarder supervisor gate must remain disabled")
+	}
+	if !strings.Contains(stderr.String(), supervisorTranscriptMetaEnv) {
+		t.Fatalf("warning = %q, want the invalid gate name", stderr.String())
 	}
 }


### PR DESCRIPTION
Summary
- allow a long-lived supervisor using an external event-stream forwarder to arm transcript metadata without configuring the built-in exporter
- keep one-shot CLI processes disabled by default
- reject invalid gate values with an operator-visible warning

Validation
- go test ./cmd/gc -run "^(TestArmSupervisorTranscriptMetaFromEnv|TestArmSupervisorTranscriptMetaFromEnvRejectsInvalidValue|TestStartEventExport_)" -count=1
- go vet ./cmd/gc
- commit-hook lint and generated-contract checks