### PR TITLE
Stale-Dolt janitor formula never runs unattended under the claude provider — fall back to the trigger work-bead id

### DIFF
--- a/examples/bd/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/bd/dolt/formulas/mol-dog-stale-db.toml
@@ -85,7 +85,7 @@ Run this as one shell script so every derived value remains in the same process:
 ```bash
 set -euo pipefail
 
-WORK_BEAD="${GC_BEAD_ID:?GC_BEAD_ID required (set by gc hook); aborting}"
+WORK_BEAD="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dolt-cleanup.XXXXXX")
 DRAIN_ACKED=0
 

--- a/examples/bd/dolt/stale_db_formula_test.go
+++ b/examples/bd/dolt/stale_db_formula_test.go
@@ -36,7 +36,7 @@ func TestStaleDBFormulaRuntimeContract(t *testing.T) {
 	desc := f.Steps[0].Description
 	for _, want := range []string{
 		`set -euo pipefail`,
-		`WORK_BEAD="${GC_BEAD_ID:?GC_BEAD_ID required`,
+		`WORK_BEAD="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"`,
 		`TMP_DIR=$(mktemp -d`,
 		`trap cleanup EXIT`,
 		`drain_ack_once()`,
@@ -83,7 +83,7 @@ func TestStaleDBFormulaRenderedShellIsStrictAndValid(t *testing.T) {
 	script := renderStaleDBFormulaShell(t)
 	for _, want := range []string{
 		`set -euo pipefail`,
-		`WORK_BEAD="${GC_BEAD_ID:?GC_BEAD_ID required`,
+		`WORK_BEAD="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("rendered script missing %q", want)
@@ -94,6 +94,24 @@ func TestStaleDBFormulaRenderedShellIsStrictAndValid(t *testing.T) {
 	cmd.Stdin = strings.NewReader(script)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bash -n failed: %v\n%s", err, out)
+	}
+}
+
+func TestStaleDBFormulaAbortsWithoutAnyWorkBeadID(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not found: %v", err)
+	}
+
+	script := renderStaleDBFormulaShell(t)
+	cmd := exec.Command("bash", "-s")
+	cmd.Stdin = strings.NewReader(script)
+	cmd.Env = staleDBFilteredEnv("GC_BEAD_ID", "GC_TRIGGER_WORK_BEAD_ID")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("rendered script exited successfully with no work bead id in env\noutput:\n%s", out)
+	}
+	if !strings.Contains(string(out), "no work bead id in env") {
+		t.Fatalf("abort output missing work-bead-id guard message\noutput:\n%s", out)
 	}
 }
 
@@ -428,6 +446,81 @@ esac
 	}
 	if strings.Contains(log, "mol-dog-stale-db.escalate") {
 		t.Fatalf("rendered script escalated at dropped.count == max_orphans_for_sql; want apply because threshold is >\nlog:\n%s\noutput:\n%s", log, out)
+	}
+}
+
+func TestStaleDBFormulaFallsBackToTriggerWorkBeadID(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not found: %v", err)
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("jq not found: %v", err)
+	}
+
+	script := renderStaleDBFormulaShell(t)
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	logPath := filepath.Join(dir, "commands.log")
+	scanPath := filepath.Join(dir, "scan.json")
+	writeTestFile(t, scanPath, `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":0,"failed":[],"skipped":[]},"purge":{"bytes_reclaimed":0},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":0,"bytes_freed_rss":0,"errors_total":0}}`)
+	writeTestFile(t, filepath.Join(binDir, "gc"), `#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+  "dolt-cleanup "*)
+    cat "$GC_TEST_SCAN_JSON"
+    ;;
+  "event emit"|"session nudge"|"runtime drain-ack"|"mail send")
+    echo "gc $*" >> "$GC_TEST_LOG"
+    ;;
+  *)
+    echo "unexpected gc command: $*" >&2
+    exit 64
+    ;;
+esac
+`, 0o755)
+	writeTestFile(t, filepath.Join(binDir, "bd"), `#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  update|close)
+    echo "bd $*" >> "$GC_TEST_LOG"
+    ;;
+  *)
+    echo "unexpected bd command: $*" >&2
+    exit 64
+    ;;
+esac
+`, 0o755)
+
+	cmd := exec.Command("bash", "-s")
+	cmd.Stdin = strings.NewReader(script)
+	cmd.Env = append(staleDBFilteredEnv("GC_BEAD_ID", "GC_TRIGGER_WORK_BEAD_ID", "PATH", "TMPDIR", "GC_TEST_LOG", "GC_TEST_SCAN_JSON"),
+		"GC_TRIGGER_WORK_BEAD_ID=bead-trigger",
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TMPDIR="+dir,
+		"GC_TEST_LOG="+logPath,
+		"GC_TEST_SCAN_JSON="+scanPath,
+	)
+	out, err := cmd.CombinedOutput()
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s): %v\noutput:\n%s", logPath, readErr, out)
+	}
+	log := string(logData)
+	if err != nil {
+		t.Fatalf("rendered script failed with only GC_TRIGGER_WORK_BEAD_ID set: %v\nlog:\n%s\noutput:\n%s", err, log, out)
+	}
+	for _, want := range []string{
+		"gc event emit mol-dog-stale-db.scan",
+		"bd close bead-trigger",
+		"gc runtime drain-ack",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("command log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
+		}
 	}
 }
 


### PR DESCRIPTION
The stale-Dolt-database janitor never manages to run on its own under the claude provider: the very first line of its script demands an environment variable that provider never sets, so every unattended run dies before doing any work and a human has to finish the job by hand (this has happened on every one of its 34 recorded runs). This change lets the script accept the id the provider *does* set, falling back gracefully, while still failing loudly if no id is available at all.

### Root cause

- The formula's script requires `GC_BEAD_ID` on its first working line and aborts if it is missing.
- The claude provider exports the claimed work-bead id as `GC_TRIGGER_WORK_BEAD_ID` (and `GC_TRIGGER_BEAD_ID`), never as `GC_BEAD_ID`, so the guard always fired.

### Fix

- Accept `GC_BEAD_ID` when present, otherwise fall back to `GC_TRIGGER_WORK_BEAD_ID`; abort with a clear message only when neither is set.
- Same pattern the core do-work formula adopted in #4693.

### Tests

- New test: the rendered script completes end-to-end (scan event, bead close, drain-ack) with only the trigger variable set. ✅
- New test: the script still aborts loudly with neither variable set. ✅
- Full `examples/bd/dolt` suite passes (108s, includes the rendered-shell contract tests updated for the new guard line).

---

<details>
<summary>Machine detail</summary>

**Changed files** (commit `3c1011e5c`, branch `fix/ga-oyp60-gc-bead-id-fallback`, 2 files +96/−3)
- `examples/bd/dolt/formulas/mol-dog-stale-db.toml` *(±1)* — line 88: `WORK_BEAD="${GC_BEAD_ID:?...}"` → `WORK_BEAD="${GC_BEAD_ID:-${GC_TRIGGER_WORK_BEAD_ID:?no work bead id in env}}"`
- `examples/bd/dolt/stale_db_formula_test.go` *(+95/−2)* — updated the two contract assertions that pinned the old guard string; added `TestStaleDBFormulaFallsBackToTriggerWorkBeadID` (full mocked run, only `GC_TRIGGER_WORK_BEAD_ID=bead-trigger` in env, asserts `bd close bead-trigger` + scan event + drain-ack) and `TestStaleDBFormulaAbortsWithoutAnyWorkBeadID` (neither var set, asserts non-zero exit and the `no work bead id in env` message)

**Approach / blast radius**
Per-formula fallback rather than making the claude provider export `GC_BEAD_ID`; this matches the choice already merged for `internal/bootstrap/packs/core/formulas/mol-do-work.toml` in #4693 (`DRAIN_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-}}"`, line 145) and is provider-agnostic. `GC_TRIGGER_WORK_BEAD_ID` is the semantically exact source for a claimed work bead. Providers that do export `GC_BEAD_ID` are unaffected (it wins the fallback chain). Only this one formula file is touched; the companion `orders/mol-dog-stale-db.toml` has no id references. A former byte-identical copy at `examples/dolt/formulas/` has since been deleted from the tree, so this is the only remaining instance.

**Verification (pre-merge)**
- `go test ./examples/bd/dolt/ -run StaleDB -count=1` → ok (1.1s)
- `go test ./examples/bd/... -count=1` → ok (107.9s)

**Post-merge verification**
- On the next unattended `mol-dog-stale-db` cron wisp under the claude provider (runs every 4h per `orders/mol-dog-stale-db.toml`): the work bead should reach CLOSED with the `gc.dolt.cleanup.v1` scan JSON appended as a note, with **no manual id substitution**. Signal: `bd show <wisp-id>` shows status closed and an `## scan` note; direction: closes unattended where all 34 prior runs stayed open until hand-run.
- `gc event` stream should show `mol-dog-stale-db.scan` / `.done` events emitted by an unattended run (previously absent because the script died on line 3).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
