### PR TITLE
fix(beads): run the conditional-release CAS against a bd that has the flags (ga-nv0i3)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -14,7 +14,7 @@ This devcontainer reproduces a development environment for [gastownhall/gascity]
 | `git` | devcontainer feature | latest |
 | `gh` | devcontainer feature | latest |
 | `dolt` | `.github/scripts/install-dolt-archive.sh` (SHA-256 verified) | `DOLT_VERSION` from `deps.env` (currently 2.1.7) |
-| `bd` (Beads CLI) | `.github/scripts/install-bd-archive.sh` (SHA-256 verified) | `BD_VERSION` from `deps.env` (currently v1.0.4) |
+| `bd` (Beads CLI) | `.github/scripts/install-bd-archive.sh` (SHA-256 verified) | `BD_VERSION` from `deps.env` (currently v1.1.0) |
 | `gc` (Gas City) | `make install` from source | built from current commit |
 
 Versions come from `deps.env` so bumping is one file change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,13 @@ jobs:
         run: bd version
       - name: bd CLI contract (current)
         run: make test-bd-cli-contract
+      # The conditional-release CAS is the one bd contract only this cell can
+      # run: BdStore.ReleaseIfCurrent prefers bd's --if-assignee/--if-status verb
+      # (a rejected precondition is exit 13), and BD_VERSION — every other job's
+      # bd — is a published release that predates it, so the row skips there and
+      # the wisp-tier fix rides unguarded. The target refuses to skip.
+      - name: bd conditional-release CAS contract (current)
+        run: make test-bd-conditional-release-contract
 
   # NON-REQUIRED HEADxHEAD radar: builds bd from beads MAIN HEAD (live, not the
   # pinned BD_CURRENT_REF) and runs gc-HEAD's real bd CLI contract against it —

--- a/Makefile
+++ b/Makefile
@@ -561,12 +561,36 @@ test-bd-cli-contract:
 ## `--if-assignee`/`--if-status`, so it belongs on the source-built
 ## BD_CURRENT_REF cell. GC_REQUIRE_BD_CONDITIONAL_RELEASE=1 turns the row's
 ## capability skip into a failure, so the cell cannot pass while proving nothing.
+##
+## The existence preflight closes the other way this cell can pass having proven
+## nothing: a `-run` selector that matches no test is not an error to `go test`
+## — it prints "[no tests to run]" and exits 0 — so renaming the row, moving it
+## to another package, or dropping its build tag would leave a permanently green
+## cell guarding nothing. `go test -list` resolves the SAME name, package and
+## tags the run below uses, from the same variables, and must print the name
+## back. Deriving both from one variable is why this guard cannot rot into a
+## false pass: there is no second copy of the selector to drift, and any change
+## to `-list` output that broke the match would fail the cell loudly rather than
+## silently stop catching (which is the failure mode of grepping `go test`'s
+## human-facing "no tests to run" warning instead).
 BD_CONDITIONAL_RELEASE_TIMEOUT ?= 10m
+BD_CONDITIONAL_RELEASE_TEST = TestBdStoreReleaseIfCurrentAgainstRealBd
+BD_CONDITIONAL_RELEASE_PKG = ./internal/beads
 test-bd-conditional-release-contract:
 	@command -v bd >/dev/null 2>&1 || (echo "Error: bd not found; cannot run the conditional-release contract" >&2; exit 1)
+	@listed=$$($(TEST_ENV) GOFLAGS= GOENV=off GOWORK=off go test -tags integration \
+		-list '^$(BD_CONDITIONAL_RELEASE_TEST)$$' $(BD_CONDITIONAL_RELEASE_PKG) 2>&1) || { \
+		printf '%s\n' "$$listed" >&2; \
+		echo "Error: could not list $(BD_CONDITIONAL_RELEASE_TEST) in $(BD_CONDITIONAL_RELEASE_PKG)" >&2; \
+		exit 1; }; \
+	printf '%s\n' "$$listed" | grep -qx '$(BD_CONDITIONAL_RELEASE_TEST)' || { \
+		echo "Error: $(BD_CONDITIONAL_RELEASE_TEST) does not exist in $(BD_CONDITIONAL_RELEASE_PKG) under -tags integration." >&2; \
+		echo "The -run selector below would match nothing, and this cell would pass having run no test." >&2; \
+		echo "Point BD_CONDITIONAL_RELEASE_TEST/_PKG at the row's current name and home." >&2; \
+		exit 1; }
 	$(TEST_ENV) GC_REQUIRE_BD_CONDITIONAL_RELEASE=1 GOFLAGS= GOENV=off GOWORK=off \
 		go test -tags integration -timeout $(BD_CONDITIONAL_RELEASE_TIMEOUT) -count=1 \
-		-run '^TestBdStoreReleaseIfCurrentAgainstRealBd$$' ./internal/beads
+		-run '^$(BD_CONDITIONAL_RELEASE_TEST)$$' $(BD_CONDITIONAL_RELEASE_PKG)
 
 ## test-acceptance-b: run Tier B acceptance tests (lifecycle, ~5 min, nightly)
 ACCEPTANCE_B_TIMEOUT ?= 10m

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-split-topology-rows check-version-tag lint lint-full lint-new lint-changed lint-affected fmt-check fmt-check-changed fmt vet test test-ci-policy test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-productmetrics-testhook test-worker-core test-worker-core-phase2 test-worker-core-phase2-all test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover check-self-contained install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go dashboard-e2e-play dashboard-e2e
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-split-topology-rows check-version-tag lint lint-full lint-new lint-changed lint-affected fmt-check fmt-check-changed fmt vet test test-ci-policy test-mac test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-productmetrics-testhook test-worker-core test-worker-core-phase2 test-worker-core-phase2-all test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-bd-conditional-release-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover check-self-contained install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go dashboard-e2e-play dashboard-e2e
 .PHONY: check-release-dist-ignore
 
 ## build: compile gc binary with version metadata
@@ -554,6 +554,19 @@ test-bd-cli-contract:
 	@command -v bd >/dev/null 2>&1 || (echo "Error: bd not found; cannot run external CLI contract" >&2; exit 1)
 	$(TEST_ENV) go test -tags acceptance_bd_contract -timeout $(BD_CLI_CONTRACT_TIMEOUT) -count=1 \
 		-run '^(TestBdBasicCRUD|TestBdDependencies|TestBdDestructive|TestBdWorkflow)$$' ./test/acceptance
+
+## test-bd-conditional-release-contract: run the ReleaseIfCurrent CAS contract
+## against the bd on PATH. Split from test-bd-cli-contract because it is the one
+## bd contract the installable default cannot run: deps.env BD_VERSION predates
+## `--if-assignee`/`--if-status`, so it belongs on the source-built
+## BD_CURRENT_REF cell. GC_REQUIRE_BD_CONDITIONAL_RELEASE=1 turns the row's
+## capability skip into a failure, so the cell cannot pass while proving nothing.
+BD_CONDITIONAL_RELEASE_TIMEOUT ?= 10m
+test-bd-conditional-release-contract:
+	@command -v bd >/dev/null 2>&1 || (echo "Error: bd not found; cannot run the conditional-release contract" >&2; exit 1)
+	$(TEST_ENV) GC_REQUIRE_BD_CONDITIONAL_RELEASE=1 GOFLAGS= GOENV=off GOWORK=off \
+		go test -tags integration -timeout $(BD_CONDITIONAL_RELEASE_TIMEOUT) -count=1 \
+		-run '^TestBdStoreReleaseIfCurrentAgainstRealBd$$' ./internal/beads
 
 ## test-acceptance-b: run Tier B acceptance tests (lifecycle, ~5 min, nightly)
 ACCEPTANCE_B_TIMEOUT ?= 10m

--- a/deps.env
+++ b/deps.env
@@ -8,12 +8,16 @@ DOLT_VERSION=2.1.7
 BD_REPO=gastownhall/beads
 # BD_VERSION is the installable default: a PUBLISHED beads release whose tarball
 # SHA is pinned in .github/scripts/install-bd-archive.sh. It cannot move past the
-# conditional-write flags yet, and that is an upstream fact, not an oversight:
-# `--if-assignee`/`--if-status` (a rejected precondition is exit 13, nothing
-# written) landed on beads main in 6e8af8bf8 (beads#5008, 2026-07-24) and were
-# ported to proxied-server mode in 4b1d9c875 (beads#5364), while the newest
-# published release — v1.1.2 — was cut from the hotfix/v1.1.1 branch off v1.1.0
-# and carries neither (verified: its `bd update --help` names no --if-assignee).
+# conditional-write flags yet, and that is an upstream fact, not an oversight.
+# The capability boundary is ONE commit: `--if-assignee`/`--if-status` (a
+# rejected precondition is exit 13, nothing written, which is where the exit-13
+# constant comes from) landed on beads main in 6e8af8bf8 (beads#5008,
+# 2026-07-24). Compare bd pins against #5008, not against 4b1d9c875 (beads#5364,
+# 2026-08-05), which only ports the same CAS to proxied-server mode — a bd after
+# #5008 and before #5364 already has the flags on the embedded path this repo's
+# contract exercises. The newest published release — v1.1.2 — was cut from the
+# hotfix/v1.1.1 branch off v1.1.0 and predates both (verified: its
+# `bd update --help` names no --if-assignee).
 # Until beads publishes a release cut from main, the only flag-capable bd CI can
 # obtain is the source-built BD_CURRENT_REF cell below, which is where the
 # ReleaseIfCurrent CAS contract runs. Promote BD_VERSION the day that release

--- a/deps.env
+++ b/deps.env
@@ -6,6 +6,18 @@
 
 DOLT_VERSION=2.1.7
 BD_REPO=gastownhall/beads
+# BD_VERSION is the installable default: a PUBLISHED beads release whose tarball
+# SHA is pinned in .github/scripts/install-bd-archive.sh. It cannot move past the
+# conditional-write flags yet, and that is an upstream fact, not an oversight:
+# `--if-assignee`/`--if-status` (a rejected precondition is exit 13, nothing
+# written) landed on beads main in 6e8af8bf8 (beads#5008, 2026-07-24) and were
+# ported to proxied-server mode in 4b1d9c875 (beads#5364), while the newest
+# published release — v1.1.2 — was cut from the hotfix/v1.1.1 branch off v1.1.0
+# and carries neither (verified: its `bd update --help` names no --if-assignee).
+# Until beads publishes a release cut from main, the only flag-capable bd CI can
+# obtain is the source-built BD_CURRENT_REF cell below, which is where the
+# ReleaseIfCurrent CAS contract runs. Promote BD_VERSION the day that release
+# exists; do not point it at an unpublished tag.
 BD_VERSION=v1.1.0
 BR_VERSION=0.1.20
 
@@ -17,6 +29,13 @@ BR_VERSION=0.1.20
 # has no release tarball, so the matrix builds it from beads source at
 # BD_CURRENT_REF (a gastownhall/beads commit). Bump BD_CURRENT_REF deliberately,
 # in lockstep with the vendored corpus, per the coordination protocol.
+#
+# BD_PREV_VERSION is also the floor that keeps BdStore's raw-SQL release fallback
+# alive (bdSQLStringLiteral, releaseIfCurrentViaEmbeddedDoltSQL,
+# parseDoltRowsAffected, isBdSQLUnsupportedInEmbeddedMode). Raising it past
+# beads#5008 would delete all four — but it cannot be raised there for the same
+# reason BD_VERSION cannot: the floor must be a published release with pinned
+# tarball SHAs, and no published release has the flags.
 BD_PREV_VERSION=v1.0.4
 BD_CURRENT_VERSION=v1.1.1-0.20260805093327-bf97b73749ac
 BD_CURRENT_REF=bf97b73749ac3ef2fca2365b54537ac041ad4293

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1228,9 +1228,13 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 // It prefers bd's native conditional-release verb, which evaluates both
 // preconditions server-side and reports a failed one as exit 13 having written
 // nothing (bdstore_conditional_release.go). The raw `bd sql` path below is the
-// fallback for bd 1.0.4, the contract-tested minimum, which predates the flags:
-// there the sqlite backend refuses raw DB access, so that rejection — and
-// embedded dolt WITHOUT a configured dolt directory — surface
+// fallback for any bd predating the flags (beads#5008) — which today is the LIVE
+// path, not a floor nobody runs: no published beads release carries them, so the
+// installable default (deps.env BD_VERSION) lands here, and that is what every
+// CI job and every operator install obtains. The contract-tested minimum
+// (BD_PREV_VERSION, 1.0.4) lands here too, but it is not what makes the fallback
+// load-bearing. On that path the sqlite backend refuses raw DB access, so that
+// rejection — and embedded dolt WITHOUT a configured dolt directory — surface
 // ErrConditionalReleaseUnsupported (the latter via the
 // releaseIfCurrentViaEmbeddedDoltSQL fallback), while embedded dolt WITH a
 // configured directory services the CAS through that fallback directly. Callers

--- a/internal/beads/bdstore_conditional_release.go
+++ b/internal/beads/bdstore_conditional_release.go
@@ -31,9 +31,15 @@ import (
 // whole reason to prefer this verb: the load-bearing branch stops depending on
 // message text.
 //
-// bd 1.0.4 is the contract-tested minimum (deps.env BD_PREV_VERSION) and predates
-// the flags, so the raw-SQL path stays as the fallback and is selected by a
-// per-store latch the first time bd rejects the flag as unknown.
+// BOTH bd pins predate the flags, so the raw-SQL path stays as the fallback,
+// selected by a per-store latch the first time bd rejects the flag as unknown:
+// the contract-tested minimum (deps.env BD_PREV_VERSION, 1.0.4) and — the
+// load-bearing one — the installable default CI and operators actually install
+// (deps.env BD_VERSION, 1.1.0). The flags landed on beads main after that
+// release, in beads#5008, and no published release carries them yet, so on a
+// stock install the FALLBACK is still the live path. The verb is exercised
+// against the source-built deps.env BD_CURRENT_REF bd
+// (make test-bd-conditional-release-contract).
 
 // bdCASPreconditionExitCode is bd's dedicated exit status for a rejected
 // --if-assignee / --if-status precondition: nothing was written, and the verdict

--- a/internal/beads/bdstore_conditional_release_integration_test.go
+++ b/internal/beads/bdstore_conditional_release_integration_test.go
@@ -4,11 +4,20 @@ package beads_test
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
+
+// requireConditionalReleaseEnv is set by the one CI cell that installs a bd
+// built from deps.env BD_CURRENT_REF, which carries the flags. There the
+// capability skip below is a FAILURE: the cell exists to guard the CAS, so a
+// green run that skipped it has guarded nothing — exactly the state this row was
+// in while every job installed the flagless BD_VERSION release. Unset (every
+// other shard, and local runs on a stock bd) it still skips.
+const requireConditionalReleaseEnv = "GC_REQUIRE_BD_CONDITIONAL_RELEASE"
 
 // TestBdStoreReleaseIfCurrentAgainstRealBd executes the conditional-release CAS
 // against a REAL bd binary in EMBEDDED mode — the mode where `bd sql` is
@@ -22,12 +31,24 @@ import (
 // fails the capability leg here; a bd that changes the exit status fails the
 // mismatch leg, loudly, instead of silently degrading gascity to "someone else
 // holds it" on every release.
+//
+// It runs on the contract matrix's "current" cell, whose bd is built from
+// deps.env BD_CURRENT_REF. That is not a preference: no PUBLISHED beads release
+// carries the flags, so on every shard that installs BD_VERSION this row can
+// only skip.
 func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 	store, scope := newConditionalIntegrationBdStore(t)
 	if !bdParsesConditionalReleaseFlags(t, scope) {
-		t.Skip("installed bd does not advertise --if-assignee/--if-status (pre-beads#5364): " +
+		const detail = "installed bd does not advertise --if-assignee/--if-status (pre-beads#5008): " +
 			"the store latches to the raw-SQL fallback, which embedded mode rejects outright, " +
-			"so this row cannot exercise the verb at all. Move deps.env BD_VERSION past #5364 to run it.")
+			"so this row cannot exercise the verb at all"
+		if os.Getenv(requireConditionalReleaseEnv) == "1" {
+			t.Fatalf("%s. %s=1 promised a flag-capable bd (deps.env BD_CURRENT_REF); "+
+				"either the pin regressed or bd renamed the flags", detail, requireConditionalReleaseEnv)
+		}
+		t.Skipf("%s. deps.env BD_VERSION is a published release that predates the flags and none has "+
+			"shipped with them yet, so this row runs on the source-built BD_CURRENT_REF cell "+
+			"(make test-bd-conditional-release-contract), not on the shards that install BD_VERSION.", detail)
 	}
 
 	created, err := store.Create(beads.Bead{Title: "conditional release row", Type: "task"})

--- a/internal/beads/bdstore_conditional_release_integration_test.go
+++ b/internal/beads/bdstore_conditional_release_integration_test.go
@@ -4,7 +4,9 @@ package beads_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -12,12 +14,51 @@ import (
 )
 
 // requireConditionalReleaseEnv is set by the one CI cell that installs a bd
-// built from deps.env BD_CURRENT_REF, which carries the flags. There the
-// capability skip below is a FAILURE: the cell exists to guard the CAS, so a
-// green run that skipped it has guarded nothing — exactly the state this row was
-// in while every job installed the flagless BD_VERSION release. Unset (every
-// other shard, and local runs on a stock bd) it still skips.
+// built from deps.env BD_CURRENT_REF, which carries the flags. There every exit
+// that is not "the CAS ran and passed" is a FAILURE: the cell exists to guard
+// the CAS, so a green run that skipped it has guarded nothing — exactly the
+// state this row was in while every job installed the flagless BD_VERSION
+// release. Unset (every other shard, and local runs on a stock bd) it still
+// skips.
 const requireConditionalReleaseEnv = "GC_REQUIRE_BD_CONDITIONAL_RELEASE"
+
+// conditionalReleaseRequired reports whether this run promised a bd that can
+// prove the CAS. Any set, non-false value counts. An equality test against "1"
+// would make GC_REQUIRE_BD_CONDITIONAL_RELEASE=true quietly mean "not
+// required" — a green path bought with a typo, which is the exact disease this
+// knob exists to cure.
+func conditionalReleaseRequired() bool {
+	value := strings.TrimSpace(os.Getenv(requireConditionalReleaseEnv))
+	if value == "" {
+		return false
+	}
+	if parsed, err := strconv.ParseBool(value); err == nil {
+		return parsed
+	}
+	return true
+}
+
+// conditionalReleaseUnprovable ends the caller at an exit that did NOT prove the
+// CAS — the capability probe itself failed, bd lacks the flags, or a leg is not
+// drivable against this bd. It skips normally and FAILS under
+// requireConditionalReleaseEnv.
+//
+// Every such exit routes through here on purpose. Honoring the promise only on
+// the "flags absent" branch would leave the others green: a bd whose `update`
+// verb disappeared makes the probe ERROR rather than report the flags missing,
+// and skipping there passes a cell that proved nothing while claiming a
+// flag-capable bd. Under the env there is exactly one green path — the row ran
+// end to end. (bd being absent outright needs no branch: the scope builder
+// shells `bd init` and t.Fatals when it cannot, on every run, env or not.)
+func conditionalReleaseUnprovable(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if conditionalReleaseRequired() {
+		t.Fatalf("%s [%s is set: this run promised a bd that can prove the CAS (deps.env "+
+			"BD_CURRENT_REF); either that pin regressed, bd changed under it, or the row is being "+
+			"run somewhere it cannot run]", fmt.Sprintf(format, args...), requireConditionalReleaseEnv)
+	}
+	t.Skipf(format, args...)
+}
 
 // TestBdStoreReleaseIfCurrentAgainstRealBd executes the conditional-release CAS
 // against a REAL bd binary in EMBEDDED mode — the mode where `bd sql` is
@@ -35,20 +76,17 @@ const requireConditionalReleaseEnv = "GC_REQUIRE_BD_CONDITIONAL_RELEASE"
 // It runs on the contract matrix's "current" cell, whose bd is built from
 // deps.env BD_CURRENT_REF. That is not a preference: no PUBLISHED beads release
 // carries the flags, so on every shard that installs BD_VERSION this row can
-// only skip.
+// only skip. There the cell sets requireConditionalReleaseEnv and every exit
+// short of a full run is a failure (conditionalReleaseUnprovable).
 func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 	store, scope := newConditionalIntegrationBdStore(t)
 	if !bdParsesConditionalReleaseFlags(t, scope) {
-		const detail = "installed bd does not advertise --if-assignee/--if-status (pre-beads#5008): " +
-			"the store latches to the raw-SQL fallback, which embedded mode rejects outright, " +
-			"so this row cannot exercise the verb at all"
-		if os.Getenv(requireConditionalReleaseEnv) == "1" {
-			t.Fatalf("%s. %s=1 promised a flag-capable bd (deps.env BD_CURRENT_REF); "+
-				"either the pin regressed or bd renamed the flags", detail, requireConditionalReleaseEnv)
-		}
-		t.Skipf("%s. deps.env BD_VERSION is a published release that predates the flags and none has "+
-			"shipped with them yet, so this row runs on the source-built BD_CURRENT_REF cell "+
-			"(make test-bd-conditional-release-contract), not on the shards that install BD_VERSION.", detail)
+		conditionalReleaseUnprovable(t, "installed bd does not advertise --if-assignee/--if-status "+
+			"(pre-beads#5008): the store latches to the raw-SQL fallback, which embedded mode rejects "+
+			"outright, so this row cannot exercise the verb at all. deps.env BD_VERSION is a published "+
+			"release that predates the flags and none has shipped with them yet, so this row runs on the "+
+			"source-built BD_CURRENT_REF cell (make test-bd-conditional-release-contract), not on the "+
+			"shards that install BD_VERSION.")
 	}
 
 	created, err := store.Create(beads.Bead{Title: "conditional release row", Type: "task"})
@@ -167,7 +205,8 @@ func TestBdStoreReleaseIfCurrentAgainstRealBd(t *testing.T) {
 		}
 		truncated := held.ID[:len(held.ID)-1]
 		if _, getErr := store.Get(truncated); !errors.Is(getErr, beads.ErrIDCollision) {
-			t.Skipf("bd did not prefix-resolve %q to another bead (Get: %v); the collision cell is not drivable here", truncated, getErr)
+			conditionalReleaseUnprovable(t, "bd did not prefix-resolve %q to another bead (Get: %v); "+
+				"the collision cell is not drivable here", truncated, getErr)
 		}
 
 		released, err := store.ReleaseIfCurrent(truncated, "worker-1")
@@ -201,7 +240,11 @@ func bdParsesConditionalReleaseFlags(t *testing.T, scope string) bool {
 	t.Helper()
 	out, err := newConditionalIntegrationRunner(scope)(scope, "bd", "update", "--help")
 	if err != nil {
-		t.Skipf("bd update --help failed (bd broken?): %v", err)
+		// The probe's OWN failure is not evidence about the flags — a bd that
+		// dropped the `update` verb errors here rather than reporting the flags
+		// absent — so it is unprovable, not skippable, under the require-env.
+		conditionalReleaseUnprovable(t, "bd update --help failed, so the capability probe could not "+
+			"run at all (bd broken, or the update verb is gone?): %v", err)
 	}
 	help := string(out)
 	return strings.Contains(help, "--if-assignee") && strings.Contains(help, "--if-status")

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3412,12 +3412,14 @@ esac
 
 // legacyBdReleaseRunner adapts a runner that only understands the raw-SQL
 // release path to bd 1.0.4 semantics: the native conditional-release verb is
-// rejected as an unknown flag, exactly as a bd predating gastownhall/beads#5364
+// rejected as an unknown flag, exactly as a bd predating gastownhall/beads#5008
 // rejects it, so the store latches its fallback. It also answers the verb path's
 // exact-ID preflight by resolving the id to itself, so a test that pins the
 // generated SQL still sees only the SQL. Every test that pins the generated SQL
-// is a FALLBACK-path test — the minimum supported bd
-// (deps.env BD_PREV_VERSION=v1.0.4) still takes it — and must go through this.
+// is a FALLBACK-path test — and not only the minimum supported bd
+// (deps.env BD_PREV_VERSION=v1.0.4) takes it: so does the installable default
+// (deps.env BD_VERSION), which is what CI and operators actually install, so
+// this is the shape of production today, not of a floor nobody runs.
 func legacyBdReleaseRunner(inner beads.CommandRunner) beads.CommandRunner {
 	return func(dir, name string, args ...string) ([]byte, error) {
 		if len(args) == 3 && args[0] == "show" && args[1] == "--json" {

--- a/scripts/bd_version_pin_test.go
+++ b/scripts/bd_version_pin_test.go
@@ -134,6 +134,29 @@ func TestBDVersionPins(t *testing.T) {
 	// assignment in both .yml and .yaml workflows: a file-level presence check
 	// would let a stale pin ride along beside a correct one.
 	assertWorkflowPins(t, root, "BD_VERSION", bdVersion)
+
+	// The devcontainer README restates the installed version in prose, which
+	// makes it an anchor like any other -- and it was the only one no test read,
+	// so it sat at v1.0.4 through the promotion to v1.1.0. A doc anchor nothing
+	// asserts is how the next bump goes half-applied.
+	assertDocPinAnchor(t, root, ".devcontainer/README.md", "BD_VERSION", bdVersion)
+}
+
+// assertDocPinAnchor fails when a doc restates a deps.env pin as
+// "`KEY` from `deps.env` (currently VALUE)" and VALUE has drifted. The phrasing
+// is the contract: prose that names the variable without restating the value is
+// not an anchor and is not matched, so a doc can always opt out by dropping the
+// parenthetical rather than by going stale.
+func assertDocPinAnchor(t *testing.T, root, rel, key, want string) {
+	t.Helper()
+	re := regexp.MustCompile("`" + regexp.QuoteMeta(key) + "` from `deps\\.env` \\(currently ([^)]+)\\)")
+	m := re.FindStringSubmatch(readFile(t, root, rel))
+	if m == nil {
+		t.Fatalf("%s no longer restates %s as \"`%s` from `deps.env` (currently <value>)\"; either restore that phrasing or drop this assertion with the anchor", rel, key, key)
+	}
+	if got := strings.TrimSpace(m[1]); got != want {
+		t.Errorf("%s says %s is currently %q, want %q (deps.env)", rel, key, got, want)
+	}
 }
 
 // TestScanPinAssignments proves the workflow pin scanner catches the partial

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -20,7 +20,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "b16d700bb89ac6cee0d6d486afcfc121d6de9b12e6b2cdab88ad1f3116f07502"
+	expectedCIExecutionHash      = "ba5381bced878344c38f6009e9449ec3c864518ebadedfbe2bea9fe530b3ac1c"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "80575ca368f28ba9f8b14bf72ce5767a7877ffe4dcadc136854ab4b0b5f1377a"
 	expectedSetupActionHash      = "b7864038195cd054aee7fccfa903cab335b375bcab1a35239c17c5da7d32c07e"

--- a/scripts/dolt_version_pin_test.go
+++ b/scripts/dolt_version_pin_test.go
@@ -50,4 +50,8 @@ func TestDoltVersionPins(t *testing.T) {
 	// using the same shared scanner as the bd pin guard so neither analog can
 	// false-pass on partial drift or a .yaml workflow.
 	assertWorkflowPins(t, repoRoot, "DOLT_VERSION", doltPin)
+
+	// The devcontainer README restates this pin on the line above the bd one and
+	// was equally unread; guard both or the next bump half-applies here instead.
+	assertDocPinAnchor(t, repoRoot, ".devcontainer/README.md", "DOLT_VERSION", doltPin)
 }


### PR DESCRIPTION
## Problem

`BdStore.ReleaseIfCurrent` routes through bd's native CAS verb — `bd update <id> --if-assignee <expected> --if-status in_progress --status open --assignee ""`, where a rejected precondition is exit 13 with nothing written — and falls back to hand-built SQL behind a per-store latch when bd rejects the flags as unknown (#5126).

That fallback is still the **live** path everywhere, because `deps.env BD_VERSION=v1.1.0` predates the flags. Measured against the pinned release tarball:

```
$ bd version
bd version 1.1.0 (8e4e59d39: HEAD@8e4e59d39f34)
$ bd update --help | grep -c -- --if-assignee
0
```

So on a stock install the store latches to `UPDATE issues … WHERE id=…`, which can never match the `wisps` table — every wisp-held assignment answers *"someone else holds it"*, forever, and gascity runs formula steps as wisps. `TestBdStoreReleaseIfCurrentAgainstRealBd`, added by #5126 to guard exactly this, skipped in every job that installs `BD_VERSION`. **It guarded nothing.**

## Why `BD_VERSION` does not move here

ga-nv0i3 asked for a `BD_VERSION` bump. There is nothing to bump to:

| anchor | value | has `--if-assignee`? |
|---|---|---|
| `BD_VERSION` (installable default) | v1.1.0 tarball | no (verified: 0 hits in `bd update --help`) |
| newest published beads release | v1.1.2 | no (cut from `hotfix/v1.1.1`, a branch off v1.1.0) |
| `BD_CURRENT_REF` (source-built cell) | `bf97b73749ac` | **yes** |

The capability boundary is one commit: the flags — and the exit-13 verdict — landed on beads main in `6e8af8bf8` (beads#5008, 2026-07-24). `4b1d9c875` (beads#5364, 2026-08-05) only ports the same CAS to proxied-server mode, so a bd after #5008 and before #5364 already has what the embedded contract needs; pins are compared against **#5008**. `install-bd-archive.sh` installs a **published** tarball with a pinned SHA, so pinning an unpublished tag would break every build. The same constraint blocks raising `BD_PREV_VERSION` past #5008 — which is what would let `bdSQLStringLiteral`, `releaseIfCurrentViaEmbeddedDoltSQL`, `parseDoltRowsAffected` and `isBdSQLUnsupportedInEmbeddedMode` die together. Both pins stay; the reasons are now recorded in `deps.env`.

## Fix

CI already obtains a flag-capable bd: the contract matrix's `current` cell builds one from source at `deps.env BD_CURRENT_REF`, and `contrib/k8s/Dockerfile.agent` ships the same build. Run the CAS row there.

- **`make test-bd-conditional-release-contract`** runs the row with `GC_REQUIRE_BD_CONDITIONAL_RELEASE=1`, which turns the capability skip into a **failure**. A cell that installed a capable bd and skipped anyway has proven nothing — it now fails loudly, including if a future `BD_CURRENT_REF` bump loses the flags or bd renames them.
- **`contract-acceptance-current`** gains one step invoking that target, after the bd it already builds is on PATH. Unset, the row still skips on every shard that installs `BD_VERSION`, so nothing else changes.
- **`deps.env`** records why `BD_VERSION`/`BD_PREV_VERSION` are stuck and what unblocks them, so the next bump attempt does not repeat the archaeology or pin something unfetchable.
- The skip message and `legacyBdReleaseRunner` named #5364; corrected to **#5008** throughout, along with the source comment that credited only `BD_PREV_VERSION` for keeping the SQL fallback alive — the **installable default** is the load-bearing one, so the fallback is production's shape today, not a floor nobody runs.
- `scripts/cipolicy` execution hash re-pinned for the new step; stale `v1.0.4` in the devcontainer README corrected to the actual `BD_VERSION`, and that anchor — the only `BD_VERSION` anchor no test read, which is how it went stale — is now asserted against `deps.env` (with the `DOLT_VERSION` anchor beside it).

### The cell cannot go green without running

The claim this rests on is "the target hardcodes `GC_REQUIRE_BD_CONDITIONAL_RELEASE=1`, so a skip is a failure — therefore the job passing IS the proof the CAS ran." Two holes let the cell pass having executed nothing; both are closed and both are demonstrated below.

- **A `-run` selector that matches nothing is not an error.** `go test` prints `[no tests to run]` and exits 0, so renaming the row, moving it, or dropping its build tag would leave a permanently green cell. The target now resolves the name through `go test -list` first, using the **same** variable, package and build tags the run uses. Deriving both from one variable is why this guard cannot rot into a false pass: there is no second copy of the selector to drift, and a `-list` output change would fail the cell loudly — the opposite of grepping `go test`'s human-facing "no tests to run" warning, which would silently stop catching.
- **The require-env was honoured on one branch only.** A bd whose `update` verb disappeared makes the capability probe **error** rather than report the flags absent, and that path skipped — green, under the env, having proven nothing. Every non-proving exit (probe error, flags absent, a leg that is not drivable) now routes through one helper that fails under the env and skips without it. bd being absent outright was already a `t.Fatal` on every run. Under the env there is exactly **one** green path: the row ran end to end. The env is also read as a bool, so `=true` no longer quietly means "not required".

## Verification

Against a bd built the way the cell builds it (source @ `BD_CURRENT_REF`, `-tags gms_pure_go`), the whole row runs — **wisp leg included**:

```
--- PASS: TestBdStoreReleaseIfCurrentAgainstRealBd (13.54s)
    --- PASS: .../a_wrong_assignee_writes_nothing_and_is_not_an_error (0.97s)
    --- PASS: .../the_matching_assignee_releases (1.04s)
    --- PASS: .../a_second_release_is_a_no-op,_not_an_error (0.60s)
    --- PASS: .../an_ephemeral_bead_releases_too (2.01s)
    --- PASS: .../an_unresolvable_id_is_not_held (0.87s)
    --- PASS: .../a_non-exact_id_refuses_instead_of_releasing_a_different_bead (2.06s)
```

**Escape hatch 1 — rename the row.** Before, the selector matched nothing and the cell passed:

```
$ go test -tags integration -run '^TestBdStoreReleaseIfCurrentAgainstRealBd$' ./internal/beads
ok  	github.com/gastownhall/gascity/internal/beads	0.061s [no tests to run]
EXIT=0
```

After, the same rename is red before a single test runs:

```
$ make test-bd-conditional-release-contract
Error: TestBdStoreReleaseIfCurrentAgainstRealBd does not exist in ./internal/beads under -tags integration.
The -run selector below would match nothing, and this cell would pass having run no test.
Point BD_CONDITIONAL_RELEASE_TEST/_PKG at the row's current name and home.
make: *** [Makefile:581: test-bd-conditional-release-contract] Error 1
```

**Escape hatch 2 — make the capability probe error** (a bd whose `update` verb is gone). Before, under `GC_REQUIRE_BD_CONDITIONAL_RELEASE=1`:

```
--- SKIP: TestBdStoreReleaseIfCurrentAgainstRealBd (4.95s)
ok  	github.com/gastownhall/gascity/internal/beads	5.011s
EXIT=0
```

After, same shim, same env:

```
--- FAIL: TestBdStoreReleaseIfCurrentAgainstRealBd (4.90s)
    bd update --help failed, so the capability probe could not run at all (bd broken, or the
    update verb is gone?): exit status 1: Error: unknown command "update" for "bd"
    [GC_REQUIRE_BD_CONDITIONAL_RELEASE is set: this run promised a bd that can prove the CAS …]
FAIL	github.com/gastownhall/gascity/internal/beads	4.989s
EXIT=1
```

**The skip every other shard depends on is unchanged.** With the env unset, a flagless bd still SKIPs green (exit 0), and so does the probe-error shim. With the env set, a flagless bd, a probe error, a bd absent from PATH, and `=true` instead of `=1` all fail.

**The devcontainer anchor is now guarded.** Reverting it to `v1.0.4`:

```
--- FAIL: TestBDVersionPins (0.01s)
    bd_version_pin_test.go:142: .devcontainer/README.md says BD_VERSION is currently "v1.0.4", want "v1.1.0" (deps.env)
```

Gates: `go build ./...`, `go vet ./...` (and `-tags integration`), `gofmt`, `golangci-lint` 0 issues (and 0 introduced under `--build-tags integration`), `go test ./scripts/...`, `go test ./internal/beads/...`, `go test ./cmd/gc -timeout 25m`, `make test-ci-policy`, `scripts/check-core-boundary.sh`, `check-routed-test-rows`, `check-split-topology-rows`, `test/docsync` — all green.

Refs ga-nv0i3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
