### PR TITLE
fix(beads): release claims through bd's CAS verb, not hand-built SQL

### DIFF
--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2435,7 +2435,14 @@ prefix = "fe"
 	}
 	fakeBin := t.TempDir()
 	sqlLog := filepath.Join(fakeBin, "sql.log")
+	// bd 1.0.4 — the contract-tested minimum (deps.env BD_PREV_VERSION) — has no
+	// conditional-release flags and rejects them the way its flag parser does,
+	// which is what latches the store onto the raw-SQL path this test pins.
 	fakeBD := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"update\" ]; then\n" +
+		"  printf 'unknown flag: --if-assignee\\n' >&2\n" +
+		"  exit 1\n" +
+		"fi\n" +
 		"if [ \"$1\" = \"sql\" ] && [ \"$2\" = \"--json\" ]; then\n" +
 		"  printf '%s\\n' \"$3\" > " + strconv.Quote(sqlLog) + "\n" +
 		"  printf '{\"rows_affected\":1,\"schema_version\":1}\\n'\n" +
@@ -2476,6 +2483,82 @@ prefix = "fe"
 	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP WHERE id = 'fe-abc' AND status = 'in_progress' AND assignee = 'worker-1'"
 	if strings.TrimSpace(string(query)) != wantQuery {
 		t.Fatalf("SQL query = %q, want %q", strings.TrimSpace(string(query)), wantQuery)
+	}
+}
+
+// TestDoBdReleaseIfCurrentUsesNativeVerbAndReadsExit13 is the CLI twin of the
+// store-level conversion: on a bd that HAS the conditional-release flags, the
+// command must issue the native verb (never SQL) and must read bd's exit 13 as
+// an authoritative "not released", printing skipped and exiting 0 — not as a
+// command failure.
+func TestDoBdReleaseIfCurrentUsesNativeVerbAndReadsExit13(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	origCityFlag, origRigFlag := cityFlag, rigFlag
+	defer func() { cityFlag, rigFlag = origCityFlag, origRigFlag }()
+	cityFlag, rigFlag = "", ""
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir rig .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+
+	fakeBin := t.TempDir()
+	argvLog := filepath.Join(fakeBin, "argv.log")
+	// A capable bd: the verb is understood, and the precondition miss is
+	// reported the way bd reports it — exit 13, nothing written.
+	fakeBD := "#!/bin/sh\n" +
+		"printf ' %s' \"$@\" >> " + strconv.Quote(argvLog) + "\n" +
+		"if [ \"$1\" = \"update\" ]; then\n" +
+		"  printf 'assignee mismatch\\n' >&2\n" +
+		"  exit 13\n" +
+		"fi\n" +
+		"printf 'unexpected bd args:' >&2\n" +
+		"printf ' %s' \"$@\" >&2\n" +
+		"exit 2\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "bd"), []byte(fakeBD), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setCwd(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_BEADS_FORCE_FALLBACK", "1")
+
+	target := execStoreTarget{ScopeRoot: rigDir, ScopeKind: "rig", Prefix: "fe"}
+	var stdout, stderr bytes.Buffer
+	if got := doBdReleaseIfCurrent(cityDir, nil, target, "fe-abc", "worker-1", &stdout, &stderr); got != 0 {
+		t.Fatalf("doBdReleaseIfCurrent = %d, want 0 (exit 13 is a verdict, not a failure); stderr=%q", got, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "skipped" {
+		t.Fatalf("output = %q, want skipped", stdout.String())
+	}
+	argv, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	for _, want := range []string{"update fe-abc", "--if-assignee worker-1", "--if-status in_progress", "--status open"} {
+		if !strings.Contains(string(argv), want) {
+			t.Errorf("bd argv %q does not contain %q", string(argv), want)
+		}
+	}
+	if strings.Contains(string(argv), "UPDATE issues SET") {
+		t.Fatalf("a capable bd still received hand-built SQL: %q", string(argv))
 	}
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2562,6 +2562,80 @@ prefix = "fe"
 	}
 }
 
+// TestDoBdReleaseIfCurrentRefusesAFuzzyIDCollision covers the one `gc bd` write
+// that never reaches the pre-flight exact-ID guard: release-if-current is
+// dispatched before that block and bdMutationWriteIDs does not recognize it, so
+// the store-level guard is the only thing standing between an operator's
+// abbreviated id and bd's substring resolver. Without it the command prints
+// "released", exits 0, and revokes a live claim on a bead nobody named (gcy-g4o:
+// "gcy-dv7" → "gcy-wisp-dv78").
+func TestDoBdReleaseIfCurrentRefusesAFuzzyIDCollision(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	origCityFlag, origRigFlag := cityFlag, rigFlag
+	defer func() { cityFlag, rigFlag = origCityFlag, origRigFlag }()
+	cityFlag, rigFlag = "", ""
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir rig .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+
+	fakeBin := t.TempDir()
+	argvLog := filepath.Join(fakeBin, "argv.log")
+	// A capable bd whose resolver prefix-matches "fe-abc" onto the wisp
+	// "fe-wisp-abc9" — and which would happily perform the write.
+	fakeBD := "#!/bin/sh\n" +
+		"printf ' %s' \"$@\" >> " + strconv.Quote(argvLog) + "\n" +
+		"if [ \"$1\" = \"show\" ]; then\n" +
+		"  printf '[{\"id\":\"fe-wisp-abc9\",\"status\":\"in_progress\",\"assignee\":\"worker-1\"}]\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "bd"), []byte(fakeBD), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setCwd(t, cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_BEADS_FORCE_FALLBACK", "1")
+
+	target := execStoreTarget{ScopeRoot: rigDir, ScopeKind: "rig", Prefix: "fe"}
+	var stdout, stderr bytes.Buffer
+	if got := doBdReleaseIfCurrent(cityDir, nil, target, "fe-abc", "worker-1", &stdout, &stderr); got != 1 {
+		t.Fatalf("doBdReleaseIfCurrent = %d, want 1 (a substring collision must not be reported as a release); stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("output = %q, want nothing on stdout", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "fe-wisp-abc9") {
+		t.Fatalf("stderr = %q, want the bead bd actually resolved", stderr.String())
+	}
+	argv, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	if strings.Contains(string(argv), "--if-assignee") {
+		t.Fatalf("the release still reached bd for a colliding id: %q", string(argv))
+	}
+}
+
 // TestGcBdPassthroughResolvesBdBinary pins the binary the `gc bd`
 // passthrough execs. A city whose scope carries a complete storage binding
 // runs the bd its workspace PATH pins — an ambient bd that cannot speak the

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -309,6 +309,12 @@ type BdStore struct {
 	readyProjectionChecked bool
 	readyProjectionEnabled bool
 
+	// condReleaseLatchedUnsupported records that this bd rejected the
+	// conditional-release flags, pinning ReleaseIfCurrent to the raw-SQL
+	// fallback for the rest of the process (bdstore_conditional_release.go).
+	condReleaseMu                 sync.Mutex
+	condReleaseLatchedUnsupported bool
+
 	// Conditional-write (ConditionalWriter) capability state, populated lazily on
 	// the first conditional write (bdstore_conditional.go). condWriteProbed/
 	// condWriteCapable memoize the four-verb --if-revision probe; condWriteLatched
@@ -1179,19 +1185,29 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 // ReleaseIfCurrent clears an in-progress assignment only when the bead still
 // has the expected assignee.
 //
-// SEAM (bd conditional-release verb): today this rides raw `bd sql`. The
-// sqlite backend refuses raw DB access, so that rejection — and embedded dolt
-// WITHOUT a configured dolt directory — surface ErrConditionalReleaseUnsupported
-// (the latter via the releaseIfCurrentViaEmbeddedDoltSQL fallback). Embedded
-// dolt WITH a configured directory instead services the CAS directly through
-// that fallback, returning real rows-affected rather than reporting
-// unsupported. When bd ships its native issueops CAS release verb, consume it
-// HERE as the first attempt:
-// probe by invoking the verb and fall back to this `bd sql` path when bd
-// reports the command unknown (older pinned bd). Callers already treat
-// ErrConditionalReleaseUnsupported as "take a conditional recheck fallback"
-// (see cmd/gc releasePoolAssignmentIfCurrent), so no caller changes are needed.
+// It prefers bd's native conditional-release verb, which evaluates both
+// preconditions server-side and reports a failed one as exit 13 having written
+// nothing (bdstore_conditional_release.go). The raw `bd sql` path below is the
+// fallback for bd 1.0.4, the contract-tested minimum, which predates the flags:
+// there the sqlite backend refuses raw DB access, so that rejection — and
+// embedded dolt WITHOUT a configured dolt directory — surface
+// ErrConditionalReleaseUnsupported (the latter via the
+// releaseIfCurrentViaEmbeddedDoltSQL fallback), while embedded dolt WITH a
+// configured directory services the CAS through that fallback directly. Callers
+// treat ErrConditionalReleaseUnsupported as "take a conditional recheck
+// fallback" (see cmd/gc releasePoolAssignmentIfCurrent), which is why the verb
+// path never returns it for a precondition miss.
 func (s *BdStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	if !s.conditionalReleaseUnsupported() {
+		released, handled, err := s.releaseIfCurrentViaBdVerb(id, expectedAssignee)
+		if handled {
+			if err != nil {
+				return false, fmt.Errorf("bd release-if-current: %w", err)
+			}
+			return released, nil
+		}
+		s.latchConditionalReleaseUnsupported()
+	}
 	query := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
 		" WHERE id = " + bdSQLStringLiteral(id) +
 		" AND status = 'in_progress'" +

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1197,6 +1197,14 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 // treat ErrConditionalReleaseUnsupported as "take a conditional recheck
 // fallback" (see cmd/gc releasePoolAssignmentIfCurrent), which is why the verb
 // path never returns it for a precondition miss.
+//
+// id must be a canonical full bead ID, the same requirement Update documents.
+// bd's resolver prefix/substring-matches an id with no exact hit, and the
+// preconditions are then evaluated against whatever it resolved, so the verb
+// path verifies the id names exactly one existing bead before it mutates
+// anything and returns an error wrapping ErrIDCollision when bd resolved a
+// different one (gcy-g4o). The raw-SQL fallback matches id literally and needs
+// no such check.
 func (s *BdStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
 	if !s.conditionalReleaseUnsupported() {
 		released, handled, err := s.releaseIfCurrentViaBdVerb(id, expectedAssignee)

--- a/internal/beads/bdstore_conditional.go
+++ b/internal/beads/bdstore_conditional.go
@@ -334,19 +334,7 @@ func isBdConditionalPrecondition(body bdConditionalErrorBody, msg string) bool {
 // "contains if-revision" check would latch a CAPABLE bd the moment gascity passed
 // some unrelated unknown flag — the exact silent-degrade the latch must avoid.
 func isBdUnknownIfRevisionFlag(msg string) bool {
-	lower := strings.ToLower(msg)
-	for _, anchor := range []string{
-		"unknown flag: --if-revision",
-		"unknown flag: -if-revision",
-		"unknown flag '--if-revision'",
-		"flag provided but not defined: -if-revision",
-		"flag provided but not defined: --if-revision",
-	} {
-		if strings.Contains(lower, anchor) {
-			return true
-		}
-	}
-	return false
+	return isBdUnknownFlagError(msg, "--if-revision")
 }
 
 // conditionalRawDetail returns a bounded forensic snapshot of a failed

--- a/internal/beads/bdstore_conditional_release.go
+++ b/internal/beads/bdstore_conditional_release.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -60,12 +61,16 @@ func (s *BdStore) latchConditionalReleaseUnsupported() {
 }
 
 // releaseIfCurrentViaBdVerb performs the conditional release through bd's native
-// verb.
+// verb, after checking that id names exactly the bead bd resolves
+// (releaseIDCollision).
 //
 // handled=false means this bd does not support the verb and the caller must take
 // the raw-SQL fallback; it is the ONLY value that causes a fallback, so a real
 // backend failure can never be mistaken for an old bd.
 func (s *BdStore) releaseIfCurrentViaBdVerb(id, expectedAssignee string) (released, handled bool, err error) {
+	if collision := s.releaseIDCollision(id); collision != nil {
+		return false, true, collision
+	}
 	// --assignee "" is how bd clears an assignment; the paired --status open
 	// completes the same swap the SQL statement performed, and both --if-* flags
 	// carry the preconditions bd now evaluates server-side.
@@ -88,7 +93,7 @@ func (s *BdStore) releaseIfCurrentViaBdVerb(id, expectedAssignee string) (releas
 	if isBdUnknownFlagError(detail, "--if-assignee") || isBdUnknownFlagError(detail, "--if-status") {
 		return false, false, nil
 	}
-	if isBdNotFound(runErr) {
+	if isBdIssueNotFound(runErr) {
 		// A bead this store cannot resolve can hold no assignment, which is the
 		// same verdict the SQL statement reached by matching zero rows. Kept so
 		// the observable contract does not change with the backend verb.
@@ -97,13 +102,92 @@ func (s *BdStore) releaseIfCurrentViaBdVerb(id, expectedAssignee string) (releas
 	return false, true, runErr
 }
 
+// releaseIDCollision reports bd having resolved id to a DIFFERENT bead.
+//
+// The statement this verb replaced was `WHERE id = <literal>` — exact by
+// construction. bd's resolver is not: with no exact hit it falls back to
+// prefix/substring matching, so `bd update tst-d6 --if-assignee worker-1 …`
+// mutates tst-d6e and reports success. The CAS preconditions are no defense,
+// because bd evaluates them against the bead it resolved rather than the one the
+// caller named, and a worker usually holds several beads, so a sibling satisfies
+// them. That is the incident shape gcy-g4o records ("gcy-dv7" → "gcy-wisp-dv78"),
+// and gascity is systematically exposed to it because formula steps run as
+// <prefix>-wisp-<suffix> wisps.
+//
+// Get already enforces the exact match and reports ErrIDCollision, so the guard
+// costs one read. Only a confirmed collision blocks the release: a plain
+// ErrNotFound falls through (the bead may be invisible to the read seam, and the
+// verb reaches the same "not held" verdict anyway), and a failed read falls
+// through rather than converting a broken read into a refused write — the
+// fail-open tradeoff cmd_bd.go's pre-flight guard documents.
+//
+// Only the verb path needs this; the raw-SQL fallback still matches id
+// literally.
+func (s *BdStore) releaseIDCollision(id string) error {
+	if _, err := s.Get(id); errors.Is(err, ErrIDCollision) {
+		return fmt.Errorf("refusing to release %q: %w", id, err)
+	}
+	return nil
+}
+
+// bdIssueNotFoundPhrases are bd's wordings for "that id resolves to no issue".
+// Measured against bd: `bd update tst-nosuchbead --status open` exits 1 with
+// `Error resolving tst-nosuchbead: no issue found matching "tst-nosuchbead"`,
+// and its --json envelope carries the plural form.
+var bdIssueNotFoundPhrases = []string{
+	"no issue found",
+	"no issues found",
+	"issue not found",
+}
+
+// isBdIssueNotFound reports whether err is bd refusing to resolve the bead id.
+//
+// It deliberately does not use the package-wide isBdNotFound, whose bare
+// "not found" substring is unanchored and matched against the whole runner
+// error. Everywhere else that helper produces an ERROR (ErrNotFound); here the
+// verdict is a CAS ANSWER — "nobody holds it, do not retry" — so a bd that fell
+// off PATH (`exec: "bd": executable file not found in $PATH`), a renamed
+// database (`database "fe" not found on Dolt server …`) or a gateway's
+// `404 page not found` would each be answered as a clean refusal instead of
+// surfacing as the infrastructure failure it is. The replaced SQL path reported
+// every one of those as an error, and a CAS verdict invented out of a dead
+// backend is the exact failure this conversion exists to remove.
+//
+// The gate is numeric first: bd exits 1 for an unresolvable id (13 is reserved
+// for a rejected precondition), so a spawn failure — which carries no process
+// exit status at all — can never reach this verdict.
+func isBdIssueNotFound(err error) bool {
+	if err == nil || bdExitCode(err) != 1 {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	for _, phrase := range bdIssueNotFoundPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// exitCoder is the process-status surface bdExitCode reads. *exec.ExitError —
+// what the runner actually wraps — satisfies it through its embedded
+// *os.ProcessState. Matching the method instead of the concrete type lets the
+// CAS classifier be driven from a unit test without spawning a process, which
+// the untagged test-resource ledger forbids (TESTING.md: "untagged subprocess
+// call/file totals cannot grow"). The assertion below is the link back to
+// reality: if bd's runner error ever stops carrying its exit status this way,
+// this file stops compiling.
+type exitCoder interface{ ExitCode() int }
+
+var _ exitCoder = (*exec.ExitError)(nil)
+
 // bdExitCode returns the process exit status carried by err, or -1 when err is
 // not a process failure. The runner wraps the *exec.ExitError with %w
 // (classifyBDExecResult), so the status survives to here.
 func bdExitCode(err error) int {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return exitErr.ExitCode()
+	var coder exitCoder
+	if errors.As(err, &coder) {
+		return coder.ExitCode()
 	}
 	return -1
 }

--- a/internal/beads/bdstore_conditional_release.go
+++ b/internal/beads/bdstore_conditional_release.go
@@ -1,0 +1,138 @@
+package beads
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// This file consumes bd's native conditional-release verb, which is what the
+// ReleaseIfCurrent SEAM was waiting for.
+//
+// The release is a compare-and-swap: clear an in-progress assignment only while
+// the bead still carries the expected assignee. It used to be assembled as raw
+// SQL — `UPDATE issues SET status='open', assignee='' WHERE id=… AND
+// status='in_progress' AND assignee=…` — and the verdict was read out of
+// rows_affected. That had three costs: the statement had to be built by
+// concatenating hand-escaped MySQL string literals, `bd sql` is rejected outright
+// in embedded mode (so the path needed a second implementation shelling directly
+// to `dolt sql`), and a CAS that matches zero rows is indistinguishable from one
+// that could not run.
+//
+// bd now expresses the same two preconditions natively:
+//
+//	bd update <id> --if-assignee <expected> --if-status in_progress \
+//	               --status open --assignee ""
+//
+// and — unlike every other bd failure, which is exit 1 with a message — reports
+// a failed precondition as its own exit status, 13, having written nothing. The
+// CAS verdict is therefore a NUMBER, not a parse of bd's prose. That is the
+// whole reason to prefer this verb: the load-bearing branch stops depending on
+// message text.
+//
+// bd 1.0.4 is the contract-tested minimum (deps.env BD_PREV_VERSION) and predates
+// the flags, so the raw-SQL path stays as the fallback and is selected by a
+// per-store latch the first time bd rejects the flag as unknown.
+
+// bdCASPreconditionExitCode is bd's dedicated exit status for a rejected
+// --if-assignee / --if-status precondition: nothing was written, and the verdict
+// is "the precondition no longer held", not "the command failed". Every other bd
+// failure, including an unresolvable id, is exit 1.
+const bdCASPreconditionExitCode = 13
+
+// conditionalReleaseUnsupported reports whether this store has already seen bd
+// reject the conditional-release flags. The latch is one-way: a bd that lacks
+// the flags cannot grow them inside one process lifetime, and re-probing on
+// every release would pay a failed subprocess per call.
+func (s *BdStore) conditionalReleaseUnsupported() bool {
+	s.condReleaseMu.Lock()
+	defer s.condReleaseMu.Unlock()
+	return s.condReleaseLatchedUnsupported
+}
+
+// latchConditionalReleaseUnsupported records that bd does not understand the
+// conditional-release flags, sending every later release straight to the SQL
+// fallback.
+func (s *BdStore) latchConditionalReleaseUnsupported() {
+	s.condReleaseMu.Lock()
+	defer s.condReleaseMu.Unlock()
+	s.condReleaseLatchedUnsupported = true
+}
+
+// releaseIfCurrentViaBdVerb performs the conditional release through bd's native
+// verb.
+//
+// handled=false means this bd does not support the verb and the caller must take
+// the raw-SQL fallback; it is the ONLY value that causes a fallback, so a real
+// backend failure can never be mistaken for an old bd.
+func (s *BdStore) releaseIfCurrentViaBdVerb(id, expectedAssignee string) (released, handled bool, err error) {
+	// --assignee "" is how bd clears an assignment; the paired --status open
+	// completes the same swap the SQL statement performed, and both --if-* flags
+	// carry the preconditions bd now evaluates server-side.
+	out, runErr := s.runBDTransientWriteOutput(
+		"update", id,
+		"--if-assignee", expectedAssignee,
+		"--if-status", "in_progress",
+		"--status", "open",
+		"--assignee", "",
+	)
+	if runErr == nil {
+		return true, true, nil
+	}
+	if bdExitCode(runErr) == bdCASPreconditionExitCode {
+		// The precondition no longer held. bd wrote nothing, and the caller must
+		// read this as an authoritative "someone else holds it", not an error.
+		return false, true, nil
+	}
+	detail := strings.TrimSpace(string(out)) + " " + runErr.Error()
+	if isBdUnknownFlagError(detail, "--if-assignee") || isBdUnknownFlagError(detail, "--if-status") {
+		return false, false, nil
+	}
+	if isBdNotFound(runErr) {
+		// A bead this store cannot resolve can hold no assignment, which is the
+		// same verdict the SQL statement reached by matching zero rows. Kept so
+		// the observable contract does not change with the backend verb.
+		return false, true, nil
+	}
+	return false, true, runErr
+}
+
+// bdExitCode returns the process exit status carried by err, or -1 when err is
+// not a process failure. The runner wraps the *exec.ExitError with %w
+// (classifyBDExecResult), so the status survives to here.
+func bdExitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// isBdUnknownFlagError matches the usage error bd's flag parser emits for a flag
+// this build does not have.
+//
+// It is ANCHORED to the flag name immediately following the parser's marker. A
+// cobra usage echo lists every flag in its help block on ANY flag error, so a
+// floating "contains --if-assignee" check would latch a CAPABLE bd the moment
+// gascity passed some unrelated bad flag — the exact silent degrade the latch
+// exists to avoid. isBdUnknownIfRevisionFlag applies the same rule to the
+// revision-CAS probe.
+func isBdUnknownFlagError(msg, flag string) bool {
+	flag = strings.ToLower(strings.TrimLeft(flag, "-"))
+	if flag == "" {
+		return false
+	}
+	lower := strings.ToLower(msg)
+	for _, anchor := range []string{
+		"unknown flag: --" + flag,
+		"unknown flag: -" + flag,
+		"unknown flag '--" + flag + "'",
+		"flag provided but not defined: -" + flag,
+		"flag provided but not defined: --" + flag,
+	} {
+		if strings.Contains(lower, anchor) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/beads/bdstore_conditional_release_integration_test.go
+++ b/internal/beads/bdstore_conditional_release_integration_test.go
@@ -23,7 +23,12 @@ import (
 // mismatch leg, loudly, instead of silently degrading gascity to "someone else
 // holds it" on every release.
 func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
-	store, _ := newConditionalIntegrationBdStore(t)
+	store, scope := newConditionalIntegrationBdStore(t)
+	if !bdParsesConditionalReleaseFlags(t, scope) {
+		t.Skip("installed bd does not advertise --if-assignee/--if-status (pre-beads#5364): " +
+			"the store latches to the raw-SQL fallback, which embedded mode rejects outright, " +
+			"so this row cannot exercise the verb at all. Move deps.env BD_VERSION past #5364 to run it.")
+	}
 
 	created, err := store.Create(beads.Bead{Title: "conditional release row", Type: "task"})
 	if err != nil {
@@ -52,11 +57,6 @@ func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 	t.Run("a wrong assignee writes nothing and is not an error", func(t *testing.T) {
 		released, err := store.ReleaseIfCurrent(created.ID, "worker-2")
 		if err != nil {
-			// An old bd (pre-#5364) has no flags and falls back to bd sql, which
-			// embedded mode rejects; that surfaces as unsupported, not a bug.
-			if isUnsupportedOnThisBd(err) {
-				t.Skipf("installed bd lacks the conditional-release flags and bd sql is embedded-rejected: %v", err)
-			}
 			t.Fatalf("ReleaseIfCurrent(wrong assignee): %v", err)
 		}
 		if released {
@@ -68,9 +68,6 @@ func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 	t.Run("the matching assignee releases", func(t *testing.T) {
 		released, err := store.ReleaseIfCurrent(created.ID, "worker-1")
 		if err != nil {
-			if isUnsupportedOnThisBd(err) {
-				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
-			}
 			t.Fatalf("ReleaseIfCurrent(matching assignee): %v", err)
 		}
 		if !released {
@@ -82,9 +79,6 @@ func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 	t.Run("a second release is a no-op, not an error", func(t *testing.T) {
 		released, err := store.ReleaseIfCurrent(created.ID, "worker-1")
 		if err != nil {
-			if isUnsupportedOnThisBd(err) {
-				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
-			}
 			t.Fatalf("ReleaseIfCurrent(already released): %v", err)
 		}
 		if released {
@@ -111,9 +105,6 @@ func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 		}
 		released, err := store.ReleaseIfCurrent(wisp.ID, "worker-1")
 		if err != nil {
-			if isUnsupportedOnThisBd(err) {
-				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
-			}
 			t.Fatalf("ReleaseIfCurrent(ephemeral): %v", err)
 		}
 		if !released {
@@ -131,24 +122,66 @@ func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 	t.Run("an unresolvable id is not held", func(t *testing.T) {
 		released, err := store.ReleaseIfCurrent("tst-nosuchbead", "worker-1")
 		if err != nil {
-			if isUnsupportedOnThisBd(err) {
-				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
-			}
 			t.Fatalf("ReleaseIfCurrent(missing id): %v", err)
 		}
 		if released {
 			t.Fatal("released a bead that does not exist")
 		}
 	})
+
+	// The statement this verb replaced matched `WHERE id = <literal>`. bd's
+	// resolver prefix-matches instead, and it evaluates the CAS preconditions
+	// against whatever it resolved — so an id one character short of a held bead
+	// releases that bead and reports success. This leg drives the real resolver.
+	t.Run("a non-exact id refuses instead of releasing a different bead", func(t *testing.T) {
+		held, err := store.Create(beads.Bead{Title: "collision target", Type: "task"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := store.Update(held.ID, beads.UpdateOpts{
+			Status:   strPtr("in_progress"),
+			Assignee: strPtr("worker-1"),
+		}); err != nil {
+			t.Fatalf("Update to in_progress: %v", err)
+		}
+		truncated := held.ID[:len(held.ID)-1]
+		if _, getErr := store.Get(truncated); !errors.Is(getErr, beads.ErrIDCollision) {
+			t.Skipf("bd did not prefix-resolve %q to another bead (Get: %v); the collision cell is not drivable here", truncated, getErr)
+		}
+
+		released, err := store.ReleaseIfCurrent(truncated, "worker-1")
+		if !errors.Is(err, beads.ErrIDCollision) {
+			t.Fatalf("ReleaseIfCurrent(%q) = released=%v err=%v, want a refusal wrapping ErrIDCollision", truncated, released, err)
+		}
+		if released {
+			t.Fatal("released = true for an id that resolved to a different bead")
+		}
+		got, err := store.Get(held.ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", held.ID, err)
+		}
+		if got.Status != "in_progress" || got.Assignee != "worker-1" {
+			t.Fatalf("a bead the caller never named was released: state = (%s, %q), want (in_progress, \"worker-1\")", got.Status, got.Assignee)
+		}
+	})
 }
 
-// isUnsupportedOnThisBd reports whether err is the old-bd path bottoming out:
-// no conditional-release flags AND no usable bd sql (embedded mode rejects it).
-// Only that combination is a legitimate skip.
-func isUnsupportedOnThisBd(err error) bool {
-	if err == nil {
-		return false
+// bdParsesConditionalReleaseFlags reports whether the installed bd advertises
+// both conditional-release preconditions.
+//
+// The signal is POSITIVE — the flags appear in `bd update --help`, the same
+// shape the production four-verb probe uses for --if-revision
+// (conditionalWritesCapable). Deciding from an error string instead cannot work
+// here: on a flagless bd the store latches to the raw-SQL path, embedded mode
+// rejects `bd sql`, and the dolt fallback then SUCCEEDS with released=false for
+// a wisp (it names the `issues` table), so no error ever surfaces to classify
+// and the row hard-fails instead of skipping.
+func bdParsesConditionalReleaseFlags(t *testing.T, scope string) bool {
+	t.Helper()
+	out, err := newConditionalIntegrationRunner(scope)(scope, "bd", "update", "--help")
+	if err != nil {
+		t.Skipf("bd update --help failed (bd broken?): %v", err)
 	}
-	return errors.Is(err, beads.ErrConditionalReleaseUnsupported) ||
-		strings.Contains(err.Error(), "not yet supported in embedded mode")
+	help := string(out)
+	return strings.Contains(help, "--if-assignee") && strings.Contains(help, "--if-status")
 }

--- a/internal/beads/bdstore_conditional_release_integration_test.go
+++ b/internal/beads/bdstore_conditional_release_integration_test.go
@@ -1,0 +1,154 @@
+//go:build integration
+
+package beads_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestBdStoreReleaseIfCurrentAgainstRealBd executes the conditional-release CAS
+// against a REAL bd binary in EMBEDDED mode — the mode where `bd sql` is
+// rejected outright ("'bd sql' is not yet supported in embedded mode"), so the
+// raw-SQL path this conversion replaces could only reach it by shelling
+// separately to `dolt sql`.
+//
+// It is the authoritative guard for the two facts the unit tests can only
+// assume about bd: that the flag spelling still exists, and that a rejected
+// precondition is exit 13 with nothing written. A bd that renames the flags
+// fails the capability leg here; a bd that changes the exit status fails the
+// mismatch leg, loudly, instead of silently degrading gascity to "someone else
+// holds it" on every release.
+func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
+	store, _ := newConditionalIntegrationBdStore(t)
+
+	created, err := store.Create(beads.Bead{Title: "conditional release row", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := store.Update(created.ID, beads.UpdateOpts{
+		Status:   strPtr("in_progress"),
+		Assignee: strPtr("worker-1"),
+	}); err != nil {
+		t.Fatalf("Update to in_progress: %v", err)
+	}
+
+	assertHeld := func(t *testing.T, wantStatus, wantAssignee string) {
+		t.Helper()
+		got, err := store.Get(created.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Status != wantStatus || got.Assignee != wantAssignee {
+			t.Fatalf("state = (%s, %q), want (%s, %q)", got.Status, got.Assignee, wantStatus, wantAssignee)
+		}
+	}
+	assertHeld(t, "in_progress", "worker-1")
+
+	t.Run("a wrong assignee writes nothing and is not an error", func(t *testing.T) {
+		released, err := store.ReleaseIfCurrent(created.ID, "worker-2")
+		if err != nil {
+			// An old bd (pre-#5364) has no flags and falls back to bd sql, which
+			// embedded mode rejects; that surfaces as unsupported, not a bug.
+			if isUnsupportedOnThisBd(err) {
+				t.Skipf("installed bd lacks the conditional-release flags and bd sql is embedded-rejected: %v", err)
+			}
+			t.Fatalf("ReleaseIfCurrent(wrong assignee): %v", err)
+		}
+		if released {
+			t.Fatal("released a bead held by someone else")
+		}
+		assertHeld(t, "in_progress", "worker-1")
+	})
+
+	t.Run("the matching assignee releases", func(t *testing.T) {
+		released, err := store.ReleaseIfCurrent(created.ID, "worker-1")
+		if err != nil {
+			if isUnsupportedOnThisBd(err) {
+				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
+			}
+			t.Fatalf("ReleaseIfCurrent(matching assignee): %v", err)
+		}
+		if !released {
+			t.Fatal("did not release a matching in-progress assignment")
+		}
+		assertHeld(t, "open", "")
+	})
+
+	t.Run("a second release is a no-op, not an error", func(t *testing.T) {
+		released, err := store.ReleaseIfCurrent(created.ID, "worker-1")
+		if err != nil {
+			if isUnsupportedOnThisBd(err) {
+				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
+			}
+			t.Fatalf("ReleaseIfCurrent(already released): %v", err)
+		}
+		if released {
+			t.Fatal("released an already-open bead")
+		}
+	})
+
+	// The replaced statement was `UPDATE issues SET ... WHERE id = ...`, so a
+	// bead in the EPHEMERAL tier lived in the `wisps` table and matched zero
+	// rows — the CAS reported "someone else holds it" for every wisp, forever.
+	// bd's verb resolves the id across both tiers, so the conditional release
+	// now covers ephemeral work. gascity runs formula steps as wisps, which is
+	// where that silent no-op landed.
+	t.Run("an ephemeral bead releases too", func(t *testing.T) {
+		wisp, err := store.Create(beads.Bead{Title: "ephemeral release row", Type: "task", Ephemeral: true})
+		if err != nil {
+			t.Fatalf("Create ephemeral: %v", err)
+		}
+		if err := store.Update(wisp.ID, beads.UpdateOpts{
+			Status:   strPtr("in_progress"),
+			Assignee: strPtr("worker-1"),
+		}); err != nil {
+			t.Fatalf("Update ephemeral to in_progress: %v", err)
+		}
+		released, err := store.ReleaseIfCurrent(wisp.ID, "worker-1")
+		if err != nil {
+			if isUnsupportedOnThisBd(err) {
+				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
+			}
+			t.Fatalf("ReleaseIfCurrent(ephemeral): %v", err)
+		}
+		if !released {
+			t.Fatal("did not release an ephemeral in-progress assignment")
+		}
+		got, err := store.Get(wisp.ID)
+		if err != nil {
+			t.Fatalf("Get ephemeral: %v", err)
+		}
+		if got.Status != "open" || got.Assignee != "" {
+			t.Fatalf("ephemeral state = (%s, %q), want (open, \"\")", got.Status, got.Assignee)
+		}
+	})
+
+	t.Run("an unresolvable id is not held", func(t *testing.T) {
+		released, err := store.ReleaseIfCurrent("tst-nosuchbead", "worker-1")
+		if err != nil {
+			if isUnsupportedOnThisBd(err) {
+				t.Skipf("installed bd lacks the conditional-release flags: %v", err)
+			}
+			t.Fatalf("ReleaseIfCurrent(missing id): %v", err)
+		}
+		if released {
+			t.Fatal("released a bead that does not exist")
+		}
+	})
+}
+
+// isUnsupportedOnThisBd reports whether err is the old-bd path bottoming out:
+// no conditional-release flags AND no usable bd sql (embedded mode rejects it).
+// Only that combination is a legitimate skip.
+func isUnsupportedOnThisBd(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, beads.ErrConditionalReleaseUnsupported) ||
+		strings.Contains(err.Error(), "not yet supported in embedded mode")
+}

--- a/internal/beads/bdstore_conditional_release_test.go
+++ b/internal/beads/bdstore_conditional_release_test.go
@@ -3,7 +3,6 @@ package beads_test
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -11,38 +10,59 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// exitErrorWithCode returns a real *exec.ExitError carrying code, which is what
-// the bd runner surfaces and what the CAS classifier reads. Fabricating the
-// process state directly is not possible, so a shell that exits with the code
-// stands in for bd.
+// bdExit stands in for the *exec.ExitError the bd runner wraps. bdExitCode
+// matches the ExitCode() method rather than the concrete type precisely so this
+// classifier can be driven without spawning a process: the untagged
+// test-resource ledger's invariant is that untagged subprocess call sites cannot
+// grow (TESTING.md), and a shell that exits with a code adds one.
+// bdstore_conditional_release.go asserts at compile time that the real
+// *exec.ExitError satisfies the same interface, so the substitution cannot drift
+// away from what production reads.
+type bdExit struct{ code int }
+
+func (e *bdExit) Error() string { return fmt.Sprintf("exit status %d", e.code) }
+
+func (e *bdExit) ExitCode() int { return e.code }
+
+// exitErrorWithCode returns the shape the production runner surfaces for a
+// failed bd process.
 func exitErrorWithCode(t *testing.T, code int) error {
 	t.Helper()
-	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("sh -c 'exit %d' did not produce an *exec.ExitError: %v", code, err)
-	}
-	if exitErr.ExitCode() != code {
-		t.Fatalf("fabricated exit code = %d, want %d", exitErr.ExitCode(), code)
-	}
-	// The production runner wraps the ExitError with %w and appends bd's stderr
-	// detail (classifyBDExecResult); wrap here so the classifier is exercised
-	// through the same shape it sees in production.
-	return fmt.Errorf("%w: bd said something", exitErr)
+	return exitErrorWithDetail(t, code, "bd said something")
 }
 
-// releaseVerbRunner records every bd invocation and answers the conditional
-// release verb with reply.
+// exitErrorWithDetail is exitErrorWithCode with bd's own stderr wording, which
+// classifyBDExecResult appends to the process error with %w.
+func exitErrorWithDetail(t *testing.T, code int, detail string) error {
+	t.Helper()
+	if code == 0 {
+		t.Fatal("exit 0 is not a process failure; the classifier never sees one")
+	}
+	return fmt.Errorf("%w: %s", &bdExit{code: code}, detail)
+}
+
+// releaseVerbRunner records every bd invocation, answers the exact-ID preflight
+// (`bd show --json <id>`) with the bead the caller named, and answers the
+// conditional release verb with reply.
 type releaseVerbRunner struct {
 	mu    sync.Mutex
 	calls [][]string
 	reply func(args []string) ([]byte, error)
+	// show overrides the preflight answer; the default resolves exactly, which
+	// is the non-colliding case every cell but the collision one wants.
+	show func(id string) ([]byte, error)
 }
 
 func (r *releaseVerbRunner) run(_, name string, args ...string) ([]byte, error) {
 	r.mu.Lock()
 	r.calls = append(r.calls, append([]string{name}, args...))
 	r.mu.Unlock()
+	if id, ok := showedID(args); ok {
+		if r.show != nil {
+			return r.show(id)
+		}
+		return []byte(`[{"id":"` + id + `"}]`), nil
+	}
 	if r.reply != nil {
 		return r.reply(args)
 	}
@@ -53,6 +73,26 @@ func (r *releaseVerbRunner) argv() [][]string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.calls
+}
+
+// releaseVerbArgv returns the recorded calls with the exact-ID preflight reads
+// dropped, so a cell can pin the mutation argv without restating the guard.
+func (r *releaseVerbRunner) releaseVerbArgv() [][]string {
+	var mutations [][]string
+	for _, call := range r.argv() {
+		if _, ok := showedID(call[1:]); ok {
+			continue
+		}
+		mutations = append(mutations, call)
+	}
+	return mutations
+}
+
+func showedID(args []string) (string, bool) {
+	if len(args) != 3 || args[0] != "show" {
+		return "", false
+	}
+	return args[2], true
 }
 
 func isReleaseVerb(args []string) bool {
@@ -81,7 +121,7 @@ func TestReleaseIfCurrentPrefersTheNativeVerb(t *testing.T) {
 		t.Fatal("ReleaseIfCurrent released = false, want true")
 	}
 	want := []string{"bd", "update", "bd-42", "--if-assignee", "worker-1", "--if-status", "in_progress", "--status", "open", "--assignee", ""}
-	calls := runner.argv()
+	calls := runner.releaseVerbArgv()
 	if len(calls) != 1 {
 		t.Fatalf("calls = %v, want exactly one", calls)
 	}
@@ -115,7 +155,7 @@ func TestReleaseIfCurrentReadsPreconditionMissFromTheExitCode(t *testing.T) {
 	if released {
 		t.Fatal("ReleaseIfCurrent released = true on a precondition miss")
 	}
-	if len(runner.argv()) != 1 {
+	if len(runner.releaseVerbArgv()) != 1 {
 		t.Fatalf("a precondition miss must not fall back or retry; calls = %v", runner.argv())
 	}
 }
@@ -156,19 +196,107 @@ func TestReleaseIfCurrentPreconditionMissDoesNotClassifyOnMessageText(t *testing
 
 // TestReleaseIfCurrentTreatsAnUnresolvableIDAsNotHeld keeps the observable
 // contract the raw-SQL path had, where an absent bead matched zero rows.
+//
+// The fixture is bd's measured wording and exit status for an id that resolves
+// to nothing (`bd update tst-nosuchbead --status open` → exit 1, `Error
+// resolving …: no issue found matching …`), not an invented one: the verdict is
+// gated on the exit code as well as the prose, so a fabricated error carries no
+// evidence.
 func TestReleaseIfCurrentTreatsAnUnresolvableIDAsNotHeld(t *testing.T) {
-	runner := &releaseVerbRunner{reply: func(args []string) ([]byte, error) {
-		if isReleaseVerb(args) {
-			return []byte(`{"error":"issue not found: bd-42"}`), fmt.Errorf("exit status 1: issue not found: bd-42")
-		}
-		return nil, fmt.Errorf("unexpected %v", args)
-	}}
+	runner := &releaseVerbRunner{
+		show: func(id string) ([]byte, error) {
+			return nil, exitErrorWithDetail(t, 1, `Error resolving `+id+`: no issue found matching "`+id+`"`)
+		},
+		reply: func(args []string) ([]byte, error) {
+			if isReleaseVerb(args) {
+				return []byte(`{"error":"1 of 1 issues failed to update","failed":[{"id":"bd-42","error":"resolving issue: no issue found matching \"bd-42\""}],"schema_version":1}`),
+					exitErrorWithDetail(t, 1, `Error resolving bd-42: no issue found matching "bd-42"`)
+			}
+			return nil, fmt.Errorf("unexpected %v", args)
+		},
+	}
 	released, err := beads.NewBdStore("/city", runner.run).ReleaseIfCurrent("bd-42", "worker-1")
 	if err != nil {
 		t.Fatalf("an unresolvable id must not error: %v", err)
 	}
 	if released {
 		t.Fatal("released = true for an unresolvable id")
+	}
+}
+
+// TestReleaseIfCurrentRefusesAFuzzyIDCollision is the exact-ID guard: bd's
+// resolver prefix/substring-matches an id with no exact hit, so handing it
+// through unverified releases a bead the caller never named — and reports
+// success. The CAS preconditions are no defense, because bd evaluates them
+// against the bead it resolved, and one worker commonly holds several. The
+// statement this verb replaced matched `WHERE id = <literal>` and was therefore
+// exact by construction.
+func TestReleaseIfCurrentRefusesAFuzzyIDCollision(t *testing.T) {
+	runner := &releaseVerbRunner{
+		// bd resolved a LONGER id — the gcy-g4o shape ("gcy-dv7" →
+		// "gcy-wisp-dv78"), which gascity meets constantly because formula steps
+		// run as <prefix>-wisp-<suffix> wisps.
+		show: func(string) ([]byte, error) { return []byte(`[{"id":"bd-42-wisp-7"}]`), nil },
+		// A capable bd would happily perform this write and exit 0.
+		reply: func([]string) ([]byte, error) { return nil, nil },
+	}
+
+	released, err := beads.NewBdStore("/city", runner.run).ReleaseIfCurrent("bd-42", "worker-1")
+	if !errors.Is(err, beads.ErrIDCollision) {
+		t.Fatalf("ReleaseIfCurrent released a bead the caller never named: released=%v err=%v, want an error wrapping ErrIDCollision", released, err)
+	}
+	if released {
+		t.Fatal("released = true for an id that resolved to a different bead")
+	}
+	if mutations := runner.releaseVerbArgv(); len(mutations) != 0 {
+		t.Fatalf("the release still reached bd: %v", mutations)
+	}
+}
+
+// TestReleaseIfCurrentSurfacesInfraFailuresAsErrors guards the other half of
+// "the CAS verdict is a number": a failure that is not a precondition miss and
+// not an unresolvable bead must surface as an error, never as the authoritative
+// "nobody holds it" answer. The package-wide isBdNotFound matches a bare
+// "not found" anywhere in the runner error, which every one of these carries.
+func TestReleaseIfCurrentSurfacesInfraFailuresAsErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		err  error
+	}{
+		{
+			name: "a renamed or unmounted database",
+			err:  exitErrorWithDetail(t, 1, `Error 1049 (42000): database "fe" not found on Dolt server at 127.0.0.1:3306`),
+		},
+		{
+			name: "bd fell off PATH",
+			err:  errors.New(`exec: "bd": executable file not found in $PATH`),
+		},
+		{
+			name: "a hosted gateway misroute",
+			out:  "404 page not found",
+			err:  exitErrorWithDetail(t, 1, "404 page not found"),
+		},
+		{
+			name: "the beads workspace is gone",
+			err:  exitErrorWithDetail(t, 1, "beads workspace not found: /city/.beads"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &releaseVerbRunner{reply: func(args []string) ([]byte, error) {
+				if isReleaseVerb(args) {
+					return []byte(tc.out), tc.err
+				}
+				return nil, fmt.Errorf("unexpected %v", args)
+			}}
+			released, err := beads.NewBdStore("/city", runner.run).ReleaseIfCurrent("bd-42", "worker-1")
+			if err == nil {
+				t.Fatalf("an infrastructure failure became a CAS verdict: released=%v err=<nil>", released)
+			}
+			if released {
+				t.Fatal("released = true on a failure")
+			}
+		})
 	}
 }
 
@@ -192,7 +320,7 @@ func TestReleaseIfCurrentFallsBackToSQLOnAnOldBd(t *testing.T) {
 	if !released {
 		t.Fatal("ReleaseIfCurrent released = false, want true")
 	}
-	calls := runner.argv()
+	calls := runner.releaseVerbArgv()
 	if len(calls) != 2 {
 		t.Fatalf("calls = %v, want the verb probe then the SQL fallback", calls)
 	}

--- a/internal/beads/bdstore_conditional_release_test.go
+++ b/internal/beads/bdstore_conditional_release_test.go
@@ -1,0 +1,289 @@
+package beads_test
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// exitErrorWithCode returns a real *exec.ExitError carrying code, which is what
+// the bd runner surfaces and what the CAS classifier reads. Fabricating the
+// process state directly is not possible, so a shell that exits with the code
+// stands in for bd.
+func exitErrorWithCode(t *testing.T, code int) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("sh -c 'exit %d' did not produce an *exec.ExitError: %v", code, err)
+	}
+	if exitErr.ExitCode() != code {
+		t.Fatalf("fabricated exit code = %d, want %d", exitErr.ExitCode(), code)
+	}
+	// The production runner wraps the ExitError with %w and appends bd's stderr
+	// detail (classifyBDExecResult); wrap here so the classifier is exercised
+	// through the same shape it sees in production.
+	return fmt.Errorf("%w: bd said something", exitErr)
+}
+
+// releaseVerbRunner records every bd invocation and answers the conditional
+// release verb with reply.
+type releaseVerbRunner struct {
+	mu    sync.Mutex
+	calls [][]string
+	reply func(args []string) ([]byte, error)
+}
+
+func (r *releaseVerbRunner) run(_, name string, args ...string) ([]byte, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, append([]string{name}, args...))
+	r.mu.Unlock()
+	if r.reply != nil {
+		return r.reply(args)
+	}
+	return nil, nil
+}
+
+func (r *releaseVerbRunner) argv() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func isReleaseVerb(args []string) bool {
+	if len(args) == 0 || args[0] != "update" {
+		return false
+	}
+	for _, a := range args {
+		if a == "--if-assignee" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestReleaseIfCurrentPrefersTheNativeVerb pins the exact argv, because the
+// whole conversion is "stop assembling SQL, state the two preconditions".
+func TestReleaseIfCurrentPrefersTheNativeVerb(t *testing.T) {
+	runner := &releaseVerbRunner{}
+	s := beads.NewBdStore("/city", runner.run)
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	want := []string{"bd", "update", "bd-42", "--if-assignee", "worker-1", "--if-status", "in_progress", "--status", "open", "--assignee", ""}
+	calls := runner.argv()
+	if len(calls) != 1 {
+		t.Fatalf("calls = %v, want exactly one", calls)
+	}
+	if strings.Join(calls[0], "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("argv = %q\nwant  %q", calls[0], want)
+	}
+	// No SQL is assembled at all on this path.
+	for _, arg := range calls[0] {
+		if strings.Contains(strings.ToUpper(arg), "UPDATE ISSUES SET") {
+			t.Fatalf("the native verb path still built SQL: %q", arg)
+		}
+	}
+}
+
+// TestReleaseIfCurrentReadsPreconditionMissFromTheExitCode is the heart of the
+// change: the CAS verdict is a number, not a parse of bd's prose.
+func TestReleaseIfCurrentReadsPreconditionMissFromTheExitCode(t *testing.T) {
+	runner := &releaseVerbRunner{}
+	runner.reply = func(args []string) ([]byte, error) {
+		if isReleaseVerb(args) {
+			return []byte("Error updating bd-42: assignee mismatch"), exitErrorWithCode(t, 13)
+		}
+		return nil, fmt.Errorf("unexpected command %v", args)
+	}
+	s := beads.NewBdStore("/city", runner.run)
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("a precondition miss must not be an error, got %v", err)
+	}
+	if released {
+		t.Fatal("ReleaseIfCurrent released = true on a precondition miss")
+	}
+	if len(runner.argv()) != 1 {
+		t.Fatalf("a precondition miss must not fall back or retry; calls = %v", runner.argv())
+	}
+}
+
+// TestReleaseIfCurrentPreconditionMissDoesNotClassifyOnMessageText proves the
+// verdict is the exit code alone: bd prose that says nothing about a mismatch
+// still reads as a precondition miss at exit 13, and prose that DOES say
+// "assignee mismatch" at any other exit code does not.
+func TestReleaseIfCurrentPreconditionMissDoesNotClassifyOnMessageText(t *testing.T) {
+	t.Run("exit 13 with unrelated prose is still a miss", func(t *testing.T) {
+		runner := &releaseVerbRunner{reply: func(args []string) ([]byte, error) {
+			if isReleaseVerb(args) {
+				return []byte("some future wording"), exitErrorWithCode(t, 13)
+			}
+			return nil, fmt.Errorf("unexpected %v", args)
+		}}
+		released, err := beads.NewBdStore("/city", runner.run).ReleaseIfCurrent("bd-42", "worker-1")
+		if err != nil || released {
+			t.Fatalf("released=%v err=%v, want false/nil", released, err)
+		}
+	})
+	t.Run("mismatch prose at exit 1 is a real error", func(t *testing.T) {
+		runner := &releaseVerbRunner{reply: func(args []string) ([]byte, error) {
+			if isReleaseVerb(args) {
+				return []byte("assignee mismatch: bd-42 is held by \"other\""), exitErrorWithCode(t, 1)
+			}
+			return nil, fmt.Errorf("unexpected %v", args)
+		}}
+		released, err := beads.NewBdStore("/city", runner.run).ReleaseIfCurrent("bd-42", "worker-1")
+		if err == nil {
+			t.Fatal("a non-13 failure must surface as an error, not a silent false")
+		}
+		if released {
+			t.Fatal("released = true on an error")
+		}
+	})
+}
+
+// TestReleaseIfCurrentTreatsAnUnresolvableIDAsNotHeld keeps the observable
+// contract the raw-SQL path had, where an absent bead matched zero rows.
+func TestReleaseIfCurrentTreatsAnUnresolvableIDAsNotHeld(t *testing.T) {
+	runner := &releaseVerbRunner{reply: func(args []string) ([]byte, error) {
+		if isReleaseVerb(args) {
+			return []byte(`{"error":"issue not found: bd-42"}`), fmt.Errorf("exit status 1: issue not found: bd-42")
+		}
+		return nil, fmt.Errorf("unexpected %v", args)
+	}}
+	released, err := beads.NewBdStore("/city", runner.run).ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("an unresolvable id must not error: %v", err)
+	}
+	if released {
+		t.Fatal("released = true for an unresolvable id")
+	}
+}
+
+// TestReleaseIfCurrentFallsBackToSQLOnAnOldBd is the bd 1.0.4 compatibility
+// proof: the minimum supported bd rejects the flags, and the store must reach
+// the raw-SQL statement byte-identically to how it did before the conversion.
+func TestReleaseIfCurrentFallsBackToSQLOnAnOldBd(t *testing.T) {
+	runner := &releaseVerbRunner{}
+	runner.reply = func(args []string) ([]byte, error) {
+		if isReleaseVerb(args) {
+			return nil, errors.New("unknown flag: --if-assignee")
+		}
+		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", runner.run)
+
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-'1")
+	if err != nil {
+		t.Fatalf("ReleaseIfCurrent: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseIfCurrent released = false, want true")
+	}
+	calls := runner.argv()
+	if len(calls) != 2 {
+		t.Fatalf("calls = %v, want the verb probe then the SQL fallback", calls)
+	}
+	wantQuery := "UPDATE issues SET status = 'open', assignee = '', updated_at = CURRENT_TIMESTAMP" +
+		" WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-''1'"
+	want := []string{"bd", "sql", "--json", wantQuery}
+	if strings.Join(calls[1], "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("fallback argv = %q\nwant          %q", calls[1], want)
+	}
+}
+
+// TestReleaseIfCurrentLatchesTheOldBdFallback proves the probe is paid once:
+// a store that has seen the flags rejected must not spend a failed subprocess
+// on every later release.
+func TestReleaseIfCurrentLatchesTheOldBdFallback(t *testing.T) {
+	runner := &releaseVerbRunner{}
+	runner.reply = func(args []string) ([]byte, error) {
+		if isReleaseVerb(args) {
+			return nil, errors.New("unknown flag: --if-assignee")
+		}
+		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
+	}
+	s := beads.NewBdStore("/city", runner.run)
+
+	for i := range 3 {
+		if _, err := s.ReleaseIfCurrent("bd-42", "worker-1"); err != nil {
+			t.Fatalf("release %d: %v", i, err)
+		}
+	}
+	verbProbes := 0
+	for _, call := range runner.argv() {
+		if isReleaseVerb(call[1:]) {
+			verbProbes++
+		}
+	}
+	if verbProbes != 1 {
+		t.Fatalf("verb probes = %d across 3 releases, want exactly 1 (latched)", verbProbes)
+	}
+}
+
+// TestReleaseIfCurrentDoesNotLatchOnARealFailure guards the inverse: a backend
+// error must never be mistaken for an old bd and permanently downgrade a
+// capable store to the SQL path.
+func TestReleaseIfCurrentDoesNotLatchOnARealFailure(t *testing.T) {
+	runner := &releaseVerbRunner{}
+	fail := true
+	runner.reply = func(args []string) ([]byte, error) {
+		if !isReleaseVerb(args) {
+			return nil, fmt.Errorf("fell back to %v after a transient failure", args)
+		}
+		if fail {
+			return []byte("dial tcp: connection refused"), exitErrorWithCode(t, 1)
+		}
+		return nil, nil
+	}
+	s := beads.NewBdStore("/city", runner.run)
+
+	if _, err := s.ReleaseIfCurrent("bd-42", "worker-1"); err == nil {
+		t.Fatal("a backend failure must surface as an error")
+	}
+	fail = false
+	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
+	if err != nil {
+		t.Fatalf("the store latched the fallback after a transient failure: %v", err)
+	}
+	if !released {
+		t.Fatal("released = false after recovery")
+	}
+}
+
+// TestReleaseIfCurrentUnknownFlagMatchIsAnchored guards the latch against a
+// capable bd's cobra usage echo, which lists every flag it HAS whenever any
+// flag is wrong. A floating substring check would latch a capable bd into the
+// SQL path forever the first time gascity passed an unrelated bad flag.
+func TestReleaseIfCurrentUnknownFlagMatchIsAnchored(t *testing.T) {
+	runner := &releaseVerbRunner{}
+	runner.reply = func(args []string) ([]byte, error) {
+		if isReleaseVerb(args) {
+			// A capable bd rejecting something else, echoing its own flags.
+			return []byte("unknown flag: --nope\nFlags:\n  --if-assignee string\n  --if-status string\n"), exitErrorWithCode(t, 1)
+		}
+		return nil, fmt.Errorf("latched the fallback on a capable bd's usage echo: %v", args)
+	}
+	s := beads.NewBdStore("/city", runner.run)
+
+	if _, err := s.ReleaseIfCurrent("bd-42", "worker-1"); err == nil {
+		t.Fatal("expected the underlying failure to surface")
+	}
+	for _, call := range runner.argv() {
+		if len(call) > 1 && call[1] == "sql" {
+			t.Fatalf("a capable bd was latched into the SQL fallback: %v", runner.argv())
+		}
+	}
+}

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3413,11 +3413,16 @@ esac
 // legacyBdReleaseRunner adapts a runner that only understands the raw-SQL
 // release path to bd 1.0.4 semantics: the native conditional-release verb is
 // rejected as an unknown flag, exactly as a bd predating gastownhall/beads#5364
-// rejects it, so the store latches its fallback. Every test that pins the
-// generated SQL is a FALLBACK-path test — the minimum supported bd
+// rejects it, so the store latches its fallback. It also answers the verb path's
+// exact-ID preflight by resolving the id to itself, so a test that pins the
+// generated SQL still sees only the SQL. Every test that pins the generated SQL
+// is a FALLBACK-path test — the minimum supported bd
 // (deps.env BD_PREV_VERSION=v1.0.4) still takes it — and must go through this.
 func legacyBdReleaseRunner(inner beads.CommandRunner) beads.CommandRunner {
 	return func(dir, name string, args ...string) ([]byte, error) {
+		if len(args) == 3 && args[0] == "show" && args[1] == "--json" {
+			return []byte(`[{"id":"` + args[2] + `"}]`), nil
+		}
 		if len(args) > 0 && args[0] == "update" {
 			for _, arg := range args {
 				if arg == "--if-assignee" {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3410,6 +3410,25 @@ esac
 	}
 }
 
+// legacyBdReleaseRunner adapts a runner that only understands the raw-SQL
+// release path to bd 1.0.4 semantics: the native conditional-release verb is
+// rejected as an unknown flag, exactly as a bd predating gastownhall/beads#5364
+// rejects it, so the store latches its fallback. Every test that pins the
+// generated SQL is a FALLBACK-path test — the minimum supported bd
+// (deps.env BD_PREV_VERSION=v1.0.4) still takes it — and must go through this.
+func legacyBdReleaseRunner(inner beads.CommandRunner) beads.CommandRunner {
+	return func(dir, name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "update" {
+			for _, arg := range args {
+				if arg == "--if-assignee" {
+					return nil, errors.New("unknown flag: --if-assignee")
+				}
+			}
+		}
+		return inner(dir, name, args...)
+	}
+}
+
 func TestBdStoreReleaseIfCurrentUsesGuardedSQL(t *testing.T) {
 	var gotName string
 	var gotArgs []string
@@ -3418,7 +3437,7 @@ func TestBdStoreReleaseIfCurrentUsesGuardedSQL(t *testing.T) {
 		gotArgs = append([]string(nil), args...)
 		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
 	}
-	s := beads.NewBdStore("/city", runner)
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
 
 	released, err := s.ReleaseIfCurrent("bd-42", "worker-'1")
 	if err != nil {
@@ -3445,7 +3464,7 @@ func TestBdStoreReleaseIfCurrentSQLLiteralEscapesBackslash(t *testing.T) {
 		gotArgs = append([]string(nil), args...)
 		return []byte(`{"rows_affected":1,"schema_version":1}`), nil
 	}
-	s := beads.NewBdStore("/city", runner)
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
 
 	if _, err := s.ReleaseIfCurrent("bd-\\42", "worker-\\1"); err != nil {
 		t.Fatalf("ReleaseIfCurrent: %v", err)
@@ -3477,7 +3496,7 @@ func TestBdStoreReleaseIfCurrentFallsBackWhenEmbeddedBdSQLUnsupported(t *testing
 			return nil, fmt.Errorf("unexpected call %s", call)
 		}
 	}
-	s := beads.NewBdStore(dir, runner)
+	s := beads.NewBdStore(dir, legacyBdReleaseRunner(runner))
 
 	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
 	if err != nil {
@@ -3556,7 +3575,7 @@ func TestBdStoreReleaseIfCurrentEmbeddedFallbackSkipsWrongAssignee(t *testing.T)
 			return nil, fmt.Errorf("unexpected command %s %q", name, args)
 		}
 	}
-	s := beads.NewBdStore(dir, runner)
+	s := beads.NewBdStore(dir, legacyBdReleaseRunner(runner))
 
 	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
 	if err != nil {
@@ -3586,7 +3605,7 @@ func embeddedDoltReleaseIfCurrentStore(t *testing.T, doltOut []byte) *beads.BdSt
 			return nil, fmt.Errorf("unexpected command %s %q", name, args)
 		}
 	}
-	return beads.NewBdStore(dir, runner)
+	return beads.NewBdStore(dir, legacyBdReleaseRunner(runner))
 }
 
 func TestBdStoreReleaseIfCurrentSkipsWhenRowsAffectedIsZero(t *testing.T) {
@@ -3598,7 +3617,7 @@ func TestBdStoreReleaseIfCurrentSkipsWhenRowsAffectedIsZero(t *testing.T) {
 			out: []byte(`{"rows_affected":0,"schema_version":1}`),
 		},
 	})
-	s := beads.NewBdStore("/city", runner)
+	s := beads.NewBdStore("/city", legacyBdReleaseRunner(runner))
 
 	released, err := s.ReleaseIfCurrent("bd-42", "worker-1")
 	if err != nil {


### PR DESCRIPTION
## Problem

`BdStore.ReleaseIfCurrent` is a compare-and-swap — clear an in-progress assignment only while the bead still carries the expected assignee — and it was assembled as raw SQL, with the verdict read out of `rows_affected`:

```sql
UPDATE issues SET status='open', assignee='', updated_at=CURRENT_TIMESTAMP
 WHERE id=<lit> AND status='in_progress' AND assignee=<lit>
```

Three costs:

1. **A hand-rolled escaping surface.** `bdSQLStringLiteral` hand-escapes MySQL string literals — an injection surface that exists *only* because the statement is concatenated by hand.
2. **`bd sql` does not work in embedded mode.** Verified against bd 1.1.0: `Error: 'bd sql' is not yet supported in embedded mode`. So the path needed a *second* implementation shelling directly to `dolt sql` (`releaseIfCurrentViaEmbeddedDoltSQL` + `parseDoltRowsAffected`), selected by matching bd's error prose.
3. **It could not see the ephemeral tier.** The statement names the `issues` table. A bead in the ephemeral tier lives in `wisps`, so it matched zero rows and the CAS returned `released=false` — *"someone else holds it"* — no matter who held it. **gascity runs formula steps as wisps, so this silent no-op was live.**

And a CAS that matches zero rows is indistinguishable from one that could not run — the same failure shape as #5125.

## Fix

bd now expresses both preconditions natively (landed in beads `4b1d9c875`, gastownhall/beads#5364):

```
bd update <id> --if-assignee <expected> --if-status in_progress --status open --assignee ""
```

and — unlike every other bd failure, which is exit 1 with a message — reports a **rejected precondition as its own exit status, 13**, having written nothing.

**The CAS verdict is therefore a number, not a parse of bd's prose.** That is the main reason to prefer the verb: the load-bearing branch stops depending on message text. `TestReleaseIfCurrentPreconditionMissDoesNotClassifyOnMessageText` pins it from both sides — exit 13 with unrelated wording is still a miss, and "assignee mismatch" prose at exit 1 is still a real error.

This is exactly what the in-code SEAM comment was waiting for (*"When bd ships its native issueops CAS release verb, consume it HERE as the first attempt … fall back to this `bd sql` path when bd reports the command unknown (older pinned bd)"*), implemented as prescribed.

### Old-bd compatibility

`deps.env` pins `BD_PREV_VERSION=v1.0.4` as the contract-tested minimum, and it predates the flags. So **the raw-SQL path stays**, selected by a one-way per-store latch the first time bd rejects the flag as unknown. The latch is paid once, not per release (`TestReleaseIfCurrentLatchesTheOldBdFallback`).

The unknown-flag match is **anchored** to the flag name immediately following the parser's marker, because a capable bd's cobra usage echo lists every flag it *has* whenever any flag is wrong — a floating `strings.Contains` would latch a capable store into the SQL path forever. `isBdUnknownIfRevisionFlag` now shares that matcher rather than duplicating the five spellings.

### What did *not* get deleted, and why

Because the bd-1.0.4 fallback survives, so do `bdSQLStringLiteral`, `releaseIfCurrentViaEmbeddedDoltSQL`, `parseDoltRowsAffected` and `isBdSQLUnsupportedInEmbeddedMode`. **The hand-rolled MySQL-escaping injection surface is narrowed to the bd-1.0.4 fallback, not removed.** It can be deleted the day `BD_PREV_VERSION` moves past beads#5364 — at which point all four helpers go together. Deleting them now would break the minimum supported bd, which is contract-tested.

## Behavior change (deliberate)

**The CAS now covers the ephemeral tier.** bd's verb resolves the id across `issues` and `wisps`, so a wisp-held assignment is now genuinely released instead of always reporting "someone else holds it". Pinned by the `an ephemeral bead releases too` integration subtest, verified against real bd (`tst-wisp-2ci` → `released=true`, state `open`/`""`).

Everything else is verdict-for-verdict identical: success → `(true, nil)`; precondition miss → `(false, nil)`; unresolvable id → `(false, nil)` (what `rows_affected=0` meant); anything else → error.

## Reader/writer agreement

**Writers of the `(status, assignee)` pair**

| Writer | Mechanism | Agreement |
|---|---|---|
| `BdStore.Claim` | `bd update --claim` | the CAS now reads the same row through the same bd id resolution the claim wrote through |
| `BdStore.Update` | `bd update --status/--assignee` | same verb family as the new CAS |
| `BdStore.ReleaseIfCurrent` | **converted** | was `bd sql`, now the native verb |
| `releaseIfCurrentViaEmbeddedDoltSQL` | direct `dolt sql` | retained, bd-1.0.4 only |
| `MemStore` / `FileStore` / `NativeDoltStore` / `SQLiteStore` / `storebinding` graph front door | own backends | untouched — none used bd SQL |
| external `bd unclaim` / `bd reclaim` | bd-native | unaffected |

**Readers of the verdict**

| Reader | Agreement |
|---|---|
| `releasePoolAssignmentIfCurrent` | **Contract preserved.** The verb path never returns `ErrConditionalReleaseUnsupported`, so the recheck-fallback arm is unchanged; a precondition miss returns `(false, nil)`, the pre-existing "authoritative, do not retry" arm. A mismatch can never downgrade into a clobbering unconditional write. |
| `doBdReleaseIfCurrent` (`gc bd release-if-current`) | exit 13 maps to `skipped` / exit 0, exactly as `rows_affected=0` did |
| `CachingStore.ReleaseIfCurrent` | refreshes only on `released=true`; unchanged |
| `beadPolicyStore.ReleaseIfCurrent` | delegates; unchanged |
| `storebinding/beads_nudge_queue.go` (3 sites) | consumes the bool; verdicts unchanged |

Both callers of the converted path are covered at *both* layers — store (`internal/beads`) and CLI (`cmd/gc`) — for *both* the verb path and the bd-1.0.4 fallback. No half-converted path.

## Tests — red-before evidence

Each production change reverted in isolation:

**A. Remove the verb preference from `ReleaseIfCurrent`**
```
--- FAIL: TestReleaseIfCurrentPrefersTheNativeVerb
    ReleaseIfCurrent: bd release-if-current: parsing SQL result: unexpected end of JSON input
--- FAIL: TestReleaseIfCurrentReadsPreconditionMissFromTheExitCode
    a precondition miss must not be an error, got bd release-if-current: unexpected command [sql --json UPDATE issues SET ...]
```

**B. Classify the CAS verdict on message text instead of the exit code**
```
--- FAIL: .../exit_13_with_unrelated_prose_is_still_a_miss
    released=false err=bd release-if-current: exit status 13: bd said something, want false/nil
--- FAIL: .../mismatch_prose_at_exit_1_is_a_real_error
    a non-13 failure must surface as an error, not a silent false
```

**C. Remove the latch**
```
--- FAIL: TestReleaseIfCurrentLatchesTheOldBdFallback
    verb probes = 3 across 3 releases, want exactly 1 (latched)
```

**D. Make the unknown-flag match unanchored (`strings.Contains`)**
```
--- FAIL: TestReleaseIfCurrentUnknownFlagMatchIsAnchored
    a capable bd was latched into the SQL fallback: [[bd update ... --if-assignee ...] [bd sql --json UPDATE issues SET ...]]
```

**E. Remove the verb preference (CLI layer)**
```
--- FAIL: TestDoBdReleaseIfCurrentUsesNativeVerbAndReadsExit13
    doBdReleaseIfCurrent = 1, want 0 (exit 13 is a verdict, not a failure)
```

**Old-bd fallback stays byte-identical.** Every pre-existing test that pinned the generated SQL is now a *fallback*-path test: its runner rejects the verb as bd 1.0.4 does, and the asserted argv is unchanged, including the escaping cases (`worker-'1`, `bd-\42`). `TestReleaseIfCurrentFallsBackToSQLOnAnOldBd` asserts the full fallback argv `[bd sql --json UPDATE issues SET ... WHERE id = 'bd-42' AND status = 'in_progress' AND assignee = 'worker-''1']`.

**Real-bd integration row** (`//go:build integration`), reusing the existing `newConditionalIntegrationBdStore` harness, in **embedded** mode — the mode where `bd sql` is rejected outright:

```
--- PASS: TestBdStoreReleaseIfCurrentAgainstRealBd (12.81s)
    --- PASS: .../a_wrong_assignee_writes_nothing_and_is_not_an_error (0.98s)
    --- PASS: .../the_matching_assignee_releases (1.13s)
    --- PASS: .../a_second_release_is_a_no-op,_not_an_error (0.62s)
    --- PASS: .../an_ephemeral_bead_releases_too (1.71s)
    --- PASS: .../an_unresolvable_id_is_not_held (0.95s)
    --- PASS: .../a_non-exact_id_refuses_instead_of_releasing_a_different_bead (2.02s)
```

**Correction to an earlier revision of this description:** that run is against a bd that HAS the flags. `deps.env` pins `BD_VERSION=v1.1.0`, and the released v1.1.0 predates them (they landed in beads#5008 / #5364, three weeks later) — a local binary that self-reports `bd version 1.1.0` is a dev build from a later commit. **On the bd CI installs, this row now SKIPS** on a positive capability probe rather than hard-failing; see "Review fixes" below. Moving `BD_VERSION` past #5364 is what makes it (and the headline wisp fix) live on shipped bd; that bump is deliberately not in this PR.

Its red-before is otherwise a **bd** change, not a gc revert: it is the authoritative guard that the flag spelling still exists and that a rejected precondition is still exit 13. The exception is the new collision leg, which is red on a gc revert — see below.

## Review fixes (`392a3ce196`)

Four defects found in review, two of them this PR's own red CI. Every fix is verified red-before by reverting only its production change.

### 1. The verb rode bd's fuzzy ID resolver, bypassing the gcy-g4o exact-ID guard — BLOCKING DEFECT

The statement the verb replaced matched `WHERE id = <literal>` and was **exact by construction**. `bd update <id>` is not: with no exact hit, bd prefix/substring-resolves. Measured against real bd, with `tst-d6e` held `in_progress` by `worker-1`:

```
$ bd update tst-d6 --if-assignee worker-1 --if-status in_progress --status open --assignee ""
✓ Updated issue: tst-d6e — probe row      # exit 0
```

The caller never named `tst-d6e`. The CAS preconditions are no defense — bd evaluates them against the bead it *resolved*, and one worker commonly holds several beads — so `gc bd release-if-current tst-d6 worker-1` printed `released`, exited 0, and revoked a live claim. The bead is then re-dispatched while the worker still believes it holds it.

This is exactly the incident class `cmd/gc/cmd_bd.go`'s "Pre-flight exact-ID guard for write-mutating subcommands (gcy-g4o)" and `beads.ErrIDCollision` exist for (`gcy-dv7` → `gcy-wisp-dv78`), and gascity is systematically exposed because formula steps run as `<prefix>-wisp-<suffix>` wisps. `gc bd release-if-current` is dispatched at `cmd_bd.go:238`, **before** the guard at `:253`, and `bdMutationWriteIDs` does not recognize the subcommand — it was the one `gc bd` mutation with no exact-ID verification.

**Fix:** the verb path resolves the id through `Get` first and refuses on `ErrIDCollision`, so every store-level caller is covered — including the CLI that bypasses the `cmd_bd.go` guard. Only a *confirmed* collision blocks: a plain `ErrNotFound` or a failed read falls through, the same fail-open tradeoff `cmd_bd.go`'s guard documents. `ReleaseIfCurrent` now documents the canonical-full-ID requirement the way `Update` does. **The raw-SQL fallback is untouched** — it still matches the id literally, so no preflight and no argv change there.

Scope note: bd prefers an exact id when one exists, so in-process Go callers passing canonical ids were never exposed. The reachable surface is ids with no exact match — truncated, typo'd, stale — which is precisely what the documented CLI entry point accepts from humans and agents.

### 2. Text classification, reintroduced one line below the exit-code branch

The PR's thesis is "stop classifying CAS verdicts by message text, use exit 13". One line below that branch, `if isBdNotFound(runErr)` did exactly what the PR removes: an **unanchored** `strings.Contains(msg, "not found")` over the *whole* runner error, returning `(false, nil)` — the authoritative "someone else holds it, do not retry" verdict.

Measured at the head before this fix, `ReleaseIfCurrent` answered `(released=false, err=nil)` for all of:

| Failure | Text |
|---|---|
| bd off PATH / `BD_BIN` drift | `exec: "bd": executable file not found in $PATH` |
| renamed or unmounted database | `Error 1049 (42000): database "fe" not found on Dolt server at …` |
| hosted-gateway misroute | `404 page not found` |
| missing workspace | `beads workspace not found: …` |

On main every one of these was an error. Downstream, `gc bd release-if-current` printed `skipped` and exited 0 against a dead store; `lifecycle_wrappers.go` recorded `observeClaim("ReleaseIfCurrent", false, nil)` — a clean refusal — in claim telemetry; `releasePoolAssignmentIfCurrent` logged "assignment changed since snapshot" instead of "conditional release failed".

**Fix:** a local `isBdIssueNotFound` replaces the loose package-wide helper on this branch. It requires **numeric evidence** (`bdExitCode == 1`; 13 is the precondition miss) **AND** bd's measured issue-scoped wording (`no issue found` / `no issues found` / `issue not found` — real bd emits `Error resolving tst-nosuchbead: no issue found matching "tst-nosuchbead"` at exit 1). A spawn failure carries no process exit status at all, so it can never reach the verdict. Everything else flows to `return false, true, runErr`. This also settles the reported MINOR.

### 3. CI red — resource-census ledger (`packages-core-1-of-4`)

`TestRepositoryLedgerMatchesCensusAndDocumentation` failed with `scope=untagged resource=subprocess calls=404 (baseline 403), files=113 (baseline 112)` in three scopes.

The cause is **not** the production file's `os/exec` import — `census.go:901` skips non-`_test.go` files ("Sibling Go source supplies package-level declaration context but is never counted"). It is the new **untagged test** file's `exec.Command("sh", "-c", fmt.Sprintf("exit %d", code))`, used to fabricate a real `*exec.ExitError`. Proven by replacing that one call at the PR head with the production import left alone: the ledger goes green.

The ledger's own invariant is `untagged subprocess call/file totals cannot grow; reductions must lower this baseline`, with `resource_owner = each process-owning test removes or replaces its source call site` — so the sanctioned fix is to remove the call site, not to bump the three lockstepped baselines. `bdExitCode` now matches an `ExitCode() int` interface, which `*exec.ExitError` satisfies through its embedded `*os.ProcessState`; a compile-time `var _ exitCoder = (*exec.ExitError)(nil)` in the production file keeps the substitution honest.

```
$ go test -tags integration ./internal/testpolicy/resourcecensus
ok      github.com/gastownhall/gascity/internal/testpolicy/resourcecensus  3.5s
```

### 4. CI red — the integration row FAILED instead of skipping (`packages-core-2-of-4`)

`isUnsupportedOnThisBd` could never fire. On a flagless bd the verb probe returns `handled=false`, the store latches, `bd sql` is embedded-rejected, and `releaseIfCurrentViaEmbeddedDoltSQL` then **succeeds** with `released=false` for a wisp (it names the `issues` table) — so `err == nil` and the ephemeral leg reached `t.Fatal`.

**Fix:** the row gates on a **positive capability signal** — `bd update --help` advertising both flags, the same shape the production `conditionalWritesCapable` probe uses for `--if-revision` — and skips the whole test cleanly. All five error-string skip guards are deleted; after the gate, an error is a bug.

Verified against a shim that reproduces the CI-pinned bd (rejects `--if-assignee`/`--if-status`, real bd otherwise), with dolt on PATH:

```
# PR head b73b24a165 — byte-identical to CI job 93186748769
--- FAIL: TestBdStoreReleaseIfCurrentAgainstRealBd/an_ephemeral_bead_releases_too
    bdstore_conditional_release_integration_test.go:120: did not release an ephemeral in-progress assignment

# with this fix
--- SKIP: TestBdStoreReleaseIfCurrentAgainstRealBd (4.97s)
    installed bd does not advertise --if-assignee/--if-status (pre-beads#5364) …
ok  github.com/gastownhall/gascity/internal/beads  36.2s   # whole package, -tags integration, flagless bd
```

### Red-before for the review fixes

**Remove the exact-ID preflight** — store, CLI, and real bd:
```
--- FAIL: TestReleaseIfCurrentRefusesAFuzzyIDCollision
    ReleaseIfCurrent released a bead the caller never named: released=true err=<nil>, want an error wrapping ErrIDCollision

--- FAIL: TestDoBdReleaseIfCurrentRefusesAFuzzyIDCollision
    doBdReleaseIfCurrent = 0, want 1 (a substring collision must not be reported as a release); stdout="released\n" stderr=""

--- FAIL: TestBdStoreReleaseIfCurrentAgainstRealBd/a_non-exact_id_refuses_instead_of_releasing_a_different_bead
    ReleaseIfCurrent("tst-68") = released=true err=<nil>, want a refusal wrapping ErrIDCollision
```

**Restore `isBdNotFound` on the not-held branch:**
```
--- FAIL: TestReleaseIfCurrentSurfacesInfraFailuresAsErrors/a_renamed_or_unmounted_database
    an infrastructure failure became a CAS verdict: released=false err=<nil>
--- FAIL: .../bd_fell_off_PATH            an infrastructure failure became a CAS verdict: released=false err=<nil>
--- FAIL: .../a_hosted_gateway_misroute   an infrastructure failure became a CAS verdict: released=false err=<nil>
--- FAIL: .../the_beads_workspace_is_gone an infrastructure failure became a CAS verdict: released=false err=<nil>
```

### Contracts preserved

- A genuine CAS miss is still `(false, nil)` and never `ErrConditionalReleaseUnsupported`, so `releasePoolAssignmentIfCurrent` cannot downgrade to a clobbering unconditional write. A collision and an infra failure are *errors*, which that caller already handles by skipping the tick.
- **bd 1.0.4 behavior is byte-identical.** The preflight is on the verb path only; the fallback argv and `bdSQLStringLiteral` escaping are unchanged, including `worker-'1` and `bd-\42`. `legacyBdReleaseRunner` answers the preflight so every SQL-pinning test still asserts exactly the same statement.

## Gates

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `gofmt -l ./cmd ./internal` | clean |
| `golangci-lint run ./internal/beads/... ./cmd/gc/...` (2.10.1) | **0 issues** |
| `go test ./internal/beads/ ./internal/storebinding/...` | all ok (20.0s / 11.8s / 19.0s) |
| `go test ./cmd/gc -timeout 40m` | ok 815.5s |
| `go test -tags integration ./internal/beads` (capable bd) | ok 44.0s |
| `go test -tags integration ./internal/beads` (CI-pinned flagless bd) | ok 36.2s — row skips |
| `go test -tags integration ./internal/testpolicy/resourcecensus` | ok 3.5s (was the `packages-core-1-of-4` red) |
| `.githooks/pre-commit` | pass (lint-changed 0 issues, doc-gen clean, `go vet`) |

`internal/beads` is package index 21 → shard **2 of 4**; `internal/testpolicy/resourcecensus` is index 148 → shard **1 of 4** — the two jobs that were red.

Based on `a1d8e21c7d`. Independent of #5125; the two touch adjacent lines in `ReleaseIfCurrent` and will need a one-line merge resolution whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

