### PR TITLE
test: compare paths via firmlink-aware helpers after #4930 (#4934)

### DIFF
--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -2679,13 +2679,8 @@ schema = 1
 	if err != nil {
 		t.Fatalf("resolveImportRoot: %v", err)
 	}
-	want, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatalf("EvalSymlinks(%q): %v", dir, err)
-	}
-	if got != want {
-		t.Fatalf("resolveImportRoot() = %q, want %q", got, want)
-	}
+	// production paths are NormalizePathForCompare form; compare firmlink-aware (#4934)
+	assertSameTestPath(t, got, dir)
 }
 
 func TestFindNearestImportRootSkipsRuntimeOnlyDirs(t *testing.T) {
@@ -2754,13 +2749,7 @@ func TestResolveImportRootPrefersNearestPackUnderCity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveImportRoot: %v", err)
 	}
-	want, err := filepath.EvalSymlinks(packDir)
-	if err != nil {
-		t.Fatalf("EvalSymlinks(%q): %v", packDir, err)
-	}
-	if got != want {
-		t.Fatalf("resolveImportRoot() = %q, want nearest pack %q", got, want)
-	}
+	assertSameTestPath(t, got, packDir)
 }
 
 func TestResolveImportRootRuntimeOnlyAncestorResolvesRegisteredRigCity(t *testing.T) {

--- a/internal/convergence/evaluate_test.go
+++ b/internal/convergence/evaluate_test.go
@@ -20,10 +20,9 @@ func TestResolveEvaluateStep_DefaultPath(t *testing.T) {
 	if step.Name != EvaluateStepName {
 		t.Errorf("Name = %q, want %q", step.Name, EvaluateStepName)
 	}
+	// production paths are NormalizePathForCompare form; compare firmlink-aware (#4934)
 	want := filepath.Join("/home/user/city", DefaultEvaluatePromptPath)
-	if step.PromptPath != want {
-		t.Errorf("PromptPath = %q, want %q", step.PromptPath, want)
-	}
+	testutil.AssertSamePath(t, step.PromptPath, want)
 }
 
 func TestResolveEvaluateStep_CustomPath(t *testing.T) {
@@ -40,9 +39,7 @@ func TestResolveEvaluateStep_CustomPath(t *testing.T) {
 		t.Errorf("Name = %q, want %q", step.Name, EvaluateStepName)
 	}
 	want := filepath.Join("/home/user/city", "custom/my-evaluate.md")
-	if step.PromptPath != want {
-		t.Errorf("PromptPath = %q, want %q", step.PromptPath, want)
-	}
+	testutil.AssertSamePath(t, step.PromptPath, want)
 }
 
 func TestResolveEvaluateStep_PathTraversal(t *testing.T) {
@@ -138,9 +135,7 @@ func TestResolveEvaluateStep_RelativeCityPathReturnsAbsolutePromptPath(t *testin
 		t.Fatalf("PromptPath = %q, want an absolute path — cityPath must be canonicalized to absolute before joining, not left relative", step.PromptPath)
 	}
 	want := filepath.Join(dir, DefaultEvaluatePromptPath)
-	if step.PromptPath != want {
-		t.Errorf("PromptPath = %q, want %q", step.PromptPath, want)
-	}
+	testutil.AssertSamePath(t, step.PromptPath, want)
 }
 
 // Pins the symlink-presence rejection itself, which the comparison above sits


### PR DESCRIPTION
## Summary

- Fix macOS-only test failures introduced after #4930's path-normalization change.
- Four tests compared production paths (via `pathutil.NormalizePathForCompare`) against bare `filepath.EvalSymlinks` or literal strings. (The diff touches a fifth comparison in the same file, converted for consistency — it already passed.) On macOS those spellings diverge because of firmlinks:
  - `/var` ↔ `/private/var` (temp dirs under `$TMPDIR`)
  - `/home` ↔ `/System/Volumes/Data/home` (literal fixture city paths)
- On Linux there are no firmlinks, so the two forms are identical and CI stayed green.
- Comparison sites now use the repo's existing helpers (`assertSameTestPath` / `testutil.AssertSamePath`), which apply the same production normalization on both sides. No product path semantics changed.

Credits: reported by @wbern in #4934.

## Firmlink note for Linux reviewers

macOS exposes some directories as **firmlinks** — OS-level path aliases. `filepath.EvalSymlinks` expands them to the physical spelling (`/private/var/...`, `/System/Volumes/Data/home/...`), while `pathutil.NormalizePathForCompare` (used by production code after #4930) collapses the `/private/{tmp,var}` aliases back to `/tmp`/`/var` and also resolves firmlinks such as `/home`. Asserting with raw string equality therefore fails on darwin even when both sides name the same location.

## Testing

- [x] Reproduced the four listed failures on darwin/arm64 at base `06f8b61`
- [x] After fix: listed tests pass
  - `go test ./cmd/gc/ -count=1 -run '^(TestResolveImportRootPrefersNearestPackUnderCity|TestResolveImportRootFallsBackToStandalonePackDir)$'`
  - `go test ./internal/convergence/ -count=1 -run '^TestResolveEvaluateStep_'`
- [x] `go test ./internal/convergence/ -count=1` — ok
- [x] `go test ./cmd/gc/ -count=1 -run 'TestResolveImportRoot|TestFindNearestImportRoot'` — ok
- [ ] Full `go test ./cmd/gc/ -count=1` hit the package ~10m budget and aborted with parallel-test goroutine dumps (pre-existing package size / timeout issue on this machine; not caused by this test-only change)
- [ ] `make check` (not run; test-only change)

## Checklist

- [x] Linked an issue: #4934
- [x] Added or updated tests for behavior changes (comparison-site only)
- [ ] Updated docs for user-facing changes (n/a)
- [ ] Called out breaking changes or migration notes (n/a — tests only)
