### PR TITLE
fix(supervisor): clear initStatus when an init failure is recorded

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1916,7 +1916,22 @@ func reconcileCities(
 			})
 		}
 
-		// recordInitFailure logs the error and records backoff state.
+		// recordInitFailure logs the error, ends the attempt, and records
+		// backoff state.
+		//
+		// Clearing initStatus is part of recording the failure, not a courtesy
+		// each branch performs for itself. reconcileCities selects cities to
+		// start by skipping any with a live initStatus entry, and it consults
+		// that skip BEFORE the backoff and its config-mtime reset. So a branch
+		// that records a failure but leaves the entry behind wedges the city out
+		// of the loop for the life of the process: it logs "next retry in 10s"
+		// and is then never selected again, and neither editing city.toml nor
+		// `gc start` recovers it — only a supervisor restart does.
+		//
+		// Three of the branches below used to clear it and three did not, which
+		// is what the split produced. Every call site either has already cleared
+		// it (the pre-runtime branches, and publishManagedCity for everything
+		// after it) or needs it cleared, so the delete belongs here, once.
 		recordInitFailure := func(cityName, msg string) {
 			fmt.Fprintln(stderr, logutil.FormatFatalLine(msg))                              //nolint:errcheck // best-effort stderr
 			fmt.Fprintf(stderr, "gc supervisor: city '%s': %s (skipping)\n", cityName, msg) //nolint:errcheck
@@ -1926,10 +1941,11 @@ func reconcileCities(
 			}
 			cr.BatchUpdate(func(
 				_ map[string]*managedCity,
-				_ map[string]cityInitProgress,
+				initStatus map[string]cityInitProgress,
 				initFailures map[string]*initFailRecord,
 				_ map[string]*panicRecord,
 			) {
+				delete(initStatus, path)
 				ifrec := initFailures[path]
 				if ifrec == nil {
 					ifrec = &initFailRecord{}
@@ -1995,14 +2011,6 @@ func reconcileCities(
 				initStatus[path] = cityInitProgress{name: cityName, status: status}
 			})
 		}); err != nil {
-			cr.BatchUpdate(func(
-				_ map[string]*managedCity,
-				initStatus map[string]cityInitProgress,
-				_ map[string]*initFailRecord,
-				_ map[string]*panicRecord,
-			) {
-				delete(initStatus, path)
-			})
 			emitPendingCityCreateFailure(cr, path, cityName, "city_init_failed", err, stderr)
 			recordInitFailure(cityName, fmt.Sprintf("init: %v", err))
 			continue
@@ -2044,14 +2052,6 @@ func reconcileCities(
 			return nil
 		})
 		if spErr != nil {
-			cr.BatchUpdate(func(
-				_ map[string]*managedCity,
-				initStatus map[string]cityInitProgress,
-				_ map[string]*initFailRecord,
-				_ map[string]*panicRecord,
-			) {
-				delete(initStatus, path)
-			})
 			emitPendingCityCreateFailure(cr, path, cityName, "session_provider_failed", spErr, stderr)
 			recordInitFailure(cityName, fmt.Sprintf("session provider: %v", spErr))
 			continue
@@ -2061,14 +2061,6 @@ func reconcileCities(
 		if err := runPostPrepareStep("checking_agent_images", func() error {
 			return checkAgentImages(sp, cfg.Agents, stderr)
 		}); err != nil {
-			cr.BatchUpdate(func(
-				_ map[string]*managedCity,
-				initStatus map[string]cityInitProgress,
-				_ map[string]*initFailRecord,
-				_ map[string]*panicRecord,
-			) {
-				delete(initStatus, path)
-			})
 			emitPendingCityCreateFailure(cr, path, cityName, "agent_image_check_failed", err, stderr)
 			recordInitFailure(cityName, err.Error())
 			continue

--- a/cmd/gc/supervisor_init_retry_test.go
+++ b/cmd/gc/supervisor_init_retry_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+// unservableStorageCityTOML is a city whose [storage.classes] describe a partial
+// split. storageSplitShapeOf classifies it storageSplitUnsupported, so
+// storageBootGate refuses before it constructs a registry, resolves a plan or
+// reads a byte of a binding root — which makes newCityRuntime fail
+// deterministically, with no filesystem state and no store handles to clean up.
+//
+// That is the real production failure shape: the city_runtime_failed branch is
+// reachable ONLY through storageBootGate, and a stranded-bead boot verdict is
+// what took maintainer-city down this branch.
+const unservableStorageCityTOML = `[workspace]
+name = "wedged-city"
+
+[session]
+provider = "fake"
+
+[daemon]
+shutdown_timeout = "100ms"
+
+[storage.classes]
+work = "work"
+graph = "infra"
+sessions = "work"
+messaging = "work"
+orders = "work"
+nudges = "work"
+
+[storage.bindings.infra]
+provider = "sqlite-beads"
+path = ".gc/store"
+`
+
+// newWedgedInitCity registers a city that fails inside newCityRuntime and
+// returns its path.
+func newWedgedInitCity(t *testing.T) (*supervisor.Registry, string) {
+	t.Helper()
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := shortSocketTempDir(t, "gc-wedged-city-")
+	cleanupManagedDoltTestCity(t, cityPath)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(unservableStorageCityTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := writeSpyScript(t, filepath.Join(t.TempDir(), "ops.log"))
+	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "wedged-city"); err != nil {
+		t.Fatal(err)
+	}
+	return reg, cityPath
+}
+
+// initStatusEntry reports whether the registry still lists path as initializing.
+func initStatusEntry(cr *cityRegistry, path string) (cityInitProgress, bool) {
+	var (
+		progress cityInitProgress
+		ok       bool
+	)
+	cr.ReadCallback(func(
+		_ map[string]*managedCity,
+		initStatus map[string]cityInitProgress,
+		_ map[string]*initFailRecord,
+		_ map[string]*panicRecord,
+	) {
+		progress, ok = initStatus[path]
+	})
+	return progress, ok
+}
+
+func initFailureCount(cr *cityRegistry, path string) int {
+	var count int
+	cr.ReadCallback(func(
+		_ map[string]*managedCity,
+		_ map[string]cityInitProgress,
+		initFailures map[string]*initFailRecord,
+		_ map[string]*panicRecord,
+	) {
+		if rec := initFailures[path]; rec != nil {
+			count = rec.count
+		}
+	})
+	return count
+}
+
+// TestReconcileCitiesClearsInitStatusOnRuntimeFailure pins the invariant the
+// retry path depends on: recording an init failure ENDS the attempt, so the city
+// must no longer be listed as initializing.
+//
+// reconcileCities selects cities to start by skipping any with a live initStatus
+// entry. A failure branch that records the backoff but leaves the entry behind
+// wedges the city out of the loop permanently: it logs "next retry in 10s" and
+// then never retries, because it is never selected again.
+func TestReconcileCitiesClearsInitStatusOnRuntimeFailure(t *testing.T) {
+	reg, cityPath := newWedgedInitCity(t)
+	cr := newCityRegistry()
+
+	var stdout, stderr bytes.Buffer
+	reconcileCities(reg, cr, supervisor.PublicationConfig{}, &stdout, &stderr)
+
+	key := canonicalTestPath(cityPath)
+	if count := initFailureCount(cr, key); count != 1 {
+		t.Fatalf("init failure count = %d, want 1; the city must actually have failed inside newCityRuntime for this test to mean anything (stderr: %s)", count, stderr.String())
+	}
+	if progress, ok := initStatusEntry(cr, key); ok {
+		t.Fatalf("initStatus[%s] = %+v after an init failure, want absent; the city is wedged out of the reconcile loop and its backoff/retry can never run", key, progress)
+	}
+}
+
+// elapseInitBackoff rewinds a city's recorded init backoff into the past, which
+// is what the supervisor's own 10s timer does in production.
+func elapseInitBackoff(cr *cityRegistry, path string) {
+	cr.BatchUpdate(func(
+		_ map[string]*managedCity,
+		_ map[string]cityInitProgress,
+		initFailures map[string]*initFailRecord,
+		_ map[string]*panicRecord,
+	) {
+		if rec := initFailures[path]; rec != nil {
+			rec.backoff = time.Now().Add(-time.Second)
+		}
+	})
+}
+
+// TestReconcileCitiesRetriesAfterInitBackoffElapses pins the documented
+// behavior: "init failure #1, next retry in 10s" must be followed by an actual
+// retry once those 10s pass. With the initStatus entry leaked the city is never
+// re-selected, so the promised retry never happens and the count stays at 1 for
+// the life of the supervisor process.
+func TestReconcileCitiesRetriesAfterInitBackoffElapses(t *testing.T) {
+	reg, cityPath := newWedgedInitCity(t)
+	cr := newCityRegistry()
+	key := canonicalTestPath(cityPath)
+
+	var stdout, stderr bytes.Buffer
+	reconcileCities(reg, cr, supervisor.PublicationConfig{}, &stdout, &stderr)
+	if count := initFailureCount(cr, key); count != 1 {
+		t.Fatalf("first pass: init failure count = %d, want 1 (stderr: %s)", count, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "init failure #1, next retry in") {
+		t.Fatalf("first pass stderr = %q, want the promised-retry line", stderr.String())
+	}
+
+	elapseInitBackoff(cr, key)
+	stderr.Reset()
+	reconcileCities(reg, cr, supervisor.PublicationConfig{}, &stdout, &stderr)
+
+	if count := initFailureCount(cr, key); count != 2 {
+		t.Fatalf("after the backoff elapsed: init failure count = %d, want 2; the promised retry never ran because the leaked initStatus entry skips the city before the backoff is ever consulted (stderr: %s)", count, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "init failure #2") {
+		t.Fatalf("second reconcile stderr = %q, want an \"init failure #2\" line proving the documented backoff/retry actually ran", stderr.String())
+	}
+}
+
+// TestReconcileCitiesRetriesAfterConfigEdit is the operator-observed symptom: a
+// city wedged by a leaked initStatus entry could not be recovered by editing
+// city.toml, because the initializing-skip is consulted BEFORE the config-mtime
+// backoff reset — so the city never re-entered the start loop at all, and only a
+// supervisor restart cleared it.
+//
+// A config edit deliberately RESETS the failure record (the user may have fixed
+// the config), so the retry's own failure is recorded fresh as #1. The proof of
+// a retry is therefore that the pass attempted the city at all.
+func TestReconcileCitiesRetriesAfterConfigEdit(t *testing.T) {
+	reg, cityPath := newWedgedInitCity(t)
+	cr := newCityRegistry()
+	key := canonicalTestPath(cityPath)
+
+	var stdout, stderr bytes.Buffer
+	reconcileCities(reg, cr, supervisor.PublicationConfig{}, &stdout, &stderr)
+	if count := initFailureCount(cr, key); count != 1 {
+		t.Fatalf("first pass: init failure count = %d, want 1 (stderr: %s)", count, stderr.String())
+	}
+
+	// The operator's fix: edit city.toml. A newer mtime resets the backoff, so
+	// the very next reconcile must attempt the city again.
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(filepath.Join(cityPath, "city.toml"), future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr.Reset()
+	reconcileCities(reg, cr, supervisor.PublicationConfig{}, &stdout, &stderr)
+
+	if !strings.Contains(stderr.String(), "init failure #") {
+		t.Fatalf("after editing city.toml the reconcile pass never attempted the city (stderr: %q); editing city.toml resets the backoff, but the leaked initStatus entry skips the city before the backoff is ever consulted, so only a supervisor restart recovers it", stderr.String())
+	}
+}


### PR DESCRIPTION
## Problem

**A city whose initialization fails after its runtime is built never retries.** It logs `init failure #1, next retry in 10s` and is then skipped forever.

`reconcileCities` picks cities to start by skipping any with a live `initStatus` entry:

```go
if _, initializing := initStatus[path]; initializing {
    continue
}
```

Three of the six failure branches in the start loop clear that entry; three do not — `city_runtime_failed`, `controller_state_failed`, and `pool_on_boot_failed`. After any of those, the city keeps an `initStatus` entry for the life of the supervisor process and is never selected again, so the backoff it just recorded can never be consulted.

The skip is also evaluated **before** the config-mtime backoff reset, which is why the obvious operator remedy does nothing: editing `city.toml` resets the backoff, but the city never reaches that code. `gc start` does not help either.

Measured tonight: maintainer-city was wedged out of the reconcile loop for **48 minutes**. Only `systemctl restart` cleared it.

The reachable branch is `city_runtime_failed`, and it is reachable exactly one way — `newCityRuntime`'s only error return is `storageBootGate`. A boot verdict that refuses (for example a stranded-bead convergence failure) therefore both stops the city *and* removes its ability to retry.

## Fix

Clearing `initStatus` becomes part of recording the failure, in `recordInitFailure`.

Every call site either already cleared it — the pre-runtime branches, and `publishManagedCity` for everything after it — or needs it cleared. There is no site that wants the entry to survive a recorded failure, so this is one fact with one owner rather than a courtesy each branch performs for itself. The three now-redundant `BatchUpdate` blocks are removed with it: net **18 insertions, 26 deletions**.

`emitPendingCityCreateFailure` does not read `initStatus`, so moving the delete after it changes nothing observable.

## Tests

`cmd/gc/supervisor_init_retry_test.go` drives the real `reconcileCities` against a registered city whose `[storage.classes]` describe a partial split. `storageSplitShapeOf` classifies that `storageSplitUnsupported`, so `storageBootGate` refuses before it constructs a registry, resolves a plan or reads a byte of a binding root — a deterministic `newCityRuntime` failure with no filesystem state to clean up, down the same branch production took.

| Test | Red-before |
|---|---|
| `TestReconcileCitiesClearsInitStatusOnRuntimeFailure` | `initStatus[…/gc-wedged-city-…] = {name:wedged-city status:building_city_runtime} after an init failure, want absent; the city is wedged out of the reconcile loop and its backoff/retry can never run` |
| `TestReconcileCitiesRetriesAfterInitBackoffElapses` | `after the backoff elapsed: init failure count = 1, want 2; the promised retry never ran because the leaked initStatus entry skips the city before the backoff is ever consulted (stderr: )` |
| `TestReconcileCitiesRetriesAfterConfigEdit` | `after editing city.toml the reconcile pass never attempted the city (stderr: ""); editing city.toml resets the backoff, but the leaked initStatus entry skips the city before the backoff is ever consulted, so only a supervisor restart recovers it` |

The empty `stderr` in rows 2 and 3 is the finding stated precisely: the second reconcile pass produced no output at all, because the city was never attempted.

Row 3 is the operator-observed symptom. Note that a config edit deliberately *resets* the failure record (the user may have fixed the config), so the retry's own failure is recorded fresh as `#1` — the proof of a retry is that the pass attempted the city at all, not that the count grew.

## Gates

- `go build ./...` clean · `go vet ./cmd/gc` clean · `gofmt` clean
- `go test ./cmd/gc -count=1 -timeout 40m` — **ok, 813s**
- `golangci-lint` 2.10.1 on `./cmd/gc/...` — **0 issues**

## Scope

Deliberately narrow. It does not touch the boot verdict, the backoff policy, or what makes `newCityRuntime` fail — only the leak that makes the recorded backoff unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)