### PR TITLE
feat(beads): derive the postgres endpoint from bd's postgres_dsn

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -630,7 +630,8 @@ func scopeMetadataJSONPath(scopeRoot string) string {
 // applyResolvedScopePostgresEnv projects PG credentials and connection
 // info into env. Caller guarantees meta.Backend == "postgres". The
 // resolver chain in internal/pgauth supplies the password; the host,
-// port, user, and database come straight from MetadataState.
+// port, user, and database come from meta.PostgresEndpoint, which reads
+// either the discrete metadata fields or bd's postgres_dsn.
 //
 // On resolver exhaustion returns an error wrapping
 // pgauth.ErrNoPasswordResolvable; callers can match with errors.Is.
@@ -642,14 +643,21 @@ func applyResolvedScopePostgresEnv(env map[string]string, cityPath, scopeRoot st
 	if env == nil {
 		return nil
 	}
+	// LoadMetadataState refuses a postgres scope it cannot derive a complete
+	// endpoint for, so this only fires for a hand-built MetadataState.
+	// Failing here beats projecting empty BEADS_POSTGRES_* values.
+	pg, err := meta.PostgresEndpoint()
+	if err != nil {
+		return fmt.Errorf("deriving postgres endpoint for %s: %w", scopeRoot, err)
+	}
 	clearProjectedBeadsBackendEnv(env)
 	clearProjectedDoltEnv(env)
 	mirrorBeadsDoltEnv(env)
 	clearProjectedPostgresEnv(env)
 	endpoint := pgauth.Endpoint{
-		Host: meta.PostgresHost,
-		Port: meta.PostgresPort,
-		User: meta.PostgresUser,
+		Host: pg.Host,
+		Port: pg.Port,
+		User: pg.User,
 	}
 	// Scope projection clears inherited PG keys first, so credential
 	// resolution intentionally starts at process and file-backed sources.
@@ -659,12 +667,12 @@ func applyResolvedScopePostgresEnv(env map[string]string, cityPath, scopeRoot st
 	}
 	env["GC_POSTGRES_PASSWORD"] = resolved.Password
 	env["BEADS_POSTGRES_PASSWORD"] = resolved.Password
-	env["BEADS_POSTGRES_HOST"] = meta.PostgresHost
-	env["BEADS_POSTGRES_PORT"] = meta.PostgresPort
-	env["BEADS_POSTGRES_USER"] = meta.PostgresUser
-	env["BEADS_POSTGRES_DATABASE"] = meta.PostgresDatabase
+	env["BEADS_POSTGRES_HOST"] = pg.Host
+	env["BEADS_POSTGRES_PORT"] = pg.Port
+	env["BEADS_POSTGRES_USER"] = pg.User
+	env["BEADS_POSTGRES_DATABASE"] = pg.Database
 	mirrorBeadsPostgresEnv(env)
-	emitPostgresCredentialResolved(cityPath, scopeRoot, meta, resolved.Source)
+	emitPostgresCredentialResolved(cityPath, scopeRoot, pg, resolved.Source)
 	return nil
 }
 
@@ -673,7 +681,7 @@ func applyResolvedScopePostgresEnv(env map[string]string, cityPath, scopeRoot st
 // Best-effort: recorder failures (file unreachable, JSONL write error) do
 // not propagate to the caller. The payload deliberately omits the password
 // value (asserted by TestPostgresEventOmitsPassword).
-func emitPostgresCredentialResolved(cityPath, scopeRoot string, meta contract.MetadataState, source pgauth.Source) {
+func emitPostgresCredentialResolved(cityPath, scopeRoot string, pg contract.PostgresEndpoint, source pgauth.Source) {
 	scopeKind, scopeName := scopeKindAndName(cityPath, scopeRoot)
 	subject := "city/" + scopeName
 	if scopeKind == "rig" {
@@ -683,9 +691,9 @@ func emitPostgresCredentialResolved(cityPath, scopeRoot string, meta contract.Me
 		ScopeKind: scopeKind,
 		ScopeName: scopeName,
 		Source:    source.String(),
-		Host:      meta.PostgresHost,
-		Port:      meta.PostgresPort,
-		User:      meta.PostgresUser,
+		Host:      pg.Host,
+		Port:      pg.Port,
+		User:      pg.User,
 	}
 	if _, loaded := postgresCredentialResolvedSeen.LoadOrStore(postgresCredentialResolvedKey(cityPath, payload), struct{}{}); loaded {
 		return
@@ -1283,7 +1291,11 @@ func bdCommandRunnerWithManagedRetryErr(cityPath string, envFn func(dir string) 
 				return out, fmt.Errorf("classifying scope backend (bd error: %w): %w", err, classifyErr)
 			}
 			if ok {
-				return out, fmt.Errorf("postgres at %s:%s: gc does not manage external PG endpoints (no managed recovery attempted): %w", meta.PostgresHost, meta.PostgresPort, err)
+				pg, pgErr := meta.PostgresEndpoint()
+				if pgErr != nil {
+					return out, fmt.Errorf("postgres scope with an underivable endpoint (%w): gc does not manage external PG endpoints (no managed recovery attempted): %w", pgErr, err)
+				}
+				return out, fmt.Errorf("postgres at %s:%s: gc does not manage external PG endpoints (no managed recovery attempted): %w", pg.Host, pg.Port, err)
 			}
 		}
 		if err == nil && scopeBackendIsPostgres(cityPath, dir) {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -4307,6 +4307,66 @@ func TestApplyResolvedScopePostgresEnv_HappyPath(t *testing.T) {
 	}
 }
 
+// TestApplyResolvedScopePostgresEnv_DerivesFromDSN covers bd's own postgres
+// metadata shape: a password-free postgres_dsn with no discrete fields. The
+// BEADS_POSTGRES_* projection has to derive the tuple rather than ship empty
+// values, which is what it would do if it read the metadata fields directly.
+func TestApplyResolvedScopePostgresEnv_DerivesFromDSN(t *testing.T) {
+	clearAmbientPostgresEnv(t)
+	cityPath := t.TempDir()
+	scopeRoot := t.TempDir()
+	writePGScopeFixture(t, scopeRoot, "devpw")
+
+	env := map[string]string{}
+	meta := contract.MetadataState{
+		Backend:        "postgres",
+		PostgresDSN:    "postgres://gc_city@pg.example.test:6543/gascity_infra",
+		PostgresSchema: "city_x",
+	}
+	if err := applyResolvedScopePostgresEnv(env, cityPath, scopeRoot, meta); err != nil {
+		t.Fatalf("applyResolvedScopePostgresEnv: %v", err)
+	}
+	want := map[string]string{
+		"BEADS_POSTGRES_HOST":     "pg.example.test",
+		"BEADS_POSTGRES_PORT":     "6543",
+		"BEADS_POSTGRES_USER":     "gc_city",
+		"BEADS_POSTGRES_DATABASE": "gascity_infra",
+	}
+	for key, value := range want {
+		if got := env[key]; got != value {
+			t.Errorf("env[%q] = %q, want %q", key, got, value)
+		}
+	}
+}
+
+// TestApplyResolvedScopePostgresEnv_RefusesUnderivableDSN pins the libpq
+// limitation at the projection boundary: gc fails loudly instead of handing bd
+// a set of empty connection variables.
+func TestApplyResolvedScopePostgresEnv_RefusesUnderivableDSN(t *testing.T) {
+	clearAmbientPostgresEnv(t)
+	cityPath := t.TempDir()
+	scopeRoot := t.TempDir()
+	writePGScopeFixture(t, scopeRoot, "devpw")
+
+	env := map[string]string{}
+	meta := contract.MetadataState{
+		Backend:     "postgres",
+		PostgresDSN: "host=pg.example.test port=6543 user=gc_city dbname=gascity_infra",
+	}
+	err := applyResolvedScopePostgresEnv(env, cityPath, scopeRoot, meta)
+	if err == nil {
+		t.Fatalf("applyResolvedScopePostgresEnv = nil error, want refusal; env=%v", env)
+	}
+	if !errors.Is(err, contract.ErrPostgresDSNUnsupportedForm) {
+		t.Fatalf("error %v, want errors.Is(err, contract.ErrPostgresDSNUnsupportedForm)", err)
+	}
+	for _, key := range []string{"BEADS_POSTGRES_HOST", "BEADS_POSTGRES_PORT", "BEADS_POSTGRES_USER", "BEADS_POSTGRES_DATABASE"} {
+		if got, ok := env[key]; ok {
+			t.Errorf("env[%q] = %q, want it unset (no partial projection)", key, got)
+		}
+	}
+}
+
 func TestEmitPostgresCredentialResolved_DedupsWithinProcess(t *testing.T) {
 	clearAmbientPostgresEnv(t)
 

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -4367,6 +4367,32 @@ func TestApplyResolvedScopePostgresEnv_RefusesUnderivableDSN(t *testing.T) {
 	}
 }
 
+// TestApplyResolvedScopePostgresEnv_RefusalOmitsDSN keeps the projection
+// boundary's "deriving postgres endpoint for %s: %w" wrap clean. It re-emits
+// whatever the contract layer returns, and this error reaches stderr and
+// `gc --json` failure payloads, so a hand-written password in a malformed DSN
+// must not ride out with it.
+func TestApplyResolvedScopePostgresEnv_RefusalOmitsDSN(t *testing.T) {
+	clearAmbientPostgresEnv(t)
+	cityPath := t.TempDir()
+	scopeRoot := t.TempDir()
+	writePGScopeFixture(t, scopeRoot, "devpw")
+
+	const dsn = "postgres://operator:sw%ordfish@db.example.com:5432/gascity"
+	err := applyResolvedScopePostgresEnv(map[string]string{}, cityPath, scopeRoot, contract.MetadataState{
+		Backend:     "postgres",
+		PostgresDSN: dsn,
+	})
+	if err == nil {
+		t.Fatalf("applyResolvedScopePostgresEnv = nil error, want refusal")
+	}
+	for _, leak := range []string{dsn, "ordfish"} {
+		if strings.Contains(err.Error(), leak) {
+			t.Errorf("error leaks %q: %q", leak, err.Error())
+		}
+	}
+}
+
 func TestEmitPostgresCredentialResolved_DedupsWithinProcess(t *testing.T) {
 	clearAmbientPostgresEnv(t)
 

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -94,12 +94,24 @@ type MetadataState struct {
 	PostgresPort     string `json:"postgres_port,omitempty"`
 	PostgresUser     string `json:"postgres_user,omitempty"`
 	PostgresDatabase string `json:"postgres_database,omitempty"`
-	// PostgresDSN and PostgresSchema are bd's postgres shape:
-	// `bd init --backend=postgres` persists a password-free connection URL
-	// plus the per-workspace search_path schema instead of the discrete
-	// host/port/user/database fields above. The password never lands on
-	// disk — bd reads BEADS_PG_PASSWORD (or a credential command) at
-	// command time.
+	// PostgresDSN and PostgresSchema are bd's postgres shape, and the only
+	// shape any bd writes: the Postgres add-on's
+	// `bd init --backend=postgres --pg-url --pg-schema` persists a
+	// password-free connection URL plus the per-workspace search_path schema
+	// (bd-enterprise cmd/bd/backend_init_distribution_enterprise.go,
+	// runInitPostgres), and reads them back through
+	// internal/storage/postgres/fromconfig.go. The discrete
+	// host/port/user/database fields above are gc's own draft-era shape; no
+	// bd writes or reads them. The password never lands on disk —
+	// pgdialect.RedactPassword strips it fail-closed before the write, and bd
+	// re-supplies it at command time from BEADS_PG_PASSWORD_COMMAND or
+	// BEADS_PG_PASSWORD.
+	//
+	// OSS bd carries these two fields as deprecated round-trip-only storage
+	// and refuses backend=postgres outright; only the add-on build can open
+	// such a workspace. gc must therefore preserve the keys it finds and
+	// never force an operator to hand-convert away from a shape bd will
+	// write back.
 	PostgresDSN    string `json:"postgres_dsn,omitempty"`
 	PostgresSchema string `json:"postgres_schema,omitempty"`
 }
@@ -399,30 +411,12 @@ func LoadMetadataState(fs fsys.FS, path string) (MetadataState, bool, error) {
 	}
 
 	if state.Backend == "postgres" {
-		hasDSN := strings.TrimSpace(state.PostgresDSN) != ""
-		hasAllDiscrete := state.PostgresHost != "" && state.PostgresPort != "" && state.PostgresUser != "" && state.PostgresDatabase != ""
-		if !hasDSN && !hasAllDiscrete {
-			return MetadataState{}, false, &MetadataParseError{
-				Path:   abs,
-				Reason: "backend=postgres requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database",
-			}
-		}
-		endpoint, err := state.PostgresEndpoint()
-		if err != nil {
+		// validatePostgresEndpoint is shared with preflight's contract_shape
+		// check, and its messages never quote postgres_dsn: this Reason is
+		// rendered to stderr and into `gc --json` failure payloads, where a
+		// hand-written password would outlive the file it came from.
+		if err := state.validatePostgresEndpoint(); err != nil {
 			return MetadataState{}, false, &MetadataParseError{Path: abs, Reason: err.Error()}
-		}
-		if missing := missingPostgresEndpointFields(endpoint); len(missing) > 0 {
-			return MetadataState{}, false, &MetadataParseError{
-				Path:   abs,
-				Reason: fmt.Sprintf("backend=postgres resolves to an incomplete endpoint: postgres_dsn supplies no %s", strings.Join(missing, ", ")),
-			}
-		}
-		port, err := strconv.Atoi(endpoint.Port)
-		if err != nil || port < 1 || port > 65535 {
-			return MetadataState{}, false, &MetadataParseError{
-				Path:   abs,
-				Reason: fmt.Sprintf("postgres_port must be a TCP port (1..65535), got %q", endpoint.Port),
-			}
 		}
 	}
 
@@ -434,12 +428,21 @@ func LoadMetadataState(fs fsys.FS, path string) (MetadataState, bool, error) {
 // the opposite backend is mixed. For empty or unknown backends, mixed still
 // means both Dolt-shaped and Postgres-shaped fields are populated.
 //
+// postgres_dsn and postgres_schema are deliberately absent: they are bd's own
+// fields, retained across a re-init, so a Postgres workspace flipped to Dolt
+// carries them with no operator involvement. A declared backend is not
+// ambiguous and the residue is inert, so it is scrubbed by
+// crossBackendKeysToScrub on the next canonicalise rather than made fatal —
+// this guard exists to catch configurations gc cannot interpret, not to brick
+// a bootable city over keys it knows how to remove. The discrete
+// postgres_host/port/user/database fields have no such producer and stay
+// fatal.
+//
 // Field-iteration order is the JSON-key declaration order on MetadataState
 // (dolt_mode, dolt_database, postgres_host, postgres_port, postgres_user,
-// postgres_database, postgres_dsn, postgres_schema). When state.Backend is
-// empty or unknown and both backend families appear, the first populated
-// field across both backends wins (with Dolt fields preferred per
-// declaration order).
+// postgres_database). When state.Backend is empty or unknown and both backend
+// families appear, the first populated field across both backends wins (with
+// Dolt fields preferred per declaration order).
 func mixedBackendField(state MetadataState) (string, bool) {
 	type entry struct {
 		name    string
@@ -453,8 +456,6 @@ func mixedBackendField(state MetadataState) (string, bool) {
 		{"postgres_port", state.PostgresPort, "postgres"},
 		{"postgres_user", state.PostgresUser, "postgres"},
 		{"postgres_database", state.PostgresDatabase, "postgres"},
-		{"postgres_dsn", state.PostgresDSN, "postgres"},
-		{"postgres_schema", state.PostgresSchema, "postgres"},
 	}
 	var firstDolt, firstPostgres string
 	for _, f := range fields {

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -82,8 +82,9 @@ func (c DoltConfig) DisableEventFlushEnabled() bool {
 // Backend determines which backend-specific fields are meaningful. When
 // returned from LoadMetadataState the populated backend-specific fields are
 // guaranteed consistent with Backend — i.e. a state with Backend == "postgres"
-// always has every Postgres field non-empty and PostgresPort already verified
-// as a TCP-port-shaped string.
+// carries either a parseable postgres_dsn or the complete discrete field set,
+// PostgresEndpoint derives a full host/port/user/database tuple from it, and
+// the effective port is already verified as a TCP-port-shaped string.
 type MetadataState struct {
 	Database         string `json:"database"`
 	Backend          string `json:"backend"`
@@ -93,6 +94,14 @@ type MetadataState struct {
 	PostgresPort     string `json:"postgres_port,omitempty"`
 	PostgresUser     string `json:"postgres_user,omitempty"`
 	PostgresDatabase string `json:"postgres_database,omitempty"`
+	// PostgresDSN and PostgresSchema are bd's postgres shape:
+	// `bd init --backend=postgres` persists a password-free connection URL
+	// plus the per-workspace search_path schema instead of the discrete
+	// host/port/user/database fields above. The password never lands on
+	// disk — bd reads BEADS_PG_PASSWORD (or a credential command) at
+	// command time.
+	PostgresDSN    string `json:"postgres_dsn,omitempty"`
+	PostgresSchema string `json:"postgres_schema,omitempty"`
 }
 
 // MetadataParseError reports a failure to parse or validate metadata.json.
@@ -132,6 +141,8 @@ var postgresBackendKeys = []string{
 	"postgres_port",
 	"postgres_user",
 	"postgres_database",
+	"postgres_dsn",
+	"postgres_schema",
 }
 
 // crossBackendKeysToScrub returns the on-disk metadata keys that should be
@@ -388,17 +399,29 @@ func LoadMetadataState(fs fsys.FS, path string) (MetadataState, bool, error) {
 	}
 
 	if state.Backend == "postgres" {
-		if state.PostgresHost == "" || state.PostgresPort == "" || state.PostgresUser == "" || state.PostgresDatabase == "" {
+		hasDSN := strings.TrimSpace(state.PostgresDSN) != ""
+		hasAllDiscrete := state.PostgresHost != "" && state.PostgresPort != "" && state.PostgresUser != "" && state.PostgresDatabase != ""
+		if !hasDSN && !hasAllDiscrete {
 			return MetadataState{}, false, &MetadataParseError{
 				Path:   abs,
-				Reason: "backend=postgres requires postgres_host, postgres_port, postgres_user, postgres_database (all four must be non-empty)",
+				Reason: "backend=postgres requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database",
 			}
 		}
-		port, err := strconv.Atoi(state.PostgresPort)
+		endpoint, err := state.PostgresEndpoint()
+		if err != nil {
+			return MetadataState{}, false, &MetadataParseError{Path: abs, Reason: err.Error()}
+		}
+		if missing := missingPostgresEndpointFields(endpoint); len(missing) > 0 {
+			return MetadataState{}, false, &MetadataParseError{
+				Path:   abs,
+				Reason: fmt.Sprintf("backend=postgres resolves to an incomplete endpoint: postgres_dsn supplies no %s", strings.Join(missing, ", ")),
+			}
+		}
+		port, err := strconv.Atoi(endpoint.Port)
 		if err != nil || port < 1 || port > 65535 {
 			return MetadataState{}, false, &MetadataParseError{
 				Path:   abs,
-				Reason: fmt.Sprintf("postgres_port must be a TCP port (1..65535), got %q", state.PostgresPort),
+				Reason: fmt.Sprintf("postgres_port must be a TCP port (1..65535), got %q", endpoint.Port),
 			}
 		}
 	}
@@ -413,9 +436,10 @@ func LoadMetadataState(fs fsys.FS, path string) (MetadataState, bool, error) {
 //
 // Field-iteration order is the JSON-key declaration order on MetadataState
 // (dolt_mode, dolt_database, postgres_host, postgres_port, postgres_user,
-// postgres_database). When state.Backend is empty or unknown and both backend
-// families appear, the first populated field across both backends wins (with
-// Dolt fields preferred per declaration order).
+// postgres_database, postgres_dsn, postgres_schema). When state.Backend is
+// empty or unknown and both backend families appear, the first populated
+// field across both backends wins (with Dolt fields preferred per
+// declaration order).
 func mixedBackendField(state MetadataState) (string, bool) {
 	type entry struct {
 		name    string
@@ -429,6 +453,8 @@ func mixedBackendField(state MetadataState) (string, bool) {
 		{"postgres_port", state.PostgresPort, "postgres"},
 		{"postgres_user", state.PostgresUser, "postgres"},
 		{"postgres_database", state.PostgresDatabase, "postgres"},
+		{"postgres_dsn", state.PostgresDSN, "postgres"},
+		{"postgres_schema", state.PostgresSchema, "postgres"},
 	}
 	var firstDolt, firstPostgres string
 	for _, f := range fields {
@@ -586,6 +612,8 @@ func EnsureCanonicalMetadata(fs fsys.FS, path string, state MetadataState) (bool
 		"postgres_port":     strings.TrimSpace(state.PostgresPort),
 		"postgres_user":     strings.TrimSpace(state.PostgresUser),
 		"postgres_database": strings.TrimSpace(state.PostgresDatabase),
+		"postgres_dsn":      strings.TrimSpace(state.PostgresDSN),
+		"postgres_schema":   strings.TrimSpace(state.PostgresSchema),
 	}
 	for key, want := range defaults {
 		if want == "" {

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -1586,12 +1586,12 @@ func TestLoadMetadataStateRejectFixtures(t *testing.T) {
 		{
 			name:            "E4 postgres missing host",
 			fixture:         "reject_pg_missing_host.json",
-			wantErrContains: "backend=postgres requires postgres_host, postgres_port, postgres_user, postgres_database (all four must be non-empty)",
+			wantErrContains: "backend=postgres requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database",
 		},
 		{
 			name:            "E4 postgres missing all fields",
 			fixture:         "reject_pg_missing_all.json",
-			wantErrContains: "backend=postgres requires postgres_host, postgres_port, postgres_user, postgres_database (all four must be non-empty)",
+			wantErrContains: "backend=postgres requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database",
 		},
 		{
 			name:            "E5 postgres_port non-numeric",

--- a/internal/beads/contract/postgres_dsn.go
+++ b/internal/beads/contract/postgres_dsn.go
@@ -1,0 +1,162 @@
+package contract
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ErrPostgresDSNUnsupportedForm reports a postgres_dsn gc cannot derive an
+// endpoint from. Errors from ParsePostgresDSNEndpoint wrap it when the DSN is
+// not a postgres:// URL — most often because it uses libpq's keyword/value
+// form ("host=... port=..."), which bd accepts at init time but gc does not.
+// Callers match with errors.Is.
+var ErrPostgresDSNUnsupportedForm = errors.New("postgres_dsn must be a postgres:// (or postgresql://) URL")
+
+// PostgresEndpoint is the effective connection tuple for a postgres-backed
+// scope: the values gc projects to bd subprocesses (BEADS_POSTGRES_* names)
+// and keys credential lookups on ([host:port] credentials-file sections).
+//
+// ParsePostgresDSNEndpoint always populates Host and Port (Port defaults to
+// 5432) but may leave User or Database empty when the DSN omits them.
+// LoadMetadataState rejects a postgres scope whose endpoint is incomplete, so
+// an endpoint derived from a state it returned always has all four.
+type PostgresEndpoint struct {
+	Host     string
+	Port     string
+	User     string
+	Database string
+}
+
+// ParsePostgresDSNEndpoint derives the endpoint from a postgres:// (or
+// postgresql://) URL — the password-free shape bd persists to metadata.json
+// as postgres_dsn (`bd init --backend=postgres`). A missing port defaults to
+// 5432. Query parameters (sslmode etc.) are bd's business and are ignored. A
+// userinfo password is ignored: bd never persists one, and the password
+// reaches bd via BEADS_PG_PASSWORD at command time.
+//
+// libpq's keyword/value form ("host=... port=...") is not supported. bd
+// accepts it at init time, but gc requires the URL form to derive an endpoint
+// deterministically, and fails with ErrPostgresDSNUnsupportedForm rather than
+// deriving a partial one.
+func ParsePostgresDSNEndpoint(dsn string) (PostgresEndpoint, error) {
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" {
+		return PostgresEndpoint{}, errors.New("postgres_dsn is empty")
+	}
+	if isLibpqKeywordValueDSN(dsn) {
+		return PostgresEndpoint{}, fmt.Errorf("%w: libpq keyword/value form is not supported", ErrPostgresDSNUnsupportedForm)
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return PostgresEndpoint{}, fmt.Errorf("parse postgres_dsn: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "postgres", "postgresql":
+	default:
+		return PostgresEndpoint{}, fmt.Errorf("%w, got scheme %q", ErrPostgresDSNUnsupportedForm, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return PostgresEndpoint{}, errors.New("postgres_dsn has no host")
+	}
+	port := u.Port()
+	if port == "" {
+		port = "5432"
+	}
+	user := ""
+	if u.User != nil {
+		user = u.User.Username()
+	}
+	return PostgresEndpoint{
+		Host:     host,
+		Port:     port,
+		User:     user,
+		Database: strings.TrimPrefix(u.Path, "/"),
+	}, nil
+}
+
+// isLibpqKeywordValueDSN reports whether dsn is libpq's keyword/value form:
+// whitespace-separated key=value pairs with no URL scheme. Recognizing it
+// explicitly lets the failure name the unsupported form instead of reporting
+// a confusing empty scheme.
+func isLibpqKeywordValueDSN(dsn string) bool {
+	if strings.Contains(dsn, "://") {
+		return false
+	}
+	fields := strings.Fields(dsn)
+	if len(fields) == 0 {
+		return false
+	}
+	for _, field := range fields {
+		key, _, ok := strings.Cut(field, "=")
+		if !ok || key == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// PostgresEndpoint returns the effective endpoint for a postgres-backed
+// scope. The discrete postgres_host/port/user/database fields win outright
+// when all four are present; otherwise each missing field is filled from
+// postgres_dsn. A scope with neither a DSN nor the complete discrete set is
+// an error, as is one whose DSN does not parse.
+//
+// LoadMetadataState applies the same rules and additionally rejects an
+// incomplete result, so a postgres state it returns always derives a full
+// tuple here.
+func (s MetadataState) PostgresEndpoint() (PostgresEndpoint, error) {
+	ep := PostgresEndpoint{
+		Host:     strings.TrimSpace(s.PostgresHost),
+		Port:     strings.TrimSpace(s.PostgresPort),
+		User:     strings.TrimSpace(s.PostgresUser),
+		Database: strings.TrimSpace(s.PostgresDatabase),
+	}
+	if len(missingPostgresEndpointFields(ep)) == 0 {
+		return ep, nil
+	}
+	dsn := strings.TrimSpace(s.PostgresDSN)
+	if dsn == "" {
+		return PostgresEndpoint{}, errors.New("postgres scope requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database")
+	}
+	derived, err := ParsePostgresDSNEndpoint(dsn)
+	if err != nil {
+		return PostgresEndpoint{}, err
+	}
+	if ep.Host == "" {
+		ep.Host = derived.Host
+	}
+	if ep.Port == "" {
+		ep.Port = derived.Port
+	}
+	if ep.User == "" {
+		ep.User = derived.User
+	}
+	if ep.Database == "" {
+		ep.Database = derived.Database
+	}
+	return ep, nil
+}
+
+// missingPostgresEndpointFields names the metadata fields an endpoint still
+// lacks, in metadata declaration order, so rejections can tell an operator
+// exactly what the DSN did not supply.
+func missingPostgresEndpointFields(ep PostgresEndpoint) []string {
+	var missing []string
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"postgres_host", ep.Host},
+		{"postgres_port", ep.Port},
+		{"postgres_user", ep.User},
+		{"postgres_database", ep.Database},
+	} {
+		if field.value == "" {
+			missing = append(missing, field.name)
+		}
+	}
+	return missing
+}

--- a/internal/beads/contract/postgres_dsn.go
+++ b/internal/beads/contract/postgres_dsn.go
@@ -4,14 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
 // ErrPostgresDSNUnsupportedForm reports a postgres_dsn gc cannot derive an
 // endpoint from. Errors from ParsePostgresDSNEndpoint wrap it when the DSN is
-// not a postgres:// URL — most often because it uses libpq's keyword/value
-// form ("host=... port=..."), which bd accepts at init time but gc does not.
-// Callers match with errors.Is.
+// not a single-host postgres:// URL — most often because it uses libpq's
+// keyword/value form ("host=... port=..."), which bd accepts at init time but
+// gc does not. Callers match with errors.Is.
 var ErrPostgresDSNUnsupportedForm = errors.New("postgres_dsn must be a postgres:// (or postgresql://) URL")
 
 // PostgresEndpoint is the effective connection tuple for a postgres-backed
@@ -30,16 +31,25 @@ type PostgresEndpoint struct {
 }
 
 // ParsePostgresDSNEndpoint derives the endpoint from a postgres:// (or
-// postgresql://) URL — the password-free shape bd persists to metadata.json
-// as postgres_dsn (`bd init --backend=postgres`). A missing port defaults to
-// 5432. Query parameters (sslmode etc.) are bd's business and are ignored. A
-// userinfo password is ignored: bd never persists one, and the password
-// reaches bd via BEADS_PG_PASSWORD at command time.
+// postgresql://) URL — the password-free shape the Postgres add-on's
+// `bd init --backend=postgres --pg-url --pg-schema` persists to metadata.json
+// as postgres_dsn. A missing port defaults to 5432. Query parameters (sslmode
+// etc.) are bd's business and are ignored. A userinfo password is ignored: bd
+// strips it before persisting (pgdialect.RedactPassword, fail-closed) and
+// re-supplies it at command time from its credential ladder.
 //
-// libpq's keyword/value form ("host=... port=...") is not supported. bd
-// accepts it at init time, but gc requires the URL form to derive an endpoint
-// deterministically, and fails with ErrPostgresDSNUnsupportedForm rather than
-// deriving a partial one.
+// Three shapes are refused rather than guessed at, all wrapping
+// ErrPostgresDSNUnsupportedForm: libpq's keyword/value form ("host=..."),
+// libpq's multi-host form, and an unbracketed IPv6 literal. url.Parse splits
+// the latter two into a host that is not a host, and gc projects that host to
+// bd and keys credential lookups on it — a silently wrong endpoint is worse
+// than a refusal.
+//
+// No error returned here may quote the DSN. net/url's *url.Error renders as
+// `%s %q: %s` with the raw input, so wrapping it publishes a hand-written
+// password to stderr, `gc --json` failure payloads and CI logs. Unwrapping to
+// url.Error.Err is not sufficient either: `invalid port ":sword" after host`
+// and `invalid URL escape "%or"` still quote password fragments.
 func ParsePostgresDSNEndpoint(dsn string) (PostgresEndpoint, error) {
 	dsn = strings.TrimSpace(dsn)
 	if dsn == "" {
@@ -50,7 +60,7 @@ func ParsePostgresDSNEndpoint(dsn string) (PostgresEndpoint, error) {
 	}
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return PostgresEndpoint{}, fmt.Errorf("parse postgres_dsn: %w", err)
+		return PostgresEndpoint{}, fmt.Errorf("%w: not a parseable URL", ErrPostgresDSNUnsupportedForm)
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "postgres", "postgresql":
@@ -60,6 +70,15 @@ func ParsePostgresDSNEndpoint(dsn string) (PostgresEndpoint, error) {
 	host := u.Hostname()
 	if host == "" {
 		return PostgresEndpoint{}, errors.New("postgres_dsn has no host")
+	}
+	if strings.Contains(host, ",") {
+		return PostgresEndpoint{}, fmt.Errorf("%w: libpq multi-host form is not supported", ErrPostgresDSNUnsupportedForm)
+	}
+	// url.Hostname strips the brackets from an IPv6 literal, so a colon here
+	// with no bracket in the raw authority means url.Parse split somewhere
+	// other than a port separator.
+	if strings.Contains(host, ":") && !strings.HasPrefix(u.Host, "[") {
+		return PostgresEndpoint{}, fmt.Errorf("%w: an IPv6 host must be bracketed, as postgres://user@[::1]:5432/db", ErrPostgresDSNUnsupportedForm)
 	}
 	port := u.Port()
 	if port == "" {
@@ -138,6 +157,40 @@ func (s MetadataState) PostgresEndpoint() (PostgresEndpoint, error) {
 		ep.Database = derived.Database
 	}
 	return ep, nil
+}
+
+// validatePostgresEndpoint is the single gate every postgres scope passes: it
+// applies the derivation, completeness and port-range rules that decide
+// whether gc can open the scope at all. LoadMetadataState and preflight's
+// contract_shape check both call it, so a preflight PASS and a successful load
+// mean the same thing — a preflight that blessed a scope the loader then
+// refused would be worse than no check. Callers that need the tuple itself
+// call PostgresEndpoint, which this guarantees will succeed.
+//
+// The returned error is a plain error with a DSN-free message; callers that
+// need a typed rejection wrap it.
+func (s MetadataState) validatePostgresEndpoint() error {
+	hasDSN := strings.TrimSpace(s.PostgresDSN) != ""
+	hasAllDiscrete := len(missingPostgresEndpointFields(PostgresEndpoint{
+		Host:     strings.TrimSpace(s.PostgresHost),
+		Port:     strings.TrimSpace(s.PostgresPort),
+		User:     strings.TrimSpace(s.PostgresUser),
+		Database: strings.TrimSpace(s.PostgresDatabase),
+	})) == 0
+	if !hasDSN && !hasAllDiscrete {
+		return errors.New("backend=postgres requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database")
+	}
+	endpoint, err := s.PostgresEndpoint()
+	if err != nil {
+		return err
+	}
+	if missing := missingPostgresEndpointFields(endpoint); len(missing) > 0 {
+		return fmt.Errorf("backend=postgres resolves to an incomplete endpoint: postgres_dsn supplies no %s", strings.Join(missing, ", "))
+	}
+	if port, err := strconv.Atoi(endpoint.Port); err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("postgres_port must be a TCP port (1..65535), got %q", endpoint.Port)
+	}
+	return nil
 }
 
 // missingPostgresEndpointFields names the metadata fields an endpoint still

--- a/internal/beads/contract/postgres_dsn_test.go
+++ b/internal/beads/contract/postgres_dsn_test.go
@@ -1,19 +1,27 @@
 package contract
 
 import (
+	"encoding/json"
 	"errors"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-// These tests pin gc to bd origin/main's postgres metadata contract:
-// `bd init --backend=postgres` persists a password-free postgres_dsn plus a
-// per-workspace postgres_schema (beads internal/configfile/configfile.go),
-// NOT the draft-era discrete postgres_host/port/user/database fields. The
-// password never lands on disk; bd reads BEADS_PG_PASSWORD at command time.
+// These tests pin gc to bd's postgres metadata contract. The Postgres add-on's
+// `bd init --backend=postgres --pg-url --pg-schema` persists a password-free
+// postgres_dsn plus a per-workspace postgres_schema — see bd-enterprise
+// cmd/bd/backend_init_distribution_enterprise.go (runInitPostgres) for the
+// write and internal/storage/postgres/fromconfig.go for the read — NOT the
+// draft-era discrete postgres_host/port/user/database fields, which no bd has
+// ever written. pgdialect.RedactPassword keeps the password off disk
+// fail-closed; bd re-supplies it at command time from
+// BEADS_PG_PASSWORD_COMMAND or BEADS_PG_PASSWORD. OSS bd retains both keys as
+// deprecated round-trip storage and refuses to open backend=postgres, so gc
+// must preserve the shape it finds rather than force a hand-conversion.
 
 func TestParsePostgresDSNEndpoint(t *testing.T) {
 	cases := []struct {
@@ -103,9 +111,13 @@ func TestParsePostgresDSNEndpoint(t *testing.T) {
 			wantErr: "postgres_dsn must be a postgres:// (or postgresql://) URL",
 		},
 		{
+			// The rejection deliberately does NOT name the port: url.Parse's
+			// own "invalid port" message quotes the raw DSN, so the reason is
+			// the static unsupported-form sentinel instead. See
+			// TestParsePostgresDSNEndpointErrorsNeverEchoTheDSN.
 			name:    "non-numeric port",
 			dsn:     "postgres://bd@db.example.test:notaport/beads",
-			wantErr: "port",
+			wantErr: "not a parseable URL",
 		},
 	}
 	for _, tc := range cases {
@@ -286,20 +298,69 @@ func TestLoadMetadataStateAcceptsBdMainPostgresDSNShape(t *testing.T) {
 	}
 }
 
-func TestLoadMetadataStateRejectsDoltWithPostgresDSN(t *testing.T) {
+// TestLoadMetadataStateToleratesDoltScopeWithPostgresResidue pins the one
+// asymmetry in the mixed-backend guard. postgres_dsn/postgres_schema are bd's
+// own fields: bd retains them across a re-init, so flipping a Postgres
+// workspace to Dolt leaves them behind on disk with no operator involvement.
+// A declared backend=dolt is unambiguous and the residue is inert, so the
+// scope must still load — gc scrubs the keys on the next canonicalise instead
+// of bricking every command until a human hand-edits the file. The discrete
+// postgres_host/port/user/database fields have no such producer and stay
+// fatal (TestLoadMetadataStateRejectsDoltWithPostgresField).
+func TestLoadMetadataStateToleratesDoltScopeWithPostgresResidue(t *testing.T) {
 	fs := fsys.OSFS{}
-	path, _ := copyMetadataFixture(t, fs, "reject_dolt_with_postgres_dsn.json")
+	path, _ := copyMetadataFixture(t, fs, "dolt_with_postgres_residue.json")
+	got, ok, err := LoadMetadataState(fs, path)
+	if err != nil || !ok {
+		t.Fatalf("LoadMetadataState(dolt_with_postgres_residue.json) = ok=%v err=%v, want the scope to load", ok, err)
+	}
+	if got.Backend != "dolt" || got.DoltDatabase != "hq" {
+		t.Fatalf("state = %+v, want the dolt binding preserved", got)
+	}
+
+	// The residue must survive into the state so canonicalisation can see and
+	// scrub it, and EnsureCanonicalMetadata must actually remove it.
+	if got.PostgresDSN == "" || got.PostgresSchema == "" {
+		t.Fatalf("state = %+v, want the postgres residue carried through for scrubbing", got)
+	}
+	if _, err := EnsureCanonicalMetadata(fs, path, MetadataState{
+		Database:     got.Database,
+		Backend:      "dolt",
+		DoltMode:     got.DoltMode,
+		DoltDatabase: got.DoltDatabase,
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"postgres_dsn", "postgres_schema"} {
+		if strings.Contains(string(data), key) {
+			t.Errorf("canonicalise left %q behind: %s", key, data)
+		}
+	}
+	if _, ok, err := LoadMetadataState(fs, path); err != nil || !ok {
+		t.Fatalf("LoadMetadataState after canonicalise = ok=%v err=%v, want a clean load", ok, err)
+	}
+}
+
+// TestLoadMetadataStateRejectsDoltWithPostgresField keeps the mixed-backend
+// guard fatal for the discrete fields, which are gc's own and have no
+// legitimate producer on a dolt scope.
+func TestLoadMetadataStateRejectsDoltWithPostgresField(t *testing.T) {
+	fs := fsys.OSFS{}
+	path, _ := copyMetadataFixture(t, fs, "reject_dolt_with_postgres_field.json")
 	_, ok, err := LoadMetadataState(fs, path)
 	if err == nil || ok {
-		t.Fatalf("LoadMetadataState(reject_dolt_with_postgres_dsn.json) = ok=%v err=%v, want mixed-backend rejection", ok, err)
+		t.Fatalf("LoadMetadataState(reject_dolt_with_postgres_field.json) = ok=%v err=%v, want mixed-backend rejection", ok, err)
 	}
 	var parseErr *MetadataParseError
 	if !errors.As(err, &parseErr) {
 		t.Fatalf("error %T = %v, want *MetadataParseError", err, err)
 	}
-	want := "cannot mix dolt and postgres fields in a single scope (backend=dolt but postgres_dsn is also set)"
-	if !strings.Contains(parseErr.Reason, want) {
-		t.Fatalf("Reason = %q, want substring %q", parseErr.Reason, want)
+	if !strings.Contains(parseErr.Reason, "cannot mix dolt and postgres fields") {
+		t.Fatalf("Reason = %q, want the mixed-backend rejection", parseErr.Reason)
 	}
 }
 
@@ -357,6 +418,194 @@ func TestLoadMetadataStateRejectsPostgresDSNPortOutOfRange(t *testing.T) {
 	}
 	if !strings.Contains(parseErr.Reason, "postgres_port must be a TCP port (1..65535), got \"99999\"") {
 		t.Fatalf("Reason = %q, want the TCP-port rejection naming the DSN-derived port", parseErr.Reason)
+	}
+}
+
+// leakyDSNCases are the malformed DSNs whose parse failure is most likely to
+// carry a credential: url.Parse fails on exactly the bytes ('%', '/', control
+// characters, brackets) that generated passwords contain, so the failure
+// correlates with the secret being present. secret is a fragment that must not
+// survive into any error text — checking a fragment rather than the whole
+// password catches the partial echoes ("invalid URL escape \"%or\"",
+// "invalid port \":sword\"") that unwrapping to url.Error.Err would leave.
+var leakyDSNCases = []struct {
+	name   string
+	dsn    string
+	secret string
+}{
+	{
+		name:   "percent in password",
+		dsn:    "postgres://operator:sw%ordfish@db.example.com:5432/gascity",
+		secret: "ordfish",
+	},
+	{
+		name:   "slash in password",
+		dsn:    "postgres://operator:sword/fish@db.example.com:5432/gascity",
+		secret: "sword",
+	},
+	{
+		name:   "control character in password",
+		dsn:    "postgres://operator:sword\x7ffish@db.example.com:5432/gascity",
+		secret: "sword",
+	},
+	{
+		name:   "unbalanced bracket in host",
+		dsn:    "postgres://operator:swordfish@[db.example.com:5432/gascity",
+		secret: "swordfish",
+	},
+	{
+		name:   "non-numeric port",
+		dsn:    "postgres://operator:swordfish@db.example.com:notaport/gascity",
+		secret: "swordfish",
+	},
+}
+
+// TestParsePostgresDSNEndpointErrorsNeverEchoTheDSN pins the invariant at the
+// point of failure: no error ParsePostgresDSNEndpoint returns may quote the
+// DSN. net/url's *url.Error renders as `%s %q: %s` with the raw input, so
+// wrapping it with %w publishes any hand-written password verbatim.
+func TestParsePostgresDSNEndpointErrorsNeverEchoTheDSN(t *testing.T) {
+	for _, tc := range leakyDSNCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParsePostgresDSNEndpoint(tc.dsn)
+			if err == nil {
+				t.Fatalf("ParsePostgresDSNEndpoint(%q) error = nil, want a rejection", tc.dsn)
+			}
+			assertDSNFree(t, err.Error(), tc.dsn, tc.secret)
+		})
+	}
+}
+
+// TestLoadMetadataStateErrorNeverEchoesPostgresDSN is the load-path twin of
+// TestPreflightFailsContractShapeOnUnderivablePostgresDSN's leak assertion.
+// The preflight summary is a diagnostic surface; this is the one every gc
+// command traverses to build a bd subprocess environment, and its error text
+// reaches stderr, `gc --json` failure payloads, and captured CI logs.
+func TestLoadMetadataStateErrorNeverEchoesPostgresDSN(t *testing.T) {
+	for _, tc := range leakyDSNCases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(map[string]string{
+				"database":     "beads",
+				"backend":      "postgres",
+				"postgres_dsn": tc.dsn,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := writeTempMetadata(t, string(raw))
+			_, ok, err := LoadMetadataState(fsys.OSFS{}, path)
+			if err == nil || ok {
+				t.Fatalf("LoadMetadataState = ok=%v err=%v, want a rejection", ok, err)
+			}
+			assertDSNFree(t, err.Error(), tc.dsn, tc.secret)
+
+			var parseErr *MetadataParseError
+			if !errors.As(err, &parseErr) {
+				t.Fatalf("error %T = %v, want *MetadataParseError", err, err)
+			}
+			assertDSNFree(t, parseErr.Reason, tc.dsn, tc.secret)
+			// The rejection still has to be actionable without the DSN.
+			if !strings.Contains(parseErr.Reason, "postgres_dsn") {
+				t.Errorf("Reason = %q, want it to name postgres_dsn as the offending field", parseErr.Reason)
+			}
+		})
+	}
+}
+
+// dsnWithUserinfoRe matches a postgres URL carrying userinfo. Naming the
+// required form ("must be a postgres:// URL") is fine; echoing a concrete URL
+// that reached the `user:password@host` stage is not, and catches the leak
+// class even for fixtures whose password this test does not know.
+var dsnWithUserinfoRe = regexp.MustCompile(`postgres(ql)?://[^\s"]*@`)
+
+// assertDSNFree fails when a message quotes the DSN or any fragment of its
+// password.
+func assertDSNFree(t *testing.T, msg, dsn, secret string) {
+	t.Helper()
+	if strings.Contains(msg, dsn) {
+		t.Errorf("message echoes the raw postgres_dsn: %q", msg)
+	}
+	if strings.Contains(msg, secret) {
+		t.Errorf("message leaks password fragment %q: %q", secret, msg)
+	}
+	if dsnWithUserinfoRe.MatchString(msg) {
+		t.Errorf("message quotes a postgres URL carrying userinfo: %q", msg)
+	}
+}
+
+// TestParsePostgresDSNEndpointRejectsAmbiguousHosts covers the DSN shapes
+// url.Parse accepts but splits wrongly. libpq's multi-host form and an
+// unbracketed IPv6 literal both yield a host that is not a host, and every
+// downstream gate passes it: it is projected as BEADS_POSTGRES_HOST and keyed
+// into credential lookups. Refusing beats connecting somewhere unintended.
+func TestParsePostgresDSNEndpointRejectsAmbiguousHosts(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+	}{
+		{name: "multi-host with ports", dsn: "postgres://bd@host1.example.test:5432,host2.example.test:5432/beads"},
+		{name: "multi-host without ports", dsn: "postgres://bd@host1.example.test,host2.example.test/beads"},
+		{name: "unbracketed ipv6 with port", dsn: "postgres://bd@2001:db8::1:5432/beads"},
+		{name: "unbracketed ipv6 loopback", dsn: "postgres://bd@::1/beads"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParsePostgresDSNEndpoint(tc.dsn)
+			if err == nil {
+				t.Fatalf("ParsePostgresDSNEndpoint(%q) = %+v, want a rejection (host is ambiguous)", tc.dsn, got)
+			}
+			if !errors.Is(err, ErrPostgresDSNUnsupportedForm) {
+				t.Fatalf("error %v, want errors.Is(err, ErrPostgresDSNUnsupportedForm)", err)
+			}
+			if got != (PostgresEndpoint{}) {
+				t.Fatalf("ParsePostgresDSNEndpoint(%q) = %+v, want the zero endpoint", tc.dsn, got)
+			}
+		})
+	}
+}
+
+// TestPreflightContractShapeAgreesWithLoadMetadataState pins preflight to the
+// load gate. contract_shape reporting PASS for a DSN LoadMetadataState refuses
+// is worse than no check at all: preflight exists to tell an operator whether
+// gc can open the scope, so a PASS that precedes a hard load failure is a lie.
+func TestPreflightContractShapeAgreesWithLoadMetadataState(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+		want PreflightCheckState
+	}{
+		{name: "derivable", dsn: "postgres://gc_city@pg.example.test:6543/gascity_infra", want: PreflightCheckPass},
+		{name: "no database", dsn: "postgres://bd@db.example.test:5432", want: PreflightCheckFail},
+		{name: "no user", dsn: "postgres://db.example.test:5432/beads", want: PreflightCheckFail},
+		{name: "port out of range", dsn: "postgres://bd@db.example.test:99999/beads", want: PreflightCheckFail},
+		{name: "libpq keyword/value", dsn: "host=db.example.test port=5432 user=bd dbname=beads", want: PreflightCheckFail},
+		{name: "multi-host", dsn: "postgres://bd@host1.example.test:5432,host2.example.test:5432/beads", want: PreflightCheckFail},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PreflightChecker{}.checkContractShape(preflightMetadata{
+				Backend:     "postgres",
+				PostgresDSN: tc.dsn,
+			})
+			if got.State != tc.want {
+				t.Errorf("checkContractShape state = %v, want %v (summary %q)", got.State, tc.want, got.Summary)
+			}
+
+			raw, err := json.Marshal(map[string]string{
+				"database":     "beads",
+				"backend":      "postgres",
+				"postgres_dsn": tc.dsn,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := writeTempMetadata(t, string(raw))
+			_, ok, loadErr := LoadMetadataState(fsys.OSFS{}, path)
+			loads := ok && loadErr == nil
+			if loads != (tc.want == PreflightCheckPass) {
+				t.Errorf("LoadMetadataState loads = %v but contract_shape wants %v — preflight and the load gate disagree (load err %v)", loads, tc.want, loadErr)
+			}
+		})
 	}
 }
 

--- a/internal/beads/contract/postgres_dsn_test.go
+++ b/internal/beads/contract/postgres_dsn_test.go
@@ -1,0 +1,450 @@
+package contract
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// These tests pin gc to bd origin/main's postgres metadata contract:
+// `bd init --backend=postgres` persists a password-free postgres_dsn plus a
+// per-workspace postgres_schema (beads internal/configfile/configfile.go),
+// NOT the draft-era discrete postgres_host/port/user/database fields. The
+// password never lands on disk; bd reads BEADS_PG_PASSWORD at command time.
+
+func TestParsePostgresDSNEndpoint(t *testing.T) {
+	cases := []struct {
+		name    string
+		dsn     string
+		want    PostgresEndpoint
+		wantErr string
+	}{
+		{
+			name: "full url",
+			dsn:  "postgres://gc_city@pg.example.test:5432/gascity_infra",
+			want: PostgresEndpoint{Host: "pg.example.test", Port: "5432", User: "gc_city", Database: "gascity_infra"},
+		},
+		{
+			name: "postgresql scheme",
+			dsn:  "postgresql://gc_city@pg.example.test:5432/gascity_infra",
+			want: PostgresEndpoint{Host: "pg.example.test", Port: "5432", User: "gc_city", Database: "gascity_infra"},
+		},
+		{
+			name: "non-default port",
+			dsn:  "postgres://bd@db.example.test:6543/beads",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "6543", User: "bd", Database: "beads"},
+		},
+		{
+			name: "missing port defaults to 5432",
+			dsn:  "postgres://bd@db.example.test/beads",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "bd", Database: "beads"},
+		},
+		{
+			name: "missing user",
+			dsn:  "postgres://db.example.test:6543/beads",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "6543", User: "", Database: "beads"},
+		},
+		{
+			name: "missing database",
+			dsn:  "postgres://bd@db.example.test:5432",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "bd", Database: ""},
+		},
+		{
+			name: "ipv6 host with port",
+			dsn:  "postgres://bd@[2001:db8::1]:6543/beads",
+			want: PostgresEndpoint{Host: "2001:db8::1", Port: "6543", User: "bd", Database: "beads"},
+		},
+		{
+			name: "ipv6 host without port defaults to 5432",
+			dsn:  "postgres://bd@[::1]/beads",
+			want: PostgresEndpoint{Host: "::1", Port: "5432", User: "bd", Database: "beads"},
+		},
+		{
+			name: "percent-encoded user is decoded",
+			dsn:  "postgres://gc%40city@db.example.test:5432/beads",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "gc@city", Database: "beads"},
+		},
+		{
+			name: "percent-encoded database is decoded",
+			dsn:  "postgres://bd@db.example.test:5432/gas%20city",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "bd", Database: "gas city"},
+		},
+		{
+			name: "query params are ignored",
+			dsn:  "postgres://bd@db.example.test:6543/beads?sslmode=require&connect_timeout=5",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "6543", User: "bd", Database: "beads"},
+		},
+		{
+			name: "userinfo password is ignored (never persisted by bd)",
+			dsn:  "postgres://bd:sneaky@db.example.test:5432/beads",
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "bd", Database: "beads"},
+		},
+		{
+			name:    "empty dsn",
+			dsn:     "",
+			wantErr: "postgres_dsn is empty",
+		},
+		{
+			name:    "non-postgres scheme",
+			dsn:     "mysql://bd@db.example.test:3306/beads",
+			wantErr: "postgres_dsn must be a postgres:// (or postgresql://) URL",
+		},
+		{
+			name:    "no host",
+			dsn:     "postgres:///beads",
+			wantErr: "postgres_dsn has no host",
+		},
+		{
+			name:    "libpq keyword/value form is not a URL",
+			dsn:     "host=db.example.test port=5432 user=bd dbname=beads",
+			wantErr: "postgres_dsn must be a postgres:// (or postgresql://) URL",
+		},
+		{
+			name:    "non-numeric port",
+			dsn:     "postgres://bd@db.example.test:notaport/beads",
+			wantErr: "port",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParsePostgresDSNEndpoint(tc.dsn)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParsePostgresDSNEndpoint(%q) error = nil, want substring %q (got %+v)", tc.dsn, tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("ParsePostgresDSNEndpoint(%q) error = %q, want substring %q", tc.dsn, err.Error(), tc.wantErr)
+				}
+				if got != (PostgresEndpoint{}) {
+					t.Fatalf("ParsePostgresDSNEndpoint(%q) = %+v on error, want the zero endpoint (no partial derivation)", tc.dsn, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePostgresDSNEndpoint(%q) error = %v, want nil", tc.dsn, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParsePostgresDSNEndpoint(%q) = %+v, want %+v", tc.dsn, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParsePostgresDSNEndpointRejectsLibpqKeywordValue pins the one shape bd
+// accepts at init time but gc cannot derive an endpoint from. It must fail by
+// name rather than silently deriving a wrong or partial endpoint.
+func TestParsePostgresDSNEndpointRejectsLibpqKeywordValue(t *testing.T) {
+	const dsn = "host=db.example.test port=6543 user=bd dbname=beads sslmode=require"
+	got, err := ParsePostgresDSNEndpoint(dsn)
+	if err == nil {
+		t.Fatalf("ParsePostgresDSNEndpoint(%q) = %+v, want an error", dsn, got)
+	}
+	if !errors.Is(err, ErrPostgresDSNUnsupportedForm) {
+		t.Fatalf("error %v, want errors.Is(err, ErrPostgresDSNUnsupportedForm)", err)
+	}
+	if got != (PostgresEndpoint{}) {
+		t.Fatalf("ParsePostgresDSNEndpoint(%q) = %+v, want the zero endpoint", dsn, got)
+	}
+	// The failure must name the unsupported form so an operator knows what to
+	// change, not just that "something" is wrong.
+	for _, want := range []string{"keyword/value", "postgres://"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want substring %q", err.Error(), want)
+		}
+	}
+}
+
+func TestMetadataStatePostgresEndpoint(t *testing.T) {
+	cases := []struct {
+		name    string
+		state   MetadataState
+		want    PostgresEndpoint
+		wantErr string
+	}{
+		{
+			name: "draft shape: discrete fields pass through untouched",
+			state: MetadataState{
+				Backend:          "postgres",
+				PostgresHost:     "db.example.test",
+				PostgresPort:     "5432",
+				PostgresUser:     "bd",
+				PostgresDatabase: "beads",
+			},
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "bd", Database: "beads"},
+		},
+		{
+			name: "complete discrete fields win over a DSN pointing elsewhere",
+			state: MetadataState{
+				Backend:          "postgres",
+				PostgresDSN:      "postgres://other@elsewhere.test:9999/otherdb",
+				PostgresHost:     "db.example.test",
+				PostgresPort:     "5432",
+				PostgresUser:     "bd",
+				PostgresDatabase: "beads",
+			},
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "bd", Database: "beads"},
+		},
+		{
+			name: "complete discrete fields win even when the DSN is unparseable",
+			state: MetadataState{
+				Backend:          "postgres",
+				PostgresDSN:      "host=elsewhere.test port=9999",
+				PostgresHost:     "db.example.test",
+				PostgresPort:     "5432",
+				PostgresUser:     "bd",
+				PostgresDatabase: "beads",
+			},
+			want: PostgresEndpoint{Host: "db.example.test", Port: "5432", User: "bd", Database: "beads"},
+		},
+		{
+			name: "bd-main shape: endpoint derived from postgres_dsn",
+			state: MetadataState{
+				Backend:        "postgres",
+				PostgresDSN:    "postgres://gc_city@pg.example.test:6543/gascity_infra",
+				PostgresSchema: "city_x",
+			},
+			want: PostgresEndpoint{Host: "pg.example.test", Port: "6543", User: "gc_city", Database: "gascity_infra"},
+		},
+		{
+			name: "incomplete discrete set falls back to the DSN for the missing fields",
+			state: MetadataState{
+				Backend:      "postgres",
+				PostgresDSN:  "postgres://gc_city@pg.example.test:5432/gascity_infra",
+				PostgresHost: "override.example.test",
+			},
+			want: PostgresEndpoint{Host: "override.example.test", Port: "5432", User: "gc_city", Database: "gascity_infra"},
+		},
+		{
+			name:    "neither DSN nor discrete fields",
+			state:   MetadataState{Backend: "postgres"},
+			wantErr: "postgres scope requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database",
+		},
+		{
+			name: "incomplete discrete set with an unparseable DSN surfaces the parse error",
+			state: MetadataState{
+				Backend:      "postgres",
+				PostgresDSN:  "host=db.example.test port=5432",
+				PostgresHost: "db.example.test",
+			},
+			wantErr: "keyword/value",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.state.PostgresEndpoint()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("PostgresEndpoint() error = nil, want substring %q (got %+v)", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("PostgresEndpoint() error = %q, want substring %q", err.Error(), tc.wantErr)
+				}
+				if got != (PostgresEndpoint{}) {
+					t.Fatalf("PostgresEndpoint() = %+v on error, want the zero endpoint (no partial derivation)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("PostgresEndpoint() error = %v, want nil", err)
+			}
+			if got != tc.want {
+				t.Fatalf("PostgresEndpoint() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadMetadataStateAcceptsBdMainPostgresDSNShape(t *testing.T) {
+	fs := fsys.OSFS{}
+	path, _ := copyMetadataFixture(t, fs, "valid_postgres_dsn.json")
+	got, ok, err := LoadMetadataState(fs, path)
+	if err != nil {
+		t.Fatalf("LoadMetadataState(valid_postgres_dsn.json) error = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatalf("LoadMetadataState(valid_postgres_dsn.json) ok = false, want true")
+	}
+	want := MetadataState{
+		Database:       "beads",
+		Backend:        "postgres",
+		PostgresDSN:    "postgres://gc_city@pg.example.test:6543/gascity_infra",
+		PostgresSchema: "city_x",
+	}
+	if got != want {
+		t.Fatalf("LoadMetadataState(valid_postgres_dsn.json) = %+v, want %+v", got, want)
+	}
+	endpoint, err := got.PostgresEndpoint()
+	if err != nil {
+		t.Fatalf("PostgresEndpoint() error = %v, want nil (LoadMetadataState guarantees derivable states)", err)
+	}
+	wantEndpoint := PostgresEndpoint{Host: "pg.example.test", Port: "6543", User: "gc_city", Database: "gascity_infra"}
+	if endpoint != wantEndpoint {
+		t.Fatalf("PostgresEndpoint() = %+v, want %+v", endpoint, wantEndpoint)
+	}
+}
+
+func TestLoadMetadataStateRejectsDoltWithPostgresDSN(t *testing.T) {
+	fs := fsys.OSFS{}
+	path, _ := copyMetadataFixture(t, fs, "reject_dolt_with_postgres_dsn.json")
+	_, ok, err := LoadMetadataState(fs, path)
+	if err == nil || ok {
+		t.Fatalf("LoadMetadataState(reject_dolt_with_postgres_dsn.json) = ok=%v err=%v, want mixed-backend rejection", ok, err)
+	}
+	var parseErr *MetadataParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error %T = %v, want *MetadataParseError", err, err)
+	}
+	want := "cannot mix dolt and postgres fields in a single scope (backend=dolt but postgres_dsn is also set)"
+	if !strings.Contains(parseErr.Reason, want) {
+		t.Fatalf("Reason = %q, want substring %q", parseErr.Reason, want)
+	}
+}
+
+// TestLoadMetadataStateRejectsUnparseablePostgresDSN is the load-boundary half
+// of the libpq limitation: a scope gc cannot derive an endpoint for is refused
+// outright, so no consumer ever sees a half-populated MetadataState.
+func TestLoadMetadataStateRejectsUnparseablePostgresDSN(t *testing.T) {
+	fs := fsys.OSFS{}
+	path, _ := copyMetadataFixture(t, fs, "reject_pg_dsn_libpq_form.json")
+	_, ok, err := LoadMetadataState(fs, path)
+	if err == nil || ok {
+		t.Fatalf("LoadMetadataState(reject_pg_dsn_libpq_form.json) = ok=%v err=%v, want rejection", ok, err)
+	}
+	var parseErr *MetadataParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error %T = %v, want *MetadataParseError", err, err)
+	}
+	for _, want := range []string{"postgres_dsn", "keyword/value"} {
+		if !strings.Contains(parseErr.Reason, want) {
+			t.Errorf("Reason = %q, want substring %q", parseErr.Reason, want)
+		}
+	}
+}
+
+// TestLoadMetadataStateRejectsIncompletePostgresDSN keeps MetadataState's
+// documented invariant true across the widening: a postgres state handed to a
+// consumer always derives a complete host/port/user/database tuple, so the
+// BEADS_POSTGRES_* projection can never go out with empty values.
+func TestLoadMetadataStateRejectsIncompletePostgresDSN(t *testing.T) {
+	fs := fsys.OSFS{}
+	path, _ := copyMetadataFixture(t, fs, "reject_pg_dsn_no_database.json")
+	_, ok, err := LoadMetadataState(fs, path)
+	if err == nil || ok {
+		t.Fatalf("LoadMetadataState(reject_pg_dsn_no_database.json) = ok=%v err=%v, want rejection", ok, err)
+	}
+	var parseErr *MetadataParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error %T = %v, want *MetadataParseError", err, err)
+	}
+	if !strings.Contains(parseErr.Reason, "postgres_database") {
+		t.Fatalf("Reason = %q, want it to name the missing postgres_database", parseErr.Reason)
+	}
+}
+
+func TestLoadMetadataStateRejectsPostgresDSNPortOutOfRange(t *testing.T) {
+	fs := fsys.OSFS{}
+	path := writeTempMetadata(t, `{"database":"beads","backend":"postgres","postgres_dsn":"postgres://bd@db.example.test:99999/beads"}`)
+	_, ok, err := LoadMetadataState(fs, path)
+	if err == nil || ok {
+		t.Fatalf("LoadMetadataState = ok=%v err=%v, want port-range rejection", ok, err)
+	}
+	var parseErr *MetadataParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error %T = %v, want *MetadataParseError", err, err)
+	}
+	if !strings.Contains(parseErr.Reason, "postgres_port must be a TCP port (1..65535), got \"99999\"") {
+		t.Fatalf("Reason = %q, want the TCP-port rejection naming the DSN-derived port", parseErr.Reason)
+	}
+}
+
+func TestEnsureCanonicalMetadataWritesPostgresDSNAndSchema(t *testing.T) {
+	fs := fsys.OSFS{}
+	path := writeTempMetadata(t, `{"database":"beads","backend":"postgres"}`)
+	changed, err := EnsureCanonicalMetadata(fs, path, MetadataState{
+		Database:       "beads",
+		Backend:        "postgres",
+		PostgresDSN:    "postgres://gc_city@pg.example.test:5432/gascity_infra",
+		PostgresSchema: "city_x",
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	if !changed {
+		t.Fatalf("EnsureCanonicalMetadata changed = false, want true")
+	}
+	state, ok, err := LoadMetadataState(fs, path)
+	if err != nil || !ok {
+		t.Fatalf("LoadMetadataState after canonicalise: ok=%v err=%v", ok, err)
+	}
+	if state.PostgresDSN != "postgres://gc_city@pg.example.test:5432/gascity_infra" {
+		t.Errorf("postgres_dsn = %q, want persisted DSN", state.PostgresDSN)
+	}
+	if state.PostgresSchema != "city_x" {
+		t.Errorf("postgres_schema = %q, want city_x", state.PostgresSchema)
+	}
+}
+
+func TestEnsureCanonicalMetadataScrubsPostgresDSNOnDoltCanonicalise(t *testing.T) {
+	fs := fsys.OSFS{}
+	path := writeTempMetadata(t, `{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq","postgres_dsn":"postgres://bd@db.example.test:5432/beads","postgres_schema":"city_x"}`)
+	changed, err := EnsureCanonicalMetadata(fs, path, MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "hq",
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	if !changed {
+		t.Fatalf("EnsureCanonicalMetadata changed = false, want true (postgres_dsn/postgres_schema must be scrubbed)")
+	}
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"postgres_dsn", "postgres_schema"} {
+		if strings.Contains(string(data), key) {
+			t.Errorf("dolt canonicalise left %q in metadata.json: %s", key, data)
+		}
+	}
+}
+
+func TestEnsureCanonicalMetadataByteIdenticalForCanonicalDSNScope(t *testing.T) {
+	fs := fsys.OSFS{}
+	path := writeTempMetadata(t, `{"backend":"postgres","database":"beads","postgres_dsn":"postgres://gc_city@pg.example.test:5432/gascity_infra","postgres_schema":"city_x"}`)
+	state, ok, err := LoadMetadataState(fs, path)
+	if err != nil || !ok {
+		t.Fatalf("LoadMetadataState: ok=%v err=%v", ok, err)
+	}
+	before, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureCanonicalMetadata(fs, path, state)
+	if err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	if changed {
+		t.Fatalf("EnsureCanonicalMetadata changed = true, want false (round-trip must be a no-op)")
+	}
+	after, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("metadata.json rewritten on no-op round-trip:\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func writeTempMetadata(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "metadata.json")
+	if err := (fsys.OSFS{}).WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -310,17 +310,20 @@ func (c PreflightChecker) checkContractShape(metadata preflightMetadata) Preflig
 		if hasDSN {
 			// Gas City derives the endpoint from postgres_dsn (see
 			// MetadataState.PostgresEndpoint), so the DSN form is a shape gc
-			// understands rather than one to convert. Only a DSN gc cannot
-			// derive from — libpq's keyword/value form, a non-postgres scheme,
-			// a hostless URL — is a shape problem, and it is a hard one: the
-			// scope has no usable endpoint at all.
+			// understands rather than one to convert. The gate is
+			// validatePostgresEndpoint — the one LoadMetadataState uses — so a
+			// PASS here means the loader will accept the scope. Gating on
+			// ParsePostgresDSNEndpoint alone would PASS a DSN that parses but
+			// supplies no database, or a port outside 1..65535, both of which
+			// the loader hard-rejects.
 			//
 			// The summary stays free of the DSN itself: only
 			// PostgresDSNRedacted is sanitized on the way out, so echoing a
 			// parse error that quotes the DSN would leak a hand-written
 			// password past Redacted().
-			if _, err := ParsePostgresDSNEndpoint(metadata.PostgresDSN); err != nil {
-				return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckFail, "postgres_dsn is not a derivable postgres:// URL", details)
+			state := MetadataState{Backend: "postgres", PostgresDSN: metadata.PostgresDSN}
+			if err := state.validatePostgresEndpoint(); err != nil {
+				return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckFail, "postgres_dsn does not resolve to a complete postgres endpoint", details)
 			}
 			return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckPass, "Metadata uses postgres_dsn shape", details)
 		}

--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -308,7 +308,21 @@ func (c PreflightChecker) checkContractShape(metadata preflightMetadata) Preflig
 		return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckPass, "Metadata uses dolt shape", details)
 	case "postgres":
 		if hasDSN {
-			return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckWarn, "postgres_dsn present; Gas City expects split fields", details)
+			// Gas City derives the endpoint from postgres_dsn (see
+			// MetadataState.PostgresEndpoint), so the DSN form is a shape gc
+			// understands rather than one to convert. Only a DSN gc cannot
+			// derive from — libpq's keyword/value form, a non-postgres scheme,
+			// a hostless URL — is a shape problem, and it is a hard one: the
+			// scope has no usable endpoint at all.
+			//
+			// The summary stays free of the DSN itself: only
+			// PostgresDSNRedacted is sanitized on the way out, so echoing a
+			// parse error that quotes the DSN would leak a hand-written
+			// password past Redacted().
+			if _, err := ParsePostgresDSNEndpoint(metadata.PostgresDSN); err != nil {
+				return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckFail, "postgres_dsn is not a derivable postgres:// URL", details)
+			}
+			return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckPass, "Metadata uses postgres_dsn shape", details)
 		}
 		if metadata.hasCompletePostgresSplitFields() {
 			return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckPass, "Metadata uses split postgres shape", details)

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -50,7 +50,10 @@ func TestPreflightRedactsPostgresDSN(t *testing.T) {
 
 	assertPreflightVerdict(t, result, PreflightVerdictDegraded, false)
 	assertCheckState(t, result, PreflightCheckMetadataBackend, PreflightCheckWarn)
-	assertCheckState(t, result, PreflightCheckContractShape, PreflightCheckWarn)
+	// Gas City derives the endpoint from postgres_dsn, so the DSN form is a
+	// shape gc understands — the contract-shape check must not nag operators
+	// to convert it back to the discrete fields.
+	assertCheckState(t, result, PreflightCheckContractShape, PreflightCheckPass)
 	check := findPreflightCheck(t, result, PreflightCheckMetadataBackend)
 	if check.Details.PostgresDSNRedacted != "postgres://[REDACTED]" {
 		t.Fatalf("PostgresDSNRedacted = %q, want redacted DSN", check.Details.PostgresDSNRedacted)
@@ -61,6 +64,36 @@ func TestPreflightRedactsPostgresDSN(t *testing.T) {
 	}
 	if strings.Contains(string(data), "swordfish") || strings.Contains(string(data), "operator:swordfish") {
 		t.Fatalf("serialized result leaked DSN secret: %s", data)
+	}
+}
+
+// TestPreflightFailsContractShapeOnUnderivablePostgresDSN pins the other half
+// of the postgres_dsn widening: gc accepts the DSN form, so the shape check
+// only fires for a DSN it cannot derive an endpoint from — and it fails hard,
+// because such a scope has no usable endpoint at all.
+func TestPreflightFailsContractShapeOnUnderivablePostgresDSN(t *testing.T) {
+	scope := "/city"
+	checker := testPreflightChecker(preflightMetadataJSON(`{
+		"backend": "postgres",
+		"postgres_dsn": "host=db.example.com port=5432 user=operator dbname=gascity",
+		"project_id": "gc-local"
+	}`), PreflightBDContext{Backend: "postgres"}, "gc-local")
+
+	result, err := checker.Check(scope)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	assertPreflightVerdict(t, result, PreflightVerdictBlocked, false)
+	assertCheckState(t, result, PreflightCheckContractShape, PreflightCheckFail)
+	check := findPreflightCheck(t, result, PreflightCheckContractShape)
+	if !strings.Contains(check.Summary, "postgres_dsn") {
+		t.Errorf("Summary = %q, want it to name postgres_dsn", check.Summary)
+	}
+	// The summary must never echo the DSN: only PostgresDSNRedacted is
+	// sanitized on the way out.
+	if strings.Contains(check.Summary, "db.example.com") {
+		t.Errorf("Summary = %q, leaked the raw DSN", check.Summary)
 	}
 }
 

--- a/internal/beads/contract/testdata/metadata/dolt_with_postgres_residue.json
+++ b/internal/beads/contract/testdata/metadata/dolt_with_postgres_residue.json
@@ -3,5 +3,6 @@
   "backend": "dolt",
   "dolt_mode": "server",
   "dolt_database": "hq",
-  "postgres_dsn": "postgres://bd@db.example.test:5432/beads"
+  "postgres_dsn": "postgres://bd@db.example.test:5432/beads",
+  "postgres_schema": "city_x"
 }

--- a/internal/beads/contract/testdata/metadata/reject_dolt_with_postgres_dsn.json
+++ b/internal/beads/contract/testdata/metadata/reject_dolt_with_postgres_dsn.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "hq",
+  "postgres_dsn": "postgres://bd@db.example.test:5432/beads"
+}

--- a/internal/beads/contract/testdata/metadata/reject_pg_dsn_libpq_form.json
+++ b/internal/beads/contract/testdata/metadata/reject_pg_dsn_libpq_form.json
@@ -1,0 +1,5 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_dsn": "host=db.example.test port=6543 user=bd dbname=beads"
+}

--- a/internal/beads/contract/testdata/metadata/reject_pg_dsn_no_database.json
+++ b/internal/beads/contract/testdata/metadata/reject_pg_dsn_no_database.json
@@ -1,0 +1,5 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_dsn": "postgres://bd@db.example.test:6543"
+}

--- a/internal/beads/contract/testdata/metadata/valid_postgres_dsn.json
+++ b/internal/beads/contract/testdata/metadata/valid_postgres_dsn.json
@@ -1,0 +1,6 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_dsn": "postgres://gc_city@pg.example.test:6543/gascity_infra",
+  "postgres_schema": "city_x"
+}

--- a/internal/doctor/checks/postgres_auth.go
+++ b/internal/doctor/checks/postgres_auth.go
@@ -247,10 +247,16 @@ func loadPostgresAuthScope(scopeRoot, kind, displayBase, relEnv string) (postgre
 	if err != nil || meta.Backend != "postgres" {
 		return postgresAuthScope{}, false
 	}
+	// LoadMetadataState guarantees a postgres state derives cleanly, so this
+	// only skips a scope whose metadata.json was mutated underneath us.
+	pg, err := meta.PostgresEndpoint()
+	if err != nil {
+		return postgresAuthScope{}, false
+	}
 	endpoint := pgauth.Endpoint{
-		Host: meta.PostgresHost,
-		Port: meta.PostgresPort,
-		User: meta.PostgresUser,
+		Host: pg.Host,
+		Port: pg.Port,
+		User: pg.User,
 	}
 	display := fmt.Sprintf("%s (%s:%s)", displayBase, endpoint.Host, endpoint.Port)
 	scope := postgresAuthScope{


### PR DESCRIPTION
## This is a contract widening, not a bug fix

`internal/beads/contract` today **rejects** a postgres scope that does not
carry all four discrete fields:

```go
// files.go, LoadMetadataState
if state.PostgresHost == "" || state.PostgresPort == "" || state.PostgresUser == "" || state.PostgresDatabase == "" {
    return ..., "backend=postgres requires postgres_host, postgres_port, postgres_user, postgres_database (all four must be non-empty)"
}
```

and preflight knows about `postgres_dsn` only well enough to nag about it
(`preflight_checker.go`: `"postgres_dsn present; Gas City expects split fields"`).

But `bd init --backend=postgres --pg-url --pg-schema` persists a
password-free `postgres_dsn` plus a per-workspace `postgres_schema` — not the
discrete fields. So a scope bd just initialised is a shape Gas City refuses to
load.

<details>
<summary><b>Primary-source evidence for that premise</b> (a reviewer challenged it — it holds, for the add-on build)</summary>

The writer is in the **Postgres add-on** distribution, not OSS bd. Build tag
`//go:build enterprise`, `gascity/bd-enterprise` branch `enterprise`
@ `754dbe10af819343ab5aaa6ec040c6c177c3b87f`,
`cmd/bd/backend_init_distribution_enterprise.go`, `runInitPostgres`:

```go
persistDSN, err := pgdialect.RedactPassword(dsn)   // L135, fail-closed
...
cfg.Backend = configfile.BackendPostgres
cfg.PostgresDSN = persistDSN                       // L186
cfg.PostgresSchema = in.pgSchema                   // L187
if err := cfg.Save(in.beadsDir); err != nil { ... } // L189
```

The read side is `internal/storage/postgres/fromconfig.go` L41-43:

```go
dsn = cfg.GetPostgresDSN()
if dsn == "" {
    return "", "", fmt.Errorf("postgres: no DSN (set postgres_dsn in metadata.json, or BEADS_POSTGRES_URL)")
}
```

`BEADS_PG_PASSWORD` is real, not invented: `internal/storage/postgres/credential.go`
L41-42 is the credential ladder (`BEADS_PG_PASSWORD_COMMAND`, then
`BEADS_PG_PASSWORD`). Shipped binaries carrying this writer are installed on
the fleet at `/opt/beads/releases/mc-postgres-p0-*`, `mc-postgres-field-p0-*`,
`mc-field-integrated-*` (`strings` confirms
`a password may be included for init but is never persisted`).

**Where the reviewer was right:** OSS bd contradicts a naive reading. At the
`deps.env` pins — `BD_VERSION=v1.1.0`, `BD_PREV_VERSION=v1.0.4` (neither has
the field at all) and `BD_CURRENT_REF=bf97b73749ac` — `PostgresDSN` appears
exactly once, in `internal/configfile/configfile.go:42`, under "Deprecated
backend fields … retained only to round-trip metadata written by the
short-lived PostgreSQL/MySQL implementations", and `bd init --backend=postgres`
returns `storage backend "postgres" is no longer supported`. The old comments
cited that file as their authority, which read as self-contradictory. They now
cite the add-on. Both halves matter: the add-on **writes** the shape, and OSS
bd **round-trips** the keys without clearing them — which is exactly why gc
must tolerate them rather than force a hand-conversion.

</details>

**This PR makes that shape load.** It turns a currently-rejected metadata
shape into an accepted one. That is the whole point, and it deserves review
attention as a contract change rather than a fix.

What it does *not* relax: `LoadMetadataState` still guarantees the property
every consumer already depends on — a postgres state resolves to a
**complete, port-checked** `host/port/user/database` tuple. The DSN is
simply allowed to be where that tuple comes from. A DSN that resolves to a
partial tuple (no database, say) is rejected by name, so the widening cannot
turn "loud rejection" into "loads fine, then misbehaves".

## Design

`MetadataState.PostgresEndpoint()` is the single derivation point:

- all four discrete fields present -> they win outright, DSN ignored
  (and not even parsed)
- otherwise each missing field is filled from `postgres_dsn`
- neither available -> error

Ported from `feat/split-store-conformance`
(`internal/beads/contract/postgres_dsn.go`).

## Known limitation, preserved and made loud

libpq's keyword/value form (`host=... port=... user=...`) is **not
supported**. bd accepts it at init time; gc cannot derive an endpoint from it
deterministically. Rather than fall through to a partial or silently wrong
derivation, it fails with a named sentinel:

```go
var ErrPostgresDSNUnsupportedForm = errors.New("postgres_dsn must be a postgres:// (or postgresql://) URL")
```

The keyword/value form is detected *explicitly* (every whitespace-separated
token is `key=value`, no `://`) so the message says
`libpq keyword/value form is not supported` instead of the useless
`got scheme ""` you'd get from bare URL parsing. `errors.Is` works at every
layer: parse -> `PostgresEndpoint()` -> `LoadMetadataState` -> the
`BEADS_POSTGRES_*` projection.

## The preflight warning: it becomes wrong, so it's fixed here

`checkContractShape` currently returns
**WARN `"postgres_dsn present; Gas City expects split fields"`** for a
DSN-only postgres scope.

Once this PR lands, that sentence is false, and acting on it is harmful: it
tells an operator to hand-convert away from bd's own canonical shape, which
`bd init` will just write back. A warning that tells operators to fix a shape
we now accept is worse than no warning. So:

- DSN resolves to a complete endpoint -> **PASS** `"Metadata uses postgres_dsn shape"`
- it does not -> **FAIL** `"postgres_dsn does not resolve to a complete postgres endpoint"`

Both branches call `validatePostgresEndpoint`, the same gate `LoadMetadataState`
uses, so a preflight PASS means the loader will accept the scope. (Gating on
`ParsePostgresDSNEndpoint` alone — as the first revision did — PASSed a DSN
supplying no database or a port outside 1..65535, which the loader then
hard-rejected. A preflight that says PASS where load fails is a lie.)

Deliberately left alone:

- `checkMetadataBackend`'s WARN `"Metadata backend is postgres (postgres_dsn form)"`
  is descriptive, not prescriptive, and is about native-store eligibility
  (native supports dolt only) — this change doesn't make it false.
- `hasDSN && hasSplit` -> FAIL stays. A DSN pointing at one host beside
  discrete fields pointing at another is genuinely ambiguous on disk and
  worth flagging, even though the derivation resolves it deterministically.

The FAIL summary deliberately does **not** interpolate the parse error:
only `PostgresDSNRedacted` is sanitized by `Redacted()`, so echoing an error
that quotes the DSN would leak a hand-written password past redaction.
There's a regression test for that.

## Consumers had to move too

Widening the load without this would be the silent-failure trap: a DSN-only
scope would newly load fine and then project **empty** `BEADS_POSTGRES_HOST`
/ `PORT` / `USER` / `DATABASE` to every bd subprocess. So the three sites
that read the discrete fields directly now go through the derived endpoint:

- `cmd/gc/bd_env.go` — the `BEADS_POSTGRES_*` projection and the
  `pg.credential_resolved` payload (`emitPostgresCredentialResolved` now
  takes the derived `PostgresEndpoint` instead of the raw state)
- `cmd/gc/bd_env.go` — the external-PG "no managed recovery" error hint
- `internal/doctor/checks/postgres_auth.go` — scope discovery

`postgres_dsn` / `postgres_schema` participate in cross-backend **scrubbing**
but deliberately **not** in mixed-backend rejection — see "Review round 2"
below for why making them fatal bricked dolt scopes that main loads fine.

## Tests

New `internal/beads/contract/postgres_dsn_test.go` + 4 fixtures:

- URL-form derivation: non-default port, missing port defaults to 5432,
  query params ignored, IPv6, percent-encoding, userinfo password ignored
- discrete fields win when complete — including when the DSN points
  elsewhere, and when the DSN is unparseable (it's never consulted)
- incomplete discrete set falls back to the DSN per field
- libpq keyword/value fails with `ErrPostgresDSNUnsupportedForm`, names the
  form, and returns the **zero** endpoint (no partial derivation) — asserted
  at parse, state, and load layers
- malformed DSN, non-postgres scheme, hostless URL, out-of-range
  DSN-derived port all rejected
- `LoadMetadataState` accepts bd's shape, tolerates a dolt scope carrying
  bd's residual `postgres_dsn`/`postgres_schema` (and self-heals it), still
  rejects dolt + a discrete `postgres_host`, rejects an incomplete derivation
  naming the missing field
- `EnsureCanonicalMetadata` persists and scrubs the two keys, and a
  canonical DSN scope round-trips byte-identical

New in `cmd/gc/bd_env_test.go`: the projection derives from a DSN-only state,
and refuses an underivable DSN without writing partial env.

Updated: the two E4 message expectations in `files_test.go` and the
contract-shape state in `TestPreflightRedactsPostgresDSN`.

Every one of these was verified red by reverting the corresponding production
change (derivation fallback, libpq detection, load widening, preflight
branch) — each revert fails the tests that pin it, including
`TestApplyResolvedScopePostgresEnv_RefusesUnderivableDSN`, which reproduces
the empty-`BEADS_POSTGRES_*` projection this PR prevents.

## Review round 2 — three defects found and fixed

A council review found six majors clustering into three defects. Each fix has
a test that fails without it.

### 1. Password leak on the load path (security regression vs main)

`ParsePostgresDSNEndpoint` wrapped `url.Parse`'s `*url.Error` with `%w`.
`net/url` renders that as `%s %q: %s` with the **raw input**, so
`LoadMetadataState` copied a hand-written password into
`MetadataParseError.Reason`, and `cmd/gc` re-emitted it to stderr and into
`gc --json` failure payloads.

This is the same leak class the preflight-summary fix above targets, surviving
one frame up on the path every `gc` command traverses.

Measured end to end with a built binary, not reasoned about. With
`.beads/metadata.json` holding
`postgres://operator:sw%ordfish@db.example.com:5432/gascity`:

| binary | occurrences of the raw DSN in one `gc doctor` |
| --- | --- |
| base `main` | **0** (static, DSN-free reason) |
| this PR, before the fix | **98** (fires per-probe in a loop) |
| this PR, after the fix | **0** |

`gc bd list --json`, the machine-captured surface, went 2 -> 0. Reproduced for
four malformation classes (`%`-escape, `/` in password, non-numeric port,
unbalanced bracket) — 98 -> 0 in every one.

Unwrapping to `url.Error.Err` is **not** sufficient: `invalid port ":sword"
after host` and `invalid URL escape "%or"` still quote password fragments. The
reason is now a static sentinel. Note `TestParsePostgresDSNEndpoint`'s
non-numeric-port case asserted `wantErr: "port"`; it now asserts the sentinel,
because naming the port requires quoting the DSN.

Tests: `TestParsePostgresDSNEndpointErrorsNeverEchoTheDSN` and the load-path
twin `TestLoadMetadataStateErrorNeverEchoesPostgresDSN` (both table-driven over
the four shapes), plus `TestApplyResolvedScopePostgresEnv_RefusalOmitsDSN`
pinning the `cmd/gc` re-wrap.

### 2. Dolt scopes carrying bd's residue hard-failed, with no self-heal

Adding `postgres_dsn`/`postgres_schema` to `mixedBackendField` made
`backend=dolt` plus either key a fatal `MetadataParseError` — on
`applyCanonicalScopeBackendEnv`, i.e. every bd subprocess env projection, and
on `normalizeCanonicalBdScopeFiles` at startup. Main loads those scopes fine.
Worse, gc could not repair it: the canonicaliser that would scrub the keys
calls `LoadMetadataState` first and returns the error.

Verified end to end: `gc doctor` on `{"backend":"dolt","dolt_database":"hq",
"postgres_dsn":...,"postgres_schema":...}` printed `cannot mix dolt and
postgres fields` 98 times before the fix; base main and the fixed binary both
print it 0 times.

**Fix chosen: drop the two keys from `mixedBackendField`, keep them in
`postgresBackendKeys`.** Justification — the two field families are not
symmetric. `postgres_dsn`/`postgres_schema` are *bd's own* fields, retained
across a re-init (`bd init` preserves existing config and flips `Backend`), so
a Postgres workspace moved to Dolt carries them with no operator involvement.
The discrete `postgres_host/port/user/database` fields are gc's draft-era
shape that no bd has ever written, so a dolt scope carrying those is genuine
corruption and stays fatal. This guard exists to catch configurations gc
cannot interpret; a declared `backend=dolt` is not ambiguous and the residue
is inert. `EnsureCanonicalMetadata` scrubs it on the next canonicalise.

The alternative — extending `allowLegacyDoltMetadataRepair` — was rejected: it
keeps a fatal guard on the hot path that only the init/repair path can bypass,
so every non-repair reader stays broken until repair happens to run.

Test: `TestLoadMetadataStateToleratesDoltScopeWithPostgresResidue` asserts the
scope loads, the residue survives into the state so canonicalisation can see
it, `EnsureCanonicalMetadata` removes it, and the result reloads clean.
`TestLoadMetadataStateRejectsDoltWithPostgresField` keeps the discrete-field
rejection. Fixture `reject_dolt_with_postgres_dsn.json` renamed to
`dolt_with_postgres_residue.json`.

### 3. Multi-host and unbracketed-IPv6 DSNs derived a mangled host

`url.Parse` accepts these and splits them wrongly — and every downstream gate
passed the result, which gc then projects as `BEADS_POSTGRES_HOST` and keys
credential lookups on:

| DSN | derived host | derived port |
| --- | --- | --- |
| `postgres://bd@h1.test:5432,h2.test:5432/beads` | `h1.test:5432,h2.test` | `5432` |
| `postgres://bd@::1/beads` | `:` | `1` |

A silently wrong endpoint is worse than a refusal, which is this program's
whole thesis. Both now fail with `ErrPostgresDSNUnsupportedForm`. Bracketed
IPv6 (`postgres://bd@[::1]:6543/beads`) is unaffected and still covered.

Test: `TestParsePostgresDSNEndpointRejectsAmbiguousHosts`.

### Also

`TestPreflightContractShapeAgreesWithLoadMetadataState` asserts, per case,
that contract_shape's verdict and `LoadMetadataState`'s acceptance agree — so
the two gates cannot drift apart again.

## Gates

Re-run after round 2, rebased onto `origin/main` @ `5c217feff3`:
`go build ./...`, `go vet ./...`, `gofmt -l` clean, `golangci-lint` (2.10.1)
0 issues on `internal/beads/contract`, `internal/doctor/checks`, `cmd/gc`,
`go test ./internal/beads/... ./internal/doctor/...` green, `go test ./cmd/gc`
green (needs `-timeout 25m`; the package exceeds the 10m default on main
too), `scripts/check-core-boundary.sh` OK. The leak fix is additionally proven
end to end with a built binary, not only by unit test.

## Not included

- No `BEADS_POSTGRES_SCHEMA` projection. `postgres_schema` is carried so the
  on-disk shape round-trips and scrubs coherently; wiring bd's `search_path`
  is a separate change.
- The `DeferIdentityToNativeOpen` preflight work that sits in the same
  source branch is unrelated to DSN derivation and is not ported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

