### PR TITLE
fix(dashboardbff): pin canonical a//b/ diff prefixes against ambient …

### DIFF
--- a/internal/config/pack_fetch_test.go
+++ b/internal/config/pack_fetch_test.go
@@ -230,7 +230,11 @@ func TestUpdatePack(t *testing.T) {
 	}
 	mustGit(t, pushDir, "add", "-A")
 	mustGit(t, pushDir, "commit", "-m", "v2")
-	mustGit(t, pushDir, "push")
+	// Explicit refspec: a bare `git push` relies on push.default, which ambient
+	// user config commonly sets to "nothing" (refusing the push). Pushing HEAD
+	// to origin is deterministic regardless of push.default and of the default
+	// branch name (master/main), simulating upstream advancement reliably.
+	mustGit(t, pushDir, "push", "origin", "HEAD")
 
 	// Update cache.
 	if err := updatePack(cacheDir, ""); err != nil {
@@ -277,7 +281,10 @@ func TestUpdatePackWithBranchRef(t *testing.T) {
 	}
 	mustGit(t, pushDir, "add", "-A")
 	mustGit(t, pushDir, "commit", "-m", "v2")
-	mustGit(t, pushDir, "push")
+	// Explicit refspec: see TestUpdatePack — a bare `git push` depends on
+	// push.default, which ambient config may set to "nothing". Push HEAD to
+	// origin deterministically, independent of push.default and branch name.
+	mustGit(t, pushDir, "push", "origin", "HEAD")
 
 	// Update cache with explicit branch ref.
 	if err := updatePack(cacheDir, "main"); err != nil {

--- a/internal/runtime/runtimecapability/runner_test.go
+++ b/internal/runtime/runtimecapability/runner_test.go
@@ -84,6 +84,9 @@ for tprog in gc bd git; do printf '#!/bin/sh\nexit 127\n' > "$D/bin/$tprog"; chm
 		copyBack = `:` // transcript egress not wired (mutant)
 	}
 
+	failbin := `mkdir -p "$S/failbin"
+for tprog in gc bd git; do printf '#!/bin/sh\nexit 1\n' > "$S/failbin/$tprog"; chmod +x "$S/failbin/$tprog"; done`
+
 	body := fmt.Sprintf(`#!/bin/sh
 S=%q
 op="$1"; name="$2"
@@ -100,6 +103,7 @@ case "$op" in
     %s
     %s
     %s
+    %s
     ;;
   exec)
     cmd=$(cat)
@@ -108,7 +112,12 @@ case "$op" in
     cd "$D/workdir" || exit 1
     # Controlled PATH so the "session" models an isolated sandbox: only the
     # reference-installed tools ($D/bin) + base utils — host gc/bd do not leak.
-    PATH="$D/bin:/usr/bin:/bin" sh -c "$cmd"
+    # $S/failbin sits between $D/bin and /usr/bin holding failing gc/bd/git
+    # stubs: a runtime that installs its toolchain ($D/bin) shadows them, while
+    # one that forgets hits the stubs (not the host's real tools in /usr/bin),
+    # so the tooling probe fails for the right reason even on hosts that ship
+    # gc/bd/git in /usr/bin.
+    PATH="$D/bin:$S/failbin:/usr/bin:/bin" sh -c "$cmd"
     exit $?
     ;;
   stop)
@@ -118,7 +127,7 @@ case "$op" in
   is-running) [ -d "$D" ] && echo true || echo false ;;
   *) exit 2 ;;
 esac
-`, state, capsJSON, materialize, install, inject, wire, copyBack)
+`, state, capsJSON, failbin, materialize, install, inject, wire, copyBack)
 
 	path := filepath.Join(t.TempDir(), "gc-runtime-ref")
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {


### PR DESCRIPTION
## Summary

The run-diff endpoint assumed `git diff` emits `diff --git a/<path> b/<path>` headers: diffGitHeaderRE, normalizeGitDiffPath, and the SPA's diff viewer all require exactly the a//b/ prefixes. But cleanEnv() forwards HOME, so git honored ambient user/global config. A developer dotfile with diff.noprefix=true (common) or diff.srcPrefix="" strips those prefixes, serving prefix-less patches the SPA cannot parse and that bypass the .beads/.gc block filter (diffGitHeaderRE no longer matches, so isReviewablePatchBlock keeps every block).

Pin the canonical shape in gitHardeningArgs via -c overrides (noprefix=false, relative=false, srcPrefix=a/, dstPrefix=b/), which win over system/global/repo config. Verified --name-status and --porcelain output is unchanged (bare paths), so changedFiles/status wire shapes are unaffected; only Patch gains the prefixes it always required.

Added TestRunDiffImmuneToAmbientDiffDisplayConfig, a portable regression guard that injects the prefix-stripping config into the repo so the guard holds on clean runners, not just those carrying ambient ~/.gitconfig. The pre-existing TestRunDiffIncludesUntrackedNewFiles was the original failing test on this host.

Associated issue: #5146 

Found+fixed using GLM 5.2

## Testing

- [X] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [X] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
