### PR TITLE
feat(storage): serve out-of-tree engine bindings under a born-split discipline

### DIFF
--- a/cmd/gc/cmd_storage.go
+++ b/cmd/gc/cmd_storage.go
@@ -341,6 +341,28 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 		return 1
 	}
 	if !ok {
+		if shape, binding := storageSplitShapeOf(storage); shape == storageSplitWhole {
+			// The split shape is supported and only the provider refused the
+			// target: a binding this build cannot migrate onto, serving under
+			// the born-split discipline. Report that discipline's state — the
+			// same one boot enforces — rather than claiming the work store
+			// serves classes it does not.
+			provider := storage.Bindings[binding].Provider
+			fmt.Fprintf(stdout, "binding: %s\n  provider: %s (not this build's engine; serves under the born-split discipline)\n", binding, provider) //nolint:errcheck // best-effort stdout
+			report := checkBornSplitDiscipline(request.CityPath, logPrefix, stderr)
+			switch report.Outcome {
+			case infraMigrationConverged:
+				fmt.Fprintln(stdout, "born-split: clean — the work store holds no infrastructure bead, so the binding may serve.") //nolint:errcheck // best-effort stdout
+				return 0
+			case infraMigrationBornSplitBlocked:
+				fmt.Fprintf(stdout, "born-split: BLOCKED — the work store holds %d infrastructure bead(s) the binding cannot read: %s\n", //nolint:errcheck // best-effort stdout
+					len(report.Stranded), strings.Join(report.Stranded, ", "))
+				return 1
+			default:
+				fmt.Fprintf(stdout, "born-split: could not be verified (%s); reason on stderr\n", report.Outcome) //nolint:errcheck // best-effort stdout
+				return 1
+			}
+		}
 		fmt.Fprintln(stdout, "binding: none — every class is served by the work store, and nothing migrates.") //nolint:errcheck // best-effort stdout
 		return 0
 	}

--- a/cmd/gc/cmd_storage.go
+++ b/cmd/gc/cmd_storage.go
@@ -349,6 +349,22 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 			// serves classes it does not.
 			provider := storage.Bindings[binding].Provider
 			fmt.Fprintf(stdout, "binding: %s\n  provider: %s (not this build's engine; serves under the born-split discipline)\n", binding, provider) //nolint:errcheck // best-effort stdout
+			// The same resolution and seam check boot performs, so this
+			// command's exit code keeps its deploy-gate contract: a city boot
+			// refuses must not report may-serve here.
+			plan, planErr := resolveCityStoragePlan(request.CityPath, request.Cfg)
+			if planErr != nil {
+				fmt.Fprintf(stderr, "%s: %v\n", logPrefix, planErr) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			if plannedBindingOpener(plan, binding) == nil {
+				fmt.Fprintf(stdout, "born-split: BLOCKED — provider %s does not open a bead engine, so the classes assigned to binding %s cannot be served\n", provider, binding) //nolint:errcheck // best-effort stdout
+				return 1
+			}
+			if blocked, held := servedBindingNoteHold(request.CityPath, binding, provider); held {
+				fmt.Fprintf(stdout, "born-split: BLOCKED — %s\n", infraMigrationOperatorAdvice(blocked, logPrefix)) //nolint:errcheck // best-effort stdout
+				return 1
+			}
 			report := checkBornSplitDiscipline(request.CityPath, logPrefix, stderr)
 			switch report.Outcome {
 			case infraMigrationConverged:

--- a/cmd/gc/cmd_storage.go
+++ b/cmd/gc/cmd_storage.go
@@ -361,7 +361,7 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 				fmt.Fprintf(stdout, "born-split: BLOCKED — provider %s does not open a bead engine, so the classes assigned to binding %s cannot be served\n", provider, binding) //nolint:errcheck // best-effort stdout
 				return 1
 			}
-			if blocked, held := servedBindingNoteHold(request.CityPath, binding, provider); held {
+			if blocked, held := servedBindingNoteHold(request.CityPath, binding, provider, configuredBindingLocation(storage.Bindings[binding])); held {
 				fmt.Fprintf(stdout, "born-split: BLOCKED — %s\n", infraMigrationOperatorAdvice(blocked, logPrefix)) //nolint:errcheck // best-effort stdout
 				return 1
 			}
@@ -384,6 +384,12 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 	}
 	fmt.Fprintf(stdout, "binding: %s\n  database: %s\n  marker:   %s\n  manifest: %s\n", //nolint:errcheck // best-effort stdout
 		target.Binding, target.Database, target.MarkerPath(), target.ManifestPath())
+
+	if blocked, held := servedBindingNoteHold(request.CityPath, target.Binding, config.StorageProviderSQLiteBeads, target.Database); held {
+		blocked.Target = target
+		fmt.Fprintf(stdout, "served-binding hold: %s\n", infraMigrationOperatorAdvice(blocked, logPrefix)) //nolint:errcheck // best-effort stdout
+		return 1
+	}
 
 	state, err := readInfraConvergenceState(target)
 	if err != nil {

--- a/cmd/gc/infra_class_migrate.go
+++ b/cmd/gc/infra_class_migrate.go
@@ -427,11 +427,24 @@ func infraMigrationOperatorAdvice(report infraMigrationReport, logPrefix string)
 	case infraMigrationUncheckable:
 		situation = fmt.Sprintf("%s: this city's infrastructure binding %q could NOT be verified (reason above), so nothing here proved it is safe to serve from.", logPrefix, report.Target.Binding)
 	case infraMigrationBornSplitBlocked:
-		situation = fmt.Sprintf("%s: binding %q is served by a provider this build cannot migrate onto, so it serves only while the work store holds no infrastructure bead — and the work store holds %d: %s. Either an earlier configuration wrote them before this city moved to the split, or a writer without this [storage] configuration is still writing. The named beads are intact in the work store; recover them into the binding's database with every writer stopped.",
+		situation = fmt.Sprintf("%s: binding %q is served by a provider this build cannot migrate onto, so it serves only while the work store holds no infrastructure bead — and the work store holds %d: %s. Either an earlier configuration wrote them before this city moved to the split, or a writer without this [storage] configuration is still writing. The named beads are intact in the work store. Recover them into the binding's database with every writer stopped, then delete them from the work store — the work store was never this split's infrastructure source, and the next boot serves once it holds none.",
 			logPrefix, report.Target.Binding, len(report.Stranded), infraStrandedIDList(report.Stranded))
 	case infraMigrationGenesisBlocked:
-		situation = fmt.Sprintf("%s: this city previously served its infrastructure classes from binding %q (provider %q), and nothing here can read what that binding holds. Creating a fresh store on this build's engine would make every bead written there permanently invisible, so genesis is refused. Recover the binding's contents first; removing %s is the operator's attestation that they are recovered or deliberately abandoned.",
-			logPrefix, report.ServedBinding, report.ServedProvider, report.ServedNotePath)
+		if report.ServedProvider == "" {
+			// The note exists but could not be read. It is still evidence
+			// that some binding served this city's infrastructure classes,
+			// so it holds exactly as a readable note would.
+			situation = fmt.Sprintf("%s: this city's served-binding note (%s) exists but cannot be read, and an unreadable note must hold exactly as a readable one would: some binding served this city's infrastructure classes, and re-pointing them elsewhere would make every bead written there permanently invisible. Repair or inspect the note; removing it is the operator's attestation that the previously served binding's contents are recovered or deliberately abandoned.",
+				logPrefix, report.ServedNotePath)
+		} else {
+			situation = fmt.Sprintf("%s: this city's infrastructure classes are served from binding %q (provider %q), and this configuration points them somewhere else that cannot read what that binding holds. Proceeding would make every bead written there permanently invisible, so this refuses. Recover the binding's contents first; removing %s is the operator's attestation that they are recovered or deliberately abandoned.",
+				logPrefix, report.ServedBinding, report.ServedProvider, report.ServedNotePath)
+		}
+		// Neither canned tail applies: the revert grant is evidence about the
+		// NEW target and says nothing about the served binding this outcome
+		// is protecting, and the do-not-revert tail names the wrong hazard.
+		// The withholding is explicit instead.
+		return situation + fmt.Sprintf(" Do NOT revert [storage.classes] to %q either: new infrastructure writes would land in the work store while the served binding's contents stay unrecovered.", config.StorageWorkBinding)
 	default:
 		return ""
 	}
@@ -658,6 +671,10 @@ func inspectInfraConvergence(cityPath string, target infraBindingTarget, logPref
 		return infraMigrationReport{Outcome: outcome}
 	}
 
+	if blocked, ok := servedBindingNoteHold(cityPath, target.Binding, config.StorageProviderSQLiteBeads); ok {
+		return blocked
+	}
+
 	state, err := readInfraConvergenceState(target)
 	if err != nil {
 		return say(infraMigrationUncheckable, err)
@@ -690,16 +707,6 @@ func inspectInfraConvergence(cityPath string, target infraBindingTarget, logPref
 	}
 	if len(rows) > 0 {
 		return infraMigrationReport{Outcome: infraMigrationUnconverged}
-	}
-	if note, present, noteErr := readBornSplitServedNote(cityPath); noteErr != nil {
-		return say(infraMigrationUncheckable, fmt.Errorf("reading the served-binding note: %w", noteErr))
-	} else if present {
-		return infraMigrationReport{
-			Outcome:        infraMigrationGenesisBlocked,
-			ServedBinding:  note.Binding,
-			ServedProvider: note.Provider,
-			ServedNotePath: bornSplitServedNotePath(cityPath),
-		}
 	}
 	if err := recordInfraGenesis(target); err != nil {
 		return say(infraMigrationUnconverged, err)
@@ -893,6 +900,14 @@ func runInfraClassMigration(cityPath string, target infraBindingTarget, logPrefi
 		return infraMigrationReport{Outcome: outcome}
 	}
 
+	// A served-binding note naming any other binding is a hold on this whole
+	// command: a copy of the work store's slice would bless a destination
+	// that silently omits everything the served binding holds. The note's
+	// removal is the operator's attestation, checked before anything opens.
+	if blocked, ok := servedBindingNoteHold(cityPath, target.Binding, config.StorageProviderSQLiteBeads); ok {
+		return blocked
+	}
+
 	state, err := readInfraConvergenceState(target)
 	if err != nil {
 		return say(infraMigrationUncheckable, err)
@@ -916,22 +931,6 @@ func runInfraClassMigration(cityPath string, target infraBindingTarget, logPrefi
 	case infraConvergenceStale:
 		fmt.Fprintf(stderr, "%s: %s claims convergence but %s is gone; re-running the copy\n", //nolint:errcheck // best-effort stderr
 			logPrefix, target.MarkerPath(), target.Database)
-	}
-
-	// A served-binding note is a hold on re-pointing the infrastructure
-	// classes at this build's engine: the previously served binding holds
-	// state nothing here can read, and a copy of the work store's slice would
-	// bless a destination that silently omits it. The note's removal is the
-	// operator's attestation, checked before anything opens.
-	if note, present, noteErr := readBornSplitServedNote(cityPath); noteErr != nil {
-		return say(infraMigrationUncheckable, fmt.Errorf("reading the served-binding note: %w", noteErr))
-	} else if present {
-		return infraMigrationReport{
-			Outcome:        infraMigrationGenesisBlocked,
-			ServedBinding:  note.Binding,
-			ServedProvider: note.Provider,
-			ServedNotePath: bornSplitServedNotePath(cityPath),
-		}
 	}
 
 	// The one writer exclusion this can prove. A source another controller is

--- a/cmd/gc/infra_class_migrate.go
+++ b/cmd/gc/infra_class_migrate.go
@@ -291,6 +291,13 @@ const (
 	// migration may create. Boot creates the binding, records an empty proven
 	// copy, and serves from it.
 	infraMigrationGenesis
+	// infraMigrationBornSplitBlocked reports a city whose binding is served by
+	// a provider this build carries no migration discipline for, and whose
+	// work store holds infrastructure beads that binding cannot read. Such a
+	// binding serves only under the born-split invariant — the work store
+	// holds no infrastructure bead at all — and this outcome is that invariant
+	// failing, with the ids named.
+	infraMigrationBornSplitBlocked
 )
 
 // String names the outcome for operator-visible diagnostics and test failures.
@@ -308,6 +315,8 @@ func (o infraMigrationOutcome) String() string {
 		return "uncheckable"
 	case infraMigrationGenesis:
 		return "genesis"
+	case infraMigrationBornSplitBlocked:
+		return "born-split-blocked"
 	}
 	return fmt.Sprintf("infraMigrationOutcome(%d)", int(o))
 }
@@ -399,6 +408,9 @@ func infraMigrationOperatorAdvice(report infraMigrationReport, logPrefix string)
 			logPrefix, report.Target.Binding, len(report.Stranded), infraStrandedIDList(report.Stranded))
 	case infraMigrationUncheckable:
 		situation = fmt.Sprintf("%s: this city's infrastructure binding %q could NOT be verified (reason above), so nothing here proved it is safe to serve from.", logPrefix, report.Target.Binding)
+	case infraMigrationBornSplitBlocked:
+		situation = fmt.Sprintf("%s: binding %q is served by a provider this build cannot migrate onto, so it serves only while the work store holds no infrastructure bead — and the work store holds %d: %s. Either an earlier configuration wrote them before this city moved to the split, or a writer without this [storage] configuration is still writing. The named beads are intact in the work store. Recover them into the binding's database with every writer stopped, or assign the infrastructure classes to a binding served by this build's own engine.",
+			logPrefix, report.Target.Binding, len(report.Stranded), infraStrandedIDList(report.Stranded))
 	default:
 		return ""
 	}

--- a/cmd/gc/infra_class_migrate.go
+++ b/cmd/gc/infra_class_migrate.go
@@ -299,12 +299,12 @@ const (
 	// failing, with the ids named.
 	infraMigrationBornSplitBlocked
 	// infraMigrationGenesisBlocked reports a city whose configuration points
-	// the infrastructure classes at this build's own engine, but whose served
-	// note records that they were previously served from a binding this build
-	// cannot read. Genesis's premise — no marker and an empty work store mean
-	// nothing exists anywhere — is false for such a city: its infrastructure
-	// state lives in the previously served binding, and creating a fresh
-	// store would make every bead there permanently invisible.
+	// the infrastructure classes somewhere other than the binding its served
+	// note records. Nothing on this path proves the configured target holds
+	// what the served binding holds — genesis's premise that no marker and an
+	// empty work store mean nothing exists anywhere is false for such a city —
+	// so serving, genesis and migration all refuse until the operator attests
+	// by removing the note.
 	infraMigrationGenesisBlocked
 )
 
@@ -437,7 +437,7 @@ func infraMigrationOperatorAdvice(report infraMigrationReport, logPrefix string)
 			situation = fmt.Sprintf("%s: this city's served-binding note (%s) exists but cannot be read, and an unreadable note must hold exactly as a readable one would: some binding served this city's infrastructure classes, and re-pointing them elsewhere would make every bead written there permanently invisible. Repair or inspect the note; removing it is the operator's attestation that the previously served binding's contents are recovered or deliberately abandoned.",
 				logPrefix, report.ServedNotePath)
 		} else {
-			situation = fmt.Sprintf("%s: this city's infrastructure classes are served from binding %q (provider %q), and this configuration points them somewhere else that cannot read what that binding holds. Proceeding would make every bead written there permanently invisible, so this refuses. Recover the binding's contents first; removing %s is the operator's attestation that they are recovered or deliberately abandoned.",
+			situation = fmt.Sprintf("%s: this city's infrastructure classes are served from binding %q (provider %q), and this configuration points them somewhere else. Nothing here proves the configured target holds what the served binding holds, so this refuses rather than risk making every bead written there invisible. Verify or recover the served binding's contents first; removing %s is the operator's attestation that they are recovered, still reachable through the new configuration, or deliberately abandoned.",
 				logPrefix, report.ServedBinding, report.ServedProvider, report.ServedNotePath)
 		}
 		// Neither canned tail applies: the revert grant is evidence about the
@@ -671,7 +671,7 @@ func inspectInfraConvergence(cityPath string, target infraBindingTarget, logPref
 		return infraMigrationReport{Outcome: outcome}
 	}
 
-	if blocked, ok := servedBindingNoteHold(cityPath, target.Binding, config.StorageProviderSQLiteBeads); ok {
+	if blocked, ok := servedBindingNoteHold(cityPath, target.Binding, config.StorageProviderSQLiteBeads, target.Database); ok {
 		return blocked
 	}
 
@@ -904,7 +904,7 @@ func runInfraClassMigration(cityPath string, target infraBindingTarget, logPrefi
 	// command: a copy of the work store's slice would bless a destination
 	// that silently omits everything the served binding holds. The note's
 	// removal is the operator's attestation, checked before anything opens.
-	if blocked, ok := servedBindingNoteHold(cityPath, target.Binding, config.StorageProviderSQLiteBeads); ok {
+	if blocked, ok := servedBindingNoteHold(cityPath, target.Binding, config.StorageProviderSQLiteBeads, target.Database); ok {
 		return blocked
 	}
 

--- a/cmd/gc/infra_class_migrate.go
+++ b/cmd/gc/infra_class_migrate.go
@@ -298,6 +298,14 @@ const (
 	// holds no infrastructure bead at all — and this outcome is that invariant
 	// failing, with the ids named.
 	infraMigrationBornSplitBlocked
+	// infraMigrationGenesisBlocked reports a city whose configuration points
+	// the infrastructure classes at this build's own engine, but whose served
+	// note records that they were previously served from a binding this build
+	// cannot read. Genesis's premise — no marker and an empty work store mean
+	// nothing exists anywhere — is false for such a city: its infrastructure
+	// state lives in the previously served binding, and creating a fresh
+	// store would make every bead there permanently invisible.
+	infraMigrationGenesisBlocked
 )
 
 // String names the outcome for operator-visible diagnostics and test failures.
@@ -317,6 +325,8 @@ func (o infraMigrationOutcome) String() string {
 		return "genesis"
 	case infraMigrationBornSplitBlocked:
 		return "born-split-blocked"
+	case infraMigrationGenesisBlocked:
+		return "genesis-blocked"
 	}
 	return fmt.Sprintf("infraMigrationOutcome(%d)", int(o))
 }
@@ -345,6 +355,14 @@ type infraMigrationReport struct {
 	// else, so ids carried anywhere but in the message are ids the operator
 	// never sees.
 	Stranded []string
+	// ServedBinding, ServedProvider and ServedNotePath carry the genesis-blocked
+	// evidence: which binding this city previously served its infrastructure
+	// classes from, under which provider, and the note file whose removal is
+	// the operator's attestation. They travel on the report for the same
+	// reason Stranded does — the refusal string is the only output recorded.
+	ServedBinding  string
+	ServedProvider string
+	ServedNotePath string
 	// Target is the resolved destination the outcome is about. Its zero value
 	// belongs to the outcomes that resolved nothing.
 	Target infraBindingTarget
@@ -409,8 +427,11 @@ func infraMigrationOperatorAdvice(report infraMigrationReport, logPrefix string)
 	case infraMigrationUncheckable:
 		situation = fmt.Sprintf("%s: this city's infrastructure binding %q could NOT be verified (reason above), so nothing here proved it is safe to serve from.", logPrefix, report.Target.Binding)
 	case infraMigrationBornSplitBlocked:
-		situation = fmt.Sprintf("%s: binding %q is served by a provider this build cannot migrate onto, so it serves only while the work store holds no infrastructure bead — and the work store holds %d: %s. Either an earlier configuration wrote them before this city moved to the split, or a writer without this [storage] configuration is still writing. The named beads are intact in the work store. Recover them into the binding's database with every writer stopped, or assign the infrastructure classes to a binding served by this build's own engine.",
+		situation = fmt.Sprintf("%s: binding %q is served by a provider this build cannot migrate onto, so it serves only while the work store holds no infrastructure bead — and the work store holds %d: %s. Either an earlier configuration wrote them before this city moved to the split, or a writer without this [storage] configuration is still writing. The named beads are intact in the work store; recover them into the binding's database with every writer stopped.",
 			logPrefix, report.Target.Binding, len(report.Stranded), infraStrandedIDList(report.Stranded))
+	case infraMigrationGenesisBlocked:
+		situation = fmt.Sprintf("%s: this city previously served its infrastructure classes from binding %q (provider %q), and nothing here can read what that binding holds. Creating a fresh store on this build's engine would make every bead written there permanently invisible, so genesis is refused. Recover the binding's contents first; removing %s is the operator's attestation that they are recovered or deliberately abandoned.",
+			logPrefix, report.ServedBinding, report.ServedProvider, report.ServedNotePath)
 	default:
 		return ""
 	}
@@ -670,6 +691,16 @@ func inspectInfraConvergence(cityPath string, target infraBindingTarget, logPref
 	if len(rows) > 0 {
 		return infraMigrationReport{Outcome: infraMigrationUnconverged}
 	}
+	if note, present, noteErr := readBornSplitServedNote(cityPath); noteErr != nil {
+		return say(infraMigrationUncheckable, fmt.Errorf("reading the served-binding note: %w", noteErr))
+	} else if present {
+		return infraMigrationReport{
+			Outcome:        infraMigrationGenesisBlocked,
+			ServedBinding:  note.Binding,
+			ServedProvider: note.Provider,
+			ServedNotePath: bornSplitServedNotePath(cityPath),
+		}
+	}
 	if err := recordInfraGenesis(target); err != nil {
 		return say(infraMigrationUnconverged, err)
 	}
@@ -885,6 +916,22 @@ func runInfraClassMigration(cityPath string, target infraBindingTarget, logPrefi
 	case infraConvergenceStale:
 		fmt.Fprintf(stderr, "%s: %s claims convergence but %s is gone; re-running the copy\n", //nolint:errcheck // best-effort stderr
 			logPrefix, target.MarkerPath(), target.Database)
+	}
+
+	// A served-binding note is a hold on re-pointing the infrastructure
+	// classes at this build's engine: the previously served binding holds
+	// state nothing here can read, and a copy of the work store's slice would
+	// bless a destination that silently omits it. The note's removal is the
+	// operator's attestation, checked before anything opens.
+	if note, present, noteErr := readBornSplitServedNote(cityPath); noteErr != nil {
+		return say(infraMigrationUncheckable, fmt.Errorf("reading the served-binding note: %w", noteErr))
+	} else if present {
+		return infraMigrationReport{
+			Outcome:        infraMigrationGenesisBlocked,
+			ServedBinding:  note.Binding,
+			ServedProvider: note.Provider,
+			ServedNotePath: bornSplitServedNotePath(cityPath),
+		}
 	}
 
 	// The one writer exclusion this can prove. A source another controller is

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -42,6 +42,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -178,15 +179,20 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", logPrefix, err)
 	}
-	if !ok {
+	var report infraMigrationReport
+	if ok {
+		report = checkInfraClassConvergence(cityPath, cfg, logPrefix, stderr)
+	} else {
 		// The shape is the supported one, so the only thing that can have
 		// refused the target is the provider: this build carries the migration
 		// and genesis discipline for its own bead engine and for nothing else.
-		return nil, fmt.Errorf("%s: binding %q is backed by provider %q, and this build carries no migration or genesis discipline for it. %s",
-			logPrefix, binding, storage.Bindings[binding].Provider, storageSupportedTopologyStatement)
+		// A compiled provider that opens a bead engine can still serve — under
+		// the born-split discipline below, which asks nothing of the binding
+		// and proves the one invariant the work store alone can prove.
+		target = infraBindingTarget{Binding: binding}
+		report = checkBornSplitDiscipline(cityPath, logPrefix, stderr)
+		report.Target = target
 	}
-
-	report := checkInfraClassConvergence(cityPath, cfg, logPrefix, stderr)
 	if !report.serving() {
 		advice := infraMigrationOperatorAdvice(report, logPrefix)
 		if advice == "" {
@@ -199,16 +205,59 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 	return openStorageRoutes(plan, target)
 }
 
+// checkBornSplitDiscipline decides whether a binding served by a provider this
+// build carries no migration discipline for may serve this city's split.
+//
+// Such a provider can still open the binding's bead engine — that is the
+// EngineOpener seam — but nothing in this build can move a bead onto its
+// binding, prove a marker about it, or read a manifest from it: the whole
+// convergence apparatus is written against this build's own engine. What CAN
+// be proven, from the work store alone, is the one invariant that matters for
+// a city born on the split: no infrastructure bead has ever landed in the
+// work store. So the discipline is containment with nothing persisted,
+// re-proven on every boot — serve while the work store holds zero
+// infrastructure beads, and refuse naming ids the moment one exists, whether
+// it was written by an earlier configuration, by a writer that never saw this
+// [storage] section, or by a city that in fact predates the split and needs a
+// migration this build cannot perform.
+//
+// Failures to prove are reported as facts about the check, not the city: a
+// work store that cannot be opened or listed decides nothing, and the
+// uncheckable outcome withholds both serving and the revert instruction.
+func checkBornSplitDiscipline(cityPath string, logPrefix string, stderr io.Writer) infraMigrationReport {
+	source, err := openInfraMigrationSource(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: born-split check: opening the work store: %v\n", logPrefix, err) //nolint:errcheck // best-effort stderr
+		return infraMigrationReport{Outcome: infraMigrationUncheckable}
+	}
+	defer closeBeadStoreHandle(source) //nolint:errcheck // best-effort close
+	infra, err := readInfraSnapshot(source)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: born-split check: %v\n", logPrefix, err) //nolint:errcheck // best-effort stderr
+		return infraMigrationReport{Outcome: infraMigrationUncheckable}
+	}
+	if len(infra) == 0 {
+		return infraMigrationReport{Outcome: infraMigrationConverged}
+	}
+	ids := make([]string, 0, len(infra))
+	for _, b := range infra {
+		ids = append(ids, b.ID)
+	}
+	sort.Strings(ids)
+	return infraMigrationReport{Outcome: infraMigrationBornSplitBlocked, Stranded: ids}
+}
+
 // storageBindingEventTypes maps a migration outcome to the event that reports
 // it. Outcomes with no entry are not events: not-configured describes a city
 // that was never asked, and stranded is carried inside the refusal that names
 // the ids.
 var storageBindingEventTypes = map[infraMigrationOutcome]string{
-	infraMigrationConverged:   events.StorageBindingConverged,
-	infraMigrationGenesis:     events.StorageBindingGenesis,
-	infraMigrationUnconverged: events.StorageBindingUnconverged,
-	infraMigrationStranded:    events.StorageBindingUnconverged,
-	infraMigrationUncheckable: events.StorageBindingUncheckable,
+	infraMigrationConverged:        events.StorageBindingConverged,
+	infraMigrationGenesis:          events.StorageBindingGenesis,
+	infraMigrationUnconverged:      events.StorageBindingUnconverged,
+	infraMigrationStranded:         events.StorageBindingUnconverged,
+	infraMigrationBornSplitBlocked: events.StorageBindingUnconverged,
+	infraMigrationUncheckable:      events.StorageBindingUncheckable,
 }
 
 // recordStorageBindingOutcome publishes what one gate or one migration

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -200,17 +200,25 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 			return nil, fmt.Errorf("%s: binding %q is served by provider %q, which does not open a bead engine, so the classes assigned to it cannot be served",
 				logPrefix, binding, storage.Bindings[binding].Provider)
 		}
-		report = checkBornSplitDiscipline(cityPath, logPrefix, stderr)
-		report.Target = target
-		if report.serving() {
-			// Serving is durable history the moment it happens: record it
-			// before the first route opens, so a later re-point at this
-			// build's own engine cannot genesis an empty store while this
-			// binding still holds the city's infrastructure state.
-			note := bornSplitServedNote{Binding: binding, Provider: storage.Bindings[binding].Provider}
-			if err := writeBornSplitServedNote(cityPath, note); err != nil {
-				return nil, fmt.Errorf("%s: %w", logPrefix, err)
-			}
+		if blocked, held := servedBindingNoteHold(cityPath, binding, storage.Bindings[binding].Provider); held {
+			report = blocked
+			report.Target = target
+		} else {
+			report = checkBornSplitDiscipline(cityPath, logPrefix, stderr)
+			report.Target = target
+		}
+	}
+	if report.serving() {
+		// Serving is durable history the moment it happens, on BOTH arms:
+		// the note records which binding and provider serve this city's
+		// infrastructure classes, and every later boot or migration that
+		// points them anywhere else refuses until the operator attests by
+		// removing it. Without the built-in arm writing it too, a city that
+		// genesised on this build's engine could be re-pointed at another
+		// binding and orphaned silently in the outbound direction.
+		note := bornSplitServedNote{Binding: target.Binding, Provider: storage.Bindings[target.Binding].Provider}
+		if err := writeBornSplitServedNote(cityPath, note); err != nil {
+			return nil, fmt.Errorf("%s: %w", logPrefix, err)
 		}
 	}
 	if !report.serving() {
@@ -293,6 +301,32 @@ func writeBornSplitServedNote(cityPath string, note bornSplitServedNote) error {
 		return fmt.Errorf("installing the served-binding note: %w", err)
 	}
 	return nil
+}
+
+// servedBindingNoteHold is the one rule every serving and migrating path asks:
+// does the served-binding note name a different binding or provider than the
+// one this path is about to serve or migrate onto? A mismatch is a hold — the
+// note's binding holds infrastructure state the new target cannot read — and
+// an unreadable note holds exactly as a readable one would, because a corrupt
+// file must not grant what its absence grants. The note's removal is the
+// operator's attestation, and the refusal string carries everything.
+func servedBindingNoteHold(cityPath, binding, provider string) (infraMigrationReport, bool) {
+	note, present, err := readBornSplitServedNote(cityPath)
+	if err != nil {
+		return infraMigrationReport{
+			Outcome:        infraMigrationGenesisBlocked,
+			ServedNotePath: bornSplitServedNotePath(cityPath),
+		}, true
+	}
+	if !present || (note.Binding == binding && note.Provider == provider) {
+		return infraMigrationReport{}, false
+	}
+	return infraMigrationReport{
+		Outcome:        infraMigrationGenesisBlocked,
+		ServedBinding:  note.Binding,
+		ServedProvider: note.Provider,
+		ServedNotePath: bornSplitServedNotePath(cityPath),
+	}, true
 }
 
 // checkBornSplitDiscipline decides whether a binding served by a provider this

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -174,6 +174,17 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 		return nil, fmt.Errorf("%s: %w", logPrefix, err)
 	}
 	if shape == storageSplitNone {
+		// The natural revert edit — every class pointed back at work — is
+		// exactly the re-point the served-binding note exists to hold. A city
+		// that never served a split has no note and passes untouched; the
+		// no-[storage]-at-all bypass above is deliberately not covered, so
+		// that boundary stays where the compatibility contract drew it.
+		if blocked, held := servedBindingNoteHold(cityPath, config.StorageWorkBinding, "", ""); held {
+			blocked.Target = infraBindingTarget{Binding: config.StorageWorkBinding}
+			advice := infraMigrationOperatorAdvice(blocked, logPrefix)
+			recordStorageBindingOutcome(rec, blocked, advice)
+			return nil, errors.New(advice)
+		}
 		return nil, nil
 	}
 
@@ -200,7 +211,7 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 			return nil, fmt.Errorf("%s: binding %q is served by provider %q, which does not open a bead engine, so the classes assigned to it cannot be served",
 				logPrefix, binding, storage.Bindings[binding].Provider)
 		}
-		if blocked, held := servedBindingNoteHold(cityPath, binding, storage.Bindings[binding].Provider); held {
+		if blocked, held := servedBindingNoteHold(cityPath, binding, storage.Bindings[binding].Provider, configuredBindingLocation(storage.Bindings[binding])); held {
 			report = blocked
 			report.Target = target
 		} else {
@@ -216,9 +227,14 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 		// removing it. Without the built-in arm writing it too, a city that
 		// genesised on this build's engine could be re-pointed at another
 		// binding and orphaned silently in the outbound direction.
-		note := bornSplitServedNote{Binding: target.Binding, Provider: storage.Bindings[target.Binding].Provider}
+		bindingCfg := storage.Bindings[target.Binding]
+		location := configuredBindingLocation(bindingCfg)
+		if bindingCfg.Provider == config.StorageProviderSQLiteBeads {
+			location = target.Database
+		}
+		note := bornSplitServedNote{Binding: target.Binding, Provider: bindingCfg.Provider, Location: location}
 		if err := writeBornSplitServedNote(cityPath, note); err != nil {
-			return nil, fmt.Errorf("%s: %w", logPrefix, err)
+			return nil, fmt.Errorf("%s: recording the served-binding note, the durable record of which binding serves this city's infrastructure classes: %w", logPrefix, err)
 		}
 	}
 	if !report.serving() {
@@ -241,6 +257,21 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 type bornSplitServedNote struct {
 	Binding  string `json:"binding"`
 	Provider string `json:"provider"`
+	// Location pins WHERE the binding serves from — the resolved database
+	// path for this build's engine, the configured reference otherwise — so
+	// a re-point that keeps the binding's name but moves its storage cannot
+	// slip past a name-and-provider comparison.
+	Location string `json:"location"`
+}
+
+// configuredBindingLocation is the location a note records for a binding this
+// build cannot resolve: the opaque reference its provider does, or the path
+// when a spec carries one.
+func configuredBindingLocation(binding config.StorageBindingConfig) string {
+	if binding.ConfigRef != "" {
+		return binding.ConfigRef
+	}
+	return binding.Path
 }
 
 // bornSplitServedNotePath is where the note lives, under the city's own .gc.
@@ -310,7 +341,7 @@ func writeBornSplitServedNote(cityPath string, note bornSplitServedNote) error {
 // an unreadable note holds exactly as a readable one would, because a corrupt
 // file must not grant what its absence grants. The note's removal is the
 // operator's attestation, and the refusal string carries everything.
-func servedBindingNoteHold(cityPath, binding, provider string) (infraMigrationReport, bool) {
+func servedBindingNoteHold(cityPath, binding, provider, location string) (infraMigrationReport, bool) {
 	note, present, err := readBornSplitServedNote(cityPath)
 	if err != nil {
 		return infraMigrationReport{
@@ -318,7 +349,7 @@ func servedBindingNoteHold(cityPath, binding, provider string) (infraMigrationRe
 			ServedNotePath: bornSplitServedNotePath(cityPath),
 		}, true
 	}
-	if !present || (note.Binding == binding && note.Provider == provider) {
+	if !present || (note.Binding == binding && note.Provider == provider && note.Location == location) {
 		return infraMigrationReport{}, false
 	}
 	return infraMigrationReport{

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -41,6 +41,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -190,8 +192,26 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 		// the born-split discipline below, which asks nothing of the binding
 		// and proves the one invariant the work store alone can prove.
 		target = infraBindingTarget{Binding: binding}
+		// A provider that opens no bead engine cannot serve regardless of
+		// what the work store holds. Refusing here, before any outcome is
+		// recorded, keeps the event stream honest: a permanently unservable
+		// binding must not publish converged on every boot.
+		if opener := plannedBindingOpener(plan, binding); opener == nil {
+			return nil, fmt.Errorf("%s: binding %q is served by provider %q, which does not open a bead engine, so the classes assigned to it cannot be served",
+				logPrefix, binding, storage.Bindings[binding].Provider)
+		}
 		report = checkBornSplitDiscipline(cityPath, logPrefix, stderr)
 		report.Target = target
+		if report.serving() {
+			// Serving is durable history the moment it happens: record it
+			// before the first route opens, so a later re-point at this
+			// build's own engine cannot genesis an empty store while this
+			// binding still holds the city's infrastructure state.
+			note := bornSplitServedNote{Binding: binding, Provider: storage.Bindings[binding].Provider}
+			if err := writeBornSplitServedNote(cityPath, note); err != nil {
+				return nil, fmt.Errorf("%s: %w", logPrefix, err)
+			}
+		}
 	}
 	if !report.serving() {
 		advice := infraMigrationOperatorAdvice(report, logPrefix)
@@ -203,6 +223,76 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 	}
 	recordStorageBindingOutcome(rec, report, "")
 	return openStorageRoutes(plan, target)
+}
+
+// bornSplitServedNote records the durable fact that this city has served its
+// infrastructure classes from a binding this build cannot read. It is not
+// process state — it is history, the same durability class as the convergence
+// marker, and the one input that keeps a later genesis from blessing an empty
+// store while the city's real state lives in that binding.
+type bornSplitServedNote struct {
+	Binding  string `json:"binding"`
+	Provider string `json:"provider"`
+}
+
+// bornSplitServedNotePath is where the note lives, under the city's own .gc.
+func bornSplitServedNotePath(cityPath string) string {
+	return filepath.Join(cityPath, ".gc", "storage-served-binding.json")
+}
+
+// readBornSplitServedNote reads the note if one exists. An unreadable or
+// undecodable note is an error, never an absence: absence is the license
+// genesis acts on, and a corrupt file must not grant it.
+func readBornSplitServedNote(cityPath string) (bornSplitServedNote, bool, error) {
+	data, err := os.ReadFile(bornSplitServedNotePath(cityPath))
+	if errors.Is(err, fs.ErrNotExist) {
+		return bornSplitServedNote{}, false, nil
+	}
+	if err != nil {
+		return bornSplitServedNote{}, false, err
+	}
+	var note bornSplitServedNote
+	if err := json.Unmarshal(data, &note); err != nil {
+		return bornSplitServedNote{}, false, fmt.Errorf("decoding %s: %w", bornSplitServedNotePath(cityPath), err)
+	}
+	return note, true, nil
+}
+
+// writeBornSplitServedNote durably records the served binding before the first
+// serve. Atomic replace, idempotent, and a failure refuses the boot: serving
+// without the note is what re-opens the genesis hole this note closes.
+func writeBornSplitServedNote(cityPath string, note bornSplitServedNote) error {
+	path := bornSplitServedNotePath(cityPath)
+	if existing, present, err := readBornSplitServedNote(cityPath); err != nil {
+		return err
+	} else if present && existing == note {
+		return nil
+	}
+	data, err := json.Marshal(note)
+	if err != nil {
+		return fmt.Errorf("encoding the served-binding note: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".storage-served-binding-*")
+	if err != nil {
+		return fmt.Errorf("staging the served-binding note: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		_ = os.Remove(temp.Name())
+		return fmt.Errorf("writing the served-binding note: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(temp.Name())
+		return fmt.Errorf("closing the served-binding note: %w", err)
+	}
+	if err := os.Rename(temp.Name(), path); err != nil {
+		_ = os.Remove(temp.Name())
+		return fmt.Errorf("installing the served-binding note: %w", err)
+	}
+	return nil
 }
 
 // checkBornSplitDiscipline decides whether a binding served by a provider this
@@ -247,6 +337,25 @@ func checkBornSplitDiscipline(cityPath string, logPrefix string, stderr io.Write
 	return infraMigrationReport{Outcome: infraMigrationBornSplitBlocked, Stranded: ids}
 }
 
+// plannedBindingOpener returns the engine-opening hook for the named binding
+// in a resolved plan, or nil when the plan does not carry the binding or its
+// provider opens no engine.
+func plannedBindingOpener(plan *storebinding.StoragePlan, name string) storebinding.EngineOpener {
+	if plan == nil {
+		return nil
+	}
+	for _, planned := range plan.Bindings() {
+		if string(planned.Name) != name {
+			continue
+		}
+		if opener, ok := storebinding.EngineOpenerFor(planned); ok {
+			return opener
+		}
+		return nil
+	}
+	return nil
+}
+
 // storageBindingEventTypes maps a migration outcome to the event that reports
 // it. Outcomes with no entry are not events: not-configured describes a city
 // that was never asked, and stranded is carried inside the refusal that names
@@ -257,6 +366,7 @@ var storageBindingEventTypes = map[infraMigrationOutcome]string{
 	infraMigrationUnconverged:      events.StorageBindingUnconverged,
 	infraMigrationStranded:         events.StorageBindingUnconverged,
 	infraMigrationBornSplitBlocked: events.StorageBindingUnconverged,
+	infraMigrationGenesisBlocked:   events.StorageBindingUnconverged,
 	infraMigrationUncheckable:      events.StorageBindingUncheckable,
 }
 

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -1060,3 +1060,170 @@ func TestNewCityRuntimeRefusesAnUnconvergedCity(t *testing.T) {
 		t.Errorf("the constructor error does not name %q: %v", storageMigrationCommand, err)
 	}
 }
+
+// renamedEngineProviderFactory re-registers this build's own engine factory
+// under a foreign provider ID. A plan resolved against it carries a binding
+// that resolveInfraBindingTarget refuses — the provider is not the built-in
+// engine — while the binding itself still opens a real bead engine. That is
+// the exact shape of an out-of-tree engine provider, built from compiled
+// parts so the test proves the gate, not a mock.
+type renamedEngineProviderFactory struct {
+	inner storebinding.ProviderFactory
+	id    storebinding.ProviderID
+}
+
+func (f renamedEngineProviderFactory) ID() storebinding.ProviderID { return f.id }
+
+func (f renamedEngineProviderFactory) New(spec storebinding.BindingSpec) (storebinding.Provider, error) {
+	spec.Provider = f.inner.ID()
+	provider, err := f.inner.New(spec)
+	if err != nil {
+		return nil, err
+	}
+	return renamedEngineProvider{Provider: provider, innerID: f.inner.ID()}, nil
+}
+
+// renamedEngineProvider forwards the whole provider facade and re-spells the
+// binding spec's provider before delegating OpenEngine, mirroring what a real
+// out-of-tree provider does with its own spec: the inner engine's "refuse a
+// foreign spec" defense stays armed, and the seam under test stays honest.
+type renamedEngineProvider struct {
+	storebinding.Provider
+	innerID storebinding.ProviderID
+}
+
+func (p renamedEngineProvider) OpenEngine(spec storebinding.BindingSpec, classes storebinding.ClassSet) (beads.Store, io.Closer, error) {
+	opener, ok := p.Provider.(storebinding.EngineOpener)
+	if !ok {
+		return nil, nil, errors.New("renamed inner provider opens no engine")
+	}
+	spec.Provider = p.innerID
+	return opener.OpenEngine(spec, classes)
+}
+
+// bornSplitCity configures a city whose infrastructure binding is served by a
+// registered non-built-in engine provider, and returns the in-memory work
+// store the born-split discipline scans.
+func bornSplitCity(t *testing.T) (cityPath string, cfg *config.City, source beads.Store) {
+	t.Helper()
+	cityPath = t.TempDir()
+	source = stubInfraMigrationSource(t)
+	cfg = infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
+	binding := cfg.Storage.Bindings["infra"]
+	binding.Provider = "outoftree-engine"
+	cfg.Storage.Bindings["infra"] = binding
+
+	prev := newStorageRegistryForPlan
+	newStorageRegistryForPlan = func() (*storebinding.ProviderRegistry, error) {
+		registry := storebinding.NewProviderRegistry()
+		if err := registry.Register(renamedEngineProviderFactory{
+			inner: sqlitebinding.BeadsProviderFactory{},
+			id:    "outoftree-engine",
+		}); err != nil {
+			return nil, err
+		}
+		if err := registry.Freeze(); err != nil {
+			return nil, err
+		}
+		return registry, nil
+	}
+	t.Cleanup(func() { newStorageRegistryForPlan = prev })
+	return cityPath, cfg, source
+}
+
+// TestStorageGateServesBornSplitBindingWithCleanWorkStore proves the discipline's
+// serving half: a provider this build cannot migrate onto still serves the
+// split when the work store holds no infrastructure bead, and the routes it
+// returns reach a live engine.
+func TestStorageGateServesBornSplitBindingWithCleanWorkStore(t *testing.T) {
+	cityPath, cfg, source := bornSplitCity(t)
+	mustCreateInfraBead(t, source, beads.Bead{Title: "plain work", Type: "task"})
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("a born-split city with a clean work store refused to serve: %v\nstderr: %s", err, stderr.String())
+	}
+	if routes == nil {
+		t.Fatal("the gate served but returned no routes")
+	}
+	defer routes.close() //nolint:errcheck // test cleanup
+	store, ok := routes.stores[coordclass.ClassSessions]
+	if !ok {
+		t.Fatal("the routes carry no store for the session class")
+	}
+	if _, err := store.Create(beads.Bead{Title: "born on the binding", Type: "session", Labels: []string{"gc:session"}}); err != nil {
+		t.Fatalf("writing through the born-split routes: %v", err)
+	}
+}
+
+// TestStorageGateRefusesBornSplitBindingWhenWorkStoreHoldsInfraBeads proves the
+// refusing half, and pins where the evidence lives: the ids and the advice are
+// in the refusal STRING, because the supervisor records that string and
+// nothing else.
+func TestStorageGateRefusesBornSplitBindingWhenWorkStoreHoldsInfraBeads(t *testing.T) {
+	cityPath, cfg, source := bornSplitCity(t)
+	strayed := mustCreateInfraBead(t, source, beads.Bead{Title: "landed in work", Type: "session", Labels: []string{"gc:session"}})
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err == nil {
+		_ = routes.close()
+		t.Fatal("a born-split city with an infrastructure bead in the work store served")
+	}
+	if !strings.Contains(err.Error(), strayed.ID) {
+		t.Errorf("the refusal does not name the bead %s: %v", strayed.ID, err)
+	}
+	if !strings.Contains(err.Error(), `binding "infra"`) {
+		t.Errorf("the refusal does not name the binding: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Do NOT revert") {
+		t.Errorf("the refusal does not withhold the revert: %v", err)
+	}
+}
+
+// TestStorageGateBornSplitCheckFailureIsUncheckableNotUnconverged proves that a
+// work store that cannot be read decides nothing about the city: the refusal
+// is a fact about the check, and it does not hand the operator a migration
+// this build cannot perform.
+func TestStorageGateBornSplitCheckFailureIsUncheckableNotUnconverged(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+	failInfraMigrationSourceWith(t, func(string) (beads.Store, error) {
+		return nil, errors.New("injected work-store open failure")
+	})
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err == nil {
+		_ = routes.close()
+		t.Fatal("an unprovable born-split invariant served")
+	}
+	if !strings.Contains(err.Error(), "could NOT be verified") {
+		t.Errorf("the refusal does not report an uncheckable city: %v", err)
+	}
+	if strings.Contains(err.Error(), storageMigrationCommand) {
+		t.Errorf("an uncheckable born-split city was handed the migration command this build cannot honor here: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "injected work-store open failure") {
+		t.Errorf("stderr does not carry the check's failure reason: %s", stderr.String())
+	}
+}
+
+// TestStorageGateBornSplitListFailureIsUncheckable proves the same for a work
+// store that opens but cannot be listed.
+func TestStorageGateBornSplitListFailureIsUncheckable(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+	failInfraMigrationSourceWith(t, func(string) (beads.Store, error) {
+		return unlistableInfraSource{Store: beads.NewMemStore(), err: errors.New("injected list failure")}, nil
+	})
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err == nil {
+		_ = routes.close()
+		t.Fatal("an unlistable work store served a born-split binding")
+	}
+	if !strings.Contains(err.Error(), "could NOT be verified") {
+		t.Errorf("the refusal does not report an uncheckable city: %v", err)
+	}
+}

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -1108,6 +1108,14 @@ func (p renamedEngineProvider) OpenEngine(spec storebinding.BindingSpec, classes
 func bornSplitCity(t *testing.T) (cityPath string, cfg *config.City, source beads.Store) {
 	t.Helper()
 	cityPath = t.TempDir()
+	cfg, source = bornSplitCityAt(t, cityPath)
+	return cityPath, cfg, source
+}
+
+// bornSplitCityAt is bornSplitCity against a caller-owned city directory, for
+// tests that re-point an existing city rather than starting fresh.
+func bornSplitCityAt(t *testing.T, cityPath string) (cfg *config.City, source beads.Store) {
+	t.Helper()
 	source = stubInfraMigrationSource(t)
 	cfg = infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
 	binding := cfg.Storage.Bindings["infra"]
@@ -1129,7 +1137,7 @@ func bornSplitCity(t *testing.T) (cityPath string, cfg *config.City, source bead
 		return registry, nil
 	}
 	t.Cleanup(func() { newStorageRegistryForPlan = prev })
-	return cityPath, cfg, source
+	return cfg, source
 }
 
 // TestStorageGateServesBornSplitBindingWithCleanWorkStore proves the discipline's
@@ -1434,5 +1442,175 @@ func TestMigrateRefusesWhileServedBindingNoteStands(t *testing.T) {
 	}
 	if !strings.Contains(advice, "outoftree-engine") {
 		t.Errorf("the advice does not name the previously served provider: %s", advice)
+	}
+}
+
+// TestBornSplitRepointToOtherBindingRefusesUntilAttested pins the symmetric
+// hold: the note is last-writer-wins only through the operator's attestation,
+// never through a config edit. Re-pointing a born-split city at a different
+// binding must refuse naming the served one, not overwrite the record of it.
+func TestBornSplitRepointToOtherBindingRefusesUntilAttested(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("first born-split boot refused: %v", err)
+	}
+	if err := routes.close(); err != nil {
+		t.Fatalf("closing routes: %v", err)
+	}
+
+	repointed := infraSplitConfig(filepath.Join(cityPath, ".gc", "other-store"))
+	other := repointed.Storage.Bindings["infra"]
+	other.Provider = "outoftree-engine"
+	delete(repointed.Storage.Bindings, "infra")
+	repointed.Storage.Bindings["infra2"] = other
+	repointed.Storage.Classes.Graph = "infra2"
+	repointed.Storage.Classes.Sessions = "infra2"
+	repointed.Storage.Classes.Messaging = "infra2"
+	repointed.Storage.Classes.Orders = "infra2"
+	repointed.Storage.Classes.Nudges = "infra2"
+
+	blocked, err := storageBootGate(cityPath, repointed, "gc start", nil, &stderr)
+	if err == nil {
+		_ = blocked.close()
+		t.Fatal("re-pointing at a different binding served while the note named the first")
+	}
+	if !strings.Contains(err.Error(), `"infra"`) {
+		t.Errorf("the refusal does not name the served binding: %v", err)
+	}
+	if !strings.Contains(err.Error(), bornSplitServedNotePath(cityPath)) {
+		t.Errorf("the refusal does not name the note: %v", err)
+	}
+	if strings.Contains(err.Error(), "point [storage.classes] back at") {
+		t.Errorf("a note hold granted the revert instruction: %v", err)
+	}
+
+	note, present, err := readBornSplitServedNote(cityPath)
+	if err != nil || !present || note.Binding != "infra" {
+		t.Fatalf("the refusal overwrote the served-binding note: %+v present=%v err=%v", note, present, err)
+	}
+}
+
+// TestBuiltinGenesisCityRepointToOutOfTreeRefuses pins the outbound leg: a
+// city that genesised on this build's engine holds all its infrastructure
+// state in the binding and none in the work store, so a clean work store
+// alone must not license serving another binding.
+func TestBuiltinGenesisCityRepointToOutOfTreeRefuses(t *testing.T) {
+	cityPath := t.TempDir()
+	_ = stubInfraMigrationSource(t)
+	builtin := infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, builtin, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("genesis boot refused: %v", err)
+	}
+	if err := routes.close(); err != nil {
+		t.Fatalf("closing genesis routes: %v", err)
+	}
+
+	cityCfg, source := bornSplitCityAt(t, cityPath)
+	_ = source
+	blocked, err := storageBootGate(cityPath, cityCfg, "gc start", nil, &stderr)
+	if err == nil {
+		_ = blocked.close()
+		t.Fatal("a genesis city re-pointed at an out-of-tree binding served on a clean work store")
+	}
+	if !strings.Contains(err.Error(), config.StorageProviderSQLiteBeads) {
+		t.Errorf("the refusal does not name the served provider: %v", err)
+	}
+}
+
+// TestConvergedCityWithForeignNoteRefusesOnMarkedPath pins the marked arm: a
+// standing note naming another binding must hold even when the built-in
+// marker and database are intact, or the interim binding's state is orphaned
+// with no refusal.
+func TestConvergedCityWithForeignNoteRefusesOnMarkedPath(t *testing.T) {
+	cityPath, cfg, _, _ := convergedInfraCity(t)
+	if err := writeBornSplitServedNote(cityPath, bornSplitServedNote{Binding: "elsewhere", Provider: "outoftree-engine"}); err != nil {
+		t.Fatalf("writing the note: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err == nil {
+		_ = routes.close()
+		t.Fatal("a converged city served through the marked path while the note named another binding")
+	}
+	if !strings.Contains(err.Error(), `"elsewhere"`) {
+		t.Errorf("the refusal does not name the served binding: %v", err)
+	}
+	if strings.Contains(err.Error(), "point [storage.classes] back at") {
+		t.Errorf("a note hold granted the revert instruction: %v", err)
+	}
+}
+
+// TestCorruptServedNoteHoldsWithoutGrantingAnything pins the unreadable-note
+// contract end to end: the hold fires, the note path is named, and neither
+// the revert grant nor genesis is reachable.
+func TestCorruptServedNoteHoldsWithoutGrantingAnything(t *testing.T) {
+	cityPath := t.TempDir()
+	_ = stubInfraMigrationSource(t)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bornSplitServedNotePath(cityPath), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	builtin := infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, builtin, "gc start", nil, &stderr)
+	if err == nil {
+		_ = routes.close()
+		t.Fatal("a corrupt served-binding note granted genesis")
+	}
+	if !strings.Contains(err.Error(), bornSplitServedNotePath(cityPath)) {
+		t.Errorf("the refusal does not name the note: %v", err)
+	}
+	if strings.Contains(err.Error(), "point [storage.classes] back at") {
+		t.Errorf("a corrupt note granted the revert instruction: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, ".gc", "store")); !os.IsNotExist(err) {
+		t.Errorf("a held boot still created the built-in destination: %v", err)
+	}
+}
+
+// TestStorageStatusBornSplitKeepsDeployGateContract pins the status exit code
+// to what boot decides: an unresolvable provider or a missing engine seam must
+// exit non-zero, never report may-serve.
+func TestStorageStatusBornSplitKeepsDeployGateContract(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+
+	// Unknown provider: same config, stock registry.
+	prev := newStorageRegistryForPlan
+	newStorageRegistryForPlan = newStorageProviderRegistry
+	var stdout, stderr bytes.Buffer
+	if code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr); code == 0 {
+		t.Fatalf("status = 0 for a provider this build cannot resolve\nstdout: %s", stdout.String())
+	}
+	newStorageRegistryForPlan = prev
+
+	// Engine-less provider: registered but without the seam.
+	newStorageRegistryForPlan = func() (*storebinding.ProviderRegistry, error) {
+		registry := storebinding.NewProviderRegistry()
+		if err := registry.Register(engineLessProviderFactory{renamedEngineProviderFactory{
+			inner: sqlitebinding.BeadsProviderFactory{},
+			id:    "outoftree-engine",
+		}}); err != nil {
+			return nil, err
+		}
+		if err := registry.Freeze(); err != nil {
+			return nil, err
+		}
+		return registry, nil
+	}
+	t.Cleanup(func() { newStorageRegistryForPlan = prev })
+	stdout.Reset()
+	if code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr); code == 0 {
+		t.Fatalf("status = 0 for a provider without the engine seam\nstdout: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "does not open a bead engine") {
+		t.Errorf("status does not name the missing seam: %s", stdout.String())
 	}
 }

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/storebinding"
 	sqlitebinding "github.com/gastownhall/gascity/internal/storebinding/sqlite"
 )
@@ -1207,6 +1208,9 @@ func TestStorageGateBornSplitCheckFailureIsUncheckableNotUnconverged(t *testing.
 	if !strings.Contains(stderr.String(), "injected work-store open failure") {
 		t.Errorf("stderr does not carry the check's failure reason: %s", stderr.String())
 	}
+	if strings.Contains(err.Error(), "point [storage.classes] back at") {
+		t.Errorf("an uncheckable city was handed the revert instruction: %v", err)
+	}
 }
 
 // TestStorageGateBornSplitListFailureIsUncheckable proves the same for a work
@@ -1225,5 +1229,210 @@ func TestStorageGateBornSplitListFailureIsUncheckable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "could NOT be verified") {
 		t.Errorf("the refusal does not report an uncheckable city: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "injected list failure") {
+		t.Errorf("stderr does not carry the check's failure reason: %s", stderr.String())
+	}
+	if strings.Contains(err.Error(), "point [storage.classes] back at") {
+		t.Errorf("an uncheckable city was handed the revert instruction: %v", err)
+	}
+}
+
+// TestStorageGateBornSplitBlocksOnClosedInfraBead pins the scan's closed-tier
+// reach: a closed infrastructure bead is exactly the row a weakened List query
+// (dropping IncludeClosed or TierBoth) would stop seeing, and it must still
+// block the binding.
+func TestStorageGateBornSplitBlocksOnClosedInfraBead(t *testing.T) {
+	cityPath, cfg, source := bornSplitCity(t)
+	closed := mustCreateInfraBead(t, source, beads.Bead{Title: "closed session", Type: "session", Labels: []string{"gc:session"}})
+	if err := source.Close(closed.ID); err != nil {
+		t.Fatalf("closing the infra bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err == nil {
+		_ = routes.close()
+		t.Fatal("a closed infrastructure bead in the work store did not block the born-split binding")
+	}
+	if !strings.Contains(err.Error(), closed.ID) {
+		t.Errorf("the refusal does not name the closed bead %s: %v", closed.ID, err)
+	}
+}
+
+// TestStorageGateBornSplitRecordsOutcomeEvents pins the event stream to the
+// gate's actual decisions: exactly one converged event on a clean serve,
+// exactly one unconverged event on a blocked boot, and nothing else.
+func TestStorageGateBornSplitRecordsOutcomeEvents(t *testing.T) {
+	cityPath, cfg, source := bornSplitCity(t)
+
+	rec := events.NewFake()
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", rec, &stderr)
+	if err != nil {
+		t.Fatalf("clean born-split boot refused: %v", err)
+	}
+	defer routes.close() //nolint:errcheck // test cleanup
+	if got := len(rec.Events); got != 1 || rec.Events[0].Type != events.StorageBindingConverged {
+		t.Fatalf("clean serve recorded %d event(s) %+v, want one %s", got, rec.Events, events.StorageBindingConverged)
+	}
+
+	mustCreateInfraBead(t, source, beads.Bead{Title: "stray", Type: "session", Labels: []string{"gc:session"}})
+	blockedRec := events.NewFake()
+	blocked, err := storageBootGate(cityPath, cfg, "gc start", blockedRec, &stderr)
+	if err == nil {
+		_ = blocked.close()
+		t.Fatal("a dirtied work store served")
+	}
+	if got := len(blockedRec.Events); got != 1 || blockedRec.Events[0].Type != events.StorageBindingUnconverged {
+		t.Fatalf("blocked boot recorded %d event(s) %+v, want one %s", got, blockedRec.Events, events.StorageBindingUnconverged)
+	}
+}
+
+// TestStorageGateBornSplitEngineLessProviderRecordsNoConvergedEvent pins the
+// ordering fix: a compiled provider without the engine seam must refuse BEFORE
+// any outcome is recorded, or a permanently unbootable city publishes
+// converged on every boot.
+func TestStorageGateBornSplitEngineLessProviderRecordsNoConvergedEvent(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+	prev := newStorageRegistryForPlan
+	newStorageRegistryForPlan = func() (*storebinding.ProviderRegistry, error) {
+		registry := storebinding.NewProviderRegistry()
+		if err := registry.Register(engineLessProviderFactory{renamedEngineProviderFactory{
+			inner: sqlitebinding.BeadsProviderFactory{},
+			id:    "outoftree-engine",
+		}}); err != nil {
+			return nil, err
+		}
+		if err := registry.Freeze(); err != nil {
+			return nil, err
+		}
+		return registry, nil
+	}
+	t.Cleanup(func() { newStorageRegistryForPlan = prev })
+
+	rec := events.NewFake()
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", rec, &stderr)
+	if err == nil {
+		_ = routes.close()
+		t.Fatal("an engine-less binding served")
+	}
+	if !strings.Contains(err.Error(), "does not open a bead engine") {
+		t.Errorf("the refusal does not name the missing engine seam: %v", err)
+	}
+	if len(rec.Events) != 0 {
+		t.Errorf("an unservable binding recorded %d event(s): %+v", len(rec.Events), rec.Events)
+	}
+}
+
+// TestBornSplitServeBlocksLaterBuiltinGenesis pins the served-binding note's
+// whole reason to exist: serve under born-split once, re-point the classes at
+// this build's own engine, and genesis must refuse rather than bless an empty
+// store while the city's infrastructure state lives in a binding this build
+// cannot read. Removing the note is the operator's attestation, and after it
+// genesis proceeds.
+func TestBornSplitServeBlocksLaterBuiltinGenesis(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("clean born-split boot refused: %v", err)
+	}
+	if err := routes.close(); err != nil {
+		t.Fatalf("closing born-split routes: %v", err)
+	}
+	notePath := bornSplitServedNotePath(cityPath)
+	if _, err := os.Stat(notePath); err != nil {
+		t.Fatalf("serving under born-split left no served-binding note: %v", err)
+	}
+
+	// The operator re-points the infrastructure classes at this build's own
+	// engine. The work store is clean and no marker exists — exactly the
+	// genesis premise — and the note is what proves the premise false.
+	builtin := infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
+	prev := newStorageRegistryForPlan
+	newStorageRegistryForPlan = newStorageProviderRegistry
+	t.Cleanup(func() { newStorageRegistryForPlan = prev })
+
+	blocked, err := storageBootGate(cityPath, builtin, "gc start", nil, &stderr)
+	if err == nil {
+		_ = blocked.close()
+		t.Fatal("genesis blessed an empty store while the served-binding note stood")
+	}
+	if !strings.Contains(err.Error(), notePath) {
+		t.Errorf("the refusal does not name the note whose removal is the attestation: %v", err)
+	}
+	if !strings.Contains(err.Error(), "outoftree-engine") {
+		t.Errorf("the refusal does not name the previously served provider: %v", err)
+	}
+
+	if err := os.Remove(notePath); err != nil {
+		t.Fatalf("removing the served-binding note: %v", err)
+	}
+	served, err := storageBootGate(cityPath, builtin, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("genesis still refused after the note was removed: %v", err)
+	}
+	if served == nil {
+		t.Fatal("the gate served but returned no routes")
+	}
+	if err := served.close(); err != nil {
+		t.Fatalf("closing genesis routes: %v", err)
+	}
+}
+
+// TestStorageStatusReportsBornSplitStates pins the diagnosis command to the
+// same discipline boot enforces: a serving born-split city reports clean and
+// exits zero, a blocked one names the ids and exits non-zero — never "every
+// class is served by the work store".
+func TestStorageStatusReportsBornSplitStates(t *testing.T) {
+	cityPath, cfg, source := bornSplitCity(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status on a clean born-split city = %d, want 0\nstdout: %s\nstderr: %s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "born-split: clean") {
+		t.Errorf("status does not report the born-split discipline: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "every class is served by the work store") {
+		t.Errorf("status claims the work store serves classes it does not: %s", stdout.String())
+	}
+
+	strayed := mustCreateInfraBead(t, source, beads.Bead{Title: "stray", Type: "session", Labels: []string{"gc:session"}})
+	stdout.Reset()
+	if code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr); code == 0 {
+		t.Fatalf("status on a blocked born-split city = 0, want non-zero\nstdout: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), strayed.ID) {
+		t.Errorf("status does not name the blocking bead %s: %s", strayed.ID, stdout.String())
+	}
+}
+
+// TestMigrateRefusesWhileServedBindingNoteStands pins the operator command to
+// the same hold boot's genesis honors: a proven copy of the work store's slice
+// would bless a destination that silently omits everything in the previously
+// served binding.
+func TestMigrateRefusesWhileServedBindingNoteStands(t *testing.T) {
+	cityPath := t.TempDir()
+	_ = stubInfraMigrationSource(t)
+	if err := writeBornSplitServedNote(cityPath, bornSplitServedNote{Binding: "infra", Provider: "outoftree-engine"}); err != nil {
+		t.Fatalf("writing the served-binding note: %v", err)
+	}
+	cfg := infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
+
+	var log bytes.Buffer
+	report := migrateInfraClasses(t, cityPath, cfg, &log)
+	if report.Outcome != infraMigrationGenesisBlocked {
+		t.Fatalf("migrate outcome = %v, want genesis-blocked; log: %s", report.Outcome, log.String())
+	}
+	advice := infraMigrationOperatorAdvice(report, "gc storage migrate")
+	if !strings.Contains(advice, bornSplitServedNotePath(cityPath)) {
+		t.Errorf("the advice does not name the note whose removal is the attestation: %s", advice)
+	}
+	if !strings.Contains(advice, "outoftree-engine") {
+		t.Errorf("the advice does not name the previously served provider: %s", advice)
 	}
 }

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -1189,6 +1189,9 @@ func TestStorageGateRefusesBornSplitBindingWhenWorkStoreHoldsInfraBeads(t *testi
 	if !strings.Contains(err.Error(), "Do NOT revert") {
 		t.Errorf("the refusal does not withhold the revert: %v", err)
 	}
+	if !strings.Contains(err.Error(), "then delete them from the work store") {
+		t.Errorf("the refusal does not state the full recovery; the re-check reads only the work store: %v", err)
+	}
 }
 
 // TestStorageGateBornSplitCheckFailureIsUncheckableNotUnconverged proves that a
@@ -1612,5 +1615,125 @@ func TestStorageStatusBornSplitKeepsDeployGateContract(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "does not open a bead engine") {
 		t.Errorf("status does not name the missing seam: %s", stdout.String())
+	}
+}
+
+// TestRevertToWorkRefusesWhileNoteStands pins the splitNone arm: pointing
+// every class back at work is the exact re-point the note exists to hold, and
+// the natural full edit (binding definition removed too) must refuse.
+func TestRevertToWorkRefusesWhileNoteStands(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("born-split boot refused: %v", err)
+	}
+	if err := routes.close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reverted := &config.City{Storage: &config.StorageConfig{
+		Classes: config.StorageClasses{
+			Work:      config.StorageWorkBinding,
+			Graph:     config.StorageWorkBinding,
+			Sessions:  config.StorageWorkBinding,
+			Messaging: config.StorageWorkBinding,
+			Orders:    config.StorageWorkBinding,
+			Nudges:    config.StorageWorkBinding,
+		},
+	}}
+	blocked, err := storageBootGate(cityPath, reverted, "gc start", nil, &stderr)
+	if err == nil {
+		if blocked != nil {
+			_ = blocked.close()
+		}
+		t.Fatal("reverting every class to work served while the note stood")
+	}
+	if !strings.Contains(err.Error(), `"infra"`) {
+		t.Errorf("the refusal does not name the served binding: %v", err)
+	}
+}
+
+// TestBornSplitSameNamePathRepointRefuses pins the location leg of the note:
+// keeping the binding's name and provider while moving its storage is the
+// same outbound orphan, reached through a path edit instead of a name edit.
+func TestBornSplitSameNamePathRepointRefuses(t *testing.T) {
+	cityPath, cfg, _ := bornSplitCity(t)
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("born-split boot refused: %v", err)
+	}
+	if err := routes.close(); err != nil {
+		t.Fatal(err)
+	}
+
+	moved := cfg
+	binding := moved.Storage.Bindings["infra"]
+	binding.Path = filepath.Join(cityPath, ".gc", "moved-store")
+	moved.Storage.Bindings["infra"] = binding
+
+	blocked, err := storageBootGate(cityPath, moved, "gc start", nil, &stderr)
+	if err == nil {
+		_ = blocked.close()
+		t.Fatal("moving the binding's storage under the same name served while the note recorded the old location")
+	}
+	if !strings.Contains(err.Error(), bornSplitServedNotePath(cityPath)) {
+		t.Errorf("the refusal does not name the note: %v", err)
+	}
+}
+
+// TestBuiltinPathEditRefusesUntilAttested pins the same location leg on the
+// built-in arm: editing the binding's path with the marker left at the old
+// root used to reach genesis at the new root; the note now holds it.
+func TestBuiltinPathEditRefusesUntilAttested(t *testing.T) {
+	cityPath := t.TempDir()
+	_ = stubInfraMigrationSource(t)
+	original := infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, original, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("genesis boot refused: %v", err)
+	}
+	if err := routes.close(); err != nil {
+		t.Fatal(err)
+	}
+
+	moved := infraSplitConfig(filepath.Join(cityPath, ".gc", "moved-store"))
+	blocked, err := storageBootGate(cityPath, moved, "gc start", nil, &stderr)
+	if err == nil {
+		_ = blocked.close()
+		t.Fatal("a path edit reached genesis at the new root while the note recorded the old one")
+	}
+	if !strings.Contains(err.Error(), bornSplitServedNotePath(cityPath)) {
+		t.Errorf("the refusal does not name the note: %v", err)
+	}
+}
+
+// TestStorageStatusHonorsNoteHoldOnBothArms pins the diagnosis command's exit
+// code to the hold on the sqlite arm and the born-split arm alike.
+func TestStorageStatusHonorsNoteHoldOnBothArms(t *testing.T) {
+	cityPath, cfg, _, _ := convergedInfraCity(t)
+	if err := writeBornSplitServedNote(cityPath, bornSplitServedNote{Binding: "elsewhere", Provider: "outoftree-engine", Location: "ref"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr); code == 0 {
+		t.Fatalf("status = 0 on a converged city whose note names another binding\nstdout: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"elsewhere"`) {
+		t.Errorf("status does not name the served binding: %s", stdout.String())
+	}
+
+	bornPath, bornCfg, _ := bornSplitCity(t)
+	if err := writeBornSplitServedNote(bornPath, bornSplitServedNote{Binding: "old-binding", Provider: "outoftree-engine", Location: "old-ref"}); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	if code := doStorageStatus(storageOperatorRequest{CityPath: bornPath, Cfg: bornCfg}, &stdout, &stderr); code == 0 {
+		t.Fatalf("status = 0 on a born-split city whose note names another binding\nstdout: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"old-binding"`) {
+		t.Errorf("status does not name the served binding: %s", stdout.String())
 	}
 }


### PR DESCRIPTION
## What

The boot gate refused any `[storage]` binding whose provider is not the built-in bead engine — correct for a build that cannot prove convergence for such a binding, but it also closed the `EngineOpener` seam for its designed purpose: a compiled out-of-tree provider could resolve a plan and open an engine, and the gate turned it away unconditionally.

This adds the **born-split discipline**: a binding served by a provider this build carries no migration discipline for may serve when the one invariant provable from the work store alone holds — the work store contains zero infrastructure-class beads. Re-proven on every boot; refusal names the ids; an unreadable work store is uncheckable (a fact about the check — no revert instruction, no migration command handed out).

## The served-binding note

Adversarial review of the discipline found that "persist nothing" left a symmetric loss class open: a city serving from one binding, re-pointed at another (in either direction, by name or by path edit), presented exactly the fresh-city shape — and genesis would bless an empty store while the city's infrastructure state lived in the previous binding, permanently invisible.

Serving now records a **served-binding note** (`.gc/storage-served-binding.json` — history, the same durability class as the convergence marker, not process state) carrying `{binding, provider, location}`. Every path that would serve, genesis, or migrate toward a *different* binding/provider/location refuses until the operator attests by removing the note: the born-split arm, the built-in marked and genesis arms, the operator migration, and the classes-reverted-to-work shape. An unreadable note holds exactly as a readable one would. Note-derived refusals never print the revert grant — that evidence is probed from the new target and says nothing about the served binding.

`gc storage status` performs the same plan resolution, engine-seam check, and note-hold check boot does, on both arms, preserving its deploy-gate exit-code contract.

## Deliberate boundaries

- Removing the entire `[storage]` section still bypasses the gate — that boundary is the no-config compatibility contract. The work-store residue a revert leaves makes the eventual re-point loud.
- `gc storage status` exit-0 for *unsupported* shapes boot refuses predates this change and is unchanged.
- The built-in engine's convergence path is behavior-unchanged apart from honoring the note.

## Review and testing

Three adversarial review rounds (three-lens council with per-finding refutation, then two closure/fresh-eyes rounds); every confirmed finding fixed with a pinning regression test. 20 new tests cover: serve/refuse/uncheckable on the born-split arm, closed-bead scan reach, outcome events (including that a provider without the engine seam refuses before any event), the full note lifecycle (serve → hold → attest → proceed) in every direction — out-of-tree→built-in, built-in→out-of-tree, out-of-tree→out-of-tree, same-name path moves on both arms, revert-to-work — corrupt-note behavior, and both status arms' exit codes. The test fake is this build's own engine factory re-registered under a foreign ID with its foreign-spec defense left armed, so the gate is proven against a real engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
