### PR TITLE
refactor(beads): replace the hardcoded backend allowlist with a registry (ga-jpxww)

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -555,8 +555,31 @@ func applyCanonicalScopeBackendEnv(env map[string]string, cityPath, scopeRoot st
 		}
 		return true, nil
 	default:
-		return true, fmt.Errorf("unsupported backend %q for scope %s", meta.Backend, scopeRoot)
+		return true, unprojectableBackendError(meta.Backend, scopeRoot)
 	}
+}
+
+// unprojectableBackendError refuses a backend this projector has no arm for.
+//
+// It reports the same four facts the metadata loader reports — the name, where
+// it was found, what this build registers, and that nothing was opened —
+// because an operator who meets one backend refusal must not have to learn a
+// second vocabulary to read the next one. This is the last guard before a bd
+// subprocess would inherit the ambient environment, so it never returns nil.
+//
+// A registered backend arriving here is a composition defect rather than bad
+// metadata (a registrar added a name without an env-projection arm), and the
+// message says so instead of telling the operator their metadata is wrong.
+func unprojectableBackendError(backend, scopeRoot string) error {
+	if err := contract.RecognizeBackend(backend); err != nil {
+		return fmt.Errorf("%w (scope %s)", err, scopeRoot)
+	}
+	supported, err := contract.RegisteredBackends()
+	if err != nil {
+		return fmt.Errorf("backend %q for scope %s cannot be projected: %w; %s", backend, scopeRoot, err, contract.BackendNotOpenedGuarantee)
+	}
+	return fmt.Errorf("backend %q for scope %s is registered by this build but has no environment projection (registered: %s); %s",
+		backend, scopeRoot, strings.Join(supported, ", "), contract.BackendNotOpenedGuarantee)
 }
 
 func applyCityPostgresBackendEnv(env map[string]string, cityPath string) (bool, error) {
@@ -585,7 +608,7 @@ func applyCityPostgresBackendEnv(env map[string]string, cityPath string) (bool, 
 	case "", "dolt", "doltlite":
 		return false, nil
 	default:
-		return true, fmt.Errorf("unsupported backend %q for scope %s", meta.Backend, cityPath)
+		return true, unprojectableBackendError(meta.Backend, cityPath)
 	}
 }
 

--- a/cmd/gc/bd_env_backend_registry_test.go
+++ b/cmd/gc/bd_env_backend_registry_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+)
+
+// writeUnregisteredBackendScope writes an authoritative scope whose metadata
+// names a backend no assembly of gc registers.
+func writeUnregisteredBackendScope(t *testing.T, backend string) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config := "issue_prefix: demo\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	metadata := `{"database":"beads","backend":"` + backend + `"}`
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(metadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cityPath
+}
+
+// TestScopeBackendEnvRefusalEnumeratesRegisteredBackends is Invariant 0 on the
+// env-projection path: an unregistered backend stops the projection by name,
+// and the refusal enumerates what this build registers rather than a list typed
+// into a format string.
+//
+// It also pins that nothing was projected. The failure this guards against is
+// not a missing error — it is a partially populated env reaching a bd
+// subprocess, which would then resolve a store from whatever the parent process
+// happened to be carrying.
+func TestScopeBackendEnvRefusalEnumeratesRegisteredBackends(t *testing.T) {
+	cityPath := writeUnregisteredBackendScope(t, "sqlite")
+
+	env := map[string]string{}
+	used, err := applyCanonicalScopeBackendEnv(env, cityPath, cityPath)
+	if err == nil {
+		t.Fatal("applyCanonicalScopeBackendEnv accepted an unregistered backend")
+	}
+	if !used {
+		t.Error("used = false, want true — the scope is authoritative and the failure is semantic")
+	}
+	if !errors.Is(err, contract.ErrUnknownBackend) {
+		t.Fatalf("refusal = %v, want it to wrap ErrUnknownBackend", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("a refused projection left %d env keys behind: %v", len(env), env)
+	}
+
+	registered, regErr := contract.RegisteredBackends()
+	if regErr != nil {
+		t.Fatal(regErr)
+	}
+	if !strings.Contains(err.Error(), `"sqlite"`) {
+		t.Errorf("refusal %q does not name the backend", err)
+	}
+	for _, name := range registered {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("refusal %q omits registered backend %q", err, name)
+		}
+	}
+	if !strings.Contains(err.Error(), contract.BackendNotOpenedGuarantee) {
+		t.Errorf("refusal %q drops the data-safety guarantee", err)
+	}
+}
+
+// TestCityPostgresBackendEnvRefusalEnumeratesRegisteredBackends covers the
+// second projection entry point — the one an inherited-city scope takes — which
+// has its own switch and therefore its own chance to fall through silently.
+func TestCityPostgresBackendEnvRefusalEnumeratesRegisteredBackends(t *testing.T) {
+	cityPath := writeUnregisteredBackendScope(t, "mysql")
+
+	env := map[string]string{}
+	used, err := applyCityPostgresBackendEnv(env, cityPath)
+	if err == nil {
+		t.Fatal("applyCityPostgresBackendEnv accepted an unregistered backend")
+	}
+	if !used {
+		t.Error("used = false, want true — an unregistered backend must not fall through to the dolt path")
+	}
+	if !errors.Is(err, contract.ErrUnknownBackend) {
+		t.Fatalf("refusal = %v, want it to wrap ErrUnknownBackend", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("a refused projection left %d env keys behind: %v", len(env), env)
+	}
+	if !strings.Contains(err.Error(), `"mysql"`) || !strings.Contains(err.Error(), contract.BackendNotOpenedGuarantee) {
+		t.Errorf("refusal %q must name the backend and state the data-safety guarantee", err)
+	}
+}
+
+// TestEveryRegisteredBackendHasAnEnvironmentProjection closes the gap the
+// projector's default arm exists to catch, from the other side.
+//
+// Both switches sit behind LoadMetadataState, so an unregistered backend can
+// never reach their default arm — which means the arm an operator actually
+// meets is the one a registrar opens by adding a backend name without adding a
+// projection arm for it. This walks the registered set and refuses to let that
+// pair drift. Backends may still fail here for their own reasons (an
+// unreachable host, an unresolvable credential); the one outcome that is a
+// defect is reaching the default arm at all.
+func TestEveryRegisteredBackendHasAnEnvironmentProjection(t *testing.T) {
+	registered, err := contract.RegisteredBackends()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registered) == 0 {
+		t.Fatal("this build registers no backends")
+	}
+
+	// Metadata each backend accepts, so the call reaches its projection arm
+	// rather than stopping at the metadata contract. A name with no entry gets
+	// the bare shape, which is exactly the case this test is here to catch.
+	valid := map[string]string{
+		"dolt":     `{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"hq"}`,
+		"doltlite": `{"database":"doltlite","backend":"doltlite","dolt_database":"hq"}`,
+		"postgres": `{"database":"beads","backend":"postgres","postgres_host":"db.example.com","postgres_port":"5432","postgres_user":"bd","postgres_database":"beads"}`,
+	}
+	for _, backend := range registered {
+		t.Run(backend, func(t *testing.T) {
+			metadata, ok := valid[backend]
+			if !ok {
+				metadata = `{"database":"beads","backend":"` + backend + `"}`
+			}
+			cityPath := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			config := "issue_prefix: demo\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"
+			if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(config), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(metadata), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := applyCanonicalScopeBackendEnv(map[string]string{}, cityPath, cityPath)
+			if err != nil && strings.Contains(err.Error(), "has no environment projection") {
+				t.Fatalf("backend %q is registered but the env projector has no arm for it: %v", backend, err)
+			}
+		})
+	}
+}
+
+// TestUnprojectableBackendErrorNeverReturnsNil exercises the projector's own
+// default arm directly.
+//
+// Both switches sit behind LoadMetadataState, which refuses an unregistered
+// backend first, so no metadata file can reach the arm today — it is
+// defense-in-depth, and defense-in-depth that is never executed is where a
+// silent fall-through hides. The two shapes it must distinguish are an
+// unregistered name (the operator's metadata) and a registered name with no
+// projection arm (a composition defect), and neither may produce a nil error.
+func TestUnprojectableBackendErrorNeverReturnsNil(t *testing.T) {
+	registered, err := contract.RegisteredBackends()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registered) == 0 {
+		t.Fatal("this build registers no backends")
+	}
+
+	unregistered := unprojectableBackendError("sqlite", "/city/rigs/demo")
+	if unregistered == nil {
+		t.Fatal("an unregistered backend produced no error")
+	}
+	if !errors.Is(unregistered, contract.ErrUnknownBackend) {
+		t.Errorf("refusal = %v, want it to wrap ErrUnknownBackend", unregistered)
+	}
+	for _, want := range []string{`"sqlite"`, "/city/rigs/demo", contract.BackendNotOpenedGuarantee} {
+		if !strings.Contains(unregistered.Error(), want) {
+			t.Errorf("refusal %q omits %q", unregistered, want)
+		}
+	}
+
+	// A registered backend reaching the default arm is a composition defect,
+	// not bad metadata, and the message must not blame the operator's file.
+	defect := unprojectableBackendError(registered[0], "/city")
+	if defect == nil {
+		t.Fatal("a registered but unprojectable backend produced no error")
+	}
+	if errors.Is(defect, contract.ErrUnknownBackend) {
+		t.Errorf("refusal %q calls a registered backend unknown", defect)
+	}
+	for _, want := range []string{registered[0], "/city", "registered by this build", contract.BackendNotOpenedGuarantee} {
+		if !strings.Contains(defect.Error(), want) {
+			t.Errorf("refusal %q omits %q", defect, want)
+		}
+	}
+}

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -57,6 +57,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
@@ -247,8 +248,8 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 		// recorded, keeps the event stream honest: a permanently unservable
 		// binding must not publish converged on every boot.
 		if opener := plannedBindingOpener(plan, binding); opener == nil {
-			return nil, fmt.Errorf("%s: binding %q is served by provider %q, which does not open a bead engine, so the classes assigned to it cannot be served",
-				logPrefix, binding, storage.Bindings[binding].Provider)
+			return nil, fmt.Errorf("%s: binding %q is served by provider %q, which does not open a bead engine, so the classes assigned to it cannot be served; %s",
+				logPrefix, binding, storage.Bindings[binding].Provider, contract.BackendNotOpenedGuarantee)
 		}
 		location, err := servedBindingLocation(plan, binding, storage.Bindings[binding])
 		if err != nil {
@@ -618,8 +619,8 @@ func openStorageRoutes(plan *storebinding.StoragePlan, target infraBindingTarget
 	}
 	opener, ok := storebinding.EngineOpenerFor(planned)
 	if !ok {
-		return nil, fmt.Errorf("storage routing: binding %q is served by provider %q, which does not open a bead engine, so the classes assigned to it cannot be served",
-			target.Binding, planned.ProviderID)
+		return nil, fmt.Errorf("storage routing: binding %q is served by provider %q, which does not open a bead engine, so the classes assigned to it cannot be served; %s",
+			target.Binding, planned.ProviderID, contract.BackendNotOpenedGuarantee)
 	}
 	store, closer, err := opener.OpenEngine(planned.Spec, planned.AssignedClasses)
 	if err != nil {

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
@@ -776,6 +777,9 @@ func TestStorageRoutesRefuseAProviderThatOpensNoEngine(t *testing.T) {
 	if !strings.Contains(err.Error(), string(planned.ProviderID)) {
 		t.Errorf("the refusal does not name the provider %q: %v", planned.ProviderID, err)
 	}
+	if !strings.Contains(err.Error(), contract.BackendNotOpenedGuarantee) {
+		t.Errorf("the refusal does not tell the operator their storage is untouched: %v", err)
+	}
 	// Positive evidence that the refusal opened nothing: the binding parent is
 	// listed and the root is not among its entries. A stat of the database
 	// path would report "absent" just as readily for a path typo.
@@ -898,15 +902,29 @@ func TestStorageGateChecksTheRollbackSpelling(t *testing.T) {
 // TestStorageGateRefusesAnUnknownProvider proves the plan's structural refusals
 // reach boot: a binding naming a provider this binary does not compile in stops
 // the city instead of being ignored.
+//
+// The refusal also enumerates the providers this binary does carry. "Provider
+// not found" alone cannot tell an operator whether they typed the ID wrong or
+// are running a build that never had it, and those have different fixes.
 func TestStorageGateRefusesAnUnknownProvider(t *testing.T) {
 	root := t.TempDir()
 	cfg := infraSplitConfig(filepath.Join(root, "store"))
 	cfg.Storage.Bindings["infra"] = config.StorageBindingConfig{Provider: "not-compiled-in", Path: filepath.Join(root, "store")}
 
-	if _, err := storageBootGate(root, cfg, "gc start", nil, io.Discard); err == nil {
+	_, err := storageBootGate(root, cfg, "gc start", nil, io.Discard)
+	if err == nil {
 		t.Fatal("a binding naming an uncompiled provider started the city")
-	} else if !errors.Is(err, storebinding.ErrUnknownProvider) {
-		t.Errorf("the refusal is %v, want an %v", err, storebinding.ErrUnknownProvider)
+	}
+	if !errors.Is(err, storebinding.ErrUnknownProvider) {
+		t.Fatalf("the refusal is %v, want an %v", err, storebinding.ErrUnknownProvider)
+	}
+	if !strings.Contains(err.Error(), `"not-compiled-in"`) {
+		t.Errorf("the refusal does not name the provider: %v", err)
+	}
+	for _, factory := range compiledStorageProviderFactories() {
+		if !strings.Contains(err.Error(), string(factory.ID())) {
+			t.Errorf("the refusal omits compiled provider %q: %v", factory.ID(), err)
+		}
 	}
 }
 

--- a/internal/beads/contract/backend_bundle.go
+++ b/internal/beads/contract/backend_bundle.go
@@ -1,0 +1,81 @@
+package contract
+
+import (
+	"fmt"
+	"sync"
+)
+
+// The sole backend-name composition root.
+//
+// Backend names are compiled in, never discovered. This file names the set once,
+// builds ONE registry from it, freezes it, and every backend refusal in gc reads
+// its enumeration from that registry — so the refusal an operator sees is a
+// statement about the binary in front of them rather than a list some other
+// build's author typed into a format string.
+//
+// There is no init() and no blank-import registration: which backends a build
+// knows is a property of the assembly being built, not of the import graph, and
+// a registration side effect fired by an import has no ordering relation to
+// config load or boot. Construction is deferred to first use, so importing this
+// package still does nothing.
+//
+// An assembly that serves a backend this list omits adds it here — one line, in
+// one file — and every refusal message, in all four paths, enumerates the new
+// set with no other edit.
+
+// compiledBackendNames returns the backend names this build recognizes, in the
+// order refusals enumerate them.
+//
+// UnsetBackend leads because it is not a choice: metadata written before the
+// key existed, and a scope that inherits its city's backend, both name nothing,
+// and that has always been legal at the parse layer. It is registered rather
+// than special-cased so "does this build recognize this backend?" has exactly
+// one answer, in one place.
+func compiledBackendNames() []BackendName {
+	return []BackendName{
+		UnsetBackend,
+		"dolt",
+		"doltlite",
+		"postgres",
+	}
+}
+
+// compiledBackendRegistry builds and freezes this build's backend-name registry
+// exactly once. It is the only place a registry is constructed outside tests.
+var compiledBackendRegistry = sync.OnceValues(newCompiledBackendRegistry)
+
+func newCompiledBackendRegistry() (*BackendRegistry, error) {
+	registry := NewBackendRegistry()
+	for _, name := range compiledBackendNames() {
+		if err := registry.Register(name); err != nil {
+			return nil, fmt.Errorf("registering compiled beads backend: %w", err)
+		}
+	}
+	if err := registry.Freeze(); err != nil {
+		return nil, fmt.Errorf("freezing the beads backend registry: %w", err)
+	}
+	return registry, nil
+}
+
+// RecognizeBackend reports whether this build registers the given backend name.
+// A registered name — including the empty name, which is metadata that names no
+// backend — returns nil. Anything else returns an *UnknownBackendError naming
+// the backend and enumerating what is registered.
+func RecognizeBackend(backend string) error {
+	registry, err := compiledBackendRegistry()
+	if err != nil {
+		return err
+	}
+	return registry.Lookup(BackendName(backend))
+}
+
+// RegisteredBackends returns the operator-selectable backend names this build
+// registers, in registration order. Callers that compose their own refusal
+// wording use it so their enumeration cannot drift from the loader's.
+func RegisteredBackends() ([]string, error) {
+	registry, err := compiledBackendRegistry()
+	if err != nil {
+		return nil, err
+	}
+	return registry.Names(), nil
+}

--- a/internal/beads/contract/backend_registry.go
+++ b/internal/beads/contract/backend_registry.go
@@ -1,0 +1,181 @@
+package contract
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// BackendName is the value of the `backend` key in .beads/metadata.json. It
+// names the storage engine bd serves a scope from; it is not a storage-provider
+// ID (that vocabulary belongs to internal/storebinding and is registered
+// separately).
+type BackendName string
+
+// UnsetBackend is metadata that names no backend at all. It is recognized —
+// scopes written before the key existed, and scopes that inherit their city's
+// backend, legitimately carry it — but it is never enumerated as something an
+// operator may write, because an absent name is not a name.
+const UnsetBackend BackendName = ""
+
+// Backend-name registry errors.
+var (
+	// ErrUnknownBackend reports a backend name this assembly does not register.
+	ErrUnknownBackend = errors.New("unknown beads backend")
+	// ErrDuplicateBackend reports one backend name registered twice.
+	ErrDuplicateBackend = errors.New("duplicate beads backend")
+	// ErrInvalidBackendName reports a backend name that cannot be registered.
+	ErrInvalidBackendName = errors.New("invalid beads backend name")
+	// ErrBackendRegistryFrozen reports a registration attempted after Freeze.
+	ErrBackendRegistryFrozen = errors.New("beads backend registry is frozen")
+	// ErrBackendRegistryNotFrozen reports a lookup attempted before Freeze.
+	ErrBackendRegistryNotFrozen = errors.New("beads backend registry is not frozen")
+	// ErrBackendRegistryUnavailable reports a registry that cannot answer.
+	ErrBackendRegistryUnavailable = errors.New("beads backend registry is unavailable")
+)
+
+// BackendNotOpenedGuarantee is the fail-closed data-safety clause carried by
+// every backend refusal: refusing a scope reads its metadata and stops there.
+// An operator who meets one of these messages needs to know that the database
+// the metadata names is exactly as they left it before they start recovering.
+const BackendNotOpenedGuarantee = "no storage database was opened or modified"
+
+// BackendRegistry is an explicit, freezeable, non-global registry of the
+// backend names one assembly of gc recognizes.
+//
+// It is the storebinding.ProviderRegistry shape applied to a second vocabulary:
+// registration is explicit and returns an error rather than panicking, the
+// registry is frozen before it is read, and lookups return a typed error. There
+// is deliberately no package-level Register: which backends a build knows is a
+// property of the assembly being built, not of who imported what.
+type BackendRegistry struct {
+	mu     sync.RWMutex
+	known  map[BackendName]struct{}
+	names  []BackendName
+	frozen bool
+}
+
+// NewBackendRegistry creates an empty explicit backend-name registry.
+func NewBackendRegistry() *BackendRegistry {
+	return &BackendRegistry{known: make(map[BackendName]struct{})}
+}
+
+// Register adds one backend name before the registry is frozen. UnsetBackend
+// registers the no-backend-named shape and, like every other name, may be
+// registered only once.
+func (r *BackendRegistry) Register(name BackendName) error {
+	if r == nil {
+		return fmt.Errorf("%w: registry is nil", ErrBackendRegistryUnavailable)
+	}
+	if err := validateBackendName(name); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.frozen {
+		return fmt.Errorf("%w: %q", ErrBackendRegistryFrozen, string(name))
+	}
+	if r.known == nil {
+		r.known = make(map[BackendName]struct{})
+	}
+	if _, exists := r.known[name]; exists {
+		return fmt.Errorf("%w: %q", ErrDuplicateBackend, string(name))
+	}
+	r.known[name] = struct{}{}
+	if name != UnsetBackend {
+		r.names = append(r.names, name)
+	}
+	return nil
+}
+
+// Freeze prevents further registration and enables lookups.
+func (r *BackendRegistry) Freeze() error {
+	if r == nil {
+		return fmt.Errorf("%w: registry is nil", ErrBackendRegistryUnavailable)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.frozen = true
+	return nil
+}
+
+// Lookup reports whether a backend name is registered. A registered name
+// returns nil; anything else returns an *UnknownBackendError carrying both the
+// refused name and the registered set.
+func (r *BackendRegistry) Lookup(name BackendName) error {
+	if r == nil {
+		return fmt.Errorf("%w: registry is nil", ErrBackendRegistryUnavailable)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if !r.frozen {
+		return fmt.Errorf("%w: %q", ErrBackendRegistryNotFrozen, string(name))
+	}
+	if _, ok := r.known[name]; ok {
+		return nil
+	}
+	return &UnknownBackendError{Backend: string(name), Registered: r.namesLocked()}
+}
+
+// Names returns the registered operator-selectable backend names in
+// registration order. UnsetBackend is never included.
+func (r *BackendRegistry) Names() []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.namesLocked()
+}
+
+func (r *BackendRegistry) namesLocked() []string {
+	names := make([]string, 0, len(r.names))
+	for _, name := range r.names {
+		names = append(names, string(name))
+	}
+	return names
+}
+
+func validateBackendName(name BackendName) error {
+	if name == UnsetBackend {
+		return nil
+	}
+	for _, runeValue := range string(name) {
+		if (runeValue >= 'a' && runeValue <= 'z') || (runeValue >= '0' && runeValue <= '9') || runeValue == '-' || runeValue == '_' {
+			continue
+		}
+		return fmt.Errorf("%w: %q", ErrInvalidBackendName, string(name))
+	}
+	return nil
+}
+
+// UnknownBackendError refuses a backend name the registry does not carry.
+//
+// It reports three things on purpose, and every backend refusal in gc renders
+// the same three: the name that was refused, what this build actually
+// registers, and the guarantee that nothing was opened. The middle one is why
+// this type exists — an assembly that registers a different set must say so
+// rather than recite a list compiled into a message somewhere else, or the
+// operator is debugging against a build they do not have.
+type UnknownBackendError struct {
+	// Backend is the refused name, exactly as metadata spelled it.
+	Backend string
+	// Registered is the operator-selectable set this assembly carries.
+	Registered []string
+}
+
+// Error implements error.
+func (e *UnknownBackendError) Error() string {
+	return fmt.Sprintf("unsupported backend %q (supported: %s); %s", e.Backend, e.supported(), BackendNotOpenedGuarantee)
+}
+
+// Unwrap supports errors.Is.
+func (e *UnknownBackendError) Unwrap() error { return ErrUnknownBackend }
+
+func (e *UnknownBackendError) supported() string {
+	if len(e.Registered) == 0 {
+		return "none"
+	}
+	return strings.Join(e.Registered, ", ")
+}

--- a/internal/beads/contract/backend_registry_test.go
+++ b/internal/beads/contract/backend_registry_test.go
@@ -1,0 +1,192 @@
+package contract
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func frozenRegistry(t *testing.T, names ...BackendName) *BackendRegistry {
+	t.Helper()
+	registry := NewBackendRegistry()
+	for _, name := range names {
+		if err := registry.Register(name); err != nil {
+			t.Fatalf("Register(%q) error = %v, want nil", string(name), err)
+		}
+	}
+	if err := registry.Freeze(); err != nil {
+		t.Fatalf("Freeze() error = %v, want nil", err)
+	}
+	return registry
+}
+
+func TestBackendRegistryRefusesDuplicateRegistration(t *testing.T) {
+	registry := NewBackendRegistry()
+	if err := registry.Register("dolt"); err != nil {
+		t.Fatalf("first Register(dolt) error = %v, want nil", err)
+	}
+
+	err := registry.Register("dolt")
+	if !errors.Is(err, ErrDuplicateBackend) {
+		t.Fatalf("second Register(dolt) error = %v, want ErrDuplicateBackend", err)
+	}
+	if !strings.Contains(err.Error(), `"dolt"`) {
+		t.Fatalf("duplicate refusal %q does not name the backend", err)
+	}
+}
+
+// TestBackendRegistryRefusesDuplicateUnsetBackend pins that the no-backend-named
+// sentinel is an ordinary registration rather than a special case: registering
+// it twice is the same defect as registering "dolt" twice.
+func TestBackendRegistryRefusesDuplicateUnsetBackend(t *testing.T) {
+	registry := NewBackendRegistry()
+	if err := registry.Register(UnsetBackend); err != nil {
+		t.Fatalf("first Register(unset) error = %v, want nil", err)
+	}
+	if err := registry.Register(UnsetBackend); !errors.Is(err, ErrDuplicateBackend) {
+		t.Fatalf("second Register(unset) error = %v, want ErrDuplicateBackend", err)
+	}
+}
+
+func TestBackendRegistryRefusesRegistrationAfterFreeze(t *testing.T) {
+	registry := frozenRegistry(t, "dolt")
+
+	err := registry.Register("doltlite")
+	if !errors.Is(err, ErrBackendRegistryFrozen) {
+		t.Fatalf("Register after Freeze error = %v, want ErrBackendRegistryFrozen", err)
+	}
+	if got := registry.Names(); !reflect.DeepEqual(got, []string{"dolt"}) {
+		t.Fatalf("a refused registration still landed: Names() = %v", got)
+	}
+}
+
+func TestBackendRegistryRefusesLookupBeforeFreeze(t *testing.T) {
+	registry := NewBackendRegistry()
+	if err := registry.Register("dolt"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := registry.Lookup("dolt"); !errors.Is(err, ErrBackendRegistryNotFrozen) {
+		t.Fatalf("Lookup before Freeze error = %v, want ErrBackendRegistryNotFrozen", err)
+	}
+}
+
+func TestBackendRegistryRefusesInvalidName(t *testing.T) {
+	registry := NewBackendRegistry()
+	for _, name := range []BackendName{"Postgres", "post gres", "pg:14", "dolt\n"} {
+		if err := registry.Register(name); !errors.Is(err, ErrInvalidBackendName) {
+			t.Fatalf("Register(%q) error = %v, want ErrInvalidBackendName", string(name), err)
+		}
+	}
+}
+
+func TestBackendRegistryNamesOmitTheUnsetBackend(t *testing.T) {
+	registry := frozenRegistry(t, UnsetBackend, "dolt", "doltlite")
+
+	if got, want := registry.Names(), []string{"dolt", "doltlite"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Names() = %v, want %v (registration order, no empty name)", got, want)
+	}
+	if err := registry.Lookup(UnsetBackend); err != nil {
+		t.Fatalf("Lookup(unset) error = %v, want nil — metadata that names no backend is recognized", err)
+	}
+}
+
+// TestBackendRegistryRefusalNamesBackendAndEnumeratesRegistered is the property
+// the whole registry exists for: the refusal must be true about the binary that
+// produced it, so an assembly registering a different set says a different
+// sentence rather than reciting a list compiled into a format string.
+func TestBackendRegistryRefusalNamesBackendAndEnumeratesRegistered(t *testing.T) {
+	oss := frozenRegistry(t, UnsetBackend, "dolt", "doltlite")
+
+	err := oss.Lookup("postgres")
+	if !errors.Is(err, ErrUnknownBackend) {
+		t.Fatalf("Lookup(postgres) error = %v, want ErrUnknownBackend", err)
+	}
+	var unknown *UnknownBackendError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("Lookup error %T = %v, want *UnknownBackendError", err, err)
+	}
+	if unknown.Backend != "postgres" {
+		t.Fatalf("UnknownBackendError.Backend = %q, want %q", unknown.Backend, "postgres")
+	}
+	if got, want := unknown.Registered, []string{"dolt", "doltlite"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("UnknownBackendError.Registered = %v, want %v", got, want)
+	}
+	if got, want := err.Error(), `unsupported backend "postgres" (supported: dolt, doltlite); `+BackendNotOpenedGuarantee; got != want {
+		t.Fatalf("refusal = %q, want %q", got, want)
+	}
+
+	withPostgres := frozenRegistry(t, UnsetBackend, "dolt", "doltlite", "postgres")
+	if err := withPostgres.Lookup("postgres"); err != nil {
+		t.Fatalf("an assembly that registers postgres refused it: %v", err)
+	}
+	if got, want := withPostgres.Lookup("postgress").Error(),
+		`unsupported backend "postgress" (supported: dolt, doltlite, postgres); `+BackendNotOpenedGuarantee; got != want {
+		t.Fatalf("refusal = %q, want %q", got, want)
+	}
+}
+
+func TestBackendRegistryRefusalOnEmptyRegistrySaysNone(t *testing.T) {
+	registry := frozenRegistry(t)
+
+	if got, want := registry.Lookup("dolt").Error(),
+		`unsupported backend "dolt" (supported: none); `+BackendNotOpenedGuarantee; got != want {
+		t.Fatalf("refusal = %q, want %q", got, want)
+	}
+}
+
+// TestCompiledBackendBundleIsWellFormed pins the composition root itself. The
+// bundle is the one list an assembly edits, and a duplicate or malformed entry
+// in it would otherwise surface as an unrelated failure at a city's first read.
+func TestCompiledBackendBundleIsWellFormed(t *testing.T) {
+	registry, err := compiledBackendRegistry()
+	if err != nil {
+		t.Fatalf("compiledBackendRegistry() error = %v, want nil", err)
+	}
+	if err := registry.Register("late"); !errors.Is(err, ErrBackendRegistryFrozen) {
+		t.Fatalf("the compiled registry is not frozen: Register error = %v", err)
+	}
+}
+
+// TestCompiledBackendBundleStillCarriesPostgres pins slice E0's deliberate
+// scope: the hardcoded allowlist becomes a registry and nothing else changes.
+// Removing postgres from OSS is a later slice that waits on the enterprise
+// registration hook existing, and doing it here would break every OSS city
+// whose metadata names it.
+func TestCompiledBackendBundleStillCarriesPostgres(t *testing.T) {
+	names, err := RegisteredBackends()
+	if err != nil {
+		t.Fatalf("RegisteredBackends() error = %v, want nil", err)
+	}
+	if want := []string{"dolt", "doltlite", "postgres"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("RegisteredBackends() = %v, want %v", names, want)
+	}
+}
+
+func TestRecognizeBackendAcceptsEveryCompiledName(t *testing.T) {
+	for _, name := range compiledBackendNames() {
+		if err := RecognizeBackend(string(name)); err != nil {
+			t.Fatalf("RecognizeBackend(%q) error = %v, want nil", string(name), err)
+		}
+	}
+}
+
+func TestRecognizeBackendRefusalEnumeratesTheCompiledSet(t *testing.T) {
+	err := RecognizeBackend("postgress")
+	if !errors.Is(err, ErrUnknownBackend) {
+		t.Fatalf("RecognizeBackend(postgress) error = %v, want ErrUnknownBackend", err)
+	}
+
+	names, namesErr := RegisteredBackends()
+	if namesErr != nil {
+		t.Fatal(namesErr)
+	}
+	want := `unsupported backend "postgress" (supported: ` + strings.Join(names, ", ") + `); ` + BackendNotOpenedGuarantee
+	if err.Error() != want {
+		t.Fatalf("refusal = %q, want %q", err.Error(), want)
+	}
+	if !strings.Contains(err.Error(), BackendNotOpenedGuarantee) {
+		t.Fatalf("refusal %q drops the data-safety guarantee", err)
+	}
+}

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -127,11 +127,19 @@ type MetadataParseError struct {
 	Path string
 	// Reason is the verbatim rejection reason text (the part after `: `).
 	Reason string
+	// Err is the typed cause, when the rejection has one. E2 carries
+	// *UnknownBackendError so a caller can ask whether this build simply does
+	// not register the backend — a fact worth acting on differently from
+	// malformed metadata — without matching on Reason.
+	Err error
 }
 
 func (e *MetadataParseError) Error() string {
 	return fmt.Sprintf("load metadata %s: %s", e.Path, e.Reason)
 }
+
+// Unwrap exposes the typed cause for errors.Is and errors.As.
+func (e *MetadataParseError) Unwrap() error { return e.Err }
 
 var deprecatedMetadataKeys = []string{
 	"dolt_host",
@@ -368,9 +376,13 @@ func ReadDoltDatabase(fs fsys.FS, path string) (string, bool, error) {
 // Validation order is deterministic: the operator always sees the same
 // top-most message when several things are wrong. Order is JSON parse (E1) →
 // mixed-backend (E3) → unknown backend (E2) → postgres-required (E4) →
-// postgres-port-format (E5). An empty Backend is permitted at the parse
-// layer; downstream consumers that need a backend must check
-// state.Backend != "" themselves.
+// postgres-port-format (E5). E2 asks the compiled backend-name registry
+// (backend_bundle.go) rather than a literal allowlist, so its refusal
+// enumerates what this build actually registers; the position of the question
+// in the ladder is unchanged and pinned by
+// TestLoadMetadataStateRejectionOrderIsPinned. An empty Backend is permitted at
+// the parse layer — it is a registered name — and downstream consumers that
+// need a backend must check state.Backend != "" themselves.
 func LoadMetadataState(fs fsys.FS, path string) (MetadataState, bool, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
@@ -400,14 +412,8 @@ func LoadMetadataState(fs fsys.FS, path string) (MetadataState, bool, error) {
 		}
 	}
 
-	switch state.Backend {
-	case "", "dolt", "doltlite", "postgres":
-		// allowed
-	default:
-		return MetadataState{}, false, &MetadataParseError{
-			Path:   abs,
-			Reason: fmt.Sprintf("unsupported backend %q (supported: dolt, doltlite, postgres)", state.Backend),
-		}
+	if err := RecognizeBackend(state.Backend); err != nil {
+		return MetadataState{}, false, &MetadataParseError{Path: abs, Reason: err.Error(), Err: err}
 	}
 
 	if state.Backend == "postgres" {

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -1642,6 +1642,119 @@ func TestLoadMetadataStateRejectFixtures(t *testing.T) {
 	}
 }
 
+// TestLoadMetadataStateRejectionOrderIsPinned holds the documented E1 → E3 → E2
+// → E4 → E5 ladder in place.
+//
+// The order is a contract, not an accident: an operator whose metadata is wrong
+// in several ways must see the same top-most message on every gc invocation, or
+// the fix they are told to make changes between two runs of the same command.
+// Each case below violates two adjacent rungs at once and asserts which one
+// speaks, so swapping any pair of checks in LoadMetadataState fails here.
+func TestLoadMetadataStateRejectionOrderIsPinned(t *testing.T) {
+	fs := fsys.OSFS{}
+	cases := []struct {
+		name     string
+		metadata string
+		want     string
+		loses    string
+	}{
+		{
+			name:     "E1 parse beats everything downstream",
+			metadata: `{"backend":"postgress","dolt_database":"hq","postgres_host":"h"`,
+			want:     "invalid metadata.json:",
+			loses:    "unsupported backend",
+		},
+		{
+			name:     "E3 mixed backends beats E2 unknown backend",
+			metadata: `{"backend":"postgress","dolt_database":"hq","postgres_host":"h"}`,
+			want:     "cannot mix dolt and postgres fields in a single scope (backend=postgress but dolt_database is also set)",
+			loses:    "unsupported backend",
+		},
+		{
+			name:     "E2 unknown backend speaks once nothing is mixed",
+			metadata: `{"backend":"postgress","database":"beads"}`,
+			want:     `unsupported backend "postgress"`,
+			loses:    "cannot mix dolt and postgres fields",
+		},
+		{
+			name:     "E3 mixed backends beats E4 postgres-required",
+			metadata: `{"backend":"postgres","dolt_database":"hq"}`,
+			want:     "cannot mix dolt and postgres fields in a single scope (backend=postgres but dolt_database is also set)",
+			loses:    "backend=postgres requires",
+		},
+		{
+			name:     "E4 postgres-required beats E5 port format",
+			metadata: `{"backend":"postgres","postgres_host":"h","postgres_port":"abc","postgres_database":"d"}`,
+			want:     "backend=postgres requires postgres_dsn or all of postgres_host, postgres_port, postgres_user, postgres_database",
+			loses:    "must be a TCP port",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "metadata.json")
+			if err := fs.WriteFile(path, []byte(tc.metadata), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, ok, err := LoadMetadataState(fs, path)
+			if err == nil || ok {
+				t.Fatalf("LoadMetadataState() = ok %v, err %v, want a rejection", ok, err)
+			}
+			var parseErr *MetadataParseError
+			if !errors.As(err, &parseErr) {
+				t.Fatalf("LoadMetadataState() error %T = %v, want *MetadataParseError", err, err)
+			}
+			if !strings.Contains(parseErr.Reason, tc.want) {
+				t.Fatalf("top-most rejection = %q, want substring %q", parseErr.Reason, tc.want)
+			}
+			if strings.Contains(parseErr.Reason, tc.loses) {
+				t.Fatalf("rejection %q reports the later check %q — the ladder was reordered", parseErr.Reason, tc.loses)
+			}
+		})
+	}
+}
+
+// TestLoadMetadataStateUnknownBackendEnumeratesTheRegisteredSet asserts the
+// content of the E2 refusal, not just that one happened.
+//
+// The message is the deliverable. gc is assembled in more than one shape, and a
+// refusal that recites a list some other assembly's author typed sends the
+// operator to debug a build they do not have. Reading the enumeration back out
+// of the registry is what keeps the sentence true wherever it is printed.
+func TestLoadMetadataStateUnknownBackendEnumeratesTheRegisteredSet(t *testing.T) {
+	fs := fsys.OSFS{}
+	path, _ := copyMetadataFixture(t, fs, "reject_unknown_backend.json")
+
+	_, _, err := LoadMetadataState(fs, path)
+	if err == nil {
+		t.Fatal("LoadMetadataState() accepted an unregistered backend")
+	}
+	if !errors.Is(err, ErrUnknownBackend) {
+		t.Fatalf("LoadMetadataState() error = %v, want ErrUnknownBackend", err)
+	}
+
+	registered, regErr := RegisteredBackends()
+	if regErr != nil {
+		t.Fatal(regErr)
+	}
+	var parseErr *MetadataParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("LoadMetadataState() error %T = %v, want *MetadataParseError", err, err)
+	}
+	want := `unsupported backend "postgress" (supported: ` + strings.Join(registered, ", ") + `); ` + BackendNotOpenedGuarantee
+	if parseErr.Reason != want {
+		t.Fatalf("E2 reason = %q, want %q", parseErr.Reason, want)
+	}
+	for _, name := range registered {
+		if !strings.Contains(parseErr.Reason, name) {
+			t.Fatalf("E2 reason %q omits registered backend %q", parseErr.Reason, name)
+		}
+	}
+	if !strings.Contains(parseErr.Reason, BackendNotOpenedGuarantee) {
+		t.Fatalf("E2 reason %q drops the data-safety guarantee", parseErr.Reason)
+	}
+}
+
 func TestLoadMetadataStateSurfacesIOErrors(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()

--- a/internal/storebinding/provider.go
+++ b/internal/storebinding/provider.go
@@ -1565,9 +1565,25 @@ func (r *ProviderRegistry) Lookup(id ProviderID) (ProviderFactory, error) {
 	}
 	factory, ok := r.factories[id]
 	if !ok {
-		return nil, fmt.Errorf("%w: %q", ErrUnknownProvider, id)
+		return nil, fmt.Errorf("%w: %q (compiled in: %s)", ErrUnknownProvider, id, strings.Join(r.registeredIDsLocked(), ", "))
 	}
 	return factory, nil
+}
+
+// registeredIDsLocked lists the provider IDs compiled into this registry so a
+// refusal can enumerate them. "Provider not found" is only actionable next to
+// the list it was not found in — otherwise the operator cannot tell a typo from
+// a build that never carried the provider.
+func (r *ProviderRegistry) registeredIDsLocked() []string {
+	ids := make([]string, 0, len(r.factories))
+	for id := range r.factories {
+		ids = append(ids, string(id))
+	}
+	sort.Strings(ids)
+	if len(ids) == 0 {
+		return []string{"none"}
+	}
+	return ids
 }
 
 // New validates a binding and constructs only its exact registered provider.

--- a/internal/storebinding/provider_registry_test.go
+++ b/internal/storebinding/provider_registry_test.go
@@ -31,6 +31,38 @@ func TestProviderRegistryRequiresExactFrozenRegistration(t *testing.T) {
 	}
 }
 
+// TestProviderRegistryRefusalEnumeratesCompiledProviders pins the second half
+// of an unknown-provider refusal. Naming the ID that was not found tells an
+// operator nothing about whether they typed it wrong or are running a build
+// that never carried it; the list it was not found in is what separates those.
+func TestProviderRegistryRefusalEnumeratesCompiledProviders(t *testing.T) {
+	registry := NewProviderRegistry()
+	for _, id := range []ProviderID{"builtin-two", "builtin-one"} {
+		if err := registry.Register(&recordingFactory{id: id}); err != nil {
+			t.Fatalf("Register(%s): %v", id, err)
+		}
+	}
+	if err := registry.Freeze(); err != nil {
+		t.Fatalf("Freeze(): %v", err)
+	}
+
+	_, err := registry.Lookup(ProviderID("builtin-missing"))
+	if !errors.Is(err, ErrUnknownProvider) {
+		t.Fatalf("Lookup(unknown) error = %v, want ErrUnknownProvider", err)
+	}
+	if want := `unknown storage provider: "builtin-missing" (compiled in: builtin-one, builtin-two)`; err.Error() != want {
+		t.Fatalf("refusal = %q, want %q", err.Error(), want)
+	}
+
+	empty := NewProviderRegistry()
+	if err := empty.Freeze(); err != nil {
+		t.Fatalf("empty Freeze(): %v", err)
+	}
+	if _, err := empty.Lookup(ProviderID("builtin-one")); err == nil || !strings.Contains(err.Error(), "compiled in: none") {
+		t.Fatalf("empty-registry refusal = %v, want it to say nothing is compiled in", err)
+	}
+}
+
 func TestProviderRegistryUsesOneExactFactoryAndHasNoGlobalFallback(t *testing.T) {
 	registry := NewProviderRegistry()
 	wanted := &recordingFactory{id: ProviderID("builtin-wanted"), provider: &recordingProvider{}}


### PR DESCRIPTION
Implements **ga-jpxww** — E0 of the postgres-extraction program. Everything else in that program waits on this cell.

## What this is

`internal/beads/contract/files.go` decided which storage backends gc knows with a literal allowlist:

```go
switch state.Backend {
case "", "dolt", "doltlite", "postgres":
default:
    Reason: fmt.Sprintf("unsupported backend %q (supported: dolt, doltlite, postgres)", state.Backend)
}
```

Both halves are wrong for a codebase assembled in more than one shape. The set is not editable without touching the loader, and the refusal recites a list typed into a format string — a sentence that may not describe the binary the operator is actually running.

This replaces both with an explicit registry, and changes **nothing else**.

## Intentionally behaviour-preserving

**OSS still registers `postgres`.** The compiled set is `""`, `dolt`, `doltlite`, `postgres` — identical to the allowlist it replaces. Every city that boots today boots after this change, every committed fixture keeps its verdict, and the E2 message keeps its existing text as a prefix.

That is deliberate, not an oversight. Removing postgres from OSS is a later slice (E3) that waits on the enterprise registration hook (E2) existing for an assembly to add it back. Shipping E0 and E3 together would leave OSS unable to read a city whose metadata names postgres. `TestCompiledBackendBundleStillCarriesPostgres` pins the scope so a later slice has to make the removal explicit.

## The registry shape

`contract.BackendRegistry` is `storebinding.ProviderRegistry` applied to a second vocabulary — the shape this codebase's own five-arm boundary test already enforces for storage providers:

- explicit and non-global; there is no package-level `Register`
- freezeable; `Lookup` refuses on an unfrozen registry
- `Register` returns an **error** on a duplicate or malformed name; it does not panic
- `Lookup` returns a typed error (`*UnknownBackendError`, unwrapping to `ErrUnknownBackend`)

No `init()`, no blank-import registration. Which backends a build knows is a property of the assembly being built, not of the import graph — and a registration side effect fired by an import has no ordering relation to config load or boot, which is exactly the hazard the metadata allowlist, the env projector and the doctor checks all sit inside.

`backend_bundle.go` is the sole composition root, mirroring `cmd/gc/storage_provider_bundle.go`: one list, built and frozen once on first use via `sync.OnceValues`, so importing the package still does nothing. An assembly that serves a backend the list omits adds **one line to one file**, and every refusal message in all four paths enumerates the new set with no other edit. That single-line, single-file extension point is what E2 build-tag-splits.

The empty name is *registered* rather than special-cased, so "does this build recognize this backend?" has exactly one answer in one place. It is excluded from the enumeration, because an absent name is not a name an operator can write.

## Loud failure on all four paths (Invariant 0)

An unregistered backend must fail by name and never fall through to the work store. Each path now names the thing it refused, enumerates what this build registers, and states the data-safety guarantee gc has always honoured but never said out loud — borrowed from bd's centralised message module (`internal/configfile/backend_messages.go`, `BackendNotOpenedGuarantee`):

| path | change |
|---|---|
| **metadata load** (`files.go`) | `RecognizeBackend`, wrapped in `*MetadataParseError` — which now unwraps to `ErrUnknownBackend`, so callers can discriminate an unregistered backend from malformed metadata without matching on text |
| **env projection** (`bd_env.go`, both switches) | one helper that distinguishes an unregistered name (the operator's metadata) from a registered name with no projection arm (a composition defect), and never returns nil |
| **storage plan** (`ProviderRegistry.Lookup`) | now enumerates the compiled provider IDs — "provider not found" alone cannot tell an operator whether they typed the ID wrong or are running a build that never had it, and those have different fixes |
| **class serving** (`storage_boot.go`, both engine-opener refusals) | carries the not-opened guarantee |

The provider-ID paths keep their own vocabulary and their own registry; they were already loud and by-name, and this PR adds the enumeration and the guarantee rather than folding them into backend names.

## Preserving the E1–E5 ladder and the fixtures

The documented rejection order — JSON parse (E1) → mixed-backend (E3) → unknown backend (E2) → postgres-required (E4) → postgres-port-format (E5) — is a contract: an operator whose metadata is wrong in several ways must see the same top-most message on every invocation, or the fix they are told to make changes between two runs of the same command.

Only the *question* at E2 changed (registry instead of literal); its position did not. `TestLoadMetadataStateRejectionOrderIsPinned` now holds the whole ladder with inputs that violate two adjacent rungs at once and assert which one speaks — so a reorder fails here rather than being discovered in an incident.

Fixtures under `internal/beads/contract/testdata/metadata/` are untouched and every verdict is unchanged. The one deliberate text change is the E2 refusal, which keeps its existing prefix and appends the data-safety clause the bead asks for:

```
unsupported backend "postgress" (supported: dolt, doltlite, postgres); no storage database was opened or modified
```

The committed assertion in `files_test.go` still matches verbatim.

## Tests

- `TestLoadMetadataStateRejectionOrderIsPinned` — the full ladder. Red before: swapping E2 ahead of E3 reports `unsupported backend "postgress" ...` where the mixed-backend message is required.
- `TestLoadMetadataStateUnknownBackendEnumeratesTheRegisteredSet` — asserts the refusal text against the registry rather than a constant, because its truthfulness in more than one assembly is the entire point. Red before: `error = load metadata …: unsupported backend "postgress" (supported: dolt, doltlite, postgres), want ErrUnknownBackend`.
- `TestEveryRegisteredBackendHasAnEnvironmentProjection` — closes the gap from the other side. Both projector switches sit behind `LoadMetadataState`, so their default arm cannot be reached by any metadata file; the arm an operator actually meets is the one a registrar opens by adding a name without adding a projection arm. Adding a bogus name to the bundle turns it red.
- `TestProviderRegistryRefusalEnumeratesCompiledProviders` and the extended `TestStorageGateRefusesAnUnknownProvider` / `TestStorageRoutesRefuseAProviderThatOpensNoEngine` — the provider-ID half.
- Registry unit tests: duplicate registration, duplicate unset backend, registration after freeze, lookup before freeze, malformed names, empty-registry enumeration, and the compiled bundle's own well-formedness.

## Gates

`go build ./...` · `go vet ./...` · `gofmt` · `golangci-lint 2.10.1` (0 issues) · `go test ./internal/beads/... ./internal/testpolicy/... ./internal/storebinding/...` · `go test ./cmd/gc -timeout 25m` (783s, pass) · `scripts/check-core-boundary.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
