### PR TITLE
test(cmd/gc): widen the dolt leak guard to the package directory (gas-dfn)

### DIFF
--- a/cmd/gc/dolt_leak_repo_root_test.go
+++ b/cmd/gc/dolt_leak_repo_root_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// doltProcWithConfigUnder builds a dolt sql-server process record whose
+// --config path sits under dir, the shape discoverDoltProcesses reports.
+func doltProcWithConfigUnder(pid int, dir string) DoltProcInfo {
+	return DoltProcInfo{
+		PID: pid,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(dir, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+}
+
+// TestSnapshotDoltProcessesForConfigRootsSeesRepoRootedServer is the gas-dfn
+// regression. The leak guard scopes its before/after snapshots to the private
+// temp root, so a test that starts a managed dolt whose data-dir resolves to
+// the PACKAGE DIRECTORY instead of t.TempDir() is outside both snapshots: it
+// leaks silently, the package still reports ok, and the live server holds the
+// lock on $REPO/cmd/gc/.beads/dolt so the next run in that checkout can block.
+// Scoping to the temp root AND the package dir makes that class loud.
+func TestSnapshotDoltProcessesForConfigRootsSeesRepoRootedServer(t *testing.T) {
+	tempRoot := filepath.Join("/tmp", "gc-cmd-test-root")
+	repoRoot := filepath.Join("/Users/someone/code/gascity", "cmd", "gc")
+	owned := doltProcWithConfigUnder(1001, filepath.Join(tempRoot, "TestOwned", "001"))
+	repoRooted := doltProcWithConfigUnder(1002, repoRoot)
+	unrelated := doltProcWithConfigUnder(1003, filepath.Join("/tmp", "TestOther", "001"))
+
+	got, err := snapshotDoltProcessesForConfigRoots(func() ([]DoltProcInfo, error) {
+		return []DoltProcInfo{owned, repoRooted, unrelated}, nil
+	}, tempRoot, repoRoot)
+	if err != nil {
+		t.Fatalf("snapshotDoltProcessesForConfigRoots: %v", err)
+	}
+	if _, ok := got[1002]; !ok {
+		t.Errorf("snapshot missed the repo-rooted server (PID 1002): %#v — this is the leak that reports ok today", got)
+	}
+	if _, ok := got[1001]; !ok {
+		t.Errorf("snapshot dropped the temp-root server (PID 1001): %#v", got)
+	}
+	if _, ok := got[1003]; ok {
+		t.Errorf("snapshot included an unrelated server (PID 1003): %#v — the guard must not claim processes it does not own", got)
+	}
+}
+
+// TestSnapshotDoltProcessesForConfigRootsIgnoresEmptyRoots proves a blank root
+// never widens the scope to everything. An empty tempRoot (createActiveTestTempRoot
+// failed) must not turn the guard into a box-wide reaper of other checkouts'
+// dolt servers.
+func TestSnapshotDoltProcessesForConfigRootsIgnoresEmptyRoots(t *testing.T) {
+	proc := doltProcWithConfigUnder(1001, filepath.Join("/tmp", "elsewhere"))
+
+	got, err := snapshotDoltProcessesForConfigRoots(func() ([]DoltProcInfo, error) {
+		return []DoltProcInfo{proc}, nil
+	}, "", "")
+	if err != nil {
+		t.Fatalf("snapshotDoltProcessesForConfigRoots: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("snapshot = %#v with no roots configured, want empty", got)
+	}
+}
+
+// TestSnapshotDoltProcessesForConfigRootMatchesSingleRootBehavior keeps the
+// original single-root entry point honest once it delegates to the multi-root
+// form: the existing callers' semantics must not shift.
+func TestSnapshotDoltProcessesForConfigRootMatchesSingleRootBehavior(t *testing.T) {
+	root := filepath.Join("/tmp", "gc-cmd-test-root")
+	owned := doltProcWithConfigUnder(1001, filepath.Join(root, "TestOwned", "001"))
+	unowned := doltProcWithConfigUnder(1002, filepath.Join("/tmp", "TestOther", "001"))
+	enumerate := func() ([]DoltProcInfo, error) {
+		return []DoltProcInfo{owned, unowned}, nil
+	}
+
+	single, err := snapshotDoltProcessesForConfigRoot(enumerate, root)
+	if err != nil {
+		t.Fatalf("snapshotDoltProcessesForConfigRoot: %v", err)
+	}
+	multi, err := snapshotDoltProcessesForConfigRoots(enumerate, root)
+	if err != nil {
+		t.Fatalf("snapshotDoltProcessesForConfigRoots: %v", err)
+	}
+	if len(single) != len(multi) {
+		t.Fatalf("single-root snapshot = %#v, multi-root snapshot = %#v, want identical", single, multi)
+	}
+	for pid := range single {
+		if _, ok := multi[pid]; !ok {
+			t.Errorf("multi-root snapshot missing PID %d present in single-root", pid)
+		}
+	}
+}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -101,15 +101,24 @@ func requireNoLeakedDoltAfterForPaths(t *testing.T, paths ...string) {
 }
 
 type doltLeakGuardedTestingM struct {
-	m            *testing.M
-	tempRoot     string
+	m        *testing.M
+	tempRoot string
+	// packageDir is go test's working directory — this package's source dir.
+	// It is watched alongside tempRoot because a test whose city path resolves
+	// to the cwd roots its managed dolt at $REPO/cmd/gc/.beads/dolt, where the
+	// temp-root-scoped snapshots could never see it leak (gas-dfn).
+	packageDir   string
 	cleanupPaths []string
 }
 
 func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...string) *doltLeakGuardedTestingM {
+	// A failed lookup yields "", which the snapshot ignores rather than
+	// treating as a match-everything root.
+	packageDir, _ := os.Getwd()
 	return &doltLeakGuardedTestingM{
 		m:            m,
 		tempRoot:     tempRoot,
+		packageDir:   packageDir,
 		cleanupPaths: cleanupPaths,
 	}
 }
@@ -131,7 +140,7 @@ func (g *doltLeakGuardedTestingM) runWith(
 	stopSignalHandler := g.installSignalHandler()
 	defer stopSignalHandler()
 
-	initial, initialErr := snapshotDoltProcessesForConfigRoot(enumerate, g.tempRoot)
+	initial, initialErr := snapshotDoltProcessesForConfigRoots(enumerate, g.tempRoot, g.packageDir)
 	if initialErr != nil {
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: initial scan failed: %v\n", initialErr) //nolint:errcheck
 	}
@@ -140,12 +149,12 @@ func (g *doltLeakGuardedTestingM) runWith(
 
 	guardFailed := initialErr != nil
 	if initialErr == nil {
-		final, finalErr := snapshotDoltProcessesForConfigRoot(enumerate, g.tempRoot)
+		final, finalErr := snapshotDoltProcessesForConfigRoots(enumerate, g.tempRoot, g.packageDir)
 		if finalErr != nil {
 			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: final scan failed: %v\n", finalErr) //nolint:errcheck
 			guardFailed = true
 		} else if leaked := diffDoltProcessSnapshots(initial, final); len(leaked) > 0 {
-			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: leaked %d dolt sql-server process(es) under %s\n", len(leaked), g.tempRoot) //nolint:errcheck
+			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: leaked %d dolt sql-server process(es) under %s or %s\n", len(leaked), g.tempRoot, g.packageDir) //nolint:errcheck
 			writeDoltLeakReport(os.Stderr, leaked)
 			reapLeaks(leaked)
 			guardFailed = true
@@ -311,6 +320,23 @@ func cmdGCTestConfigOwnerPID(configPath string, tempParent string) (int, bool) {
 }
 
 func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error), root string) (map[int]DoltProcInfo, error) {
+	return snapshotDoltProcessesForConfigRoots(enumerate, root)
+}
+
+// snapshotDoltProcessesForConfigRoots collects the dolt servers this package's
+// tests own, keyed by PID. A server is owned when its --config path lies under
+// ANY of roots; empty roots are ignored so a failed root resolution can never
+// widen the guard into a box-wide reaper of other checkouts' servers.
+//
+// Multiple roots exist because the private temp root is not the only place a
+// test can strand a server. A test whose city path resolves to the package
+// directory (go test's cwd) instead of t.TempDir() roots its managed dolt at
+// $REPO/cmd/gc/.beads/dolt, outside the temp root and therefore outside both
+// the before and after snapshots — so it leaked silently while the package
+// still reported ok, and its lock on that data dir could block the next run in
+// the same checkout (gas-dfn). Scoping to the package directory as well turns
+// that class from silent into a reported leak.
+func snapshotDoltProcessesForConfigRoots(enumerate func() ([]DoltProcInfo, error), roots ...string) (map[int]DoltProcInfo, error) {
 	procs, err := enumerate()
 	if err != nil {
 		return nil, err
@@ -318,10 +344,13 @@ func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error)
 	out := make(map[int]DoltProcInfo, len(procs))
 	for _, p := range procs {
 		configPath := extractConfigPath(p.Argv)
-		if root == "" || !pathutil.PathWithin(root, configPath) {
-			continue
+		for _, root := range roots {
+			if root == "" || !pathutil.PathWithin(root, configPath) {
+				continue
+			}
+			out[p.PID] = p
+			break
 		}
-		out[p.PID] = p
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Problem

The `cmd/gc` dolt leak guard scopes its before/after snapshots to the private temp root:

```go
snapshotDoltProcessesForConfigRoot(enumerate, g.tempRoot)
```

A test whose city path resolves to `go test`'s cwd instead of `t.TempDir()` starts a managed dolt at `$REPO/cmd/gc/.beads/dolt` — **outside both snapshots**. Such a server leaks silently, the package still reports `ok`, and its lock on that data dir can block the next run in the same checkout (cf. `TestStartManagedDoltFailsClosedWhenDataDirLockHeld`).

Not hypothetical: a `dolt sql-server` was found alive for a day rooted at `gascity-v140/cmd/gc/.beads/dolt`, and that residue is still on disk in the v140 checkout.

## What this changes

The snapshot takes multiple roots and watches the package directory alongside the temp root, so the class is **reported instead of invisible**.

- The single-root entry point delegates to the multi-root form, so existing callers keep identical semantics (pinned by a test).
- Empty roots are ignored rather than treated as match-everything — a failed root resolution must never turn the guard into a box-wide reaper of other checkouts' dolt servers (also pinned by a test).
- The leak message now names both roots.

## Scope — deliberately not "fixing" the test

**The offending test is not fixed here, because it no longer reproduces.** A full `cmd/gc` run on current code leaves no `cmd/gc/.beads` or `cmd/gc/.gc` behind in this worktree, and only the v140 checkout carries residue — consistent with an older run, exactly as the bead suspected when it said to confirm against current code before assuming. Inventing a fix for a test that no longer misbehaves would be guesswork; widening the guard is what makes the class loud if it returns.

The signal-path reaper still scopes to the temp root alone. It kills processes, and widening it would reap a repo-rooted server that *predates* the run rather than one this run leaked; the diff-based path already reaps genuinely new ones.

Follow-ups left to the bead, not done here: gitignoring `cmd/gc/.beads` + `cmd/gc/.gc` as defense in depth (the working tree has unrelated uncommitted `.gitignore` edits, so I kept this commit clean), and removing the stale v140 residue (a checkout I do not own; its leaked PID 74766 is already gone).

## Verification

- TDD, red first: `snapshotDoltProcessesForConfigRoots` undefined → 3 new tests green.
- Leak-guard/snapshot/diff tests green; `gofmt` clean; `make lint-changed` 0 issues.
- Full `cmd/gc` run: no residue produced. Its failures (`TestReapSkipTracker_*`, a 10m package timeout) are pre-existing and reproduce identically on clean `origin/main` — I confirmed that on a control worktree earlier today; the one "dolt leak guard" line in the log is the guard's own unit-test fixture, not a real leak.
- Local pre-push gate bypassed under the standing gas-90h authorization (gas-bsj / #5111 pending); Linux CI is the oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)