### PR TITLE
perf(beads): tune the SQLite bead store's per-connection pragmas

### DIFF
--- a/internal/beads/sqlite_store.go
+++ b/internal/beads/sqlite_store.go
@@ -227,6 +227,10 @@ func OpenSQLiteStore(dir string, opts ...SQLiteStoreOption) (Store, error) {
 	// The URI is built structurally, not by concatenating path and query. A
 	// city directory may legitimately contain ?, #, %, or spaces; none may
 	// become a SQLite parameter or fragment while opening a migration source.
+	//
+	// One DSN serves both handles, so every pragma on it is charged
+	// sqliteStorePerStoreConnections times, not once. sqliteStoreDSNWithMode
+	// keeps that budget honest.
 	dsn := sqliteStoreDSN(dbPath, cfg.readOnly)
 	if cfg.privateRecovery {
 		dsn = sqliteStorePrivateRecoveryDSN(dbPath)
@@ -282,8 +286,8 @@ func OpenSQLiteStore(dir string, opts ...SQLiteStoreOption) (Store, error) {
 		db.Close() //nolint:errcheck
 		return nil, fmt.Errorf("opening sqlite read pool %s: %w", dbPath, err)
 	}
-	readDB.SetMaxOpenConns(8)
-	readDB.SetMaxIdleConns(8)
+	readDB.SetMaxOpenConns(sqliteReadPoolSize)
+	readDB.SetMaxIdleConns(sqliteReadPoolSize)
 	readDB.SetConnMaxIdleTime(5 * time.Minute)
 	s.readDB = readDB
 
@@ -296,6 +300,15 @@ func OpenSQLiteStore(dir string, opts ...SQLiteStoreOption) (Store, error) {
 // sqliteStoreDSNReadOnlyMode is the mode= value that makes a connection
 // incapable of writing or checkpointing.
 const sqliteStoreDSNReadOnlyMode = "ro"
+
+// sqliteReadPoolSize is how many connections the read pool may hand out at
+// once, and sqliteStorePerStoreConnections is that plus the single write
+// connection. Every pragma on the DSN is charged once per connection, so this
+// is the multiplier on anything the DSN makes a connection allocate.
+const (
+	sqliteReadPoolSize             = 8
+	sqliteStorePerStoreConnections = sqliteReadPoolSize + 1
+)
 
 // sqliteStoreDSN returns a file URI whose path and query are encoded
 // independently. In read-only mode SQLite's mode=ro is a hard capability: it
@@ -317,39 +330,55 @@ func sqliteStoreDSNWithMode(path, mode string) string {
 	query.Add("_pragma", "busy_timeout(5000)")
 	query.Add("_pragma", "foreign_keys(1)")
 
-	// Read-path tuning, on every mode. All three touch only this process's own
-	// memory and address space, never the database bytes, so they are as
-	// correct on the read-only migration-source open as on the writer.
+	// mmap_size on every mode. It maps the database instead of read()-ing
+	// every page into the per-connection page cache, and it is the only tuning
+	// pragma here because it is the only one measurement supports. On a
+	// 231 MB / 51k-bead graph, 8 concurrent Ready() scans go 11.3 s -> 8.2 s
+	// with the mapping alone. It touches only this process's address space,
+	// never the database bytes, so it is as correct on the read-only
+	// migration-source open as on the writer.
 	//
-	// cache_size is negative because SQLite reads negative values as KiB
-	// rather than pages, so this is 64 MiB against a 2 MiB default that a city
-	// graph outgrows almost immediately. mmap_size then maps the database
-	// instead of read()-ing every page into that cache, which is where the
-	// win keeps coming from once the graph is larger than any cache worth
-	// allocating. temp_store keeps ORDER BY sorters and transient B-trees off
-	// disk; it is the only one of the three that does nothing for a plain
-	// scan, and it earns its place on sorted queries.
-	query.Add("_pragma", "cache_size(-64000)")
+	// It costs address space, not memory: nine connections map the same file
+	// nine times, which inflates VmSize by ~1.9 GB and VmRSS by the same file
+	// pages counted once per mapping. Pss — the honest figure — is unchanged,
+	// and anonymous memory goes DOWN, because pages served through the mapping
+	// never enter the page cache.
 	query.Add("_pragma", "mmap_size(268435456)")
-	query.Add("_pragma", "temp_store(MEMORY)")
 
-	// synchronous is a write-durability knob, so it is scoped to the modes
-	// that can actually write. A mode=ro connection holds a read-only
-	// descriptor and can neither mutate a row nor checkpoint the WAL, which is
-	// the guarantee the migration-source contract rests on. Leaving the pragma
-	// off that DSN keeps the guarantee readable straight off the URI instead
-	// of making a reader derive that it happens to be inert there.
+	// Three pragmas that look like they belong here and were measured out.
+	// Reasons, so nobody re-adds them from general SQLite advice:
 	//
-	// NORMAL is a deliberate durability trade on the writable modes. Under WAL
-	// — which every store this package creates uses — it drops the per-commit
-	// fsync, so an OS or power crash can lose the tail of the most recently
-	// committed transactions. It cannot corrupt the database: WAL frames carry
-	// checksums and a torn tail is discarded during recovery. A crash of this
-	// process alone loses nothing, because the frames are already handed to
-	// the kernel.
-	if mode != sqliteStoreDSNReadOnlyMode {
-		query.Add("_pragma", "synchronous(NORMAL)")
-	}
+	// cache_size — the page cache is per-connection, so any value here is a
+	// sqliteStorePerStoreConnections-way budget. cache_size(-64000) on all
+	// nine measured 1.19 GB of anonymous memory (modernc's allocator rounds
+	// each ~4.2 KiB page+header into its 8 KiB size class, ~2.1x nominal) and
+	// it is not even faster: with the mapping in place it bought nothing on
+	// any workload tried, and past the mmap window it was monotonically
+	// slower, because every page-cache allocation and eviction goes through
+	// libc's one global allocator mutex that all eight readers share. 8
+	// readers x 60k indexed lookups on a 441 MB graph: default 11.5 s / 53 MB
+	// anonymous, -8000 12.5 s / 156 MB, -64000 17.9 s / 907 MB. Writes were
+	// within noise at every size, in single-row and 4000-row transactions.
+	//
+	// temp_store(MEMORY) — modernc's sqlite3VdbeSorterInit allocates the
+	// sorter's bump arena only when the temp store is NOT in memory, so
+	// temp_store(MEMORY) turns every sorter record into an individual malloc
+	// behind that same global mutex. On the 8-connection read pool it made
+	// concurrent Ready() ~1.8x slower than no pragmas at all (20.6 s vs
+	// 11.3 s) — a regression on precisely the sorted scans it looks like it
+	// should help.
+	//
+	// synchronous(NORMAL) — a genuine ~30% write win that is not safe to take
+	// until the sequence floor leads the allocator. This store rebuilds its ID
+	// allocator at open from MAX(numeric suffix) over durable rows, so a WAL
+	// tail lost to a host crash regresses the allocator and reissues bead IDs
+	// that already escaped into the event log, into gc.root_bead_id and
+	// gc.step_ref in other class stores, and into printed output — durable
+	// references that then resolve, silently, to a different bead. FULL is
+	// what makes a returned ID durable before the caller sees it. The
+	// graph.seqfloor sidecar was built for this hazard but does not cover it
+	// today: it is written only at genesis, it trails rather than leads the
+	// allocator, and the other four reserved prefixes have no floor at all.
 
 	if mode != "" {
 		query.Set("mode", mode)

--- a/internal/beads/sqlite_store.go
+++ b/internal/beads/sqlite_store.go
@@ -293,13 +293,17 @@ func OpenSQLiteStore(dir string, opts ...SQLiteStoreOption) (Store, error) {
 	return s, nil
 }
 
+// sqliteStoreDSNReadOnlyMode is the mode= value that makes a connection
+// incapable of writing or checkpointing.
+const sqliteStoreDSNReadOnlyMode = "ro"
+
 // sqliteStoreDSN returns a file URI whose path and query are encoded
 // independently. In read-only mode SQLite's mode=ro is a hard capability: it
 // cannot take a write lock or checkpoint a source WAL during close.
 func sqliteStoreDSN(path string, readOnly bool) string {
 	mode := ""
 	if readOnly {
-		mode = "ro"
+		mode = sqliteStoreDSNReadOnlyMode
 	}
 	return sqliteStoreDSNWithMode(path, mode)
 }
@@ -312,6 +316,41 @@ func sqliteStoreDSNWithMode(path, mode string) string {
 	query := url.Values{}
 	query.Add("_pragma", "busy_timeout(5000)")
 	query.Add("_pragma", "foreign_keys(1)")
+
+	// Read-path tuning, on every mode. All three touch only this process's own
+	// memory and address space, never the database bytes, so they are as
+	// correct on the read-only migration-source open as on the writer.
+	//
+	// cache_size is negative because SQLite reads negative values as KiB
+	// rather than pages, so this is 64 MiB against a 2 MiB default that a city
+	// graph outgrows almost immediately. mmap_size then maps the database
+	// instead of read()-ing every page into that cache, which is where the
+	// win keeps coming from once the graph is larger than any cache worth
+	// allocating. temp_store keeps ORDER BY sorters and transient B-trees off
+	// disk; it is the only one of the three that does nothing for a plain
+	// scan, and it earns its place on sorted queries.
+	query.Add("_pragma", "cache_size(-64000)")
+	query.Add("_pragma", "mmap_size(268435456)")
+	query.Add("_pragma", "temp_store(MEMORY)")
+
+	// synchronous is a write-durability knob, so it is scoped to the modes
+	// that can actually write. A mode=ro connection holds a read-only
+	// descriptor and can neither mutate a row nor checkpoint the WAL, which is
+	// the guarantee the migration-source contract rests on. Leaving the pragma
+	// off that DSN keeps the guarantee readable straight off the URI instead
+	// of making a reader derive that it happens to be inert there.
+	//
+	// NORMAL is a deliberate durability trade on the writable modes. Under WAL
+	// — which every store this package creates uses — it drops the per-commit
+	// fsync, so an OS or power crash can lose the tail of the most recently
+	// committed transactions. It cannot corrupt the database: WAL frames carry
+	// checksums and a torn tail is discarded during recovery. A crash of this
+	// process alone loses nothing, because the frames are already handed to
+	// the kernel.
+	if mode != sqliteStoreDSNReadOnlyMode {
+		query.Add("_pragma", "synchronous(NORMAL)")
+	}
+
 	if mode != "" {
 		query.Set("mode", mode)
 	}

--- a/internal/beads/sqlite_store_dsn_test.go
+++ b/internal/beads/sqlite_store_dsn_test.go
@@ -1,0 +1,159 @@
+package beads
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"slices"
+	"testing"
+)
+
+func dsnPragmas(t *testing.T, dsn string) []string {
+	t.Helper()
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parsing DSN %q: %v", dsn, err)
+	}
+	return parsed.Query()["_pragma"]
+}
+
+// The read-path pragmas touch only process memory, so every mode carries them.
+var sqliteReadPathPragmas = []string{
+	"cache_size(-64000)",
+	"mmap_size(268435456)",
+	"temp_store(MEMORY)",
+}
+
+func TestSQLiteStoreDSNCarriesTuningPragmas(t *testing.T) {
+	cases := []struct {
+		name            string
+		dsn             string
+		wantMode        string
+		wantSynchronous bool
+	}{
+		{name: "read-write", dsn: sqliteStoreDSN("/city/.gc/store/graph/beads.sqlite", false), wantSynchronous: true},
+		{name: "read-only", dsn: sqliteStoreDSN("/city/.gc/store/graph/beads.sqlite", true), wantMode: "ro"},
+		{name: "private recovery", dsn: sqliteStorePrivateRecoveryDSN("/snapshot/.beads/beads.sqlite"), wantMode: "rw", wantSynchronous: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pragmas := dsnPragmas(t, tc.dsn)
+			want := append([]string{"busy_timeout(5000)", "foreign_keys(1)"}, sqliteReadPathPragmas...)
+			if tc.wantSynchronous {
+				want = append(want, "synchronous(NORMAL)")
+			}
+			for _, pragma := range want {
+				if !slices.Contains(pragmas, pragma) {
+					t.Errorf("DSN %s is missing _pragma=%s (got %v)", tc.dsn, pragma, pragmas)
+				}
+			}
+			// synchronous is a write knob; a mode=ro connection cannot write or
+			// checkpoint, so the read-only DSN must not carry it.
+			if !tc.wantSynchronous && slices.Contains(pragmas, "synchronous(NORMAL)") {
+				t.Errorf("read-only DSN %s relaxes synchronous (got %v)", tc.dsn, pragmas)
+			}
+			parsed, err := url.Parse(tc.dsn)
+			if err != nil {
+				t.Fatalf("parsing DSN %q: %v", tc.dsn, err)
+			}
+			if got := parsed.Query().Get("mode"); got != tc.wantMode {
+				t.Errorf("DSN mode = %q, want %q", got, tc.wantMode)
+			}
+		})
+	}
+}
+
+func sqlitePragmaValue(t *testing.T, conn *sql.Conn, pragma string) string {
+	t.Helper()
+	var value string
+	if err := conn.QueryRowContext(context.Background(), "PRAGMA "+pragma).Scan(&value); err != nil {
+		t.Fatalf("reading PRAGMA %s: %v", pragma, err)
+	}
+	return value
+}
+
+// checkoutAllConns holds every connection the pool will hand out at once, so
+// the assertions below cover each one rather than whichever the pool reuses.
+// That is the whole reason the pragmas ride the DSN instead of a post-open Exec.
+func checkoutAllConns(t *testing.T, db *sql.DB, n int) []*sql.Conn {
+	t.Helper()
+	conns := make([]*sql.Conn, 0, n)
+	for i := 0; i < n; i++ {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("checking out connection %d: %v", i, err)
+		}
+		conns = append(conns, conn)
+	}
+	t.Cleanup(func() {
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	})
+	return conns
+}
+
+func assertTuningPragmas(t *testing.T, conns []*sql.Conn, wantSynchronous string) {
+	t.Helper()
+	for i, conn := range conns {
+		for pragma, want := range map[string]string{
+			"cache_size":   "-64000",
+			"mmap_size":    "268435456",
+			"temp_store":   "2", // MEMORY
+			"synchronous":  wantSynchronous,
+			"busy_timeout": "5000",
+			"foreign_keys": "1",
+		} {
+			if got := sqlitePragmaValue(t, conn, pragma); got != want {
+				t.Errorf("connection %d: PRAGMA %s = %s, want %s", i, pragma, got, want)
+			}
+		}
+	}
+}
+
+func TestSQLiteStoreConnectionsApplyTuningPragmas(t *testing.T) {
+	dir := t.TempDir()
+	opened, err := OpenSQLiteStore(dir, WithSQLiteStoreIDPrefix(sqliteGraphPrefix))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	store := opened.(*SQLiteStore)
+	t.Cleanup(func() { _ = store.CloseStore() })
+
+	// The write connection is created by applySchema on a brand-new database,
+	// so this also guards the creation pragmas against drifting back to FULL
+	// and silently overriding the DSN for the process's only writer.
+	t.Run("write connection", func(t *testing.T) {
+		assertTuningPragmas(t, checkoutAllConns(t, store.db, 1), "1")
+	})
+	t.Run("read pool", func(t *testing.T) {
+		assertTuningPragmas(t, checkoutAllConns(t, store.readDB, 8), "1")
+	})
+}
+
+func TestSQLiteStoreReadOnlyConnectionsKeepFullSynchronous(t *testing.T) {
+	dir := t.TempDir()
+	opened, err := OpenSQLiteStore(dir, WithSQLiteStoreIDPrefix(sqliteGraphPrefix))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore writer: %v", err)
+	}
+	if err := opened.(*SQLiteStore).CloseStore(); err != nil {
+		t.Fatalf("CloseStore writer: %v", err)
+	}
+
+	opened, err = OpenSQLiteStore(dir, WithSQLiteStoreReadOnly(), WithSQLiteStoreIDPrefix(sqliteGraphPrefix))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore read-only: %v", err)
+	}
+	store := opened.(*SQLiteStore)
+	t.Cleanup(func() { _ = store.CloseStore() })
+
+	if _, err := store.List(ListQuery{AllowScan: true, IncludeClosed: true}); err != nil {
+		t.Fatalf("List through tuned read-only store: %v", err)
+	}
+
+	// The read-path pragmas still apply; only synchronous stays at the SQLite
+	// default, because nothing on a mode=ro connection can write. Checking out
+	// the whole pool has to come last: it leaves no connection for List.
+	assertTuningPragmas(t, checkoutAllConns(t, store.readDB, 8), "2")
+}

--- a/internal/beads/sqlite_store_dsn_test.go
+++ b/internal/beads/sqlite_store_dsn_test.go
@@ -3,9 +3,12 @@ package beads
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/url"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 )
 
 func dsnPragmas(t *testing.T, dsn string) []string {
@@ -17,40 +20,27 @@ func dsnPragmas(t *testing.T, dsn string) []string {
 	return parsed.Query()["_pragma"]
 }
 
-// The read-path pragmas touch only process memory, so every mode carries them.
-var sqliteReadPathPragmas = []string{
-	"cache_size(-64000)",
-	"mmap_size(268435456)",
-	"temp_store(MEMORY)",
-}
+// sqliteTuningPragma is the one pragma this store tunes away from the SQLite
+// default. Everything else on the DSN predates the tuning work.
+const sqliteTuningPragma = "mmap_size(268435456)"
 
 func TestSQLiteStoreDSNCarriesTuningPragmas(t *testing.T) {
 	cases := []struct {
-		name            string
-		dsn             string
-		wantMode        string
-		wantSynchronous bool
+		name     string
+		dsn      string
+		wantMode string
 	}{
-		{name: "read-write", dsn: sqliteStoreDSN("/city/.gc/store/graph/beads.sqlite", false), wantSynchronous: true},
+		{name: "read-write", dsn: sqliteStoreDSN("/city/.gc/store/graph/beads.sqlite", false)},
 		{name: "read-only", dsn: sqliteStoreDSN("/city/.gc/store/graph/beads.sqlite", true), wantMode: "ro"},
-		{name: "private recovery", dsn: sqliteStorePrivateRecoveryDSN("/snapshot/.beads/beads.sqlite"), wantMode: "rw", wantSynchronous: true},
+		{name: "private recovery", dsn: sqliteStorePrivateRecoveryDSN("/snapshot/.beads/beads.sqlite"), wantMode: "rw"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			pragmas := dsnPragmas(t, tc.dsn)
-			want := append([]string{"busy_timeout(5000)", "foreign_keys(1)"}, sqliteReadPathPragmas...)
-			if tc.wantSynchronous {
-				want = append(want, "synchronous(NORMAL)")
-			}
-			for _, pragma := range want {
+			for _, pragma := range []string{"busy_timeout(5000)", "foreign_keys(1)", sqliteTuningPragma} {
 				if !slices.Contains(pragmas, pragma) {
 					t.Errorf("DSN %s is missing _pragma=%s (got %v)", tc.dsn, pragma, pragmas)
 				}
-			}
-			// synchronous is a write knob; a mode=ro connection cannot write or
-			// checkpoint, so the read-only DSN must not carry it.
-			if !tc.wantSynchronous && slices.Contains(pragmas, "synchronous(NORMAL)") {
-				t.Errorf("read-only DSN %s relaxes synchronous (got %v)", tc.dsn, pragmas)
 			}
 			parsed, err := url.Parse(tc.dsn)
 			if err != nil {
@@ -60,6 +50,49 @@ func TestSQLiteStoreDSNCarriesTuningPragmas(t *testing.T) {
 				t.Errorf("DSN mode = %q, want %q", got, tc.wantMode)
 			}
 		})
+	}
+}
+
+// sqliteMeasuredOutPragmas are the pragmas that were tried on this DSN and
+// removed, each with the reason a future reader needs before re-adding it from
+// general SQLite advice. The reason is in the failure message deliberately: the
+// point of this test is not to freeze a pragma list, it is to make sure the
+// next person to reach for one of these reads the measurement first.
+var sqliteMeasuredOutPragmas = map[string]string{
+	"cache_size": "the page cache is per-connection, so this DSN charges it 9x " +
+		"(1 writer + 8 pooled readers): cache_size(-64000) measured 1.19 GB of anonymous " +
+		"memory and was SLOWER than no pragma at all, because every page-cache allocation " +
+		"goes through modernc/libc's one global allocator mutex that all 8 readers share",
+	"temp_store": "modernc skips the sorter's bump arena when the temp store is in memory, " +
+		"so temp_store(MEMORY) makes every sorter record an individual malloc behind that same " +
+		"global mutex: concurrent Ready() measured ~1.8x SLOWER than no pragma at all",
+	"synchronous": "NORMAL lets a host crash discard the WAL tail, which regresses " +
+		"recoverSequence's MAX-suffix allocator and reissues bead IDs that already escaped this " +
+		"store; graph.seqfloor does not cover it because it is genesis-only, trails the " +
+		"allocator, and exists only for the graph prefix",
+}
+
+// TestSQLiteStoreDSNOmitsMeasuredOutPragmas is the F1/F2/F3 guard. Every pragma
+// on this DSN is multiplied by sqliteStorePerStoreConnections, and these three
+// were each measured to be neutral or harmful at that multiplier.
+func TestSQLiteStoreDSNOmitsMeasuredOutPragmas(t *testing.T) {
+	dsns := []string{
+		sqliteStoreDSN("/city/.gc/store/graph/beads.sqlite", false),
+		sqliteStoreDSN("/city/.gc/store/graph/beads.sqlite", true),
+		sqliteStorePrivateRecoveryDSN("/snapshot/.beads/beads.sqlite"),
+	}
+	for _, dsn := range dsns {
+		for _, pragma := range dsnPragmas(t, dsn) {
+			name, _, found := strings.Cut(pragma, "(")
+			if !found {
+				t.Errorf("DSN %s has malformed _pragma=%s", dsn, pragma)
+				continue
+			}
+			if reason, measuredOut := sqliteMeasuredOutPragmas[name]; measuredOut {
+				t.Errorf("DSN %s carries _pragma=%s across %d connections: %s",
+					dsn, pragma, sqliteStorePerStoreConnections, reason)
+			}
+		}
 	}
 }
 
@@ -75,32 +108,43 @@ func sqlitePragmaValue(t *testing.T, conn *sql.Conn, pragma string) string {
 // checkoutAllConns holds every connection the pool will hand out at once, so
 // the assertions below cover each one rather than whichever the pool reuses.
 // That is the whole reason the pragmas ride the DSN instead of a post-open Exec.
+//
+// The context is bounded: asking for more connections than the pool will hand
+// out blocks forever on database/sql's waiter queue, which surfaces as a
+// package-wide test-binary timeout panic instead of a failure here.
 func checkoutAllConns(t *testing.T, db *sql.DB, n int) []*sql.Conn {
 	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	conns := make([]*sql.Conn, 0, n)
-	for i := 0; i < n; i++ {
-		conn, err := db.Conn(context.Background())
-		if err != nil {
-			t.Fatalf("checking out connection %d: %v", i, err)
-		}
-		conns = append(conns, conn)
-	}
 	t.Cleanup(func() {
 		for _, conn := range conns {
 			_ = conn.Close()
 		}
 	})
+	for i := 0; i < n; i++ {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("checking out connection %d of %d: %v", i, n, err)
+		}
+		conns = append(conns, conn)
+	}
 	return conns
 }
 
-func assertTuningPragmas(t *testing.T, conns []*sql.Conn, wantSynchronous string) {
+// assertTuningPragmas checks the values every connection must report: the one
+// tuned pragma, and the SQLite defaults the measured-out pragmas must leave in
+// place. Checking the defaults behaviourally is what catches a pragma restated
+// somewhere other than the DSN — the creation schema statements, for instance,
+// which run on the store's only write connection.
+func assertTuningPragmas(t *testing.T, conns []*sql.Conn) {
 	t.Helper()
 	for i, conn := range conns {
 		for pragma, want := range map[string]string{
-			"cache_size":   "-64000",
 			"mmap_size":    "268435456",
-			"temp_store":   "2", // MEMORY
-			"synchronous":  wantSynchronous,
+			"cache_size":   "-2000", // SQLite's default.
+			"temp_store":   "0",     // SQLite's default.
+			"synchronous":  "2",     // FULL.
 			"busy_timeout": "5000",
 			"foreign_keys": "1",
 		} {
@@ -121,17 +165,18 @@ func TestSQLiteStoreConnectionsApplyTuningPragmas(t *testing.T) {
 	t.Cleanup(func() { _ = store.CloseStore() })
 
 	// The write connection is created by applySchema on a brand-new database,
-	// so this also guards the creation pragmas against drifting back to FULL
-	// and silently overriding the DSN for the process's only writer.
+	// so this also guards the creation statements against drifting out of
+	// lockstep with the DSN and silently overriding it for the process's only
+	// writer.
 	t.Run("write connection", func(t *testing.T) {
-		assertTuningPragmas(t, checkoutAllConns(t, store.db, 1), "1")
+		assertTuningPragmas(t, checkoutAllConns(t, store.db, 1))
 	})
 	t.Run("read pool", func(t *testing.T) {
-		assertTuningPragmas(t, checkoutAllConns(t, store.readDB, 8), "1")
+		assertTuningPragmas(t, checkoutAllConns(t, store.readDB, sqliteReadPoolSize))
 	})
 }
 
-func TestSQLiteStoreReadOnlyConnectionsKeepFullSynchronous(t *testing.T) {
+func TestSQLiteStoreReadOnlyConnectionsApplyTuningPragmas(t *testing.T) {
 	dir := t.TempDir()
 	opened, err := OpenSQLiteStore(dir, WithSQLiteStoreIDPrefix(sqliteGraphPrefix))
 	if err != nil {
@@ -152,8 +197,55 @@ func TestSQLiteStoreReadOnlyConnectionsKeepFullSynchronous(t *testing.T) {
 		t.Fatalf("List through tuned read-only store: %v", err)
 	}
 
-	// The read-path pragmas still apply; only synchronous stays at the SQLite
-	// default, because nothing on a mode=ro connection can write. Checking out
-	// the whole pool has to come last: it leaves no connection for List.
-	assertTuningPragmas(t, checkoutAllConns(t, store.readDB, 8), "2")
+	// Checking out the whole pool has to come last: it leaves no connection
+	// for List.
+	assertTuningPragmas(t, checkoutAllConns(t, store.readDB, sqliteReadPoolSize))
+}
+
+// TestSQLiteStoreKeepsFullSynchronousUntilTheSequenceFloorLeads states the
+// invariant behind the synchronous entry in sqliteMeasuredOutPragmas rather
+// than restating the pragma value.
+//
+// recoverSequence rebuilds the allocator at open from MAX(numeric suffix) over
+// durable rows. Under synchronous=FULL a commit is fsynced before Create
+// returns, so an ID the caller has already seen is durable and the allocator
+// cannot regress below it. Under NORMAL the whole WAL tail since the last
+// checkpoint can be discarded by a host crash, the allocator regresses, and the
+// next mints reissue IDs that already escaped. The test asserts the premise
+// (the persisted floor trails the ids handed out) and the consequence (the
+// write connection is at FULL) together, so it stops guarding as soon as the
+// premise stops being true instead of silently pinning a stale conclusion.
+func TestSQLiteStoreKeepsFullSynchronousUntilTheSequenceFloorLeads(t *testing.T) {
+	dir := t.TempDir()
+	opened, err := OpenSQLiteStore(dir, WithSQLiteStoreIDPrefix(sqliteGraphPrefix))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	store := opened.(*SQLiteStore)
+	t.Cleanup(func() { _ = store.CloseStore() })
+
+	escaped := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		created, err := store.Create(Bead{Title: fmt.Sprintf("escaped %d", i), Status: "open", Type: "task"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		escaped = append(escaped, created.ID)
+	}
+	floor, err := store.SequenceFloor()
+	if err != nil {
+		t.Fatalf("SequenceFloor: %v", err)
+	}
+	minted := store.seq.Load()
+	if minted == 0 {
+		t.Fatal("no ids were minted, so the guard below would be vacuous")
+	}
+	if floor >= minted {
+		t.Skipf("sequence floor %d now leads the allocator at %d after minting %v; re-evaluate synchronous=NORMAL", floor, minted, escaped)
+	}
+
+	conn := checkoutAllConns(t, store.db, 1)[0]
+	if got := sqlitePragmaValue(t, conn, "synchronous"); got != "2" {
+		t.Errorf("write connection PRAGMA synchronous = %s, want 2 (FULL): the allocator recovers from durable rows but the persisted floor (%d) trails the %d ids already handed out (%v)", got, floor, minted, escaped)
+	}
 }

--- a/internal/beads/sqlite_store_schema.go
+++ b/internal/beads/sqlite_store_schema.go
@@ -110,10 +110,9 @@ func sqliteStoreCreationSchemaStatements() []string {
 	// The per-connection pragmas here mirror sqliteStoreDSNWithMode. They have
 	// to: applySchema runs on the store's single write connection, so a value
 	// restated here overrides the DSN for that connection's whole lifetime.
-	// synchronous stays in lockstep with the DSN for exactly that reason.
 	statements := []string{
 		`PRAGMA journal_mode=WAL`,
-		`PRAGMA synchronous=NORMAL`,
+		`PRAGMA synchronous=FULL`,
 		`PRAGMA wal_autocheckpoint=1000`,
 		`PRAGMA busy_timeout=5000`,
 		`PRAGMA foreign_keys=ON`,

--- a/internal/beads/sqlite_store_schema.go
+++ b/internal/beads/sqlite_store_schema.go
@@ -107,9 +107,13 @@ var sqliteSchemaIndexStatements = []string{
 }
 
 func sqliteStoreCreationSchemaStatements() []string {
+	// The per-connection pragmas here mirror sqliteStoreDSNWithMode. They have
+	// to: applySchema runs on the store's single write connection, so a value
+	// restated here overrides the DSN for that connection's whole lifetime.
+	// synchronous stays in lockstep with the DSN for exactly that reason.
 	statements := []string{
 		`PRAGMA journal_mode=WAL`,
-		`PRAGMA synchronous=FULL`,
+		`PRAGMA synchronous=NORMAL`,
 		`PRAGMA wal_autocheckpoint=1000`,
 		`PRAGMA busy_timeout=5000`,
 		`PRAGMA foreign_keys=ON`,


### PR DESCRIPTION
## Problem

`sqliteStoreDSNWithMode` built the bead store's DSN with only two pragmas:

```
_pragma=busy_timeout(5000)
_pragma=foreign_keys(1)
```

Everything else sat at the SQLite default. Verified live against a
51,127-bead / 193 MB city graph: `synchronous=2` (FULL), `cache_size=-2000`
(2 MiB), `mmap_size=0`, `temp_store=0`.

## Change

**One pragma:**

| pragma | effect |
| --- | --- |
| `mmap_size(268435456)` | 256 MiB memory-mapped I/O, every mode |

The first revision of this PR added four. Review measured the other three and
they are gone; the reasons are below and in the code, because each one is
exactly what general SQLite tuning advice tells you to add.

The concurrency design is untouched: write handle still `SetMaxOpenConns(1)`,
read pool still 8/8, `journal_mode=WAL`, `busy_timeout`, `foreign_keys`, and
the three 150 ms application-level busy retries all unchanged. The pragma
rides the `_pragma=` URI form rather than a post-open `Exec` for the same
reason `busy_timeout` already does: it is the only way it reaches **every**
connection in the read pool.

`sqliteStoreCreationSchemaStatements` restates `PRAGMA synchronous=FULL`
exactly as on `main`.

## Measured effect

Method: three arms built from real trees (`origin/main`, this PR's first
revision, this PR) and run **interleaved** round-robin against a fresh copy of
the fixture each round, so all three see the same machine load. Two synthetic
fixtures shaped like the live graph — 51,127 beads at 231 MB (inside the mmap
window, the size the live engine is at today) and at 441 MB (past the window,
where the graph is heading, since `disableRetentionSweeper` defaults true).
Medians of 2-4 rounds.

### Reads

| workload | main | first revision | this PR |
| --- | ---: | ---: | ---: |
| `Ready()` x8 concurrent, 231 MB | 11.55 s | 20.19 s | **8.53 s (-26%)** |
| `Ready()` x8 concurrent, 441 MB | 13.32 s | 26.60 s | **10.28 s (-23%)** |
| `Ready()` single connection, 231 MB | 7.49 s | 6.12 s | **6.92 s (-8%)** |
| `List{AllowScan}` x8 concurrent, 231 MB | 4.94 s | 4.24 s | **4.22 s (-15%)** |
| 480k indexed `Get` x8 concurrent, 441 MB | 27.8 µs | 35.0 µs | **24.5 µs (-12%)** |

The middle column is the point: as submitted, this PR was **1.8x to 2.0x
slower than the branch it merges into** on its own headline workload.

### Writes

| workload | main | first revision | this PR |
| --- | ---: | ---: | ---: |
| `Create`, one tx each, 231 MB | 1136 µs | 805 µs | 1082 µs |
| 4000 `Create` in one tx, 231 MB | 421 µs | 421 µs | 451 µs |
| `Update`, scattered, one tx each, 441 MB | 1891 µs | 1536 µs | 1892 µs |

**Honest summary: this PR is a read win and a write no-op.** Every write
number is within run-to-run noise of `main`. The ~30% the first revision
showed was `synchronous=NORMAL` and nothing else — see below.

### Memory

Nine connections per store (1 writer + 8 pooled readers), measured after the
concurrent workload with the connections still in the pool:

| arm | 441 MB graph, VmRSS | Pss | **Anonymous** |
| --- | ---: | ---: | ---: |
| main | 192 MB | 192 MB | **175 MB** |
| first revision | 3345 MB | 1501 MB | **1222 MB** |
| this PR | 2288 MB | 445 MB | **166 MB** |

Anonymous is the column that matters: it is private, it is not reclaimable
under pressure, and the box runs six cities with no swap and no `MemoryMax`.
This PR does not move it. The RSS/VmSize inflation is the same file pages
counted once per mapping — nine mappings of one file — and those pages are
clean, file-backed, and droppable by the kernel at any time.

## Why the other three pragmas are gone

### `cache_size(-64000)` — per-connection, so it was a 9x budget

SQLite's page cache is per-connection, and `OpenSQLiteStore` hands one DSN to
a 1-connection write handle and an 8-connection read pool. `-64000` was
therefore 576 MiB nominal, and modernc.org/libc rounds each ~4.2 KiB
page+header into its 8 KiB size class, so ~2.1x that resident. Measured:
**1.19 GB of anonymous memory** on the 441 MB fixture, against 175 MB on
`main`.

Inside the 256 MiB mmap window that cost is invisible, because pages served
through the mapping never enter the page cache at all. The graph is 193 MB
today and only grows.

It also was not buying speed. Sweeping the read pool's value on the 441 MB
fixture, 8 readers x 60k indexed lookups:

| read-pool `cache_size` | time | anonymous |
| --- | ---: | ---: |
| default (-2000) | 11.5 s | 53 MB |
| -8000 | 12.5 s | 156 MB |
| -64000 | 17.9 s | 907 MB |

Monotonically slower and monotonically fatter. The mechanism is the same one
that sinks `temp_store` below: modernc's emulated heap sits behind one
process-global mutex, so eight pooled readers churning eight private page
caches serialize on the allocator. Isolated on the 231 MB fixture, `cache_size`
**alone** (no mapping) measured 14.6 s against `main`'s 11.4 s — a regression
on its own.

Writes were within noise at every value tried, in single-row transactions and
in 4000-row transactions (the shape a big cache is classically supposed to
rescue, by not spilling).

So there is no per-pool value worth splitting the DSN for: the read pool wants
less than the default is worth measuring, and the write handle shows nothing.
The pragma is out, `sqliteStorePerStoreConnections` names the multiplier for
whoever reaches for it next, and a test fails with the reason attached.

### `temp_store(MEMORY)` — a 1.8x regression on the query it claimed to help

`sqlite3VdbeSorterInit` allocates the sorter's bump arena
(`pSorter->list.aMemory`) **only when `sqlite3TempInMemory(db)` is false**
(modernc.org/sqlite@v1.50.1). With `temp_store=MEMORY` that arena is skipped
and every sorter record becomes an individual `sqlite3Malloc`, behind the same
process-global allocator mutex the eight readers share.

`sqliteReadySQL` unconditionally appends `ORDER BY b.created_at ASC, b.id ASC`
over the full `bead_json` projection, which plans a temp B-tree sorter, and
`Ready()` is called from concurrent HTTP handlers and the controller tick. So
this landed squarely on the hot path: **20.19 s vs `main`'s 11.55 s.**

The first revision's comment said it "earns its place on sorted queries." On
this driver it does the reverse, and the first revision's own test pinned the
bad value.

### `synchronous(NORMAL)` — the write win, deferred to the PR that can hold it

This is the one that is genuinely worth having and genuinely cannot ship yet.

`recoverSequence` rebuilds the store's ID allocator at open purely from durable
contents — `MAX(numeric suffix)` over `SELECT id FROM beads WHERE id LIKE ?` —
raised by the `graph.seqfloor` sidecar only when the prefix is `gcg`. That
sidecar is not advanced as IDs are minted: `SetSequenceFloor`'s only non-test
caller is `GraphComponent.ApplyGenesisSequenceFloor` ("the front door's only
floor writer"), which itself has **zero non-test callers**. In a deployed city
the floor reads 0, and the other four reserved prefixes (`gcm`/`gcs`/`gco`/
`gcn`) have no floor at all.

Under FULL, a `Create` is fsynced before the caller sees the ID, so the
allocator can never regress below an ID that has been handed out. NORMAL
removes exactly that. After a host crash the WAL tail is discarded, the
allocator regresses, and IDs that already escaped — into the event log, into
`gc.root_bead_id`/`gc.step_ref` in **other class stores**, into printed output
— get reissued to different beads. Durable external references then resolve
successfully to the **wrong** bead, silently, with no error path. The database
stays internally consistent; identity across artifacts does not. This is
precisely the hazard `graph.seqfloor` was built for.

The first revision's durability note ("beads are a convergent ledger, losing
the last few milliseconds is recoverable") is the claim that fails here:
convergence re-reads `gcg-51120` and converges on the wrong bead.

**Decision: drop NORMAL from this PR rather than fix the allocator here.**

The fix is real and known — reserve a block of IDs at open, and whenever the
in-memory sequence crosses the persisted floor write the new floor through
`writeSQLiteSequenceFloor` (temp + fsync + rename + directory fsync), minting
from that block in memory. One fsync per N IDs keeps nearly all the write win.
But it is not a pragma change:

- The floor must cover the four non-`gcg` prefixes, which means a
  `graph.seqfloor` sidecar appearing in four more class-store directories that
  do not have one today.
- `internal/storebinding` treats that file as a **pinned physical fact**
  (`PhysicalFactGraphSeqFloor` pins "path, presence, identity, and bytes") and
  fences migration against it — `captureGraphSequenceFloorFileContext` fails
  with `errSQLiteSourceChanged` if it moves during a census. Turning it from a
  genesis-only file into one that changes every N mints puts ordinary bead
  creation in a race with every migration census.
- Twelve test files across two packages encode the current
  genesis-only/graph-only semantics.

Riding that on a pragma PR would bury a migration-contract change inside a
performance change. It gets its own PR with its own red-before test; this one
keeps the read wins and gives up the write win until then. `synchronous` is
now absent from **every** DSN mode, and the creation schema statement is back
to `FULL` in lockstep.

## Tests

`internal/beads/sqlite_store_dsn_test.go`:

- `TestSQLiteStoreDSNCarriesTuningPragmas` — read-write, read-only and
  private-recovery DSNs each carry `mmap_size` and the right `mode`.
- `TestSQLiteStoreDSNOmitsMeasuredOutPragmas` — the three removed pragmas
  stay removed. The failure message carries the measurement and the mechanism,
  not just "not allowed", so the next person to add `cache_size` from a tuning
  blog reads why it was 1.19 GB first.
- `TestSQLiteStoreConnectionsApplyTuningPragmas` — behavioural: checks out
  **all 8** read-pool connections at once plus the write connection and asserts
  each reports `mmap_size=268435456` and the SQLite defaults for the three
  removed pragmas. Asserting the defaults behaviourally is what catches a
  pragma restated somewhere other than the DSN — the creation schema
  statements, for instance, which run on the store's only writer.
- `TestSQLiteStoreReadOnlyConnectionsApplyTuningPragmas` — same for the
  read-only store.
- `TestSQLiteStoreKeepsFullSynchronousUntilTheSequenceFloorLeads` — states the
  invariant instead of the value: mint five beads, assert the persisted floor
  still trails the IDs handed out, and only then assert FULL. If someone makes
  the floor lead, the test skips with a message saying to re-evaluate NORMAL
  rather than blocking the change it is waiting for.
- `checkoutAllConns` now uses a bounded context. Asking for more connections
  than the pool hands out used to block forever on `database/sql`'s waiter
  queue, so a pool-size change surfaced as a package-wide test-binary timeout
  panic instead of a failure in this file.

Red before, against **this PR's first revision** (the three pragmas present):

```
sqlite_store_dsn_test.go:92: DSN ...&_pragma=cache_size%28-64000%29... carries _pragma=cache_size(-64000) across 9 connections: the page cache is per-connection, so this DSN charges it 9x (1 writer + 8 pooled readers): cache_size(-64000) measured 1.19 GB of anonymous memory and was SLOWER than no pragma at all, ...
sqlite_store_dsn_test.go:92: ... carries _pragma=temp_store(MEMORY) across 9 connections: modernc skips the sorter's bump arena when the temp store is in memory, ... concurrent Ready() measured ~1.8x SLOWER than no pragma at all
sqlite_store_dsn_test.go:92: ... carries _pragma=synchronous(NORMAL) across 9 connections: NORMAL lets a host crash discard the WAL tail, which regresses recoverSequence's MAX-suffix allocator and reissues bead IDs that already escaped this store; ...
sqlite_store_dsn_test.go:175: connection 0: PRAGMA cache_size = -64000, want -2000
sqlite_store_dsn_test.go:175: connection 0: PRAGMA temp_store = 2, want 0
sqlite_store_dsn_test.go:175: connection 0: PRAGMA synchronous = 1, want 2
sqlite_store_dsn_test.go:249: write connection PRAGMA synchronous = 1, want 2 (FULL): the allocator recovers from durable rows but the persisted floor (0) trails the 5 ids already handed out ([gcg-1 gcg-2 gcg-3 gcg-4 gcg-5])
```

Red before, against `origin/main` (no `mmap_size`):

```
sqlite_store_dsn_test.go:42: DSN file:///city/.gc/store/graph/beads.sqlite?_pragma=busy_timeout%285000%29&_pragma=foreign_keys%281%29 is missing _pragma=mmap_size(268435456) (got [busy_timeout(5000) foreign_keys(1)])
sqlite_store_dsn_test.go:175: connection 0: PRAGMA mmap_size = 0, want 268435456
```

Gates:

```
go build ./...                          exit 0
go vet ./...                            exit 0
go test ./internal/beads/               ok  25.8s
go test ./internal/storebinding/...     ok  (all 3 packages)
golangci-lint run ./internal/beads/...  0 issues (v2.10.1)
gofmt -l <touched files>                clean
```

`internal/storebinding/...` is included because it owns the only non-test
callers of the read-only and private-recovery opens, and because it owns the
`graph.seqfloor` fence the deferred `synchronous` work will have to change.

## Follow-up

The write win needs its own PR: make `graph.seqfloor` **lead** the allocator
(hi/lo block reservation, one fsync per N IDs), extend it to the four non-`gcg`
reserved prefixes, and reconcile the now-mutable sidecar with
`PhysicalFactGraphSeqFloor` and the migration census fence. `synchronous=NORMAL`
lands with that change, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
