### PR TITLE
fix(orders): create order-dispatched wisps in the graph store

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -2816,6 +2816,17 @@ func (cs *controllerState) WebhookDispatcher() orderdispatch.Dispatcher {
 type controllerWebhookDispatcher struct{ cs *controllerState }
 
 func (d controllerWebhookDispatcher) Dispatch(ctx context.Context, req orderdispatch.DispatchRequest) (orderdispatch.DispatchResult, error) {
+	return d.dispatcher().Dispatch(ctx, req)
+}
+
+// dispatcher builds the per-delivery dispatcher Dispatch fires through, reading
+// the controller's live config, recorder and storage binding under the
+// hot-reload lock. It is separate from Dispatch so what this seam hands the
+// dispatcher is assertable without firing a delivery: the routes are the whole
+// reason a webhook-fired wisp lands in the same graph store a tick-fired one
+// does, and they arrive as a constructor argument that nothing downstream
+// re-resolves.
+func (d controllerWebhookDispatcher) dispatcher() *memoryOrderDispatcher {
 	cs := d.cs
 	cs.mu.RLock()
 	cfg := cs.cfg
@@ -2827,11 +2838,7 @@ func (d controllerWebhookDispatcher) Dispatch(ctx context.Context, req orderdisp
 		// discard recorder keeps it panic-free when the city has events disabled.
 		rec = events.Discard
 	}
-	// The per-delivery dispatcher serves the same storage binding the
-	// controller booted, so a webhook-fired wisp lands in the same graph store
-	// a tick-fired one does.
-	md := newMemoryOrderDispatcher(routes, nil, cs.cityPath, cfg, rec, os.Stderr)
-	return md.Dispatch(ctx, req)
+	return newMemoryOrderDispatcher(routes, nil, cs.cityPath, cfg, rec, os.Stderr)
 }
 
 // ExtMsgServices returns the external messaging services.

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -2790,6 +2790,7 @@ func (d controllerWebhookDispatcher) Dispatch(ctx context.Context, req orderdisp
 	cs := d.cs
 	cs.mu.RLock()
 	cfg := cs.cfg
+	routes := cs.storageRoutes
 	var rec events.Recorder = cs.eventProv
 	cs.mu.RUnlock()
 	if rec == nil {
@@ -2797,7 +2798,10 @@ func (d controllerWebhookDispatcher) Dispatch(ctx context.Context, req orderdisp
 		// discard recorder keeps it panic-free when the city has events disabled.
 		rec = events.Discard
 	}
-	md := newMemoryOrderDispatcher(nil, cs.cityPath, cfg, rec, os.Stderr)
+	// The per-delivery dispatcher serves the same storage binding the
+	// controller booted, so a webhook-fired wisp lands in the same graph store
+	// a tick-fired one does.
+	md := newMemoryOrderDispatcher(routes, nil, cs.cityPath, cfg, rec, os.Stderr)
 	return md.Dispatch(ctx, req)
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -329,7 +329,7 @@ func newCityRuntime(p CityRuntimeParams) (*CityRuntime, error) {
 		warnIfClosedOrderTrackingBacklogLarge(sweepStore, p.Stderr)
 	}()
 
-	od, orderSnapshot := buildOrderDispatcherWithSnapshot(p.CityPath, p.Cfg, p.Rec, p.Stderr, "gc start: order scan")
+	od, orderSnapshot := buildOrderDispatcherWithSnapshot(routes, p.CityPath, p.Cfg, p.Rec, p.Stderr, "gc start: order scan")
 
 	suspendedNames := computeSuspendedNames(p.Cfg, p.CityName, p.CityPath)
 
@@ -1462,7 +1462,7 @@ func (cr *CityRuntime) rescanOrderDispatcher(ctx context.Context, cityRoot strin
 		cr.drainOutgoingOrderDispatcher(drainCtx, cr.od)
 		drainCancel()
 	}
-	cr.replaceOrderDispatcher(buildOrderDispatcherFromOrderSet(cityRoot, cfg, snapshot.Orders, cr.rec, cr.stderr))
+	cr.replaceOrderDispatcher(buildOrderDispatcherFromOrderSet(cr.storageRoutes, cityRoot, cfg, snapshot.Orders, cr.rec, cr.stderr))
 	cr.orderSet = snapshot.Orders
 	cr.orderSetSignature = snapshot.Signature
 	if summary != "unchanged" {
@@ -2123,7 +2123,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 		cr.drainOutgoingOrderDispatcher(drainCtx, cr.od)
 		drainCancel()
 	}
-	nextOD, orderSnapshot := buildOrderDispatcherWithSnapshot(cityRoot, nextCfg, cr.rec, cr.stderr, "gc reload: order scan")
+	nextOD, orderSnapshot := buildOrderDispatcherWithSnapshot(cr.storageRoutes, cityRoot, nextCfg, cr.rec, cr.stderr, "gc reload: order scan")
 	orderSummary := orderSetChangeSummary(cr.orderSet, orderSnapshot.Orders)
 	cr.replaceOrderDispatcher(nextOD)
 	cr.orderSet = orderSnapshot.Orders

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1542,7 +1542,7 @@ func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
 	// Closed-history retention is intentionally left to the maintenance exec
 	// order or the gc order sweep-tracking CLI; the watchdog only recovers
 	// stale open tracking beads.
-	result, sweepErr := sweepStaleOrderTrackingAcrossStoresLimit(stores, now, orderTrackingSweepWatchdogStaleAfter, nil, orderTrackingWatchdogMetadataInitiator, false, orderTrackingSweepCloseBudget)
+	result, sweepErr := sweepStaleOrderTrackingAcrossStoresLimit(stores, nil, now, orderTrackingSweepWatchdogStaleAfter, nil, orderTrackingWatchdogMetadataInitiator, false, orderTrackingSweepCloseBudget)
 	if err := errors.Join(storeErr, sweepErr); err != nil {
 		if cr.stderr != nil {
 			fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1980,6 +1980,7 @@ func TestOrderTrackingSweepWatchdogAllowsSweepOrderToCleanStaleTracking(t *testi
 		execRan = true
 		_, err := sweepStaleOrderTrackingAcrossStores(
 			[]beads.Store{store},
+			nil,
 			freshMerge.CreatedAt.Add(25*time.Millisecond),
 			50*time.Millisecond,
 			nil,

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1762,7 +1762,10 @@ func cmdOrderSweepTrackingWithOptions(staleAfter time.Duration, includeWisps, dr
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	stores, openErr := orderTrackingSweepStoresForConfigTargets(cityPath, cfg, requiredTargets)
+	// wispStore is the store the sweep's wisp-subtree half runs against: on a
+	// split city the wisp roots this force-closes are graph class and live in
+	// the binding, not in any of the order stores beside them.
+	stores, wispStore, openErr := orderTrackingSweepStoresForConfigTargets(cityPath, cfg, requiredTargets)
 	if len(stores) == 0 {
 		if openErr != nil {
 			fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", openErr) //nolint:errcheck // best-effort stderr
@@ -1781,9 +1784,9 @@ func cmdOrderSweepTrackingWithOptions(staleAfter time.Duration, includeWisps, dr
 	// the non-zero exit is deferred to the end of the function.
 	confirmGateBlocked := false
 	if dryRun {
-		result, sweepErr = sweepStaleOrderTrackingAcrossStoresDryRun(stores, now, staleAfter, onlyOrders, includeWisps)
+		result, sweepErr = sweepStaleOrderTrackingAcrossStoresDryRun(stores, wispStore, now, staleAfter, onlyOrders, includeWisps)
 	} else {
-		result, sweepErr = sweepStaleOrderTrackingAcrossStores(stores, now, staleAfter, onlyOrders, includeWisps)
+		result, sweepErr = sweepStaleOrderTrackingAcrossStores(stores, wispStore, now, staleAfter, onlyOrders, includeWisps)
 
 		// Bulk-delete confirm gate: before any retention deletions, count
 		// eligible beads and require --confirm when above

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -645,7 +645,7 @@ func TestReloadConfigTracedRescansOrdersWhenConfigRevisionUnchanged(t *testing.T
 		cfg:                cfg,
 		sp:                 runtime.NewFake(),
 		dops:               newDrainOps(runtime.NewFake()),
-		od:                 buildOrderDispatcherFromOrderSet(dir, cfg, initialOrders.Orders, events.Discard, &stderr),
+		od:                 buildOrderDispatcherFromOrderSet(nil, dir, cfg, initialOrders.Orders, events.Discard, &stderr),
 		orderSet:           initialOrders.Orders,
 		orderSetSignature:  initialOrders.Signature,
 		orderRescanEnabled: true,

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -2280,28 +2280,46 @@ func sweepStaleOrderTrackingLimit(store beads.Store, now time.Time, staleAfter t
 	return result.trackingClosed, err
 }
 
-func sweepStaleOrderTrackingAcrossStores(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
-	return sweepStaleOrderTrackingAcrossStoresLimit(stores, now, staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0)
+func sweepStaleOrderTrackingAcrossStores(stores []beads.Store, wispStore beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingAcrossStoresLimit(stores, wispStore, now, staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0)
 }
 
 // sweepStaleOrderTrackingAcrossStoresLimit applies limit only to
 // order-tracking bead closes. Wisp subtree recovery is operator-scoped by
 // order name and closes complete stale subtrees when explicitly requested.
-func sweepStaleOrderTrackingAcrossStoresLimit(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
-	return sweepStaleOrderTrackingAcrossStoresLimitMode(stores, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, limit, false)
+func sweepStaleOrderTrackingAcrossStoresLimit(stores []beads.Store, wispStore beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingAcrossStoresLimitMode(stores, wispStore, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, limit, false)
 }
 
-func sweepStaleOrderTrackingAcrossStoresDryRun(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
-	return sweepStaleOrderTrackingAcrossStoresLimitMode(stores, now, staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0, true)
+func sweepStaleOrderTrackingAcrossStoresDryRun(stores []beads.Store, wispStore beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingAcrossStoresLimitMode(stores, wispStore, now, staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0, true)
 }
 
-func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int, dryRun bool) (orderTrackingSweepResult, error) {
+// sweepStaleOrderTrackingAcrossStoresLimitMode sweeps two coordination classes,
+// and wispStore is what keeps them apart.
+//
+// stores are the per-scope ORDER/work stores that own the tracking beads.
+// wispStore, when non-nil, is the separate binding this city serves the GRAPH
+// class from — where dispatchWisp now creates order wisp roots and where the
+// single-flight gate now reads them. The force-close that releases a stalled
+// wisp has to look in the same place: a wisp-subtree sweep aimed at the work
+// stores finds no "order-run:<name>" root, reports wispClosed: 0, and leaves
+// hasOpenWorkStrict suppressing the order on every tick forever, with no
+// gc-level recovery left.
+//
+// nil means the two classes share a store — every city that relocates nothing —
+// and the wisp half then runs inside the per-store loop exactly where it always
+// did, once per scope. It is hoisted out of the loop only when wispStore is
+// distinct, because that store is city-level: sweeping it once per scope would
+// re-close the same subtrees and multiply the reported count.
+func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, wispStore beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int, dryRun bool) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
 	}
 	if includeWispSubtrees && len(onlyOrders) == 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("include-wisps requires at least one order name")
 	}
+	perStoreWisps := includeWispSubtrees && wispStore == nil
 	result := orderTrackingSweepResult{}
 	var errs []error
 	for i, store := range stores {
@@ -2315,7 +2333,7 @@ func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, now time
 				break
 			}
 		}
-		partial, err := sweepStaleOrderTrackingWithOptionsLimitMode(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, remainingLimit, dryRun)
+		partial, err := sweepStaleOrderTrackingWithOptionsLimitMode(store, now, staleAfter, onlyOrders, initiator, perStoreWisps, remainingLimit, dryRun)
 		result.trackingClosed += partial.trackingClosed
 		result.wispClosed += partial.wispClosed
 		if err != nil {
@@ -2328,6 +2346,13 @@ func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, now time
 				result.sweptStoreKeys = make(map[string]struct{})
 			}
 			result.sweptStoreKeys[key] = struct{}{}
+		}
+	}
+	if includeWispSubtrees && wispStore != nil {
+		n, err := sweepStaleOrderWispSubtreesMode(wispStore, now.Add(-staleAfter), onlyOrders, initiator, dryRun)
+		result.wispClosed += n
+		if err != nil {
+			errs = append(errs, fmt.Errorf("sweeping order wisp subtrees in the graph binding: %w", err))
 		}
 	}
 	return result, errors.Join(errs...)

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -2309,9 +2309,21 @@ func sweepStaleOrderTrackingAcrossStoresDryRun(stores []beads.Store, wispStore b
 //
 // nil means the two classes share a store — every city that relocates nothing —
 // and the wisp half then runs inside the per-store loop exactly where it always
-// did, once per scope. It is hoisted out of the loop only when wispStore is
-// distinct, because that store is city-level: sweeping it once per scope would
-// re-close the same subtrees and multiply the reported count.
+// did, once per scope.
+//
+// A non-nil wispStore ADDS a place to look; it does not move the search. The
+// per-scope stores keep their wisp half because a converged split city holds
+// wisp roots in both classes: every subtree born before cutover stayed in the
+// work ledger, and `gc order run` still mints its root through the unrouted
+// scope store. Those roots hold their order's gate shut just as hard — the gate
+// federates over both stores — so trading the work half for the graph half only
+// swaps which stalled wisp has no recovery.
+//
+// The binding is swept once, outside the loop, because it is city-level rather
+// than per-scope: sweeping it once per scope would re-close the same subtrees
+// and multiply the reported count. When it is itself one of the swept stores the
+// loop has already covered it, and the hoisted pass is skipped for the same
+// count-once reason.
 func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, wispStore beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int, dryRun bool) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
@@ -2319,7 +2331,7 @@ func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, wispStor
 	if includeWispSubtrees && len(onlyOrders) == 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("include-wisps requires at least one order name")
 	}
-	perStoreWisps := includeWispSubtrees && wispStore == nil
+	perStoreWisps := includeWispSubtrees
 	result := orderTrackingSweepResult{}
 	var errs []error
 	for i, store := range stores {
@@ -2348,7 +2360,7 @@ func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, wispStor
 			result.sweptStoreKeys[key] = struct{}{}
 		}
 	}
-	if includeWispSubtrees && wispStore != nil {
+	if includeWispSubtrees && wispStore != nil && !storeListContains(stores, wispStore) {
 		n, err := sweepStaleOrderWispSubtreesMode(wispStore, now.Add(-staleAfter), onlyOrders, initiator, dryRun)
 		result.wispClosed += n
 		if err != nil {

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -284,8 +284,16 @@ type orderSetSnapshot struct {
 // ctx OR dispatchCtx is done (see launchDispatchOne). cancel() cancels
 // dispatchCtx.
 type memoryOrderDispatcher struct {
-	aa                   []orders.Order
-	storeFn              orderStoreFunc
+	aa      []orders.Order
+	storeFn orderStoreFunc
+	// storageRoutes is the opened non-work storage binding this process
+	// resolved at boot. It is the graph leg of a wisp dispatch: the molecule a
+	// formula order materializes is graph class (coordclass classifies wisp
+	// roots as ClassGraph), while the order-tracking bead storeFn opens stays
+	// on the order/work side. A nil value relocates nothing, so graphStoreFor
+	// hands back the caller's own store and the dispatch is byte-identical to
+	// the single-store path.
+	storageRoutes        *storageRoutes
 	ep                   events.Provider
 	execRun              ExecRunner
 	rec                  events.Recorder
@@ -329,19 +337,20 @@ type orderTrackingSummary struct {
 // buildOrderDispatcher scans formula layers for orders and returns a
 // dispatcher. Returns nil if no auto-dispatchable orders are found.
 // Scans both city-level and per-rig orders. Rig orders get their Rig
-// field stamped so they use independent scoped labels.
-func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) orderDispatcher {
-	od, _ := buildOrderDispatcherWithSnapshot(cityPath, cfg, rec, stderr, "gc start: order scan")
+// field stamped so they use independent scoped labels. routes is the caller's
+// resolved storage binding; nil is the identity routing of a single-store city.
+func buildOrderDispatcher(routes *storageRoutes, cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) orderDispatcher { //nolint:unparam // routes is nil in current callers but is the storage binding a production caller must pass
+	od, _ := buildOrderDispatcherWithSnapshot(routes, cityPath, cfg, rec, stderr, "gc start: order scan")
 	return od
 }
 
-func buildOrderDispatcherWithSnapshot(cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer, cmdName string) (orderDispatcher, orderSetSnapshot) {
+func buildOrderDispatcherWithSnapshot(routes *storageRoutes, cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer, cmdName string) (orderDispatcher, orderSetSnapshot) {
 	snapshot, err := scanOrderSetSnapshotFS(fsys.OSFS{}, cityPath, cfg, stderr, cmdName)
 	if err != nil {
 		logDispatchError(stderr, "%s: %v", cmdName, err)
 		return nil, orderSetSnapshot{}
 	}
-	return buildOrderDispatcherFromOrderSet(cityPath, cfg, snapshot.Orders, rec, stderr), snapshot
+	return buildOrderDispatcherFromOrderSet(routes, cityPath, cfg, snapshot.Orders, rec, stderr), snapshot
 }
 
 func scanOrderSetSnapshotFS(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer, cmdName string) (orderSetSnapshot, error) {
@@ -390,7 +399,7 @@ func orderSetSignature(aa []orders.Order) string {
 	return fmt.Sprintf("%x", sum[:])
 }
 
-func buildOrderDispatcherFromOrderSet(cityPath string, cfg *config.City, allAA []orders.Order, rec events.Recorder, stderr io.Writer) orderDispatcher {
+func buildOrderDispatcherFromOrderSet(routes *storageRoutes, cityPath string, cfg *config.City, allAA []orders.Order, rec events.Recorder, stderr io.Writer) orderDispatcher {
 	if cfg == nil {
 		cfg = &config.City{}
 	}
@@ -408,14 +417,17 @@ func buildOrderDispatcherFromOrderSet(cityPath string, cfg *config.City, allAA [
 		return nil
 	}
 
-	return newMemoryOrderDispatcher(auto, cityPath, cfg, rec, stderr)
+	return newMemoryOrderDispatcher(routes, auto, cityPath, cfg, rec, stderr)
 }
 
 // newMemoryOrderDispatcher builds a memoryOrderDispatcher over a resolved order
 // set. aa is the tick loop's auto-dispatchable set; it may be nil for callers
 // that only fire pre-resolved orders through the orderdispatch.Dispatcher seam
 // (the webhook receiver), where the tick dispatch() path is never invoked.
-func newMemoryOrderDispatcher(aa []orders.Order, cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) *memoryOrderDispatcher {
+// routes is the storage binding the caller already opened, so a dispatched wisp
+// materializes in the same graph store the rest of the process reads; nil is
+// the identity routing of a single-store city.
+func newMemoryOrderDispatcher(routes *storageRoutes, aa []orders.Order, cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) *memoryOrderDispatcher {
 	if cfg == nil {
 		cfg = &config.City{}
 	}
@@ -432,6 +444,7 @@ func newMemoryOrderDispatcher(aa []orders.Order, cityPath string, cfg *config.Ci
 		storeFn: func(target execStoreTarget) (beads.Store, error) {
 			return openStoreAtForCity(target.ScopeRoot, cityPath)
 		},
+		storageRoutes:        routes,
 		ep:                   ep,
 		execRun:              shellExecRunner,
 		rec:                  rec,
@@ -533,6 +546,17 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		storeKeysForGate := []string{storeKey}
 		if legacyStore != nil {
 			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
+		}
+		// A dispatched wisp root is graph class and carries this order's
+		// order-run label, so on a split city the single-flight gate, the
+		// cooldown clock and the event cursor all have to read the graph store
+		// as well — otherwise an order re-fires while its previous wisp is
+		// still open. When nothing is relocated the graph store IS the target
+		// store, the append is skipped, and the gate reads the exact store list
+		// it always did.
+		if graphStore := m.graphStoreFor(store); graphStore != nil && !storeListContains(storesForGate, graphStore) {
+			storesForGate = append(storesForGate, graphStore)
+			storeKeysForGate = append(storeKeysForGate, m.graphStoreKey())
 		}
 		scoped := a.ScopedName()
 		// NoWorkGate orders (pure probes/sweeps that track no beads) opt out of
@@ -1515,6 +1539,48 @@ func redactOrderEnvError(err error, env []string) string {
 	return execenv.RedactText(err.Error(), env)
 }
 
+// graphStoreFor returns the store that owns the graph beads a dispatch is about
+// to materialize, given the store the tick opened for the order's target.
+//
+// A wisp root and its steps are graph class, and on a split city the graph class
+// is served by a different database than the order's own target store. Creating
+// them through the target store puts graph beads in the work ledger under the
+// work prefix, which the city's own convergence check then reads as graph beads
+// stranded off their binding. When the routes relocate nothing — every
+// single-store city — resolveGraphStore returns the exact store value it was
+// handed, so the dispatch stays on the one store it always used, including the
+// optional-capability assertions (GraphApplyFor, StorageCreateStore) the
+// molecule create makes against it.
+func (m *memoryOrderDispatcher) graphStoreFor(store beads.Store) beads.Store {
+	return resolveGraphStore(m.storageRoutes, store, m.cfg, m.cityPath, m.rec)
+}
+
+// graphStoreKey is the gate/cooldown cache key for the graph store. It names the
+// binding rather than the order's target scope, because one graph binding serves
+// every scope: keying it per target would read the same database once per rig.
+func (m *memoryOrderDispatcher) graphStoreKey() string {
+	binding := ""
+	if m.storageRoutes != nil {
+		binding = m.storageRoutes.binding
+	}
+	if binding == "" {
+		binding = "graph"
+	}
+	return "graph\x00" + binding
+}
+
+// storeListContains reports whether stores already holds this exact store, so a
+// city whose classes collapse onto one store gates on one store rather than the
+// same one twice.
+func storeListContains(stores []beads.Store, want beads.Store) bool {
+	for _, store := range stores {
+		if store == want {
+			return true
+		}
+	}
+	return false
+}
+
 // dispatchWisp instantiates a wisp from the order's formula.
 func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string, vars map[string]string) {
 	scoped := a.ScopedName()
@@ -1595,9 +1661,14 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		}
 	}
 
+	// Everything from here on writes the molecule, which is graph class, so it
+	// goes to the graph store rather than the order-class store the tracking
+	// bead lives in. On a single-store city the two are the same value.
+	graphStore := m.graphStoreFor(store)
+
 	// Route before instantiation. A routing failure must not leave an
 	// unreachable graph in the store while reporting the order as completed.
-	if err := applyOrderRecipeRouting(recipe, pool, vars, target, store, m.cityName, cityPath, m.cfg); err != nil {
+	if err := applyOrderRecipeRouting(recipe, pool, vars, target, graphStore, m.cityName, cityPath, m.cfg); err != nil {
 		logDispatchError(m.stderr, "gc: order %s: routing decoration failed: %v", scoped, err)
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
@@ -1609,7 +1680,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		return
 	}
 
-	cookResult, err := molecule.Instantiate(ctx, store, recipe, molecule.Options{})
+	cookResult, err := molecule.Instantiate(ctx, graphStore, recipe, molecule.Options{})
 	if err != nil {
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
@@ -1622,13 +1693,19 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	}
 	rootID := cookResult.RootID
 	if cookResult.GraphWorkflow {
-		if err := executionevent.EmitCurrent(m.rec, beads.GraphStore{Store: store}, beads.WorkStore{Store: store}, rootID, "order-dispatch"); err != nil {
+		// Two classes, two stores: the graph store owns the root and its steps,
+		// the work store owns the tracks edges of any input convoy the root
+		// names. Wrapping one store as both legs reads the convoy out of the
+		// ledger it does not live in.
+		if err := executionevent.EmitCurrent(m.rec, beads.GraphStore{Store: graphStore}, beads.WorkStore{Store: store}, rootID, "order-dispatch"); err != nil {
 			logDispatchError(m.stderr, "gc: order %s: projecting execution facts for %s: %v", scoped, rootID, err)
 		}
 	}
 
 	// Stamp the created wisp through the store contract rather than a raw
-	// bd subprocess so controller dispatch stays provider-aware.
+	// bd subprocess so controller dispatch stays provider-aware. The label goes
+	// to the store that holds the root; orders.Store's mixed orders+graph reads
+	// are what union it back with the tracking bead's own order-run evidence.
 	update := beads.UpdateOpts{Labels: []string{"order-run:" + scoped}}
 	if a.Trigger == "event" && m.ep != nil {
 		update.Labels = append(update.Labels,
@@ -1639,7 +1716,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if a.Pool != "" {
 		update.Metadata = map[string]string{beadmeta.RoutedToMetadataKey: pool}
 	}
-	if err := store.Update(rootID, update); err != nil {
+	if err := graphStore.Update(rootID, update); err != nil {
 		// Label failure is critical for duplicate-dispatch prevention.
 		// Log and emit an event so operators can investigate.
 		logDispatchError(m.stderr, "gc: order %s: failed to label wisp %s: %v", scoped, rootID, err)

--- a/cmd/gc/order_dispatch_graph_store_test.go
+++ b/cmd/gc/order_dispatch_graph_store_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
-	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
@@ -25,7 +24,6 @@ import (
 // dispatcher tests below fire.
 func newGraphOrderFixture(t *testing.T) (string, *config.City, orders.Order) {
 	t.Helper()
-	formulatest.EnableV2ForTest(t)
 	cityPath := t.TempDir()
 	formulaDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(formulaDir, "reaper.toml"), []byte(`
@@ -42,12 +40,19 @@ metadata = { "gc.run_target" = "worker" }
 	}
 	maxOne, maxTwo := 1, 2
 	cfg := &config.City{
+		Daemon:    config.DaemonConfig{FormulaV2: boolPtr(true)},
 		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{
 			{Name: "worker", MaxActiveSessions: &maxTwo},
 			{Name: config.ControlDispatcherAgentName, MaxActiveSessions: &maxOne},
 		},
 	}
+	// The order's formula declares the graph.v2 contract, so the compiler
+	// capability has to be on for it to compile at all. Derive it from the city
+	// config the way a booting city does, so the dispatch under test runs the
+	// same gate pairing production runs; the cleanup restores the default.
+	applyFeatureFlags(cfg)
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
 	a := orders.Order{
 		Name:         "reaper",
 		Formula:      "reaper",

--- a/cmd/gc/order_dispatch_graph_store_test.go
+++ b/cmd/gc/order_dispatch_graph_store_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -13,26 +14,11 @@ import (
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/runtime"
 )
-
-// splitCityStorageRoutes builds the routes a converged split city runs on: work
-// keeps its own ledger and every infrastructure class — graph included — is
-// served by one shared binding. That is the arrangement storageSplitWhole names
-// and openStorageRoutes produces, so a dispatcher handed these routes resolves
-// classes exactly as it does after a real cutover.
-func splitCityStorageRoutes(infra beads.Store) *storageRoutes {
-	routes := &storageRoutes{stores: make(map[coordclass.Class]beads.Store), binding: "infra"}
-	for _, class := range coordclass.Classes() {
-		if class.IsInfrastructure() {
-			routes.stores[class] = infra
-		}
-	}
-	return routes
-}
 
 // newGraphOrderFixture writes a city-scoped graph.v2 order whose single worker
 // step routes to a city agent, and returns the city path, config and order the
@@ -126,7 +112,7 @@ func TestOrderDispatchWispRootLandsInGraphStoreOnSplitCity(t *testing.T) {
 	m := &memoryOrderDispatcher{
 		aa:                   []orders.Order{a},
 		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
-		storageRoutes:        splitCityStorageRoutes(graphStore),
+		storageRoutes:        messagingSplitRoutes(graphStore),
 		cfg:                  cfg,
 		cityName:             "test-city",
 		cityPath:             cityPath,
@@ -181,7 +167,7 @@ func TestOrderDispatchSingleFlightGateSeesGraphResidentWisp(t *testing.T) {
 	m := &memoryOrderDispatcher{
 		aa:                   []orders.Order{a},
 		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
-		storageRoutes:        splitCityStorageRoutes(graphStore),
+		storageRoutes:        messagingSplitRoutes(graphStore),
 		cfg:                  cfg,
 		cityName:             "test-city",
 		cityPath:             cityPath,
@@ -306,7 +292,7 @@ func TestOrderDispatchExecutionFactsProjectFromTheGraphStore(t *testing.T) {
 	m := &memoryOrderDispatcher{
 		aa:                   []orders.Order{a},
 		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
-		storageRoutes:        splitCityStorageRoutes(graphStore),
+		storageRoutes:        messagingSplitRoutes(graphStore),
 		cfg:                  cfg,
 		cityName:             "test-city",
 		cityPath:             cityPath,
@@ -347,4 +333,332 @@ func TestOrderDispatchExecutionFactsProjectFromTheGraphStore(t *testing.T) {
 	if got := trackingBeads(t, graphStore, labelOrderTracking); len(got) != 0 {
 		t.Fatalf("graph store holds order-tracking beads %+v, want none", got)
 	}
+}
+
+// TestOrderDispatchConstructorDeliversRoutesToTheWispBirth closes the gap
+// between "the routing decision is right" and "the routing decision is reached".
+//
+// Every other test in this file hands memoryOrderDispatcher its storageRoutes as
+// a struct-literal field, which proves dispatchWisp USES the field and nothing
+// about the four-hop argument chain that fills it in production
+// (newCityRuntime/rescan/reload/webhook -> buildOrderDispatcher* ->
+// newMemoryOrderDispatcher). Reverting those call sites to nil is a one-token
+// edit — the shape a rebase or a bad conflict resolution produces — and it
+// leaves build, vet, lint and every routing test green while putting every
+// dispatched wisp back in the work ledger, which is the stranded-graph-bead
+// incident this change exists to fix.
+//
+// So this one builds the dispatcher through the constructor and asserts on
+// behavior. Only storeFn is replaced afterwards, because the production opener
+// would reach for a real bd store; the routes come from the constructor, which
+// is the thing under test.
+func TestOrderDispatchConstructorDeliversRoutesToTheWispBirth(t *testing.T) {
+	cityPath, cfg, a := newGraphOrderFixture(t)
+	workStore := beads.NewMemStore()
+	workStore.IDPrefix = "mc"
+	graphStore := beads.NewMemStore()
+	graphStore.IDPrefix = "gcg"
+
+	var rec memRecorder
+	od := buildOrderDispatcherFromOrderSet(messagingSplitRoutes(graphStore), cityPath, cfg, []orders.Order{a}, &rec, io.Discard)
+	m, ok := od.(*memoryOrderDispatcher)
+	if !ok {
+		t.Fatalf("buildOrderDispatcherFromOrderSet returned %T, want *memoryOrderDispatcher", od)
+	}
+	t.Cleanup(m.dispatchCancel)
+	m.storeFn = func(execStoreTarget) (beads.Store, error) { return workStore, nil }
+	m.maxDispatchesPerTick = 1
+
+	dispatchGraphOrder(t, m, cityPath)
+
+	root := workflowRoot(t, graphStore)
+	if !strings.HasPrefix(root.ID, "gcg-") {
+		t.Fatalf("wisp root id = %q, want the graph binding's %q prefix", root.ID, "gcg-")
+	}
+	for _, b := range allBeads(t, workStore) {
+		if b.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflow {
+			t.Fatalf("wisp root %s was born in the work ledger; the constructor did not carry the storage routes to dispatchWisp", b.ID)
+		}
+	}
+}
+
+// TestOrderDispatcherServesTheBootResolvedBinding pins the three production
+// wiring sites that hand a live CityRuntime's opened binding to its order
+// dispatcher: boot, the order rescan, and a config reload.
+//
+// Pointer identity is the assertion, and it is the point: the dispatcher must
+// serve the binding this process OPENED AT BOOT, not a second resolution of the
+// same config. Storage handles are immutable for the life of a process — a
+// reload that changes [storage] is refused rather than applied — so a dispatcher
+// holding anything other than cr.storageRoutes is holding a handle to a database
+// nothing else in the process is reading.
+func TestOrderDispatcherServesTheBootResolvedBinding(t *testing.T) {
+	cr, tomlPath, _ := bootSplitCityForReloadWithOrder(t)
+
+	assertDispatcherRoutes := func(stage string) {
+		t.Helper()
+		if cr.od == nil {
+			t.Fatalf("%s: the split city has no order dispatcher, so this test asserts nothing", stage)
+		}
+		m, ok := cr.od.(*memoryOrderDispatcher)
+		if !ok {
+			t.Fatalf("%s: cr.od is %T, want *memoryOrderDispatcher", stage, cr.od)
+		}
+		if m.storageRoutes != cr.storageRoutes {
+			t.Fatalf("%s: dispatcher routes = %p, want the runtime's boot-resolved routes %p; every wisp it dispatches is born in the work ledger and lands stranded off the binding",
+				stage, m.storageRoutes, cr.storageRoutes)
+		}
+	}
+
+	assertDispatcherRoutes("boot")
+
+	// The rescan rebuilds the dispatcher only when the order SET changed, so
+	// add an order rather than rescanning an unchanged one.
+	writeCityOrder(t, cr.cityPath, "sweeper")
+	changed, _, err := cr.rescanOrderDispatcher(context.Background(), cr.cityPath, cr.cfg, "test: order scan", time.Now())
+	if err != nil {
+		t.Fatalf("rescanOrderDispatcher: %v", err)
+	}
+	if !changed {
+		t.Fatal("the rescan reported no change, so it never rebuilt the dispatcher and this stage asserts nothing")
+	}
+	assertDispatcherRoutes("after rescanOrderDispatcher")
+
+	// A reload that leaves [storage] alone but changes something else: the
+	// dispatcher is rebuilt, and it must be rebuilt over the same binding.
+	writeSplitCityConfig(t, tomlPath, cr.cfg.Storage.Bindings["infra"].Path, "\n[daemon]\nshutdown_timeout = \"7s\"\n")
+	lastProviderName := "fake"
+	if reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cr.cityPath, nil, reloadSourceManual); reply.Outcome == reloadOutcomeFailed {
+		t.Fatalf("reload failed, so the rebuilt dispatcher proves nothing: %s", reply.Error)
+	}
+	assertDispatcherRoutes("after reloadConfigTraced")
+}
+
+// TestWebhookOrderDispatcherServesTheBootResolvedBinding is the fourth wiring
+// site. The webhook receiver builds its own detached dispatcher per delivery
+// from controllerState rather than reusing cr.od, so it is a separate call to
+// newMemoryOrderDispatcher with its own lock-scoped read of the routes — and a
+// webhook-fired wisp has to land in the same graph store a tick-fired one does.
+func TestWebhookOrderDispatcherServesTheBootResolvedBinding(t *testing.T) {
+	graphStore := beads.NewMemStore()
+	routes := messagingSplitRoutes(graphStore)
+	cs := &controllerState{
+		cityPath:      t.TempDir(),
+		cfg:           &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		storageRoutes: routes,
+	}
+
+	md := controllerWebhookDispatcher{cs: cs}.dispatcher()
+	if md.storageRoutes != routes {
+		t.Fatalf("webhook dispatcher routes = %p, want the controller's %p; a webhook-fired wisp would be born in the work ledger", md.storageRoutes, routes)
+	}
+	if got := md.graphStoreFor(beads.NewMemStore()); got != beads.Store(graphStore) {
+		t.Fatalf("webhook dispatcher graph store = %T(%p), want the binding %p", got, got, graphStore)
+	}
+}
+
+// TestOrderWispForceCloseReachesTheGraphBinding pins the recovery half of the
+// wisp move.
+//
+// This change puts order wisp roots in the graph binding and federates the
+// single-flight gate over it, so a wisp whose agent died mid-run keeps
+// hasOpenWorkStrict returning true and suppresses its order on every tick. The
+// only gc-level force-close for that state is `gc order sweep-tracking
+// --include-wisps`, and its root selection (staleOrderWispRoots, by the
+// "order-run:<name>" label) runs against whatever store it is handed. Handed the
+// work stores, it finds no root, reports wispClosed: 0, exits 0 — and the order
+// stays wedged with no documented recovery but raw bd against the binding.
+func TestOrderWispForceCloseReachesTheGraphBinding(t *testing.T) {
+	workStore := beads.NewMemStore()
+	graphStore := beads.NewMemStore()
+	graphStore.IDPrefix = "gcg"
+
+	root, err := graphStore.Create(beads.Bead{
+		Title:    "reaper wisp",
+		Type:     "molecule",
+		Labels:   []string{"order-run:reaper"},
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create wisp root: %v", err)
+	}
+	child, err := graphStore.Create(beads.Bead{
+		Title:    "reaper step",
+		Type:     "task",
+		ParentID: root.ID,
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("create wisp step: %v", err)
+	}
+
+	onlyOrders := orderFilterForTest("reaper")
+	// Same shape the existing wisp-sweep tests use: push "now" past the fixture
+	// so the whole open subtree sits before the cutoff.
+	now := root.CreatedAt.Add(2 * time.Hour)
+
+	// The regression: sweeping only the work stores is a silent no-op.
+	blind, err := sweepStaleOrderTrackingAcrossStores([]beads.Store{workStore}, nil, now, time.Hour, onlyOrders, true)
+	if err != nil {
+		t.Fatalf("work-store-only sweep: %v", err)
+	}
+	if blind.wispClosed != 0 {
+		t.Fatalf("work-store-only sweep closed %d wisp bead(s); the fixture no longer models a graph-resident wisp", blind.wispClosed)
+	}
+	if got := beadByIDForTest(t, graphStore, root.ID); got.Status == "closed" {
+		t.Fatal("the work-store-only sweep closed the graph-resident root; the fixture is wrong")
+	}
+
+	result, err := sweepStaleOrderTrackingAcrossStores([]beads.Store{workStore}, graphStore, now, time.Hour, onlyOrders, true)
+	if err != nil {
+		t.Fatalf("graph-routed sweep: %v", err)
+	}
+	if result.wispClosed == 0 {
+		t.Fatal("gc order sweep-tracking --include-wisps closed no wisp beads in the graph binding; a stalled graph-resident wisp has no gc-level recovery and its order stays suppressed forever")
+	}
+	for _, id := range []string{root.ID, child.ID} {
+		if got := beadByIDForTest(t, graphStore, id); got.Status != "closed" {
+			t.Fatalf("bead %s status = %q, want closed by the force-close", id, got.Status)
+		}
+	}
+}
+
+// TestOrderWispForceCloseStaysInTheOneStoreOnSingleStoreCity is the
+// compatibility half: a city that relocates nothing resolves no separate wisp
+// store, so the sweep keeps closing wisp subtrees in the same store as the
+// tracking beads, once per scope, exactly as before.
+func TestOrderWispForceCloseStaysInTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityPath := t.TempDir()
+	resetCLIStorageRoutes(t)
+	if got := orderWispSweepStore(cityPath, &config.City{Workspace: config.Workspace{Name: "test-city"}}); got != nil {
+		t.Fatalf("orderWispSweepStore = %T(%p) for a city with no [storage]; want nil so the sweep stays on the store it always used", got, got)
+	}
+
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "reaper wisp",
+		Type:     "molecule",
+		Labels:   []string{"order-run:reaper"},
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create wisp root: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "reaper step",
+		Type:     "task",
+		ParentID: root.ID,
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	}); err != nil {
+		t.Fatalf("create wisp step: %v", err)
+	}
+	result, err := sweepStaleOrderTrackingAcrossStores([]beads.Store{store}, nil, root.CreatedAt.Add(2*time.Hour), time.Hour, orderFilterForTest("reaper"), true)
+	if err != nil {
+		t.Fatalf("single-store sweep: %v", err)
+	}
+	if result.wispClosed == 0 {
+		t.Fatal("single-store sweep closed no wisp beads; the per-store wisp half was lost")
+	}
+	if got := beadByIDForTest(t, store, root.ID); got.Status != "closed" {
+		t.Fatalf("wisp root status = %q, want closed", got.Status)
+	}
+}
+
+func beadByIDForTest(t *testing.T, store beads.Store, id string) beads.Bead {
+	t.Helper()
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("get %s: %v", id, err)
+	}
+	return b
+}
+
+// bootSplitCityForReloadWithOrder boots a split city that actually has an order,
+// so its runtime has a real order dispatcher to assert on. Orders are discovered
+// from <city>/orders/<name>.toml, not from city.toml, so the order file is
+// written before the runtime boots and survives the reloads below.
+func bootSplitCityForReloadWithOrder(t *testing.T) (*CityRuntime, string, *bytes.Buffer) {
+	t.Helper()
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeSplitCityConfig(t, tomlPath, filepath.Join(t.TempDir(), "store"), "")
+
+	writeCityOrder(t, cityPath, "reaper")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	stubInfraMigrationSource(t)
+
+	sp := runtime.NewFake()
+	var stdout, stderr bytes.Buffer
+	cr := newTestCityRuntime(t, CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if cr.storageRoutes == nil {
+		t.Fatal("the split city opened no storage routes, so nothing below is about a binding")
+	}
+	return cr, tomlPath, &stderr
+}
+
+// writeCityOrder drops a city-scoped cron order on disk. Orders are discovered
+// from <city>/orders/<name>.toml, so adding one is what makes an order rescan
+// report a changed set and rebuild the dispatcher.
+func writeCityOrder(t *testing.T, cityPath, name string) {
+	t.Helper()
+	ordersDir := filepath.Join(cityPath, "orders")
+	if err := os.MkdirAll(ordersDir, 0o755); err != nil {
+		t.Fatalf("mkdir orders: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ordersDir, name+".toml"), []byte(`
+[order]
+exec = "true"
+trigger = "cron"
+schedule = "*/1 * * * *"
+`), 0o644); err != nil {
+		t.Fatalf("write order %s: %v", name, err)
+	}
+}
+
+// TestOrderTrackingSweepResolverPairsTheWispStoreWithTheTrackingStores pins
+// what `gc order sweep-tracking` is handed, which is the other half of the
+// force-close fix: the sweep can only reach the graph binding if its resolver
+// hands the binding over in the first place.
+func TestOrderTrackingSweepResolverPairsTheWispStoreWithTheTrackingStores(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+
+	t.Run("split city resolves the graph binding", func(t *testing.T) {
+		cityPath := t.TempDir()
+		graphStore := beads.NewMemStore()
+		resetCLIStorageRoutes(t)
+		entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+		entry.once.Do(func() { entry.routes = messagingSplitRoutes(graphStore) })
+
+		_, wispStore, _ := orderTrackingSweepStoresForConfigTargets(cityPath, cfg, nil)
+		if wispStore != beads.Store(graphStore) {
+			t.Fatalf("wisp sweep store = %T(%p), want the graph binding %p; --include-wisps would report wispClosed: 0 and exit 0", wispStore, wispStore, graphStore)
+		}
+	})
+
+	t.Run("single-store city resolves none", func(t *testing.T) {
+		cityPath := t.TempDir()
+		resetCLIStorageRoutes(t)
+
+		_, wispStore, _ := orderTrackingSweepStoresForConfigTargets(cityPath, cfg, nil)
+		if wispStore != nil {
+			t.Fatalf("wisp sweep store = %T(%p) for a city with no [storage]; want nil so the sweep stays on the store it always used", wispStore, wispStore)
+		}
+	})
 }

--- a/cmd/gc/order_dispatch_graph_store_test.go
+++ b/cmd/gc/order_dispatch_graph_store_test.go
@@ -564,6 +564,96 @@ func TestOrderWispForceCloseStaysInTheOneStoreOnSingleStoreCity(t *testing.T) {
 	}
 }
 
+// TestOrderWispForceCloseSweepsBothClassesOnASplitCity is the other half of the
+// same recovery, and the two halves are not exclusive.
+//
+// Routing the force-close at the graph binding is only correct if it does not
+// stop looking in the work stores. A converged split city holds wisp roots in
+// both: every subtree born before cutover stayed in the work ledger, and
+// `gc order run` still mints its root through the unrouted scope store. Those
+// roots keep hasOpenWorkStrict returning true — the gate federates over both
+// stores — so a sweep that trades the work half for the graph half leaves them
+// suppressing their order with the same no-gc-level-recovery wedge the graph
+// half was written to close, only with the stores swapped.
+//
+// Both roots are also asserted as a count, not just as a status, because the
+// hoisted binding sweep must stay outside the per-scope loop: a work-half fix
+// that re-swept the binding once per scope would still turn both of these
+// closed while multiplying wispClosed.
+func TestOrderWispForceCloseSweepsBothClassesOnASplitCity(t *testing.T) {
+	workStore := beads.NewMemStore()
+	graphStore := beads.NewMemStore()
+	graphStore.IDPrefix = "gcg"
+
+	workRoot, workChild := seedOrderWispSubtreeForTest(t, workStore, "reaper")
+	graphRoot, graphChild := seedOrderWispSubtreeForTest(t, graphStore, "reaper")
+
+	now := workRoot.CreatedAt.Add(2 * time.Hour)
+	result, err := sweepStaleOrderTrackingAcrossStores([]beads.Store{workStore}, graphStore, now, time.Hour, orderFilterForTest("reaper"), true)
+	if err != nil {
+		t.Fatalf("split-city sweep: %v", err)
+	}
+
+	for _, id := range []string{workRoot.ID, workChild.ID} {
+		if got := beadByIDForTest(t, workStore, id); got.Status != "closed" {
+			t.Fatalf("work-resident wisp bead %s status = %q, want closed; --include-wisps stopped sweeping the work stores, so a work-resident wisp root has no gc-level force-close and keeps its order suppressed on every tick", id, got.Status)
+		}
+	}
+	for _, id := range []string{graphRoot.ID, graphChild.ID} {
+		if got := beadByIDForTest(t, graphStore, id); got.Status != "closed" {
+			t.Fatalf("graph-resident wisp bead %s status = %q, want closed", id, got.Status)
+		}
+	}
+	if result.wispClosed != 4 {
+		t.Fatalf("wispClosed = %d, want 4 (both subtrees, each closed once)", result.wispClosed)
+	}
+}
+
+// TestOrderWispForceCloseCountsAStoreServingBothClassesOnce pins the reason the
+// binding sweep is hoisted out of the per-scope loop: a city whose graph binding
+// IS one of the swept stores must report its subtree once, not twice. Dry-run is
+// the mode that can actually double-count — the live path skips an
+// already-closed root on the second pass and would hide the double sweep.
+func TestOrderWispForceCloseCountsAStoreServingBothClassesOnce(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := seedOrderWispSubtreeForTest(t, store, "reaper")
+
+	now := root.CreatedAt.Add(2 * time.Hour)
+	result, err := sweepStaleOrderTrackingAcrossStoresDryRun([]beads.Store{store}, store, now, time.Hour, orderFilterForTest("reaper"), true)
+	if err != nil {
+		t.Fatalf("collapsed-class dry-run sweep: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("dry-run wispClosed = %d, want 2; one store serving both classes was swept twice and the operator is told twice as much work is stale as there is", result.wispClosed)
+	}
+}
+
+// seedOrderWispSubtreeForTest creates the open wisp root and step the stale-wisp
+// force-close selects on: the "order-run:<name>" label plus gc.kind=workflow is
+// what staleOrderWispRoots matches.
+func seedOrderWispSubtreeForTest(t *testing.T, store beads.Store, order string) (beads.Bead, beads.Bead) {
+	t.Helper()
+	root, err := store.Create(beads.Bead{
+		Title:    order + " wisp",
+		Type:     "molecule",
+		Labels:   []string{"order-run:" + order},
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create wisp root: %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    order + " step",
+		Type:     "task",
+		ParentID: root.ID,
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("create wisp step: %v", err)
+	}
+	return root, child
+}
+
 func beadByIDForTest(t *testing.T, store beads.Store, id string) beads.Bead {
 	t.Helper()
 	b, err := store.Get(id)

--- a/cmd/gc/order_dispatch_graph_store_test.go
+++ b/cmd/gc/order_dispatch_graph_store_test.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// splitCityStorageRoutes builds the routes a converged split city runs on: work
+// keeps its own ledger and every infrastructure class — graph included — is
+// served by one shared binding. That is the arrangement storageSplitWhole names
+// and openStorageRoutes produces, so a dispatcher handed these routes resolves
+// classes exactly as it does after a real cutover.
+func splitCityStorageRoutes(infra beads.Store) *storageRoutes {
+	routes := &storageRoutes{stores: make(map[coordclass.Class]beads.Store), binding: "infra"}
+	for _, class := range coordclass.Classes() {
+		if class.IsInfrastructure() {
+			routes.stores[class] = infra
+		}
+	}
+	return routes
+}
+
+// newGraphOrderFixture writes a city-scoped graph.v2 order whose single worker
+// step routes to a city agent, and returns the city path, config and order the
+// dispatcher tests below fire.
+func newGraphOrderFixture(t *testing.T) (string, *config.City, orders.Order) {
+	t.Helper()
+	formulatest.EnableV2ForTest(t)
+	cityPath := t.TempDir()
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "reaper.toml"), []byte(`
+formula = "reaper"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "sweep"
+title = "Reaper sweep"
+metadata = { "gc.run_target" = "worker" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	maxOne, maxTwo := 1, 2
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker", MaxActiveSessions: &maxTwo},
+			{Name: config.ControlDispatcherAgentName, MaxActiveSessions: &maxOne},
+		},
+	}
+	a := orders.Order{
+		Name:         "reaper",
+		Formula:      "reaper",
+		Trigger:      "cooldown",
+		Interval:     "15m",
+		FormulaLayer: formulaDir,
+	}
+	return cityPath, cfg, a
+}
+
+// dispatchGraphOrder fires one tick of the order and waits for the dispatch
+// goroutine to persist its outcome.
+func dispatchGraphOrder(t *testing.T, m *memoryOrderDispatcher, cityPath string) {
+	t.Helper()
+	m.dispatch(context.Background(), cityPath, time.Now())
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer drainCancel()
+	if !m.drain(drainCtx) {
+		t.Fatal("order dispatch did not drain")
+	}
+}
+
+// allBeads returns every bead a store holds, open or closed.
+func allBeads(t *testing.T, store beads.Store) []beads.Bead {
+	t.Helper()
+	list, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("listing beads: %v", err)
+	}
+	return list
+}
+
+// workflowRoot returns the graph.v2 workflow root a dispatch materialized.
+func workflowRoot(t *testing.T, store beads.Store) beads.Bead {
+	t.Helper()
+	for _, b := range allBeads(t, store) {
+		if b.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflow {
+			return b
+		}
+	}
+	t.Fatalf("no graph.v2 workflow root in store; beads = %+v", allBeads(t, store))
+	return beads.Bead{}
+}
+
+// TestOrderDispatchWispRootLandsInGraphStoreOnSplitCity pins the producer half
+// of the graph-store split for order dispatch. coordclass classifies a wisp root
+// as ClassGraph, so on a city whose graph class is served by its own binding the
+// molecule an order materializes must be created in — and minted by — that
+// binding. Creating it through the order's own target store puts graph beads in
+// the work ledger under the work prefix, and the city's convergence check then
+// reads them as graph-class beads stranded off their binding.
+func TestOrderDispatchWispRootLandsInGraphStoreOnSplitCity(t *testing.T) {
+	cityPath, cfg, a := newGraphOrderFixture(t)
+	workStore := beads.NewMemStore()
+	workStore.IDPrefix = "mc"
+	graphStore := beads.NewMemStore()
+	graphStore.IDPrefix = "gcg"
+
+	var rec memRecorder
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:                   []orders.Order{a},
+		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
+		storageRoutes:        splitCityStorageRoutes(graphStore),
+		cfg:                  cfg,
+		cityName:             "test-city",
+		cityPath:             cityPath,
+		rec:                  &rec,
+		stderr:               io.Discard,
+		maxDispatchesPerTick: 1,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       cancel,
+	}
+	dispatchGraphOrder(t, m, cityPath)
+
+	if rec.hasType(events.OrderFailed) || !rec.hasType(events.OrderCompleted) {
+		t.Fatalf("events = %+v, want completed without failure", rec.events)
+	}
+
+	root := workflowRoot(t, graphStore)
+	if !strings.HasPrefix(root.ID, "gcg-") {
+		t.Fatalf("wisp root id = %q, want the graph binding's %q prefix", root.ID, "gcg-")
+	}
+	if !hasLabel(root.Labels, "order-run:reaper") {
+		t.Fatalf("wisp root labels = %v, want order-run:reaper stamped in the graph store", root.Labels)
+	}
+
+	for _, b := range allBeads(t, workStore) {
+		if kind := b.Metadata[beadmeta.KindMetadataKey]; kind != "" {
+			t.Fatalf("work store holds graph bead %s (%s, gc.kind=%q); graph beads belong in the graph binding", b.ID, b.Title, kind)
+		}
+	}
+	for _, b := range allBeads(t, graphStore) {
+		if hasLabel(b.Labels, labelOrderTracking) {
+			t.Fatalf("graph store holds order-tracking bead %s; order tracking stays on the order store", b.ID)
+		}
+	}
+}
+
+// TestOrderDispatchSingleFlightGateSeesGraphResidentWisp pins the read half of
+// the same move. The wisp root carries this order's order-run label, and it is
+// the evidence the wisp-aware open-work gate uses to suppress a re-fire while
+// the previous run is still in flight. Once the root lives in the graph binding,
+// a gate that only scans the order's target store finds nothing and the order
+// re-dispatches on every tick.
+func TestOrderDispatchSingleFlightGateSeesGraphResidentWisp(t *testing.T) {
+	cityPath, cfg, a := newGraphOrderFixture(t)
+	workStore := beads.NewMemStore()
+	workStore.IDPrefix = "mc"
+	graphStore := beads.NewMemStore()
+	graphStore.IDPrefix = "gcg"
+
+	var rec memRecorder
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:                   []orders.Order{a},
+		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
+		storageRoutes:        splitCityStorageRoutes(graphStore),
+		cfg:                  cfg,
+		cityName:             "test-city",
+		cityPath:             cityPath,
+		rec:                  &rec,
+		stderr:               io.Discard,
+		maxDispatchesPerTick: 1,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       cancel,
+	}
+	dispatchGraphOrder(t, m, cityPath)
+	firstRoot := workflowRoot(t, graphStore)
+
+	// The order's cooldown is 15m, so drop the tracking-bead evidence and the
+	// cooldown cache to leave the still-open wisp root as the only thing that
+	// can hold the gate shut.
+	for _, b := range allBeads(t, workStore) {
+		if err := workStore.Delete(b.ID); err != nil {
+			t.Fatalf("deleting %s: %v", b.ID, err)
+		}
+	}
+	m.cacheMu.Lock()
+	m.lastRunCache = nil
+	m.cacheMu.Unlock()
+
+	hasOpen, err := m.hasOpenWorkInStoresStrict([]beads.Store{workStore, graphStore}, "reaper")
+	if err != nil {
+		t.Fatalf("open-work gate: %v", err)
+	}
+	if !hasOpen {
+		t.Fatalf("open-work gate did not see open wisp root %s in the graph store", firstRoot.ID)
+	}
+
+	m.dispatch(context.Background(), cityPath, time.Now())
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer drainCancel()
+	if !m.drain(drainCtx) {
+		t.Fatal("second order dispatch did not drain")
+	}
+	var roots int
+	for _, b := range allBeads(t, graphStore) {
+		if b.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflow {
+			roots++
+		}
+	}
+	if roots != 1 {
+		t.Fatalf("workflow roots in the graph store = %d, want 1; the gate re-fired the order while %s was still open", roots, firstRoot.ID)
+	}
+}
+
+// TestOrderDispatchWispStaysOnTheOneStoreOnSingleStoreCity is the compatibility
+// guarantee: a city that relocates nothing routes nothing. The dispatcher must
+// hand the molecule create the exact store value it was already using — not a
+// re-wrapped one, which would drop the optional-capability assertions the
+// create path makes — and the wisp must keep minting under that store's prefix.
+func TestOrderDispatchWispStaysOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityPath, cfg, a := newGraphOrderFixture(t)
+	store := beads.NewMemStore()
+
+	var rec memRecorder
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:                   []orders.Order{a},
+		storeFn:              func(execStoreTarget) (beads.Store, error) { return store, nil },
+		storageRoutes:        nil, // no [storage] section: every class is the work store
+		cfg:                  cfg,
+		cityName:             "test-city",
+		cityPath:             cityPath,
+		rec:                  &rec,
+		stderr:               io.Discard,
+		maxDispatchesPerTick: 1,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       cancel,
+	}
+	if got := m.graphStoreFor(store); got != beads.Store(store) {
+		t.Fatalf("graphStoreFor returned %T(%p), want the identical store value %p", got, got, store)
+	}
+	dispatchGraphOrder(t, m, cityPath)
+
+	if rec.hasType(events.OrderFailed) || !rec.hasType(events.OrderCompleted) {
+		t.Fatalf("events = %+v, want completed without failure", rec.events)
+	}
+	root := workflowRoot(t, store)
+	if !strings.HasPrefix(root.ID, "gc-") {
+		t.Fatalf("wisp root id = %q, want the single store's %q prefix", root.ID, "gc-")
+	}
+	if !hasLabel(root.Labels, "order-run:reaper") {
+		t.Fatalf("wisp root labels = %v, want order-run:reaper", root.Labels)
+	}
+	tracking := trackingBeads(t, store, "order-run:reaper")
+	if len(tracking) == 0 {
+		t.Fatal("no order-run beads in the single store")
+	}
+	var foundTracking bool
+	for _, b := range tracking {
+		if hasLabel(b.Labels, labelOrderTracking) {
+			foundTracking = true
+		}
+	}
+	if !foundTracking {
+		t.Fatalf("order-run beads = %+v, want the tracking bead colocated with the wisp", tracking)
+	}
+}
+
+// TestOrderDispatchExecutionFactsProjectFromTheGraphStore pins the two
+// event-emission legs. The graph store exclusively owns the workflow root and
+// its physical steps; the work store owns the tracks edges of any input convoy
+// the root names. Wrapping one store as both legs projects the snapshot out of
+// whichever ledger happens to hold the root, so on a split city the emitted
+// step-definition subjects are work-store ids for beads the graph binding is
+// supposed to own.
+func TestOrderDispatchExecutionFactsProjectFromTheGraphStore(t *testing.T) {
+	cityPath, cfg, a := newGraphOrderFixture(t)
+	workStore := beads.NewMemStore()
+	workStore.IDPrefix = "mc"
+	graphStore := beads.NewMemStore()
+	graphStore.IDPrefix = "gcg"
+
+	var rec memRecorder
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:                   []orders.Order{a},
+		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
+		storageRoutes:        splitCityStorageRoutes(graphStore),
+		cfg:                  cfg,
+		cityName:             "test-city",
+		cityPath:             cityPath,
+		rec:                  &rec,
+		stderr:               io.Discard,
+		maxDispatchesPerTick: 1,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       cancel,
+	}
+	dispatchGraphOrder(t, m, cityPath)
+
+	var subjects []string
+	rec.mu.Lock()
+	for _, e := range rec.events {
+		if e.Type == events.ExecutionStepDefined {
+			subjects = append(subjects, e.Subject)
+		}
+	}
+	rec.mu.Unlock()
+	if len(subjects) == 0 {
+		t.Fatalf("events = %+v, want execution step-definition facts projected from the graph store", rec.events)
+	}
+	for _, subject := range subjects {
+		if _, err := graphStore.Get(subject); err != nil {
+			t.Fatalf("step-definition subject %q not in the graph store: %v", subject, err)
+		}
+		if _, err := workStore.Get(subject); !errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("step-definition subject %q resolves in the work store (err = %v); the graph leg projected from the wrong class", subject, err)
+		}
+	}
+
+	// The work leg stays the order's own store, so the two classes end the
+	// dispatch in their own bindings rather than piled into one.
+	tracking := trackingBeads(t, workStore, "order-run:reaper")
+	if len(tracking) == 0 {
+		t.Fatal("no order-run tracking bead in the work store")
+	}
+	if got := trackingBeads(t, graphStore, labelOrderTracking); len(got) != 0 {
+		t.Fatalf("graph store holds order-tracking beads %+v, want none", got)
+	}
+}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4374,6 +4374,7 @@ func TestSweepStaleOrderTrackingAcrossStoresClosesRigStoreAndUnblocksDispatch(t 
 
 	result, err := sweepStaleOrderTrackingAcrossStores(
 		[]beads.Store{rigStore, legacyStore},
+		nil,
 		stale.CreatedAt.Add(time.Hour),
 		time.Minute,
 		orderFilterForTest("rig-digest:rig:frontend"),
@@ -4438,6 +4439,7 @@ func TestSweepStaleOrderTrackingAcrossStoresContinuesAfterStoreError(t *testing.
 
 	result, err := sweepStaleOrderTrackingAcrossStores(
 		[]beads.Store{failingStore, cityStore, rigStore},
+		nil,
 		cityStale.CreatedAt.Add(time.Hour),
 		time.Minute,
 		nil,

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -270,7 +270,7 @@ func (s strictCloseReasonStore) CloseAll(ids []string, metadata map[string]strin
 }
 
 func TestOrderDispatcherNil(t *testing.T) {
-	ad := buildOrderDispatcher(t.TempDir(), &config.City{}, events.Discard, &bytes.Buffer{})
+	ad := buildOrderDispatcher(nil, t.TempDir(), &config.City{}, events.Discard, &bytes.Buffer{})
 	if ad != nil {
 		t.Error("expected nil dispatcher for empty orders")
 	}
@@ -280,7 +280,7 @@ func TestBuildOrderDispatcherNoOrders(t *testing.T) {
 	// City with formula layers that exist but contain no orders.
 	dir := t.TempDir()
 	cfg := &config.City{}
-	ad := buildOrderDispatcher(dir, cfg, events.Discard, &bytes.Buffer{})
+	ad := buildOrderDispatcher(nil, dir, cfg, events.Discard, &bytes.Buffer{})
 	if ad != nil {
 		t.Error("expected nil dispatcher when no orders exist")
 	}
@@ -6538,7 +6538,7 @@ pool = "polecat"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(t.TempDir(), cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, t.TempDir(), cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -6819,7 +6819,7 @@ pool = "worker"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, cityDir, cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -6888,7 +6888,7 @@ pool = "worker"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, cityDir, cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -6970,7 +6970,7 @@ pool = "dog"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, cityDir, cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -7059,7 +7059,7 @@ pool = "worker"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, cityDir, cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -7334,7 +7334,7 @@ pool = "worker"
 		},
 	}
 
-	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &bytes.Buffer{})
+	ad := buildOrderDispatcher(nil, cityDir, cfg, events.Discard, &bytes.Buffer{})
 	if ad == nil {
 		t.Fatal("expected non-nil dispatcher")
 	}
@@ -7406,7 +7406,7 @@ interval = "2m"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(t.TempDir(), cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, t.TempDir(), cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -7473,7 +7473,7 @@ interval = "2m"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(t.TempDir(), cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, t.TempDir(), cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -7549,7 +7549,7 @@ interval = "2m"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(t.TempDir(), cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, t.TempDir(), cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
 	}
@@ -7603,7 +7603,7 @@ interval = "30s"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(t.TempDir(), cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, t.TempDir(), cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("expected non-nil dispatcher (beads-health should still be found); stderr: %s", stderr.String())
 	}

--- a/cmd/gc/order_enabled_filter_test.go
+++ b/cmd/gc/order_enabled_filter_test.go
@@ -42,7 +42,7 @@ func TestBuildOrderDispatcherOverrideDisablesOrder(t *testing.T) {
 	cityDir, cfg := newOrderEnabledFilterCity(t)
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, cityDir, cfg, events.Discard, &stderr)
 	if ad == nil {
 		t.Fatalf("buildOrderDispatcher returned nil; stderr: %s", stderr.String())
 	}

--- a/cmd/gc/order_scan_contract_test.go
+++ b/cmd/gc/order_scan_contract_test.go
@@ -236,7 +236,7 @@ trigger = "manual"
 	}
 
 	var stderr bytes.Buffer
-	ad := buildOrderDispatcher(cityPath, cfg, events.Discard, &stderr)
+	ad := buildOrderDispatcher(nil, cityPath, cfg, events.Discard, &stderr)
 	if ad != nil {
 		t.Error("expected nil dispatcher — manual-trigger orders must be excluded from auto-dispatch")
 	}

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -600,7 +600,16 @@ func orderTrackingSweepTargetsForConfig(cityPath string, cfg *config.City) []ord
 	return targets
 }
 
-func orderTrackingSweepStoresForConfigTargets(cityPath string, cfg *config.City, requiredTargets map[string][]string) ([]beads.Store, error) {
+// orderTrackingSweepStoresForConfigTargets returns the per-scope ORDER stores a
+// sweep closes tracking beads in, together with the store its wisp-subtree half
+// has to run against when that is a different database.
+//
+// The two are returned together on purpose. `gc order sweep-tracking
+// --include-wisps` sweeps two coordination classes, and a caller that resolves
+// the tracking stores and forgets the wisp store gets a sweep that reports
+// wispClosed: 0 on a split city and exits 0 — the silent no-op this pairing
+// exists to make un-writable.
+func orderTrackingSweepStoresForConfigTargets(cityPath string, cfg *config.City, requiredTargets map[string][]string) ([]beads.Store, beads.Store, error) {
 	targets := orderTrackingSweepTargetsForConfig(cityPath, cfg)
 	if len(requiredTargets) > 0 {
 		filtered := targets[:0]
@@ -611,9 +620,28 @@ func orderTrackingSweepStoresForConfigTargets(cityPath string, cfg *config.City,
 		}
 		targets = filtered
 	}
-	return orderTrackingSweepStoresFromTargets(targets, func(sweepTarget orderTrackingSweepTarget) (beads.Store, error) {
+	stores, err := orderTrackingSweepStoresFromTargets(targets, func(sweepTarget orderTrackingSweepTarget) (beads.Store, error) {
 		return openStoreAtForCity(sweepTarget.target.ScopeRoot, cityPath)
 	})
+	return stores, orderWispSweepStore(cityPath, cfg), err
+}
+
+// orderWispSweepStore returns the store that owns this city's order wisp roots
+// when it is NOT one of the stores orderTrackingSweepStoresForConfigTargets
+// opens — that is, when [storage] serves the graph class from its own binding.
+//
+// nil is the answer for every city that relocates nothing, and it is the signal
+// to keep sweeping wisp subtrees in the same store as the tracking beads. That
+// makes the single-store path byte-identical: resolveGraphStore returns the
+// workStore it is handed when nothing is relocated, and the workStore handed in
+// here is nil.
+//
+// The split-city case is the one this exists for. dispatchWisp creates the wisp
+// root in the graph store and the single-flight gate reads it there, so
+// `gc order sweep-tracking --include-wisps` — the only gc-level force-close for
+// a stalled wisp, and the recovery the docs name — has to look there too.
+func orderWispSweepStore(cityPath string, cfg *config.City) beads.Store {
+	return resolveGraphStore(cliStorageRoutes(cityPath), nil, cfg, cityPath, nil)
 }
 
 func orderTrackingSweepStoresFromTargets(targets []orderTrackingSweepTarget, openStore func(orderTrackingSweepTarget) (beads.Store, error)) ([]beads.Store, error) {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -28,6 +28,13 @@ type MemStore struct {
 	// wrapper — see the class_store optional-capability lesson).
 	DisableConditionalWrites bool
 
+	// IDPrefix replaces the "gc" prefix this store mints ids under. Two real
+	// bead databases mint under different prefixes, which is how an operator
+	// tells which store a bead came from; a test that stands two MemStores up
+	// as different coordination-class bindings needs the same distinction.
+	// Empty keeps the default, so every existing caller mints "gc-<n>".
+	IDPrefix string
+
 	// localStrings holds clone-local key-value data set via SetLocalString,
 	// keyed by bead ID then key. Deliberately excluded from
 	// restoreFrom/snapshot so FileStore's disk persistence never touches it.
@@ -93,7 +100,11 @@ func (m *MemStore) Create(b Bead) (Bead, error) {
 	defer m.mu.Unlock()
 
 	m.seq++
-	b.ID = fmt.Sprintf("gc-%d", m.seq)
+	prefix := m.IDPrefix
+	if prefix == "" {
+		prefix = "gc"
+	}
+	b.ID = fmt.Sprintf("%s-%d", prefix, m.seq)
 	b.Status = "open"
 	if b.Type == "" {
 		b.Type = "task"


### PR DESCRIPTION
## Problem

On a city whose graph class is served by its own storage binding, **every wisp a formula order dispatched was born in the WORK ledger and minted under the WORK prefix.**

`internal/coordclass/class.go` classifies wisp roots as `ClassGraph`. The city's own convergence check therefore reads those beads as graph-class beads residing outside their binding and reports them **stranded** — and stranded is **fatal to boot**.

Measured on maintainer-city: **72 wrong-store `mc-wisp-*` beads accrued in roughly two hours**, a mix of closed and open (e.g. `order:reaper` open). Every one of them was created *after* the city converged onto the split. Left alone, **the city cannot restart.**

The cause is that order dispatch held a single store — the one opened for the order's target scope — and used it for two different coordination classes. It instantiated the molecule through that store, and wrapped that same value as **both** legs of the execution-fact emission:

```go
executionevent.EmitCurrent(m.rec, beads.GraphStore{Store: store}, beads.WorkStore{Store: store}, rootID, "order-dispatch")
```

`internal/orders/store.go` already documents the intended two-leg design (orders class + graph class) and warns: *"never rebase them onto a single class store — that is the single-store-assumption bug the graph-store-split audit root-caused."* The order-dispatch path was the site that still did.

## Fix

Resolve the graph class through the storage routes the process **already opened at boot**, and route the graph-class writes through it.

This is plumbing, not a variable swap. `memoryOrderDispatcher` gained a `storageRoutes *storageRoutes` field, threaded from `CityRuntime.storageRoutes` and `controllerState.storageRoutes` through `buildOrderDispatcher{,WithSnapshot,FromOrderSet}` into `newMemoryOrderDispatcher`. A new `graphStoreFor(store)` delegates to the existing `resolveGraphStore(routes, …)` seam rather than inventing a mechanism. The routes are *passed*, never re-resolved, so a tick-fired wisp and a webhook-fired wisp land in the same store the rest of the process reads.

Routed through the graph store in `dispatchWisp`: the graph-routing decoration, `molecule.Instantiate`, the root's `order-run:` label stamp, and the graph leg of the emission. The order-tracking bead stays on the order/work store. The double-wrap becomes two distinct stores:

```go
executionevent.EmitCurrent(m.rec, beads.GraphStore{Store: graphStore}, beads.WorkStore{Store: store}, rootID, "order-dispatch")
```

**The gate/cooldown/cursor federation is part of the fix, not a bonus.** The wisp root carries this order's `order-run:<scoped>` label, and that label is exactly what the wisp-aware single-flight gate, the cooldown clock and the event cursor read. Once the root lives in the graph binding, a gate that only scans the order's target store finds nothing — so **the order re-dispatches on every tick while its previous wisp is still open.** The dispatcher's gate store federation therefore gains the graph store (deduplicated by store identity), which is precisely what `orders.NewStoreWithGraph`'s union was built for.

## Single-store compatibility

Byte-identical. `resolveGraphStore` returns the **exact store value it was handed** when the routes relocate nothing (every city with no `[storage]` section), so:

- the molecule create sees the same instance, preserving the `GraphApplyFor` / `StorageCreateStore` optional-capability assertions it makes against it — no re-wrapping;
- the gate federation's append is skipped by the identity check, so the gate reads the same store list, with the same cache keys, that it always did.

Stated plainly: **the single-store compatibility test is green both before and after this change, by design.** A compatibility guard that went red on revert would be testing the wrong thing. Its teeth were proven by mutation instead — making `graphStoreFor` return a fresh store when routes are nil:

```
graphStoreFor returned *beads.MemStore(0x1928e42b4240), want the identical store value 0x1928e42b41b0
```

## Tests

Four new tests in `cmd/gc/order_dispatch_graph_store_test.go`, all driving the real `dispatch()` → `drain()` path against a `storageRoutes` value shaped exactly like the converged whole-split binding `openStorageRoutes` produces.

Red-before evidence (reverting only the routing decisions, keeping the plumbing so the package still compiles):

| Test | Red-before |
|---|---|
| `TestOrderDispatchWispRootLandsInGraphStoreOnSplitCity` | `order_dispatch_graph_store_test.go:145: no graph.v2 workflow root in store; beads = []` |
| `TestOrderDispatchExecutionFactsProjectFromTheGraphStore` | `order_dispatch_graph_store_test.go:265: step-definition subject "mc-3" not in the graph store: getting bead "mc-3": bead not found` |
| `TestOrderDispatchSingleFlightGateSeesGraphResidentWisp` | `order_dispatch_graph_store_test.go:230: workflow roots in the graph store = 2, want 1; the gate re-fired the order while gcg-1 was still open` |
| `TestOrderDispatchWispStaysOnTheOneStoreOnSingleStoreCity` | green before and after by design; mutation proof above |

The second row is **the production symptom reproduced in a unit test**: `mc-3` is a work-prefixed id for a bead the graph binding is supposed to own — the same class of bead as the 72 `mc-wisp-*` records on maintainer-city.

`internal/beads.MemStore` gained an `IDPrefix` knob so two in-memory stores can stand in as two bindings with distinguishable ids, following the existing `DisableConditionalWrites` precedent on that documented test double. Default is unchanged (`gc-<n>`).

## Gates

- `go build ./...` clean
- `go vet` clean on `cmd/gc`, `internal/beads`, `internal/orders`, `internal/molecule`
- `go test ./cmd/gc -run 'Order|Dispatch|Wisp|Storage|Molecule|Graph'` — ok, 48.2s
- `go test ./internal/{orders,molecule,beads,executionevent}` — ok
- New tests pass under `-race`
- `golangci-lint` 2.10.1 on `./cmd/gc/... ./internal/beads/...` — **0 issues**
- `gofmt` clean

## Follow-ups

This is **PR-1 of a series**. An audit of the same bug class found further sites where a coordination class is born in or read from the wrong store; they are deliberately not bundled here, because each theme needs its own single-store byte-identity proof and its own revert:

- **Boot routing correctness** — the controller's mail provider is constructed before `storageRoutes` is installed, `storageRoutes` is written unlocked while read under `RLock`, and extmsg services are never routed.
- **Remaining graph-class births** — convergence tick, `cmd_formula`, control dispatch.
- **Orders-class births *together with* every reader** — the boot orphan sweep, the tracking watchdog, `gc order check`/`history`, force-close and the API feed must move atomically with the writer. Landing the birth alone would make open tracking beads invisible, the single-flight marker would never clear, and orders would stop firing permanently — strictly worse than the symptom this PR fixes.
- **Read-side API projections** — `internal/api` State exposes no `OrdersBeadStore` and no `MailBeadStore`.

Separately, flagged for an **owner decision rather than a fix**: `internal/storebinding/sqlite/beads_engine.go:55` mints `gcg` for *all* classes, while `reserved_prefixes.go` documents distinct per-class prefixes. Whether the engine or the documented reservation is authoritative is a product call, so this PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Review follow-up (2026-08-08)

Council review found three majors — two reviewers on the same test-coverage defect, one on the recovery path. All are fixed here; the branch is also merged up to `main` (past #5107).

## Majors 1 + 3 — the production plumbing was untested

All four original tests assigned `storageRoutes:` as a struct-literal field. That proves `dispatchWisp` USES the field and nothing about the chain that fills it. The reviewers demonstrated — and I reproduced on this branch — that reverting the four production call sites to `nil` (`city_runtime.go` boot/rescan/reload, `api_state.go`'s webhook seam) leaves `go build`, `go vet`, `golangci-lint` (**0 issues**) and the whole `cmd/gc` suite green, while putting every dispatched wisp back in the work ledger. That is exactly the stranded-graph-bead incident this PR exists to fix, shipping green.

Note the verifier's correction to the original report: deleting `storageRoutes: routes,` inside `newMemoryOrderDispatcher` does **not** ship green — it leaves `routes` unused and revive fires. The call-site revert is the real regression shape, so that is the mutation used as the regression target below.

Three tests close it, and they reach the dispatcher through the constructor rather than around it:

- **`TestOrderDispatchConstructorDeliversRoutesToTheWispBirth`** — builds via `buildOrderDispatcherFromOrderSet(routes, …)`, drives the real `dispatch()` -> `drain()`, and asserts the wisp root mints under the binding's prefix with no workflow root in the work ledger. Only `storeFn` is replaced afterwards (the production opener would reach for a real bd store); the routes come from the constructor, which is the thing under test.
- **`TestOrderDispatcherServesTheBootResolvedBinding`** — boots a real split `CityRuntime` with an order on disk and pins `cr.od.(*memoryOrderDispatcher).storageRoutes == cr.storageRoutes` at boot, after `rescanOrderDispatcher` and after `reloadConfigTraced`. Pointer identity is the point: storage handles are immutable for the life of a process, so a dispatcher holding anything other than the boot-resolved routes is holding a handle to a database nothing else in the process reads. (The rescan stage adds an order first — the rescan only rebuilds when the order SET changed, so without that the stage would assert nothing.)
- **`TestWebhookOrderDispatcherServesTheBootResolvedBinding`** — the fourth site, which builds its own detached dispatcher per delivery. `controllerWebhookDispatcher.Dispatch` is split into a `dispatcher()` builder so what the seam hands the dispatcher is assertable without firing a delivery.

## Major 2 — the stale-wisp force-close still read the work stores

This PR moves order wisp roots into the graph binding and federates the single-flight gate over it. So a wisp whose pool agent dies mid-run leaves the root open with open descendants, `hasOpenWorkStrict` returns true, and the order is suppressed on every tick — while `gc order sweep-tracking --include-wisps`, the only gc-level force-close and the recovery the docs name, scanned the work stores, found no `order-run:<name>` root, reported `wispClosed: 0` and **exited 0**. The controller watchdog cannot help either (it passes `includeWispSubtrees=false`). The order stayed wedged with no recovery but raw `bd` against the binding.

This is a regression this PR introduces, not a pre-existing gap: on `main` the wisp is born in the work store (the bug), so the sweep finds it.

Fixed rather than documented, because "order wedged forever with no documented recovery" is a bad state to ship knowingly, and the seam already existed — `resolveGraphStore(cliStorageRoutes(cityPath), …)` is the same one-shot CLI hop `cmd_formula`, `cmd_sling` and `cmd_convoy_dispatch` already use.

- `sweepStaleOrderTrackingAcrossStores*` take the wisp store alongside the tracking stores. It is hoisted out of the per-scope loop **only when it is distinct**, because the binding is city-level and sweeping it once per scope would re-close the same subtrees and multiply the reported count.
- `orderTrackingSweepStoresForConfigTargets` returns the pair, so a caller cannot resolve the tracking stores and silently forget the wisp store — which is the same untested-wire defect as majors 1+3, and worth not re-introducing one function over.

This is the graph-class half only. The orders-class readers stay where they are; they still have to move atomically with the orders-class writer, which is the separate PR the follow-up list names.

## Single-store compatibility

Unchanged and still byte-identical. `orderWispSweepStore` returns `nil` when the routes relocate nothing (`resolveGraphStore` hands back the `workStore` it was given, and that is `nil` here), and `nil` is the signal to keep sweeping wisp subtrees inside the per-store loop, once per scope, exactly where they were.

## Red-before (mutations on this branch)

| Mutation | Red-before |
|---|---|
| revert all four production call sites to `nil` routes | `boot: dispatcher routes = 0x0, want the runtime's boot-resolved routes 0x…` and `webhook dispatcher routes = 0x0, want the controller's 0x…` |
| rescan site only | `after rescanOrderDispatcher: dispatcher routes = 0x0, want the runtime's boot-resolved routes 0x…` |
| reload site only | `after reloadConfigTraced: dispatcher routes = 0x0, want the runtime's boot-resolved routes 0x…` |
| drop the `storageRoutes` field in `newMemoryOrderDispatcher` | `no graph.v2 workflow root in store; beads = []` |
| keep the wisp sweep per-store only | `gc order sweep-tracking --include-wisps closed no wisp beads in the graph binding; a stalled graph-resident wisp has no gc-level recovery and its order stays suppressed forever` |
| drop the wisp store from the sweep resolver | `wisp sweep store = <nil>, want the graph binding 0x…; --include-wisps would report wispClosed: 0 and exit 0` |

The mutation that matters most is the first: it is the one the verifier proved could ship with build, vet, lint and the entire `cmd/gc` package green.

## Helper dedupe

`splitCityStorageRoutes` is gone; this branch uses `messagingSplitRoutes`, which #5107 landed on `main`. #5108 does the same, so the three near-identical helpers collapse to one without either PR depending on the other's merge order.

## Gates (re-run)

- `go build ./...` clean · `go vet ./...` clean · `gofmt` clean
- `go test ./cmd/gc ./internal/orders/... ./internal/molecule/... ./internal/beads/... ./internal/executionevent/...` — ok
- `golangci-lint` 2.10.1 on `./cmd/gc/...` — **0 issues**
- `scripts/check-core-boundary.sh` OK · `scripts/check-routed-test-rows.sh` OK · native dependency guard OK


---

# Review follow-up 2 (2026-08-08): the wisp sweep traded one class for the other

Council re-review found a Major that this branch introduced while fixing the
graph-side half, and it is right.

## What was wrong

```go
perStoreWisps := includeWispSubtrees && wispStore == nil
```

One non-nil `wispStore` turned the wisp half **off for every store in the
loop**, not just for the hoisted binding. The doc comment justified hoisting
the *binding* out of the loop — "sweeping it once per scope would re-close the
same subtrees and multiply the reported count" — and that rationale never
applied to the per-scope work/order stores, which are distinct databases and
cannot double-count anything.

So on a converged split city `gc order sweep-tracking --include-wisps` looked
**only** in the binding. A work-resident wisp root was unreachable by the only
gc-level force-close there is, while `hasOpenWorkStrict` still federates over
**both** stores (`dispatch()` *appends* the graph store to `storesForGate`
rather than replacing the target), so that root kept its order suppressed on
every tick. That is the same unrecoverable wedge the graph-side fix was written
to close, with the stores swapped — and the command printed
`closed 0 stale order wisp bead(s)` and exited 0, including under `--dry-run`.

Both arms are live, not hypothetical:

1. **Migration residue.** This PR's own problem statement measures 72
   wrong-store `mc-wisp-*` beads on maintainer-city, "a mix of closed and open
   (e.g. `order:reaper` open)". Those are work-ledger-resident open wisp roots.
2. **Ongoing.** `gc order run` still births the wisp through the raw scope
   store (`cmd_order.go:810` → `openOrderStoreForOrder` →
   `openStoreAtForCity`, no class routing), so a converged city keeps minting
   fresh work-resident wisp roots.

## Fix

Sweep both classes instead of trading one for the other. `perStoreWisps` is
`includeWispSubtrees` again, and the hoisted binding pass is guarded so a store
serving both classes is still swept exactly once — which is what the hoist was
actually for:

```go
perStoreWisps := includeWispSubtrees
...
if includeWispSubtrees && wispStore != nil && !storeListContains(stores, wispStore) {
```

`storeListContains` is the identity helper this branch already added for the
gate.

## Tests

| Test | What it pins |
|---|---|
| `TestOrderWispForceCloseSweepsBothClassesOnASplitCity` | a wisp subtree in EITHER class is recoverable, and the count is exact (4, not 2 and not 8) |
| `TestOrderWispForceCloseCountsAStoreServingBothClassesOnce` | the hoist's own reason survives: one store serving both classes reports its subtree once |

Red-before:

```
order_dispatch_graph_store_test.go:599: work-resident wisp bead gc-1 status = "open",
want closed; --include-wisps stopped sweeping the work stores, so a work-resident
wisp root has no gc-level force-close and keeps its order suppressed on every tick
```

The count-once test's teeth, proven by deleting the `storeListContains` guard:

```
order_dispatch_graph_store_test.go:627: dry-run wispClosed = 4, want 2; one store
serving both classes was swept twice and the operator is told twice as much work
is stale as there is
```

Dry-run is the mode that can actually double-count — the live path skips an
already-closed root on the second pass, which would hide a double sweep.

## Single-store compatibility

Still byte-identical, and now by construction rather than by argument:
`wispStore` is `nil` on a single-store city, so
`includeWispSubtrees && wispStore == nil` and `includeWispSubtrees` are the same
value, and the hoisted pass never runs.
`TestOrderWispForceCloseStaysInTheOneStoreOnSingleStoreCity` is green before and
after.

## Gates (re-run)

- `go build ./...` clean · `go vet ./...` clean · `gofmt` clean
- `go test ./cmd/gc -count=1 -timeout 40m` — **ok, 742s**
- `golangci-lint` 2.10.1 on `./cmd/gc/...` — **0 issues**
