### PR TITLE
fix(api): route the controller's messaging class at construction

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -68,9 +68,13 @@ type controllerState struct {
 	beadStores    map[string]beads.Store
 	cityBeadStore beads.Store // city-level store for session beads
 	// storageRoutes is the opened non-work storage binding the city runtime
-	// resolved at boot, installed by CityRuntime.setControllerState. Nil for
-	// every city that authors no [storage] section, and for an API state built
-	// without a runtime — both of which route every class at the work store.
+	// resolved at boot: a constructor input, written once in
+	// newControllerStateWithRoutes and never reassigned, so reads are lock-free
+	// by construction like version/startedAt. It has to arrive at construction
+	// because the class-routed services below (cityMailProv, extmsgSvc) are
+	// built from it there. Nil for every city that authors no [storage] section,
+	// and for an API state built without a runtime — both route every class at
+	// the work store.
 	storageRoutes          *storageRoutes
 	cityBeadsDiagnostic    *beads.BeadsDiagnostic
 	cityMailProv           mail.Provider // city-level mail provider (all mail is city-scoped)
@@ -155,9 +159,35 @@ type configMutationSnapshot struct {
 }
 
 // newControllerState creates a controllerState with per-rig stores.
-// BdStores are wrapped with CachingStore for in-memory reads.
+// BdStores are wrapped with CachingStore for in-memory reads. It takes the
+// identity routing: every coordination class resolves at the work store. Use
+// newControllerStateWithRoutes wherever a city runtime has already opened a
+// storage binding — the class-routed services this constructor builds are built
+// HERE, so routes that arrive afterwards arrive too late to route them.
 func newControllerState(
 	ctx context.Context,
+	cfg *config.City,
+	sp runtime.Provider,
+	ep events.Provider,
+	cityName, cityPath string,
+) *controllerState {
+	return newControllerStateWithRoutes(ctx, nil, cfg, sp, ep, cityName, cityPath)
+}
+
+// newControllerStateWithRoutes creates a controllerState serving the storage
+// binding the city runtime resolved at boot.
+//
+// routes is taken as a parameter rather than installed afterwards because the
+// mail provider and the external-messaging services are constructed inside this
+// function, from the class resolvers, and a controllerState whose routes are
+// assigned after construction builds both of them against the work store on a
+// split city — the messaging class never reaches its binding at all. Passing the
+// routes in also makes the field write-once at construction, which is what
+// removes the unsynchronized second write the API's own RLock-guarded class
+// accessors were racing.
+func newControllerStateWithRoutes(
+	ctx context.Context,
+	routes *storageRoutes,
 	cfg *config.City,
 	sp runtime.Provider,
 	ep events.Provider,
@@ -187,6 +217,7 @@ func newControllerState(
 		cfg:                 cfg,
 		sp:                  sp,
 		cacheCtx:            ctx,
+		storageRoutes:       routes,
 		eventProv:           ep,
 		usageSink:           usageSinkForCity(cfg, cityPath),
 		editor:              configedit.NewEditor(fsys.OSFS{}, tomlPath),
@@ -219,8 +250,7 @@ func newControllerState(
 		cs.cityBeadStore = wrapWithCachingStore(ctx, store, ep, true)
 		cs.cityBeadsDiagnostic = diagnosticPtr(opened.Diagnostic)
 		cs.cityMailProv = newCityMailProvider(cs.storageRoutes, cs.cityBeadStore, cfg, cityPath, ep)
-		svc := extmsg.NewServices(cs.cityBeadStore)
-		cs.extmsgSvc = &svc
+		cs.extmsgSvc = newCityExtMsgServices(cs.storageRoutes, cs.cityBeadStore, cfg, cityPath, ep)
 	}
 	cs.preflightConditionalWrites()
 	cs.storeMetadataSignature = storeMetadataSignature(cityPath, cfg)
@@ -820,8 +850,7 @@ func (cs *controllerState) update(cfg *config.City, sp runtime.Provider) {
 	if cityStore != nil {
 		cityStore = wrapWithCachingStore(cs.cacheCtx, cityStore, cs.eventProv, true)
 		cityMailProv = newCityMailProvider(cs.storageRoutes, cityStore, cfg, cs.cityPath, cs.eventProv)
-		svc := extmsg.NewServices(cityStore)
-		extSvc = &svc
+		extSvc = newCityExtMsgServices(cs.storageRoutes, cityStore, cfg, cs.cityPath, cs.eventProv)
 	}
 
 	// Swap under short critical section.

--- a/cmd/gc/api_state_storage_routes_test.go
+++ b/cmd/gc/api_state_storage_routes_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/gastownhall/gascity/internal/rollout/gate"
+)
+
+// messagingSplitRoutes builds the routes a converged split city runs on: work
+// keeps its own ledger and every infrastructure class is served by one shared
+// binding, which is the arrangement storageSplitWhole names and
+// openStorageRoutes produces.
+func messagingSplitRoutes(infra beads.Store) *storageRoutes {
+	routes := &storageRoutes{stores: make(map[coordclass.Class]beads.Store), binding: "infra"}
+	for _, class := range coordclass.Classes() {
+		if class.IsInfrastructure() {
+			routes.stores[class] = infra
+		}
+	}
+	return routes
+}
+
+// stubControllerCityStore points newControllerState's city-store opener at an
+// in-memory store for the duration of a test.
+func stubControllerCityStore(t *testing.T, store beads.Store) {
+	t.Helper()
+	prev := newControllerStateOpenCityStore
+	newControllerStateOpenCityStore = func(string, gate.Mode) (beads.StoreOpenResult, error) {
+		return beads.StoreOpenResult{Store: store}, nil
+	}
+	t.Cleanup(func() { newControllerStateOpenCityStore = prev })
+}
+
+func newRoutedControllerStateForTest(t *testing.T, routes *storageRoutes, work beads.Store) *controllerState {
+	t.Helper()
+	stubControllerCityStore(t, work)
+	cityPath := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	return newControllerStateWithRoutes(context.Background(), routes, cfg, nil, nil, "test-city", cityPath)
+}
+
+func appendTestTranscript(t *testing.T, svc *extmsg.Services) extmsg.ConversationTranscriptRecord {
+	t.Helper()
+	rec, err := svc.Transcript.Append(context.Background(), extmsg.AppendTranscriptInput{
+		Caller: extmsg.Caller{
+			Kind:      extmsg.CallerAdapter,
+			ID:        "adapter-1",
+			Provider:  "discord",
+			AccountID: "acct-1",
+		},
+		Conversation: extmsg.ConversationRef{
+			ScopeID:        "city-1",
+			Provider:       "discord",
+			AccountID:      "acct-1",
+			ConversationID: "thread-1",
+			Kind:           extmsg.ConversationThread,
+		},
+		Kind:              extmsg.TranscriptMessageInbound,
+		Provenance:        extmsg.TranscriptProvenanceLive,
+		ProviderMessageID: "msg-1",
+		Text:              "hello",
+		CreatedAt:         time.Date(2026, time.March, 23, 9, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("transcript append: %v", err)
+	}
+	return rec
+}
+
+// TestControllerStateRoutesMessagingClassAtConstruction pins the boot-ordering
+// bug. The mail provider and the external-messaging services are BUILT during
+// newControllerState, from the class resolvers. Installing the storage routes
+// after construction — which is what CityRuntime.setControllerState used to do —
+// leaves both of them resolved against the work store forever, so on a split
+// city every message bead and every extmsg record is written to the ledger the
+// messaging class was moved off.
+func TestControllerStateRoutesMessagingClassAtConstruction(t *testing.T) {
+	workStore := beads.NewMemStore()
+	infraStore := beads.NewMemStore()
+
+	cs := newRoutedControllerStateForTest(t, messagingSplitRoutes(infraStore), workStore)
+
+	if cs.cityMailProv == nil {
+		t.Fatal("no city mail provider built")
+	}
+	msg, err := cs.cityMailProv.Send("mayor", "worker", "subject", "body")
+	if err != nil {
+		t.Fatalf("mail send: %v", err)
+	}
+	if _, err := infraStore.Get(msg.ID); err != nil {
+		t.Fatalf("message %q not in the messaging binding: %v", msg.ID, err)
+	}
+	if _, err := workStore.Get(msg.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("message %q resolves in the work store (err = %v); the mail provider was built before the routes arrived", msg.ID, err)
+	}
+
+	if cs.extmsgSvc == nil {
+		t.Fatal("no extmsg services built")
+	}
+	rec := appendTestTranscript(t, cs.extmsgSvc)
+	if _, err := infraStore.Get(rec.ID); err != nil {
+		t.Fatalf("transcript %q not in the messaging binding: %v", rec.ID, err)
+	}
+	if _, err := workStore.Get(rec.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("transcript %q resolves in the work store (err = %v); extmsg was never routed", rec.ID, err)
+	}
+}
+
+// TestControllerStateSingleStoreKeepsMessagingOnTheWorkStore is the
+// compatibility guarantee: a city that relocates nothing routes nothing, so
+// mail and extmsg keep writing to the one store they always did. Green before
+// and after by design — the value it carries is that it goes red if the class
+// resolvers ever stop being identity for an unrelocated class.
+func TestControllerStateSingleStoreKeepsMessagingOnTheWorkStore(t *testing.T) {
+	store := beads.NewMemStore()
+	cs := newRoutedControllerStateForTest(t, nil, store)
+
+	msg, err := cs.cityMailProv.Send("mayor", "worker", "subject", "body")
+	if err != nil {
+		t.Fatalf("mail send: %v", err)
+	}
+	if _, err := store.Get(msg.ID); err != nil {
+		t.Fatalf("message %q not in the single store: %v", msg.ID, err)
+	}
+	rec := appendTestTranscript(t, cs.extmsgSvc)
+	if _, err := store.Get(rec.ID); err != nil {
+		t.Fatalf("transcript %q not in the single store: %v", rec.ID, err)
+	}
+	if got := cs.mailBeadStore().Store; got != cs.cityBeadStore {
+		t.Fatalf("mailBeadStore = %p, want the identical city store %p", got, cs.cityBeadStore)
+	}
+	if got := cs.SessionsBeadStore().Store; got != cs.cityBeadStore {
+		t.Fatalf("SessionsBeadStore = %p, want the identical city store %p", got, cs.cityBeadStore)
+	}
+}
+
+// TestSetControllerStateDoesNotRaceClassAccessors pins the second half of the
+// same bug. The routes used to be written by setControllerState with no lock
+// held, while every class accessor on the API surface reads them under
+// cs.mu.RLock(). Run under -race this fails on the pre-fix code; it passes now
+// because the field is a constructor input, written once and never reassigned.
+func TestSetControllerStateDoesNotRaceClassAccessors(t *testing.T) {
+	store := beads.NewMemStore()
+	stubControllerCityStore(t, store)
+	cityPath := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	cs := newControllerState(context.Background(), cfg, nil, nil, "test-city", cityPath)
+	cr := &CityRuntime{storageRoutes: messagingSplitRoutes(beads.NewMemStore())}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		cr.setControllerState(cs)
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = cs.GraphBeadStore()
+			_ = cs.NudgesBeadStore()
+			_ = cs.SessionsBeadStore()
+			_ = cs.mailBeadStore()
+			_ = cs.ordersBeadStore("")
+		}
+	}()
+	wg.Wait()
+}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -406,14 +406,14 @@ func newCityRuntime(p CityRuntimeParams) (*CityRuntime, error) {
 // setControllerState sets the API state for this city. The controller
 // state is managed by the caller (who also owns the API server), installed
 // before run starts, and never replaced afterward.
+// The routes deliberately do NOT cross here. They are a construction input to
+// newControllerStateWithRoutes, because the class-routed services a
+// controllerState owns — the mail provider and the external-messaging services —
+// are built during construction and cannot be re-pointed by a later assignment.
+// Installing them here also wrote the field without cs.mu while the API's class
+// accessors read it under RLock.
 func (cr *CityRuntime) setControllerState(cs *controllerState) {
 	cr.cs = cs
-	// The API projection reads the same classes through the same routes. This
-	// is the one place the pair is composed, so it is the one place the routes
-	// cross — a second resolution would be a second plan.
-	if cs != nil {
-		cs.storageRoutes = cr.storageRoutes
-	}
 }
 
 // crashTracker returns the crash tracker for API server wiring.

--- a/cmd/gc/class_store.go
+++ b/cmd/gc/class_store.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 // This file is the controller/CLI-side seam of the per-class store refactor.
@@ -311,4 +316,32 @@ func newCityMailProvider(routes *storageRoutes, workStore beads.Store, cfg *conf
 	msgStore := resolveMailMessagesStore(routes, workStore, cfg, cityPath, rec)
 	sessStore := resolveSessionStore(routes, workStore, cfg, cityPath, rec)
 	return newMailProviderWithSessionStore(msgStore, sessStore)
+}
+
+// newCityExtMsgServices builds the controller's external-messaging services as
+// the split Messaging/Sessions form extmsg already exposes: bindings, groups,
+// participants, delivery contexts, memberships and transcripts persist in the
+// messaging-class store, while identity and liveness reads go to the
+// session-class directory.
+//
+// extmsg records are messaging class — they hide under type=task carrying a
+// gc:extmsg-* label, which is exactly why coordclass.Classify is a runtime
+// function and not a type filter. Both classes resolve to the work store at the
+// single-store bd backend, so this is byte-identical to the prior
+// extmsg.NewServices(workStore) and diverges only once a class relocates.
+//
+// A nil session directory is the one thing extmsg refuses, and it cannot happen
+// here: resolveSessionStore returns the work store when sessions are not
+// relocated. On the impossible path the error is reported and the unrouted
+// services are returned rather than dropping external messaging entirely.
+func newCityExtMsgServices(routes *storageRoutes, workStore beads.Store, cfg *config.City, cityPath string, rec events.Recorder) *extmsg.Services {
+	msgStore := resolveMailMessagesStore(routes, workStore, cfg, cityPath, rec)
+	sessStore := resolveSessionStore(routes, workStore, cfg, cityPath, rec)
+	svc, err := extmsg.NewServicesWithSessionDirectory(msgStore, session.NewStore(beads.SessionStore{Store: sessStore}))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "api: external messaging services: %v\n", err) //nolint:errcheck // best-effort stderr
+		unrouted := extmsg.NewServices(workStore)
+		return &unrouted
+	}
+	return &svc
 }

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -2150,7 +2150,7 @@ func reconcileCities(
 		// Wire API state.
 		var cs *controllerState
 		if err := runPostPrepareStep("opening_controller_state", func() error {
-			cs = newControllerState(cityCtx, cfg, sp, eventProv, cityName, path)
+			cs = newControllerStateWithRoutes(cityCtx, cityRuntime.storageRoutes, cfg, sp, eventProv, cityName, path)
 			return nil
 		}); err != nil {
 			// The runtime is already built, and it holds this city's storage

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -1383,7 +1383,7 @@ func runController(
 	// Install controller-managed bead stores even when the HTTP API is
 	// disabled. Standalone runtime still needs cached city/rig stores for
 	// session-bead sync and rig-scoped wake decisions.
-	cs := newControllerState(ctx, cfg, sp, eventProv, cityName, cityPath)
+	cs := newControllerStateWithRoutes(ctx, cr.storageRoutes, cfg, sp, eventProv, cityName, cityPath)
 	cs.ct = cr.crashTrack()
 	cs.pokeCh = pokeCh
 	cs.configDirty = configDirty


### PR DESCRIPTION
## Problem

On a city whose messaging class is served by its own storage binding, **every message bead and every external-messaging record the controller wrote still landed in the WORK ledger.**

Two symptoms, one shape: **the storage routes were installed after the constructors that consume them had already run.**

The controller's mail provider is built *inside* `newControllerState`, from the class resolvers. The routes were installed afterwards, by `CityRuntime.setControllerState`. So `resolveMailMessagesStore` ran while `cs.storageRoutes` was still `nil`, resolved the identity route, and the provider stayed pointed at the work store **for the life of the process** — a later assignment cannot re-point an already-constructed provider.

The external-messaging services were never routed at all. `extmsg.NewServices(cs.cityBeadStore)` took the work store directly, on both the construction path and the reload path, so bindings, groups, participants, delivery contexts, memberships and transcripts were all written to the work ledger regardless of configuration.

That same late assignment was also **a data race**: `setControllerState` wrote `cs.storageRoutes` with no lock held, while every class accessor on the API surface — `GraphBeadStore`, `NudgesBeadStore`, `SessionsBeadStore`, `mailBeadStore`, `ordersBeadStore` — reads it under `cs.mu.RLock()`.

**These are not two bugs that happen to be adjacent. They are the same bug**: a field that arrives after the things that need it, delivered by a second, unsynchronized write.

## Fix

Take the routes as a **constructor input**. `newControllerStateWithRoutes` sets the field before anything that resolves a class is built, and `setControllerState` no longer touches it. The field is now written once at construction and never reassigned, so the race is gone **by construction rather than by locking** — matching how `rolloutFlags` is already handled and documented in that same struct.

Route extmsg through the split Messaging/Sessions form the package **already exposes**: `extmsg.NewServicesWithSessionDirectory` persists bindings, groups, participants, delivery contexts, memberships and transcripts in the messaging-class store, while identity and liveness reads use the session-class directory. This mirrors `newCityMailProvider` exactly rather than introducing a second mechanism.

## Deliberate decision: NO read-union, and one must not be added later

The obvious worry is that routing messaging writes to the binding strands the records already sitting in the work ledger, and that a read-union is needed to keep them reachable. **It is not, and a union would be actively harmful.** Three pieces of evidence, please read them before "helpfully" adding one:

1. **The migration already covers messaging.** `infraMigrationClasses` (`cmd/gc/infra_class_migrate.go:239`) includes `config.StorageClassMessaging`. The storage-class migration copies that class into the binding, **tests equality between source and destination, and only then records convergence.**
2. **Boot refuses an unconverged split.** `storage_boot.go` turns a non-serving verdict into a refusal to start — *"refuses to start the city when config and reality disagree"*, and from the migration file's own header: *"A boot inside that window refuses to start and names the command, so no read is ever served from the wrong side of it."* A **running** split city therefore already has its messaging beads in the binding. This is confirmed in production: maintainer-city refuses boot on an unconverged split (`init_failed` plus the stranded refusal), and its satellites were retained verbatim after migration.
3. **It is a copy, not a move.** The only `.Delete(` in `infra_class_migrate.go` is at `:1292`, on `destination`, as failed-copy cleanup. Source rows remain in the work store. A read-union would therefore **double-count every migrated record** rather than rescue anything.

So there is nothing to strand — the migration plus the boot gate already own that problem — and a union would return duplicates for every record the copy left behind.

## Single-store compatibility

Byte-identical. Both class resolvers return the exact work store value they were handed when nothing is relocated, so the mail provider and the extmsg services are built over the same instance they always were. `TestControllerStateSingleStoreKeepsMessagingOnTheWorkStore` asserts mail and extmsg both land in the one store **and** that `mailBeadStore()` / `SessionsBeadStore()` return the identical `cityBeadStore` instance.

That test is green before *and* after this change, by design — a compatibility guard that went red on revert would be testing the wrong thing.

## Tests

Red-before evidence, reverting **one decision at a time** (keeping the rest so the package still compiles):

| Reverted decision | Red-before |
|---|---|
| routes installed after construction | `api_state_storage_routes_test.go:99: message "gc-1" not in the messaging binding: getting bead "gc-1": bead not found` |
| extmsg left unrouted | `api_state_storage_routes_test.go:110: transcript "gc-2" not in the messaging binding: getting bead "gc-2": bead not found` |
| late assignment restored | `WARNING: DATA RACE` — `Write at 0x00c000edbda8 by goroutine 19107: … city_runtime.go:418` / `Previous read at 0x00c000edbda8 by goroutine 19108` |
| single-store compatibility | green before and after by design |

The race row is the whole reason the field became a constructor input rather than gaining a lock: with the write removed there is no longer anything to synchronize.

## Gates

- `go build ./...` clean
- `go vet` clean on `cmd/gc`, `internal/extmsg`, `internal/mail/...`
- `gofmt` clean
- `go test ./internal/{extmsg,mail,mail/beadmail,mail/exec}` — ok
- `go test ./cmd/gc -run 'ControllerState|Mail|ExtMsg|Extmsg|Storage|Supervisor|Controller'` — ok, 69.5s
- New tests pass under `-race`
- `golangci-lint` 2.10.1 on `./cmd/gc/... ./internal/extmsg/...` — **0 issues**

## Merge-order note

This is **PR-2 of a series**. It is based on `main` and does **not** depend on PR-1 (#5106) — in particular it deliberately does not use the `MemStore.IDPrefix` knob PR-1 adds, asserting by store membership instead.

PR-1 and this PR each define a near-identical `*storageRoutes` test helper in `package main`: `splitCityStorageRoutes` (PR-1, `order_dispatch_graph_store_test.go`) and `messagingSplitRoutes` (here). The names differ so there is no collision either way, but **whichever lands second should collapse them into one helper.**

Remaining themes in the series: the rest of the graph-class births (convergence tick, `cmd_formula`, control dispatch); the orders-class births together with every reader, atomically; and the read-side API projections, where `internal/api` State still exposes no `OrdersBeadStore` and no `MailBeadStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
