### PR TITLE
fix(productmetrics): classify a mutated record swap in the mint window as a concurrent change

### DIFF
--- a/internal/productmetrics/control_unix_test.go
+++ b/internal/productmetrics/control_unix_test.go
@@ -1340,6 +1340,51 @@ func TestDisableAndPurgeDetectsByteIdenticalRecordSwapAtAuthorityMint(t *testing
 	requirePurgeErrorClass(t, err, PurgeErrorStateChanged)
 }
 
+// The different-bytes variant of the mint-window race: a peer installing a
+// MUTATED record between the disable write's rename and the read-back must
+// classify as a concurrent state change, not as a generic disable-write
+// failure. This is the interleaving TestDisableAndPurgeRejectsUnprovenPeerSuccessor
+// hits nondeterministically when its unlocked successor write lands before
+// authority is minted.
+func TestDisableAndPurgeClassifiesMutatedRecordSwapAtAuthorityMint(t *testing.T) {
+	home, service, _ := newRecordServiceFixture(t, testEventIDThree)
+	configPath := filepath.Join(home.Root(), configFileName)
+	var swapped atomic.Bool
+	var swapErr error
+	service.deps.storageHooks.afterAtomicWrite = func(path string, outcome storageWriteState) {
+		if path != configPath || outcome != storageWriteAppliedDurable || swapped.Load() {
+			return
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			swapErr = err
+			return
+		}
+		state, err := decodePersistedState(data)
+		if err != nil || state.Preference != preferenceDisabled || state.CleanupKind != cleanupDisable {
+			return
+		}
+		swapped.Store(true)
+		state.RequiredNoticeVersion++
+		mutated, err := encodePersistedState(state)
+		if err != nil {
+			swapErr = err
+			return
+		}
+		temp := path + ".mutated-swap"
+		if err := os.WriteFile(temp, mutated, 0o600); err != nil {
+			swapErr = err
+			return
+		}
+		swapErr = os.Rename(temp, path)
+	}
+	_, err := service.DisableAndPurge(context.Background())
+	if swapErr != nil || !swapped.Load() {
+		t.Fatalf("mutated swap: performed=%v err=%v", swapped.Load(), swapErr)
+	}
+	requirePurgeErrorClass(t, err, PurgeErrorStateChanged)
+}
+
 func TestDisableAndPurgeExactTokenConflictAndPeerCleanRecovery(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/productmetrics/service.go
+++ b/internal/productmetrics/service.go
@@ -1180,6 +1180,14 @@ func persistStateMutation(root *storageRoot, state persistedState, allowAppliedA
 	installed := loadStateFromDirectory(root)
 	if installed.err != nil || !installed.present || installed.state != state || !bytes.Equal(installed.raw, data) {
 		err := errors.Join(installed.err, errors.New("productmetrics: applied state did not read back exactly"))
+		if installed.err == nil {
+			// A cleanly readable record that is absent or differs from the
+			// content this mutation just installed means a peer changed state
+			// inside the rename→read-back window — the same concurrency the
+			// incarnation check below reports for byte-identical replacement.
+			// An unreadable record stays unlabeled: it cannot be attributed.
+			err = errors.Join(ErrStateChangedConcurrently, err)
+		}
 		_ = installed.Close()
 		if result.state == storageWriteAppliedSyncPending {
 			err = errors.Join(errStateAppliedSyncPending, writeErr, err)


### PR DESCRIPTION
## Problem

`Preflight / unit cover (noncmdgc)` on `7322908444` failed `TestDisableAndPurgeRejectsUnprovenPeerSuccessor/changed_full-state_field`: `purge error = productmetrics: disable-write-failed, want class "state-changed-concurrently"`.

This is the different-bytes sibling of the mint-window race #5082 closed. The test's unlocked successor write landed between the disable write's rename and the authority-minting read-back; the read-back-exactly check in `persistStateMutation` then surfaced a generic error, which `DisableAndPurge` classifies as `disable-write-failed`. But a cleanly readable record that differs from the content the mutation just installed IS a peer changing state concurrently — the same condition the incarnation check reports for byte-identical replacement, and the same class the test rightly expects regardless of which side of the mint the peer write lands on.

## Fix

Join `ErrStateChangedConcurrently` into the read-back error when the record was cleanly readable (absent, or different content). An unreadable record stays unlabeled — it cannot be attributed to a peer.

## Testing

- New regression test drives the mutated-record swap deterministically from the `afterAtomicWrite` hook; without the classification it fails with the exact cover-job signature (`disable-write-failed`).
- Full `internal/productmetrics` suite green; the previously flaky subtest green under `-cover -count=30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
