### PR TITLE
test(storebinding/sqlite): ignore cover-runtime scratch in the SIGKILL residue check

### DIFF
--- a/internal/storebinding/sqlite/sqlite_fence_process_linux_test.go
+++ b/internal/storebinding/sqlite/sqlite_fence_process_linux_test.go
@@ -130,11 +130,19 @@ func TestSQLiteLegacySnapshotSIGKILLAtBoundaries(t *testing.T) {
 			if err != nil {
 				t.Fatalf("reading private legacy snapshot root: %v", err)
 			}
-			if len(entries) != 0 {
-				names := make([]string, 0, len(entries))
-				for _, entry := range entries {
-					names = append(names, entry.Name())
+			var names []string
+			for _, entry := range entries {
+				// Under -cover the re-exec'd child's coverage runtime keeps
+				// its scratch directory beneath TMPDIR (= privateRoot), and a
+				// SIGKILLed child cannot remove it. That is cover-runtime
+				// residue, not snapshot-machinery residue, which is what this
+				// assertion guards.
+				if strings.HasPrefix(entry.Name(), "gocoverdir") {
+					continue
 				}
+				names = append(names, entry.Name())
+			}
+			if len(names) != 0 {
 				t.Fatalf("private legacy snapshot residue after recovery from SIGKILL at %q: %v", boundary, names)
 			}
 			outcome = runSQLiteFenceChild(t,


### PR DESCRIPTION
## Problem

`Preflight / unit cover (noncmdgc)` on `7322908444` failed `TestSQLiteLegacySnapshotSIGKILLAtBoundaries/legacy-claim-release-after`: `private legacy snapshot residue after recovery from SIGKILL: [gocoverdir4009324455]`.

The fence-process test pins the re-exec'd child's `TMPDIR` to the private snapshot root so the residue assertion can prove the snapshot machinery cleans up across SIGKILL. Under `-cover`, the child's coverage runtime keeps its scratch directory (`gocoverdirNNN`) beneath that same `TMPDIR`, and a SIGKILLed child never removes it — so the assertion reports cover-runtime scratch as snapshot residue whenever the kill lands while the scratch exists.

## Fix

Skip `gocoverdir*` entries in the residue scan. The assertion guards snapshot-machinery residue; coverage-runtime scratch is outside its scope, and redirecting the child's coverage output is Go-version-dependent where filtering is deterministic.

## Testing

`TestSQLiteLegacySnapshotSIGKILLAtBoundaries` green under `-cover` (including 5× stress) and in normal mode; full `internal/storebinding/sqlite` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
