### PR TITLE
fix(storage): raise the closed-guard floor to its proven count, and name recovery in the stranded refusal

### DIFF
--- a/cmd/gc/infra_class_migrate.go
+++ b/cmd/gc/infra_class_migrate.go
@@ -395,7 +395,7 @@ func infraMigrationOperatorAdvice(report infraMigrationReport, logPrefix string)
 				logPrefix, infraMigrationClassList(), report.Target.Binding, report.Target.MarkerPath(), storageMigrationCommand)
 		}
 	case infraMigrationStranded:
-		situation = fmt.Sprintf("%s: this city converged on binding %q, and the retained work store holds %d infrastructure bead(s) the binding cannot read: %s.",
+		situation = fmt.Sprintf("%s: this city converged on binding %q, and the retained work store holds %d infrastructure bead(s) the binding cannot read: %s. The named beads are intact in the retained work store. Stop every writer, recover them into the binding's database, and re-check with `gc storage status`, which exits zero once the binding contains them.",
 			logPrefix, report.Target.Binding, len(report.Stranded), infraStrandedIDList(report.Stranded))
 	case infraMigrationUncheckable:
 		situation = fmt.Sprintf("%s: this city's infrastructure binding %q could NOT be verified (reason above), so nothing here proved it is safe to serve from.", logPrefix, report.Target.Binding)

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -384,6 +384,12 @@ func TestStorageGateRefusalNamesTheStrandedIDs(t *testing.T) {
 	if strings.Contains(err.Error(), "see the ids above") {
 		t.Errorf("the refusal defers to output the supervisor never records: %v", err)
 	}
+	// The refusal must also say what recovery looks like: the ids alone tell
+	// the operator what is wrong, not what to do, and this string is the only
+	// output the supervisor records.
+	if !strings.Contains(err.Error(), "gc storage status") {
+		t.Errorf("the refusal names no recovery re-check: %v", err)
+	}
 }
 
 // TestStorageGateDoesNotCallAnUnreadableBindingUnmigrated covers the message on

--- a/internal/beads/sqlite_store_closed_test.go
+++ b/internal/beads/sqlite_store_closed_test.go
@@ -76,8 +76,12 @@ func TestSQLiteStoreExportedMethodsRejectUseAfterClose(t *testing.T) {
 			}
 		})
 	}
-	if guarded < 30 {
-		t.Fatalf("reflection reached only %d error-returning methods; the enumeration is broken", guarded)
+	// The floor is the count this enumeration reaches today. New methods are
+	// covered automatically and only raise it; a drop below it means the
+	// enumeration broke, not that the store shrank. Raise the floor when
+	// methods are deliberately removed.
+	if guarded < 36 {
+		t.Fatalf("reflection reached only %d error-returning methods, below the proven floor of 36; the enumeration is broken", guarded)
 	}
 
 	for name := range sqliteMethodsExemptFromClosedGuard {


### PR DESCRIPTION
## What

The two minor observations from the storage stack's independent verification pass, plus the test that pins the second one.

**1. The use-after-close reflection sweep floored its tripwire at 30 while the enumeration provably reaches 36.** A regression that shrank the enumeration anywhere between 31 and 35 passed silently. The floor is now the proven count, with the maintenance rule stated at the assertion: new methods are auto-covered and only raise the count; the floor moves only when methods are deliberately removed.

**2. The stranded-city refusal named the ids and stopped.** It said what is wrong but not what to do, and the refusal string is the only output the supervisor records. It now states that the named beads are intact in the retained work store, that recovery is copying them into the binding's database with every writer stopped, and that `gc storage status` re-runs the containment check and exits zero once the binding contains them. That last claim holds because containment classifies *absences* against the copy manifest — a bead present in the binding is never stranded regardless of how it arrived.

There is deliberately no recovery *command* named, because none exists: `gc storage migrate` on a marked city only re-reports. That gap is real feature work (targeted copy of exactly the stranded set, manifest append, GC-absence interplay) and is filed as #5087 rather than smuggled in here.

## Testing

`TestSQLiteStoreExportedMethodsRejectUseAfterClose` green at the raised floor; `TestStorageGateRefusalNamesTheStrandedIDs` extended to pin the recovery re-check into the refusal string alongside the ids. Vet clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
