### PR TITLE
fix(runtime): surface max_active_sessions changes on gc reload (#2897)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2245,9 +2245,8 @@ func (cr *CityRuntime) reloadConfigTraced(
 		fmt.Fprintf(cr.stderr, "%s: orders reloaded: %s\n", cr.logPrefix, orderSummary) //nolint:errcheck // best-effort stderr
 	}
 
-	// FR-PM.3: diff pool max_active_sessions before the in-memory swap so the
-	// reload reply surfaces old → new bounds. Active counts use the still-
-	// current config for template attribution.
+	// Diff pool bounds and count active sessions against the still-current
+	// config before the swap below (#2897 FR-PM.3).
 	poolBoundChanges := poolMaxActiveSessionChanges(cr.cfg, nextCfg)
 	poolActiveCounts := cr.countActiveSessionsByTemplate(cr.cfg)
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2245,6 +2245,12 @@ func (cr *CityRuntime) reloadConfigTraced(
 		fmt.Fprintf(cr.stderr, "%s: orders reloaded: %s\n", cr.logPrefix, orderSummary) //nolint:errcheck // best-effort stderr
 	}
 
+	// FR-PM.3: diff pool max_active_sessions before the in-memory swap so the
+	// reload reply surfaces old → new bounds. Active counts use the still-
+	// current config for template attribution.
+	poolBoundChanges := poolMaxActiveSessionChanges(cr.cfg, nextCfg)
+	poolActiveCounts := cr.countActiveSessionsByTemplate(cr.cfg)
+
 	cr.serviceStateMu.Lock()
 	cr.cfg = nextCfg
 	cr.sp = nextSp
@@ -2318,6 +2324,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	message := fmt.Sprintf("Config reloaded: %s (rev %s)",
 		configReloadSummary(oldAgentCount, oldRigCount, len(nextCfg.Agents), len(nextCfg.Rigs)),
 		shortRev(result.Revision))
+	message, warnings = appendPoolMaxBoundFeedback(message, warnings, poolBoundChanges, poolActiveCounts)
 	fmt.Fprintln(cr.stdout, message) //nolint:errcheck // best-effort stdout
 	telemetry.RecordConfigReload(ctx, result.Revision, string(source), string(reloadOutcomeApplied), len(warnings), nil)
 	if trace != nil {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2245,10 +2245,14 @@ func (cr *CityRuntime) reloadConfigTraced(
 		fmt.Fprintf(cr.stderr, "%s: orders reloaded: %s\n", cr.logPrefix, orderSummary) //nolint:errcheck // best-effort stderr
 	}
 
-	// Diff pool bounds and count active sessions against the still-current
-	// config before the swap below (#2897 FR-PM.3).
+	// Diff pool bounds against the still-current config before the swap
+	// below (#2897 FR-PM.3). Session counting is only needed for drain
+	// warnings (finite decreases); skip store work on no-op and increase-only reloads.
 	poolBoundChanges := poolMaxActiveSessionChanges(cr.cfg, nextCfg)
-	poolActiveCounts := cr.countActiveSessionsByTemplate(cr.cfg)
+	var poolActiveCounts map[string]int
+	if poolBoundChangesNeedActiveCounts(poolBoundChanges) {
+		poolActiveCounts = cr.countActiveSessionsByTemplate(cr.cfg)
+	}
 
 	cr.serviceStateMu.Lock()
 	cr.cfg = nextCfg

--- a/cmd/gc/reload_pool_bounds.go
+++ b/cmd/gc/reload_pool_bounds.go
@@ -156,16 +156,13 @@ func (cr *CityRuntime) countActiveSessionsByTemplate(cfg *config.City) map[strin
 		}
 		template := resolvedTemplateForIdentity(name, cfg)
 		if template == "" {
-			// Strip city session-template prefix if present.
-			if st := strings.TrimSpace(cfg.Workspace.SessionTemplate); st != "" {
-				prefix := strings.ReplaceAll(st, "{name}", "")
-				// Common shape: "gc-{city}-{name}" — try suffix identity match.
-				if idx := strings.LastIndex(name, "-"); idx >= 0 {
-					if resolved := resolvedTemplateForIdentity(name[idx+1:], cfg); resolved != "" {
-						template = resolved
-					}
+			// Provider process names are sometimes city-prefixed
+			// (e.g. "gc-city-planner"). Try the final dash-separated
+			// segment as an agent identity before giving up.
+			if idx := strings.LastIndex(name, "-"); idx >= 0 {
+				if resolved := resolvedTemplateForIdentity(name[idx+1:], cfg); resolved != "" {
+					template = resolved
 				}
-				_ = prefix
 			}
 		}
 		if template == "" {

--- a/cmd/gc/reload_pool_bounds.go
+++ b/cmd/gc/reload_pool_bounds.go
@@ -82,6 +82,12 @@ func poolMaxBoundDrainWarning(c poolMaxBoundChange, active int) string {
 	if c.New == nil || *c.New < 0 {
 		return ""
 	}
+	// Only a genuine tightening drains: unlimited → finite, or a lower finite
+	// bound. An increased bound never awaits attrition even if the current
+	// active count happens to sit above it (stale beads, out-of-band change).
+	if c.Old != nil && *c.Old >= 0 && *c.New >= *c.Old {
+		return ""
+	}
 	if active <= *c.New {
 		return ""
 	}

--- a/cmd/gc/reload_pool_bounds.go
+++ b/cmd/gc/reload_pool_bounds.go
@@ -118,84 +118,51 @@ func appendPoolMaxBoundFeedback(message string, warnings []string, changes []poo
 	return strings.Join(lines, "\n"), warnings
 }
 
+// poolBoundChangesNeedActiveCounts reports whether any change is a decrease to a
+// finite bound. Drain warnings are the only consumer of session counts; skip
+// store work on unchanged reloads and on increase-only / unlimited reloads.
+func poolBoundChangesNeedActiveCounts(changes []poolMaxBoundChange) bool {
+	for _, c := range changes {
+		if c.New == nil || *c.New < 0 {
+			continue // unlimited new bound never drains
+		}
+		// Finite new bound: need counts only when it is strictly tighter than old.
+		if c.Old == nil || *c.Old < 0 {
+			return true // unlimited → finite is a decrease
+		}
+		if *c.New < *c.Old {
+			return true
+		}
+	}
+	return false
+}
+
 // countActiveSessionsByTemplate returns open session counts keyed by agent
-// QualifiedName. Prefers session beads when available; falls back to running
-// provider sessions attributed via identity resolution against cfg.
+// QualifiedName from the sessions bead store. When the store is unavailable or
+// ListAll fails, returns an empty map so callers omit drain warnings honestly
+// rather than inventing counts via provider-name heuristics.
 func (cr *CityRuntime) countActiveSessionsByTemplate(cfg *config.City) map[string]int {
 	counts := make(map[string]int)
 	if cr == nil || cfg == nil {
 		return counts
 	}
-	if store := cr.sessionsBeadStore(); store.Store != nil {
-		infos, err := sessionFrontDoor(store.Store).ListAll(sessionpkg.ListAllOptions{})
-		if err == nil {
-			for _, info := range infos {
-				if info.Closed {
-					continue
-				}
-				template := strings.TrimSpace(normalizedSessionTemplateInfo(info, cfg))
-				if template == "" {
-					continue
-				}
-				counts[template]++
-			}
-			return counts
-		}
-	}
-	if cr.sp == nil {
+	store := cr.sessionsBeadStore()
+	if store.Store == nil {
 		return counts
 	}
-	running, err := cr.sp.ListRunning("")
+	infos, err := sessionFrontDoor(store.Store).ListAll(sessionpkg.ListAllOptions{})
 	if err != nil {
 		return counts
 	}
-	for _, name := range running {
-		name = strings.TrimSpace(name)
-		if name == "" {
+	for _, info := range infos {
+		if info.Closed {
 			continue
 		}
-		template := resolvedTemplateForIdentity(name, cfg)
+		template := strings.TrimSpace(normalizedSessionTemplateInfo(info, cfg))
 		if template == "" {
-			// Provider process names are sometimes city-prefixed
-			// (e.g. "gc-city-planner"). Try the final dash-separated
-			// segment as an agent identity before giving up.
-			if idx := strings.LastIndex(name, "-"); idx >= 0 {
-				if resolved := resolvedTemplateForIdentity(name[idx+1:], cfg); resolved != "" {
-					template = resolved
-				}
-			}
+			continue
 		}
-		if template == "" {
-			// Match bounded pool instance "template-N" / "dir/template-N".
-			if base := poolBaseIdentity(name); base != "" {
-				template = resolvedTemplateForIdentity(base, cfg)
-			}
-		}
-		if template != "" {
-			counts[template]++
-		}
+		counts[template]++
 	}
 	return counts
-}
-
-// poolBaseIdentity strips a trailing "-N" pool slot suffix when present.
-func poolBaseIdentity(sessionName string) string {
-	sessionName = strings.TrimSpace(sessionName)
-	if sessionName == "" {
-		return ""
-	}
-	i := strings.LastIndex(sessionName, "-")
-	if i <= 0 || i == len(sessionName)-1 {
-		return ""
-	}
-	slot := sessionName[i+1:]
-	for _, r := range slot {
-		if r < '0' || r > '9' {
-			return ""
-		}
-	}
-	if slot == "0" || (len(slot) > 1 && slot[0] == '0') {
-		return ""
-	}
-	return sessionName[:i]
 }

--- a/cmd/gc/reload_pool_bounds.go
+++ b/cmd/gc/reload_pool_bounds.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// poolMaxBoundChange records a ResolvedMaxActiveSessions change for one agent.
+type poolMaxBoundChange struct {
+	Name string
+	Old  *int
+	New  *int
+}
+
+// formatResolvedMaxActiveSessions formats a resolved max_active_sessions value
+// for operator-facing reload output. Nil and negative mean unlimited.
+func formatResolvedMaxActiveSessions(m *int) string {
+	if m == nil || *m < 0 {
+		return "unlimited"
+	}
+	return strconv.Itoa(*m)
+}
+
+// resolvedMaxEqual reports whether two resolved max values are operator-equivalent.
+func resolvedMaxEqual(a, b *int) bool {
+	return formatResolvedMaxActiveSessions(a) == formatResolvedMaxActiveSessions(b)
+}
+
+// poolMaxActiveSessionChanges diffs ResolvedMaxActiveSessions for agents present
+// in both old and new configs. Uses the same resolution helper the reconciler
+// uses (Agent.ResolvedMaxActiveSessions) so inheritance from rig/workspace is
+// visible when only a parent bound changes.
+func poolMaxActiveSessionChanges(oldCfg, newCfg *config.City) []poolMaxBoundChange {
+	if oldCfg == nil || newCfg == nil {
+		return nil
+	}
+	oldByName := make(map[string]*config.Agent, len(oldCfg.Agents))
+	for i := range oldCfg.Agents {
+		a := &oldCfg.Agents[i]
+		oldByName[a.QualifiedName()] = a
+	}
+	var changes []poolMaxBoundChange
+	for i := range newCfg.Agents {
+		a := &newCfg.Agents[i]
+		name := a.QualifiedName()
+		oldA, ok := oldByName[name]
+		if !ok {
+			continue
+		}
+		oldM := oldA.ResolvedMaxActiveSessions(oldCfg)
+		newM := a.ResolvedMaxActiveSessions(newCfg)
+		if resolvedMaxEqual(oldM, newM) {
+			continue
+		}
+		changes = append(changes, poolMaxBoundChange{Name: name, Old: oldM, New: newM})
+	}
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Name < changes[j].Name
+	})
+	return changes
+}
+
+// formatPoolMaxBoundChangeLine formats one pool bound change for the reload Message.
+func formatPoolMaxBoundChangeLine(c poolMaxBoundChange) string {
+	return fmt.Sprintf("pool %s: max_active_sessions %s → %s",
+		c.Name,
+		formatResolvedMaxActiveSessions(c.Old),
+		formatResolvedMaxActiveSessions(c.New),
+	)
+}
+
+// poolMaxBoundDrainWarning returns a warning when the new bound is below the
+// current active count. Decreases apply by lazy attrition (FR-PM.4): excess
+// sessions are not killed; the reconciler stops replacing them when they finish
+// (new demand is capped by the fresh ResolvedMaxActiveSessions).
+func poolMaxBoundDrainWarning(c poolMaxBoundChange, active int) string {
+	if c.New == nil || *c.New < 0 {
+		return ""
+	}
+	if active <= *c.New {
+		return ""
+	}
+	return fmt.Sprintf(
+		"pool %s: max_active_sessions %s → %s cannot take full effect until sessions drain (%d active); excess sessions wind down via normal reconcile and are not replaced when they finish",
+		c.Name,
+		formatResolvedMaxActiveSessions(c.Old),
+		formatResolvedMaxActiveSessions(c.New),
+		active,
+	)
+}
+
+// appendPoolMaxBoundFeedback adds per-pool max_active_sessions change lines to
+// message and drain warnings to the warnings list. Pure: activeCounts is
+// keyed by agent QualifiedName.
+func appendPoolMaxBoundFeedback(message string, warnings []string, changes []poolMaxBoundChange, activeCounts map[string]int) (string, []string) {
+	if len(changes) == 0 {
+		return message, warnings
+	}
+	lines := make([]string, 0, len(changes)+1)
+	if strings.TrimSpace(message) != "" {
+		lines = append(lines, strings.TrimSpace(message))
+	}
+	for _, c := range changes {
+		lines = append(lines, formatPoolMaxBoundChangeLine(c))
+		active := 0
+		if activeCounts != nil {
+			active = activeCounts[c.Name]
+		}
+		if w := poolMaxBoundDrainWarning(c, active); w != "" {
+			warnings = append(warnings, w)
+		}
+	}
+	return strings.Join(lines, "\n"), warnings
+}
+
+// countActiveSessionsByTemplate returns open session counts keyed by agent
+// QualifiedName. Prefers session beads when available; falls back to running
+// provider sessions attributed via identity resolution against cfg.
+func (cr *CityRuntime) countActiveSessionsByTemplate(cfg *config.City) map[string]int {
+	counts := make(map[string]int)
+	if cr == nil || cfg == nil {
+		return counts
+	}
+	if store := cr.sessionsBeadStore(); store.Store != nil {
+		infos, err := sessionFrontDoor(store.Store).ListAll(sessionpkg.ListAllOptions{})
+		if err == nil {
+			for _, info := range infos {
+				if info.Closed {
+					continue
+				}
+				template := strings.TrimSpace(normalizedSessionTemplateInfo(info, cfg))
+				if template == "" {
+					continue
+				}
+				counts[template]++
+			}
+			return counts
+		}
+	}
+	if cr.sp == nil {
+		return counts
+	}
+	running, err := cr.sp.ListRunning("")
+	if err != nil {
+		return counts
+	}
+	for _, name := range running {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		template := resolvedTemplateForIdentity(name, cfg)
+		if template == "" {
+			// Strip city session-template prefix if present.
+			if st := strings.TrimSpace(cfg.Workspace.SessionTemplate); st != "" {
+				prefix := strings.ReplaceAll(st, "{name}", "")
+				// Common shape: "gc-{city}-{name}" — try suffix identity match.
+				if idx := strings.LastIndex(name, "-"); idx >= 0 {
+					if resolved := resolvedTemplateForIdentity(name[idx+1:], cfg); resolved != "" {
+						template = resolved
+					}
+				}
+				_ = prefix
+			}
+		}
+		if template == "" {
+			// Match bounded pool instance "template-N" / "dir/template-N".
+			if base := poolBaseIdentity(name); base != "" {
+				template = resolvedTemplateForIdentity(base, cfg)
+			}
+		}
+		if template != "" {
+			counts[template]++
+		}
+	}
+	return counts
+}
+
+// poolBaseIdentity strips a trailing "-N" pool slot suffix when present.
+func poolBaseIdentity(sessionName string) string {
+	sessionName = strings.TrimSpace(sessionName)
+	if sessionName == "" {
+		return ""
+	}
+	i := strings.LastIndex(sessionName, "-")
+	if i <= 0 || i == len(sessionName)-1 {
+		return ""
+	}
+	slot := sessionName[i+1:]
+	for _, r := range slot {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	if slot == "0" || (len(slot) > 1 && slot[0] == '0') {
+		return ""
+	}
+	return sessionName[:i]
+}

--- a/cmd/gc/reload_pool_bounds_test.go
+++ b/cmd/gc/reload_pool_bounds_test.go
@@ -1,0 +1,434 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func reloadPoolIntPtr(n int) *int { return &n }
+
+func TestFormatResolvedMaxActiveSessions(t *testing.T) {
+	if got := formatResolvedMaxActiveSessions(nil); got != "unlimited" {
+		t.Fatalf("nil = %q, want unlimited", got)
+	}
+	if got := formatResolvedMaxActiveSessions(reloadPoolIntPtr(-1)); got != "unlimited" {
+		t.Fatalf("-1 = %q, want unlimited", got)
+	}
+	if got := formatResolvedMaxActiveSessions(reloadPoolIntPtr(0)); got != "0" {
+		t.Fatalf("0 = %q, want 0", got)
+	}
+	if got := formatResolvedMaxActiveSessions(reloadPoolIntPtr(8)); got != "8" {
+		t.Fatalf("8 = %q, want 8", got)
+	}
+}
+
+func TestPoolMaxActiveSessionChanges_Table(t *testing.T) {
+	t.Parallel()
+
+	agent := func(name, dir string, max *int) config.Agent {
+		return config.Agent{Name: name, Dir: dir, MaxActiveSessions: max}
+	}
+
+	tests := []struct {
+		name string
+		old  *config.City
+		new  *config.City
+		want []string // formatted change lines; empty means no changes
+	}{
+		{
+			name: "bound increase reported",
+			old: &config.City{
+				Agents: []config.Agent{agent("executor", "rig-a", reloadPoolIntPtr(6))},
+			},
+			new: &config.City{
+				Agents: []config.Agent{agent("executor", "rig-a", reloadPoolIntPtr(8))},
+			},
+			want: []string{"pool rig-a/executor: max_active_sessions 6 → 8"},
+		},
+		{
+			name: "bound decrease reported",
+			old: &config.City{
+				Agents: []config.Agent{agent("executor", "rig-a", reloadPoolIntPtr(4))},
+			},
+			new: &config.City{
+				Agents: []config.Agent{agent("executor", "rig-a", reloadPoolIntPtr(2))},
+			},
+			want: []string{"pool rig-a/executor: max_active_sessions 4 → 2"},
+		},
+		{
+			name: "no pool changes",
+			old: &config.City{
+				Agents: []config.Agent{agent("executor", "rig-a", reloadPoolIntPtr(6))},
+			},
+			new: &config.City{
+				Agents: []config.Agent{agent("executor", "rig-a", reloadPoolIntPtr(6))},
+			},
+			want: nil,
+		},
+		{
+			name: "default resolution via workspace max",
+			old: &config.City{
+				Workspace: config.Workspace{MaxActiveSessions: reloadPoolIntPtr(2)},
+				Agents:    []config.Agent{agent("worker", "", nil)},
+			},
+			new: &config.City{
+				Workspace: config.Workspace{MaxActiveSessions: reloadPoolIntPtr(5)},
+				Agents:    []config.Agent{agent("worker", "", nil)},
+			},
+			want: []string{"pool worker: max_active_sessions 2 → 5"},
+		},
+		{
+			name: "default resolution via rig max",
+			old: &config.City{
+				Rigs:   []config.Rig{{Name: "oss", MaxActiveSessions: reloadPoolIntPtr(3)}},
+				Agents: []config.Agent{agent("polecat", "oss", nil)},
+			},
+			new: &config.City{
+				Rigs:   []config.Rig{{Name: "oss", MaxActiveSessions: reloadPoolIntPtr(7)}},
+				Agents: []config.Agent{agent("polecat", "oss", nil)},
+			},
+			want: []string{"pool oss/polecat: max_active_sessions 3 → 7"},
+		},
+		{
+			name: "explicit agent max wins over workspace change",
+			old: &config.City{
+				Workspace: config.Workspace{MaxActiveSessions: reloadPoolIntPtr(2)},
+				Agents:    []config.Agent{agent("worker", "", reloadPoolIntPtr(4))},
+			},
+			new: &config.City{
+				Workspace: config.Workspace{MaxActiveSessions: reloadPoolIntPtr(9)},
+				Agents:    []config.Agent{agent("worker", "", reloadPoolIntPtr(4))},
+			},
+			want: nil,
+		},
+		{
+			name: "nil to unlimited equivalent skips",
+			old: &config.City{
+				Agents: []config.Agent{agent("worker", "", nil)},
+			},
+			new: &config.City{
+				Agents: []config.Agent{agent("worker", "", reloadPoolIntPtr(-1))},
+			},
+			want: nil,
+		},
+		{
+			name: "added agent does not produce pool line",
+			old: &config.City{
+				Agents: []config.Agent{agent("a", "", reloadPoolIntPtr(1))},
+			},
+			new: &config.City{
+				Agents: []config.Agent{
+					agent("a", "", reloadPoolIntPtr(1)),
+					agent("b", "", reloadPoolIntPtr(3)),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "multiple pools sorted by name",
+			old: &config.City{
+				Agents: []config.Agent{
+					agent("planner", "rig-a", reloadPoolIntPtr(2)),
+					agent("executor", "rig-a", reloadPoolIntPtr(6)),
+				},
+			},
+			new: &config.City{
+				Agents: []config.Agent{
+					agent("planner", "rig-a", reloadPoolIntPtr(3)),
+					agent("executor", "rig-a", reloadPoolIntPtr(8)),
+				},
+			},
+			want: []string{
+				"pool rig-a/executor: max_active_sessions 6 → 8",
+				"pool rig-a/planner: max_active_sessions 2 → 3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := poolMaxActiveSessionChanges(tt.old, tt.new)
+			if len(tt.want) == 0 {
+				if len(got) != 0 {
+					t.Fatalf("changes = %+v, want none", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(changes) = %d, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i, line := range tt.want {
+				if gotLine := formatPoolMaxBoundChangeLine(got[i]); gotLine != line {
+					t.Fatalf("change[%d] = %q, want %q", i, gotLine, line)
+				}
+			}
+		})
+	}
+}
+
+func TestPoolMaxBoundDrainWarning(t *testing.T) {
+	t.Parallel()
+	c := poolMaxBoundChange{
+		Name: "rig-a/executor",
+		Old:  reloadPoolIntPtr(4),
+		New:  reloadPoolIntPtr(2),
+	}
+	if got := poolMaxBoundDrainWarning(c, 2); got != "" {
+		t.Fatalf("active==new bound: warning = %q, want empty", got)
+	}
+	if got := poolMaxBoundDrainWarning(c, 1); got != "" {
+		t.Fatalf("active<new bound: warning = %q, want empty", got)
+	}
+	got := poolMaxBoundDrainWarning(c, 3)
+	if !strings.Contains(got, "rig-a/executor") {
+		t.Fatalf("warning missing pool name: %q", got)
+	}
+	if !strings.Contains(got, "4 → 2") {
+		t.Fatalf("warning missing bounds: %q", got)
+	}
+	if !strings.Contains(got, "3 active") {
+		t.Fatalf("warning missing active count: %q", got)
+	}
+	if !strings.Contains(got, "normal reconcile") || !strings.Contains(got, "not replaced") {
+		t.Fatalf("warning missing attrition semantics: %q", got)
+	}
+	// Unlimited new bound never warns.
+	c.New = nil
+	if got := poolMaxBoundDrainWarning(c, 99); got != "" {
+		t.Fatalf("unlimited new: warning = %q, want empty", got)
+	}
+}
+
+func TestAppendPoolMaxBoundFeedback(t *testing.T) {
+	t.Parallel()
+	base := "Config reloaded: 1 agents, 0 rigs (rev abc)"
+	changes := []poolMaxBoundChange{
+		{Name: "rig-a/executor", Old: reloadPoolIntPtr(6), New: reloadPoolIntPtr(8)},
+		{Name: "rig-a/planner", Old: reloadPoolIntPtr(4), New: reloadPoolIntPtr(2)},
+	}
+	active := map[string]int{"rig-a/planner": 3}
+	msg, warnings := appendPoolMaxBoundFeedback(base, nil, changes, active)
+	if !strings.HasPrefix(msg, base+"\n") {
+		t.Fatalf("message prefix = %q", msg)
+	}
+	if !strings.Contains(msg, "pool rig-a/executor: max_active_sessions 6 → 8") {
+		t.Fatalf("message missing increase line: %q", msg)
+	}
+	if !strings.Contains(msg, "pool rig-a/planner: max_active_sessions 4 → 2") {
+		t.Fatalf("message missing decrease line: %q", msg)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "rig-a/planner") {
+		t.Fatalf("warnings = %v, want one planner drain warning", warnings)
+	}
+
+	// No changes: message and warnings unchanged.
+	msg2, warnings2 := appendPoolMaxBoundFeedback(base, []string{"keep"}, nil, nil)
+	if msg2 != base {
+		t.Fatalf("no-change message = %q, want %q", msg2, base)
+	}
+	if len(warnings2) != 1 || warnings2[0] != "keep" {
+		t.Fatalf("no-change warnings = %v", warnings2)
+	}
+}
+
+func TestPoolBaseIdentity(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"executor-3":       "executor",
+		"rig-a/executor-2": "rig-a/executor",
+		"executor":         "",
+		"executor-0":       "",
+		"executor-01":      "",
+		"":                 "",
+	}
+	for in, want := range cases {
+		if got := poolBaseIdentity(in); got != want {
+			t.Fatalf("poolBaseIdentity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestReloadConfigTracedReportsPoolMaxBoundChanges(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeReloadPoolBoundConfig(t, tomlPath, 6, 4)
+
+	cfg, configRev := loadCityRuntimeControllerConfig(t, cityPath)
+	sp := runtime.NewFake()
+	// Three running pool instances under the planner template so a decrease
+	// to 2 produces a drain warning.
+	for _, name := range []string{"planner-1", "planner-2", "planner-3"} {
+		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+			t.Fatalf("start %s: %v", name, err)
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	cr := newTestCityRuntime(t, CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		ConfigRev: configRev,
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	// (a) increase + (b) decrease with active above new bound
+	writeReloadPoolBoundConfig(t, tomlPath, 8, 2)
+	lastProviderName := "fake"
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
+	if reply.Outcome != reloadOutcomeApplied {
+		t.Fatalf("reply.Outcome = %q, want applied; error=%q warnings=%v stderr=%q",
+			reply.Outcome, reply.Error, reply.Warnings, stderr.String())
+	}
+	if !strings.Contains(reply.Message, "pool executor: max_active_sessions 6 → 8") {
+		t.Fatalf("message missing increase: %q", reply.Message)
+	}
+	if !strings.Contains(reply.Message, "pool planner: max_active_sessions 4 → 2") {
+		t.Fatalf("message missing decrease: %q", reply.Message)
+	}
+	if !warningsContain(reply.Warnings, "pool planner: max_active_sessions 4 → 2") {
+		t.Fatalf("warnings missing drain notice: %v", reply.Warnings)
+	}
+	if !warningsContain(reply.Warnings, "3 active") {
+		t.Fatalf("warnings missing active count: %v", reply.Warnings)
+	}
+	// Increase must not produce a drain warning.
+	for _, w := range reply.Warnings {
+		if strings.Contains(w, "executor") && strings.Contains(w, "drain") {
+			t.Fatalf("unexpected drain warning for increase: %q", w)
+		}
+	}
+}
+
+func TestReloadConfigTracedNoPoolLinesWhenBoundsUnchanged(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeReloadPoolBoundConfig(t, tomlPath, 6, 4)
+
+	cfg, configRev := loadCityRuntimeControllerConfig(t, cityPath)
+	sp := runtime.NewFake()
+	var stdout bytes.Buffer
+	cr := newTestCityRuntime(t, CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		ConfigRev: configRev,
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: io.Discard,
+	})
+
+	// Change only an unrelated field so revision changes but pool bounds do not.
+	writeReloadPoolBoundConfigWithExtra(t, tomlPath, 6, 4, "1s")
+	lastProviderName := "fake"
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
+	if reply.Outcome != reloadOutcomeApplied {
+		t.Fatalf("reply.Outcome = %q, want applied; error=%q", reply.Outcome, reply.Error)
+	}
+	if strings.Contains(reply.Message, "max_active_sessions") {
+		t.Fatalf("message should omit pool lines when bounds unchanged: %q", reply.Message)
+	}
+	for _, w := range reply.Warnings {
+		if strings.Contains(w, "max_active_sessions") {
+			t.Fatalf("warnings should omit pool lines: %v", reply.Warnings)
+		}
+	}
+}
+
+func TestReloadConfigTracedDefaultResolutionWorkspaceMax(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeReloadWorkspaceMaxConfig(t, tomlPath, 2)
+
+	cfg, configRev := loadCityRuntimeControllerConfig(t, cityPath)
+	sp := runtime.NewFake()
+	var stdout bytes.Buffer
+	cr := newTestCityRuntime(t, CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		ConfigRev: configRev,
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: io.Discard,
+	})
+
+	writeReloadWorkspaceMaxConfig(t, tomlPath, 5)
+	lastProviderName := "fake"
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
+	if reply.Outcome != reloadOutcomeApplied {
+		t.Fatalf("reply.Outcome = %q, want applied; error=%q", reply.Outcome, reply.Error)
+	}
+	if !strings.Contains(reply.Message, "pool worker: max_active_sessions 2 → 5") {
+		t.Fatalf("message missing default-resolution change: %q", reply.Message)
+	}
+}
+
+func writeReloadPoolBoundConfig(t *testing.T, tomlPath string, executorMax, plannerMax int) {
+	t.Helper()
+	writeReloadPoolBoundConfigWithExtra(t, tomlPath, executorMax, plannerMax, "")
+}
+
+func writeReloadPoolBoundConfigWithExtra(t *testing.T, tomlPath string, executorMax, plannerMax int, shutdownTimeout string) {
+	t.Helper()
+	clearInheritedBeadsEnv(t)
+	var b strings.Builder
+	b.WriteString("[workspace]\nname = \"test-city\"\n\n")
+	b.WriteString("[beads]\nprovider = \"file\"\n\n")
+	b.WriteString("[session]\nprovider = \"fake\"\n\n")
+	if shutdownTimeout != "" {
+		b.WriteString("[daemon]\nshutdown_timeout = \"")
+		b.WriteString(shutdownTimeout)
+		b.WriteString("\"\n\n")
+	}
+	b.WriteString("[[agent]]\nname = \"executor\"\nmax_active_sessions = ")
+	b.WriteString(strconv.Itoa(executorMax))
+	b.WriteString("\n\n[[agent]]\nname = \"planner\"\nmax_active_sessions = ")
+	b.WriteString(strconv.Itoa(plannerMax))
+	b.WriteString("\n")
+	if err := os.WriteFile(tomlPath, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func writeReloadWorkspaceMaxConfig(t *testing.T, tomlPath string, workspaceMax int) {
+	t.Helper()
+	clearInheritedBeadsEnv(t)
+	data := "[workspace]\nname = \"test-city\"\nmax_active_sessions = " + strconv.Itoa(workspaceMax) +
+		"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"fake\"\n\n" +
+		"[[agent]]\nname = \"worker\"\n"
+	if err := os.WriteFile(tomlPath, []byte(data), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}

--- a/cmd/gc/reload_pool_bounds_test.go
+++ b/cmd/gc/reload_pool_bounds_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func reloadPoolIntPtr(n int) *int { return &n }
@@ -92,13 +93,13 @@ func TestPoolMaxActiveSessionChanges_Table(t *testing.T) {
 			name: "default resolution via rig max",
 			old: &config.City{
 				Rigs:   []config.Rig{{Name: "oss", MaxActiveSessions: reloadPoolIntPtr(3)}},
-				Agents: []config.Agent{agent("polecat", "oss", nil)},
+				Agents: []config.Agent{agent("worker-pool", "oss", nil)},
 			},
 			new: &config.City{
 				Rigs:   []config.Rig{{Name: "oss", MaxActiveSessions: reloadPoolIntPtr(7)}},
-				Agents: []config.Agent{agent("polecat", "oss", nil)},
+				Agents: []config.Agent{agent("worker-pool", "oss", nil)},
 			},
-			want: []string{"pool oss/polecat: max_active_sessions 3 → 7"},
+			want: []string{"pool oss/worker-pool: max_active_sessions 3 → 7"},
 		},
 		{
 			name: "explicit agent max wins over workspace change",
@@ -243,51 +244,49 @@ func TestAppendPoolMaxBoundFeedback(t *testing.T) {
 	}
 }
 
-func TestPoolBaseIdentity(t *testing.T) {
+func TestPoolBoundChangesNeedActiveCounts(t *testing.T) {
 	t.Parallel()
-	cases := map[string]string{
-		"executor-3":       "executor",
-		"rig-a/executor-2": "rig-a/executor",
-		"executor":         "",
-		"executor-0":       "",
-		"executor-01":      "",
-		"":                 "",
+	if poolBoundChangesNeedActiveCounts(nil) {
+		t.Fatal("nil changes should not need counts")
 	}
-	for in, want := range cases {
-		if got := poolBaseIdentity(in); got != want {
-			t.Fatalf("poolBaseIdentity(%q) = %q, want %q", in, got, want)
-		}
+	if poolBoundChangesNeedActiveCounts([]poolMaxBoundChange{
+		{Name: "a", Old: reloadPoolIntPtr(2), New: reloadPoolIntPtr(8)},
+	}) {
+		t.Fatal("increase-only should not need counts")
+	}
+	if !poolBoundChangesNeedActiveCounts([]poolMaxBoundChange{
+		{Name: "a", Old: reloadPoolIntPtr(8), New: reloadPoolIntPtr(2)},
+	}) {
+		t.Fatal("finite decrease should need counts")
+	}
+	if !poolBoundChangesNeedActiveCounts([]poolMaxBoundChange{
+		{Name: "a", Old: nil, New: reloadPoolIntPtr(2)},
+	}) {
+		t.Fatal("unlimited→finite should need counts")
+	}
+	if poolBoundChangesNeedActiveCounts([]poolMaxBoundChange{
+		{Name: "a", Old: reloadPoolIntPtr(2), New: nil},
+	}) {
+		t.Fatal("finite→unlimited should not need counts")
 	}
 }
 
-// TestCountActiveSessionsByTemplate_ProviderFallback covers the provider-list
-// attribution path when no session-bead store is available: direct identity,
-// last-segment city-prefixed names, and pool slot suffixes.
-func TestCountActiveSessionsByTemplate_ProviderFallback(t *testing.T) {
+// TestCountActiveSessionsByTemplate_NoStore returns empty when the sessions
+// bead store is unavailable — no provider-list heuristics.
+func TestCountActiveSessionsByTemplate_NoStore(t *testing.T) {
 	t.Parallel()
-
 	cfg := &config.City{
-		// SessionTemplate deliberately empty: last-segment fallback must not
-		// depend on it (prefix stripping was dead code).
-		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{
 			{Name: "planner", MaxActiveSessions: reloadPoolIntPtr(4)},
-			{Name: "executor", MaxActiveSessions: reloadPoolIntPtr(6)},
 		},
 	}
-
 	sp := runtime.NewFake()
-	for _, name := range []string{
-		"planner-1",            // pool slot → planner
-		"gc-test-city-planner", // city-prefixed process name → last segment
-		"executor-2",
-		"unrelated-session", // no matching agent
-	} {
+	// Provider sessions must not be attributed without a bead store.
+	for _, name := range []string{"planner-1", "planner-2", "gc-test-city-planner"} {
 		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
 			t.Fatalf("start %s: %v", name, err)
 		}
 	}
-
 	cr := newTestCityRuntime(t, CityRuntimeParams{
 		CityPath: t.TempDir(),
 		CityName: "test-city",
@@ -301,16 +300,75 @@ func TestCountActiveSessionsByTemplate_ProviderFallback(t *testing.T) {
 		Stdout: io.Discard,
 		Stderr: io.Discard,
 	})
+	counts := cr.countActiveSessionsByTemplate(cfg)
+	if len(counts) != 0 {
+		t.Fatalf("without bead store, counts = %v, want empty", counts)
+	}
+}
+
+// TestCountActiveSessionsByTemplate_BeadStore counts open session beads by template.
+func TestCountActiveSessionsByTemplate_BeadStore(t *testing.T) {
+	t.Parallel()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "planner", MaxActiveSessions: reloadPoolIntPtr(4)},
+			{Name: "executor", MaxActiveSessions: reloadPoolIntPtr(6)},
+		},
+	}
+	store := beads.NewMemStore()
+	for i, name := range []string{"planner-1", "planner-2", "executor-1"} {
+		agent := "planner"
+		if strings.HasPrefix(name, "executor") {
+			agent = "executor"
+		}
+		if _, err := sessionFrontDoor(store).CreateSession(session.CreateSpec{
+			Title:     agent,
+			AgentName: agent,
+			Metadata: map[string]string{
+				"session_name": name,
+				"template":     agent,
+			},
+		}); err != nil {
+			t.Fatalf("create session %d (%s): %v", i, name, err)
+		}
+	}
+	// Closed session must not count.
+	closedID, err := sessionFrontDoor(store).CreateSession(session.CreateSpec{
+		Title:     "planner",
+		AgentName: "planner",
+		Metadata: map[string]string{
+			"session_name": "planner-closed",
+			"template":     "planner",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed session: %v", err)
+	}
+	if err := store.Close(closedID); err != nil {
+		t.Fatalf("close session: %v", err)
+	}
+
+	cr := newTestCityRuntime(t, CityRuntimeParams{
+		CityPath: t.TempDir(),
+		CityName: "test-city",
+		Cfg:      cfg,
+		SP:       runtime.NewFake(),
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(runtime.NewFake()),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+	cr.standaloneCityStore = store
 
 	counts := cr.countActiveSessionsByTemplate(cfg)
 	if got := counts["planner"]; got != 2 {
-		t.Fatalf("counts[planner] = %d, want 2 (slot + city-prefixed); full=%v", got, counts)
+		t.Fatalf("counts[planner] = %d, want 2; full=%v", got, counts)
 	}
 	if got := counts["executor"]; got != 1 {
 		t.Fatalf("counts[executor] = %d, want 1; full=%v", got, counts)
-	}
-	if _, ok := counts["unrelated-session"]; ok {
-		t.Fatalf("unexpected count for unresolved name: %v", counts)
 	}
 }
 
@@ -321,11 +379,19 @@ func TestReloadConfigTracedReportsPoolMaxBoundChanges(t *testing.T) {
 
 	cfg, configRev := loadCityRuntimeControllerConfig(t, cityPath)
 	sp := runtime.NewFake()
-	// Three running pool instances under the planner template so a decrease
-	// to 2 produces a drain warning.
-	for _, name := range []string{"planner-1", "planner-2", "planner-3"} {
-		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
-			t.Fatalf("start %s: %v", name, err)
+	// Three open planner session beads so a decrease to 2 produces a drain warning.
+	// Counts come only from the sessions bead store (no provider-list heuristics).
+	store := beads.NewMemStore()
+	for i, name := range []string{"planner-1", "planner-2", "planner-3"} {
+		if _, err := sessionFrontDoor(store).CreateSession(session.CreateSpec{
+			Title:     "planner",
+			AgentName: "planner",
+			Metadata: map[string]string{
+				"session_name": name,
+				"template":     "planner",
+			},
+		}); err != nil {
+			t.Fatalf("create session %d (%s): %v", i, name, err)
 		}
 	}
 	var stdout, stderr bytes.Buffer
@@ -344,6 +410,7 @@ func TestReloadConfigTracedReportsPoolMaxBoundChanges(t *testing.T) {
 		Stdout: &stdout,
 		Stderr: &stderr,
 	})
+	cr.standaloneCityStore = store
 
 	// (a) increase + (b) decrease with active above new bound
 	writeReloadPoolBoundConfig(t, tomlPath, 8, 2)

--- a/cmd/gc/reload_pool_bounds_test.go
+++ b/cmd/gc/reload_pool_bounds_test.go
@@ -212,6 +212,36 @@ func TestPoolMaxBoundDrainWarning(t *testing.T) {
 	}
 }
 
+func TestPoolMaxBoundDrainWarningIgnoresIncreases(t *testing.T) {
+	t.Parallel()
+	// Bound went UP but active sits above the new bound: not a drain.
+	up := poolMaxBoundChange{Name: "rig-a/executor", Old: reloadPoolIntPtr(2), New: reloadPoolIntPtr(4)}
+	if got := poolMaxBoundDrainWarning(up, 6); got != "" {
+		t.Fatalf("increase with active above new bound: warning = %q, want empty", got)
+	}
+	// Unlimited → finite is still a tightening and must warn.
+	tighten := poolMaxBoundChange{Name: "rig-a/planner", Old: nil, New: reloadPoolIntPtr(2)}
+	if got := poolMaxBoundDrainWarning(tighten, 5); got == "" {
+		t.Fatal("unlimited→finite with active above new bound: want warning")
+	}
+}
+
+func TestAppendPoolMaxBoundFeedbackMixedChanges(t *testing.T) {
+	t.Parallel()
+	changes := []poolMaxBoundChange{
+		{Name: "rig-a/executor", Old: reloadPoolIntPtr(2), New: reloadPoolIntPtr(4)},
+		{Name: "rig-a/planner", Old: reloadPoolIntPtr(4), New: reloadPoolIntPtr(2)},
+	}
+	active := map[string]int{"rig-a/executor": 6, "rig-a/planner": 3}
+	msg, warnings := appendPoolMaxBoundFeedback("Config reloaded", nil, changes, active)
+	if !strings.Contains(msg, "pool rig-a/executor: max_active_sessions 2 → 4") {
+		t.Fatalf("message missing increase line: %q", msg)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "rig-a/planner") {
+		t.Fatalf("warnings = %v, want exactly one planner drain warning", warnings)
+	}
+}
+
 func TestAppendPoolMaxBoundFeedback(t *testing.T) {
 	t.Parallel()
 	base := "Config reloaded: 1 agents, 0 rigs (rev abc)"

--- a/cmd/gc/reload_pool_bounds_test.go
+++ b/cmd/gc/reload_pool_bounds_test.go
@@ -260,6 +260,60 @@ func TestPoolBaseIdentity(t *testing.T) {
 	}
 }
 
+// TestCountActiveSessionsByTemplate_ProviderFallback covers the provider-list
+// attribution path when no session-bead store is available: direct identity,
+// last-segment city-prefixed names, and pool slot suffixes.
+func TestCountActiveSessionsByTemplate_ProviderFallback(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.City{
+		// SessionTemplate deliberately empty: last-segment fallback must not
+		// depend on it (prefix stripping was dead code).
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "planner", MaxActiveSessions: reloadPoolIntPtr(4)},
+			{Name: "executor", MaxActiveSessions: reloadPoolIntPtr(6)},
+		},
+	}
+
+	sp := runtime.NewFake()
+	for _, name := range []string{
+		"planner-1",            // pool slot → planner
+		"gc-test-city-planner", // city-prefixed process name → last segment
+		"executor-2",
+		"unrelated-session", // no matching agent
+	} {
+		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+			t.Fatalf("start %s: %v", name, err)
+		}
+	}
+
+	cr := newTestCityRuntime(t, CityRuntimeParams{
+		CityPath: t.TempDir(),
+		CityName: "test-city",
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+
+	counts := cr.countActiveSessionsByTemplate(cfg)
+	if got := counts["planner"]; got != 2 {
+		t.Fatalf("counts[planner] = %d, want 2 (slot + city-prefixed); full=%v", got, counts)
+	}
+	if got := counts["executor"]; got != 1 {
+		t.Fatalf("counts[executor] = %d, want 1; full=%v", got, counts)
+	}
+	if _, ok := counts["unrelated-session"]; ok {
+		t.Fatalf("unexpected count for unresolved name: %v", counts)
+	}
+}
+
 func TestReloadConfigTracedReportsPoolMaxBoundChanges(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")

--- a/cmd/gc/reload_pool_bounds_test.go
+++ b/cmd/gc/reload_pool_bounds_test.go
@@ -37,8 +37,8 @@ func TestFormatResolvedMaxActiveSessions(t *testing.T) {
 func TestPoolMaxActiveSessionChanges_Table(t *testing.T) {
 	t.Parallel()
 
-	agent := func(name, dir string, max *int) config.Agent {
-		return config.Agent{Name: name, Dir: dir, MaxActiveSessions: max}
+	agent := func(name, dir string, maxActive *int) config.Agent {
+		return config.Agent{Name: name, Dir: dir, MaxActiveSessions: maxActive}
 	}
 
 	tests := []struct {


### PR DESCRIPTION
## Summary

Implements **per-pool changed-bound reporting + attrition drain warning** for
`gc reload` (#2897): when reload applies a new config, the reply surfaces each
pool whose resolved `max_active_sessions` changed (`old → new`). If the new
bound is a finite decrease and currently-active sessions (from the sessions
bead store) exceed that bound, a warning notes that excess sessions wind down
via normal reconcile attrition (they are not killed; new spawns honor the lower
bound — FR-PM.4).

This is **Message/Warnings construction only**. There is zero behavior change
to reconcile, accept, or apply logic.

**Not in this PR:** the issue's full FR-PM.3 sample (no restart-recommended
warning, no unchanged-pool listing). Only changed bounds are listed; drain
warnings are best-effort and omit when the sessions store is unavailable
rather than inventing counts from provider process-name heuristics.

Credits: issue reported by @bourgois.

### Scope claim

This PR implements **only** the operator-visible reload feedback for pool
bounds (changed-bound lines + optional drain warning). It does **not** claim
the full FR-PM.3 sample from the issue (restart-recommended warning, listing
unchanged pools). Accept/reply latency portions of #2897 appear already
addressed on main by prior work cited in source comments:

- bead `ga-8nbr` — reload acceptance must not be starved by a slow reconciler
- #3206 — manual hard reload replies before dispatch / desired-state rebuild
- #3667 — demand snapshot refresh for routed work

FR-PM.1/FR-PM.2 (in-memory bound refresh + scaleCheck independence) are
**not** claimed here; operators already get live bound application via
the existing config swap + next reconcile tick using
`ResolvedMaxActiveSessions`. This PR only makes that change visible.

### Design notes

- Session counting runs only when at least one bound **decreases to a finite
  value** (drain warnings are the only consumer). Unchanged-config reloads and
  increase-only reloads do zero session-store work from this feature.
- Counts come **only** from the sessions bead store. If the store is
  unavailable, drain warnings are omitted honestly — no provider-list name
  parsing or last-dash / pool-slot heuristics.

## Testing

- [x] Scoped: `go test ./cmd/gc/ -run 'TestReload|TestPoolMax|TestAppendPool|TestFormatResolved|TestCountActiveSessions|TestPoolBound'` — pass (~23s)
- [x] `gofmt -l cmd/gc/` empty for touched files; `go vet ./cmd/gc/` clean
- [x] Full `go test ./cmd/gc/` exceeds the Go default **10m test-binary timeout** in this environment. The 4 observed failures were A/B-confirmed identical on `origin/main` (not introduced by this branch):
  - `TestBdRuntimeEnvManagedCityProjectsHostOverride` — port-allocation / env pollution
  - `TestBdRuntimeEnvForRigInheritedManagedCityProjectsHostOverride` — same
  - `TestResolveImportRootFallsBackToStandalonePackDir` — macOS `/var` vs `/private/var` symlink path
  - `TestResolveImportRootPrefersNearestPackUnderCity` — same
- [ ] `make check` (maintainer CI)
- [ ] `make test-integration` if maintainers want runtime/controller coverage

### Local results (scoped reload/pool suite)

```
ok  github.com/gastownhall/gascity/cmd/gc  ~23s
```

Coverage includes:
- bound increase reported
- bound decrease with active > new bound → drain warning (bead-store counts)
- no pool changes → no pool lines
- default resolution via workspace/rig max (no agent-level max)
- finite-decrease gate for session counting
- no store → empty counts (no provider heuristic attribution)
- bead-store open sessions counted; closed sessions ignored

## Checklist

- [x] Linked an issue (#2897)
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes (optional: short note under reload CLI docs if maintainers want)
- [x] No breaking changes
