### PR TITLE
feat(beads): make the revision fence portable, reachable, and atomic at close

### DIFF
--- a/cmd/gc/class_store_emit.go
+++ b/cmd/gc/class_store_emit.go
@@ -277,6 +277,20 @@ func (s *emittingClassStore) emitClosed(id string) {
 	s.emit(classStoreEmission{eventType: events.BeadClosed, bead: bead})
 }
 
+// emitClosedBead records bead.closed from the committed row an atomic fenced
+// close returned. That row IS the post-commit state (status closed, metadata
+// merged), so unlike emitClosed it needs no re-read — mirroring emitCreated's
+// "trust what the store returned" fallback. An empty id is the one thing it
+// cannot emit, and a close that returned one is a store bug worth surfacing.
+func (s *emittingClassStore) emitClosedBead(bead beads.Bead) {
+	if strings.TrimSpace(bead.ID) == "" {
+		warnClassStoreEmit(errors.New("bead.closed skipped: the atomic close returned an empty id"))
+		return
+	}
+	bead.Status = beadStatusClosed
+	s.emit(classStoreEmission{eventType: events.BeadClosed, bead: bead})
+}
+
 // closedBefore reports whether a bead was already closed before a write. A read
 // that fails answers "not closed", which is the safe direction: the write's own
 // post-state then decides, and an event that says closed when the bead is closed
@@ -489,6 +503,40 @@ func (s *emittingClassStore) CloseIfMatch(id string, revision int64) error {
 	}
 	s.emitClosed(id)
 	return nil
+}
+
+// CloseWithMetadataIfMatch forwards the atomic fenced terminal close (merge
+// metadata and close in one transaction, guarded by the revision) to the
+// backing capability, so AtomicConditionalCloserFor discovers it on the CLI's
+// wrapped store instead of stopping at this wrapper. It emits bead.closed from
+// the committed row the close returned.
+func (s *emittingClassStore) CloseWithMetadataIfMatch(id string, revision int64, metadata map[string]string) (beads.Bead, error) {
+	closer, ok := beads.AtomicConditionalCloserFor(s.Store)
+	if !ok {
+		return beads.Bead{}, beads.ErrConditionalWriteUnsupported
+	}
+	closed, err := closer.CloseWithMetadataIfMatch(id, revision, metadata)
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	s.emitClosedBead(closed)
+	return closed, nil
+}
+
+// AtomicConditionalCloserHandle keeps AtomicConditionalCloserFor honest over
+// this wrapper. TestEmittingClassStoreKeepsEveryEngineCapability forces the
+// wrapper to carry CloseWithMetadataIfMatch structurally for every engine, so a
+// bare type assertion would advertise the capability even over a backing (for
+// example the sqlite CLI engine) that cannot honor it — and that discovery is
+// contractually a hard capability gate, not a rollout seam. Consulted first by
+// AtomicConditionalCloserFor, this answers yes only when the resolved backing
+// truly provides the atomic close, and returns the emitting wrapper (not the
+// raw backing) so the discovered closer still emits bead.closed.
+func (s *emittingClassStore) AtomicConditionalCloserHandle() (beads.AtomicConditionalCloser, bool) {
+	if _, ok := beads.AtomicConditionalCloserFor(s.Store); !ok {
+		return nil, false
+	}
+	return s, true
 }
 
 func (s *emittingClassStore) DeleteIfMatch(id string, revision int64) error {

--- a/cmd/gc/class_store_emit_test.go
+++ b/cmd/gc/class_store_emit_test.go
@@ -223,6 +223,65 @@ func closeThroughClassResolver(resolve func(*storageRoutes, beads.Store, *config
 	}
 }
 
+// AtomicConditionalCloserFor is a hard capability gate, not a rollout seam. The
+// emitting class-store wrapper carries CloseWithMetadataIfMatch structurally for
+// every engine — TestEmittingClassStoreKeepsEveryEngineCapability forces that,
+// because *NativeDoltStore has it — so a bare type assertion would advertise
+// atomic close even over a backing (the sqlite CLI engine) that cannot honor it.
+// The wrapper's AtomicConditionalCloserHandle keeps discovery honest: yes only
+// when the resolved backing truly provides atomic close, and the closer it hands
+// back is the emitting wrapper itself, so a DISCOVERED atomic close still appends
+// bead.closed rather than silently going dark on the binding.
+func TestEmittingClassStoreAtomicCloseHonorsBackingCapability(t *testing.T) {
+	t.Run("an atomic backing yields an emitting closer that appends bead.closed", func(t *testing.T) {
+		cityPath := t.TempDir()
+		leaf := beads.NewAtomicCloseMemStore()
+		wrapped := splitClassRoutes(leaf).withCLIEmission(cityPath).stores[coordclass.ClassGraph]
+
+		closer, ok := beads.AtomicConditionalCloserFor(wrapped)
+		if !ok {
+			t.Fatal("AtomicConditionalCloserFor(wrapper over an atomic backing) = unavailable, want the emitting wrapper's closer")
+		}
+
+		bead := seedClassBead(t, leaf, "atomic-close")
+		if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 0 {
+			t.Fatalf("seeding the leaf emitted %d bead event(s); the fixture must be silent", len(got))
+		}
+
+		closed, err := closer.CloseWithMetadataIfMatch(bead.ID, bead.Revision, map[string]string{"state": "drained"})
+		if err != nil {
+			t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+		}
+		if !strings.EqualFold(closed.Status, "closed") || closed.Metadata["state"] != "drained" {
+			t.Fatalf("returned bead = %#v, want a closed row carrying the merged metadata", closed)
+		}
+
+		got := beadEvents(readCityJournal(t, cityPath))
+		if len(got) != 1 {
+			t.Fatalf("a discovered atomic close appended %d bead event(s), want exactly 1: %s", len(got), eventSummary(got))
+		}
+		if got[0].Type != events.BeadClosed || got[0].Subject != bead.ID {
+			t.Errorf("event = %q on %q, want %q on %q", got[0].Type, got[0].Subject, events.BeadClosed, bead.ID)
+		}
+		snapshot, ok := beads.DecodeBeadEventPayload(got[0].Payload)
+		if !ok || !strings.EqualFold(snapshot.Status, "closed") {
+			t.Errorf("payload = %s, want a decodable closed snapshot", got[0].Payload)
+		}
+	})
+
+	t.Run("a non-atomic backing refuses discovery even though the wrapper carries the method", func(t *testing.T) {
+		cityPath := t.TempDir()
+		wrapped := splitClassRoutes(beads.NewMemStore()).withCLIEmission(cityPath).stores[coordclass.ClassGraph]
+
+		if _, ok := any(wrapped).(beads.AtomicConditionalCloser); !ok {
+			t.Fatal("the emitting wrapper must carry CloseWithMetadataIfMatch structurally; the engine-parity gate requires it")
+		}
+		if closer, ok := beads.AtomicConditionalCloserFor(wrapped); ok || closer != nil {
+			t.Fatalf("AtomicConditionalCloserFor(wrapper over a non-atomic backing) = (%v, %v), want (nil, false): the seam is a hard capability gate, and a bare type assertion would answer yes here", closer, ok)
+		}
+	})
+}
+
 // GATE 2 (the control). The CONTROLLER's routes — the ones openStorageRoutes
 // builds, which never carry an emit target — stay silent under a
 // reconcile-shaped absorption, even when the resolver is handed a live
@@ -682,6 +741,73 @@ func TestClassStoreEmissionCoversConditionalRelease(t *testing.T) {
 	}
 	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 1 {
 		t.Fatalf("a release that did not fire appended a row: %s", eventSummary(got))
+	}
+}
+
+// A landed atomic fenced close — merge metadata and close in one revision-guarded
+// transaction — is a terminal transition a fold has to see. The capability is
+// discovered through AtomicConditionalCloserFor, and it must resolve to the
+// EMITTING wrapper: a bare backing would close silently and leave the run view
+// rendering the step running forever, the exact silence this seam ends.
+func TestClassStoreEmissionCoversAtomicMetadataClose(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewAtomicCloseMemStore()
+	store := resolveGraphStore(splitClassRoutes(leaf).withCLIEmission(cityPath), beads.NewMemStore(), nil, cityPath, nil)
+
+	bead := seedClassBead(t, leaf, "finalize")
+	seeded, err := leaf.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("reading the seeded revision: %v", err)
+	}
+
+	closer, ok := beads.AtomicConditionalCloserFor(store)
+	if !ok {
+		t.Fatalf("AtomicConditionalCloserFor did not discover the capability on the emitting wrapper (%T)", store)
+	}
+	closed, err := closer.CloseWithMetadataIfMatch(bead.ID, seeded.Revision, map[string]string{"gc.outcome": "pass"})
+	if err != nil {
+		t.Fatalf("atomic fenced close: %v", err)
+	}
+	if !beadStatusIsClosed(closed.Status) {
+		t.Errorf("returned bead status = %q, want closed", closed.Status)
+	}
+	if closed.Metadata["gc.outcome"] != "pass" {
+		t.Errorf("returned bead metadata = %v, want the merged gc.outcome=pass", closed.Metadata)
+	}
+
+	got := beadEvents(readCityJournal(t, cityPath))
+	if len(got) != 1 || got[0].Type != events.BeadClosed || got[0].Subject != bead.ID {
+		t.Fatalf("got %s, want one bead.closed for %s", eventSummary(got), bead.ID)
+	}
+	// The committed row IS the payload, emitted without a re-read, so it carries
+	// the merged metadata and the closed status the transaction established.
+	snapshot, ok := beads.DecodeBeadEventPayload(got[0].Payload)
+	if !ok || snapshot.Metadata["gc.outcome"] != "pass" || !beadStatusIsClosed(snapshot.Status) {
+		t.Errorf("bead.closed payload = %s, want the committed closed row with gc.outcome=pass", got[0].Payload)
+	}
+
+	// A fence that no longer matches commits nothing, and must say nothing: the
+	// first close bumped the revision, so replaying the stale one is refused.
+	if _, err := closer.CloseWithMetadataIfMatch(bead.ID, seeded.Revision, map[string]string{"gc.outcome": "fail"}); err == nil {
+		t.Fatal("a stale-revision fenced close reported success")
+	}
+	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 1 {
+		t.Fatalf("a fenced close that did not fire appended a row: %s", eventSummary(got))
+	}
+}
+
+// Atomic close is a hard capability gate, not a rollout seam. The wrapper is
+// forced to carry CloseWithMetadataIfMatch structurally for every engine
+// (TestEmittingClassStoreKeepsEveryEngineCapability), so a bare type assertion
+// would advertise the capability even over a backing that cannot honor the
+// all-or-nothing close. AtomicConditionalCloserFor must consult the resolved
+// backing and answer no when it lacks the atomic terminal write.
+func TestEmittingClassStoreRefusesAtomicCloseOverANonAtomicBacking(t *testing.T) {
+	cityPath := t.TempDir()
+	// Plain MemStore deliberately does not expose the atomic terminal close.
+	store := resolveGraphStore(splitClassRoutes(beads.NewMemStore()).withCLIEmission(cityPath), beads.NewMemStore(), nil, cityPath, nil)
+	if _, ok := beads.AtomicConditionalCloserFor(store); ok {
+		t.Fatal("the emitting wrapper advertised atomic close over a backing that cannot honor it")
 	}
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -2633,9 +2634,12 @@ prefix = "fe"
 	if err != nil {
 		t.Fatalf("read SQL log: %v", err)
 	}
-	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'fe-abc' AND status = 'in_progress' AND assignee = 'worker-1'"
-	if strings.TrimSpace(string(query)) != wantQuery {
-		t.Fatalf("SQL query = %q, want %q", strings.TrimSpace(string(query)), wantQuery)
+	// The release mints a fresh revision so the pre-release token is stale, so
+	// the token itself is not pinnable — everything around it is.
+	gotQuery := strings.TrimSpace(string(query))
+	wantQuery := regexp.MustCompile(`^UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = -?\d+ WHERE id = 'fe-abc' AND status = 'in_progress' AND assignee = 'worker-1'$`)
+	if !wantQuery.MatchString(gotQuery) {
+		t.Fatalf("SQL query = %q, want match for %s", gotQuery, wantQuery)
 	}
 }
 

--- a/internal/beads/atomic_close_memstore.go
+++ b/internal/beads/atomic_close_memstore.go
@@ -1,0 +1,53 @@
+package beads
+
+import (
+	"fmt"
+	"time"
+)
+
+// atomicCloseMemStore is an opt-in test store for terminal paths that require
+// an atomic metadata-and-close transition. Plain MemStore intentionally does
+// not expose this narrower capability.
+type atomicCloseMemStore struct {
+	*MemStore
+}
+
+var _ AtomicConditionalCloser = (*atomicCloseMemStore)(nil)
+
+// NewAtomicCloseMemStore returns an in-memory Store with atomic terminal close
+// support for synthetic workloads and deterministic tests.
+func NewAtomicCloseMemStore() Store {
+	return &atomicCloseMemStore{MemStore: NewMemStore()}
+}
+
+// CloseWithMetadataIfMatch merges metadata and closes one open bead while its
+// revision remains expectedRevision. Both changes share one MemStore lock and
+// one fresh revision.
+func (s *atomicCloseMemStore) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) (Bead, error) {
+	if s == nil || s.MemStore == nil {
+		return Bead{}, fmt.Errorf("atomic closing bead %q: store is nil", id)
+	}
+	m := s.MemStore
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.DisableConditionalWrites {
+		return Bead{}, ErrConditionalWriteUnsupported
+	}
+	i := m.indexOfLocked(id)
+	if i < 0 {
+		return Bead{}, fmt.Errorf("atomic closing bead %q: %w", id, ErrNotFound)
+	}
+	if m.beads[i].Revision != expectedRevision {
+		return Bead{}, &PreconditionFailedError{ID: id, Expected: expectedRevision, Current: m.beads[i].Revision}
+	}
+	if m.beads[i].Metadata == nil {
+		m.beads[i].Metadata = make(StringMap, len(metadata))
+	}
+	for key, value := range metadata {
+		m.beads[i].Metadata[key] = value
+	}
+	m.beads[i].Status = "closed"
+	m.beads[i].UpdatedAt = time.Now()
+	m.beads[i].Revision++
+	return cloneBead(m.beads[i]), nil
+}

--- a/internal/beads/atomic_close_memstore_test.go
+++ b/internal/beads/atomic_close_memstore_test.go
@@ -1,0 +1,119 @@
+package beads
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestAtomicCloseMemStoreIsOptIn(t *testing.T) {
+	if _, ok := AtomicConditionalCloserFor(NewMemStore()); ok {
+		t.Fatal("plain MemStore unexpectedly exposes atomic terminal close")
+	}
+	store := NewAtomicCloseMemStore()
+	closer, ok := AtomicConditionalCloserFor(store)
+	if !ok {
+		t.Fatal("opt-in atomic MemStore does not expose atomic terminal close")
+	}
+	created, err := store.Create(Bead{Title: "atomic close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	closed, err := closer.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{
+		"state": "drained",
+	})
+	if err != nil {
+		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if closed.Status != "closed" || closed.Revision != created.Revision+1 || closed.Metadata["state"] != "drained" {
+		t.Fatalf("closed bead = %#v, want one fresh terminal revision", closed)
+	}
+	closed.Metadata["state"] = "corrupted caller copy"
+	fresh, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fresh.Metadata["state"] != "drained" {
+		t.Fatalf("returned bead aliases store metadata: %#v", fresh)
+	}
+}
+
+func TestAtomicCloseMemStoreRejectsStaleRevisionWithoutTerminalMutation(t *testing.T) {
+	store := NewAtomicCloseMemStore()
+	closer, ok := AtomicConditionalCloserFor(store)
+	if !ok {
+		t.Fatal("atomic closer unavailable")
+	}
+	created, err := store.Create(Bead{Title: "stale atomic close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := closer.CloseWithMetadataIfMatch(created.ID, created.Revision-1, map[string]string{"state": "drained"}); !IsPreconditionFailed(err) {
+		t.Fatalf("stale close error = %v, want precondition failure", err)
+	}
+	fresh, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fresh.Status != "open" || fresh.Revision != created.Revision || fresh.Metadata["state"] != "" {
+		t.Fatalf("stale close mutated row: %#v", fresh)
+	}
+}
+
+func TestAtomicCloseMemStoreHasOneSameRevisionWinner(t *testing.T) {
+	store := NewAtomicCloseMemStore()
+	closer, ok := AtomicConditionalCloserFor(store)
+	if !ok {
+		t.Fatal("atomic closer unavailable")
+	}
+	created, err := store.Create(Bead{Title: "racing atomic close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	type result struct {
+		bead Bead
+		err  error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for _, winner := range []string{"first", "second"} {
+		winner := winner
+		go func() {
+			ready.Done()
+			<-start
+			bead, closeErr := closer.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{
+				"state": "drained", "winner": winner,
+			})
+			results <- result{bead: bead, err: closeErr}
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	wins, losses := 0, 0
+	for range 2 {
+		result := <-results
+		if result.err == nil {
+			wins++
+			if result.bead.Status != "closed" || result.bead.Metadata["state"] != "drained" {
+				t.Fatalf("winner returned non-terminal row: %#v", result.bead)
+			}
+			continue
+		}
+		if !IsPreconditionFailed(result.err) {
+			t.Fatalf("losing close error = %v, want precondition failure", result.err)
+		}
+		losses++
+	}
+	if wins != 1 || losses != 1 {
+		t.Fatalf("same-revision close winners/losses = %d/%d, want 1/1", wins, losses)
+	}
+	fresh, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get final row: %v", err)
+	}
+	if fresh.Status != "closed" || fresh.Metadata["state"] != "drained" || fresh.Metadata["winner"] == "" || fresh.Revision != created.Revision+1 {
+		t.Fatalf("final row = %#v, want one atomic terminal winner", fresh)
+	}
+}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -768,6 +768,32 @@ func (m *StringMap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// bdRevision is bd's signed optimistic-concurrency token at the JSON edge.
+// Current bd emits a decimal string; older supported versions emitted a JSON
+// integer. Both forms parse directly to int64 without passing through float64.
+type bdRevision int64
+
+// UnmarshalJSON accepts current decimal-string and legacy integer revisions.
+func (r *bdRevision) UnmarshalJSON(data []byte) error {
+	token := bytes.TrimSpace(data)
+	if len(token) == 0 {
+		return errors.New("bd revision is empty")
+	}
+
+	decimal := string(token)
+	if token[0] == '"' {
+		if err := json.Unmarshal(token, &decimal); err != nil {
+			return fmt.Errorf("decoding bd revision string: %w", err)
+		}
+	}
+	value, err := strconv.ParseInt(decimal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("decoding bd revision %q: %w", decimal, err)
+	}
+	*r = bdRevision(value)
+	return nil
+}
+
 // bdIssue is the JSON shape returned by bd CLI commands. We decode only the
 // fields Gas City cares about; all others are silently ignored.
 type bdIssue struct {
@@ -798,14 +824,9 @@ type bdIssue struct {
 	DeferUntil      *time.Time   `json:"defer_until,omitempty"`
 	IsBlocked       optionalBool `json:"is_blocked,omitempty"`
 	// Revision carries bd's optimistic-concurrency token for ConditionalWriter.
-	// Pre-#4682 bd omits it, so it decodes to 0; toBead stamps it onto the
-	// otherwise json:"-" Bead.Revision field. The "revision" key is provisional:
-	// bd #4682 (which adds the column and --if-revision) is unlanded, so the
-	// exact wire key is unconfirmed. The integration conformance row against a
-	// #4682-capable bd is the guard — an absent key is indistinguishable from
-	// legacy bd here (both decode to 0), so a key-name mismatch would fail there,
-	// not silently.
-	Revision int64 `json:"revision,omitempty"`
+	// Older bd versions omit it, so it decodes to 0; toBead stamps it onto the
+	// otherwise json:"-" Bead.Revision field.
+	Revision bdRevision `json:"revision,omitempty"`
 }
 
 type bdIssueDep struct {
@@ -958,7 +979,7 @@ func (b *bdIssue) toBead() Bead {
 		NoHistory:    b.NoHistory,
 		DeferUntil:   cloneTimePtr(b.DeferUntil),
 		IsBlocked:    b.IsBlocked.ptr(),
-		Revision:     b.Revision,
+		Revision:     int64(b.Revision),
 	}
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -3,11 +3,14 @@ package beads
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1368,15 +1371,34 @@ func (s *BdStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
 		}
 		s.latchConditionalReleaseUnsupported()
 	}
-	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
+	// The raw-SQL fallback writes the row itself, so it also has to mint the
+	// fresh revision bd's verb path mints for us: a release that left the
+	// pre-release token in place would keep a stale fence current.
+	revision, err := newRevisionToken()
+	if err != nil {
+		return false, fmt.Errorf("bd release-if-current: minting revision: %w", err)
+	}
+	legacyQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
 		" WHERE id = " + bdSQLStringLiteral(id) +
 		" AND status = 'in_progress'" +
 		" AND assignee = " + bdSQLStringLiteral(expectedAssignee)
-	out, err := s.runBDTransientWriteOutput("sql", "--json", query)
-	if err != nil {
+	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = " +
+		strconv.FormatInt(revision, 10) +
+		" WHERE id = " + bdSQLStringLiteral(id) +
+		" AND status = 'in_progress'" +
+		" AND assignee = " + bdSQLStringLiteral(expectedAssignee)
+	args := s.bdTransientWriteArgs([]string{"sql", "--json", query})
+	out, err := s.runner(s.dir, "bd", args...)
+	if err != nil && !isBdTransientWriteError(err) {
 		if isBdSQLUnsupportedInEmbeddedMode(err) {
-			return s.releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee)
+			return s.releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee, revision)
 		}
+		if isMissingRevisionColumn(err) {
+			args = s.bdTransientWriteArgs([]string{"sql", "--json", legacyQuery})
+			out, err = s.runner(s.dir, "bd", args...)
+		}
+	}
+	if err != nil {
 		return false, fmt.Errorf("bd release-if-current: %w", err)
 	}
 	var result struct {
@@ -1388,7 +1410,7 @@ func (s *BdStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
 	return result.RowsAffected > 0, nil
 }
 
-func (s *BdStore) releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee string) (bool, error) {
+func (s *BdStore) releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee string, revision int64) (bool, error) {
 	doltDir, ok, err := s.embeddedDoltDir()
 	if err != nil {
 		return false, fmt.Errorf("bd release-if-current embedded fallback: %w", err)
@@ -1396,20 +1418,60 @@ func (s *BdStore) releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee string
 	if !ok {
 		return false, fmt.Errorf("bd release-if-current embedded fallback: %w", ErrConditionalReleaseUnsupported)
 	}
-	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
+	legacyQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
+		" WHERE id = " + bdSQLStringLiteral(id) +
+		" AND status = 'in_progress'" +
+		" AND assignee = " + bdSQLStringLiteral(expectedAssignee) +
+		"; SELECT ROW_COUNT() AS rows_affected"
+	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = " +
+		strconv.FormatInt(revision, 10) +
 		" WHERE id = " + bdSQLStringLiteral(id) +
 		" AND status = 'in_progress'" +
 		" AND assignee = " + bdSQLStringLiteral(expectedAssignee) +
 		"; SELECT ROW_COUNT() AS rows_affected"
 	out, err := s.runner(doltDir, "dolt", "sql", "-r", "json", "-q", query)
 	if err != nil {
-		return false, fmt.Errorf("bd release-if-current embedded fallback: dolt sql: %w", err)
+		if isBdTransientWriteError(err) || !isMissingRevisionColumn(err) {
+			return false, fmt.Errorf("bd release-if-current embedded fallback: dolt sql: %w", err)
+		}
+		out, err = s.runner(doltDir, "dolt", "sql", "-r", "json", "-q", legacyQuery)
+		if err != nil {
+			return false, fmt.Errorf("bd release-if-current embedded fallback: dolt sql: %w", err)
+		}
 	}
 	rowsAffected, err := parseDoltRowsAffected(out)
 	if err != nil {
 		return false, fmt.Errorf("bd release-if-current embedded fallback: parsing SQL result: %w", err)
 	}
 	return rowsAffected > 0, nil
+}
+
+func newRevisionToken() (int64, error) {
+	for {
+		var data [8]byte
+		if _, err := rand.Read(data[:]); err != nil {
+			return 0, err
+		}
+		revision := int64(binary.BigEndian.Uint64(data[:]) & math.MaxInt64)
+		if revision != 0 {
+			return revision, nil
+		}
+	}
+}
+
+func isMissingRevisionColumn(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "unknown column 'revision'") ||
+		strings.Contains(message, "unknown column `revision`") ||
+		strings.Contains(message, `unknown column "revision"`) ||
+		strings.Contains(message, "no such column: revision") ||
+		strings.Contains(message, `column "revision" not found`) ||
+		strings.Contains(message, "column 'revision' not found") ||
+		strings.Contains(message, "column `revision` not found") ||
+		strings.Contains(message, "column not found: revision")
 }
 
 func (s *BdStore) embeddedDoltDir() (string, bool, error) {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -779,6 +779,14 @@ func (r *bdRevision) UnmarshalJSON(data []byte) error {
 	if len(token) == 0 {
 		return errors.New("bd revision is empty")
 	}
+	// A JSON null revision means the row has no recorded token yet (legacy rows,
+	// or a backend that has not minted one). Decode it as the zero token — the
+	// same "no revision" sentinel a never-mutated bead carries — rather than
+	// failing the whole issue decode on strconv.ParseInt("null").
+	if string(token) == "null" {
+		*r = 0
+		return nil
+	}
 
 	decimal := string(token)
 	if token[0] == '"' {
@@ -1408,15 +1416,20 @@ func (s *BdStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
 		" WHERE id = " + bdSQLStringLiteral(id) +
 		" AND status = 'in_progress'" +
 		" AND assignee = " + bdSQLStringLiteral(expectedAssignee)
-	args := s.bdTransientWriteArgs([]string{"sql", "--json", query})
-	out, err := s.runner(s.dir, "bd", args...)
-	if err != nil && !isBdTransientWriteError(err) {
+	// Retry ordinary serialization conflicts, but never replay an ambiguous
+	// write: a revision-aware release mints a fresh token and matches on
+	// status+assignee, so replaying one that may already have committed could
+	// stomp a same-assignee reclaim that landed in between — reinstating the
+	// release token over the reclaim's. runBDTransientReleaseOutput draws that
+	// line; a single-attempt raw runner would instead surface every transient
+	// blip as a spurious release failure.
+	out, err := s.runBDTransientReleaseOutput("sql", "--json", query)
+	if err != nil {
 		if isBdSQLUnsupportedInEmbeddedMode(err) {
 			return s.releaseIfCurrentViaEmbeddedDoltSQL(id, expectedAssignee, revision)
 		}
 		if isMissingRevisionColumn(err) {
-			args = s.bdTransientWriteArgs([]string{"sql", "--json", legacyQuery})
-			out, err = s.runner(s.dir, "bd", args...)
+			out, err = s.runBDTransientReleaseOutput("sql", "--json", legacyQuery)
 		}
 	}
 	if err != nil {
@@ -2175,6 +2188,19 @@ func (s *BdStore) runBDTransientCreateOutput(hasStableID bool, args ...string) (
 			return false
 		}
 		return hasStableID || !isBdAmbiguousWriteError(err)
+	}, args...)
+}
+
+// runBDTransientReleaseOutput runs a revision-aware release UPDATE, retrying
+// ordinary serialization conflicts but never replaying an ambiguous write.
+// Unlike a create there is no stable id to make the write idempotent: the
+// release matches on status+assignee and installs a fresh token, so replaying
+// one that may already have committed could stomp a same-assignee reclaim that
+// landed in between. Same ambiguity guard as an id-less create, named for the
+// release path it protects.
+func (s *BdStore) runBDTransientReleaseOutput(args ...string) ([]byte, error) {
+	return s.runBDTransientWriteOutputWhen(func(err error) bool {
+		return isBdTransientWriteError(err) && !isBdAmbiguousWriteError(err)
 	}, args...)
 }
 

--- a/internal/beads/bdstore_conditional.go
+++ b/internal/beads/bdstore_conditional.go
@@ -119,11 +119,11 @@ func (s *BdStore) markConditionalWritesUnsupported() {
 }
 
 // Machine body codes bd emits (or, per beads #4682, will emit) for conditional
-// writes. The codes are provisional until #4682 lands; the //go:build integration
-// conformance row against a #4682-capable bd is the authoritative guard.
+// writes. The //go:build integration conformance row against a CAS-capable bd
+// is the authoritative guard.
 const (
-	bdConditionalCodePreconditionFailed = "precondition-failed"
-	bdConditionalCodeUnsupported        = "conditional-write-unsupported"
+	bdConditionalCodePreconditionFailed = "precondition_failed"
+	bdConditionalCodeUnsupported        = "conditional_write_unsupported"
 )
 
 // bdConditionalErrorBody is the machine JSON bd attaches to a failed conditional
@@ -323,7 +323,6 @@ func isBdConditionalPrecondition(body bdConditionalErrorBody, msg string) bool {
 	}
 	lower := strings.ToLower(msg)
 	return strings.Contains(lower, "precondition failed") ||
-		strings.Contains(lower, "precondition-failed") ||
 		strings.Contains(lower, "revision mismatch")
 }
 
@@ -389,8 +388,8 @@ func conditionalWriteBackoff(attempt int) time.Duration {
 // ErrConditionalWriteUnsupported rather than falling through to an
 // unconditional write.
 func (s *BdStore) UpdateIfMatch(id string, expectedRevision int64, opts UpdateOpts) error {
-	if isEmptyUpdateOpts(opts) {
-		return fmt.Errorf("conditional update %s: %w", id, ErrEmptyConditionalUpdate)
+	if err := validateConditionalUpdateOpts(opts); err != nil {
+		return fmt.Errorf("conditional update %s: %w", id, err)
 	}
 	if capable, _ := s.conditionalWritesCapable(); !capable {
 		return ErrConditionalWriteUnsupported
@@ -440,7 +439,7 @@ func (s *BdStore) DeleteIfMatch(id string, expectedRevision int64) error {
 //     would misreport a landed write as a precondition.
 //   - SERIALIZATION-class transient (transient AND not ambiguous: the txn rolled
 //     back) → re-read the revision; if it moved, the fence is permanently stale
-//     (revisions are monotonic and never reused) so return a precondition
+//     (the observed token is no longer current) so return a precondition
 //     immediately rather than replaying a doomed fence; otherwise back off and
 //     retry the SAME argv with the SAME expectedRevision. Re-fencing with a
 //     freshly-read revision would silently downgrade CAS to last-writer-wins.

--- a/internal/beads/bdstore_conditional_integration_test.go
+++ b/internal/beads/bdstore_conditional_integration_test.go
@@ -84,6 +84,7 @@ func TestBdStoreConditionalWriterConformance(t *testing.T) {
 			},
 			beadstest.ConditionalWriterOptions{
 				RowBackedMutationFlavors: true,
+				RestrictedUpdateFields:   true,
 				// bd's precondition body carries current_revision (#4682);
 				// asserting Current here is part of the wire-key guard.
 				SuppliesCurrent: true,

--- a/internal/beads/bdstore_conditional_integration_test.go
+++ b/internal/beads/bdstore_conditional_integration_test.go
@@ -14,8 +14,8 @@ import (
 
 // TestBdStoreConditionalWriterConformance is the S2-T12 integration row: the
 // ConditionalWriter conformance suite over a REAL bd binary. It is the
-// authoritative guard for the provisional conditional-write machine codes
-// ("precondition-failed" / "conditional-write-unsupported") and the
+// authoritative guard for the canonical conditional-write machine codes
+// ("precondition_failed" / "conditional_write_unsupported") and the
 // "revision" wire key, all assumed ahead of beads#4682 landing — a rename in
 // the shipped bd fails here loudly instead of drifting silently
 // (bdstore_conditional.go's classifier note points at this row).
@@ -83,6 +83,7 @@ func TestBdStoreConditionalWriterConformance(t *testing.T) {
 				return store
 			},
 			beadstest.ConditionalWriterOptions{
+				RowBackedMutationFlavors: true,
 				// bd's precondition body carries current_revision (#4682);
 				// asserting Current here is part of the wire-key guard.
 				SuppliesCurrent: true,

--- a/internal/beads/bdstore_conditional_internal_test.go
+++ b/internal/beads/bdstore_conditional_internal_test.go
@@ -31,19 +31,19 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 	})
 
 	t.Run("precondition from flat body", func(t *testing.T) {
-		out := []byte(`{"error":"revision precondition failed","code":"precondition-failed","expected_revision":5,"current_revision":8}`)
+		out := []byte(`{"error":"revision precondition failed","code":"precondition_failed","expected_revision":5,"current_revision":8}`)
 		err := errors.New("exit status 1")
 		assertPrecondition(t, classifyConditionalWriteResult(out, err), 5, 8)
 	})
 
 	t.Run("precondition from data-wrapped envelope", func(t *testing.T) {
-		out := []byte(`{"schema_version":6,"data":{"code":"precondition-failed","expected_revision":2,"current_revision":9}}`)
+		out := []byte(`{"schema_version":6,"data":{"code":"precondition_failed","expected_revision":2,"current_revision":9}}`)
 		err := errors.New("exit status 1")
 		assertPrecondition(t, classifyConditionalWriteResult(out, err), 2, 9)
 	})
 
 	t.Run("precondition body wrapped in log noise", func(t *testing.T) {
-		out := []byte("bd: writing to dolt\n{\"code\":\"precondition-failed\",\"expected_revision\":1,\"current_revision\":4}\n")
+		out := []byte("bd: writing to dolt\n{\"code\":\"precondition_failed\",\"expected_revision\":1,\"current_revision\":4}\n")
 		err := errors.New("exit status 1")
 		assertPrecondition(t, classifyConditionalWriteResult(out, err), 1, 4)
 	})
@@ -51,7 +51,7 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 	t.Run("precondition recovered from err string when stdout empty", func(t *testing.T) {
 		// bd wrote the JSON envelope to stderr, so classifyBDExecResult folded it
 		// into err.Error() and stdout is empty.
-		err := errors.New(`exit status 1: {"code":"precondition-failed","expected_revision":3,"current_revision":7}`)
+		err := errors.New(`exit status 1: {"code":"precondition_failed","expected_revision":3,"current_revision":7}`)
 		assertPrecondition(t, classifyConditionalWriteResult(nil, err), 3, 7)
 	})
 
@@ -79,11 +79,11 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 	t.Run("precondition inferred from non-JSON message forms", func(t *testing.T) {
 		// The message-fallback substrings (no parseable body): each must classify
 		// as a zero-valued precondition so a caller still re-reads rather than
-		// hard-failing. Guards the "revision mismatch" and hyphenated
-		// "precondition-failed" message forms bd might emit outside a JSON envelope.
+		// hard-failing. Guards the human "revision mismatch" and
+		// "precondition failed" message forms bd might emit outside a JSON envelope.
 		for _, msg := range []string{
 			"exit status 1: revision mismatch on ga-1",
-			"exit status 1: error: precondition-failed for ga-1 (expected 3, got 5)",
+			"exit status 1: error: precondition failed for ga-1 (expected 3, got 5)",
 		} {
 			got := classifyConditionalWriteResult(nil, errors.New(msg))
 			if !IsPreconditionFailed(got) {
@@ -93,7 +93,7 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 	})
 
 	t.Run("unsupported from machine body code latches", func(t *testing.T) {
-		out := []byte(`{"error":"conditional writes not supported","code":"conditional-write-unsupported"}`)
+		out := []byte(`{"error":"conditional writes not supported","code":"conditional_write_unsupported"}`)
 		err := errors.New("exit status 1")
 		if got := classifyConditionalWriteResult(out, err); !IsConditionalWriteUnsupported(got) {
 			t.Fatalf("classify = %v, want ErrConditionalWriteUnsupported", got)
@@ -225,12 +225,12 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 		// coded precondition body folded into err.Error() from stderr. The source
 		// carrying a discriminator must win.
 		out := []byte(`{"error":"progress: 1 of 2 committed"}`)
-		err := errors.New(`exit status 1: {"code":"precondition-failed","expected_revision":3,"current_revision":9}`)
+		err := errors.New(`exit status 1: {"code":"precondition_failed","expected_revision":3,"current_revision":9}`)
 		assertPrecondition(t, classifyConditionalWriteResult(out, err), 3, 9)
 	})
 
 	t.Run("precondition body with trailing log noise still parses", func(t *testing.T) {
-		out := []byte("{\"code\":\"precondition-failed\",\"expected_revision\":6,\"current_revision\":6}\nWARN: dolt reconnected\n")
+		out := []byte("{\"code\":\"precondition_failed\",\"expected_revision\":6,\"current_revision\":6}\nWARN: dolt reconnected\n")
 		err := errors.New("exit status 1")
 		assertPrecondition(t, classifyConditionalWriteResult(out, err), 6, 6)
 	})
@@ -238,7 +238,7 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 	t.Run("precondition body behind a bracketed log prefix parses", func(t *testing.T) {
 		// extractJSON stops at the first '{' OR '[': a "[WARN]" prefix would make a
 		// naive parse reject the object. The multi-object scan must skip it.
-		out := []byte("[WARN] dolt reconnect\n{\"code\":\"precondition-failed\",\"expected_revision\":3,\"current_revision\":9}")
+		out := []byte("[WARN] dolt reconnect\n{\"code\":\"precondition_failed\",\"expected_revision\":3,\"current_revision\":9}")
 		err := errors.New("exit status 1")
 		assertPrecondition(t, classifyConditionalWriteResult(out, err), 3, 9)
 	})
@@ -246,7 +246,7 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 	t.Run("precondition body after a leading JSON log line parses", func(t *testing.T) {
 		// A JSON log line precedes the real envelope; the first-object-only parse
 		// would read the log line (no discriminator) and miss the body.
-		out := []byte("{\"level\":\"info\",\"msg\":\"connecting\"}\n{\"code\":\"precondition-failed\",\"expected_revision\":4,\"current_revision\":5}")
+		out := []byte("{\"level\":\"info\",\"msg\":\"connecting\"}\n{\"code\":\"precondition_failed\",\"expected_revision\":4,\"current_revision\":5}")
 		err := errors.New("exit status 1")
 		assertPrecondition(t, classifyConditionalWriteResult(out, err), 4, 5)
 	})
@@ -256,7 +256,7 @@ func TestClassifyConditionalWriteResult(t *testing.T) {
 		// body rides err.Error(). The discriminator-preferring parse must pick it,
 		// exercising the Code arm of hasDiscriminator alone.
 		out := []byte(`{"error":"progress: 1 of 2 committed"}`)
-		err := errors.New(`exit status 1: {"code":"conditional-write-unsupported"}`)
+		err := errors.New(`exit status 1: {"code":"conditional_write_unsupported"}`)
 		if got := classifyConditionalWriteResult(out, err); !IsConditionalWriteUnsupported(got) {
 			t.Fatalf("classify = %v, want ErrConditionalWriteUnsupported from the err-string body", got)
 		}
@@ -659,7 +659,7 @@ func TestUpdateIfMatchPreconditionOverridesExpected(t *testing.T) {
 	// harness asserts this), while Current stays from the body.
 	w := &scriptedBd{id: "ga-1", revision: 5}
 	w.writeHook = func(_ *scriptedBd, _ string, _ int64) ([]byte, error, bool) {
-		return []byte(`{"code":"precondition-failed","expected_revision":4242,"current_revision":5}`),
+		return []byte(`{"code":"precondition_failed","expected_revision":4242,"current_revision":5}`),
 			errors.New("exit status 1"), true
 	}
 	s := NewBdStore("/city", w.runner)
@@ -1295,7 +1295,7 @@ func TestCompareAndSetMetadataKeyExhaustionFinalReadDetectsValueLoss(t *testing.
 		if attempts == casEmulationMaxAttempts {
 			w.metadata["k"] = "competitor"
 		}
-		return []byte(`{"error":"revision precondition failed","code":"precondition-failed"}`), errors.New("exit status 1"), true
+		return []byte(`{"error":"revision precondition failed","code":"precondition_failed"}`), errors.New("exit status 1"), true
 	}
 	s := NewBdStore("/city", w.runner)
 
@@ -1319,7 +1319,7 @@ func TestCompareAndSetMetadataKeyExhaustionWithoutValueLossStaysTyped(t *testing
 	w := &scriptedBd{id: "ga-1", revision: 1, metadata: map[string]string{}}
 	w.writeHook = func(w *scriptedBd, _ string, _ int64) ([]byte, error, bool) {
 		w.revision++
-		return []byte(`{"error":"revision precondition failed","code":"precondition-failed"}`), errors.New("exit status 1"), true
+		return []byte(`{"error":"revision precondition failed","code":"precondition_failed"}`), errors.New("exit status 1"), true
 	}
 	s := NewBdStore("/city", w.runner)
 

--- a/internal/beads/bdstore_conditional_internal_test.go
+++ b/internal/beads/bdstore_conditional_internal_test.go
@@ -1328,3 +1328,54 @@ func TestCompareAndSetMetadataKeyExhaustionWithoutValueLossStaysTyped(t *testing
 		t.Fatalf("CompareAndSetMetadataKey = (%v, %v), want (false, *CASRetriesExhaustedError)", swapped, err)
 	}
 }
+
+// TestBdRevisionUnmarshalJSON pins the revision token decode across the forms bd
+// emits: a current decimal string, a legacy JSON integer, a signed value, and —
+// the case that regressed — a JSON null, which means "no token recorded yet" and
+// must decode to the zero token rather than hard-failing the whole issue decode.
+func TestBdRevisionUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bdRevision
+		wantErr bool
+	}{
+		{name: "decimal string", input: `"5"`, want: 5},
+		{name: "legacy integer", input: `7`, want: 7},
+		{name: "signed string", input: `"-3"`, want: -3},
+		{name: "null is the zero token", input: `null`, want: 0},
+		{name: "empty string value is invalid", input: `""`, wantErr: true},
+		{name: "non-numeric is invalid", input: `"abc"`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bdRevision
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Unmarshal(%s) = %d, nil; want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unmarshal(%s): %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Unmarshal(%s) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBdIssueDecodesNullRevisionAsZero guards the real path: a bd issue whose
+// revision column is null must decode into a Bead carrying the zero token, not
+// fail the whole issue decode.
+func TestBdIssueDecodesNullRevisionAsZero(t *testing.T) {
+	var issue bdIssue
+	if err := json.Unmarshal([]byte(`{"id":"ga-1","title":"t","revision":null}`), &issue); err != nil {
+		t.Fatalf("decoding issue with null revision: %v", err)
+	}
+	if got := issue.toBead().Revision; got != 0 {
+		t.Fatalf("Bead.Revision = %d, want 0 for a null revision column", got)
+	}
+}

--- a/internal/beads/bdstore_conditional_release_test.go
+++ b/internal/beads/bdstore_conditional_release_test.go
@@ -302,7 +302,9 @@ func TestReleaseIfCurrentSurfacesInfraFailuresAsErrors(t *testing.T) {
 
 // TestReleaseIfCurrentFallsBackToSQLOnAnOldBd is the bd 1.0.4 compatibility
 // proof: the minimum supported bd rejects the flags, and the store must reach
-// the raw-SQL statement byte-identically to how it did before the conversion.
+// the raw-SQL statement. The statement mints a fresh revision — a release that
+// left the pre-release token current would keep a stale fence valid — so the
+// token is the one part of it that cannot be pinned.
 func TestReleaseIfCurrentFallsBackToSQLOnAnOldBd(t *testing.T) {
 	runner := &releaseVerbRunner{}
 	runner.reply = func(args []string) ([]byte, error) {
@@ -324,10 +326,12 @@ func TestReleaseIfCurrentFallsBackToSQLOnAnOldBd(t *testing.T) {
 	if len(calls) != 2 {
 		t.Fatalf("calls = %v, want the verb probe then the SQL fallback", calls)
 	}
-	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
+	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = <revision>" +
 		" WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-''1'"
+	got := append([]string(nil), calls[1]...)
+	got[len(got)-1] = normalizeReleaseRevisionQuery(t, got[len(got)-1])
 	want := []string{"bd", "sql", "--json", wantQuery}
-	if strings.Join(calls[1], "\x00") != strings.Join(want, "\x00") {
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("fallback argv = %q\nwant          %q", calls[1], want)
 	}
 }

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3630,6 +3630,38 @@ func TestBdStoreReleaseIfCurrentDoesNotReplayAmbiguousLegacyFallback(t *testing.
 	}
 }
 
+// A clean serialization conflict — the backend rolled the write back atomically,
+// leaving nothing applied — is safe to replay, and ReleaseIfCurrent must, or a
+// merge-queue release loses a race it should have won on retry. This pins the
+// transient-but-unambiguous branch that the ambiguous-write tests above exclude:
+// the release retry predicate is isBdTransientWriteError && !isBdAmbiguousWriteError.
+func TestBdStoreReleaseIfCurrentRetriesACleanSerializationConflict(t *testing.T) {
+	var calls int
+	cleanConflict := errors.New("Error 1213 (40001): serialization failure")
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" || len(args) != 3 || args[0] != "sql" || args[1] != "--json" {
+			return nil, fmt.Errorf("unexpected command %s %q", name, args)
+		}
+		calls++
+		if calls == 1 {
+			return nil, cleanConflict
+		}
+		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true after a clean conflict is replayed")
+	}
+	if calls != 2 {
+		t.Fatalf("release attempts = %d, want the clean conflict retried once then applied", calls)
+	}
+}
+
 func TestBdStoreReleaseIfCurrentFallsBackWhenEmbeddedBdSQLUnsupported(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -3459,8 +3460,8 @@ func TestBdStoreReleaseIfCurrentUsesGuardedSQL(t *testing.T) {
 	if len(gotArgs) != 3 || gotArgs[0] != "sql" || gotArgs[1] != "--json" {
 		t.Fatalf("args = %q, want bd sql --json <query>", gotArgs)
 	}
-	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-''1'"
-	if gotArgs[2] != wantQuery {
+	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = <revision> WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-''1'"
+	if got := normalizeReleaseRevisionQuery(t, gotArgs[2]); got != wantQuery {
 		t.Fatalf("SQL query = %q, want %q", gotArgs[2], wantQuery)
 	}
 }
@@ -3476,9 +3477,156 @@ func TestBdStoreReleaseIfCurrentSQLLiteralEscapesBackslash(t *testing.T) {
 	if _, err := s.ReleaseIfCurrent("bd-\\42", "worker-\\1"); err != nil {
 		t.Fatalf("ReleaseIfCurrent: %v", err)
 	}
-	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-\\\\42' AND status = 'in_progress' AND assignee = 'worker-\\\\1'"
-	if gotArgs[2] != wantQuery {
+	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = <revision> WHERE id = 'bd-\\\\42' AND status = 'in_progress' AND assignee = 'worker-\\\\1'"
+	if got := normalizeReleaseRevisionQuery(t, gotArgs[2]); got != wantQuery {
 		t.Fatalf("SQL query = %q, want %q", gotArgs[2], wantQuery)
+	}
+}
+
+func TestBdStoreReleaseIfCurrentFallsBackOnlyWhenRevisionColumnMissing(t *testing.T) {
+	var queries []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" || len(args) != 3 || args[0] != "sql" || args[1] != "--json" {
+			return nil, fmt.Errorf("unexpected command %s %q", name, args)
+		}
+		queries = append(queries, args[2])
+		if strings.Contains(args[2], ", revision = ") {
+			return nil, errors.New("Error 1054 (42S22): Unknown column 'revision' in 'field list'")
+		}
+		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	if len(queries) != 2 {
+		t.Fatalf("release queries = %d, want revision-aware attempt then legacy fallback: %q", len(queries), queries)
+	}
+	if got := normalizeReleaseRevisionQuery(t, queries[0]); !strings.Contains(got, "revision = <revision>") {
+		t.Fatalf("first query = %q, want revision-aware release", queries[0])
+	}
+	if strings.Contains(queries[1], "revision") {
+		t.Fatalf("legacy fallback query unexpectedly references revision: %q", queries[1])
+	}
+}
+
+func TestBdStoreReleaseIfCurrentDoesNotFallbackOnOtherMissingColumn(t *testing.T) {
+	var calls int
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		calls++
+		return nil, errors.New("Error 1054 (42S22): Unknown column 'claim_fence' in 'field list'")
+	}
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err == nil || released {
+		t.Fatalf("ReleaseIfCurrent = (%v, %v), want false and the original schema error", released, err)
+	}
+	if calls != 1 {
+		t.Fatalf("release attempts = %d, want no legacy fallback for a non-revision column error", calls)
+	}
+}
+
+func TestBdStoreReleaseIfCurrentDoesNotReplayAmbiguousRevisionAwareWrite(t *testing.T) {
+	type releaseRow struct {
+		status   string
+		assignee string
+		revision int64
+	}
+	row := releaseRow{status: "in_progress", assignee: "worker-1", revision: 41}
+	var (
+		calls             int
+		releaseRevision   int64
+		reclaimRevision   int64
+		ambiguousWriteErr = errors.New("read tcp 127.0.0.1:53001->127.0.0.1:3306: connection reset by peer")
+	)
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" || len(args) != 3 || args[0] != "sql" || args[1] != "--json" {
+			return nil, fmt.Errorf("unexpected command %s %q", name, args)
+		}
+		calls++
+		releaseRevision = releaseRevisionFromQuery(t, args[2])
+		if row.status == "in_progress" && row.assignee == "worker-1" {
+			row = releaseRow{status: "open", revision: releaseRevision}
+		}
+		if calls == 1 {
+			reclaimRevision = releaseRevision + 1
+			if reclaimRevision <= 0 {
+				reclaimRevision = releaseRevision - 1
+			}
+			row = releaseRow{
+				status:   "in_progress",
+				assignee: "worker-1",
+				revision: reclaimRevision,
+			}
+			return nil, ambiguousWriteErr
+		}
+		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err == nil || !strings.Contains(err.Error(), ambiguousWriteErr.Error()) {
+		t.Errorf("ReleaseIfCurrent error = %v, want ambiguous execution error", err)
+	}
+	if released {
+		t.Error("ReleaseIfCurrent released = true, want false while execution is ambiguous")
+	}
+	if calls != 1 {
+		t.Errorf("release attempts = %d, want exactly one", calls)
+	}
+	if row.status != "in_progress" || row.assignee != "worker-1" || row.revision != reclaimRevision {
+		t.Errorf("same-assignee reclaim = %+v, want in_progress/worker-1/revision %d", row, reclaimRevision)
+	}
+	if row.revision == releaseRevision {
+		t.Errorf("same-assignee reclaim token was reinstalled to release token %d", releaseRevision)
+	}
+}
+
+func TestBdStoreReleaseIfCurrentDoesNotReplayAmbiguousLegacyFallback(t *testing.T) {
+	var (
+		calls          int
+		legacyAttempts int
+		rowStatus      = "in_progress"
+		ambiguousErr   = errors.New("write tcp 127.0.0.1:3306: broken pipe")
+	)
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" || len(args) != 3 || args[0] != "sql" || args[1] != "--json" {
+			return nil, fmt.Errorf("unexpected command %s %q", name, args)
+		}
+		calls++
+		if strings.Contains(args[2], ", revision = ") {
+			return nil, errors.New("Error 1054 (42S22): Unknown column 'revision' in 'field list'")
+		}
+		legacyAttempts++
+		if rowStatus == "in_progress" {
+			rowStatus = "open"
+			if legacyAttempts == 1 {
+				return nil, ambiguousErr
+			}
+			return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+		}
+		return []byte(`{"rows_affected":0,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err == nil || !strings.Contains(err.Error(), ambiguousErr.Error()) {
+		t.Errorf("ReleaseIfCurrent error = %v, want ambiguous legacy execution error", err)
+	}
+	if released {
+		t.Error("ReleaseIfCurrent released = true, want false while legacy execution is ambiguous")
+	}
+	if calls != 2 || legacyAttempts != 1 {
+		t.Errorf("release attempts = %d total/%d legacy, want one revision-aware plus one legacy", calls, legacyAttempts)
+	}
+	if rowStatus != "open" {
+		t.Errorf("simulated ambiguous legacy commit left status %q, want open", rowStatus)
 	}
 }
 
@@ -3513,10 +3661,14 @@ func TestBdStoreReleaseIfCurrentFallsBackWhenEmbeddedBdSQLUnsupported(t *testing
 		t.Fatal("ReleaseIfCurrent released = false, want true")
 	}
 	wantCalls := []string{
-		dir + ": bd sql --json UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'",
-		filepath.Join(dir, ".beads", "embeddeddolt", "demo") + ": dolt sql -r json -q UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'; SELECT ROW_COUNT() AS rows_affected",
+		dir + ": bd sql --json UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = <revision> WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'",
+		filepath.Join(dir, ".beads", "embeddeddolt", "demo") + ": dolt sql -r json -q UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP, revision = <revision> WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'; SELECT ROW_COUNT() AS rows_affected",
 	}
-	if !reflect.DeepEqual(calls, wantCalls) {
+	normalizedCalls := make([]string, len(calls))
+	for i, call := range calls {
+		normalizedCalls[i] = normalizeReleaseRevisionQuery(t, call)
+	}
+	if !reflect.DeepEqual(normalizedCalls, wantCalls) {
 		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
 	}
 }
@@ -3616,14 +3768,11 @@ func embeddedDoltReleaseIfCurrentStore(t *testing.T, doltOut []byte) *beads.BdSt
 }
 
 func TestBdStoreReleaseIfCurrentSkipsWhenRowsAffectedIsZero(t *testing.T) {
-	runner := fakeRunner(map[string]struct {
-		out []byte
-		err error
-	}{
-		`bd sql --json UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-1'`: {
-			out: []byte(`{"rows_affected":0,"schema_version":1}`),
-		},
-	})
+	var query string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		query = args[2]
+		return []byte(`{"rows_affected":0,"schema_version":1}`), nil
+	}
 	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
 
 	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
@@ -3633,6 +3782,39 @@ func TestBdStoreReleaseIfCurrentSkipsWhenRowsAffectedIsZero(t *testing.T) {
 	if released {
 		t.Fatal("ReleaseIfCurrent released = true, want false")
 	}
+	if got := normalizeReleaseRevisionQuery(t, query); !strings.Contains(got, "revision = <revision>") {
+		t.Fatalf("no-op release query = %q, want revision-aware guarded update", query)
+	}
+}
+
+func normalizeReleaseRevisionQuery(t *testing.T, query string) string {
+	t.Helper()
+	revision := releaseRevisionFromQuery(t, query)
+	const marker = "revision = "
+	start := strings.Index(query, marker)
+	valueStart := start + len(marker)
+	valueEnd := valueStart + len(strconv.FormatInt(revision, 10))
+	return query[:valueStart] + "<revision>" + query[valueEnd:]
+}
+
+func releaseRevisionFromQuery(t *testing.T, query string) int64 {
+	t.Helper()
+	const marker = "revision = "
+	start := strings.Index(query, marker)
+	if start < 0 {
+		t.Fatalf("release query has no revision assignment: %q", query)
+	}
+	valueStart := start + len(marker)
+	valueEnd := strings.Index(query[valueStart:], " WHERE ")
+	if valueEnd < 0 {
+		t.Fatalf("release query has no WHERE after revision assignment: %q", query)
+	}
+	valueEnd += valueStart
+	revision, err := strconv.ParseInt(query[valueStart:valueEnd], 10, 64)
+	if err != nil || revision <= 0 {
+		t.Fatalf("release query revision = %q (%v), want a positive int64", query[valueStart:valueEnd], err)
+	}
+	return revision
 }
 
 // --- ListByLabel ---

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -221,7 +221,7 @@ type ConditionalWriter interface {
 // terminal-state writers that cannot tolerate a metadata/close split, and is
 // exposed only by stores that can prove both operations share one transaction.
 type AtomicConditionalCloser interface {
-	CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error
+	CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) (Bead, error)
 }
 
 // AtomicConditionalCloserHandleProvider lets a wrapper expose the atomic
@@ -239,6 +239,7 @@ func AtomicConditionalCloserFor(store Store) (AtomicConditionalCloser, bool) {
 	if store == nil {
 		return nil, false
 	}
+	store = followConditionalWritesResolveTarget(store)
 	if provider, ok := store.(AtomicConditionalCloserHandleProvider); ok {
 		return provider.AtomicConditionalCloserHandle()
 	}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -162,10 +162,12 @@ type ConditionalAssignmentReleaser interface {
 // table against every implementing store, including real bd under the
 // integration build tag):
 //
-//   - Every bead carries a nonzero opaque int64 revision. Callers may test it
-//     only for equality; arithmetic, ordering across beads, and gap inference
-//     are undefined. A token is never intentionally reused during one bead's
-//     observed lifetime.
+//   - Every mutated bead carries a nonzero opaque int64 revision. Callers may
+//     test it only for equality; arithmetic, ordering across beads, and gap
+//     inference are undefined. A token is never intentionally reused during one
+//     bead's observed lifetime. A never-mutated bead may read back as zero on a
+//     counter-backed store, so zero means "no usable token", not "revisions
+//     unsupported".
 //   - Every successful mutation of revision-guarded whole-row content —
 //     conditional or unconditional — mints a fresh nonzero revision. This
 //     covers row-backed Update fields, metadata writes, Close, and Reopen;
@@ -192,10 +194,12 @@ type ConditionalAssignmentReleaser interface {
 // assumptions on top of it.
 type ConditionalWriter interface {
 	// UpdateIfMatch applies row-backed opts only if the bead's revision equals
-	// expectedRevision; otherwise it returns *PreconditionFailedError. ParentID,
-	// Labels, and RemoveLabels are rejected with
-	// *ConditionalUpdateFieldUnsupportedError: bd persists those fields through
-	// separate writes, so they cannot share this guarded-update contract.
+	// expectedRevision; otherwise it returns *PreconditionFailedError. A store
+	// that persists ParentID, Labels, or RemoveLabels through separate writes
+	// cannot fold them into the guarded update and rejects them with
+	// *ConditionalUpdateFieldUnsupportedError; bd-backed and Dolt-backed stores
+	// do. Callers must therefore handle that error rather than assume the
+	// fields applied.
 	UpdateIfMatch(id string, expectedRevision int64, opts UpdateOpts) error
 	// CloseIfMatch closes the bead only if its revision equals expectedRevision;
 	// otherwise it returns *PreconditionFailedError.

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -162,12 +162,16 @@ type ConditionalAssignmentReleaser interface {
 // table against every implementing store, including real bd under the
 // integration build tag):
 //
-//   - Every bead carries an opaque int64 revision. Callers may test it only for
-//     equality; arithmetic, ordering across beads, and gap inference are all
-//     undefined.
-//   - Every USER-VISIBLE mutation of this bead bumps the revision: field
-//     updates, label add/remove, metadata writes (any key), assign, close,
-//     reopen, delete. Reads never bump.
+//   - Every bead carries a nonzero opaque int64 revision. Callers may test it
+//     only for equality; arithmetic, ordering across beads, and gap inference
+//     are undefined. A token is never intentionally reused during one bead's
+//     observed lifetime.
+//   - Every successful mutation of revision-guarded whole-row content —
+//     conditional or unconditional — mints a fresh nonzero revision. This
+//     covers row-backed Update fields, metadata writes, Close, and Reopen;
+//     reads never change it.
+//     Separate label/parent persistence and derived or heartbeat fields are
+//     outside this guarantee.
 //   - Denormalized/derived projection columns are OUTSIDE this guarantee. bd
 //     maintains a denormalized is_blocked column on the issue row that other
 //     beads' dependency/close/route writes recompute (the same reason bd pins
@@ -175,8 +179,9 @@ type ConditionalAssignmentReleaser interface {
 //     bumps the revision is backend-dependent and callers must not rely on
 //     either answer. This is why every consumer treats PreconditionFailedError
 //     as a re-read trigger, never as a conclusion about what changed.
-//   - A bead's revision is monotonically increasing for the lifetime of the bead
-//     and is never reused.
+//   - The immediately prior token is stale after a whole-row mutation and is
+//     rejected; concurrent writes with the same observed revision have exactly
+//     one winner. Backends may generate either counters or random tokens.
 //
 // GRANULARITY CONTRACT: consumers may assume NEITHER value-level nor
 // revision-level conflict semantics. Backends differ — sqlite and the native
@@ -186,8 +191,11 @@ type ConditionalAssignmentReleaser interface {
 // the value-CAS RESULT either way, but must not build timing or interference
 // assumptions on top of it.
 type ConditionalWriter interface {
-	// UpdateIfMatch applies opts only if the bead's revision equals
-	// expectedRevision; otherwise it returns *PreconditionFailedError.
+	// UpdateIfMatch applies row-backed opts only if the bead's revision equals
+	// expectedRevision; otherwise it returns *PreconditionFailedError. ParentID,
+	// Labels, and RemoveLabels are rejected with
+	// *ConditionalUpdateFieldUnsupportedError: bd persists those fields through
+	// separate writes, so they cannot share this guarded-update contract.
 	UpdateIfMatch(id string, expectedRevision int64, opts UpdateOpts) error
 	// CloseIfMatch closes the bead only if its revision equals expectedRevision;
 	// otherwise it returns *PreconditionFailedError.
@@ -211,6 +219,37 @@ type ConditionalWriter interface {
 // pinned as invalid input: an empty fenced update neither evaluates the fence
 // nor bumps the revision on ANY store.
 var ErrEmptyConditionalUpdate = errors.New("conditional update: empty UpdateOpts (nothing to apply)")
+
+// ConditionalUpdateFieldUnsupportedError reports an UpdateIfMatch option that
+// is not row-backed across every ConditionalWriter implementation.
+type ConditionalUpdateFieldUnsupportedError struct {
+	Field string
+}
+
+// Error reports the conditional-update field that cannot be revision-guarded.
+func (e *ConditionalUpdateFieldUnsupportedError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("conditional update: %s is not supported with revision matching", e.Field)
+}
+
+// validateConditionalUpdateOpts rejects the fields bd must persist separately
+// before any store evaluates a revision fence or mutates state.
+func validateConditionalUpdateOpts(o UpdateOpts) error {
+	switch {
+	case o.ParentID != nil:
+		return &ConditionalUpdateFieldUnsupportedError{Field: "parent_id"}
+	case len(o.Labels) > 0:
+		return &ConditionalUpdateFieldUnsupportedError{Field: "labels"}
+	case len(o.RemoveLabels) > 0:
+		return &ConditionalUpdateFieldUnsupportedError{Field: "remove_labels"}
+	case isEmptyUpdateOpts(o):
+		return ErrEmptyConditionalUpdate
+	default:
+		return nil
+	}
+}
 
 // isEmptyUpdateOpts reports whether opts carries no mutation at all.
 func isEmptyUpdateOpts(o UpdateOpts) bool {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -213,6 +213,39 @@ type ConditionalWriter interface {
 	CompareAndSetMetadataKey(id, key, expected, next string) (bool, error)
 }
 
+// AtomicConditionalCloser closes a bead and merges metadata only when the
+// bead's revision still equals expectedRevision. Implementations commit the
+// metadata and close together, or neither change persists.
+//
+// This is deliberately narrower than ConditionalWriter: it is needed only by
+// terminal-state writers that cannot tolerate a metadata/close split, and is
+// exposed only by stores that can prove both operations share one transaction.
+type AtomicConditionalCloser interface {
+	CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error
+}
+
+// AtomicConditionalCloserHandleProvider lets a wrapper expose the atomic
+// terminal-write capability of its resolved backing without claiming it when
+// that backing cannot provide it.
+type AtomicConditionalCloserHandleProvider interface {
+	AtomicConditionalCloserHandle() (AtomicConditionalCloser, bool)
+}
+
+// AtomicConditionalCloserFor returns the atomic terminal-write capability when
+// store implements it. Unlike ConditionalWriterFor, this is not a rollout
+// policy seam: callers must refuse when the underlying store cannot provide
+// this all-or-nothing operation.
+func AtomicConditionalCloserFor(store Store) (AtomicConditionalCloser, bool) {
+	if store == nil {
+		return nil, false
+	}
+	if provider, ok := store.(AtomicConditionalCloserHandleProvider); ok {
+		return provider.AtomicConditionalCloserHandle()
+	}
+	closer, ok := store.(AtomicConditionalCloser)
+	return closer, ok
+}
+
 // ErrEmptyConditionalUpdate reports an UpdateIfMatch with no fields to apply.
 // The three in-tree implementations diverged here (bd cannot express an empty
 // fenced update; the native stores validated-and-bumped), so the contract is

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -433,6 +433,7 @@ func TestBdIssueDecodesRevision(t *testing.T) {
 		{name: "maximum signed decimal string", raw: `"9223372036854775807"`, want: math.MaxInt64},
 		{name: "minimum signed decimal string", raw: `"-9223372036854775808"`, want: math.MinInt64},
 		{name: "legacy integer", raw: `7`, want: 7},
+		{name: "json null is the no-revision sentinel", raw: `null`, want: 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -460,7 +461,6 @@ func TestBdIssueRejectsInvalidRevision(t *testing.T) {
 		`"not-a-revision"`,
 		`"1.5"`,
 		`1.5`,
-		`null`,
 		`"9223372036854775808"`,
 		`"-9223372036854775809"`,
 	} {

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -419,16 +420,30 @@ func TestBeadRevisionWireInvisible(t *testing.T) {
 	}
 }
 
-// TestBdIssueDecodesRevision proves the store-internal revision is carried by the
-// bd decode envelope (bdIssue) and stamped onto Bead by toBead — the population
-// path that survives Bead's json:"-" wire tag. Pre-#4682 bd omits the key → 0.
+// TestBdIssueDecodesRevision proves the store-internal revision is carried
+// losslessly by the bd decode envelope (bdIssue) and stamped onto Bead by
+// toBead — the population path that survives Bead's json:"-" wire tag.
 func TestBdIssueDecodesRevision(t *testing.T) {
-	var present bdIssue
-	if err := json.Unmarshal([]byte(`{"id":"gc-1","revision":7}`), &present); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{name: "decimal string beyond JS safe integer", raw: `"9007199254740993"`, want: 9007199254740993},
+		{name: "maximum signed decimal string", raw: `"9223372036854775807"`, want: math.MaxInt64},
+		{name: "minimum signed decimal string", raw: `"-9223372036854775808"`, want: math.MinInt64},
+		{name: "legacy integer", raw: `7`, want: 7},
 	}
-	if got := present.toBead().Revision; got != 7 {
-		t.Fatalf("toBead().Revision (present) = %d, want 7", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var issue bdIssue
+			if err := json.Unmarshal([]byte(`{"id":"gc-1","revision":`+tt.raw+`}`), &issue); err != nil {
+				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if got := issue.toBead().Revision; got != tt.want {
+				t.Fatalf("toBead().Revision = %d, want %d", got, tt.want)
+			}
+		})
 	}
 
 	var absent bdIssue
@@ -437,5 +452,23 @@ func TestBdIssueDecodesRevision(t *testing.T) {
 	}
 	if got := absent.toBead().Revision; got != 0 {
 		t.Fatalf("toBead().Revision (absent) = %d, want 0", got)
+	}
+}
+
+func TestBdIssueRejectsInvalidRevision(t *testing.T) {
+	for _, raw := range []string{
+		`"not-a-revision"`,
+		`"1.5"`,
+		`1.5`,
+		`null`,
+		`"9223372036854775808"`,
+		`"-9223372036854775809"`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			var issue bdIssue
+			if err := json.Unmarshal([]byte(`{"id":"gc-1","revision":`+raw+`}`), &issue); err == nil {
+				t.Fatalf("json.Unmarshal revision %s succeeded, want error", raw)
+			}
+		})
 	}
 }

--- a/internal/beads/beadstest/conditional_writer_conformance.go
+++ b/internal/beads/beadstest/conditional_writer_conformance.go
@@ -63,104 +63,142 @@ func RunConditionalWriterConformance(t *testing.T, name string, open func(t *tes
 
 // RunConditionalWriterConformanceWithOptions is RunConditionalWriterConformance
 // with the optional disable-toggle leg wired.
+//
+// The body is a flat table of contents: each contract leg lives in its own
+// conformance* helper so this dispatcher stays a readable manifest of the
+// suite, and the optional legs (opts.RestrictedUpdateFields,
+// opts.RowBackedMutationFlavors, opts.OpenDisabled) are the only branches here.
 func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open func(t *testing.T) beads.Store, opts ConditionalWriterOptions) {
 	t.Helper()
 
-	// writerFor resolves the ConditionalWriter for a store or fails loudly: the
-	// suite is only meaningful against a capable store.
-	writerFor := func(t *testing.T, s beads.Store) beads.ConditionalWriter {
-		t.Helper()
-		w, ok := beads.ConditionalWriterFor(s)
-		if !ok {
-			t.Fatalf("store does not implement beads.ConditionalWriter; "+
-				"RunConditionalWriterConformance requires a capable store (got %T)", s)
-		}
-		return w
-	}
-
-	// revOf reads the current revision of id through the plain Store surface.
-	revOf := func(t *testing.T, s beads.Store, id string) int64 {
-		t.Helper()
-		b, err := s.Get(id)
-		if err != nil {
-			t.Fatalf("Get(%q): %v", id, err)
-		}
-		return b.Revision
-	}
-
-	strPtr := func(s string) *string { return &s }
-
 	t.Run(name, func(t *testing.T) { runEmptyUpdateContract(t, open) })
+	conformanceWholeBeadWriteChangesRevision(t, name, open)
+	if opts.RestrictedUpdateFields {
+		conformanceRestrictedUpdateFieldsRejected(t, name, open)
+	}
+	conformanceReadsNeverBump(t, name, open)
+	conformanceRevisionTokensNeverReused(t, name, open)
+	conformanceReleaseIfCurrentMintsRevision(t, name, open)
+	if opts.RowBackedMutationFlavors {
+		conformanceRowBackedMutationFlavors(t, name, open)
+	}
+	conformanceStaleRevisionIsPreconditionFailed(t, name, open, opts)
+	conformanceConditionalSuccessPaths(t, name, open)
+	conformanceCASEmptyExpectedClaimsAbsentOrEmpty(t, name, open)
+	conformanceCASValueMismatchIsFalseNil(t, name, open)
+	conformanceCASWinnerValueVisibleToLoser(t, name, open)
+	conformanceUpdateIfMatchContentionPair(t, name, open)
+	conformanceContention(t, name, open)
+	if opts.OpenDisabled != nil {
+		conformanceDisableToggle(t, name, opts)
+	}
+}
 
+// conformanceWriterFor resolves the ConditionalWriter for a store or fails
+// loudly: the suite is only meaningful against a capable store.
+func conformanceWriterFor(t *testing.T, s beads.Store) beads.ConditionalWriter {
+	t.Helper()
+	w, ok := beads.ConditionalWriterFor(s)
+	if !ok {
+		t.Fatalf("store does not implement beads.ConditionalWriter; "+
+			"RunConditionalWriterConformance requires a capable store (got %T)", s)
+	}
+	return w
+}
+
+// conformanceRevOf reads the current revision of id through the plain Store
+// surface.
+func conformanceRevOf(t *testing.T, s beads.Store, id string) int64 {
+	t.Helper()
+	b, err := s.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", id, err)
+	}
+	return b.Revision
+}
+
+// conformanceStrPtr returns a pointer to s, for the *string UpdateOpts fields.
+func conformanceStrPtr(s string) *string { return &s }
+
+// conformanceWholeBeadWriteChangesRevision asserts a conditional whole-bead
+// write moves the revision to a fresh nonzero token.
+func conformanceWholeBeadWriteChangesRevision(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/whole_bead_conditional_write_changes_revision", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "orig"})
 		if err != nil {
 			t.Fatal(err)
 		}
 		id := b.ID
 
-		before := revOf(t, s, id)
-		if err := w.UpdateIfMatch(id, before, beads.UpdateOpts{Title: strPtr("renamed")}); err != nil {
+		before := conformanceRevOf(t, s, id)
+		if err := w.UpdateIfMatch(id, before, beads.UpdateOpts{Title: conformanceStrPtr("renamed")}); err != nil {
 			t.Fatalf("UpdateIfMatch: %v", err)
 		}
-		after := revOf(t, s, id)
+		after := conformanceRevOf(t, s, id)
 		if after == 0 || after == before {
 			t.Fatalf("UpdateIfMatch did not change to a nonzero revision: %d -> %d", before, after)
 		}
 	})
+}
 
-	if opts.RestrictedUpdateFields {
-		t.Run(name+"/restricted_update_fields_are_rejected_without_mutation", func(t *testing.T) {
-			s := open(t)
-			w := writerFor(t, s)
-			parentBefore, err := s.Create(beads.Bead{Title: "restricted-update-parent"})
-			if err != nil {
-				t.Fatalf("Create parent fixture: %v", err)
-			}
-			parent := "parent-after"
-			tests := []struct {
-				name string
-				opts beads.UpdateOpts
-			}{
-				{name: "parent", opts: beads.UpdateOpts{ParentID: &parent}},
-				{name: "add_labels", opts: beads.UpdateOpts{Labels: []string{"added"}}},
-				{name: "remove_labels", opts: beads.UpdateOpts{RemoveLabels: []string{"remove"}}},
-			}
+// conformanceRestrictedUpdateFieldsRejected asserts a store that cannot fold
+// parent/labels into a revision-guarded update rejects them with the typed
+// unsupported error and mutates nothing.
+func conformanceRestrictedUpdateFieldsRejected(t *testing.T, name string, open func(t *testing.T) beads.Store) {
+	t.Run(name+"/restricted_update_fields_are_rejected_without_mutation", func(t *testing.T) {
+		s := open(t)
+		w := conformanceWriterFor(t, s)
+		parentBefore, err := s.Create(beads.Bead{Title: "restricted-update-parent"})
+		if err != nil {
+			t.Fatalf("Create parent fixture: %v", err)
+		}
+		parent := "parent-after"
+		tests := []struct {
+			name string
+			opts beads.UpdateOpts
+		}{
+			{name: "parent", opts: beads.UpdateOpts{ParentID: &parent}},
+			{name: "add_labels", opts: beads.UpdateOpts{Labels: []string{"added"}}},
+			{name: "remove_labels", opts: beads.UpdateOpts{RemoveLabels: []string{"remove"}}},
+		}
 
-			for _, tt := range tests {
-				t.Run(tt.name, func(t *testing.T) {
-					created, err := s.Create(beads.Bead{
-						Title:    "restricted-update",
-						ParentID: parentBefore.ID,
-						Labels:   []string{"keep", "remove"},
-					})
-					if err != nil {
-						t.Fatal(err)
-					}
-					before, err := s.Get(created.ID)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					err = w.UpdateIfMatch(created.ID, before.Revision, tt.opts)
-					var unsupported *beads.ConditionalUpdateFieldUnsupportedError
-					if !errors.As(err, &unsupported) {
-						t.Fatalf("UpdateIfMatch(%s) = %v, want *ConditionalUpdateFieldUnsupportedError", tt.name, err)
-					}
-					after, err := s.Get(created.ID)
-					if err != nil {
-						t.Fatal(err)
-					}
-					if !reflect.DeepEqual(after, before) {
-						t.Fatalf("restricted conditional update mutated bead: before=%#v after=%#v", before, after)
-					}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				created, err := s.Create(beads.Bead{
+					Title:    "restricted-update",
+					ParentID: parentBefore.ID,
+					Labels:   []string{"keep", "remove"},
 				})
-			}
-		})
-	}
+				if err != nil {
+					t.Fatal(err)
+				}
+				before, err := s.Get(created.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
 
+				err = w.UpdateIfMatch(created.ID, before.Revision, tt.opts)
+				var unsupported *beads.ConditionalUpdateFieldUnsupportedError
+				if !errors.As(err, &unsupported) {
+					t.Fatalf("UpdateIfMatch(%s) = %v, want *ConditionalUpdateFieldUnsupportedError", tt.name, err)
+				}
+				after, err := s.Get(created.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(after, before) {
+					t.Fatalf("restricted conditional update mutated bead: before=%#v after=%#v", before, after)
+				}
+			})
+		}
+	})
+}
+
+// conformanceReadsNeverBump asserts a spread of read paths leaves the revision
+// unchanged.
+func conformanceReadsNeverBump(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/reads_never_bump", func(t *testing.T) {
 		s := open(t)
 		b, err := s.Create(beads.Bead{Title: "read-target", Labels: []string{"l"}})
@@ -171,7 +209,7 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		if err := s.SetMetadata(id, "k", "v"); err != nil {
 			t.Fatal(err)
 		}
-		before := revOf(t, s, id)
+		before := conformanceRevOf(t, s, id)
 
 		// A spread of read paths — none may bump the revision.
 		if _, err := s.Get(id); err != nil {
@@ -187,11 +225,15 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatal(err)
 		}
 
-		if after := revOf(t, s, id); after != before {
+		if after := conformanceRevOf(t, s, id); after != before {
 			t.Fatalf("reads bumped the revision: %d -> %d", before, after)
 		}
 	})
+}
 
+// conformanceRevisionTokensNeverReused asserts each mutation mints a nonzero
+// token never seen before in the bead's lifetime.
+func conformanceRevisionTokensNeverReused(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/revision_tokens_are_never_reused_during_a_bead_lifetime", func(t *testing.T) {
 		s := open(t)
 		b, err := s.Create(beads.Bead{Title: "mono"})
@@ -202,7 +244,7 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 
 		// A never-mutated bead may legitimately carry the zero token on a
 		// counter-backed store, so seed the seen set only from a real token.
-		last := revOf(t, s, id)
+		last := conformanceRevOf(t, s, id)
 		seen := map[int64]struct{}{}
 		if last != 0 {
 			seen[last] = struct{}{}
@@ -211,7 +253,7 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			if err := s.SetMetadata(id, "counter", string(rune('a'+i))); err != nil {
 				t.Fatal(err)
 			}
-			cur := revOf(t, s, id)
+			cur := conformanceRevOf(t, s, id)
 			if cur == 0 || cur == last {
 				t.Fatalf("revision did not change to a nonzero token at step %d: %d -> %d", i, last, cur)
 			}
@@ -222,10 +264,15 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			last = cur
 		}
 	})
+}
 
+// conformanceReleaseIfCurrentMintsRevision asserts ReleaseIfCurrent no-ops for a
+// wrong assignee, releases for the matching one, and mints a fresh token that
+// stales the pre-release snapshot.
+func conformanceReleaseIfCurrentMintsRevision(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/release_if_current_mints_revision_and_stales_prior_token", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		releaser, ok := s.(beads.ConditionalAssignmentReleaser)
 		if !ok {
 			t.Fatalf("%T does not implement ConditionalAssignmentReleaser", s)
@@ -292,106 +339,114 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatalf("stale pre-release write changed title to %q", final.Title)
 		}
 	})
+}
 
-	if opts.RowBackedMutationFlavors {
-		t.Run(name+"/row_backed_mutation_flavors_mint_fresh_tokens", func(t *testing.T) {
-			s := open(t)
-			w := writerFor(t, s)
-			strPtr := func(s string) *string { return &s }
-			row, err := s.Create(beads.Bead{Title: "row-backed-mutations"})
-			if err != nil {
-				t.Fatal(err)
+// conformanceRowBackedMutationFlavors asserts every whole-row mutation flavor
+// (Update fields, SetMetadata(Batch), the *IfMatch verbs, CAS) mints a fresh
+// nonzero token visible through the Store read surface.
+func conformanceRowBackedMutationFlavors(t *testing.T, name string, open func(t *testing.T) beads.Store) {
+	t.Run(name+"/row_backed_mutation_flavors_mint_fresh_tokens", func(t *testing.T) {
+		s := open(t)
+		w := conformanceWriterFor(t, s)
+		strPtr := func(s string) *string { return &s }
+		row, err := s.Create(beads.Bead{Title: "row-backed-mutations"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen := map[int64]struct{}{conformanceRevOf(t, s, row.ID): {}}
+		priority := 2
+
+		assertFresh := func(label string, mutate func() error) {
+			t.Helper()
+			before := conformanceRevOf(t, s, row.ID)
+			if err := mutate(); err != nil {
+				t.Fatalf("%s: %v", label, err)
 			}
-			seen := map[int64]struct{}{revOf(t, s, row.ID): {}}
-			priority := 2
-
-			assertFresh := func(label string, mutate func() error) {
-				t.Helper()
-				before := revOf(t, s, row.ID)
-				if err := mutate(); err != nil {
-					t.Fatalf("%s: %v", label, err)
-				}
-				after := revOf(t, s, row.ID)
-				if after == 0 || after == before {
-					t.Fatalf("%s did not mint a fresh nonzero revision: %d -> %d", label, before, after)
-				}
-				if _, exists := seen[after]; exists {
-					t.Fatalf("%s reused revision token %d", label, after)
-				}
-				seen[after] = struct{}{}
-			}
-
-			updates := []struct {
-				name string
-				opts beads.UpdateOpts
-			}{
-				{name: "Update(title)", opts: beads.UpdateOpts{Title: strPtr("updated")}},
-				{name: "Update(status)", opts: beads.UpdateOpts{Status: strPtr("in_progress")}},
-				{name: "Update(type)", opts: beads.UpdateOpts{Type: strPtr("task")}},
-				{name: "Update(priority)", opts: beads.UpdateOpts{Priority: &priority}},
-				{name: "Update(description)", opts: beads.UpdateOpts{Description: strPtr("description")}},
-				{name: "Update(assignee)", opts: beads.UpdateOpts{Assignee: strPtr("agent")}},
-				{name: "Update(metadata)", opts: beads.UpdateOpts{Metadata: map[string]string{"update_metadata": "value"}}},
-			}
-			for _, update := range updates {
-				assertFresh(update.name, func() error { return s.Update(row.ID, update.opts) })
-			}
-
-			assertFresh("SetMetadata", func() error {
-				return s.SetMetadata(row.ID, "key", "value")
-			})
-
-			assertFresh("SetMetadataBatch", func() error {
-				return s.SetMetadataBatch(row.ID, map[string]string{"left": "one", "right": "two"})
-			})
-
-			assertFresh("UpdateIfMatch", func() error {
-				return w.UpdateIfMatch(row.ID, revOf(t, s, row.ID), beads.UpdateOpts{Title: strPtr("conditional-updated")})
-			})
-
-			assertFresh("CompareAndSetMetadataKey", func() error {
-				ok, err := w.CompareAndSetMetadataKey(row.ID, "conditional_metadata", "", "value")
-				if err != nil {
-					return err
-				}
-				if !ok {
-					t.Fatal("CompareAndSetMetadataKey claiming an absent key returned (false, nil)")
-				}
-				return nil
-			})
-
-			assertFresh("Close", func() error { return s.Close(row.ID) })
-			assertFresh("Reopen", func() error { return s.Reopen(row.ID) })
-
-			conditionalClose, err := s.Create(beads.Bead{Title: "conditional-close"})
-			if err != nil {
-				t.Fatal(err)
-			}
-			before := revOf(t, s, conditionalClose.ID)
-			if err := w.CloseIfMatch(conditionalClose.ID, before); err != nil {
-				t.Fatalf("CloseIfMatch: %v", err)
-			}
-			after := revOf(t, s, conditionalClose.ID)
+			after := conformanceRevOf(t, s, row.ID)
 			if after == 0 || after == before {
-				t.Fatalf("CloseIfMatch did not mint a fresh nonzero revision: %d -> %d", before, after)
+				t.Fatalf("%s did not mint a fresh nonzero revision: %d -> %d", label, before, after)
 			}
-		})
-	}
+			if _, exists := seen[after]; exists {
+				t.Fatalf("%s reused revision token %d", label, after)
+			}
+			seen[after] = struct{}{}
+		}
 
+		updates := []struct {
+			name string
+			opts beads.UpdateOpts
+		}{
+			{name: "Update(title)", opts: beads.UpdateOpts{Title: strPtr("updated")}},
+			{name: "Update(status)", opts: beads.UpdateOpts{Status: strPtr("in_progress")}},
+			{name: "Update(type)", opts: beads.UpdateOpts{Type: strPtr("task")}},
+			{name: "Update(priority)", opts: beads.UpdateOpts{Priority: &priority}},
+			{name: "Update(description)", opts: beads.UpdateOpts{Description: strPtr("description")}},
+			{name: "Update(assignee)", opts: beads.UpdateOpts{Assignee: strPtr("agent")}},
+			{name: "Update(metadata)", opts: beads.UpdateOpts{Metadata: map[string]string{"update_metadata": "value"}}},
+		}
+		for _, update := range updates {
+			assertFresh(update.name, func() error { return s.Update(row.ID, update.opts) })
+		}
+
+		assertFresh("SetMetadata", func() error {
+			return s.SetMetadata(row.ID, "key", "value")
+		})
+
+		assertFresh("SetMetadataBatch", func() error {
+			return s.SetMetadataBatch(row.ID, map[string]string{"left": "one", "right": "two"})
+		})
+
+		assertFresh("UpdateIfMatch", func() error {
+			return w.UpdateIfMatch(row.ID, conformanceRevOf(t, s, row.ID), beads.UpdateOpts{Title: strPtr("conditional-updated")})
+		})
+
+		assertFresh("CompareAndSetMetadataKey", func() error {
+			ok, err := w.CompareAndSetMetadataKey(row.ID, "conditional_metadata", "", "value")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				t.Fatal("CompareAndSetMetadataKey claiming an absent key returned (false, nil)")
+			}
+			return nil
+		})
+
+		assertFresh("Close", func() error { return s.Close(row.ID) })
+		assertFresh("Reopen", func() error { return s.Reopen(row.ID) })
+
+		conditionalClose, err := s.Create(beads.Bead{Title: "conditional-close"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := conformanceRevOf(t, s, conditionalClose.ID)
+		if err := w.CloseIfMatch(conditionalClose.ID, before); err != nil {
+			t.Fatalf("CloseIfMatch: %v", err)
+		}
+		after := conformanceRevOf(t, s, conditionalClose.ID)
+		if after == 0 || after == before {
+			t.Fatalf("CloseIfMatch did not mint a fresh nonzero revision: %d -> %d", before, after)
+		}
+	})
+}
+
+// conformanceStaleRevisionIsPreconditionFailed asserts each *IfMatch verb
+// rejects a stale revision with a typed PreconditionFailedError carrying the
+// caller's Expected (and Current when opts.SuppliesCurrent) without mutating.
+func conformanceStaleRevisionIsPreconditionFailed(t *testing.T, name string, open func(t *testing.T) beads.Store, opts ConditionalWriterOptions) {
 	t.Run(name+"/stale_revision_is_precondition_failed", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "stale"})
 		if err != nil {
 			t.Fatal(err)
 		}
 		id := b.ID
-		stale := revOf(t, s, id)
+		stale := conformanceRevOf(t, s, id)
 		// Move the revision on so the caller's snapshot is out of date.
 		if err := s.SetMetadata(id, "k", "moved"); err != nil {
 			t.Fatal(err)
 		}
-		current := revOf(t, s, id)
+		current := conformanceRevOf(t, s, id)
 
 		assertPrecondition := func(verb string, err error) {
 			t.Helper()
@@ -411,7 +466,7 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			}
 		}
 
-		assertPrecondition("UpdateIfMatch", w.UpdateIfMatch(id, stale, beads.UpdateOpts{Title: strPtr("x")}))
+		assertPrecondition("UpdateIfMatch", w.UpdateIfMatch(id, stale, beads.UpdateOpts{Title: conformanceStrPtr("x")}))
 		assertPrecondition("CloseIfMatch", w.CloseIfMatch(id, stale))
 		assertPrecondition("DeleteIfMatch", w.DeleteIfMatch(id, stale))
 		// The bead must still exist (every stale write was rejected).
@@ -419,21 +474,26 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatalf("bead vanished after rejected conditional writes: %v", err)
 		}
 	})
+}
 
+// conformanceConditionalSuccessPaths asserts the matching-revision (success) leg
+// of each *IfMatch verb actually applies and removes, so a store whose gated
+// verbs always fail — or return nil without applying — cannot pass by omission.
+func conformanceConditionalSuccessPaths(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/conditional_success_paths", func(t *testing.T) {
 		// The matching-revision (success) leg of each *IfMatch verb — without this,
 		// a store whose gated verbs always return PreconditionFailedError, or that
 		// returns nil without applying anything, passes the whole suite.
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 
 		// UpdateIfMatch at the current revision applies opts and bumps.
 		a, err := s.Create(beads.Bead{Title: "upd"})
 		if err != nil {
 			t.Fatal(err)
 		}
-		aRev := revOf(t, s, a.ID)
-		if err := w.UpdateIfMatch(a.ID, aRev, beads.UpdateOpts{Title: strPtr("applied")}); err != nil {
+		aRev := conformanceRevOf(t, s, a.ID)
+		if err := w.UpdateIfMatch(a.ID, aRev, beads.UpdateOpts{Title: conformanceStrPtr("applied")}); err != nil {
 			t.Fatalf("UpdateIfMatch at current revision: %v", err)
 		}
 		got, err := s.Get(a.ID)
@@ -452,7 +512,7 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := w.CloseIfMatch(b.ID, revOf(t, s, b.ID)); err != nil {
+		if err := w.CloseIfMatch(b.ID, conformanceRevOf(t, s, b.ID)); err != nil {
 			t.Fatalf("CloseIfMatch at current revision: %v", err)
 		}
 
@@ -461,17 +521,22 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := w.DeleteIfMatch(c.ID, revOf(t, s, c.ID)); err != nil {
+		if err := w.DeleteIfMatch(c.ID, conformanceRevOf(t, s, c.ID)); err != nil {
 			t.Fatalf("DeleteIfMatch at current revision: %v", err)
 		}
 		if _, err := s.Get(c.ID); !errors.Is(err, beads.ErrNotFound) {
 			t.Fatalf("DeleteIfMatch left the bead present: Get returned %v, want ErrNotFound", err)
 		}
 	})
+}
 
+// conformanceCASEmptyExpectedClaimsAbsentOrEmpty asserts CompareAndSetMetadataKey
+// with an empty expected value claims an absent or empty-valued key but not a
+// populated one.
+func conformanceCASEmptyExpectedClaimsAbsentOrEmpty(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/cas_empty_expected_claims_absent_or_empty_only", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "cas-empty"})
 		if err != nil {
 			t.Fatal(err)
@@ -498,10 +563,14 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatalf("value after rejected empty-expected CAS = %q, want %q", got.Metadata["k"], "two")
 		}
 	})
+}
 
+// conformanceCASValueMismatchIsFalseNil asserts a value-mismatched CAS returns
+// (false, nil) — a lost race, not an error — and mutates nothing.
+func conformanceCASValueMismatchIsFalseNil(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/cas_value_mismatch_is_false_nil_not_error", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "cas-mismatch"})
 		if err != nil {
 			t.Fatal(err)
@@ -521,10 +590,15 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatalf("value mutated on a lost CAS: %q, want %q", got.Metadata["k"], "A")
 		}
 	})
+}
 
+// conformanceCASWinnerValueVisibleToLoser asserts a CAS winner's value is
+// visible to a loser's re-read and that a CAS from the pre-swap value then loses
+// cleanly.
+func conformanceCASWinnerValueVisibleToLoser(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/cas_winner_value_visible_to_loser_reread", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "cas-visible"})
 		if err != nil {
 			t.Fatal(err)
@@ -545,10 +619,15 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatalf("stale-value CAS after a swap: (%v, %v), want (false, nil)", ok, err)
 		}
 	})
+}
 
+// conformanceUpdateIfMatchContentionPair asserts that under contention exactly
+// one UpdateIfMatch racer commits its complete metadata pair, losers commit
+// nothing partial, and an unrelated sibling key is preserved.
+func conformanceUpdateIfMatchContentionPair(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/update_if_match_contention_commits_one_complete_metadata_pair", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "fenced-metadata-pair"})
 		if err != nil {
 			t.Fatal(err)
@@ -641,10 +720,15 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatalf("sole successful UpdateIfMatch did not change to a nonzero revision: %d -> %d", before.Revision, after.Revision)
 		}
 	})
+}
 
+// conformanceContention asserts that under contention exactly one
+// CompareAndSetMetadataKey racer wins (never an error) and the store persists
+// precisely that winner's value.
+func conformanceContention(t *testing.T, name string, open func(t *testing.T) beads.Store) {
 	t.Run(name+"/contention", func(t *testing.T) {
 		s := open(t)
-		w := writerFor(t, s)
+		w := conformanceWriterFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "contention"})
 		if err != nil {
 			t.Fatal(err)
@@ -694,40 +778,43 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 			t.Fatalf("final value %q does not match the sole winner %q", got.Metadata["k"], winners[0])
 		}
 	})
+}
 
-	if opts.OpenDisabled != nil {
-		t.Run(name+"/disable_toggle_returns_typed_unsupported_with_interfaces_intact", func(t *testing.T) {
-			s := opts.OpenDisabled(t)
-			// The store still CLAIMS the interface — disabling is a runtime toggle,
-			// not interface-stripping (no hiding wrapper, per the class_store lesson).
-			w, ok := beads.ConditionalWriterFor(s)
-			if !ok {
-				t.Fatal("disabled store must still implement ConditionalWriter (toggle is runtime, not interface-stripping)")
-			}
-			b, err := s.Create(beads.Bead{Title: "disabled"})
-			if err != nil {
-				t.Fatal(err)
-			}
-			id := b.ID
+// conformanceDisableToggle asserts an instance whose conditional writes are
+// disabled returns ErrConditionalWriteUnsupported from the four CAS methods
+// while still claiming the interface and keeping its other optional interfaces.
+func conformanceDisableToggle(t *testing.T, name string, opts ConditionalWriterOptions) {
+	t.Run(name+"/disable_toggle_returns_typed_unsupported_with_interfaces_intact", func(t *testing.T) {
+		s := opts.OpenDisabled(t)
+		// The store still CLAIMS the interface — disabling is a runtime toggle,
+		// not interface-stripping (no hiding wrapper, per the class_store lesson).
+		w, ok := beads.ConditionalWriterFor(s)
+		if !ok {
+			t.Fatal("disabled store must still implement ConditionalWriter (toggle is runtime, not interface-stripping)")
+		}
+		b, err := s.Create(beads.Bead{Title: "disabled"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := b.ID
 
-			assertUnsupported := func(verb string, err error) {
-				t.Helper()
-				if !errors.Is(err, beads.ErrConditionalWriteUnsupported) {
-					t.Fatalf("%s on disabled store: got %v, want ErrConditionalWriteUnsupported", verb, err)
-				}
+		assertUnsupported := func(verb string, err error) {
+			t.Helper()
+			if !errors.Is(err, beads.ErrConditionalWriteUnsupported) {
+				t.Fatalf("%s on disabled store: got %v, want ErrConditionalWriteUnsupported", verb, err)
 			}
-			assertUnsupported("UpdateIfMatch", w.UpdateIfMatch(id, 1, beads.UpdateOpts{Title: strPtr("x")}))
-			assertUnsupported("CloseIfMatch", w.CloseIfMatch(id, 1))
-			assertUnsupported("DeleteIfMatch", w.DeleteIfMatch(id, 1))
-			_, casErr := w.CompareAndSetMetadataKey(id, "k", "", "v")
-			assertUnsupported("CompareAndSetMetadataKey", casErr)
+		}
+		assertUnsupported("UpdateIfMatch", w.UpdateIfMatch(id, 1, beads.UpdateOpts{Title: conformanceStrPtr("x")}))
+		assertUnsupported("CloseIfMatch", w.CloseIfMatch(id, 1))
+		assertUnsupported("DeleteIfMatch", w.DeleteIfMatch(id, 1))
+		_, casErr := w.CompareAndSetMetadataKey(id, "k", "", "v")
+		assertUnsupported("CompareAndSetMetadataKey", casErr)
 
-			// Other optional interfaces stay intact on the disabled store.
-			if _, ok := s.(beads.ConditionalAssignmentReleaser); !ok {
-				t.Fatal("disabled store lost ConditionalAssignmentReleaser (interface set must stay intact)")
-			}
-		})
-	}
+		// Other optional interfaces stay intact on the disabled store.
+		if _, ok := s.(beads.ConditionalAssignmentReleaser); !ok {
+			t.Fatal("disabled store lost ConditionalAssignmentReleaser (interface set must stay intact)")
+		}
+	})
 }
 
 // runEmptyUpdateContract asserts the pinned empty-fenced-update contract: an

--- a/internal/beads/beadstest/conditional_writer_conformance.go
+++ b/internal/beads/beadstest/conditional_writer_conformance.go
@@ -19,6 +19,14 @@ type ConditionalWriterOptions struct {
 	// preserve every unconditional flavor leave this false.
 	RowBackedMutationFlavors bool
 
+	// RestrictedUpdateFields declares that this store persists parent and
+	// labels through writes it cannot fold into a revision-guarded update, so
+	// UpdateIfMatch must reject those options with
+	// *beads.ConditionalUpdateFieldUnsupportedError instead of applying them.
+	// bd-backed and Dolt-backed stores do; a store that keeps the whole bead in
+	// one row can apply them and leaves this false.
+	RestrictedUpdateFields bool
+
 	// OpenDisabled returns a fresh store of the same kind whose conditional
 	// writes are turned off at the instance level (e.g. MemStore/FileStore with
 	// DisableConditionalWrites=true). When non-nil, the disable_toggle subtest
@@ -103,53 +111,55 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		}
 	})
 
-	t.Run(name+"/restricted_update_fields_are_rejected_without_mutation", func(t *testing.T) {
-		s := open(t)
-		w := writerFor(t, s)
-		parentBefore, err := s.Create(beads.Bead{Title: "restricted-update-parent"})
-		if err != nil {
-			t.Fatalf("Create parent fixture: %v", err)
-		}
-		parent := "parent-after"
-		tests := []struct {
-			name string
-			opts beads.UpdateOpts
-		}{
-			{name: "parent", opts: beads.UpdateOpts{ParentID: &parent}},
-			{name: "add_labels", opts: beads.UpdateOpts{Labels: []string{"added"}}},
-			{name: "remove_labels", opts: beads.UpdateOpts{RemoveLabels: []string{"remove"}}},
-		}
+	if opts.RestrictedUpdateFields {
+		t.Run(name+"/restricted_update_fields_are_rejected_without_mutation", func(t *testing.T) {
+			s := open(t)
+			w := writerFor(t, s)
+			parentBefore, err := s.Create(beads.Bead{Title: "restricted-update-parent"})
+			if err != nil {
+				t.Fatalf("Create parent fixture: %v", err)
+			}
+			parent := "parent-after"
+			tests := []struct {
+				name string
+				opts beads.UpdateOpts
+			}{
+				{name: "parent", opts: beads.UpdateOpts{ParentID: &parent}},
+				{name: "add_labels", opts: beads.UpdateOpts{Labels: []string{"added"}}},
+				{name: "remove_labels", opts: beads.UpdateOpts{RemoveLabels: []string{"remove"}}},
+			}
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				created, err := s.Create(beads.Bead{
-					Title:    "restricted-update",
-					ParentID: parentBefore.ID,
-					Labels:   []string{"keep", "remove"},
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					created, err := s.Create(beads.Bead{
+						Title:    "restricted-update",
+						ParentID: parentBefore.ID,
+						Labels:   []string{"keep", "remove"},
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					before, err := s.Get(created.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					err = w.UpdateIfMatch(created.ID, before.Revision, tt.opts)
+					var unsupported *beads.ConditionalUpdateFieldUnsupportedError
+					if !errors.As(err, &unsupported) {
+						t.Fatalf("UpdateIfMatch(%s) = %v, want *ConditionalUpdateFieldUnsupportedError", tt.name, err)
+					}
+					after, err := s.Get(created.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(after, before) {
+						t.Fatalf("restricted conditional update mutated bead: before=%#v after=%#v", before, after)
+					}
 				})
-				if err != nil {
-					t.Fatal(err)
-				}
-				before, err := s.Get(created.ID)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				err = w.UpdateIfMatch(created.ID, before.Revision, tt.opts)
-				var unsupported *beads.ConditionalUpdateFieldUnsupportedError
-				if !errors.As(err, &unsupported) {
-					t.Fatalf("UpdateIfMatch(%s) = %v, want *ConditionalUpdateFieldUnsupportedError", tt.name, err)
-				}
-				after, err := s.Get(created.ID)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if !reflect.DeepEqual(after, before) {
-					t.Fatalf("restricted conditional update mutated bead: before=%#v after=%#v", before, after)
-				}
-			})
-		}
-	})
+			}
+		})
+	}
 
 	t.Run(name+"/reads_never_bump", func(t *testing.T) {
 		s := open(t)
@@ -190,11 +200,13 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		}
 		id := b.ID
 
+		// A never-mutated bead may legitimately carry the zero token on a
+		// counter-backed store, so seed the seen set only from a real token.
 		last := revOf(t, s, id)
-		if last == 0 {
-			t.Fatal("created bead has zero revision")
+		seen := map[int64]struct{}{}
+		if last != 0 {
+			seen[last] = struct{}{}
 		}
-		seen := map[int64]struct{}{last: {}}
 		for i := 0; i < 8; i++ {
 			if err := s.SetMetadata(id, "counter", string(rune('a'+i))); err != nil {
 				t.Fatal(err)

--- a/internal/beads/beadstest/conditional_writer_conformance.go
+++ b/internal/beads/beadstest/conditional_writer_conformance.go
@@ -2,6 +2,7 @@ package beadstest
 
 import (
 	"errors"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -12,6 +13,12 @@ import (
 // ConditionalWriterOptions controls optional legs of the ConditionalWriter
 // conformance suite that not every store can express.
 type ConditionalWriterOptions struct {
+	// RowBackedMutationFlavors declares that direct whole-row mutation flavors
+	// expose their fresh revision through the Store read surface. MemStore,
+	// FileStore, and real BdStore do; wrappers whose cache projection cannot
+	// preserve every unconditional flavor leave this false.
+	RowBackedMutationFlavors bool
+
 	// OpenDisabled returns a fresh store of the same kind whose conditional
 	// writes are turned off at the instance level (e.g. MemStore/FileStore with
 	// DisableConditionalWrites=true). When non-nil, the disable_toggle subtest
@@ -77,7 +84,7 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 
 	t.Run(name, func(t *testing.T) { runEmptyUpdateContract(t, open) })
 
-	t.Run(name+"/every_mutation_bumps_revision", func(t *testing.T) {
+	t.Run(name+"/whole_bead_conditional_write_changes_revision", func(t *testing.T) {
 		s := open(t)
 		w := writerFor(t, s)
 		b, err := s.Create(beads.Bead{Title: "orig"})
@@ -86,55 +93,62 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		}
 		id := b.ID
 
-		prev := revOf(t, s, id)
-		bump := func(label string, mutate func() error) {
-			t.Helper()
-			if err := mutate(); err != nil {
-				t.Fatalf("%s: %v", label, err)
-			}
-			cur := revOf(t, s, id)
-			if cur <= prev {
-				t.Fatalf("%s did not bump revision: %d -> %d (want strictly greater)", label, prev, cur)
-			}
-			prev = cur
+		before := revOf(t, s, id)
+		if err := w.UpdateIfMatch(id, before, beads.UpdateOpts{Title: strPtr("renamed")}); err != nil {
+			t.Fatalf("UpdateIfMatch: %v", err)
+		}
+		after := revOf(t, s, id)
+		if after == 0 || after == before {
+			t.Fatalf("UpdateIfMatch did not change to a nonzero revision: %d -> %d", before, after)
+		}
+	})
+
+	t.Run(name+"/restricted_update_fields_are_rejected_without_mutation", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		parentBefore, err := s.Create(beads.Bead{Title: "restricted-update-parent"})
+		if err != nil {
+			t.Fatalf("Create parent fixture: %v", err)
+		}
+		parent := "parent-after"
+		tests := []struct {
+			name string
+			opts beads.UpdateOpts
+		}{
+			{name: "parent", opts: beads.UpdateOpts{ParentID: &parent}},
+			{name: "add_labels", opts: beads.UpdateOpts{Labels: []string{"added"}}},
+			{name: "remove_labels", opts: beads.UpdateOpts{RemoveLabels: []string{"remove"}}},
 		}
 
-		// Every UpdateOpts field flavor is exercised separately: MemStore bumps
-		// once regardless, but BdStore fans different opts to different bd
-		// subcommands, so a per-field missed bump is exactly what this catches.
-		bump("Update(title)", func() error { return s.Update(id, beads.UpdateOpts{Title: strPtr("renamed")}) })
-		bump("Update(labels)", func() error { return s.Update(id, beads.UpdateOpts{Labels: []string{"alpha"}}) })
-		bump("Update(status)", func() error { return s.Update(id, beads.UpdateOpts{Status: strPtr("in_progress")}) })
-		bump("Update(description)", func() error { return s.Update(id, beads.UpdateOpts{Description: strPtr("desc")}) })
-		bump("Update(priority)", func() error { p := 2; return s.Update(id, beads.UpdateOpts{Priority: &p}) })
-		bump("Update(metadata-opt)", func() error { return s.Update(id, beads.UpdateOpts{Metadata: map[string]string{"mo": "1"}}) })
-		bump("Update(removeLabels)", func() error { return s.Update(id, beads.UpdateOpts{RemoveLabels: []string{"alpha"}}) })
-		bump("SetMetadata", func() error { return s.SetMetadata(id, "k", "v") })
-		bump("Update(assignee)", func() error { return s.Update(id, beads.UpdateOpts{Assignee: strPtr("agent")}) })
-		// Close then Reopen. Isolate each verb's bump where the store allows a Get
-		// on a closed bead (MemStore, FileStore, bd); for stores that return
-		// ErrNotFound from Get on a closed bead (CachingStore), fall back to
-		// asserting only that the Close+Reopen pair bumped.
-		if err := s.Close(id); err != nil {
-			t.Fatalf("Close: %v", err)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				created, err := s.Create(beads.Bead{
+					Title:    "restricted-update",
+					ParentID: parentBefore.ID,
+					Labels:   []string{"keep", "remove"},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				before, err := s.Get(created.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = w.UpdateIfMatch(created.ID, before.Revision, tt.opts)
+				var unsupported *beads.ConditionalUpdateFieldUnsupportedError
+				if !errors.As(err, &unsupported) {
+					t.Fatalf("UpdateIfMatch(%s) = %v, want *ConditionalUpdateFieldUnsupportedError", tt.name, err)
+				}
+				after, err := s.Get(created.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(after, before) {
+					t.Fatalf("restricted conditional update mutated bead: before=%#v after=%#v", before, after)
+				}
+			})
 		}
-		if closed, err := s.Get(id); err == nil {
-			if closed.Revision <= prev {
-				t.Fatalf("Close did not bump revision: %d -> %d", prev, closed.Revision)
-			}
-			prev = closed.Revision
-		}
-		bump("Reopen", func() error { return s.Reopen(id) })
-		bump("CompareAndSetMetadataKey", func() error {
-			ok, err := w.CompareAndSetMetadataKey(id, "casKey", "", "first")
-			if err != nil {
-				return err
-			}
-			if !ok {
-				t.Fatal("CompareAndSetMetadataKey claiming an absent key returned (false, nil)")
-			}
-			return nil
-		})
 	})
 
 	t.Run(name+"/reads_never_bump", func(t *testing.T) {
@@ -168,7 +182,7 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		}
 	})
 
-	t.Run(name+"/revision_monotonic_never_reused", func(t *testing.T) {
+	t.Run(name+"/revision_tokens_are_never_reused_during_a_bead_lifetime", func(t *testing.T) {
 		s := open(t)
 		b, err := s.Create(beads.Bead{Title: "mono"})
 		if err != nil {
@@ -176,24 +190,181 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		}
 		id := b.ID
 
-		seen := map[int64]bool{}
 		last := revOf(t, s, id)
-		seen[last] = true
+		if last == 0 {
+			t.Fatal("created bead has zero revision")
+		}
+		seen := map[int64]struct{}{last: {}}
 		for i := 0; i < 8; i++ {
 			if err := s.SetMetadata(id, "counter", string(rune('a'+i))); err != nil {
 				t.Fatal(err)
 			}
 			cur := revOf(t, s, id)
-			if cur <= last {
-				t.Fatalf("revision not monotonic at step %d: %d -> %d", i, last, cur)
+			if cur == 0 || cur == last {
+				t.Fatalf("revision did not change to a nonzero token at step %d: %d -> %d", i, last, cur)
 			}
-			if seen[cur] {
-				t.Fatalf("revision %d reused at step %d", cur, i)
+			if _, exists := seen[cur]; exists {
+				t.Fatalf("revision token %d was reused at step %d", cur, i)
 			}
-			seen[cur] = true
+			seen[cur] = struct{}{}
 			last = cur
 		}
 	})
+
+	t.Run(name+"/release_if_current_mints_revision_and_stales_prior_token", func(t *testing.T) {
+		s := open(t)
+		w := writerFor(t, s)
+		releaser, ok := s.(beads.ConditionalAssignmentReleaser)
+		if !ok {
+			t.Fatalf("%T does not implement ConditionalAssignmentReleaser", s)
+		}
+		created, err := s.Create(beads.Bead{
+			Title:    "release-fence",
+			Assignee: "worker-1",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		inProgress := "in_progress"
+		if err := s.Update(created.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+			t.Fatal(err)
+		}
+		before, err := s.Get(created.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		released, err := releaser.ReleaseIfCurrent(created.ID, "worker-2")
+		if err != nil {
+			t.Fatalf("ReleaseIfCurrent wrong assignee: %v", err)
+		}
+		if released {
+			t.Fatal("ReleaseIfCurrent wrong assignee = true, want false")
+		}
+		afterNoop, err := s.Get(created.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if afterNoop.Revision != before.Revision {
+			t.Fatalf("no-op ReleaseIfCurrent minted revision %d -> %d", before.Revision, afterNoop.Revision)
+		}
+
+		released, err = releaser.ReleaseIfCurrent(created.ID, "worker-1")
+		if err != nil {
+			t.Fatalf("ReleaseIfCurrent matching assignee: %v", err)
+		}
+		if !released {
+			t.Fatal("ReleaseIfCurrent matching assignee = false, want true")
+		}
+		afterRelease, err := s.Get(created.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if afterRelease.Revision == 0 || afterRelease.Revision == before.Revision {
+			t.Fatalf("ReleaseIfCurrent did not mint a fresh nonzero revision: %d -> %d", before.Revision, afterRelease.Revision)
+		}
+		if afterRelease.Status != "open" || afterRelease.Assignee != "" {
+			t.Fatalf("released bead = %+v, want open and unassigned", afterRelease)
+		}
+
+		title := "stale overwrite"
+		err = w.UpdateIfMatch(created.ID, before.Revision, beads.UpdateOpts{Title: &title})
+		if !beads.IsPreconditionFailed(err) {
+			t.Fatalf("UpdateIfMatch with pre-release revision = %v, want precondition failure", err)
+		}
+		final, err := s.Get(created.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final.Title != "release-fence" {
+			t.Fatalf("stale pre-release write changed title to %q", final.Title)
+		}
+	})
+
+	if opts.RowBackedMutationFlavors {
+		t.Run(name+"/row_backed_mutation_flavors_mint_fresh_tokens", func(t *testing.T) {
+			s := open(t)
+			w := writerFor(t, s)
+			strPtr := func(s string) *string { return &s }
+			row, err := s.Create(beads.Bead{Title: "row-backed-mutations"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			seen := map[int64]struct{}{revOf(t, s, row.ID): {}}
+			priority := 2
+
+			assertFresh := func(label string, mutate func() error) {
+				t.Helper()
+				before := revOf(t, s, row.ID)
+				if err := mutate(); err != nil {
+					t.Fatalf("%s: %v", label, err)
+				}
+				after := revOf(t, s, row.ID)
+				if after == 0 || after == before {
+					t.Fatalf("%s did not mint a fresh nonzero revision: %d -> %d", label, before, after)
+				}
+				if _, exists := seen[after]; exists {
+					t.Fatalf("%s reused revision token %d", label, after)
+				}
+				seen[after] = struct{}{}
+			}
+
+			updates := []struct {
+				name string
+				opts beads.UpdateOpts
+			}{
+				{name: "Update(title)", opts: beads.UpdateOpts{Title: strPtr("updated")}},
+				{name: "Update(status)", opts: beads.UpdateOpts{Status: strPtr("in_progress")}},
+				{name: "Update(type)", opts: beads.UpdateOpts{Type: strPtr("task")}},
+				{name: "Update(priority)", opts: beads.UpdateOpts{Priority: &priority}},
+				{name: "Update(description)", opts: beads.UpdateOpts{Description: strPtr("description")}},
+				{name: "Update(assignee)", opts: beads.UpdateOpts{Assignee: strPtr("agent")}},
+				{name: "Update(metadata)", opts: beads.UpdateOpts{Metadata: map[string]string{"update_metadata": "value"}}},
+			}
+			for _, update := range updates {
+				assertFresh(update.name, func() error { return s.Update(row.ID, update.opts) })
+			}
+
+			assertFresh("SetMetadata", func() error {
+				return s.SetMetadata(row.ID, "key", "value")
+			})
+
+			assertFresh("SetMetadataBatch", func() error {
+				return s.SetMetadataBatch(row.ID, map[string]string{"left": "one", "right": "two"})
+			})
+
+			assertFresh("UpdateIfMatch", func() error {
+				return w.UpdateIfMatch(row.ID, revOf(t, s, row.ID), beads.UpdateOpts{Title: strPtr("conditional-updated")})
+			})
+
+			assertFresh("CompareAndSetMetadataKey", func() error {
+				ok, err := w.CompareAndSetMetadataKey(row.ID, "conditional_metadata", "", "value")
+				if err != nil {
+					return err
+				}
+				if !ok {
+					t.Fatal("CompareAndSetMetadataKey claiming an absent key returned (false, nil)")
+				}
+				return nil
+			})
+
+			assertFresh("Close", func() error { return s.Close(row.ID) })
+			assertFresh("Reopen", func() error { return s.Reopen(row.ID) })
+
+			conditionalClose, err := s.Create(beads.Bead{Title: "conditional-close"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			before := revOf(t, s, conditionalClose.ID)
+			if err := w.CloseIfMatch(conditionalClose.ID, before); err != nil {
+				t.Fatalf("CloseIfMatch: %v", err)
+			}
+			after := revOf(t, s, conditionalClose.ID)
+			if after == 0 || after == before {
+				t.Fatalf("CloseIfMatch did not mint a fresh nonzero revision: %d -> %d", before, after)
+			}
+		})
+	}
 
 	t.Run(name+"/stale_revision_is_precondition_failed", func(t *testing.T) {
 		s := open(t)
@@ -260,8 +431,8 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		if got.Title != "applied" {
 			t.Fatalf("UpdateIfMatch did not apply opts: title = %q, want %q", got.Title, "applied")
 		}
-		if got.Revision <= aRev {
-			t.Fatalf("UpdateIfMatch did not bump revision: %d -> %d", aRev, got.Revision)
+		if got.Revision == 0 || got.Revision == aRev {
+			t.Fatalf("UpdateIfMatch did not change to a nonzero revision: %d -> %d", aRev, got.Revision)
 		}
 
 		// CloseIfMatch at the current revision succeeds.
@@ -454,8 +625,8 @@ func RunConditionalWriterConformanceWithOptions(t *testing.T, name string, open 
 		if got := after.Metadata["sibling"]; got != "preserved" {
 			t.Fatalf("unrelated sibling metadata = %q, want %q", got, "preserved")
 		}
-		if after.Revision == before.Revision {
-			t.Fatalf("sole successful UpdateIfMatch did not bump revision %d", before.Revision)
+		if after.Revision == 0 || after.Revision == before.Revision {
+			t.Fatalf("sole successful UpdateIfMatch did not change to a nonzero revision: %d -> %d", before.Revision, after.Revision)
 		}
 	})
 

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -29,18 +29,19 @@ type CachingStore struct {
 	backing  Store // runtime: usually *BdStore; tests and projections may use any Store
 	idPrefix string
 
-	mu              sync.RWMutex
-	beads           map[string]Bead
-	deps            map[string][]Dep
-	depsComplete    bool
-	dirty           map[string]struct{}
-	beadSeq         map[string]uint64
-	localBeadAt     map[string]time.Time
-	deletedSeq      map[string]uint64
-	state           cacheState
-	lastFreshAt     time.Time
-	mutationSeq     uint64
-	primePartialErr error
+	mu                  sync.RWMutex
+	beads               map[string]Bead
+	deps                map[string][]Dep
+	depsComplete        bool
+	dirty               map[string]struct{}
+	beadSeq             map[string]uint64
+	localBeadAt         map[string]time.Time
+	deletedSeq          map[string]uint64
+	state               cacheState
+	lastFreshAt         time.Time
+	mutationSeq         uint64
+	observationRevision uint64
+	primePartialErr     error
 
 	// readyProjectionDegraded latches when the backing store reported it cannot
 	// serve the ready projection at all. It is deliberately NOT primePartialErr:
@@ -93,6 +94,13 @@ type CachingStore struct {
 	latencyDriverActive bool
 
 	applyEventBeforeCommitForTest func()
+}
+
+// CacheObservation is an opaque, process-local stamp returned with a cached
+// active-bead census. It is valid only with its originating CachingStore.
+type CacheObservation struct {
+	owner    *CachingStore
+	revision uint64
 }
 
 var (
@@ -361,6 +369,7 @@ func (c *CachingStore) WaitForParentProjection(ctx context.Context, id, oldParen
 }
 
 func (c *CachingStore) noteMutationLocked(ids ...string) uint64 {
+	c.advanceObservationLocked()
 	c.mutationSeq++
 	seq := c.mutationSeq
 	for _, id := range ids {
@@ -370,6 +379,16 @@ func (c *CachingStore) noteMutationLocked(ids ...string) uint64 {
 		c.beadSeq[id] = seq
 	}
 	return seq
+}
+
+// advanceObservationLocked invalidates cache observations without changing the
+// mutation-sequence fences used by reconciliation. Caller must hold c.mu.
+func (c *CachingStore) advanceObservationLocked() {
+	if c.observationRevision == ^uint64(0) {
+		c.observationRevision = 1
+		return
+	}
+	c.observationRevision++
 }
 
 func (c *CachingStore) noteLocalMutationLocked(ids ...string) uint64 {
@@ -463,6 +482,7 @@ type absorbOpts struct {
 // state. now is the caller's clock read for the whole pass; it is consulted
 // only by seqClearGuarded. Caller must hold c.mu in write mode.
 func (c *CachingStore) absorbFreshLocked(id string, bead Bead, now time.Time, opts absorbOpts) {
+	c.advanceObservationLocked()
 	bead = c.absorbReadyProjectionLocked(id, bead, opts)
 	c.beads[id] = cloneBead(bead)
 	switch opts.depsMode {
@@ -632,6 +652,7 @@ func (c *CachingStore) readyProjectionUnknownLocked(id string) bool {
 // not touch mutationSeq, depsComplete, state, or stats. Caller must hold c.mu
 // in write mode.
 func (c *CachingStore) evictLocked(id string) {
+	c.advanceObservationLocked()
 	delete(c.beads, id)
 	delete(c.deps, id)
 	delete(c.dirty, id)
@@ -652,6 +673,7 @@ func (c *CachingStore) tombstoneLocked(id string, seq uint64) {
 // markDirtyLocked flags id as known-stale so reads bypass the cache until a
 // refresh clears the mark. Caller must hold c.mu in write mode.
 func (c *CachingStore) markDirtyLocked(id string) {
+	c.advanceObservationLocked()
 	c.dirty[id] = struct{}{}
 }
 
@@ -948,6 +970,7 @@ func (c *CachingStore) PrimeActive() error {
 		c.state = cachePartial
 	}
 	c.primePartialErr = partialErr
+	c.advanceObservationLocked()
 	c.markFreshLocked(now)
 	c.updateStatsLocked()
 	return nil
@@ -1111,6 +1134,7 @@ func (c *CachingStore) prime(ctx context.Context) error {
 	c.circuitTripped = false
 	c.stats.SyncFailures = 0
 	c.primePartialErr = partialErr
+	c.advanceObservationLocked()
 	c.markFreshLocked(now)
 	c.updateStatsLocked()
 	return nil

--- a/internal/beads/caching_store_conditional.go
+++ b/internal/beads/caching_store_conditional.go
@@ -31,9 +31,54 @@ import (
 // succeeds, feeds the change notification verbatim and nothing else.
 var (
 	_ ConditionalWriter                = (*CachingStore)(nil)
+	_ AtomicConditionalCloser          = (*CachingStore)(nil)
 	_ conditionalWritesModeCarrier     = (*CachingStore)(nil)
 	_ conditionalWriteCapabilityProber = (*CachingStore)(nil)
 )
+
+// CloseWithMetadataIfMatch delegates the indivisible terminal write only when
+// its resolved backing exposes that capability. The cache always evicts after
+// a proven success: no returned row can be attributed to this write, so
+// retaining one would invent a revisioned snapshot. The closed notification is
+// emitted exactly once even when a backing hides closed beads from Get.
+func (c *CachingStore) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error {
+	closer, ok := AtomicConditionalCloserFor(c.conditionalBacking())
+	if !ok {
+		return ErrConditionalWriteUnsupported
+	}
+	if err := closer.CloseWithMetadataIfMatch(id, expectedRevision, metadata); err != nil {
+		c.applyConditionalWriteFailure(id, err)
+		return err
+	}
+
+	fresh, err := c.backing.Get(id)
+	c.evictForConditionalWrite(id)
+	if err == nil {
+		// The successful capability call proves the terminal status. Do not
+		// install this best-effort reread into the cache.
+		fresh.Status = "closed"
+		c.notifyChange("bead.closed", fresh)
+		return nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		c.recordProblem("refresh bead after atomic conditional close", fmt.Errorf("%s: %w", id, err))
+	}
+	// The capability call is the proof of closure; ID and terminal status are
+	// the only facts safe to publish when the reread is unavailable.
+	c.notifyChange("bead.closed", Bead{ID: id, Status: "closed"})
+	return nil
+}
+
+// AtomicConditionalCloserHandle exposes the cache forwarding surface only when
+// its resolved backing can perform the atomic terminal write. Returning the
+// cache (rather than the backing) preserves eviction and notification semantics
+// for callers that discover the optional capability through this handle.
+func (c *CachingStore) AtomicConditionalCloserHandle() (AtomicConditionalCloser, bool) {
+	if _, ok := AtomicConditionalCloserFor(c.conditionalBacking()); !ok {
+		return nil, false
+	}
+	return c, true
+}
 
 // The cache is a wrapper, not a second store, so it carries no
 // conditional-writes stamp of its own (§6.3): the stamp, its read, and the

--- a/internal/beads/caching_store_conditional.go
+++ b/internal/beads/caching_store_conditional.go
@@ -114,6 +114,9 @@ func (c *CachingStore) probeConditionalWriteCapability() (bool, string) {
 // fails or the precondition does. A backing without the capability yields
 // ErrConditionalWriteUnsupported — never an unconditional write.
 func (c *CachingStore) UpdateIfMatch(id string, expectedRevision int64, opts UpdateOpts) error {
+	if err := validateConditionalUpdateOpts(opts); err != nil {
+		return fmt.Errorf("conditional update %s: %w", id, err)
+	}
 	writer, ok := ConditionalWriterFor(c.conditionalBacking())
 	if !ok {
 		return ErrConditionalWriteUnsupported

--- a/internal/beads/caching_store_conditional.go
+++ b/internal/beads/caching_store_conditional.go
@@ -31,42 +31,27 @@ import (
 // succeeds, feeds the change notification verbatim and nothing else.
 var (
 	_ ConditionalWriter                = (*CachingStore)(nil)
-	_ AtomicConditionalCloser          = (*CachingStore)(nil)
 	_ conditionalWritesModeCarrier     = (*CachingStore)(nil)
 	_ conditionalWriteCapabilityProber = (*CachingStore)(nil)
 )
 
-// CloseWithMetadataIfMatch delegates the indivisible terminal write only when
-// its resolved backing exposes that capability. The cache always evicts after
-// a proven success: no returned row can be attributed to this write, so
-// retaining one would invent a revisioned snapshot. The closed notification is
-// emitted exactly once even when a backing hides closed beads from Get.
-func (c *CachingStore) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error {
-	closer, ok := AtomicConditionalCloserFor(c.conditionalBacking())
-	if !ok {
-		return ErrConditionalWriteUnsupported
-	}
-	if err := closer.CloseWithMetadataIfMatch(id, expectedRevision, metadata); err != nil {
-		c.applyConditionalWriteFailure(id, err)
-		return err
-	}
+// cachingAtomicConditionalCloser preserves cache eviction and notification
+// while exposing the capability only for a backing that actually supports it.
+type cachingAtomicConditionalCloser struct{ cache *CachingStore }
 
-	fresh, err := c.backing.Get(id)
-	c.evictForConditionalWrite(id)
-	if err == nil {
-		// The successful capability call proves the terminal status. Do not
-		// install this best-effort reread into the cache.
-		fresh.Status = "closed"
-		c.notifyChange("bead.closed", fresh)
-		return nil
+func (h *cachingAtomicConditionalCloser) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) (Bead, error) {
+	closer, ok := AtomicConditionalCloserFor(h.cache.conditionalBacking())
+	if !ok {
+		return Bead{}, ErrConditionalWriteUnsupported
 	}
-	if !errors.Is(err, ErrNotFound) {
-		c.recordProblem("refresh bead after atomic conditional close", fmt.Errorf("%s: %w", id, err))
+	closed, err := closer.CloseWithMetadataIfMatch(id, expectedRevision, metadata)
+	if err != nil {
+		h.cache.applyConditionalWriteFailure(id, err)
+		return Bead{}, err
 	}
-	// The capability call is the proof of closure; ID and terminal status are
-	// the only facts safe to publish when the reread is unavailable.
-	c.notifyChange("bead.closed", Bead{ID: id, Status: "closed"})
-	return nil
+	h.cache.evictForConditionalWrite(id)
+	h.cache.notifyChange("bead.closed", closed)
+	return closed, nil
 }
 
 // AtomicConditionalCloserHandle exposes the cache forwarding surface only when
@@ -77,7 +62,7 @@ func (c *CachingStore) AtomicConditionalCloserHandle() (AtomicConditionalCloser,
 	if _, ok := AtomicConditionalCloserFor(c.conditionalBacking()); !ok {
 		return nil, false
 	}
-	return c, true
+	return &cachingAtomicConditionalCloser{cache: c}, true
 }
 
 // The cache is a wrapper, not a second store, so it carries no

--- a/internal/beads/caching_store_conditional_internal_test.go
+++ b/internal/beads/caching_store_conditional_internal_test.go
@@ -32,6 +32,38 @@ type casBackingStore struct {
 	onListOnce func()
 }
 
+type atomicConditionalCloseBacking struct {
+	Store
+	closeCalls  int
+	closeErr    error
+	hideClosed  bool
+	failNextGet bool
+}
+
+func (s *atomicConditionalCloseBacking) Get(id string) (Bead, error) {
+	if s.failNextGet {
+		s.failNextGet = false
+		return Bead{}, errors.New("injected atomic-close refresh failure")
+	}
+	b, err := s.Store.Get(id)
+	if err == nil && s.hideClosed && b.Status == "closed" {
+		return Bead{}, ErrNotFound
+	}
+	return b, err
+}
+
+func (s *atomicConditionalCloseBacking) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error {
+	s.closeCalls++
+	if s.closeErr != nil {
+		return s.closeErr
+	}
+	closer, ok := AtomicConditionalCloserFor(s.Store)
+	if !ok {
+		return ErrConditionalWriteUnsupported
+	}
+	return closer.CloseWithMetadataIfMatch(id, expectedRevision, metadata)
+}
+
 func (s *casBackingStore) List(query ListQuery) ([]Bead, error) {
 	items, err := s.Store.List(query)
 	if hook := s.onListOnce; hook != nil {
@@ -598,6 +630,258 @@ func TestCachingStoreCloseIfMatchClearsDependentReadyProjection(t *testing.T) {
 		t.Fatalf("CachedReady after fenced close = %v, want the dependent unblocked (its projected IsBlocked must be cleared)",
 			readyByID)
 	}
+}
+
+func TestCachingStoreCloseWithMetadataIfMatchDelegatesAndEmitsOnlyClosed(t *testing.T) {
+	var notes []cacheWriteNotification
+	backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	created, err := cache.Create(Bead{Title: "atomic cached close", Metadata: map[string]string{"sibling": "kept"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	notes = nil
+	if err := cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if len(notes) != 1 || notes[0].eventType != "bead.closed" || notes[0].beadID != created.ID {
+		t.Fatalf("notifications = %+v, want exactly one bead.closed for %s", notes, created.ID)
+	}
+	fresh, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after close: %v", err)
+	}
+	if fresh.Status != "closed" || fresh.Metadata["sibling"] != "kept" || fresh.Metadata["state"] != "drained" {
+		t.Fatalf("post-close bead = %#v, want closed with merged metadata", fresh)
+	}
+}
+
+func TestCachingStoreCloseWithMetadataIfMatchUnsupportedBackingDoesNotMutateOrNotify(t *testing.T) {
+	var notes []cacheWriteNotification
+	backing := NewMemStore()
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	created, err := cache.Create(Bead{Title: "unsupported atomic close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	notes = nil
+	err = cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"})
+	if !IsConditionalWriteUnsupported(err) {
+		t.Fatalf("CloseWithMetadataIfMatch error = %v, want unsupported", err)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("notifications = %+v, want none after unsupported close", notes)
+	}
+	fresh, err := backing.Get(created.ID)
+	if err != nil {
+		t.Fatalf("backing Get: %v", err)
+	}
+	if fresh.Status != "open" || fresh.Metadata["state"] != "" {
+		t.Fatalf("unsupported close mutated backing: %#v", fresh)
+	}
+}
+
+func TestCachingStoreCloseWithMetadataIfMatchBackingFailureMarksDirtyWithoutNotification(t *testing.T) {
+	sentinel := errors.New("injected atomic close failure")
+	var notes []cacheWriteNotification
+	backing := &atomicConditionalCloseBacking{
+		Store:    newNativeDoltStoreForTest(newNativeDoltMemStorage()),
+		closeErr: sentinel,
+	}
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	created, err := cache.Create(Bead{Title: "atomic close failure"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	notes = nil
+	err = cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("CloseWithMetadataIfMatch error = %v, want injected failure", err)
+	}
+	if backing.closeCalls != 1 {
+		t.Fatalf("backing close calls = %d, want one delegated call", backing.closeCalls)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("notifications = %+v, want none after failed close", notes)
+	}
+	cache.mu.RLock()
+	_, cached := cache.beads[created.ID]
+	_, dirty := cache.dirty[created.ID]
+	cache.mu.RUnlock()
+	if !cached || !dirty {
+		t.Fatalf("failure cache state cached=%v dirty=%v, want retained-but-dirty for an ambiguous backing error", cached, dirty)
+	}
+}
+
+func TestCachingStoreCloseWithMetadataIfMatchNotifiesWhenClosedRowsAreHidden(t *testing.T) {
+	var notes []cacheWriteNotification
+	backing := &atomicConditionalCloseBacking{
+		Store:      newNativeDoltStoreForTest(newNativeDoltMemStorage()),
+		hideClosed: true,
+	}
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	created, err := cache.Create(Bead{Title: "hidden atomic close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	notes = nil
+	if err := cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if len(notes) != 1 || notes[0].eventType != "bead.closed" || notes[0].beadID != created.ID {
+		t.Fatalf("notifications = %+v, want exactly one closed notification", notes)
+	}
+	var payload Bead
+	if err := json.Unmarshal(notes[0].payload, &payload); err != nil {
+		t.Fatalf("closed notification payload: %v", err)
+	}
+	if payload.ID != created.ID || payload.Status != "closed" {
+		t.Fatalf("closed notification payload = %#v, want confirmed ID and closed status", payload)
+	}
+	assertConditionalEvicted(t, cache, created.ID)
+}
+
+func TestCachingStoreCloseWithMetadataIfMatchNotifiesWhenRefreshFails(t *testing.T) {
+	var notes []cacheWriteNotification
+	backing := &atomicConditionalCloseBacking{Store: newNativeDoltStoreForTest(newNativeDoltMemStorage())}
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	created, err := cache.Create(Bead{Title: "refresh-failing atomic close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	notes = nil
+	backing.failNextGet = true
+	if err := cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if len(notes) != 1 || notes[0].eventType != "bead.closed" || notes[0].beadID != created.ID {
+		t.Fatalf("notifications = %+v, want exactly one closed notification after refresh failure", notes)
+	}
+	assertConditionalEvicted(t, cache, created.ID)
+}
+
+func TestAtomicConditionalCloserForCachingStoreResolvesBackingCapabilityHonestly(t *testing.T) {
+	t.Run("supported cache exposes its resolved native closer", func(t *testing.T) {
+		var notes []cacheWriteNotification
+		backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+		cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+			notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
+		})
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+		closer, ok := AtomicConditionalCloserFor(cache)
+		if !ok {
+			t.Fatal("AtomicConditionalCloserFor(cache) = unavailable, want native-backed capability")
+		}
+		if got, ok := closer.(*CachingStore); !ok || got != cache {
+			t.Fatalf("cache closer = %T, want CachingStore forwarding handle", closer)
+		}
+		created, err := cache.Create(Bead{Title: "handle cache close"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		got, err := cache.Get(created.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		notes = nil
+		if err := closer.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+			t.Fatalf("handle CloseWithMetadataIfMatch: %v", err)
+		}
+		if len(notes) != 1 || notes[0].eventType != "bead.closed" {
+			t.Fatalf("handle notifications = %+v, want one bead.closed", notes)
+		}
+		assertConditionalEvicted(t, cache, created.ID)
+	})
+
+	t.Run("unsupported cache does not claim a deferred failure", func(t *testing.T) {
+		cache := NewCachingStoreForTest(NewMemStore(), nil)
+		if closer, ok := AtomicConditionalCloserFor(cache); ok || closer != nil {
+			t.Fatalf("AtomicConditionalCloserFor(unsupported cache) = (%T, %v), want (nil, false)", closer, ok)
+		}
+	})
+
+	t.Run("target-declaring wrapper reaches native backing", func(t *testing.T) {
+		backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+		wrapped := &resolveTargetWrapper{Store: backing, target: backing}
+		cache := NewCachingStoreForTest(wrapped, nil)
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+		created, err := cache.Create(Bead{Title: "target wrapper atomic close"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		got, err := cache.Get(created.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		closer, ok := AtomicConditionalCloserFor(cache)
+		if !ok {
+			t.Fatal("AtomicConditionalCloserFor(target-wrapper cache) = unavailable")
+		}
+		if err := closer.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+			t.Fatalf("CloseWithMetadataIfMatch through target wrapper: %v", err)
+		}
+		fresh, err := backing.Get(created.ID)
+		if err != nil {
+			t.Fatalf("backing Get: %v", err)
+		}
+		if fresh.Status != "closed" || fresh.Metadata["state"] != "drained" {
+			t.Fatalf("target-wrapper result = %#v, want closed merged row", fresh)
+		}
+	})
 }
 
 func TestCachingStoreDeleteIfMatchMirrorsDeleteScrub(t *testing.T) {

--- a/internal/beads/caching_store_conditional_internal_test.go
+++ b/internal/beads/caching_store_conditional_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -34,34 +35,39 @@ type casBackingStore struct {
 
 type atomicConditionalCloseBacking struct {
 	Store
-	closeCalls  int
-	closeErr    error
-	hideClosed  bool
-	failNextGet bool
+	closeCalls int
+	getCalls   int
+	closeErr   error
+	afterClose func()
 }
 
 func (s *atomicConditionalCloseBacking) Get(id string) (Bead, error) {
-	if s.failNextGet {
-		s.failNextGet = false
-		return Bead{}, errors.New("injected atomic-close refresh failure")
-	}
-	b, err := s.Store.Get(id)
-	if err == nil && s.hideClosed && b.Status == "closed" {
-		return Bead{}, ErrNotFound
-	}
-	return b, err
+	s.getCalls++
+	return s.Store.Get(id)
 }
 
-func (s *atomicConditionalCloseBacking) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error {
+func (s *atomicConditionalCloseBacking) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) (Bead, error) {
 	s.closeCalls++
 	if s.closeErr != nil {
-		return s.closeErr
+		return Bead{}, s.closeErr
 	}
 	closer, ok := AtomicConditionalCloserFor(s.Store)
 	if !ok {
-		return ErrConditionalWriteUnsupported
+		return Bead{}, ErrConditionalWriteUnsupported
 	}
-	return closer.CloseWithMetadataIfMatch(id, expectedRevision, metadata)
+	closed, err := closer.CloseWithMetadataIfMatch(id, expectedRevision, metadata)
+	if err == nil && s.afterClose != nil {
+		s.afterClose()
+	}
+	return closed, err
+}
+
+func closeWithCacheHandle(cache *CachingStore, id string, revision int64, metadata map[string]string) (Bead, error) {
+	closer, ok := AtomicConditionalCloserFor(cache)
+	if !ok {
+		return Bead{}, ErrConditionalWriteUnsupported
+	}
+	return closer.CloseWithMetadataIfMatch(id, revision, metadata)
 }
 
 func (s *casBackingStore) List(query ListQuery) ([]Bead, error) {
@@ -632,9 +638,9 @@ func TestCachingStoreCloseIfMatchClearsDependentReadyProjection(t *testing.T) {
 	}
 }
 
-func TestCachingStoreCloseWithMetadataIfMatchDelegatesAndEmitsOnlyClosed(t *testing.T) {
+func TestCachingAtomicConditionalCloserReturnsExactRowWithoutPostCloseRead(t *testing.T) {
 	var notes []cacheWriteNotification
-	backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	backing := &atomicConditionalCloseBacking{Store: newNativeDoltStoreForTest(newNativeDoltMemStorage())}
 	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
 		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
 	})
@@ -651,8 +657,16 @@ func TestCachingStoreCloseWithMetadataIfMatchDelegatesAndEmitsOnlyClosed(t *test
 	}
 
 	notes = nil
-	if err := cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+	backing.getCalls = 0
+	closed, err := closeWithCacheHandle(cache, created.ID, got.Revision, map[string]string{"state": "drained"})
+	if err != nil {
 		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if closed.Status != "closed" || closed.Metadata["sibling"] != "kept" || closed.Metadata["state"] != "drained" {
+		t.Fatalf("returned bead = %#v, want exact terminal backing row", closed)
+	}
+	if backing.getCalls != 0 {
+		t.Fatalf("post-close backing Get calls = %d, want 0", backing.getCalls)
 	}
 	if len(notes) != 1 || notes[0].eventType != "bead.closed" || notes[0].beadID != created.ID {
 		t.Fatalf("notifications = %+v, want exactly one bead.closed for %s", notes, created.ID)
@@ -663,6 +677,60 @@ func TestCachingStoreCloseWithMetadataIfMatchDelegatesAndEmitsOnlyClosed(t *test
 	}
 	if fresh.Status != "closed" || fresh.Metadata["sibling"] != "kept" || fresh.Metadata["state"] != "drained" {
 		t.Fatalf("post-close bead = %#v, want closed with merged metadata", fresh)
+	}
+}
+
+func TestCachingAtomicConditionalCloserEmitsReturnedClosedRowAfterLaterReopen(t *testing.T) {
+	var notes []cacheWriteNotification
+	backing := &atomicConditionalCloseBacking{Store: newNativeDoltStoreForTest(newNativeDoltMemStorage())}
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	created, err := cache.Create(Bead{Title: "reopen after close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	current, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	backing.afterClose = func() {
+		if err := backing.Reopen(created.ID); err != nil {
+			t.Fatalf("deterministic reopen: %v", err)
+		}
+	}
+
+	notes = nil
+	backing.getCalls = 0
+	closed, err := closeWithCacheHandle(cache, created.ID, current.Revision, map[string]string{"state": "drained"})
+	if err != nil {
+		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if closed.Status != "closed" {
+		t.Fatalf("returned bead status = %q, want closed", closed.Status)
+	}
+	if backing.getCalls != 0 {
+		t.Fatalf("post-close backing Get calls = %d, want 0", backing.getCalls)
+	}
+	if len(notes) != 1 || notes[0].eventType != "bead.closed" {
+		t.Fatalf("notifications = %+v, want exactly one bead.closed", notes)
+	}
+	var emitted Bead
+	if err := json.Unmarshal(notes[0].payload, &emitted); err != nil {
+		t.Fatalf("decode closed payload: %v", err)
+	}
+	if emitted.ID != closed.ID || emitted.Title != closed.Title || emitted.Status != closed.Status || !reflect.DeepEqual(emitted.Metadata, closed.Metadata) {
+		t.Fatalf("emitted bead = %#v, want wire-equivalent returned bead %#v", emitted, closed)
+	}
+	fresh, err := backing.Store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("backing Get after reopen: %v", err)
+	}
+	if fresh.Status != "open" {
+		t.Fatalf("backing status after reopen = %q, want open", fresh.Status)
 	}
 }
 
@@ -685,7 +753,7 @@ func TestCachingStoreCloseWithMetadataIfMatchUnsupportedBackingDoesNotMutateOrNo
 	}
 
 	notes = nil
-	err = cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"})
+	_, err = closeWithCacheHandle(cache, created.ID, got.Revision, map[string]string{"state": "drained"})
 	if !IsConditionalWriteUnsupported(err) {
 		t.Fatalf("CloseWithMetadataIfMatch error = %v, want unsupported", err)
 	}
@@ -724,7 +792,7 @@ func TestCachingStoreCloseWithMetadataIfMatchBackingFailureMarksDirtyWithoutNoti
 	}
 
 	notes = nil
-	err = cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"})
+	_, err = closeWithCacheHandle(cache, created.ID, got.Revision, map[string]string{"state": "drained"})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("CloseWithMetadataIfMatch error = %v, want injected failure", err)
 	}
@@ -743,73 +811,6 @@ func TestCachingStoreCloseWithMetadataIfMatchBackingFailureMarksDirtyWithoutNoti
 	}
 }
 
-func TestCachingStoreCloseWithMetadataIfMatchNotifiesWhenClosedRowsAreHidden(t *testing.T) {
-	var notes []cacheWriteNotification
-	backing := &atomicConditionalCloseBacking{
-		Store:      newNativeDoltStoreForTest(newNativeDoltMemStorage()),
-		hideClosed: true,
-	}
-	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
-		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
-	})
-	if err := cache.Prime(context.Background()); err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
-	created, err := cache.Create(Bead{Title: "hidden atomic close"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	got, err := cache.Get(created.ID)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-
-	notes = nil
-	if err := cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
-		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
-	}
-	if len(notes) != 1 || notes[0].eventType != "bead.closed" || notes[0].beadID != created.ID {
-		t.Fatalf("notifications = %+v, want exactly one closed notification", notes)
-	}
-	var payload Bead
-	if err := json.Unmarshal(notes[0].payload, &payload); err != nil {
-		t.Fatalf("closed notification payload: %v", err)
-	}
-	if payload.ID != created.ID || payload.Status != "closed" {
-		t.Fatalf("closed notification payload = %#v, want confirmed ID and closed status", payload)
-	}
-	assertConditionalEvicted(t, cache, created.ID)
-}
-
-func TestCachingStoreCloseWithMetadataIfMatchNotifiesWhenRefreshFails(t *testing.T) {
-	var notes []cacheWriteNotification
-	backing := &atomicConditionalCloseBacking{Store: newNativeDoltStoreForTest(newNativeDoltMemStorage())}
-	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
-		notes = append(notes, cacheWriteNotification{eventType: eventType, beadID: beadID, payload: payload})
-	})
-	if err := cache.Prime(context.Background()); err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
-	created, err := cache.Create(Bead{Title: "refresh-failing atomic close"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	got, err := cache.Get(created.ID)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-
-	notes = nil
-	backing.failNextGet = true
-	if err := cache.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
-		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
-	}
-	if len(notes) != 1 || notes[0].eventType != "bead.closed" || notes[0].beadID != created.ID {
-		t.Fatalf("notifications = %+v, want exactly one closed notification after refresh failure", notes)
-	}
-	assertConditionalEvicted(t, cache, created.ID)
-}
-
 func TestAtomicConditionalCloserForCachingStoreResolvesBackingCapabilityHonestly(t *testing.T) {
 	t.Run("supported cache exposes its resolved native closer", func(t *testing.T) {
 		var notes []cacheWriteNotification
@@ -824,8 +825,11 @@ func TestAtomicConditionalCloserForCachingStoreResolvesBackingCapabilityHonestly
 		if !ok {
 			t.Fatal("AtomicConditionalCloserFor(cache) = unavailable, want native-backed capability")
 		}
-		if got, ok := closer.(*CachingStore); !ok || got != cache {
-			t.Fatalf("cache closer = %T, want CachingStore forwarding handle", closer)
+		if _, ok := any(cache).(AtomicConditionalCloser); ok {
+			t.Fatal("CachingStore directly implements AtomicConditionalCloser")
+		}
+		if _, ok := closer.(*cachingAtomicConditionalCloser); !ok {
+			t.Fatalf("cache closer = %T, want private cache forwarding handle", closer)
 		}
 		created, err := cache.Create(Bead{Title: "handle cache close"})
 		if err != nil {
@@ -836,7 +840,7 @@ func TestAtomicConditionalCloserForCachingStoreResolvesBackingCapabilityHonestly
 			t.Fatalf("Get: %v", err)
 		}
 		notes = nil
-		if err := closer.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+		if _, err := closer.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
 			t.Fatalf("handle CloseWithMetadataIfMatch: %v", err)
 		}
 		if len(notes) != 1 || notes[0].eventType != "bead.closed" {
@@ -847,6 +851,9 @@ func TestAtomicConditionalCloserForCachingStoreResolvesBackingCapabilityHonestly
 
 	t.Run("unsupported cache does not claim a deferred failure", func(t *testing.T) {
 		cache := NewCachingStoreForTest(NewMemStore(), nil)
+		if _, ok := any(cache).(AtomicConditionalCloser); ok {
+			t.Fatal("unsupported cache directly implements AtomicConditionalCloser")
+		}
 		if closer, ok := AtomicConditionalCloserFor(cache); ok || closer != nil {
 			t.Fatalf("AtomicConditionalCloserFor(unsupported cache) = (%T, %v), want (nil, false)", closer, ok)
 		}
@@ -855,6 +862,10 @@ func TestAtomicConditionalCloserForCachingStoreResolvesBackingCapabilityHonestly
 	t.Run("target-declaring wrapper reaches native backing", func(t *testing.T) {
 		backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
 		wrapped := &resolveTargetWrapper{Store: backing, target: backing}
+		direct, ok := AtomicConditionalCloserFor(wrapped)
+		if !ok || direct != backing {
+			t.Fatalf("AtomicConditionalCloserFor(target wrapper) = (%T, %v), want direct native closer", direct, ok)
+		}
 		cache := NewCachingStoreForTest(wrapped, nil)
 		if err := cache.Prime(context.Background()); err != nil {
 			t.Fatalf("Prime: %v", err)
@@ -871,7 +882,7 @@ func TestAtomicConditionalCloserForCachingStoreResolvesBackingCapabilityHonestly
 		if !ok {
 			t.Fatal("AtomicConditionalCloserFor(target-wrapper cache) = unavailable")
 		}
-		if err := closer.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
+		if _, err := closer.CloseWithMetadataIfMatch(created.ID, got.Revision, map[string]string{"state": "drained"}); err != nil {
 			t.Fatalf("CloseWithMetadataIfMatch through target wrapper: %v", err)
 		}
 		fresh, err := backing.Get(created.ID)

--- a/internal/beads/caching_store_conditional_internal_test.go
+++ b/internal/beads/caching_store_conditional_internal_test.go
@@ -184,8 +184,8 @@ func TestCachingStoreCASRetryLoopConverges(t *testing.T) {
 		if backing.getCalls == pre {
 			t.Fatal("post-evict Get did not consult the backing")
 		}
-		if fresh.Revision <= got.Revision {
-			t.Fatalf("post-evict Get returned revision %d, want > %d (the post-write revision)", fresh.Revision, got.Revision)
+		if fresh.Revision == 0 || fresh.Revision == got.Revision {
+			t.Fatalf("post-evict Get returned revision %d, want a nonzero token different from %d (the post-write revision)", fresh.Revision, got.Revision)
 		}
 		if fresh.Title != title {
 			t.Fatalf("post-evict Get returned title %q, want %q", fresh.Title, title)
@@ -225,7 +225,7 @@ func TestCachingStoreCASRetryLoopConverges(t *testing.T) {
 		if backing.getCalls != pre {
 			t.Fatal("pre-evict Get consulted the backing; the staleness setup is vacuous")
 		}
-		if stale.Revision >= live.Revision {
+		if stale.Revision == live.Revision {
 			t.Fatalf("cached revision %d is not stale against the backing's %d", stale.Revision, live.Revision)
 		}
 

--- a/internal/beads/caching_store_conditional_test.go
+++ b/internal/beads/caching_store_conditional_test.go
@@ -24,7 +24,8 @@ func TestCachingStoreConditionalWriterConformance(t *testing.T) {
 			// The MemStore backing populates PreconditionFailedError.Current and
 			// CachingStore forwards its errors untouched, so the wrapped row
 			// asserts Current too.
-			SuppliesCurrent: true,
+			RestrictedUpdateFields: true,
+			SuppliesCurrent:        true,
 			// Disabled is a backing-level toggle: the backing still claims the
 			// interface, returns typed unsupported per call, and CachingStore
 			// forwards that verdict.

--- a/internal/beads/caching_store_observation_test.go
+++ b/internal/beads/caching_store_observation_test.go
@@ -1,0 +1,615 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestCachingStoreObservedListResultContract(t *testing.T) {
+	backing := &observationReadCountingStore{Store: NewMemStore()}
+	if _, err := backing.Create(Bead{Title: "first"}); err != nil {
+		t.Fatalf("Create(first): %v", err)
+	}
+	priority := 2
+	deferUntil := time.Now().Add(time.Hour).Round(0)
+	blocked := true
+	second, err := backing.Create(Bead{
+		Title:        "second",
+		Priority:     &priority,
+		Labels:       []string{"label"},
+		Needs:        []string{"blocks:dependency"},
+		Metadata:     StringMap{"key": "value"},
+		Dependencies: []Dep{{DependsOnID: "dependency", Type: "blocks"}},
+		DeferUntil:   &deferUntil,
+		IsBlocked:    &blocked,
+	})
+	if err != nil {
+		t.Fatalf("Create(second): %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	beforeReads := backing.readCalls.Load()
+	rows, observation, ok := cache.ObservedList(ListQuery{
+		Status: "open",
+		Sort:   SortCreatedDesc,
+		Limit:  1,
+	})
+	if !ok || len(rows) != 1 || rows[0].ID != second.ID {
+		t.Fatalf("ObservedList = %#v, %v; want newest one-row prefix %s", rows, ok, second.ID)
+	}
+
+	// Ordinary cache-only reads between observation and conditional use do not
+	// invalidate the stamp or consult the backing store.
+	if cached, ok := cache.CachedList(ListQuery{Status: "open"}); !ok || len(cached) != 2 {
+		t.Fatalf("CachedList between observation and use = %#v, %v; want two cached rows", cached, ok)
+	}
+
+	*rows[0].Priority = 99
+	rows[0].Labels[0] = "changed"
+	rows[0].Needs[0] = "changed"
+	rows[0].Metadata["key"] = "changed"
+	rows[0].Dependencies[0].DependsOnID = "changed"
+	*rows[0].DeferUntil = rows[0].DeferUntil.Add(time.Hour)
+	*rows[0].IsBlocked = false
+
+	got, err := cache.Get(second.ID)
+	if err != nil {
+		t.Fatalf("Get after returned-row mutation: %v", err)
+	}
+	if !reflect.DeepEqual(got, second) {
+		t.Fatalf("cached row changed through ObservedList result:\n got: %#v\nwant: %#v", got, second)
+	}
+
+	called := false
+	accepted, err := cache.WithCurrentObservation(observation, func() error {
+		called = true
+		return nil
+	})
+	if err != nil || !accepted || !called {
+		t.Fatalf("WithCurrentObservation = %v, %v, called=%v; want accepted callback", accepted, err, called)
+	}
+	if got := backing.readCalls.Load(); got != beforeReads {
+		t.Fatalf("backing reads = %d after ObservedList/cache-only use, want %d", got, beforeReads)
+	}
+}
+
+func TestCachingStoreWithCurrentObservationRejectsStaleZeroForeignAndNilCallback(t *testing.T) {
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	observation := mustObserveActiveCache(t, cache)
+
+	title := "changed"
+	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	for _, tc := range []struct {
+		name        string
+		observation CacheObservation
+	}{
+		{name: "zero"},
+		{name: "stale", observation: observation},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertObservationRejected(t, cache, tc.observation)
+		})
+	}
+
+	other := NewCachingStoreForTest(NewMemStore(), nil)
+	if err := other.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime(other): %v", err)
+	}
+	foreign := mustObserveActiveCache(t, other)
+	assertObservationRejected(t, cache, foreign)
+
+	if accepted, err := cache.WithCurrentObservation(mustObserveActiveCache(t, cache), nil); err == nil || accepted {
+		t.Fatalf("WithCurrentObservation(nil callback) = %v, %v; want false, error", accepted, err)
+	}
+}
+
+func TestCachingStoreObservedListRejectsUnavailableQueriesWithoutBackingRead(t *testing.T) {
+	backing := &observationReadCountingStore{Store: NewMemStore()}
+	cache := NewCachingStoreForTest(backing, nil)
+	for _, tc := range []struct {
+		name       string
+		state      cacheState
+		revision   uint64
+		query      ListQuery
+		dirty      bool
+		partialErr error
+	}{
+		{name: "uninitialized", state: cacheUninitialized, revision: 1, query: ListQuery{Status: "open"}},
+		{name: "degraded", state: cacheDegraded, revision: 1, query: ListQuery{Status: "open"}},
+		{name: "dirty", state: cacheLive, revision: 1, query: ListQuery{Status: "open"}, dirty: true},
+		{name: "partial result", state: cachePartial, revision: 1, query: ListQuery{Status: "open"}, partialErr: errors.New("partial")},
+		{name: "zero revision", state: cacheLive, query: ListQuery{Status: "open"}},
+		{name: "live", state: cacheLive, revision: 1, query: ListQuery{Status: "open", Live: true}},
+		{name: "closed", state: cacheLive, revision: 1, query: ListQuery{Status: "closed"}},
+		{name: "include closed", state: cacheLive, revision: 1, query: ListQuery{Status: "open", IncludeClosed: true}},
+		{name: "parent", state: cacheLive, revision: 1, query: ListQuery{ParentID: "parent"}},
+		{name: "parents", state: cacheLive, revision: 1, query: ListQuery{ParentIDs: []string{"parent"}, AllowScan: true}},
+		{name: "invalid", state: cacheLive, revision: 1, query: ListQuery{Assignee: "a", Assignees: []string{"b"}}},
+		{name: "scan required", state: cacheLive, revision: 1, query: ListQuery{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cache.mu.Lock()
+			cache.state = tc.state
+			cache.dirty = map[string]struct{}{}
+			if tc.dirty {
+				cache.dirty["dirty"] = struct{}{}
+			}
+			cache.primePartialErr = tc.partialErr
+			cache.observationRevision = tc.revision
+			cache.mu.Unlock()
+
+			beforeReads := backing.readCalls.Load()
+			if rows, _, ok := cache.ObservedList(tc.query); ok || rows != nil {
+				t.Fatalf("ObservedList = %#v, ok=true; want unavailable", rows)
+			}
+			if got := backing.readCalls.Load(); got != beforeReads {
+				t.Fatalf("backing reads = %d, want %d", got, beforeReads)
+			}
+		})
+	}
+}
+
+func TestCachingStoreObservedListRejectsRealPartialPrimeWithoutBackingRead(t *testing.T) {
+	mem := NewMemStore()
+	if _, err := mem.Create(Bead{Title: "partial survivor"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	partial := &partialListErrorStore{
+		Store:           mem,
+		partialStatuses: map[string]bool{"open": true},
+	}
+	backing := &observationReadCountingStore{Store: partial}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	beforeReads := backing.readCalls.Load()
+	if rows, _, ok := cache.ObservedList(ListQuery{Status: "open"}); ok || rows != nil {
+		t.Fatalf("ObservedList after partial PrimeActive = %#v, true; want unavailable", rows)
+	}
+	if got := backing.readCalls.Load(); got != beforeReads {
+		t.Fatalf("backing reads = %d, want %d", got, beforeReads)
+	}
+}
+
+func TestCachingStoreObservedListAcceptsCleanPrimeActiveCache(t *testing.T) {
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "active"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	rows, observation, ok := cache.ObservedList(ListQuery{Status: "open"})
+	if !ok || len(rows) != 1 || rows[0].ID != bead.ID {
+		t.Fatalf("ObservedList(clean partial) = %#v, %v", rows, ok)
+	}
+	if accepted, err := cache.WithCurrentObservation(observation, func() error { return nil }); err != nil || !accepted {
+		t.Fatalf("WithCurrentObservation(clean partial) = %v, %v", accepted, err)
+	}
+}
+
+func TestCachingStoreObservationInvalidatedByMutationPaths(t *testing.T) {
+	t.Run("local write", func(t *testing.T) {
+		_, cache, bead, observation := newObservationFixture(t, Bead{Title: "work"})
+		title := "changed"
+		if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		assertObservationRejected(t, cache, observation)
+	})
+
+	t.Run("applied event", func(t *testing.T) {
+		backing, cache, _, observation := newObservationFixture(t, Bead{Title: "existing"})
+		added, err := backing.Create(Bead{Title: "event-created"})
+		if err != nil {
+			t.Fatalf("out-of-band Create: %v", err)
+		}
+		payload, err := json.Marshal(added)
+		if err != nil {
+			t.Fatalf("Marshal event: %v", err)
+		}
+		cache.ApplyEvent("bead.created", payload)
+		if got, err := cache.Get(added.ID); err != nil || got.Title != added.Title {
+			t.Fatalf("Get(event-created) = %#v, %v", got, err)
+		}
+		assertObservationRejected(t, cache, observation)
+	})
+
+	t.Run("live list refresh", func(t *testing.T) {
+		backing, cache, bead, observation := newObservationFixture(t, Bead{Title: "before"})
+		title := "after"
+		if err := backing.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+			t.Fatalf("out-of-band Update: %v", err)
+		}
+		if _, err := cache.List(ListQuery{Status: "open", Live: true}); err != nil {
+			t.Fatalf("List(Live): %v", err)
+		}
+		if got, err := cache.Get(bead.ID); err != nil || got.Title != title {
+			t.Fatalf("Get after Live refresh = %#v, %v", got, err)
+		}
+		assertObservationRejected(t, cache, observation)
+	})
+
+	t.Run("conditional eviction", func(t *testing.T) {
+		_, cache, bead, observation := newObservationFixture(t, Bead{Title: "work"})
+		cache.evictForConditionalWrite(bead.ID)
+		cache.mu.RLock()
+		_, cached := cache.beads[bead.ID]
+		_, dirty := cache.dirty[bead.ID]
+		cache.mu.RUnlock()
+		if cached || !dirty {
+			t.Fatalf("conditional eviction left cached=%v dirty=%v; want false, true", cached, dirty)
+		}
+		assertObservationRejected(t, cache, observation)
+	})
+
+	t.Run("conditional ambiguous failure", func(t *testing.T) {
+		_, cache, bead, observation := newObservationFixture(t, Bead{Title: "work"})
+		cache.applyConditionalWriteFailure(bead.ID, errors.New("ambiguous write result"))
+		cache.mu.RLock()
+		_, dirty := cache.dirty[bead.ID]
+		cache.mu.RUnlock()
+		if !dirty {
+			t.Fatal("ambiguous conditional failure did not mark cached row dirty")
+		}
+		assertObservationRejected(t, cache, observation)
+	})
+
+	t.Run("ready projection", func(t *testing.T) {
+		blocked := true
+		_, cache, bead, observation := newObservationFixture(t, Bead{
+			Title:     "projected",
+			IsBlocked: &blocked,
+		})
+		cache.mu.Lock()
+		changed := cache.clearAllReadyProjectionsLocked()
+		projected := cache.beads[bead.ID].IsBlocked
+		cache.mu.Unlock()
+		if !changed || projected != nil {
+			t.Fatalf("clearAllReadyProjectionsLocked = %v, projection=%v; want true, nil", changed, projected)
+		}
+		assertObservationRejected(t, cache, observation)
+	})
+}
+
+func TestCachingStoreDirtyOverlayRefreshAdvancesObservationWithoutMutationSequence(t *testing.T) {
+	backing, cache, bead, observation := newObservationFixture(t, Bead{Title: "before"})
+	title := "after"
+	if err := backing.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("out-of-band Update: %v", err)
+	}
+
+	cache.mu.Lock()
+	mutationSeq := cache.mutationSeq
+	cache.markDirtyLocked(bead.ID)
+	dirtyRevision := cache.observationRevision
+	cache.mu.Unlock()
+
+	rows, err := cache.List(ListQuery{Status: "open"})
+	if err != nil {
+		t.Fatalf("List with dirty overlay: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Title != title {
+		t.Fatalf("List with dirty overlay = %#v, want refreshed title %q", rows, title)
+	}
+	cache.mu.RLock()
+	_, dirty := cache.dirty[bead.ID]
+	gotMutationSeq := cache.mutationSeq
+	gotRevision := cache.observationRevision
+	cache.mu.RUnlock()
+	if dirty {
+		t.Fatal("dirty overlay left refreshed row dirty")
+	}
+	if gotRevision == dirtyRevision {
+		t.Fatal("dirty overlay publication did not advance observation revision")
+	}
+	if gotMutationSeq != mutationSeq {
+		t.Fatalf("mutationSeq = %d after read refresh, want %d", gotMutationSeq, mutationSeq)
+	}
+	assertObservationRejected(t, cache, observation)
+}
+
+func TestCachingStorePrimePublicationsInvalidateObservationsWithoutMutationSequence(t *testing.T) {
+	for _, method := range []string{"PrimeActive", "Prime"} {
+		for _, populated := range []bool{false, true} {
+			name := method + "/empty"
+			if populated {
+				name = method + "/populated"
+			}
+			t.Run(name, func(t *testing.T) {
+				backing := NewMemStore()
+				if populated {
+					if _, err := backing.Create(Bead{Title: "work"}); err != nil {
+						t.Fatalf("Create: %v", err)
+					}
+				}
+				cache := NewCachingStoreForTest(backing, nil)
+				if err := cache.Prime(context.Background()); err != nil {
+					t.Fatalf("initial Prime: %v", err)
+				}
+				observation := mustObserveActiveCache(t, cache)
+				mutationSeq := cacheMutationSeq(cache)
+
+				var err error
+				if method == "PrimeActive" {
+					err = cache.PrimeActive()
+				} else {
+					err = cache.Prime(context.Background())
+				}
+				if err != nil {
+					t.Fatalf("%s: %v", method, err)
+				}
+				if got := cacheMutationSeq(cache); got != mutationSeq {
+					t.Fatalf("mutationSeq = %d after %s publication, want %d", got, method, mutationSeq)
+				}
+				assertObservationRejected(t, cache, observation)
+			})
+		}
+	}
+}
+
+func TestCachingStoreReconciliationPublicationsInvalidateObservationsWithoutMutationSequence(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		populated bool
+		mutate    func(*testing.T, *MemStore, Bead)
+	}{
+		{name: "unchanged empty"},
+		{
+			name: "add",
+			mutate: func(t *testing.T, backing *MemStore, _ Bead) {
+				t.Helper()
+				if _, err := backing.Create(Bead{Title: "added"}); err != nil {
+					t.Fatalf("out-of-band Create: %v", err)
+				}
+			},
+		},
+		{
+			name:      "update",
+			populated: true,
+			mutate: func(t *testing.T, backing *MemStore, bead Bead) {
+				t.Helper()
+				title := "updated"
+				if err := backing.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+					t.Fatalf("out-of-band Update: %v", err)
+				}
+			},
+		},
+		{
+			name:      "delete",
+			populated: true,
+			mutate: func(t *testing.T, backing *MemStore, bead Bead) {
+				t.Helper()
+				if err := backing.Delete(bead.ID); err != nil {
+					t.Fatalf("out-of-band Delete: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backing := NewMemStore()
+			var bead Bead
+			if tc.populated {
+				var err error
+				bead, err = backing.Create(Bead{Title: "work"})
+				if err != nil {
+					t.Fatalf("Create: %v", err)
+				}
+			}
+			cache := NewCachingStoreForTest(backing, nil)
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+			observation := mustObserveActiveCache(t, cache)
+			mutationSeq := cacheMutationSeq(cache)
+			if tc.mutate != nil {
+				tc.mutate(t, backing, bead)
+			}
+
+			cache.runReconciliation()
+
+			if got := cacheMutationSeq(cache); got != mutationSeq {
+				t.Fatalf("mutationSeq = %d after reconciliation publication, want %d", got, mutationSeq)
+			}
+			assertObservationRejected(t, cache, observation)
+		})
+	}
+}
+
+func TestCachingStoreObservationDoesNotResurrectAfterDegradedEmptyRecovery(t *testing.T) {
+	backing := &partialListErrorStore{Store: NewMemStore()}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	observation := mustObserveActiveCache(t, cache)
+	mutationSeq := cacheMutationSeq(cache)
+
+	backing.partialAllowScan = true
+	cache.runReconciliation()
+	cache.mu.RLock()
+	degraded := cache.state == cacheDegraded
+	cache.mu.RUnlock()
+	if !degraded {
+		t.Fatal("partial reconciliation did not degrade cache")
+	}
+
+	backing.partialAllowScan = false
+	cache.runReconciliation()
+	cache.mu.RLock()
+	live := cache.state == cacheLive
+	cache.mu.RUnlock()
+	if !live {
+		t.Fatal("clean empty reconciliation did not restore live cache")
+	}
+	if got := cacheMutationSeq(cache); got != mutationSeq {
+		t.Fatalf("mutationSeq = %d after availability publications, want %d", got, mutationSeq)
+	}
+	assertObservationRejected(t, cache, observation)
+}
+
+func TestCachingStoreWithCurrentObservationBlocksWriterUntilCallbackReturns(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		backing := NewMemStore()
+		if _, err := backing.Create(Bead{Title: "work"}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		cache := NewCachingStoreForTest(backing, nil)
+		if err := cache.Prime(t.Context()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+		observation := mustObserveActiveCache(t, cache)
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		callbackResult := make(chan struct {
+			accepted bool
+			err      error
+		}, 1)
+		callbackErr := errors.New("callback failure")
+		go func() {
+			accepted, err := cache.WithCurrentObservation(observation, func() error {
+				close(entered)
+				<-release
+				return callbackErr
+			})
+			callbackResult <- struct {
+				accepted bool
+				err      error
+			}{accepted: accepted, err: err}
+		}()
+		synctest.Wait()
+		select {
+		case <-entered:
+		default:
+			t.Fatal("callback did not enter")
+		}
+		if cache.mu.TryLock() {
+			cache.mu.Unlock()
+			t.Fatal("writer acquired cache lock while observation callback held read lock")
+		}
+		close(release)
+		synctest.Wait()
+		result := <-callbackResult
+		if !result.accepted || !errors.Is(result.err, callbackErr) {
+			t.Fatalf("WithCurrentObservation callback result = accepted:%v err:%v", result.accepted, result.err)
+		}
+		if !cache.mu.TryLock() {
+			t.Fatal("writer could not acquire cache lock after callback returned")
+		}
+		cache.mu.Unlock()
+	})
+}
+
+func TestCachingStoreWithCurrentObservationReleasesLockAfterPanic(t *testing.T) {
+	cache := NewCachingStoreForTest(NewMemStore(), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	observation := mustObserveActiveCache(t, cache)
+	panicValue := &struct{}{}
+	var recovered any
+	func() {
+		defer func() {
+			recovered = recover()
+		}()
+		_, _ = cache.WithCurrentObservation(observation, func() error {
+			panic(panicValue)
+		})
+	}()
+	if recovered != panicValue {
+		t.Fatalf("recovered panic = %v, want original %p", recovered, panicValue)
+	}
+	if !cache.mu.TryLock() {
+		t.Fatal("cache writer lock remained held after observation callback panic")
+	}
+	cache.mu.Unlock()
+}
+
+func newObservationFixture(t *testing.T, seed Bead) (*MemStore, *CachingStore, Bead, CacheObservation) {
+	t.Helper()
+	backing := NewMemStore()
+	bead, err := backing.Create(seed)
+	if err != nil {
+		t.Fatalf("Create fixture: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime fixture: %v", err)
+	}
+	return backing, cache, bead, mustObserveActiveCache(t, cache)
+}
+
+func mustObserveActiveCache(t *testing.T, cache *CachingStore) CacheObservation {
+	t.Helper()
+	_, observation, ok := cache.ObservedList(ListQuery{AllowScan: true})
+	if !ok {
+		t.Fatal("ObservedList(active scan) unavailable")
+	}
+	return observation
+}
+
+func assertObservationRejected(t *testing.T, cache *CachingStore, observation CacheObservation) {
+	t.Helper()
+	called := false
+	accepted, err := cache.WithCurrentObservation(observation, func() error {
+		called = true
+		return nil
+	})
+	if err != nil || accepted || called {
+		t.Fatalf("WithCurrentObservation = %v, %v, called=%v; want rejected without callback", accepted, err, called)
+	}
+}
+
+func cacheMutationSeq(cache *CachingStore) uint64 {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	return cache.mutationSeq
+}
+
+type observationReadCountingStore struct {
+	Store
+	readCalls atomic.Int64
+}
+
+func (s *observationReadCountingStore) List(query ListQuery) ([]Bead, error) {
+	s.readCalls.Add(1)
+	return s.Store.List(query)
+}
+
+func (s *observationReadCountingStore) Get(id string) (Bead, error) {
+	s.readCalls.Add(1)
+	return s.Store.Get(id)
+}
+
+func (s *observationReadCountingStore) DepList(id, direction string) ([]Dep, error) {
+	s.readCalls.Add(1)
+	return s.Store.DepList(id, direction)
+}
+
+func (s *observationReadCountingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
+	s.readCalls.Add(1)
+	return s.Store.Ready(query...)
+}

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -195,6 +195,59 @@ func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
 	if c.primePartialErr != nil || len(c.dirty) > 0 {
 		return nil, false
 	}
+	return c.collectCachedListLocked(query), true
+}
+
+// ObservedList returns a detached active-only cache census and an opaque stamp
+// that may be conditionally consumed with WithCurrentObservation. It never
+// performs backing-store I/O. The stamp fences only this process's cache
+// projection; it does not certify durable-store lineage or event delivery.
+func (c *CachingStore) ObservedList(query ListQuery) ([]Bead, CacheObservation, bool) {
+	if query.Validate() != nil ||
+		(!query.HasFilter() && !query.AllowScan) ||
+		query.Live ||
+		query.IncludesClosed() ||
+		query.ParentID != "" ||
+		len(query.ParentIDs) > 0 {
+		return nil, CacheObservation{}, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.observationAdmissibleLocked() {
+		return nil, CacheObservation{}, false
+	}
+	return c.collectCachedListLocked(query), CacheObservation{owner: c, revision: c.observationRevision}, true
+}
+
+// WithCurrentObservation runs publish while holding the originating cache's
+// read lock only when observation still describes a clean active cache. The
+// callback must perform bounded in-memory work and must not call the cache,
+// backing store, or wait for other work.
+func (c *CachingStore) WithCurrentObservation(observation CacheObservation, publish func() error) (bool, error) {
+	if publish == nil {
+		return false, fmt.Errorf("using cache observation: nil callback")
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if observation.owner != c || observation.revision == 0 || observation.revision != c.observationRevision ||
+		!c.observationAdmissibleLocked() {
+		return false, nil
+	}
+	return true, publish()
+}
+
+// observationAdmissibleLocked reports whether an active-only cache census can
+// be observed and conditionally used. Caller must hold c.mu.
+func (c *CachingStore) observationAdmissibleLocked() bool {
+	return (c.state == cacheLive || c.state == cachePartial) &&
+		c.primePartialErr == nil &&
+		len(c.dirty) == 0 &&
+		c.observationRevision != 0
+}
+
+// collectCachedListLocked materializes CachedList and ObservedList results.
+// Caller must hold c.mu for reading or writing.
+func (c *CachingStore) collectCachedListLocked(query ListQuery) []Bead {
 	cached := make([]Bead, 0, len(c.beads))
 	for _, b := range c.beads {
 		if !query.Matches(b) {
@@ -206,7 +259,7 @@ func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
 	if query.Limit > 0 && len(cached) > query.Limit {
 		cached = cached[:query.Limit]
 	}
-	return cached, true
+	return cached
 }
 
 func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, items []Bead) []Bead {

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -306,6 +306,7 @@ func (c *CachingStore) runReconciliation() {
 				c.circuitTripped = true
 				c.problemf(fmt.Sprintf("circuit-breaker tripped rig=%s syncFailures=%d", c.idPrefix, c.syncFailures))
 			}
+			c.advanceObservationLocked()
 		}
 		c.recordProblemLocked("reconcile cache", err)
 		c.recordReconcileLatencyLocked(bdLatency)
@@ -629,6 +630,7 @@ func (c *CachingStore) mergeSnapshotLocked(
 	c.syncFailures = 0
 	c.depsComplete = nextDepsComplete
 	c.primePartialErr = nil
+	c.advanceObservationLocked()
 	c.promoteLiveLocked()
 	c.stats.LastReconcileAt = now
 	c.stats.Adds += res.adds

--- a/internal/beads/caching_store_reconcile_census_test.go
+++ b/internal/beads/caching_store_reconcile_census_test.go
@@ -92,7 +92,10 @@ func TestMergeOracleFieldCoverage(t *testing.T) {
 		"stats": true, // stats compared field-wise below
 	}
 	excludedStore := map[string]bool{
-		"backing": true, "idPrefix": true, "mu": true, "reconciling": true,
+		// observationRevision is a process-local publication fence, orthogonal to
+		// the merge oracle's durable cache-state comparison.
+		"observationRevision": true,
+		"backing":             true, "idPrefix": true, "mu": true, "reconciling": true,
 		"onChange": true, "problemf": true, "problemLog": true,
 		"lastReconcileLogAt": true, "primeMu": true, "primeRunning": true,
 		"primeCycle": true, "lastFullPrimeStartedAt": true, "primeRetryDelay": true,

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -21,13 +21,13 @@ type fileData struct {
 	// because Bead.Revision is json:"-" and never survives the on-disk []Bead.
 	// Without this, every reloadFromDisk (which runs before each write in
 	// cross-process flock mode) would reset all revisions to 0, breaking the
-	// monotonic-never-reused contract. Absent (legacy files) ≡ all zero.
+	// FileStore's monotonic-never-reused guarantee. Absent (legacy files) ≡ all zero.
 	Revisions map[string]int64 `json:"revisions,omitempty"`
 	// RevisionsSealed marks a file written by a revisions-aware binary. An
 	// OLDER binary's full rewrite drops both this marker and the revisions
 	// map while keeping the beads — the exact state in which fresh-from-zero
 	// revisions would REUSE previously issued tokens and break the
-	// monotonic-never-reused contract. Loading an unsealed file with beads
+	// FileStore's monotonic-never-reused guarantee. Loading an unsealed file with beads
 	// therefore re-seeds every revision at a deterministic floor far above
 	// any counter a prior writer could have issued (see
 	// applyBeadRevisionsSealed).

--- a/internal/beads/filestore_conditional.go
+++ b/internal/beads/filestore_conditional.go
@@ -15,8 +15,8 @@ var _ ConditionalWriter = (*FileStore)(nil)
 // then flushes to disk. A precondition failure or not-found leaves the store
 // unchanged (no save). A failed flush rolls back the in-memory mutation.
 func (fs *FileStore) UpdateIfMatch(id string, expectedRevision int64, opts UpdateOpts) error {
-	if isEmptyUpdateOpts(opts) {
-		return fmt.Errorf("conditional update %s: %w", id, ErrEmptyConditionalUpdate)
+	if err := validateConditionalUpdateOpts(opts); err != nil {
+		return fmt.Errorf("conditional update %s: %w", id, err)
 	}
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -105,7 +105,8 @@ func TestFileStoreConditionalWriterConformance(t *testing.T) {
 	}
 	beadstest.RunConditionalWriterConformanceWithOptions(t, "FileStore", open,
 		beadstest.ConditionalWriterOptions{
-			SuppliesCurrent: true,
+			RowBackedMutationFlavors: true,
+			SuppliesCurrent:          true,
 			OpenDisabled: func(st *testing.T) beads.Store {
 				s := open(st)
 				s.(*beads.FileStore).DisableConditionalWrites = true
@@ -1983,15 +1984,16 @@ func TestFileStoreRevisionContinuityAcrossDowngradeRewrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	title := "mutated"
+	seen := make(map[int64]struct{})
 	for range 3 {
 		got, err := s.Get(created.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
+		seen[got.Revision] = struct{}{}
 		if err := s.Update(created.ID, beads.UpdateOpts{Title: &title}); err != nil {
 			t.Fatal(err)
 		}
-		_ = got
 	}
 	preToken, err := s.Get(created.ID)
 	if err != nil {
@@ -2026,9 +2028,9 @@ func TestFileStoreRevisionContinuityAcrossDowngradeRewrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reloaded.Revision <= preToken.Revision {
-		t.Fatalf("post-rewrite revision %d <= previously issued %d: token reuse — the monotonic-never-reused contract is broken",
-			reloaded.Revision, preToken.Revision)
+	seen[preToken.Revision] = struct{}{}
+	if _, reused := seen[reloaded.Revision]; reused {
+		t.Fatalf("post-rewrite revision token %d reuses a token observed before the rewrite", reloaded.Revision)
 	}
 	w, _ := beads.ConditionalWriterFor(s2)
 	if err := w.UpdateIfMatch(created.ID, preToken.Revision, beads.UpdateOpts{Title: &title}); !beads.IsPreconditionFailed(err) {

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -106,6 +106,7 @@ func TestFileStoreConditionalWriterConformance(t *testing.T) {
 	beadstest.RunConditionalWriterConformanceWithOptions(t, "FileStore", open,
 		beadstest.ConditionalWriterOptions{
 			RowBackedMutationFlavors: true,
+			RestrictedUpdateFields:   true,
 			SuppliesCurrent:          true,
 			OpenDisabled: func(st *testing.T) beads.Store {
 				s := open(st)

--- a/internal/beads/memstore_conditional.go
+++ b/internal/beads/memstore_conditional.go
@@ -35,8 +35,8 @@ func (m *MemStore) probeConditionalWriteCapability() (bool, string) {
 // expectedRevision, otherwise it returns *PreconditionFailedError. When the
 // instance has DisableConditionalWrites set it returns ErrConditionalWriteUnsupported.
 func (m *MemStore) UpdateIfMatch(id string, expectedRevision int64, opts UpdateOpts) error {
-	if isEmptyUpdateOpts(opts) {
-		return fmt.Errorf("conditional update %s: %w", id, ErrEmptyConditionalUpdate)
+	if err := validateConditionalUpdateOpts(opts); err != nil {
+		return fmt.Errorf("conditional update %s: %w", id, err)
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -36,6 +36,7 @@ func TestMemStoreConditionalWriterConformance(t *testing.T) {
 		func(_ *testing.T) beads.Store { return beads.NewMemStore() },
 		beadstest.ConditionalWriterOptions{
 			RowBackedMutationFlavors: true,
+			RestrictedUpdateFields:   true,
 			SuppliesCurrent:          true,
 			OpenDisabled: func(_ *testing.T) beads.Store {
 				s := beads.NewMemStore()

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -35,7 +35,8 @@ func TestMemStoreConditionalWriterConformance(t *testing.T) {
 	beadstest.RunConditionalWriterConformanceWithOptions(t, "MemStore",
 		func(_ *testing.T) beads.Store { return beads.NewMemStore() },
 		beadstest.ConditionalWriterOptions{
-			SuppliesCurrent: true,
+			RowBackedMutationFlavors: true,
+			SuppliesCurrent:          true,
 			OpenDisabled: func(_ *testing.T) beads.Store {
 				s := beads.NewMemStore()
 				s.DisableConditionalWrites = true

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -249,31 +249,10 @@ type NativeDoltStore struct {
 	// tests set it (to exercise budget exhaustion without a real 90s wait).
 	readRetryBudgetOverride time.Duration
 
-	// condWritesStamp carries the factory-stamped conditional-writes mode.
-	// NativeDoltStore implements the NARROW metadata value-CAS
-	// (MetadataCASWriter, see native_dolt_store_conditional.go) but NOT
-	// ConditionalWriter, so the stamp's effect at the seam is unchanged:
-	// require→typed refusal / auto→loud degrade, never a silent legacy write
-	// under require.
-	//
-	// The gap is the revision-CAS trio, and it is a BACKEND gap, not an
-	// unwritten method. UpdateIfMatch/CloseIfMatch/DeleteIfMatch need a fence
-	// token that advances on every mutation and is never reused; beads v1.1.0
-	// has none. types.Issue carries no revision, the issues DDL has no version
-	// column, updated_at is second-granularity — so two same-second writes
-	// compare EQUAL and a stale fence silently succeeds, which is the lost
-	// update the fence exists to prevent — and label mutations never touch
-	// updated_at at all. A counter this store maintained itself would fence
-	// nothing, because the Dolt database is multi-writer (bd CLI, other
-	// gascity processes, graph-apply). Upstream beads #4697 (claim_fence) is
-	// the missing primitive; when it lands the trio becomes implementable and
-	// this store can declare ConditionalWriter.
-	//
-	// Declaring ConditionalWriter early to expose the CAS method would make
-	// ResolveConditionalWriter resolve under require and hand the trio's
-	// callers a wrong fence — the precise silent-write failure this refusal
-	// currently makes impossible. internal/beads/metadata_cas.go carries the
-	// full reasoning and the narrow interface's own resolution path.
+	// condWritesStamp carries the factory-stamped conditional-writes mode. The
+	// pinned upstream Storage contract requires row-version checked update and
+	// close plus transactions; DeleteIfMatch composes the matching transaction
+	// from GetIssue, RowVersion equality, and DeleteIssue.
 	condWritesStamp
 
 	localStrings *localSidecar // clone-local data; see Store.SetLocalString

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -1525,6 +1525,7 @@ func isNativeDoltSerializationConflict(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "error 1213") ||
+		strings.Contains(msg, "error 1205") ||
 		(strings.Contains(msg, "sqlstate") && strings.Contains(msg, "40001")) ||
 		strings.Contains(msg, "(40001)") ||
 		strings.Contains(msg, "this transaction conflicts with a committed transaction")

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -2010,6 +2010,7 @@ func nativeIssueFromBead(b Bead) (*beadslib.Issue, error) {
 		Ephemeral:   b.Ephemeral,
 		NoHistory:   b.NoHistory,
 		DeferUntil:  cloneTimePtr(b.DeferUntil),
+		RowVersion:  b.Revision,
 	}
 	if b.Priority != nil {
 		issue.Priority = *b.Priority
@@ -2074,6 +2075,7 @@ func beadFromNativeIssue(issue *beadslib.Issue) (Bead, error) {
 		Ephemeral:   issue.Ephemeral,
 		NoHistory:   issue.NoHistory,
 		DeferUntil:  cloneTimePtr(issue.DeferUntil),
+		Revision:    issue.RowVersion,
 	}
 	for _, dep := range issue.Dependencies {
 		if dep == nil {

--- a/internal/beads/native_dolt_store_conditional.go
+++ b/internal/beads/native_dolt_store_conditional.go
@@ -18,60 +18,75 @@ var (
 
 // CloseWithMetadataIfMatch merges metadata and closes id inside one native
 // transaction, but only while the exact opaque row version still matches.
-// A close error rolls back the preceding metadata write with the transaction.
-func (s *NativeDoltStore) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error {
+// It returns the final in-transaction row only after the transaction commits.
+func (s *NativeDoltStore) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) (Bead, error) {
 	storage, release, err := s.acquireStorage()
 	if err != nil {
-		return err
+		return Bead{}, err
 	}
 	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
 
-	err = storage.RunInTransaction(ctx, fmt.Sprintf("gc: fenced metadata close bead %s", id), func(tx beadslib.Transaction) error {
-		issue, err := tx.GetIssue(ctx, id)
-		if err != nil {
-			return nativeStoreError(id, err)
-		}
-		if issue == nil {
-			return fmt.Errorf("bead %q: %w", id, ErrNotFound)
-		}
-		if issue.RowVersion != expectedRevision {
-			return &PreconditionFailedError{
-				ID:       id,
-				Expected: expectedRevision,
-				Current:  issue.RowVersion,
-				Raw:      "native row-version mismatch",
+	var closed Bead
+	err = retryOnNativeDoltSerializationConflict(func() error {
+		closed = Bead{}
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		return storage.RunInTransaction(ctx, fmt.Sprintf("gc: fenced metadata close bead %s", id), func(tx beadslib.Transaction) error {
+			issue, err := tx.GetIssue(ctx, id)
+			if err != nil {
+				return nativeStoreError(id, err)
 			}
-		}
-		merged, err := metadataMapFromNative(issue.Metadata)
-		if err != nil {
-			return fmt.Errorf("parsing metadata for bead %q: %w", id, err)
-		}
-		if merged == nil {
-			merged = make(map[string]string, len(metadata))
-		}
-		for key, value := range metadata {
-			merged[key] = value
-		}
-		raw, err := metadataRawFromMap(merged)
-		if err != nil {
+			if issue == nil {
+				return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+			}
+			if issue.RowVersion != expectedRevision {
+				return &PreconditionFailedError{
+					ID:       id,
+					Expected: expectedRevision,
+					Current:  issue.RowVersion,
+					Raw:      "native row-version mismatch",
+				}
+			}
+			merged, err := metadataMapFromNative(issue.Metadata)
+			if err != nil {
+				return fmt.Errorf("parsing metadata for bead %q: %w", id, err)
+			}
+			if merged == nil {
+				merged = make(map[string]string, len(metadata))
+			}
+			for key, value := range metadata {
+				merged[key] = value
+			}
+			raw, err := metadataRawFromMap(merged)
+			if err != nil {
+				return err
+			}
+			if err := tx.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor); err != nil {
+				return nativeStoreError(id, err)
+			}
+			issueWithMergedMetadata := *issue
+			issueWithMergedMetadata.Metadata = raw
+			if err := tx.CloseIssue(ctx, id, nativeCloseReasonFromIssue(&issueWithMergedMetadata), s.actor, ""); err != nil {
+				return nativeStoreError(id, err)
+			}
+			finalIssue, err := tx.GetIssue(ctx, id)
+			if err != nil {
+				return nativeStoreError(id, err)
+			}
+			if finalIssue == nil {
+				return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+			}
+			if finalIssue.Status != beadslib.StatusClosed {
+				return fmt.Errorf("closing bead %q atomically: transaction returned status %q", id, finalIssue.Status)
+			}
+			closed, err = beadFromNativeIssue(finalIssue)
 			return err
-		}
-		if err := tx.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor); err != nil {
-			return nativeStoreError(id, err)
-		}
-		// Close uses close_reason for its history event. Read it from the
-		// merged blob, exactly as a sequential SetMetadataBatch followed by
-		// Close would, without splitting their commit boundary.
-		issueWithMergedMetadata := *issue
-		issueWithMergedMetadata.Metadata = raw
-		if err := tx.CloseIssue(ctx, id, nativeCloseReasonFromIssue(&issueWithMergedMetadata), s.actor, ""); err != nil {
-			return nativeStoreError(id, err)
-		}
-		return nil
+		})
 	})
-	return nativeStoreError(id, err)
+	if err != nil {
+		return Bead{}, nativeStoreError(id, err)
+	}
+	return closed, nil
 }
 
 func (s *NativeDoltStore) probeConditionalWriteCapability() (bool, string) {

--- a/internal/beads/native_dolt_store_conditional.go
+++ b/internal/beads/native_dolt_store_conditional.go
@@ -11,9 +11,68 @@ import (
 
 var (
 	_ ConditionalWriter                = (*NativeDoltStore)(nil)
+	_ AtomicConditionalCloser          = (*NativeDoltStore)(nil)
 	_ MetadataCASWriter                = (*NativeDoltStore)(nil)
 	_ conditionalWriteCapabilityProber = (*NativeDoltStore)(nil)
 )
+
+// CloseWithMetadataIfMatch merges metadata and closes id inside one native
+// transaction, but only while the exact opaque row version still matches.
+// A close error rolls back the preceding metadata write with the transaction.
+func (s *NativeDoltStore) CloseWithMetadataIfMatch(id string, expectedRevision int64, metadata map[string]string) error {
+	storage, release, err := s.acquireStorage()
+	if err != nil {
+		return err
+	}
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+
+	err = storage.RunInTransaction(ctx, fmt.Sprintf("gc: fenced metadata close bead %s", id), func(tx beadslib.Transaction) error {
+		issue, err := tx.GetIssue(ctx, id)
+		if err != nil {
+			return nativeStoreError(id, err)
+		}
+		if issue == nil {
+			return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+		}
+		if issue.RowVersion != expectedRevision {
+			return &PreconditionFailedError{
+				ID:       id,
+				Expected: expectedRevision,
+				Current:  issue.RowVersion,
+				Raw:      "native row-version mismatch",
+			}
+		}
+		merged, err := metadataMapFromNative(issue.Metadata)
+		if err != nil {
+			return fmt.Errorf("parsing metadata for bead %q: %w", id, err)
+		}
+		if merged == nil {
+			merged = make(map[string]string, len(metadata))
+		}
+		for key, value := range metadata {
+			merged[key] = value
+		}
+		raw, err := metadataRawFromMap(merged)
+		if err != nil {
+			return err
+		}
+		if err := tx.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor); err != nil {
+			return nativeStoreError(id, err)
+		}
+		// Close uses close_reason for its history event. Read it from the
+		// merged blob, exactly as a sequential SetMetadataBatch followed by
+		// Close would, without splitting their commit boundary.
+		issueWithMergedMetadata := *issue
+		issueWithMergedMetadata.Metadata = raw
+		if err := tx.CloseIssue(ctx, id, nativeCloseReasonFromIssue(&issueWithMergedMetadata), s.actor, ""); err != nil {
+			return nativeStoreError(id, err)
+		}
+		return nil
+	})
+	return nativeStoreError(id, err)
+}
 
 func (s *NativeDoltStore) probeConditionalWriteCapability() (bool, string) {
 	_, release, err := s.acquireStorage()

--- a/internal/beads/native_dolt_store_conditional.go
+++ b/internal/beads/native_dolt_store_conditional.go
@@ -9,14 +9,6 @@ import (
 	beadslib "github.com/steveyegge/beads"
 )
 
-// nativeGuardedIssueDeleter is the optional upstream capability that completes
-// the row-version guarded mutation set. Its presence is also the version-safe
-// capability marker: older beads libraries expose neither this method nor the
-// complete family-transition fencing required by ConditionalWriter.
-type nativeGuardedIssueDeleter interface {
-	DeleteIssueChecked(context.Context, string, int64) error
-}
-
 var (
 	_ ConditionalWriter                = (*NativeDoltStore)(nil)
 	_ MetadataCASWriter                = (*NativeDoltStore)(nil)
@@ -24,28 +16,12 @@ var (
 )
 
 func (s *NativeDoltStore) probeConditionalWriteCapability() (bool, string) {
-	storage, release, err := s.acquireStorage()
+	_, release, err := s.acquireStorage()
 	if err != nil {
 		return false, err.Error()
 	}
 	defer release()
-	if _, ok := storage.(nativeGuardedIssueDeleter); !ok {
-		return false, "native beads backend does not expose guarded issue deletion"
-	}
-	return true, "native beads backend exposes row-version guarded mutations"
-}
-
-func (s *NativeDoltStore) guardedStorage() (beadslib.Storage, nativeGuardedIssueDeleter, func(), error) {
-	storage, release, err := s.acquireStorage()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	deleter, ok := storage.(nativeGuardedIssueDeleter)
-	if !ok {
-		release()
-		return nil, nil, nil, ErrConditionalWriteUnsupported
-	}
-	return storage, deleter, release, nil
+	return true, "native beads backend exposes row-version checked writes and transactions"
 }
 
 // UpdateIfMatch applies row-backed opts only while id still has
@@ -54,7 +30,7 @@ func (s *NativeDoltStore) UpdateIfMatch(id string, expectedRevision int64, opts 
 	if err := validateConditionalUpdateOpts(opts); err != nil {
 		return fmt.Errorf("conditional update %s: %w", id, err)
 	}
-	storage, _, release, err := s.guardedStorage()
+	storage, release, err := s.acquireStorage()
 	if err != nil {
 		return err
 	}
@@ -74,7 +50,7 @@ func (s *NativeDoltStore) UpdateIfMatch(id string, expectedRevision int64, opts 
 
 // CloseIfMatch closes id only while it still has expectedRevision.
 func (s *NativeDoltStore) CloseIfMatch(id string, expectedRevision int64) error {
-	storage, _, release, err := s.guardedStorage()
+	storage, release, err := s.acquireStorage()
 	if err != nil {
 		return err
 	}
@@ -98,7 +74,7 @@ func (s *NativeDoltStore) CloseIfMatch(id string, expectedRevision int64) error 
 
 // DeleteIfMatch deletes id only while it still has expectedRevision.
 func (s *NativeDoltStore) DeleteIfMatch(id string, expectedRevision int64) error {
-	storage, deleter, release, err := s.guardedStorage()
+	storage, release, err := s.acquireStorage()
 	if err != nil {
 		return err
 	}
@@ -106,8 +82,29 @@ func (s *NativeDoltStore) DeleteIfMatch(id string, expectedRevision int64) error
 	ctx, cancel := nativeDoltOperationContext(context.TODO())
 	defer cancel()
 
-	if err := s.conditionalWriteError(ctx, storage, id, expectedRevision,
-		deleter.DeleteIssueChecked(ctx, id, expectedRevision)); err != nil {
+	commitMsg := fmt.Sprintf("gc: delete bead %s at revision %d", id, expectedRevision)
+	err = storage.RunInTransaction(ctx, commitMsg, func(tx beadslib.Transaction) error {
+		issue, err := tx.GetIssue(ctx, id)
+		if err != nil {
+			return nativeStoreError(id, err)
+		}
+		if issue == nil {
+			return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+		}
+		if issue.RowVersion != expectedRevision {
+			return &PreconditionFailedError{
+				ID:       id,
+				Expected: expectedRevision,
+				Current:  issue.RowVersion,
+				Raw:      "native row-version mismatch",
+			}
+		}
+		if err := tx.DeleteIssue(ctx, id); err != nil {
+			return nativeStoreError(id, err)
+		}
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 	if err := s.localStrings.DeleteBead(id); err != nil {

--- a/internal/beads/native_dolt_store_conditional.go
+++ b/internal/beads/native_dolt_store_conditional.go
@@ -116,8 +116,18 @@ func (s *NativeDoltStore) UpdateIfMatch(id string, expectedRevision int64, opts 
 	if err != nil {
 		return err
 	}
-	err = storage.UpdateIssueChecked(ctx, id, updates, s.actor, beadslib.UpdateIssueOptions{
-		ExpectedVersion: &expectedRevision,
+	// Retry a transient native-Dolt serialization conflict rather than letting
+	// it escape raw: embedded-Dolt has no internal withRetryTx, and the
+	// nudge-queue CAS loop only re-drives PreconditionFailedError, so an
+	// un-retried conflict would hard-fail to an API 500. The fence is
+	// unaffected — ExpectedVersion is re-checked every attempt and a genuine
+	// mismatch returns ErrVersionMismatch, which is not a serialization
+	// conflict, so precondition failures still propagate immediately (never
+	// retried). Mirrors DeleteIfMatch/CloseWithMetadataIfMatch.
+	err = retryOnNativeDoltSerializationConflict(func() error {
+		return storage.UpdateIssueChecked(ctx, id, updates, s.actor, beadslib.UpdateIssueOptions{
+			ExpectedVersion: &expectedRevision,
+		})
 	})
 	return s.conditionalWriteError(ctx, storage, id, expectedRevision, err)
 }
@@ -139,9 +149,16 @@ func (s *NativeDoltStore) CloseIfMatch(id string, expectedRevision int64) error 
 	if current == nil {
 		return fmt.Errorf("bead %q: %w", id, ErrNotFound)
 	}
-	_, err = storage.CloseIssueChecked(ctx, id, s.actor, beadslib.CloseIssueOptions{
-		Reason:          nativeCloseReasonFromIssue(current),
-		ExpectedVersion: &expectedRevision,
+	// See UpdateIfMatch: wrap only the checked write so a transient
+	// serialization conflict is retried while a version mismatch still
+	// short-circuits through conditionalWriteError. The pre-read close reason is
+	// a deterministic function of the issue and stays valid across attempts.
+	err = retryOnNativeDoltSerializationConflict(func() error {
+		_, closeErr := storage.CloseIssueChecked(ctx, id, s.actor, beadslib.CloseIssueOptions{
+			Reason:          nativeCloseReasonFromIssue(current),
+			ExpectedVersion: &expectedRevision,
+		})
+		return closeErr
 	})
 	return s.conditionalWriteError(ctx, storage, id, expectedRevision, err)
 }
@@ -153,30 +170,31 @@ func (s *NativeDoltStore) DeleteIfMatch(id string, expectedRevision int64) error
 		return err
 	}
 	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
-
 	commitMsg := fmt.Sprintf("gc: delete bead %s at revision %d", id, expectedRevision)
-	err = storage.RunInTransaction(ctx, commitMsg, func(tx beadslib.Transaction) error {
-		issue, err := tx.GetIssue(ctx, id)
-		if err != nil {
-			return nativeStoreError(id, err)
-		}
-		if issue == nil {
-			return fmt.Errorf("bead %q: %w", id, ErrNotFound)
-		}
-		if issue.RowVersion != expectedRevision {
-			return &PreconditionFailedError{
-				ID:       id,
-				Expected: expectedRevision,
-				Current:  issue.RowVersion,
-				Raw:      "native row-version mismatch",
+	err = retryOnNativeDoltSerializationConflict(func() error {
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		return storage.RunInTransaction(ctx, commitMsg, func(tx beadslib.Transaction) error {
+			issue, err := tx.GetIssue(ctx, id)
+			if err != nil {
+				return nativeStoreError(id, err)
 			}
-		}
-		if err := tx.DeleteIssue(ctx, id); err != nil {
-			return nativeStoreError(id, err)
-		}
-		return nil
+			if issue == nil {
+				return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+			}
+			if issue.RowVersion != expectedRevision {
+				return &PreconditionFailedError{
+					ID:       id,
+					Expected: expectedRevision,
+					Current:  issue.RowVersion,
+					Raw:      "native row-version mismatch",
+				}
+			}
+			if err := tx.DeleteIssue(ctx, id); err != nil {
+				return nativeStoreError(id, err)
+			}
+			return nil
+		})
 	})
 	if err != nil {
 		return err

--- a/internal/beads/native_dolt_store_conditional.go
+++ b/internal/beads/native_dolt_store_conditional.go
@@ -3,18 +3,143 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	beadslib "github.com/steveyegge/beads"
 )
 
-// NativeDoltStore offers the narrow metadata value-CAS and deliberately NOT
-// the full ConditionalWriter. The revision-CAS trio needs a backend fence
-// token that beads v1.1.0 cannot supply, and declaring the interface to get
-// this one method would make ResolveConditionalWriter resolve under require
-// mode — converting a loud typed refusal into a silent wrong-fenced write.
-// internal/beads/metadata_cas.go carries the full reasoning.
-var _ MetadataCASWriter = (*NativeDoltStore)(nil)
+// nativeGuardedIssueDeleter is the optional upstream capability that completes
+// the row-version guarded mutation set. Its presence is also the version-safe
+// capability marker: older beads libraries expose neither this method nor the
+// complete family-transition fencing required by ConditionalWriter.
+type nativeGuardedIssueDeleter interface {
+	DeleteIssueChecked(context.Context, string, int64) error
+}
+
+var (
+	_ ConditionalWriter                = (*NativeDoltStore)(nil)
+	_ MetadataCASWriter                = (*NativeDoltStore)(nil)
+	_ conditionalWriteCapabilityProber = (*NativeDoltStore)(nil)
+)
+
+func (s *NativeDoltStore) probeConditionalWriteCapability() (bool, string) {
+	storage, release, err := s.acquireStorage()
+	if err != nil {
+		return false, err.Error()
+	}
+	defer release()
+	if _, ok := storage.(nativeGuardedIssueDeleter); !ok {
+		return false, "native beads backend does not expose guarded issue deletion"
+	}
+	return true, "native beads backend exposes row-version guarded mutations"
+}
+
+func (s *NativeDoltStore) guardedStorage() (beadslib.Storage, nativeGuardedIssueDeleter, func(), error) {
+	storage, release, err := s.acquireStorage()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	deleter, ok := storage.(nativeGuardedIssueDeleter)
+	if !ok {
+		release()
+		return nil, nil, nil, ErrConditionalWriteUnsupported
+	}
+	return storage, deleter, release, nil
+}
+
+// UpdateIfMatch applies row-backed opts only while id still has
+// expectedRevision.
+func (s *NativeDoltStore) UpdateIfMatch(id string, expectedRevision int64, opts UpdateOpts) error {
+	if err := validateConditionalUpdateOpts(opts); err != nil {
+		return fmt.Errorf("conditional update %s: %w", id, err)
+	}
+	storage, _, release, err := s.guardedStorage()
+	if err != nil {
+		return err
+	}
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+
+	updates, err := s.nativeUpdates(ctx, storage, id, opts)
+	if err != nil {
+		return err
+	}
+	err = storage.UpdateIssueChecked(ctx, id, updates, s.actor, beadslib.UpdateIssueOptions{
+		ExpectedVersion: &expectedRevision,
+	})
+	return s.conditionalWriteError(ctx, storage, id, expectedRevision, err)
+}
+
+// CloseIfMatch closes id only while it still has expectedRevision.
+func (s *NativeDoltStore) CloseIfMatch(id string, expectedRevision int64) error {
+	storage, _, release, err := s.guardedStorage()
+	if err != nil {
+		return err
+	}
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+
+	current, err := storage.GetIssue(ctx, id)
+	if err != nil {
+		return nativeStoreError(id, err)
+	}
+	if current == nil {
+		return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+	}
+	_, err = storage.CloseIssueChecked(ctx, id, s.actor, beadslib.CloseIssueOptions{
+		Reason:          nativeCloseReasonFromIssue(current),
+		ExpectedVersion: &expectedRevision,
+	})
+	return s.conditionalWriteError(ctx, storage, id, expectedRevision, err)
+}
+
+// DeleteIfMatch deletes id only while it still has expectedRevision.
+func (s *NativeDoltStore) DeleteIfMatch(id string, expectedRevision int64) error {
+	storage, deleter, release, err := s.guardedStorage()
+	if err != nil {
+		return err
+	}
+	defer release()
+	ctx, cancel := nativeDoltOperationContext(context.TODO())
+	defer cancel()
+
+	if err := s.conditionalWriteError(ctx, storage, id, expectedRevision,
+		deleter.DeleteIssueChecked(ctx, id, expectedRevision)); err != nil {
+		return err
+	}
+	if err := s.localStrings.DeleteBead(id); err != nil {
+		return fmt.Errorf("deleting bead %q: cleaning up local strings: %w", id, err)
+	}
+	return nil
+}
+
+func (s *NativeDoltStore) conditionalWriteError(
+	ctx context.Context,
+	storage beadslib.Storage,
+	id string,
+	expectedRevision int64,
+	err error,
+) error {
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, beadslib.ErrVersionMismatch) {
+		return nativeStoreError(id, err)
+	}
+	current := int64(0)
+	if issue, readErr := storage.GetIssue(ctx, id); readErr == nil && issue != nil {
+		current = issue.RowVersion
+	}
+	return &PreconditionFailedError{
+		ID:       id,
+		Expected: expectedRevision,
+		Current:  current,
+		Raw:      err.Error(),
+	}
+}
 
 // CompareAndSetMetadataKey atomically sets metadata[key] = next when the key's
 // current value equals expected.

--- a/internal/beads/native_dolt_store_conditional_retry_test.go
+++ b/internal/beads/native_dolt_store_conditional_retry_test.go
@@ -1,0 +1,170 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// openIssueForConditionalTest is a minimal well-formed open issue the
+// conditional-write spies serve from GetIssue, so nativeCloseReasonFromIssue and
+// the row-version read below have real fields to work with.
+func openIssueForConditionalTest(id string) *beadslib.Issue {
+	return &beadslib.Issue{ID: id, Status: beadslib.StatusOpen, IssueType: beadslib.TypeTask, Priority: 2}
+}
+
+// TestNativeDoltStoreUpdateIfMatchRetriesSerializationConflict guards the
+// fenced-write half of the serialization-retry symmetry: UpdateIfMatch must
+// absorb a transient conflict exactly like DeleteIfMatch/CloseWithMetadataIfMatch.
+// Embedded-Dolt has no internal withRetryTx, so an unwrapped conflict escapes as
+// a raw error the nudge-queue CAS loop cannot absorb (it retries only
+// PreconditionFailedError) and hard-fails to the API as a 500.
+func TestNativeDoltStoreUpdateIfMatchRetriesSerializationConflict(t *testing.T) {
+	var attempts int32
+	spy := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return openIssueForConditionalTest(id), nil
+		},
+		updateIssueChecked: func(_ context.Context, _ string, _ map[string]interface{}, _ string, _ beadslib.UpdateIssueOptions) error {
+			if atomic.AddInt32(&attempts, 1) == 1 {
+				return errors.New(serializationConflictErr)
+			}
+			return nil
+		},
+	}
+	store := newNativeDoltStoreForTest(spy)
+
+	status := "in_progress"
+	if err := store.UpdateIfMatch("gc-1", 7, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("UpdateIfMatch after one serialization conflict: got %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("UpdateIssueChecked attempts = %d, want 2 (one conflict, one retry)", got)
+	}
+}
+
+func TestNativeDoltStoreUpdateIfMatchStopsAtAttemptLimit(t *testing.T) {
+	var attempts int32
+	spy := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return openIssueForConditionalTest(id), nil
+		},
+		updateIssueChecked: func(_ context.Context, _ string, _ map[string]interface{}, _ string, _ beadslib.UpdateIssueOptions) error {
+			atomic.AddInt32(&attempts, 1)
+			return errors.New(serializationConflictErr)
+		},
+	}
+	store := newNativeDoltStoreForTest(spy)
+
+	status := "in_progress"
+	err := store.UpdateIfMatch("gc-1", 7, UpdateOpts{Status: &status})
+	if err == nil {
+		t.Fatal("UpdateIfMatch with unrelenting conflicts: got nil, want the serialization error")
+	}
+	if !isNativeDoltSerializationConflict(err) {
+		t.Fatalf("returned error lost its serialization-conflict identity: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != int32(nativeWriteAttempts) {
+		t.Fatalf("UpdateIssueChecked attempts = %d, want %d", got, nativeWriteAttempts)
+	}
+}
+
+// TestNativeDoltStoreUpdateIfMatchDoesNotRetryVersionMismatch proves the retry
+// wrapper leaves the fence itself intact: a version mismatch is ErrVersionMismatch,
+// which isNativeDoltSerializationConflict does not match, so the precondition
+// failure surfaces on the first attempt rather than being replayed.
+func TestNativeDoltStoreUpdateIfMatchDoesNotRetryVersionMismatch(t *testing.T) {
+	var attempts int32
+	spy := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return openIssueForConditionalTest(id), nil
+		},
+		updateIssueChecked: func(_ context.Context, _ string, _ map[string]interface{}, _ string, _ beadslib.UpdateIssueOptions) error {
+			atomic.AddInt32(&attempts, 1)
+			return beadslib.ErrVersionMismatch
+		},
+	}
+	store := newNativeDoltStoreForTest(spy)
+
+	status := "in_progress"
+	err := store.UpdateIfMatch("gc-1", 7, UpdateOpts{Status: &status})
+	if !IsPreconditionFailed(err) {
+		t.Fatalf("UpdateIfMatch on version mismatch: got %v, want a precondition failure", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("UpdateIssueChecked attempts = %d, want 1 (a precondition failure must not retry)", got)
+	}
+}
+
+func TestNativeDoltStoreCloseIfMatchRetriesSerializationConflict(t *testing.T) {
+	var attempts int32
+	spy := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return openIssueForConditionalTest(id), nil
+		},
+		closeIssueChecked: func(_ context.Context, _ string, _ string, _ beadslib.CloseIssueOptions) (beadslib.CloseIssueResult, error) {
+			if atomic.AddInt32(&attempts, 1) == 1 {
+				return beadslib.CloseIssueResult{}, errors.New(serializationConflictErr)
+			}
+			return beadslib.CloseIssueResult{}, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(spy)
+
+	if err := store.CloseIfMatch("gc-1", 7); err != nil {
+		t.Fatalf("CloseIfMatch after one serialization conflict: got %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("CloseIssueChecked attempts = %d, want 2 (one conflict, one retry)", got)
+	}
+}
+
+func TestNativeDoltStoreCloseIfMatchStopsAtAttemptLimit(t *testing.T) {
+	var attempts int32
+	spy := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return openIssueForConditionalTest(id), nil
+		},
+		closeIssueChecked: func(_ context.Context, _ string, _ string, _ beadslib.CloseIssueOptions) (beadslib.CloseIssueResult, error) {
+			atomic.AddInt32(&attempts, 1)
+			return beadslib.CloseIssueResult{}, errors.New(serializationConflictErr)
+		},
+	}
+	store := newNativeDoltStoreForTest(spy)
+
+	err := store.CloseIfMatch("gc-1", 7)
+	if err == nil {
+		t.Fatal("CloseIfMatch with unrelenting conflicts: got nil, want the serialization error")
+	}
+	if !isNativeDoltSerializationConflict(err) {
+		t.Fatalf("returned error lost its serialization-conflict identity: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != int32(nativeWriteAttempts) {
+		t.Fatalf("CloseIssueChecked attempts = %d, want %d", got, nativeWriteAttempts)
+	}
+}
+
+func TestNativeDoltStoreCloseIfMatchDoesNotRetryVersionMismatch(t *testing.T) {
+	var attempts int32
+	spy := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return openIssueForConditionalTest(id), nil
+		},
+		closeIssueChecked: func(_ context.Context, _ string, _ string, _ beadslib.CloseIssueOptions) (beadslib.CloseIssueResult, error) {
+			atomic.AddInt32(&attempts, 1)
+			return beadslib.CloseIssueResult{}, beadslib.ErrVersionMismatch
+		},
+	}
+	store := newNativeDoltStoreForTest(spy)
+
+	err := store.CloseIfMatch("gc-1", 7)
+	if !IsPreconditionFailed(err) {
+		t.Fatalf("CloseIfMatch on version mismatch: got %v, want a precondition failure", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("CloseIssueChecked attempts = %d, want 1 (a precondition failure must not retry)", got)
+	}
+}

--- a/internal/beads/native_dolt_store_metadata_cas_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_integration_test.go
@@ -5,11 +5,13 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/rollout/gate"
 	beadslib "github.com/steveyegge/beads"
 )
 
@@ -95,7 +97,7 @@ func openRealNativeDoltStoreForCAS(t *testing.T, actor string) *NativeDoltStore 
 	ctx := context.Background()
 	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))
 	if err != nil {
-		t.Skipf("upstream native beads storage unavailable: %v", err)
+		t.Fatalf("open upstream native beads storage: %v", err)
 	}
 	t.Cleanup(func() {
 		if err := storage.Close(); err != nil {
@@ -106,6 +108,66 @@ func openRealNativeDoltStoreForCAS(t *testing.T, actor string) *NativeDoltStore 
 		t.Fatalf("set issue prefix: %v", err)
 	}
 	return newNativeDoltStoreWithStorageAndPrefix(storage, actor, "gc")
+}
+
+// TestNativeDoltStoreConditionalWriterRequireAgainstRealOpenBestAvailable
+// proves that the exact upstream production constructor resolves the required
+// conditional-write capability and executes all three revision-fenced verbs.
+func TestNativeDoltStoreConditionalWriterRequireAgainstRealOpenBestAvailable(t *testing.T) {
+	store := openRealNativeDoltStoreForCAS(t, "conditional-writer-require")
+	store.stampConditionalWritesMode(gate.Require, false)
+
+	writer, diagnostic, err := ResolveConditionalWriter(store)
+	if err != nil || diagnostic != nil || writer == nil {
+		t.Fatalf("ResolveConditionalWriter = (%T, %+v, %v), want writer, nil, nil", writer, diagnostic, err)
+	}
+
+	created, err := store.Create(Bead{Title: "conditional-writer-real"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err = store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after create: %v", err)
+	}
+	if created.Revision == 0 {
+		t.Fatal("revision after create = 0, want a live token")
+	}
+	title := "conditional-writer-updated"
+	if err := writer.UpdateIfMatch(created.ID, created.Revision, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("UpdateIfMatch: %v", err)
+	}
+	updated, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+	if updated.Title != title {
+		t.Fatalf("title after update = %q, want %q", updated.Title, title)
+	}
+	if updated.Revision == created.Revision {
+		t.Fatalf("revision after update = %d, want a fresh token", updated.Revision)
+	}
+
+	if err := writer.CloseIfMatch(updated.ID, updated.Revision); err != nil {
+		t.Fatalf("CloseIfMatch: %v", err)
+	}
+	closed, err := store.Get(updated.ID)
+	if err != nil {
+		t.Fatalf("Get after close: %v", err)
+	}
+	if closed.Status != "closed" {
+		t.Fatalf("status after CloseIfMatch = %q, want closed", closed.Status)
+	}
+	if closed.Revision == updated.Revision {
+		t.Fatalf("revision after close = %d, want a fresh token", closed.Revision)
+	}
+
+	if err := writer.DeleteIfMatch(closed.ID, closed.Revision); err != nil {
+		t.Fatalf("DeleteIfMatch: %v", err)
+	}
+	if _, err := store.Get(closed.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after delete = %v, want ErrNotFound", err)
+	}
 }
 
 // TestNativeDoltStoreMetadataCASSequentialAgainstRealDolt exercises the

--- a/internal/beads/native_dolt_store_metadata_cas_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_integration_test.go
@@ -386,3 +386,104 @@ func TestNativeDoltStoreMetadataCASContentionAcrossIndependentHandles(t *testing
 		}
 	}
 }
+
+// TestNativeDoltStoreAtomicConditionalCloseAcrossIndependentHandles proves
+// the atomic terminal-write fence against the actual OpenBestAvailable
+// backend. The fast native fixture owns retry branch coverage; this test owns
+// the database isolation and rollback boundary shared by independent handles.
+func TestNativeDoltStoreAtomicConditionalCloseAcrossIndependentHandles(t *testing.T) {
+	ctx := context.Background()
+	dir := filepath.Join(t.TempDir(), ".beads")
+	openHandle := func(actor string) *NativeDoltStore {
+		t.Helper()
+		storage, err := beadslib.OpenBestAvailable(ctx, dir)
+		if err != nil {
+			t.Fatalf("open upstream native beads storage (%s): %v", actor, err)
+		}
+		t.Cleanup(func() {
+			if err := storage.Close(); err != nil {
+				t.Errorf("close upstream storage (%s): %v", actor, err)
+			}
+		})
+		if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+			t.Fatalf("set issue prefix (%s): %v", actor, err)
+		}
+		return newNativeDoltStoreWithStorageAndPrefix(storage, actor, "gc")
+	}
+
+	writerA := openHandle("atomic-close-A")
+	writerB := openHandle("atomic-close-B")
+	created, err := writerA.Create(Bead{Title: "real atomic conditional close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	snapshot, err := writerA.Get(created.ID)
+	if err != nil {
+		t.Fatalf("writerA Get: %v", err)
+	}
+	if peer, err := writerB.Get(created.ID); err != nil || peer.Revision != snapshot.Revision {
+		t.Fatalf("writerB snapshot = (%#v, %v), want revision %d", peer, err, snapshot.Revision)
+	}
+
+	type result struct {
+		bead Bead
+		err  error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	for _, writer := range []*NativeDoltStore{writerA, writerB} {
+		go func(store *NativeDoltStore) {
+			<-start
+			bead, err := store.CloseWithMetadataIfMatch(created.ID, snapshot.Revision, map[string]string{"winner": store.actor})
+			results <- result{bead: bead, err: err}
+		}(writer)
+	}
+	close(start)
+
+	var winner Bead
+	for range 2 {
+		result := <-results
+		switch {
+		case result.err == nil:
+			if winner.ID != "" {
+				t.Fatalf("multiple successful terminal writes: %#v and %#v", winner, result.bead)
+			}
+			winner = result.bead
+		case IsPreconditionFailed(result.err):
+			if result.bead.ID != "" {
+				t.Fatalf("losing close returned %#v, want zero bead", result.bead)
+			}
+		default:
+			t.Fatalf("contending close error = %v, want precondition failure", result.err)
+		}
+	}
+	if winner.ID == "" || winner.Status != "closed" || winner.Metadata["winner"] == "" {
+		t.Fatalf("winner = %#v, want exact closed row", winner)
+	}
+
+	staleCreated, err := writerA.Create(Bead{Title: "real atomic close stale rollback", Metadata: map[string]string{"before": "keep"}})
+	if err != nil {
+		t.Fatalf("Create stale bead: %v", err)
+	}
+	if err := writerB.SetMetadata(staleCreated.ID, "intervening", "write"); err != nil {
+		t.Fatalf("intervening SetMetadata: %v", err)
+	}
+	before, err := writerA.Get(staleCreated.ID)
+	if err != nil {
+		t.Fatalf("Get before stale close: %v", err)
+	}
+	closed, err := writerA.CloseWithMetadataIfMatch(staleCreated.ID, staleCreated.Revision, map[string]string{"state": "drained"})
+	if !IsPreconditionFailed(err) {
+		t.Fatalf("stale CloseWithMetadataIfMatch error = %v, want precondition failure", err)
+	}
+	if closed.ID != "" {
+		t.Fatalf("stale close returned %#v, want zero bead", closed)
+	}
+	after, err := writerB.Get(staleCreated.ID)
+	if err != nil {
+		t.Fatalf("Get after stale close: %v", err)
+	}
+	if after.Status != before.Status || after.Metadata["before"] != "keep" || after.Metadata["intervening"] != "write" || after.Metadata["state"] != "" {
+		t.Fatalf("stale close mutated real row: before=%#v after=%#v", before, after)
+	}
+}

--- a/internal/beads/native_dolt_store_metadata_cas_internal_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_internal_test.go
@@ -91,52 +91,52 @@ func assertMixedMetadataCASResult(t *testing.T, raw json.RawMessage, wantLargeNu
 	}
 }
 
-// TestNativeDoltStoreDeclaresNarrowCASButNotConditionalWriter pins the exact
-// capability split the narrow interface exists to express: NativeDoltStore
-// offers a sound metadata value-CAS and makes NO revision-fence claim.
-//
-// Declaring the full ConditionalWriter would make ResolveConditionalWriter
-// RESOLVE under require mode and hand the revision-CAS trio's callers a
-// silently wrong-fenced write, because no sound revision token exists at
-// beads v1.1.0 (see internal/beads/metadata_cas.go). This asserts the ABSENCE
-// of that capability, which no conformance suite can do.
-func TestNativeDoltStoreDeclaresNarrowCASButNotConditionalWriter(t *testing.T) {
+func TestNativeDoltStoreDeclaresConditionalWriterAndProbesBackendGuard(t *testing.T) {
 	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
 
-	if w, ok := ConditionalWriterFor(store); ok {
-		t.Fatalf("NativeDoltStore resolved a ConditionalWriter (%T); the revision-CAS trio has "+
-			"no sound backend fence at beads v1.1.0, so declaring it is a safety regression", w)
+	if _, ok := ConditionalWriterFor(store); !ok {
+		t.Fatal("NativeDoltStore does not resolve a ConditionalWriter")
 	}
 	if _, ok := MetadataCASWriterFor(store); !ok {
-		t.Fatal("NativeDoltStore does not resolve a MetadataCASWriter; the narrow value-CAS " +
-			"capability is what unblocks target_scope member-declaration and the D3/D5 lease lane")
+		t.Fatal("NativeDoltStore does not resolve a MetadataCASWriter")
+	}
+	if capable, reason := store.probeConditionalWriteCapability(); !capable {
+		t.Fatalf("guarded backend capability = false (%s), want true", reason)
+	}
+
+	incapable := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
+	if capable, reason := incapable.probeConditionalWriteCapability(); capable || reason == "" {
+		t.Fatalf("unguarded backend capability = (%t, %q), want false with reason", capable, reason)
 	}
 }
 
 // TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade pins the seam
 // behavior the condWritesStamp comment in native_dolt_store.go guarantees:
-// require yields a typed refusal and auto yields a loud degrade — never a
-// silent legacy write under require. Adding the narrow CAS must not move
-// either verdict.
+// capable native stores resolve, while an older unguarded backend still
+// refuses under require and degrades loudly under auto.
 func TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade(t *testing.T) {
-	t.Run("require_refuses", func(t *testing.T) {
+	t.Run("require_resolves_capable_backend", func(t *testing.T) {
 		store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
 		store.stampConditionalWritesMode(gate.Require, false)
 
 		writer, diag, err := ResolveConditionalWriter(store)
-		if writer != nil {
-			t.Fatalf("writer = %T, want nil (require must fail closed)", writer)
-		}
-		if !IsConditionalWritesRequired(err) {
-			t.Fatalf("err = %v, want *ConditionalWritesRequiredError", err)
-		}
-		if diag == nil {
-			t.Fatal("diagnostic = nil, want a refusal diagnostic")
+		if writer == nil || diag != nil || err != nil {
+			t.Fatalf("ResolveConditionalWriter = (%T, %+v, %v), want writer, nil, nil", writer, diag, err)
 		}
 	})
 
-	t.Run("auto_degrades_loudly", func(t *testing.T) {
-		store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	t.Run("require_refuses_unguarded_backend", func(t *testing.T) {
+		store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
+		store.stampConditionalWritesMode(gate.Require, false)
+
+		writer, diag, err := ResolveConditionalWriter(store)
+		if writer != nil || diag == nil || !IsConditionalWritesRequired(err) {
+			t.Fatalf("ResolveConditionalWriter = (%T, %+v, %v), want nil, diagnostic, required error", writer, diag, err)
+		}
+	})
+
+	t.Run("auto_degrades_unguarded_backend", func(t *testing.T) {
+		store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
 		store.stampConditionalWritesMode(gate.Auto, false)
 
 		writer, diag, err := ResolveConditionalWriter(store)
@@ -152,13 +152,10 @@ func TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade(t *testing.T) {
 	})
 }
 
-// TestCachingStoreOverNativeDoltStoreForwardsNarrowCAS covers the wrapper
-// shape the plan calls out: a CachingStore whose backing offers only the
-// narrow capability must still forward the metadata CAS. The cache resolves
-// its trio verbs through ConditionalWriterFor, so without a narrow fallback
-// this path would answer ErrConditionalWriteUnsupported and the lease lane
-// would be blocked behind the cache.
-func TestCachingStoreOverNativeDoltStoreForwardsNarrowCAS(t *testing.T) {
+// TestCachingStoreOverNativeDoltStoreForwardsConditionalWrites covers the
+// production wrapper shape: the cache must preserve both metadata CAS and the
+// guarded whole-row writer advertised by its native backing.
+func TestCachingStoreOverNativeDoltStoreForwardsConditionalWrites(t *testing.T) {
 	backing := newNativeDoltStoreForTest(newNativeDoltMemStorage())
 	cache := NewCachingStore(backing, nil)
 
@@ -188,11 +185,11 @@ func TestCachingStoreOverNativeDoltStoreForwardsNarrowCAS(t *testing.T) {
 		t.Fatalf("lease through cache = %q, want %q", got.Metadata["lease"], "holder-1")
 	}
 
-	// The trio stays refused: the backing makes no revision claim, so the
-	// cache must not report itself conditionally capable over it.
-	if capable, _ := cache.probeConditionalWriteCapability(); capable {
-		t.Fatal("CachingStore reports conditional-write capability over a narrow-only backing; " +
-			"the revision-CAS trio has no sound fence there")
+	if capable, reason := cache.probeConditionalWriteCapability(); !capable {
+		t.Fatalf("CachingStore reports conditional-write capability = false (%s)", reason)
+	}
+	if _, ok := ConditionalWriterFor(cache); !ok {
+		t.Fatal("CachingStore over NativeDoltStore does not resolve a ConditionalWriter")
 	}
 }
 

--- a/internal/beads/native_dolt_store_metadata_cas_internal_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_internal_test.go
@@ -91,7 +91,7 @@ func assertMixedMetadataCASResult(t *testing.T, raw json.RawMessage, wantLargeNu
 	}
 }
 
-func TestNativeDoltStoreDeclaresConditionalWriterAndProbesBackendGuard(t *testing.T) {
+func TestNativeDoltStoreDeclaresConditionalWriterAndProbesPinnedStorageContract(t *testing.T) {
 	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
 
 	if _, ok := ConditionalWriterFor(store); !ok {
@@ -101,55 +101,31 @@ func TestNativeDoltStoreDeclaresConditionalWriterAndProbesBackendGuard(t *testin
 		t.Fatal("NativeDoltStore does not resolve a MetadataCASWriter")
 	}
 	if capable, reason := store.probeConditionalWriteCapability(); !capable {
-		t.Fatalf("guarded backend capability = false (%s), want true", reason)
+		t.Fatalf("pinned backend capability = false (%s), want true", reason)
 	}
 
-	incapable := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
-	if capable, reason := incapable.probeConditionalWriteCapability(); capable || reason == "" {
-		t.Fatalf("unguarded backend capability = (%t, %q), want false with reason", capable, reason)
+	compiledStorage := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
+	if capable, reason := compiledStorage.probeConditionalWriteCapability(); !capable {
+		t.Fatalf("compiled Storage capability = false (%s), want true", reason)
 	}
 }
 
-// TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade pins the seam
-// behavior the condWritesStamp comment in native_dolt_store.go guarantees:
-// capable native stores resolve, while an older unguarded backend still
-// refuses under require and degrades loudly under auto.
-func TestNativeDoltStoreConditionalWritesStillRefuseOrDegrade(t *testing.T) {
-	t.Run("require_resolves_capable_backend", func(t *testing.T) {
-		store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
-		store.stampConditionalWritesMode(gate.Require, false)
+// TestNativeDoltStoreConditionalWritesResolveForPinnedStorageModes pins the
+// mode seam over the compile-time Storage contract. The pinned upstream
+// interface requires checked update/close and transactions, so there is no
+// runtime "older backend" shape hidden behind the same interface.
+func TestNativeDoltStoreConditionalWritesResolveForPinnedStorageModes(t *testing.T) {
+	for _, mode := range []gate.Mode{gate.Require, gate.Auto} {
+		t.Run(string(mode), func(t *testing.T) {
+			store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+			store.stampConditionalWritesMode(mode, false)
 
-		writer, diag, err := ResolveConditionalWriter(store)
-		if writer == nil || diag != nil || err != nil {
-			t.Fatalf("ResolveConditionalWriter = (%T, %+v, %v), want writer, nil, nil", writer, diag, err)
-		}
-	})
-
-	t.Run("require_refuses_unguarded_backend", func(t *testing.T) {
-		store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
-		store.stampConditionalWritesMode(gate.Require, false)
-
-		writer, diag, err := ResolveConditionalWriter(store)
-		if writer != nil || diag == nil || !IsConditionalWritesRequired(err) {
-			t.Fatalf("ResolveConditionalWriter = (%T, %+v, %v), want nil, diagnostic, required error", writer, diag, err)
-		}
-	})
-
-	t.Run("auto_degrades_unguarded_backend", func(t *testing.T) {
-		store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{})
-		store.stampConditionalWritesMode(gate.Auto, false)
-
-		writer, diag, err := ResolveConditionalWriter(store)
-		if writer != nil {
-			t.Fatalf("writer = %T, want nil (auto must take the legacy path)", writer)
-		}
-		if err != nil {
-			t.Fatalf("err = %v, want nil (auto degrades, it does not refuse)", err)
-		}
-		if diag == nil {
-			t.Fatal("diagnostic = nil, want a loud-degrade diagnostic")
-		}
-	})
+			writer, diag, err := ResolveConditionalWriter(store)
+			if writer == nil || diag != nil || err != nil {
+				t.Fatalf("ResolveConditionalWriter = (%T, %+v, %v), want writer, nil, nil", writer, diag, err)
+			}
+		})
+	}
 }
 
 // TestCachingStoreOverNativeDoltStoreForwardsConditionalWrites covers the

--- a/internal/beads/native_dolt_store_metadata_cas_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_test.go
@@ -9,23 +9,19 @@ import (
 )
 
 // TestNativeDoltStoreMetadataCASConformance holds NativeDoltStore to the
-// narrow value-CAS contract, including both traps the in-tree implementations
-// historically diverged on.
-//
-// The contention leg is declared unevaluatable HERE and only here: the
-// in-memory fixture behind this factory snapshots for rollback and then runs
-// the transaction callback unlocked, so concurrent CAS calls interleave freely
-// no matter how the store behaves. The property is not waived — it is proven
-// against real Dolt by
-// TestNativeDoltStoreMetadataCASContentionAgainstRealDolt (build tag
-// `integration`), where 8 racers yield exactly one winner.
+// complete value-CAS contract. The in-memory native fixture serializes
+// transaction callbacks so its contention behavior matches real Dolt.
 func TestNativeDoltStoreMetadataCASConformance(t *testing.T) {
-	beadstest.RunMetadataCASConformanceWithOptions(t, "NativeDoltStore",
+	beadstest.RunMetadataCASConformance(t, "NativeDoltStore",
+		func(_ *testing.T) beads.Store { return beads.NewNativeDoltStoreForConformance() })
+}
+
+func TestNativeDoltStoreConditionalWriterConformance(t *testing.T) {
+	beadstest.RunConditionalWriterConformanceWithOptions(t, "NativeDoltStore",
 		func(_ *testing.T) beads.Store { return beads.NewNativeDoltStoreForConformance() },
-		beadstest.MetadataCASOptions{
-			FixtureLacksIsolationReason: "nativeDoltMemStorage.RunInTransaction models rollback but not " +
-				"isolation (it unlocks before running the callback); contention is covered against real " +
-				"Dolt by TestNativeDoltStoreMetadataCASContentionAgainstRealDolt (-tags=integration)",
+		beadstest.ConditionalWriterOptions{
+			RowBackedMutationFlavors: true,
+			SuppliesCurrent:          true,
 		},
 	)
 }

--- a/internal/beads/native_dolt_store_metadata_cas_test.go
+++ b/internal/beads/native_dolt_store_metadata_cas_test.go
@@ -21,6 +21,7 @@ func TestNativeDoltStoreConditionalWriterConformance(t *testing.T) {
 		func(_ *testing.T) beads.Store { return beads.NewNativeDoltStoreForConformance() },
 		beadstest.ConditionalWriterOptions{
 			RowBackedMutationFlavors: true,
+			RestrictedUpdateFields:   true,
 			SuppliesCurrent:          true,
 		},
 	)

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -1320,6 +1321,142 @@ func TestNativeDoltStoreTxRollsBackOnError(t *testing.T) {
 	}
 }
 
+func TestNativeDoltStoreCloseWithMetadataIfMatchCommitsOneFencedTerminalState(t *testing.T) {
+	storage := &commitCountingMemStorage{nativeDoltMemStorage: newNativeDoltMemStorage()}
+	store := newNativeDoltStoreForTest(storage)
+	created, err := store.Create(Bead{
+		Title:    "atomic terminal state",
+		Metadata: map[string]string{"sibling": "preserved"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	commitsBeforeClose := storage.commits
+	if err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{
+		"state":        "drained",
+		"close_reason": "reconciler stop",
+	}); err != nil {
+		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if got := storage.commits - commitsBeforeClose; got != 1 {
+		t.Fatalf("atomic metadata close issued %d commits, want exactly one", got)
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed", got.Status)
+	}
+	for key, want := range map[string]string{
+		"sibling":      "preserved",
+		"state":        "drained",
+		"close_reason": "reconciler stop",
+	} {
+		if got.Metadata[key] != want {
+			t.Fatalf("metadata[%q] = %q, want %q (metadata and close must share one commit)", key, got.Metadata[key], want)
+		}
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchRejectsStaleRevisionWithoutMutation(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	created, err := store.Create(Bead{Title: "stale fenced close", Metadata: map[string]string{"sibling": "before"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.SetMetadata(created.ID, "intervening", "write"); err != nil {
+		t.Fatalf("intervening SetMetadata: %v", err)
+	}
+	before, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get before stale close: %v", err)
+	}
+
+	err = store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+	if !IsPreconditionFailed(err) {
+		t.Fatalf("CloseWithMetadataIfMatch stale error = %v, want precondition failure", err)
+	}
+	after, getErr := store.Get(created.ID)
+	if getErr != nil {
+		t.Fatalf("Get after stale close: %v", getErr)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("stale close mutated bead:\n got: %#v\nwant: %#v", after, before)
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchRollsBackMetadataWhenCloseFails(t *testing.T) {
+	sentinel := errors.New("injected close failure")
+	storage := &nativeDoltFailingCloseStorage{
+		nativeDoltMemStorage: newNativeDoltMemStorage(),
+		closeIssue: func(context.Context, string, string, string, string) error {
+			return sentinel
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+	created, err := store.Create(Bead{Title: "rollback fenced close", Metadata: map[string]string{"sibling": "before"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	before, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get before close: %v", err)
+	}
+
+	err = store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("CloseWithMetadataIfMatch error = %v, want injected close failure", err)
+	}
+	after, getErr := store.Get(created.ID)
+	if getErr != nil {
+		t.Fatalf("Get after failed close: %v", getErr)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("failed close left partial mutation:\n got: %#v\nwant: %#v", after, before)
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchHasOneSameRevisionWinner(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	created, err := store.Create(Bead{Title: "racing fenced close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	results := make(chan error, 2)
+	for _, value := range []string{"first", "second"} {
+		value := value
+		go func() {
+			results <- store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"winner": value})
+		}()
+	}
+	var wins, losses int
+	for range 2 {
+		err := <-results
+		switch {
+		case err == nil:
+			wins++
+		case IsPreconditionFailed(err):
+			losses++
+		default:
+			t.Fatalf("same-revision close error = %v, want nil or precondition failure", err)
+		}
+	}
+	if wins != 1 || losses != 1 {
+		t.Fatalf("same-revision results wins=%d losses=%d, want exactly one of each", wins, losses)
+	}
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after race: %v", err)
+	}
+	if got.Status != "closed" || (got.Metadata["winner"] != "first" && got.Metadata["winner"] != "second") {
+		t.Fatalf("winner state = %#v, want one complete terminal result", got)
+	}
+}
+
 func TestNativeDoltStoreDependencyRoundTrip(t *testing.T) {
 	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
 	parent, err := store.Create(Bead{Title: "dependency parent"})
@@ -2557,6 +2694,24 @@ func (s *nativeDoltMemStorage) Close() error {
 type nativeDoltCloseCapturingStorage struct {
 	*nativeDoltMemStorage
 	closeReasons []string
+}
+
+type nativeDoltFailingCloseStorage struct {
+	*nativeDoltMemStorage
+	closeIssue func(context.Context, string, string, string, string) error
+}
+
+func (s *nativeDoltFailingCloseStorage) RunInTransaction(_ context.Context, _ string, fn func(beadslib.Transaction) error) error {
+	return runNativeDoltMemStorageTransactionForTest(s.nativeDoltMemStorage, func() error {
+		return fn(nativeDoltTransactionForTest{storage: s})
+	})
+}
+
+func (s *nativeDoltFailingCloseStorage) CloseIssue(ctx context.Context, id, reason, actor, session string) error {
+	if s.closeIssue != nil {
+		return s.closeIssue(ctx, id, reason, actor, session)
+	}
+	return s.nativeDoltMemStorage.CloseIssue(ctx, id, reason, actor, session)
 }
 
 func (s *nativeDoltCloseCapturingStorage) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -1277,6 +1277,62 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchReturnsZeroAfterRetryExhaustion(
 	}
 }
 
+// DeleteIfMatch runs its fence check and delete inside one transaction, so a
+// serialization conflict must replay the WHOLE transaction — re-reading the row
+// version each attempt — exactly like the close path. Retrying only the delete
+// would fence against a RowVersion the rolled-back read already invalidated.
+func TestNativeDoltStoreDeleteIfMatchRetriesWholeTransaction(t *testing.T) {
+	for _, conflict := range []error{
+		errors.New("Error 1213 (40001): deadlock"),
+		errors.New("Error 1205 (HY000): lock wait timeout exceeded"),
+	} {
+		t.Run(conflict.Error(), func(t *testing.T) {
+			storage := &retryingNativeDoltStorage{
+				nativeDoltMemStorage: newNativeDoltMemStorage(),
+				txErrors:             []error{conflict},
+			}
+			store := newNativeDoltStoreForTest(storage)
+			created, err := store.Create(Bead{Title: "retry whole delete transaction"})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			if err := store.DeleteIfMatch(created.ID, created.Revision); err != nil {
+				t.Fatalf("DeleteIfMatch: %v", err)
+			}
+			if storage.txCalls != 2 {
+				t.Fatalf("RunInTransaction calls = %d, want 2", storage.txCalls)
+			}
+			if _, err := store.Get(created.ID); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("Get after replayed delete = %v, want ErrNotFound", err)
+			}
+		})
+	}
+}
+
+// An ambiguous failure — one that may have committed — must NOT replay a delete,
+// or a delete that already applied would run again against a moved fence. This
+// pins the same transient/ambiguous split the close path draws.
+func TestNativeDoltStoreDeleteIfMatchDoesNotRetryAmbiguousFailure(t *testing.T) {
+	sentinel := errors.New("connection reset by peer")
+	storage := &retryingNativeDoltStorage{
+		nativeDoltMemStorage: newNativeDoltMemStorage(),
+		txErrors:             []error{sentinel},
+	}
+	store := newNativeDoltStoreForTest(storage)
+	created, err := store.Create(Bead{Title: "ambiguous delete"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := store.DeleteIfMatch(created.ID, created.Revision); !errors.Is(err, sentinel) {
+		t.Fatalf("DeleteIfMatch error = %v, want %v", err, sentinel)
+	}
+	if storage.txCalls != 1 {
+		t.Fatalf("RunInTransaction calls = %d, want 1", storage.txCalls)
+	}
+}
+
 func TestNativeDoltStoreReadyFiltersGasCityExcludedTypesBeforeLimit(t *testing.T) {
 	storage := &nativeDoltStorageSpy{
 		getReadyWork: func(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
@@ -2452,9 +2508,11 @@ type nativeDoltStorageSpy struct {
 	createIssues                func(context.Context, []*beadslib.Issue, string) error
 	getIssue                    func(context.Context, string) (*beadslib.Issue, error)
 	updateIssue                 func(context.Context, string, map[string]interface{}, string) error
+	updateIssueChecked          func(context.Context, string, map[string]interface{}, string, beadslib.UpdateIssueOptions) error
 	runInTransaction            func(context.Context, string, func(beadslib.Transaction) error) error
 	reopenIssue                 func(context.Context, string, string, string) error
 	closeIssue                  func(context.Context, string, string, string, string) error
+	closeIssueChecked           func(context.Context, string, string, beadslib.CloseIssueOptions) (beadslib.CloseIssueResult, error)
 	deleteIssue                 func(context.Context, string) error
 	searchIssues                func(context.Context, string, beadslib.IssueFilter) ([]*beadslib.Issue, error)
 	countIssues                 func(context.Context, string, beadslib.IssueFilter) (int64, error)
@@ -2503,6 +2561,13 @@ func (s *nativeDoltStorageSpy) UpdateIssue(ctx context.Context, id string, updat
 	return s.updateIssue(ctx, id, updates, actor)
 }
 
+func (s *nativeDoltStorageSpy) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts beadslib.UpdateIssueOptions) error {
+	if s.updateIssueChecked == nil {
+		return nil
+	}
+	return s.updateIssueChecked(ctx, id, updates, actor, opts)
+}
+
 func (s *nativeDoltStorageSpy) RunInTransaction(ctx context.Context, commitMsg string, fn func(beadslib.Transaction) error) error {
 	if s.runInTransaction != nil {
 		return s.runInTransaction(ctx, commitMsg, fn)
@@ -2522,6 +2587,13 @@ func (s *nativeDoltStorageSpy) CloseIssue(ctx context.Context, id string, reason
 		return nil
 	}
 	return s.closeIssue(ctx, id, reason, actor, session)
+}
+
+func (s *nativeDoltStorageSpy) CloseIssueChecked(ctx context.Context, id string, actor string, opts beadslib.CloseIssueOptions) (beadslib.CloseIssueResult, error) {
+	if s.closeIssueChecked == nil {
+		return beadslib.CloseIssueResult{}, nil
+	}
+	return s.closeIssueChecked(ctx, id, actor, opts)
 }
 
 func (s *nativeDoltStorageSpy) DeleteIssue(ctx context.Context, id string) error {

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -2040,6 +2040,7 @@ type nativeDoltTransactionTestStorage interface {
 	GetIssue(context.Context, string) (*beadslib.Issue, error)
 	UpdateIssue(context.Context, string, map[string]interface{}, string) error
 	CloseIssue(context.Context, string, string, string, string) error
+	DeleteIssue(context.Context, string) error
 	AddLabel(context.Context, string, string, string) error
 	RemoveLabel(context.Context, string, string, string) error
 	AddDependency(context.Context, *beadslib.Dependency, string) error
@@ -2062,6 +2063,10 @@ func (tx nativeDoltTransactionForTest) CreateIssues(ctx context.Context, issues 
 
 func (tx nativeDoltTransactionForTest) CloseIssue(ctx context.Context, id, reason, actor, session string) error {
 	return tx.storage.CloseIssue(ctx, id, reason, actor, session)
+}
+
+func (tx nativeDoltTransactionForTest) DeleteIssue(ctx context.Context, id string) error {
+	return tx.storage.DeleteIssue(ctx, id)
 }
 
 func (tx nativeDoltTransactionForTest) GetIssue(ctx context.Context, id string) (*beadslib.Issue, error) {
@@ -2390,10 +2395,6 @@ func (s *nativeDoltMemStorage) CloseIssueChecked(
 
 func (s *nativeDoltMemStorage) DeleteIssue(_ context.Context, id string) error {
 	return s.store.Delete(id)
-}
-
-func (s *nativeDoltMemStorage) DeleteIssueChecked(_ context.Context, id string, expectedVersion int64) error {
-	return nativeDoltMemCheckedError(s.store.DeleteIfMatch(id, expectedVersion))
 }
 
 func nativeDoltMemCheckedError(err error) error {

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1149,6 +1150,7 @@ func TestNativeDoltSerializationConflictClassification(t *testing.T) {
 		want bool
 	}{
 		{name: "mysql error and SQLSTATE", err: errors.New("Error 1213 (40001): serialization failure"), want: true},
+		{name: "mysql lock wait timeout", err: errors.New("Error 1205 (HY000): lock wait timeout exceeded"), want: true},
 		{name: "SQLSTATE", err: errors.New("commit failed (SQLSTATE 40001)"), want: true},
 		{name: "Dolt conflict wording", err: errors.New("this transaction conflicts with a committed transaction"), want: true},
 		{name: "unrelated serialization wording", err: errors.New("serialization failed while encoding metadata"), want: false},
@@ -1161,6 +1163,117 @@ func TestNativeDoltSerializationConflictClassification(t *testing.T) {
 				t.Fatalf("isNativeDoltSerializationConflict(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchRetriesWholeTransaction(t *testing.T) {
+	for _, conflict := range []error{
+		errors.New("Error 1213 (40001): deadlock"),
+		errors.New("Error 1205 (HY000): lock wait timeout exceeded"),
+	} {
+		t.Run(conflict.Error(), func(t *testing.T) {
+			storage := &retryingNativeDoltStorage{
+				nativeDoltMemStorage: newNativeDoltMemStorage(),
+				txErrors:             []error{conflict},
+			}
+			store := newNativeDoltStoreForTest(storage)
+			created, err := store.Create(Bead{Title: "retry whole transaction"})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+			if err != nil {
+				t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+			}
+			if storage.txCalls != 2 {
+				t.Fatalf("RunInTransaction calls = %d, want 2", storage.txCalls)
+			}
+			if closed.Status != "closed" || closed.Metadata["state"] != "drained" {
+				t.Fatalf("returned bead = %#v, want closed row from replay", closed)
+			}
+		})
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchRetryRereadsFence(t *testing.T) {
+	storage := &retryingNativeDoltStorage{nativeDoltMemStorage: newNativeDoltMemStorage()}
+	store := newNativeDoltStoreForTest(storage)
+	created, err := store.Create(Bead{Title: "retry stale fence"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	storage.txErrors = []error{errors.New("Error 1213 (40001): deadlock")}
+	storage.afterConflict = func() {
+		if err := storage.store.SetMetadata(created.ID, "intervening", "write"); err != nil {
+			t.Fatalf("intervening write: %v", err)
+		}
+	}
+
+	closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+	if !IsPreconditionFailed(err) {
+		t.Fatalf("CloseWithMetadataIfMatch error = %v, want precondition failure", err)
+	}
+	if !reflect.DeepEqual(closed, Bead{}) {
+		t.Fatalf("failed replay returned %#v, want zero bead", closed)
+	}
+	if storage.txCalls != 2 {
+		t.Fatalf("RunInTransaction calls = %d, want 2", storage.txCalls)
+	}
+	fresh, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fresh.Status != "open" || fresh.Metadata["state"] != "" || fresh.Metadata["intervening"] != "write" {
+		t.Fatalf("replay fence result = %#v, want later open row without close", fresh)
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchDoesNotRetryAmbiguousFailure(t *testing.T) {
+	sentinel := errors.New("connection reset by peer")
+	storage := &retryingNativeDoltStorage{
+		nativeDoltMemStorage: newNativeDoltMemStorage(),
+		txErrors:             []error{sentinel},
+	}
+	store := newNativeDoltStoreForTest(storage)
+	created, err := store.Create(Bead{Title: "ambiguous close"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, nil)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("CloseWithMetadataIfMatch error = %v, want %v", err, sentinel)
+	}
+	if !reflect.DeepEqual(closed, Bead{}) {
+		t.Fatalf("ambiguous failure returned %#v, want zero bead", closed)
+	}
+	if storage.txCalls != 1 {
+		t.Fatalf("RunInTransaction calls = %d, want 1", storage.txCalls)
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchReturnsZeroAfterRetryExhaustion(t *testing.T) {
+	conflict := errors.New("Error 1213 (40001): deadlock")
+	storage := &retryingNativeDoltStorage{
+		nativeDoltMemStorage: newNativeDoltMemStorage(),
+		txErrors:             []error{conflict, conflict, conflict},
+	}
+	store := newNativeDoltStoreForTest(storage)
+	created, err := store.Create(Bead{Title: "exhaust close retries"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, nil)
+	if !errors.Is(err, conflict) {
+		t.Fatalf("CloseWithMetadataIfMatch error = %v, want %v", err, conflict)
+	}
+	if !reflect.DeepEqual(closed, Bead{}) {
+		t.Fatalf("exhausted retry returned %#v, want zero bead", closed)
+	}
+	if storage.txCalls != nativeWriteAttempts {
+		t.Fatalf("RunInTransaction calls = %d, want %d", storage.txCalls, nativeWriteAttempts)
 	}
 }
 
@@ -1333,11 +1446,15 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchCommitsOneFencedTerminalState(t 
 	}
 
 	commitsBeforeClose := storage.commits
-	if err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{
+	closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{
 		"state":        "drained",
 		"close_reason": "reconciler stop",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("CloseWithMetadataIfMatch: %v", err)
+	}
+	if closed.Status != "closed" || closed.Metadata["state"] != "drained" || closed.Metadata["sibling"] != "preserved" {
+		t.Fatalf("returned closed bead = %#v, want exact merged terminal row", closed)
 	}
 	if got := storage.commits - commitsBeforeClose; got != 1 {
 		t.Fatalf("atomic metadata close issued %d commits, want exactly one", got)
@@ -1362,7 +1479,8 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchCommitsOneFencedTerminalState(t 
 }
 
 func TestNativeDoltStoreCloseWithMetadataIfMatchRejectsStaleRevisionWithoutMutation(t *testing.T) {
-	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+	storage := newNativeDoltMemStorage()
+	store := newNativeDoltStoreForTest(storage)
 	created, err := store.Create(Bead{Title: "stale fenced close", Metadata: map[string]string{"sibling": "before"}})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -1374,10 +1492,18 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchRejectsStaleRevisionWithoutMutat
 	if err != nil {
 		t.Fatalf("Get before stale close: %v", err)
 	}
+	beforeIssue, err := storage.GetIssue(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetIssue before stale close: %v", err)
+	}
+	beforeRawMetadata := bytes.Clone(beforeIssue.Metadata)
 
-	err = store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+	closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
 	if !IsPreconditionFailed(err) {
 		t.Fatalf("CloseWithMetadataIfMatch stale error = %v, want precondition failure", err)
+	}
+	if !reflect.DeepEqual(closed, Bead{}) {
+		t.Fatalf("stale close result = %#v, want zero bead", closed)
 	}
 	after, getErr := store.Get(created.ID)
 	if getErr != nil {
@@ -1385,6 +1511,36 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchRejectsStaleRevisionWithoutMutat
 	}
 	if !reflect.DeepEqual(after, before) {
 		t.Fatalf("stale close mutated bead:\n got: %#v\nwant: %#v", after, before)
+	}
+	afterIssue, err := storage.GetIssue(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetIssue after stale close: %v", err)
+	}
+	if !bytes.Equal(afterIssue.Metadata, beforeRawMetadata) {
+		t.Fatalf("stale close changed raw metadata bytes:\n got: %q\nwant: %q", afterIssue.Metadata, beforeRawMetadata)
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchReturnsZeroOnMalformedMetadata(t *testing.T) {
+	storage := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return &beadslib.Issue{
+				ID:         id,
+				Status:     beadslib.StatusOpen,
+				IssueType:  beadslib.TypeTask,
+				Metadata:   json.RawMessage(`{"broken":`),
+				RowVersion: 17,
+			}, nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	closed, err := store.CloseWithMetadataIfMatch("gc-malformed", 17, map[string]string{"state": "drained"})
+	if err == nil {
+		t.Fatal("CloseWithMetadataIfMatch error = nil, want malformed metadata error")
+	}
+	if !reflect.DeepEqual(closed, Bead{}) {
+		t.Fatalf("malformed close result = %#v, want zero bead", closed)
 	}
 }
 
@@ -1405,8 +1561,16 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchRollsBackMetadataWhenCloseFails(
 	if err != nil {
 		t.Fatalf("Get before close: %v", err)
 	}
+	beforeIssue, err := storage.GetIssue(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetIssue before close: %v", err)
+	}
+	beforeRawMetadata := bytes.Clone(beforeIssue.Metadata)
 
-	err = store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+	closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+	if !reflect.DeepEqual(closed, Bead{}) {
+		t.Fatalf("CloseWithMetadataIfMatch result = %#v, want zero bead on failure", closed)
+	}
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("CloseWithMetadataIfMatch error = %v, want injected close failure", err)
 	}
@@ -1417,6 +1581,42 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchRollsBackMetadataWhenCloseFails(
 	if !reflect.DeepEqual(after, before) {
 		t.Fatalf("failed close left partial mutation:\n got: %#v\nwant: %#v", after, before)
 	}
+	afterIssue, err := storage.GetIssue(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetIssue after failed close: %v", err)
+	}
+	if !bytes.Equal(afterIssue.Metadata, beforeRawMetadata) {
+		t.Fatalf("failed close changed raw metadata bytes:\n got: %q\nwant: %q", afterIssue.Metadata, beforeRawMetadata)
+	}
+}
+
+func TestNativeDoltStoreCloseWithMetadataIfMatchRejectsUnclosedResult(t *testing.T) {
+	storage := &nativeDoltFailingCloseStorage{
+		nativeDoltMemStorage: newNativeDoltMemStorage(),
+		closeIssue: func(context.Context, string, string, string, string) error {
+			return nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+	created, err := store.Create(Bead{Title: "close postcondition"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	closed, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"state": "drained"})
+	if err == nil {
+		t.Fatal("CloseWithMetadataIfMatch error = nil, want unclosed-result refusal")
+	}
+	if !reflect.DeepEqual(closed, Bead{}) {
+		t.Fatalf("unclosed transaction returned %#v, want zero bead", closed)
+	}
+	fresh, getErr := store.Get(created.ID)
+	if getErr != nil {
+		t.Fatalf("Get after refused close: %v", getErr)
+	}
+	if fresh.Status != "open" || fresh.Metadata["state"] != "" {
+		t.Fatalf("refused close left a partial mutation: %#v", fresh)
+	}
 }
 
 func TestNativeDoltStoreCloseWithMetadataIfMatchHasOneSameRevisionWinner(t *testing.T) {
@@ -1426,21 +1626,33 @@ func TestNativeDoltStoreCloseWithMetadataIfMatchHasOneSameRevisionWinner(t *test
 		t.Fatalf("Create: %v", err)
 	}
 
-	results := make(chan error, 2)
+	type closeResult struct {
+		bead Bead
+		err  error
+	}
+	results := make(chan closeResult, 2)
 	for _, value := range []string{"first", "second"} {
 		value := value
 		go func() {
-			results <- store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"winner": value})
+			bead, err := store.CloseWithMetadataIfMatch(created.ID, created.Revision, map[string]string{"winner": value})
+			results <- closeResult{bead: bead, err: err}
 		}()
 	}
 	var wins, losses int
 	for range 2 {
-		err := <-results
+		result := <-results
+		err := result.err
 		switch {
 		case err == nil:
 			wins++
+			if result.bead.Status != "closed" || result.bead.Metadata["winner"] == "" {
+				t.Fatalf("winning result = %#v, want exact closed winner", result.bead)
+			}
 		case IsPreconditionFailed(err):
 			losses++
+			if !reflect.DeepEqual(result.bead, Bead{}) {
+				t.Fatalf("losing result = %#v, want zero bead", result.bead)
+			}
 		default:
 			t.Fatalf("same-revision close error = %v, want nil or precondition failure", err)
 		}
@@ -2699,6 +2911,32 @@ type nativeDoltCloseCapturingStorage struct {
 type nativeDoltFailingCloseStorage struct {
 	*nativeDoltMemStorage
 	closeIssue func(context.Context, string, string, string, string) error
+}
+
+type retryingNativeDoltStorage struct {
+	*nativeDoltMemStorage
+	txCalls       int
+	txErrors      []error
+	afterConflict func()
+}
+
+func (s *retryingNativeDoltStorage) RunInTransaction(_ context.Context, _ string, fn func(beadslib.Transaction) error) error {
+	s.txCalls++
+	var txErr error
+	if len(s.txErrors) > 0 {
+		txErr = s.txErrors[0]
+		s.txErrors = s.txErrors[1:]
+	}
+	err := runNativeDoltMemStorageTransactionForTest(s.nativeDoltMemStorage, func() error {
+		if err := fn(nativeDoltTransactionForTest{storage: s}); err != nil {
+			return err
+		}
+		return txErr
+	})
+	if txErr != nil && s.afterConflict != nil {
+		s.afterConflict()
+	}
+	return err
 }
 
 func (s *nativeDoltFailingCloseStorage) RunInTransaction(_ context.Context, _ string, fn func(beadslib.Transaction) error) error {

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2271,6 +2272,7 @@ func (s *nativeDoltStorageSpy) Close() error {
 type nativeDoltMemStorage struct {
 	beadslib.Storage
 	store *MemStore
+	txMu  sync.Mutex
 }
 
 func newNativeDoltMemStorage() *nativeDoltMemStorage {
@@ -2284,6 +2286,8 @@ func (s *nativeDoltMemStorage) RunInTransaction(_ context.Context, _ string, fn 
 }
 
 func runNativeDoltMemStorageTransactionForTest(storage *nativeDoltMemStorage, fn func() error) error {
+	storage.txMu.Lock()
+	defer storage.txMu.Unlock()
 	storage.store.mu.Lock()
 	seq, beads, deps := storage.store.snapshot()
 	storage.store.mu.Unlock()
@@ -2338,6 +2342,23 @@ func (s *nativeDoltMemStorage) UpdateIssue(_ context.Context, id string, updates
 	return s.store.Update(id, opts)
 }
 
+func (s *nativeDoltMemStorage) UpdateIssueChecked(
+	_ context.Context,
+	id string,
+	updates map[string]interface{},
+	_ string,
+	opts beadslib.UpdateIssueOptions,
+) error {
+	updateOpts, err := nativeDoltMemUpdateOpts(updates)
+	if err != nil {
+		return err
+	}
+	if opts.ExpectedVersion == nil {
+		return s.store.Update(id, updateOpts)
+	}
+	return nativeDoltMemCheckedError(s.store.UpdateIfMatch(id, *opts.ExpectedVersion, updateOpts))
+}
+
 func (s *nativeDoltMemStorage) ReopenIssue(_ context.Context, id string, _ string, _ string) error {
 	return s.store.Reopen(id)
 }
@@ -2346,8 +2367,40 @@ func (s *nativeDoltMemStorage) CloseIssue(_ context.Context, id string, _ string
 	return s.store.Close(id)
 }
 
+func (s *nativeDoltMemStorage) CloseIssueChecked(
+	_ context.Context,
+	id string,
+	_ string,
+	opts beadslib.CloseIssueOptions,
+) (beadslib.CloseIssueResult, error) {
+	current, err := s.store.Get(id)
+	if err != nil {
+		return beadslib.CloseIssueResult{}, err
+	}
+	if opts.ExpectedVersion == nil {
+		err = s.store.Close(id)
+	} else {
+		err = s.store.CloseIfMatch(id, *opts.ExpectedVersion)
+	}
+	if err != nil {
+		return beadslib.CloseIssueResult{}, nativeDoltMemCheckedError(err)
+	}
+	return beadslib.CloseIssueResult{Unchanged: current.Status == "closed"}, nil
+}
+
 func (s *nativeDoltMemStorage) DeleteIssue(_ context.Context, id string) error {
 	return s.store.Delete(id)
+}
+
+func (s *nativeDoltMemStorage) DeleteIssueChecked(_ context.Context, id string, expectedVersion int64) error {
+	return nativeDoltMemCheckedError(s.store.DeleteIfMatch(id, expectedVersion))
+}
+
+func nativeDoltMemCheckedError(err error) error {
+	if !IsPreconditionFailed(err) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", beadslib.ErrVersionMismatch, err)
 }
 
 func (s *nativeDoltMemStorage) SearchIssues(_ context.Context, _ string, filter beadslib.IssueFilter) ([]*beadslib.Issue, error) {


### PR DESCRIPTION
## What this hardens

Four independent gaps in the conditional-write path, plus one cache primitive.

**1. The revision contract required monotonicity.** That is a property of a
counter, not of a fence, and it excluded any backend whose
optimistic-concurrency token is a row version rather than a running total. The
contract is restated as what conditional writes actually need: a mutation
mints a fresh, nonzero, non-reused token, and the immediately prior token is
stale. The shared conformance suite proves that instead of monotonicity, and
the legs that are genuinely per-backend moved behind `ConditionalWriterOptions`.

Also made explicit: a store that persists parent and labels through writes it
cannot fold into the guarded row now rejects them from `UpdateIfMatch` with the
new `ConditionalUpdateFieldUnsupportedError`, rather than applying them
unfenced.

**2. bd revisions decoded lossily.** `bdIssue` decoded the token as a plain
`int64`, which fails outright once bd emits it as a decimal string, and a
generic JSON-number path would round a large token through `float64`. The new
`bdRevision` type accepts both the current string and legacy integer forms and
parses straight to `int64`.

**3. The native Dolt store had no whole-row fence, and what it had was
unreachable.** It could only fence on metadata keys, so a caller needing a
whole-row guard had no conditional write against it at all — and the
conditional writer that did exist was reachable only from its own tests,
because the production construction path never advertised the capability. A
routed city therefore fell through the resolver to unconditional writes.
`UpdateIfMatch`/`CloseIfMatch`/`DeleteIfMatch` now fence on the row-version
token the `Store` read surface returns, and the capability is wired through the
production path and proven from the integration row.

**4. Recording terminal metadata and closing a bead were two writes.** A crash
between them left a bead closed without its terminal record, or carrying a
terminal record while still open. `AtomicConditionalCloser.CloseWithMetadataIfMatch`
merges metadata and closes under one revision fence, committing both or
neither. It is deliberately narrower than `ConditionalWriter` and is exposed
only by stores that can prove both halves share a transaction, so a caller
needing all-or-nothing must refuse rather than degrade. A wrapper resolves the
capability through the backing it will actually write through
(`AtomicConditionalCloserHandleProvider`), so it cannot advertise atomicity the
backing cannot deliver.

**5. A cache census could not be acted on safely.** A caller that read the
active-bead census out of `CachingStore` had no way to prove the cache had not
changed underneath it. `ObservedList` returns a detached census plus an opaque
process-local stamp; `WithCurrentObservation` runs a bounded callback only
while that stamp still describes a clean cache. The stamp fences this process's
cache projection only — it certifies neither durable-store lineage nor event
delivery.

**6. Releasing an assignment did not stale the prior token.** `ReleaseIfCurrent`
reopened and unassigned the bead without minting a fresh revision, so a writer
holding the pre-release token could still overwrite a bead someone else had
already re-claimed. It now mints a fresh token in the same statement, falling
back to the legacy statement when the backend has no revision column. The one
`cmd/gc` test that pinned the exact SQL string now matches around the token
instead of the whole literal.

## Why this is reconciler-independent

Every change is a property of `internal/beads` and its store implementations.
The new surface is additive: `AtomicConditionalCloser` and
`AtomicConditionalCloserHandleProvider` are optional interfaces resolved by
`AtomicConditionalCloserFor`, and callers that do not ask for them are
unaffected. Nothing here knows about sessions, reconciliation, or `cmd/gc`, and
`internal/beads` gained no new dependency.

Making the native store's conditional writes production-reachable is a
standalone correctness fix, independent of any consumer: today a routed city
silently downgrades fenced writes to unconditional ones.

## A note on SQLiteStore

The tightened contract asserted two clauses against every `ConditionalWriter`
that turn out to be properties of a bd- or Dolt-backed store. `SQLiteStore`,
added to `main` after this work was written, falsifies both:

- it keeps the whole bead in one row and *can* apply parent and label updates
  inside a guarded write, so requiring `ConditionalUpdateFieldUnsupportedError`
  from every implementation would forbid a capability it legitimately has;
- a never-mutated bead reads back at revision zero, so demanding a nonzero
  token straight out of `Create` is a counter-implementation detail, not a
  fence requirement.

The last commit therefore moves the restricted-field leg behind
`ConditionalWriterOptions.RestrictedUpdateFields` (enabled for the stores that
persist those fields separately) and seeds the token-reuse leg only from a real
token. Both doc clauses now say what is actually guaranteed. `SQLiteStore`
itself is left unchanged — whether it should also mint a nonzero token on
`Create` is a separate question this PR does not decide, and worth a reviewer's
opinion.

## Test evidence

`go build ./...` and `go vet ./...` are clean.

Focused packages (`-count=1`):

```
ok  	github.com/gastownhall/gascity/internal/beads	19.851s
ok  	github.com/gastownhall/gascity/internal/beads/beadstest	0.079s
ok  	github.com/gastownhall/gascity/internal/beads/contract	0.539s
ok  	github.com/gastownhall/gascity/internal/beads/exec	14.353s
ok  	github.com/gastownhall/gascity/internal/session	20.826s
ok  	github.com/gastownhall/gascity/internal/worker	91.040s
ok  	github.com/gastownhall/gascity/internal/runtime	35.321s
ok  	github.com/gastownhall/gascity/internal/runtime/tmux	26.076s
```

Full fast-unit baseline (`make test`):

```
observable go test: command=go test -json -p=4 -count=1 -timeout 15m ./...
pass github.com/gastownhall/gascity/cmd/gc
observable go test: PASS log=/data/tmp/gascity-test.jsonl.mkjODI
```

## Provenance and scope

Extracted from a larger reconciler integration branch and rebased onto current
`main`; independent of the runtime substrate PR. Deliberately **not** included,
from the same branch:

- `CachingStore.CachedReadyByID` / `LiveReadyByID` — exported single-bead
  readiness reads whose only callers live on that branch and which carry no test
  inside `internal/beads`. Landing them here would add dead exported API; they
  should arrive with their consumer.
- letting `isBareBdQueryValue` accept `/`. `main` has a deliberate guard
  (`TestCheckUsesSingleAssigneeMessageScanForSlashRecipient`) that a slash
  recipient must not reach the supplemental wisp `bd query`, and the branch
  reconciled that in `cmd/gc/work_assignment.go` in the same commit. It belongs
  with that change, not here.

`AtomicConditionalCloser` has no in-tree caller yet; it is landed deliberately
as the substrate a follow-up depends on, and is covered by unit tests plus
integration-tagged rows against the native store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
