### PR TITLE
perf(beads): skip post-write backing Get on cached Update/Close/Reopen

### DIFF
--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1385,9 +1385,9 @@ func TestCachingStoreUpdateInvalidatesStaleCacheWhenRefreshFails(t *testing.T) {
 	}
 
 	cache := NewCachingStoreForTest(backing, nil)
-	if err := cache.Prime(context.Background()); err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
+	// Deliberately NOT primed. Update's refresh-failure handling now
+	// lives on the cache-miss path only — a cache hit applies opts in-memory and
+	// never calls backing.Get, so priming here would bypass the branch under test.
 
 	title := "after"
 	backing.failNextGet = true
@@ -1428,9 +1428,9 @@ func TestCachingStoreUpdateRemovesCacheWhenRefreshReturnsNotFound(t *testing.T) 
 	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
 		events = append(events, eventType+":"+beadID)
 	})
-	if err := cache.Prime(context.Background()); err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
+	// Deliberately NOT primed. Update's refresh-failure handling now
+	// lives on the cache-miss path only — a cache hit applies opts in-memory and
+	// never calls backing.Get, so priming here would bypass the branch under test.
 
 	title := "after"
 	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
@@ -1447,8 +1447,10 @@ func TestCachingStoreUpdateRemovesCacheWhenRefreshReturnsNotFound(t *testing.T) 
 	if len(items) != 0 {
 		t.Fatalf("List after update/refresh NotFound = %#v, want no resurrected bead", items)
 	}
-	if len(events) != 1 || events[0] != "bead.closed:"+bead.ID {
-		t.Fatalf("events = %v, want [bead.closed:%s]", events, bead.ID)
+	// With no prior cached state there is no bead.closed to emit, but the
+	// tombstone must still prevent resurrection.
+	if len(events) != 0 {
+		t.Fatalf("events = %v, want none (cache-miss NotFound refresh emits no close)", events)
 	}
 	stats := cache.Stats()
 	if stats.ProblemCount != 0 {
@@ -1468,9 +1470,9 @@ func TestCachingStoreUpdateLogsRefreshFailure(t *testing.T) {
 	cache.problemf = func(msg string) {
 		logged = append(logged, msg)
 	}
-	if err := cache.Prime(context.Background()); err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
+	// Deliberately NOT primed. Update's refresh-failure handling now
+	// lives on the cache-miss path only — a cache hit applies opts in-memory and
+	// never calls backing.Get, so priming here would bypass the branch under test.
 
 	title := "after"
 	backing.failNextGet = true
@@ -2585,80 +2587,17 @@ func TestCachingStoreCloseAllMarksRefreshFailuresDirty(t *testing.T) {
 	}
 }
 
-func TestCachingStoreCachedListUnavailableAfterWriteThroughRefreshFailure(t *testing.T) {
-	t.Parallel()
+// Removed TestCachingStoreCachedListUnavailableAfterWriteThroughRefreshFailure.
+// Its premise was a FAILED cache-hit refresh leaving a dirty write-through
+// projection, and a cache-hit Update no longer refreshes at all, so the state it
+// asserted can no longer be reached from Update. Dirty-projection behavior is
+// still covered on the cache-miss branch (TestCachingStoreUpdateInvalidatesStaleCacheWhenRefreshFails)
+// and by the reconciler's own dirty-clearing coverage.
 
-	backing := &refreshFailingStore{Store: NewMemStore()}
-	bead, err := backing.Create(Bead{Title: "active work"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	cache := NewCachingStoreForTest(backing, nil)
-	if err := cache.Prime(context.Background()); err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
-
-	title := "updated while refresh fails"
-	backing.failNextGet = true
-	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
-		t.Fatalf("Update: %v", err)
-	}
-
-	if rows, ok := cache.CachedList(ListQuery{Status: "open"}); ok {
-		t.Fatalf("CachedList returned clean rows after refresh failure: %#v", rows)
-	}
-	if _, err := cache.Handles().Cached.List(ListQuery{Status: "open"}); !errors.Is(err, ErrCacheUnavailable) {
-		t.Fatalf("Cached.List after refresh failure = %v, want ErrCacheUnavailable", err)
-	}
-
-	got, err := cache.Get(bead.ID)
-	if err != nil {
-		t.Fatalf("Get after refresh failure: %v", err)
-	}
-	if got.Title != title {
-		t.Fatalf("Get title = %q, want authoritative title %q", got.Title, title)
-	}
-	rows, ok := cache.CachedList(ListQuery{Status: "open"})
-	if !ok {
-		t.Fatal("CachedList returned ok=false after authoritative Get refresh")
-	}
-	if len(rows) != 1 || rows[0].ID != bead.ID || rows[0].Title != title {
-		t.Fatalf("CachedList after authoritative refresh = %#v, want %s title %q", rows, bead.ID, title)
-	}
-}
-
-func TestCachingStoreReconciliationClearsDirtyWriteThroughProjection(t *testing.T) {
-	t.Parallel()
-
-	backing := &refreshFailingStore{Store: NewMemStore()}
-	bead, err := backing.Create(Bead{Title: "active work"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	cache := NewCachingStoreForTest(backing, nil)
-	if err := cache.Prime(context.Background()); err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
-
-	title := "updated while refresh fails"
-	backing.failNextGet = true
-	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
-		t.Fatalf("Update: %v", err)
-	}
-	if rows, ok := cache.CachedList(ListQuery{Status: "open"}); ok {
-		t.Fatalf("CachedList returned clean rows after refresh failure: %#v", rows)
-	}
-
-	cache.runReconciliation()
-
-	rows, ok := cache.CachedList(ListQuery{Status: "open"})
-	if !ok {
-		t.Fatal("CachedList returned ok=false after authoritative reconciliation")
-	}
-	if len(rows) != 1 || rows[0].ID != bead.ID || rows[0].Title != title {
-		t.Fatalf("CachedList after reconciliation = %#v, want %s title %q", rows, bead.ID, title)
-	}
-}
+// Removed TestCachingStoreReconciliationClearsDirtyWriteThroughProjection
+// for the same reason: it drove the reconciler from a dirty write-through
+// projection that only a failed cache-hit refresh could produce. The reconciler's
+// dirty-clearing paths are exercised directly by the reconcile tests.
 
 func TestCachingStoreCachedListSupportsActiveTierQueries(t *testing.T) {
 	t.Parallel()

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -1246,18 +1247,6 @@ func (s *dirtyGetRaceStore) Get(id string) (beads.Bead, error) {
 	return s.Store.Get(id)
 }
 
-type updateRefreshStore struct {
-	beads.Store
-	fresh map[string]beads.Bead
-}
-
-func (s *updateRefreshStore) Get(id string) (beads.Bead, error) {
-	if b, ok := s.fresh[id]; ok {
-		return b, nil
-	}
-	return s.Store.Get(id)
-}
-
 func TestCachingStoreGetFallsBackForClosedBeadsAfterPrime(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
@@ -1865,48 +1854,11 @@ func TestCachingStoreCachedReadyClearsExplicitEventNeeds(t *testing.T) {
 	}
 }
 
-func TestCachingStoreUpdateClearsCachedDependenciesFromFreshBead(t *testing.T) {
-	t.Parallel()
-	mem := beads.NewMemStore()
-	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
-	if err != nil {
-		t.Fatalf("Create(blocker): %v", err)
-	}
-	blocked, err := mem.Create(beads.Bead{Title: "Blocked", Needs: []string{blocker.ID}})
-	if err != nil {
-		t.Fatalf("Create(blocked): %v", err)
-	}
-	backing := &updateRefreshStore{
-		Store: beads.NewMemStoreFrom(2, []beads.Bead{blocker, blocked}, nil),
-		fresh: make(map[string]beads.Bead),
-	}
-	cache := beads.NewCachingStoreForTest(backing, nil)
-	if err := cache.PrimeActive(); err != nil {
-		t.Fatalf("PrimeActive: %v", err)
-	}
-
-	fresh := blocked
-	fresh.Title = "Cleared"
-	fresh.Needs = nil
-	fresh.Dependencies = nil
-	backing.fresh[blocked.ID] = fresh
-	title := "Cleared"
-	if err := cache.Update(blocked.ID, beads.UpdateOpts{Title: &title}); err != nil {
-		t.Fatalf("Update(blocked): %v", err)
-	}
-
-	ready, ok := cache.CachedReady()
-	if !ok {
-		t.Fatal("CachedReady reported cache unavailable")
-	}
-	ids := map[string]bool{}
-	for _, b := range ready {
-		ids[b.ID] = true
-	}
-	if !ids[blocked.ID] {
-		t.Fatalf("CachedReady ids = %v, want update refresh to clear stale deps", ids)
-	}
-}
+// Removed TestCachingStoreUpdateClearsCachedDependenciesFromFreshBead.
+// It asserted that a backing-side dependency change surprises its way into the
+// cache via Update's refresh read. A cache-hit Update now derives deps from the
+// locally-applied bead (depsFromFields), so backing-side dep edits that are not
+// in opts propagate via the periodic reconciler instead.
 
 func TestCachingStoreListPartialAllowScanReturnsCompleteActiveSnapshot(t *testing.T) {
 	t.Parallel()
@@ -3182,5 +3134,109 @@ func TestCachingStoreAppliesRoutedMetadataEventAfterPriorEventMutation(t *testin
 	if got.Metadata["gc.routed_to"] != "pool/polecat" {
 		t.Fatalf("gc.routed_to after sling-stamp event = %q, want %q (event dropped; pool demand stranded — #2210)",
 			got.Metadata["gc.routed_to"], "pool/polecat")
+	}
+}
+
+// The three tests below pin the cache-hit no-fetch contract: after Prime, an
+// Update/Close/Reopen against a cached bead must not issue a backing.Get.
+func TestCachingStoreUpdateOnCacheHitDoesNotCallBackingGet(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	created, err := mem.Create(beads.Bead{Title: "before", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing := &countingGetStore{Store: mem}
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.resetGets()
+
+	status := "in_progress"
+	for i := 0; i < 5; i++ {
+		if err := cs.Update(created.ID, beads.UpdateOpts{
+			Status: &status,
+			Metadata: map[string]string{
+				"fastpath.iteration": fmt.Sprintf("%d", i),
+			},
+		}); err != nil {
+			t.Fatalf("Update[%d]: %v", i, err)
+		}
+	}
+
+	if gets := backing.getCount(); gets != 0 {
+		t.Fatalf("backing.Get called %d times on cache-hit Update, want 0", gets)
+	}
+	got, err := cs.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Metadata["fastpath.iteration"] != "4" {
+		t.Fatalf("metadata = %#v, want last iteration applied", got.Metadata)
+	}
+}
+
+func TestCachingStoreCloseOnCacheHitDoesNotCallBackingGet(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	created, err := mem.Create(beads.Bead{Title: "doomed", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing := &countingGetStore{Store: mem}
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.resetGets()
+
+	if err := cs.Close(created.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if gets := backing.getCount(); gets != 0 {
+		t.Fatalf("backing.Get called %d times on cache-hit Close, want 0", gets)
+	}
+	got, err := cs.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed", got.Status)
+	}
+}
+
+func TestCachingStoreReopenOnCacheHitDoesNotCallBackingGet(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	created, err := mem.Create(beads.Bead{Title: "reopened"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing := &countingGetStore{Store: mem}
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if err := cs.Close(created.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	backing.resetGets()
+
+	if err := cs.Reopen(created.ID); err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	if gets := backing.getCount(); gets != 0 {
+		t.Fatalf("backing.Get called %d times on cache-hit Reopen, want 0", gets)
+	}
+	got, err := cs.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
 	}
 }

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -67,7 +67,45 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 		return err
 	}
 
-	// Re-fetch from backing to get the authoritative state.
+	// Cache-hit fast path: in the steady-state post-Prime case, apply opts to
+	// the cached bead in-memory under c.mu — symmetric with SetMetadata. This
+	// skips the post-write backing Get, which for BdStore is a `bd` subprocess
+	// per Update. It mirrors the cache-miss success path's side effects
+	// exactly, including clearing dependent ready-projections on a status
+	// change.
+	//
+	// Revision is advanced locally rather than adopted from a backing read, so
+	// the store still satisfies the conditional-writer contract that every
+	// mutation bumps the revision (beadstest
+	// RunConditionalWriterConformance/every_mutation_bumps_revision). The local
+	// counter can under-report if the backing advanced by more than one — for
+	// example if another writer also mutated the bead. That is self-healing: a
+	// write fenced on a lagged revision precondition-fails, which evicts the
+	// entry and forces a re-read (applyConditionalWriteFailure →
+	// evictForConditionalWrite).
+	c.mu.Lock()
+	if cached, ok := c.beads[id]; ok {
+		fresh := applyUpdateOptsToBead(cloneBead(cached), opts)
+		fresh.Revision = cached.Revision + 1
+		c.noteLocalMutationLocked(id)
+		c.absorbFreshLocked(id, fresh, time.Now(), absorbOpts{
+			depsMode:   depsFromFields,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
+		if opts.Status != nil {
+			c.clearDependentReadyProjectionsLocked(id)
+		}
+		c.markFreshLocked(time.Now())
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		c.notifyChange("bead.updated", fresh)
+		return nil
+	}
+	c.mu.Unlock()
+
+	// Cache miss (rare, only pre-Prime): re-fetch from backing to get the
+	// authoritative state so the bead can be admitted to the cache.
 	fresh, err := c.backing.Get(id)
 	if err != nil {
 		c.mu.Lock()
@@ -195,6 +233,33 @@ func (c *CachingStore) Close(id string) error {
 		return err
 	}
 
+	// Cache-hit fast path: flip Status to "closed" on the cached bead in-memory
+	// and advance its revision locally, instead of re-reading the bead this
+	// call just closed. Mirrors the unrefreshed branch below, including
+	// dependent ready-projection clearing. See the Update fast path for why a
+	// locally advanced revision still satisfies the conditional-writer
+	// contract. On a cache miss, fall through so the backing read admits the
+	// closed bead to the cache.
+	c.mu.Lock()
+	if b, ok := c.beads[id]; ok {
+		b.Status = "closed"
+		b.Revision++
+		c.noteLocalMutationLocked(id)
+		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
+		hit := cloneBead(b)
+		c.clearDependentReadyProjectionsLocked(id)
+		c.markFreshLocked(time.Now())
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		c.notifyChange("bead.closed", hit)
+		return nil
+	}
+	c.mu.Unlock()
+
 	// Adopt the successful refresh read: it carries the post-close revision,
 	// which Get→conditional-write consumers fence against — patching only the
 	// cached entry's status would keep serving the pre-close revision forever.
@@ -251,6 +316,28 @@ func (c *CachingStore) Reopen(id string) error {
 	if err := c.backing.Reopen(id); err != nil {
 		return err
 	}
+
+	// Cache-hit fast path: flip Status to "open" on the cached bead in-memory
+	// and advance its revision locally — same reasoning as the Close fast path.
+	c.mu.Lock()
+	if b, ok := c.beads[id]; ok {
+		b.Status = "open"
+		b.Revision++
+		c.noteLocalMutationLocked(id)
+		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
+			depsMode:   depsKeepCached,
+			seqMode:    seqKeep,
+			clearDirty: true,
+		})
+		hit := cloneBead(b)
+		c.clearDependentReadyProjectionsLocked(id)
+		c.markFreshLocked(time.Now())
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		c.notifyChange("bead.updated", hit)
+		return nil
+	}
+	c.mu.Unlock()
 
 	// Adopt the successful refresh read with the status written through —
 	// same reasoning as Close.


### PR DESCRIPTION
## Summary

`CachingStore.Update`, `Close`, and `Reopen` each re-read the bead they just wrote via `c.backing.Get(id)`, to adopt the authoritative post-write state. When the bead is already in the cache that read is redundant — the store has the prior bead and the transition it just applied, so it can derive the new state in memory. For a `BdStore` backing each of those reads is a `bd` subprocess plus a database round trip.

This adds a cache-hit fast path to each of the three verbs. On a cache miss nothing changes.

This is an optimization, not a correctness fix, and it makes one deliberate tradeoff around revision numbers. That tradeoff is spelled out under **Revision accounting** below — please read that section before the diff, it is the part most worth arguing about.

## Problem

All three verbs have the same shape today (`internal/beads/caching_store_writes.go`):

```go
if err := c.backing.Update(id, opts); err != nil {
    return err
}
// Re-fetch from backing to get the authoritative state.
fresh, err := c.backing.Get(id)
```

The write already succeeded and the transition is known. The `Get` exists to pick up whatever else the backing decided — most importantly the post-write revision. But on a cache hit the store is re-reading a bead it already has, to learn a change it just made.

The project has already established that this refresh is worth avoiding. #2152 (Phase 1 of #1978) added the `updateMatchesCached` / `closeAlreadyMatchesCached` idempotence filters, and item 4 of that issue was explicitly *"Skip the post-mutation `c.backing.Get(id)` refresh on the short-circuited path."* That covered writes that turn out to be no-ops. This change extends the same idea to writes that really do mutate a bead that is already cached.

## Fix

Each verb gets a cache-hit branch ahead of the existing backing read:

- **`Update`** applies `opts` to the cached bead with the existing `applyUpdateOptsToBead`, then absorbs it through `absorbFreshLocked(absorbOpts{depsMode: depsFromFields, seqMode: seqKeep, clearDirty: true})` — the same options the cache-miss success path uses.
- **`Close` / `Reopen`** flip `Status` on the cached bead and absorb with `depsKeepCached`, matching their own fall-through branches.

All three keep the surrounding side effects: `noteLocalMutationLocked`, `clearDependentReadyProjectionsLocked` on a status change, `markFreshLocked`, `updateStatsLocked`, and the same `notifyChange` event name the bypassed path emits (`bead.updated` / `bead.closed` / `bead.updated`).

Deliberately left alone:

- The `updateMatchesCached` / `closeAlreadyMatchesCached` idempotence short-circuits still run **ahead** of these fast paths and are untouched.
- `Create`, `CloseAll`, `SetMetadata*`, `DepAdd/DepRemove`, `Delete*`, `ReleaseIfCurrent`, and the `Tx` paths are unchanged.
- The cache-miss path in all three verbs is unchanged, so a bead that is not cached is still admitted via a backing read.

### Revision accounting — the tradeoff

The fast paths advance `Revision` **locally** (`+1`) instead of adopting it from a backing read. That is required: `beadstest.RunConditionalWriterConformance`'s `every_mutation_bumps_revision` case asserts that the store's own `Get` shows a strictly greater revision after every mutation, and `CachingStore` is run through that suite (`TestCachingStoreConditionalWriterConformance`).

**The limitation: a local `+1` can under-report when the backing advanced the revision by more than one** — for example when another writer also mutated the bead between this store's write and its next read. The cached revision is then behind the backing's.

I think this is acceptable, and here is the argument — but it is the thing to push back on if you disagree:

- It is self-healing, not silently wrong. A later conditional write fenced on the lagged revision precondition-fails, and `applyConditionalWriteFailure` → `evictForConditionalWrite` drops the entry, forcing a re-read of the real state. `TestCachingStoreConditionalWriteEvictsOnLaggedRefresh` and `TestCachingStoreConditionalPreconditionEvictsPerVerb` already cover that recovery and still pass.
- Consumers that fence on a revision must already handle a precondition failure and retry, so the failure mode is one they are built for.
- The pre-existing comment in `Close` makes the same argument in the other direction — it notes a lagged *revision* is self-healing while a lagged *status* is not, which is why `Close` force-writes the status. The fast paths preserve that asymmetry: status is always correct, revision may lag by a bounded amount.

What this costs is extra precondition failures under genuine multi-writer contention on the same bead, in exchange for removing a backing read from every cache-hit mutation. If you would rather have exact revisions, the alternative is to keep the `Get` and take the round trip, and this PR should be closed.

### One behavior change worth naming

`TestCachingStoreUpdateClearsCachedDependenciesFromFreshBead` is removed. It asserted that a **backing-side** dependency edit — one not present in `opts` — reaches the cache via `Update`'s refresh read. A cache-hit `Update` now derives deps from the locally applied bead (`depsFromFields`), so that class of edit propagates via the periodic reconciler instead of by riding along on the next unrelated `Update`. I removed the test rather than weaken it, with a comment in place naming what replaced the coverage.

Two other tests are removed for a narrower reason: their premise was a **failed** cache-hit refresh, and a cache hit no longer refreshes, so the state they asserted is unreachable from `Update`. Both left comments pointing at the coverage that remains (`TestCachingStoreCachedListUnavailableAfterWriteThroughRefreshFailure`, `TestCachingStoreReconciliationClearsDirtyWriteThroughProjection`).

## What this does NOT do

- Does not change any store other than `CachingStore` — no `bd`, protocol, or schema changes.
- Does not touch the storage-binding stack from #5069/#5070/#5071. I checked: none of those three commits modify `caching_store.go` or `caching_store_writes.go`, and the new SQLite store and storage-class conformance suites pass unchanged.
- Does not reduce cross-agent write traffic. #1978's storm is many processes each writing; this only removes the *read-back* that each write performs, in one process. #1978 and #2152 are closed; I am citing them as lineage, not claiming to close anything.
- Does not address #4499 (reconcile amplification under load) — that is about the reconciler's recovery path, which still issues its own backing reads.
- Does not change `CloseAll`, which still does a backing `Get` per id in its loop. Same optimization probably applies; I left it out to keep this reviewable.

## Measurement

I did not benchmark wall-clock latency — doing that honestly needs a `bd`/dolt-backed store under a realistic workload, and I would rather not report a number I cannot stand behind. The improvement is structural: **one fewer backing round trip per cache-hit mutation.**

That count is measured, via the new tests and the existing `countingGetStore` helper. Running the new tests against the unmodified write paths on `main`:

```
--- FAIL: TestCachingStoreUpdateOnCacheHitDoesNotCallBackingGet
    backing.Get called 5 times on cache-hit Update, want 0     (5 Updates)
--- FAIL: TestCachingStoreCloseOnCacheHitDoesNotCallBackingGet
    backing.Get called 1 times on cache-hit Close, want 0
--- FAIL: TestCachingStoreReopenOnCacheHitDoesNotCallBackingGet
    backing.Get called 1 times on cache-hit Reopen, want 0
```

With the change, all three report 0.

## Testing

- [x] `make lint` — 0 issues
- [x] `make vet` — clean
- [x] `go test ./internal/beads/...` — **all packages pass** (`internal/beads`, `beadstest`, `contract`, `exec`), including `TestCachingStoreConditionalWriterConformance` and every subtest of it: `every_mutation_bumps_revision`, `revision_monotonic_never_reused`, `stale_revision_is_precondition_failed`, `conditional_success_paths`, `contention`, and the CAS cases. The SQLite and storage-class conformance suites added by #5069/#5070 also pass.
- [ ] `make check` — **did not come back green on my machine, but not because of this change.** Details below; I would like CI's opinion on this one.
- [ ] `make check-docs` — not run; no docs, navigation, or links changed.
- [ ] `make test-integration` — not run. This change is confined to an in-memory caching layer with no new I/O, and the unit suite covers the store contract, but it is fair to say a caching store is runtime behavior — I would not object to CI running it.

### On `make check`

`make check` failed at its `test` target on four packages, none of which are `internal/beads` and none of which import the changed code:

- `examples/bd/dolt` — fails **identically on a clean `upstream/main` checkout**, which I verified by running it there:
  ```
  --- FAIL: TestRunBoundedPython3FallbackSendsSigtermBeforeKill
      runtime_bounded_test.go:106: run_bounded exit code = 127, want 124 (timeout)
      output:
      /usr/bin/env: 'bash': No such file or directory
  ```
  That is my host lacking `bash` on the sanitized `env -i` PATH the test harness builds, not a regression.
- `internal/runtime/acp`, `internal/runtime/subprocess`, `internal/sdnotify` — these **pass when re-run**, both on a clean `upstream/main` checkout and on this branch. They failed only in the `-p=4` parallel run on a machine that was heavily loaded at the time; the failures are handshake/signal timing, not assertions about store behavior.

So the honest summary is: every gate that exercises the changed code passes, and the `make check` failures reproduce without the change. I have not been able to get a fully green `make check` on this host even on `main`.

New tests:

- `TestCachingStoreUpdateOnCacheHitDoesNotCallBackingGet`
- `TestCachingStoreCloseOnCacheHitDoesNotCallBackingGet`
- `TestCachingStoreReopenOnCacheHitDoesNotCallBackingGet`

Reframed onto the cache-miss path (`Prime` skipped, since a cache hit no longer refreshes): the `Update` refresh-failure and `NotFound` tests — `...InvalidatesStaleCacheWhenRefreshFails`, `...LogsWhenRefreshFails`, `...RemovesCacheWhenRefreshReturnsNotFound`.

## Checklist

- [x] Linked issues — #1978 and #2152 as lineage; both already closed, so nothing here claims to close them.
- [x] Added tests for behavior changes
- [x] No user-facing surface changed, so no docs update
- [x] No breaking changes. The behavior change to backing-side dependency propagation on `Update` is called out above.

## Related

- #1978 / #2152 — the write-amplification lineage this extends. Closed; not duplicates.
- #4499 — caching-store reconcile amplification. Adjacent, different code path, not addressed here.
- #3253 — hydration-free/bounded reads for formulas and `beads(all=true)`. Read-side performance; unrelated to these write paths.
