### PR TITLE
fix(reconciler): resolve named-session work_dir from its own alias

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2574,7 +2574,8 @@ func discoverSessionBeadsWithRoots(
 			// identity mismatch caused config-drift drains; the canonical shape
 			// still keeps routing/display identity and remaining fingerprint
 			// inputs aligned across buildDesiredState paths. Named beads
-			// intentionally pass through with the base shape (see
+			// resolve to their own stored alias so this seam reproduces the
+			// identity the named-session loop assigned (see
 			// canonicalSessionIdentity).
 			resolveAgent, sessionQualifiedName = canonicalSessionIdentityWithConfigInfo(cfg, cfgAgent, bInfo)
 		}
@@ -3267,19 +3268,22 @@ func resolveTemplateForSessionBeadInfo(
 // FingerprintExtra are part of CoreFingerprint, so divergent shapes across
 // ticks trip the reconciler's config-drift drain.
 //
-// Named beads are deliberately NOT canonicalized here. The named-session
-// TemplateParams contract (ConfiguredNamedIdentity/Mode, GC_SESSION_ORIGIN,
-// canonical session_name, ...) is authored by the main named-session loop
-// and reconstructNamedSessionTemplateParams; rewriting only the (agent,
-// qualifiedName) pair in rediscovery while leaving the rest of the shape
-// as plain ephemeral would produce a partially-named TemplateParams that
-// downstream consumers don't expect. The Env-side drift that named beads
-// can still exhibit across rediscovery vs. the named-session loop is a
-// separate fix — the accompanying PR explicitly scopes it out.
+// Named beads resolve to their own stored alias (configured_named_identity),
+// NOT the shared backing template's qualified name. The main named-session
+// loop builds the session with spec.Identity; this rediscovery seam must
+// return the same identity or ParseQualifiedName binds AgentBase to the
+// template's base name, and every named session backed by that template
+// resolves work_dir to one shared directory instead of its own. A named bead
+// with no stored identity (legacy, pre-stamp) falls back to the template QN,
+// unchanged from before. NOTE: this aligns the (agent, qualifiedName) pair and
+// therefore WorkDir/AgentBase; the rest of the named TemplateParams Env shape
+// (GC_SESSION_ORIGIN=named, ConfiguredNamedIdentity/Mode) is still authored
+// only by the named-session loop, so Env-side drift across rediscovery vs.
+// that loop remains a separate follow-up.
 //
 // Rules:
-//   - Named bead → (cfgAgent, cfgAgent.QualifiedName()). Identical to the
-//     pre-change rediscovery shape so named-bead handling is unchanged.
+//   - Named bead with stored identity → (cfgAgent, configured_named_identity).
+//   - Named bead without stored identity → (cfgAgent, cfgAgent.QualifiedName()).
 //   - Non-expanding agent → (cfgAgent, cfgAgent.QualifiedName()).
 //   - Instance-expanding agent with a stamped pool_slot → (deepCopyAgent
 //     at that slot, qualifiedInstance). Matches realizePoolDesiredSessions.
@@ -3294,6 +3298,17 @@ func canonicalSessionIdentityWithConfig(cfg *config.City, cfgAgent *config.Agent
 		return nil, ""
 	}
 	if isNamedSessionBead(bead) {
+		// A named-session bead's work_dir/AgentBase must resolve from its own
+		// stored alias, not from the shared backing template. The named-session
+		// loop builds the session with spec.Identity; this rediscovery seam must
+		// return the same identity or ParseQualifiedName yields the template's
+		// base name, collapsing every named session on that template onto one
+		// work_dir. In practice this bites on_demand sessions, which can fall
+		// through the named-session loop's mode gate and get their identity
+		// recomputed here.
+		if identity := namedSessionIdentity(bead); identity != "" {
+			return cfgAgent, identity
+		}
 		return cfgAgent, cfgAgent.QualifiedName()
 	}
 	if cfgAgent.UsesCanonicalSingletonPoolIdentity() {
@@ -3317,6 +3332,15 @@ func canonicalSessionIdentityWithConfigInfo(cfg *config.City, cfgAgent *config.A
 		return nil, ""
 	}
 	if isNamedSessionInfo(info) {
+		// Mirror of the raw form's named-bead branch: resolve from the
+		// session's own stored alias so rediscovery reproduces the identity
+		// the named-session loop assigned, and work_dir does not collapse
+		// onto the backing template's path. Both forms must change together —
+		// TestCanonicalSessionIdentityWithConfigInfoMatchesRaw pins them to
+		// identical behavior. See canonicalSessionIdentityWithConfig.
+		if identity := namedSessionIdentityInfo(info); identity != "" {
+			return cfgAgent, identity
+		}
 		return cfgAgent, cfgAgent.QualifiedName()
 	}
 	if cfgAgent.UsesCanonicalSingletonPoolIdentity() {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -11171,20 +11171,40 @@ func TestCanonicalSessionIdentity(t *testing.T) {
 		}
 	})
 
-	t.Run("named bead keeps base identity (out of scope for this canonicalization)", func(t *testing.T) {
-		// Named-session TemplateParams carry ConfiguredNamedIdentity/Mode,
-		// GC_SESSION_ORIGIN=named, and a canonical session_name set by the
-		// main named-sessions loop and reconstructNamedSessionTemplateParams.
-		// Rewriting just the identity qualifier in rediscovery without also
-		// repopulating that contract would produce a partially-named
-		// TemplateParams that downstream consumers don't expect — so the
-		// helper intentionally leaves named beads on the base shape.
+	t.Run("named bead resolves to its own stored alias, not the backing template", func(t *testing.T) {
+		// A named-session bead must resolve its identity (and therefore its
+		// work_dir/AgentBase) from its stored configured_named_identity
+		// ("gascity/opus"), NOT the shared backing template ("gascity/dog").
+		// Returning the template QN here binds AgentBase to the template's base
+		// name, so every named session on that template resolves work_dir to one
+		// shared directory instead of its own.
 		agent, qn := canonicalSessionIdentity(poolAgent, namedBead)
 		if agent != poolAgent {
 			t.Errorf("named bead must not produce a deep-copied instance agent")
 		}
+		if qn != "gascity/opus" {
+			t.Errorf("qn = %q, want stored alias %q", qn, "gascity/opus")
+		}
+	})
+
+	t.Run("named bead without stored identity falls back to base template QN", func(t *testing.T) {
+		// Legacy named beads that predate the identity stamp have no
+		// configured_named_identity; they must still resolve safely (base QN)
+		// rather than empty. Such beads get corrected on their next fresh spawn.
+		unstampedNamedBead := beads.Bead{
+			Metadata: map[string]string{
+				"template":              "gascity/dog",
+				"agent_name":            "gascity/dog",
+				"session_name":          "s-legacy",
+				namedSessionMetadataKey: "true",
+			},
+		}
+		agent, qn := canonicalSessionIdentity(poolAgent, unstampedNamedBead)
+		if agent != poolAgent {
+			t.Errorf("unstamped named bead must not produce a deep-copied instance agent")
+		}
 		if qn != "gascity/dog" {
-			t.Errorf("qn = %q, want base %q (named canonicalization is scoped out)", qn, "gascity/dog")
+			t.Errorf("qn = %q, want base fallback %q", qn, "gascity/dog")
 		}
 	})
 

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -484,3 +484,69 @@ dolt.auto-start: false
 		t.Fatalf("HOME should be passed through to agent env")
 	}
 }
+
+// TestRediscoveredNamedBeadWorkDirUsesAliasNotTemplate is the end-to-end
+// regression for the named-session work_dir collision: a named-session bead
+// whose backing template is "demo/worker" but whose stored identity is
+// "demo/alpha" must resolve its work_dir to .gc/worktrees/demo/alpha, NOT
+// .gc/worktrees/demo/worker. It drives the exact reconciler seam
+// (canonicalSessionIdentity -> resolveTemplateForSessionBeadInfo) that
+// session-bead rediscovery uses for a woken on_demand named session.
+func TestRediscoveredNamedBeadWorkDirUsesAliasNotTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	rigRoot := filepath.Join(cityPath, "demo")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		rigs:       []config.Rig{{Name: "demo", Path: rigRoot}},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	// The shared template that several [[named_session]] entries back onto.
+	templateAgent := &config.Agent{
+		Name:    "worker",
+		Dir:     "demo",
+		WorkDir: ".gc/worktrees/{{.Rig}}/{{.AgentBase}}",
+	}
+	namedBead := beads.Bead{
+		ID: "ga-alpha",
+		Metadata: map[string]string{
+			"template":                   "demo/worker",
+			"agent_name":                 "demo/alpha",
+			"session_name":               "demo--alpha",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "demo/alpha",
+		},
+	}
+
+	// Rediscovery seam: canonicalize the bead's identity, then resolve the
+	// template exactly as build_desired_state's rediscovery path does.
+	_, qn := canonicalSessionIdentity(templateAgent, namedBead)
+	if qn != "demo/alpha" {
+		t.Fatalf("canonicalSessionIdentity qn = %q, want demo/alpha", qn)
+	}
+	tp, err := resolveTemplateForSessionBeadInfo(params, templateAgent, qn, nil, seedSessionInfo(namedBead))
+	if err != nil {
+		t.Fatalf("resolveTemplateForSessionBeadInfo: %v", err)
+	}
+
+	wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "alpha")
+	if tp.WorkDir != wantWorkDir {
+		t.Fatalf("WorkDir = %q, want %q (collapsed onto the template path?)", tp.WorkDir, wantWorkDir)
+	}
+	sharedWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "worker")
+	if tp.WorkDir == sharedWorkDir {
+		t.Fatalf("WorkDir collapsed onto the shared template path %q", sharedWorkDir)
+	}
+}


### PR DESCRIPTION
## Summary

Session-bead rediscovery resolves a named-session bead's identity to the shared
backing template's qualified name instead of the session's own stored identity.
Because `work_dir` and worktree-setup `pre_start` hooks interpolate
`{{.AgentBase}}`, every `on_demand` named session backed by a given template
resolves its working directory to one shared path keyed by the template, rather
than one path per session. Where that path is a git worktree, distinct agents
end up sharing one working tree, one branch, and one index.

This changes `canonicalSessionIdentityWithConfig` and its `session.Info` twin to
return the bead's stored `configured_named_identity` when it has one.

## Problem

In `cmd/gc/build_desired_state.go`, both forms of the canonical-identity helper
short-circuit named beads to the template's qualified name:

```go
if isNamedSessionInfo(info) {
    return cfgAgent, cfgAgent.QualifiedName()
}
```

`ParseQualifiedName` then binds `AgentBase` to the *template's* base name. With a
config shaped like the one the example pack teaches —

```toml
[[agent]]
name = "worker"
work_dir = ".gc/worktrees/{{.Rig}}/{{.AgentBase}}"
pre_start = ["worktree-setup.sh ..."]
```

— several `[[named_session]]` entries backed by `worker` all resolve to
`.gc/worktrees/<rig>/worker` instead of `.gc/worktrees/<rig>/<session name>`.

Where I am confident, and where I am not: the named-session loop emits sessions
with the correct `spec.Identity`, and its mode gate
(`spec.Mode != "always" && !hasCanonical && !namedWorkReady[identity]`) means an
`on_demand` session can fall through it and have its identity recomputed at the
rediscovery seam instead — that is the case I have actually observed. I have
*not* convinced myself that `always` sessions can never reach the same seam:
`discoverSessionBeadsWithRoots` writes `desired[sn] = tp` unconditionally, so if
an already-desired named session is re-keyed there it would be overwritten too.
Either way the seam should reproduce the loop's identity, which is what this
patch makes it do — but I did not want to assert a scope I had not proven, and
a maintainer will know this ordering better than I do.

This is the named-session analogue of #774, which fixed the same
`{{.AgentBase}}`-collapses-to-the-template-name symptom for namepool slots in
`PathContextForQualifiedName`. That fix did not cover the named-session path,
which resolves identity through a different seam.

## Fix

For a named bead carrying `configured_named_identity`, return that identity, so
rediscovery resolves the same `(agent, qualifiedName)` pair — and therefore the
same `WorkDir`/`AgentBase` — as the named-session loop does when it builds the
session in the first place. It reuses the existing `namedSessionIdentity` /
`namedSessionIdentityInfo` accessors rather than reading metadata directly.

Legacy beads with no identity stamp keep the previous behavior (template QN)
rather than resolving to an empty name; they pick up the correct identity on
their next fresh spawn.

The change is applied to **both** forms of the helper. The raw (`beads.Bead`)
form and the `session.Info` form are pinned to identical behavior by the
existing `TestCanonicalSessionIdentityWithConfigInfoMatchesRaw`, and live
rediscovery runs on the `Info` form — so changing only one form would either
trip that oracle or land in a path the reconciler no longer takes. The pool
branches of both functions are untouched; the change sits entirely behind the
existing `isNamedSessionBead` / `isNamedSessionInfo` guard.

## What this does NOT do

- It does not touch pool-slot identity or `PathContextForQualifiedName`.
- It does not repair the rest of the named-session `TemplateParams` contract.
  Rediscovery still does not reconstruct `GC_SESSION_ORIGIN=named` or
  `ConfiguredNamedIdentity`/`Mode` in `Env` the way the named-session loop does.
  This patch aligns only the `(agent, qualifiedName)` pair, which is what
  `WorkDir`/`AgentBase` derive from. The remaining Env-side drift is a separate
  problem and is called out in the updated doc comment.
- It does not migrate existing beads. A session whose worktree was already
  materialized at the shared template path is not moved; the next resolution
  simply points at the correct path.
- It does not address #1181 (implicit pool agents that have no `work_dir` at
  all). That is a different gap — no isolation configured, versus isolation
  configured but resolving to the wrong name.

## Testing

Run on Linux against this branch:

- `make lint` — pass, 0 issues.
- `make vet` — pass.
- `go test ./cmd/gc/... -short -run 'CanonicalSessionIdentity|Workdir|WorkDir|NamedSession'` — pass.
- `TestCanonicalSessionIdentityWithConfigInfoMatchesRaw` — pass (explicitly
  re-run, since this change has to keep the two forms in agreement).
- `make check` — **fails**, at the `test` target. Every failure reproduces on a
  clean `upstream/main` worktree at the same commit, so none of them are from
  this change. Details below, because I would rather show the work than assert
  "unrelated".
- `make test-integration` — **did not complete.** Details below.

Tests changed/added, all in `cmd/gc`:

- `TestCanonicalSessionIdentity` — the named-bead subtest previously asserted the
  template QN as expected behavior; it now asserts the stored alias.
- `TestCanonicalSessionIdentity` — new subtest for the unstamped-bead fallback.
- `TestRediscoveredNamedBeadWorkDirUsesAliasNotTemplate` — new end-to-end
  regression driving `canonicalSessionIdentity` →
  `resolveTemplateForSessionBeadInfo` and asserting `WorkDir` lands on the
  session's own path, not the template's.

Red/green verified: with the test changes applied but the production hunks
reverted to `main`, both new assertions fail with
`qn = "demo/worker", want demo/alpha`; with the fix they pass.

### Why `make check` fails here, and why it is not this change

`make test` produced 7 failures. I re-ran every one of them on a pristine
`upstream/main` worktree at the same commit:

| Test | On this branch | On clean `main` |
|---|---|---|
| `TestDetectStandaloneBdDoltLiveDoltForDifferentDataDirDoesNotConflict` | FAIL (30s timeout) | FAIL (30s timeout) |
| `TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt` | FAIL (30s timeout) | FAIL (30s timeout) |
| `TestInitDirIfReadyDetectsStandaloneBdDoltAtProviderConvergence` | FAIL (30s timeout) | FAIL (30s timeout) |
| `TestRunBoundedPython3FallbackSendsSigtermBeforeKill` | FAIL | FAIL |
| `TestRunBoundedPython3FallbackEscalatesToSigkillAfterGrace` | FAIL | FAIL |
| `TestRunBoundedPython3FallbackPassesThroughOutputAndExitCode` | FAIL | FAIL |
| `TestRunSetupCommandActivityStreamingSurvivesIdleWindow` | FAIL under load | PASS |

The three `StandaloneBdDolt` timeouts look like the ambient-dolt collision
already tracked in #4677 / #4673 — my host has a dolt sql-server running.

`TestRunSetupCommandActivityStreamingSurvivesIdleWindow` is the one that did not
immediately reproduce, so I chased it: it passes 5/5 with `-count=5` on **both**
this branch and clean `main` when run on its own, and only failed inside the
full parallel run while the machine was heavily loaded. It is a timing-sensitive
tmux streaming test, and it lives in `internal/runtime/tmux`, which this patch
does not touch. I am treating it as load-induced flake rather than a regression,
but flagging it rather than burying it.

### Why `make test-integration` did not complete

I ran it, because the template asks for it when reconciler behavior changes and
this does. The `test/integration` package hit the 30-minute package timeout and
was killed with SIGQUIT after ~1980s. No named integration test reported a
failure — the only `--- FAIL` lines in the whole run were the same six above.

I am not claiming this gate as passing, and I am also not claiming the timeout is
unrelated on the strength of a hunch: my host was running several other full
suites concurrently, which is the most likely explanation, but I could not get a
quiet enough machine to produce a clean comparison run before opening this. If a
maintainer wants that comparison before merging, say so and I will produce it; if
CI runs the suite on a quiet box, that will be a better signal than anything I
can generate here.

**Environment note, in case it matters to a reviewer:** the Makefile points CGO
at Homebrew `icu4c` only on Darwin, and otherwise expects system ICU headers on
Linux. My host has linuxbrew `icu4c` but no `libicu-dev`, so I supplied
`CGO_CPPFLAGS`/`CGO_LDFLAGS` manually for all of the above. That is a local
environment quirk, not something this patch changes, and I mention it only so
the gate results above are interpretable.

## Related

- #774 — closed, the namepool-slot version of this same `{{.AgentBase}}`
  collision, fixed in a different resolver. Prior art, not a duplicate.
- #1181 — open, implicit pool agents sharing a working tree because they have no
  `work_dir` at all. Same class of consequence, different cause; not fixed here.
- #3582 — open, named work_dir precedence at session launch
  (`session_lifecycle_parallel.go`). Adjacent layer, no file overlap.

## Checklist

- [x] `make check` — run; fails only on pre-existing failures verified against
      clean `main` (table above).
- [ ] `make check-docs` — not run; no docs, navigation, or links changed.
- [ ] `make test-integration` — run but did not complete (30m package timeout);
      see above. Not claiming it.
- [x] Linked issues, or explained why one is not needed — no existing issue
      tracks this specific path; I did not open one separately since the
      description above is self-contained. Happy to file one if you would rather
      have it tracked.
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — none identified; this restores the
      documented `{{.AgentBase}}` contract rather than changing it. Point me at a
      page if you think one should change.
- [x] Called out breaking changes or migration notes — see below.

**Migration note.** For any `on_demand` named session that has already been
rediscovered at least once, the resolved `work_dir` changes from the shared
template path to the session's own path. That is the intended correction, but it
does mean a session can appear to "move" on the tick after upgrading, and any
uncommitted work sitting in the old shared directory stays there. I think that is
the right trade, but it is a behavior change worth a release note.
