### PR TITLE
fix(herdr): make wisp-id tab labels prefix-agnostic

### DIFF
--- a/internal/runtime/herdr/placement_test.go
+++ b/internal/runtime/herdr/placement_test.go
@@ -50,6 +50,44 @@ func TestPlacementFor(t *testing.T) {
 			wantTab:  "polecat-gc-wisp-abc123",
 		},
 		{
+			// The wisp id is a bead id minted by the pouring scope, so it carries
+			// that scope's beads prefix — "gc-" only when the city's HQ prefix is
+			// literally "gc". Detection must be prefix-agnostic or every other
+			// city keeps raw wisp ids in its tabs.
+			name:     "wisp with non-gc city prefix gets themed tab",
+			sessName: "gastown__polecat-az-wisp-z0pu0",
+			env:      map[string]string{"GC_RIG": "gascity", "GC_ALIAS": "gascity/gastown.furiosa"},
+			wantWS:   "gascity",
+			wantTab:  "polecat-furiosa",
+		},
+		{
+			name:     "wisp id with no role prefix is replaced whole",
+			sessName: "gastown__az-wisp-z0pu0",
+			env:      map[string]string{"GC_RIG": "gascity", "GC_ALIAS": "gascity/gastown.furiosa"},
+			wantWS:   "gascity",
+			wantTab:  "furiosa",
+		},
+		{
+			// The deferred pool spawn blanks GC_ALIAS and leaves the session name
+			// in GC_AGENT (build_desired_state_pool_info.go); once the alias
+			// resolves the reconciler repopulates it.
+			name:     "non-gc wisp falls back to GC_AGENT when alias not yet resolved",
+			sessName: "gastown__polecat-az-wisp-g8ha3",
+			env:      map[string]string{"GC_RIG": "gascity", "GC_ALIAS": "", "GC_AGENT": "gascity/gastown.nux"},
+			wantWS:   "gascity",
+			wantTab:  "polecat-nux",
+		},
+		{
+			// Guard case: the deferred fallback hands back the session name
+			// itself, which still carries the wisp id. Substituting it would
+			// produce "polecat-gastown__polecat-az-wisp-z0pu0".
+			name:     "non-gc alias that is itself the wisp identity is ignored",
+			sessName: "gastown__polecat-az-wisp-z0pu0",
+			env:      map[string]string{"GC_RIG": "gascity", "GC_ALIAS": "", "GC_AGENT": "gastown__polecat-az-wisp-z0pu0"},
+			wantWS:   "gascity",
+			wantTab:  "polecat-az-wisp-z0pu0",
+		},
+		{
 			name:     "persistent rig agent unchanged",
 			sessName: "webapp--gastown__witness",
 			env:      map[string]string{"GC_RIG": "webapp", "GC_ALIAS": "webapp/gastown.witness"},

--- a/internal/runtime/herdr/provider.go
+++ b/internal/runtime/herdr/provider.go
@@ -887,7 +887,8 @@ func workspaceTabFor(name string) (workspace, tab string) {
 // populates these via RuntimeEnvWithSessionContext).
 //
 // This matters for ephemeral pool wisps: their runtime name is town-qualified
-// (e.g. "gastown__polecat-gc-wisp-3nvj3yx"), so workspaceTabFor alone drops them
+// (e.g. "gastown__polecat-az-wisp-3nvj3yx", where "az" is the pouring scope's
+// beads prefix and varies by city), so workspaceTabFor alone drops them
 // in the town workspace under an opaque wisp-id tab. GC_RIG restores the
 // originating rig workspace (webapp/mobile), and GC_ALIAS swaps the wisp id for
 // the themed instance name, yielding e.g. workspace "webapp", tab
@@ -904,19 +905,37 @@ func placementFor(name string, env map[string]string) (workspace, tab string) {
 		workspace = rig
 	}
 	// Replace a wisp id with the themed instance alias so tabs read e.g.
-	// "polecat-furiosa" rather than "polecat-gc-wisp-3nvj3yx". The role prefix
+	// "polecat-furiosa" rather than "polecat-az-wisp-3nvj3yx". The role prefix
 	// (everything before the wisp id) is preserved. Falls through unchanged when
 	// no alias is available yet, or when the alias is itself the wisp identity.
-	if i := strings.Index(tab, "gc-wisp-"); i >= 0 {
+	if i := wispIDStart(tab); i >= 0 {
 		alias := strings.TrimSpace(env["GC_ALIAS"])
 		if alias == "" {
 			alias = strings.TrimSpace(env["GC_AGENT"])
 		}
-		if leaf := lastSegment(alias); leaf != "" && !strings.Contains(leaf, "gc-wisp-") {
+		if leaf := lastSegment(alias); leaf != "" && wispIDStart(leaf) < 0 {
 			tab = tab[:i] + leaf
 		}
 	}
 	return workspace, tab
+}
+
+// wispIDStart reports the index where a wisp id begins inside s, or -1 when s
+// carries none. A wisp id is a bead id minted by PourWisp, so it reads
+// "<prefix>-wisp-<suffix>" where <prefix> is the beads prefix of the scope that
+// poured it — "gc" in a default city, but "az", "py", … anywhere else.
+// Detection therefore keys on the "-wisp-" infix and walks back over the prefix
+// token; keying on a literal "gc-wisp-" silently no-ops on every other city,
+// and keying on "-wisp-" alone would cut mid-id ("polecat-az" + leaf).
+func wispIDStart(s string) int {
+	i := strings.Index(s, "-wisp-")
+	if i < 0 {
+		return -1
+	}
+	// i sits on the "-" closing the beads prefix, so the id starts just after
+	// the preceding "-" — or at 0 when the wisp id has no role prefix, which
+	// LastIndex's -1 gives for free.
+	return strings.LastIndex(s[:i], "-") + 1
 }
 
 // lastSegment returns the trailing identity segment after the final "/" or ".",


### PR DESCRIPTION
## Problem

herdr tabs for pool agents read `polecat-az-wisp-z0pu0` instead of the intended
`polecat-furiosa`. The alias substitution that produces the readable name already
exists and is correct — it just never fires outside a default city.

## Root cause

A wisp id is a bead id minted by `PourWisp`, so it carries the beads prefix of the
scope that poured it: `<prefix>-wisp-<suffix>`. Upstream's default city prefix is
`gc`, giving `gc-wisp-`, and `placementFor` hardcoded exactly that literal:

```go
if i := strings.Index(tab, "gc-wisp-"); i >= 0 {
```

with the same literal in its guard. On any city whose HQ scope prefix is not
literally `gc`, `strings.Index` returns -1, the substitution is skipped silently,
and the raw wisp id survives into the tab label. Observed on two separate cities
whose prefixes are `az` and `py`.

This is cosmetic but city-wide: it affects every pool agent's tab, not just one rig.

## Fix

Key on the `-wisp-` infix and walk back over the prefix token:

```go
func wispIDStart(s string) int {
	i := strings.Index(s, "-wisp-")
	if i < 0 {
		return -1
	}
	return strings.LastIndex(s[:i], "-") + 1
}
```

Two details worth flagging for review:

- **Matching `-wisp-` directly is not sufficient.** `placementFor` keeps `tab[:i]`
  as the role prefix, so cutting at the infix would yield `polecat-az` + leaf.
  The walk-back finds the start of the prefix token instead.
- **`LastIndex` returning -1 handles the no-role-prefix case for free**, giving
  index 0 so a bare `az-wisp-z0pu0` is replaced whole.

The guard that rejects an alias which is itself the wisp identity carried the same
hardcoded prefix and needed the same treatment. Without it, the deferred pool spawn
(which blanks `GC_ALIAS` and leaves the session name in `GC_AGENT`) produced
`polecat-gastown__polecat-az-wisp-z0pu0`.

Used `strings` rather than a regexp to match this package's production idiom —
`regexp` currently appears only in `agentname_test.go`.

## Tests

Four cases added to the existing `TestPlacementFor` table, using real observed
session data:

- non-`gc` city prefix gets the themed tab (`az-wisp-z0pu0` -> `polecat-furiosa`)
- wisp id with no role prefix is replaced whole (-> `furiosa`)
- deferred spawn falls back to `GC_AGENT` when `GC_ALIAS` is blank
- guard: an alias that is itself the wisp identity is ignored

The guard case is a regression guard and passes before the change. I verified it
has teeth by fixing only the detection first, which made it fail with exactly the
corruption above.

Behavior is unchanged for default-city `gc-wisp-` ids, persistent rig agents, and
town-level agents; all pre-existing cases still pass.

## Note for reviewers

`placementFor` is consulted only at `Provider.Start`, so this renames no existing
tab — labels correct themselves as agents respawn. A retroactive sweep is possible
via `client.tabRename` but is deliberately out of scope here.

Verified: `internal/runtime/herdr` passes, `go vet` clean, lint clean.
