### PR TITLE
test(beads): pin that reconcile emits bead.updated for an external claim (ga-bplkj.3)

### DIFF
--- a/internal/beads/caching_store_reconcile_external_claim_test.go
+++ b/internal/beads/caching_store_reconcile_external_claim_test.go
@@ -1,0 +1,88 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+// TestReconcileEmitsBeadUpdatedForAnExternallyClaimedBead pins the emission that a claim
+// landing outside this process depends on.
+//
+// A claim arriving over HTTP (bd serve's claimIssue row) fires no bd on_update hook — the
+// upstream documents and enforces that — and it is not one of gc's own writes, so
+// CachingStore.notifyChange does not run at the write. The event that reaches the city's
+// event log for such a claim is the one runReconciliation synthesizes from the diff: the
+// claim moves status and assignee, both of which beadChanged compares, so the next pass
+// absorbs the row and emits bead.updated with Actor "cache-reconcile"
+// (cmd/gc/api_state.go wires onChange straight to events.Recorder.Record).
+//
+// That matters because bead.updated is the trigger of the one core order keyed on it,
+// internal/bootstrap/packs/core/orders/nudge-on-route.toml. If this test fails, an
+// externally claimed bead stops waking a warm-idle worker.
+func TestReconcileEmitsBeadUpdatedForAnExternallyClaimedBead(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	seed, err := mem.Create(Bead{Title: "ready work", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var mu sync.Mutex
+	type emitted struct {
+		eventType string
+		beadID    string
+		payload   json.RawMessage
+	}
+	var events []emitted
+	cs := NewCachingStoreForTest(mem, func(eventType, beadID string, payload json.RawMessage) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, emitted{eventType, beadID, payload})
+	})
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	mu.Lock()
+	events = nil
+	mu.Unlock()
+
+	// The write goes to the BACKING store, never through the cache: that is what an HTTP
+	// claim looks like from here, and it is the whole point — a claim made through cs
+	// would emit at the write and prove nothing.
+	claimed, inProgress := "agent@example.test", "in_progress"
+	if err := mem.Update(seed.ID, UpdateOpts{Assignee: &claimed, Status: &inProgress}); err != nil {
+		t.Fatalf("external claim: %v", err)
+	}
+
+	mu.Lock()
+	atWrite := len(events)
+	mu.Unlock()
+	if atWrite != 0 {
+		t.Fatalf("a write that bypassed the cache emitted %d events; the premise of this test is that it emits none", atWrite)
+	}
+
+	cs.runReconciliation()
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, e := range events {
+		if e.eventType != "bead.updated" || e.beadID != seed.ID {
+			continue
+		}
+		var b Bead
+		if err := json.Unmarshal(e.payload, &b); err != nil {
+			t.Fatalf("decode payload: %v: %s", err, e.payload)
+		}
+		// The payload has to carry the claim, not just the id: a consumer that re-reads
+		// is a consumer that races, and nudge-on-route routes on what the event says.
+		if b.Assignee != claimed || b.Status != inProgress {
+			t.Fatalf("bead.updated payload does not carry the claim: assignee=%q status=%q", b.Assignee, b.Status)
+		}
+		return
+	}
+	t.Fatalf("reconcile emitted no bead.updated for %s; got %v", seed.ID, events)
+}


### PR DESCRIPTION
Closes ga-bplkj.3.

## The premise, and where it breaks

ga-bplkj.3 was filed on a three-way split with a hole in it: gc's own writes emit `bead.updated` in-process via `CachingStore.notifyChange`, an agent's `bd` CLI write emits it through the `.beads/hooks/on_update` forwarder, and an HTTP claim through `bd serve` is covered by neither — `bd serve` documents and *enforces* that hooks do not fire, and gc is not the caller. It concluded: "Cache staleness self-heals through the reconciler poll; a never-emitted event is never replayed."

The first half is right. The conclusion is not. `runReconciliation` does not merely refresh the cache — it **emits**:

- `caching_store_reconcile.go:355` — `c.notifyChanges(res.notifications)`
- `reconcileMergeDecision` returns `"bead.updated"` whenever `beadChanged` sees the cached row diverge from the fresh full scan
- `beadChanged` compares `Status` and `Assignee`, which is exactly and only what a claim moves
- `cmd/gc/api_state.go` wires `onChange` straight to `events.Recorder.Record` with `Actor="cache-reconcile"` — the same event log `packs/core/orders/nudge-on-route.toml` triggers on

The controller's reconcile **is** the replay the bead said did not exist. What an HTTP claim actually costs is bounded latency — one cadence, 30s/60s/120s by ledger size, plus the 5s poll tick — not the event.

That was already known to the consumer, in writing: `nudge-on-route.sh`'s header explains its dedup retention window as covering "an active routing — which keeps re-emitting bead.updated as the reconciler refreshes it".

## Why a test and not a fix

Nothing failed if that emission stopped. A behaviour three subsystems depend on, that a one-word change to `reconcileMergeDecision` would silently remove, is the actual defect here.

The test mutates the **backing** store directly — the shape an HTTP claim leaves behind, with nothing going through the cache, which is the only construction that proves anything (a claim made through the `CachingStore` would emit at the write and prove nothing). It asserts the bypassing write emits nothing, then that the next reconcile pass emits `bead.updated` carrying the new assignee and status.

## Verification

`go test ./internal/beads/` green (also at pristine `f59a20cf2d`, so this is not a property of a stale tree); `go vet` clean; `gofmt` clean; `make test-fast-parallel` green via pre-push.

Mutation-tested rather than assumed: dropping the notification from the `beadChanged` arm of `reconcileMergeDecision` (`"bead.updated"` → `""`) makes it fail with `reconcile emitted no bead.updated for gc-1`. Restored before commit.

Unrelated finding filed as **ga-dznhx** while getting this through pre-push: `internal/testenv`'s AST census tests walk **zero files** when the checkout directory name starts with `_` or `.` (`skipRepoLintDir` fires on the root entry, unlike the `isNestedWorktreeRoot` arm beside it which is guarded with `path != root`). `/data/projects/_wt-*` is a standing convention on this fleet, so any worktree there fails `TestGCEnvReadBaseline` and `TestLegacyFormulaV2MechanismFrozen` with a wall of spurious "REMOVED". `git worktree move` to a non-underscore path, same commit, and both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)