### PR TITLE
fix(productmetrics): bind cleanup authority to the installed record, not a path re-open

### DIFF
--- a/internal/productmetrics/control_unix_test.go
+++ b/internal/productmetrics/control_unix_test.go
@@ -1301,6 +1301,45 @@ func TestDisableAndPurgeFilesystemFailureKeepsExactOwnerForRetry(t *testing.T) {
 	requireCleanDisabledTree(t, home)
 }
 
+// A peer that re-persists the byte-identical owner record between the disable
+// write's rename and the authority-minting read-back must surface as a
+// conflict, not be silently adopted as this process's own record. Before
+// authority was bound to the installed incarnation, this window let two
+// holders revalidate successfully against the same inode — the exact hole the
+// same-numeric-ABA case guards at revalidation time, one step earlier.
+func TestDisableAndPurgeDetectsByteIdenticalRecordSwapAtAuthorityMint(t *testing.T) {
+	home, service, _ := newRecordServiceFixture(t, testEventIDThree)
+	configPath := filepath.Join(home.Root(), configFileName)
+	var swapped atomic.Bool
+	var swapErr error
+	service.deps.storageHooks.afterAtomicWrite = func(path string, outcome storageWriteState) {
+		if path != configPath || outcome != storageWriteAppliedDurable || swapped.Load() {
+			return
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			swapErr = err
+			return
+		}
+		state, err := decodePersistedState(data)
+		if err != nil || state.Preference != preferenceDisabled || state.CleanupKind != cleanupDisable {
+			return
+		}
+		swapped.Store(true)
+		temp := path + ".aba-swap"
+		if err := os.WriteFile(temp, data, 0o600); err != nil {
+			swapErr = err
+			return
+		}
+		swapErr = os.Rename(temp, path)
+	}
+	_, err := service.DisableAndPurge(context.Background())
+	if swapErr != nil || !swapped.Load() {
+		t.Fatalf("byte-identical swap: performed=%v err=%v", swapped.Load(), swapErr)
+	}
+	requirePurgeErrorClass(t, err, PurgeErrorStateChanged)
+}
+
 func TestDisableAndPurgeExactTokenConflictAndPeerCleanRecovery(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/productmetrics/service.go
+++ b/internal/productmetrics/service.go
@@ -1186,6 +1186,16 @@ func persistStateMutation(root *storageRoot, state persistedState, allowAppliedA
 		}
 		return loadedState{}, err
 	}
+	if installed.lease == nil || installed.lease.incarnation() != result.record {
+		// The path re-open read back the exact bytes this mutation wrote, but
+		// from a different file than the one this write installed: a peer
+		// replaced the record inside the rename→read-back window. Authority
+		// must bind to the record this process installed — adopting the
+		// peer's file would leave two holders revalidating successfully
+		// against the same incarnation.
+		_ = installed.Close()
+		return loadedState{}, ErrStateChangedConcurrently
+	}
 	if result.state == storageWriteAppliedSyncPending {
 		if !allowAppliedActivation {
 			_ = installed.Close()

--- a/internal/productmetrics/storage.go
+++ b/internal/productmetrics/storage.go
@@ -165,6 +165,12 @@ const (
 
 type storageWriteResult struct {
 	state storageWriteState
+	// record identifies the exact file this write installed at the target
+	// name (rename preserves the temporary file's inode). Callers that mint
+	// exact-record authority from a subsequent path re-open must require the
+	// re-opened record to match, or a peer's byte-identical replacement
+	// landing between the rename and the re-open is silently adopted.
+	record recordIncarnation
 }
 
 type recordIncarnation struct {

--- a/internal/productmetrics/storage_unix.go
+++ b/internal/productmetrics/storage_unix.go
@@ -1584,6 +1584,7 @@ func (directory *unixStorageDirectory) writeFileAtomically(name string, data []b
 	if metadataErr != nil {
 		return result, metadataErr
 	}
+	result.record = recordIncarnation{dev: tempMetadata.dev, ino: tempMetadata.ino}
 	if marker != nil {
 		if err := marker.revalidateBound(tempMetadata); err != nil {
 			return result, err


### PR DESCRIPTION
## Problem

`TestDisableAndPurgeExactTokenConflictAndPeerCleanRecovery/same_numeric_ABA_is_a_conflict` failed once on main (#5077) with `purge error = <nil>, want class "state-changed-concurrently"`. Investigation showed it is not test flake — the test caught a real authority-minting race.

`persistStateMutation` writes the new state atomically, then re-opens the config **by path** to mint the record lease that becomes cleanup authority. A peer re-persisting a byte-identical record between the rename and the re-open passes the read-back-exactly check (`bytes.Equal` on identical content), so the service adopts the **peer's inode** as its own authority. From then on, two holders' exact-record revalidations both succeed against the same incarnation — defeating the concurrent-purge serialization that `PurgeErrorStateChanged` exists to provide. The ABA test's unlocked fixture write landed inside that window on a slow CI runner.

## Fix

The atomic writer already stats the temporary file immediately before the rename, and rename preserves the inode — so the writer now reports the installed record's `recordIncarnation` in its write outcome. `persistStateMutation` refuses to mint authority unless the re-opened record is that exact incarnation, classifying a mismatch as `ErrStateChangedConcurrently`. The caller's retry then adopts the surviving record under the state lock, the same way any pending-owner recovery does.

## Testing

- New regression test drives the byte-identical peer swap deterministically from the `afterAtomicWrite` hook (the same idiom existing displacement tests use). Without the incarnation check it fails with the exact signature from #5077; with it, the conflict is classified correctly.
- Full `internal/productmetrics` suite green; `-race -count=10` over the DisableAndPurge tests green; the original ABA subtest green under `-cover` and `-race` stress (80 runs).

Fixes #5077.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
