### PR TITLE
fix(runtime): bound the startup-dialog sequence so it cannot outlive the start budget

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -29,6 +29,50 @@ func StartupDialogTimeout() time.Duration {
 	return dialogPollTimeout
 }
 
+// startupDialogBudget bounds the polling startup-dialog sequence as a whole
+// instead of per dialog class.
+//
+// Every phase early-returns as soon as it recognizes the pane — its own dialog,
+// any later dialog, or a ready prompt — so a phase only ever burns its full
+// timeout when the pane shows nothing recognizable at all. In that state the
+// remaining phases are polling the very same blank pane and will burn theirs
+// too, so a per-phase timeout multiplied the wait by the number of dialog
+// classes: nine phases x 8s = 72s, past the 60s default [session]
+// startup_timeout. The caller's context then expired mid-sequence and turned
+// "the agent never drew anything" into a hard start failure blamed on whichever
+// dialog the wall-clock happened to land in.
+//
+// A shared deadline collapses that to one timeout for the whole sequence.
+// Recognizing the pane (observe) refreshes it, so a real dialog chain still gets
+// a fresh timeout for each follow-on dialog to render — the streaming twin,
+// AcceptStartupDialogsFromStreamWithStatus, already stops early on the same
+// "nothing observed" signal.
+//
+// The budget is therefore the window for the pane to draw its FIRST recognizable
+// frame. A runtime slower than that wants a larger timeout, and raising one is
+// now affordable: it costs its own value once instead of once per dialog class,
+// so it no longer has to be kept small enough that nine of them fit in the start
+// deadline.
+type startupDialogBudget struct {
+	timeout  time.Duration
+	deadline time.Time
+}
+
+func newStartupDialogBudget(timeout time.Duration) *startupDialogBudget {
+	return &startupDialogBudget{timeout: timeout, deadline: time.Now().Add(timeout)}
+}
+
+// live reports whether the sequence may keep polling.
+func (b *startupDialogBudget) live() bool {
+	return time.Now().Before(b.deadline)
+}
+
+// observe records that a phase recognized the pane and grants the next phase a
+// fresh timeout to wait for its own dialog to render.
+func (b *startupDialogBudget) observe() {
+	b.deadline = time.Now().Add(b.timeout)
+}
+
 // StartupDialogOption configures optional policy for the startup-dialog helpers.
 // Options are variadic so existing callers stay source-compatible.
 type StartupDialogOption func(*startupDialogConfig)
@@ -64,6 +108,7 @@ func newStartupDialogConfig(opts []StartupDialogOption) startupDialogConfig {
 
 // AcceptStartupDialogs dismisses startup dialogs that can block automated
 // sessions. Handles (in order):
+//  0. Claude first-run theme picker ("Choose the text style…") — requires Enter
 //  1. Claude resume selector — requires Down+Enter to resume the full session
 //  2. Codex update dialog ("Update available") — requires Down+Enter to skip
 //  3. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?", pi "Trust project folder?")
@@ -118,7 +163,18 @@ func AcceptStartupDialogsFromStreamWithStatus(
 		return sendKeys(keys...)
 	}
 
-	phaseObserved, err := acceptClaudeResumeDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	phaseObserved, err := acceptThemeSelectionDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	if err != nil {
+		return observed, fmt.Errorf("theme selection dialog: %w", err)
+	}
+	observed = observed || phaseObserved
+	if !phaseObserved && !observed {
+		return false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return observed, err
+	}
+	phaseObserved, err = acceptClaudeResumeDialogFromStream(ctx, timeout, stream, trackingSendKeys)
 	if err != nil {
 		return observed, fmt.Errorf("claude resume dialog: %w", err)
 	}
@@ -226,8 +282,10 @@ func AcceptStartupDialogsFromStreamWithStatus(
 	return observed, nil
 }
 
-// AcceptStartupDialogsWithTimeout dismisses known startup dialogs using the
-// provided timeout budget for each dialog class.
+// AcceptStartupDialogsWithTimeout dismisses known startup dialogs within the
+// provided timeout budget. The budget covers the sequence as a whole and is
+// refreshed every time a phase recognizes the pane, so a pane that never renders
+// costs one timeout rather than one per dialog class (see startupDialogBudget).
 func AcceptStartupDialogsWithTimeout(
 	ctx context.Context,
 	timeout time.Duration,
@@ -236,58 +294,136 @@ func AcceptStartupDialogsWithTimeout(
 	opts ...StartupDialogOption,
 ) error {
 	cfg := newStartupDialogConfig(opts)
-	if err := acceptClaudeResumeDialog(ctx, timeout, peek, sendKeys); err != nil {
+	budget := newStartupDialogBudget(timeout)
+	if err := acceptThemeSelectionDialog(ctx, budget, peek, sendKeys); err != nil {
+		return fmt.Errorf("theme selection dialog: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := acceptClaudeResumeDialog(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("claude resume dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptCodexUpdateDialog(ctx, timeout, peek, sendKeys); err != nil {
+	if err := acceptCodexUpdateDialog(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("codex update dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptWorkspaceTrustDialog(ctx, timeout, peek, sendKeys); err != nil {
+	if err := acceptWorkspaceTrustDialog(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("workspace trust dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptExternalImportsDialog(ctx, timeout, peek, sendKeys, cfg.trustedImportRoot); err != nil {
+	if err := acceptExternalImportsDialog(ctx, budget, peek, sendKeys, cfg.trustedImportRoot); err != nil {
 		return fmt.Errorf("external imports dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptMCPTrustDialog(ctx, timeout, peek, sendKeys); err != nil {
+	if err := acceptMCPTrustDialog(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("mcp trust dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptCodexHookReviewDialog(ctx, timeout, peek, sendKeys); err != nil {
+	if err := acceptCodexHookReviewDialog(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("codex hook review dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptBypassPermissionsWarning(ctx, timeout, peek, sendKeys); err != nil {
+	if err := acceptBypassPermissionsWarning(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("bypass permissions warning: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := acceptCustomAPIKeyDialog(ctx, timeout, peek, sendKeys); err != nil {
+	if err := acceptCustomAPIKeyDialog(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("custom API key dialog: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := dismissRateLimitDialog(ctx, timeout, peek, sendKeys); err != nil {
+	if err := dismissRateLimitDialog(ctx, budget, peek, sendKeys); err != nil {
 		return fmt.Errorf("rate limit dialog: %w", err)
 	}
 	return nil
+}
+
+// acceptThemeSelectionDialog dismisses Claude Code's first-run theme picker
+// ("Choose the text style that looks best with your terminal"). It is the very
+// first screen Claude draws when the box has no ~/.claude config yet, so it runs
+// ahead of every other phase — nothing else is reachable until it is answered.
+//
+// A container runtime that gives each session a fresh box hits this on EVERY
+// start, not just once: the config that records the choice dies with the box.
+// The pre-selected option is already the sane default, so Enter accepts it.
+func acceptThemeSelectionDialog(
+	ctx context.Context,
+	budget *startupDialogBudget,
+	peek func(lines int) (string, error),
+	sendKeys func(keys ...string) error,
+) error {
+	for budget.live() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		content, err := peek(startupDialogPeekLines)
+		if err != nil {
+			return err
+		}
+
+		if containsThemeSelectionDialog(content) {
+			budget.observe()
+			if err := sendKeys("Enter"); err != nil {
+				return err
+			}
+			sleep(ctx, startupDialogAcceptDelay)
+			return nil
+		}
+
+		if containsPromptIndicator(content) || containsPostThemeStartupDialog(content) {
+			budget.observe()
+			return nil
+		}
+
+		sleep(ctx, dialogPollInterval)
+	}
+	return nil
+}
+
+func acceptThemeSelectionDialogFromStream(
+	ctx context.Context,
+	timeout time.Duration,
+	snapshots *replayableSnapshotCursor,
+	sendKeys func(keys ...string) error,
+) (bool, error) {
+	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
+		match:       containsThemeSelectionDialog,
+		matchKeys:   []string{"Enter"},
+		matchDelay:  startupDialogAcceptDelay,
+		ready:       containsPromptIndicator,
+		readyOrNext: containsPostThemeStartupDialog,
+	})
+}
+
+// containsThemeSelectionDialog requires both the picker's prompt and its
+// "/theme" escape hatch so ordinary output mentioning a text style cannot
+// false-match and eat an Enter.
+func containsThemeSelectionDialog(content string) bool {
+	return strings.Contains(content, "Choose the text style") &&
+		strings.Contains(content, "/theme")
+}
+
+func containsPostThemeStartupDialog(content string) bool {
+	return containsClaudeResumeDialog(content) ||
+		containsPostClaudeResumeStartupDialog(content)
 }
 
 // acceptClaudeResumeDialog dismisses Claude's high-token/old-session resume
@@ -296,12 +432,11 @@ func AcceptStartupDialogsWithTimeout(
 // as-is" to preserve the in-flight workflow context instead of summarizing it.
 func acceptClaudeResumeDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -312,6 +447,7 @@ func acceptClaudeResumeDialog(
 		}
 
 		if containsClaudeResumeDialog(content) {
+			budget.observe()
 			if err := sendKeys("Down"); err != nil {
 				return err
 			}
@@ -328,6 +464,7 @@ func acceptClaudeResumeDialog(
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -372,12 +509,11 @@ func containsPostClaudeResumeStartupDialog(content string) bool {
 // selection is "Update now", so automated sessions must move down to "Skip".
 func acceptCodexUpdateDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -388,6 +524,7 @@ func acceptCodexUpdateDialog(
 		}
 
 		if containsCodexUpdateDialog(content) {
+			budget.observe()
 			if err := sendKeys("Down"); err != nil {
 				return err
 			}
@@ -403,6 +540,7 @@ func acceptCodexUpdateDialog(
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -449,12 +587,11 @@ func containsPostUpdateStartupDialog(content string) bool {
 // pre-selected, so Enter accepts.
 func acceptWorkspaceTrustDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -465,6 +602,7 @@ func acceptWorkspaceTrustDialog(
 		}
 
 		if containsWorkspaceTrustDialog(content) {
+			budget.observe()
 			if err := sendKeys("Enter"); err != nil {
 				return err
 			}
@@ -473,6 +611,7 @@ func acceptWorkspaceTrustDialog(
 		}
 
 		if containsPromptIndicator(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -482,6 +621,7 @@ func acceptWorkspaceTrustDialog(
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -539,13 +679,12 @@ func containsPostTrustStartupDialog(content string) bool {
 // repository. An empty trustedRoot trusts nothing.
 func acceptExternalImportsDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 	trustedRoot string,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -556,6 +695,7 @@ func acceptExternalImportsDialog(
 		}
 
 		if containsExternalImportsDialog(content) && externalImportsTrusted(content, trustedRoot) {
+			budget.observe()
 			if err := sendKeys("Enter"); err != nil {
 				return err
 			}
@@ -564,6 +704,7 @@ func acceptExternalImportsDialog(
 		}
 
 		if containsPromptIndicator(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -572,6 +713,7 @@ func acceptExternalImportsDialog(
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -729,12 +871,11 @@ func isPathPrefix(ancestor, descendant string) bool {
 // runs after acceptWorkspaceTrustDialog. See gascity#3466.
 func acceptMCPTrustDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -745,6 +886,7 @@ func acceptMCPTrustDialog(
 		}
 
 		if containsMCPTrustDialog(content) {
+			budget.observe()
 			if err := sendKeys("Down"); err != nil {
 				return err
 			}
@@ -757,6 +899,7 @@ func acceptMCPTrustDialog(
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -797,12 +940,11 @@ func acceptMCPTrustDialogFromStream(
 // second option, "Trust all and continue", so press Down then Enter.
 func acceptCodexHookReviewDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -813,6 +955,7 @@ func acceptCodexHookReviewDialog(
 		}
 
 		if containsCodexHookReviewDialog(content) {
+			budget.observe()
 			if err := sendKeys("Down"); err != nil {
 				return err
 			}
@@ -824,6 +967,7 @@ func acceptCodexHookReviewDialog(
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -867,12 +1011,11 @@ func containsPostCodexHookReviewStartupDialog(content string) bool {
 // warning requiring Down arrow to select "Yes, I accept" and then Enter.
 func acceptBypassPermissionsWarning(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -883,6 +1026,7 @@ func acceptBypassPermissionsWarning(
 		}
 
 		if strings.Contains(content, "Bypass Permissions mode") {
+			budget.observe()
 			if err := sendKeys("Down"); err != nil {
 				return err
 			}
@@ -890,7 +1034,12 @@ func acceptBypassPermissionsWarning(
 			return sendKeys("Enter")
 		}
 
-		if containsPromptIndicator(content) {
+		// Hand off as soon as a later dialog is on screen, matching the stream
+		// twin's readyOrNext. Without this the phase polls out its budget on a
+		// pane that already shows the API-key or rate-limit dialog and starves
+		// the two phases that handle them.
+		if containsPromptIndicator(content) || containsPostBypassStartupDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -924,12 +1073,11 @@ func containsPostBypassStartupDialog(content string) bool {
 // Enter to choose "Yes" and proceed with the configured provider.
 func acceptCustomAPIKeyDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -940,6 +1088,7 @@ func acceptCustomAPIKeyDialog(
 		}
 
 		if containsCustomAPIKeyDialog(content) {
+			budget.observe()
 			if err := sendKeys("Up"); err != nil {
 				return err
 			}
@@ -948,6 +1097,7 @@ func acceptCustomAPIKeyDialog(
 		}
 
 		if containsPromptIndicator(content) || ContainsRateLimitDialog(content) {
+			budget.observe()
 			return nil
 		}
 
@@ -983,12 +1133,11 @@ func containsCustomAPIKeyDialog(content string) bool {
 // wake failures.
 func dismissRateLimitDialog(
 	ctx context.Context,
-	timeout time.Duration,
+	budget *startupDialogBudget,
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for budget.live() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -1001,6 +1150,7 @@ func dismissRateLimitDialog(
 		if ContainsRateLimitDialog(content) {
 			// Select "Stop" (option 2). The menu has "Keep trying" selected
 			// by default, so press Down then Enter.
+			budget.observe()
 			if err := sendKeys("Down"); err != nil {
 				return err
 			}
@@ -1009,6 +1159,7 @@ func dismissRateLimitDialog(
 		}
 
 		if containsPromptIndicator(content) {
+			budget.observe()
 			return nil
 		}
 

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -117,6 +117,7 @@ func newStartupDialogConfig(opts []StartupDialogOption) startupDialogConfig {
 //  6. Codex hook review dialog — requires Down+Enter to trust hooks
 //  7. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
 //  8. Claude custom API key confirmation — requires Up+Enter to select "Yes"
+//  9. Rate-limit / usage-limit dialog ("Usage limit reached") — requires Down+Enter to select "Stop" so the session exits cleanly
 //
 // The peek function should return the last N lines of the session's terminal output.
 // The sendKeys function should send bare tmux-style keystrokes (e.g., "Enter", "Down").

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -1410,6 +1410,180 @@ func TestAcceptStartupDialogsDismissesRateLimitDialog(t *testing.T) {
 	}
 }
 
+// claudeThemePickerPane is the first screen Claude Code v2.1.197 draws in a box
+// with no ~/.claude config, captured from a Crucible sandbox. Container runtimes
+// hand every session a fresh box, so this is not a once-per-machine prompt — it
+// blocks EVERY start until something answers it.
+const claudeThemePickerPane = `Welcome to Claude Code v2.1.197
+
+ Let's get started.
+
+ Choose the text style that looks best with your terminal
+ To change this later, run /theme
+
+   1. Auto (match terminal)
+ ❯ 2. Dark mode ✔
+   3. Light mode
+   4. Dark mode (colorblind-friendly)
+   5. Light mode (colorblind-friendly)
+   6. Dark mode (ANSI colors only)
+   7. Light mode (ANSI colors only)
+`
+
+func TestAcceptStartupDialogsAcceptsClaudeThemePicker(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) {
+			if len(sent) == 0 {
+				return claudeThemePickerPane, nil
+			}
+			return "user@host $", nil
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs() error = %v", err)
+	}
+	if !reflect.DeepEqual(sent, []string{"Enter"}) {
+		t.Fatalf("sent keys = %v, want [Enter] to accept the pre-selected theme", sent)
+	}
+}
+
+func TestContainsThemeSelectionDialog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "captured first-run picker", content: claudeThemePickerPane, want: true},
+		{
+			name:    "prose mentioning a text style is not the picker",
+			content: "I'll choose the text style used by the docs theme.",
+			want:    false,
+		},
+		{
+			name:    "slash-command help is not the picker",
+			content: "  /theme    Change the color theme",
+			want:    false,
+		},
+		{name: "ordinary prompt", content: "user@host $", want: false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := containsThemeSelectionDialog(tt.content); got != tt.want {
+				t.Fatalf("containsThemeSelectionDialog(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// The theme picker's cursor row ("❯ 2. Dark mode ✔") wears the same glyph as a
+// ready input prompt. If readiness detection accepted it, every phase would
+// early-return on a session that is still blocked and the picker would never be
+// answered.
+func TestClaudeThemePickerIsNotMistakenForAReadyPrompt(t *testing.T) {
+	t.Parallel()
+	if containsPromptIndicator(claudeThemePickerPane) {
+		t.Fatal("theme picker pane reads as a ready prompt; the session is still blocked")
+	}
+}
+
+// TestAcceptStartupDialogsWithTimeoutBoundsBlankPaneToOneTimeout pins the whole
+// sequence to a single timeout when the pane never renders anything
+// recognizable — the shape an agent that exits at launch leaves behind, where
+// the in-box tmux server is gone and every capture comes back empty.
+//
+// Per-dialog timeouts made that cost timeout x the number of dialog classes.
+// With the 8s default that is 72s, past the 60s default [session]
+// startup_timeout, so the caller's context expired mid-sequence and a session
+// whose agent had simply died failed as "<some dialog>: context deadline
+// exceeded" — naming whichever dialog the wall-clock landed in.
+func TestAcceptStartupDialogsWithTimeoutBoundsBlankPaneToOneTimeout(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollInterval = 5 * time.Millisecond
+
+	const timeout = 150 * time.Millisecond
+	var sent []string
+	start := time.Now()
+	err := AcceptStartupDialogsWithTimeout(
+		context.Background(),
+		timeout,
+		func(_ int) (string, error) { return "", nil },
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsWithTimeout() error = %v, want nil", err)
+	}
+	if len(sent) != 0 {
+		t.Fatalf("sent keys = %v, want none on a blank pane", sent)
+	}
+	if elapsed >= 2*timeout {
+		t.Fatalf("blank pane took %v with a %v budget; the sequence is still spending a timeout per dialog class", elapsed, timeout)
+	}
+}
+
+// TestAcceptStartupDialogsWithTimeoutRefreshesBudgetOnProgress guards the other
+// half of the budget: a dialog that only renders after the sequence has already
+// dismissed an earlier one must still be handled. Every dismissal grants a fresh
+// timeout, so a chain of slow-rendering dialogs is not cut off by the bound that
+// stops a dead pane.
+func TestAcceptStartupDialogsWithTimeoutRefreshesBudgetOnProgress(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollInterval = 5 * time.Millisecond
+
+	const timeout = 500 * time.Millisecond
+	const renderDelay = 300 * time.Millisecond
+
+	var sent []string
+	start := time.Now()
+	var trustAccepted time.Time
+	err := AcceptStartupDialogsWithTimeout(
+		context.Background(),
+		timeout,
+		func(_ int) (string, error) {
+			if trustAccepted.IsZero() {
+				if time.Since(start) < renderDelay {
+					return "", nil // agent still booting: nothing on screen yet
+				}
+				return "Quick safety check", nil
+			}
+			if time.Since(trustAccepted) < renderDelay {
+				return "", nil // next dialog has not rendered yet
+			}
+			return "Bypass Permissions mode", nil
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			if keys[0] == "Enter" && trustAccepted.IsZero() {
+				trustAccepted = time.Now()
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsWithTimeout() error = %v, want nil", err)
+	}
+	if !reflect.DeepEqual(sent, []string{"Enter", "Down", "Enter"}) {
+		t.Fatalf("sent keys = %v, want [Enter Down Enter] (trust accepted, then bypass warning)", sent)
+	}
+}
+
 func TestContainsRateLimitDialog(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -1456,6 +1456,47 @@ func TestAcceptStartupDialogsAcceptsClaudeThemePicker(t *testing.T) {
 	}
 }
 
+// TestAcceptStartupDialogsFromStreamAcceptsClaudeThemePicker covers the theme
+// picker on the production stream path
+// (AcceptStartupDialogsFromStreamWithStatus, dialog.go:150), which the
+// polling-path twin TestAcceptStartupDialogsAcceptsClaudeThemePicker does not
+// exercise. It proves the picker is accepted with Enter and — because the
+// picker must not be mistaken for readiness — the next startup dialog in the
+// same stream (here the Claude resume selector) still advances afterward.
+func TestAcceptStartupDialogsFromStreamAcceptsClaudeThemePicker(t *testing.T) {
+	withZeroDialogTimings(t)
+
+	snapshots := make(chan string, 2)
+	snapshots <- claudeThemePickerPane
+	snapshots <- strings.Join([]string{
+		"This session is 1h 55m old and 212.7k tokens.",
+		"",
+		"❯ 1. Resume from summary (recommended)",
+		"  2. Resume full session as-is",
+		"  3. Don't ask me again",
+		"",
+		"Enter to confirm · Esc to cancel",
+	}, "\n")
+	close(snapshots)
+
+	var sent []string
+	err := AcceptStartupDialogsFromStream(
+		context.Background(),
+		time.Second,
+		snapshots,
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
+	}
+	if !reflect.DeepEqual(sent, []string{"Enter", "Down", "Enter"}) {
+		t.Fatalf("sent keys = %v, want [Enter Down Enter] (accept theme, then advance the resume dialog)", sent)
+	}
+}
+
 func TestContainsThemeSelectionDialog(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> **Scope note.** This is **not** the fix for the sessions currently failing on the Crucible runtime. That root cause is a provisioning gap — the managed `settings.json` and Claude's first-run marker never reach the sandbox — and is fixed in the Crucible pack. This PR fixes a **latent defect in the dismissal loop itself** that turned that failure into a 60s timeout blaming a dialog that was never on screen. It is worth landing on its own merits; it is not what unblocks the city.

## The latent defect

`AcceptStartupDialogsWithTimeout` gave each of its **nine** dialog phases its own full `timeout`.

Every phase already early-returns the moment it recognizes the pane — its own dialog, any later dialog, or a ready prompt. So a phase only burns its full timeout when the pane shows **nothing recognizable**, and in that state the remaining phases are polling the same blank pane and burn theirs too.

Nine phases x the 8s default = **72s**, past the 60s default `[session] startup_timeout`. The caller's context expires mid-sequence, and a helper documented as best-effort and "idempotent: safe to call on sessions without dialogs" turns a quiet pane into a hard start failure — which `exec.Provider.Start` follows with a `Stop`, destroying the box and the evidence.

That is a defect regardless of *why* the pane was quiet. Any future agent that is slow to draw, or any runtime whose peek transport reports a dead box as empty output, lands in the same 72s > 60s hole.

## How it surfaced

A pane that never rendered produced this, ~60s in:

```
… dismissing startup dialogs: codex hook review dialog: context deadline exceeded
… dismissing startup dialogs: bypass permissions warning: context deadline exceeded
… dismissing startup dialogs: mcp trust dialog: context deadline exceeded
outcome=deadline_exceeded duration=1m0.907s phases=[start_call=1m0.907s]
```

Three names, one bug — the name is just whichever phase the wall-clock landed in. The city's provider was `claude`, so a *Codex* dialog was never plausible. The arithmetic predicts each name exactly from the provider's `start` duration `T0`:

| failing phase | window | implied `T0` |
|---|---|---|
| mcp trust (5) | `[T0+32, T0+40]` | 20-28s |
| codex hook review (6) | `[T0+40, T0+48]` | 12-20s |
| bypass permissions (7) | `[T0+48, T0+56]` | 4-12s |

Measured `T0` on that runtime was ~15-20s, squarely in the band.

## The fix

Give the sequence **one shared budget**, refreshed every time a phase recognizes the pane.

- A quiet pane costs **one** timeout instead of nine.
- A real dialog chain is unaffected: each dismissal grants a fresh timeout for the next dialog to render.
- This is the invariant the streaming twin `AcceptStartupDialogsFromStreamWithStatus` already enforces — it stops as soon as a phase observes nothing. The polling path just never got it.

Side effect worth having: `dialogPollTimeout` becomes tunable. It previously had to stay small enough that *nine* of it fit inside the start deadline; now it costs its own value once.

Deliberately **not** a timeout bump — in the observed failure the dialogs never appeared at all, so a longer timeout would only have failed slower.

### Gap this exposed

`acceptBypassPermissionsWarning` never handed off to the phases after it. Unlike its stream twin's `readyOrNext`, it only checked for a ready prompt — so with the API-key or rate-limit dialog on screen it polled out and left the two phases that handle them running against a spent clock. Two existing tests caught this the moment the budget became shared. It is now the only phase whose forward-lookahead matched its twin.

## The theme-picker handler — please review this part specifically

Claude Code's first-run theme picker was unhandled:

```
 Choose the text style that looks best with your terminal
 To change this later, run /theme
 ❯ 2. Dark mode ✔
```

On a runtime that hands every session a fresh box, this blocks **every** start, because the state that records the choice dies with the box. Its cursor row wears the same `❯` glyph as a ready prompt, so nothing downstream could tell the session was blocked rather than idle. Verified live that `Enter` accepts the pre-selected option.

**The primary fix for this is elsewhere** — the Crucible pack now seeds `hasCompletedOnboarding`, so the picker does not render at all (verified: Claude reaches its prompt with zero dialogs). I have kept the handler here anyway, and I think it should stay:

- The marker is **pack-specific**. This is the OSS runtime layer; any other fresh-container runtime — a k8s pod on a clean image, another exec pack, docker — hits the identical picker with no marker.
- The pack's seed is **best-effort and gated** on the launch command looking like Claude. A wrapper it does not recognize, or a box that refuses the write, still needs a backstop.
- It is ~40 lines and provider-agnostic.

If you would rather this repo not carry a handler for a dialog the pack is expected to prevent, the theme commit is cleanly separable and I will drop it — say the word.

## Verification

`gofmt`, `go build ./...`, `go vet`, `make lint-changed` (0 issues), `go test ./internal/runtime/... ./internal/session/... ./internal/worker/... ./internal/api/...`, plus the full `test-local-parallel fast` gate at push time.

- `TestAcceptStartupDialogsWithTimeoutBoundsBlankPaneToOneTimeout` — the repro. On `main`: **1.37s against a 150ms budget (9.1x)**. Passes here.
- `TestAcceptStartupDialogsWithTimeoutRefreshesBudgetOnProgress` — guards against over-tightening: a dialog that renders only after an earlier one was dismissed is still handled.
- `TestAcceptStartupDialogsAcceptsClaudeThemePicker`, `TestContainsThemeSelectionDialog`, `TestClaudeThemePickerIsNotMistakenForAReadyPrompt` — using pane text captured from a real sandbox.

## Known tradeoff

The budget is now the window for the pane's **first** recognizable frame — 8s by default, where a slow runtime previously got up to 72s spread across phases (though it could never use it, since the caller's 60s deadline killed the start first). If a dialog first renders after the budget is spent, a Claude session sits on it: `needsDeferredStartupDialogVerification` gates the mid-session `DismissKnownDialogs` sweep on `providerKind == "codex"`, so Claude has no second pass. I did not raise the default, having found no case where a dialog genuinely appears late — only cases where it never appears. `dialogPollTimeout` is now the safe single knob if one turns up.

Separately worth a look: `tmuxCarrier.Peek` returns `("", nil)` for a failed `capture-pane`, which is what made a dead box indistinguishable from a quiet one for 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
