### PR TITLE
fix(session): thread liveness-probe observation into heal-state instead of hardcoding Observed:true

### DIFF
--- a/cmd/gc/session_r3_info_equiv_test.go
+++ b/cmd/gc/session_r3_info_equiv_test.go
@@ -28,14 +28,19 @@ func (s setMetadataBatchFailStore) SetMetadataBatch(string, map[string]string) e
 // healOracleCase is a heal fixture plus the runtime/clock/lease knobs the heal
 // patch reads and the exact batch the Info form must return.
 type healOracleCase struct {
-	name     string
-	status   string
-	created  time.Duration // relative to clk.Now(); 0 = zero time
-	meta     map[string]string
-	alive    bool
-	timeout  time.Duration
-	rollback bool
-	want     map[string]string
+	name    string
+	status  string
+	created time.Duration // relative to clk.Now(); 0 = zero time
+	meta    map[string]string
+	alive   bool
+	// unobserved marks the liveness probe itself as failed (RuntimeFacts.Observed
+	// = false), distinct from alive=false (probe succeeded, runtime confirmed
+	// dead). Zero value (false) preserves every existing case's prior hardcoded-
+	// Observed:true behavior unchanged.
+	unobserved bool
+	timeout    time.Duration
+	rollback   bool
+	want       map[string]string
 }
 
 // TestHealStatePatchWithRollbackInfo pins healStatePatchWithRollbackInfo against
@@ -140,6 +145,20 @@ func TestHealStatePatchWithRollbackInfo(t *testing.T) {
 			rollback: true,
 			want:     map[string]string{"continuation_reset_pending": "true", "primed_at": "", "priming_attempted_at": "", "prompt_hash": "", "session_key": "", "sleep_reason": "runtime-missing", "started_config_hash": "", "state": "asleep"},
 		},
+		{
+			// gascity#5121: a failed liveness probe (Observed=false) must not be
+			// treated as a confirmed-dead runtime. Before the fix this produced
+			// the same drain batch as a genuinely observed-dead alive=false case
+			// ({"sleep_reason": "runtime-missing", "state": "asleep"}), silently
+			// respawning a healthy long-lived session on every transient probe
+			// failure.
+			name:       "unobserved-liveness-preserves-active",
+			meta:       map[string]string{"state": "active"},
+			alive:      false,
+			unobserved: true,
+			rollback:   true,
+			want:       nil,
+		},
 	}
 
 	for _, tc := range cases {
@@ -152,7 +171,7 @@ func TestHealStatePatchWithRollbackInfo(t *testing.T) {
 			if tc.created != 0 {
 				b.CreatedAt = clk.Now().Add(tc.created)
 			}
-			got := healStatePatchWithRollbackInfo(seedSessionInfo(b), tc.alive, clk, tc.timeout, tc.rollback)
+			got := healStatePatchWithRollbackInfo(seedSessionInfo(b), tc.alive, !tc.unobserved, clk, tc.timeout, tc.rollback)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("healStatePatchWithRollbackInfo = %#v, want %#v", got, tc.want)
 			}
@@ -175,7 +194,7 @@ func TestHealStateWithRollbackInfoClosedGuardAndWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	closed, _ = store.Get(closed.ID)
-	batch, err := healStateWithRollbackInfo(sessiontest.SeedBead(t, closed), false, sessionFrontDoor(store), clk, 0, true)
+	batch, err := healStateWithRollbackInfo(sessiontest.SeedBead(t, closed), false, true, sessionFrontDoor(store), clk, 0, true)
 	if err != nil {
 		t.Fatalf("heal closed bead: %v", err)
 	}
@@ -187,7 +206,7 @@ func TestHealStateWithRollbackInfoClosedGuardAndWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	batch, err = healStateWithRollbackInfo(sessiontest.SeedBead(t, live), false, sessionFrontDoor(store), clk, 0, true)
+	batch, err = healStateWithRollbackInfo(sessiontest.SeedBead(t, live), false, true, sessionFrontDoor(store), clk, 0, true)
 	if err != nil {
 		t.Fatalf("heal live bead: %v", err)
 	}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -878,7 +878,7 @@ func mergeMetadataPatch(dst, src map[string]string) map[string]string {
 // pendingCreateLeaseExpiredForRollbackInfo, isNamedSessionInfo,
 // namedSessionModeInfo). Byte-identical to the bead form; the reconciler forward
 // pass folds the returned batch onto its coherent infoByID snapshot.
-func healStatePatchWithRollbackInfo(info sessionpkg.Info, alive bool, clk clock.Clock, startupTimeout time.Duration, rollbackAvailable bool) map[string]string {
+func healStatePatchWithRollbackInfo(info sessionpkg.Info, alive bool, observed bool, clk clock.Clock, startupTimeout time.Duration, rollbackAvailable bool) map[string]string {
 	var now time.Time
 	var staleCreatingAfter time.Duration
 	if clk != nil {
@@ -886,7 +886,7 @@ func healStatePatchWithRollbackInfo(info sessionpkg.Info, alive bool, clk clock.
 		staleCreatingAfter = staleCreatingStateTimeout
 	}
 	lcInput := sessionpkg.LifecycleInputFromInfo(info)
-	lcInput.Runtime = sessionpkg.RuntimeFacts{Observed: true, Alive: alive}
+	lcInput.Runtime = sessionpkg.RuntimeFacts{Observed: observed, Alive: alive}
 	lcInput.CreatedAt = info.CreatedAt
 	lcInput.StaleCreatingAfter = staleCreatingAfter
 	lcInput.Now = now
@@ -959,14 +959,14 @@ func healStatePatchWithRollbackInfo(info sessionpkg.Info, alive bool, clk clock.
 // healStateWithRollbackInfo computes and persists an advisory-state heal.
 // Callers may fold the returned patch only when err is nil; an error leaves
 // their current projection authoritative for the rest of the pass.
-func healStateWithRollbackInfo(info sessionpkg.Info, alive bool, sessFront *sessionpkg.Store, clk clock.Clock, startupTimeout time.Duration, rollbackAvailable bool) (map[string]string, error) {
+func healStateWithRollbackInfo(info sessionpkg.Info, alive bool, observed bool, sessFront *sessionpkg.Store, clk clock.Clock, startupTimeout time.Duration, rollbackAvailable bool) (map[string]string, error) {
 	// Closed beads are terminal; their advisory state metadata should not move
 	// (matches healStateWithRollback's session.Status == "closed" guard —
 	// Info.Closed is the projected mirror).
 	if info.Closed {
 		return nil, nil
 	}
-	batch := healStatePatchWithRollbackInfo(info, alive, clk, startupTimeout, rollbackAvailable)
+	batch := healStatePatchWithRollbackInfo(info, alive, observed, clk, startupTimeout, rollbackAvailable)
 	if len(batch) == 0 {
 		return nil, nil
 	}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -124,7 +124,7 @@ func healStateInfo(session *beads.Bead, alive bool, sessFront *sessionpkg.Store,
 	if session == nil {
 		return
 	}
-	batch, err := healStateWithRollbackInfo(seedSessionInfo(*session), alive, sessFront, clk, 0, true)
+	batch, err := healStateWithRollbackInfo(seedSessionInfo(*session), alive, true, sessFront, clk, 0, true)
 	if err != nil {
 		panic("healStateInfo: " + err.Error())
 	}
@@ -139,7 +139,7 @@ func healStateInfo(session *beads.Bead, alive bool, sessFront *sessionpkg.Store,
 // healStatePatchFromBead is the test shim for the retired raw healStatePatch /
 // healStatePatchWithRollback: it projects the bead to Info and calls the Info form.
 func healStatePatchFromBead(session beads.Bead, alive bool, clk clock.Clock, startupTimeout time.Duration) map[string]string {
-	return healStatePatchWithRollbackInfo(seedSessionInfo(session), alive, clk, startupTimeout, true)
+	return healStatePatchWithRollbackInfo(seedSessionInfo(session), alive, true, clk, startupTimeout, true)
 }
 
 // syncBeadFromStore mirrors the persisted metadata writes for session.ID back

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1844,7 +1844,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			stateBeforeHeal := strings.TrimSpace(infoByID[id].MetadataState)
 			pendingCreateStartedAtBeforeHeal := strings.TrimSpace(infoByID[id].PendingCreateStartedAt)
 			lastWokeAtBeforeHeal := strings.TrimSpace(infoByID[id].LastWokeAt)
-			healBatch, healErr := healStateWithRollbackInfo(infoByID[id], providerAlive, sessFront, clk, startupTimeout, !storeQueryPartial)
+			healBatch, healErr := healStateWithRollbackInfo(infoByID[id], providerAlive, livenessErr == nil, sessFront, clk, startupTimeout, !storeQueryPartial)
 			if healErr != nil {
 				fmt.Fprintf(stderr, "healState: SetMetadataBatch %s: %v\n", id, healErr) //nolint:errcheck
 				continue
@@ -2620,7 +2620,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		stateBeforeHeal := sessionpkg.State(strings.TrimSpace(infoByID[id].MetadataState))
 		pendingCreateStartedAtBeforeHeal := strings.TrimSpace(infoByID[id].PendingCreateStartedAt)
 		lastWokeAtBeforeHeal := strings.TrimSpace(infoByID[id].LastWokeAt)
-		healBatch, healErr := healStateWithRollbackInfo(infoByID[id], alive, sessFront, clk, startupTimeout, true)
+		healBatch, healErr := healStateWithRollbackInfo(infoByID[id], alive, true, sessFront, clk, startupTimeout, true)
 		if healErr != nil {
 			fmt.Fprintf(stderr, "healState: SetMetadataBatch %s: %v\n", id, healErr) //nolint:errcheck
 			continue


### PR DESCRIPTION
## Summary

Fixes #5121: the reconciler's heal-state path hardcoded `RuntimeFacts.Observed: true`, so a failed liveness probe (couldn't tell if a session was alive) was treated identically to a *confirmed*-dead runtime. Every other destructive decision in the same reconciler pass already fails closed on a liveness-observation error (pending-create rollback, failed-create close, drain-ack finalize, close) — the heal-state call site at `session_reconciler.go:1847` was the one path that dropped the error signal, hardcoding `Observed: true` regardless of whether the probe actually succeeded.

Under fleet load, a transient probe failure would drain and respawn a healthy long-lived session — since the affected templates use `wake_mode: fresh`, the reconciler replaced rather than resumed, killing any in-flight foreground work. The issue's own trace shows 22 false-positive respawns in one day across every long-lived agent.

## What changed

- `healStatePatchWithRollbackInfo` / `healStateWithRollbackInfo` now take an `observed bool` parameter, threaded through as `livenessErr == nil` at the reported call site.
- `RuntimeFacts.Observed` and the existing `RuntimeProjectionUnknown` branch ("take no action") in `internal/session/lifecycle_projection.go` already handled this case correctly — nothing there needed to change, only the caller that never set it accurately.
- A second call site for the same function (`session_reconciler.go:2623`) is fed by an older probe (`observeRuntimeProviderLiveness`) that returns no error signal at all (`(running, alive bool)`, no `error`). Left at `observed: true` to preserve its exact current behavior — extending it isn't evidenced by #5121's trace/line citations and would need its own investigation into whether that probe should grow an error return.

## Testing

- New pinned regression case (`unobserved-liveness-preserves-active` in `cmd/gc/session_r3_info_equiv_test.go`): alive=false + unobserved=true on an active session now returns a nil batch (no-op). Before the fix, this produced the same `{state: asleep, sleep_reason: runtime-missing}` drain as a genuinely-dead session.
- Full `cmd/gc` build + `go vet ./...` clean.
- Targeted heal-state/reconciler test suite: 100% pass, no regressions.
- Full 6-way sharded `cmd/gc` run: 9 failures surfaced across 4 of 6 shards; all 9 reproduced in isolation — 7 confirmed as parallel-shard resource contention (pass standalone), the remaining 2 (`TestResolveImportRootFallsBackToStandalonePackDir`/`TestResolveImportRootPrefersNearestPackUnderCity`, a macOS `/var/folders` vs `/private/var/folders` symlink artifact; and `TestRunStartDriftCheck_DelegatedTryRestartTimeoutThenReplacementSucceeds`, a missing `GC_SUPERVISOR_SYSTEMD_UNIT` env var) reproduce identically on clean `main` before this change.
- Base commit `0b73be294`, confirmed no upstream changes to the touched files since (`cmd/gc/session_reconcile.go`, `cmd/gc/session_reconciler.go`, `cmd/gc/session_reconcile_test.go`, `cmd/gc/session_r3_info_equiv_test.go`) via `git log 0b73be294..origin/main -- <files>` (empty).

---

Generated with [Claude Code](https://claude.com/claude-code)
