### PR TITLE
antigravity: add model/effort options and plan/accept-edits permission modes

### DIFF
--- a/cmd/gc/session_reasoning_effort_test.go
+++ b/cmd/gc/session_reasoning_effort_test.go
@@ -33,6 +33,17 @@ func claudeEffortResolvedProvider() *config.ResolvedProvider {
 	}
 }
 
+func antigravityEffortResolvedProvider() *config.ResolvedProvider {
+	agy := config.BuiltinProviders()["antigravity"]
+	return &config.ResolvedProvider{
+		Name:              "antigravity",
+		BuiltinAncestor:   "antigravity",
+		Command:           agy.Command,
+		OptionsSchema:     agy.OptionsSchema,
+		EffectiveDefaults: config.ComputeEffectiveDefaults(agy.OptionsSchema, agy.OptionDefaults, nil),
+	}
+}
+
 // newOptionSessionWithWork creates a session bead plus an in-progress work bead
 // assigned to that session carrying opt_<key> option metadata.
 func newOptionSessionWithWork(t *testing.T, rp *config.ResolvedProvider, baseCommand string, options map[string]string) (startCandidate, *config.City, beads.Store) {
@@ -103,6 +114,21 @@ func TestBuildPreparedStart_ProviderEffortOptionUsesProviderSchema(t *testing.T)
 	}
 	if strings.Contains(prepared.cfg.Command, "model_reasoning_effort") {
 		t.Fatalf("command %q should not contain codex reasoning flags for claude", prepared.cfg.Command)
+	}
+}
+
+func TestBuildPreparedStart_AntigravityDispatchEffortOptionPresent(t *testing.T) {
+	candidate, cfg, store := newOptionSessionWithWork(t, antigravityEffortResolvedProvider(), "agy", map[string]string{"effort": "high"})
+
+	prepared, _, err := buildPreparedStart(candidate, cfg, store)
+	if err != nil {
+		t.Fatalf("buildPreparedStart: %v", err)
+	}
+	if !strings.Contains(prepared.cfg.Command, "--effort high") {
+		t.Fatalf("command %q should contain agy --effort high", prepared.cfg.Command)
+	}
+	if strings.Contains(prepared.cfg.Command, "model_reasoning_effort") {
+		t.Fatalf("command %q should not contain codex reasoning flags for antigravity", prepared.cfg.Command)
 	}
 }
 

--- a/cmd/gc/session_reasoning_effort_test.go
+++ b/cmd/gc/session_reasoning_effort_test.go
@@ -132,6 +132,21 @@ func TestBuildPreparedStart_AntigravityDispatchEffortOptionPresent(t *testing.T)
 	}
 }
 
+func TestBuildPreparedStart_AntigravityPermissionModePlan(t *testing.T) {
+	candidate, cfg, store := newOptionSessionWithWork(t, antigravityEffortResolvedProvider(), "agy", map[string]string{"permission_mode": "plan"})
+
+	prepared, _, err := buildPreparedStart(candidate, cfg, store)
+	if err != nil {
+		t.Fatalf("buildPreparedStart: %v", err)
+	}
+	if !strings.Contains(prepared.cfg.Command, "--mode plan") {
+		t.Fatalf("command %q should contain agy --mode plan", prepared.cfg.Command)
+	}
+	if strings.Contains(prepared.cfg.Command, "--dangerously-skip-permissions") {
+		t.Fatalf("command %q should not also carry the unrestricted default", prepared.cfg.Command)
+	}
+}
+
 func TestBuildPreparedStart_ExplicitEffortOverrideWinsOverDispatchOption(t *testing.T) {
 	candidate, cfg, store := newOptionSessionWithWork(t, codexEffortResolvedProvider(), "codex", map[string]string{"effort": "high"})
 	// Set an explicit effort override on the typed twin the executor reads

--- a/docs/guides/harness-recipes.md
+++ b/docs/guides/harness-recipes.md
@@ -42,7 +42,7 @@ Two things hold for every recipe:
 | Pi | `pi` | login | yes |
 | Auggie | `auggie` | login | — |
 | Oh My Pi | `omp` | login | — |
-| Antigravity | `antigravity` | login | — |
+| Antigravity | `antigravity` | login | yes |
 
 "—" under base URL means the harness has no standard base-URL env var: for a
 custom endpoint, supply it through the upstream's raw [`env`](/guides/configuring-an-agent#axis-3-upstream-who-serves-the-model)
@@ -269,18 +269,22 @@ provider = "pi"          # Pi Coding Agent     — has a model option (ollama-cl
 # provider = "antigravity"   # Antigravity (agy) — effort + plan/accept-edits modes
 ```
 
-Antigravity also takes an `effort` option (`low` · `medium` · `high`) and
-`plan` / `accept-edits` permission modes, mapped to agy's `--effort` and
-`--mode` flags:
+Antigravity also takes `model` and `effort` options (`low` · `medium` ·
+`high`) and `plan` / `accept-edits` permission modes, mapped to agy's
+`--model`, `--effort`, and `--mode` flags. Model values are agy's stable
+slugs (`agy models` lists them):
 
 ```toml
 provider        = "antigravity"
-option_defaults = { effort = "high", permission_mode = "plan" }
+option_defaults = { model = "gemini-3.1-pro-high", permission_mode = "plan" }
+# also: gemini-3.6-flash-high/-medium/-low · gemini-3.5-flash-high/-medium/-low
+#       gemini-3.1-pro-low · claude-sonnet-4-6 · claude-opus-4-6-thinking
+#       gpt-oss-120b-medium
 ```
 
 <Note>
-`effort` needs agy **1.1.10 or newer** — older versions silently ignore
-`--effort` at launch and run at the model's default.
+`model` and `effort` need agy **1.1.10 or newer** — older versions silently
+ignore both flags at launch and run on the persisted default model.
 </Note>
 
 If one of these later needs a custom endpoint, give it a raw upstream `env` block

--- a/docs/guides/harness-recipes.md
+++ b/docs/guides/harness-recipes.md
@@ -276,7 +276,7 @@ slugs (`agy models` lists them):
 
 ```toml
 provider        = "antigravity"
-option_defaults = { model = "gemini-3.1-pro-high", permission_mode = "plan" }
+option_defaults = { model = "gemini-3.1-pro-high" }
 # also: gemini-3.6-flash-high/-medium/-low · gemini-3.5-flash-high/-medium/-low
 #       gemini-3.1-pro-low · claude-sonnet-4-6 · claude-opus-4-6-thinking
 #       gpt-oss-120b-medium

--- a/docs/guides/harness-recipes.md
+++ b/docs/guides/harness-recipes.md
@@ -266,8 +266,22 @@ upstream env. Set `provider` and run their normal `login` once on the box; no
 provider = "pi"          # Pi Coding Agent     — has a model option (ollama-cloud-gpt-oss-20b)
 # provider = "auggie"    # Augment Auggie CLI
 # provider = "omp"       # Oh My Pi
-# provider = "antigravity"   # Antigravity (agy)
+# provider = "antigravity"   # Antigravity (agy) — effort + plan/accept-edits modes
 ```
+
+Antigravity also takes an `effort` option (`low` · `medium` · `high`) and
+`plan` / `accept-edits` permission modes, mapped to agy's `--effort` and
+`--mode` flags:
+
+```toml
+provider        = "antigravity"
+option_defaults = { effort = "high", permission_mode = "plan" }
+```
+
+<Note>
+`effort` needs agy **1.1.10 or newer** — older versions silently ignore
+`--effort` at launch and run at the model's default.
+</Note>
 
 If one of these later needs a custom endpoint, give it a raw upstream `env` block
 with whatever vars its CLI documents — the same escape hatch shown for Grok

--- a/internal/runtime/runtimecapability/runner_test.go
+++ b/internal/runtime/runtimecapability/runner_test.go
@@ -58,7 +58,12 @@ func writeRef(t *testing.T, cfg refConfig) string {
 for tprog in gc git; do printf '#!/bin/sh\necho "%s version (ref)\n"' "$tprog" > "$D/bin/$tprog"; chmod +x "$D/bin/$tprog"; done
 printf '#!/bin/sh\nif [ "$1" = ready ]; then [ -n "$GC_BEADS_API" ] || exit 1; command -v curl >/dev/null 2>&1 && exec curl -fsS -o /dev/null "$GC_BEADS_API/v0/beads/ready"; exec wget -q -O /dev/null "$GC_BEADS_API/v0/beads/ready"; fi\necho "bd version (ref)"\n' > "$D/bin/bd"; chmod +x "$D/bin/bd"`
 	if !cfg.installTooling {
-		install = `mkdir -p "$D/bin"` // no gc/bd/git installed
+		// "Not provided" must stay false even when the host has the tools
+		// system-wide (a real /usr/bin/bd install, or graphviz's /usr/bin/gc,
+		// whose `gc version` exits 0): shadow the probe's tools with failing
+		// stubs so the sandbox PATH's base-util dirs cannot leak them in.
+		install = `mkdir -p "$D/bin"
+for tprog in gc bd git; do printf '#!/bin/sh\nexit 127\n' > "$D/bin/$tprog"; chmod +x "$D/bin/$tprog"; done`
 	}
 	inject := `printf 'export GC_SESSION=%s\n' "$sess" > "$D/env"`
 	if !cfg.injectIdentity {

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -737,6 +737,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		PrintArgs:         []string{"--print"},
 		PermissionModes: map[string]string{
 			"unrestricted": "--dangerously-skip-permissions",
+			"accept-edits": "--mode accept-edits",
+			"plan":         "--mode plan",
 		},
 		OptionsSchema: []BuiltinProviderOption{
 			{
@@ -747,6 +749,23 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Choices: []BuiltinOptionChoice{
 					{Value: "unrestricted", Label: "Bypass permissions", FlagArgs: []string{"--dangerously-skip-permissions"}},
 					{Value: "standard", Label: "Standard (prompt for permissions)", FlagArgs: []string{}},
+					{Value: "accept-edits", Label: "Accept edits", FlagArgs: []string{"--mode", "accept-edits"}},
+					{Value: "plan", Label: "Plan mode", FlagArgs: []string{"--mode", "plan"}},
+				},
+			},
+			// effort intentionally has no Default and no OptionDefaults entry:
+			// agy < 1.1.10 silently ignores --effort (and --model) on the
+			// --prompt-interactive launch path, so the flag must only ever be
+			// sent when a user opts in explicitly.
+			{
+				Key:   "effort",
+				Label: "Effort",
+				Type:  "select",
+				Choices: []BuiltinOptionChoice{
+					{Value: "", Label: "Default"},
+					{Value: "low", Label: "Low", FlagArgs: []string{"--effort", "low"}},
+					{Value: "medium", Label: "Medium", FlagArgs: []string{"--effort", "medium"}},
+					{Value: "high", Label: "High", FlagArgs: []string{"--effort", "high"}},
 				},
 			},
 			{

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -768,6 +768,28 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 					{Value: "high", Label: "High", FlagArgs: []string{"--effort", "high"}},
 				},
 			},
+			// Stable slugs + display names as enumerated by `agy models`; agy
+			// defines no -m short alias, so no FlagAliases. Same no-default
+			// rule as effort (agy < 1.1.10 drops --model silently at launch).
+			{
+				Key:   "model",
+				Label: "Model",
+				Type:  "select",
+				Choices: []BuiltinOptionChoice{
+					{Value: "", Label: "Default"},
+					{Value: "gemini-3.6-flash-high", Label: "Gemini 3.6 Flash (High)", FlagArgs: []string{"--model", "gemini-3.6-flash-high"}},
+					{Value: "gemini-3.6-flash-medium", Label: "Gemini 3.6 Flash (Medium)", FlagArgs: []string{"--model", "gemini-3.6-flash-medium"}},
+					{Value: "gemini-3.6-flash-low", Label: "Gemini 3.6 Flash (Low)", FlagArgs: []string{"--model", "gemini-3.6-flash-low"}},
+					{Value: "gemini-3.5-flash-high", Label: "Gemini 3.5 Flash (High)", FlagArgs: []string{"--model", "gemini-3.5-flash-high"}},
+					{Value: "gemini-3.5-flash-medium", Label: "Gemini 3.5 Flash (Medium)", FlagArgs: []string{"--model", "gemini-3.5-flash-medium"}},
+					{Value: "gemini-3.5-flash-low", Label: "Gemini 3.5 Flash (Low)", FlagArgs: []string{"--model", "gemini-3.5-flash-low"}},
+					{Value: "gemini-3.1-pro-high", Label: "Gemini 3.1 Pro (High)", FlagArgs: []string{"--model", "gemini-3.1-pro-high"}},
+					{Value: "gemini-3.1-pro-low", Label: "Gemini 3.1 Pro (Low)", FlagArgs: []string{"--model", "gemini-3.1-pro-low"}},
+					{Value: "claude-sonnet-4-6", Label: "Claude Sonnet 4.6 (Thinking)", FlagArgs: []string{"--model", "claude-sonnet-4-6"}},
+					{Value: "claude-opus-4-6-thinking", Label: "Claude Opus 4.6 (Thinking)", FlagArgs: []string{"--model", "claude-opus-4-6-thinking"}},
+					{Value: "gpt-oss-120b-medium", Label: "GPT-OSS 120B (Medium)", FlagArgs: []string{"--model", "gpt-oss-120b-medium"}},
+				},
+			},
 			{
 				Key:   "sandbox",
 				Label: "Sandbox",

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -130,6 +130,125 @@ func TestBuiltinCodexModelChoicesUseAvailable53CodexAlias(t *testing.T) {
 	}
 }
 
+func TestBuiltinAntigravityPermissionModeChoices(t *testing.T) {
+	agy, ok := BuiltinProviders()["antigravity"]
+	if !ok {
+		t.Fatal("BuiltinProviders() missing antigravity")
+	}
+
+	var permissionOption BuiltinProviderOption
+	for _, option := range agy.OptionsSchema {
+		if option.Key == "permission_mode" {
+			permissionOption = option
+			break
+		}
+	}
+	if permissionOption.Key == "" {
+		t.Fatal("antigravity provider missing permission_mode option")
+	}
+	if permissionOption.Default != "unrestricted" {
+		t.Errorf("permission_mode Default = %q, want %q", permissionOption.Default, "unrestricted")
+	}
+	if agy.OptionDefaults["permission_mode"] != "unrestricted" {
+		t.Errorf("OptionDefaults[permission_mode] = %q, want %q", agy.OptionDefaults["permission_mode"], "unrestricted")
+	}
+
+	byValue := make(map[string]BuiltinOptionChoice, len(permissionOption.Choices))
+	for _, choice := range permissionOption.Choices {
+		byValue[choice.Value] = choice
+	}
+	wantFlagArgs := map[string][]string{
+		"unrestricted": {"--dangerously-skip-permissions"},
+		"standard":     {},
+		"accept-edits": {"--mode", "accept-edits"},
+		"plan":         {"--mode", "plan"},
+	}
+	if len(permissionOption.Choices) != len(wantFlagArgs) {
+		t.Errorf("permission_mode choice count = %d, want %d", len(permissionOption.Choices), len(wantFlagArgs))
+	}
+	for value, want := range wantFlagArgs {
+		choice, ok := byValue[value]
+		if !ok {
+			t.Fatalf("permission_mode choices missing %q", value)
+		}
+		if len(choice.FlagArgs) != len(want) {
+			t.Fatalf("%s FlagArgs = %v, want %v", value, choice.FlagArgs, want)
+		}
+		for i := range want {
+			if choice.FlagArgs[i] != want[i] {
+				t.Fatalf("%s FlagArgs = %v, want %v", value, choice.FlagArgs, want)
+			}
+		}
+	}
+
+	// PermissionModes is the config-only display table; it mirrors the
+	// flag-bearing schema choices (the no-flag "standard" mode stays unmapped).
+	wantModes := map[string]string{
+		"unrestricted": "--dangerously-skip-permissions",
+		"accept-edits": "--mode accept-edits",
+		"plan":         "--mode plan",
+	}
+	if len(agy.PermissionModes) != len(wantModes) {
+		t.Errorf("PermissionModes = %v, want %v", agy.PermissionModes, wantModes)
+	}
+	for mode, want := range wantModes {
+		if agy.PermissionModes[mode] != want {
+			t.Errorf("PermissionModes[%s] = %q, want %q", mode, agy.PermissionModes[mode], want)
+		}
+	}
+}
+
+func TestBuiltinAntigravityEffortChoices(t *testing.T) {
+	agy, ok := BuiltinProviders()["antigravity"]
+	if !ok {
+		t.Fatal("BuiltinProviders() missing antigravity")
+	}
+
+	var effortOption BuiltinProviderOption
+	for _, option := range agy.OptionsSchema {
+		if option.Key == "effort" {
+			effortOption = option
+			break
+		}
+	}
+	if effortOption.Key == "" {
+		t.Fatal("antigravity provider missing effort option")
+	}
+
+	// agy < 1.1.10 silently ignores --effort on the --prompt-interactive
+	// launch path, so the option must never fire by default: no schema
+	// Default and no OptionDefaults entry.
+	if effortOption.Default != "" {
+		t.Errorf("effort Default = %q, want empty (agy <1.1.10 drops the flag silently)", effortOption.Default)
+	}
+	if _, ok := agy.OptionDefaults["effort"]; ok {
+		t.Errorf("OptionDefaults[effort] = %q, want absent (agy <1.1.10 drops the flag silently)", agy.OptionDefaults["effort"])
+	}
+
+	if len(effortOption.Choices) == 0 || effortOption.Choices[0].Value != "" || len(effortOption.Choices[0].FlagArgs) != 0 {
+		t.Fatalf("effort choices must lead with the empty no-flag sentinel, got %v", effortOption.Choices)
+	}
+
+	byValue := make(map[string]BuiltinOptionChoice, len(effortOption.Choices))
+	for _, choice := range effortOption.Choices {
+		byValue[choice.Value] = choice
+	}
+	// agy exposes exactly three effort levels (agy --help: --effort low|medium|high).
+	wantValues := []string{"low", "medium", "high"}
+	if len(effortOption.Choices) != len(wantValues)+1 {
+		t.Errorf("effort choice count = %d, want %d (sentinel + %v)", len(effortOption.Choices), len(wantValues)+1, wantValues)
+	}
+	for _, value := range wantValues {
+		choice, ok := byValue[value]
+		if !ok {
+			t.Fatalf("effort choices missing %q", value)
+		}
+		if len(choice.FlagArgs) != 2 || choice.FlagArgs[0] != "--effort" || choice.FlagArgs[1] != value {
+			t.Errorf("%s FlagArgs = %v, want [--effort %s]", value, choice.FlagArgs, value)
+		}
+	}
+}
+
 func TestBuiltinCodexModelChoicesIncludeGPT56Variants(t *testing.T) {
 	codex, ok := BuiltinProviders()["codex"]
 	if !ok {

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -249,6 +249,76 @@ func TestBuiltinAntigravityEffortChoices(t *testing.T) {
 	}
 }
 
+func TestBuiltinAntigravityModelChoices(t *testing.T) {
+	agy, ok := BuiltinProviders()["antigravity"]
+	if !ok {
+		t.Fatal("BuiltinProviders() missing antigravity")
+	}
+
+	var modelOption BuiltinProviderOption
+	for _, option := range agy.OptionsSchema {
+		if option.Key == "model" {
+			modelOption = option
+			break
+		}
+	}
+	if modelOption.Key == "" {
+		t.Fatal("antigravity provider missing model option")
+	}
+
+	// agy < 1.1.10 silently ignores --model on the --prompt-interactive
+	// launch path, so the option must never fire by default.
+	if modelOption.Default != "" {
+		t.Errorf("model Default = %q, want empty (agy <1.1.10 drops the flag silently)", modelOption.Default)
+	}
+	if _, ok := agy.OptionDefaults["model"]; ok {
+		t.Errorf("OptionDefaults[model] = %q, want absent (agy <1.1.10 drops the flag silently)", agy.OptionDefaults["model"])
+	}
+
+	if len(modelOption.Choices) == 0 || modelOption.Choices[0].Value != "" || len(modelOption.Choices[0].FlagArgs) != 0 {
+		t.Fatalf("model choices must lead with the empty no-flag sentinel, got %v", modelOption.Choices)
+	}
+
+	byValue := make(map[string]BuiltinOptionChoice, len(modelOption.Choices))
+	for _, choice := range modelOption.Choices {
+		byValue[choice.Value] = choice
+	}
+
+	// Stable slugs + display names as enumerated by `agy models` (agy 1.1.5+).
+	wantLabels := map[string]string{
+		"gemini-3.6-flash-high":    "Gemini 3.6 Flash (High)",
+		"gemini-3.6-flash-medium":  "Gemini 3.6 Flash (Medium)",
+		"gemini-3.6-flash-low":     "Gemini 3.6 Flash (Low)",
+		"gemini-3.5-flash-high":    "Gemini 3.5 Flash (High)",
+		"gemini-3.5-flash-medium":  "Gemini 3.5 Flash (Medium)",
+		"gemini-3.5-flash-low":     "Gemini 3.5 Flash (Low)",
+		"gemini-3.1-pro-high":      "Gemini 3.1 Pro (High)",
+		"gemini-3.1-pro-low":       "Gemini 3.1 Pro (Low)",
+		"claude-sonnet-4-6":        "Claude Sonnet 4.6 (Thinking)",
+		"claude-opus-4-6-thinking": "Claude Opus 4.6 (Thinking)",
+		"gpt-oss-120b-medium":      "GPT-OSS 120B (Medium)",
+	}
+	if len(modelOption.Choices) != len(wantLabels)+1 {
+		t.Errorf("model choice count = %d, want %d (sentinel + %d slugs)", len(modelOption.Choices), len(wantLabels)+1, len(wantLabels))
+	}
+	for slug, wantLabel := range wantLabels {
+		choice, ok := byValue[slug]
+		if !ok {
+			t.Fatalf("model choices missing %q", slug)
+		}
+		if choice.Label != wantLabel {
+			t.Errorf("%s label = %q, want %q", slug, choice.Label, wantLabel)
+		}
+		if len(choice.FlagArgs) != 2 || choice.FlagArgs[0] != "--model" || choice.FlagArgs[1] != slug {
+			t.Errorf("%s FlagArgs = %v, want [--model %s]", slug, choice.FlagArgs, slug)
+		}
+		// agy has no -m short alias (unlike claude/codex) — keep aliases empty.
+		if len(choice.FlagAliases) != 0 {
+			t.Errorf("%s FlagAliases = %v, want none (agy --help defines no -m)", slug, choice.FlagAliases)
+		}
+	}
+}
+
 func TestBuiltinCodexModelChoicesIncludeGPT56Variants(t *testing.T) {
 	codex, ok := BuiltinProviders()["codex"]
 	if !ok {


### PR DESCRIPTION
## What

Brings the `antigravity` builtin's options schema to parity with claude/codex on tmux runners:

- **`effort` option** — `low` / `medium` / `high` → `--effort <v>` (agy exposes exactly three levels).
- **`model` option** — the stable slugs enumerated by `agy models` (Gemini 3.6/3.5 Flash and 3.1 Pro effort variants, Claude Sonnet 4.6 / Opus 4.6 thinking, GPT-OSS 120B) → `--model <slug>`. No `FlagAliases`: agy defines no `-m` short flag.
- **`permission_mode`** gains `plan` and `accept-edits` (agy `--mode plan|accept-edits`), mirrored into the `PermissionModes` display map.
- Docs: harness-recipes at-a-glance table + antigravity recipe updated.
- One test-infra fix ridealong: the `env.tooling` negative-gating mutant (`TestEveryCapabilityIsGated`) left `$D/bin` empty, so hosts with the probed tool names in `/usr/bin` (a system-wide `bd`, graphviz's `gc` — whose `gc version` exits 0) leaked through the sandbox PATH and flipped the probe to a false PASS. The mutant now shadows `gc`/`bd`/`git` with exit-127 stubs.

## Why model/effort ship default-less

agy < 1.1.10 silently ignores `--model`/`--effort` on the `--prompt-interactive` launch path (the path this SDK uses; fixed per the agy 1.1.10 changelog). Both options lead with the empty no-flag sentinel and add no `OptionDefaults` entries, so old binaries never receive the flags unless a user opts in explicitly. This is pinned by test assertions, and the launch-command goldens (`template_resolve_phase2`, worker_inference classification's literal `agy --dangerously-skip-permissions`) pass unmodified — no effective-default change.

## Testing

- New schema pins: `TestBuiltinAntigravityPermissionModeChoices`, `TestBuiltinAntigravityEffortChoices`, `TestBuiltinAntigravityModelChoices` (`internal/worker/builtin`), plus `TestBuildPreparedStart_AntigravityDispatchEffortOptionPresent` (`cmd/gc`) covering `opt_effort` dispatch through the real builtin schema.
- `PROFILE=antigravity/tmux-cli make test-worker-core-phase2`, `make test-fast-parallel`, `go vet ./...`, `make check-docs` — all green (also re-run against this branch's upstream base).
- Verified against a live agy 1.1.10: slug list from `agy models`; flag surface from `agy --help` (`--effort low|medium|high`, `--mode accept-edits|plan`, no `-m`); a `--print` run confirming the flags are honored post-1.1.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
