### PR TITLE
fix(session): stop the retired-session sweeps clobbering a re-claimed assignee

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -626,36 +626,21 @@ func directSessionBeadIDCandidates(assignee string) []string {
 	return candidates
 }
 
-// liveWorkAssignmentStillReleasable confirms the snapshot is not stale
-// before clearing assignee. The expectedStatus must match the snapshot
-// status the caller observed: if the bead has since transitioned (e.g. a
-// concurrent claim moved open→in_progress, or another release moved
-// in_progress→open) the snapshot's release decision is no longer safe.
-// Open status is required for the issue #2793 path — graph.v2 step
-// beads stuck on a dead session's long-form assignee are status=open,
-// not in_progress.
+// liveWorkAssignmentStillReleasable confirms the snapshot is not stale before
+// clearing assignee, collapsing a read failure to "not releasable" for callers
+// that have no error channel. Open status is required for the issue #2793 path —
+// graph.v2 step beads stuck on a dead session's long-form assignee are
+// status=open, not in_progress.
+//
+// The check itself lives in liveWorkAssignmentAssigneeMatches (work_assignment.go),
+// shared with the work-release and reassign paths.
 func liveWorkAssignmentStillReleasable(store beads.Store, id, expectedStatus, assignee string) bool {
-	id = strings.TrimSpace(id)
-	expectedStatus = strings.TrimSpace(expectedStatus)
-	if store == nil || id == "" || expectedStatus == "" {
-		return false
-	}
-	work, err := store.List(beads.ListQuery{
-		Status:   expectedStatus,
-		Live:     true,
-		TierMode: beads.TierBoth,
-	})
+	matches, err := liveWorkAssignmentAssigneeMatches(store, id, expectedStatus, assignee)
 	if err != nil {
 		log.Printf("releaseOrphanedPoolAssignments: live work validation failed for %q: %v", id, err)
 		return false
 	}
-	for _, wb := range work {
-		if wb.ID != id {
-			continue
-		}
-		return strings.TrimSpace(wb.Assignee) == strings.TrimSpace(assignee)
-	}
-	return false
+	return matches
 }
 
 func assigneePreservesNamedSessionRoute(cfg *config.City, cityPath, template, assignee, workStoreRef string, storeRefAware bool) bool {

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -966,9 +966,14 @@ func workAssignmentStores(store beads.Store, rigStores map[string]beads.Store) [
 }
 
 // unclaimResult reports the outcome of one unassign sweep over a retired
-// session bead's owned work: Released counts work beads whose assignee was
-// successfully cleared/reopened, Failed counts ReleaseWorkBead errors (already
-// logged per item to stderr). Void callers (named-session retirement, closed-
+// session bead's owned work: Released counts release attempts that completed
+// without error, Failed counts ReleaseWorkBead errors (already logged per item
+// to stderr). Released is deliberately NOT a count of writes — a release whose
+// snapshot went stale (the work was re-claimed by a live worker before the
+// write) correctly performs no write and reports no error, and is counted here
+// with the ones that did write. Both mean the same thing to every caller: this
+// session no longer holds that work. Only Failed distinguishes the case where
+// that is still unknown. Void callers (named-session retirement, closed-
 // session release) ignore it; the stranded-repair path reads Failed to avoid
 // reporting a clean repair — or closing the session bead — when an unassign did
 // not land, so a stale-assignee item is not masked behind a "repaired" close.
@@ -1061,7 +1066,7 @@ func reassignWorkAssignedToRetiredSessionBead(
 						continue
 					}
 					seen[key] = struct{}{}
-					if err := wa.ReassignWorkBead(item.ID, newSessionID); err != nil {
+					if err := wa.ReassignWorkBead(item, newSessionID); err != nil {
 						fmt.Fprintf(stderr, "session beads: reassigning work %s from retired session %s to %s: %v\n", item.ID, retiredSession.ID, newSessionID, err) //nolint:errcheck
 					}
 				}
@@ -1108,7 +1113,7 @@ func reassignWorkAssignedToRetiredSessionInfo(
 						continue
 					}
 					seen[key] = struct{}{}
-					if err := wa.ReassignWorkBead(item.ID, newSessionID); err != nil {
+					if err := wa.ReassignWorkBead(item, newSessionID); err != nil {
 						fmt.Fprintf(stderr, "session beads: reassigning work %s from retired session %s to %s: %v\n", item.ID, retiredSession.ID, newSessionID, err) //nolint:errcheck
 					}
 				}
@@ -1256,6 +1261,8 @@ func repairStrandedPoolWorkerBead(
 		// report a repair: closing now would strand the still-assigned work
 		// against a retired session. Leave the bead open so the next tick
 		// re-attempts (episode marker still aged, session still not-alive).
+		// The denominator counts every attempt, including releases that correctly
+		// no-oped because the work had already moved to a live worker.
 		fmt.Fprintf(stderr, "session beads: stranded-repair for %s deferred: %d of %d unassign(s) failed; leaving session bead open for retry\n", info.ID, res.Failed, res.Failed+res.Released) //nolint:errcheck
 		return false
 	}

--- a/cmd/gc/work_assignment.go
+++ b/cmd/gc/work_assignment.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"log"
 	"strings"
 
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
@@ -157,43 +160,220 @@ func excludeMailMessageBeads(items []beads.Bead) []beads.Bead {
 // metadata, and resets an in_progress bead to open so a fresh worker can
 // re-claim it via the routed queue. When runTargetFallback is non-empty AND the
 // bead carries neither run_target nor routed_to, the fallback route is stamped so
-// the reopened work stays reachable by the controller demand query. It emits the
-// exact beads.UpdateOpts the raw release ops in releaseWorkFromClosedSessionBead
-// and unclaimWorkAssignedToRetiredSessionBead emitted (proven byte-identical by
-// the recording-fake write tests). Pass runTargetFallback="" for the close-
-// release path, which never stamps a fallback.
+// the reopened work stays reachable by the controller demand query. Pass
+// runTargetFallback="" for the close-release path, which never stamps a fallback.
+//
+// The release is CONDITIONAL on the caller's snapshot still being true. Callers
+// compute their release set from a List taken earlier in the tick, so by the time
+// the write lands a fresh worker may already hold the bead; the raw ops this
+// replaced wrote unconditionally and destroyed that claim (dr-huhn). Two tiers
+// narrow the window: the store's atomic ReleaseIfCurrent when it has one,
+// otherwise a live re-read immediately before an unconditional write.
+//
+// Only the tier-2 write stays byte-identical to the raw release ops in
+// releaseWorkFromClosedSessionBead and unclaimWorkAssignedToRetiredSessionBead
+// (pinned by the recording-fake write tests). Tier 1 differs by design:
+// ReleaseIfCurrent swaps status/assignee itself, so when that tier applies the
+// metadata clear rides a second write — which is also why it does not always
+// apply (see singleWriteRequired below).
 func (w workAssignment) ReleaseWorkBead(item beads.Bead, runTargetFallback string) error {
 	store := w.unwrapped()
 	if store == nil {
 		return nil
 	}
+	metadata := clearedSessionAffinityMetadata()
+	stampFallbackRoute := runTargetFallback != "" &&
+		strings.TrimSpace(item.Metadata[beadmeta.RunTargetMetadataKey]) == "" &&
+		strings.TrimSpace(item.Metadata[beadmeta.RoutedToMetadataKey]) == ""
+	if stampFallbackRoute {
+		metadata[beadmeta.RunTargetMetadataKey] = runTargetFallback
+	}
+	// Tier 1 clears status/assignee atomically but leaves the metadata to a second
+	// write, so it is usable only when that second write is not routing-
+	// consequential. Both conditions below make it so, and in the gap between the
+	// two writes the bead is open and unassigned:
+	//
+	//   - a fallback route to stamp: the bead carries neither run_target nor
+	//     routed_to, leaving it invisible to the controller demand query and to
+	//     the orphan sweep (which scans only assigned work). If the second write
+	//     then fails, nothing revisits the bead and it is stranded silently.
+	//   - an active continuation group: gc.continuation_group is still set, and a
+	//     concurrent `gc hook --claim` reads it to vacuum this bead and its
+	//     {root, group} siblings onto the claiming session. This is the same
+	//     hazard releaseOrphanedPoolAssignment bypasses tier 1 for, and it is read
+	//     from the same snapshot for the same reason: a group stamped after the
+	//     caller's List but before this write still takes tier 1. Narrowing that
+	//     would need a live metadata re-read on every release, and it is the
+	//     assignee — not the group — that tier 1 verifies atomically.
+	//
+	// Either way the release must land as ONE write, which is what the tier-2
+	// recheck does: status, assignee and metadata in a single Update, so the bead
+	// is never claimable in a half-released state.
+	singleWriteRequired := stampFallbackRoute || beadHasActiveContinuationGroup(item)
+	// Tier 1: the store's atomic conditional release. A release computed from a
+	// snapshot must never write over an assignee that changed after that
+	// snapshot was taken.
+	if !singleWriteRequired {
+		released, handled, err := releaseWorkAssignmentIfCurrent(store, item)
+		if err != nil {
+			// Surface the failure. Callers gate on it: a swallowed error here
+			// reads as a successful release, and repairStrandedPoolWorkerBead
+			// would then close the session bead while its work is still
+			// assigned to it, with nothing left watching the work.
+			return err
+		}
+		if handled {
+			if !released {
+				return nil
+			}
+			// If this metadata clear fails the error propagates, but no retry
+			// follows: the bead is already unassigned, so the next tick's
+			// OpenAssignedTo sweep will not see it again. A bead whose SNAPSHOT
+			// carried a continuation group took the single-write path above and
+			// cannot be here, so what is normally left behind is only the
+			// advisory SessionAffinityMetadataKey. The exception is the same
+			// snapshot-bound gap singleWriteRequired documents: a group stamped
+			// after the caller's List still reaches this second write, and if
+			// this write fails that group outlives the release.
+			if err := store.Update(item.ID, beads.UpdateOpts{Metadata: metadata}); err != nil {
+				return fmt.Errorf("clearing session affinity on %q after conditional release: %w", item.ID, err)
+			}
+			return nil
+		}
+	}
+	// Tier 2: no usable conditional verb (or a route to stamp), so re-verify the
+	// snapshot with a live read immediately before the unconditional write. This
+	// shrinks the window rather than closing it; the residual recheck->write gap
+	// needs a store-level conditional write, which is exactly what tier 1 is.
+	stillCurrent, err := liveWorkAssignmentAssigneeMatches(store, item.ID, item.Status, item.Assignee)
+	if err != nil {
+		return err
+	}
+	if !stillCurrent {
+		log.Printf("ReleaseWorkBead: skipping release for %s: assignment changed between snapshot and release write", item.ID)
+		return nil
+	}
 	empty := ""
 	update := beads.UpdateOpts{
 		Assignee: &empty,
-		Metadata: clearedSessionAffinityMetadata(),
+		Metadata: metadata,
 	}
 	if item.Status == "in_progress" {
 		open := "open"
 		update.Status = &open
 	}
-	if runTargetFallback != "" &&
-		strings.TrimSpace(item.Metadata[beadmeta.RunTargetMetadataKey]) == "" &&
-		strings.TrimSpace(item.Metadata[beadmeta.RoutedToMetadataKey]) == "" {
-		update.Metadata[beadmeta.RunTargetMetadataKey] = runTargetFallback
-	}
 	return store.Update(item.ID, update)
+}
+
+// releaseWorkAssignmentIfCurrent attempts the store's atomic conditional
+// release. handled reports whether the conditional path owns the outcome (so
+// the caller must not fall through to an unconditional write); released reports
+// whether the assignment was actually cleared.
+//
+// It mirrors releasePoolAssignmentIfCurrent: the verb's contract covers
+// in_progress assignments with a known assignee, and the capability is asserted
+// on the unwrapped Store because a class wrapper does not promote optional
+// capabilities.
+func releaseWorkAssignmentIfCurrent(store beads.Store, item beads.Bead) (released, handled bool, err error) {
+	expectedAssignee := strings.TrimSpace(item.Assignee)
+	if item.Status != "in_progress" || expectedAssignee == "" {
+		return false, false, nil
+	}
+	releaser, ok := store.(beads.ConditionalAssignmentReleaser)
+	if !ok {
+		return false, false, nil
+	}
+	released, err = releaser.ReleaseIfCurrent(item.ID, expectedAssignee)
+	if err != nil {
+		if errors.Is(err, beads.ErrConditionalReleaseUnsupported) {
+			return false, false, nil
+		}
+		// The store supports conditional release but this attempt failed. Do NOT
+		// downgrade to an unconditional write that could clobber a concurrent
+		// re-claim, and do NOT report success: the assignment is still live and
+		// the caller must count this as a failed unassign.
+		return false, true, fmt.Errorf("conditional release of %q: %w", item.ID, err)
+	}
+	if !released {
+		// Not a failure: the bead now belongs to someone else, so there is
+		// nothing for this release to detach and the caller may proceed.
+		log.Printf("ReleaseWorkBead: skipping release for %s: assignment changed since snapshot (re-claimed or transitioned)", item.ID)
+	}
+	return released, true, nil
+}
+
+// liveWorkAssignmentAssigneeMatches reports whether a WORK bead still carries the
+// (status, assignee) pair a caller's earlier snapshot recorded. It is the single
+// implementation of the pre-write staleness check for both the work path here and
+// the pool path in pool_session_name.go, because the subtleties below are easy to
+// get wrong once and impossible to keep in sync twice.
+//
+// It uses a LIVE list query, not Get, and that choice is load-bearing:
+// CachingStore.Get serves a clone straight from the in-memory cache for a bead
+// that is tracked and not dirty (internal/beads/caching_store_reads.go). A
+// cached read here would re-verify the caller's stale snapshot against an
+// equally stale cache and confirm it, which reproduces the exact clobber this
+// guard exists to prevent.
+//
+// expectedStatus must be the status the caller observed: if the bead has since
+// transitioned (a concurrent claim moved open→in_progress, or another release
+// moved in_progress→open) the snapshot's decision is no longer safe. A bead
+// absent from the live result no longer holds that status, so it is not current
+// and not an error.
+//
+// A read failure returns the error rather than a verdict. Writing on an
+// unverified snapshot can destroy a live worker's claim, and reporting the write
+// as done when the read failed would let a caller close a session bead whose work
+// is still assigned to it.
+func liveWorkAssignmentAssigneeMatches(store beads.Store, id, expectedStatus, expectedAssignee string) (bool, error) {
+	id = strings.TrimSpace(id)
+	expectedStatus = strings.TrimSpace(expectedStatus)
+	if store == nil || id == "" || expectedStatus == "" {
+		return false, nil
+	}
+	work, err := store.List(beads.ListQuery{
+		Status:   expectedStatus,
+		Live:     true,
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return false, fmt.Errorf("live work-assignment verification of %q: %w", id, err)
+	}
+	for _, wb := range work {
+		if wb.ID != id {
+			continue
+		}
+		return strings.TrimSpace(wb.Assignee) == strings.TrimSpace(expectedAssignee), nil
+	}
+	return false, nil
 }
 
 // ReassignWorkBead re-homes one WORK bead onto a new session identity, emitting
 // the exact Update{Assignee:&new} the raw reassign op in
 // reassignWorkAssignedToRetiredSessionBead emitted. It deliberately touches
 // neither Status nor Metadata.
-func (w workAssignment) ReassignWorkBead(beadID, newSessionID string) error {
+//
+// The write is CONDITIONAL on item still being assigned to the session the
+// caller's snapshot saw. Both callers walk an OpenAssignedTo list taken earlier
+// in the tick (session_beads.go), so this carries the same lost-update hazard as
+// the release path (dr-huhn): a fresh worker can claim the bead between the list
+// and the write, and an unconditional reassign then stamps the retired session's
+// successor over that live claim. There is no conditional-reassign verb to reach
+// for — ReleaseIfCurrent only clears — so the guard is the live re-read.
+func (w workAssignment) ReassignWorkBead(item beads.Bead, newSessionID string) error {
 	store := w.unwrapped()
 	if store == nil {
 		return nil
 	}
-	return store.Update(beadID, beads.UpdateOpts{Assignee: &newSessionID})
+	stillCurrent, err := liveWorkAssignmentAssigneeMatches(store, item.ID, item.Status, item.Assignee)
+	if err != nil {
+		return err
+	}
+	if !stillCurrent {
+		log.Printf("ReassignWorkBead: skipping reassign for %s: assignment changed between snapshot and reassign write", item.ID)
+		return nil
+	}
+	return store.Update(item.ID, beads.UpdateOpts{Assignee: &newSessionID})
 }
 
 // ClearDetachedProbe clears the detached-probe metadata contract on a WORK bead,

--- a/cmd/gc/work_assignment_release_race_test.go
+++ b/cmd/gc/work_assignment_release_race_test.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// Every fake below embeds *beads.MemStore and overrides one method to shape a
+// specific race. These assertions exist because that override is silent when it
+// drifts: if the interface signature changes, the override stops satisfying it,
+// MemStore's own implementation gets promoted in its place, and every subtest
+// quietly reroutes onto the other tier while still reporting green.
+var (
+	_ beads.ConditionalAssignmentReleaser = (*errReleaseStore)(nil)
+	_ beads.ConditionalAssignmentReleaser = (*errGetStore)(nil)
+	_ beads.ConditionalAssignmentReleaser = (*staleGetReleaseStore)(nil)
+	_ beads.ConditionalAssignmentReleaser = (*failSecondWriteStore)(nil)
+	_ beads.ConditionalAssignmentReleaser = (*clobberingReleaseStore)(nil)
+)
+
+// errReleaseStore fails the conditional release with a genuine backend error
+// (not the unsupported sentinel), standing in for a bd sql failure or a JSON
+// parse failure from BdStore.ReleaseIfCurrent.
+type errReleaseStore struct {
+	*beads.MemStore
+	err error
+}
+
+func (s *errReleaseStore) ReleaseIfCurrent(string, string) (bool, error) {
+	return false, s.err
+}
+
+// errGetStore fails the tier-2 pre-release verification read. It reports the
+// conditional verb as unsupported so the release is forced onto tier 2. The
+// verification is a LIVE List (not Get), because a cached Get would re-confirm
+// the caller's stale snapshot against an equally stale cache.
+type errGetStore struct {
+	*beads.MemStore
+	err  error
+	fail bool
+}
+
+func (s *errGetStore) ReleaseIfCurrent(string, string) (bool, error) {
+	return false, beads.ErrConditionalReleaseUnsupported
+}
+
+func (s *errGetStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if s.fail {
+		return nil, s.err
+	}
+	return s.MemStore.List(q)
+}
+
+// TestReleaseWorkBead_PropagatesBackendFailures pins the failure DIRECTION for
+// both tiers. A release that did not happen must not report success: callers
+// count a nil error as a completed unassign, and repairStrandedPoolWorkerBead
+// gates on that count before closing a session bead. Swallowing the error there
+// closes the session bead while its work is still assigned to it, and nothing
+// watches the work afterwards. That is worse than the unconditional write this
+// guard replaced, which propagated its Update error.
+func TestReleaseWorkBead_PropagatesBackendFailures(t *testing.T) {
+	backendErr := errors.New("transient backend failure")
+
+	t.Run("tier 1 conditional release error", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		store := &errReleaseStore{MemStore: mem, err: backendErr}
+		claimed := seedClaimedBead(t, mem, "retired-session")
+
+		wa := workAssignmentForStore(beads.WorkStore{Store: store})
+		err := wa.ReleaseWorkBead(claimed, "")
+		if err == nil {
+			t.Fatal("ReleaseWorkBead returned nil after a backend failure; the caller will count this as a completed unassign")
+		}
+		if !errors.Is(err, backendErr) {
+			t.Errorf("error = %v, want it to wrap %v", err, backendErr)
+		}
+		got, getErr := mem.Get(claimed.ID)
+		if getErr != nil {
+			t.Fatalf("Get: %v", getErr)
+		}
+		if got.Assignee != "retired-session" || got.Status != "in_progress" {
+			t.Errorf("bead moved despite the failure: status=%q assignee=%q", got.Status, got.Assignee)
+		}
+	})
+
+	t.Run("tier 2 verification read error", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		store := &errGetStore{MemStore: mem, err: backendErr}
+		claimed := seedClaimedBead(t, mem, "retired-session")
+		store.fail = true
+
+		wa := workAssignmentForStore(beads.WorkStore{Store: store})
+		err := wa.ReleaseWorkBead(claimed, "")
+		if err == nil {
+			t.Fatal("ReleaseWorkBead returned nil after the pre-release read failed; the caller will count this as a completed unassign")
+		}
+		if !errors.Is(err, backendErr) {
+			t.Errorf("error = %v, want it to wrap %v", err, backendErr)
+		}
+	})
+}
+
+// TestReleaseWorkBead_FallbackRouteNeverRidesASecondWrite pins the tier-1
+// bypass. ReleaseIfCurrent swaps only status/assignee, so a run_target stamped
+// afterwards rides a separate write. In that gap the bead is open, unassigned,
+// and carries neither run_target nor routed_to, which makes it invisible to the
+// controller demand query and to the orphan sweep (which scans only ASSIGNED
+// work); if the second write then fails, nothing revisits it. The release must
+// therefore take the single-write path whenever a route has to be stamped, the
+// same bypass releaseOrphanedPoolAssignment applies to continuation groups.
+func TestReleaseWorkBead_FallbackRouteNeverRidesASecondWrite(t *testing.T) {
+	store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
+	claimed := seedClaimedBead(t, store, "retired-session")
+
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	if err := wa.ReleaseWorkBead(claimed, "worker"); err != nil {
+		t.Fatalf("ReleaseWorkBead: %v", err)
+	}
+
+	got, err := store.Get(claimed.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Assignee != "" || got.Status != "open" {
+		t.Fatalf("release did not land: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+	// The invariant: a released bead is never claimable without its route. On the
+	// two-write path this bead would be open, unassigned, and unrouted.
+	if got.Metadata[beadmeta.RunTargetMetadataKey] != "worker" {
+		t.Errorf("run_target = %q, want %q — a released bead with no route is invisible to the demand query and to the orphan sweep",
+			got.Metadata[beadmeta.RunTargetMetadataKey], "worker")
+	}
+}
+
+// staleGetReleaseStore answers Get from a stale snapshot while List(Live:true) tells
+// the truth, which is the shape CachingStore has: Get serves a clone from the
+// in-memory cache for a tracked, non-dirty bead. It reports the conditional verb
+// as unsupported so the release is forced onto tier 2.
+type staleGetReleaseStore struct {
+	*beads.MemStore
+	stale beads.Bead
+}
+
+func (s *staleGetReleaseStore) ReleaseIfCurrent(string, string) (bool, error) {
+	return false, beads.ErrConditionalReleaseUnsupported
+}
+
+func (s *staleGetReleaseStore) Get(id string) (beads.Bead, error) {
+	if id == s.stale.ID {
+		return s.stale, nil
+	}
+	return s.MemStore.Get(id)
+}
+
+// TestReleaseWorkBead_Tier2DoesNotTrustACachedRead is the cache half of the
+// dr-huhn race. Verifying the caller's stale snapshot with a CACHED read
+// re-confirms it against an equally stale cache and lets the unconditional write
+// clobber a live claim, which is the original bug wearing a guard. The
+// verification must read live.
+func TestReleaseWorkBead_Tier2DoesNotTrustACachedRead(t *testing.T) {
+	mem := beads.NewMemStore()
+	store := &staleGetReleaseStore{MemStore: mem}
+	// Live truth: a fresh worker holds it.
+	claimed := seedClaimedBead(t, mem, "fresh-worker")
+	// The caller's snapshot, and what a cached Get would still answer.
+	stale := claimed
+	stale.Assignee = "retired-session"
+	store.stale = stale
+
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	if err := wa.ReleaseWorkBead(stale, ""); err != nil {
+		t.Fatalf("ReleaseWorkBead: %v", err)
+	}
+
+	got, err := mem.Get(claimed.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Assignee != "fresh-worker" || got.Status != "in_progress" {
+		t.Errorf("status=%q assignee=%q, want in_progress/fresh-worker — a cached verification read let the release clobber a live claim",
+			got.Status, got.Assignee)
+	}
+}
+
+// failSecondWriteStore implements the conditional verb but fails a
+// METADATA-ONLY Update, which is exactly the second write of the tier-1 path.
+// A combined status+assignee+metadata Update (the single-write tier-2 release)
+// still succeeds. So a release that correctly bypasses tier 1 lands whole, and
+// one that splits the write leaves the bead released but unrouted.
+type failSecondWriteStore struct {
+	*beads.MemStore
+}
+
+func (s *failSecondWriteStore) Update(id string, opts beads.UpdateOpts) error {
+	if opts.Assignee == nil && opts.Status == nil && opts.Metadata != nil {
+		return errors.New("metadata-only write failed")
+	}
+	return s.MemStore.Update(id, opts)
+}
+
+// clobberingReleaseStore simulates the dr-huhn race: the caller computed its
+// release set from a snapshot, and between that snapshot and the release write
+// a fresh worker re-claimed the bead. The store answers reads with the CURRENT
+// (re-claimed) state, so a release that still writes unconditionally destroys
+// the new owner's claim.
+type clobberingReleaseStore struct {
+	*beads.MemStore
+	supportsConditional bool
+}
+
+func newClobberingReleaseStore(conditional bool) *clobberingReleaseStore {
+	return &clobberingReleaseStore{MemStore: beads.NewMemStore(), supportsConditional: conditional}
+}
+
+// ReleaseIfCurrent hides MemStore's implementation when this store is standing
+// in for a backend without the conditional verb, so the fallback path is
+// exercised rather than the CAS fast path.
+func (s *clobberingReleaseStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	if !s.supportsConditional {
+		return false, beads.ErrConditionalReleaseUnsupported
+	}
+	return s.MemStore.ReleaseIfCurrent(id, expectedAssignee)
+}
+
+// seedClaimedBead creates a bead and drives it to in_progress under owner.
+// MemStore.Create hard-sets status to "open", so the claim must be a follow-up
+// Update rather than a field on the create.
+func seedClaimedBead(t *testing.T, store beads.Store, owner string) beads.Bead {
+	t.Helper()
+	created, err := store.Create(beads.Bead{Title: "work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	inProgress, assignee := "in_progress", owner
+	if err := store.Update(created.ID, beads.UpdateOpts{Status: &inProgress, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update to claimed: %v", err)
+	}
+	claimed, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after claim: %v", err)
+	}
+	if claimed.Status != "in_progress" || claimed.Assignee != owner {
+		t.Fatalf("seed failed: status=%q assignee=%q, want in_progress/%s", claimed.Status, claimed.Assignee, owner)
+	}
+	return claimed
+}
+
+// seedReclaimedBead creates a bead already owned by newOwner and returns the
+// STALE snapshot (owned by staleOwner) that a caller would be holding.
+func seedReclaimedBead(t *testing.T, store beads.Store, staleOwner, newOwner string) beads.Bead {
+	t.Helper()
+	stale := seedClaimedBead(t, store, newOwner)
+	stale.Assignee = staleOwner
+	return stale
+}
+
+// TestReleaseWorkBead_DoesNotClobberReclaimedAssignee is the dr-huhn regression:
+// releasing against a stale snapshot must not clear an assignee that now belongs
+// to a different, live worker. Asserted for both store shapes — with the atomic
+// conditional verb (CAS fast path) and without it (recheck fallback).
+func TestReleaseWorkBead_DoesNotClobberReclaimedAssignee(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		conditional bool
+	}{
+		{"conditional release available", true},
+		{"conditional release unsupported", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newClobberingReleaseStore(tc.conditional)
+			stale := seedReclaimedBead(t, store, "retired-session", "fresh-worker")
+
+			wa := workAssignmentForStore(beads.WorkStore{Store: store})
+			if err := wa.ReleaseWorkBead(stale, ""); err != nil {
+				t.Fatalf("ReleaseWorkBead: %v", err)
+			}
+
+			got, err := store.Get(stale.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.Assignee != "fresh-worker" {
+				t.Errorf("assignee = %q, want %q — the release clobbered a re-claim it did not own", got.Assignee, "fresh-worker")
+			}
+			if got.Status != "in_progress" {
+				t.Errorf("status = %q, want in_progress — the release reset a bead a live worker still holds", got.Status)
+			}
+		})
+	}
+}
+
+// TestReleaseWorkBead_ReleasesWhenSnapshotStillCurrent guards the other
+// direction: the no-clobber guard must not block the release it exists to
+// perform. When the snapshot is still accurate the bead is released normally.
+func TestReleaseWorkBead_ReleasesWhenSnapshotStillCurrent(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		conditional bool
+	}{
+		{"conditional release available", true},
+		{"conditional release unsupported", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newClobberingReleaseStore(tc.conditional)
+			created := seedClaimedBead(t, store, "retired-session")
+
+			wa := workAssignmentForStore(beads.WorkStore{Store: store})
+			if err := wa.ReleaseWorkBead(created, ""); err != nil {
+				t.Fatalf("ReleaseWorkBead: %v", err)
+			}
+
+			got, err := store.Get(created.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.Assignee != "" {
+				t.Errorf("assignee = %q, want empty — a current snapshot must still release", got.Assignee)
+			}
+			if got.Status != "open" {
+				t.Errorf("status = %q, want open — an in_progress release must reset to open", got.Status)
+			}
+		})
+	}
+}
+
+// TestReassignWorkBead_DoesNotClobberReclaimedAssignee is the dr-huhn regression
+// on the sibling write. reassignWorkAssignedToRetiredSession* walks the same
+// OpenAssignedTo snapshot the release sweep walks (session_beads.go), so a
+// reassign computed from it carries the identical lost-update hazard: a fresh
+// worker claims the bead after the list, and an unconditional
+// Update{Assignee:&successor} stamps the retired session's replacement over that
+// live claim. There is no conditional-reassign verb, so the only guard is the
+// live re-read — which is why this test exercises a plain MemStore rather than
+// the two store shapes the release test needs.
+func TestReassignWorkBead_DoesNotClobberReclaimedAssignee(t *testing.T) {
+	store := beads.NewMemStore()
+	stale := seedReclaimedBead(t, store, "retired-session", "fresh-worker")
+
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	if err := wa.ReassignWorkBead(stale, "successor-session"); err != nil {
+		t.Fatalf("ReassignWorkBead: %v", err)
+	}
+
+	got, err := store.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Assignee != "fresh-worker" {
+		t.Errorf("assignee = %q, want fresh-worker — a stale snapshot reassigned live work to the retired session's successor", got.Assignee)
+	}
+}
+
+// TestReassignWorkBead_ReassignsWhenSnapshotStillCurrent is the other half: the
+// guard must not turn every reassign into a no-op. Without this, deleting the
+// write entirely would pass the clobber test above.
+func TestReassignWorkBead_ReassignsWhenSnapshotStillCurrent(t *testing.T) {
+	store := beads.NewMemStore()
+	claimed := seedClaimedBead(t, store, "retired-session")
+
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	if err := wa.ReassignWorkBead(claimed, "successor-session"); err != nil {
+		t.Fatalf("ReassignWorkBead: %v", err)
+	}
+
+	got, err := store.Get(claimed.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Assignee != "successor-session" {
+		t.Errorf("assignee = %q, want successor-session — a current snapshot must still reassign", got.Assignee)
+	}
+}
+
+// TestReassignWorkBead_PropagatesVerificationFailure pins the failure direction:
+// a reassign whose verification read failed must not report success. The callers
+// log per-bead failures, and a swallowed error there reads as a completed
+// re-home of work that is in fact still on the retired session.
+func TestReassignWorkBead_PropagatesVerificationFailure(t *testing.T) {
+	backendErr := errors.New("transient backend failure")
+	mem := beads.NewMemStore()
+	claimed := seedClaimedBead(t, mem, "retired-session")
+	store := &errGetStore{MemStore: mem, err: backendErr, fail: true}
+
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	err := wa.ReassignWorkBead(claimed, "successor-session")
+	if !errors.Is(err, backendErr) {
+		t.Fatalf("ReassignWorkBead err = %v, want wrapped %v", err, backendErr)
+	}
+}
+
+// TestReleaseWorkBead_ContinuationGroupNeverRidesASecondWrite covers the other
+// disjunct of singleWriteRequired. A bead carrying gc.continuation_group must be
+// released in ONE write, because between a tier-1 conditional release and its
+// follow-up metadata write the bead is open, unassigned, and still carrying the
+// group — and `gc hook --claim` reads that group to vacuum the bead and its
+// {root, group} siblings onto the claiming session. The fallback-route disjunct
+// is covered separately; this one has no route to stamp, so only the group
+// forces the single write.
+func TestReleaseWorkBead_ContinuationGroupNeverRidesASecondWrite(t *testing.T) {
+	store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
+	claimed := seedClaimedBead(t, store, "retired-session")
+	if err := store.SetMetadata(claimed.ID, beadmeta.ContinuationGroupMetadataKey, "grp-1"); err != nil {
+		t.Fatalf("seed continuation group: %v", err)
+	}
+	claimed.Metadata = map[string]string{beadmeta.ContinuationGroupMetadataKey: "grp-1"}
+
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	// runTargetFallback is empty, so stampFallbackRoute is false and the group is
+	// the only thing that can force the single-write path.
+	if err := wa.ReleaseWorkBead(claimed, ""); err != nil {
+		t.Fatalf("ReleaseWorkBead: %v", err)
+	}
+
+	got, err := store.Get(claimed.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Assignee != "" || got.Status != "open" {
+		t.Fatalf("release did not land: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+	// The invariant: the bead is never claimable while still carrying the group.
+	// On the two-write path the group would survive the failing second write.
+	if g := strings.TrimSpace(got.Metadata[beadmeta.ContinuationGroupMetadataKey]); g != "" {
+		t.Errorf("continuation group = %q, want cleared — an open, unassigned bead still carrying its group lets a concurrent claim vacuum its siblings through it", g)
+	}
+}

--- a/cmd/gc/work_assignment_release_race_test.go
+++ b/cmd/gc/work_assignment_release_race_test.go
@@ -113,27 +113,56 @@ func TestReleaseWorkBead_PropagatesBackendFailures(t *testing.T) {
 // therefore take the single-write path whenever a route has to be stamped, the
 // same bypass releaseOrphanedPoolAssignment applies to continuation groups.
 func TestReleaseWorkBead_FallbackRouteNeverRidesASecondWrite(t *testing.T) {
-	store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
-	claimed := seedClaimedBead(t, store, "retired-session")
+	t.Run("current snapshot uses one combined write", func(t *testing.T) {
+		store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
+		claimed := seedClaimedBead(t, store, "retired-session")
+		store.updateCalls = 0
 
-	wa := workAssignmentForStore(beads.WorkStore{Store: store})
-	if err := wa.ReleaseWorkBead(claimed, "worker"); err != nil {
-		t.Fatalf("ReleaseWorkBead: %v", err)
-	}
+		wa := workAssignmentForStore(beads.WorkStore{Store: store})
+		if err := wa.ReleaseWorkBead(claimed, "worker"); err != nil {
+			t.Fatalf("ReleaseWorkBead: %v", err)
+		}
 
-	got, err := store.Get(claimed.ID)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if got.Assignee != "" || got.Status != "open" {
-		t.Fatalf("release did not land: status=%q assignee=%q", got.Status, got.Assignee)
-	}
-	// The invariant: a released bead is never claimable without its route. On the
-	// two-write path this bead would be open, unassigned, and unrouted.
-	if got.Metadata[beadmeta.RunTargetMetadataKey] != "worker" {
-		t.Errorf("run_target = %q, want %q — a released bead with no route is invisible to the demand query and to the orphan sweep",
-			got.Metadata[beadmeta.RunTargetMetadataKey], "worker")
-	}
+		if store.updateCalls != 1 {
+			t.Fatalf("Update calls = %d, want 1 combined release write", store.updateCalls)
+		}
+		got, err := store.Get(claimed.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Assignee != "" || got.Status != "open" {
+			t.Fatalf("release did not land: status=%q assignee=%q", got.Status, got.Assignee)
+		}
+		// The invariant: a released bead is never claimable without its route. On the
+		// two-write path this bead would be open, unassigned, and unrouted.
+		if got.Metadata[beadmeta.RunTargetMetadataKey] != "worker" {
+			t.Errorf("run_target = %q, want %q — a released bead with no route is invisible to the demand query and to the orphan sweep",
+				got.Metadata[beadmeta.RunTargetMetadataKey], "worker")
+		}
+	})
+
+	t.Run("stale snapshot performs no write", func(t *testing.T) {
+		store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
+		stale := seedReclaimedBead(t, store)
+		store.updateCalls = 0
+
+		wa := workAssignmentForStore(beads.WorkStore{Store: store})
+		if err := wa.ReleaseWorkBead(stale, "worker"); err != nil {
+			t.Fatalf("ReleaseWorkBead: %v", err)
+		}
+
+		if store.updateCalls != 0 {
+			t.Fatalf("Update calls = %d, want 0 for a stale release snapshot", store.updateCalls)
+		}
+		got, err := store.Get(stale.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Assignee != "fresh-worker" || got.Status != "in_progress" {
+			t.Errorf("status=%q assignee=%q, want in_progress/fresh-worker — the stale fallback-route release clobbered a live claim",
+				got.Status, got.Assignee)
+		}
+	})
 }
 
 // staleGetReleaseStore answers Get from a stale snapshot while List(Live:true) tells
@@ -193,9 +222,11 @@ func TestReleaseWorkBead_Tier2DoesNotTrustACachedRead(t *testing.T) {
 // one that splits the write leaves the bead released but unrouted.
 type failSecondWriteStore struct {
 	*beads.MemStore
+	updateCalls int
 }
 
 func (s *failSecondWriteStore) Update(id string, opts beads.UpdateOpts) error {
+	s.updateCalls++
 	if opts.Assignee == nil && opts.Status == nil && opts.Metadata != nil {
 		return errors.New("metadata-only write failed")
 	}
@@ -249,12 +280,13 @@ func seedClaimedBead(t *testing.T, store beads.Store, owner string) beads.Bead {
 	return claimed
 }
 
-// seedReclaimedBead creates a bead already owned by newOwner and returns the
-// STALE snapshot (owned by staleOwner) that a caller would be holding.
-func seedReclaimedBead(t *testing.T, store beads.Store, staleOwner, newOwner string) beads.Bead {
+// seedReclaimedBead creates a bead already owned by the fixture "fresh-worker"
+// owner and returns the STALE snapshot (owned by the fixture "retired-session"
+// owner) that a caller would be holding.
+func seedReclaimedBead(t *testing.T, store beads.Store) beads.Bead {
 	t.Helper()
-	stale := seedClaimedBead(t, store, newOwner)
-	stale.Assignee = staleOwner
+	stale := seedClaimedBead(t, store, "fresh-worker")
+	stale.Assignee = "retired-session"
 	return stale
 }
 
@@ -272,7 +304,7 @@ func TestReleaseWorkBead_DoesNotClobberReclaimedAssignee(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := newClobberingReleaseStore(tc.conditional)
-			stale := seedReclaimedBead(t, store, "retired-session", "fresh-worker")
+			stale := seedReclaimedBead(t, store)
 
 			wa := workAssignmentForStore(beads.WorkStore{Store: store})
 			if err := wa.ReleaseWorkBead(stale, ""); err != nil {
@@ -338,7 +370,7 @@ func TestReleaseWorkBead_ReleasesWhenSnapshotStillCurrent(t *testing.T) {
 // the two store shapes the release test needs.
 func TestReassignWorkBead_DoesNotClobberReclaimedAssignee(t *testing.T) {
 	store := beads.NewMemStore()
-	stale := seedReclaimedBead(t, store, "retired-session", "fresh-worker")
+	stale := seedReclaimedBead(t, store)
 
 	wa := workAssignmentForStore(beads.WorkStore{Store: store})
 	if err := wa.ReassignWorkBead(stale, "successor-session"); err != nil {
@@ -401,30 +433,63 @@ func TestReassignWorkBead_PropagatesVerificationFailure(t *testing.T) {
 // is covered separately; this one has no route to stamp, so only the group
 // forces the single write.
 func TestReleaseWorkBead_ContinuationGroupNeverRidesASecondWrite(t *testing.T) {
-	store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
-	claimed := seedClaimedBead(t, store, "retired-session")
-	if err := store.SetMetadata(claimed.ID, beadmeta.ContinuationGroupMetadataKey, "grp-1"); err != nil {
-		t.Fatalf("seed continuation group: %v", err)
-	}
-	claimed.Metadata = map[string]string{beadmeta.ContinuationGroupMetadataKey: "grp-1"}
+	t.Run("current snapshot uses one combined write", func(t *testing.T) {
+		store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
+		claimed := seedClaimedBead(t, store, "retired-session")
+		if err := store.SetMetadata(claimed.ID, beadmeta.ContinuationGroupMetadataKey, "grp-1"); err != nil {
+			t.Fatalf("seed continuation group: %v", err)
+		}
+		claimed.Metadata = map[string]string{beadmeta.ContinuationGroupMetadataKey: "grp-1"}
+		store.updateCalls = 0
 
-	wa := workAssignmentForStore(beads.WorkStore{Store: store})
-	// runTargetFallback is empty, so stampFallbackRoute is false and the group is
-	// the only thing that can force the single-write path.
-	if err := wa.ReleaseWorkBead(claimed, ""); err != nil {
-		t.Fatalf("ReleaseWorkBead: %v", err)
-	}
+		wa := workAssignmentForStore(beads.WorkStore{Store: store})
+		// runTargetFallback is empty, so stampFallbackRoute is false and the group is
+		// the only thing that can force the single-write path.
+		if err := wa.ReleaseWorkBead(claimed, ""); err != nil {
+			t.Fatalf("ReleaseWorkBead: %v", err)
+		}
 
-	got, err := store.Get(claimed.ID)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if got.Assignee != "" || got.Status != "open" {
-		t.Fatalf("release did not land: status=%q assignee=%q", got.Status, got.Assignee)
-	}
-	// The invariant: the bead is never claimable while still carrying the group.
-	// On the two-write path the group would survive the failing second write.
-	if g := strings.TrimSpace(got.Metadata[beadmeta.ContinuationGroupMetadataKey]); g != "" {
-		t.Errorf("continuation group = %q, want cleared — an open, unassigned bead still carrying its group lets a concurrent claim vacuum its siblings through it", g)
-	}
+		if store.updateCalls != 1 {
+			t.Fatalf("Update calls = %d, want 1 combined release write", store.updateCalls)
+		}
+		got, err := store.Get(claimed.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Assignee != "" || got.Status != "open" {
+			t.Fatalf("release did not land: status=%q assignee=%q", got.Status, got.Assignee)
+		}
+		// The invariant: the bead is never claimable while still carrying the group.
+		// On the two-write path the group would survive the failing second write.
+		if g := strings.TrimSpace(got.Metadata[beadmeta.ContinuationGroupMetadataKey]); g != "" {
+			t.Errorf("continuation group = %q, want cleared — an open, unassigned bead still carrying its group lets a concurrent claim vacuum its siblings through it", g)
+		}
+	})
+
+	t.Run("stale snapshot performs no write", func(t *testing.T) {
+		store := &failSecondWriteStore{MemStore: beads.NewMemStore()}
+		stale := seedReclaimedBead(t, store)
+		if err := store.SetMetadata(stale.ID, beadmeta.ContinuationGroupMetadataKey, "grp-1"); err != nil {
+			t.Fatalf("seed continuation group: %v", err)
+		}
+		stale.Metadata = map[string]string{beadmeta.ContinuationGroupMetadataKey: "grp-1"}
+		store.updateCalls = 0
+
+		wa := workAssignmentForStore(beads.WorkStore{Store: store})
+		if err := wa.ReleaseWorkBead(stale, ""); err != nil {
+			t.Fatalf("ReleaseWorkBead: %v", err)
+		}
+
+		if store.updateCalls != 0 {
+			t.Fatalf("Update calls = %d, want 0 for a stale release snapshot", store.updateCalls)
+		}
+		got, err := store.Get(stale.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Assignee != "fresh-worker" || got.Status != "in_progress" {
+			t.Errorf("status=%q assignee=%q, want in_progress/fresh-worker — the stale continuation-group release clobbered a live claim",
+				got.Status, got.Assignee)
+		}
+	})
 }

--- a/cmd/gc/work_assignment_write_test.go
+++ b/cmd/gc/work_assignment_write_test.go
@@ -54,6 +54,50 @@ func (s *recordingWriteWorkStore) SetMetadata(id, key, value string) error {
 	return nil
 }
 
+// The assertion is the enforcement of the comment below: on a signature drift
+// the override stops satisfying the interface, MemStore's implementation is
+// promoted in its place, and every assert here silently reroutes onto tier 1
+// while still reporting green.
+var _ beads.ConditionalAssignmentReleaser = (*recordingWriteWorkStore)(nil)
+
+// ReleaseIfCurrent reports the conditional verb as unsupported so these tests
+// pin the UNCONDITIONAL fallback write — the shape that must stay byte-identical
+// to the raw release ops. The conditional fast path emits a different (metadata-
+// only) write by design and is covered in work_assignment_release_race_test.go.
+// Without this override the embedded MemStore would promote its own
+// implementation and silently move every assert onto the other path.
+func (s *recordingWriteWorkStore) ReleaseIfCurrent(_, _ string) (bool, error) {
+	return false, beads.ErrConditionalReleaseUnsupported
+}
+
+// seedWriteWorkBead puts the bead the façade is about to release into the
+// backing store with live state matching the caller's snapshot. The release path
+// re-reads the bead immediately before writing (the dr-huhn no-clobber guard), so
+// a snapshot with no bead behind it is correctly refused. Seeding goes straight to
+// the MemStore because the recorder's own Update deliberately does not delegate.
+func seedWriteWorkBead(t *testing.T, rec *recordingWriteWorkStore, item beads.Bead) {
+	t.Helper()
+	rec.HonorExplicitIDs = true
+	if _, err := rec.Create(beads.Bead{ID: item.ID, Title: "work", Metadata: item.Metadata}); err != nil {
+		t.Fatalf("seed Create(%s): %v", item.ID, err)
+	}
+	status, assignee := item.Status, item.Assignee
+	// Qualified on MemStore deliberately: the recorder's own Update records
+	// without delegating, so seeding through it would leave the store empty and
+	// pollute the recorded ops the asserts read.
+	if err := rec.MemStore.Update(item.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("seed Update(%s): %v", item.ID, err)
+	}
+	got, err := rec.Get(item.ID)
+	if err != nil {
+		t.Fatalf("seed Get(%s): %v", item.ID, err)
+	}
+	if got.Status != item.Status || got.Assignee != item.Assignee {
+		t.Fatalf("seed(%s) failed: status=%q assignee=%q, want %q/%q",
+			item.ID, got.Status, got.Assignee, item.Status, item.Assignee)
+	}
+}
+
 func derefStr(p *string) string {
 	if p == nil {
 		return "<nil>"
@@ -86,6 +130,7 @@ func TestWorkAssignmentReleaseWorkBead_OpenStaysOpen(t *testing.T) {
 	wa := workAssignmentForStore(beads.WorkStore{Store: rec})
 
 	item := beads.Bead{ID: "w-open", Status: "open", Assignee: "agent-1"}
+	seedWriteWorkBead(t, rec, item)
 	if err := wa.ReleaseWorkBead(item, ""); err != nil {
 		t.Fatalf("ReleaseWorkBead: %v", err)
 	}
@@ -115,6 +160,7 @@ func TestWorkAssignmentReleaseWorkBead_InProgressResetsToOpen(t *testing.T) {
 	wa := workAssignmentForStore(beads.WorkStore{Store: rec})
 
 	item := beads.Bead{ID: "w-ip", Status: "in_progress", Assignee: "agent-1"}
+	seedWriteWorkBead(t, rec, item)
 	if err := wa.ReleaseWorkBead(item, ""); err != nil {
 		t.Fatalf("ReleaseWorkBead: %v", err)
 	}
@@ -135,6 +181,7 @@ func TestWorkAssignmentReleaseWorkBead_RunTargetFallbackApplied(t *testing.T) {
 	wa := workAssignmentForStore(beads.WorkStore{Store: rec})
 
 	item := beads.Bead{ID: "w-route", Status: "in_progress", Assignee: "agent-1"}
+	seedWriteWorkBead(t, rec, item)
 	if err := wa.ReleaseWorkBead(item, "worker"); err != nil {
 		t.Fatalf("ReleaseWorkBead: %v", err)
 	}
@@ -156,6 +203,7 @@ func TestWorkAssignmentReleaseWorkBead_RunTargetFallbackSkippedWhenRouted(t *tes
 		Assignee: "agent-1",
 		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "existing"},
 	}
+	seedWriteWorkBead(t, rec, item)
 	if err := wa.ReleaseWorkBead(item, "worker"); err != nil {
 		t.Fatalf("ReleaseWorkBead: %v", err)
 	}
@@ -166,12 +214,16 @@ func TestWorkAssignmentReleaseWorkBead_RunTargetFallbackSkippedWhenRouted(t *tes
 }
 
 // TestWorkAssignmentReassignWorkBead_ByteIdentical asserts reassign emits only
-// Update{Assignee:&new}, byte-identical to the raw retire-reassign op.
+// Update{Assignee:&new}, byte-identical to the raw retire-reassign op. The bead
+// is seeded live because the reassign is conditional on the snapshot: an
+// unseeded fixture verifies as stale and emits no write at all.
 func TestWorkAssignmentReassignWorkBead_ByteIdentical(t *testing.T) {
 	rec := newRecordingWriteWorkStore()
+	item := beads.Bead{ID: "w-1", Status: "in_progress", Assignee: "retired-session"}
+	seedWriteWorkBead(t, rec, item)
 	wa := workAssignmentForStore(beads.WorkStore{Store: rec})
 
-	if err := wa.ReassignWorkBead("w-1", "new-session"); err != nil {
+	if err := wa.ReassignWorkBead(item, "new-session"); err != nil {
 		t.Fatalf("ReassignWorkBead: %v", err)
 	}
 	if len(rec.updates) != 1 {
@@ -208,7 +260,7 @@ func TestWorkAssignmentWrite_NilStoreSafe(t *testing.T) {
 	if err := wa.ReleaseWorkBead(beads.Bead{ID: "x"}, ""); err != nil {
 		t.Fatalf("nil store ReleaseWorkBead: %v", err)
 	}
-	if err := wa.ReassignWorkBead("x", "y"); err != nil {
+	if err := wa.ReassignWorkBead(beads.Bead{ID: "x"}, "y"); err != nil {
 		t.Fatalf("nil store ReassignWorkBead: %v", err)
 	}
 	if err := wa.ClearDetachedProbe("x"); err != nil { // must not panic


### PR DESCRIPTION
Two reconciler sweeps computed a work set from a `List` early in a tick, then wrote per bead. A worker can claim a bead in that gap, and both writes were unconditional:

- `ReleaseWorkBead` cleared an assignee it no longer owned and reset a bead someone was actively working.
- `ReassignWorkBead` stamped the retired session's successor over that live claim.

Neither reported an error, so the caller counted a destroyed claim as a completed unassign.

## The guard already existed

`beads.ConditionalAssignmentReleaser.ReleaseIfCurrent`, backed by bd's `--if-assignee`/`--if-status` CAS, is what the pool path already uses in `releaseOrphanedPoolAssignment`. The release mirrors that precedent rather than adding new plumbing:

- **tier 1** the store's atomic `ReleaseIfCurrent` when it has one. The verb swaps status and assignee itself, so the metadata clear rides a second write.
- **tier 2** no usable conditional verb, so re-read live state immediately before the unconditional write.

Tier 1 is bypassed whenever that second write would be routing-consequential, because between the two writes the bead is claimable in a half-released state: either unrouted, and so invisible to both the demand query and the orphan sweep (which scans only assigned work), or still carrying a continuation group that a concurrent claim will vacuum its siblings through. Both cases take the single-write path, which lands status, assignee and metadata in one `Update`.

Reassign has no conditional verb to reach for, since `ReleaseIfCurrent` only clears, so it takes the live re-read alone.

## Two details that are load-bearing

**The verification read is a live `List`, not `Get`.** `CachingStore.Get` serves a clone from the in-memory cache for a tracked, non-dirty bead, so a cached read would confirm the caller's stale snapshot against an equally stale cache and reproduce the bug behind a guard. That check is now one function shared with the pool path instead of two copies of the same subtlety.

**A failed read returns the error rather than a verdict.** Refusing to write costs one tick; reporting a write that did not happen lets `repairStrandedPoolWorkerBead` close a session bead while its work is still assigned to it, with nothing left watching the work. That is worse than the unconditional write this replaces, which at least propagated its `Update` error.

The capability is asserted on the unwrapped `Store`. A class wrapper does not promote optional capabilities, so asserting on the wrapper would silently take tier 2 forever.

## Tests

Both directions on both store shapes, conditional verb present and absent: a stale snapshot must not clobber a re-claim, and a current snapshot must still write. Plus backend-failure propagation on every tier, both disjuncts of the single-write bypass, the cached-read trap, and clobber/positive/error for reassign.

Every guard was checked by reverting it individually and confirming its own test fails. The existing byte-identity tests now seed the backing store so their snapshots are live-accurate, and all six test fakes carry a compile-time `ConditionalAssignmentReleaser` assertion, because they embed `*beads.MemStore`, which implements the interface itself. Without the assertion a signature drift would promote MemStore's method and silently reroute every assertion onto the other tier while still reporting green.

## Test plan

- `go test ./cmd/gc/ -run 'TestReleaseWorkBead|TestReassignWorkBead|TestWorkAssignment'` passes
- `make build`, `golangci-lint run ./...` (0 issues), `go vet ./...` clean
- `go test ./internal/testpolicy/resourcecensus/ ./scripts/cipolicy/ ./internal/testenv/` passes
- Full `cmd/gc` sweep produces zero `--- FAIL` lines. The package still exits non-zero from the post-suite dolt leak guard on three pre-existing leakers (`TestInitFromWithoutHostedPreservesTemplate`, `TestOneShotOrderReadsReachTheOrdersBinding`, `TestOrderSweepTrackingReachesTheOrdersBinding`). Verified identical on clean `origin/main` at `7be7f0aad`, and none of those tests are in the five files this changes.

## Not included

`internal/api/session_resolution.go`'s `reassignOpenWorkAssignedToSession` carries the same shape. It is materially narrower, since its `List` is already `Live:true` and sits in the same function as the writes, so the window is one loop iteration rather than a whole tick. Closing it properly means hoisting the shared verification helper into `internal/beads` so both layers use one implementation, which is a design call rather than a mechanical port. Left out deliberately.
