### PR TITLE
fix(bd): route by-ID reads at the class binding for every provider

### DIFF
--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -392,8 +392,8 @@ func TestGcBdQueryRefusesAGraphClassQueryOnASplitCity(t *testing.T) {
 	}
 }
 
-// TestGcBdDepTreeIsStillARawPassthroughOnASplitCity is the fact that made the
-// old refusal message wrong, pinned for the verb that still carries it.
+// TestGcBdDepTreeSplitsOnOwnershipNotOnServability is the fact that made the old
+// refusal message wrong, pinned in the shape it now takes.
 //
 // The message used to end "Use the federated `gc bd show <id>` or `gc bd dep
 // tree <id>`". Neither verb was federated: doBd resolved a scope and then
@@ -401,27 +401,50 @@ func TestGcBdQueryRefusesAGraphClassQueryOnASplitCity(t *testing.T) {
 // routing anywhere on the path, so following the advice ran the blind read the
 // refusal had just prevented.
 //
-// `gc bd show` is federated now (cmd_bd_by_id.go). `dep tree` is not — it
-// reaches no by-ID routing and is still forwarded verbatim — so the residue is
-// pinned here rather than left to be rediscovered by the next operator who
-// takes the message at its word.
-func TestGcBdDepTreeIsStillARawPassthroughOnASplitCity(t *testing.T) {
-	args := []string{"dep", "tree", "gcg-abc123"}
-	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
-	resetCLIStorageRoutes(t)
-	captureCLIStorageStderr(t)
+// `dep tree` is still not served in process — this surface implements no tree
+// walk — but servability is no longer what decides where it goes. On a
+// class-owned id it is refused before the subprocess, because bd would answer
+// from the one ledger that cannot hold the bead; on a work id it is forwarded
+// verbatim, because that ledger is exactly the right answerer. Both halves are
+// asserted together: either alone is satisfied by a surface that stopped
+// discriminating.
+func TestGcBdDepTreeSplitsOnOwnershipNotOnServability(t *testing.T) {
+	t.Run("work id is forwarded verbatim", func(t *testing.T) {
+		args := []string{"dep", "tree", "demo-abc123"}
+		capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+		resetCLIStorageRoutes(t)
+		captureCLIStorageStderr(t)
 
-	var stdout, stderr bytes.Buffer
-	if code := doBd(args, &stdout, &stderr); code != 0 {
-		t.Fatalf("doBd(%v) = %d; stderr=%q", args, code, stderr.String())
-	}
-	data, err := os.ReadFile(capture)
-	if err != nil {
-		t.Fatalf("bd was not invoked for %v: %v", args, err)
-	}
-	if !strings.Contains(string(data), strings.Join(args, " ")) {
-		t.Fatalf("bd received %q, want the args forwarded verbatim", data)
-	}
+		var stdout, stderr bytes.Buffer
+		if code := doBd(args, &stdout, &stderr); code != 0 {
+			t.Fatalf("doBd(%v) = %d; stderr=%q", args, code, stderr.String())
+		}
+		data, err := os.ReadFile(capture)
+		if err != nil {
+			t.Fatalf("bd was not invoked for %v: %v", args, err)
+		}
+		if !strings.Contains(string(data), strings.Join(args, " ")) {
+			t.Fatalf("bd received %q, want the args forwarded verbatim", data)
+		}
+	})
+
+	t.Run("class-owned id is refused", func(t *testing.T) {
+		args := []string{"dep", "tree", "gcg-abc123"}
+		capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+		resetCLIStorageRoutes(t)
+		captureCLIStorageStderr(t)
+
+		var stdout, stderr bytes.Buffer
+		if code := doBd(args, &stdout, &stderr); code == 0 {
+			t.Fatalf("doBd(%v) exited 0 for a class-owned id; stdout=%q", args, stdout.String())
+		}
+		if data, err := os.ReadFile(capture); err == nil && strings.Contains(string(data), strings.Join(args, " ")) {
+			t.Fatalf("the class-owned dep tree was forwarded to bd: %q", data)
+		}
+		if !strings.Contains(stderr.String(), "gc bd dep tree") {
+			t.Errorf("the refusal does not name the command the operator ran; stderr=%q", stderr.String())
+		}
+	})
 }
 
 // TestGcBdShowNeverReachesBdForAClassOwnedIDOnASplitCity is the other half, and

--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -392,36 +392,135 @@ func TestGcBdQueryRefusesAGraphClassQueryOnASplitCity(t *testing.T) {
 	}
 }
 
-// TestGcBdShowIsARawPassthroughOnASplitCity is the fact that made the old
-// refusal message wrong, pinned so it cannot be forgotten again.
+// TestGcBdDepTreeIsStillARawPassthroughOnASplitCity is the fact that made the
+// old refusal message wrong, pinned for the verb that still carries it.
 //
 // The message used to end "Use the federated `gc bd show <id>` or `gc bd dep
-// tree <id>`". Neither verb is federated: doBd resolves a scope and then execs
-// the bd binary with the args verbatim and cmd.Dir at that scope root, with no
-// coordination-class routing anywhere on the path. Following the advice ran the
-// blind read the refusal had just prevented. The class-routed read the message
-// names instead is proved by internal/api's TestBeadGetResolvesARelocatedGraphID.
-func TestGcBdShowIsARawPassthroughOnASplitCity(t *testing.T) {
-	for name, args := range map[string][]string{
-		"show":     {"show", "gcg-abc123"},
-		"dep tree": {"dep", "tree", "gcg-abc123"},
-	} {
-		t.Run(name, func(t *testing.T) {
-			capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+// tree <id>`". Neither verb was federated: doBd resolved a scope and then
+// exec'd the bd binary with the args verbatim, with no coordination-class
+// routing anywhere on the path, so following the advice ran the blind read the
+// refusal had just prevented.
+//
+// `gc bd show` is federated now (cmd_bd_by_id.go). `dep tree` is not — it
+// reaches no by-ID routing and is still forwarded verbatim — so the residue is
+// pinned here rather than left to be rediscovered by the next operator who
+// takes the message at its word.
+func TestGcBdDepTreeIsStillARawPassthroughOnASplitCity(t *testing.T) {
+	args := []string{"dep", "tree", "gcg-abc123"}
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	resetCLIStorageRoutes(t)
+	captureCLIStorageStderr(t)
 
-			var stdout, stderr bytes.Buffer
-			if code := doBd(args, &stdout, &stderr); code != 0 {
-				t.Fatalf("doBd(%v) = %d; stderr=%q", args, code, stderr.String())
-			}
-			data, err := os.ReadFile(capture)
-			if err != nil {
-				t.Fatalf("bd was not invoked for %v: %v", args, err)
-			}
-			if !strings.Contains(string(data), strings.Join(args, " ")) {
-				t.Fatalf("bd received %q, want the args forwarded verbatim", data)
-			}
-		})
+	var stdout, stderr bytes.Buffer
+	if code := doBd(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("doBd(%v) = %d; stderr=%q", args, code, stderr.String())
 	}
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("bd was not invoked for %v: %v", args, err)
+	}
+	if !strings.Contains(string(data), strings.Join(args, " ")) {
+		t.Fatalf("bd received %q, want the args forwarded verbatim", data)
+	}
+}
+
+// TestGcBdShowNeverReachesBdForAClassOwnedIDOnASplitCity is the other half, and
+// the behavior change this pin used to forbid.
+//
+// The split city here serves its binding, and it is empty, so the read is a
+// genuine absence. The old passthrough answered it from the work ledger and
+// exited 0 — a confident wrong answer about a bead that ledger cannot hold. The
+// routed surface reports the absence in bd's own shape and never reaches the
+// subprocess.
+func TestGcBdShowNeverReachesBdForAClassOwnedIDOnASplitCity(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	resetCLIStorageRoutes(t)
+	captureCLIStorageStderr(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"show", "gcg-abc123"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("doBd exited 0 for a class-owned id the binding does not hold; stdout=%q", stdout.String())
+	}
+	// The capture records every bd invocation this command made, including the
+	// convergence check's own census of the work store — which is a read of the
+	// ledger it is entitled to read. What must not appear is the operator's
+	// read, forwarded verbatim.
+	if data, err := os.ReadFile(capture); err == nil && strings.Contains(string(data), "show gcg-abc123") {
+		t.Fatalf("the by-ID read was forwarded to bd: %q", data)
+	}
+	if !strings.Contains(stderr.String(), "gcg-abc123") {
+		t.Errorf("the answer does not name the bead; stderr=%q", stderr.String())
+	}
+}
+
+// bdUnservableStorage is a class arrangement this build refuses outright: a
+// partial split, with graph moved and the other four classes left on work. It
+// reaches the funnel's refusing store without needing a binding that fails to
+// open, so a test can stand in the state where every relocated-class read
+// carries a standing refusal.
+const bdUnservableStorage = `
+[storage.classes]
+work = "work"
+graph = "infra"
+sessions = "work"
+messaging = "work"
+orders = "work"
+nudges = "work"
+
+[storage.bindings.infra]
+provider = "sqlite-beads"
+path = ".gc/store"
+`
+
+// TestGcBdOnARefusedCitySeparatesWorkFromClassOwnedIDs is the boundary of the
+// refusal, and it is the regression the first draft of the routed surface
+// introduced.
+//
+// A city this build must not serve resolves every relocated class at a store
+// whose operations all return the boot refusal. Probing a WORK id against that
+// store returns the refusal too — and reading THAT as "the class binding owns
+// this bead" refused every `gc bd` write on the city, including writes to the
+// work ledger the refusal explicitly leaves alone. A storage misconfiguration
+// must not take a city's work offline.
+//
+// Both halves are asserted together because either one alone is satisfied by a
+// surface that has simply stopped discriminating.
+func TestGcBdOnARefusedCitySeparatesWorkFromClassOwnedIDs(t *testing.T) {
+	t.Run("work id still reaches bd", func(t *testing.T) {
+		capture := bdSQLRefusalCity(t, bdUnservableStorage)
+		resetCLIStorageRoutes(t)
+		captureCLIStorageStderr(t)
+
+		args := []string{"update", "demo-abc123", "--status", "closed"}
+		var stdout, stderr bytes.Buffer
+		if code := doBd(args, &stdout, &stderr); code != 0 {
+			t.Fatalf("doBd(%v) = %d on a work id; stderr=%q", args, code, stderr.String())
+		}
+		data, err := os.ReadFile(capture)
+		if err != nil {
+			t.Fatalf("bd was not invoked for a work mutation: %v", err)
+		}
+		if !strings.Contains(string(data), strings.Join(args, " ")) {
+			t.Fatalf("bd received %q, want the work mutation forwarded verbatim", data)
+		}
+	})
+
+	t.Run("class-owned id is refused", func(t *testing.T) {
+		capture := bdSQLRefusalCity(t, bdUnservableStorage)
+		resetCLIStorageRoutes(t)
+		captureCLIStorageStderr(t)
+
+		var stdout, stderr bytes.Buffer
+		if code := doBd([]string{"show", "gcg-abc123"}, &stdout, &stderr); code == 0 {
+			t.Fatalf("doBd exited 0 for a class-owned id on a city this build must not serve; stdout=%q", stdout.String())
+		}
+		if data, err := os.ReadFile(capture); err == nil && strings.Contains(string(data), "show gcg-abc123") {
+			t.Fatalf("the by-ID read was forwarded to bd: %q", data)
+		}
+		if !strings.Contains(stderr.String(), storageSupportedTopologyStatement) {
+			t.Errorf("the refusal does not carry the reason this city cannot be served; stderr=%q", stderr.String())
+		}
+	})
 }
 
 // TestGcBdSQLOverrideRunsTheQueryLoudly pins the escape hatch. The matcher

--- a/cmd/gc/cli_storage_routes.go
+++ b/cmd/gc/cli_storage_routes.go
@@ -211,7 +211,7 @@ func closeCLIStorageRoutes() error {
 // Under-refusing there would leave a class silently on the work store, which is
 // the exact failure the refusal exists to prevent.
 func refusingStorageRoutes(binding string, refusal error) *storageRoutes {
-	store := refusedClassStore{err: refusal}
+	store := refusedClassStore{err: standingStorageRefusal{err: refusal}}
 	routes := &storageRoutes{stores: make(map[coordclass.Class]beads.Store), binding: binding}
 	for _, class := range coordclass.Classes() {
 		if class.IsInfrastructure() {
@@ -219,6 +219,30 @@ func refusingStorageRoutes(binding string, refusal error) *storageRoutes {
 		}
 	}
 	return routes
+}
+
+// standingStorageRefusal marks an error as the verdict this build took about a
+// CITY, rather than a fault a particular read ran into. The message is the
+// refusal verbatim — wrapping adds no prefix — and the only thing the wrapper
+// adds is that the two can be told apart.
+//
+// They are told apart because a caller can act on the difference. A refused
+// city still serves its WORK beads from its work ledger, which is the whole
+// reason this file leaves work unrouted; so a caller holding a work id has been
+// told nothing about that id and must keep its existing path, while a caller
+// holding an id only a relocated class could own has been told the one thing
+// that matters. Answering both the same way turns a storage misconfiguration
+// into a city where no `gc bd` write runs at all.
+type standingStorageRefusal struct{ err error }
+
+func (e standingStorageRefusal) Error() string { return e.err.Error() }
+func (e standingStorageRefusal) Unwrap() error { return e.err }
+
+// isStandingStorageRefusal reports whether err is this build's standing verdict
+// about the city rather than a fault in the read that produced it.
+func isStandingStorageRefusal(err error) bool {
+	var refusal standingStorageRefusal
+	return errors.As(err, &refusal)
 }
 
 // refusedClassStore is the store a relocated class resolves to on a city this
@@ -269,6 +293,20 @@ func (s refusedClassStore) SetMetadata(string, string, string) error { return s.
 func (s refusedClassStore) SetMetadataBatch(string, map[string]string) error {
 	return s.err
 }
+
+// Claim and ReleaseIfCurrent are the conditional-assignment pair. They are
+// here for the reason the whole optional set is: the by-ID class front door
+// discovers them by type assertion, and a refusing store that lacked them
+// would answer "this store cannot claim" — a statement about a capability —
+// where the truth is that this city must not be served at all.
+func (s refusedClassStore) Claim(string, string) (beads.Bead, bool, error) { //nolint:unparam // a refusing store returns the refusal and never a value
+	return beads.Bead{}, false, s.err
+}
+
+func (s refusedClassStore) ReleaseIfCurrent(string, string) (bool, error) { //nolint:unparam // a refusing store returns the refusal and never a value
+	return false, s.err
+}
+
 func (s refusedClassStore) SetLocalString(string, string, string) error { return s.err }
 func (s refusedClassStore) GetLocalString(string, string) (string, error) {
 	return "", s.err

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -251,6 +251,15 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		// refused travels with the result they are about to trust.
 		fmt.Fprintf(stderr, "gc bd: %s is set; running anyway: %s\n", bdRelocatedClassOverrideEnvVar, msg) //nolint:errcheck // best-effort stderr
 	}
+	// A by-ID operation whose subject a relocated class owns is answered in
+	// process, from the binding that class is served from, and never handed to
+	// the subprocess — which opens the work workspace and cannot see the bead.
+	// It runs BEFORE the release-if-current arm below because that arm resolves
+	// only the work scope: on a split city it would release against the ledger
+	// the bead was moved off. See cmd_bd_by_id.go.
+	if code, handled := maybeRouteBdByID(cityPath, bdArgs, stdout, stderr); handled {
+		return code
+	}
 	if id, expectedAssignee, ok, err := parseBdReleaseIfCurrentArgs(bdArgs); ok || err != nil {
 		if err != nil {
 			fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -1,0 +1,622 @@
+package main
+
+// The in-process by-ID surface for `gc bd`.
+//
+// `gc bd` resolves a WORK scope and hands the command to the `bd` subprocess.
+// On a city whose coordination classes are served from a non-work [storage]
+// binding, an infrastructure bead lives in that binding and not in the work
+// workspace bd is pointed at, so a by-ID read of one is answered by a
+// subprocess that cannot see it: bd opens the work backend instead, which on a
+// managed-Dolt city means a connect attempt that can block for the whole
+// command, and otherwise means an empty answer indistinguishable from a real
+// one.
+//
+// So an id whose owning class is the relocated binding is answered HERE,
+// through that class's closed front door, and the subprocess is never spawned.
+//
+// # Where the store comes from, and why not from the migration
+//
+// The store is resolved through the one-shot storage funnel
+// (cli_storage_routes.go), which takes the same verdict the controller takes at
+// boot and opens the binding through the planned provider's own EngineOpener.
+//
+// The obvious alternative — resolveInfraBindingTarget, the migration's own
+// destination resolver — is the defect this file was written to avoid, and it
+// is worth naming because it looks like the right function. That resolver
+// answers "is this a binding THIS BUILD can migrate onto", which is true only
+// of the built-in SQLite engine: it returns not-configured for a beads
+// workspace, for a fork's own engine, and for every provider added after it.
+// A by-ID surface gated on that answer routes correctly for one provider and
+// falls through to the subprocess for all the others — which is the wrong-answer
+// lane this surface exists to close, reappearing on exactly the cities that
+// moved furthest from the default. The question a READ has is not "can I
+// migrate this", it is "where is this class served from", and the funnel
+// answers that for every provider because the answer comes from the provider.
+//
+// # Three deliberate properties
+//
+//   - The routed operations take ONLY the closed contract
+//     (storebinding.GraphStore). They cannot reach a raw bead store through
+//     their parameter, so claim/release CAS lives in the store the contract is
+//     bound to and is never re-implemented as a read-then-write in the CLI.
+//   - A miss is not flattened into a fall-through when the id can only live in
+//     the class store. A reserved-prefix id (gcg-…) is minted by that store and
+//     nowhere else, so its absence is genuine absence and is reported in bd's
+//     own shape. Falling through would print a work-store answer for a bead the
+//     work store never held.
+//   - A resolution failure surfaces. Reading "the binding could not be opened"
+//     as "the bead is not there" is the root-loss shape this whole lane exists
+//     to prevent. A city this build must not serve resolves to the funnel's
+//     refusing store, so every routed read on it returns the boot refusal that
+//     names the remedy — never absence, and never the work store's answer.
+//
+// Served here: show, update --claim, release-if-current, and dep list. `gc bd
+// heartbeat` is not — it is rewritten to a metadata update before this hook
+// runs — and neither is the general query surface, which bd_relocated_classes.go
+// refuses on its own terms.
+//
+// An operation that is NOT served but whose subject the class store owns does
+// not fall through either: bd would open the work store, which cannot see the
+// bead, and the command would hang or answer about the wrong workspace. It is
+// refused instead, before the subprocess. Refusal is the floor, not the goal —
+// each verb worth serving is served, and the rest at least fail in a way an
+// operator can act on.
+//
+// Ownership is read from an id in an ID POSITION and never from an id-shaped
+// value. A `gc bd list --metadata-field workflow_id=gcg-…` probe is a work
+// question that quotes a class id: the work store answers for its own rows and
+// must keep doing so. A `--parent gcg-…` names a class bead, and letting the
+// work store answer that returns a silent empty result.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storebinding"
+)
+
+// bdByIDVerb names a recognized by-ID gc bd invocation.
+type bdByIDVerb string
+
+const (
+	// bdByIDShow is `gc bd show <id> [--json]`.
+	bdByIDShow bdByIDVerb = "show"
+	// bdByIDClaim is `gc bd update <id> --claim [--json]`, the acquire half of
+	// the conditional-assignment pair.
+	bdByIDClaim bdByIDVerb = "claim"
+	// bdByIDRelease is `gc bd release-if-current <id> <assignee>`, the release
+	// half. doBd already ran this in process, but only ever against the work
+	// scope.
+	bdByIDRelease bdByIDVerb = "release-if-current"
+	// bdByIDDepList is `gc bd dep list <id> [--direction=up|down] [--type=T]
+	// [--json]`. This is the dependency read the cascade-nudge order makes on
+	// every closed blocker, and on a split city it is the operation whose
+	// subprocess never returned.
+	bdByIDDepList bdByIDVerb = "dep-list"
+)
+
+// bdByIDDepDirectionUp asks for the beads that depend ON the subject; the
+// default direction asks for the beads the subject depends on. These are bd's
+// own two --direction values and the only ones the routed arm accepts.
+const (
+	bdByIDDepDirectionUp   = "up"
+	bdByIDDepDirectionDown = "down"
+)
+
+// bdByIDOp is a parsed by-ID invocation: exactly one bead id and the operation
+// to apply to it.
+type bdByIDOp struct {
+	Verb     bdByIDVerb
+	ID       string
+	JSON     bool
+	Assignee string
+	// Direction and DepType carry `dep list`'s two selectors. Direction is
+	// always populated for that verb; an empty DepType means every edge type.
+	Direction string
+	DepType   string
+}
+
+// parseBdByIDOp recognizes the by-ID invocations this surface serves. Anything
+// else — a different verb, several ids, or a flag the in-process arm does not
+// implement — is not recognized, and the caller leaves it on its existing path
+// rather than serving a partial imitation of bd.
+func parseBdByIDOp(bdArgs []string) (bdByIDOp, bool) {
+	if len(bdArgs) == 0 {
+		return bdByIDOp{}, false
+	}
+	switch bdArgs[0] {
+	case "show":
+		id, jsonOut, ok := parseBdByIDPositional(bdArgs[1:], nil)
+		if !ok {
+			return bdByIDOp{}, false
+		}
+		return bdByIDOp{Verb: bdByIDShow, ID: id, JSON: jsonOut}, true
+	case "update":
+		claim := false
+		id, jsonOut, ok := parseBdByIDPositional(bdArgs[1:], map[string]*bool{"--claim": &claim})
+		if !ok || !claim {
+			return bdByIDOp{}, false
+		}
+		return bdByIDOp{Verb: bdByIDClaim, ID: id, JSON: jsonOut}, true
+	case "release-if-current":
+		id, assignee, ok, err := parseBdReleaseIfCurrentArgs(bdArgs)
+		if err != nil || !ok {
+			return bdByIDOp{}, false
+		}
+		return bdByIDOp{Verb: bdByIDRelease, ID: id, Assignee: assignee}, true
+	case "dep":
+		if len(bdArgs) < 2 || bdArgs[1] != "list" {
+			return bdByIDOp{}, false
+		}
+		return parseBdDepListArgs(bdArgs[2:])
+	}
+	return bdByIDOp{}, false
+}
+
+// parseBdDepListArgs parses the tail of `gc bd dep list`.
+//
+// It knows every flag it accepts and whether that flag consumes the next
+// argument, so a value can never be mistaken for the subject id. That is the
+// whole point: `--type gcg-blocks` names an edge type, not a bead, and a
+// scanner that took the first non-flag token would route the command on it.
+// An unrecognized flag makes the invocation unrecognized rather than
+// best-guessed — the routed arm would otherwise silently drop a selector and
+// answer a different question than the one asked.
+func parseBdDepListArgs(args []string) (bdByIDOp, bool) {
+	op := bdByIDOp{Verb: bdByIDDepList, Direction: bdByIDDepDirectionDown}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--json":
+			op.JSON = true
+		case strings.HasPrefix(arg, "--direction="):
+			op.Direction = strings.TrimPrefix(arg, "--direction=")
+		case strings.HasPrefix(arg, "--type="):
+			op.DepType = strings.TrimPrefix(arg, "--type=")
+		case arg == "--direction", arg == "--type":
+			if i+1 >= len(args) {
+				return bdByIDOp{}, false
+			}
+			i++
+			if arg == "--direction" {
+				op.Direction = args[i]
+			} else {
+				op.DepType = args[i]
+			}
+		case strings.HasPrefix(arg, "-"):
+			return bdByIDOp{}, false
+		default:
+			if op.ID != "" || arg == "" {
+				return bdByIDOp{}, false
+			}
+			op.ID = arg
+		}
+	}
+	if op.ID == "" {
+		return bdByIDOp{}, false
+	}
+	if op.Direction != bdByIDDepDirectionUp && op.Direction != bdByIDDepDirectionDown {
+		return bdByIDOp{}, false
+	}
+	return op, true
+}
+
+// parseBdByIDPositional extracts exactly one positional bead id from args,
+// accepting --json plus the boolean flags named in extra and rejecting
+// everything else. Rejecting unknown flags is what keeps this arm honest: a
+// flag it silently ignored would change the meaning of a command it then
+// claimed to have executed.
+func parseBdByIDPositional(args []string, extra map[string]*bool) (id string, jsonOut, ok bool) {
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			if id != "" || arg == "" {
+				return "", false, false
+			}
+			id = arg
+			continue
+		}
+		if arg == "--json" {
+			jsonOut = true
+			continue
+		}
+		seen, known := extra[arg]
+		if !known {
+			return "", false, false
+		}
+		*seen = true
+	}
+	if id == "" {
+		return "", false, false
+	}
+	return id, jsonOut, true
+}
+
+// bdByIDResolution is what the class-ownership walk concluded about one id: the
+// front door of the class that would own it, whether the id can only live there
+// (a reserved-prefix id), and the row itself when it is resident.
+type bdByIDResolution struct {
+	Graph    storebinding.GraphStore
+	Bead     beads.Bead
+	Found    bool
+	Reserved bool
+}
+
+// Owned reports whether the class store answers for this id — either because
+// the id carries the class's reserved prefix, or because the row is resident.
+func (r bdByIDResolution) Owned() bool { return r.Reserved || r.Found }
+
+// bdByIDClassDoor is the opened class front door serving this city.
+//
+// It owns no handle to release. The store belongs to the one-shot funnel, which
+// opens each city's binding at most once per process and closes it where the
+// process ends — so a command that touches this surface and a class resolver
+// reads one database rather than two, and a routed read cannot close a handle
+// another call site is still using.
+type bdByIDClassDoor struct {
+	Graph   storebinding.GraphStore
+	Binding string
+}
+
+// openBdByIDClassFrontDoor opens the class front door serving this city, for
+// whatever provider its coordination classes are served from.
+//
+// routed=false means the city relocates no class, so every id is still the work
+// store's and the caller's existing path is correct and byte-identical. An error
+// means the city IS relocated and the front door could not be projected; the
+// caller surfaces it instead of guessing.
+//
+// The gate is the funnel's verdict, which is the boot gate's: a city configured
+// for a binding it has not converged on, or one this build must not serve,
+// resolves to a store whose every operation returns that refusal. So an
+// unconverged city neither serves stale answers from the work store here nor
+// goes quiet — it reports the same sentence `gc start` would have printed.
+func openBdByIDClassFrontDoor(cityPath string) (bdByIDClassDoor, bool, error) {
+	routes := cliStorageRoutes(cityPath)
+	store, relocated := graphClassBinding(routes)
+	if !relocated {
+		return bdByIDClassDoor{}, false, nil
+	}
+	graph, err := storebinding.NewBeadsGraphStore(store)
+	if err != nil {
+		return bdByIDClassDoor{}, false, fmt.Errorf("projecting the class front door of binding %q: %w", routes.binding, err)
+	}
+	return bdByIDClassDoor{Graph: graph, Binding: routes.binding}, true, nil
+}
+
+// resolve asks the open front door whether it owns id.
+//
+// A read failure is an error, never absence. Reading "the binding could not
+// answer" as "the bead is not there" is the root-loss shape this whole lane
+// exists to prevent, and it is the one classification a caller cannot recover
+// from once it has been flattened.
+//
+// The residence probe is why an id with no reserved prefix is asked about at
+// all: `gc storage migrate` copies the work store's infrastructure slice with
+// its ids PRESERVED, so a converged city holds work-shaped ids in its binding
+// and deciding ownership by prefix alone would send those reads back to the
+// ledger they were moved off.
+//
+// The one error that is not a fault is the funnel's standing refusal. It says
+// this city's storage configuration cannot be served, which is a statement
+// about the city and about no particular bead — and a refused city still serves
+// work from its work ledger. So for a work id it establishes nothing and the
+// existing path stands; for an id only the class binding could own it is the
+// answer, and falls through to the fault arm.
+func (d bdByIDClassDoor) resolve(id string) (bdByIDResolution, error) {
+	resolution := bdByIDResolution{Graph: d.Graph, Reserved: bdIDIsClassReserved(id)}
+	bead, err := d.Graph.Get(id)
+	switch {
+	case err == nil:
+		resolution.Bead = bead
+		resolution.Found = true
+	case errors.Is(err, beads.ErrNotFound):
+	case isStandingStorageRefusal(err) && !resolution.Reserved:
+	default:
+		return bdByIDResolution{}, fmt.Errorf("reading %q from the %s class binding: %w", id, d.Binding, err)
+	}
+	return resolution, nil
+}
+
+// bdIDIsClassReserved reports whether id carries a reserved class id prefix.
+// Those prefixes are minted only by the relocated class stores, so such an id
+// existing anywhere else is not a thing bd can answer for.
+func bdIDIsClassReserved(id string) bool {
+	for _, prefix := range config.ReservedClassPrefixes() {
+		if prefix != "" && strings.HasPrefix(id, prefix+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+// maybeRouteBdByID serves a by-ID gc bd invocation from the owning class front
+// door. handled=false means the caller proceeds on its existing path unchanged
+// — the city relocates no class, the invocation is not one of the routed by-ID
+// forms, or the id is a work-store id the class store does not answer for.
+func maybeRouteBdByID(cityPath string, bdArgs []string, stdout, stderr io.Writer) (int, bool) {
+	op, served := parseBdByIDOp(bdArgs)
+	refusable, refusableOK, ambiguous := bdMutationWriteIDs(bdArgs)
+	mutationRefusable := refusableOK && !ambiguous && len(refusable) > 0
+	listNamed, listNames := bdListNamesClassOwnedBead(bdArgs)
+	if !served && !mutationRefusable && !listNames {
+		// Nothing here could concern a class-owned id, so the binding is not
+		// even opened. An ambiguous mutation scan is left to the fail-closed
+		// guard doBd already applies to it.
+		return 0, false
+	}
+	door, routed, err := openBdByIDClassFrontDoor(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1, true
+	}
+	if !routed {
+		return 0, false
+	}
+	if !served {
+		if listNames {
+			// A reserved prefix is proof of ownership on its own, so no
+			// residence probe is needed to know the work store cannot answer.
+			return refuseClassOwnedTarget(door, "list", listNamed, stderr)
+		}
+		return refuseClassOwnedPassthrough(door, bdArgs[0], refusable, stderr)
+	}
+
+	resolution, err := door.resolve(op.ID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1, true
+	}
+	if !resolution.Owned() {
+		// A work-store id the class store has never seen: bd is still its
+		// truth, and the passthrough answers it byte-identically.
+		return 0, false
+	}
+	if !resolution.Found {
+		// Reserved-prefix id with no row: it has nowhere else to live.
+		printBdByIDNotFound(stderr, op.ID)
+		return 1, true
+	}
+	switch op.Verb {
+	case bdByIDShow:
+		return printBdByIDBead(resolution.Bead, op.JSON, stdout, stderr), true
+	case bdByIDClaim:
+		return doBdByIDClaim(resolution.Graph, op.ID, bdByIDClaimActor(), op.JSON, stdout, stderr), true
+	case bdByIDRelease:
+		return doBdByIDReleaseIfCurrent(resolution.Graph, op.ID, op.Assignee, stdout, stderr), true
+	case bdByIDDepList:
+		return doBdByIDDepList(resolution.Graph, op, stdout, stderr), true
+	}
+	return 0, false
+}
+
+// refuseClassOwnedPassthrough stops a write mutation whose subject the class
+// store owns but which this surface does not serve.
+//
+// The alternative is what a bare passthrough does: hand it to bd, which opens
+// the work store, cannot see the bead, and either blocks on a work backend that
+// has nothing to say or mutates whatever its substring resolver found there
+// instead. A refusal with the bead named is recoverable; both of those are not.
+//
+// handled=false — the passthrough, unchanged — is the answer whenever no
+// subject is class-owned, which is every work mutation on these cities.
+func refuseClassOwnedPassthrough(door bdByIDClassDoor, verb string, ids []string, stderr io.Writer) (int, bool) {
+	for _, id := range ids {
+		resolution, err := door.resolve(id)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1, true
+		}
+		if !resolution.Owned() {
+			continue
+		}
+		return refuseClassOwnedTarget(door, verb, id, stderr)
+	}
+	return 0, false
+}
+
+// refuseClassOwnedTarget is the single refusal message, so every unsupported
+// class-owned operation reports the same way.
+func refuseClassOwnedTarget(door bdByIDClassDoor, verb, id string, stderr io.Writer) (int, bool) {
+	fmt.Fprintf(stderr, "gc bd: %s is owned by the %s class binding, and `gc bd %s` is not served in process; refusing rather than running it against the work store, which does not hold the bead\n", id, door.Binding, verb) //nolint:errcheck // best-effort stderr
+	return 1, true
+}
+
+// bdListNamesClassOwnedBead reports whether a `gc bd list` NAMES a class-owned
+// bead as its target, as opposed to merely mentioning one inside a filter
+// value.
+//
+// A `--metadata-field workflow_id=gcg-…` probe is a work question that happens
+// to quote a class id: the work store answers for its own rows and must keep
+// doing so, and refusing it exec-fails the consumer that asks it. A
+// `--parent gcg-…` or a positional class id is a class-targeted read, and
+// letting the work store answer it produces the silent empty result.
+//
+// Ownership is decided by reserved prefix alone, with no residence probe: this
+// runs on every `gc bd list`, and a prefix is proof enough for the only
+// decision being made — whether a work store could possibly be the right
+// answerer.
+func bdListNamesClassOwnedBead(bdArgs []string) (string, bool) {
+	if len(bdArgs) == 0 || bdArgs[0] != "list" {
+		return "", false
+	}
+	// The filters whose value is content to match, never a bead being
+	// addressed. Every other token in an id position addresses one.
+	valueOnly := map[string]bool{"--metadata-field": true, "--label": true}
+	args := bdArgs[1:]
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if valueOnly[arg] {
+			i++
+			continue
+		}
+		if eq := strings.IndexByte(arg, '='); eq > 0 && strings.HasPrefix(arg, "--") && valueOnly[arg[:eq]] {
+			continue
+		}
+		if bdIDIsClassReserved(arg) {
+			return arg, true
+		}
+	}
+	return "", false
+}
+
+// bdByIDClaimActor returns the identity a routed claim acquires the bead for.
+// It is BEADS_ACTOR — the same variable gc puts in the subprocess environment
+// and bd itself claims under — so a routed claim and a passthrough claim record
+// the same owner.
+func bdByIDClaimActor() string { return strings.TrimSpace(os.Getenv("BEADS_ACTOR")) }
+
+// doBdByIDClaim acquires a class-store bead for assignee through the closed
+// graph contract.
+//
+// The CAS is the store's, not this function's: the contract's Claim is the
+// acquire dual of ReleaseIfCurrent and already carries the deployed semantics —
+// a same-owner reclaim is a true no-op, a bead held by someone else or in a
+// terminal state is a conflict rather than an error, and concurrent claims
+// serialize so exactly one wins. Re-deriving any of that here as a
+// read-then-write would lose the single-winner guarantee, which is why the CLI
+// projection only calls it.
+//
+// A conflict is reported to the operator as a non-zero exit, matching what the
+// bd passthrough does with a lost claim race; the conflict-is-not-an-error
+// property is about the store contract, not about the shell.
+func doBdByIDClaim(graph storebinding.GraphStore, id, assignee string, jsonOut bool, stdout, stderr io.Writer) int {
+	if assignee == "" {
+		fmt.Fprintf(stderr, "gc bd: claiming %s requires BEADS_ACTOR to name the claimant\n", id) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	claimed, ok, err := graph.Claim(id, assignee)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd: claiming %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !ok {
+		reason := "it is held by another claimant"
+		if current, getErr := graph.Get(id); getErr == nil {
+			if held := strings.TrimSpace(current.Assignee); held != "" {
+				reason = fmt.Sprintf("it is held by %q", held)
+			} else {
+				reason = fmt.Sprintf("its status is %q", current.Status)
+			}
+		}
+		fmt.Fprintf(stderr, "gc bd: %s was not claimed for %q: %s\n", id, assignee, reason) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return printBdByIDBead(claimed, jsonOut, stdout, stderr)
+}
+
+// doBdByIDReleaseIfCurrent applies the conditional release through the closed
+// graph contract, preserving doBdReleaseIfCurrent's released/skipped output so
+// the orphan-recovery scripts that read it keep working when the bead lives in
+// a class binding.
+func doBdByIDReleaseIfCurrent(graph storebinding.GraphStore, id, expectedAssignee string, stdout, stderr io.Writer) int {
+	released, err := graph.ReleaseIfCurrent(id, expectedAssignee)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd release-if-current: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if released {
+		fmt.Fprintln(stdout, "released") //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	fmt.Fprintln(stdout, "skipped") //nolint:errcheck // best-effort stdout
+	return 0
+}
+
+// bdByIDDepRow is one row of `bd dep list --json`: the related issue, plus the
+// edge type that related it. bd emits exactly this — an issue object with an
+// added dependency_type — and the pack scripts read it with jq field by field,
+// so the embedded bead must stay inlined rather than nested.
+type bdByIDDepRow struct {
+	beads.Bead
+	DepType string `json:"dependency_type"`
+	// External marks an edge whose other end is not resident in this class
+	// store — a declared reference to a work bead. Its typed kind is kept and
+	// it is not reported as dangling, but no fields are invented for it: this
+	// arm answers from one class store and does not read across the boundary.
+	External bool `json:"external,omitempty"`
+}
+
+// doBdByIDDepList answers the dependency read from the owning class store.
+//
+// The edges come from the closed contract's DepList, and each related bead is
+// then read through the same front door. An edge pointing out of this class is
+// reported as external rather than resolved: crossing to the work store here
+// would be a federated cross-store dependency read, and dropping the edge would
+// misreport a declared reference as absent.
+func doBdByIDDepList(graph storebinding.GraphStore, op bdByIDOp, stdout, stderr io.Writer) int {
+	deps, err := graph.DepList(op.ID, op.Direction)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd dep list: listing %s dependencies of %s: %v\n", op.Direction, op.ID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	rows := make([]bdByIDDepRow, 0, len(deps))
+	for _, dep := range deps {
+		if op.DepType != "" && dep.Type != op.DepType {
+			continue
+		}
+		related := dep.DependsOnID
+		if op.Direction == bdByIDDepDirectionUp {
+			related = dep.IssueID
+		}
+		bead, err := graph.Get(related)
+		switch {
+		case err == nil:
+			rows = append(rows, bdByIDDepRow{Bead: bead, DepType: dep.Type})
+		case errors.Is(err, beads.ErrNotFound):
+			rows = append(rows, bdByIDDepRow{Bead: beads.Bead{ID: related}, DepType: dep.Type, External: true})
+		default:
+			fmt.Fprintf(stderr, "gc bd dep list: reading %s: %v\n", related, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	}
+	if op.JSON {
+		out, err := json.MarshalIndent(rows, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "gc bd dep list: rendering %s: %v\n", op.ID, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintln(stdout, string(out)) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	for _, row := range rows {
+		title := row.Title
+		if row.External {
+			title = "(not resident in this class binding)"
+		}
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", row.ID, row.DepType, row.Status, title) //nolint:errcheck // best-effort stdout
+	}
+	return 0
+}
+
+// printBdByIDBead renders a bead in bd's show shape: --json emits a JSON array
+// of issues, which is what bd emits and what the pack parsers already read; the
+// text form is the id/status/title line.
+func printBdByIDBead(b beads.Bead, jsonOut bool, stdout, stderr io.Writer) int {
+	if jsonOut {
+		out, err := json.MarshalIndent([]beads.Bead{b}, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "gc bd: rendering %q: %v\n", b.ID, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintln(stdout, string(out)) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	fmt.Fprintf(stdout, "%s\t%s\t%s\n", b.ID, b.Status, b.Title) //nolint:errcheck // best-effort stdout
+	return 0
+}
+
+// printBdByIDNotFound renders genuine absence in bd's own shape so existing
+// parsers see the same signal the passthrough would have produced, and adds the
+// one thing that differs: class stores resolve ids exactly, so a truncated id
+// pasted from a log reads as absent here where bd would have substring-matched
+// it.
+func printBdByIDNotFound(stderr io.Writer, id string) {
+	fmt.Fprintf(stderr, "Error fetching %s: no issue found matching %q\n", id, id)                                                       //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "gc bd: %s is a class-store id; class stores resolve ids exactly (no substring match) — pass the full id\n", id) //nolint:errcheck // best-effort stderr
+}

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -46,9 +46,12 @@ package main
 //     work store never held.
 //   - A resolution failure surfaces. Reading "the binding could not be opened"
 //     as "the bead is not there" is the root-loss shape this whole lane exists
-//     to prevent. A city this build must not serve resolves to the funnel's
-//     refusing store, so every routed read on it returns the boot refusal that
-//     names the remedy — never absence, and never the work store's answer.
+//     to prevent. On a city this build must not serve, an id only the class
+//     binding could own gets the boot refusal that names the remedy — never
+//     absence, and never the work store's answer. A WORK id on that same city
+//     keeps its existing path, because the refusal is a fact about the city's
+//     storage and says nothing about a bead the work ledger still serves. See
+//     resolve.
 //
 // Served here: show, update --claim, release-if-current, and dep list. `gc bd
 // heartbeat` is not — it is rewritten to a metadata update before this hook

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -53,23 +53,42 @@ package main
 //     storage and says nothing about a bead the work ledger still serves. See
 //     resolve.
 //
-// Served here: show, update --claim, release-if-current, and dep list. `gc bd
-// heartbeat` is not — it is rewritten to a metadata update before this hook
-// runs — and neither is the general query surface, which bd_relocated_classes.go
-// refuses on its own terms.
+// Served here: show, update (fields and metadata, including --claim),
+// release-if-current, and dep list. `gc bd heartbeat` is not — it is rewritten
+// to a metadata update before this hook runs — and neither is the general query
+// surface, which bd_relocated_classes.go refuses on its own terms.
+//
+// # Ownership is decided before servability
 //
 // An operation that is NOT served but whose subject the class store owns does
 // not fall through either: bd would open the work store, which cannot see the
 // bead, and the command would hang or answer about the wrong workspace. It is
-// refused instead, before the subprocess. Refusal is the floor, not the goal —
-// each verb worth serving is served, and the rest at least fail in a way an
-// operator can act on.
+// refused instead, before the subprocess.
+//
+// The two questions are answered by different code on purpose, and answering
+// them with one function was a real defect rather than a hypothetical. The
+// served parsers reject every flag they do not implement, so "can this be
+// served" said no to `show --long`, `show --id`, `dep list -t` and the rest of
+// bd's own manifest — and while a rejection meant fall-through, those were
+// precisely the invocations sent to the ledger that cannot answer. Ownership is
+// now decided by bdArgsNameClassOwnedBead, which reads only the argv and knows
+// nothing about what this surface implements.
 //
 // Ownership is read from an id in an ID POSITION and never from an id-shaped
 // value. A `gc bd list --metadata-field workflow_id=gcg-…` probe is a work
 // question that quotes a class id: the work store answers for its own rows and
 // must keep doing so. A `--parent gcg-…` names a class bead, and letting the
 // work store answer that returns a silent empty result.
+//
+// # What entering costs, and who pays it
+//
+// Resolving the funnel loads the city config, resolves a storage plan, opens a
+// binding and — on a born-split city — re-proves its invariant with a full work
+// store census. That is once per process, memoized with every other one-shot
+// command's routing, but it is not free, so it is paid only by an invocation
+// that could concern a class-owned bead: a served by-ID form, or an argv that
+// addresses a reserved-prefix id. An ordinary work mutation addresses only work
+// ids and never enters.
 
 import (
 	"encoding/json"
@@ -77,8 +96,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/gastownhall/gascity/internal/bdflags"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/storebinding"
@@ -102,6 +125,16 @@ const (
 	// every closed blocker, and on a split city it is the operation whose
 	// subprocess never returned.
 	bdByIDDepList bdByIDVerb = "dep-list"
+	// bdByIDUpdate is `gc bd update <id>` carrying field and metadata writes.
+	//
+	// It is here because it is the step-completion write the core pack makes on
+	// every worked bead — graph-worker.md renders
+	// `gc bd update <id> --set-metadata gc.outcome=pass --status closed`, and
+	// mol-do-work.toml closes the formula step the same way. On a split city
+	// that bead is class-owned, so the passthrough wrote the outcome into the
+	// work ledger and left the step open in the binding forever: a molecule
+	// that stalls with no error anywhere.
+	bdByIDUpdate bdByIDVerb = "update"
 )
 
 // bdByIDDepDirectionUp asks for the beads that depend ON the subject; the
@@ -123,6 +156,9 @@ type bdByIDOp struct {
 	// always populated for that verb; an empty DepType means every edge type.
 	Direction string
 	DepType   string
+	// Update carries the field and metadata writes of the update verb, already
+	// translated into the object model's own shape.
+	Update beads.UpdateOpts
 }
 
 // parseBdByIDOp recognizes the by-ID invocations this surface serves. Anything
@@ -141,12 +177,8 @@ func parseBdByIDOp(bdArgs []string) (bdByIDOp, bool) {
 		}
 		return bdByIDOp{Verb: bdByIDShow, ID: id, JSON: jsonOut}, true
 	case "update":
-		claim := false
-		id, jsonOut, ok := parseBdByIDPositional(bdArgs[1:], map[string]*bool{"--claim": &claim})
-		if !ok || !claim {
-			return bdByIDOp{}, false
-		}
-		return bdByIDOp{Verb: bdByIDClaim, ID: id, JSON: jsonOut}, true
+		op, _, ok := parseBdByIDUpdateArgs(bdArgs[1:])
+		return op, ok
 	case "release-if-current":
 		id, assignee, ok, err := parseBdReleaseIfCurrentArgs(bdArgs)
 		if err != nil || !ok {
@@ -160,6 +192,155 @@ func parseBdByIDOp(bdArgs []string) (bdByIDOp, bool) {
 		return parseBdDepListArgs(bdArgs[2:])
 	}
 	return bdByIDOp{}, false
+}
+
+// parseBdByIDUpdateArgs parses the tail of `gc bd update`.
+//
+// rejected names the first flag that stopped this from being served, so the
+// refusal an unserved class-owned update produces can say WHICH flag it was
+// rather than leaving an operator to bisect their own command line.
+//
+// The served set is exactly the flags that map onto beads.UpdateOpts, which is
+// the whole of what the object model can represent. Anything else is rejected
+// rather than dropped: a flag this arm silently ignored would change the
+// meaning of a command it then reported as executed, and on the step-completion
+// write that means an outcome an operator believes was recorded and was not.
+//
+// `--notes` is the consequential rejection and it is not an oversight — see
+// bdByIDUpdateUnrepresentable.
+func parseBdByIDUpdateArgs(args []string) (op bdByIDOp, rejected string, ok bool) {
+	op = bdByIDOp{Verb: bdByIDUpdate}
+	claim := false
+	metadata := map[string]string{}
+	set := func(field **string, value string) { v := value; *field = &v }
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "-") {
+			if op.ID != "" || arg == "" {
+				return bdByIDOp{}, arg, false
+			}
+			op.ID = arg
+			continue
+		}
+		name, inline, hasInline := strings.Cut(arg, "=")
+		// The inline form already carries the value; the separated form takes
+		// the next token. An `=` on a flag that takes no value is not a
+		// spelling bd accepts, and guessing at it would change the command.
+		value := inline
+		takesValue := bdByIDUpdateValueFlags[name]
+		switch {
+		case takesValue && !hasInline:
+			if i+1 >= len(args) {
+				return bdByIDOp{}, name, false
+			}
+			i++
+			value = args[i]
+		case !takesValue && hasInline:
+			return bdByIDOp{}, name, false
+		}
+		switch name {
+		case "--json":
+			op.JSON = true
+		case "--claim":
+			claim = true
+		case "--status", "-s":
+			set(&op.Update.Status, value)
+		case "--title":
+			set(&op.Update.Title, value)
+		case "--description", "-d":
+			set(&op.Update.Description, value)
+		case "--assignee", "-a":
+			set(&op.Update.Assignee, value)
+		case "--type", "-t":
+			set(&op.Update.Type, value)
+		case "--parent":
+			set(&op.Update.ParentID, value)
+		case "--priority", "-p":
+			priority, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return bdByIDOp{}, name, false
+			}
+			op.Update.Priority = &priority
+		case "--add-label":
+			op.Update.Labels = append(op.Update.Labels, value)
+		case "--remove-label":
+			op.Update.RemoveLabels = append(op.Update.RemoveLabels, value)
+		case "--set-metadata":
+			key, metaValue, split := strings.Cut(value, "=")
+			if !split || strings.TrimSpace(key) == "" {
+				return bdByIDOp{}, name, false
+			}
+			metadata[key] = metaValue
+		default:
+			return bdByIDOp{}, name, false
+		}
+	}
+	if op.ID == "" {
+		return bdByIDOp{}, "", false
+	}
+	if claim {
+		// The claim is a compare-and-swap the store owns; bundling other field
+		// writes into it here would either apply them outside that swap or
+		// re-implement it. bd's own `--claim` is likewise its own operation.
+		if bdByIDUpdateWritesFields(op, metadata) {
+			return bdByIDOp{}, "--claim", false
+		}
+		return bdByIDOp{Verb: bdByIDClaim, ID: op.ID, JSON: op.JSON}, "", true
+	}
+	if len(metadata) > 0 {
+		op.Update.Metadata = metadata
+	}
+	if !bdByIDUpdateWritesFields(op, metadata) {
+		// `gc bd update <id>` with nothing to write is bd's to answer.
+		return bdByIDOp{}, "", false
+	}
+	return op, "", true
+}
+
+// bdByIDUpdateValueFlags are the update flags this arm serves that consume the
+// next argument as their value. It is deliberately a local set rather than
+// bdflags.ValueFlags("update"): that manifest describes what BD accepts, and
+// this describes what the object model can represent. Reading the wider one
+// here would make every flag gc cannot write look served.
+var bdByIDUpdateValueFlags = map[string]bool{
+	"--status": true, "-s": true, "--title": true, "--description": true,
+	"-d": true, "--assignee": true, "-a": true, "--type": true, "-t": true,
+	"--parent": true, "--priority": true, "-p": true, "--add-label": true,
+	"--remove-label": true, "--set-metadata": true,
+}
+
+// bdByIDUpdateUnrepresentable explains the rejection an operator is most likely
+// to hit, because the core pack writes it.
+//
+// beads.Bead has no notes field and beads.UpdateOpts has no notes write: notes
+// are outside gc's object model entirely, and `gc bd update --notes` works on an
+// unrelocated city only because gc hands the whole command to bd. There is
+// therefore no faithful in-process spelling of it for a class-owned bead, and
+// the honest answer is to refuse and say so — a partial write reported as a
+// success is the failure mode this whole surface exists to remove.
+const bdByIDUpdateUnrepresentable = "--notes"
+
+// bdByIDUpdateWritesFields reports whether an update carries anything to write.
+func bdByIDUpdateWritesFields(op bdByIDOp, metadata map[string]string) bool {
+	u := op.Update
+	return u.Status != nil || u.Title != nil || u.Description != nil ||
+		u.Assignee != nil || u.Type != nil || u.ParentID != nil ||
+		u.Priority != nil || len(u.Labels) > 0 || len(u.RemoveLabels) > 0 ||
+		len(metadata) > 0
+}
+
+// bdByIDUnservedFlag names the flag that kept an otherwise-routable invocation
+// off this surface, or "" when the shape itself was never one this serves.
+func bdByIDUnservedFlag(bdArgs []string) string {
+	if len(bdArgs) == 0 || bdArgs[0] != "update" {
+		return ""
+	}
+	_, rejected, ok := parseBdByIDUpdateArgs(bdArgs[1:])
+	if ok {
+		return ""
+	}
+	return rejected
 }
 
 // parseBdDepListArgs parses the tail of `gc bd dep list`.
@@ -182,7 +363,13 @@ func parseBdDepListArgs(args []string) (bdByIDOp, bool) {
 			op.Direction = strings.TrimPrefix(arg, "--direction=")
 		case strings.HasPrefix(arg, "--type="):
 			op.DepType = strings.TrimPrefix(arg, "--type=")
-		case arg == "--direction", arg == "--type":
+		case strings.HasPrefix(arg, "-t="):
+			op.DepType = strings.TrimPrefix(arg, "-t=")
+		// -t is bd's own short form of --type (bdflags "dep list"). Omitting it
+		// meant the short spelling parsed as unrecognized, and while an
+		// unrecognized invocation fell through, `gc bd dep list <gcg-id> -t
+		// blocks` asked the work ledger a question only the binding can answer.
+		case arg == "--direction", arg == "--type", arg == "-t":
 			if i+1 >= len(args) {
 				return bdByIDOp{}, false
 			}
@@ -266,6 +453,20 @@ type bdByIDClassDoor struct {
 	Binding string
 }
 
+// bindingName names the binding in operator-facing text.
+//
+// A refused city whose [storage.classes] describe an arrangement this build
+// cannot read a class map out of has no binding NAME to report — the funnel
+// routes those at a refusing store under the empty name — and "owned by the
+// class binding" with a hole in it reads as a formatting bug rather than as a
+// fact. The literal keeps the sentence true when the name is unknown.
+func (d bdByIDClassDoor) bindingName() string {
+	if strings.TrimSpace(d.Binding) == "" {
+		return "the relocated class binding"
+	}
+	return fmt.Sprintf("the %s class binding", d.Binding)
+}
+
 // openBdByIDClassFrontDoor opens the class front door serving this city, for
 // whatever provider its coordination classes are served from.
 //
@@ -279,6 +480,17 @@ type bdByIDClassDoor struct {
 // resolves to a store whose every operation returns that refusal. So an
 // unconverged city neither serves stale answers from the work store here nor
 // goes quiet — it reports the same sentence `gc start` would have printed.
+//
+// # One door for every reserved prefix
+//
+// bdIDIsClassReserved matches ANY reserved class prefix and every match is
+// answered from this ONE store, which is sound only because the shape the
+// runtime serves is storageSplitWhole: storageSplitShapeOf admits a split only
+// when all five infrastructure classes name the same binding, and refuses a
+// per-class fan-out outright (storageSupportedTopologyStatement). If that ever
+// stops holding, this door has to resolve per class — the graph store would
+// otherwise be asked for a sessions-class id it does not hold, and would
+// truthfully answer that it is absent.
 func openBdByIDClassFrontDoor(cityPath string) (bdByIDClassDoor, bool, error) {
 	routes := cliStorageRoutes(cityPath)
 	store, relocated := graphClassBinding(routes)
@@ -321,7 +533,7 @@ func (d bdByIDClassDoor) resolve(id string) (bdByIDResolution, error) {
 	case errors.Is(err, beads.ErrNotFound):
 	case isStandingStorageRefusal(err) && !resolution.Reserved:
 	default:
-		return bdByIDResolution{}, fmt.Errorf("reading %q from the %s class binding: %w", id, d.Binding, err)
+		return bdByIDResolution{}, fmt.Errorf("reading %q from %s: %w", id, d.bindingName(), err)
 	}
 	return resolution, nil
 }
@@ -344,13 +556,17 @@ func bdIDIsClassReserved(id string) bool {
 // forms, or the id is a work-store id the class store does not answer for.
 func maybeRouteBdByID(cityPath string, bdArgs []string, stdout, stderr io.Writer) (int, bool) {
 	op, served := parseBdByIDOp(bdArgs)
-	refusable, refusableOK, ambiguous := bdMutationWriteIDs(bdArgs)
-	mutationRefusable := refusableOK && !ambiguous && len(refusable) > 0
-	listNamed, listNames := bdListNamesClassOwnedBead(bdArgs)
-	if !served && !mutationRefusable && !listNames {
-		// Nothing here could concern a class-owned id, so the binding is not
-		// even opened. An ambiguous mutation scan is left to the fail-closed
-		// guard doBd already applies to it.
+	named, namesClassBead := bdArgsNameClassOwnedBead(bdArgs)
+	if !served && !namesClassBead {
+		// Nothing here can concern a class-owned bead, so the binding is not
+		// opened and the funnel is not entered.
+		//
+		// This is also the cost gate. Entering the funnel resolves a plan and
+		// opens a database, and the born-split arm re-proves its invariant with
+		// a full work-store census; a work mutation that addresses only work
+		// ids must not pay that. A non-reserved positional id on update/close
+		// needs the exact-ID collision guard doBd already applies to it, not
+		// class routing — the class store has no claim on it.
 		return 0, false
 	}
 	door, routed, err := openBdByIDClassFrontDoor(cityPath)
@@ -362,12 +578,11 @@ func maybeRouteBdByID(cityPath string, bdArgs []string, stdout, stderr io.Writer
 		return 0, false
 	}
 	if !served {
-		if listNames {
-			// A reserved prefix is proof of ownership on its own, so no
-			// residence probe is needed to know the work store cannot answer.
-			return refuseClassOwnedTarget(door, "list", listNamed, stderr)
-		}
-		return refuseClassOwnedPassthrough(door, bdArgs[0], refusable, stderr)
+		// The invocation addresses a bead only the class binding could own, in
+		// a spelling this surface does not serve. A reserved prefix is proof of
+		// ownership on its own, so no residence probe is needed to know the
+		// work store cannot answer.
+		return refuseClassOwnedTarget(door, bdByIDRefusedVerb(bdArgs), named, bdByIDUnservedFlag(bdArgs), stderr)
 	}
 
 	resolution, err := door.resolve(op.ID)
@@ -387,82 +602,246 @@ func maybeRouteBdByID(cityPath string, bdArgs []string, stdout, stderr io.Writer
 	}
 	switch op.Verb {
 	case bdByIDShow:
-		return printBdByIDBead(resolution.Bead, op.JSON, stdout, stderr), true
+		return printBdByIDBead(resolution.Bead, op.JSON, door.bindingName(), stdout, stderr), true
 	case bdByIDClaim:
-		return doBdByIDClaim(resolution.Graph, op.ID, bdByIDClaimActor(), op.JSON, stdout, stderr), true
+		return doBdByIDClaim(resolution.Graph, op.ID, bdByIDClaimActor(), op.JSON, door.bindingName(), stdout, stderr), true
 	case bdByIDRelease:
 		return doBdByIDReleaseIfCurrent(resolution.Graph, op.ID, op.Assignee, stdout, stderr), true
 	case bdByIDDepList:
 		return doBdByIDDepList(resolution.Graph, op, stdout, stderr), true
+	case bdByIDUpdate:
+		return doBdByIDUpdate(resolution.Graph, op, door.bindingName(), stdout, stderr), true
 	}
-	return 0, false
-}
-
-// refuseClassOwnedPassthrough stops a write mutation whose subject the class
-// store owns but which this surface does not serve.
-//
-// The alternative is what a bare passthrough does: hand it to bd, which opens
-// the work store, cannot see the bead, and either blocks on a work backend that
-// has nothing to say or mutates whatever its substring resolver found there
-// instead. A refusal with the bead named is recoverable; both of those are not.
-//
-// handled=false — the passthrough, unchanged — is the answer whenever no
-// subject is class-owned, which is every work mutation on these cities.
-func refuseClassOwnedPassthrough(door bdByIDClassDoor, verb string, ids []string, stderr io.Writer) (int, bool) {
-	for _, id := range ids {
-		resolution, err := door.resolve(id)
-		if err != nil {
-			fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1, true
-		}
-		if !resolution.Owned() {
-			continue
-		}
-		return refuseClassOwnedTarget(door, verb, id, stderr)
-	}
-	return 0, false
+	// Unreachable while the verb set and this switch agree, and a refusal
+	// rather than a fall-through because the two disagreeing is exactly the
+	// case that must not reach bd: the id is already known to be class-owned,
+	// so the passthrough would run a verb this build recognized against the one
+	// ledger that cannot hold the bead.
+	return refuseClassOwnedTarget(door, string(op.Verb), op.ID, "", stderr)
 }
 
 // refuseClassOwnedTarget is the single refusal message, so every unsupported
 // class-owned operation reports the same way.
-func refuseClassOwnedTarget(door bdByIDClassDoor, verb, id string, stderr io.Writer) (int, bool) {
-	fmt.Fprintf(stderr, "gc bd: %s is owned by the %s class binding, and `gc bd %s` is not served in process; refusing rather than running it against the work store, which does not hold the bead\n", id, door.Binding, verb) //nolint:errcheck // best-effort stderr
+//
+// flag, when known, names the spelling that kept the command off this surface.
+// Without it an operator hitting a rejected `--notes` sees only that `gc bd
+// update` "is not served", which is false in general and unactionable in
+// particular.
+func refuseClassOwnedTarget(door bdByIDClassDoor, verb, id, flag string, stderr io.Writer) (int, bool) {
+	because := ""
+	if flag != "" {
+		because = fmt.Sprintf(" (%s has no representation in the class store contract)", flag)
+	}
+	fmt.Fprintf(stderr, "gc bd: %s is owned by %s, and `gc bd %s` is not served in process%s; refusing rather than running it against the work store, which does not hold the bead\n", id, door.bindingName(), verb, because) //nolint:errcheck // best-effort stderr
 	return 1, true
 }
 
-// bdListNamesClassOwnedBead reports whether a `gc bd list` NAMES a class-owned
-// bead as its target, as opposed to merely mentioning one inside a filter
-// value.
+// bdByIDRefusedVerb names the subcommand a refusal is about, as an operator
+// typed it.
 //
-// A `--metadata-field workflow_id=gcg-…` probe is a work question that happens
-// to quote a class id: the work store answers for its own rows and must keep
-// doing so, and refusing it exec-fails the consumer that asks it. A
-// `--parent gcg-…` or a positional class id is a class-targeted read, and
-// letting the work store answer it produces the silent empty result.
-//
-// Ownership is decided by reserved prefix alone, with no residence probe: this
-// runs on every `gc bd list`, and a prefix is proof enough for the only
-// decision being made — whether a work store could possibly be the right
-// answerer.
-func bdListNamesClassOwnedBead(bdArgs []string) (string, bool) {
-	if len(bdArgs) == 0 || bdArgs[0] != "list" {
-		return "", false
+// It reports the bd subcommand rather than argv[0], so a root flag before the
+// verb (`gc bd --json close gcg-1`) does not make the refusal name a flag. When
+// the manifest does not carry the subcommand it reconstructs the spelling from
+// the leading non-flag tokens instead of truncating to the first: `dep tree` is
+// not in bdflags (only dep add/list/remove are), and reporting it as "dep" tells
+// an operator to look for a command they did not run.
+func bdByIDRefusedVerb(bdArgs []string) string {
+	if sub, _, resolved := bdByIDSubcommand(bdArgs); resolved {
+		return sub
 	}
-	// The filters whose value is content to match, never a bead being
-	// addressed. Every other token in an id position addresses one.
-	valueOnly := map[string]bool{"--metadata-field": true, "--label": true}
-	args := bdArgs[1:]
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if valueOnly[arg] {
+	globals := bdflags.GlobalValueFlags()
+	bools := bdflags.GlobalBoolFlags()
+	// Two is bd's deepest verb nesting ("mol pour", "dep tree"); a third token
+	// is an argument, and on these paths it is usually the bead being refused.
+	words := make([]string, 0, 2)
+	for i := 0; i < len(bdArgs) && len(words) < 2; i++ {
+		arg := bdArgs[i]
+		if !strings.HasPrefix(arg, "-") {
+			if bdIDIsClassReserved(arg) {
+				break
+			}
+			words = append(words, arg)
+			continue
+		}
+		if strings.IndexByte(arg, '=') >= 0 || bools[arg] {
+			continue
+		}
+		if globals[arg] {
 			i++
 			continue
 		}
-		if eq := strings.IndexByte(arg, '='); eq > 0 && strings.HasPrefix(arg, "--") && valueOnly[arg[:eq]] {
+		break
+	}
+	if len(words) == 0 {
+		return "(no subcommand)"
+	}
+	return strings.Join(words, " ")
+}
+
+// bdArgsNameClassOwnedBead reports the first reserved-prefix id an invocation
+// ADDRESSES, for any bd subcommand, and is what keeps an unserved spelling from
+// reaching the work ledger.
+//
+// It exists because the served parsers are deliberately strict: they reject
+// every flag they do not implement, and a rejection used to mean the command
+// fell through to the subprocess. bd's own manifest names the spellings that
+// took that exit — `show --long/--short/--children/--refs/--thread/
+// --include-comments/--include-dependents/--as-of/--id`, `dep list -t/--type/
+// --direction` — so the very flags an operator reaches for when the terse
+// answer is not enough were the ones routed at the ledger that cannot answer.
+// Ownership is therefore decided HERE, independently of whether this surface
+// can serve the command, and an unserved spelling on a class-owned bead is
+// refused rather than forwarded.
+//
+// # ID position
+//
+// An id is ADDRESSED when it is a positional token, or the value of a flag that
+// takes a bead id. It is merely QUOTED when it is the value of any other flag,
+// and a quoted id decides nothing: `gc bd list --metadata-field
+// workflow_id=gcg-…` is a work question about work rows, and refusing it
+// exec-fails the consumer that asks it.
+//
+// The value/positional split comes from bdflags — the tree's own manifest of
+// what each subcommand's flags consume — rather than from a local list, so a
+// flag bd grows does not silently become an id position here. The id-valued
+// subset is local because bdflags records arity, not meaning.
+//
+// # Failing closed
+//
+// Two things can stop the walk from deciding: an unresolvable subcommand and an
+// unknown flag, and both mean the same thing — from here on, nothing can be
+// told from a value. Both widen the scan rather than ending it: every remaining
+// token is treated as addressed. That is the same choice bdRelocatedClassVerb
+// makes and it is bounded the same way, because only a token that actually
+// carries a reserved class prefix can refuse anything.
+func bdArgsNameClassOwnedBead(bdArgs []string) (string, bool) {
+	sub, args, resolved := bdByIDSubcommand(bdArgs)
+	valueFlags := bdflags.GlobalValueFlags()
+	boolFlags := bdflags.GlobalBoolFlags()
+	if resolved {
+		for flag := range bdflags.ValueFlags(sub) {
+			valueFlags[flag] = true
+		}
+		for flag := range bdflags.BoolFlags(sub) {
+			boolFlags[flag] = true
+		}
+	}
+	// An unresolved subcommand cannot say what any flag consumes, so nothing is
+	// skipped and every token is judged.
+	undecidable := !resolved
+	positionalOnly := false
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case positionalOnly:
+		case arg == "--":
+			positionalOnly = true
+			continue
+		case strings.HasPrefix(arg, "-") && arg != "-":
+			name, inline, hasInline := strings.Cut(arg, "=")
+			if hasInline {
+				if bdIDValuedFlags[name] || (undecidable && !boolFlags[name]) {
+					if id, named := bdFirstReservedClassID(inline); named {
+						return id, true
+					}
+				}
+				continue
+			}
+			if boolFlags[name] {
+				continue
+			}
+			if !valueFlags[name] {
+				// Unknown flag: it may or may not consume the next token, so
+				// from here nothing is skipped.
+				undecidable = true
+				continue
+			}
+			if i+1 >= len(args) {
+				continue
+			}
+			i++
+			if bdIDValuedFlags[name] {
+				if id, named := bdFirstReservedClassID(args[i]); named {
+					return id, true
+				}
+			} else if undecidable {
+				// The flag is known to consume this token, so it is a value —
+				// but an earlier unknown flag may already have shifted the
+				// alignment, so judge it rather than trust the offset.
+				if id, named := bdFirstReservedClassID(args[i]); named {
+					return id, true
+				}
+			}
 			continue
 		}
-		if bdIDIsClassReserved(arg) {
-			return arg, true
+		if id, named := bdFirstReservedClassID(arg); named {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// bdByIDSubcommand locates the bd subcommand in an argv and returns the
+// arguments that follow it.
+//
+// bd accepts its root flags BEFORE the subcommand (`bd --json show <id>`) and
+// `gc bd` forwards argv verbatim, so indexing bdArgs[0] reads a flag as the
+// verb. Compound subcommands ("dep list", "mol pour") are matched two tokens
+// first, the way bdflags itself keys them.
+func bdByIDSubcommand(bdArgs []string) (sub string, args []string, resolved bool) {
+	globals := bdflags.GlobalValueFlags()
+	bools := bdflags.GlobalBoolFlags()
+	for i := 0; i < len(bdArgs); i++ {
+		arg := bdArgs[i]
+		if !strings.HasPrefix(arg, "-") {
+			if i+1 < len(bdArgs) {
+				if two := arg + " " + bdArgs[i+1]; bdflags.Known(two) {
+					return two, bdArgs[i+2:], true
+				}
+			}
+			if bdflags.Known(arg) {
+				return arg, bdArgs[i+1:], true
+			}
+			// A subcommand this build's manifest does not carry. Everything
+			// after it is judged rather than skipped.
+			return "", bdArgs[i+1:], false
+		}
+		if strings.IndexByte(arg, '=') >= 0 || bools[arg] {
+			continue
+		}
+		if globals[arg] {
+			i++
+			continue
+		}
+		return "", bdArgs[i+1:], false
+	}
+	return "", nil, false
+}
+
+// bdIDValuedFlags are the flags whose value NAMES a bead rather than describing
+// one. bdflags records what a flag consumes; this records what it means, which
+// is the distinction between addressing a bead and quoting one.
+//
+// Over-inclusion is cheap and under-inclusion is not: a flag listed here whose
+// value is not an id (`-p 2` is a priority on most subcommands and a parent on
+// some) costs nothing, because only a value carrying a reserved class prefix
+// decides anything, and no priority ever does.
+var bdIDValuedFlags = map[string]bool{
+	"--id": true, "--parent": true, "-p": true, "--depends-on": true,
+	"--blocked-by": true, "--await-id": true, "--deps": true,
+	"--waits-for": true, "--waits-for-gate": true, "--mol": true,
+	"--for": true, "--attach": true,
+}
+
+// bdFirstReservedClassID returns the first reserved-prefix id in a token,
+// splitting the comma lists bd accepts for `--deps` and friends so an id in a
+// later position is not missed.
+func bdFirstReservedClassID(token string) (string, bool) {
+	for _, part := range strings.Split(token, ",") {
+		part = strings.TrimSpace(part)
+		if bdIDIsClassReserved(part) {
+			return part, true
 		}
 	}
 	return "", false
@@ -488,7 +867,7 @@ func bdByIDClaimActor() string { return strings.TrimSpace(os.Getenv("BEADS_ACTOR
 // A conflict is reported to the operator as a non-zero exit, matching what the
 // bd passthrough does with a lost claim race; the conflict-is-not-an-error
 // property is about the store contract, not about the shell.
-func doBdByIDClaim(graph storebinding.GraphStore, id, assignee string, jsonOut bool, stdout, stderr io.Writer) int {
+func doBdByIDClaim(graph storebinding.GraphStore, id, assignee string, jsonOut bool, binding string, stdout, stderr io.Writer) int {
 	if assignee == "" {
 		fmt.Fprintf(stderr, "gc bd: claiming %s requires BEADS_ACTOR to name the claimant\n", id) //nolint:errcheck // best-effort stderr
 		return 1
@@ -510,7 +889,7 @@ func doBdByIDClaim(graph storebinding.GraphStore, id, assignee string, jsonOut b
 		fmt.Fprintf(stderr, "gc bd: %s was not claimed for %q: %s\n", id, assignee, reason) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	return printBdByIDBead(claimed, jsonOut, stdout, stderr)
+	return printBdByIDBead(claimed, jsonOut, binding, stdout, stderr)
 }
 
 // doBdByIDReleaseIfCurrent applies the conditional release through the closed
@@ -597,10 +976,22 @@ func doBdByIDDepList(graph storebinding.GraphStore, op bdByIDOp, stdout, stderr 
 	return 0
 }
 
-// printBdByIDBead renders a bead in bd's show shape: --json emits a JSON array
-// of issues, which is what bd emits and what the pack parsers already read; the
-// text form is the id/status/title line.
-func printBdByIDBead(b beads.Bead, jsonOut bool, stdout, stderr io.Writer) int {
+// printBdByIDBead renders a routed bead.
+//
+// --json emits a JSON array of issues, which is what bd emits and what the pack
+// parsers already read, and it carries the whole record because beads.Bead
+// marshals whole.
+//
+// The text form is the one that had to change. It used to be an id/status/title
+// line, and that is the wrong-answer harm class this surface exists to close,
+// one layer in: graph-worker.md tells an agent to `gc bd show <id>` and then
+// "execute exactly that bead's description", so a well-formed record with the
+// description silently absent is an instruction to do nothing, reported as a
+// successful read. It renders the full record instead — description, metadata,
+// labels, dependencies, assignee, priority, parent — and says on stderr where
+// the record came from, so a human who expected bd's own layout can see why it
+// differs rather than assume the bead is thin.
+func printBdByIDBead(b beads.Bead, jsonOut bool, binding string, stdout, stderr io.Writer) int {
 	if jsonOut {
 		out, err := json.MarshalIndent([]beads.Bead{b}, "", "  ")
 		if err != nil {
@@ -610,8 +1001,84 @@ func printBdByIDBead(b beads.Bead, jsonOut bool, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, string(out)) //nolint:errcheck // best-effort stdout
 		return 0
 	}
-	fmt.Fprintf(stdout, "%s\t%s\t%s\n", b.ID, b.Status, b.Title) //nolint:errcheck // best-effort stdout
+	fmt.Fprintf(stderr, "gc bd: served in process from %s\n", binding) //nolint:errcheck // best-effort stderr
+
+	line := func(label, value string) {
+		if strings.TrimSpace(value) == "" {
+			return
+		}
+		fmt.Fprintf(stdout, "%-12s %s\n", label+":", value) //nolint:errcheck // best-effort stdout
+	}
+	line("id", b.ID)
+	line("title", b.Title)
+	line("status", b.Status)
+	line("type", b.Type)
+	if b.Priority != nil {
+		line("priority", strconv.Itoa(*b.Priority))
+	}
+	line("assignee", b.Assignee)
+	line("from", b.From)
+	line("parent", b.ParentID)
+	line("ref", b.Ref)
+	line("created", b.CreatedAt.Format(time.RFC3339))
+	if !b.UpdatedAt.IsZero() {
+		line("updated", b.UpdatedAt.Format(time.RFC3339))
+	}
+	line("labels", strings.Join(b.Labels, ", "))
+	line("needs", strings.Join(b.Needs, ", "))
+	if len(b.Metadata) > 0 {
+		fmt.Fprintln(stdout, "metadata:") //nolint:errcheck // best-effort stdout
+		keys := make([]string, 0, len(b.Metadata))
+		for key := range b.Metadata {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			fmt.Fprintf(stdout, "  %s=%s\n", key, b.Metadata[key]) //nolint:errcheck // best-effort stdout
+		}
+	}
+	if len(b.Dependencies) > 0 {
+		fmt.Fprintln(stdout, "dependencies:") //nolint:errcheck // best-effort stdout
+		for _, dep := range b.Dependencies {
+			fmt.Fprintf(stdout, "  %s\t%s\n", dep.DependsOnID, dep.Type) //nolint:errcheck // best-effort stdout
+		}
+	}
+	// Last, and never elided: an agent reads this to know what to do, so it is
+	// the field whose silent absence costs the most.
+	fmt.Fprintln(stdout, "description:") //nolint:errcheck // best-effort stdout
+	if strings.TrimSpace(b.Description) == "" {
+		fmt.Fprintln(stdout, "  (none)") //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	for _, descLine := range strings.Split(b.Description, "\n") {
+		fmt.Fprintf(stdout, "  %s\n", descLine) //nolint:errcheck // best-effort stdout
+	}
 	return 0
+}
+
+// doBdByIDUpdate applies a field and metadata write through the closed graph
+// contract, then re-reads and renders what the store now holds.
+//
+// It is one Update call carrying every change, rather than a status write and a
+// metadata write in sequence: the step-completion pattern sets the outcome and
+// closes in the same command, and splitting it would let a crash between the
+// two leave a bead closed with no outcome — the state the reader of that
+// metadata cannot tell from a bead that failed to record one.
+//
+// The re-read is deliberate. bd prints the row after a mutation and callers
+// have learned to trust that output; rendering the UpdateOpts back would report
+// what was asked for rather than what the store now holds.
+func doBdByIDUpdate(graph storebinding.GraphStore, op bdByIDOp, binding string, stdout, stderr io.Writer) int {
+	if err := graph.Update(op.ID, op.Update); err != nil {
+		fmt.Fprintf(stderr, "gc bd update: %s: %v\n", op.ID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	updated, err := graph.Get(op.ID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd update: %s was written and could not be re-read: %v\n", op.ID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return printBdByIDBead(updated, op.JSON, binding, stdout, stderr)
 }
 
 // printBdByIDNotFound renders genuine absence in bd's own shape so existing

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -1,0 +1,565 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/storebinding"
+	"github.com/gastownhall/gascity/internal/storebinding/beadsworkspace"
+	sqlitebinding "github.com/gastownhall/gascity/internal/storebinding/sqlite"
+)
+
+// configRefEngineProviderID is the foreign provider the fixtures below serve
+// their infrastructure classes from. It is not the built-in engine, so
+// resolveInfraBindingTarget refuses it and the whole migration apparatus is out
+// of the picture — which is exactly the city this surface used to answer with a
+// bd subprocess against the work workspace.
+const configRefEngineProviderID = storebinding.ProviderID("outoftree-configref-engine")
+
+// configRefEngineProviderFactory re-registers this build's own engine factory
+// under a foreign provider ID that is configured the way every non-built-in
+// provider must be: by CONFIGURATION REFERENCE. city.toml admits `path` only for
+// the built-in engine (config.validateStorageBindingConfig), so a fixture that
+// has to survive a real config load cannot borrow the built-in spelling.
+//
+// The binding still opens a real bead engine minting real reserved-prefix ids,
+// so these tests prove the routing rather than a mock of it.
+type configRefEngineProviderFactory struct{}
+
+func (configRefEngineProviderFactory) ID() storebinding.ProviderID { return configRefEngineProviderID }
+
+func (configRefEngineProviderFactory) New(spec storebinding.BindingSpec) (storebinding.Provider, error) {
+	inner := sqlitebinding.BeadsProviderFactory{}
+	provider, err := inner.New(configRefEngineSpec(spec))
+	if err != nil {
+		return nil, err
+	}
+	return configRefEngineProvider{Provider: provider}, nil
+}
+
+// configRefEngineSpec translates this provider's configuration reference into
+// the path the inner engine is configured with, the way a real out-of-tree
+// provider turns its own opaque reference into a location.
+func configRefEngineSpec(spec storebinding.BindingSpec) storebinding.BindingSpec {
+	spec.Provider = sqlitebinding.BeadsProviderID
+	spec.Path = filepath.Join(spec.CityRoot, ".gc", "engine-"+string(spec.ConfigRef))
+	spec.ConfigRef = ""
+	return spec
+}
+
+// configRefEngineProvider forwards the provider facade and translates the spec
+// on both seams a serving binding uses, so the inner engine's own "refuse a
+// foreign spec" defense stays armed.
+type configRefEngineProvider struct {
+	storebinding.Provider
+}
+
+func (p configRefEngineProvider) OpenEngine(spec storebinding.BindingSpec, classes storebinding.ClassSet) (beads.Store, io.Closer, error) {
+	opener, ok := p.Provider.(storebinding.EngineOpener)
+	if !ok {
+		return nil, nil, errors.New("inner provider opens no engine")
+	}
+	return opener.OpenEngine(configRefEngineSpec(spec), classes)
+}
+
+func (p configRefEngineProvider) BindingLocation(spec storebinding.BindingSpec) (string, error) {
+	locator, ok := p.Provider.(storebinding.BindingLocator)
+	if !ok {
+		return "", errors.New("inner provider reports no location")
+	}
+	return locator.BindingLocation(configRefEngineSpec(spec))
+}
+
+// writeForeignProviderCityTOML writes a city whose whole infrastructure split is
+// served by a foreign provider, in the config-reference spelling.
+func writeForeignProviderCityTOML(t *testing.T, cityPath, provider, ref string) {
+	t.Helper()
+	body := fmt.Sprintf(`[workspace]
+name = "by-id-city"
+
+[storage.classes]
+work = %q
+graph = "infra"
+sessions = "infra"
+messaging = "infra"
+orders = "infra"
+nudges = "infra"
+
+[storage.bindings.infra]
+provider = %q
+config_ref = %q
+`, config.StorageWorkBinding, provider, ref)
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing city.toml: %v", err)
+	}
+}
+
+// registerConfigRefEngineProvider freezes a registry carrying only the foreign
+// engine provider, for the whole of one test.
+func registerConfigRefEngineProvider(t *testing.T) {
+	t.Helper()
+	prev := newStorageRegistryForPlan
+	newStorageRegistryForPlan = func() (*storebinding.ProviderRegistry, error) {
+		registry := storebinding.NewProviderRegistry()
+		if err := registry.Register(configRefEngineProviderFactory{}); err != nil {
+			return nil, err
+		}
+		if err := registry.Freeze(); err != nil {
+			return nil, err
+		}
+		return registry, nil
+	}
+	t.Cleanup(func() { newStorageRegistryForPlan = prev })
+}
+
+// foreignProviderCity prepares a city that SERVES its infrastructure classes
+// from a non-built-in provider, and returns the class store the binding opened.
+//
+// The work store is stubbed empty because the born-split discipline is what
+// admits such a city: a provider this build cannot migrate onto serves only
+// while no infrastructure bead sits in the work store.
+func foreignProviderCity(t *testing.T) (cityPath string, classStore beads.Store) {
+	t.Helper()
+	clearGCEnv(t)
+	cityPath = t.TempDir()
+	writeForeignProviderCityTOML(t, cityPath, string(configRefEngineProviderID), "infra")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_CITY", cityPath)
+	registerConfigRefEngineProvider(t)
+	stubInfraMigrationSource(t)
+	resetCLIStorageRoutes(t)
+	captureCLIStorageStderr(t)
+
+	store, relocated := graphClassBinding(cliStorageRoutes(cityPath))
+	if !relocated {
+		t.Fatal("a city serving its classes from a foreign provider resolved no class binding")
+	}
+	return cityPath, store
+}
+
+// mustCreateClassBead creates a bead in the class binding and proves it carries
+// a reserved class prefix, which is what makes it unanswerable by any other
+// store.
+func mustCreateClassBead(t *testing.T, store beads.Store, b beads.Bead) beads.Bead {
+	t.Helper()
+	created, err := store.Create(b)
+	if err != nil {
+		t.Fatalf("creating %q in the class binding: %v", b.Title, err)
+	}
+	if !bdIDIsClassReserved(created.ID) {
+		t.Fatalf("the class binding minted %q, which carries no reserved class prefix", created.ID)
+	}
+	return created
+}
+
+// TestBdByIDServesAClassBeadFromANonBuiltInProviderBinding is the regression.
+//
+// The city serves its infrastructure classes from a provider this build carries
+// no migration discipline for — a beads workspace, a fork's own engine, anything
+// that is not the built-in one. A by-ID read of a bead that lives in that
+// binding must be answered from it. Before this, target resolution asked the
+// MIGRATION whether it recognized the provider, that answer was no, and the read
+// fell through to the bd subprocess pointed at the work workspace, which does
+// not hold the bead and cannot say so.
+func TestBdByIDServesAClassBeadFromANonBuiltInProviderBinding(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "lives in the binding", Type: "task"})
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"show", bead.ID, "--json"}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-owned id fell through to the bd subprocess: stderr %q", stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("showing %s exited %d: %s", bead.ID, code, stderr.String())
+	}
+	var shown []beads.Bead
+	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
+		t.Fatalf("decoding the routed show output %q: %v", stdout.String(), err)
+	}
+	if len(shown) != 1 || shown[0].ID != bead.ID {
+		t.Fatalf("the routed show printed %+v, want exactly %s", shown, bead.ID)
+	}
+	if shown[0].Title != bead.Title {
+		t.Errorf("the routed show printed title %q, want %q", shown[0].Title, bead.Title)
+	}
+}
+
+// TestBdByIDServesClaimReleaseAndDepListFromTheClassBinding covers the other
+// three verbs on the same foreign-provider city. They are the cascade-nudge
+// order's reads and the orphan-recovery scripts' writes, and every one of them
+// used to be answered by a subprocess against the wrong workspace.
+func TestBdByIDServesClaimReleaseAndDepListFromTheClassBinding(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	subject := mustCreateClassBead(t, classStore, beads.Bead{Title: "the subject", Type: "task"})
+	blocker := mustCreateClassBead(t, classStore, beads.Bead{Title: "the blocker", Type: "task"})
+	if err := classStore.DepAdd(subject.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("adding the dependency: %v", err)
+	}
+
+	t.Setenv("BEADS_ACTOR", "by-id-tester")
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, []string{"update", subject.ID, "--claim"}, &stdout, &stderr); !handled || code != 0 {
+		t.Fatalf("claiming %s = (%d, %t): %s", subject.ID, code, handled, stderr.String())
+	}
+	claimed, err := classStore.Get(subject.ID)
+	if err != nil {
+		t.Fatalf("re-reading the claimed bead: %v", err)
+	}
+	if claimed.Assignee != "by-id-tester" {
+		t.Errorf("the routed claim recorded assignee %q, want %q", claimed.Assignee, "by-id-tester")
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code, handled := maybeRouteBdByID(cityPath, []string{"release-if-current", subject.ID, "by-id-tester"}, &stdout, &stderr); !handled || code != 0 {
+		t.Fatalf("releasing %s = (%d, %t): %s", subject.ID, code, handled, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "released" {
+		t.Errorf("the routed release printed %q, want %q", got, "released")
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code, handled := maybeRouteBdByID(cityPath, []string{"dep", "list", subject.ID, "--json"}, &stdout, &stderr)
+	if !handled || code != 0 {
+		t.Fatalf("listing %s dependencies = (%d, %t): %s", subject.ID, code, handled, stderr.String())
+	}
+	var rows []bdByIDDepRow
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("decoding the routed dep list %q: %v", stdout.String(), err)
+	}
+	if len(rows) != 1 || rows[0].ID != blocker.ID {
+		t.Fatalf("the routed dep list printed %+v, want exactly %s", rows, blocker.ID)
+	}
+	if rows[0].DepType != "blocks" {
+		t.Errorf("the routed dep list reported edge type %q, want %q", rows[0].DepType, "blocks")
+	}
+}
+
+// TestBdByIDReservedPrefixAbsenceIsNotAFallThrough pins the rule that makes the
+// routing safe: a reserved-prefix id is minted by the class store and nowhere
+// else, so its absence there is genuine absence. Falling through would print a
+// work-store answer about a bead the work store never held.
+func TestBdByIDReservedPrefixAbsenceIsNotAFallThrough(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	missing := reservedClassID(t, "notthere")
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"show", missing}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("an absent reserved-prefix id fell through to the bd subprocess")
+	}
+	if code == 0 {
+		t.Errorf("an absent bead exited 0 with stdout %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), missing) {
+		t.Errorf("the absence does not name %s: %q", missing, stderr.String())
+	}
+}
+
+// TestBdByIDLeavesWorkStoreIDsToThePassthrough is the other half of the same
+// rule. An ordinary work id the class store has never seen is still bd's to
+// answer, and the passthrough answers it byte-identically.
+func TestBdByIDLeavesWorkStoreIDsToThePassthrough(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, []string{"show", "gc-abc123"}, &stdout, &stderr); handled {
+		t.Fatalf("a work-store id was answered here (exit %d): %s%s", code, stdout.String(), stderr.String())
+	}
+}
+
+// TestBdByIDDoesNotRouteAnIDInAValuePosition pins the value-position escape: a
+// filter whose VALUE quotes a class id is a work question, and answering or
+// refusing it here breaks the consumer that asks it.
+func TestBdByIDDoesNotRouteAnIDInAValuePosition(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	quoted := reservedClassID(t, "quoted")
+
+	for _, args := range [][]string{
+		{"list", "--metadata-field", "workflow_id=" + quoted},
+		{"list", "--label", quoted},
+	} {
+		var stdout, stderr bytes.Buffer
+		if code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr); handled {
+			t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
+		}
+	}
+}
+
+// TestBdByIDRefusesAnUnservedVerbOnAClassOwnedBead is the fail-closed floor. An
+// operation this surface does not serve, whose subject the class binding owns,
+// must not reach bd: bd opens the work workspace, cannot see the bead, and
+// either blocks on it or mutates whatever its substring resolver found there.
+func TestBdByIDRefusesAnUnservedVerbOnAClassOwnedBead(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "not yours to close", Type: "task"})
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"close", bead.ID}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("an unserved mutation of a class-owned bead was handed to the bd subprocess")
+	}
+	if code == 0 {
+		t.Error("an unserved mutation of a class-owned bead exited 0")
+	}
+	if !strings.Contains(stderr.String(), bead.ID) {
+		t.Errorf("the refusal does not name the bead: %q", stderr.String())
+	}
+	if got, err := classStore.Get(bead.ID); err != nil {
+		t.Fatalf("re-reading the refused bead: %v", err)
+	} else if got.Status == "closed" {
+		t.Error("the refused close reached the class binding anyway")
+	}
+}
+
+// TestBdByIDRefusesRatherThanFallsThroughWhenTheWorkspaceIsNotThere is the
+// failure semantics against the real beads workspace provider: a binding whose
+// workspace is missing produces the boot gate's own refusal, naming the
+// directory, rather than a silent fall-through to bd.
+//
+// A read failure classified as absence is the root-loss shape this whole lane
+// exists to prevent, and a fall-through is that classification in its most
+// expensive form: the answer comes back confidently from the wrong ledger.
+func TestBdByIDRefusesRatherThanFallsThroughWhenTheWorkspaceIsNotThere(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	writeForeignProviderCityTOML(t, cityPath, string(beadsworkspace.ProviderID), "infra")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_CITY", cityPath)
+	stubInfraMigrationSource(t)
+	resetCLIStorageRoutes(t)
+	gateStderr := captureCLIStorageStderr(t)
+
+	root, err := beadsworkspace.WorkspaceRoot(cityPath, "infra")
+	if err != nil {
+		t.Fatalf("resolving the workspace root: %v", err)
+	}
+
+	missing := reservedClassID(t, "unreachable")
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"show", missing}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("a city whose infrastructure workspace is missing fell through to the bd subprocess")
+	}
+	if code == 0 {
+		t.Errorf("an unreadable binding exited 0 with stdout %q", stdout.String())
+	}
+	// The command's OWN stderr, not the funnel's. The one-shot funnel prints
+	// the boot refusal once when it takes the verdict, so a surface that
+	// swallowed the read failure and reported absence would still leave the
+	// workspace path on the terminal — and the test would pass while the
+	// operator was told the bead does not exist.
+	said := stderr.String()
+	if !strings.Contains(said, root) {
+		t.Errorf("the routed refusal does not name the workspace directory %s: %q", root, said)
+	}
+	if !strings.Contains(said, beadsworkspace.ErrWorkspaceUnavailable.Error()) {
+		t.Errorf("the routed refusal does not carry %v: %q", beadsworkspace.ErrWorkspaceUnavailable, said)
+	}
+	if strings.Contains(said, "no issue found") {
+		t.Errorf("a binding that could not be read was reported as an absent bead: %q", said)
+	}
+	if gateStderr.Len() == 0 {
+		t.Error("the one-shot funnel took a refusing verdict without printing its reason")
+	}
+}
+
+// TestBdByIDReadFailureIsAnErrorNotAbsence is the classification the whole lane
+// turns on, isolated from any one provider: a class store that cannot answer
+// must produce the store's error, and must never be reported as a bead that is
+// not there.
+//
+// Absence and failure are indistinguishable to every consumer once they have
+// been flattened, and the consumers act on absence — a graph-blind read that
+// reported a live molecule root as missing is what produced a destructive
+// restart. So the failing read is asserted twice: the cause must reach stderr,
+// and bd's own absence shape must not.
+func TestBdByIDReadFailureIsAnErrorNotAbsence(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	present := reservedClassID(t, "present")
+	failure := errors.New("the class binding is having a bad day")
+	failClassBindingReads(t, cityPath, failure)
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"show", present}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("a failing class-store read fell through to the bd subprocess")
+	}
+	if code == 0 {
+		t.Errorf("a failing read exited 0 with stdout %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), failure.Error()) {
+		t.Errorf("the failure does not carry the store's cause: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "no issue found") {
+		t.Errorf("a failing read was reported as an absent bead: %q", stderr.String())
+	}
+}
+
+// failClassBindingReads replaces this city's resolved class store with one whose
+// every read fails, so a test can assert what the surface does with a store that
+// cannot answer rather than one that answers emptily.
+func failClassBindingReads(t *testing.T, cityPath string, cause error) {
+	t.Helper()
+	routes := cliStorageRoutes(cityPath)
+	if routes == nil {
+		t.Fatal("the city resolved no routes to fail")
+	}
+	store := refusedClassStore{err: cause}
+	restore := make(map[coordclass.Class]beads.Store, len(routes.stores))
+	for class, previous := range routes.stores {
+		restore[class] = previous
+		routes.stores[class] = store
+	}
+	t.Cleanup(func() {
+		for class, previous := range restore {
+			routes.stores[class] = previous
+		}
+	})
+}
+
+// TestBdByIDLeavesAnUnrelocatedCityAlone is the compatibility claim: a city that
+// authors no [storage] section routes nothing here, so every `gc bd` invocation
+// takes the path it takes today.
+func TestBdByIDLeavesAnUnrelocatedCityAlone(t *testing.T) {
+	cityPath := oneShotCLICity(t, "")
+	refuseInfraMigrationSource(t)
+	captureCLIStorageStderr(t)
+
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, []string{"show", reservedClassID(t, "anything")}, &stdout, &stderr); handled {
+		t.Fatalf("an unrelocated city routed a by-id read here (exit %d): %s%s", code, stdout.String(), stderr.String())
+	}
+}
+
+// TestBdByIDSurfaceNeverSpawnsAProcess is the property the whole surface exists
+// for, asserted where it cannot rot: the file that answers a by-ID read imports
+// nothing that can start one. The reported symptom was a `gc bd show` that never
+// returned because the subprocess blocked on a work backend, so a routed read
+// that reached for a subprocess would reintroduce it exactly.
+func TestBdByIDSurfaceNeverSpawnsAProcess(t *testing.T) {
+	const file = "cmd_bd_by_id.go"
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	for _, spec := range parsed.Imports {
+		path := strings.Trim(spec.Path.Value, `"`)
+		if path == "os/exec" || strings.HasPrefix(path, "os/exec/") {
+			t.Errorf("%s imports %q; a routed by-ID read must never spawn a process", file, path)
+		}
+	}
+}
+
+// TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation pins the shape of
+// the resolution rather than its result: the surface asks the one-shot storage
+// funnel where this city's classes are served from, exactly once per command,
+// and never re-derives a destination of its own.
+//
+// The migration's target resolver is the one it must not use. That function
+// answers "is this a binding this build can migrate onto", which is true only of
+// the built-in engine — asking it is what made every other provider fall through
+// — and it resolves a SQLite path this surface has no business opening.
+func TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation(t *testing.T) {
+	const file = "cmd_bd_by_id.go"
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	counts := map[string]int{}
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok {
+			counts[ident.Name]++
+		}
+		return true
+	})
+	for _, forbidden := range []string{
+		"resolveInfraBindingTarget",
+		"openInfraDestination",
+		"openStoreAtForCity",
+		"openStoreAtForCityWithConfig",
+		"beads.OpenSQLiteStore",
+	} {
+		if counts[forbidden] != 0 {
+			t.Errorf("%s calls %s %d time(s); the by-ID surface must resolve its store through the storage funnel alone", file, forbidden, counts[forbidden])
+		}
+	}
+	if counts["cliStorageRoutes"] != 1 {
+		t.Errorf("%s calls cliStorageRoutes %d time(s), want exactly 1: one store resolution per command", file, counts["cliStorageRoutes"])
+	}
+	if counts["graphClassBinding"] != 1 {
+		t.Errorf("%s calls graphClassBinding %d time(s), want exactly 1", file, counts["graphClassBinding"])
+	}
+}
+
+// TestBdByIDSurfaceServesAClosedVerbSet pins what this surface answers. Growing
+// it silently is how a partial imitation of bd ships: a verb parsed here but
+// only half implemented answers a different question than the one asked.
+func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
+	served := map[bdByIDVerb]bool{
+		bdByIDShow:    true,
+		bdByIDClaim:   true,
+		bdByIDRelease: true,
+		bdByIDDepList: true,
+	}
+	for _, args := range [][]string{
+		{"show", "gcg-1"},
+		{"update", "gcg-1", "--claim"},
+		{"release-if-current", "gcg-1", "someone"},
+		{"dep", "list", "gcg-1"},
+	} {
+		op, ok := parseBdByIDOp(args)
+		if !ok {
+			t.Fatalf("%v is not recognized by the by-ID parser", args)
+		}
+		if !served[op.Verb] {
+			t.Errorf("%v parsed to unserved verb %q", args, op.Verb)
+		}
+	}
+	for _, args := range [][]string{
+		{"show"},
+		{"show", "gcg-1", "gcg-2"},
+		{"show", "gcg-1", "--unknown"},
+		{"update", "gcg-1"},
+		{"dep", "tree", "gcg-1"},
+		{"dep", "list"},
+		{"dep", "list", "gcg-1", "--direction=sideways"},
+		{"close", "gcg-1"},
+		{"list"},
+	} {
+		if op, ok := parseBdByIDOp(args); ok {
+			t.Errorf("%v was recognized as %q, want the caller's existing path", args, op.Verb)
+		}
+	}
+}
+
+// reservedClassID builds an id in the reserved class namespace, so a test can
+// name a bead only a class store could own without minting one.
+func reservedClassID(t *testing.T, suffix string) string {
+	t.Helper()
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok || prefix == "" {
+		t.Fatalf("no reserved id prefix is registered for the %q class", config.BeadClassGraph)
+	}
+	return prefix + "-" + suffix
+}

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -271,6 +271,131 @@ func TestBdByIDReservedPrefixAbsenceIsNotAFallThrough(t *testing.T) {
 	}
 }
 
+// TestBdByIDRoutesAWorkShapedIDResidentInTheClassBinding pins the residence
+// probe, which is the arm that has no reserved prefix to lean on.
+//
+// `gc storage migrate` copies the work store's infrastructure slice with its ids
+// PRESERVED, so a converged city holds work-SHAPED ids inside the class binding.
+// Deciding ownership by prefix alone would send exactly those reads back to the
+// ledger they were moved off — and they are the beads a migrated city has the
+// most of, because every one of them predates the split.
+func TestBdByIDRoutesAWorkShapedIDResidentInTheClassBinding(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	migrated := beads.Bead{ID: "demo-premigration", Title: "carried across by the migration", Type: "task", Description: "work-shaped id, class-resident row"}
+	created, err := classStore.Create(migrated)
+	if err != nil {
+		t.Fatalf("seeding a work-shaped id in the class binding: %v", err)
+	}
+	if bdIDIsClassReserved(created.ID) {
+		t.Fatalf("the fixture id %q carries a reserved class prefix; it cannot exercise the residence probe", created.ID)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"show", created.ID, "--json"}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident work-shaped id fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("showing %s exited %d: %s", created.ID, code, stderr.String())
+	}
+	var shown []beads.Bead
+	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
+		t.Fatalf("decoding %q: %v", stdout.String(), err)
+	}
+	if len(shown) != 1 || shown[0].ID != created.ID {
+		t.Fatalf("the routed show printed %+v, want %s from the class binding", shown, created.ID)
+	}
+}
+
+// TestBdByIDServesTheStepCompletionWrite is the core-pack write:
+// graph-worker.md closes a worked bead with
+// `gc bd update <id> --set-metadata gc.outcome=pass --status closed`, and on a
+// split city that bead is class-owned. The passthrough wrote the outcome into
+// the work ledger and left the bead open in the binding — a molecule that stalls
+// with no error anywhere.
+func TestBdByIDServesTheStepCompletionWrite(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	step := mustCreateClassBead(t, classStore, beads.Bead{Title: "the step", Type: "task"})
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"update", step.ID, "--set-metadata", "gc.outcome=pass", "--status", "closed"}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("the step-completion write fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("the step-completion write exited %d: %s", code, stderr.String())
+	}
+	after, err := classStore.Get(step.ID)
+	if err != nil {
+		t.Fatalf("re-reading the closed step: %v", err)
+	}
+	if after.Status != "closed" {
+		t.Errorf("status = %q, want closed", after.Status)
+	}
+	if after.Metadata["gc.outcome"] != "pass" {
+		t.Errorf("gc.outcome = %q, want pass (metadata=%v)", after.Metadata["gc.outcome"], after.Metadata)
+	}
+
+	// The `--status=closed` spelling the formula uses must land identically.
+	other := mustCreateClassBead(t, classStore, beads.Bead{Title: "the other step", Type: "task"})
+	stdout.Reset()
+	stderr.Reset()
+	if code, handled := maybeRouteBdByID(cityPath, []string{"update", other.ID, "--set-metadata", "gc.outcome=fail", "--set-metadata", "gc.failure_class=transient", "--status=closed"}, &stdout, &stderr); !handled || code != 0 {
+		t.Fatalf("the inline-equals spelling = (%d, %t): %s", code, handled, stderr.String())
+	}
+	afterOther, err := classStore.Get(other.ID)
+	if err != nil {
+		t.Fatalf("re-reading: %v", err)
+	}
+	if afterOther.Status != "closed" || afterOther.Metadata["gc.failure_class"] != "transient" {
+		t.Errorf("status=%q metadata=%v, want closed with both metadata keys", afterOther.Status, afterOther.Metadata)
+	}
+}
+
+// TestBdByIDShowRendersTheWholeRecord is the second-order wrong answer.
+//
+// graph-worker.md tells an agent to `gc bd show <id>` and then "execute exactly
+// that bead's description". A terse id/status/title line is a well-formed
+// answer with the instruction silently missing — the agent reads it, finds
+// nothing to do, and reports success. The routed text form therefore renders the
+// whole record, and says where it came from.
+func TestBdByIDShowRendersTheWholeRecord(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	priority := 1
+	bead := mustCreateClassBead(t, classStore, beads.Bead{
+		Title:       "do the thing",
+		Type:        "task",
+		Priority:    &priority,
+		Assignee:    "worker-1",
+		Description: "Line one of the instruction.\nLine two.",
+		Labels:      []string{"gc:step"},
+		Metadata:    beads.StringMap{"gc.outcome": "pending"},
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, []string{"show", bead.ID}, &stdout, &stderr); !handled || code != 0 {
+		t.Fatalf("showing %s = (%d, %t): %s", bead.ID, code, handled, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		bead.ID,
+		"do the thing",
+		"Line one of the instruction.",
+		"Line two.",
+		"gc.outcome=pending",
+		"gc:step",
+		"worker-1",
+		"description:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the routed record omits %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(stderr.String(), "served in process") {
+		t.Errorf("the routed record does not say where it came from: %q", stderr.String())
+	}
+}
+
 // TestBdByIDLeavesWorkStoreIDsToThePassthrough is the other half of the same
 // rule. An ordinary work id the class store has never seen is still bd's to
 // answer, and the passthrough answers it byte-identically.
@@ -488,11 +613,25 @@ func TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation(t *testing.T) {
 		if !ok {
 			return true
 		}
-		if ident, ok := call.Fun.(*ast.Ident); ok {
-			counts[ident.Name]++
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			counts[fn.Name]++
+		case *ast.SelectorExpr:
+			// pkg.Fn — without this arm every qualified entry in the forbidden
+			// list below counted zero no matter what the file did, which made
+			// the assertion about beads.OpenSQLiteStore vacuous.
+			if pkg, ok := fn.X.(*ast.Ident); ok {
+				counts[pkg.Name+"."+fn.Sel.Name]++
+			}
+			counts[fn.Sel.Name]++
 		}
 		return true
 	})
+	// The scanner must be able to see a qualified call at all, or the forbidden
+	// list is a list of names nothing could ever match.
+	if counts["storebinding.NewBeadsGraphStore"] == 0 {
+		t.Fatal("the call scanner records no qualified calls; the forbidden list below cannot fail")
+	}
 	for _, forbidden := range []string{
 		"resolveInfraBindingTarget",
 		"openInfraDestination",
@@ -512,6 +651,62 @@ func TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation(t *testing.T) {
 	}
 }
 
+// TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead pins the
+// cost gate, as a NEGATIVE about work that must not happen.
+//
+// Resolving the funnel loads the city config, resolves a storage plan, opens a
+// binding, and on a born-split city re-proves the invariant with a full,
+// unpaginated work-store census.
+//
+// The line this draws is servability, and it is drawn where correctness allows
+// it rather than where it would be cheapest:
+//
+//   - An UNSERVED verb enters only when the argv addresses a reserved-prefix
+//     id. `gc bd close gc-123` and `gc bd delete gc-123` are pure work
+//     invocations — this surface would refuse them or nothing — so they pay
+//     nothing and keep the exact-ID collision guard doBd already applies.
+//   - A SERVED verb always enters, including on a work-shaped id, because the
+//     residence probe is the only thing that finds a migrated row: `gc storage
+//     migrate` preserves ids, so a work-shaped id can be class-resident, and a
+//     WRITE that skipped the probe would close the retained copy and leave the
+//     binding's row open — the molecule stall this surface exists to remove.
+//
+// The observer is the registry constructor, because "the routes came back nil"
+// would still pass if the funnel had resolved a plan and thrown it away.
+func TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	reserved := reservedClassID(t, "addressed")
+
+	for name, tc := range map[string]struct {
+		args  []string
+		enter bool
+	}{
+		"unserved work close":       {[]string{"close", "gc-123"}, false},
+		"unserved work delete":      {[]string{"delete", "gc-123"}, false},
+		"unserved work reopen":      {[]string{"reopen", "gc-123"}, false},
+		"unserved update spelling":  {[]string{"update", "gc-123", "--notes", "x"}, false},
+		"work list":                 {[]string{"list", "--status", "open"}, false},
+		"work dep tree":             {[]string{"dep", "tree", "gc-123"}, false},
+		"quoted id in a value":      {[]string{"list", "--metadata-field", "workflow_id=" + reserved}, false},
+		"class mutation":            {[]string{"update", reserved, "--status", "closed"}, true},
+		"class close":               {[]string{"close", reserved}, true},
+		"class id in an id flag":    {[]string{"list", "--parent", reserved}, true},
+		"served read on a work id":  {[]string{"show", "gc-123"}, true},
+		"served write on a work id": {[]string{"update", "gc-123", "--status", "closed"}, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetCLIStorageRoutes(t)
+			registries := countStorageRegistryConstructions(t)
+			var stdout, stderr bytes.Buffer
+			maybeRouteBdByID(cityPath, tc.args, &stdout, &stderr)
+			entered := *registries > 0
+			if entered != tc.enter {
+				t.Errorf("%v entered the storage funnel = %t, want %t", tc.args, entered, tc.enter)
+			}
+		})
+	}
+}
+
 // TestBdByIDSurfaceServesAClosedVerbSet pins what this surface answers. Growing
 // it silently is how a partial imitation of bd ships: a verb parsed here but
 // only half implemented answers a different question than the one asked.
@@ -521,12 +716,17 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		bdByIDClaim:   true,
 		bdByIDRelease: true,
 		bdByIDDepList: true,
+		bdByIDUpdate:  true,
 	}
 	for _, args := range [][]string{
 		{"show", "gcg-1"},
 		{"update", "gcg-1", "--claim"},
 		{"release-if-current", "gcg-1", "someone"},
 		{"dep", "list", "gcg-1"},
+		{"dep", "list", "gcg-1", "-t", "blocks"},
+		{"dep", "list", "gcg-1", "--direction=up"},
+		{"update", "gcg-1", "--status", "closed"},
+		{"update", "gcg-1", "--set-metadata", "gc.outcome=pass", "--status=closed"},
 	} {
 		op, ok := parseBdByIDOp(args)
 		if !ok {
@@ -540,7 +740,10 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		{"show"},
 		{"show", "gcg-1", "gcg-2"},
 		{"show", "gcg-1", "--unknown"},
+		{"show", "gcg-1", "--long"},
+		{"show", "--id", "gcg-1"},
 		{"update", "gcg-1"},
+		{"update", "gcg-1", "--notes", "hello"},
 		{"dep", "tree", "gcg-1"},
 		{"dep", "list"},
 		{"dep", "list", "gcg-1", "--direction=sideways"},
@@ -550,6 +753,119 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		if op, ok := parseBdByIDOp(args); ok {
 			t.Errorf("%v was recognized as %q, want the caller's existing path", args, op.Verb)
 		}
+	}
+}
+
+// TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead is the flagged-spelling
+// fallthrough, which is the hole the closed verb set opens if ownership is
+// decided by "can this be served".
+//
+// Each of these is a real bd spelling from the tree's own manifest
+// (internal/bdflags) that the served parsers reject. While a rejection meant
+// fall-through, every one of them ran against the work ledger — so the flags an
+// operator reaches for when the terse answer is not enough were exactly the ones
+// that answered about the wrong workspace.
+//
+// The `--metadata-field` row is the boundary: an id quoted in a filter VALUE is
+// a work question and must still reach bd, or the consumer that asks it
+// exec-fails on every tick.
+func TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "addressed", Type: "task"})
+	quoted := reservedClassID(t, "quoted")
+
+	refused := [][]string{
+		{"show", bead.ID, "--long"},
+		{"show", bead.ID, "--short"},
+		{"show", bead.ID, "--children"},
+		{"show", bead.ID, "--refs"},
+		{"show", bead.ID, "--thread"},
+		{"show", bead.ID, "--include-comments"},
+		{"show", bead.ID, "--include-dependents"},
+		{"show", bead.ID, "--as-of", "2026-01-01"},
+		{"show", "--id", bead.ID},
+		{"dep", "tree", bead.ID},
+		{"close", bead.ID},
+		{"delete", bead.ID},
+		{"update", bead.ID, "--notes", "a note"},
+		{"--json", "close", bead.ID},
+		{"list", "--parent", bead.ID},
+	}
+	for _, args := range refused {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr)
+			if !handled {
+				t.Fatalf("%v fell through to the bd subprocess", args)
+			}
+			if code == 0 {
+				t.Errorf("%v exited 0; stdout=%q", args, stdout.String())
+			}
+			if !strings.Contains(stderr.String(), bead.ID) {
+				t.Errorf("the refusal does not name the bead: %q", stderr.String())
+			}
+		})
+	}
+
+	// dep list's own selectors are SERVED rather than refused — all three
+	// spellings bd accepts, including the short `-t`.
+	for _, args := range [][]string{
+		{"dep", "list", bead.ID, "-t", "blocks"},
+		{"dep", "list", bead.ID, "--type", "blocks"},
+		{"dep", "list", bead.ID, "--direction", "up"},
+		{"dep", "list", bead.ID, "-t=blocks"},
+	} {
+		t.Run("served "+strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr)
+			if !handled {
+				t.Fatalf("%v fell through to the bd subprocess", args)
+			}
+			if code != 0 {
+				t.Errorf("%v exited %d: %s", args, code, stderr.String())
+			}
+		})
+	}
+
+	for _, args := range [][]string{
+		{"list", "--metadata-field", "workflow_id=" + quoted},
+		{"list", "--label", quoted},
+		{"list", "--metadata-field=workflow_id=" + quoted},
+	} {
+		t.Run("passthrough "+strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr); handled {
+				t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+// TestBdByIDRefusalNamesTheUnrepresentableFlag pins the actionable half of the
+// update refusal. `--notes` has no representation in the object model — there is
+// no notes field on beads.Bead and no notes write on beads.UpdateOpts — so the
+// step-completion write the core pack makes cannot be served faithfully, and an
+// operator has to be told WHICH flag stopped it rather than that `gc bd update`
+// is "not served", which is false in general.
+func TestBdByIDRefusalNamesTheUnrepresentableFlag(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "step", Type: "task"})
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, []string{"update", bead.ID, "--set-metadata", "gc.outcome=pass", "--status=closed", "--notes", "done"}, &stdout, &stderr)
+	if !handled || code == 0 {
+		t.Fatalf("the unrepresentable update was not refused: (%d, %t) %s", code, handled, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), bdByIDUpdateUnrepresentable) {
+		t.Errorf("the refusal does not name %s: %q", bdByIDUpdateUnrepresentable, stderr.String())
+	}
+	// Refused means refused: nothing may have been written.
+	after, err := classStore.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("re-reading the refused bead: %v", err)
+	}
+	if after.Status == "closed" || len(after.Metadata) != 0 {
+		t.Errorf("the refused update wrote anyway: status=%q metadata=%v", after.Status, after.Metadata)
 	}
 }
 

--- a/internal/beads/bdsql_relocation.go
+++ b/internal/beads/bdsql_relocation.go
@@ -246,9 +246,9 @@ func isIDBodyByte(b byte) bool {
 // `gc bd show <id>` and `gc bd dep list <id>` are now answered in process from
 // the binding the class is served from (cmd/gc/cmd_bd_by_id.go), so they are
 // the read this message names first — they need no controller, which the API
-// lane does. `gc bd dep tree <id>` reached no such routing and is still a raw
-// passthrough (doBd ends at exec.Command(bdPath, bdArgs...)), so it is still
-// named as blind rather than offered as an escape.
+// lane does. `gc bd dep tree <id>` is not served there, and on a relocated id
+// that surface refuses it rather than forwarding it, so it is named as
+// unavailable rather than offered as an escape.
 func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 	if len(matched) == 0 {
 		return nil
@@ -271,6 +271,6 @@ func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 		"`gc bd show <id>`, which answers a reserved-prefix id in process from the binding its class is served from "+
 		"and needs no controller, or with `gc beads show <id>`, which routes by class through the controller API "+
 		"(GET /v0/city/{cityName}/bead/{id}) and falls back to a work-store scan when no controller is reachable. "+
-		"`gc bd dep tree <id>` is still a raw bd passthrough against this same ledger",
+		"`gc bd dep tree <id>` is not served in process; on a relocated id it is refused rather than answered from this ledger",
 		ErrBdSQLClassRelocated, op, strings.Join(parts, "; "))
 }

--- a/internal/beads/bdsql_relocation.go
+++ b/internal/beads/bdsql_relocation.go
@@ -239,10 +239,16 @@ func isIDBodyByte(b byte) bool {
 // would have returned nothing — that is false for a statement that references a
 // relocated id from a column this ledger does own — only that no row under the
 // reserved prefix is here, so an id-scoped predicate naming one cannot match.
-// And it does not name `gc bd show` / `gc bd dep tree`: those are raw bd
-// passthroughs (doBd ends at exec.Command(bdPath, bdArgs...)) and answer from
-// this same ledger, so recommending them handed the operator the very bug this
-// refusal exists to report.
+// And it does not recommend a verb that answers from this same ledger: doing so
+// handed the operator the very bug this refusal exists to report.
+//
+// Which verbs those are is a fact about gc's by-ID routing and changed once.
+// `gc bd show <id>` and `gc bd dep list <id>` are now answered in process from
+// the binding the class is served from (cmd/gc/cmd_bd_by_id.go), so they are
+// the read this message names first — they need no controller, which the API
+// lane does. `gc bd dep tree <id>` reached no such routing and is still a raw
+// passthrough (doBd ends at exec.Command(bdPath, bdArgs...)), so it is still
+// named as blind rather than offered as an escape.
 func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 	if len(matched) == 0 {
 		return nil
@@ -262,9 +268,9 @@ func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 	return fmt.Errorf("%w: %s: %s. This bd ledger does not serve those classes and holds no row under their reserved id "+
 		"prefixes, so a read scoped to one cannot match here — and bd does not fail: it runs the read successfully "+
 		"against this ledger and returns an empty result indistinguishable from a real one. Read these beads with "+
-		"`gc beads show <id>`, which routes by class through the controller API (GET /v0/city/{cityName}/bead/{id}). "+
-		"That API lane is the only class-routed by-id read there is: `gc beads show` falls back to a work-store scan "+
-		"when no controller is reachable, and `gc bd show` and `gc bd dep tree` are raw bd passthroughs against this "+
-		"same ledger",
+		"`gc bd show <id>`, which answers a reserved-prefix id in process from the binding its class is served from "+
+		"and needs no controller, or with `gc beads show <id>`, which routes by class through the controller API "+
+		"(GET /v0/city/{cityName}/bead/{id}) and falls back to a work-store scan when no controller is reachable. "+
+		"`gc bd dep tree <id>` is still a raw bd passthrough against this same ledger",
 		ErrBdSQLClassRelocated, op, strings.Join(parts, "; "))
 }

--- a/internal/beads/bdsql_relocation_internal_test.go
+++ b/internal/beads/bdsql_relocation_internal_test.go
@@ -45,18 +45,27 @@ func TestRelocatedClassRefusalNamesEverythingAnOperatorNeeds(t *testing.T) {
 }
 
 // TestRelocatedClassRefusalDoesNotRecommendABlindVerb pins the correction that
-// mattered most: `gc bd show` and `gc bd dep tree` are raw bd passthroughs
-// (cmd/gc/cmd_bd.go ends at exec.Command(bdPath, bdArgs...) with no class
-// routing), so recommending them sent the operator to a command carrying the
-// exact bug this refusal warns about. The message must name them as blind
-// rather than as the escape hatch.
+// mattered most: a verb this message names as the way out must not answer from
+// the same ledger the message just said cannot hold the rows. Recommending one
+// sent the operator to a command carrying the exact bug this refusal warns
+// about.
+//
+// The set of blind verbs shrank once. `gc bd show` and `gc bd dep list` acquired
+// in-process class routing (cmd/gc/cmd_bd_by_id.go) and are now the read this
+// message names first. `gc bd dep tree` did not, so it is the one that must
+// still be named as blind — and the pin moved with the fact rather than being
+// deleted, because a message that stops warning about a verb that is still
+// blind is the original defect returning.
 func TestRelocatedClassRefusalDoesNotRecommendABlindVerb(t *testing.T) {
 	msg := RelocatedClassRefusal("bd sql", []RelocatedClass{graphRelocated()}).Error()
 	if strings.Contains(msg, "Use the federated `gc bd") {
 		t.Errorf("refusal still recommends a raw bd passthrough as federated:\n%s", msg)
 	}
-	if !strings.Contains(msg, "`gc bd show` and `gc bd dep tree` are raw bd passthroughs") {
-		t.Errorf("refusal does not warn that the bd read verbs answer from this same ledger:\n%s", msg)
+	if !strings.Contains(msg, "`gc bd dep tree <id>` is still a raw bd passthrough") {
+		t.Errorf("refusal does not warn that dep tree answers from this same ledger:\n%s", msg)
+	}
+	if !strings.Contains(msg, "`gc bd show <id>`") {
+		t.Errorf("refusal does not name the by-ID read that IS class-routed:\n%s", msg)
 	}
 }
 

--- a/internal/beads/bdsql_relocation_internal_test.go
+++ b/internal/beads/bdsql_relocation_internal_test.go
@@ -52,17 +52,17 @@ func TestRelocatedClassRefusalNamesEverythingAnOperatorNeeds(t *testing.T) {
 //
 // The set of blind verbs shrank once. `gc bd show` and `gc bd dep list` acquired
 // in-process class routing (cmd/gc/cmd_bd_by_id.go) and are now the read this
-// message names first. `gc bd dep tree` did not, so it is the one that must
-// still be named as blind — and the pin moved with the fact rather than being
-// deleted, because a message that stops warning about a verb that is still
-// blind is the original defect returning.
+// message names first. `gc bd dep tree` did not acquire routing, but it is no
+// longer blind either: on a relocated id that surface refuses it. The pin moved
+// with the fact rather than being deleted, because a message that offered a
+// verb which cannot answer would be the original defect returning.
 func TestRelocatedClassRefusalDoesNotRecommendABlindVerb(t *testing.T) {
 	msg := RelocatedClassRefusal("bd sql", []RelocatedClass{graphRelocated()}).Error()
 	if strings.Contains(msg, "Use the federated `gc bd") {
 		t.Errorf("refusal still recommends a raw bd passthrough as federated:\n%s", msg)
 	}
-	if !strings.Contains(msg, "`gc bd dep tree <id>` is still a raw bd passthrough") {
-		t.Errorf("refusal does not warn that dep tree answers from this same ledger:\n%s", msg)
+	if !strings.Contains(msg, "`gc bd dep tree <id>` is not served in process") {
+		t.Errorf("refusal does not say dep tree is unavailable on a relocated id:\n%s", msg)
 	}
 	if !strings.Contains(msg, "`gc bd show <id>`") {
 		t.Errorf("refusal does not name the by-ID read that IS class-routed:\n%s", msg)

--- a/internal/storebinding/beads_adapter.go
+++ b/internal/storebinding/beads_adapter.go
@@ -57,7 +57,10 @@ func NewBeadsAdapters(store beads.Store, identity BeadsAdapterIdentity, queue ..
 	if len(queue) > 1 {
 		return BeadsAdapters{}, errors.New("adapting canonical beads store: at most one nudge queue is allowed")
 	}
-	graph := &beadsGraphAdapter{store: store}
+	graph, err := NewBeadsGraphStore(store)
+	if err != nil {
+		return BeadsAdapters{}, err
+	}
 	queueFront := NudgeQueue(nil)
 	if len(queue) > 0 {
 		queueFront = queue[0]
@@ -86,6 +89,27 @@ func NewBeadsAdapters(store beads.Store, identity BeadsAdapterIdentity, queue ..
 			Shadows: nudgequeue.NewStore(beads.NudgesStore{Store: store}),
 		},
 	}, nil
+}
+
+// NewBeadsGraphStore projects an already-opened Beads store into the closed
+// graph class front door, and nothing else.
+//
+// It is the single-class half of NewBeadsAdapters, for a caller that holds one
+// resolved class store and has no Work topology to pin: a one-shot CLI command
+// answering a by-ID read from the binding its city serves that class from.
+//
+// It takes no identity, and the omission is the point rather than a relaxation.
+// BeadsAdapterIdentity exists so WorkTopology can deduplicate shared handles
+// across the workspaces an aggregate carries; the graph adapter itself holds
+// none and reads none. Demanding one from a caller with no workspace to
+// deduplicate would force it to invent three strings to satisfy a check —
+// and an invented physical identity is worse than no identity, because it
+// compares equal to nothing and unequal to nothing in particular.
+func NewBeadsGraphStore(store beads.Store) (GraphStore, error) {
+	if nilInterface(store) {
+		return nil, errors.New("adapting canonical beads store: store is required")
+	}
+	return &beadsGraphAdapter{store: store}, nil
 }
 
 // BindBeadsMessaging captures one already-open Beads-backed Messaging


### PR DESCRIPTION
## Problem

`gc bd` has no coordination-class routing. `doBd` resolves a WORK scope and ends
at `exec.Command(bdPath, bdArgs...)`, and its one in-process arm —
`release-if-current` — opens only that work scope.

So on a city whose classes are served from a non-work `[storage]` binding, every
by-ID operation on a bead that lives in that binding is answered by the wrong
ledger:

| invocation | before |
| --- | --- |
| `gc bd show <gcg-id>` | bd subprocess against the work workspace |
| `gc bd dep list <gcg-id>` | bd subprocess against the work workspace |
| `gc bd update <gcg-id> --claim` | bd subprocess against the work workspace |
| `gc bd release-if-current <gcg-id> <who>` | in process, against the **work** store |

The subprocess does not fail. On a managed-Dolt city it is a connect attempt
that can block for the whole command; otherwise it runs successfully against a
ledger that holds no row under the reserved prefix and returns an empty result
indistinguishable from a real one. That is the same wrong-answer lane #5125
closed for `bd sql`/`bd query`, on the verbs #5125 deliberately left alone.

## Fix

An id whose owning class is the relocated binding is answered in process,
through that class's closed front door (`cmd/gc/cmd_bd_by_id.go`), and the
subprocess is never spawned. `show`, `update` (fields and metadata, including
`--claim`), `release-if-current` and `dep list` are served; anything else whose
subject the class binding owns is refused before the subprocess rather than run
against a store that cannot see the bead.

**Ownership is decided from the argv, not from servability.** The served parsers
reject every flag they do not implement, so gating on "can this be served" leaked
exactly the invocations an operator reaches for when the terse answer is not
enough — `show --long/--short/--children/--refs/--thread/--include-comments/
--include-dependents/--as-of/--id` and `dep list -t`, all named in the tree's own
`internal/bdflags` manifest. `bdArgsNameClassOwnedBead` decides ownership by
walking the argv with each subcommand's own flag manifest and knows nothing about
what this surface implements.

### Where the store comes from, and why not from the migration

The store is resolved through **`cliStorageRoutes`** — the one-shot funnel that
takes the same verdict the controller takes at boot and opens the binding
through the planned provider's own `EngineOpener`. So it routes for the built-in
SQLite engine, for a beads workspace (postgres infra), and for any provider a
fork registers, with no per-provider code.

It deliberately does **not** use `resolveInfraBindingTarget`, which looks like
the right function and is not. That resolver answers *"is this a binding this
build can MIGRATE onto"*, which is true only of `sqlite-beads` — it returns
`ok=false` for a beads workspace and for every provider added after it. A by-ID
surface gated on that answer routes correctly for one provider and falls through
to the subprocess for all the others, i.e. the wrong-answer lane reappearing on
exactly the cities that moved furthest from the default.

`resolveInfraBindingTarget` is therefore **left unchanged**. Its provider gate is
correct for the migration/genesis discipline it serves, and `storage_boot.go`'s
born-split arm depends on it answering no — making it provider-agnostic would
route born-split cities into the convergence machinery instead. The question a
*read* has is not "can I migrate this", it is "where is this class served from",
and only the funnel answers that.

### Failure semantics

- A read failure is an **error, never absence**.
- A reserved-prefix id (`gcg-`) is minted by the class store and nowhere else, so
  its absence there is genuine and is reported in bd's own shape — never
  flattened into a fall-through that would print a work-store answer.
- A non-reserved id gets a residence probe, because `gc storage migrate` copies
  the work store's infrastructure slice with ids **preserved**: a converged city
  holds work-shaped ids in its binding, and prefix-only ownership would send
  those reads back to the ledger they were moved off.
- Ownership is read from an id in an **ID position** — a positional token, or the
  value of a flag that names a bead — never from an id-shaped value:
  `gc bd list --metadata-field workflow_id=gcg-…` stays a work question, while
  `--parent gcg-…` does not. An unresolvable subcommand or an unknown flag widens
  the scan rather than ending it, the same fail-closed choice
  `bdRelocatedClassVerb` makes.
- Flags with no representation in the object model are refused **by name**, never
  dropped. See the update contract below.

### The one error that is not a fault

The funnel's standing refusal is now distinguishable (`standingStorageRefusal`).
It says *this city's storage cannot be served* — a fact about the city and about
no particular bead — and a refused city still serves work from its work ledger.

A work id therefore keeps its existing path while an id only the class binding
could own is refused. **Without that distinction a storage misconfiguration took
every `gc bd` write on the city offline, work included** — a regression the first
draft of this surface introduced and `TestGcBdOnARefusedCitySeparatesWorkFromClassOwnedIDs`
now pins from both sides.

## The step-completion write

`graph-worker.md` closes every worked bead with
`gc bd update <id> --set-metadata gc.outcome=pass --status closed`, and
`mol-do-work.toml` closes the formula step the same way. On a split city that bead
is class-owned, so the passthrough wrote the outcome into the **work** ledger and
left the step open in the binding — a molecule that stalls with nothing in any log.

`update` is now served through the closed contract as **one** `Update` call
carrying status, metadata, labels, assignee, title, type, priority, parent and
description. One call because splitting it would let a crash between the status
write and the metadata write leave a bead closed with no outcome, which its reader
cannot tell from a bead that failed to record one.

**`--notes` is refused, by name.** `beads.Bead` has no notes field and
`beads.UpdateOpts` has no notes write — notes are outside gc's object model
entirely, and `gc bd update --notes` works on an unrelocated city only because gc
hands the whole command to bd. There is no faithful in-process spelling, and a
partial write reported as success is the failure this surface exists to remove. So:

| core-pack site | outcome |
| --- | --- |
| `graph-worker.md:32,36,44` (`--set-metadata … --status closed`) | **served** |
| `mol-do-work.toml:95,123` (same, plus `--notes`) | **refused, naming `--notes`** |

That is a strict improvement on today (a silent write to the wrong ledger), but it
does not unblock those two lines. Disclosed below.

## The terse `show`

`graph-worker.md` tells an agent to `gc bd show <id>` and then "execute exactly
that bead's description". The routed text form was an id/status/title line — a
well-formed record with the instruction silently absent, the same harm class one
layer in. It renders the whole record now (description last and never elided, plus
metadata, labels, dependencies, assignee, priority, parent, ref) and names the
serving binding on stderr. `--json` already carried the whole record.

## Hot-path cost, and the residual trigger set

Entering the funnel resolves a storage plan, opens a binding, and on a born-split
city re-proves the invariant with a full, unpaginated work-store census — once per
process, memoized with every other one-shot command's routing.

The gate now enters only when the invocation is a **served by-ID form** or the argv
**addresses a reserved-prefix id**. `gc bd close gc-123` / `delete` / `reopen` and
every `gc bd list` over work pay nothing and keep the exact-ID collision guard
`doBd` already applies.

**Residual, disclosed:** a *served* verb still enters on a work-shaped id —
`gc bd show gc-123`, `gc bd update gc-123 --status closed`, and the rewritten
`gc bd heartbeat` (`update <id> --set-metadata …`). That is deliberate: `gc storage
migrate` preserves ids, so a work-shaped id can be class-resident, and a write that
skipped the residence probe would close the retained copy while the binding's row
stayed open. On a city with no `[storage]` this costs one config load and one
served-binding-note read (the gate bypasses before the registry). On a split city
it costs the plan resolve + census that `gc mail`, `gc nudge`, `gc sling` and
`gc prime` already pay per invocation through the same funnel — `gc bd` joins that
regime rather than inventing a new one. No read-only seam exists to skip the
born-split re-proof, and adding one would mean serving a city the boot gate
refuses; narrowing it is a change to `cliStorageRoutes` for all its callers, not to
this surface.

`TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead` pins the
whole table, observing registry construction rather than the returned routes.

## Consequential changes

- **`refusedClassStore` gains `Claim`/`ReleaseIfCurrent`.** The front door
  discovers them by type assertion, and a refusing store that lacked them
  answered *"this store cannot claim"* — a statement about a capability — where
  the truth is that the city must not be served at all. This is the reason the
  whole optional set on that type already exists.
- **`storebinding.NewBeadsGraphStore`** projects one opened store into the graph
  front door without an adapter identity. `beadsGraphAdapter` holds and reads
  none; `BeadsAdapterIdentity` exists so `WorkTopology` can deduplicate shared
  handles, which a one-shot CLI has nothing to do with. Forcing a caller to
  invent three strings to satisfy that check would be worse than omitting it —
  an invented physical identity compares equal to nothing in particular.
  `NewBeadsAdapters` now builds its graph field through it, so there is one
  construction site.
- **The relocated-class refusal message changed**, because it asserted something
  this PR makes false: it named `gc bd show` as a raw passthrough. It now names
  `gc bd show <id>` as the class-routed read that needs no controller (`gc beads
  show` routes only through the controller API and falls back to a work-store
  scan without one), and keeps warning about `gc bd dep tree`, which **is** still
  a passthrough. The pin moved with the fact rather than being deleted.

## Review note: the no-router test accounting

The pinning tests assert the *shape* of the resolution, not just its result:

- `TestBdByIDSurfaceNeverSpawnsAProcess` — the file imports nothing from
  `os/exec`.
- `TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation` — exactly **one**
  `cliStorageRoutes` call and **one** `graphClassBinding` call, and **zero**
  calls to `resolveInfraBindingTarget`, `openInfraDestination`,
  `openStoreAtForCity`, `openStoreAtForCityWithConfig`, `beads.OpenSQLiteStore`.
  The forbidden list is what makes "one store resolution per operation"
  enforceable rather than aspirational: the migration resolver is on it by name,
  so the defect this PR fixes cannot be reintroduced silently. The call scanner
  now records `pkg.Fn` as well as bare identifiers — without that arm every
  qualified entry counted zero regardless of what the file did — and the test
  fails outright if it sees no qualified call at all.
- `TestBdByIDSurfaceServesAClosedVerbSet` — the parser recognizes exactly the
  served forms and rejects thirteen near-misses, including `show --long`,
  `show --id` and `update --notes`.

## Test evidence

New: `cmd/gc/cmd_bd_by_id_test.go` (12 tests). The serving fixture registers a
**foreign engine provider configured by `config_ref`** — city.toml admits `path`
only for the built-in engine — wrapping this build's own engine, so the city
survives a real config load and opens a real bead engine minting real reserved
prefixes. The refusal fixture uses the real `beadsworkspace` provider.

The suite is **mutation-tested**; every mutation below was run and the listed
tests died:

| # | mutation | killed |
| --- | --- | --- |
| 1 | gate the surface on `resolveInfraBindingTarget` (the original defect) | 5 tests |
| 2 | flatten a class-store read failure into absence | 2 tests |
| 3 | drop the standing-refusal arm (work ids refused on a misconfigured city) | boundary test |
| 4 | drop its `!Reserved` guard (class ids fall through on a refused city) | boundary test |
| 5 | `Owned()` → `return r.Reserved` (residence probe dropped) | `…RoutesAWorkShapedIDResidentInTheClassBinding` |
| 6 | unserved-but-owned spelling falls through again | 4 tests |
| 7 | post-switch `default` falls through | *see below* |
| 8 | `show` text form drops the description | `…ShowRendersTheWholeRecord` |
| 9 | `update` silently drops unrepresentable flags | `…RefusalNamesTheUnrepresentableFlag` |
| 10 | id-valued flag set collapsed to plain values | 2 tests |

**Mutation 7 is not killable in isolation, and that is reported rather than
papered over:** the post-switch `default` is unreachable while the verb set and
the switch agree. Its behaviour is observable only when the switch regresses, so
it was exercised paired — dropping `case bdByIDUpdate` and comparing the two
arms:

```
switch loses the update case, default REFUSES:
  the step-completion write exited 1: gc bd: gcg-1 is owned by the infra class
  binding, and `gc bd update` is not served in process; refusing rather than
  running it against the work store, which does not hold the bead
switch loses the update case, default FALLS THROUGH:
  the step-completion write fell through to the bd subprocess: ""
```

A recoverable refusal versus the wrong-answer lane. Adding a seam purely to make
an unreachable arm killable would be the over-engineering, so the arm keeps its
comment and this evidence.

Also run: `go vet ./...` clean; `make lint-new LINT_BASE=origin/main` → 0 issues;
`go test ./internal/storebinding/... ./internal/beads/...` green;
`make test-fast-parallel` green apart from `TestDoRegistryPublish*` /
`TestBuildRegistryPublishRequest*`, which failed with
`fork/exec /usr/bin/git: resource temporarily unavailable` (shared-host `ulimit -u`
exhaustion) and pass standalone on this branch and on `origin/main` alike.

## Adjacent gaps found, not fixed here

1. **`mol-do-work.toml:95,123` pass `--notes` and are refused on a split city.**
   File-worthy: either the pack drops `--notes` for class-owned beads (it is
   already absent from `graph-worker.md`'s spelling, which is served), or the
   object model grows a notes field — `beads.Bead` and `beads.UpdateOpts` have
   none, so today no gc path can write one to any store. The refusal names the
   flag, so an operator is not left bisecting a command line.
2. **`gc bd dep tree <id>` is still not served in process.** It is no longer
   blind, though: on a class-owned id it is now refused before the subprocess,
   and on a work id it is forwarded verbatim.
   `TestGcBdDepTreeSplitsOnOwnershipNotOnServability` pins both halves.
3. **`gc beads show` falls back to a work-store scan when no controller is
   reachable.** `openAllConvoyStoresAt` does not consult `cliStorageRoutes`, so
   the documented class-routed read is blind exactly when the controller is down.
3. **The refusal message's location spelling is the weaker one.**
   `relocatedClassLocation` uses `configuredBindingLocation` (ConfigRef or Path),
   not `servedBindingLocation`. For a beads-workspace binding that prints the
   configuration reference `infra` rather than the resolved workspace directory —
   the exact ambiguity `bornSplitServedNote.Location` exists to remove, since two
   cities carrying the same reference serve different directories. **This PR does
   not touch `servedBindingLocation` semantics, `recordServedBinding`, or the
   born-split note discipline at all.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
