### PR TITLE
test(cmd/gc): stop the order-store routing fixtures leaking a dolt server

### DIFF
--- a/cmd/gc/order_dispatch_orders_store_test.go
+++ b/cmd/gc/order_dispatch_orders_store_test.go
@@ -476,6 +476,7 @@ func TestOrderTrackingWatchdogsReachTheOrdersBinding(t *testing.T) {
 // whose orders fire every few minutes as never having run.
 func TestOneShotOrderReadsReachTheOrdersBinding(t *testing.T) {
 	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	binding := beads.NewMemStore()
 	binding.IDPrefix = "gcg"
@@ -517,6 +518,7 @@ func TestOneShotOrderReadsReachTheOrdersBinding(t *testing.T) {
 // operator is trying to unwedge a city.
 func TestOrderSweepTrackingReachesTheOrdersBinding(t *testing.T) {
 	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	binding := beads.NewMemStore()
 	binding.IDPrefix = "gcg"


### PR DESCRIPTION
`cmd/gc`'s post-suite guard fails the whole package when a test leaks a `dolt sql-server`. Three tests leaked, so `cmd/gc` exited non-zero for everyone, on every run, and the repo's pre-push hook failed with it. That turns a real gate into one people learn to push past.

`TestOneShotOrderReadsReachTheOrdersBinding` and `TestOrderSweepTrackingReachesTheOrdersBinding` are two of the three. #5096 fixed the third.

## Why these leaked

Neither test is about dolt. Both inject their subject explicitly:

```go
binding := beads.NewMemStore()
binding.IDPrefix = "gcg"
resetCLIStorageRoutes(t)
entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
entry.once.Do(func() { entry.routes = messagingSplitRoutes(binding) })
```

The assertion is that `cachedOrderStoresResolver` and `cachedOrderHistoryStoresResolver` reach that binding. The dolt server was never the subject: it was ambient state started by the default backend while the resolvers were constructed, and nothing in the test ever stopped it.

Pinning the backend to `file` stops that stray server from starting. The binding under assertion is still the same `MemStore`, and the routing under assertion is unchanged, so this isolates the fixture rather than narrowing what the test covers.

## Evidence

Measured before and after against clean `origin/main`, not inferred from the diff.

Without the change, on main:

```
cmd/gc test dolt leak guard: leaked 2 dolt sql-server process(es)
  pid=... TestOneShotOrderReadsReachTheOrdersBinding.../dolt-config.yaml
  pid=... TestOrderSweepTrackingReachesTheOrdersBinding.../dolt-config.yaml
FAIL	github.com/gastownhall/gascity/cmd/gc
```

With it:

```
ok  	github.com/gastownhall/gascity/cmd/gc
```

With #5096 also landed, the full package sweep is clean:

```
GC_FAST_UNIT=1 go test ./cmd/gc/ -count=1
ok  	github.com/gastownhall/gascity/cmd/gc	178.700s
```

That is the whole point of this change. Those were the last two leakers, so `cmd/gc` now exits zero and the pre-push hook passes. This branch was pushed with the hook enabled and no bypass.

## Test plan

- `go test ./cmd/gc/ -run 'TestOneShotOrderReadsReachTheOrdersBinding|TestOrderSweepTrackingReachesTheOrdersBinding'` passes with no leak; the same run on `origin/main` leaks both and fails
- Full `GC_FAST_UNIT=1 go test ./cmd/gc/` exits 0
- `go vet ./...` clean, `golangci-lint run ./...` reports 0 issues

## Note on the alternative

The deeper fix is for the no-start path to stop the server it starts, so no test has to know the backend matters. That belongs with whoever owns that lifecycle. This change is deliberately the smallest one that gets the package back to exiting zero.
