### PR TITLE
fix(bd): honor the workspace bd pin in the gc bd passthrough

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -118,6 +118,37 @@ func workspacePinnedBdBinary(cityPath string) (string, error) {
 	return "", fmt.Errorf("workspace.env PATH is configured but contains no executable bd at an absolute path")
 }
 
+// errBdNotOnPath reports that neither the workspace pin nor the ambient
+// lookup produced a bd executable. Callers phrase their own remediation.
+var errBdNotOnPath = errors.New("bd not found in PATH")
+
+// resolveBdBinaryForCity resolves the bd executable a city runs. A scope
+// carrying a complete storage binding runs the binary its workspace PATH
+// pins, because only that build speaks the bound backend; every other scope
+// keeps the ambient lookup. An ambient miss is errBdNotOnPath so callers can
+// phrase their own remediation; a pin that is configured but unresolvable is
+// returned verbatim rather than masked as a missing binary.
+func resolveBdBinaryForCity(cityPath string) (string, error) {
+	completeBinding, err := scopeHasCompleteStorageBinding(scopeMetadataJSONPath(cityPath))
+	if err != nil {
+		return "", err
+	}
+	if completeBinding {
+		pinned, err := workspacePinnedBdBinary(cityPath)
+		if err != nil {
+			return "", err
+		}
+		if pinned = strings.TrimSpace(pinned); filepath.IsAbs(pinned) {
+			return pinned, nil
+		}
+	}
+	bdPath, err := exec.LookPath("bd")
+	if err != nil {
+		return "", errBdNotOnPath
+	}
+	return bdPath, nil
+}
+
 func bdStoreForCity(dir, cityPath string) *beads.BdStore {
 	cfg, err := loadCityConfig(cityPath, io.Discard)
 	if err != nil {

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -122,18 +122,19 @@ func workspacePinnedBdBinary(cityPath string) (string, error) {
 // lookup produced a bd executable. Callers phrase their own remediation.
 var errBdNotOnPath = errors.New("bd not found in PATH")
 
-// resolveBdBinaryForCity resolves the bd executable a city runs. A scope
-// carrying a complete storage binding runs the binary its workspace PATH
-// pins, because only that build speaks the bound backend; every other scope
-// keeps the ambient lookup. An ambient miss is errBdNotOnPath so callers can
-// phrase their own remediation; a pin that is configured but unresolvable is
-// returned verbatim rather than masked as a missing binary.
-func resolveBdBinaryForCity(cityPath string) (string, error) {
-	completeBinding, err := scopeHasCompleteStorageBinding(scopeMetadataJSONPath(cityPath))
+// resolveBdBinaryForScope resolves the bd executable a scope's commands run.
+// A scope bound to a complete storage binding runs the binary its workspace
+// PATH pins, because only that build speaks the bound backend; every other
+// scope keeps the ambient lookup. An ambient miss is errBdNotOnPath so
+// callers can phrase their own remediation; a pin that is configured but
+// unresolvable for a scope that needs it is returned verbatim rather than
+// masked as a missing binary.
+func resolveBdBinaryForScope(cityPath, scopeRoot string) (string, error) {
+	bound, err := scopeBindsPinnedBdBinary(cityPath, scopeRoot)
 	if err != nil {
 		return "", err
 	}
-	if completeBinding {
+	if bound {
 		pinned, err := workspacePinnedBdBinary(cityPath)
 		if err != nil {
 			return "", err
@@ -147,6 +148,25 @@ func resolveBdBinaryForCity(cityPath string) (string, error) {
 		return "", errBdNotOnPath
 	}
 	return bdPath, nil
+}
+
+// scopeBindsPinnedBdBinary reports whether a scope's bd commands must run the
+// workspace-pinned build: the scope carries a complete storage binding of its
+// own, or it inherits the city's the way applyCanonicalScopeBackendEnv does.
+// A scope that overrides the city backend never reads the city binding, so a
+// fault in it is not that scope's fault and degrades to the ambient lookup
+// instead of taking the scope's bd offline. Only the scope's own binding
+// surfaces an error.
+func scopeBindsPinnedBdBinary(cityPath, scopeRoot string) (bool, error) {
+	completeBinding, err := scopeHasCompleteStorageBinding(scopeMetadataJSONPath(scopeRoot))
+	if err != nil || completeBinding {
+		return completeBinding, err
+	}
+	if samePath(cityPath, scopeRoot) || scopeOverridesCityBackend(cityPath, scopeRoot) {
+		return false, nil
+	}
+	inherited, err := scopeHasCompleteStorageBinding(scopeMetadataJSONPath(cityPath))
+	return err == nil && inherited, nil
 }
 
 func bdStoreForCity(dir, cityPath string) *beads.BdStore {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -6352,3 +6352,109 @@ func TestProjectGitHubTokenExecEnv(t *testing.T) {
 		}
 	})
 }
+
+// TestResolveBdBinaryForScope pins which scope decides the bd binary. The
+// scope the command targets owns the decision: it is the scope whose store
+// the command reads and writes, and only its binding says which build speaks
+// the backend. A scope that never reads the city's binding must not be taken
+// offline by a fault in it.
+func TestResolveBdBinaryForScope(t *testing.T) {
+	const complete = `{"backend":"postgres","storage_endpoint":"postgres://beads@db.example.test:5432","storage_database":"beads_pg"}`
+	const partial = `{"backend":"postgres","storage_endpoint":"postgres://beads@db.example.test:5432"}`
+
+	// newPinnedCity stages a city pinning its own bd on the workspace PATH,
+	// with a different bd on the ambient PATH, and returns the two paths.
+	newPinnedCity := func(t *testing.T, cityMetadata string) (cityDir, pinned, ambient string) {
+		t.Helper()
+		cityDir = t.TempDir()
+		pinDir := t.TempDir()
+		pinned = filepath.Join(pinDir, "bd")
+		writeExecutable(t, pinned, "#!/bin/sh\nexit 0\n")
+		ambientDir := t.TempDir()
+		ambient = filepath.Join(ambientDir, "bd")
+		writeExecutable(t, ambient, "#!/bin/sh\nexit 0\n")
+		t.Setenv("PATH", ambientDir)
+		cityTOML := "[workspace]\nname = \"demo\"\n[workspace.env]\nPATH = " + strconv.Quote(pinDir) + "\n"
+		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityTOML), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if cityMetadata != "" {
+			if err := os.WriteFile(scopeMetadataJSONPath(cityDir), []byte(cityMetadata), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return cityDir, pinned, ambient
+	}
+	writeRig := func(t *testing.T, cityDir, name, metadata string) string {
+		t.Helper()
+		rigDir := filepath.Join(cityDir, "rigs", name)
+		if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if metadata != "" {
+			if err := os.WriteFile(scopeMetadataJSONPath(rigDir), []byte(metadata), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return rigDir
+	}
+
+	t.Run("city scope surfaces its own partial binding", func(t *testing.T) {
+		cityDir, _, _ := newPinnedCity(t, partial)
+		got, err := resolveBdBinaryForScope(cityDir, cityDir)
+		if err == nil || !strings.Contains(err.Error(), "partial beads storage binding") {
+			t.Fatalf("resolveBdBinaryForScope(city, city) = (%q, %v), want the partial-binding error", got, err)
+		}
+	})
+
+	t.Run("rig overriding the city backend survives a partial city binding", func(t *testing.T) {
+		cityDir, _, ambient := newPinnedCity(t, partial)
+		rigDir := writeRig(t, cityDir, "dl", `{"backend":"doltlite"}`)
+		got, err := resolveBdBinaryForScope(cityDir, rigDir)
+		if err != nil {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) error = %v, want the ambient bd", err)
+		}
+		if got != ambient {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) = %q, want ambient %q", got, ambient)
+		}
+	})
+
+	t.Run("rig carrying its own binding resolves the pin", func(t *testing.T) {
+		cityDir, pinned, _ := newPinnedCity(t, "")
+		rigDir := writeRig(t, cityDir, "frontend", complete)
+		got, err := resolveBdBinaryForScope(cityDir, rigDir)
+		if err != nil {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) error = %v", err)
+		}
+		if got != pinned {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) = %q, want workspace-pinned %q", got, pinned)
+		}
+	})
+
+	t.Run("rig inheriting the city binding resolves the pin", func(t *testing.T) {
+		cityDir, pinned, _ := newPinnedCity(t, complete)
+		rigDir := writeRig(t, cityDir, "inherit", "")
+		got, err := resolveBdBinaryForScope(cityDir, rigDir)
+		if err != nil {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) error = %v", err)
+		}
+		if got != pinned {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) = %q, want workspace-pinned %q", got, pinned)
+		}
+	})
+
+	t.Run("rig overriding the city backend keeps the ambient bd", func(t *testing.T) {
+		cityDir, _, ambient := newPinnedCity(t, complete)
+		rigDir := writeRig(t, cityDir, "dl", `{"backend":"doltlite"}`)
+		got, err := resolveBdBinaryForScope(cityDir, rigDir)
+		if err != nil {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) error = %v", err)
+		}
+		if got != ambient {
+			t.Fatalf("resolveBdBinaryForScope(city, rig) = %q, want ambient %q: a doltlite rig's runtime env carries no BD_BIN", got, ambient)
+		}
+	})
+}

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -321,9 +321,13 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	reapStaleBdExportJSONL(target.ScopeRoot)
 	warnExternalBdOverrideDrift(stderr, cityPath, target)
 
-	bdPath, err := exec.LookPath("bd")
+	// Resolve the same binary every other bd path in the tree resolves: a
+	// city whose scope carries a complete storage binding pins the bd build
+	// that speaks that backend, and the passthrough must honor the pin or it
+	// hands the command to an ambient bd that rejects the bound backend.
+	bdPath, err := resolveBdBinaryForCity(cityPath)
 	if err != nil {
-		fmt.Fprintln(stderr, "gc bd: bd not found in PATH") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -321,11 +321,14 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	reapStaleBdExportJSONL(target.ScopeRoot)
 	warnExternalBdOverrideDrift(stderr, cityPath, target)
 
-	// Resolve the same binary every other bd path in the tree resolves: a
-	// city whose scope carries a complete storage binding pins the bd build
-	// that speaks that backend, and the passthrough must honor the pin or it
-	// hands the command to an ambient bd that rejects the bound backend.
-	bdPath, err := resolveBdBinaryForCity(cityPath)
+	// Resolve the same binary every other bd path in the tree resolves for
+	// this scope: a scope bound to a complete storage binding pins the bd
+	// build that speaks that backend, and the passthrough must honor the pin
+	// or it hands the command to an ambient bd that rejects the bound
+	// backend. Keying on the target scope rather than the city keeps a rig
+	// that owns its binding on its pin, and keeps a rig that overrides the
+	// city backend on the ambient bd its runtime env already implies.
+	bdPath, err := resolveBdBinaryForScope(cityPath, target.ScopeRoot)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2478,3 +2478,91 @@ prefix = "fe"
 		t.Fatalf("SQL query = %q, want %q", strings.TrimSpace(string(query)), wantQuery)
 	}
 }
+
+// TestGcBdPassthroughResolvesBdBinary pins the binary the `gc bd`
+// passthrough execs. A city whose scope carries a complete storage binding
+// runs the bd its workspace PATH pins — an ambient bd that cannot speak the
+// bound backend would reject every command. A city with neither a binding
+// nor a pin keeps the ambient lookup.
+func TestGcBdPassthroughResolvesBdBinary(t *testing.T) {
+	t.Run("complete binding runs the workspace-pinned bd", func(t *testing.T) {
+		cityDir := newGcBdBinaryProbeCity(t, "ambient-bd")
+
+		pinDir := t.TempDir()
+		writeGcBdProbeScript(t, filepath.Join(pinDir, "bd"), "pinned-bd")
+		cityTOML := "[workspace]\nname = \"demo\"\n\n[workspace.env]\nPATH = " +
+			strconv.Quote(pinDir+string(os.PathListSeparator)+"$PATH") + "\n"
+		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityTOML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		metadata := []byte(`{"backend":"postgres","storage_endpoint":"postgres://beads@db.example.test:5432","storage_database":"beads_pg"}`)
+		if err := os.WriteFile(scopeMetadataJSONPath(cityDir), metadata, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"show", "gc-1"}, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd() = %d, want 0; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "pinned-bd" {
+			t.Fatalf("executed bd = %q, want workspace-pinned %q", got, "pinned-bd")
+		}
+	})
+
+	t.Run("no binding falls back to ambient bd", func(t *testing.T) {
+		cityDir := newGcBdBinaryProbeCity(t, "ambient-bd")
+		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"show", "gc-1"}, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd() = %d, want 0; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "ambient-bd" {
+			t.Fatalf("executed bd = %q, want ambient %q", got, "ambient-bd")
+		}
+	})
+}
+
+// newGcBdBinaryProbeCity returns a city whose only bd on the ambient PATH
+// reports the given identity, so a passthrough test can tell which binary
+// actually ran. The caller writes city.toml.
+func newGcBdBinaryProbeCity(t *testing.T, ambientIdentity string) string {
+	t.Helper()
+	disableManagedDoltRecoveryForTest(t)
+
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	t.Cleanup(func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	})
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// See TestResolveBdScopeTarget: isolate cwd so any `.beads/redirect` in
+	// the ambient working tree doesn't surface here.
+	setCwd(t, cityDir)
+	writeBuiltinImportsFixture(t, cityDir, "core", "bd")
+
+	ambientDir := t.TempDir()
+	writeGcBdProbeScript(t, filepath.Join(ambientDir, "bd"), ambientIdentity)
+	t.Setenv("PATH", ambientDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_BEADS", "bd")
+	return cityDir
+}
+
+// writeGcBdProbeScript writes a stand-in bd that announces which binary ran.
+func writeGcBdProbeScript(t *testing.T, path, identity string) {
+	t.Helper()
+	script := "#!/bin/sh\necho " + identity + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2486,7 +2486,7 @@ prefix = "fe"
 // nor a pin keeps the ambient lookup.
 func TestGcBdPassthroughResolvesBdBinary(t *testing.T) {
 	t.Run("complete binding runs the workspace-pinned bd", func(t *testing.T) {
-		cityDir := newGcBdBinaryProbeCity(t, "ambient-bd")
+		cityDir := newGcBdBinaryProbeCity(t)
 
 		pinDir := t.TempDir()
 		writeGcBdProbeScript(t, filepath.Join(pinDir, "bd"), "pinned-bd")
@@ -2510,7 +2510,7 @@ func TestGcBdPassthroughResolvesBdBinary(t *testing.T) {
 	})
 
 	t.Run("no binding falls back to ambient bd", func(t *testing.T) {
-		cityDir := newGcBdBinaryProbeCity(t, "ambient-bd")
+		cityDir := newGcBdBinaryProbeCity(t)
 		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -2523,12 +2523,148 @@ func TestGcBdPassthroughResolvesBdBinary(t *testing.T) {
 			t.Fatalf("executed bd = %q, want ambient %q", got, "ambient-bd")
 		}
 	})
+
+	// A city-scoped command reads the city's own binding, so a half-written
+	// one is that command's fault and must stay fatal — the rig-scope
+	// tolerance below it must not soften the scope that owns the binding.
+	t.Run("partial city binding still fails the city scope", func(t *testing.T) {
+		cityDir := newGcBdBinaryProbeCity(t)
+		writeGcBdProbeCityTOML(t, cityDir, t.TempDir())
+		if err := os.WriteFile(scopeMetadataJSONPath(cityDir), []byte(partialStorageBindingJSON), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"list"}, &stdout, &stderr); got != 1 {
+			t.Fatalf("doBd() = %d, want 1; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if want := "partial beads storage binding"; !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want it to name the %q", stderr.String(), want)
+		}
+	})
 }
 
+// TestGcBdPassthroughResolvesBdBinaryForRigScope pins the binary the
+// passthrough execs for `gc bd --rig`, a form the command's own help
+// documents. The scope the command targets decides the binary, because that
+// is the scope whose store the command reads and writes: a rig carrying its
+// own complete binding runs the pinned build that speaks it, and a rig that
+// overrides the city backend keeps the ambient lookup even when the city is
+// bound — its store is not the bound one, and its runtime env carries no
+// BD_BIN.
+func TestGcBdPassthroughResolvesBdBinaryForRigScope(t *testing.T) {
+	t.Run("rig carrying its own complete binding runs the workspace-pinned bd", func(t *testing.T) {
+		cityDir := newGcBdBinaryProbeCity(t)
+		pinDir := t.TempDir()
+		writeGcBdProbeScript(t, filepath.Join(pinDir, "bd"), "pinned-bd")
+		writeGcBdProbeCityTOML(t, cityDir, pinDir, "frontend")
+		writeGcBdProbeRig(t, cityDir, "frontend", completeStorageBindingJSON)
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"--rig", "frontend", "list"}, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd(--rig frontend) = %d, want 0; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "pinned-bd" {
+			t.Fatalf("executed bd = %q, want workspace-pinned %q", got, "pinned-bd")
+		}
+	})
+
+	t.Run("doltlite rig survives a partial city binding", func(t *testing.T) {
+		cityDir := newGcBdBinaryProbeCity(t)
+		pinDir := t.TempDir()
+		writeGcBdProbeScript(t, filepath.Join(pinDir, "bd"), "pinned-bd")
+		writeGcBdProbeCityTOML(t, cityDir, pinDir, "dl")
+		// Half-written city provisioning state: storage_database never
+		// landed. scopeHasCompleteStorageBinding rejects it, but the rig
+		// below never reads that binding.
+		if err := os.WriteFile(scopeMetadataJSONPath(cityDir), []byte(partialStorageBindingJSON), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		writeGcBdProbeRig(t, cityDir, "dl", `{"backend":"doltlite"}`)
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"--rig", "dl", "list"}, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd(--rig dl) = %d, want 0; a city-level binding fault must not take a doltlite rig offline; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "ambient-bd" {
+			t.Fatalf("executed bd = %q, want ambient %q", got, "ambient-bd")
+		}
+	})
+
+	t.Run("doltlite rig in a bound city keeps the ambient bd", func(t *testing.T) {
+		cityDir := newGcBdBinaryProbeCity(t)
+		pinDir := t.TempDir()
+		writeGcBdProbeScript(t, filepath.Join(pinDir, "bd"), "pinned-bd")
+		writeGcBdProbeCityTOML(t, cityDir, pinDir, "dl")
+		if err := os.WriteFile(scopeMetadataJSONPath(cityDir), []byte(completeStorageBindingJSON), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		writeGcBdProbeRig(t, cityDir, "dl", `{"backend":"doltlite"}`)
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"--rig", "dl", "list"}, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd(--rig dl) = %d, want 0; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "ambient-bd" {
+			t.Fatalf("executed bd = %q, want ambient %q: a doltlite rig's runtime env carries no BD_BIN, so the passthrough must not exec the city's pin", got, "ambient-bd")
+		}
+	})
+}
+
+// completeStorageBindingJSON and partialStorageBindingJSON are the two
+// storage-binding shapes scopeHasCompleteStorageBinding distinguishes: all
+// three fields non-empty, and the half-written state it fails closed on.
+const (
+	completeStorageBindingJSON = `{"backend":"postgres","storage_endpoint":"postgres://beads@db.example.test:5432","storage_database":"beads_pg"}`
+	partialStorageBindingJSON  = `{"backend":"postgres","storage_endpoint":"postgres://beads@db.example.test:5432"}`
+)
+
+// writeGcBdProbeCityTOML writes a city.toml pinning pinDir ahead of the
+// ambient PATH and declaring the named rigs, plus the .gc/site.toml bindings
+// that give them their paths under rigs/<name>.
+func writeGcBdProbeCityTOML(t *testing.T, cityDir, pinDir string, rigNames ...string) {
+	t.Helper()
+	cityTOML := "[workspace.env]\nPATH = " +
+		strconv.Quote(pinDir+string(os.PathListSeparator)+"$PATH") + "\n"
+	siteTOML := "workspace_name = \"demo\"\n"
+	for _, name := range rigNames {
+		cityTOML += "\n[[rigs]]\nname = " + strconv.Quote(name) +
+			"\nprefix = " + strconv.Quote(name) + "\n"
+		siteTOML += "\n[[rig]]\nname = " + strconv.Quote(name) +
+			"\npath = " + strconv.Quote(filepath.Join(cityDir, "rigs", name)) + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".gc", "site.toml"), []byte(siteTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeGcBdProbeRig stages rigs/<name> carrying the given
+// .beads/metadata.json.
+func writeGcBdProbeRig(t *testing.T, cityDir, name, metadata string) {
+	t.Helper()
+	rigDir := filepath.Join(cityDir, "rigs", name)
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scopeMetadataJSONPath(rigDir), []byte(metadata), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// gcBdAmbientProbeIdentity is what the bd on the ambient PATH prints, so a
+// passthrough test can tell it apart from a workspace-pinned build.
+const gcBdAmbientProbeIdentity = "ambient-bd"
+
 // newGcBdBinaryProbeCity returns a city whose only bd on the ambient PATH
-// reports the given identity, so a passthrough test can tell which binary
-// actually ran. The caller writes city.toml.
-func newGcBdBinaryProbeCity(t *testing.T, ambientIdentity string) string {
+// announces gcBdAmbientProbeIdentity, so a passthrough test can tell which
+// binary actually ran. The caller writes city.toml.
+func newGcBdBinaryProbeCity(t *testing.T) string {
 	t.Helper()
 	disableManagedDoltRecoveryForTest(t)
 
@@ -2551,7 +2687,7 @@ func newGcBdBinaryProbeCity(t *testing.T, ambientIdentity string) string {
 	writeBuiltinImportsFixture(t, cityDir, "core", "bd")
 
 	ambientDir := t.TempDir()
-	writeGcBdProbeScript(t, filepath.Join(ambientDir, "bd"), ambientIdentity)
+	writeGcBdProbeScript(t, filepath.Join(ambientDir, "bd"), gcBdAmbientProbeIdentity)
 	t.Setenv("PATH", ambientDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("GC_CITY_PATH", cityDir)
 	t.Setenv("GC_BEADS", "bd")

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1492,7 +1492,7 @@ func openStoreResultAtForCityWithConfig(storePath, cityPath string, cfg *config.
 // runner keeps the logical command name as "bd" so its timeout, telemetry,
 // and backup policy still apply while executing that pin.
 func requireBdBinaryForCity(cityPath string) error {
-	_, err := resolveBdBinaryForCity(cityPath)
+	_, err := resolveBdBinaryForScope(cityPath, cityPath)
 	if errors.Is(err, errBdNotOnPath) {
 		return fmt.Errorf("bd not found in PATH (install beads or set GC_BEADS=file)")
 	}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -1493,23 +1492,11 @@ func openStoreResultAtForCityWithConfig(storePath, cityPath string, cfg *config.
 // runner keeps the logical command name as "bd" so its timeout, telemetry,
 // and backup policy still apply while executing that pin.
 func requireBdBinaryForCity(cityPath string) error {
-	completeBinding, err := scopeHasCompleteStorageBinding(scopeMetadataJSONPath(cityPath))
-	if err != nil {
-		return err
-	}
-	if completeBinding {
-		pinned, err := workspacePinnedBdBinary(cityPath)
-		if err != nil {
-			return err
-		}
-		if filepath.IsAbs(strings.TrimSpace(pinned)) {
-			return nil
-		}
-	}
-	if _, err := exec.LookPath("bd"); err != nil {
+	_, err := resolveBdBinaryForCity(cityPath)
+	if errors.Is(err, errBdNotOnPath) {
 		return fmt.Errorf("bd not found in PATH (install beads or set GC_BEADS=file)")
 	}
-	return nil
+	return err
 }
 
 // openExecStoreAtForCityWithConfig opens the exec-provider store for a city.

--- a/cmd/gc/scoped_store_test.go
+++ b/cmd/gc/scoped_store_test.go
@@ -120,6 +120,57 @@ func TestRequireBdBinaryForCityRejectsWorkspacePinWithoutCompleteBinding(t *test
 	}
 }
 
+// TestRequireBdBinaryForCityErrorText pins the three messages the preflight
+// produces. They are the whole reason errBdNotOnPath is a sentinel rather
+// than a formatted string: an ambient miss gets the remediation hint, while
+// a pin or binding fault the operator can actually act on is returned
+// verbatim instead of being flattened into "bd not found in PATH".
+func TestRequireBdBinaryForCityErrorText(t *testing.T) {
+	newCity := func(t *testing.T, cityTOML, metadata string) string {
+		t.Helper()
+		cityDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityTOML), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if metadata != "" {
+			if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(scopeMetadataJSONPath(cityDir), []byte(metadata), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		t.Setenv("PATH", t.TempDir())
+		return cityDir
+	}
+
+	t.Run("ambient miss keeps the remediation hint", func(t *testing.T) {
+		cityDir := newCity(t, "[workspace]\nname = \"demo\"\n", "")
+		err := requireBdBinaryForCity(cityDir)
+		if err == nil || err.Error() != "bd not found in PATH (install beads or set GC_BEADS=file)" {
+			t.Fatalf("requireBdBinaryForCity() = %v, want the ambient-miss message with its remediation", err)
+		}
+	})
+
+	t.Run("unresolvable pin is returned verbatim", func(t *testing.T) {
+		pinDir := t.TempDir() // configured, but holds no bd
+		cityTOML := "[workspace]\nname = \"demo\"\n[workspace.env]\nPATH = " + strconv.Quote(pinDir) + "\n"
+		cityDir := newCity(t, cityTOML, `{"backend":"postgres","storage_endpoint":"opaque-remote","storage_database":"work"}`)
+		err := requireBdBinaryForCity(cityDir)
+		if err == nil || err.Error() != "workspace.env PATH is configured but contains no executable bd at an absolute path" {
+			t.Fatalf("requireBdBinaryForCity() = %v, want the unresolvable-pin message verbatim", err)
+		}
+	})
+
+	t.Run("partial binding is returned verbatim", func(t *testing.T) {
+		cityDir := newCity(t, "[workspace]\nname = \"demo\"\n", `{"backend":"postgres","storage_endpoint":"opaque-remote"}`)
+		err := requireBdBinaryForCity(cityDir)
+		if err == nil || !strings.Contains(err.Error(), "partial beads storage binding") {
+			t.Fatalf("requireBdBinaryForCity() = %v, want the partial-binding message verbatim", err)
+		}
+	})
+}
+
 func TestBdStoreBackingFindsDirectBdStore(t *testing.T) {
 	store := beads.NewBdStore("/city", noopBdRunner())
 	got, ok := bdStoreBacking(store)


### PR DESCRIPTION
## Problem

`gc bd` resolves the binary it execs with a bare `exec.LookPath("bd")` (`cmd/gc/cmd_bd.go:324`). It never consults the city's `[workspace.env]` PATH pin, so a city that deliberately pins a bd build — because its work store is bound to a backend only that build speaks — has the pin silently ignored by the passthrough, while every other bd path in the tree honors it.

The symptom is a passthrough that fails on a store the rest of `gc` reads fine:

```
$ gc bd show <id>
storage backend "postgres" is no longer supported
```

The ambient `bd` first on PATH was a build that rejects that backend. The identical command with the pin prefixed on PATH succeeded — the store was healthy the whole time; only the passthrough picked the wrong binary.

## Fix

Resolve the passthrough's binary the way `requireBdBinaryForCity` (`cmd/gc/main.go`) already resolves it: when the scope carries a complete storage binding (`scopeHasCompleteStorageBinding`), prefer `workspacePinnedBdBinary` if it yields an absolute path; otherwise fall back to the ambient lookup.

Rather than copy that logic a second time, both call sites now share a new `resolveBdBinaryForCity` in `cmd/gc/bd_env.go` — next to `workspacePinnedBdBinary`, which it wraps — so the passthrough and the managed-runner precondition cannot drift apart again.

Behavior is unchanged whenever there is no complete binding or no pin: same `exec.LookPath("bd")`, same `gc bd: bd not found in PATH` message, byte for byte. `requireBdBinaryForCity` keeps its own distinct remediation text (`... (install beads or set GC_BEADS=file)`) via the `errBdNotOnPath` sentinel. A pin that is configured but unresolvable now surfaces its real error instead of being masked as a missing binary.

## Tests

`TestGcBdPassthroughResolvesBdBinary` drives `doBd` end to end against two stand-in `bd` scripts that announce which one ran, covering both arms:

- **complete binding + workspace pin** → the pinned absolute binary runs
- **no binding, no pin** → the ambient binary runs, unchanged

Red before the production change (call site reverted to `exec.LookPath`, test unchanged):

```
--- FAIL: TestGcBdPassthroughResolvesBdBinary (0.59s)
    --- FAIL: TestGcBdPassthroughResolvesBdBinary/complete_binding_runs_the_workspace-pinned_bd (0.39s)
        cmd_bd_test.go:2508: executed bd = "ambient-bd", want workspace-pinned "pinned-bd"
FAIL
```

The fallback arm passed while red, confirming the second arm is a genuine no-regression guard rather than a restatement of the fix.

Green after:

```
--- PASS: TestGcBdPassthroughResolvesBdBinary (0.69s)
    --- PASS: TestGcBdPassthroughResolvesBdBinary/complete_binding_runs_the_workspace-pinned_bd (0.46s)
    --- PASS: TestGcBdPassthroughResolvesBdBinary/no_binding_falls_back_to_ambient_bd (0.23s)
```

## Gates

- `go build ./...` clean
- `go vet ./cmd/gc/` clean
- `go test ./cmd/gc/ -run 'Bd|BD|Workspace|Pin' -count=1` → `ok ... 73.443s`
- `golangci-lint run ./cmd/gc/` → `0 issues`
- `golangci-lint fmt --diff ./cmd/gc/` → no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)