### PR TITLE
test(integration): build the pinned bd embedded-capable

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -399,8 +399,11 @@ func buildPinnedIntegrationBDBinary(tmpDir string) (string, error) {
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		return "", fmt.Errorf("create pinned bd directory: %w", err)
 	}
+	// CGO_ENABLED=1 + gms_pure_go is the embedded-capable bd build (per beads
+	// INSTALLING.md): the pinned bd's `bd init` defaults to embedded Dolt,
+	// which a CGO_ENABLED=0 binary refuses at runtime.
 	cmd := exec.Command("go", "install", "-tags", "gms_pure_go", "github.com/steveyegge/beads/cmd/bd@"+version)
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOBIN="+binDir)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=1", "GOBIN="+binDir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("go install github.com/steveyegge/beads/cmd/bd@%s: %w\n%s", version, err, out)
 	}


### PR DESCRIPTION
## Problem

`Integration / rest-full-3-of-16` has been red on main since #5030 merged (#5078). Bisecting main's CI runs pinpoints the boundary exactly at that merge: green on `c3c006c1d5`, red on `f4546f132e` and every run since.

`buildPinnedIntegrationBDBinary` builds the pinned harness bd with `CGO_ENABLED=0`. That happened to work under the previous Beads pin because `bd init` did not take the embedded-Dolt path. At the current pin `bd init` defaults to embedded Dolt, and a `CGO_ENABLED=0` bd has refused embedded mode at runtime since Beads v0.63.2 (`store_factory_nocgo.go`) — so every `requireDoltIntegration` standalone-init test dies with `embedded Dolt requires a CGO build`. The job env's `CGO_ENABLED=1` cannot help a binary that was already built without it.

## Fix

Build the pinned bd the way the Beads install docs define the embedded-capable build: `CGO_ENABLED=1` with the `gms_pure_go` tag (the tag only selects the pure-Go regex engine in go-mysql-server and is orthogonal to CGO).

## Testing

Reproduced the exact CI failure locally (`go test -tags integration ./test/integration/ -run TestInitBdAllowsStandaloneCreate` → `embedded Dolt requires a CGO build`), applied the one-line change, test passes.

Fixes #5078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
