### PR TITLE
fix(api): resolve class-prefix bead ids before any rig-route fallback

### DIFF
--- a/internal/api/class_store_test.go
+++ b/internal/api/class_store_test.go
@@ -1,11 +1,30 @@
 package api
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
+
+// writeRoutesJSONL writes a routes.jsonl into scopeDir/.beads/, creating the
+// directory. Lines are already-encoded JSON objects.
+func writeRoutesJSONL(t *testing.T, scopeDir string, lines ...string) {
+	t.Helper()
+	beadsDir := filepath.Join(scopeDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", beadsDir, err)
+	}
+	var body string
+	for _, line := range lines {
+		body += line + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s/routes.jsonl): %v", beadsDir, err)
+	}
+}
 
 // TestBeadStoresForIDDefaultBackendIsCityLed pins the single-store invariant:
 // when the graph class is NOT relocated (GraphBeadStore() == CityBeadStore()),
@@ -55,5 +74,107 @@ func TestBeadStoresForIDClassAwareGraphArm(t *testing.T) {
 	got := s.beadStoresForID(prefix + "-1")
 	if len(got) != 2 || got[0] != s.state.GraphBeadStore().Store || got[1] != s.state.CityBeadStore() {
 		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, work]", prefix, got, len(got))
+	}
+}
+
+// relocatedGraphRouteState builds a relocated-graph city with one rig, and
+// returns the state plus the graph, city and rig stores. The graph store lives
+// at <city>/.gc/infra, which is NOT a registered rig path.
+func relocatedGraphRouteState(t *testing.T) (*fakeState, beads.Store, beads.Store, beads.Store) {
+	t.Helper()
+	st := newFakeState(t)
+	city := beads.NewMemStore()
+	graph := beads.NewMemStore()
+	rig := beads.NewMemStore()
+	st.cityBeadStore = city
+	st.graphBeadStore = graph
+	st.stores = map[string]beads.Store{"myrig": rig}
+	st.cfg.Rigs = []config.Rig{{Name: "myrig", Path: filepath.Join(st.cityPath, "rigs", "myrig")}}
+	return st, graph, city, rig
+}
+
+// TestBeadStoresForIDClassArmBeatsRigRouteCapture pins the ordering the split
+// city depends on: a rig routes.jsonl entry for the reserved graph prefix
+// resolves to the relocated graph directory, which is not a rig, so the rig
+// must NOT answer for it — the class arm must.
+func TestBeadStoresForIDClassArmBeatsRigRouteCapture(t *testing.T) {
+	st, graph, city, rig := relocatedGraphRouteState(t)
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	// The rig's routes.jsonl routes the graph class OUT of the rig, to the
+	// relocated graph store directory.
+	writeRoutesJSONL(t, st.cfg.Rigs[0].Path,
+		`{"prefix":"mr","path":"."}`,
+		`{"prefix":"`+prefix+`","path":"../../.gc/infra"}`,
+	)
+
+	s := New(st)
+	got := s.beadStoresForID(prefix + "-1")
+	if len(got) != 2 || got[0] != graph || got[1] != city {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, city]; rig store is %p", prefix, got, len(got), rig)
+	}
+}
+
+// TestBeadStoresForIDClassArmBeatsCityRouteCapture pins the same ordering for a
+// city-scope route: a routes.jsonl entry that resolves the reserved graph prefix
+// back to the city directory must not hand graph-class ids to the city work
+// store — the class arm owns reserved prefixes.
+func TestBeadStoresForIDClassArmBeatsCityRouteCapture(t *testing.T) {
+	st, graph, city, _ := relocatedGraphRouteState(t)
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	writeRoutesJSONL(t, st.cityPath, `{"prefix":"`+prefix+`","path":"."}`)
+
+	s := New(st)
+	got := s.beadStoresForID(prefix + "-1")
+	if len(got) != 2 || got[0] != graph || got[1] != city {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, city]; graph is %p, city is %p", prefix, got, len(got), graph, city)
+	}
+}
+
+// TestBeadStoresForIDClassArmBeatsShadowingRigPrefix pins the ordering against
+// the other way a work store can name a reserved prefix: a rig configured with
+// the class prefix itself. config.ReservedPrefixWarnings allows that today but
+// documents the class store as the owner once relocation is active, so on a
+// relocated city the class arm — not the shadowing rig — answers.
+func TestBeadStoresForIDClassArmBeatsShadowingRigPrefix(t *testing.T) {
+	st, graph, city, rig := relocatedGraphRouteState(t)
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	st.cfg.Rigs[0].Prefix = prefix
+
+	s := New(st)
+	got := s.beadStoresForID(prefix + "-1")
+	if len(got) != 2 || got[0] != graph || got[1] != city {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, city]; shadowing rig store is %p", prefix, got, len(got), rig)
+	}
+}
+
+// TestBeadStoresForIDShadowingRigPrefixStillWinsOnDefaultCity pins the other
+// side of that rule: with no relocation (GraphBeadStore() == CityBeadStore())
+// the class arm never fires, so a rig configured with the reserved prefix keeps
+// owning those ids exactly as it does today.
+func TestBeadStoresForIDShadowingRigPrefixStillWinsOnDefaultCity(t *testing.T) {
+	st := newFakeState(t)
+	city := beads.NewMemStore()
+	rig := beads.NewMemStore()
+	st.cityBeadStore = city
+	st.stores = map[string]beads.Store{"myrig": rig}
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	st.cfg.Rigs = []config.Rig{{Name: "myrig", Path: filepath.Join(st.cityPath, "rigs", "myrig"), Prefix: prefix}}
+
+	s := New(st)
+	got := s.beadStoresForID(prefix + "-1")
+	if len(got) != 1 || got[0] != rig {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want only the shadowing rig store %p", prefix, got, len(got), rig)
 	}
 }

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -159,28 +159,25 @@ func (s *Server) findStore(rig string) beads.Store {
 // The result is the per-class by-id candidate set: a successful prefix/route
 // match returns the single store that owns the ID's namespace (which is already
 // the bead's class+rig store), and the unrouted fallback leads with the
-// city/HQ store ahead of the per-rig work stores. A graph-relocated city adds a
-// class-prefix arm so graph-class ids reach the dedicated graph store.
+// city/HQ store ahead of the per-rig work stores. A graph-relocated city is
+// resolved by the class-prefix arm, which runs first so a reserved class prefix
+// can never be captured by a rig/HQ prefix or a routes.jsonl entry.
 func (s *Server) beadStoresForID(id string) []beads.Store {
 	id = strings.TrimSpace(id)
-	if store := s.resolveStoreByConfiguredIDPrefix(id); store != nil {
-		return []beads.Store{store}
-	}
-	if prefix := beadPrefix(id); prefix != "" {
-		if store := s.resolveStoreByPrefix(prefix); store != nil {
-			return []beads.Store{store}
-		}
-	}
 
 	// Class-prefix arm: a graph-relocated city keeps graph-class beads (reserved
-	// id-prefix "gcg") in a dedicated graph store that is NOT reachable via a
-	// rig/HQ prefix or a routes.jsonl entry, so a graph-class id would otherwise
-	// fall through to the candidate scan and miss. Return [graph, work] —
+	// id-prefix "gcg") in a dedicated graph store, which is the only store that
+	// mints and owns that prefix. The arm runs FIRST — ahead of the configured
+	// prefix and routes.jsonl resolvers — because both of those can name the
+	// reserved prefix and would otherwise hand a class id to a work store: a
+	// routed prefix wins unconditionally, and a shadowing rig/HQ prefix is
+	// warned-but-allowed (config.ReservedPrefixWarnings), which documents the
+	// class store as the owner once relocation is active. Return [graph, work] —
 	// graph-first (prefix-owner first) — so the per-store Get-then-mutate loop in
 	// the by-id handlers federates the graph store ahead of work and pins it on
 	// the first probe. Skipped for a default (non-relocated) city, where
-	// GraphBeadStore() == CityBeadStore(): the arm never fires and this path stays
-	// byte-identical.
+	// GraphBeadStore() == CityBeadStore(): the arm never fires and this path
+	// stays byte-identical.
 	if graph := s.state.GraphBeadStore().Store; graph != nil {
 		if city := s.state.CityBeadStore(); graph != city {
 			if prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph); ok && beadIDHasConfiguredPrefix(id, prefix) {
@@ -189,6 +186,15 @@ func (s *Server) beadStoresForID(id string) []beads.Store {
 				}
 				return []beads.Store{graph}
 			}
+		}
+	}
+
+	if store := s.resolveStoreByConfiguredIDPrefix(id); store != nil {
+		return []beads.Store{store}
+	}
+	if prefix := beadPrefix(id); prefix != "" {
+		if store := s.resolveStoreByPrefix(prefix); store != nil {
+			return []beads.Store{store}
 		}
 	}
 
@@ -335,9 +341,15 @@ func (s *Server) resolveStoreByPrefix(prefix string) beads.Store {
 				return store
 			}
 		}
-		// Fallback: the route pointed to the same rig.
-		if store, exists := stores[rig.Name]; exists {
-			return store
+		// Fallback: the route pointed back at this rig itself (a self-route).
+		// Only then may this rig answer. A route that resolves to some OTHER
+		// path — one that is not a registered rig, e.g. a relocated class store
+		// directory — says the prefix does NOT live here, so it must fall
+		// through to the caller's candidate scan rather than pin the wrong store.
+		if cleanPath == filepath.Clean(rigPath) {
+			if store, exists := stores[rig.Name]; exists {
+				return store
+			}
 		}
 	}
 	return nil

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -352,6 +352,55 @@ func TestBeadPrefixAllowsAlphanumericPrefixes(t *testing.T) {
 	}
 }
 
+// TestResolveStoreByPrefixKeepsRigRouteResolution pins the non-class routing
+// behavior: a self-route ("ga" -> ".") resolves to the rig that owns the routes
+// file, and a cross-rig route ("gb" -> "../beta") resolves to the rig it points
+// at. Both must stay exactly as they are.
+func TestResolveStoreByPrefixKeepsRigRouteResolution(t *testing.T) {
+	state, alphaStore, betaStore := configureBeadRouteState(t)
+	s := New(state)
+
+	if got := s.resolveStoreByPrefix("ga"); got != beads.Store(alphaStore) {
+		t.Errorf("resolveStoreByPrefix(ga) = %p, want alpha store %p", got, alphaStore)
+	}
+	if got := s.resolveStoreByPrefix("gb"); got != beads.Store(betaStore) {
+		t.Errorf("resolveStoreByPrefix(gb) = %p, want beta store %p", got, betaStore)
+	}
+}
+
+// TestResolveStoreByPrefixDoesNotCaptureForeignRoute pins that a rig route
+// resolving to a path which is NOT a registered rig no longer answers with that
+// rig's store. The route says the prefix lives elsewhere, so resolution falls
+// through to the by-id candidate scan — which still contains every store, so the
+// bead stays reachable instead of being pinned to the wrong one.
+func TestResolveStoreByPrefixDoesNotCaptureForeignRoute(t *testing.T) {
+	state, alphaStore, betaStore := configureBeadRouteState(t)
+	cityStore := beads.NewMemStore()
+	state.cityBeadStore = cityStore
+	alphaPath := filepath.Join(state.cityPath, "rigs", "alpha")
+	routes := `{"prefix":"ga","path":"."}` + "\n" +
+		`{"prefix":"gb","path":"../beta"}` + "\n" +
+		`{"prefix":"gz","path":"../../elsewhere"}`
+	if err := os.WriteFile(filepath.Join(alphaPath, ".beads", "routes.jsonl"), []byte(routes), 0o644); err != nil {
+		t.Fatalf("WriteFile(routes.jsonl): %v", err)
+	}
+	s := New(state)
+
+	if got := s.resolveStoreByPrefix("gz"); got != nil {
+		t.Fatalf("resolveStoreByPrefix(gz) = %p, want nil (route resolves outside every rig); alpha is %p", got, alphaStore)
+	}
+	got := s.beadStoresForID("gz-1")
+	want := []beads.Store{cityStore, alphaStore, betaStore}
+	if len(got) != len(want) {
+		t.Fatalf("beadStoresForID(gz-1) = %v (len %d), want the full candidate scan %v", got, len(got), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("beadStoresForID(gz-1)[%d] = %p, want %p", i, got[i], want[i])
+		}
+	}
+}
+
 func TestBeadCloseVerifiesStoreContainsBeadBeforeClosing(t *testing.T) {
 	rigStore := beads.NewMemStore()
 	created, err := rigStore.Create(beads.Bead{Title: "close me"})


### PR DESCRIPTION
## Problem

`internal/api/resolveStoreByPrefix` ends its rig `routes.jsonl` scan with an
unconditional fallback:

```go
// Fallback: the route pointed to the same rig.
if store, exists := stores[rig.Name]; exists {
    return store
}
```

The comment says "the same rig", but nothing checks that. The arm is reached
whenever a rig's routes file resolves the prefix to a path that is not a
registered rig — i.e. precisely when the route says *the prefix does not live
here*. The resolver answers with this rig's store anyway.

`beadStoresForID` consults `resolveStoreByPrefix` **before** its class-prefix
arm, so a routed prefix wins unconditionally and the class arm never runs.

This is **latent on main today**: `collectRigRoutes` only emits HQ/rig prefixes,
which all resolve to real rig paths, so nothing currently produces a route that
resolves elsewhere. It becomes **active the moment a class route exists** — the
instant a split city writes a reserved class prefix (`gcg`) into any scope's
`routes.jsonl`, a `gcg-` by-id read is captured by a work store before the class
arm can route it to the graph store, and reads/mutations resolve against the
wrong store. That makes this a precondition for split-store CLI federation: it
has to land before any class route is added, not after.

Two further captures exist on the same path once a class prefix is in play, both
of which survive a fix to the fallback alone:

- a **city-scope** route resolving the class prefix back to the city directory
  hands class ids to the city work store;
- a rig **configured** with the reserved prefix (warned-but-allowed by
  `config.ReservedPrefixWarnings`) wins over the class store, even though that
  warning text names the class store as the owner "once per-class stores
  activate".

## Fix

Make the ordering explicit and total, in two small edits confined to
`internal/api/handler_beads.go`:

1. **The class-prefix arm runs first** in `beadStoresForID`, ahead of both the
   configured-prefix and `routes.jsonl` resolvers. It is the candidate-probe
   shape (`[graph, city]`), not an unconditional single route, so the by-id
   handler loop still federates to the city store if the bead is not in graph.
   The arm remains gated on `GraphBeadStore() != CityBeadStore()`.
2. **The rig-route fallback answers only for a self-route** —
   `cleanPath == filepath.Clean(rigPath)`. A route resolving anywhere else falls
   through to the by-id candidate scan, which already contains every store, so
   no bead becomes unreachable; a wrong *pin* is replaced by a correct *probe*.

A default, non-relocated city is unchanged: the class arm is skipped when
`GraphBeadStore() == CityBeadStore()`, and self-routes and cross-rig routes
resolve exactly as before.

## Tests

Four new tests are red on main and green with the fix. Exact red-before output
(new tests run against pristine `internal/api/handler_beads.go` from `main`):

```
--- FAIL: TestBeadStoresForIDClassArmBeatsRigRouteCapture (0.00s)
    class_store_test.go:116: beadStoresForID(gcg-1) = [0x1e5b297cd9e0] (len 1), want [graph, city]; rig store is 0x1e5b297cd9e0
--- FAIL: TestBeadStoresForIDClassArmBeatsCityRouteCapture (0.00s)
    class_store_test.go:135: beadStoresForID(gcg-1) = [0x1e5b297cdc20] (len 1), want [graph, city]; graph is 0x1e5b297cdcb0, city is 0x1e5b297cdc20
--- FAIL: TestBeadStoresForIDClassArmBeatsShadowingRigPrefix (0.00s)
    class_store_test.go:155: beadStoresForID(gcg-1) = [0x1e5b29dbc120] (len 1), want [graph, city]; shadowing rig store is 0x1e5b29dbc120
--- FAIL: TestResolveStoreByPrefixDoesNotCaptureForeignRoute (0.00s)
    handler_beads_test.go:390: resolveStoreByPrefix(gz) = 0x1e5b29cb29c0, want nil (route resolves outside every rig); alpha is 0x1e5b29cb29c0
```

The returned pointer is byte-identical to the wrong store's pointer in each
case, so the capture is proven by identity rather than by inference.

No-regression pins (green **before and after**, so they pin today's behavior,
not the fix):

- `TestResolveStoreByPrefixKeepsRigRouteResolution` — a self-route (`ga` -> `.`)
  still resolves to its own rig and a cross-rig route (`gb` -> `../beta`) still
  resolves to the rig it points at.
- `TestBeadStoresForIDShadowingRigPrefixStillWinsOnDefaultCity` — with no
  relocation, a rig configured with the reserved prefix keeps owning those ids.
- `TestBeadStoresForIDDefaultBackendIsCityLed` (existing) — single-store city
  stays city-led.
- `TestResolveStoreByPrefixDoesNotCaptureForeignRoute` also asserts the full
  fall-through candidate list `[city, alpha, beta]`, proving the store that used
  to be wrongly pinned is still probed.

**Teeth proven by mutation, not argument.** Each half of the fix was reverted
independently and the suite re-run:

- revert only the fallback guard -> `TestResolveStoreByPrefixDoesNotCaptureForeignRoute`
  fails (`resolveStoreByPrefix(gz) = 0xfdffed59c0 ... alpha is 0xfdffed59c0`).
- revert only the class-arm hoist -> `TestBeadStoresForIDClassArmBeatsCityRouteCapture`
  fails (`= [0x2924e6abfcb0] (len 1) ... graph is 0x2924e6abfd40, city is 0x2924e6abfcb0`).

## Gates

`go build ./...`, `go vet ./...`, `gofmt -l internal/api/`, `golangci-lint run
./internal/api/...` (2.10.1, 0 issues), `go test ./internal/api/` (ok, 78.8s),
`go test ./internal/testpolicy/...`, `scripts/check-core-boundary.sh`,
`scripts/check-routed-test-rows.sh`. `cmd/gc` is untouched; the route/prefix/store
subset (`-run 'Route|Routes|Prefix|BeadStore|CrossStore|Storage'`) was run anyway
and passes. No wire, OpenAPI or dashboard surface changes.

## Note

The production `feat/split-store-conformance` branch found and fixed the
fallback half of this independently while building split-store federation; that
branch's fix is not on `main`. This PR lands the routing precondition on its own,
separate from that branch's larger class-store work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
