### PR TITLE
fix(cmd/gc): stop TestInitFromWithoutHostedPreservesTemplate leaking a managed dolt sql-server

### DIFF
--- a/cmd/gc/init_from_hosted_dolt_test.go
+++ b/cmd/gc/init_from_hosted_dolt_test.go
@@ -71,6 +71,11 @@ func TestInitFromWithoutHostedPreservesTemplate(t *testing.T) {
 
 	src := gastownExamplePath(t)
 	cityPath := filepath.Join(t.TempDir(), "city")
+	// With no endpoint supplied this is the only test in this file that takes
+	// the managed-local bootstrap path, so it is the only one that starts a
+	// real Dolt sql-server; without teardown the server outlives the test and
+	// the TestMain leak guard fails the whole package.
+	cleanupManagedDoltTestCity(t, cityPath)
 
 	var stdout, stderr bytes.Buffer
 	// disabled hosted options => template preserved


### PR DESCRIPTION
`TestInitFromWithoutHostedPreservesTemplate` supplies no endpoint, so it is the only
test in `cmd/gc/init_from_hosted_dolt_test.go` that takes the managed-local bootstrap
path — and therefore the only one that starts a real Dolt `sql-server`. It never tore
that server down, so the process outlived the test and the `TestMain` leak guard failed
the entire package:

```
cmd/gc test dolt leak guard: leaked 1 dolt sql-server process(es) under <tempRoot>
```

The fix calls the existing `cleanupManagedDoltTestCity` helper (`cmd/gc/path_helpers_test.go`)
the same way the other managed-dolt tests in the package already do. Test-only change,
five added lines, no production code touched.

## Why this is worth landing promptly

This is the last non-transient failure in the `cmd/gc` shard of `make test-fast-parallel`,
which runs as the pre-push hook. The tests themselves pass and then the post-test guard
fails the shard, so every contributor touching Go has to push with `--no-verify` to get
around a leak that has nothing to do with their change. That is a bad habit to force on
people, and it masks real gate failures.

## Verification

- `go test ./cmd/gc/ -run TestInitFromWithoutHostedPreservesTemplate -count=1 -v` — test
  passes and the `TestMain` leak guard does not fire.
- The guard is scoped to the test's own `tempRoot`, so this is not masking a leak
  elsewhere on the machine.
- Rebased onto current `main` and cherry-picked cleanly; the test file is unchanged
  between the original base and `main`, so there is no merge risk.

Tracked as gas-2ip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
