### PR TITLE
refactor(beads): lift the by-id class resolver out of internal/api (ga-ia7li)

### DIFF
--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -43,15 +43,18 @@ import (
 // Some invariants name a capability main does not have yet. Those SKIP with the
 // reason and the seam that is missing, rather than being quietly omitted or
 // asserted against a seam that does not exist. The skip list is this program's
-// verified remaining work.
+// verified remaining work, and it is currently EMPTY: I5's claim-mutation half
+// was the last entry, and it closed when the shared by-id class resolver landed
+// (storeref.ClassCandidates, ga-ia7li). A new gap gets a skip, not a deletion.
 //
 // Others pin behavior main HAS but should not keep. Those carry a KNOWN GAP
 // paragraph naming the divergence, the assertions that move when it closes, and
 // the slice that closes it — I1 and I2 (the HQ work store is in neither arm of
-// the controller's cross-store scan on a split city) and I10 (the wake filter
-// has no coordination-class reachability arm). Leaving such a leg UNSEEDED is
-// the failure mode this convention exists to prevent: the invariant then reads
-// as coverage of a path it never touches.
+// the controller's cross-store scan on a split city), I5 (`gc hook --claim`
+// does not consume the shared resolver yet) and I10 (the wake filter has no
+// coordination-class reachability arm). Leaving such a leg UNSEEDED is the
+// failure mode this convention exists to prevent: the invariant then reads as
+// coverage of a path it never touches.
 //
 // # Which authority an invariant is pinning
 //
@@ -391,14 +394,27 @@ func conformanceMaterializationResidence(t *testing.T, e splitEnv) {
 // asserted as a negative here so it cannot change silently under a future
 // resolver.
 //
-// The CLAIM-MUTATION half is SKIPPED — the seam does not exist on main.
-// `gc hook --claim` resolves its stores as hookStore{dir, env} pairs
-// (hook_cross_store.go) and execs bd in a work directory; the fan-out is city +
-// rigs, all of them WORK scopes, with no coordination-class arm anywhere on the
-// path. The only by-id class resolver in the tree is Server.beadStoresForID
-// (internal/api/handler_beads.go), method-bound to the API server and graph-only.
-// Lifting it into a shared resolver is the next slice in this program (ga-ia7li,
-// which this work blocks).
+// The CLAIM-MUTATION half runs on the SHARED resolver, storeref.ClassCandidates
+// (ga-ia7li), which is the seam this invariant was waiting on: a candidate list
+// keyed on the resolveClassStore identity, probed in order, with the mutation
+// written through the store that answered. splitEnv.claimByID is that shape, and
+// the assertion is residence — the claim is visible in the owning store and in
+// no other leg.
+//
+// KNOWN GAP, pinned rather than asserted as desirable — `gc hook --claim` does
+// not consume the resolver yet. It resolves its stores as hookStore{dir, env}
+// pairs (hook_cross_store.go) and execs bd in a work directory; the fan-out is
+// city + rigs, all WORK scopes, so a claim it issues for a relocated class id
+// still runs against a ledger that cannot see the bead. claimByID's own
+// fallback IS that fan-out, so the rows below state both answers side by side:
+// a class id routes, a work id keeps the legacy path byte-for-byte. Rewiring
+// the command is ga-xo8ch (class-routed writes from one-shot commands); when it
+// lands, this paragraph goes and the assertions move from claimByID to the
+// command.
+//
+// `gc bd update --claim` is already routed (#5132, cmd_bd_by_id.go) and probes
+// the same way, so the resolver is not the only class-aware claim path — it is
+// the one a caller holding just an id and a set of stores can use.
 func conformanceClaimRouting(t *testing.T, e splitEnv) {
 	workBead, err := e.work.Create(beads.Bead{Title: "claim-routing work bead", Type: "task"})
 	if err != nil {
@@ -426,7 +442,24 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 		if reservedClassNamespace(wisp.ID) {
 			t.Fatalf("single-store wisp %q sits in a reserved class namespace; a legacy city mints work-store ids", wisp.ID)
 		}
-		t.Skip("single-store collapse: there is no second store to route a claim to, and no coordination-class claim arm to route it with (ga-ia7li)")
+		// The single-store statement about the shared resolver: its identity
+		// gate (class store IS the work store) means it claims NOTHING here, so
+		// every by-id claim keeps running on the one store exactly as it does
+		// today. A resolver that answered on a legacy city would be routing a
+		// city with nowhere to route to.
+		for _, id := range []string{workBead.ID, wisp.ID} {
+			if got := e.classCandidatesForID(id); got != nil {
+				t.Fatalf("classCandidatesForID(%q) returned %d candidates on a single-store city; the resolver must be inert where the class store IS the work store", id, len(got))
+			}
+		}
+		for _, id := range []string{workBead.ID, wisp.ID} {
+			landed := e.claimByID(t, id, "single-store-claimant")
+			if !sameStorePtr(landed, e.work) {
+				t.Errorf("claim of %s landed in %p, want the single work store %p", id, landed, e.work)
+			}
+			e.assertClaimedIn(t, id, "single-store-claimant", e.work)
+		}
+		return
 	}
 
 	durable := mintDurableGraphBead(t, e, "claim-routing durable control bead", "")
@@ -472,7 +505,32 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 		t.Errorf("sling.BeadPrefixForCity(%q) = %q, want the reserved class prefix — the heuristic must at least agree with the namespace rule on the ORDINARY class id shape", durable.ID, got)
 	}
 
-	t.Skip("gc hook --claim has no coordination-class arm: hookStore is a (dir, env) bd scope pair over city+rigs, all work scopes. The shared by-id class resolver is ga-ia7li; until it lands there is no cmd/gc seam that routes a claim MUTATION by class.")
+	// The CLAIM MUTATION, through the shared resolver. Both class id shapes must
+	// route to the class store — including the wisp shape, which is where the
+	// heuristic pinned above disagrees — and the work id must keep the legacy
+	// work-scope fan-out. The negative matters more than the positive: a claim
+	// that ran against the store not holding the bead is the silent-no-op the
+	// work-scope fan-out performs on a split city today.
+	for _, tt := range []struct {
+		name, id  string
+		wantClass bool
+	}{
+		{"durable graph bead", durable.ID, true},
+		{"wisp (the -wisp- suffix shape)", wisp.ID, true},
+		{"work bead", workBead.ID, false},
+	} {
+		assignee := "claimant-" + tt.id
+		want := e.work
+		if tt.wantClass {
+			want = e.class
+		}
+		landed := e.claimByID(t, tt.id, assignee)
+		if !sameStorePtr(landed, want) {
+			t.Errorf("%s: the by-id claim of %s landed in %p, want %p (class store %p, work store %p)", tt.name, tt.id, landed, want, e.class, e.work)
+			continue
+		}
+		e.assertClaimedIn(t, tt.id, assignee, want)
+	}
 }
 
 // conformanceStrictCrossStoreDeps (I6) guards the cross-store dependency class:

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -384,15 +384,19 @@ func conformanceMaterializationResidence(t *testing.T, e splitEnv) {
 //
 // storeref.PrefixOwner is that routing primitive (internal/dispatch,
 // internal/convoy and cmd/gc/cmd_wait already route on it), and it resolves on
-// the store's own declared namespace — the prefix+"-" segment rule
-// internal/api's beadIDHasConfiguredPrefix applies too. This invariant pins that
-// both shapes route to the class store on a split city, and pins the TRAP that
-// makes the wisp shape special: the config-free sling.BeadPrefix heuristic
-// answers "gcg-wisp" for a gcg-wisp-0042 id, which is not a reserved class
-// prefix at all, so a by-id router built on that heuristic instead of the
-// namespace rule would hand every wisp to the work store. That divergence is
-// asserted as a negative here so it cannot change silently under a future
-// resolver.
+// the store's own declared namespace: the prefix+"-" SEGMENT rule. Its sibling
+// predicate storeref.IDInNamespace — the CONFIGURED-prefix rule the shared class
+// resolver gates on — is deliberately not the same rule, because a configured
+// rig/HQ prefix can be a whole id while a store that mints "gcg-1" never mints
+// the bare "gcg". They agree on every id shape this invariant routes and diverge
+// on the bare form, so nothing here may be read as one implying the other.
+// This invariant pins that both shapes route to the class store on a split
+// city, and pins the TRAP that makes the wisp shape special: the config-free
+// sling.BeadPrefix heuristic answers "gcg-wisp" for a gcg-wisp-0042 id, which is
+// not a reserved class prefix at all, so a by-id router built on that heuristic
+// instead of the namespace rule would hand every wisp to the work store. That
+// divergence is asserted as a negative here so it cannot change silently under a
+// future resolver.
 //
 // The CLAIM-MUTATION half runs on the SHARED resolver, storeref.ClassCandidates
 // (ga-ia7li), which is the seam this invariant was waiting on: a candidate list
@@ -412,6 +416,13 @@ func conformanceMaterializationResidence(t *testing.T, e splitEnv) {
 // lands, this paragraph goes and the assertions move from claimByID to the
 // command.
 //
+// The gap is ASSERTED and not merely described, the way I1, I2 and I10 assert
+// theirs: hookQueryEnv is the production seam that decides which store the
+// hook's claim runs against, and the row below pins that it answers a WORK scope
+// rooted at the city path on BOTH topologies — identically on a city whose graph
+// class lives in a binding of its own. A gap stated in prose and nowhere else
+// can close, or widen, without a single test moving.
+//
 // `gc bd update --claim` is already routed (#5132, cmd_bd_by_id.go) and probes
 // the same way, so the resolver is not the only class-aware claim path — it is
 // the one a caller holding just an id and a set of stores can use.
@@ -423,6 +434,25 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 	if reservedClassNamespace(workBead.ID) {
 		t.Fatalf("work bead %q sits in a reserved class namespace; by-id routing cannot be built on this id space", workBead.ID)
 	}
+	classPrefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("config.ReservedClassPrefix(graph) = ok:false; there is no reserved namespace for by-id class routing to run on")
+	}
+
+	// The KNOWN GAP above, pinned on both topologies: the store `gc hook
+	// --claim` runs its claim against is a WORK scope, resolved from cfg with no
+	// class arm anywhere in it. Relocating graph does not move it.
+	hookEnv, err := hookQueryEnv(e.cityPath, e.cfg, &config.Agent{Name: splitEnvPoolAgent})
+	if err != nil {
+		t.Fatalf("build the hook's work-query env: %v", err)
+	}
+	if got := hookEnv["GC_STORE_SCOPE"]; got != "city" {
+		t.Errorf("`gc hook --claim` resolves store scope %q, want \"city\" — if it now names a coordination class, the ga-xo8ch rewire has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", got)
+	}
+	if got := hookEnv["GC_STORE_ROOT"]; got != e.cityPath {
+		t.Errorf("`gc hook --claim` resolves store root %q, want the city work root %q — a claim it issues for a relocated class id runs against the work ledger, and that is the gap this row pins", got, e.cityPath)
+	}
+
 	if !e.split {
 		wisp := e.mintWisp(t, "claim-routing wisp")
 		// A legacy city mints no reserved-class ids at all, so there is nothing
@@ -447,9 +477,20 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 		// every by-id claim keeps running on the one store exactly as it does
 		// today. A resolver that answered on a legacy city would be routing a
 		// city with nowhere to route to.
-		for _, id := range []string{workBead.ID, wisp.ID} {
-			if got := e.classCandidatesForID(id); got != nil {
-				t.Fatalf("classCandidatesForID(%q) returned %d candidates on a single-store city; the resolver must be inert where the class store IS the work store", id, len(got))
+		//
+		// The rows are not interchangeable, and the class-shaped one is the only
+		// one that pins the IDENTITY gate. A legacy city's own ids sit outside
+		// the reserved namespace, so the NAMESPACE gate alone rejects them and
+		// those rows would still pass with the identity gate deleted. A
+		// class-shaped id clears the namespace gate, so identity is the only
+		// thing left that can reject it.
+		for _, tt := range []struct{ name, id string }{
+			{"work bead — namespace gate", workBead.ID},
+			{"wisp — namespace gate", wisp.ID},
+			{"class-shaped id — identity gate", classPrefix + "-1"},
+		} {
+			if got := e.classCandidatesForID(tt.id); got != nil {
+				t.Fatalf("%s: classCandidatesForID(%q) returned %d candidates on a single-store city; the resolver must be inert where the class store IS the work store", tt.name, tt.id, len(got))
 			}
 		}
 		for _, id := range []string{workBead.ID, wisp.ID} {

--- a/cmd/gc/split_topology_env_test.go
+++ b/cmd/gc/split_topology_env_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sling"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // This file is the two-topology fixture the split-store conformance suite
@@ -895,15 +896,99 @@ func assertRigPrefixDisjoint(t *testing.T, e splitEnv) {
 	}
 }
 
+// classCandidatesForID answers "which stores could hold this id" through the
+// SHARED by-id class resolver, storeref.ClassCandidates.
+//
+// The routing is keyed on the resolveClassStore identity this fixture already
+// derives everything from — graphStore() vs work — so the single-store topology
+// gets nil back and its by-id resolution stays byte-identical. The shadows are
+// the configured work prefixes (HQ, then each rig), which is what keeps a rig
+// whose prefix sits inside the class namespace reachable by id.
+func (e splitEnv) classCandidatesForID(id string) []beads.Store {
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		return nil
+	}
+	shadows := []storeref.PrefixedStore{{Prefix: config.EffectiveHQPrefix(e.cfg), Store: e.work}}
+	for _, rig := range e.cfg.Rigs {
+		if store := e.rigStores[rig.Name]; store != nil {
+			shadows = append(shadows, storeref.PrefixedStore{Prefix: rig.EffectivePrefix(), Store: store})
+		}
+	}
+	return storeref.ClassCandidates(id, storeref.ClassRouting{
+		Prefix:  prefix,
+		Class:   e.graphStore(),
+		Work:    e.work,
+		Shadows: shadows,
+	})
+}
+
+// claimByID runs the by-id claim MUTATION the way a class-aware caller has to:
+// take the candidate list from the shared resolver, PROBE it in order, and write
+// through the store that answered. An id the resolver does not claim falls back
+// to the work fan-out `gc hook --claim` uses today — city store then rig stores,
+// all work scopes — which is also the whole of the single-store path.
+//
+// It returns the store the claim landed in, so the caller can assert residence
+// rather than assert that some write succeeded somewhere.
+func (e splitEnv) claimByID(t *testing.T, id, assignee string) beads.Store {
+	t.Helper()
+	candidates := e.classCandidatesForID(id)
+	if len(candidates) == 0 {
+		candidates = append(candidates, e.work)
+		for _, rig := range e.cfg.Rigs {
+			if store := e.rigStores[rig.Name]; store != nil {
+				candidates = append(candidates, store)
+			}
+		}
+	}
+	inProgress := "in_progress"
+	for _, store := range candidates {
+		if _, err := store.Get(id); err != nil {
+			continue
+		}
+		if err := store.Update(id, beads.UpdateOpts{Assignee: &assignee, Status: &inProgress}); err != nil {
+			t.Fatalf("claiming %s through the resolved store: %v", id, err)
+		}
+		return store
+	}
+	t.Fatalf("no candidate store held %s: the by-id claim had nowhere to run (candidates %d)", id, len(candidates))
+	return nil
+}
+
+// assertClaimedIn asserts the claim on id is visible in want and in no other
+// leg — the residence half of a routed mutation, which a write that merely
+// "succeeded" does not establish.
+func (e splitEnv) assertClaimedIn(t *testing.T, id, assignee string, want beads.Store) {
+	t.Helper()
+	legs := map[string]beads.Store{"work": e.work}
+	if e.split {
+		legs["class"] = e.class
+	}
+	for name, store := range legs {
+		got, err := store.Get(id)
+		if err != nil {
+			continue
+		}
+		holds := strings.TrimSpace(got.Assignee) == assignee
+		if sameStorePtr(store, want) && !holds {
+			t.Errorf("%s store holds %s with assignee %q, want %q — the claim did not land in the store that owns the bead", name, id, got.Assignee, assignee)
+		}
+		if !sameStorePtr(store, want) && holds {
+			t.Errorf("%s store holds %s claimed for %q; the mutation ran against a store that does not own the bead", name, id, assignee)
+		}
+	}
+}
+
 // reservedClassNamespace reports whether an id sits inside a reserved
 // coordination class's id namespace.
 //
 // It applies the prefix+"-" SEGMENT rule — the same one storeref.PrefixOwner
-// routes on and internal/api's beadIDHasConfiguredPrefix matches on — and
-// deliberately NOT the config-free sling.BeadPrefix heuristic, which answers
-// "gcg-wisp" for a gcg-wisp-0042 id and would call it unreserved. That
-// divergence is real and is pinned as a negative by I5; a residence assertion
-// built on the heuristic would report every wisp as a boundary violation.
+// routes on — and deliberately NOT the config-free sling.BeadPrefix heuristic,
+// which answers "gcg-wisp" for a gcg-wisp-0042 id and would call it unreserved.
+// That divergence is real and is pinned as a negative by I5; a residence
+// assertion built on the heuristic would report every wisp as a boundary
+// violation.
 func reservedClassNamespace(id string) bool {
 	id = strings.ToLower(strings.TrimSpace(id))
 	for _, prefix := range config.ReservedClassPrefixes() {

--- a/internal/api/class_store_test.go
+++ b/internal/api/class_store_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -148,6 +149,11 @@ func TestBeadStoresForIDClassArmBeatsCityRouteCapture(t *testing.T) {
 // through), so that rig's beads are real; a list that dropped it made every one
 // of them unreachable by id the moment graph relocated. That was carried minor
 // (a) from PR #5128's council, and this is where it is closed.
+//
+// It goes behind the CITY store too, so [graph, city] — the whole of the
+// pre-seam list — stays the head. The handlers fail a by-id read fast on a
+// non-ErrNotFound probe, so a leg inserted ahead of the city store would let
+// that rig's outage answer for a bead the city store was serving.
 func TestBeadStoresForIDClassArmBeatsShadowingRigPrefix(t *testing.T) {
 	st, graph, city, rig := relocatedGraphRouteState(t)
 	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
@@ -158,8 +164,8 @@ func TestBeadStoresForIDClassArmBeatsShadowingRigPrefix(t *testing.T) {
 
 	s := New(st)
 	got := s.beadStoresForID(prefix + "-1")
-	if len(got) != 3 || got[0] != graph || got[1] != rig || got[2] != city {
-		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, rig, city]; graph is %p, rig is %p, city is %p", prefix, got, len(got), graph, rig, city)
+	if len(got) != 3 || got[0] != graph || got[1] != city || got[2] != rig {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, city, rig]; graph is %p, city is %p, rig is %p", prefix, got, len(got), graph, city, rig)
 	}
 }
 
@@ -169,8 +175,9 @@ func TestBeadStoresForIDClassArmBeatsShadowingRigPrefix(t *testing.T) {
 // fires — and used to return [graph, city], silently losing the rig store that
 // declares the longer prefix and actually mints the id.
 //
-// The rig sorts ahead of the city store because it is the more specific
-// declared owner, and behind the class store, which is never captured.
+// The rig is appended behind the pre-seam [graph, city] head: it is a leg this
+// slice ADDS, and an added leg extends reachability rather than re-answering an
+// id the old list already resolved.
 func TestBeadStoresForIDClassArmKeepsLongerRigPrefix(t *testing.T) {
 	st, graph, city, rig := relocatedGraphRouteState(t)
 	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
@@ -182,8 +189,80 @@ func TestBeadStoresForIDClassArmKeepsLongerRigPrefix(t *testing.T) {
 
 	s := New(st)
 	got := s.beadStoresForID(longer + "-1")
-	if len(got) != 3 || got[0] != graph || got[1] != rig || got[2] != city {
-		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, rig, city]; graph is %p, rig is %p, city is %p", longer, got, len(got), graph, rig, city)
+	if len(got) != 3 || got[0] != graph || got[1] != city || got[2] != rig {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, city, rig]; graph is %p, city is %p, rig is %p", longer, got, len(got), graph, city, rig)
+	}
+}
+
+// getFailStore is a store whose by-id read fails HARD — the shape an
+// unreachable rig backend takes on the by-id probe path, as distinct from a
+// clean ErrNotFound miss.
+type getFailStore struct {
+	beads.Store
+	err error
+}
+
+func (s getFailStore) Get(string) (beads.Bead, error) { return beads.Bead{}, s.err }
+
+// TestBeadGetSurvivesAShadowingRigOutage is the availability half of the
+// shadowing-store fix, and the reason the added legs go LAST.
+//
+// The by-id handlers fail fast on a non-ErrNotFound probe: an unreachable store
+// must not be reported as a missing bead, and where two stores claim one
+// namespace it must not be silently replaced by the other store's row of the
+// same id. That rule costs availability the moment a leg is inserted AHEAD of a
+// store that was answering — a rig outage would then 500 a read the city store
+// had been serving. Appending the shadows behind [graph, city] is what removes
+// that exposure, and this drives it through the real handler.
+func TestBeadGetSurvivesAShadowingRigOutage(t *testing.T) {
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	st, _, city, rig := relocatedGraphRouteState(t)
+	st.cfg.Rigs[0].Prefix = prefix
+	st.stores["myrig"] = getFailStore{Store: rig, err: errors.New("rig backend unreachable")}
+
+	memCity, isMem := city.(*beads.MemStore)
+	if !isMem {
+		t.Fatalf("fixture city store is %T, want *beads.MemStore so the test can pin its minted prefix", city)
+	}
+	memCity.IDPrefix = prefix
+	created, err := memCity.Create(beads.Bead{Title: "city work bead in the class namespace"})
+	if err != nil {
+		t.Fatalf("seeding the city store: %v", err)
+	}
+
+	out, err := New(st).humaHandleBeadGet(context.Background(), &BeadGetInput{ID: created.ID})
+	if err != nil {
+		t.Fatalf("GET bead %s: %v — an unrelated rig's outage answered for a bead the city store holds", created.ID, err)
+	}
+	if out.Body.ID != created.ID {
+		t.Fatalf("resolved bead id = %q, want %q", out.Body.ID, created.ID)
+	}
+}
+
+// TestBeadStoresForIDDoesNotCoverMigratedLegacyIDs pins the limitation the
+// resolver's doc now states instead of the coverage the doc used to claim.
+//
+// `gc storage migrate` copies the work store's infrastructure slice with ids
+// PRESERVED and never deletes the source (infra_class_migrate.go). So a
+// relocated bead can carry an HQ-prefixed id — which is OUTSIDE the class
+// namespace, so the class arm never fires for it, and the configured-prefix
+// resolver answers it from the work store's retained copy. The relocated store
+// is not even a candidate.
+//
+// cmd/gc/cmd_bd_by_id.go covers this case the other way, by probing residence
+// for every id rather than routing on the prefix. This path has no equivalent;
+// the assertion exists so the gap cannot be forgotten or silently closed.
+func TestBeadStoresForIDDoesNotCoverMigratedLegacyIDs(t *testing.T) {
+	st, graph, city, _ := relocatedGraphRouteState(t)
+	st.cfg.Workspace.Prefix = "mc"
+
+	s := New(st)
+	got := s.beadStoresForID("mc-123")
+	if len(got) != 1 || got[0] != city {
+		t.Fatalf("beadStoresForID(mc-123) = %v (len %d), want only the city work store %p — a legacy-prefixed id is outside the class namespace; graph is %p", got, len(got), city, graph)
 	}
 }
 

--- a/internal/api/class_store_test.go
+++ b/internal/api/class_store_test.go
@@ -141,7 +141,13 @@ func TestBeadStoresForIDClassArmBeatsCityRouteCapture(t *testing.T) {
 // the other way a work store can name a reserved prefix: a rig configured with
 // the class prefix itself. config.ReservedPrefixWarnings allows that today but
 // documents the class store as the owner once relocation is active, so on a
-// relocated city the class arm — not the shadowing rig — answers.
+// relocated city the class arm — not the shadowing rig — answers FIRST.
+//
+// The shadowing rig store still has to be IN the list, behind the class store.
+// The prefix is warned-and-allowed, not rejected (config.ValidateRigs lets it
+// through), so that rig's beads are real; a list that dropped it made every one
+// of them unreachable by id the moment graph relocated. That was carried minor
+// (a) from PR #5128's council, and this is where it is closed.
 func TestBeadStoresForIDClassArmBeatsShadowingRigPrefix(t *testing.T) {
 	st, graph, city, rig := relocatedGraphRouteState(t)
 	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
@@ -152,8 +158,72 @@ func TestBeadStoresForIDClassArmBeatsShadowingRigPrefix(t *testing.T) {
 
 	s := New(st)
 	got := s.beadStoresForID(prefix + "-1")
-	if len(got) != 2 || got[0] != graph || got[1] != city {
-		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, city]; shadowing rig store is %p", prefix, got, len(got), rig)
+	if len(got) != 3 || got[0] != graph || got[1] != rig || got[2] != city {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, rig, city]; graph is %p, rig is %p, city is %p", prefix, got, len(got), graph, rig, city)
+	}
+}
+
+// TestBeadStoresForIDClassArmKeepsLongerRigPrefix closes carried minor (b): an
+// id under a LONGER configured prefix that starts with the reserved one is
+// inside the class namespace by the exact-or-hyphen rule, so the class arm
+// fires — and used to return [graph, city], silently losing the rig store that
+// declares the longer prefix and actually mints the id.
+//
+// The rig sorts ahead of the city store because it is the more specific
+// declared owner, and behind the class store, which is never captured.
+func TestBeadStoresForIDClassArmKeepsLongerRigPrefix(t *testing.T) {
+	st, graph, city, rig := relocatedGraphRouteState(t)
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	longer := prefix + "-alpha"
+	st.cfg.Rigs[0].Prefix = longer
+
+	s := New(st)
+	got := s.beadStoresForID(longer + "-1")
+	if len(got) != 3 || got[0] != graph || got[1] != rig || got[2] != city {
+		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want [graph, rig, city]; graph is %p, rig is %p, city is %p", longer, got, len(got), graph, rig, city)
+	}
+}
+
+// TestBeadGetResolvesAShadowingRigID is the mutation proof behind the two
+// carried minors: a bead that exists ONLY in a rig whose configured prefix sits
+// inside the relocated class namespace must still resolve through the handler
+// the by-id candidate list feeds. Before the fix the rig store was not a
+// candidate at all, so this read 404'd.
+func TestBeadGetResolvesAShadowingRigID(t *testing.T) {
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	for _, rigPrefix := range []string{prefix, prefix + "-alpha"} {
+		t.Run(rigPrefix, func(t *testing.T) {
+			st, graph, city, rig := relocatedGraphRouteState(t)
+			st.cfg.Rigs[0].Prefix = rigPrefix
+			memRig, isMem := rig.(*beads.MemStore)
+			if !isMem {
+				t.Fatalf("fixture rig store is %T, want *beads.MemStore so the test can pin its minted prefix", rig)
+			}
+			memRig.IDPrefix = rigPrefix
+			created, err := memRig.Create(beads.Bead{Title: "rig work bead in the class namespace"})
+			if err != nil {
+				t.Fatalf("seeding the rig store: %v", err)
+			}
+			for name, other := range map[string]beads.Store{"graph": graph, "city": city} {
+				if _, err := other.Get(created.ID); err == nil {
+					t.Fatalf("the %s store also holds %s; the fixture proves nothing", name, created.ID)
+				}
+			}
+
+			out, err := New(st).humaHandleBeadGet(context.Background(), &BeadGetInput{ID: created.ID})
+			if err != nil {
+				t.Fatalf("GET bead %s: %v — a shadowing rig's bead is unreachable by id on a relocated city", created.ID, err)
+			}
+			if out.Body.ID != created.ID {
+				t.Fatalf("resolved bead id = %q, want %q", out.Body.ID, created.ID)
+			}
+		})
 	}
 }
 

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -16,6 +16,7 @@ import (
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sling"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 func appendMetadataAttachedChildren(store beads.Store, parent beads.Bead, children []beads.Bead) []beads.Bead {
@@ -161,35 +162,31 @@ func (s *Server) findStore(rig string) beads.Store {
 // the bead's class+rig store), and the unrouted fallback leads with the
 // city/HQ store ahead of the per-rig work stores. A graph-relocated city is
 // resolved by the class-prefix arm, which runs first so a reserved class prefix
-// can never be captured by a rig/HQ prefix or a routes.jsonl entry.
+// can never be captured by a rig/HQ prefix or a routes.jsonl entry — but that
+// arm returns a probe LIST, not a route, so a work store configured with the
+// reserved prefix keeps its own ids reachable behind the class store.
 func (s *Server) beadStoresForID(id string) []beads.Store {
 	id = strings.TrimSpace(id)
+	// Built once and shared by both prefix resolvers below: they answer
+	// different questions about the same set of configured work prefixes, and
+	// this is the walk of cfg.Rigs the pre-seam code already did.
+	configured := s.configuredPrefixStores()
 
 	// Class-prefix arm: a graph-relocated city keeps graph-class beads (reserved
 	// id-prefix "gcg") in a dedicated graph store, which is the only store that
-	// mints and owns that prefix. The arm runs FIRST — ahead of the configured
-	// prefix and routes.jsonl resolvers — because both of those can name the
-	// reserved prefix and would otherwise hand a class id to a work store: a
-	// routed prefix wins unconditionally, and a shadowing rig/HQ prefix is
-	// warned-but-allowed (config.ReservedPrefixWarnings), which documents the
-	// class store as the owner once relocation is active. Return [graph, work] —
-	// graph-first (prefix-owner first) — so the per-store Get-then-mutate loop in
-	// the by-id handlers federates the graph store ahead of work and pins it on
-	// the first probe. Skipped for a default (non-relocated) city, where
-	// GraphBeadStore() == CityBeadStore(): the arm never fires and this path
-	// stays byte-identical.
-	if graph := s.state.GraphBeadStore().Store; graph != nil {
-		if city := s.state.CityBeadStore(); graph != city {
-			if prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph); ok && beadIDHasConfiguredPrefix(id, prefix) {
-				if city != nil {
-					return []beads.Store{graph, city}
-				}
-				return []beads.Store{graph}
-			}
-		}
+	// MINTS that prefix. The arm runs FIRST — ahead of the configured prefix and
+	// routes.jsonl resolvers — because both of those can name the reserved prefix
+	// and would otherwise hand a class id to a work store: a routed prefix wins
+	// unconditionally, and a shadowing rig/HQ prefix is warned-but-allowed
+	// (config.ReservedPrefixWarnings), which documents the class store as the
+	// owner once relocation is active. Skipped for a default (non-relocated)
+	// city, where GraphBeadStore() == CityBeadStore(): the arm never fires and
+	// this path stays byte-identical.
+	if candidates := s.classStoresForID(id, configured); len(candidates) > 0 {
+		return candidates
 	}
 
-	if store := s.resolveStoreByConfiguredIDPrefix(id); store != nil {
+	if store := resolveStoreByConfiguredIDPrefix(id, configured); store != nil {
 		return []beads.Store{store}
 	}
 	if prefix := beadPrefix(id); prefix != "" {
@@ -210,55 +207,89 @@ func (s *Server) beadStoresForID(id string) []beads.Store {
 	return candidates
 }
 
-func (s *Server) resolveStoreByConfiguredIDPrefix(id string) beads.Store {
-	if id == "" {
+// classStoresForID returns the by-id candidate probe list for a relocated
+// coordination class, or nil when id is not a relocated class id.
+//
+// It delegates to storeref.ClassCandidates, the shared resolver: the same
+// question is asked by cmd/gc's one-shot commands, and answering it twice is
+// exactly how the split-store bug class reproduces. The routing is keyed on
+// STORE IDENTITY (GraphBeadStore() != CityBeadStore()) rather than a marker
+// file, so a MIGRATED city — where infra_class_migrate.go deliberately preserves
+// legacy ids, and a relocated bead can still carry its HQ/rig-era prefix — is
+// resolved by probing the returned list rather than by trusting the prefix.
+//
+// GRAPH ONLY. Sessions, orders and nudges have relocated-store accessors on
+// State, but adding them here would change which stores answer for gcs-/gco-/
+// gcn- ids, which is a production routing change and not part of lifting this
+// arm. Messaging has no State accessor at all (mail routes through
+// mail.Provider). The shared resolver takes the prefix as data, so adding a
+// class is a call-site change here, not a change to the resolver.
+func (s *Server) classStoresForID(id string, configured []storeref.PrefixedStore) []beads.Store {
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
 		return nil
 	}
+	return storeref.ClassCandidates(id, storeref.ClassRouting{
+		Prefix:  prefix,
+		Class:   s.state.GraphBeadStore().Store,
+		Work:    s.state.CityBeadStore(),
+		Shadows: configured,
+	})
+}
+
+// configuredPrefixStores returns the loaded work stores paired with the id
+// prefixes they were CONFIGURED with — the city/HQ prefix first, then each rig
+// in config order.
+//
+// Only stores that are actually loaded are listed: a configured prefix whose
+// store is missing must not win a slot, so a shorter loaded prefix can still own
+// an id (and otherwise the id is left to the legacy scan).
+func (s *Server) configuredPrefixStores() []storeref.PrefixedStore {
 	cfg := s.state.Config()
 	if cfg == nil {
 		return nil
 	}
-
-	// Only stores that are actually loaded are candidates: a configured prefix
-	// whose store is missing must not win the slot, so a shorter loaded prefix
-	// can still own the id (and otherwise the id is left to the legacy scan).
-	//
-	// This caller routes on the configured (rig/HQ) prefixes with a
-	// longest-prefix, exact-or-hyphen match (beadIDHasConfiguredPrefix). It
-	// resolves against the configured prefixes (not each store's own IDPrefix)
-	// and requires the longest configured prefix to win, so it keeps the scan
-	// inline rather than using the namespace-only, first-match by-id resolver.
-	var bestStore beads.Store
-	bestLen := -1
-	if prefix := strings.TrimSpace(config.EffectiveHQPrefix(cfg)); beadIDHasConfiguredPrefix(id, prefix) {
-		if cityStore := s.state.CityBeadStore(); cityStore != nil {
-			bestStore = cityStore
-			bestLen = len(prefix)
-		}
+	prefixed := make([]storeref.PrefixedStore, 0, len(cfg.Rigs)+1)
+	if cityStore := s.state.CityBeadStore(); cityStore != nil {
+		prefixed = append(prefixed, storeref.PrefixedStore{
+			Prefix: strings.TrimSpace(config.EffectiveHQPrefix(cfg)),
+			Store:  cityStore,
+		})
 	}
 	for _, rig := range cfg.Rigs {
-		prefix := strings.TrimSpace(rig.EffectivePrefix())
-		if !beadIDHasConfiguredPrefix(id, prefix) || len(prefix) <= bestLen {
-			continue
-		}
 		store := s.state.BeadStore(rig.Name)
 		if store == nil {
 			continue
 		}
-		bestStore = store
-		bestLen = len(prefix)
+		prefixed = append(prefixed, storeref.PrefixedStore{
+			Prefix: strings.TrimSpace(rig.EffectivePrefix()),
+			Store:  store,
+		})
 	}
-	return bestStore
+	return prefixed
 }
 
-// beadIDHasConfiguredPrefix reports whether id falls under prefix, matching a
-// bare id == prefix exactly or the "prefix-" namespace. This is the
-// exact-or-hyphen match the configured-prefix resolver uses.
-func beadIDHasConfiguredPrefix(id, prefix string) bool {
-	if prefix == "" {
-		return false
+// resolveStoreByConfiguredIDPrefix routes an id on the configured (rig/HQ)
+// prefixes with a longest-prefix, exact-or-hyphen match
+// (storeref.IDInNamespace). It resolves against the configured prefixes, not
+// each store's own IDPrefix, and requires the longest configured prefix to win
+// — so it is not the namespace-only, first-match storeref.PrefixOwner. Ties keep
+// config order (HQ first), which cannot arise between distinct prefixes: two
+// prefixes of equal length never cover the same id.
+func resolveStoreByConfiguredIDPrefix(id string, configured []storeref.PrefixedStore) beads.Store {
+	if id == "" {
+		return nil
 	}
-	return id == prefix || strings.HasPrefix(id, prefix+"-")
+	var bestStore beads.Store
+	bestLen := -1
+	for _, candidate := range configured {
+		if !storeref.IDInNamespace(id, candidate.Prefix) || len(candidate.Prefix) <= bestLen {
+			continue
+		}
+		bestStore = candidate.Store
+		bestLen = len(candidate.Prefix)
+	}
+	return bestStore
 }
 
 // resolveStoreByPrefix finds the store that owns a bead prefix by checking

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -164,12 +164,22 @@ func (s *Server) findStore(rig string) beads.Store {
 // resolved by the class-prefix arm, which runs first so a reserved class prefix
 // can never be captured by a rig/HQ prefix or a routes.jsonl entry — but that
 // arm returns a probe LIST, not a route, so a work store configured with the
-// reserved prefix keeps its own ids reachable behind the class store.
+// reserved prefix keeps its own ids reachable behind the class store and the
+// city store.
+//
+// The handlers probe this list in order and stop at the first store that
+// answers, and they surface a non-ErrNotFound read as a 500 rather than
+// continuing — an unreachable store must not be reported as a missing bead, and
+// on a city where two stores claim one namespace it must not be silently
+// replaced by the other store's row of the same id. The class arm's list is
+// ordered so that the legs it ADDS sit behind the ones this resolver already
+// returned, which is what keeps that fail-fast rule from costing availability:
+// an added store can only be probed after the previously-answering ones have
+// already missed.
 func (s *Server) beadStoresForID(id string) []beads.Store {
 	id = strings.TrimSpace(id)
 	// Built once and shared by both prefix resolvers below: they answer
-	// different questions about the same set of configured work prefixes, and
-	// this is the walk of cfg.Rigs the pre-seam code already did.
+	// different questions about the same set of configured work prefixes.
 	configured := s.configuredPrefixStores()
 
 	// Class-prefix arm: a graph-relocated city keeps graph-class beads (reserved
@@ -214,9 +224,18 @@ func (s *Server) beadStoresForID(id string) []beads.Store {
 // question is asked by cmd/gc's one-shot commands, and answering it twice is
 // exactly how the split-store bug class reproduces. The routing is keyed on
 // STORE IDENTITY (GraphBeadStore() != CityBeadStore()) rather than a marker
-// file, so a MIGRATED city — where infra_class_migrate.go deliberately preserves
-// legacy ids, and a relocated bead can still carry its HQ/rig-era prefix — is
-// resolved by probing the returned list rather than by trusting the prefix.
+// file or a migration flag, and it returns a probe list rather than a route, so
+// a work store that legitimately holds an id inside the class namespace stays
+// reachable behind the class store.
+//
+// NOT covered here: a bead `gc storage migrate` relocated with its id PRESERVED
+// (infra_class_migrate.go). That id keeps its HQ/rig-era prefix, so it is
+// outside the class namespace, the arm never fires, and the configured-prefix
+// resolver below answers it from the work store — which still holds the
+// migration's retained source copy, frozen at migration time. Covering it needs
+// a residence probe that asks the class store about every id; that is what
+// cmd/gc/cmd_bd_by_id.go's bdByIDClassDoor.resolve does, and this path has no
+// equivalent yet.
 //
 // GRAPH ONLY. Sessions, orders and nudges have relocated-store accessors on
 // State, but adding them here would change which stores answer for gcs-/gco-/
@@ -244,6 +263,12 @@ func (s *Server) classStoresForID(id string, configured []storeref.PrefixedStore
 // Only stores that are actually loaded are listed: a configured prefix whose
 // store is missing must not win a slot, so a shorter loaded prefix can still own
 // an id (and otherwise the id is left to the legacy scan).
+//
+// This walks every rig, which the pre-seam resolver did not: it looked the store
+// up only for a rig whose prefix already covered the id and beat the best match
+// so far. The set is built here because two resolvers now consume it and they
+// select different subsets of it. State.BeadStore is a map read under an RLock,
+// so the widened walk costs a lookup per rig and no I/O.
 func (s *Server) configuredPrefixStores() []storeref.PrefixedStore {
 	cfg := s.state.Config()
 	if cfg == nil {

--- a/internal/storeref/class_candidates.go
+++ b/internal/storeref/class_candidates.go
@@ -25,10 +25,12 @@ type ClassRouting struct {
 	// value equal to Work, means the class is NOT relocated.
 	Class beads.Store
 
-	// Work is the city/HQ work store the class was relocated away from. It is
-	// the trailing fallback leg of the candidate list: on a MIGRATED city an id
-	// minted before relocation keeps its work-era prefix, and a bead the class
-	// arm has not physically moved yet is still readable there.
+	// Work is the city/HQ work store the class was relocated away from. It stays
+	// in the candidate list directly behind the class store — where the pre-seam
+	// resolver already put it — as the fallback leg for an id inside the class
+	// namespace that the class store does not hold. The reserved prefix is
+	// warned-and-allowed on work stores, so one can legitimately mint and hold
+	// such an id.
 	Work beads.Store
 
 	// Shadows are the loaded work stores paired with the id prefixes they were
@@ -59,17 +61,46 @@ type PrefixedStore struct {
 //     migration flag. A city whose class store IS its work store gets nil here
 //     and keeps its legacy resolution byte-identical.
 //   - Nil unless id is inside the class namespace (IDInNamespace).
-//   - Otherwise: the class store FIRST, then every shadowing work store whose
-//     configured prefix also covers id (most specific first), then Work.
+//   - Otherwise: the class store FIRST, then Work, then every shadowing work
+//     store whose configured prefix also covers id (most specific first).
 //
-// The result is a candidate list, never an unconditional route: a bead lives in
-// exactly one store, so the caller probes the list in order and pins the first
-// store that answers. The class store leads because it is the sole minter of
-// the reserved namespace, so a class id pins it on the first probe; the rest of
-// the list exists because "reserved prefix" is an ADVISORY on work stores, and
-// on a migrated city an id can predate the relocation that gave the namespace
-// away. Routing unconditionally on the prefix instead would strand exactly
-// those ids.
+// # Why a probe list rather than a route
+//
+// A bead lives in exactly one store, so the caller probes the list in order and
+// pins the first store that answers. The value of the shape is that it PROBES:
+// the class store leads because it is the sole MINTER of the reserved
+// namespace, but minting is not holding, and a reserved prefix is only an
+// ADVISORY on work stores (config.ReservedPrefixWarnings warns;
+// config.ValidateRigs does not reject). A work store can therefore legitimately
+// hold an id inside the class namespace, and a resolver that routed
+// unconditionally on the prefix would report those beads as absent.
+//
+// # What the order guarantees
+//
+// [class, work] is exactly the list the pre-seam internal/api arm returned, and
+// it stays the HEAD of this one — the shadowing stores are appended behind it.
+// Every probe the pre-seam list performed still happens, in the same order, and
+// the added legs are reached only where it had already given up. So a store
+// added here can neither change an answer that resolution already served nor
+// turn a served read into an error by failing ahead of the store that holds the
+// bead: the worst a broken shadow can do is turn a not-found into a hard error,
+// which is the honest report when a store that could hold the id is unreachable.
+//
+// # NOT covered: a relocated bead that kept a legacy id
+//
+// IDInNamespace gates BEFORE the list is built, so this resolver only ever sees
+// ids inside the class namespace. `gc storage migrate` preserves ids
+// (cmd/gc/infra_class_migrate.go), so a bead it relocated keeps its HQ/rig-era
+// prefix, is outside the namespace, and gets nil back here. This resolver does
+// not cover that bead and must not be described as if it does.
+//
+// What covers it is a residence probe — asking the class store about EVERY id
+// rather than only about prefixed ones. cmd/gc/cmd_bd_by_id.go's
+// bdByIDClassDoor.resolve does exactly that, for exactly this reason. Nothing
+// on the internal/api by-id path does, so there a legacy-prefixed relocated
+// bead is still answered from the work store's retained pre-migration copy (the
+// migration never deletes its source). Giving that path a residence probe is
+// open work, not a property of this function.
 func ClassCandidates(id string, routing ClassRouting) []beads.Store {
 	id = strings.TrimSpace(id)
 	if routing.Class == nil || routing.Class == routing.Work {
@@ -88,10 +119,10 @@ func ClassCandidates(id string, routing ClassRouting) []beads.Store {
 		candidates = append(candidates, s)
 	}
 	add(routing.Class)
+	add(routing.Work)
 	for _, shadow := range shadowsCovering(id, routing.Shadows) {
 		add(shadow)
 	}
-	add(routing.Work)
 	return candidates
 }
 
@@ -124,11 +155,18 @@ func shadowsCovering(id string, shadows []PrefixedStore) []beads.Store {
 // rule — it admits the bare form because a configured rig/HQ prefix can be a
 // whole id.
 //
-// It is deliberately NOT the rule PrefixOwner applies. PrefixOwner routes on a
-// store's SELF-DECLARED IDPrefix() and requires the "prefix-" separator, because
-// a store that mints "gcg-1" never mints the bare id "gcg". Keep the two
-// distinct: widening PrefixOwner would let a bare id capture a store that cannot
-// hold it.
+// It is deliberately NOT the rule PrefixOwner applies, and the two are the
+// package's two namespace predicates. Which to use:
+//
+//   - IDInNamespace, when the prefix comes from CONFIG — a rig/HQ prefix, or a
+//     reserved class prefix from config.ReservedClassPrefix. A configured prefix
+//     can be a whole id, so the bare form counts.
+//   - PrefixOwner, when the prefix comes from the STORE — its self-declared
+//     IDPrefix(). It requires the "prefix-" separator, because a store that
+//     mints "gcg-1" never mints the bare id "gcg".
+//
+// Keep them distinct: widening PrefixOwner would let a bare id capture a store
+// that cannot hold it.
 func IDInNamespace(id, prefix string) bool {
 	prefix = strings.TrimSpace(prefix)
 	if prefix == "" {

--- a/internal/storeref/class_candidates.go
+++ b/internal/storeref/class_candidates.go
@@ -1,0 +1,138 @@
+package storeref
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// ClassRouting describes ONE relocated coordination class for by-id candidate
+// resolution: the reserved id prefix the class mints, the store it was
+// relocated to, the work store it was relocated away from, and the configured
+// work-store prefixes that can shadow the class namespace.
+//
+// The class is identified by its Prefix rather than by a class constant, so
+// this package stays free of internal/config (which imports internal/beads and
+// could not import back). Callers supply the prefix from
+// config.ReservedClassPrefix.
+type ClassRouting struct {
+	// Prefix is the reserved class id prefix the relocated store mints, e.g.
+	// "gcg" for the graph class. Empty disables the routing entirely.
+	Prefix string
+
+	// Class is the store the coordination class was relocated to. Nil, or a
+	// value equal to Work, means the class is NOT relocated.
+	Class beads.Store
+
+	// Work is the city/HQ work store the class was relocated away from. It is
+	// the trailing fallback leg of the candidate list: on a MIGRATED city an id
+	// minted before relocation keeps its work-era prefix, and a bead the class
+	// arm has not physically moved yet is still readable there.
+	Work beads.Store
+
+	// Shadows are the loaded work stores paired with the id prefixes they were
+	// CONFIGURED with (the city/HQ prefix and each rig's effective prefix).
+	// Reserved class prefixes are warned-and-allowed on work stores
+	// (config.ReservedPrefixWarnings, not rejected by config.ValidateRigs), so a
+	// work store can legitimately own ids inside — or under a longer prefix
+	// starting with — the class namespace. Listing it here keeps those ids
+	// reachable by id once the class relocates.
+	Shadows []PrefixedStore
+}
+
+// PrefixedStore pairs a work store with the id prefix it was configured with.
+type PrefixedStore struct {
+	Prefix string
+	Store  beads.Store
+}
+
+// ClassCandidates returns the by-id candidate PROBE LIST for id under routing,
+// or nil when routing does not apply to id.
+//
+// It is the shared form of the class arm internal/api's by-id resolver used to
+// carry inline. The contract, in order:
+//
+//   - Nil unless the class is actually relocated. "Relocated" is decided by
+//     STORE IDENTITY — Class != nil && Class != Work, the same question
+//     cmd/gc's resolveClassStore answers — never by a marker file or a
+//     migration flag. A city whose class store IS its work store gets nil here
+//     and keeps its legacy resolution byte-identical.
+//   - Nil unless id is inside the class namespace (IDInNamespace).
+//   - Otherwise: the class store FIRST, then every shadowing work store whose
+//     configured prefix also covers id (most specific first), then Work.
+//
+// The result is a candidate list, never an unconditional route: a bead lives in
+// exactly one store, so the caller probes the list in order and pins the first
+// store that answers. The class store leads because it is the sole minter of
+// the reserved namespace, so a class id pins it on the first probe; the rest of
+// the list exists because "reserved prefix" is an ADVISORY on work stores, and
+// on a migrated city an id can predate the relocation that gave the namespace
+// away. Routing unconditionally on the prefix instead would strand exactly
+// those ids.
+func ClassCandidates(id string, routing ClassRouting) []beads.Store {
+	id = strings.TrimSpace(id)
+	if routing.Class == nil || routing.Class == routing.Work {
+		return nil
+	}
+	if !IDInNamespace(id, routing.Prefix) {
+		return nil
+	}
+	candidates := make([]beads.Store, 0, len(routing.Shadows)+2)
+	seen := make(map[beads.Store]bool, len(routing.Shadows)+2)
+	add := func(s beads.Store) {
+		if s == nil || seen[s] {
+			return
+		}
+		seen[s] = true
+		candidates = append(candidates, s)
+	}
+	add(routing.Class)
+	for _, shadow := range shadowsCovering(id, routing.Shadows) {
+		add(shadow)
+	}
+	add(routing.Work)
+	return candidates
+}
+
+// shadowsCovering returns the work stores whose configured prefix also covers
+// id, most specific (longest configured prefix) first so the narrowest declared
+// owner is probed before a broader one. Ties keep input order; two distinct
+// prefixes of equal length cannot both cover the same id, so a tie only happens
+// between duplicate prefixes, which config.ValidateRigs already rejects.
+func shadowsCovering(id string, shadows []PrefixedStore) []beads.Store {
+	matched := make([]PrefixedStore, 0, len(shadows))
+	for _, shadow := range shadows {
+		prefix := strings.TrimSpace(shadow.Prefix)
+		if shadow.Store == nil || !IDInNamespace(id, prefix) {
+			continue
+		}
+		matched = append(matched, PrefixedStore{Prefix: prefix, Store: shadow.Store})
+	}
+	sort.SliceStable(matched, func(i, j int) bool {
+		return len(matched[i].Prefix) > len(matched[j].Prefix)
+	})
+	stores := make([]beads.Store, 0, len(matched))
+	for _, m := range matched {
+		stores = append(stores, m.Store)
+	}
+	return stores
+}
+
+// IDInNamespace reports whether id falls under prefix's id namespace: a bare
+// id equal to prefix, or anything under "prefix-". This is the CONFIGURED-prefix
+// rule — it admits the bare form because a configured rig/HQ prefix can be a
+// whole id.
+//
+// It is deliberately NOT the rule PrefixOwner applies. PrefixOwner routes on a
+// store's SELF-DECLARED IDPrefix() and requires the "prefix-" separator, because
+// a store that mints "gcg-1" never mints the bare id "gcg". Keep the two
+// distinct: widening PrefixOwner would let a bare id capture a store that cannot
+// hold it.
+func IDInNamespace(id, prefix string) bool {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return false
+	}
+	return id == prefix || strings.HasPrefix(id, prefix+"-")
+}

--- a/internal/storeref/class_candidates_test.go
+++ b/internal/storeref/class_candidates_test.go
@@ -94,11 +94,68 @@ func TestClassCandidatesOutsideNamespace(t *testing.T) {
 
 // TestClassCandidatesRelocated pins the base list a relocated class produces:
 // the class store first (it is the sole minter of the namespace), then the work
-// store as the trailing fallback leg for a migrated city's legacy ids.
+// store as the fallback leg for an in-namespace id the class store does not
+// hold. This pair is also the whole of the pre-seam internal/api list, and it
+// stays the HEAD of every list this resolver builds.
 func TestClassCandidatesRelocated(t *testing.T) {
 	f := newClassFixture()
 	got := ClassCandidates("gcg-1", ClassRouting{Prefix: "gcg", Class: f.class, Work: f.work})
 	assertCandidates(t, f, got, "class", "work")
+}
+
+// TestClassCandidatesMigratedLegacyIDIsOutOfNamespace pins the limitation the
+// doc now states instead of the coverage it used to claim.
+//
+// `gc storage migrate` preserves ids, so a bead it relocated keeps its HQ/rig-era
+// prefix. IDInNamespace gates before the candidate list is built, so such an id
+// gets NIL here however thoroughly the class is relocated — the candidate shape
+// cannot rescue an id it never sees. Covering it needs a residence probe that
+// asks the class store about every id (cmd/gc/cmd_bd_by_id.go does; the
+// internal/api by-id path does not).
+//
+// If this ever starts returning candidates, the resolver has grown a residence
+// arm and the "NOT covered" section of ClassCandidates' doc is stale.
+func TestClassCandidatesMigratedLegacyIDIsOutOfNamespace(t *testing.T) {
+	f := newClassFixture()
+	routing := ClassRouting{
+		Prefix:  "gcg",
+		Class:   f.class,
+		Work:    f.work,
+		Shadows: []PrefixedStore{{Prefix: "mc", Store: f.work}},
+	}
+	// The id a migrated graph bead carries: minted by the work store under the
+	// HQ prefix, then copied into the class store with the id preserved.
+	if got := ClassCandidates("mc-123", routing); got != nil {
+		t.Fatalf("ClassCandidates(mc-123) = %v, want nil — a relocated bead that kept its work-era id is OUTSIDE this resolver's namespace and is not covered by it", storeNames(f, got))
+	}
+}
+
+// TestClassCandidatesKeepsPreSeamHead pins the property that makes the added
+// legs safe: the pre-seam [class, work] list is a strict PREFIX of whatever this
+// resolver returns, whatever shadows are configured. Every probe the old list
+// made still happens in the same order, so a shadow store cannot change an
+// answer the old list served, and cannot fail ahead of the store that holds the
+// bead and turn a served read into an error.
+func TestClassCandidatesKeepsPreSeamHead(t *testing.T) {
+	f := newClassFixture()
+	for _, tt := range []struct {
+		name    string
+		id      string
+		shadows []PrefixedStore
+	}{
+		{"no shadows", "gcg-1", nil},
+		{"reserved-prefix rig", "gcg-1", []PrefixedStore{{Prefix: "gcg", Store: f.rig}}},
+		{"longer-prefix rig", "gcg-alpha-1", []PrefixedStore{{Prefix: "gcg-alpha", Store: f.rig}}},
+		{"HQ shadows too", "gcg-alpha-1", []PrefixedStore{{Prefix: "gcg", Store: f.work}, {Prefix: "gcg-alpha", Store: f.rig}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassCandidates(tt.id, ClassRouting{Prefix: "gcg", Class: f.class, Work: f.work, Shadows: tt.shadows})
+			names := storeNames(f, got)
+			if len(names) < 2 || names[0] != "class" || names[1] != "work" {
+				t.Fatalf("candidates = %v, want the pre-seam [class work] head first", names)
+			}
+		})
+	}
 }
 
 // TestClassCandidatesNoWorkStore pins the class-only list: with no work store to
@@ -126,7 +183,7 @@ func TestClassCandidatesKeepsShadowingWorkStore(t *testing.T) {
 			{Prefix: "gcg", Store: f.rig},
 		},
 	})
-	assertCandidates(t, f, got, "class", "rig", "work")
+	assertCandidates(t, f, got, "class", "work", "rig")
 }
 
 // TestClassCandidatesKeepsLongerPrefixWorkStore is carried minor (b): an id
@@ -135,8 +192,9 @@ func TestClassCandidatesKeepsShadowingWorkStore(t *testing.T) {
 // to silently drop the rig store that actually declares the longer prefix.
 //
 // The longer prefix sorts FIRST among the shadows because it is the more
-// specific declared owner, but still behind the class store, which is never
-// captured.
+// specific declared owner — but the whole shadow tail sits behind the pre-seam
+// [class, work] head, so the added leg can only extend reachability and never
+// re-answer an id the old list already resolved.
 func TestClassCandidatesKeepsLongerPrefixWorkStore(t *testing.T) {
 	f := newClassFixture()
 	got := ClassCandidates("gcg-alpha-1", ClassRouting{
@@ -148,7 +206,7 @@ func TestClassCandidatesKeepsLongerPrefixWorkStore(t *testing.T) {
 			{Prefix: "gcg-alpha", Store: f.rig},
 		},
 	})
-	assertCandidates(t, f, got, "class", "rig", "work")
+	assertCandidates(t, f, got, "class", "work", "rig")
 }
 
 // TestClassCandidatesDedupesAndSkipsNils pins that a store named twice (the HQ

--- a/internal/storeref/class_candidates_test.go
+++ b/internal/storeref/class_candidates_test.go
@@ -1,0 +1,218 @@
+package storeref
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// classFixture is the shape every case below routes over: a relocated class
+// store, the work store it moved away from, and a rig work store that may or may
+// not shadow the class namespace.
+type classFixture struct {
+	class beads.Store
+	work  beads.Store
+	rig   beads.Store
+}
+
+func newClassFixture() classFixture {
+	return classFixture{
+		class: beads.NewMemStore(),
+		work:  beads.NewMemStore(),
+		rig:   beads.NewMemStore(),
+	}
+}
+
+func storeNames(f classFixture, stores []beads.Store) []string {
+	names := make([]string, 0, len(stores))
+	for _, s := range stores {
+		switch s {
+		case f.class:
+			names = append(names, "class")
+		case f.work:
+			names = append(names, "work")
+		case f.rig:
+			names = append(names, "rig")
+		default:
+			names = append(names, "unknown")
+		}
+	}
+	return names
+}
+
+func assertCandidates(t *testing.T, f classFixture, got []beads.Store, want ...string) {
+	t.Helper()
+	names := storeNames(f, got)
+	if len(names) != len(want) {
+		t.Fatalf("candidates = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("candidates = %v, want %v", names, want)
+		}
+	}
+}
+
+// TestClassCandidatesNotRelocated pins the identity gate: the resolver is keyed
+// on whether the class store IS the work store, never on a marker file or a
+// migration flag. A default city gets nil, which is what keeps its legacy by-id
+// resolution byte-identical.
+func TestClassCandidatesNotRelocated(t *testing.T) {
+	f := newClassFixture()
+	for _, tt := range []struct {
+		name    string
+		routing ClassRouting
+	}{
+		{"class store is the work store", ClassRouting{Prefix: "gcg", Class: f.work, Work: f.work}},
+		{"no class store at all", ClassRouting{Prefix: "gcg", Class: nil, Work: f.work}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassCandidates("gcg-1", tt.routing); got != nil {
+				t.Fatalf("ClassCandidates(gcg-1) = %v, want nil — the class is not relocated", storeNames(f, got))
+			}
+		})
+	}
+}
+
+// TestClassCandidatesOutsideNamespace pins that the arm only fires for ids in
+// the class namespace, and only under the exact-or-hyphen rule: a bare "gcg" is
+// in, a longer word starting with the same letters is not.
+func TestClassCandidatesOutsideNamespace(t *testing.T) {
+	f := newClassFixture()
+	routing := ClassRouting{Prefix: "gcg", Class: f.class, Work: f.work}
+	for _, id := range []string{"gc-1", "gcgx-1", "gcgraph-9", "", "  "} {
+		if got := ClassCandidates(id, routing); got != nil {
+			t.Errorf("ClassCandidates(%q) = %v, want nil — %q is outside the gcg namespace", id, storeNames(f, got), id)
+		}
+	}
+	for _, id := range []string{"gcg", "gcg-1", "gcg-wisp-0042", " gcg-1 "} {
+		if got := ClassCandidates(id, routing); len(got) == 0 {
+			t.Errorf("ClassCandidates(%q) = nil, want the class candidate list", id)
+		}
+	}
+}
+
+// TestClassCandidatesRelocated pins the base list a relocated class produces:
+// the class store first (it is the sole minter of the namespace), then the work
+// store as the trailing fallback leg for a migrated city's legacy ids.
+func TestClassCandidatesRelocated(t *testing.T) {
+	f := newClassFixture()
+	got := ClassCandidates("gcg-1", ClassRouting{Prefix: "gcg", Class: f.class, Work: f.work})
+	assertCandidates(t, f, got, "class", "work")
+}
+
+// TestClassCandidatesNoWorkStore pins the class-only list: with no work store to
+// fall back to, the class store is the whole answer rather than a nil entry the
+// caller has to skip.
+func TestClassCandidatesNoWorkStore(t *testing.T) {
+	f := newClassFixture()
+	got := ClassCandidates("gcg-1", ClassRouting{Prefix: "gcg", Class: f.class})
+	assertCandidates(t, f, got, "class")
+}
+
+// TestClassCandidatesKeepsShadowingWorkStore is carried minor (a) from PR
+// #5128's council: a rig configured with the reserved class prefix is
+// warned-and-ALLOWED (config.ReservedPrefixWarnings; config.ValidateRigs does
+// not reject it), so its beads are real and must stay reachable by id once the
+// class relocates. Dropping it from the candidate set made them unreachable.
+func TestClassCandidatesKeepsShadowingWorkStore(t *testing.T) {
+	f := newClassFixture()
+	got := ClassCandidates("gcg-1", ClassRouting{
+		Prefix: "gcg",
+		Class:  f.class,
+		Work:   f.work,
+		Shadows: []PrefixedStore{
+			{Prefix: "mc", Store: f.work},
+			{Prefix: "gcg", Store: f.rig},
+		},
+	})
+	assertCandidates(t, f, got, "class", "rig", "work")
+}
+
+// TestClassCandidatesKeepsLongerPrefixWorkStore is carried minor (b): an id
+// under a LONGER configured prefix that starts with the reserved one is inside
+// the class namespace by the exact-or-hyphen rule, so the arm fires — and used
+// to silently drop the rig store that actually declares the longer prefix.
+//
+// The longer prefix sorts FIRST among the shadows because it is the more
+// specific declared owner, but still behind the class store, which is never
+// captured.
+func TestClassCandidatesKeepsLongerPrefixWorkStore(t *testing.T) {
+	f := newClassFixture()
+	got := ClassCandidates("gcg-alpha-1", ClassRouting{
+		Prefix: "gcg",
+		Class:  f.class,
+		Work:   f.work,
+		Shadows: []PrefixedStore{
+			{Prefix: "gcg", Store: f.work},
+			{Prefix: "gcg-alpha", Store: f.rig},
+		},
+	})
+	assertCandidates(t, f, got, "class", "rig", "work")
+}
+
+// TestClassCandidatesDedupesAndSkipsNils pins that a store named twice (the HQ
+// prefix shadowing the class namespace makes the work store its own shadow)
+// appears once, and that an unloaded store never occupies a slot.
+func TestClassCandidatesDedupesAndSkipsNils(t *testing.T) {
+	f := newClassFixture()
+	got := ClassCandidates("gcg-1", ClassRouting{
+		Prefix: "gcg",
+		Class:  f.class,
+		Work:   f.work,
+		Shadows: []PrefixedStore{
+			{Prefix: "gcg", Store: f.work},
+			{Prefix: "gcg", Store: nil},
+			{Prefix: "", Store: f.rig},
+		},
+	})
+	assertCandidates(t, f, got, "class", "work")
+}
+
+// TestClassCandidatesIgnoresNonCoveringShadows pins that a shadow whose prefix
+// does not cover the id contributes nothing — the list is not "every work
+// store", it is the stores that could actually hold this id.
+func TestClassCandidatesIgnoresNonCoveringShadows(t *testing.T) {
+	f := newClassFixture()
+	got := ClassCandidates("gcg-1", ClassRouting{
+		Prefix: "gcg",
+		Class:  f.class,
+		Work:   f.work,
+		Shadows: []PrefixedStore{
+			{Prefix: "mc", Store: f.work},
+			{Prefix: "mr", Store: f.rig},
+		},
+	})
+	assertCandidates(t, f, got, "class", "work")
+}
+
+// TestIDInNamespace pins the exact-or-hyphen rule and, on the same ids, the
+// deliberate divergence from PrefixOwner's separator-only rule. Collapsing the
+// two would let a bare id capture a store that never mints it.
+func TestIDInNamespace(t *testing.T) {
+	for _, tt := range []struct {
+		id, prefix string
+		want       bool
+	}{
+		{"gcg", "gcg", true},
+		{"gcg-1", "gcg", true},
+		{"gcg-wisp-0042", "gcg", true},
+		{"gcgx-1", "gcg", false},
+		{"gc-1", "gcg", false},
+		{"gcg-1", "", false},
+		{"gcg-1", "  ", false},
+		{"gcg-1", " gcg ", true},
+	} {
+		if got := IDInNamespace(tt.id, tt.prefix); got != tt.want {
+			t.Errorf("IDInNamespace(%q, %q) = %v, want %v", tt.id, tt.prefix, got, tt.want)
+		}
+	}
+	// The bare-id divergence, stated against PrefixOwner directly.
+	bare := newPrefixed("gcg")
+	if owner := PrefixOwner("gcg", []beads.Store{bare}); owner != nil {
+		t.Fatal("PrefixOwner(\"gcg\") claimed a store; the separator rule must reject the bare form, and IDInNamespace must stay the only accessor that admits it")
+	}
+	if !IDInNamespace("gcg", "gcg") {
+		t.Fatal("IDInNamespace(\"gcg\", \"gcg\") = false; the configured-prefix rule must admit the bare form")
+	}
+}

--- a/internal/storeref/storeref.go
+++ b/internal/storeref/storeref.go
@@ -5,9 +5,28 @@
 // (prefixBackendForID + Get): the Router is the live graph_store=sqlite wiring
 // today and is retired in the final phase of the infra/beads split, so this
 // package carries the same routing forward over an explicit []beads.Store the
-// caller assembles, with no central Router. Bead ids are prefix-disjoint across
-// stores (reserved class prefixes are kept off HQ/rig work-store prefixes by
-// config.ValidateRigs), so the owning store is the sole residence.
+// caller assembles, with no central Router.
+//
+// # Ids are NOT prefix-disjoint across stores
+//
+// A bead is resident in exactly one store, but its id namespace can be claimed
+// by more than one: config.ValidateRigs rejects duplicate prefixes and nothing
+// else, and it deliberately does NOT reject a reserved coordination-class
+// prefix on an HQ or rig work store — config.ReservedPrefixWarnings warns and
+// allows it. So a work store can mint and hold ids inside a relocated class's
+// namespace, and every resolver here PROBES a candidate list rather than
+// assuming one store owns a prefix outright.
+//
+// # Two namespace predicates, deliberately different
+//
+//   - IDInNamespace (class_candidates.go) matches a CONFIGURED prefix — a
+//     rig/HQ prefix or a reserved class prefix — and admits the bare id, because
+//     a configured prefix can be a whole id.
+//   - PrefixOwner matches a store's SELF-DECLARED IDPrefix() and requires the
+//     "prefix-" separator, because a store that mints "gcg-1" never mints "gcg".
+//
+// Collapsing them would let a bare id capture a store that cannot hold it. Use
+// the one whose prefix source matches where your prefix came from.
 package storeref
 
 import (
@@ -48,6 +67,11 @@ type HasIDPrefix interface {
 // purely on the static id prefix and never reads a store. Mirrors
 // coordrouter.Router.prefixBackendForID. nil stores and stores without an
 // IDPrefix() (or an empty one, e.g. the work store) are skipped.
+//
+// This is the SELF-DECLARED-prefix predicate, and it requires the "prefix-"
+// separator. For a prefix that came from config — a rig/HQ prefix, or a reserved
+// class prefix — use IDInNamespace instead; it also admits the bare id, which
+// this rule must not. See the package doc.
 func PrefixOwner(id string, stores []beads.Store) beads.Store {
 	for _, s := range stores {
 		if s == nil {


### PR DESCRIPTION
## What

`internal/api`'s `beadStoresForID` carried the only by-id class resolver in the tree: a class-prefix arm, method-bound to the API server, that returns a candidate **probe list** for a `gcg-` id on a graph-relocated city. This lifts that arm into `storeref.ClassCandidates` and makes `internal/api` consume it.

`gc bd` by-id routing, `gc ready`, claim routing and the work-query federation all need the same answer. Answering it a second time — a second place that decides "which store owns this class of bead?" — is precisely how this repo's split-store bug class reproduces (#5125, #5127).

Behaviour-preserving apart from the two carried minors below, which the bead requires closing.

## CORRECTION: this resolver does NOT survive a migrated city

An earlier revision of this PR, and of the resolver's own doc, said the candidate-list shape is what lets the arm survive a **migrated** city. That was false, and it is corrected at the source rather than softened.

`IDInNamespace(id, prefix)` gates **before** the candidate list is built. `gc storage migrate` preserves ids (`infra_class_migrate.go`), so a bead it relocated keeps its HQ/rig-era prefix — which is *outside* the class namespace. The arm returns **nil candidates** for exactly the ids the claim said it covered. Stated plainly: **a legacy-prefixed relocated bead is out of this resolver's namespace and is not covered by it.**

Pinned, so the limitation cannot drift:

- `TestClassCandidatesMigratedLegacyIDIsOutOfNamespace` — `ClassCandidates("mc-123", …)` is nil however thoroughly graph is relocated.
- `TestBeadStoresForIDDoesNotCoverMigratedLegacyIDs` — the handler-side consequence: the id resolves to the **work** store, and the relocated store is not even a candidate.

**What does cover a migrated id is the other approach.** `cmd/gc/cmd_bd_by_id.go`'s `bdByIDClassDoor.resolve` probes RESIDENCE: it asks the class front door about *every* id, prefixed or not, and its own doc gives this exact reason — "`gc storage migrate` copies the work store's infrastructure slice with its ids PRESERVED, so a converged city holds work-shaped ids in its binding and deciding ownership by prefix alone would send those reads back to the ledger they were moved off."

The `internal/api` by-id path has **no** equivalent. There a legacy-prefixed relocated bead is answered from the work store's retained pre-migration copy (the migration never deletes its source, so the row is present but frozen at migration time). That is **open work**, named in the code and here rather than left for a reader to find.

The candidate-list shape does have a real virtue — a different one. It **probes** instead of routing unconditionally: the class store leads because it is the sole *minter* of the reserved namespace, but minting is not holding. A reserved prefix is only an advisory on work stores (`config.ReservedPrefixWarnings` warns; `config.ValidateRigs` does not reject), so a work store can legitimately hold an in-namespace id, and a prefix route would report those beads as absent.

## The contract

```go
// internal/storeref/class_candidates.go
func ClassCandidates(id string, routing ClassRouting) []beads.Store
```

| result | when |
|---|---|
| `nil` | `routing.Class` is nil or IS `routing.Work` (class not relocated) |
| `nil` | `id` is outside the class namespace — including every migrated legacy id |
| `[class, work, …shadows…]` | otherwise — class first, then work, then shadowing work stores most-specific-prefix first; deduped, nils dropped |

The routing is gated on `resolveClassStore` **identity** — `Class != nil && Class != Work`, the same question `cmd/gc`'s `resolveClassStore` answers — never on a marker file or a migration flag. A single-store city gets `nil` back and keeps its legacy resolution byte-identical.

`ClassRouting{Prefix, Class, Work, Shadows}` takes the reserved prefix as **data**, so the package stays free of `internal/config` (which imports `internal/beads` and could not be imported back), and adding a class later is a call-site change rather than a resolver change.

Deliberately *not* the branch's `storeForID`, which scans every argument and routes the entire command on the first reserved-looking token with no existence probe (so `gc bd dep add ga-123 gcg-456 blocks` routes to the store that does not hold the subject).

## Why the shadowing stores go LAST

Council finding, evaluated rather than taken at face value: *"a shadowing work store inserted mid-chain lets an unrelated rig outage 500 a read main served."* Verified against the probe loop — it is real, and narrow. The by-id handlers stop at the first store that answers and surface a non-`ErrNotFound` read as a 500. So with the shadows inserted between the class store and the work store, a hard-failing rig store aborted the walk before the work store that held the bead.

`[class, work]` is exactly the pre-seam list, and it is now the **head** of the new one — the shadows are appended behind it. Every probe the old list made still happens, in the same order, and the added legs are reached only where the old list had already given up. A store added here can therefore neither change an answer resolution already served nor turn a served read into an error. The worst a broken shadow can do is turn a not-found into a hard error, which is the honest report when a store that could hold the id is unreachable.

Not taken: relaxing the handlers' fail-fast rule to "skip a failing candidate and continue". That would let a mutation land on a *different* store's row of the same id whenever the leading class store is unreachable — the residence-violation class this whole program exists to prevent — and it would change legacy multi-rig behaviour on the unrelated fallback scan. Ordering removes the exposure without either cost.

Red before, through the real resolver and the real handler:

```
GET bead gcg-1: rig backend unreachable — an unrelated rig's outage answered for a bead the city store holds
candidates = [class rig work], want the pre-seam [class work] head first
```

## Two namespace predicates, and the invariant that stopped being true

`storeref`'s package doc used to state that bead ids are prefix-disjoint across stores because `config.ValidateRigs` keeps reserved class prefixes off work-store prefixes. It does not: `ValidateRigs` rejects duplicate prefixes and nothing else, and deliberately allows a reserved class prefix (`config.ReservedPrefixWarnings` warns). This PR's shadowing support is the proof, so the package doc now says ids are **not** namespace-disjoint and that every resolver here probes rather than assumes.

The tree now has two namespace predicates with different rules, and the package doc, `PrefixOwner` and `IDInNamespace` all cross-reference each other and say which to use:

- `IDInNamespace` — the prefix came from **config** (rig/HQ prefix, or `config.ReservedClassPrefix`). Exact-or-hyphen: admits the bare id, because a configured prefix can be a whole id. Moved out of `internal/api`'s `beadIDHasConfiguredPrefix`, which this PR deletes.
- `PrefixOwner` — the prefix came from the **store** (its self-declared `IDPrefix()`). Separator-only: a store that mints `gcg-1` never mints the bare `gcg`. Widening it would let a bare id capture a store that cannot hold it.

The conformance suite's I5 cited the deleted `beadIDHasConfiguredPrefix` and asserted the two rules were the same; it now names `storeref.IDInNamespace` and states the divergence.

## The two carried minors from #5128's council

Reserved class prefixes are warned-and-**allowed** on work stores (`config.ReservedPrefixWarnings`); `config.ValidateRigs` does not reject them — verified, not assumed. So a work store can legitimately hold ids inside the class namespace, and the hoisted arm dropped it from the candidate set:

- **(a)** a rig configured with the reserved prefix itself lost by-id reachability for every one of its beads the moment graph relocated.
- **(b)** an id under a **longer** prefix that starts with the reserved one (`gcg-alpha-1` under rig prefix `gcg-alpha`) silently lost its rig store.

Neither was tested. Red before, through the real resolver and the real handler:

```
beadStoresForID(gcg-1) = [graph city]; shadowing rig store is NOT a candidate
beadStoresForID(gcg-alpha-1) = [graph city]; rig store under the LONGER prefix "gcg-alpha" is NOT a candidate
GET bead gcg-1: bead gcg-1 not found — a shadowing rig's bead is unreachable by id on a relocated city
```

The list now carries the shadowing work stores **behind** the class store and the city store. #5128's rule that a reserved prefix can never be captured by a rig/HQ prefix or a `routes.jsonl` entry is unchanged — this is about reachability, not precedence.

## Graph only — what the other four prefixes turned out to be

`gcs` / `gco` / `gcn` **do** have relocated-store accessors on `api.State` today (`SessionsBeadStore`, `OrdersBeadStore`, `NudgesBeadStore`, all wired through `resolveClassStore` in `cmd/gc/api_state.go`). `gcm` has **none** — mail routes through `mail.Provider`, and there is no `MessagingBeadStore()` anywhere.

Generalising to them is still out of scope: it would change which stores answer for `gcs-`/`gco-`/`gcn-` ids, which is a production routing change and not part of lifting this arm. The call site stays graph-only and says so.

## I5 un-skipped, and its gap pinned

`TestSplitTopologyConformance/I5-claim-routing`'s claim-mutation half skipped naming this bead — there was no seam that routed a claim **mutation** by class. It now runs on both topologies through `splitEnv.claimByID`: candidates from the shared resolver, probed in order, mutation written through the store that answered, asserting **residence** (visible in the owning store, in no other leg).

Two fixes to that invariant, from the council:

- **The single-store leg now pins the IDENTITY gate.** It asserted the resolver is inert using the city's own work ids — which are outside the reserved namespace, so the NAMESPACE gate alone rejected them and the row still passed with the identity gate deleted. It now also routes a **class-shaped** id, which clears the namespace gate so identity is the only thing that can reject it. Red under mutation: `class-shaped id — identity gate: classCandidatesForID("gcg-1") returned 1 candidates on a single-store city`.
- **The KNOWN GAP is now asserted, not just described.** Every other KNOWN GAP in the suite (I1, I2, I10) pins today's answer through production code; I5's did not. It now asserts through `hookQueryEnv` — the seam that decides which store `gc hook --claim` runs its claim against — that the answer is a WORK scope rooted at the city path, identically on **both** topologies. When ga-xo8ch rewires the command onto the shared resolver, that row is what moves.

`gc bd update --claim` is already routed (#5132, `cmd_bd_by_id.go`) and probes the same way. The suite's skip list is now empty; the header says so, and says a new gap gets a skip rather than a deletion.

## Teeth, proved by mutation not argument

| mutation | result |
|---|---|
| drop the shadow arm | both minors redden **and** the handler 404s on a shadowing rig's bead |
| move the shadows ahead of the work store | `TestBeadGetSurvivesAShadowingRigOutage` reddens — a rig outage 500s a read the city store was serving |
| drop the `IDInNamespace` gate | `TestClassCandidatesMigratedLegacyIDIsOutOfNamespace` reddens with `ClassCandidates(mc-123) = [class work]` |
| drop the `Class != Work` identity gate | `TestBeadStoresForIDShadowingRigPrefixStillWinsOnDefaultCity` **and** I5's single-store class-shaped row redden — single-store byte-identity is exactly what that gate protects |
| drop the class candidates from `claimByID` | I5's split leg fails: `no candidate store held gcg-1: the by-id claim had nowhere to run` |

## Gates

`go build ./...` · `go vet ./...` · `gofmt -l` clean · `golangci-lint run` (2.10.1) **0 issues** · `go test ./internal/api/ ./internal/beads/... ./internal/storeref/` · `go test ./cmd/gc -timeout 25m` · `scripts/check-core-boundary.sh` · `make check-split-topology-rows`

Precondition #5128 (`dec245e181`) merged; built on `internal/beads/splittest` (#5130) and the conformance suite (#5134). Rebased onto current `main` (through #5140).

Closes nothing on its own — it unblocks ga-4k2c3, ga-xo8ch and ga-wnjr4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
