### PR TITLE
fix(pool): exclude deferred beads from pool demand

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -139,8 +140,22 @@ func filterAssignedWorkBeadsForPoolDemand(
 			assigneeToSessionBeadID[id] = sb.ID
 		}
 	}
+	now := time.Now().UTC()
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
 	for i, wb := range assignedWorkBeads {
+		// A deferred bead is deliberately parked (future defer_until) and is
+		// invisible to bd ready, so scale_check reports zero demand for it.
+		// But this pool-demand pass draws from a raw List(status=open) that
+		// still returns deferred beads. A deferred bead that retains a stale
+		// gc.routed_to would otherwise count as poolDesired=1 with no matching
+		// ready work, driving the reconciler to spawn an ephemeral session that
+		// immediately orphan-drains — a spawn/drain loop that only ends when
+		// the bead's defer elapses or the route is stripped by hand. Excluding
+		// deferred beads here mirrors bd ready's server-side filter so gc's
+		// internal demand agrees with the shim.
+		if beads.IsDeferred(wb, now) {
+			continue
+		}
 		template := routedToOrLegacyWorkflowTarget(wb)
 		if template == "" {
 			if sessionBeadID := assigneeToSessionBeadID[strings.TrimSpace(wb.Assignee)]; sessionBeadID != "" {

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -242,6 +243,70 @@ func TestFilterAssignedWorkBeadsForPoolDemandLeavesUnmatchedInstanceSuffixAlone(
 
 	if len(got) != 0 {
 		t.Fatalf("filtered work = %#v, want out-of-range instance suffix left unmatched and dropped", got)
+	}
+}
+
+func TestFilterAssignedWorkBeadsForPoolDemandDropsDeferredRoutedBead(t *testing.T) {
+	// A deferred bead retaining a stale gc.routed_to must not count as pool
+	// demand. bd ready (and so scale_check) already hides it; the raw
+	// List(status=open) pass this filter draws from does not. Without the
+	// deferred exclusion it drives poolDesired=1 with no ready work behind it.
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name: "worker",
+		}},
+	}
+	future := time.Now().UTC().Add(720 * time.Hour)
+	work := []beads.Bead{
+		{
+			ID:       "deferred-routed-anchor",
+			Status:   "open",
+			Assignee: "worker-dead",
+			Metadata: map[string]string{
+				"gc.routed_to": "worker",
+			},
+			DeferUntil: &future,
+		},
+		{
+			ID:       "live-routed-work",
+			Status:   "in_progress",
+			Assignee: "worker-dead",
+			Metadata: map[string]string{
+				"gc.routed_to": "worker",
+			},
+		},
+	}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{"", ""})
+
+	if len(got) != 1 || got[0].ID != "live-routed-work" {
+		t.Fatalf("filtered work = %#v, want only live-routed-work (deferred anchor dropped)", got)
+	}
+}
+
+func TestFilterAssignedWorkBeadsForPoolDemandKeepsElapsedDeferRoutedBead(t *testing.T) {
+	// A defer_until in the past is elapsed — the bead is ready again and must
+	// still count as demand. Only a FUTURE defer_until parks it.
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name: "worker",
+		}},
+	}
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	work := []beads.Bead{{
+		ID:       "elapsed-defer-work",
+		Status:   "open",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+		DeferUntil: &past,
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+
+	if len(got) != 1 || got[0].ID != "elapsed-defer-work" {
+		t.Fatalf("filtered work = %#v, want elapsed-defer bead preserved as demand", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`filterAssignedWorkBeadsForPoolDemand` has no deferred-bead gate, so a work
bead that is deliberately parked with a future `defer_until` but still carries
a stale `gc.routed_to` is counted as standing pool demand. `bd ready` hides the
same bead, so `scale_check` reports zero for it. The two views disagree and the
controller spawns a worker every tick for work no worker can claim. This adds
the gate, with two regression tests.

## Problem

`collectAssignedWorkBeadsWithStores`' open pass draws from a raw
`List(status=open)`. That query still returns deferred beads, and
`appendOpenRoutedWorkUnique` keeps any that have an assignee plus a
`gc.routed_to`. Nothing downstream filters them out before
`ComputePoolDesiredStates` sees them, because the pool-demand filter only
resolves the route target and store reachability:

```go
filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
for i, wb := range assignedWorkBeads {
	template := routedToOrLegacyWorkflowTarget(wb)
	...
}
```

`computePoolDesiredStates` turns that bead into a resume / wake-known-identity
request. The controller spawns an ephemeral session, the session finds no ready
work (the bead is deferred, so it is not in `bd ready`) and orphan-drains the
same tick with no wake reason, and the next tick repeats. Nothing self-corrects:
the loop ends only when the defer elapses or an operator strips the route by
hand.

The observable consequence is a steady, silent spawn/drain churn — two such
parked beads were seen driving roughly 1000 session spawns per day across two
pools, each one costing a session create/close pair and a full agent boot. The
demand snapshot looks healthy the whole time, because from the controller's side
there genuinely is a routed open bead.

This is one concrete instance of the divergence described in #4114: the demand
definition (routed + open at the storage layer) is broader than the claimable
definition (`bd ready` semantics — dependency-aware, defer-aware).

## Fix

Gate the loop with `beads.IsDeferred(wb, now)`, mirroring `bd ready`'s
server-side `defer_until IS NULL OR defer_until <= now` filter so the
controller's internal demand agrees with the shim.

Deliberately narrow:

- Only the `ForPoolDemand` path. `filterAssignedWorkBeadsForSessionWake` is
  untouched, so a concrete session that owns a deferred bead can still be woken
  by the existing wake rules.
- An *elapsed* `defer_until` (in the past) still counts as demand — the bead is
  ready again. Only a future `defer_until` parks it. There is a test pinning
  this, because the obvious over-broad version of this fix ("has a `DeferUntil`
  at all") would silently under-provision.
- The pool-filtered set also backs `reusablePoolSessionBead`'s assigned-work
  guard, so this has a second effect worth naming: a session whose only
  "assigned work" is a parked bead is now correctly reusable rather than pinned
  to it.

## What this does NOT do

- **No zero-claim backoff.** #4114 asks for consecutive-zero-claim detection and
  exponential backoff. This does not implement that. It removes one cause of
  unclaimable demand; other causes (agent-side convention markers, the
  dependency-blocked case in that issue's follow-up comment) still produce the
  same shape and would still benefit from the backoff.
- **Does not touch blocked beads.** The dependency-blocked variant is #3758's
  subject, not this one.
- **Does not address a redundant ephemeral spawned alongside a live
  resume-owner.** That is a separate, bounded and self-correcting defect that
  needs scale-check-versus-live-owner accounting, and it carries
  under-provisioning risk if done carelessly. Left as a follow-up rather than
  bundled here.
- **Does not add a recovery path for beads already stranded by a defer.** #3995
  proposed that (a `ClearDefer` path so orphan-recovery can see and release
  deferred routed beads) and was closed for being bundled. This is the demand
  side only; the two are complementary, not alternatives.

## Testing

Environment note up front: this host has a running Dolt sql-server and no
system ICU dev package (only a Homebrew `icu4c@78`), which affects several
gates. Where a gate failed I re-ran the same thing on a clean `upstream/main`
worktree at `a699601f0` under an identical environment to check whether it was
mine. Details below.

| Gate | Result |
|---|---|
| `make lint` | pass, 0 issues |
| `make vet` | pass |
| `make check` (`fmt-check`, `lint`, `vet`, `check-release-dist-ignore`, `check-routed-test-rows`) | pass |
| `make check` (`test` stage) | see below |
| `go test ./cmd/gc/... -short -run 'AssignedWork\|PoolDemand'` | pass, 39 tests |
| `make test-integration` | see below |

**Unit suite.** `make test` runs under `env -i`, which drops `LD_LIBRARY_PATH`;
on this host that makes every CGO-linked test binary fail to load
`libicui18n.so.78` before running a single test. That reproduces identically on
clean `upstream/main`, so it is a local environment gap, not this change. (For
what it's worth: the Makefile's Homebrew-ICU CGO block at line 41 is gated to
`ifeq ($(shell uname),Darwin)` on the assumption that Linux always has system
ICU. A Linux host with Homebrew ICU and no `libicu-dev` falls through it. Not
touching that here — separate concern, and arguably my environment's problem.)

Re-running the same suite with the ICU path restored gets a real result. The
only failures are:

- `cmd/gc`: `TestDetectStandaloneBdDoltLiveDoltForDifferentDataDirDoesNotConflict`,
  `TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt`,
  `TestInitDirIfReadyDetectsStandaloneBdDoltAtProviderConvergence` (each times
  out at 30s against the ambient Dolt server), plus `TestImportMigrateScript`
  and `TestPackV2ImportsScript`. All five fail identically on clean
  `upstream/main`.
- `internal/testenv`: 5 tests, all failing identically on clean `upstream/main`.
- `examples/bd/dolt`: 3 `TestRunBoundedPython3Fallback*` tests, failing with
  `/usr/bin/env: 'bash': No such file or directory`. Identical on clean
  `upstream/main`.
- `internal/storebinding/sqlite`:
  `TestSQLiteWriterFenceSIGKILLAtReservationBoundaries` failed once under
  parallel load and passes in isolation on both this branch and clean
  `upstream/main`. Load flake.

Nothing in `cmd/gc` related to assigned-work scoping or pool demand fails.

**Integration.** The PR template asks for `make test-integration` when
controller behavior changes, which this does, so I tried. `make
test-integration` hits the same `env -i` ICU problem. Running the underlying
`go test -tags integration -timeout 30m ./...` directly with the ICU path
restored, the suite ran for over 20 minutes without a single package
completing — unsurprising given the ambient Dolt sql-server that already makes
the standalone-Dolt detection tests time out at 30s each in the unit run.

**So: I could not get a usable integration result on this host, and I am not
claiming one.** I would rather say that plainly than tick the box. The change
is a pure predicate added to one filter function — no I/O, no new state, no
new call sites — so CI's integration run should be the real signal here. If it
turns up something, I will fix it.

**Regression tests added** (`cmd/gc/assigned_work_scope_test.go`):

- `TestFilterAssignedWorkBeadsForPoolDemandDropsDeferredRoutedBead` — a bead
  with a future `defer_until` and a stale `gc.routed_to` is dropped, while a
  live in-progress bead routed to the same template is kept. Verified red
  against the unpatched filter (it keeps the deferred anchor).
- `TestFilterAssignedWorkBeadsForPoolDemandKeepsElapsedDeferRoutedBead` — a
  past `defer_until` still counts as demand. Passes both with and without the
  fix by design; it exists to catch a future over-broad defer check.

## Related

Adjacent, checked, and not duplicates:

- **#4114** (open) — same failure shape, broader scope. This closes one of the
  divergences that issue names; it does not implement the backoff it asks for.
  Referenced rather than closed.
- **#3758** (open) — `fix(runtime): ignore blocked assigned work for demand`.
  Same insertion point in the same function, different predicate (blocked vs
  deferred). Genuinely complementary: neither one covers the other's case. Heads
  up that the two will conflict textually at that line; whichever lands second
  is a one-line rebase, and I am happy to be the one that rebases.
- **#3995** (closed) — bundled four dispatch fixes, one of which was deferred-bead
  *recovery* (letting orphan-release see and clear a defer). Closed for mixed
  scope with an invitation to resubmit the slices separately. That is the
  recovery side; this is the demand side.
- **#4572** (open) — stale `start-pending` session records consuming pool
  capacity. Also a demand-accounting bug, but about session records, not work
  beads, and it causes under-provisioning rather than over-spawning.
- **#4448** (open) — drained pool sessions not reaped, their open session beads
  starving demand at cap. Again the session-bead side, and again the opposite
  direction (too few workers, not too many).

I did not find an existing issue specifically for the deferred case, so there is
nothing to close here. Happy to file one if you would rather have the bug
tracked separately from the fix.

## Checklist

- [x] Linked an issue — Refs #4114 (partial; does not close it)
- [x] Added tests for the behavior change
- [ ] Docs — no user-facing surface changed
- [x] No breaking changes or migration notes. One behavior note for reviewers:
      a pool that was being kept awake purely by a parked routed bead will now
      correctly scale to zero. That is the intended fix, but it is a visible
      change for anyone who had come to rely on the accidental floor.
