### PR TITLE
fix(storage): create one-shot graph-class beads in the graph store (ga-xo8ch)

### DIFF
--- a/cmd/gc/class_store.go
+++ b/cmd/gc/class_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -313,6 +314,55 @@ func resolveSessionStore(routes *storageRoutes, workStore beads.Store, cfg *conf
 // parity with the other resolve*Store helpers and ignored here).
 func resolveGraphStore(routes *storageRoutes, workStore beads.Store, cfg *config.City, cityPath string, rec events.Recorder) beads.Store {
 	return resolveClassStore(routes, workStore, cfg, cityPath, config.BeadClassGraph, rec)
+}
+
+// moleculeClassStore returns the store a compiled recipe's molecule must be
+// materialized in: graphStore when the beads instantiating it produces are
+// graph class, and the caller's own scope/work store otherwise.
+//
+// The question is the CLASSIFIER'S, not the compiler's. Routing on "did this
+// formula use the v2 compiler" is wrong in both directions. A v1 formula that
+// is root-only — `phase = "vapor"`, or no [[steps]] at all — compiles to a root
+// carrying gc.kind=wisp (internal/formula/compile.go), and that is the first
+// arm coordclass.Classify tests, so the bead is ClassGraph and belongs in the
+// binding. A v1 POURED formula compiles to a molecule container whose every
+// bead is ClassWork, and work stays on the work ledger even in a split city —
+// relocating it hides the steps from every work-scope reader, `gc hook`
+// included.
+func moleculeClassStore(recipe *formula.Recipe, workStore, graphStore beads.Store) beads.Store {
+	if recipeCoordClass(recipe) == coordclass.ClassGraph {
+		return graphStore
+	}
+	return workStore
+}
+
+// recipeCoordClass returns the coordination class of the beads that
+// instantiating recipe produces.
+//
+// molecule.Instantiate materializes a recipe as one atomic plan, so the plan is
+// classified wholesale exactly as coordclass.ClassifyGraphPlan does: a single
+// graph-marked node makes the whole molecule graph class, which keeps its
+// intra-plan edges inside one store. Steps a RootOnly recipe never creates are
+// skipped, matching the instantiate loop's own `if recipe.RootOnly && i > 0`
+// break.
+func recipeCoordClass(recipe *formula.Recipe) coordclass.Class {
+	if recipe == nil {
+		return coordclass.ClassWork
+	}
+	for i, step := range recipe.Steps {
+		if recipe.RootOnly && i > 0 {
+			break
+		}
+		stepType := step.Type
+		if stepType == "" {
+			stepType = "task"
+		}
+		bead := beads.Bead{Type: stepType, Labels: step.Labels, Metadata: step.Metadata}
+		if coordclass.Classify(bead) == coordclass.ClassGraph {
+			return coordclass.ClassGraph
+		}
+	}
+	return coordclass.ClassWork
 }
 
 // graphClassBinding returns the store these routes serve the graph class from,

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -646,6 +646,20 @@ conflicting live workflow from the same source is an error.`,
 			if err != nil {
 				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
+			// A graph.v2 cook materializes a workflow root and its steps, and
+			// every one of those beads is GRAPH class (molecule.Instantiate
+			// stamps gc.root_bead_id on each member of a graph pour). On a city
+			// whose graph class is served by its own binding, creating them
+			// through the scope store mints them in the WORK ledger under the
+			// work prefix — the stranded-infrastructure-bead shape that is fatal
+			// to boot. The scope store still answers the work-class beads the
+			// cook touches: the synthetic input convoy and, on the --attach arms,
+			// the attach bead. resolveGraphStore returns the exact store value it
+			// was handed on every city that relocates nothing, so a single-store
+			// cook runs against the one store it always did.
+			//
+			// The --attach arms are excluded — see the deferral comment on each.
+			graphStore := resolveGraphStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)
 
 			cookVars := parseFormulaVars(vars)
 
@@ -655,6 +669,24 @@ conflicting live workflow from the same source is an error.`,
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("load formula %q: %w", args[0], err))
 				}
 				if isGraphFormula {
+					// NOT routed at the graph class, deliberately — the same
+					// deferral the legacy molecule.Attach arm below carries, for
+					// the same reason. A graft is a two-ended edge: the sub-DAG
+					// root is graph class, the attach bead is whatever class owns
+					// it, and ensureFormulaCookAttachDep writes a `blocks` row
+					// binding them. Move only the root and the work store records
+					// an edge naming an id it cannot resolve. No backend rejects
+					// that write (internal/beads/splittest documents both: bd
+					// passes a cross-prefix target through as an external ref,
+					// SQLite's deps table has no foreign key), and every Ready
+					// implementation treats an unresolvable blocker as open — so
+					// the caller's own work bead silently leaves Ready forever
+					// and the documented graft gate is void. Splitting it needs
+					// the attach bead's owning store resolved by id — the shared
+					// by-id class resolver, ga-k8pzw — plus a cross-boundary
+					// representation of the block, which is a production behavior
+					// change rather than wiring. Whole arm stays on the scope
+					// store until then, root and dep co-resident.
 					storeRef := workflowStoreRefForDir(scope.storeRoot, cityPath, loadedCityName(cfg, cityPath), cfg)
 					var result *molecule.Result
 					var syntheticInputConvoyID string
@@ -727,7 +759,7 @@ conflicting live workflow from the same source is an error.`,
 							}
 							return err
 						}
-						emitFormulaCookExecutionFacts(store, cityPath, result, stderr)
+						emitFormulaCookExecutionFacts(store, store, cityPath, result, stderr)
 						return ensureFormulaCookAttachDep(store, attach, result.RootID)
 					})
 					if err != nil {
@@ -776,6 +808,16 @@ conflicting live workflow from the same source is an error.`,
 					graphRootKey = stampFormulaCookGraphV2Root(recipe, args[0], inv.InputConvoy, cookVars)
 				}
 
+				// NOT routed at the graph class, deliberately. molecule.Attach is a
+				// one-store operation that reads the attach bead, materializes the
+				// sub-DAG and writes the blocking dep through the SAME store, and
+				// on a split city those are two classes: the attach bead is
+				// whatever class owns it, while every sub-DAG bead is graph (Attach
+				// stamps the parent's gc.root_bead_id onto each step). Answering
+				// that needs the attach bead's owning store resolved by id — the
+				// shared by-id class resolver, ga-k8pzw — and a two-store Attach,
+				// which is a production behavior change rather than wiring. Left on
+				// the scope store until then.
 				result, err := molecule.Attach(cmd.Context(), store, recipe, attach, molecule.AttachOptions{
 					Title:          title,
 					Vars:           cookVars,
@@ -823,6 +865,10 @@ conflicting live workflow from the same source is an error.`,
 			cookVars = inv.Vars
 
 			var result *molecule.Result
+			// rootStore is the store the cooked root ended up in, so the --meta
+			// stamp below lands on the bead it just created rather than on a
+			// store that has never held it.
+			rootStore := store
 			if isGraphFormula {
 				// Stamp the run root with its store/scope identity before
 				// instantiating, exactly as the --attach branch does via
@@ -838,15 +884,21 @@ conflicting live workflow from the same source is an error.`,
 				if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Title: title, Vars: cookVars}); err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
+				// One rule for both arms: the classifier picks the store, and it
+				// answers ClassGraph for every graph.v2 pour (the compiler stamps
+				// gc.kind=workflow on the root). The recipe is decorated through
+				// the store that will own it, so the root's identity metadata is
+				// written where the root lands.
+				rootStore = moleculeClassStore(recipe, store, graphStore)
 				graphRootKey := stampFormulaCookGraphV2Root(recipe, args[0], inv.InputConvoy, cookVars)
-				if err := decorateFormulaCookGraphV2Recipe(recipe, cookVars, storeRef, scope.rig, store, loadedCityName(cfg, cityPath), cityPath, cfg); err != nil {
+				if err := decorateFormulaCookGraphV2Recipe(recipe, cookVars, storeRef, scope.rig, rootStore, loadedCityName(cfg, cityPath), cityPath, cfg); err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("decorate formulas v2 recipe: %w", err))
 				}
 				if graphRootKey != "" {
 					unlock := graphv2.LockKey(graphRootKey)
 					defer unlock()
 				}
-				result, err = molecule.Instantiate(cmd.Context(), store, recipe, molecule.Options{
+				result, err = molecule.Instantiate(cmd.Context(), rootStore, recipe, molecule.Options{
 					Title:          title,
 					Vars:           cookVars,
 					IdempotencyKey: graphRootKey,
@@ -854,12 +906,27 @@ conflicting live workflow from the same source is an error.`,
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
-				emitFormulaCookExecutionFacts(store, cityPath, result, stderr)
+				emitFormulaCookExecutionFacts(rootStore, store, cityPath, result, stderr)
 			} else {
-				result, err = molecule.Cook(cmd.Context(), store, args[0], scope.searchPaths, molecule.Options{
-					Title: title,
-					Vars:  cookVars,
-				})
+				// The legacy compiler still emits a graph-class root for a
+				// root-only formula: `phase = "vapor"` (or no [[steps]]) compiles
+				// to a root stamped gc.kind=wisp, which is coordclass.Classify's
+				// first arm. Asking the classifier instead of asking which
+				// compiler ran is what keeps such a wisp out of the work ledger,
+				// where it would read as a stranded infrastructure bead and stop
+				// boot. A v1 POURED molecule classifies as work and stays exactly
+				// where it always was. This is molecule.Cook's body, inlined only
+				// so the store can be chosen from the compiled recipe.
+				opts := molecule.Options{Title: title, Vars: cookVars}
+				recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
+				if err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("compiling formula %q: %w", args[0], err))
+				}
+				if err := molecule.ValidateRecipeRuntimeVars(recipe, opts); err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+				}
+				rootStore = moleculeClassStore(recipe, store, graphStore)
+				result, err = molecule.Instantiate(cmd.Context(), rootStore, recipe, opts)
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
@@ -870,7 +937,7 @@ conflicting live workflow from the same source is an error.`,
 				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
 			if len(rootMeta) > 0 {
-				if err := store.SetMetadataBatch(result.RootID, rootMeta); err != nil {
+				if err := rootStore.SetMetadataBatch(result.RootID, rootMeta); err != nil {
 					err := fmt.Errorf("setting root metadata on %s: %w", result.RootID, err)
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
@@ -908,11 +975,16 @@ conflicting live workflow from the same source is an error.`,
 	return cmd
 }
 
-func emitFormulaCookExecutionFacts(store beads.Store, cityPath string, result *molecule.Result, stderr io.Writer) {
+// emitFormulaCookExecutionFacts projects the cooked run's execution facts from
+// the two stores that own them: the graph store holds the root and its steps,
+// the work store holds the tracks edges of the input convoy the root names.
+// Wrapping one store as both legs reads the convoy out of the ledger it does not
+// live in; on a city that relocates nothing the two arguments are the same value.
+func emitFormulaCookExecutionFacts(graphStore, workStore beads.Store, cityPath string, result *molecule.Result, stderr io.Writer) {
 	if result == nil || !result.GraphWorkflow {
 		return
 	}
-	if err := executionevent.EmitCurrent(openCityRecorderAt(cityPath, stderr), beads.GraphStore{Store: store}, beads.WorkStore{Store: store}, result.RootID, "formula-cook"); err != nil {
+	if err := executionevent.EmitCurrent(openCityRecorderAt(cityPath, stderr), beads.GraphStore{Store: graphStore}, beads.WorkStore{Store: workStore}, result.RootID, "formula-cook"); err != nil {
 		fmt.Fprintf(stderr, "warning: gc formula cook: projecting execution facts for %s: %v\n", result.RootID, err) //nolint:errcheck // successful cook is preserved
 	}
 }

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -830,25 +830,51 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 		}
 	}
 
-	if err := applyOrderRecipeRouting(recipe, pool, vars, storeTarget, genericStore, cityName, cityPath, cfg); err != nil {
+	// Everything from here on writes the molecule, so it goes to the store that
+	// owns the class the molecule's beads belong to rather than to the
+	// order/scope store the tracking bead lives in — the same split dispatchWisp
+	// takes through graphStoreFor. The class is the classifier's verdict on the
+	// compiled recipe, not the formula's compiler version: a graph.v2 pour and a
+	// root-only wisp are graph class and belong in the binding, while a v1
+	// POURED order formula compiles to a molecule container whose every bead is
+	// work class and must stay on the work ledger, which is the only place
+	// `gc hook` looks for the steps it assigns.
+	//
+	// A one-shot command builds no CityRuntime, so the routes come from the
+	// one-shot funnel; on a city that relocates nothing resolveGraphStore hands
+	// back the exact store value it was given, so this stays the single store
+	// `gc order run` always used, including the optional-capability assertions
+	// molecule.Instantiate makes against it.
+	graphStore := resolveGraphStore(cliStorageRoutes(cityPath), genericStore, cfg, cityPath, nil)
+	moleculeStore := moleculeClassStore(recipe, genericStore, graphStore)
+
+	if err := applyOrderRecipeRouting(recipe, pool, vars, storeTarget, moleculeStore, cityName, cityPath, cfg); err != nil {
 		fmt.Fprintf(stderr, "gc order run: routing decoration failed: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	cookResult, err := molecule.Instantiate(context.Background(), genericStore, recipe, molecule.Options{})
+	cookResult, err := molecule.Instantiate(context.Background(), moleculeStore, recipe, molecule.Options{})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	rootID := cookResult.RootID
 	if cookResult.GraphWorkflow {
-		if err := executionevent.EmitCurrent(ep, beads.GraphStore{Store: genericStore}, beads.WorkStore{Store: genericStore}, rootID, "order-run"); err != nil {
+		// Two classes, two stores: the molecule store owns the root and its
+		// steps, the scope store owns the tracks edges of any input convoy the
+		// root names. Wrapping one store as both legs reads the convoy out of the
+		// ledger it does not live in.
+		if err := executionevent.EmitCurrent(ep, beads.GraphStore{Store: moleculeStore}, beads.WorkStore{Store: genericStore}, rootID, "order-run"); err != nil {
 			fmt.Fprintf(stderr, "warning: gc order run: projecting execution facts for %s: %v\n", rootID, err) //nolint:errcheck // successful order run is preserved
 		}
 	}
 
 	// Track the spawned root in the same store that created it so manual runs
-	// stay provider-aware and do not fall back to ambient bd CLI state.
+	// stay provider-aware and do not fall back to ambient bd CLI state. The
+	// order-run / order: / seq: labels are the run's evidence and they have to
+	// ride the bead they describe, which is resident wherever the molecule was
+	// materialized. cachedOrderStoresResolver reads that binding back, so
+	// `gc order check` still finds this run.
 	update := beads.UpdateOpts{
 		Labels: []string{"order-run:" + scoped},
 	}
@@ -861,7 +887,7 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 	if a.Pool != "" {
 		update.Metadata = map[string]string{beadmeta.RoutedToMetadataKey: pool}
 	}
-	if err := store.Update(rootID, update); err != nil {
+	if err := moleculeStore.Update(rootID, update); err != nil {
 		fmt.Fprintf(stderr, "gc order run: labeling wisp: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/oneshot_class_routes_test.go
+++ b/cmd/gc/oneshot_class_routes_test.go
@@ -1,0 +1,839 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// This file is the one-shot half of the graph-class birth invariant that
+// order dispatch already holds (order_dispatch_graph_store_test.go, #5106).
+//
+// A one-shot command builds no CityRuntime, so it never sees the routes the
+// controller opened at boot; it opens one store for the scope it is working in
+// and, before this change, materialized the whole molecule through it. On a
+// city whose graph class is served by its own binding, that mints every wisp
+// root and every step in the WORK ledger under the WORK prefix, and the city's
+// own convergence check reads them as graph-class beads stranded off their
+// binding — which is fatal to boot. The measured rate on maintainer-city was
+// ~42 stranded beads an hour.
+//
+// The tests come in pairs. The split subtest is the regression: it fails if the
+// routing is reverted. The single-store subtest is the compatibility claim, and
+// it is green before and after by design — resolveGraphStore returns the exact
+// store value it was handed when the routes relocate nothing, so a compatibility
+// guard that went red on revert would be testing the wrong thing. Its teeth come
+// from mutation instead (documented on each such test).
+
+// enableFormulaV2ForOneShotTest turns on the graph.v2 compiler capability the way
+// a booting city does — through the sanctioned propagator, derived from a config
+// that declares [daemon] formula_v2, rather than through the legacy global
+// setters the freeze in internal/testenv is ratcheting down.
+func enableFormulaV2ForOneShotTest(t *testing.T) {
+	t.Helper()
+	applyFeatureFlags(&config.City{Daemon: config.DaemonConfig{FormulaV2: boolPtr(true)}})
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
+}
+
+// oneShotGraphOrderCity writes a city an actual `gc order run` can load config
+// for, plus a graph.v2 order whose single step routes to a city agent. It is the
+// CLI twin of newGraphOrderFixture: the order runs through doOrderRunWithJSON,
+// which loads the city config from disk rather than being handed one.
+func oneShotGraphOrderCity(t *testing.T, trigger string) (string, orders.Order) {
+	t.Helper()
+	cityPath := t.TempDir()
+	body := `[workspace]
+name = "one-shot-city"
+
+[daemon]
+formula_v2 = true
+
+[[agent]]
+name = "worker"
+max_active_sessions = 2
+` + testControlDispatcherAgentTOML("")
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	formulaDir := filepath.Join(cityPath, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "reaper.toml"), []byte(`
+formula = "reaper"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "sweep"
+title = "Reaper sweep"
+metadata = { "gc.run_target" = "worker" }
+`), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	enableFormulaV2ForOneShotTest(t)
+	return cityPath, orders.Order{
+		Name:         "reaper",
+		Formula:      "reaper",
+		Trigger:      trigger,
+		Interval:     "15m",
+		FormulaLayer: formulaDir,
+	}
+}
+
+// oneShotPouredOrderCity is oneShotGraphOrderCity's v1 twin: a city whose order
+// formula is a legacy POURED molecule. Its root is a molecule container and its
+// steps are plain assigned tasks — no gc.kind, no gc.root_bead_id — so
+// coordclass.Classify calls every one of them ClassWork, and work is the one
+// class a split city does not relocate.
+func oneShotPouredOrderCity(t *testing.T) (string, orders.Order) {
+	t.Helper()
+	cityPath := t.TempDir()
+	body := `[workspace]
+name = "one-shot-city"
+
+[daemon]
+formula_v2 = true
+
+[[agent]]
+name = "worker"
+max_active_sessions = 2
+` + testControlDispatcherAgentTOML("")
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	formulaDir := filepath.Join(cityPath, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "poured.toml"), []byte(`
+formula = "poured"
+version = 1
+pour = true
+
+[[steps]]
+id = "sweep"
+title = "Poured sweep"
+assignee = "worker"
+`), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	enableFormulaV2ForOneShotTest(t)
+	return cityPath, orders.Order{
+		Name:         "poured",
+		Formula:      "poured",
+		Trigger:      "cooldown",
+		Interval:     "15m",
+		FormulaLayer: formulaDir,
+	}
+}
+
+// runOneShotOrder fires `gc order run` against the given scope store and returns
+// the wisp id it reported.
+func runOneShotOrder(t *testing.T, cityPath string, a orders.Order, scope beads.Store, ep events.Provider) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunWithJSON([]orders.Order{a}, a.Name, a.Rig, cityPath, beads.OrdersStore{Store: scope}, ep, true, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc order run = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var res orderRunJSON
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("parse order run json %q: %v", stdout.String(), err)
+	}
+	if res.WispID == "" {
+		t.Fatalf("order run reported no wisp id: %s", stdout.String())
+	}
+	return res.WispID
+}
+
+// assertNoGraphBeads fails when store holds any bead a coordination-class split
+// assigns to the graph class. gc.kind and gc.root_bead_id are the two markers
+// coordclass.Classify reads for the workflow/wisp arms, so a molecule that
+// landed here is caught whether it is the root or one of its steps.
+func assertNoGraphBeads(t *testing.T, store beads.Store, storeName string) {
+	t.Helper()
+	for _, b := range allBeads(t, store) {
+		kind := b.Metadata[beadmeta.KindMetadataKey]
+		root := b.Metadata[beadmeta.RootBeadIDMetadataKey]
+		if kind == "" && root == "" {
+			continue
+		}
+		t.Errorf("%s store holds graph bead %s (%q, gc.kind=%q gc.root_bead_id=%q); on a split city that row is a stranded infrastructure bead and boot refuses on it", storeName, b.ID, b.Title, kind, root)
+	}
+}
+
+// TestOrderRunWispRootLandsInGraphStoreOnSplitCity is the producer half for the
+// manual run. `gc order run <formula-order>` materializes the same molecule the
+// controller's dispatchWisp does, and coordclass classifies a wisp root and its
+// steps as ClassGraph, so on a split city they belong in the graph binding. The
+// scope store the command opened is a work ledger; creating them there is the
+// stranded-bead shape #5106 fixed for the dispatcher and left open here.
+func TestOrderRunWispRootLandsInGraphStoreOnSplitCity(t *testing.T) {
+	cityPath, a := oneShotGraphOrderCity(t, "cooldown")
+	scope := splittest.NewWorkStore(t, "mc")
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graph))
+
+	wispID := runOneShotOrder(t, cityPath, a, scope, nil)
+
+	root, err := graph.Get(wispID)
+	if err != nil {
+		t.Fatalf("wisp root %s is not resident in the graph binding: %v", wispID, err)
+	}
+	if !strings.HasPrefix(root.ID, "gcg-") {
+		t.Errorf("wisp root id = %q, want the graph binding's %q prefix", root.ID, "gcg-")
+	}
+	if !hasLabel(root.Labels, "order-run:reaper") {
+		t.Errorf("wisp root labels = %v, want order-run:reaper stamped on the bead the run created", root.Labels)
+	}
+	if _, err := scope.Get(wispID); !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("wisp root %s resolves in the scope work store (err=%v); the run minted a graph bead in the work ledger", wispID, err)
+	}
+	assertNoGraphBeads(t, scope, "scope work")
+}
+
+// TestOrderRunWispStaysOnTheOneStoreOnSingleStoreCity is the compatibility half:
+// a city that authors no [storage] relocates nothing, so every bead the run
+// creates stays in the single store it always used and nothing else is opened.
+//
+// Green before and after by design — see the file header. Its teeth were proven
+// by mutation: making resolveGraphStore's identity branch hand back a fresh
+// store when the routes are nil fails this test with
+//
+//	wisp root gc-1 is not resident in the single store: bead not found
+func TestOrderRunWispStaysOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityPath, a := oneShotGraphOrderCity(t, "cooldown")
+	store := splittest.NewWorkStore(t, "gc")
+	seedCLIStorageRoutes(t, cityPath, nil)
+
+	wispID := runOneShotOrder(t, cityPath, a, store, nil)
+
+	root, err := store.Get(wispID)
+	if err != nil {
+		t.Fatalf("wisp root %s is not resident in the single store: %v", wispID, err)
+	}
+	if !hasLabel(root.Labels, "order-run:reaper") {
+		t.Errorf("wisp root labels = %v, want order-run:reaper", root.Labels)
+	}
+	tracking, err := store.ListByLabel(labelOrderTracking, 0, beads.IncludeClosed, beads.WithBothTiers)
+	if err != nil {
+		t.Fatalf("listing order-tracking beads: %v", err)
+	}
+	if len(tracking) != 1 {
+		t.Fatalf("order-tracking beads in the single store = %d, want 1", len(tracking))
+	}
+}
+
+// TestOrderRunGraphResidentRunIsVisibleToTheOrderReaders is the reader half, and
+// it is the check that stops this change from being a moved write with a reader
+// left behind.
+//
+// The run's evidence is a pair of beads carrying the same order-run:<scoped>
+// label: the ORDERS-class tracking bead whose CreatedAt is the cooldown clock,
+// and the GRAPH-class wisp root that also carries the order:<scoped> and seq:<n>
+// event-cursor labels. `gc order check` reads both through the front doors
+// cachedOrderStoresResolver builds, and that federation appends
+// relocatedOrdersClassStore. The only split shape this build serves puts every
+// infrastructure class on ONE binding, so that leg is also where the graph class
+// lives — which is why the readers still see a run whose root moved. This test
+// pins that agreement rather than asserting it in prose.
+func TestOrderRunGraphResidentRunIsVisibleToTheOrderReaders(t *testing.T) {
+	cityPath, a := oneShotGraphOrderCity(t, "event")
+	scope := splittest.NewWorkStore(t, "mc")
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graph))
+
+	ep := events.NewFake()
+	ep.Record(events.Event{Type: events.OrderCompleted, Actor: "test", Subject: "seed"})
+	wispID := runOneShotOrder(t, cityPath, a, scope, ep)
+
+	cfg, err := loadCityConfig(cityPath, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("load city config: %v", err)
+	}
+	ordersLeg := relocatedOrdersClassStore(cityPath, cfg)
+	if ordersLeg == nil {
+		t.Fatal("a split city resolved no orders-class leg for the one-shot order readers")
+	}
+	if _, err := ordersLeg.Get(wispID); err != nil {
+		t.Fatalf("the order readers' class leg cannot see the wisp root %s: %v — `gc order check` would report an order that just fired as never run", wispID, err)
+	}
+
+	front := orders.NewStoreWithGraph(beads.OrdersStore{Store: ordersLeg}, beads.GraphStore{Store: ordersLeg})
+	last, err := front.LastRun(a.ScopedName())
+	if err != nil {
+		t.Fatalf("LastRun(%s): %v", a.ScopedName(), err)
+	}
+	if last.IsZero() {
+		t.Errorf("LastRun(%s) is zero after a manual run; the cooldown clock cannot see the run's evidence", a.ScopedName())
+	}
+	if cursor := front.Cursor(a.ScopedName()); cursor == 0 {
+		t.Errorf("Cursor(%s) is zero after an event-triggered manual run; the seq: label rides the wisp root and the readers must reach it", a.ScopedName())
+	}
+}
+
+// oneShotCookCity writes a city `gc formula cook` can resolve, holding one
+// graph.v2 formula and one legacy (v1) formula, and puts the process in the
+// hermetic env the cook command needs. The env/cwd setup routes through
+// internal/formulatest so its t.Setenv/t.Chdir call sites stay off the cmd/gc
+// resource-census ratchet.
+func oneShotCookCity(t *testing.T) string {
+	t.Helper()
+	enableFormulaV2ForOneShotTest(t)
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(withBuiltinProviderAliasesTOMLForTest(`
+[workspace]
+name = "cook-city"
+provider = "claude"
+
+[daemon]
+formula_v2 = true
+`, "claude")+testControlDispatcherAgentTOML("")), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatalf("write graph.v2 formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "legacy-work.formula.toml"), []byte(`
+formula = "legacy-work"
+version = 1
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatalf("write legacy formula: %v", err)
+	}
+	// A v1 ROOT-ONLY formula: the legacy compiler stamps gc.kind=wisp on the
+	// root of any `phase = "vapor"` (or step-less) formula, which is
+	// coordclass.Classify's first arm. examples/bd/dolt/formulas/mol-dog-stale-db.toml
+	// is a shipped instance of this shape, and formula-spec-v1 documents it.
+	if err := os.WriteFile(filepath.Join(formulaDir, "vapor-work.formula.toml"), []byte(`
+formula = "vapor-work"
+version = 1
+phase = "vapor"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatalf("write vapor formula: %v", err)
+	}
+	formulatest.SetupHermeticCookEnv(t, cityDir, cityDir)
+	return cityDir
+}
+
+// cookFormula runs `gc formula cook <name> --json` and returns the result.
+// extraArgs are appended after the formula name, so a caller can drive the
+// --attach and --meta arms through the same real cobra command.
+func cookFormula(t *testing.T, name string, extraArgs ...string) formulaCookJSONResult {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs(append([]string{name, "--json"}, extraArgs...))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc formula cook %s: %v\nstdout=%s\nstderr=%s", name, err, stdout.String(), stderr.String())
+	}
+	var res formulaCookJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("parse cook json %q: %v", stdout.String(), err)
+	}
+	return res
+}
+
+// TestFormulaCookGraphV2RootLandsInGraphStoreOnSplitCity is the producer half
+// for `gc formula cook`. A graph.v2 pour is graph class end to end —
+// molecule.Instantiate stamps gc.root_bead_id on every member — so on a split
+// city the root and its steps belong in the binding, not in the scope store the
+// command opened for the formula's scope.
+func TestFormulaCookGraphV2RootLandsInGraphStoreOnSplitCity(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+
+	res := cookFormula(t, "graph-work")
+
+	root, err := graph.Get(res.RootID)
+	if err != nil {
+		t.Fatalf("cooked root %s is not resident in the graph binding: %v", res.RootID, err)
+	}
+	if !strings.HasPrefix(root.ID, "gcg-") {
+		t.Errorf("cooked root id = %q, want the graph binding's %q prefix", root.ID, "gcg-")
+	}
+	if got := root.Metadata[beadmeta.RootStoreRefMetadataKey]; got != "city:cook-city" {
+		t.Errorf("cooked root %s: gc.root_store_ref = %q, want %q — the recipe must be decorated through the store that will own it", res.RootID, got, "city:cook-city")
+	}
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	if _, err := work.Get(res.RootID); err == nil {
+		t.Errorf("cooked root %s resolves in the WORK store; the pour minted graph beads in the work ledger", res.RootID)
+	}
+	assertNoGraphBeads(t, work, "work")
+}
+
+// TestFormulaCookLegacyMoleculeStaysOnTheWorkStore is the boundary this change
+// deliberately does not cross. A v1 molecule is NOT graph class: Instantiate
+// stamps gc.root_bead_id only on a graph pour and on gc.kind steps, so
+// coordclass.Classify leaves a legacy molecule on ClassWork — and work stays on
+// the work ledger even in a split city. Routing it at the graph binding would
+// relocate a class the split does not relocate.
+func TestFormulaCookLegacyMoleculeStaysOnTheWorkStore(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+
+	res := cookFormula(t, "legacy-work")
+
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	if _, err := work.Get(res.RootID); err != nil {
+		t.Fatalf("legacy molecule root %s is not resident in the work store: %v", res.RootID, err)
+	}
+	if got := allBeads(t, graph); len(got) != 0 {
+		t.Errorf("graph binding holds %d beads after a legacy cook, want 0 — a work-class molecule was relocated: %+v", len(got), got)
+	}
+	// The negative has to be two-sided. Asserting only that the binding is
+	// empty stays true while the work store quietly holds a graph-class bead,
+	// which is the stranded row boot refuses on.
+	assertNoGraphBeads(t, work, "work")
+}
+
+// TestFormulaCookGraphV2StaysOnTheOneStoreOnSingleStoreCity is the
+// compatibility half for the cook path: a city that relocates nothing cooks
+// into the one store it always did.
+//
+// Green before and after by design — see the file header. Its teeth were proven
+// by mutation: making resolveGraphStore's identity branch hand back a fresh
+// store when the routes are nil fails this test with
+//
+//	cooked root gc-1 is not resident in the single store: no issue found: gc-1
+func TestFormulaCookGraphV2StaysOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	seedCLIStorageRoutes(t, cityDir, nil)
+
+	res := cookFormula(t, "graph-work")
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	root, err := store.Get(res.RootID)
+	if err != nil {
+		t.Fatalf("cooked root %s is not resident in the single store: %v", res.RootID, err)
+	}
+	if got := root.Metadata[beadmeta.RootStoreRefMetadataKey]; got != "city:cook-city" {
+		t.Errorf("cooked root %s: gc.root_store_ref = %q, want %q", res.RootID, got, "city:cook-city")
+	}
+	recorded, err := events.ReadAll(filepath.Join(cityDir, ".gc", "events.jsonl"))
+	if err != nil {
+		t.Fatalf("read execution events: %v", err)
+	}
+	if len(recorded) == 0 || recorded[0].RunID != res.RootID {
+		t.Fatalf("execution events = %#v, want the initial step-definition snapshot for %s", recorded, res.RootID)
+	}
+}
+
+// closeEveryBeadExcept closes every bead the store holds apart from keep. It
+// models "the whole workflow ran to completion", which is the state the
+// --attach contract promises will unblock the source bead.
+func closeEveryBeadExcept(t *testing.T, store beads.Store, keep string) {
+	t.Helper()
+	closed := "closed"
+	for _, b := range allBeads(t, store) {
+		if b.ID == keep || b.Status == "closed" {
+			continue
+		}
+		if err := store.Update(b.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+			t.Fatalf("closing bead %s: %v", b.ID, err)
+		}
+	}
+}
+
+// TestFormulaCookAttachLeavesTheSourceBeadUnblockableOnSplitCity is the
+// assertion the --attach arm never had, and the one that catches a half-split
+// attach.
+//
+// `gc formula cook --attach` is documented as a graft: "the bead gains a
+// blocking dependency on the sub-DAG root, so it won't close until the sub-DAG
+// completes". A dep is a two-ended edge. If the sub-DAG root is created in the
+// graph binding while the blocking dep is written through the work store, the
+// work store holds a `blocks` row naming an id it can never resolve — and
+// MemStore/FileStore/SQLite all treat an unresolvable blocker as open
+// (readyLocked: statusByID[dep.DependsOnID] != "closed"), so the source bead
+// leaves Ready permanently. Neither production backend rejects that write
+// (internal/beads/splittest/strict_store.go's backend table), so the only thing
+// that can catch it is this test.
+func TestFormulaCookAttachLeavesTheSourceBeadUnblockableOnSplitCity(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create attach bead: %v", err)
+	}
+
+	res := cookFormula(t, "graph-work", "--attach", source.ID)
+
+	deps, err := work.DepList(source.ID, "down")
+	if err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatalf("attach bead %s has no blocking dep after cook; the graft was never wired", source.ID)
+	}
+	for _, dep := range deps {
+		if _, err := work.Get(dep.DependsOnID); err != nil {
+			t.Errorf("work store holds dep %s -> %s (%s) whose target it cannot resolve: %v — a dangling cross-store blocking edge no backend rejects and no finalize path removes", dep.IssueID, dep.DependsOnID, dep.Type, err)
+		}
+	}
+
+	closeEveryBeadExcept(t, graph, source.ID)
+	closeEveryBeadExcept(t, work, source.ID)
+
+	ready, err := work.Ready()
+	if err != nil {
+		t.Fatalf("work Ready(): %v", err)
+	}
+	if !slices.Contains(beadIDs(ready), source.ID) {
+		t.Fatalf("attach bead %s is not Ready after the whole workflow closed (ready=%v, root=%s); the --attach contract says the graft unblocks it, so it is wedged out of Ready forever", source.ID, beadIDs(ready), res.RootID)
+	}
+}
+
+// TestFormulaCookRootOnlyLegacyWispLandsInGraphStoreOnSplitCity is the class
+// verdict re-derived from the classifier rather than from the compiler version.
+//
+// "v1 means work class" is false for a root-only formula. internal/formula
+// compiles `phase = "vapor"` (and any step-less formula) to `RootOnly` with the
+// root stamped gc.kind=wisp, and gc.kind=wisp is coordclass.Classify's FIRST
+// arm — reached long before gc.root_bead_id is consulted. Cooked into the work
+// ledger on a split city, that single bead is exactly the row readInfraSnapshot
+// selects as a graph-class bead residing outside its binding, and boot refuses
+// on it.
+func TestFormulaCookRootOnlyLegacyWispLandsInGraphStoreOnSplitCity(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+
+	res := cookFormula(t, "vapor-work")
+
+	root, err := graph.Get(res.RootID)
+	if err != nil {
+		t.Fatalf("root-only wisp %s is not resident in the graph binding: %v", res.RootID, err)
+	}
+	if got := root.Metadata[beadmeta.KindMetadataKey]; got != beadmeta.KindWisp {
+		t.Fatalf("cooked root %s: gc.kind = %q, want %q — the fixture must actually be the root-only shape", res.RootID, got, beadmeta.KindWisp)
+	}
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	assertNoGraphBeads(t, work, "work")
+}
+
+// TestFormulaCookRootOnlyLegacyWispStaysOnTheOneStoreOnSingleStoreCity is the
+// compatibility half: a city that relocates nothing cooks the same wisp into
+// the one store it always used.
+//
+// Green before and after by design — see the file header.
+func TestFormulaCookRootOnlyLegacyWispStaysOnTheOneStoreOnSingleStoreCity(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	seedCLIStorageRoutes(t, cityDir, nil)
+
+	res := cookFormula(t, "vapor-work")
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if _, err := store.Get(res.RootID); err != nil {
+		t.Fatalf("root-only wisp %s is not resident in the single store: %v", res.RootID, err)
+	}
+}
+
+// TestFormulaCookMetaStampLandsOnTheGraphResidentRoot pins the --meta arm's
+// store. SetMetadataBatch is a by-id write; addressed at the scope store while
+// the root lives in the binding, it fails the cook after the workflow is
+// already materialized.
+func TestFormulaCookMetaStampLandsOnTheGraphResidentRoot(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+
+	res := cookFormula(t, "graph-work", "--meta", "gc.trace=abc123")
+
+	root, err := graph.Get(res.RootID)
+	if err != nil {
+		t.Fatalf("cooked root %s is not resident in the graph binding: %v", res.RootID, err)
+	}
+	if got := root.Metadata["gc.trace"]; got != "abc123" {
+		t.Errorf("cooked root %s: gc.trace = %q, want %q — the --meta stamp went to a store that never held the root", res.RootID, got, "abc123")
+	}
+}
+
+// TestFormulaCookAttachIsIdempotentOnSplitCity drives the `existing != nil`
+// early return, the one attach path that returns without instantiating. A
+// convoy target gives the invocation a stable input-convoy id and therefore a
+// stable graph root key, so a repeat cook must adopt the live workflow instead
+// of minting a second one — and must not add a second blocking edge. The lookup
+// that decides this reads the store, so it is a residence assertion: point it at
+// a ledger the root is not in and every re-cook duplicates the workflow.
+func TestFormulaCookAttachIsIdempotentOnSplitCity(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	source, err := work.Create(beads.Bead{Title: "attach target", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create attach bead: %v", err)
+	}
+
+	first := cookFormula(t, "graph-work", "--attach", source.ID)
+	second := cookFormula(t, "graph-work", "--attach", source.ID)
+
+	if first.RootID != second.RootID {
+		t.Fatalf("re-cook minted a second workflow root (%s then %s); the idempotent lookup read a store that does not hold the root", first.RootID, second.RootID)
+	}
+	deps, err := work.DepList(source.ID, "down")
+	if err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	}
+	blocking := 0
+	for _, dep := range deps {
+		if dep.Type == "blocks" {
+			blocking++
+		}
+	}
+	if blocking != 1 {
+		t.Errorf("attach bead %s carries %d blocking deps after two cooks, want 1: %+v", source.ID, blocking, deps)
+	}
+}
+
+// TestOrderRunPouredV1MoleculeStaysOnTheWorkStoreOnSplitCity is the mirror of
+// the wisp test, and the other half of the class verdict.
+//
+// `gc order run` must route on what the classifier says about the compiled
+// recipe, not on "an order molecule is graph class". A v1 poured order formula
+// compiles to a molecule container and plain assigned task steps: every bead is
+// ClassWork, and the routes never relocate work. Minting them in the graph
+// binding puts the step assigned to `worker` somewhere no work-scope reader
+// scans — `gc hook` resolves GC_STORE_SCOPE=city against the city WORK root — so
+// the run silently produces work nobody executes.
+func TestOrderRunPouredV1MoleculeStaysOnTheWorkStoreOnSplitCity(t *testing.T) {
+	cityPath, a := oneShotPouredOrderCity(t)
+	scope := splittest.NewWorkStore(t, "mc")
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graph))
+
+	rootID := runOneShotOrder(t, cityPath, a, scope, nil)
+
+	root, err := scope.Get(rootID)
+	if err != nil {
+		t.Fatalf("poured molecule root %s is not resident in the scope work store: %v", rootID, err)
+	}
+	if !hasLabel(root.Labels, "order-run:poured") {
+		t.Errorf("root labels = %v, want order-run:poured stamped on the bead the run created", root.Labels)
+	}
+	var assigned []string
+	for _, b := range allBeads(t, scope) {
+		if b.Assignee != "" {
+			assigned = append(assigned, b.ID)
+		}
+	}
+	if len(assigned) == 0 {
+		t.Errorf("no assigned step landed in the work store; `gc hook` reads the work scope and would find nothing to run")
+	}
+	// The binding legitimately holds the ORDERS-class tracking bead (this build
+	// serves every infrastructure class from one binding), so the assertion is
+	// about the molecule: nothing the cook materialized may be in there.
+	for _, b := range allBeads(t, graph) {
+		if hasLabel(b.Labels, labelOrderTracking) {
+			continue
+		}
+		t.Errorf("graph binding holds molecule bead %s (%q) after a v1 poured order run — a work-class molecule was relocated into a binding no work-scope reader scans", b.ID, b.Title)
+	}
+	assertNoGraphBeads(t, scope, "scope work")
+}
+
+// TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg pins the two
+// legs of the cook's execution-fact projection.
+//
+// executionevent.ProjectCurrent reads the root and its steps from the GRAPH
+// leg and the input convoy's `tracks` edges from the WORK leg, and the convoy
+// is work class (coordclass routes synthetic convoys to ClassWork explicitly).
+// Wrapping one store as both legs therefore reads the convoy out of the ledger
+// it does not live in, and the run's work associations vanish from the event
+// stream while the step facts still look right.
+//
+// It is asserted on the helper rather than through the cobra command because no
+// one-shot cook can reach the two-leg state today: PrepareInvocation only mints
+// an input convoy for a targeted invocation, and the --attach arms — the only
+// targeted ones — run wholly on the scope store (see the deferral comment in
+// cmd_formula.go). The helper is where the leg assignment lives, so it is where
+// a collapse is catchable.
+func TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg(t *testing.T) {
+	cityPath := t.TempDir()
+	graph := splittest.NewClassStore(t, config.BeadClassGraph)
+	work := splittest.NewWorkStore(t, "mc")
+
+	convoy, err := work.Create(beads.Bead{Title: "input convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create convoy: %v", err)
+	}
+	item, err := work.Create(beads.Bead{Title: "tracked work", Type: "task"})
+	if err != nil {
+		t.Fatalf("create tracked work: %v", err)
+	}
+	if err := work.DepAdd(convoy.ID, item.ID, convoycore.TrackingDepType); err != nil {
+		t.Fatalf("track %s in %s: %v", item.ID, convoy.ID, err)
+	}
+	root, err := graph.Create(beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+			beadmeta.InputConvoyIDMetadataKey:   convoy.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	if _, err := graph.Create(beads.Bead{
+		Title: "step",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+			beadmeta.StepRefMetadataKey:    "graph-work.step",
+		},
+	}); err != nil {
+		t.Fatalf("create step: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	emitFormulaCookExecutionFacts(graph, work, cityPath, &molecule.Result{RootID: root.ID, GraphWorkflow: true}, &stderr)
+
+	recorded, err := events.ReadAll(filepath.Join(cityPath, ".gc", "events.jsonl"))
+	if err != nil {
+		t.Fatalf("read execution events: %v", err)
+	}
+	associated := false
+	for _, e := range recorded {
+		if e.Type == events.ExecutionWorkAssociated && e.RunID == root.ID && e.Subject == item.ID {
+			associated = true
+		}
+	}
+	if !associated {
+		t.Fatalf("no execution.work_associated fact for %s in run %s (events=%+v, stderr=%s); the convoy leg read a ledger the convoy does not live in", item.ID, root.ID, recorded, stderr.String())
+	}
+}
+
+// TestRecipeCoordClassRederivesTheVerdictFromTheClassifier is the unit-level
+// statement of the rule both one-shot paths now route on: the store follows
+// coordclass.Classify's verdict on the compiled recipe, never the formula's
+// compiler version. The three rows are the three shapes the compiler emits, and
+// the middle one is the shape a version-based gate gets wrong.
+func TestRecipeCoordClassRederivesTheVerdictFromTheClassifier(t *testing.T) {
+	rootOnly := func(kind string) *formula.Recipe {
+		return &formula.Recipe{
+			RootOnly: true,
+			Steps: []formula.RecipeStep{
+				{ID: "root", Type: "task", IsRoot: true, Metadata: map[string]string{beadmeta.KindMetadataKey: kind}},
+				// A step RootOnly never creates. It must not vote.
+				{ID: "root.step", Type: "task", Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow}},
+			},
+		}
+	}
+	for _, tc := range []struct {
+		name   string
+		recipe *formula.Recipe
+		want   coordclass.Class
+	}{
+		{
+			name: "graph.v2 pour is graph class",
+			recipe: &formula.Recipe{Steps: []formula.RecipeStep{
+				{ID: "root", Type: "task", IsRoot: true, Metadata: map[string]string{
+					beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+					beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+				}},
+				{ID: "root.step", Type: "task"},
+			}},
+			want: coordclass.ClassGraph,
+		},
+		{
+			name:   "v1 root-only wisp is graph class",
+			recipe: rootOnly(beadmeta.KindWisp),
+			want:   coordclass.ClassGraph,
+		},
+		{
+			name: "v1 poured molecule is work class",
+			recipe: &formula.Recipe{Steps: []formula.RecipeStep{
+				{ID: "root", Type: "molecule", IsRoot: true, Metadata: map[string]string{beadmeta.FormulaNameMetadataKey: "poured"}},
+				{ID: "root.step", Type: "task", Assignee: "worker", Metadata: map[string]string{beadmeta.StepRefMetadataKey: "poured.sweep"}},
+			}},
+			want: coordclass.ClassWork,
+		},
+		{
+			name:   "an unmarked root-only recipe is work class and its skipped steps do not vote",
+			recipe: rootOnly(""),
+			want:   coordclass.ClassWork,
+		},
+		{name: "nil recipe is work class", recipe: nil, want: coordclass.ClassWork},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := recipeCoordClass(tc.recipe); got != tc.want {
+				t.Fatalf("recipeCoordClass = %v, want %v", got, tc.want)
+			}
+			work, graph := beads.NewMemStore(), beads.NewMemStore()
+			wantStore := beads.Store(work)
+			if tc.want == coordclass.ClassGraph {
+				wantStore = graph
+			}
+			if got := moleculeClassStore(tc.recipe, work, graph); got != wantStore {
+				t.Fatalf("moleculeClassStore picked the wrong store for a %v recipe", tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1744,6 +1744,23 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	// Everything from here on writes the molecule, which is graph class, so it
 	// goes to the graph store rather than the order-class store the tracking
 	// bead lives in. On a single-store city the two are the same value.
+	//
+	// KNOWN GAP, deliberately not closed here (ga-fk1a5). "Graph class" is true
+	// of a graph.v2 pour and a root-only wisp but NOT of a v1 POURED order
+	// formula, whose molecule container and assigned task steps are all
+	// ClassWork by coordclass.Classify — relocating those hides the assigned
+	// steps from `gc hook`, which reads the work scope. The CLI twin
+	// (doOrderRunWithJSON) gates this on moleculeClassStore and is correct.
+	// The dispatcher cannot simply follow, because this root is a TWO-CLASS
+	// object: it also carries the order:/seq: event-cursor labels, and
+	// orders.Store unions order-run evidence across the ORDERS and GRAPH legs
+	// only. Route the molecule by class and an event-triggered v1 poured order
+	// loses its cursor and re-fires; leave it and its steps stay unreachable.
+	// Closing it means persisting the cursor onto the orders-class tracking
+	// bead the way the exec arm already does (front.SetCursor at the exec
+	// branch above) — a production behavior change rather than wiring, so it is
+	// its own slice. TestOrderDispatchPouredV1MoleculeRelocatesWithTheGraphClass
+	// pins the current answer so that slice has a test to flip.
 	graphStore := m.graphStoreFor(store)
 
 	// Route before instantiation. A routing failure must not leave an

--- a/cmd/gc/order_dispatch_graph_store_test.go
+++ b/cmd/gc/order_dispatch_graph_store_test.go
@@ -750,3 +750,107 @@ func TestOrderTrackingSweepResolverPairsTheWispStoreWithTheTrackingStores(t *tes
 		}
 	})
 }
+
+// newPouredOrderFixture is newGraphOrderFixture's v1 twin: an order whose
+// formula is a legacy POURED molecule. Its root is a molecule container and its
+// steps are plain assigned tasks — no gc.kind, no gc.root_bead_id — so
+// coordclass.Classify calls every bead it materializes ClassWork.
+func newPouredOrderFixture(t *testing.T) (string, *config.City, orders.Order) {
+	t.Helper()
+	cityPath := t.TempDir()
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "poured.toml"), []byte(`
+formula = "poured"
+version = 1
+pour = true
+
+[[steps]]
+id = "sweep"
+title = "Poured sweep"
+assignee = "worker"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	maxOne, maxTwo := 1, 2
+	cfg := &config.City{
+		Daemon:    config.DaemonConfig{FormulaV2: boolPtr(true)},
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker", MaxActiveSessions: &maxTwo},
+			{Name: config.ControlDispatcherAgentName, MaxActiveSessions: &maxOne},
+		},
+	}
+	applyFeatureFlags(cfg)
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
+	a := orders.Order{
+		Name:         "poured",
+		Formula:      "poured",
+		Trigger:      "cooldown",
+		Interval:     "15m",
+		FormulaLayer: formulaDir,
+	}
+	return cityPath, cfg, a
+}
+
+// TestOrderDispatchPouredV1MoleculeRelocatesWithTheGraphClass pins a KNOWN GAP
+// rather than a desirable behavior — ga-fk1a5.
+//
+// dispatchWisp sends every order molecule to the graph binding. That is right
+// for a graph.v2 pour and a root-only wisp, but a v1 POURED order formula
+// compiles to a molecule container plus plain assigned task steps, and
+// coordclass.Classify calls all of them ClassWork. Relocated, the step assigned
+// to `worker` sits in a binding `gc hook` never scans, so the dispatch produces
+// work nobody can pick up. The CLI twin (doOrderRunWithJSON) is gated on
+// moleculeClassStore and is correct; the dispatcher is not, because this root is
+// a TWO-CLASS object: it also carries the order:/seq: event-cursor labels, and
+// orders.Store unions order-run evidence across the ORDERS and GRAPH legs only.
+// Routing by class alone would fix the steps and lose the cursor. Closing it
+// means moving the cursor onto the orders-class tracking bead first.
+//
+// When ga-fk1a5 lands, this test flips: the molecule moves to workStore and the
+// assertions become the ones its CLI twin already makes
+// (TestOrderRunPouredV1MoleculeStaysOnTheWorkStoreOnSplitCity).
+func TestOrderDispatchPouredV1MoleculeRelocatesWithTheGraphClass(t *testing.T) {
+	cityPath, cfg, a := newPouredOrderFixture(t)
+	workStore := beads.NewMemStore()
+	workStore.IDPrefix = "mc"
+	graphStore := beads.NewMemStore()
+	graphStore.IDPrefix = "gcg"
+
+	var rec memRecorder
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:                   []orders.Order{a},
+		storeFn:              func(execStoreTarget) (beads.Store, error) { return workStore, nil },
+		storageRoutes:        messagingSplitRoutes(graphStore),
+		cfg:                  cfg,
+		cityName:             "test-city",
+		cityPath:             cityPath,
+		rec:                  &rec,
+		stderr:               io.Discard,
+		maxDispatchesPerTick: 1,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       cancel,
+	}
+	dispatchGraphOrder(t, m, cityPath)
+
+	if rec.hasType(events.OrderFailed) || !rec.hasType(events.OrderCompleted) {
+		t.Fatalf("events = %+v, want completed without failure", rec.events)
+	}
+	assigned := false
+	for _, b := range allBeads(t, graphStore) {
+		if b.Assignee == "worker" {
+			assigned = true
+		}
+	}
+	if !assigned {
+		t.Fatalf("no step assigned to `worker` in the graph binding; if it moved to the work store, ga-fk1a5 has landed — flip this test to the assertions its CLI twin makes")
+	}
+	for _, b := range allBeads(t, workStore) {
+		if b.Assignee == "worker" {
+			t.Fatalf("a work-class order step reached the work store; ga-fk1a5 has landed — flip this test")
+		}
+	}
+	t.Logf("KNOWN GAP (ga-fk1a5): a v1 poured order molecule is materialized in the graph binding, where `gc hook`'s work-scope query cannot see its assigned steps")
+}

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -413,9 +413,12 @@ func conformanceMaterializationResidence(t *testing.T, e splitEnv) {
 // still runs against a ledger that cannot see the bead. claimByID's own
 // fallback IS that fan-out, so the rows below state both answers side by side:
 // a class id routes, a work id keeps the legacy path byte-for-byte. Rewiring
-// the command is ga-xo8ch (class-routed writes from one-shot commands); when it
+// the command is ga-k8pzw (by-id routing through the shared resolver); when it
 // lands, this paragraph goes and the assertions move from claimByID to the
-// command.
+// command. ga-xo8ch — class-routed WRITES from one-shot commands — landed
+// without touching it: it routes where a coordination-class bead is BORN
+// (`gc order run`'s wisp, `gc formula cook`'s graph pour), and a claim is a
+// by-id mutation of a bead that already exists somewhere.
 //
 // The gap is ASSERTED and not merely described, the way I1, I2 and I10 assert
 // theirs: hookQueryEnv is the production seam that decides which store the
@@ -448,7 +451,7 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 		t.Fatalf("build the hook's work-query env: %v", err)
 	}
 	if got := hookEnv["GC_STORE_SCOPE"]; got != "city" {
-		t.Errorf("`gc hook --claim` resolves store scope %q, want \"city\" — if it now names a coordination class, the ga-xo8ch rewire has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", got)
+		t.Errorf("`gc hook --claim` resolves store scope %q, want \"city\" — if it now names a coordination class, the ga-k8pzw rewire has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", got)
 	}
 	if got := hookEnv["GC_STORE_ROOT"]; got != e.cityPath {
 		t.Errorf("`gc hook --claim` resolves store root %q, want the city work root %q — a claim it issues for a relocated class id runs against the work ledger, and that is the gap this row pins", got, e.cityPath)


### PR DESCRIPTION
## Problem

`gc order run` and `gc formula cook` open **one** store — the one for the
scope they are working in — and materialize the whole molecule through it.
On a city whose graph class is served by its own storage binding, every
wisp root, every workflow root and every step they create is therefore
**born in the WORK ledger, minted under the WORK prefix.**

`internal/coordclass` classifies those beads as `ClassGraph`. The city's own
convergence check reads them as graph-class beads residing outside their
binding and reports them **stranded** — and stranded is **fatal to boot**.

#5106 fixed it for controller-driven order dispatch and explicitly listed
the remaining sites: *"Remaining graph-class births — convergence tick,
`cmd_formula`, control dispatch."* Control dispatch landed in #5108. This
PR is the one-shot CLI half.

## The rule: the store follows the CLASSIFIER, not the compiler version

`moleculeClassStore(recipe, workStore, graphStore)` (`cmd/gc/class_store.go`)
classifies the compiled recipe the way `coordclass.ClassifyGraphPlan`
classifies a plan — a molecule is materialized as one atomic plan, so one
graph-marked node makes the whole molecule graph class — and both one-shot
paths route on its verdict.

Asking *"did this formula use the v2 compiler"* is wrong **in both
directions**, and an earlier revision of this PR was wrong in both:

| shape | compiler | `coordclass.Classify` | store |
|---|---|---|---|
| graph.v2 pour (root `gc.kind=workflow`) | v2 | `ClassGraph` | graph binding |
| **root-only wisp** (`phase = "vapor"`, or no `[[steps]]`) | **v1** | **`ClassGraph`** (`gc.kind=wisp` is Classify's FIRST arm) | **graph binding** |
| **poured molecule** (container root + assigned task steps) | **v1** | **`ClassWork`** | **work ledger** |

The root-only row is a shipped, documented shape
(`docs/reference/specs/formula-spec-v1.md` "Root-only wisps";
`examples/bd/dolt/formulas/mol-dog-stale-db.toml`). `internal/formula/compile.go`
sets `rootOnly := (!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0` and
stamps `gc.kind=wisp` on that root, and `coordclass.Classify` reaches the wisp
arm before `gc.root_bead_id` is ever consulted. Cooked into the work ledger it
is exactly the row `readInfraSnapshot` selects as stranded.

The poured row is the mirror error: relocating a work-class molecule hides the
step assigned to an agent from every work-scope reader — `gc hook` resolves
`GC_STORE_SCOPE=city` against the city WORK root, asserted by this PR's own
`conformanceClaimRouting` row.

## What moved

### `gc order run` (formula arm) — `cmd/gc/cmd_order.go`

| write | before | after |
|---|---|---|
| `applyOrderRecipeRouting` | scope store | the store the recipe's class names |
| `molecule.Instantiate` (root + steps) | scope store | ⤷ same |
| root label stamp (`order-run:`, `order:`, `seq:`) | scope store | ⤷ same (evidence rides the bead it describes) |
| `EmitCurrent` graph leg | scope store | ⤷ same (work leg stays the scope store) |

The order-tracking bead is untouched: `orderTrackingFrontDoor` already put
it on the ORDERS class (#5127).

### `gc formula cook` (standalone arm, both compilers) — `cmd/gc/cmd_formula.go`

| write / read | before | after |
|---|---|---|
| `decorateFormulaCookGraphV2Recipe` | scope store | the store the recipe's class names |
| `molecule.Instantiate` (graph.v2 arm) | scope store | ⤷ same |
| legacy `molecule.Cook` | scope store | ⤷ same (inlined as compile + validate + Instantiate so the store can be chosen from the recipe; the compile-error wrapping is `molecule.Cook`'s, verbatim) |
| `--meta` root `SetMetadataBatch` | scope store | the store that created the root |
| `emitFormulaCookExecutionFacts` | one store as **both** legs | graph leg + work leg |

## Deliberately NOT routed

**Not graph class.** The synthetic input convoy `graphv2.PrepareInvocation`
mints (`coordclass` routes synthetic convoys to `ClassWork` explicitly), and a
v1 **poured** molecule. `TestFormulaCookLegacyMoleculeStaysOnTheWorkStore` pins
that boundary from **both** sides now — the graph binding stays empty *and* the
work store holds no graph-marked bead.

**Needs more than wiring — BOTH `--attach` arms.** A graft is a **two-ended
edge**: the sub-DAG root is graph class, the attach bead is whatever class owns
it, and `ensureFormulaCookAttachDep` / `molecule.Attach` writes a `blocks` row
binding them. Move only the root and the work store records an edge naming an
id it cannot resolve. Nothing rejects that write —
`internal/beads/splittest`'s own backend table says bd passes a cross-prefix
target through as an external ref and SQLite's `deps` table has no foreign key
— and every `Ready` implementation treats an unresolvable blocker as open
(`memstore.go readyLocked`: `statusByID[dep.DependsOnID] != "closed"`). The
caller's own work bead then leaves Ready **forever** and the documented graft
gate ("the bead won't close until the sub-DAG completes") is silently void.

An earlier revision of this PR shipped exactly that half-split on the graph.v2
`--attach` arm. It is reverted: **both** arms now stay whole on the scope
store, root and dep co-resident, byte-identical to `main`, with the deferral
named at each call site. Splitting them needs the attach bead's owning store
resolved **by id** — the shared resolver, `ga-k8pzw` — plus a cross-boundary
representation of the block, which is a production behavior change rather than
wiring.

**Order dispatcher — `ga-fk1a5`, pinned not closed.** `dispatchWisp` has the
same v1-poured defect the CLI twin just fixed, but its root is a **two-class
object**: it also carries the `order:`/`seq:` event-cursor labels, and
`orders.Store` unions order-run evidence across the **ORDERS and GRAPH legs
only** (`internal/orders/store.go`). Routing the molecule by class alone would
fix the steps and lose the cursor, so an event-triggered v1 poured order would
re-fire every tick. Closing it means persisting the cursor onto the
orders-class tracking bead the way the exec arm already does
(`front.SetCursor`) — its own slice. `gc order run` has no such tension: on
`main` its molecule *and* its cursor labels already live on the scope store, so
gating it by class is a pure restoration.
`TestOrderDispatchPouredV1MoleculeRelocatesWithTheGraphClass` pins the current
answer so `ga-fk1a5` has a test to flip.

## Writers moved, and every reader of what they wrote

| reader | routes at the graph class? |
|---|---|
| controller order gate / cooldown / cursor (`gateStoresFor`) | ✅ federates the graph binding since #5106 |
| `gc order check`, `gc order history`, `gc doctor` order firing | ✅ `cachedOrderStoresResolver` appends `relocatedOrdersClassStore`, and the only split shape this build serves puts all five infrastructure classes on ONE binding (`storageSplitWhole`), so that leg *is* the graph binding. Asserted by `TestOrderRunGraphResidentRunIsVisibleToTheOrderReaders` (`LastRun` **and** `Cursor`). |
| `gc order sweep-tracking --include-wisps` | ✅ `orderWispSweepStore` is `resolveGraphStore(cliStorageRoutes(...))` |
| control dispatcher | ✅ `controlGraphStore` (#5108) |
| `gc bd show/update` by id | ✅ `cmd_bd_by_id.go` + `storeref.ClassCandidates` (#5132) |
| API / dashboard run detail | ✅ `CityRuntime.graphBeadStore()` |
| `gc hook` (work scope) | ✅ **by construction** — a work-class molecule is no longer relocated away from it |
| `gc formula version-check <bead-id>` | ❌ **disagrees** — a by-id read; **named for `ga-k8pzw`, not fixed here.** Pre-existing (#5106/#5108 already relocated graph roots); this PR extends the set. |
| `gc sling`'s source-workflow replacement machinery (`internal/sling/sling_core.go`) | ❌ **disagrees** — by-id / scope-federated reads of graph roots; **named for `ga-k8pzw`.** |

## Tests

All drive the **real** production entry points — the cobra `gc formula cook`
command, `doOrderRunWithJSON`, and `memoryOrderDispatcher.dispatch` — against a
`storageRoutes` value shaped like the converged whole-split binding, seeded
through the production memo (`seedCLIStorageRoutes`).

### Red-before evidence (mutation applied, test run, string quoted verbatim)

| mutation | test | red-before |
|---|---|---|
| graph.v2 `--attach`: `Instantiate` on `graphStore`, dep on `store` (the earlier revision) | `TestFormulaCookAttachLeavesTheSourceBeadUnblockableOnSplitCity` | `work store holds dep gc-1 -> gcg-1 (blocks) whose target it cannot resolve: getting bead "gcg-1": bead not found` **and** `attach bead gc-1 is not Ready after the whole workflow closed (ready=[], root=gcg-1)` |
| attach arm's live-root lookup → `graphStore` | `TestFormulaCookAttachIsIdempotentOnSplitCity` | `re-cook minted a second workflow root (gc-2 then gc-5); the idempotent lookup read a store that does not hold the root` |
| legacy cook routed by version (`rootStore = store`) | `TestFormulaCookRootOnlyLegacyWispLandsInGraphStoreOnSplitCity` | `root-only wisp gc-1 is not resident in the graph binding: getting bead "gc-1": bead not found` |
| legacy cook relocated wholesale (`rootStore = graphStore`) | `TestFormulaCookLegacyMoleculeStaysOnTheWorkStore` | `legacy molecule root gcg-1 is not resident in the work store: getting bead "gcg-1": bead not found` |
| `--meta` stamp on the scope store | `TestFormulaCookMetaStampLandsOnTheGraphResidentRoot` | `gc formula cook graph-work: setting root metadata on gcg-1: setting metadata batch on "gcg-1": bead not found` |
| `gc order run` routes unconditionally (`moleculeStore = graphStore`) | `TestOrderRunPouredV1MoleculeStaysOnTheWorkStoreOnSplitCity` | `poured molecule root gcg-1 is not resident in the scope work store: getting bead "gcg-1": bead not found` |
| execution-fact work leg collapsed onto the graph store | `TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg` | `no execution.work_associated fact for mc-2 in run gcg-1 (events=[]); the convoy leg read a ledger the convoy does not live in` |
| `resolveClassStore`'s identity branch returns a fresh store | all four `…StaysOnTheOneStoreOnSingleStoreCity` | `wisp root gc-1 is not resident in the single store`, `cooked root gc-1 is not resident in the single store`, `root-only wisp gc-1 is not resident in the single store`, `graphStoreFor returned *beads.MemStore(0x…), want the identical store value 0x…` |

The `--attach` case is the assertion that would have caught the earlier
revision: it closes **every** bead in both stores and then asserts the source
bead is back in `Ready()` — the contract `--attach` documents.

### Also added

- `TestRecipeCoordClassRederivesTheVerdictFromTheClassifier` — the three
  compiler-emitted shapes plus the RootOnly-skipped-step case, stated at the
  helper.
- `TestFormulaCookRootOnlyLegacyWispStaysOnTheOneStoreOnSingleStoreCity` —
  the compatibility half for the new legacy route.
- `TestOrderDispatchPouredV1MoleculeRelocatesWithTheGraphClass` — the
  `ga-fk1a5` KNOWN GAP pin.

`TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg` is asserted on
the helper rather than through the cobra command, and the comment says why: no
one-shot cook can reach the two-leg state today, because `PrepareInvocation`
only mints an input convoy for a **targeted** invocation and the `--attach`
arms — the only targeted ones — now run wholly on the scope store. The helper
is where the leg assignment lives, so it is where a collapse is catchable.

## Single-store compatibility

**Byte-identical, by construction.** `resolveGraphStore` returns the *exact
store value it was handed* when the routes relocate nothing, and
`moleculeClassStore` picks between two values that are then the same value, so
the molecule create sees the same instance and the `GraphApplyFor` /
`StorageCreateStore` optional-capability assertions still resolve. The
single-store tests are green before and after by design; their teeth come from
the identity-branch mutation above.

## Conformance suite

No KNOWN GAP closes. I5's paragraph named *this* bead as the slice that would
close `gc hook --claim`; that attribution is wrong and is corrected to
`ga-k8pzw` — a claim is a by-id mutation of a bead that already exists. The
skip list stays empty; nothing was skipped or deleted. I12
(`conformanceMoleculeMembership`, #5149) is intact — an earlier rebase of this
branch silently dropped it and it has been restored.

## Gates

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l cmd/gc internal` — clean
- `golangci-lint` 2.10.1 on `./cmd/gc/...` — **0 issues**
- `go test ./cmd/gc -timeout 25m` — ok
- `go test ./internal/...` — ok
- `scripts/check-core-boundary.sh` — OK
- `scripts/check-routed-test-rows.sh` — OK
- `make check-split-topology-rows` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
