### PR TITLE
refactor(beads): fold the native graph-plan validator into the shared one

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -652,7 +652,7 @@ func (s *NativeDoltStore) ApplyGraphPlanWithStorage(parent context.Context, plan
 	if err != nil {
 		return nil, fmt.Errorf("native graph apply: %w", err)
 	}
-	if err := validateNativeGraphApplyPlan(plan); err != nil {
+	if err := validateGraphApplyPlan(plan); err != nil {
 		return nil, fmt.Errorf("native graph apply: %w", err)
 	}
 
@@ -1758,53 +1758,6 @@ func nativeBeadIDPrefix(id string) string {
 		return ""
 	}
 	return normalizeIDPrefix(before)
-}
-
-func validateNativeGraphApplyPlan(plan *GraphApplyPlan) error {
-	if len(plan.Nodes) == 0 {
-		return fmt.Errorf("plan has no nodes")
-	}
-	knownKeys := make(map[string]bool, len(plan.Nodes))
-	for i, node := range plan.Nodes {
-		if strings.TrimSpace(node.Key) == "" {
-			return fmt.Errorf("node %d has empty key", i)
-		}
-		if knownKeys[node.Key] {
-			return fmt.Errorf("duplicate node key %q", node.Key)
-		}
-		knownKeys[node.Key] = true
-		if strings.TrimSpace(node.Title) == "" {
-			return fmt.Errorf("node %q has empty title", node.Key)
-		}
-	}
-	for _, node := range plan.Nodes {
-		for metaKey, refKey := range node.MetadataRefs {
-			if !knownKeys[refKey] {
-				return fmt.Errorf("node %q: metadata ref %q references unknown key %q", node.Key, metaKey, refKey)
-			}
-		}
-		if node.ParentKey != "" && !knownKeys[node.ParentKey] {
-			return fmt.Errorf("node %q: parent key %q not found in plan", node.Key, node.ParentKey)
-		}
-	}
-	for i, edge := range plan.Edges {
-		if edge.FromKey != "" && !knownKeys[edge.FromKey] {
-			return fmt.Errorf("edge %d: from key %q not found in plan", i, edge.FromKey)
-		}
-		if edge.ToKey != "" && !knownKeys[edge.ToKey] {
-			return fmt.Errorf("edge %d: to key %q not found in plan", i, edge.ToKey)
-		}
-		if edge.FromKey == "" && edge.FromID == "" {
-			return fmt.Errorf("edge %d: must specify from_key or from_id", i)
-		}
-		if edge.ToKey == "" && edge.ToID == "" {
-			return fmt.Errorf("edge %d: must specify to_key or to_id", i)
-		}
-		if depType := nativeGraphApplyDependencyType(edge.Type); !depType.IsValid() {
-			return fmt.Errorf("edge %d: invalid dependency type %q", i, edge.Type)
-		}
-	}
-	return nil
 }
 
 func nativeGraphApplyDependencyType(depType string) beadslib.DependencyType {

--- a/internal/beads/native_dolt_store_graph_validate_test.go
+++ b/internal/beads/native_dolt_store_graph_validate_test.go
@@ -1,0 +1,35 @@
+package beads
+
+import (
+	"context"
+	"testing"
+)
+
+// The native applier shares validateGraphApplyPlan with every other
+// in-process graph applier. Validation must run before any storage is
+// acquired, so a zero store proves the ordering: an invalid plan returns the
+// contract error without touching a backend.
+func TestNativeApplyGraphPlanValidatesBeforeAcquiringStorage(t *testing.T) {
+	store := &NativeDoltStore{}
+	for _, test := range []struct {
+		name string
+		plan *GraphApplyPlan
+	}{
+		{name: "nil plan", plan: nil},
+		{name: "empty plan", plan: &GraphApplyPlan{}},
+		{name: "empty node title", plan: &GraphApplyPlan{Nodes: []GraphApplyNode{{Key: "root"}}}},
+		{
+			name: "unknown edge endpoint",
+			plan: &GraphApplyPlan{
+				Nodes: []GraphApplyNode{{Key: "root", Title: "root"}},
+				Edges: []GraphApplyEdge{{FromKey: "root", ToKey: "missing"}},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := store.ApplyGraphPlanWithStorage(context.Background(), test.plan, StorageDefault); err == nil {
+				t.Fatal("invalid plan was accepted")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fold `validateNativeGraphApplyPlan` into `validateGraphApplyPlan`. The two were line-for-line identical except that the shared validator also nil-guards its argument — and that difference is unreachable through the native entry, because `ApplyGraphPlanWithStorage` nil-guards before validating. So this is pure deduplication with no behavior change on any entry path.

The duplicate was deliberate when the shared validator landed in #5069: a library-addition PR must not carry even a theoretical behavior change to a pre-existing path, so the fold was deferred to its own reviewable change. This is that change. `nativeGraphApplyDependencyType` stays — it has a second caller in the apply path.

## Testing

New `TestNativeApplyGraphPlanValidatesBeforeAcquiringStorage` drives the native entry with a zero store across the invalid-plan shapes, proving validation still runs before any storage is acquired. Full `internal/beads` suite green, vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
