### PR TITLE
fix(runtime/herdr): confirm startup first-turn submission, recover swallowed submit CR (gas-90h)

### DIFF
--- a/internal/runtime/herdr-provider-design.md
+++ b/internal/runtime/herdr-provider-design.md
@@ -71,6 +71,15 @@ exhaustion; bead az-405 has the full evidence trail). The adapter was rewritten 
 - **Delivery**: `deliverNudge` targets the pane id via native `agent prompt`
   (registered agents), falling back to paste+Enter for unregistered panes.
   `WaitForIdle` uses `agent wait --until idle`. `Peek` reads via `pane read`.
+- **Startup delivery** (`deliverStartupTurn`, gas-90h): the FIRST turn opts into
+  submission confirmation — `agent prompt --wait --until working/done/blocked`
+  — because a freshly-booted TUI can swallow the submit CR while the un-waited
+  prompt reports ok (text typed-but-unsubmitted, agent stranded idle). On
+  `agent_prompt_stalled`/`timeout` the recovery is one explicit `send-keys
+  Enter` (the text is already in the box; never re-prompt) plus a confirming
+  wait; a still-unconfirmed delivery is recorded on the sidecar
+  (`GC_HERDR_STARTUP_DELIVERY_UNCONFIRMED`) and stderr. Mid-session nudges keep
+  the fast un-waited form.
 
 ### Operational gotchas (learned in production, 2026-07-26)
 

--- a/internal/runtime/herdr/capabilities.go
+++ b/internal/runtime/herdr/capabilities.go
@@ -22,18 +22,49 @@ var (
 	_ runtime.LivenessObserver = (*Provider)(nil)
 )
 
-// WaitForIdle blocks until herdr reports the agent idle or the timeout elapses,
-// via herdr's native `agent wait --until idle` (the ≥0.7.5 flag spelling) — vs
-// the pane-polling tmux does. Either outcome (idle reached or timed out) means
-// the caller may proceed — as does an unregistered session (raw shell panes
-// have no agent to wait on) — so only context cancellation surfaces as an
-// error; the timeout is a hard bound.
-func (p *Provider) WaitForIdle(ctx context.Context, name string, timeout time.Duration) error {
+// idleWaitOutcome is the legible verdict of one `agent wait --until idle`
+// probe. The interface-facing WaitForIdle keeps its proceed-either-way
+// contract, but internal callers (Start's startup delivery) need to see WHY a
+// wait did not confirm: the live city measured 0 ok / 8 timeout / 2 error
+// over 20h with every verdict silently discarded (gas-90h).
+type idleWaitOutcome string
+
+const (
+	idleWaitReached idleWaitOutcome = "idle"     // herdr observed the agent idle
+	idleWaitTimeout idleWaitOutcome = "timeout"  // bound elapsed without idle
+	idleWaitNoAgent idleWaitOutcome = "no_agent" // no registered agent (raw shell pane)
+	idleWaitError   idleWaitOutcome = "error"    // transport or unexpected herdr error
+)
+
+// waitForIdleOutcome blocks until herdr reports the agent idle or the timeout
+// elapses, via herdr's native `agent wait --until idle` (the ≥0.7.5 flag
+// spelling) — vs the pane-polling tmux does — and returns the verdict
+// distinctly instead of discarding it.
+func (p *Provider) waitForIdleOutcome(ctx context.Context, name string, timeout time.Duration) idleWaitOutcome {
 	ms := int(timeout / time.Millisecond)
 	if ms < 1 {
 		ms = 1
 	}
-	_, _ = p.c.run(ctx, "agent", "wait", herdrAgentName(name), "--until", "idle", "--timeout", strconv.Itoa(ms))
+	_, err := p.c.run(ctx, "agent", "wait", herdrAgentName(name), "--until", "idle", "--timeout", strconv.Itoa(ms))
+	switch {
+	case err == nil:
+		return idleWaitReached
+	case herdrErrorCode(err) == "timeout":
+		return idleWaitTimeout
+	case isAgentNotFound(err):
+		return idleWaitNoAgent
+	default:
+		return idleWaitError
+	}
+}
+
+// WaitForIdle blocks until herdr reports the agent idle or the timeout
+// elapses. Either outcome (idle reached or timed out) means the caller may
+// proceed — as does an unregistered session (raw shell panes have no agent to
+// wait on) — so only context cancellation surfaces as an error; the timeout
+// is a hard bound.
+func (p *Provider) WaitForIdle(ctx context.Context, name string, timeout time.Duration) error {
+	_ = p.waitForIdleOutcome(ctx, name, timeout)
 	return ctx.Err()
 }
 

--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -251,20 +251,107 @@ func (c *client) paneRun(ctx context.Context, paneID, command string) error {
 // Panes with no registered agent (raw `exec /bin/sh -c` sessions, bare
 // shells) fall back to paste + Enter: there is no TUI prompt machinery to
 // confirm against, so delivery is best-effort by construction.
+//
+// Note this path does NOT confirm the submit landed: `agent prompt` without
+// --wait reports ok the moment the text is typed. Against a live mid-session
+// TUI that is reliable; a FIRST turn into a freshly-booted TUI must go
+// through deliverStartupTurn, which opts into herdr's submission
+// confirmation.
 func (c *client) deliverNudge(ctx context.Context, paneID, text string) error {
 	err := c.agentPrompt(ctx, paneID, text)
 	if err == nil {
 		return nil
 	}
-	if !strings.Contains(err.Error(), "not_found") && !strings.Contains(err.Error(), "not found") {
+	if !isAgentNotFound(err) {
 		return err
 	}
-	// No registered agent on this pane: paste, settle, submit.
+	return c.pasteAndSubmit(ctx, paneID, text)
+}
+
+// Startup-delivery confirmation bounds (herdr ≥0.7.5 `agent prompt --wait`).
+// herdr's stall verdict fires at its fixed 5000ms observed-state-change
+// window, so the prompt timeout must exceed 5000 or a plain "timeout" masks
+// the more precise "agent_prompt_stalled".
+const (
+	startupPromptConfirmTimeoutMS = 15000
+	startupStallRecoveryTimeoutMS = 10000
+)
+
+// startupConfirmStates are the post-submission states that prove the submit
+// CR took: the turn is running (working), already finished (done — an
+// ultra-short turn can settle between herdr's observations), or hit a dialog
+// (blocked). "idle" is deliberately absent — it is the pre-submit state, and
+// matching it would confirm a swallowed CR.
+var startupConfirmStates = []string{"working", "done", "blocked"}
+
+// deliverStartupTurn delivers an agent's FIRST turn with submission
+// confirmation, unlike deliverNudge's fire-and-forget prompt. A freshly
+// spawned TUI boots through a shell→TUI handoff during which the submit CR
+// can be swallowed: the text sits typed-but-unsubmitted in the input box and
+// the agent idles forever (the stranded-startup outage, gas-90h). The
+// un-waited `agent prompt` reports ok without verifying the CR took, so here
+// the prompt runs with --wait: herdr requires an observed state change after
+// submission and returns agent_prompt_stalled when the agent never leaves
+// idle — the swallowed-CR detector.
+//
+// On a stall (or a wait that elapsed without a confirming state), recovery is
+// a single explicit Enter — the text is already in the input box, and a bare
+// Enter on an empty box is a no-op, so this is safe in every plausible state
+// — followed by a confirming wait. Never re-prompt: retyping would double the
+// text. Unregistered panes (raw shells) keep the best-effort
+// paste+settle+Enter path. A non-nil error means the turn could not be
+// confirmed submitted.
+func (c *client) deliverStartupTurn(ctx context.Context, paneID, text string) error {
+	args := []string{"agent", "prompt", paneID, text, "--wait"}
+	for _, s := range startupConfirmStates {
+		args = append(args, "--until", s)
+	}
+	args = append(args, "--timeout", strconv.Itoa(startupPromptConfirmTimeoutMS))
+	_, err := c.run(ctx, args...)
+	if err == nil {
+		return nil
+	}
+	if isAgentNotFound(err) {
+		return c.pasteAndSubmit(ctx, paneID, text)
+	}
+	switch herdrErrorCode(err) {
+	case "agent_prompt_stalled", "timeout":
+		if kerr := c.sendKeys(ctx, paneID, "Enter"); kerr != nil {
+			return fmt.Errorf("startup submit not confirmed (%w) and recovery Enter failed: %w", err, kerr)
+		}
+		wait := []string{"agent", "wait", paneID}
+		for _, s := range startupConfirmStates {
+			wait = append(wait, "--until", s)
+		}
+		wait = append(wait, "--timeout", strconv.Itoa(startupStallRecoveryTimeoutMS))
+		if _, werr := c.run(ctx, wait...); werr != nil {
+			return fmt.Errorf("startup submit not confirmed after Enter recovery (%w): %w", err, werr)
+		}
+		return nil
+	}
+	return err
+}
+
+// pasteAndSubmit is the unregistered-pane delivery: paste, settle, submit.
+func (c *client) pasteAndSubmit(ctx context.Context, paneID, text string) error {
 	if err := c.paneRun(ctx, paneID, text); err != nil {
 		return err
 	}
 	time.Sleep(submitSettleDelay)
 	return c.sendKeys(ctx, paneID, "Enter")
+}
+
+// isAgentNotFound reports whether err is herdr's missing-agent rejection
+// (typed agent_not_found, or the message-text forms the pre-typed-error
+// callers matched on).
+func isAgentNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if herdrErrorCode(err) == "agent_not_found" {
+		return true
+	}
+	return strings.Contains(err.Error(), "not_found") || strings.Contains(err.Error(), "not found")
 }
 
 // submitSettleDelay is how long the unregistered-pane fallback waits for a

--- a/internal/runtime/herdr/panebinding_provider_test.go
+++ b/internal/runtime/herdr/panebinding_provider_test.go
@@ -56,13 +56,21 @@ agent_start)
   if [ -e "$METADIR/$3/GC_HERDR_PANE_ID" ]; then : > "$STATE/bound_before_launch"; fi
   printf '%s' '{"result":{"agent":{"name":"'"$3"'","pane_id":"%5","tab_id":"t1","workspace_id":"w1","agent_status":"idle"}}}' ;;
 agent_wait)
-  printf '%s' '{"result":{"agent":{"name":"'"$3"'","agent_status":"idle"}}}' ;;
+  if [ ! -e "$STATE/registered" ]; then
+    printf '%s' '{"error":{"code":"agent_not_found","message":"agent target not found"}}'
+  elif [ -e "$STATE/wait_times_out" ]; then
+    printf '%s' '{"error":{"code":"timeout","message":"timed out waiting for agent status"}}'
+  else
+    printf '%s' '{"result":{"agent":{"name":"'"$3"'","agent_status":"idle"}}}'
+  fi ;;
 agent_prompt)
-  if [ -e "$STATE/registered" ]; then
+  if [ ! -e "$STATE/registered" ]; then
+    printf '%s' '{"error":{"code":"agent_not_found","message":"agent target not found"}}'
+  elif [ -e "$STATE/prompt_stalled" ]; then
+    printf '%s' '{"error":{"code":"agent_prompt_stalled","message":"no state change observed after submission"}}'
+  else
     : > "$STATE/prompted"
     printf '%s' '{"result":{"type":"agent_prompted"}}'
-  else
-    printf '%s' '{"error":{"code":"agent_not_found","message":"agent target not found"}}'
   fi ;;
 pane_run)
   : > "$STATE/busy"

--- a/internal/runtime/herdr/provider.go
+++ b/internal/runtime/herdr/provider.go
@@ -216,15 +216,44 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 		// Bounded and best-effort: on a boot that never idles we deliver anyway (no
 		// worse than the prior unconditional send), and the reconciler tolerates a
 		// slow Start (pendingCreateNeverStartedTimeout = 10m).
-		_ = p.WaitForIdle(ctx, name, startupNudgeIdleTimeout)
-		if err := p.c.deliverNudge(ctx, info.PaneID, startupText); err != nil {
-			// Best-effort: the submit didn't confirm (TUI race under boot load).
-			// Surface it rather than silently leaving a stranded startup turn;
-			// nudgeStalledPoolClaims is the reconcile-tick backstop of last resort.
-			fmt.Fprintf(os.Stderr, "herdr: startup delivery for %q not confirmed: %v\n", name, err) //nolint:errcheck // best-effort diagnostic
+		idleOutcome := p.waitForIdleOutcome(ctx, name, startupNudgeIdleTimeout)
+		// Deliver with submission confirmation: the swallowed-CR strand is
+		// detected (agent_prompt_stalled) and recovered in-band with an explicit
+		// Enter (deliverStartupTurn). An error here means even recovery could not
+		// confirm the first turn started — the session is live, so failing Start
+		// would only trigger a respawn storm; record the strand durably instead
+		// so it is machine-visible and countable. nudgeStalledPoolClaims remains
+		// the reconcile-tick backstop of last resort for pool slots.
+		// Reset any marker a crashed prior life left behind (Stop wipes the
+		// sidecar, a crash does not): this life's delivery decides the marker.
+		_ = p.RemoveMeta(name, metaStartupUnconfirmed)
+		if err := p.c.deliverStartupTurn(ctx, info.PaneID, startupText); err != nil {
+			p.recordStartupDeliveryUnconfirmed(name, info.PaneID, idleOutcome, err)
 		}
 	}
 	return nil
+}
+
+// metaStartupUnconfirmed is the sidecar key recording that this life's startup
+// first-turn delivery was never confirmed submitted, even after Enter
+// recovery. The value carries when, the pane, the readiness-guard verdict, and
+// herdr's error. Stop's clearMeta wipes it with the session, so a marker
+// always refers to the CURRENT life; herdr-server.log keeps the historical
+// count (agent.prompt outcomes). Consumers: operators (`gc` sidecar
+// inspection) and a future named-session delivery backstop (gas-90h fix 3).
+const metaStartupUnconfirmed = "GC_HERDR_STARTUP_DELIVERY_UNCONFIRMED"
+
+// recordStartupDeliveryUnconfirmed persists an unconfirmed startup delivery on
+// the session's sidecar and mirrors it to stderr for interactive runs. stderr
+// alone is not enough: daemonized controllers devnull it, which is how this
+// failure stayed invisible for 20h of live operation (gas-90h).
+func (p *Provider) recordStartupDeliveryUnconfirmed(name, paneID string, idleOutcome idleWaitOutcome, derr error) {
+	detail := fmt.Sprintf("%s pane=%s idle_wait=%s: %v",
+		time.Now().UTC().Format(time.RFC3339), paneID, idleOutcome, derr)
+	if err := p.SetMeta(name, metaStartupUnconfirmed, detail); err != nil {
+		fmt.Fprintf(os.Stderr, "herdr: recording unconfirmed startup delivery for %q failed: %v\n", name, err) //nolint:errcheck // best-effort diagnostic
+	}
+	fmt.Fprintf(os.Stderr, "herdr: startup delivery for %q not confirmed: %v\n", name, derr) //nolint:errcheck // best-effort diagnostic
 }
 
 // startupDeliveryText resolves the first-turn text Start delivers to a freshly
@@ -273,9 +302,9 @@ func startupPrimeText(cfg runtime.Config) string {
 // startupNudgeIdleTimeout bounds how long Start waits for a freshly-spawned
 // agent to reach its idle input prompt before delivering the startup nudge. The
 // wait returns as soon as the agent idles (typically a few seconds); the bound
-// only bites on a boot that never idles, after which the nudge is sent
-// best-effort. Sized generously to cover cold, concurrent boots during a
-// town-wide restart.
+// only bites on a boot that never idles, after which delivery proceeds anyway —
+// deliverStartupTurn confirms (or recovers) the submit either way. Sized
+// generously to cover cold, concurrent boots during a town-wide restart.
 const startupNudgeIdleTimeout = 60 * time.Second
 
 const (

--- a/internal/runtime/herdr/startup_delivery_confirm_test.go
+++ b/internal/runtime/herdr/startup_delivery_confirm_test.go
@@ -1,0 +1,161 @@
+package herdr
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// ── startup-delivery confirmation against the fake herdr (gas-90h) ───────────
+//
+// The stranded-startup outage: a freshly-spawned TUI can swallow the submit
+// CR, leaving the first turn typed-but-unsubmitted while the un-waited
+// `agent prompt` reports ok — the agent then idles forever with its
+// instruction visible in the input box. These tests pin the confirmed
+// delivery path: --wait confirmation flags on the startup prompt, an Enter
+// recovery on agent_prompt_stalled, and a durable sidecar marker when even
+// recovery cannot confirm the submit.
+
+// A registered agent's startup turn must be delivered through
+// `agent prompt --wait`, so herdr verifies the submission actually started a
+// turn instead of reporting ok the instant the text is typed.
+func TestStartupDeliveryPromptsWithConfirmation(t *testing.T) {
+	p, session, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, session)
+
+	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
+	if err := p.Start(context.Background(), "gastown__witness", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	calls := fakeCalls(t, state)
+	want := "agent prompt %5 Run gc hook --claim --json now. --wait --until working --until done --until blocked --timeout 15000"
+	if !strings.Contains(calls, want) {
+		t.Fatalf("startup delivery did not request submission confirmation:\nwant %q in:\n%s", want, calls)
+	}
+	if strings.Contains(calls, "send-keys") {
+		t.Fatalf("confirmed delivery must not fire a recovery Enter:\n%s", calls)
+	}
+	if v, _ := p.GetMeta("gastown__witness", metaStartupUnconfirmed); v != "" {
+		t.Fatalf("confirmed delivery recorded an unconfirmed marker: %q", v)
+	}
+}
+
+// agent_prompt_stalled means the text was typed but the submit CR was
+// swallowed (the agent never left idle). Recovery is a single explicit Enter —
+// the text is already sitting in the input box — followed by a confirming
+// wait. No re-prompt: retyping would double the text in the box.
+func TestStartupDeliveryStallRecoversWithEnter(t *testing.T) {
+	p, session, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, session)
+	setState(t, state, "prompt_stalled")
+
+	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
+	if err := p.Start(context.Background(), "gastown__witness", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	calls := fakeCalls(t, state)
+	if !strings.Contains(calls, "pane send-keys %5 Enter") {
+		t.Fatalf("stalled submit was not recovered with an explicit Enter:\n%s", calls)
+	}
+	if !strings.Contains(calls, "agent wait %5 --until working --until done --until blocked --timeout 10000") {
+		t.Fatalf("Enter recovery was not re-confirmed:\n%s", calls)
+	}
+	if n := strings.Count(calls, "agent prompt"); n != 1 {
+		t.Fatalf("stall recovery must not re-prompt (typed text would double); prompts = %d:\n%s", n, calls)
+	}
+	if v, _ := p.GetMeta("gastown__witness", metaStartupUnconfirmed); v != "" {
+		t.Fatalf("recovered delivery recorded an unconfirmed marker: %q", v)
+	}
+}
+
+// When the stall recovery cannot confirm either, Start still succeeds (the
+// session is live; failing Start would trigger a respawn storm) but the
+// strand must be recorded durably on the sidecar so it is machine-visible
+// and countable — stderr alone is discarded in daemon contexts.
+func TestStartupDeliveryUnconfirmedRecordsSidecarMarker(t *testing.T) {
+	p, session, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, session)
+	setState(t, state, "prompt_stalled")
+	setState(t, state, "wait_times_out")
+
+	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
+	if err := p.Start(context.Background(), "gastown__witness", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	calls := fakeCalls(t, state)
+	if !strings.Contains(calls, "pane send-keys %5 Enter") {
+		t.Fatalf("unconfirmed delivery skipped the Enter recovery attempt:\n%s", calls)
+	}
+	v, err := p.GetMeta("gastown__witness", metaStartupUnconfirmed)
+	if err != nil || v == "" {
+		t.Fatalf("unconfirmed startup delivery left no sidecar marker (v=%q err=%v)", v, err)
+	}
+	if !strings.Contains(v, "agent_prompt_stalled") {
+		t.Fatalf("marker does not carry the stall verdict: %q", v)
+	}
+}
+
+// Raw-exec sessions never register an agent, so there is no prompt machinery
+// to confirm against: the legacy paste+settle+Enter path stays, best-effort
+// by construction, and must not record an unconfirmed marker.
+func TestStartupDeliveryUnregisteredPaneFallsBackToPaste(t *testing.T) {
+	p, session, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, session)
+
+	cfg := runtime.Config{Command: "python3 worker.py", Nudge: "Read your brief."}
+	if err := p.Start(context.Background(), "gastown__worker", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	calls := fakeCalls(t, state)
+	if !strings.Contains(calls, "pane run %5 Read your brief.") {
+		t.Fatalf("unregistered pane did not fall back to paste:\n%s", calls)
+	}
+	if !strings.Contains(calls, "pane send-keys %5 Enter") {
+		t.Fatalf("paste fallback did not submit with Enter:\n%s", calls)
+	}
+	if v, _ := p.GetMeta("gastown__worker", metaStartupUnconfirmed); v != "" {
+		t.Fatalf("best-effort raw delivery must not record an unconfirmed marker: %q", v)
+	}
+}
+
+// A marker left by a prior life (controller crash: Stop never wiped the
+// sidecar) must not outlive a life whose delivery confirms — a stale marker
+// would false-positive the named-session delivery backstop built on it.
+func TestStartupDeliveryConfirmedClearsStaleMarker(t *testing.T) {
+	p, session, _ := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, session)
+	if err := p.SetMeta("gastown__witness", metaStartupUnconfirmed, "stale prior-life record"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
+	if err := p.Start(context.Background(), "gastown__witness", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if v, _ := p.GetMeta("gastown__witness", metaStartupUnconfirmed); v != "" {
+		t.Fatalf("stale unconfirmed marker survived a confirmed delivery: %q", v)
+	}
+}
+
+// waitForIdleOutcome makes the startup readiness guard legible: the live city
+// measured 0 ok / 8 timeout / 2 error across 20h with every verdict discarded.
+// The interface-facing WaitForIdle keeps its proceed-either-way contract; the
+// outcome lets Start record WHY a strand happened.
+func TestWaitForIdleOutcomeMapping(t *testing.T) {
+	p, _, state := newFakeHerdrProvider(t)
+
+	if got := p.waitForIdleOutcome(context.Background(), "gastown__witness", time.Second); got != idleWaitNoAgent {
+		t.Fatalf("unregistered agent outcome = %q; want %q", got, idleWaitNoAgent)
+	}
+	setState(t, state, "registered")
+	if got := p.waitForIdleOutcome(context.Background(), "gastown__witness", time.Second); got != idleWaitReached {
+		t.Fatalf("idle agent outcome = %q; want %q", got, idleWaitReached)
+	}
+	setState(t, state, "wait_times_out")
+	if got := p.waitForIdleOutcome(context.Background(), "gastown__witness", time.Second); got != idleWaitTimeout {
+		t.Fatalf("timed-out wait outcome = %q; want %q", got, idleWaitTimeout)
+	}
+}


### PR DESCRIPTION
## Relay, not new work

This proposes an existing commit (`c79416739`) that was completed on bead **gas-90h** by polecat session `gastown__polecat-az-wisp-396im`, along with its tests and design notes. **Credit for the fix and its verification belongs to that session, not to me** — I am relaying it upstream.

Why it needs relaying: the bead was closed as *"Fixed and PUBLISHED: ajb branch fix/gas-90h-herdr-startup-delivery-confirm"*. "Published" there meant pushed to the fork; it was never proposed upstream, so the work has sat on one fork branch since Aug 7 while a follow-up bead (gas-mvl) blocks on it.

That is a live instance of the class gas-9sg names — quoting the framing from that investigation:

> work that looked published, wasn't, and is now blocking downstream work

The mechanism is in #5116: a self-referential git remote creates `refs/remotes/<name>/*` entries, so publication probes report success while nothing has left the host.

## What the commit does

Startup first turns are delivered via `agent prompt --wait --until working/done/blocked --timeout 15000` (`deliverStartupTurn`). Before it, `gc` called `herdr agent prompt` without `--wait`, so a swallowed submit CR stranded a brand-new agent with its prompt typed but never submitted, and no backstop covered named sessions. Now a swallowed CR surfaces as `agent_prompt_stalled` and is recovered in-band with one explicit Enter plus a confirming wait; `WaitForIdle` verdicts are made legible (`waitForIdleOutcome`); and a delivery that even recovery cannot confirm is recorded durably via the sidecar marker `GC_HERDR_STARTUP_DELIVERY_UNCONFIRMED` (reset each life) plus stderr. Mid-session nudges are unchanged — still fast and un-waited.

6 files, one commit off `main`: provider/client/capabilities plus a new `startup_delivery_confirm_test.go` and the provider design note.

## Verification (as recorded by the original author on gas-90h)

6 new unit tests pinning the `--wait` flags, Enter recovery (no re-prompt), marker semantics, raw-pane fallback, and outcome mapping; the herdr package green including a live herdr+claude kind-path smoke (28.6s); repo-wide `go vet` clean; `gofmt` clean; and a real cold-boot demo confirming a prompt in 217ms against a baseline of 65 unverified oks / 0 confirmed.

I have not re-run those locally — CI here is the independent check.

## Follow-up this unblocks

gas-mvl widens the startup-delivery backstop to named sessions and keys on the `GC_HERDR_STARTUP_DELIVERY_UNCONFIRMED` marker this commit introduces. It cannot be built on `main` until this lands, because nothing there would ever set the marker.

@quad341 — review/merge when you have a moment. This joins #5103, #5104, #5111, #5114, #5115, and #5116 as the batch of fork PRs awaiting maintainer action; #5111 is the one with fleet-wide leverage, since until it lands the macOS pre-push gate is broken for every agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)