### PR TITLE
test(cmd/gc): tear down managed dolt after init-from without hosted endpoint (#5066)

### DIFF
--- a/cmd/gc/init_from_hosted_dolt_test.go
+++ b/cmd/gc/init_from_hosted_dolt_test.go
@@ -71,6 +71,11 @@ func TestInitFromWithoutHostedPreservesTemplate(t *testing.T) {
 
 	src := gastownExamplePath(t)
 	cityPath := filepath.Join(t.TempDir(), "city")
+	// initDirIfReady (via finalizeInit) starts a managed dolt sql-server for the
+	// copied template's local beads backend. noStart skips supervisor handoff
+	// but leaves that server running — tear it down so the package leak guard
+	// does not fail the suite (gastownhall/gascity#5066).
+	cleanupManagedDoltTestCity(t, cityPath)
 
 	var stdout, stderr bytes.Buffer
 	// disabled hosted options => template preserved


### PR DESCRIPTION
## Summary

- `TestInitFromWithoutHostedPreservesTemplate` was leaking a managed `dolt sql-server` after `finalizeInit` → `initDirIfReady` started one for the copied template's local beads backend. With `noStart=true` the test never handed off to the supervisor, so the server outlived the test and the package dolt leak guard failed the suite even though the test's own assertions passed.
- Teardown now uses the existing `cleanupManagedDoltTestCity` helper (`shutdownBeadsProvider` + stop of any remaining managed servers under the city path).
- Reported by @jm2 in #5066. Related #5057 proposes to widen leak-guard *visibility* (source-tree roots); this is the teardown fix for the named temp-root culprit.

## Why teardown in the test, not in `noStart`

A fair question is whether `noStart` itself should stop the server `initDirIfReady` started, making this a product fix instead. Two reasons this PR stays at the test layer:

- Leaving the managed server running after init is the existing product behavior — the initialized city is live and usable; `noStart` only skips supervisor handoff. Tests in this package own their teardown for exactly this case: `cleanupManagedDoltTestCity` has 22 call sites in `cmd/gc`, including two (`script_resolve_test.go`, `cityinit_impl_test.go`) that register it in this identical pre-init shape. Registering before init is what gives the helper a clean PID baseline, and every teardown step no-ops safely if init fails early.
- #5066 is scoped to the leaking test, and changing `noStart` semantics would be a behavior change for all callers.

If you'd rather `noStart` stop the server it started, happy to rework at that layer instead — flagging the option rather than deciding it unilaterally.

## Testing

- [x] `go test ./cmd/gc -run '^TestInitFromWithoutHostedPreservesTemplate$' -count=1` — PASS, no package leak-guard failure, no leftover `dolt sql-server` under the test temp root
- [x] `go test ./cmd/gc -run 'TestInitFrom(PinsHosted|WithoutHosted|RejectsIncomplete|RejectsDolt|HostedPreserves)' -count=1` — all PASS
- [x] `gofmt` clean on touched file
- [ ] `make check` (not run end-to-end; change is one-line test teardown)
- [ ] `make check-docs` N/A
- [ ] `make test-integration` N/A

### Before (verbatim leak-guard failure)

```
cmd/gc test dolt leak guard: leaked 1 dolt sql-server process(es) under /var/folders/.../gct...
  pid=... argv="dolt sql-server --config .../TestInitFromWithoutHostedPreservesTemplate.../002/city/.gc/runtime/packs/dolt/dolt-config.yaml"
FAIL	github.com/gastownhall/gascity/cmd/gc
```

### After

```
--- PASS: TestInitFromWithoutHostedPreservesTemplate
PASS
ok  	github.com/gastownhall/gascity/cmd/gc
```

## Checklist

- [x] Linked an issue: closes #5066 (credits @jm2)
- [x] Added or updated tests for behavior changes (test teardown only; production code unchanged)
- [x] Updated docs for user-facing changes — N/A
- [x] Called out breaking changes or migration notes — none

Closes #5066
