### PR TITLE
fix(dispatch): run control dispatch against the graph store

### DIFF
--- a/cmd/gc/class_store.go
+++ b/cmd/gc/class_store.go
@@ -306,6 +306,17 @@ func resolveGraphStore(routes *storageRoutes, workStore beads.Store, cfg *config
 	return resolveClassStore(routes, workStore, cfg, cityPath, config.BeadClassGraph, rec)
 }
 
+// graphClassBinding returns the store these routes serve the graph class from,
+// and whether they relocate it at all — the same question resolveClassStore asks
+// to choose its branch, exposed for the callers that must BEHAVE differently
+// rather than merely read elsewhere. A reader that answers by shelling `bd` in
+// the work directory cannot follow a relocated class, so it has to know it must
+// go in-process instead; resolveGraphStore alone cannot tell it, because a
+// relocated store and an unrelocated one are both just a beads.Store.
+func graphClassBinding(routes *storageRoutes) (beads.Store, bool) {
+	return routes.storeFor(coordclassFor(config.BeadClassGraph))
+}
+
 // newCityMailProvider builds the controller's mail provider as a two-store mail
 // provider: message beads persist in the messaging-class store, and mail's
 // session reads/writes for addressing/identity resolution go to the session-class

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -193,10 +193,12 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 	}
 
 	// store is the SCOPE store. Control beads, the workflow topology they
-	// mutate, and every bead the control kinds create (retry attempts, fanout
-	// fragments, drain units and their convoys) are graph class, so all of that
-	// runs against the graph store. store itself stays the work leg: it owns the
-	// input convoy whose tracks edges the execution snapshot below reads.
+	// mutate, and the graph beads the control kinds create (retry attempts,
+	// fanout fragments, drain item roots) are graph class, so all of that runs
+	// against the graph store. store itself stays the work leg: EVERY convoy is
+	// a work bead, the synthetic drain-unit ones included, so it owns both the
+	// input convoy whose tracks edges the execution snapshot below reads and the
+	// unit convoys a drain mints alongside its members.
 	graphStore := controlGraphStore(cityPath, storePath, cfg, store)
 
 	bead, err := graphStore.Get(beadID)

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -160,7 +160,10 @@ func runControlDispatcherInStore(cityPath, storePath, beadID string, stdout, std
 	if err != nil {
 		return fmt.Errorf("opening scoped control store %q: %w", storePath, err)
 	}
-	bead, err := store.Get(beadID)
+	// The control bead is graph class, so it is read from the graph store — not
+	// from the scope store, which on a split city holds only the copy the
+	// migration retained and no longer receives the workflow's mutations.
+	bead, err := controlGraphStore(cityPath, cfg, store).Get(beadID)
 	if err != nil {
 		return fmt.Errorf("loading bead %s from scoped control store %q: %w", beadID, storePath, err)
 	}
@@ -187,6 +190,13 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 	} else {
 		warnLegacyWorkflowTracePath(cityPath, nil, stderr)
 	}
+
+	// store is the SCOPE store. Control beads, the workflow topology they
+	// mutate, and every bead the control kinds create (retry attempts, fanout
+	// fragments, drain units and their convoys) are graph class, so all of that
+	// runs against the graph store. store itself stays the work leg: it owns the
+	// input convoy whose tracks edges the execution snapshot below reads.
+	graphStore := controlGraphStore(cityPath, cfg, store)
 
 	opts := dispatch.ProcessOptions{CityPath: cityPath, StorePath: storePath}
 	opts.Tracef = workflowTracef
@@ -223,12 +233,12 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 		case "check", "fanout":
 			opts.FormulaSearchPaths = workflowFormulaSearchPaths(cfg, bead)
 			opts.PrepareFragment = func(fragment *formula.FragmentRecipe, source beads.Bead) error {
-				return decorateDynamicFragmentRecipe(fragment, source, store, loadedCityName(cfg, cityPath), cityPath, cfg)
+				return decorateDynamicFragmentRecipe(fragment, source, graphStore, loadedCityName(cfg, cityPath), cityPath, cfg)
 			}
 		case "drain":
 			opts.FormulaSearchPaths = workflowFormulaSearchPaths(cfg, bead)
 			opts.PrepareRecipe = func(recipe *formula.Recipe, source beads.Bead) error {
-				return decorateDrainItemRecipe(recipe, source, store, workflowStoreRefForDir(storePath, cityPath, loadedCityName(cfg, cityPath), cfg), loadedCityName(cfg, cityPath), cityPath, cfg)
+				return decorateDrainItemRecipe(recipe, source, graphStore, workflowStoreRefForDir(storePath, cityPath, loadedCityName(cfg, cityPath), cfg), loadedCityName(cfg, cityPath), cityPath, cfg)
 			}
 		case "retry-eval":
 			sp, err := dispatchControlSessionProvider()
@@ -256,7 +266,7 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 		}
 	}
 
-	result, err := dispatch.ProcessControl(store, bead, opts)
+	result, err := dispatch.ProcessControl(graphStore, bead, opts)
 	if err != nil {
 		if errors.Is(err, dispatch.ErrControlPending) {
 			return err
@@ -264,7 +274,7 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 		if dispatch.IsTransientControllerError(err) {
 			return err
 		}
-		if quarantineErr := quarantineControlFailureBead(store, beadID, err); quarantineErr != nil {
+		if quarantineErr := quarantineControlFailureBead(graphStore, beadID, err); quarantineErr != nil {
 			return errors.Join(err, quarantineErr)
 		}
 		_, _ = fmt.Fprintf(stderr, "control dispatch: quarantined bead=%s reason=%v\n", beadID, err)
@@ -273,7 +283,6 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 	if result.Processed {
 		rootID := strings.TrimSpace(bead.Metadata[beadmeta.RootBeadIDMetadataKey])
 		if rootID != "" {
-			graphStore := resolveGraphStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)
 			recorder := openCityRecorderAt(cityPath, stderr)
 			emitErr := executionevent.EmitCurrent(recorder, beads.GraphStore{Store: graphStore}, beads.WorkStore{Store: store}, rootID, "control-dispatch")
 			var closeErr error
@@ -448,6 +457,30 @@ func sourceWorkflowLockScopeForStoreRef(cityPath string, cfg *config.City, defau
 	})
 }
 
+// controlGraphStore returns the store that owns a control bead and everything
+// its dispatch creates, given the scope store the caller resolved.
+//
+// Control beads are graph class: coordclass counts every gc.kind control bead,
+// and the molecule/step topology they mutate, as ClassGraph. The scope store
+// answers WHICH city or rig; the graph class answers WHICH database inside it.
+// Running control dispatch against the scope store on a split city reads the
+// copy the migration retained in the work ledger and writes the results back
+// there, where no graph-routed reader looks.
+//
+// When the routes relocate nothing this returns the exact store value it was
+// handed, so a single-store city dispatches against the very store it always
+// did — same bd command runner, same scope issue prefix, same instance for the
+// optional-capability assertions (DepListBatch, UpdateAll) the scope-skip paths
+// make against it.
+func controlGraphStore(cityPath string, cfg *config.City, scopeStore beads.Store) beads.Store {
+	return resolveGraphStore(cliStorageRoutes(cityPath), scopeStore, cfg, cityPath, nil)
+}
+
+// openControlStoreAtForCity resolves the control store for a city or rig SCOPE.
+// It answers WHICH scope only; the coordination class — which database within
+// that scope — is applied by controlGraphStore at the point of use, because the
+// control dispatcher needs BOTH: the graph store that owns control beads, and
+// this scope/work store that owns the input convoy an execution snapshot reads.
 func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (beads.Store, error) {
 	scopeRoot := resolveStoreScopeRoot(cityPath, storePath)
 	provider := rawBeadsProviderForScope(scopeRoot, cityPath)

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -130,13 +130,15 @@ func runControlDispatcher(beadID string, stdout, stderr io.Writer) error {
 	}
 
 	// Manual control dispatch keeps the operator convenience of resolving a
-	// bead ID across city and rig stores.
-	store, bead, storePath, err := findBeadAcrossStores(cityPath, beadID, stderr)
+	// bead ID across city and rig stores. That resolution answers WHICH SCOPE
+	// owns the id; the bead the dispatch gates on is read below from the store
+	// it is about to mutate, not from the unrouted scope store searched here.
+	store, storePath, err := findBeadScopeAcrossStores(cityPath, beadID, stderr)
 	if err != nil {
 		return fmt.Errorf("loading bead %s: %w", beadID, err)
 	}
 
-	return runControlDispatcherWithStore(cityPath, storePath, store, bead, beadID, stdout, stderr)
+	return runControlDispatcherWithStore(cityPath, storePath, store, beadID, stdout, stderr)
 }
 
 func runControlDispatcherInStore(cityPath, storePath, beadID string, stdout, stderr io.Writer) error {
@@ -160,22 +162,21 @@ func runControlDispatcherInStore(cityPath, storePath, beadID string, stdout, std
 	if err != nil {
 		return fmt.Errorf("opening scoped control store %q: %w", storePath, err)
 	}
-	// The control bead is graph class, so it is read from the graph store — not
-	// from the scope store, which on a split city holds only the copy the
-	// migration retained and no longer receives the workflow's mutations.
-	bead, err := controlGraphStore(cityPath, cfg, store).Get(beadID)
-	if err != nil {
-		return fmt.Errorf("loading bead %s from scoped control store %q: %w", beadID, storePath, err)
-	}
 
-	return runControlDispatcherWithStoreAndConfig(cityPath, storePath, store, bead, beadID, cfg, stdout, stderr)
+	return runControlDispatcherWithStoreAndConfig(cityPath, storePath, store, beadID, cfg, stdout, stderr)
 }
 
-func runControlDispatcherWithStore(cityPath, storePath string, store beads.Store, bead beads.Bead, beadID string, stdout, stderr io.Writer) error {
-	return runControlDispatcherWithStoreAndConfig(cityPath, storePath, store, bead, beadID, nil, stdout, stderr)
+func runControlDispatcherWithStore(cityPath, storePath string, store beads.Store, beadID string, stdout, stderr io.Writer) error {
+	return runControlDispatcherWithStoreAndConfig(cityPath, storePath, store, beadID, nil, stdout, stderr)
 }
 
-func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store beads.Store, bead beads.Bead, beadID string, cfg *config.City, stdout, stderr io.Writer) error {
+// runControlDispatcherWithStoreAndConfig reads the control bead itself rather
+// than accepting a value, so the copy ProcessControl's idempotence gate consults
+// is by construction the copy the dispatch is about to mutate. Both entry points
+// above resolve a SCOPE and hand it over; a bead value resolved alongside that
+// scope comes from an unrouted store, and gating on it while writing elsewhere
+// re-runs a control kind the graph store had already finished.
+func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store beads.Store, beadID string, cfg *config.City, stdout, stderr io.Writer) error {
 	restoreTraceWarnings := useWorkflowTraceWarnings(stderr)
 	defer restoreTraceWarnings()
 	var cfgLoadErr error
@@ -196,7 +197,12 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 	// fragments, drain units and their convoys) are graph class, so all of that
 	// runs against the graph store. store itself stays the work leg: it owns the
 	// input convoy whose tracks edges the execution snapshot below reads.
-	graphStore := controlGraphStore(cityPath, cfg, store)
+	graphStore := controlGraphStore(cityPath, storePath, cfg, store)
+
+	bead, err := graphStore.Get(beadID)
+	if err != nil {
+		return fmt.Errorf("loading control bead %s from the %s for scope %q: %w", beadID, controlStoreDescription(cityPath, storePath), storePath, err)
+	}
 
 	opts := dispatch.ProcessOptions{CityPath: cityPath, StorePath: storePath}
 	opts.Tracef = workflowTracef
@@ -457,22 +463,74 @@ func sourceWorkflowLockScopeForStoreRef(cityPath string, cfg *config.City, defau
 	})
 }
 
+// controlScopeTakesGraphClass reports whether control dispatch for a scope
+// resolves its control beads through the graph class instead of staying on the
+// store the scope opened.
+//
+// Only the CITY scope does. The scope guard is load-bearing: resolveClassStore
+// holds a single city-level store per class, so there is no per-scope graph
+// binding to route a RIG to, and `gc storage migrate` copies only the city work
+// store (openInfraMigrationSource), so a rig's control beads were never carried
+// into the binding in the first place. Redirecting a rig scope at the city
+// binding would point both the readiness scan and the dispatch at a database
+// that has never held that rig's beads — every rig-scoped control bead would
+// read as "bead not found", which IsTransientControllerError does not match, so
+// the dispatcher would exit non-zero and crash-loop. A rig scope therefore stays
+// entirely on its own store, exactly as it does today.
+func controlScopeTakesGraphClass(cityPath, storePath string) bool {
+	return samePath(resolveStoreScopeRoot(cityPath, storePath), cityPath)
+}
+
+// controlGraphBinding returns the store this scope's control beads live in when
+// that store is somewhere the scope directory's own `bd` cannot reach, and
+// whether that is the case at all.
+//
+// It is the question a shell-based readiness scan has to ask before running:
+// `bd ready` in the work directory enumerates the copies the migration retained
+// there, which no longer receive the workflow's mutations.
+func controlGraphBinding(cityPath, storePath string) (beads.Store, bool) {
+	if !controlScopeTakesGraphClass(cityPath, storePath) {
+		return nil, false
+	}
+	return graphClassBinding(cliStorageRoutes(cityPath))
+}
+
+// controlGraphRelocated reports whether this scope's control beads are served by
+// a database the scope directory's own `bd` cannot reach.
+func controlGraphRelocated(cityPath, storePath string) bool {
+	_, relocated := controlGraphBinding(cityPath, storePath)
+	return relocated
+}
+
+// controlStoreDescription names the ledger a control-bead read actually went to,
+// so a not-found sends the operator to the database that was searched rather
+// than to the scope directory that merely selected it.
+func controlStoreDescription(cityPath, storePath string) string {
+	if controlGraphRelocated(cityPath, storePath) {
+		return "graph-class binding"
+	}
+	return "scoped control store"
+}
+
 // controlGraphStore returns the store that owns a control bead and everything
 // its dispatch creates, given the scope store the caller resolved.
 //
 // Control beads are graph class: coordclass counts every gc.kind control bead,
 // and the molecule/step topology they mutate, as ClassGraph. The scope store
-// answers WHICH city or rig; the graph class answers WHICH database inside it.
-// Running control dispatch against the scope store on a split city reads the
-// copy the migration retained in the work ledger and writes the results back
-// there, where no graph-routed reader looks.
+// answers WHICH city or rig; for the city scope the graph class then answers
+// WHICH database inside it. Running control dispatch against the scope store on
+// a split city reads the copy the migration retained in the work ledger and
+// writes the results back there, where no graph-routed reader looks.
 //
-// When the routes relocate nothing this returns the exact store value it was
-// handed, so a single-store city dispatches against the very store it always
-// did — same bd command runner, same scope issue prefix, same instance for the
-// optional-capability assertions (DepListBatch, UpdateAll) the scope-skip paths
-// make against it.
-func controlGraphStore(cityPath string, cfg *config.City, scopeStore beads.Store) beads.Store {
+// When the routes relocate nothing — every city with no [storage] section, and
+// every rig scope — this returns the exact store value it was handed, so those
+// callers dispatch against the very store they always did: same bd command
+// runner, same scope issue prefix, same instance for the optional-capability
+// assertions (DepListBatch, UpdateAll) the scope-skip paths make against it.
+func controlGraphStore(cityPath, storePath string, cfg *config.City, scopeStore beads.Store) beads.Store {
+	if !controlScopeTakesGraphClass(cityPath, storePath) {
+		return scopeStore
+	}
 	return resolveGraphStore(cliStorageRoutes(cityPath), scopeStore, cfg, cityPath, nil)
 }
 
@@ -512,41 +570,46 @@ func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (be
 	})
 }
 
-// findBeadAcrossStores tries the city store first, then all rig stores,
-// returning the store and bead on first match.
-func findBeadAcrossStores(cityPath, beadID string, warningWriter io.Writer) (beads.Store, beads.Bead, string, error) {
+// findBeadScopeAcrossStores tries the city store first, then all rig stores,
+// returning the scope store and its path on first match.
+//
+// It answers WHICH SCOPE owns an id, and nothing else. The bead it reads along
+// the way is deliberately not returned: these are unrouted scope stores, so on a
+// split city a graph-class bead's value here is the copy the migration retained,
+// and a caller that gated on it while writing the graph store would act on work
+// the graph store had already finished.
+func findBeadScopeAcrossStores(cityPath, beadID string, warningWriter io.Writer) (beads.Store, string, error) {
 	// Try city store first.
 	cityStore, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
-		return nil, beads.Bead{}, "", fmt.Errorf("opening city store: %w", err)
+		return nil, "", fmt.Errorf("opening city store: %w", err)
 	}
-	if b, err := cityStore.Get(beadID); err == nil {
-		return cityStore, b, cityPath, nil
+	if _, err := cityStore.Get(beadID); err == nil {
+		return cityStore, cityPath, nil
 	} else if !errors.Is(err, beads.ErrNotFound) {
-		return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q from %s: %w", beadID, cityPath, err)
+		return nil, "", fmt.Errorf("getting bead %q from %s: %w", beadID, cityPath, err)
 	}
 
 	// Try rig stores.
 	cfg, err := loadCityConfig(cityPath, warningWriter)
 	if err != nil {
-		return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q: not in city store, and config unavailable: %w", beadID, err)
+		return nil, "", fmt.Errorf("getting bead %q: not in city store, and config unavailable: %w", beadID, err)
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
 	for _, rig := range cfg.Rigs {
 		store, err := openControlStoreAtForCity(rig.Path, cityPath, cfg)
 		if err != nil {
-			return nil, beads.Bead{}, "", fmt.Errorf("opening rig store %q: %w", rig.Name, err)
+			return nil, "", fmt.Errorf("opening rig store %q: %w", rig.Name, err)
 		}
-		bead, err := store.Get(beadID)
-		if err != nil {
+		if _, err := store.Get(beadID); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue
 			}
-			return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q from %s: %w", beadID, rig.Path, err)
+			return nil, "", fmt.Errorf("getting bead %q from %s: %w", beadID, rig.Path, err)
 		}
-		return store, bead, rig.Path, nil
+		return store, rig.Path, nil
 	}
-	return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
+	return nil, "", fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
 }
 
 func findUniqueBeadAcrossStoresView(cityPath, beadID string) (convoyStoreView, beads.Bead, error) {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -246,6 +246,20 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 			opts.PrepareRecipe = func(recipe *formula.Recipe, source beads.Bead) error {
 				return decorateDrainItemRecipe(recipe, source, graphStore, workflowStoreRefForDir(storePath, cityPath, loadedCityName(cfg, cityPath), cfg), loadedCityName(cfg, cityPath), cityPath, cfg)
 			}
+			// A drain is the one control kind that reads beads it did not
+			// create. Its control and item roots are graph class and run
+			// against graphStore above, but the convoy it expands over is
+			// minted alongside its work members and stays in the scope store —
+			// the same store handed to EmitCurrent below as the work leg that
+			// owns that convoy's tracks edges. Naming it here is what lets the
+			// membership read, the member reservations and the member
+			// dependency projection cross the class boundary. Only when the
+			// class actually relocated: on every other city graphStore IS
+			// store, and an empty tail keeps each of those reads on the single
+			// direct call it makes today.
+			if controlGraphRelocated(cityPath, storePath) {
+				opts.MemberStores = []beads.Store{store}
+			}
 		case "retry-eval":
 			sp, err := dispatchControlSessionProvider()
 			if err != nil {
@@ -409,8 +423,29 @@ func makeSourceWorkflowLocker(ctx context.Context, cityPath string, cfg *config.
 	}
 }
 
+// makeSourceWorkflowStoresLister lists every store that can hold a LIVE workflow
+// root, which is the precondition workflow-finalize checks before closing a
+// source bead: a source bead with another workflow still running against it must
+// stay open.
+//
+// Each scope is opened through the same class hop the dispatch itself takes.
+// Workflow roots are graph class (coordclass classifies gc.kind=workflow that
+// way), so on a converged split city the city scope's roots are in the binding,
+// and a scan of the city WORK store finds none of them. That is a guard that
+// silently answers "no live roots" for the one arrangement it exists to catch —
+// and unlike a missed read it is destructive, because the answer closes and
+// terminally stamps a human-visible source bead while its other workflow is
+// still executing. Routing the scan and the mutation to the same ledger is the
+// whole point.
+//
+// The hop is scope-guarded by controlGraphBinding, so rig scopes keep their own
+// stores; a relocated scope does not open the scope store at all, because that
+// would be a bd process this scan never reads.
 func makeSourceWorkflowStoresLister(cityPath string, cfg *config.City) func() ([]dispatch.SourceWorkflowStore, error) {
 	return makeSourceWorkflowStoresListerWithOpenStore(cityPath, cfg, func(dir string) (beads.Store, error) {
+		if binding, relocated := controlGraphBinding(cityPath, dir); relocated {
+			return binding, nil
+		}
 		return openStoreAtForCity(dir, cityPath)
 	})
 }

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2428,7 +2428,7 @@ func TestRunControlDispatcherReturnsTransientControlErrorWithoutQuarantine(t *te
 
 	var stderr bytes.Buffer
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-	err = runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr)
+	err = runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control.ID, cfg, io.Discard, &stderr)
 	if err == nil {
 		t.Fatal("runControlDispatcherWithStoreAndConfig error = nil, want transient error")
 	}
@@ -2492,7 +2492,7 @@ title = "Review {reviewer}"
 		Workspace:     config.Workspace{Name: "test-city"},
 		FormulaLayers: config.FormulaLayers{City: []string{formulaDir}},
 	}
-	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control.ID, cfg, io.Discard, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
 	}
 
@@ -2542,7 +2542,7 @@ func TestRunControlDispatcherPreservesSuccessfulControlWhenReprojectionFails(t *
 	_, _, control := createProcessedScopeCheckControl(t, store, false)
 
 	var stderr bytes.Buffer
-	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control, control.ID, &config.City{Workspace: config.Workspace{Name: "test-city"}}, io.Discard, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control.ID, &config.City{Workspace: config.Workspace{Name: "test-city"}}, io.Discard, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
 	}
 
@@ -2700,7 +2700,7 @@ func TestRunControlDispatcherQuarantineReconcilesScopedControlFailure(t *testing
 
 	var stderr bytes.Buffer
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control.ID, cfg, io.Discard, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
 	}
 
@@ -3050,7 +3050,7 @@ func TestRunControlDispatcherWithStoreRoutesRalphTraceWarningToStderr(t *testing
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := runControlDispatcherWithStore(cityDir, cityDir, store, check1, check1.ID, &stdout, &stderr); err != nil {
+	if err := runControlDispatcherWithStore(cityDir, cityDir, store, check1.ID, &stdout, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStore: %v", err)
 	}
 
@@ -3154,7 +3154,7 @@ func TestRunControlDispatcherWithStoreWarnsOnLegacyTracePath(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := runControlDispatcherWithStore(cityDir, cityDir, store, check1, check1.ID, &stdout, &stderr); err != nil {
+	if err := runControlDispatcherWithStore(cityDir, cityDir, store, check1.ID, &stdout, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStore: %v", err)
 	}
 
@@ -3285,11 +3285,7 @@ func TestRunWorkflowServeDedupsTraceWarningsAcrossNestedControlDispatch(t *testi
 		return next, nil
 	}
 	controlDispatcherServe = func(cityPath, storePath, beadID string, stdout, stderr io.Writer) error {
-		bead, err := store.Get(beadID)
-		if err != nil {
-			return err
-		}
-		return runControlDispatcherWithStore(cityPath, storePath, store, bead, beadID, stdout, stderr)
+		return runControlDispatcherWithStore(cityPath, storePath, store, beadID, stdout, stderr)
 	}
 
 	var stderr bytes.Buffer
@@ -3421,11 +3417,7 @@ func TestRunWorkflowServeDedupsLegacyTraceWarningsAcrossNestedControlDispatch(t 
 		return next, nil
 	}
 	controlDispatcherServe = func(cityPath, storePath, beadID string, stdout, stderr io.Writer) error {
-		bead, err := store.Get(beadID)
-		if err != nil {
-			return err
-		}
-		return runControlDispatcherWithStore(cityPath, storePath, store, bead, beadID, stdout, stderr)
+		return runControlDispatcherWithStore(cityPath, storePath, store, beadID, stdout, stderr)
 	}
 
 	var stderr bytes.Buffer
@@ -4720,7 +4712,7 @@ func TestRunControlDispatcherReturnsPendingForOpenScopeSubject(t *testing.T) {
 
 	var stderr bytes.Buffer
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-	err = runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr)
+	err = runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control.ID, cfg, io.Discard, &stderr)
 	if !errors.Is(err, dispatch.ErrControlPending) {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig error = %v, want ErrControlPending", err)
 	}
@@ -4904,12 +4896,8 @@ func TestRunWorkflowServeQuarantinesUnexpectedNonControlBead(t *testing.T) {
 		return []hookBead{{ID: nonControl.ID, Metadata: map[string]string{"gc.kind": "workflow"}}}, nil
 	}
 	controlDispatcherServe = func(cityPath, storePath, beadID string, stdout, stderr io.Writer) error {
-		bead, err := store.Get(beadID)
-		if err != nil {
-			return err
-		}
 		cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-		return runControlDispatcherWithStoreAndConfig(cityPath, storePath, store, bead, beadID, cfg, stdout, stderr)
+		return runControlDispatcherWithStoreAndConfig(cityPath, storePath, store, beadID, cfg, stdout, stderr)
 	}
 
 	var stderr bytes.Buffer
@@ -5091,7 +5079,7 @@ func TestRunControlDispatcherQuarantinesMalformedControlGraph(t *testing.T) {
 
 	var stderr bytes.Buffer
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control.ID, cfg, io.Discard, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
 	}
 
@@ -5157,7 +5145,7 @@ func TestRunControlDispatcherQuarantinesMalformedFanoutScopeBody(t *testing.T) {
 
 	var stderr bytes.Buffer
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, fanout, fanout.ID, cfg, io.Discard, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, fanout.ID, cfg, io.Discard, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
 	}
 
@@ -5223,7 +5211,7 @@ func TestRunControlDispatcherQuarantinesRalphControlMissingIteration(t *testing.
 
 	var stderr bytes.Buffer
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control.ID, cfg, io.Discard, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
 	}
 
@@ -5271,7 +5259,7 @@ func TestRunControlDispatcherQuarantinesGenericControlFailure(t *testing.T) {
 
 	var stderr bytes.Buffer
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
-	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control.ID, cfg, io.Discard, &stderr); err != nil {
 		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
 	}
 
@@ -6226,15 +6214,15 @@ name = "test-city"
 	}
 	t.Setenv("GC_BEADS", "exec:/definitely/missing/provider")
 
-	_, _, _, err := findBeadAcrossStores(cityPath, "gc-missing", io.Discard)
+	_, _, err := findBeadScopeAcrossStores(cityPath, "gc-missing", io.Discard)
 	if err == nil {
-		t.Fatal("findBeadAcrossStores() error = nil, want provider failure")
+		t.Fatal("findBeadScopeAcrossStores() error = nil, want provider failure")
 	}
 	if !strings.Contains(err.Error(), "getting bead \"gc-missing\" from "+cityPath) {
-		t.Fatalf("findBeadAcrossStores() error = %v, want city store path context", err)
+		t.Fatalf("findBeadScopeAcrossStores() error = %v, want city store path context", err)
 	}
 	if strings.Contains(err.Error(), "bead not found") {
-		t.Fatalf("findBeadAcrossStores() error = %v, want provider failure instead of masked not-found", err)
+		t.Fatalf("findBeadScopeAcrossStores() error = %v, want provider failure instead of masked not-found", err)
 	}
 }
 

--- a/cmd/gc/control_dispatch_graph_store_test.go
+++ b/cmd/gc/control_dispatch_graph_store_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+// controlSplitRoutes builds the routes a converged split city runs on: work
+// keeps its own ledger and every infrastructure class is served by one shared
+// binding — the arrangement storageSplitWhole names and openStorageRoutes
+// produces.
+func controlSplitRoutes(infra beads.Store) *storageRoutes {
+	routes := &storageRoutes{stores: make(map[coordclass.Class]beads.Store), binding: "infra"}
+	for _, class := range coordclass.Classes() {
+		if class.IsInfrastructure() {
+			routes.stores[class] = infra
+		}
+	}
+	return routes
+}
+
+// seedCLIStorageRoutes installs routes for cityPath in the one-shot memo, so a
+// test can drive the CLI class resolvers without standing up a real binding.
+func seedCLIStorageRoutes(t *testing.T, cityPath string, routes *storageRoutes) {
+	t.Helper()
+	resetCLIStorageRoutes(t)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = routes })
+}
+
+// newOrphanControlFixture writes a control bead whose workflow root was
+// canceled. Both are graph class. The returned ids are identical in whichever
+// store they are written to, so the same fixture models the live binding copy
+// and the stale copy the migration retained in the work ledger.
+func newControlBead(t *testing.T, store beads.Store, rootID string) beads.Bead {
+	t.Helper()
+	bead, err := store.Create(beads.Bead{
+		Title: "check 1",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:          "check",
+			beadmeta.RootBeadIDMetadataKey:    rootID,
+			beadmeta.RootStoreRefMetadataKey:  "city:test-city",
+			beadmeta.StepIDMetadataKey:        "implement",
+			beadmeta.CheckModeMetadataKey:     "exec",
+			beadmeta.MaxAttemptsMetadataKey:   "1",
+			beadmeta.LogicalBeadIDMetadataKey: "logical-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control bead: %v", err)
+	}
+	return bead
+}
+
+func beadByID(t *testing.T, store beads.Store, id string) beads.Bead {
+	t.Helper()
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("get %s: %v", id, err)
+	}
+	return b
+}
+
+// TestControlDispatchReadsAndWritesTheGraphStoreOnSplitCity pins both halves of
+// the control-dispatch class hop on a split city.
+//
+// The fixture is the shape a converged city actually has: the migration COPIES
+// infrastructure into the binding and retains the source, so the same control
+// bead id exists in both stores. Only the binding's copy is live.
+//
+// Both directions are asserted, and the disposition is what separates them.
+// The dispatcher closes a control bead differently depending on where it finds
+// the workflow root: root present and canceled means gc.outcome=canceled, root
+// absent means gc.final_disposition=orphaned_workflow. Writing the canceled root
+// ONLY into the graph store therefore makes the outcome a direct readout of
+// which store the dispatcher READ. Which copy ends up closed is the readout of
+// which store it WROTE.
+func TestControlDispatchReadsAndWritesTheGraphStoreOnSplitCity(t *testing.T) {
+	cityPath := t.TempDir()
+	scopeStore := beads.NewMemStore()
+	graphStore := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, controlSplitRoutes(graphStore))
+
+	// Both stores hold the workflow root, because the migration copied it and
+	// retained the source. Only the BINDING's copy carries the cancellation:
+	// the operator canceled after cutover, through the graph-routed API, so the
+	// retained source still holds the pre-cutover version.
+	staleRoot, err := scopeStore.Create(beads.Bead{
+		Title:    "workflow",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create retained workflow root: %v", err)
+	}
+	root, err := graphStore.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	if staleRoot.ID != root.ID {
+		t.Fatalf("fixture root ids diverged (%s vs %s)", staleRoot.ID, root.ID)
+	}
+	stale := newControlBead(t, scopeStore, root.ID)
+	live := newControlBead(t, graphStore, root.ID)
+	if live.ID != stale.ID {
+		t.Fatalf("fixture ids diverged (%s vs %s); the retained copy must share the binding copy's id", live.ID, stale.ID)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, scopeStore, live, live.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("control dispatch: %v", err)
+	}
+
+	// READ: the root was resolved from the graph store, so the control bead was
+	// closed as canceled rather than as an orphan of a missing root.
+	got := beadByID(t, graphStore, live.ID)
+	if disposition := got.Metadata[beadmeta.FinalDispositionMetadataKey]; disposition == beadmeta.DispositionOrphanedWorkflow {
+		t.Fatalf("control bead closed as %q; the dispatcher read the scope store, where the canceled root does not exist", disposition)
+	}
+	if outcome := got.Metadata[beadmeta.OutcomeMetadataKey]; outcome != beadmeta.OutcomeCanceled {
+		t.Fatalf("gc.outcome = %q, want %q from the canceled root in the graph binding", outcome, beadmeta.OutcomeCanceled)
+	}
+
+	// WRITE: the binding's copy advanced.
+	if got.Status != "closed" {
+		t.Fatalf("graph-store control bead status = %q, want closed; the dispatcher's mutation went somewhere else", got.Status)
+	}
+
+	// And the retained source did NOT: a write there is invisible to every
+	// graph-routed reader and becomes a strand at the next boot.
+	if stayed := beadByID(t, scopeStore, stale.ID); stayed.Status == "closed" {
+		t.Fatalf("retained work-store copy was closed too; control mutations must not land in the source the migration left behind")
+	}
+}
+
+// TestControlDispatchSingleStoreUsesTheOneStore is the compatibility guarantee.
+// A city that relocates nothing routes nothing, so control dispatch runs against
+// the exact scope store it always did — same instance, so the bd command runner,
+// the scope issue prefix and the optional-capability assertions the scope-skip
+// paths make (DepListBatch, UpdateAll) all still land on the store they used to.
+//
+// Green before and after by design; its teeth are proven by mutation.
+func TestControlDispatchSingleStoreUsesTheOneStore(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, nil)
+
+	if got := controlGraphStore(cityPath, nil, store); got != beads.Store(store) {
+		t.Fatalf("controlGraphStore returned %T(%p), want the identical scope store %p", got, got, store)
+	}
+
+	root, err := store.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	control := newControlBead(t, store, root.ID)
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control, control.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("control dispatch: %v", err)
+	}
+	got := beadByID(t, store, control.ID)
+	if got.Status != "closed" {
+		t.Fatalf("control bead status = %q, want closed in the single store", got.Status)
+	}
+	if outcome := got.Metadata[beadmeta.OutcomeMetadataKey]; outcome != beadmeta.OutcomeCanceled {
+		t.Fatalf("gc.outcome = %q, want %q", outcome, beadmeta.OutcomeCanceled)
+	}
+}

--- a/cmd/gc/control_dispatch_graph_store_test.go
+++ b/cmd/gc/control_dispatch_graph_store_test.go
@@ -2,13 +2,18 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // seedCLIStorageRoutes installs routes for cityPath in the one-shot memo, so a
@@ -463,5 +468,215 @@ func TestControlDispatchGatesOnTheStoreItMutates(t *testing.T) {
 	}
 	if got := beadByID(t, graphStore, live.ID); got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
 		t.Fatalf("gc.outcome = %q, want the terminal %q left untouched", got.Metadata[beadmeta.OutcomeMetadataKey], beadmeta.OutcomePass)
+	}
+}
+
+// splitClassDrainFormulaDir writes the item formula a drain expands into and
+// returns the search path the city config exposes for it.
+func splitClassDrainFormulaDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	content := `formula = "drain-item"
+version = 1
+contract = "graph.v2"
+type = "workflow"
+
+[[steps]]
+id = "work"
+title = "Work {{convoy_id}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "drain-item.formula.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write drain item formula: %v", err)
+	}
+	return dir
+}
+
+// TestControlDispatchDrainNamesTheWorkLegForConvoyMembership drives the real
+// dispatcher entry point on a converged split city and pins that a drain still
+// sees its convoy.
+//
+// A drain is the one control kind that reads beads it did not create. Its
+// control and item roots are graph class and the dispatch hops them to the
+// binding, but the graph.v2 input convoy is minted alongside its work members
+// and stays in the scope store — the same store this function hands to
+// EmitCurrent as the work leg that owns that convoy's tracks edges. If the
+// dispatch does not name that leg, the membership read runs entirely against the
+// binding, which has never seen the convoy and answers EMPTY rather than
+// failing. A zero-member drain is a drain SUCCESS: it closes gc.outcome=pass with
+// an empty manifest, the whole convoy is left open and never dispatched, and the
+// command exits 0 with no operator signal — strictly worse than the loud
+// orphaned_workflow the unrouted read produced before.
+//
+// The assertion is therefore on the manifest, not on the drain completing: the
+// convoy must expand to one row per member, and the pass-with-nothing-expanded
+// state must not be reachable over a convoy that has members.
+func TestControlDispatchDrainNamesTheWorkLegForConvoyMembership(t *testing.T) {
+	cityPath := t.TempDir()
+	scopeStore := beads.NewMemStore()
+	graphStore := beads.NewMemStoreFrom(1000, nil, nil)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
+
+	convoy, err := scopeStore.Create(beads.Bead{
+		Title:    "input convoy",
+		Type:     "convoy",
+		Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+	})
+	if err != nil {
+		t.Fatalf("create input convoy: %v", err)
+	}
+	var memberIDs []string
+	for _, title := range []string{"first", "second"} {
+		member, err := scopeStore.Create(beads.Bead{Title: title, Type: "task"})
+		if err != nil {
+			t.Fatalf("create member: %v", err)
+		}
+		if err := convoycore.TrackItem(scopeStore, convoy.ID, member.ID); err != nil {
+			t.Fatalf("track member: %v", err)
+		}
+		memberIDs = append(memberIDs, member.ID)
+	}
+
+	root, err := graphStore.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey: beadmeta.KindWorkflow,
+			"gc.formula_contract":    "graph.v2",
+			"gc.input_convoy_id":     convoy.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	drain, err := graphStore.Create(beads.Bead{
+		Title: "drain",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       "drain",
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+			"gc.drain_context":             "separate",
+			"gc.drain_formula":             "drain-item",
+			"gc.drain_member_access":       "read",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create drain control: %v", err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	cfg.FormulaLayers.City = []string{splitClassDrainFormulaDir(t)}
+	var stdout, stderr bytes.Buffer
+	// The dispatch may fail loudly downstream of the expansion; what it may not
+	// do is silently report the convoy as drained.
+	_ = runControlDispatcherWithStoreAndConfig(cityPath, cityPath, scopeStore, drain.ID, cfg, &stdout, &stderr)
+
+	got := beadByID(t, graphStore, drain.ID)
+	raw := got.Metadata[beadmeta.DrainManifestMetadataKey]
+	if strings.TrimSpace(raw) == "" {
+		t.Fatalf("drain recorded no manifest at all; status=%q outcome=%q stderr=%q", got.Status, got.Metadata[beadmeta.OutcomeMetadataKey], stderr.String())
+	}
+	var manifest struct {
+		Rows []struct {
+			MemberID string `json:"member_id"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(raw), &manifest); err != nil {
+		t.Fatalf("parse drain manifest %q: %v", raw, err)
+	}
+	if got.Metadata[beadmeta.OutcomeMetadataKey] == beadmeta.OutcomePass && len(manifest.Rows) == 0 {
+		t.Fatalf("drain closed gc.outcome=pass with an empty manifest over a convoy of %d members; every member is left open and the run reports green. stdout=%q", len(memberIDs), stdout.String())
+	}
+	if len(manifest.Rows) != len(memberIDs) {
+		t.Fatalf("manifest rows = %d, want %d — one per convoy member; the dispatch did not name the work leg that owns this convoy's tracks edges", len(manifest.Rows), len(memberIDs))
+	}
+	for i, id := range memberIDs {
+		if manifest.Rows[i].MemberID != id {
+			t.Fatalf("manifest row %d member = %q, want %q", i, manifest.Rows[i].MemberID, id)
+		}
+	}
+}
+
+// TestSourceWorkflowStoresScanTheLedgerThatHoldsWorkflowRoots pins the
+// precondition that guards a destructive close.
+//
+// workflow-finalize will not close a source bead while another live workflow
+// root still references it — that is what keeps an "Adopt PR" request open while
+// its second workflow is still executing. Workflow roots are graph class, so on
+// a converged split city they live in the binding, while the source bead they
+// were launched from stays in the work store. Feed that scan the work store and
+// it answers "no live roots" for exactly the arrangement it exists to catch, and
+// the answer is acted on: the source bead is closed and terminally stamped under
+// a running workflow. The launch-side singleton guard is work-store-only too, so
+// a split city reaches the two-live-roots state without --force.
+//
+// The assertion is behavioral rather than structural: the store this lister
+// hands the scan must actually find a root that exists only in the binding.
+func TestSourceWorkflowStoresScanTheLedgerThatHoldsWorkflowRoots(t *testing.T) {
+	cityPath := t.TempDir()
+	graphStore := beads.NewMemStoreFrom(1000, nil, nil)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
+
+	const sourceBeadID = "gc-1"
+	const storeRef = "city:test-city"
+	live, err := graphStore.Create(beads.Bead{
+		Title: "workflow B",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:           beadmeta.KindWorkflow,
+			beadmeta.SourceBeadIDMetadataKey:   sourceBeadID,
+			beadmeta.SourceStoreRefMetadataKey: storeRef,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live workflow root: %v", err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	stores, err := makeSourceWorkflowStoresLister(cityPath, cfg)()
+	if err != nil {
+		t.Fatalf("source workflow stores: %v", err)
+	}
+	if len(stores) == 0 {
+		t.Fatal("no source workflow stores to scan")
+	}
+
+	var found []string
+	for _, info := range stores {
+		roots, err := sourceworkflow.ListLiveRoots(info.Store, sourceBeadID, storeRef, storeRef)
+		if err != nil {
+			t.Fatalf("ListLiveRoots(%s): %v", info.StoreRef, err)
+		}
+		for _, root := range roots {
+			found = append(found, root.ID)
+		}
+	}
+	if !slices.Contains(found, live.ID) {
+		t.Fatalf("live-root scan found %v, want the binding-resident root %s; the scan reads a ledger that holds no workflow roots, so the guard answers \"none live\" and workflow-finalize closes the source bead under a running workflow", found, live.ID)
+	}
+}
+
+// TestSourceWorkflowStoresStayOnTheScopeStoreWithNoRelocation is the
+// compatibility half: a city that relocates nothing resolves the same scope
+// store the scan always used, and no graph binding is consulted.
+func TestSourceWorkflowStoresStayOnTheScopeStoreWithNoRelocation(t *testing.T) {
+	cityPath := t.TempDir()
+	resetCLIStorageRoutes(t)
+	graphStore := beads.NewMemStoreFrom(1000, nil, nil)
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	stores, err := makeSourceWorkflowStoresLister(cityPath, cfg)()
+	if err != nil {
+		t.Fatalf("source workflow stores: %v", err)
+	}
+	if len(stores) == 0 {
+		t.Fatal("no source workflow stores to scan")
+	}
+	for _, info := range stores {
+		if info.Store == beads.Store(graphStore) {
+			t.Fatal("a city with no [storage] resolved a graph binding for the live-root scan")
+		}
+		if info.Store == nil {
+			t.Fatal("nil store in the live-root scan set")
+		}
 	}
 }

--- a/cmd/gc/control_dispatch_graph_store_test.go
+++ b/cmd/gc/control_dispatch_graph_store_test.go
@@ -3,27 +3,13 @@ package main
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/coordclass"
 )
-
-// controlSplitRoutes builds the routes a converged split city runs on: work
-// keeps its own ledger and every infrastructure class is served by one shared
-// binding — the arrangement storageSplitWhole names and openStorageRoutes
-// produces.
-func controlSplitRoutes(infra beads.Store) *storageRoutes {
-	routes := &storageRoutes{stores: make(map[coordclass.Class]beads.Store), binding: "infra"}
-	for _, class := range coordclass.Classes() {
-		if class.IsInfrastructure() {
-			routes.stores[class] = infra
-		}
-	}
-	return routes
-}
 
 // seedCLIStorageRoutes installs routes for cityPath in the one-shot memo, so a
 // test can drive the CLI class resolvers without standing up a real binding.
@@ -86,7 +72,7 @@ func TestControlDispatchReadsAndWritesTheGraphStoreOnSplitCity(t *testing.T) {
 	cityPath := t.TempDir()
 	scopeStore := beads.NewMemStore()
 	graphStore := beads.NewMemStore()
-	seedCLIStorageRoutes(t, cityPath, controlSplitRoutes(graphStore))
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
 
 	// Both stores hold the workflow root, because the migration copied it and
 	// retained the source. Only the BINDING's copy carries the cancellation:
@@ -122,7 +108,7 @@ func TestControlDispatchReadsAndWritesTheGraphStoreOnSplitCity(t *testing.T) {
 
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	var stdout, stderr bytes.Buffer
-	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, scopeStore, live, live.ID, cfg, &stdout, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, scopeStore, live.ID, cfg, &stdout, &stderr); err != nil {
 		t.Fatalf("control dispatch: %v", err)
 	}
 
@@ -160,7 +146,7 @@ func TestControlDispatchSingleStoreUsesTheOneStore(t *testing.T) {
 	store := beads.NewMemStore()
 	seedCLIStorageRoutes(t, cityPath, nil)
 
-	if got := controlGraphStore(cityPath, nil, store); got != beads.Store(store) {
+	if got := controlGraphStore(cityPath, cityPath, nil, store); got != beads.Store(store) {
 		t.Fatalf("controlGraphStore returned %T(%p), want the identical scope store %p", got, got, store)
 	}
 
@@ -179,7 +165,7 @@ func TestControlDispatchSingleStoreUsesTheOneStore(t *testing.T) {
 
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	var stdout, stderr bytes.Buffer
-	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control, control.ID, cfg, &stdout, &stderr); err != nil {
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control.ID, cfg, &stdout, &stderr); err != nil {
 		t.Fatalf("control dispatch: %v", err)
 	}
 	got := beadByID(t, store, control.ID)
@@ -188,5 +174,294 @@ func TestControlDispatchSingleStoreUsesTheOneStore(t *testing.T) {
 	}
 	if outcome := got.Metadata[beadmeta.OutcomeMetadataKey]; outcome != beadmeta.OutcomeCanceled {
 		t.Fatalf("gc.outcome = %q, want %q", outcome, beadmeta.OutcomeCanceled)
+	}
+}
+
+// resetControlReadyCache clears the per-dir readiness snapshot registry so a
+// test observes a fresh scan rather than one memoized inside controlReadyCacheTTL.
+func resetControlReadyCache(t *testing.T) {
+	t.Helper()
+	flush := func() {
+		controlReadyCacheRegistry.mu.Lock()
+		defer controlReadyCacheRegistry.mu.Unlock()
+		controlReadyCacheRegistry.byDir = make(map[string]*controlReadyCacheEntry)
+	}
+	flush()
+	t.Cleanup(flush)
+}
+
+// newRoutedControlBead writes a control bead routed to the control dispatcher,
+// so the readiness scan's route filter admits it.
+func newRoutedControlBead(t *testing.T, store beads.Store, rootID, route string) beads.Bead {
+	t.Helper()
+	bead := newControlBead(t, store, rootID)
+	if err := store.Update(bead.ID, beads.UpdateOpts{
+		Metadata: map[string]string{beadmeta.RunTargetMetadataKey: route},
+	}); err != nil {
+		t.Fatalf("route control bead: %v", err)
+	}
+	return beadByID(t, store, bead.ID)
+}
+
+// controlReadyScan runs the production readiness scan the serve loop's queue
+// comes from, for a control dispatcher whose scope directory is dir.
+func controlReadyScan(t *testing.T, dir string, agentCfg config.Agent, beadsCfg config.BeadsConfig) []string {
+	t.Helper()
+	resetControlReadyCache(t)
+	queue, handled, err := tryControlReadyFromCacheOrFallback(
+		workflowServeControlReadyQueryForBeads(agentCfg, beadsCfg), dir, nil)
+	if err != nil {
+		t.Fatalf("control-ready scan: %v", err)
+	}
+	if !handled {
+		t.Fatal("control-ready scan: the generated query was not recognized as a control-ready query")
+	}
+	ids := make([]string, 0, len(queue))
+	for _, item := range queue {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}
+
+// TestControlReadyScanEnumeratesTheGraphBindingOnSplitCity pins the producer
+// side of the control dispatcher against the same ledger the consumer mutates.
+//
+// The dispatch hop is only half a fix. The serve loop's queue comes from
+// nextWorkflowServeBeads -> tryControlReadyFromCacheOrFallback, and if that scan
+// keeps reading the work store while the dispatch closes the binding's copy, the
+// retained work copy stays open and ready forever: it is re-offered on every
+// tick, ProcessControl no-ops on the already-closed binding copy, and
+// drainWorkflowServeWork counts a no-op as progress and immediately re-queries.
+// The loop never returns. Symmetrically, the beads a dispatch CREATES land in
+// the binding, which a work-store scan never reads, so the workflow cannot
+// advance past its first hop.
+//
+// Both arms of the scan are covered, because they reach the store by different
+// routes: the cached arm wraps a CachingStore around the resolved class store,
+// and the fallback arm (taken under bd-1.0.5 compatibility, which needs a tier
+// CachedReady cannot serve) would otherwise shell `bd ready` in a directory that
+// no longer holds the class.
+func TestControlReadyScanEnumeratesTheGraphBindingOnSplitCity(t *testing.T) {
+	agentCfg := config.Agent{Name: config.ControlDispatcherAgentName}
+	route := agentCfg.QualifiedName()
+
+	for _, tc := range []struct {
+		name  string
+		beads config.BeadsConfig
+	}{
+		{name: "cached arm", beads: config.BeadsConfig{}},
+		{name: "fallback arm", beads: config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			graphStore := beads.NewMemStore()
+			seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
+
+			root, err := graphStore.Create(beads.Bead{
+				Title:    "workflow",
+				Type:     "task",
+				Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+			})
+			if err != nil {
+				t.Fatalf("create workflow root: %v", err)
+			}
+			live := newRoutedControlBead(t, graphStore, root.ID, route)
+
+			got := controlReadyScan(t, cityPath, agentCfg, tc.beads)
+			if len(got) != 1 || got[0] != live.ID {
+				t.Fatalf("control-ready queue = %v, want [%s] from the graph binding; the scan read a ledger the dispatch does not write", got, live.ID)
+			}
+		})
+	}
+}
+
+// TestControlReadyScanStopsOfferingAControlBeadTheDispatchClosed is the
+// termination property the drain loop depends on, asserted directly.
+//
+// drainWorkflowServeWork loops until its queue comes back empty, and it has no
+// iteration bound and no sleep between passes. What makes it terminate is that
+// the copy it enumerates is the copy the dispatch closes. On a converged split
+// city the migration retains the source verbatim, so the same control-bead id is
+// open in the work store and live in the binding; a scan pointed at the work
+// store therefore keeps returning an id the dispatch has already finished.
+//
+// The assertion is the fixed point: after the dispatch, a fresh scan is empty
+// even though the retained work copy is still open.
+func TestControlReadyScanStopsOfferingAControlBeadTheDispatchClosed(t *testing.T) {
+	agentCfg := config.Agent{Name: config.ControlDispatcherAgentName}
+	route := agentCfg.QualifiedName()
+
+	cityPath := t.TempDir()
+	scopeStore := beads.NewMemStore()
+	graphStore := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
+
+	staleRoot, err := scopeStore.Create(beads.Bead{
+		Title:    "workflow",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create retained workflow root: %v", err)
+	}
+	root, err := graphStore.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	stale := newRoutedControlBead(t, scopeStore, staleRoot.ID, route)
+	live := newRoutedControlBead(t, graphStore, root.ID, route)
+	if live.ID != stale.ID {
+		t.Fatalf("fixture ids diverged (%s vs %s); the retained copy must share the binding copy's id", live.ID, stale.ID)
+	}
+
+	if got := controlReadyScan(t, cityPath, agentCfg, config.BeadsConfig{}); len(got) != 1 || got[0] != live.ID {
+		t.Fatalf("control-ready queue before dispatch = %v, want [%s]", got, live.ID)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, scopeStore, live.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("control dispatch: %v", err)
+	}
+	if closed := beadByID(t, graphStore, live.ID); closed.Status != "closed" {
+		t.Fatalf("binding control bead status = %q, want closed", closed.Status)
+	}
+	// The precondition that makes this test meaningful: the work-store copy the
+	// unrouted scan reads is still open, exactly as the migration left it.
+	if retained := beadByID(t, scopeStore, stale.ID); retained.Status != "open" {
+		t.Fatalf("retained work-store copy status = %q, want open; the fixture no longer models a converged city", retained.Status)
+	}
+
+	if got := controlReadyScan(t, cityPath, agentCfg, config.BeadsConfig{}); len(got) != 0 {
+		t.Fatalf("control-ready queue after dispatch = %v, want empty; the serve loop re-offers a bead the dispatch already finished and never returns", got)
+	}
+}
+
+// TestControlDispatchRigScopeStaysOnItsOwnStore guards the scope half of the
+// class hop.
+//
+// There is no per-scope graph binding: resolveClassStore holds one city-level
+// store per class, and `gc storage migrate` copies only the CITY work store, so
+// a rig's control beads were never carried into the binding. Redirecting a rig
+// scope there would look up every rig-scoped control bead in a database that has
+// never held it — "bead not found", which IsTransientControllerError does not
+// match, so drainWorkflowServeWork returns it as fatal and the dispatcher
+// session exits and crash-loops.
+func TestControlDispatchRigScopeStaysOnItsOwnStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "fixture")
+	rigStore := beads.NewMemStore()
+	graphStore := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
+
+	if got := controlGraphStore(cityPath, rigPath, nil, rigStore); got != beads.Store(rigStore) {
+		t.Fatalf("controlGraphStore for a rig scope returned %T(%p), want the rig's own store %p; the city binding never held this rig's beads", got, got, rigStore)
+	}
+	if controlGraphRelocated(cityPath, rigPath) {
+		t.Fatal("controlGraphRelocated for a rig scope = true; the readiness scan would go in-process against a binding with none of this rig's beads")
+	}
+
+	// End to end: a rig-scoped control bead dispatches against the rig store,
+	// with the city binding empty throughout.
+	root, err := rigStore.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	control := newControlBead(t, rigStore, root.ID)
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, rigPath, rigStore, control.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("rig-scoped control dispatch: %v", err)
+	}
+	if got := beadByID(t, rigStore, control.ID); got.Status != "closed" {
+		t.Fatalf("rig control bead status = %q, want closed in the rig's own store", got.Status)
+	}
+	empty, err := graphStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("list city binding: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("city binding holds %d bead(s) after a rig-scoped dispatch, want 0", len(empty))
+	}
+}
+
+// TestControlDispatchGatesOnTheStoreItMutates pins the idempotence gate to the
+// copy the dispatch is about to write.
+//
+// ProcessControl decides whether to act from bead.Status and per-kind spawn
+// metadata. The manual `gc convoy control <id>` path resolves its bead through
+// findBeadAcrossStores, which opens unrouted scope stores, so on a split city
+// that value is the frozen copy the migration retained. Gating on it while
+// mutating the binding re-enters a control kind the graph store had already
+// finished: a finished check re-runs its gate command, a finished fanout
+// re-enters its spawn branch and the resulting quarantine rewrites a terminal
+// outcome. runControlDispatcherWithStoreAndConfig therefore reads the bead
+// itself, from graphStore, rather than accepting a caller's value.
+func TestControlDispatchGatesOnTheStoreItMutates(t *testing.T) {
+	cityPath := t.TempDir()
+	scopeStore := beads.NewMemStore()
+	graphStore := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
+
+	staleRoot, err := scopeStore.Create(beads.Bead{
+		Title:    "workflow",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create retained workflow root: %v", err)
+	}
+	root, err := graphStore.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	stale := newControlBead(t, scopeStore, staleRoot.ID)
+	live := newControlBead(t, graphStore, root.ID)
+	if live.ID != stale.ID {
+		t.Fatalf("fixture ids diverged (%s vs %s)", live.ID, stale.ID)
+	}
+
+	// The binding's copy is already finished; the retained work copy is not.
+	// This is what a split city looks like on the second `gc convoy control`.
+	closed := "closed"
+	if err := graphStore.Update(live.ID, beads.UpdateOpts{
+		Status:   &closed,
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass},
+	}); err != nil {
+		t.Fatalf("close the binding copy: %v", err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, cityPath, scopeStore, live.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("control dispatch: %v", err)
+	}
+	if action := stdout.String(); action != "" {
+		t.Fatalf("control dispatch acted (%q) on a bead the graph store had already finished; the idempotence gate read the retained work copy", strings.TrimSpace(action))
+	}
+	if got := beadByID(t, graphStore, live.ID); got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("gc.outcome = %q, want the terminal %q left untouched", got.Metadata[beadmeta.OutcomeMetadataKey], beadmeta.OutcomePass)
 	}
 }

--- a/cmd/gc/dispatch_control_ready.go
+++ b/cmd/gc/dispatch_control_ready.go
@@ -284,12 +284,20 @@ func beadsToHookBeads(items []beads.Bead) []hookBead {
 	return out
 }
 
-// controlReadyFallbackReady issues exactly one batched `bd ready --json`
-// call covering the whole active ready set (no --assignee/--metadata-field
-// filter), for evaluateControlReady to filter in Go. Used when the in-process
-// cache can't answer: dirty, still priming, or the rig's bd compatibility
-// mode requires --include-ephemeral (a tier CachedReady can't serve).
-func controlReadyFallbackReady(dir string, env map[string]string, includeEphemeral bool) ([]beads.Bead, error) {
+// controlReadyFallbackReady answers the batched ready scan the in-process cache
+// could not: dirty, still priming, or a bd compatibility mode that requires
+// --include-ephemeral (a tier CachedReady can't serve).
+//
+// It reads whichever ledger the control dispatcher will actually dispatch
+// against. On a scope whose graph class has been relocated to a binding, that is
+// an in-process Ready() on the binding: `bd` in dir speaks to the work store,
+// and the control beads there are the copies the migration retained, which no
+// longer receive the workflow's mutations. Enumerating those would hand the
+// drain loop a queue of ids the dispatch then no-ops on forever.
+func controlReadyFallbackReady(dir, cityPath string, env map[string]string, includeEphemeral bool) ([]beads.Bead, error) {
+	if binding, relocated := controlGraphBinding(cityPath, dir); relocated {
+		return controlReadyBindingReady(dir, binding, includeEphemeral)
+	}
 	query := fmt.Sprintf("bd --readonly --sandbox ready --json --exclude-type=%s --limit=%d", controlReadyExcludeType, controlReadyFallbackLimit)
 	if includeEphemeral {
 		query += " --include-ephemeral"
@@ -308,6 +316,39 @@ func controlReadyFallbackReady(dir string, env map[string]string, includeEphemer
 	}
 	if len(result) == controlReadyFallbackLimit {
 		log.Printf("control-ready fallback: bd ready for %s returned exactly the %d-item limit -- city-wide ready set may be truncated, some candidates/routes could see fewer beads than are actually ready", dir, controlReadyFallbackLimit)
+	}
+	beads.SortBeadsReadyOrder(result)
+	return result, nil
+}
+
+// controlReadyBindingReady is the relocated-graph arm of the fallback: the same
+// batched ready scan, taken in-process against the binding instead of by
+// shelling `bd` in a directory that no longer holds the class.
+//
+// It reproduces the shell arm's three filters rather than approximating them:
+// --include-ephemeral is the TierBoth/TierIssues split BdStore.Ready itself
+// applies, --exclude-type is applied in Go because ReadyQuery carries no type
+// selector, and the limit is taken after that exclusion so the batched cap means
+// the same thing on both arms.
+func controlReadyBindingReady(dir string, binding beads.Store, includeEphemeral bool) ([]beads.Bead, error) {
+	tier := beads.TierIssues
+	if includeEphemeral {
+		tier = beads.TierBoth
+	}
+	ready, err := binding.Ready(beads.ReadyQuery{TierMode: tier})
+	if err != nil {
+		return nil, fmt.Errorf("control-ready fallback: reading the graph binding for %s: %w", dir, err)
+	}
+	result := make([]beads.Bead, 0, len(ready))
+	for _, bead := range ready {
+		if bead.Type == controlReadyExcludeType {
+			continue
+		}
+		result = append(result, bead)
+		if len(result) == controlReadyFallbackLimit {
+			log.Printf("control-ready fallback: the graph binding for %s returned at least the %d-item limit -- city-wide ready set may be truncated, some candidates/routes could see fewer beads than are actually ready", dir, controlReadyFallbackLimit)
+			break
+		}
 	}
 	beads.SortBeadsReadyOrder(result)
 	return result, nil
@@ -333,6 +374,16 @@ type controlReadyCacheEntry struct {
 // (runControlDispatcherInStore) would already be failing loudly if it were a
 // real production gap.
 //
+// The snapshot is taken over the SAME store runControlDispatcherWithStoreAndConfig
+// dispatches against: controlGraphStore resolves the scope's graph class, so the
+// queue and the mutation are one ledger. They must not diverge. A queue drawn
+// from the work store while the dispatch closes the binding's copy re-offers the
+// same id every tick -- ProcessControl no-ops on the already-closed copy, and
+// drainWorkflowServeWork counts a no-op as progress -- so the drain loop never
+// returns; and the beads the dispatch CREATES (fanout fragments, retry attempts,
+// drain units) would land in a ledger the scan never reads, stalling the
+// workflow at its first hop.
+//
 // Known limitation (low-impact, not fixed here): concurrent callers racing a
 // stale/missing entry for the same dir each independently open+prime their
 // own store rather than coalescing behind one in-flight prime -- last writer
@@ -350,11 +401,18 @@ func controlReadyCacheFor(dir, cityPath string, cfg *config.City) *beads.Caching
 		return entry.cache
 	}
 
-	store, err := openControlStoreAtForCity(dir, cityPath, cfg)
-	if err != nil {
-		return nil
+	// The snapshot must be taken over the store the dispatch will mutate. When
+	// the scope's graph class is relocated that is the binding, and the scope
+	// store is not opened at all — it would be a bd process this scan never reads.
+	source, relocated := controlGraphBinding(cityPath, dir)
+	if !relocated {
+		opened, err := openControlStoreAtForCity(dir, cityPath, cfg)
+		if err != nil {
+			return nil
+		}
+		source = opened
 	}
-	cs := beads.NewCachingStore(store, nil)
+	cs := beads.NewCachingStore(source, nil)
 	if err := cs.PrimeActive(); err != nil {
 		log.Printf("control-ready cache: pre-prime failed for %s: %v (falling back to a live bd query)", dir, err)
 		return nil
@@ -392,7 +450,7 @@ func tryControlReadyFromCacheOrFallback(workQuery, dir string, env map[string]st
 		}
 	}
 
-	ready, err := controlReadyFallbackReady(dir, env, parsed.includeEphemeral)
+	ready, err := controlReadyFallbackReady(dir, cityPath, env, parsed.includeEphemeral)
 	if err != nil {
 		return nil, true, err
 	}

--- a/cmd/gc/dispatch_control_ready_test.go
+++ b/cmd/gc/dispatch_control_ready_test.go
@@ -466,7 +466,7 @@ func TestControlReadyFallbackReadyLogsWhenResultHitsLimit(t *testing.T) {
 	defer restore()
 
 	dir := t.TempDir()
-	result, err := controlReadyFallbackReady(dir, nil, false)
+	result, err := controlReadyFallbackReady(dir, dir, nil, false)
 	if err != nil {
 		t.Fatalf("controlReadyFallbackReady: %v", err)
 	}
@@ -498,7 +498,8 @@ func TestControlReadyFallbackReadyNoWarningBelowLimit(t *testing.T) {
 	restore := captureLogOutput(&logBuf)
 	defer restore()
 
-	result, err := controlReadyFallbackReady(t.TempDir(), nil, false)
+	dir := t.TempDir()
+	result, err := controlReadyFallbackReady(dir, dir, nil, false)
 	if err != nil {
 		t.Fatalf("controlReadyFallbackReady: %v", err)
 	}

--- a/cmd/gc/infra_class_migrate_equality_test.go
+++ b/cmd/gc/infra_class_migrate_equality_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
@@ -858,5 +859,83 @@ func TestEnsureInfraClassMigratedLeavesAnAllocatorThatCannotCollide(t *testing.T
 	}
 	if got := idSuffix(t, minted.ID); got <= idSuffix(t, highest) {
 		t.Fatalf("the runtime handle minted %s, colliding with the imported slice whose highest id is %s", minted.ID, highest)
+	}
+}
+
+// TestInfraSnapshotLeavesSyntheticConvoysInTheWorkStore is the blast-radius pin
+// for reclassifying synthetic convoys as WORK.
+//
+// readInfraSnapshot is the one selector shared by the copy and by the boot-time
+// containment re-check, so a bead it returns is both carried into the binding
+// and, if it is ever absent from the binding, reported as STRANDED — which
+// refuses the boot. Synthetic convoys are minted in the work store and stay
+// there, so returning them would make every drain a city runs after cutover mint
+// a fresh bead the binding never receives, and the next boot would count them as
+// stranded writes and refuse to serve.
+//
+// The wisp row is the other half and is what makes this a boundary rather than a
+// blanket exemption. Wisp roots stay GRAPH class, so a city whose binding is
+// missing them still reports them stranded exactly as it does today.
+func TestInfraSnapshotLeavesSyntheticConvoysInTheWorkStore(t *testing.T) {
+	source := beads.NewMemStore()
+	seed := func(b beads.Bead) beads.Bead {
+		created, err := source.Create(b)
+		if err != nil {
+			t.Fatalf("seeding %s: %v", b.Title, err)
+		}
+		return created
+	}
+
+	inputConvoy := seed(beads.Bead{
+		Title:    "input convoy for a graph.v2 pour",
+		Type:     "convoy",
+		Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+	})
+	unitConvoy := seed(beads.Bead{
+		Title:    "drain unit 0",
+		Type:     "convoy",
+		Metadata: map[string]string{beadmeta.SyntheticKindMetadataKey: "drain-unit-convoy"},
+	})
+	userConvoy := seed(beads.Bead{Title: "a human convoy", Type: "convoy"})
+	member := seed(beads.Bead{Title: "a work bead", Type: "task"})
+
+	// The maintainer-city shape: wisp roots carrying each of the three markers
+	// the wisp arm matches. All three stay graph class.
+	wispByKind := seed(beads.Bead{Title: "wisp root", Type: "molecule", Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWisp}})
+	wispByType := seed(beads.Bead{Title: "wisp by type", Type: beadmeta.KindWisp})
+	wispByLabel := seed(beads.Bead{Title: "wisp by label", Type: "task", Labels: []string{"gc:wisp"}})
+	sessionBead := seed(beads.Bead{Title: "a session", Type: "session"})
+
+	rows, err := readInfraSnapshot(source)
+	if err != nil {
+		t.Fatalf("readInfraSnapshot: %v", err)
+	}
+	carried := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		carried[row.ID] = true
+	}
+
+	for _, tc := range []struct {
+		bead beads.Bead
+		why  string
+	}{
+		{inputConvoy, "a graph.v2 input convoy is minted in the work store alongside the members it tracks"},
+		{unitConvoy, "a drain-unit convoy is minted in the work store alongside the member it tracks"},
+		{userConvoy, "a user convoy has always been work"},
+		{member, "an ordinary work bead"},
+	} {
+		if carried[tc.bead.ID] {
+			t.Errorf("readInfraSnapshot carried %s (%s): %s; a work bead the copy carries is one the boot-time containment check will report stranded when the binding does not have it",
+				tc.bead.ID, tc.bead.Title, tc.why)
+		}
+	}
+
+	for _, b := range []beads.Bead{wispByKind, wispByType, wispByLabel, sessionBead} {
+		if !carried[b.ID] {
+			t.Errorf("readInfraSnapshot dropped %s (%s); the synthetic-convoy reclassification must not widen past convoys", b.ID, b.Title)
+		}
+	}
+	if got := len(rows); got != 4 {
+		t.Fatalf("snapshot carried %d rows, want exactly the 4 infra beads; ids=%v", got, carried)
 	}
 }

--- a/cmd/gc/provider_factory_e2c3_test.go
+++ b/cmd/gc/provider_factory_e2c3_test.go
@@ -210,7 +210,7 @@ func assertE2c3ControlDispatchFailures(t *testing.T, cityPath string) {
 			t.Fatalf("create %s control bead: %v", kind, err)
 		}
 		before := control
-		err = runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control, control.ID, cfg, io.Discard, io.Discard)
+		err = runControlDispatcherWithStoreAndConfig(cityPath, cityPath, store, control.ID, cfg, io.Discard, io.Discard)
 		if err == nil || err.Error() != e2c3ProviderConstructionFailure {
 			t.Fatalf("%s control dispatch error = %v, want %q", kind, err, e2c3ProviderConstructionFailure)
 		}

--- a/engdocs/plans/store-domain-objects/spec.md
+++ b/engdocs/plans/store-domain-objects/spec.md
@@ -38,7 +38,11 @@ logic's hands at all.
 | **ClassOrders** | `orders.OrderRun` | Typed. `orders.Store` returns `OrderRun` but has **no `Get(handle)`** yet. |
 | **ClassNudges** | `nudgequeue.NudgeShadow` (partial read-only view; authority for the full `Item` is the flock'd `state.json`, not the bead) | Typed. Handle for this class is the **durable nudge ID**, not the bead ID. |
 
-Convoy is not its own class; it resolves to Work (user/sling) or Graph (synthetic).
+Convoy is not its own class; it resolves to Work — every convoy, including the
+synthetic ones the system mints as glue (graph.v2 input convoys, drain-unit
+convoys). A convoy holds `tracks` edges to work members and `convoy.TrackItemIn`
+refuses an edge across a class boundary, so a convoy owned by any other class
+could never track the members it exists for.
 
 ## 3. Read model
 

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -93,6 +93,14 @@ const (
 	DrainParentConvoyIDMetadataKey       = "gc.drain_parent_convoy_id"
 	DrainStateMetadataKey                = "gc.drain_state"
 	DrainUnitKeyMetadataKey              = "gc.drain_unit_key"
+	// DrainUnprojectedBlockersMetadataKey records, on a drain item root, the
+	// out-of-convoy blockers of its source member that the item workflow could
+	// not depend on because they live in another class store. The item workflow
+	// runs without those constraints: a dependency row can only reference an id
+	// its own store resolves, and writing one anyway removes the dependent from
+	// Ready forever. Only OPEN blockers are recorded — a terminal one constrains
+	// nothing, so omitting its edge loses no meaning. Comma-separated bead ids.
+	DrainUnprojectedBlockersMetadataKey  = "gc.drain_unprojected_blockers"
 	DurationMsMetadataKey                = "gc.duration_ms"
 	DynamicFragmentMetadataKey           = "gc.dynamic_fragment"
 	ExclusiveDrainReservationMetadataKey = "gc.exclusive_drain_reservation"
@@ -342,6 +350,7 @@ var KnownMetadataKeys = []string{
 	DrainParentConvoyIDMetadataKey,
 	DrainStateMetadataKey,
 	DrainUnitKeyMetadataKey,
+	DrainUnprojectedBlockersMetadataKey,
 	DurationMsMetadataKey,
 	DynamicFragmentMetadataKey,
 	ExclusiveDrainReservationMetadataKey,

--- a/internal/convoy/classes.go
+++ b/internal/convoy/classes.go
@@ -48,8 +48,9 @@ type MemberClasses struct {
 	Work []beads.Store
 
 	// Graph names the Graph-class handle when graph-class beads (formula steps,
-	// control beads, synthetic convoys) can be members. Nil means this
-	// operation does not span the Graph class.
+	// control beads, wisp roots) can be members. It is never the class that owns
+	// the convoy itself — synthetic convoys are work beads like every other
+	// convoy. Nil means this operation does not span the Graph class.
 	Graph beads.Store
 }
 

--- a/internal/convoy/classes.go
+++ b/internal/convoy/classes.go
@@ -14,13 +14,12 @@ import (
 // MemberClasses names the class handles a single convoy operation spans.
 //
 // Convoy membership is the one deliberately mixed-class relation in the bead
-// substrate: the convoy bead and its `tracks` edges are owned by one class
-// (Work for a user convoy, Graph for a synthetic formula/drain convoy) while
-// the members themselves can be owned by the other. Per the class-ownership
-// table only Work and Graph ever own
-// convoy members, so those are the only classes an operation can name here;
-// Sessions, Messaging, Orders and Nudges are non-participating by construction
-// rather than by a runtime skip.
+// substrate: the convoy bead and its `tracks` edges are owned by Work — every
+// convoy is a work bead, the synthetic formula/drain ones included — while the
+// members themselves can be owned by another class. Per the class-ownership
+// table only Work and Graph ever own convoy members, so those are the only
+// classes an operation can name here; Sessions, Messaging, Orders and Nudges are
+// non-participating by construction rather than by a runtime skip.
 //
 // Naming is the whole contract, in both directions:
 //

--- a/internal/coordclass/class.go
+++ b/internal/coordclass/class.go
@@ -55,16 +55,18 @@ type Class int
 
 const (
 	// ClassWork is the real backlog: tasks, epics, bugs, features,
-	// merge-requests, and user/sling convoys. Owner: the bd backlog. This is the
-	// zero value so any bead not matched by an explicit infrastructure arm
-	// defaults to work.
+	// merge-requests, and EVERY convoy — user, sling, and the synthetic ones the
+	// system mints as glue (graph.v2 input convoys, drain-unit convoys). Owner:
+	// the bd backlog. This is the zero value so any bead not matched by an
+	// explicit infrastructure arm defaults to work.
 	ClassWork Class = iota
 
 	// ClassGraph is the formula-v2 execution engine's topology and control lane:
 	// molecule/step/gate/scope/run beads, every gc.kind control bead, wisp
-	// roots, convergence beads, spec sidecars, and synthetic (graph.v2 input /
-	// drain-unit) convoys. Owner: internal/dispatch + internal/molecule +
-	// internal/formula. This is the bead explosion the split primarily targets.
+	// roots, convergence beads, and spec sidecars. Owner: internal/dispatch +
+	// internal/molecule + internal/formula. This is the bead explosion the split
+	// primarily targets. Convoys are NOT here, synthetic ones included — see
+	// ClassWork and the synthetic-convoy arm in classify.go.
 	ClassGraph
 
 	// ClassMessaging is mail (type=message) and the extmsg families (type=task

--- a/internal/coordclass/classify.go
+++ b/internal/coordclass/classify.go
@@ -47,9 +47,9 @@ const (
 	// label (gc:extmsg-binding, -delivery, -group, -transcript, ...).
 	// Canonical: internal/extmsg/labels.go.
 	labelExtmsgPrefix = "gc:extmsg-"
-	// typeConvoy is the convoy bead type. Convoys are work-class UNLESS marked
-	// synthetic (graph.v2 input convoys, drain-unit convoys), which fold into
-	// ClassGraph. Canonical: internal/convoy.
+	// typeConvoy is the convoy bead type. EVERY convoy is work class, including
+	// the synthetic ones the system mints as glue (graph.v2 input convoys,
+	// drain-unit convoys). Canonical: internal/convoy.
 	typeConvoy = "convoy"
 	// typeConvergence is the convergence-loop root bead type. Convergence roots
 	// carry no graph metadata, so they need an explicit arm to fold into
@@ -74,9 +74,10 @@ const (
 // classify_test.go:
 //
 //   - ClassMessaging for type=message (mail) and gc:extmsg-* (extmsg).
-//   - ClassGraph for synthetic convoys (gc.synthetic on a type=convoy bead),
-//     so graph.v2 input convoys and drain-unit convoys travel with the graph
-//     they glue, while user convoys remain ClassWork.
+//   - ClassWork for synthetic convoys (gc.synthetic / gc.synthetic_kind on a
+//     type=convoy bead), stated as an explicit arm rather than left to the
+//     default — see isSyntheticConvoy for why the arm has to be explicit and
+//     why it has to run before the workflow arm.
 //   - ClassGraph for convergence roots (type=convergence), folding the
 //     convergence engine's state in with the graph it pours.
 //
@@ -161,9 +162,12 @@ func classifyFields(beadType string, labels []string, metadata, metadataRefs map
 		return ClassSessions
 	case hasLabel(labels, labelNudge) || hasLabel(labels, labelNudgeQueue):
 		return ClassNudges
-	case isWorkflowMetadata(metadata) || isWorkflowMetadata(metadataRefs):
-		return ClassGraph
+	// Ahead of the workflow arm on purpose: a synthetic convoy is glue for a
+	// graph and can carry that graph's markers, and the workflow arm would take
+	// it on any one of them. See isSyntheticConvoy.
 	case beadType == typeConvoy && isSyntheticConvoy(metadata):
+		return ClassWork
+	case isWorkflowMetadata(metadata) || isWorkflowMetadata(metadataRefs):
 		return ClassGraph
 	case beadType == typeConvergence:
 		return ClassGraph
@@ -193,6 +197,24 @@ func isWorkflowMetadata(metadata map[string]string) bool {
 
 // isSyntheticConvoy reports whether a convoy bead is system-minted glue
 // (graph.v2 input convoy or drain-unit convoy) rather than a human/sling convoy.
+//
+// It exists to route those convoys to ClassWork, which is where the default
+// would put them anyway — so the arm looks redundant and is not. Two things
+// make it load-bearing:
+//
+// It has to run BEFORE the workflow arm. A synthetic convoy is minted as glue
+// for a specific graph and carries that graph's identifying metadata (a
+// drain-unit convoy names its control and its parent convoy; nothing stops a
+// future one from carrying gc.root_bead_id, which is all the workflow arm
+// needs). Left to the default, the classification of a convoy would depend on
+// which incidental keys happen to be stamped on it.
+//
+// And a misclassification here is not a routing preference, it is a hard
+// failure. A convoy exists to hold `tracks` edges to its members, its members
+// are work beads, and convoy.TrackItemIn refuses an edge whose member is owned
+// by another class because a dep row cannot reference an id its own store
+// cannot resolve. A synthetic convoy classified anywhere but Work is a convoy
+// that can never track anything.
 func isSyntheticConvoy(metadata map[string]string) bool {
 	if metadata == nil {
 		return false

--- a/internal/coordclass/classify_test.go
+++ b/internal/coordclass/classify_test.go
@@ -28,6 +28,12 @@ func TestClassifyGoldenTable(t *testing.T) {
 		{"merge-request", beads.Bead{Type: "merge-request"}, ClassWork},
 		{"user convoy (not synthetic)", beads.Bead{Type: "convoy", Labels: []string{"owned"}}, ClassWork},
 		{"spec doc bead", beads.Bead{Type: "spec"}, ClassWork},
+		// A convoy is a work bead, synthetic ones included. It holds `tracks`
+		// edges to work members, and TrackItemIn refuses an edge across a class
+		// boundary, so a synthetic convoy owned by any other class is a convoy
+		// that can never track the members it was minted for.
+		{"synthetic input convoy", beads.Bead{Type: "convoy", Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"}}, ClassWork},
+		{"drain-unit convoy", beads.Bead{Type: "convoy", Metadata: map[string]string{beadmeta.SyntheticKindMetadataKey: "drain-unit-convoy"}}, ClassWork},
 
 		// ---- GRAPH (formula-v2 topology + control lane; the explosion) ----
 		// Convergence roots carry no graph metadata, so this is a deliberate
@@ -41,8 +47,6 @@ func TestClassifyGoldenTable(t *testing.T) {
 		{"graph child by root_bead_id", beads.Bead{Type: "step", Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "gc-100"}}, ClassGraph},
 		{"control bead (fanout) by root_bead_id", beads.Bead{Type: "task", Metadata: map[string]string{beadmeta.KindMetadataKey: "fanout", beadmeta.RootBeadIDMetadataKey: "gc-100"}}, ClassGraph},
 		{"embedded work-typed step stays with graph", beads.Bead{Type: "bug", Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "gc-100"}}, ClassGraph},
-		{"synthetic input convoy", beads.Bead{Type: "convoy", Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"}}, ClassGraph},
-		{"drain-unit convoy", beads.Bead{Type: "convoy", Metadata: map[string]string{beadmeta.SyntheticKindMetadataKey: "drain-unit-convoy"}}, ClassGraph},
 
 		// ---- MESSAGING (net-new arm: was work under policy store) ----
 		{"mail message", beads.Bead{Type: "message"}, ClassMessaging},
@@ -96,6 +100,25 @@ func TestClassifyGoldenTable(t *testing.T) {
 		// ---- PRECEDENCE (tracker/session arms win over the broad workflow arm) ----
 		{"order-tracking with stray root_bead_id stays orders", beads.Bead{Type: "task", Labels: []string{"order-tracking"}, Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "gc-9"}}, ClassOrders},
 		{"session with stray root_bead_id stays sessions", beads.Bead{Type: "session", Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "gc-9"}}, ClassSessions},
+
+		// ---- PRECEDENCE (the synthetic-convoy arm wins over the workflow arm) ----
+		// A synthetic convoy is glue for one specific graph and carries that
+		// graph's markers. If the workflow arm reached it first, the convoy would
+		// answer to the graph class while its members stayed in work — and
+		// TrackItemIn refuses that edge, so the convoy could never track them.
+		// This is why the arm is explicit rather than left to the default.
+		{"synthetic convoy with root_bead_id stays work", beads.Bead{Type: "convoy", Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true", beadmeta.RootBeadIDMetadataKey: "gc-9"}}, ClassWork},
+		{"drain-unit convoy with graph.v2 contract stays work", beads.Bead{Type: "convoy", Metadata: map[string]string{beadmeta.SyntheticKindMetadataKey: "drain-unit-convoy", beadmeta.FormulaContractMetadataKey: "graph.v2"}}, ClassWork},
+		// The arm is scoped to convoys: a non-convoy bead carrying gc.synthetic
+		// is not exempted from the workflow arm by it.
+		{"non-convoy synthetic bead is unaffected by the convoy arm", beads.Bead{Type: "task", Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true", beadmeta.RootBeadIDMetadataKey: "gc-9"}}, ClassGraph},
+		// And the wisp arm still runs first, so no bead a wisp marker reaches can
+		// be pulled into work by the convoy arm. This is what bounds the
+		// reclassification for a converged city: the only beads whose class moves
+		// are type=convoy beads carrying a synthetic marker, so an existing
+		// city's wisp population — and everything the strand detector says about
+		// it — is untouched.
+		{"a wisp carrying a synthetic marker is still graph", beads.Bead{Type: "convoy", Labels: []string{"gc:wisp"}, Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"}}, ClassGraph},
 	}
 
 	for _, tc := range cases {

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -138,7 +138,7 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 			row.UnitConvoyID = unit.ID
 			row.Status = "unit-created"
 		} else {
-			reloaded, err := reloadDrainUnitConvoy(store, row.UnitConvoyID, member, opts)
+			reloaded, err := reloadDrainUnitConvoy(store, row.UnitConvoyID, opts)
 			if err != nil {
 				return ControlResult{}, fmt.Errorf("%s: loading drain unit convoy %s: %w", bead.ID, row.UnitConvoyID, err)
 			}
@@ -146,11 +146,11 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 		}
 
 		if row.ItemRootID == "" {
-			blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, manifest, opts)
+			projection, err := drainProjectedBlockerIDs(store, member.ID, manifest, opts)
 			if err != nil {
 				return ControlResult{}, fmt.Errorf("%s: listing source dependencies for member %s: %w", bead.ID, member.ID, err)
 			}
-			rootID, created, err := ensureDrainItemRoot(store, bead, unit, member, len(members), row, itemFormula, parentVars, blockerIDs, opts)
+			rootID, created, err := ensureDrainItemRoot(store, bead, unit, member, len(members), row, itemFormula, parentVars, projection.BlockerIDs, opts)
 			if err != nil {
 				if errors.Is(err, errDrainInvalidItemFormula) {
 					return closeDrainItemFormulaFailure(store, bead, manifest, err, opts)
@@ -640,18 +640,18 @@ func materializeDrainRow(store beads.Store, control beads.Bead, manifest drainMa
 		row.UnitConvoyID = unit.ID
 		row.Status = "unit-created"
 	} else {
-		reloaded, err := reloadDrainUnitConvoy(store, row.UnitConvoyID, member, opts)
+		reloaded, err := reloadDrainUnitConvoy(store, row.UnitConvoyID, opts)
 		if err != nil {
 			return 0, fmt.Errorf("%s: loading drain unit convoy %s: %w", control.ID, row.UnitConvoyID, err)
 		}
 		unit = reloaded
 	}
 	if row.ItemRootID == "" {
-		blockerIDs, err := drainProjectedBlockerIDs(store, member.ID, manifest, opts)
+		projection, err := drainProjectedBlockerIDs(store, member.ID, manifest, opts)
 		if err != nil {
 			return 0, fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, member.ID, err)
 		}
-		rootID, created, err := ensureDrainItemRoot(store, control, unit, member, len(members), row, itemFormula, parentVars, blockerIDs, opts)
+		rootID, created, err := ensureDrainItemRoot(store, control, unit, member, len(members), row, itemFormula, parentVars, projection.BlockerIDs, opts)
 		if err != nil {
 			return 0, err
 		}
@@ -692,17 +692,20 @@ func ensureDrainDependencyProjection(store beads.Store, control beads.Bead, mani
 }
 
 func ensureDrainRowDependencyProjection(store beads.Store, control beads.Bead, manifest drainManifest, memberID, rootID string, opts ProcessOptions) error {
-	blockerIDs, err := drainProjectedBlockerIDs(store, memberID, manifest, opts)
+	projection, err := drainProjectedBlockerIDs(store, memberID, manifest, opts)
 	if err != nil {
 		return fmt.Errorf("%s: listing source dependencies for member %s: %w", control.ID, memberID, err)
 	}
-	for _, blockerID := range blockerIDs {
+	for _, blockerID := range projection.BlockerIDs {
 		if blockerID == rootID {
 			continue
 		}
 		if err := ensureDrainWorkflowBlocksOn(store, rootID, blockerID); err != nil {
 			return fmt.Errorf("%s: wiring item workflow %s for member %s to blocker %s: %w", control.ID, rootID, memberID, blockerID, err)
 		}
+	}
+	if err := recordUnprojectableDrainBlockers(store, control, memberID, rootID, projection.Unprojectable, opts); err != nil {
+		return fmt.Errorf("%s: recording unprojectable blockers for member %s: %w", control.ID, memberID, err)
 	}
 	if err := repairDrainWorkflowSourceMemberDeps(store, manifest, memberID, rootID); err != nil {
 		return fmt.Errorf("%s: repairing source-member dependencies on item workflow %s for member %s: %w", control.ID, rootID, memberID, err)
@@ -735,7 +738,85 @@ func drainManifestMemberIDs(manifest drainManifest) map[string]bool {
 	return memberIDs
 }
 
-func drainProjectedBlockerIDs(store beads.Store, memberID string, manifest drainManifest, opts ProcessOptions) ([]string, error) {
+// drainBlockerProjection is the result of projecting one drain member's
+// ready-blocking dependencies onto its item workflow.
+type drainBlockerProjection struct {
+	// BlockerIDs are the ids the item workflow's beads can actually depend on:
+	// either another manifest row's item root, or an out-of-manifest blocker the
+	// item workflow's own store can resolve.
+	BlockerIDs []string
+
+	// Unprojectable are out-of-manifest blockers that are still open and that the
+	// item workflow's own store cannot resolve, so the constraint they express
+	// cannot be written down at all. Sorted, and recorded on the item root by
+	// ensureDrainRowDependencyProjection.
+	Unprojectable []string
+}
+
+// drainBlockerResidence classifies one out-of-manifest blocker for projection.
+type drainBlockerResidence int
+
+const (
+	// drainBlockerUnclassified is the zero value, returned only alongside an
+	// error. It is not a decision, and the projection switch refuses it rather
+	// than letting a read failure look like a dropped blocker.
+	drainBlockerUnclassified drainBlockerResidence = iota
+
+	// drainBlockerProjectable: the item workflow's own store resolves the
+	// blocker, so the dependency edge is writable and means what it says.
+	drainBlockerProjectable
+
+	// drainBlockerSatisfied: the blocker is not co-resident, but it is already
+	// terminal, so it constrains nothing. Omitting the edge loses no meaning —
+	// on a single-store city the edge exists and the readiness reader ignores it
+	// for exactly the same reason.
+	drainBlockerSatisfied
+
+	// drainBlockerUnprojectable: the blocker is not co-resident and is still an
+	// open constraint. Omitting the edge does lose meaning, so it is recorded.
+	drainBlockerUnprojectable
+)
+
+// classifyDrainBlocker decides whether an out-of-manifest blocker can be
+// projected onto an item workflow that lives in store.
+//
+// A dependency row lives in one store's dep table and can only reference an id
+// that store resolves — the same rule convoy.ErrMemberNotCoResident enforces for
+// membership edges. Writing one anyway does not degrade to "unenforced": the
+// readiness reader LEFT JOINs the blocker row, so an absent target yields a NULL
+// status that is never 'closed', and the dependent bead drops out of Ready
+// permanently. Closing the real blocker in its own store cannot release it,
+// because the store holding the edge can never see that row. So the choice is
+// not between a strict edge and a loose one, it is between omitting the edge and
+// wedging the workflow forever.
+//
+// Single-store callers skip the check entirely: there is one store, so every id
+// it resolves is co-resident and the probe would be pure overhead.
+func classifyDrainBlocker(store beads.Store, blockerID string, opts ProcessOptions) (drainBlockerResidence, error) {
+	if len(opts.MemberStores) == 0 {
+		return drainBlockerProjectable, nil
+	}
+	if _, err := store.Get(blockerID); err == nil {
+		return drainBlockerProjectable, nil
+	} else if !errors.Is(err, beads.ErrNotFound) {
+		return drainBlockerUnclassified, err
+	}
+	blocker, err := storeref.Resolve(blockerID, opts.MemberStores)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			// Resolvable nowhere: the source member's own edge already dangles.
+			// Report it rather than copying the dangle into another store.
+			return drainBlockerUnprojectable, nil
+		}
+		return drainBlockerUnclassified, err
+	}
+	if convoycore.IsTerminalStatus(blocker.Status) {
+		return drainBlockerSatisfied, nil
+	}
+	return drainBlockerUnprojectable, nil
+}
+
+func drainProjectedBlockerIDs(store beads.Store, memberID string, manifest drainManifest, opts ProcessOptions) (drainBlockerProjection, error) {
 	rootByMember := drainRootByMember(manifest)
 	manifestMembers := drainManifestMemberIDs(manifest)
 	// A member work bead's dependency edges are co-resident with it and may live
@@ -744,14 +825,14 @@ func drainProjectedBlockerIDs(store beads.Store, memberID string, manifest drain
 	// ambient store for single-store callers — see drainMemberDepStore).
 	memberStore, err := drainMemberDepStore(store, memberID, opts)
 	if err != nil {
-		return nil, err
+		return drainBlockerProjection{}, err
 	}
 	deps, err := memberStore.DepList(memberID, "down")
 	if err != nil {
-		return nil, err
+		return drainBlockerProjection{}, err
 	}
 	seen := make(map[string]bool, len(deps))
-	blockerIDs := make([]string, 0, len(deps))
+	projection := drainBlockerProjection{BlockerIDs: make([]string, 0, len(deps))}
 	for _, dep := range deps {
 		if !beads.IsReadyBlockingDependencyType(dep.Type) {
 			continue
@@ -761,8 +842,10 @@ func drainProjectedBlockerIDs(store beads.Store, memberID string, manifest drain
 			continue
 		}
 		blockerID := dependsOnID
+		onItemRoot := false
 		if projectedRootID := strings.TrimSpace(rootByMember[dependsOnID]); projectedRootID != "" {
 			blockerID = projectedRootID
+			onItemRoot = true
 		} else if manifestMembers[dependsOnID] {
 			// An in-manifest member without a materialized item root must not
 			// be embedded as a blocker: drains do not close source members,
@@ -776,9 +859,59 @@ func drainProjectedBlockerIDs(store beads.Store, memberID string, manifest drain
 			continue
 		}
 		seen[blockerID] = true
-		blockerIDs = append(blockerIDs, blockerID)
+		if onItemRoot {
+			// Item roots are minted in store, so this one is co-resident by
+			// construction and needs no probe.
+			projection.BlockerIDs = append(projection.BlockerIDs, blockerID)
+			continue
+		}
+		residence, err := classifyDrainBlocker(store, blockerID, opts)
+		if err != nil {
+			return drainBlockerProjection{}, err
+		}
+		switch residence {
+		case drainBlockerProjectable:
+			projection.BlockerIDs = append(projection.BlockerIDs, blockerID)
+		case drainBlockerSatisfied:
+			opts.tracef("drain: member %s blocker %s is already terminal and lives outside the item workflow's store; not projecting an edge that would constrain nothing", memberID, blockerID)
+		case drainBlockerUnprojectable:
+			projection.Unprojectable = append(projection.Unprojectable, blockerID)
+		default:
+			return drainBlockerProjection{}, fmt.Errorf("classifying blocker %s for member %s: unclassified residence %d", blockerID, memberID, residence)
+		}
 	}
-	return blockerIDs, nil
+	slices.Sort(projection.Unprojectable)
+	return projection, nil
+}
+
+// recordUnprojectableDrainBlockers stamps the blockers a drain could not express
+// onto the item root, so an item workflow that runs without a constraint its
+// source member had says so on its own bead instead of only in a log line.
+//
+// It is a durable record rather than a failure on purpose. Refusing the drain
+// would turn the commonest backlog shape — a member with any out-of-convoy
+// `blocks` edge — into a hard control failure on split cities, which is the
+// terminal state this routing exists to remove; and writing the edge anyway
+// wedges the item workflow permanently (see classifyDrainBlocker). Recording is
+// the only option that neither loses the information nor stalls the work.
+func recordUnprojectableDrainBlockers(store beads.Store, control beads.Bead, memberID, rootID string, blockerIDs []string, opts ProcessOptions) error {
+	if len(blockerIDs) == 0 {
+		return nil
+	}
+	value := strings.Join(blockerIDs, ",")
+	root, err := store.Get(rootID)
+	if err != nil {
+		return fmt.Errorf("loading item root %s: %w", rootID, err)
+	}
+	if root.Metadata[beadmeta.DrainUnprojectedBlockersMetadataKey] == value {
+		return nil
+	}
+	opts.tracef("drain %s: member %s is blocked by %s, which the item workflow's store cannot resolve; item root %s runs without that constraint (recorded as %s)",
+		control.ID, memberID, value, rootID, beadmeta.DrainUnprojectedBlockersMetadataKey)
+	if err := store.SetMetadata(rootID, beadmeta.DrainUnprojectedBlockersMetadataKey, value); err != nil {
+		return fmt.Errorf("recording unprojectable blockers on item root %s: %w", rootID, err)
+	}
+	return nil
 }
 
 func ensureDrainWorkflowBlocksOn(store beads.Store, rootID, blockerID string) error {
@@ -1025,9 +1158,43 @@ func orderDrainMembersByDependencies(store beads.Store, members []beads.Bead, op
 	return ordered, nil
 }
 
-// drainUnitConvoyStore returns the store a drain mints its unit convoy in, looks
-// it up in, and reads it back from: the store that owns the member the unit
-// convoy exists to track.
+// drainUnitConvoyProbeSet returns the ordered store set a drain resolves its own
+// unit convoys through: the work-class member stores first, then the ambient
+// store.
+//
+// It is the reverse of drainMemberProbeSet, and deliberately so. A unit convoy is
+// a SYNTHETIC convoy and a synthetic convoy is a WORK bead (coordclass.Classify),
+// so the work class is the authoritative answer and the ambient graph binding is
+// only a fallback for rows that predate that ruling. Asking the binding first
+// gets the wrong answer on a real converged city: cities migrated under the
+// previous classification carry an EDGELESS copy of every synthetic convoy in
+// their binding (`gc storage migrate` copied the row; importInfraSnapshot re-added
+// only the edges whose both endpoints were infra), so the binding can answer
+// gc.drain_unit_key with a convoy that has no tracks edge and cannot grow one.
+//
+// With no member stores configured — every single-store caller — this is the one
+// ambient store, so every read through it is the single read it is today.
+func drainUnitConvoyProbeSet(store beads.Store, opts ProcessOptions) []beads.Store {
+	probe := make([]beads.Store, 0, 1+len(opts.MemberStores))
+	probe = append(probe, opts.MemberStores...)
+	probe = append(probe, store)
+	return probe
+}
+
+// drainWorkClassStore returns the handle for the work class: the first member
+// store the caller named, or the ambient store when it named none.
+func drainWorkClassStore(store beads.Store, opts ProcessOptions) beads.Store {
+	for _, probe := range opts.MemberStores {
+		if probe == nil {
+			continue
+		}
+		return probe
+	}
+	return store
+}
+
+// drainUnitConvoyStore returns the store a drain MINTS a unit convoy in: the
+// store that owns the member the unit convoy exists to track.
 //
 // That is not a choice among stores, it is the only store that works. A drain
 // unit convoy is a SYNTHETIC convoy and a synthetic convoy is a WORK bead
@@ -1038,33 +1205,87 @@ func orderDrainMembersByDependencies(store beads.Store, members []beads.Bead, op
 // anywhere else the convoy can never track the member it was created for, and
 // the drain fails on the very next call.
 //
+// A member no store can resolve pins the convoy to the WORK class rather than
+// falling back to the ambient store. An unresolved member is a supported state,
+// not an error — loadDrainManifestMembers synthesizes a placeholder for a member
+// deleted mid-drain and trackDrainMember stamps gc.drain_member_unresolved
+// instead of writing an edge — so the mint still has to happen, and it still has
+// to happen in the class that owns synthetic convoys. Falling back to the ambient
+// graph binding would write a work-class bead into the infra ledger, which the
+// migration's own equality invariant says never happens.
+//
+// Only the mint is derived from the member. Lookup by gc.drain_unit_key and
+// reload by id go through drainUnitConvoyProbeSet, because a member's
+// resolvability can change between drain passes while the convoy it already
+// minted does not move.
+//
 // With no member stores configured — every single-store caller — it returns the
-// ambient store without the owning-store probe, so the lookup, the create and
-// the reload are the same single-store reads they are today, with no extra
-// round-trip.
+// ambient store without any probe, so the create is the same single-store write
+// it is today, with no extra round-trip.
 func drainUnitConvoyStore(store beads.Store, member beads.Bead, opts ProcessOptions) (beads.Store, error) {
 	if len(opts.MemberStores) == 0 {
 		return store, nil
 	}
-	return drainMemberOwningStore(store, strings.TrimSpace(member.ID), opts)
+	memberID := strings.TrimSpace(member.ID)
+	if memberID == "" || convoycore.IsUnresolvedTrackedItem(member) {
+		return drainWorkClassStore(store, opts), nil
+	}
+	for _, probe := range drainUnitConvoyProbeSet(store, opts) {
+		if probe == nil {
+			continue
+		}
+		if _, err := probe.Get(memberID); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		return probe, nil
+	}
+	return drainWorkClassStore(store, opts), nil
+}
+
+// drainUnitConvoyByKey finds the unit convoy a previous pass already minted for
+// row.UnitKey, and the store that holds it, across every candidate store.
+//
+// The key is the idempotence token for the mint, so the lookup has to see every
+// store the mint could have chosen. Running it against one store re-derived from
+// the member is what mints a duplicate: a member that resolved on the pass that
+// minted the convoy and does not resolve on the pass that resumes sends the
+// lookup to a different store, it misses, and the drain mints a second unit
+// convoy for a row that already has one.
+func drainUnitConvoyByKey(store beads.Store, unitKey string, opts ProcessOptions) (beads.Bead, beads.Store, bool, error) {
+	for _, probe := range drainUnitConvoyProbeSet(store, opts) {
+		if probe == nil {
+			continue
+		}
+		existing, err := probe.ListByMetadata(map[string]string{beadmeta.DrainUnitKeyMetadataKey: unitKey}, 1, beads.WithBothTiers)
+		if err != nil {
+			return beads.Bead{}, nil, false, err
+		}
+		if len(existing) > 0 {
+			return existing[0], probe, true, nil
+		}
+	}
+	return beads.Bead{}, nil, false, nil
 }
 
 func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID string, count int, row drainManifestRow, member beads.Bead, opts ProcessOptions) (beads.Bead, bool, error) {
-	unitStore, err := drainUnitConvoyStore(store, member, opts)
-	if err != nil {
-		return beads.Bead{}, false, fmt.Errorf("%s: resolving the store for member %s: %w", control.ID, member.ID, err)
-	}
 	unlock := graphv2.LockKey(row.UnitKey)
 	defer unlock()
-	existing, err := unitStore.ListByMetadata(map[string]string{beadmeta.DrainUnitKeyMetadataKey: row.UnitKey}, 1, beads.WithBothTiers)
+	existing, existingStore, found, err := drainUnitConvoyByKey(store, row.UnitKey, opts)
 	if err != nil {
 		return beads.Bead{}, false, fmt.Errorf("%s: looking up unit convoy for member %s: %w", control.ID, member.ID, err)
 	}
-	if len(existing) > 0 {
-		if err := ensureDrainUnitTrack(unitStore, control.ID, existing[0].ID, member); err != nil {
+	if found {
+		if err := ensureDrainUnitTrack(existingStore, control.ID, existing.ID, member); err != nil {
 			return beads.Bead{}, false, err
 		}
-		return existing[0], false, nil
+		return existing, false, nil
+	}
+	unitStore, err := drainUnitConvoyStore(store, member, opts)
+	if err != nil {
+		return beads.Bead{}, false, fmt.Errorf("%s: resolving the store for member %s: %w", control.ID, member.ID, err)
 	}
 	metadata := map[string]string{
 		beadmeta.SyntheticMetadataKey:         "true",
@@ -1093,16 +1314,25 @@ func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID
 }
 
 // reloadDrainUnitConvoy re-reads a unit convoy a previous pass already minted,
-// from the store that owns it. A drain resumes from its persisted manifest, so
-// the reload has to reach the same ledger drainUnitConvoyStore minted into —
-// reading the ambient graph store instead would report a unit convoy that exists
-// as missing, which fails the whole dispatch.
-func reloadDrainUnitConvoy(store beads.Store, unitConvoyID string, member beads.Bead, opts ProcessOptions) (beads.Bead, error) {
-	unitStore, err := drainUnitConvoyStore(store, member, opts)
-	if err != nil {
-		return beads.Bead{}, err
+// by the convoy's OWN id, exactly as loadDrainManifestMembers re-reads a member
+// by its own id.
+//
+// Re-deriving the store from the member instead is unstable across passes, and
+// that instability is a permanent quarantine rather than a retry. The manifest
+// persists row.UnitConvoyID but not the store that answered when it was minted,
+// so a member that resolves on the minting pass and not on the resuming pass —
+// a hard delete between passes, which the drain otherwise tolerates by design —
+// sends the reload to a different store, Get reports a convoy that exists as
+// missing, and a not-found is not a transient controller error, so the caller
+// quarantines the control instead of retrying it.
+//
+// With no member stores configured this is the same single store.Get it has
+// always been, including its error text.
+func reloadDrainUnitConvoy(store beads.Store, unitConvoyID string, opts ProcessOptions) (beads.Bead, error) {
+	if len(opts.MemberStores) == 0 {
+		return store.Get(unitConvoyID)
 	}
-	return unitStore.Get(unitConvoyID)
+	return storeref.Resolve(unitConvoyID, drainUnitConvoyProbeSet(store, opts))
 }
 
 func ensureDrainUnitTrack(store beads.Store, controlID, unitConvoyID string, member beads.Bead) error {

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -128,7 +128,7 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 		if row.UnitConvoyID == "" {
 			var created bool
 			var err error
-			unit, created, err = ensureDrainUnitConvoy(store, bead, parentConvoyID, len(members), *row, member)
+			unit, created, err = ensureDrainUnitConvoy(store, bead, parentConvoyID, len(members), *row, member, opts)
 			if err != nil {
 				return ControlResult{}, err
 			}
@@ -138,7 +138,7 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 			row.UnitConvoyID = unit.ID
 			row.Status = "unit-created"
 		} else {
-			reloaded, err := store.Get(row.UnitConvoyID)
+			reloaded, err := reloadDrainUnitConvoy(store, row.UnitConvoyID, member, opts)
 			if err != nil {
 				return ControlResult{}, fmt.Errorf("%s: loading drain unit convoy %s: %w", bead.ID, row.UnitConvoyID, err)
 			}
@@ -356,25 +356,31 @@ func drainMemberDepStore(store beads.Store, memberID string, opts ProcessOptions
 // never seen the convoy answers both reads EMPTY rather than erroring, and an
 // empty membership is indistinguishable from a genuinely empty input convoy, so
 // the drain expands to zero rows and closes gc.outcome=pass with every member
-// left open and undispatched. A graph.v2 input convoy is minted alongside its
-// work members (convoycore.TrackItemIn refuses a tracks edge whose member is
-// owned by another class, so a convoy is co-resident with its members), which
-// puts the edges in the work store while the drain runs in the binding.
+// left open and undispatched.
 //
-// Picking one store as the owner is not enough, because on a converged city the
-// convoy bead exists in BOTH: gc storage migrate copies the synthetic convoy row
-// into the binding while importInfraSnapshot re-adds only the edges whose both
-// endpoints are infra, so the copy carries no membership at all. An owner probe
-// finds that empty copy first and reports the same silent zero.
+// Which store SHOULD answer is settled: a convoy is a work bead, synthetic ones
+// included, so its edges are in the work store while the drain runs in the
+// binding. The work leg is therefore the authoritative one and the graph leg is
+// expected to contribute nothing.
 //
-// So membership is read as the UNION of what each candidate store records, which
-// is what convoy membership already is — an edge inventory. The union is
-// order-free and monotone: a store that never saw the convoy contributes
-// nothing, an edgeless migration copy contributes nothing, and no single store's
-// answer can subtract a member another store records. That makes a zero-row
-// expansion over a non-empty convoy structurally impossible rather than merely
-// unlikely. A member seen as an unresolved placeholder in one store and as a
-// real bead in another keeps the real bead.
+// It is still read as the UNION of what each candidate store records rather than
+// as a single lookup, for two reasons. A city migrated under the previous
+// classification has an edgeless copy of every synthetic convoy in its binding —
+// the migration copied the row and importInfraSnapshot re-added only the edges
+// whose both endpoints were infra — so "the store that has the convoy bead" is
+// still an ambiguous question on real disks, and answering it wrong is silent.
+// And the failure this guards is not a wrong answer but a green one: a drain
+// that could not read its membership produces byte-for-byte the same terminal
+// state as a drain that correctly found nothing to do.
+//
+// The union cannot be wrong in the way a single lookup can. It is order-free and
+// monotone — a store that never saw the convoy contributes nothing, an edgeless
+// copy contributes nothing, and no store's silence can subtract a member another
+// store records — so a zero-row expansion over a non-empty convoy is structurally
+// impossible rather than merely unlikely, and stays impossible even if some
+// future path mints a convoy somewhere this comment does not predict. A member
+// seen as an unresolved placeholder in one store and as a real bead in another
+// keeps the real bead.
 //
 // With no member stores configured — every single-store caller — this collapses
 // to the single convoycore.Members call it replaces, byte for byte.
@@ -623,7 +629,7 @@ func materializeDrainRow(store beads.Store, control beads.Bead, manifest drainMa
 	createdCount := 0
 	var unit beads.Bead
 	if row.UnitConvoyID == "" {
-		createdUnit, created, err := ensureDrainUnitConvoy(store, control, manifest.ParentConvoyID, len(members), *row, member)
+		createdUnit, created, err := ensureDrainUnitConvoy(store, control, manifest.ParentConvoyID, len(members), *row, member, opts)
 		if err != nil {
 			return 0, err
 		}
@@ -634,7 +640,7 @@ func materializeDrainRow(store beads.Store, control beads.Bead, manifest drainMa
 		row.UnitConvoyID = unit.ID
 		row.Status = "unit-created"
 	} else {
-		reloaded, err := store.Get(row.UnitConvoyID)
+		reloaded, err := reloadDrainUnitConvoy(store, row.UnitConvoyID, member, opts)
 		if err != nil {
 			return 0, fmt.Errorf("%s: loading drain unit convoy %s: %w", control.ID, row.UnitConvoyID, err)
 		}
@@ -1019,15 +1025,43 @@ func orderDrainMembersByDependencies(store beads.Store, members []beads.Bead, op
 	return ordered, nil
 }
 
-func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID string, count int, row drainManifestRow, member beads.Bead) (beads.Bead, bool, error) {
+// drainUnitConvoyStore returns the store a drain mints its unit convoy in, looks
+// it up in, and reads it back from: the store that owns the member the unit
+// convoy exists to track.
+//
+// That is not a choice among stores, it is the only store that works. A drain
+// unit convoy is a SYNTHETIC convoy and a synthetic convoy is a WORK bead
+// (coordclass.Classify), which is the same thing the mechanics already require:
+// the convoy's whole content is one `tracks` edge to one work member, and
+// convoy.TrackItemIn refuses an edge whose member is owned by another class,
+// because a dep row cannot reference an id its own store cannot resolve. Minted
+// anywhere else the convoy can never track the member it was created for, and
+// the drain fails on the very next call.
+//
+// With no member stores configured — every single-store caller — it returns the
+// ambient store without the owning-store probe, so the lookup, the create and
+// the reload are the same single-store reads they are today, with no extra
+// round-trip.
+func drainUnitConvoyStore(store beads.Store, member beads.Bead, opts ProcessOptions) (beads.Store, error) {
+	if len(opts.MemberStores) == 0 {
+		return store, nil
+	}
+	return drainMemberOwningStore(store, strings.TrimSpace(member.ID), opts)
+}
+
+func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID string, count int, row drainManifestRow, member beads.Bead, opts ProcessOptions) (beads.Bead, bool, error) {
+	unitStore, err := drainUnitConvoyStore(store, member, opts)
+	if err != nil {
+		return beads.Bead{}, false, fmt.Errorf("%s: resolving the store for member %s: %w", control.ID, member.ID, err)
+	}
 	unlock := graphv2.LockKey(row.UnitKey)
 	defer unlock()
-	existing, err := store.ListByMetadata(map[string]string{beadmeta.DrainUnitKeyMetadataKey: row.UnitKey}, 1, beads.WithBothTiers)
+	existing, err := unitStore.ListByMetadata(map[string]string{beadmeta.DrainUnitKeyMetadataKey: row.UnitKey}, 1, beads.WithBothTiers)
 	if err != nil {
 		return beads.Bead{}, false, fmt.Errorf("%s: looking up unit convoy for member %s: %w", control.ID, member.ID, err)
 	}
 	if len(existing) > 0 {
-		if err := ensureDrainUnitTrack(store, control.ID, existing[0].ID, member); err != nil {
+		if err := ensureDrainUnitTrack(unitStore, control.ID, existing[0].ID, member); err != nil {
 			return beads.Bead{}, false, err
 		}
 		return existing[0], false, nil
@@ -1043,7 +1077,7 @@ func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID
 		beadmeta.DrainMemberAccessMetadataKey: drainMemberAccess(control),
 		beadmeta.DrainUnitKeyMetadataKey:      row.UnitKey,
 	}
-	created, err := store.Create(beads.Bead{
+	created, err := unitStore.Create(beads.Bead{
 		Title:    fmt.Sprintf("drain unit %d for %s", row.Index, member.ID),
 		Type:     "convoy",
 		Priority: member.Priority,
@@ -1052,10 +1086,23 @@ func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID
 	if err != nil {
 		return beads.Bead{}, false, fmt.Errorf("%s: creating unit convoy for member %s: %w", control.ID, member.ID, err)
 	}
-	if err := trackDrainMember(store, created.ID, member); err != nil {
+	if err := trackDrainMember(unitStore, created.ID, member); err != nil {
 		return beads.Bead{}, false, fmt.Errorf("%s: tracking member %s from unit convoy %s: %w", control.ID, member.ID, created.ID, err)
 	}
 	return created, true, nil
+}
+
+// reloadDrainUnitConvoy re-reads a unit convoy a previous pass already minted,
+// from the store that owns it. A drain resumes from its persisted manifest, so
+// the reload has to reach the same ledger drainUnitConvoyStore minted into —
+// reading the ambient graph store instead would report a unit convoy that exists
+// as missing, which fails the whole dispatch.
+func reloadDrainUnitConvoy(store beads.Store, unitConvoyID string, member beads.Bead, opts ProcessOptions) (beads.Bead, error) {
+	unitStore, err := drainUnitConvoyStore(store, member, opts)
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	return unitStore.Get(unitConvoyID)
 }
 
 func ensureDrainUnitTrack(store beads.Store, controlID, unitConvoyID string, member beads.Bead) error {

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -215,7 +215,7 @@ func loadOrBuildDrainManifest(store beads.Store, bead beads.Bead, parentConvoyID
 		}
 		return manifest, members, nil
 	}
-	members, err := convoycore.Members(store, parentConvoyID, false, opts.MemberStores...)
+	members, err := drainConvoyMembers(store, parentConvoyID, opts)
 	if err != nil {
 		return drainManifest{}, nil, fmt.Errorf("%s: loading convoy members for %s: %w", bead.ID, parentConvoyID, err)
 	}
@@ -344,6 +344,75 @@ func drainMemberDepStore(store beads.Store, memberID string, opts ProcessOptions
 		return store, nil
 	}
 	return drainMemberOwningStore(store, memberID, opts)
+}
+
+// drainConvoyMembers reads a drain's input-convoy membership across every
+// candidate store rather than from the one store the drain itself runs in.
+//
+// opts.MemberStores resolves member beads, and that is only the TAIL of the
+// lookup. The head — the convoy's own legacy children (List by ParentID) and its
+// tracks edges (DepList) — is read from a single handle, and reading it from the
+// ambient graph store is what silently loses a whole convoy: a store that has
+// never seen the convoy answers both reads EMPTY rather than erroring, and an
+// empty membership is indistinguishable from a genuinely empty input convoy, so
+// the drain expands to zero rows and closes gc.outcome=pass with every member
+// left open and undispatched. A graph.v2 input convoy is minted alongside its
+// work members (convoycore.TrackItemIn refuses a tracks edge whose member is
+// owned by another class, so a convoy is co-resident with its members), which
+// puts the edges in the work store while the drain runs in the binding.
+//
+// Picking one store as the owner is not enough, because on a converged city the
+// convoy bead exists in BOTH: gc storage migrate copies the synthetic convoy row
+// into the binding while importInfraSnapshot re-adds only the edges whose both
+// endpoints are infra, so the copy carries no membership at all. An owner probe
+// finds that empty copy first and reports the same silent zero.
+//
+// So membership is read as the UNION of what each candidate store records, which
+// is what convoy membership already is — an edge inventory. The union is
+// order-free and monotone: a store that never saw the convoy contributes
+// nothing, an edgeless migration copy contributes nothing, and no single store's
+// answer can subtract a member another store records. That makes a zero-row
+// expansion over a non-empty convoy structurally impossible rather than merely
+// unlikely. A member seen as an unresolved placeholder in one store and as a
+// real bead in another keeps the real bead.
+//
+// With no member stores configured — every single-store caller — this collapses
+// to the single convoycore.Members call it replaces, byte for byte.
+func drainConvoyMembers(store beads.Store, convoyID string, opts ProcessOptions) ([]beads.Bead, error) {
+	if len(opts.MemberStores) == 0 {
+		return convoycore.Members(store, convoyID, false)
+	}
+	var merged []beads.Bead
+	at := make(map[string]int)
+	for _, probe := range drainMemberProbeSet(store, opts) {
+		if probe == nil {
+			continue
+		}
+		members, err := convoycore.Members(probe, convoyID, false, opts.MemberStores...)
+		if err != nil {
+			return nil, err
+		}
+		for _, member := range members {
+			i, seen := at[member.ID]
+			if !seen {
+				at[member.ID] = len(merged)
+				merged = append(merged, member)
+				continue
+			}
+			if convoycore.IsUnresolvedTrackedItem(merged[i]) && !convoycore.IsUnresolvedTrackedItem(member) {
+				merged[i] = member
+			}
+		}
+	}
+	// Same order convoycore.MembersIn returns within one store, so the manifest
+	// row order does not depend on which store answered first.
+	slices.SortStableFunc(merged, func(a, b beads.Bead) int {
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+	return merged, nil
 }
 
 func loadDrainManifestMembers(store beads.Store, controlID string, manifest drainManifest, opts ProcessOptions) ([]beads.Bead, error) {

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -296,12 +296,15 @@ func TestDrainProjectedBlockerIDsRoutesMemberDepsToOwningStore(t *testing.T) {
 		},
 	}
 
-	blockerIDs, err := drainProjectedBlockerIDs(ambient, dependent.ID, manifest, ProcessOptions{MemberStores: []beads.Store{memberStore}})
+	projection, err := drainProjectedBlockerIDs(ambient, dependent.ID, manifest, ProcessOptions{MemberStores: []beads.Store{memberStore}})
 	if err != nil {
 		t.Fatalf("drainProjectedBlockerIDs: %v", err)
 	}
-	if len(blockerIDs) != 1 || blockerIDs[0] != "root-blocker" {
-		t.Fatalf("blockerIDs = %v, want [root-blocker] (member deps routed to member store, projected onto the blocker's item root)", blockerIDs)
+	if len(projection.BlockerIDs) != 1 || projection.BlockerIDs[0] != "root-blocker" {
+		t.Fatalf("blockerIDs = %v, want [root-blocker] (member deps routed to member store, projected onto the blocker's item root)", projection.BlockerIDs)
+	}
+	if len(projection.Unprojectable) != 0 {
+		t.Fatalf("unprojectable = %v, want none: an in-manifest blocker projects onto an item root, which is co-resident with the item workflow by construction", projection.Unprojectable)
 	}
 }
 
@@ -2190,5 +2193,474 @@ func TestDrainUnitConvoyStoreFollowsTheMemberAcrossTheClassBoundary(t *testing.T
 	}
 	if got != beads.Store(work) {
 		t.Fatalf("drainUnitConvoyStore chose the ambient graph store for a work-resident member; the tracks edge it is about to write cannot reference an id that store cannot resolve")
+	}
+}
+
+// itemWorkflowBeadIDs returns every bead id in the item workflow rooted at
+// rootID, so an assertion can talk about the whole molecule rather than guessing
+// which step carries the projection.
+func itemWorkflowBeadIDs(t *testing.T, store beads.Store, rootID string) []string {
+	t.Helper()
+	workflowBeads, err := listByWorkflowRoot(store, rootID)
+	if err != nil {
+		t.Fatalf("listByWorkflowRoot(%s): %v", rootID, err)
+	}
+	ids := make([]string, 0, len(workflowBeads))
+	for _, bead := range workflowBeads {
+		ids = append(ids, bead.ID)
+	}
+	return ids
+}
+
+// assertNoUnresolvableBlockingDeps fails on any ready-blocking dependency in
+// store whose target store cannot resolve.
+//
+// This is the invariant, not a proxy for it: a dependency row lives in one
+// store's dep table, and both MemStore.readyLocked and sqliteReadySQL read a
+// missing target's status as "" — which is not "closed", so the dependent is
+// excluded from Ready forever and no action in any other store can release it.
+func assertNoUnresolvableBlockingDeps(t *testing.T, store *beads.MemStore) {
+	t.Helper()
+	all, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, bead := range all {
+		deps, err := store.DepList(bead.ID, "down")
+		if err != nil {
+			t.Fatalf("DepList(%s): %v", bead.ID, err)
+		}
+		for _, dep := range deps {
+			if !beads.IsReadyBlockingDependencyType(dep.Type) {
+				continue
+			}
+			if _, err := store.Get(dep.DependsOnID); err != nil {
+				t.Fatalf("dangling %s edge %s -> %s: the store holding the edge cannot resolve the target, so the dependent never becomes ready and closing the real blocker in its own store cannot release it: %v",
+					dep.Type, bead.ID, dep.DependsOnID, err)
+			}
+		}
+	}
+}
+
+// TestProcessDrainSplitCityResumeCompletesAfterAMemberVanishes pins the resume
+// half of routing unit convoys across the class boundary.
+//
+// A drain resumes from its persisted manifest, and expandDrain persists after
+// every row, so any mid-loop exit — ErrControlPending from the spawn boundary, a
+// reservation retry, a transient store error on row i>0 — leaves rows 0..i-1
+// with their unit convoy ids recorded and gc.drain_state=expanding. That is a
+// designed re-entry, not a crash.
+//
+// A member hard-deleted between passes is likewise a supported state, pinned for
+// single-store cities by TestProcessDrainReplayUsesManifestWhenMemberWasDeleted-
+// BeforeUnitCreation: loadDrainManifestMembers substitutes an unresolved
+// placeholder and the drain continues. Deriving the unit convoy's store from the
+// member breaks that on a split city, because the manifest records the convoy's
+// id but not the store that answered when it was minted — so mint and reload
+// disagree the moment the member's resolvability changes, and a not-found is not
+// a transient controller error, so the caller QUARANTINES the drain instead of
+// retrying it.
+func TestProcessDrainSplitCityResumeCompletesAfterAMemberVanishes(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	work, graph, drain, memberIDs := seedSplitClassDrainWorkflow(t, false)
+	opts := ProcessOptions{FormulaSearchPaths: []string{dir}, MemberStores: []beads.Store{work}}
+
+	if _, err := ProcessControl(graph, drain, opts); err != nil {
+		t.Fatalf("ProcessControl(first pass): %v", err)
+	}
+	expanded := mustDrainManifest(t, mustGetBead(t, graph, drain.ID))
+
+	// The designed re-entry: rows persisted, control still expanding.
+	if err := graph.SetMetadata(drain.ID, beadmeta.DrainStateMetadataKey, beadmeta.DrainStateExpanding); err != nil {
+		t.Fatalf("rewind gc.drain_state: %v", err)
+	}
+	if err := work.Delete(memberIDs[0]); err != nil {
+		t.Fatalf("Delete(%s): %v", memberIDs[0], err)
+	}
+
+	result, err := ProcessControl(graph, mustGetBead(t, graph, drain.ID), opts)
+	if err != nil {
+		t.Fatalf("ProcessControl(resume after a member vanished): %v; a non-transient control error is quarantined by the caller, and the drain never expands its remaining rows", err)
+	}
+	if result.Action != "drain-expanded" {
+		t.Fatalf("result = %+v, want drain-expanded", result)
+	}
+	resumed := mustDrainManifest(t, mustGetBead(t, graph, drain.ID))
+	if len(resumed.Rows) != len(expanded.Rows) {
+		t.Fatalf("manifest rows after resume = %d, want the original %d", len(resumed.Rows), len(expanded.Rows))
+	}
+	for i, row := range resumed.Rows {
+		if row.UnitConvoyID != expanded.Rows[i].UnitConvoyID {
+			t.Fatalf("row %d unit convoy = %q, want the already-minted %q; a resume that cannot find the convoy it minted mints a duplicate", i, row.UnitConvoyID, expanded.Rows[i].UnitConvoyID)
+		}
+		if row.ItemRootID != expanded.Rows[i].ItemRootID {
+			t.Fatalf("row %d item root = %q, want the already-created %q", i, row.ItemRootID, expanded.Rows[i].ItemRootID)
+		}
+		if row.Status != "wired" {
+			t.Fatalf("row %d status = %q, want wired", i, row.Status)
+		}
+	}
+}
+
+// TestProcessDrainSplitCityUnitConvoyForAVanishedMember is the mint half, and
+// the split-city counterpart of
+// TestProcessDrainReplayUsesManifestWhenMemberWasDeletedBeforeUnitCreation.
+//
+// A drain resumes with row.UnitConvoyID empty either because no pass ever got to
+// the mint, or because one crashed between minting and persisting the id — and
+// both are the same shape once the member has since been deleted, because the
+// resumed pass sees only an unresolved placeholder for it.
+//
+// Neither may be answered from the ambient graph binding. A unit convoy is a
+// synthetic convoy and a synthetic convoy is a WORK bead, so a fresh mint belongs
+// in the work store — a member no store can resolve is a reason to have no tracks
+// edge (trackDrainMember stamps gc.drain_member_unresolved instead), not a reason
+// to file the convoy in the infra ledger, which the migration's own equality
+// invariant says work never enters. And the gc.drain_unit_key lookup that decides
+// between mint and reuse has to span the same stores, or the crashed-mid-mint
+// resume silently mints a second unit convoy for a row that already has one.
+func TestProcessDrainSplitCityUnitConvoyForAVanishedMember(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		premint  bool
+		wantMint bool
+	}{
+		{name: "no unit convoy minted yet", premint: false, wantMint: true},
+		{name: "a previous pass minted one before crashing", premint: true, wantMint: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			formulatest.EnableV2ForTest(t)
+			dir := t.TempDir()
+			writeDrainItemFormula(t, dir)
+			work, graph, drain, _ := seedSplitClassDrainWorkflow(t, false)
+			if err := graph.SetMetadata(drain.ID, beadmeta.DrainMemberAccessMetadataKey, "exclusive"); err != nil {
+				t.Fatalf("SetMetadata(exclusive): %v", err)
+			}
+			drain = mustGetBead(t, graph, drain.ID)
+			root := mustGetBead(t, graph, drain.Metadata["gc.root_bead_id"])
+			parentConvoyID := root.Metadata["gc.input_convoy_id"]
+			members, err := convoycore.Members(work, parentConvoyID, false)
+			if err != nil {
+				t.Fatalf("Members: %v", err)
+			}
+			manifest := buildDrainManifest(drain, parentConvoyID, "drain-item", members)
+			missingID := manifest.Rows[0].MemberID
+
+			preminted := ""
+			if tc.premint {
+				// The mint the crashed pass completed, while the member was
+				// still resolvable. Its id never reached the manifest.
+				unit, created, err := ensureDrainUnitConvoy(graph, drain, parentConvoyID, len(members), manifest.Rows[0], members[0], ProcessOptions{MemberStores: []beads.Store{work}})
+				if err != nil {
+					t.Fatalf("pre-mint unit convoy: %v", err)
+				}
+				if !created {
+					t.Fatal("pre-mint did not create the unit convoy")
+				}
+				preminted = unit.ID
+			}
+
+			if err := work.Delete(missingID); err != nil {
+				t.Fatalf("Delete(%s): %v", missingID, err)
+			}
+			if err := persistDrainManifest(graph, drain.ID, manifest, map[string]string{beadmeta.DrainStateMetadataKey: beadmeta.DrainStateExpanding}); err != nil {
+				t.Fatalf("persist manifest: %v", err)
+			}
+
+			if _, err := ProcessControl(graph, mustGetBead(t, graph, drain.ID), ProcessOptions{
+				FormulaSearchPaths: []string{dir},
+				MemberStores:       []beads.Store{work},
+			}); err != nil {
+				t.Fatalf("ProcessControl(replay with a vanished member): %v", err)
+			}
+
+			replayed := mustDrainManifest(t, mustGetBead(t, graph, drain.ID))
+			row := replayed.Rows[0]
+			if row.UnitConvoyID == "" || row.ItemRootID == "" {
+				t.Fatalf("row = %+v, want a unit convoy and an item root despite the missing member", row)
+			}
+			if !tc.wantMint && row.UnitConvoyID != preminted {
+				t.Fatalf("row unit convoy = %s, want the already-minted %s; a gc.drain_unit_key lookup that does not span the store the mint chose mints a duplicate for a row that already has one", row.UnitConvoyID, preminted)
+			}
+			if _, err := graph.Get(row.UnitConvoyID); err == nil {
+				t.Fatalf("unit convoy %s for the vanished member %s is in the GRAPH binding; a synthetic convoy is a work bead, and the migration's own equality invariant says work never crosses into the infra ledger", row.UnitConvoyID, missingID)
+			}
+			unit, err := work.Get(row.UnitConvoyID)
+			if err != nil {
+				t.Fatalf("unit convoy %s is not in the work store either: %v", row.UnitConvoyID, err)
+			}
+			if got := unit.Metadata[beadmeta.DrainMemberUnresolvedMetadataKey]; tc.wantMint && got != "true" {
+				t.Fatalf("unit convoy metadata = %#v, want the unresolved marker", unit.Metadata)
+			}
+			unitMembers, err := convoycore.Members(work, row.UnitConvoyID, true)
+			if err != nil {
+				t.Fatalf("Members(unit): %v", err)
+			}
+			for _, member := range unitMembers {
+				if member.ID == missingID && !convoycore.IsUnresolvedTrackedItem(member) {
+					t.Fatalf("unit members = %+v, want no resolvable track to the missing member %s", unitMembers, missingID)
+				}
+			}
+			// The surviving sibling is unaffected and still lands in the work store.
+			sibling := replayed.Rows[1]
+			if _, err := work.Get(sibling.UnitConvoyID); err != nil {
+				t.Fatalf("sibling unit convoy %s is not in the work store: %v", sibling.UnitConvoyID, err)
+			}
+		})
+	}
+}
+
+// TestEnsureDrainUnitConvoyPrefersTheWorkStoreOverAnEdgelessBindingCopy pins the
+// probe ORDER of the gc.drain_unit_key idempotence lookup.
+//
+// The lookup has to span every store the mint could have chosen, or a resume
+// mints a duplicate. Spanning them primary-first gets the wrong one on a real
+// converged city: a city migrated under the previous classification carries an
+// EDGELESS copy of every synthetic convoy in its binding — `gc storage migrate`
+// copied the row, and importInfraSnapshot re-added only the edges whose both
+// endpoints were infra — so the binding answers with a convoy that has no tracks
+// edge and cannot grow one, and the repair attempt fails cross-class.
+//
+// A unit convoy is a work bead, so the work class answers first.
+func TestEnsureDrainUnitConvoyPrefersTheWorkStoreOverAnEdgelessBindingCopy(t *testing.T) {
+	work := beads.NewMemStore()
+	control, err := work.Create(beads.Bead{Title: "drain", Type: "task"})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	parent, err := work.Create(beads.Bead{Title: "parent", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	member, err := work.Create(beads.Bead{Title: "member", Type: "task"})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	row := drainManifestRow{Index: 0, MemberID: member.ID, UnitKey: "drain-unit:" + control.ID + ":0:" + member.ID}
+
+	// The real unit convoy, minted in the work store with its tracks edge.
+	minted, created, err := ensureDrainUnitConvoy(work, control, parent.ID, 1, row, member, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ensureDrainUnitConvoy(single store): %v", err)
+	}
+	if !created {
+		t.Fatal("first ensureDrainUnitConvoy did not create the unit convoy")
+	}
+
+	// What `gc storage migrate` left in the binding: the row, none of its edges.
+	graph := beads.NewMemStoreFrom(1000, []beads.Bead{minted}, nil)
+
+	reused, createdAgain, err := ensureDrainUnitConvoy(graph, control, parent.ID, 1, row, member, ProcessOptions{MemberStores: []beads.Store{work}})
+	if err != nil {
+		t.Fatalf("ensureDrainUnitConvoy(split city): %v; the lookup answered with the binding's edgeless copy and then tried to repair its missing track across the class boundary", err)
+	}
+	if createdAgain {
+		t.Fatalf("the lookup missed the unit convoy %s a previous pass already minted and created a duplicate", minted.ID)
+	}
+	if reused.ID != minted.ID {
+		t.Fatalf("reused unit convoy = %s, want the already-minted %s", reused.ID, minted.ID)
+	}
+	tracked, err := convoycore.HasTrack(work, minted.ID, member.ID)
+	if err != nil {
+		t.Fatalf("HasTrack: %v", err)
+	}
+	if !tracked {
+		t.Fatalf("unit convoy %s lost its tracks edge to %s", minted.ID, member.ID)
+	}
+}
+
+// TestProcessDrainSplitCityDoesNotWriteACrossStoreBlockerEdge pins the blocker
+// projection to the same co-residence rule the convoy edge has.
+//
+// A drained member's out-of-convoy `blocks` dependency is an ordinary backlog
+// shape, and its target is a WORK bead. The item workflow the drain builds for
+// that member is graph-resident, so projecting the raw id writes a dependency row
+// into a store that cannot resolve its own target. That does not degrade to an
+// unenforced edge: the readiness reader treats a missing target's status as not
+// closed, so the item step is excluded from Ready permanently, completeDrain
+// returns ErrControlPending forever, and closing the real blocker in the work
+// store cannot release it — recovery needs manual DepRemove surgery in the
+// binding. There is no error, no quarantine, and no operator signal.
+//
+// An already-closed blocker is the same shape and far more common (any historical
+// `blocks` edge in a real backlog), which is why the classification is by
+// residence AND status: a terminal blocker constrains nothing, so omitting its
+// edge loses no meaning and is not worth an operator's attention. An open one
+// does lose meaning, so it is recorded on the item root.
+func TestProcessDrainSplitCityDoesNotWriteACrossStoreBlockerEdge(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		closeBlocker   bool
+		wantRecordedOn bool
+	}{
+		{name: "open out-of-convoy blocker is recorded", closeBlocker: false, wantRecordedOn: true},
+		{name: "closed out-of-convoy blocker constrains nothing", closeBlocker: true, wantRecordedOn: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			formulatest.EnableV2ForTest(t)
+			dir := t.TempDir()
+			writeDrainItemFormula(t, dir)
+			work, graph, drain, memberIDs := seedSplitClassDrainWorkflow(t, false)
+
+			blocker, err := work.Create(beads.Bead{Title: "outside the convoy", Type: "task"})
+			if err != nil {
+				t.Fatalf("create blocker: %v", err)
+			}
+			if tc.closeBlocker {
+				if err := work.Close(blocker.ID); err != nil {
+					t.Fatalf("Close(%s): %v", blocker.ID, err)
+				}
+			}
+			mustDepAdd(t, work, memberIDs[0], blocker.ID, "blocks")
+
+			result, err := ProcessControl(graph, drain, ProcessOptions{
+				FormulaSearchPaths: []string{dir},
+				MemberStores:       []beads.Store{work},
+			})
+			if err != nil {
+				t.Fatalf("ProcessControl(member with an out-of-convoy blocker): %v", err)
+			}
+			if result.Action != "drain-expanded" {
+				t.Fatalf("result = %+v, want drain-expanded", result)
+			}
+
+			assertNoUnresolvableBlockingDeps(t, graph)
+
+			manifest := mustDrainManifest(t, mustGetBead(t, graph, drain.ID))
+			ready, err := graph.Ready()
+			if err != nil {
+				t.Fatalf("Ready: %v", err)
+			}
+			readyIDs := make(map[string]bool, len(ready))
+			for _, b := range ready {
+				readyIDs[b.ID] = true
+			}
+			for i, row := range manifest.Rows {
+				runnable := false
+				for _, id := range itemWorkflowBeadIDs(t, graph, row.ItemRootID) {
+					if readyIDs[id] {
+						runnable = true
+						break
+					}
+				}
+				if !runnable {
+					t.Fatalf("row %d item workflow %s has nothing ready; the drained item can never be dispatched and the drain waits on it forever", i, row.ItemRootID)
+				}
+			}
+
+			root := mustGetBead(t, graph, manifest.Rows[0].ItemRootID)
+			recorded := root.Metadata[beadmeta.DrainUnprojectedBlockersMetadataKey]
+			if tc.wantRecordedOn {
+				if recorded != blocker.ID {
+					t.Fatalf("%s on item root %s = %q, want %q; an item workflow that runs without a constraint its source member had must say so on its own bead, not only in a log line",
+						beadmeta.DrainUnprojectedBlockersMetadataKey, root.ID, recorded, blocker.ID)
+				}
+			} else if recorded != "" {
+				t.Fatalf("%s = %q, want empty: a closed blocker constrains nothing, so omitting its edge loses no meaning and recording it would fire on every real backlog",
+					beadmeta.DrainUnprojectedBlockersMetadataKey, recorded)
+			}
+
+			// The sibling row has no blocker at all and must be untouched.
+			sibling := mustGetBead(t, graph, manifest.Rows[1].ItemRootID)
+			if got := sibling.Metadata[beadmeta.DrainUnprojectedBlockersMetadataKey]; got != "" {
+				t.Fatalf("sibling item root %s recorded %q, want nothing", sibling.ID, got)
+			}
+		})
+	}
+}
+
+// TestDrainProjectedBlockerIDsIsProbeFreeOnASingleStoreCity is the byte-identity
+// half of the blocker co-residence rule.
+//
+// Every city with no relocated graph class names no member stores, and for those
+// co-residence is not a question: there is one store, so every id it resolves is
+// co-resident. The check must not run for them — the projection is a per-row,
+// per-pass sweep, and the answer would be the read it already did.
+func TestDrainProjectedBlockerIDsIsProbeFreeOnASingleStoreCity(t *testing.T) {
+	inner := beads.NewMemStore()
+	blocker, err := inner.Create(beads.Bead{Title: "blocker", Type: "task"})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	member, err := inner.Create(beads.Bead{Title: "member", Type: "task"})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	mustDepAdd(t, inner, member.ID, blocker.ID, "blocks")
+	store := &countingGetStore{Store: inner}
+
+	manifest := drainManifest{Version: 1, Rows: []drainManifestRow{{Index: 0, MemberID: member.ID, ItemRootID: "root-member"}}}
+	projection, err := drainProjectedBlockerIDs(store, member.ID, manifest, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("drainProjectedBlockerIDs: %v", err)
+	}
+	if len(projection.BlockerIDs) != 1 || projection.BlockerIDs[0] != blocker.ID {
+		t.Fatalf("blockerIDs = %v, want [%s]", projection.BlockerIDs, blocker.ID)
+	}
+	if len(projection.Unprojectable) != 0 {
+		t.Fatalf("unprojectable = %v, want none on a single-store city", projection.Unprojectable)
+	}
+	if store.gets != 0 {
+		t.Fatalf("the single-store path issued %d co-residence probe read(s); with one store every blocker is co-resident and the read is pure overhead on a per-row, per-pass sweep", store.gets)
+	}
+}
+
+// TestEnsureDrainUnitConvoyFindsAConvoyMintedBeforeItsMemberVanished pins the
+// SPAN of the gc.drain_unit_key idempotence lookup, as
+// TestEnsureDrainUnitConvoyPrefersTheWorkStoreOverAnEdgelessBindingCopy pins its
+// order.
+//
+// The key is the token that decides mint-or-reuse, and the manifest persists the
+// unit convoy's id but never the store that answered when it was minted. So the
+// lookup cannot be re-derived from the member: convoy members may be graph-class
+// (convoy.MemberClasses names Graph for exactly that), and a member that resolves
+// on the minting pass and not on the resuming pass moves the derived answer. Ask
+// one store and the resume misses a convoy that exists and mints a second one for
+// a row that already has one.
+func TestEnsureDrainUnitConvoyFindsAConvoyMintedBeforeItsMemberVanished(t *testing.T) {
+	work := beads.NewMemStore()
+	graph := beads.NewMemStoreFrom(1000, nil, nil)
+	opts := ProcessOptions{MemberStores: []beads.Store{work}}
+
+	control, err := graph.Create(beads.Bead{Title: "drain", Type: "task"})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	parent, err := work.Create(beads.Bead{Title: "parent", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	member, err := graph.Create(beads.Bead{Title: "a graph-class member", Type: "task"})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	row := drainManifestRow{Index: 0, MemberID: member.ID, UnitKey: "drain-unit:" + control.ID + ":0:" + member.ID}
+
+	minted, created, err := ensureDrainUnitConvoy(graph, control, parent.ID, 1, row, member, opts)
+	if err != nil {
+		t.Fatalf("ensureDrainUnitConvoy(minting pass): %v", err)
+	}
+	if !created {
+		t.Fatal("minting pass did not create the unit convoy")
+	}
+	if _, err := graph.Get(minted.ID); err != nil {
+		t.Fatalf("unit convoy %s did not land with its member: %v", minted.ID, err)
+	}
+
+	// The member vanishes before the resuming pass, which therefore sees the
+	// unresolved placeholder loadDrainManifestMembers synthesizes.
+	if err := graph.Delete(member.ID); err != nil {
+		t.Fatalf("Delete(%s): %v", member.ID, err)
+	}
+	placeholder := beads.Bead{ID: member.ID, Title: member.ID, Type: "task", Status: "unknown"}
+
+	reused, createdAgain, err := ensureDrainUnitConvoy(graph, control, parent.ID, 1, row, placeholder, opts)
+	if err != nil {
+		t.Fatalf("ensureDrainUnitConvoy(resuming pass): %v", err)
+	}
+	if createdAgain || reused.ID != minted.ID {
+		t.Fatalf("resuming pass created unit convoy %s (created=%v), want the already-minted %s; a lookup re-derived from the member moves stores the moment the member stops resolving", reused.ID, createdAgain, minted.ID)
 	}
 }

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -1280,7 +1280,7 @@ func TestEnsureDrainUnitConvoyRepairsExistingTrack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unit, created, err := ensureDrainUnitConvoy(store, control, parent.ID, 1, row, member)
+	unit, created, err := ensureDrainUnitConvoy(store, control, parent.ID, 1, row, member, ProcessOptions{})
 	if err != nil {
 		t.Fatalf("ensureDrainUnitConvoy: %v", err)
 	}
@@ -1348,7 +1348,7 @@ func TestEnsureDrainUnitConvoyLooksAcrossBothTiers(t *testing.T) {
 		UnitKey:  "drain-unit:test:0:" + member.ID,
 	}
 
-	if _, _, err := ensureDrainUnitConvoy(store, control, parent.ID, 1, row, member); err != nil {
+	if _, _, err := ensureDrainUnitConvoy(store, control, parent.ID, 1, row, member, ProcessOptions{}); err != nil {
 		t.Fatalf("ensureDrainUnitConvoy: %v", err)
 	}
 	if len(store.listMetadataOpts) == 0 {
@@ -1865,12 +1865,14 @@ func assertNoBlockingDep(t *testing.T, store beads.Store, issueID, dependsOnID s
 // actually has: the graph.v2 input convoy and its work members in the WORK
 // store, the workflow root and the drain control in the graph binding.
 //
-// carryConvoyCopy models what `gc storage migrate` leaves behind. A synthetic
-// convoy is graph class, so the migration copies the convoy ROW into the
-// binding — but importInfraSnapshot re-adds only the dep edges whose BOTH
-// endpoints are infra, so the copy carries none of its tracks edges to the work
-// members. The two stores mint from disjoint id ranges, the way two real bead
-// databases with different prefixes do.
+// carryConvoyCopy models what a city migrated under the PREVIOUS classification
+// has on disk. Synthetic convoys used to be graph class, so `gc storage migrate`
+// copied the convoy ROW into the binding — but importInfraSnapshot re-adds only
+// the dep edges whose BOTH endpoints are infra, so the copy carries none of its
+// tracks edges to the work members. Synthetic convoys are work class now, so a
+// migration run today leaves no such copy; the copies already written are why
+// the shape still has to be covered. The two stores mint from disjoint id
+// ranges, the way two real bead databases with different prefixes do.
 func seedSplitClassDrainWorkflow(t *testing.T, carryConvoyCopy bool) (work *beads.MemStore, graph *beads.MemStore, drain beads.Bead, memberIDs []string) {
 	t.Helper()
 	work = beads.NewMemStore()
@@ -2039,5 +2041,154 @@ func TestProcessDrainNeverPassesAConvoyItCouldNotRead(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestProcessDrainSplitCityExpandsAndCompletes is the end-to-end acceptance for
+// the owner ruling that a synthetic convoy is a WORK bead.
+//
+// It is the whole point of the ruling stated as an outcome: on a converged split
+// city a drain over a non-empty input convoy must reach the same terminal state
+// it reaches on a single-store city — a manifest row per member, a unit convoy
+// per row that actually TRACKS its member, and an item root per row. Expansion
+// alone is not the bar. Before the ruling the expansion happened and then
+// ensureDrainUnitConvoy minted the unit convoy in the GRAPH store while its
+// member lived in the work store, so the tracks edge convoycore refuses to write
+// across a class boundary failed the whole dispatch and the control quarantined.
+//
+// Both migration shapes are covered because they exercise different halves: a
+// convoy that only ever lived in the work store, and one whose edgeless copy
+// `gc storage migrate` left in the binding is the first thing a graph-store read
+// finds.
+func TestProcessDrainSplitCityExpandsAndCompletes(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		carryConvoyCopy bool
+	}{
+		{name: "convoy only in the work store", carryConvoyCopy: false},
+		{name: "edgeless migration copy also in the binding", carryConvoyCopy: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			formulatest.EnableV2ForTest(t)
+			dir := t.TempDir()
+			writeDrainItemFormula(t, dir)
+			work, graph, drain, memberIDs := seedSplitClassDrainWorkflow(t, tc.carryConvoyCopy)
+
+			result, err := ProcessControl(graph, drain, ProcessOptions{
+				FormulaSearchPaths: []string{dir},
+				MemberStores:       []beads.Store{work},
+			})
+			if err != nil {
+				t.Fatalf("ProcessControl(split-city drain): %v; a control dispatch that returns a non-transient error is QUARANTINED by the caller, which is the state this ruling exists to remove", err)
+			}
+			if result.Action != "drain-expanded" {
+				t.Fatalf("result = %+v, want drain-expanded", result)
+			}
+			if result.Created != 2*len(memberIDs) {
+				t.Fatalf("created = %d, want %d — one unit convoy and one item root per member", result.Created, 2*len(memberIDs))
+			}
+
+			reloaded := mustGetBead(t, graph, drain.ID)
+			if got := reloaded.Metadata[beadmeta.DrainStateMetadataKey]; got != beadmeta.DrainStateExpanded {
+				t.Fatalf("gc.drain_state = %q, want %q", got, beadmeta.DrainStateExpanded)
+			}
+			manifest := mustDrainManifest(t, reloaded)
+			if len(manifest.Rows) != len(memberIDs) {
+				t.Fatalf("manifest rows = %d, want %d", len(manifest.Rows), len(memberIDs))
+			}
+			for i, row := range manifest.Rows {
+				if row.UnitConvoyID == "" {
+					t.Fatalf("row %d has no unit convoy", i)
+				}
+				if row.ItemRootID == "" {
+					t.Fatalf("row %d has no item root", i)
+				}
+				if row.Status != "wired" {
+					t.Fatalf("row %d status = %q, want wired", i, row.Status)
+				}
+				// The unit convoy is a synthetic convoy, so per the ruling it is a
+				// work bead: it must be readable from the work store and it must
+				// hold the tracks edge to its member there.
+				unit, err := work.Get(row.UnitConvoyID)
+				if err != nil {
+					t.Fatalf("unit convoy %s is not in the work store: %v; a synthetic convoy is a work bead and its tracks edge cannot reference a member the convoy's own store cannot resolve", row.UnitConvoyID, err)
+				}
+				if unit.Metadata[beadmeta.SyntheticKindMetadataKey] != "drain-unit-convoy" {
+					t.Fatalf("unit convoy %s metadata = %v, want gc.synthetic_kind=drain-unit-convoy", unit.ID, unit.Metadata)
+				}
+				tracked, err := convoycore.HasTrack(work, row.UnitConvoyID, row.MemberID)
+				if err != nil {
+					t.Fatalf("HasTrack(%s, %s): %v", row.UnitConvoyID, row.MemberID, err)
+				}
+				if !tracked {
+					t.Fatalf("unit convoy %s does not track member %s; the drain item formula resolves its work from convoy_id, so an untracked unit dispatches an empty convoy", row.UnitConvoyID, row.MemberID)
+				}
+			}
+		})
+	}
+}
+
+// countingGetStore counts Get calls so a test can assert that a code path
+// issued no read at all, which is what "byte-identical" means for a probe that
+// must not run.
+type countingGetStore struct {
+	beads.Store
+	gets int
+}
+
+func (s *countingGetStore) Get(id string) (beads.Bead, error) {
+	s.gets++
+	return s.Store.Get(id)
+}
+
+// TestDrainUnitConvoyStoreIsTheAmbientStoreOnASingleStoreCity is the
+// byte-identity half of routing unit convoys to the member's owning store.
+//
+// Every city with no relocated graph class names no member stores, and for those
+// the unit convoy's store is not a question: it is the one store there is. The
+// owning-store probe must not run for them — not because the answer would be
+// wrong (it would be the same store) but because it is a read the drain does not
+// make today, once per unit convoy per pass, on the per-tick projection sweep.
+//
+// The identity assertion alone would not catch a probe, because the probe
+// returns the same handle. Counting the reads is what does.
+func TestDrainUnitConvoyStoreIsTheAmbientStoreOnASingleStoreCity(t *testing.T) {
+	store := &countingGetStore{Store: beads.NewMemStore()}
+	member, err := store.Create(beads.Bead{Title: "a member", Type: "task"})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	store.gets = 0
+
+	got, err := drainUnitConvoyStore(store, member, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("drainUnitConvoyStore: %v", err)
+	}
+	if got != beads.Store(store) {
+		t.Fatalf("drainUnitConvoyStore returned a different handle than the ambient store; the optional-capability assertions the drain makes are against that instance")
+	}
+	if store.gets != 0 {
+		t.Fatalf("the single-store path issued %d owning-store probe read(s); with no member stores named there is nothing to probe and the read is pure overhead", store.gets)
+	}
+}
+
+// TestDrainUnitConvoyStoreFollowsTheMemberAcrossTheClassBoundary is the other
+// half: once a work-class member store is named, the unit convoy goes where the
+// member is, because convoy.TrackItemIn refuses an edge whose member is owned by
+// another class store.
+func TestDrainUnitConvoyStoreFollowsTheMemberAcrossTheClassBoundary(t *testing.T) {
+	work := beads.NewMemStore()
+	graph := beads.NewMemStoreFrom(1000, nil, nil)
+	member, err := work.Create(beads.Bead{Title: "a work member", Type: "task"})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+
+	got, err := drainUnitConvoyStore(graph, member, ProcessOptions{MemberStores: []beads.Store{work}})
+	if err != nil {
+		t.Fatalf("drainUnitConvoyStore: %v", err)
+	}
+	if got != beads.Store(work) {
+		t.Fatalf("drainUnitConvoyStore chose the ambient graph store for a work-resident member; the tracks edge it is about to write cannot reference an id that store cannot resolve")
 	}
 }

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1857,5 +1858,186 @@ func assertNoBlockingDep(t *testing.T, store beads.Store, issueID, dependsOnID s
 		if beads.IsReadyBlockingDependencyType(dep.Type) && dep.DependsOnID == dependsOnID {
 			t.Fatalf("dependencies for %s = %+v, want no blocking dependency on %s", issueID, deps, dependsOnID)
 		}
+	}
+}
+
+// seedSplitClassDrainWorkflow builds the drain fixture a converged split city
+// actually has: the graph.v2 input convoy and its work members in the WORK
+// store, the workflow root and the drain control in the graph binding.
+//
+// carryConvoyCopy models what `gc storage migrate` leaves behind. A synthetic
+// convoy is graph class, so the migration copies the convoy ROW into the
+// binding — but importInfraSnapshot re-adds only the dep edges whose BOTH
+// endpoints are infra, so the copy carries none of its tracks edges to the work
+// members. The two stores mint from disjoint id ranges, the way two real bead
+// databases with different prefixes do.
+func seedSplitClassDrainWorkflow(t *testing.T, carryConvoyCopy bool) (work *beads.MemStore, graph *beads.MemStore, drain beads.Bead, memberIDs []string) {
+	t.Helper()
+	work = beads.NewMemStore()
+	parent, err := work.Create(beads.Bead{
+		Title:    "input convoy",
+		Type:     "convoy",
+		Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+	})
+	if err != nil {
+		t.Fatalf("create input convoy: %v", err)
+	}
+	for _, title := range []string{"first", "second"} {
+		member, err := work.Create(beads.Bead{Title: title, Type: "task"})
+		if err != nil {
+			t.Fatalf("create member %s: %v", title, err)
+		}
+		if err := convoycore.TrackItem(work, parent.ID, member.ID); err != nil {
+			t.Fatalf("track member %s: %v", title, err)
+		}
+		memberIDs = append(memberIDs, member.ID)
+	}
+
+	var carried []beads.Bead
+	if carryConvoyCopy {
+		carried = append(carried, parent)
+	}
+	graph = beads.NewMemStoreFrom(1000, carried, nil)
+
+	root, err := graph.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.input_convoy_id":  parent.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	drain, err = graph.Create(beads.Bead{
+		Title: "drain",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                "drain",
+			"gc.root_bead_id":        root.ID,
+			"gc.drain_context":       "separate",
+			"gc.drain_formula":       "drain-item",
+			"gc.drain_member_access": "read",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create drain control: %v", err)
+	}
+	return work, graph, drain, memberIDs
+}
+
+// TestDrainReadsConvoyMembershipAcrossTheClassBoundary pins the head of the
+// membership lookup, which opts.MemberStores does not reach.
+//
+// MemberStores resolves member BEADS. The convoy's own membership — its legacy
+// children and its tracks edges — is read from one store, and reading it from
+// the store the drain runs in is what loses the convoy: a store that never saw
+// the convoy answers both reads empty instead of erroring, which is
+// indistinguishable from a genuinely empty convoy.
+//
+// Both shapes are covered because the naive repair — pick the one store that
+// holds the convoy bead — passes the first and fails the second. On a converged
+// city the convoy bead is in BOTH stores and the binding's copy is the empty one.
+func TestDrainReadsConvoyMembershipAcrossTheClassBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		carryConvoyCopy bool
+	}{
+		{name: "convoy only in the work store", carryConvoyCopy: false},
+		{name: "edgeless migration copy also in the binding", carryConvoyCopy: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			work, graph, drain, memberIDs := seedSplitClassDrainWorkflow(t, tc.carryConvoyCopy)
+			root := mustGetBead(t, graph, drain.Metadata["gc.root_bead_id"])
+			convoyID := root.Metadata["gc.input_convoy_id"]
+
+			members, err := drainConvoyMembers(graph, convoyID, ProcessOptions{MemberStores: []beads.Store{work}})
+			if err != nil {
+				t.Fatalf("drainConvoyMembers: %v", err)
+			}
+			var got []string
+			for _, member := range members {
+				got = append(got, member.ID)
+			}
+			if !slices.Equal(got, memberIDs) {
+				t.Fatalf("members = %v, want %v; membership read from a store that does not hold this convoy's edges returns empty instead of failing, and an empty convoy is a drain SUCCESS", got, memberIDs)
+			}
+		})
+	}
+}
+
+// TestDrainSingleStoreMembershipIsUnchanged is the compatibility half: with no
+// member stores named — every single-store caller — the membership read is the
+// one convoycore.Members call it always was, against the one store.
+func TestDrainSingleStoreMembershipIsUnchanged(t *testing.T) {
+	store, drain := seedDrainWorkflow(t)
+	root := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	convoyID := root.Metadata["gc.input_convoy_id"]
+
+	want, err := convoycore.Members(store, convoyID, false)
+	if err != nil {
+		t.Fatalf("convoycore.Members: %v", err)
+	}
+	got, err := drainConvoyMembers(store, convoyID, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("drainConvoyMembers: %v", err)
+	}
+	if len(got) != len(want) || len(got) != 2 {
+		t.Fatalf("members = %d, want the same 2 convoycore.Members returns", len(got))
+	}
+	for i := range got {
+		if got[i].ID != want[i].ID {
+			t.Fatalf("member %d = %s, want %s; the single-store read must be order-identical", i, got[i].ID, want[i].ID)
+		}
+	}
+}
+
+// TestProcessDrainNeverPassesAConvoyItCouldNotRead is the invariant that makes
+// the failure mode unwritable rather than merely fixed.
+//
+// A drain over an EMPTY input convoy closes gc.outcome=pass with zero rows, and
+// TestProcessDrainSeparateSucceedsForEmptyInputConvoy pins that as intended. That
+// is exactly what makes a lost convoy invisible: a drain that could not read its
+// membership produces byte-for-byte the same terminal state as a drain that
+// correctly found nothing to do, so the whole convoy is left open and
+// undispatched while the run reports green and exits 0.
+//
+// Whatever else a split-class drain does, it may never reach that state over a
+// convoy that has members. Failing loudly is allowed; passing is not.
+func TestProcessDrainNeverPassesAConvoyItCouldNotRead(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		carryConvoyCopy bool
+	}{
+		{name: "convoy only in the work store", carryConvoyCopy: false},
+		{name: "edgeless migration copy also in the binding", carryConvoyCopy: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			formulatest.EnableV2ForTest(t)
+			dir := t.TempDir()
+			writeDrainItemFormula(t, dir)
+			work, graph, drain, memberIDs := seedSplitClassDrainWorkflow(t, tc.carryConvoyCopy)
+
+			result, _ := ProcessControl(graph, drain, ProcessOptions{
+				FormulaSearchPaths: []string{dir},
+				MemberStores:       []beads.Store{work},
+			})
+			got := mustGetBead(t, graph, drain.ID)
+			manifest := mustDrainManifest(t, got)
+
+			if got.Metadata[beadmeta.OutcomeMetadataKey] == beadmeta.OutcomePass && len(manifest.Rows) == 0 {
+				t.Fatalf("drain closed gc.outcome=pass over a convoy of %d members with an empty manifest (action=%q); every member is left open and the run reports green", len(memberIDs), result.Action)
+			}
+			if len(manifest.Rows) != len(memberIDs) {
+				t.Fatalf("manifest rows = %d, want %d — one per convoy member", len(manifest.Rows), len(memberIDs))
+			}
+			for _, id := range memberIDs {
+				if !slices.ContainsFunc(manifest.Rows, func(row drainManifestRow) bool { return row.MemberID == id }) {
+					t.Fatalf("member %s is missing from the drain manifest %+v", id, manifest.Rows)
+				}
+			}
+		})
 	}
 }

--- a/internal/graphv2/invocation.go
+++ b/internal/graphv2/invocation.go
@@ -412,6 +412,17 @@ func NormalizeInputConvoy(store beads.Store, targetID string) (string, error) {
 
 // CreateSingleItemInputConvoy creates a system-created one-item convoy for a
 // graph.v2 invocation target.
+//
+// store is the store the TARGET was resolved from, and that is the only store
+// this convoy can be minted in. A synthetic input convoy is a WORK bead
+// (coordclass.Classify) for the same reason the mechanics require it: its whole
+// content is one `tracks` edge to the target, and convoycore.TrackItemIn refuses
+// an edge whose member is owned by another class store, because a dep row cannot
+// reference an id its own store cannot resolve. Every caller reaches this through
+// NormalizeInputConvoy, which Gets the target from the same handle it passes
+// here, so co-residence is structural rather than a convention a caller has to
+// remember: routing this at a graph binding would fail to find the target long
+// before it could mint a convoy in the wrong ledger.
 func CreateSingleItemInputConvoy(store beads.Store, target beads.Bead) (beads.Bead, error) {
 	if store == nil {
 		return beads.Bead{}, fmt.Errorf("formulas v2 invocation requires a bead store")

--- a/internal/graphv2/invocation_test.go
+++ b/internal/graphv2/invocation_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/formulatest"
 )
 
@@ -1110,5 +1111,42 @@ title = "Inspect {{issue}}"
 	}
 	if len(open) != 0 {
 		t.Fatalf("open synthetic convoys after failed pour = %d, want 0 (ids: %v)", len(open), open)
+	}
+}
+
+// TestSyntheticInputConvoyIsWorkClassAndCoResidentWithItsTarget pins the
+// creation path against the classification.
+//
+// A synthetic input convoy is a WORK bead, and that is not a filing preference:
+// the convoy's whole content is a `tracks` edge to its target, and TrackItemIn
+// refuses an edge whose member is owned by another class store. So the two have
+// to agree — the classification says work, and the mint has to land where the
+// target is. NormalizeInputConvoy makes that structural by resolving the target
+// from the same handle it mints through; this test is what fails if a future
+// caller splits them.
+func TestSyntheticInputConvoyIsWorkClassAndCoResidentWithItsTarget(t *testing.T) {
+	work := beads.NewMemStore()
+	target, err := work.Create(beads.Bead{Title: "a work bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	convoyID, err := NormalizeInputConvoy(work, target.ID)
+	if err != nil {
+		t.Fatalf("NormalizeInputConvoy: %v", err)
+	}
+	convoy, err := work.Get(convoyID)
+	if err != nil {
+		t.Fatalf("the input convoy is not in the target's store: %v", err)
+	}
+	if got := coordclass.Classify(convoy); got != coordclass.ClassWork {
+		t.Fatalf("Classify(input convoy) = %s, want work; a convoy owned by any other class cannot hold a tracks edge to its work target", got)
+	}
+	tracked, err := convoycore.HasTrack(work, convoyID, target.ID)
+	if err != nil {
+		t.Fatalf("HasTrack: %v", err)
+	}
+	if !tracked {
+		t.Fatalf("input convoy %s does not track target %s", convoyID, target.ID)
 	}
 }


### PR DESCRIPTION
## The owner ruling

> "the synthetic convoy bead is a work bead so it should live in the work db not the infra one"

`coordclass` classified graph.v2 input convoys and drain-unit convoys as
`ClassGraph`. That was the defect this PR kept running into rather than the
routing this PR was adding.

A convoy exists to hold `tracks` edges to its members. Its members are work
beads. `convoy.TrackItemIn` refuses an edge whose member is owned by another
class, because a dep row lives in one store's dep table and can only reference
an id that store can resolve. So a convoy owned by any class but Work is a
convoy that can never track anything — the classification was not a filing
preference, it was unsatisfiable.

With this PR's earlier commits routing control dispatch to the graph binding,
that became visible as a hard failure: a split-city graph.v2 drain expanded to N
rows and then died at `trackDrainMember`, because `ensureDrainUnitConvoy` minted
the unit convoy in the GRAPH store and immediately tried to track a WORK member.
A non-transient control error is quarantined by the caller, so drains
quarantined instead of completing on a converged split city.

## What changed

**`internal/coordclass`** — `type=convoy` carrying `gc.synthetic` /
`gc.synthetic_kind` is now `ClassWork`. The rest of `ClassGraph` is untouched:
molecule/step/gate/scope/run beads, every `gc.kind` control bead, wisp roots,
convergence beads and spec sidecars all stay graph. The doc comments on
`ClassWork`/`ClassGraph` no longer claim otherwise.

It is an **explicit arm placed before the workflow arm**, not the absence of an
arm. A synthetic convoy is glue for one specific graph and carries that graph's
identifying metadata; left to the default, a convoy's class would depend on
which incidental keys happen to be stamped on it, and one `gc.root_bead_id`
would silently re-break drains. Pinned by
`synthetic convoy with root_bead_id stays work` and
`drain-unit convoy with graph.v2 contract stays work`.

**`internal/dispatch/drain.go`** — a drain unit convoy is minted, looked up
(`gc.drain_unit_key`) and reloaded in the store that owns the member it tracks,
via the new `drainUnitConvoyStore`. Deriving it from the member is not a
heuristic: co-residence is what `TrackItemIn` requires, so the member's owning
store is the only store where the edge can be written. It reuses the
`drainMemberOwningStore` probe this series already established, with the same
single-store guard `drainMemberDepStore` uses.

**`internal/graphv2`** — no plumbing change, deliberately. Every caller of
`PrepareInvocation` already passes the work/scope store (`sling` passes
`deps.Store`, explicitly distinct from `deps.GraphStore`; `gc formula cook`
passes `openStoreAtForCity(scope.storeRoot, …)`), and `NormalizeInputConvoy`
resolves the target from the same handle it mints through — so co-residence is
structural, and routing it at the graph binding would fail to find the target
long before it could mint into the wrong ledger. Documented and pinned by
`TestSyntheticInputConvoyIsWorkClassAndCoResidentWithItsTarget` rather than
re-plumbed into a parallel mechanism. The classification was the only thing that
disagreed with where the code already put these.

## End-to-end drain result

`TestProcessDrainSplitCityExpandsAndCompletes` is the acceptance test, over both
migration shapes (convoy only in the work store; edgeless migration copy also in
the binding). It asserts the terminal state, not just the expansion: no error
(i.e. no quarantine), `action=drain-expanded`, `gc.drain_state=expanded`, a
manifest row per member, and for each row a unit convoy that is **readable from
the work store** and **actually tracks its member** there, plus an item root and
`status=wired`.

Red before:

```
--- FAIL: TestProcessDrainSplitCityExpandsAndCompletes/convoy_only_in_the_work_store
    ProcessControl(split-city drain): gc-1002: tracking member gc-2 from unit convoy gc-1003:
    getting tracked item gc-2: resolving gc-2 across convoy: bead not found;
    a control dispatch that returns a non-transient error is QUARANTINED by the caller,
    which is the state this ruling exists to remove
--- FAIL: TestProcessDrainSplitCityExpandsAndCompletes/edgeless_migration_copy_also_in_the_binding
    (same)
```

Green after, both shapes. The prior behavior (expand to N, then quarantine) is
gone.

## Blast-radius audit

`coordclass.Classify` has exactly five non-test consumers; each was checked.

| Consumer | Effect |
|---|---|
| `readInfraSnapshot` (`gc storage migrate` copy, `gc storage status`, **and the boot-time containment re-check**) | Synthetic convoys are no longer selected. This is the one that mattered: they are minted in the work store and stay there, so under the old classification **every drain a converged city ran after cutover minted a bead the binding never received**, and the next boot would count them as stranded writes and refuse to serve. Pinned by `TestInfraSnapshotLeavesSyntheticConvoysInTheWorkStore`. |
| `censusRigInfraResidue` (pre-migration refusal) | A synthetic convoy in a rig scope no longer blocks a cutover. Correct: it is a work bead and belongs where it is. Strictly a relaxation. |
| `infraCopyClassDifference` (migration equality stage) | Never sees synthetic convoys now, since the copy no longer carries them. Migration-time only; not on any boot path. |
| `LegacyCombinedSource.ReadAll` / `ReadClass` (born-split legacy import) | Synthetic convoys now land in the Work partition **with their members**, instead of being split away from the tracks edges that reference them. Improvement. |
| `beadPolicyStore.Create` → `createTarget(Classify(b))` | `createTarget` is identity today; no behavior change. |

Storage tier is a separate classifier (`policyNameForBead`) and has no
synthetic-convoy arm — it never did — so tiering is untouched.

Also checked: `workflowStores`/graph-first readers (they scan for workflow
**roots**, not convoys, and still scan the city store); `internal/convoy`
`MemberClasses` (doc corrected — it claimed Graph owned synthetic convoys);
`internal/executionevent` (already read input-convoy `tracks` edges from
`beads.WorkStore` while reading steps from `beads.GraphStore` — the ruling makes
`coordclass` agree with an assumption this code already encoded); the whole
`internal/storebinding` tree (no convoy references); and
`engdocs/plans/store-domain-objects/spec.md`, which stated the old rule and is
corrected.

**Boot verdict / running cities.** The check itself is unchanged. The snapshot
`readInfraSnapshot` returns is now a strict **subset** of what it returned
before, and `classifyInfraContainmentGap` only ever iterates that set — so
`Stranded` and `RemovedSinceCutover` can only shrink. A city that boots today
cannot stop booting because of this; the verdict can only move
`stranded → converged`, never the reverse.

For maintainer-city specifically (137 stranded `mc-wisp-*`): **no change,
confirmed**. The wisp arm runs first and is untouched, so wisp roots stay graph
class no matter what else they carry — pinned by
`a wisp carrying a synthetic marker is still graph`, and by the wisp rows
(`gc.kind=wisp`, `type=wisp`, `gc:wisp`) in the snapshot test. The only beads
whose class moves are `type=convoy` beads carrying a synthetic marker. If any
city's stranded list ever did contain a synthetic convoy id, it would drop off —
that is the correction, not a regression, since such a bead was never going to
be in the binding.

**Not fixed here (pre-existing, now reachable).** `collectInputConvoyWorkflowRoots`
(`cmd/gc/wisp_autoclose.go`) reads a work bead's tracking convoys from the
*graph* store, so on a split city it finds nothing. That is independent of this
ruling — input convoys were already work-resident at every call site — but it
becomes reachable for drain item roots now that split-city drains complete at
all. Separate concern, separate change.

## The membership-union decision

Kept, with its rationale demoted and rewritten.

The union is now **redundant for correctness**: under the ruling the work leg is
the authoritative one, and a work-only read is provably sufficient (an edge
inventory can only exist co-resident with its members, members are work beads,
and `gc storage migrate` copies rather than moves, so the work store always
retains the original with its edges).

It is **not redundant for safety**, and the risk is asymmetric. A work-only read
is correct only for as long as the residency proof holds; if any future path
mints a convoy somewhere unexpected, it returns zero members — and a drain that
could not read its membership produces byte-for-byte the same terminal state as
a drain that correctly found nothing to do (`gc.outcome=pass`, every member left
open and undispatched, exit 0). The union cannot fail that way: it is order-free
and monotone, no store's silence can subtract a member another store records,
and it cannot error on a store that never saw the convoy (verified: both
`SQLiteStore.DepList` and `BdStore.DepList` return empty for an unknown id). Its
cost is one extra edge read per drain, on split cities only.

Its *stated* justification did have to change, and did: it no longer claims
membership legitimately lives in either class. It now says the work leg answers,
and the graph leg exists because cities migrated under the previous
classification carry an edgeless copy of every synthetic convoy in their binding
— so "the store that has the convoy bead" is still an ambiguous question on real
disks. New migrations no longer create those copies.

## Teeth (mutation-verified, not argued)

| Mutation | Caught by |
|---|---|
| synthetic convoy arm back to `ClassGraph` | `TestClassifyGoldenTable` (4 rows) + `TestInfraSnapshotLeavesSyntheticConvoysInTheWorkStore` (`snapshot carried 6 rows, want exactly the 4 infra beads`) |
| unit convoy minted in the ambient (graph) store | `TestProcessDrainSplitCityExpandsAndCompletes` (both shapes) + `TestDrainUnitConvoyStoreFollowsTheMemberAcrossTheClassBoundary` |
| single-store guard removed from `drainUnitConvoyStore` | `TestDrainUnitConvoyStoreIsTheAmbientStoreOnASingleStoreCity`: `the single-store path issued 1 owning-store probe read(s)` |

Single-store byte-identity is pinned by **read count**, not by inspection: with
no member stores named the owning-store probe must not run at all.

## Gates

- `go build ./...` clean; `go vet ./...` clean
- `golangci-lint 2.10.1` — **0 issues** on `./cmd/gc/...` and on
  `./internal/{coordclass,dispatch,convoy,graphv2}/...`
- `go test ./cmd/gc -timeout 40m` — **ok, 751.9s**
- `go test ./internal/...` — all packages pass (full sweep)
- `scripts/check-core-boundary.sh` — OK
- pre-commit hook (lint-changed + doc-gen + `test/docsync`) ran clean
- rebased on current `main` (`#5105`, `#5106`, `#5107` merged) — **no conflicts**


---

# Council review fixes (1 blocker, 1 major)

Two independent reviewers found defects in the split-city drain routing above.
Both were **reproduced by experiment against head `f6c38623cf`** before being
fixed, and every fix is **mutation-verified**: reverting it turns a named test
red. Red-before strings are quoted verbatim below.

## BLOCKER — an out-of-convoy blocker became a dangling graph-store edge

`drainProjectedBlockerIDs` mapped in-manifest blockers onto the blocker's item
root (graph-resident, fine), but for a blocker that is **not** a manifest member
it kept the raw id — a WORK-store id. This PR moves item roots into the graph
binding, so those raw work ids were written as `blocks` edges **into the graph
store** by both `molecule.Instantiate(ExternalDeps)` and
`ensureDrainWorkflowBlocksOn` → `store.DepAdd`. `DepAdd` does not validate its
target, so the row was written silently and dangled.

That does **not** degrade to an unenforced edge. Both `MemStore.readyLocked` and
`sqliteReadySQL` read an absent blocker's status as `""` — which is not
`'closed'` — so the item step drops out of `Ready` **permanently**,
`completeDrain` returns `ErrControlPending` forever, and closing the real blocker
in the work store cannot release it: the store holding the edge can never see
that row. No error, no quarantine, no operator signal; recovery needs manual
`DepRemove` surgery in the binding. An **already-closed** out-of-convoy blocker
produced the identical permanent block, which makes the trigger *any* historical
`blocks` edge in a real backlog rather than only an open dependency. This
falsified the stated acceptance ("expands to N rows **and completes**").

**Fix — the same co-residence rule the convoy edge already has**
(`classifyDrainBlocker`). An out-of-manifest blocker is projected only when the
item workflow's own store resolves it. Otherwise:

| blocker | outcome | why |
|---|---|---|
| terminal (closed/tombstone) | dropped, traced | it constrains nothing; on a single-store city its edge exists only for the readiness reader to ignore, so omitting it loses no meaning. Recording it would fire on essentially every real backlog and train operators to ignore the key. |
| open | dropped, **recorded** on the item root as `gc.drain_unprojected_blockers`, plus a trace line | the constraint is real and cannot be written down, so the loss is made durable and operator-visible |

**Why record rather than refuse** (the deliberate choice the review asked for):
refusing would turn the commonest backlog shape into a hard control failure on
split cities — the exact terminal state this routing exists to remove — and
writing the edge wedges the workflow forever. Recording is the only option that
neither loses the information nor stalls the work. The rejected alternative (a
graph-resident proxy bead mirroring the work blocker's status) needs a whole new
reconciler to close the proxy; that is a mechanism, not a fix, and it is out of
scope here.

In-manifest blockers are untouched: they project onto another row's item root,
minted in the same store, so they are co-resident by construction and need no
probe.

Red before (`TestProcessDrainSplitCityDoesNotWriteACrossStoreBlockerEdge`, both
subtests):

```
dangling blocks edge gc-1003 -> gc-4: the store holding the edge cannot resolve
the target, so the dependent never becomes ready and closing the real blocker in
its own store cannot release it: getting bead "gc-4": bead not found
```

and, with the record suppressed:

```
gc.drain_unprojected_blockers on item root gc-1003 = "", want "gc-4"; an item
workflow that runs without a constraint its source member had must say so on its
own bead, not only in a log line
```

## MAJOR — unit-convoy residence was re-derived from the member on every pass

`drainUnitConvoyStore` answered "which store owns this unit convoy?" by probing
the **member**, and `drainMemberOwningStore` falls back to the ambient graph
store when no probe owns it. But `row.UnitConvoyID` is persisted in the manifest
while its store is not, and the mint, the `gc.drain_unit_key` idempotence lookup
and the reload each re-derived it independently — so the instant a member's
resolvability changed between passes, mint and reload disagreed.

`expandDrain` persists after every row, so any mid-loop exit (`ErrControlPending`,
a reservation retry, a transient store error) leaves rows recorded with
`gc.drain_state=expanding`; that is a designed re-entry, not a crash. A member
hard-deleted between passes is likewise a supported state —
`loadDrainManifestMembers` synthesizes a placeholder, `trackDrainMember` stamps
`gc.drain_member_unresolved` — and is pinned for single-store cities by the
existing `TestProcessDrainReplayUsesManifestWhenMemberWasDeletedBeforeUnitCreation`.
On a split city the reload then probed the graph binding, reported a convoy that
exists as missing, and — a not-found is not a transient controller error — the
caller **quarantined** the drain. The mirror case (`row.UnitConvoyID` empty)
missed the key lookup and minted a **work-class bead into the infra ledger**,
which `infraCopyClassDifference` says never happens.

**Fix — separate the three questions.**

| question | answered by | was |
|---|---|---|
| reload a convoy the manifest names | its **own id**, `storeref.Resolve` over the probe set — exactly as `loadDrainManifestMembers` resolves a member | re-derived from the member |
| does one already exist for this `gc.drain_unit_key`? | `drainUnitConvoyByKey`, spanning **every** candidate store | one store, re-derived from the member |
| where to **mint** a new one | the member's owning store; an **unresolved** member pins it to the WORK class (`drainWorkClassStore`) | fell back to the ambient graph binding |

The unit-convoy probe set is **work-class first**, the reverse of
`drainMemberProbeSet`. A synthetic convoy is a work bead, so the work class is
authoritative — and a city migrated under the previous classification carries an
**edgeless copy** of every synthetic convoy in its binding, so asking the binding
first answers `gc.drain_unit_key` with a convoy that has no `tracks` edge and
cannot grow one.

Red before:

```
--- FAIL: TestProcessDrainSplitCityResumeCompletesAfterAMemberVanishes
    ProcessControl(resume after a member vanished): gc-1002: loading drain unit
    convoy gc-4: getting bead "gc-4": bead not found; a non-transient control
    error is quarantined by the caller, and the drain never expands its
    remaining rows

--- FAIL: TestProcessDrainSplitCityUnitConvoyForAVanishedMember/no_unit_convoy_minted_yet
    unit convoy gc-1003 for the vanished member gc-2 is in the GRAPH binding; a
    synthetic convoy is a work bead, and the migration's own equality invariant
    says work never crosses into the infra ledger

--- FAIL: TestEnsureDrainUnitConvoyFindsAConvoyMintedBeforeItsMemberVanished
    resuming pass created unit convoy gc-2 (created=true), want the
    already-minted gc-1003; a lookup re-derived from the member moves stores the
    moment the member stops resolving

--- FAIL: TestEnsureDrainUnitConvoyPrefersTheWorkStoreOverAnEdgelessBindingCopy
    ensureDrainUnitConvoy(split city): gc-1: repairing unit convoy gc-4 track for
    member gc-3: getting tracked item gc-3: resolving gc-3 across convoy: bead
    not found; the lookup answered with the binding's edgeless copy and then
    tried to repair its missing track across the class boundary
```

## Single-store byte-identity, preserved

`drainUnitConvoyStore` keeps its zero-probe short-circuit;
`reloadDrainUnitConvoy` keeps the same bare `store.Get` including its error text;
the key lookup is the one `ListByMetadata` it was; and `classifyDrainBlocker`
returns without reading anything. Both are pinned by read **count**, not by
inspection: `TestDrainUnitConvoyStoreIsTheAmbientStoreOnASingleStoreCity` (kept
meaningful, unchanged) and the new
`TestDrainProjectedBlockerIDsIsProbeFreeOnASingleStoreCity`. The boot verdict and
the stranded check are untouched.

## Docs (the reported minors)

Two comments still asserted the pre-ruling classification — `MemberClasses.Graph`
("formula steps, control beads, **synthetic convoys**"), which the body above
claimed was corrected when only the type header had been, and
`cmd_convoy_dispatch.go`'s store-split comment ("drain units **and their
convoys**) are graph class"). Both now say what the ruling says.

## Teeth (mutation-verified)

| Mutation | Caught by |
|---|---|
| reload reads the ambient store instead of resolving by id | `TestProcessDrainSplitCityResumeCompletesAfterAMemberVanishes` |
| mint falls back to the ambient store for an unresolved member | `…UnitConvoyForAVanishedMember/no_unit_convoy_minted_yet` |
| `gc.drain_unit_key` lookup against one re-derived store | `TestEnsureDrainUnitConvoyFindsAConvoyMintedBeforeItsMemberVanished` |
| probe order back to primary-first | `TestEnsureDrainUnitConvoyPrefersTheWorkStoreOverAnEdgelessBindingCopy` |
| co-residence rule removed | `TestProcessDrainSplitCityDoesNotWriteACrossStoreBlockerEdge` (both) |
| unprojectable blockers dropped without a record | `…DoesNotWriteACrossStoreBlockerEdge/open_out-of-convoy_blocker_is_recorded` |

## Gates (council-fix commit)

- `go build ./...` clean; `go vet ./...` clean; `gofmt` clean
- `golangci-lint 2.10.1` — **0 issues** on `./cmd/gc/...` and
  `./internal/{dispatch,convoy,coordclass,beadmeta}/...`
- `go test ./cmd/gc ./internal/dispatch ./internal/convoy ./internal/coordclass -timeout 40m` — pass
- `go test ./internal/...` — full sweep, pass
- `scripts/check-core-boundary.sh` — OK
- `cmd/genschema` + `cmd/genspec` produce no drift
