### PR TITLE
fix(api): federate the graph store on ready/list and fail loud on a dead leg (ga-4k2c3)

### DIFF
--- a/internal/api/beads_graph_federation.go
+++ b/internal/api/beads_graph_federation.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"github.com/gastownhall/gascity/internal/api/apierr"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// graphFederationLegKey returns the synthetic fan-out key the bead-list
+// federation files the relocated graph store under.
+//
+// The list fan-out is keyed by rig name, so the graph leg needs a key of its
+// own. ':' cannot appear in a rig name, so the key can never collide with a
+// real one — and the merge that mints it is skipped for rig-scoped requests, so
+// the key is not addressable through ?rig= either.
+func graphFederationLegKey(cityName string) string {
+	return "infra:" + cityName
+}
+
+// relocatedGraphStore returns the graph-class store when — and only when — the
+// city has actually relocated it.
+//
+// Routing is keyed on STORE IDENTITY, the same rule handler_beads.go's by-id
+// class resolver and handler_convoy_dispatch.go's workflow scan use: on a
+// default city GraphBeadStore() returns the city store itself, so there is
+// nothing to federate and every caller's extra arm stays dead. That identity
+// guard is what keeps a single-store city byte-identical.
+func relocatedGraphStore(state State) beads.Store {
+	graph := state.GraphBeadStore().Store
+	if graph == nil || graph == state.CityBeadStore() {
+		return nil
+	}
+	return graph
+}
+
+// graphPlaneUnavailable is the authoritative failure a dead graph leg produces.
+//
+// This is the half of the federation that is NOT a partial degradation. A rig
+// going dark is one scope reporting a hole, and Partial/partial_errors says so
+// honestly. The graph plane going dark means the execution DAG — molecule
+// roots, step beads, control beads — is gone from the answer, and a work-only
+// 200 is indistinguishable from "the DAG finished". So the graph leg either
+// answers or the request fails loud, including when it answers PARTIALLY: a
+// partial graph read leaves an unnamed hole in a dependency graph, and the
+// response has no way to say which part is missing.
+func graphPlaneUnavailable(op string, err error) error {
+	return apierr.StoreUnavailable.Msg("graph store " + op + " read failed (graph plane unreadable): " + err.Error())
+}

--- a/internal/api/beads_graph_federation.go
+++ b/internal/api/beads_graph_federation.go
@@ -1,20 +1,11 @@
 package api
 
 import (
+	"strings"
+
 	"github.com/gastownhall/gascity/internal/api/apierr"
 	"github.com/gastownhall/gascity/internal/beads"
 )
-
-// graphFederationLegKey returns the synthetic fan-out key the bead-list
-// federation files the relocated graph store under.
-//
-// The list fan-out is keyed by rig name, so the graph leg needs a key of its
-// own. ':' cannot appear in a rig name, so the key can never collide with a
-// real one — and the merge that mints it is skipped for rig-scoped requests, so
-// the key is not addressable through ?rig= either.
-func graphFederationLegKey(cityName string) string {
-	return "infra:" + cityName
-}
 
 // relocatedGraphStore returns the graph-class store when — and only when — the
 // city has actually relocated it.
@@ -42,6 +33,16 @@ func relocatedGraphStore(state State) beads.Store {
 // answers or the request fails loud, including when it answers PARTIALLY: a
 // partial graph read leaves an unnamed hole in a dependency graph, and the
 // response has no way to say which part is missing.
-func graphPlaneUnavailable(op string, err error) error {
-	return apierr.StoreUnavailable.Msg("graph store " + op + " read failed (graph plane unreadable): " + err.Error())
+//
+// workLegErrors are the degraded work legs recorded before the graph leg failed.
+// They ride along because this 503 replaces the Partial 200 that would have
+// carried them: without them "the graph plane is down" and "every store in the
+// city is down" are byte-identical responses, and the operator loses the
+// work-side diagnosis the response had already collected.
+func graphPlaneUnavailable(op string, err error, workLegErrors ...string) error {
+	detail := "graph store " + op + " read failed (graph plane unreadable): " + err.Error()
+	if len(workLegErrors) > 0 {
+		detail += "; work legs also degraded: " + strings.Join(workLegErrors, "; ")
+	}
+	return apierr.StoreUnavailable.Msg(detail)
 }

--- a/internal/api/handler_beads_bounded_test.go
+++ b/internal/api/handler_beads_bounded_test.go
@@ -58,7 +58,12 @@ func (s *countingListStore) Count(_ context.Context, q beads.ListQuery, excludeT
 	return n, nil
 }
 
-func seedMoleculeStore(total int) ([]beads.Bead, *beads.MemStore) {
+// seedMoleculeStore builds a store of molecule beads minting under idPrefix.
+// The prefix is a parameter because two rig stores in a real city mint under
+// different prefixes (config.Rig.EffectivePrefix) — two seeded stores sharing
+// one prefix would hold the same ids, which is a bead co-resident in two legs,
+// not two beads.
+func seedMoleculeStore(idPrefix string, total int) ([]beads.Bead, *beads.MemStore) {
 	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	seed := make([]beads.Bead, 0, total)
 	for i := 0; i < total; i++ {
@@ -67,7 +72,7 @@ func seedMoleculeStore(total int) ([]beads.Bead, *beads.MemStore) {
 			status = "closed"
 		}
 		seed = append(seed, beads.Bead{
-			ID:        fmt.Sprintf("gc-mol-%03d", i),
+			ID:        fmt.Sprintf("%s-mol-%03d", idPrefix, i),
 			Type:      "molecule",
 			Status:    status,
 			Title:     fmt.Sprintf("molecule %d", i),
@@ -100,7 +105,7 @@ func TestBeadListAllTrueBoundsCounterStore(t *testing.T) {
 	const total = 30
 	const limit = 10
 	fs := newFakeState(t)
-	seed, mem := seedMoleculeStore(total)
+	seed, mem := seedMoleculeStore("gc", total)
 	store := &countingListStore{Store: mem}
 	fs.stores["myrig"] = store
 
@@ -145,7 +150,7 @@ func TestBeadListAllTrueBoundsCounterStore(t *testing.T) {
 func TestBeadListAllTrueNoCursorWhenAllFit(t *testing.T) {
 	const total = 8
 	fs := newFakeState(t)
-	_, mem := seedMoleculeStore(total)
+	_, mem := seedMoleculeStore("gc", total)
 	fs.stores["myrig"] = &countingListStore{Store: mem}
 
 	body := fetchBoundedBeads(t, fs, "?type=molecule&all=true&limit=50")
@@ -167,7 +172,7 @@ func TestBeadListAllTrueFallsBackWithoutCounter(t *testing.T) {
 	const total = 30
 	const limit = 10
 	fs := newFakeState(t)
-	_, mem := seedMoleculeStore(total)
+	_, mem := seedMoleculeStore("gc", total)
 	// Plain MemStore is not a Counter, so the handler must not bound it.
 	fs.stores["myrig"] = mem
 
@@ -215,7 +220,7 @@ func TestBeadListAllTrueBoundedTotalExcludesFailedRigList(t *testing.T) {
 	const good = 30
 	const limit = 10
 	fs := newFakeState(t)
-	_, mem := seedMoleculeStore(good)
+	_, mem := seedMoleculeStore("gc", good)
 	fs.stores["myrig"] = &countingListStore{Store: mem}
 	// "zrig" Counts 10 molecules but its List fails with a non-partial error,
 	// so its 10 rows never reach the page. Pre-fix, those 10 stay baked into
@@ -310,9 +315,9 @@ func TestBeadListAllTrueBoundedPartialResultRigKeepsCount(t *testing.T) {
 	const good = 30
 	const partial = 12
 	fs := newFakeState(t)
-	_, goodMem := seedMoleculeStore(good)
+	_, goodMem := seedMoleculeStore("gc", good)
 	fs.stores["myrig"] = &countingListStore{Store: goodMem}
-	_, partMem := seedMoleculeStore(partial)
+	_, partMem := seedMoleculeStore("zr", partial)
 	fs.stores["zrig"] = &countingPartialListStore{countingListStore: &countingListStore{Store: partMem}}
 
 	// Limit covers everything so the whole set must be reachable in one page.

--- a/internal/api/handler_beads_infra_federation_fanout_test.go
+++ b/internal/api/handler_beads_infra_federation_fanout_test.go
@@ -1,0 +1,352 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// Fan-out properties of the split-city bead list: page bounding, cross-leg id
+// identity, and what a dead graph leg tells an operator.
+//
+// FIXTURE FIDELITY. The graph leaf here is deliberately NOT
+// splittest.StrictStore. StrictStore declares beads.Counter (its Count forwards
+// to the leaf), so a fixture built from the kit keeps the bounded page path
+// alive no matter what the handler does with the leg — the exact dimension
+// these tests are about. The canonical compiled-in binding hands the API a raw
+// *beads.SQLiteStore (internal/storebinding/sqlite/beads_engine.go OpenEngine →
+// beads.OpenSQLiteStore; cmd/gc/storage_boot.go stores it verbatim and
+// cmd/gc/class_store.go returns it unwrapped), and *beads.SQLiteStore has no
+// Count method at all. nonCounterLeg models THAT.
+
+// nonCounterLeg is a store with no beads.Counter capability, modeling the
+// canonical relocated-class binding. It embeds the beads.Store INTERFACE rather
+// than a concrete type, so no method outside beads.Store can leak through and
+// the leg stays Counter-less even if the backing leaf later grows a Count. It
+// records the largest List limit it was handed so a test can prove the handler
+// did NOT push a page bound into a store that cannot count.
+type nonCounterLeg struct {
+	beads.Store
+	mu         sync.Mutex
+	maxListLim int
+}
+
+func (s *nonCounterLeg) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.mu.Lock()
+	if q.Limit > s.maxListLim {
+		s.maxListLim = q.Limit
+	}
+	s.mu.Unlock()
+	return s.Store.List(q)
+}
+
+// seedMoleculeLeg builds one prefix-disjoint leg of molecule beads, the way a
+// real city's stores mint under different prefixes.
+func seedMoleculeLeg(idPrefix string, n int) *beads.MemStore {
+	_, mem := seedMoleculeStore(idPrefix, n)
+	return mem
+}
+
+// newBoundedSplitState wires a split city whose WORK legs are Counter-capable
+// (every production work store is: cmd/gc/api_state.go caching-wraps the city
+// and each rig, and CachingStore/NativeDoltStore both implement beads.Counter)
+// and whose graph leg is whatever capability shape the caller wants to model.
+func newBoundedSplitState(t *testing.T, graph beads.Store) (*fakeState, *countingListStore, *countingListStore) {
+	t.Helper()
+	fs := newFakeState(t)
+	city := &countingListStore{Store: seedMoleculeLeg("hq", 30)}
+	rig := &countingListStore{Store: seedMoleculeLeg("ra", 30)}
+	fs.cityBeadStore = city
+	fs.stores = map[string]beads.Store{"myrig": rig, fs.CityName(): city}
+	fs.graphBeadStore = graph
+	return fs, city, rig
+}
+
+// TestBeadListSplitCityKeepsWorkLegsBounded is the regression guard for the
+// defect this file exists for: the graph leg must not be able to veto bounded
+// paging for the rest of the fan-out.
+//
+// The graph binding cannot Count, so the whole all=true request used to collapse
+// onto the O(full history) scan — every rig hydrating its closed history on a
+// read the dashboard issues with a 2s response-cache TTL. The work legs stay
+// bounded; only the leg that genuinely cannot count hydrates.
+func TestBeadListSplitCityKeepsWorkLegsBounded(t *testing.T) {
+	const limit = 5
+	graph := &nonCounterLeg{Store: seedMoleculeLeg("gcg", 12)}
+	fs, city, rig := newBoundedSplitState(t, graph)
+
+	body := fetchBoundedBeads(t, fs, fmt.Sprintf("?type=molecule&all=true&limit=%d", limit))
+
+	if city.maxListLim != limit+1 {
+		t.Errorf("city leg max List limit = %d, want %d — a non-Counter graph leg must not unbound the work legs", city.maxListLim, limit+1)
+	}
+	if rig.maxListLim != limit+1 {
+		t.Errorf("rig leg max List limit = %d, want %d — a non-Counter graph leg must not unbound the work legs", rig.maxListLim, limit+1)
+	}
+	if !city.countCalled || !rig.countCalled {
+		t.Errorf("Count called: city=%v rig=%v, want both — bounding did not engage", city.countCalled, rig.countCalled)
+	}
+	if graph.maxListLim != 0 {
+		t.Errorf("graph leg List limit = %d, want 0 — a leg that cannot Count must hydrate so its own row count is its exact total", graph.maxListLim)
+	}
+	if want := 30 + 30 + 12; body.Total != want {
+		t.Errorf("Total = %d, want %d (work counts from Count, graph count from its own rows)", body.Total, want)
+	}
+	if len(body.Items) != limit {
+		t.Fatalf("len(Items) = %d, want %d", len(body.Items), limit)
+	}
+	if body.NextCursor == "" {
+		t.Errorf("NextCursor empty, want a cursor")
+	}
+}
+
+// TestBeadListSplitCityBoundsACounterCapableGraphLeg is the control: the
+// exemption is scoped to legs that genuinely cannot count. A graph binding that
+// CAN Count (the beads adapter and the SQLite front door both do) is bounded
+// like every other leg.
+func TestBeadListSplitCityBoundsACounterCapableGraphLeg(t *testing.T) {
+	const limit = 5
+	graph := &countingListStore{Store: seedMoleculeLeg("gcg", 12)}
+	fs, city, rig := newBoundedSplitState(t, graph)
+
+	body := fetchBoundedBeads(t, fs, fmt.Sprintf("?type=molecule&all=true&limit=%d", limit))
+
+	if graph.maxListLim != limit+1 {
+		t.Errorf("graph leg max List limit = %d, want %d — a Counter-capable graph leg is bounded like the rest", graph.maxListLim, limit+1)
+	}
+	if !graph.countCalled {
+		t.Errorf("graph Count was not called; the leg was hydrated although it can count")
+	}
+	if city.maxListLim != limit+1 || rig.maxListLim != limit+1 {
+		t.Errorf("work leg limits = city:%d rig:%d, want %d", city.maxListLim, rig.maxListLim, limit+1)
+	}
+	if want := 30 + 30 + 12; body.Total != want {
+		t.Errorf("Total = %d, want %d", body.Total, want)
+	}
+}
+
+// TestBeadListSplitCityBoundedWalkIsTheFullScanPrefix proves the bounded split
+// fan-out serves the same rows the un-bounded scan would, page by page: Total
+// stays constant across the walk and the concatenated pages are the exact
+// created_at-desc order.
+func TestBeadListSplitCityBoundedWalkIsTheFullScanPrefix(t *testing.T) {
+	const limit = 7
+	graph := &nonCounterLeg{Store: seedMoleculeLeg("gcg", 12)}
+	fs, _, _ := newBoundedSplitState(t, graph)
+
+	const total = 30 + 30 + 12
+	var got []string
+	cursor := ""
+	for page := 0; page < 20; page++ {
+		q := fmt.Sprintf("?type=molecule&all=true&limit=%d", limit)
+		if cursor != "" {
+			q += "&cursor=" + cursor
+		}
+		body := fetchBoundedBeads(t, fs, q)
+		if body.Total != total {
+			t.Fatalf("page %d Total = %d, want %d (Total must be constant across a walk)", page, body.Total, total)
+		}
+		for _, b := range body.Items {
+			got = append(got, b.ID)
+		}
+		cursor = body.NextCursor
+		if cursor == "" {
+			break
+		}
+	}
+	if len(got) != total {
+		t.Fatalf("walk served %d rows, want %d (ids=%v)", len(got), total, got)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i] == got[i-1] {
+			t.Fatalf("walk repeated %q at position %d", got[i], i)
+		}
+	}
+	seen := map[string]bool{}
+	for _, id := range got {
+		if seen[id] {
+			t.Fatalf("walk served %q twice", id)
+		}
+		seen[id] = true
+	}
+}
+
+// TestBeadListDedupesBeadIDsAcrossLegs is the cross-leg identity guard. A
+// migrated split city keeps its pre-cutover infrastructure rows in the work
+// store — `gc storage migrate` copies with CreateWithForeignID (ids preserved)
+// and never deletes back — so the same bead id is genuinely resident in the
+// work store and in the binding. Without a cross-leg id gate the list arm
+// serves it twice and double-counts it, while the ready arm (which has one)
+// serves it once.
+//
+// Winner rule: legs are federated work-first, graph LAST, and the first leg to
+// return an id wins — identical to the ready arm, so both endpoints resolve a
+// co-resident bead to the same row.
+func TestBeadListDedupesBeadIDsAcrossLegs(t *testing.T) {
+	fs := newFakeState(t)
+	created := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	work := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID: "gcg-7", Type: "task", Status: "open", Title: "retained work-store copy", CreatedAt: created,
+	}}, nil)
+	graph := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID: "gcg-7", Type: "task", Status: "open", Title: "relocated binding copy", CreatedAt: created,
+	}}, nil)
+	fs.cityBeadStore = work
+	fs.stores = map[string]beads.Store{fs.CityName(): work}
+	fs.graphBeadStore = graph
+
+	body := getListBody(t, fs, "/beads")
+
+	if len(body.Items) != 1 || body.Total != 1 {
+		t.Fatalf("items=%d total=%d, want 1/1 — a bead co-resident in the work store and the binding is ONE bead (items=%+v)", len(body.Items), body.Total, body.Items)
+	}
+	if body.Items[0].Title != "retained work-store copy" {
+		t.Fatalf("winning row = %q, want the work leg's copy — legs are work-first, graph last, first leg wins (same rule as GET /beads/ready)", body.Items[0].Title)
+	}
+
+	ready := getListBody(t, fs, "/beads/ready")
+	if len(ready.Items) != 1 || ready.Items[0].Title != "retained work-store copy" {
+		t.Fatalf("ready resolved the co-resident bead to %+v; list and ready must agree on the winner", ready.Items)
+	}
+}
+
+// TestBeadListDedupedWalkServesEachIDOnce pins the paging half: with every id
+// co-resident, a limit-bounded walk must serve each bead exactly once and report
+// the deduped total, not double it.
+func TestBeadListDedupedWalkServesEachIDOnce(t *testing.T) {
+	created := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	rows := make([]beads.Bead, 0, 3)
+	for i := 0; i < 3; i++ {
+		rows = append(rows, beads.Bead{
+			ID: fmt.Sprintf("gcg-%d", i), Type: "task", Status: "open",
+			Title: fmt.Sprintf("step %d", i), CreatedAt: created.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	fs := newFakeState(t)
+	work := beads.NewMemStoreFrom(len(rows), rows, nil)
+	graph := beads.NewMemStoreFrom(len(rows), rows, nil)
+	fs.cityBeadStore = work
+	fs.stores = map[string]beads.Store{fs.CityName(): work}
+	fs.graphBeadStore = graph
+
+	var got []string
+	cursor := ""
+	for page := 0; page < 6; page++ {
+		q := "/beads?limit=2"
+		if cursor != "" {
+			q += "&cursor=" + cursor
+		}
+		body := getListBody(t, fs, q)
+		if body.Total != len(rows) {
+			t.Fatalf("page %d Total = %d, want %d (co-residence must not inflate the total)", page, body.Total, len(rows))
+		}
+		for _, b := range body.Items {
+			got = append(got, b.ID)
+		}
+		cursor = body.NextCursor
+		if cursor == "" {
+			break
+		}
+	}
+	if len(got) != len(rows) {
+		t.Fatalf("walk served %v, want each of %d ids exactly once", got, len(rows))
+	}
+}
+
+// TestBeadListGraphLeg503NamesWorkLegFailures pins that the authoritative graph
+// failure does not erase the work-side diagnosis. "The graph plane is down" and
+// "the entire city is down" must not be byte-identical responses: an operator
+// reading the 503 needs to know the rigs failed too.
+func TestBeadListGraphLeg503NamesWorkLegFailures(t *testing.T) {
+	fs := newSplitFederationState(t)
+	fs.stores["myrig"] = &failingBeadStore{Store: beads.NewMemStore(), listErr: errors.New("rig ledger unreachable")}
+	fs.graphBeadStore = &failingBeadStore{Store: beads.NewMemStore(), listErr: errors.New("infra dolt unreachable")}
+
+	rec := getRaw(t, fs, "/beads")
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503 (body=%q)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "infra dolt unreachable") {
+		t.Errorf("503 body %q does not name the graph failure", body)
+	}
+	if !strings.Contains(body, "rig ledger unreachable") {
+		t.Errorf("503 body %q drops the work-leg failure; the operator cannot tell a dead graph plane from a dead city", body)
+	}
+}
+
+// TestBeadReadyGraphLeg503NamesWorkLegFailures is the same property on the ready
+// arm, which federates the graph leg last and therefore has every work-leg error
+// in hand when it fails loud.
+func TestBeadReadyGraphLeg503NamesWorkLegFailures(t *testing.T) {
+	fs := newSplitFederationState(t)
+	fs.stores["myrig"] = &failingBeadStore{Store: beads.NewMemStore(), readyErr: errors.New("rig ledger unreachable")}
+	fs.graphBeadStore = &failingBeadStore{Store: beads.NewMemStore(), readyErr: errors.New("infra dolt unreachable")}
+
+	rec := getRaw(t, fs, "/beads/ready")
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503 (body=%q)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "rig ledger unreachable") {
+		t.Errorf("503 body %q drops the work-leg failure", body)
+	}
+}
+
+// TestBeadListRigNamedLikeTheGraphLegIsStillServed kills the synthetic-key
+// collision. The leg key the first cut minted ("infra:<city>") was justified by
+// an unenforced claim that ':' cannot appear in a rig name; a rig that did carry
+// that name was silently overwritten in the fan-out map and vanished from the
+// response. Legs are a slice now, so there is no key to collide with.
+func TestBeadListRigNamedLikeTheGraphLegIsStillServed(t *testing.T) {
+	fs := newFakeState(t)
+	created := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	rig := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID: "ra-1", Type: "task", Status: "open", Title: "rig work", CreatedAt: created,
+	}}, nil)
+	graph := beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID: "gcg-1", Type: "task", Status: "open", Title: "graph step", CreatedAt: created.Add(time.Minute),
+	}}, nil)
+	fs.cityBeadStore = beads.NewMemStore()
+	fs.stores = map[string]beads.Store{"infra:" + fs.CityName(): rig}
+	fs.graphBeadStore = graph
+
+	body := getListBody(t, fs, "/beads")
+	if body.Total != 2 {
+		t.Fatalf("total = %d, want 2 (items=%+v) — a rig whose name looks like the old synthetic leg key must still be served", body.Total, body.Items)
+	}
+	if !bodyContainsBeadID(body.Items, "ra-1") {
+		t.Errorf("items = %+v, want the rig bead ra-1", body.Items)
+	}
+	if !bodyContainsBeadID(body.Items, "gcg-1") {
+		t.Errorf("items = %+v, want the graph bead gcg-1", body.Items)
+	}
+}
+
+// TestFederationFixturesModelProductionCapabilities keeps these tests honest
+// about what they model. The graph leaf must be Counter-LESS the way the raw
+// *beads.SQLiteStore binding is, and the work legs must be Counters the way
+// every caching-wrapped production work store is. splittest.StrictStore is
+// checked here too: it declares beads.Counter, so a fixture built from the kit
+// would keep the bounded path alive regardless of what the handler does with the
+// graph leg — which is exactly why these tests do not use it.
+func TestFederationFixturesModelProductionCapabilities(t *testing.T) {
+	var leg beads.Store = &nonCounterLeg{Store: beads.NewMemStore()}
+	if _, ok := leg.(beads.Counter); ok {
+		t.Fatal("nonCounterLeg implements beads.Counter; it no longer models the raw *beads.SQLiteStore graph binding")
+	}
+	var work beads.Store = &countingListStore{Store: beads.NewMemStore()}
+	if _, ok := work.(beads.Counter); !ok {
+		t.Fatal("countingListStore must implement beads.Counter to model a caching-wrapped work store")
+	}
+	if _, ok := splittest.NewClassStore(t, config.BeadClassGraph).(beads.Counter); !ok {
+		t.Fatal("splittest.NewClassStore no longer declares beads.Counter; the fixture-fidelity note on splittest.StrictStore.Count is stale")
+	}
+}

--- a/internal/api/handler_beads_infra_federation_test.go
+++ b/internal/api/handler_beads_infra_federation_test.go
@@ -1,0 +1,419 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// Landmine #13: on a split city the graph-class DAG (gcg- molecule roots, steps,
+// control beads) lives in the relocated graph store, which BeadStores() does not
+// include. The HTTP ready/list handlers must federate it — or the whole DAG is
+// invisible behind an authoritative 200 — and an infra-leg hard failure is an
+// authoritative failure (503), not a degraded Partial 200.
+//
+// The second property is this program's Invariant 0 at the API layer. A rig that
+// falls over is one scope going dark and Partial says so honestly; the graph
+// plane going dark means the execution DAG is gone, and a work-only 200 is
+// indistinguishable from "the DAG finished". So the graph leg does not
+// participate in partial degradation at all: it either answers or the request
+// fails loud.
+//
+// Fixtures come from internal/beads/splittest, not bare MemStores: the graph leg
+// mints real reserved-prefix (gcg-) ids and the work legs mint their own
+// disjoint prefixes, so these tests exercise the same prefix-disjoint shape a
+// real split city has. The one exception is a leg whose read must FAIL — that
+// wraps a plain leaf, because splittest.StrictStore implements Handles() and
+// beads.HandlesFor would resolve straight past the failure injection to the
+// leaf's own reader.
+
+// newSplitFederationState returns a fakeState shaped like a split city: an HQ
+// work store, one rig work store, and a relocated graph store, all
+// prefix-disjoint.
+func newSplitFederationState(t *testing.T) *fakeState {
+	t.Helper()
+	fs := newFakeState(t)
+	fs.cityBeadStore = splittest.NewWorkStore(t, "hq")
+	fs.stores["myrig"] = splittest.NewWorkStore(t, "ra")
+	fs.graphBeadStore = splittest.NewClassStore(t, config.BeadClassGraph)
+	return fs
+}
+
+// newLegacyFederationState returns a fakeState shaped like a legacy
+// single-store city: the graph class is NOT relocated, so
+// GraphBeadStore() == CityBeadStore() and the infra arm never fires.
+func newLegacyFederationState(t *testing.T) *fakeState {
+	t.Helper()
+	fs := newFakeState(t)
+	fs.cityBeadStore = splittest.NewWorkStore(t, "hq")
+	fs.stores["myrig"] = splittest.NewWorkStore(t, "ra")
+	return fs
+}
+
+func seedGraphStepBead(t *testing.T, fs *fakeState) string {
+	t.Helper()
+	created, err := fs.graphBeadStore.Create(beads.Bead{Type: "task", Title: "graph step"})
+	if err != nil {
+		t.Fatalf("seed graph step: %v", err)
+	}
+	return created.ID
+}
+
+func bodyContainsBeadID(items []beads.Bead, id string) bool {
+	for _, b := range items {
+		if b.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// listBody is the decoded shape of a ListBody[beads.Bead] response.
+type listBody struct {
+	Items         []beads.Bead `json:"items"`
+	Total         int          `json:"total"`
+	NextCursor    string       `json:"next_cursor"`
+	Partial       bool         `json:"partial"`
+	PartialErrors []string     `json:"partial_errors"`
+}
+
+// getListBody issues a GET against the city handler and decodes the list
+// envelope, failing the test on a non-200.
+func getListBody(t *testing.T, fs *fakeState, path string) listBody {
+	t.Helper()
+	rec := getRaw(t, fs, path)
+	if rec.Code != 200 {
+		t.Fatalf("GET %s status = %d, want 200 (body=%q)", path, rec.Code, rec.Body.String())
+	}
+	var body listBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode %s: %v (body=%q)", path, err, rec.Body.String())
+	}
+	return body
+}
+
+func getRaw(t *testing.T, fs *fakeState, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest("GET", cityURL(fs, path), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestBeadReadyFederatesGraphStore(t *testing.T) {
+	fs := newSplitFederationState(t)
+	graphID := seedGraphStepBead(t, fs)
+
+	body := getListBody(t, fs, "/beads/ready")
+	if !bodyContainsBeadID(body.Items, graphID) {
+		t.Fatalf("ready items = %+v, want the graph-store step %q (DAG invisible behind an authoritative 200?)", body.Items, graphID)
+	}
+	if body.Partial {
+		t.Fatalf("Partial = true, want false — a healthy graph federation is authoritative")
+	}
+}
+
+// TestBeadReadyGraphLegHardFailIs503 is the Invariant 0 half: a dead graph leg
+// is an authoritative failure, never a degraded Partial 200. The rig store holds
+// claimable work, so a handler that degrades would have something to serve —
+// that is exactly the work-only 200 this pins against.
+func TestBeadReadyGraphLegHardFailIs503(t *testing.T) {
+	fs := newSplitFederationState(t)
+	if _, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"}); err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+	fs.graphBeadStore = &failingBeadStore{Store: beads.NewMemStore(), readyErr: errors.New("infra dolt unreachable")}
+
+	rec := getRaw(t, fs, "/beads/ready")
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503 when the graph plane is unreadable — a work-only Partial 200 hides the whole DAG (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBeadReadyGraphLegPartialIsAlso503 pins the sharper edge of Invariant 0: a
+// PartialResultError from the graph leg is still authoritative failure. A rig
+// that skipped rows is one scope reporting a hole; the graph plane skipping rows
+// means an unknown slice of the DAG is missing, and the response cannot say
+// which.
+func TestBeadReadyGraphLegPartialIsAlso503(t *testing.T) {
+	fs := newSplitFederationState(t)
+	base := beads.NewMemStore()
+	survivor, err := base.Create(beads.Bead{Type: "task", Title: "surviving graph row"})
+	if err != nil {
+		t.Fatalf("seed graph survivor: %v", err)
+	}
+	fs.graphBeadStore = &failingBeadStore{
+		Store:       base,
+		readyResult: []beads.Bead{survivor},
+		readyErr:    &beads.PartialResultError{Op: "bd ready", Err: errors.New("skipped 1 corrupt bead")},
+	}
+
+	rec := getRaw(t, fs, "/beads/ready")
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503 — a partial graph read leaves an unnamed hole in the DAG (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBeadListFederatesGraphStore(t *testing.T) {
+	fs := newSplitFederationState(t)
+	graphID := seedGraphStepBead(t, fs)
+
+	body := getListBody(t, fs, "/beads")
+	if !bodyContainsBeadID(body.Items, graphID) {
+		t.Fatalf("list items = %+v, want the graph-store bead %q (DAG invisible behind an authoritative 200?)", body.Items, graphID)
+	}
+}
+
+func TestBeadListGraphLegHardFailIs503(t *testing.T) {
+	fs := newSplitFederationState(t)
+	if _, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"}); err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+	fs.graphBeadStore = &failingBeadStore{Store: beads.NewMemStore(), listErr: errors.New("infra dolt unreachable")}
+
+	rec := getRaw(t, fs, "/beads")
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503 when the graph list read hard-fails (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBeadListGraphLegPartialIsAlso503(t *testing.T) {
+	fs := newSplitFederationState(t)
+	base := beads.NewMemStore()
+	survivor, err := base.Create(beads.Bead{Type: "task", Title: "surviving graph row"})
+	if err != nil {
+		t.Fatalf("seed graph survivor: %v", err)
+	}
+	fs.graphBeadStore = &failingBeadStore{
+		Store:      base,
+		listResult: []beads.Bead{survivor},
+		listErr:    &beads.PartialResultError{Op: "bd list", Err: errors.New("skipped 1 corrupt bead")},
+	}
+
+	rec := getRaw(t, fs, "/beads")
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503 — a partial graph read leaves an unnamed hole in the DAG (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBeadListRigScopedReadExcludesGraphLeg pins that ?rig=<name> stays a
+// rig-scoped read: the graph plane is not a rig, so it is not merged and the
+// synthetic federation key is never addressable as one.
+func TestBeadListRigScopedReadExcludesGraphLeg(t *testing.T) {
+	fs := newSplitFederationState(t)
+	graphID := seedGraphStepBead(t, fs)
+	rigBead, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"})
+	if err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+
+	body := getListBody(t, fs, "/beads?rig=myrig")
+	if !bodyContainsBeadID(body.Items, rigBead.ID) {
+		t.Fatalf("rig-scoped items = %+v, want the rig bead %q", body.Items, rigBead.ID)
+	}
+	if bodyContainsBeadID(body.Items, graphID) {
+		t.Fatalf("rig-scoped items include the graph bead %q; ?rig= is a rig-scoped read and the graph plane is not a rig", graphID)
+	}
+
+	// The synthetic federation key must not be selectable as a rig either.
+	synthetic := getListBody(t, fs, "/beads?rig="+graphFederationLegKey(fs.CityName()))
+	if len(synthetic.Items) != 0 {
+		t.Fatalf("?rig=%s returned %d items; the synthetic graph leg key must not be addressable as a rig", graphFederationLegKey(fs.CityName()), len(synthetic.Items))
+	}
+}
+
+// TestBeadReadyLegacyCityUnchanged is the single-store byte-identity half. On a
+// legacy city GraphBeadStore() == CityBeadStore(), so the infra arm never fires
+// and the response is what it was before this leg existed.
+//
+// It is also the mutation-killer for the arm's identity guard: drop
+// `graph != CityBeadStore()` and the city store is federated a second time —
+// harmless for the rows (seen[] dedupes them) but NOT for the failure
+// accounting, because the second attempt runs under the graph leg's fail-loud
+// contract. TestBeadReadyLegacyCityDegradedCityStoreStaysPartial pins that.
+func TestBeadReadyLegacyCityUnchanged(t *testing.T) {
+	fs := newLegacyFederationState(t)
+	if _, err := fs.cityBeadStore.Create(beads.Bead{Type: "task", Title: "city work"}); err != nil {
+		t.Fatalf("seed city work: %v", err)
+	}
+	if _, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"}); err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+
+	body := getListBody(t, fs, "/beads/ready")
+	if body.Partial {
+		t.Fatalf("Partial = true on a single-store city, want false")
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("ready items = %d, want 2 (one city, one rig)", len(body.Items))
+	}
+	seen := map[string]bool{}
+	for _, b := range body.Items {
+		if seen[b.ID] {
+			t.Fatalf("duplicate bead %q in single-store ready set", b.ID)
+		}
+		seen[b.ID] = true
+	}
+}
+
+// TestBeadReadyLegacyCityDegradedCityStoreStaysPartial kills the mutation that
+// drops the arm's `graph != CityBeadStore()` identity guard. On a legacy city
+// the two accessors return the SAME store, so an unguarded arm would re-read it
+// under the fail-loud contract and turn today's honest Partial 200 into a 503 —
+// a single-store city taking a new failure mode from a split-city feature.
+func TestBeadReadyLegacyCityDegradedCityStoreStaysPartial(t *testing.T) {
+	fs := newLegacyFederationState(t)
+	rigBead, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"})
+	if err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+	fs.cityBeadStore = &failingBeadStore{Store: beads.NewMemStore(), readyErr: errors.New("city store hiccup")}
+
+	body := getListBody(t, fs, "/beads/ready")
+	if !body.Partial {
+		t.Fatalf("Partial = false, want true — a degraded city store on a legacy city degrades, it does not fail loud")
+	}
+	if !bodyContainsBeadID(body.Items, rigBead.ID) {
+		t.Fatalf("items = %+v, want the healthy rig's bead %q still served", body.Items, rigBead.ID)
+	}
+}
+
+// TestBeadListLegacyCityUnchanged is the list-side byte-identity half: a legacy
+// city's rows come back exactly once, with the graph arm dead.
+//
+// Two independent mechanisms hold that here, and knowing which is which matters
+// when this goes red: the arm's `graph != CityBeadStore()` identity guard keeps
+// the leg from being minted at all, and sortedRigNames' store-identity dedup
+// would collapse it even if the guard were dropped. The mutation-killer for the
+// guard itself is TestBeadListLegacyCityDoesNotSmuggleCityStore.
+func TestBeadListLegacyCityUnchanged(t *testing.T) {
+	fs := newLegacyFederationState(t)
+	cityBead, err := fs.cityBeadStore.Create(beads.Bead{Type: "task", Title: "city work"})
+	if err != nil {
+		t.Fatalf("seed city work: %v", err)
+	}
+	if _, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"}); err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+	// The city store is reachable through BeadStores() the way production wires
+	// it (cmd/gc/api_state.go keys it by CityName()), so the legacy response
+	// already contains it exactly once.
+	fs.stores[fs.CityName()] = fs.cityBeadStore
+
+	body := getListBody(t, fs, "/beads")
+	if body.Partial {
+		t.Fatalf("Partial = true on a single-store city, want false (errors=%v)", body.PartialErrors)
+	}
+	if body.Total != 2 || len(body.Items) != 2 {
+		t.Fatalf("list total=%d items=%d, want 2/2 — a duplicated city leg is the unguarded-merge mutation", body.Total, len(body.Items))
+	}
+	count := 0
+	for _, b := range body.Items {
+		if b.ID == cityBead.ID {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("city bead %q appears %d times, want exactly 1", cityBead.ID, count)
+	}
+}
+
+// TestBeadReadyWorkStoresDownButGraphUpIsPartial200 pins the deliberate
+// consequence of counting the graph leg as a backend attempt: totalOutage means
+// "every leg we asked failed", so a split city whose work stores are all down
+// but whose graph plane answered gets a Partial 200 carrying the DAG, not the
+// 503 a work-only fan-out would have produced. The asymmetry is the point — the
+// graph plane answered authoritatively, and the rig errors are named in
+// partial_errors.
+func TestBeadReadyWorkStoresDownButGraphUpIsPartial200(t *testing.T) {
+	fs := newSplitFederationState(t)
+	graphID := seedGraphStepBead(t, fs)
+	fs.cityBeadStore = &failingBeadStore{Store: beads.NewMemStore(), readyErr: errors.New("city store down")}
+	fs.stores["myrig"] = &failingBeadStore{Store: beads.NewMemStore(), readyErr: errors.New("rig store down")}
+
+	body := getListBody(t, fs, "/beads/ready")
+	if !body.Partial || len(body.PartialErrors) != 2 {
+		t.Fatalf("Partial=%v errors=%v, want partial with both work-store failures named", body.Partial, body.PartialErrors)
+	}
+	if !bodyContainsBeadID(body.Items, graphID) {
+		t.Fatalf("items = %+v, want the graph step %q — the plane that answered is the DAG", body.Items, graphID)
+	}
+}
+
+// TestBeadListLegacyCityDoesNotSmuggleCityStore is the mutation-killer for the
+// list arm's `graph != CityBeadStore()` identity guard. It pins the byte-identity
+// property directly: on a legacy city the graph arm must not change WHICH stores
+// the fan-out reads. Here BeadStores() deliberately does not carry the city
+// store, so an unguarded arm would mint a synthetic leg pointing at it and the
+// city's beads would appear in a response that never contained them.
+func TestBeadListLegacyCityDoesNotSmuggleCityStore(t *testing.T) {
+	fs := newLegacyFederationState(t)
+	cityBead, err := fs.cityBeadStore.Create(beads.Bead{Type: "task", Title: "city work"})
+	if err != nil {
+		t.Fatalf("seed city work: %v", err)
+	}
+	rigBead, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"})
+	if err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+
+	body := getListBody(t, fs, "/beads")
+	if !bodyContainsBeadID(body.Items, rigBead.ID) {
+		t.Fatalf("list items = %+v, want the rig bead %q", body.Items, rigBead.ID)
+	}
+	if bodyContainsBeadID(body.Items, cityBead.ID) {
+		t.Fatalf("list items include city bead %q, which is not in BeadStores() — the graph arm minted a leg on a legacy city, so it is no longer byte-identical", cityBead.ID)
+	}
+	if body.Total != 1 {
+		t.Fatalf("list total = %d, want 1", body.Total)
+	}
+}
+
+// TestBeadReadyFederationOrderIsLegConcatenation pins the ordering rule the
+// follow-on CLI federation (ga-oxsyu) has to match so its conformance test can
+// assert CLI == API instead of inventing an oracle:
+//
+//	legs, in order:  city store, then rigs by name ascending, then the graph store
+//	within a leg:    that leg's canonical ready order (priority, created_at, id)
+//	dedupe:          first leg to return an id wins
+//	merged order:    leg concatenation — deliberately NOT re-sorted, because a
+//	                 global sort would change the bytes a single-store city
+//	                 already serves
+//
+// Because every leg is already in canonical ready order and that order is total,
+// both sides normalize with beads.SortBeadsReadyOrder before comparing. The
+// graph leg goes LAST, which matches the CLI composite's work-then-infra leg
+// order, so on a rig-less city the two sequences agree without normalizing.
+func TestBeadReadyFederationOrderIsLegConcatenation(t *testing.T) {
+	fs := newSplitFederationState(t)
+	cityBead, err := fs.cityBeadStore.Create(beads.Bead{Type: "task", Title: "city work"})
+	if err != nil {
+		t.Fatalf("seed city work: %v", err)
+	}
+	rigBead, err := fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "rig work"})
+	if err != nil {
+		t.Fatalf("seed rig work: %v", err)
+	}
+	graphID := seedGraphStepBead(t, fs)
+
+	body := getListBody(t, fs, "/beads/ready")
+	want := []string{cityBead.ID, rigBead.ID, graphID}
+	got := make([]string, 0, len(body.Items))
+	for _, b := range body.Items {
+		got = append(got, b.ID)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ready ids = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ready ids = %v, want %v (leg order is city, rigs asc, graph last)", got, want)
+		}
+	}
+}

--- a/internal/api/handler_beads_infra_federation_test.go
+++ b/internal/api/handler_beads_infra_federation_test.go
@@ -203,8 +203,9 @@ func TestBeadListGraphLegPartialIsAlso503(t *testing.T) {
 }
 
 // TestBeadListRigScopedReadExcludesGraphLeg pins that ?rig=<name> stays a
-// rig-scoped read: the graph plane is not a rig, so it is not merged and the
-// synthetic federation key is never addressable as one.
+// rig-scoped read: the graph plane is not a rig, so a rig-scoped request gets no
+// graph leg. The leg has no name of its own to be selected by either — legs are
+// a slice, and only the named rig stores are addressable through ?rig=.
 func TestBeadListRigScopedReadExcludesGraphLeg(t *testing.T) {
 	fs := newSplitFederationState(t)
 	graphID := seedGraphStepBead(t, fs)
@@ -221,10 +222,11 @@ func TestBeadListRigScopedReadExcludesGraphLeg(t *testing.T) {
 		t.Fatalf("rig-scoped items include the graph bead %q; ?rig= is a rig-scoped read and the graph plane is not a rig", graphID)
 	}
 
-	// The synthetic federation key must not be selectable as a rig either.
-	synthetic := getListBody(t, fs, "/beads?rig="+graphFederationLegKey(fs.CityName()))
-	if len(synthetic.Items) != 0 {
-		t.Fatalf("?rig=%s returned %d items; the synthetic graph leg key must not be addressable as a rig", graphFederationLegKey(fs.CityName()), len(synthetic.Items))
+	// A rig name that does not exist selects nothing — there is no leg reachable
+	// through ?rig= other than a configured rig store.
+	unknown := getListBody(t, fs, "/beads?rig=not-a-rig")
+	if len(unknown.Items) != 0 {
+		t.Fatalf("?rig=not-a-rig returned %d items; only configured rig stores are addressable", len(unknown.Items))
 	}
 }
 
@@ -380,16 +382,20 @@ func TestBeadListLegacyCityDoesNotSmuggleCityStore(t *testing.T) {
 // assert CLI == API instead of inventing an oracle:
 //
 //	legs, in order:  city store, then rigs by name ascending, then the graph store
-//	within a leg:    that leg's canonical ready order (priority, created_at, id)
+//	within a leg:    whatever order that leg's own Ready reader emits
 //	dedupe:          first leg to return an id wins
 //	merged order:    leg concatenation — deliberately NOT re-sorted, because a
 //	                 global sort would change the bytes a single-store city
 //	                 already serves
 //
-// Because every leg is already in canonical ready order and that order is total,
-// both sides normalize with beads.SortBeadsReadyOrder before comparing. The
-// graph leg goes LAST, which matches the CLI composite's work-then-infra leg
-// order, so on a rig-less city the two sequences agree without normalizing.
+// Per-leg order is deterministic but NOT canonical across leg kinds: a
+// caching-wrapped work store emits (priority, created_at, id) via
+// sortBeadsReadyOrder, while the canonical relocated graph binding
+// (beads.SQLiteStore) emits (created_at, id) with no priority term at all
+// (sqliteReadySQL). Both sides therefore normalize with
+// beads.SortBeadsReadyOrder before comparing — a load-bearing step, not a
+// formality. The graph leg goes LAST, which matches the CLI composite's
+// work-then-infra leg order.
 func TestBeadReadyFederationOrderIsLegConcatenation(t *testing.T) {
 	fs := newSplitFederationState(t)
 	cityBead, err := fs.cityBeadStore.Create(beads.Bead{Type: "task", Title: "city work"})

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -718,6 +718,10 @@ func TestBeadListFiltering(t *testing.T) {
 func TestBeadListCrossRig(t *testing.T) {
 	state := newFakeState(t)
 	store2 := beads.NewMemStore()
+	// Two rigs mint under different prefixes (config.Rig.EffectivePrefix); two
+	// MemStores left on the default prefix would both mint "gc-1", i.e. one bead
+	// co-resident in two legs rather than two beads.
+	store2.IDPrefix = "r2"
 	state.stores["rig2"] = store2
 
 	state.stores["myrig"].Create(beads.Bead{Title: "Bead from rig1"}) //nolint:errcheck
@@ -1824,16 +1828,28 @@ func TestPhase2BeadAssignNormalizesCurrentSessionAlias(t *testing.T) {
 	}
 }
 
-func TestPhase2BeadListAssigneeAliasKeepsCrossRigDuplicateIDs(t *testing.T) {
+// TestPhase2BeadListAssigneeAliasServesEveryRigsBeads pins that resolving an
+// assignee alias into several identity terms does not cost a rig its rows: every
+// bead assigned to the session, in every rig, is in the response exactly once.
+//
+// The rigs mint under different prefixes because that is the only shape a
+// running city can have — config.ValidateRigs rejects a colliding rig prefix on
+// every start, reload and config-edit path, so two rigs cannot mint the same id.
+// (Its ancestor left both MemStores on the default prefix, which made "two beads"
+// and "one bead resident in two legs" the same fixture; the fan-out reads bead
+// ids as identity, the way GET /v0/beads/ready and every by-id endpoint do.)
+func TestPhase2BeadListAssigneeAliasServesEveryRigsBeads(t *testing.T) {
 	state := newFakeState(t)
 	state.cityBeadStore = beads.NewMemStore()
-	state.stores["otherrig"] = beads.NewMemStore()
-	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "otherrig", Path: "/tmp/otherrig"})
+	otherStore := beads.NewMemStore()
+	otherStore.IDPrefix = "or"
+	state.stores["otherrig"] = otherStore
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "otherrig", Path: "/tmp/otherrig", Prefix: "or"})
 	sessionBead := createPhase2APISessionBead(t, state.cityBeadStore)
 	workA, _ := state.stores["myrig"].Create(beads.Bead{Title: "Task A", Assignee: sessionBead.ID})
-	workB, _ := state.stores["otherrig"].Create(beads.Bead{Title: "Task B", Assignee: sessionBead.ID})
-	if workA.ID != workB.ID {
-		t.Fatalf("test setup expected duplicate local IDs, got %q and %q", workA.ID, workB.ID)
+	workB, _ := otherStore.Create(beads.Bead{Title: "Task B", Assignee: sessionBead.ID})
+	if workA.ID == workB.ID {
+		t.Fatalf("test setup expected distinct per-rig IDs, got %q twice", workA.ID)
 	}
 	srv := New(state)
 	h := newTestCityHandlerWith(t, state, srv)
@@ -1854,6 +1870,17 @@ func TestPhase2BeadListAssigneeAliasKeepsCrossRigDuplicateIDs(t *testing.T) {
 	}
 	if listed.Total != 2 || len(listed.Items) != 2 {
 		t.Fatalf("list by alias total/items = %d/%d, want 2/2: %#v", listed.Total, len(listed.Items), listed.Items)
+	}
+	for _, want := range []string{workA.ID, workB.ID} {
+		found := false
+		for _, b := range listed.Items {
+			if b.ID == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("alias fan-out dropped %q: %#v", want, listed.Items)
+		}
 	}
 }
 

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -581,11 +581,20 @@ type statusWorkResult struct {
 }
 
 // statusWorkCounts tallies persisted open/in_progress work across BeadStores
-// and federates canonical Ready work exactly like GET /beads/ready: the city
-// store first, then BeadStores excluding the CityName alias. Stores exposing
-// beads.Counter answer persisted counts without hydrating rows — the caching
-// layer counts matches in memory when its cache is clean (#1896). Stores are
-// queried concurrently; results aggregate in deterministic city/rig order.
+// and federates canonical Ready work the way GET /beads/ready does over the
+// work stores: the city store first, then BeadStores excluding the CityName
+// alias. Stores exposing beads.Counter answer persisted counts without
+// hydrating rows — the caching layer counts matches in memory when its cache is
+// clean (#1896). Stores are queried concurrently; results aggregate in
+// deterministic city/rig order.
+//
+// NOT identical to GET /beads/ready on a split city: that handler grew a
+// relocated-graph-store leg (huma_handlers_beads.go) and this one has none, so
+// on a city with [beads.classes.graph] relocated the status ready count omits
+// graph-class ready work while /beads/ready includes it. Left divergent
+// deliberately rather than fixed here: this read is cache-only and error-lenient
+// by design (see cacheColdRigs below), which is the opposite of the graph leg's
+// fail-loud contract, so wiring one in is its own slice, not a rider.
 //
 // Rigs in cacheColdRigs are asked for persisted counts but not for ready work.
 // Their store runs no background cache refresh, so the cache-only Ready

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -69,25 +69,6 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	stores := s.state.BeadStores()
 	assigneeTerms := s.beadListAssigneeTerms(ctx, input.Assignee)
 	var rigNames []string
-	// Split city: graph-class beads (gcg- molecule roots, steps, control beads)
-	// live in the relocated graph store, which BeadStores() does not include.
-	// Merge it in as one more fan-out leg — under a synthetic key, so the whole
-	// per-store body below (bounded Count, keyset seek, the global re-sort, the
-	// page cut) covers it too — or the DAG is invisible behind an authoritative
-	// 200. Skipped for a rig-scoped request, which is asking for one rig and the
-	// graph plane is not one; that also keeps the synthetic key unaddressable.
-	// The map is copied, never mutated in place: State hands its own map out by
-	// reference.
-	infraLeg := ""
-	if graph := relocatedGraphStore(s.state); graph != nil && input.Rig == "" {
-		infraLeg = graphFederationLegKey(s.state.CityName())
-		merged := make(map[string]beads.Store, len(stores)+1)
-		for k, v := range stores {
-			merged[k] = v
-		}
-		merged[infraLeg] = graph
-		stores = merged
-	}
 	if input.Rig != "" {
 		if _, ok := stores[input.Rig]; ok {
 			rigNames = []string{input.Rig}
@@ -95,38 +76,47 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	} else {
 		rigNames = sortedRigNames(stores)
 	}
+	legs := beadListFanOut(s.state, stores, rigNames, input.Rig != "")
 
 	var all []beads.Bead
-	dedupe := len(assigneeTerms) > 1
 
 	// all=true reads materialize closed history per rig, so the build is
 	// O(history) even though the caller only wants a recency-bounded page
-	// (gascity#3253). When every store can Count the query exactly, push the
-	// page bound down so each store returns only the rows this page needs and
-	// source Total from a hydration-free Count instead of len(full history).
+	// (gascity#3253). When a store can Count the query exactly, push the page
+	// bound down so it returns only the rows this page needs and source its
+	// share of Total from a hydration-free Count instead of len(full history).
 	// This collapses the FIRST page (no seek boundary) to O(limit) at the store
 	// boundary via each backend's native LIMIT; a seeked cursor page disables
 	// that native limit and hydrates matching history before the Go-side seek
 	// filter (see query.SeekAfter), trading O(limit) fetches for exactness on a
 	// deep walk. The response shape (a created_at-desc prefix plus an accurate
 	// Total and next_cursor) is unchanged. Scoped to the single-assignee all=true
-	// hot path; if any store cannot Count the query, keep the full-scan path so
-	// Total and ordering stay correct (the Count fallback contract from #3211).
+	// hot path; a WORK store that cannot Count the query keeps the whole request
+	// on the full-scan path so Total and ordering stay correct (the Count
+	// fallback contract from #3211), while a Counter-less GRAPH leg hydrates
+	// alone — see beadListBounding.
 	boundedMode := false
 	boundedFetch := 0
-	var boundedCounts map[string]int
-	if input.All && !dedupe && len(assigneeTerms) == 1 {
+	var boundedCounts map[int]int
+	var hydrateLegs map[int]bool
+	if input.All && len(assigneeTerms) == 1 {
 		// limit+1: the seek boundary rides on each store query and is enforced
 		// Go-side, so a store returns only rows after the boundary — one extra
 		// row is the has-more signal (Counts are un-seeked totals and cannot tell).
 		boundedFetch = limit + 1
-		boundedMode, boundedCounts = beadListBoundedTotal(ctx, stores, rigNames, assigneeTerms[0], input)
+		boundedMode, boundedCounts, hydrateLegs = beadListBounding(ctx, legs, assigneeTerms[0], input)
 	}
 
+	// Bead ids are globally unique, so an id is one bead no matter how many legs
+	// hold a row for it. A migrated split city really does hold both: `gc storage
+	// migrate` copies infrastructure rows into the binding with their ids
+	// preserved (CreateWithForeignID) and never deletes them back, so the work
+	// store keeps its copy — convergence is DEFINED as that full overlap. First
+	// leg wins, and the graph leg is federated last, so the work store's row is
+	// the one served — byte-identical to the rule humaHandleBeadReady applies.
 	seen := map[string]bool{}
 	var pa partialAggregator
-	for _, rigName := range rigNames {
-		store := stores[rigName]
+	for i, leg := range legs {
 		for _, assignee := range assigneeTerms {
 			query := beads.ListQuery{
 				Status:        input.Status,
@@ -143,7 +133,8 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 			if !query.HasFilter() {
 				query.AllowScan = true
 			}
-			if boundedMode {
+			legBounded := boundedMode && !hydrateLegs[i]
+			if legBounded {
 				// Each store need only return enough rows to cover this page;
 				// the cross-rig merge below cuts the exact global prefix. On the
 				// first page (seek == nil) the native LIMIT makes the per-store
@@ -157,15 +148,17 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 				query.SeekAfter = seek
 			}
 			pa.attempt()
-			list, err := store.List(query)
+			list, err := leg.store.List(query)
 			if err != nil {
-				if rigName == infraLeg {
+				if leg.graph {
 					// The graph leg is the execution DAG, not a rig: any degraded
 					// read there — hard failure or partial — leaves an unnamed hole
 					// in a dependency graph, so it fails LOUD instead of degrading
 					// to a work-only 200 (the authoritative-failure contract, same
-					// as the ready arm).
-					return nil, graphPlaneUnavailable("list", err)
+					// as the ready arm). Work-leg failures recorded so far ride
+					// along: without them "the graph plane is down" and "the whole
+					// city is down" are the same response.
+					return nil, graphPlaneUnavailable("list", err, pa.messages()...)
 				}
 				if beads.IsPartialResult(err) && len(list) > 0 {
 					// Partial result: the rig returned rows (appended to `all`
@@ -175,10 +168,10 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 					// loss), strictly worse than the count's slight possible
 					// over-advertisement. Only a hard List failure (zero
 					// reachable rows, below) drops its count (gascity#3253).
-					pa.record("rig "+rigName, err)
+					pa.record(leg.label, err)
 					pa.success()
 				} else {
-					pa.record("rig "+rigName, err)
+					pa.record(leg.label, err)
 					if boundedMode {
 						// This rig's exact Count was baked into boundedCounts
 						// upfront, but its List failed so its rows never reach
@@ -186,21 +179,31 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 						// rows — matching the full-scan accounting under the same
 						// partial failure (where total == rows returned) and
 						// keeping next_cursor from overshooting (gascity#3253).
-						delete(boundedCounts, rigName)
+						delete(boundedCounts, i)
 					}
 					continue
 				}
 			} else {
 				pa.success()
 			}
+			if boundedMode && !legBounded {
+				// This leg hydrated because it cannot Count, so the rows it just
+				// returned ARE its exact un-seeked total — which is what Total
+				// needs, and what keeps Total constant across a cursor walk.
+				boundedCounts[i] = len(list)
+			}
 			for _, b := range list {
-				dedupeKey := rigName + "\x00" + b.ID
-				if dedupe && seen[dedupeKey] {
+				if boundedMode && !legBounded && seek != nil && !seek.After(b, beads.SortCreatedDesc) {
+					// A hydrated leg carries no store-side seek boundary (that is
+					// what made its row count the un-seeked total), so the page
+					// boundary is applied here instead. resolveBeadListPage's
+					// bounded branch assumes every row it receives is past it.
 					continue
 				}
-				if dedupe {
-					seen[dedupeKey] = true
+				if seen[b.ID] {
+					continue
 				}
+				seen[b.ID] = true
 				all = append(all, b)
 			}
 		}
@@ -215,9 +218,9 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	// Per-store results are each (created_at, id)-ordered, but the
 	// concatenation across rigs and assignee terms is not: re-sort so the
 	// merged set has one global total order and a bounded read is a
-	// deterministic prefix of it (#3208). A single (rig, assignee) source is
+	// deterministic prefix of it (#3208). A single (leg, assignee) source is
 	// already in canonical order — skip the redundant hot-path sort.
-	if len(rigNames)*len(assigneeTerms) > 1 {
+	if len(legs)*len(assigneeTerms) > 1 {
 		beads.SortBeads(all, beads.SortCreatedDesc)
 	}
 
@@ -270,14 +273,23 @@ func beadListSeek(cursor string) (*beads.SeekBoundary, error) {
 // order the store fan-out produced. It performs no I/O.
 //
 // In boundedMode `all` is the limit+1 overfetch prefix and boundedCounts holds
-// the exact per-rig un-seeked Counts, so Total is their sum (constant across a
+// the exact per-leg un-seeked totals, so Total is their sum (constant across a
 // walk) and the extra overfetched row is the has-more signal. A degraded
 // (partial) rig can fall short of that signal, so a non-empty partial page
 // force-mints a resume cursor to keep the walk going past the degradation
 // (gascity#3253). Otherwise `all` is the complete un-seeked set: Total is its
 // length and the page is the contiguous suffix strictly after the Go-side seek
 // boundary.
-func resolveBeadListPage(all []beads.Bead, seek *beads.SeekBoundary, limit int, boundedMode bool, boundedCounts map[string]int, partial bool) (page []beads.Bead, total int, hasMore bool) {
+//
+// One honest limit on the bounded Total: per-leg counts are summed, and a leg
+// counted (rather than hydrated) reports its own rows without knowing which of
+// them another leg also holds. On a migrated split city whose graph binding CAN
+// Count, an id co-resident in the work store and the binding is therefore
+// counted twice even though it is served once. Every page and the has-more
+// signal are still exact — they come from the deduped row set — so a cursor walk
+// terminates on the real end of the set; only the advertised Total runs high,
+// the same direction the partial-failure rule already accepts.
+func resolveBeadListPage(all []beads.Bead, seek *beads.SeekBoundary, limit int, boundedMode bool, boundedCounts map[int]int, partial bool) (page []beads.Bead, total int, hasMore bool) {
 	if boundedMode {
 		for _, n := range boundedCounts {
 			total += n
@@ -317,13 +329,13 @@ func resolveBeadListPage(all []beads.Bead, seek *beads.SeekBoundary, limit int, 
 // the (created_at, id) boundary of the last row served. An exhausted or empty
 // page mints nothing, which the client reads as walk-complete.
 //
-// The resume key is (created_at, id) while the fan-out's identity key is
-// (rig, id): this assumes (created_at, id) is globally unique across the merged
-// rigs. That holds for distinct-store rigs; the only collision is the
-// documented legacy file-mode aliasing of the city and rig stores, where twins
-// would make the page boundary position-dependent (benign today — a true
-// duplicate). A future globally-non-unique ID scheme would need a wider resume
-// key here.
+// The resume key is (created_at, id), which assumes (created_at, id) is
+// globally unique across the merged legs. The fan-out's identity key is the
+// bead id alone, so the two ways a leg pair can hold the same id — legacy
+// file-mode aliasing of the city and rig stores, and the work/binding
+// co-residence a migrated split city keeps — are collapsed before the page is
+// cut, and no twin can reach a page boundary. A future globally-non-unique ID
+// scheme would need a wider resume key here.
 func mintNextCursor(page []beads.Bead, hasMore bool) string {
 	if !hasMore || len(page) == 0 {
 		return ""
@@ -336,31 +348,101 @@ func mintNextCursor(page []beads.Bead, hasMore bool) string {
 	})
 }
 
-// beadListBoundedTotal returns the exact per-rig bead counts for the all=true
-// list query across rigNames, sourced from each store's hydration-free Count.
-// The first return value reports whether bounding is safe: it is false (and
-// the caller keeps the full-scan path) if any store does not implement Counter
-// or cannot count the query exactly (ErrCountUnsupported), so Total and the
-// recency-ordered prefix stay correct on backends without a cheap count.
+// beadListLeg is one source in the bead-list fan-out.
 //
-// Counts are returned keyed by rig (not pre-summed) so the caller can drop the
-// count of any rig whose subsequent List fails: Total must reflect only the
-// rows actually reachable, matching the full-scan path under partial failure
-// (gascity#3253).
-func beadListBoundedTotal(ctx context.Context, stores map[string]beads.Store, rigNames []string, assignee string, input *BeadListInput) (bool, map[string]int) {
-	counts := make(map[string]int, len(rigNames))
+// Legs are a SLICE, not a map keyed by rig name: the relocated graph store has
+// no rig name, and giving it a synthetic one put it in the same namespace as
+// real rigs — a rig that happened to carry that name was silently overwritten
+// and vanished from the response — while sorting it into the middle of the rig
+// order made the merged sequence depend on the city's name.
+type beadListLeg struct {
+	// label is what a degraded read is reported under in partial_errors.
+	label string
+	store beads.Store
+	// graph marks the relocated graph plane, which does not degrade: it either
+	// answers or the request fails loud (see graphPlaneUnavailable).
+	graph bool
+}
+
+// beadListFanOut builds the ordered leg list for a bead-list request: the work
+// stores in rigNames order, then the relocated graph store last.
+//
+// Graph-class beads (gcg- molecule roots, steps, control beads) live in the
+// relocated graph store on a split city, and BeadStores() does not include it —
+// without this leg the whole execution DAG is invisible behind an authoritative
+// 200. It goes LAST so first-leg-wins id dedupe resolves a bead co-resident in
+// both planes to the work store's row, exactly as humaHandleBeadReady does, and
+// so the merged order stays a leg concatenation whose prefix is what a legacy
+// city already serves.
+//
+// A rig-scoped request gets no graph leg: it is asking for one rig, and the
+// graph plane is not a rig.
+func beadListFanOut(state State, stores map[string]beads.Store, rigNames []string, rigScoped bool) []beadListLeg {
+	legs := make([]beadListLeg, 0, len(rigNames)+1)
 	for _, rigName := range rigNames {
-		counter, ok := stores[rigName].(beads.Counter)
-		if !ok {
-			return false, nil
-		}
-		n, err := counter.Count(ctx, beadListCountQuery(assignee, input))
-		if err != nil {
-			return false, nil
-		}
-		counts[rigName] = n
+		legs = append(legs, beadListLeg{label: "rig " + rigName, store: stores[rigName]})
 	}
-	return true, counts
+	if rigScoped {
+		return legs
+	}
+	if graph := relocatedGraphStore(state); graph != nil {
+		legs = append(legs, beadListLeg{label: "graph", store: graph, graph: true})
+	}
+	return legs
+}
+
+// beadListBounding plans, per leg, how the all=true page is bounded.
+//
+// It returns whether bounding is on at all, the exact un-seeked count of every
+// leg it could count (keyed by leg index, not pre-summed, so the caller can drop
+// the count of a leg whose subsequent List fails — Total must reflect only rows
+// actually reachable, matching the full-scan path under partial failure,
+// gascity#3253), and the legs that must hydrate instead.
+//
+// The WORK legs are all-or-nothing, which is the #3211 Count-fallback contract:
+// one work store that cannot Count the query exactly means Total and the
+// recency-ordered prefix have to come from the full scan.
+//
+// The GRAPH leg is deliberately outside that gate. It is one more source, not a
+// capability veto: the canonical compiled-in binding hands the API a raw
+// *beads.SQLiteStore (internal/storebinding/sqlite/beads_engine.go OpenEngine),
+// which implements no Count at all, so letting it into the all-or-nothing gate
+// would switch bounded paging off for every leg on precisely the split city this
+// federation exists for. When it can Count it is bounded like the rest; when it
+// cannot, only that leg hydrates and the caller takes its exact total from the
+// rows it returned.
+func beadListBounding(ctx context.Context, legs []beadListLeg, assignee string, input *BeadListInput) (on bool, counts map[int]int, hydrate map[int]bool) {
+	counts = make(map[int]int, len(legs))
+	for i, leg := range legs {
+		n, ok := beadListLegCount(ctx, leg.store, assignee, input)
+		if ok {
+			counts[i] = n
+			continue
+		}
+		if !leg.graph {
+			return false, nil, nil
+		}
+		if hydrate == nil {
+			hydrate = make(map[int]bool, 1)
+		}
+		hydrate[i] = true
+	}
+	return true, counts, hydrate
+}
+
+// beadListLegCount returns one leg's exact un-seeked count, reporting false when
+// the store implements no Counter or cannot count this query shape exactly
+// (ErrCountUnsupported).
+func beadListLegCount(ctx context.Context, store beads.Store, assignee string, input *BeadListInput) (int, bool) {
+	counter, ok := store.(beads.Counter)
+	if !ok {
+		return 0, false
+	}
+	n, err := counter.Count(ctx, beadListCountQuery(assignee, input))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // beadListCountQuery builds the count query for the all=true list path. It
@@ -390,17 +472,27 @@ func beadListCountQuery(assignee string, input *BeadListInput) beads.ListQuery {
 //   - Legs, in order: the city store, then the rigs by name ascending, then the
 //     relocated graph store. The CLI composite's legs are work-then-infra, the
 //     same relative order, so on a rig-less city the two sequences agree.
-//   - Within a leg: that leg's own canonical ready order — (priority ASC,
-//     created_at ASC, id ASC), what beads.SortBeadsReadyOrder produces.
-//   - Dedupe: first leg to return an id wins.
+//     GET /v0/beads federates the same legs in the same order.
+//   - Within a leg: whatever order that leg's own Ready reader emits. That is
+//     the canonical (priority ASC, created_at ASC, id ASC) for a work store —
+//     CachingStore.Ready sorts with sortBeadsReadyOrder — but NOT for the graph
+//     leg: the canonical relocated binding is beads.SQLiteStore, whose
+//     sqliteReadySQL orders by (created_at ASC, id ASC) with no priority term at
+//     all. Per-leg order is therefore deterministic, not canonical.
+//   - Dedupe: first leg to return an id wins. The graph leg runs last, so a bead
+//     co-resident in the work store and the binding — the documented steady
+//     state of a migrated city, where the migration preserves ids and never
+//     deletes back — resolves to the work store's row on both endpoints.
 //   - Merged order: leg concatenation, deliberately NOT re-sorted. A global
 //     re-sort would change the bytes a multi-rig single-store city already
 //     serves, and the graph leg must be free for such a city. Both sides are
-//     therefore compared after normalizing with beads.SortBeadsReadyOrder,
-//     which is well-defined: every leg is already in that order and the order
-//     is total.
+//     therefore compared after normalizing with beads.SortBeadsReadyOrder. That
+//     normalization is load-bearing rather than cosmetic, precisely because the
+//     graph leg is not priority-ordered; it is well-defined because
+//     SortBeadsReadyOrder is a total order over the merged set.
 //   - Failure: a rig degrades (Partial 200 + partial_errors); the graph leg
-//     does not (503). See graphPlaneUnavailable.
+//     does not (503, carrying any work-leg errors recorded before it). See
+//     graphPlaneUnavailable.
 func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput) (*ListOutput[beads.Bead], error) {
 	bp := input.toBlockingParams()
 	if bp.isBlocking() {
@@ -431,7 +523,10 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 		}
 		for _, b := range ready {
 			if seen[b.ID] {
-				continue // legacy file mode can alias the city and rig stores
+				// An id is one bead: legacy file mode can alias the city and rig
+				// stores, and a migrated split city holds the same infrastructure
+				// row in both the work store and the binding.
+				continue
 			}
 			seen[b.ID] = true
 			all = append(all, b)
@@ -461,7 +556,7 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 		pa.attempt()
 		ready, err := beads.HandlesFor(graph).Live.Ready()
 		if err != nil {
-			return nil, graphPlaneUnavailable("ready", err)
+			return nil, graphPlaneUnavailable("ready", err, pa.messages()...)
 		}
 		pa.success()
 		for _, b := range ready {

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -69,6 +69,25 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 	stores := s.state.BeadStores()
 	assigneeTerms := s.beadListAssigneeTerms(ctx, input.Assignee)
 	var rigNames []string
+	// Split city: graph-class beads (gcg- molecule roots, steps, control beads)
+	// live in the relocated graph store, which BeadStores() does not include.
+	// Merge it in as one more fan-out leg — under a synthetic key, so the whole
+	// per-store body below (bounded Count, keyset seek, the global re-sort, the
+	// page cut) covers it too — or the DAG is invisible behind an authoritative
+	// 200. Skipped for a rig-scoped request, which is asking for one rig and the
+	// graph plane is not one; that also keeps the synthetic key unaddressable.
+	// The map is copied, never mutated in place: State hands its own map out by
+	// reference.
+	infraLeg := ""
+	if graph := relocatedGraphStore(s.state); graph != nil && input.Rig == "" {
+		infraLeg = graphFederationLegKey(s.state.CityName())
+		merged := make(map[string]beads.Store, len(stores)+1)
+		for k, v := range stores {
+			merged[k] = v
+		}
+		merged[infraLeg] = graph
+		stores = merged
+	}
 	if input.Rig != "" {
 		if _, ok := stores[input.Rig]; ok {
 			rigNames = []string{input.Rig}
@@ -140,6 +159,14 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 			pa.attempt()
 			list, err := store.List(query)
 			if err != nil {
+				if rigName == infraLeg {
+					// The graph leg is the execution DAG, not a rig: any degraded
+					// read there — hard failure or partial — leaves an unnamed hole
+					// in a dependency graph, so it fails LOUD instead of degrading
+					// to a work-only 200 (the authoritative-failure contract, same
+					// as the ready arm).
+					return nil, graphPlaneUnavailable("list", err)
+				}
 				if beads.IsPartialResult(err) && len(list) > 0 {
 					// Partial result: the rig returned rows (appended to `all`
 					// below) but flagged a degraded read. Keep its bounded count
@@ -355,6 +382,25 @@ func beadListCountQuery(assignee string, input *BeadListInput) beads.ListQuery {
 }
 
 // humaHandleBeadReady is the Huma-typed handler for GET /v0/beads/ready.
+//
+// FEDERATION CONTRACT — the follow-on CLI federation (`gc ready`, ga-oxsyu) is
+// specified against this handler, so its conformance test can assert CLI == API
+// instead of inventing an oracle. The rules it has to match:
+//
+//   - Legs, in order: the city store, then the rigs by name ascending, then the
+//     relocated graph store. The CLI composite's legs are work-then-infra, the
+//     same relative order, so on a rig-less city the two sequences agree.
+//   - Within a leg: that leg's own canonical ready order — (priority ASC,
+//     created_at ASC, id ASC), what beads.SortBeadsReadyOrder produces.
+//   - Dedupe: first leg to return an id wins.
+//   - Merged order: leg concatenation, deliberately NOT re-sorted. A global
+//     re-sort would change the bytes a multi-rig single-store city already
+//     serves, and the graph leg must be free for such a city. Both sides are
+//     therefore compared after normalizing with beads.SortBeadsReadyOrder,
+//     which is well-defined: every leg is already in that order and the order
+//     is total.
+//   - Failure: a rig degrades (Partial 200 + partial_errors); the graph leg
+//     does not (503). See graphPlaneUnavailable.
 func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput) (*ListOutput[beads.Bead], error) {
 	bp := input.toBlockingParams()
 	if bp.isBlocking() {
@@ -404,6 +450,27 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 			// BeadStores() also returns it under cityName (cmd/gc/api_state.go)
 		}
 		federate("rig "+rigName, stores[rigName])
+	}
+	// Split city: graph-class ready work (gcg- steps, control beads, molecule
+	// roots) lives in the relocated graph store, which BeadStores() does not
+	// include — federate it or the whole execution DAG is invisible behind an
+	// authoritative-looking 200. It runs LAST so the merged order stays a leg
+	// concatenation whose prefix is exactly what a legacy city serves, and it
+	// does NOT go through federate(): the graph leg has no partial tier.
+	if graph := relocatedGraphStore(s.state); graph != nil {
+		pa.attempt()
+		ready, err := beads.HandlesFor(graph).Live.Ready()
+		if err != nil {
+			return nil, graphPlaneUnavailable("ready", err)
+		}
+		pa.success()
+		for _, b := range ready {
+			if seen[b.ID] {
+				continue
+			}
+			seen[b.ID] = true
+			all = append(all, b)
+		}
 	}
 	if pa.totalOutage() {
 		return nil, pa.outageError()

--- a/internal/beads/splittest/strict_store.go
+++ b/internal/beads/splittest/strict_store.go
@@ -443,6 +443,17 @@ func (s *StrictStore) ConditionalWritesResolveTarget() beads.Store {
 // Count forwards the leaf's beads.Counter capability. Leaves without one report
 // beads.ErrCountUnsupported, signaling callers to fall back to List — the same
 // contract cmd/gc's beadPolicyStore forwards.
+//
+// FIDELITY GAP, read this before using a kit leaf to model a count. Declaring
+// this method makes every kit store type-assert as beads.Counter, and the
+// production relocated-class binding does NOT: OpenEngine hands callers a raw
+// *beads.SQLiteStore, which has no Count at all (only CachingStore,
+// NativeDoltStore and DoltliteReadStore implement it). The two shapes are
+// indistinguishable to a caller that reaches Count — both end at
+// ErrCountUnsupported — but not to one that branches on the type assertion
+// alone. A fixture whose subject is that assertion (internal/api's bead-list
+// page bounding is the live example) must use a leaf that implements no Count,
+// or it silently models a capability the class binding does not have.
 func (s *StrictStore) Count(ctx context.Context, query beads.ListQuery, excludeTypes ...string) (int, error) {
 	counter, ok := s.Store.(beads.Counter)
 	if !ok {


### PR DESCRIPTION
Closes the API half of the split-store graph blindness: `ga-4k2c3`.

## The bug, measured

On a split city the graph-class DAG — `gcg-` molecule roots, step beads, control
beads — lives in the relocated graph store. `State.BeadStores()` does not include
it, and `humaHandleBeadReady` / `humaHandleBeadList` federated only `BeadStores()`.
The whole execution DAG was therefore invisible **behind an authoritative 200**.

Measured on a city that already has the fix, same city same moment:
API ready = **22 beads, 14 of them `gcg-`**; without the leg, 5 beads, 0 `gcg-`.

## Two properties, both landed

**1. The graph-class DAG is federated.** Both arms federate the same ordered
legs: the work stores, then the relocated graph store **last**. List builds an
ordered `[]beadListLeg` rather than merging into the rig-keyed map, so the graph
leg reuses the existing per-leg body — keyset seek, the global re-sort, the page
cut — while `Count`-based page bounding is planned **per leg** (see *Review
follow-ups*, M-A).

**2. A dead graph leg is an authoritative 503, not a degraded Partial 200.**
This is Invariant 0 at the API layer, and it is the half `partialAggregator`
violated. A rig going dark is one scope reporting a hole and `partial` /
`partial_errors` says so honestly. The graph plane going dark means the DAG is
gone from the answer, and a work-only 200 is indistinguishable from *"the DAG
finished"*. So the graph leg has no partial tier at all: **hard failure and
`PartialResultError` both 503**, because a partial graph read leaves an unnamed
hole in a dependency graph and the response has no way to say which part is
missing.

## Single-store cities are byte-identical

Both arms are gated on **store identity** (`GraphBeadStore() != CityBeadStore()`)
— the same rule `handler_beads.go`'s by-id class resolver and
`handler_convoy_dispatch.go`'s workflow scan already use — so on a default city
they never fire. Proven by mutation, not by assertion:

| mutation | test that dies |
| --- | --- |
| drop the `graph != CityBeadStore()` guard | `TestBeadReadyLegacyCityDegradedCityStoreStaysPartial` (`status = 503, want 200`) and `TestBeadListLegacyCityDoesNotSmuggleCityStore` (`list items include city bead "hq-1" ... so it is no longer byte-identical`) |
| drop the `?rig=` exclusion | `TestBeadListRigScopedReadExcludesGraphLeg` (`rig-scoped items include the graph bead`) |
| let the graph leg back into the all-or-nothing `Counter` gate | `TestBeadListSplitCityKeepsWorkLegsBounded` (`city leg max List limit = 0, want 6`) |
| drop the cross-leg `seen[b.ID]` gate | `TestBeadListDedupesBeadIDsAcrossLegs` (`items=2 total=2, want 1/1`) |
| federate the graph leg FIRST instead of last | `TestBeadListDedupesBeadIDsAcrossLegs` (`winning row = "relocated binding copy"`) and `TestBeadListGraphLeg503NamesWorkLegFailures` |
| revert the list 503 to degradation | `TestBeadListGraphLegHardFailIs503`, `TestBeadListGraphLegPartialIsAlso503` |
| revert the ready 503 to degradation | `TestBeadReadyGraphLegHardFailIs503`, `TestBeadReadyGraphLegPartialIsAlso503` |
| remove the ready leg | `TestBeadReadyFederatesGraphStore`, `TestBeadReadyFederationOrderIsLegConcatenation` |
| remove the list leg | `TestBeadListFederatesGraphStore` |

`TestBeadListLegacyCityUnchanged` names the *two* mechanisms that hold
duplicate-freedom on a legacy city (the identity guard and `sortedRigNames`'
store-identity dedup) so a future reader knows which one went red.

## Why this matters beyond the bug: CLI == API

The follow-on CLI federation (`gc ready`, `ga-oxsyu`) is blocked on this bead and
is specified **against this handler**, so its conformance test can assert
CLI == API instead of inventing an oracle. `humaHandleBeadReady`'s doc comment
now states the contract it has to match:

- **Legs, in order:** city store → rigs by name ascending → relocated graph store.
  The CLI composite's legs are work-then-infra, the same relative order.
- **Within a leg:** whatever order that leg's own `Ready` reader emits.
  Deterministic, but **not** canonical across leg kinds: a caching-wrapped work
  store emits `(priority, created_at, id)` via `sortBeadsReadyOrder`, while the
  canonical relocated graph binding (`beads.SQLiteStore`) emits
  `(created_at, id)` with no priority term at all (`sqliteReadySQL`).
- **Dedupe:** first leg to return an id wins.
- **Merged order:** leg concatenation, deliberately **not** re-sorted — a global
  re-sort would change the bytes a multi-rig single-store city already serves.
  Both sides therefore normalize with `beads.SortBeadsReadyOrder` before
  comparing — load-bearing precisely *because* the graph leg is not
  priority-ordered, and well-defined because that order is total.
- **Failure:** rigs degrade, the graph leg does not.

`TestBeadReadyFederationOrderIsLegConcatenation` pins the leg order so the
contract is executable, not just prose.

## Scope: the other set-returning handlers

`humaHandleBeadList` had the identical gap and is **in scope** — a half-federated
API is the failure mode this program keeps hitting, and the lifted Landmine #13
suite pins both handlers.

Audited every other `state.BeadStores()` fan-out. Three share the gap and are
deliberately **out of scope**:

- `statusWorkCounts` (`/v0/status`) — its comment claimed it federated ready work
  *"exactly like GET /beads/ready"*, which this PR would have made false. The
  comment now names the divergence and why closing it is its own slice: that read
  is cache-only and error-lenient by design (`cacheColdRigs`), the exact opposite
  of the graph leg's fail-loud contract.
- `humaHandleConvoyList` (`/v0/convoys`) — graph-relocated workflow convoys are
  invisible to the list even though `isGraphConvoyID` already probes the graph
  store by id.
- `findActiveBeadForAssignees` — an agent holding a claimed graph step shows no
  active bead.

## Notes

- Fixtures come from `internal/beads/splittest`, so the graph leg mints real
  `gcg-` ids and the work legs mint their own disjoint prefixes. Two exceptions:
  a leg whose read must *fail* wraps a plain leaf, because
  `splittest.StrictStore` implements `Handles()` and `beads.HandlesFor` would
  resolve straight past the failure injection; and a leg whose subject is the
  `beads.Counter` **type assertion** wraps a Counter-less leaf, because
  `StrictStore` declares `Counter` and the production class binding does not
  (recorded on `splittest.StrictStore.Count`).
- Counting the graph leg as a backend attempt has one deliberate consequence,
  pinned by `TestBeadReadyWorkStoresDownButGraphUpIsPartial200`: a split city
  whose work stores are all down but whose graph plane answered gets a Partial
  200 carrying the DAG, not `totalOutage`'s 503.
- **No wire change.** 503 was already in both ops' declared error set;
  `TestOpenAPISpecInSync` passes and the OpenAPI spec and generated dashboard
  types are untouched.
- `relocatedGraphStore` is the shared "is graph relocated?" predicate; new call
  sites should use it. `handler_convoys.go` and `handler_convoy_dispatch.go`
  still inline the same test — left alone to keep this a bug-fix diff.
- No conformance-suite KNOWN GAP becomes closable: I1/I2 (HQ work store leg), I5
  (`gc hook --claim`) and I10 (wake-filter class arm) are all cmd/gc controller
  paths, and the suite's SKIP list is still empty.

## Review follow-ups (three MAJOR + five minors, `e0d215b540`)

**M-A — the graph leg silently disabled bounded paging for the whole request.**
The leg was merged into the fan-out map *before* `sortedRigNames`, so it reached
`beadListBoundedTotal`, which is all-or-nothing. The canonical compiled-in
binding is a raw `*beads.SQLiteStore` with **no `Count` at all**, so one
Counter-less leg switched bounding off for **every** leg — every work store back
to hydrating full closed history on the dashboard's `?all=true` read, behind a
2s response cache. Worse, the comment added with the leg asserted the opposite,
and the `splittest` fixtures hid it because `StrictStore` declares
`beads.Counter`.

Fixed by planning bounding **per leg** rather than by giving `*SQLiteStore` a
`Count`: the defect is the veto, and a per-leg plan is robust to *any* binding
shape, where a new exact-count surface on `SQLiteStore` would fix today's
binding while leaving the veto for tomorrow's — and would trade a perf bug for
a wrong-`Total` correctness risk. Work legs keep the #3211 all-or-nothing
`Count`-fallback contract; the graph leg is bounded when it can `Count` and
hydrates alone when it cannot, its exact un-seeked total taken from the rows it
returned.

Differential, identical fixture, `GET ?type=molecule&all=true&limit=5`, work
legs `Counter`-capable, sole variable the graph leg:

| | city `Count` | city `List` `Limit` | rig `List` `Limit` | graph `List` `Limit` |
| --- | --- | --- | --- | --- |
| legacy, before **and** after | 1× | `[6]` | `[6]` | — |
| split, **before** (`c5a54c134d`) | 0× | `[0]` | `[0]` | `[0]` |
| split, **after** | 1× | `[6]` | `[6]` | `[0]` |

**M-B — the list fan-out had no cross-leg id dedupe.** `gc storage migrate`
preserves ids (`CreateWithForeignID`) and never deletes back, so a converged
migrated split city holds the same infrastructure bead in the work store *and*
the binding — convergence is *defined* as that overlap — and the list served it
twice with a doubled `total`. The append loop now applies the same
`seen[b.ID]` rule `humaHandleBeadReady` already had. **Winner: first leg wins,
graph leg last, so the work store's row is served** — identical on both
endpoints. The per-`(rig, assignee)` key it replaces was a strict subset of that
rule. Honest limit, documented on `resolveBeadListPage`: page and has-more are
exact (they come from the deduped rows), but a *counted* leg cannot see
co-residence, so the bounded `Total` can run high — never low.

**Minors taken:** the graph-leg 503 now carries the work-leg errors recorded
before it, so *"the graph plane is down"* and *"the whole city is down"* stop
being byte-identical; the synthetic `infra:<city>` key is **gone** (its
*"':' cannot appear in a rig name"* justification was unenforced, and a rig
carrying that name was silently overwritten and dropped from the response —
`TestBeadListRigNamedLikeTheGraphLegIsStillServed`); and the FEDERATION
CONTRACT's per-leg canonical-order claim is corrected above.

**Fixture fidelity was itself a finding**, so it is recorded where it bites:
`splittest.StrictStore.Count` now documents that every kit store type-asserts as
`beads.Counter` while the class binding implements no `Count`, and any fixture
whose subject is that assertion must use a Counter-less leaf. Separately, two
bead-list fixtures left both `MemStore`s on the default prefix, so two "rigs"
minted the same ids — a shape `config.ValidateRigs` rejects on every start,
reload and config-edit path. They are prefix-disjoint now.

## Gates

`go build ./...` · `go vet ./...` · `gofmt` · `golangci-lint run` **0 issues** ·
`go test ./internal/api/ ./internal/beads/...` · `go test ./cmd/gc -timeout 25m` (722s) ·
`scripts/check-core-boundary.sh` OK · `TestOpenAPISpecInSync` green and the
dashboard Go suites pass; nothing on the wire moved, so no regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

