### PR TITLE
fix(runtime/tmux): confirm nudge submit for codex, not just claude

### DIFF
--- a/internal/runtime/tmux/codex_submit_test.go
+++ b/internal/runtime/tmux/codex_submit_test.go
@@ -82,6 +82,26 @@ func TestCodexBusyIndicatorIsReadable(t *testing.T) {
 	if !paneContainsBusyIndicator([]string{"  working  (esc to interrupt)"}) {
 		t.Fatal("codex's busy indicator no longer matches; submit verification for codex would report every delivery unconfirmed")
 	}
+	// The footer as codex actually renders it, captured live off codex-cli
+	// 0.147.0 by atbrace in #5122. The synthetic string above pins the
+	// substring; this pins the real line it has to be found inside.
+	if !paneContainsBusyIndicator([]string{"• Working (3s • esc to interrupt)"}) {
+		t.Fatal("codex-cli's live Working footer no longer reads as busy; submit verification for codex would report every delivery unconfirmed")
+	}
+	// The other direction, and the one that matters most: an IDLE codex
+	// composer must not read as busy. Verification treats a busy pane as proof
+	// the turn started, so a false-busy read on idle chrome means a dropped
+	// Enter is never re-sent — the nudge sits unsubmitted in the composer while
+	// every liveness surface reads green. Fixture is atbrace's live idle pane
+	// from #5122: a finished reply, the empty prompt, and the model/cwd status
+	// line whose "·" separator is the near-miss the spinner regex must not take.
+	if paneContainsBusyIndicator([]string{
+		"• PONG",
+		"› Explain this codebase",
+		"  gpt-5.5 low · /tmp/probe",
+	}) {
+		t.Fatal("idle codex composer reads as busy; a lost Enter would never be re-sent and the nudge would stall unsubmitted")
+	}
 }
 
 // TestNudgeSessionComposesEscapeThenSubmitSequence pins the PROVENANCE of the


### PR DESCRIPTION
## Problem

A codex worker that receives a nudge can end up with the text **drafted in its composer and no turn started**. The submit `Enter` is lost — raced against the paste, or against a detached-pane wake — and the session then idles indefinitely while every liveness surface reads green. Only an external re-nudge unsticks it, at which point the agent does the work correctly.

This is the same ga-bwm *"drafted but not submitted"* failure `NudgeSession` already guards against with `submitEnterAndConfirm`. The guard is gated on `submitVerifyEligible`, which was hardcoded to the Claude family:

```go
func (t *Tmux) submitVerifyEligible(target string) bool {
	if provider := t.providerEnv(target); provider != "" {
		return sessionlog.ProviderFamily(provider) == "claude"
	}
	return t.targetLooksLikeProvider(target, "claude")
}
```

so codex kept best-effort single delivery and inherited the stall.

Observed in a live Gas City rig: codex pool workers spawned on sling, primed successfully, then sat idle for ~11 and ~35 minutes without picking up their assigned bead. A manual `gc session nudge` unstuck them and they completed cleanly. Claude workers slung seconds later went straight to work.

## Why codex is safe to include

The confirmation signal is **already implemented** for codex — `paneContainsBusyIndicator` matches `"esc to interrupt"`, and its own doc comment says so ("older Claude Code and Codex show `esc to interrupt`"). Only the eligibility gate was withholding it.

Verified live against **codex-cli 0.147.0** in a tmux pane:

- submitted turn, 1s after Enter: `• Working (1s • esc to interrupt)` → matches, confirm succeeds, no extra Enter
- drafted-but-unsubmitted (text delivered, Enter withheld): no such footer → the exact state the loop is meant to detect and re-Enter

Both directions discriminate cleanly, which is what makes re-sending safe.

## Change

Replace the hardcoded claude check with a `providersWithVerifiableBusyIndicator` list, mirroring the existing `providersSkippingEscapeBeforeEnter` shape, and add `codex`. Providers absent from the list are untouched and keep best-effort single delivery, so this cannot regress them.

## Blast radius

The confirm loop is bounded: `submitEnterMaxSends = 3`, ~2s worst case, and it re-checks `busy()` before every re-send — a turn that *did* submit never receives a second Enter. The only behavior change for codex is that a **lost** Enter is now retried instead of silently stranding the session.

## Tests

- `TestProviderHasVerifiableBusyIndicator` pins the eligibility set (including that `codex-max` resolves through the family and that unlisted providers stay ineligible).
- `TestPaneContainsBusyIndicatorMatchesCodexWorkingFooter` pins the live-captured codex footer in both directions, so submit confirmation for codex stays sound only while the indicator keeps matching.
- Full `./internal/runtime/tmux` suite green (330 tests), `golangci-lint` clean.

## Relation to #4706

#4706 proposes a declarative per-provider `nudge_submit_keys` sequence, motivated by the k8s carrier where the codex TUI buffers the send-keys burst as a paste and never submits at all. That is the larger, provider-manifest-shaped fix. This PR is the narrow, already-supported half: on the local tmux carrier a single-line and a multi-line `send-keys -l` + `Enter` **do** submit for codex 0.147.0 (verified), so the residual failure there is a *lost* Enter, not a wrong key sequence — and detecting that is already free. Happy to fold this into #4706 instead if you'd prefer one change.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5192 — extends the existing lost-Enter submit confirmation (previously Claude-family only) to codex workers, so a nudge whose Enter is dropped is re-sent instead of leaving the text drafted and the session idle; it does not clear the input line before typing, so the fragment-concatenation mode described in that issue, and providers outside the verified-indicator list, are untouched
- Related to #5954 — extends nudge submit confirmation to the codex provider family through the same submitVerifyEligible / paneContainsBusyIndicator / submitEnterAndConfirm path that the filed issue reports as defective; it does not change the busy-indicator matching itself, so the Claude Code 2.1.x spinner blind spot, the already-busy false confirm, the discarded WakePane resize error, and the missing copy-mode cancel all remain open — and codex now inherits the same confirm machinery

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->