### PR TITLE
fix(molecule): extend residual-var guard to routing metadata (#5060)

### DIFF
--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -127,6 +127,28 @@ func instantiateFragmentViaGraphApply(ctx context.Context, store beads.Store, ap
 	}, nil
 }
 
+// Routing fields the title-only guard below (#618) never covered — #5060.
+var residualVarRoutingMetadataKeys = []string{
+	beadmeta.RunTargetMetadataKey,
+	beadmeta.RoutedToMetadataKey,
+	beadmeta.ExecutionRoutedToMetadataKey,
+	DeferredRoutedToMetadataKey,
+	DeferredExecutionRoutedToMetadataKey,
+}
+
+func validateResidualRoutingVars(stepID string, metadata map[string]string) error {
+	for _, key := range residualVarRoutingMetadataKeys {
+		value := metadata[key]
+		if !strings.Contains(value, "{{") {
+			continue
+		}
+		if residual := formula.CheckResidualVars(value); len(residual) > 0 {
+			return fmt.Errorf("step %q: metadata %s contains unresolved variable(s) %s — missing or misspelled --var(s)?", stepID, key, strings.Join(residual, ", "))
+		}
+	}
+	return nil
+}
+
 func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApplyPlan, bool, string, error) {
 	if recipe == nil {
 		return nil, false, "", fmt.Errorf("recipe is nil")
@@ -254,6 +276,10 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 			if residual := formula.CheckResidualVars(node.Title); len(residual) > 0 {
 				return nil, false, "", fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
+		}
+		// Same guard, extended to routing metadata — see #5060.
+		if err := validateResidualRoutingVars(step.ID, node.Metadata); err != nil {
+			return nil, false, "", err
 		}
 		if err := validateTimeoutMetadataVars(step.ID, node.Metadata); err != nil {
 			return nil, false, "", err
@@ -477,6 +503,10 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 			if residual := formula.CheckResidualVars(node.Title); len(residual) > 0 {
 				return nil, fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
+		}
+		// Same guard, extended to routing metadata — see #5060.
+		if err := validateResidualRoutingVars(step.ID, node.Metadata); err != nil {
+			return nil, err
 		}
 		if err := validateTimeoutMetadataVars(step.ID, node.Metadata); err != nil {
 			return nil, err

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -953,6 +953,11 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				return nil, fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
 		}
+		// Same guard, extended to routing metadata — see #5060.
+		if err := validateResidualRoutingVars(step.ID, b.Metadata); err != nil {
+			markFailed(store, createdIDs)
+			return nil, err
+		}
 		if err := validateTimeoutMetadataVars(step.ID, b.Metadata); err != nil {
 			markFailed(store, createdIDs)
 			return nil, err
@@ -1184,6 +1189,11 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 				markFailed(store, createdIDs)
 				return nil, fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
+		}
+		// Same guard, extended to routing metadata — see #5060.
+		if err := validateResidualRoutingVars(step.ID, b.Metadata); err != nil {
+			markFailed(store, createdIDs)
+			return nil, err
 		}
 		if err := validateTimeoutMetadataVars(step.ID, b.Metadata); err != nil {
 			markFailed(store, createdIDs)

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/formulatest"
@@ -2701,6 +2702,113 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 	})
 }
 
+func TestInstantiateRejectsResidualRoutingMetadataVars(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "residual-routing-check",
+		Steps: []formula.RecipeStep{
+			{ID: "residual-routing-check", Title: "Root", Type: "molecule", IsRoot: true},
+			{
+				ID:    "residual-routing-check.review",
+				Title: "Review: {{topic}}",
+				Type:  "task",
+				Metadata: map[string]string{
+					beadmeta.RunTargetMetadataKey: "{{review_target}}",
+				},
+			},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "residual-routing-check.review", DependsOnID: "residual-routing-check", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"topic":         {Description: "Work topic"},
+			"review_target": {Description: "Reviewer role"},
+		},
+	}
+
+	t.Run("sequential path rejects unresolved routing var", func(t *testing.T) {
+		_, err := Instantiate(context.Background(), beads.NewMemStore(), recipe, Options{
+			Vars: map[string]string{"topic": "widgets"},
+		})
+		if err == nil {
+			t.Fatal("Instantiate should reject unresolved {{review_target}} in gc.run_target")
+		}
+		if !strings.Contains(err.Error(), "unresolved variable") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !strings.Contains(err.Error(), beadmeta.RunTargetMetadataKey) || !strings.Contains(err.Error(), "review_target") {
+			t.Errorf("error should mention %s and review_target: %v", beadmeta.RunTargetMetadataKey, err)
+		}
+	})
+
+	t.Run("sequential path allows resolved routing var", func(t *testing.T) {
+		result, err := Instantiate(context.Background(), beads.NewMemStore(), recipe, Options{
+			Vars: map[string]string{"topic": "widgets", "review_target": "gc.review-synthesizer"},
+		})
+		if err != nil {
+			t.Fatalf("Instantiate should succeed: %v", err)
+		}
+		if result.Created != 2 {
+			t.Errorf("Created = %d, want 2", result.Created)
+		}
+	})
+
+	t.Run("graph-apply path rejects unresolved routing var", func(t *testing.T) {
+		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+		prev := IsGraphApplyEnabled()
+		SetGraphApplyEnabled(true)
+		t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+		_, err := Instantiate(context.Background(), gaStore, recipe, Options{
+			Vars: map[string]string{"topic": "widgets"},
+		})
+		if err == nil {
+			t.Fatal("graph-apply Instantiate should reject unresolved {{review_target}} in gc.run_target")
+		}
+		if !strings.Contains(err.Error(), "unresolved variable") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !strings.Contains(err.Error(), beadmeta.RunTargetMetadataKey) || !strings.Contains(err.Error(), "review_target") {
+			t.Errorf("error should mention %s and review_target: %v", beadmeta.RunTargetMetadataKey, err)
+		}
+	})
+
+	t.Run("graph-apply path rejects unresolved gc.routed_to", func(t *testing.T) {
+		routedToRecipe := &formula.Recipe{
+			Name: "residual-routed-to-check",
+			Steps: []formula.RecipeStep{
+				{ID: "residual-routed-to-check", Title: "Root", Type: "molecule", IsRoot: true},
+				{
+					ID:    "residual-routed-to-check.review",
+					Title: "Review",
+					Type:  "task",
+					Metadata: map[string]string{
+						beadmeta.RoutedToMetadataKey: "{{review_target}}",
+					},
+				},
+			},
+			Deps: []formula.RecipeDep{
+				{StepID: "residual-routed-to-check.review", DependsOnID: "residual-routed-to-check", Type: "parent-child"},
+			},
+			Vars: map[string]*formula.VarDef{
+				"review_target": {Description: "Reviewer role"},
+			},
+		}
+
+		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+		prev := IsGraphApplyEnabled()
+		SetGraphApplyEnabled(true)
+		t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+		_, err := Instantiate(context.Background(), gaStore, routedToRecipe, Options{})
+		if err == nil {
+			t.Fatal("graph-apply Instantiate should reject unresolved {{review_target}} in gc.routed_to")
+		}
+		if !strings.Contains(err.Error(), beadmeta.RoutedToMetadataKey) || !strings.Contains(err.Error(), "review_target") {
+			t.Errorf("error should mention %s and review_target: %v", beadmeta.RoutedToMetadataKey, err)
+		}
+	})
+}
+
 func TestAttachReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
 	store := beads.NewMemStore()
 	parent, err := store.Create(beads.Bead{Title: "Parent", Type: "task", Status: "open"})
@@ -2926,6 +3034,69 @@ func TestInstantiateFragmentRejectsResidualTitleVars(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "unresolved variable") {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestInstantiateFragmentRejectsResidualRoutingMetadataVars(t *testing.T) {
+	fragment := &formula.FragmentRecipe{
+		Name: "frag-residual-routing",
+		Steps: []formula.RecipeStep{
+			{
+				ID:    "frag-residual-routing.step-a",
+				Title: "Review",
+				Type:  "task",
+				Metadata: map[string]string{
+					beadmeta.RunTargetMetadataKey: "{{review_target}}",
+				},
+			},
+		},
+		Vars: map[string]*formula.VarDef{
+			"review_target": {Description: "Reviewer role"},
+		},
+	}
+
+	t.Run("sequential path rejects unresolved routing var", func(t *testing.T) {
+		store := beads.NewMemStore()
+		root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		prev := IsGraphApplyEnabled()
+		SetGraphApplyEnabled(false)
+		t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+		_, err = InstantiateFragment(context.Background(), store, fragment, FragmentOptions{
+			RootID: root.ID,
+		})
+		if err == nil {
+			t.Fatal("InstantiateFragment should reject unresolved {{review_target}} in gc.run_target")
+		}
+		if !strings.Contains(err.Error(), beadmeta.RunTargetMetadataKey) || !strings.Contains(err.Error(), "review_target") {
+			t.Errorf("error should mention %s and review_target: %v", beadmeta.RunTargetMetadataKey, err)
+		}
+	})
+
+	t.Run("graph-apply path rejects unresolved routing var", func(t *testing.T) {
+		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+		root, err := gaStore.Create(beads.Bead{Title: "root", Type: "molecule"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		prev := IsGraphApplyEnabled()
+		SetGraphApplyEnabled(true)
+		t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+		_, err = InstantiateFragment(context.Background(), gaStore, fragment, FragmentOptions{
+			RootID: root.ID,
+		})
+		if err == nil {
+			t.Fatal("graph-apply InstantiateFragment should reject unresolved {{review_target}} in gc.run_target")
+		}
+		if !strings.Contains(err.Error(), beadmeta.RunTargetMetadataKey) || !strings.Contains(err.Error(), "review_target") {
+			t.Errorf("error should mention %s and review_target: %v", beadmeta.RunTargetMetadataKey, err)
 		}
 	})
 }

--- a/internal/molecule/native_step_topology_test.go
+++ b/internal/molecule/native_step_topology_test.go
@@ -131,7 +131,8 @@ func TestCompiledReviewQuorumCollapsesRetryMachineryIntoNativeSteps(t *testing.T
 		t.Fatalf("getwd: %v", err)
 	}
 	searchDir := filepath.Join(cwd, "..", "bootstrap", "packs", "core", "formulas")
-	recipe, err := formula.Compile(context.Background(), "mol-review-quorum", []string{searchDir}, map[string]string{
+	// Fed to both calls below, like sling.go threads a single opts.Vars.
+	vars := map[string]string{
 		"subject":           "PR-123",
 		"lane_one_id":       "primary",
 		"lane_one_provider": "provider-a",
@@ -142,12 +143,13 @@ func TestCompiledReviewQuorumCollapsesRetryMachineryIntoNativeSteps(t *testing.T
 		"lane_two_model":    "model-b",
 		"lane_two_target":   "target-b",
 		"synthesis_target":  "review-synthesis",
-	})
+	}
+	recipe, err := formula.Compile(context.Background(), "mol-review-quorum", []string{searchDir}, vars)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
 
-	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{Vars: vars})
 	if err != nil {
 		t.Fatalf("buildRecipeApplyPlan: %v", err)
 	}


### PR DESCRIPTION
## Summary

The `#618` residual-`{{var}}` guard added to `buildRecipeApplyPlan` /
`buildFragmentApplyPlan` only inspects the bead **title**. A missing or
misspelled `--var` for a routing var leaves a literal, unrendered
`{{...}}` placeholder in `gc.run_target` / `gc.routed_to` /
`gc.execution_routed_to` instead of failing the sling, and the bead is
written durable with no error. The route then resolves to no agent, so
the bead lands with an empty/unclaimable assignee after an otherwise
"verified" `gc sling` — reported in #5060 with a 212-bead field sample,
185 of which (~87%) carried this exact fingerprint.

This extends the same guard to routing metadata at every site the
title-only guard already covers:

- `internal/molecule/graph_apply.go`: `buildRecipeApplyPlan` and
  `buildFragmentApplyPlan` (the graph-apply path)
- `internal/molecule/molecule.go`: `Instantiate` and `InstantiateFragment`
  (the sequential fallback path used when graph-apply is disabled, and by
  `Attach`, which calls `Instantiate` internally)

A new `validateResidualRoutingVars` helper (`internal/molecule/graph_apply.go`)
checks `gc.run_target`, `gc.routed_to`, `gc.execution_routed_to`, and their
`gc.deferred_*` counterparts (populated when `opts.DeferAssignees` defers
routing before this guard runs) for residual placeholders, reusing the
existing `formula.CheckResidualVars`. It's called from both the graph-apply
and sequential paths, immediately after the existing title check.

This is fix option A from the issue's own root-cause analysis (the
maintainer-recommended narrow fix, reusing the #618 guard rather than
adding a second validation layer at the graph-route boundary).

## Testing

```
ICU=/opt/homebrew/opt/icu4c@78 \
CGO_CXXFLAGS="-I$ICU/include" CGO_CFLAGS="-I$ICU/include" \
CGO_LDFLAGS="-L$ICU/lib -licuuc -licui18n -licudata" \
go test ./internal/molecule/... -count=1
go vet ./internal/molecule/...
golangci-lint run ./internal/molecule/...
```

All pass. Added four test cases (`TestInstantiateRejectsResidualRoutingMetadataVars`,
`TestInstantiateFragmentRejectsResidualRoutingMetadataVars`) mirroring the
existing `TestInstantiateRejectsResidualTitleVars` /
`TestInstantiateFragmentRejectsResidualTitleVars` table shape, covering both
the sequential and graph-apply paths, `gc.run_target` and `gc.routed_to`,
and a success case with the var resolved.

Verified the new tests actually catch the regression: reverted the guard
changes (keeping the tests), confirmed the four new test cases fail with
the exact pre-fix symptom ("should reject unresolved ... in gc.run_target"),
then restored the fix and confirmed a clean pass.

Also updated `TestCompiledReviewQuorumCollapsesRetryMachineryIntoNativeSteps`
(`internal/molecule/native_step_topology_test.go`), which called
`buildRecipeApplyPlan` directly with empty `Options{}` despite passing var
values to the preceding `formula.Compile` call. `formula.Compile`'s own doc
comment states substitution happens at instantiation time, not compile
time, and the real production path (`internal/sling/sling.go`) threads the
same `opts.Vars` map to both calls — so this test now does the same,
matching real usage rather than relying on an under-substituted input that
happened to slip past the title-only guard.

The two pre-existing failures in `internal/formula` (`TestDescriptionFileBaseDirResolvesSymlinkedParentWithMissingLeaf`,
`TestCanonicalExistingPathResolvesSymlinkedGrandparentWithTwoMissingLevels`)
are environmental (macOS `/tmp` → `/private/tmp` symlink resolution) and
reproduce identically on unmodified `main`; unrelated to this change.

Fixes #5060. Reported by @tdupu.
