### PR TITLE
fix(cli): refuse a `gc bd list` projection over a class it cannot see (ga-fq54n)

### DIFF
--- a/cmd/gc/bd_relocated_classes.go
+++ b/cmd/gc/bd_relocated_classes.go
@@ -101,20 +101,29 @@ func bdRelocatedClassOverrideEnabled() bool {
 // operator or agent wrote by hand, both resolve it against the bd ledger alone,
 // and both answer no-match with an empty result and exit 0.
 //
-// `list` is here for the same reason and it is the one that took longest to
-// see, because the flag it arrives through does not look like an id position.
-// `gc bd list --metadata-field gc.root_bead_id=<gcg root>` answered `[]` with
-// exit 0 on a converged split city: --metadata-field is not id-VALUED, so the
-// by-id door in cmd_bd_by_id.go correctly declined it (a quoted id decides
-// nothing about ownership), and bd then ran the projection successfully against
-// the one ledger that holds no gcg- row. The value named an id but the VERB is
-// a PROJECTION over a class this ledger cannot see, and a projection that
-// cannot see a class must fail loudly rather than answer with the empty set.
-// That is the whole of ga-iaj7k's Invariant 0, and it is what makes `list`
-// COHERENT with `dep tree`, which already refuses a relocated id — two
-// projections over the same data with opposite failure semantics is worse than
-// either one alone, because an operator who learned the loud one trusts the
-// quiet one.
+// `list`, `ready` and `search` are here for the same reason and they were the
+// ones that took longest to see, because the flag the id arrives through does
+// not look like an id position. `gc bd list --metadata-field
+// gc.root_bead_id=<gcg root>` answered `[]` with exit 0 on a converged split
+// city: --metadata-field is not id-VALUED, so the by-id door in cmd_bd_by_id.go
+// correctly declined it (a quoted id decides nothing about ownership), and bd
+// then ran the projection successfully against the one ledger that holds no
+// gcg- row. The value named an id but the VERB is a PROJECTION over a class
+// this ledger cannot see, and a projection that cannot see a class must fail
+// loudly rather than answer with the empty set. That is the whole of ga-iaj7k's
+// Invariant 0, and it is what makes `list` COHERENT with `dep tree`, which
+// already refuses a relocated id — two projections over the same data with
+// opposite failure semantics is worse than either one alone, because an
+// operator who learned the loud one trusts the quiet one.
+//
+// `ready` and `search` are the same projection over the same flag: bdflags
+// lists --metadata-field for `ready`, bd registers it for `search`, and both
+// answer no-match with `[]` and exit 0. Guarding `list` alone would have minted
+// the asymmetry it retired — one verb over, on the same molecule, through the
+// same selector — and inside `gc bd ready` itself, whose --parent/--mol
+// spellings the by-id door already refuses loudly. They share `list`'s scan
+// because they share bd's selector dialect, so the negatives that keep a
+// free-text search answerable hold for all three unchanged.
 //
 // The other verbs are unguarded because they are no longer blind, not because
 // they were ever safe:
@@ -130,13 +139,18 @@ func bdRelocatedClassOverrideEnabled() bool {
 //     positional or an id-valued flag — is refused there too, by ownership
 //     rather than by servability.
 //
-// `ready` stays out: its selectors name templates and labels, not bead ids, so
-// there is nothing in its argv for this scan to classify, and the federated
-// answer to a claimable-work question already exists as `gc ready`.
+// The selector surface is COMPLETE, and that is checkable rather than hopeful:
+// --metadata-field — the only bd flag whose value side is a key=value predicate
+// on a read — is registered on exactly three subcommands (list.go, ready.go,
+// search.go in the pinned beads module), and all three are in this map.
+// TestBdRelocatedClassGuardCoversEverySelectorVerb pins that against bdflags so
+// a fourth cannot appear unguarded.
 var bdRelocatedClassGuardedVerbs = map[string]bdRelocatedClassScan{
-	"sql":   beads.RelocatedClassesInSQL,
-	"query": beads.RelocatedClassesInQueryExpr,
-	"list":  beads.RelocatedClassesInListSelector,
+	"sql":    beads.RelocatedClassesInSQL,
+	"query":  beads.RelocatedClassesInQueryExpr,
+	"list":   beads.RelocatedClassesInSelector,
+	"ready":  beads.RelocatedClassesInSelector,
+	"search": beads.RelocatedClassesInSelector,
 }
 
 // bdRelocatedClassScan classifies one argument's text in one bd dialect.
@@ -169,6 +183,14 @@ func bdRelocatedClassScanText(arg string) (string, bool) {
 // bdSQLRelocatedClassRefusal reports whether a `gc bd` invocation is an ad-hoc
 // read that names the id namespace of a class this city serves elsewhere, and
 // returns the operator-facing refusal when it is.
+//
+// The override is named HERE rather than inside beads.RelocatedClassRefusal
+// because this is the only seam where it works: the same error text is returned
+// by BdStore's id-scoped guard, which honors no env var, and a message that
+// offers an escape the reader cannot take is worse than one that offers none.
+// An escape hatch nobody can find is not an escape hatch — the scan classifies
+// TEXT, so a false positive is always possible, and the operator holding one
+// needs the way out in the message that stopped them.
 func bdSQLRelocatedClassRefusal(cfg *config.City, bdArgs []string) (string, bool) {
 	relocated := relocatedBeadClasses(cfg)
 	if len(relocated) == 0 {
@@ -200,6 +222,25 @@ func bdSQLRelocatedClassRefusal(cfg *config.City, bdArgs []string) (string, bool
 		return "", false
 	}
 	return beads.RelocatedClassRefusal(op, matched).Error(), true
+}
+
+// bdRelocatedClassEscapeHint is the sentence appended to a refusal that is
+// actually being ENFORCED, naming the knob that lifts it.
+//
+// It is not part of beads.RelocatedClassRefusal because that same text is
+// returned by BdStore's id-scoped guard, which honors no env var: a message
+// that offers an escape its reader cannot take is worse than one that offers
+// none. And it is not appended when the override is already set, because there
+// the operator is being told what they overrode, not how.
+//
+// The scan classifies TEXT, so a false positive is always possible — a work-row
+// query whose value legitimately holds a relocated id (gc.drain_control_id) is
+// indistinguishable from a class-scoped one. An escape hatch nobody can find is
+// not an escape hatch, so it travels with the refusal that stopped them.
+func bdRelocatedClassEscapeHint() string {
+	return fmt.Sprintf(" If this read is about work rows that merely REFERENCE such an id — a metadata comparison on "+
+		"gc.drain_control_id, say — it is a question this ledger can answer, and %s=1 runs it anyway.",
+		bdRelocatedClassOverrideEnvVar)
 }
 
 // bdRelocatedClassScans returns the dialect scans to run over an invocation's

--- a/cmd/gc/bd_relocated_classes.go
+++ b/cmd/gc/bd_relocated_classes.go
@@ -94,27 +94,77 @@ func bdRelocatedClassOverrideEnabled() bool {
 	}
 }
 
-// bdRelocatedClassGuardedVerbs are the bd read verbs whose positional text
-// names ids in a dialect this guard can classify.
+// bdRelocatedClassGuardedVerbs are the bd read verbs whose argument text names
+// ids in a dialect this guard can classify.
 //
 // `sql` and `query` are the two ad-hoc ones: both take an expression an
 // operator or agent wrote by hand, both resolve it against the bd ledger alone,
 // and both answer no-match with an empty result and exit 0.
 //
-// list/ready are left alone — they answer about the ledger they are scoped to
-// and claim nothing more. show/dep tree are left alone too, but NOT because
-// they are safe: they are raw bd passthroughs against the same blind ledger
-// (doBd ends at exec.Command(bdPath, bdArgs...) with no class routing). They
-// stay unguarded because a bare id is not a dialect this scan can read without
-// refusing every work-store id that starts with the same letters, and because
-// the refusal now steers to `gc beads show` instead of to them.
+// `list` is here for the same reason and it is the one that took longest to
+// see, because the flag it arrives through does not look like an id position.
+// `gc bd list --metadata-field gc.root_bead_id=<gcg root>` answered `[]` with
+// exit 0 on a converged split city: --metadata-field is not id-VALUED, so the
+// by-id door in cmd_bd_by_id.go correctly declined it (a quoted id decides
+// nothing about ownership), and bd then ran the projection successfully against
+// the one ledger that holds no gcg- row. The value named an id but the VERB is
+// a PROJECTION over a class this ledger cannot see, and a projection that
+// cannot see a class must fail loudly rather than answer with the empty set.
+// That is the whole of ga-iaj7k's Invariant 0, and it is what makes `list`
+// COHERENT with `dep tree`, which already refuses a relocated id — two
+// projections over the same data with opposite failure semantics is worse than
+// either one alone, because an operator who learned the loud one trusts the
+// quiet one.
+//
+// The other verbs are unguarded because they are no longer blind, not because
+// they were ever safe:
+//
+//   - `show`, `update` (including `--claim`), `release-if-current` and
+//     `dep list` are answered IN PROCESS from the binding their class is served
+//     from — cmd_bd_by_id.go, wired into doBd immediately after this scan — so
+//     they never reach the subprocess for a class-owned bead.
+//   - `dep tree` is not served in process, and on a class-owned id that same
+//     surface REFUSES it (exit 1, naming the bead and the binding) rather than
+//     forwarding it.
+//   - Every other bd subcommand that ADDRESSES a reserved-prefix id — in a
+//     positional or an id-valued flag — is refused there too, by ownership
+//     rather than by servability.
+//
+// `ready` stays out: its selectors name templates and labels, not bead ids, so
+// there is nothing in its argv for this scan to classify, and the federated
+// answer to a claimable-work question already exists as `gc ready`.
 var bdRelocatedClassGuardedVerbs = map[string]bdRelocatedClassScan{
 	"sql":   beads.RelocatedClassesInSQL,
 	"query": beads.RelocatedClassesInQueryExpr,
+	"list":  beads.RelocatedClassesInListSelector,
 }
 
-// bdRelocatedClassScan classifies one positional argument in one bd dialect.
+// bdRelocatedClassScan classifies one argument's text in one bd dialect.
 type bdRelocatedClassScan func([]beads.RelocatedClass, string) []beads.RelocatedClass
+
+// bdRelocatedClassScanText returns the part of an argument a dialect scan
+// should read, and whether there is one.
+//
+// A separated flag value arrives as its own token (`--metadata-field
+// gc.root_bead_id=gcg-1`) and is scanned as a positional. The INLINE spelling
+// of the same selector (`--metadata-field=gc.root_bead_id=gcg-1`) is one token
+// that begins with a dash, and skipping it wholesale — which is what this scan
+// used to do — let a single `=` switch the guard off on the exact query it was
+// added for. So the flag NAME is dropped and everything after the first `=` is
+// scanned, which is the value bd itself parses out of that token.
+//
+// A flag carrying no value (`--json`, `-q`) has no value text and is skipped,
+// which is what keeps `bd sql --json 'select 1'` from classifying its own flags.
+func bdRelocatedClassScanText(arg string) (string, bool) {
+	if !strings.HasPrefix(arg, "-") {
+		return arg, true
+	}
+	_, value, inline := strings.Cut(arg, "=")
+	if !inline {
+		return "", false
+	}
+	return value, true
+}
 
 // bdSQLRelocatedClassRefusal reports whether a `gc bd` invocation is an ad-hoc
 // read that names the id namespace of a class this city serves elsewhere, and
@@ -132,11 +182,12 @@ func bdSQLRelocatedClassRefusal(cfg *config.City, bdArgs []string) (string, bool
 	var matched []beads.RelocatedClass
 	seen := make(map[string]bool, len(relocated))
 	for _, arg := range verbArgs {
-		if strings.HasPrefix(arg, "-") {
+		text, scannable := bdRelocatedClassScanText(arg)
+		if !scannable {
 			continue
 		}
 		for _, namedIn := range scans {
-			for _, class := range namedIn(relocated, arg) {
+			for _, class := range namedIn(relocated, text) {
 				if seen[class.Class] {
 					continue
 				}

--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/bdflags"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
@@ -161,20 +162,57 @@ func TestBdSQLRelocatedClassRefusalOnASplitCity(t *testing.T) {
 		"a flag that looks like an id": {[]string{"sql", "--json", "select 1"}, false},
 		"no args":                      {nil, false},
 
-		// `bd list` is the third ad-hoc dialect: its selector flags carry
-		// key=value predicates whose value side names ids exactly the way bd's
-		// query DSL does, and a no-match answer is `[]` with exit 0. Both
-		// spellings of every selector are covered because a guard a `=` can
-		// switch off is not a guard.
+		// The selector dialect: `list`, `ready` and `search` carry key=value
+		// predicates whose value side names ids, and a no-match answer is `[]`
+		// with exit 0. Both spellings of every selector are covered because a
+		// guard a `=` can switch off is not a guard.
 		"list on a graph root id":              {[]string{"list", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
 		"list on a graph root id inline":       {[]string{"list", "--metadata-field=gc.root_bead_id=gcg-abc123"}, true},
 		"list on a graph id behind --json":     {[]string{"list", "--json", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
 		"list on a nudge id":                   {[]string{"list", "--metadata-field", "gc.nudge_id=gcn-1"}, true},
 		"list on a work root id":               {[]string{"list", "--metadata-field", "gc.root_bead_id=demo-abc"}, false},
 		"list with a metadata key only":        {[]string{"list", "--has-metadata-key", "gc.root_bead_id"}, false},
-		"list whose text mentions a graph id":  {[]string{"list", "--title-contains", "fix gcg-1 regression"}, false},
 		"list on a prefix continuation":        {[]string{"list", "--metadata-field", "gc.root_bead_id=gcgx-1"}, false},
 		"list on a graph id in a rig-scoped q": {[]string{"--json", "list", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
+
+		// A selector flag whose value is SEARCH TEXT is a LIKE-contains over a
+		// column this ledger owns, and bd answers it correctly and often
+		// non-emptily. `bd list` takes no positionals (cmd/bd/list.go: "bd list
+		// does not accept positional arguments"), so EVERY token this scan sees
+		// is some flag's value — which is why the dialect anchors on the `=` of
+		// a predicate and not on the start of a token. Each row below refused
+		// while the scan reused the query DSL's anchor.
+		"list on a title search for an id":         {[]string{"list", "--title-contains", "gcg-abc123"}, false},
+		"list on a title search for an id inline":  {[]string{"list", "--title-contains=gcg-abc123"}, false},
+		"list on a description search for an id":   {[]string{"list", "--desc-contains", "gcg-abc123"}, false},
+		"list on a notes search for an id":         {[]string{"list", "--notes-contains", "gcg-abc123"}, false},
+		"list on a title match for an id":          {[]string{"list", "--title", "gcg-abc123"}, false},
+		"list on a label named for an id":          {[]string{"list", "--label", "gcg-abc123"}, false},
+		"list EXCLUDING a label named for an id":   {[]string{"list", "--exclude-label", "gcg-abc123"}, false},
+		"list on a label glob":                     {[]string{"list", "--label-pattern", "gcg-*"}, false},
+		"list on an assignee named for a class":    {[]string{"list", "--assignee", "gcg-worker"}, false},
+		"list on a short assignee flag":            {[]string{"list", "-a", "gcg-worker"}, false},
+		"list whose text mentions a graph id":      {[]string{"list", "--title-contains", "fix gcg-1 regression"}, false},
+		"list whose text parenthesizes a graph id": {[]string{"list", "--title-contains", "fix (gcg-1) regression"}, false},
+		"list whose text lists graph ids":          {[]string{"list", "--title-contains", "regressions: gcg-1, gcg-2"}, false},
+		"list whose text quotes a graph id":        {[]string{"list", "--title-contains", "root is 'gcg-1' here"}, false},
+
+		// `ready` and `search` take the same --metadata-field predicate (bd
+		// registers it on exactly these three verbs) and answer no-match the
+		// same way. Guarding `list` alone left the identical silent empty one
+		// verb over, on the same molecule, through the same flag.
+		"ready on a graph root id":         {[]string{"ready", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
+		"ready on a graph root id inline":  {[]string{"ready", "--metadata-field=gc.root_bead_id=gcg-abc123"}, true},
+		"ready on a pool route":            {[]string{"ready", "--metadata-field", "gc.routed_to=demo/worker"}, false},
+		"ready on a label named for an id": {[]string{"ready", "--label", "gcg-abc123"}, false},
+		"ready with no selector":           {[]string{"ready", "--unassigned", "--json"}, false},
+		"search on a graph root id":        {[]string{"search", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
+		// `bd search <query>` takes a positional, and free text is a search over
+		// this ledger's own columns, so the DIALECT lets it through. It is still
+		// refused end-to-end — `search` is not in bdflags, so the by-id door's
+		// fail-closed widening treats the positional as an addressed id, exactly
+		// as it did before this change.
+		"search on free text": {[]string{"search", "gcg-abc123"}, false},
 
 		// A query about the work ledger that merely mentions a relocated id is
 		// answered correctly and non-emptily by bd, so it must pass.
@@ -250,6 +288,9 @@ func TestBdSQLRelocatedClassRefusalIsInertOnASingleStoreCity(t *testing.T) {
 		"query":                  {"query", "id=gcg-abc"},
 		"list":                   {"list", "--metadata-field", "gc.root_bead_id=gcg-abc"},
 		"list inline":            {"list", "--metadata-field=gc.root_bead_id=gcg-abc"},
+		"list free text":         {"list", "--title-contains", "gcg-abc"},
+		"ready":                  {"ready", "--metadata-field", "gc.root_bead_id=gcg-abc"},
+		"search":                 {"search", "--metadata-field", "gc.root_bead_id=gcg-abc"},
 		"unrecognized flag":      {"--frobnicate", "x", "sql", "select * from issues where id = 'gcg-abc'"},
 	}
 	for name, cfg := range map[string]*config.City{
@@ -551,6 +592,202 @@ func TestGcBdListOverrideRunsTheProjectionLoudly(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), bdRelocatedClassOverrideEnvVar) {
 		t.Errorf("override was honored silently; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdListForwardsAFreeTextSearchThatNamesAGraphID is the false-positive
+// proof, end to end, through the real command.
+//
+// `--title-contains gcg-abc123` is `title LIKE '%gcg-abc123%'` over a column
+// THIS ledger owns, and the work ledger really does carry gcg- strings — the
+// drain-unit convoys minted at internal/dispatch/drain.go title themselves
+// after the member they drain. bd answers this correctly and often
+// non-emptily, so refusing it is the exact false positive
+// internal/beads/bdsql_relocation.go's header promises the anchoring rules
+// exist to let through.
+//
+// The stub answers a NON-EMPTY row on purpose: a refusal here does not merely
+// inconvenience an operator, it withholds rows that exist.
+func TestGcBdListForwardsAFreeTextSearchThatNamesAGraphID(t *testing.T) {
+	const row = `[{"id":"demo-1","title":"drain unit 3 for gcg-abc123"}]`
+	for name, args := range map[string][]string{
+		"title search":           {"list", "--title-contains", "gcg-abc123", "--json"},
+		"title search inline":    {"list", "--title-contains=gcg-abc123", "--json"},
+		"notes search":           {"list", "--notes-contains", "gcg-abc123", "--json"},
+		"description search":     {"list", "--desc-contains", "gcg-abc123", "--json"},
+		"label filter":           {"list", "--label", "gcg-abc123", "--json"},
+		"label exclusion":        {"list", "--exclude-label", "gcg-abc123", "--json"},
+		"assignee filter":        {"list", "--assignee", "gcg-worker", "--json"},
+		"prose with punctuation": {"list", "--title-contains", "fix (gcg-1) regression", "--json"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+			t.Setenv("BD_STUB_STDOUT", row)
+
+			var stdout, stderr bytes.Buffer
+			if code := doBd(args, &stdout, &stderr); code != 0 {
+				t.Fatalf("`gc bd %s` exited %d on a split city; a LIKE-contains over this ledger's own columns is a question bd answers, and refusing it withholds rows that exist. stderr=%q",
+					strings.Join(args, " "), code, stderr.String())
+			}
+			data, err := os.ReadFile(capture)
+			if err != nil {
+				t.Fatalf("bd was not invoked for %v: %v", args, err)
+			}
+			if !strings.Contains(string(data), strings.Join(args, " ")) {
+				t.Fatalf("bd received %q, want the search forwarded verbatim", data)
+			}
+			if strings.TrimSpace(stdout.String()) != row {
+				t.Fatalf("stdout = %q, want bd's own rows passed through untouched", stdout.String())
+			}
+		})
+	}
+}
+
+// TestGcBdListOnAnIDValuedFlagRefusesByOwnership pins which door answers an
+// ADDRESSED id, and it is the reason the selector dialect does not need an
+// offset-0 anchor.
+//
+// `--id`, `--parent` and `-p` are in bdIDValuedFlags, so the by-id door has
+// always refused them and names the BEAD and the binding that owns it.
+// Anchoring the selector scan at offset 0 to catch them a second time would
+// shadow that with the vaguer namespace message — the dialect guard runs first
+// — while adding no coverage. So the behavior here must be the ownership
+// refusal, byte for byte the same one a legacy build produced.
+func TestGcBdListOnAnIDValuedFlagRefusesByOwnership(t *testing.T) {
+	for name, args := range map[string][]string{
+		"--id":     {"list", "--id", "gcg-abc123", "--json"},
+		"--parent": {"list", "--parent", "gcg-abc123", "--json"},
+		"-p":       {"list", "-p", "gcg-abc123", "--json"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+			t.Setenv("BD_STUB_STDOUT", "[]")
+			resetCLIStorageRoutes(t)
+			captureCLIStorageStderr(t)
+
+			var stdout, stderr bytes.Buffer
+			if code := doBd(args, &stdout, &stderr); code == 0 {
+				t.Fatalf("doBd(%v) exited 0; stdout=%q", args, stdout.String())
+			}
+			if !strings.Contains(stderr.String(), "gcg-abc123 is owned by") {
+				t.Errorf("the refusal is not the by-id OWNERSHIP one, so the dialect guard is shadowing a more specific message; stderr=%q", stderr.String())
+			}
+			// The by-id door resolves the class binding before it refuses, and
+			// that resolution censuses the work store through bd. What must not
+			// reach bd is the REFUSED argv.
+			if data, err := os.ReadFile(capture); err == nil && strings.Contains(string(data), strings.Join(args, " ")) {
+				t.Fatalf("the refused invocation was forwarded to bd: %q", data)
+			}
+		})
+	}
+}
+
+// TestGcBdReadyRefusesAGraphClassProjectionOnASplitCity closes the asymmetry
+// the `list` fix would otherwise have moved one verb over.
+//
+// `bd ready` takes the same --metadata-field predicate as `bd list` (bd
+// registers it on exactly three verbs: list, ready, search) and answers no
+// match the same way — `[]`, exit 0. Before this, `gc bd ready --metadata-field
+// gc.root_bead_id=<gcg root>` ran that projection against the one ledger that
+// holds no gcg- row, on the same molecule where `gc bd list` had just refused,
+// and where `gc bd ready --parent <gcg root>` refuses loudly through the by-id
+// door. One verb, two opposite failure semantics.
+func TestGcBdReadyRefusesAGraphClassProjectionOnASplitCity(t *testing.T) {
+	for name, args := range map[string][]string{
+		"ready":        {"ready", "--metadata-field", "gc.root_bead_id=gcg-abc123", "--json"},
+		"ready inline": {"ready", "--metadata-field=gc.root_bead_id=gcg-abc123", "--json"},
+		"search":       {"search", "--metadata-field", "gc.root_bead_id=gcg-abc123", "--json"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+			t.Setenv("BD_STUB_STDOUT", "[]")
+
+			var stdout, stderr bytes.Buffer
+			if code := doBd(args, &stdout, &stderr); code == 0 {
+				t.Fatalf("`gc bd %s` exited 0 with stdout=%q; that empty array is the same silent-empty `gc bd list` refuses on the same molecule",
+					strings.Join(args, " "), stdout.String())
+			}
+			if !strings.Contains(stderr.String(), "graph-class beads") {
+				t.Errorf("the refusal does not name the class that cannot be seen; stderr=%q", stderr.String())
+			}
+			if _, err := os.Stat(capture); err == nil {
+				data, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+				t.Fatalf("bd was invoked despite the refusal: %q", data)
+			}
+		})
+	}
+}
+
+// TestGcBdReadyKeepsAnsweringItsOrdinaryWorkQueries is the other half of the
+// ready guard: the work loop must not notice it.
+//
+// The pool-demand probe and the control dispatcher select on
+// `--metadata-field gc.routed_to=<pool>` / `gc.run_target=<route>`, whose
+// values are pool template names and never bead ids, and they invoke raw `bd`
+// rather than `gc bd` anyway. This pins the argv-level claim: a selector whose
+// value carries no reserved prefix is forwarded verbatim.
+func TestGcBdReadyKeepsAnsweringItsOrdinaryWorkQueries(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	t.Setenv("BD_STUB_STDOUT", "[]")
+
+	args := []string{"ready", "--metadata-field", "gc.routed_to=demo/worker", "--unassigned", "--json"}
+	var stdout, stderr bytes.Buffer
+	if code := doBd(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("doBd = %d on an ordinary pool-demand query; stderr=%q", code, stderr.String())
+	}
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("bd was not invoked for the pool-demand query: %v", err)
+	}
+	if !strings.Contains(string(data), strings.Join(args, " ")) {
+		t.Fatalf("bd received %q, want the work query forwarded verbatim", data)
+	}
+}
+
+// TestGcBdRefusalNamesTheOverride pins the minor that makes the rest usable: an
+// escape hatch nobody can find is not an escape hatch.
+//
+// The scan classifies TEXT, so a false positive is always possible — the work
+// ledger legitimately carries gcg- strings under gc.drain_control_id. An
+// operator holding one gets exit 1 and needs the way out in the message that
+// stopped them, not in the source. It is appended at the CLI seam rather than
+// inside beads.RelocatedClassRefusal because the store-level guard that shares
+// that string honors no override.
+func TestGcBdRefusalNamesTheOverride(t *testing.T) {
+	bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	t.Setenv("BD_STUB_STDOUT", "[]")
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd(bdListGraphProjection, &stdout, &stderr); code == 0 {
+		t.Fatalf("doBd exited 0; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), bdRelocatedClassOverrideEnvVar) {
+		t.Errorf("the refusal never names %s, so the operator holding a false positive has no in-band way out; stderr=%q",
+			bdRelocatedClassOverrideEnvVar, stderr.String())
+	}
+}
+
+// TestBdRelocatedClassGuardCoversEverySelectorVerb is the anti-drift pin for
+// the completeness claim on bdRelocatedClassGuardedVerbs.
+//
+// --metadata-field is the only bd read flag whose value side is a key=value
+// predicate, and it is registered on exactly three subcommands. Two of them are
+// in bdflags, so this derives the requirement from the manifest rather than
+// restating a list: if bd grows a fourth and bdflags picks it up, this fails
+// instead of the guard silently covering two thirds of its own surface.
+func TestBdRelocatedClassGuardCoversEverySelectorVerb(t *testing.T) {
+	for _, sub := range bdflags.Subcommands() {
+		if !bdflags.ValueFlags(sub)["--metadata-field"] {
+			continue
+		}
+		if _, guarded := bdRelocatedClassGuardedVerbs[sub]; !guarded {
+			t.Errorf("bd %q takes --metadata-field but is not in bdRelocatedClassGuardedVerbs, so `gc bd %s --metadata-field <k>=<relocated id>` answers the empty set against a ledger that cannot hold the rows", sub, sub)
+		}
+	}
+	// bd search is not in bdflags (the manifest is generated from the
+	// subcommands gc's own lint check walks), so it is named explicitly.
+	if _, guarded := bdRelocatedClassGuardedVerbs["search"]; !guarded {
+		t.Error("`search` takes --metadata-field (cmd/bd/search.go) and is not guarded")
 	}
 }
 

--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -161,6 +161,21 @@ func TestBdSQLRelocatedClassRefusalOnASplitCity(t *testing.T) {
 		"a flag that looks like an id": {[]string{"sql", "--json", "select 1"}, false},
 		"no args":                      {nil, false},
 
+		// `bd list` is the third ad-hoc dialect: its selector flags carry
+		// key=value predicates whose value side names ids exactly the way bd's
+		// query DSL does, and a no-match answer is `[]` with exit 0. Both
+		// spellings of every selector are covered because a guard a `=` can
+		// switch off is not a guard.
+		"list on a graph root id":              {[]string{"list", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
+		"list on a graph root id inline":       {[]string{"list", "--metadata-field=gc.root_bead_id=gcg-abc123"}, true},
+		"list on a graph id behind --json":     {[]string{"list", "--json", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
+		"list on a nudge id":                   {[]string{"list", "--metadata-field", "gc.nudge_id=gcn-1"}, true},
+		"list on a work root id":               {[]string{"list", "--metadata-field", "gc.root_bead_id=demo-abc"}, false},
+		"list with a metadata key only":        {[]string{"list", "--has-metadata-key", "gc.root_bead_id"}, false},
+		"list whose text mentions a graph id":  {[]string{"list", "--title-contains", "fix gcg-1 regression"}, false},
+		"list on a prefix continuation":        {[]string{"list", "--metadata-field", "gc.root_bead_id=gcgx-1"}, false},
+		"list on a graph id in a rig-scoped q": {[]string{"--json", "list", "--metadata-field", "gc.root_bead_id=gcg-abc123"}, true},
+
 		// A query about the work ledger that merely mentions a relocated id is
 		// answered correctly and non-emptily by bd, so it must pass.
 		"sql matching work rows that reference a graph id": {[]string{"sql", "select id from issues where metadata like '%gcg-abc%'"}, false},
@@ -233,6 +248,8 @@ func TestBdSQLRelocatedClassRefusalIsInertOnASingleStoreCity(t *testing.T) {
 		"sql":                    {"sql", "select * from issues where id = 'gcg-abc'"},
 		"sql behind a root flag": {"--json", "sql", "select * from issues where id = 'gcg-abc'"},
 		"query":                  {"query", "id=gcg-abc"},
+		"list":                   {"list", "--metadata-field", "gc.root_bead_id=gcg-abc"},
+		"list inline":            {"list", "--metadata-field=gc.root_bead_id=gcg-abc"},
 		"unrecognized flag":      {"--frobnicate", "x", "sql", "select * from issues where id = 'gcg-abc'"},
 	}
 	for name, cfg := range map[string]*config.City{
@@ -305,7 +322,11 @@ dolt.auto-start: false
 
 	binDir := t.TempDir()
 	capture = filepath.Join(t.TempDir(), "bd-invocation.txt")
-	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"${CAPTURE_PATH}\"\n"), 0o755); err != nil {
+	// The stub records every invocation and, when BD_STUB_STDOUT is set, answers
+	// with that body and exit 0 — which is how a projection's confident empty
+	// answer (`[]`, exit 0) is reproduced without a real ledger. It exits 0
+	// explicitly so an unset BD_STUB_STDOUT does not leak the test's exit code.
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"${CAPTURE_PATH}\"\nif [ -n \"${BD_STUB_STDOUT}\" ]; then printf '%s\\n' \"${BD_STUB_STDOUT}\"; fi\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -389,6 +410,147 @@ func TestGcBdQueryRefusesAGraphClassQueryOnASplitCity(t *testing.T) {
 	}
 	if _, err := os.Stat(capture); err == nil {
 		t.Fatal("bd was invoked despite the refusal")
+	}
+}
+
+// bdListGraphProjection is win-mc-forge's measurement row #2, verbatim: a
+// set-returning `gc bd list` whose selector names a graph-class molecule root.
+var bdListGraphProjection = []string{"list", "--metadata-field", "gc.root_bead_id=gcg-abc123", "--json"}
+
+// TestGcBdListRefusesAGraphClassProjectionOnASplitCity is the measurement this
+// whole program started from, as a test.
+//
+// On a converged split city the command below answered `[]` with exit 0. Every
+// piece of that was working as designed: the guard was scoped to `sql`/`query`,
+// --metadata-field is not an id-valued flag so cmd_bd_by_id.go's by-id door
+// never fired, and bd ran the projection successfully against the one ledger
+// that holds no gcg- row. The value named an id, but the VERB is a projection —
+// and a projection that cannot see a class must fail loudly rather than answer
+// with the empty set (ga-iaj7k Invariant 0).
+//
+// The stub answers `[]` and exits 0, so this test fails in exactly the shape the
+// live city produced if the guard is removed: a well-formed empty array,
+// indistinguishable from "this molecule has no members".
+func TestGcBdListRefusesAGraphClassProjectionOnASplitCity(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	t.Setenv("BD_STUB_STDOUT", "[]")
+
+	var stdout, stderr bytes.Buffer
+	code := doBd(bdListGraphProjection, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("`gc bd %s` exited 0 with stdout=%q; that empty array is the silent-empty this refusal exists to remove", strings.Join(bdListGraphProjection, " "), stdout.String())
+	}
+	for _, want := range []string{"graph-class beads", `"gcg-"`, "gc beads show <id>", "gc ready --metadata-field"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("refusal is missing %q; stderr=%q", want, stderr.String())
+		}
+	}
+	if _, err := os.Stat(capture); err == nil {
+		data, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+		t.Fatalf("bd was invoked despite the refusal: %q", data)
+	}
+}
+
+// TestGcBdProjectionsAgreeOnAClassTheyCannotSee is the coherence assertion, and
+// it is the reason this fix is not just "one more guarded verb".
+//
+// `gc bd dep tree <gcg id>` and `gc bd list --metadata-field <k>=<gcg id>` are
+// two projections over the same data, asked through the same command, on the
+// same city. Before this change they disagreed about what happens when the class
+// cannot be seen: dep tree refused with exit 1 while list answered `[]` with exit
+// 0. Two failure semantics for one fact is worse than either one alone, because
+// an operator who learned the loud one trusts the quiet one.
+//
+// The assertion is the correspondence, not the wording: BOTH exit non-zero,
+// BOTH name the id namespace that cannot be seen AND the binding it is served
+// from, and NEITHER reaches the ledger that cannot answer. Those three are what
+// an operator needs and what a script can rely on.
+//
+// The two messages are deliberately not compared verbatim, because they are
+// produced by different arms answering different questions and the difference
+// is real: `dep tree` is refused by the by-id door, which knows the exact bead
+// and reports OWNERSHIP of it, while `list` is refused by the dialect guard,
+// which knows only that the query names the namespace and reports that. Pinning
+// identical wording would force one arm to say something it does not know.
+func TestGcBdProjectionsAgreeOnAClassTheyCannotSee(t *testing.T) {
+	for name, args := range map[string][]string{
+		"dep tree": {"dep", "tree", "gcg-abc123"},
+		"list":     bdListGraphProjection,
+	} {
+		t.Run(name, func(t *testing.T) {
+			capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+			t.Setenv("BD_STUB_STDOUT", "[]")
+			resetCLIStorageRoutes(t)
+			captureCLIStorageStderr(t)
+
+			var stdout, stderr bytes.Buffer
+			if code := doBd(args, &stdout, &stderr); code == 0 {
+				t.Fatalf("doBd(%v) exited 0; stdout=%q", args, stdout.String())
+			}
+			for _, want := range []string{"gcg", "infra"} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Errorf("the refusal does not name %q — the namespace that cannot be seen and the binding it is served from; stderr=%q", want, stderr.String())
+				}
+			}
+			if data, err := os.ReadFile(capture); err == nil && strings.Contains(string(data), strings.Join(args, " ")) {
+				t.Fatalf("the blind projection was forwarded to bd: %q", data)
+			}
+		})
+	}
+}
+
+// TestGcBdListIsUnchangedOnASingleStoreCity is the mutation proof for the new
+// arm: the exact invocation a split city refuses reaches bd verbatim, and
+// answers, when nothing has been relocated.
+func TestGcBdListIsUnchangedOnASingleStoreCity(t *testing.T) {
+	capture := bdSQLRefusalCity(t, "")
+	t.Setenv("BD_STUB_STDOUT", "[]")
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd(bdListGraphProjection, &stdout, &stderr); code != 0 {
+		t.Fatalf("doBd = %d on a single-store city; stderr=%q", code, stderr.String())
+	}
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("bd was not invoked on a single-store city: %v", err)
+	}
+	if !strings.Contains(string(data), strings.Join(bdListGraphProjection, " ")) {
+		t.Fatalf("bd received %q, want the projection forwarded verbatim", data)
+	}
+	if strings.TrimSpace(stdout.String()) != "[]" {
+		t.Fatalf("stdout = %q, want bd's own answer passed through untouched", stdout.String())
+	}
+}
+
+// TestGcBdListOverrideRunsTheProjectionLoudly pins the escape hatch on the arm
+// that needs it most.
+//
+// The work ledger legitimately carries gcg- strings in its metadata —
+// ensureDrainUnitConvoy stamps gc.drain_control_id = <graph control id> on a
+// convoy coordclass deliberately keeps work-class — so a
+// `--metadata-field gc.drain_control_id=gcg-…` projection is a real question
+// about real work rows, and indistinguishable from a class-scoped one by text.
+// The operator says "I know, run it", and gc says so on stderr rather than
+// letting the override be silent.
+func TestGcBdListOverrideRunsTheProjectionLoudly(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	t.Setenv(bdRelocatedClassOverrideEnvVar, "1")
+	t.Setenv("BD_STUB_STDOUT", "[]")
+
+	args := []string{"list", "--metadata-field", "gc.drain_control_id=gcg-abc123", "--json"}
+	var stdout, stderr bytes.Buffer
+	if code := doBd(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("doBd = %d with the override set; stderr=%q", code, stderr.String())
+	}
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("bd was not invoked with the override set: %v", err)
+	}
+	if !strings.Contains(string(data), strings.Join(args, " ")) {
+		t.Fatalf("bd received %q, want the unmodified projection", data)
+	}
+	if !strings.Contains(stderr.String(), bdRelocatedClassOverrideEnvVar) {
+		t.Errorf("override was honored silently; stderr=%q", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -245,14 +245,15 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// `gc bd sql` and `gc bd query` are passthroughs to bd, and bd answers about
-	// the bd ledger only. On a split city a read that names a relocated class's
-	// beads comes back empty and exit 0 — a confident wrong answer, and the one
-	// that reported live molecule roots as missing. Refuse it here, where the
-	// class routing is known; bd cannot know a class was relocated.
+	// `gc bd sql`, `gc bd query` and the selector verbs (`list`, `ready`,
+	// `search`) are passthroughs to bd, and bd answers about the bd ledger only.
+	// On a split city a read that names a relocated class's beads comes back
+	// empty and exit 0 — a confident wrong answer, and the one that reported
+	// live molecule roots as missing. Refuse it here, where the class routing is
+	// known; bd cannot know a class was relocated.
 	if msg, blind := bdSQLRelocatedClassRefusal(cfg, bdArgs); blind {
 		if !bdRelocatedClassOverrideEnabled() {
-			fmt.Fprintf(stderr, "gc bd: %s\n", msg) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc bd: %s.%s\n", msg, bdRelocatedClassEscapeHint()) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		// Overridden, but never silently: the operator asked for a read this

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -96,10 +96,17 @@ package main
 // nothing about what this surface implements.
 //
 // Ownership is read from an id in an ID POSITION and never from an id-shaped
-// value. A `gc bd list --metadata-field workflow_id=gcg-…` probe is a work
-// question that quotes a class id: the work store answers for its own rows and
-// must keep doing so. A `--parent gcg-…` names a class bead, and letting the
+// value. A `gc bd list --metadata-field workflow_id=gcg-…` probe quotes a class
+// id rather than addressing one, so this surface declines it — OWNERSHIP is not
+// what is wrong with it. A `--parent gcg-…` names a class bead, and letting the
 // work store answer that returns a silent empty result.
+//
+// Declining is not forwarding. That same selector is refused one pre-flight
+// earlier, by bd_relocated_classes.go, and for a different reason: `list` is a
+// PROJECTION over a class this ledger cannot see, so its `[]` is a confident
+// wrong answer whatever the id's position. The two doors ask different
+// questions — "who owns this bead" and "can this ledger answer this verb at
+// all" — and only the first one is answered here.
 //
 // # What entering costs, and who pays it
 //
@@ -785,9 +792,16 @@ func bdByIDRefusedVerb(bdArgs []string) string {
 //
 // An id is ADDRESSED when it is a positional token, or the value of a flag that
 // takes a bead id. It is merely QUOTED when it is the value of any other flag,
-// and a quoted id decides nothing: `gc bd list --metadata-field
-// workflow_id=gcg-…` is a work question about work rows, and refusing it
-// exec-fails the consumer that asks it.
+// and a quoted id decides nothing ABOUT OWNERSHIP: `gc bd list --metadata-field
+// workflow_id=gcg-…` selects work rows by a field they carry, so no bead of the
+// relocated class is being addressed and this walk returns false for it.
+//
+// False here does not mean forwarded. The selector dialect guard in
+// bd_relocated_classes.go runs first and refuses that same argv on servability
+// — a projection whose predicate names a namespace this ledger holds no row
+// under cannot answer it, and `[]` is a confident wrong answer. What this walk
+// must not do is claim OWNERSHIP from a quoted id, because that decides which
+// STORE serves the read, and a quoted id says nothing about that.
 //
 // The value/positional split comes from bdflags — the tree's own manifest of
 // what each subcommand's flags consume — rather than from a local list, so a

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -89,6 +89,7 @@ func TestSplitTopologyConformance(t *testing.T) {
 	t.Run("I11-read-path-consistency", func(t *testing.T) { forEachTopology(t, conformanceReadPathConsistency) })
 	t.Run("I12-molecule-membership", func(t *testing.T) { forEachTopology(t, conformanceMoleculeMembership) })
 	t.Run("I13-cli-ready-federation", func(t *testing.T) { forEachTopologyWithRig(t, conformanceCLIReadyFederation) })
+	t.Run("I14-projection-coherence", func(t *testing.T) { forEachTopology(t, conformanceProjectionCoherence) })
 }
 
 // conformanceReadyFederation (I1) guards the "no work" fail-open: a worker
@@ -1234,6 +1235,14 @@ func splitEnvPoolSessionBead(qualified, sessionName string) beads.Bead {
 // projection that cannot see a class must ERROR, not return [] — and it is not
 // closed. When it closes, the split arm below flips from "0 members" to "an
 // error naming the class", and both arms move together.
+//
+// The gap here is the OBJECT-MODEL one and I14 did not close it. I14 closed the
+// CLI half — `gc bd list --metadata-field gc.root_bead_id=<root>` refuses
+// instead of answering [] — by classifying the argv before any store is opened.
+// This half is a beads.DirectMembers call handed the wrong store, and nothing in
+// that signature says which classes the store serves, so closing it means giving
+// a store the ability to refuse a class it does not hold. That is a behavior
+// change on every DirectMembers consumer, not a read-path guard.
 func conformanceMoleculeMembership(t *testing.T, e splitEnv) {
 	front := e.graphStore()
 	root := mintDurableGraphBead(t, e, "membership molecule root", "")
@@ -1517,6 +1526,124 @@ func apiReadyBody(t *testing.T, e splitEnv) apiReadyListBody {
 		t.Fatalf("decode /beads/ready: %v (body=%q)", err, rec.Body.String())
 	}
 	return body
+}
+
+// conformanceProjectionCoherence (I14) pins that the two `gc bd` PROJECTIONS
+// over a molecule agree about what happens when the class cannot be seen.
+//
+// The bug is win-mc-forge's measurement row #2, and it survived the by-id lane
+// because it does not look like a by-id read. On a converged split city:
+//
+//	gc bd dep tree <gcg root>                          → exit 1, refused
+//	gc bd list --metadata-field gc.root_bead_id=<root> → 0 rows, exit 0
+//
+// Two projections, the same molecule, the same command, opposite failure
+// semantics. `dep tree` names the bead in an id POSITION so the by-id door
+// decides ownership and refuses; --metadata-field is not id-valued, so that door
+// correctly declines (a QUOTED id decides nothing about ownership — see
+// cmd_bd_by_id.go) and the passthrough asks the one ledger that holds no gcg-
+// row, which answers `[]` and exits 0. The value named an id; the VERB is a
+// projection. Invariant 0 of ga-iaj7k: a projection that cannot see a class must
+// fail LOUDLY, and `[]` is forbidden.
+//
+// The asymmetry is what makes it urgent rather than merely wrong. An operator
+// who has learned that this CLI refuses what it cannot see reads the empty array
+// as a fact about the molecule.
+//
+// # What this asserts, and why on the argv predicates
+//
+// The two fates are decided before any store is touched, by two pure functions
+// of (config, argv): bdSQLRelocatedClassRefusal for `list` and
+// bdArgsNameClassOwnedBead for every other verb. So the coherence claim is
+// checkable exactly where it is decided, and the row runs on both topologies
+// without opening a binding. The end-to-end proof through the real command —
+// real doBd, real refusals, a bd stub that answers `[]` and exits 0 — is
+// TestGcBdProjectionsAgreeOnAClassTheyCannotSee.
+//
+// # The single-store row is the byte-identity claim
+//
+// It is not a formality and it is not hardcoded: the fixture mints work-prefixed
+// ids on that topology, so the SAME two argvs carry no reserved prefix, name no
+// relocated class, and both projections pass through to bd exactly as a legacy
+// city always ran them. A guard that started refusing there would fail here
+// first.
+//
+// # A refusal has to be actionable
+//
+// Loud is necessary and not sufficient: refusing a question nothing can answer
+// just moves the dead end. So the last leg asserts the way OUT that the refusal
+// names — the federated `gc ready` reader — returns the molecule's members on
+// BOTH topologies, from the store that owns them.
+func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
+	root := mintDurableGraphBead(t, e, "projection coherence molecule root", "")
+	step, err := e.graphStore().Create(beads.Bead{
+		Title:    "graph step carrying the root id",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("create molecule step: %v", err)
+	}
+	// A work-store bead under a DIFFERENT root: without it a projection that
+	// returned everything would pass the last leg.
+	decoy, err := e.work.Create(beads.Bead{
+		Title:    "work bead under another root",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "gc-some-other-root"},
+	})
+	if err != nil {
+		t.Fatalf("create decoy work bead: %v", err)
+	}
+
+	listArgs := []string{"list", "--metadata-field", beadmeta.RootBeadIDMetadataKey + "=" + root.ID, "--json"}
+	depTreeArgs := []string{"dep", "tree", root.ID}
+
+	// `dep tree` must stay UNSERVED in process, or the arm being compared here is
+	// not the refusal arm and the coherence claim is about something else.
+	if _, served := parseBdByIDOp(depTreeArgs); served {
+		t.Fatalf("`gc bd dep tree` is now served in process; I14 compares the REFUSAL arms, so re-point this row at the served answer")
+	}
+
+	msg, listRefused := bdSQLRelocatedClassRefusal(e.cfg, listArgs)
+	_, depTreeRefused := bdArgsNameClassOwnedBead(depTreeArgs)
+
+	if listRefused != depTreeRefused {
+		t.Fatalf("`gc bd list --metadata-field %s=%s` refused = %v but `gc bd dep tree %s` refused = %v on the same molecule; two projections over the same data must not disagree about what happens when a class cannot be seen",
+			beadmeta.RootBeadIDMetadataKey, root.ID, listRefused, root.ID, depTreeRefused)
+	}
+	if listRefused != e.split {
+		t.Fatalf("the projections over %s refused = %v on a split=%v city; a relocated class must refuse and a legacy city must pass through byte-identically", root.ID, listRefused, e.split)
+	}
+	if e.split {
+		// Loud is not enough: the refusal has to say which class, where it is
+		// served, and what to run instead.
+		for _, want := range []string{"graph-class beads", `"gcg-"`, splitEnvBinding, "gc ready --metadata-field"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("the list refusal does not name %q: %s", want, msg)
+			}
+		}
+	}
+
+	// The way out the refusal names, on both topologies.
+	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
+	rows, err := readyBeadsForOpts(legs, readyOpts{
+		status:         "open",
+		metadataFields: []string{beadmeta.RootBeadIDMetadataKey + "=" + root.ID},
+	})
+	if err != nil {
+		t.Fatalf("the federated reader the refusal steers to failed: %v", err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+	if !containsString(ids, step.ID) {
+		t.Errorf("`gc ready --metadata-field %s=%s` = %v, missing the molecule step %s; the refusal steers operators here, so an empty answer here is the original bug one command over",
+			beadmeta.RootBeadIDMetadataKey, root.ID, ids, step.ID)
+	}
+	if containsString(ids, decoy.ID) {
+		t.Errorf("the federated reader returned %s, which carries a different root id; the metadata filter is not filtering", decoy.ID)
+	}
 }
 
 // fixtureGraphLeg resolves the fixture's graph leg through the SAME identity

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -1568,12 +1568,25 @@ func apiReadyBody(t *testing.T, e splitEnv) apiReadyListBody {
 // city always ran them. A guard that started refusing there would fail here
 // first.
 //
-// # A refusal has to be actionable
+// # A refusal has to be actionable, and honest about how far it goes
 //
 // Loud is necessary and not sufficient: refusing a question nothing can answer
-// just moves the dead end. So the last leg asserts the way OUT that the refusal
+// just moves the dead end. So the last legs assert the way OUT that the refusal
 // names — the federated `gc ready` reader — returns the molecule's members on
 // BOTH topologies, from the store that owns them.
+//
+// They also assert its LIMIT, on a molecule that is not all open, because the
+// modal case is a stuck one: a molecule with no claimable step is exactly the
+// molecule an operator lists, and the escape's default spelling returns []
+// there. The refusal text states that (one status per invocation, no --all, no
+// deferred) and this row is what keeps the statement true — a fixture where
+// every step is open would let the steering silently become wrong again.
+//
+// # The verbs move together
+//
+// `ready` is asserted alongside `list` because they take the SAME selector and
+// answer no-match the same way. Guarding one and not the other reproduces the
+// asymmetry this invariant exists to forbid, one verb over.
 func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
 	root := mintDurableGraphBead(t, e, "projection coherence molecule root", "")
 	step, err := e.graphStore().Create(beads.Bead{
@@ -1583,6 +1596,21 @@ func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
 	})
 	if err != nil {
 		t.Fatalf("create molecule step: %v", err)
+	}
+	// A mid-flight sibling: the molecule is not all-open, which is the state a
+	// stuck one is actually in when someone reaches for `bd list`. Stores mint
+	// every bead open, so the status is a second write.
+	inFlight, err := e.graphStore().Create(beads.Bead{
+		Title:    "graph step already claimed",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("create in-flight molecule step: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := e.graphStore().Update(inFlight.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("put the molecule step in flight: %v", err)
 	}
 	// A work-store bead under a DIFFERENT root: without it a projection that
 	// returned everything would pass the last leg.
@@ -1595,7 +1623,9 @@ func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
 		t.Fatalf("create decoy work bead: %v", err)
 	}
 
-	listArgs := []string{"list", "--metadata-field", beadmeta.RootBeadIDMetadataKey + "=" + root.ID, "--json"}
+	selector := beadmeta.RootBeadIDMetadataKey + "=" + root.ID
+	listArgs := []string{"list", "--metadata-field", selector, "--json"}
+	readyArgs := []string{"ready", "--metadata-field", selector, "--json"}
 	depTreeArgs := []string{"dep", "tree", root.ID}
 
 	// `dep tree` must stay UNSERVED in process, or the arm being compared here is
@@ -1605,19 +1635,28 @@ func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
 	}
 
 	msg, listRefused := bdSQLRelocatedClassRefusal(e.cfg, listArgs)
+	_, readyRefused := bdSQLRelocatedClassRefusal(e.cfg, readyArgs)
 	_, depTreeRefused := bdArgsNameClassOwnedBead(depTreeArgs)
 
 	if listRefused != depTreeRefused {
-		t.Fatalf("`gc bd list --metadata-field %s=%s` refused = %v but `gc bd dep tree %s` refused = %v on the same molecule; two projections over the same data must not disagree about what happens when a class cannot be seen",
-			beadmeta.RootBeadIDMetadataKey, root.ID, listRefused, root.ID, depTreeRefused)
+		t.Fatalf("`gc bd list --metadata-field %s` refused = %v but `gc bd dep tree %s` refused = %v on the same molecule; two projections over the same data must not disagree about what happens when a class cannot be seen",
+			selector, listRefused, root.ID, depTreeRefused)
+	}
+	if readyRefused != listRefused {
+		t.Fatalf("`gc bd ready --metadata-field %s` refused = %v but `gc bd list` with the same selector refused = %v; the two verbs take the same predicate and answer no-match the same way, so guarding one moves the silent empty rather than removing it",
+			selector, readyRefused, listRefused)
 	}
 	if listRefused != e.split {
 		t.Fatalf("the projections over %s refused = %v on a split=%v city; a relocated class must refuse and a legacy city must pass through byte-identically", root.ID, listRefused, e.split)
 	}
 	if e.split {
 		// Loud is not enough: the refusal has to say which class, where it is
-		// served, and what to run instead.
-		for _, want := range []string{"graph-class beads", `"gcg-"`, splitEnvBinding, "gc ready --metadata-field"} {
+		// served, what to run instead, and how far that gets.
+		for _, want := range []string{
+			"graph-class beads", `"gcg-"`, splitEnvBinding,
+			"gc ready --metadata-field",
+			"with no --status it returns only claimable work",
+		} {
 			if !strings.Contains(msg, want) {
 				t.Errorf("the list refusal does not name %q: %s", want, msg)
 			}
@@ -1626,23 +1665,38 @@ func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
 
 	// The way out the refusal names, on both topologies.
 	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
-	rows, err := readyBeadsForOpts(legs, readyOpts{
-		status:         "open",
-		metadataFields: []string{beadmeta.RootBeadIDMetadataKey + "=" + root.ID},
-	})
-	if err != nil {
-		t.Fatalf("the federated reader the refusal steers to failed: %v", err)
+	readyIDs := func(status string) []string {
+		t.Helper()
+		rows, err := readyBeadsForOpts(legs, readyOpts{status: status, metadataFields: []string{selector}})
+		if err != nil {
+			t.Fatalf("the federated reader the refusal steers to failed on --status %q: %v", status, err)
+		}
+		ids := make([]string, 0, len(rows))
+		for _, row := range rows {
+			ids = append(ids, row.ID)
+		}
+		return ids
 	}
-	ids := make([]string, 0, len(rows))
-	for _, row := range rows {
-		ids = append(ids, row.ID)
+
+	open := readyIDs("open")
+	if !containsString(open, step.ID) {
+		t.Errorf("`gc ready --metadata-field %s --status open` = %v, missing the molecule step %s; the refusal steers operators here, so an empty answer here is the original bug one command over",
+			selector, open, step.ID)
 	}
-	if !containsString(ids, step.ID) {
-		t.Errorf("`gc ready --metadata-field %s=%s` = %v, missing the molecule step %s; the refusal steers operators here, so an empty answer here is the original bug one command over",
-			beadmeta.RootBeadIDMetadataKey, root.ID, ids, step.ID)
-	}
-	if containsString(ids, decoy.ID) {
+	if containsString(open, decoy.ID) {
 		t.Errorf("the federated reader returned %s, which carries a different root id; the metadata filter is not filtering", decoy.ID)
+	}
+
+	// The limit the refusal now states, asserted rather than assumed: the
+	// spelling an operator copies verbatim cannot see a step that is already in
+	// flight, and reaching it takes a second invocation naming its status.
+	if bare := readyIDs(""); containsString(bare, inFlight.ID) {
+		t.Errorf("`gc ready --metadata-field %s` (no --status) returned the in-flight step %s; the refusal text says that spelling returns only claimable work, so either the text or this expectation is now wrong",
+			selector, inFlight.ID)
+	}
+	if byStatus := readyIDs("in_progress"); !containsString(byStatus, inFlight.ID) {
+		t.Errorf("`gc ready --metadata-field %s --status in_progress` = %v, missing %s; the refusal tells operators to enumerate a mid-flight molecule one status at a time, and this is that leg",
+			selector, byStatus, inFlight.ID)
 	}
 }
 

--- a/internal/beads/bdsql_relocation.go
+++ b/internal/beads/bdsql_relocation.go
@@ -125,6 +125,28 @@ func RelocatedClassesInQueryExpr(relocated []RelocatedClass, expr string) []Relo
 	return relocatedClassesNamedIn(relocated, expr, atQueryValueStart)
 }
 
+// RelocatedClassesInListSelector is the same scan for one `bd list` selector
+// argument — `--metadata-field gc.root_bead_id=gcg-abc`, `--id gcg-abc`, and
+// the rest of the key=value predicates bd list accepts.
+//
+// It shares atQueryValueStart with the query DSL because the two dialects pose
+// the same question in the same shape: a comparison whose VALUE side names an
+// id. The difference is only where the text comes from — one expression for
+// `bd query`, one token per selector flag for `bd list` — so a whole-token
+// value (`--id gcg-abc`) anchors at offset 0 and a value quoted inside prose
+// (`--title-contains "fix gcg-1 regression"`) does not anchor at all, which is
+// exactly the split the anchor rule already draws.
+//
+// It is named separately rather than aliased at the call site because `list` is
+// a PROJECTION, not an ad-hoc read: bd runs it successfully against the work
+// ledger and answers `[]` with exit 0 for a class that ledger does not serve,
+// which is the same confident empty answer the sql/query guard exists for, and
+// naming the dialect keeps that reason at the definition instead of in a
+// comment on a map entry.
+func RelocatedClassesInListSelector(relocated []RelocatedClass, selector string) []RelocatedClass {
+	return relocatedClassesNamedIn(relocated, selector, atQueryValueStart)
+}
+
 // relocatedClassesNamedIn is the shared scan. anchored decides what counts as
 // an id-shaped position for the dialect being scanned; everything else — the
 // case folding, the trailing-boundary rule, the per-class loop — is common.
@@ -249,6 +271,20 @@ func isIDBodyByte(b byte) bool {
 // lane does. `gc bd dep tree <id>` is not served there, and on a relocated id
 // that surface refuses it rather than forwarding it, so it is named as
 // unavailable rather than offered as an escape.
+//
+// The set-returning escape is named too, because a by-ID read is no answer at
+// all to a refused PROJECTION: an operator listing a molecule's members by
+// gc.root_bead_id has no single id to show. `gc ready` federates the city
+// store, the rig stores and the relocated binding as ordered legs and fails
+// loud on any leg it cannot read (cmd/gc/ready_federation.go), so it answers a
+// class-scoped question without a controller.
+//
+// `gc beads list` is deliberately NOT offered, under the same rule that keeps a
+// blind verb out of this message. Its API lane federates, but its fallback lane
+// opens the city and rig stores only (openAllConvoyStoresAt) — so on a city
+// whose controller is down it would return exactly the confident empty answer
+// being refused here, and the operator hitting this at 2am is often hitting it
+// BECAUSE the controller is down.
 func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 	if len(matched) == 0 {
 		return nil
@@ -271,6 +307,9 @@ func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 		"`gc bd show <id>`, which answers a reserved-prefix id in process from the binding its class is served from "+
 		"and needs no controller, or with `gc beads show <id>`, which routes by class through the controller API "+
 		"(GET /v0/city/{cityName}/bead/{id}) and falls back to a work-store scan when no controller is reachable. "+
+		"For a SET of beads rather than one id, use `gc ready --metadata-field \"key=value\" [--status <status>]`, "+
+		"which federates the city store, the rig stores and the relocated binding as ordered legs and fails loud on a "+
+		"leg it cannot read. "+
 		"`gc bd dep tree <id>` is not served in process; on a relocated id it is refused rather than answered from this ledger",
 		ErrBdSQLClassRelocated, op, strings.Join(parts, "; "))
 }

--- a/internal/beads/bdsql_relocation.go
+++ b/internal/beads/bdsql_relocation.go
@@ -9,7 +9,8 @@ import (
 
 // Why this guard exists.
 //
-// `bd sql` and `bd query` run against the bd ledger this scope's .beads/ names,
+// `bd sql`, `bd query` and the selector-flag verbs (`bd list`, `bd ready`,
+// `bd search`) run against the bd ledger this scope's .beads/ names,
 // and nothing else. A relocated coordination class is served from a store that
 // ledger's metadata never mentions — a SQLite file bd has no backend for
 // (storage: Dolt/embedded-Dolt/dbproxy), or a different beads workspace with a
@@ -26,11 +27,12 @@ import (
 //
 // The refusal is deliberately narrow. It fires when a bd-ledger read puts the
 // id namespace of a class this store does not serve in an ID-SHAPED POSITION —
-// a string literal in SQL, the value side of a comparison in bd's query DSL —
-// which is the case where the empty answer is provably wrong. A statement that
-// merely mentions such an id somewhere else (a LIKE-contains over a text
-// column, a JSON metadata comparison, a comment) is a question about the rows
-// THIS ledger holds, and bd answers those correctly and often non-emptily: the
+// a string literal in SQL, the value side of a comparison in bd's query DSL,
+// the value side of a `key=value` selector predicate — which is the case where
+// the empty answer is provably wrong. A statement that merely mentions such an
+// id somewhere else (a LIKE-contains over a text column, a JSON metadata
+// comparison, a comment) is a question about the rows THIS ledger holds, and
+// bd answers those correctly and often non-emptily: the
 // work ledger really does carry gcg- strings in its metadata, because
 // ensureDrainUnitConvoy stamps gc.drain_control_id = <graph control id> onto a
 // convoy coordclass deliberately keeps work-class. Refusing those would be a
@@ -125,26 +127,43 @@ func RelocatedClassesInQueryExpr(relocated []RelocatedClass, expr string) []Relo
 	return relocatedClassesNamedIn(relocated, expr, atQueryValueStart)
 }
 
-// RelocatedClassesInListSelector is the same scan for one `bd list` selector
-// argument — `--metadata-field gc.root_bead_id=gcg-abc`, `--id gcg-abc`, and
-// the rest of the key=value predicates bd list accepts.
+// RelocatedClassesInSelector is the same scan for one selector argument of the
+// flag dialect `bd list`, `bd ready` and `bd search` share —
+// `--metadata-field gc.root_bead_id=gcg-abc` and the rest of the key=value
+// predicates those verbs accept.
 //
-// It shares atQueryValueStart with the query DSL because the two dialects pose
-// the same question in the same shape: a comparison whose VALUE side names an
-// id. The difference is only where the text comes from — one expression for
-// `bd query`, one token per selector flag for `bd list` — so a whole-token
-// value (`--id gcg-abc`) anchors at offset 0 and a value quoted inside prose
-// (`--title-contains "fix gcg-1 regression"`) does not anchor at all, which is
-// exactly the split the anchor rule already draws.
+// It does NOT share atQueryValueStart with the query DSL, and that is the whole
+// of the dialect. In `bd query` one token is a whole expression, so an id at
+// offset 0 is a value position (`bd query gcg-1` is a bare term). In this
+// dialect the flag has already consumed its own token, so what arrives here is
+// one flag's VALUE — and `bd list` accepts no positionals at all, so there is
+// no argument that is not some flag's value. Anchoring at offset 0 would
+// therefore make EVERY selector value id-shaped: `--title-contains gcg-abc123`
+// would be indistinguishable from `--metadata-field gc.root_bead_id=gcg-abc123`
+// even though the first is a LIKE-contains over this ledger's own title column,
+// which is the first false positive the header above promises to let through.
 //
-// It is named separately rather than aliased at the call site because `list` is
-// a PROJECTION, not an ad-hoc read: bd runs it successfully against the work
-// ledger and answers `[]` with exit 0 for a class that ledger does not serve,
-// which is the same confident empty answer the sql/query guard exists for, and
-// naming the dialect keeps that reason at the definition instead of in a
-// comment on a map entry.
-func RelocatedClassesInListSelector(relocated []RelocatedClass, selector string) []RelocatedClass {
-	return relocatedClassesNamedIn(relocated, selector, atQueryValueStart)
+// So the anchor is the `=` of a key=value predicate, and nothing else. That is
+// the shape that makes an empty answer provably wrong: the selector asks bd for
+// rows whose field EQUALS an id no row here can carry. A whole-token value is a
+// search term over a column this ledger owns and passes, wherever the id sits
+// in it.
+//
+// The two id-VALUED selectors that look like a hole — `--id`, `--parent`/`-p` —
+// are not one. Ownership of an ADDRESSED id is decided before servability, by
+// the by-id door in cmd/gc/cmd_bd_by_id.go, which already refuses them and
+// names the bead and its binding rather than only the namespace. Anchoring at
+// offset 0 to catch them here would shadow that more specific refusal with a
+// vaguer one and buy no coverage.
+//
+// The dialect is named separately rather than aliased at the call site because
+// these verbs are PROJECTIONS, not ad-hoc reads: bd runs one successfully
+// against the work ledger and answers `[]` with exit 0 for a class that ledger
+// does not serve, which is the same confident empty answer the sql/query guard
+// exists for, and naming the dialect keeps that reason at the definition
+// instead of in a comment on a map entry.
+func RelocatedClassesInSelector(relocated []RelocatedClass, selector string) []RelocatedClass {
+	return relocatedClassesNamedIn(relocated, selector, atSelectorValueStart)
 }
 
 // relocatedClassesNamedIn is the shared scan. anchored decides what counts as
@@ -235,6 +254,34 @@ func atQueryValueStart(text string, at int) bool {
 	}
 }
 
+// atSelectorValueStart reports whether at opens the value side of a `key=value`
+// predicate inside one selector-flag token.
+//
+// Quotes are skipped on the way back because a shell can leave them inside the
+// token bd parses (`--metadata-field 'gc.root_bead_id="gcg-1"'`), and the value
+// is the same value either way. Whitespace is skipped for the same reason it is
+// in the query DSL. Everything else — prose, punctuation, the start of the
+// token — is not a predicate, so it does not anchor: `fix (gcg-1) regression`,
+// `regressions: gcg-1, gcg-2` and a bare `gcg-abc123` are all search text.
+func atSelectorValueStart(text string, at int) bool {
+	i := at - 1
+	for i >= 0 && isSelectorValuePadding(text[i]) {
+		i--
+	}
+	return i >= 0 && text[i] == '='
+}
+
+// isSelectorValuePadding reports whether b can sit between a predicate's `=`
+// and the value it compares.
+func isSelectorValuePadding(b byte) bool {
+	switch b {
+	case ' ', '\t', '\'', '"', '`':
+		return true
+	default:
+		return false
+	}
+}
+
 // isIDBodyByte reports whether b can appear inside a bead id, which is what
 // makes a prefix match a continuation rather than a start.
 func isIDBodyByte(b byte) bool {
@@ -279,12 +326,35 @@ func isIDBodyByte(b byte) bool {
 // loud on any leg it cannot read (cmd/gc/ready_federation.go), so it answers a
 // class-scoped question without a controller.
 //
+// # And it states what that escape does NOT cover
+//
+// Steering is only worth printing if the command it names answers the question
+// that was refused, and `gc ready` answers a NARROWER one. With no --status it
+// issues a ReadyQuery — claimable, unblocked work only — so a molecule whose
+// steps are in flight, blocked or done comes back `[]` from the very command
+// this message sent the operator to, which is the refused bug one command over.
+// --status takes exactly ONE of open, in_progress, blocked, closed
+// (readyKnownStatuses); there is no `--all` and no comma list, and `deferred`
+// is not selectable at all. So the membership question `bd list --all` answers
+// in one invocation has no single federated spelling, and the message says so
+// rather than letting the operator discover it as an empty array. Overstating
+// the escape is the same failure as the silent empty: a confident answer to a
+// question that was not asked.
+//
 // `gc beads list` is deliberately NOT offered, under the same rule that keeps a
 // blind verb out of this message. Its API lane federates, but its fallback lane
 // opens the city and rig stores only (openAllConvoyStoresAt) — so on a city
 // whose controller is down it would return exactly the confident empty answer
 // being refused here, and the operator hitting this at 2am is often hitting it
 // BECAUSE the controller is down.
+//
+// # The override is named by the CLI, not here
+//
+// GC_BD_ALLOW_RELOCATED_CLASS_READ is a `gc bd` pre-flight knob and applies to
+// nothing else. This error is also returned by BdStore's own id-scoped guard,
+// where no override exists, so naming it in this shared string would advertise
+// an escape that does not work on half the paths that print it. cmd/gc appends
+// it where it is true (bdSQLRelocatedClassRefusal).
 func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 	if len(matched) == 0 {
 		return nil
@@ -307,9 +377,12 @@ func RelocatedClassRefusal(op string, matched []RelocatedClass) error {
 		"`gc bd show <id>`, which answers a reserved-prefix id in process from the binding its class is served from "+
 		"and needs no controller, or with `gc beads show <id>`, which routes by class through the controller API "+
 		"(GET /v0/city/{cityName}/bead/{id}) and falls back to a work-store scan when no controller is reachable. "+
-		"For a SET of beads rather than one id, use `gc ready --metadata-field \"key=value\" [--status <status>]`, "+
-		"which federates the city store, the rig stores and the relocated binding as ordered legs and fails loud on a "+
-		"leg it cannot read. "+
+		"For a SET of beads rather than one id, `gc ready --metadata-field \"key=value\"` federates the city store, the "+
+		"rig stores and the relocated binding as ordered legs and fails loud on a leg it cannot read — but it answers a "+
+		"NARROWER question than this read did: with no --status it returns only claimable work, and --status takes "+
+		"exactly one of open, in_progress, blocked, closed (no --all, no comma list, and deferred is not selectable), "+
+		"so enumerating a molecule's full membership takes one invocation per status and cannot reach a deferred member "+
+		"at all. There is no federated equivalent of `bd list --all` yet. "+
 		"`gc bd dep tree <id>` is not served in process; on a relocated id it is refused rather than answered from this ledger",
 		ErrBdSQLClassRelocated, op, strings.Join(parts, "; "))
 }

--- a/internal/beads/bdsql_relocation_internal_test.go
+++ b/internal/beads/bdsql_relocation_internal_test.go
@@ -37,6 +37,7 @@ func TestRelocatedClassRefusalNamesEverythingAnOperatorNeeds(t *testing.T) {
 		"cannot match here",                 // stated as a property of the prefix, not of this query's result
 		"gc beads show <id>",                // the verb that is actually class-routed
 		"GET /v0/city/{cityName}/bead/{id}", // and the route it uses
+		"gc ready --metadata-field",         // the SET-returning escape, for a refused projection
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("refusal is missing %q:\n%v", want, err)
@@ -156,6 +157,45 @@ func TestRelocatedClassesInQueryExprMatchesTheValueSide(t *testing.T) {
 	}
 }
 
+// TestRelocatedClassesInListSelectorMatchesTheSelectorValue covers the third
+// dialect, and the one that produced the measurement this guard family was
+// opened for: `gc bd list --metadata-field gc.root_bead_id=<gcg root>` answered
+// `[]` with exit 0 on a converged split city. `list` is a PROJECTION — bd runs
+// it successfully against the work ledger and matches nothing, because no gcg-
+// row is there to match — so the empty array is a confident wrong answer about
+// a class the ledger does not serve.
+//
+// The negatives matter as much as the positives: a `list` whose selector merely
+// contains a relocated id is a search over THIS ledger's own text columns and
+// must keep being answered, because refusing it would break a query bd answers
+// correctly and non-emptily.
+func TestRelocatedClassesInListSelectorMatchesTheSelectorValue(t *testing.T) {
+	relocated := []RelocatedClass{graphRelocated()}
+	for name, tc := range map[string]struct {
+		selector string
+		want     bool
+	}{
+		"metadata field on the root id":  {"gc.root_bead_id=gcg-abc123", true},
+		"metadata field on a step ref":   {"gc.step_ref=gcg-abc123.mol.work", true},
+		"whole-token id":                 {"gcg-abc123", true},
+		"quoted value":                   {`gc.root_bead_id="gcg-abc123"`, true},
+		"uppercase":                      {"gc.root_bead_id=GCG-ABC123", true},
+		"metadata field on a work root":  {"gc.root_bead_id=demo-abc123", false},
+		"metadata key with no value":     {"gc.root_bead_id", false},
+		"title search mentioning an id":  {"fix gcg-1 regression", false},
+		"prefix continuation":            {"gc.root_bead_id=gcgx-1", false},
+		"prefix without the hyphen":      {"gc.root_bead_id=gcgabc", false},
+		"a status the work store serves": {"open", false},
+		"empty":                          {"", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := len(RelocatedClassesInListSelector(relocated, tc.selector)) > 0; got != tc.want {
+				t.Fatalf("RelocatedClassesInListSelector(%q) matched = %v, want %v", tc.selector, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestRelocatedClassesInSQLIsInertWithoutRelocation is the single-store
 // compatibility proof for the text scanner: the exact query that a split city
 // refuses is not even examined when nothing is relocated.
@@ -165,6 +205,9 @@ func TestRelocatedClassesInSQLIsInertWithoutRelocation(t *testing.T) {
 	}
 	if got := RelocatedClassesInQueryExpr(nil, "id=gcg-abc"); len(got) != 0 {
 		t.Fatalf("RelocatedClassesInQueryExpr with no relocated classes matched %v, want none", got)
+	}
+	if got := RelocatedClassesInListSelector(nil, "gc.root_bead_id=gcg-abc"); len(got) != 0 {
+		t.Fatalf("RelocatedClassesInListSelector with no relocated classes matched %v, want none", got)
 	}
 }
 

--- a/internal/beads/bdsql_relocation_internal_test.go
+++ b/internal/beads/bdsql_relocation_internal_test.go
@@ -76,6 +76,50 @@ func TestRelocatedClassRefusalIsNilWhenNothingMatched(t *testing.T) {
 	}
 }
 
+// TestRelocatedClassRefusalStatesTheLimitsOfTheSetEscape is the honesty pin on
+// the one line of this message that is steering rather than diagnosis.
+//
+// Naming `gc ready --metadata-field` and stopping there sends an operator to a
+// command that answers a NARROWER question: with no --status it returns only
+// claimable work, so a molecule whose steps are in flight, blocked or closed
+// comes back `[]` — the refused bug, one command over, from the command this
+// message recommended. --status takes exactly one of open/in_progress/blocked/
+// closed (cmd/gc/cmd_ready.go readyKnownStatuses): no --all, no comma list, and
+// `deferred` is not selectable at all, so `bd list --all`'s question has no
+// federated spelling yet.
+//
+// A refusal that oversells its escape is the same failure as the silent empty
+// it exists to remove: a confident answer to a question that was not asked. So
+// the message states the limit, and this test fails if the statement is dropped.
+func TestRelocatedClassRefusalStatesTheLimitsOfTheSetEscape(t *testing.T) {
+	msg := RelocatedClassRefusal("bd list", []RelocatedClass{graphRelocated()}).Error()
+	for _, want := range []string{
+		"with no --status it returns only claimable work",
+		"exactly one of open, in_progress, blocked, closed",
+		"deferred is not selectable",
+		"no federated equivalent of `bd list --all`",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the steering does not state %q, so it oversells `gc ready` as the way out:\n%s", want, msg)
+		}
+	}
+}
+
+// TestRelocatedClassRefusalLeavesTheOverrideToTheCLI pins where the escape
+// hatch is named, and why it is not named here.
+//
+// This string is also what BdStore's id-scoped guard returns, and that path
+// honors no environment variable. Naming GC_BD_ALLOW_RELOCATED_CLASS_READ in
+// the shared text would advertise an escape that does not work on half the
+// paths that print it — a false statement of the same kind this guard exists to
+// stop. cmd/gc appends it at the one seam where it is true.
+func TestRelocatedClassRefusalLeavesTheOverrideToTheCLI(t *testing.T) {
+	msg := RelocatedClassRefusal("release-if-current gcg-abc123", []RelocatedClass{graphRelocated()}).Error()
+	if strings.Contains(msg, "GC_BD_ALLOW_RELOCATED_CLASS_READ") {
+		t.Errorf("the shared refusal names a `gc bd` override that does not apply to the store guard:\n%s", msg)
+	}
+}
+
 func TestRelocatedClassesInSQLMatchesOnlyAtIDBoundaries(t *testing.T) {
 	relocated := []RelocatedClass{graphRelocated()}
 	for name, tc := range map[string]struct {
@@ -157,7 +201,7 @@ func TestRelocatedClassesInQueryExprMatchesTheValueSide(t *testing.T) {
 	}
 }
 
-// TestRelocatedClassesInListSelectorMatchesTheSelectorValue covers the third
+// TestRelocatedClassesInSelectorMatchesOnlyThePredicateValue covers the third
 // dialect, and the one that produced the measurement this guard family was
 // opened for: `gc bd list --metadata-field gc.root_bead_id=<gcg root>` answered
 // `[]` with exit 0 on a converged split city. `list` is a PROJECTION — bd runs
@@ -165,34 +209,73 @@ func TestRelocatedClassesInQueryExprMatchesTheValueSide(t *testing.T) {
 // row is there to match — so the empty array is a confident wrong answer about
 // a class the ledger does not serve.
 //
-// The negatives matter as much as the positives: a `list` whose selector merely
-// contains a relocated id is a search over THIS ledger's own text columns and
-// must keep being answered, because refusing it would break a query bd answers
-// correctly and non-emptily.
-func TestRelocatedClassesInListSelectorMatchesTheSelectorValue(t *testing.T) {
+// The negatives matter MORE than the positives here, and they are the reason
+// this dialect does not reuse atQueryValueStart. `bd list` accepts no
+// positional arguments, so every token this scan sees is some flag's VALUE; an
+// offset-0 anchor would therefore make every free-text selector id-shaped and
+// refuse `--title-contains gcg-abc123`, a LIKE-contains over this ledger's own
+// title column that bd answers correctly and often non-emptily. So the whole
+// negative half of this table is a bare or embedded id in a value with no `=`
+// in front of it, in every spelling an operator produces — including the ones
+// with punctuation before the id, which a prose-only negative would miss.
+func TestRelocatedClassesInSelectorMatchesOnlyThePredicateValue(t *testing.T) {
 	relocated := []RelocatedClass{graphRelocated()}
 	for name, tc := range map[string]struct {
 		selector string
 		want     bool
 	}{
-		"metadata field on the root id":  {"gc.root_bead_id=gcg-abc123", true},
-		"metadata field on a step ref":   {"gc.step_ref=gcg-abc123.mol.work", true},
-		"whole-token id":                 {"gcg-abc123", true},
-		"quoted value":                   {`gc.root_bead_id="gcg-abc123"`, true},
-		"uppercase":                      {"gc.root_bead_id=GCG-ABC123", true},
+		"metadata field on the root id": {"gc.root_bead_id=gcg-abc123", true},
+		"metadata field on a step ref":  {"gc.step_ref=gcg-abc123.mol.work", true},
+		"quoted value":                  {`gc.root_bead_id="gcg-abc123"`, true},
+		"single-quoted value":           {"gc.root_bead_id='gcg-abc123'", true},
+		"spaced predicate":              {"gc.root_bead_id= gcg-abc123", true},
+		"uppercase":                     {"gc.root_bead_id=GCG-ABC123", true},
+
 		"metadata field on a work root":  {"gc.root_bead_id=demo-abc123", false},
 		"metadata key with no value":     {"gc.root_bead_id", false},
-		"title search mentioning an id":  {"fix gcg-1 regression", false},
 		"prefix continuation":            {"gc.root_bead_id=gcgx-1", false},
 		"prefix without the hyphen":      {"gc.root_bead_id=gcgabc", false},
 		"a status the work store serves": {"open", false},
 		"empty":                          {"", false},
+
+		// Every one of these is a whole free-text selector value — the shape a
+		// `--title-contains`/`--label`/`--assignee` search arrives in. All of
+		// them refused before this anchor existed.
+		"bare id as a whole selector value": {"gcg-abc123", false},
+		"bare prefix":                       {"gcg", false},
+		"label glob":                        {"gcg-*", false},
+		"title search mentioning an id":     {"fix gcg-1 regression", false},
+		"prose with a paren before the id":  {"fix (gcg-1) regression", false},
+		"prose with a comma before the id":  {"regressions: gcg-1, gcg-2", false},
+		"prose with a quote before the id":  {"root is 'gcg-1' here", false},
+		"prose with a colon before the id":  {"root: gcg-1", false},
+		"prose with an angle before the id": {"<gcg-1> is stuck", false},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if got := len(RelocatedClassesInListSelector(relocated, tc.selector)) > 0; got != tc.want {
-				t.Fatalf("RelocatedClassesInListSelector(%q) matched = %v, want %v", tc.selector, got, tc.want)
+			if got := len(RelocatedClassesInSelector(relocated, tc.selector)) > 0; got != tc.want {
+				t.Fatalf("RelocatedClassesInSelector(%q) matched = %v, want %v", tc.selector, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRelocatedClassesInSelectorDivergesFromTheQueryDialect states the split
+// between the two dialects as a fact rather than leaving it implied by two
+// tables that happen to disagree.
+//
+// `bd query` takes ONE expression, so a bare term at offset 0 is a value
+// position and `bd query gcg-1` is an id-scoped read. A selector flag has
+// already consumed its own token, so the same text arriving here is one flag's
+// search string. Same characters, different question — and reusing the query
+// anchor for selectors is exactly the bug this pins.
+func TestRelocatedClassesInSelectorDivergesFromTheQueryDialect(t *testing.T) {
+	relocated := []RelocatedClass{graphRelocated()}
+	const bare = "gcg-abc123"
+	if len(RelocatedClassesInQueryExpr(relocated, bare)) == 0 {
+		t.Errorf("RelocatedClassesInQueryExpr(%q) did not match; a bare term IS a value in the query DSL", bare)
+	}
+	if got := RelocatedClassesInSelector(relocated, bare); len(got) != 0 {
+		t.Errorf("RelocatedClassesInSelector(%q) matched %v; a whole-token selector value is a search string, and refusing it breaks `--title-contains`", bare, got)
 	}
 }
 
@@ -206,8 +289,8 @@ func TestRelocatedClassesInSQLIsInertWithoutRelocation(t *testing.T) {
 	if got := RelocatedClassesInQueryExpr(nil, "id=gcg-abc"); len(got) != 0 {
 		t.Fatalf("RelocatedClassesInQueryExpr with no relocated classes matched %v, want none", got)
 	}
-	if got := RelocatedClassesInListSelector(nil, "gc.root_bead_id=gcg-abc"); len(got) != 0 {
-		t.Fatalf("RelocatedClassesInListSelector with no relocated classes matched %v, want none", got)
+	if got := RelocatedClassesInSelector(nil, "gc.root_bead_id=gcg-abc"); len(got) != 0 {
+		t.Fatalf("RelocatedClassesInSelector with no relocated classes matched %v, want none", got)
 	}
 }
 

--- a/internal/beads/membership.go
+++ b/internal/beads/membership.go
@@ -24,10 +24,12 @@ import (
 //
 // 60 - 13 + 1 = 48, so dependency reachability returned exactly the set the
 // adopt-pr driver wanted. It did so by coincidence. Spec sidecars are built
-// with no dependency edges at all — formula.newSourceSpecStep clears
-// DependsOn, Needs and WaitsFor — and this molecule linked none of them by
-// hand, so the set dep-reachability dropped happened to equal the set the
-// consumer was filtering out anyway.
+// with no dependency edges at all — formula.newSourceSpecStep returns a fresh
+// Step literal that never SETS DependsOn, Needs or WaitsFor, and
+// formula.namespaceSourceSpecStep is the one place that actively nils them,
+// on the clone a ralph iteration re-namespaces — and this molecule linked none
+// of them by hand, so the set dep-reachability dropped happened to equal the
+// set the consumer was filtering out anyway.
 //
 // That is a property of one graph's shape, not a contract, and it fails in
 // both directions:

--- a/internal/beads/membership_test.go
+++ b/internal/beads/membership_test.go
@@ -35,8 +35,9 @@ const gcgArnRootID = "gcg-arn"
 // buildGcgArnShape reconstructs the measured gcg-arn molecule: one root, 60
 // beads carrying gc.root_bead_id == root, of which 13 are gc.kind=spec
 // sidecars with no dependency edge of any kind — the shape
-// formula.newSourceSpecStep produces, since it clears DependsOn, Needs and
-// WaitsFor on the step it serializes. The remaining 47 hang off the root
+// formula.newSourceSpecStep produces, since it builds the sidecar as a fresh
+// Step literal and never sets DependsOn, Needs or WaitsFor on it. The
+// remaining 47 hang off the root
 // through the blocks/parent-child edges molecule.Instantiate authors, so a
 // dependency walk from the root reaches 1 + 47 == gcgArnDepTreeSize beads.
 //

--- a/internal/dispatch/fanout_membership_test.go
+++ b/internal/dispatch/fanout_membership_test.go
@@ -11,8 +11,9 @@ import (
 // control dispatcher runs on. Fan-out, retry, ralph, drain and scope all
 // resolve their member set through beads.DirectMembers
 // (beads.MembershipDirectRootID), and this is why: a gc.kind=spec sidecar
-// carries the root id and NOTHING else — formula.newSourceSpecStep clears
-// DependsOn, Needs and WaitsFor — so a dependency walk cannot see it, while
+// carries the root id and NOTHING else — formula.newSourceSpecStep builds it as
+// a fresh Step literal that never sets DependsOn, Needs or WaitsFor — so a
+// dependency walk cannot see it, while
 // findSpecBead must. Swapping the fan-out's membership for dependency
 // reachability would not empty the member set; it would silently shrink it,
 // and the first symptom would be a retry that cannot find the step it is

--- a/internal/formula/source_spec.go
+++ b/internal/formula/source_spec.go
@@ -43,6 +43,15 @@ func isSourceSpecStep(step *Step) bool {
 	return isSourceSpecKind(step.Metadata[beadmeta.KindMetadataKey])
 }
 
+// namespaceSourceSpecStep re-namespaces a spec sidecar into a ralph iteration.
+//
+// The dependency fields are nilled rather than rewritten the way
+// namespaceRalphBodySteps rewrites a body step's: a spec is a SNAPSHOT of the
+// step it describes, not a node in the graph, and an edge on it would put a
+// bead with no worker in the iteration's critical path. That is also what makes
+// a spec unreachable by any dependency walk — the property beads.Membership
+// cites when it explains why direct root-id membership is the only complete
+// rule.
 func namespaceSourceSpecStep(step *Step, iterationID string) *Step {
 	clone := cloneStep(step)
 	clone.ID = iterationID + "." + step.ID


### PR DESCRIPTION
## The bug (ga-fq54n)

win-mc-forge's measurement row #2, the one that started this program, verified
still open on `f08858b8a4`. On a converged split city:

```
gc bd list --metadata-field gc.root_bead_id=<gcg root>   →   0 rows, exit 0
```

Every piece worked as designed. The dialect guard was scoped to `sql`/`query`;
`--metadata-field` is not an id-VALUED flag, so `cmd_bd_by_id.go`'s by-id door
correctly declined it (a QUOTED id decides nothing about ownership —
`cmd_bd_by_id.go:78-81`, `:830-835`); and bd then ran the projection
successfully against the one ledger that holds no `gcg-` row. The value named
an id, but the **verb is a PROJECTION** over a class this ledger cannot see.

**Invariant 0: a projection that cannot see a class MUST fail loudly.
Returning `[]` is forbidden.**

The asymmetry is what made it urgent: `gc bd dep tree <gcg id>` already
**refuses with exit 1** (`cmd_bd_by_id.go:580-586`, `:630-637`) while `list`
answered `[]` with exit 0. Two projections over the same molecule, through the
same command, with opposite failure semantics — worse than either alone,
because an operator who learned the loud one trusts the quiet one.

## The shape chosen: refuse loudly, and name the federated reader

**(b) refuse**, not (a) federate. `gc bd list` is a bd passthrough with ~40
value flags and ~23 bool flags (`internal/bdflags`), plus output shapes
(`--long`, `--tree`, `--pretty`, the human table) that cannot be reproduced in
process. Federating the representable subset would still leave every other
spelling silent — so it would need this refusal arm **anyway**, on top of a
partial in-process imitation of bd, which is precisely what
`cmd_bd_by_id.go`'s own header refuses to build ("the caller leaves it on its
existing path rather than serving a partial imitation of bd"). It would also
make split-city `gc bd list` bytes diverge from single-store bytes for the same
query, which `gc ready` never had to do because it was a new command with its
own contract.

So (a)'s *user outcome* is delivered by steering to the surface that already
has the leg composition, the fail-loud rule and CLI==API conformance: the
refusal names `gc ready --metadata-field "key=value"`, which federates
city → rigs ascending → graph last, first-leg-wins, and fails loud on a dead or
unopenable leg (`cmd/gc/ready_federation.go`, #5158) — **and the message states
exactly how far that gets**, because it answers a narrower question than the
read it replaces (see "The steering is honest about its limit" below).
`gc beads list` is deliberately **not** offered: its API lane federates, but
its no-controller fallback opens only the city and rig stores
(`openAllConvoyStoresAt`), so it would hand back the same blind answer this
message is refusing — and an operator hits this at 2am often *because* the
controller is down.

`list`, `ready` and `search` join the existing dialect guard rather than
growing a new mechanism. The argv scan now also reads a flag's **inline**
value, so `--metadata-field=k=gcg-1` cannot switch the guard off with a
single `=`. The
pre-existing `GC_BD_ALLOW_RELOCATED_CLASS_READ` override still covers the real
false positive (the work ledger legitimately carries `gcg-` strings in
metadata — `ensureDrainUnitConvoy` stamps `gc.drain_control_id`), and honoring
it stays loud.

## The two projections now agree

| invocation | before | after |
| --- | --- | --- |
| `gc bd dep tree gcg-abc123` | exit 1, refused | exit 1, refused (unchanged) |
| `gc bd list --metadata-field gc.root_bead_id=gcg-abc123 --json` | **`[]`, exit 0** | exit 1, refused |

Both exit non-zero, both name the id namespace that cannot be seen **and** the
binding it is served from, and neither reaches the ledger that cannot answer.
`I14-projection-coherence` asserts that correspondence on **both** topologies
from the two production predicates that decide it
(`bdSQLRelocatedClassRefusal` for `list`, `bdArgsNameClassOwnedBead` for
everything else), and `TestGcBdProjectionsAgreeOnAClassTheyCannotSee` drives it
end to end through the real `doBd` against a bd stub that answers `[]` and
exits 0.

The messages are deliberately not compared verbatim: `dep tree` is refused by
the by-id door, which knows the exact bead and reports OWNERSHIP of it, while
`list` is refused by the dialect guard, which knows only that the query names
the namespace. Pinning identical wording would force one arm to say something
it does not know.

## Single-store cities are byte-identical, proven by mutation

`relocatedBeadClasses` returns nothing on a city with no `[storage]` split, the
scan is never entered, and the same argv reaches bd verbatim
(`TestGcBdListIsUnchangedOnASingleStoreCity` asserts bd received the exact
projection and that stdout is bd's own answer untouched). I14's single-store
row is not hardcoded: the fixture mints work-prefixed ids there, so the same
two argvs carry no reserved prefix and both projections pass through.

Mutations run, all of which turn the new rows red:

* removing the `"list"` entry from `bdRelocatedClassGuardedVerbs` → 5 table
  rows + 3 end-to-end tests + I14's split row fail
* reverting the inline-value scan → `list on a graph root id inline` fails
* removing `"ready"`/`"search"` → 3 table rows, 3 end-to-end rows,
  `TestBdRelocatedClassGuardCoversEverySelectorVerb` and I14's split row fail
* reverting `atSelectorValueStart` to `atQueryValueStart` → 8 internal rows,
  15 table rows and 8 end-to-end rows fail

## Stale docs in the same files (ga-kqk8j)

1. `cmd/gc/bd_relocated_classes.go` still claimed `show`/`dep tree` were raw
   passthroughs with **no class routing**. Falsified by #5132 (`18b1743e07`),
   wired at `cmd_bd.go:260`. Rewritten to state what each verb actually does:
   `show`, `update` (incl. `--claim`), `release-if-current` and `dep list` are
   class-routed in process; `dep tree` is refused on a class-owned id; every
   other subcommand that ADDRESSES a reserved-prefix id is refused by
   ownership rather than servability.
2. `internal/beads/membership.go` attributed spec-sidecar dependency isolation
   to `formula.newSourceSpecStep` "clearing" `DependsOn`/`Needs`/`WaitsFor`.
   Verified against the tree: that function
   (`internal/formula/source_spec.go:22-33`) is a fresh `&Step{...}` literal
   that never SETS them; `namespaceSourceSpecStep:52-54` is the one place that
   actively nils them. The conclusion holds; the citation sent the next reader
   to the wrong function, and it is load-bearing for why the measured 48 looked
   stable. Two verbatim copies of the same wrong citation
   (`internal/beads/membership_test.go`, `internal/dispatch/fanout_membership_test.go`)
   move with it, and `namespaceSourceSpecStep` — which had no doc — now says
   why a spec carries no edges.

## Conformance gap accounting

No KNOWN GAP became closable. I12's gap is the **object-model** half of
Invariant 0 (`beads.DirectMembers` handed the wrong store still answers with an
empty member set); closing it means giving a store the ability to refuse a
class it does not hold, which is a behavior change on every `DirectMembers`
consumer, not a read-path guard. I12's paragraph now says so explicitly, so a
reader does not mistake I14 for having closed it. No new gap was introduced, so
no new skip.

## Gates

* `go build ./...` — clean
* `go vet ./...` — clean
* `gofmt -l ./cmd ./internal` — empty
* `golangci-lint` 2.10.1 over `./cmd/gc/... ./internal/beads/... ./internal/formula/... ./internal/dispatch/...` — **0 issues**
* `go test ./cmd/gc -timeout 25m` (serial) — **ok, 756.3s**
* `go test ./internal/...` — **exit 0, 144 packages**
* `scripts/check-core-boundary.sh` — OK
* `make check-split-topology-rows` — exit 0

---

# Council review round 2 — three defects, fixed (`d05afb11dd`)

Rebased onto `31ecad2364` (#5163). Seven confirmed majors reduced to three
distinct defects; all three plus the three minors are fixed.

## Defect 1 — the refusal was far too broad

`RelocatedClassesInListSelector` reused `atQueryValueStart`, which returns
`true` at offset 0. For `bd query` one token is a whole expression, so a bare
term IS a value position. For a **selector flag** the flag has already consumed
its own token, and `bd list` accepts **no positional arguments at all**
(`cmd/bd/list.go:494`: *"bd list does not accept positional arguments; use
flags instead"*), so every token the scan sees is some flag's VALUE. Offset-0
anchoring therefore made **every free-text selector id-shaped**, and
`--title-contains gcg-abc123` became indistinguishable from
`--metadata-field gc.root_bead_id=gcg-abc123`.

That is the exact false positive the guard's own header
(`internal/beads/bdsql_relocation.go`) names FIRST as the thing the anchoring
rules exist to let through — a LIKE-contains over a text column is a question
about the rows THIS ledger holds, and the work ledger really does carry `gcg-`
strings.

**Anchor chosen: `atSelectorValueStart` — the id must be preceded by the `=` of
a `key=value` predicate** (whitespace and quotes skipped on the way back, so
`k="gcg-1"` and `k= gcg-1` still anchor). Dropping the offset-0 arm is the
whole fix.

**Why this over gating on `bdflags.ValueFlags("list")`:**

1. `bdflags` records **arity, not meaning**. A flag allowlist needs a *second*
   manifest of what each flag MEANS, maintained by hand against every flag bd
   grows — and its failure mode is *silent under-guarding*, which is the bug
   class this PR exists to close.
2. It needs one list **per verb**. `list`, `ready` and `search` have different
   selector sets; the `=` anchor is correct for all three with no list at all.
3. Every other dialect in this family classifies **text**. The `=` anchor
   derives the answer from the token's own shape the way `atSQLLiteralStart`
   and `atQueryValueStart` do, so the three dialects stay one mechanism.
4. It is strictly **narrower** where it matters. `--id`/`--parent`/`-p` fall
   through to the by-id ownership door — which was already refusing them on
   `main` — and that door names the **bead and its binding**, not just the
   namespace. The offset-0 arm was shadowing a more specific refusal with a
   vaguer one, for zero added coverage.
   `TestGcBdListOnAnIDValuedFlagRefusesByOwnership` pins that.

## Defect 2 — the same bug was still live one verb over

`gc bd ready --metadata-field <k>=<gcg id>` and `gc bd search` answered `[]`
exit 0, and the shipped comment justified the exemption with *"`ready` stays
out: its selectors name templates and labels, not bead ids"* — which
`internal/bdflags/bdflags.go` falsifies in the same tree.

**Both verbs are now guarded.** `--metadata-field` is registered on exactly
three bd subcommands (`cmd/bd/list.go:831`, `ready.go:820`, `search.go:390`),
and all three are in `bdRelocatedClassGuardedVerbs`.
`TestBdRelocatedClassGuardCoversEverySelectorVerb` derives that requirement
from `bdflags` so a fourth cannot appear unguarded. The false rationale is
gone; the replacement states the checkable completeness claim.

Verified safe for the work loop: the pool-demand probe and the control
dispatcher select on `gc.routed_to` / `gc.run_target`, whose values are pool
template names, and they invoke raw `bd`, not `gc bd`.
`TestGcBdReadyKeepsAnsweringItsOrdinaryWorkQueries` pins the argv-level half.

## Defect 3 — the steering is honest about its limit

`gc ready --metadata-field` answers a **narrower** question than the refused
read. With no `--status` it issues a `ReadyQuery` — claimable, unblocked work
only — so a molecule whose steps are in flight, blocked or closed comes back
`[]` **from the command the refusal recommended**. And that is the modal case:
a stuck molecule is precisely one with no claimable step. `--status` takes
exactly one of `open`/`in_progress`/`blocked`/`closed`; there is no `--all`, no
comma list, and `deferred` is not selectable at all.

The message now says all of that and states plainly that **there is no
federated equivalent of `bd list --all` yet**:

> For a SET of beads rather than one id, `gc ready --metadata-field "key=value"`
> federates the city store, the rig stores and the relocated binding as ordered
> legs and fails loud on a leg it cannot read — but it answers a NARROWER
> question than this read did: with no --status it returns only claimable work,
> and --status takes exactly one of open, in_progress, blocked, closed (no
> --all, no comma list, and deferred is not selectable), so enumerating a
> molecule's full membership takes one invocation per status and cannot reach a
> deferred member at all. There is no federated equivalent of `bd list --all`
> yet.

I14's last leg previously ran against a molecule whose only step was open — the
one status for which the escape works. It now mints a **mid-flight** step and
asserts both halves: the bare spelling does NOT return it, and
`--status in_progress` does. The steering cannot silently become wrong again.

## The three minors

1. **The refusal now names `GC_BD_ALLOW_RELOCATED_CLASS_READ`.** Appended at
   the CLI seam (`bdRelocatedClassEscapeHint`), *not* inside
   `beads.RelocatedClassRefusal` — that same string is returned by `BdStore`'s
   id-scoped guard, which honors no env var, so naming it there would advertise
   an escape that does not work on half the paths that print it.
   `TestRelocatedClassRefusalLeavesTheOverrideToTheCLI` pins the negative;
   `TestGcBdRefusalNamesTheOverride` pins the positive.
2. **`cmd_bd_by_id.go`'s header** said `gc bd list --metadata-field
   workflow_id=gcg-…` "is a work question about work rows, and refusing it
   exec-fails the consumer that asks it" — the exact argv this PR refuses. Both
   sites now state what is true: the by-id door **declines it on OWNERSHIP**
   (a quoted id decides nothing about which store serves the read), and the
   dialect guard refuses it one pre-flight earlier on **SERVABILITY**.
3. `RelocatedClassesInListSelector` → `RelocatedClassesInSelector`, since it
   now serves three verbs. A name that says "list" while `ready` uses it is the
   same class of false citation ga-kqk8j exists to remove.

## Per-flag A/B: `main` (31ecad2364) → old head (17d7d83171) → now (d05afb11dd)

Predicates measured directly (`bdSQLRelocatedClassRefusal ‖
bdArgsNameClassOwnedBead`) on `splitCityConfig()`.

| argv | main | old head | now |
| --- | --- | --- | --- |
| `list --title-contains gcg-abc123` | pass | **REFUSE** | pass |
| `list --title-contains=gcg-abc123` | pass | **REFUSE** | pass |
| `list --desc-contains gcg-abc123` | pass | **REFUSE** | pass |
| `list --notes-contains gcg-abc123` | pass | **REFUSE** | pass |
| `list --title gcg-abc123` | pass | **REFUSE** | pass |
| `list --label gcg-abc123` | pass | **REFUSE** | pass |
| `list --exclude-label gcg-abc123` | pass | **REFUSE** | pass |
| `list --label-pattern 'gcg-*'` | pass | **REFUSE** | pass |
| `list --label-regex 'gcg-.*'` | pass | **REFUSE** | pass |
| `list --assignee gcg-worker` | pass | **REFUSE** | pass |
| `list -a gcg-worker` | pass | **REFUSE** | pass |
| `list --sort gcg` | pass | **REFUSE** | pass |
| `list --spec gcg-abc123` | pass | **REFUSE** | pass |
| `list --title-contains gcg` | pass | **REFUSE** | pass |
| `list --title-contains "fix (gcg-1) regression"` | pass | **REFUSE** | pass |
| `list --title-contains "regressions: gcg-1, gcg-2"` | pass | **REFUSE** | pass |
| `list --title-contains "root is 'gcg-1' here"` | pass | **REFUSE** | pass |
| `list --title-contains "fix gcg-1 regression"` | pass | pass | pass |
| `list --metadata-field gc.root_bead_id=gcg-abc123` | pass | refuse | **refuse** |
| `list --metadata-field=gc.root_bead_id=gcg-abc123` | pass | refuse | **refuse** |
| `list --json --metadata-field gc.root_bead_id=gcg-abc123` | pass | refuse | **refuse** |
| `--json list --metadata-field gc.root_bead_id=gcg-abc123` | pass | refuse | **refuse** |
| `list --metadata-field gc.nudge_id=gcn-1` | pass | refuse | **refuse** |
| `list --metadata-field 'gc.root_bead_id="gcg-abc123"'` | pass | refuse | **refuse** |
| `list --metadata-field gc.root_bead_id=GCG-ABC123` | pass | refuse | **refuse** |
| `list --metadata-field gc.root_bead_id=demo-abc` | pass | pass | pass |
| `list --metadata-field gc.root_bead_id=gcgx-1` | pass | pass | pass |
| `list --has-metadata-key gc.root_bead_id` | pass | pass | pass |
| `list --status open` | pass | pass | pass |
| `list --id gcg-abc123` | refuse (by-id) | refuse | refuse (by-id) |
| `list --parent gcg-abc123` | refuse (by-id) | refuse | refuse (by-id) |
| `list -p gcg-abc123` | refuse (by-id) | refuse | refuse (by-id) |
| `ready --metadata-field gc.root_bead_id=gcg-abc123` | **pass** | **pass** | **refuse** |
| `ready --metadata-field=gc.root_bead_id=gcg-abc123` | **pass** | **pass** | **refuse** |
| `ready --label gcg-abc123` | pass | pass | pass |
| `ready --metadata-field gc.routed_to=demo/worker` | pass | pass | pass |
| `ready --parent gcg-abc123` | refuse (by-id) | refuse (by-id) | refuse (by-id) |
| `search --metadata-field gc.root_bead_id=gcg-abc123` | **pass** | **pass** | **refuse** |
| `search gcg-abc123` | refuse (by-id) | refuse (by-id) | refuse (by-id) |
| `sql "... id = 'gcg-abc'"` | refuse | refuse | refuse |
| `sql "... title like '%gcg-abc123%'"` | pass | pass | pass |
| `sql --format=gcg-abc123 'select 1'` | refuse (by-id) | refuse | refuse (by-id) |
| `query id=gcg-abc123` | refuse | refuse | refuse |
| `query title~gcg-abc123` | pass | pass | pass |

Every regressed row is back to its `main` behaviour; the original bug still
refuses in every spelling; `ready`/`search --metadata-field` are the only
intentionally-new refusals.

## Red-before strings

Reverting `atSelectorValueStart` → `atQueryValueStart`:

```
--- FAIL: TestRelocatedClassesInSelectorMatchesOnlyThePredicateValue/bare_id_as_a_whole_selector_value
    RelocatedClassesInSelector("gcg-abc123") matched = true, want false
--- FAIL: TestRelocatedClassesInSelectorMatchesOnlyThePredicateValue/prose_with_a_paren_before_the_id
    RelocatedClassesInSelector("fix (gcg-1) regression") matched = true, want false
--- FAIL: TestRelocatedClassesInSelectorMatchesOnlyThePredicateValue/prose_with_a_quote_before_the_id
    RelocatedClassesInSelector("root is 'gcg-1' here") matched = true, want false
--- FAIL: TestRelocatedClassesInSelectorDivergesFromTheQueryDialect
    RelocatedClassesInSelector("gcg-abc123") matched [{graph gcg ...}]; a whole-token
    selector value is a search string, and refusing it breaks `--title-contains`
--- FAIL: TestGcBdListForwardsAFreeTextSearchThatNamesAGraphID/title_search
    `gc bd list --title-contains gcg-abc123 --json` exited 1 on a split city; a
    LIKE-contains over this ledger's own columns is a question bd answers, and
    refusing it withholds rows that exist.
```

(plus 15 rows of `TestBdSQLRelocatedClassRefusalOnASplitCity` and 7 more
subtests of `TestGcBdListForwardsAFreeTextSearchThatNamesAGraphID`.)

Removing `"ready"`/`"search"` from the guard map:

```
--- FAIL: TestBdSQLRelocatedClassRefusalOnASplitCity/ready_on_a_graph_root_id
    bdSQLRelocatedClassRefusal([ready --metadata-field gc.root_bead_id=gcg-abc123]) refused = false, want true
--- FAIL: TestGcBdReadyRefusesAGraphClassProjectionOnASplitCity/ready
    `gc bd ready --metadata-field gc.root_bead_id=gcg-abc123 --json` exited 0 with
    stdout="[]\n"; that empty array is the same silent-empty `gc bd list` refuses
    on the same molecule
--- FAIL: TestBdRelocatedClassGuardCoversEverySelectorVerb
    bd "ready" takes --metadata-field but is not in bdRelocatedClassGuardedVerbs
--- FAIL: TestSplitTopologyConformance/I14-projection-coherence/split
    `gc bd ready --metadata-field gc.root_bead_id=gcg-1` refused = false but `gc bd
    list` with the same selector refused = true
```

Reverting the steering + the override hint:

```
--- FAIL: TestRelocatedClassRefusalStatesTheLimitsOfTheSetEscape
    the steering does not state "with no --status it returns only claimable work"
    the steering does not state "exactly one of open, in_progress, blocked, closed"
    the steering does not state "deferred is not selectable"
    the steering does not state "no federated equivalent of `bd list --all`"
--- FAIL: TestGcBdRefusalNamesTheOverride
    the refusal never names GC_BD_ALLOW_RELOCATED_CLASS_READ, so the operator
    holding a false positive has no in-band way out
--- FAIL: TestSplitTopologyConformance/I14-projection-coherence/split
    the list refusal does not name "with no --status it returns only claimable work"
```

## Gates (on `d05afb11dd`, rebased on `31ecad2364`)

* `go build ./...` — clean
* `go vet ./...` — clean
* `gofmt -l ./cmd ./internal` — empty
* `golangci-lint` 2.10.1 over `./...` — **0 issues**
* `go test ./cmd/gc -timeout 25m` (serial, on the committed tree) — **ok, 736.3s**
* `go test ./internal/...` — **exit 0, 144 packages**
* `scripts/check-core-boundary.sh` — OK
* `scripts/check-split-topology-rows.sh` — exit 0
* `scripts/check-routed-test-rows.sh` — exit 0

`cmd/gc/cmd_bd_by_id.go` is touched for **comments only** (the two doc sites
that contradicted shipped behaviour); no by-id routing logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

