### PR TITLE
fix(orders): create order-tracking beads in the orders-class store

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1574,6 +1574,20 @@ func (cs *controllerState) GraphBeadStore() beads.GraphStore {
 	return beads.GraphStore{Store: resolveGraphStore(cs.storageRoutes, cs.cityBeadStore, cs.cfg, cs.cityPath, cs.eventProv)}
 }
 
+// OrdersBeadStore returns the store backing orders-class beads. At the default
+// backend resolveOrderStore returns cityBeadStore, so this is byte-identical to
+// CityBeadStore; when [beads.classes.orders] is relocated it returns the
+// per-class store, which is the store the order dispatcher creates every
+// tracking bead in. cs.eventProv is the recorder, matching the nudges/sessions
+// wiring. The result is wrapped in the strongly-typed beads.OrdersStore so the
+// orders class is statically visible to callers; the wrapper carries the same
+// underlying store value, so runtime behavior is unchanged.
+func (cs *controllerState) OrdersBeadStore() beads.OrdersStore {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return beads.OrdersStore{Store: resolveOrderStore(cs.storageRoutes, cs.cityBeadStore, cs.cfg, cs.cityPath, cs.eventProv)}
+}
+
 // CityBeadsDiagnostic returns the city-level bead store selection diagnostic.
 func (cs *controllerState) CityBeadsDiagnostic() *beads.BeadsDiagnostic {
 	cs.mu.RLock()

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -75,8 +75,13 @@ func sweepOrphanedOrderTrackingAtBoot(routes *storageRoutes, cityPath string, cf
 		} else if n > 0 {
 			fmt.Fprintf(stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
 		}
-		warnIfClosedOrderTrackingBacklogLarge(store, stderr)
 	}
+	// The advisory is about the city's backlog, so it counts the stores together.
+	// Per-store thresholds would halve the sensitivity on exactly the split cities
+	// the sweep was extended for: a converged city holds half its closed tracking
+	// beads in the work ledger and half in the binding, and neither half alone
+	// reaches the threshold the pair clears.
+	warnIfClosedOrderTrackingBacklogLarge(stores, stderr)
 }
 
 // reloadOrderDrainTimeout bounds how long config reload will wait for
@@ -1632,7 +1637,7 @@ func (cr *CityRuntime) runOrderTrackingRetentionWatchdog(now time.Time) {
 
 const (
 	// orderTrackingRetentionStartupWarnThreshold is the minimum number of closed
-	// order-tracking beads in the city store that triggers a startup advisory.
+	// order-tracking beads a city holds that triggers a startup advisory.
 	// The watchdog prunes automatically; this warning surfaces cities that have
 	// accumulated a visible backlog before the first watchdog cycle completes.
 	orderTrackingRetentionStartupWarnThreshold = 100
@@ -1641,26 +1646,43 @@ const (
 	orderTrackingRetentionStartupListLimit = 1001
 )
 
-// warnIfClosedOrderTrackingBacklogLarge writes a one-line advisory to stderr
-// when the city store holds more than orderTrackingRetentionStartupWarnThreshold
-// closed order-tracking beads. It is best-effort: a nil store or a List error is
-// silently ignored so startup is never blocked.
-func warnIfClosedOrderTrackingBacklogLarge(store beads.Store, stderr io.Writer) {
-	if store == nil {
+// warnIfClosedOrderTrackingBacklogLarge writes one advisory line to stderr when
+// the city's stores together hold more than
+// orderTrackingRetentionStartupWarnThreshold closed order-tracking beads. It is
+// best-effort: a nil store or a List error is skipped so startup is never
+// blocked.
+//
+// The count is the total across the stores, not a per-store test, because the
+// backlog is one city's. A split city holds its pre-cutover half in the work
+// ledger and everything since in the binding; testing each half separately
+// stays silent on a city with twice the backlog the threshold is set at.
+func warnIfClosedOrderTrackingBacklogLarge(stores []beads.Store, stderr io.Writer) {
+	total := 0
+	truncated := false
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		closed, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+			Status:   "closed",
+			Label:    labelOrderTracking,
+			TierMode: beads.TierBoth,
+			Limit:    orderTrackingRetentionStartupListLimit,
+		})
+		if err != nil {
+			continue
+		}
+		total += len(closed)
+		if len(closed) >= orderTrackingRetentionStartupListLimit {
+			truncated = true
+		}
+	}
+	if total <= orderTrackingRetentionStartupWarnThreshold {
 		return
 	}
-	closed, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
-		Status:   "closed",
-		Label:    labelOrderTracking,
-		TierMode: beads.TierBoth,
-		Limit:    orderTrackingRetentionStartupListLimit,
-	})
-	if err != nil || len(closed) <= orderTrackingRetentionStartupWarnThreshold {
-		return
-	}
-	countStr := fmt.Sprintf("%d", len(closed))
-	if len(closed) >= orderTrackingRetentionStartupListLimit {
-		countStr = "≥1001"
+	countStr := fmt.Sprintf("%d", total)
+	if truncated {
+		countStr = "≥" + countStr
 	}
 	fmt.Fprintf(stderr, "gc start: %s closed order-tracking beads detected — retention watchdog will prune automatically (7d TTL default; configure: [beads.policies.order_tracking].delete_after_close). For immediate cleanup: gc order sweep-tracking\n", countStr) //nolint:errcheck // best-effort stderr
 }

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -40,6 +40,45 @@ import (
 // managed dolt.
 var newCityRuntimeOpenSweepStore = openStoreAtForCity
 
+// sweepOrphanedOrderTrackingAtBoot closes order-tracking beads a previous
+// controller instance left open (goroutines killed on restart, or silent Close
+// failures). It runs on startup only, never on config reload, and is
+// best-effort: a store it cannot open is reported and skipped, and the retry
+// with backoff is defense-in-depth against transient store errors immediately
+// after ensureBeadsProvider returns (#753).
+//
+// It sweeps the city work store AND, on a split city, the orders binding those
+// tracking beads are now born in. Both, not one. A converged city holds
+// pre-cutover orphans in the work store and every new one in the binding, and an
+// orphan left open is an order that never fires again — the open bead IS the
+// single-flight marker, so a controller that cannot see it never clears it. A
+// boot sweep that reads only the work store on a split city is therefore not a
+// degraded sweep, it is no sweep at all.
+//
+// The binding handle belongs to routes and is closed with them at runtime
+// shutdown; only the work store opened here is closed here.
+func sweepOrphanedOrderTrackingAtBoot(routes *storageRoutes, cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) {
+	workStore, err := newCityRuntimeOpenSweepStore(cityPath, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc start: order tracking sweep: %v\n", err) //nolint:errcheck // best-effort stderr
+		return
+	}
+	defer closeBeadStoreHandle(workStore) //nolint:errcheck
+
+	stores := []beads.Store{workStore}
+	if ordersStore := resolveOrderStore(routes, nil, cfg, cityPath, rec); ordersStore != nil && ordersStore != workStore {
+		stores = append(stores, ordersStore)
+	}
+	for _, store := range stores {
+		if n, err := sweepOrphanedOrderTrackingRetryLimit(store, 3, time.Second, orderTrackingSweepCloseBudget); err != nil {
+			fmt.Fprintf(stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr
+		} else if n > 0 {
+			fmt.Fprintf(stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
+		}
+		warnIfClosedOrderTrackingBacklogLarge(store, stderr)
+	}
+}
+
 // reloadOrderDrainTimeout bounds how long config reload will wait for
 // the outgoing order dispatcher's in-flight goroutines before replacing
 // it. Reload runs on the tick loop, so a larger budget would stall all
@@ -309,25 +348,7 @@ func newCityRuntime(p CityRuntimeParams) (*CityRuntime, error) {
 		return nil, err
 	}
 
-	// Sweep orphaned order-tracking beads on startup only (not config reload).
-	// A previous controller instance may have left tracking beads open
-	// (goroutines killed on restart, or silent Close failures).
-	// Retry with backoff as defense-in-depth against transient store
-	// errors immediately after ensureBeadsProvider returns (#753).
-	func() {
-		sweepStore, err := newCityRuntimeOpenSweepStore(p.CityPath, p.CityPath)
-		if err != nil {
-			fmt.Fprintf(p.Stderr, "gc start: order tracking sweep: %v\n", err) //nolint:errcheck // best-effort stderr
-			return
-		}
-		defer closeBeadStoreHandle(sweepStore) //nolint:errcheck
-		if n, err := sweepOrphanedOrderTrackingRetryLimit(sweepStore, 3, time.Second, orderTrackingSweepCloseBudget); err != nil {
-			fmt.Fprintf(p.Stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr
-		} else if n > 0 {
-			fmt.Fprintf(p.Stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
-		}
-		warnIfClosedOrderTrackingBacklogLarge(sweepStore, p.Stderr)
-	}()
+	sweepOrphanedOrderTrackingAtBoot(routes, p.CityPath, p.Cfg, p.Rec, p.Stderr)
 
 	od, orderSnapshot := buildOrderDispatcherWithSnapshot(routes, p.CityPath, p.Cfg, p.Rec, p.Stderr, "gc start: order scan")
 
@@ -1702,6 +1723,14 @@ func (cr *CityRuntime) orderTrackingSweepStores() ([]beads.Store, []orderTrackin
 		}
 		return store, nil
 	})
+	// The tracking beads this controller writes are born in the orders binding,
+	// so both watchdogs — stale-close and closed-retention — have to sweep it.
+	// Without it a split city's open tracking beads are never recovered and its
+	// closed ones are never pruned: the stale-close jam (#2168) comes back with
+	// no watchdog able to see it. The binding comes from the routes this process
+	// opened at boot, never a second resolution, so nothing here is closed by
+	// closeOpened — the runtime owns that handle for its whole life.
+	stores = appendOrdersSweepStore(stores, cr.relocatedOrdersStore())
 	closeOpened := func() {
 		for _, s := range freshlyOpened {
 			_ = closeBeadStoreHandle(s) //nolint:errcheck // best-effort

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -7338,7 +7338,7 @@ func TestWarnIfClosedOrderTrackingBacklogLarge_SilentAtThreshold(t *testing.T) {
 	}
 	store := beads.NewMemStoreFrom(200, seed, nil)
 	var buf bytes.Buffer
-	warnIfClosedOrderTrackingBacklogLarge(store, &buf)
+	warnIfClosedOrderTrackingBacklogLarge([]beads.Store{store}, &buf)
 	if buf.Len() > 0 {
 		t.Fatalf("got unexpected warning at count=100: %q", buf.String())
 	}
@@ -7356,7 +7356,7 @@ func TestWarnIfClosedOrderTrackingBacklogLarge_FiresAboveThreshold(t *testing.T)
 	}
 	store := beads.NewMemStoreFrom(200, seed, nil)
 	var buf bytes.Buffer
-	warnIfClosedOrderTrackingBacklogLarge(store, &buf)
+	warnIfClosedOrderTrackingBacklogLarge([]beads.Store{store}, &buf)
 	got := buf.String()
 	if !strings.Contains(got, "101") {
 		t.Fatalf("warning = %q, want count 101", got)
@@ -7378,7 +7378,7 @@ func TestWarnIfClosedOrderTrackingBacklogLarge_CapFormatAtLimit(t *testing.T) {
 	}
 	store := beads.NewMemStoreFrom(1100, seed, nil)
 	var buf bytes.Buffer
-	warnIfClosedOrderTrackingBacklogLarge(store, &buf)
+	warnIfClosedOrderTrackingBacklogLarge([]beads.Store{store}, &buf)
 	got := buf.String()
 	if !strings.Contains(got, "≥1001") {
 		t.Fatalf("warning = %q, want ≥1001 cap format", got)
@@ -7387,5 +7387,33 @@ func TestWarnIfClosedOrderTrackingBacklogLarge_CapFormatAtLimit(t *testing.T) {
 
 func TestWarnIfClosedOrderTrackingBacklogLarge_SilentOnNilStore(_ *testing.T) {
 	// nil store: must not panic.
-	warnIfClosedOrderTrackingBacklogLarge(nil, io.Discard)
+	warnIfClosedOrderTrackingBacklogLarge([]beads.Store{nil}, io.Discard)
+}
+
+// TestWarnIfClosedOrderTrackingBacklogLarge_CountsStoresTogether is the split
+// city: a converged one holds its pre-cutover backlog in the work ledger and
+// everything since in the orders binding. Neither half clears the threshold on
+// its own, so a per-store test stays silent on a city holding 120.
+func TestWarnIfClosedOrderTrackingBacklogLarge_CountsStoresTogether(t *testing.T) {
+	seedClosed := func(prefix string, n int) beads.Store {
+		seed := make([]beads.Bead, n)
+		for i := range seed {
+			seed[i] = beads.Bead{
+				ID:     fmt.Sprintf("%s-%03d", prefix, i),
+				Status: "closed",
+				Labels: []string{labelOrderTracking},
+			}
+		}
+		return beads.NewMemStoreFrom(200, seed, nil)
+	}
+
+	var buf bytes.Buffer
+	warnIfClosedOrderTrackingBacklogLarge([]beads.Store{seedClosed("work", 60), seedClosed("bind", 60)}, &buf)
+	got := buf.String()
+	if !strings.Contains(got, "120") {
+		t.Fatalf("warning = %q, want the combined count 120; a per-store threshold halves the advisory's sensitivity on exactly the split cities it was extended for", got)
+	}
+	if strings.Count(got, "gc start:") != 1 {
+		t.Fatalf("warning = %q, want one advisory line for the city", got)
+	}
 }

--- a/cmd/gc/class_store.go
+++ b/cmd/gc/class_store.go
@@ -61,18 +61,17 @@ func (cs *controllerState) nudgesBeadStore() beads.NudgesStore {
 }
 
 // ordersBeadStore returns the store that owns order-tracking bookkeeping beads
-// for the given scope (rig name, or "" for the city): the configured orders class
-// store when [beads.classes.orders] relocates orders, else the work store. The
-// scope is accepted so a future per-scope orders backend can route without a
-// call-site change. Identity to the work store at the default bd backend;
-// returned as the strongly-typed beads.OrdersStore so the orders class stays
-// statically visible. This is the city-scope simple case; per-order scope
-// (rig/pool-routed orders) resolves PER ORDER through resolveOrderStoreTarget
-// (the federated dispatch/sweep paths in order_store.go / order_dispatch.go).
+// for the given scope (rig name, or "" for the city). It delegates to the
+// exported OrdersBeadStore() accessor so the api.State surface and the
+// controller's own callers share one resolver. The scope is accepted so a future
+// per-scope orders backend can route without a call-site change. Identity to the
+// work store at the default bd backend; returned as the strongly-typed
+// beads.OrdersStore so the orders class stays statically visible. This is the
+// city-scope simple case; per-order scope (rig/pool-routed orders) resolves PER
+// ORDER through resolveOrderStoreTarget (the federated dispatch/sweep paths in
+// order_store.go / order_dispatch.go).
 func (cs *controllerState) ordersBeadStore(_ string) beads.OrdersStore {
-	cs.mu.RLock()
-	defer cs.mu.RUnlock()
-	return beads.OrdersStore{Store: resolveOrderStore(cs.storageRoutes, cs.cityBeadStore, cs.cfg, cs.cityPath, cs.eventProv)}
+	return cs.OrdersBeadStore()
 }
 
 // cityWorkStore returns the city-level store for ordinary WORK-class beads that
@@ -144,6 +143,16 @@ func (cr *CityRuntime) nudgesBeadStore() beads.NudgesStore {
 // in the federated dispatch/sweep paths.
 func (cr *CityRuntime) ordersBeadStore(_ string) beads.OrdersStore {
 	return beads.OrdersStore{Store: resolveOrderStore(cr.storageRoutes, cr.cityBeadStore(), cr.cfg, cr.cityPath, cr.rec)}
+}
+
+// relocatedOrdersStore returns the runtime's ORDERS-class binding store when
+// [storage] relocates the orders class, and nil when it does not — the
+// controller-side twin of relocatedOrdersClassStore (order_store.go), resolved
+// through the routes this process opened at boot rather than the one-shot CLI
+// funnel. nil is what keeps a federation on a single-store city byte-identical:
+// there is no second store to add.
+func (cr *CityRuntime) relocatedOrdersStore() beads.Store {
+	return resolveOrderStore(cr.storageRoutes, nil, cr.cfg, cr.cityPath, cr.rec)
 }
 
 // cityWorkStore returns the runtime's city-level WORK-class bead store. Work is

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -710,7 +710,7 @@ func cmdOrderRun(name, rig string, jsonOutput bool, vars map[string]string, stdo
 			}
 			defer ep.Close() //nolint:errcheck // best-effort
 		}
-		return doOrderRunExecTracked(a, cityPath, cfg, orders.NewStore(store), ep, vars, stdout, stderr)
+		return doOrderRunExecTracked(a, cityPath, cfg, orderTrackingFrontDoor(cityPath, cfg, store), ep, vars, stdout, stderr)
 	}
 	store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
 	if store.Store == nil {
@@ -762,7 +762,7 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 			fmt.Fprintf(stderr, "gc order run: %v\n", cfgErr) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		return doOrderRunExecTracked(a, cityPath, cfg, orders.NewStore(store), ep, vars, stdout, stderr)
+		return doOrderRunExecTracked(a, cityPath, cfg, orderTrackingFrontDoor(cityPath, cfg, store), ep, vars, stdout, stderr)
 	}
 
 	// Capture event head before wisp creation (race-free cursor). Event runs
@@ -877,7 +877,7 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 	// (#3294). Create it closed: its CreatedAt is the cooldown marker, and a
 	// lingering open tracking bead would read as in-flight work and block
 	// re-dispatch (ga-jra/ga-lo8c). Best-effort: the wisp already launched.
-	if _, err := orders.NewStore(store).CreateRunClosed(scoped, orders.RunOutcomeNone, nil, ""); err != nil {
+	if _, err := orderTrackingFrontDoor(cityPath, cfg, store).CreateRunClosed(scoped, orders.RunOutcomeNone, nil, ""); err != nil {
 		fmt.Fprintf(stderr, "gc order run: recording tracking bead: %v\n", err) //nolint:errcheck
 	}
 

--- a/cmd/gc/doctor_order_tracking_retention.go
+++ b/cmd/gc/doctor_order_tracking_retention.go
@@ -54,22 +54,38 @@ func (c *orderTrackingRetentionCheck) Run(_ *doctor.CheckContext) *doctor.CheckR
 		res.Message = fmt.Sprintf("order-tracking retention unknown: opening city bead store: %v", err)
 		return res
 	}
-	entries, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
-		Status:   "closed",
-		Label:    labelOrderTracking,
-		TierMode: beads.TierBoth,
-		Limit:    orderTrackingRetentionCheckListLimit,
-	})
-	if err != nil {
-		res.Status = doctor.StatusWarning
-		res.Message = fmt.Sprintf("order-tracking retention unknown: listing closed beads: %v", err)
-		return res
+	// The city work store holds the pre-cutover backlog; the orders binding
+	// holds everything a split city has written since. Counting only one of them
+	// reports a healthy 0 on exactly the city whose backlog is growing.
+	stores := []beads.Store{store}
+	if ordersStore := relocatedOrdersClassStore(c.cityPath, nil); ordersStore != nil && ordersStore != store {
+		stores = append(stores, ordersStore)
 	}
-	count := len(entries)
+	count := 0
+	capped := false
+	for _, s := range stores {
+		entries, err := beads.HandlesFor(s).Live.List(beads.ListQuery{
+			Status:   "closed",
+			Label:    labelOrderTracking,
+			TierMode: beads.TierBoth,
+			Limit:    orderTrackingRetentionCheckListLimit,
+		})
+		if err != nil {
+			res.Status = doctor.StatusWarning
+			res.Message = fmt.Sprintf("order-tracking retention unknown: listing closed beads: %v", err)
+			return res
+		}
+		count += len(entries)
+		// Each store's read is capped independently, so "at least this many"
+		// has to be tracked per store rather than inferred from the total.
+		if len(entries) >= orderTrackingRetentionCheckListLimit {
+			capped = true
+		}
+	}
 	if count >= orderTrackingRetentionCheckThreshold {
 		countStr := fmt.Sprintf("%d", count)
-		if count >= orderTrackingRetentionCheckListLimit {
-			countStr = "≥" + fmt.Sprintf("%d", orderTrackingRetentionCheckListLimit)
+		if capped {
+			countStr = "≥" + countStr
 		}
 		res.Status = doctor.StatusWarning
 		res.Message = fmt.Sprintf("%s closed order-tracking beads: retention watchdog will prune automatically (7d TTL default; configure [beads.policies.order_tracking].delete_after_close)", countStr)

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1647,6 +1647,20 @@ func storeListContains(stores []beads.Store, want beads.Store) bool {
 	return false
 }
 
+// sweepStoreListContains is storeListContains for a tracking-sweep store list,
+// whose entries carry a scope label around the store. The comparison has to look
+// through that wrapper: a bare identity check sees the label, decides the
+// binding is absent, and sweeps it a second time — which in dry-run tells the
+// operator twice as much work is stale as there is.
+func sweepStoreListContains(stores []beads.Store, want beads.Store) bool {
+	for _, store := range stores {
+		if unwrapOrderTrackingSweepStore(store) == want {
+			return true
+		}
+	}
+	return false
+}
+
 // dispatchWisp instantiates a wisp from the order's formula.
 func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string, vars map[string]string) {
 	scoped := a.ScopedName()
@@ -2426,7 +2440,7 @@ func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, wispStor
 			result.sweptStoreKeys[key] = struct{}{}
 		}
 	}
-	if includeWispSubtrees && wispStore != nil && !storeListContains(stores, wispStore) {
+	if includeWispSubtrees && wispStore != nil && !sweepStoreListContains(stores, wispStore) {
 		n, err := sweepStaleOrderWispSubtreesMode(wispStore, now.Add(-staleAfter), onlyOrders, initiator, dryRun)
 		result.wispClosed += n
 		if err != nil {

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -287,12 +287,14 @@ type memoryOrderDispatcher struct {
 	aa      []orders.Order
 	storeFn orderStoreFunc
 	// storageRoutes is the opened non-work storage binding this process
-	// resolved at boot. It is the graph leg of a wisp dispatch: the molecule a
-	// formula order materializes is graph class (coordclass classifies wisp
-	// roots as ClassGraph), while the order-tracking bead storeFn opens stays
-	// on the order/work side. A nil value relocates nothing, so graphStoreFor
-	// hands back the caller's own store and the dispatch is byte-identical to
-	// the single-store path.
+	// resolved at boot, and it carries BOTH classes a dispatch writes: the
+	// molecule a formula order materializes is graph class (coordclass
+	// classifies wisp roots as ClassGraph), and the order-tracking bead that
+	// gates repeat firing is orders class (coordclass.ClassOrders is defined as
+	// exactly those records). storeFn opens the order's TARGET scope, which is a
+	// work ledger; neither class belongs there on a split city. A nil value
+	// relocates nothing, so graphStoreFor/ordersStoreFor hand back the caller's
+	// own store and the dispatch is byte-identical to the single-store path.
 	storageRoutes        *storageRoutes
 	ep                   events.Provider
 	execRun              ExecRunner
@@ -535,29 +537,11 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			stores[storeKey] = store
 		}
 
-		storesForGate := []beads.Store{store}
 		legacyStore, legacyOK := m.legacyCityStoreForTarget(cityPath, target, stores)
 		if !legacyOK {
 			continue
 		}
-		if legacyStore != nil {
-			storesForGate = append(storesForGate, legacyStore)
-		}
-		storeKeysForGate := []string{storeKey}
-		if legacyStore != nil {
-			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
-		}
-		// A dispatched wisp root is graph class and carries this order's
-		// order-run label, so on a split city the single-flight gate, the
-		// cooldown clock and the event cursor all have to read the graph store
-		// as well — otherwise an order re-fires while its previous wisp is
-		// still open. When nothing is relocated the graph store IS the target
-		// store, the append is skipped, and the gate reads the exact store list
-		// it always did.
-		if graphStore := m.graphStoreFor(store); graphStore != nil && !storeListContains(storesForGate, graphStore) {
-			storesForGate = append(storesForGate, graphStore)
-			storeKeysForGate = append(storeKeysForGate, m.graphStoreKey())
-		}
+		storesForGate, storeKeysForGate := m.gateStoresFor(cityPath, store, storeKey, legacyStore)
 		scoped := a.ScopedName()
 		// NoWorkGate orders (pure probes/sweeps that track no beads) opt out of
 		// BOTH open-work gates entirely. The gates exist to suppress re-dispatch
@@ -621,7 +605,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			logDispatchError(m.stderr, "gc: order dispatch: building trigger env for %s: %s", a.ScopedName(), redacted)
 			// Leave this open so the existing open-work gate suppresses repeat
 			// ticks until the normal stale tracking sweep gives the order another try.
-			trackingBead, createErr := orders.NewStore(beads.OrdersStore{Store: store}).CreateRun(scoped, orders.RunOpts{Outcome: orders.RunOutcomeTriggerEnvFailed})
+			trackingBead, createErr := m.orderFrontDoorFor(store).CreateRun(scoped, orders.RunOpts{Outcome: orders.RunOutcomeTriggerEnvFailed})
 			if createErr != nil {
 				logDispatchError(m.stderr, "gc: order dispatch: creating trigger env failure tracking bead for %s: %v", scoped, createErr)
 			} else {
@@ -781,7 +765,7 @@ func (m *memoryOrderDispatcher) runDispatchGuarded(ctx context.Context, store be
 // A caller tracking its own WaitGroup must register it before calling and
 // release it in onDone (and, on a returned error, itself — nothing launched).
 func (m *memoryOrderDispatcher) launchResolvedDispatch(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath string, vars, execEnv map[string]string, onDone func()) (orders.OrderRun, error) {
-	trackingRun, err := orders.NewStore(beads.OrdersStore{Store: store}).CreateRun(a.ScopedName(), orders.RunOpts{})
+	trackingRun, err := m.orderFrontDoorFor(store).CreateRun(a.ScopedName(), orders.RunOpts{})
 	if err != nil {
 		return orders.OrderRun{}, err
 	}
@@ -1195,7 +1179,11 @@ func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Sto
 	// tracking bead outcome observable to a waiting drain.
 	defer m.doneInflight()
 	defer func() {
-		if err := closeOrderTrackingBead(ctx, store, trackingID); err != nil {
+		// The tracking bead was born in the orders store, so its close has to
+		// address that store: closing through the target scope on a split city
+		// finds nothing, and the marker that suppresses re-dispatch stays open
+		// forever.
+		if err := closeOrderTrackingBead(ctx, m.ordersStoreFor(store), trackingID); err != nil {
 			logDispatchError(m.stderr, "gc: order %s: closing tracking bead %s: %v", a.ScopedName(), trackingID, err)
 		}
 	}()
@@ -1229,9 +1217,9 @@ func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Sto
 		// dispatchExec is order-only: hand it the typed order front door so the
 		// goroutine leaf has no raw beads.Store to misuse. Constructed here (the
 		// per-order coordination point that still holds the raw store for the
-		// closeOrderTrackingBead defer) from the same store, so the bead writes
-		// stay byte-identical.
-		front := orders.NewStore(beads.OrdersStore{Store: store})
+		// target-scoped exec env) from the orders class store, which is the store
+		// the tracking bead this leaf stamps was created in.
+		front := m.orderFrontDoorFor(store)
 		// The exec-env overlay is namespaced by an untrusted caller (webhook);
 		// nil means use the raw vars (tick/CLI), preserving prior behavior.
 		execOverlay := execEnv
@@ -1555,6 +1543,33 @@ func (m *memoryOrderDispatcher) graphStoreFor(store beads.Store) beads.Store {
 	return resolveGraphStore(m.storageRoutes, store, m.cfg, m.cityPath, m.rec)
 }
 
+// ordersStoreFor returns the store that owns the order-tracking bead a dispatch
+// writes, given the store the tick opened for the order's target scope.
+//
+// The tracking bead is the ORDERS class — coordclass.ClassOrders is defined as
+// "order-dispatch tracking beads (the order-tracking / order-run records that
+// gate repeat order firing)" — and on a split city that class is served by a
+// different database than the order's target scope, which is a work ledger.
+// Creating tracking beads through the target store puts orders-class beads in
+// the work ledger under the work prefix, which the city's own convergence check
+// then reads as infrastructure beads stranded off their binding, and stranded is
+// fatal to boot. When the routes relocate nothing — every single-store city —
+// resolveOrderStore returns the exact store value it was handed, so the dispatch
+// stays on the one store it always used.
+func (m *memoryOrderDispatcher) ordersStoreFor(store beads.Store) beads.Store {
+	return resolveOrderStore(m.storageRoutes, store, m.cfg, m.cityPath, m.rec)
+}
+
+// orderFrontDoorFor is the tracking-bead front door for a dispatch: the orders
+// class store this city serves, wrapped as the typed order store. Every
+// tracking-bead write and read in a dispatch goes through this one constructor,
+// so the bead a dispatch creates and the bead its outcome/close writes address
+// are the same bead in the same database by construction rather than by each
+// call site remembering to route.
+func (m *memoryOrderDispatcher) orderFrontDoorFor(store beads.Store) *orders.Store {
+	return orders.NewStore(beads.OrdersStore{Store: m.ordersStoreFor(store)})
+}
+
 // graphStoreKey is the gate/cooldown cache key for the graph store. It names the
 // binding rather than the order's target scope, because one graph binding serves
 // every scope: keying it per target would read the same database once per rig.
@@ -1567,6 +1582,57 @@ func (m *memoryOrderDispatcher) graphStoreKey() string {
 		binding = "graph"
 	}
 	return "graph\x00" + binding
+}
+
+// ordersStoreKey is the gate/cooldown cache key for the orders store. Like
+// graphStoreKey it names the binding rather than the order's target scope,
+// because one orders binding serves every scope: keying it per target would read
+// the same database once per rig.
+func (m *memoryOrderDispatcher) ordersStoreKey() string {
+	binding := ""
+	if m.storageRoutes != nil {
+		binding = m.storageRoutes.binding
+	}
+	if binding == "" {
+		binding = "orders"
+	}
+	return "orders\x00" + binding
+}
+
+// gateStoresFor returns the stores an order's open-work gate, cooldown clock and
+// event cursor read, with the cache key each one is memoized under.
+//
+// It is the order's target scope, the legacy city store when a rig order needs
+// the fallback, and then the two infrastructure bindings that hold the order-run
+// evidence a dispatch itself writes:
+//
+//   - GRAPH, because a dispatched wisp root carries the order's order-run label
+//     and is created in the graph binding. A gate that misses it re-fires the
+//     order while the previous wisp is still open.
+//   - ORDERS, because the tracking bead carries the same label and IS the
+//     single-flight marker, the cooldown clock and the cursor. A gate that
+//     misses it never sees the marker its own dispatch just wrote.
+//
+// Both appends are guarded by store identity, so a city that relocates nothing
+// gates on exactly the list it always did, and the whole-split shape this build
+// serves — where one binding serves both classes — reads that binding once
+// rather than twice per order per tick.
+func (m *memoryOrderDispatcher) gateStoresFor(cityPath string, store beads.Store, storeKey string, legacyStore beads.Store) ([]beads.Store, []string) {
+	storesForGate := []beads.Store{store}
+	storeKeysForGate := []string{storeKey}
+	if legacyStore != nil {
+		storesForGate = append(storesForGate, legacyStore)
+		storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
+	}
+	if graphStore := m.graphStoreFor(store); graphStore != nil && !storeListContains(storesForGate, graphStore) {
+		storesForGate = append(storesForGate, graphStore)
+		storeKeysForGate = append(storeKeysForGate, m.graphStoreKey())
+	}
+	if ordersStore := m.ordersStoreFor(store); ordersStore != nil && !storeListContains(storesForGate, ordersStore) {
+		storesForGate = append(storesForGate, ordersStore)
+		storeKeysForGate = append(storeKeysForGate, m.ordersStoreKey())
+	}
+	return storesForGate, storeKeysForGate
 }
 
 // storeListContains reports whether stores already holds this exact store, so a
@@ -1592,7 +1658,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 			Subject: scoped,
 			Message: err.Error(),
 		})
-		orders.NewStore(beads.OrdersStore{Store: store}).SetOutcome(trackingID, orders.RunOutcomeWispCanceled) //nolint:errcheck // best-effort
+		m.orderFrontDoorFor(store).SetOutcome(trackingID, orders.RunOutcomeWispCanceled) //nolint:errcheck // best-effort
 		return
 	}
 
@@ -1737,7 +1803,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	})
 
 	// Label tracking bead with outcome.
-	orders.NewStore(beads.OrdersStore{Store: store}).SetOutcome(trackingID, orders.RunOutcomeWisp) //nolint:errcheck // best-effort
+	m.orderFrontDoorFor(store).SetOutcome(trackingID, orders.RunOutcomeWisp) //nolint:errcheck // best-effort
 }
 
 // orderRigSuspended reports whether the order targets a suspended rig.
@@ -1765,7 +1831,7 @@ func (m *memoryOrderDispatcher) markTrackingFailure(store beads.Store, trackingI
 		c := orders.EventCursor(headSeq)
 		cursor = &c
 	}
-	front := orders.NewStore(beads.OrdersStore{Store: store})
+	front := m.orderFrontDoorFor(store)
 	if err := front.MarkFailed(trackingID, scoped, orders.RunOutcomeWispFailed, cursor); err != nil {
 		logDispatchError(m.stderr, "gc: order %s: failed to mark tracking bead %s as failed: %v", scoped, trackingID, err)
 	}

--- a/cmd/gc/order_dispatch_graph_store_test.go
+++ b/cmd/gc/order_dispatch_graph_store_test.go
@@ -146,11 +146,6 @@ func TestOrderDispatchWispRootLandsInGraphStoreOnSplitCity(t *testing.T) {
 			t.Fatalf("work store holds graph bead %s (%s, gc.kind=%q); graph beads belong in the graph binding", b.ID, b.Title, kind)
 		}
 	}
-	for _, b := range allBeads(t, graphStore) {
-		if hasLabel(b.Labels, labelOrderTracking) {
-			t.Fatalf("graph store holds order-tracking bead %s; order tracking stays on the order store", b.ID)
-		}
-	}
 }
 
 // TestOrderDispatchSingleFlightGateSeesGraphResidentWisp pins the read half of
@@ -329,14 +324,12 @@ func TestOrderDispatchExecutionFactsProjectFromTheGraphStore(t *testing.T) {
 		}
 	}
 
-	// The work leg stays the order's own store, so the two classes end the
-	// dispatch in their own bindings rather than piled into one.
-	tracking := trackingBeads(t, workStore, "order-run:reaper")
-	if len(tracking) == 0 {
-		t.Fatal("no order-run tracking bead in the work store")
-	}
-	if got := trackingBeads(t, graphStore, labelOrderTracking); len(got) != 0 {
-		t.Fatalf("graph store holds order-tracking beads %+v, want none", got)
+	// The work leg is still the order's own store — it is where an input
+	// convoy's tracks edges live — but nothing the dispatch WRITES lands there
+	// on a split city: the graph class owns the root and its steps, the orders
+	// class owns the tracking bead, and both are served by the binding.
+	if got := allBeads(t, workStore); len(got) != 0 {
+		t.Fatalf("work store holds %+v after a split-city dispatch, want nothing; every bead a dispatch writes is infrastructure class and belongs in the binding", got)
 	}
 }
 

--- a/cmd/gc/order_dispatch_orders_store_test.go
+++ b/cmd/gc/order_dispatch_orders_store_test.go
@@ -627,3 +627,30 @@ func TestOrderRunRecordsItsTrackingBeadInTheOrdersBinding(t *testing.T) {
 		t.Fatalf("scope store holds order-tracking beads %+v, want none", got)
 	}
 }
+
+// TestOrderWispSweepCountsTheWrappedOrdersBindingOnce is the count-once
+// invariant of sweepStaleOrderTrackingAcrossStoresLimitMode reached through the
+// sweep's own store list. The orders binding enters that list wrapped in the
+// scope wrapper carrying its label, so an identity check against the wrapper
+// cannot see the database inside it and sweeps the binding a second time. On the
+// shape this build serves — one binding for graph and orders — that is the same
+// store as the hoisted wisp pass, and `gc order sweep-tracking --dry-run
+// --include-wisps` reports twice as much stale work as there is.
+func TestOrderWispSweepCountsTheWrappedOrdersBindingOnce(t *testing.T) {
+	binding := beads.NewMemStore()
+	root, _ := seedOrderWispSubtreeForTest(t, binding, "dolt-health")
+
+	stores := appendOrdersSweepStore(nil, binding)
+	if len(stores) != 1 {
+		t.Fatalf("sweep stores = %d, want the orders binding alone", len(stores))
+	}
+
+	now := root.CreatedAt.Add(2 * time.Hour)
+	result, err := sweepStaleOrderTrackingAcrossStoresDryRun(stores, binding, now, time.Hour, orderFilterForTest("dolt-health"), true)
+	if err != nil {
+		t.Fatalf("dry-run sweep across the wrapped binding: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("dry-run wispClosed = %d, want 2; the wrapped binding was swept twice and the operator is told twice as much work is stale as there is", result.wispClosed)
+	}
+}

--- a/cmd/gc/order_dispatch_orders_store_test.go
+++ b/cmd/gc/order_dispatch_orders_store_test.go
@@ -1,0 +1,629 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orderdispatch"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// The tests in this file cover the ORDERS coordination class the way
+// order_dispatch_graph_store_test.go covers the graph class. coordclass defines
+// ClassOrders as exactly "order-dispatch tracking beads (the order-tracking /
+// order-run records that gate repeat order firing)", so on a city whose
+// infrastructure classes are served by their own binding those beads belong in
+// the binding — not in the work ledger the order's target scope resolves to,
+// where the city's own convergence check reads them as stranded.
+//
+// The move is only safe as one change. The tracking bead is a lifecycle, not a
+// record: it is created OPEN as the single-flight marker, stamped with an
+// outcome, closed when the dispatch returns, swept when a controller dies
+// holding it, and read by the gate, the cooldown clock, the CLI and the API.
+// Moving the birth alone leaves every one of those addressing a database the
+// bead is not in — the marker never clears and the order stops firing forever,
+// which is strictly worse than the strand. So each half is pinned here.
+
+// newExecOrderFixture writes a city-scoped exec order the dispatcher can fire
+// without a formula layer, and returns the city path, config and order.
+func newExecOrderFixture(t *testing.T) (string, *config.City, orders.Order) {
+	t.Helper()
+	cityPath := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := orders.Order{
+		Name:     "dolt-health",
+		Exec:     "true",
+		Trigger:  "cooldown",
+		Interval: "15m",
+	}
+	return cityPath, cfg, a
+}
+
+// newSplitOrderDispatcher builds a dispatcher for a city whose infrastructure
+// classes are served by one binding, with the order's target scope on a separate
+// work store — the converged whole-split shape openStorageRoutes produces.
+func newSplitOrderDispatcher(t *testing.T, cityPath string, cfg *config.City, aa []orders.Order, workStore, binding beads.Store, rec events.Recorder) *memoryOrderDispatcher {
+	t.Helper()
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &memoryOrderDispatcher{
+		aa:                   aa,
+		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
+		storageRoutes:        messagingSplitRoutes(binding),
+		execRun:              func(context.Context, string, string, []string) ([]byte, error) { return nil, nil },
+		cfg:                  cfg,
+		cityName:             "test-city",
+		cityPath:             cityPath,
+		rec:                  rec,
+		stderr:               io.Discard,
+		maxDispatchesPerTick: 1,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       cancel,
+	}
+}
+
+// dispatchOrderTick fires one tick and waits for the dispatch goroutine to
+// persist its outcome.
+func dispatchOrderTick(t *testing.T, m *memoryOrderDispatcher, cityPath string) {
+	t.Helper()
+	m.dispatch(context.Background(), cityPath, time.Now())
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer drainCancel()
+	if !m.drain(drainCtx) {
+		t.Fatal("order dispatch did not drain")
+	}
+}
+
+// onlyTrackingBead returns the single order-tracking bead a store holds, failing
+// when the count is anything but one.
+func onlyTrackingBead(t *testing.T, store beads.Store) beads.Bead {
+	t.Helper()
+	found := trackingBeads(t, store, labelOrderTracking)
+	if len(found) != 1 {
+		t.Fatalf("order-tracking beads = %+v, want exactly one", found)
+	}
+	return found[0]
+}
+
+// TestOrderDispatchTrackingBeadLandsInTheOrdersBinding is the producer half.
+//
+// This is the production incident: on maintainer-city the tracking beads a
+// running controller wrote kept accruing in the work ledger at ~42/h, every one
+// of them an infrastructure-class bead outside its binding, and the city's own
+// convergence check reads that as stranded — which is fatal to boot.
+func TestOrderDispatchTrackingBeadLandsInTheOrdersBinding(t *testing.T) {
+	cityPath, cfg, a := newExecOrderFixture(t)
+	workStore := beads.NewMemStore()
+	workStore.IDPrefix = "mc"
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, []orders.Order{a}, workStore, binding, &rec)
+	dispatchOrderTick(t, m, cityPath)
+
+	tracking := onlyTrackingBead(t, binding)
+	if !hasLabel(tracking.Labels, "order-run:dolt-health") {
+		t.Fatalf("tracking bead labels = %v, want order-run:dolt-health", tracking.Labels)
+	}
+	for _, b := range allBeads(t, workStore) {
+		if hasLabel(b.Labels, labelOrderTracking) {
+			t.Fatalf("work store holds order-tracking bead %s (%s); orders-class beads outside their binding are what the convergence check reports as stranded, and stranded is fatal to boot", b.ID, b.Title)
+		}
+	}
+}
+
+// TestOrderDispatchClearsTheTrackingBeadItCreated is the lifecycle half, and it
+// is the reason the move cannot be split.
+//
+// The tracking bead is created OPEN as the single-flight marker. dispatchOne's
+// deferred close and the outcome stamp are what release it. If the birth moves
+// to the binding and those writes keep addressing the target scope, the close
+// finds nothing, the marker stays open forever, and the open-work gate
+// suppresses the order on every subsequent tick — permanently.
+func TestOrderDispatchClearsTheTrackingBeadItCreated(t *testing.T) {
+	cityPath, cfg, a := newExecOrderFixture(t)
+	workStore := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, []orders.Order{a}, workStore, binding, &rec)
+	dispatchOrderTick(t, m, cityPath)
+
+	tracking := onlyTrackingBead(t, binding)
+	if tracking.Status != "closed" {
+		t.Fatalf("tracking bead %s status = %q, want closed; an open marker in a store the close never addresses suppresses this order on every later tick, forever", tracking.ID, tracking.Status)
+	}
+	run, ok := orders.RunFromTrackingBead(tracking)
+	if !ok || run.Outcome != orders.RunOutcomeExec {
+		t.Fatalf("tracking bead labels = %v, want the exec outcome stamped on the bead the dispatch created", tracking.Labels)
+	}
+}
+
+// TestOrderDispatchWispOutcomeLandsOnTheOrdersResidentBead is the same lifecycle
+// property for the formula arm, which stamps its outcome from dispatchWisp
+// rather than dispatchExec — a separate call site, and separately revertible.
+func TestOrderDispatchWispOutcomeLandsOnTheOrdersResidentBead(t *testing.T) {
+	cityPath, cfg, a := newGraphOrderFixture(t)
+	workStore := beads.NewMemStore()
+	workStore.IDPrefix = "mc"
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, []orders.Order{a}, workStore, binding, &rec)
+	dispatchOrderTick(t, m, cityPath)
+
+	if rec.hasType(events.OrderFailed) || !rec.hasType(events.OrderCompleted) {
+		t.Fatalf("events = %+v, want completed without failure", rec.events)
+	}
+	tracking := onlyTrackingBead(t, binding)
+	run, ok := orders.RunFromTrackingBead(tracking)
+	if !ok || run.Outcome != orders.RunOutcomeWisp {
+		t.Fatalf("tracking bead labels = %v, want the wisp outcome stamped in the binding", tracking.Labels)
+	}
+	if tracking.Status != "closed" {
+		t.Fatalf("tracking bead %s status = %q, want closed", tracking.ID, tracking.Status)
+	}
+}
+
+// TestOrderDispatchTriggerEnvFailureTrackingBeadLandsInTheOrdersBinding pins the
+// third creation site: the pre-dispatch trigger-env failure deliberately leaves
+// an OPEN tracking bead so the gate suppresses repeat ticks until the stale
+// sweep retries. That bead is the most damaging one to misplace — it is designed
+// to stay open, so a sweep that cannot see it never gives the order another try.
+func TestOrderDispatchTriggerEnvFailureTrackingBeadLandsInTheOrdersBinding(t *testing.T) {
+	clearAmbientPostgresEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+
+	// A scope whose beads metadata names a Postgres backend with no reachable
+	// password: building the trigger env fails before dispatch, which is the arm
+	// that mints an open tracking bead of its own.
+	cityPath := t.TempDir()
+	writePGScopeFixture(t, cityPath, "")
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: city
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := orders.Order{Name: "pg-condition", Exec: "true", Trigger: "condition", Check: "true"}
+
+	workStore := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, []orders.Order{a}, workStore, binding, &rec)
+	m.dispatch(context.Background(), cityPath, time.Now())
+
+	tracking := onlyTrackingBead(t, binding)
+	run, ok := orders.RunFromTrackingBead(tracking)
+	if !ok || run.Outcome != orders.RunOutcomeTriggerEnvFailed {
+		t.Fatalf("tracking bead labels = %v, want the trigger-env-failed marker in the binding", tracking.Labels)
+	}
+	if !run.Open {
+		t.Fatalf("tracking bead %s is closed; the trigger-env-failure marker is deliberately left open", tracking.ID)
+	}
+	for _, b := range allBeads(t, workStore) {
+		if hasLabel(b.Labels, labelOrderTracking) {
+			t.Fatalf("work store holds order-tracking bead %s; the trigger-env-failure marker is orders class too", b.ID)
+		}
+	}
+}
+
+// TestWebhookOrderDispatchTrackingBeadLandsInTheOrdersBinding covers the seam a
+// webhook delivery fires through. It builds its own store handle per delivery
+// and calls launchResolvedDispatch directly, so it is a second entry into the
+// same creation path and would keep writing to the work ledger if the routing
+// lived at the tick loop's call site instead of inside the shared core.
+func TestWebhookOrderDispatchTrackingBeadLandsInTheOrdersBinding(t *testing.T) {
+	cityPath, cfg, a := newExecOrderFixture(t)
+	workStore := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, nil, workStore, binding, &rec)
+
+	result, err := m.Dispatch(context.Background(), orderdispatch.DispatchRequest{Order: a})
+	if err != nil {
+		t.Fatalf("webhook dispatch: %v", err)
+	}
+	if !result.Fired {
+		t.Fatalf("webhook dispatch result = %+v, want fired", result)
+	}
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer drainCancel()
+	if !m.drain(drainCtx) {
+		t.Fatal("webhook dispatch did not drain")
+	}
+
+	tracking := onlyTrackingBead(t, binding)
+	if tracking.ID != result.TrackingID {
+		t.Fatalf("binding holds tracking bead %s, want the dispatch's own %s", tracking.ID, result.TrackingID)
+	}
+	for _, b := range allBeads(t, workStore) {
+		if hasLabel(b.Labels, labelOrderTracking) {
+			t.Fatalf("work store holds order-tracking bead %s from a webhook dispatch", b.ID)
+		}
+	}
+}
+
+// TestOrderDispatchGateFederatesTheOrdersBindingExactlyOnce pins the read half
+// of the single-flight gate.
+//
+// The gate, the cooldown clock and the event cursor all read order-run evidence,
+// and after this change the tracking bead carrying it is in the binding. The
+// federation must therefore include the binding — and must include it ONCE: on
+// the whole-split shape this build serves, the graph class and the orders class
+// are the same binding, and appending it twice would read one database twice on
+// every gate of every order on every tick.
+func TestOrderDispatchGateFederatesTheOrdersBindingExactlyOnce(t *testing.T) {
+	cityPath, cfg, a := newExecOrderFixture(t)
+	workStore := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, []orders.Order{a}, workStore, binding, &rec)
+
+	if got := m.ordersStoreFor(workStore); got != beads.Store(binding) {
+		t.Fatalf("ordersStoreFor = %T(%p), want the binding %p; the tracking bead's own store is not in the gate's reach", got, got, binding)
+	}
+
+	storesForGate, storeKeysForGate := m.gateStoresFor(cityPath, workStore, "city\x00"+cityPath, nil)
+	if !storeListContains(storesForGate, beads.Store(binding)) {
+		t.Fatalf("gate store list = %+v, missing the binding the tracking bead lives in; the marker the dispatch just wrote is invisible and the order re-fires every tick", storesForGate)
+	}
+	if len(storesForGate) != 2 {
+		t.Fatalf("gate store list = %d stores, want 2 (the target scope and the one binding serving both classes); one database is being read twice for every order on every tick", len(storesForGate))
+	}
+	if len(storeKeysForGate) != len(storesForGate) {
+		t.Fatalf("gate store keys = %d for %d stores; the cooldown cache key and the store it memoizes have drifted apart", len(storeKeysForGate), len(storesForGate))
+	}
+}
+
+// TestOrderDispatchGateStaysOnTheOneStoreOnSingleStoreCity is the byte-identity
+// half: a city that relocates nothing gates on exactly the list it always did.
+func TestOrderDispatchGateStaysOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityPath, cfg, a := newExecOrderFixture(t)
+	store := beads.NewMemStore()
+
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:             []orders.Order{a},
+		storeFn:        func(execStoreTarget) (beads.Store, error) { return store, nil },
+		storageRoutes:  nil,
+		cfg:            cfg,
+		cityPath:       cityPath,
+		stderr:         io.Discard,
+		dispatchCtx:    dispatchCtx,
+		dispatchCancel: cancel,
+	}
+	storesForGate, storeKeysForGate := m.gateStoresFor(cityPath, store, "city\x00"+cityPath, nil)
+	if len(storesForGate) != 1 || storesForGate[0] != beads.Store(store) {
+		t.Fatalf("gate store list = %+v, want exactly the one store the city has", storesForGate)
+	}
+	if len(storeKeysForGate) != 1 || storeKeysForGate[0] != "city\x00"+cityPath {
+		t.Fatalf("gate store keys = %+v, want exactly the target scope key; a changed key set silently invalidates the cooldown cache", storeKeysForGate)
+	}
+}
+
+// TestOrderDispatchTrackingStaysOnTheOneStoreOnSingleStoreCity is the
+// compatibility guarantee, and it is green before and after this change by
+// design: a city that relocates nothing routes nothing. resolveOrderStore
+// returns the exact store value it was handed, so the dispatch writes the
+// tracking bead through the same instance it always did — not a re-wrapped one,
+// which would drop the optional-capability assertions the store path makes.
+func TestOrderDispatchTrackingStaysOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityPath, cfg, a := newExecOrderFixture(t)
+	store := beads.NewMemStore()
+
+	var rec memRecorder
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:                   []orders.Order{a},
+		storeFn:              func(execStoreTarget) (beads.Store, error) { return store, nil },
+		storageRoutes:        nil, // no [storage] section: every class is the work store
+		execRun:              func(context.Context, string, string, []string) ([]byte, error) { return nil, nil },
+		cfg:                  cfg,
+		cityName:             "test-city",
+		cityPath:             cityPath,
+		rec:                  &rec,
+		stderr:               io.Discard,
+		maxDispatchesPerTick: 1,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       cancel,
+	}
+	if got := m.ordersStoreFor(store); got != beads.Store(store) {
+		t.Fatalf("ordersStoreFor returned %T(%p), want the identical store value %p", got, got, store)
+	}
+	dispatchOrderTick(t, m, cityPath)
+
+	tracking := onlyTrackingBead(t, store)
+	if tracking.Status != "closed" {
+		t.Fatalf("tracking bead %s status = %q, want closed", tracking.ID, tracking.Status)
+	}
+}
+
+// TestBootOrphanSweepReachesTheOrdersBinding pins the recovery the production
+// incident actually blocks: maintainer-city could not be restarted without a
+// manual prune. A tracking bead left open by a killed controller is a permanent
+// single-flight marker, and the boot sweep is what clears it. Once the beads are
+// born in the binding, a sweep that only opens the city work store closes
+// nothing and every order that was mid-dispatch at the kill stays suppressed.
+func TestBootOrphanSweepReachesTheOrdersBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	workStore := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+
+	prev := newCityRuntimeOpenSweepStore
+	newCityRuntimeOpenSweepStore = func(string, string) (beads.Store, error) { return workStore, nil }
+	t.Cleanup(func() { newCityRuntimeOpenSweepStore = prev })
+
+	orphans := map[string]beads.Store{"binding": binding, "work store": workStore}
+	seeded := make(map[string]string, len(orphans))
+	for name, store := range orphans {
+		bead, err := store.Create(beads.Bead{
+			Title:  "order:dolt-health",
+			Labels: []string{"order-run:dolt-health", labelOrderTracking},
+		})
+		if err != nil {
+			t.Fatalf("seeding the %s orphan: %v", name, err)
+		}
+		seeded[name] = bead.ID
+	}
+
+	sweepOrphanedOrderTrackingAtBoot(messagingSplitRoutes(binding), cityPath, &config.City{Workspace: config.Workspace{Name: "test-city"}}, events.Discard, io.Discard)
+
+	for name, store := range orphans {
+		got, err := store.Get(seeded[name])
+		if err != nil {
+			t.Fatalf("reading the %s orphan back: %v", name, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("the %s orphan %s is still open after the boot sweep; its order never fires again and the city cannot be restarted without a manual prune", name, got.ID)
+		}
+	}
+}
+
+// TestOrderTrackingWatchdogsReachTheOrdersBinding pins the two controller
+// watchdogs that keep tracking beads from accumulating: the stale-close sweep
+// that recovers the #2168 jam, and the retention prune that bounds closed
+// history. Both resolve their stores from the runtime, so both go blind on a
+// split city if the resolution stays on the scope stores.
+func TestOrderTrackingWatchdogsReachTheOrdersBinding(t *testing.T) {
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+	cityStore := beads.NewMemStore()
+
+	stale, err := binding.Create(beads.Bead{
+		Title:  "order:dolt-health",
+		Labels: []string{"order-run:dolt-health", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("seeding the stale tracking bead: %v", err)
+	}
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		storageRoutes:       messagingSplitRoutes(binding),
+		standaloneCityStore: cityStore,
+		standaloneRigStores: map[string]beads.Store{},
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+	}
+
+	if got := cr.relocatedOrdersStore(); got != beads.Store(binding) {
+		t.Fatalf("relocatedOrdersStore = %T(%p), want the binding %p", got, got, binding)
+	}
+
+	now := stale.CreatedAt.Add(orderTrackingSweepWatchdogStaleAfter + time.Millisecond)
+	cr.runOrderTrackingSweepWatchdog(now)
+
+	closed, err := binding.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("reading the stale tracking bead back: %v", err)
+	}
+	if closed.Status != "closed" {
+		t.Fatalf("stale tracking bead %s status = %q, want closed; the watchdog cannot see the binding, so the tracking jam (#2168) has no recovery on a split city", closed.ID, closed.Status)
+	}
+
+	// The retention watchdog prunes closed tracking history through the same
+	// resolver, so the binding has to be in the list it is handed. Asserted on
+	// the resolver rather than by running the prune, because the prune's own
+	// gates (backup freshness, the retain-last floor) are policy this change
+	// does not touch.
+	stores, _, closeOpened, err := cr.orderTrackingSweepStores()
+	defer closeOpened()
+	if err != nil {
+		t.Fatalf("resolving the watchdog sweep stores: %v", err)
+	}
+	var reachesBinding bool
+	for _, store := range stores {
+		if unwrapOrderTrackingSweepStore(store) == beads.Store(binding) {
+			reachesBinding = true
+		}
+	}
+	if !reachesBinding {
+		t.Fatalf("watchdog sweep stores = %d, none of them the binding; the retention watchdog never prunes a split city's closed tracking history", len(stores))
+	}
+}
+
+// TestOneShotOrderReadsReachTheOrdersBinding pins the CLI read federations.
+// `gc order check` decides whether an order is due from its last run, and
+// `gc order history` lists those runs; both resolve per-order stores from the
+// order's target scope. On a split city every run they are being asked about is
+// in the binding, so a resolver that stops at the scope stores reports a city
+// whose orders fire every few minutes as never having run.
+func TestOneShotOrderReadsReachTheOrdersBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+	resetCLIStorageRoutes(t)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = messagingSplitRoutes(binding) })
+
+	a := orders.Order{Name: "dolt-health", Exec: "true", Trigger: "cooldown", Interval: "15m"}
+	run, err := binding.Create(beads.Bead{
+		Title:  "order:dolt-health",
+		Labels: []string{"order-run:dolt-health", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("seeding the run: %v", err)
+	}
+
+	for name, resolve := range map[string]orderStoresResolver{
+		"gc order check":   cachedOrderStoresResolver(cityPath, cfg),
+		"gc order history": cachedOrderHistoryStoresResolver(cityPath, cfg, io.Discard),
+	} {
+		stores, err := resolve(a)
+		if err != nil {
+			t.Fatalf("%s: resolving stores: %v", name, err)
+		}
+		last, err := orders.LastRunAcross(orderFrontDoorsForTypedStores(stores))(a.ScopedName())
+		if err != nil {
+			t.Fatalf("%s: reading last run: %v", name, err)
+		}
+		if last.IsZero() {
+			t.Fatalf("%s: last run is zero though %s is in the binding; the order reads as never run and every cooldown/cron trigger fires again immediately", name, run.ID)
+		}
+	}
+}
+
+// TestOrderSweepTrackingReachesTheOrdersBinding pins the operator-facing
+// recovery. `gc order sweep-tracking` is the documented way to clear a stuck
+// tracking bead by hand; handed only the scope stores on a split city it closes
+// nothing, reports zero and exits zero — a silent no-op at exactly the moment an
+// operator is trying to unwedge a city.
+func TestOrderSweepTrackingReachesTheOrdersBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+	resetCLIStorageRoutes(t)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = messagingSplitRoutes(binding) })
+
+	stale, err := binding.Create(beads.Bead{
+		Title:  "order:dolt-health",
+		Labels: []string{"order-run:dolt-health", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("seeding the stale tracking bead: %v", err)
+	}
+
+	stores, _, err := orderTrackingSweepStoresForConfigTargets(cityPath, cfg, nil)
+	if err != nil {
+		t.Fatalf("resolving sweep stores: %v", err)
+	}
+	result, err := sweepStaleOrderTrackingAcrossStores(stores, nil, stale.CreatedAt.Add(2*time.Hour), time.Hour, nil, false)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if result.trackingClosed == 0 {
+		t.Fatal("gc order sweep-tracking closed nothing in the binding; the documented recovery for a stuck order is a silent no-op on a split city")
+	}
+	got, err := binding.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("reading the stale bead back: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("stale tracking bead %s status = %q, want closed", got.ID, got.Status)
+	}
+}
+
+// TestOneShotOrderFederationsStayOnTheOneStoreOnSingleStoreCity is the
+// compatibility half of the one-shot changes: a city with no [storage] resolves
+// no orders binding at all, so every federation keeps exactly the stores it had.
+func TestOneShotOrderFederationsStayOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	resetCLIStorageRoutes(t)
+
+	if got := relocatedOrdersClassStore(cityPath, cfg); got != nil {
+		t.Fatalf("relocatedOrdersClassStore = %T(%p) for a city with no [storage]; want nil so every federation stays exactly as it was", got, got)
+	}
+
+	scope := beads.NewMemStore()
+	if got := appendOrdersClassStore([]beads.OrdersStore{{Store: scope}}, nil); len(got) != 1 || got[0].Store != beads.Store(scope) {
+		t.Fatalf("typed federation = %+v, want the single scope store unchanged", got)
+	}
+	if got := appendOrdersSweepStore([]beads.Store{scope}, nil); len(got) != 1 || got[0] != beads.Store(scope) {
+		t.Fatalf("sweep federation = %+v, want the single scope store unchanged", got)
+	}
+	if got := appendOrdersSweepStore([]beads.Store{scope}, scope); len(got) != 1 {
+		t.Fatalf("sweep federation = %+v, want the store it already reads added no second time", got)
+	}
+}
+
+// TestDoctorOrderTrackingRetentionCountsTheOrdersBinding pins the advisory an
+// operator reads to decide whether retention is keeping up. It counts closed
+// tracking beads, and on a split city every one of them is in the binding, so a
+// work-store-only count reports a reassuring zero on exactly the city whose
+// backlog is growing.
+func TestDoctorOrderTrackingRetentionCountsTheOrdersBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStoreFrom(700, makeClosedOrderTrackingBeads(600), nil)
+	resetCLIStorageRoutes(t)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = messagingSplitRoutes(binding) })
+
+	check := newOrderTrackingRetentionCheck(cityPath, func(string) (beads.Store, error) {
+		return beads.NewMemStore(), nil
+	})
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v (%s), want a warning: the binding holds 600 closed tracking beads and the advisory reports the work store's zero", res.Status, res.Message)
+	}
+}
+
+// TestOrderRunRecordsItsTrackingBeadInTheOrdersBinding pins the manual arm.
+// `gc order run` writes the tracking bead whose CreatedAt is the cooldown clock
+// the next controller tick reads. Written to a store the tick does not consult,
+// a manual run advances a clock nothing sees and the order re-fires immediately
+// — the #3294 failure with the stores swapped.
+func TestOrderRunRecordsItsTrackingBeadInTheOrdersBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	scope := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+	resetCLIStorageRoutes(t)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = messagingSplitRoutes(binding) })
+
+	front := orderTrackingFrontDoor(cityPath, cfg, beads.OrdersStore{Store: scope})
+	if _, err := front.CreateRun("dolt-health", orders.RunOpts{}); err != nil {
+		t.Fatalf("recording the manual run: %v", err)
+	}
+
+	if got := trackingBeads(t, binding, labelOrderTracking); len(got) != 1 {
+		t.Fatalf("binding holds %d order-tracking beads, want the manual run's own; a run recorded off the binding advances a cooldown clock nothing reads", len(got))
+	}
+	if got := trackingBeads(t, scope, labelOrderTracking); len(got) != 0 {
+		t.Fatalf("scope store holds order-tracking beads %+v, want none", got)
+	}
+}

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -554,6 +554,7 @@ func cachedOrderStoresResolver(cityPath string, cfg *config.City) orderStoresRes
 		stores[key] = store
 		return store, nil
 	}
+	ordersStore := relocatedOrdersClassStore(cityPath, cfg)
 	return func(a orders.Order) ([]beads.OrdersStore, error) {
 		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
 		if err != nil {
@@ -571,7 +572,7 @@ func cachedOrderStoresResolver(cityPath string, cfg *config.City) orderStoresRes
 			}
 			out = append(out, beads.OrdersStore{Store: legacy})
 		}
-		return out, nil
+		return appendOrdersClassStore(out, ordersStore), nil
 	}
 }
 
@@ -623,6 +624,7 @@ func orderTrackingSweepStoresForConfigTargets(cityPath string, cfg *config.City,
 	stores, err := orderTrackingSweepStoresFromTargets(targets, func(sweepTarget orderTrackingSweepTarget) (beads.Store, error) {
 		return openStoreAtForCity(sweepTarget.target.ScopeRoot, cityPath)
 	})
+	stores = appendOrdersSweepStore(stores, relocatedOrdersClassStore(cityPath, cfg))
 	return stores, orderWispSweepStore(cityPath, cfg), err
 }
 
@@ -642,6 +644,102 @@ func orderTrackingSweepStoresForConfigTargets(cityPath string, cfg *config.City,
 // a stalled wisp, and the recovery the docs name — has to look there too.
 func orderWispSweepStore(cityPath string, cfg *config.City) beads.Store {
 	return resolveGraphStore(cliStorageRoutes(cityPath), nil, cfg, cityPath, nil)
+}
+
+// relocatedOrdersClassStore returns the store this city serves the ORDERS class
+// from when [storage] relocates it, and nil when it does not.
+//
+// nil is the answer for every city that relocates nothing, and it is the signal
+// to leave a federation exactly as it was: passing a nil workStore to
+// resolveOrderStore makes the identity branch return nil rather than smuggling
+// a second copy of the work store into the list. That is what keeps the
+// single-store path byte-identical — the same shape orderWispSweepStore uses for
+// the graph class.
+//
+// Every one-shot order command needs it, because a relocated tracking bead is
+// invisible to a reader that only opens the order's target scope: `gc order
+// check` would report an order that just fired as never run, `gc order history`
+// would print nothing, and `gc order sweep-tracking` would report zero and exit
+// zero on a city whose tracking beads are all in the binding.
+func relocatedOrdersClassStore(cityPath string, cfg *config.City) beads.Store {
+	return resolveOrderStore(cliStorageRoutes(cityPath), nil, cfg, cityPath, nil)
+}
+
+// orderTrackingFrontDoor returns the front door a one-shot command writes its
+// order-tracking bead through, given the scope store it already opened.
+//
+// It is the CLI twin of memoryOrderDispatcher.orderFrontDoorFor: a manual
+// `gc order run` records the same orders-class bead a dispatched run does — the
+// one whose CreatedAt is the cooldown clock the next tick reads — so it has to
+// land in the same database, or the manual run advances a clock nothing consults
+// and the order re-fires immediately (#3294, with the stores swapped). The scope
+// store stays the caller's for everything else it does; only the tracking bead
+// routes here. On a city that relocates nothing this returns a front door over
+// the exact store value it was handed.
+func orderTrackingFrontDoor(cityPath string, cfg *config.City, scopeStore beads.OrdersStore) *orders.Store {
+	return orders.NewStore(beads.OrdersStore{
+		Store: resolveOrderStore(cliStorageRoutes(cityPath), scopeStore.Store, cfg, cityPath, nil),
+	})
+}
+
+// appendOrdersSweepStore adds the orders-class binding to a tracking sweep's
+// store list, labeled so the sweep's own diagnostics can name it.
+//
+// The scope stores stay in the list rather than being replaced. A converged
+// split city holds tracking beads in both: everything written before cutover
+// stayed in the work ledger, and the sweep is the mechanism that drains it.
+// Trading the work half for the binding half would leave those beads open
+// forever, suppressing their orders with exactly the wedge the sweep exists to
+// clear.
+func appendOrdersSweepStore(stores []beads.Store, ordersStore beads.Store) []beads.Store {
+	if ordersStore == nil {
+		return stores
+	}
+	for _, existing := range stores {
+		if unwrapOrderTrackingSweepStore(existing) == ordersStore {
+			return stores
+		}
+	}
+	return append(stores, orderTrackingSweepScopedStore{
+		Store: ordersStore,
+		label: "orders binding",
+		key:   ordersClassSweepStoreKey,
+	})
+}
+
+// ordersClassSweepStoreKey is the sweep dedup/reporting key for the orders
+// binding. It names the class rather than a scope root, because one binding
+// serves every scope; an execStoreTarget-shaped key would claim it is a city or
+// rig store, which it is not.
+const ordersClassSweepStoreKey = "orders\x00class"
+
+// unwrapOrderTrackingSweepStore returns the underlying store behind a sweep's
+// scope wrapper, so identity comparisons see the database rather than the label
+// that was attached to it.
+func unwrapOrderTrackingSweepStore(store beads.Store) beads.Store {
+	if scoped, ok := store.(orderTrackingSweepScopedStore); ok {
+		return scoped.Store
+	}
+	return store
+}
+
+// appendOrdersClassStore appends the orders-class binding to a typed federation
+// of order stores, unless the federation already reads it.
+//
+// The append is deduplicated on the underlying store value for the same reason
+// the dispatcher's gate federation is: a city that relocates nothing resolves no
+// binding at all (nil), and a city whose orders binding IS one of the scope
+// stores must read it once, not twice.
+func appendOrdersClassStore(stores []beads.OrdersStore, ordersStore beads.Store) []beads.OrdersStore {
+	if ordersStore == nil {
+		return stores
+	}
+	for _, existing := range stores {
+		if existing.Store == ordersStore {
+			return stores
+		}
+	}
+	return append(stores, beads.OrdersStore{Store: ordersStore})
 }
 
 func orderTrackingSweepStoresFromTargets(targets []orderTrackingSweepTarget, openStore func(orderTrackingSweepTarget) (beads.Store, error)) ([]beads.Store, error) {
@@ -689,6 +787,7 @@ func cachedOrderHistoryStoresResolver(cityPath string, cfg *config.City, stderr 
 		stores[key] = store
 		return store, nil
 	}
+	ordersStore := relocatedOrdersClassStore(cityPath, cfg)
 	return func(a orders.Order) ([]beads.OrdersStore, error) {
 		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
 		if err != nil {
@@ -703,11 +802,11 @@ func cachedOrderHistoryStoresResolver(cityPath string, cfg *config.City, stderr 
 			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
 			if err != nil {
 				fmt.Fprintf(stderr, "gc order history: legacy city fallback unavailable for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
-				return out, nil
+				return appendOrdersClassStore(out, ordersStore), nil
 			}
 			out = append(out, beads.OrdersStore{Store: legacy})
 		}
-		return out, nil
+		return appendOrdersClassStore(out, ordersStore), nil
 	}
 }
 

--- a/internal/api/convoy_sql.go
+++ b/internal/api/convoy_sql.go
@@ -600,11 +600,13 @@ func workflowSQLRouteCandidate(state State, prefix string) (workflowSQLStoreCand
 }
 
 func workflowStorePath(state State, info workflowStoreInfo) (string, bool) {
-	// The dedicated graph store lives at its own legacy .gc/ location (or a gcg
-	// Postgres schema), not at a rig/city path derivable here, so it has no
-	// rig-path-derived SQL fast-path candidate. Skip it; the slow store-scan in
-	// buildWorkflowSnapshot consults the graph store directly.
-	if strings.HasPrefix(strings.TrimSpace(info.ref), workflowGraphStoreRefPrefix+":") {
+	// A class ref names a storage binding, not a scope root: the graph and orders
+	// bindings live at their own legacy .gc/ location (or a gcg Postgres schema),
+	// not at a rig/city path derivable here. They carry the city scope as their
+	// fallback, so answering the city path here would run the SQL fast path against
+	// the wrong database. Skip them; the slow store-scan reads the binding directly.
+	ref := strings.TrimSpace(info.ref)
+	if strings.HasPrefix(ref, workflowGraphStoreRefPrefix+":") || strings.HasPrefix(ref, ordersClassStoreRefPrefix+":") {
 		return "", false
 	}
 	switch strings.TrimSpace(info.scopeKind) {

--- a/internal/api/dashport_support.go
+++ b/internal/api/dashport_support.go
@@ -246,9 +246,9 @@ func (s *seededState) ScopedStoreLike(context.Context, beads.Store) (beads.Store
 	return nil, nil
 }
 
-// NudgesBeadStore, SessionsBeadStore, and GraphBeadStore all collapse to the
-// city store on a seeded single-store city, exactly as they do on a default
-// (non-relocated) controller city.
+// NudgesBeadStore, SessionsBeadStore, GraphBeadStore and OrdersBeadStore all
+// collapse to the city store on a seeded single-store city, exactly as they do
+// on a default (non-relocated) controller city.
 func (s *seededState) NudgesBeadStore() beads.NudgesStore {
 	return beads.NudgesStore{Store: s.cityStore}
 }
@@ -259,6 +259,10 @@ func (s *seededState) SessionsBeadStore() beads.SessionStore {
 
 func (s *seededState) GraphBeadStore() beads.GraphStore {
 	return beads.GraphStore{Store: s.cityStore}
+}
+
+func (s *seededState) OrdersBeadStore() beads.OrdersStore {
+	return beads.OrdersStore{Store: s.cityStore}
 }
 
 func (s *seededState) Orders() []orders.Order    { return nil }

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -45,6 +45,7 @@ type fakeState struct {
 	nudgesBeadStore   beads.Store // relocated nudges store; nil falls back to cityBeadStore (default backend)
 	sessionsBeadStore beads.Store // relocated sessions store; nil falls back to cityBeadStore (default backend)
 	graphBeadStore    beads.Store // relocated graph store; nil falls back to cityBeadStore (default backend)
+	ordersBeadStore   beads.Store // relocated orders store; nil falls back to cityBeadStore (default backend)
 	cityBeadsDiag     *beads.BeadsDiagnostic
 	cityMailProv      mail.Provider // city-level mail provider (all mail is city-scoped)
 	eventProv         events.Provider
@@ -154,6 +155,13 @@ func (f *fakeState) GraphBeadStore() beads.GraphStore {
 		return beads.GraphStore{Store: f.graphBeadStore}
 	}
 	return beads.GraphStore{Store: f.cityBeadStore}
+}
+
+func (f *fakeState) OrdersBeadStore() beads.OrdersStore {
+	if f.ordersBeadStore != nil {
+		return beads.OrdersStore{Store: f.ordersBeadStore}
+	}
+	return beads.OrdersStore{Store: f.cityBeadStore}
 }
 
 func (f *fakeState) CityBeadsDiagnostic() *beads.BeadsDiagnostic {

--- a/internal/api/handler_convoy_dispatch.go
+++ b/internal/api/handler_convoy_dispatch.go
@@ -654,6 +654,23 @@ func workflowStoreByRef(state State, ref string) (workflowStoreInfo, bool) {
 			scopeRef:  cityName,
 			store:     graphStore,
 		}, true
+	case ordersClassStoreRefPrefix:
+		// Round-trip the orders-class ref minted by appendOrdersClassStoreInfo: the
+		// order history list hands it to a client as the store_ref for every
+		// binding-resident tracking bead, and the detail endpoint takes it back. On
+		// a default city (orders == city) there is no orders entry to name, so this
+		// resolves nothing and callers fall back to the store scan.
+		ordersStore := state.OrdersBeadStore().Store
+		cityName := workflowCityScopeRef(state.CityName())
+		if ordersStore == nil || ordersStore == state.CityBeadStore() || scopeRef != cityName {
+			return workflowStoreInfo{}, false
+		}
+		return workflowStoreInfo{
+			ref:       ordersClassStoreRefPrefix + ":" + cityName,
+			scopeKind: beadmeta.ScopeKindCity,
+			scopeRef:  cityName,
+			store:     ordersStore,
+		}, true
 	case beadmeta.ScopeKindRig:
 		store := state.BeadStore(scopeRef)
 		if store == nil {

--- a/internal/api/handler_convoy_dispatch_test.go
+++ b/internal/api/handler_convoy_dispatch_test.go
@@ -647,6 +647,64 @@ func TestWorkflowStoreByRef(t *testing.T) {
 	if _, ok := workflowStoreByRef(state, "rig:missing"); ok {
 		t.Fatal("workflowStoreByRef(rig:missing) = true, want false")
 	}
+
+	// A city that relocates nothing has no orders binding to name: OrdersBeadStore()
+	// is the city store, and an orders: ref there would be a second name for a store
+	// the city: ref already resolves.
+	if _, ok := workflowStoreByRef(state, "orders:city"); ok {
+		t.Fatal("workflowStoreByRef(orders:city) on a single-store city = true, want false")
+	}
+}
+
+// TestWorkflowStoreByRefResolvesTheOrdersBinding covers the class ref the order
+// history list mints. A ref one endpoint publishes and its sibling cannot resolve
+// is a 404 on a bead that exists.
+func TestWorkflowStoreByRefResolvesTheOrdersBinding(t *testing.T) {
+	state := newFakeState(t)
+	state.cityName = "bright-lights"
+	state.cityBeadStore = beads.NewMemStore()
+	binding := beads.NewMemStore()
+	state.ordersBeadStore = binding
+	state.stores = nil
+	state.cfg.Rigs = nil
+
+	info, ok := workflowStoreByRef(state, "orders:bright-lights")
+	if !ok {
+		t.Fatal("workflowStoreByRef(orders:bright-lights) = false, want true")
+	}
+	if info.ref != "orders:bright-lights" || info.scopeKind != "city" || info.scopeRef != "bright-lights" {
+		t.Fatalf("orders info = %+v, want orders:bright-lights", info)
+	}
+	if info.store != beads.Store(binding) {
+		t.Fatal("orders store mismatch")
+	}
+
+	if _, ok := workflowStoreByRef(state, "orders:other-city"); ok {
+		t.Fatal("workflowStoreByRef(orders:other-city) = true, want false")
+	}
+}
+
+// TestWorkflowStorePathSkipsClassRefs pins that a class ref — one naming a
+// binding rather than a scope root — yields no rig/city path to run SQL against.
+// Answering the city path for the orders binding would point the workflow SQL
+// fast path at the wrong database.
+func TestWorkflowStorePathSkipsClassRefs(t *testing.T) {
+	state := newFakeState(t)
+	state.cityName = "bright-lights"
+	state.cityPath = t.TempDir()
+	state.cityBeadStore = beads.NewMemStore()
+
+	for _, ref := range []string{"graph:bright-lights", "orders:bright-lights"} {
+		info := workflowStoreInfo{
+			ref:       ref,
+			scopeKind: beadmeta.ScopeKindCity,
+			scopeRef:  "bright-lights",
+			store:     beads.NewMemStore(),
+		}
+		if path, ok := workflowStorePath(state, info); ok {
+			t.Fatalf("workflowStorePath(%q) = %q, true; want no path", ref, path)
+		}
+	}
 }
 
 func TestWorkflowStoresSkipsCityStoreEntriesFromBeadStoreMap(t *testing.T) {

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -301,7 +301,12 @@ func (s *Server) humaHandleOrderHistoryDetail(_ context.Context, input *OrderHis
 	Body orderHistoryDetailResponse
 }, error,
 ) {
-	storeInfos := workflowStores(s.state)
+	// The bead this reads is an order-tracking bead, which on a split city lives in
+	// the orders binding. workflowStores leads with the GRAPH binding, so without
+	// the orders leg this only finds one because the shape this build serves
+	// happens to serve both classes from one store — the co-residency the feed
+	// already refuses to rely on.
+	storeInfos := appendOrdersClassStoreInfo(workflowStores(s.state), s.state, workflowCityScopeRef(s.state.CityName()))
 	if input.StoreRef != "" {
 		info, ok := workflowStoreByRef(s.state, input.StoreRef)
 		if !ok {

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -371,10 +371,48 @@ func orderStoreInfosForState(state State, a orders.Order) ([]workflowStoreInfo, 
 		})
 	}
 
+	infos = appendOrdersClassStoreInfo(infos, state, cityName)
+
 	if len(infos) == 0 {
 		return nil, errNoOrderStores
 	}
 	return infos, nil
+}
+
+// ordersClassStoreRefPrefix distinguishes the orders binding from the scope
+// stores in a store_ref. It names the class rather than a scope because one
+// binding serves every scope, and a ref that claimed a scope would tell an
+// operator to look in the wrong database.
+const ordersClassStoreRefPrefix = "orders"
+
+// appendOrdersClassStoreInfo adds the orders-class binding to an order read's
+// store list, unless the list already reads it.
+//
+// The controller creates every order-tracking bead in this store, so a read that
+// skips it reports a split city's orders as never having run — `gc order check`
+// through the API sees no last run and calls a just-fired order due, and
+// `gc order history` returns nothing. The scope stores stay in the list because a
+// converged city holds the pre-cutover history in them.
+//
+// Skipped whenever the binding is one of the stores already present, which is
+// every city that relocates nothing: OrdersBeadStore() == CityBeadStore() there,
+// so the read stays byte-identical rather than scanning one database twice.
+func appendOrdersClassStoreInfo(infos []workflowStoreInfo, state State, cityName string) []workflowStoreInfo {
+	ordersStore := state.OrdersBeadStore().Store
+	if ordersStore == nil {
+		return infos
+	}
+	for _, info := range infos {
+		if info.store == ordersStore {
+			return infos
+		}
+	}
+	return append(infos, workflowStoreInfo{
+		ref:       ordersClassStoreRefPrefix + ":" + cityName,
+		scopeKind: beadmeta.ScopeKindCity,
+		scopeRef:  cityName,
+		store:     ordersStore,
+	})
 }
 
 // orderFrontDoorsFromWorkflowInfos wraps the order read path's store infos as

--- a/internal/api/orders_class_store_test.go
+++ b/internal/api/orders_class_store_test.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -130,5 +134,212 @@ func TestOrderFeedCountsAStoreServingBothClassesOnce(t *testing.T) {
 	}
 	if seen != 1 {
 		t.Fatalf("tracking bead %s appears %d times in the feed, want 1", tracking.ID, seen)
+	}
+}
+
+// seedClosedOrderRunBead writes one closed order-tracking bead carrying captured
+// exec output, the shape the history endpoints read.
+func seedClosedOrderRunBead(t *testing.T, store beads.Store, scoped, output string) beads.Bead {
+	t.Helper()
+	bead, err := store.Create(beads.Bead{
+		Title:    "order:" + scoped,
+		Status:   "closed",
+		Labels:   []string{"order-run:" + scoped, "order-tracking"},
+		Metadata: map[string]string{"convergence.gate_stdout": output},
+	})
+	if err != nil {
+		t.Fatalf("seeding the closed tracking bead: %v", err)
+	}
+	return bead
+}
+
+// orderHistoryListStoreRef drives GET /orders/history and returns the single
+// entry's bead ID and store_ref — the handle the endpoint tells a client to use.
+func orderHistoryListStoreRef(t *testing.T, h http.Handler, fs *fakeState, scoped string) (string, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name="+scoped), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var listResp struct {
+		Entries []struct {
+			BeadID   string `json:"bead_id"`
+			StoreRef string `json:"store_ref"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(listResp.Entries) != 1 {
+		t.Fatalf("list entries = %+v, want exactly 1", listResp.Entries)
+	}
+	return listResp.Entries[0].BeadID, listResp.Entries[0].StoreRef
+}
+
+type orderHistoryDetailBody struct {
+	BeadID   string `json:"bead_id"`
+	StoreRef string `json:"store_ref"`
+	Output   string `json:"output"`
+}
+
+// orderHistoryDetail drives GET /order/history/{bead_id}, appending store_ref
+// when one is supplied, and returns the status and decoded body.
+func orderHistoryDetail(t *testing.T, h http.Handler, fs *fakeState, beadID, storeRef string) (int, orderHistoryDetailBody) {
+	t.Helper()
+	path := "/order/history/" + beadID
+	if storeRef != "" {
+		path += "?store_ref=" + url.QueryEscape(storeRef)
+	}
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, path), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	var body orderHistoryDetailBody
+	if w.Code == http.StatusOK {
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal detail: %v", err)
+		}
+	}
+	return w.Code, body
+}
+
+// splitOrdersFakeState builds the production split shape: the work ledger holds
+// the city's own beads and ONE binding serves both the graph and orders classes,
+// which is the only split a city boots with (storageSplitWhole assigns the same
+// store value to every relocated class).
+func splitOrdersFakeState(t *testing.T) (*fakeState, beads.Store) {
+	t.Helper()
+	binding := beads.NewMemStore()
+
+	st := newFakeState(t)
+	st.cityBeadStore = beads.NewMemStore()
+	st.graphBeadStore = binding
+	st.ordersBeadStore = binding
+	st.stores = nil
+	st.cfg.Rigs = nil
+	return st, binding
+}
+
+// TestOrderHistoryListStoreRefRoundTripsToDetail is the list->detail contract:
+// the store_ref the list hands a client is the handle the detail endpoint takes
+// back. An endpoint that mints a ref its sibling rejects answers 404 for every
+// order run on a split city — every run after cutover.
+func TestOrderHistoryListStoreRefRoundTripsToDetail(t *testing.T) {
+	st, binding := splitOrdersFakeState(t)
+	seedClosedOrderRunBead(t, binding, "nightly-review", "binding output")
+
+	h := newTestCityHandler(t, st)
+	beadID, listRef := orderHistoryListStoreRef(t, h, st, "nightly-review")
+
+	code, body := orderHistoryDetail(t, h, st, beadID, listRef)
+	if code != http.StatusOK {
+		t.Fatalf("detail status for the list's own store_ref %q = %d, want %d", listRef, code, http.StatusOK)
+	}
+	if body.BeadID != beadID {
+		t.Fatalf("detail bead_id = %q, want %q", body.BeadID, beadID)
+	}
+	if body.Output != "binding output" {
+		t.Fatalf("detail output = %q, want %q", body.Output, "binding output")
+	}
+	if body.StoreRef != listRef {
+		t.Fatalf("detail store_ref = %q, want the list's %q; one bead must not carry two names", body.StoreRef, listRef)
+	}
+}
+
+// TestOrderHistoryDetailReachesTheOrdersBindingDirectly pins the second half of
+// the fix: the detail read reaches the orders class itself rather than through
+// the graph binding it happens to share a store with today.
+func TestOrderHistoryDetailReachesTheOrdersBindingDirectly(t *testing.T) {
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+
+	st := newFakeState(t)
+	st.cityBeadStore = work
+	st.ordersBeadStore = binding // orders relocated, graph left on the work store
+	st.stores = nil
+	st.cfg.Rigs = nil
+
+	tracking := seedClosedOrderRunBead(t, binding, "dolt-health", "binding output")
+
+	h := newTestCityHandler(t, st)
+	code, body := orderHistoryDetail(t, h, st, tracking.ID, "")
+	if code != http.StatusOK {
+		t.Fatalf("detail status without store_ref = %d, want %d; the read never opened the orders binding", code, http.StatusOK)
+	}
+	if body.Output != "binding output" {
+		t.Fatalf("detail output = %q, want %q", body.Output, "binding output")
+	}
+}
+
+// TestOrderHistoryStoreRefsAllResolveToTheSameStore holds the invariant the 404
+// broke: every store_ref the order endpoints publish for one bead resolves, and
+// resolves to the database that bead is actually in.
+func TestOrderHistoryStoreRefsAllResolveToTheSameStore(t *testing.T) {
+	st, binding := splitOrdersFakeState(t)
+	tracking := seedClosedOrderRunBead(t, binding, "nightly-review", "binding output")
+
+	h := newTestCityHandler(t, st)
+	_, listRef := orderHistoryListStoreRef(t, h, st, "nightly-review")
+	_, detailBody := orderHistoryDetail(t, h, st, tracking.ID, "")
+
+	feed, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()))
+	if err != nil {
+		t.Fatalf("buildOrderRunFeedItems: %v", err)
+	}
+	feedRef := ""
+	for _, item := range feed.Items {
+		if item.BeadID == tracking.ID {
+			feedRef = item.StoreRef
+		}
+	}
+	if feedRef == "" {
+		t.Fatalf("feed items = %+v, want the binding-resident tracking bead %s", feed.Items, tracking.ID)
+	}
+
+	for _, ref := range []string{listRef, detailBody.StoreRef, feedRef} {
+		info, ok := workflowStoreByRef(st, ref)
+		if !ok {
+			t.Fatalf("workflowStoreByRef(%q) = false; an order endpoint published a ref no reader resolves", ref)
+		}
+		if info.store != binding {
+			t.Fatalf("workflowStoreByRef(%q) resolved to a store other than the bead's own binding", ref)
+		}
+	}
+}
+
+// TestOrderHistoryStoreRefUnchangedOnSingleStoreCity is the compatibility half:
+// a city that relocates nothing publishes the same city:<name> ref it always
+// did, and that ref still round-trips.
+func TestOrderHistoryStoreRefUnchangedOnSingleStoreCity(t *testing.T) {
+	city := beads.NewMemStore()
+
+	st := newFakeState(t)
+	st.cityBeadStore = city
+	st.stores = nil
+	st.cfg.Rigs = nil
+
+	seedClosedOrderRunBead(t, city, "weekly-audit", "city output")
+
+	h := newTestCityHandler(t, st)
+	beadID, listRef := orderHistoryListStoreRef(t, h, st, "weekly-audit")
+	if listRef != "city:test-city" {
+		t.Fatalf("list store_ref = %q, want city:test-city", listRef)
+	}
+
+	code, body := orderHistoryDetail(t, h, st, beadID, listRef)
+	if code != http.StatusOK {
+		t.Fatalf("detail status = %d, want %d", code, http.StatusOK)
+	}
+	if body.StoreRef != "city:test-city" || body.Output != "city output" {
+		t.Fatalf("detail = %+v, want city:test-city / city output", body)
+	}
+
+	code, body = orderHistoryDetail(t, h, st, beadID, "")
+	if code != http.StatusOK {
+		t.Fatalf("detail status without store_ref = %d, want %d", code, http.StatusOK)
+	}
+	if body.StoreRef != "city:test-city" {
+		t.Fatalf("detail store_ref without a hint = %q, want city:test-city", body.StoreRef)
 	}
 }

--- a/internal/api/orders_class_store_test.go
+++ b/internal/api/orders_class_store_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// The order-tracking bead is orders class, and on a city whose infrastructure
+// classes are served by their own binding the controller creates it there. Every
+// API read of those beads therefore has to reach the binding: the check/history
+// edge through orderStoreInfosForState, and the monitor feed through its own
+// store list. Reading only the work stores reports a city whose orders fire every
+// few minutes as having no runs at all.
+
+// seedOrdersTrackingBead writes one open order-tracking bead into store.
+func seedOrdersTrackingBead(t *testing.T, store beads.Store, scoped string) beads.Bead {
+	t.Helper()
+	bead, err := store.Create(beads.Bead{
+		Title:  "order:" + scoped,
+		Labels: []string{"order-run:" + scoped, "order-tracking"},
+	})
+	if err != nil {
+		t.Fatalf("seeding the tracking bead: %v", err)
+	}
+	return bead
+}
+
+// TestOrderStoreInfosReachTheOrdersBinding pins the check/history read path.
+func TestOrderStoreInfosReachTheOrdersBinding(t *testing.T) {
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+
+	st := newFakeState(t)
+	st.cityBeadStore = work
+	st.ordersBeadStore = binding
+	st.stores = nil
+	st.cfg.Rigs = nil
+
+	infos, err := orderStoreInfosForState(st, orders.Order{Name: "dolt-health"})
+	if err != nil {
+		t.Fatalf("orderStoreInfosForState: %v", err)
+	}
+	var reachesBinding bool
+	for _, info := range infos {
+		if info.store == beads.Store(binding) {
+			reachesBinding = true
+		}
+	}
+	if !reachesBinding {
+		t.Fatalf("order store infos = %+v, none of them the orders binding; the API reports a split city's orders as never run and calls a just-fired order due", infos)
+	}
+}
+
+// TestOrderStoreInfosStayOnTheOneStoreOnSingleStoreCity is the compatibility
+// half: with OrdersBeadStore() == CityBeadStore() — every city that relocates
+// nothing — the list is exactly the one it always was, so the read does not scan
+// one database twice.
+func TestOrderStoreInfosStayOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	city := beads.NewMemStore()
+
+	st := newFakeState(t)
+	st.cityBeadStore = city
+	st.stores = nil
+	st.cfg.Rigs = nil
+
+	infos, err := orderStoreInfosForState(st, orders.Order{Name: "dolt-health"})
+	if err != nil {
+		t.Fatalf("orderStoreInfosForState: %v", err)
+	}
+	if len(infos) != 1 || infos[0].store != beads.Store(city) {
+		t.Fatalf("order store infos = %+v, want exactly the city store", infos)
+	}
+}
+
+// TestOrderFeedListsTrackingBeadsFromTheOrdersBinding pins the monitor feed.
+// It builds its store list from the workflow scan (which leads with the GRAPH
+// binding), so the orders leg is a distinct decision and a distinct revert.
+func TestOrderFeedListsTrackingBeadsFromTheOrdersBinding(t *testing.T) {
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+
+	st := newFakeState(t)
+	st.cityBeadStore = work
+	st.ordersBeadStore = binding
+	st.stores = nil
+	st.cfg.Rigs = nil
+
+	tracking := seedOrdersTrackingBead(t, binding, "dolt-health")
+
+	result, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()))
+	if err != nil {
+		t.Fatalf("buildOrderRunFeedItems: %v", err)
+	}
+	var found bool
+	for _, item := range result.Items {
+		if item.BeadID == tracking.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("order feed items = %+v, want the binding-resident tracking bead %s; the dashboard shows no order activity at all on a split city", result.Items, tracking.ID)
+	}
+}
+
+// TestOrderFeedCountsAStoreServingBothClassesOnce is the byte-identity half:
+// a city that relocates nothing lists each tracking bead exactly once, rather
+// than once per store list entry that happens to resolve to the same database.
+func TestOrderFeedCountsAStoreServingBothClassesOnce(t *testing.T) {
+	city := beads.NewMemStore()
+
+	st := newFakeState(t)
+	st.cityBeadStore = city
+	st.stores = nil
+	st.cfg.Rigs = nil
+
+	tracking := seedOrdersTrackingBead(t, city, "dolt-health")
+
+	result, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()))
+	if err != nil {
+		t.Fatalf("buildOrderRunFeedItems: %v", err)
+	}
+	var seen int
+	for _, item := range result.Items {
+		if item.BeadID == tracking.ID {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("tracking bead %s appears %d times in the feed, want 1", tracking.ID, seen)
+	}
+}

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -336,7 +336,13 @@ func listActiveWorkflowProjectionBeads(store beads.Store) ([]beads.Bead, error) 
 }
 
 func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef string) (orderRunFeedResult, error) {
-	stores := workflowStores(state)
+	// The feed lists order-tracking beads, which are orders class and live in
+	// the orders binding on a split city. workflowStores leads with the GRAPH
+	// binding (its own callers scan workflow roots), so on a city that relocates
+	// only graph the tracking beads would still be missed; the orders leg is
+	// appended here and deduplicated, so a city that serves both classes from
+	// one binding — the shape this build supports — reads it once.
+	stores := appendOrdersClassStoreInfo(workflowStores(state), state, workflowCityScopeRef(state.CityName()))
 	allOrders := state.OrdersAll()
 	orderByScopedName := make(map[string]orders.Order, len(allOrders))
 	for _, order := range allOrders {

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -159,6 +159,18 @@ type State interface {
 	// store is available.
 	GraphBeadStore() beads.GraphStore
 
+	// OrdersBeadStore returns the store backing orders-class beads — the
+	// order-tracking / order-run records that gate repeat order firing. At the
+	// default backend this is the same store as CityBeadStore; when
+	// [beads.classes.orders] is relocated it is the per-class store, which is
+	// where the controller now creates every tracking bead. Without this
+	// accessor the API layer is structurally unable to route orders: the order
+	// feed and the check/history reads would scan the work store and report a
+	// split city's orders as never having run. The strongly-typed
+	// beads.OrdersStore return makes the orders class statically visible at the
+	// call site; its embedded .Store is nil when no store is available.
+	OrdersBeadStore() beads.OrdersStore
+
 	// Orders returns the current active set of scanned orders.
 	// Returns nil if orders are not configured.
 	Orders() []orders.Order


### PR DESCRIPTION
## Problem

On a city whose infrastructure classes are served by their own storage binding, **every order-tracking bead the controller writes is born in the WORK ledger and minted under the WORK prefix.**

`internal/coordclass/class.go` defines `ClassOrders` as exactly *"order-dispatch tracking beads (the order-tracking / order-run records that gate repeat order firing)"*. maintainer-city routes `orders -> infra`, so those beads belong in the infra binding. The city's own convergence check reads a `ClassOrders` bead sitting in the source work store as **stranded** — and stranded is **fatal to boot**.

#5106 fixed the wisp roots and drew the boundary explicitly in its own description: *"roots as ClassGraph), while the order-tracking bead `storeFn` opens stays on the order/work side."* That left the dominant case in place.

### Measured on maintainer-city tonight

Running `76123b700a`, with all four recent storage fixes verified as ancestors:

| Signal | Before #5106 | After #5106 (`76123b700a`) |
|---|---|---|
| Stranded infra beads accruing | ~41/h | **~42/h** — essentially unchanged |

Control group, same night:

- With the controller **DOWN**, the stranded count held at **0 for 21 minutes**.
- Within **46 minutes** of the controller running it went **0 -> 32**.

And the composition of the strand:

- Of **28** beads pruned tonight, **1** was a wisp root (#5106's case) and **27** were order-tracking beads.

A representative one: `mc-wisp-4t3`, title `order:dolt-health`, labels `['exec', 'order-run:dolt-health', 'order-tracking']`, `created_by=controller`, non-ephemeral. Work-store prefix, orders class, created after convergence.

Because strands are fatal to boot, this is also why **the city cannot be restarted without a manual prune first.**

## Fix

Route order-tracking / order-run bead creation — and every reader, sweeper and projection of those beads — through the ORDERS-class store, exactly as #5106 did for graph-class wisp roots. The resolver already existed (`resolveOrderStore`); nothing in `internal/coordclass`, the stranded check, or the boot verdict changes.

## Why this had to be one change

This work was deliberately deferred once, and #5106's own follow-up list says why: *"Landing the birth alone would make open tracking beads invisible, the single-flight marker would never clear, and orders would stop firing permanently — strictly worse than the symptom this PR fixes."*

The tracking bead is not a record, it is a **lifecycle**. It is created OPEN as the single-flight marker; its `CreatedAt` is the cooldown clock; its labels carry the event cursor; an outcome is stamped on it; it is closed when the dispatch returns; a watchdog closes it when a controller dies holding it; and the CLI, the doctor and the API all read it. Move the birth without the rest and every one of those addresses a database the bead is not in. The close finds nothing, the marker never clears, the open-work gate suppresses the order — **permanently, for every order.**

So the writer and every reader move together, and each half is pinned by a test that fails when only that half is reverted.

## Reader / writer enumeration

Every site that writes or reads an order-tracking bead, and what it addresses now.

### Writers

| Site | Operation | Before | Now |
|---|---|---|---|
| `cmd/gc/order_dispatch.go` `dispatch()` trigger-env failure | `CreateRun` (open, `trigger-env-failed`) | order's target scope | orders class |
| `cmd/gc/order_dispatch.go` `launchResolvedDispatch` (tick **and** webhook seam) | `CreateRun` (open single-flight marker) | order's target scope | orders class |
| `cmd/gc/order_dispatch.go` `dispatchOne` deferred close | `CloseRuns` | order's target scope | orders class |
| `cmd/gc/order_dispatch.go` `dispatchOne` -> `dispatchExec` front door | `SetOutcome` / `SetCursor` | order's target scope | orders class |
| `cmd/gc/order_dispatch.go` `dispatchWisp` canceled | `SetOutcome(wisp-canceled)` | order's target scope | orders class |
| `cmd/gc/order_dispatch.go` `dispatchWisp` success | `SetOutcome(wisp)` | order's target scope | orders class |
| `cmd/gc/order_dispatch.go` `markTrackingFailure` | `MarkFailed` | order's target scope | orders class |
| `cmd/gc/cmd_order.go` `gc order run` (exec, tracked) | `CreateRun` + `SetCursor` + `SetOutcome` + `CloseRun` | scope store | orders class |
| `cmd/gc/cmd_order.go` `gc order run` (formula) | `CreateRunClosed` (cooldown marker) | scope store | orders class |

All nine route through one of two constructors — `memoryOrderDispatcher.orderFrontDoorFor` and `orderTrackingFrontDoor` — so the bead a dispatch creates and the bead its outcome/close addresses are the same bead by construction, not by each call site remembering.

### Sweepers (close / delete)

| Site | Selection | Before | Now |
|---|---|---|---|
| `cmd/gc/city_runtime.go` boot orphan sweep (`sweepOrphanedOrderTrackingAtBoot`) | `OrphanedOpenRuns` + close | city work store | city work store **+** orders binding |
| `cmd/gc/city_runtime.go` `runOrderTrackingSweepWatchdog` | `StaleOpenRuns` + close | scope stores | scope stores **+** orders binding |
| `cmd/gc/city_runtime.go` `runOrderTrackingRetentionWatchdog` | `ClosedRunsForRetention` + delete | scope stores | scope stores **+** orders binding |
| `cmd/gc/cmd_order.go` `gc order sweep-tracking` (stale close, retention prune, confirm-gate count) | via `orderTrackingSweepStoresForConfigTargets` | scope stores | scope stores **+** orders binding |

The scope stores stay in every one of these lists. A converged city holds pre-cutover tracking beads in the work ledger, and the sweeps are what drain them; trading the work half for the binding half would leave those open forever.

### Readers

| Site | Read | Before | Now |
|---|---|---|---|
| `cmd/gc/order_dispatch.go` open-work gate | `OpenRuns` via the tracking index | gate federation | gate federation **+** orders leg |
| `cmd/gc/order_dispatch.go` cooldown clock | `RecentRunsAll`, `LastRunAcross` | gate federation | gate federation **+** orders leg |
| `cmd/gc/order_dispatch.go` event cursor | `CursorAcross`, `bdCursorAcrossStores` | gate federation | gate federation **+** orders leg |
| `cmd/gc/order_dispatch.go` single-flight | `HasOpenWork` via `hasOpenWorkInStoresStrict` | gate federation | gate federation **+** orders leg |
| `cmd/gc/cmd_order.go` `gc order check` (and the `gc doctor` order-firing check, same resolver) | `cachedOrderStoresResolver` | scope stores | scope stores **+** orders binding |
| `cmd/gc/cmd_order.go` `gc order history` | `cachedOrderHistoryStoresResolver` -> `RecentRuns` | scope stores | scope stores **+** orders binding |
| `cmd/gc/city_runtime.go` `warnIfClosedOrderTrackingBacklogLarge` | closed-count boot advisory | city work store | city work store **+** orders binding, counted together |
| `cmd/gc/doctor_order_tracking_retention.go` | closed-count doctor advisory | city work store | city work store **+** orders binding |
| `internal/api/huma_handlers_orders.go` `orderStoreInfosForState` (order check, order history list) | `workflowStoreInfo` list | rig + city | rig + city **+** orders binding |
| `internal/api/huma_handlers_orders.go` `humaHandleOrderHistoryDetail` (order history detail) | `workflowStores` + `workflowStoreByRef` | graph + city + rigs | graph + city + rigs **+** orders binding |
| `internal/api/orders_feed.go` `buildOrderRunFeedItems` | `ListTracking`, `LatestOpenRun` | `workflowStores` | `workflowStores` **+** orders binding |

The API half needed a new accessor: `State` exposed no `OrdersBeadStore()`, so `internal/api` was **structurally unable** to route orders. It is added here alongside the existing `GraphBeadStore` / `SessionsBeadStore` / `NudgesBeadStore` accessors, implemented on `controllerState` (which now shares one resolver with the controller's own `ordersBeadStore`), on `seededState`, and on the API test fake.

### Deliberately unchanged, with reasons

- **`hasOpenWorkStrict`'s `orders.NewStoreWithGraph(store, store)`** — this is the PER-STORE predicate the federation applies to each member in turn. Both legs are that member by design; the class union comes from the federation, and splitting the legs here would read each database twice.
- **`orderLastRunFn` (`cmd_order.go`)** — has no production caller; it is reachable only from a test.
- **`internal/storebinding/beads_adapter.go`** — constructs `orders.NewStore` over the binding's own store, already class-correct.
- **`internal/coordclass`, the stranded check, the boot verdict** — untouched, as required.

## Tests

New: `cmd/gc/order_dispatch_orders_store_test.go` (16 tests) and `internal/api/orders_class_store_test.go` (8 tests), plus two cases added to `internal/api/handler_convoy_dispatch_test.go` and one to `cmd/gc/city_runtime_test.go`.

Two assertions in `cmd/gc/order_dispatch_graph_store_test.go` are updated rather than kept: they pinned #5106's boundary (*"order tracking stays on the order store"*), which is precisely the boundary this change moves. One of them becomes the stronger statement — on a split city the work store ends a dispatch holding **nothing at all**, because every bead a dispatch writes is infrastructure class.

### Red-before evidence

Each row reverts exactly one production routing decision, keeping the plumbing so the package still compiles.

| Reverted decision | Red-before |
|---|---|
| Tracking-bead birth back on the target store | `order_dispatch_orders_store_test.go:112: order-tracking beads = [], want exactly one` (also `:210` trigger-env failure, `:252` webhook seam) |
| Outcome stamp + close back on the target store (birth still routed) | `order_dispatch_orders_store_test.go:143: tracking bead gcg-1 status = "open", want closed; an open marker in a store the close never addresses suppresses this order on every later tick, forever` |
| Wisp outcome stamp back on the target store | `order_dispatch_orders_store_test.go:171: tracking bead labels = [order-run:reaper order-tracking], want the wisp outcome stamped in the binding` |
| Boot orphan sweep back on the work store alone | `order_dispatch_orders_store_test.go:399: the binding orphan gcg-1 is still open after the boot sweep; its order never fires again and the city cannot be restarted without a manual prune` |
| Tracking sweep watchdog back on the scope stores alone | `order_dispatch_orders_store_test.go:446: stale tracking bead gcg-1 status = "open", want closed; the watchdog cannot see the binding, so the tracking jam (#2168) has no recovery on a split city` |
| `gc order check` / `history` resolvers back on the scope stores alone | `order_dispatch_orders_store_test.go:507: gc order check: last run is zero though gcg-1 is in the binding; the order reads as never run and every cooldown/cron trigger fires again immediately` |
| `gc order sweep-tracking` back on the scope stores alone | `order_dispatch_orders_store_test.go:543: gc order sweep-tracking closed nothing in the binding; the documented recovery for a stuck order is a silent no-op on a split city` |
| `gc order run` records its tracking bead on the scope store | `order_dispatch_orders_store_test.go:602: binding holds 0 order-tracking beads, want the manual run's own; a run recorded off the binding advances a cooldown clock nothing reads` |
| Gate federation loses both infrastructure legs | `order_dispatch_orders_store_test.go:287: gate store list = [0x27f1915e67e0], missing the binding the tracking bead lives in; the marker the dispatch just wrote is invisible and the order re-fires every tick` |
| API order check/history read loses the orders leg | `orders_class_store_test.go:52: order store infos = [{ref:city:test-city ...}], none of them the orders binding; the API reports a split city's orders as never run and calls a just-fired order due` |
| API order feed loses the orders leg | `orders_class_store_test.go:103: order feed items = [], want the binding-resident tracking bead gc-1; the dashboard shows no order activity at all on a split city` |

One case is deliberately reported as **green**, because claiming otherwise would be false: reverting only #5106's GRAPH leg from the gate federation leaves `TestOrderDispatchGateFederatesTheOrdersBindingExactlyOnce` passing. That is exactly what the orders leg is for — on the whole-split shape this build serves, one binding serves both classes, so the orders leg deduplicates against the graph leg and costs nothing, while making the orders class able to reach its own single-flight marker without depending on the graph class's routing. Removing **both** legs is the red row above.

## Single-store cities

Byte-identical, and proven by mutation rather than argument. `resolveOrderStore` returns the exact store value it was handed when the routes relocate nothing, and `relocatedOrdersClassStore` returns `nil` there, so no federation gains an entry and no write changes instance.

Mutating `ordersStoreFor` to return a fresh store when routes are nil:

```
order_dispatch_orders_store_test.go:353: ordersStoreFor returned *beads.MemStore(0x378c7b4b2360), want the identical store value 0x378c7b4b22d0
order_dispatch_orders_store_test.go:318: gate store list = [0x378c7b4b2090 0x378c7b4b2240], want exactly the one store the city has
```

Mutating `relocatedOrdersClassStore` to return a store when the city has no `[storage]`:

```
order_dispatch_orders_store_test.go:564: relocatedOrdersClassStore = *beads.MemStore(0xc730b7ba1b0) for a city with no [storage]; want nil so every federation stays exactly as it was
```

Every append in this change — dispatcher gate, one-shot resolvers, sweep federations, API store lists — is guarded by store identity, so a city whose binding IS one of the stores already in a list reads it once, not twice.

## Review fixes (second pass)

Three reviewers independently found the same MAJOR on the first head, and a verifier reproduced it end to end. Fixed here, with the minors that came with it.

### MAJOR — the order-history list minted a `store_ref` its own detail endpoint rejected with 404

`appendOrdersClassStoreInfo` mints a **new ref namespace**, `orders:<city>`, and `GET /v0/city/{city}/orders/history` returns it verbatim as each entry's `store_ref`. But `humaHandleOrderHistoryDetail` never called `orderStoreInfosForState` — it resolved `?store_ref=` through `workflowStoreByRef`, which switched on exactly `city` / `graph` / `rig`. The ref the list had just handed the client fell through to `(workflowStoreInfo{}, false)` and the handler answered `apierr.ScopeNotFound` — **HTTP 404 for a bead that exists**, on every order run of a split city.

Reproduced on a production-shaped whole-split state (`cityBeadStore` = work store, `ordersBeadStore` == `graphBeadStore` == one binding):

```
LIST   /orders/history?scoped_name=nightly-review      -> entries[0].store_ref = "orders:test-city"
DETAIL /order/history/gc-1?store_ref=orders:test-city  -> 404 scope-not-found
DETAIL /order/history/gc-1 (no store_ref)              -> 200, body store_ref = "graph:test-city"
SINGLE-STORE baseline                                  -> "city:test-city", round-trips 200
```

Two things made it worth fixing properly:

- **It was a regression of this PR.** Pre-PR those rows carried `city:<name>`, which resolves. The `orders:` namespace and the break arrived together.
- **The same bead was labelled two ways by two endpoints.** The no-`store_ref` path only still worked because on `storageSplitWhole` the graph and orders bindings are the *same store value* — the detail path was reaching orders data **through the graph leg**, which is exactly the co-residency this PR added an orders leg to stop depending on.

Three changes:

1. `internal/api/handler_convoy_dispatch.go` — `workflowStoreByRef` gains a `case ordersClassStoreRefPrefix:` arm mirroring the graph arm. It resolves `state.OrdersBeadStore().Store` and returns false when that is nil, is the city store, or the scope ref is not this city, so a city that relocates nothing never gains a second name for a store `city:` already resolves.
2. `internal/api/huma_handlers_orders.go` — the detail handler's default store list is now `appendOrdersClassStoreInfo(workflowStores(s.state), s.state, workflowCityScopeRef(s.state.CityName()))`, the same expression `orders_feed.go` already uses, so the read reaches the orders class itself rather than through the graph binding.
3. `internal/api/convoy_sql.go` — `workflowStorePath` now skips the `orders:` class ref as it already skipped `graph:`. A class ref names a binding, not a scope root, and carries the city scope as its fallback; without this the newly-resolvable ref would answer the **city path** and point the workflow SQL fast path at the wrong database.

### Minors from the same pass

- **`gc order sweep-tracking --include-wisps` swept the orders binding twice.** `appendOrdersSweepStore` puts the binding into the sweep list wrapped in `orderTrackingSweepScopedStore` (it carries the store's label), but the hoisted wisp pass guarded itself with `storeListContains`, a bare identity check that sees the wrapper and concludes the binding is absent. On the whole-split shape the wisp store IS that binding, so `--dry-run --include-wisps` reported twice as much stale work as there is. New `sweepStoreListContains` looks through the wrapper. This is the same count-once invariant `TestOrderWispForceCloseCountsAStoreServingBothClassesOnce` already pins for a raw store — the wrapper was the hole in it.
- **The boot closed-backlog advisory applied its 100-bead threshold per store.** `sweepOrphanedOrderTrackingAtBoot` called `warnIfClosedOrderTrackingBacklogLarge` inside the per-store loop, so a converged split city holding 60 closed tracking beads in the work ledger and 60 in the binding stayed silent — half the sensitivity on exactly the cities the sweep was extended for. It now takes the store list and warns once on the total. The `≥1001` cap becomes "capped if any store hit the list limit", which leaves the single-store output byte-identical.

### Red-before

Each string is from the new tests run against this branch with only the corresponding production change reverted.

| Reverted decision | Red-before |
|---|---|
| No `orders:` arm in `workflowStoreByRef` (list→detail round trip) | `orders_class_store_test.go:237: detail status for the list's own store_ref "orders:test-city" = 404, want 200` |
| Detail handler back on bare `workflowStores` | `orders_class_store_test.go:268: detail status without store_ref = 404, want 200; the read never opened the orders binding` |
| Same, at the invariant level | `orders_class_store_test.go:303: workflowStoreByRef("orders:test-city") = false; an order endpoint published a ref no reader resolves` |
| Same, at the resolver level | `handler_convoy_dispatch_test.go:673: workflowStoreByRef(orders:bright-lights) = false, want true` |
| `workflowStorePath` not skipping the class ref | `handler_convoy_dispatch_test.go:705: workflowStorePath("orders:bright-lights") = "/tmp/.../002", true; want no path` |
| Wisp-sweep dedup back on the bare identity check | `order_dispatch_orders_store_test.go:654: dry-run wispClosed = 4, want 2; the wrapped binding was swept twice and the operator is told twice as much work is stale as there is` |
| Boot advisory back on a per-store threshold | `city_runtime_test.go:7414: warning = "", want the combined count 120; a per-store threshold halves the advisory's sensitivity on exactly the split cities it was extended for` |

Single-store byte-identity is proven by mutation, not argument. Dropping the `ordersStore == state.CityBeadStore()` guard from the new arm:

```
handler_convoy_dispatch_test.go:655: workflowStoreByRef(orders:city) on a single-store city = true, want false
```

Removing the dedup from `appendOrdersClassStoreInfo`:

```
orders_class_store_test.go:78: order store infos = [{ref:city:test-city ...} {ref:orders:test-city ...}], want exactly the city store
orders_class_store_test.go:136: tracking bead gc-1 appears 2 times in the feed, want 1
orders_class_store_test.go:326: list entries = [{BeadID:gc-1 StoreRef:city:test-city} {BeadID:gc-1 StoreRef:orders:test-city}], want exactly 1
```

### One alias is left, deliberately

On the whole-split shape the same binding serves graph and orders, so a client can obtain two names for one store: the history list mints `orders:<city>`, and the feed and the unparameterized detail path report `graph:<city>` because `workflowStores` leads with the graph entry and the append deduplicates on store identity. **Both now resolve, and both resolve to the same store** — asserted by `TestOrderHistoryStoreRefsAllResolveToTheSameStore`. Collapsing the alias would mean relabelling the graph entry inside the order read lists, which changes the feed's emitted `store_ref` for no consumer's benefit. The invariant worth holding is the one now under test: no order endpoint may publish a ref no reader resolves.

## Gates

- `go build ./...` clean
- `go vet ./cmd/gc/... ./internal/api/...` clean
- `gofmt` clean
- `golangci-lint` 2.10.1 on `./cmd/gc/... ./internal/api/...` — **0 issues** (baseline at the previous head was also 0)
- `go test ./internal/api` — pass
- `go test ./cmd/gc -timeout 40m` — pass
- `make check-core-boundary` — OK
- `make check-docs` — OK. No wire type or endpoint changed; the `store_ref` **value space** gains `orders:<city>` on split cities, and that value now round-trips through `workflowStoreByRef` like `graph:` and `rig:` do. `OrdersBeadStore` is an internal read accessor, not an OpenAPI surface.

## Follow-ups, not bundled

- `gc order run`'s FORMULA arm still instantiates its molecule through the unrouted scope store, so a manually-run wisp root is still born in the work ledger. That is a **graph**-class birth — part of #5106's remaining follow-up list, not this one — and it needs its own revert and its own byte-identity proof.
- Retention-prune policy (backup-freshness gate, retain-last floor) is untouched; the retention watchdog's reach into the binding is asserted at the shared store resolver rather than by running the prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

